### PR TITLE
ci: add Alpine/musl support to setup-haskell-env + build.sh (foundation)

### DIFF
--- a/.github/actions/setup-haskell-env/action.yml
+++ b/.github/actions/setup-haskell-env/action.yml
@@ -62,8 +62,23 @@ runs:
         source /d/ghcup/env
         ghc --version && cabal --version && cabal update
 
-    - name: Install build dependencies (Linux)
+    # Auto-detect runtime libc on Linux. Workflows that opt into
+    # `container: alpine:3.19` get musl; the default ubuntu-latest runner
+    # gets glibc. This drives apt-vs-apk + OpenBLAS source-build branching
+    # below, with no caller-side change required.
+    - name: Detect Linux libc
       if: inputs.matrix-os == 'linux'
+      id: libc
+      shell: sh
+      run: |
+        if [ -f /etc/alpine-release ]; then
+          echo "libc=musl" >> "$GITHUB_OUTPUT"
+        else
+          echo "libc=glibc" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Install build dependencies (Linux glibc)
+      if: inputs.matrix-os == 'linux' && steps.libc.outputs.libc == 'glibc'
       shell: bash
       run: |
         sudo apt-get update
@@ -90,6 +105,68 @@ runs:
             fi
           fi
         fi
+
+    # Alpine containers run as root and have no apt/sudo — install everything
+    # via apk. Mirrors the package list from docker/Dockerfile.musl, the only
+    # other place we build volca against musl. `*-static` packages ship the
+    # .a variants required by `executable-static`. github-cli is needed for
+    # the workflow's `gh release download` steps.
+    - name: Install build dependencies (Linux musl)
+      if: inputs.matrix-os == 'linux' && steps.libc.outputs.libc == 'musl'
+      shell: sh
+      run: |
+        apk add --no-cache \
+          bash binutils curl file git tar xz perl python3 make cmake pkgconfig \
+          linux-headers musl-dev libc-dev \
+          gcc g++ gfortran \
+          gmp-dev libffi-dev \
+          ncurses-dev ncurses-static \
+          zlib-dev zlib-static \
+          zstd-dev zstd-static \
+          xz-dev xz-static \
+          github-cli \
+          ${{ inputs.install-upx == 'true' && 'upx' || '' }}
+
+    # OpenBLAS source-build on Alpine: Alpine's lapack-dev / blas-dev ship
+    # .so only, so a static link can't resolve -llapack / -lblas. OpenBLAS
+    # bundles both BLAS and LAPACK into a single libopenblas.a — one source
+    # build replaces both. Knobs match docker/Dockerfile.musl so the CI
+    # binary is bit-for-bit comparable to the Docker image one.
+    #
+    # Cached on (matrix-name, OPENBLAS_VERSION) so an unchanged version
+    # reuses the previous build in ~5 s instead of compiling for ~8 min.
+    # Cache invalidates automatically on every versions.env edit.
+    - name: Restore OpenBLAS build (Linux musl)
+      if: inputs.matrix-os == 'linux' && steps.libc.outputs.libc == 'musl' && inputs.ghc-version != ''
+      id: cache-openblas
+      uses: actions/cache@v4
+      with:
+        path: deps/openblas
+        key: openblas-${{ inputs.matrix-name }}-${{ hashFiles('versions.env') }}-v1
+
+    - name: Build OpenBLAS (Linux musl)
+      if: inputs.matrix-os == 'linux' && steps.libc.outputs.libc == 'musl' && inputs.ghc-version != '' && steps.cache-openblas.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        source versions.env
+        SRC="/tmp/OpenBLAS-${OPENBLAS_VERSION}"
+        curl -fsSL "https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.tar.gz" \
+          | tar -xz -C /tmp
+        cd "$SRC"
+        make -j"$(nproc)" \
+          NO_SHARED=1 \
+          USE_THREAD=1 USE_OPENMP=0 \
+          DYNAMIC_ARCH=1 \
+          TARGET=GENERIC
+        make PREFIX="$GITHUB_WORKSPACE/deps/openblas" NO_SHARED=1 install
+        rm -rf "$SRC"
+
+    - name: Export OpenBLAS paths (Linux musl)
+      if: inputs.matrix-os == 'linux' && steps.libc.outputs.libc == 'musl' && inputs.ghc-version != ''
+      shell: sh
+      run: |
+        echo "OPENBLAS_LIB_DIR=$GITHUB_WORKSPACE/deps/openblas/lib" >> "$GITHUB_ENV"
+        echo "OPENBLAS_INCLUDE_DIR=$GITHUB_WORKSPACE/deps/openblas/include" >> "$GITHUB_ENV"
 
     - name: Install build dependencies (macOS)
       if: inputs.matrix-os == 'macos'

--- a/.github/actions/setup-haskell-env/action.yml
+++ b/.github/actions/setup-haskell-env/action.yml
@@ -111,6 +111,11 @@ runs:
     # other place we build volca against musl. `*-static` packages ship the
     # .a variants required by `executable-static`. github-cli is needed for
     # the workflow's `gh release download` steps.
+    #
+    # IMPORTANT ordering invariant: this step installs bash on the Alpine
+    # image. Every later step on the musl path uses `shell: bash`; every
+    # step before it (e.g. "Detect Linux libc") must use `shell: sh`. Do
+    # not reorder.
     - name: Install build dependencies (Linux musl)
       if: inputs.matrix-os == 'linux' && steps.libc.outputs.libc == 'musl'
       shell: sh

--- a/build.sh
+++ b/build.sh
@@ -457,6 +457,13 @@ elif [[ "$OS" == "macos" ]] && [[ "$MUMPS_BUILT_LOCALLY" == "true" ]]; then
     # libs from extra-lib-dirs (ld64's natural fallback) and pulls Fortran
     # runtime + openblas via -L/-l flags.
     LINK_MODE="darwin"
+elif [[ -f /etc/alpine-release ]] && { [[ "$STATIC_BUILD" == "true" ]] || [[ "$MUMPS_BUILT_LOCALLY" == "true" ]]; }; then
+    # Alpine host (musl libc): produce a fully-static binary linked against
+    # musl + OpenBLAS-from-source. The glibc-static `static` mode below
+    # doesn't apply — its link line references libquadmath/libgfortran/.a
+    # that the system doesn't expose, and its glibc shim is moot under musl.
+    LINK_MODE="musl"
+    : "${OPENBLAS_LIB_DIR:?OPENBLAS_LIB_DIR required for musl builds (path to libopenblas.a — build via prebuild-openblas or apk add openblas-static + headers)}"
 elif [[ "$STATIC_BUILD" == "true" ]] || [[ "$MUMPS_BUILT_LOCALLY" == "true" ]]; then
     # Static linking required when using locally-built MUMPS (only .a libs available)
     LINK_MODE="static"

--- a/versions.env
+++ b/versions.env
@@ -17,6 +17,13 @@ MUMPS_VERSION=5.8.1
 # value forces every CI run to use the freshly-built archives.
 MUMPS_PREBUILT_REVISION=1
 
+# OpenBLAS (built from source when Linux + musl static linking — Alpine
+# ships BLAS/LAPACK as shared libs only, so a static link can't resolve
+# -llapack / -lblas. OpenBLAS bundles both into one libopenblas.a, fixing
+# this with a single source build. Consumed by setup-haskell-env's Alpine
+# branch and by docker/Dockerfile's musl runtime image.
+OPENBLAS_VERSION=0.3.27
+
 # Downloaded dependencies (fetched and built by build scripts)
 PETSC_VERSION=3.24.2
 


### PR DESCRIPTION
## Summary

Foundation PR for moving the Linux release binary from glibc-static to musl. Same motivation as the recent Docker switch ([#49](https://github.com/ccomb/volca/pull/49)): a glibc-static binary is not truly portable across distros, while a musl-static binary runs unchanged on any Linux host.

This PR loads the gun without firing it:

1. **\`setup-haskell-env\`** now auto-detects the runtime libc via \`/etc/alpine-release\`. On Alpine (workflows opting into \`container: alpine:3.19\`), it installs build deps via \`apk\` and source-builds OpenBLAS (cached on \`hashFiles('versions.env')\`). On plain \`ubuntu-latest\`, the existing \`apt\` path is unchanged.

2. **\`build.sh\`** auto-selects \`LINK_MODE=musl\` when \`/etc/alpine-release\` exists and MUMPS is locally-built. So \`./build.sh --test\` produces a musl binary on Alpine and a glibc-static one on Ubuntu, with no caller-side knob.

3. **\`OPENBLAS_VERSION=0.3.27\`** added to \`versions.env\` as the single source of truth for the pin (was hardcoded as \`ARG OPENBLAS_VERSION\` in \`docker/Dockerfile.musl\`).

**No workflow file is changed in this PR.** The apt/glibc path is still the default; existing CI behaviour is identical.

## What comes next (separate PR)

Flip the Linux jobs in \`_build-matrix.yml\`, \`prebuild-mumps.yml\`, and \`prebuild-cabal-store.yml\` to \`container: alpine:3.19\`. That exercises the new path; the release binary becomes musl-static, matching the Docker image.

## Test plan

Hard to test without firing the next PR — the new code paths only activate on Alpine. Verifies:
- [ ] Diff is reviewable in isolation
- [ ] Existing CI still passes (foundation is no-op for ubuntu-latest runners)