### PR TITLE
release: v0.6.0

### DIFF
--- a/volca.cabal
+++ b/volca.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                volca
-version:             0.6.0-dev
+version:             0.6.0
 build-type:          Simple
 
 license:             Apache-2.0


### PR DESCRIPTION
## Summary

Bump `volca.cabal` version from `0.6.0-dev` to `0.6.0` ahead of pushing the `v0.6.0` tag.

The `verify-tag` job in `release.yml` requires the cabal version to match the tag, so this PR must merge before the tag is pushed.

## Procedure

1. Merge this PR.
2. From `main`: `git tag v0.6.0 && git push origin v0.6.0`.
3. `release.yml` fires: matrix builds → publish job creates the GitHub Release with the four binary tarballs/zip + data bundle + SHA256SUMS.
4. Follow-up: bump `volca.cabal` to `0.6.1-dev` to reopen the dev cycle.

## Note on the orphan tag

A previous push of `v0.6.0` was rejected by `verify-tag` (it pointed at a commit where `volca.cabal` still said `0.6.0-dev`). The orphan tag must be deleted before the new tag can be pushed:

```bash
git push origin :refs/tags/v0.6.0
git tag -d v0.6.0
```

## Test plan

- [ ] Merge → from `main` push `v0.6.0` → `release.yml` succeeds → 4 platform tarballs + data bundle + SHA256SUMS attached to a new GH Release.