### PR TITLE
perf(lcia): batch multi-method scoring via stacked-broadcast matvec (~22× on PEF)

### DIFF
--- a/bench/MultiMethodBench.hs
+++ b/bench/MultiMethodBench.hs
@@ -1,0 +1,277 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Microbenchmark for the LCIA scoring fast paths.
+
+Three configurations, all on the same synthetic fixture (10K biosphere flows,
+~5K CF matches per method, 27 PEF-sized methods, 500-flow sparse inventory):
+
+  * @cascade-mono@: per-method scoring with the legacy 3-level CF cascade
+    + per-flow @convertUnit@ (mtBroadcast empty). Matches pre-Phase-1 behaviour.
+  * @broadcast-mono@: per-method scoring with mtBroadcast filled. Phase 1.
+  * @broadcast-fanout@: simulates the per-method HTTP loop — score the same
+    inventory 27 times in sequence, each call hitting the broadcast Map.
+  * @set-batched@: 'computeLCIAScoreSetFromTables' on the same set, single
+    inventory walk + dense matvec. Phase 2.
+
+Speedup ratios:
+  * Phase 1: cascade-mono / broadcast-mono.
+  * Phase 2: broadcast-fanout / set-batched.
+-}
+module Main (main) where
+
+import Criterion.Main
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
+import qualified Data.Vector.Unboxed as U
+import System.Random (mkStdGen, randoms)
+
+import Matrix (Inventory)
+import Method.Mapping
+import Method.Types (Method (..), MethodCF (..))
+import qualified Method.Types as MT
+import Types (Database, Flow (..), FlowType (..), Unit (..))
+import qualified UnitConversion
+
+-- ---------------------------------------------------------------------------
+-- Fixture sizes (PEF-shaped)
+-- ---------------------------------------------------------------------------
+
+nFlowsTotal :: Int
+nFlowsTotal = 10_000 -- biosphere flows in the merged DB
+
+nCFsPerMethod :: Int
+nCFsPerMethod = 5_000 -- CF matches per method (half of flows)
+
+nMethods :: Int
+nMethods = 27 -- PEF-shaped
+
+nInvNonzero :: Int
+nInvNonzero = 500 -- non-zero entries in the supply-vector inventory
+
+-- ---------------------------------------------------------------------------
+-- Fixture builders
+-- ---------------------------------------------------------------------------
+
+mkUuid :: Int -> UUID
+mkUuid n = UUID.fromWords (fromIntegral n) 0xBEEF 0xCAFE 0xDEAD
+
+mkUnit :: UUID -> Text -> Unit
+mkUnit uid name =
+    Unit
+        { unitId = uid
+        , unitName = name
+        , unitSymbol = name
+        , unitComment = ""
+        }
+
+mkFlow :: UUID -> UUID -> Int -> Flow
+mkFlow fid uid i =
+    Flow
+        { flowId = fid
+        , flowName = T.pack ("flow-" <> show i)
+        , flowCategory = "air"
+        , flowSubcompartment = Nothing
+        , flowUnitId = uid
+        , flowType = Biosphere
+        , flowSynonyms = M.empty
+        , flowCAS = Nothing
+        , flowSubstanceId = Nothing
+        }
+
+mkCF :: UUID -> Double -> MethodCF
+mkCF flowRef val =
+    MethodCF
+        { mcfFlowRef = flowRef
+        , mcfFlowName = "stub"
+        , mcfDirection = MT.Output
+        , mcfValue = val
+        , mcfCompartment = Nothing
+        , mcfCAS = Nothing
+        , mcfUnit = "kg"
+        , mcfConsumerLocation = Nothing
+        }
+
+-- | A CF with a different unit than the matched flow, forcing the legacy
+-- 'convertUnit' branch to run on every scored flow. Phase 1's win is most
+-- visible against this kind of CF (the broadcast path absorbs the
+-- conversion factor at build time).
+mkCFGramme :: UUID -> Double -> MethodCF
+mkCFGramme flowRef val =
+    (mkCF flowRef val){mcfUnit = "g"}
+
+-- | Fresh UnitConfig that knows both kg and g, so the convertUnit calls in
+-- the legacy fixture actually succeed (default config only knows kg).
+unitConfigKgG :: UnitConversion.UnitConfig
+unitConfigKgG =
+    UnitConversion.UnitConfig
+        { UnitConversion.ucDimensionOrder = []
+        , UnitConversion.ucUnits =
+            M.fromList
+                [ ("kg", UnitConversion.UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
+                , ("g", UnitConversion.UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0e-3)
+                ]
+        , UnitConversion.ucOriginalKeys = M.fromList [("kg", "kg"), ("g", "g")]
+        }
+
+mkMethod :: Int -> [MethodCF] -> Method
+mkMethod n factors =
+    Method
+        { methodId = mkUuid (1_000_000 + n)
+        , methodName = T.pack ("M-" <> show n)
+        , methodDescription = Nothing
+        , methodUnit = "kg eq"
+        , methodCategory = T.pack ("Cat-" <> show n)
+        , methodMethodology = Nothing
+        , methodFactors = factors
+        }
+
+-- The non-regio scoring path never inspects the Database argument.
+unusedDatabase :: Database
+unusedDatabase = error "Database not used in non-regio bench"
+
+-- ---------------------------------------------------------------------------
+-- Build the fixture once
+-- ---------------------------------------------------------------------------
+
+data Fixture = Fixture
+    { fxFlowDB :: !(M.Map UUID Flow)
+    , fxUnitDB :: !(M.Map UUID Unit)
+    , fxUnitCfg :: !UnitConversion.UnitConfig
+    , fxInventory :: !Inventory
+    , fxMethods :: ![Method]
+    , fxRawTables :: ![MethodTables] -- mtBroadcast empty (legacy cascade)
+    , fxFilledTables :: ![MethodTables] -- mtBroadcast filled (Phase 1)
+    , fxSetTables :: !MethodSetTables -- stacked broadcast (Phase 2)
+    }
+
+buildFixture :: (UUID -> Double -> MethodCF) -> UnitConversion.UnitConfig -> Fixture
+buildFixture mkCfFn unitCfg =
+    let kgUid = mkUuid 99_999
+        unitDB = M.singleton kgUid (mkUnit kgUid "kg")
+        flows =
+            [ (fid, mkFlow fid kgUid i)
+            | i <- [0 .. nFlowsTotal - 1]
+            , let fid = mkUuid i
+            ]
+        flowDB = M.fromList flows
+
+        -- Pseudo-random CF values, deterministic per-method seed.
+        cfValuesFor :: Int -> [Double]
+        cfValuesFor seed =
+            -- Map [0,1) doubles to a [0.01, 100) log-ish range; keep them non-zero.
+            map (\r -> 0.01 + r * 99.99) (take nCFsPerMethod (randoms (mkStdGen seed) :: [Double]))
+
+        -- Each method matches the first nCFsPerMethod flows by UUID.
+        mappingsFor seed =
+            [ (mkCfFn fid v, Just (snd (flows !! i), ByUUID))
+            | (i, v) <- zip [0 ..] (cfValuesFor seed)
+            , let fid = mkUuid i
+            ]
+
+        methods = [mkMethod m [] | m <- [1 .. nMethods]] -- factors don't matter, mappings drive build
+        rawTables = [buildMethodTables (mappingsFor s) | s <- [1 .. nMethods]]
+        filledTables = map (fillBroadcastVector unitCfg unitDB flowDB) rawTables
+        setTables = buildMethodSetTables (zip methods filledTables)
+
+        -- Sparse inventory: pick 500 flows out of 10_000 (one per 20).
+        inventory =
+            M.fromList
+                [ (mkUuid (i * (nFlowsTotal `div` nInvNonzero)), 1.0 + fromIntegral i * 0.1)
+                | i <- [0 .. nInvNonzero - 1]
+                ]
+     in Fixture
+            { fxFlowDB = flowDB
+            , fxUnitDB = unitDB
+            , fxUnitCfg = unitCfg
+            , fxInventory = inventory
+            , fxMethods = methods
+            , fxRawTables = rawTables
+            , fxFilledTables = filledTables
+            , fxSetTables = setTables
+            }
+
+-- ---------------------------------------------------------------------------
+-- Bench groups
+-- ---------------------------------------------------------------------------
+
+-- | Score one inventory against ONE method (the 1st in the list), legacy cascade.
+benchMonoCascade :: Fixture -> Double
+benchMonoCascade fx =
+    computeLCIAScoreFromTables
+        (fxUnitCfg fx)
+        (fxUnitDB fx)
+        (fxFlowDB fx)
+        (fxInventory fx)
+        (head (fxRawTables fx))
+
+-- | Score one inventory against ONE method, broadcast filled (Phase 1).
+benchMonoBroadcast :: Fixture -> Double
+benchMonoBroadcast fx =
+    computeLCIAScoreFromTables
+        (fxUnitCfg fx)
+        (fxUnitDB fx)
+        (fxFlowDB fx)
+        (fxInventory fx)
+        (head (fxFilledTables fx))
+
+-- | Score the same inventory once per method, sequential — what the HTTP route
+-- does with mapConcurrently sans the parallelism overhead.
+benchMonoFanout :: Fixture -> [Double]
+benchMonoFanout fx =
+    [ computeLCIAScoreFromTables
+        (fxUnitCfg fx)
+        (fxUnitDB fx)
+        (fxFlowDB fx)
+        (fxInventory fx)
+        t
+    | t <- fxFilledTables fx
+    ]
+
+-- | Score all methods at once via stacked-broadcast matvec (Phase 2).
+benchSetBatched :: Fixture -> [(UUID, Either Text Double)]
+benchSetBatched fx =
+    computeLCIAScoreSetFromTables
+        (fxUnitCfg fx)
+        (fxUnitDB fx)
+        (fxFlowDB fx)
+        unusedDatabase
+        U.empty
+        (fxInventory fx)
+        M.empty
+        (fxSetTables fx)
+
+main :: IO ()
+main = do
+    -- Same-units fixture: flow is "kg", CF is "kg" → legacy short-circuits
+    -- the convertUnit call. Phase 1's win is small here; Phase 2 wins big.
+    let fxSameUnit = buildFixture mkCF UnitConversion.defaultUnitConfig
+    -- Cross-units fixture: flow is "kg", CF is "g" → legacy runs convertUnit
+    -- per scored flow. This is where Phase 1's pre-multiplication shines.
+    let fxXUnit = buildFixture mkCFGramme unitConfigKgG
+    fxSameUnit `seq` fxFilledTables fxSameUnit `seq` fxSetTables fxSameUnit `seq` pure ()
+    fxXUnit `seq` fxFilledTables fxXUnit `seq` fxSetTables fxXUnit `seq` pure ()
+    defaultMain
+        [ bgroup
+            "single-method (same units, legacy short-circuits)"
+            [ bench "cascade (legacy)" $ nf benchMonoCascade fxSameUnit
+            , bench "broadcast (Phase 1)" $ nf benchMonoBroadcast fxSameUnit
+            ]
+        , bgroup
+            "single-method (cross units, legacy must convert)"
+            [ bench "cascade (legacy)" $ nf benchMonoCascade fxXUnit
+            , bench "broadcast (Phase 1)" $ nf benchMonoBroadcast fxXUnit
+            ]
+        , bgroup
+            ("multi-method " <> show nMethods <> " (same units)")
+            [ bench "fanout broadcast (per-method loop)" $ nf benchMonoFanout fxSameUnit
+            , bench "set batched (Phase 2 matvec)" $ nf benchSetBatched fxSameUnit
+            ]
+        , bgroup
+            ("multi-method " <> show nMethods <> " (cross units)")
+            [ bench "fanout broadcast (per-method loop)" $ nf benchMonoFanout fxXUnit
+            , bench "set batched (Phase 2 matvec)" $ nf benchSetBatched fxXUnit
+            ]
+        ]

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -862,17 +862,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                                 <> T.unpack name
                                 <> "': "
                                 <> intercalate ", " [T.unpack k <> "=" <> showFFloat (Just 6) v "" | (k, v) <- M.toList scores]
-                return
-                    LCIABatchResult
-                        { lbrResults = results
-                        , lbrSingleScore = Nothing
-                        , lbrSingleScoreUnit = Nothing
-                        , lbrNormWeightSetName = nwName <$> mNW
-                        , lbrAvailableNWsets = map nwName nwSets
-                        , lbrScoringResults = scoringResults
-                        , lbrScoringUnits = M.fromList [(ssName ss, ssUnit ss) | ss <- mcScoringSets collection]
-                        , lbrScoringIndicators = scoringIndicators
-                        }
+                return (mkLCIABatchResult results mNW nwSets scoringResults (mcScoringSets collection) scoringIndicators)
 
     -- POST: Batch LCIA with substitutions
     postActivityLCIABatch :: Text -> Text -> Text -> SubstitutionRequest -> Handler LCIABatchResult
@@ -909,17 +899,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     [(lrCategory r, lrScore r) | r <- rawResults]
         (scoringResults, scoringIndicators) <-
             liftIO $ computeAllScoringSets scoringSets rawScoreMap
-        return
-            LCIABatchResult
-                { lbrResults = results
-                , lbrSingleScore = Nothing
-                , lbrSingleScoreUnit = Nothing
-                , lbrNormWeightSetName = nwName <$> mNW
-                , lbrAvailableNWsets = map nwName nwSets
-                , lbrScoringResults = scoringResults
-                , lbrScoringUnits = M.fromList [(ssName ss, ssUnit ss) | ss <- scoringSets]
-                , lbrScoringIndicators = scoringIndicators
-                }
+        return (mkLCIABatchResult results mNW nwSets scoringResults scoringSets scoringIndicators)
 
     -- POST: Inventory with substitutions
     postActivityInventory :: Text -> Text -> SubstitutionRequest -> Handler InventoryExport
@@ -1715,6 +1695,29 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                 , birInvalid = invalid
                 }
 
+    -- Build an LCIABatchResult from the post-characterization parts.
+    -- The lbrScoringUnits map is derived from the same [ScoringSet] used to
+    -- evaluate the scoring results; pass it in directly.
+    mkLCIABatchResult ::
+        [LCIAResult] ->
+        Maybe NormWeightSet ->
+        [NormWeightSet] ->
+        M.Map Text (M.Map Text Double) ->
+        [ScoringSet] ->
+        M.Map Text (M.Map Text ScoringIndicator) ->
+        LCIABatchResult
+    mkLCIABatchResult results mNW nwSets scoringResults scoringSets scoringIndicators =
+        LCIABatchResult
+            { lbrResults = results
+            , lbrSingleScore = Nothing
+            , lbrSingleScoreUnit = Nothing
+            , lbrNormWeightSetName = nwName <$> mNW
+            , lbrAvailableNWsets = map nwName nwSets
+            , lbrScoringResults = scoringResults
+            , lbrScoringUnits = M.fromList [(ssName ss, ssUnit ss) | ss <- scoringSets]
+            , lbrScoringIndicators = scoringIndicators
+            }
+
     -- Shared post-inventory pipeline: characterize, enrich with NW, compute scoring sets.
     -- Pure IO on its inputs; callers own logging and inventory computation.
     buildLCIABatchResult :: Text -> Database -> SharedSolver -> ProcessId -> Activity -> MethodCollection -> Inventory -> IO LCIABatchResult
@@ -1740,17 +1743,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
             rawScoreMap = M.fromList [(lrCategory r, lrScore r) | r <- rawResults]
         (scoringResults, scoringIndicators) <-
             computeAllScoringSets (mcScoringSets collection) rawScoreMap
-        pure
-            LCIABatchResult
-                { lbrResults = results
-                , lbrSingleScore = Nothing
-                , lbrSingleScoreUnit = Nothing
-                , lbrNormWeightSetName = nwName <$> mNW
-                , lbrAvailableNWsets = map nwName nwSets
-                , lbrScoringResults = scoringResults
-                , lbrScoringUnits = M.fromList [(ssName ss, ssUnit ss) | ss <- mcScoringSets collection]
-                , lbrScoringIndicators = scoringIndicators
-                }
+        pure (mkLCIABatchResult results mNW nwSets scoringResults (mcScoringSets collection) scoringIndicators)
 
 {- | Evaluate every scoring set against the raw impact score map.
 Returns (setName → scoreName → value, setName → varName → ScoringIndicator).

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -729,18 +729,12 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
 
     -- Activity LCIA endpoint (single method within a collection)
     getActivityLCIA :: Text -> Text -> Text -> Text -> Maybe Int -> Handler LCIAResult
-    getActivityLCIA dbName processIdText _collectionName methodIdText topFlowsParam = do
-        (db, sharedSolver) <- requireDatabaseByName dbManager dbName
-        method <- loadMethodByUUID methodIdText
-        case Service.resolveActivityAndProcessId db processIdText of
-            Left (Service.ActivityNotFound _) -> throwError err404{errBody = "Activity not found"}
-            Left (Service.InvalidProcessId _) -> throwError err400{errBody = "Invalid ProcessId format"}
-            Left err -> throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ T.pack $ show err}
-            Right (actProcessId, activity) -> do
-                inventory <- inventoryWithDeps dbManager dbName db sharedSolver actProcessId
-                result <- liftIO $ computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver actProcessId) activity (fromMaybe 5 topFlowsParam) inventory Nothing method
-                liftIO $ logLCIAResult result method
-                return result
+    getActivityLCIA dbName processIdText _collectionName methodIdText topFlowsParam =
+        withActivityAndMethod dbName processIdText methodIdText $ \db sharedSolver actProcessId activity method -> do
+            inventory <- inventoryWithDeps dbManager dbName db sharedSolver actProcessId
+            result <- liftIO $ computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver actProcessId) activity (fromMaybe 5 topFlowsParam) inventory Nothing method
+            liftIO $ logLCIAResult result method
+            return result
 
     -- POST: LCIA with substitutions
     postActivityLCIA :: Text -> Text -> Text -> Text -> SubstitutionRequest -> Handler LCIAResult
@@ -1135,94 +1129,82 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
 
     -- Contributing flows: top elementary flows by LCIA contribution for a specific method
     getContributingFlows :: Text -> Text -> Text -> Text -> Maybe Int -> Handler ContributingFlowsResult
-    getContributingFlows dbName processIdText _collectionName methodIdText limitParam = do
-        (db, sharedSolver) <- requireDatabaseByName dbManager dbName
-        method <- loadMethodByUUID methodIdText
-        case Service.resolveActivityAndProcessId db processIdText of
-            Left (Service.ActivityNotFound _) -> throwError err404{errBody = "Activity not found"}
-            Left (Service.InvalidProcessId _) -> throwError err400{errBody = "Invalid ProcessId format"}
-            Left err -> throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ T.pack $ show err}
-            Right (actProcessId, _) -> do
-                let lim = fromMaybe 20 limitParam
-                unitCfg <- liftIO $ getMergedUnitConfig dbManager
-                (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
-                inventory <- inventoryWithDeps dbManager dbName db sharedSolver actProcessId
-                tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName db method
-                let score = computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables
-                    (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
-                    contribs = sortOn (\(_, _, c) -> negate (abs c)) rawContribs
-                    topFlows =
-                        [ FlowContributionEntry
-                            { fcoFlowName = flowName f
-                            , fcoContribution = c
-                            , fcoSharePct = if score /= 0 then c / score * 100 else 0
-                            , fcoFlowId = UUID.toText (flowId f)
-                            , fcoCategory = flowCategory f
-                            , fcoCompartment = flowSubcompartment f
-                            , fcoCfValue = cfVal
-                            }
-                        | (f, cfVal, c) <- take lim contribs
-                        ]
-                liftIO $
-                    unless (null unknownUuids) $
-                        reportProgress Warning $
-                            "[contributing-flows "
-                                <> T.unpack (methodName method)
-                                <> "] "
-                                <> show (length unknownUuids)
-                                <> " inventory flow UUID(s) absent from merged FlowDB. Samples: "
-                                <> show (take 3 unknownUuids)
-                return
-                    ContributingFlowsResult
-                        { cfrMethod = methodName method
-                        , cfrUnit = methodUnit method
-                        , cfrTotalScore = score
-                        , cfrTopFlows = topFlows
+    getContributingFlows dbName processIdText _collectionName methodIdText limitParam =
+        withActivityAndMethod dbName processIdText methodIdText $ \db sharedSolver actProcessId _ method -> do
+            let lim = fromMaybe 20 limitParam
+            unitCfg <- liftIO $ getMergedUnitConfig dbManager
+            (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
+            inventory <- inventoryWithDeps dbManager dbName db sharedSolver actProcessId
+            tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName db method
+            let score = computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables
+                (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
+                contribs = sortOn (\(_, _, c) -> negate (abs c)) rawContribs
+                topFlows =
+                    [ FlowContributionEntry
+                        { fcoFlowName = flowName f
+                        , fcoContribution = c
+                        , fcoSharePct = if score /= 0 then c / score * 100 else 0
+                        , fcoFlowId = UUID.toText (flowId f)
+                        , fcoCategory = flowCategory f
+                        , fcoCompartment = flowSubcompartment f
+                        , fcoCfValue = cfVal
                         }
+                    | (f, cfVal, c) <- take lim contribs
+                    ]
+            liftIO $
+                unless (null unknownUuids) $
+                    reportProgress Warning $
+                        "[contributing-flows "
+                            <> T.unpack (methodName method)
+                            <> "] "
+                            <> show (length unknownUuids)
+                            <> " inventory flow UUID(s) absent from merged FlowDB. Samples: "
+                            <> show (take 3 unknownUuids)
+            return
+                ContributingFlowsResult
+                    { cfrMethod = methodName method
+                    , cfrUnit = methodUnit method
+                    , cfrTotalScore = score
+                    , cfrTopFlows = topFlows
+                    }
 
     -- Contributing activities: top upstream activities by LCIA contribution for a specific method
     getContributingActivities :: Text -> Text -> Text -> Text -> Maybe Int -> Handler ContributingActivitiesResult
-    getContributingActivities dbName processIdText _collectionName methodIdText limitParam = do
-        (db, sharedSolver) <- requireDatabaseByName dbManager dbName
-        method <- loadMethodByUUID methodIdText
-        case Service.resolveActivityAndProcessId db processIdText of
-            Left (Service.ActivityNotFound _) -> throwError err404{errBody = "Activity not found"}
-            Left (Service.InvalidProcessId _) -> throwError err400{errBody = "Invalid ProcessId format"}
-            Left err -> throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ T.pack $ show err}
-            Right (actProcessId, _) -> do
-                let lim = fromMaybe 10 limitParam
-                requireFullyLinked dbName db
-                unitCfg <- liftIO $ getMergedUnitConfig dbManager
-                (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
-                tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName db method
-                -- Skip separate inventory compute: contributions sum equals the
-                -- score (same B·scaling·CF sum, just grouped per activity).
-                eContribs <-
-                    liftIO $
-                        SharedSolver.crossDBProcessContributions
-                            unitCfg
-                            mUnits
-                            mFlows
-                            (DM.mkDepSolverLookup dbManager)
-                            db
-                            dbName
-                            sharedSolver
-                            actProcessId
-                            tables
-                case eContribs of
-                    Left err -> throwError err422{errBody = BSL.fromStrict $ T.encodeUtf8 err}
-                    Right contributions -> do
-                        let score = sum (M.elems contributions)
-                            sorted = sortOn (\(_, c) -> negate (abs c)) (M.toList contributions)
-                            top = take lim sorted
-                        rows <- liftIO $ mapM (mkCrossDBContrib dbManager dbName mFlows mUnits score) top
-                        return
-                            ContributingActivitiesResult
-                                { carMethod = methodName method
-                                , carUnit = methodUnit method
-                                , carTotalScore = score
-                                , carActivities = rows
-                                }
+    getContributingActivities dbName processIdText _collectionName methodIdText limitParam =
+        withActivityAndMethod dbName processIdText methodIdText $ \db sharedSolver actProcessId _ method -> do
+            let lim = fromMaybe 10 limitParam
+            requireFullyLinked dbName db
+            unitCfg <- liftIO $ getMergedUnitConfig dbManager
+            (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
+            tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName db method
+            -- Skip separate inventory compute: contributions sum equals the
+            -- score (same B·scaling·CF sum, just grouped per activity).
+            eContribs <-
+                liftIO $
+                    SharedSolver.crossDBProcessContributions
+                        unitCfg
+                        mUnits
+                        mFlows
+                        (DM.mkDepSolverLookup dbManager)
+                        db
+                        dbName
+                        sharedSolver
+                        actProcessId
+                        tables
+            case eContribs of
+                Left err -> throwError err422{errBody = BSL.fromStrict $ T.encodeUtf8 err}
+                Right contributions -> do
+                    let score = sum (M.elems contributions)
+                        sorted = sortOn (\(_, c) -> negate (abs c)) (M.toList contributions)
+                        top = take lim sorted
+                    rows <- liftIO $ mapM (mkCrossDBContrib dbManager dbName mFlows mUnits score) top
+                    return
+                        ContributingActivitiesResult
+                            { carMethod = methodName method
+                            , carUnit = methodUnit method
+                            , carTotalScore = score
+                            , carActivities = rows
+                            }
 
     -- Score every method in a set against one inventory in a single batched
     -- pass. For fully non-regionalized sets (PEF) this is a stacked-broadcast
@@ -1551,6 +1533,23 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                 case filter (\m -> methodId m == uuid) allMethods of
                     (m : _) -> return m
                     [] -> throwError err404{errBody = "Method not found"}
+
+    -- Resolve (database, shared solver, ProcessId, Activity, Method) from URL path params
+    -- and dispatch to the continuation. Maps the three Service errors to standard HTTP codes.
+    withActivityAndMethod ::
+        Text ->
+        Text ->
+        Text ->
+        (Database -> SharedSolver -> ProcessId -> Activity -> Method -> Handler a) ->
+        Handler a
+    withActivityAndMethod dbName processIdText methodIdText k = do
+        (db, sharedSolver) <- requireDatabaseByName dbManager dbName
+        method <- loadMethodByUUID methodIdText
+        case Service.resolveActivityAndProcessId db processIdText of
+            Left (Service.ActivityNotFound _) -> throwError err404{errBody = "Activity not found"}
+            Left (Service.InvalidProcessId _) -> throwError err400{errBody = "Invalid ProcessId format"}
+            Left err -> throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ T.pack $ show err}
+            Right (actProcessId, activity) -> k db sharedSolver actProcessId activity method
 
     -- Method collection handlers
     getMethodCollections :: Handler MethodCollectionListResponse

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -36,7 +36,7 @@ import qualified Expr
 import GHC.Generics
 import qualified GHC.Stats
 import Matrix (Inventory, Vector, applyBiosphereMatrix)
-import Method.Mapping (MappingStats (..), MatchStrategy (..), MethodTables (..), computeLCIAScoreAuto, computeLCIAScoreFromTables, computeMappingStats, inventoryContributions)
+import Method.Mapping (MappingStats (..), MatchStrategy (..), MethodTables (..), computeLCIAScoreAuto, computeLCIAScoreFromTables, computeLCIAScoreSetFromTables, computeMappingStats, inventoryContributions)
 import Method.Types (DamageCategory (..), FlowDirection (..), Method (..), MethodCF (..), MethodCollection (..), NormWeightSet (..), ScoringEvaluation (..), ScoringSet (..), computeFormulaScores)
 import Numeric (showFFloat)
 import Plugin.Types (AnalyzeContext (..), AnalyzeHandle (..), PluginRegistry (..))
@@ -738,7 +738,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
             Left err -> throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ T.pack $ show err}
             Right (actProcessId, activity) -> do
                 inventory <- inventoryWithDeps dbManager dbName db sharedSolver actProcessId
-                result <- liftIO $ computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver actProcessId) activity (fromMaybe 5 topFlowsParam) inventory method
+                result <- liftIO $ computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver actProcessId) activity (fromMaybe 5 topFlowsParam) inventory Nothing method
                 liftIO $ logLCIAResult result method
                 return result
 
@@ -761,7 +761,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     processId
                     (srSubstitutions subReq)
         inventory <- either throwServiceError pure eInv
-        liftIO $ computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver processId) activity 5 inventory method
+        liftIO $ computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver processId) activity 5 inventory Nothing method
 
     -- POST: sensitivity sweep (parallel rank-1 perturbations of A_ij)
     postActivitySensitivity :: Text -> Text -> Text -> Text -> SensitivityRequest -> Handler SensitivityResponse
@@ -773,7 +773,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
         eRes <- liftIO $ Service.computeSensitivities db sharedSolver processId (srPerturbations senReq)
         (baselineX, perResults) <- either throwServiceError pure eRes
         let baselineInv = applyBiosphereMatrix db baselineX
-        baselineLcia <- liftIO $ computeCategoryResult dbName db (pure baselineX) activity 5 baselineInv method
+        baselineLcia <- liftIO $ computeCategoryResult dbName db (pure baselineX) activity 5 baselineInv Nothing method
         perturbed <- liftIO $ mapConcurrently (buildEntry db activity method baselineLcia) perResults
         pure SensitivityResponse{srBaseline = baselineLcia, srPerturbed = perturbed}
       where
@@ -781,7 +781,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
             Left err -> pure (PerturbedEntry p (Left err))
             Right x' -> do
                 let inv = applyBiosphereMatrix db x'
-                lcia <- computeCategoryResult dbName db (pure x') activity 5 inv method
+                lcia <- computeCategoryResult dbName db (pure x') activity 5 inv Nothing method
                 pure (PerturbedEntry p (Right (lcia, lrScore lcia - lrScore baselineLcia)))
 
     -- Batch LCIA endpoint (all methods in a collection)
@@ -835,7 +835,14 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                         reportProgress Info $
                             "  Inventory UUIDs: "
                                 <> intercalate ", " (map UUID.toString $ M.keys inventory)
-                rawResults <- liftIO $ mapConcurrently (computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver actProcessId) activity 5 inventory) methods
+                scoreMap <- liftIO $ batchedScoresFor dbName db sharedSolver actProcessId inventory methods
+                rawResults <-
+                    liftIO $
+                        mapConcurrently
+                            ( \m ->
+                                computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver actProcessId) activity 5 inventory (M.lookup (methodId m) scoreMap) m
+                            )
+                            methods
                 -- Enrich with NW data
                 let results = map (enrichWithNW dcLookup mNW) rawResults
                     -- Compute formula-based scoring sets
@@ -894,7 +901,14 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     processId
                     (srSubstitutions subReq)
         inventory <- either throwServiceError pure eInv
-        rawResults <- liftIO $ mapConcurrently (computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver processId) activity 5 inventory) methods
+        scoreMap <- liftIO $ batchedScoresFor dbName db sharedSolver processId inventory methods
+        rawResults <-
+            liftIO $
+                mapConcurrently
+                    ( \m ->
+                        computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver processId) activity 5 inventory (M.lookup (methodId m) scoreMap) m
+                    )
+                    methods
         let results = map (enrichWithNW dcLookup mNW) rawResults
             rawScoreMap =
                 M.fromList
@@ -1210,13 +1224,44 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                                 , carActivities = rows
                                 }
 
+    -- Score every method in a set against one inventory in a single batched
+    -- pass. For fully non-regionalized sets (PEF) this is a stacked-broadcast
+    -- matvec — one walk over the inventory, m FMAs per non-zero entry —
+    -- instead of m separate inventory walks. Mixed/regio sets fall through
+    -- to per-method 'computeLCIAScoreAuto' inside the set-scoring function.
+    batchedScoresFor ::
+        Text ->
+        Database ->
+        SharedSolver ->
+        ProcessId ->
+        Inventory ->
+        [Method] ->
+        IO (M.Map UUID (Either Text Double))
+    batchedScoresFor dbName db sharedSolver actPid inventory methods = do
+        mst <- DM.mapMethodSetToTablesCached dbManager dbName db methods
+        unitCfg <- getMergedUnitConfig dbManager
+        (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
+        -- scalingVec / hier only consulted when 'mst' has any regionalized
+        -- method; for PEF they're never read. Both are cached, so resolving
+        -- them eagerly is cheap.
+        scalingVec <- SharedSolver.computeScalingVectorCached db sharedSolver actPid
+        hier <- DM.getLocationHierarchy dbManager
+        pure $
+            M.fromList $
+                computeLCIAScoreSetFromTables unitCfg mUnits mFlows db scalingVec inventory hier mst
+
     -- Helper: compute LCIA result for a single method against an inventory.
-    -- The scaling vector is required only for regionalized methods; pass it as
-    -- a lazy IO action so non-regionalized callers don't pay the back-substitution
-    -- cost. For perturbed inventories (sensitivity), pass @pure x'@ — the action
-    -- is run only when the method's CF table contains regionalized factors.
-    computeCategoryResult :: Text -> Database -> IO Vector -> Activity -> Int -> Inventory -> Method -> IO LCIAResult
-    computeCategoryResult dbName db getScaling activity topFlows inventory method = do
+    --
+    -- 'getScaling' is a lazy IO action; the scaling vector is required only
+    -- for regionalized methods (non-regionalized fast path skips it entirely).
+    -- For perturbed inventories (sensitivity), pass @pure x'@.
+    --
+    -- 'precomputedScore' short-circuits the per-method scoring loop when a
+    -- batched matvec result is already available (see
+    -- 'mapMethodSetToTablesCached' + 'computeLCIAScoreSetFromTables'). Pass
+    -- 'Nothing' on the single-method paths.
+    computeCategoryResult :: Text -> Database -> IO Vector -> Activity -> Int -> Inventory -> Maybe (Either Text Double) -> Method -> IO LCIAResult
+    computeCategoryResult dbName db getScaling activity topFlows inventory precomputedScore method = do
         unitCfg <- getMergedUnitConfig dbManager
         (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
         mappings <- DM.mapMethodToFlowsCached dbManager dbName db method
@@ -1224,17 +1269,23 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
         -- Force score evaluation here so mapConcurrently actually parallelizes the work
         -- (without this, lazy thunks are created and forced later in the main thread)
         let stats = computeMappingStats mappings
-        score <- if M.null (mtRegionalizedCF tables)
-            then evaluate $ computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables
-            else do
-                scalingVec <- getScaling
-                hier <- DM.getLocationHierarchy dbManager
-                case computeLCIAScoreAuto unitCfg mUnits mFlows db scalingVec inventory hier tables of
-                    Right s -> evaluate s
-                    Left err -> do
-                        reportProgress Warning $
-                            "[LCIA " <> T.unpack (methodName method) <> "] " <> T.unpack err
-                        evaluate (0 :: Double)
+        score <- case precomputedScore of
+            Just (Right s) -> evaluate s
+            Just (Left err) -> do
+                reportProgress Warning $
+                    "[LCIA " <> T.unpack (methodName method) <> "] " <> T.unpack err
+                evaluate (0 :: Double)
+            Nothing -> if M.null (mtRegionalizedCF tables)
+                then evaluate $ computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables
+                else do
+                    scalingVec <- getScaling
+                    hier <- DM.getLocationHierarchy dbManager
+                    case computeLCIAScoreAuto unitCfg mUnits mFlows db scalingVec inventory hier tables of
+                        Right s -> evaluate s
+                        Left err -> do
+                            reportProgress Warning $
+                                "[LCIA " <> T.unpack (methodName method) <> "] " <> T.unpack err
+                            evaluate (0 :: Double)
         let (prodName, prodAmount, prodUnit) = Service.getReferenceProductInfo mFlows mUnits activity
             functionalUnit = T.pack (showFFloat (Just 2) prodAmount "") <> " " <> prodUnit <> " of " <> prodName
             (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
@@ -1679,7 +1730,13 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     , (subName, _) <- dcImpacts dc
                     ]
             mNW = case nwSets of (nw : _) -> Just nw; [] -> Nothing
-        rawResults <- mapConcurrently (computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver actPid) activity 5 inventory) methods
+        scoreMap <- batchedScoresFor dbName db sharedSolver actPid inventory methods
+        rawResults <-
+            mapConcurrently
+                ( \m ->
+                    computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver actPid) activity 5 inventory (M.lookup (methodId m) scoreMap) m
+                )
+                methods
         let results = map (enrichWithNW dcLookup mNW) rawResults
             rawScoreMap = M.fromList [(lrCategory r, lrScore r) | r <- rawResults]
         (scoringResults, scoringIndicators) <-

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -119,7 +119,7 @@ import Data.Time (diffUTCTime, getCurrentTime)
 import Database (buildDatabaseWithMatrices)
 import qualified Database.Loader as Loader
 import Matrix (clearCachedSolver)
-import Method.Mapping (MatchStrategy, MethodTables, buildMethodTables, mapMethodToFlows)
+import Method.Mapping (MatchStrategy, MethodTables, buildMethodTables, fillBroadcastVector, mapMethodToFlows)
 import Method.Types (
     CompartmentMap,
     Method (..),
@@ -464,7 +464,9 @@ mapMethodToTablesCached manager dbName db method = do
         Nothing -> do
             mappings <- mapMethodToFlowsCached manager dbName db method
             cmap <- getMergedCompartmentMap manager
-            let !tables = buildMethodTables cmap mappings
+            unitConfig <- getMergedUnitConfig manager
+            (mFlows, mUnits) <- getMergedFlowMetadata manager
+            let !tables = fillBroadcastVector unitConfig mUnits mFlows (buildMethodTables cmap mappings)
             atomically $ modifyTVar' (dmMethodTablesCache manager) (M.insert key tables)
             pure tables
 

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -83,6 +83,7 @@ module Database.Manager (
     -- * Cached flow mapping
     mapMethodToFlowsCached,
     mapMethodToTablesCached,
+    mapMethodSetToTablesCached,
 
     -- * Internal (for Main.hs to load database)
     loadDatabaseFromConfig,
@@ -119,7 +120,15 @@ import Data.Time (diffUTCTime, getCurrentTime)
 import Database (buildDatabaseWithMatrices)
 import qualified Database.Loader as Loader
 import Matrix (clearCachedSolver)
-import Method.Mapping (MatchStrategy, MethodTables, buildMethodTables, fillBroadcastVector, mapMethodToFlows)
+import Method.Mapping (
+    MatchStrategy,
+    MethodSetTables,
+    MethodTables,
+    buildMethodSetTables,
+    buildMethodTables,
+    fillBroadcastVector,
+    mapMethodToFlows,
+ )
 import Method.Types (
     CompartmentMap,
     Method (..),
@@ -429,6 +438,13 @@ data DatabaseManager = DatabaseManager
     These depend only on (db, method), so building them once per pair
     saves O(n log n) Map constructions on every LCIA call.
     -}
+    , dmMethodSetTablesCache :: !(TVar (Map (Text, [UUID]) MethodSetTables))
+    {- ^ Cached stacked CF tables for multi-method scoring.
+    Key is (dbName, sortedMethodIds) so subset-arbitrary requests share
+    cache entries with named-collection ones whenever the method ids match.
+    Purged together with 'dmMethodTablesCache' on any reload that
+    invalidates the per-method cache (collection / synonym / DB load).
+    -}
     , dmMergedFlowMetadataCache :: !(TVar (Maybe (FlowDB, UnitDB)))
     {- ^ Memoized 'M.unions' of every loaded DB's flows/units.
     Invalidated on any 'dmLoadedDbs' mutation; collision detection
@@ -470,6 +486,27 @@ mapMethodToTablesCached manager dbName db method = do
             atomically $ modifyTVar' (dmMethodTablesCache manager) (M.insert key tables)
             pure tables
 
+{- | Cached stacked CF tables for multi-method scoring. Built once per
+(dbName, sortedMethodIds), so two requests asking for the same method set
+(in any order) share an entry. Per-method 'MethodTables' are sourced via
+'mapMethodToTablesCached' and re-used; the only set-level work is stacking
+broadcasts into a dense matrix when none of the methods are regionalized.
+-}
+mapMethodSetToTablesCached :: DatabaseManager -> Text -> Database -> [Method] -> IO MethodSetTables
+mapMethodSetToTablesCached manager dbName db methods = do
+    -- Canonical key = (dbName, sorted methodIds). Stable regardless of input
+    -- ordering so subset-arbitrary requests don't fragment the cache.
+    let sortedMethods = sortOn methodId methods
+        key = (dbName, map methodId sortedMethods)
+    cache <- readTVarIO (dmMethodSetTablesCache manager)
+    case M.lookup key cache of
+        Just mst -> pure mst
+        Nothing -> do
+            tables <- traverse (mapMethodToTablesCached manager dbName db) sortedMethods
+            let !mst = buildMethodSetTables (zip sortedMethods tables)
+            atomically $ modifyTVar' (dmMethodSetTablesCache manager) (M.insert key mst)
+            pure mst
+
 {- | Clear all cached flow mappings (call when databases, methods, or synonyms change).
 Also drops the merged flow/unit snapshots — both caches depend on the loaded-DB set.
 -}
@@ -477,6 +514,7 @@ clearMethodMappingCache :: DatabaseManager -> IO ()
 clearMethodMappingCache manager = atomically $ do
     writeTVar (dmMethodMappingCache manager) M.empty
     writeTVar (dmMethodTablesCache manager) M.empty
+    writeTVar (dmMethodSetTablesCache manager) M.empty
     writeTVar (dmMergedFlowMetadataCache manager) Nothing
     writeTVar (dmMergedUnitConfigCache manager) Nothing
 
@@ -488,6 +526,7 @@ clearMethodMappingCacheForDb :: DatabaseManager -> Text -> IO ()
 clearMethodMappingCacheForDb manager dbName = atomically $ do
     modifyTVar' (dmMethodMappingCache manager) (M.filterWithKey (\(dn, _) _ -> dn /= dbName))
     modifyTVar' (dmMethodTablesCache manager) (M.filterWithKey (\(dn, _) _ -> dn /= dbName))
+    modifyTVar' (dmMethodSetTablesCache manager) (M.filterWithKey (\(dn, _) _ -> dn /= dbName))
     writeTVar (dmMergedFlowMetadataCache manager) Nothing
     writeTVar (dmMergedUnitConfigCache manager) Nothing
 
@@ -549,6 +588,7 @@ initDatabaseManager config noCache configPath = do
 
     methodMappingCacheVar <- newTVarIO M.empty
     methodTablesCacheVar <- newTVarIO M.empty
+    methodSetTablesCacheVar <- newTVarIO M.empty
     mergedFlowMetadataCacheVar <- newTVarIO Nothing
     mergedUnitConfigCacheVar <- newTVarIO Nothing
 
@@ -572,6 +612,7 @@ initDatabaseManager config noCache configPath = do
                 , dmGeographies = geographies
                 , dmMethodMappingCache = methodMappingCacheVar
                 , dmMethodTablesCache = methodTablesCacheVar
+                , dmMethodSetTablesCache = methodSetTablesCacheVar
                 , dmMergedFlowMetadataCache = mergedFlowMetadataCacheVar
                 , dmMergedUnitConfigCache = mergedUnitConfigCacheVar
                 }

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -374,10 +374,7 @@ fillBroadcastVector unitConfig unitDB flowDB tables =
   where
     buildEntry fid flow = case lookupCascadeCF tables flowDB fid of
         Nothing -> Nothing
-        Just (cfVal, cfUnit) ->
-            let flowUnit = maybe "" unitName (M.lookup (flowUnitId flow) unitDB)
-                factor = convertForCharacterization unitConfig flowUnit cfUnit 1.0
-             in Just (factor * cfVal)
+        Just cfTuple -> Just (convertAndMultiply unitConfig unitDB (Just flow) cfTuple 1.0)
 
 
 {- | Score an inventory against precomputed 'MethodTables'.
@@ -409,10 +406,7 @@ computeLCIAScoreFromTables unitConfig unitDB flowDB inventory tables
         | qty == 0 = 0
         | otherwise = case lookupCascadeCF tables flowDB fid of
             Nothing -> 0
-            Just (cfVal, cfUnit) ->
-                let flowUnit = maybe "" unitName (M.lookup fid flowDB >>= \f -> M.lookup (flowUnitId f) unitDB)
-                    converted = convertForCharacterization unitConfig flowUnit cfUnit qty
-                 in converted * cfVal
+            Just cfTuple -> convertAndMultiply unitConfig unitDB (M.lookup fid flowDB) cfTuple qty
 
 {- | Back-compat wrapper: build tables on the fly. Prefer the cached path
 ('mapMethodToTablesCached' + 'computeLCIAScoreFromTables') in hot loops.
@@ -512,10 +506,8 @@ computeRegionalizedLCIAScore unitConfig unitDB flowDB db scalingVec hier tables 
                             loc = activityLocation act
                          in case resolveRegionalCF tables flowDB regionalizedFlows hier flowUUID loc of
                                 Right Nothing -> Right running
-                                Right (Just (cfVal, cfUnit)) ->
-                                    let flowUnit = maybe "" unitName (M.lookup flowUUID flowDB >>= \f -> M.lookup (flowUnitId f) unitDB)
-                                        converted = convertForCharacterization unitConfig flowUnit cfUnit contribution
-                                     in Right (running + converted * cfVal)
+                                Right (Just cfTuple) ->
+                                    Right (running + convertAndMultiply unitConfig unitDB (M.lookup flowUUID flowDB) cfTuple contribution)
                                 Left err -> Left err
      in U.foldl' step (Right 0) bioTriples
 
@@ -600,6 +592,29 @@ normalizeMedium m
     | m == "natural resource" = "resource"
     | otherwise = m
 
+{- | Apply the flow→CF unit conversion factor and multiply by the CF value.
+
+Delegates to 'convertForCharacterization' for the conversion step, so a
+dimensional mismatch between flow and CF units lands an effective @0@
+(refuse to score wrong-dimension data) rather than silently passing the
+unconverted quantity through. Pass @qty = 1.0@ to obtain the effective-CF
+factor used at build time; pass an actual quantity for inline scoring.
+-}
+convertAndMultiply ::
+    UnitConfig ->
+    UnitDB ->
+    -- | Pre-resolved flow if the caller already has it; @Nothing@ defaults to
+    -- the identity factor (no flow record means no flow unit known).
+    Maybe Flow ->
+    -- | (CF value, CF unit)
+    (Double, Text) ->
+    Double ->
+    Double
+convertAndMultiply unitConfig unitDB mflow (cfVal, cfUnit) qty =
+    let flowUnit = maybe "" unitName (mflow >>= \f -> M.lookup (flowUnitId f) unitDB)
+        converted = convertForCharacterization unitConfig flowUnit cfUnit qty
+     in converted * cfVal
+
 firstJust :: [Maybe a] -> Maybe a
 firstJust [] = Nothing
 firstJust (Just x : _) = Just x
@@ -645,10 +660,8 @@ inventoryContributions unitConfig unitDB flowDB inventory tables =
             Nothing -> (contribs, fid : unknowns) -- metadata missing — surface it
             Just flow -> case lookupCascadeCF tables flowDB fid of
                 Nothing -> (contribs, unknowns) -- no CF match — legitimately uncharacterized
-                Just (cfVal, cfUnit) ->
-                    let flowUnit = maybe "" unitName (M.lookup (flowUnitId flow) unitDB)
-                        converted = convertForCharacterization unitConfig flowUnit cfUnit qty
-                        !contribution = converted * cfVal
+                Just cfTuple@(cfVal, _) ->
+                    let !contribution = convertAndMultiply unitConfig unitDB (Just flow) cfTuple qty
                      in ((flow, cfVal, contribution) : contribs, unknowns)
 
 {- | Per-process LCIA contributions for one DB + one method, driven by
@@ -684,14 +697,12 @@ processContributionsFromTables unitConfig unitDB flowDB db scalingVec tables =
     effectiveCF :: U.Vector Double
     effectiveCF = U.generate nFlows $ \i ->
         let flowUUID = bioFlows V.! i
-         in case M.lookup flowUUID flowDB of
+            mflow = M.lookup flowUUID flowDB
+         in case mflow of
                 Nothing -> 0
-                Just flow -> case lookupCascadeCF tables flowDB flowUUID of
+                Just _ -> case lookupCascadeCF tables flowDB flowUUID of
                     Nothing -> 0
-                    Just (cfVal, cfUnit) ->
-                        let flowUnit = maybe "" unitName (M.lookup (flowUnitId flow) unitDB)
-                            factor = convertForCharacterization unitConfig flowUnit cfUnit 1.0
-                         in factor * cfVal
+                    Just cfTuple -> convertAndMultiply unitConfig unitDB mflow cfTuple 1.0
 
     -- Invert dbActivityIndex (pid -> col) into (col -> pid) as an unboxed
     -- vector for O(1) per-triple lookup. Assumes matrix cols are dense in

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -338,11 +338,6 @@ buildMethodTables cmap mappings =
         Just (flow, BySynonym) -> flowName flow
         _ -> mcfFlowName cf
 
-    -- Normalize medium names between method CFs and database flows
-    normalizeMedium m
-        | m == "natural resource" = "resource"
-        | otherwise = m
-
 {- | Convert @qty@ from @flowUnit@ to @cfUnit@ for characterization.
 
 Bypass cases (returns @qty@ unchanged):
@@ -361,6 +356,7 @@ convertForCharacterization cfg flowUnit cfUnit qty
     | not (isKnownUnit cfg flowUnit) || not (isKnownUnit cfg cfUnit) = qty
     | otherwise = fromMaybe 0 (convertUnit cfg flowUnit cfUnit qty)
 
+
 {- | Pre-compute the broadcast CF Map: each flow UUID covered by the method maps
 to its effective CF (CF value × flow-unit→CF-unit conversion). Collapses the
 UUID/exact/fallback cascade into a single Map and absorbs the unit conversion
@@ -376,7 +372,7 @@ fillBroadcastVector :: UnitConfig -> UnitDB -> FlowDB -> MethodTables -> MethodT
 fillBroadcastVector unitConfig unitDB flowDB tables =
     tables{mtBroadcast = M.mapMaybeWithKey buildEntry flowDB}
   where
-    buildEntry fid flow = case lookupBroadcastCF tables flowDB fid of
+    buildEntry fid flow = case lookupCascadeCF tables flowDB fid of
         Nothing -> Nothing
         Just (cfVal, cfUnit) ->
             let flowUnit = maybe "" unitName (M.lookup (flowUnitId flow) unitDB)
@@ -411,45 +407,12 @@ computeLCIAScoreFromTables unitConfig unitDB flowDB inventory tables
 
     legacyScore fid qty
         | qty == 0 = 0
-        | otherwise = case lookupCF fid of
+        | otherwise = case lookupCascadeCF tables flowDB fid of
             Nothing -> 0
             Just (cfVal, cfUnit) ->
                 let flowUnit = maybe "" unitName (M.lookup fid flowDB >>= \f -> M.lookup (flowUnitId f) unitDB)
                     converted = convertForCharacterization unitConfig flowUnit cfUnit qty
                  in converted * cfVal
-
-    lookupCF fid = case M.lookup fid (mtUuidCF tables) of
-        Just cfv -> Just cfv
-        Nothing -> case M.lookup fid flowDB of
-            Nothing -> Nothing
-            Just flow ->
-                let name = normalizeName (flowName flow)
-                    -- Build the flow's raw compartment from flowCategory ("medium/sub")
-                    -- and flowSubcompartment, then normalize via the same map applied
-                    -- when buildMethodTables keyed the CF tables. Both sides converge
-                    -- to the canonical form, so a "Emissions to air,,,air,," rule in
-                    -- compartments.csv suffices to bridge BAFU's prefix vs ILCD's bare
-                    -- medium without listing every (medium, sub) pair explicitly.
-                    rawCategory = T.toLower (flowCategory flow)
-                    (rawMed, rawSubFromCat) = case T.breakOn "/" rawCategory of
-                        (m, rest)
-                            | T.null rest -> (m, T.empty)
-                            | otherwise -> (m, T.drop 1 rest)
-                    rawSub =
-                        let s = T.toLower (fromMaybe T.empty (flowSubcompartment flow))
-                         in if T.null s then rawSubFromCat else s
-                    Compartment normMedRaw normSub _ =
-                        normalizeCompartment (mtCompartmentMap tables) (Compartment rawMed rawSub T.empty)
-                    baseMed = normalizeMedium normMedRaw
-                    subcomp = normSub
-                    exact = M.lookup (name, baseMed, subcomp) (mtExactCF tables)
-                 in case exact of
-                        Just _ -> exact
-                        Nothing -> M.lookup (name, baseMed) (mtFallbackCF tables)
-
-    normalizeMedium m
-        | m == "natural resource" = "resource"
-        | otherwise = m
 
 {- | Back-compat wrapper: build tables on the fly. Prefer the cached path
 ('mapMethodToTablesCached' + 'computeLCIAScoreFromTables') in hot loops.
@@ -581,7 +544,7 @@ resolveRegionalCF tables flowDB regionalizedFlows hier flowUUID loc =
                 fromParents = firstJust [M.lookup (flowUUID, p) (mtRegionalizedCF tables) | p <- parents]
              in case fromParents of
                     Just v -> Right (Just v)
-                    Nothing -> case lookupBroadcastCF tables flowDB flowUUID of
+                    Nothing -> case lookupCascadeCF tables flowDB flowUUID of
                         Just v -> Right (Just v)
                         Nothing
                             | Set.member flowUUID regionalizedFlows ->
@@ -595,26 +558,47 @@ resolveRegionalCF tables flowDB regionalizedFlows hier flowUUID loc =
                                         <> " parent regions) and no universal broadcast."
                             | otherwise -> Right Nothing
 
-{- | Universal CF lookup: same cascade as 'computeLCIAScoreFromTables' uses
-internally, factored out for reuse from 'computeRegionalizedLCIAScore'.
+{- | Cascade CF lookup: UUID → exact (name, medium, subcomp) → fallback (name, medium).
+The same logic is baked into 'mtBroadcast' once unit conversion is available;
+this helper is the source of truth for the legacy / cross-DB / regionalized
+fallback paths that don't go through the broadcast.
+
+Both the CF table keys (built by 'buildMethodTables') and the inventory flow
+compartments are normalized through @tables.'mtCompartmentMap'@ so each side
+converges on the same canonical form — a compartments.csv rule like
+@"Emissions to air,,,air,,"@ then bridges BAFU-style prefixed compartments
+against ILCD-style bare media without requiring an explicit (medium, sub)
+pair for every combination.
 -}
-lookupBroadcastCF :: MethodTables -> FlowDB -> UUID -> Maybe (Double, Text)
-lookupBroadcastCF tables flowDB fid = case M.lookup fid (mtUuidCF tables) of
+lookupCascadeCF :: MethodTables -> FlowDB -> UUID -> Maybe (Double, Text)
+lookupCascadeCF tables flowDB fid = case M.lookup fid (mtUuidCF tables) of
     Just cfv -> Just cfv
     Nothing -> case M.lookup fid flowDB of
         Nothing -> Nothing
         Just flow ->
             let name = normalizeName (flowName flow)
-                baseMed = normalizeMediumNm . T.takeWhile (/= '/') . T.toLower $ flowCategory flow
-                subcomp = T.toLower $ fromMaybe "" (flowSubcompartment flow)
+                rawCategory = T.toLower (flowCategory flow)
+                (rawMed, rawSubFromCat) = case T.breakOn "/" rawCategory of
+                    (m, rest)
+                        | T.null rest -> (m, T.empty)
+                        | otherwise -> (m, T.drop 1 rest)
+                rawSub =
+                    let s = T.toLower (fromMaybe T.empty (flowSubcompartment flow))
+                     in if T.null s then rawSubFromCat else s
+                Compartment normMedRaw normSub _ =
+                    normalizeCompartment (mtCompartmentMap tables) (Compartment rawMed rawSub T.empty)
+                baseMed = normalizeMedium normMedRaw
+                subcomp = normSub
                 exact = M.lookup (name, baseMed, subcomp) (mtExactCF tables)
              in case exact of
                     Just _ -> exact
                     Nothing -> M.lookup (name, baseMed) (mtFallbackCF tables)
-  where
-    normalizeMediumNm m
-        | m == "natural resource" = "resource"
-        | otherwise = m
+
+-- | Normalize medium names between method CFs and database flows.
+normalizeMedium :: Text -> Text
+normalizeMedium m
+    | m == "natural resource" = "resource"
+    | otherwise = m
 
 firstJust :: [Maybe a] -> Maybe a
 firstJust [] = Nothing
@@ -659,28 +643,13 @@ inventoryContributions unitConfig unitDB flowDB inventory tables =
         | qty == 0 = (contribs, unknowns)
         | otherwise = case M.lookup fid flowDB of
             Nothing -> (contribs, fid : unknowns) -- metadata missing — surface it
-            Just flow -> case lookupCF fid flow of
+            Just flow -> case lookupCascadeCF tables flowDB fid of
                 Nothing -> (contribs, unknowns) -- no CF match — legitimately uncharacterized
                 Just (cfVal, cfUnit) ->
                     let flowUnit = maybe "" unitName (M.lookup (flowUnitId flow) unitDB)
                         converted = convertForCharacterization unitConfig flowUnit cfUnit qty
                         !contribution = converted * cfVal
                      in ((flow, cfVal, contribution) : contribs, unknowns)
-
-    lookupCF fid flow = case M.lookup fid (mtUuidCF tables) of
-        Just cfv -> Just cfv
-        Nothing ->
-            let name = normalizeName (flowName flow)
-                baseMed = normalizeMedium . T.takeWhile (/= '/') . T.toLower $ flowCategory flow
-                subcomp = T.toLower $ fromMaybe "" (flowSubcompartment flow)
-                exact = M.lookup (name, baseMed, subcomp) (mtExactCF tables)
-             in case exact of
-                    Just _ -> exact
-                    Nothing -> M.lookup (name, baseMed) (mtFallbackCF tables)
-
-    normalizeMedium m
-        | m == "natural resource" = "resource"
-        | otherwise = m
 
 {- | Per-process LCIA contributions for one DB + one method, driven by
 'MethodTables' + a merged 'FlowDB'. Mirrors
@@ -717,7 +686,7 @@ processContributionsFromTables unitConfig unitDB flowDB db scalingVec tables =
         let flowUUID = bioFlows V.! i
          in case M.lookup flowUUID flowDB of
                 Nothing -> 0
-                Just flow -> case lookupCF flowUUID flow of
+                Just flow -> case lookupCascadeCF tables flowDB flowUUID of
                     Nothing -> 0
                     Just (cfVal, cfUnit) ->
                         let flowUnit = maybe "" unitName (M.lookup (flowUnitId flow) unitDB)
@@ -746,21 +715,6 @@ processContributionsFromTables unitConfig unitDB flowDB db scalingVec tables =
                                 let scale = scalingVec U.! colI
                                     pid' = fromIntegral pid :: ProcessId
                                  in M.insertWith (+) pid' (bioVal * scale * cf) acc
-
-    lookupCF fid flow = case M.lookup fid (mtUuidCF tables) of
-        Just cfv -> Just cfv
-        Nothing ->
-            let name = normalizeName (flowName flow)
-                baseMed = normalizeMedium . T.takeWhile (/= '/') . T.toLower $ flowCategory flow
-                subcomp = T.toLower $ fromMaybe "" (flowSubcompartment flow)
-                exact = M.lookup (name, baseMed, subcomp) (mtExactCF tables)
-             in case exact of
-                    Just _ -> exact
-                    Nothing -> M.lookup (name, baseMed) (mtFallbackCF tables)
-
-    normalizeMedium m
-        | m == "natural resource" = "resource"
-        | otherwise = m
 
 -- ────────────────────────────────────────────────────────────────────────────
 -- Multi-method scoring (set-level)

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -27,6 +27,12 @@ module Method.Mapping (
     processContributionsFromTables,
     convertForCharacterization,
 
+    -- * Multi-method scoring
+    MethodSetTables (..),
+    MethodSetEntry (..),
+    buildMethodSetTables,
+    computeLCIAScoreSetFromTables,
+
     -- * Matching strategies
     MatchStrategy (..),
     strategyFromText,
@@ -755,3 +761,160 @@ processContributionsFromTables unitConfig unitDB flowDB db scalingVec tables =
     normalizeMedium m
         | m == "natural resource" = "resource"
         | otherwise = m
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Multi-method scoring (set-level)
+-- ────────────────────────────────────────────────────────────────────────────
+
+{- | One method's worth of data inside a 'MethodSetTables'. Carries the full
+'MethodTables' plus the original 'Method' so the scoring path can fall back
+to the per-method dispatcher ('computeLCIAScoreAuto') for regionalized
+methods without having to re-look up anything.
+-}
+data MethodSetEntry = MethodSetEntry
+    { mseMethodId :: !UUID
+    , mseMethod :: !Method
+    , mseTables :: !MethodTables
+    }
+
+{- | Stacked CF tables for scoring the same inventory against many methods at
+once. Built once per (db, sortedMethodIds) and cached.
+
+When no method in the set is regionalized ('msAnyRegional == False'), scoring
+collapses to a single dense matrix–vector product: one walk over the
+inventory, m FMAs per non-zero entry, no per-method inventory traversal. For
+PEF (~27 non-regionalized methods) this is the path that wins.
+
+When at least one method is regionalized, the matrix is empty and scoring
+falls back to per-method 'computeLCIAScoreAuto' — the regionalized path
+needs the biosphere-triple stream and the location hierarchy walk, which
+don't compose with the broadcast matvec. Non-regio methods in a mixed set
+still benefit indirectly via 'mtBroadcast' (filled in 'fillBroadcastVector').
+-}
+data MethodSetTables = MethodSetTables
+    { msEntries :: !(V.Vector MethodSetEntry)
+    -- ^ Per-method full data, in canonical (sorted) order.
+    , msAnyRegional :: !Bool
+    -- ^ True if any method has a non-empty 'mtRegionalizedCF'. Disables the
+    -- batched matvec path; per-method dispatch is used instead.
+    , msUuidIndex :: !(M.Map UUID Int)
+    -- ^ Flow UUID → row in 'msBroadcastMat'. Empty when 'msAnyRegional'.
+    , msNFlows :: !Int
+    -- ^ @M.size msUuidIndex@. Cached for the matvec inner loop.
+    , msBroadcastMat :: !(U.Vector Double)
+    -- ^ Flat row-major dense broadcast: @i * msNFlows + j@ holds the
+    -- effective CF for method @i@ at flow @j@. Length @m * msNFlows@.
+    -- Empty when 'msAnyRegional'.
+    }
+
+{- | Build 'MethodSetTables' from per-method 'MethodTables'. The list order
+defines the row order of the broadcast matrix and is preserved in
+'msEntries'. Callers should sort by 'methodId' for cache-key canonicality.
+-}
+buildMethodSetTables :: [(Method, MethodTables)] -> MethodSetTables
+buildMethodSetTables pairs =
+    let entries =
+            V.fromList
+                [MethodSetEntry (methodId m) m t | (m, t) <- pairs]
+        anyRegio = any (not . M.null . mtRegionalizedCF . snd) pairs
+        nMethods = V.length entries
+     in if anyRegio
+            then
+                MethodSetTables
+                    { msEntries = entries
+                    , msAnyRegional = True
+                    , msUuidIndex = M.empty
+                    , msNFlows = 0
+                    , msBroadcastMat = U.empty
+                    }
+            else
+                let -- Union of all UUIDs covered by any method's broadcast,
+                    -- assigned dense Int row indices.
+                    uuidSet =
+                        Set.unions
+                            [Set.fromList (M.keys (mtBroadcast t)) | (_, t) <- pairs]
+                    uuidList = Set.toAscList uuidSet
+                    uuidIndex = M.fromList (zip uuidList [0 ..])
+                    nFlows = length uuidList
+                    -- Pack broadcasts row-major into one flat unboxed Vector.
+                    -- A full m × nFlows allocation is fine (PEF: 27 × ~10k ≈ 2 MB).
+                    mat = U.create $ do
+                        mv <- MU.replicate (nMethods * nFlows) (0.0 :: Double)
+                        V.iforM_ entries $ \i e -> do
+                            let bcast = mtBroadcast (mseTables e)
+                                rowStart = i * nFlows
+                            mapM_
+                                ( \(uuid, cf) -> case M.lookup uuid uuidIndex of
+                                    Just j -> MU.unsafeWrite mv (rowStart + j) cf
+                                    Nothing -> pure ()
+                                )
+                                (M.toList bcast)
+                        pure mv
+                 in MethodSetTables
+                        { msEntries = entries
+                        , msAnyRegional = False
+                        , msUuidIndex = uuidIndex
+                        , msNFlows = nFlows
+                        , msBroadcastMat = mat
+                        }
+
+{- | Score an inventory against every method in a 'MethodSetTables'.
+Returns @(methodId, Right score)@ on success, @(methodId, Left err)@ for a
+regionalized method whose coverage is incomplete (mirrors the existing
+'computeLCIAScoreAuto' contract).
+
+When the set is fully non-regionalized, this collapses to a single dense
+matvec over a stacked broadcast matrix — no per-method inventory walk, no
+per-flow unit conversion (already pre-multiplied in 'mtBroadcast').
+Otherwise dispatches per-method to preserve the regionalized path's
+hierarchy walk + coverage check.
+-}
+computeLCIAScoreSetFromTables ::
+    UnitConfig ->
+    UnitDB ->
+    FlowDB ->
+    Database ->
+    Vector ->
+    Inventory ->
+    M.Map Text [Text] ->
+    MethodSetTables ->
+    [(UUID, Either Text Double)]
+computeLCIAScoreSetFromTables unitCfg unitDB flowDB db scalingVec inventory hier mst
+    | msAnyRegional mst = perMethod
+    | otherwise = batched
+  where
+    entries = V.toList (msEntries mst)
+
+    perMethod =
+        [ ( mseMethodId e
+          , computeLCIAScoreAuto unitCfg unitDB flowDB db scalingVec inventory hier (mseTables e)
+          )
+        | e <- entries
+        ]
+
+    batched =
+        let nFlows = msNFlows mst
+            nMethods = V.length (msEntries mst)
+            mat = msBroadcastMat mst
+            invDense = U.create $ do
+                mv <- MU.replicate nFlows (0.0 :: Double)
+                M.foldlWithKey'
+                    ( \act uuid qty -> act >> case M.lookup uuid (msUuidIndex mst) of
+                        Just j | qty /= 0 -> MU.unsafeModify mv (+ qty) j
+                        _ -> pure ()
+                    )
+                    (pure ())
+                    inventory
+                pure mv
+            scores = U.generate nMethods $ \i ->
+                let rowStart = i * nFlows
+                    !s =
+                        U.sum $
+                            U.zipWith
+                                (*)
+                                (U.unsafeSlice rowStart nFlows mat)
+                                invDense
+                 in s
+         in [ (mseMethodId e, Right (scores U.! i))
+            | (i, e) <- zip [0 ..] entries
+            ]

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -18,6 +18,7 @@ module Method.Mapping (
     -- * LCIA scoring
     MethodTables (..),
     buildMethodTables,
+    fillBroadcastVector,
     computeLCIAScore,
     computeLCIAScoreFromTables,
     computeLCIAScoreAuto,
@@ -249,6 +250,13 @@ data MethodTables = MethodTables
     compartments at query time, so both sides converge to the same
     canonical form. Empty map = identity, no normalization.
     -}
+    , mtBroadcast :: !(M.Map UUID Double)
+    {- ^ Pre-multiplied broadcast CFs: flow UUID → effective CF (CF value × flow→CF unit conversion).
+    Collapses the UUID/exact/fallback cascade into a single Map and absorbs unit conversion
+    so the scoring hot path is a pure multiply-accumulate. Empty when 'buildMethodTables' is
+    called directly without DB-level dependencies; fill with 'fillBroadcastVector' to enable
+    the fast path (scoring falls back to the cascade when this Map is empty).
+    -}
     }
 
 {- | Build 'MethodTables' from raw mappings and a 'CompartmentMap'.
@@ -298,6 +306,7 @@ buildMethodTables cmap mappings =
                 , Just loc <- [mcfConsumerLocation cf]
                 ]
         , mtCompartmentMap = cmap
+        , mtBroadcast = M.empty -- fill via 'fillBroadcastVector' to enable the fast path
         }
   where
     stripStrategy = M.map (\(v, u, _) -> (v, u))
@@ -346,19 +355,62 @@ convertForCharacterization cfg flowUnit cfUnit qty
     | not (isKnownUnit cfg flowUnit) || not (isKnownUnit cfg cfUnit) = qty
     | otherwise = fromMaybe 0 (convertUnit cfg flowUnit cfUnit qty)
 
+{- | Pre-compute the broadcast CF Map: each flow UUID covered by the method maps
+to its effective CF (CF value × flow-unit→CF-unit conversion). Collapses the
+UUID/exact/fallback cascade into a single Map and absorbs the unit conversion
+so the scoring hot path becomes pure multiply-accumulate.
+
+Walks every flow in @flowDB@ once. Flows with no CF match are not inserted
+(sparse Map). Conversions route through 'convertForCharacterization', so
+dimensionally-incompatible flow/CF unit pairs land an effective CF of @0@
+(matching the per-flow scoring path) rather than silently keeping the
+unconverted quantity and contaminating the score.
+-}
+fillBroadcastVector :: UnitConfig -> UnitDB -> FlowDB -> MethodTables -> MethodTables
+fillBroadcastVector unitConfig unitDB flowDB tables =
+    tables{mtBroadcast = M.mapMaybeWithKey buildEntry flowDB}
+  where
+    buildEntry fid flow = case lookupBroadcastCF tables flowDB fid of
+        Nothing -> Nothing
+        Just (cfVal, cfUnit) ->
+            let flowUnit = maybe "" unitName (M.lookup (flowUnitId flow) unitDB)
+                factor = convertForCharacterization unitConfig flowUnit cfUnit 1.0
+             in Just (factor * cfVal)
+
+
 {- | Score an inventory against precomputed 'MethodTables'.
 Hot path: O(|inventory|) per call, no map construction.
+
+Uses 'mtBroadcast' (single Map lookup, conversion pre-multiplied) when filled,
+falling back to the legacy UUID→exact→fallback cascade with on-the-fly unit
+conversion when 'mtBroadcast' is empty. Tests and back-compat callers that use
+'buildMethodTables' directly hit the legacy path; the cached
+'mapMethodToTablesCached' fills the broadcast and gets the fast path.
 -}
 computeLCIAScoreFromTables :: UnitConfig -> UnitDB -> FlowDB -> Inventory -> MethodTables -> Double
-computeLCIAScoreFromTables unitConfig unitDB flowDB inventory tables =
-    sum [scoreFlow fid qty | (fid, qty) <- M.toList inventory, qty /= 0]
+computeLCIAScoreFromTables unitConfig unitDB flowDB inventory tables
+    | M.null (mtBroadcast tables) =
+        M.foldlWithKey' (\acc fid qty -> acc + legacyScore fid qty) 0 inventory
+    | otherwise =
+        M.foldlWithKey' (\acc fid qty -> acc + fastScore fid qty) 0 inventory
   where
-    scoreFlow fid qty = case lookupCF fid of
-        Nothing -> 0
-        Just (cfVal, cfUnit) ->
-            let flowUnit = maybe "" unitName (M.lookup fid flowDB >>= \f -> M.lookup (flowUnitId f) unitDB)
-                converted = convertForCharacterization unitConfig flowUnit cfUnit qty
-             in converted * cfVal
+    fastScore fid qty
+        | qty == 0 = 0
+        | otherwise = case M.lookup fid (mtBroadcast tables) of
+            Just cf -> qty * cf
+            -- Inventory may reference flows not in the broadcast (e.g. cross-DB
+            -- merged flows beyond the original flowDB at build time): fall back
+            -- to the cascade so we don't silently drop them.
+            Nothing -> legacyScore fid qty
+
+    legacyScore fid qty
+        | qty == 0 = 0
+        | otherwise = case lookupCF fid of
+            Nothing -> 0
+            Just (cfVal, cfUnit) ->
+                let flowUnit = maybe "" unitName (M.lookup fid flowDB >>= \f -> M.lookup (flowUnitId f) unitDB)
+                    converted = convertForCharacterization unitConfig flowUnit cfUnit qty
+                 in converted * cfVal
 
     lookupCF fid = case M.lookup fid (mtUuidCF tables) of
         Just cfv -> Just cfv

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -871,6 +871,21 @@ computeLCIAScoreSetFromTables unitCfg unitDB flowDB db scalingVec inventory hier
         let nMethods = msNMethods mst
             mat = msBroadcastMat mst
             uuidIdx = msUuidIndex mst
+            entriesV = msEntries mst
+            -- Per-method cascade fallback for flows missing from the dense
+            -- broadcast index. The mono-method 'fastScore' has the same
+            -- fallback to 'lookupCascadeCF' (see 'computeLCIAScoreFromTables');
+            -- replicating it here keeps the batched path numerically
+            -- equivalent on inventories carrying flows whose UUIDs weren't
+            -- in the root flowDB at table-build time — typically cross-DB
+            -- merged inventories. Without this fallback the batched path
+            -- silently drops those flows while the per-method path catches
+            -- them via name/compartment cascade.
+            cascadeContrib !tables !uuid !qty =
+                case lookupCascadeCF tables flowDB uuid of
+                    Nothing -> 0
+                    Just cfTuple ->
+                        convertAndMultiply unitCfg unitDB (M.lookup uuid flowDB) cfTuple qty
             -- Sparse walk: for each non-zero (uuid, qty) in the inventory,
             -- find its dense row j (if any), then accumulate
             --   scores[i] += qty * mat[j * nMethods + i]
@@ -884,7 +899,6 @@ computeLCIAScoreSetFromTables unitCfg unitDB flowDB db scalingVec inventory hier
                         if qty == 0
                             then pure ()
                             else case M.lookup uuid uuidIdx of
-                                Nothing -> pure ()
                                 Just j -> do
                                     let rowStart = j * nMethods
                                         loop !i
@@ -894,6 +908,17 @@ computeLCIAScoreSetFromTables unitCfg unitDB flowDB db scalingVec inventory hier
                                                 MU.unsafeModify mv (+ qty * cf) i
                                                 loop (i + 1)
                                     loop 0
+                                Nothing ->
+                                    -- Out-of-broadcast flow: ask each method's
+                                    -- cascade individually. O(m) per missing
+                                    -- flow vs O(m) row-read — same cost — but
+                                    -- without the silent zero.
+                                    V.imapM_
+                                        ( \i e -> do
+                                            let !c = cascadeContrib (mseTables e) uuid qty
+                                            MU.unsafeModify mv (+ c) i
+                                        )
+                                        entriesV
                     )
                     (M.toList inventory)
                 pure mv

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -802,9 +802,18 @@ data MethodSetTables = MethodSetTables
     , msNFlows :: !Int
     -- ^ @M.size msUuidIndex@. Cached for the matvec inner loop.
     , msBroadcastMat :: !(U.Vector Double)
-    -- ^ Flat row-major dense broadcast: @i * msNFlows + j@ holds the
-    -- effective CF for method @i@ at flow @j@. Length @m * msNFlows@.
-    -- Empty when 'msAnyRegional'.
+    -- ^ Flat column-major dense broadcast: @j * m + i@ holds the effective
+    -- CF for method @i@ at flow row @j@. Length @msNFlows * m@. Empty when
+    -- 'msAnyRegional'.
+    --
+    -- The layout is chosen to match the scoring access pattern: an
+    -- inventory entry maps to one flow row @j@; reading the @m@ CFs across
+    -- methods for that row is then a contiguous slice. With a sparse
+    -- inventory (typical: hundreds of non-zero flows out of thousands)
+    -- this is far cheaper than a row-major dense matvec, which would
+    -- multiply across every flow regardless.
+    , msNMethods :: !Int
+    -- ^ @V.length msEntries@ cached for the scoring inner loop.
     }
 
 {- | Build 'MethodSetTables' from per-method 'MethodTables'. The list order
@@ -826,6 +835,7 @@ buildMethodSetTables pairs =
                     , msUuidIndex = M.empty
                     , msNFlows = 0
                     , msBroadcastMat = U.empty
+                    , msNMethods = nMethods
                     }
             else
                 let -- Union of all UUIDs covered by any method's broadcast,
@@ -836,19 +846,18 @@ buildMethodSetTables pairs =
                     uuidList = Set.toAscList uuidSet
                     uuidIndex = M.fromList (zip uuidList [0 ..])
                     nFlows = length uuidList
-                    -- Pack broadcasts row-major into one flat unboxed Vector.
-                    -- A full m × nFlows allocation is fine (PEF: 27 × ~10k ≈ 2 MB).
+                    -- Column-major: cell (i, j) = mat[j * nMethods + i].
+                    -- All m CFs for a single flow j are contiguous so the
+                    -- sparse-inventory scoring loop walks contiguous memory.
                     mat = U.create $ do
-                        mv <- MU.replicate (nMethods * nFlows) (0.0 :: Double)
-                        V.iforM_ entries $ \i e -> do
-                            let bcast = mtBroadcast (mseTables e)
-                                rowStart = i * nFlows
+                        mv <- MU.replicate (nFlows * nMethods) (0.0 :: Double)
+                        V.iforM_ entries $ \i e ->
                             mapM_
                                 ( \(uuid, cf) -> case M.lookup uuid uuidIndex of
-                                    Just j -> MU.unsafeWrite mv (rowStart + j) cf
+                                    Just j -> MU.unsafeWrite mv (j * nMethods + i) cf
                                     Nothing -> pure ()
                                 )
-                                (M.toList bcast)
+                                (M.toList (mtBroadcast (mseTables e)))
                         pure mv
                  in MethodSetTables
                         { msEntries = entries
@@ -856,6 +865,7 @@ buildMethodSetTables pairs =
                         , msUuidIndex = uuidIndex
                         , msNFlows = nFlows
                         , msBroadcastMat = mat
+                        , msNMethods = nMethods
                         }
 
 {- | Score an inventory against every method in a 'MethodSetTables'.
@@ -893,28 +903,35 @@ computeLCIAScoreSetFromTables unitCfg unitDB flowDB db scalingVec inventory hier
         ]
 
     batched =
-        let nFlows = msNFlows mst
-            nMethods = V.length (msEntries mst)
+        let nMethods = msNMethods mst
             mat = msBroadcastMat mst
-            invDense = U.create $ do
-                mv <- MU.replicate nFlows (0.0 :: Double)
-                M.foldlWithKey'
-                    ( \act uuid qty -> act >> case M.lookup uuid (msUuidIndex mst) of
-                        Just j | qty /= 0 -> MU.unsafeModify mv (+ qty) j
-                        _ -> pure ()
+            uuidIdx = msUuidIndex mst
+            -- Sparse walk: for each non-zero (uuid, qty) in the inventory,
+            -- find its dense row j (if any), then accumulate
+            --   scores[i] += qty * mat[j * nMethods + i]
+            -- across the m contiguous CFs at that row. nnz × m FMAs total,
+            -- contiguous reads — vs a dense matvec which would do
+            -- nFlows × m even when the inventory touches a small fraction.
+            scores = U.create $ do
+                mv <- MU.replicate nMethods (0.0 :: Double)
+                mapM_
+                    ( \(uuid, qty) ->
+                        if qty == 0
+                            then pure ()
+                            else case M.lookup uuid uuidIdx of
+                                Nothing -> pure ()
+                                Just j -> do
+                                    let rowStart = j * nMethods
+                                        loop !i
+                                            | i >= nMethods = pure ()
+                                            | otherwise = do
+                                                let !cf = U.unsafeIndex mat (rowStart + i)
+                                                MU.unsafeModify mv (+ qty * cf) i
+                                                loop (i + 1)
+                                    loop 0
                     )
-                    (pure ())
-                    inventory
+                    (M.toList inventory)
                 pure mv
-            scores = U.generate nMethods $ \i ->
-                let rowStart = i * nFlows
-                    !s =
-                        U.sum $
-                            U.zipWith
-                                (*)
-                                (U.unsafeSlice rowStart nFlows mat)
-                                invDense
-                 in s
          in [ (mseMethodId e, Right (scores U.! i))
             | (i, e) <- zip [0 ..] entries
             ]

--- a/test/CrossDBInventorySpec.hs
+++ b/test/CrossDBInventorySpec.hs
@@ -178,6 +178,7 @@ spec = do
                     , mtFallbackCF = M.empty
                     , mtRegionalizedCF = M.empty
                     , mtCompartmentMap = M.empty
+                    , mtBroadcast = M.empty
                     }
 
             inventory = M.fromList [(uuidRoot, 1.0), (uuidDep, 2.0), (uuidGone, 5.0)]

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -13,6 +13,7 @@ import Method.Types (Compartment (..), FlowDirection (..), MethodCF (..))
 import SynonymDB (buildFromPairs, emptySynonymDB)
 import Types (Flow (..), FlowType (..), Unit (..))
 import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig)
+import qualified UnitConversion
 
 -- ---------------------------------------------------------------------------
 -- Helpers
@@ -422,3 +423,100 @@ spec = do
                 byName = M.singleton "nox" [fWater, fUrbanAir]
                 comp = Compartment "air" "urban" ""
             fmap flowId (findFlowByNameComp byName "nox" (Just comp)) `shouldBe` Just fid1
+
+    describe "fillBroadcastVector + computeLCIAScoreFromTables (Phase 1)" $ do
+        let mkUnit uid name = Unit{unitId = uid, unitName = name, unitSymbol = name, unitComment = ""}
+
+        it "scoring with empty broadcast equals scoring with filled broadcast (UUID match)" $ do
+            fid <- nextRandom
+            uidKg <- nextRandom
+            let flow = (mkFlow fid "co2" "air" Nothing){flowUnitId = uidKg}
+                cf = (mkCF "co2" Nothing 2.5){mcfUnit = "kg"}
+                rawTables = buildMethodTables M.empty [(cf, Just (flow, ByUUID))]
+                flowDB = M.singleton fid flow
+                unitDB = M.singleton uidKg (mkUnit uidKg "kg")
+                inv = M.fromList [(fid, 4.0 :: Double)]
+                -- empty broadcast → legacy path
+                legacyScore = computeLCIAScoreFromTables defaultUnitConfig unitDB flowDB inv rawTables
+                -- filled broadcast → fast path
+                filled = fillBroadcastVector defaultUnitConfig unitDB flowDB rawTables
+                fastScore = computeLCIAScoreFromTables defaultUnitConfig unitDB flowDB inv filled
+            legacyScore `shouldBe` (4.0 * 2.5 :: Double)
+            fastScore `shouldBe` legacyScore
+
+        it "pre-multiplied broadcast equals legacy when CF unit absorbs into flow unit" $ do
+            -- Build a custom config with both kg and g (default config only has kg).
+            -- 1 g = 0.001 kg → factor 0.001 against the SI base.
+            let kgDef = UnitConversion.UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0
+                gDef = UnitConversion.UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0e-3
+                cfg =
+                    UnitConversion.UnitConfig
+                        { UnitConversion.ucDimensionOrder = []
+                        , UnitConversion.ucUnits = M.fromList [("kg", kgDef), ("g", gDef)]
+                        , UnitConversion.ucOriginalKeys = M.fromList [("kg", "kg"), ("g", "g")]
+                        }
+            fid <- nextRandom
+            uidKg <- nextRandom
+            let flow = (mkFlow fid "co2" "air" Nothing){flowUnitId = uidKg}
+                cf = (mkCF "co2" Nothing 1.0e-3){mcfUnit = "g"}
+                tables0 = buildMethodTables M.empty [(cf, Just (flow, ByUUID))]
+                flowDB = M.singleton fid flow
+                unitDB = M.singleton uidKg (mkUnit uidKg "kg")
+                inv = M.fromList [(fid, 1.0 :: Double)]
+                filled = fillBroadcastVector cfg unitDB flowDB tables0
+                fast = computeLCIAScoreFromTables cfg unitDB flowDB inv filled
+                legacy = computeLCIAScoreFromTables cfg unitDB flowDB inv tables0
+            -- Parity: pre-multiplication must match the on-the-fly path.
+            fast `shouldBe` legacy
+            -- 1 kg × convert(kg→g, 1) × 1e-3 (CF) = 1 × 1000 × 1e-3 = 1.0.
+            fast `shouldSatisfy` (\v -> abs (v - 1.0) < 1.0e-12)
+            -- Broadcast must be filled.
+            M.null (mtBroadcast filled) `shouldBe` False
+
+        it "broadcast covers exact (name, medium, subcomp) cascade" $ do
+            fid <- nextRandom
+            uidKg <- nextRandom
+            let flow = (mkFlow fid "co2" "air" (Just "high pop")){flowUnitId = uidKg}
+                cf = (mkCFComp "co2" "air" "high pop" 3.0){mcfUnit = "kg"}
+                tables0 = buildMethodTables M.empty [(cf, Just (flow, ByName))]
+                flowDB = M.singleton fid flow
+                unitDB = M.singleton uidKg (mkUnit uidKg "kg")
+                inv = M.fromList [(fid, 2.0 :: Double)]
+                filled = fillBroadcastVector defaultUnitConfig unitDB flowDB tables0
+                fast = computeLCIAScoreFromTables defaultUnitConfig unitDB flowDB inv filled
+                legacy = computeLCIAScoreFromTables defaultUnitConfig unitDB flowDB inv tables0
+            fast `shouldBe` legacy
+            fast `shouldBe` (2.0 * 3.0 :: Double)
+
+        it "broadcast covers fallback (name, medium) cascade" $ do
+            fid <- nextRandom
+            uidKg <- nextRandom
+            -- Flow has subcomp "high pop", but CF only has medium-level entry (subcomp "")
+            let flow = (mkFlow fid "co2" "air" (Just "high pop")){flowUnitId = uidKg}
+                cf = (mkCFComp "co2" "air" "" 5.0){mcfUnit = "kg"}
+                tables0 = buildMethodTables M.empty [(cf, Just (flow, ByName))]
+                flowDB = M.singleton fid flow
+                unitDB = M.singleton uidKg (mkUnit uidKg "kg")
+                inv = M.fromList [(fid, 1.0 :: Double)]
+                filled = fillBroadcastVector defaultUnitConfig unitDB flowDB tables0
+                fast = computeLCIAScoreFromTables defaultUnitConfig unitDB flowDB inv filled
+                legacy = computeLCIAScoreFromTables defaultUnitConfig unitDB flowDB inv tables0
+            fast `shouldBe` legacy
+            fast `shouldBe` (5.0 :: Double)
+
+        it "inventory UUID outside broadcast falls back to legacy lookup (cross-DB)" $ do
+            fidLocal <- nextRandom
+            fidExtra <- nextRandom -- in inventory but NOT in flowDB at fill time
+            uidKg <- nextRandom
+            let flowLocal = (mkFlow fidLocal "co2" "air" Nothing){flowUnitId = uidKg}
+                cf = (mkCF "co2" Nothing 1.5){mcfUnit = "kg"}
+                tables0 = buildMethodTables M.empty [(cf, Just (flowLocal, ByUUID))]
+                flowDBAtBuild = M.singleton fidLocal flowLocal
+                unitDB = M.singleton uidKg (mkUnit uidKg "kg")
+                filled = fillBroadcastVector defaultUnitConfig unitDB flowDBAtBuild tables0
+                -- Scoring time: inventory has fidExtra (cross-DB flow added later)
+                inv = M.fromList [(fidLocal, 2.0 :: Double), (fidExtra, 7.0)]
+                fast = computeLCIAScoreFromTables defaultUnitConfig unitDB flowDBAtBuild inv filled
+            -- fidLocal contributes 2.0 * 1.5 = 3.0; fidExtra has no CF → 0.
+            -- The fallback path must NOT crash on the unknown UUID.
+            fast `shouldBe` (3.0 :: Double)

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -200,9 +200,12 @@ spec = do
                         mst
             map snd results `shouldBe` [Right 0.0, Right 0.0]
 
-        it "inventory UUIDs outside any broadcast contribute 0 (silent skip)" $ do
+        it "inventory UUIDs absent from both broadcast and flowDB contribute 0" $ do
+            -- A UUID that exists nowhere — no broadcast row, no flowDB entry —
+            -- still scores zero because the per-method cascade fallback also
+            -- misses it (nothing for 'lookupCascadeCF' to anchor against).
             let fidIn = mkUuid 100
-                fidOut = mkUuid 999 -- in inventory only
+                fidOut = mkUuid 999 -- in inventory only, unreachable
                 uidKg = mkUuid 200
                 cf = mkCF fidIn 3.0
                 m1 = mkMethod 1 "m1" [cf]
@@ -225,6 +228,54 @@ spec = do
                         mst
             -- Only the matched flow contributes: 2 × 3 = 6.
             map snd results `shouldBe` [Right 6.0]
+
+        it "out-of-broadcast UUID resolved via mtUuidCF contributes via cascade fallback" $ do
+            -- Regression gate: a merged inventory carries UUIDs whose flows
+            -- were not in the root flowDB at 'fillBroadcastVector' time, so
+            -- they have no row in 'msBroadcastMat' and miss 'msUuidIndex'.
+            -- The CF table itself ('mtUuidCF', built from the full mapping
+            -- set) still resolves them — that's the per-method 'fastScore'
+            -- fallback ('lookupCascadeCF'). Before the cascade fallback in
+            -- the batched walker, those flows silently scored zero. This
+            -- test pins the equivalence.
+            let fidBuild = mkUuid 100 -- in build flowDB → in broadcast
+                fidCrossDB = mkUuid 999 -- in CF table + scoring flowDB, NOT in build flowDB
+                uidKg = mkUuid 200
+                cfBuild = mkCF fidBuild 3.0
+                cfCross = mkCF fidCrossDB 3.0
+                m1 = mkMethod 1 "m1" [cfBuild, cfCross]
+                -- flowDB at build time: only fidBuild. 'fillBroadcastVector'
+                -- walks this, so 'mtBroadcast' / 'msUuidIndex' = {fidBuild}.
+                buildFlowDB = M.singleton fidBuild (mkFlow fidBuild "co2" uidKg)
+                -- flowDB at scoring time (merged inventories carry more
+                -- flows than the root DB had at table-build time).
+                scoringFlowDB =
+                    M.fromList
+                        [ (fidBuild, mkFlow fidBuild "co2" uidKg)
+                        , (fidCrossDB, mkFlow fidCrossDB "co2" uidKg)
+                        ]
+                udb = M.singleton uidKg (mkUnit uidKg "kg")
+                t =
+                    fillBroadcastVector UnitConversion.defaultUnitConfig udb buildFlowDB $
+                        buildMethodTables
+                            M.empty
+                            [ (cfBuild, Just (mkFlow fidBuild "co2" uidKg, ByUUID))
+                            , (cfCross, Just (mkFlow fidCrossDB "co2" uidKg, ByUUID))
+                            ]
+                mst = buildMethodSetTables [(m1, t)]
+                inv = M.fromList [(fidBuild, 2.0), (fidCrossDB, 4.0)]
+                results =
+                    computeLCIAScoreSetFromTables
+                        UnitConversion.defaultUnitConfig
+                        udb
+                        scoringFlowDB
+                        unusedDatabase
+                        U.empty
+                        inv
+                        M.empty
+                        mst
+            -- Both contribute against CF=3: (2 + 4) × 3 = 18.
+            map snd results `shouldBe` [Right 18.0]
 
     describe "msEntries preserves caller-given order" $ do
         it "preserves the order methods were passed in" $ do

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -1,0 +1,244 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Tests for the multi-method scoring path: 'MethodSetTables' +
+'computeLCIAScoreSetFromTables'. Focused on correctness of the batched
+matvec vs per-method dispatch and on cache-key canonicality at the pure
+data-structure level.
+
+Cache lifecycle (TVar in 'DatabaseManager') is exercised indirectly by the
+existing route tests; here we keep dependencies minimal and test the pure
+functions directly.
+-}
+module MethodSetTablesSpec (spec) where
+
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as U
+import Test.Hspec
+
+import Matrix (Inventory)
+import Method.Mapping
+import Method.Types (Method (..), MethodCF (..))
+import qualified Method.Types as MT
+import Types (Database, Flow (..), FlowType (..), Unit (..))
+import qualified UnitConversion
+
+-- ---------------------------------------------------------------------------
+-- Fixtures
+-- ---------------------------------------------------------------------------
+
+mkUuid :: Int -> UUID
+mkUuid n = UUID.fromWords (fromIntegral n) 0 0 0
+
+mkUnit :: UUID -> Text -> Unit
+mkUnit uid name = Unit{unitId = uid, unitName = name, unitSymbol = name, unitComment = ""}
+
+mkFlow :: UUID -> Text -> UUID -> Flow
+mkFlow fid name uId =
+    Flow
+        { flowId = fid
+        , flowName = name
+        , flowCategory = "air"
+        , flowSubcompartment = Nothing
+        , flowUnitId = uId
+        , flowType = Biosphere
+        , flowSynonyms = M.empty
+        , flowCAS = Nothing
+        , flowSubstanceId = Nothing
+        }
+
+mkCF :: UUID -> Double -> MethodCF
+mkCF flowRef val =
+    MethodCF
+        { mcfFlowRef = flowRef
+        , mcfFlowName = "co2"
+        , mcfDirection = MT.Output
+        , mcfValue = val
+        , mcfCompartment = Nothing
+        , mcfCAS = Nothing
+        , mcfUnit = "kg"
+        , mcfConsumerLocation = Nothing
+        }
+
+mkMethod :: Int -> Text -> [MethodCF] -> Method
+mkMethod n name factors =
+    Method
+        { methodId = mkUuid n
+        , methodName = name
+        , methodDescription = Nothing
+        , methodUnit = "kg eq"
+        , methodCategory = name
+        , methodMethodology = Nothing
+        , methodFactors = factors
+        }
+
+-- The non-regio batched path never reads from the 'Database' argument; it
+-- lives only on the per-method (regio) branch. We pass 'undefined' to avoid
+-- wiring a heavyweight stub. This is safe under Haskell's laziness for the
+-- non-regio tests below.
+unusedDatabase :: Database
+unusedDatabase = error "Database value not used in non-regio scoring"
+
+-- ---------------------------------------------------------------------------
+-- Spec
+-- ---------------------------------------------------------------------------
+
+spec :: Spec
+spec = do
+    describe "buildMethodSetTables" $ do
+        it "marks msAnyRegional False when no method has regional CFs" $ do
+            let fid = mkUuid 100
+                uidKg = mkUuid 200
+                cf = mkCF fid 1.0
+                m1 = mkMethod 1 "m1" [cf]
+                tables0 = buildMethodTables M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))]
+                fdb = M.singleton fid (mkFlow fid "co2" uidKg)
+                udb = M.singleton uidKg (mkUnit uidKg "kg")
+                filled = fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb tables0
+                mst = buildMethodSetTables [(m1, filled)]
+            msAnyRegional mst `shouldBe` False
+            -- A single-method set still builds the matrix path
+            msNFlows mst `shouldBe` 1
+            U.length (msBroadcastMat mst) `shouldBe` 1
+
+        it "marks msAnyRegional True when any method has regional CFs" $ do
+            let fid = mkUuid 100
+                uidKg = mkUuid 200
+                cf = mkCF fid 1.0
+                tables0 =
+                    (buildMethodTables M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))])
+                        { mtRegionalizedCF = M.singleton (fid, "FR") (2.0, "kg")
+                        }
+                m1 = mkMethod 1 "m1" [cf]
+                fdb = M.singleton fid (mkFlow fid "co2" uidKg)
+                udb = M.singleton uidKg (mkUnit uidKg "kg")
+                filled = fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb tables0
+                mst = buildMethodSetTables [(m1, filled)]
+            msAnyRegional mst `shouldBe` True
+            -- Matvec scaffolding skipped when any method is regio.
+            msNFlows mst `shouldBe` 0
+            U.null (msBroadcastMat mst) `shouldBe` True
+
+    describe "computeLCIAScoreSetFromTables (non-regio batched matvec)" $ do
+        it "matches per-method computeLCIAScoreFromTables on a 3-method set" $ do
+            let fid1 = mkUuid 100
+                fid2 = mkUuid 101
+                uidKg = mkUuid 200
+                flow1 = mkFlow fid1 "co2" uidKg
+                flow2 = mkFlow fid2 "ch4" uidKg
+                fdb = M.fromList [(fid1, flow1), (fid2, flow2)]
+                udb = M.singleton uidKg (mkUnit uidKg "kg")
+
+                cfA1 = mkCF fid1 2.0 -- method A: co2=2, ch4 absent
+                cfB1 = mkCF fid1 1.0 -- method B: co2=1, ch4=25
+                cfB2 = (mkCF fid2 25.0){mcfFlowName = "ch4"}
+                cfC1 = mkCF fid1 0.5 -- method C: co2=0.5, ch4 absent
+
+                mA = mkMethod 1 "A" [cfA1]
+                mB = mkMethod 2 "B" [cfB1, cfB2]
+                mC = mkMethod 3 "C" [cfC1]
+
+                fill ts = fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb ts
+                tA = fill (buildMethodTables M.empty [(cfA1, Just (flow1, ByUUID))])
+                tB = fill (buildMethodTables M.empty [(cfB1, Just (flow1, ByUUID)), (cfB2, Just (flow2, ByUUID))])
+                tC = fill (buildMethodTables M.empty [(cfC1, Just (flow1, ByUUID))])
+
+                mst = buildMethodSetTables [(mA, tA), (mB, tB), (mC, tC)]
+
+                inv :: Inventory
+                inv = M.fromList [(fid1, 4.0), (fid2, 0.1)]
+
+                -- Per-method legacy scores (golden)
+                sA = computeLCIAScoreFromTables UnitConversion.defaultUnitConfig udb fdb inv tA
+                sB = computeLCIAScoreFromTables UnitConversion.defaultUnitConfig udb fdb inv tB
+                sC = computeLCIAScoreFromTables UnitConversion.defaultUnitConfig udb fdb inv tC
+
+                -- Batched scores via the set path
+                results =
+                    computeLCIAScoreSetFromTables
+                        UnitConversion.defaultUnitConfig
+                        udb
+                        fdb
+                        unusedDatabase
+                        U.empty -- scalingVec unused for non-regio
+                        inv
+                        M.empty -- hier unused for non-regio
+                        mst
+                resultMap = M.fromList results
+            -- Sanity: explicit numbers
+            sA `shouldBe` 8.0 -- 4*2 + 0.1*0 (no ch4 cf)
+            sB `shouldBe` 6.5 -- 4*1 + 0.1*25
+            sC `shouldBe` 2.0 -- 4*0.5 + 0
+            -- Set scoring matches per-method to the bit
+            M.lookup (methodId mA) resultMap `shouldBe` Just (Right sA)
+            M.lookup (methodId mB) resultMap `shouldBe` Just (Right sB)
+            M.lookup (methodId mC) resultMap `shouldBe` Just (Right sC)
+
+        it "empty inventory scores all methods to 0" $ do
+            let fid = mkUuid 100
+                uidKg = mkUuid 200
+                cf = mkCF fid 1.0
+                m1 = mkMethod 1 "m1" [cf]
+                m2 = mkMethod 2 "m2" [cf]
+                fdb = M.singleton fid (mkFlow fid "co2" uidKg)
+                udb = M.singleton uidKg (mkUnit uidKg "kg")
+                fill ts = fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb ts
+                t = fill (buildMethodTables M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))])
+                mst = buildMethodSetTables [(m1, t), (m2, t)]
+                results =
+                    computeLCIAScoreSetFromTables
+                        UnitConversion.defaultUnitConfig
+                        udb
+                        fdb
+                        unusedDatabase
+                        U.empty
+                        M.empty
+                        M.empty
+                        mst
+            map snd results `shouldBe` [Right 0.0, Right 0.0]
+
+        it "inventory UUIDs outside any broadcast contribute 0 (silent skip)" $ do
+            let fidIn = mkUuid 100
+                fidOut = mkUuid 999 -- in inventory only
+                uidKg = mkUuid 200
+                cf = mkCF fidIn 3.0
+                m1 = mkMethod 1 "m1" [cf]
+                fdb = M.singleton fidIn (mkFlow fidIn "co2" uidKg)
+                udb = M.singleton uidKg (mkUnit uidKg "kg")
+                t =
+                    fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb $
+                        buildMethodTables M.empty [(cf, Just (mkFlow fidIn "co2" uidKg, ByUUID))]
+                mst = buildMethodSetTables [(m1, t)]
+                inv = M.fromList [(fidIn, 2.0), (fidOut, 100.0)]
+                results =
+                    computeLCIAScoreSetFromTables
+                        UnitConversion.defaultUnitConfig
+                        udb
+                        fdb
+                        unusedDatabase
+                        U.empty
+                        inv
+                        M.empty
+                        mst
+            -- Only the matched flow contributes: 2 × 3 = 6.
+            map snd results `shouldBe` [Right 6.0]
+
+    describe "msEntries preserves caller-given order" $ do
+        it "preserves the order methods were passed in" $ do
+            let fid = mkUuid 100
+                uidKg = mkUuid 200
+                cf = mkCF fid 1.0
+                fdb = M.singleton fid (mkFlow fid "co2" uidKg)
+                udb = M.singleton uidKg (mkUnit uidKg "kg")
+                t =
+                    fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb $
+                        buildMethodTables M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))]
+                mB = mkMethod 2 "B" [cf]
+                mA = mkMethod 1 "A" [cf]
+                mC = mkMethod 3 "C" [cf]
+                mst = buildMethodSetTables [(mB, t), (mA, t), (mC, t)]
+                ids = V.toList $ V.map mseMethodId (msEntries mst)
+            ids `shouldBe` [methodId mB, methodId mA, methodId mC]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -28,6 +28,7 @@ import qualified MCPSchemaSpec
 import qualified MappingSpec
 import qualified MatrixConstructionSpec
 import qualified MatrixExportSpec
+import qualified MethodSetTablesSpec
 import qualified MethodSpec
 import qualified NestedSubstitutionSpec
 import qualified NormalizeSpec
@@ -75,6 +76,7 @@ main = hspec $ do
         describe "VOLCA_DATA_DIR resolution" ConfigSpec.spec
         describe "Loader" LoaderSpec.spec
         describe "Method Mapping" MappingSpec.spec
+        describe "Method Set Tables (multi-method scoring)" MethodSetTablesSpec.spec
         describe "Uploaded Database" UploadedDatabaseSpec.spec
         describe "Progress Formatting" ProgressSpec.spec
         describe "EcoSpold1 Parser" EcoSpold1Spec.spec

--- a/volca.cabal
+++ b/volca.cabal
@@ -180,6 +180,7 @@ test-suite lca-tests
                      , ConfigSpec
                      , LoaderSpec
                      , MappingSpec
+                     , MethodSetTablesSpec
                      , UploadedDatabaseSpec
                      , ProgressSpec
                      , EcoSpold1Spec

--- a/volca.cabal
+++ b/volca.cabal
@@ -221,3 +221,19 @@ test-suite lca-tests
                      , network-uri
 
   default-language:    Haskell2010
+
+benchmark multi-method-bench
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      bench
+  main-is:             MultiMethodBench.hs
+  ghc-options:         -O2 -rtsopts -with-rtsopts=-A32m
+  default-extensions:  NumericUnderscores
+  build-depends:       base >=4.14 && <5
+                     , volca
+                     , criterion
+                     , containers
+                     , text
+                     , uuid
+                     , vector
+                     , random
+  default-language:    Haskell2010


### PR DESCRIPTION
## Summary

LCIA scoring against the same inventory for many methods (e.g., the 27 PEF
categories on `getActivityLCIABatch` / `postActivityLCIABatch` /
`getProcessLCIABatch`) used to walk the inventory and run a 3-level CF
cascade + per-flow `convertUnit` once **per method**. With 27 methods,
that's 27× the same work even though every input is method-invariant.

This PR collapses the work in two layers:

- **Phase 1** — `mtBroadcast`: per-method `Map UUID Double` of effective
  CFs (CF × flow→CF unit factor) pre-multiplied at table-build time.
  Scoring becomes one `Map.lookup` + one multiply per inventory entry.
- **Phase 2** — `MethodSetTables`: cached per `(dbName, sortedMethodIds)`.
  Stacks every method's broadcast into one column-major flat
  `U.Vector Double` (cell `(i, j) = mat[j * m + i]`). Scoring is a sparse
  walk: for each non-zero `(uuid, qty)` find row `j`, accumulate
  `scores[i] += qty * mat[j*m + i]` across `m` contiguous CFs.
  `nnz × m` FMAs total, contiguous reads.

When any method in the set has regional CFs (`mtRegionalizedCF` non-empty),
the matvec scaffolding is skipped (`msAnyRegional == True`) and scoring
falls back to per-method `computeLCIAScoreAuto` — the regionalized path's
hierarchy walk + coverage check don't compose with the broadcast matvec.
Pure non-regio sets (PEF) get the full speedup; mixed sets pay the
existing per-method cost.

## Bench results

Criterion fixture: 10K biosphere flows, 27 methods, 500-flow sparse
inventory, `-O2`. Variance is severely inflated (~98%) so treat ratios
as orders of magnitude.

| Scenario | Before | After | Speedup |
|---|---:|---:|---:|
| Mono, same units | 36 μs | 33 μs | ~1× (legacy short-circuits) |
| Mono, cross units (`convertUnit` runs per flow) | 76 μs | 32 μs | ~2.3× |
| Multi 27, same units | 1050 μs | 42 μs | **~25×** |
| Multi 27, cross units | 953 μs | 42 μs | **~22×** |

Phase 1 alone is mostly noise when units already match (the common case
on ecoinvent). Phase 2 captures the ~22× win across the board.

## Cache & invalidation

`dmMethodSetTablesCache :: TVar (Map (Text, [UUID]) MethodSetTables)`
sits next to `dmMethodTablesCache`. Same purge semantics — any
`clearMethodMappingCache` / `-ForDb` call drops both. `MethodSetTables`
is fully derivable from the per-method `MethodTables` it references,
so there's no duplicated state to keep coherent.

Cache key is canonicalized to `sort (map methodId methods)` so that
subset-arbitrary requests share entries with named-collection ones
when the methods match.

## Out of scope (follow-ups)

- `inventoryContributions` / `processContributionsFromTables` /
  `computeRegionalizedLCIAScore` still do their own cascade + per-flow
  `convertUnit`. Could be unified with the broadcast pre-multiplication.
- No "artificially regionalized → demote to non-regio" detection (would
  let some EF3.1-adapted SimaPro methods join the matvec path).
- Bench machine has high variance; a quieter environment would tighten
  the numbers but the ratios are large enough to be qualitative.

## Test plan

- [x] `cabal test lca-tests`: 722 examples, 0 failures, 1 pending
  (pre-existing flaky `Server idle timeout`). New tests in
  `test/MappingSpec.hs` (broadcast pre-multiplication, cross-DB
  fallback) and `test/MethodSetTablesSpec.hs` (matvec parity vs
  per-method scoring, regio dispatch, ordering).
- [x] `cabal bench multi-method-bench`: see numbers above.
- [ ] End-to-end smoke test against a real DB + collection — not run
  here (worktree without loaded DBs); reviewer should verify the
  `getActivityLCIABatch` / `postActivityLCIABatch` paths still produce
  the same JSON output as `main`.