### PR TITLE
License compliance: relicense mumps-hs, add NOTICE/THIRD_PARTY_LICENSES, ship /api/v1/licenses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ cache/
 *.md
 !README.md
 !CHANGELOG.md
+!THIRD_PARTY_LICENSES.md
 !docs/**/*.md
 
 # temporary python stuff (not pyvolca/)

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,57 @@
+VoLCA — Life Cycle Assessment engine
+Copyright (c) 2024-present Christophe Combelles and contributors
+
+Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+==============================================================================
+This product includes third-party software. A detailed inventory with full
+copyright notices and license texts is in THIRD_PARTY_LICENSES.md and at the
+runtime endpoint /api/v1/licenses.
+
+The notable third-party components are:
+
+  * MUMPS 5.8.1 (sequential sparse direct solver) — CeCILL-C
+    https://mumps-solver.org/
+
+  * mumps-hs (Haskell FFI bindings to MUMPS) — Apache-2.0
+
+  * PORD (ordering library bundled with MUMPS) — public domain
+
+  * AMD ordering routines and *_TRUNCATED_RRQR variants (bundled with MUMPS)
+    — BSD 3-Clause
+
+  * BLAS, LAPACK (linked at runtime) — BSD 3-Clause
+
+  * Numerous Haskell libraries — predominantly BSD 3-Clause and MIT
+    (full table in THIRD_PARTY_LICENSES.md)
+
+==============================================================================
+MUMPS — required CeCILL-C copyright notice
+==============================================================================
+
+MUMPS is a software application for the direct solution of large sparse
+systems of linear equations on distributed memory parallel computers.
+
+  Copyright 1991–2024 CERFACS, CNRS, ENS Lyon, INP Toulouse, Inria,
+  Mumps Technologies, University of Bordeaux.
+
+This software is governed by the CeCILL-C license under French law and abiding
+by the rules of distribution of free software. You can use, modify and/or
+redistribute the software under the terms of the CeCILL-C license as
+circulated by CEA, CNRS and Inria at http://www.cecill.info.
+
+The unmodified MUMPS source code is available from the upstream project at
+https://mumps-solver.org/. CeCILL-C §5.3.1 entitles you to request it at no
+more than the cost of transfer.
+
+When citing MUMPS in academic work, please reference:
+
+  [1] P. R. Amestoy, I. S. Duff, J.-Y. L'Excellent and J. Koster.
+      A fully asynchronous multifrontal solver using distributed dynamic
+      scheduling. SIAM Journal on Matrix Analysis and Applications,
+      Vol 23, No 1, pp 15–41 (2001).
+
+  [2] P. R. Amestoy, A. Buttari, J.-Y. L'Excellent and T. Mary.
+      Performance and scalability of the block low-rank multifrontal
+      factorization on multicore architectures. ACM Transactions on
+      Mathematical Software, Vol 45, Issue 1, Article 2, pp 1–26 (2019).

--- a/README.md
+++ b/README.md
@@ -556,6 +556,14 @@ Tests cover matrix construction (sign convention), inventory calculation (golden
 
 ---
 
-## License
+## License & third-party software
 
-Apache License 2.0 — see LICENSE for details.
+VoLCA is licensed under the **Apache License 2.0** — see [LICENSE](LICENSE).
+
+Third-party components bundled with or linked into VoLCA are inventoried in
+[NOTICE](NOTICE) and [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md). The
+notable ones are MUMPS 5.8.1 (CeCILL-C), BLAS/LAPACK (BSD-3), and a number of
+Haskell libraries (predominantly BSD-3 and MIT).
+
+A running engine also exposes the same inventory as JSON at
+`/api/v1/licenses` so any client can render it.

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,114 @@
+# Third-party licenses
+
+VoLCA is licensed under the Apache License, Version 2.0 (see [LICENSE](LICENSE)).
+This document inventories the third-party software bundled with, or linked into,
+a VoLCA distribution. See also [NOTICE](NOTICE) for the abridged summary.
+
+## MUMPS 5.8.1 — CeCILL-C
+
+The MUMPS sequential sparse direct solver is statically linked into the VoLCA
+binary via the `mumps-hs` FFI bindings.
+
+- **License**: CeCILL-C (LGPL-compatible French free-software license).
+  Full text: <http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt>
+- **Upstream**: <https://mumps-solver.org/>
+- **Copyright**: 1991–2024 CERFACS, CNRS, ENS Lyon, INP Toulouse, Inria,
+  Mumps Technologies, University of Bordeaux.
+- **Source**: fetchable from the upstream URL above. CeCILL-C §5.3.1 entitles
+  you to request the unmodified source at no more than the cost of transfer.
+
+The MUMPS distribution embeds two further components covered by their own
+licenses:
+
+### PORD — public domain
+
+Ordering library by Jürgen Schulze, included in `MUMPS_5.8.1/PORD/`. Released
+into the public domain.
+
+### AMD variants and `*_TRUNCATED_RRQR` — BSD 3-Clause
+
+Approximate Minimum Degree ordering and rank-revealing QR variants distributed
+with MUMPS. BSD 3-Clause license; copyright held by the respective authors as
+declared in the source headers.
+
+## BLAS / LAPACK — BSD 3-Clause
+
+Linked at runtime as system shared libraries; not redistributed by VoLCA.
+
+- **License**: BSD 3-Clause. Full text: <https://www.netlib.org/lapack/LICENSE.txt>
+- **Upstream**: <https://www.netlib.org/lapack/>
+
+## mumps-hs — Apache-2.0
+
+Haskell FFI bindings to MUMPS, maintained inside this repository
+(`mumps-hs/`). Apache-2.0; copyright Christophe Combelles. See
+`mumps-hs/LICENSE`.
+
+## Haskell direct dependencies
+
+The following table covers the libraries declared in `volca.cabal`'s
+`build-depends`. Transitive dependencies are not listed individually; their
+licenses are uniformly BSD-style or MIT and can be re-derived from a fresh
+`cabal-plan license-report` run.
+
+| Package | License | Source |
+|---|---|---|
+| aeson | BSD-3-Clause | <https://hackage.haskell.org/package/aeson> |
+| aeson-pretty | BSD-3-Clause | <https://hackage.haskell.org/package/aeson-pretty> |
+| async | BSD-3-Clause | <https://hackage.haskell.org/package/async> |
+| base | BSD-3-Clause (with GHC exceptions) | bundled with GHC |
+| base64-bytestring | BSD-3-Clause | <https://hackage.haskell.org/package/base64-bytestring> |
+| bytestring | BSD-3-Clause | bundled with GHC |
+| cassava | BSD-3-Clause | <https://hackage.haskell.org/package/cassava> |
+| conduit | MIT | <https://hackage.haskell.org/package/conduit> |
+| containers | BSD-3-Clause | bundled with GHC |
+| deepseq | BSD-3-Clause | bundled with GHC |
+| directory | BSD-3-Clause | bundled with GHC |
+| filelock | CC0-1.0 | <https://hackage.haskell.org/package/filelock> |
+| filepath | BSD-3-Clause | bundled with GHC |
+| hashable | BSD-3-Clause | <https://hackage.haskell.org/package/hashable> |
+| haskeline | BSD-3-Clause | <https://hackage.haskell.org/package/haskeline> |
+| http-client | MIT | <https://hackage.haskell.org/package/http-client> |
+| http-types | BSD-3-Clause | <https://hackage.haskell.org/package/http-types> |
+| insert-ordered-containers | BSD-3-Clause | <https://hackage.haskell.org/package/insert-ordered-containers> |
+| lens | BSD-2-Clause | <https://hackage.haskell.org/package/lens> |
+| megaparsec | BSD-2-Clause | <https://hackage.haskell.org/package/megaparsec> |
+| mtl | BSD-3-Clause | bundled with GHC |
+| network-uri | BSD-3-Clause | <https://hackage.haskell.org/package/network-uri> |
+| openapi3 | BSD-3-Clause | <https://hackage.haskell.org/package/openapi3> |
+| optparse-applicative | BSD-3-Clause | <https://hackage.haskell.org/package/optparse-applicative> |
+| parallel | BSD-3-Clause | bundled with GHC |
+| process | BSD-3-Clause | bundled with GHC |
+| random | BSD-3-Clause | bundled with GHC |
+| scientific | BSD-3-Clause | <https://hackage.haskell.org/package/scientific> |
+| servant | BSD-3-Clause | <https://hackage.haskell.org/package/servant> |
+| servant-multipart | BSD-3-Clause | <https://hackage.haskell.org/package/servant-multipart> |
+| servant-openapi3 | BSD-3-Clause | <https://hackage.haskell.org/package/servant-openapi3> |
+| servant-server | BSD-3-Clause | <https://hackage.haskell.org/package/servant-server> |
+| stm | BSD-3-Clause | bundled with GHC |
+| store | MIT | <https://hackage.haskell.org/package/store> |
+| streaming-commons | MIT | <https://hackage.haskell.org/package/streaming-commons> |
+| temporary | BSD-3-Clause | <https://hackage.haskell.org/package/temporary> |
+| text | BSD-2-Clause | bundled with GHC |
+| time | BSD-3-Clause | bundled with GHC |
+| toml-reader | BSD-3-Clause | <https://hackage.haskell.org/package/toml-reader> |
+| transformers | BSD-3-Clause | bundled with GHC |
+| unicode-transforms | BSD-3-Clause | <https://hackage.haskell.org/package/unicode-transforms> |
+| uuid | BSD-3-Clause | <https://hackage.haskell.org/package/uuid> |
+| vector | BSD-3-Clause | <https://hackage.haskell.org/package/vector> |
+| wai | MIT | <https://hackage.haskell.org/package/wai> |
+| wai-app-static | MIT | <https://hackage.haskell.org/package/wai-app-static> |
+| wai-cors | MIT | <https://hackage.haskell.org/package/wai-cors> |
+| warp | MIT | <https://hackage.haskell.org/package/warp> |
+| xeno | BSD-3-Clause | <https://hackage.haskell.org/package/xeno> |
+| xml-types | MIT | <https://hackage.haskell.org/package/xml-types> |
+| zstd | BSD-3-Clause | <https://hackage.haskell.org/package/zstd> |
+
+## Regenerating this list
+
+After `cabal build all`, the canonical license for every direct dep is in the
+matching `~/.cabal/store/ghc-<ver>/package.db/<name>-<version>-<hash>.conf`
+file (`grep ^license:`). The list above was last reconciled by reading those
+conf files for every entry of `volca:lib:volca`'s `depends` set in
+`dist-newstyle/cache/plan.json`. Re-run that reconciliation at release time
+and update any drifted entries.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main where
@@ -246,67 +247,46 @@ createServerApp dbManager maxTreeDepth staticDir desktopMode password hostingCon
             putStrLn $ C8.unpack (requestMethod req) ++ " " ++ C8.unpack fullUrl
             hFlush stdout
 
-        -- Route requests based on path prefix
-        if path == "/mcp"
-            then mcp req respond
-            else
-                if path == "/api/v1/openapi.json"
-                    then
+        -- Route requests based on path prefix.
+        let staticSettings =
+                (defaultWebAppSettings staticDir)
+                    { ssIndices = [unsafeToPiece (T.pack "index.html")]
+                    , ssMaxAge = NoMaxAge
+                    }
+
+            serveStripped =
+                let strippedPath = BS.drop 7 path
+                    newPathInfo = case pathInfo req of
+                        (segment : rest) | segment == T.pack "static" -> rest
+                        other -> other
+                    staticReq = req{rawPathInfo = strippedPath, pathInfo = newPathInfo}
+                 in staticApp staticSettings staticReq respond
+
+            serveSpaIndex =
+                let indexReq = req{rawPathInfo = C8.pack "/", pathInfo = []}
+                    noCacheRespond res =
                         respond $
-                            responseLBS
-                                status200
-                                [(hContentType, "application/json")]
-                                openApiJson
-                    else
-                        if path == "/api/v1/licenses"
-                            then respond licensesResponse
-                            else
-                                if path == "/api/v1/docs"
-                                    then
-                                        respond $
-                                            responseLBS
-                                                status200
-                                                [(hContentType, "text/html; charset=utf-8")]
-                                                swaggerHtml
-                                    else
-                                        if path == "/api/v1/logs/stream"
-                                            then handleLogStream req respond
-                                            else
-                                                if C8.pack "/api/" `BS.isPrefixOf` path
-                                                    then
-                                                        serve lcaAPI (lcaServer dbManager maxTreeDepth password hostingConfig filterPresets) req respond
-                                                    else
-                                                        if C8.pack "/static/" `BS.isPrefixOf` path
-                                                            then
-                                                                let strippedPath = BS.drop 7 path
-                                                                    originalPathInfo = pathInfo req
-                                                                    newPathInfo = case originalPathInfo of
-                                                                        (segment : rest) | segment == T.pack "static" -> rest
-                                                                        other -> other
-                                                                    staticReq = req{rawPathInfo = strippedPath, pathInfo = newPathInfo}
-                                                                    staticSettings =
-                                                                        (defaultWebAppSettings staticDir)
-                                                                            { ssIndices = [unsafeToPiece (T.pack "index.html")]
-                                                                            , ssMaxAge = NoMaxAge
-                                                                            }
-                                                                 in staticApp staticSettings staticReq respond
-                                                            else
-                                                                let staticSettings =
-                                                                        (defaultWebAppSettings staticDir)
-                                                                            { ssIndices = [unsafeToPiece (T.pack "index.html")]
-                                                                            , ssMaxAge = NoMaxAge
-                                                                            }
-                                                                    indexReq = req{rawPathInfo = C8.pack "/", pathInfo = []}
-                                                                    noCacheRespond res =
-                                                                        respond $
-                                                                            mapResponseHeaders
-                                                                                ( \hs ->
-                                                                                    (hCacheControl, C8.pack "no-cache, no-store, must-revalidate")
-                                                                                        : (hPragma, C8.pack "no-cache")
-                                                                                        : hs
-                                                                                )
-                                                                                res
-                                                                 in staticApp staticSettings indexReq noCacheRespond
+                            mapResponseHeaders
+                                ( \hs ->
+                                    (hCacheControl, C8.pack "no-cache, no-store, must-revalidate")
+                                        : (hPragma, C8.pack "no-cache")
+                                        : hs
+                                )
+                                res
+                 in staticApp staticSettings indexReq noCacheRespond
+
+        if
+            | path == "/mcp" -> mcp req respond
+            | path == "/api/v1/openapi.json" ->
+                respond $ responseLBS status200 [(hContentType, "application/json")] openApiJson
+            | path == "/api/v1/licenses" -> respond licensesResponse
+            | path == "/api/v1/docs" ->
+                respond $ responseLBS status200 [(hContentType, "text/html; charset=utf-8")] swaggerHtml
+            | path == "/api/v1/logs/stream" -> handleLogStream req respond
+            | C8.pack "/api/" `BS.isPrefixOf` path ->
+                serve lcaAPI (lcaServer dbManager maxTreeDepth password hostingConfig filterPresets) req respond
+            | C8.pack "/static/" `BS.isPrefixOf` path -> serveStripped
+            | otherwise -> serveSpaIndex
 
 -- | SSE endpoint for real-time log streaming
 handleLogStream :: Request -> (Response -> IO ResponseReceived) -> IO ResponseReceived

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -33,6 +33,7 @@ import Network.HTTP.Client (defaultManagerSettings, newManager)
 import Progress
 
 -- For server mode
+import API.Licenses (licensesResponse)
 import API.MCP (mcpApp, toolDefinitions)
 import API.Routes (lcaAPI, lcaServer, volcaOpenApi)
 import Data.Aeson (encode)
@@ -257,52 +258,55 @@ createServerApp dbManager maxTreeDepth staticDir desktopMode password hostingCon
                                 [(hContentType, "application/json")]
                                 openApiJson
                     else
-                        if path == "/api/v1/docs"
-                            then
-                                respond $
-                                    responseLBS
-                                        status200
-                                        [(hContentType, "text/html; charset=utf-8")]
-                                        swaggerHtml
+                        if path == "/api/v1/licenses"
+                            then respond licensesResponse
                             else
-                                if path == "/api/v1/logs/stream"
-                                    then handleLogStream req respond
+                                if path == "/api/v1/docs"
+                                    then
+                                        respond $
+                                            responseLBS
+                                                status200
+                                                [(hContentType, "text/html; charset=utf-8")]
+                                                swaggerHtml
                                     else
-                                        if C8.pack "/api/" `BS.isPrefixOf` path
-                                            then
-                                                serve lcaAPI (lcaServer dbManager maxTreeDepth password hostingConfig filterPresets) req respond
+                                        if path == "/api/v1/logs/stream"
+                                            then handleLogStream req respond
                                             else
-                                                if C8.pack "/static/" `BS.isPrefixOf` path
+                                                if C8.pack "/api/" `BS.isPrefixOf` path
                                                     then
-                                                        let strippedPath = BS.drop 7 path
-                                                            originalPathInfo = pathInfo req
-                                                            newPathInfo = case originalPathInfo of
-                                                                (segment : rest) | segment == T.pack "static" -> rest
-                                                                other -> other
-                                                            staticReq = req{rawPathInfo = strippedPath, pathInfo = newPathInfo}
-                                                            staticSettings =
-                                                                (defaultWebAppSettings staticDir)
-                                                                    { ssIndices = [unsafeToPiece (T.pack "index.html")]
-                                                                    , ssMaxAge = NoMaxAge
-                                                                    }
-                                                         in staticApp staticSettings staticReq respond
+                                                        serve lcaAPI (lcaServer dbManager maxTreeDepth password hostingConfig filterPresets) req respond
                                                     else
-                                                        let staticSettings =
-                                                                (defaultWebAppSettings staticDir)
-                                                                    { ssIndices = [unsafeToPiece (T.pack "index.html")]
-                                                                    , ssMaxAge = NoMaxAge
-                                                                    }
-                                                            indexReq = req{rawPathInfo = C8.pack "/", pathInfo = []}
-                                                            noCacheRespond res =
-                                                                respond $
-                                                                    mapResponseHeaders
-                                                                        ( \hs ->
-                                                                            (hCacheControl, C8.pack "no-cache, no-store, must-revalidate")
-                                                                                : (hPragma, C8.pack "no-cache")
-                                                                                : hs
-                                                                        )
-                                                                        res
-                                                         in staticApp staticSettings indexReq noCacheRespond
+                                                        if C8.pack "/static/" `BS.isPrefixOf` path
+                                                            then
+                                                                let strippedPath = BS.drop 7 path
+                                                                    originalPathInfo = pathInfo req
+                                                                    newPathInfo = case originalPathInfo of
+                                                                        (segment : rest) | segment == T.pack "static" -> rest
+                                                                        other -> other
+                                                                    staticReq = req{rawPathInfo = strippedPath, pathInfo = newPathInfo}
+                                                                    staticSettings =
+                                                                        (defaultWebAppSettings staticDir)
+                                                                            { ssIndices = [unsafeToPiece (T.pack "index.html")]
+                                                                            , ssMaxAge = NoMaxAge
+                                                                            }
+                                                                 in staticApp staticSettings staticReq respond
+                                                            else
+                                                                let staticSettings =
+                                                                        (defaultWebAppSettings staticDir)
+                                                                            { ssIndices = [unsafeToPiece (T.pack "index.html")]
+                                                                            , ssMaxAge = NoMaxAge
+                                                                            }
+                                                                    indexReq = req{rawPathInfo = C8.pack "/", pathInfo = []}
+                                                                    noCacheRespond res =
+                                                                        respond $
+                                                                            mapResponseHeaders
+                                                                                ( \hs ->
+                                                                                    (hCacheControl, C8.pack "no-cache, no-store, must-revalidate")
+                                                                                        : (hPragma, C8.pack "no-cache")
+                                                                                        : hs
+                                                                                )
+                                                                                res
+                                                                 in staticApp staticSettings indexReq noCacheRespond
 
 -- | SSE endpoint for real-time log streaming
 handleLogStream :: Request -> (Response -> IO ResponseReceived) -> IO ResponseReceived

--- a/mumps-hs/LICENSE
+++ b/mumps-hs/LICENSE
@@ -1,0 +1,167 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other transformations
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including the
+      original version of the Work and any modifications or additions to
+      that Work or Derivative Works of the Work, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright
+      owner or by an individual or Legal Entity authorized to submit on
+      behalf of the copyright owner.
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and incorporated
+      within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those Contributions made by
+      such Contributor as patent licenses necessarily infringed by their
+      Contribution(s) alone or by the combined work. If You institute patent
+      litigation against any entity (including a cross-claim or counterclaim
+      in a lawsuit) alleging that the Work or any related Contribution
+      constitutes patent or contributory patent infringement, then any patent
+      licenses granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or in addition to the
+          NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or reproducing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or all other
+      commercial damages or losses), even if such Contributor has been
+      advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may offer only
+      conditions consistent with this License.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025 Christophe Combelles
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/mumps-hs/cbits/mumps_wrapper.c
+++ b/mumps-hs/cbits/mumps_wrapper.c
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2024-present Christophe Combelles
+ */
+
 #include "mumps_wrapper.h"
 #include <dmumps_c.h>
 #include <stdlib.h>

--- a/mumps-hs/cbits/mumps_wrapper.h
+++ b/mumps-hs/cbits/mumps_wrapper.h
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2024-present Christophe Combelles
+ */
+
 #ifndef MUMPS_WRAPPER_H
 #define MUMPS_WRAPPER_H
 

--- a/mumps-hs/mumps-hs.cabal
+++ b/mumps-hs/mumps-hs.cabal
@@ -2,7 +2,11 @@ cabal-version:  2.4
 name:           mumps-hs
 version:        0.1.0.0
 synopsis:       Haskell bindings for MUMPS sequential sparse direct solver
-license:        AGPL-3.0-or-later
+license:        Apache-2.0
+license-file:   LICENSE
+copyright:      Copyright (c) 2024-present Christophe Combelles
+author:         Christophe Combelles
+maintainer:     ccomb@free.fr
 build-type:     Simple
 
 library

--- a/mumps-hs/src/Numerical/MUMPS.hs
+++ b/mumps-hs/src/Numerical/MUMPS.hs
@@ -1,3 +1,6 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) 2024-present Christophe Combelles
+
 {- | Haskell bindings for MUMPS sequential direct sparse solver.
 
 Provides a thin, safe wrapper around MUMPS_SEQ for solving

--- a/mumps-hs/src/Numerical/MUMPS/FFI.hs
+++ b/mumps-hs/src/Numerical/MUMPS/FFI.hs
@@ -1,3 +1,6 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) 2024-present Christophe Combelles
+
 module Numerical.MUMPS.FFI (
     MumpsSolverC,
     c_mumps_create,

--- a/mumps-hs/src/Numerical/MUMPS/Solver.hs
+++ b/mumps-hs/src/Numerical/MUMPS/Solver.hs
@@ -1,3 +1,6 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) 2024-present Christophe Combelles
+
 module Numerical.MUMPS.Solver (
     mumpsCreate,
     mumpsAnalyze,

--- a/mumps-hs/src/Numerical/MUMPS/Types.hs
+++ b/mumps-hs/src/Numerical/MUMPS/Types.hs
@@ -1,3 +1,6 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) 2024-present Christophe Combelles
+
 module Numerical.MUMPS.Types (
     MUMPSSolver (..),
     MUMPSError (..),

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -2,7 +2,7 @@
 
 Python client for [VoLCA](https://github.com/ccomb/volca) — Life Cycle Assessment engine over Agribalyse and ecoinvent.
 
-> **Full guide and tutorials**: <https://volca.run/docs/guides/pyvolca/>
+> **Full guide and tutorials**: <https://volca.run/docs/python/>
 > **Issues / source**: <https://github.com/ccomb/volca>
 
 ## Install
@@ -76,7 +76,7 @@ with Server(config="volca.toml") as srv:
     c = Client(base_url=srv.base_url, db="agribalyse-3.2", password=srv.password)
     plants = c.search_activities(name="wheat flour, at plant", limit=5)
     chain = c.get_supply_chain(plants[0].process_id, name="at farm")
-    score = c.get_impacts(plants[0].process_id, method_id=c.list_methods()[0]["methodId"])
+    score = c.get_impacts(plants[0].process_id, method_id=c.list_methods()[0]["id"])
 ```
 
 This example starts a local engine process from Python. `Server` reads `port` and `password` from the TOML config. The engine self-stops after `idle_timeout` seconds without traffic (default 5 min).
@@ -92,7 +92,7 @@ for db in c.list_databases():
     print(f"  {db.name} [{db.status}]: {db.activity_count} activities")
 
 for m in c.list_methods()[:5]:
-    print(f"  {m['methodId']}  {m['name']} [{m['unit']}]")
+    print(f"  {m['id']}  {m['name']} [{m['unit']}]")
 ```
 
 Other listings: `c.list_classifications()` returns the classification systems and their values for the current database; `c.list_presets()` returns named filter presets configured in the engine. Use `c.load_database(name)` / `c.unload_database(name)` to manage memory if a database isn't auto-loaded.
@@ -299,6 +299,7 @@ Pyvolca dispatches dynamically against the engine's OpenAPI spec, so it ships wi
 ## API reference
 
 <!-- BEGIN: api-reference -->
+
 _This reference is generated from the installed package. Run `python scripts/gen_api_md.py` to regenerate._
 
 ## Classes
@@ -489,7 +490,7 @@ An exchange with the environment (resource extraction or emission).
 
 Filter a supply-chain/consumers query by a classification (system, value, mode).
 
-Matches one classification system entry (e.g. ("Category", "Agricultural\Food",
+Matches one classification system entry (e.g. ("Category", "Agricultural\\Food",
 "exact")). Mode is "exact" (case-insensitive equality) or "contains" (substring).
 Multiple filters are AND-combined by the server.
 
@@ -755,12 +756,11 @@ Returns:
 
 Type alias: `Union[TechnosphereExchange, BiosphereExchange]`.
 
-
 <!-- END: api-reference -->
 
 ## See also
 
-- Full guide and tutorials: <https://volca.run/docs/guides/pyvolca/>
+- Full guide and tutorials: <https://volca.run/docs/python/>
 - VoLCA engine: <https://github.com/ccomb/volca>
 - Examples folder: [`examples/`](examples/)
 

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -865,9 +865,9 @@ class Client:
         """List every LCIA method available in the engine.
 
         Returns:
-            Raw method dicts; each carries ``methodId``, ``name``,
+            Raw method dicts; each carries ``id``, ``name``,
             ``unit``, ``collection``, and the impact category metadata.
-            Pass any ``methodId`` to :meth:`get_impacts`.
+            Pass any ``id`` value to :meth:`get_impacts` as ``method_id``.
         """
         return self._call("list_methods")
 

--- a/pyvolca/tests/conftest.py
+++ b/pyvolca/tests/conftest.py
@@ -351,7 +351,7 @@ def readme_namespace() -> dict[str, Any]:
         ),
     ]
     c.list_methods.return_value = [
-        {"methodId": "EF3.1-climate-change", "name": "Climate change", "unit": "kg CO2 eq"},
+        {"id": "EF3.1-climate-change", "name": "Climate change", "unit": "kg CO2 eq"},
     ]
     c.list_classifications.return_value = [
         {"system": "ISIC rev.4 ecoinvent", "values": ["1061", "1071", "0111"]},

--- a/src/API/Licenses.hs
+++ b/src/API/Licenses.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Licenses & third-party attribution payload served at @/api/v1/licenses@.
+
+CeCILL-C §6.4 requires that the bundled MUMPS notice be easily accessible
+from the application interface. Apache-2.0 §4(d) requires that we propagate
+attribution for every component we redistribute. This module exposes the
+canonical inventory as a stable JSON shape so any client (web SPA, desktop,
+MCP, pyvolca) can fetch and render it without duplicating the data.
+
+The payload is a hand-written constant — small, no IO, no partial functions.
+Keep it in sync with @NOTICE@ and @THIRD_PARTY_LICENSES.md@ at the repo root.
+-}
+module API.Licenses (licensesJson, licensesResponse) where
+
+import Data.Aeson (Value, encode, object, (.=))
+import qualified Data.ByteString.Lazy as BL
+import Data.Text (Text)
+import Network.HTTP.Types (hContentType, status200)
+import Network.Wai (Response, responseLBS)
+import qualified Version
+
+licensesJson :: BL.ByteString
+licensesJson = encode licensesValue
+
+{- | The fully-formed HTTP response served at @/api/v1/licenses@. Exported so
+the dispatcher in @app\/Main.hs@ stays a one-liner and tests can assert on
+status\/headers without spinning up a server.
+-}
+licensesResponse :: Response
+licensesResponse =
+    responseLBS
+        status200
+        [(hContentType, "application/json; charset=utf-8")]
+        licensesJson
+
+licensesValue :: Value
+licensesValue =
+    object
+        [ "engine"
+            .= object
+                [ "name" .= ("VoLCA" :: Text)
+                , "version" .= Version.version
+                , "license" .= ("Apache-2.0" :: Text)
+                , "copyright" .= ("Copyright (c) 2024-present Christophe Combelles and contributors" :: Text)
+                , "homepage" .= ("https://volca.run/" :: Text)
+                ]
+        , "components" .= componentList
+        , "haskell_dependencies_url" .= ("https://github.com/ccomb/volca/blob/main/THIRD_PARTY_LICENSES.md" :: Text)
+        ]
+
+componentList :: [Value]
+componentList =
+    [ component
+        "MUMPS"
+        (Just "5.8.1")
+        "CeCILL-C"
+        (Just "Copyright 1991-2024 CERFACS, CNRS, ENS Lyon, INP Toulouse, Inria, Mumps Technologies, University of Bordeaux.")
+        (Just "https://mumps-solver.org/")
+        Nothing
+    , component
+        "mumps-hs"
+        Nothing
+        "Apache-2.0"
+        (Just "Copyright (c) 2024-present Christophe Combelles")
+        (Just "https://github.com/ccomb/volca/tree/main/mumps-hs")
+        Nothing
+    , component
+        "PORD (bundled in MUMPS)"
+        Nothing
+        "Public domain"
+        (Just "Juergen Schulze")
+        Nothing
+        Nothing
+    , component
+        "AMD ordering and *_TRUNCATED_RRQR variants (bundled in MUMPS)"
+        Nothing
+        "BSD-3-Clause"
+        Nothing
+        Nothing
+        Nothing
+    , component
+        "BLAS"
+        Nothing
+        "BSD-3-Clause"
+        Nothing
+        (Just "https://www.netlib.org/blas/")
+        Nothing
+    , component
+        "LAPACK"
+        Nothing
+        "BSD-3-Clause"
+        Nothing
+        (Just "https://www.netlib.org/lapack/")
+        Nothing
+    ]
+
+component :: Text -> Maybe Text -> Text -> Maybe Text -> Maybe Text -> Maybe Text -> Value
+component name mVersion lic mCopyright mHomepage mSource =
+    object
+        [ "name" .= name
+        , "version" .= mVersion
+        , "license" .= lic
+        , "copyright" .= mCopyright
+        , "homepage" .= mHomepage
+        , "source" .= mSource
+        ]

--- a/test/LicensesSpec.hs
+++ b/test/LicensesSpec.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module LicensesSpec (spec) where
+
+import Data.Aeson (Value (..), decode)
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KM
+import Data.Text (Text)
+import qualified Data.Vector as V
+import Network.HTTP.Types (hContentType, statusCode)
+import Network.Wai (responseHeaders, responseStatus)
+import Test.Hspec
+
+import API.Licenses (licensesJson, licensesResponse)
+
+-- The /api/v1/licenses payload is a stable contract: clients (web SPA, desktop,
+-- pyvolca) decode it without negotiation. These tests guard the shape so a
+-- refactor doesn't silently break a downstream renderer.
+
+spec :: Spec
+spec = describe "/api/v1/licenses payload" $ do
+    it "is valid JSON" $ do
+        let parsed = decode licensesJson :: Maybe Value
+        parsed `shouldSatisfy` isJust
+
+    it "declares the engine as Apache-2.0" $ do
+        let lic = lookupPath ["engine", "license"] =<< decode licensesJson
+        lic `shouldBe` Just (String "Apache-2.0")
+
+    it "exposes a non-empty components list" $ do
+        let cs = lookupPath ["components"] =<< decode licensesJson
+        case cs of
+            Just (Array v) -> V.length v `shouldSatisfy` (>= 4)
+            _ -> expectationFailure "components is missing or not an array"
+
+    it "lists MUMPS as a CeCILL-C component" $ do
+        let mumps = do
+                Array cs <- lookupPath ["components"] =<< decode licensesJson
+                find (componentNamed "MUMPS") (V.toList cs)
+        mumps `shouldSatisfy` isJust
+        let licField = lookupPath ["license"] =<< mumps
+        licField `shouldBe` Just (String "CeCILL-C")
+
+    it "points clients at the Haskell-deps markdown" $ do
+        let url = lookupPath ["haskell_dependencies_url"] =<< decode licensesJson
+        url `shouldBe` Just (String "https://github.com/ccomb/volca/blob/main/THIRD_PARTY_LICENSES.md")
+
+    it "wraps the JSON in a 200 response with the right content-type" $ do
+        statusCode (responseStatus licensesResponse) `shouldBe` 200
+        lookup hContentType (responseHeaders licensesResponse)
+            `shouldBe` Just "application/json; charset=utf-8"
+
+-- helpers
+
+isJust :: Maybe a -> Bool
+isJust (Just _) = True
+isJust Nothing = False
+
+lookupPath :: [Text] -> Value -> Maybe Value
+lookupPath [] v = Just v
+lookupPath (k : ks) (Object o) = lookupPath ks =<< KM.lookup (Key.fromText k) o
+lookupPath _ _ = Nothing
+
+componentNamed :: Text -> Value -> Bool
+componentNamed expected v = case lookupPath ["name"] v of
+    Just (String n) -> n == expected
+    _ -> False
+
+find :: (a -> Bool) -> [a] -> Maybe a
+find _ [] = Nothing
+find p (x : xs) = if p x then Just x else find p xs

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -20,6 +20,7 @@ import qualified FuzzySpec
 import qualified HotspotSpec
 import qualified ILCDParserSpec
 import qualified InventorySpec
+import qualified LicensesSpec
 import qualified LoaderSpec
 import qualified MCPSchemaSpec
 import qualified MappingSpec
@@ -80,3 +81,4 @@ main = hspec $ do
         describe "Search.Fuzzy" FuzzySpec.spec
         describe "Nested Substitutions" NestedSubstitutionSpec.spec
         describe "Database Status (depends_on)" DatabaseStatusSpec.spec
+        describe "Licenses Endpoint" LicensesSpec.spec

--- a/volca.cabal
+++ b/volca.cabal
@@ -52,6 +52,7 @@ library
                      , API.MCP
                      , API.OpenApi
                      , API.Resources
+                     , API.Licenses
                      , CLI.Types
                      , CLI.Parser
                      , CLI.Command
@@ -191,6 +192,7 @@ test-suite lca-tests
                      , CrossDBSubstitutionSpec
                      , DatabaseStatusSpec
                      , OlcaSchemaSpec
+                     , LicensesSpec
   build-depends:       base >=4.14 && <5
                      , volca
                      , hspec


### PR DESCRIPTION
## Summary

Brings VoLCA into license compliance for both binary and SaaS distribution.

- **Relicense `mumps-hs/` from AGPL-3.0-or-later to Apache-2.0.**
- **Add `NOTICE` and `THIRD_PARTY_LICENSES.md`** at the repo root. Required by Apache-2.0 §4(d) for downstream attribution and by CeCILL-C §6.4 for the bundled MUMPS notice. Includes the mandatory MUMPS copyright block (CERFACS, CNRS, ENS Lyon, INP Toulouse, Inria, Mumps Technologies, University of Bordeaux), academic citations, and a per-direct-dep license table reconciled against the cabal store.
- **Ship `/api/v1/licenses`** returning the canonical inventory as JSON, so any client can render attribution without duplicating the data. Satisfies CeCILL-C §6.4 ("easily accessible from the application interface") for SaaS clients.
- **Flatten the request dispatcher** in `app/Main.hs` from an 8-level nested if-then-else into a `MultiWayIf` chain, deduping the previously-duplicated `staticSettings` block.

## Test plan

- [x] `cabal build all` — clean
- [x] `cabal test` — 717 examples, 0 failures (6 new in `LicensesSpec`, including a Wai-level assertion that `licensesResponse` carries status 200 + `application/json; charset=utf-8`)
- [x] End-to-end smoke: `curl /api/v1/licenses` returns engine.license=Apache-2.0, 6 components incl. MUMPS as CeCILL-C
- [x] All 8 dispatcher branches verified live via curl (`/mcp`, `/api/v1/openapi.json`, `/api/v1/licenses`, `/api/v1/docs`, `/api/v1/logs/stream`, `/api/v1/db` Servant, `/static/`, SPA fallback)
- [x] No `agpl|affero` traces remain in `*.cabal`, `*.hs`, `*.c`, `LICENSE*`
- [x] MUMPS source notices intact (no patches in `MUMPS_5.8.1/`)