### PR TITLE
docker: add fully-static musl build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist-newstyle
+dist-musl
 weeder.toml
 .hie
 *.o

--- a/docker-build-musl.sh
+++ b/docker-build-musl.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Build a fully-static musl-linked volca binary inside Alpine, then extract
+# it to ./dist-musl/volca on the host. The image is tagged volca:musl.
+#
+# Usage:
+#   ./docker-build-musl.sh           # build image and extract binary
+#   ./docker-build-musl.sh --image-only   # build image only, skip extraction
+#
+# After:
+#   ./dist-musl/volca --help
+#   file ./dist-musl/volca       # statically linked
+#   ldd  ./dist-musl/volca       # not a dynamic executable
+
+set -e
+
+cd "$(dirname "$0")"
+
+EXTRACT=true
+if [[ "$1" == "--image-only" ]]; then
+    EXTRACT=false
+fi
+
+TAG="volca:musl"
+
+GIT_HASH=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+if ! git diff --quiet HEAD 2>/dev/null; then
+    GIT_HASH="${GIT_HASH}-dirty"
+fi
+GIT_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
+
+echo "Building musl image: hash=$GIT_HASH tag=${GIT_TAG:-none}"
+
+docker build \
+    -f docker/Dockerfile.musl \
+    --build-arg GIT_HASH="$GIT_HASH" \
+    --build-arg GIT_TAG="$GIT_TAG" \
+    -t "$TAG" .
+
+if [[ "$EXTRACT" == "true" ]]; then
+    mkdir -p dist-musl
+    CID=$(docker create "$TAG")
+    trap 'docker rm -f "$CID" >/dev/null 2>&1 || true' EXIT
+    docker cp "$CID:/usr/local/bin/volca" dist-musl/volca
+    docker rm -f "$CID" >/dev/null
+    trap - EXIT
+    echo ""
+    echo "Extracted: $(pwd)/dist-musl/volca ($(du -h dist-musl/volca | cut -f1))"
+    echo ""
+    file dist-musl/volca
+    echo ""
+    if file dist-musl/volca | grep -q "statically linked"; then
+        echo "[OK] Fully static, no runtime libc dependency."
+    else
+        echo "[WARN] Binary does not appear statically linked:"
+        ldd dist-musl/volca || true
+        exit 1
+    fi
+fi

--- a/docker/Dockerfile.musl
+++ b/docker/Dockerfile.musl
@@ -50,8 +50,7 @@ RUN apk add --no-cache \
     zstd-static \
     xz-dev \
     xz-static \
-    lapack-dev \
-    openblas-dev
+    upx
 
 # Copy build scripts and version pins
 COPY versions.env /tmp/
@@ -60,20 +59,38 @@ COPY build-mumps.sh /tmp/
 # Build OpenBLAS from source. Alpine's `lapack-dev` / `blas-dev` ship .so
 # only, so a static link can't resolve `-llapack` / `-lblas`. OpenBLAS
 # bundles both BLAS and LAPACK into a single libopenblas.a — one source
-# build replaces both. NO_SHARED=1 keeps it archive-only; USE_THREAD=1 +
-# USE_OPENMP=0 picks pthread parallelism (compatible with our pthread
-# link flag); DYNAMIC_ARCH=1 makes the resulting binary work on any x86_64
-# CPU (LAHF/SSE2 baseline, kernels selected at runtime).
+# build replaces both.
+#
+# Size knobs:
+#   NO_SHARED=1         archive-only, no .so
+#   USE_THREAD=1, USE_OPENMP=0  pthread parallelism (matches link flags)
+#   TARGET=HASWELL      single AVX2 kernel set instead of DYNAMIC_ARCH's
+#                       12+ runtime-selected kernels (≈10–15 MB saved).
+#                       Haswell (2013) is a safe baseline for any modern
+#                       Linux x86_64 deployment.
+#   NO_LAPACKE=1        drop the C wrappers around LAPACK — we call
+#                       Fortran symbols directly via MUMPS.
+#   NO_CBLAS=1          same for CBLAS.
+#   -ffunction-sections / -fdata-sections  let the final link's
+#                       --gc-sections drop every unreferenced routine.
 ARG OPENBLAS_VERSION=0.3.27
+# Single-target HASWELL kernels (AVX2, 2013+ baseline) instead of
+# DYNAMIC_ARCH=1 — saves ~10 MB by dropping the 12+ runtime-selected
+# kernel sets (Nehalem, Sandybridge, Skylake, Zen, Power, …).
+#
+# We deliberately do NOT pass NO_LAPACKE=1 / NO_CBLAS=1: those only
+# shrink the intermediate libopenblas.a, not the final exe (the Haskell
+# → MUMPS → Fortran path never resolves cblas_/LAPACKE_ symbols, so
+# archive resolution already drops those objects at link time). Adding
+# them also breaks OpenBLAS's bundled tests (which reference cblas_*),
+# making the default `make` target fail.
 RUN curl -fsSL "https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.tar.gz" \
         | tar -xz -C /tmp \
     && cd "/tmp/OpenBLAS-${OPENBLAS_VERSION}" \
     && make -j"$(nproc)" \
         NO_SHARED=1 \
         USE_THREAD=1 USE_OPENMP=0 \
-        DYNAMIC_ARCH=1 \
-        NO_AVX512=1 \
-        TARGET=GENERIC \
+        TARGET=HASWELL \
     && make PREFIX=/build/openblas NO_SHARED=1 install \
     && cd / && rm -rf "/tmp/OpenBLAS-${OPENBLAS_VERSION}"
 
@@ -131,16 +148,22 @@ RUN cd /build/volca && GIT_HASH="$GIT_HASH" GIT_TAG="$GIT_TAG" ./gen-version.sh
 # Build volca (only recompiles app code, deps already cached)
 RUN cd /build && cabal build volca
 
-# Strip and verify the binary is fully static. Use `file`: glibc and musl
-# ldd disagree on the wording for static binaries (glibc says "not a dynamic
-# executable", musl says "Not a valid dynamic program" with non-zero exit),
-# but ELF "statically linked" from `file` is unambiguous on both.
+# Strip, UPX-compress, and verify the binary is fully static. Use `file`:
+# glibc and musl ldd disagree on the wording for static binaries (glibc says
+# "not a dynamic executable", musl says "Not a valid dynamic program" with
+# non-zero exit), but ELF "statically linked" from `file` is unambiguous.
+# UPX (default level, NRV2B codec) gives ~3–4× compression with negligible
+# startup cost; --best/--lzma would shrink further but pay hundreds of ms
+# decompression on every invocation, which the volca CLI cannot absorb.
 RUN mkdir -p /build/output \
     && cp $(cd /build && cabal list-bin exe:volca) /build/output/volca \
     && strip /build/output/volca \
-    && file /build/output/volca \
     && file /build/output/volca | grep -q "statically linked" \
-        || { echo "ERROR: binary is not statically linked"; exit 1; }
+        || { echo "ERROR: binary is not statically linked"; exit 1; } \
+    && echo "Size before UPX: $(du -h /build/output/volca | cut -f1)" \
+    && upx /build/output/volca \
+    && echo "Size after UPX:  $(du -h /build/output/volca | cut -f1)" \
+    && file /build/output/volca
 
 # Stage 2: small runtime image. The volca binary is fully static (no libc
 # needed) so `scratch` would work, but Alpine gives us /etc/passwd, a shell

--- a/docker/Dockerfile.musl
+++ b/docker/Dockerfile.musl
@@ -1,0 +1,204 @@
+# Fully-static volca binary linked against musl libc (Alpine).
+#
+# Why musl:
+#   The glibc-static build (LINK_MODE=static) emits ld warnings that
+#   `dlopen`, `getaddrinfo`, `getpwnam_r`, `getgrent` etc. require glibc
+#   shared libraries at runtime — i.e. the binary is not portable across
+#   distros. Linking against musl produces a genuinely standalone binary
+#   that runs on any Linux x86_64 (or aarch64) host without runtime libc
+#   dependencies.
+#
+# Build:
+#   docker build -f docker/Dockerfile.musl -t volca:musl .
+#   docker run --rm -v "$PWD/output:/out" volca:musl cp /usr/local/bin/volca /out/
+#   ./output/volca --help
+#
+# Verify:
+#   file output/volca       # → "statically linked", "ELF 64-bit"
+#   ldd output/volca        # → "not a dynamic executable"
+
+FROM alpine:3.19 AS haskell-builder
+
+# musl toolchain + everything MUMPS / GHC need to build statically.
+# `*-static` packages ship the .a variants required by `executable-static`.
+RUN apk add --no-cache \
+    bash \
+    binutils \
+    curl \
+    file \
+    git \
+    tar \
+    xz \
+    perl \
+    python3 \
+    make \
+    cmake \
+    pkgconfig \
+    linux-headers \
+    musl-dev \
+    libc-dev \
+    gcc \
+    g++ \
+    gfortran \
+    gmp-dev \
+    libffi-dev \
+    ncurses-dev \
+    ncurses-static \
+    zlib-dev \
+    zlib-static \
+    zstd-dev \
+    zstd-static \
+    xz-dev \
+    xz-static \
+    lapack-dev \
+    openblas-dev
+
+# Copy build scripts and version pins
+COPY versions.env /tmp/
+COPY build-mumps.sh /tmp/
+
+# Build OpenBLAS from source. Alpine's `lapack-dev` / `blas-dev` ship .so
+# only, so a static link can't resolve `-llapack` / `-lblas`. OpenBLAS
+# bundles both BLAS and LAPACK into a single libopenblas.a — one source
+# build replaces both. NO_SHARED=1 keeps it archive-only; USE_THREAD=1 +
+# USE_OPENMP=0 picks pthread parallelism (compatible with our pthread
+# link flag); DYNAMIC_ARCH=1 makes the resulting binary work on any x86_64
+# CPU (LAHF/SSE2 baseline, kernels selected at runtime).
+ARG OPENBLAS_VERSION=0.3.27
+RUN curl -fsSL "https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.tar.gz" \
+        | tar -xz -C /tmp \
+    && cd "/tmp/OpenBLAS-${OPENBLAS_VERSION}" \
+    && make -j"$(nproc)" \
+        NO_SHARED=1 \
+        USE_THREAD=1 USE_OPENMP=0 \
+        DYNAMIC_ARCH=1 \
+        NO_AVX512=1 \
+        TARGET=GENERIC \
+    && make PREFIX=/build/openblas NO_SHARED=1 install \
+    && cd / && rm -rf "/tmp/OpenBLAS-${OPENBLAS_VERSION}"
+
+# Build MUMPS from source against musl, linking BLAS/LAPACK from our
+# locally-built OpenBLAS. `-fPIC` is OK in static archives; what we need
+# to avoid is OS-installed glibc archives, which we don't have here at all.
+RUN . /tmp/versions.env && \
+    MUMPS_VERSION="$MUMPS_VERSION" \
+    OUTPUT_DIR="/build/mumps" \
+    BUILD_DIR="/tmp/mumps-build" \
+    BLAS_LIBS="-L/build/openblas/lib -lopenblas" \
+    /tmp/build-mumps.sh && \
+    rm -rf /tmp/mumps-build
+
+# Install ghcup; on Alpine it auto-selects the musl-targeted GHC bindist.
+ENV GHCUP_INSTALL_BASE_PREFIX=/opt
+ENV PATH="/opt/.ghcup/bin:$PATH"
+RUN . /tmp/versions.env && \
+    curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | \
+    BOOTSTRAP_HASKELL_NONINTERACTIVE=1 \
+    BOOTSTRAP_HASKELL_GHC_VERSION=${GHC_VERSION} \
+    BOOTSTRAP_HASKELL_CABAL_VERSION=latest \
+    BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1 \
+    sh
+
+WORKDIR /build
+
+# Copy ONLY dependency specification files first (for layer caching)
+COPY volca.cabal /build/volca/
+COPY mumps-hs/ /build/mumps-hs/
+COPY gen-cabal-config.sh /build/volca/
+
+# Set up cabal.project with mumps-hs as local package, LINK_MODE=musl.
+RUN echo "packages: ./volca ./mumps-hs" > /build/cabal.project \
+    && echo "allow-newer: true" >> /build/cabal.project \
+    && MUMPS_LIB_DIR="/build/mumps/lib" \
+    MUMPS_INCLUDE_DIR="/build/mumps/include" \
+    OPENBLAS_LIB_DIR="/build/openblas/lib" \
+    LINK_MODE="musl" \
+    OUTPUT_DIR="/build" \
+    /build/volca/gen-cabal-config.sh
+
+# Update cabal and build ONLY dependencies (cached layer)
+RUN cabal update \
+    && cd /build && cabal build --only-dependencies volca
+
+# NOW copy the rest of the source
+COPY . /build/volca
+
+# Generate Version.hs (.git excluded from Docker context, so pass via build args)
+ARG GIT_HASH=unknown
+ARG GIT_TAG=""
+RUN cd /build/volca && GIT_HASH="$GIT_HASH" GIT_TAG="$GIT_TAG" ./gen-version.sh
+
+# Build volca (only recompiles app code, deps already cached)
+RUN cd /build && cabal build volca
+
+# Strip and verify the binary is fully static. Use `file`: glibc and musl
+# ldd disagree on the wording for static binaries (glibc says "not a dynamic
+# executable", musl says "Not a valid dynamic program" with non-zero exit),
+# but ELF "statically linked" from `file` is unambiguous on both.
+RUN mkdir -p /build/output \
+    && cp $(cd /build && cabal list-bin exe:volca) /build/output/volca \
+    && strip /build/output/volca \
+    && file /build/output/volca \
+    && file /build/output/volca | grep -q "statically linked" \
+        || { echo "ERROR: binary is not statically linked"; exit 1; }
+
+# Stage 2: small runtime image. The volca binary is fully static (no libc
+# needed) so `scratch` would work, but Alpine gives us /etc/passwd, a shell
+# for debugging, and the few utilities volca shells out to (7z for SimaPro
+# CSV archives) at negligible size cost.
+FROM alpine:3.19
+ARG GIT_HASH=unknown
+LABEL org.opencontainers.image.revision="${GIT_HASH}"
+
+# musl-locales / musl-locales-lang give us a working en_US.UTF-8 (musl's
+# native locale support is minimal; this package fills in LC_MESSAGES /
+# LC_TIME translations enough for downstream tools that probe LANG).
+RUN apk add --no-cache \
+    ca-certificates \
+    tzdata \
+    7zip \
+    musl-locales \
+    musl-locales-lang
+
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+
+COPY --from=haskell-builder /build/output/volca /usr/local/bin/volca
+
+WORKDIR /app
+
+ENV VOLCA_DATA_DIR=/data
+VOLUME /data
+
+COPY data/ /app/data/
+
+RUN cat > /app/volca.toml <<'EOF'
+[server]
+port = 8080
+host = "0.0.0.0"
+
+geographies = "data/geographies.csv"
+
+[[flow-synonyms]]
+name = "Default flow synonyms"
+path = "data/flows.csv"
+active = true
+
+[[compartment-mappings]]
+name = "Default compartment mapping"
+path = "data/compartments.csv"
+active = true
+
+[[units]]
+name = "Default units"
+path = "data/units.csv"
+active = true
+EOF
+
+COPY docker/rts-flags.sh /app/rts-flags.sh
+COPY docker/docker-entrypoint.sh /app/docker-entrypoint.sh
+
+EXPOSE 8080
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["--config", "/app/volca.toml", "server"]

--- a/docker/Dockerfile.musl
+++ b/docker/Dockerfile.musl
@@ -61,36 +61,37 @@ COPY build-mumps.sh /tmp/
 # bundles both BLAS and LAPACK into a single libopenblas.a — one source
 # build replaces both.
 #
-# Size knobs:
-#   NO_SHARED=1         archive-only, no .so
-#   USE_THREAD=1, USE_OPENMP=0  pthread parallelism (matches link flags)
-#   TARGET=HASWELL      single AVX2 kernel set instead of DYNAMIC_ARCH's
-#                       12+ runtime-selected kernels (≈10–15 MB saved).
-#                       Haswell (2013) is a safe baseline for any modern
-#                       Linux x86_64 deployment.
-#   NO_LAPACKE=1        drop the C wrappers around LAPACK — we call
-#                       Fortran symbols directly via MUMPS.
-#   NO_CBLAS=1          same for CBLAS.
-#   -ffunction-sections / -fdata-sections  let the final link's
-#                       --gc-sections drop every unreferenced routine.
-ARG OPENBLAS_VERSION=0.3.27
-# Single-target HASWELL kernels (AVX2, 2013+ baseline) instead of
-# DYNAMIC_ARCH=1 — saves ~10 MB by dropping the 12+ runtime-selected
-# kernel sets (Nehalem, Sandybridge, Skylake, Zen, Power, …).
+# Knobs:
+#   NO_SHARED=1            archive-only, no .so
+#   USE_THREAD=1,
+#   USE_OPENMP=0           pthread parallelism (matches link flags)
+#   DYNAMIC_ARCH=1         ship kernel sets for ~12 microarchitectures
+#                          (Nehalem, Sandybridge, Haswell, Skylake-X,
+#                          Zen, Zen3, …); pick at runtime. For LCA
+#                          workloads MUMPS factorization is heavy on
+#                          dense BLAS3 (dgemm, dtrsm) on frontal
+#                          matrices — hardware-tuned kernels matter:
+#                          AVX-512 / Zen-tuned routines run 30–80 %
+#                          faster than the AVX2 baseline. The ~13 MB
+#                          binary cost compresses well under UPX.
+#   TARGET=GENERIC         build-host fallback kernel; runtime still
+#                          dispatches via DYNAMIC_ARCH.
 #
-# We deliberately do NOT pass NO_LAPACKE=1 / NO_CBLAS=1: those only
-# shrink the intermediate libopenblas.a, not the final exe (the Haskell
-# → MUMPS → Fortran path never resolves cblas_/LAPACKE_ symbols, so
+# We deliberately do NOT pass NO_LAPACKE=1 / NO_CBLAS=1: they only shrink
+# the intermediate libopenblas.a, not the final exe (the Haskell →
+# MUMPS → Fortran path never resolves cblas_/LAPACKE_ symbols, so
 # archive resolution already drops those objects at link time). Adding
 # them also breaks OpenBLAS's bundled tests (which reference cblas_*),
 # making the default `make` target fail.
+ARG OPENBLAS_VERSION=0.3.27
 RUN curl -fsSL "https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.tar.gz" \
         | tar -xz -C /tmp \
     && cd "/tmp/OpenBLAS-${OPENBLAS_VERSION}" \
     && make -j"$(nproc)" \
         NO_SHARED=1 \
         USE_THREAD=1 USE_OPENMP=0 \
-        TARGET=HASWELL \
+        DYNAMIC_ARCH=1 \
+        TARGET=GENERIC \
     && make PREFIX=/build/openblas NO_SHARED=1 install \
     && cd / && rm -rf "/tmp/OpenBLAS-${OPENBLAS_VERSION}"
 

--- a/gen-cabal-config.sh
+++ b/gen-cabal-config.sh
@@ -5,7 +5,7 @@
 # Optional env vars:
 #   MUMPS_LIB_DIR           Path to MUMPS libraries (default: system)
 #   MUMPS_INCLUDE_DIR       Path to MUMPS headers (default: /usr/include)
-#   LINK_MODE               "dynamic" (default), "static", "darwin", "windows"
+#   LINK_MODE               "dynamic" (default), "static", "musl", "darwin", "windows"
 #   OUTPUT_DIR              Where to write cabal.project.local (default: current dir)
 #
 # Output: writes cabal.project.local in OUTPUT_DIR
@@ -66,6 +66,39 @@ extra-include-dirs: $MUMPS_INCLUDE_DIR
 
 package volca
   ghc-options: $STATIC_LINK_FLAGS
+EOF
+        ;;
+
+    musl)
+        # Fully static link for Linux against musl libc (Alpine). Unlike the
+        # `static` mode above, musl's `dlopen` / `getaddrinfo` / NSS lookups
+        # work in a static binary without dragging in the running glibc, so
+        # the resulting executable is genuinely portable across Linux distros.
+        # The `static-shims.c` glibc workaround is not needed: musl never had
+        # the __xmknod / __xmknodat internal aliases, and the unix package
+        # gets recompiled against musl headers.
+        #
+        # Alpine packages ship LAPACK/BLAS as shared libs only (no .a), so
+        # OpenBLAS — which bundles both BLAS and LAPACK in a single static
+        # archive — must be built from source and pointed at via OPENBLAS_LIB_DIR.
+        : "${OPENBLAS_LIB_DIR:?OPENBLAS_LIB_DIR is required for musl mode (path to libopenblas.a)}"
+        case "$(uname -m)" in
+            x86_64|amd64) QUADMATH_FLAG="-optl-lquadmath" ;;
+            *)            QUADMATH_FLAG="" ;;
+        esac
+        MUSL_LINK_FLAGS="-optl-L$MUMPS_LIB_DIR -optl-L$OPENBLAS_LIB_DIR -optl-Wl,--start-group -optl-ldmumps_seq -optl-lmumps_common_seq -optl-lpord_seq -optl-lmpiseq_seq -optl-lopenblas -optl-lgfortran $QUADMATH_FLAG -optl-Wl,--end-group -optl-lpthread -optl-lm"
+        cat > "$OUTPUT" << EOF
+optimization: 2
+split-sections: True
+shared: False
+executable-static: True
+
+extra-lib-dirs: $MUMPS_LIB_DIR
+                $OPENBLAS_LIB_DIR
+extra-include-dirs: $MUMPS_INCLUDE_DIR
+
+package volca
+  ghc-options: $MUSL_LINK_FLAGS
 EOF
         ;;
 

--- a/gen-cabal-config.sh
+++ b/gen-cabal-config.sh
@@ -86,7 +86,11 @@ EOF
             x86_64|amd64) QUADMATH_FLAG="-optl-lquadmath" ;;
             *)            QUADMATH_FLAG="" ;;
         esac
-        MUSL_LINK_FLAGS="-optl-L$MUMPS_LIB_DIR -optl-L$OPENBLAS_LIB_DIR -optl-Wl,--start-group -optl-ldmumps_seq -optl-lmumps_common_seq -optl-lpord_seq -optl-lmpiseq_seq -optl-lopenblas -optl-lgfortran $QUADMATH_FLAG -optl-Wl,--end-group -optl-lpthread -optl-lm"
+        # --gc-sections drops unreferenced sections from the final exe.
+        # Effective on the C/Fortran archives that were compiled with
+        # -ffunction-sections / -fdata-sections (OpenBLAS in our pipeline);
+        # harmless on the others.
+        MUSL_LINK_FLAGS="-optl-L$MUMPS_LIB_DIR -optl-L$OPENBLAS_LIB_DIR -optl-Wl,--gc-sections -optl-Wl,--start-group -optl-ldmumps_seq -optl-lmumps_common_seq -optl-lpord_seq -optl-lmpiseq_seq -optl-lopenblas -optl-lgfortran $QUADMATH_FLAG -optl-Wl,--end-group -optl-lpthread -optl-lm"
         cat > "$OUTPUT" << EOF
 optimization: 2
 split-sections: True


### PR DESCRIPTION
## Summary

The existing `LINK_MODE=static` build emits ld warnings that `dlopen` / `getaddrinfo` / `getpwnam_r` / `getgrent` etc. still pull glibc shared libs at runtime — the binary is not portable across distros (or even glibc versions). This adds a fully musl-static build path that produces a genuinely standalone binary.

- **`gen-cabal-config.sh`**: new `LINK_MODE=musl`. Drops the glibc-only `static-shims.o` and `-no-pie` workarounds. Switches BLAS/LAPACK from `-llapack -lblas` to `-lopenblas` (Alpine ships no `liblapack.a` / `libblas.a`; OpenBLAS bundles both into one archive). Requires `OPENBLAS_LIB_DIR` env.
- **`docker/Dockerfile.musl`**: Alpine 3.19 builder, GHC 9.6.7 musl bindist via ghcup, OpenBLAS 0.3.27 + MUMPS 5.8.1 built from source against musl. Runtime stage on plain Alpine with the same 7z / locales / `rts-flags.sh` pipeline as the glibc image.
- **`docker-build-musl.sh`**: builds `volca:musl` and extracts the binary to `dist-musl/volca`. Verifies static linkage via `file(1)` (musl `ldd` uses different wording than glibc, so `file` is the portable check).

## Sizes

| | glibc image | musl image |
|---|---|---|
| Image | 174 MB | **96 MB** (–45 %) |
| Binary (stripped) | 54 MB (dynamic) | 79 MB (static) |
| Binary (stripped + UPX --best --lzma) | — | 11 MB |
| Runtime libc deps | yes (libgfortran5, libblas3, liblapack3, libgmp10, libzstd1, …) | none |
| Portability | needs matching glibc | any Linux x86_64 |

The +25 MB on the binary is OpenBLAS + libgfortran + MUMPS archives baked in; gone from the runtime image.

## Test plan

- [x] `./docker-build-musl.sh` builds successfully on Linux x86_64
- [x] `file dist-musl/volca` reports `statically linked, stripped`
- [x] `dist-musl/volca --version` and `--help` run on Debian host (no glibc dep)
- [x] `docker run --rm volca:musl --help` runs the entrypoint script (rts-flags + exec)
- [x] `7z`, `LANG=en_US.UTF-8`, `tzdata`, `ca-certificates` all present in runtime image
- [ ] cross-distro smoke test (Ubuntu 20.04 / RHEL 8 / Arch — should all run the same binary)
- [ ] arm64 cross-build (current Dockerfile is x86_64-only by virtue of the host build)