### PR TITLE
ci(prebuild-cabal-store): use git-bash for MUMPS download on Windows

### DIFF
--- a/.github/workflows/prebuild-cabal-store.yml
+++ b/.github/workflows/prebuild-cabal-store.yml
@@ -141,6 +141,12 @@ jobs:
           "$HOME/.ghcup/bin/cabal" --numeric-version
 
       - name: Download prebuilt MUMPS
+        # Force git-bash on Windows instead of the workflow-level msys2 default.
+        # MSYS2's CMD wrapper drops most of the GH Actions runner env on entry
+        # (notably GITHUB_REPOSITORY), so `gh release view -R ""` fails on
+        # Windows even when the release does exist. _build-matrix.yml's
+        # equivalent step pins shell: bash for the same reason.
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

Run [25231193197](https://github.com/ccomb/volca/actions/runs/25231193197) (manual trigger of \`prebuild-cabal-store.yml\` on main) failed only on \`windows-amd64\` at the **Download prebuilt MUMPS** step:

\`\`\`
Required prebuilt MUMPS release mumps-prebuilt-5.8.1-r1 does not exist.
\`\`\`

…even though the release very much exists and was successfully fetched by Linux/macOS in the same run, and by every Windows CI build in \`_build-matrix.yml\`.

## Root cause

\`prebuild-cabal-store.yml\` declares a workflow-level shell default of \`msys2 {0}\` for Windows. When that wrapper enters the inner MSYS2 bash, it drops most of the runner's auto-injected env vars — including \`GITHUB_REPOSITORY\`. So:

\`\`\`bash
gh release view "$TAG" -R "${GITHUB_REPOSITORY}"
\`\`\`

…runs as \`gh release view \"$TAG\" -R \"\"\` and 404s. The script then \`exit 1\`s with the misleading \"does not exist\" message.

## Why \`_build-matrix.yml\` doesn't have this

Its identical MUMPS-download step explicitly sets \`shell: bash\` to opt out of the msys2 wrapper for Windows, falling back to git-bash (which inherits the runner env natively). I'd just forgotten to add the same shell override to \`prebuild-cabal-store.yml\`.

## Fix

One-line addition: \`shell: bash\` on the **Download prebuilt MUMPS** step. The remaining Windows steps still need msys2 (cabal build with the UCRT64 toolchain), so the workflow default stays as-is.

## Test plan

- [x] Re-run \`prebuild-cabal-store.yml\` on main after merge. \`windows-amd64\` reaches the **Build cabal deps** step.
- [x] All 4 platforms succeed; \`Publish prebuilt release\` job creates \`cabal-store-prebuilt-ghc9.6.7-<hash>-r1\` with 4 tarballs + SHA256SUMS.