### PR TITLE
docker: bring Dockerfile in line with Alpine 3.23 / GHC 9.12.4 CI

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 #   file dist/volca       # → "statically linked", "ELF 64-bit"
 #   ldd dist/volca        # → "not a dynamic executable"
 
-FROM alpine:3.19 AS haskell-builder
+FROM alpine:3.23 AS haskell-builder
 
 # musl toolchain + everything MUMPS / GHC need to build statically.
 # `*-static` packages ship the .a variants required by `executable-static`.
@@ -37,6 +37,7 @@ RUN apk add --no-cache \
     g++ \
     gfortran \
     gmp-dev \
+    gmp-static \
     libffi-dev \
     ncurses-dev \
     ncurses-static \
@@ -166,7 +167,7 @@ RUN mkdir -p /build/output \
 # needed) so `scratch` would work, but Alpine gives us /etc/passwd, a shell
 # for debugging, and the few utilities volca shells out to (7z for SimaPro
 # CSV archives) at negligible size cost.
-FROM alpine:3.19
+FROM alpine:3.23
 ARG GIT_HASH=unknown
 LABEL org.opencontainers.image.revision="${GIT_HASH}"
 


### PR DESCRIPTION
## Summary

- PR #52 unified CI on Alpine 3.23 + GHC 9.12.4 but left `docker/Dockerfile` on `alpine:3.19`. That combination is now broken end-to-end:
  - `ghcup install ghc 9.12.4` has no `alpine3_19` bindist; the `alpine3_20` fallback fails at `gmake install` on a 3.19 base.
  - Bumping the base to 3.23 surfaces a second issue: Alpine 3.23 split the static `libgmp.a` out into its own `gmp-static` package, so the final static link fails with `cannot find -lgmp` unless we add it explicitly.
- Both build and runtime stages move to `alpine:3.23` (matches CI) and the build stage gains `gmp-static` alongside the other `*-static` packages.

## Test plan

- [ ] `docker build -f docker/Dockerfile -t volca .` completes end-to-end on Linux/amd64
- [ ] Resulting image runs (`docker run --rm volca --help`) and reports the expected version
- [ ] `volca-deploy`'s `volca/docker-build.sh --with-frontend` overlay build no longer trips on the missing `/data/` bundled snapshot