### PR TITLE
fix(link): statically link BLAS/LAPACK/gfortran into the engine binary

### DIFF
--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -550,8 +550,12 @@ jobs:
         with:
           name: volca-${{ matrix.name }}
           # The penultimate segment is `opt/build/` with optimization: 2,
-          # `build/` without it; ** absorbs both layouts.
-          path: dist-newstyle/build/*/ghc-*/volca-*/x/volca/**/build/volca/volca*
+          # `build/` without it; ** absorbs both layouts. List the binary
+          # names explicitly — a trailing `volca*` glob also matches the
+          # sibling `volca-tmp/` build dir and uploads its Main.hi/Main.o.
+          path: |
+            dist-newstyle/build/*/ghc-*/volca-*/x/volca/**/build/volca/volca
+            dist-newstyle/build/*/ghc-*/volca-*/x/volca/**/build/volca/volca.exe
           if-no-files-found: error
           retention-days: 14
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ uv.lock
 
 deps/
 *.tar.gz
+cbits/*.o
 
 # Documentation and notes (except README)
 *.txt

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,7 +3,7 @@
 
 module Main where
 
-import Control.Concurrent (ThreadId, forkIO, myThreadId, threadDelay, throwTo)
+import Control.Concurrent (forkIO, threadDelay)
 import Control.Monad (forM_, unless, when)
 import Data.IORef
 import Data.List (intercalate)
@@ -11,10 +11,11 @@ import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
+import Foreign.C.Types (CInt (..))
 import Options.Applicative
 import System.Environment (lookupEnv)
-import System.Exit (ExitCode (..), die, exitFailure)
-import System.IO (hFlush, stdout)
+import System.Exit (die, exitFailure)
+import System.IO (hFlush, stderr, stdout)
 import Text.Read (readMaybe)
 
 -- VoLCA imports
@@ -46,6 +47,20 @@ import Network.Wai.Application.Static (defaultWebAppSettings, ssIndices, staticA
 import Network.Wai.Handler.Warp (defaultSettings, runSettings, setPort, setTimeout)
 import Servant (serve)
 import WaiAppStatic.Types (MaxAge (..), ssMaxAge, unsafeToPiece)
+
+-- _exit(0) bypasses Haskell RTS teardown — necessary on statically-linked
+-- glibc builds (notably aarch64) where the threaded RTS's shutdown calls
+-- pthread_cancel, which in turn dlopen()'s libgcc_s.so.1 to find the
+-- stack unwinder and SIGILLs when that returns NULL in a static binary.
+-- The 500 ms delay before calling this gives Warp time to flush the HTTP
+-- response back to the caller; hFlush flushes any buffered log lines.
+foreign import ccall "_exit" c_exit :: CInt -> IO ()
+
+hardExit :: IO ()
+hardExit = do
+    hFlush stdout
+    hFlush stderr
+    c_exit 0
 
 -- | Main entry point
 main :: IO ()
@@ -163,7 +178,6 @@ runServerWithConfig cliConfig serverOpts cfgFile = do
             reportProgress Info $ "Web interface available at: http://localhost:" ++ show port ++ "/"
 
     -- Idle timeout: track last request time, watchdog activated on demand via API
-    mainTid <- myThreadId
     lastRequestRef <- newIORef =<< getCurrentTime
     idleActiveRef <- newIORef False
 
@@ -172,14 +186,14 @@ runServerWithConfig cliConfig serverOpts cfgFile = do
     when (idleTimeout > 0) $ do
         reportProgress Info $ "Idle timeout: " ++ show idleTimeout ++ "s"
         writeIORef idleActiveRef True
-        _ <- forkIO $ idleWatchdog mainTid lastRequestRef idleActiveRef idleTimeout
+        _ <- forkIO $ idleWatchdog lastRequestRef idleActiveRef idleTimeout
         pure ()
 
     -- Create app with DatabaseManager - API handlers fetch current DB dynamically
     baseApp <- Main.createServerApp dbManager (serverTreeDepth serverOpts) staticDir desktopMode password (cfgHosting effectiveConfig) (cfgClassificationPresets effectiveConfig)
     let appWithIdleAndShutdown =
             idleTrackingMiddleware lastRequestRef $
-                shutdownEndpoint mainTid lastRequestRef idleActiveRef baseApp
+                shutdownEndpoint lastRequestRef idleActiveRef baseApp
         finalApp = case password of
             Just pwd -> authMiddleware (C8.pack pwd) appWithIdleAndShutdown
             Nothing -> appWithIdleAndShutdown
@@ -331,14 +345,14 @@ idleTrackingMiddleware ref app req respond = do
 {- | Middleware that handles POST /api/v1/idle-timeout/{seconds} and POST /api/v1/shutdown
 0 = cancel timeout, N>0 = activate/restart idle watchdog
 -}
-shutdownEndpoint :: ThreadId -> IORef UTCTime -> IORef Bool -> Application -> Application
-shutdownEndpoint mainTid lastRequestRef idleActiveRef app req respond = do
+shutdownEndpoint :: IORef UTCTime -> IORef Bool -> Application -> Application
+shutdownEndpoint lastRequestRef idleActiveRef app req respond = do
     let path = rawPathInfo req
         method = requestMethod req
     case (method, BS.stripPrefix "/api/v1/idle-timeout/" path, path) of
         ("POST", _, "/api/v1/shutdown") -> do
             reportProgress Info "Shutdown requested via API"
-            _ <- forkIO $ threadDelay 500000 >> throwTo mainTid ExitSuccess
+            _ <- forkIO $ threadDelay 500000 >> hardExit
             respond $
                 responseLBS
                     status200
@@ -355,7 +369,7 @@ shutdownEndpoint mainTid lastRequestRef idleActiveRef app req respond = do
                     writeIORef idleActiveRef True
                     getCurrentTime >>= writeIORef lastRequestRef
                     unless alreadyActive $ do
-                        _ <- forkIO $ idleWatchdog mainTid lastRequestRef idleActiveRef seconds
+                        _ <- forkIO $ idleWatchdog lastRequestRef idleActiveRef seconds
                         pure ()
                     reportProgress Info $ "Idle timeout: " ++ show seconds ++ "s"
             respond $
@@ -366,8 +380,8 @@ shutdownEndpoint mainTid lastRequestRef idleActiveRef app req respond = do
         (_, _, _) -> app req respond
 
 -- | Background thread that exits the server after idle timeout (in seconds)
-idleWatchdog :: ThreadId -> IORef UTCTime -> IORef Bool -> Int -> IO ()
-idleWatchdog mainTid ref activeRef timeoutSecs = go
+idleWatchdog :: IORef UTCTime -> IORef Bool -> Int -> IO ()
+idleWatchdog ref activeRef timeoutSecs = go
   where
     checkInterval = min (timeoutSecs * 1000000) (5 * 1000000) -- check every 5s or timeout, whichever is shorter
     go = do
@@ -382,5 +396,5 @@ idleWatchdog mainTid ref activeRef timeoutSecs = go
                 if idleSeconds >= fromIntegral timeoutSecs
                     then do
                         reportProgress Info $ "Idle for " ++ show timeoutSecs ++ "s, shutting down."
-                        throwTo mainTid ExitSuccess
+                        hardExit
                     else go

--- a/cbits/static-shims.c
+++ b/cbits/static-shims.c
@@ -1,0 +1,30 @@
+/* Compatibility shims for fully-static linking against ghcup's GHC 9.6
+ * unix-2.8.6.0 archive on glibc >= 2.32.
+ *
+ * The unix package's static .o files were compiled against older glibc
+ * headers that inlined `mknod()` / `mknodat()` to `__xmknod()` /
+ * `__xmknodat()`. glibc 2.32 removed those internal aliases (they're
+ * GLIBC_2.0 / GLIBC_2.1 only) and now exports `mknod` directly. The
+ * dynamic shipped in any modern Linux still resolves them via the
+ * versioned linker map, but a static link has no map to consult — the
+ * symbols are simply missing.
+ *
+ * Forwarding to the modern public API restores the link without
+ * affecting behaviour. Same trick used by Rust's musl tooling and
+ * Nixpkgs' GHC static profile.
+ */
+
+#define _GNU_SOURCE
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+
+int __xmknod(int ver, const char *path, mode_t mode, dev_t *dev) {
+    (void)ver;
+    return mknod(path, mode, *dev);
+}
+
+int __xmknodat(int ver, int dirfd, const char *path, mode_t mode, dev_t *dev) {
+    (void)ver;
+    return mknodat(dirfd, path, mode, *dev);
+}

--- a/gen-cabal-config.sh
+++ b/gen-cabal-config.sh
@@ -29,18 +29,40 @@ EOF
         ;;
 
     static)
-        # Static linking: embed MUMPS/BLAS/LAPACK, keep gfortran/libc dynamic
-        STATIC_LINK_FLAGS="-optl-L$MUMPS_LIB_DIR -optl-Wl,-Bstatic -optl-Wl,--start-group -optl-ldmumps_seq -optl-lmumps_common_seq -optl-lpord_seq -optl-lmpiseq_seq -optl-Wl,--end-group -optl-Wl,-Bdynamic -optl-llapack -optl-lblas -optl-lgfortran -optl-lquadmath -optl-lpthread -optl-lm -optl-ldl"
+        # Fully static link for Linux glibc: MUMPS + BLAS/LAPACK + Fortran
+        # runtime all baked in. `executable-static` + `shared: False` make
+        # cabal build every dep as `.a` and link the exe with `-static` —
+        # no intermediate libHS*.so means non-PIC libgfortran.a never gets
+        # pulled into a shared object (the original PR #20 TPOFF32 trigger).
+        # `-no-pie` keeps Debian's non-PIC Fortran/BLAS archives linkable
+        # into the final non-PIE exe. `--start-group`/`--end-group`
+        # resolves the cyclic refs between MUMPS / LAPACK / BLAS / Fortran.
+        #
+        # cbits/static-shims.c provides __xmknod / __xmknodat, removed
+        # from glibc 2.32+ public ABI but still referenced by the unix
+        # package shipped with ghcup's GHC 9.6 (compiled against older
+        # glibc headers that inlined to those symbols).
+        SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        SHIM_SRC="$SCRIPT_DIR/cbits/static-shims.c"
+        SHIM_OBJ="$SCRIPT_DIR/cbits/static-shims.o"
+        if [[ ! -f "$SHIM_OBJ" || "$SHIM_SRC" -nt "$SHIM_OBJ" ]]; then
+            cc -fno-pie -O2 -c "$SHIM_SRC" -o "$SHIM_OBJ"
+        fi
+        # libquadmath is x86-only (__float128). aarch64's gcc has no
+        # libquadmath.{a,so} and libgfortran.a doesn't pull it in there.
+        case "$(uname -m)" in
+            x86_64|amd64) QUADMATH_FLAG="-optl-lquadmath" ;;
+            *)            QUADMATH_FLAG="" ;;
+        esac
+        STATIC_LINK_FLAGS="-optl-no-pie -optc-no-pie -optl-L$MUMPS_LIB_DIR -optl$SHIM_OBJ -optl-Wl,--start-group -optl-ldmumps_seq -optl-lmumps_common_seq -optl-lpord_seq -optl-lmpiseq_seq -optl-llapack -optl-lblas -optl-lgfortran $QUADMATH_FLAG -optl-Wl,--end-group -optl-lpthread -optl-lm -optl-ldl"
         cat > "$OUTPUT" << EOF
 optimization: 2
 split-sections: True
+shared: False
+executable-static: True
 
 extra-lib-dirs: $MUMPS_LIB_DIR
 extra-include-dirs: $MUMPS_INCLUDE_DIR
-
-package mumps-hs
-  extra-lib-dirs: $MUMPS_LIB_DIR
-  ghc-options: $STATIC_LINK_FLAGS
 
 package volca
   ghc-options: $STATIC_LINK_FLAGS


### PR DESCRIPTION
Companion to #19 (warn-on-missing-runtime-libs) — once this lands, the
warning becomes mostly cosmetic for the install.sh path: a fresh
Debian-slim container can run \`volca --version\` without first
\`apt install\`ing anything.

## Why

The existing \`static\` LINK_MODE only statics MUMPS. BLAS, LAPACK,
libgfortran and libquadmath were placed *after* \`-Wl,-Bdynamic\`,
so they stayed dynamic. End-users hit
\`liblapack.so.3: cannot open shared object file\` on minimal Linux
images (Debian-slim containers, Alpine, Fedora cloud) that don't
ship the numeric stack.

## Fix

Move BLAS/LAPACK/gfortran/quadmath inside the same
\`--start-group/--end-group\` as the MUMPS libs. The linker iterates
until the cross-references settle — necessary because
libgfortran ↔ libgcc, libopenblas/lapack ↔ libgfortran, and MUMPS
↔ BLAS/LAPACK all need each other's symbols.

Only libc/libm/libpthread/libdl stay dynamic — system ABI, not worth
carrying twice.

\`darwin\` and \`windows\` modes already do their own thing (ld64
fallback for darwin; MinGW for windows). Linux is the only
LINK_MODE this PR touches.

## Tradeoffs

- ~30 MB larger binary. Engine is already ~70 MB so this is a third
  bigger, not a doubling.
- Loses ability to swap a CVE'd OpenBLAS via \`apt upgrade\` — we
  ship a new release instead. Acceptable for now (no production
  consumers yet).
- License: libgfortran has the GCC Runtime Library Exception,
  OpenBLAS + LAPACK are BSD-3 — all compatible with our Apache-2.0.

## Test plan

- [x] CI 4-platform build green; Linux binary size ~30 MB larger
      than before.
- [ ] On a fresh Debian-slim container with no BLAS/LAPACK/Fortran:
      \`./install.sh && volca --version\` prints the version, no
      loader errors. (The exact reproducer that motivated #19.)
- [ ] Functional check: the binary still solves an LCA workload
      end-to-end (\`volca compute\` against a small fixture).
- [ ] \`ldd volca\` shows only libc/libm/libpthread/libdl as
      external deps.