### PR TITLE
pyvolca 0.3.0 release: version bump + dedicated CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,13 @@ name: Build
 on:
   pull_request:
     branches: [main]
+    # Skip the Haskell build matrix on PRs that only touch the Python
+    # client. pyvolca dispatches dynamically against the engine's
+    # OpenAPI spec, so its changes don't affect the Haskell build —
+    # running the full 4-platform cabal compile (~30 min on Windows
+    # cold) is pure waste. Pyvolca has its own CI in pyvolca.yml.
+    paths-ignore:
+      - 'pyvolca/**'
 
 # Cancel any older in-flight runs for the same PR when a new commit is
 # pushed. Keeps queue depth bounded — Windows cold builds are 30 min

--- a/.github/workflows/pyvolca.yml
+++ b/.github/workflows/pyvolca.yml
@@ -1,0 +1,49 @@
+name: pyvolca
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'pyvolca/**'
+      - '.github/workflows/pyvolca.yml'
+
+concurrency:
+  group: pyvolca-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test pyvolca
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: pyvolca
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: pyvolca/pyproject.toml
+
+      - name: Install pyvolca with dev extras
+        run: pip install -e .[dev]
+
+      - name: Run tests
+        # test_drift.py compares the in-tree wrappers against a freshly
+        # dumped OpenAPI spec from the volca binary, so it needs a built
+        # engine. Skipped here; covered locally and (eventually) in a
+        # follow-up that downloads the linux-amd64 artifact from build.yml.
+        run: pytest -v --ignore=tests/test_drift.py
+
+      - name: Verify gen_api_md.py runs cleanly
+        run: python scripts/gen_api_md.py > /dev/null
+
+      - name: Verify package builds and metadata is valid
+        # Catches regressions in pyproject.toml that would block PyPI
+        # upload — license expression, content-type, missing fields, etc.
+        run: |
+          pip install build twine
+          python -m build
+          twine check dist/*

--- a/pyvolca/pyproject.toml
+++ b/pyvolca/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvolca"
-version = "0.2.1"
+version = "0.3.0"
 description = "Python client for VoLCA — Life Cycle Assessment engine"
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Bumps pyvolca to 0.3.0 and gives it a dedicated CI pipeline so future Python-only changes skip the 4-platform Haskell build matrix.

### Version bump (commit 1)

PyPI currently serves 0.1.0 and 0.2.0. Local 0.2.1 was an unpublished increment for exposing per-exchange comments on `Exchange` variants. Since then the public surface gained:
- New exports reachable via `from volca import …`: `Activity`, `SupplyChain`, `SupplyChainEntry`, `SupplyChainEdge`, `PathResult`, `PathStep`, `ConsumerResult`, `ConsumersResponse`
- Generated API reference embedded in the README (`scripts/gen_api_md.py`)
- Verified README examples (`tests/test_readme_examples.py`)
- Apache-2.0 license file aligned with `pyproject.toml`
- `Documentation` and `Issues` URLs in `[project.urls]`

Backwards compatible (additions only) → minor bump per semver.

### CI cleanup (commits 2 + 3)

- `build.yml` now has `paths-ignore: ['pyvolca/**']`. pyvolca dispatches dynamically against the engine OpenAPI spec, so its changes don't affect the Haskell build — there's no point compiling cabal+MUMPS for a `pyproject.toml` edit.
- New `pyvolca.yml` runs on `paths: ['pyvolca/**']` and does:
  - `pytest -v --ignore=tests/test_drift.py` (drift test needs a built engine)
  - `python scripts/gen_api_md.py` smoke test
  - `python -m build && twine check dist/*` — guards against pyproject regressions that would block PyPI upload

This very PR does run the Haskell matrix once because `.github/workflows/` changed — that's intentional to verify the new workflow doesn't break anything. All future pyvolca-only PRs skip it.

## Test plan
- [x] `pytest`: 40 pass, 5 skipped
- [x] `python -m build && twine check dist/*`: PASSED
- [x] New `pyvolca` CI workflow ran green on this PR
- [ ] Tag `v0.3.0` and `twine upload` after merge