### PR TITLE
Split Flow into TechnosphereFlow + BiosphereFlow

### DIFF
--- a/bench/Bench/Helpers.hs
+++ b/bench/Bench/Helpers.hs
@@ -14,7 +14,7 @@ import Data.Text (Text)
 
 import Database (buildDatabaseWithMatrices)
 import qualified Database.Loader as Loader
-import Types (Database, sdbActivities, sdbFlows, sdbUnits)
+import Types (Database, sdbActivities, sdbBioFlows, sdbTechFlows, sdbUnits)
 import qualified UnitConversion as UC
 
 {- | Parse a fixture path and build the indexed 'Database' with matrices.
@@ -34,7 +34,8 @@ loadFullDatabase path = do
                 buildDatabaseWithMatrices
                     UC.defaultUnitConfig
                     (sdbActivities sdb)
-                    (sdbFlows sdb)
+                    (sdbTechFlows sdb)
+                    (sdbBioFlows sdb)
                     (sdbUnits sdb)
             case built of
                 Left err -> pure (Left ("buildDatabaseWithMatrices failed: " <> err))

--- a/bench/Bench/Lcia.hs
+++ b/bench/Bench/Lcia.hs
@@ -43,9 +43,9 @@ import Method.Types (Method (..), MethodCF (..))
 import qualified Method.Types as MT
 import qualified Plugin.Builtin as Builtin
 import Types (
+    BiosphereFlow (..),
+    Compartment (..),
     Database (..),
-    Flow (..),
-    FlowType (..),
     Indexes (..),
     ProductIndex (..),
     Unit (..),
@@ -90,18 +90,16 @@ mkUnit uid name =
         , unitComment = ""
         }
 
-mkFlow :: UUID -> UUID -> Int -> Flow
+mkFlow :: UUID -> UUID -> Int -> BiosphereFlow
 mkFlow fid uid i =
-    Flow
-        { flowId = fid
-        , flowName = T.pack ("flow-" <> show i)
-        , flowCategory = "air"
-        , flowSubcompartment = Nothing
-        , flowUnitId = uid
-        , flowType = Biosphere
-        , flowSynonyms = M.empty
-        , flowCAS = Nothing
-        , flowSubstanceId = Nothing
+    BiosphereFlow
+        { bfId = fid
+        , bfName = T.pack ("flow-" <> show i)
+        , bfUnitId = uid
+        , bfSynonyms = M.empty
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfCompartment = Compartment "air" Nothing
         }
 
 mkCF :: UUID -> Double -> MethodCF
@@ -145,13 +143,14 @@ emptyDatabase =
         , dbActivityProductsIndex = M.empty
         , dbProductIndex = ProductIndex M.empty M.empty M.empty
         , dbActivities = V.empty
-        , dbFlows = M.empty
+        , dbTechFlows = M.empty
+        , dbBioFlows = M.empty
         , dbUnits = M.empty
-        , dbIndexes = Indexes M.empty M.empty M.empty M.empty M.empty M.empty
+        , dbIndexes = Indexes M.empty M.empty M.empty M.empty
         , dbTechnosphereTriples = U.empty
         , dbBiosphereTriples = U.empty
         , dbActivityIndex = V.empty
-        , dbBiosphereFlows = V.empty
+        , dbBiosphereOrder = V.empty
         , dbActivityCount = 0
         , dbBiosphereCount = 0
         , dbCrossDBLinks = []
@@ -165,7 +164,7 @@ emptyDatabase =
         }
 
 data SynFixture = SynFixture
-    { fxFlowDB :: !(M.Map UUID Flow)
+    { fxFlowDB :: !(M.Map UUID BiosphereFlow)
     , fxUnitDB :: !(M.Map UUID Unit)
     , fxUnitCfg :: !UC.UnitConfig
     , fxInventory :: !Inventory
@@ -337,7 +336,7 @@ registerReal = do
                             putStrLn "[bench] lcia.real.score_method: mapping CFs to flows + filling broadcast..."
                             mappings <- mapMethodToFlows Builtin.defaultMappers db method
                             let unitDB = dbUnits db
-                                flowDB = dbFlows db
+                                flowDB = dbBioFlows db
                                 tables0 = buildMethodTables M.empty mappings
                                 !tables = fillBroadcastVector UC.defaultUnitConfig unitDB flowDB tables0
                                 !nCFs = length (methodFactors method)

--- a/bench/Bench/Parsers.hs
+++ b/bench/Bench/Parsers.hs
@@ -176,7 +176,7 @@ registerSimaPro = do
         Nothing -> pure []
         Just path -> do
             -- Parse once to learn N_actual; the bench measurement re-parses fresh.
-            (acts, _, _) <- SP.parseSimaProCSV UC.defaultUnitConfig path
+            (acts, _, _, _) <- SP.parseSimaProCSV UC.defaultUnitConfig path
             let !n = length acts
             pure
                 [ BenchSpec
@@ -191,7 +191,7 @@ registerSimaPro = do
                     , bsMetric = "seconds"
                     , bsFixture = J.Fixture{J.fSource = F.fixtureSourceLabel F.Agribalyse, J.fSlice = "whole file"}
                     , bsAction = nfIO $ do
-                        (acts', _, _) <- SP.parseSimaProCSV UC.defaultUnitConfig path
+                        (acts', _, _, _) <- SP.parseSimaProCSV UC.defaultUnitConfig path
                         evaluate (length acts')
                     }
                 ]

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -479,7 +479,7 @@ An exchange with the environment (resource extraction or emission).
 | Field | Type | Default |
 |-------|------|---------|
 | `flow_name` | `str` | — |
-| `flow_category` | `str` | — |
+| `compartment` | `Compartment \| None` | — |
 | `amount` | `float` | — |
 | `unit` | `str` | — |
 | `is_input` | `bool` | — |
@@ -499,6 +499,15 @@ Multiple filters are AND-combined by the server.
 | `system` | `str` | — |
 | `value` | `str` | — |
 | `mode` | `str` | 'contains' |
+
+### `Compartment`
+
+Biosphere compartment (medium + optional subcompartment).
+
+| Field | Type | Default |
+|-------|------|---------|
+| `name` | `str` | — |
+| `sub` | `str \| None` | None |
 
 ### `ConsumerResult`
 
@@ -701,19 +710,15 @@ One per-variable entry inside ``LCIABatchResult.scoring_indicators``.
 
 ### `TechnosphereExchange`
 
-An exchange with another activity (input or output of an intermediate product).
-
-Built from an `ExchangeWithUnit` envelope: outer fields like flowName/unitName
-live next to an inner `exchange` object (the discriminated `Exchange` sum).
+An exchange with another activity. Carries no compartment — the
+producing activity's classifications describe the product taxonomy.
 
 | Field | Type | Default |
 |-------|------|---------|
 | `flow_name` | `str` | — |
-| `flow_category` | `str` | — |
 | `amount` | `float` | — |
 | `unit` | `str` | — |
-| `is_input` | `bool` | — |
-| `is_reference` | `bool` | — |
+| `role` | `Literal['ReferenceProduct', 'Coproduct', 'ReferenceInput', 'Input']` | — |
 | `target_activity` | `str \| None` | — |
 | `target_location` | `str \| None` | — |
 | `target_process_id` | `str \| None` | — |
@@ -755,6 +760,10 @@ Returns:
 ### `Exchange`
 
 Type alias: `Union[TechnosphereExchange, BiosphereExchange]`.
+
+### `TechRole`
+
+Type alias: `Literal['ReferenceProduct', 'Coproduct', 'ReferenceInput', 'Input']`.
 
 <!-- END: api-reference -->
 

--- a/pyvolca/src/volca/__init__.py
+++ b/pyvolca/src/volca/__init__.py
@@ -14,6 +14,7 @@ from .types import (
     AggregateResult,
     BiosphereExchange,
     ClassificationFilter,
+    Compartment,
     ConsumerResult,
     ConsumersResponse,
     DatabaseInfo,
@@ -27,6 +28,7 @@ from .types import (
     SupplyChain,
     SupplyChainEdge,
     SupplyChainEntry,
+    TechRole,
     TechnosphereExchange,
 )
 
@@ -40,6 +42,7 @@ __all__ = [
     "BiosphereExchange",
     "Client",
     "ClassificationFilter",
+    "Compartment",
     "ConsumerResult",
     "ConsumersResponse",
     "DatabaseInfo",
@@ -56,6 +59,7 @@ __all__ = [
     "SupplyChain",
     "SupplyChainEdge",
     "SupplyChainEntry",
+    "TechRole",
     "TechnosphereExchange",
     "VoLCAError",
     "compare_activities",

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -3,7 +3,7 @@
 import dataclasses
 import re
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, Union
+from typing import Any, ClassVar, Literal, Union
 
 
 _CAMEL_BOUNDARY = re.compile(r"(?<!^)(?=[A-Z])")
@@ -331,19 +331,41 @@ def _exchange_comment(ewu: dict | None, inner: dict) -> str | None:
 
 
 @dataclass
-class TechnosphereExchange:
-    """An exchange with another activity (input or output of an intermediate product).
+class Compartment:
+    """Biosphere compartment (medium + optional subcompartment)."""
 
-    Built from an `ExchangeWithUnit` envelope: outer fields like flowName/unitName
-    live next to an inner `exchange` object (the discriminated `Exchange` sum).
+    name: str
+    sub: str | None = None
+
+    @classmethod
+    def from_json(cls, c: dict | None) -> "Compartment | None":
+        if c is None:
+            return None
+        return cls(name=c.get("name", ""), sub=c.get("sub"))
+
+
+# Roles a technosphere exchange can play within its host activity.
+TechRole = Literal["ReferenceProduct", "Coproduct", "ReferenceInput", "Input"]
+
+
+def _role_is_input(role: TechRole) -> bool:
+    return role in ("Input", "ReferenceInput")
+
+
+def _role_is_reference(role: TechRole) -> bool:
+    return role in ("ReferenceProduct", "ReferenceInput")
+
+
+@dataclass
+class TechnosphereExchange:
+    """An exchange with another activity. Carries no compartment — the
+    producing activity's classifications describe the product taxonomy.
     """
 
     flow_name: str
-    flow_category: str
     amount: float
     unit: str
-    is_input: bool
-    is_reference: bool
+    role: TechRole
     target_activity: str | None
     target_location: str | None
     target_process_id: str | None
@@ -351,16 +373,22 @@ class TechnosphereExchange:
 
     is_biosphere: bool = False  # discriminator for callers using duck typing
 
+    @property
+    def is_input(self) -> bool:
+        return _role_is_input(self.role)
+
+    @property
+    def is_reference(self) -> bool:
+        return _role_is_reference(self.role)
+
     @classmethod
     def from_json(cls, ewu: dict) -> "TechnosphereExchange":
         inner = ewu["exchange"]
         return cls(
             flow_name=ewu["flowName"],
-            flow_category=ewu["flowCategory"],
             amount=inner["amount"],
             unit=ewu["unitName"],
-            is_input=inner["isInput"],
-            is_reference=inner["isReference"],
+            role=inner["role"],
             target_activity=ewu.get("targetActivity"),
             target_location=ewu.get("targetLocation"),
             target_process_id=ewu.get("targetProcessId"),
@@ -373,7 +401,7 @@ class BiosphereExchange:
     """An exchange with the environment (resource extraction or emission)."""
 
     flow_name: str
-    flow_category: str
+    compartment: Compartment | None
     amount: float
     unit: str
     is_input: bool  # True = resource extraction, False = emission
@@ -386,7 +414,7 @@ class BiosphereExchange:
         inner = ewu["exchange"]
         return cls(
             flow_name=ewu["flowName"],
-            flow_category=ewu["flowCategory"],
+            compartment=Compartment.from_json(ewu.get("compartment")),
             amount=inner["amount"],
             unit=ewu["unitName"],
             is_input=inner["isInput"],
@@ -413,28 +441,25 @@ def parse_exchange(ewu: dict) -> Exchange:
 
 
 def parse_exchange_detail(ed: dict) -> Exchange:
-    """Parse an `ExchangeDetail` JSON dict (returned by GET /activity/{pid}/inputs|outputs).
+    """Parse an ``ExchangeDetail`` JSON dict (returned by GET /activity/{pid}/inputs|outputs).
 
-    The richer ExchangeDetail shape carries full Flow / Unit / ActivitySummary
-    objects. This parser projects it onto the lean Exchange representation; if a
-    caller needs the richer shape it should hit the REST endpoint directly.
+    The flow is a tagged sum: ``{"Left": <techFlow>}`` or
+    ``{"Right": <bioFlow>}``. Compartment lives on biosphere flows only.
     """
     inner = ed["exchange"]
-    flow = ed.get("flow", {})
-    flow_name = flow.get("name", "")
-    flow_category = flow.get("category", "")
+    flow_outer = ed.get("flow", {})
+    tech_flow = flow_outer.get("Left") or {}
+    bio_flow = flow_outer.get("Right") or {}
     unit = ed.get("exchangeUnitName", "")
     comment = _exchange_comment(ed, inner)
     tag = inner.get("tag")
     if tag == "TechnosphereExchange":
         target = ed.get("targetActivity") or {}
         return TechnosphereExchange(
-            flow_name=flow_name,
-            flow_category=flow_category or "technosphere",
+            flow_name=tech_flow.get("name", ""),
             amount=inner["amount"],
             unit=unit,
-            is_input=inner["isInput"],
-            is_reference=inner["isReference"],
+            role=inner["role"],
             target_activity=target.get("name"),
             target_location=target.get("location"),
             target_process_id=target.get("processId"),
@@ -442,8 +467,8 @@ def parse_exchange_detail(ed: dict) -> Exchange:
         )
     if tag == "BiosphereExchange":
         return BiosphereExchange(
-            flow_name=flow_name,
-            flow_category=flow_category,
+            flow_name=bio_flow.get("name", ""),
+            compartment=Compartment.from_json(bio_flow.get("compartment")),
             amount=inner["amount"],
             unit=unit,
             is_input=inner["isInput"],

--- a/pyvolca/tests/conftest.py
+++ b/pyvolca/tests/conftest.py
@@ -172,6 +172,7 @@ def readme_namespace() -> dict[str, Any]:
         AggregateResult,
         BiosphereExchange,
         Client,
+        Compartment,
         ConsumerResult,
         ConsumersResponse,
         FlowContribution,
@@ -213,18 +214,16 @@ def readme_namespace() -> dict[str, Any]:
         exchanges=[
             TechnosphereExchange(
                 flow_name="soft wheat grain, conventional",
-                flow_category="agricultural",
                 amount=1.31,
                 unit="kg",
-                is_input=True,
-                is_reference=False,
+                role="Input",
                 target_activity="Soft wheat grain production, FR",
                 target_location="FR",
                 target_process_id="cccc3333-aaaa-bbbb-cccc-111122223333_aaaa4444-eeee-ffff-aaaa-444455556666",
             ),
             BiosphereExchange(
                 flow_name="Carbon dioxide, fossil",
-                flow_category="air",
+                compartment=Compartment(name="air"),
                 amount=0.41,
                 unit="kg",
                 is_input=False,

--- a/pyvolca/tests/test_exchange_comment.py
+++ b/pyvolca/tests/test_exchange_comment.py
@@ -28,18 +28,19 @@ def _ewu(tag: str, *, ex_comment: str | None, inner_comment: str | None) -> dict
         "isInput": True,
     }
     if tag == "TechnosphereExchange":
-        inner["isReference"] = False
+        inner["role"] = "Input"
     if inner_comment is not None:
         inner["comment"] = inner_comment
     out: dict = {
         "exchange": inner,
         "flowName": "wheat",
-        "flowCategory": "technosphere" if tag == "TechnosphereExchange" else "air",
         "unitName": "kg",
         "targetActivity": None,
         "targetLocation": None,
         "targetProcessId": None,
     }
+    if tag == "BiosphereExchange":
+        out["compartment"] = {"name": "air", "sub": None}
     if ex_comment is not None:
         out["exComment"] = ex_comment
     return out
@@ -53,14 +54,17 @@ def _ed(tag: str, *, inner_comment: str | None, ex_comment: str | None = None) -
         "isInput": True,
     }
     if tag == "TechnosphereExchange":
-        inner["isReference"] = False
+        inner["role"] = "Input"
     if inner_comment is not None:
         inner["comment"] = inner_comment
     out: dict = {
         "exchange": inner,
-        "flow": {"name": "wheat", "category": "technosphere"},
         "exchangeUnitName": "kg",
     }
+    if tag == "TechnosphereExchange":
+        out["flow"] = {"Left": {"name": "wheat"}}
+    else:
+        out["flow"] = {"Right": {"name": "wheat", "compartment": {"name": "air", "sub": None}}}
     if ex_comment is not None:
         out["exComment"] = ex_comment
     return out

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -49,7 +49,7 @@ import qualified Service
 import qualified Service.Aggregate as Agg
 import SharedSolver (SharedSolver, computeInventoryMatrixWithDepsCached, crossDBProcessContributions)
 import qualified SharedSolver
-import Types (Activity (..), Database (..), Flow, FlowDB, FlowType (..), Indexes (..), ProcessId, UnitDB, activityLocation, activityName, exchangeIsInput, flowCategory, flowId, flowName, flowSubcompartment, getUnitNameForFlow, processIdToText, unresolvedCount)
+import Types (Activity (..), BioFlowDB, BiosphereFlow (..), Compartment (..), Database (..), Indexes (..), ProcessId, UnitDB, activityLocation, activityName, exchangeIsInput, getUnitNameForBioFlow, isTechnosphereExchange, processIdToText, unresolvedCount)
 import UnitConversion (defaultUnitConfig)
 
 -- ---------------------------------------------------------------------------
@@ -567,8 +567,8 @@ callGetActivity rid args (db, _) =
             && isNothing isInputFilter
     matchExchange ewu = matchType ewu && matchFlow ewu && matchIsInput ewu
     matchType ewu = case exchangeType of
-        Just "biosphere" -> ewuFlowCategory ewu /= "technosphere"
-        Just "technosphere" -> ewuFlowCategory ewu == "technosphere"
+        Just "biosphere" -> not (isTechnosphereExchange (ewuExchange ewu))
+        Just "technosphere" -> isTechnosphereExchange (ewuExchange ewu)
         _ -> True
     matchFlow ewu = case flowFilter of
         Nothing -> True
@@ -672,8 +672,8 @@ callAggregate dbManager rid args (db, solver) =
                                         mapMaybe parseClassFilter (textArrayArg "filter_classification" args)
                                     , Agg.apFilterTargetName = textArg "filter_target_name" args
                                     , Agg.apFilterExchangeType = case textArg "filter_exchange_type" args of
-                                        Just "technosphere" -> Just Technosphere
-                                        Just "biosphere" -> Just Biosphere
+                                        Just "technosphere" -> Just Agg.KindTechnosphere
+                                        Just "biosphere" -> Just Agg.KindBiosphere
                                         _ -> Nothing
                                     , Agg.apFilterIsReference = boolArg "filter_is_reference" args
                                     , Agg.apGroupBy = textArg "group_by" args
@@ -800,12 +800,12 @@ callGetInventory dbManager rid args =
                     flows = ieFlows inv
                     filtered = case nameFilter of
                         Nothing -> flows
-                        Just q -> filter (T.isInfixOf (T.toLower q) . T.toLower . flowName . ifdFlow) flows
+                        Just q -> filter (T.isInfixOf (T.toLower q) . T.toLower . bfName . ifdFlow) flows
                     sorted = L.sortBy (\a b -> compare (abs $ ifdQuantity b) (abs $ ifdQuantity a)) filtered
                     topN = take limit sorted
                     slim f =
                         object
-                            [ "flow" .= flowName (ifdFlow f)
+                            [ "flow" .= bfName (ifdFlow f)
                             , "quantity" .= ifdQuantity f
                             , "unit" .= ifdUnitName f
                             , "category" .= ifdCategory f
@@ -861,7 +861,7 @@ to drift from this one.
 data ImpactsResult = ImpactsResult
     { irOutcome :: !LCIAOutcome
     , irMappingStats :: !MappingStats
-    , irContribs :: ![(Flow, Double, Double)]
+    , irContribs :: ![(BiosphereFlow, Double, Double)]
     -- ^ Sorted descending by absolute contribution.
     , irUnknownUuids :: ![UUID.UUID]
     , irRefProductName :: !Text
@@ -910,7 +910,7 @@ runImpactsRequest dbManager args req = do
         baseOutcome = computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables
         (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
         contribs = L.sortOn (\(_, _, c) -> negate (abs c)) rawContribs
-        (prodName, prodAmount, prodUnit) = Service.getReferenceProductInfo mFlows mUnits (raActivity ra)
+        (prodName, prodAmount, prodUnit) = Service.getReferenceProductInfo (dbTechFlows db) mUnits (raActivity ra)
     -- Diagnostics path: opt-in via include_diagnostics. Skips the suggester
     -- work entirely when not requested, so the hot path stays bit-identical
     -- to runs without the flag.
@@ -1003,14 +1003,14 @@ callGetImpacts dbManager baseUrl rid args =
                             , "web_url" .= webUrl
                             , "top_flows"
                                 .= [ object
-                                        [ "flow_name" .= flowName f
+                                        [ "flow_name" .= bfName f
                                         , "contribution" .= c
                                         , "contribution_percent" .= (if score /= 0 then c / score * 100 else 0 :: Double)
-                                        , "flow_id" .= UUID.toText (flowId f)
-                                        , "category" .= flowCategory f
-                                        , "compartment" .= flowSubcompartment f
+                                        , "flow_id" .= UUID.toText (bfId f)
+                                        , "category" .= compartmentName (bfCompartment f)
+                                        , "compartment" .= compartmentSub (bfCompartment f)
                                         , "cf_value" .= cfVal
-                                        , "flow_unit" .= getUnitNameForFlow mUnits f
+                                        , "flow_unit" .= getUnitNameForBioFlow mUnits f
                                         ]
                                    | (f, cfVal, c) <- topFlows
                                    ]
@@ -1138,9 +1138,9 @@ callCompareImpacts dbManager rid args =
                     bMap = M.fromList [(flowKey f, c) | (f, _, c) <- irContribs irB]
                     common =
                         [ object
-                            [ "flow_name" .= flowName f
-                            , "category" .= flowCategory f
-                            , "compartment" .= flowSubcompartment f
+                            [ "flow_name" .= bfName f
+                            , "category" .= compartmentName (bfCompartment f)
+                            , "compartment" .= compartmentSub (bfCompartment f)
                             , "a_contrib" .= cA
                             , "b_contrib" .= cB
                             , "delta" .= (cA - cB)
@@ -1191,19 +1191,19 @@ callCompareImpacts dbManager rid args =
                 ]
     encodeContrib f c =
         object
-            [ "flow_name" .= flowName f
-            , "category" .= flowCategory f
-            , "compartment" .= flowSubcompartment f
+            [ "flow_name" .= bfName f
+            , "category" .= compartmentName (bfCompartment f)
+            , "compartment" .= compartmentSub (bfCompartment f)
             , "contribution" .= c
             ]
 
     -- Align flows across databases by (normalized name, medium, subcompartment).
     -- UUIDs differ across DBs by construction — see Method/Mapping comments.
-    flowKey :: Flow -> (Text, Text, Text)
+    flowKey :: BiosphereFlow -> (Text, Text, Text)
     flowKey f =
-        ( T.toLower (T.strip (flowName f))
-        , T.toLower (flowCategory f)
-        , maybe "" T.toLower (flowSubcompartment f)
+        ( T.toLower (T.strip (bfName f))
+        , T.toLower (compartmentName (bfCompartment f))
+        , maybe "" T.toLower (compartmentSub (bfCompartment f))
         )
 
 {- | Pull side-specific args (suffixed @_a@ / @_b@) up to the standard names
@@ -1385,7 +1385,7 @@ callGetCharacterization dbManager rid args =
                             let matched =
                                     [ (cf, f, strat)
                                     | (cf, Just (f, strat)) <- mappings
-                                    , matchQuery queryLower (mcfFlowName cf) (flowName f)
+                                    , matchQuery queryLower (mcfFlowName cf) (bfName f)
                                     ]
                                 sorted = L.sortOn (\(cf, _, _) -> negate (abs (mcfValue cf))) matched
                                 top = take lim sorted
@@ -1395,11 +1395,11 @@ callGetCharacterization dbManager rid args =
                                         , "cf_value" .= mcfValue cf
                                         , "cf_unit" .= mcfUnit cf
                                         , "direction" .= (case mcfDirection cf of Input -> "Input" :: Text; Output -> "Output")
-                                        , "db_flow_name" .= flowName f
-                                        , "flow_id" .= UUID.toText (flowId f)
-                                        , "flow_unit" .= getUnitNameForFlow (dbUnits db) f
-                                        , "category" .= flowCategory f
-                                        , "compartment" .= flowSubcompartment f
+                                        , "db_flow_name" .= bfName f
+                                        , "flow_id" .= UUID.toText (bfId f)
+                                        , "flow_unit" .= getUnitNameForBioFlow (dbUnits db) f
+                                        , "category" .= compartmentName (bfCompartment f)
+                                        , "compartment" .= compartmentSub (bfCompartment f)
                                         , "match_strategy" .= show strat
                                         ]
                             return $
@@ -1429,7 +1429,7 @@ mkMcpCrossDBEntry ::
     Text ->
     -- | method UUID text
     Text ->
-    FlowDB ->
+    BioFlowDB ->
     UnitDB ->
     -- | total score (for share %)
     Double ->
@@ -1445,7 +1445,8 @@ mkMcpCrossDBEntry dbManager rootDbName baseUrl colName methodIdText flowDB unitD
                         if depDbName == rootDbName
                             then processIdToText d pid
                             else depDbName <> "::" <> processIdToText d pid
-                    (pn, _, _) = maybe ("", 0, "") (Service.getReferenceProductInfo flowDB unitDB) mAct
+                    -- Reference products are technosphere; pull the supplier's tech flow map.
+                    (pn, _, _) = maybe ("", 0, "") (Service.getReferenceProductInfo (dbTechFlows d) unitDB) mAct
                  in (maybe "" activityName mAct, maybe "" activityLocation mAct, pn, txt)
             Nothing ->
                 ("", "", "", depDbName <> "::<unloaded>")
@@ -1630,12 +1631,12 @@ callGetContributingFlows dbManager baseUrl rid args =
                             , "web_url" .= webUrl
                             , "top_flows"
                                 .= [ object
-                                        [ "flow_name" .= flowName f
+                                        [ "flow_name" .= bfName f
                                         , "contribution" .= c
                                         , "contribution_percent" .= (if score /= 0 then c / score * 100 else 0 :: Double)
-                                        , "flow_id" .= UUID.toText (flowId f)
-                                        , "category" .= flowCategory f
-                                        , "compartment" .= flowSubcompartment f
+                                        , "flow_id" .= UUID.toText (bfId f)
+                                        , "category" .= compartmentName (bfCompartment f)
+                                        , "compartment" .= compartmentSub (bfCompartment f)
                                         , "cf_value" .= cfVal
                                         ]
                                    | (f, cfVal, c) <- top

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -547,28 +547,40 @@ callGetActivity :: Value -> KeyMap Value -> (Database, SharedSolver) -> IO Value
 callGetActivity rid args (db, _) =
     case textArg "process_id" args of
         Nothing -> return $ toolError rid "Missing required parameter: process_id"
-        Just pid ->
-            case Service.getActivityInfo defaultUnitConfig db pid of
-                Left err -> return $ toolError rid (T.pack $ show err)
-                Right val
-                    | noFilters -> return $ toolSuccessJson rid val
-                    | otherwise -> case fromJSON val of
-                        Error _ -> return $ toolSuccessJson rid val
-                        Success ai ->
-                            let filtered = ai{piActivity = (piActivity ai){pfaExchanges = filter matchExchange (pfaExchanges (piActivity ai))}}
-                             in return $ toolSuccessJson rid (toJSON filtered)
+        Just pid -> case validatedExchangeType of
+            Left err -> return $ toolError rid err
+            Right _ ->
+                case Service.getActivityInfo defaultUnitConfig db pid of
+                    Left err -> return $ toolError rid (T.pack $ show err)
+                    Right val
+                        | noFilters -> return $ toolSuccessJson rid val
+                        | otherwise -> case fromJSON val of
+                            Error _ -> return $ toolSuccessJson rid val
+                            Success ai ->
+                                let filtered = ai{piActivity = (piActivity ai){pfaExchanges = filter matchExchange (pfaExchanges (piActivity ai))}}
+                                 in return $ toolSuccessJson rid (toJSON filtered)
   where
     exchangeType = textArg "exchange_type" args
     flowFilter = textArg "flow" args
     isInputFilter = boolArg "is_input" args
+    -- Mirror /api/aggregate's strictness: silently swallowing typos like
+    -- `exchange_type=tecnosphere` would yield "all exchanges" with no signal
+    -- to the caller that the filter was ignored.
+    validatedExchangeType = case exchangeType of
+        Nothing -> Right Nothing
+        Just "all" -> Right Nothing
+        Just "technosphere" -> Right (Just True)
+        Just "biosphere" -> Right (Just False)
+        Just other ->
+            Left $ "exchange_type must be one of: all | technosphere | biosphere (got " <> other <> ")"
     noFilters =
         exchangeType `elem` [Nothing, Just "all"]
             && isNothing flowFilter
             && isNothing isInputFilter
     matchExchange ewu = matchType ewu && matchFlow ewu && matchIsInput ewu
-    matchType ewu = case exchangeType of
-        Just "biosphere" -> not (isTechnosphereExchange (ewuExchange ewu))
-        Just "technosphere" -> isTechnosphereExchange (ewuExchange ewu)
+    matchType ewu = case validatedExchangeType of
+        Right (Just True) -> isTechnosphereExchange (ewuExchange ewu)
+        Right (Just False) -> not (isTechnosphereExchange (ewuExchange ewu))
         _ -> True
     matchFlow ewu = case flowFilter of
         Nothing -> True

--- a/src/API/OpenApi.hs
+++ b/src/API/OpenApi.hs
@@ -28,7 +28,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Database.Manager (DatabaseSetupInfo, DependencySuggestion, MissingSupplier)
 import Network.HTTP.Types.Method (StdMethod (..))
-import Types (Exchange, Flow, FlowType, Pedigree, Unit)
+import Types (BiosphereFlow, Compartment, Exchange, Pedigree, TechRole, TechnosphereFlow, Unit)
 
 {- | Orphan schema instance forward declaration for the login request body.
 The real type lives in "API.Routes"; this is defined there and re-imported
@@ -41,9 +41,11 @@ instance ToSchema Value where
     declareNamedSchema _ = pure $ NamedSchema (Just "JsonValue") mempty
 
 -- Domain types
-instance ToSchema FlowType
+instance ToSchema TechRole
+instance ToSchema Compartment where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 instance ToSchema Unit where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
-instance ToSchema Flow where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
+instance ToSchema TechnosphereFlow where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
+instance ToSchema BiosphereFlow where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 instance ToSchema Pedigree where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 instance ToSchema Exchange where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -39,7 +39,8 @@ import qualified GHC.Stats
 import Matrix (Inventory, Vector)
 import Method.Mapping (LCIAOutcome (..), MappingStats (..), MatchStrategy (..), MethodTables (..), computeLCIAScoreFromTables, computeLCIAScoreSetFromTables, computeMappingStats, inventoryContributions, sumRegionalizedLCIAScoreCrossDB)
 import qualified Method.Mapping
-import Method.Types (DamageCategory (..), FlowDirection (..), Method (..), MethodCF (..), MethodCollection (..), NormWeightSet (..), ScoringEvaluation (..), ScoringSet (..), computeFormulaScores)
+import qualified Method.Types as MT
+import Method.Types (DamageCategory (..), Method (..), MethodCF (..), MethodCollection (..), NormWeightSet (..), ScoringEvaluation (..), ScoringSet (..), computeFormulaScores)
 import Numeric (showFFloat)
 import Plugin.Types (AnalyzeContext (..), AnalyzeHandle (..), PluginRegistry (..))
 import Progress (ProgressLevel (Info, Warning), getLogLines, reportProgress)
@@ -270,15 +271,15 @@ mkCrossDBContrib ::
     DatabaseManager ->
     -- | root DB name
     Text ->
-    -- | merged flowDB
-    FlowDB ->
+    -- | merged biosphere flow DB
+    BioFlowDB ->
     -- | merged unitDB
     UnitDB ->
     -- | total score (for share %)
     Double ->
     ((Text, ProcessId), Double) ->
     IO ActivityContribution
-mkCrossDBContrib dbManager rootDbName flowDB unitDB score ((depDbName, pid), c) = do
+mkCrossDBContrib dbManager rootDbName _flowDB unitDB score ((depDbName, pid), c) = do
     mLd <- DM.getDatabase dbManager depDbName
     pure $ case mLd of
         Just ld ->
@@ -288,7 +289,8 @@ mkCrossDBContrib dbManager rootDbName flowDB unitDB score ((depDbName, pid), c) 
                     if depDbName == rootDbName
                         then processIdToText d pid
                         else depDbName <> "::" <> processIdToText d pid
-                (prodName, _, _) = maybe ("", 0, "") (Service.getReferenceProductInfo flowDB unitDB) mAct
+                -- Reference products are technosphere; pull from the dep DB's tech flows.
+                (prodName, _, _) = maybe ("", 0, "") (Service.getReferenceProductInfo (dbTechFlows d) unitDB) mAct
              in ActivityContribution
                     { acProcessId = pidText
                     , acActivityName = maybe "" activityName mAct
@@ -316,8 +318,9 @@ withValidatedActivity db processId action = do
         Left _ -> throwError err400{errBody = "Invalid request"}
         Right activity -> action activity
 
--- | Helper function to validate UUID and lookup flow
-withValidatedFlow :: Database -> Text -> (Flow -> Handler a) -> Handler a
+-- | Helper function to validate UUID and lookup flow. Returns a tagged sum
+-- so callers can dispatch on tech vs bio.
+withValidatedFlow :: Database -> Text -> (Either TechnosphereFlow BiosphereFlow -> Handler a) -> Handler a
 withValidatedFlow db uuid action = do
     case Service.validateUUID uuid of
         Left (Service.InvalidUUID errorMsg) -> throwError err400{errBody = BSL.fromStrict $ T.encodeUtf8 errorMsg}
@@ -326,9 +329,11 @@ withValidatedFlow db uuid action = do
             case UUID.fromText validUuidText of
                 Nothing -> throwError err400{errBody = "Invalid UUID format"}
                 Just validUuid ->
-                    case M.lookup validUuid (dbFlows db) of
-                        Nothing -> throwError err404{errBody = "Flow not found"}
-                        Just flow -> action flow
+                    case M.lookup validUuid (dbTechFlows db) of
+                        Just flow -> action (Left flow)
+                        Nothing -> case M.lookup validUuid (dbBioFlows db) of
+                            Just flow -> action (Right flow)
+                            Nothing -> throwError err404{errBody = "Flow not found"}
 
 -- | Login request body
 newtype LoginRequest = LoginRequest
@@ -785,8 +790,8 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                 _ -> throwError err400{errBody = "scope must be one of: direct | supply_chain | biosphere"}
             exchangeType <- case fexchangeTypeParam of
                 Nothing -> return Nothing
-                Just "technosphere" -> return (Just Technosphere)
-                Just "biosphere" -> return (Just Biosphere)
+                Just "technosphere" -> return (Just Agg.KindTechnosphere)
+                Just "biosphere" -> return (Just Agg.KindBiosphere)
                 Just _ -> throwError err400{errBody = "filter_exchange_type must be one of: technosphere | biosphere"}
             case (exchangeType, scope) of
                 (Just _, Agg.ScopeBiosphere) ->
@@ -1124,7 +1129,8 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                                     , acInventory = inventory
                                     , acMethods = methods
                                     , acParameters = M.empty
-                                    , acFlowDB = mFlows
+                                    , acTechFlowDB = M.empty
+                                    , acBioFlowDB = mFlows
                                     , acUnitDB = mUnits
                                     }
                         liftIO $ ahAnalyze analyzer ctx
@@ -1143,12 +1149,12 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                 contribs = sortOn (\(_, _, c) -> negate (abs c)) rawContribs
                 topFlows =
                     [ FlowContributionEntry
-                        { fcoFlowName = flowName f
+                        { fcoFlowName = bfName f
                         , fcoContribution = c
                         , fcoSharePct = if score /= 0 then c / score * 100 else 0
-                        , fcoFlowId = UUID.toText (flowId f)
-                        , fcoCategory = flowCategory f
-                        , fcoCompartment = flowSubcompartment f
+                        , fcoFlowId = UUID.toText (bfId f)
+                        , fcoCategory = compartmentName (bfCompartment f)
+                        , fcoCompartment = compartmentSub (bfCompartment f)
                         , fcoCfValue = cfVal
                         }
                     | (f, cfVal, c) <- take lim contribs
@@ -1307,19 +1313,19 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                                 reportProgress Warning $
                                     "[LCIA " <> T.unpack (methodName method) <> "] " <> T.unpack err
                                 evaluate (0 :: Double)
-        let (prodName, prodAmount, prodUnit) = Service.getReferenceProductInfo mFlows mUnits activity
+        let (prodName, prodAmount, prodUnit) = Service.getReferenceProductInfo (dbTechFlows db) mUnits activity
             functionalUnit = T.pack (showFFloat (Just 2) prodAmount "") <> " " <> prodUnit <> " of " <> prodName
             (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
             contribs = sortOn (\(_, _, c) -> negate (abs c)) rawContribs
             topContribs = take topFlows contribs
             topContributors =
                 [ FlowContributionEntry
-                    { fcoFlowName = flowName f
+                    { fcoFlowName = bfName f
                     , fcoContribution = c
                     , fcoSharePct = if score /= 0 then c / score * 100 else 0
-                    , fcoFlowId = UUID.toText (flowId f)
-                    , fcoCategory = flowCategory f
-                    , fcoCompartment = flowSubcompartment f
+                    , fcoFlowId = UUID.toText (bfId f)
+                    , fcoCategory = compartmentName (bfCompartment f)
+                    , fcoCompartment = compartmentSub (bfCompartment f)
                     , fcoCfValue = cfVal
                     }
                 | (f, cfVal, c) <- topContribs
@@ -1379,21 +1385,23 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                 <> T.unpack (methodUnit method)
         reportProgress Info $ "  Flow mapping: " <> show mapped <> " CFs mapped"
 
-    -- Flow detail endpoint
+    -- Flow detail endpoint. Resolves either side via the tagged-sum from
+    -- 'withValidatedFlow' and projects the per-side accessors uniformly.
     getFlowDetail :: Text -> Text -> Handler FlowDetail
     getFlowDetail dbName flowIdText = do
         (db, _) <- requireDatabaseByName dbManager dbName
         withValidatedFlow db flowIdText $ \flow -> do
-            let usageCount = Service.getFlowUsageCount db (flowId flow)
-            let flowUnitName = getUnitNameForFlow (dbUnits db) flow
-            return $ FlowDetail flow flowUnitName usageCount
+            let fid = either tfId bfId flow
+                unitName' = either (getUnitNameForTechFlow (dbUnits db)) (getUnitNameForBioFlow (dbUnits db)) flow
+                usageCount = Service.getFlowUsageCount db fid
+            return $ FlowDetail flow unitName' usageCount
 
     -- Activities using a specific flow
     getFlowActivities :: Text -> Text -> Handler [ActivitySummary]
     getFlowActivities dbName flowIdText = do
         (db, _) <- requireDatabaseByName dbManager dbName
         withValidatedFlow db flowIdText $ \flow ->
-            return $ Service.getActivitiesUsingFlow db (flowId flow)
+            return $ Service.getActivitiesUsingFlow db (either tfId bfId flow)
 
     -- List all available methods (from loaded collections)
     getMethods :: Handler [MethodSummary]
@@ -1452,12 +1460,12 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                         { ufaFlowRef = mcfFlowRef cf
                         , ufaFlowName = mcfFlowName cf
                         , ufaDirection = case mcfDirection cf of
-                            Input -> "Input"
-                            Output -> "Output"
+                            MT.Input -> "Input"
+                            MT.Output -> "Output"
                         }
                     | (cf, Nothing) <- mappings
                     ]
-            uniqueDbFlows = S.size $ S.fromList [flowId f | (_, Just (f, _)) <- mappings]
+            uniqueDbFlows = S.size $ S.fromList [bfId f | (_, Just (f, _)) <- mappings]
         return
             MappingStatus
                 { mstMethodId = methodId method
@@ -1484,9 +1492,9 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
             -- Build reverse index: DB flow UUID → (MethodCF, MatchStrategy)
             reverseIndex =
                 M.fromList
-                    [(flowId f, (cf, strat)) | (cf, Just (f, strat)) <- mappings]
+                    [(bfId f, (cf, strat)) | (cf, Just (f, strat)) <- mappings]
             -- Build entries for all biosphere flows
-            entries = map (buildFlowEntry db reverseIndex) (V.toList (dbBiosphereFlows db))
+            entries = map (buildFlowEntry db reverseIndex) (V.toList (dbBiosphereOrder db))
             matchedCount = length [() | e <- entries, isJust (fceCfValue e)]
         return
             FlowCFMapping
@@ -1499,12 +1507,12 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
 
     buildFlowEntry :: Database -> M.Map UUID (MethodCF, MatchStrategy) -> UUID -> FlowCFEntry
     buildFlowEntry db reverseIndex uuid =
-        let mFlow = M.lookup uuid (dbFlows db)
+        let mFlow = M.lookup uuid (dbBioFlows db)
             mMatch = M.lookup uuid reverseIndex
          in FlowCFEntry
                 { fceFlowId = uuid
-                , fceFlowName = maybe "" flowName mFlow
-                , fceFlowCategory = maybe "" flowCategory mFlow
+                , fceFlowName = maybe "" bfName mFlow
+                , fceFlowCategory = maybe "" (compartmentName . bfCompartment) mFlow
                 , fceCfValue = fmap (mcfValue . fst) mMatch
                 , fceCfFlowName = fmap (mcfFlowName . fst) mMatch
                 , fceMatchStrategy = fmap (strategyToText . snd) mMatch
@@ -1529,7 +1537,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
         let matched =
                 [ (cf, f, strat)
                 | (cf, Just (f, strat)) <- mappings
-                , matchesQuery queryLower (mcfFlowName cf) (flowName f)
+                , matchesQuery queryLower (mcfFlowName cf) (bfName f)
                 ]
             sorted = sortOn (\(cf, _, _) -> negate (abs (mcfValue cf))) matched
             top = take lim sorted
@@ -1539,13 +1547,13 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     , cheCfValue = mcfValue cf
                     , cheCfUnit = mcfUnit cf
                     , cheDirection = case mcfDirection cf of
-                        Input -> "Input"
-                        Output -> "Output"
-                    , cheDbFlowName = flowName f
-                    , cheFlowId = UUID.toText (flowId f)
-                    , cheFlowUnit = getUnitNameForFlow (dbUnits db) f
-                    , cheCategory = flowCategory f
-                    , cheCompartment = flowSubcompartment f
+                        MT.Input -> "Input"
+                        MT.Output -> "Output"
+                    , cheDbFlowName = bfName f
+                    , cheFlowId = UUID.toText (bfId f)
+                    , cheFlowUnit = getUnitNameForBioFlow (dbUnits db) f
+                    , cheCategory = compartmentName (bfCompartment f)
+                    , cheCompartment = compartmentSub (bfCompartment f)
                     , cheMatchStrategy = strategyToText strat
                     }
         return
@@ -1626,8 +1634,8 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
             { mfaFlowRef = mcfFlowRef cf
             , mfaFlowName = mcfFlowName cf
             , mfaDirection = case mcfDirection cf of
-                Input -> "Input"
-                Output -> "Output"
+                MT.Input -> "Input"
+                MT.Output -> "Output"
             , mfaValue = mcfValue cf
             }
 
@@ -1857,7 +1865,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
             if topFlows > 0
                 then Just <$> getMergedUnitConfig dbManager
                 else pure Nothing
-        let (prodName, prodAmount, prodUnit) = Service.getReferenceProductInfo mFlows mUnits activity
+        let (prodName, prodAmount, prodUnit) = Service.getReferenceProductInfo (dbTechFlows db) mUnits activity
             functionalUnit = T.pack (showFFloat (Just 2) prodAmount "") <> " " <> prodUnit <> " of " <> prodName
             -- Per-pid warning on Left mirrors the non-batch 'computeCategoryResult'
             -- path. The build-time WARN lists global (flow, location) gaps but
@@ -1888,12 +1896,12 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                             top = take topFlows sorted
                         pure
                             [ FlowContributionEntry
-                                { fcoFlowName = flowName f
+                                { fcoFlowName = bfName f
                                 , fcoContribution = c
                                 , fcoSharePct = if score /= 0 then c / score * 100 else 0
-                                , fcoFlowId = UUID.toText (flowId f)
-                                , fcoCategory = flowCategory f
-                                , fcoCompartment = flowSubcompartment f
+                                , fcoFlowId = UUID.toText (bfId f)
+                                , fcoCategory = compartmentName (bfCompartment f)
+                                , fcoCompartment = compartmentSub (bfCompartment f)
                                 , fcoCfValue = cfVal
                                 }
                             | (f, cfVal, c) <- top
@@ -1979,7 +1987,12 @@ searchFlowsInternal :: Database -> Service.FlowFilter -> Handler (SearchResults 
 searchFlowsInternal db Service.FlowFilter{Service.ffQuery = query, Service.ffLimit = limitParam, Service.ffOffset = offsetParam, Service.ffSort = sortParam, Service.ffOrder = orderParam} = do
     -- Language filtering not yet implemented, search all synonyms
     let flows = findFlowsBySynonym db query
-        allResults = [FlowSearchResult (flowId flow) (flowName flow) (flowCategory flow) (getUnitNameForFlow (dbUnits db) flow) (M.map S.toList (flowSynonyms flow)) | flow <- flows]
+        nameOf = either tfName bfName
+        idOf = either tfId bfId
+        unitOf = either (getUnitNameForTechFlow (dbUnits db)) (getUnitNameForBioFlow (dbUnits db))
+        synonymsOf = either tfSynonyms bfSynonyms
+        categoryOf = either (const "") (compartmentName . bfCompartment)
+        allResults = [FlowSearchResult (idOf flow) (nameOf flow) (categoryOf flow) (unitOf flow) (M.map S.toList (synonymsOf flow)) | flow <- flows]
         isDesc = orderParam == Just "desc"
         fsCmp = case sortParam of
             Just "category" -> \a b -> compare (fsrCategory a) (fsrCategory b)

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -14,7 +14,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import GHC.Generics
 import Servant.API.ContentTypes (MimeRender (..), OctetStream)
-import Types (Exchange, Flow, Pedigree, UUID, Unit)
+import Types (BiosphereFlow, Compartment, Exchange, Pedigree, TechnosphereFlow, UUID, Unit)
 
 -- | Search response combining results and count
 data SearchResults a = SearchResults
@@ -91,7 +91,7 @@ data InventoryMetadata = InventoryMetadata
     deriving (Generic)
 
 data InventoryFlowDetail = InventoryFlowDetail
-    { ifdFlow :: Flow
+    { ifdFlow :: BiosphereFlow -- Inventory flows are always biosphere
     , ifdQuantity :: Double
     , ifdUnitName :: Text
     , ifdIsEmission :: Bool -- True for emissions, False for resource extraction
@@ -190,9 +190,10 @@ data GraphEdge = GraphEdge
     }
     deriving (Generic)
 
--- | Lightweight flow information for lists
+-- | Lightweight flow information for lists. Carries either a tech or a bio
+-- flow; the active variant doubles as the discriminator in the wire response.
 data FlowSummary = FlowSummary
-    { fsFlow :: Flow -- Core flow data
+    { fsFlow :: Either TechnosphereFlow BiosphereFlow
     , fsUnitName :: Text -- Unit name for the flow
     , fsUsageCount :: Int -- How many activities use this flow
     , fsRole :: FlowRole -- Role in this specific activity
@@ -663,12 +664,14 @@ parseSubRef (RootDb rootDb) raw = case T.breakOn (T.pack "::") raw of
         | T.null rest -> (rootDb, pid)
         | otherwise -> (pid, T.drop 2 rest)
 
--- | Exchange with unit and flow information for API responses
+-- | Exchange with unit and flow information for API responses.
+-- Compartment is biosphere-only; technosphere exchanges have no taxonomy here
+-- (their classification lives on the producing activity).
 data ExchangeWithUnit = ExchangeWithUnit
     { ewuExchange :: Exchange
     , ewuUnitName :: Text -- Unit name for the exchange
     , ewuFlowName :: Text -- Name of the flow being exchanged
-    , ewuFlowCategory :: Text -- Category/compartment (for biosphere) or "technosphere"
+    , ewuCompartment :: Maybe Compartment -- Biosphere compartment, Nothing for technosphere
     , ewuTargetActivity :: Maybe Text -- For technosphere: name of target activity
     , ewuTargetLocation :: Maybe Text -- For technosphere: location of target activity
     , ewuTargetProcessId :: Maybe Text -- For technosphere: ProcessId for navigation (activityUUID_productUUID)
@@ -731,18 +734,19 @@ data ActivityStats = ActivityStats
     }
     deriving (Generic)
 
--- | Flow with additional metadata
+-- | Flow with additional metadata. Carries either a tech or bio flow.
 data FlowDetail = FlowDetail
-    { fdFlow :: Flow
+    { fdFlow :: Either TechnosphereFlow BiosphereFlow
     , fdUnitName :: Text -- Unit name for the flow
     , fdUsageCount :: Int -- How many activities use this flow
     }
     deriving (Generic)
 
--- | Exchange with flow, unit, and target activity information
+-- | Exchange with flow, unit, and target activity information.
+-- The carried flow's variant lines up with the Exchange variant.
 data ExchangeDetail = ExchangeDetail
     { edExchange :: Exchange
-    , edFlow :: Flow
+    , edFlow :: Either TechnosphereFlow BiosphereFlow
     , edFlowUnitName :: Text -- Unit name for the flow's default unit
     , edUnit :: Unit -- Unit information for the exchange
     , edExchangeUnitName :: Text -- Unit name for the exchange's specific unit
@@ -831,7 +835,6 @@ instance ToJSON ActivityMetadata where toJSON = strippedToJSON; toEncoding = str
 instance ToJSON ActivityLinks where toJSON = strippedToJSON; toEncoding = strippedToEncoding
 instance ToJSON ActivityStats where toJSON = strippedToJSON; toEncoding = strippedToEncoding
 instance ToJSON InventoryFlowDetail where toJSON = strippedToJSON; toEncoding = strippedToEncoding
-instance ToJSON Flow where toJSON = strippedToJSON; toEncoding = strippedToEncoding
 instance ToJSON FlowSummary where toJSON = strippedToJSON; toEncoding = strippedToEncoding
 instance ToJSON InventoryExport where toJSON = strippedToJSON; toEncoding = strippedToEncoding
 instance ToJSON ExchangeDetail where toJSON = strippedToJSON; toEncoding = strippedToEncoding

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -515,7 +515,7 @@ executeFlowMappingCommand registry fmt database manager opts = do
                         dbBioCount = fromIntegral (Types.dbBiosphereCount database) :: Int
                         characterizedUUIDs =
                             S.fromList
-                                [Types.flowId f | (_cf, Just (f, _)) <- mappings]
+                                [Types.bfId f | (_cf, Just (f, _)) <- mappings]
                         characterizedCount = S.size characterizedUUIDs
                         uncharacterizedCount = dbBioCount - characterizedCount
                         charCoverage =
@@ -551,7 +551,7 @@ executeFlowMappingCommand registry fmt database manager opts = do
                                                 ++ "] "
                                                 ++ T.unpack (mcfFlowName cf)
                                                 ++ " → "
-                                                ++ T.unpack (Types.flowName f)
+                                                ++ T.unpack (Types.bfName f)
                                     )
                                     [(cf, f, strat) | (cf, Just (f, strat)) <- mappings]
 
@@ -599,10 +599,10 @@ executeFlowMappingCommand registry fmt database manager opts = do
                                                     toJSON
                                                         [ object
                                                             [ "cfName" .= mcfFlowName cf
-                                                            , "dbFlowName" .= Types.flowName f
+                                                            , "dbFlowName" .= Types.bfName f
                                                             , "strategy" .= strategyText strat
                                                             , "cfUUID" .= mcfFlowRef cf
-                                                            , "dbFlowUUID" .= Types.flowId f
+                                                            , "dbFlowUUID" .= Types.bfId f
                                                             ]
                                                         | (cf, Just (f, strat)) <- mappings
                                                         ]
@@ -641,10 +641,10 @@ strategyText NoMatch = "none"
 -- | Get names of biosphere flows not matched by any CF
 uncharacterizedFlowNames :: Types.Database -> S.Set UUID.UUID -> [Text]
 uncharacterizedFlowNames db characterized =
-    [ Types.flowName f
-    | uuid <- V.toList (Types.dbBiosphereFlows db)
+    [ Types.bfName f
+    | uuid <- V.toList (Types.dbBiosphereOrder db)
     , not (S.member uuid characterized)
-    , Just f <- [M.lookup uuid (Types.dbFlows db)]
+    , Just f <- [M.lookup uuid (Types.dbBioFlows db)]
     ]
 
 -- | Report service errors to stderr and exit

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -71,7 +71,7 @@ buildDatabaseWithMatrices unitConfig activityMap techFlowDB bioFlowDB unitDB = d
         dbActivities = V.fromList [activityMap M.! key | key <- sortedKeys]
 
         -- Build indexes (now using Vector)
-        indexes = buildIndexesWithProcessIds dbActivities dbProcessIdTable bioFlowDB
+        indexes = buildIndexesWithProcessIds dbActivities dbProcessIdTable
 
         -- Build supplier reference unit lookup: ProcessId -> unit name of reference product
         -- Used to convert exchange amounts to the supplier's unit for correct A-matrix coefficients
@@ -258,18 +258,16 @@ buildDatabaseWithMatrices unitConfig activityMap techFlowDB bioFlowDB unitDB = d
                         , dbBM25Index = Nothing
                         }
 
--- | Build indexes with ProcessIds. Biosphere flows feed the compartment index;
--- technosphere flows carry no taxonomy and are not indexed here.
-buildIndexesWithProcessIds :: V.Vector Activity -> V.Vector (UUID, UUID) -> BioFlowDB -> Indexes
-buildIndexesWithProcessIds activityVec processIdTable bioFlowDB =
+-- | Build activity-level indexes (name / location / flow / unit). Flow-side
+-- taxonomy lives on activities or biosphere compartments and is queried via
+-- the flow databases directly, so no separate flow index is built here.
+buildIndexesWithProcessIds :: V.Vector Activity -> V.Vector (UUID, UUID) -> Indexes
+buildIndexesWithProcessIds activityVec processIdTable =
     let
-        -- Convert Vector to temporary Map for index building
-        -- We use the ProcessId-to-UUID mapping for lookups
         activityUUIDs = [actUUID | (actUUID, _) <- V.toList processIdTable]
         activities = V.toList activityVec
         activityPairs = zip activityUUIDs activities
 
-        -- Build indexes using activity UUIDs
         nameIdx =
             M.fromListWith
                 (++)
@@ -290,18 +288,12 @@ buildIndexesWithProcessIds activityVec processIdTable bioFlowDB =
             M.fromListWith
                 (++)
                 [(activityUnit activity, [uuid]) | (uuid, activity) <- activityPairs]
-
-        bioCompartmentIdx =
-            M.fromListWith
-                (++)
-                [(compartmentName (bfCompartment flow), [bfId flow]) | flow <- M.elems bioFlowDB]
      in
         Indexes
             { idxByName = nameIdx
             , idxByLocation = locationIdx
             , idxByFlow = flowIdx
             , idxByUnit = unitIdx
-            , idxBioByCompartment = bioCompartmentIdx
             }
 
 {- | Build ProductIndex for product-based lookups

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -42,8 +42,8 @@ Matrix Construction:
   * Self-loop NOT exported as matrix entry (matches Ecoinvent convention)
 - Solver constructs (I-A) by adding identity and negating technosphere triplets
 -}
-buildDatabaseWithMatrices :: UnitConfig -> M.Map (UUID, UUID) Activity -> FlowDB -> UnitDB -> IO (Either Text Database)
-buildDatabaseWithMatrices unitConfig activityMap flowDB unitDB = do
+buildDatabaseWithMatrices :: UnitConfig -> M.Map (UUID, UUID) Activity -> TechFlowDB -> BioFlowDB -> UnitDB -> IO (Either Text Database)
+buildDatabaseWithMatrices unitConfig activityMap techFlowDB bioFlowDB unitDB = do
     reportMatrixOperation "Building database with pre-computed sparse matrices"
 
     -- Step 1: Build UUID interning tables from Map keys
@@ -71,7 +71,7 @@ buildDatabaseWithMatrices unitConfig activityMap flowDB unitDB = do
         dbActivities = V.fromList [activityMap M.! key | key <- sortedKeys]
 
         -- Build indexes (now using Vector)
-        indexes = buildIndexesWithProcessIds dbActivities dbProcessIdTable flowDB
+        indexes = buildIndexesWithProcessIds dbActivities dbProcessIdTable bioFlowDB
 
         -- Build supplier reference unit lookup: ProcessId -> unit name of reference product
         -- Used to convert exchange amounts to the supplier's unit for correct A-matrix coefficients
@@ -226,7 +226,7 @@ buildDatabaseWithMatrices unitConfig activityMap flowDB unitDB = do
             reportMatrixOperation ("Final matrix stats: " ++ show (VU.length techTriples) ++ " tech entries, " ++ show (VU.length bioTriples) ++ " bio entries")
 
             reportMatrixOperation "Building product index"
-            let !productIndex = buildProductIndex dbActivities dbProcessIdTable flowDB
+            let !productIndex = buildProductIndex dbActivities dbProcessIdTable techFlowDB
             reportMatrixOperation ("Product index: " ++ show (M.size (piByUUID productIndex)) ++ " products indexed")
 
             return $
@@ -238,13 +238,14 @@ buildDatabaseWithMatrices unitConfig activityMap flowDB unitDB = do
                         , dbActivityProductsIndex = dbActivityProductsIndex
                         , dbProductIndex = productIndex
                         , dbActivities = dbActivities
-                        , dbFlows = flowDB
+                        , dbTechFlows = techFlowDB
+                        , dbBioFlows = bioFlowDB
                         , dbUnits = unitDB
                         , dbIndexes = indexes
                         , dbTechnosphereTriples = techTriples
                         , dbBiosphereTriples = bioTriples
                         , dbActivityIndex = V.generate (fromIntegral activityCount) fromIntegral
-                        , dbBiosphereFlows = bioFlowUUIDs
+                        , dbBiosphereOrder = bioFlowUUIDs
                         , dbActivityCount = activityCount
                         , dbBiosphereCount = bioFlowCount
                         , dbCrossDBLinks = []
@@ -257,9 +258,10 @@ buildDatabaseWithMatrices unitConfig activityMap flowDB unitDB = do
                         , dbBM25Index = Nothing
                         }
 
--- | Build indexes with ProcessIds
-buildIndexesWithProcessIds :: V.Vector Activity -> V.Vector (UUID, UUID) -> FlowDB -> Indexes
-buildIndexesWithProcessIds activityVec processIdTable flowDB =
+-- | Build indexes with ProcessIds. Biosphere flows feed the compartment index;
+-- technosphere flows carry no taxonomy and are not indexed here.
+buildIndexesWithProcessIds :: V.Vector Activity -> V.Vector (UUID, UUID) -> BioFlowDB -> Indexes
+buildIndexesWithProcessIds activityVec processIdTable bioFlowDB =
     let
         -- Convert Vector to temporary Map for index building
         -- We use the ProcessId-to-UUID mapping for lookups
@@ -289,36 +291,25 @@ buildIndexesWithProcessIds activityVec processIdTable flowDB =
                 (++)
                 [(activityUnit activity, [uuid]) | (uuid, activity) <- activityPairs]
 
-        flowCatIdx =
+        bioCompartmentIdx =
             M.fromListWith
                 (++)
-                [(flowCategory flow, [flowId]) | (flowId, flow) <- M.toList flowDB]
-
-        flowTypeIdx =
-            M.fromListWith
-                (++)
-                [(flowType flow, [flowId]) | (flowId, flow) <- M.toList flowDB]
+                [(compartmentName (bfCompartment flow), [bfId flow]) | flow <- M.elems bioFlowDB]
      in
-        -- Memory optimization: Removed exchange indexes (exchangeIdx, procExchangeIdx, refProdIdx,
-        -- inputIdx, outputIdx) that duplicated 600K Exchange records across 5 maps.
-        -- Exchanges can be accessed directly from Activity.exchanges when needed.
-        -- This saves ~3-4GB of RAM on Ecoinvent 3.12.
-
         Indexes
             { idxByName = nameIdx
             , idxByLocation = locationIdx
             , idxByFlow = flowIdx
             , idxByUnit = unitIdx
-            , idxFlowByCategory = flowCatIdx
-            , idxFlowByType = flowTypeIdx
+            , idxBioByCompartment = bioCompartmentIdx
             }
 
 {- | Build ProductIndex for product-based lookups
 Used for: (1) SimaPro upstream link resolution, (2) future product search
 Maps product flow UUIDs and names to the activities that produce them
 -}
-buildProductIndex :: V.Vector Activity -> V.Vector (UUID, UUID) -> FlowDB -> ProductIndex
-buildProductIndex activities processIdTable flowDb =
+buildProductIndex :: V.Vector Activity -> V.Vector (UUID, UUID) -> TechFlowDB -> ProductIndex
+buildProductIndex activities processIdTable techFlowDb =
     let
         -- Build list of (ProcessId, productUUID, productName, location) for each activity
         entries =
@@ -326,8 +317,8 @@ buildProductIndex activities processIdTable flowDb =
             | (pid, (_, prodUUID)) <- zip [0 ..] (V.toList processIdTable)
             , let act = activities V.! fromIntegral pid
             , let actLoc = activityLocation act
-            , Just flow <- [M.lookup prodUUID flowDb]
-            , let prodName = T.toLower (flowName flow)
+            , Just flow <- [M.lookup prodUUID techFlowDb]
+            , let prodName = T.toLower (tfName flow)
             ]
      in
         ProductIndex
@@ -422,11 +413,11 @@ applyStructuredFilters db geoParam productParam classFilters exactMatch candidat
                      in [(pid, a) | (pid, a) <- candidates, T.isInfixOf geoLower (T.toLower (activityLocation a))]
 
         getProductNames a' =
-            [ flowName flow
+            [ tfName flow
             | ex <- exchanges a'
             , exchangeIsReference ex
             , not (exchangeIsInput ex)
-            , Just flow <- [M.lookup (exchangeFlowId ex) (dbFlows db)]
+            , Just flow <- [M.lookup (exchangeFlowId ex) (dbTechFlows db)]
             ]
 
         productFiltered = case productParam of
@@ -481,15 +472,16 @@ findActivitiesByFields db nameParam geoParam productParam classFilters exactMatc
         exactMatch
         (findActivityNameCandidates db nameParam exactMatch)
 
--- | Search flows by synonym
-findFlowsBySynonym :: Database -> Text -> [Flow]
+-- | Search flows by synonym across both technosphere and biosphere maps.
+-- Result tagged with the flow kind so consumers can render the appropriate shape.
+findFlowsBySynonym :: Database -> Text -> [Either TechnosphereFlow BiosphereFlow]
 findFlowsBySynonym db query =
     let queryLower = T.toLower query
-        flows = M.elems (dbFlows db)
-     in [ f
-        | f <- flows
-        , T.isInfixOf queryLower (T.toLower (flowName f))
-            || any
-                (any (T.isInfixOf queryLower . T.toLower) . S.toList)
-                (M.elems (flowSynonyms f))
-        ]
+        matchesTech f =
+            T.isInfixOf queryLower (T.toLower (tfName f))
+                || any (any (T.isInfixOf queryLower . T.toLower) . S.toList) (M.elems (tfSynonyms f))
+        matchesBio f =
+            T.isInfixOf queryLower (T.toLower (bfName f))
+                || any (any (T.isInfixOf queryLower . T.toLower) . S.toList) (M.elems (bfSynonyms f))
+     in [Left f | f <- M.elems (dbTechFlows db), matchesTech f]
+            ++ [Right f | f <- M.elems (dbBioFlows db), matchesBio f]

--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -69,7 +69,7 @@ import Data.UUID (UUID)
 
 import qualified Data.Vector as V
 import SynonymDB (SynonymDB, lookupSynonymGroup, normalizeName)
-import Types (Activity (..), Database (..), Exchange (..), Flow (..), LinkBlocker (..), SimpleDatabase (..), getActivity)
+import Types (Activity (..), Database (..), LinkBlocker (..), SimpleDatabase (..), TechnosphereFlow (..), exchangeFlowId, exchangeIsReference, exchanges, getActivity)
 import qualified UnitConversion as UC
 
 {- | Pre-indexed database for fast cross-DB supplier lookup
@@ -298,23 +298,17 @@ buildIndexedDatabase dbName synDB db =
             , idbBySynonymGroup = bySynonym
             }
 
--- | Build supplier entries from a SimpleDatabase
+-- | Build supplier entries from a SimpleDatabase. Reference exchanges of
+-- production processes are always technosphere outputs, so the supplier flow
+-- lives in `sdbTechFlows`.
 buildSupplierEntries :: SimpleDatabase -> [(Text, SupplierEntry)]
 buildSupplierEntries db =
-    [ (flowName flow, SupplierEntry actUUID prodUUID (activityLocation act) (activityUnit act) (flowName flow))
+    [ (tfName flow, SupplierEntry actUUID prodUUID (activityLocation act) (activityUnit act) (tfName flow))
     | ((actUUID, prodUUID), act) <- M.toList (sdbActivities db)
     , ex <- exchanges act
-    , isReferenceExchange ex
-    , Just flow <- [M.lookup (getExchangeFlowId ex) (sdbFlows db)]
+    , exchangeIsReference ex
+    , Just flow <- [M.lookup (exchangeFlowId ex) (sdbTechFlows db)]
     ]
-  where
-    isReferenceExchange :: Exchange -> Bool
-    isReferenceExchange TechnosphereExchange{techIsReference = isRef} = isRef
-    isReferenceExchange BiosphereExchange{} = False
-
-    getExchangeFlowId :: Exchange -> UUID
-    getExchangeFlowId TechnosphereExchange{techFlowId = fid} = fid
-    getExchangeFlowId BiosphereExchange{bioFlowId = fid} = fid
 
 {- | Build an indexed database from a full Database (used when loading from cache)
 This is the preferred method as it works with cached databases
@@ -345,24 +339,17 @@ buildIndexedDatabaseFromDB dbName synDB db =
             , idbBySynonymGroup = bySynonym
             }
 
--- | Build supplier entries from a full Database
+-- | Build supplier entries from a full Database. Same invariant as
+-- 'buildSupplierEntries' above: reference exchanges are technosphere.
 buildSupplierEntriesFromDB :: Database -> [(Text, SupplierEntry)]
 buildSupplierEntriesFromDB db =
-    [ (flowName flow, SupplierEntry actUUID prodUUID (activityLocation act) (activityUnit act) (flowName flow))
+    [ (tfName flow, SupplierEntry actUUID prodUUID (activityLocation act) (activityUnit act) (tfName flow))
     | (pid, (actUUID, prodUUID)) <- zip ([0 ..] :: [Int]) (V.toList (dbProcessIdTable db))
     , Just act <- [getActivity db (fromIntegral pid)]
     , ex <- exchanges act
-    , isReferenceExchange ex
-    , Just flow <- [M.lookup (getExchangeFlowId ex) (dbFlows db)]
+    , exchangeIsReference ex
+    , Just flow <- [M.lookup (exchangeFlowId ex) (dbTechFlows db)]
     ]
-  where
-    isReferenceExchange :: Exchange -> Bool
-    isReferenceExchange TechnosphereExchange{techIsReference = isRef} = isRef
-    isReferenceExchange BiosphereExchange{} = False
-
-    getExchangeFlowId :: Exchange -> UUID
-    getExchangeFlowId TechnosphereExchange{techFlowId = fid} = fid
-    getExchangeFlowId BiosphereExchange{bioFlowId = fid} = fid
 
 {- | Find a supplier across all loaded databases (using pre-built indexes)
 This is the fast O(1) lookup version

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 
 {- |
 Module      : Database.Loader
@@ -61,7 +62,8 @@ module Database.Loader (
 
     -- * Internal (exposed for testing)
     normalizeText,
-    mergeFlows,
+    mergeTechFlows,
+    mergeBioFlows,
     generateActivityUUIDFromActivity,
     getReferenceProductUUID,
     UnlinkedSummary (..),
@@ -81,7 +83,7 @@ import Data.Bits (xor)
 import qualified Data.ByteString as BS
 import Data.Char (toLower)
 import Data.Either (partitionEithers)
-import Data.List (sort, sortBy, sortOn, unzip7)
+import Data.List (sort, sortBy, sortOn)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
@@ -126,12 +128,23 @@ import qualified UnitConversion as UC
 cacheMagic :: BS.ByteString
 cacheMagic = "VOLCACHE"
 
-{- | Merge two Flow records with the same UUID, combining their synonyms.
-When multiple .spold files reference the same biosphere flow, each may carry
-different synonyms. M.fromListWith mergeFlows ensures no synonym is lost.
+{- | Merge two technosphere flows with the same UUID, combining their synonyms.
+When multiple .spold files reference the same flow each may carry different
+synonyms; M.fromListWith mergeTechFlows ensures no synonym is lost.
 -}
-mergeFlows :: Flow -> Flow -> Flow
-mergeFlows a b = a{flowSynonyms = M.unionWith S.union (flowSynonyms a) (flowSynonyms b)}
+mergeTechFlows :: TechnosphereFlow -> TechnosphereFlow -> TechnosphereFlow
+mergeTechFlows a b = a{tfSynonyms = M.unionWith S.union (tfSynonyms a) (tfSynonyms b)}
+
+-- | Biosphere counterpart of 'mergeTechFlows'.
+mergeBioFlows :: BiosphereFlow -> BiosphereFlow -> BiosphereFlow
+mergeBioFlows a b = a{bfSynonyms = M.unionWith S.union (bfSynonyms a) (bfSynonyms b)}
+
+-- | 8-element unzip helper (Data.List ships 7-tuple as max).
+unzip8 :: [(a, b, c, d, e, f, g, h)] -> ([a], [b], [c], [d], [e], [f], [g], [h])
+unzip8 = foldr step ([], [], [], [], [], [], [], [])
+  where
+    step (a, b, c, d, e, f, g, h) (as, bs, cs, ds, es, fs, gs, hs) =
+        (a : as, b : bs, c : cs, d : ds, e : es, f : fs, g : gs, h : hs)
 
 {- |
 Schema signature automatically derived from the Database type structure.
@@ -287,28 +300,28 @@ normalizeText = T.toLower . T.strip . normalizeUnicode
 {- | Build supplier index: (normalizedProductName, location) → (activityUUID, productUUID)
 For each activity, we index it by its reference product name + activity location
 -}
-buildSupplierIndex :: ActivityMap -> FlowDB -> SupplierIndex
-buildSupplierIndex activities flowDb =
+buildSupplierIndex :: ActivityMap -> TechFlowDB -> SupplierIndex
+buildSupplierIndex activities techFlowDb =
     M.fromList
-        [ ((normalizeText (flowName flow), activityLocation act), (actUUID, prodUUID))
+        [ ((normalizeText (tfName flow), activityLocation act), (actUUID, prodUUID))
         | ((actUUID, prodUUID), act) <- M.toList activities
         , ex <- exchanges act
         , exchangeIsReference ex
-        , Just flow <- [M.lookup (exchangeFlowId ex) flowDb]
+        , Just flow <- [M.lookup (exchangeFlowId ex) techFlowDb]
         ]
 
 {- | Build name-only supplier index for SimaPro linking
 Uses the normalized product name + extracted prefixes (no location required).
 Exact names take priority via M.union.
 -}
-buildSupplierIndexByName :: ActivityMap -> FlowDB -> NameOnlyIndex
-buildSupplierIndexByName activities flowDb =
+buildSupplierIndexByName :: ActivityMap -> TechFlowDB -> NameOnlyIndex
+buildSupplierIndexByName activities techFlowDb =
     let entries =
-            [ (flowName flow, (actUUID, prodUUID))
+            [ (tfName flow, (actUUID, prodUUID))
             | ((actUUID, prodUUID), act) <- M.toList activities
             , ex <- exchanges act
             , exchangeIsReference ex
-            , Just flow <- [M.lookup (exchangeFlowId ex) flowDb]
+            , Just flow <- [M.lookup (exchangeFlowId ex) techFlowDb]
             ]
         exactIndex = M.fromList [(normalizeText name, val) | (name, val) <- entries]
         prefixIndex =
@@ -324,14 +337,14 @@ buildSupplierIndexByName activities flowDb =
 Used when exchange has no location attribute to find the activity's actual location
 Maps normalizedProductName → (activityUUID, productUUID, activityLocation)
 -}
-buildSupplierIndexByNameWithLocation :: ActivityMap -> FlowDB -> SupplierByNameWithLocation
-buildSupplierIndexByNameWithLocation activities flowDb =
+buildSupplierIndexByNameWithLocation :: ActivityMap -> TechFlowDB -> SupplierByNameWithLocation
+buildSupplierIndexByNameWithLocation activities techFlowDb =
     M.fromList
-        [ (normalizeText (flowName flow), (actUUID, prodUUID, activityLocation act))
+        [ (normalizeText (tfName flow), (actUUID, prodUUID, activityLocation act))
         | ((actUUID, prodUUID), act) <- M.toList activities
         , ex <- exchanges act
         , exchangeIsReference ex
-        , Just flow <- [M.lookup (exchangeFlowId ex) flowDb]
+        , Just flow <- [M.lookup (exchangeFlowId ex) techFlowDb]
         ]
 
 {- | Fix EcoSpold1 activity links by resolving supplier references.
@@ -342,9 +355,9 @@ Location aliases map wrongLocation → correctLocation (e.g., "ENTSO" → "ENTSO
 fixEcoSpold1ActivityLinks :: M.Map T.Text T.Text -> DatasetNumberIndex -> M.Map UUID.UUID Int -> SimpleDatabase -> IO SimpleDatabase
 fixEcoSpold1ActivityLinks locationAliases dsIndex supplierLinks db = do
     -- Build supplier index
-    let supplierIndex = buildSupplierIndex (sdbActivities db) (sdbFlows db)
+    let supplierIndex = buildSupplierIndex (sdbActivities db) (sdbTechFlows db)
     -- Build name-only index with location for exchanges missing location attribute
-    let nameIndex = buildSupplierIndexByNameWithLocation (sdbActivities db) (sdbFlows db)
+    let nameIndex = buildSupplierIndexByNameWithLocation (sdbActivities db) (sdbTechFlows db)
     reportProgress Info $
         printf
             "Built supplier index with %d entries for activity linking (%d location aliases, %d name-only entries, %d dataset-number entries)"
@@ -361,7 +374,7 @@ fixEcoSpold1ActivityLinks locationAliases dsIndex supplierLinks db = do
                 , elcNameIndex = nameIndex
                 , elcDatasetIndex = dsIndex
                 , elcSupplierLinks = supplierLinks
-                , elcFlowDB = sdbFlows db
+                , elcFlowDB = sdbTechFlows db
                 }
         (fixedActivities, summary) = fixAllActivities ctx (sdbActivities db)
 
@@ -390,7 +403,7 @@ data ExchangeLinkContext = ExchangeLinkContext
     , elcNameIndex :: !SupplierByNameWithLocation
     , elcDatasetIndex :: !DatasetNumberIndex
     , elcSupplierLinks :: !(M.Map UUID.UUID Int)
-    , elcFlowDB :: !FlowDB
+    , elcFlowDB :: !TechFlowDB
     }
 
 -- | Fix all activities and return statistics with unlinked summary
@@ -415,11 +428,11 @@ Unlinked exchanges stay unlinked for cross-DB resolution.
 Returns (fixed exchange, UnlinkedSummary)
 -}
 fixExchangeLink :: ExchangeLinkContext -> T.Text -> Exchange -> (Exchange, UnlinkedSummary)
-fixExchangeLink ExchangeLinkContext{..} consumerName ex@TechnosphereExchange{techFlowId = fid, techIsInput = isInp, techLocation = loc}
-    | isInp =
+fixExchangeLink ExchangeLinkContext{..} consumerName ex@TechnosphereExchange{techFlowId = fid, techRole = role, techLocation = loc}
+    | role == Input || role == ReferenceInput =
         let linked actUUID prodUUID = (ex{techFlowId = prodUUID, techActivityLinkId = actUUID}, UnlinkedSummary M.empty 1 1 0)
             unlinked flow lookupLoc =
-                let ue = UnlinkedExchange (flowName flow) lookupLoc
+                let ue = UnlinkedExchange (tfName flow) lookupLoc
                  in (ex, UnlinkedSummary (M.singleton consumerName [ue]) 1 0 1)
          in case M.lookup fid elcFlowDB of
                 Just flow ->
@@ -427,23 +440,23 @@ fixExchangeLink ExchangeLinkContext{..} consumerName ex@TechnosphereExchange{tec
                     case M.lookup fid elcSupplierLinks >>= \dsNum -> M.lookup dsNum elcDatasetIndex of
                         Just (actUUID, prodUUID)
                             | Just supplierFlow <- M.lookup prodUUID elcFlowDB
-                            , normalizeText (flowName supplierFlow) == normalizeText (flowName flow) ->
+                            , normalizeText (tfName supplierFlow) == normalizeText (tfName flow) ->
                                 linked actUUID prodUUID
                         _ ->
                             -- Tier 2: name + location lookup
                             let normalizedLoc = fromMaybe loc (M.lookup loc elcLocationAliases)
                                 lookupLoc
                                     | T.null normalizedLoc =
-                                        case M.lookup (normalizeText (flowName flow)) elcNameIndex of
+                                        case M.lookup (normalizeText (tfName flow)) elcNameIndex of
                                             Just (_, _, actLoc) -> actLoc
                                             Nothing -> normalizedLoc
                                     | otherwise = normalizedLoc
-                                key = (normalizeText (flowName flow), lookupLoc)
+                                key = (normalizeText (tfName flow), lookupLoc)
                              in case M.lookup key elcSupplierIndex of
                                     Just (actUUID, prodUUID) -> linked actUUID prodUUID
                                     Nothing ->
                                         -- Tier 3: name-only fallback (safe for EcoSpold1 where names include {LOCATION})
-                                        case M.lookup (normalizeText (flowName flow)) elcNameIndex of
+                                        case M.lookup (normalizeText (tfName flow)) elcNameIndex of
                                             Just (actUUID, prodUUID, _) -> linked actUUID prodUUID
                                             Nothing -> unlinked flow lookupLoc
                 Nothing ->
@@ -500,7 +513,7 @@ loadDatabaseWithLocationAliases unitConfig locationAliases path = do
 -- | Load SimaPro CSV file
 loadSimaProCSV :: UC.UnitConfig -> FilePath -> IO (Either T.Text SimpleDatabase)
 loadSimaProCSV unitConfig csvPath = do
-    (activities, flowDB, unitDB) <- SimaPro.parseSimaProCSV unitConfig csvPath
+    (activities, techFlowDB, bioFlowDB, unitDB) <- SimaPro.parseSimaProCSV unitConfig csvPath
 
     if null activities
         then return $ Left "No activities found in SimaPro CSV file."
@@ -514,7 +527,7 @@ loadSimaProCSV unitConfig csvPath = do
                         ]
 
             -- Build initial database
-            let simpleDb = SimpleDatabase procMap flowDB unitDB
+            let simpleDb = SimpleDatabase procMap techFlowDB bioFlowDB unitDB
 
             -- Fix activity links using supplier lookup (same as EcoSpold1)
             Right <$> fixSimaProActivityLinks simpleDb
@@ -524,11 +537,11 @@ Uses name-only matching (no location required) for SimaPro technosphere inputs
 -}
 fixSimaProActivityLinks :: SimpleDatabase -> IO SimpleDatabase
 fixSimaProActivityLinks db = do
-    let nameIndex = buildSupplierIndexByName (sdbActivities db) (sdbFlows db)
+    let nameIndex = buildSupplierIndexByName (sdbActivities db) (sdbTechFlows db)
     reportProgress Info $ printf "Built name-only supplier index with %d entries for SimaPro linking" (M.size nameIndex)
 
     -- Count and report statistics
-    let (fixedActivities, summary) = fixAllActivitiesByName nameIndex (sdbFlows db) (sdbActivities db)
+    let (fixedActivities, summary) = fixAllActivitiesByName nameIndex (sdbTechFlows db) (sdbActivities db)
 
     reportProgress Info $
         printf
@@ -544,39 +557,37 @@ fixSimaProActivityLinks db = do
     return $ db{sdbActivities = fixedActivities}
 
 -- | Fix all activities using name-only matching
-fixAllActivitiesByName :: NameOnlyIndex -> FlowDB -> ActivityMap -> (ActivityMap, UnlinkedSummary)
-fixAllActivitiesByName idx flowDb activities =
-    let results = M.map (\act -> fixActivityExchangesByName idx flowDb act) activities
+fixAllActivitiesByName :: NameOnlyIndex -> TechFlowDB -> ActivityMap -> (ActivityMap, UnlinkedSummary)
+fixAllActivitiesByName idx techFlowDb activities =
+    let results = M.map (fixActivityExchangesByName idx techFlowDb) activities
         summaries = map snd $ M.elems results
         combinedSummary = foldr mergeUnlinkedSummaries emptyUnlinkedSummary summaries
         fixedActivities = M.map fst results
      in (fixedActivities, combinedSummary)
 
 -- | Fix activity exchanges using name-only matching
-fixActivityExchangesByName :: NameOnlyIndex -> FlowDB -> Activity -> (Activity, UnlinkedSummary)
-fixActivityExchangesByName idx flowDb act =
-    let (fixedExchanges, summaries) = unzip $ map (fixExchangeLinkByName idx flowDb (activityName act)) (exchanges act)
+fixActivityExchangesByName :: NameOnlyIndex -> TechFlowDB -> Activity -> (Activity, UnlinkedSummary)
+fixActivityExchangesByName idx techFlowDb act =
+    let (fixedExchanges, summaries) = unzip $ map (fixExchangeLinkByName idx techFlowDb (activityName act)) (exchanges act)
         combinedSummary = foldr mergeUnlinkedSummaries emptyUnlinkedSummary summaries
      in (act{exchanges = fixedExchanges}, combinedSummary)
 
-{- | Fix a single exchange's activity link using name-only matching
-Returns (fixed exchange, UnlinkedSummary)
+{- | Fix a single exchange's activity link using name-only matching.
+Inputs and non-reference outputs (coproducts / avoided-production credits)
+are eligible for relinking. Returns (fixed exchange, UnlinkedSummary).
 -}
-fixExchangeLinkByName :: NameOnlyIndex -> FlowDB -> T.Text -> Exchange -> (Exchange, UnlinkedSummary)
-fixExchangeLinkByName idx flowDb consumerName ex@TechnosphereExchange{techFlowId = fid, techIsInput = isInp, techIsReference = isRef, techLocation = loc}
-    | isInp || not isRef -- Inputs + co-product outputs (avoided production credits)
-        =
-        case M.lookup fid flowDb of
+fixExchangeLinkByName :: NameOnlyIndex -> TechFlowDB -> T.Text -> Exchange -> (Exchange, UnlinkedSummary)
+fixExchangeLinkByName idx techFlowDb consumerName ex@TechnosphereExchange{techFlowId = fid, techRole = role, techLocation = loc}
+    | role == Input || role == ReferenceInput || role == Coproduct =
+        case M.lookup fid techFlowDb of
             Just flow ->
-                let key = normalizeText (flowName flow)
+                let key = normalizeText (tfName flow)
                     relink actUUID prodUUID = ex{techFlowId = prodUUID, techActivityLinkId = actUUID}
                  in case M.lookup key idx of
                         Just (actUUID, prodUUID) ->
-                            -- Found supplier: update both activityLinkId AND flowId to match supplier's reference product
                             (relink actUUID prodUUID, UnlinkedSummary M.empty 1 1 0)
                         Nothing ->
-                            -- Fallback: try splitting compound name at separators
-                            let prefixes = extractProductPrefixes (flowName flow)
+                            let prefixes = extractProductPrefixes (tfName flow)
                                 tryPrefix [] = Nothing
                                 tryPrefix (p : ps) = case M.lookup (normalizeText p) idx of
                                     Just result -> Just result
@@ -585,15 +596,14 @@ fixExchangeLinkByName idx flowDb consumerName ex@TechnosphereExchange{techFlowId
                                     Just (actUUID, prodUUID) ->
                                         (relink actUUID prodUUID, UnlinkedSummary M.empty 1 1 0)
                                     Nothing ->
-                                        -- Supplier not found - collect unlinked exchange info
-                                        let unlinked = UnlinkedExchange (flowName flow) loc
+                                        let unlinked = UnlinkedExchange (tfName flow) loc
                                             unlinkedMap = M.singleton consumerName [unlinked]
                                          in (ex, UnlinkedSummary unlinkedMap 1 0 1)
             Nothing ->
-                -- Flow not in database - shouldn't happen but be safe
+                -- Flow not in technosphere map — shouldn't happen but be safe
                 (ex, UnlinkedSummary M.empty 1 0 1)
-    | otherwise = (ex, emptyUnlinkedSummary) -- Not a linkable exchange (outputs/references)
-fixExchangeLinkByName _ _ _ ex@BiosphereExchange{} = (ex, emptyUnlinkedSummary) -- No supplier linking
+    | otherwise = (ex, emptyUnlinkedSummary) -- Reference products: nothing to relink
+fixExchangeLinkByName _ _ _ ex@BiosphereExchange{} = (ex, emptyUnlinkedSummary)
 
 -- | Load EcoSpold files from directory
 loadEcoSpoldDirectory :: M.Map T.Text T.Text -> FilePath -> IO (Either T.Text SimpleDatabase)
@@ -644,9 +654,10 @@ loadEcoSpoldDirectory locationAliases dir = do
             (firstErr : _) -> return $ Left firstErr
             [] -> do
                 let successResults = [r | Right r <- results]
-                let (procMaps, flowMaps, unitMaps, rawFlowCounts, rawUnitCounts, dsIndexes, supplierLinksLists) = unzip7 successResults
+                let (procMaps, techFlowMaps, bioFlowMaps, unitMaps, rawFlowCounts, rawUnitCounts, dsIndexes, supplierLinksLists) = unzip8 successResults
                 let !finalProcMap = M.unions procMaps
-                let !finalFlowMap = M.unionsWith mergeFlows flowMaps
+                let !finalTechFlowMap = M.unionsWith mergeTechFlows techFlowMaps
+                let !finalBioFlowMap = M.unionsWith mergeBioFlows bioFlowMaps
                 let !finalUnitMap = M.unions unitMaps
                 let !finalDsIndex = M.unions dsIndexes
                 let !finalSupplierLinks = M.unions supplierLinksLists
@@ -657,15 +668,17 @@ loadEcoSpoldDirectory locationAliases dir = do
                 let avgFilesPerSec = fromIntegral totalFiles / totalDuration
                 let totalRawFlows = sum rawFlowCounts
                 let totalRawUnits = sum rawUnitCounts
-                let flowDeduplication = if totalRawFlows > 0 then 100.0 * (1.0 - fromIntegral (M.size finalFlowMap) / fromIntegral totalRawFlows) else 0.0 :: Double
+                let totalFlows = M.size finalTechFlowMap + M.size finalBioFlowMap
+                let flowDeduplication = if totalRawFlows > 0 then 100.0 * (1.0 - fromIntegral totalFlows / fromIntegral totalRawFlows) else 0.0 :: Double
                 let unitDeduplication = if totalRawUnits > 0 then 100.0 * (1.0 - fromIntegral (M.size finalUnitMap) / fromIntegral totalRawUnits) else 0.0 :: Double
 
                 reportProgress Info $ printf "Parsing completed (%s, %.1f files/sec):" (formatDuration totalDuration) avgFilesPerSec
                 reportProgress Info $ printf "  Activities: %d processes" (M.size finalProcMap)
                 reportProgress Info $
                     printf
-                        "  Flows: %d unique (%.1f%% deduplication from %d raw)"
-                        (M.size finalFlowMap)
+                        "  Flows: %d tech + %d bio (%.1f%% deduplication from %d raw)"
+                        (M.size finalTechFlowMap)
+                        (M.size finalBioFlowMap)
                         flowDeduplication
                         totalRawFlows
                 reportProgress Info $
@@ -677,52 +690,49 @@ loadEcoSpoldDirectory locationAliases dir = do
                 reportMemoryUsage "Final parsing memory usage"
 
                 -- For EcoSpold1: fix activity links using supplier lookup table
-                let simpleDb = SimpleDatabase finalProcMap finalFlowMap finalUnitMap
+                let simpleDb = SimpleDatabase finalProcMap finalTechFlowMap finalBioFlowMap finalUnitMap
                 if isEcoSpold1
                     then Right <$> fixEcoSpold1ActivityLinks locationAliases finalDsIndex finalSupplierLinks simpleDb
                     else return $ Right simpleDb
 
     -- Process one worker's share of files
-    processWorker :: UTCTime -> Bool -> (Int, [FilePath]) -> IO (Either T.Text (ActivityMap, FlowDB, UnitDB, Int, Int, DatasetNumberIndex, M.Map UUID.UUID Int))
+    processWorker :: UTCTime -> Bool -> (Int, [FilePath]) -> IO (Either T.Text (ActivityMap, TechFlowDB, BioFlowDB, UnitDB, Int, Int, DatasetNumberIndex, M.Map UUID.UUID Int))
     processWorker _startTime isEcoSpold1 (workerNum, workerFiles) = do
         workerStartTime <- getCurrentTime
         reportProgress Info $ printf "Worker %d started: processing %d files" workerNum (length workerFiles)
 
-        -- Parse all files for this worker using appropriate parser
-        -- Both paths return (Activity, [Flow], [Unit], Int, M.Map UUID Int)
-        -- For EcoSpold2: dataset number = 0, supplier links = empty
+        -- Parse all files for this worker using appropriate parser.
+        -- Both paths return (Activity, [TechnosphereFlow], [BiosphereFlow], [Unit], Int, M.Map UUID Int).
+        -- For EcoSpold2: dataset number = 0, supplier links = empty (fields padded here).
         let parseFile =
                 if isEcoSpold1
                     then streamParseActivityAndFlowsFromFile1
-                    else \f -> fmap (fmap (\(a, fs, us) -> (a, fs, us, 0, M.empty))) (streamParseActivityAndFlowsFromFile f)
+                    else fmap (fmap (\(a, ts, bs, us) -> (a, ts, bs, us, 0, M.empty))) . streamParseActivityAndFlowsFromFile
         workerResults <- mapM parseFile workerFiles
-        -- Pair each result with its file path, then partition
-        let paired = zipWith (\f r -> fmap (\v -> (f, v)) r) workerFiles workerResults
+        let paired = zipWith (\f r -> fmap (f,) r) workerFiles workerResults
         let (errs, oks) = partitionEithers paired
         forM_ errs $ \e ->
             reportProgress Warning e
         let (okFiles, okResults) = unzip oks
-        let procs = [a | (a, _, _, _, _) <- okResults]
-            flowLists = [fs | (_, fs, _, _, _) <- okResults]
-            unitLists = [us | (_, _, us, _, _) <- okResults]
-            dsNums = [n | (_, _, _, n, _) <- okResults]
-            supplierLinksList = [sl | (_, _, _, _, sl) <- okResults]
-        let !allFlows = concat flowLists
+        let procs = [a | (a, _, _, _, _, _) <- okResults]
+            techLists = [ts | (_, ts, _, _, _, _) <- okResults]
+            bioLists = [bs | (_, _, bs, _, _, _) <- okResults]
+            unitLists = [us | (_, _, _, us, _, _) <- okResults]
+            dsNums = [n | (_, _, _, _, n, _) <- okResults]
+            supplierLinksList = [sl | (_, _, _, _, _, sl) <- okResults]
+        let !allTechs = concat techLists
+        let !allBios = concat bioLists
         let !allUnits = concat unitLists
 
-        -- Build maps for this worker - extract UUID pairs from filenames
-        -- For EcoSpold1: generate UUIDs from numeric dataset number
-        -- For EcoSpold2: parse UUIDs from filename (activityUUID_productUUID.spold)
         let procEntries = zipWith (buildProcEntry isEcoSpold1) okFiles procs
 
-        -- Check for any filename parsing errors
         case [e | Left e <- procEntries] of
             (firstErr : _) -> return $ Left firstErr
             [] -> do
                 let !procMap = M.fromList [e | Right e <- procEntries]
-                let !flowMap = M.fromListWith mergeFlows [(flowId f, f) | f <- allFlows]
+                let !techFlowMap = M.fromListWith mergeTechFlows [(tfId f, f) | f <- allTechs]
+                let !bioFlowMap = M.fromListWith mergeBioFlows [(bfId f, f) | f <- allBios]
                 let !unitMap = M.fromList [(unitId u, u) | u <- allUnits]
-                -- Build dataset number index: dsNum → (actUUID, prodUUID)
                 let !dsIndex =
                         M.fromList
                             [(n, key) | (n, Right (key, _)) <- zip dsNums procEntries, n /= 0]
@@ -731,18 +741,19 @@ loadEcoSpoldDirectory locationAliases dir = do
                 workerEndTime <- getCurrentTime
                 let workerDuration = realToFrac $ diffUTCTime workerEndTime workerStartTime
                 let filesPerSec = fromIntegral (length workerFiles) / workerDuration
-                let rawFlowCount = length allFlows
+                let rawFlowCount = length allTechs + length allBios
                 let rawUnitCount = length allUnits
                 reportProgress Info $
                     printf
-                        "Worker %d completed: %d activities, %d flows (%s, %.1f files/sec)"
+                        "Worker %d completed: %d activities, %d tech + %d bio flows (%s, %.1f files/sec)"
                         workerNum
                         (M.size procMap)
-                        (M.size flowMap)
+                        (M.size techFlowMap)
+                        (M.size bioFlowMap)
                         (formatDuration workerDuration)
                         filesPerSec
 
-                return $ Right (procMap, flowMap, unitMap, rawFlowCount, rawUnitCount, dsIndex, allSupplierLinks)
+                return $ Right (procMap, techFlowMap, bioFlowMap, unitMap, rawFlowCount, rawUnitCount, dsIndex, allSupplierLinks)
 
     -- Build a single process entry, returning Either for error handling
     buildProcEntry :: Bool -> FilePath -> Activity -> Either T.Text ((UUID, UUID), Activity)
@@ -772,29 +783,27 @@ loadSingleEcoSpold1File locationAliases filepath = do
 
     -- Build activity map from all parsed activities
     let expanded = map buildProcEntryFromResult results
-        !procMap = M.fromList [(key, act) | (key, act) <- expanded]
-        !flowMap = M.fromListWith mergeFlows [(flowId f, f) | (_, flows, _, _, _) <- results, f <- flows]
-        !unitMap = M.fromList [(unitId u, u) | (_, _, units, _, _) <- results, u <- units]
-        -- Build dataset number index: dsNum → (actUUID, prodUUID)
+        !procMap = M.fromList expanded
+        !techFlowMap = M.fromListWith mergeTechFlows [(tfId f, f) | (_, techs, _, _, _, _) <- results, f <- techs]
+        !bioFlowMap = M.fromListWith mergeBioFlows [(bfId f, f) | (_, _, bios, _, _, _) <- results, f <- bios]
+        !unitMap = M.fromList [(unitId u, u) | (_, _, _, units, _, _) <- results, u <- units]
         !dsIndex =
             M.fromList
-                [(dsNum, key) | ((_, _, _, dsNum, _), (key, _)) <- zip results expanded, dsNum /= 0]
-        -- Merge supplier links from all datasets
-        !supplierLinks = M.unions [sl | (_, _, _, _, sl) <- results]
-        simpleDb = SimpleDatabase procMap flowMap unitMap
+                [(dsNum, key) | ((_, _, _, _, dsNum, _), (key, _)) <- zip results expanded, dsNum /= 0]
+        !supplierLinks = M.unions [sl | (_, _, _, _, _, sl) <- results]
+        simpleDb = SimpleDatabase procMap techFlowMap bioFlowMap unitMap
 
-    -- Report statistics
-    let totalFlows = sum [length flows | (_, flows, _, _, _) <- results]
-    let totalUnits = sum [length units | (_, _, units, _, _) <- results]
+    let totalTechs = sum [length techs | (_, techs, _, _, _, _) <- results]
+    let totalBios = sum [length bios | (_, _, bios, _, _, _) <- results]
+    let totalUnits = sum [length units | (_, _, _, units, _, _) <- results]
     reportProgress Info $ printf "  Activities: %d processes" (M.size procMap)
-    reportProgress Info $ printf "  Flows: %d unique (from %d raw)" (M.size flowMap) totalFlows
+    reportProgress Info $ printf "  Flows: %d tech + %d bio (from %d raw)" (M.size techFlowMap) (M.size bioFlowMap) (totalTechs + totalBios)
     reportProgress Info $ printf "  Units: %d unique (from %d raw)" (M.size unitMap) totalUnits
 
-    -- Fix activity links using supplier lookup
     Right <$> fixEcoSpold1ActivityLinks locationAliases dsIndex supplierLinks simpleDb
   where
-    buildProcEntryFromResult :: (Activity, [Flow], [Unit], Int, M.Map UUID.UUID Int) -> ((UUID.UUID, UUID.UUID), Activity)
-    buildProcEntryFromResult (activity, _, _, _, _) =
+    buildProcEntryFromResult :: (Activity, [TechnosphereFlow], [BiosphereFlow], [Unit], Int, M.Map UUID.UUID Int) -> ((UUID.UUID, UUID.UUID), Activity)
+    buildProcEntryFromResult (activity, _, _, _, _, _) =
         let actUUID = generateActivityUUIDFromActivity activity
             prodUUID = getReferenceProductUUID activity
          in ((actUUID, prodUUID), activity)
@@ -1168,7 +1177,7 @@ fixActivityLinksWithCrossDB indexedDbs synonymDB unitConfig locationHier db = do
             let stats =
                     findAllCrossDBLinks
                         linkingCtx
-                        (sdbFlows db)
+                        (sdbTechFlows db)
                         (sdbUnits db)
                         (sdbActivities db)
 
@@ -1185,11 +1194,12 @@ collectUnlinkedProductNames :: SimpleDatabase -> M.Map T.Text Int
 collectUnlinkedProductNames db =
     M.fromListWith
         (+)
-        [ (flowName flow, 1)
+        [ (tfName flow, 1)
         | act <- M.elems (sdbActivities db)
-        , TechnosphereExchange{techFlowId = fid, techIsInput = True, techActivityLinkId = linkId} <- exchanges act
+        , ex@TechnosphereExchange{techFlowId = fid, techActivityLinkId = linkId} <- exchanges act
+        , exchangeIsInput ex
         , linkId == UUID.nil
-        , Just flow <- [M.lookup fid (sdbFlows db)]
+        , Just flow <- [M.lookup fid (sdbTechFlows db)]
         ]
 
 -- | Count unlinked technosphere exchanges in a database
@@ -1203,8 +1213,8 @@ countUnlinkedExchanges db =
         ]
   where
     isUnlinkedTechInput :: Exchange -> Bool
-    isUnlinkedTechInput TechnosphereExchange{techIsInput = isInp, techActivityLinkId = linkId} =
-        isInp && linkId == UUID.nil
+    isUnlinkedTechInput ex@TechnosphereExchange{techActivityLinkId = linkId} =
+        exchangeIsInput ex && linkId == UUID.nil
     isUnlinkedTechInput BiosphereExchange{} = False
 
 -- | Count total technosphere input exchanges in a database
@@ -1218,7 +1228,7 @@ countTotalTechInputs db =
         ]
   where
     isTechInput :: Exchange -> Bool
-    isTechInput TechnosphereExchange{techIsInput = isInp} = isInp
+    isTechInput ex@TechnosphereExchange{} = exchangeIsInput ex
     isTechInput BiosphereExchange{} = False
 
 {- | Find all cross-database links without modifying activities
@@ -1226,61 +1236,49 @@ Returns statistics including the CrossDBLinks for chained solving
 -}
 findAllCrossDBLinks ::
     LinkingContext ->
-    FlowDB ->
+    TechFlowDB ->
     UnitDB ->
     ActivityMap ->
     CrossDBLinkingStats
-findAllCrossDBLinks ctx flowDb unitDb activities =
-    let results = M.mapWithKey (findActivityCrossDBLinks ctx flowDb unitDb) activities
+findAllCrossDBLinks ctx techFlowDb unitDb activities =
+    let results = M.mapWithKey (findActivityCrossDBLinks ctx techFlowDb unitDb) activities
      in foldr mergeCrossDBStats emptyCrossDBLinkingStats (M.elems results)
 
 -- | Find cross-database links for one activity's exchanges
 findActivityCrossDBLinks ::
     LinkingContext ->
-    FlowDB ->
+    TechFlowDB ->
     UnitDB ->
     -- | Consumer activity key (actUUID, prodUUID)
     (UUID.UUID, UUID.UUID) ->
     Activity ->
     CrossDBLinkingStats
-findActivityCrossDBLinks ctx flowDb unitDb (consumerActUUID, consumerProdUUID) act =
-    let stats = map (findExchangeCrossDBLink ctx flowDb unitDb consumerActUUID consumerProdUUID) (exchanges act)
+findActivityCrossDBLinks ctx techFlowDb unitDb (consumerActUUID, consumerProdUUID) act =
+    let stats = map (findExchangeCrossDBLink ctx techFlowDb unitDb consumerActUUID consumerProdUUID) (exchanges act)
      in foldr mergeCrossDBStats emptyCrossDBLinkingStats stats
 
-{- | Find cross-database link for a single exchange
+{- | Find cross-database link for a single exchange.
 
 Only attempts cross-DB linking if:
-1. Exchange is a technosphere input
+1. Exchange is a technosphere input (or reference input on a treatment process)
 2. Exchange is currently unlinked (activityLinkId is nil)
-
-When a link is found, a CrossDBLink is created and returned in stats.
-The exchange itself is NOT modified.
 -}
 findExchangeCrossDBLink ::
     LinkingContext ->
-    FlowDB ->
+    TechFlowDB ->
     UnitDB ->
-    -- | Consumer activity UUID
     UUID.UUID ->
-    -- | Consumer product UUID
     UUID.UUID ->
     Exchange ->
     CrossDBLinkingStats
-findExchangeCrossDBLink ctx flowDb unitDb consumerActUUID consumerProdUUID TechnosphereExchange{techFlowId = fid, techAmount = amt, techIsInput = isInp, techActivityLinkId = linkId, techLocation = loc}
-    | isInp && linkId == UUID.nil -- Unlinked technosphere input
-        =
-        case M.lookup fid flowDb of
-            Nothing ->
-                -- Flow not found in FlowDB - can't name it
-                emptyCrossDBLinkingStats
+findExchangeCrossDBLink ctx techFlowDb unitDb consumerActUUID consumerProdUUID ex@TechnosphereExchange{techFlowId = fid, techAmount = amt, techActivityLinkId = linkId, techLocation = loc}
+    | exchangeIsInput ex && linkId == UUID.nil =
+        case M.lookup fid techFlowDb of
+            Nothing -> emptyCrossDBLinkingStats
             Just flow ->
-                -- Get unit name from UnitDB
-                let flowUnitName = case M.lookup (flowUnitId flow) unitDb of
-                        Just u -> unitName u
-                        Nothing -> "" -- Unknown unit
-                 in case findSupplierAcrossDatabases ctx (flowName flow) loc flowUnitName of
+                let flowUnitName = maybe "" unitName (M.lookup (tfUnitId flow) unitDb)
+                 in case findSupplierAcrossDatabases ctx (tfName flow) loc flowUnitName of
                         CrossDBLinked supplierActUUID supplierProdUUID dbName _score prodName supplierLoc warnings ->
-                            -- Successfully found cross-DB supplier
                             let !crossLink =
                                     CrossDBLink
                                         { cdlConsumerActUUID = consumerActUUID
@@ -1293,13 +1291,11 @@ findExchangeCrossDBLink ctx flowDb unitDb consumerActUUID consumerProdUUID Techn
                                         , cdlLocation = supplierLoc
                                         , cdlSourceDatabase = dbName
                                         }
-                                fallbacks = [(prodName, req, act) | UpperLocationUsed req act <- warnings]
+                                fallbacks = [(prodName, req, actLoc) | UpperLocationUsed req actLoc <- warnings]
                              in CrossDBLinkingStats [crossLink] M.empty S.empty fallbacks 0
                         CrossDBNotLinked blocker ->
-                            -- Record as unresolved with the blocker reason
-                            CrossDBLinkingStats [] (M.singleton (flowName flow) (1, blocker)) S.empty [] 0
-    | otherwise =
-        emptyCrossDBLinkingStats
+                            CrossDBLinkingStats [] (M.singleton (tfName flow) (1, blocker)) S.empty [] 0
+    | otherwise = emptyCrossDBLinkingStats
 findExchangeCrossDBLink _ _ _ _ _ BiosphereExchange{} = emptyCrossDBLinkingStats
 
 -- | Report cross-database linking statistics

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -158,7 +158,7 @@ import qualified Search.BM25 as BM25
 import SharedSolver (SharedSolver, createSharedSolver)
 import qualified SharedSolver
 import SynonymDB (SynonymDB (..), buildFromCSV, buildFromPairs, emptySynonymDB, loadFromCSVFileWithCache, mergeSynonymDBs, synonymCount)
-import Types (Activity (..), CrossDBLink (..), CrossDBLinkingStats (..), Database (..), Flow (..), FlowDB, LinkBlocker (..), SimpleDatabase (..), SparseTriple (..), UUID, Unit (..), UnitDB, crossDBBySource, deduplicateFallbacks, exchangeFlowId, exchangeIsReference, initializeRuntimeFields, toSimpleDatabase, unresolvedCount)
+import Types (Activity (..), BioFlowDB, BiosphereFlow (..), Compartment (..), CrossDBLink (..), CrossDBLinkingStats (..), Database (..), LinkBlocker (..), SimpleDatabase (..), SparseTriple (..), TechFlowDB, TechnosphereFlow (..), UUID, Unit (..), UnitDB, crossDBBySource, deduplicateFallbacks, exchangeFlowId, exchangeIsReference, initializeRuntimeFields, toSimpleDatabase, unresolvedCount)
 import qualified UnitConversion
 
 -- CrossDBLinkingStats is now in Types, re-exported from Database.Loader
@@ -442,7 +442,7 @@ data DatabaseManager = DatabaseManager
     , dmNoCache :: !Bool -- Caching disabled flag
     , dmPlugins :: !PluginRegistry -- Plugin registry (built-in + external)
     , dmGeographies :: !(Map Text (Text, [Text])) -- code → (display_name, parent_codes)
-    , dmMethodMappingCache :: !(TVar (Map (Text, UUID) [(MethodCF, Maybe (Flow, MatchStrategy))]))
+    , dmMethodMappingCache :: !(TVar (Map (Text, UUID) [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]))
     {- ^ Cached flow mappings: (dbName, methodId) → mappings.
     Invalidated on database/method/synonym reload.
     -}
@@ -469,7 +469,7 @@ data DatabaseManager = DatabaseManager
     suggester's synonym-expansion signal. Empty when no path is configured
     or when the file is missing — suggester degrades to plain Jaccard.
     -}
-    , dmMergedFlowMetadataCache :: !(TVar (Maybe (FlowDB, UnitDB)))
+    , dmMergedFlowMetadataCache :: !(TVar (Maybe (BioFlowDB, UnitDB)))
     {- ^ Memoized 'M.unions' of every loaded DB's flows/units.
     Invalidated on any 'dmLoadedDbs' mutation; collision detection
     runs once per rebuild rather than per hot-path call.
@@ -483,7 +483,7 @@ data DatabaseManager = DatabaseManager
 {- | Cached flow mapping: avoids re-matching method CFs to database flows on every LCIA call.
 The mapping depends only on (database, method), not on the process being evaluated.
 -}
-mapMethodToFlowsCached :: DatabaseManager -> Text -> Database -> Method -> IO [(MethodCF, Maybe (Flow, MatchStrategy))]
+mapMethodToFlowsCached :: DatabaseManager -> Text -> Database -> Method -> IO [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]
 mapMethodToFlowsCached manager dbName db method = do
     let key = (dbName, methodId method)
     cache <- readTVarIO (dmMethodMappingCache manager)
@@ -838,20 +838,19 @@ loadOneDatabase synonymDB unitConfig noCache otherIndexes loadedDbsVar indexedDb
             reportProgressWithTiming Info ("  [OK] Loaded: " <> T.unpack (dcDisplayName dbConfig)) dbDuration
             -- Auto-extract synonyms from biosphere flows
             let db = ldDatabase loaded
-                bioUUIDs = S.fromList (V.toList (dbBiosphereFlows db))
-                !pairs = extractFromEcoSpold2 (dbFlows db) bioUUIDs
+                bioFlowDb = dbBioFlows db
+                !pairs = extractFromEcoSpold2 bioFlowDb
                 !bioFlowsWithSyns =
                     length
                         [ ()
-                        | f <- M.elems (dbFlows db)
-                        , S.member (flowId f) bioUUIDs
-                        , not (M.null (flowSynonyms f))
+                        | f <- M.elems bioFlowDb
+                        , not (M.null (bfSynonyms f))
                         ]
             reportProgress Info $
                 "  [EXTRACT] "
                     <> T.unpack (dcName dbConfig)
                     <> ": "
-                    <> show (S.size bioUUIDs)
+                    <> show (M.size bioFlowDb)
                     <> " bio flows, "
                     <> show bioFlowsWithSyns
                     <> " with synonyms, "
@@ -1085,7 +1084,7 @@ loadDatabaseFromConfigWithCrossDBAndTransforms transforms dbConfig synonymDB uni
             dbRebuiltResult <-
                 if null transforms
                     then pure (Right dbRaw)
-                    else buildDatabaseWithMatrices unitConfig (sdbActivities transformed) (sdbFlows transformed) (sdbUnits transformed)
+                    else buildDatabaseWithMatrices unitConfig (sdbActivities transformed) (sdbTechFlows transformed) (sdbBioFlows transformed) (sdbUnits transformed)
 
             case dbRebuiltResult of
                 Left err -> return $ Left err
@@ -1259,11 +1258,11 @@ loadDatabaseRawWithCrossDB dbName locationAliases sourcePath noCache synonymDB u
             Left err -> return $ Left err
             Right csvFile -> do
                 reportProgress Info $ "Parsing SimaPro CSV: " <> csvFile
-                (activities, flowDB, unitDB) <- SimaPro.parseSimaProCSV unitConfig csvFile
+                (activities, techFlowDB, bioFlowDB, unitDB) <- SimaPro.parseSimaProCSV unitConfig csvFile
                 reportProgress Info $ "Building database from " <> show (length activities) <> " activities"
-                let simpleDb = SimpleDatabase (buildActivityMap activities) flowDB unitDB
+                let simpleDb = SimpleDatabase (buildActivityMap activities) techFlowDB bioFlowDB unitDB
                 linkedDb <- Loader.fixSimaProActivityLinks simpleDb
-                dbResult <- buildDatabaseWithMatrices unitConfig (sdbActivities linkedDb) flowDB unitDB
+                dbResult <- buildDatabaseWithMatrices unitConfig (sdbActivities linkedDb) techFlowDB bioFlowDB unitDB
                 case dbResult of
                     Left err -> return $ Left err
                     Right db -> do
@@ -1288,7 +1287,8 @@ loadDatabaseRawWithCrossDB dbName locationAliases sourcePath noCache synonymDB u
                     buildDatabaseWithMatrices
                         unitConfig
                         (sdbActivities simpleDb)
-                        (sdbFlows simpleDb)
+                        (sdbTechFlows simpleDb)
+                        (sdbBioFlows simpleDb)
                         (sdbUnits simpleDb)
                 case dbResult of
                     Left err -> return $ Left err
@@ -1367,8 +1367,7 @@ loadDatabaseSingleFromConfig manager dbName = do
                             reportProgress Info $ "  [OK] Loaded:" <> T.unpack (dcDisplayName dbConfig)
                             -- Auto-extract synonyms from biosphere flows
                             let db = ldDatabase loaded
-                                bioUUIDs = S.fromList (V.toList (dbBiosphereFlows db))
-                                pairs = extractFromEcoSpold2 (dbFlows db) bioUUIDs
+                                pairs = extractFromEcoSpold2 (dbBioFlows db)
                             autoCreateFlowSynonyms
                                 manager
                                 dbName
@@ -1453,7 +1452,7 @@ relinkDatabase manager dbName = do
                 rawStats =
                     Loader.findAllCrossDBLinks
                         ctx
-                        (dbFlows db)
+                        (dbTechFlows db)
                         (dbUnits db)
                         activityMap
                 newStats = rawStats{cdlTotalInputs = totalInputs}
@@ -2223,7 +2222,8 @@ finalizeDatabase manager dbName = do
                                         buildDatabaseWithMatrices
                                             unitConfig
                                             (sdbActivities (sdSimpleDB staged))
-                                            (sdbFlows (sdSimpleDB staged))
+                                            (sdbTechFlows (sdSimpleDB staged))
+                                            (sdbBioFlows (sdSimpleDB staged))
                                             (sdbUnits (sdSimpleDB staged))
                                     case dbResult of
                                         Left err -> return $ Left err
@@ -2579,7 +2579,10 @@ regionalized scoring path (see 'Method.Mapping.computeRegionalizedLCIAScore').
 getLocationHierarchy :: DatabaseManager -> IO (M.Map Text [Text])
 getLocationHierarchy manager = pure (M.map snd (dmGeographies manager))
 
-getMergedFlowMetadata :: DatabaseManager -> IO (FlowDB, UnitDB)
+-- | Merged biosphere flow metadata + units across all loaded DBs. Technosphere
+-- flows are not merged here because characterization (the only consumer of
+-- this cache) targets biosphere flows exclusively.
+getMergedFlowMetadata :: DatabaseManager -> IO (BioFlowDB, UnitDB)
 getMergedFlowMetadata manager = do
     cached <- readTVarIO (dmMergedFlowMetadataCache manager)
     case cached of
@@ -2587,29 +2590,29 @@ getMergedFlowMetadata manager = do
         Nothing -> do
             loaded <- readTVarIO (dmLoadedDbs manager)
             let dbs = map ldDatabase (M.elems loaded)
-                flowMaps = map dbFlows dbs
+                bioMaps = map dbBioFlows dbs
                 unitMaps = map dbUnits dbs
-                !mergedFlows = M.unions flowMaps
+                !mergedBios = M.unions bioMaps
                 !mergedUnits = M.unions unitMaps
-                flowHits = collisions flowFingerprint flowMaps
+                bioHits = collisions bioFingerprint bioMaps
                 unitHits = collisions unitFingerprint unitMaps
-            unless (null flowHits) $
+            unless (null bioHits) $
                 reportProgress Warning $
-                    "[merged FlowDB] "
-                        <> show (length flowHits)
-                        <> " UUID collision(s) with divergent flow metadata; keeping first. Samples: "
-                        <> show (take 3 flowHits)
+                    "[merged BioFlowDB] "
+                        <> show (length bioHits)
+                        <> " UUID collision(s) with divergent biosphere flow metadata; keeping first. Samples: "
+                        <> show (take 3 bioHits)
             unless (null unitHits) $
                 reportProgress Warning $
                     "[merged UnitDB] "
                         <> show (length unitHits)
                         <> " UUID collision(s) with divergent unit metadata; keeping first. Samples: "
                         <> show (take 3 unitHits)
-            let !snap = (mergedFlows, mergedUnits)
+            let !snap = (mergedBios, mergedUnits)
             atomically $ writeTVar (dmMergedFlowMetadataCache manager) (Just snap)
             pure snap
   where
-    flowFingerprint f = (flowName f, flowCategory f, flowSubcompartment f)
+    bioFingerprint f = (bfName f, compartmentName (bfCompartment f), compartmentSub (bfCompartment f))
     unitFingerprint = unitName
 
     collisions :: (Ord fp) => (v -> fp) -> [Map UUID v] -> [UUID]

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -113,13 +113,14 @@ data ParseState = ParseState
     , psRefUnit :: !(Maybe Text)
     , psDescription :: ![Text]
     , psExchanges :: ![Exchange]
-    , psFlows :: ![Flow]
+    , psTechFlows :: ![TechnosphereFlow]
+    , psBioFlows :: ![BiosphereFlow]
     , psUnits :: ![Unit]
     , psPath :: ![BS.ByteString]
     , psContext :: !ElementContext
     , psTextAccum :: ![BS.ByteString]
     , psSupplierLinks :: !(M.Map UUID Int) -- flowId → supplier dataset number (technosphere inputs)
-    , psCompletedActivities :: ![Either String (Activity, [Flow], [Unit], Int, M.Map UUID Int)]
+    , psCompletedActivities :: ![Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [Unit], Int, M.Map UUID Int)]
     }
 
 -- | Initial parsing state
@@ -134,7 +135,8 @@ initialParseState =
         , psRefUnit = Nothing
         , psDescription = []
         , psExchanges = []
-        , psFlows = []
+        , psTechFlows = []
+        , psBioFlows = []
         , psUnits = []
         , psPath = []
         , psContext = Other
@@ -144,7 +146,7 @@ initialParseState =
         }
 
 -- | Xeno SAX parser for EcoSpold1
-parseWithXeno :: BS.ByteString -> Either String (Activity, [Flow], [Unit], Int, M.Map UUID Int)
+parseWithXeno :: BS.ByteString -> Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [Unit], Int, M.Map UUID Int)
 parseWithXeno xmlContent =
     case X.fold openTag attribute endOpen text closeTag cdata initialParseState xmlContent of
         Left err -> Left (show err)
@@ -261,15 +263,19 @@ parseWithXeno xmlContent =
         | isElement tagName "exchange" =
             case psContext state of
                 InExchange edata ->
-                    let (exchange, flow, unit) = buildExchange (psDatasetNumber state) (psLocation state) edata
+                    let (exchange, flowEither, unit) = buildExchange (psDatasetNumber state) (psLocation state) edata
                         !supplierLinks = case exchange of
-                            TechnosphereExchange{techIsInput = True}
+                            TechnosphereExchange{techRole = Input}
                                 | exNumber edata /= 0 ->
                                     M.insert (exchangeFlowId exchange) (exNumber edata) (psSupplierLinks state)
                             _ -> psSupplierLinks state
+                        (techs, bios) = case flowEither of
+                            Left tf -> (tf : psTechFlows state, psBioFlows state)
+                            Right bf -> (psTechFlows state, bf : psBioFlows state)
                      in state
                             { psExchanges = exchange : psExchanges state
-                            , psFlows = flow : psFlows state
+                            , psTechFlows = techs
+                            , psBioFlows = bios
                             , psUnits = unit : psUnits state
                             , psSupplierLinks = supplierLinks
                             , psContext = Other
@@ -297,7 +303,8 @@ parseWithXeno xmlContent =
                         , psRefUnit = Nothing
                         , psDescription = []
                         , psExchanges = []
-                        , psFlows = []
+                        , psTechFlows = []
+                        , psBioFlows = []
                         , psUnits = []
                         , psContext = Other
                         , psTextAccum = []
@@ -312,7 +319,7 @@ parseWithXeno xmlContent =
 
     -- Build exchange, flow, and unit from exchange data
     -- activityLoc is the activity's location for fallback
-    buildExchange :: Int -> Maybe Text -> ExchangeData -> (Exchange, Flow, Unit)
+    buildExchange :: Int -> Maybe Text -> ExchangeData -> (Exchange, Either TechnosphereFlow BiosphereFlow, Unit)
     buildExchange datasetNum activityLoc edata =
         let flowId = generateFlowUUID datasetNum (exNumber edata) (exName edata) (exCategory edata)
             unitId = generateUnitUUID (exUnit edata)
@@ -328,14 +335,6 @@ parseWithXeno xmlContent =
             isInput = not (T.null inputGroup)
             isReferenceProduct = outputGroup == "0"
 
-            -- Build category string
-            category =
-                if T.null (exSubCategory edata)
-                    then exCategory edata
-                    else exCategory edata <> "/" <> exSubCategory edata
-
-            flowType = if isBiosphere then Biosphere else Technosphere
-
             -- Exchange location: use exchange's own location
             -- For technosphere: leave empty if not specified, so Loader can use name-only lookup
             -- For biosphere: fall back to activity location (biosphere flows don't need supplier linking)
@@ -347,42 +346,51 @@ parseWithXeno xmlContent =
                             else "" -- Technosphere: leave empty for name-only lookup in Loader
                     else exLocation edata
 
+            cas = if T.null (exCASNumber edata) then Nothing else Just (exCASNumber edata)
+            unit = Unit unitId (exUnit edata) (exUnit edata) ""
+
+            -- Role: EcoSpold1 never emits ReferenceInput (no waste-treatment encoding here)
+            techRoleFor
+                | isReferenceProduct = ReferenceProduct
+                | isInput = Input
+                | otherwise = Coproduct
+
             -- Set activityLinkId to nil - will be resolved later in Loader using
             -- (flowName, exchangeLocation) lookup against supplier activities
-            exchange =
-                if isBiosphere
-                    then
-                        BiosphereExchange
-                            { bioFlowId = flowId
-                            , bioAmount = exMeanValue edata
-                            , bioUnitId = unitId
-                            , bioIsInput = inputGroup == "4"
-                            , bioLocation = exchangeLocation
-                            , bioComment = nonEmptyText (exComment edata)
-                            , bioPedigree = Nothing
-                            }
-                    else
-                        TechnosphereExchange
-                            { techFlowId = flowId
-                            , techAmount = exMeanValue edata
-                            , techUnitId = unitId
-                            , techIsInput = isInput
-                            , techIsReference = isReferenceProduct
-                            , techActivityLinkId = UUID.nil -- Will be resolved in Loader.fixEcoSpold1ActivityLinks
-                            , techProcessLinkId = Nothing
-                            , techLocation = exchangeLocation
-                            , techComment = nonEmptyText (exComment edata)
-                            , techPedigree = Nothing
-                            }
-
-            cas = if T.null (exCASNumber edata) then Nothing else Just (exCASNumber edata)
-            flow = Flow flowId (exName edata) category Nothing unitId flowType M.empty cas Nothing
-
-            unit = Unit unitId (exUnit edata) (exUnit edata) ""
-         in (exchange, flow, unit)
+         in if isBiosphere
+                then
+                    let subCat = if T.null (exSubCategory edata) then Nothing else Just (exSubCategory edata)
+                        compartment = Compartment (exCategory edata) subCat
+                        bioFlow = BiosphereFlow flowId (exName edata) unitId M.empty cas Nothing compartment
+                        ex =
+                            BiosphereExchange
+                                { bioFlowId = flowId
+                                , bioAmount = exMeanValue edata
+                                , bioUnitId = unitId
+                                , bioIsInput = inputGroup == "4"
+                                , bioLocation = exchangeLocation
+                                , bioComment = nonEmptyText (exComment edata)
+                                , bioPedigree = Nothing
+                                }
+                     in (ex, Right bioFlow, unit)
+                else
+                    let techFlow = TechnosphereFlow flowId (exName edata) unitId M.empty cas Nothing
+                        ex =
+                            TechnosphereExchange
+                                { techFlowId = flowId
+                                , techAmount = exMeanValue edata
+                                , techUnitId = unitId
+                                , techRole = techRoleFor
+                                , techActivityLinkId = UUID.nil
+                                , techProcessLinkId = Nothing
+                                , techLocation = exchangeLocation
+                                , techComment = nonEmptyText (exComment edata)
+                                , techPedigree = Nothing
+                                }
+                     in (ex, Left techFlow, unit)
 
     -- Build final result
-    buildResult :: ParseState -> Either String (Activity, [Flow], [Unit], Int, M.Map UUID Int)
+    buildResult :: ParseState -> Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [Unit], Int, M.Map UUID Int)
     buildResult st =
         let name = fromMaybe "Unknown Activity" (psActivityName st)
             location = fromMaybe "GLO" (psLocation st)
@@ -394,14 +402,15 @@ parseWithXeno xmlContent =
                         (not . T.null . snd)
                         [("Category", psActivityCategory st), ("SubCategory", psActivitySubCategory st)]
             activity = Activity name description M.empty classifications location refUnit (reverse $ psExchanges st) M.empty M.empty Nothing Nothing
-            flows = reverse (psFlows st)
+            techs = reverse (psTechFlows st)
+            bios = reverse (psBioFlows st)
             units = reverse (psUnits st)
          in case applyCutoffStrategy activity of
-                Right act -> Right (act, flows, units, psDatasetNumber st, psSupplierLinks st)
+                Right act -> Right (act, techs, bios, units, psDatasetNumber st, psSupplierLinks st)
                 Left err -> Left err
 
 -- | Parse EcoSpold1 file using Xeno SAX parser
-streamParseActivityAndFlowsFromFile1 :: FilePath -> IO (Either String (Activity, [Flow], [Unit], Int, M.Map UUID Int))
+streamParseActivityAndFlowsFromFile1 :: FilePath -> IO (Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [Unit], Int, M.Map UUID Int))
 streamParseActivityAndFlowsFromFile1 path = do
     !xmlContent <- BS.readFile path
     return (parseWithXeno xmlContent)
@@ -427,9 +436,10 @@ hasReferenceProduct act = any exchangeIsReference (exchanges act)
 removeZeroAmountCoproducts :: [Exchange] -> [Exchange]
 removeZeroAmountCoproducts = filter keepExchange
   where
-    keepExchange TechnosphereExchange{techIsInput = False, techIsReference = True} = True
-    keepExchange TechnosphereExchange{techIsInput = False, techIsReference = False, techAmount = amount} = amount /= 0.0
-    keepExchange TechnosphereExchange{techIsInput = True} = True
+    keepExchange TechnosphereExchange{techRole = ReferenceProduct} = True
+    keepExchange TechnosphereExchange{techRole = ReferenceInput} = True
+    keepExchange TechnosphereExchange{techRole = Input} = True
+    keepExchange TechnosphereExchange{techRole = Coproduct, techAmount = amount} = amount /= 0.0
     keepExchange BiosphereExchange{} = True
 
 -- | Assign single product as reference product
@@ -443,10 +453,12 @@ assignSingleProductAsReference act =
                  in act{exchanges = updatedExchanges}
             _ -> act
 
--- | Check if exchange is production exchange
+-- | Check if exchange is production exchange (technosphere output)
 isProductionExchange :: Exchange -> Bool
-isProductionExchange TechnosphereExchange{techIsInput = False} = True
-isProductionExchange TechnosphereExchange{techIsInput = True} = False
+isProductionExchange TechnosphereExchange{techRole = ReferenceProduct} = True
+isProductionExchange TechnosphereExchange{techRole = Coproduct} = True
+isProductionExchange TechnosphereExchange{techRole = Input} = False
+isProductionExchange TechnosphereExchange{techRole = ReferenceInput} = False
 isProductionExchange BiosphereExchange{} = False
 
 -- | Update reference product flag
@@ -455,14 +467,19 @@ updateReferenceProduct target current
     | exchangeFlowId target == exchangeFlowId current = markAsReference current
     | otherwise = unmarkAsReference current
 
--- | Mark exchange as reference product
+-- | Promote a production exchange to reference product
 markAsReference :: Exchange -> Exchange
-markAsReference ex@TechnosphereExchange{} = ex{techIsReference = True}
+markAsReference ex@TechnosphereExchange{} = ex{techRole = ReferenceProduct}
 markAsReference ex@BiosphereExchange{} = ex
 
--- | Unmark exchange as reference product
+-- | Demote a reference role back to non-reference (preserving input/output direction)
 unmarkAsReference :: Exchange -> Exchange
-unmarkAsReference ex@TechnosphereExchange{} = ex{techIsReference = False}
+unmarkAsReference ex@TechnosphereExchange{techRole = role} = ex{techRole = demote role}
+  where
+    demote ReferenceProduct = Coproduct
+    demote ReferenceInput = Input
+    demote Coproduct = Coproduct
+    demote Input = Input
 unmarkAsReference ex@BiosphereExchange{} = ex
 
 -- ============================================================================
@@ -473,7 +490,7 @@ unmarkAsReference ex@BiosphereExchange{} = ex
 Returns the accumulated completed activities from psCompletedActivities
 Outer Either = XML parse failure; inner Either = per-activity failure
 -}
-parseAllWithXeno :: BS.ByteString -> Either String [Either String (Activity, [Flow], [Unit], Int, M.Map UUID Int)]
+parseAllWithXeno :: BS.ByteString -> Either String [Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [Unit], Int, M.Map UUID Int)]
 parseAllWithXeno xmlContent =
     case X.fold openTag attribute endOpen text closeTag cdata initialParseState xmlContent of
         Left err -> Left (show err)
@@ -585,15 +602,19 @@ parseAllWithXeno xmlContent =
         | isElement tagName "exchange" =
             case psContext state of
                 InExchange edata ->
-                    let (exchange, flow, unit) = buildExchangeForAll (psDatasetNumber state) (psLocation state) edata
+                    let (exchange, flowEither, unit) = buildExchangeForAll (psDatasetNumber state) (psLocation state) edata
                         !supplierLinks = case exchange of
-                            TechnosphereExchange{techIsInput = True}
+                            TechnosphereExchange{techRole = Input}
                                 | exNumber edata /= 0 ->
                                     M.insert (exchangeFlowId exchange) (exNumber edata) (psSupplierLinks state)
                             _ -> psSupplierLinks state
+                        (techs, bios) = case flowEither of
+                            Left tf -> (tf : psTechFlows state, psBioFlows state)
+                            Right bf -> (psTechFlows state, bf : psBioFlows state)
                      in state
                             { psExchanges = exchange : psExchanges state
-                            , psFlows = flow : psFlows state
+                            , psTechFlows = techs
+                            , psBioFlows = bios
                             , psUnits = unit : psUnits state
                             , psSupplierLinks = supplierLinks
                             , psContext = Other
@@ -619,7 +640,8 @@ parseAllWithXeno xmlContent =
                         , psRefUnit = Nothing
                         , psDescription = []
                         , psExchanges = []
-                        , psFlows = []
+                        , psTechFlows = []
+                        , psBioFlows = []
                         , psUnits = []
                         , psContext = Other
                         , psTextAccum = []
@@ -633,7 +655,7 @@ parseAllWithXeno xmlContent =
     cdata = text
 
     -- Build exchange, flow, and unit from exchange data (same logic as parseWithXeno)
-    buildExchangeForAll :: Int -> Maybe Text -> ExchangeData -> (Exchange, Flow, Unit)
+    buildExchangeForAll :: Int -> Maybe Text -> ExchangeData -> (Exchange, Either TechnosphereFlow BiosphereFlow, Unit)
     buildExchangeForAll datasetNum activityLoc edata =
         let flowId = generateFlowUUID datasetNum (exNumber edata) (exName edata) (exCategory edata)
             unitId = generateUnitUUID (exUnit edata)
@@ -642,11 +664,6 @@ parseAllWithXeno xmlContent =
             isBiosphere = inputGroup == "4" || outputGroup == "4"
             isInput = not (T.null inputGroup)
             isReferenceProduct = outputGroup == "0"
-            category =
-                if T.null (exSubCategory edata)
-                    then exCategory edata
-                    else exCategory edata <> "/" <> exSubCategory edata
-            flowType = if isBiosphere then Biosphere else Technosphere
             exchangeLocation =
                 if T.null (exLocation edata)
                     then
@@ -654,38 +671,46 @@ parseAllWithXeno xmlContent =
                             then fromMaybe "" activityLoc
                             else ""
                     else exLocation edata
-            exchange =
-                if isBiosphere
-                    then
-                        BiosphereExchange
-                            { bioFlowId = flowId
-                            , bioAmount = exMeanValue edata
-                            , bioUnitId = unitId
-                            , bioIsInput = inputGroup == "4"
-                            , bioLocation = exchangeLocation
-                            , bioComment = nonEmptyText (exComment edata)
-                            , bioPedigree = Nothing
-                            }
-                    else
-                        TechnosphereExchange
-                            { techFlowId = flowId
-                            , techAmount = exMeanValue edata
-                            , techUnitId = unitId
-                            , techIsInput = isInput
-                            , techIsReference = isReferenceProduct
-                            , techActivityLinkId = UUID.nil
-                            , techProcessLinkId = Nothing
-                            , techLocation = exchangeLocation
-                            , techComment = nonEmptyText (exComment edata)
-                            , techPedigree = Nothing
-                            }
             cas = if T.null (exCASNumber edata) then Nothing else Just (exCASNumber edata)
-            flow = Flow flowId (exName edata) category Nothing unitId flowType M.empty cas Nothing
             unit = Unit unitId (exUnit edata) (exUnit edata) ""
-         in (exchange, flow, unit)
+            techRoleFor
+                | isReferenceProduct = ReferenceProduct
+                | isInput = Input
+                | otherwise = Coproduct
+         in if isBiosphere
+                then
+                    let subCat = if T.null (exSubCategory edata) then Nothing else Just (exSubCategory edata)
+                        compartment = Compartment (exCategory edata) subCat
+                        bioFlow = BiosphereFlow flowId (exName edata) unitId M.empty cas Nothing compartment
+                        ex =
+                            BiosphereExchange
+                                { bioFlowId = flowId
+                                , bioAmount = exMeanValue edata
+                                , bioUnitId = unitId
+                                , bioIsInput = inputGroup == "4"
+                                , bioLocation = exchangeLocation
+                                , bioComment = nonEmptyText (exComment edata)
+                                , bioPedigree = Nothing
+                                }
+                     in (ex, Right bioFlow, unit)
+                else
+                    let techFlow = TechnosphereFlow flowId (exName edata) unitId M.empty cas Nothing
+                        ex =
+                            TechnosphereExchange
+                                { techFlowId = flowId
+                                , techAmount = exMeanValue edata
+                                , techUnitId = unitId
+                                , techRole = techRoleFor
+                                , techActivityLinkId = UUID.nil
+                                , techProcessLinkId = Nothing
+                                , techLocation = exchangeLocation
+                                , techComment = nonEmptyText (exComment edata)
+                                , techPedigree = Nothing
+                                }
+                     in (ex, Left techFlow, unit)
 
     -- Build final result for a single dataset
-    buildResultForAll :: ParseState -> Either String (Activity, [Flow], [Unit], Int, M.Map UUID Int)
+    buildResultForAll :: ParseState -> Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [Unit], Int, M.Map UUID Int)
     buildResultForAll st =
         let name = fromMaybe "Unknown Activity" (psActivityName st)
             location = fromMaybe "GLO" (psLocation st)
@@ -697,17 +722,18 @@ parseAllWithXeno xmlContent =
                         (not . T.null . snd)
                         [("Category", psActivityCategory st), ("SubCategory", psActivitySubCategory st)]
             activity = Activity name description M.empty classifications location refUnit (reverse $ psExchanges st) M.empty M.empty Nothing Nothing
-            flows = reverse (psFlows st)
+            techs = reverse (psTechFlows st)
+            bios = reverse (psBioFlows st)
             units = reverse (psUnits st)
          in case applyCutoffStrategy activity of
-                Right act -> Right (act, flows, units, psDatasetNumber st, psSupplierLinks st)
+                Right act -> Right (act, techs, bios, units, psDatasetNumber st, psSupplierLinks st)
                 Left err -> Left err
 
 {- | Parse ALL datasets from a single EcoSpold1 file
 Used for multi-dataset files where <ecoSpold> contains multiple <dataset> elements
 Skips activities that fail (e.g. no reference product) and logs warnings
 -}
-streamParseAllDatasetsFromFile1 :: FilePath -> IO [(Activity, [Flow], [Unit], Int, M.Map UUID Int)]
+streamParseAllDatasetsFromFile1 :: FilePath -> IO [(Activity, [TechnosphereFlow], [BiosphereFlow], [Unit], Int, M.Map UUID Int)]
 streamParseAllDatasetsFromFile1 path = do
     !xmlContent <- BS.readFile path
     case parseAllWithXeno xmlContent of

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -359,9 +359,12 @@ parseWithXeno xmlContent processId =
                     -- Use pending group values if attribute values are empty
                     let finalInputGroup = if T.null (edInputGroup edata) then psPendingInputGroup state else edInputGroup edata
                         finalOutputGroup = if T.null (edOutputGroup edata) then psPendingOutputGroup state else edOutputGroup edata
+                        -- Empty compartment when missing: same sentinel as ILCD so
+                        -- the LCIA cascade keys converge on identical lookups
+                        -- regardless of source format.
                         compName = case edCompartments edata of
                             (c : _) -> c
-                            [] -> "unspecified"
+                            [] -> ""
                         subCompartment = case edSubcompartments edata of
                             (s : _) | not (T.null s) -> Just s
                             _ -> Nothing

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -132,7 +132,8 @@ data ParseState = ParseState
     , psRefUnit :: !(Maybe Text)
     , psDescription :: ![Text]
     , psExchanges :: ![Exchange]
-    , psFlows :: ![Flow]
+    , psTechFlows :: ![TechnosphereFlow]
+    , psBioFlows :: ![BiosphereFlow]
     , psUnits :: ![Unit]
     , psPath :: ![BS.ByteString] -- Element path stack
     , psContext :: !ElementContext
@@ -154,7 +155,8 @@ initialParseState =
         , psRefUnit = Nothing
         , psDescription = []
         , psExchanges = []
-        , psFlows = []
+        , psTechFlows = []
+        , psBioFlows = []
         , psUnits = []
         , psPath = []
         , psContext = Other
@@ -168,7 +170,7 @@ initialParseState =
         }
 
 -- | Xeno SAX parser implementation
-parseWithXeno :: BS.ByteString -> ProcessId -> Either String ((Activity, [Flow], [Unit]), [String])
+parseWithXeno :: BS.ByteString -> ProcessId -> Either String ((Activity, [TechnosphereFlow], [BiosphereFlow], [Unit]), [String])
 parseWithXeno xmlContent processId =
     case X.fold openTag attribute endOpen text closeTag cdata initialParseState xmlContent of
         Left err -> Left (show err)
@@ -297,13 +299,16 @@ parseWithXeno xmlContent processId =
                                 then (UUID.nil, Nothing)
                                 else parseUUID (idActivityLinkId idata)
                         uuidWarnings = catMaybes [flowWarn, unitWarn, linkWarn]
+                        techRoleFor
+                            | isReferenceProduct = ReferenceProduct
+                            | isInput = Input
+                            | otherwise = Coproduct
                         exchange =
                             TechnosphereExchange
                                 { techFlowId = flowUUID
                                 , techAmount = idAmount idata
                                 , techUnitId = unitUUID
-                                , techIsInput = isInput
-                                , techIsReference = isReferenceProduct
+                                , techRole = techRoleFor
                                 , techActivityLinkId = linkUUID
                                 , techProcessLinkId = Nothing
                                 , techLocation = "" -- EcoSpold2: no per-exchange location
@@ -311,13 +316,10 @@ parseWithXeno xmlContent processId =
                                 , techPedigree = Nothing
                                 }
                         flow =
-                            Flow
+                            TechnosphereFlow
                                 flowUUID
                                 (if T.null (idFlowName idata) then idFlowId idata else idFlowName idata)
-                                "technosphere"
-                                Nothing -- subcompartment
                                 unitUUID
-                                Technosphere
                                 (idSynonyms idata)
                                 Nothing -- CAS
                                 Nothing -- substanceId
@@ -340,7 +342,7 @@ parseWithXeno xmlContent processId =
                                 else psRefUnit state
                      in state
                             { psExchanges = exchange : psExchanges state
-                            , psFlows = flow : psFlows state
+                            , psTechFlows = flow : psTechFlows state
                             , psUnits = unit : psUnits state
                             , psContext = Other
                             , psPath = drop 1 (psPath state)
@@ -357,17 +359,16 @@ parseWithXeno xmlContent processId =
                     -- Use pending group values if attribute values are empty
                     let finalInputGroup = if T.null (edInputGroup edata) then psPendingInputGroup state else edInputGroup edata
                         finalOutputGroup = if T.null (edOutputGroup edata) then psPendingOutputGroup state else edOutputGroup edata
-                        category = case (edCompartments edata, edSubcompartments edata) of
-                            ([], []) -> "unspecified"
-                            (comp : _, []) -> comp
-                            ([], sub : _) -> sub
-                            (comp : _, sub : _) -> comp <> "/" <> sub
+                        compName = case edCompartments edata of
+                            (c : _) -> c
+                            [] -> "unspecified"
+                        subCompartment = case edSubcompartments edata of
+                            (s : _) | not (T.null s) -> Just s
+                            _ -> Nothing
+                        compartment = Compartment compName subCompartment
                         -- Determine if exchange is input (resource extraction)
                         -- Primary: use inputGroup/outputGroup if present
                         -- Fallback: use compartment heuristic (natural resource = input, others = output)
-                        -- Determine input/output:
-                        -- explicit inputGroup wins, then explicit outputGroup, else
-                        -- compartment-based heuristic (natural resource = input).
                         isInput
                             | not (T.null finalInputGroup) = True
                             | not (T.null finalOutputGroup) = False
@@ -388,21 +389,15 @@ parseWithXeno xmlContent processId =
                                 , bioComment = snd <$> edComment edata
                                 , bioPedigree = Nothing
                                 }
-                        -- Get subcompartment from the list (first entry if any)
-                        subcompartment = case edSubcompartments edata of
-                            (s : _) | not (T.null s) -> Just s
-                            _ -> Nothing
                         flow =
-                            Flow
+                            BiosphereFlow
                                 flowUUID
                                 (if T.null (edFlowName edata) then edFlowId edata else edFlowName edata)
-                                category
-                                subcompartment
                                 unitUUID
-                                Biosphere
                                 (edSynonyms edata)
                                 (edCAS edata)
                                 Nothing -- substanceId - to be filled later
+                                compartment
                         unitNameWarning =
                             [ "[WARNING] Missing unit name for elementary exchange with flow ID: "
                                 ++ T.unpack (edFlowId edata)
@@ -417,7 +412,7 @@ parseWithXeno xmlContent processId =
                                 ""
                      in state
                             { psExchanges = exchange : psExchanges state
-                            , psFlows = flow : psFlows state
+                            , psBioFlows = flow : psBioFlows state
                             , psUnits = unit : psUnits state
                             , psContext = Other
                             , psPath = drop 1 (psPath state)
@@ -519,7 +514,7 @@ parseWithXeno xmlContent processId =
     cdata = text
 
     -- Build final result from parse state
-    buildResult :: ParseState -> ProcessId -> Either String (Activity, [Flow], [Unit])
+    buildResult :: ParseState -> ProcessId -> Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [Unit])
     buildResult st _pid =
         let name = fromMaybe "Unknown Activity" (psActivityName st)
             location = fromMaybe "GLO" (psLocation st)
@@ -527,14 +522,15 @@ parseWithXeno xmlContent processId =
             refUnit = fromMaybe "UNKNOWN_UNIT" (psRefUnit st)
             -- Apply cutoff strategy to exchanges
             activity = Activity name description M.empty (psClassifications st) location refUnit (reverse $ psExchanges st) M.empty M.empty Nothing Nothing
-            flows = reverse (psFlows st)
+            techs = reverse (psTechFlows st)
+            bios = reverse (psBioFlows st)
             units = reverse (psUnits st)
          in case applyCutoffStrategy activity of
-                Right act -> Right (act, flows, units)
+                Right act -> Right (act, techs, bios, units)
                 Left err -> Left err
 
 -- | Parse EcoSpold file using Xeno SAX parser
-streamParseActivityAndFlowsFromFile :: FilePath -> IO (Either String (Activity, [Flow], [Unit]))
+streamParseActivityAndFlowsFromFile :: FilePath -> IO (Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [Unit]))
 streamParseActivityAndFlowsFromFile path = do
     !xmlContent <- BS.readFile path
     let filenameBase = T.pack $ takeBaseName path
@@ -572,9 +568,10 @@ hasReferenceProduct activity = any exchangeIsReference (exchanges activity)
 removeZeroAmountCoproducts :: [Exchange] -> [Exchange]
 removeZeroAmountCoproducts = filter keepExchange
   where
-    keepExchange TechnosphereExchange{techIsInput = False, techIsReference = True} = True
-    keepExchange TechnosphereExchange{techIsInput = False, techIsReference = False, techAmount = amount} = amount /= 0.0
-    keepExchange TechnosphereExchange{techIsInput = True} = True
+    keepExchange TechnosphereExchange{techRole = ReferenceProduct} = True
+    keepExchange TechnosphereExchange{techRole = ReferenceInput} = True
+    keepExchange TechnosphereExchange{techRole = Input} = True
+    keepExchange TechnosphereExchange{techRole = Coproduct, techAmount = amount} = amount /= 0.0
     keepExchange BiosphereExchange{} = True
 
 -- | Assign single product as reference product
@@ -590,10 +587,12 @@ assignSingleProductAsReference activity =
             [] -> activity -- No production exchanges, leave as-is
             _ -> activity -- Multiple production exchanges, leave as-is (shouldn't happen after cutoff)
 
--- | Check if exchange is production exchange (output, non-reference)
+-- | Check if exchange is production exchange (technosphere output)
 isProductionExchange :: Exchange -> Bool
-isProductionExchange TechnosphereExchange{techIsInput = False} = True -- Output technosphere = production
-isProductionExchange TechnosphereExchange{techIsInput = True} = False
+isProductionExchange TechnosphereExchange{techRole = ReferenceProduct} = True
+isProductionExchange TechnosphereExchange{techRole = Coproduct} = True
+isProductionExchange TechnosphereExchange{techRole = Input} = False
+isProductionExchange TechnosphereExchange{techRole = ReferenceInput} = False
 isProductionExchange BiosphereExchange{} = False
 
 -- | Update reference product flag for the specified exchange
@@ -602,12 +601,17 @@ updateReferenceProduct target current
     | exchangeFlowId target == exchangeFlowId current = markAsReference current
     | otherwise = unmarkAsReference current
 
--- | Mark exchange as reference product
+-- | Promote a production exchange to reference product
 markAsReference :: Exchange -> Exchange
-markAsReference ex@TechnosphereExchange{} = ex{techIsReference = True}
-markAsReference ex@BiosphereExchange{} = ex -- Biosphere exchanges have no reference flag
+markAsReference ex@TechnosphereExchange{} = ex{techRole = ReferenceProduct}
+markAsReference ex@BiosphereExchange{} = ex
 
--- | Unmark exchange as reference product
+-- | Demote a reference role back to non-reference (preserving input/output direction)
 unmarkAsReference :: Exchange -> Exchange
-unmarkAsReference ex@TechnosphereExchange{} = ex{techIsReference = False}
+unmarkAsReference ex@TechnosphereExchange{techRole = role} = ex{techRole = demote role}
+  where
+    demote ReferenceProduct = Coproduct
+    demote ReferenceInput = Input
+    demote Coproduct = Coproduct
+    demote Input = Input
 unmarkAsReference ex@BiosphereExchange{} = ex

--- a/src/ILCD/Parser.hs
+++ b/src/ILCD/Parser.hs
@@ -15,11 +15,13 @@ module ILCD.Parser (
     fixActivityExchanges,
 ) where
 
+import Control.Applicative ((<|>))
 import Control.Concurrent (getNumCapabilities)
 import Control.Concurrent.Async (mapConcurrently)
 import qualified Data.ByteString as BS
 import Data.Char (toLower)
 import qualified Data.Map.Strict as M
+import qualified Data.Maybe
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Read as TR
@@ -31,7 +33,7 @@ import qualified Xeno.SAX as X
 
 import EcoSpold.Common (bsToText, distributeFiles, isElement)
 import Method.FlowResolver (ILCDFlowInfo (..), parseFlowDirectory)
-import Method.Types (Compartment (..))
+import qualified Method.Types as MT
 import Progress (ProgressLevel (..), reportProgress)
 import Types
 
@@ -84,8 +86,8 @@ parseILCDDirectory dir = do
     flowInfoMap <- parseFlowDirectory (dir </> "flows")
     reportProgress Info $ printf "Parsed %d flows" (M.size flowInfoMap)
 
-    -- Step 3: Build FlowDB and UnitDB from parsed data
-    let (flowDB, unitDB) = buildFlowAndUnitDB flowInfoMap flowPropMap unitGroupMap
+    -- Step 3: Build TechFlowDB, BioFlowDB and UnitDB from parsed data
+    let (techFlowDB, bioFlowDB, unitDB) = buildFlowAndUnitDB flowInfoMap flowPropMap unitGroupMap
 
     -- Step 4: Parse process XMLs in parallel
     processFiles <- listXMLFiles (dir </> "processes")
@@ -95,16 +97,17 @@ parseILCDDirectory dir = do
     reportProgress Info $ printf "Parsed %d processes, building activity map..." (length rawProcesses)
 
     -- Step 5: Build ActivityMap
-    let activityMap = buildActivityMap flowInfoMap flowDB unitDB rawProcesses
+    let activityMap = buildActivityMap flowInfoMap techFlowDB bioFlowDB unitDB rawProcesses
 
     -- Step 6: Fix supplier links (name-based, like SimaPro)
-    let simpleDb = SimpleDatabase activityMap flowDB unitDB
+    let simpleDb = SimpleDatabase activityMap techFlowDB bioFlowDB unitDB
     fixedDb <- fixILCDActivityLinks simpleDb
     reportProgress Info $
         printf
-            "ILCD database loaded: %d activities, %d flows, %d units"
+            "ILCD database loaded: %d activities, %d tech flows, %d bio flows, %d units"
             (M.size $ sdbActivities fixedDb)
-            (M.size $ sdbFlows fixedDb)
+            (M.size $ sdbTechFlows fixedDb)
+            (M.size $ sdbBioFlows fixedDb)
             (M.size $ sdbUnits fixedDb)
     return $ Right fixedDb
 
@@ -235,10 +238,14 @@ buildFlowAndUnitDB ::
     M.Map UUID ILCDFlowInfo ->
     M.Map UUID UUID -> -- flowProperty UUID → unitGroup UUID
     M.Map UUID (Text, Int) -> -- unitGroup UUID → (refUnitName, refIdx)
-    (FlowDB, UnitDB)
-buildFlowAndUnitDB flowInfoMap fpMap ugMap = (flows, allUnits)
+    (TechFlowDB, BioFlowDB, UnitDB)
+buildFlowAndUnitDB flowInfoMap fpMap ugMap = (techFlows, bioFlows, allUnits)
   where
-    flows = M.mapWithKey mkFlow flowInfoMap
+    -- Partition flows by type at construction time
+    techFlows = M.fromList [(uuid, mkTechFlow uuid info) | (uuid, info) <- M.toList flowInfoMap, not (isElementary info)]
+    bioFlows = M.fromList [(uuid, mkBioFlow uuid info) | (uuid, info) <- M.toList flowInfoMap, isElementary info]
+
+    isElementary info = ilcdFlowType info == "Elementary flow"
 
     -- Collect all unique units (keyed by unitGroup UUID)
     allUnits =
@@ -247,24 +254,33 @@ buildFlowAndUnitDB flowInfoMap fpMap ugMap = (flows, allUnits)
             | (ugId, (uName, _)) <- M.toList ugMap
             ]
 
-    mkFlow uuid info =
-        let ftype = if ilcdFlowType info == "Elementary flow" then Biosphere else Technosphere
-         in Flow
-                { flowId = uuid
-                , flowName = ilcdBaseName info
-                , flowCategory = maybe "" (\(Compartment m _ _) -> m) (ilcdCompartment info)
-                , flowSubcompartment =
-                    ilcdCompartment info >>= \(Compartment _ sc _) ->
-                        if T.null sc then Nothing else Just sc
-                , flowUnitId = resolveUnit info
-                , flowType = ftype
-                , flowSynonyms = M.empty
-                , flowCAS = ilcdCAS info
-                , flowSubstanceId = Nothing
-                }
+    mkTechFlow uuid info =
+        TechnosphereFlow
+            { tfId = uuid
+            , tfName = ilcdBaseName info
+            , tfUnitId = resolveUnit info
+            , tfSynonyms = M.empty
+            , tfCAS = ilcdCAS info
+            , tfSubstanceId = Nothing
+            }
+
+    mkBioFlow uuid info =
+        BiosphereFlow
+            { bfId = uuid
+            , bfName = ilcdBaseName info
+            , bfUnitId = resolveUnit info
+            , bfSynonyms = M.empty
+            , bfCAS = ilcdCAS info
+            , bfSubstanceId = Nothing
+            , bfCompartment = toCompartment (ilcdCompartment info)
+            }
+
+    toCompartment Nothing = Compartment "" Nothing
+    toCompartment (Just (MT.Compartment m sc _)) =
+        Compartment m (if T.null sc then Nothing else Just sc)
 
     resolveUnit info =
-        maybe UUID.nil id $
+        Data.Maybe.fromMaybe UUID.nil $
             ilcdFlowPropertyRef info >>= (`M.lookup` fpMap) >>= \ugId ->
                 ugId <$ M.lookup ugId ugMap -- use unitGroup UUID as unit key
 
@@ -471,17 +487,18 @@ parseProcessFilesParallel files = do
 
 buildActivityMap ::
     M.Map UUID ILCDFlowInfo ->
-    FlowDB ->
+    TechFlowDB ->
+    BioFlowDB ->
     UnitDB ->
     [ILCDProcessRaw] ->
     ActivityMap
-buildActivityMap flowInfoMap flowDB unitDB procs =
+buildActivityMap flowInfoMap techFlowDB bioFlowDB unitDB procs =
     M.fromList
         [ ((iprUUID p, refFlowUUID), activity)
         | p <- procs
         , let refEx = findRefExchange p
         , let refFlowUUID = maybe (iprUUID p) ierFlowRef refEx
-        , let activity = buildActivity flowInfoMap flowDB unitDB p
+        , let activity = buildActivity flowInfoMap techFlowDB bioFlowDB unitDB p
         ]
 
 findRefExchange :: ILCDProcessRaw -> Maybe ILCDExchangeRaw
@@ -490,8 +507,8 @@ findRefExchange p =
         (e : _) -> Just e
         [] -> Nothing
 
-buildActivity :: M.Map UUID ILCDFlowInfo -> FlowDB -> UnitDB -> ILCDProcessRaw -> Activity
-buildActivity flowInfoMap flowDB unitDB p =
+buildActivity :: M.Map UUID ILCDFlowInfo -> TechFlowDB -> BioFlowDB -> UnitDB -> ILCDProcessRaw -> Activity
+buildActivity flowInfoMap techFlowDB bioFlowDB unitDB p =
     Activity
         { activityName = iprName p
         , activityDescription = []
@@ -506,13 +523,18 @@ buildActivity flowInfoMap flowDB unitDB p =
         , activityAllocationFormula = Nothing
         }
   where
+    -- Look up the reference exchange's flow unit. Reference exchange is typically
+    -- a technosphere product, but for waste-treatment processes it may be a
+    -- biosphere input — try both maps before falling back to "kg".
     refUnit = case findRefExchange p of
-        Just re -> case M.lookup (ierFlowRef re) flowDB of
-            Just flow -> case M.lookup (flowUnitId flow) unitDB of
-                Just u -> unitName u
-                Nothing -> "kg"
-            Nothing -> "kg"
         Nothing -> "kg"
+        Just re ->
+            let fid = ierFlowRef re
+                uId =
+                    Data.Maybe.fromMaybe UUID.nil $
+                        (tfUnitId <$> M.lookup fid techFlowDB)
+                            <|> (bfUnitId <$> M.lookup fid bioFlowDB)
+             in maybe "kg" unitName (M.lookup uId unitDB)
 
     mkExchange refIdx raw =
         let flowUUID = ierFlowRef raw
@@ -523,7 +545,15 @@ buildActivity flowInfoMap flowDB unitDB p =
                     False
                     (\fi -> ilcdFlowType fi == "Elementary flow")
                     (M.lookup flowUUID flowInfoMap)
-            fUnitId = maybe UUID.nil flowUnitId (M.lookup flowUUID flowDB)
+            fUnitId =
+                Data.Maybe.fromMaybe UUID.nil $
+                    (tfUnitId <$> M.lookup flowUUID techFlowDB)
+                        <|> (bfUnitId <$> M.lookup flowUUID bioFlowDB)
+            techRoleFor
+                | isRef && isInput = ReferenceInput
+                | isRef = ReferenceProduct
+                | isInput = Input
+                | otherwise = Coproduct
          in if isElementary
                 then
                     BiosphereExchange
@@ -540,8 +570,7 @@ buildActivity flowInfoMap flowDB unitDB p =
                         { techFlowId = flowUUID
                         , techAmount = ierAmount raw
                         , techUnitId = fUnitId
-                        , techIsInput = isInput
-                        , techIsReference = isRef
+                        , techRole = techRoleFor
                         , techActivityLinkId = UUID.nil
                         , techProcessLinkId = Nothing
                         , techLocation = ierLocation raw
@@ -578,14 +607,15 @@ fixActivityExchanges :: SupplierIndex -> Activity -> Activity
 fixActivityExchanges idx act =
     act{exchanges = map fixEx (exchanges act)}
   where
-    fixEx ex@TechnosphereExchange{techFlowId = fid, techIsInput = True} =
-        case M.lookup fid idx of
-            Just (actUUID, prodUUID) ->
-                ex
-                    { techFlowId = prodUUID
-                    , techIsReference = False
-                    , techActivityLinkId = actUUID
-                    }
-            Nothing -> ex
-    fixEx ex@TechnosphereExchange{techIsInput = False} = ex
+    fixEx ex@TechnosphereExchange{techFlowId = fid, techRole = role}
+        | role == Input || role == ReferenceInput =
+            case M.lookup fid idx of
+                Just (actUUID, prodUUID) ->
+                    ex
+                        { techFlowId = prodUUID
+                        , techRole = Input
+                        , techActivityLinkId = actUUID
+                        }
+                Nothing -> ex
+        | otherwise = ex
     fixEx ex@BiosphereExchange{} = ex

--- a/src/Matrix.hs
+++ b/src/Matrix.hs
@@ -523,7 +523,7 @@ applyBiosphereMatrix :: Database -> Vector -> Inventory
 applyBiosphereMatrix db supplyVec =
     let bioFlowCount = fromIntegral (dbBiosphereCount db) :: Int
         bioTriples = dbBiosphereTriples db
-        bioFlows = dbBiosphereFlows db
+        bioFlows = dbBiosphereOrder db
         supplyLen = U.length supplyVec
         inventoryVec = U.create $ do
             mv <- MU.replicate bioFlowCount 0.0
@@ -562,7 +562,7 @@ computeProcessLCIAContributions ::
 computeProcessLCIAContributions db scalingVec cfMap =
     let actIdx = dbActivityIndex db
         bioTriples = dbBiosphereTriples db
-        bioFlows = dbBiosphereFlows db
+        bioFlows = dbBiosphereOrder db
         -- Build inverse map: matrix column index → ProcessId
         colToProcess :: M.Map Int ProcessId
         colToProcess =

--- a/src/Matrix/Export.hs
+++ b/src/Matrix/Export.hs
@@ -37,7 +37,7 @@ emptyCsvUncertainty = ";;;;;"
 -- | Matrix debug information container
 data MatrixDebugInfo = MatrixDebugInfo
     { mdActivities :: ActivityDB
-    , mdFlows :: M.Map UUID Flow
+    , mdBioFlows :: BioFlowDB -- B-matrix rows are biosphere flows
     , mdTechTriples :: U.Vector SparseTriple
     , mdBioTriples :: U.Vector SparseTriple
     , mdActivityIndex :: V.Vector Int32
@@ -54,11 +54,11 @@ data MatrixDebugInfo = MatrixDebugInfo
 extractMatrixDebugInfo :: Database -> UUID -> Maybe Text -> IO MatrixDebugInfo
 extractMatrixDebugInfo database targetUUID flowFilter = do
     let activities = dbActivities database
-        flows = dbFlows database
+        bioFlows = dbBioFlows database
         techTriples = dbTechnosphereTriples database
         bioTriples = dbBiosphereTriples database
         activityIndexVec = dbActivityIndex database
-        bioFlowUUIDs = dbBiosphereFlows database
+        bioFlowUUIDs = dbBiosphereOrder database
         activityCount = dbActivityCount database
         bioFlowCount = dbBiosphereCount database
 
@@ -83,14 +83,17 @@ extractMatrixDebugInfo database targetUUID flowFilter = do
             Nothing -> bioTriples
             Just filterText ->
                 let matchingFlowIndices =
-                        [ idx | (uuid, idx) <- zip (V.toList bioFlowUUIDs) ([0 ..] :: [Int]), Just flow <- [M.lookup uuid flows], T.toLower filterText `T.isInfixOf` T.toLower (flowName flow)
+                        [ idx
+                        | (uuid, idx) <- zip (V.toList bioFlowUUIDs) ([0 ..] :: [Int])
+                        , Just flow <- [M.lookup uuid bioFlows]
+                        , T.toLower filterText `T.isInfixOf` T.toLower (bfName flow)
                         ]
                     matchingFlowIndicesInt32 = map fromIntegral matchingFlowIndices :: [Int32]
                  in U.filter (\(SparseTriple row _ _) -> row `elem` matchingFlowIndicesInt32) bioTriples
     return
         MatrixDebugInfo
             { mdActivities = activities
-            , mdFlows = flows
+            , mdBioFlows = bioFlows
             , mdTechTriples = techTriples
             , mdBioTriples = filteredBioTriples
             , mdActivityIndex = activityIndexVec
@@ -147,7 +150,7 @@ exportSupplyChainData filePath debugInfo = do
 exportBiosphereMatrixData :: FilePath -> MatrixDebugInfo -> IO ()
 exportBiosphereMatrixData filePath debugInfo = do
     let database = mdDatabase debugInfo
-        flows = mdFlows debugInfo
+        flows = mdBioFlows debugInfo
         activities = mdActivities debugInfo
         bioTriples = mdBioTriples debugInfo
         bioFlowUUIDs = mdBioFlowUUIDs debugInfo
@@ -164,7 +167,7 @@ exportBiosphereMatrixData filePath debugInfo = do
             let rowInt = fromIntegral row :: Int
                 colInt = fromIntegral col :: Int
              in [ maybe "unknown" show (getFlowUUID rowInt)
-                , maybe "unknown" (T.unpack . flowName) (getFlow rowInt)
+                , maybe "unknown" (T.unpack . bfName) (getFlow rowInt)
                 , maybe "unknown" T.unpack (getFlowUnit rowInt)
                 , maybe "unknown" (T.unpack . processIdToText database) (getActivityProcessId colInt)
                 , maybe "unknown" (T.unpack . activityName) (lookupActivity colInt)
@@ -177,10 +180,10 @@ exportBiosphereMatrixData filePath debugInfo = do
                 if rowIdx < V.length bioFlowUUIDs
                     then Just (bioFlowUUIDs V.! rowIdx)
                     else Nothing
-            getFlow :: Int -> Maybe Flow
+            getFlow :: Int -> Maybe BiosphereFlow
             getFlow rowIdx = getFlowUUID rowIdx >>= flip M.lookup flows
             getFlowUnit :: Int -> Maybe Text
-            getFlowUnit rowIdx = fmap (getUnitNameForFlow (dbUnits database)) (getFlow rowIdx)
+            getFlowUnit rowIdx = fmap (getUnitNameForBioFlow (dbUnits database)) (getFlow rowIdx)
             getActivityProcessId :: Int -> Maybe ProcessId
             getActivityProcessId colIdx =
                 L.find
@@ -227,7 +230,7 @@ exportIEIndex :: FilePath -> Database -> IO ()
 exportIEIndex filePath db = do
     let activities = dbActivities db
         processIdTable = dbProcessIdTable db
-        flows = dbFlows db
+        techFlows = dbTechFlows db
 
         rows =
             V.toList $
@@ -235,8 +238,8 @@ exportIEIndex filePath db = do
                     ( \idx (_actUuid, prodUuid) ->
                         let activity = activities V.! idx
                             refProduct = case [ex | ex <- exchanges activity, exchangeIsReference ex] of
-                                (ex : _) -> case M.lookup (exchangeFlowId ex) flows of
-                                    Just flow -> flowName flow
+                                (ex : _) -> case M.lookup (exchangeFlowId ex) techFlows of
+                                    Just flow -> tfName flow
                                     Nothing -> T.pack (show prodUuid)
                                 [] -> T.pack (show prodUuid)
                             unit = activityUnit activity
@@ -261,21 +264,19 @@ exportIEIndex filePath db = do
 -- | Export ee_index.csv (Elementary Exchanges)
 exportEEIndex :: FilePath -> Database -> IO ()
 exportEEIndex filePath db = do
-    let bioFlowUUIDs = dbBiosphereFlows db
-        flows = dbFlows db
+    let bioFlowUUIDs = dbBiosphereOrder db
+        bioFlows = dbBioFlows db
 
         rows =
             zipWith
                 ( \flowUuid idx ->
-                    case M.lookup flowUuid flows of
+                    case M.lookup flowUuid bioFlows of
                         Just flow ->
-                            let category = flowCategory flow
-                                (compartment, subcompartment) = case T.splitOn "/" category of
-                                    [] -> ("unspecified", "")
-                                    [c] -> (T.strip c, "")
-                                    (c : s : _) -> (T.strip c, T.strip s)
-                                unit = getUnitNameForFlow (dbUnits db) flow
-                             in escapeCsvField (flowName flow)
+                            let comp = bfCompartment flow
+                                compartment = compartmentName comp
+                                subcompartment = maybe "" id (compartmentSub comp)
+                                unit = getUnitNameForBioFlow (dbUnits db) flow
+                             in escapeCsvField (bfName flow)
                                     <> ";"
                                     <> escapeCsvField compartment
                                     <> ";"

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -94,7 +94,8 @@ import Method.ChemSynonyms (ChemSynonyms, expandedTokens)
 import Method.Types
 import Plugin.Types (MapContext (..), MapQuery (..), MapResult (..), MapperHandle (..))
 import SynonymDB
-import Types (Activity (..), Database (..), Flow (..), FlowDB, ProcessId, SparseTriple (..), Unit (..), UnitDB)
+import Types (Activity (..), BioFlowDB, BiosphereFlow (..), Database (..), ProcessId, SparseTriple (..), Unit (..), UnitDB)
+import qualified Types as VT
 import UnitConversion (UnitConfig, convertUnit, isKnownUnit)
 
 -- | Matching strategy used to find a flow
@@ -136,9 +137,9 @@ data MappingStats = MappingStats
 buildMapContext :: Database -> MapContext
 buildMapContext db =
     MapContext
-        { mcFlowsByUUID = dbFlows db
-        , mcFlowsByName = dbFlowsByName db
-        , mcFlowsByCAS = dbFlowsByCAS db
+        { mcBioFlowsByUUID = dbBioFlows db
+        , mcBioFlowsByName = dbFlowsByName db
+        , mcBioFlowsByCAS = dbFlowsByCAS db
         , mcSynonymDB = fromMaybe emptySynonymDB (dbSynonymDB db)
         , mcActivities = M.empty
         }
@@ -150,7 +151,7 @@ mapMethodFlows ::
     [MapperHandle] ->
     MapContext ->
     Method ->
-    IO [(MethodCF, Maybe (Flow, MatchStrategy))]
+    IO [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]
 mapMethodFlows mappers ctx method =
     mapM (\cf -> fmap (cf,) (mapSingleFlow mappers ctx cf)) (methodFactors method)
 
@@ -161,7 +162,7 @@ mapSingleFlow ::
     [MapperHandle] ->
     MapContext ->
     MethodCF ->
-    IO (Maybe (Flow, MatchStrategy))
+    IO (Maybe (BiosphereFlow, MatchStrategy))
 mapSingleFlow mappers ctx cf = go mappers
   where
     go [] = pure Nothing
@@ -169,12 +170,12 @@ mapSingleFlow mappers ctx cf = go mappers
         result <- mhMatch m ctx (MatchCF cf)
         case result of
             Just mr
-                | Just flow <- M.lookup (mrTargetId mr) (mcFlowsByUUID ctx) ->
+                | Just flow <- M.lookup (mrTargetId mr) (mcBioFlowsByUUID ctx) ->
                     pure $ Just (flow, strategyFromText (mrStrategy mr))
             _ -> go ms
 
 -- | Convenience wrapper: map method CFs using the given mappers + DB.
-mapMethodToFlows :: [MapperHandle] -> Database -> Method -> IO [(MethodCF, Maybe (Flow, MatchStrategy))]
+mapMethodToFlows :: [MapperHandle] -> Database -> Method -> IO [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]
 mapMethodToFlows mappers db = mapMethodFlows mappers (buildMapContext db)
 
 -- | Convert strategy text back to MatchStrategy
@@ -192,29 +193,29 @@ strategyFromText t = case T.toLower t of
 -- ──────────────────────────────────────────────
 
 -- | Find flow by exact UUID match
-findFlowByUUID :: M.Map UUID Flow -> UUID -> Maybe Flow
+findFlowByUUID :: M.Map UUID BiosphereFlow -> UUID -> Maybe BiosphereFlow
 findFlowByUUID flowsByUUID uuid = M.lookup uuid flowsByUUID
 
 -- | Find flow by CAS number with compartment preference
-findFlowByCAS :: M.Map Text [Flow] -> Text -> Maybe Compartment -> Maybe Flow
+findFlowByCAS :: M.Map Text [BiosphereFlow] -> Text -> Maybe Compartment -> Maybe BiosphereFlow
 findFlowByCAS flowsByCAS cas mComp =
     M.lookup cas flowsByCAS >>= \flows -> pickByCompartment flows mComp
 
 -- | Find flow by normalized name match (compartment-aware)
-findFlowByName :: M.Map Text [Flow] -> Text -> Maybe Flow
+findFlowByName :: M.Map Text [BiosphereFlow] -> Text -> Maybe BiosphereFlow
 findFlowByName flowsByName name = findFlowByNameComp flowsByName name Nothing
 
 -- | Find flow by normalized name with compartment preference
-findFlowByNameComp :: M.Map Text [Flow] -> Text -> Maybe Compartment -> Maybe Flow
+findFlowByNameComp :: M.Map Text [BiosphereFlow] -> Text -> Maybe Compartment -> Maybe BiosphereFlow
 findFlowByNameComp flowsByName name mComp =
     M.lookup (normalizeName name) flowsByName >>= \flows -> pickByCompartment flows mComp
 
 -- | Find flow via synonym group (compartment-aware)
-findFlowBySynonym :: SynonymDB -> M.Map Text [Flow] -> Text -> Maybe Flow
+findFlowBySynonym :: SynonymDB -> M.Map Text [BiosphereFlow] -> Text -> Maybe BiosphereFlow
 findFlowBySynonym synDB flowsByName name = findFlowBySynonymComp synDB flowsByName name Nothing
 
 -- | Find flow via synonym group with compartment preference
-findFlowBySynonymComp :: SynonymDB -> M.Map Text [Flow] -> Text -> Maybe Compartment -> Maybe Flow
+findFlowBySynonymComp :: SynonymDB -> M.Map Text [BiosphereFlow] -> Text -> Maybe Compartment -> Maybe BiosphereFlow
 findFlowBySynonymComp synDB flowsByName name mComp =
     case lookupSynonymGroup synDB name of
         Nothing -> Nothing
@@ -224,10 +225,12 @@ findFlowBySynonymComp synDB flowsByName name mComp =
   where
     lookupFlows fbn syn = M.findWithDefault [] (normalizeName syn) fbn
 
-{- | Pick the best flow match based on compartment preference.
-Returns Nothing for an empty candidate list.
+{- | Pick the best flow match based on compartment preference. The flow's own
+compartment now lives in 'bfCompartment' as a structured 'Types.Compartment'
+(medium + optional sub); we compare against the method-side 3-field
+'Method.Types.Compartment' here.
 -}
-pickByCompartment :: [Flow] -> Maybe Compartment -> Maybe Flow
+pickByCompartment :: [BiosphereFlow] -> Maybe Compartment -> Maybe BiosphereFlow
 pickByCompartment [] _ = Nothing
 pickByCompartment (f : _) Nothing = Just f
 pickByCompartment (f : fs) (Just comp) = Just $
@@ -236,12 +239,13 @@ pickByCompartment (f : fs) (Just comp) = Just $
         Nothing -> fromMaybe f (find (mediumMatch comp) (f : fs))
   where
     exactCompMatch (Compartment med sub _) fl =
-        let cat = T.toLower (flowCategory fl)
-            subcomp = maybe "" T.toLower (flowSubcompartment fl)
+        let c = bfCompartment fl
+            cat = T.toLower (VT.compartmentName c)
+            subcomp = maybe "" T.toLower (VT.compartmentSub c)
          in matchMedium med cat && (T.null sub || sub == subcomp || sub `T.isInfixOf` subcomp)
 
     mediumMatch (Compartment med _ _) fl =
-        matchMedium med (T.toLower (flowCategory fl))
+        matchMedium med (T.toLower (VT.compartmentName (bfCompartment fl)))
 
     matchMedium med cat
         | T.null med = True
@@ -250,7 +254,7 @@ pickByCompartment (f : fs) (Just comp) = Just $
         | otherwise = False
 
 -- | Compute statistics about mapping results
-computeMappingStats :: [(MethodCF, Maybe (Flow, MatchStrategy))] -> MappingStats
+computeMappingStats :: [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> MappingStats
 computeMappingStats mappings =
     MappingStats
         { msTotal = length mappings
@@ -509,9 +513,9 @@ preferBetter@.
 -}
 expandSynonymMappings ::
     SynonymDB ->
-    M.Map Text [Flow] ->
-    [(MethodCF, Maybe (Flow, MatchStrategy))] ->
-    [(MethodCF, Maybe (Flow, MatchStrategy))]
+    M.Map Text [BiosphereFlow] ->
+    [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] ->
+    [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]
 expandSynonymMappings synDB flowsByName mappings =
     mappings ++ concatMap expand mappings
   where
@@ -547,12 +551,12 @@ expandSynonymMappings synDB flowsByName mappings =
 -- @resources/land@ via the compartment map), so it's simpler to let
 -- the table keys do the filtering.
 
-buildMethodTables :: CompartmentMap -> [(MethodCF, Maybe (Flow, MatchStrategy))] -> MethodTables
+buildMethodTables :: CompartmentMap -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> MethodTables
 buildMethodTables cmap mappings =
     MethodTables
         { mtUuidCF =
             M.fromList
-                [ (flowId flow, (mcfValue cf, mcfUnit cf))
+                [ (bfId flow, (mcfValue cf, mcfUnit cf))
                 | (cf, Just (flow, ByUUID)) <- mappings
                 ]
         , mtExactCF =
@@ -586,7 +590,7 @@ buildMethodTables cmap mappings =
             -- fallback CF. CFs with subcomp "(unspecified)" / empty are
             -- wildcards and match any flow subcomp.
             M.fromList
-                [ ((flowId flow, loc), (mcfValue cf, mcfUnit cf))
+                [ ((bfId flow, loc), (mcfValue cf, mcfUnit cf))
                 | (cf, Just (flow, _)) <- mappings
                 , Just loc <- [mcfConsumerLocation cf]
                 , cfSubcompMatchesFlow cf flow
@@ -614,13 +618,13 @@ buildMethodTables cmap mappings =
         Just comp ->
             let Compartment _ cfSubRaw _ = normalizeCompartment cmap comp
                 !cfSubN = T.toLower (T.strip cfSubRaw)
-                rawCategory = T.toLower (flowCategory flow)
+                rawCategory = T.toLower (VT.compartmentName (bfCompartment flow))
                 (rawMed, rawSubFromCat) = case T.breakOn "/" rawCategory of
                     (m, rest)
                         | T.null rest -> (m, T.empty)
                         | otherwise -> (m, T.drop 1 rest)
                 rawSub =
-                    let s = T.toLower (fromMaybe T.empty (flowSubcompartment flow))
+                    let s = T.toLower (fromMaybe T.empty (VT.compartmentSub (bfCompartment flow)))
                      in if T.null s then rawSubFromCat else s
                 Compartment _ flowSubRaw _ =
                     normalizeCompartment cmap (Compartment rawMed rawSub T.empty)
@@ -646,8 +650,8 @@ buildMethodTables cmap mappings =
 
     -- Use matched flow's name only for name/synonym matches
     nameKey cf mflow = normalizeName $ case mflow of
-        Just (flow, ByName) -> flowName flow
-        Just (flow, BySynonym) -> flowName flow
+        Just (flow, ByName) -> bfName flow
+        Just (flow, BySynonym) -> bfName flow
         _ -> mcfFlowName cf
 
 {- | Convert @qty@ from @flowUnit@ to @cfUnit@ for characterization.
@@ -679,7 +683,7 @@ dimensionally-incompatible flow/CF unit pairs land an effective CF of @0@
 (matching the per-flow scoring path) rather than silently keeping the
 unconverted quantity and contaminating the score.
 -}
-fillBroadcastVector :: UnitConfig -> UnitDB -> FlowDB -> MethodTables -> MethodTables
+fillBroadcastVector :: UnitConfig -> UnitDB -> BioFlowDB -> MethodTables -> MethodTables
 fillBroadcastVector unitConfig unitDB flowDB tables =
     tables{mtBroadcast = M.mapMaybeWithKey buildEntry flowDB}
   where
@@ -721,7 +725,7 @@ the right answer.
 fillRegionalActivityWeights ::
     UnitConfig ->
     UnitDB ->
-    FlowDB ->
+    BioFlowDB ->
     Database ->
     M.Map Text [Text] ->
     MethodTables ->
@@ -733,7 +737,7 @@ fillRegionalActivityWeights unitCfg unitDB flowDB db hier tables
     nCols = fromIntegral (dbActivityCount db) :: Int
     actIdx = dbActivityIndex db
     activities = dbActivities db
-    bioFlows = dbBiosphereFlows db
+    bioFlows = dbBiosphereOrder db
     bioTriples = dbBiosphereTriples db
     regional = mtRegionalizedCF tables
 
@@ -861,7 +865,7 @@ conversion when 'mtBroadcast' is empty. Tests and back-compat callers that use
 'buildMethodTables' directly hit the legacy path; the cached
 'mapMethodToTablesCached' fills the broadcast and gets the fast path.
 -}
-computeLCIAScoreFromTables :: UnitConfig -> UnitDB -> FlowDB -> Inventory -> MethodTables -> LCIAOutcome
+computeLCIAScoreFromTables :: UnitConfig -> UnitDB -> BioFlowDB -> Inventory -> MethodTables -> LCIAOutcome
 computeLCIAScoreFromTables unitConfig unitDB flowDB inventory tables =
     let (!score, !charSum, !invSum) = M.foldlWithKey' step (0, 0, 0) inventory
      in LCIAOutcome
@@ -899,7 +903,7 @@ computeLCIAScoreFromTables unitConfig unitDB flowDB inventory tables =
 {- | Back-compat wrapper: build tables on the fly. Prefer the cached path
 ('mapMethodToTablesCached' + 'computeLCIAScoreFromTables') in hot loops.
 -}
-computeLCIAScore :: UnitConfig -> UnitDB -> FlowDB -> Inventory -> [(MethodCF, Maybe (Flow, MatchStrategy))] -> LCIAOutcome
+computeLCIAScore :: UnitConfig -> UnitDB -> BioFlowDB -> Inventory -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> LCIAOutcome
 computeLCIAScore unitConfig unitDB flowDB inventory mappings =
     computeLCIAScoreFromTables unitConfig unitDB flowDB inventory (buildMethodTables M.empty mappings)
 
@@ -922,7 +926,7 @@ the partial 'Right'.
 computeLCIAScoreAuto ::
     UnitConfig ->
     UnitDB ->
-    FlowDB ->
+    BioFlowDB ->
     Database ->
     -- | Scaling vector @s@ (only consulted if the method is regionalized)
     Vector ->
@@ -962,7 +966,7 @@ non-regionalized methods continue to use 'computeLCIAScoreFromTables'.
 computeRegionalizedLCIAScore ::
     UnitConfig ->
     UnitDB ->
-    FlowDB ->
+    BioFlowDB ->
     Database ->
     -- | Scaling vector @s@ from 'Matrix.computeScalingVector'
     Vector ->
@@ -1057,7 +1061,7 @@ can act on them.
 sumRegionalizedLCIAScoreCrossDB ::
     UnitConfig ->
     UnitDB ->
-    FlowDB ->
+    BioFlowDB ->
     M.Map Text [Text] ->
     {- | Per-DB triples: one per database participating in the cross-DB solve
     (root + dep DBs in the same order returned by 'SharedSolver.csScalings').
@@ -1084,20 +1088,20 @@ converges on the same canonical form — a compartments.csv rule like
 against ILCD-style bare media without requiring an explicit (medium, sub)
 pair for every combination.
 -}
-lookupCascadeCF :: MethodTables -> FlowDB -> UUID -> Maybe (Double, Text)
+lookupCascadeCF :: MethodTables -> BioFlowDB -> UUID -> Maybe (Double, Text)
 lookupCascadeCF tables flowDB fid = case M.lookup fid (mtUuidCF tables) of
     Just cfv -> Just cfv
     Nothing -> case M.lookup fid flowDB of
         Nothing -> Nothing
         Just flow ->
-            let name = normalizeName (flowName flow)
-                rawCategory = T.toLower (flowCategory flow)
+            let name = normalizeName (bfName flow)
+                rawCategory = T.toLower (VT.compartmentName (bfCompartment flow))
                 (rawMed, rawSubFromCat) = case T.breakOn "/" rawCategory of
                     (m, rest)
                         | T.null rest -> (m, T.empty)
                         | otherwise -> (m, T.drop 1 rest)
                 rawSub =
-                    let s = T.toLower (fromMaybe T.empty (flowSubcompartment flow))
+                    let s = T.toLower (fromMaybe T.empty (VT.compartmentSub (bfCompartment flow)))
                      in if T.null s then rawSubFromCat else s
                 Compartment normMedRaw normSub _ =
                     normalizeCompartment (mtCompartmentMap tables) (Compartment rawMed rawSub T.empty)
@@ -1128,13 +1132,13 @@ convertAndMultiply ::
     {- | Pre-resolved flow if the caller already has it; @Nothing@ defaults to
     the identity factor (no flow record means no flow unit known).
     -}
-    Maybe Flow ->
+    Maybe BiosphereFlow ->
     -- | (CF value, CF unit)
     (Double, Text) ->
     Double ->
     Double
 convertAndMultiply unitConfig unitDB mflow (cfVal, cfUnit) qty =
-    let flowUnit = maybe "" unitName (mflow >>= \f -> M.lookup (flowUnitId f) unitDB)
+    let flowUnit = maybe "" unitName (mflow >>= \f -> M.lookup (bfUnitId f) unitDB)
         converted = convertForCharacterization unitConfig flowUnit cfUnit qty
      in converted * cfVal
 
@@ -1159,10 +1163,10 @@ uncharacterized and silently omitted — that matches the behaviour of
 inventoryContributions ::
     UnitConfig ->
     UnitDB ->
-    FlowDB ->
+    BioFlowDB ->
     Inventory ->
     MethodTables ->
-    ([(Flow, Double, Double)], [UUID])
+    ([(BiosphereFlow, Double, Double)], [UUID])
 inventoryContributions unitConfig unitDB flowDB inventory tables =
     M.foldlWithKey' step ([], []) inventory
   where
@@ -1183,7 +1187,7 @@ inventoryContributions unitConfig unitDB flowDB inventory tables =
                      in ((flow, cfVal, contribution) : contribs, unknowns)
 
 {- | Per-process LCIA contributions for one DB + one method, driven by
-'MethodTables' + a merged 'FlowDB'. Mirrors
+'MethodTables' + a merged 'BioFlowDB'. Mirrors
 'Matrix.computeProcessLCIAContributions' but lets dep-DB flows land a CF
 via (name, medium, subcompartment) fallback — same lookup path as
 'inventoryContributions' — so this helper can be called per-DB while
@@ -1196,7 +1200,7 @@ flow-unit → CF-unit conversion) to the process owning @colIdx@.
 processContributionsFromTables ::
     UnitConfig ->
     UnitDB ->
-    FlowDB ->
+    BioFlowDB ->
     Database ->
     Vector ->
     MethodTables ->
@@ -1205,7 +1209,7 @@ processContributionsFromTables unitConfig unitDB flowDB db scalingVec tables =
     U.foldl' step M.empty (dbBiosphereTriples db)
   where
     actIdx = dbActivityIndex db
-    bioFlows = dbBiosphereFlows db
+    bioFlows = dbBiosphereOrder db
     nFlows = V.length bioFlows
     nActs = V.length actIdx
 
@@ -1382,7 +1386,7 @@ constraint makes the impossible state (no DBs participated) unrepresentable.
 computeLCIAScoreSetFromTables ::
     UnitConfig ->
     UnitDB ->
-    FlowDB ->
+    BioFlowDB ->
     Inventory ->
     M.Map Text [Text] ->
     {- | Non-empty per-DB triples: 'NE.head' is root, tail is each participating
@@ -1411,7 +1415,7 @@ whose mappings caught none of the method's regional CFs.
 scoreRegionalCrossDB ::
     UnitConfig ->
     UnitDB ->
-    FlowDB ->
+    BioFlowDB ->
     M.Map Text [Text] ->
     V.Vector MethodSetEntry ->
     NonEmpty (Database, Vector, MethodSetTables) ->
@@ -1446,7 +1450,7 @@ would have caught via name/compartment cascade.
 scoreBatched ::
     UnitConfig ->
     UnitDB ->
-    FlowDB ->
+    BioFlowDB ->
     BatchedTables ->
     Inventory ->
     [(UUID, Either Text Double)]
@@ -1500,20 +1504,20 @@ scoreBatched unitCfg unitDB flowDB bt inventory
 per-function @lookupCF@ helpers inlined elsewhere in this module, but
 exposed so 'findUncharacterized' can ask whether a flow has any CF at all.
 -}
-lookupCFForFlow :: MethodTables -> UUID -> Maybe Flow -> Maybe (Double, Text)
+lookupCFForFlow :: MethodTables -> UUID -> Maybe BiosphereFlow -> Maybe (Double, Text)
 lookupCFForFlow tables fid mFlow = case M.lookup fid (mtUuidCF tables) of
     Just cfv -> Just cfv
     Nothing -> case mFlow of
         Nothing -> Nothing
         Just flow ->
-            let name = normalizeName (flowName flow)
-                rawCategory = T.toLower (flowCategory flow)
+            let name = normalizeName (bfName flow)
+                rawCategory = T.toLower (VT.compartmentName (bfCompartment flow))
                 (rawMed, rawSubFromCat) = case T.breakOn "/" rawCategory of
                     (m, rest)
                         | T.null rest -> (m, T.empty)
                         | otherwise -> (m, T.drop 1 rest)
                 rawSub =
-                    let s = T.toLower (fromMaybe T.empty (flowSubcompartment flow))
+                    let s = T.toLower (fromMaybe T.empty (VT.compartmentSub (bfCompartment flow)))
                      in if T.null s then rawSubFromCat else s
                 Compartment normMedRaw normSub _ =
                     normalizeCompartment (mtCompartmentMap tables) (Compartment rawMed rawSub T.empty)
@@ -1551,13 +1555,13 @@ scan cheap even on methods with thousands of CFs.
 Empty result list = no signal above zero. Caller should treat that as
 \"this flow is genuinely uncharacterized by the method\", not a bug.
 -}
-findSimilarCFs :: ChemSynonyms -> MethodIndex -> Flow -> Int -> [SimilarCF]
+findSimilarCFs :: ChemSynonyms -> MethodIndex -> BiosphereFlow -> Int -> [SimilarCF]
 findSimilarCFs syns idx flow maxN
     | maxN <= 0 = []
     | otherwise =
-        let flowName' = flowName flow
-            flowCAS' = flowCAS flow
-            flowMedium = normalizeMediumTop . T.takeWhile (/= '/') . T.toLower $ flowCategory flow
+        let flowName' = bfName flow
+            flowCAS' = bfCAS flow
+            flowMedium = normalizeMediumTop . T.takeWhile (/= '/') . T.toLower $ VT.compartmentName (bfCompartment flow)
 
             flowRawTokens = S.fromList (T.words (normalizeName flowName'))
             flowExpTokens = expandedTokens syns flowName'
@@ -1639,7 +1643,7 @@ diagnostics are disabled (@uoMaxFlows == 0@ / @uoMaxSimilar == 0@).
 findUncharacterized ::
     UnitConfig ->
     UnitDB ->
-    FlowDB ->
+    BioFlowDB ->
     Inventory ->
     MethodTables ->
     ChemSynonyms ->
@@ -1663,10 +1667,10 @@ findUncharacterized _ unitDB flowDB inventory tables syns idx opts
                 take (uoMaxFlows opts) $
                     sortOn (\(_, _, w) -> Down w) unmatched
          in [ UncharacterizedFlow
-                { ucfFlowId = flowId flow
-                , ucfFlowName = flowName flow
-                , ucfCategory = flowCategory flow
-                , ucfSubcomp = flowSubcompartment flow
+                { ucfFlowId = bfId flow
+                , ucfFlowName = bfName flow
+                , ucfCategory = VT.compartmentName (bfCompartment flow)
+                , ucfSubcomp = VT.compartmentSub (bfCompartment flow)
                 , ucfFlowUnit = flowUnitText flow
                 , ucfQuantity = qty
                 , ucfAbsWeight = w
@@ -1676,7 +1680,7 @@ findUncharacterized _ unitDB flowDB inventory tables syns idx opts
             ]
   where
     !totalAbs = M.foldr (\q s -> s + abs q) 0 inventory
-    flowUnitText flow = maybe "" unitName (M.lookup (flowUnitId flow) unitDB)
+    flowUnitText flow = maybe "" unitName (M.lookup (bfUnitId flow) unitDB)
 
 {- | Score an inventory and attach diagnostics in one call.
 
@@ -1689,7 +1693,7 @@ suggester work is wasted.
 computeLCIAScoreWithDiagnostics ::
     UnitConfig ->
     UnitDB ->
-    FlowDB ->
+    BioFlowDB ->
     Inventory ->
     MethodTables ->
     ChemSynonyms ->

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -611,8 +611,8 @@ buildMethodTables cmap mappings =
     -- that rewrites a subcomp can't desynchronise the filter from the sibling
     -- 'mtExactCF' / 'mtFallbackCF' tables or the 'lookupCascadeCF' read path.
     -- Flow subcomp resolution mirrors 'lookupCascadeCF': prefer the explicit
-    -- 'flowSubcompartment' field, fall back to the tail of "<medium>/<sub>"
-    -- parsed from 'flowCategory'.
+    -- 'compartmentSub' field, fall back to the tail of "<medium>/<sub>"
+    -- parsed from the compartment name.
     cfSubcompMatchesFlow cf flow = case mcfCompartment cf of
         Nothing -> True
         Just comp ->

--- a/src/Plugin/Builtin.hs
+++ b/src/Plugin/Builtin.hs
@@ -63,7 +63,7 @@ import Method.Types (Method (..), MethodCF (..))
 import SynonymDB (emptySynonymDB)
 import System.Directory (doesDirectoryExist, doesFileExist, listDirectory)
 import System.FilePath (takeExtension, (</>))
-import Types (Database (..), Flow (..))
+import Types (Database (..), BiosphereFlow (..))
 
 -- | Default registry with all built-in plugins
 defaultRegistry :: PluginRegistry
@@ -105,8 +105,8 @@ uuidMapper =
         , mhPriority = 0
         , mhMatch = \ctx query -> pure $ case query of
             MatchCF cf ->
-                fmap (\f -> MapResult (flowId f) "uuid" 1.0) $
-                    Mapping.findFlowByUUID (mcFlowsByUUID ctx) (mcfFlowRef cf)
+                fmap (\f -> MapResult (bfId f) "uuid" 1.0) $
+                    Mapping.findFlowByUUID (mcBioFlowsByUUID ctx) (mcfFlowRef cf)
             _ -> Nothing
         }
 
@@ -119,8 +119,8 @@ casMapper =
         , mhMatch = \ctx query -> pure $ case query of
             MatchCF cf -> do
                 cas <- mcfCAS cf
-                flow <- Mapping.findFlowByCAS (mcFlowsByCAS ctx) cas (mcfCompartment cf)
-                pure $ MapResult (flowId flow) "cas" 1.0
+                flow <- Mapping.findFlowByCAS (mcBioFlowsByCAS ctx) cas (mcfCompartment cf)
+                pure $ MapResult (bfId flow) "cas" 1.0
             _ -> Nothing
         }
 
@@ -132,8 +132,8 @@ nameMapper =
         , mhPriority = 20
         , mhMatch = \ctx query -> pure $ case query of
             MatchCF cf ->
-                fmap (\f -> MapResult (flowId f) "name" 0.9) $
-                    Mapping.findFlowByNameComp (mcFlowsByName ctx) (mcfFlowName cf) (mcfCompartment cf)
+                fmap (\f -> MapResult (bfId f) "name" 0.9) $
+                    Mapping.findFlowByNameComp (mcBioFlowsByName ctx) (mcfFlowName cf) (mcfCompartment cf)
             _ -> Nothing
         }
 
@@ -145,8 +145,8 @@ synonymMapper =
         , mhPriority = 30
         , mhMatch = \ctx query -> pure $ case query of
             MatchCF cf ->
-                fmap (\f -> MapResult (flowId f) "synonym" 0.8) $
-                    Mapping.findFlowBySynonymComp (mcSynonymDB ctx) (mcFlowsByName ctx) (mcfFlowName cf) (mcfCompartment cf)
+                fmap (\f -> MapResult (bfId f) "synonym" 0.8) $
+                    Mapping.findFlowBySynonymComp (mcSynonymDB ctx) (mcBioFlowsByName ctx) (mcfFlowName cf) (mcfCompartment cf)
             _ -> Nothing
         }
 
@@ -165,9 +165,9 @@ lciaAnalyzer =
                 methods = acMethods ctx
                 mapCtx =
                     MapContext
-                        { mcFlowsByUUID = dbFlows db
-                        , mcFlowsByName = dbFlowsByName db
-                        , mcFlowsByCAS = dbFlowsByCAS db
+                        { mcBioFlowsByUUID = dbBioFlows db
+                        , mcBioFlowsByName = dbFlowsByName db
+                        , mcBioFlowsByCAS = dbFlowsByCAS db
                         , mcSynonymDB = fromMaybe emptySynonymDB (dbSynonymDB db)
                         , mcActivities = M.empty
                         }
@@ -179,7 +179,7 @@ lciaAnalyzer =
                             toJSON $
                                 M.fromList
                                     [ ("method" :: String, toJSON (show m))
-                                    , ("score", toJSON (Mapping.loScore (Mapping.computeLCIAScore UnitConversion.defaultUnitConfig (acUnitDB ctx) (acFlowDB ctx) inv mappings)))
+                                    , ("score", toJSON (Mapping.loScore (Mapping.computeLCIAScore UnitConversion.defaultUnitConfig (acUnitDB ctx) (acBioFlowDB ctx) inv mappings)))
                                     ]
                     )
                     methods
@@ -259,15 +259,15 @@ nameSearcher =
         , shPriority = 0
         , shSearch = \db query -> do
             let queryLower = T.toLower (sqText query)
-                flows = M.elems (dbFlows db)
+                flows = M.elems (dbBioFlows db)
                 matches =
                     [ (f, score)
                     | f <- flows
-                    , let nameLower = T.toLower (flowName f)
+                    , let nameLower = T.toLower (bfName f)
                           synMatches =
                             any
                                 (\syns -> any (T.isInfixOf queryLower . T.toLower) (S.toList syns))
-                                (M.elems (flowSynonyms f))
+                                (M.elems (bfSynonyms f))
                     , T.isInfixOf queryLower nameLower || synMatches
                     , let score =
                             if queryLower == nameLower
@@ -278,7 +278,7 @@ nameSearcher =
                                         else 0.7
                     ]
                 limited = take (sqLimit query) matches
-            pure [SearchResult (flowId f) (flowName f) s M.empty | (f, s) <- limited]
+            pure [SearchResult (bfId f) (bfName f) s M.empty | (f, s) <- limited]
         }
 
 -- | CAS number search: exact CAS match on dbFlowsByCAS index
@@ -292,7 +292,7 @@ casSearcher =
             let cas = sqText query
             pure $ case M.lookup cas (dbFlowsByCAS db) of
                 Just flows ->
-                    [SearchResult (flowId f) (flowName f) 1.0 (M.singleton "cas" cas) | f <- take (sqLimit query) flows]
+                    [SearchResult (bfId f) (bfName f) 1.0 (M.singleton "cas" cas) | f <- take (sqLimit query) flows]
                 Nothing -> []
         }
 
@@ -312,11 +312,11 @@ searchWithPlugins searchers db query = do
 -- ──────────────────────────────────────────────
 
 {- | Contribution of a single flow to the LCIA score.
-Returns (MethodCF, Flow, contribution_value) when the flow is present in the inventory.
+Returns (MethodCF, BiosphereFlow, contribution_value) when the flow is present in the inventory.
 -}
-flowContribution :: Inventory -> (MethodCF, Maybe (Flow, MatchStrategy)) -> Maybe (MethodCF, Flow, Double)
+flowContribution :: Inventory -> (MethodCF, Maybe (BiosphereFlow, MatchStrategy)) -> Maybe (MethodCF, BiosphereFlow, Double)
 flowContribution inv (cf, Just (flow, _))
-    | Just qty <- M.lookup (flowId flow) inv = Just (cf, flow, qty * mcfValue cf)
+    | Just qty <- M.lookup (bfId flow) inv = Just (cf, flow, qty * mcfValue cf)
 flowContribution _ _ = Nothing
 
 {- | Hotspot analyzer: for each method, return top-N flows by contribution to the score.
@@ -333,7 +333,7 @@ hotspotAnalyzer =
                 methods = acMethods ctx
                 mapCtx = Mapping.buildMapContext db
                 topN = 20
-                flowDB = acFlowDB ctx
+                flowDB = acBioFlowDB ctx
                 unitDB = acUnitDB ctx
             results <- mapM (analyzeMethod flowDB unitDB mapCtx inv topN) methods
             pure $ toJSON results
@@ -359,7 +359,7 @@ hotspotAnalyzer =
                         , toJSON
                             [ toJSON $
                                 M.fromList
-                                    [ ("flowName" :: String, toJSON (flowName f))
+                                    [ ("flowName" :: String, toJSON (bfName f))
                                     , ("cfValue", toJSON cfVal)
                                     , ("contribution", toJSON contrib)
                                     , ("percent", toJSON (if total /= 0 then contrib / total * 100 else 0 :: Double))

--- a/src/Plugin/Types.hs
+++ b/src/Plugin/Types.hs
@@ -58,7 +58,7 @@ import Data.UUID (UUID)
 import Matrix (Inventory)
 import Method.Types (Method, MethodCF)
 import SynonymDB (SynonymDB)
-import Types (Activity, ActivityMap, Database, Flow, FlowDB, SimpleDatabase, UnitDB)
+import Types (Activity, ActivityMap, BioFlowDB, BiosphereFlow, Database, SimpleDatabase, TechFlowDB, UnitDB)
 
 -- | How a plugin handle is implemented
 data PluginBackend
@@ -80,7 +80,8 @@ data ImportHandle = ImportHandle
 
 data ImportResult = ImportResult
     { irActivities :: !ActivityMap
-    , irFlows :: !FlowDB
+    , irTechFlows :: !TechFlowDB
+    , irBioFlows :: !BioFlowDB
     , irUnits :: !UnitDB
     , irWarnings :: ![Text]
     }
@@ -136,9 +137,9 @@ data MapperHandle = MapperHandle
     }
 
 data MapContext = MapContext
-    { mcFlowsByUUID :: !(Map UUID Flow)
-    , mcFlowsByName :: !(Map Text [Flow])
-    , mcFlowsByCAS :: !(Map Text [Flow])
+    { mcBioFlowsByUUID :: !BioFlowDB -- Biosphere flows by UUID (CF matching targets these)
+    , mcBioFlowsByName :: !(Map Text [BiosphereFlow])
+    , mcBioFlowsByCAS :: !(Map Text [BiosphereFlow])
     , mcSynonymDB :: !SynonymDB
     , mcActivities :: !(Map Text [Activity])
     }
@@ -218,11 +219,13 @@ data AnalyzeContext = AnalyzeContext
     , acInventory :: !Inventory
     , acMethods :: ![Method]
     , acParameters :: !(Map Text Value)
-    , acFlowDB :: !FlowDB
-    {- ^ Merged flow metadata across every loaded DB. The 'Inventory' passed
-    in may be cross-DB-merged, so analyzers that characterize or enrich
-    by flow UUID should look up through these rather than @dbFlows acDatabase@
-    (which would silently drop dep-DB flows).
+    , acTechFlowDB :: !TechFlowDB
+    , acBioFlowDB :: !BioFlowDB
+    {- ^ Merged flow metadata across every loaded DB, split by kind. The
+    'Inventory' passed in may be cross-DB-merged, so analyzers that
+    characterize or enrich by flow UUID should look up through these rather
+    than the per-database fields on @acDatabase@ (which would silently drop
+    dep-DB flows).
     -}
     , acUnitDB :: !UnitDB
     }

--- a/src/Search/BM25.hs
+++ b/src/Search/BM25.hs
@@ -24,16 +24,15 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU
 import qualified Data.Vector.Unboxed.Mutable as VUM
 
-import Data.UUID (UUID)
 import Search.BM25.Types (BM25Index (..))
 import Search.Normalize (tokenize)
-import Types (Activity, Database (..), Flow, activityName, exchangeFlowId, exchangeIsInput, exchangeIsReference, exchanges, flowName)
+import Types (Activity, Database (..), TechFlowDB, activityName, exchangeFlowId, exchangeIsInput, exchangeIsReference, exchanges, tfName)
 
 {- | Populate the BM25 index field on a Database. Called after
 initializeRuntimeFields during database load. Idempotent.
 -}
 addBM25Index :: Database -> Database
-addBM25Index db = db{dbBM25Index = Just (buildIndex (dbActivities db) (dbFlows db))}
+addBM25Index db = db{dbBM25Index = Just (buildIndex (dbActivities db) (dbTechFlows db))}
 
 -- BM25 hyperparameters. Defaults from the canonical Okapi BM25 paper.
 k1 :: Double
@@ -47,7 +46,7 @@ Document text per activity = activity name + reference product name.
 Location is intentionally excluded: it's a structured filter (geoParam),
 not a ranking signal.
 -}
-buildIndex :: V.Vector Activity -> Map UUID Flow -> BM25Index
+buildIndex :: V.Vector Activity -> TechFlowDB -> BM25Index
 buildIndex activities flowDb =
     let n = V.length activities
         tokensByDoc :: V.Vector [Text]
@@ -114,7 +113,7 @@ tokenTrigrams t
          in M.keys (M.fromList [(tg, ()) | tg <- raw]) -- dedupe
 
 -- | Extract searchable tokens for one activity: name + reference product name(s).
-documentTokens :: Map UUID Flow -> Activity -> [Text]
+documentTokens :: TechFlowDB -> Activity -> [Text]
 documentTokens flowDb a =
     tokenize (activityName a)
         ++ concatMap productTokens (exchanges a)
@@ -123,7 +122,7 @@ documentTokens flowDb a =
         | exchangeIsReference ex
         , not (exchangeIsInput ex)
         , Just flow <- M.lookup (exchangeFlowId ex) flowDb =
-            tokenize (flowName flow)
+            tokenize (tfName flow)
         | otherwise = []
 
 -- | Count term frequencies in a document.

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -1285,17 +1285,16 @@ getFlowInfo db flowIdText = do
                             Right $ toJSON $ FlowDetail (Right flow) (getUnitNameForBioFlow (dbUnits db) flow) usageCount
                         Nothing -> Left $ FlowNotFound flowIdText
 
--- | Get activities that use a specific flow as JSON (for CLI)
+-- | Get activities that use a specific flow as JSON (for CLI). Resolves
+-- against either flow side so biosphere flow IDs work too.
 getFlowActivities :: Database -> Text -> Either ServiceError Value
 getFlowActivities db flowIdText = do
     case UUID.fromText flowIdText of
         Nothing -> Left $ InvalidUUID $ "Invalid flow UUID: " <> flowIdText
-        Just fId ->
-            case M.lookup fId (dbTechFlows db) of
-                Nothing -> Left $ FlowNotFound flowIdText
-                Just _ ->
-                    let activities = getActivitiesUsingFlow db fId
-                     in Right $ toJSON activities
+        Just fId
+            | M.member fId (dbTechFlows db) || M.member fId (dbBioFlows db) ->
+                Right $ toJSON (getActivitiesUsingFlow db fId)
+            | otherwise -> Left $ FlowNotFound flowIdText
 
 {- | Compute the supply chain for an activity using the scaling vector.
 Returns all upstream activities with their scaling factors and subgraph edges.

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -216,20 +216,20 @@ cross-DB-merged inventories (whose flow UUIDs can originate in any loaded
 dep DB) can be decoded against a merged metadata snapshot. For single-DB
 callers, pass @dbFlows db@ / @dbUnits db@ directly.
 -}
-convertToInventoryExport :: Database -> FlowDB -> UnitDB -> ProcessId -> Activity -> Inventory -> InventoryExport
-convertToInventoryExport db flowDB unitDB processId rootActivity inventory =
+convertToInventoryExport :: Database -> BioFlowDB -> UnitDB -> ProcessId -> Activity -> Inventory -> InventoryExport
+convertToInventoryExport db bioFlowDB unitDB processId rootActivity inventory =
     let
-        -- Filter out flows with zero quantities to reduce noise in the results
+        -- Inventory flows are biosphere by construction (rows of B matrix).
         inventoryList = M.toList inventory
 
         !flowDetails =
             [ InventoryFlowDetail flow quantity uName isEmission category
             | (flowUUID, quantity) <- inventoryList
-            , quantity /= 0 -- Exclude flows with zero quantities
-            , Just flow <- [M.lookup flowUUID flowDB]
-            , let !uName = getUnitNameForFlow unitDB flow
-                  !isEmission = not (isResourceExtraction flow quantity)
-                  !category = flowCategory flow
+            , quantity /= 0
+            , Just flow <- [M.lookup flowUUID bioFlowDB]
+            , let !uName = getUnitNameForBioFlow unitDB flow
+                  !isEmission = not (isResourceExtraction flow)
+                  !category = compartmentName (bfCompartment flow)
             ]
 
         !emissionFlows = length [f | f <- flowDetails, ifdIsEmission f]
@@ -244,7 +244,7 @@ convertToInventoryExport db flowDB unitDB processId rootActivity inventory =
                 M.toList $
                     M.fromListWith (+) [(ifdCategory f, 1) | f <- flowDetails]
 
-        !(prodName, prodAmount, prodUnit) = getReferenceProductInfo flowDB unitDB rootActivity
+        !(prodName, prodAmount, prodUnit) = getReferenceProductInfo (dbTechFlows db) unitDB rootActivity
 
         !metadata =
             InventoryMetadata
@@ -273,15 +273,14 @@ convertToInventoryExport db flowDB unitDB processId rootActivity inventory =
      in
         InventoryExport metadata flowDetails statistics
 
-{- | Determine if a flow represents resource extraction based on flow category
-Since B matrix now stores all flows as positive (Ecoinvent convention), we use category instead of sign
-EcoSpold2: "natural resource/in ground", SimaPro: "resource/in ground"
+{- | Determine if a biosphere flow represents resource extraction based on its
+compartment. Now type-restricted to BiosphereFlow — technosphere can't reach
+this code path at compile time.
 -}
-isResourceExtraction :: Flow -> Double -> Bool
-isResourceExtraction flow _ =
-    let cat = T.toLower (flowCategory flow)
-     in flowType flow == Biosphere
-            && ("natural resource" `T.isPrefixOf` cat || "resource" `T.isPrefixOf` cat)
+isResourceExtraction :: BiosphereFlow -> Bool
+isResourceExtraction flow =
+    let cat = T.toLower (compartmentName (bfCompartment flow))
+     in "natural resource" `T.isPrefixOf` cat || "resource" `T.isPrefixOf` cat
 
 -- | Get activity inventory as rich InventoryExport (same as API)
 getActivityInventory :: Database -> Text -> IO (Either ServiceError Value)
@@ -291,7 +290,7 @@ getActivityInventory db processIdText =
         Right (processId, activity) -> do
             -- Matrix computation (will not fail if validation passed)
             inventory <- computeInventoryMatrix db processId
-            let !inventoryExport = convertToInventoryExport db (dbFlows db) (dbUnits db) processId activity inventory
+            let !inventoryExport = convertToInventoryExport db (dbBioFlows db) (dbUnits db) processId activity inventory
             return $ Right $ toJSON inventoryExport
 
 -- | Shared solver-aware activity inventory export for concurrent processing
@@ -317,7 +316,7 @@ getActivityInventoryWithSharedSolver validators sharedSolver db processIdText = 
                             let bioFlowCount = dbBiosphereCount db
                                 bioTriples = dbBiosphereTriples db
                                 activityIndex = dbActivityIndex db
-                                bioFlowUUIDs = dbBiosphereFlows db
+                                bioFlowUUIDs = dbBiosphereOrder db
                                 demandVec = buildDemandVectorFromIndex activityIndex processId
 
                             -- Use shared solver (lazy factorization on first call, cached thereafter)
@@ -339,7 +338,7 @@ getActivityInventoryWithSharedSolver validators sharedSolver db processIdText = 
                                             MatrixError $
                                                 T.intercalate "; " [viMessage i | i <- postIssues, viSeverity i == Error]
                                 else do
-                                    let inventoryExport = convertToInventoryExport db (dbFlows db) (dbUnits db) processId activity inventory
+                                    let inventoryExport = convertToInventoryExport db (dbBioFlows db) (dbUnits db) processId activity inventory
                                     return $ Right inventoryExport
 
 -- | Simple stats tracking for tree processing
@@ -383,10 +382,10 @@ findProcessIdByProductFlowWithFallback unitCfg db flowUUID =
         Just pid -> Just pid
         Nothing ->
             -- Fallback: look up the flow to get its name and unit
-            case M.lookup flowUUID (dbFlows db) of
+            case M.lookup flowUUID (dbTechFlows db) of
                 Just inputFlow ->
-                    let inputName = T.toLower (flowName inputFlow)
-                        inputUnit = getUnitNameForFlow (dbUnits db) inputFlow
+                    let inputName = T.toLower (tfName inputFlow)
+                        inputUnit = getUnitNameForTechFlow (dbUnits db) inputFlow
                         -- Get candidates by normalized name
                         candidates = searchProductsByName db inputName
                         -- Filter to only dimensionally compatible units
@@ -467,29 +466,28 @@ extractBiosphereNodesAndEdges db activity activityProcessId depth nodeAcc edgeAc
                     (\a b -> compare (abs (exchangeAmount b)) (abs (exchangeAmount a)))
                     allBiosphereExchanges
         processBiosphere ex (nodeAcc', edgeAcc') =
-            case M.lookup (exchangeFlowId ex) (dbFlows db) of
+            case M.lookup (exchangeFlowId ex) (dbBioFlows db) of
                 Nothing -> (nodeAcc', edgeAcc')
                 Just flow ->
-                    let flowIdText = UUID.toText (flowId flow)
+                    let flowIdText = UUID.toText (bfId flow)
                         isEmission = not (exchangeIsInput ex) -- False = emission, True = resource
                         nodeType = if isEmission then BiosphereEmissionNode else BiosphereResourceNode
-                        compartment = extractCompartment (flowCategory flow)
+                        compartmentTxt = compartmentName (bfCompartment flow)
                         biosphereNode =
                             ExportNode
                                 { enId = flowIdText
-                                , enName = flowName flow
-                                , enDescription = [flowCategory flow]
+                                , enName = bfName flow
+                                , enDescription = [compartmentTxt]
                                 , enLocation = ""
-                                , enUnit = getUnitNameForFlow (dbUnits db) flow
+                                , enUnit = getUnitNameForBioFlow (dbUnits db) flow
                                 , enNodeType = nodeType
                                 , enDepth = depth
                                 , enLoopTarget = Nothing
                                 , enParentId = Just activityProcessId
                                 , enChildrenCount = 0
-                                , enCompartment = Just compartment
+                                , enCompartment = Just compartmentTxt
                                 }
                         nodeAcc'' = M.insert flowIdText biosphereNode nodeAcc'
-                        -- Create edge with correct direction
                         (edgeFrom, edgeTo, edgeType) =
                             if isEmission
                                 then (activityProcessId, flowIdText, BiosphereEmissionEdge)
@@ -498,9 +496,9 @@ extractBiosphereNodesAndEdges db activity activityProcessId depth nodeAcc edgeAc
                             TreeEdge
                                 { teFrom = edgeFrom
                                 , teTo = edgeTo
-                                , teFlow = FlowInfo (flowId flow) (flowName flow) (flowCategory flow)
+                                , teFlow = FlowInfo (bfId flow) (bfName flow) compartmentTxt
                                 , teQuantity = exchangeAmount ex
-                                , teUnit = getUnitNameForFlow (dbUnits db) flow
+                                , teUnit = getUnitNameForBioFlow (dbUnits db) flow
                                 , teEdgeType = edgeType
                                 }
                         edgeAcc'' = edge : edgeAcc'
@@ -580,11 +578,11 @@ extractNodesAndEdges db tree depth parentId nodeAcc edgeAcc = case tree of
                 let (childNodes, childEdges, childStats') = extractNodesAndEdges db subtree (depth + 1) (Just currentProcessId) nodeAcc' edgeAcc'
                     edge =
                         TreeEdge
-                            { teFrom = currentProcessId -- Now ProcessId format
-                            , teTo = getTreeNodeId db subtree -- This now returns ProcessId format
-                            , teFlow = FlowInfo (flowId flow) (flowName flow) (flowCategory flow)
+                            { teFrom = currentProcessId
+                            , teTo = getTreeNodeId db subtree
+                            , teFlow = FlowInfo (tfId flow) (tfName flow) ""
                             , teQuantity = quantity
-                            , teUnit = getUnitNameForFlow (dbUnits db) flow
+                            , teUnit = getUnitNameForTechFlow (dbUnits db) flow
                             , teEdgeType = TechnosphereEdge
                             }
                     newStats = combineStats statsAcc childStats'
@@ -703,7 +701,7 @@ buildActivityGraph db sharedSolver queryText cutoffPercent = do
             let techTriples = dbTechnosphereTriples db
                 activities = dbActivities db
                 units = dbUnits db
-                flows = dbFlows db
+                flows = dbTechFlows db
 
                 -- Build edges: iterate through sparse triplets
                 edges =
@@ -728,19 +726,15 @@ buildActivityGraph db sharedSolver queryText cutoffPercent = do
                                     [ ex
                                     | ex <- exchanges srcAct
                                     , case ex of
-                                        TechnosphereExchange{techIsInput = isInput, techIsReference = isRef} -> isInput && not isRef
+                                        TechnosphereExchange{techRole = Input} -> True
+                                        TechnosphereExchange{} -> False
                                         BiosphereExchange{} -> False
                                     ]
-                            -- Match by target activity UUID
                             case [ex | ex <- techExchanges, exchangeActivityLinkId ex == Just targetUUID] of
                                 (ex : _) -> M.lookup (exchangeFlowId ex) flows
-                                [] -> Nothing -- No matching exchange found
-                          uName = case flowInfo of
-                            Just flow -> getUnitNameForFlow units flow
-                            Nothing -> "unknown"
-                          flowNameText = case flowInfo of
-                            Just flow -> flowName flow
-                            Nothing -> "Unknown flow"
+                                [] -> Nothing
+                          uName = maybe "unknown" (getUnitNameForTechFlow units) flowInfo
+                          flowNameText = maybe "Unknown flow" tfName flowInfo
                        in case (sourceNodeId, targetNodeId) of
                             (Just src, Just tgt) ->
                                 Just $ GraphEdge src tgt (realToFrac value) uName flowNameText
@@ -796,14 +790,24 @@ getFlowUsageCount db flowUUID =
         Nothing -> 0
         Just activityUUIDs -> length activityUUIDs
 
--- | Get flows used by an activity as lightweight summaries
+-- | Get flows used by an activity as lightweight summaries. Each exchange
+-- lookup is resolved against the appropriate side (tech vs bio) and wrapped
+-- in 'Either' to preserve the discriminator for downstream JSON encoders.
 getActivityFlowSummaries :: Database -> Activity -> [FlowSummary]
 getActivityFlowSummaries db activity =
-    [ FlowSummary flow (getUnitNameForFlow (dbUnits db) flow) (getFlowUsageCount db (flowId flow)) (determineFlowRole exchange)
+    [ summary
     | exchange <- exchanges activity
-    , Just flow <- [M.lookup (exchangeFlowId exchange) (dbFlows db)]
+    , Just summary <- [mkSummary exchange]
     ]
   where
+    mkSummary ex = case ex of
+        TechnosphereExchange{techFlowId = fid} ->
+            (\f -> FlowSummary (Left f) (getUnitNameForTechFlow (dbUnits db) f) (getFlowUsageCount db (tfId f)) (determineFlowRole ex))
+                <$> M.lookup fid (dbTechFlows db)
+        BiosphereExchange{bioFlowId = fid} ->
+            (\f -> FlowSummary (Right f) (getUnitNameForBioFlow (dbUnits db) f) (getFlowUsageCount db (bfId f)) (determineFlowRole ex))
+                <$> M.lookup fid (dbBioFlows db)
+
     determineFlowRole ex
         | exchangeIsReference ex = ReferenceProductFlow
         | exchangeIsInput ex = InputFlow
@@ -819,17 +823,26 @@ searchFlows db FlowFilter{ffQuery = query, ffLimit = limitParam, ffOffset = offs
         offset = maybe 0 (max 0) offsetParam
         rawResults = findFlowsBySynonym db query
         isDesc = orderParam == Just "desc"
+        -- Projection helpers: pick the per-side accessor for a tagged flow.
+        nameOf = either tfName bfName
+        idOf = either tfId bfId
+        unitOf = either (getUnitNameForTechFlow (dbUnits db)) (getUnitNameForBioFlow (dbUnits db))
+        synonymsOf = either tfSynonyms bfSynonyms
+        categoryOf = either (const "") (compartmentName . bfCompartment)
         flowCmp = case sortParam of
-            Just "category" -> \a b -> compare (flowCategory a) (flowCategory b)
-            Just "unit" -> \a b -> compare (getUnitNameForFlow (dbUnits db) a) (getUnitNameForFlow (dbUnits db) b)
-            _ -> \a b -> compare (flowName a) (flowName b)
+            Just "category" -> \a b -> compare (categoryOf a) (categoryOf b)
+            Just "unit" -> \a b -> compare (unitOf a) (unitOf b)
+            _ -> \a b -> compare (nameOf a) (nameOf b)
         allResults = L.sortBy (if isDesc then flip flowCmp else flowCmp) rawResults
         total = length allResults
         dropped = drop offset allResults
         taken = take (limit + 1) dropped
         hasMore = length taken > limit
         pagedResults = take limit taken
-        flowResults = map (\flow -> FlowSearchResult (flowId flow) (flowName flow) (flowCategory flow) (getUnitNameForFlow (dbUnits db) flow) (M.map S.toList (flowSynonyms flow))) pagedResults
+        flowResults =
+            map
+                (\flow -> FlowSearchResult (idOf flow) (nameOf flow) (categoryOf flow) (unitOf flow) (M.map S.toList (synonymsOf flow)))
+                pagedResults
     endTime <- getCurrentTime
     let searchTimeMs = realToFrac (diffUTCTime endTime startTime) * 1000 :: Double
     return $ Right $ toJSON $ SearchResults flowResults total offset limit hasMore searchTimeMs
@@ -920,7 +933,7 @@ searchActivities db (SearchFilter core exactMatch) = do
         activityResults =
             map
                 ( \(processId, activity) ->
-                    let (prodName, prodAmount, prodUnit) = getReferenceProductInfo (dbFlows db) (dbUnits db) activity
+                    let (prodName, prodAmount, prodUnit) = getReferenceProductInfo (dbTechFlows db) (dbUnits db) activity
                      in ActivitySummary
                             (processIdToText db processId)
                             (activityName activity)
@@ -994,7 +1007,7 @@ convertActivityForAPI unitCfg db processId activity =
     let allProducts = case processIdToUUIDs db processId of
             Just (activityUUID, _) -> getAllProductsForActivity db activityUUID
             Nothing -> []
-        (refProdName, refProdAmount, refProdUnit) = getReferenceProductInfo (dbFlows db) (dbUnits db) activity
+        (refProdName, refProdAmount, refProdUnit) = getReferenceProductInfo (dbTechFlows db) (dbUnits db) activity
      in ActivityForAPI
             { pfaProcessId = processIdToText db processId
             , pfaName = activityName activity
@@ -1021,27 +1034,30 @@ convertActivityForAPI unitCfg db processId activity =
         Nothing -> M.empty
 
     convertExchangeWithUnit exchange =
-        let flowInfo = M.lookup (exchangeFlowId exchange) (dbFlows db)
+        let -- Look up the flow in the appropriate side (tech vs bio) based on exchange variant.
+            techFlowInfo = case exchange of
+                TechnosphereExchange{techFlowId = fid} -> M.lookup fid (dbTechFlows db)
+                BiosphereExchange{} -> Nothing
+            bioFlowInfo = case exchange of
+                BiosphereExchange{bioFlowId = fid} -> M.lookup fid (dbBioFlows db)
+                TechnosphereExchange{} -> Nothing
             (targetActivityName, targetActivityLocation, targetProcessId) = case exchange of
-                TechnosphereExchange{techFlowId = fId, techIsInput = isInput, techActivityLinkId = linkId}
-                    | isInput && linkId /= UUID.nil ->
-                        -- EcoSpold path: use explicit activity link
+                TechnosphereExchange{techFlowId = fId, techRole = role, techActivityLinkId = linkId}
+                    | (role == Input || role == ReferenceInput) && linkId /= UUID.nil ->
                         case findActivityByActivityUUID db linkId of
                             Just targetActivity ->
                                 let maybeProcessId = findProcessIdByActivityUUID db linkId
                                     processIdText = fmap (processIdToText db) maybeProcessId
                                  in (Just (activityName targetActivity), Just (activityLocation targetActivity), processIdText)
                             Nothing -> (Nothing, Nothing, Nothing)
-                    | isInput ->
+                    | role == Input || role == ReferenceInput ->
                         -- SimaPro path: linkId is nil, resolve by product flow UUID
-                        -- Uses fallback to name+unit matching when UUID lookup fails (e.g., tkm vs kgkm)
                         case findProcessIdByProductFlowWithFallback unitCfg db fId of
                             Just pid
                                 | Just act <- getActivity db pid ->
                                     (Just (activityName act), Just (activityLocation act), Just (processIdToText db pid))
                             _ ->
-                                -- Try cross-DB links
-                                case flowInfo >>= \flow -> M.lookup (T.toLower (flowName flow)) crossDBLinkMap of
+                                case techFlowInfo >>= \flow -> M.lookup (T.toLower (tfName flow)) crossDBLinkMap of
                                     Just link ->
                                         let crossPid =
                                                 cdlSourceDatabase link
@@ -1053,15 +1069,16 @@ convertActivityForAPI unitCfg db processId activity =
                                     Nothing -> (Nothing, Nothing, Nothing)
                     | otherwise -> (Nothing, Nothing, Nothing)
                 BiosphereExchange{} -> (Nothing, Nothing, Nothing)
+            flowNameTxt = case (techFlowInfo, bioFlowInfo) of
+                (Just tf, _) -> tfName tf
+                (_, Just bf) -> bfName bf
+                _ -> "unknown"
+            compartment = bfCompartment <$> bioFlowInfo
          in ExchangeWithUnit
                 { ewuExchange = exchange
                 , ewuUnitName = getUnitNameForExchange (dbUnits db) exchange
-                , ewuFlowName = maybe "unknown" flowName flowInfo
-                , ewuFlowCategory = case flowInfo of
-                    Just flow -> case isTechnosphereExchange exchange of
-                        True -> "technosphere"
-                        False -> flowCategory flow -- This will now include compartment info like "water/ground-, long-term"
-                    Nothing -> "unknown"
+                , ewuFlowName = flowNameTxt
+                , ewuCompartment = compartment
                 , ewuTargetActivity = targetActivityName
                 , ewuTargetLocation = targetActivityLocation
                 , ewuTargetProcessId = targetProcessId
@@ -1069,19 +1086,20 @@ convertActivityForAPI unitCfg db processId activity =
                 , ewuPedigree = exchangePedigree exchange
                 }
 
--- | Get reference product name from activity exchanges
-getReferenceProductName :: M.Map UUID Flow -> Activity -> Maybe Text
+-- | Get reference product name from activity exchanges. Reference products
+-- are always technosphere.
+getReferenceProductName :: TechFlowDB -> Activity -> Maybe Text
 getReferenceProductName flows activity =
     case [ex | ex <- exchanges activity, exchangeIsReference ex] of
-        (ex : _) -> fmap flowName (M.lookup (exchangeFlowId ex) flows)
+        (ex : _) -> fmap tfName (M.lookup (exchangeFlowId ex) flows)
         [] -> Nothing
 
 -- | Get reference product info (name, amount, unit) from activity exchanges
-getReferenceProductInfo :: M.Map UUID Flow -> UnitDB -> Activity -> (Text, Double, Text)
+getReferenceProductInfo :: TechFlowDB -> UnitDB -> Activity -> (Text, Double, Text)
 getReferenceProductInfo flows units activity =
     case [ex | ex <- exchanges activity, exchangeIsReference ex] of
         (ex : _) ->
-            let name = maybe "" flowName (M.lookup (exchangeFlowId ex) flows)
+            let name = maybe "" tfName (M.lookup (exchangeFlowId ex) flows)
                 amount = exchangeAmount ex
                 uName = getUnitNameForExchange units ex
              in (name, amount, uName)
@@ -1094,7 +1112,7 @@ getAllProductsForActivity db activityUUID =
         Just processIds ->
             [ let mAct = findActivityByProcessId db pid
                   (prodName, prodAmount, prodUnit) = case mAct of
-                    Just a -> getReferenceProductInfo (dbFlows db) (dbUnits db) a
+                    Just a -> getReferenceProductInfo (dbTechFlows db) (dbUnits db) a
                     Nothing -> ("Unknown", 1.0, "")
                in ActivitySummary
                     { prsProcessId = processIdToText db pid
@@ -1116,7 +1134,7 @@ getTargetActivity db exchange = do
     targetId <- exchangeActivityLinkId exchange
     targetActivity <- findActivityByActivityUUID db targetId
     processId <- findProcessIdForActivity db targetActivity
-    let (prodName, prodAmount, prodUnit) = getReferenceProductInfo (dbFlows db) (dbUnits db) targetActivity
+    let (prodName, prodAmount, prodUnit) = getReferenceProductInfo (dbTechFlows db) (dbUnits db) targetActivity
     return $
         ActivitySummary
             { prsProcessId = processIdToText db processId
@@ -1129,16 +1147,17 @@ getTargetActivity db exchange = do
             , prsAllocationFormula = activityAllocationFormula targetActivity
             }
 
--- | Get reference product as FlowDetail (if exists)
+-- | Get reference product as FlowDetail (if exists). Reference products are
+-- technosphere by definition.
 getActivityReferenceProductDetail :: Database -> Activity -> Maybe FlowDetail
 getActivityReferenceProductDetail db activity = do
     refExchange <- case filter exchangeIsReference (exchanges activity) of
         [] -> Nothing
         (ex : _) -> Just ex
-    flow <- M.lookup (exchangeFlowId refExchange) (dbFlows db)
-    let usageCount = getFlowUsageCount db (flowId flow)
-    let uName = getUnitNameForFlow (dbUnits db) flow
-    return $ FlowDetail flow uName usageCount
+    flow <- M.lookup (exchangeFlowId refExchange) (dbTechFlows db)
+    let usageCount = getFlowUsageCount db (tfId flow)
+    let uName = getUnitNameForTechFlow (dbUnits db) flow
+    return $ FlowDetail (Left flow) uName usageCount
 
 -- | Get activities that use a specific flow as ActivitySummary list
 getActivitiesUsingFlow :: Database -> UUID -> [ActivitySummary]
@@ -1147,7 +1166,7 @@ getActivitiesUsingFlow db flowUUID =
         Nothing -> []
         Just activityUUIDs ->
             let uniqueUUIDs = S.toList $ S.fromList activityUUIDs -- Deduplicate activity UUIDs
-             in [ let (prodName, prodAmount, prodUnit) = getReferenceProductInfo (dbFlows db) (dbUnits db) proc
+             in [ let (prodName, prodAmount, prodUnit) = getReferenceProductInfo (dbTechFlows db) (dbUnits db) proc
                    in ActivitySummary
                         (processIdToText db processId)
                         (activityName proc)
@@ -1170,19 +1189,36 @@ same convention the @/activity/{pid}@ endpoint uses.
 -}
 getActivityExchangeDetails :: Database -> Activity -> (Exchange -> Bool) -> [ExchangeDetail]
 getActivityExchangeDetails db activity filterFn =
-    [ ExchangeDetail
-        exchange
-        flow
-        (getUnitNameForFlow (dbUnits db) flow)
-        unit
-        (getUnitNameForExchange (dbUnits db) exchange)
-        (resolveTarget exchange flow)
+    [ detail
     | exchange <- exchanges activity
     , filterFn exchange
-    , Just flow <- [M.lookup (exchangeFlowId exchange) (dbFlows db)]
-    , Just unit <- [M.lookup (exchangeUnitId exchange) (dbUnits db)]
+    , Just detail <- [mkDetail exchange]
     ]
   where
+    mkDetail exchange = case exchange of
+        TechnosphereExchange{techFlowId = fid} -> do
+            flow <- M.lookup fid (dbTechFlows db)
+            unit <- M.lookup (exchangeUnitId exchange) (dbUnits db)
+            pure $
+                ExchangeDetail
+                    exchange
+                    (Left flow)
+                    (getUnitNameForTechFlow (dbUnits db) flow)
+                    unit
+                    (getUnitNameForExchange (dbUnits db) exchange)
+                    (resolveTechTarget exchange flow)
+        BiosphereExchange{bioFlowId = fid} -> do
+            flow <- M.lookup fid (dbBioFlows db)
+            unit <- M.lookup (exchangeUnitId exchange) (dbUnits db)
+            pure $
+                ExchangeDetail
+                    exchange
+                    (Right flow)
+                    (getUnitNameForBioFlow (dbUnits db) flow)
+                    unit
+                    (getUnitNameForExchange (dbUnits db) exchange)
+                    Nothing -- Biosphere flows have no target activity
+
     -- Cross-DB link lookup by consumer's flow name, built once per activity
     -- for O(log n) per-exchange resolution.
     crossLinkByFlow :: M.Map Text CrossDBLink
@@ -1195,13 +1231,13 @@ getActivityExchangeDetails db activity filterFn =
                 ]
         Nothing -> M.empty
 
-    resolveTarget exchange flow =
+    resolveTechTarget exchange flow =
         case getTargetActivity db exchange of
             Just s -> Just s
             Nothing -> crossDBTarget flow
 
     crossDBTarget flow =
-        case M.lookup (T.toLower (flowName flow)) crossLinkByFlow of
+        case M.lookup (T.toLower (tfName flow)) crossLinkByFlow of
             Nothing -> Nothing
             Just link ->
                 let qualifiedPid =
@@ -1230,19 +1266,20 @@ getActivityInputDetails db activity = getActivityExchangeDetails db activity exc
 getActivityOutputDetails :: Database -> Activity -> [ExchangeDetail]
 getActivityOutputDetails db activity = getActivityExchangeDetails db activity (not . exchangeIsInput)
 
--- | Get flow info as JSON (for CLI)
+-- | Get flow info as JSON (for CLI). Resolves against either flow side.
 getFlowInfo :: Database -> Text -> Either ServiceError Value
 getFlowInfo db flowIdText = do
     case UUID.fromText flowIdText of
         Nothing -> Left $ InvalidUUID $ "Invalid flow UUID: " <> flowIdText
         Just fId ->
-            case M.lookup fId (dbFlows db) of
-                Nothing -> Left $ FlowNotFound flowIdText
-                Just flow ->
-                    let usageCount = getFlowUsageCount db fId
-                        uName = getUnitNameForFlow (dbUnits db) flow
-                        flowDetail = FlowDetail flow uName usageCount
-                     in Right $ toJSON flowDetail
+            let usageCount = getFlowUsageCount db fId
+             in case M.lookup fId (dbTechFlows db) of
+                    Just flow ->
+                        Right $ toJSON $ FlowDetail (Left flow) (getUnitNameForTechFlow (dbUnits db) flow) usageCount
+                    Nothing -> case M.lookup fId (dbBioFlows db) of
+                        Just flow ->
+                            Right $ toJSON $ FlowDetail (Right flow) (getUnitNameForBioFlow (dbUnits db) flow) usageCount
+                        Nothing -> Left $ FlowNotFound flowIdText
 
 -- | Get activities that use a specific flow as JSON (for CLI)
 getFlowActivities :: Database -> Text -> Either ServiceError Value
@@ -1250,7 +1287,7 @@ getFlowActivities db flowIdText = do
     case UUID.fromText flowIdText of
         Nothing -> Left $ InvalidUUID $ "Invalid flow UUID: " <> flowIdText
         Just fId ->
-            case M.lookup fId (dbFlows db) of
+            case M.lookup fId (dbTechFlows db) of
                 Nothing -> Left $ FlowNotFound flowIdText
                 Just _ ->
                     let activities = getActivitiesUsingFlow db fId
@@ -1437,11 +1474,11 @@ collectSupplyChainEntries db dbName mRootPid supplyVec scf includeEdges qualifyP
         nameMatchesPid pid = maybe True (IS.member (fromIntegral pid)) mNameSet
 
         getProductNames activity =
-            [ flowName flow
+            [ tfName flow
             | ex <- exchanges activity
             , exchangeIsReference ex
             , not (exchangeIsInput ex)
-            , Just flow <- [M.lookup (exchangeFlowId ex) (dbFlows db)]
+            , Just flow <- [M.lookup (exchangeFlowId ex) (dbTechFlows db)]
             ]
 
         matchesFilters activity pid =
@@ -1555,7 +1592,7 @@ buildSupplyChainFromScalingVector db dbName processId supplyVec scf includeEdges
                 , prsProduct =
                     fromMaybe
                         (activityName rootActivity)
-                        (getReferenceProductName (dbFlows db) rootActivity)
+                        (getReferenceProductName (dbTechFlows db) rootActivity)
                 , prsProductAmount = rootRefAmount
                 , prsProductUnit = activityUnit rootActivity
                 , prsAllocationPercent = activityAllocationPercent rootActivity
@@ -1616,7 +1653,7 @@ buildSupplyChainFromScalingVectorCrossDB unitCfg depLookup rootDb rootDbName roo
                 , prsProduct =
                     fromMaybe
                         (activityName rootActivity)
-                        (getReferenceProductName (dbFlows rootDb) rootActivity)
+                        (getReferenceProductName (dbTechFlows rootDb) rootActivity)
                 , prsProductAmount = rootRefAmount
                 , prsProductUnit = activityUnit rootActivity
                 , prsAllocationPercent = activityAllocationPercent rootActivity
@@ -2516,7 +2553,7 @@ getConsumers db dbName processIdText cnf = do
             , locationMatches activity
             , classMatches activity
             , let (prodName, prodAmount, prodUnit) =
-                    getReferenceProductInfo (dbFlows db) (dbUnits db) activity
+                    getReferenceProductInfo (dbTechFlows db) (dbUnits db) activity
             , productMatches prodName
             ]
 

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -1069,10 +1069,14 @@ convertActivityForAPI unitCfg db processId activity =
                                     Nothing -> (Nothing, Nothing, Nothing)
                     | otherwise -> (Nothing, Nothing, Nothing)
                 BiosphereExchange{} -> (Nothing, Nothing, Nothing)
+            -- When neither the tech nor the bio map knows the exchange flow
+            -- UUID we surface the raw UUID rather than a generic "unknown" —
+            -- that way the consumer can tell which flow failed to resolve and
+            -- the gap is debuggable instead of silently misnamed.
             flowNameTxt = case (techFlowInfo, bioFlowInfo) of
                 (Just tf, _) -> tfName tf
                 (_, Just bf) -> bfName bf
-                _ -> "unknown"
+                _ -> "<unresolved flow " <> UUID.toText (exchangeFlowId exchange) <> ">"
             compartment = bfCompartment <$> bioFlowInfo
          in ExchangeWithUnit
                 { ewuExchange = exchange

--- a/src/Service/Aggregate.hs
+++ b/src/Service/Aggregate.hs
@@ -13,6 +13,7 @@ module Service.Aggregate (
     AggregateParams (..),
     AggScope (..),
     AggregateFn (..),
+    ExchangeKind (..),
     emptyAggregateParams,
     aggregate,
 ) where
@@ -48,10 +49,10 @@ import SharedSolver (DepSolverLookup, SharedSolver, computeInventoryMatrixWithDe
 import qualified SharedSolver
 import Types (
     Activity,
+    BioFlowDB,
+    BiosphereFlow (..),
     Database (..),
-    Flow (..),
-    FlowDB,
-    FlowType (..),
+    TechnosphereFlow (..),
     UnitDB,
     exchangeAmount,
     exchangeFlowId,
@@ -66,6 +67,12 @@ import UnitConversion (UnitConfig)
 -- ---------------------------------------------------------------------------
 
 data AggScope = ScopeDirect | ScopeSupplyChain | ScopeBiosphere
+    deriving (Eq, Show)
+
+-- | Local discriminator for filtering by exchange variant. Replaces the
+-- former 'FlowType' discriminator, which is gone now that 'Flow' is split
+-- into 'TechnosphereFlow' and 'BiosphereFlow'.
+data ExchangeKind = KindTechnosphere | KindBiosphere
     deriving (Eq, Show)
 
 data AggregateFn = AggSum | AggCount | AggShare
@@ -83,7 +90,7 @@ data AggregateParams = AggregateParams
     , apFilterUnit :: Maybe Text -- exact unit name
     , apFilterClassifications :: [ClassEntry]
     , apFilterTargetName :: Maybe Text -- only ScopeDirect technosphere
-    , apFilterExchangeType :: Maybe FlowType -- only ScopeDirect
+    , apFilterExchangeType :: Maybe ExchangeKind -- only ScopeDirect
     , apFilterIsReference :: Maybe Bool
     , apGroupBy :: Maybe Text
     , apAggregate :: AggregateFn
@@ -120,7 +127,7 @@ data AggRow = AggRow
     , rowIsReference :: !(Maybe Bool)
     , rowTargetName :: !(Maybe Text) -- only direct technosphere
     , rowLocation :: !(Maybe Text) -- only supply_chain
-    , rowExchangeType :: !(Maybe FlowType) -- only direct / biosphere
+    , rowExchangeType :: !(Maybe ExchangeKind) -- only direct / biosphere
     , rowClassifications :: !(M.Map Text Text)
     }
 
@@ -130,7 +137,7 @@ data AggRow = AggRow
 
 aggregate ::
     UnitConfig ->
-    FlowDB -> -- merged (root + deps) for biosphere scope
+    BioFlowDB -> -- merged (root + deps) for biosphere scope
     UnitDB -> -- merged (root + deps) for biosphere scope
     Database ->
     Text -> -- root DB name (for tagging supply-chain entries)
@@ -198,7 +205,7 @@ rowsFromDirect db act =
   where
     mkRow (ExchangeDetail ex flow _flowUnit _unit exUnitName target) =
         AggRow
-            { rowName = flowName flow
+            { rowName = either tfName bfName flow
             , rowFlowId = UUID.toText (exchangeFlowId ex)
             , rowUnit = exUnitName
             , rowQuantity = exchangeAmount ex
@@ -206,8 +213,8 @@ rowsFromDirect db act =
             , rowIsReference = Just (exchangeIsReference ex)
             , rowTargetName = fmap prsName target
             , rowLocation = fmap prsLocation target
-            , rowExchangeType = Just (if isTechnosphereExchange ex then Technosphere else Biosphere)
-            , rowClassifications = M.empty -- flow-level classifications not yet on Flow; use filter_name instead
+            , rowExchangeType = Just (if isTechnosphereExchange ex then KindTechnosphere else KindBiosphere)
+            , rowClassifications = M.empty
             }
 
 rowsFromSupplyChain :: SupplyChainResponse -> [AggRow]
@@ -234,15 +241,15 @@ rowsFromBiosphere export =
   where
     mkRow (InventoryFlowDetail flow qty uName isEmission _cat) =
         AggRow
-            { rowName = flowName flow
-            , rowFlowId = UUID.toText (flowId flow)
+            { rowName = bfName flow
+            , rowFlowId = UUID.toText (bfId flow)
             , rowUnit = uName
             , rowQuantity = qty
             , rowIsInput = Just (not isEmission)
             , rowIsReference = Nothing
             , rowTargetName = Nothing
             , rowLocation = Nothing
-            , rowExchangeType = Just Biosphere
+            , rowExchangeType = Just KindBiosphere
             , rowClassifications = M.empty
             }
 

--- a/src/SharedSolver.hs
+++ b/src/SharedSolver.hs
@@ -404,7 +404,7 @@ for the wire when the DB differs from the root.
 crossDBProcessContributions ::
     UnitConfig ->
     UnitDB ->
-    FlowDB ->
+    BioFlowDB ->
     DepSolverLookup ->
     -- | root DB
     Database ->

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -767,7 +767,7 @@ processBlockToActivity ::
     UnitConversion.UnitConfig ->
     ([(Text, Text)], [(Text, Text)], [(Text, Text)], [(Text, Text)]) ->
     ProcessBlock ->
-    [(Activity, [Flow], [Unit])]
+    [(Activity, [TechnosphereFlow], [BiosphereFlow], [Unit])]
 processBlockToActivity unitCfg (dbInputPs, dbCalcPs, projInputPs, projCalcPs) ProcessBlock{..} =
     let
         -- Build parameter environment: input params first, then calculated params
@@ -806,8 +806,8 @@ processBlockToActivity unitCfg (dbInputPs, dbCalcPs, projInputPs, projCalcPs) Pr
 
         -- Convert all rows in one pass, collecting exchanges/flows/units together
         avoidedTriples = map (productToExchange unitCfg env False) pbAvoidedProducts
-        techTriples = map (techRowToExchange env True) (pbMaterials ++ pbElectricity)
-        wasteTriples = map (techRowToExchange env True) pbWasteToTreatment
+        techTriples = map (techRowToExchange env) (pbMaterials ++ pbElectricity)
+        wasteTriples = map (techRowToExchange env) pbWasteToTreatment
         bioTriples =
             map (bioRowToExchange env True "resource") pbResources
                 ++ map (bioRowToExchange env False "air") pbEmissionsAir
@@ -816,26 +816,24 @@ processBlockToActivity unitCfg (dbInputPs, dbCalcPs, projInputPs, projCalcPs) Pr
                 ++ map (bioRowToExchange env False "waste") pbFinalWaste
 
         -- Tech rows may have zero amounts (Maybe Exchange), others always have exchanges
-        techExchanges = [e | (Just e, _, _) <- techTriples ++ wasteTriples]
-        techFlows = [f | (_, f, _) <- techTriples ++ wasteTriples]
-        techUnits = [u | (_, _, u) <- techTriples ++ wasteTriples]
+        techRowExchanges = [e | (Just e, _, _) <- techTriples ++ wasteTriples]
+        techRowFlows = [f | (_, f, _) <- techTriples ++ wasteTriples]
+        techRowUnits = [u | (_, _, u) <- techTriples ++ wasteTriples]
 
         sharedExchanges =
             map (\(e, _, _) -> e) avoidedTriples
-                ++ techExchanges
+                ++ techRowExchanges
                 ++ map (\(e, _, _) -> e) bioTriples
-        sharedFlows =
-            map (\(_, f, _) -> f) avoidedTriples
-                ++ techFlows
-                ++ map (\(_, f, _) -> f) bioTriples
+        sharedTechFlows = map (\(_, f, _) -> f) avoidedTriples ++ techRowFlows
+        sharedBioFlows = map (\(_, f, _) -> f) bioTriples
         sharedUnits =
             S.toList . S.fromList $
                 map (\(_, _, u) -> unitName u) avoidedTriples
-                    ++ map unitName techUnits
+                    ++ map unitName techRowUnits
                     ++ map (\(_, _, u) -> unitName u) bioTriples
 
         -- Create one activity per product
-        makeActivity :: ProductRow -> (Activity, [Flow], [Unit])
+        makeActivity :: ProductRow -> (Activity, [TechnosphereFlow], [BiosphereFlow], [Unit])
         makeActivity prod =
             let (productExchange, productFlow, productUnit) = productToExchange unitCfg env True prod
                 effUnitName = unitName productUnit
@@ -874,12 +872,13 @@ processBlockToActivity unitCfg (dbInputPs, dbCalcPs, projInputPs, projCalcPs) Pr
                         , activityAllocationPercent = Just allocPercent
                         , activityAllocationFormula = allocFormula
                         }
-                allFlows = productFlow : sharedFlows
+                allTechFlows = productFlow : sharedTechFlows
+                allBioFlows = sharedBioFlows
                 allUnits =
                     map
                         (\name -> Unit (generateUnitUUID name) name name "")
                         (S.toList . S.fromList $ effUnitName : sharedUnits)
-             in (activity, allFlows, allUnits)
+             in (activity, allTechFlows, allBioFlows, allUnits)
      in
         map makeActivity pbProducts
 
@@ -906,7 +905,7 @@ If the unit is unknown to the config or its dimension has no base unit, the
 raw values are kept (the downstream matrix builder in 'Database.hs' surfaces
 unknown-unit errors with a clear message).
 -}
-productToExchange :: UnitConversion.UnitConfig -> M.Map Text Double -> Bool -> ProductRow -> (Exchange, Flow, Unit)
+productToExchange :: UnitConversion.UnitConfig -> M.Map Text Double -> Bool -> ProductRow -> (Exchange, TechnosphereFlow, Unit)
 productToExchange unitCfg env isRef ProductRow{..} =
     let cleanName = fst (extractLocation prName)
         rawAmount = resolveAmount env prAmountRaw prAmount
@@ -923,8 +922,7 @@ productToExchange unitCfg env isRef ProductRow{..} =
                 { techFlowId = flowUUID
                 , techAmount = amount
                 , techUnitId = unitUUID
-                , techIsInput = False
-                , techIsReference = isRef
+                , techRole = if isRef then ReferenceProduct else Coproduct
                 , techActivityLinkId = UUID.nil
                 , techProcessLinkId = Nothing
                 , techLocation = ""
@@ -932,16 +930,13 @@ productToExchange unitCfg env isRef ProductRow{..} =
                 , techPedigree = Nothing
                 }
         flow =
-            Flow
-                { flowId = flowUUID
-                , flowName = cleanName
-                , flowCategory = prCategory
-                , flowSubcompartment = Nothing
-                , flowUnitId = unitUUID
-                , flowType = Technosphere
-                , flowSynonyms = M.empty
-                , flowCAS = Nothing
-                , flowSubstanceId = Nothing
+            TechnosphereFlow
+                { tfId = flowUUID
+                , tfName = cleanName
+                , tfUnitId = unitUUID
+                , tfSynonyms = M.empty
+                , tfCAS = Nothing
+                , tfSubstanceId = Nothing
                 }
         unit = Unit{unitId = unitUUID, unitName = effUnitName, unitSymbol = effUnitName, unitComment = ""}
      in (exchange, flow, unit)
@@ -994,8 +989,8 @@ parsePedigreePrefix raw =
 {- | Convert technosphere row to exchange (if non-zero), flow, and unit.
 Always returns the flow/unit; exchange is Nothing for zero-amount rows.
 -}
-techRowToExchange :: M.Map Text Double -> Bool -> TechExchangeRow -> (Maybe Exchange, Flow, Unit)
-techRowToExchange env isInput TechExchangeRow{..} =
+techRowToExchange :: M.Map Text Double -> TechExchangeRow -> (Maybe Exchange, TechnosphereFlow, Unit)
+techRowToExchange env TechExchangeRow{..} =
     let (cleanName, location) = extractLocation terName
         flowUUID = generateFlowUUID cleanName "" terUnit
         unitUUID = generateUnitUUID terUnit
@@ -1010,8 +1005,7 @@ techRowToExchange env isInput TechExchangeRow{..} =
                             { techFlowId = flowUUID
                             , techAmount = resolvedAmount
                             , techUnitId = unitUUID
-                            , techIsInput = isInput
-                            , techIsReference = False
+                            , techRole = Input
                             , techActivityLinkId = UUID.nil
                             , techProcessLinkId = Nothing
                             , techLocation = location
@@ -1019,16 +1013,13 @@ techRowToExchange env isInput TechExchangeRow{..} =
                             , techPedigree = pedigree
                             }
         flow =
-            Flow
-                { flowId = flowUUID
-                , flowName = cleanName
-                , flowCategory = ""
-                , flowSubcompartment = Nothing
-                , flowUnitId = unitUUID
-                , flowType = Technosphere
-                , flowSynonyms = M.empty
-                , flowCAS = Nothing
-                , flowSubstanceId = Nothing
+            TechnosphereFlow
+                { tfId = flowUUID
+                , tfName = cleanName
+                , tfUnitId = unitUUID
+                , tfSynonyms = M.empty
+                , tfCAS = Nothing
+                , tfSubstanceId = Nothing
                 }
         unit = Unit{unitId = unitUUID, unitName = terUnit, unitSymbol = terUnit, unitComment = ""}
      in (exchange, flow, unit)
@@ -1037,13 +1028,9 @@ techRowToExchange env isInput TechExchangeRow{..} =
 The compartment parameter is the section-level compartment ("air", "water", "soil", "resource", "waste")
 and berCompartment is the row-level sub-compartment ("high. pop.", "river", etc. or empty)
 -}
-bioRowToExchange :: M.Map Text Double -> Bool -> Text -> BioExchangeRow -> (Exchange, Flow, Unit)
+bioRowToExchange :: M.Map Text Double -> Bool -> Text -> BioExchangeRow -> (Exchange, BiosphereFlow, Unit)
 bioRowToExchange env isInput compartment BioExchangeRow{..} =
-    let category =
-            if T.null berCompartment
-                then compartment
-                else compartment <> "/" <> berCompartment
-        -- Keep SimaPro's per-region flow variants (`Nitrogen dioxide, FR`,
+    let -- Keep SimaPro's per-region flow variants (`Nitrogen dioxide, FR`,
         -- `Water, FR`, …) as distinct elementary flows. EF 3.1 (and any
         -- SimaPro-style method) characterises them via suffix-keyed CFs of
         -- matching name, so collapsing them to a canonical name breaks
@@ -1071,16 +1058,14 @@ bioRowToExchange env isInput compartment BioExchangeRow{..} =
                 , bioPedigree = pedigree
                 }
         flow =
-            Flow
-                { flowId = flowUUID
-                , flowName = cleanName
-                , flowCategory = category
-                , flowSubcompartment = subcomp
-                , flowUnitId = unitUUID
-                , flowType = Biosphere
-                , flowSynonyms = M.empty
-                , flowCAS = Nothing
-                , flowSubstanceId = Nothing
+            BiosphereFlow
+                { bfId = flowUUID
+                , bfName = cleanName
+                , bfUnitId = unitUUID
+                , bfSynonyms = M.empty
+                , bfCAS = Nothing
+                , bfSubstanceId = Nothing
+                , bfCompartment = Compartment compartment subcomp
                 }
         unit = Unit{unitId = unitUUID, unitName = berUnit, unitSymbol = berUnit, unitComment = ""}
      in (exchange, flow, unit)
@@ -1224,7 +1209,7 @@ Reference-product amounts are normalized to the canonical base unit of their
 dimension (e.g. 1 t → 1000 kg) during parsing, so downstream matrix
 construction yields per-base-unit columns — matching Brightway conventions.
 -}
-parseSimaProCSV :: UnitConversion.UnitConfig -> FilePath -> IO ([Activity], FlowDB, UnitDB)
+parseSimaProCSV :: UnitConversion.UnitConfig -> FilePath -> IO ([Activity], TechFlowDB, BioFlowDB, UnitDB)
 parseSimaProCSV unitCfg path = do
     reportProgress Info $ "Loading SimaPro CSV file: " ++ path
     startTime <- getCurrentTime
@@ -1255,27 +1240,33 @@ parseSimaProCSV unitCfg path = do
 
     -- Convert all blocks to activities (one activity per product) - PARALLEL
     converted <- concat <$> mapConcurrently (evaluate . force . processBlockToActivity unitCfg globalParams) allBlocks
-    let activities = map (\(a, _, _) -> a) converted
-        allFlows = concatMap (\(_, f, _) -> f) converted
-        allUnits = concatMap (\(_, _, u) -> u) converted
+    let activities = map (\(a, _, _, _) -> a) converted
+        allTechFlows = concatMap (\(_, tf, _, _) -> tf) converted
+        allBioFlows = concatMap (\(_, _, bf, _) -> bf) converted
+        allUnits = concatMap (\(_, _, _, u) -> u) converted
 
-    -- Build deduplicated maps
-    let flowDB = M.fromList [(flowId f, f) | f <- allFlows]
+    -- Build deduplicated maps — UUID disjointness across kinds is guaranteed
+    -- by construction (tech flows hash with empty compartment, bio flows hash
+    -- with their compartment), so two plain M.fromList calls suffice.
+    let techFlowDB = M.fromList [(tfId f, f) | f <- allTechFlows]
+        bioFlowDB = M.fromList [(bfId f, f) | f <- allBioFlows]
         unitDB = M.fromList [(unitId u, u) | u <- allUnits]
 
     -- Force evaluation before returning
     let !numActivities = length activities
-    let !numFlows = M.size flowDB
+    let !numTechFlows = M.size techFlowDB
+    let !numBioFlows = M.size bioFlowDB
     let !numUnits = M.size unitDB
 
     endTime <- getCurrentTime
     let duration = realToFrac (diffUTCTime endTime startTime) :: Double
     reportProgress Info $ printf "SimaPro parsing completed in %.2fs:" duration
     reportProgress Info $ printf "  Activities: %d processes" numActivities
-    reportProgress Info $ printf "  Flows: %d unique" numFlows
+    reportProgress Info $ printf "  Technosphere flows: %d unique" numTechFlows
+    reportProgress Info $ printf "  Biosphere flows: %d unique" numBioFlows
     reportProgress Info $ printf "  Units: %d unique" numUnits
 
-    return (activities, flowDB, unitDB)
+    return (activities, techFlowDB, bioFlowDB, unitDB)
   where
     -- Strip Windows \r from ByteString (fast, often no-op)
     stripCR :: BS.ByteString -> BS.ByteString

--- a/src/SynonymDB/Extract.hs
+++ b/src/SynonymDB/Extract.hs
@@ -21,22 +21,21 @@ import qualified Data.Text.Encoding as T
 import Data.UUID (UUID)
 
 import Method.FlowResolver (ILCDFlowInfo (..))
-import Types (Flow (..), FlowDB)
+import Types (BioFlowDB, BiosphereFlow (..))
 
 {- | Extract synonym pairs from EcoSpold2 biosphere flows.
 For each flow with English synonyms, generates (flowName, synonym) pairs.
 -}
-extractFromEcoSpold2 :: FlowDB -> S.Set UUID -> [(Text, Text)]
-extractFromEcoSpold2 flowDB bioUUIDs =
+extractFromEcoSpold2 :: BioFlowDB -> [(Text, Text)]
+extractFromEcoSpold2 bioFlowDB =
     S.toList $
         S.fromList
-            [ (flowName f, syn)
-            | f <- M.elems flowDB
-            , S.member (flowId f) bioUUIDs
-            , syns <- maybe [] S.toList (M.lookup "en" (flowSynonyms f))
+            [ (bfName f, syn)
+            | f <- M.elems bioFlowDB
+            , syns <- maybe [] S.toList (M.lookup "en" (bfSynonyms f))
             , let syn = T.strip syns
             , not (T.null syn)
-            , syn /= flowName f
+            , syn /= bfName f
             ]
 
 {- | Extract synonym pairs from ILCD flow definitions.

--- a/src/Tree.hs
+++ b/src/Tree.hs
@@ -9,10 +9,11 @@ import Numeric.Natural (Natural)
 import Types
 import UnitConversion (UnitConfig, convertExchangeAmount)
 
-isTechnosphereInput :: FlowDB -> Exchange -> Bool
-isTechnosphereInput _ ex =
+isTechnosphereInput :: Exchange -> Bool
+isTechnosphereInput ex =
     case ex of
-        TechnosphereExchange{techIsInput = isInput, techIsReference = isRef} -> isInput && not isRef
+        TechnosphereExchange{techRole = Input} -> True
+        TechnosphereExchange{} -> False
         BiosphereExchange{} -> False
 
 {- | Get converted exchange amount ensuring unit compatibility.
@@ -74,7 +75,7 @@ buildNode cfg activityUUID visited depth = do
                             techInputs =
                                 [ ex
                                 | ex <- exchanges activity
-                                , isTechnosphereInput (dbFlows (tcDatabase cfg)) ex
+                                , isTechnosphereInput ex
                                 ]
                         children <- buildChildren cfg techInputs visited' (depth + 1)
                         pure $
@@ -86,13 +87,13 @@ buildNode cfg activityUUID visited depth = do
 with its converted amount and recursing. Bails out early when the node
 budget runs out so the tree stays within the 300-node envelope.
 -}
-buildChildren :: TreeConfig -> [Exchange] -> S.Set UUID -> Int -> State Int [(Double, Flow, LoopAwareTree)]
+buildChildren :: TreeConfig -> [Exchange] -> S.Set UUID -> Int -> State Int [(Double, TechnosphereFlow, LoopAwareTree)]
 buildChildren _ [] _ _ = pure []
 buildChildren cfg (ex : exs) visited depth = do
     budget <- get
     if budget <= 0
         then pure []
-        else case (exchangeActivityLinkId ex, M.lookup (exchangeFlowId ex) (dbFlows (tcDatabase cfg))) of
+        else case (exchangeActivityLinkId ex, M.lookup (exchangeFlowId ex) (dbTechFlows (tcDatabase cfg))) of
             (Just targetUUID, Just flow) -> do
                 let amount = getConvertedExchangeAmount (tcUnitConfig cfg) (tcDatabase cfg) ex targetUUID
                 subtree <- buildNode cfg targetUUID visited depth

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -365,9 +365,6 @@ type LocationIndex = M.Map Text [UUID] -- Location -> [ActivityUUID]
 -- | Index by flow - find activities that use a given flow
 type FlowIndex = M.Map UUID [UUID] -- FlowID -> [ActivityUUID]
 
--- | Index by biosphere compartment - search biosphere flows by compartment name
-type CompartmentIndex = M.Map Text [UUID] -- Compartment name -> [BiosphereFlow UUID]
-
 -- | Index of exchanges by flow - find all exchanges using a flow
 type ExchangeIndex = M.Map UUID [(UUID, Exchange)] -- FlowID -> [(ActivityID, Exchange)]
 
@@ -397,8 +394,6 @@ data Indexes = Indexes
     , idxByLocation :: !LocationIndex -- Search activities by location
     , idxByFlow :: !FlowIndex -- Search activities using a flow
     , idxByUnit :: !ActivityUnitIndex -- Search activities by reference unit
-    -- Biosphere flow index by compartment (technosphere flows carry no taxonomy)
-    , idxBioByCompartment :: !CompartmentIndex
     -- Note: Exchange-level indexes removed - exchanges can be accessed directly from Activity.exchanges
     }
     deriving (Generic, NFData, Store)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -54,9 +54,28 @@ Based on EcoSpold filename pattern {activity_uuid}_{product_uuid}.spold
 -}
 type ProcessId = Int32
 
--- | Flow type: Technosphere (exchange between activities) or Biosphere (exchange with the environment)
-data FlowType = Technosphere | Biosphere
-    deriving (Eq, Ord, Show, Generic, NFData, Store)
+{- | Biosphere compartment — the natural medium a biosphere flow exchanges
+with. Present only on `BiosphereFlow`; technosphere flows have no
+compartment (their taxonomy, when meaningful, lives on the producing
+activity's `activityClassification`).
+-}
+data Compartment = Compartment
+    { compartmentName :: !Text -- air | water | soil | natural resource
+    , compartmentSub :: !(Maybe Text) -- "high. pop.", "river water", …
+    }
+    deriving (Eq, Show, Generic, NFData, Store)
+
+{- | Role of a technosphere exchange within its host activity. Names the four
+valid combinations of (input?, reference?). `ReferenceInput` is the
+treatment-process case where the activity is defined by the waste flow it
+consumes (see `activityNormFactor`).
+-}
+data TechRole
+    = ReferenceProduct -- main output of a production process
+    | Coproduct -- secondary output (by-product, avoided product)
+    | ReferenceInput -- main input of a treatment process
+    | Input -- ordinary technosphere input
+    deriving (Eq, Show, Generic, NFData, Store)
 
 -- | Unit representation (kg, MJ, m³, etc.)
 data Unit = Unit
@@ -79,17 +98,31 @@ data Substance = Substance
     }
     deriving (Eq, Show, Generic, NFData, Store)
 
--- | Flow representation (material, energy, emission, etc.)
-data Flow = Flow
-    { flowId :: !UUID -- Flow identifier
-    , flowName :: !Text -- Human-readable name
-    , flowCategory :: !Text -- Category/compartment (e.g. air, water, soil, resource)
-    , flowSubcompartment :: !(Maybe Text) -- Sub-compartment (e.g. "urban air", "river water")
-    , flowUnitId :: !UUID -- Reference to default unit in UnitDB
-    , flowType :: !FlowType -- Flow type
-    , flowSynonyms :: !(M.Map Text (S.Set Text)) -- Synonyms by language (e.g. "en" -> {"BaP", "benzo[a]pyrene"})
-    , flowCAS :: !(Maybe Text) -- CAS number for substance identification
-    , flowSubstanceId :: !(Maybe Int) -- Link to Substance in FlowMappingData
+{- | A technosphere flow — an intermediate product that activities produce and
+consume. Carries no compartment and no taxonomy: the product classification
+(when meaningful) lives on the producing activity's `activityClassification`.
+-}
+data TechnosphereFlow = TechnosphereFlow
+    { tfId :: !UUID
+    , tfName :: !Text
+    , tfUnitId :: !UUID
+    , tfSynonyms :: !(M.Map Text (S.Set Text))
+    , tfCAS :: !(Maybe Text)
+    , tfSubstanceId :: !(Maybe Int)
+    }
+    deriving (Generic, NFData, Store)
+
+{- | A biosphere flow — an environmental exchange (resource extraction or
+emission). Always carries a `Compartment` identifying the medium.
+-}
+data BiosphereFlow = BiosphereFlow
+    { bfId :: !UUID
+    , bfName :: !Text
+    , bfUnitId :: !UUID
+    , bfSynonyms :: !(M.Map Text (S.Set Text))
+    , bfCAS :: !(Maybe Text)
+    , bfSubstanceId :: !(Maybe Int)
+    , bfCompartment :: !Compartment
     }
     deriving (Generic, NFData, Store)
 
@@ -123,8 +156,7 @@ data Exchange
         { techFlowId :: !UUID -- Flow being exchanged
         , techAmount :: !Double -- Quantity exchanged
         , techUnitId :: !UUID -- Unit of measurement
-        , techIsInput :: !Bool -- True if input
-        , techIsReference :: !Bool -- True if reference product (main output)
+        , techRole :: !TechRole -- Role within the activity (Input | Coproduct | ReferenceProduct | ReferenceInput)
         , techActivityLinkId :: !UUID -- Target activity ID (backward compatibility)
         , techProcessLinkId :: !(Maybe ProcessId) -- Target process ID (new field)
         , techLocation :: !Text -- Supplier location (EcoSpold1) or "" (EcoSpold2)
@@ -156,11 +188,19 @@ exchangeUnitId TechnosphereExchange{techUnitId = uid} = uid
 exchangeUnitId BiosphereExchange{bioUnitId = uid} = uid
 
 exchangeIsInput :: Exchange -> Bool
-exchangeIsInput TechnosphereExchange{techIsInput = isInp} = isInp
+exchangeIsInput TechnosphereExchange{techRole = role} = case role of
+    Input -> True
+    ReferenceInput -> True
+    ReferenceProduct -> False
+    Coproduct -> False
 exchangeIsInput BiosphereExchange{bioIsInput = isInp} = isInp
 
 exchangeIsReference :: Exchange -> Bool
-exchangeIsReference TechnosphereExchange{techIsReference = isRef} = isRef
+exchangeIsReference TechnosphereExchange{techRole = role} = case role of
+    ReferenceProduct -> True
+    ReferenceInput -> True
+    Input -> False
+    Coproduct -> False
 exchangeIsReference BiosphereExchange{} = False -- Biosphere exchanges are never reference products
 
 -- | Get activity link ID (backward compatibility)
@@ -249,14 +289,23 @@ getUnitNameForExchange :: UnitDB -> Exchange -> Text
 getUnitNameForExchange unitDB exchange =
     maybe "unknown" unitName (getUnitForExchange unitDB exchange)
 
--- | Get unit information for a flow
-getUnitForFlow :: UnitDB -> Flow -> Maybe Unit
-getUnitForFlow unitDB flow = M.lookup (flowUnitId flow) unitDB
+-- | Get unit information for a technosphere flow
+getUnitForTechFlow :: UnitDB -> TechnosphereFlow -> Maybe Unit
+getUnitForTechFlow unitDB f = M.lookup (tfUnitId f) unitDB
 
--- | Get unit name for a flow (fallback to "unknown" if not found)
-getUnitNameForFlow :: UnitDB -> Flow -> Text
-getUnitNameForFlow unitDB flow =
-    maybe "unknown" unitName (getUnitForFlow unitDB flow)
+-- | Get unit name for a technosphere flow (fallback to "unknown" if not found)
+getUnitNameForTechFlow :: UnitDB -> TechnosphereFlow -> Text
+getUnitNameForTechFlow unitDB f =
+    maybe "unknown" unitName (getUnitForTechFlow unitDB f)
+
+-- | Get unit information for a biosphere flow
+getUnitForBioFlow :: UnitDB -> BiosphereFlow -> Maybe Unit
+getUnitForBioFlow unitDB f = M.lookup (bfUnitId f) unitDB
+
+-- | Get unit name for a biosphere flow (fallback to "unknown" if not found)
+getUnitNameForBioFlow :: UnitDB -> BiosphereFlow -> Text
+getUnitNameForBioFlow unitDB f =
+    maybe "unknown" unitName (getUnitForBioFlow unitDB f)
 
 {- | Base LCA activity
 Note: ProcessId is the index in dbActivities vector, UUIDs stored in dbProcessIdTable
@@ -284,11 +333,14 @@ data ActivityTree
 -- | Loop-aware tree for SVG export
 data LoopAwareTree
     = TreeLeaf !Activity
-    | TreeNode !Activity ![(Double, Flow, LoopAwareTree)] -- Activity + (quantity, flow, subtree)
+    | TreeNode !Activity ![(Double, TechnosphereFlow, LoopAwareTree)] -- Activity + (quantity, child product flow, subtree)
     | TreeLoop !UUID !Text !Int -- Loop reference: UUID + ActivityName + Depth
 
--- | Flow database (deduplicated)
-type FlowDB = M.Map UUID Flow
+-- | Technosphere flow database (deduplicated by UUID)
+type TechFlowDB = M.Map UUID TechnosphereFlow
+
+-- | Biosphere flow database (deduplicated by UUID)
+type BioFlowDB = M.Map UUID BiosphereFlow
 
 -- | Unit database (deduplicated)
 type UnitDB = M.Map UUID Unit
@@ -313,11 +365,8 @@ type LocationIndex = M.Map Text [UUID] -- Location -> [ActivityUUID]
 -- | Index by flow - find activities that use a given flow
 type FlowIndex = M.Map UUID [UUID] -- FlowID -> [ActivityUUID]
 
--- | Index by flow category - search by flow type
-type FlowCategoryIndex = M.Map Text [UUID] -- Category -> [FlowUUID]
-
--- | Index by flow type - separates Technosphere/Biosphere
-type FlowTypeIndex = M.Map FlowType [UUID] -- FlowType -> [FlowUUID]
+-- | Index by biosphere compartment - search biosphere flows by compartment name
+type CompartmentIndex = M.Map Text [UUID] -- Compartment name -> [BiosphereFlow UUID]
 
 -- | Index of exchanges by flow - find all exchanges using a flow
 type ExchangeIndex = M.Map UUID [(UUID, Exchange)] -- FlowID -> [(ActivityID, Exchange)]
@@ -348,9 +397,8 @@ data Indexes = Indexes
     , idxByLocation :: !LocationIndex -- Search activities by location
     , idxByFlow :: !FlowIndex -- Search activities using a flow
     , idxByUnit :: !ActivityUnitIndex -- Search activities by reference unit
-    -- Flow-level indexes
-    , idxFlowByCategory :: !FlowCategoryIndex -- Search flows by category
-    , idxFlowByType :: !FlowTypeIndex -- Search flows by type
+    -- Biosphere flow index by compartment (technosphere flows carry no taxonomy)
+    , idxBioByCompartment :: !CompartmentIndex
     -- Note: Exchange-level indexes removed - exchanges can be accessed directly from Activity.exchanges
     }
     deriving (Generic, NFData, Store)
@@ -458,14 +506,15 @@ data Database = Database
     , dbActivityProductsIndex :: !(M.Map UUID [ProcessId]) -- Activity UUID → all ProcessIds (for multi-product activities)
     , dbProductIndex :: !ProductIndex -- Product flow → ProcessId lookups (for SimaPro links & product search)
     , dbActivities :: !ActivityDB -- Vector of activities indexed by ProcessId
-    , dbFlows :: !FlowDB
+    , dbTechFlows :: !TechFlowDB -- Technosphere flows by UUID
+    , dbBioFlows :: !BioFlowDB -- Biosphere flows by UUID
     , dbUnits :: !UnitDB
     , dbIndexes :: !Indexes
     , -- Pre-computed sparse matrices for efficient LCA calculations (unboxed for memory efficiency)
       dbTechnosphereTriples :: !(VU.Vector SparseTriple) -- A matrix: activities × activities (sparse, unboxed)
     , dbBiosphereTriples :: !(VU.Vector SparseTriple) -- B matrix: biosphere flows × activities (sparse, unboxed)
     , dbActivityIndex :: !(V.Vector Int32) -- ProcessId → matrix index mapping (direct vector indexing)
-    , dbBiosphereFlows :: !(V.Vector UUID) -- Ordered vector of biosphere flow UUIDs (source of truth for indexing, strict for memory efficiency)
+    , dbBiosphereOrder :: !(V.Vector UUID) -- Ordered vector of biosphere flow UUIDs — B-matrix row order
     , dbActivityCount :: !Int32 -- Number of activities (matrix dimension)
     , dbBiosphereCount :: !Int32 -- Number of biosphere flows (matrix dimension)
     -- Cross-database linking (serialized to cache)
@@ -475,8 +524,8 @@ data Database = Database
     , dbLinkingStats :: !CrossDBLinkingStats -- Cross-DB linking statistics (completeness, fallbacks, etc.)
     -- Runtime-only fields (not serialized to cache)
     , dbSynonymDB :: !(Maybe SynonymDB) -- Embedded synonym database for flow matching
-    , dbFlowsByName :: !(M.Map Text [Flow]) -- Biosphere flow name index for LCIA matching
-    , dbFlowsByCAS :: !(M.Map Text [Flow]) -- CAS → biosphere flows for LCIA matching
+    , dbFlowsByName :: !(M.Map Text [BiosphereFlow]) -- Biosphere flow name index for LCIA matching
+    , dbFlowsByCAS :: !(M.Map Text [BiosphereFlow]) -- CAS → biosphere flows for LCIA matching
     -- Product name search index: word token → ProcessId set (built at runtime)
     , dbProductSearchIndex :: !(M.Map Text IS.IntSet)
     , -- BM25 ranking index (built at runtime, not serialized)
@@ -495,13 +544,14 @@ instance Store Database where
             + getSize (dbActivityProductsIndex db)
             + getSize (dbProductIndex db)
             + getSize (dbActivities db)
-            + getSize (dbFlows db)
+            + getSize (dbTechFlows db)
+            + getSize (dbBioFlows db)
             + getSize (dbUnits db)
             + getSize (dbIndexes db)
             + getSize (dbTechnosphereTriples db)
             + getSize (dbBiosphereTriples db)
             + getSize (dbActivityIndex db)
-            + getSize (dbBiosphereFlows db)
+            + getSize (dbBiosphereOrder db)
             + getSize (dbActivityCount db)
             + getSize (dbBiosphereCount db)
             + getSize (dbCrossDBLinks db)
@@ -515,13 +565,14 @@ instance Store Database where
         poke (dbActivityProductsIndex db)
         poke (dbProductIndex db)
         poke (dbActivities db)
-        poke (dbFlows db)
+        poke (dbTechFlows db)
+        poke (dbBioFlows db)
         poke (dbUnits db)
         poke (dbIndexes db)
         poke (dbTechnosphereTriples db)
         poke (dbBiosphereTriples db)
         poke (dbActivityIndex db)
-        poke (dbBiosphereFlows db)
+        poke (dbBiosphereOrder db)
         poke (dbActivityCount db)
         poke (dbBiosphereCount db)
         -- Cross-database linking fields
@@ -538,13 +589,14 @@ instance Store Database where
         activityProductsIndex <- peek
         productIndex <- peek
         activities <- peek
-        flows <- peek
+        techFlows <- peek
+        bioFlows <- peek
         units <- peek
         indexes <- peek
         techTriples <- peek
         bioTriples <- peek
         activityIndex <- peek
-        biosphereFlows <- peek
+        biosphereOrder <- peek
         activityCount <- peek
         biosphereCount <- peek
         crossDBLinks <- peek
@@ -558,13 +610,14 @@ instance Store Database where
                 , dbActivityProductsIndex = activityProductsIndex
                 , dbProductIndex = productIndex
                 , dbActivities = activities
-                , dbFlows = flows
+                , dbTechFlows = techFlows
+                , dbBioFlows = bioFlows
                 , dbUnits = units
                 , dbIndexes = indexes
                 , dbTechnosphereTriples = techTriples
                 , dbBiosphereTriples = bioTriples
                 , dbActivityIndex = activityIndex
-                , dbBiosphereFlows = biosphereFlows
+                , dbBiosphereOrder = biosphereOrder
                 , dbActivityCount = activityCount
                 , dbBiosphereCount = biosphereCount
                 , -- Cross-database linking fields
@@ -661,50 +714,47 @@ parseProcessId db filename = case T.splitOn "_" filename of
 addSynonymDBToDatabase :: Database -> SynonymDB -> Database
 addSynonymDBToDatabase db synDB = db{dbSynonymDB = Just synDB}
 
-{- | Build the flow name index from biosphere flows only.
-Groups flows by their normalized names for efficient LCIA lookup.
+{- | Build the biosphere flow name index. Groups flows by normalized name
+(primary + synonyms) for efficient LCIA lookup.
 -}
-buildFlowNameIndex :: FlowDB -> S.Set UUID -> M.Map Text [Flow]
-buildFlowNameIndex flowDB bioUUIDs =
-    M.fromListWith (++) $ concatMap flowEntries bioFlows
+buildFlowNameIndex :: BioFlowDB -> M.Map Text [BiosphereFlow]
+buildFlowNameIndex bioDB =
+    M.fromListWith (++) $ concatMap flowEntries (M.elems bioDB)
   where
-    bioFlows = filter (\f -> S.member (flowId f) bioUUIDs) (M.elems flowDB)
     flowEntries f =
-        let primary = normalizeName (flowName f)
+        let primary = normalizeName (bfName f)
             synKeys =
                 [ normalizeName syn
-                | syns <- M.elems (flowSynonyms f)
+                | syns <- M.elems (bfSynonyms f)
                 , syn <- S.toList syns
                 ]
          in [(k, [f]) | k <- nub (primary : synKeys)]
 
 -- | Build CAS index from biosphere flows
-buildFlowCASIndex :: FlowDB -> S.Set UUID -> M.Map Text [Flow]
-buildFlowCASIndex flowDB bioUUIDs =
+buildFlowCASIndex :: BioFlowDB -> M.Map Text [BiosphereFlow]
+buildFlowCASIndex bioDB =
     M.fromListWith
         (++)
         [ (cas, [f])
-        | f <- M.elems flowDB
-        , S.member (flowId f) bioUUIDs
-        , Just cas <- [flowCAS f]
+        | f <- M.elems bioDB
+        , Just cas <- [bfCAS f]
         , not (T.null cas)
         ]
 
 -- | Add biosphere flow indexes (name + CAS) and search index to a Database
 addFlowNameIndexToDatabase :: Database -> Database
 addFlowNameIndexToDatabase db =
-    let bioUUIDs = S.fromList (V.toList (dbBiosphereFlows db))
-     in db
-            { dbFlowsByName = buildFlowNameIndex (dbFlows db) bioUUIDs
-            , dbFlowsByCAS = buildFlowCASIndex (dbFlows db) bioUUIDs
-            , dbProductSearchIndex = buildProductSearchIndex (dbActivities db) (dbFlows db)
-            }
+    db
+        { dbFlowsByName = buildFlowNameIndex (dbBioFlows db)
+        , dbFlowsByCAS = buildFlowCASIndex (dbBioFlows db)
+        , dbProductSearchIndex = buildProductSearchIndex (dbActivities db) (dbTechFlows db)
+        }
 
 {- | Build word-token product search index: lowercased word → IntSet of ProcessIds
 Tokenizes reference product flow names so product search can use index intersection.
 -}
-buildProductSearchIndex :: V.Vector Activity -> M.Map UUID Flow -> M.Map Text IS.IntSet
-buildProductSearchIndex activities flowDb =
+buildProductSearchIndex :: V.Vector Activity -> TechFlowDB -> M.Map Text IS.IntSet
+buildProductSearchIndex activities techDB =
     V.ifoldl' addActivity M.empty activities
   where
     addActivity !acc i a =
@@ -714,11 +764,19 @@ buildProductSearchIndex activities flowDb =
                 | ex <- exchanges a
                 , exchangeIsReference ex
                 , not (exchangeIsInput ex)
-                , Just flow <- [M.lookup (exchangeFlowId ex) flowDb]
-                , w <- T.words (T.toLower (flowName flow))
+                , Just flow <- [M.lookup (exchangeFlowId ex) techDB]
+                , w <- T.words (T.toLower (tfName flow))
                 , not (T.null w)
                 ]
          in foldl' (\m w -> MS.insertWith IS.union w (IS.singleton pid) m) acc productWords
+
+-- | Lookup a technosphere flow by UUID
+lookupTechFlow :: Database -> UUID -> Maybe TechnosphereFlow
+lookupTechFlow db uuid = M.lookup uuid (dbTechFlows db)
+
+-- | Lookup a biosphere flow by UUID
+lookupBioFlow :: Database -> UUID -> Maybe BiosphereFlow
+lookupBioFlow db uuid = M.lookup uuid (dbBioFlows db)
 
 {- | Add both SynonymDB and flow name index to a Database
 Convenience function for post-load initialization
@@ -733,7 +791,8 @@ Used during database loading, before conversion to final Vector structure
 -}
 data SimpleDatabase = SimpleDatabase
     { sdbActivities :: !ActivityMap -- Temporary Map structure
-    , sdbFlows :: !FlowDB
+    , sdbTechFlows :: !TechFlowDB
+    , sdbBioFlows :: !BioFlowDB
     , sdbUnits :: !UnitDB
     }
     deriving (Generic, Store)
@@ -745,7 +804,8 @@ toSimpleDatabase :: Database -> SimpleDatabase
 toSimpleDatabase db =
     SimpleDatabase
         { sdbActivities = M.fromList $ V.toList $ V.zipWith (,) (dbProcessIdTable db) (dbActivities db)
-        , sdbFlows = dbFlows db
+        , sdbTechFlows = dbTechFlows db
+        , sdbBioFlows = dbBioFlows db
         , sdbUnits = dbUnits db
         }
 
@@ -869,7 +929,27 @@ instance FromJSON Pedigree where
 instance ToJSON Exchange where
     toJSON = genericToJSON stripLowerPrefix
     toEncoding = genericToEncoding stripLowerPrefix
-instance ToJSON FlowType
 
 instance FromJSON Exchange where
+    parseJSON = genericParseJSON stripLowerPrefix
+
+instance ToJSON TechRole
+instance FromJSON TechRole
+
+instance ToJSON Compartment where
+    toJSON = genericToJSON stripLowerPrefix
+    toEncoding = genericToEncoding stripLowerPrefix
+instance FromJSON Compartment where
+    parseJSON = genericParseJSON stripLowerPrefix
+
+instance ToJSON TechnosphereFlow where
+    toJSON = genericToJSON stripLowerPrefix
+    toEncoding = genericToEncoding stripLowerPrefix
+instance FromJSON TechnosphereFlow where
+    parseJSON = genericParseJSON stripLowerPrefix
+
+instance ToJSON BiosphereFlow where
+    toJSON = genericToJSON stripLowerPrefix
+    toEncoding = genericToEncoding stripLowerPrefix
+instance FromJSON BiosphereFlow where
     parseJSON = genericParseJSON stripLowerPrefix

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -201,7 +201,7 @@ exchangeIsReference TechnosphereExchange{techRole = role} = case role of
     ReferenceInput -> True
     Input -> False
     Coproduct -> False
-exchangeIsReference BiosphereExchange{} = False -- Biosphere exchanges are never reference products
+exchangeIsReference BiosphereExchange{} = False
 
 -- | Get activity link ID (backward compatibility)
 exchangeActivityLinkId :: Exchange -> Maybe UUID

--- a/test/BM25Spec.hs
+++ b/test/BM25Spec.hs
@@ -43,8 +43,7 @@ mkRefOutput fid =
         { techFlowId = fid
         , techAmount = 1.0
         , techUnitId = nil
-        , techIsInput = False
-        , techIsReference = True
+        , techRole = ReferenceProduct
         , techActivityLinkId = nil
         , techProcessLinkId = Nothing
         , techLocation = ""
@@ -52,18 +51,15 @@ mkRefOutput fid =
         , techPedigree = Nothing
         }
 
-mkFlow :: UUID -> Text -> Flow
+mkFlow :: UUID -> Text -> TechnosphereFlow
 mkFlow fid name =
-    Flow
-        { flowId = fid
-        , flowName = name
-        , flowCategory = ""
-        , flowSubcompartment = Nothing
-        , flowUnitId = nil
-        , flowType = Technosphere
-        , flowSynonyms = M.empty
-        , flowCAS = Nothing
-        , flowSubstanceId = Nothing
+    TechnosphereFlow
+        { tfId = fid
+        , tfName = name
+        , tfUnitId = nil
+        , tfSynonyms = M.empty
+        , tfCAS = Nothing
+        , tfSubstanceId = Nothing
         }
 
 f1 :: UUID

--- a/test/CrossDBInventorySpec.hs
+++ b/test/CrossDBInventorySpec.hs
@@ -143,27 +143,23 @@ spec = do
             unitDB = M.singleton (unitId unitKg) unitKg
 
             flowRoot =
-                Flow
+                BiosphereFlow
                     uuidRoot
                     "Methane, biogenic"
-                    "air"
-                    (Just "low. pop.")
                     (unitId unitKg)
-                    Biosphere
                     M.empty
                     Nothing
                     Nothing
+                    (Compartment "air" (Just "low. pop."))
             flowDep =
-                Flow
+                BiosphereFlow
                     uuidDep
                     "Carbon dioxide, fossil"
-                    "air"
-                    (Just "low. pop.")
                     (unitId unitKg)
-                    Biosphere
                     M.empty
                     Nothing
                     Nothing
+                    (Compartment "air" (Just "low. pop."))
 
             rootOnlyFlowDB = M.singleton uuidRoot flowRoot
             mergedFlowDB = M.fromList [(uuidRoot, flowRoot), (uuidDep, flowDep)]
@@ -198,7 +194,7 @@ spec = do
 
         it "characterizes dep-DB flows when the merged flowDB is supplied" $ do
             let (contribs, unknowns) = inventoryContributions defaultUnitConfig unitDB mergedFlowDB inventory tables
-                namesWithContrib = [(flowName f, c) | (f, _, c) <- contribs]
+                namesWithContrib = [(bfName f, c) | (f, _, c) <- contribs]
             -- uuidGone remains unknown (it's in no flowDB at all); uuidRoot and
             -- uuidDep should both produce contributions.
             unknowns `shouldBe` [uuidGone]

--- a/test/CrossDBRegionalLCIAFixture.hs
+++ b/test/CrossDBRegionalLCIAFixture.hs
@@ -112,7 +112,7 @@ mkActivity _ loc =
         }
 
 emptyIndexes :: Indexes
-emptyIndexes = Indexes M.empty M.empty M.empty M.empty M.empty
+emptyIndexes = Indexes M.empty M.empty M.empty M.empty
 
 {- | Build a synthetic single-DB fixture parameterized by:
 * @offset@: starting index for activity UUIDs (so root and dep don't collide)

--- a/test/CrossDBRegionalLCIAFixture.hs
+++ b/test/CrossDBRegionalLCIAFixture.hs
@@ -53,6 +53,7 @@ import qualified Data.Vector.Unboxed as U
 
 import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, fillBroadcastVector, fillRegionalActivityWeights)
 import Method.Types (FlowDirection (..), MethodCF (..))
+import qualified Types as VT
 import Types
 import UnitConversion (UnitConfig (..), UnitDef (..))
 
@@ -82,18 +83,16 @@ kgUnitConfig =
         , ucOriginalKeys = M.fromList [("kg", "kg")]
         }
 
-testFlow :: Flow
+testFlow :: BiosphereFlow
 testFlow =
-    Flow
-        { flowId = flowUUID
-        , flowName = "Carbon dioxide"
-        , flowCategory = "air"
-        , flowSubcompartment = Nothing
-        , flowUnitId = unitId kgUnit
-        , flowType = Biosphere
-        , flowSynonyms = M.empty
-        , flowCAS = Nothing
-        , flowSubstanceId = Nothing
+    BiosphereFlow
+        { bfId = flowUUID
+        , bfName = "Carbon dioxide"
+        , bfUnitId = unitId kgUnit
+        , bfSynonyms = M.empty
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfCompartment = VT.Compartment "air" Nothing
         }
 
 mkActivity :: Int -> Text -> Activity
@@ -113,7 +112,7 @@ mkActivity _ loc =
         }
 
 emptyIndexes :: Indexes
-emptyIndexes = Indexes M.empty M.empty M.empty M.empty M.empty M.empty
+emptyIndexes = Indexes M.empty M.empty M.empty M.empty M.empty
 
 {- | Build a synthetic single-DB fixture parameterized by:
 * @offset@: starting index for activity UUIDs (so root and dep don't collide)
@@ -141,13 +140,14 @@ mkDB offset locs bioTriples =
             , dbActivityProductsIndex = M.empty
             , dbProductIndex = emptyProductIndex
             , dbActivities = activities
-            , dbFlows = M.singleton flowUUID testFlow
+            , dbTechFlows = M.empty
+            , dbBioFlows = M.singleton flowUUID testFlow
             , dbUnits = M.singleton (unitId kgUnit) kgUnit
             , dbIndexes = emptyIndexes
             , dbTechnosphereTriples = U.empty
             , dbBiosphereTriples = triples
             , dbActivityIndex = actIdx
-            , dbBiosphereFlows = V.singleton flowUUID
+            , dbBiosphereOrder = V.singleton flowUUID
             , dbActivityCount = fromIntegral n
             , dbBiosphereCount = 1
             , dbCrossDBLinks = []
@@ -190,7 +190,7 @@ linkAt consumerDb supplierDb supplierName supIdx coeff =
                 }
      in consumerDb{dbCrossDBLinks = link : dbCrossDBLinks consumerDb}
 
-regionalMappings :: [(Text, Double)] -> [(MethodCF, Maybe (Flow, MatchStrategy))]
+regionalMappings :: [(Text, Double)] -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]
 regionalMappings = map (\(loc, v) -> (cf loc v, Just (testFlow, ByName)))
   where
     cf loc v =
@@ -205,14 +205,14 @@ regionalMappings = map (\(loc, v) -> (cf loc v, Just (testFlow, ByName)))
             , mcfConsumerLocation = Just loc
             }
 
-buildTables :: Database -> [(MethodCF, Maybe (Flow, MatchStrategy))] -> MethodTables
+buildTables :: Database -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> MethodTables
 buildTables db mappings =
     let raw = buildMethodTables M.empty mappings
-        withBroadcast = fillBroadcastVector kgUnitConfig (dbUnits db) (dbFlows db) raw
+        withBroadcast = fillBroadcastVector kgUnitConfig (dbUnits db) (dbBioFlows db) raw
      in fillRegionalActivityWeights
             kgUnitConfig
             (dbUnits db)
-            (dbFlows db)
+            (dbBioFlows db)
             db
             M.empty
             withBroadcast

--- a/test/CrossDBRegionalLCIASensitivitySpec.hs
+++ b/test/CrossDBRegionalLCIASensitivitySpec.hs
@@ -91,7 +91,7 @@ spec = describe "cross-DB regional LCIA via sensitivity propagation" $ do
                 sumRegionalizedLCIAScoreCrossDB
                     kgUnitConfig
                     (dbUnits depDb)
-                    (dbFlows depDb)
+                    (dbBioFlows depDb)
                     M.empty
                     perDb
                     `shouldBe` Right 5.0
@@ -132,7 +132,7 @@ spec = describe "cross-DB regional LCIA via sensitivity propagation" $ do
                 sumRegionalizedLCIAScoreCrossDB
                     kgUnitConfig
                     (dbUnits depDb)
-                    (dbFlows depDb)
+                    (dbBioFlows depDb)
                     M.empty
                     perDb
                     `shouldBe` Right 10.0

--- a/test/CrossDBRegionalLCIASpec.hs
+++ b/test/CrossDBRegionalLCIASpec.hs
@@ -85,7 +85,7 @@ spec = describe "cross-DB regional LCIA" $ do
                 computeRegionalizedLCIAScore
                     kgUnitConfig
                     (dbUnits rootDb)
-                    (dbFlows rootDb)
+                    (dbBioFlows rootDb)
                     rootDb
                     rootScaling
                     M.empty
@@ -120,7 +120,7 @@ spec = describe "cross-DB regional LCIA" $ do
                 sumRegionalizedLCIAScoreCrossDB
                     kgUnitConfig
                     (dbUnits depDb)
-                    (dbFlows depDb)
+                    (dbBioFlows depDb)
                     M.empty
                     perDb
                     `shouldBe` Right 5.0
@@ -167,7 +167,7 @@ spec = describe "cross-DB regional LCIA" $ do
                 sumRegionalizedLCIAScoreCrossDB
                     kgUnitConfig
                     (dbUnits depDb)
-                    (dbFlows depDb)
+                    (dbBioFlows depDb)
                     M.empty
                     perDb
                     `shouldBe` Right 0.0
@@ -209,7 +209,7 @@ spec = describe "cross-DB regional LCIA" $ do
                 sumRegionalizedLCIAScoreCrossDB
                     kgUnitConfig
                     (dbUnits depDb)
-                    (dbFlows depDb)
+                    (dbBioFlows depDb)
                     M.empty
                     perDb
                     `shouldBe` Right 0.0
@@ -262,7 +262,7 @@ spec = describe "cross-DB regional LCIA" $ do
                             MM.computeLCIAScoreFromTables
                                 kgUnitConfig
                                 (dbUnits rootDb)
-                                (dbFlows rootDb)
+                                (dbBioFlows rootDb)
                                 (SS.csInventory sol)
                                 universalTables
                     MM.loScore outcome `shouldBe` 3.0
@@ -295,7 +295,7 @@ spec = describe "cross-DB regional LCIA" $ do
                     sumRegionalizedLCIAScoreCrossDB
                         kgUnitConfig
                         (dbUnits rootStandalone)
-                        (dbFlows rootStandalone)
+                        (dbBioFlows rootStandalone)
                         M.empty
                         perDb
                         `shouldBe` Right 7.0

--- a/test/CrossDBRegionalLCIASubsSpec.hs
+++ b/test/CrossDBRegionalLCIASubsSpec.hs
@@ -54,7 +54,7 @@ spec = describe "cross-DB regional LCIA via substitution path" $ do
              in sumRegionalizedLCIAScoreCrossDB
                     kgUnitConfig
                     (dbUnits depDb)
-                    (dbFlows depDb)
+                    (dbBioFlows depDb)
                     M.empty
                     perDb
 

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -38,8 +38,7 @@ mkOutput fid amt =
         { techFlowId = fid
         , techAmount = amt
         , techUnitId = nil
-        , techIsInput = False
-        , techIsReference = False
+        , techRole = Coproduct
         , techActivityLinkId = nil
         , techProcessLinkId = Nothing
         , techLocation = ""
@@ -49,11 +48,11 @@ mkOutput fid amt =
 
 -- | A reference output exchange
 mkRefOutput :: UUID -> Double -> Exchange
-mkRefOutput fid amt = (mkOutput fid amt){techIsReference = True}
+mkRefOutput fid amt = (mkOutput fid amt){techRole = ReferenceProduct}
 
 -- | A technosphere input exchange
 mkInput :: UUID -> Double -> Exchange
-mkInput fid amt = (mkOutput fid amt){techIsInput = True}
+mkInput fid amt = (mkOutput fid amt){techRole = Input}
 
 -- | A biosphere exchange
 mkBio :: UUID -> Double -> Exchange
@@ -306,70 +305,71 @@ spec = do
         it "parses activity name from referenceFunction" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _) -> activityName act `shouldBe` "electricity production"
+                Right (act, _, _, _, _, _) -> activityName act `shouldBe` "electricity production"
 
         it "parses activity location from geography" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _) -> activityLocation act `shouldBe` "DE"
+                Right (act, _, _, _, _, _) -> activityLocation act `shouldBe` "DE"
 
         it "parses activity unit from referenceFunction" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _) -> activityUnit act `shouldBe` "kWh"
+                Right (act, _, _, _, _, _) -> activityUnit act `shouldBe` "kWh"
 
         it "parses dataset number" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (_, _, _, num, _) -> num `shouldBe` 42
+                Right (_, _, _, _, num, _) -> num `shouldBe` 42
 
         it "produces 4 exchanges" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _) -> length (exchanges act) `shouldBe` 4
+                Right (act, _, _, _, _, _) -> length (exchanges act) `shouldBe` 4
 
-        it "produces 4 flows" $
+        it "produces 4 flows (1 tech reference + 3 bio)" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (_, flows, _, _, _) -> length flows `shouldBe` 4
+                Right (_, techs, bios, _, _, _) ->
+                    (length techs + length bios) `shouldBe` 4
 
         it "marks the reference output (outputGroup 0) as isReference" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _) ->
+                Right (act, _, _, _, _, _) ->
                     length (filter exchangeIsReference (exchanges act)) `shouldBe` 1
 
         it "marks biosphere exchange (outputGroup 4) as BiosphereExchange" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _) ->
+                Right (act, _, _, _, _, _) ->
                     let bios = filter (\e -> case e of BiosphereExchange{} -> True; _ -> False) (exchanges act)
                      in length bios `shouldBe` 2 -- CO2 output + natural gas input (inputGroup 4)
         it "parses flow with CAS number" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (_, flows, _, _, _) ->
-                    let co2Flows = filter (\f -> flowName f == "Carbon dioxide, fossil") flows
+                Right (_, _, bios, _, _, _) ->
+                    let co2Flows = filter (\f -> bfName f == "Carbon dioxide, fossil") bios
                      in case co2Flows of
-                            [f] -> flowCAS f `shouldBe` Just "124-38-9"
+                            [f] -> bfCAS f `shouldBe` Just "124-38-9"
                             _ -> expectationFailure "Expected exactly one CO2 flow"
 
         it "sets activity classification from category/subCategory" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _) ->
+                Right (act, _, _, _, _, _) ->
                     M.lookup "Category" (activityClassification act) `shouldBe` Just "Energy"
 
         it "captures per-exchange generalComment as exchangeComment" $
             case parseWithXeno commentXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _) ->
+                Right (act, _, _, _, _, _) ->
                     map exchangeComment (exchanges act) `shouldBe` [Just "Global", Nothing]
 
         it "still routes referenceFunction generalComment to activity description" $
             case parseWithXeno commentXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _) ->
+                Right (act, _, _, _, _, _) ->
                     activityDescription act `shouldBe` ["Process-level note"]
 
     -- -----------------------------------------------------------------------
@@ -390,19 +390,19 @@ spec = do
             case parseAllWithXeno multiDatasetXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
                 Right results ->
-                    let names = [activityName act | Right (act, _, _, _, _) <- results]
+                    let names = [activityName act | Right (act, _, _, _, _, _) <- results]
                      in names `shouldBe` ["process A", "process B"]
 
         it "preserves dataset numbers in order" $
             case parseAllWithXeno multiDatasetXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
                 Right results ->
-                    let nums = [n | Right (_, _, _, n, _) <- results]
+                    let nums = [n | Right (_, _, _, _, n, _) <- results]
                      in nums `shouldBe` [1, 2]
 
         it "parses location from each dataset" $
             case parseAllWithXeno multiDatasetXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
                 Right results ->
-                    let locs = [activityLocation act | Right (act, _, _, _, _) <- results]
+                    let locs = [activityLocation act | Right (act, _, _, _, _, _) <- results]
                      in locs `shouldBe` ["CH", "FR"]

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -18,7 +18,7 @@ streamParseActivityAndFlowsFromFile derives a synthetic ProcessId from the
 filename and rejects names that don't match `actUUID_prodUUID`, so we copy
 the fixture into a temp path with that shape.
 -}
-withFixture :: ((Activity, [Flow], [Unit]) -> IO ()) -> IO ()
+withFixture :: ((Activity, [TechnosphereFlow], [BiosphereFlow], [Unit]) -> IO ()) -> IO ()
 withFixture k = withSystemTempDirectory "es2-spec" $ \dir -> do
     bytes <- BS.readFile "test-data/electricity-production.spold"
     let path = dir </> "12345678-1234-5678-9abc-123456789001_12345678-1234-5678-9abc-123456789002.spold"
@@ -31,7 +31,7 @@ withFixture k = withSystemTempDirectory "es2-spec" $ \dir -> do
 spec :: Spec
 spec = describe "per-exchange comments" $ do
     it "captures English <comment> on intermediateExchange and elementaryExchange" $
-        withFixture $ \(act, _, _) ->
+        withFixture $ \(act, _, _, _) ->
             map exchangeComment (exchanges act)
                 `shouldMatchList` [ Just "Coal input for electricity generation"
                                   , Just "Electricity output (reference product)"
@@ -41,10 +41,10 @@ spec = describe "per-exchange comments" $ do
 
     it "preserves all four exchanges" $
         withFixture $
-            \(act, _, _) -> length (exchanges act) `shouldBe` 4
+            \(act, _, _, _) -> length (exchanges act) `shouldBe` 4
 
     it "comments contain no &-entity artefacts" $
-        withFixture $ \(act, _, _) ->
+        withFixture $ \(act, _, _, _) ->
             let comments = [c | ex <- exchanges act, Just c <- [exchangeComment ex]]
              in all (not . T.isInfixOf "&") comments `shouldBe` True
 
@@ -55,7 +55,7 @@ spec = describe "per-exchange comments" $ do
         result <- streamParseActivityAndFlowsFromFile "test-data/sawnwood-properties_12345678-1234-5678-9abc-12345678aaaa.spold"
         case result of
             Left err -> expectationFailure $ "Parse failed: " ++ err
-            Right (act, _, _) ->
+            Right (act, _, _, _) ->
                 map exchangeComment (exchanges act)
                     `shouldMatchList` [ Nothing -- ex1 has no top-level comment, only property comments
                                       , Just "Adhesive applied during pressing" -- ex2's exchange-level comment, NOT the noisy property comment

--- a/test/HotspotSpec.hs
+++ b/test/HotspotSpec.hs
@@ -20,7 +20,7 @@ spec = do
                 Nothing -> expectationFailure "CO2 flow not found in SAMPLE.min3"
                 Just co2 -> do
                     scalingVec <- computeScalingVector db 0
-                    let cfMap = M.singleton (flowId co2) 1.0
+                    let cfMap = M.singleton (bfId co2) 1.0
                     let contribs = computeProcessLCIAContributions db scalingVec cfMap
                     let nonZero = M.filter (\v -> abs v > 1e-15) contribs
                     -- In SAMPLE.min3 only Z emits CO2 directly
@@ -33,7 +33,7 @@ spec = do
                 Nothing -> expectationFailure "CO2 flow not found in SAMPLE.min3"
                 Just co2 -> do
                     scalingVec <- computeScalingVector db 0
-                    let cfMap = M.singleton (flowId co2) 1.0
+                    let cfMap = M.singleton (bfId co2) 1.0
                     let contribs = computeProcessLCIAContributions db scalingVec cfMap
                     let total = sum (M.elems contribs)
                     withinTolerance defaultTolerance sampleMin3ExpectedCO2 total
@@ -47,7 +47,7 @@ spec = do
                 Nothing -> expectationFailure "CO2 flow not found in SAMPLE.min3"
                 Just co2 -> do
                     scalingVec <- computeScalingVector db 0
-                    let cfMap = M.singleton (flowId co2) 1.0
+                    let cfMap = M.singleton (bfId co2) 1.0
                     let nonZero =
                             M.filter (\v -> abs v > 1e-15) $
                                 computeProcessLCIAContributions db scalingVec cfMap

--- a/test/ILCDParserSpec.hs
+++ b/test/ILCDParserSpec.hs
@@ -38,8 +38,8 @@ activityWithRefExchange fid =
                 { techFlowId = fid
                 , techAmount = 1.0
                 , techUnitId = UUID.nil
-                , techIsInput = False
-                , techIsReference = True
+                , techRole = ReferenceProduct
+                
                 , techActivityLinkId = UUID.nil
                 , techProcessLinkId = Nothing
                 , techLocation = ""
@@ -70,8 +70,8 @@ activityWithInputExchange fid =
                 { techFlowId = fid
                 , techAmount = 0.5
                 , techUnitId = UUID.nil
-                , techIsInput = True
-                , techIsReference = False
+                , techRole = Input
+                
                 , techActivityLinkId = UUID.nil
                 , techProcessLinkId = Nothing
                 , techLocation = ""
@@ -115,26 +115,24 @@ spec = do
             M.lookup "ILCDCategories" (activityClassification act)
                 `shouldBe` Just "Energy/Hard coal"
 
-        it "has two flows (Coal product + CO2 elementary)" $ do
+        it "has two flows (Coal product + CO2 elementary) split across tech and bio" $ do
             Right db <- parseILCDDirectory "test-data/SAMPLE.ilcd"
-            M.size (sdbFlows db) `shouldBe` 2
+            (M.size (sdbTechFlows db) + M.size (sdbBioFlows db)) `shouldBe` 2
 
-        it "CO2 flow is Biosphere type" $ do
+        it "CO2 flow is biosphere" $ do
             Right db <- parseILCDDirectory "test-data/SAMPLE.ilcd"
             let co2uuid = read "aaaaaaaa-0000-0000-0000-000000000003"
-            fmap (\f -> flowType f == Biosphere) (M.lookup co2uuid (sdbFlows db))
-                `shouldBe` Just True
+            M.member co2uuid (sdbBioFlows db) `shouldBe` True
 
-        it "Coal flow is Technosphere type" $ do
+        it "Coal flow is technosphere" $ do
             Right db <- parseILCDDirectory "test-data/SAMPLE.ilcd"
             let coaluuid = read "aaaaaaaa-0000-0000-0000-000000000004"
-            fmap (\f -> flowType f == Technosphere) (M.lookup coaluuid (sdbFlows db))
-                `shouldBe` Just True
+            M.member coaluuid (sdbTechFlows db) `shouldBe` True
 
         it "CO2 has CAS number 124-38-9" $ do
             Right db <- parseILCDDirectory "test-data/SAMPLE.ilcd"
             let co2uuid = read "aaaaaaaa-0000-0000-0000-000000000003"
-            fmap flowCAS (M.lookup co2uuid (sdbFlows db)) `shouldBe` Just (Just "124-38-9")
+            fmap bfCAS (M.lookup co2uuid (sdbBioFlows db)) `shouldBe` Just (Just "124-38-9")
 
         it "activity has two exchanges" $ do
             Right db <- parseILCDDirectory "test-data/SAMPLE.ilcd"
@@ -233,9 +231,9 @@ spec = do
                 act = activityWithRefExchange flowUUID1
                 fixed = fixActivityExchanges idx act
             case exchanges fixed of
-                [TechnosphereExchange{techFlowId = fid, techIsReference = isRef}] -> do
+                [TechnosphereExchange{techFlowId = fid, techRole = role}] -> do
                     fid `shouldBe` flowUUID1 -- unchanged
-                    isRef `shouldBe` True
+                    role `shouldBe` ReferenceProduct
                 _ -> expectationFailure "expected one TechnosphereExchange"
 
     -- -----------------------------------------------------------------------

--- a/test/ILCDParserSpec.hs
+++ b/test/ILCDParserSpec.hs
@@ -39,7 +39,6 @@ activityWithRefExchange fid =
                 , techAmount = 1.0
                 , techUnitId = UUID.nil
                 , techRole = ReferenceProduct
-                
                 , techActivityLinkId = UUID.nil
                 , techProcessLinkId = Nothing
                 , techLocation = ""
@@ -71,7 +70,6 @@ activityWithInputExchange fid =
                 , techAmount = 0.5
                 , techUnitId = UUID.nil
                 , techRole = Input
-                
                 , techActivityLinkId = UUID.nil
                 , techProcessLinkId = Nothing
                 , techLocation = ""

--- a/test/InventorySpec.hs
+++ b/test/InventorySpec.hs
@@ -28,8 +28,8 @@ spec = do
 
             case (co2Flow, zincFlow) of
                 (Just co2, Just zinc) -> do
-                    let co2Amount = M.findWithDefault 0.0 (flowId co2) inventory
-                    let zincAmount = M.findWithDefault 0.0 (flowId zinc) inventory
+                    let co2Amount = M.findWithDefault 0.0 (bfId co2) inventory
+                    let zincAmount = M.findWithDefault 0.0 (bfId zinc) inventory
 
                     -- Golden values: CO2 = 0.96 kg, Zinc = 0.00072 kg
                     withinTolerance defaultTolerance sampleMin3ExpectedCO2 co2Amount

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -21,18 +21,15 @@ flowUUID1 = read "aaaaaaaa-0000-0000-0000-000000000001"
 flowUUID2 = read "bbbbbbbb-0000-0000-0000-000000000002"
 actUUID1 = read "cccccccc-0000-0000-0000-000000000001"
 
-minimalFlow :: UUID.UUID -> Text -> Flow
+minimalFlow :: UUID.UUID -> Text -> TechnosphereFlow
 minimalFlow fid name =
-    Flow
-        { flowId = fid
-        , flowName = name
-        , flowCategory = ""
-        , flowSubcompartment = Nothing
-        , flowUnitId = UUID.nil
-        , flowType = Technosphere
-        , flowSynonyms = M.empty
-        , flowCAS = Nothing
-        , flowSubstanceId = Nothing
+    TechnosphereFlow
+        { tfId = fid
+        , tfName = name
+        , tfUnitId = UUID.nil
+        , tfSynonyms = M.empty
+        , tfCAS = Nothing
+        , tfSubstanceId = Nothing
         }
 
 minimalActivity :: Text -> Text -> [Exchange] -> Activity
@@ -57,8 +54,7 @@ refExchange fid =
         { techFlowId = fid
         , techAmount = 1.0
         , techUnitId = UUID.nil
-        , techIsInput = False
-        , techIsReference = True
+        , techRole = ReferenceProduct
         , techActivityLinkId = UUID.nil
         , techProcessLinkId = Nothing
         , techLocation = "GLO"
@@ -72,8 +68,7 @@ inputExchange fid loc =
         { techFlowId = fid
         , techAmount = 0.5
         , techUnitId = UUID.nil
-        , techIsInput = True
-        , techIsReference = False
+        , techRole = Input
         , techActivityLinkId = UUID.nil
         , techProcessLinkId = Nothing
         , techLocation = loc
@@ -99,19 +94,19 @@ spec = do
             normalizeText "" `shouldBe` ""
 
     -- -----------------------------------------------------------------------
-    -- mergeFlows
+    -- mergeTechFlows
     -- -----------------------------------------------------------------------
-    describe "mergeFlows" $ do
+    describe "mergeTechFlows" $ do
         it "unions synonyms from both flows" $ do
-            let a = (minimalFlow flowUUID1 "CO2"){flowSynonyms = M.singleton "en" (S.fromList ["carbon dioxide"])}
-                b = (minimalFlow flowUUID1 "CO2"){flowSynonyms = M.singleton "en" (S.fromList ["CO2"])}
-                merged = mergeFlows a b
-            M.lookup "en" (flowSynonyms merged) `shouldBe` Just (S.fromList ["carbon dioxide", "CO2"])
+            let a = (minimalFlow flowUUID1 "CO2"){tfSynonyms = M.singleton "en" (S.fromList ["carbon dioxide"])}
+                b = (minimalFlow flowUUID1 "CO2"){tfSynonyms = M.singleton "en" (S.fromList ["CO2"])}
+                merged = mergeTechFlows a b
+            M.lookup "en" (tfSynonyms merged) `shouldBe` Just (S.fromList ["carbon dioxide", "CO2"])
 
         it "keeps all other fields from the first flow" $ do
             let a = minimalFlow flowUUID1 "flow-a"
                 b = minimalFlow flowUUID2 "flow-b"
-            flowName (mergeFlows a b) `shouldBe` "flow-a"
+            tfName (mergeTechFlows a b) `shouldBe` "flow-a"
 
     -- -----------------------------------------------------------------------
     -- generateActivityUUIDFromActivity

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -293,3 +293,45 @@ spec = do
             db <- loadSampleDatabase "SAMPLE.min3"
             let sdb = Types.toSimpleDatabase db
             M.null (collectUnlinkedProductNames sdb) `shouldBe` True
+
+    -- ---------------------------------------------------------------------
+    -- activityNormFactor — exercises every TechRole branch so the
+    -- treatment-process (ReferenceInput) case can't silently regress to
+    -- the "no reference output" 1.0 fallback.
+    -- ---------------------------------------------------------------------
+    describe "activityNormFactor" $ do
+        let actUUID = actUUID1
+            prodUUID = flowUUID1
+            wasteUUID = flowUUID2
+            withRole role amt fid =
+                TechnosphereExchange
+                    { techFlowId = fid
+                    , techAmount = amt
+                    , techUnitId = UUID.nil
+                    , techRole = role
+                    , techActivityLinkId = UUID.nil
+                    , techProcessLinkId = Nothing
+                    , techLocation = ""
+                    , techComment = Nothing
+                    , techPedigree = Nothing
+                    }
+        it "returns the reference output amount for a normal producer" $ do
+            let act = minimalActivity "producer" "GLO" [withRole ReferenceProduct 3.0 prodUUID]
+            activityNormFactor act (actUUID, prodUUID) `shouldBe` 3.0
+
+        it "returns abs(reference-input amount) for a treatment process" $ do
+            -- ReferenceInput is the only role that drives the refInputs fallback;
+            -- SimaPro waste-treatment processes encode a negative amount.
+            let act = minimalActivity "incineration" "GLO" [withRole ReferenceInput (-2.5) wasteUUID]
+            activityNormFactor act (actUUID, wasteUUID) `shouldBe` 2.5
+
+        it "falls back to 1.0 when no reference exchange is present" $ do
+            let act = minimalActivity "empty" "GLO" [withRole Input 1.0 wasteUUID]
+            activityNormFactor act (actUUID, prodUUID) `shouldBe` 1.0
+
+        it "subtracts self-loop consumption from the reference output" $ do
+            let selfInput =
+                    (withRole Input 0.2 prodUUID){techActivityLinkId = actUUID}
+                refOut = withRole ReferenceProduct 1.0 prodUUID
+                act = minimalActivity "self-looper" "GLO" [refOut, selfInput]
+            activityNormFactor act (actUUID, prodUUID) `shouldBe` 0.8

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -13,25 +13,24 @@ import Method.ChemSynonyms (emptyChemSynonyms, parseChemSynonymsCSV)
 import Method.Mapping
 import Method.Types (Compartment (..), FlowDirection (..), Method (..), MethodCF (..))
 import SynonymDB (buildFromPairs, emptySynonymDB)
-import Types (Flow (..), FlowType (..), Unit (..))
+import qualified Types as VT
+import Types (BiosphereFlow (..), Unit (..))
 import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig)
 
 -- ---------------------------------------------------------------------------
 -- Helpers
 -- ---------------------------------------------------------------------------
 
-mkFlow :: UUID -> Text -> Text -> Maybe Text -> Flow
+mkFlow :: UUID -> Text -> Text -> Maybe Text -> BiosphereFlow
 mkFlow fid name cat msub =
-    Flow
-        { flowId = fid
-        , flowName = name
-        , flowCategory = cat
-        , flowSubcompartment = msub
-        , flowUnitId = nil
-        , flowType = Biosphere
-        , flowSynonyms = M.empty
-        , flowCAS = Nothing
-        , flowSubstanceId = Nothing
+    BiosphereFlow
+        { bfId = fid
+        , bfName = name
+        , bfUnitId = nil
+        , bfSynonyms = M.empty
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfCompartment = VT.Compartment cat msub
         }
 
 mkCF :: Text -> Maybe Text -> Double -> MethodCF
@@ -88,15 +87,15 @@ spec = do
             fid <- nextRandom
             let flow = mkFlow fid "CO2" "air" Nothing
                 db = M.singleton fid flow
-            fmap flowId (findFlowByUUID db fid) `shouldBe` Just fid
+            fmap bfId (findFlowByUUID db fid) `shouldBe` Just fid
 
         it "returns Nothing for unknown UUID" $ do
             fid <- nextRandom
-            fmap flowId (findFlowByUUID M.empty fid) `shouldBe` Nothing
+            fmap bfId (findFlowByUUID M.empty fid) `shouldBe` Nothing
 
     describe "pickByCompartment (via findFlowByNameComp)" $ do
         it "returns Nothing for empty candidate list" $
-            fmap flowId (findFlowByNameComp M.empty "co2" Nothing) `shouldBe` Nothing
+            fmap bfId (findFlowByNameComp M.empty "co2" Nothing) `shouldBe` Nothing
 
         it "returns first flow when no compartment preference" $ do
             fid1 <- nextRandom
@@ -104,7 +103,7 @@ spec = do
             let f1 = mkFlow fid1 "co2" "air" Nothing
                 f2 = mkFlow fid2 "co2" "water" Nothing
                 byName = M.singleton "co2" [f1, f2]
-            fmap flowId (findFlowByNameComp byName "co2" Nothing) `shouldBe` Just fid1
+            fmap bfId (findFlowByNameComp byName "co2" Nothing) `shouldBe` Just fid1
 
         it "prefers exact medium+subcomp match" $ do
             fid1 <- nextRandom
@@ -113,7 +112,7 @@ spec = do
                 fWater = mkFlow fid2 "co2" "water" (Just "surface water")
                 byName = M.singleton "co2" [fWater, fAir]
                 comp = Compartment "air" "urban air" ""
-            fmap flowId (findFlowByNameComp byName "co2" (Just comp)) `shouldBe` Just fid1
+            fmap bfId (findFlowByNameComp byName "co2" (Just comp)) `shouldBe` Just fid1
 
         it "falls back to medium match when no exact subcomp" $ do
             fid1 <- nextRandom
@@ -122,41 +121,41 @@ spec = do
                 fWater = mkFlow fid2 "co2" "water" Nothing
                 byName = M.singleton "co2" [fWater, fAir]
                 comp = Compartment "air" "unspecified" ""
-            fmap flowId (findFlowByNameComp byName "co2" (Just comp)) `shouldBe` Just fid1
+            fmap bfId (findFlowByNameComp byName "co2" (Just comp)) `shouldBe` Just fid1
 
         it "falls back to first candidate when no medium matches" $ do
             fid1 <- nextRandom
             let fWater = mkFlow fid1 "co2" "water" Nothing
                 byName = M.singleton "co2" [fWater]
                 comp = Compartment "air" "" ""
-            fmap flowId (findFlowByNameComp byName "co2" (Just comp)) `shouldBe` Just fid1
+            fmap bfId (findFlowByNameComp byName "co2" (Just comp)) `shouldBe` Just fid1
 
     describe "findFlowByCAS" $ do
         it "finds flow by CAS number" $ do
             fid <- nextRandom
             let flow = mkFlow fid "Carbon dioxide" "air" Nothing
                 byCAS = M.singleton "124-38-9" [flow]
-            fmap flowId (findFlowByCAS byCAS "124-38-9" Nothing) `shouldBe` Just fid
+            fmap bfId (findFlowByCAS byCAS "124-38-9" Nothing) `shouldBe` Just fid
 
         it "returns Nothing for unknown CAS" $
-            fmap flowId (findFlowByCAS M.empty "000-00-0" Nothing) `shouldBe` Nothing
+            fmap bfId (findFlowByCAS M.empty "000-00-0" Nothing) `shouldBe` Nothing
 
     describe "findFlowByName" $ do
         it "finds a flow by name (case-insensitive via normalization)" $ do
             fid <- nextRandom
             let flow = mkFlow fid "Carbon dioxide" "air" Nothing
                 byName = M.singleton "carbon dioxide" [flow]
-            fmap flowId (findFlowByName byName "Carbon dioxide") `shouldBe` Just fid
+            fmap bfId (findFlowByName byName "Carbon dioxide") `shouldBe` Just fid
 
         it "returns Nothing for unknown name" $
-            fmap flowId (findFlowByName M.empty "co2") `shouldBe` Nothing
+            fmap bfId (findFlowByName M.empty "co2") `shouldBe` Nothing
 
     describe "findFlowBySynonym" $ do
         it "returns Nothing when synonym not in DB" $ do
             fid <- nextRandom
             let flow = mkFlow fid "Carbon dioxide" "air" Nothing
                 byName = M.singleton "carbon dioxide" [flow]
-            fmap flowId (findFlowBySynonym emptySynonymDB byName "CO2") `shouldBe` Nothing
+            fmap bfId (findFlowBySynonym emptySynonymDB byName "CO2") `shouldBe` Nothing
 
     describe "findFlowBySynonymComp" $ do
         it "finds flow via synonym with compartment preference" $ do
@@ -167,7 +166,7 @@ spec = do
                 fWater = mkFlow fid2 "Carbon dioxide" "water" Nothing
                 byName = M.singleton "carbon dioxide" [fWater, fAir]
                 comp = Compartment "air" "" ""
-            fmap flowId (findFlowBySynonymComp synDB byName "CO2" (Just comp))
+            fmap bfId (findFlowBySynonymComp synDB byName "CO2" (Just comp))
                 `shouldBe` Just fid1
 
         it "returns Nothing when synonym not in DB" $ do
@@ -175,12 +174,12 @@ spec = do
             let synDB = buildFromPairs [("CO2", "Carbon dioxide")]
                 flow = mkFlow fid "Carbon dioxide" "air" Nothing
                 byName = M.singleton "carbon dioxide" [flow]
-            fmap flowId (findFlowBySynonymComp synDB byName "methane" Nothing)
+            fmap bfId (findFlowBySynonymComp synDB byName "methane" Nothing)
                 `shouldBe` Nothing
 
         it "returns Nothing when no flows match any synonym" $ do
             let synDB = buildFromPairs [("CO2", "Carbon dioxide")]
-            fmap flowId (findFlowBySynonymComp synDB M.empty "CO2" Nothing)
+            fmap bfId (findFlowBySynonymComp synDB M.empty "CO2" Nothing)
                 `shouldBe` Nothing
 
     describe "computeMappingStats" $ do
@@ -405,7 +404,7 @@ spec = do
             let synDB = buildFromPairs [("co2", "carbon dioxide")]
                 flow = mkFlow fid "carbon dioxide" "air" Nothing
                 byName = M.singleton "carbon dioxide" [flow]
-            fmap flowId (findFlowBySynonym synDB byName "co2")
+            fmap bfId (findFlowBySynonym synDB byName "co2")
                 `shouldBe` Just fid
 
     describe "pickByCompartment (matchMedium edge cases)" $ do
@@ -414,7 +413,7 @@ spec = do
             let flow = mkFlow fid "co2" "water" Nothing
                 byName = M.singleton "co2" [flow]
                 comp = Compartment "" "" ""
-            fmap flowId (findFlowByNameComp byName "co2" (Just comp)) `shouldBe` Just fid
+            fmap bfId (findFlowByNameComp byName "co2" (Just comp)) `shouldBe` Just fid
 
         it "medium isInfixOf category matches (air in urban air)" $ do
             fid1 <- nextRandom
@@ -423,7 +422,7 @@ spec = do
                 fWater = mkFlow fid2 "nox" "water" Nothing
                 byName = M.singleton "nox" [fWater, fUrbanAir]
                 comp = Compartment "air" "urban" ""
-            fmap flowId (findFlowByNameComp byName "nox" (Just comp)) `shouldBe` Just fid1
+            fmap bfId (findFlowByNameComp byName "nox" (Just comp)) `shouldBe` Just fid1
 
     describe "fillBroadcastVector + computeLCIAScoreFromTables (Phase 1)" $ do
         let mkUnit uid name = Unit{unitId = uid, unitName = name, unitSymbol = name, unitComment = ""}
@@ -431,7 +430,7 @@ spec = do
         it "scoring with empty broadcast equals scoring with filled broadcast (UUID match)" $ do
             fid <- nextRandom
             uidKg <- nextRandom
-            let flow = (mkFlow fid "co2" "air" Nothing){flowUnitId = uidKg}
+            let flow = (mkFlow fid "co2" "air" Nothing){bfUnitId = uidKg}
                 cf = (mkCF "co2" Nothing 2.5){mcfUnit = "kg"}
                 rawTables = buildMethodTables M.empty [(cf, Just (flow, ByUUID))]
                 flowDB = M.singleton fid flow
@@ -458,7 +457,7 @@ spec = do
                         }
             fid <- nextRandom
             uidKg <- nextRandom
-            let flow = (mkFlow fid "co2" "air" Nothing){flowUnitId = uidKg}
+            let flow = (mkFlow fid "co2" "air" Nothing){bfUnitId = uidKg}
                 cf = (mkCF "co2" Nothing 1.0e-3){mcfUnit = "g"}
                 tables0 = buildMethodTables M.empty [(cf, Just (flow, ByUUID))]
                 flowDB = M.singleton fid flow
@@ -477,7 +476,7 @@ spec = do
         it "broadcast covers exact (name, medium, subcomp) cascade" $ do
             fid <- nextRandom
             uidKg <- nextRandom
-            let flow = (mkFlow fid "co2" "air" (Just "high pop")){flowUnitId = uidKg}
+            let flow = (mkFlow fid "co2" "air" (Just "high pop")){bfUnitId = uidKg}
                 cf = (mkCFComp "co2" "air" "high pop" 3.0){mcfUnit = "kg"}
                 tables0 = buildMethodTables M.empty [(cf, Just (flow, ByName))]
                 flowDB = M.singleton fid flow
@@ -493,7 +492,7 @@ spec = do
             fid <- nextRandom
             uidKg <- nextRandom
             -- Flow has subcomp "high pop", but CF only has medium-level entry (subcomp "")
-            let flow = (mkFlow fid "co2" "air" (Just "high pop")){flowUnitId = uidKg}
+            let flow = (mkFlow fid "co2" "air" (Just "high pop")){bfUnitId = uidKg}
                 cf = (mkCFComp "co2" "air" "" 5.0){mcfUnit = "kg"}
                 tables0 = buildMethodTables M.empty [(cf, Just (flow, ByName))]
                 flowDB = M.singleton fid flow
@@ -509,7 +508,7 @@ spec = do
             fidLocal <- nextRandom
             fidExtra <- nextRandom -- in inventory but NOT in flowDB at fill time
             uidKg <- nextRandom
-            let flowLocal = (mkFlow fidLocal "co2" "air" Nothing){flowUnitId = uidKg}
+            let flowLocal = (mkFlow fidLocal "co2" "air" Nothing){bfUnitId = uidKg}
                 cf = (mkCF "co2" Nothing 1.5){mcfUnit = "kg"}
                 tables0 = buildMethodTables M.empty [(cf, Just (flowLocal, ByUUID))]
                 flowDBAtBuild = M.singleton fidLocal flowLocal
@@ -537,7 +536,7 @@ spec = do
 
         it "returns no candidates from an empty method" $ do
             fid <- nextRandom
-            let flow = (mkFlow fid "Carbon dioxide" "air" Nothing){flowCAS = Nothing}
+            let flow = (mkFlow fid "Carbon dioxide" "air" Nothing){bfCAS = Nothing}
                 idx = buildMethodIndex (mkMethod [])
             findSimilarCFs emptyChemSynonyms idx flow 3 `shouldBe` []
 
@@ -550,7 +549,7 @@ spec = do
                 co2 = (mkCFComp "CO2" "air" "" 1.0){mcfCompartment = airComp}
                 ch4 = (mkCFComp "Methane" "air" "" 27.0){mcfCompartment = airComp}
                 idx = buildMethodIndex (mkMethod [co2, ch4])
-                flow = (mkFlow fid "Carbon dioxide" "air" Nothing){flowCAS = Nothing}
+                flow = (mkFlow fid "Carbon dioxide" "air" Nothing){bfCAS = Nothing}
                 cands = findSimilarCFs syns idx flow 3
             -- The CO2 candidate must be present, with the synonym-expansion reason.
             let names = map scfMethodFlowName cands
@@ -569,7 +568,7 @@ spec = do
                 idx = buildMethodIndex (mkMethod [oddName])
                 flow =
                     (mkFlow fid "Random unrelated text" "air" Nothing)
-                        { flowCAS = Just "124-38-9"
+                        { bfCAS = Just "124-38-9"
                         }
                 cands = findSimilarCFs emptyChemSynonyms idx flow 3
             map scfReason cands `shouldBe` [SimByCASBridge]

--- a/test/MatrixConstructionSpec.hs
+++ b/test/MatrixConstructionSpec.hs
@@ -137,8 +137,7 @@ spec = do
                         { techFlowId = prodUUID
                         , techAmount = normFactor
                         , techUnitId = jUnitId
-                        , techIsInput = False
-                        , techIsReference = True
+                        , techRole = ReferenceProduct
                         , techActivityLinkId = UUID.nil
                         , techProcessLinkId = Nothing
                         , techLocation = ""
@@ -170,24 +169,15 @@ spec = do
                         , activityAllocationFormula = Nothing
                         }
                 activityMap = M.singleton (actUUID, prodUUID) activity
-                flowDB =
-                    M.fromList
-                        [
-                            ( prodUUID
-                            , Flow prodUUID "energy product" "energy" Nothing jUnitId Technosphere M.empty Nothing Nothing
-                            )
-                        ,
-                            ( bioFlowUUID
-                            , Flow bioFlowUUID "trace pollutant" "air" Nothing kgUnitId Biosphere M.empty Nothing Nothing
-                            )
-                        ]
+                techFlowDB = M.singleton prodUUID (TechnosphereFlow prodUUID "energy product" jUnitId M.empty Nothing Nothing)
+                bioFlowDB = M.singleton bioFlowUUID (BiosphereFlow bioFlowUUID "trace pollutant" kgUnitId M.empty Nothing Nothing (Compartment "air" Nothing))
                 unitDB =
                     M.fromList
                         [ (jUnitId, Unit jUnitId "j" "j" "")
                         , (kgUnitId, Unit kgUnitId "kg" "kg" "")
                         ]
 
-            result <- buildDatabaseWithMatrices defaultUnitConfig activityMap flowDB unitDB
+            result <- buildDatabaseWithMatrices defaultUnitConfig activityMap techFlowDB bioFlowDB unitDB
             case result of
                 Left err -> expectationFailure $ "buildDatabaseWithMatrices failed: " <> T.unpack err
                 Right db -> do
@@ -217,8 +207,7 @@ spec = do
                         { techFlowId = prodUUID
                         , techAmount = 1.0
                         , techUnitId = jUnitId
-                        , techIsInput = False
-                        , techIsReference = True
+                        , techRole = ReferenceProduct
                         , techActivityLinkId = UUID.nil
                         , techProcessLinkId = Nothing
                         , techLocation = ""
@@ -250,24 +239,15 @@ spec = do
                         , activityAllocationFormula = Nothing
                         }
                 activityMap = M.singleton (actUUID, prodUUID) activity
-                flowDB =
-                    M.fromList
-                        [
-                            ( prodUUID
-                            , Flow prodUUID "energy product" "energy" Nothing jUnitId Technosphere M.empty Nothing Nothing
-                            )
-                        ,
-                            ( bioFlowUUID
-                            , Flow bioFlowUUID "trace pollutant" "air" Nothing kgUnitId Biosphere M.empty Nothing Nothing
-                            )
-                        ]
+                techFlowDB = M.singleton prodUUID (TechnosphereFlow prodUUID "energy product" jUnitId M.empty Nothing Nothing)
+                bioFlowDB = M.singleton bioFlowUUID (BiosphereFlow bioFlowUUID "trace pollutant" kgUnitId M.empty Nothing Nothing (Compartment "air" Nothing))
                 unitDB =
                     M.fromList
                         [ (jUnitId, Unit jUnitId "j" "j" "")
                         , (kgUnitId, Unit kgUnitId "kg" "kg" "")
                         ]
 
-            result <- buildDatabaseWithMatrices defaultUnitConfig activityMap flowDB unitDB
+            result <- buildDatabaseWithMatrices defaultUnitConfig activityMap techFlowDB bioFlowDB unitDB
             case result of
                 Left err -> expectationFailure $ "buildDatabaseWithMatrices failed: " <> T.unpack err
                 Right db ->

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -22,9 +22,10 @@ import Test.Hspec
 
 import Matrix (Inventory)
 import Method.Mapping
-import Method.Types (Compartment (..), Method (..), MethodCF (..))
 import qualified Method.Types as MT
-import Types (Database, Flow (..), FlowType (..), Unit (..))
+import Method.Types (Compartment (..), Method (..), MethodCF (..))
+import qualified Types as VT
+import Types (BiosphereFlow (..), Database, Unit (..))
 import qualified UnitConversion
 
 -- ---------------------------------------------------------------------------
@@ -37,18 +38,16 @@ mkUuid n = UUID.fromWords (fromIntegral n) 0 0 0
 mkUnit :: UUID -> Text -> Unit
 mkUnit uid name = Unit{unitId = uid, unitName = name, unitSymbol = name, unitComment = ""}
 
-mkFlow :: UUID -> Text -> UUID -> Flow
+mkFlow :: UUID -> Text -> UUID -> BiosphereFlow
 mkFlow fid name uId =
-    Flow
-        { flowId = fid
-        , flowName = name
-        , flowCategory = "air"
-        , flowSubcompartment = Nothing
-        , flowUnitId = uId
-        , flowType = Biosphere
-        , flowSynonyms = M.empty
-        , flowCAS = Nothing
-        , flowSubstanceId = Nothing
+    BiosphereFlow
+        { bfId = fid
+        , bfName = name
+        , bfUnitId = uId
+        , bfSynonyms = M.empty
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfCompartment = VT.Compartment "air" Nothing
         }
 
 mkCF :: UUID -> Double -> MethodCF
@@ -370,13 +369,11 @@ spec = do
                 uidKg = mkUuid 200
                 flowUns =
                     (mkFlow fidUns "water" uidKg)
-                        { flowCategory = "water"
-                        , flowSubcompartment = Just "(unspecified)"
+                        { bfCompartment = VT.Compartment "water" (Just "(unspecified)")
                         }
                 flowOcean =
                     (mkFlow fidOcean "water" uidKg)
-                        { flowCategory = "water"
-                        , flowSubcompartment = Just "ocean"
+                        { bfCompartment = VT.Compartment "water" (Just "ocean")
                         }
                 cfUns =
                     (mkCF fidUns 3.0)
@@ -416,8 +413,7 @@ spec = do
                 uidKg = mkUuid 200
                 flowOcean =
                     (mkFlow fid "water" uidKg)
-                        { flowCategory = "water"
-                        , flowSubcompartment = Just "ocean"
+                        { bfCompartment = VT.Compartment "water" (Just "ocean")
                         }
                 cfEmpty =
                     (mkCF fid 2.0)
@@ -442,7 +438,7 @@ spec = do
                 uidKg = mkUuid 200
                 flowAny =
                     (mkFlow fid "water" uidKg)
-                        { flowSubcompartment = Just "groundwater, long-term"
+                        { bfCompartment = VT.Compartment "air" (Just "groundwater, long-term")
                         }
                 cf =
                     (mkCF fid 4.0)

--- a/test/MethodSpec.hs
+++ b/test/MethodSpec.hs
@@ -20,7 +20,8 @@ import Method.ParserNW (parseNormWeightCSVBytes)
 import Method.ParserSimaPro (isSimaProMethodCSV, parseSimaProMethodCSVBytes)
 import Method.Types
 import SynonymDB
-import Types (Flow (..), FlowType (..))
+import qualified Types as VT
+import Types (BiosphereFlow (..))
 import UnitConversion (defaultUnitConfig)
 
 spec :: Spec
@@ -970,17 +971,15 @@ toCRLF = BL.toStrict . BL.intercalate "\r\n" . BL.split 0x0A . BL.fromStrict
 withBOM :: BS.ByteString -> BS.ByteString
 withBOM = BS.append "\xEF\xBB\xBF"
 
--- Helper to create a test Flow
-mkTestFlow :: UUID.UUID -> T.Text -> Flow
+-- Helper to create a test biosphere flow
+mkTestFlow :: UUID.UUID -> T.Text -> BiosphereFlow
 mkTestFlow uuid name =
-    Flow
-        { flowId = uuid
-        , flowName = name
-        , flowUnitId = UUID.nil
-        , flowType = Biosphere
-        , flowCategory = "air"
-        , flowSubcompartment = Nothing
-        , flowCAS = Nothing
-        , flowSubstanceId = Nothing
-        , flowSynonyms = M.empty
+    BiosphereFlow
+        { bfId = uuid
+        , bfName = name
+        , bfUnitId = UUID.nil
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfSynonyms = M.empty
+        , bfCompartment = VT.Compartment "air" Nothing
         }

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -52,10 +52,10 @@ spec = do
         it "parses compartments without truncation" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
 
-            -- Check that compartments are parsed fully
-            let flows = M.elems (dbFlows db)
-            let categoriesNotEmpty = filter (\f -> not $ T.null $ flowCategory f) flows
-            length categoriesNotEmpty `shouldSatisfy` (>= 0)
+            -- Biosphere flows now carry a structured compartment; technosphere flows have none.
+            let bios = M.elems (dbBioFlows db)
+            let compartmentsNotEmpty = filter (\f -> not (T.null (compartmentName (bfCompartment f)))) bios
+            length compartmentsNotEmpty `shouldSatisfy` (>= 0)
 
     describe "EcoSpold Parser - SAMPLE.min (Self-Loops)" $ do
         it "parses circular dependencies" $ do
@@ -77,17 +77,17 @@ spec = do
         it "deduplicates flows correctly" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
 
-            let flowCount = M.size (dbFlows db)
+            let totalFlows = M.size (dbTechFlows db) + M.size (dbBioFlows db)
             -- SAMPLE.min3 should have exactly 2 unique flows (CO2, Zinc)
-            flowCount `shouldSatisfy` (>= 2)
+            totalFlows `shouldSatisfy` (>= 2)
 
         it "stores flow metadata" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
 
-            let flows = M.elems (dbFlows db)
-            -- All flows should have names
-            let flowsWithNames = filter (\f -> not $ T.null $ flowName f) flows
-            length flowsWithNames `shouldBe` length flows
+            let techNamed = length (filter (not . T.null . tfName) (M.elems (dbTechFlows db)))
+                bioNamed = length (filter (not . T.null . bfName) (M.elems (dbBioFlows db)))
+                total = M.size (dbTechFlows db) + M.size (dbBioFlows db)
+            (techNamed + bioNamed) `shouldBe` total
 
     describe "EcoSpold2 Parser - Classifications" $ do
         it "parses classifications from EcoSpold2" $ do

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -23,11 +23,11 @@ import Method.Types (
     FlowDirection (..),
     MethodCF (..),
  )
+import qualified Types as VT
 import Types (
     Activity (..),
+    BiosphereFlow (..),
     Database (..),
-    Flow (..),
-    FlowType (..),
     Indexes (..),
     SparseTriple (..),
     Unit (..),
@@ -65,18 +65,16 @@ kgUnitConfig =
         , ucOriginalKeys = M.fromList [("kg", "kg")]
         }
 
-testFlow :: Flow
+testFlow :: BiosphereFlow
 testFlow =
-    Flow
-        { flowId = flowUUID
-        , flowName = "Carbon dioxide"
-        , flowCategory = "air"
-        , flowSubcompartment = Nothing
-        , flowUnitId = unitId kgUnit
-        , flowType = Biosphere
-        , flowSynonyms = M.empty
-        , flowCAS = Nothing
-        , flowSubstanceId = Nothing
+    BiosphereFlow
+        { bfId = flowUUID
+        , bfName = "Carbon dioxide"
+        , bfUnitId = unitId kgUnit
+        , bfSynonyms = M.empty
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfCompartment = VT.Compartment "air" Nothing
         }
 
 mkActivity :: Text -> Activity
@@ -106,7 +104,7 @@ mkDB locsAndEmissions =
         activities = V.fromList [mkActivity loc | (loc, _) <- locsAndEmissions]
         actIdx = V.fromList [fromIntegral i :: Int32 | i <- [0 .. n - 1]]
         triples = mkTriples [(i, v) | (i, (_, v)) <- zip [0 ..] locsAndEmissions]
-        emptyIdx = Indexes M.empty M.empty M.empty M.empty M.empty M.empty
+        emptyIdx = Indexes M.empty M.empty M.empty M.empty M.empty
      in Database
             { dbProcessIdTable = V.fromList [(actUUID i, mkUUID 0) | i <- [0 .. n - 1]]
             , dbProcessIdLookup = M.empty
@@ -114,13 +112,14 @@ mkDB locsAndEmissions =
             , dbActivityProductsIndex = M.empty
             , dbProductIndex = emptyProductIndex
             , dbActivities = activities
-            , dbFlows = M.singleton flowUUID testFlow
+            , dbTechFlows = M.empty
+            , dbBioFlows = M.singleton flowUUID testFlow
             , dbUnits = M.singleton (unitId kgUnit) kgUnit
             , dbIndexes = emptyIdx
             , dbTechnosphereTriples = U.empty
             , dbBiosphereTriples = triples
             , dbActivityIndex = actIdx
-            , dbBiosphereFlows = V.singleton flowUUID
+            , dbBiosphereOrder = V.singleton flowUUID
             , dbActivityCount = fromIntegral n
             , dbBiosphereCount = 1
             , dbCrossDBLinks = []
@@ -138,7 +137,7 @@ mkDB locsAndEmissions =
 -- EF method CFs (whose UUIDs differ from the database flow UUIDs) get
 -- resolved in production: regional cells fill 'mtRegionalizedCF', but the
 -- universal broadcast for F remains empty unless a non-regional CF is added.
-regionalMappings :: [(Text, Double)] -> [(MethodCF, Maybe (Flow, MatchStrategy))]
+regionalMappings :: [(Text, Double)] -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]
 regionalMappings = map (\(loc, v) -> (cf loc v, Just (testFlow, ByName)))
   where
     cf loc v =
@@ -156,16 +155,16 @@ regionalMappings = map (\(loc, v) -> (cf loc v, Just (testFlow, ByName)))
 buildTables ::
     Database ->
     M.Map Text [Text] ->
-    [(MethodCF, Maybe (Flow, MatchStrategy))] ->
+    [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] ->
     MethodTables
 buildTables db hier mappings =
     let raw = buildMethodTables M.empty mappings
         withBroadcast =
-            fillBroadcastVector kgUnitConfig (dbUnits db) (dbFlows db) raw
+            fillBroadcastVector kgUnitConfig (dbUnits db) (dbBioFlows db) raw
      in fillRegionalActivityWeights
             kgUnitConfig
             (dbUnits db)
-            (dbFlows db)
+            (dbBioFlows db)
             db
             hier
             withBroadcast
@@ -183,7 +182,7 @@ oracleWeights db hier tables = U.generate (fromIntegral (dbActivityCount db)) wF
     regional = mtRegionalizedCF tables
     activities = dbActivities db
     actIdx = dbActivityIndex db
-    bioFlows = dbBiosphereFlows db
+    bioFlows = dbBiosphereOrder db
     colToLoc =
         M.fromList
             [ (fromIntegral (actIdx V.! pid), activityLocation (activities V.! pid))
@@ -258,7 +257,7 @@ spec = do
             computeRegionalizedLCIAScore
                 kgUnitConfig
                 (dbUnits db)
-                (dbFlows db)
+                (dbBioFlows db)
                 db
                 scaling
                 M.empty
@@ -278,7 +277,7 @@ spec = do
             computeRegionalizedLCIAScore
                 kgUnitConfig
                 (dbUnits db)
-                (dbFlows db)
+                (dbBioFlows db)
                 db
                 scaling
                 M.empty
@@ -296,7 +295,7 @@ spec = do
             computeRegionalizedLCIAScore
                 kgUnitConfig
                 (dbUnits db)
-                (dbFlows db)
+                (dbBioFlows db)
                 db
                 scaling
                 M.empty

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -104,7 +104,7 @@ mkDB locsAndEmissions =
         activities = V.fromList [mkActivity loc | (loc, _) <- locsAndEmissions]
         actIdx = V.fromList [fromIntegral i :: Int32 | i <- [0 .. n - 1]]
         triples = mkTriples [(i, v) | (i, (_, v)) <- zip [0 ..] locsAndEmissions]
-        emptyIdx = Indexes M.empty M.empty M.empty M.empty M.empty
+        emptyIdx = Indexes M.empty M.empty M.empty M.empty
      in Database
             { dbProcessIdTable = V.fromList [(actUUID i, mkUUID 0) | i <- [0 .. n - 1]]
             , dbProcessIdLookup = M.empty

--- a/test/ServiceSpec.hs
+++ b/test/ServiceSpec.hs
@@ -28,6 +28,7 @@ import Service (
  )
 import Test.Hspec
 import TestHelpers (loadSampleDatabase)
+import qualified Types as VT
 import Types
 
 spec :: Spec
@@ -137,20 +138,17 @@ spec = do
     -- -----------------------------------------------------------------------
     describe "isResourceExtraction" $ do
         it "detects natural resource category" $ do
-            let flow = mkBioFlow "natural resource/in ground"
-            isResourceExtraction flow 1.0 `shouldBe` True
+            let flow = mkBioFlow "natural resource"
+            isResourceExtraction flow `shouldBe` True
 
         it "detects resource category prefix" $ do
-            let flow = mkBioFlow "resource/in water"
-            isResourceExtraction flow 1.0 `shouldBe` True
+            let flow = mkBioFlow "resource"
+            isResourceExtraction flow `shouldBe` True
 
         it "returns False for air emission" $ do
-            let flow = mkBioFlow "air/urban air"
-            isResourceExtraction flow 1.0 `shouldBe` False
-
-        it "returns False for Technosphere flow" $ do
-            let flow = mkTechFlow "technosphere"
-            isResourceExtraction flow 1.0 `shouldBe` False
+            let flow = mkBioFlow "air"
+            isResourceExtraction flow `shouldBe` False
+        -- Technosphere flows can't reach this function under the new type system.
 
     -- -----------------------------------------------------------------------
     -- extractCompartment
@@ -249,32 +247,27 @@ spec = do
 -- Helpers
 -- ---------------------------------------------------------------------------
 
-mkBioFlow :: Text -> Flow
+mkBioFlow :: Text -> BiosphereFlow
 mkBioFlow cat =
-    Flow
-        { flowId = nil
-        , flowName = "test"
-        , flowCategory = cat
-        , flowSubcompartment = Nothing
-        , flowUnitId = nil
-        , flowType = Biosphere
-        , flowSynonyms = M.empty
-        , flowCAS = Nothing
-        , flowSubstanceId = Nothing
+    BiosphereFlow
+        { bfId = nil
+        , bfName = "test"
+        , bfUnitId = nil
+        , bfSynonyms = M.empty
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfCompartment = VT.Compartment cat Nothing
         }
 
-mkTechFlow :: Text -> Flow
-mkTechFlow cat =
-    Flow
-        { flowId = nil
-        , flowName = "test"
-        , flowCategory = cat
-        , flowSubcompartment = Nothing
-        , flowUnitId = nil
-        , flowType = Technosphere
-        , flowSynonyms = M.empty
-        , flowCAS = Nothing
-        , flowSubstanceId = Nothing
+mkTechFlow :: Text -> TechnosphereFlow
+mkTechFlow _cat =
+    TechnosphereFlow
+        { tfId = nil
+        , tfName = "test"
+        , tfUnitId = nil
+        , tfSynonyms = M.empty
+        , tfCAS = Nothing
+        , tfSubstanceId = Nothing
         }
 
 -- | Build a minimal TreeExport from a list of (id, parentId, name) and edges (from,to)

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -29,14 +29,22 @@ import System.IO.Temp (withSystemTempFile)
 import Test.Hspec
 import Types (
     Activity (..),
+    BiosphereFlow,
+    Compartment (..),
     Exchange (..),
-    Flow,
     Pedigree (..),
+    TechRole (..),
+    TechnosphereFlow,
     UUID,
     Unit (..),
+    bfCompartment,
+    bfName,
+    compartmentName,
     exchangeComment,
+    exchangeIsInput,
+    exchangeIsReference,
     exchangePedigree,
-    flowName,
+    tfName,
  )
 import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig, isKnownUnit)
 
@@ -89,7 +97,7 @@ testCSV =
         ]
 
 -- | Parse the test CSV via a temp file
-parseTestCSV :: IO ([Activity], M.Map UUID Flow, M.Map UUID Unit)
+parseTestCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID Unit)
 parseTestCSV = withSystemTempFile "test.csv" $ \path handle -> do
     BS.hPut handle testCSV
     hClose handle
@@ -176,16 +184,72 @@ wasteNoAllocCSV =
         ]
 
 -- | Parse the 6-field waste treatment CSV via a temp file
-parseWasteNoAllocCSV :: IO ([Activity], M.Map UUID Flow, M.Map UUID Unit)
+parseWasteNoAllocCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID Unit)
 parseWasteNoAllocCSV = withSystemTempFile "waste-noalloc-test.csv" $ \path handle -> do
     BS.hPut handle wasteNoAllocCSV
     hClose handle
     parseSimaProCSV defaultUnitConfig path
 
 -- | Parse the waste test CSV via a temp file
-parseWasteCSV :: IO ([Activity], M.Map UUID Flow, M.Map UUID Unit)
+parseWasteCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID Unit)
 parseWasteCSV = withSystemTempFile "waste-test.csv" $ \path handle -> do
     BS.hPut handle wasteTestCSV
+    hClose handle
+    parseSimaProCSV defaultUnitConfig path
+
+{- | Test CSV where one flow is both a producer's reference product (carrying
+the SimaPro "Category" column) and a later process's Materials/fuels input
+(no Category column). The producer block comes first, so a last-wins
+deduplication would clobber the category with the consumer's empty value.
+-}
+sharedFlowCategoryCSV :: BS.ByteString
+sharedFlowCategoryCSV =
+    BS.intercalate
+        "\r\n"
+        [ "{SimaPro 9.6.0.1}"
+        , "{CSV separator: semicolon}"
+        , "{Decimal separator: .}"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , "Tomato Recipe"
+        , ""
+        , "Type"
+        , "Unit process"
+        , ""
+        , "Products"
+        , "Tomato sauce;kg;1.0;100;not defined;Agricultural\\Food\\Recipes;"
+        , ""
+        , "End"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , "Tomato Packaging"
+        , ""
+        , "Type"
+        , "Unit process"
+        , ""
+        , "Products"
+        , "Tomato sauce packaged;kg;1.0;100;not defined;Agricultural\\Food\\Packaging;"
+        , ""
+        , "Materials/fuels"
+        , "Tomato sauce;kg;0.5;Undefined;0;0;0;packed ingredient"
+        , ""
+        , "End"
+        ]
+
+-- | Parse the shared-flow-category CSV via a temp file
+parseSharedFlowCategoryCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID Unit)
+parseSharedFlowCategoryCSV = withSystemTempFile "shared-flow-cat-test.csv" $ \path handle -> do
+    BS.hPut handle sharedFlowCategoryCSV
     hClose handle
     parseSimaProCSV defaultUnitConfig path
 
@@ -234,7 +298,7 @@ paramTestCSV =
         , "End"
         ]
 
-parseParamCSV :: IO ([Activity], M.Map UUID Flow, M.Map UUID Unit)
+parseParamCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID Unit)
 parseParamCSV = withSystemTempFile "param-test.csv" $ \path handle -> do
     BS.hPut handle paramTestCSV
     hClose handle
@@ -274,7 +338,7 @@ dbParamTestCSV =
         , "End"
         ]
 
-parseDbParamCSV :: IO ([Activity], M.Map UUID Flow, M.Map UUID Unit)
+parseDbParamCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID Unit)
 parseDbParamCSV = withSystemTempFile "dbparam-test.csv" $ \path handle -> do
     BS.hPut handle dbParamTestCSV
     hClose handle
@@ -318,7 +382,7 @@ yieldChainTestCSV =
         , "End"
         ]
 
-parseYieldChainCSV :: IO ([Activity], M.Map UUID Flow, M.Map UUID Unit)
+parseYieldChainCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID Unit)
 parseYieldChainCSV = withSystemTempFile "yield-test.csv" $ \path handle -> do
     BS.hPut handle yieldChainTestCSV
     hClose handle
@@ -329,15 +393,15 @@ techInputAmounts :: Activity -> [Double]
 techInputAmounts act =
     [ techAmount e
     | e@TechnosphereExchange{} <- exchanges act
-    , techIsInput e
-    , not (techIsReference e)
+    , exchangeIsInput e
+    , not (exchangeIsReference e)
     ]
 
 -- Helper: get reference product amount
 refProductAmount :: Activity -> Maybe Double
 refProductAmount act = case [ techAmount e
                             | e@TechnosphereExchange{} <- exchanges act
-                            , techIsReference e
+                            , exchangeIsReference e
                             ] of
     (a : _) -> Just a
     _ -> Nothing
@@ -408,13 +472,13 @@ spec = do
 
     describe "SimaPro CSV parsing" $ do
         it "correctly extracts units from CSV with quoted fields" $ do
-            (_, _, unitDB) <- parseTestCSV
+            (_, _, _, unitDB) <- parseTestCSV
             let unitNames = map unitName $ M.elems unitDB
             -- Exactly these two units — no more, no less
             S.fromList unitNames `shouldBe` S.fromList ["kg", "foo_unit"]
 
         it "reports unknown units correctly" $ do
-            (_, _, unitDB) <- parseTestCSV
+            (_, _, _, unitDB) <- parseTestCSV
             let cfg = defaultUnitConfig
                 unknowns =
                     [ unitName u
@@ -425,37 +489,37 @@ spec = do
             unknowns `shouldNotContain` ["kg"]
 
         it "parses product names with embedded delimiters correctly" $ do
-            (activities, flowDB, _) <- parseTestCSV
+            (activities, techFlowDB, _, _) <- parseTestCSV
             -- activityName now reflects the SimaPro Process name (multi-product
-            -- friendly); the quoted product name lives on the reference flow.
+            -- friendly); the quoted product name lives on the reference (technosphere) flow.
             let names = map activityName activities
             names `shouldContain` ["Irradiated Food"]
-            let flowNames = map flowName (M.elems flowDB)
+            let flowNames = map tfName (M.elems techFlowDB)
             flowNames `shouldContain` ["Food product (irradiated ; with treatment)"]
 
     describe "SimaPro classification parsing" $ do
         it "parses Category type from metadata" $ do
-            (activities, _, _) <- parseTestCSV
+            (activities, _, _, _) <- parseTestCSV
             let cls = activityClassification (head activities)
             M.lookup "Category type" cls `shouldBe` Just "material"
 
         it "parses Category from product line" $ do
-            (activities, _, _) <- parseTestCSV
+            (activities, _, _, _) <- parseTestCSV
             let cls = activityClassification (head activities)
             M.lookup "Category" cls `shouldBe` Just "material"
 
     describe "SimaPro waste treatment parsing" $ do
         it "parses waste treatment processes (Waste treatment section)" $ do
-            (activities, _, _) <- parseWasteCSV
+            (activities, _, _, _) <- parseWasteCSV
             length activities `shouldSatisfy` (>= 2)
 
         it "uses Process name as activity name (waste treatment block)" $ do
-            (activities, _, _) <- parseWasteCSV
+            (activities, _, _, _) <- parseWasteCSV
             let names = map activityName activities
             names `shouldContain` ["Incineration process"]
 
         it "parses 6-field waste treatment rows without allocation" $ do
-            (activities, _, _) <- parseWasteNoAllocCSV
+            (activities, _, _, _) <- parseWasteNoAllocCSV
             length activities `shouldBe` 1
             let a = head activities
             activityName a `shouldBe` "treatment of non-sulfidic overburden"
@@ -463,19 +527,19 @@ spec = do
             M.lookup "Category" cls `shouldBe` Just "Others\\Copied from Ecoinvent cut-off S"
 
         it "marks Waste to treatment exchanges as inputs" $ do
-            (activities, _, _) <- parseWasteCSV
+            (activities, _, _, _) <- parseWasteCSV
             let producer = head [a | a <- activities, activityName a == "Widget production"]
                 wasteExchanges =
                     [ e
                     | e@TechnosphereExchange{} <- exchanges producer
-                    , not (techIsReference e)
-                    , techIsInput e
+                    , not (exchangeIsReference e)
+                    , exchangeIsInput e
                     ]
             length wasteExchanges `shouldSatisfy` (>= 1)
 
     describe "SimaPro parameterized amounts" $ do
         it "resolves simple variable references (Qm=20.53 for cow milk, scaled by allocation)" $ do
-            (activities, _, _) <- parseParamCSV
+            (activities, _, _, _) <- parseParamCSV
             let butter = head activities
                 -- allocButter = (1*0.82/(1*0.82+20.53*0.118))*100 ≈ 25.285
                 -- Cow milk amount = 20.53 * allocButter/100 ≈ 5.19
@@ -484,12 +548,12 @@ spec = do
             head milkAmounts `shouldSatisfy` (\x -> abs (x - 5.19) < 0.01)
 
         it "resolves parameterized product amount (Qb=1)" $ do
-            (activities, _, _) <- parseParamCSV
+            (activities, _, _, _) <- parseParamCSV
             let butter = head activities
             refProductAmount butter `shouldBe` Just 1.0
 
         it "resolves calculated parameter in allocation (allocButter formula)" $ do
-            (activities, _, _) <- parseParamCSV
+            (activities, _, _, _) <- parseParamCSV
             let butter = head activities
             -- Product allocation uses allocButter = (Qb*DMb/(Qb*DMb+Qm*DMm))*100
             -- = (1*0.82/(1*0.82+20.53*0.118))*100 ≈ 25.3%
@@ -497,32 +561,32 @@ spec = do
             -- (we check that the activity was created = params didn't break parsing)
             length (exchanges butter) `shouldSatisfy` (>= 3) -- product + milk + CO2
         it "stores resolved parameter values in activity" $ do
-            (activities, _, _) <- parseParamCSV
+            (activities, _, _, _) <- parseParamCSV
             let butter = head activities
             M.lookup "Qm" (activityParams butter) `shouldBe` Just 20.53
             M.lookup "Qb" (activityParams butter) `shouldBe` Just 1.0
             M.lookup "DMb" (activityParams butter) `shouldBe` Just 0.82
 
         it "stores raw expressions for re-evaluation" $ do
-            (activities, _, _) <- parseParamCSV
+            (activities, _, _, _) <- parseParamCSV
             let butter = head activities
             M.lookup "allocButter" (activityParamExprs butter)
                 `shouldBe` Just "(Qb*DMb/(Qb*DMb+Qm*DMm))*100"
 
         it "does not drop exchanges with parameterized amounts" $ do
-            (activities, _, _) <- parseParamCSV
+            (activities, _, _, _) <- parseParamCSV
             let butter = head activities
                 techInputs =
                     [ e
                     | e@TechnosphereExchange{} <- exchanges butter
-                    , techIsInput e
-                    , not (techIsReference e)
+                    , exchangeIsInput e
+                    , not (exchangeIsReference e)
                     ]
             -- Cow milk should NOT be dropped (was the original bug)
             length techInputs `shouldBe` 1
 
         it "scales biosphere exchanges by allocation fraction" $ do
-            (activities, _, _) <- parseParamCSV
+            (activities, _, _, _) <- parseParamCSV
             let butter = head activities
                 bioExchanges = [e | e@BiosphereExchange{} <- exchanges butter]
             length bioExchanges `shouldBe` 1
@@ -531,14 +595,14 @@ spec = do
 
     describe "SimaPro database-level parameters" $ do
         it "resolves database input params in exchange amounts" $ do
-            (activities, _, _) <- parseDbParamCSV
+            (activities, _, _, _) <- parseDbParamCSV
             let act = head activities
             -- Raw material amount should be lbtokg = 0.453592
             techInputAmounts act `shouldContain` [0.453592]
 
     describe "SimaPro yield chain formulas" $ do
         it "resolves chained division (weight_g/1000/yield1/yield2)" $ do
-            (activities, _, _) <- parseYieldChainCSV
+            (activities, _, _, _) <- parseYieldChainCSV
             let act = head activities
                 amounts = techInputAmounts act
             -- corrected = 250/1000/0.95/0.90 ≈ 0.2924
@@ -650,7 +714,7 @@ spec = do
 
     describe "per-exchange comments" $ do
         it "surfaces the trailing free-text comment on a Materials/fuels row" $ do
-            (activities, _, _) <-
+            (activities, _, _, _) <-
                 parseSectionCSV
                     [ "Materials/fuels"
                     , "Soybean meal BR;kg;6506.5;Lognormal;1.533;0;0;Soybean, meal 46 BR, crushing in Brazil, at french port, average, FR"
@@ -660,14 +724,14 @@ spec = do
                     | act <- activities
                     , ex <- exchanges act
                     , case ex of
-                        TechnosphereExchange{techIsInput = True} -> True
+                        TechnosphereExchange{techRole = Input} -> True
                         _ -> False
                     ]
             map exchangeComment inputs
                 `shouldBe` [Just "Soybean, meal 46 BR, crushing in Brazil, at french port, average, FR"]
 
         it "returns Nothing for a comment-less row" $ do
-            (activities, _, _) <-
+            (activities, _, _, _) <-
                 parseSectionCSV
                     [ "Materials/fuels"
                     , "Plain {FR} U;kg;1.0;Undefined;;;;;;"
@@ -677,13 +741,13 @@ spec = do
                     | act <- activities
                     , ex <- exchanges act
                     , case ex of
-                        TechnosphereExchange{techIsInput = True} -> True
+                        TechnosphereExchange{techRole = Input} -> True
                         _ -> False
                     ]
             map exchangeComment inputs `shouldBe` [Nothing]
 
         it "surfaces a per-emission comment on a biosphere row" $ do
-            (activities, _, _) <-
+            (activities, _, _, _) <-
                 parseSectionCSV
                     [ "Emissions to air"
                     , "Carbon dioxide, fossil;high. pop.;kg;0.5;Undefined;;;;;;tail-pipe combustion"
@@ -734,7 +798,7 @@ spec = do
 
     describe "pedigree wired through to Exchange" $ do
         it "populates techPedigree and strips the prefix from the comment" $ do
-            (activities, _, _) <-
+            (activities, _, _, _) <-
                 parseSectionCSV
                     [ "Materials/fuels"
                     , "Soybean meal BR;kg;6506.5;Lognormal;1.533;0;0;(3,3,2,1,2),. Brazilian port average"
@@ -744,14 +808,14 @@ spec = do
                     | act <- activities
                     , ex <- exchanges act
                     , case ex of
-                        TechnosphereExchange{techIsInput = True} -> True
+                        TechnosphereExchange{techRole = Input} -> True
                         _ -> False
                     ]
             map exchangeComment inputs `shouldBe` [Just "Brazilian port average"]
             map exchangePedigree inputs `shouldBe` [Just (Pedigree 3 3 2 1 2)]
 
         it "populates bioPedigree for emission rows that carry only pedigree" $ do
-            (activities, _, _) <-
+            (activities, _, _, _) <-
                 parseSectionCSV
                     [ "Emissions to air"
                     , "Carbon dioxide, fossil;high. pop.;kg;0.5;Undefined;;;;;;(2,2,1,1,1),"
@@ -838,17 +902,17 @@ spec = do
 
     describe "SimaPro uncovered sections" $ do
         it "parses Electricity/heat exchanges" $ do
-            (activities, _, _) <-
+            (activities, _, _, _) <-
                 parseSectionCSV
                     [ "Electricity/heat"
                     , "Electricity, medium voltage;kWh;0.3;Undefined;;;;;;"
                     ]
             let act = head activities
-                techIn = [e | e@TechnosphereExchange{} <- exchanges act, techIsInput e, not (techIsReference e)]
+                techIn = [e | e@TechnosphereExchange{} <- exchanges act, exchangeIsInput e, not (exchangeIsReference e)]
             length techIn `shouldBe` 1
 
         it "parses Resources (biosphere inputs)" $ do
-            (activities, _, _) <-
+            (activities, _, _, _) <-
                 parseSectionCSV
                     [ "Resources"
                     , "Water, river;in water;m3;0.1;Undefined;;;;;;"
@@ -857,7 +921,7 @@ spec = do
             length bio `shouldBe` 1
 
         it "parses Emissions to water" $ do
-            (activities, _, _) <-
+            (activities, _, _, _) <-
                 parseSectionCSV
                     [ "Emissions to water"
                     , "Phosphate;river;kg;0.01;Undefined;;;;;;"
@@ -866,7 +930,7 @@ spec = do
             length bio `shouldBe` 1
 
         it "parses Emissions to soil" $ do
-            (activities, _, _) <-
+            (activities, _, _, _) <-
                 parseSectionCSV
                     [ "Emissions to soil"
                     , "Zinc;agricultural;kg;0.001;Undefined;;;;;;"
@@ -875,7 +939,7 @@ spec = do
             length bio `shouldBe` 1
 
         it "parses Final waste flows" $ do
-            (activities, _, _) <-
+            (activities, _, _, _) <-
                 parseSectionCSV
                     [ "Final waste flows"
                     , "Inert waste, for final disposal;kg;0.5;Undefined;;;;;;"
@@ -884,21 +948,21 @@ spec = do
             length bio `shouldBe` 1
 
         it "parses location from process name {XX} pattern" $ do
-            (activities, _, _) <- parseNamedCSV "Widget {FR} U" []
+            (activities, _, _, _) <- parseNamedCSV "Widget {FR} U" []
             activityLocation (head activities) `shouldBe` "FR"
 
         it "parses location from process name //[XX] pattern (ecoinvent 3.9.1 SimaPro export)" $ do
-            (activities, _, _) <- parseNamedCSV "mango//[BR] mango production" []
+            (activities, _, _, _) <- parseNamedCSV "mango//[BR] mango production" []
             activityLocation (head activities) `shouldBe` "BR"
 
         it "parses location from Geography metadata" $ do
-            (activities, _, _) <- parseTestCSV
+            (activities, _, _, _) <- parseTestCSV
             let a = head activities
             activityLocation a `shouldBe` "GLO"
 
     describe "SimaPro comma CSV separator" $ do
         it "parses comma-separated CSV" $ do
-            (activities, _, _) <- parseCommaCSV
+            (activities, _, _, _) <- parseCommaCSV
             length activities `shouldBe` 1
             activityName (head activities) `shouldBe` "Comma Product"
 
@@ -909,14 +973,14 @@ spec = do
         -- technosphere column normalization divides by 1 instead of 1000 and every
         -- impact score for that activity comes back 1000× too large.
         it "converts a 1-ton reference to 1000 kg at ingest (canonical base)" $ do
-            (activities, _, _) <- parseTonRefCSV
+            (activities, _, _, _) <- parseTonRefCSV
             length activities `shouldBe` 1
             let act = head activities
                 refExs =
                     [ ex
                     | ex <- exchanges act
-                    , techIsReference ex
-                    , not (techIsInput ex)
+                    , exchangeIsReference ex
+                    , not (exchangeIsInput ex)
                     ]
             length refExs `shouldBe` 1
             let ex = head refExs
@@ -924,9 +988,9 @@ spec = do
             activityUnit act `shouldBe` "kg"
 
         it "leaves an already-canonical kg reference unchanged" $ do
-            (activities, _, _) <- parseTestCSV
+            (activities, _, _, _) <- parseTestCSV
             let steel = head [a | a <- activities, activityName a == "Steel Production"]
-                refExs = [ex | ex <- exchanges steel, techIsReference ex, not (techIsInput ex)]
+                refExs = [ex | ex <- exchanges steel, exchangeIsReference ex, not (exchangeIsInput ex)]
             techAmount (head refExs) `shouldBe` 1.0
             activityUnit steel `shouldBe` "kg"
 
@@ -936,19 +1000,19 @@ spec = do
         -- dbActivityProductsIndex can group them) and each must carry its own
         -- allocation percentage.
         it "shares one activityUUID across all 5 coproducts" $ do
-            (activities, _, _) <- parseMultiCoproductCSV
+            (activities, _, _, _) <- parseMultiCoproductCSV
             length activities `shouldBe` 5
             let uuids = S.fromList (map generateActivityUUID activities)
             S.size uuids `shouldBe` 1
 
         it "uses the Process name as activityName for every coproduct" $ do
-            (activities, _, _) <- parseMultiCoproductCSV
+            (activities, _, _, _) <- parseMultiCoproductCSV
             let names = S.fromList (map activityName activities)
             S.size names `shouldBe` 1
             S.member "Multi-coproduct refinery" names `shouldBe` True
 
         it "stores allocation percentage on each coproduct Activity" $ do
-            (activities, _, _) <- parseMultiCoproductCSV
+            (activities, _, _, _) <- parseMultiCoproductCSV
             -- Order-agnostic: the 5 allocation percentages must match the
             -- declared shares (50/20/15/10/5) as a multiset.
             let percents = [p | a <- activities, Just p <- [activityAllocationPercent a]]
@@ -960,19 +1024,19 @@ spec = do
 
         it "preserves the raw allocation formula when non-numeric" $ do
             -- paramTestCSV (butter) uses an expression "allocButter" for allocation
-            (activities, _, _) <- parseParamCSV
+            (activities, _, _, _) <- parseParamCSV
             let butter = head activities
             activityAllocationFormula butter `shouldBe` Just "allocButter"
 
         it "leaves allocation formula populated for formula-based allocations" $ do
-            (activities, _, _) <- parseMultiCoproductCSV
+            (activities, _, _, _) <- parseMultiCoproductCSV
             -- Multi-coproduct allocations are of the form 'Sx /(...)*100',
             -- so the formula field should be populated for each coproduct.
             let formulas = [activityAllocationFormula a | a <- activities]
             all (/= Nothing) formulas `shouldBe` True
 
         it "scales shared exchanges by the per-coproduct allocation fraction" $ do
-            (activities, _, _) <- parseMultiCoproductCSV
+            (activities, _, _, _) <- parseMultiCoproductCSV
             -- A shared 1 kg upstream input is allocated across the 5 coproducts:
             -- Alpha 0.5 kg, Beta 0.2 kg, Gamma 0.15 kg, Delta 0.1 kg, Epsilon
             -- 0.05 kg. The sum across all coproduct columns restores 1 kg.
@@ -980,8 +1044,8 @@ spec = do
                     [ techAmount e
                     | a <- activities
                     , e@TechnosphereExchange{} <- exchanges a
-                    , techIsInput e
-                    , not (techIsReference e)
+                    , exchangeIsInput e
+                    , not (exchangeIsReference e)
                     ]
             length perActivity `shouldBe` 5
             let total = sum perActivity
@@ -989,7 +1053,7 @@ spec = do
 
     describe "SimaPro Process name fallback" $ do
         it "falls back to product name when Process name field is empty" $ do
-            (activities, _, _) <- parseNoProcessNameCSV
+            (activities, _, _, _) <- parseNoProcessNameCSV
             length activities `shouldBe` 1
             -- With an empty 'Process name', the product name is used as
             -- activityName (preserves legacy behaviour for mono-product CSVs
@@ -1005,7 +1069,7 @@ spec = do
     -- here, silently turning every substitution into extra consumption.
     describe "SimaPro substitutions (negative Materials/fuels)" $ do
         it "preserves the negative sign on Materials/fuels exchanges" $ do
-            (activities, _, _) <- parseSectionCSV
+            (activities, _, _, _) <- parseSectionCSV
                 [ "Materials/fuels"
                 , "Avoided diesel;kg;-1.5;Undefined;;;;;;"
                 ]
@@ -1013,7 +1077,7 @@ spec = do
             techInputAmounts (head activities) `shouldBe` [-1.5]
 
         it "keeps positive and negative rows side by side with their own signs" $ do
-            (activities, _, _) <- parseSectionCSV
+            (activities, _, _, _) <- parseSectionCSV
                 [ "Materials/fuels"
                 , "Fertilizer input;kg;231.84;Undefined;;;;;;"
                 , "Avoided diesel;kg;-1568.16;Undefined;;;;;;"
@@ -1028,11 +1092,11 @@ spec = do
 -- ---------------------------------------------------------------------------
 
 -- | Build a minimal process CSV with extra section lines inserted
-parseSectionCSV :: [BS.ByteString] -> IO ([Activity], M.Map UUID Flow, M.Map UUID Unit)
+parseSectionCSV :: [BS.ByteString] -> IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID Unit)
 parseSectionCSV sectionLines =
     parseNamedCSV "Test process" sectionLines
 
-parseNamedCSV :: BS.ByteString -> [BS.ByteString] -> IO ([Activity], M.Map UUID Flow, M.Map UUID Unit)
+parseNamedCSV :: BS.ByteString -> [BS.ByteString] -> IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID Unit)
 parseNamedCSV procName sectionLines =
     withSystemTempFile "section-test.csv" $ \path handle -> do
         let content =
@@ -1090,7 +1154,7 @@ commaCSV =
         , "End"
         ]
 
-parseCommaCSV :: IO ([Activity], M.Map UUID Flow, M.Map UUID Unit)
+parseCommaCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID Unit)
 parseCommaCSV = withSystemTempFile "comma-test.csv" $ \path handle -> do
     BS.hPut handle commaCSV
     hClose handle
@@ -1135,7 +1199,7 @@ tonRefCSV =
         , "End"
         ]
 
-parseTonRefCSV :: IO ([Activity], M.Map UUID Flow, M.Map UUID Unit)
+parseTonRefCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID Unit)
 parseTonRefCSV = withSystemTempFile "ton-ref.csv" $ \path handle -> do
     BS.hPut handle tonRefCSV
     hClose handle
@@ -1195,7 +1259,7 @@ multiCoproductCSV =
         , "End"
         ]
 
-parseMultiCoproductCSV :: IO ([Activity], M.Map UUID Flow, M.Map UUID Unit)
+parseMultiCoproductCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID Unit)
 parseMultiCoproductCSV = withSystemTempFile "multi-coproduct.csv" $ \path handle -> do
     BS.hPut handle multiCoproductCSV
     hClose handle
@@ -1233,7 +1297,7 @@ noProcessNameCSV =
         , "End"
         ]
 
-parseNoProcessNameCSV :: IO ([Activity], M.Map UUID Flow, M.Map UUID Unit)
+parseNoProcessNameCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID Unit)
 parseNoProcessNameCSV = withSystemTempFile "no-process-name.csv" $ \path handle -> do
     BS.hPut handle noProcessNameCSV
     hClose handle

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -6,6 +6,7 @@ module SimaProParserSpec (spec) where
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
+import Data.Text (Text)
 import Expr (evaluate, normalizeExpr)
 import SimaPro.Parser (
     BioExchangeRow (..),
@@ -30,17 +31,14 @@ import Test.Hspec
 import Types (
     Activity (..),
     BiosphereFlow,
-    Compartment (..),
     Exchange (..),
     Pedigree (..),
     TechRole (..),
     TechnosphereFlow,
     UUID,
     Unit (..),
-    bfCompartment,
-    bfName,
-    compartmentName,
     exchangeComment,
+    exchangeFlowId,
     exchangeIsInput,
     exchangeIsReference,
     exchangePedigree,
@@ -406,6 +404,14 @@ refProductAmount act = case [ techAmount e
     (a : _) -> Just a
     _ -> Nothing
 
+-- Helper: lookup the single activity with the given name; errors on miss
+-- so test failures point at the assertion line rather than a Maybe noise.
+findByName :: HasCallStack => Text -> [Activity] -> Activity
+findByName name acts = case [a | a <- acts, activityName a == name] of
+    [a] -> a
+    [] -> error $ "findByName: no activity named " <> show name
+    _ -> error $ "findByName: more than one activity named " <> show name
+
 spec :: Spec
 spec = do
     describe "SimaPro expression evaluator" $ do
@@ -507,6 +513,33 @@ spec = do
             (activities, _, _, _) <- parseTestCSV
             let cls = activityClassification (head activities)
             M.lookup "Category" cls `shouldBe` Just "material"
+
+        it "keeps per-activity Category when the same product is consumed downstream" $ do
+            -- Producer's reference product and a downstream Materials/fuels input
+            -- both name "Tomato sauce" (same generated flow UUID), but each
+            -- activity must keep its own Category on activityClassification.
+            (activities, techFlowDB, _, _) <- parseSharedFlowCategoryCSV
+            let producer = findByName "Tomato Recipe" activities
+                consumer = findByName "Tomato Packaging" activities
+            M.lookup "Category" (activityClassification producer)
+                `shouldBe` Just "Agricultural\\Food\\Recipes"
+            M.lookup "Category" (activityClassification consumer)
+                `shouldBe` Just "Agricultural\\Food\\Packaging"
+            let producerRefFlow =
+                    head
+                        [ exchangeFlowId ex
+                        | ex@TechnosphereExchange{} <- exchanges producer
+                        , exchangeIsReference ex
+                        , not (exchangeIsInput ex)
+                        ]
+                consumerInputFlows =
+                    [ exchangeFlowId ex
+                    | ex@TechnosphereExchange{} <- exchanges consumer
+                    , exchangeIsInput ex
+                    , not (exchangeIsReference ex)
+                    ]
+            consumerInputFlows `shouldContain` [producerRefFlow]
+            M.member producerRefFlow techFlowDB `shouldBe` True
 
     describe "SimaPro waste treatment parsing" $ do
         it "parses waste treatment processes (Waste treatment section)" $ do

--- a/test/TestHelpers.hs
+++ b/test/TestHelpers.hs
@@ -37,7 +37,7 @@ loadSampleDatabaseWithPath path = do
     case loadResult of
         Left err -> error $ "Failed to load test database: " ++ show err
         Right simpleDb -> do
-            dbResult <- buildDatabaseWithMatrices defaultUnitConfig (sdbActivities simpleDb) (sdbFlows simpleDb) (sdbUnits simpleDb)
+            dbResult <- buildDatabaseWithMatrices defaultUnitConfig (sdbActivities simpleDb) (sdbTechFlows simpleDb) (sdbBioFlows simpleDb) (sdbUnits simpleDb)
             case dbResult of
                 Left err -> error $ "Failed to build matrix: " ++ show err
                 Right db -> return db
@@ -53,11 +53,11 @@ assertVectorNear _label tolerance actualVec expectedList = do
     length actual `shouldBe` length expectedList
     zipWithM_ (\a e -> withinTolerance tolerance e a `shouldBe` True) actual expectedList
 
--- | Find a flow by name in the database
-findFlowByName :: Database -> Text -> Maybe Flow
+-- | Find a biosphere flow by name in the database (test helper).
+findFlowByName :: Database -> Text -> Maybe BiosphereFlow
 findFlowByName db name =
-    let flows = M.elems (dbFlows db)
-     in case filter (\f -> T.toLower (flowName f) == T.toLower name) flows of
+    let flows = M.elems (dbBioFlows db)
+     in case filter (\f -> T.toLower (bfName f) == T.toLower name) flows of
             (f : _) -> Just f
             [] -> Nothing
 


### PR DESCRIPTION
## Summary

The single `Flow` record carried both physical compartment data (biosphere) and a source-format taxonomy slot (technosphere) in one `Text` field, filled inconsistently by the four parsers. Pair that with `TechnosphereExchange` booleans (`techIsInput`, `techIsReference`) representing four combinations of which only three are valid, plus a load-bearing `"technosphere"` string that three layers were propping up to discriminate sum-type variants — and the type system was no longer pulling its weight.

### Domain types

- `Flow` is gone. `TechnosphereFlow` carries no compartment and no taxonomy (the product classification lives on the producing activity's `activityClassification`). `BiosphereFlow` carries a structured `Compartment { name, sub :: Maybe Text }`.
- `techIsInput` / `techIsReference` collapse into a single `TechRole = ReferenceProduct | Coproduct | ReferenceInput | Input` enum, naming the four valid combinations.
- The Exchange constructor tag (`TechnosphereExchange | BiosphereExchange`) is now the single source of truth for biosphere/technosphere dispatch throughout the engine.

### Database & parsers

- `dbFlows` / `sdbFlows` split into `dbTechFlows` / `dbBioFlows`. Each parser builds the two maps separately; cross-DB merging keys per side.
- The \`Indexes\` record drops \`idxFlowByCategory\` / \`idxFlowByType\` — technosphere has no taxonomy to index and biosphere compartments are queried via the flow database directly.
- The SimaPro \`M.fromListWith preferCategorized\` workaround becomes dead code and is removed; the producer-Category-survives-shared-product invariant is now covered by a dedicated regression in \`SimaProParserSpec\`.
- EcoSpold2 and ILCD parsers now emit the same \`Compartment "" Nothing\` sentinel when the source dataset omits a compartment, so the LCIA cascade keys converge regardless of source format.

### LCIA / characterization

\`Method.Mapping\` is now statically biosphere-only: every CF lookup reads \`BiosphereFlow\`, so a technosphere flow can no longer accidentally be characterized. Previously this was enforced by convention.

### Wire shape

- \`ExchangeWithUnit.flowCategory\` becomes a structured \`Maybe Compartment\` field (biosphere only).
- \`FlowDetail\` / \`FlowSummary\` / \`ExchangeDetail\` carry \`Either TechnosphereFlow BiosphereFlow\` so the active variant is the wire discriminator.
- The MCP \`exchange_type\` filter dispatches on the Exchange variant tag and now also rejects unknown values (\`tecnosphere\` etc.) with a \`toolError\` instead of silently matching everything — mirroring the \`/api/aggregate\` validation.
- An exchange whose flow UUID resolves to neither side now surfaces as \`<unresolved flow UUID>\` instead of the generic \`"unknown"\` — keeps the gap debuggable.
- \`getFlowActivities\` (CLI / REST) accepts both technosphere and biosphere flow IDs.

### Clients

- **pyvolca**: \`TechnosphereExchange\` loses \`flow_category\` and gains a \`TechRole\` (\`ReferenceProduct | Coproduct | ReferenceInput | Input\`); \`BiosphereExchange\` carries a \`Compartment\` dataclass. \`is_input\` / \`is_reference\` are derived from the role.
- \`volca-bench\` migrated to the split API (\`sdbTechFlows\` / \`sdbBioFlows\`, \`BiosphereFlow\`, four-tuple \`parseSimaProCSV\`).
- New tests cover \`activityNormFactor\` across all four \`TechRole\` branches (including the previously untested \`ReferenceInput\` treatment-process case) and the producer-Category-survives-shared-product SimaPro invariant.

## Test plan

- [x] \`cabal build lib:volca\` clean
- [x] \`cabal build volca-bench\` clean
- [x] \`cabal test\`: 844 examples, 0 failures, 1 pending
- [x] \`pytest pyvolca/tests/\`: 62 passed, 5 skipped