### PR TITLE
fix(simapro): unify multi-product coproducts + expose allocation

### DIFF
--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -35,6 +35,8 @@ data ActivitySummary = ActivitySummary
     , prsProduct :: Text -- Reference product name
     , prsProductAmount :: Double -- Reference product amount
     , prsProductUnit :: Text -- Reference product unit name
+    , prsAllocationPercent :: Maybe Double -- SimaPro coproduct allocation (%, 0..100); Nothing for non-allocated bases
+    , prsAllocationFormula :: Maybe Text -- Raw SimaPro allocation formula; Nothing if purely numeric
     }
     deriving (Generic)
 

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -154,6 +154,11 @@ History of manual bumps:
      pattern (ecoinvent 3.9.1 export). Caches built before this bump have
      empty activityLocation for every activity in such databases, which
      breaks geography-aware supplier lookups.
+- 7: SimaPro multi-product processes now share one activityUUID across
+     coproducts (activityName derived from "Process name" field, not from
+     the product name). Activity record gained activityAllocationPercent
+     and activityAllocationFormula. Old caches have stale per-product
+     UUIDs and miss the allocation fields entirely.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.
@@ -161,7 +166,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeOf (undefined :: Database))
-     in hi `xor` lo `xor` 6
+     in hi `xor` lo `xor` 7
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -398,7 +398,7 @@ parseWithXeno xmlContent =
                     filter
                         (not . T.null . snd)
                         [("Category", psActivityCategory st), ("SubCategory", psActivitySubCategory st)]
-            activity = Activity name description M.empty classifications location refUnit (reverse $ psExchanges st) M.empty M.empty
+            activity = Activity name description M.empty classifications location refUnit (reverse $ psExchanges st) M.empty M.empty Nothing Nothing
             flows = reverse (psFlows st)
             units = reverse (psUnits st)
          in case applyCutoffStrategy activity of
@@ -707,7 +707,7 @@ parseAllWithXeno xmlContent =
                     filter
                         (not . T.null . snd)
                         [("Category", psActivityCategory st), ("SubCategory", psActivitySubCategory st)]
-            activity = Activity name description M.empty classifications location refUnit (reverse $ psExchanges st) M.empty M.empty
+            activity = Activity name description M.empty classifications location refUnit (reverse $ psExchanges st) M.empty M.empty Nothing Nothing
             flows = reverse (psFlows st)
             units = reverse (psUnits st)
          in case applyCutoffStrategy activity of

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -535,7 +535,7 @@ parseWithXeno xmlContent processId =
                 Just u -> u
                 Nothing -> "UNKNOWN_UNIT"
             -- Apply cutoff strategy to exchanges
-            activity = Activity name description M.empty (psClassifications st) location refUnit (reverse $ psExchanges st) M.empty M.empty
+            activity = Activity name description M.empty (psClassifications st) location refUnit (reverse $ psExchanges st) M.empty M.empty Nothing Nothing
             flows = reverse (psFlows st)
             units = reverse (psUnits st)
          in case applyCutoffStrategy activity of

--- a/src/ILCD/Parser.hs
+++ b/src/ILCD/Parser.hs
@@ -502,6 +502,8 @@ buildActivity flowInfoMap flowDB unitDB p =
         , exchanges = map (mkExchange (iprRefFlowIdx p)) (iprExchanges p)
         , activityParams = M.empty
         , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
         }
   where
     refUnit = case findRefExchange p of

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -255,6 +255,8 @@ convertToInventoryExport db flowDB unitDB processId rootActivity inventory =
                         prodName
                         prodAmount
                         prodUnit
+                        (activityAllocationPercent rootActivity)
+                        (activityAllocationFormula rootActivity)
                 , imTotalFlows = length flowDetails
                 , imEmissionFlows = emissionFlows
                 , imResourceFlows = resourceFlows
@@ -925,6 +927,8 @@ searchActivities db (SearchFilter core exactMatch) = do
                             prodName
                             prodAmount
                             prodUnit
+                            (activityAllocationPercent activity)
+                            (activityAllocationFormula activity)
                 )
                 pagedResults
     endTime <- getCurrentTime
@@ -1086,31 +1090,23 @@ getAllProductsForActivity :: Database -> UUID -> [ActivitySummary]
 getAllProductsForActivity db activityUUID =
     case M.lookup activityUUID (dbActivityProductsIndex db) of
         Just processIds ->
-            [ let (prodName, prodAmount, prodUnit) = getProductInfo db pid
+            [ let mAct = findActivityByProcessId db pid
+                  (prodName, prodAmount, prodUnit) = case mAct of
+                    Just a -> getReferenceProductInfo (dbFlows db) (dbUnits db) a
+                    Nothing -> ("Unknown", 1.0, "")
                in ActivitySummary
                     { prsProcessId = processIdToText db pid
-                    , prsName = getActivityNameForPid db pid
-                    , prsLocation = maybe "" activityLocation (findActivityByProcessId db pid)
+                    , prsName = maybe "Unknown" activityName mAct
+                    , prsLocation = maybe "" activityLocation mAct
                     , prsProduct = prodName
                     , prsProductAmount = prodAmount
                     , prsProductUnit = prodUnit
+                    , prsAllocationPercent = mAct >>= activityAllocationPercent
+                    , prsAllocationFormula = mAct >>= activityAllocationFormula
                     }
             | pid <- processIds
             ]
         Nothing -> []
-  where
-    -- Get activity name for a ProcessId
-    getActivityNameForPid :: Database -> ProcessId -> Text
-    getActivityNameForPid db' pid =
-        case findActivityByProcessId db' pid of
-            Just activity -> activityName activity
-            Nothing -> "Unknown"
-    -- Get product info (name, amount, unit) from reference exchange
-    getProductInfo :: Database -> ProcessId -> (Text, Double, Text)
-    getProductInfo db' pid =
-        case findActivityByProcessId db' pid of
-            Just activity -> getReferenceProductInfo (dbFlows db') (dbUnits db') activity
-            Nothing -> ("Unknown", 1.0, "")
 
 -- | Get target activity for technosphere navigation
 getTargetActivity :: Database -> Exchange -> Maybe ActivitySummary
@@ -1127,6 +1123,8 @@ getTargetActivity db exchange = do
             , prsProduct = prodName
             , prsProductAmount = prodAmount
             , prsProductUnit = prodUnit
+            , prsAllocationPercent = activityAllocationPercent targetActivity
+            , prsAllocationFormula = activityAllocationFormula targetActivity
             }
 
 -- | Get reference product as FlowDetail (if exists)
@@ -1155,6 +1153,8 @@ getActivitiesUsingFlow db flowUUID =
                         prodName
                         prodAmount
                         prodUnit
+                        (activityAllocationPercent proc)
+                        (activityAllocationFormula proc)
                 | procUUID <- uniqueUUIDs
                 , Just proc <- [findActivityByActivityUUID db procUUID]
                 , Just processId <- [findProcessIdForActivity db proc]
@@ -1216,6 +1216,8 @@ getActivityExchangeDetails db activity filterFn =
                             , prsProduct = cdlFlowName link
                             , prsProductAmount = 1.0
                             , prsProductUnit = cdlExchangeUnit link
+                            , prsAllocationPercent = Nothing
+                            , prsAllocationFormula = Nothing
                             }
 
 -- | Get detailed input exchanges
@@ -1550,6 +1552,8 @@ buildSupplyChainFromScalingVector db dbName processId supplyVec scf includeEdges
                         (getReferenceProductName (dbFlows db) rootActivity)
                 , prsProductAmount = rootRefAmount
                 , prsProductUnit = activityUnit rootActivity
+                , prsAllocationPercent = activityAllocationPercent rootActivity
+                , prsAllocationFormula = activityAllocationFormula rootActivity
                 }
      in SupplyChainResponse
             { scrRoot = rootSummary
@@ -1609,6 +1613,8 @@ buildSupplyChainFromScalingVectorCrossDB unitCfg depLookup rootDb rootDbName roo
                         (getReferenceProductName (dbFlows rootDb) rootActivity)
                 , prsProductAmount = rootRefAmount
                 , prsProductUnit = activityUnit rootActivity
+                , prsAllocationPercent = activityAllocationPercent rootActivity
+                , prsAllocationFormula = activityAllocationFormula rootActivity
                 }
     eDep <- walkDepLevels unitCfg depLookup rootDb rootScaling extraLinks scf includeEdges 1 S.empty
     pure $ case eDep of

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -763,8 +763,12 @@ processBlockToActivity unitCfg (dbInputPs, dbCalcPs, projInputPs, projCalcPs) Pr
         exprMap = M.fromList allExprs
 
         -- Extract location from process name if not specified
-        (_, locFromName) = extractLocation pbName
+        (cleanProcessNameRaw, locFromName) = extractLocation pbName
         location = if T.null pbLocation || T.toLower pbLocation == "unspecified" then locFromName else pbLocation
+        -- Trimmed Process name (without curly-brace location tag). Empty when
+        -- the SimaPro "Process name" field is empty (typical for mono-product
+        -- blocks where only the Product line carries the human-readable name).
+        processNameTrimmed = T.strip cleanProcessNameRaw
 
         -- Convert all rows in one pass, collecting exchanges/flows/units together
         avoidedTriples = map (productToExchange unitCfg env False) pbAvoidedProducts
@@ -801,12 +805,24 @@ processBlockToActivity unitCfg (dbInputPs, dbCalcPs, projInputPs, projCalcPs) Pr
         makeActivity prod =
             let (productExchange, productFlow, productUnit) = productToExchange unitCfg env True prod
                 effUnitName = unitName productUnit
-                allocFraction = resolveAmount env (prAllocRaw prod) (prAllocation prod) / 100.0
+                allocPercent = resolveAmount env (prAllocRaw prod) (prAllocation prod)
+                allocFraction = allocPercent / 100.0
                 (cleanProductName, locFromProduct) = extractLocation (prName prod)
                 effectiveLoc = if T.null location then locFromProduct else location
+                -- Activity name = Process name when present (so coproducts of
+                -- the same Process share one activityUUID via generateActivityUUID),
+                -- otherwise fall back to product name (mono-product blocks
+                -- with empty "Process name" field).
+                effectiveActivityName =
+                    if T.null processNameTrimmed then cleanProductName else processNameTrimmed
+                allocFormulaRaw = T.strip (prAllocRaw prod)
+                allocFormula =
+                    if T.null allocFormulaRaw || isNumericFormula allocFormulaRaw
+                        then Nothing
+                        else Just allocFormulaRaw
                 activity =
                     Activity
-                        { activityName = cleanProductName
+                        { activityName = effectiveActivityName
                         , activityDescription = if T.null pbComment then [] else [pbComment]
                         , activitySynonyms = M.empty
                         , activityClassification =
@@ -821,6 +837,8 @@ processBlockToActivity unitCfg (dbInputPs, dbCalcPs, projInputPs, projCalcPs) Pr
                         , exchanges = productExchange : map (scaleExchange allocFraction) sharedExchanges
                         , activityParams = env
                         , activityParamExprs = exprMap
+                        , activityAllocationPercent = Just allocPercent
+                        , activityAllocationFormula = allocFormula
                         }
                 allFlows = productFlow : sharedFlows
                 allUnits =
@@ -830,6 +848,12 @@ processBlockToActivity unitCfg (dbInputPs, dbCalcPs, projInputPs, projCalcPs) Pr
              in (activity, allFlows, allUnits)
      in
         map makeActivity pbProducts
+
+-- | True when the raw allocation cell is a plain decimal literal (no formula).
+isNumericFormula :: Text -> Bool
+isNumericFormula t = case TR.double t of
+    Right (_, rest) -> T.null (T.strip rest)
+    Left _ -> False
 
 -- | Scale an exchange amount by a factor (for allocation)
 scaleExchange :: Double -> Exchange -> Exchange

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -240,6 +240,8 @@ data Activity = Activity
     , exchanges :: ![Exchange] -- List of exchanges
     , activityParams :: !(M.Map Text Double) -- Resolved SimaPro parameter values
     , activityParamExprs :: !(M.Map Text Text) -- Raw SimaPro parameter expressions (for re-evaluation)
+    , activityAllocationPercent :: !(Maybe Double) -- SimaPro multi-product allocation fraction (%, 0..100); Nothing for non-allocated bases
+    , activityAllocationFormula :: !(Maybe Text) -- Raw SimaPro allocation formula (e.g. "Qp*DMp/(Qp*DMp+Qw*DMw)*100"); Nothing if purely numeric
     }
     deriving (Generic, NFData, Store)
 

--- a/test/BM25Spec.hs
+++ b/test/BM25Spec.hs
@@ -33,6 +33,8 @@ mkActivity name loc xs =
         , exchanges = xs
         , activityParams = M.empty
         , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
         }
 
 mkRefOutput :: UUID -> Exchange

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -27,6 +27,8 @@ emptyActivity =
         , exchanges = []
         , activityParams = M.empty
         , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
         }
 
 -- | A production output exchange (isInput=False, isReference=False by default)

--- a/test/FuzzySpec.hs
+++ b/test/FuzzySpec.hs
@@ -24,6 +24,8 @@ mkActivity name xs =
         , exchanges = xs
         , activityParams = M.empty
         , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
         }
 
 -- Index-builder helper: create a BM25 index over a list of activity names.

--- a/test/ILCDParserSpec.hs
+++ b/test/ILCDParserSpec.hs
@@ -54,6 +54,8 @@ activityWithRefExchange fid =
             ]
         , activityParams = M.empty
         , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
         }
 
 -- An activity with a single unresolved input exchange for the given flow UUID
@@ -66,6 +68,8 @@ activityWithInputExchange fid =
         , activityClassification = M.empty
         , activityLocation = "GLO"
         , activityUnit = "kg"
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
         , exchanges =
             [ TechnosphereExchange
                 { techFlowId = fid

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -48,6 +48,8 @@ minimalActivity name loc exs =
         , exchanges = exs
         , activityParams = M.empty
         , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
         }
 
 refExchange :: UUID.UUID -> Exchange

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -91,6 +91,8 @@ mkActivity loc =
         , exchanges = []
         , activityParams = M.empty
         , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
         }
 
 -- Triples: (bioRow=0, col=i, value=v) for each activity.

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -26,7 +26,7 @@ import SimaPro.Parser (
 import System.IO (hClose)
 import System.IO.Temp (withSystemTempFile)
 import Test.Hspec
-import Types (Activity (..), Exchange (..), Flow, UUID, Unit (..), exchangeComment)
+import Types (Activity (..), Exchange (..), Flow, UUID, Unit (..), exchangeComment, flowName)
 import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig, isKnownUnit)
 
 -- | Test CSV content with a quoted product name containing the delimiter (;)
@@ -427,10 +427,13 @@ spec = do
             unknowns `shouldNotContain` ["kg"]
 
         it "parses product names with embedded delimiters correctly" $ do
-            (activities, _, _) <- parseTestCSV
+            (activities, flowDB, _) <- parseTestCSV
+            -- activityName now reflects the SimaPro Process name (multi-product
+            -- friendly); the quoted product name lives on the reference flow.
             let names = map activityName activities
-            -- The quoted product name should be extracted intact
-            names `shouldContain` ["Food product (irradiated ; with treatment)"]
+            names `shouldContain` ["Irradiated Food"]
+            let flowNames = map flowName (M.elems flowDB)
+            flowNames `shouldContain` ["Food product (irradiated ; with treatment)"]
 
     describe "SimaPro classification parsing" $ do
         it "parses Category type from metadata" $ do
@@ -448,22 +451,22 @@ spec = do
             (activities, _, _) <- parseWasteCSV
             length activities `shouldSatisfy` (>= 2)
 
-        it "uses Waste treatment row as activity name" $ do
+        it "uses Process name as activity name (waste treatment block)" $ do
             (activities, _, _) <- parseWasteCSV
             let names = map activityName activities
-            names `shouldContain` ["Municipal waste incineration"]
+            names `shouldContain` ["Incineration process"]
 
         it "parses 6-field waste treatment rows without allocation" $ do
             (activities, _, _) <- parseWasteNoAllocCSV
             length activities `shouldBe` 1
             let a = head activities
-            activityName a `shouldBe` "Non-sulfidic overburden {GLO}| treatment of | Cut-off, S"
+            activityName a `shouldBe` "treatment of non-sulfidic overburden"
             let cls = activityClassification a
             M.lookup "Category" cls `shouldBe` Just "Others\\Copied from Ecoinvent cut-off S"
 
         it "marks Waste to treatment exchanges as inputs" $ do
             (activities, _, _) <- parseWasteCSV
-            let producer = head [a | a <- activities, activityName a == "Widget"]
+            let producer = head [a | a <- activities, activityName a == "Widget production"]
                 wasteExchanges =
                     [ e
                     | e@TechnosphereExchange{} <- exchanges producer
@@ -807,10 +810,78 @@ spec = do
 
         it "leaves an already-canonical kg reference unchanged" $ do
             (activities, _, _) <- parseTestCSV
-            let steel = head [a | a <- activities, activityName a == "Steel"]
+            let steel = head [a | a <- activities, activityName a == "Steel Production"]
                 refExs = [ex | ex <- exchanges steel, techIsReference ex, not (techIsInput ex)]
             techAmount (head refExs) `shouldBe` 1.0
             activityUnit steel `shouldBe` "kg"
+
+    describe "SimaPro multi-product processes (coproducts)" $ do
+        -- One Process block declares 5 coproducts with mass-allocation formulas.
+        -- The 5 resulting Activity records must share one activityUUID (so
+        -- dbActivityProductsIndex can group them) and each must carry its own
+        -- allocation percentage.
+        it "shares one activityUUID across all 5 coproducts" $ do
+            (activities, _, _) <- parseMultiCoproductCSV
+            length activities `shouldBe` 5
+            let uuids = S.fromList (map generateActivityUUID activities)
+            S.size uuids `shouldBe` 1
+
+        it "uses the Process name as activityName for every coproduct" $ do
+            (activities, _, _) <- parseMultiCoproductCSV
+            let names = S.fromList (map activityName activities)
+            S.size names `shouldBe` 1
+            S.member "Multi-coproduct refinery" names `shouldBe` True
+
+        it "stores allocation percentage on each coproduct Activity" $ do
+            (activities, _, _) <- parseMultiCoproductCSV
+            -- Order-agnostic: the 5 allocation percentages must match the
+            -- declared shares (50/20/15/10/5) as a multiset.
+            let percents = [p | a <- activities, Just p <- [activityAllocationPercent a]]
+                expected = [50.0, 20.0, 15.0, 10.0, 5.0]
+                matchOne e = any (\p -> abs (p - e) < 0.01) percents
+            length percents `shouldBe` 5
+            all matchOne expected `shouldBe` True
+            abs (sum percents - 100.0) `shouldSatisfy` (< 0.01)
+
+        it "preserves the raw allocation formula when non-numeric" $ do
+            -- paramTestCSV (butter) uses an expression "allocButter" for allocation
+            (activities, _, _) <- parseParamCSV
+            let butter = head activities
+            activityAllocationFormula butter `shouldBe` Just "allocButter"
+
+        it "leaves allocation formula populated for formula-based allocations" $ do
+            (activities, _, _) <- parseMultiCoproductCSV
+            -- Multi-coproduct allocations are of the form 'Sx /(...)*100',
+            -- so the formula field should be populated for each coproduct.
+            let formulas = [activityAllocationFormula a | a <- activities]
+            all (/= Nothing) formulas `shouldBe` True
+
+        it "scales shared exchanges by the per-coproduct allocation fraction" $ do
+            (activities, _, _) <- parseMultiCoproductCSV
+            -- A shared 1 kg upstream input is allocated across the 5 coproducts:
+            -- Alpha 0.5 kg, Beta 0.2 kg, Gamma 0.15 kg, Delta 0.1 kg, Epsilon
+            -- 0.05 kg. The sum across all coproduct columns restores 1 kg.
+            let perActivity =
+                    [ techAmount e
+                    | a <- activities
+                    , e@TechnosphereExchange{} <- exchanges a
+                    , techIsInput e
+                    , not (techIsReference e)
+                    ]
+            length perActivity `shouldBe` 5
+            let total = sum perActivity
+            abs (total - 1.0) `shouldSatisfy` (< 0.001)
+
+    describe "SimaPro Process name fallback" $ do
+        it "falls back to product name when Process name field is empty" $ do
+            (activities, _, _) <- parseNoProcessNameCSV
+            length activities `shouldBe` 1
+            -- With an empty 'Process name', the product name is used as
+            -- activityName (preserves legacy behaviour for mono-product CSVs
+            -- that omit the field).
+            activityName (head activities) `shouldBe` "Bare product"
+            -- A single-product Process still carries Just 100.0 allocation.
+            activityAllocationPercent (head activities) `shouldBe` Just 100.0
 
 -- ---------------------------------------------------------------------------
 -- Helpers for section tests
@@ -933,3 +1004,101 @@ parseTonRefCSV = withSystemTempFile "ton-ref.csv" $ \path handle -> do
 isLeft :: Either a b -> Bool
 isLeft (Left _) = True
 isLeft _ = False
+
+-- | Two Maybe Double values, considered equal within 0.01.
+approxEqAlloc :: Maybe Double -> Maybe Double -> Bool
+approxEqAlloc (Just a) (Just b) = abs (a - b) < 0.01
+approxEqAlloc Nothing Nothing = True
+approxEqAlloc _ _ = False
+
+-- | Generic 5-coproduct fixture: one Process block emits 5 fictional outputs
+-- with five mass-allocation formulas. Percentages are chosen so they sum to
+-- exactly 100 and use round numbers (50/20/15/10/5), keeping the test
+-- self-contained without copying real LCA data. The five share-parameters
+-- (S1..S5) are arranged so the formula 'Sx /(S1+S2+S3+S4+S5)*100' returns
+-- the corresponding percentage. A single upstream input lets us assert
+-- allocation scaling on the resulting Activities.
+multiCoproductCSV :: BS.ByteString
+multiCoproductCSV =
+    BS.intercalate
+        "\r\n"
+        [ "{SimaPro 9.6.0.1}"
+        , "{CSV separator: semicolon}"
+        , "{Decimal separator: .}"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "processing"
+        , ""
+        , "Type"
+        , "Unit process"
+        , ""
+        , "Process name"
+        , "Multi-coproduct refinery"
+        , ""
+        , "Geography"
+        , "GLO"
+        , ""
+        , "Products"
+        , "Product Alpha;kg;1;S1 /(S1 + S2 + S3 + S4 + S5)*100;not defined;processing;"
+        , "Product Beta;kg;1;S2 /(S1 + S2 + S3 + S4 + S5)*100;not defined;processing;"
+        , "Product Gamma;kg;1;S3 /(S1 + S2 + S3 + S4 + S5)*100;not defined;processing;"
+        , "Product Delta;kg;1;S4 /(S1 + S2 + S3 + S4 + S5)*100;not defined;processing;"
+        , "Product Epsilon;kg;1;S5 /(S1 + S2 + S3 + S4 + S5)*100;not defined;processing;"
+        , ""
+        , "Input parameters"
+        , "S1;50;Undefined;0;0;No;"
+        , "S2;20;Undefined;0;0;No;"
+        , "S3;15;Undefined;0;0;No;"
+        , "S4;10;Undefined;0;0;No;"
+        , "S5;5;Undefined;0;0;No;"
+        , ""
+        , "Materials/fuels"
+        , "Upstream feedstock;kg;1;Undefined;;;;;;"
+        , ""
+        , "End"
+        ]
+
+parseMultiCoproductCSV :: IO ([Activity], M.Map UUID Flow, M.Map UUID Unit)
+parseMultiCoproductCSV = withSystemTempFile "multi-coproduct.csv" $ \path handle -> do
+    BS.hPut handle multiCoproductCSV
+    hClose handle
+    parseSimaProCSV defaultUnitConfig path
+
+-- | Single-product CSV with an empty Process name field. Mirrors mono-product
+-- SimaPro exports that leave the "Process name" line blank: the parser must
+-- fall back to the product row name so activityUUID stays stable.
+noProcessNameCSV :: BS.ByteString
+noProcessNameCSV =
+    BS.intercalate
+        "\r\n"
+        [ "{SimaPro 9.6.0.1}"
+        , "{CSV separator: semicolon}"
+        , "{Decimal separator: .}"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , ""
+        , ""
+        , "Type"
+        , "Unit process"
+        , ""
+        , "Geography"
+        , "GLO"
+        , ""
+        , "Products"
+        , "Bare product;kg;1.0;100;not defined;material;"
+        , ""
+        , "End"
+        ]
+
+parseNoProcessNameCSV :: IO ([Activity], M.Map UUID Flow, M.Map UUID Unit)
+parseNoProcessNameCSV = withSystemTempFile "no-process-name.csv" $ \path handle -> do
+    BS.hPut handle noProcessNameCSV
+    hClose handle
+    parseSimaProCSV defaultUnitConfig path


### PR DESCRIPTION
## Summary

- SimaPro multi-product Process blocks now produce N coproducts that share a single `activityUUID` (derived from the **Process name** field, not the product name). Mono-product blocks with an empty Process name keep current behaviour via fallback.
- `Activity` carries `activityAllocationPercent` (resolved %) and `activityAllocationFormula` (raw SimaPro expression when non-numeric); both are exposed on `ActivitySummary` so the UI can display per-coproduct allocation.
- `dbActivityProductsIndex` and `getAllProductsForActivity` now actually return coproduct siblings (previously empty for SimaPro).
- Cache schemaSignature bumped to 7 so existing binary caches auto-rebuild on next load.

## Problem this fixes

In `/db/agribalyse-3-2/activities?name=Abondance%20cheese%20production`, users currently get 5 rows with the same content in both "Activity Name" and "Product" columns, and clicking any row shows only that single product on the detail page (no siblings). After this change, the 5 rows share the Process name in the first column, list the specific coproduct in the Product column, and the activity page lists all 5 coproducts with their allocation percentages.

Matrix construction is unchanged (still N columns per multi-product Process, with allocation already applied to shared exchanges). LCA results are numerically identical.

## Breaking change

SimaPro `process_id` strings (`activityUUID_productUUID`) change because the `activityUUID` derivation moved from product name to Process name. External references (bookmarks, scripts, persisted MCP results) need regeneration. EcoSpold v2 and ILCD bases are unaffected.

## Test plan

- [x] `cabal test lca-tests` — 796/796 passing
- [x] 6 new SimaPro coproduct tests (fictional fixture, no real LCA data) covering: shared activityUUID, Process name as activityName, allocation % stored, formula preserved, exchange scaling sums to 1.0
- [x] 1 new fallback test (empty Process name → product name)
- [x] 5 existing SimaPro tests adapted to the new activityName semantic
- [x] EcoSpold/ILCD parsers updated with `Nothing` for new fields (no regression)
- [ ] Manual UI verification: ingest Agribalyse 3.2, search "Abondance cheese production", click into a coproduct, confirm the Products section lists the 5 siblings with allocation % (the corresponding frontend changes live in `volca-deploy/volca/web`).