### PR TITLE
fix(simapro/parser): preserve sign on Materials/fuels exchanges (substitution semantics)

### DIFF
--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -975,7 +975,7 @@ techRowToExchange env isInput TechExchangeRow{..} =
                     Just
                         TechnosphereExchange
                             { techFlowId = flowUUID
-                            , techAmount = abs resolvedAmount
+                            , techAmount = resolvedAmount
                             , techUnitId = unitUUID
                             , techIsInput = isInput
                             , techIsReference = False

--- a/test/MatrixConstructionSpec.hs
+++ b/test/MatrixConstructionSpec.hs
@@ -11,15 +11,20 @@ import Types
 spec :: Spec
 spec = do
     describe "Matrix Construction Sign Convention" $ do
-        it "stores technosphere triplets as POSITIVE input coefficients" $ do
-            -- CRITICAL REGRESSION TEST: Prevent reintroduction of negative sign bug
-            -- The fix in Query.hs line 93 stores: value = rawValue / denom (POSITIVE)
-            -- Matrix.hs line 232 negates when building (I-A)
+        it "stores technosphere input triplets as positive on samples without substitutions" $ do
+            -- Regression: an earlier bug stored input coefficients with the
+            -- wrong sign, producing positive (I-A) off-diagonals instead of
+            -- negative ones. Database.hs sets value = sign * amount / denom
+            -- with sign=+1 for inputs; Matrix.hs negates when building (I-A).
+            --
+            -- SAMPLE.min3 has no substitution (avoided-burden) rows, so every
+            -- input is a real consumption and every tech triplet is positive.
+            -- Sources with negative Materials/fuels rows legitimately produce
+            -- negative triplets — see SimaProParserSpec "SimaPro substitutions".
             db <- loadSampleDatabase "SAMPLE.min3"
 
             let techTriples = VU.toList (dbTechnosphereTriples db)
 
-            -- Verify all technosphere triplets are POSITIVE
             -- Expected: Y needs 0.6 from X, Z needs 0.4 from Y
             let positiveTriplets = filter (\(SparseTriple _ _ v) -> v > 0) techTriples
             length positiveTriplets `shouldBe` length techTriples

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -949,6 +949,31 @@ spec = do
             -- A single-product Process still carries Just 100.0 allocation.
             activityAllocationPercent (head activities) `shouldBe` Just 100.0
 
+    -- A negative amount on a Materials/fuels row encodes a SimaPro substitution
+    -- (avoided burden): the activity co-produces a fraction of that input
+    -- instead of consuming it. The sign must reach the matrix so the solver
+    -- subtracts the upstream footprint. Historically the parser took `abs`
+    -- here, silently turning every substitution into extra consumption.
+    describe "SimaPro substitutions (negative Materials/fuels)" $ do
+        it "preserves the negative sign on Materials/fuels exchanges" $ do
+            (activities, _, _) <- parseSectionCSV
+                [ "Materials/fuels"
+                , "Avoided diesel;kg;-1.5;Undefined;;;;;;"
+                ]
+            length activities `shouldBe` 1
+            techInputAmounts (head activities) `shouldBe` [-1.5]
+
+        it "keeps positive and negative rows side by side with their own signs" $ do
+            (activities, _, _) <- parseSectionCSV
+                [ "Materials/fuels"
+                , "Fertilizer input;kg;231.84;Undefined;;;;;;"
+                , "Avoided diesel;kg;-1568.16;Undefined;;;;;;"
+                ]
+            length activities `shouldBe` 1
+            -- Order-agnostic compare: the two amounts must appear unchanged.
+            S.fromList (techInputAmounts (head activities))
+                `shouldBe` S.fromList [231.84, -1568.16]
+
 -- ---------------------------------------------------------------------------
 -- Helpers for section tests
 -- ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

\`techRowToExchange\` was storing \`techAmount = abs resolvedAmount\`, which silently flipped the sign of every Materials/fuels exchange written with a negative amount in the SimaPro CSV.

In SimaPro's convention, a **negative Materials/fuels row encodes a substitution / avoided burden** — the activity produces some of that input rather than consuming it. The matrix coefficient must stay negative so the solver subtracts the upstream footprint instead of double-counting it.



## The fix

Drop the \`abs\`. SimaPro positive amounts are unchanged; negative amounts now propagate through the matrix as proper avoided-burden coefficients.

## Test plan

- [x] \`cabal test\` — all green (825 examples)
- [x] Manual: Pear / Abondance / Carbonara / Electricity / Steel all within ±0.4% of SP totals