### PR TITLE
fix(docker): unblock 8 GB VM target — OpenBLAS musl pthread + RTS memory discipline

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,6 +88,15 @@ RUN . /tmp/versions.env \
     && curl -fsSL "https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.tar.gz" \
         | tar -xz -C /tmp \
     && cd "/tmp/OpenBLAS-${OPENBLAS_VERSION}" \
+    # musl's pthread default stack is 128 KB (vs glibc's 8 MB read from
+    # RLIMIT_STACK). OpenBLAS worker threads inherit it and overflow on
+    # DYNAMIC_ARCH Fortran kernels with large auto-arrays → SIGSEGV at the
+    # first BLAS3 call from MUMPS. Force an 8 MB stack on each worker.
+    # Guard: fail the build if the upstream anchor disappears so a silent
+    # OpenBLAS refactor can't reintroduce the crash.
+    && grep -q 'pthread_attr_init(&attr);' driver/others/blas_server.c \
+    && sed -i 's|pthread_attr_init(&attr);|pthread_attr_init(\&attr); pthread_attr_setstacksize(\&attr, 8 << 20);|' driver/others/blas_server.c \
+    && grep -q 'pthread_attr_setstacksize(&attr, 8 << 20);' driver/others/blas_server.c \
     && make -j"$(nproc)" \
         NO_SHARED=1 \
         USE_THREAD=1 USE_OPENMP=0 \

--- a/docker/rts-flags.sh
+++ b/docker/rts-flags.sh
@@ -40,7 +40,13 @@ CHUNK_MB=$((NURSERY_MB / 32))
 MAX_MB=$((RAM_MB * 3 / 4))
 [ $MAX_MB -lt 2048 ] && MAX_MB=2048
 
-RTS_FLAGS="+RTS -N -M${MAX_MB}M -H${HEAP_MB}M -A${NURSERY_MB}M -n${CHUNK_MB}m -qg0 -c -F1.5 -I30 -RTS"
+# -Fd1.0 (GHC 9.10+): return free heap blocks to the OS over ~1 idle period
+# instead of holding them indefinitely after a parsing spike. Default decay
+# (4.0) keeps RSS pinned near the peak for minutes.
+# -I0.3 (GHC default): trigger idle-time major GC promptly. The previous
+# -I30 deferred GC for 30 s, hiding live-data drops and starving -Fd of
+# free blocks to release.
+RTS_FLAGS="+RTS -N -M${MAX_MB}M -H${HEAP_MB}M -A${NURSERY_MB}M -n${CHUNK_MB}m -qg0 -c -F1.5 -Fd1.0 -I0.3 -RTS"
 
 echo "RTS_FLAGS=\"$RTS_FLAGS\""
 


### PR DESCRIPTION
## Goal
Make VoLCA run on an 8 GB RAM VM with pre-loaded databases (no parser pressure). Two independent root causes were stopping us; both are addressed here, in two atomic commits.

## Commit 1 — RTS memory return (subset of #59)
\`docker/rts-flags.sh\`:
- **Add \`-Fd1.0\` (GHC 9.10+).** Decays free heap blocks back to the OS over ~1 idle period. Without it (default 4.0), RSS stays pinned near the peak for minutes after a spike.
- **\`-I30\` → \`-I0.3\` (GHC default).** A 30 s deferred idle GC was hiding live-data drops and starving \`-Fd\` of free blocks.

**\`-M\` left at 75 % of RAM for now.** #59 also halves it to 50 %; that's likely the right call eventually (MUMPS Fortran workspace allocates outside the GHC heap so 75 % leaves no headroom on tight VMs), but the immediate motivator for #59 was the OOM-killer firing — which we now attribute to the OpenBLAS musl crash addressed in commit 2. Re-evaluate \`-M\` once we have RSS curves on the 8 GB target.

\`-A\`, \`-c\`, \`-F1.5\`, \`-qg0\`, \`-n\` left alone — they trade off with throughput and shouldn't move without benchmarking.

## Commit 2 — OpenBLAS pthread stack on musl
Static Alpine/musl builds segfaulted (exit 139 / SIGSEGV) inside MUMPS factorization on the first dense BLAS3 call. musl's hardcoded 128 KB default pthread stack (vs glibc's 8 MB read from \`RLIMIT_STACK\`) is overflowed by OpenBLAS \`DYNAMIC_ARCH\` Fortran kernels with large auto-arrays.

Patch \`driver/others/blas_server.c\` during the Docker build to call \`pthread_attr_setstacksize(&attr, 8 << 20)\` right after \`pthread_attr_init\`. Two \`grep\` guards bracket the \`sed\` — a future upstream refactor fails the Docker build loudly instead of silently regressing the runtime.

Workaround for verification: \`OPENBLAS_NUM_THREADS=1\` (no worker pthreads spawned) makes the crash disappear without the patch — proves the worker-thread stack is the only contributor.

## Why combine in one PR
The two changes solve different layers (Haskell RTS hygiene vs native BLAS thread setup), but the goal is shared: shipping a binary that runs on an 8 GB VM with Agribalyse-class workloads. The OpenBLAS fix is the load-bearing change; the RTS tweaks are cheap incremental hygiene on top.

## Test plan
- [ ] \`./docker-build.sh --with-frontend\` succeeds (both \`grep\` guards pass)
- [ ] On an 8 GB Alpine VM: \`docker run … volca-with-frontend …\`, load Agribalyse 3.2 from cache, request \`/impacts/Environmental Footprint 3.1 (adapted)\` — completes without exit 139
- [ ] No \`OPENBLAS_NUM_THREADS\` env override needed: parallel BLAS workers auto-scale to \`nproc\`
- [ ] Printed \`RTS: ... -> +RTS ...\` summary shows \`-Fd1.0\` and \`-I0.3\` (\`-M\` stays at 75 % of cgroup limit)
- [ ] Spot-check post-request RSS drops within seconds of going idle (\`-Fd1.0\` working)