### PR TITLE
openLCA JSON-LD method ergonomics + LCIA fallback fixes

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -150,7 +150,7 @@ runServerWithConfig cliConfig serverOpts cfgFile = do
         then reportProgress Info "No databases loaded - upload or load one via the web interface"
         else reportProgress Info $ "Loaded databases: " ++ intercalate ", " (map T.unpack (M.keys loadedDbs))
 
-    let port = serverPort serverOpts
+    let port = fromMaybe (scPort (cfgServer effectiveConfig)) (serverPort serverOpts)
 
     -- Initialize matrix solver (no-op for MUMPS, kept for API compatibility)
     initializeSolverForServer

--- a/data/geographies.csv
+++ b/data/geographies.csv
@@ -89,4 +89,4 @@ TR,Turkey,Middle East|Europe|GLO|RoW
 Middle East,Middle East,GLO|RoW
 RME,Rest of Middle East,Middle East|GLO|RoW
 GLO,Global,RoW
-RoW,Rest of World,
+RoW,Rest of World,GLO

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -192,14 +192,14 @@ serverParser = Server <$> serverOptionsParser
 serverOptionsParser :: Parser ServerOptions
 serverOptionsParser = do
     serverPort <-
-        option
-            auto
-            ( long "port"
-                <> short 'p'
-                <> value 8080
-                <> metavar "PORT"
-                <> help "Server port (default: 8080)"
-            )
+        optional $
+            option
+                auto
+                ( long "port"
+                    <> short 'p'
+                    <> metavar "PORT"
+                    <> help "Server port (overrides [server].port from config; default: 8080)"
+                )
     serverLoadDbs <-
         optional $
             option

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -87,7 +87,7 @@ data UploadArgs = UploadArgs
 
 -- | Server-specific options
 data ServerOptions = ServerOptions
-    { serverPort :: Int -- Server port (--port)
+    { serverPort :: Maybe Int -- Server port (--port); falls back to config [server].port, then 8080
     , serverLoadDbs :: Maybe [Text] -- Databases to load at startup (--load db1,db2)
     , serverDesktopMode :: Bool -- Desktop mode (--desktop): print port and minimize logging
     , serverStaticDir :: Maybe FilePath -- Static directory (--static-dir): override default web/dist

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -46,6 +46,9 @@ module Database.Manager (
     addMethodCollection,
     removeMethodCollection,
 
+    -- * Geography
+    parseGeographiesCSV,
+
     -- * Reference Data Operations
     listFlowSynonyms,
     loadFlowSynonyms,

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -106,7 +106,7 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import GHC.Generics (Generic)
 import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist, listDirectory, removeDirectoryRecursive, removeFile)
-import System.FilePath (isAbsolute, normalise, takeDirectory, takeExtension, (</>))
+import System.FilePath (isAbsolute, normalise, takeDirectory, takeExtension, takeFileName, (</>))
 import System.Mem (performGC)
 
 import Config
@@ -2055,18 +2055,27 @@ and enriches CFs from ILCD flow XMLs when available.
 -}
 loadMethodCollectionFromConfig :: MethodConfig -> IO (Either Text (MethodCollection, M.Map UUID ILCDFlowInfo))
 loadMethodCollectionFromConfig mc = do
-    -- Resolve archives (ZIP → extracted directory)
+    -- Resolve archives (ZIP → extracted directory). Single .json files (openLCA
+    -- JSON-LD ImpactCategory documents) are accepted directly without a wrapping
+    -- directory or archive.
     resolvedPath <- resolveDataPath (mcPath mc)
     isDir <- doesDirectoryExist resolvedPath
-    if not isDir
+    isFile <- doesFileExist resolvedPath
+    let isSingleJson = isFile && map toLower (takeExtension resolvedPath) == ".json"
+    if not isDir && not isSingleJson
         then return $ Left $ "Method path not found: " <> T.pack (mcPath mc)
         else do
-            -- Find method directory (handles nested ILCD structures)
-            dir <- findMethodDirectory resolvedPath
-            files <- listDirectory dir
-            let xmlFiles = filter (\f -> map toLower (takeExtension f) == ".xml") files
-                csvFiles = filter (\f -> map toLower (takeExtension f) == ".csv") files
-                jsonFiles = filter (\f -> map toLower (takeExtension f) == ".json") files
+            (dir, xmlFiles, csvFiles, jsonFiles) <-
+                if isSingleJson
+                    then return (takeDirectory resolvedPath, [], [], [takeFileName resolvedPath])
+                    else do
+                        -- Find method directory (handles nested ILCD structures)
+                        d <- findMethodDirectory resolvedPath
+                        fs <- listDirectory d
+                        let xs = filter (\f -> map toLower (takeExtension f) == ".xml") fs
+                            cs = filter (\f -> map toLower (takeExtension f) == ".csv") fs
+                            js = filter (\f -> map toLower (takeExtension f) == ".json") fs
+                        return (d, xs, cs, js)
             if null xmlFiles && null csvFiles && null jsonFiles
                 then return $ Left $ "No method files (.xml/.csv/.json) found in: " <> T.pack dir
                 else do

--- a/src/Method/Parser/OlcaSchema.hs
+++ b/src/Method/Parser/OlcaSchema.hs
@@ -118,6 +118,7 @@ parseImpactFactor (Object o) = do
                 Nothing -> lookupText l "name"
             Nothing -> Nothing
         direction = directionFromFlow o
+        compartment = parseCompartment flow
     -- A factor without a flow name is unmatchable; drop it. (UUID alone could
     -- in theory match by id, but in practice the name carries the matching
     -- signal too and is required by every fallback strategy.)
@@ -130,16 +131,31 @@ parseImpactFactor (Object o) = do
                     , mcfFlowName = flowName
                     , mcfDirection = direction
                     , mcfValue = value
-                    -- Compartment can live on the openLCA Flow object via its
-                    -- 'category' field (a Ref[Category] hierarchy). Wiring that
-                    -- in is straightforward but not needed yet — UUID-based
-                    -- matching against the DB doesn't use the compartment.
-                    , mcfCompartment = Nothing
+                    , mcfCompartment = compartment
                     , mcfCAS = flowCas
                     , mcfUnit = unitName
                     , mcfConsumerLocation = loc
                     }
 parseImpactFactor _ = Nothing
+
+-- | Read the optional @flow.category@ Ref and turn it into a 'Compartment'.
+-- The category's @name@ is treated as a slash-separated path: the first
+-- segment is the medium ('resource', 'air', 'water', …) and the rest is the
+-- subcompartment ('land', 'urban air close to ground', …). Without this,
+-- VoLCA's matcher cannot disambiguate DB flows that share a name across
+-- compartments (e.g. Agribalyse has 3 flows literally named
+-- @"Occupation, annual crop"@ in @resource@, @resource/land@, and
+-- @resource/biotic@; only the @resource/land@ one is what activities emit).
+parseCompartment :: KM.KeyMap Value -> Maybe Compartment
+parseCompartment flow = do
+    cat <- objectField flow "category"
+    catName <- lookupText cat "name"
+    let parts = T.splitOn "/" catName
+        med = T.strip (head parts)
+        sub = T.strip (T.intercalate "/" (drop 1 parts))
+    if T.null med
+        then Nothing
+        else Just (Compartment med sub "")
 
 -- | Direction is carried by 'ImpactFactor.direction' (Direction enum) when
 -- present, otherwise default to 'Output' since the vast majority of

--- a/src/Method/Parser/OlcaSchema.hs
+++ b/src/Method/Parser/OlcaSchema.hs
@@ -150,12 +150,16 @@ parseCompartment :: KM.KeyMap Value -> Maybe Compartment
 parseCompartment flow = do
     cat <- objectField flow "category"
     catName <- lookupText cat "name"
-    let parts = T.splitOn "/" catName
-        med = T.strip (head parts)
-        sub = T.strip (T.intercalate "/" (drop 1 parts))
-    if T.null med
-        then Nothing
-        else Just (Compartment med sub "")
+    -- T.splitOn always returns a non-empty list, so the empty case is
+    -- unreachable; pattern-matching avoids the partial 'head'.
+    case T.splitOn "/" catName of
+        [] -> Nothing
+        (med0 : rest) ->
+            let med = T.strip med0
+                sub = T.strip (T.intercalate "/" rest)
+             in if T.null med
+                    then Nothing
+                    else Just (Compartment med sub "")
 
 -- | Direction is carried by 'ImpactFactor.direction' (Direction enum) when
 -- present, otherwise default to 'Output' since the vast majority of

--- a/test/GeographiesSpec.hs
+++ b/test/GeographiesSpec.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Regression gate for the geography cascade defined in
+@data/geographies.csv@. The cascade is the chain of fallback locations
+that the LCIA matcher walks when a CF for the requested location is
+absent — a missing edge silently demotes a location to the legacy
+global behavior.
+-}
+module GeographiesSpec (spec) where
+
+import qualified Data.Map.Strict as M
+import Database.Manager (parseGeographiesCSV)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "data/geographies.csv cascade" $ do
+        it "RoW cascades to GLO (commit 7df7921)" $ do
+            -- Before this fix, RoW had an empty parents column, so any
+            -- "Rest of World" CF lookup failed instead of falling back to
+            -- the global value — silently underestimating impact for every
+            -- ecoinvent activity whose location is RoW.
+            geos <- parseGeographiesCSV "data/geographies.csv"
+            case M.lookup "RoW" geos of
+                Just (display, parents) -> do
+                    display `shouldBe` "Rest of World"
+                    parents `shouldBe` ["GLO"]
+                Nothing -> expectationFailure "RoW missing from geographies.csv"
+
+        it "GLO cascades to RoW (existing fallback, regression gate)" $ do
+            geos <- parseGeographiesCSV "data/geographies.csv"
+            case M.lookup "GLO" geos of
+                Just (_, parents) -> parents `shouldBe` ["RoW"]
+                Nothing -> expectationFailure "GLO missing from geographies.csv"
+
+        it "every non-leaf entry has at least one parent" $ do
+            -- Sanity check that no other row regresses to the empty-parents
+            -- state RoW used to have. The only leaves are GLO and RoW
+            -- themselves (mutual fallback between the two).
+            geos <- parseGeographiesCSV "data/geographies.csv"
+            let orphaned =
+                    [ code
+                    | (code, (_, parents)) <- M.toList geos
+                    , null parents
+                    ]
+            orphaned `shouldBe` []

--- a/test/OlcaSchemaSpec.hs
+++ b/test/OlcaSchemaSpec.hs
@@ -75,6 +75,67 @@ spec = do
                 Left _ -> pure ()
                 Right _ -> expectationFailure "expected parse failure on @type=Process"
 
+    describe "parseImpactFactor flow.category → Compartment" $ do
+        -- Regression gate for d8a054d & 3d2f7e5: openLCA flows with identical
+        -- 'name' values but different category paths (e.g. Agribalyse has 3
+        -- "Occupation, annual crop" flows under resource, resource/land and
+        -- resource/biotic) must surface their full compartment path so the
+        -- DB-flow matcher can disambiguate. Without this, only one of the
+        -- three is reachable and ~30% of regionalized factors miss their
+        -- target flow silently.
+        it "extracts (medium, subcompartment) from a slash-separated path" $ do
+            let bytes =
+                    "{\"@type\":\"ImpactCategory\",\"name\":\"M\",\"referenceUnitName\":\"u\",\
+                    \\"impactFactors\":[{\"@type\":\"ImpactFactor\",\"value\":1.0,\
+                    \\"flow\":{\"@type\":\"Flow\",\"name\":\"Occupation, annual crop\",\
+                    \\"category\":{\"@type\":\"Category\",\"name\":\"resource/land\"}}}]}"
+            case parseOlcaImpactCategoryBytes bytes of
+                Left err -> expectationFailure ("parse failed: " ++ err)
+                Right method ->
+                    case methodFactors method of
+                        [cf] -> mcfCompartment cf `shouldBe` Just (Compartment "resource" "land" "")
+                        _ -> expectationFailure "expected exactly one factor"
+
+        it "keeps deeper subpaths intact (e.g. resource/in air / long-term)" $ do
+            let bytes =
+                    "{\"@type\":\"ImpactCategory\",\"name\":\"M\",\"referenceUnitName\":\"u\",\
+                    \\"impactFactors\":[{\"@type\":\"ImpactFactor\",\"value\":1.0,\
+                    \\"flow\":{\"@type\":\"Flow\",\"name\":\"f\",\
+                    \\"category\":{\"@type\":\"Category\",\"name\":\"resource/in air/upper stratosphere\"}}}]}"
+            case parseOlcaImpactCategoryBytes bytes of
+                Right method ->
+                    case methodFactors method of
+                        [cf] ->
+                            mcfCompartment cf
+                                `shouldBe` Just (Compartment "resource" "in air/upper stratosphere" "")
+                        _ -> expectationFailure "expected exactly one factor"
+                Left err -> expectationFailure ("parse failed: " ++ err)
+
+        it "leaves mcfCompartment Nothing when the flow has no category" $ do
+            -- The mini fixture has no category fields, so Compartment must
+            -- stay 'Nothing' — the matcher falls back to the legacy name-only
+            -- path. Regression gate against the disambiguation breaking
+            -- non-openLCA / non-Agribalyse methods that ship without category.
+            bytes <- BS.readFile "test-data/olca-schema-mini/impact-category-mini.json"
+            case parseOlcaImpactCategoryBytes bytes of
+                Left err -> expectationFailure ("parse failed: " ++ err)
+                Right method ->
+                    map mcfCompartment (methodFactors method)
+                        `shouldBe` replicate (length (methodFactors method)) Nothing
+
+        it "single-segment category resolves to medium with empty subcompartment" $ do
+            let bytes =
+                    "{\"@type\":\"ImpactCategory\",\"name\":\"M\",\"referenceUnitName\":\"u\",\
+                    \\"impactFactors\":[{\"@type\":\"ImpactFactor\",\"value\":1.0,\
+                    \\"flow\":{\"@type\":\"Flow\",\"name\":\"f\",\
+                    \\"category\":{\"@type\":\"Category\",\"name\":\"air\"}}}]}"
+            case parseOlcaImpactCategoryBytes bytes of
+                Right method ->
+                    case methodFactors method of
+                        [cf] -> mcfCompartment cf `shouldBe` Just (Compartment "air" "" "")
+                        _ -> expectationFailure "expected exactly one factor"
+                Left err -> expectationFailure ("parse failed: " ++ err)
+
     describe "buildMethodTables on parsed openLCA methods" $ do
         it "leaves mtRegionalizedCF empty when no flow matched (Nothing in mappings)" $ do
             -- Without database flows to match against, every CF stays unmapped, so

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -17,6 +17,7 @@ import qualified OlcaSchemaSpec
 import qualified EcoSpold2Spec
 import qualified FlowResolverSpec
 import qualified FuzzySpec
+import qualified GeographiesSpec
 import qualified HotspotSpec
 import qualified ILCDParserSpec
 import qualified InventorySpec
@@ -82,3 +83,4 @@ main = hspec $ do
         describe "Nested Substitutions" NestedSubstitutionSpec.spec
         describe "Database Status (depends_on)" DatabaseStatusSpec.spec
         describe "Licenses Endpoint" LicensesSpec.spec
+        describe "Geographies cascade" GeographiesSpec.spec

--- a/volca.cabal
+++ b/volca.cabal
@@ -193,6 +193,7 @@ test-suite lca-tests
                      , DatabaseStatusSpec
                      , OlcaSchemaSpec
                      , LicensesSpec
+                     , GeographiesSpec
   build-depends:       base >=4.14 && <5
                      , volca
                      , hspec

--- a/volca.toml
+++ b/volca.toml
@@ -7,6 +7,12 @@
 #   cp volca.toml volca.local.toml
 #   volca --config volca.local.toml server
 
+# Top-level scalar fields MUST come before any [section] / [[array-of-tables]]
+# header. After a header, every following key is parsed as a member of that
+# section until the next header — silently dropped if the schema doesn't know
+# the key. Geographies are required for regionalized LCIA cascade lookups.
+geographies = "data/geographies.csv"
+
 # ── Server ───────────────────────────────────────────────────────────
 
 [server]
@@ -63,8 +69,6 @@ host = "127.0.0.1"             # Bind address ("0.0.0.0" for all interfaces)
 # path = "DBs/EF-v3.1.zip"
 
 # ── Reference data (shipped with VoLCA) ──────────────────────────────
-
-geographies = "data/geographies.csv"
 
 [[flow-synonyms]]
 name = "Default flow synonyms"


### PR DESCRIPTION
## Summary

Five small follow-ups uncovered while exercising the openLCA JSON-LD method loader added in #25 against a real Agribalyse SimaPro CSV import. Three are bug fixes (system silently produced wrong results); two are ergonomic polish.

### Fixes

- **`fix(toml): move top-level keys above the section headers`** — \`geographies = "data/geographies.csv"\` was placed under \`[[methods]]\` in the shipped \`volca.toml\`. TOML scoping means that key was parsed as a methods-array field instead of a root key, so \`cfgGeographies\` came back \`Nothing\` and the regionalized cascade ran with an empty hierarchy (\"0 parent regions\" in the runtime error). Moved the key above the first section header and added a comment.

- **\`fix(geographies): RoW cascades to GLO\`** — \`RoW,Rest of World,\` had no parents, leaving the regionalized lookup with a dead end. Methods authored with a GLO fallback couldn't be reached from RoW activities, so every biosphere flow emitted by an unmodelled-rest-of-world upstream activity stayed uncharacterized. \`GLO,Global,RoW\` already declared the reverse direction; the two are now mutually reachable.

### Features

- **\`feat(olca-parser): read flow.category to disambiguate same-name DB flows\`** — SimaPro-derived DBs commonly carry multiple biosphere flows that share a name but differ in compartment (e.g. three flows literally named \`Occupation, annual crop\` in \`resource\`, \`resource/land\`, \`resource/biotic\`). The previous parser left \`mcfCompartment = Nothing\`, so \`pickByCompartment\` returned the first list entry arbitrarily — picking the wrong duplicate produced silent zero scores for ~30% of agricultural activities. Parsing the optional \`Flow.category\` Ref lets the matcher disambiguate via the existing exact-compartment path. Backwards compatible: documents without \`flow.category\` still parse with \`mcfCompartment = Nothing\`.

- **\`feat(methods): accept a single .json file as a method path\`** — the loader previously required a directory or an archive (.zip/.7z/...); a standalone \`.json\` file was rejected with \"Method path not found\". openLCA JSON-LD ImpactCategory documents are naturally single files; detect that case before the directory check and synthesize a one-file listing so the rest of the parse cascade runs unchanged.

- **\`feat(cli): --port falls back to [server].port from the TOML config\`** — \`--port\` was a hard-coded \`Int\` with \`value 8080\`, so the CLI default always won over the loaded config. Made \`serverPort\` a \`Maybe Int\` and resolve the fallback in \`Main\`, mirroring the existing password precedence (CLI > TOML > built-in default).

## Test plan

- [ ] \`cabal build\` cleanly
- [ ] \`cabal test\` — existing OlcaSchema spec passes unchanged (its fixture has no \`flow.category\` → \`mcfCompartment = Nothing\`, same as before)
- [ ] Start with \`--config volca.toml server\` (no \`--port\`) — picks up \`[server].port\` from the TOML (previously stayed on 8080)
- [ ] Point a \`[[methods]]\` entry at a single \`.json\` openLCA ImpactCategory file — loads (previously failed with \"Method path not found\")
- [ ] LCIA call on a SimaPro-imported DB with a method whose flows specify \`category: \"resource/land\"\` — matches the resource/land duplicate, not an arbitrary other one
- [ ] LCIA call with an upstream RoW activity — cascade reaches GLO (previously dead-ended)