### PR TITLE
rts: halve max heap, return memory to OS after parsing spikes

### DIFF
--- a/docker/rts-flags.sh
+++ b/docker/rts-flags.sh
@@ -36,11 +36,22 @@ NURSERY_MB=$((CORES * 16))
 CHUNK_MB=$((NURSERY_MB / 32))
 [ $CHUNK_MB -lt 8 ] && CHUNK_MB=8
 
-# Max heap: 75% of RAM, minimum 2G
-MAX_MB=$((RAM_MB * 3 / 4))
+# Max heap: 50% of RAM, minimum 2G.
+# The remaining half is left to: kernel + page cache, MUMPS Fortran solver
+# (which allocates outside the GHC heap), parser intermediates that
+# transiently inflate RSS above heap size, and the OOM headroom needed to
+# let `-M` trigger a clean Haskell heap-exhaustion exit before the kernel
+# OOM-killer fires.
+MAX_MB=$((RAM_MB / 2))
 [ $MAX_MB -lt 2048 ] && MAX_MB=2048
 
-RTS_FLAGS="+RTS -N -M${MAX_MB}M -H${HEAP_MB}M -A${NURSERY_MB}M -n${CHUNK_MB}m -qg0 -c -F1.5 -I30 -RTS"
+# -Fd1.0 (GHC 9.10+): return free heap blocks to the OS over ~1 idle period
+# instead of holding them indefinitely after a parsing spike. Default decay
+# (4.0) keeps RSS pinned near the peak for minutes.
+# -I0.3 (GHC default): trigger idle-time major GC promptly. The previous
+# -I30 deferred GC for 30 s, hiding live-data drops and starving -Fd of
+# free blocks to release.
+RTS_FLAGS="+RTS -N -M${MAX_MB}M -H${HEAP_MB}M -A${NURSERY_MB}M -n${CHUNK_MB}m -qg0 -c -F1.5 -Fd1.0 -I0.3 -RTS"
 
 echo "RTS_FLAGS=\"$RTS_FLAGS\""
 


### PR DESCRIPTION
## Summary

On a 16 GB host, parsing-heavy startups were being killed by the kernel OOM-killer. RTS flags computed by `docker/rts-flags.sh` left no headroom and held memory long after the parsing spike was over.

- **`-M` 75 % → 50 % of RAM.** The previous 75 % cap competed with MUMPS Fortran allocations (outside the GHC heap), transient parser-intermediate RSS, and kernel/page-cache needs. RSS hit the cgroup limit before `-M` could trigger a clean Haskell heap-exhaustion exit. 50 % leaves real headroom and lets the runtime fail gracefully on overload.
- **`-I30` → `-I0.3` (GHC default).** A 30 s idle-GC delay hid live-data drops after parsing, so the runtime kept the post-spike heap inflated for far too long.
- **Added `-Fd1.0` (GHC 9.10+).** Decays free heap blocks back to the OS over ~1 idle period. Without it, the default decay (4.0) pins RSS near the peak for minutes after parsing finishes.

`-A`, `-c`, `-F1.5`, `-qg0` are left alone — they trade off with parser throughput and shouldn't move without benchmarking.

## Expected effect

On a 16 GB host with a parsing workload:
- Peak RSS during parsing: ~16 GB+ (OOM) → ~8–10 GB.
- Steady-state RSS after parsing: ~stuck near peak → drops to live-data size within seconds.

## Test plan

- [ ] Build the Docker image and run with a parsing workload on a 16 GB cgroup; confirm no OOM and post-parse RSS converges to live-data size.
- [ ] Spot-check the printed `RTS: ... -> +RTS ...` summary on stderr to confirm the new flags appear and `-M` is half the cgroup limit.
- [ ] Verify on a small (4 GB) host that the 2 GB floor still kicks in (`-M2048M`).