### PR TITLE
build: factor ghc-options via common stanzas, enable -O2 on library

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -2,3 +2,8 @@ packages: .
           ./mumps-hs
 
 allow-newer: true
+
+jobs: $ncpus
+
+program-options
+  ghc-options: -j +RTS -A128m -RTS

--- a/volca.cabal
+++ b/volca.cabal
@@ -13,9 +13,15 @@ description:         This project is a Life Cycle Assessment (LCA) engine.
 
 extra-source-files:  README.md CHANGELOG.md
 
+common warnings
+  ghc-options:         -Wall -O2
+
+common rtsdefaults
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+
 library
+  import:              warnings
   hs-source-dirs:      src
-  ghc-options:         -Wall
   exposed-modules:     Types
                      , Progress
                      , UnitConversion
@@ -129,9 +135,9 @@ library
   default-language:    Haskell2010
 
 executable volca
+  import:              warnings, rtsdefaults
   main-is:             Main.hs
   hs-source-dirs:      app
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -O2 -j +RTS -A128m -RTS
   build-depends:       base >=4.14 && <5
                      , volca
                      , text
@@ -152,10 +158,10 @@ executable volca
   default-language:    Haskell2010
 
 test-suite lca-tests
+  import:              warnings, rtsdefaults
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Spec.hs
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   other-modules:       TestHelpers
                      , GoldenData
                      , AutoRelinkSpec
@@ -231,10 +237,11 @@ test-suite lca-tests
   default-language:    Haskell2010
 
 benchmark multi-method-bench
+  import:              warnings
   type:                exitcode-stdio-1.0
   hs-source-dirs:      bench
   main-is:             MultiMethodBench.hs
-  ghc-options:         -O2 -rtsopts -with-rtsopts=-A32m
+  ghc-options:         -rtsopts -with-rtsopts=-A32m
   default-extensions:  NumericUnderscores
   build-depends:       base >=4.14 && <5
                      , volca


### PR DESCRIPTION
## Summary

- The library was previously compiled **without `-O2`**, so the heavy code paths (parsers, matrix, solver) ran unoptimized. The `-O2` on the executable only optimized `Main.hs` — the library is where the work happens. This adds `-O2` to the library.
- Factor shared flags into two `common` stanzas (cabal-version 2.4) so the four stanzas (library / exe / tests / benchmark) stop drifting apart and have explicit, consistent flag sets:
  - `warnings`    → `-Wall -O2` — applied everywhere
  - `rtsdefaults` → `-threaded -rtsopts -with-rtsopts=-N` — applied to exe and tests (not library or bench, where they're meaningless)
- Move compile-time speedups out of the executable stanza, where they were misplaced. `-j` and `+RTS -A128m -RTS` are for GHC's own invocation during compilation, not for the resulting binary. They now live in `cabal.project` alongside `jobs: $ncpus`, so they apply uniformly to every package build.

## Before / after

| stanza | before | after |
|---|---|---|
| library | `-Wall` | `-Wall -O2` |
| exe `volca` | `-threaded -rtsopts -with-rtsopts=-N -Wall -O2 -j +RTS -A128m -RTS` | `-Wall -O2 -threaded -rtsopts -with-rtsopts=-N` |
| test-suite | `-threaded -rtsopts -with-rtsopts=-N` | `-Wall -O2 -threaded -rtsopts -with-rtsopts=-N` |
| benchmark | `-O2 -rtsopts -with-rtsopts=-A32m` | `-Wall -O2 -rtsopts -with-rtsopts=-A32m` |

`cabal.project` gains:

```
jobs: $ncpus
program-options
  ghc-options: -j +RTS -A128m -RTS
```

## Note

The `multi-method-bench` benchmark has a **pre-existing** type error in `bench/MultiMethodBench.hs` (`computeLCIAScoreSetFromTables`'s 6th argument signature drifted). It is unrelated to this refactor — verified by stashing the change and re-running `cabal build --enable-benchmarks` against `9643c93`. Out of scope here.

## Test plan

- [x] `cabal build all` → library + exe build cleanly with the new `-O2`
- [x] `cabal build --enable-tests test:lca-tests` → test-suite builds
- [ ] Run `cabal test` once locally to confirm tests still pass with `-O2`
- [ ] Benchmark fix tracked separately