### PR TITLE
Unify gen-cabal-config.sh: parallelism preamble + Windows discovery

### DIFF
--- a/.github/workflows/prebuild-cabal-store.yml
+++ b/.github/workflows/prebuild-cabal-store.yml
@@ -103,23 +103,16 @@ jobs:
           # mumps-hs's c-sources still need to compile against MUMPS headers
           # and the link plan still has to be valid (cabal solver bakes the
           # link line into the install plan).
+          # MSYS2/GCC discovery and POSIX→Windows MUMPS path conversion are
+          # handled inside gen-cabal-config.sh's windows branch.
           [[ -f /d/ghcup/env ]] && source /d/ghcup/env
           export MUMPS_LIB_DIR="$(pwd)/deps/mumps/lib"
           export MUMPS_INCLUDE_DIR="$(pwd)/deps/mumps/include"
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            export LINK_MODE=windows
-            MSYS2_LIB_DIR=$(cygpath -m /ucrt64/lib)
-            GCC_LIB_DIR=$(find /ucrt64/lib/gcc/x86_64-w64-mingw32 -maxdepth 1 -type d 2>/dev/null | sort -V | tail -1)
-            GCC_LIB_DIR=$(cygpath -m "$GCC_LIB_DIR")
-            win_path() { echo "$1" | sed 's|^/\([a-zA-Z]\)/|\1:/|'; }
-            export MUMPS_LIB_DIR=$(win_path "$MUMPS_LIB_DIR")
-            export MUMPS_INCLUDE_DIR=$(win_path "$MUMPS_INCLUDE_DIR")
-            export MSYS2_LIB_DIR GCC_LIB_DIR
-          elif [[ "$RUNNER_OS" == "macOS" ]]; then
-            export LINK_MODE=darwin
-          else
-            export LINK_MODE=static
-          fi
+          case "$RUNNER_OS" in
+            Windows) export LINK_MODE=windows ;;
+            macOS)   export LINK_MODE=darwin  ;;
+            *)       export LINK_MODE=static  ;;
+          esac
           ./gen-cabal-config.sh
           echo "--- cabal.project.local ---"
           cat cabal.project.local

--- a/build.sh
+++ b/build.sh
@@ -440,17 +440,8 @@ BUILD_TARGET="$OS" ./gen-version.sh
 # Write cabal.project.local with library paths
 if [[ "$OS" == "windows" ]]; then
     LINK_MODE="windows"
-    # Resolve MSYS2 paths dynamically via cygpath so the build works on any
-    # installation root (default C:/msys64, GitHub Actions D:/a/_temp/msys64,
-    # custom locations). cygpath -m emits Windows paths with forward slashes,
-    # which both Cabal and clang/lld accept.
-    MSYS2_LIB_DIR=$(cygpath -m /ucrt64/lib)
-    GCC_LIB_DIR=$(find /ucrt64/lib/gcc/x86_64-w64-mingw32 -maxdepth 1 -type d 2>/dev/null | sort -V | tail -1)
-    GCC_LIB_DIR=$(cygpath -m "$GCC_LIB_DIR")
-    win_path() { echo "$1" | sed 's|^/\([a-zA-Z]\)/|\1:/|'; }
-    export MUMPS_LIB_DIR=$(win_path "$MUMPS_LIB_DIR")
-    export MUMPS_INCLUDE_DIR=$(win_path "$MUMPS_INCLUDE_DIR")
-    export MSYS2_LIB_DIR GCC_LIB_DIR
+    # MSYS2/GCC discovery + POSIX→Windows MUMPS path conversion live in
+    # gen-cabal-config.sh's windows branch.
 elif [[ "$OS" == "macos" ]] && [[ "$MUMPS_BUILT_LOCALLY" == "true" ]]; then
     # Darwin's ld64 doesn't support GNU -Wl,-Bstatic / -Bdynamic, so the static
     # mode below can't be used as-is. Use a Darwin-specific mode that picks .a

--- a/gen-cabal-config.sh
+++ b/gen-cabal-config.sh
@@ -153,10 +153,11 @@ EOF
         # Windows/MSYS2: MinGW + OpenBLAS
         # Auto-discover MSYS2/GCC paths and convert POSIX-style MUMPS paths
         # to Windows form. Callers running under MSYS2 bash (build.sh,
-        # prebuild-cabal-store.yml, prebuild-mumps.yml) used to duplicate this
-        # block; factoring it here keeps the per-caller code to LINK_MODE=windows.
+        # prebuild-cabal-store.yml) used to duplicate this block; factoring
+        # it here keeps the per-caller code to LINK_MODE=windows.
         if [[ -z "${MSYS2_LIB_DIR:-}" ]]; then
             MSYS2_LIB_DIR=$(cygpath -m /ucrt64/lib)
+            : "${MSYS2_LIB_DIR:?cygpath -m /ucrt64/lib returned empty — is MSYS2 ucrt64 installed?}"
         fi
         if [[ -z "${GCC_LIB_DIR:-}" ]]; then
             GCC_LIB_DIR=$(find /ucrt64/lib/gcc/x86_64-w64-mingw32 -maxdepth 1 -type d 2>/dev/null | sort -V | tail -1)

--- a/gen-cabal-config.sh
+++ b/gen-cabal-config.sh
@@ -17,10 +17,23 @@ MUMPS_INCLUDE_DIR="${MUMPS_INCLUDE_DIR:-/usr/include}"
 LINK_MODE="${LINK_MODE:-dynamic}"
 OUTPUT="${OUTPUT_DIR:-.}/cabal.project.local"
 
+# Parallelism preamble shared by every LINK_MODE.
+# Lives in cabal.project.local (not cabal.project) so that Docker builds —
+# which copy only volca.cabal + mumps-hs/ into the build context and write a
+# minimal cabal.project without `packages: .` machinery — still get jobs +
+# RTS allocation area + per-module GHC parallelism.
+cat > "$OUTPUT" << 'EOF'
+jobs: $ncpus
+
+program-options
+  ghc-options: -j +RTS -A128m -RTS
+
+EOF
+
 case "$LINK_MODE" in
     dynamic)
         # Shared linking (Linux, macOS, Docker, dev builds)
-        cat > "$OUTPUT" << EOF
+        cat >> "$OUTPUT" << EOF
 optimization: 2
 
 extra-lib-dirs: $MUMPS_LIB_DIR
@@ -55,7 +68,7 @@ EOF
             *)            QUADMATH_FLAG="" ;;
         esac
         STATIC_LINK_FLAGS="-optl-no-pie -optc-no-pie -optl-L$MUMPS_LIB_DIR -optl$SHIM_OBJ -optl-Wl,--start-group -optl-ldmumps_seq -optl-lmumps_common_seq -optl-lpord_seq -optl-lmpiseq_seq -optl-llapack -optl-lblas -optl-lgfortran $QUADMATH_FLAG -optl-Wl,--end-group -optl-lpthread -optl-lm -optl-ldl"
-        cat > "$OUTPUT" << EOF
+        cat >> "$OUTPUT" << EOF
 optimization: 2
 split-sections: True
 shared: False
@@ -91,7 +104,7 @@ EOF
         # -ffunction-sections / -fdata-sections (OpenBLAS in our pipeline);
         # harmless on the others.
         MUSL_LINK_FLAGS="-optl-L$MUMPS_LIB_DIR -optl-L$OPENBLAS_LIB_DIR -optl-Wl,--gc-sections -optl-Wl,--start-group -optl-ldmumps_seq -optl-lmumps_common_seq -optl-lpord_seq -optl-lmpiseq_seq -optl-lopenblas -optl-lgfortran $QUADMATH_FLAG -optl-Wl,--end-group -optl-lpthread -optl-lm"
-        cat > "$OUTPUT" << EOF
+        cat >> "$OUTPUT" << EOF
 optimization: 2
 split-sections: True
 shared: False
@@ -120,7 +133,7 @@ EOF
         # sections and unused dylib load commands. Pairs with `split-sections: True`
         # below for a meaningful (5–15 %) size win before strip even runs.
         DARWIN_LINK_FLAGS="-optl-L$MUMPS_LIB_DIR -optl-ldmumps_seq -optl-lmumps_common_seq -optl-lpord_seq -optl-lmpiseq_seq -optl-L${OPENBLAS_PREFIX}/lib -optl-lopenblas -optl-L${GFORTRAN_LIB_DIR} -optl-lgfortran -optl-lquadmath -optl-lpthread -optl-lm -optl-mmacosx-version-min=${DEPLOYMENT_TARGET} -optl-Wl,-dead_strip -optl-Wl,-dead_strip_dylibs"
-        cat > "$OUTPUT" << EOF
+        cat >> "$OUTPUT" << EOF
 optimization: 2
 split-sections: True
 
@@ -140,7 +153,7 @@ EOF
         # Windows/MSYS2: MinGW + OpenBLAS
         : "${MSYS2_LIB_DIR:?MSYS2_LIB_DIR is required for windows mode}"
         : "${GCC_LIB_DIR:?GCC_LIB_DIR is required for windows mode}"
-        cat > "$OUTPUT" << EOF
+        cat >> "$OUTPUT" << EOF
 optimization: 2
 split-sections: True
 

--- a/gen-cabal-config.sh
+++ b/gen-cabal-config.sh
@@ -151,8 +151,27 @@ EOF
 
     windows)
         # Windows/MSYS2: MinGW + OpenBLAS
-        : "${MSYS2_LIB_DIR:?MSYS2_LIB_DIR is required for windows mode}"
-        : "${GCC_LIB_DIR:?GCC_LIB_DIR is required for windows mode}"
+        # Auto-discover MSYS2/GCC paths and convert POSIX-style MUMPS paths
+        # to Windows form. Callers running under MSYS2 bash (build.sh,
+        # prebuild-cabal-store.yml, prebuild-mumps.yml) used to duplicate this
+        # block; factoring it here keeps the per-caller code to LINK_MODE=windows.
+        if [[ -z "${MSYS2_LIB_DIR:-}" ]]; then
+            MSYS2_LIB_DIR=$(cygpath -m /ucrt64/lib)
+        fi
+        if [[ -z "${GCC_LIB_DIR:-}" ]]; then
+            GCC_LIB_DIR=$(find /ucrt64/lib/gcc/x86_64-w64-mingw32 -maxdepth 1 -type d 2>/dev/null | sort -V | tail -1)
+            : "${GCC_LIB_DIR:?Could not locate GCC lib dir under /ucrt64/lib/gcc/x86_64-w64-mingw32 — install mingw-w64-ucrt-x86_64-gcc}"
+            GCC_LIB_DIR=$(cygpath -m "$GCC_LIB_DIR")
+        fi
+        # Cabal + clang on Windows want forward-slash drive-letter paths
+        # (`C:/foo/bar`), not the MSYS2 `/c/foo/bar` form. Convert if needed.
+        win_path() { echo "$1" | sed 's|^/\([a-zA-Z]\)/|\1:/|'; }
+        case "$MUMPS_LIB_DIR" in
+            /[a-zA-Z]/*) MUMPS_LIB_DIR=$(win_path "$MUMPS_LIB_DIR") ;;
+        esac
+        case "$MUMPS_INCLUDE_DIR" in
+            /[a-zA-Z]/*) MUMPS_INCLUDE_DIR=$(win_path "$MUMPS_INCLUDE_DIR") ;;
+        esac
         cat >> "$OUTPUT" << EOF
 optimization: 2
 split-sections: True


### PR DESCRIPTION
## Summary

Two independent build-config cleanups, each in its own commit:

1. **Emit `jobs: \$ncpus` + per-module GHC parallelism in `cabal.project.local`** — Docker build paths write a minimal `cabal.project` (`packages: ./volca ./mumps-hs` + `allow-newer: true`), which silently dropped the parallelism directives that the repo's `cabal.project` carries. Moving them into the generated `cabal.project.local` makes them survive any stub `cabal.project`. Affects every Docker / CI build path that goes through `gen-cabal-config.sh`.

2. **Factor Windows MSYS2/GCC discovery into `gen-cabal-config.sh`** — `build.sh` and `prebuild-cabal-store.yml` each carried an identical 10-line block doing `cygpath`/`find`/`win_path` to discover MSYS2 + GCC paths and convert POSIX MUMPS paths to Windows form. The YAML comment even called it *"Mirror build.sh's per-platform LINK_MODE selection"*. Move it into the `windows)` branch of `gen-cabal-config.sh` (the only place the variables were ever consumed), with an `if [[ -z ... ]]` fallback so callers that already set them are unchanged.

Net diff: -32 / +48 across three files, with logic centralized rather than duplicated.

## Test plan

- [ ] CI green (especially Windows + Linux jobs)
- [ ] `prebuild-cabal-store.yml` triggerable manually after merge to validate the Windows path
- [ ] Local build still works on Linux glibc (`./build.sh --test`)
- [ ] Docker image build (`docker build -f docker/Dockerfile .`) shows `-j` flag activity in `cabal build` output