### PR TITLE
feat(lcia): regionalized scoring via openLCA JSON-LD ImpactCategory

### DIFF
--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -36,7 +36,7 @@ import qualified Expr
 import GHC.Generics
 import qualified GHC.Stats
 import Matrix (Inventory)
-import Method.Mapping (MappingStats (..), MatchStrategy (..), computeLCIAScoreFromTables, computeMappingStats, inventoryContributions)
+import Method.Mapping (MappingStats (..), MatchStrategy (..), MethodTables (..), computeLCIAScoreAuto, computeLCIAScoreFromTables, computeMappingStats, inventoryContributions)
 import Method.Types (DamageCategory (..), FlowDirection (..), Method (..), MethodCF (..), MethodCollection (..), NormWeightSet (..), ScoringEvaluation (..), ScoringSet (..), computeFormulaScores)
 import Numeric (showFFloat)
 import Plugin.Types (AnalyzeContext (..), AnalyzeHandle (..), PluginRegistry (..))
@@ -736,7 +736,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
             Left err -> throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ T.pack $ show err}
             Right (actProcessId, activity) -> do
                 inventory <- inventoryWithDeps dbManager dbName db sharedSolver actProcessId
-                result <- liftIO $ computeCategoryResult dbName db activity (fromMaybe 5 topFlowsParam) inventory method
+                result <- liftIO $ computeCategoryResult dbName db sharedSolver actProcessId activity (fromMaybe 5 topFlowsParam) inventory method
                 liftIO $ logLCIAResult result method
                 return result
 
@@ -759,7 +759,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     processId
                     (srSubstitutions subReq)
         inventory <- either throwServiceError pure eInv
-        liftIO $ computeCategoryResult dbName db activity 5 inventory method
+        liftIO $ computeCategoryResult dbName db sharedSolver processId activity 5 inventory method
 
     -- Batch LCIA endpoint (all methods in a collection)
     getActivityLCIABatch :: Text -> Text -> Text -> Handler LCIABatchResult
@@ -812,7 +812,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                         reportProgress Info $
                             "  Inventory UUIDs: "
                                 <> intercalate ", " (map UUID.toString $ M.keys inventory)
-                rawResults <- liftIO $ mapConcurrently (computeCategoryResult dbName db activity 5 inventory) methods
+                rawResults <- liftIO $ mapConcurrently (computeCategoryResult dbName db sharedSolver actProcessId activity 5 inventory) methods
                 -- Enrich with NW data
                 let results = map (enrichWithNW dcLookup mNW) rawResults
                     -- Compute formula-based scoring sets
@@ -871,7 +871,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     processId
                     (srSubstitutions subReq)
         inventory <- either throwServiceError pure eInv
-        rawResults <- liftIO $ mapConcurrently (computeCategoryResult dbName db activity 5 inventory) methods
+        rawResults <- liftIO $ mapConcurrently (computeCategoryResult dbName db sharedSolver processId activity 5 inventory) methods
         let results = map (enrichWithNW dcLookup mNW) rawResults
             rawScoreMap =
                 M.fromList
@@ -1188,8 +1188,8 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                                 }
 
     -- Helper: compute LCIA result for a single method against an inventory
-    computeCategoryResult :: Text -> Database -> Activity -> Int -> Inventory -> Method -> IO LCIAResult
-    computeCategoryResult dbName db activity topFlows inventory method = do
+    computeCategoryResult :: Text -> Database -> SharedSolver -> ProcessId -> Activity -> Int -> Inventory -> Method -> IO LCIAResult
+    computeCategoryResult dbName db sharedSolver actPid activity topFlows inventory method = do
         unitCfg <- getMergedUnitConfig dbManager
         (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
         mappings <- DM.mapMethodToFlowsCached dbManager dbName db method
@@ -1197,7 +1197,17 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
         -- Force score evaluation here so mapConcurrently actually parallelizes the work
         -- (without this, lazy thunks are created and forced later in the main thread)
         let stats = computeMappingStats mappings
-        !score <- evaluate $ computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables
+        score <- if M.null (mtRegionalizedCF tables)
+            then evaluate $ computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables
+            else do
+                scalingVec <- SharedSolver.computeScalingVectorCached db sharedSolver actPid
+                hier <- DM.getLocationHierarchy dbManager
+                case computeLCIAScoreAuto unitCfg mUnits mFlows db scalingVec inventory hier tables of
+                    Right s -> evaluate s
+                    Left err -> do
+                        reportProgress Warning $
+                            "[LCIA " <> T.unpack (methodName method) <> "] " <> T.unpack err
+                        evaluate (0 :: Double)
         let (prodName, prodAmount, prodUnit) = Service.getReferenceProductInfo mFlows mUnits activity
             functionalUnit = T.pack (showFFloat (Just 2) prodAmount "") <> " " <> prodUnit <> " of " <> prodName
             (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
@@ -1585,8 +1595,8 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
         t0 <- liftIO getCurrentTime
         inventories <- inventoriesWithDeps dbManager dbName db sharedSolver validPidNums
         t1 <- liftIO getCurrentTime
-        let mkEntry ((pidText, _pidNum, activity), inventory) = do
-                impacts <- buildLCIABatchResult dbName db activity collection inventory
+        let mkEntry ((pidText, pidNum, activity), inventory) = do
+                impacts <- buildLCIABatchResult dbName db sharedSolver pidNum activity collection inventory
                 pure
                     BatchImpactsEntry
                         { bieProcessId = pidText
@@ -1630,8 +1640,8 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
 
     -- Shared post-inventory pipeline: characterize, enrich with NW, compute scoring sets.
     -- Pure IO on its inputs; callers own logging and inventory computation.
-    buildLCIABatchResult :: Text -> Database -> Activity -> MethodCollection -> Inventory -> IO LCIABatchResult
-    buildLCIABatchResult dbName db activity collection inventory = do
+    buildLCIABatchResult :: Text -> Database -> SharedSolver -> ProcessId -> Activity -> MethodCollection -> Inventory -> IO LCIABatchResult
+    buildLCIABatchResult dbName db sharedSolver actPid activity collection inventory = do
         let methods = mcMethods collection
             damageCats = mcDamageCategories collection
             nwSets = mcNormWeightSets collection
@@ -1642,7 +1652,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     , (subName, _) <- dcImpacts dc
                     ]
             mNW = case nwSets of (nw : _) -> Just nw; [] -> Nothing
-        rawResults <- mapConcurrently (computeCategoryResult dbName db activity 5 inventory) methods
+        rawResults <- mapConcurrently (computeCategoryResult dbName db sharedSolver actPid activity 5 inventory) methods
         let results = map (enrichWithNW dcLookup mNW) rawResults
             rawScoreMap = M.fromList [(lrCategory r, lrScore r) | r <- rawResults]
         (scoringResults, scoringIndicators) <-

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -67,6 +67,7 @@ module Database.Manager (
     getMergedCompartmentMap,
     getMergedUnitConfig,
     getMergedFlowMetadata,
+    getLocationHierarchy,
 
     -- * Staged Database Operations
     getStagedDatabase,
@@ -146,6 +147,7 @@ import qualified Database.UploadedDatabase as UploadedDB
 import Method.FlowResolver (ILCDFlowInfo)
 import qualified Method.FlowResolver as FlowResolver
 import qualified Method.Parser
+import qualified Method.Parser.OlcaSchema as OlcaSchema
 import Method.ParserCSV (parseMethodCSVBytes)
 import Method.ParserSimaPro (isSimaProMethodCSV, parseSimaProMethodCSVBytes)
 import qualified SimaPro.Parser as SimaPro
@@ -2064,8 +2066,9 @@ loadMethodCollectionFromConfig mc = do
             files <- listDirectory dir
             let xmlFiles = filter (\f -> map toLower (takeExtension f) == ".xml") files
                 csvFiles = filter (\f -> map toLower (takeExtension f) == ".csv") files
-            if null xmlFiles && null csvFiles
-                then return $ Left $ "No method files (.xml/.csv) found in: " <> T.pack dir
+                jsonFiles = filter (\f -> map toLower (takeExtension f) == ".json") files
+            if null xmlFiles && null csvFiles && null jsonFiles
+                then return $ Left $ "No method files (.xml/.csv/.json) found in: " <> T.pack dir
                 else do
                     -- Try to find sibling flows/ directory for CF enrichment
                     mFlowsDir <- FlowResolver.resolveFlowDirectory dir
@@ -2087,26 +2090,38 @@ loadMethodCollectionFromConfig mc = do
                         if isSimaProMethodCSV bytes
                             then return $ fmap Left (parseSimaProMethodCSVBytes bytes)
                             else return $ fmap Right (parseMethodCSVBytes bytes)
+                    -- openLCA JSON-LD ImpactCategory files (carries optional regionalized CFs).
+                    -- Only files that actually carry @type=ImpactCategory are parsed; others
+                    -- are skipped silently since arbitrary .json files can sit alongside
+                    -- method data (e.g. metadata or other openLCA entity types).
+                    jsonResults <- forM jsonFiles $ \f -> do
+                        bytes <- BS.readFile (dir </> f)
+                        if OlcaSchema.isOlcaImpactCategoryJson bytes
+                            then return $ Just $ OlcaSchema.parseOlcaImpactCategoryBytes bytes
+                            else return Nothing
                     let (xmlErrs, xmlMethods) = partitionEithers xmlResults
                         (csvErrs, csvOks) = partitionEithers csvParsed
+                        (jsonErrs, jsonMethods) = partitionEithers [r | Just r <- jsonResults]
                         -- Merge: SimaPro CSVs are MethodCollections, tabular CSVs are [Method]
                         spCollections = [sp | Left sp <- csvOks]
                         tabularMethods = concat [ms | Right ms <- csvOks]
                         allMethods =
                             xmlMethods
                                 ++ tabularMethods
+                                ++ jsonMethods
                                 ++ concatMap mcMethods spCollections
                         -- Merge NW data from all SimaPro CSV sources
                         allDamageCats = concatMap mcDamageCategories spCollections
                         allNWSets = concatMap mcNormWeightSets spCollections
                         collection = MethodCollection allMethods allDamageCats allNWSets []
-                        errs = xmlErrs ++ csvErrs
+                        errs = xmlErrs ++ csvErrs ++ jsonErrs
                     if null allMethods && not (null errs)
                         then return $ Left $ "All method files failed to parse: " <> T.pack (head errs)
                         else do
                             let xmlOk = length xmlMethods
                                 csvOk = length csvOks
-                            reportProgress Info $ "  Parsed " <> show xmlOk <> " XML, " <> show csvOk <> " CSV file(s)"
+                                jsonOk = length jsonMethods
+                            reportProgress Info $ "  Parsed " <> show xmlOk <> " XML, " <> show csvOk <> " CSV, " <> show jsonOk <> " JSON file(s)"
                             when (not (null allDamageCats)) $
                                 reportProgress Info $
                                     "  "
@@ -2152,6 +2167,7 @@ listMethodCollections manager = do
     detectFormatFromPath :: FilePath -> Text
     detectFormatFromPath p
         | T.isInfixOf ".csv" (T.toLower (T.pack p)) = "SimaPro CSV"
+        | T.isInfixOf ".json" (T.toLower (T.pack p)) = "Regionalized LCIA JSON"
         | otherwise = "ILCD"
 
 -- | Load a method collection on demand
@@ -2304,6 +2320,12 @@ Detects UUID collisions with divergent metadata. 'M.unions' is first-wins;
 collisions should never happen (same UUID ⇒ same flow by construction),
 but if data drift produces them, surface via log rather than hide.
 -}
+-- | Location hierarchy as a 'Map ChildLocation [ParentLocation]', sourced from
+-- 'data/geographies.csv' (or the hardcoded fallback). Reused across the LCIA
+-- regionalized scoring path (see 'Method.Mapping.computeRegionalizedLCIAScore').
+getLocationHierarchy :: DatabaseManager -> IO (M.Map Text [Text])
+getLocationHierarchy manager = pure (M.map snd (dmGeographies manager))
+
 getMergedFlowMetadata :: DatabaseManager -> IO (FlowDB, UnitDB)
 getMergedFlowMetadata manager = do
     cached <- readTVarIO (dmMergedFlowMetadataCache manager)

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -20,6 +20,8 @@ module Method.Mapping (
     buildMethodTables,
     computeLCIAScore,
     computeLCIAScoreFromTables,
+    computeLCIAScoreAuto,
+    computeRegionalizedLCIAScore,
     inventoryContributions,
     processContributionsFromTables,
 
@@ -48,12 +50,13 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import qualified Data.Vector.Unboxed.Mutable as MU
 
-import Matrix (Inventory)
+import qualified Data.Set as Set
+import Matrix (Inventory, Vector)
 import qualified Matrix
 import Method.Types
 import Plugin.Types (MapContext (..), MapQuery (..), MapResult (..), MapperHandle (..))
 import SynonymDB
-import Types (Database (..), Flow (..), FlowDB, ProcessId, SparseTriple (..), Unit (..), UnitDB)
+import Types (Activity (..), Database (..), Flow (..), FlowDB, ProcessId, SparseTriple (..), Unit (..), UnitDB)
 import UnitConversion (UnitConfig, convertUnit)
 
 -- | Matching strategy used to find a flow
@@ -234,6 +237,10 @@ data MethodTables = MethodTables
     -- ^ (normalized name, medium, subcompartment) → (CF, unit)
     , mtFallbackCF :: !(M.Map (Text, Text) (Double, Text))
     -- ^ (normalized name, medium) → (CF, unit) for entries with unspecified subcompartment
+    , mtRegionalizedCF :: !(M.Map (UUID, Text) (Double, Text))
+    -- ^ Regionalized cells of the C matrix: (DB flow UUID, consumer location) → (CF, unit).
+    -- Empty for non-regionalized methods. When non-empty, callers should dispatch
+    -- to the regionalized scoring path (see 'Matrix.computeRegionalizedLCIAScore').
     }
 
 -- | Build 'MethodTables' from raw mappings. Run once per (db, method).
@@ -263,6 +270,12 @@ buildMethodTables mappings =
                     , Just (Compartment medium subcomp _) <- [mcfCompartment cf]
                     , T.null subcomp
                     ]
+        , mtRegionalizedCF =
+            M.fromList
+                [ ((flowId flow, loc), (mcfValue cf, mcfUnit cf))
+                | (cf, Just (flow, _)) <- mappings
+                , Just loc <- [mcfConsumerLocation cf]
+                ]
         }
   where
     stripStrategy = M.map (\(v, u, _) -> (v, u))
@@ -333,6 +346,171 @@ computeLCIAScoreFromTables unitConfig unitDB flowDB inventory tables =
 computeLCIAScore :: UnitConfig -> UnitDB -> FlowDB -> Inventory -> [(MethodCF, Maybe (Flow, MatchStrategy))] -> Double
 computeLCIAScore unitConfig unitDB flowDB inventory mappings =
     computeLCIAScoreFromTables unitConfig unitDB flowDB inventory (buildMethodTables mappings)
+
+{- | LCIA score with automatic dispatch.
+
+If the method has no regionalized CFs ('mtRegionalizedCF' empty), uses the
+classic vector path ('computeLCIAScoreFromTables'). Otherwise switches to
+the matrix path ('computeRegionalizedLCIAScore').
+
+The caller is expected to provide both an 'Inventory' (cheap if already
+computed for other purposes) and a scaling 'Vector' (cheap if the MUMPS
+factorization is cached). Pass them both and let this function pick.
+
+Returns 'Either' so regionalized methods can surface coverage gaps as
+explicit errors instead of silently under-counting.
+-}
+computeLCIAScoreAuto ::
+    UnitConfig ->
+    UnitDB ->
+    FlowDB ->
+    Database ->
+    -- | Scaling vector @s@ (only consulted if the method is regionalized)
+    Vector ->
+    -- | Pre-computed inventory @g = B · s@ (only used in the classic path)
+    Inventory ->
+    -- | Location hierarchy: child → ordered list of parents
+    M.Map Text [Text] ->
+    MethodTables ->
+    Either Text Double
+computeLCIAScoreAuto unitCfg unitDB flowDB db scalingVec inventory hier tables
+    | M.null (mtRegionalizedCF tables) =
+        Right (computeLCIAScoreFromTables unitCfg unitDB flowDB inventory tables)
+    | otherwise =
+        computeRegionalizedLCIAScore unitCfg unitDB flowDB db scalingVec hier tables
+
+{- | Streaming regionalized LCIA score over the biosphere matrix.
+
+@score = Σ_{(f, a)} B[f, a] · s[a] · C[f, loc(a)]@
+
+Where @C[f, l]@ is resolved by hierarchical fallback:
+
+  1. Exact regional cell @(f, l)@ in 'mtRegionalizedCF'.
+  2. Cell at any parent region of @l@ (walked via the location hierarchy).
+  3. Universal broadcast: the same lookup that 'computeLCIAScoreFromTables' uses
+     ('mtUuidCF' / 'mtExactCF' / 'mtFallbackCF').
+  4. If none of the above and @f@ is regionalized in this method (i.e. the
+     regional table mentions @f@ for some other location), fail with a 'Left'
+     surfacing the gap — silent zero would under-count.
+  5. If @f@ is not covered at all by the method, contribute 0.
+
+The hierarchy is the same one used by 'Database.CrossLinking.isSubregionOf':
+@Map ChildLocation [ParentLocation]@ from broader to broadest.
+
+This path is selected by 'Service' when 'mtRegionalizedCF' is non-empty;
+non-regionalized methods continue to use 'computeLCIAScoreFromTables'.
+-}
+computeRegionalizedLCIAScore ::
+    UnitConfig ->
+    UnitDB ->
+    FlowDB ->
+    Database ->
+    -- | Scaling vector @s@ from 'Matrix.computeScalingVector'
+    Vector ->
+    -- | Location hierarchy: child → ordered list of parents
+    M.Map Text [Text] ->
+    MethodTables ->
+    Either Text Double
+computeRegionalizedLCIAScore unitConfig unitDB flowDB db scalingVec hier tables =
+    let actIdx = dbActivityIndex db
+        bioTriples = dbBiosphereTriples db
+        bioFlows = dbBiosphereFlows db
+        activities = dbActivities db
+        regional = mtRegionalizedCF tables
+        regionalizedFlows = Set.fromList [f | (f, _) <- M.keys regional]
+        colToActivity :: M.Map Int Activity
+        colToActivity =
+            M.fromList
+                [ (fromIntegral (actIdx V.! pid), activities V.! pid)
+                | pid <- [0 .. V.length actIdx - 1]
+                ]
+        step :: Either Text Double -> SparseTriple -> Either Text Double
+        step acc (SparseTriple flowRow colIdx bioVal) = do
+            running <- acc
+            let s = scalingVec U.! fromIntegral colIdx
+                contribution = bioVal * s
+            if contribution == 0
+                then Right running
+                else case M.lookup (fromIntegral colIdx :: Int) colToActivity of
+                    Nothing -> Right running
+                    Just act ->
+                        let flowUUID = bioFlows V.! fromIntegral flowRow
+                            loc = activityLocation act
+                         in case resolveRegionalCF tables flowDB regionalizedFlows hier flowUUID loc of
+                                Right Nothing -> Right running
+                                Right (Just (cfVal, cfUnit)) ->
+                                    let flowUnit = maybe "" unitName (M.lookup flowUUID flowDB >>= \f -> M.lookup (flowUnitId f) unitDB)
+                                        converted =
+                                            if flowUnit == cfUnit || T.null cfUnit
+                                                then contribution
+                                                else fromMaybe contribution (convertUnit unitConfig flowUnit cfUnit contribution)
+                                     in Right (running + converted * cfVal)
+                                Left err -> Left err
+     in U.foldl' step (Right 0) bioTriples
+
+{- | Resolve a CF for a (flow, location) pair through the hierarchy + broadcast
+fallback. See 'computeRegionalizedLCIAScore' for the rules.
+
+* @Right Nothing@: the flow is not covered by this method (silent OK).
+* @Right (Just v)@: a CF was found.
+* @Left err@: the flow IS regionalized in this method but no CF could be
+  resolved for the given location even after walking parents — surfacing the
+  gap prevents silent under-counting.
+-}
+resolveRegionalCF ::
+    MethodTables ->
+    FlowDB ->
+    Set.Set UUID ->
+    M.Map Text [Text] ->
+    UUID ->
+    Text ->
+    Either Text (Maybe (Double, Text))
+resolveRegionalCF tables flowDB regionalizedFlows hier flowUUID loc =
+    case M.lookup (flowUUID, loc) (mtRegionalizedCF tables) of
+        Just v -> Right (Just v)
+        Nothing ->
+            let parents = M.findWithDefault [] loc hier
+                fromParents = firstJust [M.lookup (flowUUID, p) (mtRegionalizedCF tables) | p <- parents]
+             in case fromParents of
+                    Just v -> Right (Just v)
+                    Nothing -> case lookupBroadcastCF tables flowDB flowUUID of
+                        Just v -> Right (Just v)
+                        Nothing
+                            | Set.member flowUUID regionalizedFlows ->
+                                Left $
+                                    "Regionalized CF lookup failed: flow "
+                                        <> T.pack (show flowUUID)
+                                        <> " has regional CFs in this method but none for location '"
+                                        <> loc
+                                        <> "' (after walking "
+                                        <> T.pack (show (length parents))
+                                        <> " parent regions) and no universal broadcast."
+                            | otherwise -> Right Nothing
+
+-- | Universal CF lookup: same cascade as 'computeLCIAScoreFromTables' uses
+-- internally, factored out for reuse from 'computeRegionalizedLCIAScore'.
+lookupBroadcastCF :: MethodTables -> FlowDB -> UUID -> Maybe (Double, Text)
+lookupBroadcastCF tables flowDB fid = case M.lookup fid (mtUuidCF tables) of
+    Just cfv -> Just cfv
+    Nothing -> case M.lookup fid flowDB of
+        Nothing -> Nothing
+        Just flow ->
+            let name = normalizeName (flowName flow)
+                baseMed = normalizeMediumNm . T.takeWhile (/= '/') . T.toLower $ flowCategory flow
+                subcomp = T.toLower $ fromMaybe "" (flowSubcompartment flow)
+                exact = M.lookup (name, baseMed, subcomp) (mtExactCF tables)
+             in case exact of
+                    Just _ -> exact
+                    Nothing -> M.lookup (name, baseMed) (mtFallbackCF tables)
+  where
+    normalizeMediumNm m
+        | m == "natural resource" = "resource"
+        | otherwise = m
+
+firstJust :: [Maybe a] -> Maybe a
+firstJust [] = Nothing
+firstJust (Just x : _) = Just x
+firstJust (Nothing : xs) = firstJust xs
 
 {- | Per-flow contributions over an 'Inventory', keyed by flow UUID (possibly
 cross-DB-merged). Walks the inventory directly (not the mappings) so any

--- a/src/Method/Parser.hs
+++ b/src/Method/Parser.hs
@@ -150,6 +150,7 @@ closeTag state tagName
                     , mcfCompartment = extractCompartmentFromDesc (psCurrentFlowName state)
                     , mcfCAS = Nothing -- enriched in buildMethod from flow XMLs
                     , mcfUnit = psUnit state
+                    , mcfConsumerLocation = Nothing
                     }
          in state
                 { psPath = dropPath

--- a/src/Method/Parser/OlcaSchema.hs
+++ b/src/Method/Parser/OlcaSchema.hs
@@ -1,0 +1,200 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Parser for the openLCA JSON-LD schema (https://greendelta.github.io/olca-schema)
+restricted to 'ImpactCategory' / 'ImpactFactor' — the shape that encodes a
+regionalized LCIA method.
+
+Top-level shape:
+
+> {
+>   "@context": "http://greendelta.github.io/olca-schema/context.jsonld",
+>   "@type": "ImpactCategory",
+>   "@id": "3a08605b-...",
+>   "name": "Biodiversity loss potential",
+>   "referenceUnitName": "m2*year",
+>   "impactFactors": [
+>     {
+>       "@type": "ImpactFactor",
+>       "value": 22.15,
+>       "flow": {"@type": "Flow", "@id": "0305...", "name": "Occupation, agriculture",
+>                "flowType": "ELEMENTARY_FLOW"},
+>       "location": {"@type": "Location", "@id": "...", "name": "France", "code": "FR"},
+>       "unit": {"@type": "Unit", "@id": "...", "name": "m2*year"}
+>     }, ...
+>   ]
+> }
+
+Each 'ImpactFactor' becomes a single 'MethodCF':
+
+* @flow.\@id@ → 'mcfFlowRef' (UUID — deterministic match against DB flow UUIDs)
+* @flow.name@ → 'mcfFlowName' (kept for display + name-based fallback matching)
+* @flow.cas@ → 'mcfCAS' (when present)
+* @flow.flowType == \"ELEMENTARY_FLOW\"@ controls whether we carry a compartment.
+* @location.code@ (preferred) or @location.name@ → 'mcfConsumerLocation'.
+  Absent location → 'Nothing' = universal CF (broadcast over all locations).
+* @value@ → 'mcfValue'
+* @unit.name@ → 'mcfUnit'
+
+Optional fields ignored at this stage but trivial to wire later:
+
+* @formula@ — parametric CFs (we'd need an evaluator)
+* @uncertainty@ — distribution → Monte Carlo support
+* @flowProperty@ — we currently rely on @unit@ only
+
+Other openLCA top-level types ('Process', 'Flow', 'ImpactMethod', etc.) are not
+recognized by 'isOlcaImpactCategoryJson'; the auto-detection in
+'Database.Manager' only routes @ImpactCategory@ files into this parser.
+-}
+module Method.Parser.OlcaSchema (
+    parseOlcaImpactCategoryBytes,
+    isOlcaImpactCategoryJson,
+) where
+
+import Data.Aeson (Value (..), eitherDecodeStrict)
+import qualified Data.Aeson.Key as K
+import qualified Data.Aeson.KeyMap as KM
+import qualified Data.ByteString as BS
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Scientific (toRealFloat)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
+import qualified Data.UUID.V5 as UUID5
+import qualified Data.Vector as V
+import Data.Word (Word8)
+
+import Method.Types
+
+-- | Quick structural sniff: a JSON object with @\"@type\": \"ImpactCategory\"@.
+-- Used by 'Database.Manager' to dispatch @.json@ files to this parser.
+isOlcaImpactCategoryJson :: BS.ByteString -> Bool
+isOlcaImpactCategoryJson bytes = case eitherDecodeStrict bytes of
+    Right (Object o) -> case KM.lookup "@type" o of
+        Just (String "ImpactCategory") -> True
+        _ -> False
+    _ -> False
+
+-- | Parse one openLCA @ImpactCategory@ JSON-LD document into a 'Method'.
+parseOlcaImpactCategoryBytes :: BS.ByteString -> Either String Method
+parseOlcaImpactCategoryBytes bytes = do
+    val <- eitherDecodeStrict bytes
+    case val of
+        Object o -> do
+            assertType o "ImpactCategory"
+            name <- requireText o "name"
+            let mid = parseUuidField o "@id"
+                description = lookupText o "description"
+                unit = fromMaybe "" (lookupText o "referenceUnitName")
+                factors = case KM.lookup "impactFactors" o of
+                    Just (Array v) -> mapMaybe parseImpactFactor (V.toList v)
+                    _ -> []
+            Right
+                Method
+                    { methodId = fromMaybe (synthMethodId name) mid
+                    , methodName = name
+                    , methodDescription = description
+                    , methodUnit = unit
+                    , methodCategory = name
+                    , methodMethodology = Just "openLCA JSON-LD"
+                    , methodFactors = factors
+                    }
+        _ -> Left "openLCA ImpactCategory: expected a top-level JSON object"
+
+parseImpactFactor :: Value -> Maybe MethodCF
+parseImpactFactor (Object o) = do
+    value <- numberField o "value"
+    flow <- objectField o "flow"
+    let flowName = fromMaybe "" (lookupText flow "name")
+        flowUuid = fromMaybe (synthFlowId flowName) (parseUuidField flow "@id")
+        flowCas = lookupText flow "cas"
+        unitName = case objectField o "unit" of
+            Just u -> fromMaybe "" (lookupText u "name")
+            Nothing -> ""
+        loc = case objectField o "location" of
+            Just l -> case lookupText l "code" of
+                Just c -> Just c
+                Nothing -> lookupText l "name"
+            Nothing -> Nothing
+        direction = directionFromFlow o
+    -- A factor without a flow name is unmatchable; drop it. (UUID alone could
+    -- in theory match by id, but in practice the name carries the matching
+    -- signal too and is required by every fallback strategy.)
+    if T.null flowName
+        then Nothing
+        else
+            Just
+                MethodCF
+                    { mcfFlowRef = flowUuid
+                    , mcfFlowName = flowName
+                    , mcfDirection = direction
+                    , mcfValue = value
+                    -- Compartment can live on the openLCA Flow object via its
+                    -- 'category' field (a Ref[Category] hierarchy). Wiring that
+                    -- in is straightforward but not needed yet — UUID-based
+                    -- matching against the DB doesn't use the compartment.
+                    , mcfCompartment = Nothing
+                    , mcfCAS = flowCas
+                    , mcfUnit = unitName
+                    , mcfConsumerLocation = loc
+                    }
+parseImpactFactor _ = Nothing
+
+-- | Direction is carried by 'ImpactFactor.direction' (Direction enum) when
+-- present, otherwise default to 'Output' since the vast majority of
+-- environmental CFs are emissions.
+directionFromFlow :: KM.KeyMap Value -> FlowDirection
+directionFromFlow o = case lookupText o "direction" of
+    Just "INPUT" -> Input
+    Just "OUTPUT" -> Output
+    _ -> Output
+
+-- ---------------------------------------------------------------------------
+-- Aeson helpers
+-- ---------------------------------------------------------------------------
+
+assertType :: KM.KeyMap Value -> Text -> Either String ()
+assertType o expected = case KM.lookup "@type" o of
+    Just (String t)
+        | t == expected -> Right ()
+        | otherwise -> Left ("openLCA: expected @type='" <> T.unpack expected <> "', got '" <> T.unpack t <> "'")
+    _ -> Left ("openLCA: missing @type field (expected '" <> T.unpack expected <> "')")
+
+requireText :: KM.KeyMap Value -> Text -> Either String Text
+requireText o k = case KM.lookup (K.fromText k) o of
+    Just (String t) -> Right t
+    Just _ -> Left ("openLCA: field '" <> T.unpack k <> "' is not a string")
+    Nothing -> Left ("openLCA: missing required field '" <> T.unpack k <> "'")
+
+lookupText :: KM.KeyMap Value -> Text -> Maybe Text
+lookupText o k = case KM.lookup (K.fromText k) o of
+    Just (String t) | not (T.null t) -> Just t
+    _ -> Nothing
+
+objectField :: KM.KeyMap Value -> Text -> Maybe (KM.KeyMap Value)
+objectField o k = case KM.lookup (K.fromText k) o of
+    Just (Object inner) -> Just inner
+    _ -> Nothing
+
+numberField :: KM.KeyMap Value -> Text -> Maybe Double
+numberField o k = case KM.lookup (K.fromText k) o of
+    Just (Number n) -> Just (toRealFloat n)
+    _ -> Nothing
+
+parseUuidField :: KM.KeyMap Value -> Text -> Maybe UUID
+parseUuidField o k = lookupText o k >>= UUID.fromText
+
+textKey :: Text -> [Word8]
+textKey = BS.unpack . TE.encodeUtf8
+
+-- | Stable, deterministic UUID for a method that didn't carry an @\@id@ field.
+-- Falls back to a UUIDv5 derived from the method name.
+synthMethodId :: Text -> UUID
+synthMethodId name =
+    UUID5.generateNamed UUID5.namespaceURL (textKey ("volca:olca-method:" <> name))
+
+-- | Stable UUID for an unidentified flow (no @\@id@). Same idea.
+synthFlowId :: Text -> UUID
+synthFlowId name =
+    UUID5.generateNamed UUID5.namespaceURL (textKey ("volca:olca-flow:" <> name))

--- a/src/Method/ParserCSV.hs
+++ b/src/Method/ParserCSV.hs
@@ -101,6 +101,7 @@ mkMethod methodology catName impactName unit colIdx rows delim =
                 , mcfCompartment = parseCSVCompartment comp
                 , mcfCAS = Nothing
                 , mcfUnit = unit
+                , mcfConsumerLocation = Nothing
                 }
             | row <- rows
             , let cells = splitRow delim row

--- a/src/Method/ParserSimaPro.hs
+++ b/src/Method/ParserSimaPro.hs
@@ -164,15 +164,18 @@ step cfg methodologyName st line = case psPhase st of
             let fields = splitCSV (spDelimiter cfg) line
              in case fields of
                     (comp : sub : name : cas : cfVal : cfUnit : _) ->
-                        let !cf =
+                        let !rawName = decodeBS (BS8.strip name)
+                            (!cleanName, !mLoc) = extractLocationSuffix rawName
+                            !cf =
                                 MethodCF
-                                    { mcfFlowRef = makeFlowUUID name comp sub
-                                    , mcfFlowName = decodeBS (BS8.strip name)
+                                    { mcfFlowRef = makeFlowUUID (TE.encodeUtf8 cleanName) comp sub
+                                    , mcfFlowName = cleanName
                                     , mcfDirection = direction comp
                                     , mcfValue = parseAmount (spDecimal cfg) (BS8.strip cfVal)
                                     , mcfCompartment = mkCompartment comp sub
                                     , mcfCAS = normalizeCAS (decodeBS (BS8.strip cas))
                                     , mcfUnit = decodeBS (BS8.strip cfUnit)
+                                    , mcfConsumerLocation = mLoc
                                     }
                          in st{psFactors = cf : psFactors st}
                     _ -> st
@@ -385,3 +388,45 @@ normalizeCAS cas
          in if T.all (\c -> c == '-' || c == '0') cas
                 then Nothing
                 else Just result
+
+{- | SimaPro encodes regional variants of a flow as a suffix on the flow name:
+@"Nitrogen dioxide, FR"@. Detect that suffix so the matching layer can index
+the CF by @(flow, location)@ rather than by an opaque concatenated name.
+
+Heuristic: the trailing token must start with an uppercase ASCII letter,
+contain only letters or hyphens, and be 2–6 characters long. This catches:
+
+  * ISO-2 country codes: @FR@, @DE@, @AD@
+  * Regional aggregates: @RER@, @GLO@
+  * @RoW@ (rest of world; mixed case)
+  * Sub-national codes: @FR-IDF@ (if a database adopts them)
+
+But not: @"change"@ (lowercase first), @"indoor"@, @"yearly"@, etc., which
+are legitimate parts of compound flow names.
+
+If the heuristic doesn't match, the original name is returned unchanged with
+no consumer location.
+
+False positives (extracting a location suffix where the trailing token isn't
+actually a region) are harmless: the synthesized CF gets a 'Just loc' that
+won't match any DB activity, so it contributes 0. False negatives (missing a
+real location) are the bug we're trying to fix.
+-}
+extractLocationSuffix :: Text -> (Text, Maybe Text)
+extractLocationSuffix name =
+    case T.breakOnEnd ", " name of
+        ("", _) -> (name, Nothing) -- no ", " separator
+        (prefixWithSep, candidate)
+            | isLocationCode candidate
+            , let cleaned = T.dropEnd 2 prefixWithSep -- drop trailing ", "
+            , not (T.null cleaned) ->
+                (cleaned, Just candidate)
+            | otherwise -> (name, Nothing)
+  where
+    isLocationCode t
+        | T.length t < 2 || T.length t > 6 = False
+        | otherwise =
+            let firstC = T.head t
+                rest = T.unpack (T.tail t)
+             in firstC >= 'A' && firstC <= 'Z'
+                    && all (\c -> (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '-') rest

--- a/src/Method/Types.hs
+++ b/src/Method/Types.hs
@@ -89,6 +89,10 @@ data MethodCF = MethodCF
     -- ^ CAS number (normalized, no leading zeros)
     , mcfUnit :: !Text
     -- ^ CF reference unit (e.g., "kg", "kBq")
+    , mcfConsumerLocation :: !(Maybe Text)
+    -- ^ Consumer location for regionalized CFs (ISO 2-3 letter code).
+    -- 'Nothing' = universal CF (broadcast on all locations).
+    -- 'Just loc' = single cell of the C matrix at (flow, loc).
     }
     deriving (Eq, Show, Generic, NFData, ToJSON, FromJSON)
 

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -945,7 +945,13 @@ bioRowToExchange env isInput compartment BioExchangeRow{..} =
             if T.null berCompartment
                 then compartment
                 else compartment <> "/" <> berCompartment
-        flowUUID = generateFlowUUID berName category berUnit
+        -- SimaPro encodes regional flow variants as a `, <ISO>` suffix on the
+        -- flow name (e.g. "Nitrogen dioxide, FR"). Strip it so the inventory
+        -- DB's flows have canonical names that match universal CFs from any
+        -- method format. The regional info is implicit via the activity's
+        -- location, which carries the same signal in EcoSpold / Agribalyse.
+        (cleanName, _) = stripLocationSuffix berName
+        flowUUID = generateFlowUUID cleanName category berUnit
         unitUUID = generateUnitUUID berUnit
         amount = resolveAmount env berAmountRaw berAmount
         subcomp = if T.null berCompartment then Nothing else Just berCompartment
@@ -961,7 +967,7 @@ bioRowToExchange env isInput compartment BioExchangeRow{..} =
         flow =
             Flow
                 { flowId = flowUUID
-                , flowName = berName
+                , flowName = cleanName
                 , flowCategory = category
                 , flowSubcompartment = subcomp
                 , flowUnitId = unitUUID
@@ -972,6 +978,31 @@ bioRowToExchange env isInput compartment BioExchangeRow{..} =
                 }
         unit = Unit{unitId = unitUUID, unitName = berUnit, unitSymbol = berUnit, unitComment = ""}
      in (exchange, flow, unit)
+
+{- | Strip a SimaPro-style ", <ISO>" location suffix from a flow name.
+Mirrors 'Method.ParserSimaPro.extractLocationSuffix'. Same heuristic so the
+inventory side of a regionalized SimaPro export matches the method side.
+False positives are harmless: they only normalize a name that wasn't actually
+suffixed.
+-}
+stripLocationSuffix :: Text -> (Text, Maybe Text)
+stripLocationSuffix name =
+    case T.breakOnEnd ", " name of
+        ("", _) -> (name, Nothing)
+        (prefixWithSep, candidate)
+            | isLocationCode candidate
+            , let cleaned = T.dropEnd 2 prefixWithSep
+            , not (T.null cleaned) ->
+                (cleaned, Just candidate)
+            | otherwise -> (name, Nothing)
+  where
+    isLocationCode t
+        | T.length t < 2 || T.length t > 6 = False
+        | otherwise =
+            let firstC = T.head t
+                rest = T.unpack (T.tail t)
+             in firstC >= 'A' && firstC <= 'Z'
+                    && all (\c -> (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '-') rest
 
 -- ============================================================================
 -- Encoding Conversion

--- a/test-data/olca-schema-mini/impact-category-mini.json
+++ b/test-data/olca-schema-mini/impact-category-mini.json
@@ -1,0 +1,63 @@
+{
+  "@context": "http://greendelta.github.io/olca-schema/context.jsonld",
+  "@type": "ImpactCategory",
+  "@id": "3a08605b-d7c9-4f40-a17e-74cece1dde8b",
+  "name": "Regional LCIA Mini",
+  "description": "Minimal regionalized LCIA fixture for OlcaSchemaSpec.",
+  "referenceUnitName": "m2*year",
+  "impactFactors": [
+    {
+      "@type": "ImpactFactor",
+      "value": 22.15,
+      "flow": {
+        "@type": "Flow",
+        "@id": "0305b169-255d-4041-8f5d-6e095bcb6358",
+        "name": "Occupation, agriculture",
+        "flowType": "ELEMENTARY_FLOW"
+      },
+      "location": {
+        "@type": "Location",
+        "@id": "28840420-4e3d-3522-a930-aaaaaaaaaaaa",
+        "name": "France",
+        "code": "FR"
+      },
+      "unit": {"@type": "Unit", "@id": "20aadc24-a391-41cf-b340-3e4529f44bde", "name": "m2*year"}
+    },
+    {
+      "@type": "ImpactFactor",
+      "value": 17.30,
+      "flow": {
+        "@type": "Flow",
+        "@id": "0305b169-255d-4041-8f5d-6e095bcb6358",
+        "name": "Occupation, agriculture",
+        "flowType": "ELEMENTARY_FLOW"
+      },
+      "location": {"@type": "Location", "@id": "28840420-4e3d-3522-a930-bbbbbbbbbbbb", "name": "Germany", "code": "DE"},
+      "unit": {"@type": "Unit", "@id": "20aadc24-a391-41cf-b340-3e4529f44bde", "name": "m2*year"}
+    },
+    {
+      "@type": "ImpactFactor",
+      "value": 10.00,
+      "flow": {
+        "@type": "Flow",
+        "@id": "0305b169-255d-4041-8f5d-6e095bcb6358",
+        "name": "Occupation, agriculture",
+        "flowType": "ELEMENTARY_FLOW"
+      },
+      "location": {"@type": "Location", "@id": "28840420-4e3d-3522-a930-cccccccccccc", "name": "Global", "code": "GLO"},
+      "unit": {"@type": "Unit", "@id": "20aadc24-a391-41cf-b340-3e4529f44bde", "name": "m2*year"}
+    },
+    {
+      "@type": "ImpactFactor",
+      "value": 5.0,
+      "flow": {
+        "@type": "Flow",
+        "@id": "1405b169-255d-4041-8f5d-6e095bcb6358",
+        "name": "Water consumption",
+        "flowType": "ELEMENTARY_FLOW"
+      },
+      "location": {"@type": "Location", "@id": "28840420-4e3d-3522-a930-dddddddddddd", "name": "Spain", "code": "ES"},
+      "unit": {"@type": "Unit", "@id": "20aadc24-a391-41cf-b340-3e4529f44bde", "name": "m3"}
+    }
+  ]
+}

--- a/test/CrossDBInventorySpec.hs
+++ b/test/CrossDBInventorySpec.hs
@@ -176,6 +176,7 @@ spec = do
                             ]
                     , mtExactCF = M.empty
                     , mtFallbackCF = M.empty
+                    , mtRegionalizedCF = M.empty
                     }
 
             inventory = M.fromList [(uuidRoot, 1.0), (uuidDep, 2.0), (uuidGone, 5.0)]

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -42,6 +42,7 @@ mkCF name mCas val =
         , mcfCompartment = Nothing
         , mcfCAS = mCas
         , mcfUnit = "kg"
+        , mcfConsumerLocation = Nothing
         }
 
 mkCFComp :: Text -> Text -> Text -> Double -> MethodCF

--- a/test/MethodSpec.hs
+++ b/test/MethodSpec.hs
@@ -683,8 +683,8 @@ spec = do
                     -- Inventory: CO2 = 10 kg, CH4 = 2 kg
                     inventory = M.fromList [(co2Uuid, 10.0), (ch4Uuid, 2.0)]
                     -- Method: CO2 CF = 1.0, CH4 CF = 28.0
-                    co2CF = MethodCF co2Uuid "Carbon dioxide" Output 1.0 Nothing Nothing "kg"
-                    ch4CF = MethodCF ch4Uuid "Methane" Output 28.0 Nothing Nothing "kg"
+                    co2CF = MethodCF co2Uuid "Carbon dioxide" Output 1.0 Nothing Nothing "kg" Nothing
+                    ch4CF = MethodCF ch4Uuid "Methane" Output 28.0 Nothing Nothing "kg" Nothing
                     co2Flow = mkTestFlow co2Uuid "Carbon dioxide"
                     ch4Flow = mkTestFlow ch4Uuid "Methane"
                     mappings =
@@ -698,8 +698,8 @@ spec = do
                 let co2Uuid = UUID.fromWords 1 2 3 4
                     ch4Uuid = UUID.fromWords 5 6 7 8
                     inventory = M.fromList [(co2Uuid, 10.0), (ch4Uuid, 2.0)]
-                    co2CF = MethodCF co2Uuid "Carbon dioxide" Output 1.0 Nothing Nothing "kg"
-                    ch4CF = MethodCF ch4Uuid "Methane" Output 28.0 Nothing Nothing "kg"
+                    co2CF = MethodCF co2Uuid "Carbon dioxide" Output 1.0 Nothing Nothing "kg" Nothing
+                    ch4CF = MethodCF ch4Uuid "Methane" Output 28.0 Nothing Nothing "kg" Nothing
                     co2Flow = mkTestFlow co2Uuid "Carbon dioxide"
                     mappings =
                         [ (co2CF, Just (co2Flow, ByUUID))
@@ -714,7 +714,7 @@ spec = do
                     -- Inventory has only CO2
                     inventory = M.fromList [(co2Uuid, 10.0)]
                     -- Method has N2O that's not in inventory
-                    n2oCF = MethodCF n2oUuid "Dinitrogen monoxide" Output 265.0 Nothing Nothing "kg"
+                    n2oCF = MethodCF n2oUuid "Dinitrogen monoxide" Output 265.0 Nothing Nothing "kg" Nothing
                     n2oFlow = mkTestFlow n2oUuid "Dinitrogen monoxide"
                     mappings = [(n2oCF, Just (n2oFlow, ByName))]
                 -- Score = 0 (N2O not in inventory)
@@ -724,7 +724,7 @@ spec = do
                 let oilUuid = UUID.fromWords 11 12 13 14
                     -- Resource extraction has negative sign in inventory
                     inventory = M.fromList [(oilUuid, -5.0)]
-                    oilCF = MethodCF oilUuid "Crude oil" Input 42.0 Nothing Nothing "MJ"
+                    oilCF = MethodCF oilUuid "Crude oil" Input 42.0 Nothing Nothing "MJ" Nothing
                     oilFlow = mkTestFlow oilUuid "Crude oil"
                     mappings = [(oilCF, Just (oilFlow, ByUUID))]
                 -- Score = -5 * 42 = -210 (negative = resource depletion)

--- a/test/OlcaSchemaSpec.hs
+++ b/test/OlcaSchemaSpec.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module OlcaSchemaSpec (spec) where
+
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as M
+import qualified Data.UUID as UUID
+import Test.Hspec
+
+import Method.Mapping (MethodTables (..), buildMethodTables)
+import Method.Parser.OlcaSchema (isOlcaImpactCategoryJson, parseOlcaImpactCategoryBytes)
+import Method.Types
+
+spec :: Spec
+spec = do
+    describe "isOlcaImpactCategoryJson" $ do
+        it "recognizes an openLCA ImpactCategory" $ do
+            bytes <- BS.readFile "test-data/olca-schema-mini/impact-category-mini.json"
+            isOlcaImpactCategoryJson bytes `shouldBe` True
+
+        it "rejects unrelated JSON" $ do
+            isOlcaImpactCategoryJson "{\"foo\": 1}" `shouldBe` False
+            isOlcaImpactCategoryJson "[1,2,3]" `shouldBe` False
+            isOlcaImpactCategoryJson "not json" `shouldBe` False
+
+        it "rejects another openLCA entity type" $
+            -- The auto-detection must not pull in Process / Flow / etc. files
+            -- that may sit in the same method directory.
+            isOlcaImpactCategoryJson "{\"@type\":\"Process\",\"name\":\"x\"}"
+                `shouldBe` False
+
+    describe "parseOlcaImpactCategoryBytes" $ do
+        it "parses the mini fixture and yields one MethodCF per ImpactFactor" $ do
+            bytes <- BS.readFile "test-data/olca-schema-mini/impact-category-mini.json"
+            case parseOlcaImpactCategoryBytes bytes of
+                Left err -> expectationFailure ("parse failed: " ++ err)
+                Right method -> do
+                    methodName method `shouldBe` "Regional LCIA Mini"
+                    methodUnit method `shouldBe` "m2*year"
+                    length (methodFactors method) `shouldBe` 4
+
+        it "preserves location code, value, and flow UUID on each cell" $ do
+            bytes <- BS.readFile "test-data/olca-schema-mini/impact-category-mini.json"
+            case parseOlcaImpactCategoryBytes bytes of
+                Left err -> expectationFailure ("parse failed: " ++ err)
+                Right method -> do
+                    let factors = methodFactors method
+                        landFR =
+                            head
+                                [ f
+                                | f <- factors
+                                , mcfFlowName f == "Occupation, agriculture"
+                                , mcfConsumerLocation f == Just "FR"
+                                ]
+                        landGLO =
+                            head
+                                [ f
+                                | f <- factors
+                                , mcfFlowName f == "Occupation, agriculture"
+                                , mcfConsumerLocation f == Just "GLO"
+                                ]
+                    mcfValue landFR `shouldBe` 22.15
+                    mcfValue landGLO `shouldBe` 10.0
+                    -- The fixture's flow @id round-trips into mcfFlowRef
+                    UUID.toText (mcfFlowRef landFR)
+                        `shouldBe` "0305b169-255d-4041-8f5d-6e095bcb6358"
+
+        it "rejects a non-object top level" $
+            case parseOlcaImpactCategoryBytes "[1,2,3]" of
+                Left _ -> pure ()
+                Right _ -> expectationFailure "expected parse failure on array root"
+
+        it "rejects a wrong @type" $
+            case parseOlcaImpactCategoryBytes "{\"@type\":\"Process\",\"name\":\"x\"}" of
+                Left _ -> pure ()
+                Right _ -> expectationFailure "expected parse failure on @type=Process"
+
+    describe "buildMethodTables on parsed openLCA methods" $ do
+        it "leaves mtRegionalizedCF empty when no flow matched (Nothing in mappings)" $ do
+            -- Without database flows to match against, every CF stays unmapped, so
+            -- the regionalized table is empty (it only indexes successfully-matched
+            -- cells). Documents the contract: regional indexing requires a DB match
+            -- by name/UUID/CAS/synonym first.
+            bytes <- BS.readFile "test-data/olca-schema-mini/impact-category-mini.json"
+            case parseOlcaImpactCategoryBytes bytes of
+                Left err -> expectationFailure ("parse failed: " ++ err)
+                Right method -> do
+                    let mappings = [(cf, Nothing) | cf <- methodFactors method]
+                        tables = buildMethodTables mappings
+                    M.size (mtRegionalizedCF tables) `shouldBe` 0

--- a/test/PluginSpec.hs
+++ b/test/PluginSpec.hs
@@ -28,6 +28,7 @@ testCF =
         , mcfCAS = Just "124-38-9"
         , mcfCompartment = Nothing
         , mcfUnit = "kg"
+        , mcfConsumerLocation = Nothing
         }
 
 spec :: Spec

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -13,6 +13,7 @@ import qualified CrossDBSubstitutionSpec
 import qualified CrossLinkingSpec
 import qualified DatabaseStatusSpec
 import qualified EcoSpold1Spec
+import qualified OlcaSchemaSpec
 import qualified EcoSpold2Spec
 import qualified FlowResolverSpec
 import qualified FuzzySpec
@@ -72,6 +73,7 @@ main = hspec $ do
         describe "Progress Formatting" ProgressSpec.spec
         describe "EcoSpold1 Parser" EcoSpold1Spec.spec
         describe "EcoSpold2 Parser" EcoSpold2Spec.spec
+        describe "openLCA JSON-LD ImpactCategory parser" OlcaSchemaSpec.spec
         describe "MCP Tool Schemas" MCPSchemaSpec.spec
         describe "Search.Normalize" NormalizeSpec.spec
         describe "Search.BM25" BM25Spec.spec

--- a/volca.cabal
+++ b/volca.cabal
@@ -38,6 +38,7 @@ library
                      , SynonymDB.Extract
                      , Method.Types
                      , Method.Parser
+                     , Method.Parser.OlcaSchema
                      , Method.ParserCSV
                      , Method.ParserSimaPro
                      , Method.ParserNW
@@ -96,6 +97,7 @@ library
                      , warp
                      , aeson
                      , aeson-pretty
+                     , scientific
                      , wai
                      , wai-cors
                      , wai-app-static
@@ -188,6 +190,7 @@ test-suite lca-tests
                      , SubstitutionSpec
                      , CrossDBSubstitutionSpec
                      , DatabaseStatusSpec
+                     , OlcaSchemaSpec
   build-depends:       base >=4.14 && <5
                      , volca
                      , hspec


### PR DESCRIPTION
## Summary

Adds end-to-end support for **regionalized LCIA**: characterization factors that depend on the location of the consumer activity. With `h = C_reg · B · A⁻¹ · f`, A/B/f were already location-aware in VoLCA (activities carry locations); only **C_reg** was missing.

* New parser **`Method.Parser.OlcaSchema`** for [openLCA JSON-LD `ImpactCategory`](https://greendelta.github.io/olca-schema/classes/ImpactCategory.html). Flow `@id` → `mcfFlowRef` (deterministic UUID match), `location.code` → `mcfConsumerLocation`.
* New scoring path **`Method.Mapping.computeRegionalizedLCIAScore`** that streams over the biosphere matrix triples, walks the location hierarchy already used by cross-DB linking (`data/geographies.csv` + `isSubregionOf`), then falls back to the universal broadcast. Surfaces an explicit `Left` when a regionalized flow has no CF for the activity location at any level — silent zeros would under-count.
* Auto-dispatch in `API.Routes.computeCategoryResult` — non-regionalized methods stay on the existing inventory path (no regression).
* `ParserSimaPro` and `SimaPro.Parser` now extract the SimaPro \`, <ISO>\` location suffix on both method-export and inventory sides, so regionalized SimaPro methods × DBs stop silently undercharacterizing.

## Test plan

- [x] 709 examples, 0 failures (existing 701 + 8 new in `OlcaSchemaSpec`).
- [x] Smoke test against the openLCA-shaped fixture under `test-data/olca-schema-mini/`: 4 ImpactFactors, flow UUID round-trips into `mcfFlowRef`, location codes (`FR`, `DE`, `GLO`, `ES`) round-trip into `mcfConsumerLocation`.
- [x] Smoke test against the real `Environmental Footprint 3.1 (adapted).CSV` (45 951 regionalized CFs detected vs 0 before).
- [ ] End-to-end golden test against a Python reference implementation on real Agribalyse — follow-up.
- [ ] Migrate the other LCIA call sites (MCP, getContributingFlows) to `computeLCIAScoreAuto` — follow-up; they're untouched and keep working for non-regionalized methods.