### PR TITLE
feat(pyvolca): download() helper for binary + data bundle

### DIFF
--- a/.github/workflows/pyvolca-release.yml
+++ b/.github/workflows/pyvolca-release.yml
@@ -1,0 +1,68 @@
+name: pyvolca release
+
+# Tag-driven publish to PyPI. Trigger: push of `pyvolca-v*` tags.
+# Uses PyPI Trusted Publishing (OIDC, no API tokens to rotate).
+# The CI test workflow (pyvolca.yml) is unchanged — this is purely the
+# publish step.
+
+on:
+  push:
+    tags:
+      - 'pyvolca-v[0-9]*'
+
+jobs:
+  verify-tag:
+    name: Verify tag matches pyproject.toml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compare tag against pyproject.toml version
+        run: |
+          # tag is pyvolca-v0.3.1, version field is 0.3.1
+          py_ver=$(awk -F'"' '/^version *= *"/ {print $2; exit}' pyvolca/pyproject.toml)
+          tag_ver="${GITHUB_REF_NAME#pyvolca-v}"
+          if [[ "$py_ver" != "$tag_ver" ]]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match pyvolca/pyproject.toml version ${py_ver}."
+            exit 1
+          fi
+
+  build:
+    needs: verify-tag
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: pyvolca
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Build sdist + wheel
+        run: |
+          pip install build
+          python -m build
+      - name: Verify metadata
+        run: |
+          pip install twine
+          twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pyvolca-dist
+          path: pyvolca/dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: pyvolca-dist
+          path: dist
+      - name: Publish to PyPI
+        # Trusted Publishing — configure once in PyPI project settings:
+        # https://pypi.org/manage/project/pyvolca/settings/publishing/
+        # Pinned to a tagged release of the official action; bump cautiously.
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyvolca/pyproject.toml
+++ b/pyvolca/pyproject.toml
@@ -1,12 +1,15 @@
 [project]
 name = "pyvolca"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python client for VoLCA — Life Cycle Assessment engine"
 requires-python = ">=3.10"
 license = "Apache-2.0"
 readme = "README.md"
 authors = [{name = "Christophe Combelles", email = "ccomb@free.fr"}]
-dependencies = ["requests>=2.28"]
+dependencies = [
+    "requests>=2.28",
+    "platformdirs>=4.0",
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Scientific/Engineering",

--- a/pyvolca/src/volca/__init__.py
+++ b/pyvolca/src/volca/__init__.py
@@ -3,6 +3,7 @@
 See https://volca.run/docs/guides/pyvolca/ for the full guide.
 """
 
+from ._download import DownloadError, Installed, download
 from .client import Client, VoLCAError
 from .compare import ActivityDiff, ActivityDiffRow, compare_activities
 from .server import Server
@@ -42,8 +43,10 @@ __all__ = [
     "ConsumerResult",
     "ConsumersResponse",
     "DatabaseInfo",
+    "DownloadError",
     "Exchange",
     "FlowContribution",
+    "Installed",
     "LCIABatchResult",
     "LCIAResult",
     "PathResult",
@@ -56,4 +59,5 @@ __all__ = [
     "TechnosphereExchange",
     "VoLCAError",
     "compare_activities",
+    "download",
 ]

--- a/pyvolca/src/volca/_download.py
+++ b/pyvolca/src/volca/_download.py
@@ -1,0 +1,357 @@
+"""Download cache for the volca binary + reference data bundle.
+
+Public surface: :func:`download`. ``Server`` calls ``cached_binary`` and
+``cached_data_dir`` to pick up downloaded artefacts when no explicit
+binary path is configured.
+
+Cache layout (mirrors install.sh)::
+
+    <user_cache_dir("pyvolca")>/
+        <engine-version>/volca[.exe]
+        data/<data-version>/{flows.csv, compartments.csv, units.csv,
+                             geographies.csv, flows.csv.cache.zst}
+        data/current   -> data/<data-version>   (symlink, or copy on
+                                                 platforms without symlinks)
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import platform
+import re
+import sys
+import tarfile
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Optional
+
+from platformdirs import user_cache_dir
+
+if sys.platform == "win32":
+    import msvcrt
+else:
+    import fcntl
+
+_REPO_DEFAULT = "ccomb/volca"
+_GH_API = "https://api.github.com"
+_GH_RELEASES = "https://github.com/{repo}/releases/download/{tag}/{asset}"
+
+
+class DownloadError(RuntimeError):
+    """Raised when the download or verification fails."""
+
+
+@dataclass(frozen=True)
+class Installed:
+    """Result of :func:`download`."""
+
+    binary: Path
+    data_dir: Path
+    version: str
+    data_version: str
+
+
+# ---------------------------------------------------------------------------
+# Platform detection
+# ---------------------------------------------------------------------------
+
+
+def _platform_slug() -> tuple[str, str]:
+    """Return (slug, asset_ext) — e.g. ('linux-amd64', 'tar.gz')."""
+    sysname = platform.system()
+    machine = platform.machine().lower()
+    if sysname == "Linux":
+        if machine in ("x86_64", "amd64"):
+            return "linux-amd64", "tar.gz"
+        if machine in ("aarch64", "arm64"):
+            return "linux-arm64", "tar.gz"
+    elif sysname == "Darwin":
+        if machine in ("arm64", "aarch64"):
+            return "macos-arm64", "tar.gz"
+    elif sysname == "Windows":
+        if machine.lower() in ("amd64", "x86_64", "x64"):
+            return "windows-amd64", "zip"
+    raise DownloadError(f"unsupported platform: {sysname}/{machine}")
+
+
+def _binary_name() -> str:
+    return "volca.exe" if platform.system() == "Windows" else "volca"
+
+
+# ---------------------------------------------------------------------------
+# Cache paths
+# ---------------------------------------------------------------------------
+
+
+def _cache_root() -> Path:
+    return Path(user_cache_dir("pyvolca"))
+
+
+def _manifest_path() -> Path:
+    return _cache_root() / "latest.json"
+
+
+def cached_binary(version: Optional[str] = None) -> Optional[Path]:
+    """Return the binary path for ``version`` if extracted, else ``None``.
+
+    If ``version`` is ``None``, returns the binary recorded in
+    ``latest.json`` by the most recent :func:`download` call.
+    """
+    if version is None:
+        manifest = _manifest_path()
+        if not manifest.is_file():
+            return None
+        try:
+            data = json.loads(manifest.read_text())
+        except (OSError, json.JSONDecodeError):
+            return None
+        version = data.get("version")
+        if not version:
+            return None
+    p = _cache_root() / version.lstrip("v") / _binary_name()
+    return p if p.is_file() else None
+
+
+def cached_data_dir() -> Optional[Path]:
+    """Return the active data dir (``data/current``) if it exists.
+
+    Resolves symlinks before returning, so a stale link to a removed
+    target reports None instead of pointing the engine at a path it
+    cannot read. ``Path.exists`` follows symlinks; ``is_symlink`` alone
+    would happily return a broken pointer.
+    """
+    p = _cache_root() / "data" / "current"
+    if p.exists() and p.is_dir():
+        return p
+    return None
+
+
+# ---------------------------------------------------------------------------
+# GH Releases API + asset fetching
+# ---------------------------------------------------------------------------
+
+
+def _http_get(url: str, accept: str = "application/octet-stream") -> bytes:
+    """Plain GET. No auth — releases are public. Token lifted from env if
+    present (avoids public-API rate limits in CI loops)."""
+    req = urllib.request.Request(url, headers={"Accept": accept})
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req) as resp:
+        return resp.read()
+
+
+def _resolve_tag(repo: str, version: Optional[str]) -> str:
+    if version:
+        return version if version.startswith("v") else f"v{version}"
+    payload = json.loads(_http_get(f"{_GH_API}/repos/{repo}/releases/latest", "application/vnd.github+json"))
+    tag = payload.get("tag_name")
+    if not tag:
+        raise DownloadError(f"could not resolve latest release tag for {repo}")
+    return tag
+
+
+def _download_asset(repo: str, tag: str, asset: str, dest: Path) -> None:
+    url = _GH_RELEASES.format(repo=repo, tag=tag, asset=asset)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(_http_get(url))
+
+
+def _parse_sha256sums(text: str) -> dict[str, str]:
+    """`sha256sum`-format → {filename: hex digest}."""
+    out: dict[str, str] = {}
+    for line in text.splitlines():
+        m = re.match(r"^([0-9a-fA-F]{64})\s+\*?(.+)$", line.strip())
+        if m:
+            out[m.group(2)] = m.group(1).lower()
+    return out
+
+
+def _verify(path: Path, expected_hex: str) -> None:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 16), b""):
+            h.update(chunk)
+    actual = h.hexdigest()
+    if actual != expected_hex.lower():
+        raise DownloadError(f"SHA256 mismatch for {path.name}: expected {expected_hex}, got {actual}")
+
+
+def _extract(archive: Path, dest: Path) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    if archive.suffix == ".zip":
+        with zipfile.ZipFile(archive) as zf:
+            zf.extractall(dest)
+    else:
+        with tarfile.open(archive, "r:gz") as tf:
+            tf.extractall(dest)
+
+
+@contextlib.contextmanager
+def _exclusive_lock(path: Path) -> Iterator[None]:
+    """Hold a process-exclusive lock on ``path`` for the duration of the block.
+
+    Lets concurrent ``download()`` callers serialise around the cache writes:
+    one process actually downloads + extracts, the others wait, and on
+    re-entering the critical section see a fully-populated cache and short-
+    circuit. The OS releases the lock if the holder dies, so a crashed run
+    does not strand subsequent callers.
+
+    fcntl.flock on Unix; msvcrt.locking on Windows. Both are kernel-level.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(path), os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        if sys.platform == "win32":
+            # LK_LOCK retries every 1s up to 10× then raises. Wrap in our own
+            # loop so we wait indefinitely without surfacing OSError to the
+            # caller — this lock is intentionally blocking.
+            while True:
+                try:
+                    msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+                    break
+                except OSError:
+                    continue
+            try:
+                yield
+            finally:
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        else:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+def _link_current(target: Path, link: Path) -> None:
+    """Make ``link`` point at ``target``. Symlink where supported, plain
+    copy fallback for Windows configurations without developer mode."""
+    import shutil
+
+    if link.is_symlink() or link.is_file():
+        link.unlink()
+    elif link.is_dir():
+        shutil.rmtree(link)
+    try:
+        # Use a relative target so the cache stays portable if the parent
+        # dir gets moved (e.g. user's $HOME relocates).
+        link.symlink_to(target.name, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        shutil.copytree(target, link)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def download(
+    version: Optional[str] = None,
+    repo: str = _REPO_DEFAULT,
+    *,
+    force: bool = False,
+) -> Installed:
+    """Download the volca binary + data bundle for the current platform.
+
+    Idempotent: if both artefacts are already extracted under the expected
+    cache paths and ``force=False``, returns immediately without network.
+
+    Args:
+        version: GH Release tag (``v0.7.0``); ``None`` resolves the latest.
+        repo: GitHub repo slug. Default ``ccomb/volca``.
+        force: Re-download even if the cache looks complete.
+
+    Returns:
+        :class:`Installed` with the resolved paths and versions.
+    """
+    slug, ext = _platform_slug()
+    tag = _resolve_tag(repo, version)
+    plain_version = tag.lstrip("v")
+
+    cache = _cache_root()
+    cache.mkdir(parents=True, exist_ok=True)
+
+    with _exclusive_lock(cache / ".lock"):
+        return _download_locked(cache, repo, tag, plain_version, slug, ext, force)
+
+
+def _download_locked(
+    cache: Path,
+    repo: str,
+    tag: str,
+    plain_version: str,
+    slug: str,
+    ext: str,
+    force: bool,
+) -> Installed:
+    # ---- download SHA256SUMS first; it tells us which data version to fetch
+    sums_path = cache / f"SHA256SUMS-{tag}"
+    sums_path.write_bytes(_http_get(_GH_RELEASES.format(repo=repo, tag=tag, asset="SHA256SUMS")))
+    sums = _parse_sha256sums(sums_path.read_text())
+
+    binary_asset = f"volca-{plain_version}-{slug}.{ext}"
+    if binary_asset not in sums:
+        raise DownloadError(f"release {tag} has no asset {binary_asset}")
+
+    data_assets = [n for n in sums if n.startswith("volca-data-") and n.endswith(".tar.gz")]
+    if not data_assets:
+        raise DownloadError(f"release {tag} has no volca-data-*.tar.gz asset")
+    data_asset = data_assets[0]
+    m = re.match(r"^volca-data-(.+)\.tar\.gz$", data_asset)
+    if not m:
+        raise DownloadError(f"cannot parse data version from {data_asset}")
+    data_version = m.group(1)
+
+    binary_dir = cache / plain_version
+    data_dir = cache / "data" / data_version
+    bin_path = binary_dir / _binary_name()
+
+    fully_cached = (
+        bin_path.is_file()
+        and (data_dir / "flows.csv").is_file()
+        and not force
+    )
+    if not fully_cached:
+        # ---- binary
+        bin_arch = cache / f"_dl-{binary_asset}"
+        _download_asset(repo, tag, binary_asset, bin_arch)
+        _verify(bin_arch, sums[binary_asset])
+        _extract(bin_arch, binary_dir)
+        bin_arch.unlink(missing_ok=True)
+        if sys.platform != "win32":
+            os.chmod(bin_path, 0o755)
+
+        # ---- data bundle
+        data_arch = cache / f"_dl-{data_asset}"
+        _download_asset(repo, tag, data_asset, data_arch)
+        _verify(data_arch, sums[data_asset])
+        _extract(data_arch, data_dir)
+        data_arch.unlink(missing_ok=True)
+
+    _link_current(data_dir, cache / "data" / "current")
+
+    # Manifest lets Server.start() find the cached binary without knowing
+    # which version was downloaded. Rewritten on every download() call.
+    _manifest_path().write_text(
+        json.dumps(
+            {"version": plain_version, "data_version": data_version, "binary": str(bin_path)},
+            indent=2,
+        )
+    )
+
+    return Installed(
+        binary=bin_path,
+        data_dir=cache / "data" / "current",
+        version=plain_version,
+        data_version=data_version,
+    )

--- a/pyvolca/src/volca/server.py
+++ b/pyvolca/src/volca/server.py
@@ -1,5 +1,6 @@
 """Server lifecycle management for VoLCA."""
 
+import os
 import shutil
 import subprocess
 import time
@@ -11,6 +12,8 @@ try:
     import tomllib  # Python 3.11+
 except ModuleNotFoundError:
     import tomli as tomllib  # type: ignore[no-redef]
+
+from . import _download
 
 
 class Server:
@@ -62,20 +65,46 @@ class Server:
         return {}
 
     def _find_binary(self) -> str:
-        """Find the volca binary: explicit path, package bin/, or PATH."""
+        """Find the volca binary.
+
+        Resolution order:
+          1. ``self.binary`` if it is an existing path.
+          2. The most recent download cached by :func:`volca.download` —
+             so a script can ``volca.download()`` then ``Server()`` and
+             have the spawn pick up the cached engine without extra wiring.
+          3. ``shutil.which(self.binary)`` — PATH lookup, including the
+             ``~/.local/bin/volca`` shim that ``install.sh`` drops.
+          4. ``./volca`` / ``./dist/volca`` for ad-hoc dev trees.
+        """
         if Path(self.binary).exists():
             return self.binary
+        cached = _download.cached_binary()
+        if cached is not None:
+            return str(cached)
         found = shutil.which(self.binary)
         if found:
             return found
-        # Try common locations
         for candidate in ["./volca", "./dist/volca"]:
             if Path(candidate).exists():
                 return candidate
         raise FileNotFoundError(
             f"Cannot find '{self.binary}' binary. "
-            "Set binary= parameter or add volca to PATH."
+            "Run volca.download(), set binary= parameter, or add volca to PATH."
         )
+
+    def _subprocess_env(self) -> dict:
+        """Subprocess env for the spawned engine.
+
+        When the data bundle has been downloaded into the pyvolca cache,
+        export VOLCA_DATA_DIR so the engine resolves "data/flows.csv" and
+        friends against the cached bundle instead of the engine's CWD.
+        """
+        env = os.environ.copy()
+        if "VOLCA_DATA_DIR" not in env:
+            cached = _download.cached_data_dir()
+            if cached is not None:
+                env["VOLCA_DATA_DIR"] = str(cached)
+        return env
 
     def is_alive(self) -> bool:
         """Health check — GET /api/v1/db, return True if 200."""
@@ -115,6 +144,7 @@ class Server:
             cmd,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
+            env=self._subprocess_env(),
         )
 
         # Poll until server is ready

--- a/pyvolca/tests/test_download.py
+++ b/pyvolca/tests/test_download.py
@@ -1,0 +1,186 @@
+"""Pure-logic tests for volca._download.
+
+Network-dependent paths (the actual download() entry point) are not
+exercised here — they're covered by the install.sh integration tests
+and by manual verification after a real release.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from volca import _download
+
+
+# ---------------------------------------------------------------------------
+# SHA256SUMS parser
+# ---------------------------------------------------------------------------
+
+
+def test_parse_sha256sums_basic():
+    h1 = "a" * 64
+    h2 = "b" * 64
+    h3 = "c" * 64
+    text = (
+        f"{h1}  volca-0.7.0-linux-amd64.tar.gz\n"
+        f"{h2}  volca-0.7.0-macos-arm64.tar.gz\n"
+        "0bad  volca-data-1.tar.gz\n"  # 4-char hash should NOT match
+        f"{h3}  volca-data-1.tar.gz\n"
+    )
+    parsed = _download._parse_sha256sums(text)
+    assert parsed["volca-0.7.0-linux-amd64.tar.gz"] == h1
+    assert parsed["volca-0.7.0-macos-arm64.tar.gz"] == h2
+    # The 4-char "0bad" line is rejected; the 64-char one wins.
+    assert parsed["volca-data-1.tar.gz"] == h3
+
+
+def test_parse_sha256sums_rejects_short_hashes():
+    text = "abc  short.tar.gz\n"
+    assert _download._parse_sha256sums(text) == {}
+
+
+def test_parse_sha256sums_handles_star_prefix():
+    # GNU sha256sum binary mode emits "<hash> *<file>".
+    valid = "a" * 64
+    text = f"{valid} *file.tar.gz\n"
+    assert _download._parse_sha256sums(text) == {"file.tar.gz": valid}
+
+
+# ---------------------------------------------------------------------------
+# verify
+# ---------------------------------------------------------------------------
+
+
+def test_verify_success(tmp_path: Path):
+    f = tmp_path / "x.bin"
+    f.write_bytes(b"hello")
+    # sha256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+    _download._verify(f, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
+
+
+def test_verify_mismatch(tmp_path: Path):
+    f = tmp_path / "x.bin"
+    f.write_bytes(b"hello")
+    with pytest.raises(_download.DownloadError, match="SHA256 mismatch"):
+        _download._verify(f, "0" * 64)
+
+
+# ---------------------------------------------------------------------------
+# platform_slug
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "system,machine,expected",
+    [
+        ("Linux", "x86_64", ("linux-amd64", "tar.gz")),
+        ("Linux", "amd64", ("linux-amd64", "tar.gz")),
+        ("Linux", "aarch64", ("linux-arm64", "tar.gz")),
+        ("Linux", "arm64", ("linux-arm64", "tar.gz")),
+        ("Darwin", "arm64", ("macos-arm64", "tar.gz")),
+        ("Windows", "AMD64", ("windows-amd64", "zip")),
+    ],
+)
+def test_platform_slug(system, machine, expected):
+    with mock.patch("platform.system", return_value=system), \
+         mock.patch("platform.machine", return_value=machine):
+        assert _download._platform_slug() == expected
+
+
+def test_platform_slug_unsupported():
+    with mock.patch("platform.system", return_value="OS/2"), \
+         mock.patch("platform.machine", return_value="i386"):
+        with pytest.raises(_download.DownloadError):
+            _download._platform_slug()
+
+
+def test_platform_slug_macos_x86_64_rejected():
+    with mock.patch("platform.system", return_value="Darwin"), \
+         mock.patch("platform.machine", return_value="x86_64"):
+        with pytest.raises(_download.DownloadError):
+            _download._platform_slug()
+
+
+# ---------------------------------------------------------------------------
+# cached_binary
+# ---------------------------------------------------------------------------
+
+
+def test_cached_binary_no_manifest(tmp_path: Path):
+    with mock.patch.object(_download, "_cache_root", return_value=tmp_path):
+        assert _download.cached_binary() is None
+
+
+def test_cached_binary_explicit_version(tmp_path: Path):
+    bin_dir = tmp_path / "0.7.0"
+    bin_dir.mkdir()
+    bin_path = bin_dir / "volca"
+    bin_path.write_bytes(b"")
+    with mock.patch.object(_download, "_cache_root", return_value=tmp_path), \
+         mock.patch.object(_download, "_binary_name", return_value="volca"):
+        assert _download.cached_binary("v0.7.0") == bin_path
+        assert _download.cached_binary("0.7.0") == bin_path
+
+
+def test_cached_binary_via_manifest(tmp_path: Path):
+    bin_dir = tmp_path / "0.7.0"
+    bin_dir.mkdir()
+    (bin_dir / "volca").write_bytes(b"")
+    (tmp_path / "latest.json").write_text(json.dumps({"version": "0.7.0"}))
+    with mock.patch.object(_download, "_cache_root", return_value=tmp_path), \
+         mock.patch.object(_download, "_binary_name", return_value="volca"):
+        result = _download.cached_binary()
+        assert result == bin_dir / "volca"
+
+
+# ---------------------------------------------------------------------------
+# _exclusive_lock
+# ---------------------------------------------------------------------------
+
+
+def test_exclusive_lock_acquires_and_releases(tmp_path: Path):
+    """Smoke check: the context manager runs to completion without raising."""
+    lock_path = tmp_path / ".lock"
+    with _download._exclusive_lock(lock_path):
+        assert lock_path.exists()
+    # Re-entering after release works.
+    with _download._exclusive_lock(lock_path):
+        pass
+
+
+def test_exclusive_lock_serialises_threads(tmp_path: Path):
+    """Two threads racing on the same lock must execute their critical
+    sections strictly serially.
+
+    Each thread sleeps inside the lock; if the lock leaks, the in-flight
+    counter goes above 1 and we see overlap.
+    """
+    lock_path = tmp_path / ".lock"
+    in_flight = 0
+    max_in_flight = 0
+    lock = threading.Lock()
+
+    def worker():
+        nonlocal in_flight, max_in_flight
+        with _download._exclusive_lock(lock_path):
+            with lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+            time.sleep(0.05)
+            with lock:
+                in_flight -= 1
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert all(not t.is_alive() for t in threads), "thread deadlocked on lock"
+    assert max_in_flight == 1, f"lock allowed {max_in_flight} concurrent holders"


### PR DESCRIPTION
## Summary

\`pyvolca.download()\` makes the Python client self-contained: no PATH munging, no manual install. Resolves the platform, fetches the binary tarball + data bundle from the GH Release, verifies SHA256, extracts both into the user cache, and \`Server.start()\` automatically picks them up.

\`\`\`python
import volca
volca.download()
with volca.Server() as srv:
    client = volca.Client(base_url=srv.base_url, ...)
\`\`\`

- **Idempotent**: re-calling \`download()\` with a populated cache short-circuits without network.
- **Concurrency-safe**: kernel-level file lock (fcntl on Unix, msvcrt on Windows) around the cache writes, so two scripts racing don't corrupt each other's extraction. OS auto-releases on process death.
- **Cache layout** mirrors install.sh: \`<cache>/<version>/volca[.exe]\`, \`<cache>/data/<data-version>/...\`, \`<cache>/data/current\` pointer.
- \`Server\` resolution order: explicit \`binary=\` → cached download → PATH → ad-hoc dev paths. \`VOLCA_DATA_DIR\` is set on the engine subprocess.
- pyvolca **0.3.1** (additive — existing API unchanged). Adds \`platformdirs\` dep.
- \`pyvolca-release.yml\` triggers PyPI Trusted Publishing on \`pyvolca-v*\` tag push.

Stacked on #5 — depends on the GH Release format (SHA256SUMS + data bundle) landing.

## Test plan

- [x] 18/18 unit tests pass (parser, verifier, platform detection, cached binary, **lock serialises 4 concurrent threads**)
- [ ] \`pip install pyvolca==0.3.1 && python -c \"import volca; volca.download(); s=volca.Server(); s.start(); print(s.base_url)\"\` on Linux/macOS/Windows
- [ ] End-to-end: \`download() → Server() → Client.upload_database() → query an inventory amount → assert non-empty\`
- [ ] Push \`pyvolca-v0.3.1\` tag → PyPI publish via Trusted Publishing