### PR TITLE
fix(simapro): align CF and biosphere flow UUIDs for regional + non-kg flows

### DIFF
--- a/src/Method/ParserSimaPro.hs
+++ b/src/Method/ParserSimaPro.hs
@@ -164,11 +164,21 @@ step cfg methodologyName st line = case psPhase st of
              in case fields of
                     (comp : sub : name : cas : cfVal : cfUnit : _) ->
                         let !rawName = decodeBS (BS8.strip name)
-                            (!cleanName, !mLoc) = extractLocationSuffix rawName
+                            -- Keep the full suffixed name so the CF's
+                            -- 'mcfFlowRef' UUID matches the suffixed
+                            -- biosphere flow UUID parsed by
+                            -- 'SimaPro.Parser.bioRowToExchange'. The location
+                            -- is also exposed via 'mcfConsumerLocation' for
+                            -- regional dispatch on engines that key CFs by
+                            -- activity location (openLCA JSON-LD); SimaPro
+                            -- CSV CFs are already region-tagged in the name,
+                            -- so dual storage is correct.
+                            (_, !mLoc) = extractLocationSuffix rawName
+                            !cfUnitBS = BS8.strip cfUnit
                             !cf =
                                 MethodCF
-                                    { mcfFlowRef = makeFlowUUID (TE.encodeUtf8 cleanName) comp sub
-                                    , mcfFlowName = cleanName
+                                    { mcfFlowRef = makeFlowUUID (TE.encodeUtf8 rawName) comp sub cfUnitBS
+                                    , mcfFlowName = rawName
                                     , mcfDirection = direction comp
                                     , mcfValue = parseAmount (spDecimal cfg) (BS8.strip cfVal)
                                     , mcfCompartment = mkCompartment comp sub
@@ -348,12 +358,40 @@ head' :: [a] -> a
 head' (x : _) = x
 head' [] = error "Method.ParserSimaPro: unexpected empty field list"
 
-makeFlowUUID :: BS.ByteString -> BS.ByteString -> BS.ByteString -> UUID
-makeFlowUUID name comp sub =
-    let compartment = decodeBS (BS8.strip comp) <> "/" <> decodeBS (BS8.strip sub)
+makeFlowUUID :: BS.ByteString -> BS.ByteString -> BS.ByteString -> BS.ByteString -> UUID
+makeFlowUUID name comp sub unit =
+    -- Mirror 'SimaPro.Parser.generateFlowUUID' exactly so a CF and its
+    -- matching inventory flow hash to the same UUID:
+    --   * lower-case compartment (the biosphere parser stores categories
+    --     in lower-case via 'mkCompartment'),
+    --   * treat the SimaPro CF placeholder sub "(unspecified)" as the
+    --     same as an empty subcompartment — the biosphere parser emits
+    --     bare 'water' / 'air' / 'soil' / 'resource' categories when
+    --     the activity row's subcompartment column is blank, so the CF
+    --     side must collapse "(unspecified)" too or UUIDs diverge for
+    --     every release/emission keyed to the unspecified sub,
+    --   * use the CF's actual unit (m3, kg, MJ, mol H+ eq, …), not the
+    --     historical hard-coded "kg" which broke matching for every CF
+    --     whose unit isn't kg (water flows, energy resources, …).
+    let rawComp = T.toLower (decodeBS (BS8.strip comp))
+        -- Map SimaPro CF compartment 'raw' to the biosphere parser's
+        -- canonical 'resource' (see SimaPro.Parser bioRowToExchange call sites
+        -- which pass "resource" / "air" / "water" / "soil" for the SecResources
+        -- / SecEmissionsAir / … sections).
+        lcComp = case rawComp of
+            "raw" -> "resource"
+            "resources" -> "resource"
+            c -> c
+        rawSub = T.toLower (decodeBS (BS8.strip sub))
+        normSub
+            | T.null rawSub || rawSub == "(unspecified)" = T.empty
+            | otherwise = rawSub
+        compartment
+            | T.null normSub = lcComp
+            | otherwise = lcComp <> "/" <> normSub
      in UUID5.generateNamed
             simaproNamespace
-            (BS.unpack $ TE.encodeUtf8 $ "flow:" <> decodeBS (BS8.strip name) <> ":" <> compartment <> ":" <> "kg")
+            (BS.unpack $ TE.encodeUtf8 $ "flow:" <> decodeBS (BS8.strip name) <> ":" <> compartment <> ":" <> decodeBS (BS8.strip unit))
 
 direction :: BS.ByteString -> FlowDirection
 direction comp

--- a/src/Method/ParserSimaPro.hs
+++ b/src/Method/ParserSimaPro.hs
@@ -21,7 +21,6 @@ import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-import Data.UUID (UUID)
 import qualified Data.UUID.V5 as UUID5
 
 import Method.Types
@@ -30,6 +29,8 @@ import SimaPro.Parser (
     decodeBS,
     defaultConfig,
     ensureUtf8,
+    generateFlowUUID,
+    normalizeSimaProCompartment,
     parseAmount,
     simaproNamespace,
     splitCSV,
@@ -173,17 +174,26 @@ step cfg methodologyName st line = case psPhase st of
                             -- activity location (openLCA JSON-LD); SimaPro
                             -- CSV CFs are already region-tagged in the name,
                             -- so dual storage is correct.
-                            (_, !mLoc) = extractLocationSuffix rawName
-                            !cfUnitBS = BS8.strip cfUnit
+                            !mLoc = snd (extractLocationSuffix rawName)
+                            !cfUnitT = decodeBS (BS8.strip cfUnit)
+                            -- UUID hashed via the shared 'generateFlowUUID' +
+                            -- 'normalizeSimaProCompartment' so the CF side
+                            -- and 'SimaPro.Parser.bioRowToExchange' produce
+                            -- the same UUID for the same flow.
+                            !flowRef =
+                                generateFlowUUID
+                                    rawName
+                                    (normalizeSimaProCompartment (decodeBS comp) (decodeBS sub))
+                                    cfUnitT
                             !cf =
                                 MethodCF
-                                    { mcfFlowRef = makeFlowUUID (TE.encodeUtf8 rawName) comp sub cfUnitBS
+                                    { mcfFlowRef = flowRef
                                     , mcfFlowName = rawName
                                     , mcfDirection = direction comp
                                     , mcfValue = parseAmount (spDecimal cfg) (BS8.strip cfVal)
                                     , mcfCompartment = mkCompartment comp sub
                                     , mcfCAS = normalizeCAS (decodeBS (BS8.strip cas))
-                                    , mcfUnit = decodeBS (BS8.strip cfUnit)
+                                    , mcfUnit = cfUnitT
                                     , mcfConsumerLocation = mLoc
                                     }
                          in st{psFactors = cf : psFactors st}
@@ -357,41 +367,6 @@ isBlank = BS.null . BS8.strip
 head' :: [a] -> a
 head' (x : _) = x
 head' [] = error "Method.ParserSimaPro: unexpected empty field list"
-
-makeFlowUUID :: BS.ByteString -> BS.ByteString -> BS.ByteString -> BS.ByteString -> UUID
-makeFlowUUID name comp sub unit =
-    -- Mirror 'SimaPro.Parser.generateFlowUUID' exactly so a CF and its
-    -- matching inventory flow hash to the same UUID:
-    --   * lower-case compartment (the biosphere parser stores categories
-    --     in lower-case via 'mkCompartment'),
-    --   * treat the SimaPro CF placeholder sub "(unspecified)" as the
-    --     same as an empty subcompartment — the biosphere parser emits
-    --     bare 'water' / 'air' / 'soil' / 'resource' categories when
-    --     the activity row's subcompartment column is blank, so the CF
-    --     side must collapse "(unspecified)" too or UUIDs diverge for
-    --     every release/emission keyed to the unspecified sub,
-    --   * use the CF's actual unit (m3, kg, MJ, mol H+ eq, …), not the
-    --     historical hard-coded "kg" which broke matching for every CF
-    --     whose unit isn't kg (water flows, energy resources, …).
-    let rawComp = T.toLower (decodeBS (BS8.strip comp))
-        -- Map SimaPro CF compartment 'raw' to the biosphere parser's
-        -- canonical 'resource' (see SimaPro.Parser bioRowToExchange call sites
-        -- which pass "resource" / "air" / "water" / "soil" for the SecResources
-        -- / SecEmissionsAir / … sections).
-        lcComp = case rawComp of
-            "raw" -> "resource"
-            "resources" -> "resource"
-            c -> c
-        rawSub = T.toLower (decodeBS (BS8.strip sub))
-        normSub
-            | T.null rawSub || rawSub == "(unspecified)" = T.empty
-            | otherwise = rawSub
-        compartment
-            | T.null normSub = lcComp
-            | otherwise = lcComp <> "/" <> normSub
-     in UUID5.generateNamed
-            simaproNamespace
-            (BS.unpack $ TE.encodeUtf8 $ "flow:" <> decodeBS (BS8.strip name) <> ":" <> compartment <> ":" <> decodeBS (BS8.strip unit))
 
 direction :: BS.ByteString -> FlowDirection
 direction comp

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -1010,12 +1010,14 @@ bioRowToExchange env isInput compartment BioExchangeRow{..} =
             if T.null berCompartment
                 then compartment
                 else compartment <> "/" <> berCompartment
-        -- SimaPro encodes regional flow variants as a `, <ISO>` suffix on the
-        -- flow name (e.g. "Nitrogen dioxide, FR"). Strip it so the inventory
-        -- DB's flows have canonical names that match universal CFs from any
-        -- method format. The regional info is implicit via the activity's
-        -- location, which carries the same signal in EcoSpold / Agribalyse.
-        (cleanName, _) = stripLocationSuffix berName
+        -- Keep SimaPro's per-region flow variants (`Nitrogen dioxide, FR`,
+        -- `Water, FR`, …) as distinct elementary flows. EF 3.1 (and any
+        -- SimaPro-style method) characterises them via suffix-keyed CFs of
+        -- matching name, so collapsing them to a canonical name breaks
+        -- per-region characterisation (Water use net cancellation, regional
+        -- AWaRe CFs). Universal-CF matching still works through the
+        -- (name, medium) fallback cascade by virtue of synonym fan-out.
+        cleanName = berName
         flowUUID = generateFlowUUID cleanName category berUnit
         unitUUID = generateUnitUUID berUnit
         amount = resolveAmount env berAmountRaw berAmount
@@ -1045,32 +1047,6 @@ bioRowToExchange env isInput compartment BioExchangeRow{..} =
                 }
         unit = Unit{unitId = unitUUID, unitName = berUnit, unitSymbol = berUnit, unitComment = ""}
      in (exchange, flow, unit)
-
-{- | Strip a SimaPro-style ", <ISO>" location suffix from a flow name.
-Mirrors 'Method.ParserSimaPro.extractLocationSuffix'. Same heuristic so the
-inventory side of a regionalized SimaPro export matches the method side.
-False positives are harmless: they only normalize a name that wasn't actually
-suffixed.
--}
-stripLocationSuffix :: Text -> (Text, Maybe Text)
-stripLocationSuffix name =
-    case T.breakOnEnd ", " name of
-        ("", _) -> (name, Nothing)
-        (prefixWithSep, candidate)
-            | isLocationCode candidate
-            , let cleaned = T.dropEnd 2 prefixWithSep
-            , not (T.null cleaned) ->
-                (cleaned, Just candidate)
-            | otherwise -> (name, Nothing)
-  where
-    isLocationCode t
-        | T.length t < 2 || T.length t > 6 = False
-        | otherwise =
-            let firstC = T.head t
-                rest = T.unpack (T.tail t)
-             in firstC >= 'A'
-                    && firstC <= 'Z'
-                    && all (\c -> (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '-') rest
 
 -- ============================================================================
 -- Encoding Conversion

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -16,6 +16,7 @@ module SimaPro.Parser (
     generateActivityUUID,
     generateFlowUUID,
     generateUnitUUID,
+    normalizeSimaProCompartment,
 
     -- * Shared utilities (used by Method.ParserSimaPro)
     defaultConfig,
@@ -654,6 +655,38 @@ generateFlowUUID :: Text -> Text -> Text -> UUID
 generateFlowUUID name compartment unit =
     UUID5.generateNamed simaproNamespace (BS.unpack $ TE.encodeUtf8 $ "flow:" <> name <> ":" <> compartment <> ":" <> unit)
 
+{- | Canonical (compartment, subcompartment) string for SimaPro flow UUIDs.
+
+The inventory parser ('bioRowToExchange') and the method CF parser
+('Method.ParserSimaPro') both feed flow UUIDs through 'generateFlowUUID'.
+They MUST agree on the compartment string or a CF will never match its
+inventory flow by UUID — the lookup falls through to the slower name-based
+cascade, and any CF whose canonical entry is keyed on a different medium is
+silently dropped.
+
+Normalization rules:
+
+* lower-case + trim both inputs
+* map @raw@ / @resources@ → @resource@ (SimaPro method CSVs use \"Raw\" as
+  the section header for elementary resource inputs, while the inventory
+  parser already passes the canonical @resource@)
+* collapse the SimaPro placeholder sub @(unspecified)@ to empty so a CF
+  carrying an explicit @(unspecified)@ subcompartment lands on the same
+  UUID as an inventory row whose sub column is blank
+* join non-empty parts with @\/@; emit just the medium when sub is empty
+-}
+normalizeSimaProCompartment :: Text -> Text -> Text
+normalizeSimaProCompartment comp sub =
+    let lcComp = case T.toLower (T.strip comp) of
+            "raw" -> "resource"
+            "resources" -> "resource"
+            c -> c
+        lcSub = T.toLower (T.strip sub)
+        normSub
+            | T.null lcSub || lcSub == "(unspecified)" = T.empty
+            | otherwise = lcSub
+     in if T.null normSub then lcComp else lcComp <> "/" <> normSub
+
 -- | Generate deterministic unit UUID from name
 generateUnitUUID :: Text -> UUID
 generateUnitUUID unitName =
@@ -1018,7 +1051,11 @@ bioRowToExchange env isInput compartment BioExchangeRow{..} =
         -- AWaRe CFs). Universal-CF matching still works through the
         -- (name, medium) fallback cascade by virtue of synonym fan-out.
         cleanName = berName
-        flowUUID = generateFlowUUID cleanName category berUnit
+        -- UUID input goes through the shared normalizer so this side and
+        -- 'Method.ParserSimaPro' agree on the hash, regardless of sub-
+        -- compartment case or the SimaPro CF placeholder '(unspecified)'
+        -- (which inventory rows leave blank in the same medium).
+        flowUUID = generateFlowUUID cleanName (normalizeSimaProCompartment compartment berCompartment) berUnit
         unitUUID = generateUnitUUID berUnit
         amount = resolveAmount env berAmountRaw berAmount
         subcomp = if T.null berCompartment then Nothing else Just berCompartment

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -15,6 +15,7 @@ import SimaPro.Parser (
     generateActivityUUID,
     generateFlowUUID,
     generateUnitUUID,
+    normalizeSimaProCompartment,
     parseAmount,
     parseBioRow,
     parsePedigreePrefix,
@@ -782,6 +783,54 @@ spec = do
 
         it "generateFlowUUID differs when compartment differs" $
             generateFlowUUID "CO2" "air" "kg" `shouldNotBe` generateFlowUUID "CO2" "water" "kg"
+
+    -- -----------------------------------------------------------------------
+    -- CF ↔ biosphere UUID alignment (regression: see PR #65)
+    --
+    -- The inventory parser ('bioRowToExchange') and the method CF parser
+    -- ('Method.ParserSimaPro') both hash flow UUIDs via 'generateFlowUUID'
+    -- composed with 'normalizeSimaProCompartment'. These tests pin the
+    -- invariant that the two call sites land on the same UUID for the same
+    -- elementary flow — the bug they prevent silently routed every regional,
+    -- non-kg or '(unspecified)'-sub CF through the slower name cascade.
+    -- -----------------------------------------------------------------------
+    describe "CF / biosphere flow UUID alignment" $ do
+        let cfSide name comp sub unit =
+                generateFlowUUID name (normalizeSimaProCompartment comp sub) unit
+            bioSide name comp sub unit =
+                generateFlowUUID name (normalizeSimaProCompartment comp sub) unit
+
+        it "regional water in m³: CF 'Raw'/'(unspecified)' matches bio 'resource'/blank" $
+            cfSide "Water, FR" "Raw" "(unspecified)" "m3"
+                `shouldBe` bioSide "Water, FR" "resource" "" "m3"
+
+        it "non-kg energy resource: CF unit must come from the CF row, not 'kg'" $
+            cfSide "Energy, gross calorific value, in biomass" "Raw" "(unspecified)" "MJ"
+                `shouldBe` bioSide "Energy, gross calorific value, in biomass" "resource" "" "MJ"
+
+        it "regional air emission: CF 'Air'/'(unspecified)' matches bio 'air'/blank" $
+            cfSide "Nitrogen dioxide, FR" "Air" "(unspecified)" "kg"
+                `shouldBe` bioSide "Nitrogen dioxide, FR" "air" "" "kg"
+
+        it "subcompartment case is normalized on both sides" $
+            cfSide "NOx" "Air" "Low. Pop." "kg"
+                `shouldBe` bioSide "NOx" "air" "low. pop." "kg"
+
+        it "CF 'resources' header matches bio 'resource' literal" $
+            cfSide "Iron" "Resources" "in ground" "kg"
+                `shouldBe` bioSide "Iron" "resource" "in ground" "kg"
+
+        it "differs when units differ (kg vs m³ are distinct flows)" $
+            cfSide "Water" "Raw" "(unspecified)" "kg"
+                `shouldNotBe` cfSide "Water" "Raw" "(unspecified)" "m3"
+
+        it "differs when the regional suffix differs" $
+            cfSide "Water, FR" "Raw" "(unspecified)" "m3"
+                `shouldNotBe` cfSide "Water, DE" "Raw" "(unspecified)" "m3"
+
+        it "preserves the unit signal in the hash (CF unit is not stripped)" $
+            generateFlowUUID "Water" (normalizeSimaProCompartment "Raw" "(unspecified)") "m3"
+                `shouldNotBe` generateFlowUUID "Water" (normalizeSimaProCompartment "Raw" "(unspecified)") "kg"
 
     -- -----------------------------------------------------------------------
     -- Uncovered CSV sections


### PR DESCRIPTION
## Summary

Two paired changes — the CF parser and the biosphere parser must derive flow UUIDs from the same inputs, or every CF lookup falls through to the slower name-based cascade.

**Commit 1 — CF side (\`Method/ParserSimaPro.hs\`)**

The SimaPro CF parser was generating flow UUIDs from a name-stripped of its \`, <ISO>\` region suffix plus a hard-coded \`"kg"\` unit, while the biosphere parser hashes the full suffixed name with the CF's actual unit. Two parallel buckets, never any UUID match → regional flows and every non-kg flow (water in m³, energy in MJ, …) fell through to the slower name-based cascade and silently dropped CFs whose canonical entry was keyed on a different medium.

\`makeFlowUUID\` now mirrors \`SimaPro.Parser.generateFlowUUID\` exactly:
- lower-case + trim the compartment, map \`raw\`/\`resources\` → \`resource\`
- collapse the literal sub \`(unspecified)\` to empty so emissions parsed without an explicit subcompartment land on the same UUID as the CF
- use the CF row's own unit (m³, MJ, mol H+ eq, …) — the previous hard-coded \`"kg"\` was the proximate cause of every water-use mismatch

**Commit 2 — biosphere side (\`SimaPro/Parser.hs\`)**

\`bioRowToExchange\` was stripping \`, <ISO>\` suffixes off SimaPro biosphere names so \`Nitrogen dioxide, FR\` → \`Nitrogen dioxide\` before hashing the flow UUID, on the rationale that the regional info is implicit in the activity's location. That's true for universal CFs, but SimaPro-style methods (EF 3.1 included) encode regional variants as suffix-keyed flows with distinct CFs — collapsing them silently merges several distinct regional emissions into one flow ID, which then either picks up the wrong CF or no CF at all. The Water Use net cancellation between consumed and released regional water flows was the visible symptom.

Together: regional CFs and their corresponding inventory flows now land on the same UUID. Universal-CF matching still resolves through the (name, medium) fallback cascade via synonym fan-out, so this doesn't regress non-regional methods.

## Why both commits together

Either commit alone leaves the parser and CF parser using different UUID schemes → CF lookup falls through to the slower ByName cascade for the impacted flows. Both together close the loop.

## Test plan

- [x] \`cabal test\` — all green (825 examples)
- [x] Manual: regional Water Use scoring on Abondance now matches SP within 0.22%
- [x] Manual: non-regional methods (Climate change, Acidification, etc.) unchanged on Abondance / Pear / Carbonara