### PR TITLE
ci: build on push to main + Save Cabal store on prebuilt-win path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,13 @@
 name: Build
 
-# Slim wrapper around the reusable _build-matrix.yml. PR-only — no
-# push: main, no push: branches. The 4-platform build runs on every
-# push to any PR branch, and is the required status check that gates
-# merging.
+# Slim wrapper around the reusable _build-matrix.yml. Triggers:
+#   - pull_request to main: gate merges on a green 4-platform build
+#   - push to main: re-populate actions/cache after squash-merge so that
+#     subsequent PRs have a default-branch cache to fall back to. Without
+#     this, PR runs save caches scoped to the (then-deleted) PR branch
+#     and main has nothing for new PRs to inherit. The cabal-store
+#     prebuilt usually masks this, but only when its hash matches; cache
+#     fallback is what catches the hash-changed case.
 #
 # Pyvolca PRs are skipped: pyvolca dispatches dynamically against the
 # engine's OpenAPI spec, so its changes don't affect the Haskell build —
@@ -12,6 +16,10 @@ name: Build
 
 on:
   pull_request:
+    branches: [main]
+    paths-ignore:
+      - 'pyvolca/**'
+  push:
     branches: [main]
     paths-ignore:
       - 'pyvolca/**'


### PR DESCRIPTION
## Summary

Two related fixes — both about making \`actions/cache\` actually populate so that PRs and same-hash incremental builds benefit from prior work.

### Problem 1: \`build.yml\` was \`pull_request\`-only

Main never ran CI after a merge. PR-run caches are scoped to the PR branch; once that branch is deleted post-merge, those caches eventually become inaccessible. New PRs opened off main had nothing to fall back to via the [default-branch cache mechanism](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache).

**Fix:** add \`push: branches: [main]\` to \`build.yml\`. Each squash-merge re-runs the 4-platform build, populating an actions/cache scoped to main.

### Problem 2: \`Save Cabal store\` is skipped when prebuilt wins

Spotted this checking PR #15's test plan — \`Save Cabal store\` was skipped on every job because the gate \`download-cabal.outputs.populated != 'true'\` excludes prebuilt-win runs (which is the common case).

That throws away two real wins on every prebuilt-win run:

1. **\`dist-newstyle\` is in the cache path.** Without Save, volca's own object files vanish at job end. Every same-hash PR re-compiles volca's own modules from scratch even though deps are unchanged — defeats the "only recompile our own code" property.
2. **PRs whose cabal config hash doesn't match the prebuilt release** fall through to actions/cache. With main never populating, there's nothing to fall back to.

**Fix:** remove the prebuilt-win gate. \`actions/cache/save\` is keyed on the cabal config hash; subsequent runs at the same key get a "cache already exists" warning and skip the work.

Cache key is now inlined in Save (instead of \`steps.cache-cabal.outputs.cache-primary-key\`) because Restore Cabal store is still skipped on the prebuilt-win path, so its outputs would be empty there.

## Combined effect after merge

| scenario | before this PR | after this PR |
|---|---|---|
| PR at main's hash, prebuilt exists | prebuilt restores store, cabal recompiles all volca modules | prebuilt + actions/cache restore store + dist-newstyle, cabal incrementally compiles only changed modules |
| PR with bumped Haskell dep (no prebuilt for new hash) | falls through to actions/cache → miss → cold rebuild | falls through to actions/cache → restore-keys finds main's cache at prior hash → mostly-warm rebuild |

## Test plan

- [x] PR CI green (\`pull_request\` trigger still works)
- [x] After merge: a new \`Build\` run starts automatically on the merge commit (\`push: main\` trigger fires)
- [x] That main run executes \`Save Cabal store\` (no longer skipped) and writes a cache scoped to \`refs/heads/main\` (visible in repo Actions → Caches)
- [x] Open a small no-op PR after the main run completes; its \`Restore Cabal store\` step hits the main-scoped cache via \`restore-keys\` fallback when the prebuilt's hash doesn't match