### PR TITLE
feat: parse SimaPro pedigree matrix and expose it via API

### DIFF
--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -306,7 +306,7 @@ _This reference is generated from the installed package. Run `python scripts/gen
 
 ### `Client`
 
-HTTP client for the VoLCA REST API.
+HTTP client for the VoLCA HTTP API.
 
 Usage::
 

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -1,4 +1,4 @@
-"""HTTP client for the VoLCA REST API, dispatched by OpenAPI operationId.
+"""HTTP client for the VoLCA HTTP API, dispatched by OpenAPI operationId.
 
 Design
 ------
@@ -208,7 +208,7 @@ def _parse_spec(spec: dict) -> dict[str, _Operation]:
 
 
 class Client:
-    """HTTP client for the VoLCA REST API.
+    """HTTP client for the VoLCA HTTP API.
 
     Usage::
 

--- a/src/API/OpenApi.hs
+++ b/src/API/OpenApi.hs
@@ -28,7 +28,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Database.Manager (DatabaseSetupInfo, DependencySuggestion, MissingSupplier)
 import Network.HTTP.Types.Method (StdMethod (..))
-import Types (Exchange, Flow, FlowType, Unit)
+import Types (Exchange, Flow, FlowType, Pedigree, Unit)
 
 {- | Orphan schema instance forward declaration for the login request body.
 The real type lives in "API.Routes"; this is defined there and re-imported
@@ -44,6 +44,7 @@ instance ToSchema Value where
 instance ToSchema FlowType
 instance ToSchema Unit where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 instance ToSchema Flow where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
+instance ToSchema Pedigree where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 instance ToSchema Exchange where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 
 -- Database.Manager types
@@ -116,6 +117,7 @@ instance ToSchema SubstitutionRequest where declareNamedSchema = genericDeclareN
 instance ToSchema Substitution where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 instance ToSchema SensitivityRequest where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 instance ToSchema SensitivityResponse where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
+
 -- Manual schema: the Either inside PerturbedEntry is flattened by ToJSON
 -- to {perturbation, impact, deltaImpact} on success and {perturbation, error}
 -- on failure. The Generic-derived schema would expose the Haskell shape

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -14,7 +14,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import GHC.Generics
 import Servant.API.ContentTypes (MimeRender (..), OctetStream)
-import Types (Exchange, Flow, UUID, Unit)
+import Types (Exchange, Flow, Pedigree, UUID, Unit)
 
 -- | Search response combining results and count
 data SearchResults a = SearchResults
@@ -673,6 +673,7 @@ data ExchangeWithUnit = ExchangeWithUnit
     , ewuTargetLocation :: Maybe Text -- For technosphere: location of target activity
     , ewuTargetProcessId :: Maybe Text -- For technosphere: ProcessId for navigation (activityUUID_productUUID)
     , ewuExComment :: Maybe Text -- Free-text per-exchange comment (mirrors exchangeComment)
+    , ewuPedigree :: Maybe Pedigree -- LCA data-quality scores when available (mirrors exchangePedigree)
     }
     deriving (Generic)
 
@@ -875,9 +876,10 @@ instance ToJSON SensitivityResponse where toJSON = strippedToJSON; toEncoding = 
 -- have impact+deltaImpact and error entries have error.
 instance ToJSON PerturbedEntry where
     toJSON (PerturbedEntry p result) =
-        object $ ("perturbation" .= p) : case result of
-            Left err -> ["error" .= err]
-            Right (lcia, d) -> ["impact" .= lcia, "deltaImpact" .= d]
+        object $
+            ("perturbation" .= p) : case result of
+                Left err -> ["error" .= err]
+                Right (lcia, d) -> ["impact" .= lcia, "deltaImpact" .= d]
 
 -- FromJSON instances needed for API conversion
 instance (FromJSON a) => FromJSON (SearchResults a) where parseJSON = strippedParseJSON

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -360,6 +360,7 @@ parseWithXeno xmlContent =
                             , bioIsInput = inputGroup == "4"
                             , bioLocation = exchangeLocation
                             , bioComment = nonEmptyText (exComment edata)
+                            , bioPedigree = Nothing
                             }
                     else
                         TechnosphereExchange
@@ -372,6 +373,7 @@ parseWithXeno xmlContent =
                             , techProcessLinkId = Nothing
                             , techLocation = exchangeLocation
                             , techComment = nonEmptyText (exComment edata)
+                            , techPedigree = Nothing
                             }
 
             cas = if T.null (exCASNumber edata) then Nothing else Just (exCASNumber edata)
@@ -671,6 +673,7 @@ parseAllWithXeno xmlContent =
                             , bioIsInput = inputGroup == "4"
                             , bioLocation = exchangeLocation
                             , bioComment = nonEmptyText (exComment edata)
+                            , bioPedigree = Nothing
                             }
                     else
                         TechnosphereExchange
@@ -683,6 +686,7 @@ parseAllWithXeno xmlContent =
                             , techProcessLinkId = Nothing
                             , techLocation = exchangeLocation
                             , techComment = nonEmptyText (exComment edata)
+                            , techPedigree = Nothing
                             }
             cas = if T.null (exCASNumber edata) then Nothing else Just (exCASNumber edata)
             flow = Flow flowId (exName edata) category Nothing unitId flowType M.empty cas Nothing

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -308,6 +308,7 @@ parseWithXeno xmlContent processId =
                                 , techProcessLinkId = Nothing
                                 , techLocation = "" -- EcoSpold2: no per-exchange location
                                 , techComment = snd <$> idComment idata
+                                , techPedigree = Nothing
                                 }
                         flow =
                             Flow
@@ -388,6 +389,7 @@ parseWithXeno xmlContent processId =
                                 , bioIsInput = isInput
                                 , bioLocation = "" -- EcoSpold2: no per-exchange location
                                 , bioComment = snd <$> edComment edata
+                                , bioPedigree = Nothing
                                 }
                         -- Get subcompartment from the list (first entry if any)
                         subcompartment = case edSubcompartments edata of

--- a/src/ILCD/Parser.hs
+++ b/src/ILCD/Parser.hs
@@ -533,6 +533,7 @@ buildActivity flowInfoMap flowDB unitDB p =
                         , bioIsInput = isInput
                         , bioLocation = ierLocation raw
                         , bioComment = ierComment raw
+                        , bioPedigree = Nothing
                         }
                 else
                     TechnosphereExchange
@@ -545,6 +546,7 @@ buildActivity flowInfoMap flowDB unitDB p =
                         , techProcessLinkId = Nothing
                         , techLocation = ierLocation raw
                         , techComment = ierComment raw
+                        , techPedigree = Nothing
                         }
 
 --------------------------------------------------------------------------------

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -1066,6 +1066,7 @@ convertActivityForAPI unitCfg db processId activity =
                 , ewuTargetLocation = targetActivityLocation
                 , ewuTargetProcessId = targetProcessId
                 , ewuExComment = exchangeComment exchange
+                , ewuPedigree = exchangePedigree exchange
                 }
 
 -- | Get reference product name from activity exchanges

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -26,6 +26,7 @@ module SimaPro.Parser (
     parseProductRow,
     parseTechRow,
     parseBioRow,
+    parsePedigreePrefix,
     decodeBS,
 ) where
 
@@ -895,6 +896,7 @@ productToExchange unitCfg env isRef ProductRow{..} =
                 , techProcessLinkId = Nothing
                 , techLocation = ""
                 , techComment = Nothing
+                , techPedigree = Nothing
                 }
         flow =
             Flow
@@ -919,6 +921,43 @@ nonEmptyText t =
     let s = T.strip t
      in if T.null s then Nothing else Just s
 
+{- | Split SimaPro's trailing comment column into the pedigree matrix (when
+present at the start) and the cleaned free-text comment.
+
+SimaPro encodes pedigree as a `(r,c,t,g,f)` quintuple with each value in
+1..5. It is conventionally followed by a separator (`,` or `;`) and then
+the user-authored comment. Examples:
+
+* `"(3,3,2,1,2),"`                          → pedigree only, no comment
+* `"(3,3,2,1,2),. Water must be added"`     → pedigree + comment
+* `"Free comment with no pedigree"`         → no pedigree, comment as-is
+
+Out-of-range or malformed digits return `(Nothing, Just raw)` so we never
+silently drop data we cannot interpret.
+-}
+parsePedigreePrefix :: Text -> (Maybe Pedigree, Maybe Text)
+parsePedigreePrefix raw =
+    let trimmed = T.stripStart raw
+     in case T.stripPrefix "(" trimmed of
+            Nothing -> (Nothing, nonEmptyText trimmed)
+            Just rest -> case T.breakOn ")" rest of
+                (_, "") -> (Nothing, nonEmptyText trimmed)
+                (inside, afterClose) ->
+                    let digits = map T.strip (T.splitOn "," inside)
+                        leftover = T.drop 1 afterClose -- drop ')'
+                     in case traverse readDigit digits of
+                            Just [r, c, t, g, f]
+                                | Just ped <- mkPedigree r c t g f ->
+                                    (Just ped, nonEmptyText (stripCommentSeparators leftover))
+                            _ -> (Nothing, nonEmptyText trimmed)
+  where
+    readDigit txt = case T.unpack (T.strip txt) of
+        s | all (`elem` ("0123456789" :: String)) s && not (null s) -> Just (read s)
+        _ -> Nothing
+    -- After the closing paren SimaPro emits e.g. ",", ", ", ",. ", ";" before
+    -- the comment proper. Strip leading separators and whitespace.
+    stripCommentSeparators = T.dropWhile (`elem` (",;. \t" :: String))
+
 {- | Convert technosphere row to exchange (if non-zero), flow, and unit.
 Always returns the flow/unit; exchange is Nothing for zero-amount rows.
 -}
@@ -928,6 +967,7 @@ techRowToExchange env isInput TechExchangeRow{..} =
         flowUUID = generateFlowUUID cleanName "" terUnit
         unitUUID = generateUnitUUID terUnit
         resolvedAmount = resolveAmount env terAmountRaw terAmount
+        (pedigree, cleanedComment) = parsePedigreePrefix terComment
         exchange =
             if resolvedAmount == 0
                 then Nothing
@@ -942,7 +982,8 @@ techRowToExchange env isInput TechExchangeRow{..} =
                             , techActivityLinkId = UUID.nil
                             , techProcessLinkId = Nothing
                             , techLocation = location
-                            , techComment = nonEmptyText terComment
+                            , techComment = cleanedComment
+                            , techPedigree = pedigree
                             }
         flow =
             Flow
@@ -979,6 +1020,7 @@ bioRowToExchange env isInput compartment BioExchangeRow{..} =
         unitUUID = generateUnitUUID berUnit
         amount = resolveAmount env berAmountRaw berAmount
         subcomp = if T.null berCompartment then Nothing else Just berCompartment
+        (pedigree, cleanedComment) = parsePedigreePrefix berComment
         exchange =
             BiosphereExchange
                 { bioFlowId = flowUUID
@@ -986,7 +1028,8 @@ bioRowToExchange env isInput compartment BioExchangeRow{..} =
                 , bioUnitId = unitUUID
                 , bioIsInput = isInput
                 , bioLocation = ""
-                , bioComment = nonEmptyText berComment
+                , bioComment = cleanedComment
+                , bioPedigree = pedigree
                 }
         flow =
             Flow
@@ -1025,7 +1068,8 @@ stripLocationSuffix name =
         | otherwise =
             let firstC = T.head t
                 rest = T.unpack (T.tail t)
-             in firstC >= 'A' && firstC <= 'Z'
+             in firstC >= 'A'
+                    && firstC <= 'Z'
                     && all (\c -> (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '-') rest
 
 -- ============================================================================

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -93,6 +93,30 @@ data Flow = Flow
     }
     deriving (Generic, NFData, Store)
 
+{- | Pedigree matrix (Weidema & Wesnæs 1996) — five LCA data-quality scores
+each in 1..5 (1 = best, 5 = worst). SimaPro CSV encodes it as a prefix in the
+trailing comment column; ecoinvent/EcoSpold2 stores it as structured XML.
+-}
+data Pedigree = Pedigree
+    { pedReliability :: !Int -- 1..5
+    , pedCompleteness :: !Int -- 1..5
+    , pedTemporal :: !Int -- 1..5
+    , pedGeographical :: !Int -- 1..5
+    , pedTechnological :: !Int -- 1..5
+    }
+    deriving (Eq, Show, Generic, NFData, Store)
+
+{- | Smart constructor: rejects out-of-range values (anything not in 1..5)
+by returning Nothing. Callers should treat Nothing as "no pedigree
+recorded" — never silently clamp.
+-}
+mkPedigree :: Int -> Int -> Int -> Int -> Int -> Maybe Pedigree
+mkPedigree r c t g f
+    | all inRange [r, c, t, g, f] = Just (Pedigree r c t g f)
+    | otherwise = Nothing
+  where
+    inRange n = n >= 1 && n <= 5
+
 -- | Exchange in an activity - Mirrors EcoSpold intermediateExchange/elementaryExchange structure
 data Exchange
     = TechnosphereExchange
@@ -105,6 +129,7 @@ data Exchange
         , techProcessLinkId :: !(Maybe ProcessId) -- Target process ID (new field)
         , techLocation :: !Text -- Supplier location (EcoSpold1) or "" (EcoSpold2)
         , techComment :: !(Maybe Text) -- Free-text per-exchange comment from source
+        , techPedigree :: !(Maybe Pedigree) -- LCA data-quality scores when available
         }
     | BiosphereExchange
         { bioFlowId :: !UUID -- Flow being exchanged
@@ -113,6 +138,7 @@ data Exchange
         , bioIsInput :: !Bool -- True for resource extraction, False for emissions
         , bioLocation :: !Text -- Exchange location (EcoSpold1) or "" (EcoSpold2)
         , bioComment :: !(Maybe Text) -- Free-text per-exchange comment from source
+        , bioPedigree :: !(Maybe Pedigree) -- LCA data-quality scores when available
         }
     deriving (Generic, NFData, Store)
 
@@ -157,6 +183,11 @@ exchangeLocation BiosphereExchange{bioLocation = loc} = loc
 exchangeComment :: Exchange -> Maybe Text
 exchangeComment TechnosphereExchange{techComment = c} = c
 exchangeComment BiosphereExchange{bioComment = c} = c
+
+-- | Get pedigree matrix attached to the exchange (when the source provides it)
+exchangePedigree :: Exchange -> Maybe Pedigree
+exchangePedigree TechnosphereExchange{techPedigree = p} = p
+exchangePedigree BiosphereExchange{bioPedigree = p} = p
 
 -- | Check if exchange is technosphere
 isTechnosphereExchange :: Exchange -> Bool
@@ -830,6 +861,11 @@ data CF = CF
 
 -- JSON instances for API compatibility
 -- Note: ProcessId is Int32, which already has ToJSON/FromJSON instances
+instance ToJSON Pedigree where
+    toJSON = genericToJSON stripLowerPrefix
+    toEncoding = genericToEncoding stripLowerPrefix
+instance FromJSON Pedigree where
+    parseJSON = genericParseJSON stripLowerPrefix
 instance ToJSON Exchange where
     toJSON = genericToJSON stripLowerPrefix
     toEncoding = genericToEncoding stripLowerPrefix

--- a/test/BM25Spec.hs
+++ b/test/BM25Spec.hs
@@ -49,6 +49,7 @@ mkRefOutput fid =
         , techProcessLinkId = Nothing
         , techLocation = ""
         , techComment = Nothing
+        , techPedigree = Nothing
         }
 
 mkFlow :: UUID -> Text -> Flow

--- a/test/CrossDBRegionalLCIAFixture.hs
+++ b/test/CrossDBRegionalLCIAFixture.hs
@@ -109,6 +109,8 @@ mkActivity _ loc =
         , exchanges = []
         , activityParams = M.empty
         , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
         }
 
 emptyIndexes :: Indexes

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -44,6 +44,7 @@ mkOutput fid amt =
         , techProcessLinkId = Nothing
         , techLocation = ""
         , techComment = Nothing
+        , techPedigree = Nothing
         }
 
 -- | A reference output exchange
@@ -64,6 +65,7 @@ mkBio fid amt =
         , bioIsInput = False
         , bioLocation = ""
         , bioComment = Nothing
+        , bioPedigree = Nothing
         }
 
 fid1, fid2, fid3 :: UUID

--- a/test/ILCDParserSpec.hs
+++ b/test/ILCDParserSpec.hs
@@ -50,6 +50,7 @@ activityWithRefExchange fid =
                 , techProcessLinkId = Nothing
                 , techLocation = ""
                 , techComment = Nothing
+                , techPedigree = Nothing
                 }
             ]
         , activityParams = M.empty
@@ -81,6 +82,7 @@ activityWithInputExchange fid =
                 , techProcessLinkId = Nothing
                 , techLocation = ""
                 , techComment = Nothing
+                , techPedigree = Nothing
                 }
             ]
         , activityParams = M.empty

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -64,6 +64,7 @@ refExchange fid =
         , techProcessLinkId = Nothing
         , techLocation = "GLO"
         , techComment = Nothing
+        , techPedigree = Nothing
         }
 
 inputExchange :: UUID.UUID -> Text -> Exchange
@@ -78,6 +79,7 @@ inputExchange fid loc =
         , techProcessLinkId = Nothing
         , techLocation = loc
         , techComment = Nothing
+        , techPedigree = Nothing
         }
 
 -- ---------------------------------------------------------------------------
@@ -269,6 +271,7 @@ spec = do
                         , bioIsInput = False
                         , bioLocation = ""
                         , bioComment = Nothing
+                        , bioPedigree = Nothing
                         }
                 (fixed, summary) = fixExchangeLinkByName idx flows "act" bioEx
             -- BiosphereExchange is returned unchanged: verify it is still biosphere

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -18,6 +18,7 @@ import SimaPro.Parser (
     generateUnitUUID,
     parseAmount,
     parseBioRow,
+    parsePedigreePrefix,
     parseProductRow,
     parseSimaProCSV,
     parseTechRow,
@@ -26,7 +27,17 @@ import SimaPro.Parser (
 import System.IO (hClose)
 import System.IO.Temp (withSystemTempFile)
 import Test.Hspec
-import Types (Activity (..), Exchange (..), Flow, UUID, Unit (..), exchangeComment, flowName)
+import Types (
+    Activity (..),
+    Exchange (..),
+    Flow,
+    Pedigree (..),
+    UUID,
+    Unit (..),
+    exchangeComment,
+    exchangePedigree,
+    flowName,
+ )
 import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig, isKnownUnit)
 
 -- | Test CSV content with a quoted product name containing the delimiter (;)
@@ -701,6 +712,75 @@ spec = do
             map exchangeComment bios `shouldBe` [Just "tail-pipe combustion"]
 
     -- -----------------------------------------------------------------------
+    -- Pedigree matrix
+    -- -----------------------------------------------------------------------
+
+    describe "parsePedigreePrefix" $ do
+        it "extracts pedigree and clean comment when both are present" $
+            parsePedigreePrefix "(3,3,2,1,2),. The ecoinvent process only takes pure product"
+                `shouldBe` ( Just (Pedigree 3 3 2 1 2)
+                           , Just "The ecoinvent process only takes pure product"
+                           )
+
+        it "extracts pedigree alone when no comment follows" $
+            parsePedigreePrefix "(3,3,2,1,2),"
+                `shouldBe` (Just (Pedigree 3 3 2 1 2), Nothing)
+
+        it "keeps the raw text when there is no pedigree prefix" $
+            parsePedigreePrefix "Free comment with no pedigree"
+                `shouldBe` (Nothing, Just "Free comment with no pedigree")
+
+        it "returns Nothing/Nothing for empty input" $
+            parsePedigreePrefix "" `shouldBe` (Nothing, Nothing)
+
+        it "rejects out-of-range digits and preserves the raw text" $
+            parsePedigreePrefix "(6,3,2,1,2), extra"
+                `shouldBe` (Nothing, Just "(6,3,2,1,2), extra")
+
+        it "rejects malformed parentheses and preserves the raw text" $
+            parsePedigreePrefix "(3,3,2,1 extra"
+                `shouldBe` (Nothing, Just "(3,3,2,1 extra")
+
+        it "tolerates leading whitespace before the pedigree" $
+            parsePedigreePrefix "  (3,3,2,1,2),. note"
+                `shouldBe` (Just (Pedigree 3 3 2 1 2), Just "note")
+
+    describe "pedigree wired through to Exchange" $ do
+        it "populates techPedigree and strips the prefix from the comment" $ do
+            (activities, _, _) <-
+                parseSectionCSV
+                    [ "Materials/fuels"
+                    , "Soybean meal BR;kg;6506.5;Lognormal;1.533;0;0;(3,3,2,1,2),. Brazilian port average"
+                    ]
+            let inputs =
+                    [ ex
+                    | act <- activities
+                    , ex <- exchanges act
+                    , case ex of
+                        TechnosphereExchange{techIsInput = True} -> True
+                        _ -> False
+                    ]
+            map exchangeComment inputs `shouldBe` [Just "Brazilian port average"]
+            map exchangePedigree inputs `shouldBe` [Just (Pedigree 3 3 2 1 2)]
+
+        it "populates bioPedigree for emission rows that carry only pedigree" $ do
+            (activities, _, _) <-
+                parseSectionCSV
+                    [ "Emissions to air"
+                    , "Carbon dioxide, fossil;high. pop.;kg;0.5;Undefined;;;;;;(2,2,1,1,1),"
+                    ]
+            let bios =
+                    [ ex
+                    | act <- activities
+                    , ex <- exchanges act
+                    , case ex of
+                        BiosphereExchange{} -> True
+                        _ -> False
+                    ]
+            map exchangeComment bios `shouldBe` [Nothing]
+            map exchangePedigree bios `shouldBe` [Just (Pedigree 2 2 1 1 1)]
+
+    -- -----------------------------------------------------------------------
     -- UUID generation
     -- -----------------------------------------------------------------------
 
@@ -1011,13 +1091,14 @@ approxEqAlloc (Just a) (Just b) = abs (a - b) < 0.01
 approxEqAlloc Nothing Nothing = True
 approxEqAlloc _ _ = False
 
--- | Generic 5-coproduct fixture: one Process block emits 5 fictional outputs
--- with five mass-allocation formulas. Percentages are chosen so they sum to
--- exactly 100 and use round numbers (50/20/15/10/5), keeping the test
--- self-contained without copying real LCA data. The five share-parameters
--- (S1..S5) are arranged so the formula 'Sx /(S1+S2+S3+S4+S5)*100' returns
--- the corresponding percentage. A single upstream input lets us assert
--- allocation scaling on the resulting Activities.
+{- | Generic 5-coproduct fixture: one Process block emits 5 fictional outputs
+with five mass-allocation formulas. Percentages are chosen so they sum to
+exactly 100 and use round numbers (50/20/15/10/5), keeping the test
+self-contained without copying real LCA data. The five share-parameters
+(S1..S5) are arranged so the formula 'Sx /(S1+S2+S3+S4+S5)*100' returns
+the corresponding percentage. A single upstream input lets us assert
+allocation scaling on the resulting Activities.
+-}
 multiCoproductCSV :: BS.ByteString
 multiCoproductCSV =
     BS.intercalate
@@ -1066,9 +1147,10 @@ parseMultiCoproductCSV = withSystemTempFile "multi-coproduct.csv" $ \path handle
     hClose handle
     parseSimaProCSV defaultUnitConfig path
 
--- | Single-product CSV with an empty Process name field. Mirrors mono-product
--- SimaPro exports that leave the "Process name" line blank: the parser must
--- fall back to the product row name so activityUUID stays stable.
+{- | Single-product CSV with an empty Process name field. Mirrors mono-product
+SimaPro exports that leave the "Process name" line blank: the parser must
+fall back to the product row name so activityUUID stays stable.
+-}
 noProcessNameCSV :: BS.ByteString
 noProcessNameCSV =
     BS.intercalate


### PR DESCRIPTION
## Summary

- **Parse pedigree out of the SimaPro comment column**: new `Pedigree` type with a smart constructor that rejects out-of-1..5 values; `parsePedigreePrefix` splits the trailing column into structured scores and a cleaned free-text comment, wired into `techRowToExchange` and `bioRowToExchange`.
- **Expose pedigree on the wire**: new `pedigree` field on `ExchangeWithUnit` (5 ints), `ToJSON`/`FromJSON`/`ToSchema` instances follow the existing `strippedToJSON` / `strippedSchemaOptions` pattern, so the field appears in MCP responses and the OpenAPI spec automatically.
- **Drive-bys**: fix a missing-fields error in `CrossDBRegionalLCIAFixture.mkActivity` so the test suite compiles, and align the pyvolca `Client` docstring with the actual transport ("HTTP API", not "REST API"). EcoSpold 1/2 and ILCD parsers pass `Nothing` for pedigree — `pedigreeMatrix` XML extraction in EcoSpold 2 is a clean follow-up.

## Test plan

- [x] `cabal test --test-options="--match parsePedigreePrefix"` — 7/7 pass (well-formed, comment-only, malformed, out-of-range, leading whitespace, empty)
- [x] `cabal test --test-options="--match \"pedigree wired through\""` — 2/2 pass (cleaned comment + structured pedigree reach the parsed Exchange on both technosphere and biosphere rows)
- [x] `cabal test --test-options="--match \"SimaPro Parser\""` — 82/82 pass, no regression on existing comment / row parsing tests
- [x] `cabal build` clean
- [ ] CI green on the 4 required status checks