### PR TITLE
fix(mapping): regionalized LCIA returns partial score on tainted columns

### DIFF
--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -537,10 +537,10 @@ mapMethodToTablesCachedWithHier manager dbName db hier method = do
                 !tables = fillRegionalActivityWeights unitConfig mUnits mFlows db hier withBroadcast
             -- Surface the deduplicated regionalized CF gaps ONCE, here at
             -- table-build time, rather than per-pid × per-method on the hot
-            -- scoring path. Matches the "no silent misbehaviour" rule: the
-            -- precomputed weights still under-count for tainted activities
-            -- (callers like 'computeRegionalizedLCIAScore' return Left when a
-            -- tainted activity carries non-zero scaling — see its doc).
+            -- scoring path. This WARN is the single source of truth for
+            -- coverage gaps: 'computeRegionalizedLCIAScore' returns a
+            -- partial 'Right' with tainted activities contributing 0, so
+            -- score time no longer signals the gap.
             case mtRegionalActivityWeights tables of
                 Nothing -> pure ()
                 Just raw' ->

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -667,12 +667,13 @@ pair is accumulated in 'rawMissingPairs' for deduplicated warning emission
 by the caller — instead of one warning per pid × per method × per missing CF
 under the old per-call path.
 
-Score-time semantics: callers can choose between returning a partial score
-that under-counts tainted activities (matching the broadcast path's
-silent-omission behaviour for non-regio flows) or a 'Left' when any tainted
-activity has non-zero scaling (matching the old strict per-call surface).
-'computeRegionalizedLCIAScore' picks the strict surface, mirroring the
-existing contract documented on 'computeLCIAScoreAuto'.
+Score-time semantics: 'computeRegionalizedLCIAScore' returns a partial
+score that under-counts tainted activities (matching the broadcast path's
+silent-omission behaviour for non-regio flows, and SimaPro). The coverage
+gap is surfaced once via 'rawMissingPairs' + the build-time WARN, not by
+'Left'-ing the whole method — that contract used to be strict but masked
+every other column's valid contribution as soon as one (flow, location)
+pair was uncovered.
 
 No-op when 'mtRegionalizedCF tables' is empty — non-regionalized methods
 keep 'mtRegionalActivityWeights = Nothing' so the broadcast fast path stays
@@ -873,8 +874,11 @@ The caller is expected to provide both an 'Inventory' (cheap if already
 computed for other purposes) and a scaling 'Vector' (cheap if the MUMPS
 factorization is cached). Pass them both and let this function pick.
 
-Returns 'Either' so regionalized methods can surface coverage gaps as
-explicit errors instead of silently under-counting.
+Returns 'Either' so the regionalized path can surface integrity errors
+(scaling/weights length mismatch, weights absent) explicitly. Coverage
+gaps are NOT surfaced here — they appear once at table-build time as a
+WARN listing the uncovered (flow, location) pairs; score-time returns
+the partial 'Right'.
 -}
 computeLCIAScoreAuto ::
     UnitConfig ->
@@ -947,13 +951,19 @@ computeRegionalizedLCIAScore _unitConfig _unitDB _flowDB _db scalingVec _hier ta
                     \ this automatically)."
   where
     -- Fast path: one dot product over precomputed per-column weights.
-    -- If any tainted activity carries non-zero scaling, surface the gap
-    -- as a 'Left' to match the strict-Either contract callers depend on;
-    -- the human-readable per-(flow, location) detail was already emitted
-    -- as a single warning when the table was built.
+    -- Tainted columns contribute 0 by construction in
+    -- 'fillRegionalActivityWeights' (weights[i] == 0 when no CF matched),
+    -- so summing them yields the correct partial score. The coverage gap is
+    -- surfaced once at table-build time via 'rawMissingPairs' + the WARN
+    -- in 'Database.Manager' — not by collapsing the whole method to a
+    -- 'Left', which forced every category with even one uncovered
+    -- (flow, location) pair to 0 µPt and masked the partial score.
+    -- Matches SimaPro behaviour.
+    --
+    -- 'Left' is reserved here for genuine integrity errors (length mismatch
+    -- below; "weights absent" in the outer 'case'), not coverage gaps.
     scoreFromPrecomputed raw s =
         let !weights = rawWeights raw
-            !tainted = rawTainted raw
             !n = U.length weights
             !sLen = U.length s
          in if sLen /= n
@@ -965,27 +975,15 @@ computeRegionalizedLCIAScore _unitConfig _unitDB _flowDB _db scalingVec _hier ta
                             <> T.pack (show n)
                             <> "). Activity index and precomputed weights are built from the same database — this means the cache is stale or the wrong tables were paired."
                 else
-                    let go !i !acc !taintHits
-                            | i >= n = (acc, taintHits)
+                    let go !i !acc
+                            | i >= n = acc
                             | otherwise =
                                 let !sv = U.unsafeIndex s i
                                  in if sv == 0
-                                        then go (i + 1) acc taintHits
-                                        else
-                                            let !taintHits' =
-                                                    if U.unsafeIndex tainted i /= 0
-                                                        then taintHits + 1
-                                                        else taintHits
-                                                !acc' = acc + sv * U.unsafeIndex weights i
-                                             in go (i + 1) acc' taintHits'
-                        (!score, _touchedTaintedCount) = go 0 0 (0 :: Int)
-                     in -- Tainted columns contributed 0 (weights[i] == 0 by construction
-                        -- in 'fillRegionalActivityWeights' when no CF matched).
-                        -- Surface the gap via the build-time warning + 'rawMissingPairs',
-                        -- not by collapsing the whole method to a 'Left' (which forced
-                        -- every category with even one uncovered (flow, location) pair
-                        -- to 0 µPt, masking the partial score). Matches SimaPro behaviour.
-                        Right score
+                                        then go (i + 1) acc
+                                        else go (i + 1) (acc + sv * U.unsafeIndex weights i)
+                        !score = go 0 0
+                     in Right score
 
 {- | Cross-DB regionalized LCIA score.
 
@@ -1001,19 +999,21 @@ Closes the gap where dep-DB biosphere emissions are present in the merged
 inventory but invisible to the regional dot product (which was previously
 keyed on the root DB's activity columns alone).
 
-Per-DB 'Left' is tolerated: any DB whose 'computeRegionalizedLCIAScore'
-fails (tainted columns with non-zero scaling, missing weights, …) drops to
-a 0 contribution from THAT database and the function keeps summing the
-rest. The build-time WARN already lists every uncovered (flow, location)
-pair per @(db, method)@ — that is the single source of truth for what's
-missing. Score-time silently zeroing a whole method just because one dep
-DB has incomplete coverage would regress the user's view of computable
-methods; this best-effort sum preserves the partial answer while the
-build-time WARN keeps the coverage gap visible.
+Coverage gaps no longer show up here: 'computeRegionalizedLCIAScore'
+returns 'Right' with tainted columns contributing 0, so an incomplete-
+coverage DB just contributes its partial score to the sum. The build-time
+WARN + 'rawMissingPairs' per @(db, method)@ is the single source of truth
+for what's missing — score time stays quiet.
 
-Returns 'Left' only when 'every' triple's score is 'Left' (no recoverable
-contribution from any participating DB) — the gap is unrecoverable and the
-caller should surface it as an error rather than report 0.
+Per-DB 'Left' is tolerated for genuine integrity errors (scaling/weights
+length mismatch, weights absent on a regionalized method): that DB drops
+to a 0 contribution and the function keeps summing the rest, preserving
+the partial answer over the other DBs.
+
+Returns 'Left' only when 'every' triple's score is 'Left' — i.e. every
+participating DB hit an integrity error and there is no salvageable
+contribution. The concatenated error messages are surfaced so the caller
+can act on them.
 -}
 sumRegionalizedLCIAScoreCrossDB ::
     UnitConfig ->

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -978,15 +978,14 @@ computeRegionalizedLCIAScore _unitConfig _unitDB _flowDB _db scalingVec _hier ta
                                                         else taintHits
                                                 !acc' = acc + sv * U.unsafeIndex weights i
                                              in go (i + 1) acc' taintHits'
-                        (!score, !touchedTaintedCount) = go 0 0 (0 :: Int)
-                     in if touchedTaintedCount > 0
-                            then
-                                Left $
-                                    "Regionalized CF lookup failed on "
-                                        <> T.pack (show touchedTaintedCount)
-                                        <> " tainted activity column(s) reached by this inventory"
-                                        <> " — see warnings emitted at table-build time for the missing (flow, location) pairs."
-                            else Right score
+                        (!score, _touchedTaintedCount) = go 0 0 (0 :: Int)
+                     in -- Tainted columns contributed 0 (weights[i] == 0 by construction
+                        -- in 'fillRegionalActivityWeights' when no CF matched).
+                        -- Surface the gap via the build-time warning + 'rawMissingPairs',
+                        -- not by collapsing the whole method to a 'Left' (which forced
+                        -- every category with even one uncovered (flow, location) pair
+                        -- to 0 µPt, masking the partial score). Matches SimaPro behaviour.
+                        Right score
 
 {- | Cross-DB regionalized LCIA score.
 

--- a/test/CrossDBRegionalLCIASpec.hs
+++ b/test/CrossDBRegionalLCIASpec.hs
@@ -172,14 +172,14 @@ spec = describe "cross-DB regional LCIA" $ do
                     perDb
                     `shouldBe` Right 0.0
 
-    it "NEW path: all-Left case (every participating DB tainted) surfaces Left" $ do
-        -- Every DB Lefts (no Right to fall back to). The sum has nothing
-        -- to sum, so it Lefts — preserves no-silent-errors when there is
-        -- genuinely no recoverable contribution.
+    it "NEW path: all-tainted case returns partial sum (tainted columns contribute 0)" $ do
+        -- Every DB has tainted columns (no Right to fall back to). Each DB
+        -- returns Right with tainted-column contribution = 0; the cross-DB
+        -- sum is therefore Right 0. Build-time warnings surface the gaps.
         let strictMappings = regionalMappings [("FR", 1)]
             depTablesStrict = buildTables depDb strictMappings
             -- Root variant with a tainted biosphere triple at DE so both
-            -- root and dep tables Left on the precomputed dot product.
+            -- root and dep tables have tainted columns under strict mappings.
             taintedRoot = mkDB 100 ["DE"] [(0, 1.0)]
             taintedRootTables = buildTables taintedRoot strictMappings
         rootSolver <- mkSolverFromDb taintedRoot "root"
@@ -206,18 +206,13 @@ spec = describe "cross-DB regional LCIA" $ do
                         "root" -> taintedRootTables
                         "dep" -> depTablesStrict
                         other -> error ("unexpected dbName in csScalings: " <> show other)
-                case sumRegionalizedLCIAScoreCrossDB
+                sumRegionalizedLCIAScoreCrossDB
                     kgUnitConfig
                     (dbUnits depDb)
                     (dbFlows depDb)
                     M.empty
-                    perDb of
-                    Left _ -> pure ()
-                    Right v ->
-                        expectationFailure
-                            ( "expected Left when every DB Lefts, got Right "
-                                <> show v
-                            )
+                    perDb
+                    `shouldBe` Right 0.0
 
     describe "non-regression invariants" $ do
         -- These guard the cross-DB regional fix against drift on adjacent

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -265,24 +265,25 @@ spec = do
                 tables
                 `shouldBe` Right 220
 
-        it "returns Left when a tainted activity column carries non-zero scaling" $ do
+        it "returns partial Right when a tainted activity column carries non-zero scaling" $ do
             -- F has a regional CF only at FR. A2@DE has B[F,A2]=20 and no
             -- regional/parent/broadcast CF. With scaling[A2]=1, the column
-            -- is touched-tainted and scoring must Left out.
+            -- is touched-tainted and contributes 0 to the score (matches
+            -- SimaPro behaviour). A1@FR still contributes 1·20=20.
+            -- Build-time warnings + 'rawMissingPairs' surface the gap.
             let db = mkDB [("FR", 10), ("DE", 20)]
                 mappings = regionalMappings [("FR", 2)]
                 tables = buildTables db M.empty mappings
                 scaling = U.fromList [1, 1]
-            case computeRegionalizedLCIAScore
+            computeRegionalizedLCIAScore
                 kgUnitConfig
                 (dbUnits db)
                 (dbFlows db)
                 db
                 scaling
                 M.empty
-                tables of
-                Left _ -> pure ()
-                Right v -> expectationFailure ("expected Left, got Right " <> show v)
+                tables
+                `shouldBe` Right 20
 
         it "ignores tainted columns whose scaling is zero" $ do
             -- Same fixture as the tainted case, but with scaling[A2]=0.


### PR DESCRIPTION
## Summary

\`computeRegionalizedLCIAScore\` used to collapse the whole impact category to a \`Left\` the moment any tainted activity column carried non-zero scaling.

**A "tainted column" is** an activity column where at least one biosphere flow had a regionalized CF table entry, but none of its CFs resolved at this column's location (no direct match, no parent in the geo hierarchy, no fallback broadcast). The flow contributes 0 to that column's weight by construction in \`fillRegionalActivityWeights\`. So the precomputed weight is **incomplete**, not wrong — the missing flow simply isn't counted.

Lefting the whole method wiped out every **other** column's valid contribution and reported 0 µPt to the caller, masking partial coverage that SimaPro happily surfaces. The bigger the database (or the smaller the regional CF coverage), the more often this fired.

## The fix

Return \`Right score\` unconditionally. The gap is already named at table-build time via \`rawMissingPairs\` + the per-\`(flow, location)\` warning (visible via \`GET /api/v1/logs?since=N\` and on stderr), so callers that want to fail loud still can.

This matches SimaPro behaviour and recovers per-category contributions for any method with incomplete regional CF coverage (Water use was the canary).

## Tests

Updates two specs that asserted the old Left-out behaviour to assert the partial-score contract instead:
- \`RegionalLCIASpec\`: "returns partial Right when a tainted activity column carries non-zero scaling"
- \`CrossDBRegionalLCIASpec\`: "NEW path: all-tainted case returns partial sum (tainted columns contribute 0)"

## Test plan

- [x] \`cabal test\` — all green (825 examples)
- [x] Manual: Water-Use on activities with incomplete regional coverage now scores instead of returning 0 µPt