### PR TITLE
ci: Save Cabal store also when prebuilt wins

### DIFF
--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -492,20 +492,33 @@ jobs:
           key: ${{ steps.cache-ghcup-unix.outputs.cache-primary-key }}
 
       - name: Save Cabal store
-        # Skip when the prebuilt download wins — the prebuilt is already
-        # the durable source of truth, and dist-newstyle without a matching
-        # ~/.cabal/store would poison future cache restores.
-        if: |
-          always() &&
-          steps.download-cabal.outputs.populated != 'true' &&
-          steps.cache-cabal.outputs.cache-hit != 'true'
+        # Save even when the prebuilt download wins. Two reasons:
+        #
+        # 1. dist-newstyle (volca's own object files) is built fresh by
+        #    every run and is in the cache path. Skipping Save means
+        #    every same-hash PR rebuilds volca's own modules from
+        #    scratch instead of incrementally — kills the "only
+        #    recompile our own code" property.
+        # 2. The cache also serves as fallback for PRs whose cabal
+        #    config hash doesn't match any existing prebuilt release.
+        #    Without saving on the prebuilt-win path, main's own runs
+        #    leave no cache for those PRs to inherit.
+        #
+        # Skipping when an exact cache key already hit is still right —
+        # actions/cache/save with an existing key is a no-op (logs a
+        # warning) but we save the tar/upload work anyway.
+        #
+        # Key is inlined (not steps.cache-cabal.outputs.cache-primary-key)
+        # because Restore Cabal store is skipped on the prebuilt-win path,
+        # so its outputs are unset and we'd save with an empty key.
+        if: always() && steps.cache-cabal.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: |
             ~/.cabal/store
             C:\cabal\store
             dist-newstyle
-          key: ${{ steps.cache-cabal.outputs.cache-primary-key }}
+          key: cabal-${{ matrix.name }}-ghc${{ steps.versions.outputs.ghc }}-${{ hashFiles('volca.cabal', 'mumps-hs/mumps-hs.cabal', 'cabal.project') }}-v2
 
       - name: Package release tarball
         if: inputs.release


### PR DESCRIPTION
## Summary

Follow-up to #17. The post-merge \`Build\` run on main ([25235517697](https://github.com/ccomb/volca/actions/runs/25235517697)) confirmed \`push: main\` triggers correctly — but \`Save Cabal store\` was \`skipped\` on all 4 platforms, meaning main is still leaving no actions/cache for PRs to inherit.

Root cause: \`Save Cabal store\` is gated on \`download-cabal.outputs.populated != 'true'\`, which excludes prebuilt-win runs (the common case).

## What that costs us

1. **\`dist-newstyle\` (volca's own object files) is in the cache path.** Without Save, those files vanish at job end. Every same-hash PR re-compiles volca's own modules from scratch even though deps are unchanged — defeats the "only recompile our own code" property we wanted out of the cache layer.
2. **PRs whose cabal config hash doesn't match any prebuilt release** fall through to actions/cache. With main never populating it (Save skipped on prebuilt-win), there's nothing to fall back to via the default-branch cache lookup.

## Fix

Remove the \`populated != 'true'\` gate. \`actions/cache/save\` is keyed on the cabal config hash; subsequent runs at the same key get a "cache already exists" warning and do no redundant work, so there's no harm in saving even when prebuilt won.

Cache key is inlined in Save (instead of \`steps.cache-cabal.outputs.cache-primary-key\`) because Restore Cabal store is still skipped on the prebuilt-win path, so its outputs would be empty there.

## Test plan

- [x] PR CI green
- [x] After merge, the next push to main runs \`Save Cabal store\` (no longer skipped)
- [x] Cache visible in repo Actions → Caches under \`refs/heads/main\`
- [x] Open a no-op PR after that main run completes; its \`Restore Cabal store\` step hits the main-scoped cache via \`restore-keys\` fallback when the prebuilt's hash doesn't match