### PR TITLE
fix(mapping): filter regionalized CF table by exact subcompartment match

### DIFF
--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -578,10 +578,18 @@ buildMethodTables cmap mappings =
                     , T.null normSub
                     ]
         , mtRegionalizedCF =
+            -- Filter: a CF whose own compartment carries a specific subcomp
+            -- (e.g. "groundwater, long-term" or "ocean") must only apply to
+            -- flows in that exact subcomp — otherwise a CF=0 set explicitly for
+            -- a niche subcomp leaks onto flows in other subcomps via
+            -- ByName/synonym fan-out and clobbers the correct (unspecified)
+            -- fallback CF. CFs with subcomp "(unspecified)" / empty are
+            -- wildcards and match any flow subcomp.
             M.fromList
                 [ ((flowId flow, loc), (mcfValue cf, mcfUnit cf))
                 | (cf, Just (flow, _)) <- mappings
                 , Just loc <- [mcfConsumerLocation cf]
+                , cfSubcompMatchesFlow cf flow
                 ]
         , mtCompartmentMap = cmap
         , mtBroadcast = M.empty -- fill via 'fillBroadcastVector' to enable the fast path
@@ -589,6 +597,20 @@ buildMethodTables cmap mappings =
         }
   where
     stripStrategy = M.map (\(v, u, _) -> (v, u))
+
+    -- A CF compartment of (unspecified) / empty subcomp is a wildcard. A CF
+    -- with a specific subcomp must match the flow's subcomp exactly (after
+    -- normalisation through the compartment map) — otherwise an explicit-zero
+    -- niche-subcomp CF would clobber the correct (unspecified) CF for flows
+    -- in other subcomps via ByName/synonym fan-out.
+    cfSubcompMatchesFlow cf flow = case mcfCompartment cf of
+        Nothing -> True
+        Just (Compartment _ cfSub _) ->
+            let !cfSubN = T.toLower (T.strip cfSub)
+                !flowSubN = T.toLower (T.strip (fromMaybe T.empty (flowSubcompartment flow)))
+             in T.null cfSubN
+                    || cfSubN == "(unspecified)"
+                    || cfSubN == flowSubN
 
     preferBetter (v1, u1, s1) (v2, u2, s2)
         | stratPriority s1 < stratPriority s2 = (v1, u1, s1)

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -599,15 +599,32 @@ buildMethodTables cmap mappings =
     stripStrategy = M.map (\(v, u, _) -> (v, u))
 
     -- A CF compartment of (unspecified) / empty subcomp is a wildcard. A CF
-    -- with a specific subcomp must match the flow's subcomp exactly (after
-    -- normalisation through the compartment map) — otherwise an explicit-zero
-    -- niche-subcomp CF would clobber the correct (unspecified) CF for flows
-    -- in other subcomps via ByName/synonym fan-out.
+    -- with a specific subcomp must match the flow's subcomp exactly — otherwise
+    -- an explicit-zero niche-subcomp CF would clobber the correct
+    -- (unspecified) CF for flows in other subcomps via ByName/synonym fan-out.
+    --
+    -- Both sides go through 'normalizeCompartment' so a compartments.csv rule
+    -- that rewrites a subcomp can't desynchronise the filter from the sibling
+    -- 'mtExactCF' / 'mtFallbackCF' tables or the 'lookupCascadeCF' read path.
+    -- Flow subcomp resolution mirrors 'lookupCascadeCF': prefer the explicit
+    -- 'flowSubcompartment' field, fall back to the tail of "<medium>/<sub>"
+    -- parsed from 'flowCategory'.
     cfSubcompMatchesFlow cf flow = case mcfCompartment cf of
         Nothing -> True
-        Just (Compartment _ cfSub _) ->
-            let !cfSubN = T.toLower (T.strip cfSub)
-                !flowSubN = T.toLower (T.strip (fromMaybe T.empty (flowSubcompartment flow)))
+        Just comp ->
+            let Compartment _ cfSubRaw _ = normalizeCompartment cmap comp
+                !cfSubN = T.toLower (T.strip cfSubRaw)
+                rawCategory = T.toLower (flowCategory flow)
+                (rawMed, rawSubFromCat) = case T.breakOn "/" rawCategory of
+                    (m, rest)
+                        | T.null rest -> (m, T.empty)
+                        | otherwise -> (m, T.drop 1 rest)
+                rawSub =
+                    let s = T.toLower (fromMaybe T.empty (flowSubcompartment flow))
+                     in if T.null s then rawSubFromCat else s
+                Compartment _ flowSubRaw _ =
+                    normalizeCompartment cmap (Compartment rawMed rawSub T.empty)
+                !flowSubN = T.toLower (T.strip flowSubRaw)
              in T.null cfSubN
                     || cfSubN == "(unspecified)"
                     || cfSubN == flowSubN

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -22,7 +22,7 @@ import Test.Hspec
 
 import Matrix (Inventory)
 import Method.Mapping
-import Method.Types (Method (..), MethodCF (..))
+import Method.Types (Compartment (..), Method (..), MethodCF (..))
 import qualified Method.Types as MT
 import Types (Database, Flow (..), FlowType (..), Unit (..))
 import qualified UnitConversion
@@ -355,3 +355,100 @@ spec = do
                 s3 = loScore (computeLCIAScoreFromTables UnitConversion.defaultUnitConfig udb fdb inv tNonRegio2)
             map snd results !! 0 `shouldBe` Right s1
             map snd results !! 2 `shouldBe` Right s3
+
+    describe "buildMethodTables mtRegionalizedCF subcomp filter" $ do
+        -- Regression for the niche-subcomp clobber: ByName / synonym fan-out
+        -- pairs every CF sharing a name with every flow sharing that name,
+        -- so a CF with a specific subcomp (e.g. "ocean") ends up paired with
+        -- flows in *other* subcomps (e.g. "(unspecified)"). With M.fromList
+        -- last-write-wins, an explicit-zero niche CF would silently clobber
+        -- the correct wildcard CF at the (flow, location) key. The build-time
+        -- filter must drop those mismatched (cf, flow) pairs.
+        it "drops fan-out pairs where CF subcomp doesn't match flow subcomp" $ do
+            let fidUns = mkUuid 100
+                fidOcean = mkUuid 101
+                uidKg = mkUuid 200
+                flowUns =
+                    (mkFlow fidUns "water" uidKg)
+                        { flowCategory = "water"
+                        , flowSubcompartment = Just "(unspecified)"
+                        }
+                flowOcean =
+                    (mkFlow fidOcean "water" uidKg)
+                        { flowCategory = "water"
+                        , flowSubcompartment = Just "ocean"
+                        }
+                cfUns =
+                    (mkCF fidUns 3.0)
+                        { mcfFlowName = "water"
+                        , mcfCompartment = Just (Compartment "water" "(unspecified)" "")
+                        , mcfConsumerLocation = Just "FR"
+                        }
+                cfOcean =
+                    (mkCF fidOcean 0.0)
+                        { mcfFlowName = "water"
+                        , mcfCompartment = Just (Compartment "water" "ocean" "")
+                        , mcfConsumerLocation = Just "FR"
+                        }
+                -- Simulate ByName fan-out: each CF paired with every flow
+                -- sharing the name. Ordering matters for last-write-wins:
+                -- the niche-subcomp zero CF comes *after* the wildcard CF
+                -- for fidUns, so without the filter it would overwrite the
+                -- correct 3.0.
+                mappings =
+                    [ (cfUns, Just (flowUns, ByName))
+                    , (cfUns, Just (flowOcean, ByName))
+                    , (cfOcean, Just (flowUns, ByName))
+                    , (cfOcean, Just (flowOcean, ByName))
+                    ]
+                tables = buildMethodTables M.empty mappings
+                regio = mtRegionalizedCF tables
+            -- Pre-fix: this was (0.0, "kg") — clobbered by cfOcean. The
+            -- filter drops (cfOcean, flowUns) so the wildcard cfUns survives.
+            M.lookup (fidUns, "FR") regio `shouldBe` Just (3.0, "kg")
+            -- The ocean flow legitimately receives the ocean CF (and the
+            -- wildcard cfUns also matches, but cfOcean writes last so its
+            -- explicit zero stays — that's the intended modeller behaviour).
+            M.lookup (fidOcean, "FR") regio `shouldBe` Just (0.0, "kg")
+
+        it "treats CFs with empty / (unspecified) subcomp as wildcards" $ do
+            let fid = mkUuid 110
+                uidKg = mkUuid 200
+                flowOcean =
+                    (mkFlow fid "water" uidKg)
+                        { flowCategory = "water"
+                        , flowSubcompartment = Just "ocean"
+                        }
+                cfEmpty =
+                    (mkCF fid 2.0)
+                        { mcfFlowName = "water"
+                        , mcfCompartment = Just (Compartment "water" "" "")
+                        , mcfConsumerLocation = Just "DE"
+                        }
+                cfUnspecified =
+                    (mkCF fid 7.0)
+                        { mcfFlowName = "water"
+                        , mcfCompartment = Just (Compartment "water" "(unspecified)" "")
+                        , mcfConsumerLocation = Just "DE"
+                        }
+                tEmpty = buildMethodTables M.empty [(cfEmpty, Just (flowOcean, ByName))]
+                tUnspec = buildMethodTables M.empty [(cfUnspecified, Just (flowOcean, ByName))]
+            -- Both wildcard forms apply to a specific-subcomp flow.
+            M.lookup (fid, "DE") (mtRegionalizedCF tEmpty) `shouldBe` Just (2.0, "kg")
+            M.lookup (fid, "DE") (mtRegionalizedCF tUnspec) `shouldBe` Just (7.0, "kg")
+
+        it "keeps CF when mcfCompartment is Nothing (no subcomp info)" $ do
+            let fid = mkUuid 120
+                uidKg = mkUuid 200
+                flowAny =
+                    (mkFlow fid "water" uidKg)
+                        { flowSubcompartment = Just "groundwater, long-term"
+                        }
+                cf =
+                    (mkCF fid 4.0)
+                        { mcfFlowName = "water"
+                        , mcfCompartment = Nothing
+                        , mcfConsumerLocation = Just "IT"
+                        }
+                tables = buildMethodTables M.empty [(cf, Just (flowAny, ByName))]
+            M.lookup (fid, "IT") (mtRegionalizedCF tables) `shouldBe` Just (4.0, "kg")


### PR DESCRIPTION
## Summary

When a method CF carries a specific subcompartment (e.g. \`groundwater, long-term\` or \`ocean\`), the regionalized table was keying it on \`(flowId flow, loc)\` regardless of whether the flow's subcomp matched. Combined with ByName / synonym fan-out — which broadcasts each CF to every flow sharing its name — and \`M.fromList\`'s last-write-wins semantics, a CF=0 entry set for a niche subcomp would silently clobber the correct \`(unspecified)\` CF on flows in other subcomps.

The visible failure mode was regional Water-Use scores collapsing to ~0 for a handful of activities. Generally any regionalized method whose CFs explicitly enumerate niche subcompartments with zero CFs (Water use, regionalized acidification) was at risk.

## The fix

Add \`cfSubcompMatchesFlow\`:
- CFs whose own compartment carries \`(unspecified)\` or an empty subcomp stay wildcards (they match any flow subcomp, preserving the fallback behaviour the cascade relies on)
- CFs with a specific subcomp must match the flow's subcomp exactly

Apply the predicate as a guard in the \`mtRegionalizedCF\` comprehension so the niche entries never enter the table for the wrong (flow, location) pairs.

## Test plan

- [x] \`cabal test\` — all green (825 examples)
- [x] Manual: Water-Use scores on Abondance no longer collapse on activities that previously hit the niche-subcomp clobber

## Performance impact

Slight speedup — \`mtRegionalizedCF\` is now smaller (fewer entries to walk on the regional lookup hot path).