### PR TITLE
fix(docker): copy cbits/ before gen-cabal-config.sh

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,6 +48,8 @@ WORKDIR /build
 COPY volca.cabal /build/volca/
 COPY mumps-hs/ /build/mumps-hs/
 COPY gen-cabal-config.sh /build/volca/
+# gen-cabal-config.sh compiles cbits/static-shims.c in static mode
+COPY cbits/ /build/volca/cbits/
 
 # Set up cabal.project with mumps-hs as local package
 # Static MUMPS: link .a libs into the binary so the runtime image needs no MUMPS package


### PR DESCRIPTION
## Summary

- `docker/Dockerfile` failed at the `gen-cabal-config.sh` step with `cc1: fatal error: /build/volca/cbits/static-shims.c: No such file or directory`.
- Root cause: PR #20 made `gen-cabal-config.sh` compile `cbits/static-shims.c` to a `.o` consumed by the static link, but the Dockerfile only copies `volca.cabal`, `mumps-hs/` and `gen-cabal-config.sh` into the builder before invoking the script.
- Fix: add `COPY cbits/ /build/volca/cbits/` next to the other dep-spec copies, so the shim source is present when the script runs and layer caching only invalidates when shim sources change.

## Test plan

- [x] `./volca/docker-build.sh` (against this branch) progresses past step 11 — confirmed locally up to `cabal build --only-dependencies volca`.
- [x] Full image build completes and `docker run volca --version` works.