### PR TITLE
fix(ci): Windows 7z absolute path + rename matrix job to build

### DIFF
--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -367,7 +367,11 @@ jobs:
           cp "$VOLCA_BIN" staging/
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             ARTIFACT="volca-${VERSION}-${NAME}.zip"
-            (cd staging && 7z a "../${ARTIFACT}" volca.exe)
+            # 7z is preinstalled on the Windows runner image but lives at
+            # C:\Program Files\7-Zip\, which is on Windows' PATH but not on
+            # MSYS2 bash's PATH (the shell this step runs under). Use the
+            # absolute path explicitly.
+            (cd staging && "/c/Program Files/7-Zip/7z.exe" a "../${ARTIFACT}" volca.exe)
           else
             ARTIFACT="volca-${VERSION}-${NAME}.tar.gz"
             tar -czf "${ARTIFACT}" -C staging volca

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
 name: Build
 
 # Slim wrapper around the reusable _build-matrix.yml. PR-only — no
-# push: main, no push: branches. The 4-platform matrix runs on every
-# push to any PR branch, and the matrix is the required status check
-# that gates merging.
+# push: main, no push: branches. The 4-platform build runs on every
+# push to any PR branch, and is the required status check that gates
+# merging.
 #
 # Pyvolca PRs are skipped: pyvolca dispatches dynamically against the
 # engine's OpenAPI spec, so its changes don't affect the Haskell build —
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  matrix:
+  build:
     uses: ./.github/workflows/_build-matrix.yml
     with:
       release: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: Release
 # Calls the reusable _build-matrix.yml in release mode, then publishes a
 # GH Release with all platform tarballs + SHA256SUMS.
 #
-# The matrix is the same one PRs run, so what users download is bit-for-bit
+# The build is the same one PRs run, so what users download is bit-for-bit
 # what merged into main — no separate "release-only" build path that could
 # drift.
 
@@ -29,7 +29,7 @@ jobs:
             exit 1
           fi
 
-  matrix:
+  build:
     needs: verify-tag
     uses: ./.github/workflows/_build-matrix.yml
     with:
@@ -37,14 +37,14 @@ jobs:
 
   publish:
     name: Publish GitHub Release
-    needs: matrix
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download all matrix artefacts
+      - name: Download all build artefacts
         uses: actions/download-artifact@v4
         with:
           path: dist

--- a/docs/release.md
+++ b/docs/release.md
@@ -20,8 +20,10 @@ PR should never bump both.
 Configure once via the GitHub repo settings, then leave alone:
 
 - **Require a PR before merging to main.** Disallow direct pushes.
-- **Require all 4 matrix jobs as required status checks.** GitHub
-  auto-disables the Squash/Merge button until they're green.
+- **Require all 4 build jobs as required status checks**
+  (`build / linux-amd64`, `build / linux-arm64`, `build / windows-amd64`,
+  `build / macos-arm64`). GitHub auto-disables the Squash/Merge button
+  until they're green.
 - **Restrict who can push tags matching `v*` to maintainers.** Add a
   rule under "Tag protection rules" — accidental tag pushes from
   contributors otherwise trigger releases.
@@ -43,7 +45,7 @@ The PR should:
 
 ### 2. Wait for green CI
 
-The 4-platform matrix in `build.yml` must pass. Branch protection
+The 4-platform build in `build.yml` must pass. Branch protection
 disables the merge button until it does.
 
 ### 3. Squash-merge
@@ -64,7 +66,7 @@ git push origin v0.7.0
 
 1. Verify `tag == "v$(awk '/^version:/' volca.cabal)"` — fails fast if
    the cabal bump was forgotten.
-2. Re-run the 4-platform matrix in **release mode** (`_build-matrix.yml`
+2. Re-run the 4-platform build in **release mode** (`_build-matrix.yml`
    with `release: true`), packaging each platform's binary as
    `volca-<version>-<os>-<arch>.{tar.gz,zip}`.
 3. Generate `SHA256SUMS` for all artefacts.


### PR DESCRIPTION
## Summary

- **Commit 1** unblocks tag-driven releases. `_build-matrix.yml`'s "Package release tarball" step runs under MSYS2 bash, where `7z` is not on PATH (it lives at `C:\Program Files\7-Zip\` on the Windows runner image — Windows PATH only). Resolved by invoking it via the absolute `/c/Program Files/7-Zip/7z.exe` path. PR-mode (`build.yml`) never exercises this step (it's gated `if: inputs.release`), which is why the bug only surfaced on the `v0.6.0` tag push.
- **Commit 2** renames the caller-side job key `matrix` → `build` in both `build.yml` and `release.yml`. The GH Actions run page now shows `build / linux-amd64` etc. instead of `matrix / linux-amd64`. Pure cosmetic — the inner reusable workflow's `strategy.matrix` is unchanged (and `_build-matrix.yml` keeps its name, since it really does run a matrix).

## Why both in one PR

Two tiny commits, one CI run. Either alone would be a one-line PR.

## Manual follow-up after merge

Branch protection's required status checks reference the old `matrix / *` names. Update them:

1. Repo Settings → Branches → branch protection rule for `main` → "Require status checks to pass"
2. Re-pick the 4 build jobs: `build / linux-amd64`, `build / linux-arm64`, `build / windows-amd64`, `build / macos-arm64`

Then to recover `v0.6.0`:

1. Delete the existing `v0.6.0` tag (locally and on remote — may need to be done via Settings → Tags if tag protection is on).
2. Re-tag from main: `git tag -s v0.6.0 -m "v0.6.0" && git push origin v0.6.0`.
3. The release workflow re-runs end-to-end and creates the GH Release with all 4 tarballs/zips + SHA256SUMS.

## Test plan

- [x] PR CI run shows job names as `build / linux-amd64`, `build / linux-arm64`, `build / windows-amd64`, `build / macos-arm64`
- [x] All 4 platform builds pass on this PR (sanity — the 7z step is release-only so won't actually run here, but unrelated breakage would still surface)
- [x] After merge + re-tagging `v0.6.0`: Windows packaging step succeeds, `volca-0.6.0-windows-amd64.zip` is attached to the GH Release alongside the other 3 tarballs and `SHA256SUMS`