### PR TITLE
deps: drop unused RUST_VERSION, NODE_VERSION, ELM_VERSION pins

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,8 +1,9 @@
 # =============================================================================
-# versions.env - Central version definitions for VoLCA build
+# versions.env - Toolchain and native-dep pins for the VoLCA LCA engine
 # =============================================================================
-# Used by both build.sh (Linux/macOS) and build.ps1 (Windows)
-# This file ensures consistent versions across all platforms.
+# Sourced by build.sh, build-mumps.sh, docker/Dockerfile and the CI workflows
+# in .github/workflows/. Carries the Haskell, MUMPS and OpenBLAS pins this
+# package needs to build reproducibly.
 #
 # Syntax: KEY=VALUE (no spaces around =, no quotes needed)
 # Lines starting with # are comments
@@ -34,6 +35,3 @@ GHC_VERSION=9.12.4
 # (where HASH8 is the first 8 chars of sha256 of those three files), and
 # `_build-matrix.yml` downloads from that exact tag.
 CABAL_PREBUILT_REVISION=2
-RUST_VERSION=1.85.0
-NODE_VERSION=22.22.3
-ELM_VERSION=0.19.1


### PR DESCRIPTION
## Summary

`versions.env` declared three pins that no build script, workflow or Dockerfile in this repo actually consumes:

- `RUST_VERSION` — there is no Rust code here (no `Cargo.toml`, no `rust-toolchain.toml`).
- `NODE_VERSION` — there is no Node code here (no `package.json`).
- `ELM_VERSION` — where Elm is used downstream, its canonical version is encoded in `elm.json`; a duplicate env pin would only drift.

Removing them stops the file from advertising contracts it doesn't keep. Also tightens the file header to make the scope explicit (Haskell + MUMPS + OpenBLAS).

## Test plan

- [ ] CI on `_build-matrix.yml` stays green — none of the removed variables are referenced by any build artifact in this repo