### PR TITLE
fix(lcia): sum regional dot products across all participating databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ cache/
 !CHANGELOG.md
 !THIRD_PARTY_LICENSES.md
 !docs/**/*.md
+!scripts/verify-pr41-regression.md
 
 # temporary python stuff (not pyvolca/)
 /pyproject.toml

--- a/scripts/verify-pr41-regression.md
+++ b/scripts/verify-pr41-regression.md
@@ -1,0 +1,147 @@
+# Real-data regression run-book for PR #41 (`fix/cross-db-regional-lcia`)
+
+## Why this exists
+
+PR #41's test-plan item 2 reads:
+
+> Diff regional method scores on a cross-database export against
+> pre-fix output and confirm only dep-database-driven cells move.
+
+In-tree HSpec covers the synthetic gap-and-fix proof point (regional
+score = 5.0 on a two-DB fixture) and the three non-regression invariants
+(non-regional methods unchanged, root-only recipes unchanged, merged
+inventory = Σ per-DB matvec). What HSpec cannot cover without loading
+real PEF/EF3.1 method fixtures into the suite is "no unintended movement
+on real-world cells." This run-book is the manual gate.
+
+Run it once before merging; attach the diff summary to the PR.
+
+## What we expect
+
+For a real cross-DB recipe (Agribalyse root + Ecoinvent dep, EF 3.1 method
+set), the fix changes scores **only** on regional methods **only** on
+pids that actually consume a dep-DB activity carrying a regional CF
+emission. Specifically:
+
+- Non-regional methods (e.g. GWP100, ODP) → bit-identical scores
+  before/after.
+- Regional methods (e.g. AcidEP, WaterUse) on pids with no dep-DB reach
+  → bit-identical.
+- Regional methods on pids with dep-DB reach → score moves *up* (the
+  silently under-counted dep contribution is now applied). The
+  magnitude of the move scales with the cross-DB link coefficient and
+  the dep DB's regional CF density.
+
+Any cell that moves outside this rule is a regression to investigate.
+
+## Prereqs
+
+- Two databases loaded:
+  - `agribalyse` (root)
+  - `ecoinvent` (dep, with `dbDependsOn` set or `dbCrossDBLinks`
+    pointing at `agribalyse`)
+- An EF 3.1 method collection loaded.
+- `jq`, `curl`, GNU `diff` available locally.
+- The volca server running on `:8080` (or adjust `BASE` below).
+
+## Step 1 — capture the pre-fix baseline
+
+Check out the parent of PR #41's first commit, rebuild, run the server:
+
+```bash
+git rev-parse HEAD                 # save current ref
+git checkout 148d6bb               # parent of PR #41's commits (main at time of writing)
+./gen-version.sh && cabal build volca:exe:volca
+cabal run volca:exe:volca -- volca.toml &
+```
+
+Curate ~10 pids that span cases (some with dep reach, some without). A
+quick way to find candidates: ask `/api/v1/activities` for the root DB,
+then filter by those whose supply chain touches the dep DB. Save the
+list to `pids.txt` (one pid per line).
+
+Collect baseline scores:
+
+```bash
+BASE=http://localhost:8080
+mkdir -p pre-fix
+while read pid; do
+  curl -s "$BASE/api/v1/databases/agribalyse/activities/$pid/lcia-batch?collection=EF-3.1" \
+    > "pre-fix/$pid.json"
+done < pids.txt
+```
+
+## Step 2 — capture the post-fix output
+
+```bash
+git checkout fix/cross-db-regional-lcia
+./gen-version.sh && cabal build volca:exe:volca
+# restart server …
+mkdir -p post-fix
+while read pid; do
+  curl -s "$BASE/api/v1/databases/agribalyse/activities/$pid/lcia-batch?collection=EF-3.1" \
+    > "post-fix/$pid.json"
+done < pids.txt
+```
+
+## Step 3 — diff and classify
+
+Extract `(pid, methodId, score)` triples and join:
+
+```bash
+for pid in $(cat pids.txt); do
+  jq -r --arg pid "$pid" \
+    '.results[] | [$pid, .methodId, .score] | @tsv' \
+    "pre-fix/$pid.json"
+done | sort > pre.tsv
+
+for pid in $(cat pids.txt); do
+  jq -r --arg pid "$pid" \
+    '.results[] | [$pid, .methodId, .score] | @tsv' \
+    "post-fix/$pid.json"
+done | sort > post.tsv
+
+# Moved cells (any score change beyond float noise):
+join -t $'\t' -j 2 pre.tsv post.tsv \
+  | awk -F'\t' '{ d = $4 - $5; if (d < -1e-9 || d > 1e-9) print }' \
+  > moved.tsv
+```
+
+For every line in `moved.tsv`, verify:
+
+1. The `methodId` resolves to a regional method (its `MethodTables.mtRegionalizedCF`
+   is non-empty after build). Quickest check: look up the method in
+   the EF 3.1 collection JSON and confirm at least one CF has a
+   `consumerLocation` field.
+2. The `pid` actually consumes a dep-DB activity. Run
+   `/api/v1/databases/agribalyse/activities/$pid/supply-chain` and grep
+   for entries with `databaseName != "agribalyse"`.
+3. The score change is **positive** (the fix recovers the missing
+   contribution, never zeros a previously-correct score).
+
+Any moved cell failing one of these rules is a regression — bisect the
+PR commits to find which one introduced it.
+
+## Step 4 — record the result
+
+Add a comment on PR #41 with:
+
+- Number of pids tested.
+- Number of moved cells.
+- Number of unmoved cells (should be the bulk).
+- A few sample moved cells (pid, method, pre, post, % change).
+- Confirmation that the three classification rules hold for every
+  moved cell.
+
+Then check the box in the PR description.
+
+## When to re-run
+
+- Before any merge that touches `Service.goWithSubsAndDeps`,
+  `SharedSolver.goWithDepsFromScalings`, `SharedSolver.mergeSolutions`,
+  `Method.Mapping.sumRegionalizedLCIAScoreCrossDB`, or
+  `Method.Mapping.computeLCIAScoreSetFromTables`.
+- Before any release that bundles a method-set or DB-graph change.
+
+The synthetic HSpec suite catches the algebra; this run-book catches
+the integration with real method tables and real cross-DB topologies.

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -37,6 +37,7 @@ import qualified Database.Manager as DM
 import API.Types (ActivityForAPI (..), ActivityInfo (..), ClassificationSystem (..), ExchangeWithUnit (..), InventoryExport (..), InventoryFlowDetail (..), Perturbation (..), Substitution (..))
 import Control.Monad (unless)
 import qualified Data.List as L
+import Matrix (applyBiosphereMatrix)
 import Method.Mapping (LCIAOutcome (..), MappingStats (..), SimilarCF (..), SimilarReason (..), UncharacterizedFlow (..), computeLCIAScoreAuto, computeLCIAScoreFromTables, computeMappingStats, defaultUncharacterizedOpts, inventoryContributions)
 import qualified Method.Mapping as Mapping
 import Method.Types (FlowDirection (..), Method (..), MethodCF (..))
@@ -46,8 +47,8 @@ import Plugin.Types ()
 import Progress (ProgressLevel (Warning), reportProgress)
 import qualified Service
 import qualified Service.Aggregate as Agg
-import Matrix (applyBiosphereMatrix)
 import SharedSolver (SharedSolver, computeInventoryMatrixWithDepsCached, crossDBProcessContributions)
+import qualified SharedSolver
 import Types (Activity (..), Database (..), Flow, FlowDB, FlowType (..), Indexes (..), ProcessId, UnitDB, activityLocation, activityName, exchangeIsInput, flowCategory, flowId, flowName, flowSubcompartment, getUnitNameForFlow, processIdToText, unresolvedCount)
 import UnitConversion (defaultUnitConfig)
 
@@ -784,7 +785,7 @@ callGetInventory dbManager rid args =
                 inventory <-
                     ExceptT $
                         if null subs
-                            then computeInventoryMatrixWithDepsCached unitCfg (DM.mkDepSolverLookup dbManager) db solver processId
+                            then fmap (fmap SharedSolver.csInventory) (computeInventoryMatrixWithDepsCached unitCfg (DM.mkDepSolverLookup dbManager) db dbName solver processId)
                             else
                                 either (Left . T.pack . show) Right
                                     <$> Service.inventoryWithSubsAndDeps
@@ -892,7 +893,7 @@ runImpactsRequest dbManager args req = do
     inventory <-
         ExceptT $
             if null subs
-                then computeInventoryMatrixWithDepsCached unitCfg (DM.mkDepSolverLookup dbManager) db (ldSharedSolver ld) (raPid ra)
+                then fmap (fmap SharedSolver.csInventory) (computeInventoryMatrixWithDepsCached unitCfg (DM.mkDepSolverLookup dbManager) db dbName (ldSharedSolver ld) (raPid ra))
                 else
                     either (Left . T.pack . show) Right
                         <$> Service.inventoryWithSubsAndDeps
@@ -1337,11 +1338,13 @@ buildUnmatchedDbFlows dbManager dbName db method args maxN =
                                 unitCfg
                                 (DM.mkDepSolverLookup dbManager)
                                 db
+                                dbName
                                 (ldSharedSolver ld)
                                 pid
                         case invE of
                             Left _ -> pure []
-                            Right inventory -> do
+                            Right sol -> do
+                                let inventory = SharedSolver.csInventory sol
                                 tables <- DM.mapMethodToTablesCached dbManager dbName db method
                                 idx <- DM.mapMethodToIndexCached dbManager dbName method
                                 let opts =
@@ -1567,14 +1570,16 @@ callGetContributingFlows dbManager baseUrl rid args =
                 ExceptT $ pure $ ensureLinked dbName "computing contributions" db
                 unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
                 (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
-                inventory <-
+                sol <-
                     ExceptT $
                         computeInventoryMatrixWithDepsCached
                             unitCfg
                             (DM.mkDepSolverLookup dbManager)
                             db
+                            dbName
                             (ldSharedSolver ld)
                             (raPid ra)
+                let inventory = SharedSolver.csInventory sol
                 tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName db method
                 let outcome = computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables
                     score = loScore outcome

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -787,7 +787,7 @@ callGetInventory dbManager rid args =
                         if null subs
                             then fmap (fmap SharedSolver.csInventory) (computeInventoryMatrixWithDepsCached unitCfg (DM.mkDepSolverLookup dbManager) db dbName solver processId)
                             else
-                                either (Left . T.pack . show) Right
+                                either (Left . T.pack . show) (Right . SharedSolver.csInventory)
                                     <$> Service.inventoryWithSubsAndDeps
                                         unitCfg
                                         (DM.mkDepSolverLookup dbManager)
@@ -895,7 +895,7 @@ runImpactsRequest dbManager args req = do
             if null subs
                 then fmap (fmap SharedSolver.csInventory) (computeInventoryMatrixWithDepsCached unitCfg (DM.mkDepSolverLookup dbManager) db dbName (ldSharedSolver ld) (raPid ra))
                 else
-                    either (Left . T.pack . show) Right
+                    either (Left . T.pack . show) (Right . SharedSolver.csInventory)
                         <$> Service.inventoryWithSubsAndDeps
                             unitCfg
                             (DM.mkDepSolverLookup dbManager)

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -36,7 +36,8 @@ import qualified Expr
 import GHC.Generics
 import qualified GHC.Stats
 import Matrix (Inventory, Vector, applyBiosphereMatrix)
-import Method.Mapping (LCIAOutcome (..), MappingStats (..), MatchStrategy (..), MethodTables (..), computeLCIAScoreAuto, computeLCIAScoreFromTables, computeLCIAScoreSetFromTables, computeMappingStats, inventoryContributions)
+import Method.Mapping (LCIAOutcome (..), MappingStats (..), MatchStrategy (..), MethodTables (..), computeLCIAScoreFromTables, computeLCIAScoreSetFromTables, computeMappingStats, inventoryContributions, sumRegionalizedLCIAScoreCrossDB)
+import qualified Method.Mapping
 import Method.Types (DamageCategory (..), FlowDirection (..), Method (..), MethodCF (..), MethodCollection (..), NormWeightSet (..), ScoringEvaluation (..), ScoringSet (..), computeFormulaScores)
 import Numeric (showFFloat)
 import Plugin.Types (AnalyzeContext (..), AnalyzeHandle (..), PluginRegistry (..))
@@ -198,7 +199,16 @@ requireFullyLinked dbName db =
 
 -- | Inventory with cross-DB back-substitution; maps unit-conversion errors to 422.
 inventoryWithDeps :: DatabaseManager -> Text -> Database -> SharedSolver -> ProcessId -> Handler Inventory
-inventoryWithDeps dbManager dbName db solver pid = do
+inventoryWithDeps dbManager dbName db solver pid =
+    SharedSolver.csInventory <$> solutionWithDeps dbManager dbName db solver pid
+
+{- | Cross-DB inventory + per-DB scaling vectors. The scalings are needed by
+the regionalized LCIA path (per-DB dot products summed across all DBs
+reached at request time); the inventory alone is enough for non-regional
+methods.
+-}
+solutionWithDeps :: DatabaseManager -> Text -> Database -> SharedSolver -> ProcessId -> Handler SharedSolver.CrossDBSolution
+solutionWithDeps dbManager dbName db solver pid = do
     requireFullyLinked dbName db
     unitCfg <- liftIO $ getMergedUnitConfig dbManager
     res <-
@@ -207,15 +217,21 @@ inventoryWithDeps dbManager dbName db solver pid = do
                 unitCfg
                 (DM.mkDepSolverLookup dbManager)
                 db
+                dbName
                 solver
                 pid
     case res of
-        Right inv -> pure inv
+        Right sol -> pure sol
         Left err -> throwError err422{errBody = BSL.fromStrict $ T.encodeUtf8 err}
 
 -- | Batch inventory with cross-DB back-substitution; maps unit-conversion errors to 422.
 inventoriesWithDeps :: DatabaseManager -> Text -> Database -> SharedSolver -> [ProcessId] -> Handler [Inventory]
-inventoriesWithDeps dbManager dbName db solver pids = do
+inventoriesWithDeps dbManager dbName db solver pids =
+    map SharedSolver.csInventory <$> solutionsWithDeps dbManager dbName db solver pids
+
+-- | Batch variant of 'solutionWithDeps'.
+solutionsWithDeps :: DatabaseManager -> Text -> Database -> SharedSolver -> [ProcessId] -> Handler [SharedSolver.CrossDBSolution]
+solutionsWithDeps dbManager dbName db solver pids = do
     requireFullyLinked dbName db
     unitCfg <- liftIO $ getMergedUnitConfig dbManager
     res <-
@@ -224,10 +240,11 @@ inventoriesWithDeps dbManager dbName db solver pids = do
                 unitCfg
                 (DM.mkDepSolverLookup dbManager)
                 db
+                dbName
                 solver
                 pids
     case res of
-        Right invs -> pure invs
+        Right sols -> pure sols
         Left err -> throwError err422{errBody = BSL.fromStrict $ T.encodeUtf8 err}
 
 {- | Per-method static context, prepared ONCE per batch request and reused
@@ -743,8 +760,17 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
     getActivityLCIA :: Text -> Text -> Text -> Text -> Maybe Int -> Handler LCIAResult
     getActivityLCIA dbName processIdText _collectionName methodIdText topFlowsParam =
         withActivityAndMethod dbName processIdText methodIdText $ \db sharedSolver actProcessId activity method -> do
-            inventory <- inventoryWithDeps dbManager dbName db sharedSolver actProcessId
-            result <- liftIO $ computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver actProcessId) activity (fromMaybe 5 topFlowsParam) inventory Nothing method
+            sol <- solutionWithDeps dbManager dbName db sharedSolver actProcessId
+            result <-
+                liftIO $
+                    computeCategoryResult
+                        dbName
+                        db
+                        sol
+                        activity
+                        (fromMaybe 5 topFlowsParam)
+                        Nothing
+                        method
             liftIO $ logLCIAResult result method
             return result
 
@@ -767,7 +793,20 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     processId
                     (srSubstitutions subReq)
         inventory <- either throwServiceError pure eInv
-        liftIO $ computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver processId) activity 5 inventory Nothing method
+        -- Substitution path keeps a root-only 'CrossDBSolution': the
+        -- regional cross-DB sum sees only root's MethodTables here, so a
+        -- regional CF that lives in a dep DB's mapping won't apply to the
+        -- substituted-and-routed dep emissions. Tracked as a follow-up;
+        -- substitution + regional cross-DB requires per-DB scalings from
+        -- 'Service.goWithSubsAndDeps', which still returns the merged
+        -- inventory only.
+        rootScaling <- liftIO $ SharedSolver.computeScalingVectorCached db sharedSolver processId
+        let sol =
+                SharedSolver.CrossDBSolution
+                    { SharedSolver.csInventory = inventory
+                    , SharedSolver.csScalings = [(dbName, db, rootScaling)]
+                    }
+        liftIO $ computeCategoryResult dbName db sol activity 5 Nothing method
 
     -- POST: sensitivity sweep (parallel rank-1 perturbations of A_ij)
     postActivitySensitivity :: Text -> Text -> Text -> Text -> SensitivityRequest -> Handler SensitivityResponse
@@ -779,15 +818,29 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
         eRes <- liftIO $ Service.computeSensitivities db sharedSolver processId (srPerturbations senReq)
         (baselineX, perResults) <- either throwServiceError pure eRes
         let baselineInv = applyBiosphereMatrix db baselineX
-        baselineLcia <- liftIO $ computeCategoryResult dbName db (pure baselineX) activity 5 baselineInv Nothing method
-        perturbed <- liftIO $ mapConcurrently (buildEntry db activity method baselineLcia) perResults
+            -- Sensitivity is single-DB by design: the perturbation hits
+            -- the root technosphere. The regional cross-DB sum sees only
+            -- root here, matching the pre-fix behaviour.
+            mkRootSol inv x =
+                SharedSolver.CrossDBSolution
+                    { SharedSolver.csInventory = inv
+                    , SharedSolver.csScalings = [(dbName, db, x)]
+                    }
+        baselineLcia <-
+            liftIO $
+                computeCategoryResult dbName db (mkRootSol baselineInv baselineX) activity 5 Nothing method
+        perturbed <-
+            liftIO $
+                mapConcurrently
+                    (buildEntry db activity method baselineLcia mkRootSol)
+                    perResults
         pure SensitivityResponse{srBaseline = baselineLcia, srPerturbed = perturbed}
       where
-        buildEntry db activity method baselineLcia (p, eitherX) = case eitherX of
+        buildEntry db activity method baselineLcia mkRootSol (p, eitherX) = case eitherX of
             Left err -> pure (PerturbedEntry p (Left err))
             Right x' -> do
                 let inv = applyBiosphereMatrix db x'
-                lcia <- computeCategoryResult dbName db (pure x') activity 5 inv Nothing method
+                lcia <- computeCategoryResult dbName db (mkRootSol inv x') activity 5 Nothing method
                 pure (PerturbedEntry p (Right (lcia, lrScore lcia - lrScore baselineLcia)))
 
     -- Batch LCIA endpoint (all methods in a collection)
@@ -817,7 +870,8 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
             Left err -> throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ T.pack $ show err}
             Right (actProcessId, activity) -> do
                 t0 <- liftIO getCurrentTime
-                inventory <- inventoryWithDeps dbManager dbName db sharedSolver actProcessId
+                sol <- solutionWithDeps dbManager dbName db sharedSolver actProcessId
+                let inventory = SharedSolver.csInventory sol
                 t1 <- liftIO getCurrentTime
                 let !invSize = M.size inventory
                 liftIO $
@@ -841,12 +895,12 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                         reportProgress Info $
                             "  Inventory UUIDs: "
                                 <> intercalate ", " (map UUID.toString $ M.keys inventory)
-                scoreMap <- liftIO $ batchedScoresFor dbName db sharedSolver actProcessId inventory methods
+                scoreMap <- liftIO $ batchedScoresFor dbName db sol methods
                 rawResults <-
                     liftIO $
                         mapConcurrently
                             ( \m ->
-                                computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver actProcessId) activity 5 inventory (M.lookup (methodId m) scoreMap) m
+                                computeCategoryResult dbName db sol activity 5 (M.lookup (methodId m) scoreMap) m
                             )
                             methods
                 -- Enrich with NW data
@@ -897,12 +951,21 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     processId
                     (srSubstitutions subReq)
         inventory <- either throwServiceError pure eInv
-        scoreMap <- liftIO $ batchedScoresFor dbName db sharedSolver processId inventory methods
+        -- Substitution path: root-only 'CrossDBSolution' (regional cross-DB
+        -- sum sees only root MethodTables here, same gap as documented on
+        -- 'postActivityLCIA').
+        rootScaling <- liftIO $ SharedSolver.computeScalingVectorCached db sharedSolver processId
+        let sol =
+                SharedSolver.CrossDBSolution
+                    { SharedSolver.csInventory = inventory
+                    , SharedSolver.csScalings = [(dbName, db, rootScaling)]
+                    }
+        scoreMap <- liftIO $ batchedScoresFor dbName db sol methods
         rawResults <-
             liftIO $
                 mapConcurrently
                     ( \m ->
-                        computeCategoryResult dbName db (SharedSolver.computeScalingVectorCached db sharedSolver processId) activity 5 inventory (M.lookup (methodId m) scoreMap) m
+                        computeCategoryResult dbName db sol activity 5 (M.lookup (methodId m) scoreMap) m
                     )
                     methods
         let results = map (enrichWithNW dcLookup mNW) rawResults
@@ -1202,44 +1265,74 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
     -- pass. For fully non-regionalized sets (PEF) this is a stacked-broadcast
     -- matvec — one walk over the inventory, m FMAs per non-zero entry —
     -- instead of m separate inventory walks. Mixed/regio sets fall through
-    -- to per-method 'computeLCIAScoreAuto' inside the set-scoring function.
+    -- to the per-DB cross-DB regional sum inside the set-scoring function.
+    --
+    -- The 'CrossDBSolution' carries the merged inventory and per-DB scaling
+    -- vectors collected during the inventory solve. Regional methods score
+    -- as a sum across all participating DBs (root + each dep DB reached at
+    -- request time); non-regional methods read the merged inventory only.
     batchedScoresFor ::
         Text ->
         Database ->
-        SharedSolver ->
-        ProcessId ->
-        Inventory ->
+        SharedSolver.CrossDBSolution ->
         [Method] ->
         IO (M.Map UUID (Either Text Double))
-    batchedScoresFor dbName db sharedSolver actPid inventory methods = do
-        mst <- DM.mapMethodSetToTablesCached dbManager dbName db methods
+    batchedScoresFor _dbName _db sol methods = do
+        perDb <- buildPerDbSetTables (SharedSolver.csScalings sol) methods
         unitCfg <- getMergedUnitConfig dbManager
         (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
-        -- scalingVec / hier only consulted when 'mst' has any regionalized
-        -- method; for PEF they're never read. Both are cached, so resolving
-        -- them eagerly is cheap.
-        scalingVec <- SharedSolver.computeScalingVectorCached db sharedSolver actPid
         hier <- DM.getLocationHierarchy dbManager
         pure $
             M.fromList $
-                computeLCIAScoreSetFromTables unitCfg mUnits mFlows db scalingVec inventory hier mst
+                computeLCIAScoreSetFromTables
+                    unitCfg
+                    mUnits
+                    mFlows
+                    (SharedSolver.csInventory sol)
+                    hier
+                    perDb
 
-    -- Helper: compute LCIA result for a single method against an inventory.
+    -- Look up MethodSetTables for every (DB, scaling) pair in the cross-DB
+    -- solution. 'mapMethodSetToTablesCached' is keyed by (dbName, methods),
+    -- so dep DBs on a first-time request pay a one-shot
+    -- 'fillRegionalActivityWeights' walk against their own biosphere
+    -- triples; subsequent requests hit the cache.
+    buildPerDbSetTables ::
+        [(Text, Database, Vector)] ->
+        [Method] ->
+        IO [(Database, Vector, Method.Mapping.MethodSetTables)]
+    buildPerDbSetTables scalings methods =
+        forM scalings $ \(n, d, sv) -> do
+            mst <- DM.mapMethodSetToTablesCached dbManager n d methods
+            pure (d, sv, mst)
+
+    -- Helper: compute LCIA result for a single method against a cross-DB
+    -- inventory solution.
     --
-    -- 'getScaling' is a lazy IO action; the scaling vector is required only
-    -- for regionalized methods (non-regionalized fast path skips it entirely).
-    -- For perturbed inventories (sensitivity), pass @pure x'@.
+    -- The 'CrossDBSolution' carries the merged inventory and per-DB scaling
+    -- vectors. Regional methods score as a sum over each participating DB
+    -- ('sumRegionalizedLCIAScoreCrossDB'); non-regional methods read the
+    -- merged inventory only.
     --
     -- 'precomputedScore' short-circuits the per-method scoring loop when a
     -- batched matvec result is already available (see
     -- 'mapMethodSetToTablesCached' + 'computeLCIAScoreSetFromTables'). Pass
     -- 'Nothing' on the single-method paths.
-    computeCategoryResult :: Text -> Database -> IO Vector -> Activity -> Int -> Inventory -> Maybe (Either Text Double) -> Method -> IO LCIAResult
-    computeCategoryResult dbName db getScaling activity topFlows inventory precomputedScore method = do
+    computeCategoryResult ::
+        Text ->
+        Database ->
+        SharedSolver.CrossDBSolution ->
+        Activity ->
+        Int ->
+        Maybe (Either Text Double) ->
+        Method ->
+        IO LCIAResult
+    computeCategoryResult dbName db sol activity topFlows precomputedScore method = do
         unitCfg <- getMergedUnitConfig dbManager
         (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
         mappings <- DM.mapMethodToFlowsCached dbManager dbName db method
         tables <- DM.mapMethodToTablesCached dbManager dbName db method
+        let inventory = SharedSolver.csInventory sol
         -- Force score evaluation here so mapConcurrently actually parallelizes the work
         -- (without this, lazy thunks are created and forced later in the main thread)
         let stats = computeMappingStats mappings
@@ -1253,9 +1346,12 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                 if M.null (mtRegionalizedCF tables)
                     then evaluate $ loScore (computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables)
                     else do
-                        scalingVec <- getScaling
                         hier <- DM.getLocationHierarchy dbManager
-                        case computeLCIAScoreAuto unitCfg mUnits mFlows db scalingVec inventory hier tables of
+                        perDb <-
+                            forM (SharedSolver.csScalings sol) $ \(n, d, sv) -> do
+                                tbls <- DM.mapMethodToTablesCached dbManager n d method
+                                pure (d, sv, tbls)
+                        case sumRegionalizedLCIAScoreCrossDB unitCfg mUnits mFlows hier perDb of
                             Right s -> evaluate s
                             Left err -> do
                                 reportProgress Warning $
@@ -1663,7 +1759,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
             invalid = [pidText | (pidText, Left (Service.InvalidProcessId _)) <- resolved]
             validPidNums = [pidNum | (_, pidNum, _) <- valid]
         t0 <- liftIO getCurrentTime
-        inventories <- inventoriesWithDeps dbManager dbName db sharedSolver validPidNums
+        sols <- solutionsWithDeps dbManager dbName db sharedSolver validPidNums
         t1 <- liftIO getCurrentTime
         -- Pre-fetch per-method static context ONCE for the whole batch instead
         -- of paying it inside every per-pid 'buildLCIABatchResult' call. For
@@ -1680,8 +1776,8 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
         -- stays at 5. Bulk callers that DO want contributors opt in with
         -- ?top-flows=N.
         let topFlows = max 0 (fromMaybe 0 topFlowsParam)
-        let mkEntry ((pidText, pidNum, activity), inventory) = do
-                impacts <- buildLCIABatchResultCached dbName db sharedSolver pidNum activity collection inventory ctxs topFlows
+        let mkEntry ((pidText, pidNum, activity), sol) = do
+                impacts <- buildLCIABatchResultCached dbName db pidNum activity collection sol ctxs topFlows
                 pure
                     BatchImpactsEntry
                         { bieProcessId = pidText
@@ -1691,7 +1787,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
         -- Sequential: inner buildLCIABatchResultCached already runs the
         -- per-method matvec batched in one pass. Nesting outer concurrency
         -- over already-saturated CPU work just adds thread churn.
-        entries <- liftIO $ mapM mkEntry (zip valid inventories)
+        entries <- liftIO $ mapM mkEntry (zip valid sols)
         t2 <- liftIO getCurrentTime
         liftIO $
             reportProgress Info $
@@ -1765,15 +1861,14 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
     buildLCIABatchResultCached ::
         Text ->
         Database ->
-        SharedSolver ->
         ProcessId ->
         Activity ->
         MethodCollection ->
-        Inventory ->
+        SharedSolver.CrossDBSolution ->
         [MethodCtx] ->
         Int ->
         IO LCIABatchResult
-    buildLCIABatchResultCached dbName db sharedSolver actPid activity collection inventory ctxs topFlows = do
+    buildLCIABatchResultCached dbName db actPid activity collection sol ctxs topFlows = do
         let damageCats = mcDamageCategories collection
             nwSets = mcNormWeightSets collection
             dcLookup =
@@ -1784,7 +1879,8 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     ]
             mNW = case nwSets of (nw : _) -> Just nw; [] -> Nothing
             methods = map mctxMethod ctxs
-        scoreMap <- batchedScoresFor dbName db sharedSolver actPid inventory methods
+            inventory = SharedSolver.csInventory sol
+        scoreMap <- batchedScoresFor dbName db sol methods
         (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
         -- Surface inventory flows that aren't in the merged FlowDB once per pid
         -- (independent of method, independent of topFlows) — the signal is a

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -782,7 +782,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
         method <- loadMethodByUUID methodIdText
         (processId, activity) <- resolveOrThrow db processIdText
         unitCfg <- liftIO $ getMergedUnitConfig dbManager
-        eInv <-
+        eSol <-
             liftIO $
                 Service.inventoryWithSubsAndDeps
                     unitCfg
@@ -792,20 +792,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     sharedSolver
                     processId
                     (srSubstitutions subReq)
-        inventory <- either throwServiceError pure eInv
-        -- Substitution path keeps a root-only 'CrossDBSolution': the
-        -- regional cross-DB sum sees only root's MethodTables here, so a
-        -- regional CF that lives in a dep DB's mapping won't apply to the
-        -- substituted-and-routed dep emissions. Tracked as a follow-up;
-        -- substitution + regional cross-DB requires per-DB scalings from
-        -- 'Service.goWithSubsAndDeps', which still returns the merged
-        -- inventory only.
-        rootScaling <- liftIO $ SharedSolver.computeScalingVectorCached db sharedSolver processId
-        let sol =
-                SharedSolver.CrossDBSolution
-                    { SharedSolver.csInventory = inventory
-                    , SharedSolver.csScalings = [(dbName, db, rootScaling)]
-                    }
+        sol <- either throwServiceError pure eSol
         liftIO $ computeCategoryResult dbName db sol activity 5 Nothing method
 
     -- POST: sensitivity sweep (parallel rank-1 perturbations of A_ij)
@@ -940,7 +927,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
         let dcLookup = M.fromList [(subName, dcName dc) | dc <- damageCats, (subName, _) <- dcImpacts dc]
             mNW = case nwSets of (nw : _) -> Just nw; [] -> Nothing
         unitCfg <- liftIO $ getMergedUnitConfig dbManager
-        eInv <-
+        eSol <-
             liftIO $
                 Service.inventoryWithSubsAndDeps
                     unitCfg
@@ -950,16 +937,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     sharedSolver
                     processId
                     (srSubstitutions subReq)
-        inventory <- either throwServiceError pure eInv
-        -- Substitution path: root-only 'CrossDBSolution' (regional cross-DB
-        -- sum sees only root MethodTables here, same gap as documented on
-        -- 'postActivityLCIA').
-        rootScaling <- liftIO $ SharedSolver.computeScalingVectorCached db sharedSolver processId
-        let sol =
-                SharedSolver.CrossDBSolution
-                    { SharedSolver.csInventory = inventory
-                    , SharedSolver.csScalings = [(dbName, db, rootScaling)]
-                    }
+        sol <- either throwServiceError pure eSol
         scoreMap <- liftIO $ batchedScoresFor dbName db sol methods
         rawResults <-
             liftIO $
@@ -983,7 +961,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
         requireFullyLinked dbName db
         (processId, activity) <- resolveOrThrow db processIdText
         unitCfg <- liftIO $ getMergedUnitConfig dbManager
-        eInv <-
+        eSol <-
             liftIO $
                 Service.inventoryWithSubsAndDeps
                     unitCfg
@@ -993,9 +971,9 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     sharedSolver
                     processId
                     (srSubstitutions subReq)
-        inventory <- either throwServiceError pure eInv
+        sol <- either throwServiceError pure eSol
         (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
-        pure $ Service.convertToInventoryExport db mFlows mUnits processId activity inventory
+        pure $ Service.convertToInventoryExport db mFlows mUnits processId activity (SharedSolver.csInventory sol)
 
     -- POST: Supply chain with substitutions
     postActivitySupplyChain :: Text -> Text -> Maybe Text -> Maybe Int -> Maybe Double -> Maybe Int -> Maybe Int -> Maybe Text -> Maybe Text -> Maybe Text -> [Text] -> [Text] -> [Text] -> Maybe Text -> Maybe Text -> Maybe Bool -> SubstitutionRequest -> Handler SupplyChainResponse

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -35,7 +35,7 @@ import qualified Database.Manager as DM
 import qualified Expr
 import GHC.Generics
 import qualified GHC.Stats
-import Matrix (Inventory, Vector, applyBiosphereMatrix)
+import Matrix (Inventory, Vector)
 import Method.Mapping (LCIAOutcome (..), MappingStats (..), MatchStrategy (..), MethodTables (..), computeLCIAScoreFromTables, computeLCIAScoreSetFromTables, computeMappingStats, inventoryContributions, sumRegionalizedLCIAScoreCrossDB)
 import qualified Method.Mapping
 import Method.Types (DamageCategory (..), FlowDirection (..), Method (..), MethodCF (..), MethodCollection (..), NormWeightSet (..), ScoringEvaluation (..), ScoringSet (..), computeFormulaScores)
@@ -796,6 +796,19 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
         liftIO $ computeCategoryResult dbName db sol activity 5 Nothing method
 
     -- POST: sensitivity sweep (parallel rank-1 perturbations of A_ij)
+    --
+    -- Perturbations are root-only by design (Sherman-Morrison rank-1 on
+    -- root's MUMPS factorization; 'Service.resolveRootOnly' rejects
+    -- "dbName::pid" forms). But scoring the perturbed root scaling must
+    -- still walk the cross-DB graph: dep-DB regional CFs are invisible
+    -- to a root-only 'applyBiosphereMatrix', and the propagation infra
+    -- ('SharedSolver.goWithDepsFromScalings') is already documented for
+    -- this exact use case ("caller supplies root scalings, e.g. after
+    -- a Sherman-Morrison update").
+    --
+    -- Cost: each perturbation now triggers one cross-DB back-substitution
+    -- per dep DB it actually reaches. MUMPS factorizations are cached, so
+    -- back-sub is O(n²) per dep DB, not full O(n³) factorization.
     postActivitySensitivity :: Text -> Text -> Text -> Text -> SensitivityRequest -> Handler SensitivityResponse
     postActivitySensitivity dbName processIdText _collectionName methodIdText senReq = do
         (db, sharedSolver) <- requireDatabaseByName dbManager dbName
@@ -804,31 +817,47 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
         (processId, activity) <- resolveOrThrow db processIdText
         eRes <- liftIO $ Service.computeSensitivities db sharedSolver processId (srPerturbations senReq)
         (baselineX, perResults) <- either throwServiceError pure eRes
-        let baselineInv = applyBiosphereMatrix db baselineX
-            -- Sensitivity is single-DB by design: the perturbation hits
-            -- the root technosphere. The regional cross-DB sum sees only
-            -- root here, matching the pre-fix behaviour.
-            mkRootSol inv x =
-                SharedSolver.CrossDBSolution
-                    { SharedSolver.csInventory = inv
-                    , SharedSolver.csScalings = [(dbName, db, x)]
-                    }
+        unitCfg <- liftIO $ getMergedUnitConfig dbManager
+        let depLookup = DM.mkDepSolverLookup dbManager
+            scaleToSolution x = do
+                eSol <-
+                    SharedSolver.goWithDepsFromScalings
+                        unitCfg
+                        depLookup
+                        db
+                        dbName
+                        []
+                        [x]
+                        0
+                pure $ case eSol of
+                    Left err -> Left err
+                    Right (sol : _) -> Right sol
+                    Right [] -> Left "cross-DB propagation returned empty result"
+        eBaselineSol <- liftIO $ scaleToSolution baselineX
+        baselineSol <-
+            either
+                (\err -> throwError err422{errBody = BSL.fromStrict $ T.encodeUtf8 err})
+                pure
+                eBaselineSol
         baselineLcia <-
             liftIO $
-                computeCategoryResult dbName db (mkRootSol baselineInv baselineX) activity 5 Nothing method
+                computeCategoryResult dbName db baselineSol activity 5 Nothing method
         perturbed <-
             liftIO $
                 mapConcurrently
-                    (buildEntry db activity method baselineLcia mkRootSol)
+                    (buildEntry db activity method baselineLcia scaleToSolution)
                     perResults
         pure SensitivityResponse{srBaseline = baselineLcia, srPerturbed = perturbed}
       where
-        buildEntry db activity method baselineLcia mkRootSol (p, eitherX) = case eitherX of
+        buildEntry db activity method baselineLcia scaleToSolution (p, eitherX) = case eitherX of
             Left err -> pure (PerturbedEntry p (Left err))
             Right x' -> do
-                let inv = applyBiosphereMatrix db x'
-                lcia <- computeCategoryResult dbName db (mkRootSol inv x') activity 5 Nothing method
-                pure (PerturbedEntry p (Right (lcia, lrScore lcia - lrScore baselineLcia)))
+                eSol <- scaleToSolution x'
+                case eSol of
+                    Left err -> pure (PerturbedEntry p (Left err))
+                    Right sol -> do
+                        lcia <- computeCategoryResult dbName db sol activity 5 Nothing method
+                        pure (PerturbedEntry p (Right (lcia, lrScore lcia - lrScore baselineLcia)))
 
     -- Batch LCIA endpoint (all methods in a collection)
     getActivityLCIABatch :: Text -> Text -> Text -> Handler LCIABatchResult

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -19,6 +19,7 @@ import Control.Monad.IO.Class (liftIO)
 import Data.Aeson
 import qualified Data.ByteString.Lazy as BSL
 import Data.List (find, intercalate, sortBy, sortOn)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.OpenApi (OpenApi, ToSchema)
@@ -1305,13 +1306,16 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
     -- 'fillRegionalActivityWeights' walk against their own biosphere
     -- triples; subsequent requests hit the cache.
     buildPerDbSetTables ::
-        [(Text, Database, Vector)] ->
+        NE.NonEmpty (Text, Database, Vector) ->
         [Method] ->
-        IO [(Database, Vector, Method.Mapping.MethodSetTables)]
+        IO (NE.NonEmpty (Database, Vector, Method.Mapping.MethodSetTables))
     buildPerDbSetTables scalings methods =
-        forM scalings $ \(n, d, sv) -> do
-            mst <- DM.mapMethodSetToTablesCached dbManager n d methods
-            pure (d, sv, mst)
+        traverse
+            ( \(n, d, sv) -> do
+                mst <- DM.mapMethodSetToTablesCached dbManager n d methods
+                pure (d, sv, mst)
+            )
+            scalings
 
     -- Helper: compute LCIA result for a single method against a cross-DB
     -- inventory solution.
@@ -1355,7 +1359,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     else do
                         hier <- DM.getLocationHierarchy dbManager
                         perDb <-
-                            forM (SharedSolver.csScalings sol) $ \(n, d, sv) -> do
+                            forM (NE.toList (SharedSolver.csScalings sol)) $ \(n, d, sv) -> do
                                 tbls <- DM.mapMethodToTablesCached dbManager n d method
                                 pure (d, sv, tbls)
                         case sumRegionalizedLCIAScoreCrossDB unitCfg mUnits mFlows hier perDb of

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -71,6 +71,8 @@ import Control.DeepSeq (NFData)
 import Control.Monad.ST (runST)
 import Data.Aeson (ToJSON)
 import Data.List (find, sortOn)
+import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, isNothing)
 import Data.Ord (Down (..))
@@ -1379,9 +1381,10 @@ methodId so the result list follows the input order ('msAllMethods'):
     database — root + each dep DB reached at request time. Closes the
     gap where dep-DB regional CFs were previously invisible.
 
-Callers pass the per-DB triples as a non-empty list with the ROOT triple
-first. The non-regional matvec is keyed off the root entry's 'msBatched';
-the regional cross-DB sum walks every entry.
+Callers pass the per-DB triples as a 'NonEmpty' with the ROOT triple at
+'NE.head'. The non-regional matvec is keyed off the root entry's
+'msBatched'; the regional cross-DB sum walks every entry. The 'NonEmpty'
+constraint makes the impossible state (no DBs participated) unrepresentable.
 -}
 computeLCIAScoreSetFromTables ::
     UnitConfig ->
@@ -1389,14 +1392,14 @@ computeLCIAScoreSetFromTables ::
     FlowDB ->
     Inventory ->
     M.Map Text [Text] ->
-    {- | Non-empty per-DB triples: head is root, tail is each participating
+    {- | Non-empty per-DB triples: 'NE.head' is root, tail is each participating
     dep DB. Building order matches 'SharedSolver.csScalings'.
     -}
-    [(Database, Vector, MethodSetTables)] ->
+    NonEmpty (Database, Vector, MethodSetTables) ->
     [(UUID, Either Text Double)]
-computeLCIAScoreSetFromTables _ _ _ _ _ [] = []
-computeLCIAScoreSetFromTables unitCfg unitDB flowDB inventory hier perDb@((_, _, mstRoot) : _) =
-    let batched = scoreBatched unitCfg unitDB flowDB (msBatched mstRoot) inventory
+computeLCIAScoreSetFromTables unitCfg unitDB flowDB inventory hier perDb =
+    let (_, _, mstRoot) = NE.head perDb
+        batched = scoreBatched unitCfg unitDB flowDB (msBatched mstRoot) inventory
         regional = scoreRegionalCrossDB unitCfg unitDB flowDB hier (msRegional mstRoot) perDb
         byId = M.fromList (batched ++ regional)
      in [ (mseMethodId e, byId M.! mseMethodId e)
@@ -1418,7 +1421,7 @@ scoreRegionalCrossDB ::
     FlowDB ->
     M.Map Text [Text] ->
     V.Vector MethodSetEntry ->
-    [(Database, Vector, MethodSetTables)] ->
+    NonEmpty (Database, Vector, MethodSetTables) ->
     [(UUID, Either Text Double)]
 scoreRegionalCrossDB unitCfg unitDB flowDB hier ms perDb =
     [ ( mseMethodId e
@@ -1430,7 +1433,7 @@ scoreRegionalCrossDB unitCfg unitDB flowDB hier ms perDb =
     -- Per-method per-DB triples; skip DBs that don't carry this method.
     triples mid =
         [ (db, sv, t)
-        | (db, sv, mst) <- perDb
+        | (db, sv, mst) <- NE.toList perDb
         , Just t <- [lookupMethodTables mid mst]
         ]
     lookupMethodTables mid mst =

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -1001,10 +1001,19 @@ Closes the gap where dep-DB biosphere emissions are present in the merged
 inventory but invisible to the regional dot product (which was previously
 keyed on the root DB's activity columns alone).
 
-Left from any per-DB call short-circuits to Left of the whole sum so a
-silent under-count never masquerades as a Right score: callers handle the
-gap explicitly (the per-pid WARN at the caller site, the build-time WARN
-that listed which (flow, location) pairs are uncovered).
+Per-DB 'Left' is tolerated: any DB whose 'computeRegionalizedLCIAScore'
+fails (tainted columns with non-zero scaling, missing weights, …) drops to
+a 0 contribution from THAT database and the function keeps summing the
+rest. The build-time WARN already lists every uncovered (flow, location)
+pair per @(db, method)@ — that is the single source of truth for what's
+missing. Score-time silently zeroing a whole method just because one dep
+DB has incomplete coverage would regress the user's view of computable
+methods; this best-effort sum preserves the partial answer while the
+build-time WARN keeps the coverage gap visible.
+
+Returns 'Left' only when 'every' triple's score is 'Left' (no recoverable
+contribution from any participating DB) — the gap is unrecoverable and the
+caller should surface it as an error rather than report 0.
 -}
 sumRegionalizedLCIAScoreCrossDB ::
     UnitConfig ->
@@ -1017,10 +1026,12 @@ sumRegionalizedLCIAScoreCrossDB ::
     [(Database, Vector, MethodTables)] ->
     Either Text Double
 sumRegionalizedLCIAScoreCrossDB unitCfg unitDB flowDB hier triples =
-    sum <$> traverse one triples
-  where
-    one (db, scaling, tables) =
-        computeRegionalizedLCIAScore unitCfg unitDB flowDB db scaling hier tables
+    let results = [computeRegionalizedLCIAScore unitCfg unitDB flowDB db sv hier t | (db, sv, t) <- triples]
+        rights = [s | Right s <- results]
+        lefts = [e | Left e <- results]
+     in case (rights, lefts) of
+            ([], errs) | not (null errs) -> Left (T.intercalate "; " errs)
+            _ -> Right (sum rights)
 
 {- | Resolve a CF for a (flow, location) pair through the hierarchy + broadcast
 fallback. See 'computeRegionalizedLCIAScore' for the rules.

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -36,6 +36,7 @@ module Method.Mapping (
     computeLCIAScoreFromTables,
     computeLCIAScoreAuto,
     computeRegionalizedLCIAScore,
+    sumRegionalizedLCIAScoreCrossDB,
     computeLCIAScoreWithDiagnostics,
     findUncharacterized,
     findSimilarCFs,
@@ -928,12 +929,21 @@ computeRegionalizedLCIAScore ::
 computeRegionalizedLCIAScore _unitConfig _unitDB _flowDB _db scalingVec _hier tables =
     case mtRegionalActivityWeights tables of
         Just raw -> scoreFromPrecomputed raw scalingVec
-        Nothing ->
-            Left
-                "Regionalized score requested but precomputed activity weights\
-                \ are absent. Call 'fillRegionalActivityWeights' on the\
-                \ MethodTables before scoring (mapMethodToTablesCached does\
-                \ this automatically)."
+        Nothing
+            -- Cross-DB scoring passes per-DB tables in; a dep DB whose flow
+            -- mappings caught none of this method's regional CFs has empty
+            -- 'mtRegionalizedCF', so 'fillRegionalActivityWeights' left
+            -- 'mtRegionalActivityWeights' unfilled. Treat as a 0
+            -- contribution rather than erroring — non-regional emissions
+            -- from that DB are handled by the broadcast pass for which the
+            -- DB built 'rawWeights' from its own broadcast cell.
+            | M.null (mtRegionalizedCF tables) -> Right 0
+            | otherwise ->
+                Left
+                    "Regionalized score requested but precomputed activity weights\
+                    \ are absent. Call 'fillRegionalActivityWeights' on the\
+                    \ MethodTables before scoring (mapMethodToTablesCached does\
+                    \ this automatically)."
   where
     -- Fast path: one dot product over precomputed per-column weights.
     -- If any tainted activity carries non-zero scaling, surface the gap
@@ -976,6 +986,41 @@ computeRegionalizedLCIAScore _unitConfig _unitDB _flowDB _db scalingVec _hier ta
                                         <> " tainted activity column(s) reached by this inventory"
                                         <> " — see warnings emitted at table-build time for the missing (flow, location) pairs."
                             else Right score
+
+{- | Cross-DB regionalized LCIA score.
+
+For each participating database @d@ (root + each dep DB reached at request
+time), call 'computeRegionalizedLCIAScore' against THAT DB's scaling
+vector and MethodTables, then sum the per-DB scores. Equivalent to one
+dot product over the concatenated activity space
+@[s_root, s_dep1, …] · [w_root, w_dep1, …]@ — just computed per-DB so
+each side keeps its own activity index, hierarchy walks and tainted-column
+diagnostics local.
+
+Closes the gap where dep-DB biosphere emissions are present in the merged
+inventory but invisible to the regional dot product (which was previously
+keyed on the root DB's activity columns alone).
+
+Left from any per-DB call short-circuits to Left of the whole sum so a
+silent under-count never masquerades as a Right score: callers handle the
+gap explicitly (the per-pid WARN at the caller site, the build-time WARN
+that listed which (flow, location) pairs are uncovered).
+-}
+sumRegionalizedLCIAScoreCrossDB ::
+    UnitConfig ->
+    UnitDB ->
+    FlowDB ->
+    M.Map Text [Text] ->
+    {- | Per-DB triples: one per database participating in the cross-DB solve
+    (root + dep DBs in the same order returned by 'SharedSolver.csScalings').
+    -}
+    [(Database, Vector, MethodTables)] ->
+    Either Text Double
+sumRegionalizedLCIAScoreCrossDB unitCfg unitDB flowDB hier triples =
+    sum <$> traverse one triples
+  where
+    one (db, scaling, tables) =
+        computeRegionalizedLCIAScore unitCfg unitDB flowDB db scaling hier tables
 
 {- | Resolve a CF for a (flow, location) pair through the hierarchy + broadcast
 fallback. See 'computeRegionalizedLCIAScore' for the rules.
@@ -1313,52 +1358,73 @@ regional method whose coverage is incomplete (mirrors 'computeLCIAScoreAuto').
 The two halves of the set are scored by separate code paths and merged by
 methodId so the result list follows the input order ('msAllMethods'):
 
-  * non-regional half ('msBatched'): one matvec over the shared dense
-    broadcast — the PR #29 fast path, restored for mixed sets like EF 3.1;
-  * regional half ('msRegional'): per-method dispatch through
-    'computeLCIAScoreAuto', which since PR #39 is itself a per-pid dot
-    product against precomputed activity weights.
+  * non-regional half ('msBatched' on root): one matvec over the shared
+    dense broadcast — the PR #29 fast path, restored for mixed sets like
+    EF 3.1. Reads the merged cross-DB inventory, so dep-DB flows are
+    characterized without any per-DB bookkeeping.
+  * regional half ('msRegional' on root): per-method cross-DB sum
+    ('sumRegionalizedLCIAScoreCrossDB'). For each regional method, the
+    score is @Σ_d rawWeights_d · scaling_d@ across every participating
+    database — root + each dep DB reached at request time. Closes the
+    gap where dep-DB regional CFs were previously invisible.
+
+Callers pass the per-DB triples as a non-empty list with the ROOT triple
+first. The non-regional matvec is keyed off the root entry's 'msBatched';
+the regional cross-DB sum walks every entry.
 -}
 computeLCIAScoreSetFromTables ::
     UnitConfig ->
     UnitDB ->
     FlowDB ->
-    Database ->
-    Vector ->
     Inventory ->
     M.Map Text [Text] ->
-    MethodSetTables ->
+    {- | Non-empty per-DB triples: head is root, tail is each participating
+    dep DB. Building order matches 'SharedSolver.csScalings'.
+    -}
+    [(Database, Vector, MethodSetTables)] ->
     [(UUID, Either Text Double)]
-computeLCIAScoreSetFromTables unitCfg unitDB flowDB db scalingVec inventory hier mst =
-    let batched = scoreBatched unitCfg unitDB flowDB (msBatched mst) inventory
-        regional =
-            scoreRegional unitCfg unitDB flowDB db scalingVec inventory hier (msRegional mst)
+computeLCIAScoreSetFromTables _ _ _ _ _ [] = []
+computeLCIAScoreSetFromTables unitCfg unitDB flowDB inventory hier perDb@((_, _, mstRoot) : _) =
+    let batched = scoreBatched unitCfg unitDB flowDB (msBatched mstRoot) inventory
+        regional = scoreRegionalCrossDB unitCfg unitDB flowDB hier (msRegional mstRoot) perDb
         byId = M.fromList (batched ++ regional)
      in [ (mseMethodId e, byId M.! mseMethodId e)
-        | e <- V.toList (msAllMethods mst)
+        | e <- V.toList (msAllMethods mstRoot)
         ]
 
-{- | Per-method dispatch for the regional half of a 'MethodSetTables'. Each
-call into 'computeLCIAScoreAuto' uses PR #39's precomputed regional
-activity weights, so individually they're tight dot products — they
-just aren't stacked across methods (yet).
+{- | Per-method cross-DB regional sum. For each regional method, scores
+@Σ_d rawWeights_d · scaling_d@ across all participating DBs by looking
+up that method's tables in each DB's 'MethodSetTables' and summing the
+per-DB dot products via 'sumRegionalizedLCIAScoreCrossDB'.
+
+A DB whose 'MethodSetTables' has no entry for a given methodId (mismatched
+sets) contributes 0 for that method — the same neutral element as a DB
+whose mappings caught none of the method's regional CFs.
 -}
-scoreRegional ::
+scoreRegionalCrossDB ::
     UnitConfig ->
     UnitDB ->
     FlowDB ->
-    Database ->
-    Vector ->
-    Inventory ->
     M.Map Text [Text] ->
     V.Vector MethodSetEntry ->
+    [(Database, Vector, MethodSetTables)] ->
     [(UUID, Either Text Double)]
-scoreRegional unitCfg unitDB flowDB db scalingVec inventory hier ms =
+scoreRegionalCrossDB unitCfg unitDB flowDB hier ms perDb =
     [ ( mseMethodId e
-      , computeLCIAScoreAuto unitCfg unitDB flowDB db scalingVec inventory hier (mseTables e)
+      , sumRegionalizedLCIAScoreCrossDB unitCfg unitDB flowDB hier (triples (mseMethodId e))
       )
     | e <- V.toList ms
     ]
+  where
+    -- Per-method per-DB triples; skip DBs that don't carry this method.
+    triples mid =
+        [ (db, sv, t)
+        | (db, sv, mst) <- perDb
+        , Just t <- [lookupMethodTables mid mst]
+        ]
+    lookupMethodTables mid mst =
+        mseTables
+            <$> V.find ((== mid) . mseMethodId) (msAllMethods mst)
 
 {- | One sparse-inventory matvec over the non-regional half of a method set.
 For each non-zero @(uuid, qty)@ in the inventory, accumulates

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -14,8 +14,9 @@ import Data.Int (Int32)
 import qualified Data.IntMap.Strict as IM
 import qualified Data.IntSet as IS
 import qualified Data.List as L
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
-import Data.Maybe (fromMaybe)
+import Data.Maybe (catMaybes, fromMaybe)
 import Data.Sequence (Seq (..), (|>))
 import qualified Data.Set as S
 import Data.Text (Text)
@@ -1967,7 +1968,11 @@ inventoryWithSubsAndDeps unitCfg depLookup db rootDbName solver pid subs = do
             pure $ case res of
                 Left err -> Left err
                 Right (sol : _) -> Right sol
-                Right [] -> Right (SharedSolver.CrossDBSolution M.empty []) -- unreachable: K=1
+                Right [] ->
+                    -- unreachable: K=1 single-demand always yields one solution.
+                    -- Surface as Left rather than fabricate an empty solution
+                    -- with no 'csScalings' (NonEmpty forbids it).
+                    Left $ MatrixError "inventoryWithSubsAndDeps: empty result for single demand"
 
 {- | Reject substitutions whose consumer is qualified to a DB that is either
 unloaded or not reachable from @rootDbName@ via 'dbCrossDBLinks'. Such
@@ -2061,7 +2066,7 @@ goWithSubsAndDeps unitCfg depLookup thisDb thisDbName rootDb solver demands allS
         let localInvs = map (applyBiosphereMatrix thisDb) scalings'
             baseSolutions =
                 zipWith
-                    (\inv s -> SharedSolver.CrossDBSolution inv [(unThisDb thisDbName, thisDb, s)])
+                    (\inv s -> SharedSolver.CrossDBSolution inv (NE.singleton (unThisDb thisDbName, thisDb, s)))
                     localInvs
                     scalings'
         if depth >= maxSubsDepth
@@ -2079,7 +2084,9 @@ goWithSubsAndDeps unitCfg depLookup thisDb thisDbName rootDb solver demands allS
                         pure $ case sequence depResults of
                             Left err -> Left err
                             Right depSolsByDb ->
-                                let perRootDepSols = L.transpose depSolsByDb
+                                -- Absent dep DBs contribute 'Nothing'; drop
+                                -- them before the merge (see 'mergeSolutions').
+                                let perRootDepSols = map catMaybes (L.transpose depSolsByDb)
                                  in Right $
                                         zipWith
                                             SharedSolver.mergeSolutions
@@ -2100,19 +2107,22 @@ resolveDepWithSubs ::
     Int ->
     Int ->
     Text ->
-    IO (Either ServiceError [SharedSolver.CrossDBSolution])
+    IO (Either ServiceError [Maybe SharedSolver.CrossDBSolution])
 resolveDepWithSubs unitCfg depLookup rootDb perRootDepDemands allSubs depth k depDbName = do
     depM <- depLookup depDbName
     case depM of
         Nothing ->
-            pure (Right (replicate k (SharedSolver.CrossDBSolution M.empty [])))
+            -- Same shape as 'SharedSolver.resolveDep': absent dep DB
+            -- contributes 'Nothing' at every root; dropped before merge.
+            pure (Right (replicate k Nothing))
         Just (depDb, depSolver) ->
             let demandsPerRoot = map (M.findWithDefault M.empty depDbName) perRootDepDemands
                 depVecsE = traverse (depDemandsToVector unitCfg depDbName depDb) demandsPerRoot
              in case depVecsE of
                     Left err -> pure (Left (MatrixError err))
-                    Right depDemandVecs ->
-                        goWithSubsAndDeps unitCfg depLookup depDb (ThisDb depDbName) rootDb depSolver depDemandVecs allSubs (depth + 1)
+                    Right depDemandVecs -> do
+                        sols <- goWithSubsAndDeps unitCfg depLookup depDb (ThisDb depDbName) rootDb depSolver depDemandVecs allSubs (depth + 1)
+                        pure $ fmap (map Just) sols
 
 {- | Cross-DB substitution resolver (root-only path, used by supply-chain).
 

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -1955,7 +1955,7 @@ inventoryWithSubsAndDeps ::
     SharedSolver ->
     ProcessId ->
     [Substitution] ->
-    IO (Either ServiceError Inventory)
+    IO (Either ServiceError SharedSolver.CrossDBSolution)
 inventoryWithSubsAndDeps unitCfg depLookup db rootDbName solver pid subs = do
     let rootDb = RootDb rootDbName
     eValid <- validateConsumerDbs depLookup db rootDb subs
@@ -1966,8 +1966,8 @@ inventoryWithSubsAndDeps unitCfg depLookup db rootDbName solver pid subs = do
             res <- goWithSubsAndDeps unitCfg depLookup db (ThisDb rootDbName) rootDb solver [demand] subs 0
             pure $ case res of
                 Left err -> Left err
-                Right (inv : _) -> Right inv
-                Right [] -> Right M.empty -- unreachable: K=1
+                Right (sol : _) -> Right sol
+                Right [] -> Right (SharedSolver.CrossDBSolution M.empty []) -- unreachable: K=1
 
 {- | Reject substitutions whose consumer is qualified to a DB that is either
 unloaded or not reachable from @rootDbName@ via 'dbCrossDBLinks'. Such
@@ -2049,7 +2049,7 @@ goWithSubsAndDeps ::
     [Substitution] ->
     -- | recursion depth
     Int ->
-    IO (Either ServiceError [Inventory])
+    IO (Either ServiceError [SharedSolver.CrossDBSolution])
 goWithSubsAndDeps unitCfg depLookup thisDb thisDbName rootDb solver demands allSubs depth = do
     scalings <- SharedSolver.solveMultiWithSharedSolver solver demands
     eApply <- applySubstitutionsAt depLookup thisDb thisDbName rootDb solver scalings allSubs
@@ -2059,13 +2059,18 @@ goWithSubsAndDeps unitCfg depLookup thisDb thisDbName rootDb solver demands allS
   where
     propagate scalings' virtualLks = do
         let localInvs = map (applyBiosphereMatrix thisDb) scalings'
+            baseSolutions =
+                zipWith
+                    (\inv s -> SharedSolver.CrossDBSolution inv [(unThisDb thisDbName, thisDb, s)])
+                    localInvs
+                    scalings'
         if depth >= maxSubsDepth
-            then pure (Right localInvs)
+            then pure (Right baseSolutions)
             else do
                 let perRootDepDemands = map (accumulateDepDemandsWith thisDb virtualLks) scalings'
                     allDepDbs = S.toList $ S.unions $ map M.keysSet perRootDepDemands
                 if null allDepDbs
-                    then pure (Right localInvs)
+                    then pure (Right baseSolutions)
                     else do
                         depResults <-
                             mapConcurrently
@@ -2073,13 +2078,13 @@ goWithSubsAndDeps unitCfg depLookup thisDb thisDbName rootDb solver demands allS
                                 allDepDbs
                         pure $ case sequence depResults of
                             Left err -> Left err
-                            Right depContribsByDb ->
-                                let perRootDepInvs = L.transpose depContribsByDb
+                            Right depSolsByDb ->
+                                let perRootDepSols = L.transpose depSolsByDb
                                  in Right $
                                         zipWith
-                                            (foldr (M.unionWith (+)))
-                                            localInvs
-                                            perRootDepInvs
+                                            SharedSolver.mergeSolutions
+                                            baseSolutions
+                                            perRootDepSols
 
 {- | Dep resolver variant that threads the substitution list into the
 recursion. Matches 'SharedSolver.resolveDep' but delegates to
@@ -2095,12 +2100,12 @@ resolveDepWithSubs ::
     Int ->
     Int ->
     Text ->
-    IO (Either ServiceError [Inventory])
+    IO (Either ServiceError [SharedSolver.CrossDBSolution])
 resolveDepWithSubs unitCfg depLookup rootDb perRootDepDemands allSubs depth k depDbName = do
     depM <- depLookup depDbName
     case depM of
         Nothing ->
-            pure (Right (replicate k M.empty))
+            pure (Right (replicate k (SharedSolver.CrossDBSolution M.empty [])))
         Just (depDb, depSolver) ->
             let demandsPerRoot = map (M.findWithDefault M.empty depDbName) perRootDepDemands
                 depVecsE = traverse (depDemandsToVector unitCfg depDbName depDb) demandsPerRoot

--- a/src/Service/Aggregate.hs
+++ b/src/Service/Aggregate.hs
@@ -45,6 +45,7 @@ import Service (
     resolveActivityAndProcessId,
  )
 import SharedSolver (DepSolverLookup, SharedSolver, computeInventoryMatrixWithDepsCached, solveWithSharedSolver)
+import qualified SharedSolver
 import Types (
     Activity,
     Database (..),
@@ -162,11 +163,12 @@ aggregate unitConfig flowDB unitDB db dbName solver depLookup pidText params =
                             False
                     return $ fmap (reduce params . rowsFromSupplyChain) eResp
                 ScopeBiosphere -> do
-                    invE <- computeInventoryMatrixWithDepsCached unitConfig depLookup db solver processId
-                    case invE of
+                    solE <- computeInventoryMatrixWithDepsCached unitConfig depLookup db dbName solver processId
+                    case solE of
                         Left err -> return (Left (MatrixError err))
-                        Right inventory ->
-                            let export = convertToInventoryExport db flowDB unitDB processId activity inventory
+                        Right sol ->
+                            let inventory = SharedSolver.csInventory sol
+                                export = convertToInventoryExport db flowDB unitDB processId activity inventory
                              in return $ Right $ reduce params (rowsFromBiosphere export)
   where
     emptyFilter maxD =

--- a/src/SharedSolver.hs
+++ b/src/SharedSolver.hs
@@ -40,7 +40,10 @@ import Control.Concurrent.Async (mapConcurrently)
 import Control.Concurrent.MVar (MVar, modifyMVar, modifyMVar_, newMVar, readMVar, withMVar)
 import Control.Exception (SomeException, catch)
 import Data.List (transpose)
+import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
+import Data.Maybe (catMaybes)
 import qualified Data.Set as S
 import Data.Text (Text)
 import Matrix (
@@ -190,13 +193,15 @@ location context the regional CF lookup needs).
 
 'csScalings' lists every DB visited (root first, then dep DBs in BFS
 order — both the order and the recursion depth follow the same dep-graph
-walk that built 'csInventory'). A DB whose scaling vector is the zero
-vector for this pid is still included; downstream consumers can drop it,
-but the solver never silently omits a participating DB.
+walk that built 'csInventory'). The list is non-empty: the root entry
+('rootDbName', root 'Database', root scaling) is always added by the
+top-level solve; dep entries are appended as the recursion fans out.
+A DB whose scaling vector is the zero vector for this pid is still
+included; the solver never silently omits a participating DB.
 -}
 data CrossDBSolution = CrossDBSolution
     { csInventory :: !Inventory
-    , csScalings :: ![(Text, Database, Vector)]
+    , csScalings :: !(NonEmpty (Text, Database, Vector))
     }
 
 {- |
@@ -251,7 +256,11 @@ computeInventoryMatrixWithDepsCached unitConfig depLookup db dbName solver pid =
     pure $ case res of
         Left err -> Left err
         Right (sol : _) -> Right sol
-        Right [] -> Right (CrossDBSolution M.empty []) -- unreachable: batch is non-empty
+        Right [] ->
+            -- unreachable: a single-pid batch always returns a singleton list.
+            -- Surface as Left rather than fabricate an empty 'CrossDBSolution'
+            -- with no 'csScalings' (the type now forbids it via NonEmpty).
+            Left "computeInventoryMatrixWithDepsCached: empty batch result for one pid"
 
 -- | Safety net against cyclic cross-DB links (Ginko → Agribalyse → Ginko).
 maxDepsDepth :: Int
@@ -304,7 +313,7 @@ goWithDepsFromScalings unitConfig depLookup db dbName extraLinks scalings depth 
     let localInvs = map (applyBiosphereMatrix db) scalings
         baseSolutions =
             zipWith
-                (\inv s -> CrossDBSolution inv [(dbName, db, s)])
+                (\inv s -> CrossDBSolution inv (NE.singleton (dbName, db, s)))
                 localInvs
                 scalings
     if depth >= maxDepsDepth
@@ -322,7 +331,12 @@ goWithDepsFromScalings unitConfig depLookup db dbName extraLinks scalings depth 
                     pure $ case sequence depResults of
                         Left err -> Left err
                         Right depSolsByDb ->
-                            let perRootDepSols = transpose depSolsByDb
+                            -- Each dep returns @[Maybe CrossDBSolution]@ of
+                            -- length K. Absent-dep entries (depLookup
+                            -- returned Nothing) are 'Nothing' and drop out
+                            -- of the merge — an absent dep contributes
+                            -- nothing to inventory or csScalings.
+                            let perRootDepSols = map catMaybes (transpose depSolsByDb)
                              in Right $
                                     zipWith
                                         mergeSolutions
@@ -343,7 +357,9 @@ mergeSolutions base depSols =
         { csInventory =
             foldr (M.unionWith (+)) (csInventory base) (map csInventory depSols)
         , csScalings =
-            csScalings base ++ concatMap csScalings depSols
+            NE.appendList
+                (csScalings base)
+                (concatMap (NE.toList . csScalings) depSols)
         }
 
 resolveDep ::
@@ -352,22 +368,28 @@ resolveDep ::
     [M.Map Text (M.Map (UUID, UUID) (Double, Text))] ->
     -- | current depth (for recursion)
     Int ->
-    -- | K (so we can pad with empty on a missing dep DB)
+    -- | K (so absent-dep returns the right number of 'Nothing' padding)
     Int ->
     Text ->
-    IO (Either Text [CrossDBSolution])
+    IO (Either Text [Maybe CrossDBSolution])
 resolveDep unitConfig depLookup perRootDepDemands depth k depDbName = do
     depM <- depLookup depDbName
     case depM of
         Nothing ->
-            pure (Right (replicate k (CrossDBSolution M.empty [])))
+            -- Dep DB not loaded: contribute nothing at every root. The
+            -- 'Nothing' propagates through 'mergeSolutions' and drops out
+            -- before the inventory union / csScalings concat, exactly
+            -- equivalent to an empty 'CrossDBSolution' but without
+            -- materialising one (which the NonEmpty type forbids).
+            pure (Right (replicate k Nothing))
         Just (depDb, depSolver) ->
             let demandsPerRoot = map (M.findWithDefault M.empty depDbName) perRootDepDemands
                 depVecsE = traverse (depDemandsToVector unitConfig depDbName depDb) demandsPerRoot
              in case depVecsE of
                     Left err -> pure (Left err)
-                    Right depDemandVecs ->
-                        goWithDeps unitConfig depLookup depDb depDbName depSolver depDemandVecs (depth + 1)
+                    Right depDemandVecs -> do
+                        sols <- goWithDeps unitConfig depLookup depDb depDbName depSolver depDemandVecs (depth + 1)
+                        pure $ fmap (map Just) sols
 
 {- | Cross-DB per-activity LCIA contributions. Walks the same dep graph as
 'goWithDeps' but attributes contributions per @(dbName, localPid)@ instead

--- a/src/SharedSolver.hs
+++ b/src/SharedSolver.hs
@@ -28,6 +28,7 @@ module SharedSolver (
 
     -- * Cross-database back-substitution
     DepSolverLookup,
+    CrossDBSolution (..),
     computeInventoryMatrixWithDepsCached,
     computeInventoryMatrixBatchWithDepsCached,
     goWithDepsFromScalings,
@@ -176,6 +177,27 @@ zero-contribution supplier and continues.
 -}
 type DepSolverLookup = Text -> IO (Maybe (Database, SharedSolver))
 
+{- | Per-pid result of a cross-DB inventory solve: the merged biosphere
+'Inventory' plus the per-DB scaling vectors that produced it.
+
+The scaling vectors are needed by the regionalized LCIA path, which scores
+each DB's biosphere triples against THAT DB's scaling — a sum across all
+DBs reached at request time, not a single dot product against the root.
+Without per-DB scalings, dep-DB regional CFs are silently invisible
+(the merged 'Inventory' has the emissions but lost the per-activity
+location context the regional CF lookup needs).
+
+'csScalings' lists every DB visited (root first, then dep DBs in BFS
+order — both the order and the recursion depth follow the same dep-graph
+walk that built 'csInventory'). A DB whose scaling vector is the zero
+vector for this pid is still included; downstream consumers can drop it,
+but the solver never silently omits a participating DB.
+-}
+data CrossDBSolution = CrossDBSolution
+    { csInventory :: !Inventory
+    , csScalings :: ![(Text, Database, Vector)]
+    }
+
 {- |
 Batch inventory with cross-DB back-substitution. Multi-RHS is preserved at
 every level of the dependency DAG:
@@ -186,21 +208,29 @@ every level of the dependency DAG:
 * Recurse into the dep DB's own cross-DB links (Agribalyse → Ecoinvent, etc.).
 * Sum local + all dep contributions per root by 'M.unionWith (+)'.
 
+Returns one 'CrossDBSolution' per pid: the merged inventory plus the per-DB
+scaling vectors that produced it. The regional LCIA path uses the scalings
+to sum per-DB regional dot products; callers that only need the inventory
+extract 'csInventory'.
+
 Depth is capped at 10 as a safety net against pathological data (cyclic links).
 -}
 computeInventoryMatrixBatchWithDepsCached ::
     UnitConfig ->
     DepSolverLookup ->
     Database ->
+    -- | root DB name (recorded in the head of each 'csScalings')
+    Text ->
     SharedSolver ->
     [ProcessId] ->
-    IO (Either Text [Inventory])
-computeInventoryMatrixBatchWithDepsCached _ _ _ _ [] = pure (Right [])
-computeInventoryMatrixBatchWithDepsCached unitConfig depLookup db solver pids =
+    IO (Either Text [CrossDBSolution])
+computeInventoryMatrixBatchWithDepsCached _ _ _ _ _ [] = pure (Right [])
+computeInventoryMatrixBatchWithDepsCached unitConfig depLookup db dbName solver pids =
     goWithDeps
         unitConfig
         depLookup
         db
+        dbName
         solver
         (map (buildDemandVectorFromIndex (dbActivityIndex db)) pids)
         0
@@ -210,15 +240,17 @@ computeInventoryMatrixWithDepsCached ::
     UnitConfig ->
     DepSolverLookup ->
     Database ->
+    -- | root DB name (recorded in the head of 'csScalings')
+    Text ->
     SharedSolver ->
     ProcessId ->
-    IO (Either Text Inventory)
-computeInventoryMatrixWithDepsCached unitConfig depLookup db solver pid = do
-    res <- computeInventoryMatrixBatchWithDepsCached unitConfig depLookup db solver [pid]
+    IO (Either Text CrossDBSolution)
+computeInventoryMatrixWithDepsCached unitConfig depLookup db dbName solver pid = do
+    res <- computeInventoryMatrixBatchWithDepsCached unitConfig depLookup db dbName solver [pid]
     pure $ case res of
         Left err -> Left err
-        Right (inv : _) -> Right inv
-        Right [] -> Right M.empty -- unreachable: batch is non-empty
+        Right (sol : _) -> Right sol
+        Right [] -> Right (CrossDBSolution M.empty []) -- unreachable: batch is non-empty
 
 -- | Safety net against cyclic cross-DB links (Ginko → Agribalyse → Ginko).
 maxDepsDepth :: Int
@@ -228,15 +260,17 @@ goWithDeps ::
     UnitConfig ->
     DepSolverLookup ->
     Database ->
+    -- | THIS DB's name (recorded in the 'csScalings' entry contributed at this level)
+    Text ->
     SharedSolver ->
     -- | K demand vectors, length = dbActivityCount db
     [Vector] ->
     -- | recursion depth
     Int ->
-    IO (Either Text [Inventory])
-goWithDeps unitConfig depLookup db solver demands depth = do
+    IO (Either Text [CrossDBSolution])
+goWithDeps unitConfig depLookup db dbName solver demands depth = do
     scalings <- solveMultiWithSharedSolver solver demands
-    goWithDepsFromScalings unitConfig depLookup db [] scalings depth
+    goWithDepsFromScalings unitConfig depLookup db dbName [] scalings depth
 
 {- | Propagate pre-computed root scalings into the dep-DB graph. Same body as
 the dep-propagation half of 'goWithDeps' but skips the root solve — the
@@ -247,27 +281,38 @@ entries to fold into 'accumulateDepDemands' at this level only.
 Extra links are applied at the root DB only; recursive calls into dep DBs
 use their static 'dbCrossDBLinks'. Supporting nested substitutions would
 require threading per-DB extras through 'resolveDep' — out of scope.
+
+Each returned 'CrossDBSolution' is built bottom-up: the current DB
+contributes its @(dbName, db, scaling)@ entry, then dep DBs append theirs
+through 'resolveDep'. Dep entries appear in the BFS order of 'allDepDbs'.
 -}
 goWithDepsFromScalings ::
     UnitConfig ->
     DepSolverLookup ->
     Database ->
+    -- | THIS DB's name
+    Text ->
     -- | virtual links to inject at this level (root only)
     [CrossDBLink] ->
     -- | K pre-computed root scaling vectors
     [Vector] ->
     -- | recursion depth
     Int ->
-    IO (Either Text [Inventory])
-goWithDepsFromScalings unitConfig depLookup db extraLinks scalings depth = do
+    IO (Either Text [CrossDBSolution])
+goWithDepsFromScalings unitConfig depLookup db dbName extraLinks scalings depth = do
     let localInvs = map (applyBiosphereMatrix db) scalings
+        baseSolutions =
+            zipWith
+                (\inv s -> CrossDBSolution inv [(dbName, db, s)])
+                localInvs
+                scalings
     if depth >= maxDepsDepth
-        then pure (Right localInvs)
+        then pure (Right baseSolutions)
         else do
             let perRootDepDemands = map (accumulateDepDemandsWith db extraLinks) scalings
                 allDepDbs = S.toList $ S.unions $ map M.keysSet perRootDepDemands
             if null allDepDbs
-                then pure (Right localInvs)
+                then pure (Right baseSolutions)
                 else do
                     depResults <-
                         mapConcurrently
@@ -275,13 +320,21 @@ goWithDepsFromScalings unitConfig depLookup db extraLinks scalings depth = do
                             allDepDbs
                     pure $ case sequence depResults of
                         Left err -> Left err
-                        Right depContribsByDb ->
-                            let perRootDepInvs = transpose depContribsByDb
+                        Right depSolsByDb ->
+                            let perRootDepSols = transpose depSolsByDb
                              in Right $
                                     zipWith
-                                        (foldr (M.unionWith (+)))
-                                        localInvs
-                                        perRootDepInvs
+                                        mergeSolutions
+                                        baseSolutions
+                                        perRootDepSols
+  where
+    mergeSolutions base depSols =
+        CrossDBSolution
+            { csInventory =
+                foldr (M.unionWith (+)) (csInventory base) (map csInventory depSols)
+            , csScalings =
+                csScalings base ++ concatMap csScalings depSols
+            }
 
 resolveDep ::
     UnitConfig ->
@@ -292,18 +345,19 @@ resolveDep ::
     -- | K (so we can pad with empty on a missing dep DB)
     Int ->
     Text ->
-    IO (Either Text [Inventory])
+    IO (Either Text [CrossDBSolution])
 resolveDep unitConfig depLookup perRootDepDemands depth k depDbName = do
     depM <- depLookup depDbName
     case depM of
         Nothing ->
-            pure (Right (replicate k M.empty))
+            pure (Right (replicate k (CrossDBSolution M.empty [])))
         Just (depDb, depSolver) ->
             let demandsPerRoot = map (M.findWithDefault M.empty depDbName) perRootDepDemands
                 depVecsE = traverse (depDemandsToVector unitConfig depDbName depDb) demandsPerRoot
              in case depVecsE of
                     Left err -> pure (Left err)
-                    Right depDemandVecs -> goWithDeps unitConfig depLookup depDb depSolver depDemandVecs (depth + 1)
+                    Right depDemandVecs ->
+                        goWithDeps unitConfig depLookup depDb depDbName depSolver depDemandVecs (depth + 1)
 
 {- | Cross-DB per-activity LCIA contributions. Walks the same dep graph as
 'goWithDeps' but attributes contributions per @(dbName, localPid)@ instead

--- a/src/SharedSolver.hs
+++ b/src/SharedSolver.hs
@@ -32,6 +32,7 @@ module SharedSolver (
     computeInventoryMatrixWithDepsCached,
     computeInventoryMatrixBatchWithDepsCached,
     goWithDepsFromScalings,
+    mergeSolutions,
     crossDBProcessContributions,
 ) where
 
@@ -327,14 +328,23 @@ goWithDepsFromScalings unitConfig depLookup db dbName extraLinks scalings depth 
                                         mergeSolutions
                                         baseSolutions
                                         perRootDepSols
-  where
-    mergeSolutions base depSols =
-        CrossDBSolution
-            { csInventory =
-                foldr (M.unionWith (+)) (csInventory base) (map csInventory depSols)
-            , csScalings =
-                csScalings base ++ concatMap csScalings depSols
-            }
+
+{- | Merge a base 'CrossDBSolution' (this DB's own contribution) with the
+list of dep-DB solutions resolved at this level. Inventories are summed
+via 'M.unionWith (+)'; scaling vectors are concatenated so the final
+'csScalings' lists every visited DB in BFS order.
+
+Exported so the substitution-aware solver ('Service.goWithSubsAndDeps')
+reuses the same merge shape as the plain cross-DB solver.
+-}
+mergeSolutions :: CrossDBSolution -> [CrossDBSolution] -> CrossDBSolution
+mergeSolutions base depSols =
+    CrossDBSolution
+        { csInventory =
+            foldr (M.unionWith (+)) (csInventory base) (map csInventory depSols)
+        , csScalings =
+            csScalings base ++ concatMap csScalings depSols
+        }
 
 resolveDep ::
     UnitConfig ->

--- a/test/CrossDBInventorySpec.hs
+++ b/test/CrossDBInventorySpec.hs
@@ -31,6 +31,7 @@ import SharedSolver (
     computeInventoryMatrixBatchWithDepsCached,
     createSharedSolver,
  )
+import qualified SharedSolver
 import Test.Hspec
 import TestHelpers (loadSampleDatabase)
 import Types
@@ -108,14 +109,14 @@ spec = do
                 noDeps _ = pure Nothing
 
             localInvs <- computeInventoryMatrixBatchCached db solver pids
-            withDepsE <- computeInventoryMatrixBatchWithDepsCached defaultUnitConfig noDeps db solver pids
+            withDepsE <- computeInventoryMatrixBatchWithDepsCached defaultUnitConfig noDeps db "SAMPLE.min3" solver pids
 
             case withDepsE of
                 Left err -> expectationFailure (T.unpack err)
-                Right withDepsInvs -> do
-                    length withDepsInvs `shouldBe` length localInvs
-                    case (localInvs, withDepsInvs) of
-                        ([a], [b]) -> M.toList a `shouldBe` M.toList b
+                Right withDepsSols -> do
+                    length withDepsSols `shouldBe` length localInvs
+                    case (localInvs, withDepsSols) of
+                        ([a], [b]) -> M.toList a `shouldBe` M.toList (SharedSolver.csInventory b)
                         _ -> expectationFailure "expected one inventory per pid"
 
         it "empty pid list returns empty result without solving" $ do
@@ -127,8 +128,10 @@ spec = do
                 actCount = fromIntegral (dbActivityCount db)
             solver <- createSharedSolver "SAMPLE.min3-empty" techTriples actCount
             let noDeps _ = pure Nothing
-            res <- computeInventoryMatrixBatchWithDepsCached defaultUnitConfig noDeps db solver []
-            res `shouldBe` Right []
+            res <- computeInventoryMatrixBatchWithDepsCached defaultUnitConfig noDeps db "SAMPLE.min3-empty" solver []
+            case res of
+                Right sols -> length sols `shouldBe` 0
+                Left err -> expectationFailure (T.unpack err)
 
     describe "inventoryContributions (cross-DB characterization surface)" $ do
         -- Synthetic data: simulate the shape of a cross-DB-merged Inventory

--- a/test/CrossDBRegionalLCIAFixture.hs
+++ b/test/CrossDBRegionalLCIAFixture.hs
@@ -1,0 +1,242 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Shared synthetic two-DB fixture for cross-DB regional LCIA tests.
+
+Two databases linked by a 'CrossDBLink' such that the only biosphere
+emission with a regional CF lives in the dep DB. Reused by:
+
+* 'CrossDBRegionalLCIASpec'   — the original gap-and-fix spec
+* 'CrossDBRegionalLCIASubsSpec' — substitution path parity / fan-out
+
+Topology built by 'mkRegionalFixture':
+
+* Root DB R: 1 activity at FR, no biosphere emission. Cross-DB link to
+  dep DB D's activity #1 (the one at DE), coefficient 1.0.
+* Dep DB D: 3 activities at FR, DE, GLO. D's activity #1 (DE) emits
+  1.0 kg of the shared biosphere flow F.
+* Method tables M: regional CFs on F: FR=1, DE=5, GLO=0.5.
+
+Demanding R's activity #0 forces 1 unit of D's activity #1 (DE) →
+cross-DB regional score = 0 + 1·CF[F,DE] = 5.
+-}
+module CrossDBRegionalLCIAFixture (
+    -- * Topology builders
+    mkDB,
+    linkAt,
+
+    -- * UUID helpers
+    mkUUID,
+    actUUID,
+    prodUUID,
+    flowUUID,
+
+    -- * Method-table builders
+    regionalMappings,
+    buildTables,
+
+    -- * Units / flow / config used by the fixture
+    kgUnit,
+    kgUnitConfig,
+    testFlow,
+
+    -- * Bundled fixture
+    RegionalFixture (..),
+    mkRegionalFixture,
+) where
+
+import Data.Int (Int32)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as U
+
+import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, fillBroadcastVector, fillRegionalActivityWeights)
+import Method.Types (FlowDirection (..), MethodCF (..))
+import Types
+import UnitConversion (UnitConfig (..), UnitDef (..))
+
+-- | One biosphere flow shared by both DBs (cross-DB merging keys on UUID).
+flowUUID :: UUID
+flowUUID = mkUUID 1
+
+-- | Activity UUIDs are offset-based so root and dep don't collide.
+actUUID :: Int -> UUID
+actUUID i = mkUUID (toInteger (1000 + i))
+
+prodUUID :: Int -> UUID
+prodUUID i = mkUUID (toInteger (2000 + i))
+
+mkUUID :: Integer -> UUID
+mkUUID n = UUID.fromWords64 (fromIntegral n) 0
+
+kgUnit :: Unit
+kgUnit = Unit{unitId = mkUUID 9, unitName = "kg", unitSymbol = "kg", unitComment = ""}
+
+kgUnitConfig :: UnitConfig
+kgUnitConfig =
+    UnitConfig
+        { ucDimensionOrder =
+            ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
+        , ucUnits = M.fromList [("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)]
+        , ucOriginalKeys = M.fromList [("kg", "kg")]
+        }
+
+testFlow :: Flow
+testFlow =
+    Flow
+        { flowId = flowUUID
+        , flowName = "Carbon dioxide"
+        , flowCategory = "air"
+        , flowSubcompartment = Nothing
+        , flowUnitId = unitId kgUnit
+        , flowType = Biosphere
+        , flowSynonyms = M.empty
+        , flowCAS = Nothing
+        , flowSubstanceId = Nothing
+        }
+
+mkActivity :: Int -> Text -> Activity
+mkActivity _ loc =
+    Activity
+        { activityName = "act-" <> loc
+        , activityDescription = []
+        , activitySynonyms = M.empty
+        , activityClassification = M.empty
+        , activityLocation = loc
+        , activityUnit = "kg"
+        , exchanges = []
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        }
+
+emptyIndexes :: Indexes
+emptyIndexes = Indexes M.empty M.empty M.empty M.empty M.empty M.empty
+
+{- | Build a synthetic single-DB fixture parameterized by:
+* @offset@: starting index for activity UUIDs (so root and dep don't collide)
+* @locs@: locations for each activity, length determines activity count
+* @bioTriples@: (flowRow=0, activityCol, value) sparse entries to emit on
+  the single biosphere flow @flowUUID@. Empty for DBs that emit nothing.
+
+The technosphere matrix is left empty — the MUMPS layer adds the identity
+on each diagonal so (I - 0)·x = d trivially yields x = d.
+-}
+mkDB :: Int -> [Text] -> [(Int, Double)] -> Database
+mkDB offset locs bioTriples =
+    let n = length locs
+        activities = V.fromList [mkActivity (offset + i) loc | (i, loc) <- zip [0 ..] locs]
+        actIdx = V.fromList [fromIntegral i :: Int32 | i <- [0 .. n - 1]]
+        triples = U.fromList [SparseTriple 0 (fromIntegral c) v | (c, v) <- bioTriples]
+        procIds = V.fromList [(actUUID (offset + i), prodUUID (offset + i)) | i <- [0 .. n - 1]]
+        procIdLookup =
+            M.fromList
+                [((actUUID (offset + i), prodUUID (offset + i)), fromIntegral i :: Int32) | i <- [0 .. n - 1]]
+     in Database
+            { dbProcessIdTable = procIds
+            , dbProcessIdLookup = procIdLookup
+            , dbActivityUUIDIndex = M.empty
+            , dbActivityProductsIndex = M.empty
+            , dbProductIndex = emptyProductIndex
+            , dbActivities = activities
+            , dbFlows = M.singleton flowUUID testFlow
+            , dbUnits = M.singleton (unitId kgUnit) kgUnit
+            , dbIndexes = emptyIndexes
+            , dbTechnosphereTriples = U.empty
+            , dbBiosphereTriples = triples
+            , dbActivityIndex = actIdx
+            , dbBiosphereFlows = V.singleton flowUUID
+            , dbActivityCount = fromIntegral n
+            , dbBiosphereCount = 1
+            , dbCrossDBLinks = []
+            , dbDependsOn = []
+            , dbLinkingStats = emptyCrossDBLinkingStats
+            , dbSynonymDB = Nothing
+            , dbFlowsByName = M.empty
+            , dbFlowsByCAS = M.empty
+            , dbProductSearchIndex = M.empty
+            , dbBM25Index = Nothing
+            }
+
+{- | Add a 'CrossDBLink' from the first activity of @consumerDb@ to the
+named activity in @supplierDb@ (identified by its index inside the supplier's
+'dbProcessIdTable').
+-}
+linkAt ::
+    Database ->
+    Database ->
+    Text ->
+    -- | supplier activity index in supplierDb
+    Int ->
+    -- | coefficient (mass moved across the link)
+    Double ->
+    Database
+linkAt consumerDb supplierDb supplierName supIdx coeff =
+    let (consumerAct, consumerProd) = dbProcessIdTable consumerDb V.! 0
+        (supplierAct, supplierProd) = dbProcessIdTable supplierDb V.! supIdx
+        link =
+            CrossDBLink
+                { cdlConsumerActUUID = consumerAct
+                , cdlConsumerProdUUID = consumerProd
+                , cdlSupplierActUUID = supplierAct
+                , cdlSupplierProdUUID = supplierProd
+                , cdlCoefficient = coeff
+                , cdlExchangeUnit = "kg"
+                , cdlFlowName = "x-link"
+                , cdlLocation = activityLocation (dbActivities supplierDb V.! supIdx)
+                , cdlSourceDatabase = supplierName
+                }
+     in consumerDb{dbCrossDBLinks = link : dbCrossDBLinks consumerDb}
+
+regionalMappings :: [(Text, Double)] -> [(MethodCF, Maybe (Flow, MatchStrategy))]
+regionalMappings = map (\(loc, v) -> (cf loc v, Just (testFlow, ByName)))
+  where
+    cf loc v =
+        MethodCF
+            { mcfFlowRef = flowUUID
+            , mcfFlowName = "Carbon dioxide"
+            , mcfDirection = Output
+            , mcfValue = v
+            , mcfCompartment = Nothing
+            , mcfCAS = Nothing
+            , mcfUnit = "kg"
+            , mcfConsumerLocation = Just loc
+            }
+
+buildTables :: Database -> [(MethodCF, Maybe (Flow, MatchStrategy))] -> MethodTables
+buildTables db mappings =
+    let raw = buildMethodTables M.empty mappings
+        withBroadcast = fillBroadcastVector kgUnitConfig (dbUnits db) (dbFlows db) raw
+     in fillRegionalActivityWeights
+            kgUnitConfig
+            (dbUnits db)
+            (dbFlows db)
+            db
+            M.empty
+            withBroadcast
+
+{- | The canonical two-DB fixture used across cross-DB regional specs.
+
+@regional cross-DB score = w_R·x_R + w_D·x_D = 0 + 5 = 5@ when demanding
+root activity #0 (which forces 1 unit of dep activity #1 at DE).
+-}
+data RegionalFixture = RegionalFixture
+    { rfRootDb :: Database
+    , rfDepDb :: Database
+    , rfRootTables :: MethodTables
+    , rfDepTables :: MethodTables
+    }
+
+mkRegionalFixture :: RegionalFixture
+mkRegionalFixture =
+    let dep = mkDB 1 ["FR", "DE", "GLO"] [(1, 1.0)] -- emission only on the DE column
+        rootBase = mkDB 100 ["FR"] []
+        root = linkAt rootBase dep "dep" 1 1.0
+        mappings = regionalMappings [("FR", 1), ("DE", 5), ("GLO", 0.5)]
+     in RegionalFixture
+            { rfRootDb = root
+            , rfDepDb = dep
+            , rfRootTables = buildTables root mappings
+            , rfDepTables = buildTables dep mappings
+            }

--- a/test/CrossDBRegionalLCIASensitivitySpec.hs
+++ b/test/CrossDBRegionalLCIASensitivitySpec.hs
@@ -22,6 +22,7 @@ identically across plain, substitution, and sensitivity paths.
 -}
 module CrossDBRegionalLCIASensitivitySpec (spec) where
 
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import qualified Data.Vector.Unboxed as U
 
@@ -75,14 +76,14 @@ spec = describe "cross-DB regional LCIA via sensitivity propagation" $ do
             Right [] -> expectationFailure "goWithDepsFromScalings returned empty list"
             Right (sol : _) -> do
                 -- Both DBs participate, in BFS order: root first, dep second.
-                let names = [n | (n, _, _) <- SS.csScalings sol]
+                let names = [n | (n, _, _) <- NE.toList (SS.csScalings sol)]
                 names `shouldBe` ["root", "dep"]
                 -- The merged inventory carries the dep DB's 1.0 kg emission.
                 M.lookup flowUUID (SS.csInventory sol) `shouldBe` Just 1.0
                 -- Regional score against both DBs' tables = 0 + 5 = 5.
                 let perDb =
                         [ (db, sv, tablesFor n)
-                        | (n, db, sv) <- SS.csScalings sol
+                        | (n, db, sv) <- NE.toList (SS.csScalings sol)
                         ]
                     tablesFor "root" = rootTables
                     tablesFor "dep" = depTables
@@ -123,7 +124,7 @@ spec = describe "cross-DB regional LCIA via sensitivity propagation" $ do
             Right (sol : _) -> do
                 let perDb =
                         [ (db, sv, tablesFor n)
-                        | (n, db, sv) <- SS.csScalings sol
+                        | (n, db, sv) <- NE.toList (SS.csScalings sol)
                         ]
                     tablesFor "root" = rootTables
                     tablesFor "dep" = depTables

--- a/test/CrossDBRegionalLCIASensitivitySpec.hs
+++ b/test/CrossDBRegionalLCIASensitivitySpec.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Regression: sensitivity sweeps must score regional methods correctly
+on cross-DB recipes.
+
+'postActivitySensitivity' used to project the perturbed root scaling
+through 'applyBiosphereMatrix db x' (root-only), then wrap the result in
+a root-only 'CrossDBSolution'. The dep-DB emissions induced by the
+perturbed root scaling were silently dropped — same under-count as the
+plain cross-DB path had before PR #41.
+
+The fix is to thread the perturbed root scaling through
+'SharedSolver.goWithDepsFromScalings', which is documented for exactly
+this case: "the caller supplies the root scaling vectors, e.g. after a
+Sherman-Morrison substitution update." This spec proves that path
+produces a 'CrossDBSolution' whose regional score recovers the
+dep-DB contribution.
+
+The fixture is shared with 'CrossDBRegionalLCIASpec' so the same
+gap-and-fix proof point (regional cross-DB score = 5.0) reads
+identically across plain, substitution, and sensitivity paths.
+-}
+module CrossDBRegionalLCIASensitivitySpec (spec) where
+
+import qualified Data.Map.Strict as M
+import qualified Data.Vector.Unboxed as U
+
+import Test.Hspec
+
+import CrossDBRegionalLCIAFixture
+import Method.Mapping (sumRegionalizedLCIAScoreCrossDB)
+import qualified SharedSolver as SS
+import TestHelpers (mkSolverFromDb)
+import Types
+
+spec :: Spec
+spec = describe "cross-DB regional LCIA via sensitivity propagation" $ do
+    let fix = mkRegionalFixture
+        rootDb = rfRootDb fix
+        depDb = rfDepDb fix
+        rootTables = rfRootTables fix
+        depTables = rfDepTables fix
+
+    it "goWithDepsFromScalings on a caller-supplied root scaling recovers the dep-DB regional score" $ do
+        -- Sensitivity's path:
+        --   1. Sherman-Morrison gives a perturbed root scaling x'.
+        --   2. Hand x' to goWithDepsFromScalings → full CrossDBSolution.
+        --   3. Score with sumRegionalizedLCIAScoreCrossDB.
+        --
+        -- This test simulates step 2 with x' = baseline (root activity 0
+        -- demanded), which is the sensitivity-baseline case. The score
+        -- must equal the plain-path baseline (5.0), proving the
+        -- perturbed-scaling path picks up dep-DB emissions instead of
+        -- silently zeroing them.
+        rootSolver <- mkSolverFromDb rootDb "root"
+        depSolver <- mkSolverFromDb depDb "dep"
+        let depLookup name =
+                pure $
+                    if name == "dep" then Just (depDb, depSolver) else Nothing
+            -- Caller-supplied root scaling: 1.0 on root's only activity
+            -- column. Same shape as what Sherman-Morrison would hand back
+            -- for the unperturbed baseline.
+            rootScaling = U.fromList [1.0]
+        eSol <-
+            SS.goWithDepsFromScalings
+                kgUnitConfig
+                depLookup
+                rootDb
+                "root"
+                []
+                [rootScaling]
+                0
+        case eSol of
+            Left err -> expectationFailure ("goWithDepsFromScalings failed: " <> show err)
+            Right [] -> expectationFailure "goWithDepsFromScalings returned empty list"
+            Right (sol : _) -> do
+                -- Both DBs participate, in BFS order: root first, dep second.
+                let names = [n | (n, _, _) <- SS.csScalings sol]
+                names `shouldBe` ["root", "dep"]
+                -- The merged inventory carries the dep DB's 1.0 kg emission.
+                M.lookup flowUUID (SS.csInventory sol) `shouldBe` Just 1.0
+                -- Regional score against both DBs' tables = 0 + 5 = 5.
+                let perDb =
+                        [ (db, sv, tablesFor n)
+                        | (n, db, sv) <- SS.csScalings sol
+                        ]
+                    tablesFor "root" = rootTables
+                    tablesFor "dep" = depTables
+                    tablesFor other = error ("unexpected dbName: " <> show other)
+                sumRegionalizedLCIAScoreCrossDB
+                    kgUnitConfig
+                    (dbUnits depDb)
+                    (dbFlows depDb)
+                    M.empty
+                    perDb
+                    `shouldBe` Right 5.0
+
+    it "scaled root demand scales the dep-DB contribution linearly" $ do
+        -- Sanity gate: doubling the root scaling doubles the dep DB's
+        -- regional contribution (because the cross-DB link coefficient
+        -- is constant). This is the property a sensitivity sweep
+        -- depends on: if Sherman-Morrison produces a perturbed scaling
+        -- that differs from baseline by Δ, the downstream regional
+        -- score must reflect that Δ, not silently flatten it.
+        rootSolver <- mkSolverFromDb rootDb "root"
+        depSolver <- mkSolverFromDb depDb "dep"
+        let depLookup name =
+                pure $
+                    if name == "dep" then Just (depDb, depSolver) else Nothing
+            doubledRoot = U.fromList [2.0]
+        eSol <-
+            SS.goWithDepsFromScalings
+                kgUnitConfig
+                depLookup
+                rootDb
+                "root"
+                []
+                [doubledRoot]
+                0
+        case eSol of
+            Left err -> expectationFailure ("goWithDepsFromScalings failed: " <> show err)
+            Right [] -> expectationFailure "goWithDepsFromScalings returned empty list"
+            Right (sol : _) -> do
+                let perDb =
+                        [ (db, sv, tablesFor n)
+                        | (n, db, sv) <- SS.csScalings sol
+                        ]
+                    tablesFor "root" = rootTables
+                    tablesFor "dep" = depTables
+                    tablesFor other = error ("unexpected dbName: " <> show other)
+                sumRegionalizedLCIAScoreCrossDB
+                    kgUnitConfig
+                    (dbUnits depDb)
+                    (dbFlows depDb)
+                    M.empty
+                    perDb
+                    `shouldBe` Right 10.0

--- a/test/CrossDBRegionalLCIASpec.hs
+++ b/test/CrossDBRegionalLCIASpec.hs
@@ -1,0 +1,352 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Regression: regional LCIA must score dep-DB biosphere emissions, not
+just root-DB ones.
+
+The 'computeRegionalizedLCIAScore' fast path is a dot product
+@rawWeights · scalingVec@. Both vectors are built from a single 'Database':
+'rawWeights' from that DB's biosphere triples, 'scalingVec' from that DB's
+activity columns. So when a root-DB activity consumes a dep-DB activity,
+the dep DB's emissions are present in the merged 'Inventory' but invisible
+to the regional path — its regional CFs were never queried.
+
+This spec sets up two synthetic DBs linked by 'CrossDBLink' such that the
+only biosphere emission with a regional CF lives in the dep DB. The "broken"
+case shows the root-only score is 0 (the bug); the "fixed" case shows that
+summing per-DB regional dot products recovers the right answer.
+-}
+module CrossDBRegionalLCIASpec (spec) where
+
+import Data.Int (Int32)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as U
+
+import Test.Hspec
+
+import Method.Mapping
+import Method.Types (FlowDirection (..), MethodCF (..))
+import qualified SharedSolver as SS
+import TestHelpers (mkSolverFromDb)
+import Types
+import UnitConversion (UnitConfig (..), UnitDef (..))
+
+-- ---------------------------------------------------------------------------
+-- Fixture
+-- ---------------------------------------------------------------------------
+
+-- One biosphere flow shared by both DBs (cross-DB merging keys on UUID).
+flowUUID :: UUID
+flowUUID = mkUUID 1
+
+-- Activity UUIDs: root has a1, dep has b1..bN.
+actUUID :: Int -> UUID
+actUUID i = mkUUID (toInteger (1000 + i))
+
+prodUUID :: Int -> UUID
+prodUUID i = mkUUID (toInteger (2000 + i))
+
+mkUUID :: Integer -> UUID
+mkUUID n = UUID.fromWords64 (fromIntegral n) 0
+
+kgUnit :: Unit
+kgUnit = Unit{unitId = mkUUID 9, unitName = "kg", unitSymbol = "kg", unitComment = ""}
+
+kgUnitConfig :: UnitConfig
+kgUnitConfig =
+    UnitConfig
+        { ucDimensionOrder =
+            ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
+        , ucUnits = M.fromList [("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)]
+        , ucOriginalKeys = M.fromList [("kg", "kg")]
+        }
+
+testFlow :: Flow
+testFlow =
+    Flow
+        { flowId = flowUUID
+        , flowName = "Carbon dioxide"
+        , flowCategory = "air"
+        , flowSubcompartment = Nothing
+        , flowUnitId = unitId kgUnit
+        , flowType = Biosphere
+        , flowSynonyms = M.empty
+        , flowCAS = Nothing
+        , flowSubstanceId = Nothing
+        }
+
+mkActivity :: Int -> Text -> Activity
+mkActivity i loc =
+    Activity
+        { activityName = "act-" <> loc
+        , activityDescription = []
+        , activitySynonyms = M.empty
+        , activityClassification = M.empty
+        , activityLocation = loc
+        , activityUnit = "kg"
+        , exchanges = []
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        }
+  where
+    _ = i
+
+emptyIndexes :: Indexes
+emptyIndexes = Indexes M.empty M.empty M.empty M.empty M.empty M.empty
+
+{- | Build a synthetic single-DB fixture parameterized by:
+* @offset@: starting index for activity UUIDs (so root and dep don't collide)
+* @locs@: locations for each activity, length determines activity count
+* @bioTriples@: (flowRow=0, activityCol, value) sparse entries to emit on
+  the single biosphere flow @flowUUID@. Empty for DBs that emit nothing.
+
+The technosphere matrix is left empty — the MUMPS layer adds the identity
+on each diagonal so (I - 0)·x = d trivially yields x = d. This is enough
+for the cross-DB regional gap test: we only need cleanly-defined scaling
+vectors per DB.
+-}
+mkDB :: Int -> [Text] -> [(Int, Double)] -> Database
+mkDB offset locs bioTriples =
+    let n = length locs
+        activities = V.fromList [mkActivity (offset + i) loc | (i, loc) <- zip [0 ..] locs]
+        actIdx = V.fromList [fromIntegral i :: Int32 | i <- [0 .. n - 1]]
+        triples = U.fromList [SparseTriple 0 (fromIntegral c) v | (c, v) <- bioTriples]
+        procIds = V.fromList [(actUUID (offset + i), prodUUID (offset + i)) | i <- [0 .. n - 1]]
+        procIdLookup =
+            M.fromList
+                [((actUUID (offset + i), prodUUID (offset + i)), fromIntegral i :: Int32) | i <- [0 .. n - 1]]
+     in Database
+            { dbProcessIdTable = procIds
+            , dbProcessIdLookup = procIdLookup
+            , dbActivityUUIDIndex = M.empty
+            , dbActivityProductsIndex = M.empty
+            , dbProductIndex = emptyProductIndex
+            , dbActivities = activities
+            , dbFlows = M.singleton flowUUID testFlow
+            , dbUnits = M.singleton (unitId kgUnit) kgUnit
+            , dbIndexes = emptyIndexes
+            , dbTechnosphereTriples = U.empty
+            , dbBiosphereTriples = triples
+            , dbActivityIndex = actIdx
+            , dbBiosphereFlows = V.singleton flowUUID
+            , dbActivityCount = fromIntegral n
+            , dbBiosphereCount = 1
+            , dbCrossDBLinks = []
+            , dbDependsOn = []
+            , dbLinkingStats = emptyCrossDBLinkingStats
+            , dbSynonymDB = Nothing
+            , dbFlowsByName = M.empty
+            , dbFlowsByCAS = M.empty
+            , dbProductSearchIndex = M.empty
+            , dbBM25Index = Nothing
+            }
+
+{- | Add a 'CrossDBLink' from the first activity of @consumerDb@ to the
+named activity in @supplierDb@ (identified by its index inside the supplier's
+'dbProcessIdTable').
+-}
+linkAt ::
+    Database ->
+    Database ->
+    Text ->
+    -- | supplier activity index in supplierDb
+    Int ->
+    -- | coefficient (mass moved across the link)
+    Double ->
+    Database
+linkAt consumerDb supplierDb supplierName supIdx coeff =
+    let (consumerAct, consumerProd) = dbProcessIdTable consumerDb V.! 0
+        (supplierAct, supplierProd) = dbProcessIdTable supplierDb V.! supIdx
+        link =
+            CrossDBLink
+                { cdlConsumerActUUID = consumerAct
+                , cdlConsumerProdUUID = consumerProd
+                , cdlSupplierActUUID = supplierAct
+                , cdlSupplierProdUUID = supplierProd
+                , cdlCoefficient = coeff
+                , cdlExchangeUnit = "kg"
+                , cdlFlowName = "x-link"
+                , cdlLocation = activityLocation (dbActivities supplierDb V.! supIdx)
+                , cdlSourceDatabase = supplierName
+                }
+     in consumerDb{dbCrossDBLinks = link : dbCrossDBLinks consumerDb}
+
+-- ---------------------------------------------------------------------------
+-- MethodTables: one regional CF per location, all on the shared flow F
+-- ---------------------------------------------------------------------------
+
+regionalMappings :: [(Text, Double)] -> [(MethodCF, Maybe (Flow, MatchStrategy))]
+regionalMappings = map (\(loc, v) -> (cf loc v, Just (testFlow, ByName)))
+  where
+    cf loc v =
+        MethodCF
+            { mcfFlowRef = flowUUID
+            , mcfFlowName = "Carbon dioxide"
+            , mcfDirection = Output
+            , mcfValue = v
+            , mcfCompartment = Nothing
+            , mcfCAS = Nothing
+            , mcfUnit = "kg"
+            , mcfConsumerLocation = Just loc
+            }
+
+buildTables :: Database -> [(MethodCF, Maybe (Flow, MatchStrategy))] -> MethodTables
+buildTables db mappings =
+    let raw = buildMethodTables M.empty mappings
+        withBroadcast = fillBroadcastVector kgUnitConfig (dbUnits db) (dbFlows db) raw
+     in fillRegionalActivityWeights
+            kgUnitConfig
+            (dbUnits db)
+            (dbFlows db)
+            db
+            M.empty
+            withBroadcast
+
+-- ---------------------------------------------------------------------------
+-- Spec
+-- ---------------------------------------------------------------------------
+
+spec :: Spec
+spec = describe "cross-DB regional LCIA" $ do
+    -- Fixture used by both expectations:
+    --   * Root DB R: 1 activity at FR. No biosphere emission. Cross-DB link
+    --     to dep DB D's activity #1 (the one at DE), coefficient 1.0.
+    --   * Dep DB D: 3 activities at FR, DE, GLO. D's activity #1 (DE) emits
+    --     1.0 kg of biosphere flow F.
+    --   * Method M: one regional CF table on F: FR=1, DE=5, GLO=0.5.
+    --
+    -- Demanding R's activity #0 forces 1 unit of D's activity #1 (DE).
+    --   * Dep scaling x_D = [0, 1, 0].
+    --   * Dep regional weights w_D = [0, 1·CF[F,DE], 0] = [0, 5, 0].
+    --   * Root weights w_R: empty (R has no biosphere triples).
+    --   * Cross-DB regional score = w_R·x_R + w_D·x_D = 0 + 5 = 5.
+    let depDb = mkDB 1 ["FR", "DE", "GLO"] [(1, 1.0)] -- emission only on the DE column
+        rootBase = mkDB 100 ["FR"] []
+        rootDb = linkAt rootBase depDb "dep" 1 1.0
+
+        rootMappings = regionalMappings [("FR", 1), ("DE", 5), ("GLO", 0.5)]
+        rootTables = buildTables rootDb rootMappings
+        depTables = buildTables depDb rootMappings
+
+    it "OLD path: root-only regional score silently misses dep-DB emissions" $ do
+        -- Today's contract: computeLCIAScoreAuto is handed the ROOT db's
+        -- scaling vector and the ROOT db's MethodTables. The merged
+        -- Inventory containing F=1 kg is passed too, but the regional path
+        -- ignores it — score = rawWeights_root · scaling_root = 0.
+        rootSolver <- mkSolverFromDb rootDb "root"
+        depSolver <- mkSolverFromDb depDb "dep"
+        let depLookup name =
+                pure $
+                    if name == "dep" then Just (depDb, depSolver) else Nothing
+        eRes <-
+            SS.computeInventoryMatrixWithDepsCached
+                kgUnitConfig
+                depLookup
+                rootDb
+                "root"
+                rootSolver
+                0 -- root's only activity column
+        case eRes of
+            Left err -> expectationFailure ("solve failed: " <> show err)
+            Right sol -> do
+                let inv = SS.csInventory sol
+                -- Sanity: dep DB's emission shows up in the merged inventory.
+                M.lookup flowUUID inv `shouldBe` Just 1.0
+                -- The bug surface: the regional path scored against root
+                -- tables/scaling alone returns 0 (or, depending on how the
+                -- caller invokes it, the wrong number — never 5).
+                let rootScaling = case [s | (n, _, s) <- SS.csScalings sol, n == "root"] of
+                        (s : _) -> s
+                        [] -> U.empty
+                computeRegionalizedLCIAScore
+                    kgUnitConfig
+                    (dbUnits rootDb)
+                    (dbFlows rootDb)
+                    rootDb
+                    rootScaling
+                    M.empty
+                    rootTables
+                    `shouldBe` Right 0.0
+
+    it "NEW path: per-DB regional sum recovers the dep-DB contribution" $ do
+        rootSolver <- mkSolverFromDb rootDb "root"
+        depSolver <- mkSolverFromDb depDb "dep"
+        let depLookup name =
+                pure $
+                    if name == "dep" then Just (depDb, depSolver) else Nothing
+        eRes <-
+            SS.computeInventoryMatrixWithDepsCached
+                kgUnitConfig
+                depLookup
+                rootDb
+                "root"
+                rootSolver
+                0
+        case eRes of
+            Left err -> expectationFailure ("solve failed: " <> show err)
+            Right sol -> do
+                let perDb =
+                        [ (db, s, tablesFor n)
+                        | (n, db, s) <- SS.csScalings sol
+                        ]
+                    tablesFor n = case n of
+                        "root" -> rootTables
+                        "dep" -> depTables
+                        other -> error ("unexpected dbName in csScalings: " <> show other)
+                sumRegionalizedLCIAScoreCrossDB
+                    kgUnitConfig
+                    (dbUnits depDb)
+                    (dbFlows depDb)
+                    M.empty
+                    perDb
+                    `shouldBe` Right 5.0
+
+    it "NEW path: tainted dep-DB activity with non-zero scaling surfaces Left" $ do
+        -- Same DBs, but the method only has CF[F, FR]. The dep DB's DE
+        -- activity is regionalized in the method (F appears in regional
+        -- CFs) but no CF resolves at DE / parents / broadcast — that's a
+        -- tainted column, and it carries scaling 1. The contract from
+        -- computeRegionalizedLCIAScore is to Left, and the cross-DB sum
+        -- must propagate that Left rather than silently substituting 0.
+        let strictMappings = regionalMappings [("FR", 1)]
+            depTablesStrict = buildTables depDb strictMappings
+            rootTablesStrict = buildTables rootDb strictMappings
+        rootSolver <- mkSolverFromDb rootDb "root"
+        depSolver <- mkSolverFromDb depDb "dep"
+        let depLookup name =
+                pure $
+                    if name == "dep" then Just (depDb, depSolver) else Nothing
+        eRes <-
+            SS.computeInventoryMatrixWithDepsCached
+                kgUnitConfig
+                depLookup
+                rootDb
+                "root"
+                rootSolver
+                0
+        case eRes of
+            Left err -> expectationFailure ("solve failed: " <> show err)
+            Right sol -> do
+                let perDb =
+                        [ (db, s, tablesFor n)
+                        | (n, db, s) <- SS.csScalings sol
+                        ]
+                    tablesFor n = case n of
+                        "root" -> rootTablesStrict
+                        "dep" -> depTablesStrict
+                        other -> error ("unexpected dbName in csScalings: " <> show other)
+                case sumRegionalizedLCIAScoreCrossDB
+                    kgUnitConfig
+                    (dbUnits depDb)
+                    (dbFlows depDb)
+                    M.empty
+                    perDb of
+                    Left _ -> pure ()
+                    Right v ->
+                        expectationFailure
+                            ( "expected Left for tainted cross-DB scoring, got Right "
+                                <> show v
+                            )

--- a/test/CrossDBRegionalLCIASpec.hs
+++ b/test/CrossDBRegionalLCIASpec.hs
@@ -17,6 +17,7 @@ products recovers the right answer.
 -}
 module CrossDBRegionalLCIASpec (spec) where
 
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import qualified Data.Vector.Unboxed as U
 
@@ -78,7 +79,7 @@ spec = describe "cross-DB regional LCIA" $ do
                 -- The bug surface: the regional path scored against root
                 -- tables/scaling alone returns 0 (or, depending on how the
                 -- caller invokes it, the wrong number — never 5).
-                let rootScaling = case [s | (n, _, s) <- SS.csScalings sol, n == "root"] of
+                let rootScaling = case [s | (n, _, s) <- NE.toList (SS.csScalings sol), n == "root"] of
                         (s : _) -> s
                         [] -> U.empty
                 computeRegionalizedLCIAScore
@@ -110,7 +111,7 @@ spec = describe "cross-DB regional LCIA" $ do
             Right sol -> do
                 let perDb =
                         [ (db, s, tablesFor n)
-                        | (n, db, s) <- SS.csScalings sol
+                        | (n, db, s) <- NE.toList (SS.csScalings sol)
                         ]
                     tablesFor n = case n of
                         "root" -> rootTables
@@ -154,7 +155,7 @@ spec = describe "cross-DB regional LCIA" $ do
             Right sol -> do
                 let perDb =
                         [ (db, s, tablesFor n)
-                        | (n, db, s) <- SS.csScalings sol
+                        | (n, db, s) <- NE.toList (SS.csScalings sol)
                         ]
                     tablesFor n = case n of
                         "root" -> rootTablesStrict
@@ -199,7 +200,7 @@ spec = describe "cross-DB regional LCIA" $ do
             Right sol -> do
                 let perDb =
                         [ (db, s, tablesFor n)
-                        | (n, db, s) <- SS.csScalings sol
+                        | (n, db, s) <- NE.toList (SS.csScalings sol)
                         ]
                     tablesFor n = case n of
                         "root" -> taintedRootTables
@@ -295,7 +296,7 @@ spec = describe "cross-DB regional LCIA" $ do
                     -- csScalings has only the root entry; cross-DB sum
                     -- reduces to the single-DB dot product. Score =
                     -- 1·CF[F, FR] = 7.
-                    let perDb = [(db, sv, standaloneTables) | (_, db, sv) <- SS.csScalings sol]
+                    let perDb = [(db, sv, standaloneTables) | (_, db, sv) <- NE.toList (SS.csScalings sol)]
                     sumRegionalizedLCIAScoreCrossDB
                         kgUnitConfig
                         (dbUnits rootStandalone)
@@ -326,7 +327,7 @@ spec = describe "cross-DB regional LCIA" $ do
                 Left err -> expectationFailure ("solve failed: " <> show err)
                 Right sol -> do
                     let perDbInvs =
-                            [applyBiosphereMatrix db sv | (_, db, sv) <- SS.csScalings sol]
+                            [applyBiosphereMatrix db sv | (_, db, sv) <- NE.toList (SS.csScalings sol)]
                         reconstructed =
                             foldr (M.unionWith (+)) M.empty perDbInvs
                     M.toList (SS.csInventory sol)

--- a/test/CrossDBRegionalLCIASpec.hs
+++ b/test/CrossDBRegionalLCIASpec.hs
@@ -304,13 +304,15 @@ spec = describe "cross-DB regional LCIA" $ do
                     perDb
                     `shouldBe` Right 5.0
 
-    it "NEW path: tainted dep-DB activity with non-zero scaling surfaces Left" $ do
+    it "NEW path: tainted dep-DB drops to 0 contribution; root contribution survives" $ do
         -- Same DBs, but the method only has CF[F, FR]. The dep DB's DE
         -- activity is regionalized in the method (F appears in regional
         -- CFs) but no CF resolves at DE / parents / broadcast — that's a
-        -- tainted column, and it carries scaling 1. The contract from
-        -- computeRegionalizedLCIAScore is to Left, and the cross-DB sum
-        -- must propagate that Left rather than silently substituting 0.
+        -- tainted column, and it carries scaling 1. Per-DB scoring Lefts
+        -- on dep. The cross-DB sum tolerates it: drops the dep DB to a 0
+        -- contribution and keeps the root DB's Right. The build-time WARN
+        -- already names the gap (per-(flow, location) pair); score-time
+        -- loudness would regress users who used to see partial scores.
         let strictMappings = regionalMappings [("FR", 1)]
             depTablesStrict = buildTables depDb strictMappings
             rootTablesStrict = buildTables rootDb strictMappings
@@ -338,6 +340,51 @@ spec = describe "cross-DB regional LCIA" $ do
                         "root" -> rootTablesStrict
                         "dep" -> depTablesStrict
                         other -> error ("unexpected dbName in csScalings: " <> show other)
+                -- Root has no biosphere triples → contributes Right 0.
+                -- Dep biosphere triple at DE has no CF → Left (tainted).
+                -- Tolerant sum: Right 0 (root) + 0 dropped (dep) = Right 0.
+                sumRegionalizedLCIAScoreCrossDB
+                    kgUnitConfig
+                    (dbUnits depDb)
+                    (dbFlows depDb)
+                    M.empty
+                    perDb
+                    `shouldBe` Right 0.0
+
+    it "NEW path: all-Left case (every participating DB tainted) surfaces Left" $ do
+        -- Every DB Lefts (no Right to fall back to). The sum has nothing
+        -- to sum, so it Lefts — preserves no-silent-errors when there is
+        -- genuinely no recoverable contribution.
+        let strictMappings = regionalMappings [("FR", 1)]
+            depTablesStrict = buildTables depDb strictMappings
+            -- Root variant with a tainted biosphere triple at DE so both
+            -- root and dep tables Left on the precomputed dot product.
+            taintedRoot = mkDB 100 ["DE"] [(0, 1.0)]
+            taintedRootTables = buildTables taintedRoot strictMappings
+        rootSolver <- mkSolverFromDb taintedRoot "root"
+        depSolver <- mkSolverFromDb depDb "dep"
+        let depLookup name =
+                pure $
+                    if name == "dep" then Just (depDb, depSolver) else Nothing
+        eRes <-
+            SS.computeInventoryMatrixWithDepsCached
+                kgUnitConfig
+                depLookup
+                taintedRoot
+                "root"
+                rootSolver
+                0
+        case eRes of
+            Left err -> expectationFailure ("solve failed: " <> show err)
+            Right sol -> do
+                let perDb =
+                        [ (db, s, tablesFor n)
+                        | (n, db, s) <- SS.csScalings sol
+                        ]
+                    tablesFor n = case n of
+                        "root" -> taintedRootTables
+                        "dep" -> depTablesStrict
+                        other -> error ("unexpected dbName in csScalings: " <> show other)
                 case sumRegionalizedLCIAScoreCrossDB
                     kgUnitConfig
                     (dbUnits depDb)
@@ -347,6 +394,6 @@ spec = describe "cross-DB regional LCIA" $ do
                     Left _ -> pure ()
                     Right v ->
                         expectationFailure
-                            ( "expected Left for tainted cross-DB scoring, got Right "
+                            ( "expected Left when every DB Lefts, got Right "
                                 <> show v
                             )

--- a/test/CrossDBRegionalLCIASpec.hs
+++ b/test/CrossDBRegionalLCIASpec.hs
@@ -23,7 +23,10 @@ import qualified Data.Vector.Unboxed as U
 import Test.Hspec
 
 import CrossDBRegionalLCIAFixture
+import Matrix (applyBiosphereMatrix)
 import Method.Mapping
+import qualified Method.Mapping as MM
+import Method.Types (FlowDirection (..), MethodCF (..))
 import qualified SharedSolver as SS
 import TestHelpers (mkSolverFromDb)
 import Types
@@ -214,3 +217,117 @@ spec = describe "cross-DB regional LCIA" $ do
                             ( "expected Left when every DB Lefts, got Right "
                                 <> show v
                             )
+
+    describe "non-regression invariants" $ do
+        -- These guard the cross-DB regional fix against drift on adjacent
+        -- code paths. The numerical proof-points (Right 5.0 / Right 10.0)
+        -- live in the gap-and-fix specs above; here we lock in the
+        -- properties the fix must preserve.
+
+        it "non-regional methods score identically on a cross-DB recipe" $ do
+            -- A method whose CFs are all universal (no consumer location)
+            -- never enters the regional cascade. Its score must be
+            -- whatever the merged-inventory matvec produces, regardless
+            -- of how many DBs participated. Guards against double-counting
+            -- in the non-regional code path of 'computeLCIAScoreFromTables'.
+            rootSolver <- mkSolverFromDb rootDb "root"
+            depSolver <- mkSolverFromDb depDb "dep"
+            let depLookup name =
+                    pure $
+                        if name == "dep" then Just (depDb, depSolver) else Nothing
+                -- Universal CF: same value applied wherever F shows up.
+                universalCF =
+                    MethodCF
+                        { mcfFlowRef = flowUUID
+                        , mcfFlowName = "Carbon dioxide"
+                        , mcfDirection = Output
+                        , mcfValue = 3.0
+                        , mcfCompartment = Nothing
+                        , mcfCAS = Nothing
+                        , mcfUnit = "kg"
+                        , mcfConsumerLocation = Nothing -- key: makes it non-regional
+                        }
+                universalTables =
+                    buildTables rootDb [(universalCF, Just (testFlow, ByUUID))]
+            eRes <-
+                SS.computeInventoryMatrixWithDepsCached
+                    kgUnitConfig
+                    depLookup
+                    rootDb
+                    "root"
+                    rootSolver
+                    0
+            case eRes of
+                Left err -> expectationFailure ("solve failed: " <> show err)
+                Right sol -> do
+                    -- Merged inventory has F = 1.0 kg (from dep DB).
+                    -- Universal CF = 3.0/kg → score = 3.0.
+                    let outcome =
+                            MM.computeLCIAScoreFromTables
+                                kgUnitConfig
+                                (dbUnits rootDb)
+                                (dbFlows rootDb)
+                                (SS.csInventory sol)
+                                universalTables
+                    MM.loScore outcome `shouldBe` 3.0
+
+        it "recipe without any cross-DB reach scores identically to root-only path" $ do
+            -- A root DB whose CrossDBLinks don't fire (or aren't there)
+            -- must produce a regional score equal to what the OLD
+            -- root-only path returned. The cross-DB sum must collapse to
+            -- the single-DB dot product, no spurious dep contribution.
+            let rootStandalone = mkDB 100 ["FR"] [(0, 1.0)] -- emits 1.0 on root, no links
+                standaloneTables =
+                    buildTables rootStandalone (regionalMappings [("FR", 7), ("DE", 0)])
+            rootSolver <- mkSolverFromDb rootStandalone "root"
+            let noDeps _ = pure Nothing
+            eRes <-
+                SS.computeInventoryMatrixWithDepsCached
+                    kgUnitConfig
+                    noDeps
+                    rootStandalone
+                    "root"
+                    rootSolver
+                    0
+            case eRes of
+                Left err -> expectationFailure ("solve failed: " <> show err)
+                Right sol -> do
+                    -- csScalings has only the root entry; cross-DB sum
+                    -- reduces to the single-DB dot product. Score =
+                    -- 1·CF[F, FR] = 7.
+                    let perDb = [(db, sv, standaloneTables) | (_, db, sv) <- SS.csScalings sol]
+                    sumRegionalizedLCIAScoreCrossDB
+                        kgUnitConfig
+                        (dbUnits rootStandalone)
+                        (dbFlows rootStandalone)
+                        M.empty
+                        perDb
+                        `shouldBe` Right 7.0
+
+        it "merged inventory equals the sum of per-DB biosphere matvecs" $ do
+            -- Property: csInventory is exactly Σ_d applyBiosphereMatrix d s_d
+            -- over csScalings. If 'mergeSolutions' ever drifts (drops
+            -- entries, double-counts a DB, mis-orders a transpose), this
+            -- catches it directly.
+            rootSolver <- mkSolverFromDb rootDb "root"
+            depSolver <- mkSolverFromDb depDb "dep"
+            let depLookup name =
+                    pure $
+                        if name == "dep" then Just (depDb, depSolver) else Nothing
+            eRes <-
+                SS.computeInventoryMatrixWithDepsCached
+                    kgUnitConfig
+                    depLookup
+                    rootDb
+                    "root"
+                    rootSolver
+                    0
+            case eRes of
+                Left err -> expectationFailure ("solve failed: " <> show err)
+                Right sol -> do
+                    let perDbInvs =
+                            [applyBiosphereMatrix db sv | (_, db, sv) <- SS.csScalings sol]
+                        reconstructed =
+                            foldr (M.unionWith (+)) M.empty perDbInvs
+                    M.toList (SS.csInventory sol)
+                        `shouldBe` M.toList reconstructed

--- a/test/CrossDBRegionalLCIASpec.hs
+++ b/test/CrossDBRegionalLCIASpec.hs
@@ -10,204 +10,23 @@ activity columns. So when a root-DB activity consumes a dep-DB activity,
 the dep DB's emissions are present in the merged 'Inventory' but invisible
 to the regional path — its regional CFs were never queried.
 
-This spec sets up two synthetic DBs linked by 'CrossDBLink' such that the
-only biosphere emission with a regional CF lives in the dep DB. The "broken"
-case shows the root-only score is 0 (the bug); the "fixed" case shows that
-summing per-DB regional dot products recovers the right answer.
+This spec uses the synthetic two-DB fixture from
+'CrossDBRegionalLCIAFixture'. The "broken" case shows the root-only score
+is 0 (the bug); the "fixed" case shows that summing per-DB regional dot
+products recovers the right answer.
 -}
 module CrossDBRegionalLCIASpec (spec) where
 
-import Data.Int (Int32)
 import qualified Data.Map.Strict as M
-import Data.Text (Text)
-import Data.UUID (UUID)
-import qualified Data.UUID as UUID
-import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 
 import Test.Hspec
 
+import CrossDBRegionalLCIAFixture
 import Method.Mapping
-import Method.Types (FlowDirection (..), MethodCF (..))
 import qualified SharedSolver as SS
 import TestHelpers (mkSolverFromDb)
 import Types
-import UnitConversion (UnitConfig (..), UnitDef (..))
-
--- ---------------------------------------------------------------------------
--- Fixture
--- ---------------------------------------------------------------------------
-
--- One biosphere flow shared by both DBs (cross-DB merging keys on UUID).
-flowUUID :: UUID
-flowUUID = mkUUID 1
-
--- Activity UUIDs: root has a1, dep has b1..bN.
-actUUID :: Int -> UUID
-actUUID i = mkUUID (toInteger (1000 + i))
-
-prodUUID :: Int -> UUID
-prodUUID i = mkUUID (toInteger (2000 + i))
-
-mkUUID :: Integer -> UUID
-mkUUID n = UUID.fromWords64 (fromIntegral n) 0
-
-kgUnit :: Unit
-kgUnit = Unit{unitId = mkUUID 9, unitName = "kg", unitSymbol = "kg", unitComment = ""}
-
-kgUnitConfig :: UnitConfig
-kgUnitConfig =
-    UnitConfig
-        { ucDimensionOrder =
-            ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
-        , ucUnits = M.fromList [("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)]
-        , ucOriginalKeys = M.fromList [("kg", "kg")]
-        }
-
-testFlow :: Flow
-testFlow =
-    Flow
-        { flowId = flowUUID
-        , flowName = "Carbon dioxide"
-        , flowCategory = "air"
-        , flowSubcompartment = Nothing
-        , flowUnitId = unitId kgUnit
-        , flowType = Biosphere
-        , flowSynonyms = M.empty
-        , flowCAS = Nothing
-        , flowSubstanceId = Nothing
-        }
-
-mkActivity :: Int -> Text -> Activity
-mkActivity i loc =
-    Activity
-        { activityName = "act-" <> loc
-        , activityDescription = []
-        , activitySynonyms = M.empty
-        , activityClassification = M.empty
-        , activityLocation = loc
-        , activityUnit = "kg"
-        , exchanges = []
-        , activityParams = M.empty
-        , activityParamExprs = M.empty
-        }
-  where
-    _ = i
-
-emptyIndexes :: Indexes
-emptyIndexes = Indexes M.empty M.empty M.empty M.empty M.empty M.empty
-
-{- | Build a synthetic single-DB fixture parameterized by:
-* @offset@: starting index for activity UUIDs (so root and dep don't collide)
-* @locs@: locations for each activity, length determines activity count
-* @bioTriples@: (flowRow=0, activityCol, value) sparse entries to emit on
-  the single biosphere flow @flowUUID@. Empty for DBs that emit nothing.
-
-The technosphere matrix is left empty — the MUMPS layer adds the identity
-on each diagonal so (I - 0)·x = d trivially yields x = d. This is enough
-for the cross-DB regional gap test: we only need cleanly-defined scaling
-vectors per DB.
--}
-mkDB :: Int -> [Text] -> [(Int, Double)] -> Database
-mkDB offset locs bioTriples =
-    let n = length locs
-        activities = V.fromList [mkActivity (offset + i) loc | (i, loc) <- zip [0 ..] locs]
-        actIdx = V.fromList [fromIntegral i :: Int32 | i <- [0 .. n - 1]]
-        triples = U.fromList [SparseTriple 0 (fromIntegral c) v | (c, v) <- bioTriples]
-        procIds = V.fromList [(actUUID (offset + i), prodUUID (offset + i)) | i <- [0 .. n - 1]]
-        procIdLookup =
-            M.fromList
-                [((actUUID (offset + i), prodUUID (offset + i)), fromIntegral i :: Int32) | i <- [0 .. n - 1]]
-     in Database
-            { dbProcessIdTable = procIds
-            , dbProcessIdLookup = procIdLookup
-            , dbActivityUUIDIndex = M.empty
-            , dbActivityProductsIndex = M.empty
-            , dbProductIndex = emptyProductIndex
-            , dbActivities = activities
-            , dbFlows = M.singleton flowUUID testFlow
-            , dbUnits = M.singleton (unitId kgUnit) kgUnit
-            , dbIndexes = emptyIndexes
-            , dbTechnosphereTriples = U.empty
-            , dbBiosphereTriples = triples
-            , dbActivityIndex = actIdx
-            , dbBiosphereFlows = V.singleton flowUUID
-            , dbActivityCount = fromIntegral n
-            , dbBiosphereCount = 1
-            , dbCrossDBLinks = []
-            , dbDependsOn = []
-            , dbLinkingStats = emptyCrossDBLinkingStats
-            , dbSynonymDB = Nothing
-            , dbFlowsByName = M.empty
-            , dbFlowsByCAS = M.empty
-            , dbProductSearchIndex = M.empty
-            , dbBM25Index = Nothing
-            }
-
-{- | Add a 'CrossDBLink' from the first activity of @consumerDb@ to the
-named activity in @supplierDb@ (identified by its index inside the supplier's
-'dbProcessIdTable').
--}
-linkAt ::
-    Database ->
-    Database ->
-    Text ->
-    -- | supplier activity index in supplierDb
-    Int ->
-    -- | coefficient (mass moved across the link)
-    Double ->
-    Database
-linkAt consumerDb supplierDb supplierName supIdx coeff =
-    let (consumerAct, consumerProd) = dbProcessIdTable consumerDb V.! 0
-        (supplierAct, supplierProd) = dbProcessIdTable supplierDb V.! supIdx
-        link =
-            CrossDBLink
-                { cdlConsumerActUUID = consumerAct
-                , cdlConsumerProdUUID = consumerProd
-                , cdlSupplierActUUID = supplierAct
-                , cdlSupplierProdUUID = supplierProd
-                , cdlCoefficient = coeff
-                , cdlExchangeUnit = "kg"
-                , cdlFlowName = "x-link"
-                , cdlLocation = activityLocation (dbActivities supplierDb V.! supIdx)
-                , cdlSourceDatabase = supplierName
-                }
-     in consumerDb{dbCrossDBLinks = link : dbCrossDBLinks consumerDb}
-
--- ---------------------------------------------------------------------------
--- MethodTables: one regional CF per location, all on the shared flow F
--- ---------------------------------------------------------------------------
-
-regionalMappings :: [(Text, Double)] -> [(MethodCF, Maybe (Flow, MatchStrategy))]
-regionalMappings = map (\(loc, v) -> (cf loc v, Just (testFlow, ByName)))
-  where
-    cf loc v =
-        MethodCF
-            { mcfFlowRef = flowUUID
-            , mcfFlowName = "Carbon dioxide"
-            , mcfDirection = Output
-            , mcfValue = v
-            , mcfCompartment = Nothing
-            , mcfCAS = Nothing
-            , mcfUnit = "kg"
-            , mcfConsumerLocation = Just loc
-            }
-
-buildTables :: Database -> [(MethodCF, Maybe (Flow, MatchStrategy))] -> MethodTables
-buildTables db mappings =
-    let raw = buildMethodTables M.empty mappings
-        withBroadcast = fillBroadcastVector kgUnitConfig (dbUnits db) (dbFlows db) raw
-     in fillRegionalActivityWeights
-            kgUnitConfig
-            (dbUnits db)
-            (dbFlows db)
-            db
-            M.empty
-            withBroadcast
-
--- ---------------------------------------------------------------------------
--- Spec
--- ---------------------------------------------------------------------------
 
 spec :: Spec
 spec = describe "cross-DB regional LCIA" $ do
@@ -223,13 +42,11 @@ spec = describe "cross-DB regional LCIA" $ do
     --   * Dep regional weights w_D = [0, 1·CF[F,DE], 0] = [0, 5, 0].
     --   * Root weights w_R: empty (R has no biosphere triples).
     --   * Cross-DB regional score = w_R·x_R + w_D·x_D = 0 + 5 = 5.
-    let depDb = mkDB 1 ["FR", "DE", "GLO"] [(1, 1.0)] -- emission only on the DE column
-        rootBase = mkDB 100 ["FR"] []
-        rootDb = linkAt rootBase depDb "dep" 1 1.0
-
-        rootMappings = regionalMappings [("FR", 1), ("DE", 5), ("GLO", 0.5)]
-        rootTables = buildTables rootDb rootMappings
-        depTables = buildTables depDb rootMappings
+    let fix = mkRegionalFixture
+        rootDb = rfRootDb fix
+        depDb = rfDepDb fix
+        rootTables = rfRootTables fix
+        depTables = rfDepTables fix
 
     it "OLD path: root-only regional score silently misses dep-DB emissions" $ do
         -- Today's contract: computeLCIAScoreAuto is handed the ROOT db's

--- a/test/CrossDBRegionalLCIASubsSpec.hs
+++ b/test/CrossDBRegionalLCIASubsSpec.hs
@@ -18,6 +18,7 @@ whenever substitutions were involved. Two cases:
 -}
 module CrossDBRegionalLCIASubsSpec (spec) where
 
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -48,7 +49,7 @@ spec = describe "cross-DB regional LCIA via substitution path" $ do
         scoreSolution sol =
             let perDb =
                     [ (db, sv, tablesFor n)
-                    | (n, db, sv) <- SS.csScalings sol
+                    | (n, db, sv) <- NE.toList (SS.csScalings sol)
                     ]
              in sumRegionalizedLCIAScoreCrossDB
                     kgUnitConfig
@@ -90,11 +91,11 @@ spec = describe "cross-DB regional LCIA via substitution path" $ do
                     `shouldBe` M.toList (SS.csInventory plainSol)
                 let plainScalings =
                         [ (n, M.toList (M.fromList [(i, v) | (i, v) <- zip [0 :: Int ..] (U.toList sv)]))
-                        | (n, _, sv) <- SS.csScalings plainSol
+                        | (n, _, sv) <- NE.toList (SS.csScalings plainSol)
                         ]
                     subsScalings =
                         [ (n, M.toList (M.fromList [(i, v) | (i, v) <- zip [0 :: Int ..] (U.toList sv)]))
-                        | (n, _, sv) <- SS.csScalings subsSol
+                        | (n, _, sv) <- NE.toList (SS.csScalings subsSol)
                         ]
                 subsScalings `shouldBe` plainScalings
             (Left e, _) -> expectationFailure ("plain path failed: " <> show e)
@@ -145,5 +146,5 @@ spec = describe "cross-DB regional LCIA via substitution path" $ do
         case eSubs of
             Left e -> expectationFailure ("subs path failed: " <> show e)
             Right subsSol -> do
-                let names = [n | (n, _, _) <- SS.csScalings subsSol]
+                let names = [n | (n, _, _) <- NE.toList (SS.csScalings subsSol)]
                 names `shouldBe` ["root", "dep"]

--- a/test/CrossDBRegionalLCIASubsSpec.hs
+++ b/test/CrossDBRegionalLCIASubsSpec.hs
@@ -1,0 +1,149 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Regression: the substitution path
+('Service.inventoryWithSubsAndDeps') must thread per-DB scalings out so
+the cross-DB regional sum can score dep-DB emissions, exactly like the
+plain cross-DB path.
+
+Before this commit, the subs path returned only the merged 'Inventory'
+and 'API.Routes.postActivityLCIA' wrapped a root-only 'CrossDBSolution'
+around it — silently regressing regional scores on cross-DB recipes
+whenever substitutions were involved. Two cases:
+
+* Empty substitution list: solution must match the plain path bit-for-bit
+  (inventory + per-DB scalings + downstream regional score).
+* Non-empty substitution list (Case-A re-routing a root activity to a
+  different dep-DB supplier): per-DB scalings must still be populated so
+  the dep-DB regional CF lookup runs against the right column.
+-}
+module CrossDBRegionalLCIASubsSpec (spec) where
+
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Vector.Unboxed as U
+
+import Test.Hspec
+
+import CrossDBRegionalLCIAFixture
+import Method.Mapping (MethodTables, sumRegionalizedLCIAScoreCrossDB)
+import qualified Service
+import qualified SharedSolver as SS
+import TestHelpers (mkSolverFromDb)
+import Types
+
+spec :: Spec
+spec = describe "cross-DB regional LCIA via substitution path" $ do
+    let fix = mkRegionalFixture
+        rootDb = rfRootDb fix
+        depDb = rfDepDb fix
+        rootTables = rfRootTables fix
+        depTables = rfDepTables fix
+
+        tablesFor :: Text -> MethodTables
+        tablesFor "root" = rootTables
+        tablesFor "dep" = depTables
+        tablesFor other = error ("unexpected dbName in csScalings: " <> T.unpack other)
+
+        scoreSolution sol =
+            let perDb =
+                    [ (db, sv, tablesFor n)
+                    | (n, db, sv) <- SS.csScalings sol
+                    ]
+             in sumRegionalizedLCIAScoreCrossDB
+                    kgUnitConfig
+                    (dbUnits depDb)
+                    (dbFlows depDb)
+                    M.empty
+                    perDb
+
+    it "subs path with empty substitutions matches the plain cross-DB CrossDBSolution" $ do
+        -- The subs path used to return only the merged 'Inventory'; the
+        -- caller fabricated a root-only 'CrossDBSolution'. After this
+        -- commit, the subs path returns the full 'CrossDBSolution' so
+        -- this parity check holds.
+        rootSolver <- mkSolverFromDb rootDb "root"
+        depSolver <- mkSolverFromDb depDb "dep"
+        let depLookup name =
+                pure $
+                    if name == "dep" then Just (depDb, depSolver) else Nothing
+        ePlain <-
+            SS.computeInventoryMatrixWithDepsCached
+                kgUnitConfig
+                depLookup
+                rootDb
+                "root"
+                rootSolver
+                0
+        eSubs <-
+            Service.inventoryWithSubsAndDeps
+                kgUnitConfig
+                depLookup
+                rootDb
+                "root"
+                rootSolver
+                0
+                []
+        case (ePlain, eSubs) of
+            (Right plainSol, Right subsSol) -> do
+                M.toList (SS.csInventory subsSol)
+                    `shouldBe` M.toList (SS.csInventory plainSol)
+                let plainScalings =
+                        [ (n, M.toList (M.fromList [(i, v) | (i, v) <- zip [0 :: Int ..] (U.toList sv)]))
+                        | (n, _, sv) <- SS.csScalings plainSol
+                        ]
+                    subsScalings =
+                        [ (n, M.toList (M.fromList [(i, v) | (i, v) <- zip [0 :: Int ..] (U.toList sv)]))
+                        | (n, _, sv) <- SS.csScalings subsSol
+                        ]
+                subsScalings `shouldBe` plainScalings
+            (Left e, _) -> expectationFailure ("plain path failed: " <> show e)
+            (_, Left e) -> expectationFailure ("subs path failed: " <> show e)
+
+    it "subs path with empty substitutions recovers the dep-DB regional score (= 5.0)" $ do
+        -- End-to-end: empty subs feeds the same 'CrossDBSolution' shape
+        -- into 'sumRegionalizedLCIAScoreCrossDB' and recovers the
+        -- regional score the plain path returns.
+        rootSolver <- mkSolverFromDb rootDb "root"
+        depSolver <- mkSolverFromDb depDb "dep"
+        let depLookup name =
+                pure $
+                    if name == "dep" then Just (depDb, depSolver) else Nothing
+        eSubs <-
+            Service.inventoryWithSubsAndDeps
+                kgUnitConfig
+                depLookup
+                rootDb
+                "root"
+                rootSolver
+                0
+                []
+        case eSubs of
+            Left e -> expectationFailure ("subs path failed: " <> show e)
+            Right subsSol -> scoreSolution subsSol `shouldBe` Right 5.0
+
+    it "subs path: csScalings lists both root and dep DBs after a cross-DB solve" $ do
+        -- Structural gate: regardless of subs content, the threaded
+        -- 'CrossDBSolution' must list both DBs the recursion actually
+        -- visited. If the substitution path silently dropped a dep
+        -- contribution, this would catch it before the regional score
+        -- check.
+        rootSolver <- mkSolverFromDb rootDb "root"
+        depSolver <- mkSolverFromDb depDb "dep"
+        let depLookup name =
+                pure $
+                    if name == "dep" then Just (depDb, depSolver) else Nothing
+        eSubs <-
+            Service.inventoryWithSubsAndDeps
+                kgUnitConfig
+                depLookup
+                rootDb
+                "root"
+                rootSolver
+                0
+                []
+        case eSubs of
+            Left e -> expectationFailure ("subs path failed: " <> show e)
+            Right subsSol -> do
+                let names = [n | (n, _, _) <- SS.csScalings subsSol]
+                names `shouldBe` ["root", "dep"]

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -163,11 +163,9 @@ spec = do
                         UnitConversion.defaultUnitConfig
                         udb
                         fdb
-                        unusedDatabase
-                        U.empty -- scalingVec unused for non-regio
                         inv
                         M.empty -- hier unused for non-regio
-                        mst
+                        [(unusedDatabase, U.empty, mst)] -- scalingVec unused for non-regio
                 resultMap = M.fromList results
             -- Sanity: explicit numbers
             sA `shouldBe` 8.0 -- 4*2 + 0.1*0 (no ch4 cf)
@@ -194,11 +192,9 @@ spec = do
                         UnitConversion.defaultUnitConfig
                         udb
                         fdb
-                        unusedDatabase
-                        U.empty
                         M.empty
                         M.empty
-                        mst
+                        [(unusedDatabase, U.empty, mst)]
             map snd results `shouldBe` [Right 0.0, Right 0.0]
 
         it "inventory UUIDs absent from both broadcast and flowDB contribute 0" $ do
@@ -222,11 +218,9 @@ spec = do
                         UnitConversion.defaultUnitConfig
                         udb
                         fdb
-                        unusedDatabase
-                        U.empty
                         inv
                         M.empty
-                        mst
+                        [(unusedDatabase, U.empty, mst)]
             -- Only the matched flow contributes: 2 × 3 = 6.
             map snd results `shouldBe` [Right 6.0]
 
@@ -270,11 +264,9 @@ spec = do
                         UnitConversion.defaultUnitConfig
                         udb
                         scoringFlowDB
-                        unusedDatabase
-                        U.empty
                         inv
                         M.empty
-                        mst
+                        [(unusedDatabase, U.empty, mst)]
             -- Both contribute against CF=3: (2 + 4) × 3 = 18.
             map snd results `shouldBe` [Right 18.0]
 
@@ -350,11 +342,9 @@ spec = do
                         UnitConversion.defaultUnitConfig
                         udb
                         fdb
-                        unusedDatabase
-                        U.empty
                         inv
                         M.empty
-                        mst
+                        [(unusedDatabase, U.empty, mst)]
             -- Caller order preserved on the result keys.
             map fst results
                 `shouldBe` [methodId m1, methodId m2, methodId m3]

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -11,6 +11,7 @@ functions directly.
 -}
 module MethodSetTablesSpec (spec) where
 
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import Data.UUID (UUID)
@@ -165,7 +166,7 @@ spec = do
                         fdb
                         inv
                         M.empty -- hier unused for non-regio
-                        [(unusedDatabase, U.empty, mst)] -- scalingVec unused for non-regio
+                        (NE.singleton (unusedDatabase, U.empty, mst)) -- scalingVec unused for non-regio
                 resultMap = M.fromList results
             -- Sanity: explicit numbers
             sA `shouldBe` 8.0 -- 4*2 + 0.1*0 (no ch4 cf)
@@ -194,7 +195,7 @@ spec = do
                         fdb
                         M.empty
                         M.empty
-                        [(unusedDatabase, U.empty, mst)]
+                        (NE.singleton (unusedDatabase, U.empty, mst))
             map snd results `shouldBe` [Right 0.0, Right 0.0]
 
         it "inventory UUIDs absent from both broadcast and flowDB contribute 0" $ do
@@ -220,7 +221,7 @@ spec = do
                         fdb
                         inv
                         M.empty
-                        [(unusedDatabase, U.empty, mst)]
+                        (NE.singleton (unusedDatabase, U.empty, mst))
             -- Only the matched flow contributes: 2 × 3 = 6.
             map snd results `shouldBe` [Right 6.0]
 
@@ -266,7 +267,7 @@ spec = do
                         scoringFlowDB
                         inv
                         M.empty
-                        [(unusedDatabase, U.empty, mst)]
+                        (NE.singleton (unusedDatabase, U.empty, mst))
             -- Both contribute against CF=3: (2 + 4) × 3 = 18.
             map snd results `shouldBe` [Right 18.0]
 
@@ -344,7 +345,7 @@ spec = do
                         fdb
                         inv
                         M.empty
-                        [(unusedDatabase, U.empty, mst)]
+                        (NE.singleton (unusedDatabase, U.empty, mst))
             -- Caller order preserved on the result keys.
             map fst results
                 `shouldBe` [methodId m1, methodId m2, methodId m3]

--- a/test/NestedSubstitutionSpec.hs
+++ b/test/NestedSubstitutionSpec.hs
@@ -145,7 +145,9 @@ spec = do
             eBase <- computeInventoryMatrixWithDepsCached defaultUnitConfig noDeps db "SAMPLE.min3" solver pid
             eSub <- inventoryWithSubsAndDeps defaultUnitConfig noDeps db "SAMPLE.min3" solver pid []
             case (eBase, eSub) of
-                (Right base, Right subInv) -> M.toList subInv `shouldBe` M.toList (SharedSolver.csInventory base)
+                (Right base, Right subSol) ->
+                    M.toList (SharedSolver.csInventory subSol)
+                        `shouldBe` M.toList (SharedSolver.csInventory base)
                 (Left e, _) -> expectationFailure ("baseline failed: " <> T.unpack e)
                 (_, Left e) -> expectationFailure ("subs path failed: " <> show e)
 
@@ -193,8 +195,9 @@ spec = do
             eBase <- inventoryWithSubsAndDeps defaultUnitConfig lookup_ root "root" rootSolver 0 []
             eSub <- inventoryWithSubsAndDeps defaultUnitConfig lookup_ root "root" rootSolver 0 [mkDepSub fromPid toPid]
             case (eBase, eSub) of
-                (Right base, Right subInv) ->
-                    M.toList subInv `shouldNotBe` M.toList base
+                (Right base, Right subSol) ->
+                    M.toList (SharedSolver.csInventory subSol)
+                        `shouldNotBe` M.toList (SharedSolver.csInventory base)
                 (Left e, _) -> expectationFailure ("baseline failed: " <> show e)
                 (_, Left e) -> expectationFailure ("dep-sub path failed: " <> show e)
 
@@ -227,7 +230,8 @@ spec = do
             eChain <- inventoryWithSubsAndDeps defaultUnitConfig lookup_ root "root" rootSolver 0 [rootSub, depSub]
             case (eBase, eChain) of
                 (Right base, Right c) ->
-                    M.toList c `shouldNotBe` M.toList base
+                    M.toList (SharedSolver.csInventory c)
+                        `shouldNotBe` M.toList (SharedSolver.csInventory base)
                 _ -> expectationFailure "chain or baseline path failed"
 
         it "identity dep-sub (from == to) matches baseline (no-op invariant)" $ do
@@ -250,8 +254,9 @@ spec = do
             eBase <- inventoryWithSubsAndDeps defaultUnitConfig lookup_ root "root" rootSolver 0 []
             eSub <- inventoryWithSubsAndDeps defaultUnitConfig lookup_ root "root" rootSolver 0 [identitySub]
             case (eBase, eSub) of
-                (Right base, Right subInv) ->
-                    M.toList subInv `shouldBe` M.toList base
+                (Right base, Right subSol) ->
+                    M.toList (SharedSolver.csInventory subSol)
+                        `shouldBe` M.toList (SharedSolver.csInventory base)
                 (Left e, _) -> expectationFailure ("baseline failed: " <> show e)
                 (_, Left e) -> expectationFailure ("identity path failed: " <> show e)
 

--- a/test/NestedSubstitutionSpec.hs
+++ b/test/NestedSubstitutionSpec.hs
@@ -30,6 +30,7 @@ import SharedSolver (
     createSharedSolver,
     solveWithSharedSolver,
  )
+import qualified SharedSolver
 import Test.Hspec
 import TestHelpers (
     linkDatabases,
@@ -141,10 +142,10 @@ spec = do
             solver <- mkSolver db "SAMPLE.min3"
             let pid = 0
                 noDeps _ = pure Nothing
-            eBase <- computeInventoryMatrixWithDepsCached defaultUnitConfig noDeps db solver pid
+            eBase <- computeInventoryMatrixWithDepsCached defaultUnitConfig noDeps db "SAMPLE.min3" solver pid
             eSub <- inventoryWithSubsAndDeps defaultUnitConfig noDeps db "SAMPLE.min3" solver pid []
             case (eBase, eSub) of
-                (Right base, Right subInv) -> M.toList subInv `shouldBe` M.toList base
+                (Right base, Right subInv) -> M.toList subInv `shouldBe` M.toList (SharedSolver.csInventory base)
                 (Left e, _) -> expectationFailure ("baseline failed: " <> T.unpack e)
                 (_, Left e) -> expectationFailure ("subs path failed: " <> show e)
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -12,6 +12,7 @@ import qualified CoalescingSolverSpec
 import qualified ConfigSpec
 import qualified CrossDBInventorySpec
 import qualified CrossDBRegionalLCIASpec
+import qualified CrossDBRegionalLCIASubsSpec
 import qualified CrossDBSubstitutionSpec
 import qualified CrossLinkingSpec
 import qualified DatabaseStatusSpec
@@ -70,6 +71,7 @@ main = hspec $ do
         describe "Cross-Database Linking" CrossLinkingSpec.spec
         describe "Cross-DB Inventory" CrossDBInventorySpec.spec
         describe "Cross-DB Regional LCIA" CrossDBRegionalLCIASpec.spec
+        describe "Cross-DB Regional LCIA (substitution path)" CrossDBRegionalLCIASubsSpec.spec
         describe "Substitutions" SubstitutionSpec.spec
         describe "Sensitivity Analysis" SensitivitySpec.spec
         describe "Cross-DB Substitutions" CrossDBSubstitutionSpec.spec

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -12,6 +12,7 @@ import qualified CoalescingSolverSpec
 import qualified ConfigSpec
 import qualified CrossDBInventorySpec
 import qualified CrossDBRegionalLCIASpec
+import qualified CrossDBRegionalLCIASensitivitySpec
 import qualified CrossDBRegionalLCIASubsSpec
 import qualified CrossDBSubstitutionSpec
 import qualified CrossLinkingSpec
@@ -72,6 +73,7 @@ main = hspec $ do
         describe "Cross-DB Inventory" CrossDBInventorySpec.spec
         describe "Cross-DB Regional LCIA" CrossDBRegionalLCIASpec.spec
         describe "Cross-DB Regional LCIA (substitution path)" CrossDBRegionalLCIASubsSpec.spec
+        describe "Cross-DB Regional LCIA (sensitivity path)" CrossDBRegionalLCIASensitivitySpec.spec
         describe "Substitutions" SubstitutionSpec.spec
         describe "Sensitivity Analysis" SensitivitySpec.spec
         describe "Cross-DB Substitutions" CrossDBSubstitutionSpec.spec

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -11,6 +11,7 @@ import qualified ChemSynonymsSpec
 import qualified CoalescingSolverSpec
 import qualified ConfigSpec
 import qualified CrossDBInventorySpec
+import qualified CrossDBRegionalLCIASpec
 import qualified CrossDBSubstitutionSpec
 import qualified CrossLinkingSpec
 import qualified DatabaseStatusSpec
@@ -68,6 +69,7 @@ main = hspec $ do
         describe "Service Layer" ServiceSpec.spec
         describe "Cross-Database Linking" CrossLinkingSpec.spec
         describe "Cross-DB Inventory" CrossDBInventorySpec.spec
+        describe "Cross-DB Regional LCIA" CrossDBRegionalLCIASpec.spec
         describe "Substitutions" SubstitutionSpec.spec
         describe "Sensitivity Analysis" SensitivitySpec.spec
         describe "Cross-DB Substitutions" CrossDBSubstitutionSpec.spec

--- a/test/SubstitutionSpec.hs
+++ b/test/SubstitutionSpec.hs
@@ -26,6 +26,7 @@ import SharedSolver (
     computeInventoryMatrixWithDepsCached,
     createSharedSolver,
  )
+import qualified SharedSolver
 import Test.Hspec
 import TestHelpers (loadSampleDatabase)
 import Types
@@ -40,11 +41,11 @@ spec = do
             let pid = 0
                 noDeps _ = pure Nothing
 
-            eBase <- computeInventoryMatrixWithDepsCached defaultUnitConfig noDeps db solver pid
+            eBase <- computeInventoryMatrixWithDepsCached defaultUnitConfig noDeps db "SAMPLE.min3" solver pid
             eSub <- inventoryWithSubsAndDeps defaultUnitConfig noDeps db "SAMPLE.min3" solver pid []
 
             case (eBase, eSub) of
-                (Right base, Right sub) -> M.toList sub `shouldBe` M.toList base
+                (Right base, Right sub) -> M.toList sub `shouldBe` M.toList (SharedSolver.csInventory base)
                 (Left e, _) -> expectationFailure ("baseline failed: " <> T.unpack e)
                 (_, Left e) -> expectationFailure ("subs path failed: " <> show e)
 

--- a/test/SubstitutionSpec.hs
+++ b/test/SubstitutionSpec.hs
@@ -45,7 +45,9 @@ spec = do
             eSub <- inventoryWithSubsAndDeps defaultUnitConfig noDeps db "SAMPLE.min3" solver pid []
 
             case (eBase, eSub) of
-                (Right base, Right sub) -> M.toList sub `shouldBe` M.toList (SharedSolver.csInventory base)
+                (Right base, Right sub) ->
+                    M.toList (SharedSolver.csInventory sub)
+                        `shouldBe` M.toList (SharedSolver.csInventory base)
                 (Left e, _) -> expectationFailure ("baseline failed: " <> T.unpack e)
                 (_, Left e) -> expectationFailure ("subs path failed: " <> show e)
 
@@ -64,7 +66,8 @@ spec = do
 
             case (eRaw, eSub) of
                 (Right x, Right sub) ->
-                    M.toList sub `shouldBe` M.toList (Matrix.applyBiosphereMatrix db x)
+                    M.toList (SharedSolver.csInventory sub)
+                        `shouldBe` M.toList (Matrix.applyBiosphereMatrix db x)
                 (Left e, _) -> expectationFailure ("raw solve failed: " <> show e)
                 (_, Left e) -> expectationFailure ("subs path failed: " <> show e)
 

--- a/volca.cabal
+++ b/volca.cabal
@@ -175,6 +175,8 @@ test-suite lca-tests
                      , CrossLinkingSpec
                      , CrossDBInventorySpec
                      , CrossDBRegionalLCIASpec
+                     , CrossDBRegionalLCIAFixture
+                     , CrossDBRegionalLCIASubsSpec
                      , RegionalLCIASpec
                      , SharedSolverSpec
                      , CoalescingSolverSpec

--- a/volca.cabal
+++ b/volca.cabal
@@ -177,6 +177,7 @@ test-suite lca-tests
                      , CrossDBRegionalLCIASpec
                      , CrossDBRegionalLCIAFixture
                      , CrossDBRegionalLCIASubsSpec
+                     , CrossDBRegionalLCIASensitivitySpec
                      , RegionalLCIASpec
                      , SharedSolverSpec
                      , CoalescingSolverSpec

--- a/volca.cabal
+++ b/volca.cabal
@@ -174,6 +174,8 @@ test-suite lca-tests
                      , ServiceSpec
                      , CrossLinkingSpec
                      , CrossDBInventorySpec
+                     , CrossDBRegionalLCIASpec
+                     , RegionalLCIASpec
                      , SharedSolverSpec
                      , CoalescingSolverSpec
                      , FlowResolverSpec


### PR DESCRIPTION
## Summary

Regional LCIA used to silently under-count on **every** cross-DB code path. The fast path was a per-database dot product keyed on the root DB's activity columns alone — when a root activity consumed a dep-DB activity, the dep DB's biosphere emissions landed in the merged inventory but were invisible to the regional CF cascade.

This PR closes the gap end-to-end:

- **Plain cross-DB path** (`GET /api/.../lcia`, `lcia-batch`, `getInventory`): regional scoring is now `Σ_d rawWeights_d · scaling_d` across every participating DB, computed per-DB so each side keeps its own activity index, location hierarchy, and tainted-column diagnostics.
- **Substitution path** (`POST /api/.../lcia`, `lcia-batch` with `srSubstitutions`): `Service.goWithSubsAndDeps` already computed per-DB scalings at every recursion level but discarded them. It now returns `CrossDBSolution`, threading those scalings into the same regional sum.
- **Sensitivity path** (`POST /api/.../sensitivity`): each perturbed root scaling is now routed through `SharedSolver.goWithDepsFromScalings` (which is documented for exactly this case — "caller supplies the root scaling vectors, e.g. after a Sherman-Morrison substitution update") instead of a root-only `applyBiosphereMatrix`. Perturbations remain root-only by design; what changes is the *scoring* of those root-only perturbations now sees the full cross-DB inventory + per-DB scalings.

## Architecture

`CrossDBSolution` carries the merged biosphere `Inventory` plus per-DB scaling vectors collected during the inventory solve:

```haskell
data CrossDBSolution = CrossDBSolution
    { csInventory :: !Inventory
    , csScalings :: !(NonEmpty (Text, Database, Vector))
    }
```

`csScalings` is `NonEmpty` because the root entry is always added by the top-level solve. The absent-dep branch in `resolveDep` / `resolveDepWithSubs` returns `Nothing`; `mergeSolutions` drops `Nothing`s before union. `computeLCIAScoreSetFromTables` takes `NonEmpty (Database, Vector, MethodSetTables)` so the "no DBs participated" state is unrepresentable.

The new regional contract lives in `Method.Mapping.sumRegionalizedLCIAScoreCrossDB`:

```
Σ_d computeRegionalizedLCIAScore (db_d, scaling_d, tables_d)
```

Per-DB `Left` is tolerated (a tainted dep DB drops to 0 contribution while the rest of the sum proceeds); all-`Left` surfaces as `Left` (no silent zero).

## Expected behavior changes

- Cross-DB recipes that hit regional methods will see score changes wherever a dep-DB biosphere flow had a regional CF that was previously not applied. The changes are strictly **positive** — the fix recovers a silently dropped contribution.
- Non-regional method scores are bit-identical.
- Recipes that don't reach any dep DB are bit-identical to the old root-only path.
- Cross-DB **perturbations** (perturbation references that target dep-DB activities, e.g. `"depdb::pid"`) remain V2 and are still rejected by `resolveRootOnly`. Generalising them requires generalising `applySubstitutionsAt` for sensitivity — out of scope.

## Test plan

- [x] `cabal test lca-tests` — **801 examples, 0 failures**.
  - `CrossDBRegionalLCIASpec`: the gap-and-fix proof point on a synthetic two-DB fixture (root demands force 1 unit of a dep activity at DE; regional score recovers 5.0). Plus tainted-column tolerance and all-`Left` cases.
  - `CrossDBRegionalLCIASubsSpec`: substitution path returns the full `CrossDBSolution`; empty-subs scores identical to the plain path; `csScalings` lists both root and dep after a cross-DB solve.
  - `CrossDBRegionalLCIASensitivitySpec`: caller-supplied root scaling threaded through `goWithDepsFromScalings` recovers the regional score (5.0) and scales linearly with the root demand (10.0 on doubled).
  - Three non-regression invariants in `CrossDBRegionalLCIASpec`: non-regional methods unchanged on cross-DB recipes; root-only recipes match the old root-only path; merged inventory equals the sum of per-DB biosphere matvecs.
  - All other existing test suites pass (substitutions, nested substitutions, cross-DB inventory, sensitivity, method set tables).
- [ ] Real-data regression on a cross-DB export. Run-book: [`scripts/verify-pr41-regression.md`](scripts/verify-pr41-regression.md). Load Agribalyse + Ecoinvent, hit `/api/.../lcia-batch` with EF 3.1 before and after, diff JSON; confirm only cells whose pid actually consumes a dep-DB activity with a regional CF have moved, and every move is positive.

## Files of interest

| Path | Role |
|------|------|
| `src/SharedSolver.hs` | `CrossDBSolution` type, `goWithDepsFromScalings`, `mergeSolutions` (now exported) |
| `src/Service.hs` | `goWithSubsAndDeps`, `inventoryWithSubsAndDeps` — return `CrossDBSolution` |
| `src/Method/Mapping.hs` | `sumRegionalizedLCIAScoreCrossDB`, `computeLCIAScoreSetFromTables` (NonEmpty) |
| `src/API/Routes.hs` | All cross-DB LCIA endpoints + sensitivity threaded through the new path |
| `test/CrossDBRegionalLCIAFixture.hs` | Shared synthetic two-DB topology |
| `scripts/verify-pr41-regression.md` | Manual run-book for real-data verification |