### PR TITLE
build(docker): support building the image for a chosen --platform (ARM64)

### DIFF
--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -26,10 +26,12 @@ PLATFORM=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -t)
+            [[ -n "$2" ]] || { echo "ERROR: -t requires a tag argument" >&2; exit 1; }
             TAG="$2"
             shift 2
             ;;
         --platform)
+            [[ -n "$2" ]] || { echo "ERROR: --platform requires a platform argument (e.g. linux/arm64)" >&2; exit 1; }
             PLATFORM="$2"
             shift 2
             ;;

--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -3,10 +3,17 @@
 # Run from the volca directory.
 #
 # Usage:
-#   ./docker-build.sh                       # build image, tag `volca`
-#   ./docker-build.sh -t mytag              # build with custom tag
-#   ./docker-build.sh --extract             # build + copy binary to ./dist/volca
-#   ./docker-build.sh -t mytag --extract    # both
+#   ./docker-build.sh                          # build for the host arch, tag `volca`
+#   ./docker-build.sh -t mytag                 # build with a custom tag
+#   ./docker-build.sh --platform linux/arm64   # build for a specific architecture
+#   ./docker-build.sh --extract                # build + copy binary to ./dist/volca
+#   ./docker-build.sh -t mytag --extract       # combine flags
+#
+# --platform takes a Docker platform string (linux/amd64, linux/arm64); omitted,
+# the image is built for the host architecture. The Dockerfile builds OpenBLAS,
+# MUMPS and the GHC dependency tree from source, so building a foreign
+# architecture under QEMU emulation takes hours — build on a native host of the
+# target architecture instead. The script warns when it detects an emulated build.
 
 set -e
 
@@ -14,11 +21,16 @@ cd "$(dirname "$0")/.."
 
 TAG="volca"
 EXTRACT=false
+PLATFORM=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -t)
             TAG="$2"
+            shift 2
+            ;;
+        --platform)
+            PLATFORM="$2"
             shift 2
             ;;
         --extract)
@@ -27,11 +39,18 @@ while [[ $# -gt 0 ]]; do
             ;;
         *)
             echo "ERROR: unknown argument: $1" >&2
-            echo "Usage: $0 [-t TAG] [--extract]" >&2
+            echo "Usage: $0 [-t TAG] [--platform PLATFORM] [--extract]" >&2
             exit 1
             ;;
     esac
 done
+
+# buildx is the only builder that honours --platform together with --load. It
+# ships with Docker since 19.03; fail clearly rather than with a cryptic error.
+if ! docker buildx version >/dev/null 2>&1; then
+    echo "ERROR: 'docker buildx' is not available — install the Docker buildx plugin." >&2
+    exit 1
+fi
 
 GIT_HASH=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 if ! git diff --quiet HEAD 2>/dev/null; then
@@ -42,9 +61,32 @@ GIT_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
 # shellcheck source=../versions.env
 source versions.env
 
-echo "Building Docker image: tag=$TAG hash=$GIT_HASH git-tag=${GIT_TAG:-none} alpine=$ALPINE_VERSION"
+# Warn when --platform targets an architecture other than the host's: the
+# Dockerfile compiles OpenBLAS, MUMPS and every GHC dependency from source, so an
+# emulated (QEMU) build runs for hours. Normalize `uname -m` and the platform
+# string to Docker's arch names before comparing.
+BUILD_ARGS=()
+if [[ -n "$PLATFORM" ]]; then
+    BUILD_ARGS+=(--platform "$PLATFORM")
+    case "$(uname -m)" in
+        x86_64|amd64)  HOST_ARCH="amd64" ;;
+        aarch64|arm64) HOST_ARCH="arm64" ;;
+        *)             HOST_ARCH="$(uname -m)" ;;
+    esac
+    TARGET_ARCH="${PLATFORM##*/}"
+    if [[ "$TARGET_ARCH" != "$HOST_ARCH" ]]; then
+        echo "WARNING: building '$PLATFORM' on a '$HOST_ARCH' host runs the whole" >&2
+        echo "         from-source build under QEMU emulation and takes hours." >&2
+        echo "         Build on a native $TARGET_ARCH host for a fast build." >&2
+        echo "         (Emulation also needs QEMU binfmt handlers registered.)" >&2
+    fi
+fi
 
-docker build \
+echo "Building Docker image: tag=$TAG hash=$GIT_HASH git-tag=${GIT_TAG:-none} alpine=$ALPINE_VERSION platform=${PLATFORM:-host}"
+
+docker buildx build \
+    "${BUILD_ARGS[@]}" \
+    --load \
     -f docker/Dockerfile \
     --build-arg ALPINE_VERSION="$ALPINE_VERSION" \
     --build-arg GIT_HASH="$GIT_HASH" \

--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -14,6 +14,9 @@
 # MUMPS and the GHC dependency tree from source, so building a foreign
 # architecture under QEMU emulation takes hours — build on a native host of the
 # target architecture instead. The script warns when it detects an emulated build.
+#
+# --platform requires the `docker buildx` plugin; the default host-arch build
+# does not.
 
 set -e
 
@@ -47,13 +50,6 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# buildx is the only builder that honours --platform together with --load. It
-# ships with Docker since 19.03; fail clearly rather than with a cryptic error.
-if ! docker buildx version >/dev/null 2>&1; then
-    echo "ERROR: 'docker buildx' is not available — install the Docker buildx plugin." >&2
-    exit 1
-fi
-
 GIT_HASH=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 if ! git diff --quiet HEAD 2>/dev/null; then
     GIT_HASH="${GIT_HASH}-dirty"
@@ -63,13 +59,18 @@ GIT_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
 # shellcheck source=../versions.env
 source versions.env
 
-# Warn when --platform targets an architecture other than the host's: the
-# Dockerfile compiles OpenBLAS, MUMPS and every GHC dependency from source, so an
-# emulated (QEMU) build runs for hours. Normalize `uname -m` and the platform
-# string to Docker's arch names before comparing.
-BUILD_ARGS=()
+# Pick the build command. A host-arch build uses classic `docker build`, which
+# needs no plugin. `--platform` needs `docker buildx build --load` — the only
+# builder that honours --platform together with --load.
 if [[ -n "$PLATFORM" ]]; then
-    BUILD_ARGS+=(--platform "$PLATFORM")
+    if ! docker buildx version >/dev/null 2>&1; then
+        echo "ERROR: --platform needs 'docker buildx' — install the Docker buildx plugin." >&2
+        exit 1
+    fi
+    DOCKER_BUILD=(docker buildx build --load --platform "$PLATFORM")
+
+    # Warn when the target arch differs from the host: the from-source build
+    # then runs under QEMU emulation and takes hours.
     case "$(uname -m)" in
         x86_64|amd64)  HOST_ARCH="amd64" ;;
         aarch64|arm64) HOST_ARCH="arm64" ;;
@@ -82,13 +83,13 @@ if [[ -n "$PLATFORM" ]]; then
         echo "         Build on a native $TARGET_ARCH host for a fast build." >&2
         echo "         (Emulation also needs QEMU binfmt handlers registered.)" >&2
     fi
+else
+    DOCKER_BUILD=(docker build)
 fi
 
 echo "Building Docker image: tag=$TAG hash=$GIT_HASH git-tag=${GIT_TAG:-none} alpine=$ALPINE_VERSION platform=${PLATFORM:-host}"
 
-docker buildx build \
-    "${BUILD_ARGS[@]}" \
-    --load \
+"${DOCKER_BUILD[@]}" \
     -f docker/Dockerfile \
     --build-arg ALPINE_VERSION="$ALPINE_VERSION" \
     --build-arg GIT_HASH="$GIT_HASH" \

--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -76,7 +76,13 @@ if [[ -n "$PLATFORM" ]]; then
         aarch64|arm64) HOST_ARCH="arm64" ;;
         *)             HOST_ARCH="$(uname -m)" ;;
     esac
-    TARGET_ARCH="${PLATFORM##*/}"
+    # Match known arch names anywhere in the platform string so variant forms
+    # (linux/arm64/v8) and bare forms (arm64) are recognised, not just linux/<arch>.
+    case "$PLATFORM" in
+        *amd64*|*x86_64*)  TARGET_ARCH="amd64" ;;
+        *arm64*|*aarch64*) TARGET_ARCH="arm64" ;;
+        *)                 TARGET_ARCH="${PLATFORM##*/}" ;;
+    esac
     if [[ "$TARGET_ARCH" != "$HOST_ARCH" ]]; then
         echo "WARNING: building '$PLATFORM' on a '$HOST_ARCH' host runs the whole" >&2
         echo "         from-source build under QEMU emulation and takes hours." >&2


### PR DESCRIPTION
## Why

`docker/docker-build.sh` ran a plain `docker build`, which only ever produces an image for the **host architecture** — in practice always amd64, since the script is run on amd64 hosts. No Docker image is built in CI either (`release.yml` only ships per-platform tarballs). So there has effectively never been an ARM64 image.

The goal is to let VoLCA be evaluated on small ARM64 VMs, so a way to produce an arm64 image is needed.

## What this does

Adds a `--platform` flag to `docker-build.sh`:

```
./docker/docker-build.sh --platform linux/arm64
```

Omitted, the image is still built for the host architecture (unchanged default behaviour).

## No Dockerfile change is needed

The build pipeline is already architecture-clean — this PR only touches the build *mechanism*:

- **Dockerfile**: `FROM alpine` (multi-arch), `apk` packages exist for aarch64, OpenBLAS is built with `DYNAMIC_ARCH=1` (ships ARMv8/Neoverse kernel sets), MUMPS is built from source. No hardcoded `x86_64`.
- **`gen-cabal-config.sh`**: the `musl` link mode already branches on `case "$(uname -m)"` — it adds `-lquadmath` only on x86 and nothing on aarch64 (correct: on AArch64 `long double` is natively binary128, so libgfortran does not need libquadmath). The `-z stack-size=8388608` flag (the #60/#61 musl pthread-stack fix) is architecture-independent.
- **CI**: `_build-matrix.yml` already compiles `linux-arm64` natively on `ubuntu-24.04-arm`, proving the aarch64/musl toolchain (GHC 9.12.4 included) works.

## Implementation notes

- Switches to `docker buildx build --load` — the only builder that honours `--platform` together with `--load`. A preflight check fails clearly if `docker buildx` is absent.
- Warns when `--platform` requests a non-host architecture: the Dockerfile compiles OpenBLAS, MUMPS and the whole GHC dependency tree from source, so an emulated (QEMU) build runs for hours. The fast path is to run the script on a native host of the target architecture (e.g. an ARM64 VM).

## Verification

Script syntax-checked (`bash -n`) and reviewed. The image build itself was **not** run here — a native ARM64 host (or a slow QEMU-emulated build) is required; recommended next step is to run `./docker/docker-build.sh --platform linux/arm64` on an ARM64 VM. Points worth confirming on that first real build: the ghcup GHC 9.12.4 aarch64/musl bindist (already exercised by CI) and UPX on the aarch64 ELF (the known UPX/arm64 issue is specific to macOS Mach-O; Linux aarch64 is expected to be fine, strip-only is the fallback).
