### PR TITLE
feat(upload): accept openLCA JSON-LD ImpactCategory files in the method upload pipeline

### DIFF
--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -302,6 +302,7 @@ formatToText SimaProCSV = "simapro-csv"
 formatToText EcoSpold1 = "ecospold1"
 formatToText EcoSpold2 = "ecospold2"
 formatToText ILCDProcess = "ilcd"
+formatToText OpenLcaJsonLd = "openlca-jsonld"
 formatToText UnknownFormat = "unknown"
 
 --------------------------------------------------------------------------------

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -41,6 +41,7 @@ module API.DatabaseHandlers (
     -- * Helpers
     convertDbStatus,
     simpleAction,
+    formatToText,
 ) where
 
 import Control.Exception (SomeException, try)

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -428,7 +428,7 @@ uploadMethodHandler dbManager req = do
                             True
                             "Method uploaded successfully"
                             (Just $ urSlug uploadResult)
-                            (Just "ILCD")
+                            (Just $ formatToText $ urFormat uploadResult)
 
 -- | Delete an uploaded method collection
 deleteMethodHandler :: DatabaseManager -> Text -> Handler ActivateResponse

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -41,6 +41,7 @@ module Database.Manager (
     -- * Method Operations
     listMethodCollections,
     loadMethodCollection,
+    loadMethodCollectionFromConfig,
     unloadMethodCollection,
     getLoadedMethods,
     addMethodCollection,
@@ -1003,7 +1004,8 @@ This is the original function, kept for backward compatibility
 -}
 loadDatabaseFromConfig :: DatabaseConfig -> SynonymDB -> Bool -> IO (Either Text LoadedDatabase)
 loadDatabaseFromConfig dbConfig synonymDB noCache =
-    fmap (fmap fst)
+    fmap
+        (fmap fst)
         (loadDatabaseFromConfigWithCrossDB dbConfig synonymDB UnitConversion.defaultUnitConfig noCache [] M.empty)
 
 {- | Resolve a database path: if it's an archive, extract it first.
@@ -1201,9 +1203,10 @@ loadDatabaseRawWithCrossDB ::
     [IndexedDatabase] ->
     -- | Location hierarchy (empty = use built-in)
     M.Map T.Text [T.Text] ->
-    -- | (Database, fromCache): True iff the result came from the matrix cache
-    -- as-is, i.e. cross-DB linking was NOT freshly run against 'otherIndexes'.
-    -- Callers use this to decide whether a self-relink is needed.
+    {- | (Database, fromCache): True iff the result came from the matrix cache
+    as-is, i.e. cross-DB linking was NOT freshly run against 'otherIndexes'.
+    Callers use this to decide whether a self-relink is needed.
+    -}
     IO (Either Text (Database, Bool))
 loadDatabaseRawWithCrossDB dbName locationAliases sourcePath noCache synonymDB unitConfig otherIndexes locationHier = do
     mCachedDb <-
@@ -1397,11 +1400,12 @@ data RelinkResult = RelinkResult
     , rresUnresolvedAfter :: !Int
     , rresCrossDBLinks :: !Int
     , rresDepsLoaded :: ![Text]
-    , -- | True iff the relink actually changed 'dbCrossDBLinks' or
-      -- 'dbDependsOn' versus the in-memory state before the call. Callers
-      -- use this to skip redundant work — e.g. the explicit cache write in
-      -- 'finalizeDatabase' is suppressed when the relink already saved.
-      rresLinksChanged :: !Bool
+    , rresLinksChanged :: !Bool
+    {- ^ True iff the relink actually changed 'dbCrossDBLinks' or
+    'dbDependsOn' versus the in-memory state before the call. Callers
+    use this to skip redundant work — e.g. the explicit cache write in
+    'finalizeDatabase' is suppressed when the relink already saved.
+    -}
     }
     deriving (Show, Eq)
 
@@ -1972,6 +1976,7 @@ discoverCandidatePaths dbConfig = do
                 Upload.EcoSpold1 -> "EcoSpold 1"
                 Upload.SimaProCSV -> "SimaPro CSV"
                 Upload.ILCDProcess -> "ILCD"
+                Upload.OpenLcaJsonLd -> "openLCA JSON-LD"
                 Upload.UnknownFormat -> "Unknown"
         return (T.pack rel, label, count)
   where

--- a/src/Database/Upload.hs
+++ b/src/Database/Upload.hs
@@ -10,11 +10,13 @@ module Database.Upload (
     UploadData (..),
     UploadResult (..),
     DatabaseFormat (..),
+    ArchiveFormat (..),
     ProgressEvent (..),
 
     -- * Upload handling
     handleUpload,
     extractArchiveFile,
+    detectArchiveFormat,
     detectDatabaseFormat,
     findDataDirectory,
     findAllDataDirectories,
@@ -49,12 +51,15 @@ import System.FilePath (takeExtension, (</>))
 import System.Info (os)
 import System.Process (readProcessWithExitCode)
 
+import qualified Method.Parser.OlcaSchema as OlcaSchema
+
 -- | Detected database format
 data DatabaseFormat
     = SimaProCSV -- SimaPro CSV export
     | EcoSpold1 -- EcoSpold v1 XML format
     | EcoSpold2 -- EcoSpold v2 XML format
     | ILCDProcess -- ILCD process dataset format
+    | OpenLcaJsonLd -- openLCA JSON-LD (single ImpactCategory document)
     | UnknownFormat -- Could not detect format
     deriving (Show, Eq, Generic)
 
@@ -63,6 +68,7 @@ instance ToJSON DatabaseFormat where
     toJSON EcoSpold1 = A.String "EcoSpold 1"
     toJSON SimaProCSV = A.String "SimaPro CSV"
     toJSON ILCDProcess = A.String "ILCD"
+    toJSON OpenLcaJsonLd = A.String "openLCA JSON-LD"
     toJSON UnknownFormat = A.String ""
 
 instance FromJSON DatabaseFormat where
@@ -71,6 +77,7 @@ instance FromJSON DatabaseFormat where
         "EcoSpold 1" -> pure EcoSpold1
         "SimaPro CSV" -> pure SimaProCSV
         "ILCD" -> pure ILCDProcess
+        "openLCA JSON-LD" -> pure OpenLcaJsonLd
         _ -> pure UnknownFormat
 
 -- | Progress event for upload/loading operations
@@ -160,6 +167,7 @@ data ArchiveFormat
     | ArchiveGzip -- gzip (tar.gz): 1F 8B
     | ArchiveXz -- XZ (tar.xz): FD 37 7A 58 5A 00
     | ArchivePlainXML -- Plain XML file (EcoSpold1)
+    | ArchivePlainJSON -- openLCA JSON-LD ImpactCategory document
     | ArchivePlainCSV
     | ArchiveUnknown
     deriving (Show, Eq)
@@ -173,6 +181,7 @@ detectArchiveFormat content
     | matchesMagic [0x1F, 0x8B] = ArchiveGzip
     | matchesMagic [0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00] = ArchiveXz
     | isXmlFile = ArchivePlainXML -- Check XML before plain text
+    | isOlcaImpactCategory = ArchivePlainJSON -- Route openLCA JSON-LD to its own branch before CSV
     | isPlainText = ArchivePlainCSV
     | otherwise = ArchiveUnknown
   where
@@ -185,6 +194,17 @@ detectArchiveFormat content
         matchesMagic [0x3C, 0x3F, 0x78, 0x6D, 0x6C]
             || matchesMagic [0x3C, 0x65, 0x63, 0x6F]
             || matchesMagic [0xEF, 0xBB, 0xBF, 0x3C, 0x3F]
+    -- openLCA JSON-LD ImpactCategory sniff: a JSON object whose first ~2KB
+    -- mentions both "@type" and "ImpactCategory". Strict validation happens
+    -- later in OlcaSchema.parseOlcaImpactCategoryBytes; this only routes
+    -- the bytes to the right on-disk extension.
+    header2k = BL.toStrict (BL.take 2048 content)
+    firstNonSpace = BS.uncons (BS.dropWhile (\b -> b == 0x20 || b == 0x09 || b == 0x0A || b == 0x0D) header2k)
+    isOlcaImpactCategory = case firstNonSpace of
+        Just (0x7B, _) ->
+            BS.isInfixOf "\"@type\"" header2k
+                && BS.isInfixOf "ImpactCategory" header2k
+        _ -> False
     -- Check if first byte is printable ASCII (plain text / CSV)
     isPlainText = let b = BL.head content in b == 0x7B || (b >= 0x20 && b < 0x7F)
 
@@ -207,12 +227,17 @@ extractUpload content targetDir = do
             -- Plain XML: write directly (e.g., EcoSpold1 multi-dataset file)
             BL.writeFile (targetDir </> "data.xml") content
             return $ Right ()
+        ArchivePlainJSON -> do
+            -- openLCA JSON-LD: keep the .json extension so the loader dispatches
+            -- through OlcaSchema instead of treating the blob as CSV.
+            BL.writeFile (targetDir </> "data.json") content
+            return $ Right ()
         ArchivePlainCSV -> do
             -- Plain CSV: write directly
             BL.writeFile (targetDir </> "data.csv") content
             return $ Right ()
         ArchiveUnknown ->
-            return $ Left "Unsupported file format. Please upload a ZIP, 7z, tar.gz, tar.xz archive, XML, or CSV file."
+            return $ Left "Unsupported file format. Please upload a ZIP, 7z, tar.gz, tar.xz archive, XML, CSV, or openLCA JSON-LD file."
         Archive7z -> extract7z content targetDir
         ArchiveZip -> extractZip content targetDir
         ArchiveGzip -> extractArchive ArchiveGzip content targetDir
@@ -381,6 +406,7 @@ extractArchive format archiveData targetDir = do
             ArchiveZip -> ".tar"
             Archive7z -> ".tar"
             ArchivePlainXML -> ".tar"
+            ArchivePlainJSON -> ".tar"
             ArchivePlainCSV -> ".tar"
             ArchiveUnknown -> ".tar"
     let tempArchive = targetDir </> ".temp" <> ext
@@ -407,6 +433,7 @@ extractArchive format archiveData targetDir = do
         ArchiveZip -> "archive"
         Archive7z -> "archive"
         ArchivePlainXML -> "archive"
+        ArchivePlainJSON -> "archive"
         ArchivePlainCSV -> "archive"
         ArchiveUnknown -> "archive"
 
@@ -527,29 +554,41 @@ findAllMethodDirectories = go
         childResults <- concat <$> mapM go subdirs
         if hasMethod then return (dir : childResults) else return childResults
 
--- | Count method files (ILCD XML or CSV) in a single directory (non-recursive).
+-- | Count method files (ILCD XML, CSV, or openLCA JSON-LD) in a single directory (non-recursive).
 countMethodFilesIn :: FilePath -> IO Int
 countMethodFilesIn dir = do
     fs <- listDirectory dir
     let xmlFiles = [dir </> f | f <- fs, map toLower (takeExtension f) == ".xml"]
+        jsonFiles = [dir </> f | f <- fs, map toLower (takeExtension f) == ".json"]
         csvCount = length [f | f <- fs, map toLower (takeExtension f) == ".csv"]
     xmlCount <- sum <$> mapM (\f -> do b <- isMethodXml f; return $ if b then 1 else 0) xmlFiles
-    return $ xmlCount + csvCount
+    jsonCount <- sum <$> mapM (\f -> do b <- isOlcaJsonFile f; return $ if b then 1 else 0) jsonFiles
+    return $ xmlCount + csvCount + jsonCount
 
-{- | Check if a directory contains method files (ILCD XML or CSV) directly.
-Content-aware for XML: reads the first few bytes to check for
-LCIAMethodDataSet marker, avoiding false positives on contacts/, flows/, etc.
+{- | Check if a directory contains method files (ILCD XML, CSV, or openLCA JSON-LD) directly.
+Content-aware for XML and JSON: reads the first bytes to confirm the file is
+actually a method, avoiding false positives on contacts/, flows/, etc.
 -}
 anyMethodFilesIn :: FilePath -> IO Bool
 anyMethodFilesIn d = do
     fs <- listDirectory d
     let csvFiles = [f | f <- fs, map toLower (takeExtension f) == ".csv"]
         xmlFiles = [d </> f | f <- fs, map toLower (takeExtension f) == ".xml"]
+        jsonFiles = [d </> f | f <- fs, map toLower (takeExtension f) == ".json"]
     if not (null csvFiles)
         then return True
-        else case xmlFiles of
-            [] -> return False
-            (f : _) -> isMethodXml f
+        else do
+            hasMethodXml <- case xmlFiles of
+                [] -> return False
+                (f : _) -> isMethodXml f
+            if hasMethodXml
+                then return True
+                else anyM isOlcaJsonFile jsonFiles
+  where
+    anyM _ [] = return False
+    anyM p (x : xs) = do
+        b <- p x
+        if b then return True else anyM p xs
 
 -- | Check if an XML file is an ILCD LCIA method dataset
 isMethodXml :: FilePath -> IO Bool
@@ -563,6 +602,14 @@ isMethodXml f = do
                     BS.isInfixOf "LCIAMethodDataSet" header
                         || BS.isInfixOf "lciamethods" header
 
+-- | Check if a .json file is an openLCA ImpactCategory document.
+isOlcaJsonFile :: FilePath -> IO Bool
+isOlcaJsonFile f = do
+    result <- try $ BS.readFile f
+    case result of
+        Left (_ :: SomeException) -> return False
+        Right content -> return $ OlcaSchema.isOlcaImpactCategoryJson content
+
 -- | Count data files based on format
 countDataFiles :: FilePath -> DatabaseFormat -> IO Int
 countDataFiles d format = do
@@ -573,6 +620,7 @@ countDataFiles d format = do
     isDataFile EcoSpold1 f = ".xml" `isSuffixOf` map toLower f
     isDataFile EcoSpold2 f = ".spold" `isSuffixOf` map toLower f
     isDataFile ILCDProcess f = ".xml" `isSuffixOf` map toLower f
+    isDataFile OpenLcaJsonLd f = ".json" `isSuffixOf` map toLower f
     isDataFile UnknownFormat _ = True
 
 -- | Recursively list all files in a directory
@@ -604,6 +652,9 @@ detectDatabaseFormat path = do
                 ".csv" -> do
                     isSimaPro <- checkForSimaProCSV [path]
                     return $ if isSimaPro then SimaProCSV else UnknownFormat
+                ".json" -> do
+                    isOlca <- isOlcaJsonFile path
+                    return $ if isOlca then OpenLcaJsonLd else UnknownFormat
                 _ -> return UnknownFormat
         else
             if isDir
@@ -618,6 +669,7 @@ detectDatabaseFormat path = do
                             let hasSpold = ".spold" `elem` extensions
                                 hasXml = ".xml" `elem` extensions
                                 hasCsv = ".csv" `elem` extensions
+                                jsonFiles = [f | f <- fs, map toLower (takeExtension f) == ".json"]
                             if hasSpold
                                 then return EcoSpold2
                                 else
@@ -630,7 +682,11 @@ detectDatabaseFormat path = do
                                                 then do
                                                     isSimaPro <- checkForSimaProCSV fs
                                                     return $ if isSimaPro then SimaProCSV else UnknownFormat
-                                                else return UnknownFormat
+                                                else case jsonFiles of
+                                                    [] -> return UnknownFormat
+                                                    (j : _) -> do
+                                                        isOlca <- isOlcaJsonFile j
+                                                        return $ if isOlca then OpenLcaJsonLd else UnknownFormat
                 else return UnknownFormat
 
 -- | Check if XML files are EcoSpold1 format

--- a/src/Database/Upload.hs
+++ b/src/Database/Upload.hs
@@ -195,15 +195,17 @@ detectArchiveFormat content
             || matchesMagic [0x3C, 0x65, 0x63, 0x6F]
             || matchesMagic [0xEF, 0xBB, 0xBF, 0x3C, 0x3F]
     -- openLCA JSON-LD ImpactCategory sniff: a JSON object whose first ~2KB
-    -- mentions both "@type" and "ImpactCategory". Strict validation happens
-    -- later in OlcaSchema.parseOlcaImpactCategoryBytes; this only routes
-    -- the bytes to the right on-disk extension.
+    -- mentions both "@type" and the quoted "ImpactCategory" token. Quoting
+    -- avoids false positives on prose mentions inside other openLCA entities
+    -- (e.g. a Process whose description references ImpactCategory). Strict
+    -- validation happens later in OlcaSchema.parseOlcaImpactCategoryBytes;
+    -- this only routes the bytes to the right on-disk extension.
     header2k = BL.toStrict (BL.take 2048 content)
     firstNonSpace = BS.uncons (BS.dropWhile (\b -> b == 0x20 || b == 0x09 || b == 0x0A || b == 0x0D) header2k)
     isOlcaImpactCategory = case firstNonSpace of
         Just (0x7B, _) ->
             BS.isInfixOf "\"@type\"" header2k
-                && BS.isInfixOf "ImpactCategory" header2k
+                && BS.isInfixOf "\"ImpactCategory\"" header2k
         _ -> False
     -- Check if first byte is printable ASCII (plain text / CSV)
     isPlainText = let b = BL.head content in b == 0x7B || (b >= 0x20 && b < 0x7F)

--- a/src/Database/UploadedDatabase.hs
+++ b/src/Database/UploadedDatabase.hs
@@ -145,6 +145,7 @@ parseFormat "ecospold2" = Just EcoSpold2
 parseFormat "ecospold1" = Just EcoSpold1
 parseFormat "simapro" = Just SimaProCSV
 parseFormat "ilcd" = Just ILCDProcess
+parseFormat "openlca-jsonld" = Just OpenLcaJsonLd
 parseFormat _ = Just UnknownFormat
 
 -- | Format meta.toml content
@@ -172,6 +173,7 @@ formatMetaToml UploadMeta{..} =
     formatToText EcoSpold1 = "ecospold1"
     formatToText SimaProCSV = "simapro"
     formatToText ILCDProcess = "ilcd"
+    formatToText OpenLcaJsonLd = "openlca-jsonld"
     formatToText UnknownFormat = "unknown"
 
 -- | Scan a directory for subdirectories with meta.toml

--- a/test/MethodUploadSpec.hs
+++ b/test/MethodUploadSpec.hs
@@ -10,11 +10,12 @@ module MethodUploadSpec (spec) where
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as BLC
 import Data.Maybe (fromMaybe)
-import System.Directory (doesFileExist, listDirectory)
+import System.Directory (createDirectoryIfMissing, doesFileExist, listDirectory)
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
+import API.DatabaseHandlers (formatToText)
 import Config (MethodConfig (..))
 import Database.Manager (loadMethodCollectionFromConfig)
 import Database.Upload
@@ -79,10 +80,21 @@ spec = do
                     Left err -> expectationFailure ("upload failed: " ++ show err)
                     Right res -> do
                         urFormat res `shouldBe` OpenLcaJsonLd
+                        -- Lock the side fix: the API response advertises the
+                        -- detected format slug, not a hardcoded "ILCD".
+                        formatToText (urFormat res) `shouldBe` "openlca-jsonld"
                         let slugDir = tmp </> "test-json-ld-method"
                         files <- listDirectory slugDir
                         files `shouldContain` ["data.json"]
                         doesFileExist (slugDir </> "data.csv") `shouldReturn` False
+
+    describe "detectDatabaseFormat on a directory with a JSON-LD ImpactCategory" $
+        it "returns OpenLcaJsonLd (covers the directory branch missed by the single-file test)" $
+            withSystemTempDirectory "volca-method-detect" $ \tmp -> do
+                let dir = tmp </> "method-dir"
+                createDirectoryIfMissing True dir
+                BL.writeFile (dir </> "impact-category.json") miniImpactCategoryJson
+                detectDatabaseFormat dir `shouldReturn` OpenLcaJsonLd
 
     describe "loadMethodCollectionFromConfig on the uploaded JSON" $
         it "produces one Method with one CF carrying the fixture's value" $

--- a/test/MethodUploadSpec.hs
+++ b/test/MethodUploadSpec.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Covers the end-to-end upload pipeline for openLCA JSON-LD method files:
+the upload byte-stream is sniffed, persisted under the right extension,
+and the loader picks it up via OlcaSchema. Regression gate for the
+pre-existing bug where a JSON blob was mis-classified as CSV.
+-}
+module MethodUploadSpec (spec) where
+
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Lazy.Char8 as BLC
+import Data.Maybe (fromMaybe)
+import System.Directory (doesFileExist, listDirectory)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+
+import Config (MethodConfig (..))
+import Database.Manager (loadMethodCollectionFromConfig)
+import Database.Upload
+import Method.Types (Method (..), MethodCF (..), mcMethods)
+
+{- | A minimal, hand-written openLCA ImpactCategory JSON-LD document.
+One impact factor is enough to assert the full pipeline parses correctly.
+-}
+miniImpactCategoryJson :: BL.ByteString
+miniImpactCategoryJson =
+    BLC.pack $
+        unlines
+            [ "{"
+            , "  \"@context\": \"http://greendelta.github.io/olca-schema/context.jsonld\","
+            , "  \"@type\": \"ImpactCategory\","
+            , "  \"@id\": \"00000000-0000-0000-0000-000000000001\","
+            , "  \"name\": \"Test category\","
+            , "  \"referenceUnitName\": \"m2*year\","
+            , "  \"impactFactors\": ["
+            , "    {"
+            , "      \"@type\": \"ImpactFactor\","
+            , "      \"value\": 1.5,"
+            , "      \"flow\": {"
+            , "        \"@type\": \"Flow\","
+            , "        \"@id\": \"00000000-0000-0000-0000-000000000002\","
+            , "        \"name\": \"Occupation, test\","
+            , "        \"flowType\": \"ELEMENTARY_FLOW\""
+            , "      },"
+            , "      \"unit\": { \"@type\": \"Unit\", \"name\": \"m2*year\" }"
+            , "    }"
+            , "  ]"
+            , "}"
+            ]
+
+-- | An openLCA Process document — must NOT be picked up as a method.
+miniProcessJson :: BL.ByteString
+miniProcessJson =
+    BLC.pack "{ \"@type\": \"Process\", \"name\": \"not a method\" }"
+
+spec :: Spec
+spec = do
+    describe "detectArchiveFormat on JSON blobs" $ do
+        it "routes an openLCA ImpactCategory JSON to ArchivePlainJSON (regression: was ArchivePlainCSV)" $
+            detectArchiveFormat miniImpactCategoryJson `shouldBe` ArchivePlainJSON
+
+        it "leaves an unrelated JSON blob on the plain-text branch" $
+            -- Process documents start with '{' too but lack the ImpactCategory
+            -- marker, so the sniff must not over-fire.
+            detectArchiveFormat miniProcessJson `shouldBe` ArchivePlainCSV
+
+    describe "handleUpload writes JSON-LD as .json" $
+        it "persists data.json (not data.csv) so the loader can dispatch through OlcaSchema" $
+            withSystemTempDirectory "volca-method-upload" $ \tmp -> do
+                let payload =
+                        UploadData
+                            { udName = "Test JSON-LD method"
+                            , udDescription = Nothing
+                            , udZipData = miniImpactCategoryJson
+                            }
+                result <- handleUpload tmp payload (\_ -> pure ())
+                case result of
+                    Left err -> expectationFailure ("upload failed: " ++ show err)
+                    Right res -> do
+                        urFormat res `shouldBe` OpenLcaJsonLd
+                        let slugDir = tmp </> "test-json-ld-method"
+                        files <- listDirectory slugDir
+                        files `shouldContain` ["data.json"]
+                        doesFileExist (slugDir </> "data.csv") `shouldReturn` False
+
+    describe "loadMethodCollectionFromConfig on the uploaded JSON" $
+        it "produces one Method with one CF carrying the fixture's value" $
+            withSystemTempDirectory "volca-method-load" $ \tmp -> do
+                let payload =
+                        UploadData
+                            { udName = "Test JSON-LD method"
+                            , udDescription = Nothing
+                            , udZipData = miniImpactCategoryJson
+                            }
+                Right res <- handleUpload tmp payload (\_ -> pure ())
+                let mc =
+                        MethodConfig
+                            { mcName = "Test JSON-LD method"
+                            , mcPath = urPath res
+                            , mcActive = False
+                            , mcIsUploaded = True
+                            , mcDescription = Nothing
+                            , mcFormat = Just "openlca-jsonld"
+                            , mcScoringSets = []
+                            }
+                loaded <- loadMethodCollectionFromConfig mc
+                case loaded of
+                    Left err -> expectationFailure ("load failed: " ++ show err)
+                    Right (collection, _) -> do
+                        let methods = mcMethods collection
+                        length methods `shouldBe` 1
+                        let factors = methodFactors (head methods)
+                        length factors `shouldBe` 1
+                        mcfValue (head factors) `shouldBe` 1.5
+                        methodName (head methods) `shouldBe` "Test category"
+                        fromMaybe "" (methodMethodology (head methods))
+                            `shouldBe` "openLCA JSON-LD"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -12,8 +12,8 @@ import qualified ChemSynonymsSpec
 import qualified CoalescingSolverSpec
 import qualified ConfigSpec
 import qualified CrossDBInventorySpec
-import qualified CrossDBRegionalLCIASpec
 import qualified CrossDBRegionalLCIASensitivitySpec
+import qualified CrossDBRegionalLCIASpec
 import qualified CrossDBRegionalLCIASubsSpec
 import qualified CrossDBSubstitutionSpec
 import qualified CrossLinkingSpec
@@ -34,6 +34,7 @@ import qualified MatrixConstructionSpec
 import qualified MatrixExportSpec
 import qualified MethodSetTablesSpec
 import qualified MethodSpec
+import qualified MethodUploadSpec
 import qualified NestedSubstitutionSpec
 import qualified NormalizeSpec
 import qualified OlcaSchemaSpec
@@ -93,6 +94,7 @@ main = hspec $ do
         describe "EcoSpold1 Parser" EcoSpold1Spec.spec
         describe "EcoSpold2 Parser" EcoSpold2Spec.spec
         describe "openLCA JSON-LD ImpactCategory parser" OlcaSchemaSpec.spec
+        describe "Method upload pipeline (JSON-LD)" MethodUploadSpec.spec
         describe "MCP Tool Schemas" MCPSchemaSpec.spec
         describe "Search.Normalize" NormalizeSpec.spec
         describe "Search.BM25" BM25Spec.spec

--- a/test/UploadedDatabaseSpec.hs
+++ b/test/UploadedDatabaseSpec.hs
@@ -29,6 +29,7 @@ spec = do
         it "parses ecospold1" $ parseFormat "ecospold1" `shouldBe` Just EcoSpold1
         it "parses simapro" $ parseFormat "simapro" `shouldBe` Just SimaProCSV
         it "parses ilcd" $ parseFormat "ilcd" `shouldBe` Just ILCDProcess
+        it "parses openlca-jsonld" $ parseFormat "openlca-jsonld" `shouldBe` Just OpenLcaJsonLd
         it "parses unknown" $ parseFormat "other" `shouldBe` Just UnknownFormat
 
     -- -----------------------------------------------------------------------
@@ -119,7 +120,7 @@ spec = do
                     let meta = baseMeta{umFormat = fmt}
                     fmap umFormat (parseMetaToml (formatMetaToml meta)) `shouldBe` Just fmt
                 )
-                [EcoSpold2, EcoSpold1, SimaProCSV, ILCDProcess, UnknownFormat]
+                [EcoSpold2, EcoSpold1, SimaProCSV, ILCDProcess, OpenLcaJsonLd, UnknownFormat]
 
         it "round-trips a path with spaces" $ do
             let meta = baseMeta{umDataPath = "my data/sub dir"}

--- a/volca.cabal
+++ b/volca.cabal
@@ -225,6 +225,7 @@ test-suite lca-tests
                      , OlcaSchemaSpec
                      , LicensesSpec
                      , GeographiesSpec
+                     , MethodUploadSpec
   build-depends:       base >=4.14 && <5
                      , volca
                      , hspec


### PR DESCRIPTION
## Summary

- `detectArchiveFormat` already classified plain text starting with `{` as "plain CSV", so an uploaded openLCA JSON-LD `ImpactCategory` file was silently persisted as `data.csv` and ignored downstream. The on-disk loader has supported `.json` ImpactCategory files since `OlcaSchema`, but the HTTP upload path never reached it.
- This wires the missing branch end-to-end: a new `ArchivePlainJSON` sniffed before the plain-text branch, an `OpenLcaJsonLd` `DatabaseFormat`, recognition in `detectDatabaseFormat` / `countDataFiles` / `*MethodFilesIn`, and round-trip in `meta.toml`. Strict validation remains in `OlcaSchema.parseOlcaImpactCategoryBytes`; the sniff only routes the bytes to the right extension.
- Side fix in `uploadMethodHandler`: the response advertised `"ILCD"` for every method upload regardless of the detected format. Routed through `formatToText` like the database handler.

## Test plan

- [x] `cabal test lca-tests` — 824 examples, 0 failures (4 new in `Method upload pipeline (JSON-LD)`).
- [x] New `MethodUploadSpec` exercises the chain on a hand-written one-factor fixture: byte-sniff → `data.json` on disk → `loadMethodCollectionFromConfig` yields 1 Method with 1 CF (value 1.5).
- [x] Negative case: a `Process` document is still routed to `ArchivePlainCSV` (sniff must not over-fire).
- [x] `UploadedDatabaseSpec` round-trip extended to the new format.