### PR TITLE
add: one-liner installers for Linux/macOS/Windows

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -86,6 +86,33 @@ Pick the next patch (e.g. `0.7.1-dev`) or next minor (`0.8.0-dev`)
 depending on what's planned. The point is that `main` is never sitting
 on a released version — the `-dev` suffix marks "in flight".
 
+## One-liner installers
+
+After a `v*` release lands, end users can install with one line.
+Both installers fetch the platform tarball + data bundle from the GH
+Release, verify SHA256, and drop a shim that sets `VOLCA_DATA_DIR`.
+
+**Linux + macOS (bash):**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/ccomb/volca/main/install.sh | sh
+```
+
+Pin a specific version:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/ccomb/volca/main/install.sh | sh -s -- v0.7.0
+```
+
+**Windows (PowerShell):**
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/ccomb/volca/main/install.ps1 | iex
+```
+
+Both write to `~/.local/share/volca/` (Unix) or `%LOCALAPPDATA%\volca\`
+(Windows) and add a shim at `~/.local/bin/volca` / `%LOCALAPPDATA%\volca\bin\volca.cmd`.
+
 ## Why explicit tags, not auto-release-on-merge?
 
 Tags are durable handles for what shipped. Tagging is a deliberate,

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,159 @@
+# =============================================================================
+# volca installer (Windows / PowerShell)
+#
+# Usage:
+#   iwr -useb https://raw.githubusercontent.com/ccomb/volca/main/install.ps1 | iex
+#   & ([scriptblock]::Create((iwr -useb 'https://raw.githubusercontent.com/ccomb/volca/main/install.ps1').Content)) v0.7.0
+#
+# What it does:
+#   1. Detects platform (windows-amd64).
+#   2. Downloads volca-<version>-windows-amd64.zip from the GH Release.
+#   3. Downloads volca-data-<data-version>.tar.gz (reference data bundle).
+#   4. Verifies both against SHA256SUMS.
+#   5. Extracts to:
+#        $env:LOCALAPPDATA\volca\<version>\volca.exe
+#        $env:LOCALAPPDATA\volca\data\<data-version>\{flows.csv,...}
+#      and points $env:LOCALAPPDATA\volca\data\current at <data-version>.
+#   6. Installs a thin shim at $env:LOCALAPPDATA\volca\bin\volca.cmd that
+#      sets VOLCA_DATA_DIR and execs the real binary.
+# =============================================================================
+
+[CmdletBinding()]
+param(
+    [string]$Version = ''
+)
+
+$ErrorActionPreference = 'Stop'
+
+$Repo = 'ccomb/volca'
+$Prefix = if ($env:VOLCA_PREFIX) { $env:VOLCA_PREFIX } else { Join-Path $env:LOCALAPPDATA 'volca' }
+$BinDir = Join-Path $Prefix 'bin'
+$Shim = Join-Path $BinDir 'volca.cmd'
+
+function Say($msg) { Write-Host "==> $msg" }
+function Die($msg) { Write-Error "install.ps1: $msg"; exit 1 }
+
+# --- Platform detection ------------------------------------------------------
+
+$arch = $env:PROCESSOR_ARCHITECTURE
+if ($arch -eq 'AMD64' -or $arch -eq 'x64') {
+    $Platform = 'windows-amd64'
+} else {
+    Die "unsupported Windows arch: $arch (only AMD64 is built)"
+}
+
+# --- Resolve release tag -----------------------------------------------------
+
+if (-not $Version) {
+    Say "Resolving latest release of $Repo"
+    $rel = Invoke-RestMethod -UseBasicParsing -Uri "https://api.github.com/repos/$Repo/releases/latest"
+    $Version = $rel.tag_name
+}
+if ($Version -notmatch '^v') { $Version = "v$Version" }
+$PlainVersion = $Version.TrimStart('v')
+
+Say "Installing volca $Version for $Platform"
+
+# --- Download SHA256SUMS -----------------------------------------------------
+
+$Work = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "volca-install-$([guid]::NewGuid().Guid)")
+try {
+    $RelBase = "https://github.com/$Repo/releases/download/$Version"
+
+    Say 'Downloading SHA256SUMS'
+    $SumsPath = Join-Path $Work 'SHA256SUMS'
+    Invoke-WebRequest -UseBasicParsing -Uri "$RelBase/SHA256SUMS" -OutFile $SumsPath
+
+    $Sums = Get-Content $SumsPath
+    $BinAsset = "volca-$PlainVersion-$Platform.zip"
+    if (-not ($Sums -match "  $([regex]::Escape($BinAsset))$")) {
+        Die "release $Version has no asset $BinAsset"
+    }
+
+    $DataAsset = ($Sums | ForEach-Object {
+        if ($_ -match '^[0-9a-f]+\s+(volca-data-.*\.tar\.gz)$') { $matches[1] }
+    }) | Select-Object -First 1
+    if (-not $DataAsset) { Die "release $Version has no volca-data-* asset" }
+    $DataVersion = $DataAsset -replace '^volca-data-(.*)\.tar\.gz$', '$1'
+
+    # --- Download + verify ---------------------------------------------------
+
+    Say "Downloading $BinAsset"
+    $BinPath = Join-Path $Work $BinAsset
+    Invoke-WebRequest -UseBasicParsing -Uri "$RelBase/$BinAsset" -OutFile $BinPath
+
+    Say "Downloading $DataAsset"
+    $DataPath = Join-Path $Work $DataAsset
+    Invoke-WebRequest -UseBasicParsing -Uri "$RelBase/$DataAsset" -OutFile $DataPath
+
+    function Test-Sha256($file, $expected) {
+        $actual = (Get-FileHash -Algorithm SHA256 -Path $file).Hash.ToLower()
+        if ($actual -ne $expected.ToLower()) {
+            Die "SHA256 mismatch for $(Split-Path -Leaf $file): expected $expected, got $actual"
+        }
+    }
+    foreach ($line in $Sums) {
+        if ($line -match '^([0-9a-f]+)\s+(.+)$') {
+            $hash = $matches[1]; $name = $matches[2]
+            if ($name -eq $BinAsset)  { Test-Sha256 $BinPath  $hash }
+            if ($name -eq $DataAsset) { Test-Sha256 $DataPath $hash }
+        }
+    }
+
+    # --- Install -------------------------------------------------------------
+
+    $VersionDir = Join-Path $Prefix $PlainVersion
+    $DataDir = Join-Path (Join-Path $Prefix 'data') $DataVersion
+    $CurrentDataLink = Join-Path (Join-Path $Prefix 'data') 'current'
+
+    New-Item -ItemType Directory -Force -Path $VersionDir, $DataDir, $BinDir | Out-Null
+
+    Say "Extracting binary to $VersionDir"
+    Expand-Archive -Force -Path $BinPath -DestinationPath $VersionDir
+
+    Say "Extracting data bundle to $DataDir"
+    # PowerShell 5+ ships tar.exe (bsdtar). Use it so we don't depend on 7-Zip.
+    & tar.exe -xzf $DataPath -C $DataDir
+    if ($LASTEXITCODE -ne 0) { Die 'tar extraction failed' }
+
+    # "current" pointer. Try junction first (no admin needed); fall back to a
+    # plain copy if New-Item -ItemType Junction is unavailable.
+    if (Test-Path $CurrentDataLink) { Remove-Item -Recurse -Force $CurrentDataLink }
+    try {
+        New-Item -ItemType Junction -Path $CurrentDataLink -Target $DataDir | Out-Null
+    } catch {
+        Say 'Junction unsupported, falling back to copy'
+        Copy-Item -Recurse -Force $DataDir $CurrentDataLink
+    }
+
+    Say "Installing shim at $Shim"
+    $VolcaExe = Join-Path $VersionDir 'volca.exe'
+    @"
+@echo off
+rem Auto-generated by volca install.ps1 — do not edit. Re-run to regenerate.
+set "VOLCA_DATA_DIR=$CurrentDataLink"
+"$VolcaExe" %*
+"@ | Set-Content -Path $Shim -Encoding ASCII
+
+    # --- Post-install guidance ----------------------------------------------
+
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if (-not ($userPath -split ';' -contains $BinDir)) {
+        Write-Host ""
+        Write-Host "NOTE: $BinDir is not on your user PATH. To add it (this terminal only):"
+        Write-Host "    `$env:Path = '$BinDir;' + `$env:Path"
+        Write-Host "Or persist for future sessions:"
+        Write-Host "    [Environment]::SetEnvironmentVariable('Path', '$BinDir;' + [Environment]::GetEnvironmentVariable('Path', 'User'), 'User')"
+    }
+
+    Write-Host ""
+    Write-Host "volca $Version installed."
+    Write-Host "  binary:  $VolcaExe"
+    Write-Host "  data:    $CurrentDataLink -> $DataVersion"
+    Write-Host "  shim:    $Shim"
+    Write-Host ""
+    Write-Host "Try:  volca --version"
+}
+finally {
+    Remove-Item -Recurse -Force $Work -ErrorAction SilentlyContinue
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,182 @@
+#!/bin/sh
+# =============================================================================
+# volca installer (Linux + macOS)
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/ccomb/volca/main/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/ccomb/volca/main/install.sh | sh -s -- v0.7.0
+#
+# What it does:
+#   1. Detects platform (linux-amd64, linux-arm64, macos-arm64)
+#   2. Downloads volca-<version>-<platform>.tar.gz from the GH Release
+#   3. Downloads volca-data-<data-version>.tar.gz (the reference data bundle)
+#   4. Verifies both against SHA256SUMS
+#   5. Extracts to:
+#        ~/.local/share/volca/<version>/volca
+#        ~/.local/share/volca/data/<data-version>/{flows.csv,...}
+#      and points ~/.local/share/volca/data/current at <data-version>.
+#   6. Installs a thin shim at ~/.local/bin/volca that sets VOLCA_DATA_DIR
+#      and execs the real binary. The shim makes the data-bundle layout
+#      invisible to users — they just `volca …`.
+#
+# Windows:
+#   This script aborts. Use install.ps1 (or download from GH Releases).
+# =============================================================================
+
+set -eu
+
+REPO="ccomb/volca"
+PREFIX="${VOLCA_PREFIX:-$HOME/.local}"
+SHARE_DIR="$PREFIX/share/volca"
+BIN_DIR="$PREFIX/bin"
+SHIM="$BIN_DIR/volca"
+
+VERSION="${1:-}"
+
+err() { printf 'install.sh: %s\n' "$*" >&2; exit 1; }
+say() { printf '==> %s\n' "$*"; }
+
+# --- Platform detection ------------------------------------------------------
+
+UNAME_S=$(uname -s)
+UNAME_M=$(uname -m)
+
+case "$UNAME_S" in
+    Linux)
+        OS=linux
+        case "$UNAME_M" in
+            x86_64|amd64) ARCH=amd64 ;;
+            aarch64|arm64) ARCH=arm64 ;;
+            *) err "unsupported Linux arch: $UNAME_M" ;;
+        esac
+        ;;
+    Darwin)
+        OS=macos
+        case "$UNAME_M" in
+            arm64) ARCH=arm64 ;;
+            x86_64) err "macOS x86_64 is not built — use macos-arm64 (Apple Silicon)" ;;
+            *) err "unsupported macOS arch: $UNAME_M" ;;
+        esac
+        ;;
+    MINGW*|MSYS*|CYGWIN*)
+        err "Windows detected — use install.ps1 instead, or download from https://github.com/$REPO/releases"
+        ;;
+    *)
+        err "unsupported OS: $UNAME_S"
+        ;;
+esac
+PLATFORM="${OS}-${ARCH}"
+
+# --- Tooling sanity ----------------------------------------------------------
+
+for tool in curl tar; do
+    command -v "$tool" >/dev/null || err "missing required tool: $tool"
+done
+
+# Pick a SHA256 verifier. Linux ships sha256sum; macOS ships shasum.
+if command -v sha256sum >/dev/null; then
+    SHA256_CHECK() { sha256sum -c "$1"; }
+elif command -v shasum >/dev/null; then
+    SHA256_CHECK() { shasum -a 256 -c "$1"; }
+else
+    err "no SHA256 verifier (sha256sum / shasum) found"
+fi
+
+# --- Resolve release tag -----------------------------------------------------
+
+if [ -z "$VERSION" ]; then
+    say "Resolving latest release of $REPO"
+    VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+        | grep -o '"tag_name": *"[^"]*"' \
+        | head -n1 \
+        | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+    [ -n "$VERSION" ] || err "could not resolve latest release tag"
+fi
+case "$VERSION" in
+    v*) ;;
+    *) VERSION="v$VERSION" ;;
+esac
+PLAIN_VERSION="${VERSION#v}"
+
+say "Installing volca $VERSION for $PLATFORM"
+
+# --- Download SHA256SUMS first; it dictates which assets to fetch -----------
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+REL_BASE="https://github.com/$REPO/releases/download/$VERSION"
+
+say "Downloading SHA256SUMS"
+curl -fsSL "$REL_BASE/SHA256SUMS" -o "$WORK/SHA256SUMS"
+
+BIN_ASSET="volca-${PLAIN_VERSION}-${PLATFORM}.tar.gz"
+grep -q " $BIN_ASSET\$" "$WORK/SHA256SUMS" \
+    || err "release $VERSION has no asset $BIN_ASSET (check https://github.com/$REPO/releases/$VERSION)"
+
+# Find the data bundle line. Format: <sha>  volca-data-<version>.tar.gz
+DATA_ASSET=$(awk '{print $2}' "$WORK/SHA256SUMS" | grep '^volca-data-.*\.tar\.gz$' | head -n1)
+[ -n "$DATA_ASSET" ] || err "release $VERSION has no volca-data-* asset"
+DATA_VERSION=$(printf '%s' "$DATA_ASSET" | sed 's/^volca-data-\(.*\)\.tar\.gz$/\1/')
+
+# --- Download + verify -------------------------------------------------------
+
+say "Downloading $BIN_ASSET"
+curl -fsSL "$REL_BASE/$BIN_ASSET" -o "$WORK/$BIN_ASSET"
+
+say "Downloading $DATA_ASSET"
+curl -fsSL "$REL_BASE/$DATA_ASSET" -o "$WORK/$DATA_ASSET"
+
+# Verify only the two assets we care about (the SHA256SUMS file lists every
+# platform's tarball; restricting the check avoids "FAILED open or read" on
+# the platforms we didn't download).
+(cd "$WORK" && grep -E " ($BIN_ASSET|$DATA_ASSET)\$" SHA256SUMS > SHA256SUMS.local && SHA256_CHECK SHA256SUMS.local)
+
+# --- Install -----------------------------------------------------------------
+
+mkdir -p "$SHARE_DIR/$PLAIN_VERSION" "$SHARE_DIR/data/$DATA_VERSION" "$BIN_DIR"
+
+say "Extracting binary to $SHARE_DIR/$PLAIN_VERSION"
+tar -xzf "$WORK/$BIN_ASSET" -C "$SHARE_DIR/$PLAIN_VERSION"
+chmod +x "$SHARE_DIR/$PLAIN_VERSION/volca"
+
+say "Extracting data bundle to $SHARE_DIR/data/$DATA_VERSION"
+tar -xzf "$WORK/$DATA_ASSET" -C "$SHARE_DIR/data/$DATA_VERSION"
+
+# Atomic-ish "current" pointer. Symlink swap survives crashes; an in-place
+# overwrite would briefly leave the dir partial.
+rm -f "$SHARE_DIR/data/current"
+ln -s "$DATA_VERSION" "$SHARE_DIR/data/current"
+
+say "Installing shim at $SHIM"
+cat > "$SHIM" <<EOF
+#!/bin/sh
+# Auto-generated by volca install.sh — do not edit. Re-run install.sh
+# to regenerate after upgrading.
+export VOLCA_DATA_DIR="$SHARE_DIR/data/current"
+exec "$SHARE_DIR/$PLAIN_VERSION/volca" "\$@"
+EOF
+chmod +x "$SHIM"
+
+# --- Post-install guidance ---------------------------------------------------
+
+case ":${PATH:-}:" in
+    *":$BIN_DIR:"*) ;;
+    *)
+        cat <<EOF
+
+NOTE: $BIN_DIR is not on your PATH. Add it (in ~/.bashrc, ~/.zshrc, …):
+    export PATH="$BIN_DIR:\$PATH"
+EOF
+        ;;
+esac
+
+cat <<EOF
+
+volca $VERSION installed.
+  binary:    $SHARE_DIR/$PLAIN_VERSION/volca
+  data:      $SHARE_DIR/data/current  -> $DATA_VERSION
+  shim:      $SHIM
+
+Try:    volca --version
+EOF


### PR DESCRIPTION
## Summary

- \`install.sh\` (Linux + macOS): \`curl -fsSL …/install.sh | sh\`
- \`install.ps1\` (Windows): \`iwr -useb …/install.ps1 | iex\`

Both:

1. Detect platform (linux-amd64, linux-arm64, macos-arm64, windows-amd64).
2. Resolve target tag (latest by default, or arg-supplied).
3. Download the SHA256SUMS file, then the matching binary tarball + data bundle.
4. Verify both against SHA256SUMS.
5. Extract to \`~/.local/share/volca/{<version>,data/<data-version>}\` (or \`%LOCALAPPDATA%\\volca\\...\` on Windows).
6. Maintain a \`data/current\` pointer (symlink / NTFS junction / copy fallback).
7. Install a shim at \`~/.local/bin/volca\` (\`volca.cmd\` on Windows) that exports \`VOLCA_DATA_DIR\` and execs the real binary.
8. Print PATH guidance if the bin dir isn't on PATH.

Stacked on #5 — needs the data bundle + GH Release publishing landed first. Two short scripts, no clever shared template.

## Test plan

- [ ] Fresh Ubuntu container: \`curl -fsSL … | sh && volca --version\`
- [ ] Fresh macOS arm64: same
- [ ] Fresh Windows: \`iwr … | iex; volca --version\`
- [ ] Pinned version: \`curl -fsSL … | sh -s -- v0.7.0\`
- [ ] Repeat install: idempotent (no errors on re-run)