### PR TITLE
ci: flip Linux jobs to Alpine/musl

### DIFF
--- a/.github/actions/setup-haskell-env/action.yml
+++ b/.github/actions/setup-haskell-env/action.yml
@@ -121,7 +121,7 @@ runs:
       shell: sh
       run: |
         apk add --no-cache \
-          bash binutils curl file git tar xz perl python3 make cmake pkgconfig \
+          bash coreutils binutils curl file git tar xz perl python3 make cmake pkgconfig \
           linux-headers musl-dev libc-dev \
           gcc g++ gfortran \
           gmp-dev libffi-dev \

--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -46,9 +46,12 @@ jobs:
             runner: ubuntu-latest
             container: alpine:3.19
             os: linux
+          # linux-arm64 stays on Ubuntu/glibc-static: ghcup has no Alpine
+          # aarch64 bindist for GHC 9.6.7 (Alpine arm64 first appeared in
+          # 9.8.2), and the source-build fallback fails. amd64 keeps the
+          # musl path for fully-portable release binaries.
           - name: linux-arm64
             runner: ubuntu-24.04-arm
-            container: alpine:3.19
             os: linux
           - name: windows-amd64
             runner: windows-latest
@@ -72,8 +75,10 @@ jobs:
       # ("JavaScript Actions in Alpine containers are only supported on x64
       # Linux runners"). This composite action drops a patched gcompat shim
       # into /lib and masks /etc/os-release so the runner stops detecting
-      # Alpine. No-op on amd64 (internal `runner.arch == 'ARM64'` guard).
-      - if: matrix.os == 'linux'
+      # Alpine. Gated on `matrix.container` so it does not run (and try to
+      # `apk add`) on the Ubuntu/glibc arm64 path. The action's own
+      # `runner.arch == 'ARM64'` guard makes it a no-op on amd64.
+      - if: matrix.container == 'alpine:3.19'
         uses: laverdet/alpine-arm64@v1
       - uses: actions/checkout@v4
 

--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -25,6 +25,14 @@ jobs:
   build:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
+    # Linux jobs run in an Alpine container so the released binary links
+    # against musl libc — truly portable across distros (vs. glibc-static,
+    # which leaks dlopen/getaddrinfo dependencies and needs the
+    # cbits/static-shims.c workaround for glibc 2.32+). Windows/macOS keep
+    # running on the bare runner — GH macOS hosts cannot run containers,
+    # and Windows uses MSYS2 instead of a Linux container. setup-haskell-env
+    # auto-detects /etc/alpine-release and branches apt vs apk accordingly.
+    container: ${{ matrix.container }}
     # Catches genuine hangs without false-failing legitimate cold builds.
     # Windows cold path (MSYS2 + GHCup install + cold cabal compile + 25-min
     # test step) tops out around 50 min; 60 min gives ~10 min headroom while
@@ -36,9 +44,11 @@ jobs:
         include:
           - name: linux-amd64
             runner: ubuntu-latest
+            container: alpine:3.19
             os: linux
           - name: linux-arm64
             runner: ubuntu-24.04-arm
+            container: alpine:3.19
             os: linux
           - name: windows-amd64
             runner: windows-latest
@@ -59,17 +69,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # POSIX `sh` here — bash isn't preinstalled in the Alpine container
+      # we now use for Linux jobs (setup-haskell-env apk-installs it below).
+      # All the work these two steps do is POSIX-compatible already.
       - name: Read pinned versions
         id: versions
-        shell: bash
+        shell: sh
         run: |
-          source versions.env
+          . versions.env
           echo "ghc=$GHC_VERSION" >> "$GITHUB_OUTPUT"
           echo "mumps=$MUMPS_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Read engine version from cabal
         id: cabal-version
-        shell: bash
+        shell: sh
         run: |
           ver=$(awk '/^version:/ {print $2; exit}' volca.cabal)
           echo "version=$ver" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -89,7 +89,10 @@ jobs:
         id: versions
         shell: sh
         run: |
-          . versions.env
+          # `./` so dash (Ubuntu /bin/sh) doesn't PATH-search for the file —
+          # POSIX `.` builtin only skips PATH when the operand contains a slash.
+          # Alpine's BusyBox ash is more lenient but the slash form works for both.
+          . ./versions.env
           echo "ghc=$GHC_VERSION" >> "$GITHUB_OUTPUT"
           echo "mumps=$MUMPS_VERSION" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -67,6 +67,14 @@ jobs:
       run:
         shell: ${{ matrix.os == 'windows' && 'msys2 {0}' || 'bash' }}
     steps:
+      # GitHub's JavaScript actions (checkout, cache, …) ship a glibc-linked
+      # Node binary which refuses to run in an Alpine container on ARM64
+      # ("JavaScript Actions in Alpine containers are only supported on x64
+      # Linux runners"). This composite action drops a patched gcompat shim
+      # into /lib and masks /etc/os-release so the runner stops detecting
+      # Alpine. No-op on amd64 (internal `runner.arch == 'ARM64'` guard).
+      - if: matrix.os == 'linux'
+        uses: laverdet/alpine-arm64@v1
       - uses: actions/checkout@v4
 
       # POSIX `sh` here — bash isn't preinstalled in the Alpine container

--- a/.github/workflows/prebuild-cabal-store.yml
+++ b/.github/workflows/prebuild-cabal-store.yml
@@ -28,15 +28,21 @@ jobs:
   build:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
+    # Linux jobs prebuild the cabal store in Alpine so the cached
+    # ~/.cabal/store is linked against musl libc — matches what
+    # _build-matrix.yml consumes. See _build-matrix.yml for context.
+    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: linux-amd64
             runner: ubuntu-latest
+            container: alpine:3.19
             os: linux
           - name: linux-arm64
             runner: ubuntu-24.04-arm
+            container: alpine:3.19
             os: linux
           - name: windows-amd64
             runner: windows-latest
@@ -54,11 +60,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # POSIX `sh` here — bash isn't preinstalled in the Alpine container
+      # we now use for Linux jobs (setup-haskell-env apk-installs it below).
       - name: Read pinned versions
         id: versions
-        shell: bash
+        shell: sh
         run: |
-          source versions.env
+          . versions.env
           echo "ghc=$GHC_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Setup Haskell build environment
@@ -111,7 +119,11 @@ jobs:
           case "$RUNNER_OS" in
             Windows) export LINK_MODE=windows ;;
             macOS)   export LINK_MODE=darwin  ;;
-            *)       export LINK_MODE=static  ;;
+            *)       if [[ -f /etc/alpine-release ]]; then
+                       export LINK_MODE=musl
+                     else
+                       export LINK_MODE=static
+                     fi ;;
           esac
           ./gen-cabal-config.sh
           echo "--- cabal.project.local ---"

--- a/.github/workflows/prebuild-cabal-store.yml
+++ b/.github/workflows/prebuild-cabal-store.yml
@@ -40,9 +40,9 @@ jobs:
             runner: ubuntu-latest
             container: alpine:3.19
             os: linux
+          # arm64 stays Ubuntu/glibc — see _build-matrix.yml for context.
           - name: linux-arm64
             runner: ubuntu-24.04-arm
-            container: alpine:3.19
             os: linux
           - name: windows-amd64
             runner: windows-latest
@@ -60,7 +60,7 @@ jobs:
     steps:
       # See _build-matrix.yml for context: GH's JS actions need a glibc Node
       # and won't run in Alpine arm64 without this gcompat + os-release mask.
-      - if: matrix.os == 'linux'
+      - if: matrix.container == 'alpine:3.19'
         uses: laverdet/alpine-arm64@v1
       - uses: actions/checkout@v4
 

--- a/.github/workflows/prebuild-cabal-store.yml
+++ b/.github/workflows/prebuild-cabal-store.yml
@@ -58,6 +58,10 @@ jobs:
       run:
         shell: ${{ matrix.os == 'windows' && 'msys2 {0}' || 'bash' }}
     steps:
+      # See _build-matrix.yml for context: GH's JS actions need a glibc Node
+      # and won't run in Alpine arm64 without this gcompat + os-release mask.
+      - if: matrix.os == 'linux'
+        uses: laverdet/alpine-arm64@v1
       - uses: actions/checkout@v4
 
       # POSIX `sh` here — bash isn't preinstalled in the Alpine container

--- a/.github/workflows/prebuild-cabal-store.yml
+++ b/.github/workflows/prebuild-cabal-store.yml
@@ -70,7 +70,8 @@ jobs:
         id: versions
         shell: sh
         run: |
-          . versions.env
+          # See _build-matrix.yml: `./` keeps dash from PATH-searching.
+          . ./versions.env
           echo "ghc=$GHC_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Setup Haskell build environment

--- a/.github/workflows/prebuild-mumps.yml
+++ b/.github/workflows/prebuild-mumps.yml
@@ -35,9 +35,9 @@ jobs:
             runner: ubuntu-latest
             container: alpine:3.19
             os: linux
+          # arm64 stays Ubuntu/glibc — see _build-matrix.yml for context.
           - name: linux-arm64
             runner: ubuntu-24.04-arm
-            container: alpine:3.19
             os: linux
           - name: windows-amd64
             runner: windows-latest
@@ -55,7 +55,7 @@ jobs:
     steps:
       # See _build-matrix.yml for context: GH's JS actions need a glibc Node
       # and won't run in Alpine arm64 without this gcompat + os-release mask.
-      - if: matrix.os == 'linux'
+      - if: matrix.container == 'alpine:3.19'
         uses: laverdet/alpine-arm64@v1
       - uses: actions/checkout@v4
 

--- a/.github/workflows/prebuild-mumps.yml
+++ b/.github/workflows/prebuild-mumps.yml
@@ -23,15 +23,21 @@ jobs:
   build:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
+    # Linux jobs build MUMPS in Alpine so the archive is musl-compatible
+    # (no glibc symbols leaking into libdmumps_seq.a). See _build-matrix.yml
+    # for the wider context. Windows/macOS keep running on the bare runner.
+    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: linux-amd64
             runner: ubuntu-latest
+            container: alpine:3.19
             os: linux
           - name: linux-arm64
             runner: ubuntu-24.04-arm
+            container: alpine:3.19
             os: linux
           - name: windows-amd64
             runner: windows-latest

--- a/.github/workflows/prebuild-mumps.yml
+++ b/.github/workflows/prebuild-mumps.yml
@@ -53,6 +53,10 @@ jobs:
       run:
         shell: ${{ matrix.os == 'windows' && 'msys2 {0}' || 'bash' }}
     steps:
+      # See _build-matrix.yml for context: GH's JS actions need a glibc Node
+      # and won't run in Alpine arm64 without this gcompat + os-release mask.
+      - if: matrix.os == 'linux'
+        uses: laverdet/alpine-arm64@v1
       - uses: actions/checkout@v4
 
       - name: Setup build environment (no GHC)

--- a/versions.env
+++ b/versions.env
@@ -15,7 +15,7 @@ MUMPS_VERSION=5.8.1
 # output to a GH Release tagged `mumps-prebuilt-${MUMPS_VERSION}-r${REV}`,
 # and `_build-matrix.yml` downloads from that exact tag — so bumping this
 # value forces every CI run to use the freshly-built archives.
-MUMPS_PREBUILT_REVISION=1
+MUMPS_PREBUILT_REVISION=2
 
 # OpenBLAS (built from source when Linux + musl static linking — Alpine
 # ships BLAS/LAPACK as shared libs only, so a static link can't resolve

--- a/versions.env
+++ b/versions.env
@@ -15,7 +15,7 @@ MUMPS_VERSION=5.8.1
 # output to a GH Release tagged `mumps-prebuilt-${MUMPS_VERSION}-r${REV}`,
 # and `_build-matrix.yml` downloads from that exact tag — so bumping this
 # value forces every CI run to use the freshly-built archives.
-MUMPS_PREBUILT_REVISION=2
+MUMPS_PREBUILT_REVISION=3
 
 # OpenBLAS (built from source when Linux + musl static linking — Alpine
 # ships BLAS/LAPACK as shared libs only, so a static link can't resolve


### PR DESCRIPTION
## Summary

Companion to [#50](https://github.com/ccomb/volca/pull/50). With the foundation merged, this PR flips every Linux job to run inside \`container: alpine:3.19\`. setup-haskell-env's libc auto-detect catches \`/etc/alpine-release\` and routes through the apk + OpenBLAS-source path; build.sh auto-selects \`LINK_MODE=musl\`. The released \`linux-amd64\`/\`linux-arm64\` binaries become musl-static, finally truly portable across distros and matching the Docker image.

Stacked on top of [#50](https://github.com/ccomb/volca/pull/50): merge that first, then this. Base is set to \`ci-linux-musl\` so the diff shown reflects just the flip.

Affected workflows:
- \`_build-matrix.yml\` (release binary + PR builds)
- \`prebuild-mumps.yml\` (cached MUMPS archive)
- \`prebuild-cabal-store.yml\` (cached \`~/.cabal/store\`)

Windows and macOS jobs are unchanged: GH macOS hosts cannot run containers, and Windows uses MSYS2 directly on the runner. \`container: \${{ matrix.container }}\` resolves to empty on those entries, which GH Actions treats as no container.

## Other adjustments

- Early "Read pinned versions" / "Read engine version" steps converted to POSIX \`sh\` (replacing \`source\` with \`.\`). They run on bare Alpine before setup-haskell-env apk-installs bash, so they can't assume bash.
- \`coreutils\` added to the Alpine apk list so \`sha256sum -c -\` and friends behave like GNU coreutils on the glibc path.
- prebuild-cabal-store.yml's LINK_MODE selector recognises Alpine (\`/etc/alpine-release\`) → \`musl\`.

## Test plan

This PR is the first time the new code paths actually run. Expect to iterate:
- [ ] \`prebuild-mumps.yml\` Linux jobs (manual dispatch first — produces the artefacts everything else depends on)
- [ ] \`prebuild-cabal-store.yml\` Linux jobs (manual dispatch after the MUMPS run)
- [ ] \`_build-matrix.yml\` Linux jobs (triggered on PR push)
- [ ] Final \`linux-amd64.tar.gz\` artefact runs on a vanilla Debian/Ubuntu/RHEL/Alpine host (smoke test post-merge)

Bump \`MUMPS_PREBUILT_REVISION\` + \`CABAL_PREBUILT_REVISION\` in \`versions.env\` after merge so the prebuilt archives get re-cut with musl content (their hashes will mismatch the glibc archives still on GH Releases).