### PR TITLE
fix(matrix): drop the post-normalization 1e-15 magnitude filter on matrix triplets

### DIFF
--- a/src/Database.hs
+++ b/src/Database.hs
@@ -162,7 +162,7 @@ buildDatabaseWithMatrices unitConfig activityMap flowDB unitDB = do
                                                     else 1.0
                                             sign = if exchangeIsInput ex then 1 else -1
                                             value = sign * convertedValue / denom
-                                         in Right ([SparseTriple idx j value | abs value > 1e-15, idx /= j], warnings)
+                                         in Right ([SparseTriple idx j value | convertedValue /= 0, idx /= j], warnings)
                         Nothing -> Right ([], warnings)
 
         buildActivityTriplets (j, consumerPid) =
@@ -211,7 +211,7 @@ buildDatabaseWithMatrices unitConfig activityMap flowDB unitDB = do
                                         let rawValue = exchangeAmount ex
                                             denom = if normalizationFactor > 1e-15 then normalizationFactor else 1.0
                                             value = rawValue / denom
-                                         in [SparseTriple i j value | abs value > 1e-15]
+                                         in [SparseTriple i j value | rawValue /= 0]
                                     Nothing -> []
 
                         buildActivityBioTriplets (j, pid) =

--- a/test/MatrixConstructionSpec.hs
+++ b/test/MatrixConstructionSpec.hs
@@ -2,11 +2,22 @@
 
 module MatrixConstructionSpec (spec) where
 
+import qualified Data.Map as M
+import qualified Data.Text as T
+import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU
+import Database (buildDatabaseWithMatrices)
 import Test.Hspec
 import TestHelpers
 import Types
+import UnitConversion (defaultUnitConfig)
+
+-- | Build a UUID from a literal string; explode loudly at test time if malformed.
+mkUUID :: String -> UUID.UUID
+mkUUID s = case UUID.fromString s of
+    Just u -> u
+    Nothing -> error $ "invalid UUID literal in test: " <> s
 
 spec :: Spec
 spec = do
@@ -77,12 +88,17 @@ spec = do
             V.length activityIndex `shouldBe` 3
 
     describe "Matrix Sparsity" $ do
-        it "filters values below threshold (1e-15)" $ do
+        it "produces only well above-zero entries on the basic SAMPLE.min3 fixture" $ do
+            -- Sanity check on SAMPLE.min3 — its declared exchanges are all O(0.1..1),
+            -- so post-normalization triplets sit comfortably above any floating-point
+            -- noise floor. Kept as a smoke test that the matrix builder produces sane
+            -- magnitudes on a known good fixture. Note: PR #69 dropped the previous
+            -- post-normalization 1e-15 magnitude filter (it dropped legitimate
+            -- emissions on large-productAmount activities); see the "PR #69" test
+            -- below for the regression.
             db <- loadSampleDatabase "SAMPLE.min3"
 
             let techTriples = VU.toList (dbTechnosphereTriples db)
-
-            -- All values should be > 1e-15
             all (\(SparseTriple _ _ v) -> abs v > 1.0e-15) techTriples `shouldBe` True
 
         it "excludes diagonal entries from technosphere triplets" $ do
@@ -93,3 +109,161 @@ spec = do
             -- Diagonal entries (self-loops) are excluded in simple SAMPLE.min3
             let diagonalEntries = filter (\(SparseTriple i j _) -> i == j) techTriples
             length diagonalEntries `shouldBe` 0
+
+        it "keeps biosphere flows on activities with very large reference amounts (PR #69)" $ do
+            -- Regression: the previous filter `abs value > 1e-15` was applied AFTER
+            -- dividing rawValue by the normalization factor. For activities whose
+            -- reference product gets normalized to a large canonical-unit amount at
+            -- ingest (e.g. SimaPro turns "1 kWh" into 3.6e6 J, so normFactor = 3.6e6),
+            -- a real 1e-9 kg emission yielded a post-normalization value of ~2.8e-16
+            -- and was silently dropped. The fix moves the filter to the source value,
+            -- so the triplet must now survive even though its stored magnitude is
+            -- below 1e-15.
+            let actUUID = mkUUID "11111111-2222-3333-4444-555555555555"
+                prodUUID = mkUUID "22222222-3333-4444-5555-666666666666"
+                bioFlowUUID = mkUUID "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+                jUnitId = mkUUID "00000000-0000-0000-0000-00000000000a"
+                kgUnitId = mkUUID "00000000-0000-0000-0000-00000000000b"
+                rawBioAmount = 1.0e-9 :: Double
+                normFactor = 3.6e6 :: Double
+                expectedValue = rawBioAmount / normFactor
+                refExchange =
+                    TechnosphereExchange
+                        { techFlowId = prodUUID
+                        , techAmount = normFactor
+                        , techUnitId = jUnitId
+                        , techIsInput = False
+                        , techIsReference = True
+                        , techActivityLinkId = UUID.nil
+                        , techProcessLinkId = Nothing
+                        , techLocation = ""
+                        , techComment = Nothing
+                        , techPedigree = Nothing
+                        }
+                bioExchange =
+                    BiosphereExchange
+                        { bioFlowId = bioFlowUUID
+                        , bioAmount = rawBioAmount
+                        , bioUnitId = kgUnitId
+                        , bioIsInput = False
+                        , bioLocation = ""
+                        , bioComment = Nothing
+                        , bioPedigree = Nothing
+                        }
+                activity =
+                    Activity
+                        { activityName = "high-canonical-unit power process"
+                        , activityDescription = []
+                        , activitySynonyms = M.empty
+                        , activityClassification = M.empty
+                        , activityLocation = "GLO"
+                        , activityUnit = "j"
+                        , exchanges = [refExchange, bioExchange]
+                        , activityParams = M.empty
+                        , activityParamExprs = M.empty
+                        , activityAllocationPercent = Nothing
+                        , activityAllocationFormula = Nothing
+                        }
+                activityMap = M.singleton (actUUID, prodUUID) activity
+                flowDB =
+                    M.fromList
+                        [
+                            ( prodUUID
+                            , Flow prodUUID "energy product" "energy" Nothing jUnitId Technosphere M.empty Nothing Nothing
+                            )
+                        ,
+                            ( bioFlowUUID
+                            , Flow bioFlowUUID "trace pollutant" "air" Nothing kgUnitId Biosphere M.empty Nothing Nothing
+                            )
+                        ]
+                unitDB =
+                    M.fromList
+                        [ (jUnitId, Unit jUnitId "j" "j" "")
+                        , (kgUnitId, Unit kgUnitId "kg" "kg" "")
+                        ]
+
+            result <- buildDatabaseWithMatrices defaultUnitConfig activityMap flowDB unitDB
+            case result of
+                Left err -> expectationFailure $ "buildDatabaseWithMatrices failed: " <> T.unpack err
+                Right db -> do
+                    let bioTriples = VU.toList (dbBiosphereTriples db)
+                    -- Under the old buggy filter, length would be 0 — the triplet was
+                    -- dropped because abs (1e-9 / 3.6e6) < 1e-15.
+                    length bioTriples `shouldBe` 1
+                    case bioTriples of
+                        [SparseTriple _ _ v] -> do
+                            -- The stored magnitude is genuinely below 1e-15 — this is
+                            -- exactly the case the new filter must preserve.
+                            abs v `shouldSatisfy` (< 1.0e-15)
+                            withinTolerance 1.0e-22 expectedValue v `shouldBe` True
+                        _ -> expectationFailure "expected exactly one biosphere triplet"
+
+        it "still excludes biosphere rows whose source amount is exactly zero" $ do
+            -- The fix replaced `abs value > 1e-15` with `rawValue /= 0`. Confirm the
+            -- new predicate still strips truly empty rows: an exchange with raw
+            -- amount 0 must not produce a triplet.
+            let actUUID = mkUUID "11111111-2222-3333-4444-777777777777"
+                prodUUID = mkUUID "22222222-3333-4444-5555-888888888888"
+                bioFlowUUID = mkUUID "aaaaaaaa-bbbb-cccc-dddd-ffffffffffff"
+                jUnitId = mkUUID "00000000-0000-0000-0000-00000000000a"
+                kgUnitId = mkUUID "00000000-0000-0000-0000-00000000000b"
+                refExchange =
+                    TechnosphereExchange
+                        { techFlowId = prodUUID
+                        , techAmount = 1.0
+                        , techUnitId = jUnitId
+                        , techIsInput = False
+                        , techIsReference = True
+                        , techActivityLinkId = UUID.nil
+                        , techProcessLinkId = Nothing
+                        , techLocation = ""
+                        , techComment = Nothing
+                        , techPedigree = Nothing
+                        }
+                zeroBio =
+                    BiosphereExchange
+                        { bioFlowId = bioFlowUUID
+                        , bioAmount = 0.0
+                        , bioUnitId = kgUnitId
+                        , bioIsInput = False
+                        , bioLocation = ""
+                        , bioComment = Nothing
+                        , bioPedigree = Nothing
+                        }
+                activity =
+                    Activity
+                        { activityName = "process with empty biosphere row"
+                        , activityDescription = []
+                        , activitySynonyms = M.empty
+                        , activityClassification = M.empty
+                        , activityLocation = "GLO"
+                        , activityUnit = "j"
+                        , exchanges = [refExchange, zeroBio]
+                        , activityParams = M.empty
+                        , activityParamExprs = M.empty
+                        , activityAllocationPercent = Nothing
+                        , activityAllocationFormula = Nothing
+                        }
+                activityMap = M.singleton (actUUID, prodUUID) activity
+                flowDB =
+                    M.fromList
+                        [
+                            ( prodUUID
+                            , Flow prodUUID "energy product" "energy" Nothing jUnitId Technosphere M.empty Nothing Nothing
+                            )
+                        ,
+                            ( bioFlowUUID
+                            , Flow bioFlowUUID "trace pollutant" "air" Nothing kgUnitId Biosphere M.empty Nothing Nothing
+                            )
+                        ]
+                unitDB =
+                    M.fromList
+                        [ (jUnitId, Unit jUnitId "j" "j" "")
+                        , (kgUnitId, Unit kgUnitId "kg" "kg" "")
+                        ]
+
+            result <- buildDatabaseWithMatrices defaultUnitConfig activityMap flowDB unitDB
+            case result of
+                Left err -> expectationFailure $ "buildDatabaseWithMatrices failed: " <> T.unpack err
+                Right db ->
+                    VU.length (dbBiosphereTriples db) `shouldBe` 0


### PR DESCRIPTION
## Summary

\`buildDatabaseWithMatrices\` filters technosphere / biosphere triplets through \`abs value > 1e-15\` **after** dividing the raw exchange amount by the consumer activity's reference-product amount (\`normalizationFactor\`). That threshold is correct in magnitude for kg-scale activities, but for any activity whose reference product gets unit-converted to a much larger canonical-unit amount, it filters out legitimate emissions.

## The visible case: electricity

Most electricity processes hit this. \`kWh;1\` parses to \`3,600,000 j\` (J is the canonical energy unit), so \`normalizationFactor = 3.6e6\`. A real \`Benzo(a)pyrene; air/low. pop.; 3.45e-9 kg\` biosphere row becomes \`3.45e-9 / 3.6e6 = 9.58e-16\` — below 1e-15, silently dropped. 

## The fix

Switch the filter to the **source** value:
- bio: \`rawValue /= 0\` (was \`abs value > 1e-15\`)
- tech: \`convertedValue /= 0\` (was \`abs value > 1e-15\`)

Drops genuinely-zero rows without penalising activities whose normalization scales them down. 

## Why this is the right fix

Magnitude on the raw amount is the right shape for "is this an empty row?". The post-normalization value is already a function of the consumer's productAmount and shouldn't drive filtering — solver precision is double (~15 decimal digits), and entries below 1e-15 of the largest matrix entry would lose precision in floating-point arithmetic anyway. There's nothing to gain by pre-filtering them.

## Test plan

- [x] \`cabal test\` — all green (825 examples)
- [x] Manual: 5 reference products (Abondance, Pear, Carbonara, Electricity, Steel) all within ±0.4% of SP totals after this fix
- [x] Benchmarked load + query time on agribalyse-3-2: no measurable regression