### PR TITLE
ci: speed up CI builds and shrink macOS artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,12 +146,34 @@ jobs:
         if: matrix.os == 'macos'
         run: brew install gcc openblas upx
 
-      - name: Setup GHC + Cabal (Linux/macOS)
+      - name: Restore GHCup install (Linux/macOS)
+        id: cache-ghcup-unix
         if: matrix.os == 'linux' || matrix.os == 'macos'
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.ghcup
+          key: ghcup-${{ matrix.name }}-ghc${{ steps.versions.outputs.ghc }}
+
+      - name: Setup GHC + Cabal (Linux/macOS, cold)
+        # On cache miss, haskell-actions/setup downloads + installs GHC into
+        # ~/.ghcup (~3–4 min on macOS arm64, ~1–2 min on Linux). The "warm"
+        # branch below replaces this with a 5-second PATH+cabal-update.
+        if: (matrix.os == 'linux' || matrix.os == 'macos') && steps.cache-ghcup-unix.outputs.cache-hit != 'true'
         uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ steps.versions.outputs.ghc }}
           cabal-version: latest
+
+      - name: Use cached GHC + Cabal (Linux/macOS, warm)
+        if: (matrix.os == 'linux' || matrix.os == 'macos') && steps.cache-ghcup-unix.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          echo "$HOME/.ghcup/bin" >> "$GITHUB_PATH"
+          "$HOME/.ghcup/bin/ghc" --version
+          "$HOME/.ghcup/bin/cabal" --version
+          # ~/.cabal/packages (Hackage index) lives outside ~/.ghcup and is
+          # not in the cache; refresh it so cabal solve has a current view.
+          "$HOME/.ghcup/bin/cabal" update
 
       # Cache restore + save are split (instead of using actions/cache@v4
       # with save-always, which is deprecated). The save step runs with
@@ -181,8 +203,14 @@ jobs:
             C:\cabal\store
             dist-newstyle
           key: cabal-${{ matrix.name }}-ghc${{ steps.versions.outputs.ghc }}-${{ hashFiles('volca.cabal', 'mumps-hs/mumps-hs.cabal', 'cabal.project') }}
+          # Two-level fallback: same GHC first (object files reusable), then
+          # any GHC for the same matrix entry (cabal will re-resolve and
+          # rebuild the deps closure but reuse what it can — better than
+          # full cold). Don't widen beyond matrix.name: cabal stores are not
+          # cross-OS / cross-arch compatible.
           restore-keys: |
             cabal-${{ matrix.name }}-ghc${{ steps.versions.outputs.ghc }}-
+            cabal-${{ matrix.name }}-
 
       - name: Build and test
         run: |
@@ -212,6 +240,17 @@ jobs:
         with:
           path: deps/mumps
           key: ${{ steps.cache-mumps.outputs.cache-primary-key }}
+
+      - name: Save GHCup install (Linux/macOS)
+        # No always() here — same reasoning as the Windows save step above:
+        # a partial ~/.ghcup from a failed install would otherwise be cached
+        # and silently reused. Re-installing GHC takes ~3–4 min on a cache
+        # miss; losing the cache on failure is the safe default.
+        if: (matrix.os == 'linux' || matrix.os == 'macos') && steps.cache-ghcup-unix.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.ghcup
+          key: ${{ steps.cache-ghcup-unix.outputs.cache-primary-key }}
 
       - name: Save Cabal store
         if: always() && steps.cache-cabal.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,15 +200,21 @@ jobs:
         if: (matrix.os == 'linux' || matrix.os == 'macos') && steps.cache-ghcup-unix.outputs.cache-hit == 'true'
         shell: bash
         run: |
+          # The runner image exports GHCUP_INSTALL_BASE_PREFIX=/usr/local
+          # globally; without overriding it here, `ghcup set ghc` would look
+          # for our pinned version under /usr/local/.ghcup/ghc/ and fail with
+          # "version 9.6.7 of the tool ghc is not installed". Match the cold
+          # step's override.
+          export GHCUP_INSTALL_BASE_PREFIX="$HOME"
           GHC_VER="${{ steps.versions.outputs.ghc }}"
           if [[ ! -d "$HOME/.ghcup/ghc/$GHC_VER" ]]; then
             echo "::error::Cached ~/.ghcup is missing GHC $GHC_VER (stale cache key?)"
             ls -la "$HOME/.ghcup/" "$HOME/.ghcup/ghc/" 2>&1 || true
             exit 1
           fi
-          # Force the bare `ghc` symlink to our pinned version — ghcup-install
-          # auto-sets it but we re-assert here in case the cache snapshot was
-          # taken in a state where another version was active.
+          # Force the bare `ghc` symlink to our pinned version — bootstrap
+          # auto-sets it but we re-assert here in case the cache snapshot
+          # was taken in a state where another version was active.
           "$HOME/.ghcup/bin/ghcup" set ghc "$GHC_VER"
           echo "$HOME/.ghcup/bin" >> "$GITHUB_PATH"
           "$HOME/.ghcup/bin/ghc" --numeric-version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,20 +152,29 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.ghcup
-          key: ghcup-${{ matrix.name }}-ghc${{ steps.versions.outputs.ghc }}-v3
+          key: ghcup-${{ matrix.name }}-ghc${{ steps.versions.outputs.ghc }}-v4
 
       - name: Install GHC + Cabal via ghcup (Linux/macOS, cold)
-        # We bootstrap ghcup ourselves into ~/.ghcup instead of using
-        # haskell-actions/setup@v2 because the latter just symlinks back to
-        # the runner image's preinstalled `/usr/local/.ghcup`, leaving
-        # ~/.ghcup ~200 bytes of metadata so caching it saves nothing.
+        # We bootstrap ghcup ourselves into ~/.ghcup so that actions/cache
+        # has real content to archive (haskell-actions/setup@v2 just symlinks
+        # back to the runner's preinstalled /usr/local/.ghcup, leaving
+        # ~/.ghcup empty of cacheable bytes).
         #
-        # The runner image also exports `GHCUP_INSTALL_BASE_PREFIX=/usr/local`
-        # in the global environment, which makes the bootstrap script install
-        # into /usr/local/.ghcup as well. We override that to `$HOME` so the
-        # install lives where actions/cache expects it.
+        # Two tricks needed:
+        #  1. The runner image exports GHCUP_INSTALL_BASE_PREFIX=/usr/local
+        #     globally, redirecting installs to /usr/local/.ghcup. Override
+        #     to $HOME so install goes to ~/.ghcup.
+        #  2. The runner image pre-creates ~/.ghcup as a façade directory
+        #     containing SYMLINKS into /usr/local/.ghcup (e.g. `share ->
+        #     ./ghc/9.14.1/share`). ghcup install writes through those
+        #     symlinks, but tar archives the symlink shells (~200 bytes)
+        #     not the targets. Wipe ~/.ghcup first so our install lands in
+        #     a real, cacheable directory tree. (rm doesn't follow symlinks,
+        #     so /usr/local/.ghcup is untouched — but we don't need it
+        #     anyway because $PATH below points only at ~/.ghcup/bin.)
         if: (matrix.os == 'linux' || matrix.os == 'macos') && steps.cache-ghcup-unix.outputs.cache-hit != 'true'
         run: |
+          rm -rf "$HOME/.ghcup"
           export GHCUP_INSTALL_BASE_PREFIX="$HOME"
           curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org \
             | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 \
@@ -174,13 +183,14 @@ jobs:
               BOOTSTRAP_HASKELL_ADJUST_BASHRC=no \
               GHCUP_INSTALL_BASE_PREFIX="$HOME" \
               sh
-          # Sanity-check: bail loudly if ghcup wrote somewhere other than ~/.ghcup
-          # (this would silently revert the cache fix).
+          # Sanity-check: bail loudly if the install ended up somewhere we
+          # can't cache, so we don't silently regress the warm path.
           if [[ ! -x "$HOME/.ghcup/bin/ghc-${{ steps.versions.outputs.ghc }}" ]]; then
-            echo "::error::ghcup did not install to ~/.ghcup as expected — check GHCUP_INSTALL_BASE_PREFIX"
+            echo "::error::ghcup did not install to ~/.ghcup as expected"
             ls -la "$HOME/.ghcup/" "$HOME/.ghcup/bin/" 2>&1 || true
             exit 1
           fi
+          echo "[INFO] ~/.ghcup install size: $(du -sh "$HOME/.ghcup" | cut -f1)"
           echo "$HOME/.ghcup/bin" >> "$GITHUB_PATH"
           "$HOME/.ghcup/bin/ghc" --numeric-version
           "$HOME/.ghcup/bin/cabal" --numeric-version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,9 +168,23 @@ jobs:
         if: (matrix.os == 'linux' || matrix.os == 'macos') && steps.cache-ghcup-unix.outputs.cache-hit == 'true'
         shell: bash
         run: |
+          # haskell-actions/setup@v2 makes a GHC active by prepending its
+          # version-specific bindir to PATH, NOT by running `ghcup set`. So
+          # ~/.ghcup/bin/ghc may point to whatever was active before (on
+          # ubuntu-latest the runner image preinstalls a newer GHC; the
+          # symlink survives in the cache and silently shadows our pinned
+          # version on warm runs). Reset it explicitly.
+          GHCUP="$HOME/.ghcup/bin/ghcup"
+          GHC_VER="${{ steps.versions.outputs.ghc }}"
+          if [[ ! -d "$HOME/.ghcup/ghc/$GHC_VER" ]]; then
+            echo "::error::Cached ~/.ghcup is missing GHC $GHC_VER (stale cache key?)"
+            ls -la "$HOME/.ghcup/ghc/" || true
+            exit 1
+          fi
+          "$GHCUP" set ghc "$GHC_VER"
           echo "$HOME/.ghcup/bin" >> "$GITHUB_PATH"
-          "$HOME/.ghcup/bin/ghc" --version
-          "$HOME/.ghcup/bin/cabal" --version
+          "$HOME/.ghcup/bin/ghc" --numeric-version
+          "$HOME/.ghcup/bin/cabal" --numeric-version
           # ~/.cabal/packages (Hackage index) lives outside ~/.ghcup and is
           # not in the cache; refresh it so cabal solve has a current view.
           "$HOME/.ghcup/bin/cabal" update
@@ -257,11 +271,14 @@ jobs:
           key: ${{ steps.cache-mumps.outputs.cache-primary-key }}
 
       - name: Save GHCup install (Linux/macOS)
-        # No always() here — same reasoning as the Windows save step above:
-        # a partial ~/.ghcup from a failed install would otherwise be cached
-        # and silently reused. Re-installing GHC takes ~3–4 min on a cache
-        # miss; losing the cache on failure is the safe default.
-        if: (matrix.os == 'linux' || matrix.os == 'macos') && steps.cache-ghcup-unix.outputs.cache-hit != 'true'
+        # always() so a downstream test or optimize failure doesn't discard
+        # the GHC install we just paid 3–4 minutes for. The install completes
+        # in a single `Setup GHC + Cabal (Linux/macOS, cold)` step; if THAT
+        # step fails, the workflow halts before this save runs anyway, so
+        # there's no risk of caching a partial ~/.ghcup. (Contrast with the
+        # Windows pattern, which is split across multiple steps and prefers
+        # the safer no-always policy.)
+        if: always() && (matrix.os == 'linux' || matrix.os == 'macos') && steps.cache-ghcup-unix.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: ~/.ghcup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,24 +152,35 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.ghcup
-          key: ghcup-${{ matrix.name }}-ghc${{ steps.versions.outputs.ghc }}-v2
+          key: ghcup-${{ matrix.name }}-ghc${{ steps.versions.outputs.ghc }}-v3
 
       - name: Install GHC + Cabal via ghcup (Linux/macOS, cold)
-        # We install ghcup ourselves into ~/.ghcup instead of using
-        # haskell-actions/setup@v2 because the latter detects the runner
-        # image's preinstalled `/usr/local/.ghcup` and just symlinks back to
-        # it — `~/.ghcup` ends up holding ~200 bytes of metadata, so caching
-        # it saves nothing. Bootstrapping ghcup directly puts the full GHC
-        # tree under ~/.ghcup, which is what we want to cache. Same pattern
-        # as the Windows path above.
+        # We bootstrap ghcup ourselves into ~/.ghcup instead of using
+        # haskell-actions/setup@v2 because the latter just symlinks back to
+        # the runner image's preinstalled `/usr/local/.ghcup`, leaving
+        # ~/.ghcup ~200 bytes of metadata so caching it saves nothing.
+        #
+        # The runner image also exports `GHCUP_INSTALL_BASE_PREFIX=/usr/local`
+        # in the global environment, which makes the bootstrap script install
+        # into /usr/local/.ghcup as well. We override that to `$HOME` so the
+        # install lives where actions/cache expects it.
         if: (matrix.os == 'linux' || matrix.os == 'macos') && steps.cache-ghcup-unix.outputs.cache-hit != 'true'
         run: |
+          export GHCUP_INSTALL_BASE_PREFIX="$HOME"
           curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org \
             | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 \
               BOOTSTRAP_HASKELL_GHC_VERSION=${{ steps.versions.outputs.ghc }} \
               BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1 \
               BOOTSTRAP_HASKELL_ADJUST_BASHRC=no \
+              GHCUP_INSTALL_BASE_PREFIX="$HOME" \
               sh
+          # Sanity-check: bail loudly if ghcup wrote somewhere other than ~/.ghcup
+          # (this would silently revert the cache fix).
+          if [[ ! -x "$HOME/.ghcup/bin/ghc-${{ steps.versions.outputs.ghc }}" ]]; then
+            echo "::error::ghcup did not install to ~/.ghcup as expected — check GHCUP_INSTALL_BASE_PREFIX"
+            ls -la "$HOME/.ghcup/" "$HOME/.ghcup/bin/" 2>&1 || true
+            exit 1
+          fi
           echo "$HOME/.ghcup/bin" >> "$GITHUB_PATH"
           "$HOME/.ghcup/bin/ghc" --numeric-version
           "$HOME/.ghcup/bin/cabal" --numeric-version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,28 +234,19 @@ jobs:
             ./build.sh --test
           fi
 
-      - name: Optimize macOS binary (strip + UPX + re-sign)
+      - name: Optimize macOS binary (strip + ad-hoc sign)
         # Tests above ran on the unstripped binary because UPX'd Mach-O on
-        # arm64 fails to launch under cabal test even after ad-hoc re-sign,
-        # turning every test that spawns volca into a 5-min timeout. Now that
-        # tests are done, strip + UPX the binary so the uploaded artifact is
-        # small, then verify it still launches before upload. If UPX corrupts
-        # the binary, fall back to strip-only — still cuts ~60 % off the size.
+        # arm64 is killed at fork by the kernel even after ad-hoc re-sign
+        # (an upstream UPX 5.x / arm64 limitation — not something we can
+        # work around). Now that tests are done, strip + re-sign the binary
+        # so the uploaded artifact is meaningfully smaller. Then verify it
+        # still launches before upload — if a future UPX path is re-enabled
+        # in build.sh and breaks the binary, this catches it loudly.
         if: matrix.os == 'macos'
         run: |
           ./build.sh --optimize-only
           VOLCA_BIN=$(cabal list-bin exe:volca)
-          if ! "$VOLCA_BIN" --version >/dev/null 2>&1; then
-            echo "::warning::Optimized macOS binary fails to launch — falling back to strip-only"
-            # Delete the corrupted binary so cabal re-links from cached object
-            # files (fast — no recompile, just ld). Then strip + ad-hoc sign,
-            # skipping UPX entirely.
-            rm -f "$VOLCA_BIN"
-            cabal build -j
-            strip -x "$VOLCA_BIN"
-            codesign --force --sign - "$VOLCA_BIN"
-            "$VOLCA_BIN" --version
-          fi
+          "$VOLCA_BIN" --version
           ls -lh "$VOLCA_BIN"
 
       - name: Save MUMPS local build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,6 +234,30 @@ jobs:
             ./build.sh --test
           fi
 
+      - name: Optimize macOS binary (strip + UPX + re-sign)
+        # Tests above ran on the unstripped binary because UPX'd Mach-O on
+        # arm64 fails to launch under cabal test even after ad-hoc re-sign,
+        # turning every test that spawns volca into a 5-min timeout. Now that
+        # tests are done, strip + UPX the binary so the uploaded artifact is
+        # small, then verify it still launches before upload. If UPX corrupts
+        # the binary, fall back to strip-only — still cuts ~60 % off the size.
+        if: matrix.os == 'macos'
+        run: |
+          ./build.sh --optimize-only
+          VOLCA_BIN=$(cabal list-bin exe:volca)
+          if ! "$VOLCA_BIN" --version >/dev/null 2>&1; then
+            echo "::warning::Optimized macOS binary fails to launch — falling back to strip-only"
+            # Delete the corrupted binary so cabal re-links from cached object
+            # files (fast — no recompile, just ld). Then strip + ad-hoc sign,
+            # skipping UPX entirely.
+            rm -f "$VOLCA_BIN"
+            cabal build -j
+            strip -x "$VOLCA_BIN"
+            codesign --force --sign - "$VOLCA_BIN"
+            "$VOLCA_BIN" --version
+          fi
+          ls -lh "$VOLCA_BIN"
+
       - name: Save MUMPS local build
         if: always() && steps.cache-mumps.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,36 +152,43 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.ghcup
-          key: ghcup-${{ matrix.name }}-ghc${{ steps.versions.outputs.ghc }}
+          key: ghcup-${{ matrix.name }}-ghc${{ steps.versions.outputs.ghc }}-v2
 
-      - name: Setup GHC + Cabal (Linux/macOS, cold)
-        # On cache miss, haskell-actions/setup downloads + installs GHC into
-        # ~/.ghcup (~3–4 min on macOS arm64, ~1–2 min on Linux). The "warm"
-        # branch below replaces this with a 5-second PATH+cabal-update.
+      - name: Install GHC + Cabal via ghcup (Linux/macOS, cold)
+        # We install ghcup ourselves into ~/.ghcup instead of using
+        # haskell-actions/setup@v2 because the latter detects the runner
+        # image's preinstalled `/usr/local/.ghcup` and just symlinks back to
+        # it — `~/.ghcup` ends up holding ~200 bytes of metadata, so caching
+        # it saves nothing. Bootstrapping ghcup directly puts the full GHC
+        # tree under ~/.ghcup, which is what we want to cache. Same pattern
+        # as the Windows path above.
         if: (matrix.os == 'linux' || matrix.os == 'macos') && steps.cache-ghcup-unix.outputs.cache-hit != 'true'
-        uses: haskell-actions/setup@v2
-        with:
-          ghc-version: ${{ steps.versions.outputs.ghc }}
-          cabal-version: latest
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org \
+            | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 \
+              BOOTSTRAP_HASKELL_GHC_VERSION=${{ steps.versions.outputs.ghc }} \
+              BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1 \
+              BOOTSTRAP_HASKELL_ADJUST_BASHRC=no \
+              sh
+          echo "$HOME/.ghcup/bin" >> "$GITHUB_PATH"
+          "$HOME/.ghcup/bin/ghc" --numeric-version
+          "$HOME/.ghcup/bin/cabal" --numeric-version
+          "$HOME/.ghcup/bin/cabal" update
 
       - name: Use cached GHC + Cabal (Linux/macOS, warm)
         if: (matrix.os == 'linux' || matrix.os == 'macos') && steps.cache-ghcup-unix.outputs.cache-hit == 'true'
         shell: bash
         run: |
-          # haskell-actions/setup@v2 makes a GHC active by prepending its
-          # version-specific bindir to PATH, NOT by running `ghcup set`. So
-          # ~/.ghcup/bin/ghc may point to whatever was active before (on
-          # ubuntu-latest the runner image preinstalls a newer GHC; the
-          # symlink survives in the cache and silently shadows our pinned
-          # version on warm runs). Reset it explicitly.
-          GHCUP="$HOME/.ghcup/bin/ghcup"
           GHC_VER="${{ steps.versions.outputs.ghc }}"
           if [[ ! -d "$HOME/.ghcup/ghc/$GHC_VER" ]]; then
             echo "::error::Cached ~/.ghcup is missing GHC $GHC_VER (stale cache key?)"
-            ls -la "$HOME/.ghcup/ghc/" || true
+            ls -la "$HOME/.ghcup/" "$HOME/.ghcup/ghc/" 2>&1 || true
             exit 1
           fi
-          "$GHCUP" set ghc "$GHC_VER"
+          # Force the bare `ghc` symlink to our pinned version — ghcup-install
+          # auto-sets it but we re-assert here in case the cache snapshot was
+          # taken in a state where another version was active.
+          "$HOME/.ghcup/bin/ghcup" set ghc "$GHC_VER"
           echo "$HOME/.ghcup/bin" >> "$GITHUB_PATH"
           "$HOME/.ghcup/bin/ghc" --numeric-version
           "$HOME/.ghcup/bin/cabal" --numeric-version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,6 +154,17 @@ jobs:
           path: ~/.ghcup
           key: ghcup-${{ matrix.name }}-ghc${{ steps.versions.outputs.ghc }}-v4
 
+      - name: Pin cabal store dir (Linux/macOS)
+        # Newer cabal-install versions look at $XDG_CONFIG_HOME/cabal/config
+        # and put the package store under $XDG_STATE_HOME/cabal/store. The
+        # ubuntu-latest runner image pre-creates ~/.config/cabal/config, so
+        # cabal "ignores the former" (~/.cabal) and our cached ~/.cabal/store
+        # gets bypassed entirely — every warm run did a full cold dep
+        # rebuild. Pin CABAL_DIR=~/.cabal so the legacy paths win regardless
+        # of cabal version or runner-image state.
+        if: matrix.os == 'linux' || matrix.os == 'macos'
+        run: echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
+
       - name: Install GHC + Cabal via ghcup (Linux/macOS, cold)
         # We bootstrap ghcup ourselves into ~/.ghcup so that actions/cache
         # has real content to archive (haskell-actions/setup@v2 just symlinks
@@ -250,13 +261,17 @@ jobs:
             ~/.cabal/store
             C:\cabal\store
             dist-newstyle
-          key: cabal-${{ matrix.name }}-ghc${{ steps.versions.outputs.ghc }}-${{ hashFiles('volca.cabal', 'mumps-hs/mumps-hs.cabal', 'cabal.project') }}
+          key: cabal-${{ matrix.name }}-ghc${{ steps.versions.outputs.ghc }}-${{ hashFiles('volca.cabal', 'mumps-hs/mumps-hs.cabal', 'cabal.project') }}-v2
           # Two-level fallback: same GHC first (object files reusable), then
           # any GHC for the same matrix entry (cabal will re-resolve and
           # rebuild the deps closure but reuse what it can — better than
           # full cold). Don't widen beyond matrix.name: cabal stores are not
           # cross-OS / cross-arch compatible.
+          # Bumped to -v2: previous caches were built with cabal using XDG
+          # paths, while we now force CABAL_DIR=~/.cabal — the dist-newstyle
+          # plan would reference paths cabal can no longer resolve.
           restore-keys: |
+            cabal-${{ matrix.name }}-ghc${{ steps.versions.outputs.ghc }}-${{ hashFiles('volca.cabal', 'mumps-hs/mumps-hs.cabal', 'cabal.project') }}-
             cabal-${{ matrix.name }}-ghc${{ steps.versions.outputs.ghc }}-
             cabal-${{ matrix.name }}-
 

--- a/build.sh
+++ b/build.sh
@@ -19,6 +19,11 @@
 #   --no-optimize       Skip strip + UPX (preserves dylib load commands so
 #                       downstream tooling like dylibbundler / install_name_tool
 #                       can rewrite them — required for the macOS .app)
+#   --optimize-only     Skip the entire build: just strip + UPX + (re-)sign the
+#                       binary produced by a previous run. Used in CI to ship a
+#                       small artifact AFTER tests have run on the unstripped
+#                       binary (UPX'd Mach-O on macOS arm64 fails to launch
+#                       under cabal test even after ad-hoc re-sign).
 #
 # Examples:
 #   ./build.sh                      # Build
@@ -69,6 +74,64 @@ if [[ "$OS" == "macos" ]]; then
     export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-13.0}"
 fi
 
+# Strip + UPX + (re-)sign $1 in place. Idempotent: a binary already UPX'd
+# is left as-is. Linker output is the input; only platform-correct tooling
+# is invoked. Used both at the end of a normal build and as the sole action
+# of `--optimize-only`.
+optimize_volca_binary() {
+    local bin_path="$1"
+    if [[ -z "$bin_path" || ! -f "$bin_path" ]]; then
+        log_error "optimize_volca_binary: binary not found at '$bin_path'"
+        return 1
+    fi
+    if upx -t "$bin_path" &>/dev/null; then
+        local sz; sz=$(du -h "$bin_path" | cut -f1)
+        log_info "Binary already optimized ($sz), skipping strip/UPX"
+        return 0
+    fi
+
+    local original_size stripped_size final_size
+    original_size=$(du -h "$bin_path" | cut -f1)
+    log_info "Binary size before optimization: $original_size"
+
+    log_info "Stripping debug symbols..."
+    if [[ "$OS" == "macos" ]]; then
+        strip -x "$bin_path"
+    else
+        strip --strip-all "$bin_path"
+    fi
+    stripped_size=$(du -h "$bin_path" | cut -f1)
+    log_info "After strip: $stripped_size"
+
+    # UPX (Linux/macOS only — Windows Defender flags UPX binaries as malicious,
+    # breaking the NSIS installer). macOS Mach-O support is gated behind
+    # --force-macos in UPX 5.x.
+    if [[ "$OS" == "windows" ]]; then
+        log_success "Binary optimized: $original_size -> $stripped_size (stripped, no UPX on Windows)"
+        return 0
+    fi
+
+    log_info "Compressing with UPX (default level)..."
+    local upx_flags=()
+    if [[ "$OS" == "macos" ]]; then
+        upx_flags+=(--force-macos)
+    fi
+    if upx "${upx_flags[@]}" "$bin_path"; then
+        final_size=$(du -h "$bin_path" | cut -f1)
+        log_success "Binary optimized: $original_size -> $stripped_size (stripped) -> $final_size (compressed)"
+        # macOS arm64 refuses to launch executables without at least an ad-hoc
+        # signature. UPX rewrites the Mach-O headers and invalidates whatever
+        # signature the linker emitted, which silently kills the process at
+        # fork (the symptom is "Server failed to start within timeout" from
+        # any test that spawns volca). Re-sign in place.
+        if [[ "$OS" == "macos" ]]; then
+            codesign --force --sign - "$bin_path"
+        fi
+    else
+        log_warn "UPX compression failed — using stripped binary ($stripped_size)"
+    fi
+}
+
 # Defaults
 FORCE_REBUILD=false
 RUN_TESTS=false
@@ -76,6 +139,7 @@ CLEAN_BUILD=false
 COVERAGE=false
 STATIC_BUILD=false
 SKIP_OPTIMIZE=false
+OPTIMIZE_ONLY=false
 
 # -----------------------------------------------------------------------------
 # Parse arguments
@@ -111,6 +175,10 @@ while [[ $# -gt 0 ]]; do
             SKIP_OPTIMIZE=true
             shift
             ;;
+        --optimize-only)
+            OPTIMIZE_ONLY=true
+            shift
+            ;;
         *)
             log_error "Unknown option: $1"
             echo "Use --help for usage information"
@@ -126,6 +194,23 @@ if [[ "$STATIC_BUILD" == "true" ]]; then
     log_info "  Static linking: enabled"
 fi
 echo ""
+
+# --optimize-only: skip the entire build/test pipeline and just optimize the
+# binary produced by an earlier run. Needs `cabal` (to locate the binary),
+# `strip`, and `upx` — but none of the heavy build deps (gcc, MUMPS, ...).
+if [[ "$OPTIMIZE_ONLY" == "true" ]]; then
+    if ! command -v cabal &>/dev/null; then
+        log_error "--optimize-only requires cabal in PATH to locate the binary"
+        exit 1
+    fi
+    VOLCA_BIN_PATH=$(cabal list-bin exe:volca 2>/dev/null || true)
+    if [[ -z "$VOLCA_BIN_PATH" || ! -f "$VOLCA_BIN_PATH" ]]; then
+        log_error "--optimize-only: no built volca binary found (run ./build.sh first)"
+        exit 1
+    fi
+    optimize_volca_binary "$VOLCA_BIN_PATH"
+    exit 0
+fi
 
 # Check MSYS2 environment on Windows
 if [[ "$OS" == "windows" ]]; then
@@ -396,63 +481,15 @@ fi
 
 cabal build -j
 
-# Strip and compress the binary
-{
-    VOLCA_BIN_PATH=$(cabal list-bin exe:volca 2>/dev/null || true)
-    if [[ -n "$VOLCA_BIN_PATH" && -f "$VOLCA_BIN_PATH" ]]; then
-        if [[ "$SKIP_OPTIMIZE" == "true" ]]; then
-            FINAL_SIZE=$(du -h "$VOLCA_BIN_PATH" | cut -f1)
-            log_info "--no-optimize: leaving binary unstripped/uncompressed ($FINAL_SIZE)"
-        # Skip if already UPX-compressed (from a previous build)
-        elif upx -t "$VOLCA_BIN_PATH" &>/dev/null; then
-            FINAL_SIZE=$(du -h "$VOLCA_BIN_PATH" | cut -f1)
-            log_info "Binary already optimized ($FINAL_SIZE), skipping strip/UPX"
-        else
-            ORIGINAL_SIZE=$(du -h "$VOLCA_BIN_PATH" | cut -f1)
-            log_info "Binary size before optimization: $ORIGINAL_SIZE"
-
-            # Strip debug symbols
-            log_info "Stripping debug symbols..."
-            if [[ "$OS" == "macos" ]]; then
-                strip -x "$VOLCA_BIN_PATH"
-            else
-                strip --strip-all "$VOLCA_BIN_PATH"
-            fi
-            STRIPPED_SIZE=$(du -h "$VOLCA_BIN_PATH" | cut -f1)
-            log_info "After strip: $STRIPPED_SIZE"
-
-            # UPX compression (Linux/macOS only — Windows Defender flags UPX binaries
-            # as malicious, causing "Error opening file for writing" during NSIS install).
-            # macOS Mach-O support in UPX 5.x is gated behind --force-macos: it works
-            # for unsigned binaries but the loader stub may invalidate code-signing /
-            # notarization, which is something to revisit when shipping a signed .dmg.
-            if [[ "$OS" != "windows" ]]; then
-                log_info "Compressing with UPX..."
-                UPX_FLAGS=(-1)
-                if [[ "$OS" == "macos" ]]; then
-                    UPX_FLAGS+=(--force-macos)
-                fi
-                if upx "${UPX_FLAGS[@]}" "$VOLCA_BIN_PATH"; then
-                    FINAL_SIZE=$(du -h "$VOLCA_BIN_PATH" | cut -f1)
-                    log_success "Binary optimized: $ORIGINAL_SIZE -> $STRIPPED_SIZE (stripped) -> $FINAL_SIZE (compressed)"
-                    # macOS arm64 refuses to launch executables without at
-                    # least an ad-hoc signature. UPX rewrites the Mach-O
-                    # headers and invalidates whatever signature the linker
-                    # emitted, which silently kills the process at fork
-                    # (the symptom is "Server failed to start within timeout"
-                    # from any test that spawns volca). Re-sign in place.
-                    if [[ "$OS" == "macos" ]]; then
-                        codesign --force --sign - "$VOLCA_BIN_PATH"
-                    fi
-                else
-                    log_warn "UPX compression failed — using stripped binary ($STRIPPED_SIZE)"
-                fi
-            else
-                log_success "Binary optimized: $ORIGINAL_SIZE -> $STRIPPED_SIZE (stripped, no UPX on Windows)"
-            fi
-        fi
+VOLCA_BIN_PATH=$(cabal list-bin exe:volca 2>/dev/null || true)
+if [[ -n "$VOLCA_BIN_PATH" && -f "$VOLCA_BIN_PATH" ]]; then
+    if [[ "$SKIP_OPTIMIZE" == "true" ]]; then
+        FINAL_SIZE=$(du -h "$VOLCA_BIN_PATH" | cut -f1)
+        log_info "--no-optimize: leaving binary unstripped/uncompressed ($FINAL_SIZE)"
+    else
+        optimize_volca_binary "$VOLCA_BIN_PATH"
     fi
-}
+fi
 
 log_success "volca built successfully"
 echo ""

--- a/build.sh
+++ b/build.sh
@@ -103,30 +103,27 @@ optimize_volca_binary() {
     stripped_size=$(du -h "$bin_path" | cut -f1)
     log_info "After strip: $stripped_size"
 
-    # UPX (Linux/macOS only — Windows Defender flags UPX binaries as malicious,
-    # breaking the NSIS installer). macOS Mach-O support is gated behind
-    # --force-macos in UPX 5.x.
+    # Skip UPX on Windows (Defender flags UPX'd .exe as malicious, breaking the
+    # NSIS installer) and on macOS (UPX 5.x with --force-macos compresses arm64
+    # Mach-O fine — observed 104 M -> 48 M — but the resulting binary is killed
+    # by the kernel at fork with SIGKILL ("Killed: 9"), even after `codesign
+    # --force --sign -` re-signs it. This is an upstream UPX/Mach-O issue, not
+    # something we can paper over here. macOS arm64 still gets ad-hoc signed
+    # because strip can also invalidate the linker's signature.
     if [[ "$OS" == "windows" ]]; then
         log_success "Binary optimized: $original_size -> $stripped_size (stripped, no UPX on Windows)"
         return 0
     fi
+    if [[ "$OS" == "macos" ]]; then
+        codesign --force --sign - "$bin_path"
+        log_success "Binary optimized: $original_size -> $stripped_size (stripped + ad-hoc signed, no UPX on macOS arm64)"
+        return 0
+    fi
 
     log_info "Compressing with UPX (default level)..."
-    local upx_flags=()
-    if [[ "$OS" == "macos" ]]; then
-        upx_flags+=(--force-macos)
-    fi
-    if upx "${upx_flags[@]}" "$bin_path"; then
+    if upx "$bin_path"; then
         final_size=$(du -h "$bin_path" | cut -f1)
         log_success "Binary optimized: $original_size -> $stripped_size (stripped) -> $final_size (compressed)"
-        # macOS arm64 refuses to launch executables without at least an ad-hoc
-        # signature. UPX rewrites the Mach-O headers and invalidates whatever
-        # signature the linker emitted, which silently kills the process at
-        # fork (the symptom is "Server failed to start within timeout" from
-        # any test that spawns volca). Re-sign in place.
-        if [[ "$OS" == "macos" ]]; then
-            codesign --force --sign - "$bin_path"
-        fi
     else
         log_warn "UPX compression failed — using stripped binary ($stripped_size)"
     fi

--- a/gen-cabal-config.sh
+++ b/gen-cabal-config.sh
@@ -57,7 +57,10 @@ EOF
         GFORTRAN_LIB_DIR=$(ls -d "${BREW_PREFIX}/Cellar/gcc/"*/lib/gcc/*/ 2>/dev/null | sort -V | tail -1)
         : "${GFORTRAN_LIB_DIR:?Could not locate Homebrew gcc libgfortran — install with: brew install gcc}"
         DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-13.0}"
-        DARWIN_LINK_FLAGS="-optl-L$MUMPS_LIB_DIR -optl-ldmumps_seq -optl-lmumps_common_seq -optl-lpord_seq -optl-lmpiseq_seq -optl-L${OPENBLAS_PREFIX}/lib -optl-lopenblas -optl-L${GFORTRAN_LIB_DIR} -optl-lgfortran -optl-lquadmath -optl-lpthread -optl-lm -optl-mmacosx-version-min=${DEPLOYMENT_TARGET}"
+        # -Wl,-dead_strip and -Wl,-dead_strip_dylibs let ld64 prune unreferenced
+        # sections and unused dylib load commands. Pairs with `split-sections: True`
+        # below for a meaningful (5–15 %) size win before strip even runs.
+        DARWIN_LINK_FLAGS="-optl-L$MUMPS_LIB_DIR -optl-ldmumps_seq -optl-lmumps_common_seq -optl-lpord_seq -optl-lmpiseq_seq -optl-L${OPENBLAS_PREFIX}/lib -optl-lopenblas -optl-L${GFORTRAN_LIB_DIR} -optl-lgfortran -optl-lquadmath -optl-lpthread -optl-lm -optl-mmacosx-version-min=${DEPLOYMENT_TARGET} -optl-Wl,-dead_strip -optl-Wl,-dead_strip_dylibs"
         cat > "$OUTPUT" << EOF
 optimization: 2
 split-sections: True


### PR DESCRIPTION
## Summary

Two improvements to the build matrix introduced in #1:

- **Speed**: cache `~/.ghcup` on Linux/macOS so warm runs skip the 3–4 min GHC reinstall, and force `CABAL_DIR=~/.cabal` so cabal actually uses our cached package store (newer cabal-install otherwise prefers `$XDG_STATE_HOME` and the cached store sits unused). Various smaller fixes along the way: rm the runner-image's symlinked `~/.ghcup` shim before bootstrap, override `GHCUP_INSTALL_BASE_PREFIX=$HOME` in both cold and warm paths, widen the cabal cache `restore-keys`.
- **Size (macOS)**: tests run on the unstripped binary (UPX'd Mach-O on arm64 is killed at fork by the kernel even after ad-hoc re-sign — confirmed in this PR's first run), then a post-test step calls `./build.sh --optimize-only` to strip + re-sign. Added `-Wl,-dead_strip -Wl,-dead_strip_dylibs` to the darwin link flags.

## Final timings (run 25030160840, fully-warm)

| Platform        | Baseline (PR #1) | Warm (this PR) | Speedup |
|-----------------|------------------|----------------|---------|
| macos-arm64     | 23m54s           | **1m51s**      | −92%    |
| linux-amd64     | 17m19s           | **1m33s**      | −91%    |
| linux-arm64     | 15m37s           | **2m11s**      | −86%    |
| windows-amd64   | 19m48s           | **5m20s**      | −73%    |

Cold-cache (run 25029725786, after `-v2` invalidation): 5–6 min on Linux/macOS, 8m21s on Windows.

## Artifact size (macos-arm64)

| | Baseline | This PR |
|---|---|---|
| Zip | 26 M | 22 M |
| Binary on disk | 121 M | 104 M |

UPX on macOS arm64 is broken upstream — the `--force-macos` compressor produces a binary that is SIGKILL'd at fork even after ad-hoc re-signing. Strip-only is the ceiling for now (saved as project memory for future sessions).

## Test plan

- [x] All four matrix jobs go green on cold cache
- [x] All four matrix jobs go green on warm cache
- [x] macOS artifact `--version` smoke test passes after `--optimize-only`
- [x] Cabal cache restores under `~/.cabal/store` and gets reused (compile log shows no "Building xyz" for deps)