### PR TITLE
fix(install): warn when BLAS/LAPACK runtime libs are missing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -158,6 +158,34 @@ exec "$SHARE_DIR/$PLAIN_VERSION/volca" "\$@"
 EOF
 chmod +x "$SHIM"
 
+# --- Runtime-deps probe (Linux only) ----------------------------------------
+#
+# The Linux binary dynamically links libgfortran, libopenblas, and liblapack —
+# the standard BLAS/LAPACK/Fortran toolchain. Debian-slim containers, Alpine,
+# and minimal cloud images don't carry these by default. Probe by running the
+# binary; if its loader complains about a missing shared object, print the
+# per-distro install command. We print rather than auto-install: piping a
+# curl'd script into `sudo apt install …` is the kind of surprise behaviour we
+# don't want.
+
+if [ "$OS" = linux ]; then
+    PROBE_OUT=$("$SHIM" --version 2>&1) || PROBE_FAILED=1
+    if [ "${PROBE_FAILED:-0}" = 1 ] && \
+       printf '%s' "$PROBE_OUT" | grep -q 'cannot open shared object file'; then
+        cat <<EOF
+
+WARN: volca couldn't load. It needs the BLAS/LAPACK/Fortran runtime libs:
+    Debian/Ubuntu: sudo apt install -y liblapack3 libopenblas0-pthread libgfortran5
+    Fedora/RHEL:   sudo dnf install -y lapack openblas libgfortran
+    Arch:          sudo pacman -S --needed lapack openblas gcc-fortran
+    Alpine:        sudo apk add lapack openblas gfortran
+
+Loader said:
+$(printf '%s' "$PROBE_OUT" | sed 's/^/    /')
+EOF
+    fi
+fi
+
 # --- Post-install guidance ---------------------------------------------------
 
 case ":${PATH:-}:" in


### PR DESCRIPTION
## Why

Real-user friction surfaced today on a Debian-slim Docker container:

\`\`\`
$ ./install.sh
==> Installing volca v0.6.0 for linux-amd64
... (download, extract, install all succeed)
volca v0.6.0 installed.

$ volca --version
/root/.local/share/volca/0.6.0/volca: error while loading shared
libraries: liblapack.so.3: cannot open shared object file:
No such file or directory
\`\`\`

The Linux engine binary dynamically links \`libgfortran\`,
\`libopenblas\`, and \`liblapack\`. Minimal Debian/Alpine/cloud images
don't carry those by default; the user gets a confusing loader error
*after* the installer says \"installed.\"

## Fix

After dropping the shim, run \`volca --version\` once. If the loader
complains about a missing shared object, print:

- the per-distro install command (apt / dnf / pacman / apk)
- the loader's actual message verbatim, indented

We print rather than auto-install. \`curl … | sh\` then \`sudo apt
install …\` would be a surprising privilege escalation; better to
show the command and let the user run it.

## Test plan

- [ ] On a Debian-slim container with no BLAS: install.sh prints the
      apt command and the \`liblapack.so.3\` loader message.
- [ ] After \`apt install liblapack3 libopenblas0-pthread libgfortran5\`:
      \`volca --version\` works.
- [ ] On a Linux box that already has the libs: probe runs silently,
      no warning printed.
- [ ] On macOS: probe is skipped (\`OS\` is not \`linux\`); no warning.