### PR TITLE
fix(search): short prefix queries no longer mask stem matches

### DIFF
--- a/src/Search/Fuzzy.hs
+++ b/src/Search/Fuzzy.hs
@@ -2,13 +2,15 @@
 
 Pipeline per query token:
   1. If the token is already in the BM25 vocabulary, include it at weight 1.0.
-  2. Also try edit-distance candidates (weight 0.5) — handles typos and
-     orthographic variants (e.g. trellis ↔ treillis) even when the exact
-     token is in the vocabulary. Exact still ranks first thanks to the
-     2× IDF gap.
-  3. If edit distance finds nothing, try prefix-coverage (weight 0.7) —
-     handles stems like "electr" → "electricity".
-  4. If nothing matches at any stage, the token is dropped.
+  2. Edit-distance candidates (weight 0.5) — typos and orthographic variants
+     (e.g. trellis ↔ treillis).
+  3. Prefix-coverage candidates (weight 0.7) — stems like "elec" →
+     "electricity". Run alongside edit-distance, not as a fallback: a short
+     query like "elec" can have unrelated edit-distance hits ("alec",
+     "elect") that would otherwise mask its real intent (the stem).
+  4. Edit and prefix lists are merged; if a token appears in both, the
+     higher weight wins (prefix > edit).
+  5. If nothing matches at any stage, the token is dropped.
 
 The trigram index on BM25Index acts as a cheap prefilter so we only compute
 edit distance against plausible candidates, not the whole vocabulary.
@@ -37,9 +39,14 @@ fuzzyWeight, prefixWeight :: Double
 fuzzyWeight = 0.5
 prefixWeight = 0.7
 
-minSharedTrigrams, topN, minPrefixLen :: Int
+minSharedTrigrams, topN, prefixTopN, minPrefixLen :: Int
 minSharedTrigrams = 2
 topN = 3
+-- Stem expansions are inherently a long tail (a 4-5 char prefix typically
+-- has 5–30 covering tokens in a real LCA corpus). Keep more than the
+-- edit-distance topN so longer derived forms ("electricity") survive when
+-- many shorter siblings ("elect", "electa", "electro") share the prefix.
+prefixTopN = 10
 minPrefixLen = 4
 
 minJaccard, minCoverage :: Double
@@ -72,9 +79,11 @@ expandTokensGrouped idx = map expand
     expand t =
         let inVocab = t `M.member` bm25Postings idx
             exact = [(t, 1.0) | inVocab]
-            variants = case editCandidates idx t of
-                edits@(_ : _) -> [(c, fuzzyWeight) | c <- take topN edits, c /= t]
-                [] -> [(c, prefixWeight) | c <- take topN (prefixCandidates idx t), c /= t]
+            edits = [(c, fuzzyWeight) | c <- take topN (editCandidates idx t), c /= t]
+            prefixes = [(c, prefixWeight) | c <- take prefixTopN (prefixCandidates idx t), c /= t]
+            -- A candidate can satisfy both edit-distance and prefix-coverage
+            -- (e.g. "electricit" → "electricity"). Keep the higher weight.
+            variants = M.toList (M.fromListWith max (edits ++ prefixes))
          in exact ++ variants
 
 {- | Candidate tokens within the permitted edit distance of the query.

--- a/test/FuzzySpec.hs
+++ b/test/FuzzySpec.hs
@@ -53,10 +53,35 @@ spec = describe "Search.Fuzzy" $ do
         let idx = indexOfNames ["electricity grid"]
         expandTokens idx ["electri"] `shouldBe` [("electricity", 0.7)]
 
-    it "prefers edit-distance over prefix when both could match" $ do
-        -- "electricit" is 1 edit from "electricity" — edit-distance wins.
+    it "merges edit-distance and prefix matches on the same candidate, keeping the higher weight" $ do
+        -- "electricit" reaches "electricity" via both edit-distance (1 char)
+        -- and prefix-coverage. After merge, the prefix weight (0.7) wins.
         let idx = indexOfNames ["electricity grid"]
-        expandTokens idx ["electricit"] `shouldBe` [("electricity", 0.5)]
+        expandTokens idx ["electricit"] `shouldBe` [("electricity", 0.7)]
+
+    it "still expands a short prefix when an edit-distance candidate exists" $ do
+        -- 'elec' has an edit-distance neighbour ('elect') in vocab. Before the
+        -- merge, that short-circuited prefix expansion and 'electricity' was
+        -- never reached, so any user typing 'elec' got zero electricity hits.
+        let idx =
+                indexOfNames
+                    [ "Electricity, high voltage market"
+                    , "elect committee report"
+                    ]
+        map fst (expandTokens idx ["elec"]) `shouldContain` ["electricity"]
+
+    it "keeps long stems like 'electricity' in the prefix expansion of 'elect'" $ do
+        -- With many shorter prefix siblings (electric/election/electron…)
+        -- a topN=3 cutoff dropped 'electricity'. prefixTopN=10 keeps it.
+        let idx =
+                indexOfNames
+                    [ "Electricity, high voltage"
+                    , "election day"
+                    , "electrolyte balance"
+                    , "electron microscope"
+                    , "electric platform"
+                    ]
+        map fst (expandTokens idx ["elect"]) `shouldContain` ["electricity"]
 
     it "drops unmatchable tokens" $ do
         let idx = indexOfNames ["yaourt nature", "lait demi"]


### PR DESCRIPTION
## Summary

- Searching `elec` returned zero results; `elect` surfaced *"Apple, conventional, electric platform"* but missed *"Electricity, high voltage"* — both regressions traced to `Fuzzy.expand`.
- `editCandidates` short-circuited `prefixCandidates`, so 4-char queries got incidental edit-distance neighbours and never tried the stem path.
- Shared `topN = 3` with sort-by-length-asc dropped longer derived forms (`electricity`, 11 chars) when many shorter siblings (`electric`, `election`, `electron`) shared the prefix.

## Fix

- Run edit-distance and prefix-coverage in parallel; merge with `Map.fromListWith max` so a candidate covered by both keeps the higher weight (0.7 > 0.5).
- Separate `prefixTopN = 10` for stem expansions; `topN = 3` stays for typo correction.

## Test plan

- [x] `cabal test lca-tests --test-options="--match Search.Fuzzy"` — 13/13 pass, including the previously-passing edit/prefix interaction test (now asserts the higher prefix weight).
- [x] New regression tests in `FuzzySpec.hs`:
  - `elec` reaches `electricity` even when an edit-distance neighbour (`elect`) exists in vocab.
  - `elect` keeps `electricity` in its expansion despite shorter siblings.
- [ ] Manual end-to-end on Agribalyse + ecoinvent via the activity search UI / `search_activities` MCP tool: confirm `elec` and `elect` surface the major electricity activities in the top results.