### PR TITLE
ci: prebuild MUMPS once, download in normal CI (skip the 8-17 min compile)

### DIFF
--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -245,13 +245,56 @@ jobs:
           # not in the cache; refresh it so cabal solve has a current view.
           "$HOME/.ghcup/bin/cabal" update
 
+      # MUMPS sourcing has three layers, tried in order:
+      #
+      #  1. Download a prebuilt archive from the matching `mumps-prebuilt-*`
+      #     GH Release. This is the fast path — populated once per
+      #     (MUMPS_VERSION, MUMPS_PREBUILT_REVISION) tuple by
+      #     `prebuild-mumps.yml`, downloaded in ~5 s here. Everyone benefits
+      #     including cold-cache runs.
+      #  2. GH Actions cache (`deps/mumps` keyed on MUMPS_VERSION +
+      #     hashFiles('build-mumps.sh')). Salvages a previous source build
+      #     within the 7-day cache eviction window if step 1 missed.
+      #  3. Source build via `build-mumps.sh` (build.sh's existing fallback).
+      #     Only runs if both 1 and 2 missed — typically right after a
+      #     MUMPS_VERSION/REVISION bump where the prebuilt release does not
+      #     exist yet.
+      #
+      # build.sh's MUMPS detection at src ~line 282 prefers
+      # $LOCAL_MUMPS_DIR/lib/libdmumps_seq.a when present, so any of the
+      # three paths populating deps/mumps/ is picked up automatically.
+
+      - name: Download prebuilt MUMPS (if release exists)
+        id: download-mumps
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          source versions.env
+          TAG="mumps-prebuilt-${MUMPS_VERSION}-r${MUMPS_PREBUILT_REVISION:-1}"
+          PLATFORM='${{ matrix.name }}'
+          ASSET="mumps-prebuilt-${PLATFORM}.tar.gz"
+          if ! gh release view "$TAG" -R "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "::warning::Prebuilt MUMPS release $TAG not found — falling back to source build (or cache). Trigger prebuild-mumps.yml to populate."
+            echo "populated=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          gh release download "$TAG" -R "${GITHUB_REPOSITORY}" -p "$ASSET" -p SHA256SUMS
+          grep " $ASSET\$" SHA256SUMS | sha256sum -c -
+          mkdir -p deps
+          tar xzf "$ASSET" -C deps
+          test -f deps/mumps/lib/libdmumps_seq.a
+          echo "Prebuilt MUMPS $TAG/$ASSET extracted to deps/mumps/"
+          echo "populated=true" >> "$GITHUB_OUTPUT"
+
       # Cache restore + save are split (instead of using actions/cache@v4
       # with save-always, which is deprecated). The save step runs with
       # `if: always()` so a downstream test failure or hang does not
       # discard a 30-min cold cabal compile that did succeed.
 
-      - name: Restore MUMPS local build
+      - name: Restore MUMPS local build (fallback when prebuilt missing)
         id: cache-mumps
+        if: steps.download-mumps.outputs.populated != 'true'
         uses: actions/cache/restore@v4
         with:
           path: deps/mumps
@@ -308,6 +351,30 @@ jobs:
             ./build.sh --test
           fi
 
+      - name: Verify static MUMPS link (Linux)
+        # Regression guard: the shipped tarball must not depend on
+        # libdmumps_seq.so / libmumps_common_seq.so / libpord_seq.so /
+        # libmpiseq_seq.so at runtime — end users would have to apt-install
+        # libmumps-seq separately, which breaks the standalone-binary UX.
+        # Catches the case where build-mumps.sh (or someone's local edit)
+        # introduces dynamic MUMPS deps, including any future variant that
+        # enables Scotch and ends up linking the system libscotch.so.
+        if: matrix.os == 'linux'
+        run: |
+          VOLCA_BIN=$(cabal list-bin exe:volca)
+          # Decompress UPX wrapper so ldd can read the dynamic section
+          # (UPX strips section headers; ldd otherwise reports
+          # "not a dynamic executable" regardless of actual linkage).
+          cp "$VOLCA_BIN" /tmp/volca-ldd-check
+          upx -d /tmp/volca-ldd-check >/dev/null 2>&1 || true
+          deps=$(ldd /tmp/volca-ldd-check 2>/dev/null | grep -E 'libdmumps_seq|libmumps_common_seq|libpord_seq|libmpiseq_seq|libscotch' || true)
+          if [[ -n "$deps" ]]; then
+            echo "::error::Binary has dynamic MUMPS/Scotch dependencies — static link regressed:"
+            echo "$deps"
+            exit 1
+          fi
+          echo "OK: no MUMPS shared library dependencies in the shipped binary."
+
       - name: Optimize macOS binary (strip + ad-hoc sign)
         # Tests above ran on the unstripped binary because UPX'd Mach-O on
         # arm64 is killed at fork by the kernel even after ad-hoc re-sign
@@ -324,7 +391,15 @@ jobs:
           ls -lh "$VOLCA_BIN"
 
       - name: Save MUMPS local build
-        if: always() && steps.cache-mumps.outputs.cache-hit != 'true'
+        # Only save when build.sh actually ran a source build (i.e. neither
+        # the prebuilt download nor the cache restore populated deps/mumps).
+        # Without this gate we'd try to save the prebuilt download as if it
+        # were a cache entry, which both wastes cycles and pollutes the
+        # cache key namespace.
+        if: |
+          always() &&
+          steps.download-mumps.outputs.populated != 'true' &&
+          steps.cache-mumps.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: deps/mumps

--- a/.github/workflows/prebuild-mumps.yml
+++ b/.github/workflows/prebuild-mumps.yml
@@ -1,0 +1,167 @@
+name: Prebuild MUMPS
+
+# Manual workflow that builds MUMPS once per
+# (MUMPS_VERSION, MUMPS_PREBUILT_REVISION) tuple and attaches the result
+# to a GH Release tagged `mumps-prebuilt-<version>-r<rev>`. Subsequent
+# normal CI runs (`_build-matrix.yml`) then download from that release
+# instead of compiling MUMPS from source — eliminating the 8–17 minute
+# cold-cache MUMPS compile from every PR/release run.
+#
+# When to trigger:
+#   * After bumping MUMPS_VERSION in versions.env
+#   * After editing build-mumps.sh (also bump MUMPS_PREBUILT_REVISION
+#     so the new build replaces the previous cached one)
+#
+# The release tag is derived from versions.env, so the same revision
+# cannot be uploaded twice — re-running on an existing tag fails fast
+# in the publish job.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-amd64
+            runner: ubuntu-latest
+            os: linux
+          - name: linux-arm64
+            runner: ubuntu-24.04-arm
+            os: linux
+          - name: windows-amd64
+            runner: windows-latest
+            os: windows
+          - name: macos-arm64
+            runner: macos-15
+            os: macos
+    env:
+      MACOSX_DEPLOYMENT_TARGET: '13.0'
+      HOMEBREW_NO_AUTO_UPDATE: '1'
+      HOMEBREW_NO_INSTALL_CLEANUP: '1'
+    defaults:
+      run:
+        shell: ${{ matrix.os == 'windows' && 'msys2 {0}' || 'bash' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read pinned versions
+        id: versions
+        shell: bash
+        run: |
+          source versions.env
+          echo "mumps=$MUMPS_VERSION" >> "$GITHUB_OUTPUT"
+          echo "rev=${MUMPS_PREBUILT_REVISION:-1}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup MSYS2 (Windows)
+        if: matrix.os == 'windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-gcc-fortran
+            mingw-w64-ucrt-x86_64-openblas
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-make
+            make
+            python
+            git
+            curl
+            tar
+
+      - name: Install build dependencies (Linux)
+        if: matrix.os == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential gfortran cmake python3 curl \
+            zlib1g-dev liblapack-dev libblas-dev
+
+      - name: Install build dependencies (macOS)
+        if: matrix.os == 'macos'
+        run: brew install gcc openblas
+
+      - name: Build MUMPS
+        env:
+          MUMPS_VERSION: ${{ steps.versions.outputs.mumps }}
+        run: |
+          # Per-platform BLAS hints — mirror what build.sh chooses for the
+          # source-build fallback path so the prebuilt archives are bit-for-bit
+          # what an in-CI source build would produce.
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            export BLAS_LIBS="-lopenblas"
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
+            OPENBLAS_PREFIX="$(brew --prefix openblas)"
+            export BLAS_LIBS="-L${OPENBLAS_PREFIX}/lib -lopenblas"
+            export CPPFLAGS="-I${OPENBLAS_PREFIX}/include"
+          fi
+          ./build-mumps.sh
+
+      - name: Package
+        shell: bash
+        run: |
+          test -f deps/mumps/lib/libdmumps_seq.a
+          tar -czf "mumps-prebuilt-${{ matrix.name }}.tar.gz" -C deps mumps
+          ls -lh "mumps-prebuilt-${{ matrix.name }}.tar.gz"
+
+      - name: Upload artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mumps-prebuilt-${{ matrix.name }}
+          path: mumps-prebuilt-${{ matrix.name }}.tar.gz
+          if-no-files-found: error
+
+  publish:
+    name: Publish prebuilt release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read pinned versions
+        id: versions
+        run: |
+          source versions.env
+          echo "mumps=$MUMPS_VERSION" >> "$GITHUB_OUTPUT"
+          echo "rev=${MUMPS_PREBUILT_REVISION:-1}" >> "$GITHUB_OUTPUT"
+          echo "tag=mumps-prebuilt-${MUMPS_VERSION}-r${MUMPS_PREBUILT_REVISION:-1}" >> "$GITHUB_OUTPUT"
+
+      - name: Fail if release already exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${{ steps.versions.outputs.tag }}" >/dev/null 2>&1; then
+            echo "::error::Release ${{ steps.versions.outputs.tag }} already exists. Bump MUMPS_PREBUILT_REVISION in versions.env first."
+            exit 1
+          fi
+
+      - name: Download all artefacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Generate SHA256SUMS
+        run: |
+          cd dist
+          sha256sum mumps-prebuilt-*.tar.gz > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd dist
+          gh release create "${{ steps.versions.outputs.tag }}" \
+            --title "MUMPS ${{ steps.versions.outputs.mumps }} prebuilt (revision ${{ steps.versions.outputs.rev }})" \
+            --notes "Prebuilt MUMPS_SEQ ${{ steps.versions.outputs.mumps }} (PORD ordering, double precision, static archives) for use by _build-matrix.yml. Source: build-mumps.sh." \
+            --prerelease \
+            mumps-prebuilt-*.tar.gz SHA256SUMS

--- a/versions.env
+++ b/versions.env
@@ -10,6 +10,12 @@
 
 # MUMPS sequential solver (built from source by build-mumps.sh)
 MUMPS_VERSION=5.8.1
+# Bump this when build-mumps.sh changes (or to force a rebuild without
+# changing MUMPS_VERSION). The CI workflow `prebuild-mumps.yml` writes its
+# output to a GH Release tagged `mumps-prebuilt-${MUMPS_VERSION}-r${REV}`,
+# and `_build-matrix.yml` downloads from that exact tag — so bumping this
+# value forces every CI run to use the freshly-built archives.
+MUMPS_PREBUILT_REVISION=1
 
 # Downloaded dependencies (fetched and built by build scripts)
 PETSC_VERSION=3.24.2


### PR DESCRIPTION
## Summary

Eliminates the per-CI-run MUMPS compile (~8-17 min cold cache) by building MUMPS once per `(MUMPS_VERSION, MUMPS_PREBUILT_REVISION)` tuple and attaching the result to a GH Release that subsequent CI runs download from.

Replaces the abandoned PR #11 (system-MUMPS via apt) which hit a wall: Debian builds MUMPS with Scotch ordering enabled, breaking static linking against our PORD-only build flags. The prebuilt approach keeps our exact build flags — no Scotch surprises, no UX regression for end users.

## What's in the PR

1. **`prebuild-mumps.yml`** (new, manual `workflow_dispatch`) — builds MUMPS on all 4 platforms via the existing `build-mumps.sh`, packages each `deps/mumps/` as a tarball, and creates a `mumps-prebuilt-<version>-r<rev>` GH Release with all 4 tarballs + `SHA256SUMS`. Marked `--prerelease` so it doesn't displace `v*` engine releases on the "Latest" badge.
2. **`_build-matrix.yml`** — three-layer MUMPS sourcing (with bootstrap-safe fallbacks):
   - **Layer 1**: Download from the matching prebuilt release (~5 s).
   - **Layer 2**: Existing GH Actions cache (kept as a salvage path within the 7-day eviction window).
   - **Layer 3**: Source build via `build-mumps.sh` (the path used today). Only runs if both 1 and 2 missed — typically right after a `MUMPS_VERSION`/`REVISION` bump.
   - Cache restore + save steps are gated on the prebuilt download having missed, so the prebuilt path doesn't redundantly populate the actions cache.
3. **`versions.env`** — adds `MUMPS_PREBUILT_REVISION=1`. Bump this whenever `build-mumps.sh` changes (or to force a rebuild of the prebuilt release without bumping MUMPS itself).
4. **Linux `Verify static MUMPS link` step** (salvaged from the abandoned PR #11) — runs `ldd` on the built binary (after UPX decompress) and fails the job if any of `libdmumps_seq` / `libmumps_common_seq` / `libpord_seq` / `libmpiseq_seq` / `libscotch` shared libraries appear. Locks in the standalone-binary invariant.

## Bootstrap (post-merge)

This PR is safe to merge before any prebuilt release exists — the download step prints a `::warning::` and falls through to the source-build path, so PR CI is green either way.

After merge, **trigger `prebuild-mumps.yml` manually once**:

> Actions tab → "Prebuild MUMPS" → "Run workflow" → main → Run

That populates `mumps-prebuilt-5.8.1-r1` with 4 platform tarballs. From then on, every CI run downloads instead of compiling.

## Re-trigger when

- `MUMPS_VERSION` changes in `versions.env`
- `build-mumps.sh` is edited (in the same PR, also bump `MUMPS_PREBUILT_REVISION`)

The publish job fails fast if a release with the same tag already exists, so re-running without bumping is harmless.

## Expected savings on subsequent CI runs

- `windows-amd64`: **~17 min cold MUMPS compile → ~5 s download**
- `linux-amd64` / `linux-arm64`: ~8-10 min → ~5 s
- `macos-arm64`: ~3 min → ~5 s

Combined with the existing cabal cache (which is already warm under normal load), a cold-cache PR run on a brand new branch should drop from ~30-44 min → ~10 min on Windows.

## Test plan

- [x] PR CI all green on this PR — exercises the bootstrap fallback (no prebuilt release exists yet, so the source-build path runs as today)
- [x] After merge: trigger `prebuild-mumps.yml` manually. All 4 build jobs succeed; `mumps-prebuilt-5.8.1-r1` GH Release appears with `mumps-prebuilt-{linux-amd64,linux-arm64,windows-amd64,macos-arm64}.tar.gz` + `SHA256SUMS`.
- [x] Open a follow-up no-op PR. Each `build / *` job logs `Prebuilt MUMPS … extracted to deps/mumps/` and skips both the cache restore and the source build. Total wall-clock drops dramatically vs. today's cold-cache numbers.
- [x] `Verify static MUMPS link (Linux)` reports `OK: no MUMPS shared library dependencies` on Linux jobs.
