### PR TITLE
fix(synonyms): remove erroneous PSM bucket and Chromium III entries from flows.csv

### DIFF
--- a/data/flows.csv
+++ b/data/flows.csv
@@ -225,7 +225,6 @@ Beta-cyfluthrin,Cyfluthrin
 Beta-methylbivinyl,Isoprene
 Biethylene,Butadiene
 Bifenox,"methyl 5-(2,4-dichlorophenoxy)-2-nitrobenzoate"
-Bifenthrin,PSM
 "Bis(1-methylethyl)carbamothioic acid S-(2,3,3-trichloro-2-propenyl)ester",Tri-allate
 Bis-(N-cyclohexyldiazeniumdioxy)-copper,Cu-HDO
 Bismuth,"Bismuth, in ground"
@@ -281,10 +280,8 @@ Chloroform,Trichlormethan
 Chlorosulfonic acid,"chlorosulphuric acid, chloridosulfonic acid, sulfuric chlorohydrin"
 Chlorothalonil,tetrachloroisophthalonitrile
 Chlorotoluron,Chlortoluron
-Chromium,Chromium III
 Chromium,"Chromium, in ground"
 Chromium,"Chromium, ion"
-Chromium III,"Chromium, ion"
 Chrysotile,"Chrysotile, in ground"
 Cinnabar,"Cinnabar, in ground"
 "Clay, bentonite","Clay, bentonite, in ground"
@@ -316,11 +313,8 @@ Cumene,methyl ethyl benzene
 Curacron,Profenofos
 CxHy aromatic,Cyclohexane
 Cyanoacetic acid,Malonic mononitrile
-Cypermethrin,PSM
-Cyproconazole,PSM
 DPX-Y6202-31,Quizalofop-p-ethyl
 Dauerkultur ohne nähere Angaben,"Occupation, permanent crop"
-Deltamethrin,PSM
 Desmedipham,ethyl 3-phenylcarbamoyloxyphenylcarbamate
 "Diaminomethanal, Carbamide",Urea
 Diatomite,"Diatomite, in ground"
@@ -330,10 +324,7 @@ Dibutyl p-phthalat,"Phthalate, dibutyl-"
 Dichlormonofluormethan,"Methane, dichlorofluoro-, HCFC-21"
 Diclofop,HOE-021079
 Dicrotophos,Phosphoric acid (E)-3-(dimethylamino)-1-methyl-3-oxo-1-propenyl dimethyl ester
-Difenoconazole,PSM
 Diflufenzopyr-sodium,"sodium 2-{(EZ)-1-[4-(3,5-difluorophenyl)semicarbazono]ethyl}nicotinate"
-Dimefuron,PSM
-Dimethenamid,PSM
 Dimethoate,"O,O-dimethyl S-methylcarbamoylmethyl phosphorodithioate"
 Dimethyl malonate,"malonic acid dimethyl ester, propanedioic acid dimethyl ester"
 Dimethyl p-phthalat,"Phthalate, dimethyl-"
@@ -355,7 +346,6 @@ Dropp,Thidiazuron
 Dysprosium,"Dysprosium, in ground"
 EPTC,"N,N-dipropylthiocarbamic acid s ethyl ester"
 Elemental carbon,"TOC, Total Organic Carbon"
-Epoxiconazole,PSM
 Erbium,"Erbium, in ground"
 Ethalfluralin,Ethalfuralin
 Ethane thiol,Ethyl hydrosulfide
@@ -394,13 +384,11 @@ Fenhexamid,"N-(2,3-dichloro-4-hydroxyphenyl)-1-methylcyclohexane-1-carboxamide"
 Fenoxaprop-P ethyl ester,Fenoxaprop-p-ethyl
 Fentin acetate,triphenyltin acetate
 Floransulam,Florasulam
-Fluazinam,PSM
 Fludioxonil,"Pyrrole-3-carbonitrile, 4-(2,2-difluoro-1,3-benzodioxol-4-yl)-"
 Fluometuron,herbicide c-2059
 Fluorine,"Fluorine, in ground"
 "Fluorine, 4.5% in apatite, 3% in crude ore","Fluorine, 4.5% in apatite, 3% in crude ore, in ground"
 Fluorochloridone,Flurochloridone
-Fluoroglycofen-ethyl,PSM
 Fluorspar,"Fluorspar, in ground"
 Flutolanil,N-(3-(1-methylethoxy)phenyl)-2-(trifluoromethyl)benzamide
 Formamide,"methanamide, carbamaldehyde"
@@ -490,7 +478,6 @@ Metaldehyde,Metaldehyde (tetramer)
 Metaldehyde,"r-2,c-4,c-6,c-8-tetramethyl-1,3,5,7-tetroxocane"
 Metam-sodium,Metam-sodium dihydrate
 "Metamorphous rock, graphite containing","Metamorphous rock, graphite containing, in ground"
-Metconazole,PSM
 Methamidophos,Tahmabon
 Methane,"Methane, fossil"
 "Methane, biogenic","Methane, non-fossil"
@@ -512,7 +499,6 @@ Methyl amine,Methylamine
 Methyl parathion,"Parathion, methyl"
 Metolachlor,"Metolachlor, (S)"
 "Metolachlor, (S)",S-metolachlor
-Metsulfuron-methyl,PSM
 Molinate,Yulan
 Molybdenum,"Molybdenum, in ground"
 "Molybdenum, 0.010% in sulfide, Mo 8.2E-3% and Cu 1.83% in crude ore","Molybdenum, 0.010% in sulfide, Mo 8.2E-3% and Cu 1.83% in crude ore, in ground"
@@ -606,8 +592,6 @@ Procymidone,S-7131
 Propamocarb HCl,propyl 3-(dimethylamino)propylcarbamate hydrochloride
 Propanal,"propionaldehyde, methylacetaldehyde, propionic aldehyde, propaldehyde"
 Propanil,Stam M-4
-Propaquizafop,PSM
-Propiconazole,PSM
 Prosulfocarb,S-benzyl dipropylthiocarbamate
 Protactinium,"Protactinium, in ground"
 Pumice,"Pumice, in ground"

--- a/data/flows.csv
+++ b/data/flows.csv
@@ -247,8 +247,6 @@ Cadmium,"Cadmium, ion"
 Calcite,"Calcite, in ground"
 Calcium,"Calcium, in ground"
 Calcium,"Calcium, ion"
-Calcium carbonate,"Calcium, in ground"
-Calcium chloride,"Calcium, in ground"
 Calcium sulfate dihydrate,"Gypsum, in ground"
 Caparol,Prometryn
 Captan,"N-(trichloromethylthio)cyclohex-4-ene-1,2-dicarboximide"
@@ -559,15 +557,8 @@ Oxydemeton methyl,Oxydemeton-methyl
 Oxydemeton-methyl,"S-2-ethylsulfinylethyl O,O-dimethyl phosphorothioate"
 PCB,Polychlorinated biphenyls
 PCP,"Phenol, pentachloro-"
-PSM,Starane
-PSM,Tebuconazole
-PSM,Thifensulfuron-methyl
-PSM,Triasulfuron
-PSM,Triflusulfuron-methyl
 Palladium,"Palladium, in ground"
 "Palladium, Pd 1.6E-6%, in mixed ore","Palladium, Pd 1.6E-6%, in mixed ore, in ground"
-"Pd, Pd 2.0E-4%, Pt 4.8E-4%, Rh 2.4E-5%, Ni 3.7E-2%, Cu 5.2E-2% in ore, in ground",Platin ab Erz
-"Pd, Pd 7.3E-4%, Pt 2.5E-4%, Rh 2.0E-5%, Ni 2.3E+0%, Cu 3.2E+0% in ore, in ground",Platin ab Erz
 Peat,"Peat, in ground"
 Pentachlorphenol,"Phenol, pentachloro-"
 Perchlorate,"Perchlorate, ion"
@@ -579,8 +570,6 @@ Phosphine,phosphorated hydrogen
 Phosphorus,"Phosphorus, in ground"
 "Phosphorus, 18% in apatite, 4% in crude ore","Phosphorus, 18% in apatite, 4% in crude ore, in ground"
 Piperonyl butoxide,pyrenone 606
-Platin ab Erz,"Pt, Pt 2.5E-4%, Pd 7.3E-4%, Rh 2.0E-5%, Ni 2.3E+0%, Cu 3.2E+0% in ore, in ground"
-Platin ab Erz,"Pt, Pt 4.8E-4%, Pd 2.0E-4%, Rh 2.4E-5%, Ni 3.7E-2%, Cu 5.2E-2% in ore, in ground"
 Platinum,"Platinum, in ground"
 "Platinum, Pt 4.7E-7%, in mixed ore","Platinum, Pt 4.7E-7%, in mixed ore, in ground"
 Polonium,"Polonium, in ground"
@@ -712,9 +701,6 @@ methyl 3-(3-methylcarbaniloyloxy)carbanilate,Phenmedipham
 "methyl DL-lactate, 2-mydroxy-propanoic acid methyl ester",Methyl lactate
 methyl N-{2-[1-(4-chlorophenyl)pyrazol-3-yloxymethyl]phenyl}(N-methoxy)carbamate,Pyraclostrobin
 methyl N-{2-[1-(4-chlorophenyl)pyrazol-3-yloxymethyl]phenyl}(N-methoxy)carbamate,Pyraclostrobin (prop)
-nicht für Gesamtvolumen des Stollens,"Volume occupied, final repository for low-active radioactive waste"
-nicht für Gesamtvolumen des Stollens,"Volume occupied, final repository for radioactive waste"
-nicht für Gesamtvolumen des Stollens,"Volume occupied, underground deposit"
 "o-Mononitrotoluene, o-methylnitrobenzene, 2-nitrotoluene, ONT",o-Nitrotoluene
 p-Xylene,Xylene
 polfoschlor,Trichlorfon
@@ -724,20 +710,6 @@ sethodydim,Sethoxydim
 "sulfan, sulphuric anhydride",Sulfur trioxide
 tetramethylthiuram disulfide,Thiram
 tribenuron,Tribenuron-methyl
-"Copper, 0.52% in sulfide, Cu 0.27% and Mo 8.2E-3% in crude ore",copper
-"Copper, 0.59% in sulfide, Cu 0.22% and Mo 8.2E-3% in crude ore",copper
-"Copper, 0.97% in sulfide, Cu 0.36% and Mo 4.1E-2% in crude ore",copper
-"Copper, 0.99% in sulfide, Cu 0.36% and Mo 8.2E-3% in crude ore",copper
-"Copper, 1.13% in sulfide, Cu 0.76% and Ni 0.76% in crude ore",copper
-"Copper, 1.18% in sulfide, Cu 0.39% and Mo 8.2E-3% in crude ore",copper
-"Copper, 1.42% in sulfide, Cu 0.81% and Mo 8.2E-3% in crude ore",copper
-"Copper, 2.19% in sulfide, Cu 1.83% and Mo 8.2E-3% in crude ore",copper
-"Copper, Cu 0.38%, Au 9.7E-4%, Ag 9.7E-4%, Zn 0.63%, Pb 0.014%, in ore",copper
-"Copper, Cu 3.2E+0%, Pt 2.5E-4%, Pd 7.3E-4%, Rh 2.0E-5%, Ni 2.3E+0% in ore",copper
-"Copper, Cu 5.2E-2%, Pt 4.8E-4%, Pd 2.0E-4%, Rh 2.4E-5%, Ni 3.7E-2% in ore",copper
-"Gold, Au 1.1E-4%, Ag 4.2E-3%, in ore",gold
-"Gold, Au 1.3E-4%, Ag 4.6E-5%, in ore",gold
-"Gold, Au 7.1E-4%, in ore",gold
 "Occupation, annual crop, non-irrigated","arable, non-irrigated"
 "Transformation, from annual crop, non-irrigated","from arable, non-irrigated"
 "Transformation, to annual crop, non-irrigated","to arable, non-irrigated"


### PR DESCRIPTION
## Summary

The PSM rows (14 in total: Bifenthrin → PSM, Cypermethrin → PSM, Cyproconazole → PSM, …) treated an unrelated regulatory grouping ("plant protection substance") as if it were a name alias, so every CF keyed on any of those pesticides got cross-applied to all the others via the synonym fan-out. Same shape of bug with Chromium III, where the hub aliases linking it to "Chromium" and "Chromium, ion" let a single Chromium VI CF silently characterise both oxidation states.

\`flows.csv\` is meant for true name aliases (same substance, different label). Bucket groupings and chemical specializations need a different mechanism — until that exists, they don't belong in this file.

## Test plan

- [x] \`cabal test\` — all suites green (825 examples)
- [x] Manual: re-run Abondance / Pear / Carbonara / Electricity / Steel — all stay within ±0.4% drift vs SP