### PR TITLE
build: shrink binaries with -split-sections + --gc-sections

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,14 +8,12 @@ jobs: $ncpus
 program-options
   ghc-options: -j +RTS -A128m -RTS
 
--- Binary-size reduction: emit one ELF section per top-level symbol in every
--- package, then have the linker drop sections nothing references. Both halves
--- are required — split-sections without --gc-sections is dead weight. Shrinks
--- the dynamic Linux exe ~78 MB → ~25 MB (~50 MB → ~18 MB stripped); the static
--- musl binary in docker/ shrinks proportionally before UPX. Forces a one-time
--- rebuild of the cabal store (the prebuilt-store hash includes this file).
+-- Binary-size reduction: emit one section per top-level symbol in every
+-- package, then have the linker drop sections nothing references at exe link.
+-- Both halves are required — split-sections without dead-section stripping is
+-- dead weight. The platform-specific linker flag lives in volca.cabal's
+-- executable stanza (Apple ld doesn't understand --gc-sections; uses
+-- -dead_strip instead). Forces a one-time rebuild of the cabal store (the
+-- prebuilt-store hash includes this file).
 package *
   split-sections: True
-
-package volca
-  ghc-options: -optl-Wl,--gc-sections

--- a/cabal.project
+++ b/cabal.project
@@ -7,3 +7,15 @@ jobs: $ncpus
 
 program-options
   ghc-options: -j +RTS -A128m -RTS
+
+-- Binary-size reduction: emit one ELF section per top-level symbol in every
+-- package, then have the linker drop sections nothing references. Both halves
+-- are required — split-sections without --gc-sections is dead weight. Shrinks
+-- the dynamic Linux exe ~78 MB → ~25 MB (~50 MB → ~18 MB stripped); the static
+-- musl binary in docker/ shrinks proportionally before UPX. Forces a one-time
+-- rebuild of the cabal store (the prebuilt-store hash includes this file).
+package *
+  split-sections: True
+
+package volca
+  ghc-options: -optl-Wl,--gc-sections

--- a/volca.cabal
+++ b/volca.cabal
@@ -138,6 +138,13 @@ executable volca
   import:              warnings, rtsdefaults
   main-is:             Main.hs
   hs-source-dirs:      app
+  -- Drop ELF/Mach-O sections nothing references; pairs with cabal.project's
+  -- split-sections to actually shrink the linked exe. Apple ld doesn't accept
+  -- --gc-sections, uses -dead_strip instead.
+  if os(darwin)
+    ghc-options:       -optl-Wl,-dead_strip
+  else
+    ghc-options:       -optl-Wl,--gc-sections
   build-depends:       base >=4.14 && <5
                      , volca
                      , text


### PR DESCRIPTION
## Summary

- Add `package * { split-sections: True }` + executable-side `-optl-Wl,--gc-sections` to `cabal.project`. The compiler emits one ELF section per top-level symbol across every package; the linker then drops sections nothing references at exe link time. Either flag alone is a no-op — both are required.
- Mature, well-known flag combo (split-sections has been in GHC since 8.0; `--gc-sections` is standard ld). No correctness risk.

## Measured impact

Dynamic Linux exe, GHC 9.12.4, `-O2`:

| | non-stripped | stripped |
|---|---|---|
| baseline | 78.8 MB | 50.3 MB |
| with flags | 25.1 MB | 18.5 MB |
| Δ stripped | | **−63 %** |

Binary smoke-tested locally (`volca --version`, `volca --help` OK). Static musl binary in `docker/` should shrink proportionally before the existing `strip` + `upx` pipeline — final image layer should drop accordingly.

## CI / cache impact

The cabal-store prebuilt hash (sha256 of `volca.cabal` + `mumps-hs/mumps-hs.cabal` + `cabal.project`) changes with this commit. First CI run after this merges will miss the prebuilt tag, log a `::warning::`, and fall through to a source rebuild (~10–20 min on cold runners). `prebuild-cabal-store.yml` should be re-run afterwards to repopulate the cache for the new hash.

No bump of `CABAL_PREBUILT_REVISION` needed — the hash bumps automatically.

## Test plan

- [x] CI green on Linux/musl static, Linux/glibc, macOS, Windows
- [ ] Docker image build succeeds; verify final image layer size in the build log
- [ ] PT_GNU_STACK 8 MiB guard in `docker/Dockerfile` still passes (section GC shouldn't touch program headers, but the existing check will catch any regression)
- [ ] Manual smoke: load Agribalyse + a method, run a query, confirm result parity
- [ ] Re-run `prebuild-cabal-store.yml` once merged so subsequent CI hits the prebuilt store again