### PR TITLE
fix(lcia): sum regional dot products across all participating databases

### DIFF
--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -37,6 +37,7 @@ import qualified Database.Manager as DM
 import API.Types (ActivityForAPI (..), ActivityInfo (..), ClassificationSystem (..), ExchangeWithUnit (..), InventoryExport (..), InventoryFlowDetail (..), Perturbation (..), Substitution (..))
 import Control.Monad (unless)
 import qualified Data.List as L
+import Matrix (applyBiosphereMatrix)
 import Method.Mapping (LCIAOutcome (..), MappingStats (..), SimilarCF (..), SimilarReason (..), UncharacterizedFlow (..), computeLCIAScoreAuto, computeLCIAScoreFromTables, computeMappingStats, defaultUncharacterizedOpts, inventoryContributions)
 import qualified Method.Mapping as Mapping
 import Method.Types (FlowDirection (..), Method (..), MethodCF (..))
@@ -46,8 +47,8 @@ import Plugin.Types ()
 import Progress (ProgressLevel (Warning), reportProgress)
 import qualified Service
 import qualified Service.Aggregate as Agg
-import Matrix (applyBiosphereMatrix)
 import SharedSolver (SharedSolver, computeInventoryMatrixWithDepsCached, crossDBProcessContributions)
+import qualified SharedSolver
 import Types (Activity (..), Database (..), Flow, FlowDB, FlowType (..), Indexes (..), ProcessId, UnitDB, activityLocation, activityName, exchangeIsInput, flowCategory, flowId, flowName, flowSubcompartment, getUnitNameForFlow, processIdToText, unresolvedCount)
 import UnitConversion (defaultUnitConfig)
 
@@ -784,7 +785,7 @@ callGetInventory dbManager rid args =
                 inventory <-
                     ExceptT $
                         if null subs
-                            then computeInventoryMatrixWithDepsCached unitCfg (DM.mkDepSolverLookup dbManager) db solver processId
+                            then fmap (fmap SharedSolver.csInventory) (computeInventoryMatrixWithDepsCached unitCfg (DM.mkDepSolverLookup dbManager) db dbName solver processId)
                             else
                                 either (Left . T.pack . show) Right
                                     <$> Service.inventoryWithSubsAndDeps
@@ -892,7 +893,7 @@ runImpactsRequest dbManager args req = do
     inventory <-
         ExceptT $
             if null subs
-                then computeInventoryMatrixWithDepsCached unitCfg (DM.mkDepSolverLookup dbManager) db (ldSharedSolver ld) (raPid ra)
+                then fmap (fmap SharedSolver.csInventory) (computeInventoryMatrixWithDepsCached unitCfg (DM.mkDepSolverLookup dbManager) db dbName (ldSharedSolver ld) (raPid ra))
                 else
                     either (Left . T.pack . show) Right
                         <$> Service.inventoryWithSubsAndDeps
@@ -1337,11 +1338,13 @@ buildUnmatchedDbFlows dbManager dbName db method args maxN =
                                 unitCfg
                                 (DM.mkDepSolverLookup dbManager)
                                 db
+                                dbName
                                 (ldSharedSolver ld)
                                 pid
                         case invE of
                             Left _ -> pure []
-                            Right inventory -> do
+                            Right sol -> do
+                                let inventory = SharedSolver.csInventory sol
                                 tables <- DM.mapMethodToTablesCached dbManager dbName db method
                                 idx <- DM.mapMethodToIndexCached dbManager dbName method
                                 let opts =
@@ -1567,14 +1570,16 @@ callGetContributingFlows dbManager baseUrl rid args =
                 ExceptT $ pure $ ensureLinked dbName "computing contributions" db
                 unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
                 (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
-                inventory <-
+                sol <-
                     ExceptT $
                         computeInventoryMatrixWithDepsCached
                             unitCfg
                             (DM.mkDepSolverLookup dbManager)
                             db
+                            dbName
                             (ldSharedSolver ld)
                             (raPid ra)
+                let inventory = SharedSolver.csInventory sol
                 tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName db method
                 let outcome = computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables
                     score = loScore outcome

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -36,7 +36,8 @@ import qualified Expr
 import GHC.Generics
 import qualified GHC.Stats
 import Matrix (Inventory, Vector, applyBiosphereMatrix)
-import Method.Mapping (LCIAOutcome (..), MappingStats (..), MatchStrategy (..), MethodTables (..), computeLCIAScoreAuto, computeLCIAScoreFromTables, computeLCIAScoreSetFromTables, computeMappingStats, inventoryContributions)
+import Method.Mapping (LCIAOutcome (..), MappingStats (..), MatchStrategy (..), MethodTables (..), computeLCIAScoreFromTables, computeLCIAScoreSetFromTables, computeMappingStats, inventoryContributions, sumRegionalizedLCIAScoreCrossDB)
+import qualified Method.Mapping
 import Method.Types (DamageCategory (..), FlowDirection (..), Method (..), MethodCF (..), MethodCollection (..), NormWeightSet (..), ScoringEvaluation (..), ScoringSet (..), computeFormulaScores)
 import Numeric (showFFloat)
 import Plugin.Types (AnalyzeContext (..), AnalyzeHandle (..), PluginRegistry (..))
@@ -198,7 +199,16 @@ requireFullyLinked dbName db =
 
 -- | Inventory with cross-DB back-substitution; maps unit-conversion errors to 422.
 inventoryWithDeps :: DatabaseManager -> Text -> Database -> SharedSolver -> ProcessId -> Handler Inventory
-inventoryWithDeps dbManager dbName db solver pid = do
+inventoryWithDeps dbManager dbName db solver pid =
+    SharedSolver.csInventory <$> solutionWithDeps dbManager dbName db solver pid
+
+{- | Cross-DB inventory + per-DB scaling vectors. The scalings are needed by
+the regionalized LCIA path (per-DB dot products summed across all DBs
+reached at request time); the inventory alone is enough for non-regional
+methods.
+-}
+solutionWithDeps :: DatabaseManager -> Text -> Database -> SharedSolver -> ProcessId -> Handler SharedSolver.CrossDBSolution
+solutionWithDeps dbManager dbName db solver pid = do
     requireFullyLinked dbName db
     unitCfg <- liftIO $ getMergedUnitConfig dbManager
     res <-
@@ -207,15 +217,21 @@ inventoryWithDeps dbManager dbName db solver pid = do
                 unitCfg
                 (DM.mkDepSolverLookup dbManager)
                 db
+                dbName
                 solver
                 pid
     case res of
-        Right inv -> pure inv
+        Right sol -> pure sol
         Left err -> throwError err422{errBody = BSL.fromStrict $ T.encodeUtf8 err}
 
 -- | Batch inventory with cross-DB back-substitution; maps unit-conversion errors to 422.
 inventoriesWithDeps :: DatabaseManager -> Text -> Database -> SharedSolver -> [ProcessId] -> Handler [Inventory]
-inventoriesWithDeps dbManager dbName db solver pids = do
+inventoriesWithDeps dbManager dbName db solver pids =
+    map SharedSolver.csInventory <$> solutionsWithDeps dbManager dbName db solver pids
+
+-- | Batch variant of 'solutionWithDeps'.
+solutionsWithDeps :: DatabaseManager -> Text -> Database -> SharedSolver -> [ProcessId] -> Handler [SharedSolver.CrossDBSolution]
+solutionsWithDeps dbManager dbName db solver pids = do
     requireFullyLinked dbName db
     unitCfg <- liftIO $ getMergedUnitConfig dbManager
     res <-
@@ -224,10 +240,11 @@ inventoriesWithDeps dbManager dbName db solver pids = do
                 unitCfg
                 (DM.mkDepSolverLookup dbManager)
                 db
+                dbName
                 solver
                 pids
     case res of
-        Right invs -> pure invs
+        Right sols -> pure sols
         Left err -> throwError err422{errBody = BSL.fromStrict $ T.encodeUtf8 err}
 
 {- | Per-method static context, prepared ONCE per batch request and reused
@@ -743,8 +760,17 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
     getActivityLCIA :: Text -> Text -> Text -> Text -> Maybe Int -> Handler LCIAResult
     getActivityLCIA dbName processIdText _collectionName methodIdText topFlowsParam =
         withActivityAndMethod dbName processIdText methodIdText $ \db sharedSolver actProcessId activity method -> do
-            inventory <- inventoryWithDeps dbManager dbName db sharedSolver actProcessId
-            result <- liftIO $ computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver actProcessId) activity (fromMaybe 5 topFlowsParam) inventory Nothing method
+            sol <- solutionWithDeps dbManager dbName db sharedSolver actProcessId
+            result <-
+                liftIO $
+                    computeCategoryResult
+                        dbName
+                        db
+                        sol
+                        activity
+                        (fromMaybe 5 topFlowsParam)
+                        Nothing
+                        method
             liftIO $ logLCIAResult result method
             return result
 
@@ -767,7 +793,20 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     processId
                     (srSubstitutions subReq)
         inventory <- either throwServiceError pure eInv
-        liftIO $ computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver processId) activity 5 inventory Nothing method
+        -- Substitution path keeps a root-only 'CrossDBSolution': the
+        -- regional cross-DB sum sees only root's MethodTables here, so a
+        -- regional CF that lives in a dep DB's mapping won't apply to the
+        -- substituted-and-routed dep emissions. Tracked as a follow-up;
+        -- substitution + regional cross-DB requires per-DB scalings from
+        -- 'Service.goWithSubsAndDeps', which still returns the merged
+        -- inventory only.
+        rootScaling <- liftIO $ SharedSolver.computeScalingVectorCached db sharedSolver processId
+        let sol =
+                SharedSolver.CrossDBSolution
+                    { SharedSolver.csInventory = inventory
+                    , SharedSolver.csScalings = [(dbName, db, rootScaling)]
+                    }
+        liftIO $ computeCategoryResult dbName db sol activity 5 Nothing method
 
     -- POST: sensitivity sweep (parallel rank-1 perturbations of A_ij)
     postActivitySensitivity :: Text -> Text -> Text -> Text -> SensitivityRequest -> Handler SensitivityResponse
@@ -779,15 +818,29 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
         eRes <- liftIO $ Service.computeSensitivities db sharedSolver processId (srPerturbations senReq)
         (baselineX, perResults) <- either throwServiceError pure eRes
         let baselineInv = applyBiosphereMatrix db baselineX
-        baselineLcia <- liftIO $ computeCategoryResult dbName db (pure baselineX) activity 5 baselineInv Nothing method
-        perturbed <- liftIO $ mapConcurrently (buildEntry db activity method baselineLcia) perResults
+            -- Sensitivity is single-DB by design: the perturbation hits
+            -- the root technosphere. The regional cross-DB sum sees only
+            -- root here, matching the pre-fix behaviour.
+            mkRootSol inv x =
+                SharedSolver.CrossDBSolution
+                    { SharedSolver.csInventory = inv
+                    , SharedSolver.csScalings = [(dbName, db, x)]
+                    }
+        baselineLcia <-
+            liftIO $
+                computeCategoryResult dbName db (mkRootSol baselineInv baselineX) activity 5 Nothing method
+        perturbed <-
+            liftIO $
+                mapConcurrently
+                    (buildEntry db activity method baselineLcia mkRootSol)
+                    perResults
         pure SensitivityResponse{srBaseline = baselineLcia, srPerturbed = perturbed}
       where
-        buildEntry db activity method baselineLcia (p, eitherX) = case eitherX of
+        buildEntry db activity method baselineLcia mkRootSol (p, eitherX) = case eitherX of
             Left err -> pure (PerturbedEntry p (Left err))
             Right x' -> do
                 let inv = applyBiosphereMatrix db x'
-                lcia <- computeCategoryResult dbName db (pure x') activity 5 inv Nothing method
+                lcia <- computeCategoryResult dbName db (mkRootSol inv x') activity 5 Nothing method
                 pure (PerturbedEntry p (Right (lcia, lrScore lcia - lrScore baselineLcia)))
 
     -- Batch LCIA endpoint (all methods in a collection)
@@ -817,7 +870,8 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
             Left err -> throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ T.pack $ show err}
             Right (actProcessId, activity) -> do
                 t0 <- liftIO getCurrentTime
-                inventory <- inventoryWithDeps dbManager dbName db sharedSolver actProcessId
+                sol <- solutionWithDeps dbManager dbName db sharedSolver actProcessId
+                let inventory = SharedSolver.csInventory sol
                 t1 <- liftIO getCurrentTime
                 let !invSize = M.size inventory
                 liftIO $
@@ -841,12 +895,12 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                         reportProgress Info $
                             "  Inventory UUIDs: "
                                 <> intercalate ", " (map UUID.toString $ M.keys inventory)
-                scoreMap <- liftIO $ batchedScoresFor dbName db sharedSolver actProcessId inventory methods
+                scoreMap <- liftIO $ batchedScoresFor dbName db sol methods
                 rawResults <-
                     liftIO $
                         mapConcurrently
                             ( \m ->
-                                computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver actProcessId) activity 5 inventory (M.lookup (methodId m) scoreMap) m
+                                computeCategoryResult dbName db sol activity 5 (M.lookup (methodId m) scoreMap) m
                             )
                             methods
                 -- Enrich with NW data
@@ -897,12 +951,21 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     processId
                     (srSubstitutions subReq)
         inventory <- either throwServiceError pure eInv
-        scoreMap <- liftIO $ batchedScoresFor dbName db sharedSolver processId inventory methods
+        -- Substitution path: root-only 'CrossDBSolution' (regional cross-DB
+        -- sum sees only root MethodTables here, same gap as documented on
+        -- 'postActivityLCIA').
+        rootScaling <- liftIO $ SharedSolver.computeScalingVectorCached db sharedSolver processId
+        let sol =
+                SharedSolver.CrossDBSolution
+                    { SharedSolver.csInventory = inventory
+                    , SharedSolver.csScalings = [(dbName, db, rootScaling)]
+                    }
+        scoreMap <- liftIO $ batchedScoresFor dbName db sol methods
         rawResults <-
             liftIO $
                 mapConcurrently
                     ( \m ->
-                        computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver processId) activity 5 inventory (M.lookup (methodId m) scoreMap) m
+                        computeCategoryResult dbName db sol activity 5 (M.lookup (methodId m) scoreMap) m
                     )
                     methods
         let results = map (enrichWithNW dcLookup mNW) rawResults
@@ -1202,44 +1265,74 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
     -- pass. For fully non-regionalized sets (PEF) this is a stacked-broadcast
     -- matvec — one walk over the inventory, m FMAs per non-zero entry —
     -- instead of m separate inventory walks. Mixed/regio sets fall through
-    -- to per-method 'computeLCIAScoreAuto' inside the set-scoring function.
+    -- to the per-DB cross-DB regional sum inside the set-scoring function.
+    --
+    -- The 'CrossDBSolution' carries the merged inventory and per-DB scaling
+    -- vectors collected during the inventory solve. Regional methods score
+    -- as a sum across all participating DBs (root + each dep DB reached at
+    -- request time); non-regional methods read the merged inventory only.
     batchedScoresFor ::
         Text ->
         Database ->
-        SharedSolver ->
-        ProcessId ->
-        Inventory ->
+        SharedSolver.CrossDBSolution ->
         [Method] ->
         IO (M.Map UUID (Either Text Double))
-    batchedScoresFor dbName db sharedSolver actPid inventory methods = do
-        mst <- DM.mapMethodSetToTablesCached dbManager dbName db methods
+    batchedScoresFor _dbName _db sol methods = do
+        perDb <- buildPerDbSetTables (SharedSolver.csScalings sol) methods
         unitCfg <- getMergedUnitConfig dbManager
         (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
-        -- scalingVec / hier only consulted when 'mst' has any regionalized
-        -- method; for PEF they're never read. Both are cached, so resolving
-        -- them eagerly is cheap.
-        scalingVec <- SharedSolver.computeScalingVectorCached db sharedSolver actPid
         hier <- DM.getLocationHierarchy dbManager
         pure $
             M.fromList $
-                computeLCIAScoreSetFromTables unitCfg mUnits mFlows db scalingVec inventory hier mst
+                computeLCIAScoreSetFromTables
+                    unitCfg
+                    mUnits
+                    mFlows
+                    (SharedSolver.csInventory sol)
+                    hier
+                    perDb
 
-    -- Helper: compute LCIA result for a single method against an inventory.
+    -- Look up MethodSetTables for every (DB, scaling) pair in the cross-DB
+    -- solution. 'mapMethodSetToTablesCached' is keyed by (dbName, methods),
+    -- so dep DBs on a first-time request pay a one-shot
+    -- 'fillRegionalActivityWeights' walk against their own biosphere
+    -- triples; subsequent requests hit the cache.
+    buildPerDbSetTables ::
+        [(Text, Database, Vector)] ->
+        [Method] ->
+        IO [(Database, Vector, Method.Mapping.MethodSetTables)]
+    buildPerDbSetTables scalings methods =
+        forM scalings $ \(n, d, sv) -> do
+            mst <- DM.mapMethodSetToTablesCached dbManager n d methods
+            pure (d, sv, mst)
+
+    -- Helper: compute LCIA result for a single method against a cross-DB
+    -- inventory solution.
     --
-    -- 'getScaling' is a lazy IO action; the scaling vector is required only
-    -- for regionalized methods (non-regionalized fast path skips it entirely).
-    -- For perturbed inventories (sensitivity), pass @pure x'@.
+    -- The 'CrossDBSolution' carries the merged inventory and per-DB scaling
+    -- vectors. Regional methods score as a sum over each participating DB
+    -- ('sumRegionalizedLCIAScoreCrossDB'); non-regional methods read the
+    -- merged inventory only.
     --
     -- 'precomputedScore' short-circuits the per-method scoring loop when a
     -- batched matvec result is already available (see
     -- 'mapMethodSetToTablesCached' + 'computeLCIAScoreSetFromTables'). Pass
     -- 'Nothing' on the single-method paths.
-    computeCategoryResult :: Text -> Database -> IO Vector -> Activity -> Int -> Inventory -> Maybe (Either Text Double) -> Method -> IO LCIAResult
-    computeCategoryResult dbName db getScaling activity topFlows inventory precomputedScore method = do
+    computeCategoryResult ::
+        Text ->
+        Database ->
+        SharedSolver.CrossDBSolution ->
+        Activity ->
+        Int ->
+        Maybe (Either Text Double) ->
+        Method ->
+        IO LCIAResult
+    computeCategoryResult dbName db sol activity topFlows precomputedScore method = do
         unitCfg <- getMergedUnitConfig dbManager
         (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
         mappings <- DM.mapMethodToFlowsCached dbManager dbName db method
         tables <- DM.mapMethodToTablesCached dbManager dbName db method
+        let inventory = SharedSolver.csInventory sol
         -- Force score evaluation here so mapConcurrently actually parallelizes the work
         -- (without this, lazy thunks are created and forced later in the main thread)
         let stats = computeMappingStats mappings
@@ -1253,9 +1346,12 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                 if M.null (mtRegionalizedCF tables)
                     then evaluate $ loScore (computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables)
                     else do
-                        scalingVec <- getScaling
                         hier <- DM.getLocationHierarchy dbManager
-                        case computeLCIAScoreAuto unitCfg mUnits mFlows db scalingVec inventory hier tables of
+                        perDb <-
+                            forM (SharedSolver.csScalings sol) $ \(n, d, sv) -> do
+                                tbls <- DM.mapMethodToTablesCached dbManager n d method
+                                pure (d, sv, tbls)
+                        case sumRegionalizedLCIAScoreCrossDB unitCfg mUnits mFlows hier perDb of
                             Right s -> evaluate s
                             Left err -> do
                                 reportProgress Warning $
@@ -1663,7 +1759,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
             invalid = [pidText | (pidText, Left (Service.InvalidProcessId _)) <- resolved]
             validPidNums = [pidNum | (_, pidNum, _) <- valid]
         t0 <- liftIO getCurrentTime
-        inventories <- inventoriesWithDeps dbManager dbName db sharedSolver validPidNums
+        sols <- solutionsWithDeps dbManager dbName db sharedSolver validPidNums
         t1 <- liftIO getCurrentTime
         -- Pre-fetch per-method static context ONCE for the whole batch instead
         -- of paying it inside every per-pid 'buildLCIABatchResult' call. For
@@ -1680,8 +1776,8 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
         -- stays at 5. Bulk callers that DO want contributors opt in with
         -- ?top-flows=N.
         let topFlows = max 0 (fromMaybe 0 topFlowsParam)
-        let mkEntry ((pidText, pidNum, activity), inventory) = do
-                impacts <- buildLCIABatchResultCached dbName db sharedSolver pidNum activity collection inventory ctxs topFlows
+        let mkEntry ((pidText, pidNum, activity), sol) = do
+                impacts <- buildLCIABatchResultCached dbName db pidNum activity collection sol ctxs topFlows
                 pure
                     BatchImpactsEntry
                         { bieProcessId = pidText
@@ -1691,7 +1787,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
         -- Sequential: inner buildLCIABatchResultCached already runs the
         -- per-method matvec batched in one pass. Nesting outer concurrency
         -- over already-saturated CPU work just adds thread churn.
-        entries <- liftIO $ mapM mkEntry (zip valid inventories)
+        entries <- liftIO $ mapM mkEntry (zip valid sols)
         t2 <- liftIO getCurrentTime
         liftIO $
             reportProgress Info $
@@ -1765,15 +1861,14 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
     buildLCIABatchResultCached ::
         Text ->
         Database ->
-        SharedSolver ->
         ProcessId ->
         Activity ->
         MethodCollection ->
-        Inventory ->
+        SharedSolver.CrossDBSolution ->
         [MethodCtx] ->
         Int ->
         IO LCIABatchResult
-    buildLCIABatchResultCached dbName db sharedSolver actPid activity collection inventory ctxs topFlows = do
+    buildLCIABatchResultCached dbName db actPid activity collection sol ctxs topFlows = do
         let damageCats = mcDamageCategories collection
             nwSets = mcNormWeightSets collection
             dcLookup =
@@ -1784,7 +1879,8 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     ]
             mNW = case nwSets of (nw : _) -> Just nw; [] -> Nothing
             methods = map mctxMethod ctxs
-        scoreMap <- batchedScoresFor dbName db sharedSolver actPid inventory methods
+            inventory = SharedSolver.csInventory sol
+        scoreMap <- batchedScoresFor dbName db sol methods
         (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
         -- Surface inventory flows that aren't in the merged FlowDB once per pid
         -- (independent of method, independent of topFlows) — the signal is a

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -36,6 +36,7 @@ module Method.Mapping (
     computeLCIAScoreFromTables,
     computeLCIAScoreAuto,
     computeRegionalizedLCIAScore,
+    sumRegionalizedLCIAScoreCrossDB,
     computeLCIAScoreWithDiagnostics,
     findUncharacterized,
     findSimilarCFs,
@@ -928,12 +929,21 @@ computeRegionalizedLCIAScore ::
 computeRegionalizedLCIAScore _unitConfig _unitDB _flowDB _db scalingVec _hier tables =
     case mtRegionalActivityWeights tables of
         Just raw -> scoreFromPrecomputed raw scalingVec
-        Nothing ->
-            Left
-                "Regionalized score requested but precomputed activity weights\
-                \ are absent. Call 'fillRegionalActivityWeights' on the\
-                \ MethodTables before scoring (mapMethodToTablesCached does\
-                \ this automatically)."
+        Nothing
+            -- Cross-DB scoring passes per-DB tables in; a dep DB whose flow
+            -- mappings caught none of this method's regional CFs has empty
+            -- 'mtRegionalizedCF', so 'fillRegionalActivityWeights' left
+            -- 'mtRegionalActivityWeights' unfilled. Treat as a 0
+            -- contribution rather than erroring — non-regional emissions
+            -- from that DB are handled by the broadcast pass for which the
+            -- DB built 'rawWeights' from its own broadcast cell.
+            | M.null (mtRegionalizedCF tables) -> Right 0
+            | otherwise ->
+                Left
+                    "Regionalized score requested but precomputed activity weights\
+                    \ are absent. Call 'fillRegionalActivityWeights' on the\
+                    \ MethodTables before scoring (mapMethodToTablesCached does\
+                    \ this automatically)."
   where
     -- Fast path: one dot product over precomputed per-column weights.
     -- If any tainted activity carries non-zero scaling, surface the gap
@@ -976,6 +986,41 @@ computeRegionalizedLCIAScore _unitConfig _unitDB _flowDB _db scalingVec _hier ta
                                         <> " tainted activity column(s) reached by this inventory"
                                         <> " — see warnings emitted at table-build time for the missing (flow, location) pairs."
                             else Right score
+
+{- | Cross-DB regionalized LCIA score.
+
+For each participating database @d@ (root + each dep DB reached at request
+time), call 'computeRegionalizedLCIAScore' against THAT DB's scaling
+vector and MethodTables, then sum the per-DB scores. Equivalent to one
+dot product over the concatenated activity space
+@[s_root, s_dep1, …] · [w_root, w_dep1, …]@ — just computed per-DB so
+each side keeps its own activity index, hierarchy walks and tainted-column
+diagnostics local.
+
+Closes the gap where dep-DB biosphere emissions are present in the merged
+inventory but invisible to the regional dot product (which was previously
+keyed on the root DB's activity columns alone).
+
+Left from any per-DB call short-circuits to Left of the whole sum so a
+silent under-count never masquerades as a Right score: callers handle the
+gap explicitly (the per-pid WARN at the caller site, the build-time WARN
+that listed which (flow, location) pairs are uncovered).
+-}
+sumRegionalizedLCIAScoreCrossDB ::
+    UnitConfig ->
+    UnitDB ->
+    FlowDB ->
+    M.Map Text [Text] ->
+    {- | Per-DB triples: one per database participating in the cross-DB solve
+    (root + dep DBs in the same order returned by 'SharedSolver.csScalings').
+    -}
+    [(Database, Vector, MethodTables)] ->
+    Either Text Double
+sumRegionalizedLCIAScoreCrossDB unitCfg unitDB flowDB hier triples =
+    sum <$> traverse one triples
+  where
+    one (db, scaling, tables) =
+        computeRegionalizedLCIAScore unitCfg unitDB flowDB db scaling hier tables
 
 {- | Resolve a CF for a (flow, location) pair through the hierarchy + broadcast
 fallback. See 'computeRegionalizedLCIAScore' for the rules.
@@ -1313,52 +1358,73 @@ regional method whose coverage is incomplete (mirrors 'computeLCIAScoreAuto').
 The two halves of the set are scored by separate code paths and merged by
 methodId so the result list follows the input order ('msAllMethods'):
 
-  * non-regional half ('msBatched'): one matvec over the shared dense
-    broadcast — the PR #29 fast path, restored for mixed sets like EF 3.1;
-  * regional half ('msRegional'): per-method dispatch through
-    'computeLCIAScoreAuto', which since PR #39 is itself a per-pid dot
-    product against precomputed activity weights.
+  * non-regional half ('msBatched' on root): one matvec over the shared
+    dense broadcast — the PR #29 fast path, restored for mixed sets like
+    EF 3.1. Reads the merged cross-DB inventory, so dep-DB flows are
+    characterized without any per-DB bookkeeping.
+  * regional half ('msRegional' on root): per-method cross-DB sum
+    ('sumRegionalizedLCIAScoreCrossDB'). For each regional method, the
+    score is @Σ_d rawWeights_d · scaling_d@ across every participating
+    database — root + each dep DB reached at request time. Closes the
+    gap where dep-DB regional CFs were previously invisible.
+
+Callers pass the per-DB triples as a non-empty list with the ROOT triple
+first. The non-regional matvec is keyed off the root entry's 'msBatched';
+the regional cross-DB sum walks every entry.
 -}
 computeLCIAScoreSetFromTables ::
     UnitConfig ->
     UnitDB ->
     FlowDB ->
-    Database ->
-    Vector ->
     Inventory ->
     M.Map Text [Text] ->
-    MethodSetTables ->
+    {- | Non-empty per-DB triples: head is root, tail is each participating
+    dep DB. Building order matches 'SharedSolver.csScalings'.
+    -}
+    [(Database, Vector, MethodSetTables)] ->
     [(UUID, Either Text Double)]
-computeLCIAScoreSetFromTables unitCfg unitDB flowDB db scalingVec inventory hier mst =
-    let batched = scoreBatched unitCfg unitDB flowDB (msBatched mst) inventory
-        regional =
-            scoreRegional unitCfg unitDB flowDB db scalingVec inventory hier (msRegional mst)
+computeLCIAScoreSetFromTables _ _ _ _ _ [] = []
+computeLCIAScoreSetFromTables unitCfg unitDB flowDB inventory hier perDb@((_, _, mstRoot) : _) =
+    let batched = scoreBatched unitCfg unitDB flowDB (msBatched mstRoot) inventory
+        regional = scoreRegionalCrossDB unitCfg unitDB flowDB hier (msRegional mstRoot) perDb
         byId = M.fromList (batched ++ regional)
      in [ (mseMethodId e, byId M.! mseMethodId e)
-        | e <- V.toList (msAllMethods mst)
+        | e <- V.toList (msAllMethods mstRoot)
         ]
 
-{- | Per-method dispatch for the regional half of a 'MethodSetTables'. Each
-call into 'computeLCIAScoreAuto' uses PR #39's precomputed regional
-activity weights, so individually they're tight dot products — they
-just aren't stacked across methods (yet).
+{- | Per-method cross-DB regional sum. For each regional method, scores
+@Σ_d rawWeights_d · scaling_d@ across all participating DBs by looking
+up that method's tables in each DB's 'MethodSetTables' and summing the
+per-DB dot products via 'sumRegionalizedLCIAScoreCrossDB'.
+
+A DB whose 'MethodSetTables' has no entry for a given methodId (mismatched
+sets) contributes 0 for that method — the same neutral element as a DB
+whose mappings caught none of the method's regional CFs.
 -}
-scoreRegional ::
+scoreRegionalCrossDB ::
     UnitConfig ->
     UnitDB ->
     FlowDB ->
-    Database ->
-    Vector ->
-    Inventory ->
     M.Map Text [Text] ->
     V.Vector MethodSetEntry ->
+    [(Database, Vector, MethodSetTables)] ->
     [(UUID, Either Text Double)]
-scoreRegional unitCfg unitDB flowDB db scalingVec inventory hier ms =
+scoreRegionalCrossDB unitCfg unitDB flowDB hier ms perDb =
     [ ( mseMethodId e
-      , computeLCIAScoreAuto unitCfg unitDB flowDB db scalingVec inventory hier (mseTables e)
+      , sumRegionalizedLCIAScoreCrossDB unitCfg unitDB flowDB hier (triples (mseMethodId e))
       )
     | e <- V.toList ms
     ]
+  where
+    -- Per-method per-DB triples; skip DBs that don't carry this method.
+    triples mid =
+        [ (db, sv, t)
+        | (db, sv, mst) <- perDb
+        , Just t <- [lookupMethodTables mid mst]
+        ]
+    lookupMethodTables mid mst =
+        mseTables
+            <$> V.find ((== mid) . mseMethodId) (msAllMethods mst)
 
 {- | One sparse-inventory matvec over the non-regional half of a method set.
 For each non-zero @(uuid, qty)@ in the inventory, accumulates

--- a/src/Service/Aggregate.hs
+++ b/src/Service/Aggregate.hs
@@ -45,6 +45,7 @@ import Service (
     resolveActivityAndProcessId,
  )
 import SharedSolver (DepSolverLookup, SharedSolver, computeInventoryMatrixWithDepsCached, solveWithSharedSolver)
+import qualified SharedSolver
 import Types (
     Activity,
     Database (..),
@@ -162,11 +163,12 @@ aggregate unitConfig flowDB unitDB db dbName solver depLookup pidText params =
                             False
                     return $ fmap (reduce params . rowsFromSupplyChain) eResp
                 ScopeBiosphere -> do
-                    invE <- computeInventoryMatrixWithDepsCached unitConfig depLookup db solver processId
-                    case invE of
+                    solE <- computeInventoryMatrixWithDepsCached unitConfig depLookup db dbName solver processId
+                    case solE of
                         Left err -> return (Left (MatrixError err))
-                        Right inventory ->
-                            let export = convertToInventoryExport db flowDB unitDB processId activity inventory
+                        Right sol ->
+                            let inventory = SharedSolver.csInventory sol
+                                export = convertToInventoryExport db flowDB unitDB processId activity inventory
                              in return $ Right $ reduce params (rowsFromBiosphere export)
   where
     emptyFilter maxD =

--- a/src/SharedSolver.hs
+++ b/src/SharedSolver.hs
@@ -28,6 +28,7 @@ module SharedSolver (
 
     -- * Cross-database back-substitution
     DepSolverLookup,
+    CrossDBSolution (..),
     computeInventoryMatrixWithDepsCached,
     computeInventoryMatrixBatchWithDepsCached,
     goWithDepsFromScalings,
@@ -176,6 +177,27 @@ zero-contribution supplier and continues.
 -}
 type DepSolverLookup = Text -> IO (Maybe (Database, SharedSolver))
 
+{- | Per-pid result of a cross-DB inventory solve: the merged biosphere
+'Inventory' plus the per-DB scaling vectors that produced it.
+
+The scaling vectors are needed by the regionalized LCIA path, which scores
+each DB's biosphere triples against THAT DB's scaling — a sum across all
+DBs reached at request time, not a single dot product against the root.
+Without per-DB scalings, dep-DB regional CFs are silently invisible
+(the merged 'Inventory' has the emissions but lost the per-activity
+location context the regional CF lookup needs).
+
+'csScalings' lists every DB visited (root first, then dep DBs in BFS
+order — both the order and the recursion depth follow the same dep-graph
+walk that built 'csInventory'). A DB whose scaling vector is the zero
+vector for this pid is still included; downstream consumers can drop it,
+but the solver never silently omits a participating DB.
+-}
+data CrossDBSolution = CrossDBSolution
+    { csInventory :: !Inventory
+    , csScalings :: ![(Text, Database, Vector)]
+    }
+
 {- |
 Batch inventory with cross-DB back-substitution. Multi-RHS is preserved at
 every level of the dependency DAG:
@@ -186,21 +208,29 @@ every level of the dependency DAG:
 * Recurse into the dep DB's own cross-DB links (Agribalyse → Ecoinvent, etc.).
 * Sum local + all dep contributions per root by 'M.unionWith (+)'.
 
+Returns one 'CrossDBSolution' per pid: the merged inventory plus the per-DB
+scaling vectors that produced it. The regional LCIA path uses the scalings
+to sum per-DB regional dot products; callers that only need the inventory
+extract 'csInventory'.
+
 Depth is capped at 10 as a safety net against pathological data (cyclic links).
 -}
 computeInventoryMatrixBatchWithDepsCached ::
     UnitConfig ->
     DepSolverLookup ->
     Database ->
+    -- | root DB name (recorded in the head of each 'csScalings')
+    Text ->
     SharedSolver ->
     [ProcessId] ->
-    IO (Either Text [Inventory])
-computeInventoryMatrixBatchWithDepsCached _ _ _ _ [] = pure (Right [])
-computeInventoryMatrixBatchWithDepsCached unitConfig depLookup db solver pids =
+    IO (Either Text [CrossDBSolution])
+computeInventoryMatrixBatchWithDepsCached _ _ _ _ _ [] = pure (Right [])
+computeInventoryMatrixBatchWithDepsCached unitConfig depLookup db dbName solver pids =
     goWithDeps
         unitConfig
         depLookup
         db
+        dbName
         solver
         (map (buildDemandVectorFromIndex (dbActivityIndex db)) pids)
         0
@@ -210,15 +240,17 @@ computeInventoryMatrixWithDepsCached ::
     UnitConfig ->
     DepSolverLookup ->
     Database ->
+    -- | root DB name (recorded in the head of 'csScalings')
+    Text ->
     SharedSolver ->
     ProcessId ->
-    IO (Either Text Inventory)
-computeInventoryMatrixWithDepsCached unitConfig depLookup db solver pid = do
-    res <- computeInventoryMatrixBatchWithDepsCached unitConfig depLookup db solver [pid]
+    IO (Either Text CrossDBSolution)
+computeInventoryMatrixWithDepsCached unitConfig depLookup db dbName solver pid = do
+    res <- computeInventoryMatrixBatchWithDepsCached unitConfig depLookup db dbName solver [pid]
     pure $ case res of
         Left err -> Left err
-        Right (inv : _) -> Right inv
-        Right [] -> Right M.empty -- unreachable: batch is non-empty
+        Right (sol : _) -> Right sol
+        Right [] -> Right (CrossDBSolution M.empty []) -- unreachable: batch is non-empty
 
 -- | Safety net against cyclic cross-DB links (Ginko → Agribalyse → Ginko).
 maxDepsDepth :: Int
@@ -228,15 +260,17 @@ goWithDeps ::
     UnitConfig ->
     DepSolverLookup ->
     Database ->
+    -- | THIS DB's name (recorded in the 'csScalings' entry contributed at this level)
+    Text ->
     SharedSolver ->
     -- | K demand vectors, length = dbActivityCount db
     [Vector] ->
     -- | recursion depth
     Int ->
-    IO (Either Text [Inventory])
-goWithDeps unitConfig depLookup db solver demands depth = do
+    IO (Either Text [CrossDBSolution])
+goWithDeps unitConfig depLookup db dbName solver demands depth = do
     scalings <- solveMultiWithSharedSolver solver demands
-    goWithDepsFromScalings unitConfig depLookup db [] scalings depth
+    goWithDepsFromScalings unitConfig depLookup db dbName [] scalings depth
 
 {- | Propagate pre-computed root scalings into the dep-DB graph. Same body as
 the dep-propagation half of 'goWithDeps' but skips the root solve — the
@@ -247,27 +281,38 @@ entries to fold into 'accumulateDepDemands' at this level only.
 Extra links are applied at the root DB only; recursive calls into dep DBs
 use their static 'dbCrossDBLinks'. Supporting nested substitutions would
 require threading per-DB extras through 'resolveDep' — out of scope.
+
+Each returned 'CrossDBSolution' is built bottom-up: the current DB
+contributes its @(dbName, db, scaling)@ entry, then dep DBs append theirs
+through 'resolveDep'. Dep entries appear in the BFS order of 'allDepDbs'.
 -}
 goWithDepsFromScalings ::
     UnitConfig ->
     DepSolverLookup ->
     Database ->
+    -- | THIS DB's name
+    Text ->
     -- | virtual links to inject at this level (root only)
     [CrossDBLink] ->
     -- | K pre-computed root scaling vectors
     [Vector] ->
     -- | recursion depth
     Int ->
-    IO (Either Text [Inventory])
-goWithDepsFromScalings unitConfig depLookup db extraLinks scalings depth = do
+    IO (Either Text [CrossDBSolution])
+goWithDepsFromScalings unitConfig depLookup db dbName extraLinks scalings depth = do
     let localInvs = map (applyBiosphereMatrix db) scalings
+        baseSolutions =
+            zipWith
+                (\inv s -> CrossDBSolution inv [(dbName, db, s)])
+                localInvs
+                scalings
     if depth >= maxDepsDepth
-        then pure (Right localInvs)
+        then pure (Right baseSolutions)
         else do
             let perRootDepDemands = map (accumulateDepDemandsWith db extraLinks) scalings
                 allDepDbs = S.toList $ S.unions $ map M.keysSet perRootDepDemands
             if null allDepDbs
-                then pure (Right localInvs)
+                then pure (Right baseSolutions)
                 else do
                     depResults <-
                         mapConcurrently
@@ -275,13 +320,21 @@ goWithDepsFromScalings unitConfig depLookup db extraLinks scalings depth = do
                             allDepDbs
                     pure $ case sequence depResults of
                         Left err -> Left err
-                        Right depContribsByDb ->
-                            let perRootDepInvs = transpose depContribsByDb
+                        Right depSolsByDb ->
+                            let perRootDepSols = transpose depSolsByDb
                              in Right $
                                     zipWith
-                                        (foldr (M.unionWith (+)))
-                                        localInvs
-                                        perRootDepInvs
+                                        mergeSolutions
+                                        baseSolutions
+                                        perRootDepSols
+  where
+    mergeSolutions base depSols =
+        CrossDBSolution
+            { csInventory =
+                foldr (M.unionWith (+)) (csInventory base) (map csInventory depSols)
+            , csScalings =
+                csScalings base ++ concatMap csScalings depSols
+            }
 
 resolveDep ::
     UnitConfig ->
@@ -292,18 +345,19 @@ resolveDep ::
     -- | K (so we can pad with empty on a missing dep DB)
     Int ->
     Text ->
-    IO (Either Text [Inventory])
+    IO (Either Text [CrossDBSolution])
 resolveDep unitConfig depLookup perRootDepDemands depth k depDbName = do
     depM <- depLookup depDbName
     case depM of
         Nothing ->
-            pure (Right (replicate k M.empty))
+            pure (Right (replicate k (CrossDBSolution M.empty [])))
         Just (depDb, depSolver) ->
             let demandsPerRoot = map (M.findWithDefault M.empty depDbName) perRootDepDemands
                 depVecsE = traverse (depDemandsToVector unitConfig depDbName depDb) demandsPerRoot
              in case depVecsE of
                     Left err -> pure (Left err)
-                    Right depDemandVecs -> goWithDeps unitConfig depLookup depDb depSolver depDemandVecs (depth + 1)
+                    Right depDemandVecs ->
+                        goWithDeps unitConfig depLookup depDb depDbName depSolver depDemandVecs (depth + 1)
 
 {- | Cross-DB per-activity LCIA contributions. Walks the same dep graph as
 'goWithDeps' but attributes contributions per @(dbName, localPid)@ instead

--- a/test/CrossDBInventorySpec.hs
+++ b/test/CrossDBInventorySpec.hs
@@ -31,6 +31,7 @@ import SharedSolver (
     computeInventoryMatrixBatchWithDepsCached,
     createSharedSolver,
  )
+import qualified SharedSolver
 import Test.Hspec
 import TestHelpers (loadSampleDatabase)
 import Types
@@ -108,14 +109,14 @@ spec = do
                 noDeps _ = pure Nothing
 
             localInvs <- computeInventoryMatrixBatchCached db solver pids
-            withDepsE <- computeInventoryMatrixBatchWithDepsCached defaultUnitConfig noDeps db solver pids
+            withDepsE <- computeInventoryMatrixBatchWithDepsCached defaultUnitConfig noDeps db "SAMPLE.min3" solver pids
 
             case withDepsE of
                 Left err -> expectationFailure (T.unpack err)
-                Right withDepsInvs -> do
-                    length withDepsInvs `shouldBe` length localInvs
-                    case (localInvs, withDepsInvs) of
-                        ([a], [b]) -> M.toList a `shouldBe` M.toList b
+                Right withDepsSols -> do
+                    length withDepsSols `shouldBe` length localInvs
+                    case (localInvs, withDepsSols) of
+                        ([a], [b]) -> M.toList a `shouldBe` M.toList (SharedSolver.csInventory b)
                         _ -> expectationFailure "expected one inventory per pid"
 
         it "empty pid list returns empty result without solving" $ do
@@ -127,8 +128,10 @@ spec = do
                 actCount = fromIntegral (dbActivityCount db)
             solver <- createSharedSolver "SAMPLE.min3-empty" techTriples actCount
             let noDeps _ = pure Nothing
-            res <- computeInventoryMatrixBatchWithDepsCached defaultUnitConfig noDeps db solver []
-            res `shouldBe` Right []
+            res <- computeInventoryMatrixBatchWithDepsCached defaultUnitConfig noDeps db "SAMPLE.min3-empty" solver []
+            case res of
+                Right sols -> length sols `shouldBe` 0
+                Left err -> expectationFailure (T.unpack err)
 
     describe "inventoryContributions (cross-DB characterization surface)" $ do
         -- Synthetic data: simulate the shape of a cross-DB-merged Inventory

--- a/test/CrossDBRegionalLCIASpec.hs
+++ b/test/CrossDBRegionalLCIASpec.hs
@@ -1,0 +1,352 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Regression: regional LCIA must score dep-DB biosphere emissions, not
+just root-DB ones.
+
+The 'computeRegionalizedLCIAScore' fast path is a dot product
+@rawWeights · scalingVec@. Both vectors are built from a single 'Database':
+'rawWeights' from that DB's biosphere triples, 'scalingVec' from that DB's
+activity columns. So when a root-DB activity consumes a dep-DB activity,
+the dep DB's emissions are present in the merged 'Inventory' but invisible
+to the regional path — its regional CFs were never queried.
+
+This spec sets up two synthetic DBs linked by 'CrossDBLink' such that the
+only biosphere emission with a regional CF lives in the dep DB. The "broken"
+case shows the root-only score is 0 (the bug); the "fixed" case shows that
+summing per-DB regional dot products recovers the right answer.
+-}
+module CrossDBRegionalLCIASpec (spec) where
+
+import Data.Int (Int32)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as U
+
+import Test.Hspec
+
+import Method.Mapping
+import Method.Types (FlowDirection (..), MethodCF (..))
+import qualified SharedSolver as SS
+import TestHelpers (mkSolverFromDb)
+import Types
+import UnitConversion (UnitConfig (..), UnitDef (..))
+
+-- ---------------------------------------------------------------------------
+-- Fixture
+-- ---------------------------------------------------------------------------
+
+-- One biosphere flow shared by both DBs (cross-DB merging keys on UUID).
+flowUUID :: UUID
+flowUUID = mkUUID 1
+
+-- Activity UUIDs: root has a1, dep has b1..bN.
+actUUID :: Int -> UUID
+actUUID i = mkUUID (toInteger (1000 + i))
+
+prodUUID :: Int -> UUID
+prodUUID i = mkUUID (toInteger (2000 + i))
+
+mkUUID :: Integer -> UUID
+mkUUID n = UUID.fromWords64 (fromIntegral n) 0
+
+kgUnit :: Unit
+kgUnit = Unit{unitId = mkUUID 9, unitName = "kg", unitSymbol = "kg", unitComment = ""}
+
+kgUnitConfig :: UnitConfig
+kgUnitConfig =
+    UnitConfig
+        { ucDimensionOrder =
+            ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
+        , ucUnits = M.fromList [("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)]
+        , ucOriginalKeys = M.fromList [("kg", "kg")]
+        }
+
+testFlow :: Flow
+testFlow =
+    Flow
+        { flowId = flowUUID
+        , flowName = "Carbon dioxide"
+        , flowCategory = "air"
+        , flowSubcompartment = Nothing
+        , flowUnitId = unitId kgUnit
+        , flowType = Biosphere
+        , flowSynonyms = M.empty
+        , flowCAS = Nothing
+        , flowSubstanceId = Nothing
+        }
+
+mkActivity :: Int -> Text -> Activity
+mkActivity i loc =
+    Activity
+        { activityName = "act-" <> loc
+        , activityDescription = []
+        , activitySynonyms = M.empty
+        , activityClassification = M.empty
+        , activityLocation = loc
+        , activityUnit = "kg"
+        , exchanges = []
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        }
+  where
+    _ = i
+
+emptyIndexes :: Indexes
+emptyIndexes = Indexes M.empty M.empty M.empty M.empty M.empty M.empty
+
+{- | Build a synthetic single-DB fixture parameterized by:
+* @offset@: starting index for activity UUIDs (so root and dep don't collide)
+* @locs@: locations for each activity, length determines activity count
+* @bioTriples@: (flowRow=0, activityCol, value) sparse entries to emit on
+  the single biosphere flow @flowUUID@. Empty for DBs that emit nothing.
+
+The technosphere matrix is left empty — the MUMPS layer adds the identity
+on each diagonal so (I - 0)·x = d trivially yields x = d. This is enough
+for the cross-DB regional gap test: we only need cleanly-defined scaling
+vectors per DB.
+-}
+mkDB :: Int -> [Text] -> [(Int, Double)] -> Database
+mkDB offset locs bioTriples =
+    let n = length locs
+        activities = V.fromList [mkActivity (offset + i) loc | (i, loc) <- zip [0 ..] locs]
+        actIdx = V.fromList [fromIntegral i :: Int32 | i <- [0 .. n - 1]]
+        triples = U.fromList [SparseTriple 0 (fromIntegral c) v | (c, v) <- bioTriples]
+        procIds = V.fromList [(actUUID (offset + i), prodUUID (offset + i)) | i <- [0 .. n - 1]]
+        procIdLookup =
+            M.fromList
+                [((actUUID (offset + i), prodUUID (offset + i)), fromIntegral i :: Int32) | i <- [0 .. n - 1]]
+     in Database
+            { dbProcessIdTable = procIds
+            , dbProcessIdLookup = procIdLookup
+            , dbActivityUUIDIndex = M.empty
+            , dbActivityProductsIndex = M.empty
+            , dbProductIndex = emptyProductIndex
+            , dbActivities = activities
+            , dbFlows = M.singleton flowUUID testFlow
+            , dbUnits = M.singleton (unitId kgUnit) kgUnit
+            , dbIndexes = emptyIndexes
+            , dbTechnosphereTriples = U.empty
+            , dbBiosphereTriples = triples
+            , dbActivityIndex = actIdx
+            , dbBiosphereFlows = V.singleton flowUUID
+            , dbActivityCount = fromIntegral n
+            , dbBiosphereCount = 1
+            , dbCrossDBLinks = []
+            , dbDependsOn = []
+            , dbLinkingStats = emptyCrossDBLinkingStats
+            , dbSynonymDB = Nothing
+            , dbFlowsByName = M.empty
+            , dbFlowsByCAS = M.empty
+            , dbProductSearchIndex = M.empty
+            , dbBM25Index = Nothing
+            }
+
+{- | Add a 'CrossDBLink' from the first activity of @consumerDb@ to the
+named activity in @supplierDb@ (identified by its index inside the supplier's
+'dbProcessIdTable').
+-}
+linkAt ::
+    Database ->
+    Database ->
+    Text ->
+    -- | supplier activity index in supplierDb
+    Int ->
+    -- | coefficient (mass moved across the link)
+    Double ->
+    Database
+linkAt consumerDb supplierDb supplierName supIdx coeff =
+    let (consumerAct, consumerProd) = dbProcessIdTable consumerDb V.! 0
+        (supplierAct, supplierProd) = dbProcessIdTable supplierDb V.! supIdx
+        link =
+            CrossDBLink
+                { cdlConsumerActUUID = consumerAct
+                , cdlConsumerProdUUID = consumerProd
+                , cdlSupplierActUUID = supplierAct
+                , cdlSupplierProdUUID = supplierProd
+                , cdlCoefficient = coeff
+                , cdlExchangeUnit = "kg"
+                , cdlFlowName = "x-link"
+                , cdlLocation = activityLocation (dbActivities supplierDb V.! supIdx)
+                , cdlSourceDatabase = supplierName
+                }
+     in consumerDb{dbCrossDBLinks = link : dbCrossDBLinks consumerDb}
+
+-- ---------------------------------------------------------------------------
+-- MethodTables: one regional CF per location, all on the shared flow F
+-- ---------------------------------------------------------------------------
+
+regionalMappings :: [(Text, Double)] -> [(MethodCF, Maybe (Flow, MatchStrategy))]
+regionalMappings = map (\(loc, v) -> (cf loc v, Just (testFlow, ByName)))
+  where
+    cf loc v =
+        MethodCF
+            { mcfFlowRef = flowUUID
+            , mcfFlowName = "Carbon dioxide"
+            , mcfDirection = Output
+            , mcfValue = v
+            , mcfCompartment = Nothing
+            , mcfCAS = Nothing
+            , mcfUnit = "kg"
+            , mcfConsumerLocation = Just loc
+            }
+
+buildTables :: Database -> [(MethodCF, Maybe (Flow, MatchStrategy))] -> MethodTables
+buildTables db mappings =
+    let raw = buildMethodTables M.empty mappings
+        withBroadcast = fillBroadcastVector kgUnitConfig (dbUnits db) (dbFlows db) raw
+     in fillRegionalActivityWeights
+            kgUnitConfig
+            (dbUnits db)
+            (dbFlows db)
+            db
+            M.empty
+            withBroadcast
+
+-- ---------------------------------------------------------------------------
+-- Spec
+-- ---------------------------------------------------------------------------
+
+spec :: Spec
+spec = describe "cross-DB regional LCIA" $ do
+    -- Fixture used by both expectations:
+    --   * Root DB R: 1 activity at FR. No biosphere emission. Cross-DB link
+    --     to dep DB D's activity #1 (the one at DE), coefficient 1.0.
+    --   * Dep DB D: 3 activities at FR, DE, GLO. D's activity #1 (DE) emits
+    --     1.0 kg of biosphere flow F.
+    --   * Method M: one regional CF table on F: FR=1, DE=5, GLO=0.5.
+    --
+    -- Demanding R's activity #0 forces 1 unit of D's activity #1 (DE).
+    --   * Dep scaling x_D = [0, 1, 0].
+    --   * Dep regional weights w_D = [0, 1·CF[F,DE], 0] = [0, 5, 0].
+    --   * Root weights w_R: empty (R has no biosphere triples).
+    --   * Cross-DB regional score = w_R·x_R + w_D·x_D = 0 + 5 = 5.
+    let depDb = mkDB 1 ["FR", "DE", "GLO"] [(1, 1.0)] -- emission only on the DE column
+        rootBase = mkDB 100 ["FR"] []
+        rootDb = linkAt rootBase depDb "dep" 1 1.0
+
+        rootMappings = regionalMappings [("FR", 1), ("DE", 5), ("GLO", 0.5)]
+        rootTables = buildTables rootDb rootMappings
+        depTables = buildTables depDb rootMappings
+
+    it "OLD path: root-only regional score silently misses dep-DB emissions" $ do
+        -- Today's contract: computeLCIAScoreAuto is handed the ROOT db's
+        -- scaling vector and the ROOT db's MethodTables. The merged
+        -- Inventory containing F=1 kg is passed too, but the regional path
+        -- ignores it — score = rawWeights_root · scaling_root = 0.
+        rootSolver <- mkSolverFromDb rootDb "root"
+        depSolver <- mkSolverFromDb depDb "dep"
+        let depLookup name =
+                pure $
+                    if name == "dep" then Just (depDb, depSolver) else Nothing
+        eRes <-
+            SS.computeInventoryMatrixWithDepsCached
+                kgUnitConfig
+                depLookup
+                rootDb
+                "root"
+                rootSolver
+                0 -- root's only activity column
+        case eRes of
+            Left err -> expectationFailure ("solve failed: " <> show err)
+            Right sol -> do
+                let inv = SS.csInventory sol
+                -- Sanity: dep DB's emission shows up in the merged inventory.
+                M.lookup flowUUID inv `shouldBe` Just 1.0
+                -- The bug surface: the regional path scored against root
+                -- tables/scaling alone returns 0 (or, depending on how the
+                -- caller invokes it, the wrong number — never 5).
+                let rootScaling = case [s | (n, _, s) <- SS.csScalings sol, n == "root"] of
+                        (s : _) -> s
+                        [] -> U.empty
+                computeRegionalizedLCIAScore
+                    kgUnitConfig
+                    (dbUnits rootDb)
+                    (dbFlows rootDb)
+                    rootDb
+                    rootScaling
+                    M.empty
+                    rootTables
+                    `shouldBe` Right 0.0
+
+    it "NEW path: per-DB regional sum recovers the dep-DB contribution" $ do
+        rootSolver <- mkSolverFromDb rootDb "root"
+        depSolver <- mkSolverFromDb depDb "dep"
+        let depLookup name =
+                pure $
+                    if name == "dep" then Just (depDb, depSolver) else Nothing
+        eRes <-
+            SS.computeInventoryMatrixWithDepsCached
+                kgUnitConfig
+                depLookup
+                rootDb
+                "root"
+                rootSolver
+                0
+        case eRes of
+            Left err -> expectationFailure ("solve failed: " <> show err)
+            Right sol -> do
+                let perDb =
+                        [ (db, s, tablesFor n)
+                        | (n, db, s) <- SS.csScalings sol
+                        ]
+                    tablesFor n = case n of
+                        "root" -> rootTables
+                        "dep" -> depTables
+                        other -> error ("unexpected dbName in csScalings: " <> show other)
+                sumRegionalizedLCIAScoreCrossDB
+                    kgUnitConfig
+                    (dbUnits depDb)
+                    (dbFlows depDb)
+                    M.empty
+                    perDb
+                    `shouldBe` Right 5.0
+
+    it "NEW path: tainted dep-DB activity with non-zero scaling surfaces Left" $ do
+        -- Same DBs, but the method only has CF[F, FR]. The dep DB's DE
+        -- activity is regionalized in the method (F appears in regional
+        -- CFs) but no CF resolves at DE / parents / broadcast — that's a
+        -- tainted column, and it carries scaling 1. The contract from
+        -- computeRegionalizedLCIAScore is to Left, and the cross-DB sum
+        -- must propagate that Left rather than silently substituting 0.
+        let strictMappings = regionalMappings [("FR", 1)]
+            depTablesStrict = buildTables depDb strictMappings
+            rootTablesStrict = buildTables rootDb strictMappings
+        rootSolver <- mkSolverFromDb rootDb "root"
+        depSolver <- mkSolverFromDb depDb "dep"
+        let depLookup name =
+                pure $
+                    if name == "dep" then Just (depDb, depSolver) else Nothing
+        eRes <-
+            SS.computeInventoryMatrixWithDepsCached
+                kgUnitConfig
+                depLookup
+                rootDb
+                "root"
+                rootSolver
+                0
+        case eRes of
+            Left err -> expectationFailure ("solve failed: " <> show err)
+            Right sol -> do
+                let perDb =
+                        [ (db, s, tablesFor n)
+                        | (n, db, s) <- SS.csScalings sol
+                        ]
+                    tablesFor n = case n of
+                        "root" -> rootTablesStrict
+                        "dep" -> depTablesStrict
+                        other -> error ("unexpected dbName in csScalings: " <> show other)
+                case sumRegionalizedLCIAScoreCrossDB
+                    kgUnitConfig
+                    (dbUnits depDb)
+                    (dbFlows depDb)
+                    M.empty
+                    perDb of
+                    Left _ -> pure ()
+                    Right v ->
+                        expectationFailure
+                            ( "expected Left for tainted cross-DB scoring, got Right "
+                                <> show v
+                            )

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -163,11 +163,9 @@ spec = do
                         UnitConversion.defaultUnitConfig
                         udb
                         fdb
-                        unusedDatabase
-                        U.empty -- scalingVec unused for non-regio
                         inv
                         M.empty -- hier unused for non-regio
-                        mst
+                        [(unusedDatabase, U.empty, mst)] -- scalingVec unused for non-regio
                 resultMap = M.fromList results
             -- Sanity: explicit numbers
             sA `shouldBe` 8.0 -- 4*2 + 0.1*0 (no ch4 cf)
@@ -194,11 +192,9 @@ spec = do
                         UnitConversion.defaultUnitConfig
                         udb
                         fdb
-                        unusedDatabase
-                        U.empty
                         M.empty
                         M.empty
-                        mst
+                        [(unusedDatabase, U.empty, mst)]
             map snd results `shouldBe` [Right 0.0, Right 0.0]
 
         it "inventory UUIDs absent from both broadcast and flowDB contribute 0" $ do
@@ -222,11 +218,9 @@ spec = do
                         UnitConversion.defaultUnitConfig
                         udb
                         fdb
-                        unusedDatabase
-                        U.empty
                         inv
                         M.empty
-                        mst
+                        [(unusedDatabase, U.empty, mst)]
             -- Only the matched flow contributes: 2 × 3 = 6.
             map snd results `shouldBe` [Right 6.0]
 
@@ -270,11 +264,9 @@ spec = do
                         UnitConversion.defaultUnitConfig
                         udb
                         scoringFlowDB
-                        unusedDatabase
-                        U.empty
                         inv
                         M.empty
-                        mst
+                        [(unusedDatabase, U.empty, mst)]
             -- Both contribute against CF=3: (2 + 4) × 3 = 18.
             map snd results `shouldBe` [Right 18.0]
 
@@ -350,11 +342,9 @@ spec = do
                         UnitConversion.defaultUnitConfig
                         udb
                         fdb
-                        unusedDatabase
-                        U.empty
                         inv
                         M.empty
-                        mst
+                        [(unusedDatabase, U.empty, mst)]
             -- Caller order preserved on the result keys.
             map fst results
                 `shouldBe` [methodId m1, methodId m2, methodId m3]

--- a/test/NestedSubstitutionSpec.hs
+++ b/test/NestedSubstitutionSpec.hs
@@ -30,6 +30,7 @@ import SharedSolver (
     createSharedSolver,
     solveWithSharedSolver,
  )
+import qualified SharedSolver
 import Test.Hspec
 import TestHelpers (
     linkDatabases,
@@ -141,10 +142,10 @@ spec = do
             solver <- mkSolver db "SAMPLE.min3"
             let pid = 0
                 noDeps _ = pure Nothing
-            eBase <- computeInventoryMatrixWithDepsCached defaultUnitConfig noDeps db solver pid
+            eBase <- computeInventoryMatrixWithDepsCached defaultUnitConfig noDeps db "SAMPLE.min3" solver pid
             eSub <- inventoryWithSubsAndDeps defaultUnitConfig noDeps db "SAMPLE.min3" solver pid []
             case (eBase, eSub) of
-                (Right base, Right subInv) -> M.toList subInv `shouldBe` M.toList base
+                (Right base, Right subInv) -> M.toList subInv `shouldBe` M.toList (SharedSolver.csInventory base)
                 (Left e, _) -> expectationFailure ("baseline failed: " <> T.unpack e)
                 (_, Left e) -> expectationFailure ("subs path failed: " <> show e)
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -11,6 +11,7 @@ import qualified ChemSynonymsSpec
 import qualified CoalescingSolverSpec
 import qualified ConfigSpec
 import qualified CrossDBInventorySpec
+import qualified CrossDBRegionalLCIASpec
 import qualified CrossDBSubstitutionSpec
 import qualified CrossLinkingSpec
 import qualified DatabaseStatusSpec
@@ -68,6 +69,7 @@ main = hspec $ do
         describe "Service Layer" ServiceSpec.spec
         describe "Cross-Database Linking" CrossLinkingSpec.spec
         describe "Cross-DB Inventory" CrossDBInventorySpec.spec
+        describe "Cross-DB Regional LCIA" CrossDBRegionalLCIASpec.spec
         describe "Substitutions" SubstitutionSpec.spec
         describe "Sensitivity Analysis" SensitivitySpec.spec
         describe "Cross-DB Substitutions" CrossDBSubstitutionSpec.spec

--- a/test/SubstitutionSpec.hs
+++ b/test/SubstitutionSpec.hs
@@ -26,6 +26,7 @@ import SharedSolver (
     computeInventoryMatrixWithDepsCached,
     createSharedSolver,
  )
+import qualified SharedSolver
 import Test.Hspec
 import TestHelpers (loadSampleDatabase)
 import Types
@@ -40,11 +41,11 @@ spec = do
             let pid = 0
                 noDeps _ = pure Nothing
 
-            eBase <- computeInventoryMatrixWithDepsCached defaultUnitConfig noDeps db solver pid
+            eBase <- computeInventoryMatrixWithDepsCached defaultUnitConfig noDeps db "SAMPLE.min3" solver pid
             eSub <- inventoryWithSubsAndDeps defaultUnitConfig noDeps db "SAMPLE.min3" solver pid []
 
             case (eBase, eSub) of
-                (Right base, Right sub) -> M.toList sub `shouldBe` M.toList base
+                (Right base, Right sub) -> M.toList sub `shouldBe` M.toList (SharedSolver.csInventory base)
                 (Left e, _) -> expectationFailure ("baseline failed: " <> T.unpack e)
                 (_, Left e) -> expectationFailure ("subs path failed: " <> show e)
 

--- a/volca.cabal
+++ b/volca.cabal
@@ -174,6 +174,8 @@ test-suite lca-tests
                      , ServiceSpec
                      , CrossLinkingSpec
                      , CrossDBInventorySpec
+                     , CrossDBRegionalLCIASpec
+                     , RegionalLCIASpec
                      , SharedSolverSpec
                      , CoalescingSolverSpec
                      , FlowResolverSpec


### PR DESCRIPTION
## Summary

- Regional LCIA's fast path was a per-database dot product, keyed only on the root database's activity columns. When a root activity consumed an activity in a dependency database, the dep database's biosphere emissions landed in the merged inventory but were invisible to the regional CF cascade — the regional score silently under-counted.
- This PR threads per-database scaling vectors out of the cross-database inventory solver in a new `CrossDBSolution`, and replaces the regional scoring contract with `Σ_d rawWeights_d · scaling_d` across every participating database. Each side keeps its own activity index, location hierarchy, and tainted-column diagnostics.
- A new spec (`CrossDBRegionalLCIASpec`) pins the gap and the fix side-by-side on a synthetic two-database fixture where the only biosphere emission with a regional CF lives in the dep database. The "OLD path" expectation locks in the root-only score = 0; the "NEW path" expectation requires the cross-database sum to recover the true score; a third case keeps the no-silent-errors invariant: a tainted dep-database column with non-zero scaling surfaces as `Left`.

## Expected behavior changes

- Cross-database recipes that hit regional methods will now see score changes wherever a dep-database biosphere flow had a regional CF that was previously not applied. Non-regional method scores are unchanged.
- Substitution and sensitivity paths still build a root-only `CrossDBSolution` and inherit the same gap they had before — closing that for those paths requires per-database scalings out of `Service.goWithSubsAndDeps`, parked as a follow-up.

## Test plan

- [x] `cabal test lca-tests` — 792 examples, 0 failures (3 new in `CrossDBRegionalLCIASpec`)
- [ ] Diff regional method scores on a cross-database export against pre-fix output and confirm only dep-database-driven cells move