### PR TITLE
refactor: trim accidental complexity in the LCA engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,9 @@ debug/
 coverage-report/
 *.tix
 
+# Profiling and benchmark output
+*.prof
+dist-prof/
+bench-results.json
+
 .docker-bundle/

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1058,11 +1058,16 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
         case Service.resolveActivityAndProcessId db processIdText of
             Left (Service.ActivityNotFound _) -> throwError err404{errBody = "Activity not found"}
             Left (Service.InvalidProcessId msg) -> throwError err400{errBody = BSL.fromStrict $ T.encodeUtf8 msg}
-            Left err -> throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ T.pack $ show err}
+            Left e@(Service.MatrixError _) -> internalError e
+            Left e@(Service.InvalidUUID _) -> internalError e
+            Left e@(Service.FlowNotFound _) -> internalError e
             Right (pid, act) ->
                 case Service.validateProcessIdInMatrixIndex db pid of
-                    Left err -> throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ T.pack $ show err}
+                    Left e -> internalError e
                     Right () -> return (pid, act)
+      where
+        internalError :: Service.ServiceError -> Handler a
+        internalError e = throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ T.pack $ show e}
 
     throwServiceError :: Service.ServiceError -> Handler a
     throwServiceError (Service.ActivityNotFound _) = throwError err404{errBody = "Activity not found"}
@@ -1071,7 +1076,8 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
     -- and cross-DB unit-conversion failures — all client-submitted invariant
     -- breakages. Surface as 422 like the rest of the cross-DB pipeline.
     throwServiceError (Service.MatrixError msg) = throwError err422{errBody = BSL.fromStrict $ T.encodeUtf8 msg}
-    throwServiceError _ = throwError err500{errBody = "Internal server error"}
+    throwServiceError (Service.InvalidUUID _) = throwError err500{errBody = "Internal server error"}
+    throwServiceError (Service.FlowNotFound _) = throwError err500{errBody = "Internal server error"}
 
     -- Log a single category result in the batch
     logBatchCategory :: Int -> LCIAResult -> IO ()

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -21,7 +21,7 @@ import qualified Data.ByteString.Lazy as BSL
 import Data.List (find, intercalate, sortBy, sortOn)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
-import Data.Maybe (fromMaybe, isJust, mapMaybe)
+import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe)
 import Data.OpenApi (OpenApi, ToSchema)
 import qualified Data.Set as S
 import Data.Text (Text)
@@ -781,44 +781,27 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                                 isExact = T.drop 1 mode == "exact"
                              in Just (T.strip sys, T.strip val, isExact)
 
-    -- Activity LCIA endpoint (single method within a collection)
+    -- Activity LCIA endpoint (single method within a collection). The GET
+    -- variant honours a top-flows query param and logs the result; the POST
+    -- route carries neither (no top-flows param, no logging).
+    activityLCIACore :: Text -> Text -> Text -> Maybe Int -> Maybe SubstitutionRequest -> Handler LCIAResult
+    activityLCIACore dbName processIdText methodIdText topFlowsParam mSub = do
+        (db, sharedSolver) <- requireDatabaseByName dbManager dbName
+        method <- loadMethodByUUID methodIdText
+        (processId, activity) <- resolveOrThrow db processIdText
+        sol <- crossDBSolutionFor dbName db sharedSolver processId mSub
+        result <- liftIO $ computeCategoryResult dbName db sol activity (fromMaybe 5 topFlowsParam) Nothing method
+        when (isNothing mSub) $ liftIO $ logLCIAResult result method
+        pure result
+
     getActivityLCIA :: Text -> Text -> Text -> Text -> Maybe Int -> Handler LCIAResult
     getActivityLCIA dbName processIdText _collectionName methodIdText topFlowsParam =
-        withActivityAndMethod dbName processIdText methodIdText $ \db sharedSolver actProcessId activity method -> do
-            sol <- solutionWithDeps dbManager dbName db sharedSolver actProcessId
-            result <-
-                liftIO $
-                    computeCategoryResult
-                        dbName
-                        db
-                        sol
-                        activity
-                        (fromMaybe 5 topFlowsParam)
-                        Nothing
-                        method
-            liftIO $ logLCIAResult result method
-            return result
+        activityLCIACore dbName processIdText methodIdText topFlowsParam Nothing
 
     -- POST: LCIA with substitutions
     postActivityLCIA :: Text -> Text -> Text -> Text -> SubstitutionRequest -> Handler LCIAResult
-    postActivityLCIA dbName processIdText _collectionName methodIdText subReq = do
-        (db, sharedSolver) <- requireDatabaseByName dbManager dbName
-        requireFullyLinked dbName db
-        method <- loadMethodByUUID methodIdText
-        (processId, activity) <- resolveOrThrow db processIdText
-        unitCfg <- liftIO $ getMergedUnitConfig dbManager
-        eSol <-
-            liftIO $
-                Service.inventoryWithSubsAndDeps
-                    unitCfg
-                    (DM.mkDepSolverLookup dbManager)
-                    db
-                    dbName
-                    sharedSolver
-                    processId
-                    (srSubstitutions subReq)
-        sol <- either throwServiceError pure eSol
-        liftIO $ computeCategoryResult dbName db sol activity 5 Nothing method
+    postActivityLCIA dbName processIdText _collectionName methodIdText subReq =
+        activityLCIACore dbName processIdText methodIdText Nothing (Just subReq)
 
     -- POST: sensitivity sweep (parallel rank-1 perturbations of A_ij)
     --

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -647,12 +647,10 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
             Left _ -> throwError err500{errBody = "Internal server error"}
             Right graphExport -> return graphExport
 
-    -- Activity supply chain endpoint (scaling vector based)
-    getActivitySupplyChain :: Text -> Text -> Maybe Text -> Maybe Int -> Maybe Double -> Maybe Int -> Maybe Int -> Maybe Text -> Maybe Text -> Maybe Text -> [Text] -> [Text] -> [Text] -> Maybe Text -> Maybe Text -> Maybe Bool -> Handler SupplyChainResponse
-    getActivitySupplyChain dbName processId nameFilter limitParam minQuantity offsetParam maxDepthParam locationFilter productFilter presetParam classSystems classValues classModes sortParam orderParam includeEdgesParam = do
-        (db, sharedSolver) <- requireDatabaseByName dbManager dbName
-        let includeEdges = fromMaybe False includeEdgesParam
-            presetFilters = expandPreset classificationPresets presetParam
+    -- Build the supply-chain filter shared by the GET and POST handlers.
+    buildSupplyChainFilter :: Maybe Text -> Maybe Int -> Maybe Double -> Maybe Int -> Maybe Int -> Maybe Text -> Maybe Text -> Maybe Text -> [Text] -> [Text] -> [Text] -> Maybe Text -> Maybe Text -> Service.SupplyChainFilter
+    buildSupplyChainFilter nameFilter limitParam minQuantity offsetParam maxDepthParam locationFilter productFilter presetParam classSystems classValues classModes sortParam orderParam =
+        let presetFilters = expandPreset classificationPresets presetParam
             explicitFilters =
                 zipWith3
                     (\s v m -> (s, v, m == "exact"))
@@ -660,30 +658,90 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     classValues
                     (classModes ++ repeat "contains")
             classFilters = presetFilters ++ explicitFilters
+         in Service.SupplyChainFilter
+                { Service.scfCore =
+                    Service.ActivityFilterCore
+                        { Service.afcName = nameFilter
+                        , Service.afcLocation = locationFilter
+                        , Service.afcProduct = productFilter
+                        , Service.afcClassifications = classFilters
+                        , Service.afcLimit = limitParam
+                        , Service.afcOffset = offsetParam
+                        , Service.afcSort = sortParam
+                        , Service.afcOrder = orderParam
+                        }
+                , Service.scfMaxDepth = maxDepthParam
+                , Service.scfMinQuantity = minQuantity
+                }
+
+    -- Activity supply chain endpoint (scaling vector based). 'Nothing' takes the
+    -- cached solve; 'Just' resolves substitutions through the cross-DB resolver.
+    activitySupplyChainCore :: Text -> Text -> Maybe Text -> Maybe Int -> Maybe Double -> Maybe Int -> Maybe Int -> Maybe Text -> Maybe Text -> Maybe Text -> [Text] -> [Text] -> [Text] -> Maybe Text -> Maybe Text -> Maybe Bool -> Maybe SubstitutionRequest -> Handler SupplyChainResponse
+    activitySupplyChainCore dbName processIdText nameFilter limitParam minQuantity offsetParam maxDepthParam locationFilter productFilter presetParam classSystems classValues classModes sortParam orderParam includeEdgesParam mSub = do
+        (db, sharedSolver) <- requireDatabaseByName dbManager dbName
+        let includeEdges = fromMaybe False includeEdgesParam
             scf =
-                Service.SupplyChainFilter
-                    { Service.scfCore =
-                        Service.ActivityFilterCore
-                            { Service.afcName = nameFilter
-                            , Service.afcLocation = locationFilter
-                            , Service.afcProduct = productFilter
-                            , Service.afcClassifications = classFilters
-                            , Service.afcLimit = limitParam
-                            , Service.afcOffset = offsetParam
-                            , Service.afcSort = sortParam
-                            , Service.afcOrder = orderParam
-                            }
-                    , Service.scfMaxDepth = maxDepthParam
-                    , Service.scfMinQuantity = minQuantity
-                    }
-        unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
-        result <- liftIO $ Service.getSupplyChain unitCfg (DM.mkDepSolverLookup dbManager) db dbName sharedSolver processId scf includeEdges
-        case result of
-            Left (Service.ActivityNotFound _) -> throwError err404{errBody = "Activity not found"}
-            Left (Service.InvalidProcessId _) -> throwError err400{errBody = "Invalid ProcessId format"}
-            Left (Service.MatrixError msg) -> throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 msg}
-            Left _ -> throwError err500{errBody = "Internal server error"}
-            Right supplyChain -> return supplyChain
+                buildSupplyChainFilter
+                    nameFilter
+                    limitParam
+                    minQuantity
+                    offsetParam
+                    maxDepthParam
+                    locationFilter
+                    productFilter
+                    presetParam
+                    classSystems
+                    classValues
+                    classModes
+                    sortParam
+                    orderParam
+        case mSub of
+            Nothing -> do
+                unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
+                result <- liftIO $ Service.getSupplyChain unitCfg (DM.mkDepSolverLookup dbManager) db dbName sharedSolver processIdText scf includeEdges
+                case result of
+                    Left (Service.ActivityNotFound _) -> throwError err404{errBody = "Activity not found"}
+                    Left (Service.InvalidProcessId _) -> throwError err400{errBody = "Invalid ProcessId format"}
+                    Left (Service.MatrixError msg) -> throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 msg}
+                    Left (Service.InvalidUUID _) -> throwError err500{errBody = "Internal server error"}
+                    Left (Service.FlowNotFound _) -> throwError err500{errBody = "Internal server error"}
+                    Right supplyChain -> return supplyChain
+            Just subReq -> do
+                (processId, _) <- resolveOrThrow db processIdText
+                -- Use the cross-DB-aware substitution resolver so qualified PIDs in
+                -- subFrom/subTo are accepted; the virtual cross-DB links it returns
+                -- don't affect the root scaling vector (they drive dep-DB demand),
+                -- which is all the supply-chain navigation reads.
+                scalingResult <-
+                    liftIO $
+                        Service.computeScalingVectorWithSubstitutionsCrossDB
+                            (DM.mkDepSolverLookup dbManager)
+                            db
+                            dbName
+                            sharedSolver
+                            processId
+                            (srSubstitutions subReq)
+                case scalingResult of
+                    Left err -> throwServiceError err
+                    Right (scalingVec, virtualLinks) -> do
+                        unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
+                        eResp <-
+                            liftIO $
+                                Service.buildSupplyChainFromScalingVectorCrossDB
+                                    unitCfg
+                                    (DM.mkDepSolverLookup dbManager)
+                                    db
+                                    dbName
+                                    processId
+                                    scalingVec
+                                    virtualLinks
+                                    scf
+                                    includeEdges
+                        either throwServiceError pure eResp
+
+    getActivitySupplyChain :: Text -> Text -> Maybe Text -> Maybe Int -> Maybe Double -> Maybe Int -> Maybe Int -> Maybe Text -> Maybe Text -> Maybe Text -> [Text] -> [Text] -> [Text] -> Maybe Text -> Maybe Text -> Maybe Bool -> Handler SupplyChainResponse
+    getActivitySupplyChain dbName processIdText nameFilter limitParam minQuantity offsetParam maxDepthParam locationFilter productFilter presetParam classSystems classValues classModes sortParam orderParam includeEdgesParam =
+        activitySupplyChainCore dbName processIdText nameFilter limitParam minQuantity offsetParam maxDepthParam locationFilter productFilter presetParam classSystems classValues classModes sortParam orderParam includeEdgesParam Nothing
 
     -- Activity aggregate endpoint (generic SQL-group-by-style aggregation)
     getActivityAggregate ::
@@ -938,64 +996,8 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
 
     -- POST: Supply chain with substitutions
     postActivitySupplyChain :: Text -> Text -> Maybe Text -> Maybe Int -> Maybe Double -> Maybe Int -> Maybe Int -> Maybe Text -> Maybe Text -> Maybe Text -> [Text] -> [Text] -> [Text] -> Maybe Text -> Maybe Text -> Maybe Bool -> SubstitutionRequest -> Handler SupplyChainResponse
-    postActivitySupplyChain dbName processIdText nameFilter limitParam minQuantityParam offsetParam maxDepthParam locationFilter productFilter presetParam classSystems classValues classModes sortParam orderParam includeEdgesParam subReq = do
-        (db, sharedSolver) <- requireDatabaseByName dbManager dbName
-        let includeEdges = fromMaybe False includeEdgesParam
-            presetFilters = expandPreset classificationPresets presetParam
-            explicitFilters =
-                zipWith3
-                    (\s v m -> (s, v, m == "exact"))
-                    classSystems
-                    classValues
-                    (classModes ++ repeat "contains")
-            classFilters = presetFilters ++ explicitFilters
-            scf =
-                Service.SupplyChainFilter
-                    { Service.scfCore =
-                        Service.ActivityFilterCore
-                            { Service.afcName = nameFilter
-                            , Service.afcLocation = locationFilter
-                            , Service.afcProduct = productFilter
-                            , Service.afcClassifications = classFilters
-                            , Service.afcLimit = limitParam
-                            , Service.afcOffset = offsetParam
-                            , Service.afcSort = sortParam
-                            , Service.afcOrder = orderParam
-                            }
-                    , Service.scfMaxDepth = maxDepthParam
-                    , Service.scfMinQuantity = minQuantityParam
-                    }
-        (processId, _) <- resolveOrThrow db processIdText
-        -- Use the cross-DB-aware substitution resolver so qualified PIDs in
-        -- subFrom/subTo are accepted; the virtual cross-DB links it returns
-        -- don't affect the root scaling vector (they drive dep-DB demand),
-        -- which is all the supply-chain navigation reads.
-        scalingResult <-
-            liftIO $
-                Service.computeScalingVectorWithSubstitutionsCrossDB
-                    (DM.mkDepSolverLookup dbManager)
-                    db
-                    dbName
-                    sharedSolver
-                    processId
-                    (srSubstitutions subReq)
-        case scalingResult of
-            Left err -> throwServiceError err
-            Right (scalingVec, virtualLinks) -> do
-                unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
-                eResp <-
-                    liftIO $
-                        Service.buildSupplyChainFromScalingVectorCrossDB
-                            unitCfg
-                            (DM.mkDepSolverLookup dbManager)
-                            db
-                            dbName
-                            processId
-                            scalingVec
-                            virtualLinks
-                            scf
-                            includeEdges
-                either throwServiceError pure eResp
+    postActivitySupplyChain dbName processIdText nameFilter limitParam minQuantity offsetParam maxDepthParam locationFilter productFilter presetParam classSystems classValues classModes sortParam orderParam includeEdgesParam subReq =
+        activitySupplyChainCore dbName processIdText nameFilter limitParam minQuantity offsetParam maxDepthParam locationFilter productFilter presetParam classSystems classValues classModes sortParam orderParam includeEdgesParam (Just subReq)
 
     -- Activity consumers endpoint (reverse supply chain)
     getActivityConsumers :: Text -> Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> [Text] -> [Text] -> [Text] -> Maybe Int -> Maybe Int -> Maybe Int -> Maybe Text -> Maybe Text -> Maybe Bool -> Handler ConsumersResponse

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -867,129 +867,70 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                         lcia <- computeCategoryResult dbName db sol activity 5 Nothing method
                         pure (PerturbedEntry p (Right (lcia, lrScore lcia - lrScore baselineLcia)))
 
-    -- Batch LCIA endpoint (all methods in a collection)
-    getActivityLCIABatch :: Text -> Text -> Text -> Handler LCIABatchResult
-    getActivityLCIABatch dbName processIdText collectionName = do
+    -- Batch LCIA endpoint (all methods in a collection). The GET variant logs
+    -- timing and per-category detail; the POST (substitution) variant does not.
+    activityLCIABatchCore :: Text -> Text -> Text -> Maybe SubstitutionRequest -> Handler LCIABatchResult
+    activityLCIABatchCore dbName processIdText collectionName mSub = do
         (db, sharedSolver) <- requireDatabaseByName dbManager dbName
-        -- Look up collection
-        loadedCollections <- liftIO $ readTVarIO (dmLoadedMethods dbManager)
-        collection <- case M.lookup collectionName loadedCollections of
-            Just mc -> return mc
-            Nothing -> throwError err404{errBody = "Collection not loaded: " <> BSL.fromStrict (T.encodeUtf8 collectionName)}
-        let methods = mcMethods collection
-            damageCats = mcDamageCategories collection
-            nwSets = mcNormWeightSets collection
-            -- Build damage category lookup: subcategory name → parent name
-            dcLookup =
-                M.fromList
-                    [ (subName, dcName dc)
-                    | dc <- damageCats
-                    , (subName, _) <- dcImpacts dc
-                    ]
-            -- Use first NW set if available
-            mNW = case nwSets of (nw : _) -> Just nw; [] -> Nothing
-        case Service.resolveActivityAndProcessId db processIdText of
-            Left (Service.ActivityNotFound _) -> throwError err404{errBody = "Activity not found"}
-            Left (Service.InvalidProcessId _) -> throwError err400{errBody = "Invalid ProcessId format"}
-            Left err -> throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ T.pack $ show err}
-            Right (actProcessId, activity) -> do
-                t0 <- liftIO getCurrentTime
-                sol <- solutionWithDeps dbManager dbName db sharedSolver actProcessId
-                let inventory = SharedSolver.csInventory sol
-                t1 <- liftIO getCurrentTime
-                let !invSize = M.size inventory
-                liftIO $
-                    reportProgress Info $
-                        "[LCIA batch] "
-                            <> T.unpack collectionName
-                            <> " for "
-                            <> T.unpack (activityName activity)
-                liftIO $
-                    reportProgress Info $
-                        "  Inventory: "
-                            <> show invSize
-                            <> " flows ("
-                            <> showFFloat (Just 2) (realToFrac (diffUTCTime t1 t0) :: Double) ""
-                            <> "s)"
-                when (invSize == 0) $
-                    liftIO $
-                        reportProgress Info "  WARNING: inventory is empty — check matrix computation"
-                when (invSize > 0 && invSize <= 5) $
-                    liftIO $
-                        reportProgress Info $
-                            "  Inventory UUIDs: "
-                                <> intercalate ", " (map UUID.toString $ M.keys inventory)
-                scoreMap <- liftIO $ batchedScoresFor dbName db sol methods
-                rawResults <-
-                    liftIO $
-                        mapConcurrently
-                            ( \m ->
-                                computeCategoryResult dbName db sol activity 5 (M.lookup (methodId m) scoreMap) m
-                            )
-                            methods
-                -- Enrich with NW data
-                let results = map (enrichWithNW dcLookup mNW) rawResults
-                    -- Compute formula-based scoring sets
-                    rawScoreMap =
-                        M.fromList
-                            [(lrCategory r, lrScore r) | r <- rawResults]
-                -- Compute each scoring set, logging errors
-                (scoringResults, scoringIndicators) <-
-                    liftIO $ computeAllScoringSets (mcScoringSets collection) rawScoreMap
-                t2 <- liftIO getCurrentTime
-                liftIO $ mapM_ (logBatchCategory invSize) results
-                liftIO $
-                    reportProgress Info $
-                        "  Total: "
-                            <> show (length results)
-                            <> " categories ("
-                            <> showFFloat (Just 2) (realToFrac (diffUTCTime t2 t0) :: Double) ""
-                            <> "s)"
-                forM_ (M.toList scoringResults) $ \(name, scores) ->
-                    liftIO $
-                        reportProgress Info $
-                            "  Scoring '"
-                                <> T.unpack name
-                                <> "': "
-                                <> intercalate ", " [T.unpack k <> "=" <> showFFloat (Just 6) v "" | (k, v) <- M.toList scores]
-                return (mkLCIABatchResult results mNW nwSets scoringResults (mcScoringSets collection) scoringIndicators)
-
-    -- POST: Batch LCIA with substitutions
-    postActivityLCIABatch :: Text -> Text -> Text -> SubstitutionRequest -> Handler LCIABatchResult
-    postActivityLCIABatch dbName processIdText collectionName subReq = do
-        (db, sharedSolver) <- requireDatabaseByName dbManager dbName
-        requireFullyLinked dbName db
-        (processId, activity) <- resolveOrThrow db processIdText
+        (actProcessId, activity) <- resolveOrThrow db processIdText
         (methods, damageCats, nwSets, scoringSets) <- loadCollection collectionName
         let dcLookup = M.fromList [(subName, dcName dc) | dc <- damageCats, (subName, _) <- dcImpacts dc]
             mNW = case nwSets of (nw : _) -> Just nw; [] -> Nothing
-        unitCfg <- liftIO $ getMergedUnitConfig dbManager
-        eSol <-
-            liftIO $
-                Service.inventoryWithSubsAndDeps
-                    unitCfg
-                    (DM.mkDepSolverLookup dbManager)
-                    db
-                    dbName
-                    sharedSolver
-                    processId
-                    (srSubstitutions subReq)
-        sol <- either throwServiceError pure eSol
+        t0 <- liftIO getCurrentTime
+        sol <- crossDBSolutionFor dbName db sharedSolver actProcessId mSub
+        t1 <- liftIO getCurrentTime
+        let inventory = SharedSolver.csInventory sol
+            !invSize = M.size inventory
+        when (isNothing mSub) $
+            liftIO $ do
+                reportProgress Info $
+                    "[LCIA batch] " <> T.unpack collectionName <> " for " <> T.unpack (activityName activity)
+                reportProgress Info $
+                    "  Inventory: "
+                        <> show invSize
+                        <> " flows ("
+                        <> showFFloat (Just 2) (realToFrac (diffUTCTime t1 t0) :: Double) ""
+                        <> "s)"
+                when (invSize == 0) $
+                    reportProgress Info "  WARNING: inventory is empty — check matrix computation"
+                when (invSize > 0 && invSize <= 5) $
+                    reportProgress Info $
+                        "  Inventory UUIDs: " <> intercalate ", " (map UUID.toString $ M.keys inventory)
         scoreMap <- liftIO $ batchedScoresFor dbName db sol methods
         rawResults <-
             liftIO $
                 mapConcurrently
-                    ( \m ->
-                        computeCategoryResult dbName db sol activity 5 (M.lookup (methodId m) scoreMap) m
-                    )
+                    (\m -> computeCategoryResult dbName db sol activity 5 (M.lookup (methodId m) scoreMap) m)
                     methods
         let results = map (enrichWithNW dcLookup mNW) rawResults
-            rawScoreMap =
-                M.fromList
-                    [(lrCategory r, lrScore r) | r <- rawResults]
-        (scoringResults, scoringIndicators) <-
-            liftIO $ computeAllScoringSets scoringSets rawScoreMap
-        return (mkLCIABatchResult results mNW nwSets scoringResults scoringSets scoringIndicators)
+            rawScoreMap = M.fromList [(lrCategory r, lrScore r) | r <- rawResults]
+        (scoringResults, scoringIndicators) <- liftIO $ computeAllScoringSets scoringSets rawScoreMap
+        when (isNothing mSub) $
+            liftIO $ do
+                t2 <- getCurrentTime
+                mapM_ (logBatchCategory invSize) results
+                reportProgress Info $
+                    "  Total: "
+                        <> show (length results)
+                        <> " categories ("
+                        <> showFFloat (Just 2) (realToFrac (diffUTCTime t2 t0) :: Double) ""
+                        <> "s)"
+                forM_ (M.toList scoringResults) $ \(name, scores) ->
+                    reportProgress Info $
+                        "  Scoring '"
+                            <> T.unpack name
+                            <> "': "
+                            <> intercalate ", " [T.unpack k <> "=" <> showFFloat (Just 6) v "" | (k, v) <- M.toList scores]
+        pure (mkLCIABatchResult results mNW nwSets scoringResults scoringSets scoringIndicators)
+
+    getActivityLCIABatch :: Text -> Text -> Text -> Handler LCIABatchResult
+    getActivityLCIABatch dbName processIdText collectionName =
+        activityLCIABatchCore dbName processIdText collectionName Nothing
+
+    -- POST: Batch LCIA with substitutions
+    postActivityLCIABatch :: Text -> Text -> Text -> SubstitutionRequest -> Handler LCIABatchResult
+    postActivityLCIABatch dbName processIdText collectionName subReq =
+        activityLCIABatchCore dbName processIdText collectionName (Just subReq)
 
     -- POST: Inventory with substitutions
     postActivityInventory :: Text -> Text -> SubstitutionRequest -> Handler InventoryExport

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -598,17 +598,41 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     let loopAwareTree = buildLoopAwareTree unitCfg db activityUuid maxTreeDepth
                     return $ Service.convertToTreeExport db processId maxTreeDepth loopAwareTree
 
+    -- Cross-DB inventory solution for an activity. 'Nothing' takes the cached
+    -- no-substitution path ('requireFullyLinked' runs inside 'solutionWithDeps');
+    -- 'Just' applies the substitutions through the uncached path.
+    crossDBSolutionFor :: Text -> Database -> SharedSolver -> ProcessId -> Maybe SubstitutionRequest -> Handler SharedSolver.CrossDBSolution
+    crossDBSolutionFor dbName db solver pid mSub = case mSub of
+        Nothing -> solutionWithDeps dbManager dbName db solver pid
+        Just subReq -> do
+            requireFullyLinked dbName db
+            unitCfg <- liftIO $ getMergedUnitConfig dbManager
+            eSol <-
+                liftIO $
+                    Service.inventoryWithSubsAndDeps
+                        unitCfg
+                        (DM.mkDepSolverLookup dbManager)
+                        db
+                        dbName
+                        solver
+                        pid
+                        (srSubstitutions subReq)
+            either throwServiceError pure eSol
+
     -- Activity inventory calculation (full supply chain LCI).
     -- Goes through the cross-DB back-substitution path so inventories from
     -- dep DBs are merged into the returned flow map; metadata (flow names,
     -- units) comes from the merged FlowDB/UnitDB snapshot.
-    getActivityInventory :: Text -> Text -> Handler InventoryExport
-    getActivityInventory dbName processIdText = do
+    activityInventoryCore :: Text -> Text -> Maybe SubstitutionRequest -> Handler InventoryExport
+    activityInventoryCore dbName processIdText mSub = do
         (db, sharedSolver) <- requireDatabaseByName dbManager dbName
         (processId, activity) <- resolveOrThrow db processIdText
-        inventory <- inventoryWithDeps dbManager dbName db sharedSolver processId
+        sol <- crossDBSolutionFor dbName db sharedSolver processId mSub
         (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
-        return $ Service.convertToInventoryExport db mFlows mUnits processId activity inventory
+        pure $ Service.convertToInventoryExport db mFlows mUnits processId activity (SharedSolver.csInventory sol)
+
+    getActivityInventory :: Text -> Text -> Handler InventoryExport
+    getActivityInventory dbName processIdText = activityInventoryCore dbName processIdText Nothing
 
     -- Activity graph endpoint for network visualization
     getActivityGraph :: Text -> Text -> Maybe Double -> Handler GraphExport
@@ -986,24 +1010,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
 
     -- POST: Inventory with substitutions
     postActivityInventory :: Text -> Text -> SubstitutionRequest -> Handler InventoryExport
-    postActivityInventory dbName processIdText subReq = do
-        (db, sharedSolver) <- requireDatabaseByName dbManager dbName
-        requireFullyLinked dbName db
-        (processId, activity) <- resolveOrThrow db processIdText
-        unitCfg <- liftIO $ getMergedUnitConfig dbManager
-        eSol <-
-            liftIO $
-                Service.inventoryWithSubsAndDeps
-                    unitCfg
-                    (DM.mkDepSolverLookup dbManager)
-                    db
-                    dbName
-                    sharedSolver
-                    processId
-                    (srSubstitutions subReq)
-        sol <- either throwServiceError pure eSol
-        (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
-        pure $ Service.convertToInventoryExport db mFlows mUnits processId activity (SharedSolver.csInventory sol)
+    postActivityInventory dbName processIdText subReq = activityInventoryCore dbName processIdText (Just subReq)
 
     -- POST: Supply chain with substitutions
     postActivitySupplyChain :: Text -> Text -> Maybe Text -> Maybe Int -> Maybe Double -> Maybe Int -> Maybe Int -> Maybe Text -> Maybe Text -> Maybe Text -> [Text] -> [Text] -> [Text] -> Maybe Text -> Maybe Text -> Maybe Bool -> SubstitutionRequest -> Handler SupplyChainResponse

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -23,12 +23,7 @@ module Config (
     applyDataDir,
 
     -- * Default values
-    defaultServerConfig,
     defaultConfig,
-
-    -- * Utilities
-    getDefaultDatabase,
-    getLoadableDatabases,
 
     -- * Dependency resolution
     resolveLoadOrder,
@@ -378,19 +373,6 @@ findDuplicates xs = go [] [] xs
     go seen dups (x : rest)
         | x `elem` seen = go seen (if x `elem` dups then dups else x : dups) rest
         | otherwise = go (x : seen) dups rest
-
--- | Get the default database (or first loadable if none marked default)
-getDefaultDatabase :: Config -> Maybe DatabaseConfig
-getDefaultDatabase cfg =
-    case filter dcDefault (getLoadableDatabases cfg) of
-        (db : _) -> Just db
-        [] -> case getLoadableDatabases cfg of
-            (db : _) -> Just db
-            [] -> Nothing
-
--- | Get all databases configured to load at startup
-getLoadableDatabases :: Config -> [DatabaseConfig]
-getLoadableDatabases = filter dcLoad . cfgDatabases
 
 {- | Expand load=true transitively through depends, then topologically sort.
 Returns Left on cycle, Right with ordered list of DB names to load.

--- a/src/Method/CSV.hs
+++ b/src/Method/CSV.hs
@@ -1,0 +1,36 @@
+{- | Shared CSV plumbing for the LCIA method parsers.
+
+Delimiter detection, row splitting and number parsing were previously
+duplicated across the CSV-based method parsers — and had drifted apart
+(delimiter detection disagreed on tab support). They live here as the
+single source of truth.
+-}
+module Method.CSV (
+    detectDelimiter,
+    splitRow,
+    parseDouble,
+) where
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BC
+import Data.Text (Text)
+import qualified Data.Text.Encoding as TE
+import qualified Data.Text.Encoding.Error as TEE
+import qualified Data.Text.Read as TR
+
+-- | Auto-detect a row delimiter: semicolon, then tab, then comma.
+detectDelimiter :: BS.ByteString -> Char
+detectDelimiter line
+    | BC.elem ';' line = ';'
+    | BC.elem '\t' line = '\t'
+    | otherwise = ','
+
+-- | Split a row on the delimiter, decoding each cell to 'Text' leniently.
+splitRow :: Char -> BS.ByteString -> [Text]
+splitRow delim = map (TE.decodeUtf8With TEE.lenientDecode) . BC.split delim
+
+-- | Parse a 'Double', 'Nothing' on failure.
+parseDouble :: Text -> Maybe Double
+parseDouble t = case TR.double t of
+    Right (v, _) -> Just v
+    Left _ -> Nothing

--- a/src/Method/ParserCSV.hs
+++ b/src/Method/ParserCSV.hs
@@ -32,11 +32,11 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Encoding.Error as TEE
-import qualified Data.Text.Read as TR
 import Data.UUID (UUID)
 import qualified Data.UUID.V5 as UUID5
 import Data.Word (Word8)
 
+import Method.CSV (detectDelimiter, parseDouble, splitRow)
 import Method.Types
 
 -- | Pure parser, exported for testing.
@@ -58,7 +58,7 @@ parseMethodCSVBytes bytes =
 rows from data rows.  Returns (categories, names, units, dataRows, delimiter).
 2-row layout → categories = names.  3-row layout → distinct.
 -}
-splitHeaderFromData :: [BS.ByteString] -> Maybe ([Text], [Text], [Text], [BS.ByteString], Word8)
+splitHeaderFromData :: [BS.ByteString] -> Maybe ([Text], [Text], [Text], [BS.ByteString], Char)
 splitHeaderFromData dataLines =
     case break isLabelRow dataLines of
         (headerRows, _labelRow : rows) ->
@@ -81,14 +81,12 @@ splitHeaderFromData dataLines =
 -- | Detect the label row: first cell is a variation of "substance".
 isLabelRow :: BS.ByteString -> Bool
 isLabelRow line =
-    let first = T.toCaseFold . T.strip . head' . splitRow (detectDelimiter line) $ line
-     in first == "substance"
-  where
-    head' (x : _) = x
-    head' [] = ""
+    case splitRow (detectDelimiter line) line of
+        (first : _) -> T.toCaseFold (T.strip first) == "substance"
+        [] -> False
 
 -- | Build a single Method from one column of the CSV.
-mkMethod :: Maybe Text -> Text -> Text -> Text -> Int -> [BS.ByteString] -> Word8 -> Method
+mkMethod :: Maybe Text -> Text -> Text -> Text -> Int -> [BS.ByteString] -> Char -> Method
 mkMethod methodology catName impactName unit colIdx rows delim =
     let !ns = csvMethodNamespace
         !mId = UUID5.generateNamed ns (bsKey $ "method:" <> impactName)
@@ -147,16 +145,6 @@ parseCSVCompartment comp
   where
     lc = T.toCaseFold comp
 
--- | Auto-detect delimiter: semicolon if the line contains ';', else comma.
-detectDelimiter :: BS.ByteString -> Word8
-detectDelimiter line
-    | BC.elem ';' line = 0x3B -- ';'
-    | otherwise = 0x2C -- ','
-
--- | Split a row on the delimiter, decoding to Text.
-splitRow :: Word8 -> BS.ByteString -> [Text]
-splitRow delim = map (TE.decodeUtf8With TEE.lenientDecode) . BS.split delim
-
 -- | Extract methodology from "# methodology: ..." comment.
 extractMethodology :: [BS.ByteString] -> Maybe Text
 extractMethodology = go
@@ -166,12 +154,6 @@ extractMethodology = go
         | BC.isPrefixOf "# methodology:" l =
             Just . T.strip . TE.decodeUtf8With TEE.lenientDecode $ BS.drop 15 l
         | otherwise = go ls
-
--- | Strict double parse, Nothing on failure.
-parseDouble :: Text -> Maybe Double
-parseDouble t = case TR.double t of
-    Right (v, _) -> Just v
-    Left _ -> Nothing
 
 -- | Strip trailing carriage return (Windows CRLF line endings).
 stripCR :: BS.ByteString -> BS.ByteString

--- a/src/Method/ParserNW.hs
+++ b/src/Method/ParserNW.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 {- | Parser for standalone normalization/weighting CSV files.
@@ -23,12 +22,13 @@ module Method.ParserNW (
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.Map.Strict as M
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Encoding.Error as TEE
-import qualified Data.Text.Read as TR
 
+import Method.CSV (detectDelimiter, parseDouble, splitRow)
 import Method.Types (NormWeightSet (..))
 
 -- | Parse a normalization/weighting CSV file from disk.
@@ -44,7 +44,9 @@ parseNormWeightCSVBytes fallbackName bs =
     let allLines = BC.lines bs
         (comments, rest) = span (\l -> BC.isPrefixOf "#" l || BS.null l) allLines
         name = extractName comments fallbackName
-        delim = detectDelimiter rest
+        delim = case rest of
+            (l : _) -> detectDelimiter l
+            [] -> ';'
      in case dropHeader rest of
             [] -> Left "NW CSV: no data rows after header"
             rows ->
@@ -76,50 +78,23 @@ dropHeader (l : ls)
 
 isHeaderRow :: BS.ByteString -> Bool
 isHeaderRow l =
-    let first = T.toLower . T.strip . decode . head' . splitOn (detectDelimiterLine l) $ l
-     in first == "category" || first == "impact category" || first == "damage category"
+    case splitRow (detectDelimiter l) l of
+        (first : _) ->
+            T.toLower (T.strip first) `elem` ["category", "impact category", "damage category"]
+        [] -> False
 
 -- | Parse one data row: "category;normalization;weighting"
 parseRow :: Char -> BS.ByteString -> (Text, Double, Double)
 parseRow delim line =
-    case splitOn delim line of
-        (cat : norm : weight : _) ->
-            ( T.strip (decode cat)
-            , parseDouble (BC.strip norm)
-            , parseDouble (BC.strip weight)
-            )
-        (cat : norm : _) ->
-            ( T.strip (decode cat)
-            , parseDouble (BC.strip norm)
-            , 0
-            )
+    case map T.strip (splitRow delim line) of
+        (cat : norm : weight : _) -> (cat, num norm, num weight)
+        (cat : norm : _) -> (cat, num norm, 0)
         _ -> ("", 0, 0)
-
--- | Detect delimiter from the first data-like lines.
-detectDelimiter :: [BS.ByteString] -> Char
-detectDelimiter [] = ';'
-detectDelimiter (l : _) = detectDelimiterLine l
-
-detectDelimiterLine :: BS.ByteString -> Char
-detectDelimiterLine l
-    | BC.elem ';' l = ';'
-    | BC.elem '\t' l = '\t'
-    | otherwise = ','
-
-splitOn :: Char -> BS.ByteString -> [BS.ByteString]
-splitOn delim = BC.split delim
+  where
+    num = fromMaybe 0 . parseDouble
 
 decode :: BS.ByteString -> Text
 decode = TE.decodeUtf8With TEE.lenientDecode
-
-parseDouble :: BS.ByteString -> Double
-parseDouble bs = case TR.double (decode bs) of
-    Right (v, _) -> v
-    Left _ -> 0
-
-head' :: [a] -> a
-head' (x : _) = x
-head' [] = error "Method.ParserNW: unexpected empty split"
 
 toLowerASCII :: Char -> Char
 toLowerASCII c

--- a/src/Method/Types.hs
+++ b/src/Method/Types.hs
@@ -19,7 +19,6 @@ module Method.Types (
     MethodCollection (..),
     DamageCategory (..),
     NormWeightSet (..),
-    emptyMethodCollection,
 
     -- * Scoring sets (formula-based N/W)
     ScoringSet (..),
@@ -156,10 +155,6 @@ data MethodCollection = MethodCollection
     , mcScoringSets :: ![ScoringSet]
     }
     deriving (Eq, Show, Generic, NFData, ToJSON, FromJSON)
-
--- | Empty method collection (for wrapping plain method lists).
-emptyMethodCollection :: [Method] -> MethodCollection
-emptyMethodCollection ms = MethodCollection ms [] [] []
 
 {- | Formula-based scoring set.
 Variables map short names to impact category names.

--- a/volca.cabal
+++ b/volca.cabal
@@ -43,6 +43,7 @@ library
                      , SynonymDB.Types
                      , SynonymDB.Extract
                      , Method.Types
+                     , Method.CSV
                      , Method.Parser
                      , Method.Parser.OlcaSchema
                      , Method.ParserCSV


### PR DESCRIPTION
## Why

A review of the engine against the *"perfection = nothing left to remove"*
goal. About 95% of the codebase's complexity turned out to be essential —
MUMPS, sparse matrices, lazy factorization, cross-DB linking are all
justified. This PR removes the small, well-defined pockets that were not.

## What changed

**Dead code**
- Removed `getDefaultDatabase` and `getLoadableDatabases` (`Config`) — zero
  call sites — and `emptyMethodCollection` (`Method.Types`). Un-exported
  `defaultServerConfig` (used internally only).
- Gitignored profiling/benchmark output (`*.prof`, `dist-prof/`,
  `bench-results.json`).

**`Method.CSV` — shared parser plumbing**
- `detectDelimiter`, `splitRow` and `parseDouble` were duplicated across the
  CSV-based method parsers, and the two delimiter detectors had drifted
  apart. They now live in one module. Reworking `ParserNW` onto the shared
  `splitRow` also removes a partial `head'` that called `error` on empty
  input. Consolidating onto the more capable detector means the CSV method
  parser now recognises tab-separated files too (see *Intentional behaviour
  changes*).

**Unified the GET/POST handler pairs in `API.Routes`**
- `inventory`, single-method `impacts`, batch `impacts` and `supply-chain`
  each had a plain GET handler and a near-identical POST handler taking a
  `SubstitutionRequest` — ~150 lines of "diagonal code". Each pair is now one
  shared core plus two thin wrappers, branching once on
  `Maybe SubstitutionRequest`. No route, method or JSON-shape changes;
  single-error responses are byte-identical (one error-precedence shift is
  noted below).
- Wildcard / catch-all matches on `ServiceError` are removed for exhaustive
  ones — the GET supply-chain error handler plus the `resolveOrThrow` and
  `throwServiceError` dispatch helpers — so a future `ServiceError`
  constructor forces a deliberate HTTP-status decision.

`API/Routes.hs` drops ~61 lines; the net change across the PR is roughly
−85 lines **including** the new 36-line `Method/CSV.hs`.

## Intentional behaviour changes

1. **Malformed ProcessId message.** A malformed ProcessId on
   `GET .../impacts/...` now returns the actual parser message
   (`Invalid UUID format: ...`) instead of the generic
   `Invalid ProcessId format`. Same 400 status; the GET path now resolves
   activities the same way POST always did (and gains the matrix-index
   validation POST already had).

2. **Tab-separated method CSVs.** The shared `detectDelimiter` recognises
   tab as a delimiter; the old `ParserCSV` detector did not. A method CSV
   whose header row contains a tab is now split on tab instead of comma —
   a fix for the pre-existing drift between the two detectors.

3. **Error precedence in the unified POST handlers.** The POST cores now run
   `requireFullyLinked` *after* activity/method resolution rather than
   before. Single-error responses are unchanged, but a request that trips
   two checks at once (a not-fully-linked DB *and* an unresolvable activity)
   now surfaces the 400/404 instead of the 422.

## Verification

- `cabal build` — clean, no new warnings.
- `cabal test` — 840 examples, 0 failures.
- Regression diff: ran the pre- and post-refactor servers side by side and
  diffed all four endpoint pairs (GET + POST, with and without a
  substitution body) plus error cases — 11/13 responses byte-identical, the
  other 2 being exactly the documented 400-body change in item 1 above.

## Out of scope

Plugin-system trimming and the staged/loaded code-path unification were
identified but deliberately left for a separate change.
