### PR TITLE
fix(bench): realign multi-method-bench with current scoring API

### DIFF
--- a/bench/MultiMethodBench.hs
+++ b/bench/MultiMethodBench.hs
@@ -20,6 +20,7 @@ Speedup ratios:
 module Main (main) where
 
 import Criterion.Main
+import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -172,7 +173,7 @@ buildFixture mkCfFn unitCfg =
             ]
 
         methods = [mkMethod m [] | m <- [1 .. nMethods]] -- factors don't matter, mappings drive build
-        rawTables = [buildMethodTables (mappingsFor s) | s <- [1 .. nMethods]]
+        rawTables = [buildMethodTables M.empty (mappingsFor s) | s <- [1 .. nMethods]]
         filledTables = map (fillBroadcastVector unitCfg unitDB flowDB) rawTables
         setTables = buildMethodSetTables (zip methods filledTables)
 
@@ -200,48 +201,51 @@ buildFixture mkCfFn unitCfg =
 -- | Score one inventory against ONE method (the 1st in the list), legacy cascade.
 benchMonoCascade :: Fixture -> Double
 benchMonoCascade fx =
-    computeLCIAScoreFromTables
-        (fxUnitCfg fx)
-        (fxUnitDB fx)
-        (fxFlowDB fx)
-        (fxInventory fx)
-        (head (fxRawTables fx))
+    loScore $
+        computeLCIAScoreFromTables
+            (fxUnitCfg fx)
+            (fxUnitDB fx)
+            (fxFlowDB fx)
+            (fxInventory fx)
+            (head (fxRawTables fx))
 
 -- | Score one inventory against ONE method, broadcast filled (Phase 1).
 benchMonoBroadcast :: Fixture -> Double
 benchMonoBroadcast fx =
-    computeLCIAScoreFromTables
-        (fxUnitCfg fx)
-        (fxUnitDB fx)
-        (fxFlowDB fx)
-        (fxInventory fx)
-        (head (fxFilledTables fx))
+    loScore $
+        computeLCIAScoreFromTables
+            (fxUnitCfg fx)
+            (fxUnitDB fx)
+            (fxFlowDB fx)
+            (fxInventory fx)
+            (head (fxFilledTables fx))
 
 -- | Score the same inventory once per method, sequential — what the HTTP route
 -- does with mapConcurrently sans the parallelism overhead.
 benchMonoFanout :: Fixture -> [Double]
 benchMonoFanout fx =
-    [ computeLCIAScoreFromTables
-        (fxUnitCfg fx)
-        (fxUnitDB fx)
-        (fxFlowDB fx)
-        (fxInventory fx)
-        t
+    [ loScore $
+        computeLCIAScoreFromTables
+            (fxUnitCfg fx)
+            (fxUnitDB fx)
+            (fxFlowDB fx)
+            (fxInventory fx)
+            t
     | t <- fxFilledTables fx
     ]
 
 -- | Score all methods at once via stacked-broadcast matvec (Phase 2).
+-- No regional methods → 'scoreRegionalCrossDB' never inspects the triple,
+-- so the unused Database / empty scaling vector are never forced.
 benchSetBatched :: Fixture -> [(UUID, Either Text Double)]
 benchSetBatched fx =
     computeLCIAScoreSetFromTables
         (fxUnitCfg fx)
         (fxUnitDB fx)
         (fxFlowDB fx)
-        unusedDatabase
-        U.empty
         (fxInventory fx)
         M.empty
-        (fxSetTables fx)
+        ((unusedDatabase, U.empty, fxSetTables fx) :| [])
 
 main :: IO ()
 main = do


### PR DESCRIPTION
## Summary

The `multi-method-bench` benchmark stopped compiling after three upstream signature changes that never propagated to `bench/MultiMethodBench.hs`:

1. **`buildMethodTables` gained a `CompartmentMap` first argument.** Pass `M.empty` — the bench has no compartments (same convention as `MappingSpec`).
2. **`computeLCIAScoreFromTables` now returns `LCIAOutcome` instead of `Double`.** Extract `.loScore` from each call so the bench functions keep their existing `Double` / `[Double]` return shapes (and `nf` continues to deepseq a fully-evaluated scalar).
3. **`computeLCIAScoreSetFromTables` now takes a `NonEmpty (Database, Vector, MethodSetTables)`** instead of three separate arguments. Pack the bench's `(unusedDatabase, U.empty, fxSetTables)` into a singleton `NonEmpty`. The fixture has no regional methods, so `scoreRegionalCrossDB` walks an empty `msRegional` and never forces the unused Database / empty scaling vector.

## Why this matters

Without this, `cabal build --enable-benchmarks all` fails, and the Phase 1 / Phase 2 LCIA scoring speedups can't be measured. The benchmark is the primary regression check for those optimizations.

## Test plan

- [x] `cabal build --enable-benchmarks bench:multi-method-bench` → compiles cleanly
- [x] `cabal run bench:multi-method-bench -- --time-limit 0.5` → all four bgroups run, Phase 2 `set batched` matvec is ~2× the per-method fanout (matches docstring expectation)