### PR TITLE
fix(docker): restore -I30 idle-GC threshold to end interactive stalls

### DIFF
--- a/docker/rts-flags.sh
+++ b/docker/rts-flags.sh
@@ -43,10 +43,14 @@ MAX_MB=$((RAM_MB * 3 / 4))
 # -Fd1.0 (GHC 9.10+): return free heap blocks to the OS over ~1 idle period
 # instead of holding them indefinitely after a parsing spike. Default decay
 # (4.0) keeps RSS pinned near the peak for minutes.
-# -I0.3 (GHC default): trigger idle-time major GC promptly. The previous
-# -I30 deferred GC for 30 s, hiding live-data drops and starving -Fd of
-# free blocks to release.
-RTS_FLAGS="+RTS -N -M${MAX_MB}M -H${HEAP_MB}M -A${NURSERY_MB}M -n${CHUNK_MB}m -qg0 -c -F1.5 -Fd1.0 -I0.3 -RTS"
+# -I30: idle-time major GC only after 30 s of genuine inactivity. A major GC
+# over a multi-GB compacting heap (-c) is a multi-second stop-the-world pause
+# on a few-core VM. -I0.3 fired it after every sub-second gap between requests,
+# so each interactive page load (/activities, /classifications) stalled ~4 s
+# behind a GC. 30 s is longer than any inter-request gap, so the pause never
+# lands during active use, yet memory is still released once the VM is idle.
+# OOM protection is -M / -F1.5 / -c, all independent of -I.
+RTS_FLAGS="+RTS -N -M${MAX_MB}M -H${HEAP_MB}M -A${NURSERY_MB}M -n${CHUNK_MB}m -qg0 -c -F1.5 -Fd1.0 -I30 -RTS"
 
 echo "RTS_FLAGS=\"$RTS_FLAGS\""
 


### PR DESCRIPTION
## Problem

On the deployed version (`fplca.ecobalyse.fr`, v0.6.1.0), the `/activities`, `/classifications` and `/classification-presets` pages take ~4 s to respond on a 4-core / 16 GB VM — instant on a 24-thread / 96 GB workstation. The slowdown typically shows up when switching database (e.g. Ecoinvent 3.9.1 -> 3.11).

## Cause

Commit #60 changed the RTS flag `-I30` -> `-I0.3` in `docker/rts-flags.sh`.

`-I` triggers an **idle-time major GC**. On a few-core VM, a major GC over a multi-GB compacting heap (`-c`) is a multi-second stop-the-world pause. `-I0.3` armed it after **every** sub-second gap between requests: when switching DB, the front-end's burst of requests gets trapped behind a GC pause at each gap.

**Proof this is not the endpoint logic**: `/classification-presets` is a pure `map` over a small static config list (no DB, no I/O), and it is just as slow — the request thread is frozen by a global GC pause, not doing real work.

## Fix

`-I0.3` -> `-I30`. The idle major GC only fires after 30 s of genuine inactivity — never during a request burst — while still releasing memory once the VM is truly idle. `-Fd1.0` kept.

## Impact on the 8 GB target of #60: none

- The crash fix of #60 (OpenBLAS pthread-stack patch for the MUMPS SIGSEGV) lives in the `Dockerfile`, **independent of `-I`** — unchanged.
- The OOM protection (`-M` = 75 % RAM, `-F1.5`, `-c`) is **independent of `-I`** — unchanged.
- `-I` only governs how fast RSS is returned *while idle*, never the memory peak (which occurs under load). `-I30` was the stable value from March to May 2026 and did not OOM the 8 GB target.

## Verification

`sh docker/rts-flags.sh` emits `... -F1.5 -Fd1.0 -I30 -RTS`.