### PR TITLE
ci(linux): use system libmumps-seq-dev instead of building from source

### DIFF
--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -251,13 +251,44 @@ jobs:
       # `if: always()` so a downstream test failure or hang does not
       # discard a 30-min cold cabal compile that did succeed.
 
+      - name: Stage system MUMPS as deps/mumps (Linux)
+        if: matrix.os == 'linux'
+        # Use the static archives shipped by libmumps-seq-dev (installed
+        # above) as if they were a local source build. Why deps/mumps/ and
+        # not the system path:
+        #
+        # mumps-hs.cabal declares `extra-libraries: dmumps_seq, ...`. Cabal
+        # injects `-ldmumps_seq -lmumps_common_seq -lpord_seq -lmpiseq_seq`
+        # into the link line. If we point cabal at /usr/lib/<multiarch>
+        # directly, the linker sees both .a and .so for each name and
+        # prefers .so → DT_NEEDED dynamic dep on libdmumps_seq.so.5,
+        # breaking the standalone-binary UX. Copying only the .a files
+        # to a private dir leaves the linker no choice but static.
+        #
+        # Populating deps/mumps/ also makes build.sh's existing detection
+        # at line ~282 hit MUMPS_BUILT_LOCALLY=true → LINK_MODE=static,
+        # so no extra build.sh flag is needed.
+        run: |
+          LIBDIR=/usr/lib/$(gcc -print-multiarch)
+          mkdir -p deps/mumps/lib deps/mumps/include
+          cp "$LIBDIR/libdmumps_seq.a" \
+             "$LIBDIR/libmumps_common_seq.a" \
+             "$LIBDIR/libpord_seq.a" \
+             "$LIBDIR/libmpiseq_seq.a" \
+             deps/mumps/lib/
+          # mumps-hs/cbits/mumps_wrapper.c #includes <dmumps_c.h>; copy
+          # the whole MUMPS header set + the libseq mpi.h stub liberally
+          # so transitive includes resolve regardless of Debian's exact
+          # header layout (which has shifted between releases).
+          find /usr/include -maxdepth 2 \
+            \( -name '*mumps*' -o -name 'mpi.h' \) \
+            -exec cp -r {} deps/mumps/include/ \;
+          ls -la deps/mumps/lib/ deps/mumps/include/
+
       - name: Restore MUMPS local build
         id: cache-mumps
-        # Linux uses the apt package libmumps-seq-dev (installed in the
-        # build-deps step). Skip the local-build cache so build.sh's
-        # detection chain (which prefers $LOCAL_MUMPS_DIR over the system
-        # path) sees the empty deps/mumps and falls through to the system
-        # libraries. macOS and Windows still build from source.
+        # Linux is staged from the apt package (step above), no source-build
+        # cache. macOS and Windows still build from source.
         if: matrix.os != 'linux'
         uses: actions/cache/restore@v4
         with:
@@ -312,14 +343,32 @@ jobs:
           elif [[ "$RUNNER_OS" == "macOS" ]]; then
             ./build.sh --test --no-optimize
           else
-            # Linux: --static keeps the same statically-linked-MUMPS profile
-            # we had when CI built MUMPS from source. Without --static, system
-            # MUMPS would be detected and dynamically linked, leaving an
-            # `libdmumps_seq.so.5` runtime dep on the shipped tarball — a UX
-            # regression. The .a archives ship in the libmumps-seq-dev apt
-            # package alongside the .so, so static linking still works.
-            ./build.sh --test --static
+            ./build.sh --test
           fi
+
+      - name: Verify static MUMPS link (Linux)
+        # Regression guard: the shipped tarball must not depend on
+        # libdmumps_seq.so / libmumps_common_seq.so / libpord_seq.so /
+        # libmpiseq_seq.so at runtime — end users would have to apt-install
+        # libmumps-seq separately, which breaks the standalone-binary UX.
+        # Catches the case where a future change reintroduces dynamic
+        # MUMPS linking (e.g. by pointing extra-lib-dirs at /usr/lib/<arch>
+        # which has both .a and .so).
+        if: matrix.os == 'linux'
+        run: |
+          VOLCA_BIN=$(cabal list-bin exe:volca)
+          # Decompress UPX wrapper if present so ldd can read the dynamic
+          # section (UPX strips section headers; ldd then says "not a
+          # dynamic executable" regardless of actual linkage).
+          cp "$VOLCA_BIN" /tmp/volca-ldd-check
+          upx -d /tmp/volca-ldd-check >/dev/null 2>&1 || true
+          deps=$(ldd /tmp/volca-ldd-check 2>/dev/null | grep -E 'libdmumps_seq|libmumps_common_seq|libpord_seq|libmpiseq_seq' || true)
+          if [[ -n "$deps" ]]; then
+            echo "::error::Binary has dynamic MUMPS dependencies — static link failed:"
+            echo "$deps"
+            exit 1
+          fi
+          echo "OK: no MUMPS shared library dependencies in the shipped binary."
 
       - name: Optimize macOS binary (strip + ad-hoc sign)
         # Tests above ran on the unstripped binary because UPX'd Mach-O on

--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -132,7 +132,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             build-essential gfortran cmake python3 curl \
-            zlib1g-dev liblapack-dev libblas-dev upx-ucl
+            zlib1g-dev liblapack-dev libblas-dev upx-ucl \
+            libmumps-seq-dev
           # gcc's gfortran spec auto-adds -lquadmath when linking
           # gfortran archives (libdmumps_seq.a). amd64 ships
           # /usr/lib/x86_64-linux-gnu/libquadmath.so; arm64 noble ships
@@ -252,6 +253,12 @@ jobs:
 
       - name: Restore MUMPS local build
         id: cache-mumps
+        # Linux uses the apt package libmumps-seq-dev (installed in the
+        # build-deps step). Skip the local-build cache so build.sh's
+        # detection chain (which prefers $LOCAL_MUMPS_DIR over the system
+        # path) sees the empty deps/mumps and falls through to the system
+        # libraries. macOS and Windows still build from source.
+        if: matrix.os != 'linux'
         uses: actions/cache/restore@v4
         with:
           path: deps/mumps
@@ -305,7 +312,13 @@ jobs:
           elif [[ "$RUNNER_OS" == "macOS" ]]; then
             ./build.sh --test --no-optimize
           else
-            ./build.sh --test
+            # Linux: --static keeps the same statically-linked-MUMPS profile
+            # we had when CI built MUMPS from source. Without --static, system
+            # MUMPS would be detected and dynamically linked, leaving an
+            # `libdmumps_seq.so.5` runtime dep on the shipped tarball — a UX
+            # regression. The .a archives ship in the libmumps-seq-dev apt
+            # package alongside the .so, so static linking still works.
+            ./build.sh --test --static
           fi
 
       - name: Optimize macOS binary (strip + ad-hoc sign)
@@ -324,7 +337,9 @@ jobs:
           ls -lh "$VOLCA_BIN"
 
       - name: Save MUMPS local build
-        if: always() && steps.cache-mumps.outputs.cache-hit != 'true'
+        # Match the restore step: Linux uses the apt package, no local
+        # build to save.
+        if: always() && matrix.os != 'linux' && steps.cache-mumps.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: deps/mumps

--- a/build.sh
+++ b/build.sh
@@ -303,10 +303,15 @@ elif [[ "$OS" == "macos" ]]; then
         log_success "MUMPS found: $MUMPS_LIB_DIR"
     fi
 else
-    # Linux: check system install
-    if [[ -f "/usr/lib/x86_64-linux-gnu/libdmumps_seq.so" ]] || [[ -f "/usr/lib/x86_64-linux-gnu/libdmumps_seq.a" ]]; then
+    # Linux: check system install. Use the multiarch path so the same
+    # check works on amd64 (/usr/lib/x86_64-linux-gnu) and arm64
+    # (/usr/lib/aarch64-linux-gnu); fall back to /usr/lib for distros
+    # that don't use multiarch (rare on Debian/Ubuntu).
+    SYS_LIBDIR=/usr/lib/$(gcc -print-multiarch 2>/dev/null)
+    [[ -d "$SYS_LIBDIR" ]] || SYS_LIBDIR=/usr/lib
+    if [[ -f "$SYS_LIBDIR/libdmumps_seq.so" ]] || [[ -f "$SYS_LIBDIR/libdmumps_seq.a" ]]; then
         MUMPS_FOUND=true
-        MUMPS_LIB_DIR="/usr/lib/x86_64-linux-gnu"
+        MUMPS_LIB_DIR="$SYS_LIBDIR"
         MUMPS_INCLUDE_DIR="/usr/include"
         log_success "MUMPS_SEQ found (system): $MUMPS_LIB_DIR"
     fi


### PR DESCRIPTION
## Summary

Replace the ~8-10 min cold MUMPS source compile on `linux-amd64` and `linux-arm64` with the Debian/Ubuntu apt package `libmumps-seq-dev`, which ships exactly the static archives `mumps-hs` expects (`libdmumps_seq.a`, `libmumps_common_seq.a`, `libpord_seq.a`, `libmpiseq_seq.a`) at the standard multiarch path.

Three pieces in `_build-matrix.yml`:

1. **Install `libmumps-seq-dev`** in the Linux build-deps step.
2. **Skip MUMPS cache restore/save on Linux** — `build.sh` prefers `deps/mumps/` over the system path, so a populated cache would override system detection.
3. **Pass `--static` to `build.sh`** on Linux so the shipped binary stays statically linked w.r.t. MUMPS (preserves today's UX — without `--static`, the system MUMPS would be linked dynamically and end users would need `libmumps-seq` installed at runtime).

Plus a small `build.sh` fix: replace the hardcoded `/usr/lib/x86_64-linux-gnu` system-MUMPS-detection path with `gcc -print-multiarch`, so `linux-arm64` (which uses `/usr/lib/aarch64-linux-gnu`) also picks up the apt package. amd64 behavior unchanged.

macOS and Windows untouched. Their package ecosystems (brew `mumps`, MSYS2 `mingw-w64-ucrt-x86_64-mumps`) use unsuffixed library names and need separate work to align with `mumps-hs.cabal`'s `extra-libraries: dmumps_seq, mumps_common_seq, pord_seq, mpiseq_seq`. Out of scope here.

## Expected impact

- **Cold cache (new branch / 7-day GH eviction):** Linux jobs drop ~8-10 min each.
- **Warm cache:** roughly neutral — apt unpack ≈ tar extract of cached `deps/mumps/`.
- **Released tarball ABI:** identical — same static linking against the same MUMPS 5.x sources, just compiled by Debian's build farm instead of our CI.

## Test plan

- [x] PR CI passes all 4 platforms (`build / linux-amd64`, `build / linux-arm64`, `build / windows-amd64`, `build / macos-arm64`)
- [ ] On a Linux job, the log shows `MUMPS_SEQ found (system): /usr/lib/x86_64-linux-gnu` (or `aarch64-linux-gnu` on arm64) — confirming the apt package is detected, not the source build
- [ ] `ldd` of the resulting `volca` binary on Linux shows no `libdmumps_seq` / `libmumps_common_seq` / `libpord_seq` / `libmpiseq_seq` entries (i.e. statically linked, same as today)
- [ ] macOS and Windows jobs still build MUMPS from source as before (unchanged behavior)