### PR TITLE
fix(db): auto-relink on every Load and persist updated links to cache

### DIFF
--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -88,6 +88,9 @@ module Database.Manager (
 
     -- * Internal (for Main.hs to load database)
     loadDatabaseFromConfig,
+
+    -- * Internal (for tests: lowest-level loader, exposes the cache-hit flag)
+    loadDatabaseRawWithCrossDB,
 ) where
 
 import Control.Concurrent.Async (mapConcurrently, mapConcurrently_)

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1361,6 +1361,16 @@ loadDatabaseSingleFromConfig manager dbName = do
                                 dbName
                                 ("Auto-extracted from " <> dcDisplayName dbConfig)
                                 pairs
+                            -- Re-link THIS DB too. A cache hit can return a
+                            -- DB whose stored 'dbCrossDBLinks' point at deps
+                            -- that aren't loaded now (or miss deps that are):
+                            -- 'loadDatabaseRawWithCrossDB' only re-parses
+                            -- when 'unresolvedCount > 0', so a fully-resolved
+                            -- cache against version A is reused as-is even
+                            -- when version B is now loaded instead. The
+                            -- self-relink walks the current 'otherIndexes'
+                            -- and rewrites links + cache if they changed.
+                            _ <- relinkDatabase manager dbName
                             relinkDependents manager dbName
                             return $ Right loaded
 
@@ -1379,6 +1389,13 @@ of loaded dep DBs. Updates 'dbCrossDBLinks' and 'dbLinkingStats' in place
 in the LoadedDatabase record. Does NOT rebuild the technosphere matrix or
 invalidate the MUMPS factorization — cross-DB links are consumed only at
 solve time.
+
+Side-effect: persists the updated 'Database' back to its matrix-cache file
+('Loader.saveCachedDatabaseWithMatrices') whenever the relink actually
+changed 'dbCrossDBLinks' or 'dbDependsOn'. Without this, the next startup
+would re-load the stale cache and re-run cross-DB linking from scratch
+even though we already know the answer. The save is skipped when the
+relink is a no-op (no change vs. the in-memory state).
 -}
 relinkDatabase :: DatabaseManager -> Text -> IO (Either Text RelinkResult)
 relinkDatabase manager dbName = do
@@ -1392,6 +1409,8 @@ relinkDatabase manager dbName = do
             unitConfig <- getMergedUnitConfig manager
             let db = ldDatabase loaded
                 beforeUnresolved = unresolvedCount (dbLinkingStats db)
+                beforeLinks = dbCrossDBLinks db
+                beforeDeps = dbDependsOn db
                 activityMap =
                     M.fromList
                         [ (dbProcessIdTable db V.! i, dbActivities db V.! i)
@@ -1423,12 +1442,20 @@ relinkDatabase manager dbName = do
                         }
                 !loaded' = loaded{ldDatabase = db'}
                 afterUnresolved = unresolvedCount newStats
+                linksChanged = newLinks /= beforeLinks || newDeps /= beforeDeps
             atomically $ do
                 modifyTVar' (dmLoadedDbs manager) (M.insert dbName loaded')
                 modifyTVar'
                     (dmIndexedDbs manager)
                     (M.insert dbName (buildIndexedDatabaseFromDB dbName synonymDB db'))
             clearMethodMappingCacheForDb manager dbName
+            -- Persist the relinked Database back to its matrix cache so the
+            -- next startup doesn't have to re-discover the same links.
+            when linksChanged $
+                Loader.saveCachedDatabaseWithMatrices
+                    dbName
+                    (dcPath (ldConfig loaded'))
+                    db'
             reportProgress Info $
                 "Re-linked "
                     <> T.unpack dbName
@@ -2203,6 +2230,15 @@ finalizeDatabase manager dbName = do
                                     -- Only save to cache when matrices were built fresh
                                     when (not fromCache) $
                                         Loader.saveCachedDatabaseWithMatrices dbName (dcPath (sdConfig staged)) dbWithRuntime
+
+                                    -- Self-relink against the current dep
+                                    -- set. Same rationale as the Load path:
+                                    -- a cached DB can carry stale cross-DB
+                                    -- links that no longer match what is
+                                    -- loaded now. 'relinkDatabase' will
+                                    -- rewrite both the in-memory state and
+                                    -- the cache file when the answer changes.
+                                    _ <- relinkDatabase manager dbName
 
                                     reportProgress Info $ "  [OK] Finalized: " <> T.unpack dbName
                                     return $ Right loaded

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -94,7 +94,7 @@ import Control.Concurrent.Async (mapConcurrently, mapConcurrently_)
 import Control.Concurrent.STM
 import Control.Exception (SomeException, try)
 import qualified Control.Exception
-import Control.Monad (forM, forM_, unless, when)
+import Control.Monad (forM, forM_, unless, void, when)
 import Data.Aeson (FromJSON (..), ToJSON (..), (.:), (.:?), (.=))
 import qualified Data.Aeson as A
 import Data.Bifunctor (first)
@@ -823,7 +823,7 @@ loadOneDatabase synonymDB unitConfig noCache otherIndexes loadedDbsVar indexedDb
     let transforms = prTransforms (dmPlugins manager)
     result <- loadDatabaseFromConfigWithCrossDBAndTransforms transforms dbConfig synonymDB unitConfig noCache otherIndexes (M.map snd (dmGeographies manager))
     case result of
-        Right loaded -> do
+        Right (loaded, _fromCache) -> do
             let indexedDb = buildIndexedDatabaseFromDB (dcName dbConfig) synonymDB (ldDatabase loaded)
             atomically $ do
                 modifyTVar' loadedDbsVar (M.insert (dcName dbConfig) loaded)
@@ -999,7 +999,8 @@ This is the original function, kept for backward compatibility
 -}
 loadDatabaseFromConfig :: DatabaseConfig -> SynonymDB -> Bool -> IO (Either Text LoadedDatabase)
 loadDatabaseFromConfig dbConfig synonymDB noCache =
-    loadDatabaseFromConfigWithCrossDB dbConfig synonymDB UnitConversion.defaultUnitConfig noCache [] M.empty
+    fmap (fmap fst)
+        (loadDatabaseFromConfigWithCrossDB dbConfig synonymDB UnitConversion.defaultUnitConfig noCache [] M.empty)
 
 {- | Resolve a database path: if it's an archive, extract it first.
 Extracts to "{archivePath}.d/" and finds the actual data directory inside.
@@ -1051,7 +1052,7 @@ loadDatabaseFromConfigWithCrossDB ::
     Bool -> -- noCache
     [IndexedDatabase] -> -- Pre-built indexes from other databases for cross-DB linking
     M.Map T.Text [T.Text] -> -- Location hierarchy (empty = use built-in)
-    IO (Either Text LoadedDatabase)
+    IO (Either Text (LoadedDatabase, Bool))
 loadDatabaseFromConfigWithCrossDB = loadDatabaseFromConfigWithCrossDBAndTransforms []
 
 -- | Load with optional transform pipeline
@@ -1063,7 +1064,7 @@ loadDatabaseFromConfigWithCrossDBAndTransforms ::
     Bool -> -- noCache
     [IndexedDatabase] -> -- Pre-built indexes from other databases for cross-DB linking
     M.Map T.Text [T.Text] -> -- Location hierarchy (empty = use built-in)
-    IO (Either Text LoadedDatabase)
+    IO (Either Text (LoadedDatabase, Bool))
 loadDatabaseFromConfigWithCrossDBAndTransforms transforms dbConfig synonymDB unitConfig noCache otherIndexes locationHier = do
     let sourcePath = dcPath dbConfig
         locationAliases = dcLocationAliases dbConfig
@@ -1072,7 +1073,7 @@ loadDatabaseFromConfigWithCrossDBAndTransforms transforms dbConfig synonymDB uni
 
     case dbResult of
         Left err -> return $ Left err
-        Right dbRaw -> do
+        Right (dbRaw, fromCache) -> do
             -- Apply transform plugins (sorted by priority) before runtime init
             transformed <- applyTransforms transforms (toSimpleDatabase dbRaw)
             dbRebuiltResult <-
@@ -1095,11 +1096,13 @@ loadDatabaseFromConfigWithCrossDBAndTransforms transforms dbConfig synonymDB uni
 
                     return $
                         Right
-                            LoadedDatabase
+                            ( LoadedDatabase
                                 { ldDatabase = database
                                 , ldSharedSolver = sharedSolver
                                 , ldConfig = dbConfig
                                 }
+                            , fromCache
+                            )
 
 -- | Apply transform plugins sequentially (sorted by priority)
 applyTransforms :: [TransformHandle] -> SimpleDatabase -> IO SimpleDatabase
@@ -1194,7 +1197,10 @@ loadDatabaseRawWithCrossDB ::
     [IndexedDatabase] ->
     -- | Location hierarchy (empty = use built-in)
     M.Map T.Text [T.Text] ->
-    IO (Either Text Database)
+    -- | (Database, fromCache): True iff the result came from the matrix cache
+    -- as-is, i.e. cross-DB linking was NOT freshly run against 'otherIndexes'.
+    -- Callers use this to decide whether a self-relink is needed.
+    IO (Either Text (Database, Bool))
 loadDatabaseRawWithCrossDB dbName locationAliases sourcePath noCache synonymDB unitConfig otherIndexes locationHier = do
     mCachedDb <-
         if noCache
@@ -1210,7 +1216,7 @@ loadDatabaseRawWithCrossDB dbName locationAliases sourcePath noCache synonymDB u
     case (cacheUsable, mCachedDb) of
         (True, Just db) -> do
             Loader.reportCrossDBLinkingStats (fromIntegral (dbActivityCount db)) (dbLinkingStats db)
-            return $ Right db
+            return $ Right (db, True)
         _ -> do
             when (isJust mCachedDb && not cacheUsable) $
                 reportProgress Info "Cache has unresolved links, rebuilding with available dependencies..."
@@ -1257,7 +1263,7 @@ loadDatabaseRawWithCrossDB dbName locationAliases sourcePath noCache synonymDB u
                         unless noCache $
                             Loader.saveCachedDatabaseWithMatrices dbName sourcePath db
                         Loader.reportCrossDBLinkingStats (fromIntegral (dbActivityCount db)) (dbLinkingStats db)
-                        return $ Right db
+                        return $ Right (db, False)
 
     loadStructured path = do
         loadResult <-
@@ -1290,7 +1296,7 @@ loadDatabaseRawWithCrossDB dbName locationAliases sourcePath noCache synonymDB u
                                     }
                         unless noCache $
                             Loader.saveCachedDatabaseWithMatrices dbName sourcePath dbWithLinks
-                        return $ Right dbWithLinks
+                        return $ Right (dbWithLinks, False)
 
 -- | Load a single database without auto-loading dependencies
 loadDatabaseSingle :: DatabaseManager -> Text -> IO (Either Text LoadedDatabase)
@@ -1345,7 +1351,7 @@ loadDatabaseSingleFromConfig manager dbName = do
                     case eitherResult of
                         Left (ex :: SomeException) -> return $ Left $ "Exception loading database: " <> T.pack (show ex)
                         Right (Left err) -> return $ Left err
-                        Right (Right loaded) -> do
+                        Right (Right (loaded, fromCache)) -> do
                             let indexedDb = buildIndexedDatabaseFromDB dbName synonymDB (ldDatabase loaded)
                             atomically $ do
                                 modifyTVar' (dmLoadedDbs manager) (M.insert dbName loaded)
@@ -1361,16 +1367,16 @@ loadDatabaseSingleFromConfig manager dbName = do
                                 dbName
                                 ("Auto-extracted from " <> dcDisplayName dbConfig)
                                 pairs
-                            -- Re-link THIS DB too. A cache hit can return a
-                            -- DB whose stored 'dbCrossDBLinks' point at deps
-                            -- that aren't loaded now (or miss deps that are):
-                            -- 'loadDatabaseRawWithCrossDB' only re-parses
-                            -- when 'unresolvedCount > 0', so a fully-resolved
-                            -- cache against version A is reused as-is even
-                            -- when version B is now loaded instead. The
-                            -- self-relink walks the current 'otherIndexes'
-                            -- and rewrites links + cache if they changed.
-                            _ <- relinkDatabase manager dbName
+                            -- Self-relink only on cache hits. On a fresh
+                            -- parse, 'loadDatabaseRawWithCrossDB' already ran
+                            -- linking against the current 'otherIndexes' via
+                            -- 'loadStructured' / 'loadCSV', so a follow-up
+                            -- relink is guaranteed no-op work. On a cache
+                            -- hit the cached DB carries links computed
+                            -- against a previous dep set — possibly stale
+                            -- versions of the same dep names — so a relink
+                            -- is required to converge.
+                            when fromCache $ void $ relinkDatabase manager dbName
                             relinkDependents manager dbName
                             return $ Right loaded
 
@@ -1381,6 +1387,11 @@ data RelinkResult = RelinkResult
     , rresUnresolvedAfter :: !Int
     , rresCrossDBLinks :: !Int
     , rresDepsLoaded :: ![Text]
+    , -- | True iff the relink actually changed 'dbCrossDBLinks' or
+      -- 'dbDependsOn' versus the in-memory state before the call. Callers
+      -- use this to skip redundant work — e.g. the explicit cache write in
+      -- 'finalizeDatabase' is suppressed when the relink already saved.
+      rresLinksChanged :: !Bool
     }
     deriving (Show, Eq)
 
@@ -1474,6 +1485,7 @@ relinkDatabase manager dbName = do
                         , rresUnresolvedAfter = afterUnresolved
                         , rresCrossDBLinks = length newLinks
                         , rresDepsLoaded = newDeps
+                        , rresLinksChanged = linksChanged
                         }
 
 {- | After a DB loads (or reloads), re-link every already-loaded DB that
@@ -2227,18 +2239,26 @@ finalizeDatabase manager dbName = do
                                         modifyTVar' (dmIndexedDbs manager) (M.insert dbName indexedDb)
                                     clearMethodMappingCacheForDb manager dbName
 
-                                    -- Only save to cache when matrices were built fresh
-                                    when (not fromCache) $
-                                        Loader.saveCachedDatabaseWithMatrices dbName (dcPath (sdConfig staged)) dbWithRuntime
+                                    -- Self-relink first against the current
+                                    -- dep set: a cached or staged build can
+                                    -- carry cross-DB links that don't match
+                                    -- the deps now in 'dmIndexedDbs'.
+                                    -- 'relinkDatabase' rewrites both the
+                                    -- in-memory state and (when 'linksChanged'
+                                    -- is True) the matrix cache.
+                                    relinkOutcome <- relinkDatabase manager dbName
 
-                                    -- Self-relink against the current dep
-                                    -- set. Same rationale as the Load path:
-                                    -- a cached DB can carry stale cross-DB
-                                    -- links that no longer match what is
-                                    -- loaded now. 'relinkDatabase' will
-                                    -- rewrite both the in-memory state and
-                                    -- the cache file when the answer changes.
-                                    _ <- relinkDatabase manager dbName
+                                    -- Explicit cache save is only needed when
+                                    -- we built matrices fresh AND the relink
+                                    -- didn't already write the cache. The
+                                    -- 'Left' fallback preserves the original
+                                    -- "save iff fresh" behavior if relink
+                                    -- failed for some unexpected reason.
+                                    let linksChangedAfter = case relinkOutcome of
+                                            Right rr -> rresLinksChanged rr
+                                            Left _ -> False
+                                    when (not fromCache && not linksChangedAfter) $
+                                        Loader.saveCachedDatabaseWithMatrices dbName (dcPath (sdConfig staged)) dbWithRuntime
 
                                     reportProgress Info $ "  [OK] Finalized: " <> T.unpack dbName
                                     return $ Right loaded

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1473,16 +1473,21 @@ relinkDatabase manager dbName = do
                     dbName
                     (dcPath (ldConfig loaded'))
                     db'
-            reportProgress Info $
-                "Re-linked "
-                    <> T.unpack dbName
-                    <> ": "
-                    <> show beforeUnresolved
-                    <> " \8594 "
-                    <> show afterUnresolved
-                    <> " unresolved products ("
-                    <> show (length newLinks)
-                    <> " cross-DB links)"
+            -- Skip the log when the relink was a verification no-op: links
+            -- and deps already matched the in-memory state. This is the
+            -- common case for warm Loads after the previous commits and
+            -- carries no information worth a log line.
+            when linksChanged $
+                reportProgress Info $
+                    "Re-linked "
+                        <> T.unpack dbName
+                        <> ": "
+                        <> show beforeUnresolved
+                        <> " \8594 "
+                        <> show afterUnresolved
+                        <> " unresolved products ("
+                        <> show (length newLinks)
+                        <> " cross-DB links)"
             return $
                 Right
                     RelinkResult

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -94,7 +94,7 @@ import Control.Concurrent.Async (mapConcurrently, mapConcurrently_)
 import Control.Concurrent.STM
 import Control.Exception (SomeException, try)
 import qualified Control.Exception
-import Control.Monad (forM, forM_, unless, void, when)
+import Control.Monad (forM, forM_, unless, when)
 import Data.Aeson (FromJSON (..), ToJSON (..), (.:), (.:?), (.=))
 import qualified Data.Aeson as A
 import Data.Bifunctor (first)
@@ -1376,7 +1376,13 @@ loadDatabaseSingleFromConfig manager dbName = do
                             -- against a previous dep set — possibly stale
                             -- versions of the same dep names — so a relink
                             -- is required to converge.
-                            when fromCache $ void $ relinkDatabase manager dbName
+                            when fromCache $ do
+                                result <- relinkDatabase manager dbName
+                                case result of
+                                    Right _ -> return ()
+                                    Left err ->
+                                        reportProgress Warning $
+                                            "Self-relink of " <> T.unpack dbName <> " failed: " <> T.unpack err
                             relinkDependents manager dbName
                             return $ Right loaded
 
@@ -2254,9 +2260,12 @@ finalizeDatabase manager dbName = do
                                     -- 'Left' fallback preserves the original
                                     -- "save iff fresh" behavior if relink
                                     -- failed for some unexpected reason.
-                                    let linksChangedAfter = case relinkOutcome of
-                                            Right rr -> rresLinksChanged rr
-                                            Left _ -> False
+                                    linksChangedAfter <- case relinkOutcome of
+                                        Right rr -> return (rresLinksChanged rr)
+                                        Left err -> do
+                                            reportProgress Warning $
+                                                "Self-relink of " <> T.unpack dbName <> " failed: " <> T.unpack err
+                                            return False
                                     when (not fromCache && not linksChangedAfter) $
                                         Loader.saveCachedDatabaseWithMatrices dbName (dcPath (sdConfig staged)) dbWithRuntime
 

--- a/test/AutoRelinkSpec.hs
+++ b/test/AutoRelinkSpec.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Regression tests for the auto-relink-on-Load behavior.
+
+The PR these tests guard introduced two related changes:
+
+  1. 'loadDatabaseRawWithCrossDB' returns @(Database, Bool)@ where the
+     'Bool' is True iff the result came straight from the matrix cache
+     (i.e. cross-DB linking was NOT freshly run against 'otherIndexes').
+  2. 'loadDatabaseSingleFromConfig' uses that flag to skip the no-op
+     self-relink on fresh parses.
+
+The 'fromCache' flag is the contract these tests pin down. The end-to-end
+dep-set-swap scenario (load consumer with deps A → swap to B → reload
+consumer → links repointed) is still covered by the PR's manual test plan;
+fully automating it requires multi-DB cross-link fixtures and is left to a
+follow-up.
+-}
+module AutoRelinkSpec (spec) where
+
+import Control.Monad (forM_)
+import qualified Data.Map.Strict as M
+import qualified Data.Text as T
+import System.Directory (
+    copyFile,
+    createDirectoryIfMissing,
+    doesFileExist,
+    listDirectory,
+ )
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+
+import Database.Manager (loadDatabaseRawWithCrossDB)
+import SynonymDB (emptySynonymDB)
+import UnitConversion (defaultUnitConfig)
+
+-- | Copy regular files from one directory into another (non-recursive,
+-- which is all the EcoSpold v2 fixtures here need).
+copyDirContents :: FilePath -> FilePath -> IO ()
+copyDirContents src dst = do
+    createDirectoryIfMissing True dst
+    files <- listDirectory src
+    forM_ files $ \f -> copyFile (src </> f) (dst </> f)
+
+-- | Drive 'loadDatabaseRawWithCrossDB' with the inert defaults that this
+-- test cares about. Cross-DB linking is not exercised; we only need the
+-- cache-hit detection.
+runRaw :: FilePath -> IO (Either T.Text Bool)
+runRaw dstDir = do
+    result <-
+        loadDatabaseRawWithCrossDB
+            "test"
+            M.empty
+            dstDir
+            False -- noCache disabled: cache must be written/read
+            emptySynonymDB
+            defaultUnitConfig
+            []
+            M.empty
+    return (fmap snd result)
+
+spec :: Spec
+spec = do
+    describe "loadDatabaseRawWithCrossDB cache-hit flag" $ do
+        it "returns fromCache=False on a fresh parse and writes the cache" $
+            withSystemTempDirectory "volca-relink" $ \tmp -> do
+                let dstDir = tmp </> "sample"
+                copyDirContents "test-data/SAMPLE.min1" dstDir
+
+                -- Cache file lives next to sourcePath (in 'tmp', because
+                -- takeDirectory dstDir == tmp).
+                let cacheFile = tmp </> "volca.cache.test.bin.zst"
+                doesFileExist cacheFile `shouldReturn` False
+
+                r1 <- runRaw dstDir
+                r1 `shouldBe` Right False
+
+                doesFileExist cacheFile `shouldReturn` True
+
+        it "returns fromCache=True on a second load against the same path" $
+            withSystemTempDirectory "volca-relink" $ \tmp -> do
+                let dstDir = tmp </> "sample"
+                copyDirContents "test-data/SAMPLE.min1" dstDir
+
+                -- Prime the cache.
+                _ <- runRaw dstDir
+
+                -- Second call: must come back from the cache.
+                r2 <- runRaw dstDir
+                r2 `shouldBe` Right True

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -6,6 +6,7 @@ import Test.Hspec
 
 -- Import test modules (will be created)
 
+import qualified AutoRelinkSpec
 import qualified BM25Spec
 import qualified ChemSynonymsSpec
 import qualified CoalescingSolverSpec
@@ -94,3 +95,4 @@ main = hspec $ do
         describe "Database Status (depends_on)" DatabaseStatusSpec.spec
         describe "Licenses Endpoint" LicensesSpec.spec
         describe "Geographies cascade" GeographiesSpec.spec
+        describe "Auto-relink on Load (cache hit)" AutoRelinkSpec.spec

--- a/volca.cabal
+++ b/volca.cabal
@@ -158,6 +158,7 @@ test-suite lca-tests
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   other-modules:       TestHelpers
                      , GoldenData
+                     , AutoRelinkSpec
                      , MatrixConstructionSpec
                      , InventorySpec
                      , ParserSpec


### PR DESCRIPTION
## Summary

A cached `Database` can carry cross-DB links from a previous run against a different dep set. The cache-hit check only rejects a cache when `unresolvedCount > 0` AND fresh deps are available — a cache fully resolved against version A passes the check unchanged when version B is loaded instead, and the stale links survive in memory.

This PR closes that hole by folding cross-DB relinking into Load itself: every Load (cache hit or fresh parse, single-DB or finalize-from-staged) leaves the in-memory `dbCrossDBLinks` consistent with the currently-loaded dep set, and persists the result back to the matrix cache so the next startup doesn't have to re-discover it.

## Final state

- **Convergence is automatic.** `loadDatabaseSingleFromConfig` and `finalizeDatabase` both end with a self-relink against the current `dmIndexedDbs`. Stale cached links are rewritten in memory and on disk.
- **No duplicate work on fresh parses.** The loader now returns a `fromCache :: Bool` alongside the `LoadedDatabase`; the self-relink only fires on cache hits, where the cached state is the one that might be stale. Fresh parses already linked against the live dep set inside the loader, so the relink would have been a guaranteed no-op there.
- **One cache write per Load at most.** `relinkDatabase` writes the matrix cache when (and only when) `dbCrossDBLinks` or `dbDependsOn` changed (`rresLinksChanged`). `finalizeDatabase` defers its explicit save to the case where the matrix is fresh AND the relink didn't already persist — eliminating the previous double-write window.
- **Failures are visible.** Self-relink errors at both call sites log a Warning, matching `relinkDependents`. Previously they were silently dropped.
- **Log noise gone.** The `Re-linked X: 0 → 0 unresolved …` Info line is gated on `linksChanged`, so coherent warm Loads stay silent.
- **Regression guard.** A new `AutoRelinkSpec` locks in the `fromCache` flag contract from the loader: first call returns `False` and writes the cache; second call returns `True`. If this contract ever silently inverts or sticks, the perf optimization or the relink-on-cache-hit logic would break unnoticed.

## Verification

- `cabal test lca-tests`: **791 examples, 0 failures** (existing 789 + 2 new).
- End-to-end on `ginko-2025-v2` against `agribalyse-3-2`:
  - Stale cache from a different dep set: cache file rewritten after `Load ginko`; log shows `Re-linked ginko-2025-v2: 0 → 0 unresolved products (7085 cross-DB links)`.
  - Same dep set as cache: cache mtime/size unchanged; no Re-link log emitted.

## Test plan

- [x] Unit tests green
- [x] Cache-hit flag plumbing under automated regression (`AutoRelinkSpec`)
- [x] Manual: Load ginko after `agribalyse-3-2` rewrites the cache once, then stays no-op on subsequent loads
- [ ] Manual: swap agribalyse versions (unload ginko → unload agribalyse-X → load agribalyse-Y → load ginko) and confirm ginko relinks to Y in one step