### PR TITLE
fix(substitutions): resolve bare consumer in root DB only

### DIFF
--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -588,13 +588,34 @@ data Substitution = Substitution
     }
     deriving (Generic)
 
+{- | Name of the request-level "root" database — the DB extracted from the
+URL path and the implicit target of any bare 'ProcessId' (one without the
+@"dbName::"@ qualifier).
+
+The newtype exists so that the recursive substitution walker cannot
+accidentally confuse the *root* DB (where bare refs are resolved, per the
+'Substitution' docstring) with the *current* DB being visited during the
+descent — they are different concepts and were previously both plain
+'Text', which caused a real bug where bare consumers were retried in
+every dep DB.
+-}
+newtype RootDb = RootDb {unRootDb :: Text}
+    deriving (Eq, Show)
+
+{- | Name of the database currently being visited by the recursive
+substitution walker — distinct from 'RootDb' precisely so that the
+@thisDb@/@rootDb@ argument pair cannot be silently swapped.
+-}
+newtype ThisDb = ThisDb {unThisDb :: Text}
+    deriving (Eq, Show)
+
 {- | Parse a substitution reference into @(targetDB, bare pid)@. A bare
 @"actUUID_prodUUID"@ resolves in the caller-supplied root DB; a qualified
 @"dbName::actUUID_prodUUID"@ resolves in @dbName@. The @::@ separator is
 unambiguous because UUIDs contain no colons.
 -}
-parseSubRef :: Text -> Text -> (Text, Text)
-parseSubRef rootDb raw = case T.breakOn (T.pack "::") raw of
+parseSubRef :: RootDb -> Text -> (Text, Text)
+parseSubRef (RootDb rootDb) raw = case T.breakOn (T.pack "::") raw of
     (pid, rest)
         | T.null rest -> (rootDb, pid)
         | otherwise -> (pid, T.drop 2 rest)

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -1879,7 +1879,7 @@ inventoryWithSubsAndDeps unitCfg depLookup db rootDbName solver pid subs = do
         Left e -> pure (Left e)
         Right () -> do
             let demand = buildDemandVectorFromIndex (dbActivityIndex db) pid
-            res <- goWithSubsAndDeps unitCfg depLookup db rootDbName solver [demand] subs 0
+            res <- goWithSubsAndDeps unitCfg depLookup db rootDbName rootDbName solver [demand] subs 0
             pure $ case res of
                 Left err -> Left err
                 Right (inv : _) -> Right inv
@@ -1954,6 +1954,8 @@ goWithSubsAndDeps ::
     Database ->
     -- | THIS DB's name
     Text ->
+    -- | ROOT DB's name (default for bare consumer/from/to refs)
+    Text ->
     -- | THIS DB's cached solver
     SharedSolver ->
     -- | demand vectors at this level
@@ -1963,9 +1965,9 @@ goWithSubsAndDeps ::
     -- | recursion depth
     Int ->
     IO (Either ServiceError [Inventory])
-goWithSubsAndDeps unitCfg depLookup thisDb thisDbName solver demands allSubs depth = do
+goWithSubsAndDeps unitCfg depLookup thisDb thisDbName rootDbName solver demands allSubs depth = do
     scalings <- SharedSolver.solveMultiWithSharedSolver solver demands
-    eApply <- applySubstitutionsAt depLookup thisDb thisDbName solver scalings allSubs
+    eApply <- applySubstitutionsAt depLookup thisDb thisDbName rootDbName solver scalings allSubs
     case eApply of
         Left e -> pure (Left e)
         Right (scalings', virtualLks) -> propagate scalings' virtualLks
@@ -1982,7 +1984,7 @@ goWithSubsAndDeps unitCfg depLookup thisDb thisDbName solver demands allSubs dep
                     else do
                         depResults <-
                             mapConcurrently
-                                (resolveDepWithSubs unitCfg depLookup perRootDepDemands allSubs depth (length scalings'))
+                                (resolveDepWithSubs unitCfg depLookup rootDbName perRootDepDemands allSubs depth (length scalings'))
                                 allDepDbs
                         pure $ case sequence depResults of
                             Left err -> Left err
@@ -2001,13 +2003,15 @@ recursion. Matches 'SharedSolver.resolveDep' but delegates to
 resolveDepWithSubs ::
     UnitConfig ->
     SharedSolver.DepSolverLookup ->
+    -- | ROOT DB's name (default for bare consumer/from/to refs)
+    Text ->
     [M.Map Text (M.Map (UUID, UUID) (Double, Text))] ->
     [Substitution] ->
     Int ->
     Int ->
     Text ->
     IO (Either ServiceError [Inventory])
-resolveDepWithSubs unitCfg depLookup perRootDepDemands allSubs depth k depDbName = do
+resolveDepWithSubs unitCfg depLookup rootDbName perRootDepDemands allSubs depth k depDbName = do
     depM <- depLookup depDbName
     case depM of
         Nothing ->
@@ -2018,7 +2022,7 @@ resolveDepWithSubs unitCfg depLookup perRootDepDemands allSubs depth k depDbName
              in case depVecsE of
                     Left err -> pure (Left (MatrixError err))
                     Right depDemandVecs ->
-                        goWithSubsAndDeps unitCfg depLookup depDb depDbName depSolver depDemandVecs allSubs (depth + 1)
+                        goWithSubsAndDeps unitCfg depLookup depDb depDbName rootDbName depSolver depDemandVecs allSubs (depth + 1)
 
 {- | Cross-DB substitution resolver (root-only path, used by supply-chain).
 
@@ -2048,7 +2052,7 @@ computeScalingVectorWithSubstitutionsCrossDB depLookup db rootDbName solver pid 
         Nothing -> do
             let demandVec = buildDemandVectorFromIndex (dbActivityIndex db) pid
             originalX <- solveWithSharedSolver solver demandVec
-            res <- applySubstitutionsAt depLookup db rootDbName solver [originalX] subs
+            res <- applySubstitutionsAt depLookup db rootDbName rootDbName solver [originalX] subs
             pure $ case res of
                 Left e -> Left e
                 Right ([x'], links) -> Right (x', links)
@@ -2090,7 +2094,9 @@ applySubstitutionsAt ::
     SharedSolver.DepSolverLookup ->
     -- | THIS DB
     Database ->
-    -- | THIS DB's name (for parseSubRef)
+    -- | THIS DB's name (for sub-resolution against the local DB)
+    Text ->
+    -- | ROOT DB's name (default for bare consumer/from/to refs)
     Text ->
     -- | THIS DB's cached solver
     SharedSolver ->
@@ -2099,7 +2105,7 @@ applySubstitutionsAt ::
     -- | full sub list (filtered to consumer==this)
     [Substitution] ->
     IO (Either ServiceError ([U.Vector Double], [CrossDBLink]))
-applySubstitutionsAt depLookup thisDb thisDbName solver scalings allSubs = do
+applySubstitutionsAt depLookup thisDb thisDbName rootDbName solver scalings allSubs = do
     let localSubs = filter consumerLivesHere allSubs
     case localSubs of
         [] -> pure $ Right (scalings, [])
@@ -2107,8 +2113,13 @@ applySubstitutionsAt depLookup thisDb thisDbName solver scalings allSubs = do
             mFact <- getFactorization solver
             applyAll mFact scalings [] localSubs
   where
+    -- Bare consumer refs default to the root DB (per Substitution docstring),
+    -- not whichever DB the recursive walker happens to be visiting. Without
+    -- this, an unqualified consumer would be retried in every dep DB and
+    -- fail with a misleading "Invalid UUID format" on the first dep where
+    -- the activity does not exist.
     consumerLivesHere sub =
-        let (cDb, _) = parseSubRef thisDbName (subConsumer sub)
+        let (cDb, _) = parseSubRef rootDbName (subConsumer sub)
          in cDb == thisDbName
 
     applyAll _ xs links [] = pure $ Right (xs, links)

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -3,7 +3,7 @@
 
 module Service where
 
-import API.Types (ActivityForAPI (..), ActivityInfo (..), ActivityLinks (..), ActivityMetadata (..), ActivityStats (..), ActivitySummary (..), ClassificationSystem (..), ConsumerResult (..), ConsumersResponse (..), EdgeType (..), ExchangeDetail (..), ExchangeWithUnit (..), ExportNode (..), FlowDetail (..), FlowInfo (..), FlowRole (..), FlowSearchResult (..), FlowSummary (..), GraphEdge (..), GraphExport (..), GraphNode (..), InventoryExport (..), InventoryFlowDetail (..), InventoryMetadata (..), InventoryStatistics (..), NodeType (..), SearchResults (..), Substitution (..), SupplyChainEdge (..), SupplyChainEntry (..), SupplyChainResponse (..), TreeEdge (..), TreeExport (..), TreeMetadata (..), parseSubRef)
+import API.Types (ActivityForAPI (..), ActivityInfo (..), ActivityLinks (..), ActivityMetadata (..), ActivityStats (..), ActivitySummary (..), ClassificationSystem (..), ConsumerResult (..), ConsumersResponse (..), EdgeType (..), ExchangeDetail (..), ExchangeWithUnit (..), ExportNode (..), FlowDetail (..), FlowInfo (..), FlowRole (..), FlowSearchResult (..), FlowSummary (..), GraphEdge (..), GraphExport (..), GraphNode (..), InventoryExport (..), InventoryFlowDetail (..), InventoryMetadata (..), InventoryStatistics (..), NodeType (..), RootDb (..), SearchResults (..), Substitution (..), SupplyChainEdge (..), SupplyChainEntry (..), SupplyChainResponse (..), ThisDb (..), TreeEdge (..), TreeExport (..), TreeMetadata (..), parseSubRef)
 import CLI.Types (DebugMatricesOptions (..))
 import Control.Concurrent.Async (mapConcurrently)
 import Data.Aeson (Value, object, toJSON, (.=))
@@ -1874,12 +1874,13 @@ inventoryWithSubsAndDeps ::
     [Substitution] ->
     IO (Either ServiceError Inventory)
 inventoryWithSubsAndDeps unitCfg depLookup db rootDbName solver pid subs = do
-    eValid <- validateConsumerDbs depLookup db rootDbName subs
+    let rootDb = RootDb rootDbName
+    eValid <- validateConsumerDbs depLookup db rootDb subs
     case eValid of
         Left e -> pure (Left e)
         Right () -> do
             let demand = buildDemandVectorFromIndex (dbActivityIndex db) pid
-            res <- goWithSubsAndDeps unitCfg depLookup db rootDbName rootDbName solver [demand] subs 0
+            res <- goWithSubsAndDeps unitCfg depLookup db (ThisDb rootDbName) rootDb solver [demand] subs 0
             pure $ case res of
                 Left err -> Left err
                 Right (inv : _) -> Right inv
@@ -1894,21 +1895,22 @@ which violates the no-silent-errors invariant.
 validateConsumerDbs ::
     SharedSolver.DepSolverLookup ->
     Database ->
-    Text ->
+    RootDb ->
     [Substitution] ->
     IO (Either ServiceError ())
-validateConsumerDbs depLookup rootDb rootDbName subs = do
-    let externalConsumerDbs =
+validateConsumerDbs depLookup rootDbObj rootDb subs = do
+    let rootDbName = unRootDb rootDb
+        externalConsumerDbs =
             S.delete rootDbName $
                 S.fromList
                     [ cDb
                     | sub <- subs
-                    , let (cDb, _) = parseSubRef rootDbName (subConsumer sub)
+                    , let (cDb, _) = parseSubRef rootDb (subConsumer sub)
                     ]
     if S.null externalConsumerDbs
         then pure (Right ())
         else do
-            reachable <- reachableDepDbs depLookup rootDbName rootDb
+            reachable <- reachableDepDbs depLookup rootDbName rootDbObj
             let unreachable = externalConsumerDbs `S.difference` reachable
             case S.toList unreachable of
                 [] -> pure (Right ())
@@ -1953,9 +1955,9 @@ goWithSubsAndDeps ::
     -- | THIS DB
     Database ->
     -- | THIS DB's name
-    Text ->
+    ThisDb ->
     -- | ROOT DB's name (default for bare consumer/from/to refs)
-    Text ->
+    RootDb ->
     -- | THIS DB's cached solver
     SharedSolver ->
     -- | demand vectors at this level
@@ -1965,9 +1967,9 @@ goWithSubsAndDeps ::
     -- | recursion depth
     Int ->
     IO (Either ServiceError [Inventory])
-goWithSubsAndDeps unitCfg depLookup thisDb thisDbName rootDbName solver demands allSubs depth = do
+goWithSubsAndDeps unitCfg depLookup thisDb thisDbName rootDb solver demands allSubs depth = do
     scalings <- SharedSolver.solveMultiWithSharedSolver solver demands
-    eApply <- applySubstitutionsAt depLookup thisDb thisDbName rootDbName solver scalings allSubs
+    eApply <- applySubstitutionsAt depLookup thisDb thisDbName rootDb solver scalings allSubs
     case eApply of
         Left e -> pure (Left e)
         Right (scalings', virtualLks) -> propagate scalings' virtualLks
@@ -1984,7 +1986,7 @@ goWithSubsAndDeps unitCfg depLookup thisDb thisDbName rootDbName solver demands 
                     else do
                         depResults <-
                             mapConcurrently
-                                (resolveDepWithSubs unitCfg depLookup rootDbName perRootDepDemands allSubs depth (length scalings'))
+                                (resolveDepWithSubs unitCfg depLookup rootDb perRootDepDemands allSubs depth (length scalings'))
                                 allDepDbs
                         pure $ case sequence depResults of
                             Left err -> Left err
@@ -2004,14 +2006,14 @@ resolveDepWithSubs ::
     UnitConfig ->
     SharedSolver.DepSolverLookup ->
     -- | ROOT DB's name (default for bare consumer/from/to refs)
-    Text ->
+    RootDb ->
     [M.Map Text (M.Map (UUID, UUID) (Double, Text))] ->
     [Substitution] ->
     Int ->
     Int ->
     Text ->
     IO (Either ServiceError [Inventory])
-resolveDepWithSubs unitCfg depLookup rootDbName perRootDepDemands allSubs depth k depDbName = do
+resolveDepWithSubs unitCfg depLookup rootDb perRootDepDemands allSubs depth k depDbName = do
     depM <- depLookup depDbName
     case depM of
         Nothing ->
@@ -2022,7 +2024,7 @@ resolveDepWithSubs unitCfg depLookup rootDbName perRootDepDemands allSubs depth 
              in case depVecsE of
                     Left err -> pure (Left (MatrixError err))
                     Right depDemandVecs ->
-                        goWithSubsAndDeps unitCfg depLookup depDb depDbName rootDbName depSolver depDemandVecs allSubs (depth + 1)
+                        goWithSubsAndDeps unitCfg depLookup depDb (ThisDb depDbName) rootDb depSolver depDemandVecs allSubs (depth + 1)
 
 {- | Cross-DB substitution resolver (root-only path, used by supply-chain).
 
@@ -2043,7 +2045,8 @@ computeScalingVectorWithSubstitutionsCrossDB ::
     [Substitution] ->
     IO (Either ServiceError (U.Vector Double, [CrossDBLink]))
 computeScalingVectorWithSubstitutionsCrossDB depLookup db rootDbName solver pid subs = do
-    case firstNonRootConsumer of
+    let rootDb = RootDb rootDbName
+    case firstNonRootConsumer rootDb of
         Just cDb ->
             pure $
                 Left $
@@ -2052,17 +2055,17 @@ computeScalingVectorWithSubstitutionsCrossDB depLookup db rootDbName solver pid 
         Nothing -> do
             let demandVec = buildDemandVectorFromIndex (dbActivityIndex db) pid
             originalX <- solveWithSharedSolver solver demandVec
-            res <- applySubstitutionsAt depLookup db rootDbName rootDbName solver [originalX] subs
+            res <- applySubstitutionsAt depLookup db (ThisDb rootDbName) rootDb solver [originalX] subs
             pure $ case res of
                 Left e -> Left e
                 Right ([x'], links) -> Right (x', links)
                 Right (x' : _, links) -> Right (x', links) -- unreachable: K=1
                 Right ([], _) -> Right (originalX, []) -- unreachable
   where
-    firstNonRootConsumer =
+    firstNonRootConsumer rootDb =
         case [ cDb
              | sub <- subs
-             , let (cDb, _) = parseSubRef rootDbName (subConsumer sub)
+             , let (cDb, _) = parseSubRef rootDb (subConsumer sub)
              , cDb /= rootDbName
              ] of
             (d : _) -> Just d
@@ -2094,10 +2097,10 @@ applySubstitutionsAt ::
     SharedSolver.DepSolverLookup ->
     -- | THIS DB
     Database ->
-    -- | THIS DB's name (for sub-resolution against the local DB)
-    Text ->
-    -- | ROOT DB's name (default for bare consumer/from/to refs)
-    Text ->
+    -- | THIS DB's name (the level the walker currently visits)
+    ThisDb ->
+    -- | ROOT DB (default for bare consumer/from/to refs, per 'Substitution')
+    RootDb ->
     -- | THIS DB's cached solver
     SharedSolver ->
     -- | K scalings at this level
@@ -2105,7 +2108,7 @@ applySubstitutionsAt ::
     -- | full sub list (filtered to consumer==this)
     [Substitution] ->
     IO (Either ServiceError ([U.Vector Double], [CrossDBLink]))
-applySubstitutionsAt depLookup thisDb thisDbName rootDbName solver scalings allSubs = do
+applySubstitutionsAt depLookup thisDb thisDbObj rootDb solver scalings allSubs = do
     let localSubs = filter consumerLivesHere allSubs
     case localSubs of
         [] -> pure $ Right (scalings, [])
@@ -2113,13 +2116,18 @@ applySubstitutionsAt depLookup thisDb thisDbName rootDbName solver scalings allS
             mFact <- getFactorization solver
             applyAll mFact scalings [] localSubs
   where
-    -- Bare consumer refs default to the root DB (per Substitution docstring),
-    -- not whichever DB the recursive walker happens to be visiting. Without
-    -- this, an unqualified consumer would be retried in every dep DB and
-    -- fail with a misleading "Invalid UUID format" on the first dep where
-    -- the activity does not exist.
+    thisDbName = unThisDb thisDbObj
+
+    -- Bare consumer/from/to refs all default to the root DB (per the
+    -- 'Substitution' docstring), not whichever DB the recursive walker
+    -- happens to be visiting. Using 'thisDb' instead would cause a bare
+    -- consumer to be retried in every dep DB and fail with a misleading
+    -- "Invalid UUID format" on the first dep where the activity does
+    -- not exist, and would also misroute bare suppliers in dep-level
+    -- recursion. The 'RootDb' newtype on 'parseSubRef' makes the
+    -- argument-swap unrepresentable.
     consumerLivesHere sub =
-        let (cDb, _) = parseSubRef rootDbName (subConsumer sub)
+        let (cDb, _) = parseSubRef rootDb (subConsumer sub)
          in cDb == thisDbName
 
     applyAll _ xs links [] = pure $ Right (xs, links)
@@ -2130,12 +2138,12 @@ applySubstitutionsAt depLookup thisDb thisDbName rootDbName solver scalings allS
             Right (xs', extraLks) -> applyAll mFact xs' (links ++ extraLks) rest
 
     applySub mFact xs sub = do
-        let (_, cPidText) = parseSubRef thisDbName (subConsumer sub)
+        let (_, cPidText) = parseSubRef rootDb (subConsumer sub)
         case resolveActivityAndProcessId thisDb cPidText of
             Left e -> pure (Left e)
             Right (consumerPid, _) -> do
-                let (fromDb, fromPidText) = parseSubRef thisDbName (subFrom sub)
-                    (toDb, toPidText) = parseSubRef thisDbName (subTo sub)
+                let (fromDb, fromPidText) = parseSubRef rootDb (subFrom sub)
+                    (toDb, toPidText) = parseSubRef rootDb (subTo sub)
                 eFrom <- resolveRef fromDb fromPidText
                 eTo <- resolveRef toDb toPidText
                 case (eFrom, eTo) of

--- a/test/CrossDBSubstitutionSpec.hs
+++ b/test/CrossDBSubstitutionSpec.hs
@@ -10,7 +10,7 @@ database under two names via 'DepSolverLookup'.
 -}
 module CrossDBSubstitutionSpec (spec) where
 
-import API.Types (Substitution (..), parseSubRef)
+import API.Types (RootDb (..), Substitution (..), parseSubRef)
 import qualified Data.Text as T
 import qualified Data.Vector.Unboxed as U
 import Service (
@@ -28,19 +28,19 @@ spec :: Spec
 spec = do
     describe "parseSubRef" $ do
         it "returns (rootDb, pid) for a bare pid" $
-            parseSubRef "root" "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa_bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+            parseSubRef (RootDb "root") "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa_bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
                 `shouldBe` ( "root"
                            , "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa_bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
                            )
 
         it "returns (depDb, pid) for a qualified dbName::pid" $
-            parseSubRef "root" "agb-3-2::aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa_bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+            parseSubRef (RootDb "root") "agb-3-2::aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa_bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
                 `shouldBe` ( "agb-3-2"
                            , "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa_bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
                            )
 
         it "handles empty raw string" $
-            parseSubRef "root" "" `shouldBe` ("root", "")
+            parseSubRef (RootDb "root") "" `shouldBe` ("root", "")
 
     describe "computeScalingVectorWithSubstitutionsCrossDB" $ do
         it "with empty subs returns baseline scaling and no virtual links" $ do

--- a/test/NestedSubstitutionSpec.hs
+++ b/test/NestedSubstitutionSpec.hs
@@ -61,7 +61,7 @@ spec = do
                         , subConsumer = qualifiedPid
                         }
                 noDeps _ = pure Nothing
-            res <- applySubstitutionsAt noDeps db "root" solver [baselineX] [sub]
+            res <- applySubstitutionsAt noDeps db "root" "root" solver [baselineX] [sub]
             case res of
                 Right ([x'], links) -> do
                     links `shouldBe` []
@@ -76,7 +76,7 @@ spec = do
                 demandVec = buildDemandVectorFromIndex (dbActivityIndex db) pid
             baselineX <- solveWithSharedSolver solver demandVec
             let noDeps _ = pure Nothing
-            res <- applySubstitutionsAt noDeps db "root" solver [baselineX] []
+            res <- applySubstitutionsAt noDeps db "root" "root" solver [baselineX] []
             case res of
                 Right (xs, links) -> do
                     links `shouldBe` []
@@ -100,10 +100,37 @@ spec = do
                         , subConsumer = qualifiedToRoot
                         }
                 noDeps _ = pure Nothing
-            res <- applySubstitutionsAt noDeps db "dep" solver [baselineX, baselineX, baselineX] [sub]
+            res <- applySubstitutionsAt noDeps db "dep" "root" solver [baselineX, baselineX, baselineX] [sub]
             case res of
                 Right (xs, _) -> length xs `shouldBe` 3
                 Left e -> expectationFailure ("K>1 filter failed: " <> show e)
+
+        it "skips bare consumer subs when walker is in a dep DB" $ do
+            -- Regression gate: bare 'subConsumer' means root DB only (per the
+            -- Substitution docstring). Before this fix, the per-level filter
+            -- used 'thisDbName' as the parseSubRef default — so bare consumers
+            -- were treated as living in EVERY DB the walker visited, and the
+            -- subsequent resolve in a dep DB threw "Invalid UUID format".
+            db <- loadSampleDatabase "SAMPLE.min3"
+            solver <- mkSolver db "dep"
+            let pid = 0
+                demandVec = buildDemandVectorFromIndex (dbActivityIndex db) pid
+            baselineX <- solveWithSharedSolver solver demandVec
+            let bareRootPid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa_bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+                sub =
+                    Substitution
+                        { subFrom = bareRootPid
+                        , subTo = bareRootPid
+                        , subConsumer = bareRootPid
+                        }
+                noDeps _ = pure Nothing
+            res <- applySubstitutionsAt noDeps db "dep" "root" solver [baselineX] [sub]
+            case res of
+                Right ([x'], links) -> do
+                    links `shouldBe` []
+                    U.toList x' `shouldBe` U.toList baselineX
+                Right other -> expectationFailure ("unexpected shape: " <> show other)
+                Left e -> expectationFailure ("bare consumer must be filtered out at dep level, got: " <> show e)
 
     describe "inventoryWithSubsAndDeps (Phase A recursion)" $ do
         it "with empty subs matches the baseline cross-DB inventory path" $ do

--- a/test/NestedSubstitutionSpec.hs
+++ b/test/NestedSubstitutionSpec.hs
@@ -11,7 +11,7 @@ rely on the shared classifier body already covered by
 -}
 module NestedSubstitutionSpec (spec) where
 
-import API.Types (Substitution (..), SupplyChainEntry (..), SupplyChainResponse (..))
+import API.Types (RootDb (..), Substitution (..), SupplyChainEntry (..), SupplyChainResponse (..), ThisDb (..))
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import qualified Data.Vector.Unboxed as U
@@ -61,7 +61,7 @@ spec = do
                         , subConsumer = qualifiedPid
                         }
                 noDeps _ = pure Nothing
-            res <- applySubstitutionsAt noDeps db "root" "root" solver [baselineX] [sub]
+            res <- applySubstitutionsAt noDeps db (ThisDb "root") (RootDb "root") solver [baselineX] [sub]
             case res of
                 Right ([x'], links) -> do
                     links `shouldBe` []
@@ -76,7 +76,7 @@ spec = do
                 demandVec = buildDemandVectorFromIndex (dbActivityIndex db) pid
             baselineX <- solveWithSharedSolver solver demandVec
             let noDeps _ = pure Nothing
-            res <- applySubstitutionsAt noDeps db "root" "root" solver [baselineX] []
+            res <- applySubstitutionsAt noDeps db (ThisDb "root") (RootDb "root") solver [baselineX] []
             case res of
                 Right (xs, links) -> do
                     links `shouldBe` []
@@ -100,7 +100,7 @@ spec = do
                         , subConsumer = qualifiedToRoot
                         }
                 noDeps _ = pure Nothing
-            res <- applySubstitutionsAt noDeps db "dep" "root" solver [baselineX, baselineX, baselineX] [sub]
+            res <- applySubstitutionsAt noDeps db (ThisDb "dep") (RootDb "root") solver [baselineX, baselineX, baselineX] [sub]
             case res of
                 Right (xs, _) -> length xs `shouldBe` 3
                 Left e -> expectationFailure ("K>1 filter failed: " <> show e)
@@ -124,7 +124,7 @@ spec = do
                         , subConsumer = bareRootPid
                         }
                 noDeps _ = pure Nothing
-            res <- applySubstitutionsAt noDeps db "dep" "root" solver [baselineX] [sub]
+            res <- applySubstitutionsAt noDeps db (ThisDb "dep") (RootDb "root") solver [baselineX] [sub]
             case res of
                 Right ([x'], links) -> do
                     links `shouldBe` []


### PR DESCRIPTION
## Summary

The per-level filter in `applySubstitutionsAt` used `parseSubRef thisDbName`, so a bare `subConsumer` was classified as "lives here" at every recursion level. The walker then called `resolveActivityAndProcessId` against each loaded dep DB and threw `Invalid UUID format` on the first DB that did not contain the activity — trapping legitimate root-DB substitutions (e.g. an Agribalyse consumer when BAFU is loaded as a dep).

Per the `Substitution` docstring, bare consumer means root DB only. This PR threads `rootDbName` through `goWithSubsAndDeps` + `resolveDepWithSubs` into `applySubstitutionsAt` and uses it in `parseSubRef` for `consumerLivesHere`.

## Validation

- Existing substitution suite: 20/20 pass (`SubstitutionSpec`, `NestedSubstitutionSpec`, `CrossDBSubstitutionSpec`).
- New regression test in `NestedSubstitutionSpec.hs`: a bare-consumer sub is filtered out when the walker visits a dep DB.
- End-to-end on a real product (Lobster 1 kg, Agribalyse 3.2 + BAFU loaded) confirms the substitution now applies and yields plausible deltas (e.g. -5.35 % on Water use for the FR electricity swap).

Before this fix, the same end-to-end call returned `HTTP 400 Invalid UUID format` on every category.

## Test plan

- [ ] `cabal test --test-options='--match "ubstitution"'` — all green
- [ ] POST `/api/v1/db/<root>/activity/<pid>/impacts/.../...` with a `substitutions` body whose `consumer` is bare (root-DB) and whose `to` is qualified to a dep DB returns 200, not 400