### PR TITLE
Fix silent-zero CF lookup on compartment mismatch + parse ILCD <location>

### DIFF
--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -460,7 +460,8 @@ mapMethodToTablesCached manager dbName db method = do
         Just tables -> pure tables
         Nothing -> do
             mappings <- mapMethodToFlowsCached manager dbName db method
-            let !tables = buildMethodTables mappings
+            cmap <- getMergedCompartmentMap manager
+            let !tables = buildMethodTables cmap mappings
             atomically $ modifyTVar' (dmMethodTablesCache manager) (M.insert key tables)
             pure tables
 
@@ -2320,9 +2321,11 @@ Detects UUID collisions with divergent metadata. 'M.unions' is first-wins;
 collisions should never happen (same UUID ⇒ same flow by construction),
 but if data drift produces them, surface via log rather than hide.
 -}
--- | Location hierarchy as a 'Map ChildLocation [ParentLocation]', sourced from
--- 'data/geographies.csv' (or the hardcoded fallback). Reused across the LCIA
--- regionalized scoring path (see 'Method.Mapping.computeRegionalizedLCIAScore').
+
+{- | Location hierarchy as a 'Map ChildLocation [ParentLocation]', sourced from
+'data/geographies.csv' (or the hardcoded fallback). Reused across the LCIA
+regionalized scoring path (see 'Method.Mapping.computeRegionalizedLCIAScore').
+-}
 getLocationHierarchy :: DatabaseManager -> IO (M.Map Text [Text])
 getLocationHierarchy manager = pure (M.map snd (dmGeographies manager))
 

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -238,14 +238,30 @@ data MethodTables = MethodTables
     , mtFallbackCF :: !(M.Map (Text, Text) (Double, Text))
     -- ^ (normalized name, medium) → (CF, unit) for entries with unspecified subcompartment
     , mtRegionalizedCF :: !(M.Map (UUID, Text) (Double, Text))
-    -- ^ Regionalized cells of the C matrix: (DB flow UUID, consumer location) → (CF, unit).
-    -- Empty for non-regionalized methods. When non-empty, callers should dispatch
-    -- to the regionalized scoring path (see 'Matrix.computeRegionalizedLCIAScore').
+    {- ^ Regionalized cells of the C matrix: (DB flow UUID, consumer location) → (CF, unit).
+    Empty for non-regionalized methods. When non-empty, callers should dispatch
+    to the regionalized scoring path (see 'Matrix.computeRegionalizedLCIAScore').
+    -}
+    , mtCompartmentMap :: !CompartmentMap
+    {- ^ Compartment-normalization rules (e.g. @"Emissions to air" → "air"@).
+    Applied to both CF compartments at build time and database flow
+    compartments at query time, so both sides converge to the same
+    canonical form. Empty map = identity, no normalization.
+    -}
     }
 
--- | Build 'MethodTables' from raw mappings. Run once per (db, method).
-buildMethodTables :: [(MethodCF, Maybe (Flow, MatchStrategy))] -> MethodTables
-buildMethodTables mappings =
+{- | Build 'MethodTables' from raw mappings and a 'CompartmentMap'.
+
+The map is applied to each CF's compartment before keying the lookup
+tables, so all keys land in canonical form. The same map is then stored
+in the result so 'computeLCIAScoreFromTables' can normalize inventory-side
+compartments at query time and meet at the same canonical keys.
+
+Pass 'M.empty' for the compartment map when no normalization is desired
+(behaves identically to the pre-CompartmentMap implementation).
+-}
+buildMethodTables :: CompartmentMap -> [(MethodCF, Maybe (Flow, MatchStrategy))] -> MethodTables
+buildMethodTables cmap mappings =
     MethodTables
         { mtUuidCF =
             M.fromList
@@ -256,19 +272,23 @@ buildMethodTables mappings =
             stripStrategy $
                 M.fromListWith
                     preferBetter
-                    [ ((nameKey cf mflow, normalizeMedium medium, subcomp), (mcfValue cf, mcfUnit cf, matchStrategy mflow))
+                    [ ((nameKey cf mflow, normMed, normSub), (mcfValue cf, mcfUnit cf, matchStrategy mflow))
                     | (cf, mflow) <- mappings
-                    , Just (Compartment medium subcomp _) <- [mcfCompartment cf]
-                    , not (T.null subcomp)
+                    , Just comp <- [mcfCompartment cf]
+                    , let Compartment normMedRaw normSub _ = normalizeCompartment cmap comp
+                    , let normMed = normalizeMedium (T.toLower normMedRaw)
+                    , not (T.null normSub)
                     ]
         , mtFallbackCF =
             stripStrategy $
                 M.fromListWith
                     preferBetter
-                    [ ((nameKey cf mflow, normalizeMedium medium), (mcfValue cf, mcfUnit cf, matchStrategy mflow))
+                    [ ((nameKey cf mflow, normMed), (mcfValue cf, mcfUnit cf, matchStrategy mflow))
                     | (cf, mflow) <- mappings
-                    , Just (Compartment medium subcomp _) <- [mcfCompartment cf]
-                    , T.null subcomp
+                    , Just comp <- [mcfCompartment cf]
+                    , let Compartment normMedRaw normSub _ = normalizeCompartment cmap comp
+                    , let normMed = normalizeMedium (T.toLower normMedRaw)
+                    , T.null normSub
                     ]
         , mtRegionalizedCF =
             M.fromList
@@ -276,6 +296,7 @@ buildMethodTables mappings =
                 | (cf, Just (flow, _)) <- mappings
                 , Just loc <- [mcfConsumerLocation cf]
                 ]
+        , mtCompartmentMap = cmap
         }
   where
     stripStrategy = M.map (\(v, u, _) -> (v, u))
@@ -329,8 +350,24 @@ computeLCIAScoreFromTables unitConfig unitDB flowDB inventory tables =
             Nothing -> Nothing
             Just flow ->
                 let name = normalizeName (flowName flow)
-                    baseMed = normalizeMedium . T.takeWhile (/= '/') . T.toLower $ flowCategory flow
-                    subcomp = T.toLower $ fromMaybe "" (flowSubcompartment flow)
+                    -- Build the flow's raw compartment from flowCategory ("medium/sub")
+                    -- and flowSubcompartment, then normalize via the same map applied
+                    -- when buildMethodTables keyed the CF tables. Both sides converge
+                    -- to the canonical form, so a "Emissions to air,,,air,," rule in
+                    -- compartments.csv suffices to bridge BAFU's prefix vs ILCD's bare
+                    -- medium without listing every (medium, sub) pair explicitly.
+                    rawCategory = T.toLower (flowCategory flow)
+                    (rawMed, rawSubFromCat) = case T.breakOn "/" rawCategory of
+                        (m, rest)
+                            | T.null rest -> (m, T.empty)
+                            | otherwise -> (m, T.drop 1 rest)
+                    rawSub =
+                        let s = T.toLower (fromMaybe T.empty (flowSubcompartment flow))
+                         in if T.null s then rawSubFromCat else s
+                    Compartment normMedRaw normSub _ =
+                        normalizeCompartment (mtCompartmentMap tables) (Compartment rawMed rawSub T.empty)
+                    baseMed = normalizeMedium normMedRaw
+                    subcomp = normSub
                     exact = M.lookup (name, baseMed, subcomp) (mtExactCF tables)
                  in case exact of
                         Just _ -> exact
@@ -345,7 +382,7 @@ computeLCIAScoreFromTables unitConfig unitDB flowDB inventory tables =
 -}
 computeLCIAScore :: UnitConfig -> UnitDB -> FlowDB -> Inventory -> [(MethodCF, Maybe (Flow, MatchStrategy))] -> Double
 computeLCIAScore unitConfig unitDB flowDB inventory mappings =
-    computeLCIAScoreFromTables unitConfig unitDB flowDB inventory (buildMethodTables mappings)
+    computeLCIAScoreFromTables unitConfig unitDB flowDB inventory (buildMethodTables M.empty mappings)
 
 {- | LCIA score with automatic dispatch.
 
@@ -487,8 +524,9 @@ resolveRegionalCF tables flowDB regionalizedFlows hier flowUUID loc =
                                         <> " parent regions) and no universal broadcast."
                             | otherwise -> Right Nothing
 
--- | Universal CF lookup: same cascade as 'computeLCIAScoreFromTables' uses
--- internally, factored out for reuse from 'computeRegionalizedLCIAScore'.
+{- | Universal CF lookup: same cascade as 'computeLCIAScoreFromTables' uses
+internally, factored out for reuse from 'computeRegionalizedLCIAScore'.
+-}
 lookupBroadcastCF :: MethodTables -> FlowDB -> UUID -> Maybe (Double, Text)
 lookupBroadcastCF tables flowDB fid = case M.lookup fid (mtUuidCF tables) of
     Just cfv -> Just cfv

--- a/src/Method/Parser.hs
+++ b/src/Method/Parser.hs
@@ -66,6 +66,7 @@ data ParseState = ParseState
     , psCurrentFlowName :: !Text
     , psCurrentDirection :: !Text
     , psCurrentValue :: !Text
+    , psCurrentLocation :: !Text -- per-country CF location (e.g. "CH"), empty = global
     , -- Context tracking
       psPath :: ![BS.ByteString] -- Stack of element names
     , psInFactor :: !Bool
@@ -88,6 +89,7 @@ initialState =
         , psCurrentFlowName = ""
         , psCurrentDirection = ""
         , psCurrentValue = ""
+        , psCurrentLocation = ""
         , psPath = []
         , psInFactor = False
         , psInRefQuantity = False
@@ -150,7 +152,10 @@ closeTag state tagName
                     , mcfCompartment = extractCompartmentFromDesc (psCurrentFlowName state)
                     , mcfCAS = Nothing -- enriched in buildMethod from flow XMLs
                     , mcfUnit = psUnit state
-                    , mcfConsumerLocation = Nothing
+                    , mcfConsumerLocation =
+                        if T.null (psCurrentLocation state)
+                            then Nothing
+                            else Just (psCurrentLocation state)
                     }
          in state
                 { psPath = dropPath
@@ -161,6 +166,7 @@ closeTag state tagName
                 , psCurrentFlowName = ""
                 , psCurrentDirection = ""
                 , psCurrentValue = ""
+                , psCurrentLocation = ""
                 , psTextAccum = []
                 }
     -- UUID element - capture method UUID (only the first one, not flow UUIDs)
@@ -236,6 +242,13 @@ closeTag state tagName
         state
             { psPath = dropPath
             , psCurrentValue = accumulatedText
+            , psTextAccum = []
+            }
+    -- Per-country location for regionalized CFs (e.g. <location>CH</location>)
+    | isElement tagName "location" && psInFactor state =
+        state
+            { psPath = dropPath
+            , psCurrentLocation = accumulatedText
             , psTextAccum = []
             }
     -- Default: just pop the path

--- a/src/Method/Types.hs
+++ b/src/Method/Types.hs
@@ -90,9 +90,10 @@ data MethodCF = MethodCF
     , mcfUnit :: !Text
     -- ^ CF reference unit (e.g., "kg", "kBq")
     , mcfConsumerLocation :: !(Maybe Text)
-    -- ^ Consumer location for regionalized CFs (ISO 2-3 letter code).
-    -- 'Nothing' = universal CF (broadcast on all locations).
-    -- 'Just loc' = single cell of the C matrix at (flow, loc).
+    {- ^ Consumer location for regionalized CFs (ISO 2-3 letter code).
+    'Nothing' = universal CF (broadcast on all locations).
+    'Just loc' = single cell of the C matrix at (flow, loc).
+    -}
     }
     deriving (Eq, Show, Generic, NFData, ToJSON, FromJSON)
 
@@ -287,11 +288,25 @@ buildCompartmentMapFromCSV csvData =
                     ]
              in Right $ M.fromList pairs
 
--- | Normalize a compartment using the mapping. Returns original if not found.
+{- | Normalize a compartment using the mapping.
+
+Tries the full @(medium, sub, qualifier)@ key first. On miss, falls back to a
+medium-only key — so a single CSV entry like @"Emissions to air,,,air,,"@
+covers every @(emissions to air, *, *)@ variant by remapping just the medium
+and preserving the original sub/qualifier. Returns the input unchanged if
+neither key resolves; callers can use that as a "no rule for this
+compartment" signal.
+-}
 normalizeCompartment :: CompartmentMap -> Compartment -> Compartment
 normalizeCompartment cmap (Compartment med sub qual) =
-    let key = (T.toLower med, T.toLower sub, T.toLower qual)
-     in M.findWithDefault (Compartment med sub qual) key cmap
+    let lmed = T.toLower med
+        lsub = T.toLower sub
+        lqual = T.toLower qual
+     in case M.lookup (lmed, lsub, lqual) cmap of
+            Just c -> c
+            Nothing -> case M.lookup (lmed, T.empty, T.empty) cmap of
+                Just (Compartment med' _ _) -> Compartment med' sub qual
+                Nothing -> Compartment med sub qual
 
 -- | Number of entries in the compartment map.
 compartmentMapSize :: CompartmentMap -> Int

--- a/src/Plugin/Builtin.hs
+++ b/src/Plugin/Builtin.hs
@@ -344,7 +344,7 @@ hotspotAnalyzer =
     -- Characterization uses the merged flow/unit snapshot the caller built.
     analyzeMethod flowDB unitDB mapCtx inv topN method = do
         mappings <- Mapping.mapMethodFlows defaultMappers mapCtx method
-        let tables = Mapping.buildMethodTables mappings
+        let tables = Mapping.buildMethodTables M.empty mappings
             (rawContribs, _) = Mapping.inventoryContributions UnitConversion.defaultUnitConfig unitDB flowDB inv tables
             sorted = take topN $ sortOn (\(_, _, c) -> negate (abs c)) rawContribs
             total = Mapping.computeLCIAScoreFromTables UnitConversion.defaultUnitConfig unitDB flowDB inv tables

--- a/test/CrossDBInventorySpec.hs
+++ b/test/CrossDBInventorySpec.hs
@@ -177,6 +177,7 @@ spec = do
                     , mtExactCF = M.empty
                     , mtFallbackCF = M.empty
                     , mtRegionalizedCF = M.empty
+                    , mtCompartmentMap = M.empty
                     }
 
             inventory = M.fromList [(uuidRoot, 1.0), (uuidDep, 2.0), (uuidGone, 5.0)]

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -262,6 +262,46 @@ spec = do
                 score = computeLCIAScore defaultUnitConfig M.empty M.empty inventory mapping
             score `shouldBe` 0.0
 
+    describe "buildMethodTables compartment normalization" $ do
+        -- Regression: BAFU categorizes air emissions as "emissions to air/low. pop.",
+        -- ILCD CFs are keyed on bare "air/...". Without a compartment map applied to
+        -- both sides, the lookup misses and the flow silently scores zero.
+        it "scores zero without a compartment map (regression)" $ do
+            fid <- nextRandom
+            let flow = mkFlow fid "ammonia" "emissions to air/low. pop." Nothing
+                cf = mkCFComp "ammonia" "air" "low. pop." 0.747
+                tables = buildMethodTables M.empty [(cf, Nothing)]
+                inventory = M.singleton fid 10.0
+                flowDB = M.singleton fid flow
+                score = computeLCIAScoreFromTables defaultUnitConfig M.empty flowDB inventory tables
+            score `shouldBe` 0.0
+
+        it "bridges 'emissions to air' → 'air' via a medium-only rule" $ do
+            fid <- nextRandom
+            let flow = mkFlow fid "ammonia" "emissions to air/low. pop." Nothing
+                cf = mkCFComp "ammonia" "air" "low. pop." 0.747
+                cmap = M.singleton ("emissions to air", "", "") (Compartment "air" "" "")
+                tables = buildMethodTables cmap [(cf, Nothing)]
+                inventory = M.singleton fid 10.0
+                flowDB = M.singleton fid flow
+                score = computeLCIAScoreFromTables defaultUnitConfig M.empty flowDB inventory tables
+            score `shouldBe` 7.47
+
+        it "bridges full (medium, sub, qual) triples for subcompartment rewrites" $ do
+            fid <- nextRandom
+            let flow = mkFlow fid "ammonia" "emissions to air/low. pop." Nothing
+                -- ILCD-style CF on a different subcompartment than the BAFU flow.
+                cf = mkCFComp "ammonia" "air" "non-urban air or from high stacks" 0.747
+                cmap =
+                    M.singleton
+                        ("emissions to air", "low. pop.", "")
+                        (Compartment "air" "non-urban air or from high stacks" "")
+                tables = buildMethodTables cmap [(cf, Nothing)]
+                inventory = M.singleton fid 10.0
+                flowDB = M.singleton fid flow
+                score = computeLCIAScoreFromTables defaultUnitConfig M.empty flowDB inventory tables
+            score `shouldBe` 7.47
+
     describe "computeMappingStats (ByFuzzy and BySynonym)" $ do
         it "counts ByFuzzy matches" $ do
             fid <- nextRandom

--- a/test/MethodSpec.hs
+++ b/test/MethodSpec.hs
@@ -519,6 +519,65 @@ spec = do
                 let xml = TE.encodeUtf8 "<not-valid-xml"
                 parseMethodBytes xml `shouldSatisfy` isLeft
 
+            it "captures <location> as mcfConsumerLocation and keeps factors distinct" $ do
+                -- EF3.1 ILCD ships per-country CFs as separate <factor> entries each
+                -- carrying <location>. Without parsing this, all country variants
+                -- collapse onto the global default via preferBetter.
+                let xml =
+                        TE.encodeUtf8 $
+                            T.unlines
+                                [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                                , "<LCIAMethodDataSet>"
+                                , "  <LCIAMethodInformation>"
+                                , "    <dataSetInformation>"
+                                , "      <UUID>12345678-1234-1234-1234-123456789012</UUID>"
+                                , "      <name>Regionalized Method</name>"
+                                , "    </dataSetInformation>"
+                                , "    <quantitativeReference>"
+                                , "      <referenceQuantity>"
+                                , "        <shortDescription>mol H+ eq</shortDescription>"
+                                , "      </referenceQuantity>"
+                                , "    </quantitativeReference>"
+                                , "  </LCIAMethodInformation>"
+                                , "  <characterisationFactors>"
+                                , "    <factor>"
+                                , "      <referenceToFlowDataSet refObjectId=\"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\">"
+                                , "        <shortDescription>Ammonia (Mass)</shortDescription>"
+                                , "      </referenceToFlowDataSet>"
+                                , "      <exchangeDirection>Output</exchangeDirection>"
+                                , "      <location>CH</location>"
+                                , "      <meanValue>0.747</meanValue>"
+                                , "    </factor>"
+                                , "    <factor>"
+                                , "      <referenceToFlowDataSet refObjectId=\"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\">"
+                                , "        <shortDescription>Ammonia (Mass)</shortDescription>"
+                                , "      </referenceToFlowDataSet>"
+                                , "      <exchangeDirection>Output</exchangeDirection>"
+                                , "      <location>DE</location>"
+                                , "      <meanValue>4.0</meanValue>"
+                                , "    </factor>"
+                                , "    <factor>"
+                                , "      <referenceToFlowDataSet refObjectId=\"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\">"
+                                , "        <shortDescription>Ammonia (Mass)</shortDescription>"
+                                , "      </referenceToFlowDataSet>"
+                                , "      <exchangeDirection>Output</exchangeDirection>"
+                                , "      <meanValue>3.02</meanValue>"
+                                , "    </factor>"
+                                , "  </characterisationFactors>"
+                                , "</LCIAMethodDataSet>"
+                                ]
+                case parseMethodBytes xml of
+                    Left err -> expectationFailure $ "Parse failed: " ++ err
+                    Right method -> do
+                        let factors = methodFactors method
+                            locValuePairs = [(mcfConsumerLocation cf, mcfValue cf) | cf <- factors]
+                        length factors `shouldBe` 3
+                        locValuePairs
+                            `shouldBe` [ (Just "CH", 0.747)
+                                       , (Just "DE", 4.0)
+                                       , (Nothing, 3.02)
+                                       ]
+
     describe "parseMethodBytesWithFlows" $ do
         let minimalXML =
                 TE.encodeUtf8 $

--- a/test/OlcaSchemaSpec.hs
+++ b/test/OlcaSchemaSpec.hs
@@ -86,5 +86,5 @@ spec = do
                 Left err -> expectationFailure ("parse failed: " ++ err)
                 Right method -> do
                     let mappings = [(cf, Nothing) | cf <- methodFactors method]
-                        tables = buildMethodTables mappings
+                        tables = buildMethodTables M.empty mappings
                     M.size (mtRegionalizedCF tables) `shouldBe` 0


### PR DESCRIPTION
## Summary

Two correctness fixes for CF lookup, extracted from the larger #34 audit branch so they can land on `main` independently.

- **Compartment-map threading.** `MethodTables` now carries the `CompartmentMap` it was built with; `buildMethodTables` applies `normalizeCompartment` to CF compartments before keying, and `lookupCF` normalizes the inventory side at query time. Without this, a BAFU flow categorized as `emissions to air/low. pop.` could never reach an ILCD CF keyed on `air/non-urban air or from high stacks` even when a `compartments.csv` rule existed to bridge them — `lookupCF` returned `Nothing` and the flow silently scored zero. `normalizeCompartment` also grows a medium-only fallback so a single CSV row like `Emissions to air,,,air,,` rewrites the medium across all `(emissions to air, *, *)` variants.

- **ILCD `<location>` parsing.** The ILCD XML parser was hardcoding `mcfConsumerLocation = Nothing` on every CF, so the per-country `<factor>` entries EF3.1 ships for Acidification / Eutrophication / Particulate matter / Land use / Water use all collapsed onto the global default via `preferBetter` and `mtRegionalizedCF` stayed empty. The regionalized scoring path (`computeRegionalizedLCIAScore`) already exists on `main` from #25 — it just had no per-country cells to dispatch to on the ILCD side. Now `<location>CH</location>` is captured into `psCurrentLocation`, reset at factor close, and flows into `mtRegionalizedCF`.

## Test plan

- [x] `cabal test` — 717 passing, 0 failures, 1 pending (unchanged)
- [x] Validated on `Wheat grains IP, at farm {CH}` (BAFU) characterized with EF3.1: Swiss-specific CFs picked from ILCD instead of the global default (matches the per-country tables in the source XML)
- [ ] Reviewer can sanity-check on any regionalized-method run against ILCD XML