### PR TITLE
chore(release): bump cabal to 0.6.1-dev

### DIFF
--- a/volca.cabal
+++ b/volca.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                volca
-version:             0.6.0
+version:             0.6.1-dev
 build-type:          Simple
 
 license:             Apache-2.0


### PR DESCRIPTION
## Summary

Post-v0.6.0 dev-version marker, per `docs/release.md` step 5.

```diff
-version:             0.6.0
+version:             0.6.1-dev
```

Picked patch (`0.6.1`) over minor (`0.7.0`) on the assumption the next release is maintenance. If a feature release lands first, a one-line follow-up can re-bump to `0.7.0-dev`.

## Test plan

- [x] PR CI (`build / *`) all green on this branch