### PR TITLE
Expose batched LCIA + scoring sets via MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Available tools (auto-derived from a single resource registry shared with the RE
 | `get_path_to` | Shortest supply-chain path from one activity to another |
 | `get_inventory` | LCI biosphere flows (top N by quantity) |
 | `get_impacts` | LCIA score for an activity and method (accepts substitutions) |
+| `score_activity` | Full LCIA panel + every configured scoring set for one activity (replaces N×get_impacts calls) |
 | `get_contributing_flows` | Top biosphere flows contributing to an LCIA score |
 | `get_contributing_activities` | Top upstream activities contributing to an LCIA score |
 | `get_flow_mapping` | CF-to-flow mapping coverage for a method |

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Available tools (auto-derived from a single resource registry shared with the RE
 | `get_impacts` | LCIA score for an activity and method (accepts substitutions) |
 | `score_activity` | Full LCIA panel + every configured scoring set for one activity (replaces N×get_impacts calls) |
 | `score_activities` | Same shape as score_activity, batched over N activities in one multi-RHS solve |
+| `list_scoring_sets` | List formula-based scoring sets configured on every loaded method collection |
 | `get_contributing_flows` | Top biosphere flows contributing to an LCIA score |
 | `get_contributing_activities` | Top upstream activities contributing to an LCIA score |
 | `get_flow_mapping` | CF-to-flow mapping coverage for a method |

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Available tools (auto-derived from a single resource registry shared with the RE
 | `get_inventory` | LCI biosphere flows (top N by quantity) |
 | `get_impacts` | LCIA score for an activity and method (accepts substitutions) |
 | `score_activity` | Full LCIA panel + every configured scoring set for one activity (replaces N×get_impacts calls) |
+| `score_activities` | Same shape as score_activity, batched over N activities in one multi-RHS solve |
 | `get_contributing_flows` | Top biosphere flows contributing to an LCIA score |
 | `get_contributing_activities` | Top upstream activities contributing to an LCIA score |
 | `get_flow_mapping` | CF-to-flow mapping coverage for a method |

--- a/src/API/BatchImpacts.hs
+++ b/src/API/BatchImpacts.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 {- | Pure-IO wrappers around the LCIA batch entry points exposed by
 "API.Routes". They let non-Servant callers (notably the MCP tool
 layer) invoke the batch and multi-activity solves without going through
@@ -8,10 +6,11 @@ of an opaque 'ServerError'.
 
 The wrappers delegate to 'activityLCIABatchH' and 'batchImpactsH' via
 'Servant.runHandler', then translate the resulting 'ServerError' back
-to a domain-shaped 'BatchError'. The translation matches a fixed set
-of throw sites in "API.Routes" by HTTP status + body prefix; anything
-unrecognised collapses into 'OtherBatchError' (status + verbatim body)
-so failures surface rather than being silently flattened.
+to a domain-shaped 'BatchError'. The "Collection not loaded" /
+"Database not loaded" body prefixes are imported from "API.Routes"
+('collectionNotLoadedPrefix', 'databaseNotLoadedPrefix') so the two
+ends share a single source of truth — drift one and the build breaks
+here.
 -}
 module API.BatchImpacts (
     BatchError (..),
@@ -20,7 +19,7 @@ module API.BatchImpacts (
     translateError,
 ) where
 
-import API.Routes (activityLCIABatchH, batchImpactsH)
+import API.Routes (activityLCIABatchH, batchImpactsH, collectionNotLoadedPrefix, databaseNotLoadedPrefix)
 import API.Types (BatchImpactsRequest (..), BatchImpactsResponse, LCIABatchResult, SubstitutionRequest)
 import Control.Concurrent.STM (readTVarIO)
 import qualified Data.ByteString.Lazy as BSL
@@ -123,20 +122,17 @@ loadedCollectionNames dbm = M.keys <$> readTVarIO (dmLoadedMethods dbm)
 
 {- | Translate a Servant 'ServerError' back to the typed 'BatchError' sum.
 
-The match is by HTTP status + body prefix. The throw sites in
-"API.Routes" that this targets are stable: 'loadCollection' produces
-@404 "Collection not loaded: ..."@, 'resolveOrThrow' produces
-@404 "Activity not found"@ and @400 \<msg\>@, the cross-DB pipeline
-routes 'MatrixError' to @422 \<msg\>@. Anything else falls through to
-'OtherBatchError' rather than being silently coerced.
+The match is by HTTP status + body prefix. The prefix constants are
+imported from "API.Routes" so the throw site and the translator move
+together; changing one without the other breaks compilation here.
 -}
 translateError :: [Text] -> ServerError -> BatchError
 translateError availableCollections se
     | code == 404
-    , Just rest <- T.stripPrefix collectionPrefix body =
+    , Just rest <- T.stripPrefix collectionNotLoadedPrefix body =
         CollectionNotLoaded rest availableCollections
     | code == 404
-    , Just rest <- T.stripPrefix databasePrefix body =
+    , Just rest <- T.stripPrefix databaseNotLoadedPrefix body =
         DatabaseNotLoaded rest
     | code == 404 = ActivityResolutionFailed body
     | code == 400 = ActivityResolutionFailed body
@@ -145,5 +141,3 @@ translateError availableCollections se
   where
     code = errHTTPCode se
     body = TE.decodeUtf8 (BSL.toStrict (errBody se))
-    collectionPrefix = "Collection not loaded: "
-    databasePrefix = "Database not loaded: "

--- a/src/API/BatchImpacts.hs
+++ b/src/API/BatchImpacts.hs
@@ -17,6 +17,7 @@ module API.BatchImpacts (
     BatchError (..),
     runActivityLCIABatch,
     runBatchImpacts,
+    translateError,
 ) where
 
 import API.Routes (activityLCIABatchH, batchImpactsH)

--- a/src/API/BatchImpacts.hs
+++ b/src/API/BatchImpacts.hs
@@ -77,11 +77,10 @@ runActivityLCIABatch ::
     Maybe SubstitutionRequest ->
     IO (Either BatchError LCIABatchResult)
 runActivityLCIABatch dbm dbName pid coll mSub = do
-    avail <- loadedCollectionNames dbm
     res <- Servant.runHandler (activityLCIABatchH dbm dbName pid coll mSub)
-    pure $ case res of
-        Right lbr -> Right lbr
-        Left se -> Left (translateError avail se)
+    case res of
+        Right lbr -> pure (Right lbr)
+        Left se -> Left <$> translateErrorIO dbm se
 
 {- | Score N activities against every method in a collection in one
 multi-RHS MUMPS solve plus parallel characterization. Unresolved process
@@ -100,7 +99,6 @@ runBatchImpacts ::
     [Text] ->
     IO (Either BatchError BatchImpactsResponse)
 runBatchImpacts dbm dbName coll topFlows pids = do
-    avail <- loadedCollectionNames dbm
     res <-
         Servant.runHandler
             ( batchImpactsH
@@ -110,9 +108,19 @@ runBatchImpacts dbm dbName coll topFlows pids = do
                 topFlows
                 (BatchImpactsRequest{birProcessIds = pids})
             )
-    pure $ case res of
-        Right r -> Right r
-        Left se -> Left (translateError avail se)
+    case res of
+        Right r -> pure (Right r)
+        Left se -> Left <$> translateErrorIO dbm se
+
+{- | IO-flavoured translator: snapshot the loaded-collection names from the
+live TVar only when we actually need them (i.e. on a failure path) and
+hand them to the pure 'translateError'. On the happy path the TVar is
+not read at all.
+-}
+translateErrorIO :: DatabaseManager -> ServerError -> IO BatchError
+translateErrorIO dbm se = do
+    avail <- loadedCollectionNames dbm
+    pure (translateError avail se)
 
 {- | Snapshot of currently-loaded method collection names. Read lock-free
 from the live TVar; used to enrich 'CollectionNotLoaded' messages.

--- a/src/API/BatchImpacts.hs
+++ b/src/API/BatchImpacts.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Pure-IO wrappers around the LCIA batch entry points exposed by
+"API.Routes". They let non-Servant callers (notably the MCP tool
+layer) invoke the batch and multi-activity solves without going through
+the Servant Handler stack, and surface a typed 'BatchError' sum instead
+of an opaque 'ServerError'.
+
+The wrappers delegate to 'activityLCIABatchH' and 'batchImpactsH' via
+'Servant.runHandler', then translate the resulting 'ServerError' back
+to a domain-shaped 'BatchError'. The translation matches a fixed set
+of throw sites in "API.Routes" by HTTP status + body prefix; anything
+unrecognised collapses into 'OtherBatchError' (status + verbatim body)
+so failures surface rather than being silently flattened.
+-}
+module API.BatchImpacts (
+    BatchError (..),
+    runActivityLCIABatch,
+    runBatchImpacts,
+) where
+
+import API.Routes (activityLCIABatchH, batchImpactsH)
+import API.Types (BatchImpactsRequest (..), BatchImpactsResponse, LCIABatchResult, SubstitutionRequest)
+import Control.Concurrent.STM (readTVarIO)
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Map as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Database.Manager (DatabaseManager (..))
+import Servant (ServerError (..))
+import qualified Servant
+
+{- | Typed error sum for the batch wrappers. Carries enough context for a
+caller (CLI / MCP handler) to produce an actionable message without
+re-parsing HTTP bodies.
+-}
+data BatchError
+    = {- | Method collection not loaded. Carries the requested name and the
+      list of currently-loaded collection names (for a helpful "did you
+      mean" hint on the client side).
+      -}
+      CollectionNotLoaded Text [Text]
+    | {- | Database not loaded into the running engine. Carries the
+      requested name.
+      -}
+      DatabaseNotLoaded Text
+    | {- | Process ID could not be resolved to an activity, or its
+      format was rejected. Carries the verbatim engine message.
+      -}
+      ActivityResolutionFailed Text
+    | {- | Cross-DB linking / matrix invariant breakage (HTTP 422 in the
+      Servant layer). Carries the verbatim engine message.
+      -}
+      LinkingIncomplete Text
+    | {- | Catch-all for any other 'ServerError' surfaced by the Handler
+      stack. Carries the HTTP status code and the verbatim body so
+      nothing is silently swallowed.
+      -}
+      OtherBatchError Int Text
+    deriving (Eq, Show)
+
+{- | Score one activity against every method in a collection. Returns the
+full 'LCIABatchResult' (per-method scores, per-scoring-set aggregates,
+per-indicator breakdown, units). Substitutions, when supplied, take the
+uncached cross-DB path.
+-}
+runActivityLCIABatch ::
+    DatabaseManager ->
+    -- | database name
+    Text ->
+    -- | process_id (activityUUID_productUUID)
+    Text ->
+    -- | method collection name
+    Text ->
+    -- | optional what-if supplier substitutions
+    Maybe SubstitutionRequest ->
+    IO (Either BatchError LCIABatchResult)
+runActivityLCIABatch dbm dbName pid coll mSub = do
+    avail <- loadedCollectionNames dbm
+    res <- Servant.runHandler (activityLCIABatchH dbm dbName pid coll mSub)
+    pure $ case res of
+        Right lbr -> Right lbr
+        Left se -> Left (translateError avail se)
+
+{- | Score N activities against every method in a collection in one
+multi-RHS MUMPS solve plus parallel characterization. Unresolved process
+IDs land in 'birNotFound' / 'birInvalid' of the response, not in
+'BatchError'.
+-}
+runBatchImpacts ::
+    DatabaseManager ->
+    -- | database name
+    Text ->
+    -- | method collection name
+    Text ->
+    -- | per-(activity, method) top contributors (default 0 — see batchImpactsH)
+    Maybe Int ->
+    -- | process_ids to score
+    [Text] ->
+    IO (Either BatchError BatchImpactsResponse)
+runBatchImpacts dbm dbName coll topFlows pids = do
+    avail <- loadedCollectionNames dbm
+    res <-
+        Servant.runHandler
+            ( batchImpactsH
+                dbm
+                dbName
+                coll
+                topFlows
+                (BatchImpactsRequest{birProcessIds = pids})
+            )
+    pure $ case res of
+        Right r -> Right r
+        Left se -> Left (translateError avail se)
+
+{- | Snapshot of currently-loaded method collection names. Read lock-free
+from the live TVar; used to enrich 'CollectionNotLoaded' messages.
+-}
+loadedCollectionNames :: DatabaseManager -> IO [Text]
+loadedCollectionNames dbm = M.keys <$> readTVarIO (dmLoadedMethods dbm)
+
+{- | Translate a Servant 'ServerError' back to the typed 'BatchError' sum.
+
+The match is by HTTP status + body prefix. The throw sites in
+"API.Routes" that this targets are stable: 'loadCollection' produces
+@404 "Collection not loaded: ..."@, 'resolveOrThrow' produces
+@404 "Activity not found"@ and @400 \<msg\>@, the cross-DB pipeline
+routes 'MatrixError' to @422 \<msg\>@. Anything else falls through to
+'OtherBatchError' rather than being silently coerced.
+-}
+translateError :: [Text] -> ServerError -> BatchError
+translateError availableCollections se
+    | code == 404
+    , Just rest <- T.stripPrefix collectionPrefix body =
+        CollectionNotLoaded rest availableCollections
+    | code == 404
+    , Just rest <- T.stripPrefix databasePrefix body =
+        DatabaseNotLoaded rest
+    | code == 404 = ActivityResolutionFailed body
+    | code == 400 = ActivityResolutionFailed body
+    | code == 422 = LinkingIncomplete body
+    | otherwise = OtherBatchError code body
+  where
+    code = errHTTPCode se
+    body = TE.decodeUtf8 (BSL.toStrict (errBody se))
+    collectionPrefix = "Collection not loaded: "
+    databasePrefix = "Database not loaded: "

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -10,7 +10,6 @@ module API.MCP (mcpApp, toolDefinitions) where
 import Control.Concurrent.STM (readTVarIO)
 import Data.Aeson
 import Data.Aeson.Key (fromText)
-import qualified Data.Aeson.Key as Key
 import Data.Aeson.KeyMap (KeyMap)
 import qualified Data.Aeson.KeyMap as KM
 import qualified Data.ByteString as BS
@@ -23,7 +22,6 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.UUID as UUID
 import Network.HTTP.Types (hContentType, status200, status202, status405)
-import Network.URI (escapeURIString, isUnreserved)
 import Network.Wai (Application, requestHeaders, requestMethod, responseLBS, strictRequestBody)
 import System.Random (randomIO)
 
@@ -36,10 +34,10 @@ import Database.Manager (DatabaseManager (..), LoadedDatabase (..), getDatabase)
 import qualified Database.Manager as DM
 
 import qualified API.BatchImpacts as BI
+import API.MCP.Enrich (addWebUrl, encodeSegment, enrichBatchResults, enrichResultsWithWebUrl, filterScoringSets, filterScoringSetsBatch, scoreActivityWebUrl)
 import API.Types (ActivityForAPI (..), ActivityInfo (..), ClassificationSystem (..), ExchangeWithUnit (..), InventoryExport (..), InventoryFlowDetail (..), Perturbation (..), Substitution (..), SubstitutionRequest (..))
 import Control.Monad (unless)
 import qualified Data.List as L
-import qualified Data.Vector as V
 import Matrix (applyBiosphereMatrix)
 import Method.Mapping (LCIAOutcome (..), MappingStats (..), SimilarCF (..), SimilarReason (..), UncharacterizedFlow (..), computeLCIAScoreAuto, computeLCIAScoreFromTables, computeMappingStats, defaultUncharacterizedOpts, inventoryContributions)
 import qualified Method.Mapping as Mapping
@@ -115,10 +113,6 @@ toolSuccessJson rid val =
 newtype McpState = McpState
     { mcpSessionId :: Text
     }
-
--- | Percent-encode a Text value for use as a URL path segment.
-encodeSegment :: Text -> Text
-encodeSegment = T.pack . escapeURIString isUnreserved . T.unpack
 
 mcpApp :: DatabaseManager -> [ClassificationPreset] -> IO Application
 mcpApp dbManager presets = do
@@ -1743,89 +1737,20 @@ batchErrorMsg err = case err of
     BI.LinkingIncomplete msg -> msg
     BI.OtherBatchError code msg -> "HTTP " <> T.pack (show code) <> ": " <> msg
 
-{- | Add a 'web_url' field to a JSON object at the top level. No-op for
-non-Object values (defensive — the serialized 'LCIABatchResult' /
-'BatchImpactsResponse' shapes are always objects).
+{- | Look up the configured scoring-set names on a loaded method collection.
+Returns the empty list when the collection is not loaded; in that case
+the batch runner has already returned 'BI.CollectionNotLoaded' and the
+filter is never consulted, so the empty result here is harmless. We
+read 'mcScoringSets' directly — not the keys of @scoringResults@ — so
+that a set whose evaluation produced no scores still counts as
+"configured" for the @scoring_sets@ filter.
 -}
-addWebUrl :: Text -> Value -> Value
-addWebUrl url v = case v of
-    Object km -> Object (KM.insert (fromText "web_url") (String url) km)
-    other -> other
-
-{- | Enrich the @results@ array of a serialized 'LCIABatchResult' with a
-per-method 'web_url' built from the per-method @method_id@.
--}
-enrichResultsWithWebUrl :: Text -> Value -> Value
-enrichResultsWithWebUrl baseUrlForCategory v = case v of
-    Object km ->
-        let resultsKey = fromText "results"
-            -- The JSON shape comes from strippedToJSON on LCIAResult, which
-            -- drops the 'lr' prefix and keeps camelCase ('methodId', not
-            -- 'method_id'). Stay aligned with the wire format.
-            enrichOne (Object km') = case KM.lookup (fromText "methodId") km' of
-                Just (String mid) ->
-                    Object
-                        ( KM.insert
-                            (fromText "web_url")
-                            (String (baseUrlForCategory <> "/" <> mid))
-                            km'
-                        )
-                _ -> Object km'
-            enrichOne other = other
-            enrichArray (Array rs) = Array (V.map enrichOne rs)
-            enrichArray other = other
-            updated = case KM.lookup resultsKey km of
-                Just rs -> KM.insert resultsKey (enrichArray rs) km
-                Nothing -> km
-         in Object updated
-    other -> other
-
-{- | If 'requested' is non-empty, restrict the scoring-related maps on a
-serialized 'LCIABatchResult' (or a per-entry @impacts@ subtree) to those
-scoring set names. Errors with the list of configured set names when any
-requested name is unknown — silently dropping a typo'd name would leave
-the caller with a smaller-than-expected payload and no signal.
--}
-filterScoringSets :: [Text] -> Value -> Either Text Value
-filterScoringSets [] v = Right v
-filterScoringSets requested v = case v of
-    Object km ->
-        let srKey = fromText "scoringResults"
-            suKey = fromText "scoringUnits"
-            siKey = fromText "scoringIndicators"
-            available = case KM.lookup srKey km of
-                Just (Object o) -> map Key.toText (KM.keys o)
-                _ -> []
-            requestedSet = requested
-            missing = [r | r <- requestedSet, r `notElem` available]
-            keep k _ = Key.toText k `elem` requestedSet
-            restrict (Object o) = Object (KM.filterWithKey keep o)
-            restrict other = other
-            restrictAt k m = case KM.lookup k m of
-                Just inner -> KM.insert k (restrict inner) m
-                Nothing -> m
-            applied = restrictAt siKey . restrictAt suKey . restrictAt srKey $ km
-         in if not (null missing)
-                then
-                    Left
-                        ( "Unknown scoring set(s): "
-                            <> T.intercalate ", " missing
-                            <> ". Configured on this collection: "
-                            <> T.intercalate ", " available
-                        )
-                else Right (Object applied)
-    _ -> Right v
-
--- | Activity-level impacts page URL (the LCIA batch view in the web UI).
-scoreActivityWebUrl :: Text -> Text -> Text -> Text -> Text
-scoreActivityWebUrl baseUrl dbName pidText coll =
-    baseUrl
-        <> "/db/"
-        <> dbName
-        <> "/activity/"
-        <> pidText
-        <> "/impacts/"
-        <> encodeSegment coll
+configuredScoringSetNames :: DatabaseManager -> Text -> IO [Text]
+configuredScoringSetNames dbm collName = do
+    loaded <- readTVarIO (dmLoadedMethods dbm)
+    pure $ case M.lookup collName loaded of
+        Just mc -> map ssName (mcScoringSets mc)
+        Nothing -> []
 
 {- | Handler for the 'score_activity' MCP tool.
 
@@ -1838,7 +1763,8 @@ enriched with a top-level 'web_url' for the panel view and a per-method
 callScoreActivity :: DatabaseManager -> Text -> Value -> KeyMap Value -> IO Value
 callScoreActivity dbManager baseUrl rid args =
     either (toolError rid) id
-        <$> ( runExceptT $ do
+        <$> runExceptT
+            ( do
                 dbName <- ExceptT $ pure (requireText "database" args)
                 pidText <- ExceptT $ pure (requireText "process_id" args)
                 coll <- ExceptT $ pure (requireText "collection" args)
@@ -1848,27 +1774,31 @@ callScoreActivity dbManager baseUrl rid args =
                 res <- liftIO $ BI.runActivityLCIABatch dbManager dbName pidText coll mSub
                 case res of
                     Left e -> ExceptT $ pure (Left (batchErrorMsg e))
-                    Right lbr ->
+                    Right lbr -> do
+                        configured <- liftIO $ configuredScoringSetNames dbManager coll
                         let topUrl = scoreActivityWebUrl baseUrl dbName pidText coll
                             enriched =
                                 addWebUrl
                                     topUrl
                                     (enrichResultsWithWebUrl topUrl (toJSON lbr))
-                         in ExceptT $ pure (toolSuccessJson rid <$> filterScoringSets wantedSets enriched)
+                        ExceptT $ pure (toolSuccessJson rid <$> filterScoringSets configured wantedSets enriched)
             )
 
 {- | Handler for the 'score_activities' MCP tool.
 
 Scores N activities against every method in a collection in one
 multi-RHS MUMPS solve plus parallel characterization. Each successful
-entry's @impacts@ subtree is enriched with a 'web_url' to its impacts
-page in the web UI. Unresolved process IDs land in @not_found@ /
-@invalid@ of the response, not as a 'BatchError'.
+entry carries a top-level @web_url@ (the activity-level impacts page)
+and the same URL is replicated inside its @impacts@ subtree alongside
+per-method @web_url@s, so clients reading either shape land on the
+right link. Unresolved process IDs land in @not_found@ / @invalid@ of
+the response, not as a 'BatchError'.
 -}
 callScoreActivities :: DatabaseManager -> Text -> Value -> KeyMap Value -> IO Value
 callScoreActivities dbManager baseUrl rid args =
     either (toolError rid) id
-        <$> ( runExceptT $ do
+        <$> runExceptT
+            ( do
                 dbName <- ExceptT $ pure (requireText "database" args)
                 coll <- ExceptT $ pure (requireText "collection" args)
                 pids <- ExceptT $ pure (parseArrayArg "process_ids" (Just "'process_ids' required (array of strings)") args :: Either Text [Text])
@@ -1877,67 +1807,11 @@ callScoreActivities dbManager baseUrl rid args =
                 res <- liftIO $ BI.runBatchImpacts dbManager dbName coll topFlows pids
                 case res of
                     Left e -> ExceptT $ pure (Left (batchErrorMsg e))
-                    Right bir ->
+                    Right bir -> do
+                        configured <- liftIO $ configuredScoringSetNames dbManager coll
                         let enriched = enrichBatchResults baseUrl dbName coll (toJSON bir)
-                         in ExceptT $ pure (toolSuccessJson rid <$> filterScoringSetsBatch wantedSets enriched)
+                        ExceptT $ pure (toolSuccessJson rid <$> filterScoringSetsBatch configured wantedSets enriched)
             )
-
-{- | Apply 'filterScoringSets' to every @impacts@ subtree of a serialized
-'BatchImpactsResponse'. Fails fast on the first entry that references an
-unknown scoring set name — the configuration is collection-wide, so a
-bad name fails identically for every entry.
--}
-filterScoringSetsBatch :: [Text] -> Value -> Either Text Value
-filterScoringSetsBatch [] v = Right v
-filterScoringSetsBatch wanted v = case v of
-    Object km ->
-        let resultsKey = fromText "results"
-            impactsKey = fromText "impacts"
-            filterEntry (Object entryKM) = case KM.lookup impactsKey entryKM of
-                Just impactsValue -> do
-                    filteredImpacts <- filterScoringSets wanted impactsValue
-                    pure (Object (KM.insert impactsKey filteredImpacts entryKM))
-                Nothing -> Right (Object entryKM)
-            filterEntry other = Right other
-            filterArray (Array rs) = Array <$> traverse filterEntry rs
-            filterArray other = Right other
-         in case KM.lookup resultsKey km of
-                Just rs -> do
-                    rs' <- filterArray rs
-                    Right (Object (KM.insert resultsKey rs' km))
-                Nothing -> Right v
-    _ -> Right v
-
-{- | Enrich each entry of a serialized 'BatchImpactsResponse' with a
-@web_url@ pointing at the activity-level impacts page. Per-method
-@web_url@s inside each entry's @impacts.results@ are also added by
-reusing 'enrichResultsWithWebUrl'.
--}
-enrichBatchResults :: Text -> Text -> Text -> Value -> Value
-enrichBatchResults baseUrl dbName coll v = case v of
-    Object km ->
-        let resultsKey = fromText "results"
-            impactsKey = fromText "impacts"
-            -- strippedToJSON on BatchImpactsEntry drops 'bie' prefix and
-            -- keeps camelCase: the field is 'processId', not 'process_id'.
-            processIdKey = fromText "processId"
-            enrichEntry (Object km') = case KM.lookup processIdKey km' of
-                Just (String pidText) ->
-                    let url = scoreActivityWebUrl baseUrl dbName pidText coll
-                        enrichedImpacts = case KM.lookup impactsKey km' of
-                            Just impactsValue ->
-                                addWebUrl url (enrichResultsWithWebUrl url impactsValue)
-                            Nothing -> Object KM.empty
-                     in Object (KM.insert impactsKey enrichedImpacts km')
-                _ -> Object km'
-            enrichEntry other = other
-            enrichArray (Array rs) = Array (V.map enrichEntry rs)
-            enrichArray other = other
-            updated = case KM.lookup resultsKey km of
-                Just rs -> KM.insert resultsKey (enrichArray rs) km
-                Nothing -> km
-         in Object updated
-    other -> other
 
 {- | Handler for the 'list_scoring_sets' MCP tool.
 

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -10,6 +10,7 @@ module API.MCP (mcpApp, toolDefinitions) where
 import Control.Concurrent.STM (readTVarIO)
 import Data.Aeson
 import Data.Aeson.Key (fromText)
+import qualified Data.Aeson.Key as Key
 import Data.Aeson.KeyMap (KeyMap)
 import qualified Data.Aeson.KeyMap as KM
 import qualified Data.ByteString as BS
@@ -1779,6 +1780,42 @@ enrichResultsWithWebUrl baseUrlForCategory v = case v of
          in Object updated
     other -> other
 
+{- | If 'requested' is non-empty, restrict the scoring-related maps on a
+serialized 'LCIABatchResult' (or a per-entry @impacts@ subtree) to those
+scoring set names. Errors with the list of configured set names when any
+requested name is unknown — silently dropping a typo'd name would leave
+the caller with a smaller-than-expected payload and no signal.
+-}
+filterScoringSets :: [Text] -> Value -> Either Text Value
+filterScoringSets [] v = Right v
+filterScoringSets requested v = case v of
+    Object km ->
+        let srKey = fromText "scoringResults"
+            suKey = fromText "scoringUnits"
+            siKey = fromText "scoringIndicators"
+            available = case KM.lookup srKey km of
+                Just (Object o) -> map Key.toText (KM.keys o)
+                _ -> []
+            requestedSet = requested
+            missing = [r | r <- requestedSet, r `notElem` available]
+            keep k _ = Key.toText k `elem` requestedSet
+            restrict (Object o) = Object (KM.filterWithKey keep o)
+            restrict other = other
+            restrictAt k m = case KM.lookup k m of
+                Just inner -> KM.insert k (restrict inner) m
+                Nothing -> m
+            applied = restrictAt siKey . restrictAt suKey . restrictAt srKey $ km
+         in if not (null missing)
+                then
+                    Left
+                        ( "Unknown scoring set(s): "
+                            <> T.intercalate ", " missing
+                            <> ". Configured on this collection: "
+                            <> T.intercalate ", " available
+                        )
+                else Right (Object applied)
+    _ -> Right v
+
 -- | Activity-level impacts page URL (the LCIA batch view in the web UI).
 scoreActivityWebUrl :: Text -> Text -> Text -> Text -> Text
 scoreActivityWebUrl baseUrl dbName pidText coll =
@@ -1806,6 +1843,7 @@ callScoreActivity dbManager baseUrl rid args =
                 pidText <- ExceptT $ pure (requireText "process_id" args)
                 coll <- ExceptT $ pure (requireText "collection" args)
                 subs <- ExceptT $ pure (parseArrayArg "substitutions" Nothing args :: Either Text [Substitution])
+                wantedSets <- ExceptT $ pure (parseArrayArg "scoring_sets" Nothing args :: Either Text [Text])
                 let mSub = if null subs then Nothing else Just SubstitutionRequest{srSubstitutions = subs}
                 res <- liftIO $ BI.runActivityLCIABatch dbManager dbName pidText coll mSub
                 case res of
@@ -1816,7 +1854,7 @@ callScoreActivity dbManager baseUrl rid args =
                                 addWebUrl
                                     topUrl
                                     (enrichResultsWithWebUrl topUrl (toJSON lbr))
-                         in pure (toolSuccessJson rid enriched)
+                         in ExceptT $ pure (toolSuccessJson rid <$> filterScoringSets wantedSets enriched)
             )
 
 {- | Handler for the 'score_activities' MCP tool.
@@ -1834,14 +1872,41 @@ callScoreActivities dbManager baseUrl rid args =
                 dbName <- ExceptT $ pure (requireText "database" args)
                 coll <- ExceptT $ pure (requireText "collection" args)
                 pids <- ExceptT $ pure (parseArrayArg "process_ids" (Just "'process_ids' required (array of strings)") args :: Either Text [Text])
+                wantedSets <- ExceptT $ pure (parseArrayArg "scoring_sets" Nothing args :: Either Text [Text])
                 let topFlows = intArg "top_flows" args
                 res <- liftIO $ BI.runBatchImpacts dbManager dbName coll topFlows pids
                 case res of
                     Left e -> ExceptT $ pure (Left (batchErrorMsg e))
                     Right bir ->
                         let enriched = enrichBatchResults baseUrl dbName coll (toJSON bir)
-                         in pure (toolSuccessJson rid enriched)
+                         in ExceptT $ pure (toolSuccessJson rid <$> filterScoringSetsBatch wantedSets enriched)
             )
+
+{- | Apply 'filterScoringSets' to every @impacts@ subtree of a serialized
+'BatchImpactsResponse'. Fails fast on the first entry that references an
+unknown scoring set name — the configuration is collection-wide, so a
+bad name fails identically for every entry.
+-}
+filterScoringSetsBatch :: [Text] -> Value -> Either Text Value
+filterScoringSetsBatch [] v = Right v
+filterScoringSetsBatch wanted v = case v of
+    Object km ->
+        let resultsKey = fromText "results"
+            impactsKey = fromText "impacts"
+            filterEntry (Object entryKM) = case KM.lookup impactsKey entryKM of
+                Just impactsValue -> do
+                    filteredImpacts <- filterScoringSets wanted impactsValue
+                    pure (Object (KM.insert impactsKey filteredImpacts entryKM))
+                Nothing -> Right (Object entryKM)
+            filterEntry other = Right other
+            filterArray (Array rs) = Array <$> traverse filterEntry rs
+            filterArray other = Right other
+         in case KM.lookup resultsKey km of
+                Just rs -> do
+                    rs' <- filterArray rs
+                    Right (Object (KM.insert resultsKey rs' km))
+                Nothing -> Right v
+    _ -> Right v
 
 {- | Enrich each entry of a serialized 'BatchImpactsResponse' with a
 @web_url@ pointing at the activity-level impacts page. Per-method

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -399,6 +399,27 @@ requireText :: Text -> KeyMap Value -> Either Text Text
 requireText key args =
     maybe (Left ("Missing required parameter: " <> key)) Right (textArg key args)
 
+{- | Optional text argument. Distinguishes three cases that 'requireText'
+silently collapses:
+
+  * key absent (or explicitly @null@) — 'Right Nothing'
+  * present as a string — 'Right (Just ...)'
+  * present but the wrong JSON type — 'Left' with a message naming the
+    actual type, so a typo like @{"collection": 42}@ surfaces instead of
+    being treated as "omitted".
+-}
+optionalText :: Text -> KeyMap Value -> Either Text (Maybe Text)
+optionalText key args = case KM.lookup (fromText key) args of
+    Nothing -> Right Nothing
+    Just Null -> Right Nothing
+    Just (String t) -> Right (Just t)
+    Just (Object _) -> wrongType "object"
+    Just (Array _) -> wrongType "array"
+    Just (Number _) -> wrongType "number"
+    Just (Bool _) -> wrongType "boolean"
+  where
+    wrongType ty = Left ("Parameter '" <> key <> "' must be a string, got " <> ty)
+
 -- | Read an argument that may be either a JSON array of strings or a single string.
 textArrayArg :: Text -> KeyMap Value -> [Text]
 textArrayArg key args = case KM.lookup (fromText key) args of
@@ -1827,12 +1848,10 @@ addition to 'ScoringSet'.
 callListScoringSets :: DatabaseManager -> Value -> KeyMap Value -> IO Value
 callListScoringSets dbManager rid args = do
     loaded <- readTVarIO (dmLoadedMethods dbManager)
-    let mCollection = case requireText "collection" args of
-            Right t -> Just t
-            Left _ -> Nothing
-    case mCollection of
-        Nothing -> return $ toolSuccessJson rid (encodeAll loaded)
-        Just collName -> case M.lookup collName loaded of
+    case optionalText "collection" args of
+        Left err -> return $ toolError rid err
+        Right Nothing -> return $ toolSuccessJson rid (encodeAll loaded)
+        Right (Just collName) -> case M.lookup collName loaded of
             Nothing ->
                 return $
                     toolError

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -34,9 +34,11 @@ import Control.Monad.Trans.Except (ExceptT (..), runExceptT, throwE)
 import Database.Manager (DatabaseManager (..), LoadedDatabase (..), getDatabase)
 import qualified Database.Manager as DM
 
-import API.Types (ActivityForAPI (..), ActivityInfo (..), ClassificationSystem (..), ExchangeWithUnit (..), InventoryExport (..), InventoryFlowDetail (..), Perturbation (..), Substitution (..))
+import qualified API.BatchImpacts as BI
+import API.Types (ActivityForAPI (..), ActivityInfo (..), ClassificationSystem (..), ExchangeWithUnit (..), InventoryExport (..), InventoryFlowDetail (..), Perturbation (..), Substitution (..), SubstitutionRequest (..))
 import Control.Monad (unless)
 import qualified Data.List as L
+import qualified Data.Vector as V
 import Matrix (applyBiosphereMatrix)
 import Method.Mapping (LCIAOutcome (..), MappingStats (..), SimilarCF (..), SimilarReason (..), UncharacterizedFlow (..), computeLCIAScoreAuto, computeLCIAScoreFromTables, computeMappingStats, defaultUncharacterizedOpts, inventoryContributions)
 import qualified Method.Mapping as Mapping
@@ -351,6 +353,7 @@ callTool dbManager presets baseUrl rid name args = case name of
     "get_path_to" -> withDb dbManager rid args $ callGetPathTo rid args
     "get_consumers" -> withDb dbManager rid args $ callGetConsumers presets rid args
     "compare_impacts" -> callCompareImpacts dbManager rid args
+    "score_activity" -> callScoreActivity dbManager baseUrl rid args
     _ -> return $ toolError rid ("Unknown tool: " <> name)
 
 -- Helper: extract database, then run action
@@ -1713,3 +1716,100 @@ callListGeographies dbManager rid args =
                         toolSuccessJson rid $
                             object
                                 ["geographies" .= map mkEntry codes]
+
+-- ============================================================================
+-- score_activity / score_activities / list_scoring_sets
+--
+-- Wrappers around API.BatchImpacts so a single MCP call yields the full
+-- LCIA panel + every configured scoring set + per-indicator breakdown,
+-- removing the N round-trips of get_impacts a comparative study used to
+-- need. Each response is enriched with a 'web_url' deep link to the
+-- matching web UI view so a human can continue the exploration visually.
+-- ============================================================================
+
+-- | Translate a 'BI.BatchError' into the MCP 'toolError' payload.
+batchErrorMsg :: BI.BatchError -> Text
+batchErrorMsg err = case err of
+    BI.CollectionNotLoaded name available ->
+        "Collection not loaded: "
+            <> name
+            <> ". Available collections: "
+            <> T.intercalate ", " available
+    BI.DatabaseNotLoaded name -> "Database not loaded: " <> name
+    BI.ActivityResolutionFailed msg -> msg
+    BI.LinkingIncomplete msg -> msg
+    BI.OtherBatchError code msg -> "HTTP " <> T.pack (show code) <> ": " <> msg
+
+{- | Add a 'web_url' field to a JSON object at the top level. No-op for
+non-Object values (defensive — the serialized 'LCIABatchResult' /
+'BatchImpactsResponse' shapes are always objects).
+-}
+addWebUrl :: Text -> Value -> Value
+addWebUrl url v = case v of
+    Object km -> Object (KM.insert (fromText "web_url") (String url) km)
+    other -> other
+
+{- | Enrich the @results@ array of a serialized 'LCIABatchResult' with a
+per-method 'web_url' built from the per-method @method_id@.
+-}
+enrichResultsWithWebUrl :: Text -> Value -> Value
+enrichResultsWithWebUrl baseUrlForCategory v = case v of
+    Object km ->
+        let resultsKey = fromText "results"
+            enrichOne (Object km') = case KM.lookup (fromText "method_id") km' of
+                Just (String mid) ->
+                    Object
+                        ( KM.insert
+                            (fromText "web_url")
+                            (String (baseUrlForCategory <> "/" <> mid))
+                            km'
+                        )
+                _ -> Object km'
+            enrichOne other = other
+            enrichArray (Array rs) = Array (V.map enrichOne rs)
+            enrichArray other = other
+            updated = case KM.lookup resultsKey km of
+                Just rs -> KM.insert resultsKey (enrichArray rs) km
+                Nothing -> km
+         in Object updated
+    other -> other
+
+-- | Activity-level impacts page URL (the LCIA batch view in the web UI).
+scoreActivityWebUrl :: Text -> Text -> Text -> Text -> Text
+scoreActivityWebUrl baseUrl dbName pidText coll =
+    baseUrl
+        <> "/db/"
+        <> dbName
+        <> "/activity/"
+        <> pidText
+        <> "/impacts/"
+        <> encodeSegment coll
+
+{- | Handler for the 'score_activity' MCP tool.
+
+Returns the full LCIABatchResult shape (per-method scores, per-scoring-set
+aggregate scores, per-indicator breakdown, units) for a single activity,
+enriched with a top-level 'web_url' for the panel view and a per-method
+'web_url' in each @results@ entry. Replaces the @N@ round-trips of
+'get_impacts' a comparative study used to need.
+-}
+callScoreActivity :: DatabaseManager -> Text -> Value -> KeyMap Value -> IO Value
+callScoreActivity dbManager baseUrl rid args =
+    either (toolError rid) id
+        <$> ( runExceptT $ do
+                dbName <- ExceptT $ pure (requireText "database" args)
+                pidText <- ExceptT $ pure (requireText "process_id" args)
+                coll <- ExceptT $ pure (requireText "collection" args)
+                subs <- ExceptT $ pure (parseArrayArg "substitutions" Nothing args :: Either Text [Substitution])
+                let mSub = if null subs then Nothing else Just SubstitutionRequest{srSubstitutions = subs}
+                res <- liftIO $ BI.runActivityLCIABatch dbManager dbName pidText coll mSub
+                case res of
+                    Left e -> ExceptT $ pure (Left (batchErrorMsg e))
+                    Right lbr ->
+                        let topUrl = scoreActivityWebUrl baseUrl dbName pidText coll
+                            enriched =
+                                addWebUrl
+                                    topUrl
+                                    (enrichResultsWithWebUrl topUrl (toJSON lbr))
+                         in pure (toolSuccessJson rid enriched)
+            )

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -1758,7 +1758,10 @@ enrichResultsWithWebUrl :: Text -> Value -> Value
 enrichResultsWithWebUrl baseUrlForCategory v = case v of
     Object km ->
         let resultsKey = fromText "results"
-            enrichOne (Object km') = case KM.lookup (fromText "method_id") km' of
+            -- The JSON shape comes from strippedToJSON on LCIAResult, which
+            -- drops the 'lr' prefix and keeps camelCase ('methodId', not
+            -- 'method_id'). Stay aligned with the wire format.
+            enrichOne (Object km') = case KM.lookup (fromText "methodId") km' of
                 Just (String mid) ->
                     Object
                         ( KM.insert
@@ -1850,7 +1853,9 @@ enrichBatchResults baseUrl dbName coll v = case v of
     Object km ->
         let resultsKey = fromText "results"
             impactsKey = fromText "impacts"
-            processIdKey = fromText "process_id"
+            -- strippedToJSON on BatchImpactsEntry drops 'bie' prefix and
+            -- keeps camelCase: the field is 'processId', not 'process_id'.
+            processIdKey = fromText "processId"
             enrichEntry (Object km') = case KM.lookup processIdKey km' of
                 Just (String pidText) ->
                     let url = scoreActivityWebUrl baseUrl dbName pidText coll

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -354,6 +354,7 @@ callTool dbManager presets baseUrl rid name args = case name of
     "get_consumers" -> withDb dbManager rid args $ callGetConsumers presets rid args
     "compare_impacts" -> callCompareImpacts dbManager rid args
     "score_activity" -> callScoreActivity dbManager baseUrl rid args
+    "score_activities" -> callScoreActivities dbManager baseUrl rid args
     _ -> return $ toolError rid ("Unknown tool: " <> name)
 
 -- Helper: extract database, then run action
@@ -1813,3 +1814,56 @@ callScoreActivity dbManager baseUrl rid args =
                                     (enrichResultsWithWebUrl topUrl (toJSON lbr))
                          in pure (toolSuccessJson rid enriched)
             )
+
+{- | Handler for the 'score_activities' MCP tool.
+
+Scores N activities against every method in a collection in one
+multi-RHS MUMPS solve plus parallel characterization. Each successful
+entry's @impacts@ subtree is enriched with a 'web_url' to its impacts
+page in the web UI. Unresolved process IDs land in @not_found@ /
+@invalid@ of the response, not as a 'BatchError'.
+-}
+callScoreActivities :: DatabaseManager -> Text -> Value -> KeyMap Value -> IO Value
+callScoreActivities dbManager baseUrl rid args =
+    either (toolError rid) id
+        <$> ( runExceptT $ do
+                dbName <- ExceptT $ pure (requireText "database" args)
+                coll <- ExceptT $ pure (requireText "collection" args)
+                pids <- ExceptT $ pure (parseArrayArg "process_ids" (Just "'process_ids' required (array of strings)") args :: Either Text [Text])
+                let topFlows = intArg "top_flows" args
+                res <- liftIO $ BI.runBatchImpacts dbManager dbName coll topFlows pids
+                case res of
+                    Left e -> ExceptT $ pure (Left (batchErrorMsg e))
+                    Right bir ->
+                        let enriched = enrichBatchResults baseUrl dbName coll (toJSON bir)
+                         in pure (toolSuccessJson rid enriched)
+            )
+
+{- | Enrich each entry of a serialized 'BatchImpactsResponse' with a
+@web_url@ pointing at the activity-level impacts page. Per-method
+@web_url@s inside each entry's @impacts.results@ are also added by
+reusing 'enrichResultsWithWebUrl'.
+-}
+enrichBatchResults :: Text -> Text -> Text -> Value -> Value
+enrichBatchResults baseUrl dbName coll v = case v of
+    Object km ->
+        let resultsKey = fromText "results"
+            impactsKey = fromText "impacts"
+            processIdKey = fromText "process_id"
+            enrichEntry (Object km') = case KM.lookup processIdKey km' of
+                Just (String pidText) ->
+                    let url = scoreActivityWebUrl baseUrl dbName pidText coll
+                        enrichedImpacts = case KM.lookup impactsKey km' of
+                            Just impactsValue ->
+                                addWebUrl url (enrichResultsWithWebUrl url impactsValue)
+                            Nothing -> Object KM.empty
+                     in Object (KM.insert impactsKey enrichedImpacts km')
+                _ -> Object km'
+            enrichEntry other = other
+            enrichArray (Array rs) = Array (V.map enrichEntry rs)
+            enrichArray other = other
+            updated = case KM.lookup resultsKey km of
+                Just rs -> KM.insert resultsKey (enrichArray rs) km
+                Nothing -> km
+         in Object updated
+    other -> other

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -42,7 +42,7 @@ import qualified Data.Vector as V
 import Matrix (applyBiosphereMatrix)
 import Method.Mapping (LCIAOutcome (..), MappingStats (..), SimilarCF (..), SimilarReason (..), UncharacterizedFlow (..), computeLCIAScoreAuto, computeLCIAScoreFromTables, computeMappingStats, defaultUncharacterizedOpts, inventoryContributions)
 import qualified Method.Mapping as Mapping
-import Method.Types (FlowDirection (..), Method (..), MethodCF (..))
+import Method.Types (FlowDirection (..), Method (..), MethodCF (..), MethodCollection (..), ScoringSet (..))
 import Network.HTTP.Types.Header (hAccept, hHost)
 import Numeric (showFFloat)
 import Plugin.Types ()
@@ -355,6 +355,7 @@ callTool dbManager presets baseUrl rid name args = case name of
     "compare_impacts" -> callCompareImpacts dbManager rid args
     "score_activity" -> callScoreActivity dbManager baseUrl rid args
     "score_activities" -> callScoreActivities dbManager baseUrl rid args
+    "list_scoring_sets" -> callListScoringSets dbManager rid args
     _ -> return $ toolError rid ("Unknown tool: " <> name)
 
 -- Helper: extract database, then run action
@@ -1867,3 +1868,59 @@ enrichBatchResults baseUrl dbName coll v = case v of
                 Nothing -> km
          in Object updated
     other -> other
+
+{- | Handler for the 'list_scoring_sets' MCP tool.
+
+Returns the formula-based scoring sets configured on every loaded
+'MethodCollection'. Pure read from the live TVar; no HTTP equivalent.
+When 'collection' is supplied, filters to that one and errors if it is
+not loaded (listing the loaded names in the message).
+
+The projection is explicit (rather than @toJSON ss@) so the wire format
+stays in snake_case and is not silently affected by a future field
+addition to 'ScoringSet'.
+-}
+callListScoringSets :: DatabaseManager -> Value -> KeyMap Value -> IO Value
+callListScoringSets dbManager rid args = do
+    loaded <- readTVarIO (dmLoadedMethods dbManager)
+    let mCollection = case requireText "collection" args of
+            Right t -> Just t
+            Left _ -> Nothing
+    case mCollection of
+        Nothing -> return $ toolSuccessJson rid (encodeAll loaded)
+        Just collName -> case M.lookup collName loaded of
+            Nothing ->
+                return $
+                    toolError
+                        rid
+                        ( "Collection not loaded: "
+                            <> collName
+                            <> ". Available collections: "
+                            <> T.intercalate ", " (M.keys loaded)
+                        )
+            Just mc -> return $ toolSuccessJson rid (encodeAll (M.singleton collName mc))
+  where
+    encodeAll :: M.Map Text MethodCollection -> Value
+    encodeAll loaded =
+        object
+            [ "collections"
+                .= [ object
+                        [ "collection" .= cName
+                        , "scoring_sets" .= map encodeScoringSet (mcScoringSets mc)
+                        ]
+                   | (cName, mc) <- M.toList loaded
+                   ]
+            ]
+
+    encodeScoringSet :: ScoringSet -> Value
+    encodeScoringSet ss =
+        object
+            [ "name" .= ssName ss
+            , "unit" .= ssUnit ss
+            , "variables" .= ssVariables ss
+            , "computed" .= ssComputed ss
+            , "normalization" .= ssNormalization ss
+            , "weighting" .= ssWeighting ss
+            , "scores" .= ssScores ss
+            , "display_multiplier" .= ssDisplayMultiplier ss
+            ]

--- a/src/API/MCP/Enrich.hs
+++ b/src/API/MCP/Enrich.hs
@@ -1,0 +1,302 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Pure JSON munging used by the @score_activity@ / @score_activities@
+MCP tools.
+
+Two responsibilities:
+
+  * Decorate the serialized 'LCIABatchResult' / 'BatchImpactsResponse'
+    with @web_url@ deep links so MCP clients can hand a human a clickable
+    follow-up.
+  * Restrict the response to a user-requested subset of scoring sets,
+    failing loudly on names that are not configured on the collection.
+
+Every traversal goes through 'overObject' / 'overObjectE' / 'overArray' /
+'overArrayE', the single place that has to enumerate every constructor
+of Aeson's 'Value'. Callers stay free of wildcard patterns on the sum.
+-}
+module API.MCP.Enrich (
+    -- * URL helpers
+    encodeSegment,
+    scoreActivityWebUrl,
+
+    -- * web_url enrichment
+    addWebUrl,
+    enrichResultsWithWebUrl,
+    enrichBatchResults,
+
+    -- * scoring_sets filter
+    filterScoringSets,
+    filterScoringSetsBatch,
+
+    -- * Value combinators (exported for tests)
+    overObject,
+    overObjectE,
+    overArray,
+    valueText,
+) where
+
+import Data.Aeson (Value (..))
+import Data.Aeson.Key (fromText)
+import qualified Data.Aeson.Key as Key
+import Data.Aeson.KeyMap (KeyMap)
+import qualified Data.Aeson.KeyMap as KM
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Vector as V
+import Network.URI (escapeURIString, isUnreserved)
+
+-- ---------------------------------------------------------------------------
+-- Value combinators — single point of exhaustive Aeson pattern matching
+-- ---------------------------------------------------------------------------
+
+{- | Apply 'f' to the contents of a JSON Object; pass any other 'Value'
+shape through unchanged. One exhaustive match lives here so individual
+callers do not sprinkle wildcards.
+-}
+overObject :: (KeyMap Value -> KeyMap Value) -> Value -> Value
+overObject f = \case
+    Object km -> Object (f km)
+    Array a -> Array a
+    String s -> String s
+    Number n -> Number n
+    Bool b -> Bool b
+    Null -> Null
+
+-- | Same as 'overObject' but the transformation may fail with 'Text'.
+overObjectE :: (KeyMap Value -> Either Text (KeyMap Value)) -> Value -> Either Text Value
+overObjectE f = \case
+    Object km -> Object <$> f km
+    Array a -> Right (Array a)
+    String s -> Right (String s)
+    Number n -> Right (Number n)
+    Bool b -> Right (Bool b)
+    Null -> Right Null
+
+-- | Apply 'f' to each element of a JSON Array; pass any other shape through.
+overArray :: (Value -> Value) -> Value -> Value
+overArray f = \case
+    Array v -> Array (V.map f v)
+    Object km -> Object km
+    String s -> String s
+    Number n -> Number n
+    Bool b -> Bool b
+    Null -> Null
+
+-- | Pull a 'Text' out of a 'Value' (only 'String' is admitted).
+valueText :: Value -> Maybe Text
+valueText = \case
+    String s -> Just s
+    Object _ -> Nothing
+    Array _ -> Nothing
+    Number _ -> Nothing
+    Bool _ -> Nothing
+    Null -> Nothing
+
+-- ---------------------------------------------------------------------------
+-- URL helpers
+-- ---------------------------------------------------------------------------
+
+-- | Percent-encode a 'Text' value for use as a URL path segment.
+encodeSegment :: Text -> Text
+encodeSegment = T.pack . escapeURIString isUnreserved . T.unpack
+
+{- | Activity-level impacts page URL (the LCIA batch view in the web UI).
+Every dynamic segment is percent-encoded so a 'dbName' \/ 'processId' \/
+'collection' that contains @/@ or @?@ does not silently fracture the
+URL.
+-}
+scoreActivityWebUrl :: Text -> Text -> Text -> Text -> Text
+scoreActivityWebUrl baseUrl dbName pidText coll =
+    baseUrl
+        <> "/db/"
+        <> encodeSegment dbName
+        <> "/activity/"
+        <> encodeSegment pidText
+        <> "/impacts/"
+        <> encodeSegment coll
+
+-- ---------------------------------------------------------------------------
+-- web_url enrichment
+-- ---------------------------------------------------------------------------
+
+webUrlKey, resultsKey, impactsKey, processIdKey, methodIdKey :: Key.Key
+webUrlKey = fromText "web_url"
+resultsKey = fromText "results"
+impactsKey = fromText "impacts"
+-- 'strippedToJSON' on the API record drops the field prefix and keeps
+-- camelCase; stay aligned with what 'LCIABatchResult' / 'BatchImpactsEntry'
+-- actually serialize to ('methodId', not 'method_id').
+processIdKey = fromText "processId"
+methodIdKey = fromText "methodId"
+
+-- | Add a 'web_url' field to a JSON object at the top level.
+addWebUrl :: Text -> Value -> Value
+addWebUrl url = overObject (KM.insert webUrlKey (String url))
+
+{- | Enrich the @results@ array of a serialized 'LCIABatchResult' with a
+per-method 'web_url' built from each entry's @methodId@. Entries
+without a string @methodId@ are passed through unchanged.
+-}
+enrichResultsWithWebUrl :: Text -> Value -> Value
+enrichResultsWithWebUrl baseUrlForCategory =
+    overObject (adjustKey resultsKey (overArray (enrichResultEntry baseUrlForCategory)))
+
+enrichResultEntry :: Text -> Value -> Value
+enrichResultEntry baseUrlForCategory =
+    overObject $ \km ->
+        case KM.lookup methodIdKey km >>= valueText of
+            Just mid ->
+                KM.insert webUrlKey (String (baseUrlForCategory <> "/" <> mid)) km
+            Nothing -> km
+
+{- | Enrich each entry of a serialized 'BatchImpactsResponse' with a
+@web_url@ pointing at the activity-level impacts page.
+
+The URL is attached at two levels of each entry:
+
+  * @results[i].web_url@ — promised by the @score_activities@ resource
+    description; a client reading the entry shape directly lands on it.
+  * @results[i].impacts.web_url@ (plus per-method @web_url@s under
+    @impacts.results@) — same shape as a standalone @score_activity@
+    response.
+
+An entry that lacks an @impacts@ subtree (defensive — the
+'BatchImpactsEntry' record guarantees one) is left untouched in that
+subtree, rather than gaining an empty placeholder.
+-}
+enrichBatchResults :: Text -> Text -> Text -> Value -> Value
+enrichBatchResults baseUrl dbName coll =
+    overObject (adjustKey resultsKey (overArray (enrichBatchEntry baseUrl dbName coll)))
+
+enrichBatchEntry :: Text -> Text -> Text -> Value -> Value
+enrichBatchEntry baseUrl dbName coll =
+    overObject $ \km ->
+        case KM.lookup processIdKey km >>= valueText of
+            Just pidText ->
+                let url = scoreActivityWebUrl baseUrl dbName pidText coll
+                    withImpacts = case KM.lookup impactsKey km of
+                        Just impactsValue ->
+                            KM.insert
+                                impactsKey
+                                (addWebUrl url (enrichResultsWithWebUrl url impactsValue))
+                                km
+                        Nothing -> km
+                 in KM.insert webUrlKey (String url) withImpacts
+            Nothing -> km
+
+-- ---------------------------------------------------------------------------
+-- scoring_sets filter
+-- ---------------------------------------------------------------------------
+
+{- | Restrict the scoring-related maps on a serialized 'LCIABatchResult'
+to the scoring-set names in 'requested'.
+
+'configured' is the authoritative list of scoring-set names defined on
+the method collection (e.g. @map ssName . mcScoringSets@). Validation
+runs against it — not against the keys actually present in
+@scoringResults@ — so:
+
+  * A configured scoring set whose evaluation produced no scores (and
+    is therefore absent from @scoringResults@) is still accepted by
+    the filter, instead of being incorrectly reported as unknown.
+  * The "unknown name" error message lists the same set of legal
+    values regardless of evaluation outcomes.
+
+An empty 'requested' is a no-op; an unknown name is a hard error.
+-}
+filterScoringSets :: [Text] -> [Text] -> Value -> Either Text Value
+filterScoringSets _ [] v = Right v
+filterScoringSets configured requested v = do
+    validateRequested configured requested
+    Right (restrictScoringSets requested v)
+
+{- | Apply 'filterScoringSets' to every entry's @impacts@ subtree in a
+serialized 'BatchImpactsResponse'.
+
+Validation runs once at the top level — not inside each entry — so a
+batch with zero successful entries still surfaces an unknown-name
+error. Otherwise a @score_activities@ call where every PID is invalid
+would silently swallow a typo'd scoring-set filter.
+-}
+filterScoringSetsBatch :: [Text] -> [Text] -> Value -> Either Text Value
+filterScoringSetsBatch _ [] v = Right v
+filterScoringSetsBatch configured requested v = do
+    validateRequested configured requested
+    overObjectE (traverseKey resultsKey (overArrayE (filterEntry requested))) v
+
+{- | Check 'requested' against 'configured', failing with a message that
+lists the missing names and the legal options.
+-}
+validateRequested :: [Text] -> [Text] -> Either Text ()
+validateRequested configured requested =
+    case [r | r <- requested, r `notElem` configured] of
+        [] -> Right ()
+        missing ->
+            Left
+                ( "Unknown scoring set(s): "
+                    <> T.intercalate ", " missing
+                    <> ". Configured on this collection: "
+                    <> T.intercalate ", " configured
+                )
+
+{- | Filter the three scoring maps to keys in 'requested'. Validation has
+already run in the caller.
+-}
+restrictScoringSets :: [Text] -> Value -> Value
+restrictScoringSets requested =
+    overObject (restrictAt scoringIndicatorsKey . restrictAt scoringUnitsKey . restrictAt scoringResultsKey)
+  where
+    scoringResultsKey = fromText "scoringResults"
+    scoringUnitsKey = fromText "scoringUnits"
+    scoringIndicatorsKey = fromText "scoringIndicators"
+    keep k _ = Key.toText k `elem` requested
+    restrict = overObject (KM.filterWithKey keep)
+    restrictAt k = adjustKey k restrict
+
+-- | Restrict one entry's @impacts@ subtree; entries without one pass through.
+filterEntry :: [Text] -> Value -> Either Text Value
+filterEntry requested =
+    overObjectE $ \km ->
+        case KM.lookup impactsKey km of
+            Just impactsValue ->
+                Right (KM.insert impactsKey (restrictScoringSets requested impactsValue) km)
+            Nothing -> Right km
+
+{- | Apply a 'Value' → 'Either' transformation to each element of an
+Array; non-Array values pass through.
+-}
+overArrayE :: (Value -> Either Text Value) -> Value -> Either Text Value
+overArrayE f = \case
+    Array v -> Array . V.fromList <$> traverse f (V.toList v)
+    Object km -> Right (Object km)
+    String s -> Right (String s)
+    Number n -> Right (Number n)
+    Bool b -> Right (Bool b)
+    Null -> Right Null
+
+{- | Update one key of a 'KeyMap' via a transformation that may fail; if
+the key is absent, the map is returned unchanged.
+-}
+traverseKey ::
+    Key.Key ->
+    (Value -> Either Text Value) ->
+    KeyMap Value ->
+    Either Text (KeyMap Value)
+traverseKey k f km =
+    case KM.lookup k km of
+        Just v -> do
+            v' <- f v
+            pure (KM.insert k v' km)
+        Nothing -> Right km
+
+{- | Update one key of a 'KeyMap' via a pure transformation; if the key
+is absent, the map is returned unchanged. (Aeson's 'KeyMap' has no
+@adjust@ of its own.)
+-}
+adjustKey :: Key.Key -> (Value -> Value) -> KeyMap Value -> KeyMap Value
+adjustKey k f km =
+    case KM.lookup k km of
+        Just v -> KM.insert k (f v) km
+        Nothing -> km

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -424,6 +424,24 @@ pSubstitutions =
         \PIDs can be bare (root DB) or qualified as dbName::pid (cross-DB). \
         \When empty or absent, the call behaves as a plain GET."
 
+{- | Optional filter for score_activity / score_activities: when supplied,
+the response's scoring-related maps (scoringResults / scoringUnits /
+scoringIndicators) are restricted to these scoring set names. When
+omitted or empty, every scoring set configured on the collection is
+returned. An unknown name is a hard error (lists what's configured).
+-}
+pScoringSetsFilter :: Param
+pScoringSetsFilter =
+    Param
+        "scoring_sets"
+        "array"
+        Optional
+        "Restrict the response's scoringResults / scoringUnits / \
+        \scoringIndicators to these scoring set names (use \
+        \list_scoring_sets to discover). Omit or pass [] to keep every \
+        \scoring set configured on the collection. An unknown name \
+        \fails the call with the list of available names."
+
 -- | Parameters accepted by a resource operation.
 params :: Resource -> [Param]
 params r = case r of
@@ -581,12 +599,14 @@ params r = case r of
         , pProcessId
         , Param "collection" "string" Required "Method collection name (use list_methods to discover)"
         , pSubstitutions
+        , pScoringSetsFilter
         ]
     ScoreActivities ->
         [ pDatabase
         , Param "collection" "string" Required "Method collection name"
         , Param "process_ids" "array" Required "Process IDs to score (activityUUID_productUUID). All resolved in one multi-RHS solve."
         , Param "top_flows" "integer" Optional "Per-(activity, method) top contributors to include (default 0 — bulk-friendly, skips the per-method contribution walk)."
+        , pScoringSetsFilter
         ]
     ListScoringSets ->
         [ Param "collection" "string" Optional "Method collection name. If omitted, returns scoring sets across all loaded collections, grouped by collection."

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -64,6 +64,9 @@ data Resource
     | GetPathTo
     | GetConsumers
     | CompareImpacts
+    | ScoreActivity
+    | ScoreActivities
+    | ListScoringSets
     deriving (Eq, Ord, Show, Bounded, Enum)
 
 -- | Whether a parameter must be supplied by the caller.
@@ -140,6 +143,9 @@ apiPath r = case r of
     GetPathTo -> Just (GET, ["db", "{dbName}", "activity", "{processId}", "path-to"])
     GetConsumers -> Just (GET, ["db", "{dbName}", "activity", "{processId}", "consumers"])
     CompareImpacts -> Nothing -- MCP-only audit tool: cross-DB diff, no canonical HTTP route
+    ScoreActivity -> Just (GET, ["db", "{dbName}", "activity", "{processId}", "impacts", "{collection}"])
+    ScoreActivities -> Just (POST, ["db", "{dbName}", "impacts", "{collection}"])
+    ListScoringSets -> Nothing -- MCP-only: scoring sets are configuration metadata, no REST equivalent yet
 
 {- | The full OpenAPI path template for a resource, e.g.
 @"/api/v1/db/{dbName}/activity/{processId}/impacts/{collection}/{methodId}"@.
@@ -177,6 +183,9 @@ mcpName r = case r of
     GetPathTo -> "get_path_to"
     GetConsumers -> "get_consumers"
     CompareImpacts -> "compare_impacts"
+    ScoreActivity -> "score_activity"
+    ScoreActivities -> "score_activities"
+    ListScoringSets -> "list_scoring_sets"
 
 -- ---------------------------------------------------------------------------
 -- Projection: CLI subcommand names (kebab-case)
@@ -210,6 +219,9 @@ cliName r = case r of
     GetPathTo -> "path-to"
     GetConsumers -> "consumers"
     CompareImpacts -> "compare-impacts"
+    ScoreActivity -> "score-activity"
+    ScoreActivities -> "score-activities"
+    ListScoringSets -> "scoring-sets"
 
 -- ---------------------------------------------------------------------------
 -- Projection: human-readable description (shared across surfaces)
@@ -342,6 +354,35 @@ description r = case r of
         \field is delta.relative_pct — the metric to drive down by adding \
         \synonym pairs to data/flows.csv or by regenerating the chem_synonyms \
         \snapshot."
+    ScoreActivity ->
+        "LCA / ACV — compute the full LCIA panel + every configured scoring \
+        \set for an activity in one call. Returns per-method impact scores, \
+        \per-scoring-set aggregate scores, per-scoring-set indicator \
+        \breakdown (one entry per scoring variable), display units, and a \
+        \web_url to the matching view. Use this when you would otherwise \
+        \call get_impacts N times across every method of a collection — \
+        \replaces N round-trips with one batched solve. Discover available \
+        \scoring sets with list_scoring_sets."
+    ScoreActivities ->
+        "LCA / ACV — score N activities against every method in a collection \
+        \in one call. Returns one entry per activity with the full LCIA \
+        \panel and all configured scoring sets (same shape as \
+        \score_activity), each entry carrying a web_url to its impacts \
+        \page. Unresolved process IDs land in not_found / invalid. \
+        \Replaces N × M round-trips of get_impacts with one MUMPS \
+        \multi-RHS solve plus parallel characterization. Set top_flows>0 \
+        \only when you need per-method drill-downs; the default skips \
+        \them for bulk callers."
+    ListScoringSets ->
+        "LCA / ACV — list formula-based scoring sets defined in loaded \
+        \method collections. A scoring set is a configured aggregation of \
+        \LCIA category scores into one or more weighted/normalized 'score' \
+        \values (e.g. an overall single score plus per-area-of-protection \
+        \sub-scores). For each set returns: name, display unit, variables \
+        \referenced (with the impact category each binds to), computed \
+        \intermediates, normalization and weighting factors, and the score \
+        \formulas. Use the returned set names as keys when interpreting \
+        \score_activity / score_activities responses."
 
 -- ---------------------------------------------------------------------------
 -- Projection: parameter schema
@@ -534,4 +575,19 @@ params r = case r of
         , Param "process_id_b" "string" Required "Process ID in database_b (activityUUID_productUUID format)"
         , Param "method_id_b" "string" Required "Method UUID for the B side"
         , Param "top_flows" "integer" Optional "Per-side flow drill-down depth (default 10)"
+        ]
+    ScoreActivity ->
+        [ pDatabase
+        , pProcessId
+        , Param "collection" "string" Required "Method collection name (use list_methods to discover)"
+        , pSubstitutions
+        ]
+    ScoreActivities ->
+        [ pDatabase
+        , Param "collection" "string" Required "Method collection name"
+        , Param "process_ids" "array" Required "Process IDs to score (activityUUID_productUUID). All resolved in one multi-RHS solve."
+        , Param "top_flows" "integer" Optional "Per-(activity, method) top contributors to include (default 0 — bulk-friendly, skips the per-method contribution walk)."
+        ]
+    ListScoringSets ->
+        [ Param "collection" "string" Optional "Method collection name. If omitted, returns scoring sets across all loaded collections, grouped by collection."
         ]

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -368,6 +368,519 @@ expandPreset presets (Just pn) = case find (\p -> Config.cpName p == pn) presets
     Just p -> [(Config.ceSystem e, Config.ceValue e, Config.ceMode e == "exact") | e <- Config.cpFilters p]
     Nothing -> []
 
+-- ============================================================================
+-- Hoisted helpers — previously in lcaServer's `where`. Lifted to top level so
+-- non-Servant callers (notably src/API/BatchImpacts.hs and any client of the
+-- LCIA batch pipeline outside the Servant Handler stack) can reuse them.
+--
+-- Behavior is byte-identical to the original where-bound versions.
+-- ============================================================================
+
+-- | Enrich a raw LCIA result with damage category mapping and NW scores. Pure.
+enrichWithNW :: M.Map Text Text -> Maybe NormWeightSet -> LCIAResult -> LCIAResult
+enrichWithNW dcLookup mNW result =
+    let dmgCat = M.findWithDefault (lrCategory result) (lrCategory result) dcLookup
+        (normScore, weightScore) = case mNW of
+            Just nw ->
+                let mNorm = M.lookup dmgCat (nwNormalization nw)
+                    mWeight = M.lookup dmgCat (nwWeighting nw)
+                 in case (mNorm, mWeight) of
+                        (Just n, Just w) ->
+                            let ns = lrScore result * n
+                             in (Just ns, Just (ns * w))
+                        _ -> (Nothing, Nothing)
+            Nothing -> (Nothing, Nothing)
+     in result
+            { lrDamageCategory = dmgCat
+            , lrNormalizedScore = normScore
+            , lrWeightedScore = weightScore
+            }
+
+-- | Assemble an LCIABatchResult from the post-characterization parts. Pure.
+mkLCIABatchResult ::
+    [LCIAResult] ->
+    Maybe NormWeightSet ->
+    [NormWeightSet] ->
+    M.Map Text (M.Map Text Double) ->
+    [ScoringSet] ->
+    M.Map Text (M.Map Text ScoringIndicator) ->
+    LCIABatchResult
+mkLCIABatchResult results mNW nwSets scoringResults scoringSets scoringIndicators =
+    LCIABatchResult
+        { lbrResults = results
+        , lbrSingleScore = Nothing
+        , lbrSingleScoreUnit = Nothing
+        , lbrNormWeightSetName = nwName <$> mNW
+        , lbrAvailableNWsets = map nwName nwSets
+        , lbrScoringResults = scoringResults
+        , lbrScoringUnits = M.fromList [(ssName ss, ssUnit ss) | ss <- scoringSets]
+        , lbrScoringIndicators = scoringIndicators
+        }
+
+-- | Per-category single-line log within a batch.
+logBatchCategory :: Int -> LCIAResult -> IO ()
+logBatchCategory _invSize result = do
+    let scoreTxt = showFFloat (Just 4) (lrScore result) ""
+    reportProgress Info $
+        "  "
+            <> T.unpack (lrMethodName result)
+            <> ": "
+            <> scoreTxt
+            <> " "
+            <> T.unpack (lrUnit result)
+            <> " ("
+            <> show (lrMappedFlows result)
+            <> " CFs mapped)"
+
+-- | Single-method LCIA log line.
+logLCIAResult :: LCIAResult -> Method -> IO ()
+logLCIAResult result method = do
+    let mapped = lrMappedFlows result
+    reportProgress Info $
+        "[LCIA] "
+            <> T.unpack (methodName method)
+            <> ": "
+            <> showFFloat (Just 4) (lrScore result) ""
+            <> " "
+            <> T.unpack (methodUnit method)
+    reportProgress Info $ "  Flow mapping: " <> show mapped <> " CFs mapped"
+
+{- | Resolve a process_id text against a database, throwing the appropriate
+HTTP status. Validates the resolved ProcessId against the technosphere
+matrix index too — see Service.validateProcessIdInMatrixIndex.
+-}
+resolveOrThrow :: Database -> Text -> Handler (ProcessId, Activity)
+resolveOrThrow db processIdText =
+    case Service.resolveActivityAndProcessId db processIdText of
+        Left (Service.ActivityNotFound _) -> throwError err404{errBody = "Activity not found"}
+        Left (Service.InvalidProcessId msg) -> throwError err400{errBody = BSL.fromStrict $ T.encodeUtf8 msg}
+        Left e@(Service.MatrixError _) -> internalError e
+        Left e@(Service.InvalidUUID _) -> internalError e
+        Left e@(Service.FlowNotFound _) -> internalError e
+        Right (pid, act) ->
+            case Service.validateProcessIdInMatrixIndex db pid of
+                Left e -> internalError e
+                Right () -> return (pid, act)
+  where
+    internalError :: Service.ServiceError -> Handler a
+    internalError e = throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ T.pack $ show e}
+
+{- | Translate a Service-level error into the HTTP status used across the
+cross-DB LCIA paths.
+-}
+throwServiceError :: Service.ServiceError -> Handler a
+throwServiceError (Service.ActivityNotFound _) = throwError err404{errBody = "Activity not found"}
+throwServiceError (Service.InvalidProcessId msg) = throwError err400{errBody = BSL.fromStrict $ T.encodeUtf8 msg}
+-- MatrixError covers singular Sherman-Morrison, missing technosphere links,
+-- and cross-DB unit-conversion failures — all client-submitted invariant
+-- breakages. Surface as 422 like the rest of the cross-DB pipeline.
+throwServiceError (Service.MatrixError msg) = throwError err422{errBody = BSL.fromStrict $ T.encodeUtf8 msg}
+throwServiceError (Service.InvalidUUID _) = throwError err500{errBody = "Internal server error"}
+throwServiceError (Service.FlowNotFound _) = throwError err500{errBody = "Internal server error"}
+
+-- | Load a method collection by name from the live DatabaseManager state.
+loadCollection :: DatabaseManager -> Text -> Handler ([Method], [DamageCategory], [NormWeightSet], [ScoringSet])
+loadCollection dbManager collectionName = do
+    loadedCollections <- liftIO $ readTVarIO (dmLoadedMethods dbManager)
+    case M.lookup collectionName loadedCollections of
+        Just mc -> return (mcMethods mc, mcDamageCategories mc, mcNormWeightSets mc, mcScoringSets mc)
+        Nothing -> throwError err404{errBody = "Collection not loaded: " <> BSL.fromStrict (T.encodeUtf8 collectionName)}
+
+{- | Cross-DB inventory solution for an activity. 'Nothing' takes the cached
+no-substitution path ('requireFullyLinked' runs inside 'solutionWithDeps');
+'Just' applies the substitutions through the uncached path.
+-}
+crossDBSolutionFor :: DatabaseManager -> Text -> Database -> SharedSolver -> ProcessId -> Maybe SubstitutionRequest -> Handler SharedSolver.CrossDBSolution
+crossDBSolutionFor dbManager dbName db solver pid mSub = case mSub of
+    Nothing -> solutionWithDeps dbManager dbName db solver pid
+    Just subReq -> do
+        requireFullyLinked dbName db
+        unitCfg <- liftIO $ getMergedUnitConfig dbManager
+        eSol <-
+            liftIO $
+                Service.inventoryWithSubsAndDeps
+                    unitCfg
+                    (DM.mkDepSolverLookup dbManager)
+                    db
+                    dbName
+                    solver
+                    pid
+                    (srSubstitutions subReq)
+        either throwServiceError pure eSol
+
+{- | Look up MethodSetTables for every (DB, scaling) pair in the cross-DB
+solution. Cache-keyed by (dbName, methods).
+-}
+buildPerDbSetTables ::
+    DatabaseManager ->
+    NE.NonEmpty (Text, Database, Vector) ->
+    [Method] ->
+    IO (NE.NonEmpty (Database, Vector, Method.Mapping.MethodSetTables))
+buildPerDbSetTables dbManager scalings methods =
+    traverse
+        ( \(n, d, sv) -> do
+            mst <- DM.mapMethodSetToTablesCached dbManager n d methods
+            pure (d, sv, mst)
+        )
+        scalings
+
+{- | Score every method in 'methods' against the inventory in 'sol' in a
+single dense matvec (non-regional) plus per-method passes (regional).
+-}
+batchedScoresFor ::
+    DatabaseManager ->
+    Text ->
+    Database ->
+    SharedSolver.CrossDBSolution ->
+    [Method] ->
+    IO (M.Map UUID (Either Text Double))
+batchedScoresFor dbManager _dbName _db sol methods = do
+    perDb <- buildPerDbSetTables dbManager (SharedSolver.csScalings sol) methods
+    unitCfg <- getMergedUnitConfig dbManager
+    (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
+    hier <- DM.getLocationHierarchy dbManager
+    pure $
+        M.fromList $
+            computeLCIAScoreSetFromTables
+                unitCfg
+                mUnits
+                mFlows
+                (SharedSolver.csInventory sol)
+                hier
+                perDb
+
+{- | Pre-warm per-(db, method) cached tables so subsequent 'batchedScoresFor'
+and 'inventoryContributions' calls hit a warm cache.
+-}
+prepMethodCtx :: DatabaseManager -> Text -> Database -> Method -> IO MethodCtx
+prepMethodCtx dbManager dbName db method = do
+    mappings <- DM.mapMethodToFlowsCached dbManager dbName db method
+    _ <- DM.mapMethodToTablesCached dbManager dbName db method
+    let stats = computeMappingStats mappings
+    pure MethodCtx{mctxMethod = method, mctxMappedFlows = msTotal stats - msUnmatched stats}
+
+{- | Compute LCIA result for a single method against a cross-DB inventory
+solution. 'precomputedScore' short-circuits the per-method scoring loop
+when a batched matvec result is already available.
+-}
+computeCategoryResult ::
+    DatabaseManager ->
+    Text ->
+    Database ->
+    SharedSolver.CrossDBSolution ->
+    Activity ->
+    Int ->
+    Maybe (Either Text Double) ->
+    Method ->
+    IO LCIAResult
+computeCategoryResult dbManager dbName db sol activity topFlows precomputedScore method = do
+    unitCfg <- getMergedUnitConfig dbManager
+    (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
+    mappings <- DM.mapMethodToFlowsCached dbManager dbName db method
+    tables <- DM.mapMethodToTablesCached dbManager dbName db method
+    let inventory = SharedSolver.csInventory sol
+    let stats = computeMappingStats mappings
+    score <- case precomputedScore of
+        Just (Right s) -> evaluate s
+        Just (Left err) -> do
+            reportProgress Warning $
+                "[LCIA " <> T.unpack (methodName method) <> "] " <> T.unpack err
+            evaluate (0 :: Double)
+        Nothing ->
+            if M.null (mtRegionalizedCF tables)
+                then evaluate $ loScore (computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables)
+                else do
+                    hier <- DM.getLocationHierarchy dbManager
+                    perDb <-
+                        forM (NE.toList (SharedSolver.csScalings sol)) $ \(n, d, sv) -> do
+                            tbls <- DM.mapMethodToTablesCached dbManager n d method
+                            pure (d, sv, tbls)
+                    case sumRegionalizedLCIAScoreCrossDB unitCfg mUnits mFlows hier perDb of
+                        Right s -> evaluate s
+                        Left err -> do
+                            reportProgress Warning $
+                                "[LCIA " <> T.unpack (methodName method) <> "] " <> T.unpack err
+                            evaluate (0 :: Double)
+    let (prodName, prodAmount, prodUnit) = Service.getReferenceProductInfo mFlows mUnits activity
+        functionalUnit = T.pack (showFFloat (Just 2) prodAmount "") <> " " <> prodUnit <> " of " <> prodName
+        (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
+        contribs = sortOn (\(_, _, c) -> negate (abs c)) rawContribs
+        topContribs = take topFlows contribs
+        topContributors =
+            [ FlowContributionEntry
+                { fcoFlowName = flowName f
+                , fcoContribution = c
+                , fcoSharePct = if score /= 0 then c / score * 100 else 0
+                , fcoFlowId = UUID.toText (flowId f)
+                , fcoCategory = flowCategory f
+                , fcoCompartment = flowSubcompartment f
+                , fcoCfValue = cfVal
+                }
+            | (f, cfVal, c) <- topContribs
+            ]
+    unless (null unknownUuids) $
+        reportProgress Warning $
+            "[LCIA "
+                <> T.unpack (methodName method)
+                <> "] "
+                <> show (length unknownUuids)
+                <> " inventory flow UUID(s) absent from merged FlowDB — characterization incomplete. Samples: "
+                <> show (take 3 unknownUuids)
+    pure
+        LCIAResult
+            { lrMethodId = methodId method
+            , lrMethodName = methodName method
+            , lrCategory = methodCategory method
+            , lrDamageCategory = methodCategory method
+            , lrScore = score
+            , lrUnit = methodUnit method
+            , lrNormalizedScore = Nothing
+            , lrWeightedScore = Nothing
+            , lrMappedFlows = msTotal stats - msUnmatched stats
+            , lrFunctionalUnit = functionalUnit
+            , lrTopContributors = topContributors
+            }
+
+{- | Batch fast path: scores via 'batchedScoresFor', then build LCIAResult
+records straight from the precomputed contexts. Skips the per-pid
+'mapConcurrently' over methods entirely. When 'topFlows' is 0
+(the default) 'lrTopContributors' is left empty and the contribution
+walk is skipped; when >0, runs 'inventoryContributions' per method.
+-}
+buildLCIABatchResultCached ::
+    DatabaseManager ->
+    Text ->
+    Database ->
+    ProcessId ->
+    Activity ->
+    MethodCollection ->
+    SharedSolver.CrossDBSolution ->
+    [MethodCtx] ->
+    Int ->
+    IO LCIABatchResult
+buildLCIABatchResultCached dbManager dbName db actPid activity collection sol ctxs topFlows = do
+    let damageCats = mcDamageCategories collection
+        nwSets = mcNormWeightSets collection
+        dcLookup =
+            M.fromList
+                [ (subName, dcName dc)
+                | dc <- damageCats
+                , (subName, _) <- dcImpacts dc
+                ]
+        mNW = case nwSets of (nw : _) -> Just nw; [] -> Nothing
+        methods = map mctxMethod ctxs
+        inventory = SharedSolver.csInventory sol
+    scoreMap <- batchedScoresFor dbManager dbName db sol methods
+    (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
+    let unknownUuids =
+            [ fid
+            | (fid, qty) <- M.toList inventory
+            , qty /= 0
+            , not (M.member fid mFlows)
+            ]
+    unless (null unknownUuids) $
+        reportProgress Warning $
+            "[LCIA batch] pid="
+                <> show actPid
+                <> ": "
+                <> show (length unknownUuids)
+                <> " inventory flow UUID(s) absent from merged FlowDB — characterization incomplete. Samples: "
+                <> show (take 3 unknownUuids)
+    mUnitCfg <-
+        if topFlows > 0
+            then Just <$> getMergedUnitConfig dbManager
+            else pure Nothing
+    let (prodName, prodAmount, prodUnit) = Service.getReferenceProductInfo mFlows mUnits activity
+        functionalUnit = T.pack (showFFloat (Just 2) prodAmount "") <> " " <> prodUnit <> " of " <> prodName
+        mkResultIO ctx = do
+            let method = mctxMethod ctx
+            score <- case M.lookup (methodId method) scoreMap of
+                Just (Right s) -> pure s
+                Just (Left err) -> do
+                    reportProgress Warning $
+                        "[LCIA "
+                            <> T.unpack (methodName method)
+                            <> "] pid="
+                            <> show actPid
+                            <> ": "
+                            <> T.unpack err
+                    pure 0
+                Nothing -> pure 0
+            topContributors <- case mUnitCfg of
+                Nothing -> pure []
+                Just unitCfg -> do
+                    tables <- DM.mapMethodToTablesCached dbManager dbName db method
+                    let (rawContribs, _unknownUuids) =
+                            inventoryContributions unitCfg mUnits mFlows inventory tables
+                        sorted = sortOn (\(_, _, c) -> negate (abs c)) rawContribs
+                        top = take topFlows sorted
+                    pure
+                        [ FlowContributionEntry
+                            { fcoFlowName = flowName f
+                            , fcoContribution = c
+                            , fcoSharePct = if score /= 0 then c / score * 100 else 0
+                            , fcoFlowId = UUID.toText (flowId f)
+                            , fcoCategory = flowCategory f
+                            , fcoCompartment = flowSubcompartment f
+                            , fcoCfValue = cfVal
+                            }
+                        | (f, cfVal, c) <- top
+                        ]
+            pure $
+                enrichWithNW dcLookup mNW $
+                    LCIAResult
+                        { lrMethodId = methodId method
+                        , lrMethodName = methodName method
+                        , lrCategory = methodCategory method
+                        , lrDamageCategory = methodCategory method
+                        , lrScore = score
+                        , lrUnit = methodUnit method
+                        , lrNormalizedScore = Nothing
+                        , lrWeightedScore = Nothing
+                        , lrMappedFlows = mctxMappedFlows ctx
+                        , lrFunctionalUnit = functionalUnit
+                        , lrTopContributors = topContributors
+                        }
+    results <- traverse mkResultIO ctxs
+    let rawScoreMap = M.fromList [(lrCategory r, lrScore r) | r <- results]
+    (scoringResults, scoringIndicators) <-
+        computeAllScoringSets (mcScoringSets collection) rawScoreMap
+    pure (mkLCIABatchResult results mNW nwSets scoringResults (mcScoringSets collection) scoringIndicators)
+
+{- | Top-level LCIA batch entry point — Handler-returning. Used by the Servant
+routes (via thin where-aliases) and by API.BatchImpacts.
+-}
+activityLCIABatchH ::
+    DatabaseManager ->
+    Text ->
+    Text ->
+    Text ->
+    Maybe SubstitutionRequest ->
+    Handler LCIABatchResult
+activityLCIABatchH dbManager dbName processIdText collectionName mSub = do
+    (db, sharedSolver) <- requireDatabaseByName dbManager dbName
+    (actProcessId, activity) <- resolveOrThrow db processIdText
+    (methods, damageCats, nwSets, scoringSets) <- loadCollection dbManager collectionName
+    let dcLookup = M.fromList [(subName, dcName dc) | dc <- damageCats, (subName, _) <- dcImpacts dc]
+        mNW = case nwSets of (nw : _) -> Just nw; [] -> Nothing
+    t0 <- liftIO getCurrentTime
+    sol <- crossDBSolutionFor dbManager dbName db sharedSolver actProcessId mSub
+    t1 <- liftIO getCurrentTime
+    let inventory = SharedSolver.csInventory sol
+        !invSize = M.size inventory
+    when (isNothing mSub) $
+        liftIO $ do
+            reportProgress Info $
+                "[LCIA batch] " <> T.unpack collectionName <> " for " <> T.unpack (activityName activity)
+            reportProgress Info $
+                "  Inventory: "
+                    <> show invSize
+                    <> " flows ("
+                    <> showFFloat (Just 2) (realToFrac (diffUTCTime t1 t0) :: Double) ""
+                    <> "s)"
+            when (invSize == 0) $
+                reportProgress Info "  WARNING: inventory is empty — check matrix computation"
+            when (invSize > 0 && invSize <= 5) $
+                reportProgress Info $
+                    "  Inventory UUIDs: " <> intercalate ", " (map UUID.toString $ M.keys inventory)
+    scoreMap <- liftIO $ batchedScoresFor dbManager dbName db sol methods
+    rawResults <-
+        liftIO $
+            mapConcurrently
+                (\m -> computeCategoryResult dbManager dbName db sol activity 5 (M.lookup (methodId m) scoreMap) m)
+                methods
+    let results = map (enrichWithNW dcLookup mNW) rawResults
+        rawScoreMap = M.fromList [(lrCategory r, lrScore r) | r <- rawResults]
+    (scoringResults, scoringIndicators) <- liftIO $ computeAllScoringSets scoringSets rawScoreMap
+    when (isNothing mSub) $
+        liftIO $ do
+            t2 <- getCurrentTime
+            mapM_ (logBatchCategory invSize) results
+            reportProgress Info $
+                "  Total: "
+                    <> show (length results)
+                    <> " categories ("
+                    <> showFFloat (Just 2) (realToFrac (diffUTCTime t2 t0) :: Double) ""
+                    <> "s)"
+            forM_ (M.toList scoringResults) $ \(name, scores) ->
+                reportProgress Info $
+                    "  Scoring '"
+                        <> T.unpack name
+                        <> "': "
+                        <> intercalate ", " [T.unpack k <> "=" <> showFFloat (Just 6) v "" | (k, v) <- M.toList scores]
+    pure (mkLCIABatchResult results mNW nwSets scoringResults scoringSets scoringIndicators)
+
+{- | Top-level multi-activity batch impacts. One MUMPS multi-RHS solve for all
+valid PIDs, parallel characterization. Used by the Servant POST route and
+by API.BatchImpacts.
+-}
+batchImpactsH ::
+    DatabaseManager ->
+    Text ->
+    Text ->
+    Maybe Int ->
+    BatchImpactsRequest ->
+    Handler BatchImpactsResponse
+batchImpactsH dbManager dbName collectionName topFlowsParam req = do
+    (db, sharedSolver) <- requireDatabaseByName dbManager dbName
+    loadedCollections <- liftIO $ readTVarIO (dmLoadedMethods dbManager)
+    collection <- case M.lookup collectionName loadedCollections of
+        Just mc -> pure mc
+        Nothing -> throwError err404{errBody = "Collection not loaded: " <> BSL.fromStrict (T.encodeUtf8 collectionName)}
+    let resolved =
+            [ (pidText, Service.resolveActivityAndProcessId db pidText)
+            | pidText <- birProcessIds req
+            ]
+        valid = [(pidText, pidNum, act) | (pidText, Right (pidNum, act)) <- resolved]
+        notFound = [pidText | (pidText, Left (Service.ActivityNotFound _)) <- resolved]
+        invalid = [pidText | (pidText, Left (Service.InvalidProcessId _)) <- resolved]
+        validPidNums = [pidNum | (_, pidNum, _) <- valid]
+    t0 <- liftIO getCurrentTime
+    sols <- solutionsWithDeps dbManager dbName db sharedSolver validPidNums
+    t1 <- liftIO getCurrentTime
+    ctxs <- liftIO $ mapConcurrently (prepMethodCtx dbManager dbName db) (mcMethods collection)
+    let topFlows = max 0 (fromMaybe 0 topFlowsParam)
+    let mkEntry ((pidText, pidNum, activity), sol) = do
+            impacts <- buildLCIABatchResultCached dbManager dbName db pidNum activity collection sol ctxs topFlows
+            pure
+                BatchImpactsEntry
+                    { bieProcessId = pidText
+                    , bieActivityName = activityName activity
+                    , bieImpacts = impacts
+                    }
+    entries <- liftIO $ mapM mkEntry (zip valid sols)
+    t2 <- liftIO getCurrentTime
+    liftIO $
+        reportProgress Info $
+            "[batch-impacts] "
+                <> T.unpack dbName
+                <> " / "
+                <> T.unpack collectionName
+                <> ": "
+                <> show (length valid)
+                <> " activities"
+                <> ( if null notFound && null invalid
+                        then ""
+                        else
+                            " ("
+                                <> show (length notFound)
+                                <> " not_found, "
+                                <> show (length invalid)
+                                <> " invalid)"
+                   )
+                <> " — solve "
+                <> showFFloat (Just 2) (realToFrac (diffUTCTime t1 t0) :: Double) ""
+                <> "s, "
+                <> "total "
+                <> showFFloat (Just 2) (realToFrac (diffUTCTime t2 t0) :: Double) ""
+                <> "s"
+    pure
+        BatchImpactsResponse
+            { birResults = entries
+            , birNotFound = notFound
+            , birInvalid = invalid
+            }
+
 {- | API server implementation
 DatabaseManager is used to dynamically fetch current database on each request
 -}
@@ -598,27 +1111,6 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                     let loopAwareTree = buildLoopAwareTree unitCfg db activityUuid maxTreeDepth
                     return $ Service.convertToTreeExport db processId maxTreeDepth loopAwareTree
 
-    -- Cross-DB inventory solution for an activity. 'Nothing' takes the cached
-    -- no-substitution path ('requireFullyLinked' runs inside 'solutionWithDeps');
-    -- 'Just' applies the substitutions through the uncached path.
-    crossDBSolutionFor :: Text -> Database -> SharedSolver -> ProcessId -> Maybe SubstitutionRequest -> Handler SharedSolver.CrossDBSolution
-    crossDBSolutionFor dbName db solver pid mSub = case mSub of
-        Nothing -> solutionWithDeps dbManager dbName db solver pid
-        Just subReq -> do
-            requireFullyLinked dbName db
-            unitCfg <- liftIO $ getMergedUnitConfig dbManager
-            eSol <-
-                liftIO $
-                    Service.inventoryWithSubsAndDeps
-                        unitCfg
-                        (DM.mkDepSolverLookup dbManager)
-                        db
-                        dbName
-                        solver
-                        pid
-                        (srSubstitutions subReq)
-            either throwServiceError pure eSol
-
     -- Activity inventory calculation (full supply chain LCI).
     -- Goes through the cross-DB back-substitution path so inventories from
     -- dep DBs are merged into the returned flow map; metadata (flow names,
@@ -627,7 +1119,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
     activityInventoryCore dbName processIdText mSub = do
         (db, sharedSolver) <- requireDatabaseByName dbManager dbName
         (processId, activity) <- resolveOrThrow db processIdText
-        sol <- crossDBSolutionFor dbName db sharedSolver processId mSub
+        sol <- crossDBSolutionFor dbManager dbName db sharedSolver processId mSub
         (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
         pure $ Service.convertToInventoryExport db mFlows mUnits processId activity (SharedSolver.csInventory sol)
 
@@ -847,8 +1339,8 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
         (db, sharedSolver) <- requireDatabaseByName dbManager dbName
         method <- loadMethodByUUID methodIdText
         (processId, activity) <- resolveOrThrow db processIdText
-        sol <- crossDBSolutionFor dbName db sharedSolver processId mSub
-        result <- liftIO $ computeCategoryResult dbName db sol activity (fromMaybe 5 topFlowsParam) Nothing method
+        sol <- crossDBSolutionFor dbManager dbName db sharedSolver processId mSub
+        result <- liftIO $ computeCategoryResult dbManager dbName db sol activity (fromMaybe 5 topFlowsParam) Nothing method
         when (isNothing mSub) $ liftIO $ logLCIAResult result method
         pure result
 
@@ -907,7 +1399,7 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                 eBaselineSol
         baselineLcia <-
             liftIO $
-                computeCategoryResult dbName db baselineSol activity 5 Nothing method
+                computeCategoryResult dbManager dbName db baselineSol activity 5 Nothing method
         perturbed <-
             liftIO $
                 mapConcurrently
@@ -922,64 +1414,13 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                 case eSol of
                     Left err -> pure (PerturbedEntry p (Left err))
                     Right sol -> do
-                        lcia <- computeCategoryResult dbName db sol activity 5 Nothing method
+                        lcia <- computeCategoryResult dbManager dbName db sol activity 5 Nothing method
                         pure (PerturbedEntry p (Right (lcia, lrScore lcia - lrScore baselineLcia)))
 
-    -- Batch LCIA endpoint (all methods in a collection). The GET variant logs
-    -- timing and per-category detail; the POST (substitution) variant does not.
+    -- Batch LCIA endpoint (all methods in a collection). Thin alias over the
+    -- top-level activityLCIABatchH; preserves the Servant call sites.
     activityLCIABatchCore :: Text -> Text -> Text -> Maybe SubstitutionRequest -> Handler LCIABatchResult
-    activityLCIABatchCore dbName processIdText collectionName mSub = do
-        (db, sharedSolver) <- requireDatabaseByName dbManager dbName
-        (actProcessId, activity) <- resolveOrThrow db processIdText
-        (methods, damageCats, nwSets, scoringSets) <- loadCollection collectionName
-        let dcLookup = M.fromList [(subName, dcName dc) | dc <- damageCats, (subName, _) <- dcImpacts dc]
-            mNW = case nwSets of (nw : _) -> Just nw; [] -> Nothing
-        t0 <- liftIO getCurrentTime
-        sol <- crossDBSolutionFor dbName db sharedSolver actProcessId mSub
-        t1 <- liftIO getCurrentTime
-        let inventory = SharedSolver.csInventory sol
-            !invSize = M.size inventory
-        when (isNothing mSub) $
-            liftIO $ do
-                reportProgress Info $
-                    "[LCIA batch] " <> T.unpack collectionName <> " for " <> T.unpack (activityName activity)
-                reportProgress Info $
-                    "  Inventory: "
-                        <> show invSize
-                        <> " flows ("
-                        <> showFFloat (Just 2) (realToFrac (diffUTCTime t1 t0) :: Double) ""
-                        <> "s)"
-                when (invSize == 0) $
-                    reportProgress Info "  WARNING: inventory is empty — check matrix computation"
-                when (invSize > 0 && invSize <= 5) $
-                    reportProgress Info $
-                        "  Inventory UUIDs: " <> intercalate ", " (map UUID.toString $ M.keys inventory)
-        scoreMap <- liftIO $ batchedScoresFor dbName db sol methods
-        rawResults <-
-            liftIO $
-                mapConcurrently
-                    (\m -> computeCategoryResult dbName db sol activity 5 (M.lookup (methodId m) scoreMap) m)
-                    methods
-        let results = map (enrichWithNW dcLookup mNW) rawResults
-            rawScoreMap = M.fromList [(lrCategory r, lrScore r) | r <- rawResults]
-        (scoringResults, scoringIndicators) <- liftIO $ computeAllScoringSets scoringSets rawScoreMap
-        when (isNothing mSub) $
-            liftIO $ do
-                t2 <- getCurrentTime
-                mapM_ (logBatchCategory invSize) results
-                reportProgress Info $
-                    "  Total: "
-                        <> show (length results)
-                        <> " categories ("
-                        <> showFFloat (Just 2) (realToFrac (diffUTCTime t2 t0) :: Double) ""
-                        <> "s)"
-                forM_ (M.toList scoringResults) $ \(name, scores) ->
-                    reportProgress Info $
-                        "  Scoring '"
-                            <> T.unpack name
-                            <> "': "
-                            <> intercalate ", " [T.unpack k <> "=" <> showFFloat (Just 6) v "" | (k, v) <- M.toList scores]
-        pure (mkLCIABatchResult results mNW nwSets scoringResults scoringSets scoringIndicators)
+    activityLCIABatchCore = activityLCIABatchH dbManager
 
     getActivityLCIABatch :: Text -> Text -> Text -> Handler LCIABatchResult
     getActivityLCIABatch dbName processIdText collectionName =
@@ -1052,55 +1493,9 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
                 throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ T.pack $ show err}
             Right val -> return val
 
-    -- Helpers for POST endpoints with substitutions
-    resolveOrThrow :: Database -> Text -> Handler (ProcessId, Activity)
-    resolveOrThrow db processIdText =
-        case Service.resolveActivityAndProcessId db processIdText of
-            Left (Service.ActivityNotFound _) -> throwError err404{errBody = "Activity not found"}
-            Left (Service.InvalidProcessId msg) -> throwError err400{errBody = BSL.fromStrict $ T.encodeUtf8 msg}
-            Left e@(Service.MatrixError _) -> internalError e
-            Left e@(Service.InvalidUUID _) -> internalError e
-            Left e@(Service.FlowNotFound _) -> internalError e
-            Right (pid, act) ->
-                case Service.validateProcessIdInMatrixIndex db pid of
-                    Left e -> internalError e
-                    Right () -> return (pid, act)
-      where
-        internalError :: Service.ServiceError -> Handler a
-        internalError e = throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ T.pack $ show e}
-
-    throwServiceError :: Service.ServiceError -> Handler a
-    throwServiceError (Service.ActivityNotFound _) = throwError err404{errBody = "Activity not found"}
-    throwServiceError (Service.InvalidProcessId msg) = throwError err400{errBody = BSL.fromStrict $ T.encodeUtf8 msg}
-    -- MatrixError covers singular Sherman-Morrison, missing technosphere links,
-    -- and cross-DB unit-conversion failures — all client-submitted invariant
-    -- breakages. Surface as 422 like the rest of the cross-DB pipeline.
-    throwServiceError (Service.MatrixError msg) = throwError err422{errBody = BSL.fromStrict $ T.encodeUtf8 msg}
-    throwServiceError (Service.InvalidUUID _) = throwError err500{errBody = "Internal server error"}
-    throwServiceError (Service.FlowNotFound _) = throwError err500{errBody = "Internal server error"}
-
-    -- Log a single category result in the batch
-    logBatchCategory :: Int -> LCIAResult -> IO ()
-    logBatchCategory _invSize result = do
-        let scoreTxt = showFFloat (Just 4) (lrScore result) ""
-        reportProgress Info $
-            "  "
-                <> T.unpack (lrMethodName result)
-                <> ": "
-                <> scoreTxt
-                <> " "
-                <> T.unpack (lrUnit result)
-                <> " ("
-                <> show (lrMappedFlows result)
-                <> " CFs mapped)"
-
-    -- Load a method collection by name
-    loadCollection :: Text -> Handler ([Method], [DamageCategory], [NormWeightSet], [ScoringSet])
-    loadCollection collectionName = do
-        loadedCollections <- liftIO $ readTVarIO (dmLoadedMethods dbManager)
-        case M.lookup collectionName loadedCollections of
-            Just mc -> return (mcMethods mc, mcDamageCategories mc, mcNormWeightSets mc, mcScoringSets mc)
-            Nothing -> throwError err404{errBody = "Collection not loaded: " <> BSL.fromStrict (T.encodeUtf8 collectionName)}
+    -- (resolveOrThrow, throwServiceError, logBatchCategory and loadCollection
+    -- now live at the top level — see the block above the `lcaServer` def.
+    -- Call sites in this `where` pass `dbManager` explicitly when needed.)
 
     -- Activity analysis endpoint (dispatches to registered analyzers)
     getActivityAnalyze :: Text -> Text -> Text -> Handler Value
@@ -1218,167 +1613,6 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
     -- vectors collected during the inventory solve. Regional methods score
     -- as a sum across all participating DBs (root + each dep DB reached at
     -- request time); non-regional methods read the merged inventory only.
-    batchedScoresFor ::
-        Text ->
-        Database ->
-        SharedSolver.CrossDBSolution ->
-        [Method] ->
-        IO (M.Map UUID (Either Text Double))
-    batchedScoresFor _dbName _db sol methods = do
-        perDb <- buildPerDbSetTables (SharedSolver.csScalings sol) methods
-        unitCfg <- getMergedUnitConfig dbManager
-        (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
-        hier <- DM.getLocationHierarchy dbManager
-        pure $
-            M.fromList $
-                computeLCIAScoreSetFromTables
-                    unitCfg
-                    mUnits
-                    mFlows
-                    (SharedSolver.csInventory sol)
-                    hier
-                    perDb
-
-    -- Look up MethodSetTables for every (DB, scaling) pair in the cross-DB
-    -- solution. 'mapMethodSetToTablesCached' is keyed by (dbName, methods),
-    -- so dep DBs on a first-time request pay a one-shot
-    -- 'fillRegionalActivityWeights' walk against their own biosphere
-    -- triples; subsequent requests hit the cache.
-    buildPerDbSetTables ::
-        NE.NonEmpty (Text, Database, Vector) ->
-        [Method] ->
-        IO (NE.NonEmpty (Database, Vector, Method.Mapping.MethodSetTables))
-    buildPerDbSetTables scalings methods =
-        traverse
-            ( \(n, d, sv) -> do
-                mst <- DM.mapMethodSetToTablesCached dbManager n d methods
-                pure (d, sv, mst)
-            )
-            scalings
-
-    -- Helper: compute LCIA result for a single method against a cross-DB
-    -- inventory solution.
-    --
-    -- The 'CrossDBSolution' carries the merged inventory and per-DB scaling
-    -- vectors. Regional methods score as a sum over each participating DB
-    -- ('sumRegionalizedLCIAScoreCrossDB'); non-regional methods read the
-    -- merged inventory only.
-    --
-    -- 'precomputedScore' short-circuits the per-method scoring loop when a
-    -- batched matvec result is already available (see
-    -- 'mapMethodSetToTablesCached' + 'computeLCIAScoreSetFromTables'). Pass
-    -- 'Nothing' on the single-method paths.
-    computeCategoryResult ::
-        Text ->
-        Database ->
-        SharedSolver.CrossDBSolution ->
-        Activity ->
-        Int ->
-        Maybe (Either Text Double) ->
-        Method ->
-        IO LCIAResult
-    computeCategoryResult dbName db sol activity topFlows precomputedScore method = do
-        unitCfg <- getMergedUnitConfig dbManager
-        (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
-        mappings <- DM.mapMethodToFlowsCached dbManager dbName db method
-        tables <- DM.mapMethodToTablesCached dbManager dbName db method
-        let inventory = SharedSolver.csInventory sol
-        -- Force score evaluation here so mapConcurrently actually parallelizes the work
-        -- (without this, lazy thunks are created and forced later in the main thread)
-        let stats = computeMappingStats mappings
-        score <- case precomputedScore of
-            Just (Right s) -> evaluate s
-            Just (Left err) -> do
-                reportProgress Warning $
-                    "[LCIA " <> T.unpack (methodName method) <> "] " <> T.unpack err
-                evaluate (0 :: Double)
-            Nothing ->
-                if M.null (mtRegionalizedCF tables)
-                    then evaluate $ loScore (computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables)
-                    else do
-                        hier <- DM.getLocationHierarchy dbManager
-                        perDb <-
-                            forM (NE.toList (SharedSolver.csScalings sol)) $ \(n, d, sv) -> do
-                                tbls <- DM.mapMethodToTablesCached dbManager n d method
-                                pure (d, sv, tbls)
-                        case sumRegionalizedLCIAScoreCrossDB unitCfg mUnits mFlows hier perDb of
-                            Right s -> evaluate s
-                            Left err -> do
-                                reportProgress Warning $
-                                    "[LCIA " <> T.unpack (methodName method) <> "] " <> T.unpack err
-                                evaluate (0 :: Double)
-        let (prodName, prodAmount, prodUnit) = Service.getReferenceProductInfo mFlows mUnits activity
-            functionalUnit = T.pack (showFFloat (Just 2) prodAmount "") <> " " <> prodUnit <> " of " <> prodName
-            (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
-            contribs = sortOn (\(_, _, c) -> negate (abs c)) rawContribs
-            topContribs = take topFlows contribs
-            topContributors =
-                [ FlowContributionEntry
-                    { fcoFlowName = flowName f
-                    , fcoContribution = c
-                    , fcoSharePct = if score /= 0 then c / score * 100 else 0
-                    , fcoFlowId = UUID.toText (flowId f)
-                    , fcoCategory = flowCategory f
-                    , fcoCompartment = flowSubcompartment f
-                    , fcoCfValue = cfVal
-                    }
-                | (f, cfVal, c) <- topContribs
-                ]
-        unless (null unknownUuids) $
-            reportProgress Warning $
-                "[LCIA "
-                    <> T.unpack (methodName method)
-                    <> "] "
-                    <> show (length unknownUuids)
-                    <> " inventory flow UUID(s) absent from merged FlowDB — characterization incomplete. Samples: "
-                    <> show (take 3 unknownUuids)
-        pure
-            LCIAResult
-                { lrMethodId = methodId method
-                , lrMethodName = methodName method
-                , lrCategory = methodCategory method
-                , lrDamageCategory = methodCategory method -- default, enriched later
-                , lrScore = score
-                , lrUnit = methodUnit method
-                , lrNormalizedScore = Nothing -- enriched later
-                , lrWeightedScore = Nothing -- enriched later
-                , lrMappedFlows = msTotal stats - msUnmatched stats
-                , lrFunctionalUnit = functionalUnit
-                , lrTopContributors = topContributors
-                }
-
-    -- Enrich a raw LCIA result with damage category mapping and NW scores
-    enrichWithNW :: M.Map Text Text -> Maybe NormWeightSet -> LCIAResult -> LCIAResult
-    enrichWithNW dcLookup mNW result =
-        let dmgCat = M.findWithDefault (lrCategory result) (lrCategory result) dcLookup
-            (normScore, weightScore) = case mNW of
-                Just nw ->
-                    let mNorm = M.lookup dmgCat (nwNormalization nw)
-                        mWeight = M.lookup dmgCat (nwWeighting nw)
-                     in case (mNorm, mWeight) of
-                            (Just n, Just w) ->
-                                let ns = lrScore result * n
-                                 in (Just ns, Just (ns * w))
-                            _ -> (Nothing, Nothing)
-                Nothing -> (Nothing, Nothing)
-         in result
-                { lrDamageCategory = dmgCat
-                , lrNormalizedScore = normScore
-                , lrWeightedScore = weightScore
-                }
-
-    logLCIAResult :: LCIAResult -> Method -> IO ()
-    logLCIAResult result method = do
-        let mapped = lrMappedFlows result
-        reportProgress Info $
-            "[LCIA] "
-                <> T.unpack (methodName method)
-                <> ": "
-                <> showFFloat (Just 4) (lrScore result) ""
-                <> " "
-                <> T.unpack (methodUnit method)
-        reportProgress Info $ "  Flow mapping: " <> show mapped <> " CFs mapped"
-
     -- Flow detail endpoint
     getFlowDetail :: Text -> Text -> Handler FlowDetail
     getFlowDetail dbName flowIdText = do
@@ -1690,234 +1924,9 @@ lcaServer dbManager maxTreeDepth password hostingConfig classificationPresets =
         (db, _) <- requireDatabaseByName dbManager dbName
         return $ Service.getClassifications db
 
-    -- Batch impacts: one MUMPS multi-RHS solve for all requested processes,
-    -- followed by parallel characterization. Unresolved process ids are
-    -- returned in notFound/invalid rather than aborting the whole call.
+    -- Batch impacts: thin alias over the top-level batchImpactsH.
     postImpactsBatch :: Text -> Text -> Maybe Int -> BatchImpactsRequest -> Handler BatchImpactsResponse
-    postImpactsBatch dbName collectionName topFlowsParam req = do
-        (db, sharedSolver) <- requireDatabaseByName dbManager dbName
-        loadedCollections <- liftIO $ readTVarIO (dmLoadedMethods dbManager)
-        collection <- case M.lookup collectionName loadedCollections of
-            Just mc -> pure mc
-            Nothing -> throwError err404{errBody = "Collection not loaded: " <> BSL.fromStrict (T.encodeUtf8 collectionName)}
-        let resolved =
-                [ (pidText, Service.resolveActivityAndProcessId db pidText)
-                | pidText <- birProcessIds req
-                ]
-            valid = [(pidText, pidNum, act) | (pidText, Right (pidNum, act)) <- resolved]
-            notFound = [pidText | (pidText, Left (Service.ActivityNotFound _)) <- resolved]
-            invalid = [pidText | (pidText, Left (Service.InvalidProcessId _)) <- resolved]
-            validPidNums = [pidNum | (_, pidNum, _) <- valid]
-        t0 <- liftIO getCurrentTime
-        sols <- solutionsWithDeps dbManager dbName db sharedSolver validPidNums
-        t1 <- liftIO getCurrentTime
-        -- Pre-fetch per-method static context ONCE for the whole batch instead
-        -- of paying it inside every per-pid 'buildLCIABatchResult' call. For
-        -- 632 agribalyse pids × 27 methods that drops 17 K cache reads down
-        -- to 27 reads on the batch hot path. The context carries everything
-        -- 'buildLCIABatchResult' needs to construct an LCIAResult without
-        -- re-entering 'mapMethodToFlowsCached' / 'mapMethodToTablesCached'.
-        ctxs <- liftIO $ mapConcurrently (prepMethodCtx dbName db) (mcMethods collection)
-        -- Default top-flows=0: this endpoint exists to compute LCIA across
-        -- many activities in one call, so the cheap default skips the
-        -- per-(pid, method) 'inventoryContributions' walk (~17 K calls on a
-        -- 632-pid × 27-method batch). UI/per-activity callers want
-        -- contributors and use the single-method endpoint, whose default
-        -- stays at 5. Bulk callers that DO want contributors opt in with
-        -- ?top-flows=N.
-        let topFlows = max 0 (fromMaybe 0 topFlowsParam)
-        let mkEntry ((pidText, pidNum, activity), sol) = do
-                impacts <- buildLCIABatchResultCached dbName db pidNum activity collection sol ctxs topFlows
-                pure
-                    BatchImpactsEntry
-                        { bieProcessId = pidText
-                        , bieActivityName = activityName activity
-                        , bieImpacts = impacts
-                        }
-        -- Sequential: inner buildLCIABatchResultCached already runs the
-        -- per-method matvec batched in one pass. Nesting outer concurrency
-        -- over already-saturated CPU work just adds thread churn.
-        entries <- liftIO $ mapM mkEntry (zip valid sols)
-        t2 <- liftIO getCurrentTime
-        liftIO $
-            reportProgress Info $
-                "[batch-impacts] "
-                    <> T.unpack dbName
-                    <> " / "
-                    <> T.unpack collectionName
-                    <> ": "
-                    <> show (length valid)
-                    <> " activities"
-                    <> ( if null notFound && null invalid
-                            then ""
-                            else
-                                " ("
-                                    <> show (length notFound)
-                                    <> " not_found, "
-                                    <> show (length invalid)
-                                    <> " invalid)"
-                       )
-                    <> " — solve "
-                    <> showFFloat (Just 2) (realToFrac (diffUTCTime t1 t0) :: Double) ""
-                    <> "s, "
-                    <> "total "
-                    <> showFFloat (Just 2) (realToFrac (diffUTCTime t2 t0) :: Double) ""
-                    <> "s"
-        pure
-            BatchImpactsResponse
-                { birResults = entries
-                , birNotFound = notFound
-                , birInvalid = invalid
-                }
-
-    -- Build an LCIABatchResult from the post-characterization parts.
-    -- The lbrScoringUnits map is derived from the same [ScoringSet] used to
-    -- evaluate the scoring results; pass it in directly.
-    mkLCIABatchResult ::
-        [LCIAResult] ->
-        Maybe NormWeightSet ->
-        [NormWeightSet] ->
-        M.Map Text (M.Map Text Double) ->
-        [ScoringSet] ->
-        M.Map Text (M.Map Text ScoringIndicator) ->
-        LCIABatchResult
-    mkLCIABatchResult results mNW nwSets scoringResults scoringSets scoringIndicators =
-        LCIABatchResult
-            { lbrResults = results
-            , lbrSingleScore = Nothing
-            , lbrSingleScoreUnit = Nothing
-            , lbrNormWeightSetName = nwName <$> mNW
-            , lbrAvailableNWsets = map nwName nwSets
-            , lbrScoringResults = scoringResults
-            , lbrScoringUnits = M.fromList [(ssName ss, ssUnit ss) | ss <- scoringSets]
-            , lbrScoringIndicators = scoringIndicators
-            }
-
-    prepMethodCtx :: Text -> Database -> Method -> IO MethodCtx
-    prepMethodCtx dbName db method = do
-        mappings <- DM.mapMethodToFlowsCached dbManager dbName db method
-        -- Force the per-(db, method) tables once here too so subsequent
-        -- 'batchedScoresFor' calls hit a warm cache.
-        _ <- DM.mapMethodToTablesCached dbManager dbName db method
-        let stats = computeMappingStats mappings
-        pure MethodCtx{mctxMethod = method, mctxMappedFlows = msTotal stats - msUnmatched stats}
-
-    -- Batch fast path: scores via 'batchedScoresFor', then build LCIAResult
-    -- records straight from the precomputed contexts. Skips the per-pid
-    -- 'mapConcurrently' over 27 methods entirely. When 'topFlows' is 0
-    -- (the default) 'lrTopContributors' is left empty and the contribution
-    -- walk is skipped; when >0, we run 'inventoryContributions' per method
-    -- using the warmed-up 'MethodTables' from 'mapMethodToTablesCached'.
-    buildLCIABatchResultCached ::
-        Text ->
-        Database ->
-        ProcessId ->
-        Activity ->
-        MethodCollection ->
-        SharedSolver.CrossDBSolution ->
-        [MethodCtx] ->
-        Int ->
-        IO LCIABatchResult
-    buildLCIABatchResultCached dbName db actPid activity collection sol ctxs topFlows = do
-        let damageCats = mcDamageCategories collection
-            nwSets = mcNormWeightSets collection
-            dcLookup =
-                M.fromList
-                    [ (subName, dcName dc)
-                    | dc <- damageCats
-                    , (subName, _) <- dcImpacts dc
-                    ]
-            mNW = case nwSets of (nw : _) -> Just nw; [] -> Nothing
-            methods = map mctxMethod ctxs
-            inventory = SharedSolver.csInventory sol
-        scoreMap <- batchedScoresFor dbName db sol methods
-        (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
-        -- Surface inventory flows that aren't in the merged FlowDB once per pid
-        -- (independent of method, independent of topFlows) — the signal is a
-        -- coverage-gap warning on the inventory itself, not on any one method.
-        -- Matches what 'computeCategoryResult' emitted on the non-batch path,
-        -- but de-duplicated: one Warning per pid instead of per (pid, method).
-        let unknownUuids =
-                [ fid
-                | (fid, qty) <- M.toList inventory
-                , qty /= 0
-                , not (M.member fid mFlows)
-                ]
-        unless (null unknownUuids) $
-            reportProgress Warning $
-                "[LCIA batch] pid="
-                    <> show actPid
-                    <> ": "
-                    <> show (length unknownUuids)
-                    <> " inventory flow UUID(s) absent from merged FlowDB — characterization incomplete. Samples: "
-                    <> show (take 3 unknownUuids)
-        -- Only fetch UnitConfig when we'll actually walk the contributions; the
-        -- top-flows=0 default skips this entirely.
-        mUnitCfg <-
-            if topFlows > 0
-                then Just <$> getMergedUnitConfig dbManager
-                else pure Nothing
-        let (prodName, prodAmount, prodUnit) = Service.getReferenceProductInfo mFlows mUnits activity
-            functionalUnit = T.pack (showFFloat (Just 2) prodAmount "") <> " " <> prodUnit <> " of " <> prodName
-            -- Per-pid warning on Left mirrors the non-batch 'computeCategoryResult'
-            -- path. The build-time WARN lists global (flow, location) gaps but
-            -- can't tell a caller which specific pid actually hit one; without
-            -- this line a Left collapses silently to score=0, indistinguishable
-            -- from a true zero in the export.
-            mkResultIO ctx = do
-                let method = mctxMethod ctx
-                score <- case M.lookup (methodId method) scoreMap of
-                    Just (Right s) -> pure s
-                    Just (Left err) -> do
-                        reportProgress Warning $
-                            "[LCIA "
-                                <> T.unpack (methodName method)
-                                <> "] pid="
-                                <> show actPid
-                                <> ": "
-                                <> T.unpack err
-                        pure 0
-                    Nothing -> pure 0
-                topContributors <- case mUnitCfg of
-                    Nothing -> pure []
-                    Just unitCfg -> do
-                        tables <- DM.mapMethodToTablesCached dbManager dbName db method
-                        let (rawContribs, _unknownUuids) =
-                                inventoryContributions unitCfg mUnits mFlows inventory tables
-                            sorted = sortOn (\(_, _, c) -> negate (abs c)) rawContribs
-                            top = take topFlows sorted
-                        pure
-                            [ FlowContributionEntry
-                                { fcoFlowName = flowName f
-                                , fcoContribution = c
-                                , fcoSharePct = if score /= 0 then c / score * 100 else 0
-                                , fcoFlowId = UUID.toText (flowId f)
-                                , fcoCategory = flowCategory f
-                                , fcoCompartment = flowSubcompartment f
-                                , fcoCfValue = cfVal
-                                }
-                            | (f, cfVal, c) <- top
-                            ]
-                pure $
-                    enrichWithNW dcLookup mNW $
-                        LCIAResult
-                            { lrMethodId = methodId method
-                            , lrMethodName = methodName method
-                            , lrCategory = methodCategory method
-                            , lrDamageCategory = methodCategory method
-                            , lrScore = score
-                            , lrUnit = methodUnit method
-                            , lrNormalizedScore = Nothing
-                            , lrWeightedScore = Nothing
-                            , lrMappedFlows = mctxMappedFlows ctx
-                            , lrFunctionalUnit = functionalUnit
-                            , lrTopContributors = topContributors
-                            }
-        results <- traverse mkResultIO ctxs
-        let rawScoreMap = M.fromList [(lrCategory r, lrScore r) | r <- results]
-        (scoringResults, scoringIndicators) <-
-            computeAllScoringSets (mcScoringSets collection) rawScoreMap
-        pure (mkLCIABatchResult results mNW nwSets scoringResults (mcScoringSets collection) scoringIndicators)
+    postImpactsBatch = batchImpactsH dbManager
 
 {- | Evaluate every scoring set against the raw impact score map.
 Returns (setName → scoreName → value, setName → varName → ScoringIndicator).

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -165,13 +165,28 @@ type LCAAPI =
                 :<|> "openapi.json" :> Get '[JSON] Value
            )
 
+{- | Standard prefix for "database not loaded" 404 bodies. Exported so that
+'API.BatchImpacts.translateError' can recover a typed 'DatabaseNotLoaded'
+from the wire body without the two ends silently drifting apart.
+-}
+databaseNotLoadedPrefix :: Text
+databaseNotLoadedPrefix = "Database not loaded: "
+
+-- | Same idea for "collection not loaded" 404 bodies.
+collectionNotLoadedPrefix :: Text
+collectionNotLoadedPrefix = "Collection not loaded: "
+
+-- | Build the 404 body for a not-loaded database / collection by name.
+notLoadedBody :: Text -> Text -> BSL.ByteString
+notLoadedBody prefix name = BSL.fromStrict (T.encodeUtf8 (prefix <> name))
+
 -- | Get database by name, throw 404 if not loaded
 requireDatabaseByName :: DatabaseManager -> Text -> Handler (Database, SharedSolver)
 requireDatabaseByName dbManager dbName = do
     maybeLoaded <- liftIO $ getDatabase dbManager dbName
     case maybeLoaded of
         Just loaded -> return (ldDatabase loaded, ldSharedSolver loaded)
-        Nothing -> throwError err404{errBody = "Database not loaded: " <> BSL.fromStrict (T.encodeUtf8 dbName)}
+        Nothing -> throwError err404{errBody = notLoadedBody databaseNotLoadedPrefix dbName}
 
 {- | Refuse LCIA when the DB still has unresolved cross-DB products. Forces
 the user to load the missing dep DBs (or POST /relink) rather than
@@ -484,7 +499,7 @@ loadCollection dbManager collectionName = do
     loadedCollections <- liftIO $ readTVarIO (dmLoadedMethods dbManager)
     case M.lookup collectionName loadedCollections of
         Just mc -> return (mcMethods mc, mcDamageCategories mc, mcNormWeightSets mc, mcScoringSets mc)
-        Nothing -> throwError err404{errBody = "Collection not loaded: " <> BSL.fromStrict (T.encodeUtf8 collectionName)}
+        Nothing -> throwError err404{errBody = notLoadedBody collectionNotLoadedPrefix collectionName}
 
 {- | Cross-DB inventory solution for an activity. 'Nothing' takes the cached
 no-substitution path ('requireFullyLinked' runs inside 'solutionWithDeps');
@@ -826,7 +841,7 @@ batchImpactsH dbManager dbName collectionName topFlowsParam req = do
     loadedCollections <- liftIO $ readTVarIO (dmLoadedMethods dbManager)
     collection <- case M.lookup collectionName loadedCollections of
         Just mc -> pure mc
-        Nothing -> throwError err404{errBody = "Collection not loaded: " <> BSL.fromStrict (T.encodeUtf8 collectionName)}
+        Nothing -> throwError err404{errBody = notLoadedBody collectionNotLoadedPrefix collectionName}
     let resolved =
             [ (pidText, Service.resolveActivityAndProcessId db pidText)
             | pidText <- birProcessIds req

--- a/test/BatchImpactsSpec.hs
+++ b/test/BatchImpactsSpec.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Tests for "API.BatchImpacts" — the typed-error wrappers around the
+hoisted LCIA batch entry points.
+
+Two layers :
+
+  1. 'translateError' is exercised as a pure function over synthetic
+     'ServerError' values. This is where the heuristic-translation
+     contract is locked down so any future drift on a throw-site body
+     in "API.Routes" surfaces here, not in a downstream MCP consumer.
+
+  2. End-to-end smoke tests on the wrappers themselves, using an empty
+     'DatabaseManager' (no databases / no collections loaded). This is
+     the cheapest fixture that still exercises the Servant.runHandler
+     boundary and proves that error translation lands the right
+     constructor on a real failure path.
+-}
+module BatchImpactsSpec (spec) where
+
+import API.BatchImpacts (BatchError (..), runActivityLCIABatch, runBatchImpacts)
+import Config (defaultConfig)
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Text.Encoding as TE
+import Database.Manager (initDatabaseManager)
+import Servant (err400, err404, err422, err500, errBody)
+import Test.Hspec
+
+import qualified API.BatchImpacts as BI
+import Data.Text (Text)
+
+{- | Drive 'translateError' with a synthetic 'ServerError' of the given
+status code and body. Picks the canonical err400/404/422/500
+constructors and falls through to err500 for any other code.
+-}
+translateError' :: [Text] -> Int -> Text -> BatchError
+translateError' avail code body =
+    BI.translateError avail $ case code of
+        400 -> err400{errBody = bodyBS}
+        404 -> err404{errBody = bodyBS}
+        422 -> err422{errBody = bodyBS}
+        _ -> err500{errBody = bodyBS}
+  where
+    bodyBS = BSL.fromStrict (TE.encodeUtf8 body)
+
+spec :: Spec
+spec = do
+    describe "translateError" $ do
+        it "maps 404 + 'Collection not loaded: X' to CollectionNotLoaded" $
+            translateError' ["a", "b"] 404 "Collection not loaded: EF-3.1"
+                `shouldBe` CollectionNotLoaded "EF-3.1" ["a", "b"]
+
+        it "maps 404 + 'Database not loaded: X' to DatabaseNotLoaded" $
+            translateError' [] 404 "Database not loaded: agribalyse"
+                `shouldBe` DatabaseNotLoaded "agribalyse"
+
+        it "maps a bare 404 to ActivityResolutionFailed (verbatim body)" $
+            translateError' [] 404 "Activity not found"
+                `shouldBe` ActivityResolutionFailed "Activity not found"
+
+        it "maps 400 to ActivityResolutionFailed (verbatim body)" $
+            translateError' [] 400 "Invalid ProcessId format: x"
+                `shouldBe` ActivityResolutionFailed "Invalid ProcessId format: x"
+
+        it "maps 422 to LinkingIncomplete (verbatim body)" $
+            translateError' [] 422 "Database X has unresolved cross-DB products"
+                `shouldBe` LinkingIncomplete "Database X has unresolved cross-DB products"
+
+        it "falls through to OtherBatchError for anything else" $
+            translateError' [] 500 "internal error"
+                `shouldBe` OtherBatchError 500 "internal error"
+
+    describe "runActivityLCIABatch (empty DatabaseManager)" $ do
+        it "returns DatabaseNotLoaded when the requested DB is not loaded" $ do
+            dbm <- initDatabaseManager defaultConfig True Nothing
+            res <- runActivityLCIABatch dbm "no-such-db" "no-pid" "no-coll" Nothing
+            -- LCIABatchResult has no Show instance, so we pattern-match
+            -- rather than rely on 'shouldBe' over the whole Either.
+            case res of
+                Left e -> e `shouldBe` DatabaseNotLoaded "no-such-db"
+                Right _ -> expectationFailure "expected DatabaseNotLoaded; got a successful result"
+
+    describe "runBatchImpacts (empty DatabaseManager)" $ do
+        it "returns DatabaseNotLoaded when the requested DB is not loaded" $ do
+            dbm <- initDatabaseManager defaultConfig True Nothing
+            res <- runBatchImpacts dbm "no-such-db" "no-coll" Nothing ["pidA", "pidB"]
+            case res of
+                Left e -> e `shouldBe` DatabaseNotLoaded "no-such-db"
+                Right _ -> expectationFailure "expected DatabaseNotLoaded; got a successful result"

--- a/test/MCPEnrichSpec.hs
+++ b/test/MCPEnrichSpec.hs
@@ -1,0 +1,232 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Pure-function tests for "API.MCP.Enrich".
+
+These helpers do all the JSON munging that turns the serialized
+'LCIABatchResult' / 'BatchImpactsResponse' into the shape the MCP
+client sees: @web_url@ deep links at every level, and (optionally) a
+restricted subset of the configured scoring sets. They're easy to
+regress on a JSON-shape change, so each branch is covered here
+independently of the live server.
+-}
+module MCPEnrichSpec (spec) where
+
+import API.MCP.Enrich (
+    addWebUrl,
+    encodeSegment,
+    enrichBatchResults,
+    enrichResultsWithWebUrl,
+    filterScoringSets,
+    filterScoringSetsBatch,
+    scoreActivityWebUrl,
+ )
+import Data.Aeson (Value (..), object, (.=))
+import Data.Aeson.Key (fromText)
+import qualified Data.Aeson.KeyMap as KM
+import Data.Text (Text)
+import qualified Data.Vector as V
+import Test.Hspec
+
+-- ---------------------------------------------------------------------------
+-- Fixtures
+--
+-- These mirror the camelCase JSON shapes that 'strippedToJSON' emits for
+-- LCIABatchResult / BatchImpactsEntry, not the snake_case names that
+-- 'list_scoring_sets' uses for its own projection. Stay aligned with
+-- those producers or these tests stop catching real regressions.
+-- ---------------------------------------------------------------------------
+
+{- | Minimal LCIABatchResult-shaped Value: one method entry, three
+scoring sets, scoringResults missing one of them (simulating a
+set whose formula failed to evaluate).
+-}
+sampleLBR :: Value
+sampleLBR =
+    object
+        [ "results"
+            .= [ object
+                    [ "methodId" .= ("uuid-method-1" :: Text)
+                    , "score" .= (1.23 :: Double)
+                    ]
+               ]
+        , "scoringResults"
+            .= object
+                [ "PEF" .= object ["score" .= (1.0 :: Double)]
+                , "ECS" .= object ["score" .= (2.0 :: Double)]
+                ]
+        , "scoringUnits"
+            .= object
+                [ "PEF" .= ("Pt" :: Text)
+                , "ECS" .= ("Pt" :: Text)
+                , "FAILED" .= ("Pt" :: Text)
+                ]
+        , "scoringIndicators"
+            .= object
+                [ "PEF" .= object []
+                , "ECS" .= object []
+                , "FAILED" .= object []
+                ]
+        ]
+
+{- | Minimal BatchImpactsResponse-shaped Value: two entries with
+impacts, one entry without impacts (defensive — see enrichBatchResults).
+-}
+sampleBatch :: Value
+sampleBatch =
+    object
+        [ "results"
+            .= [ object
+                    [ "processId" .= ("pidA" :: Text)
+                    , "impacts" .= sampleLBR
+                    ]
+               , object
+                    [ "processId" .= ("pidB" :: Text)
+                    , "impacts" .= sampleLBR
+                    ]
+               , object
+                    -- malformed: no impacts subtree
+                    ["processId" .= ("pidC" :: Text)]
+               ]
+        , "not_found" .= ([] :: [Text])
+        , "invalid" .= ([] :: [Text])
+        ]
+
+-- ---------------------------------------------------------------------------
+-- Spec
+-- ---------------------------------------------------------------------------
+
+spec :: Spec
+spec = do
+    describe "scoreActivityWebUrl" $ do
+        it "encodes every dynamic segment (no raw slashes leak through)" $
+            scoreActivityWebUrl "https://volca.run" "db/with-slash" "pid/with-slash" "EF 3.1"
+                `shouldBe` "https://volca.run/db/db%2Fwith-slash/activity/pid%2Fwith-slash/impacts/EF%203.1"
+
+        it "round-trips ASCII-safe segments unchanged" $
+            scoreActivityWebUrl "https://x" "agribalyse" "abc_def" "EF31"
+                `shouldBe` "https://x/db/agribalyse/activity/abc_def/impacts/EF31"
+
+    describe "encodeSegment" $
+        it "percent-encodes unsafe URL characters" $ do
+            encodeSegment "a/b" `shouldBe` "a%2Fb"
+            encodeSegment "a b" `shouldBe` "a%20b"
+
+    describe "addWebUrl" $ do
+        it "inserts web_url into an Object" $
+            addWebUrl "https://x" (object ["a" .= (1 :: Int)])
+                `shouldBe` object ["a" .= (1 :: Int), "web_url" .= ("https://x" :: Text)]
+
+        it "passes Array through unchanged" $
+            addWebUrl "https://x" (Array (V.fromList [Null])) `shouldBe` Array (V.fromList [Null])
+
+        it "passes String/Number/Bool/Null through unchanged" $ do
+            addWebUrl "https://x" (String "s") `shouldBe` String "s"
+            addWebUrl "https://x" (Number 42) `shouldBe` Number 42
+            addWebUrl "https://x" (Bool True) `shouldBe` Bool True
+            addWebUrl "https://x" Null `shouldBe` Null
+
+    describe "enrichResultsWithWebUrl" $ do
+        it "appends /<methodId> as web_url on each results entry with a methodId" $ do
+            let enriched = enrichResultsWithWebUrl "https://x/impacts/EF31" sampleLBR
+            case enriched of
+                Object km -> case KM.lookup (fromText "results") km of
+                    Just (Array rs) -> case V.toList rs of
+                        [Object entry] ->
+                            KM.lookup (fromText "web_url") entry
+                                `shouldBe` Just (String "https://x/impacts/EF31/uuid-method-1")
+                        _ -> expectationFailure "expected a single result entry"
+                    _ -> expectationFailure "expected results to be an array"
+                _ -> expectationFailure "expected an object"
+
+        it "leaves entries without a methodId untouched" $ do
+            let v = object ["results" .= [object ["score" .= (1 :: Int)]]]
+                Object km = enrichResultsWithWebUrl "https://x" v
+                Just (Array rs) = KM.lookup (fromText "results") km
+                [Object entry] = V.toList rs
+            KM.lookup (fromText "web_url") entry `shouldBe` Nothing
+
+        it "leaves the object unchanged when there is no results key" $ do
+            let v = object ["other" .= (1 :: Int)]
+            enrichResultsWithWebUrl "https://x" v `shouldBe` v
+
+    describe "enrichBatchResults" $ do
+        it "adds web_url at the entry level (the documented shape)" $ do
+            let Object km = enrichBatchResults "https://x" "agribalyse" "EF31" sampleBatch
+                Just (Array rs) = KM.lookup (fromText "results") km
+                [Object e0, _, _] = V.toList rs
+            KM.lookup (fromText "web_url") e0
+                `shouldBe` Just (String "https://x/db/agribalyse/activity/pidA/impacts/EF31")
+
+        it "also adds web_url inside the entry's impacts subtree" $ do
+            let Object km = enrichBatchResults "https://x" "agribalyse" "EF31" sampleBatch
+                Just (Array rs) = KM.lookup (fromText "results") km
+                [Object e0, _, _] = V.toList rs
+                Just (Object impacts) = KM.lookup (fromText "impacts") e0
+            KM.lookup (fromText "web_url") impacts
+                `shouldBe` Just (String "https://x/db/agribalyse/activity/pidA/impacts/EF31")
+
+        it "does NOT materialise an empty impacts object for entries that lack one" $ do
+            let Object km = enrichBatchResults "https://x" "agribalyse" "EF31" sampleBatch
+                Just (Array rs) = KM.lookup (fromText "results") km
+                [_, _, Object e2] = V.toList rs
+            -- Entry without impacts should still gain web_url but not a fake impacts: {}
+            KM.lookup (fromText "web_url") e2
+                `shouldBe` Just (String "https://x/db/agribalyse/activity/pidC/impacts/EF31")
+            KM.lookup (fromText "impacts") e2 `shouldBe` Nothing
+
+    describe "filterScoringSets" $ do
+        it "is a no-op when requested is empty" $
+            filterScoringSets ["PEF", "ECS"] [] sampleLBR `shouldBe` Right sampleLBR
+
+        it "accepts configured names that are missing from scoringResults" $ do
+            -- 'FAILED' is configured (in scoringUnits / scoringIndicators) but
+            -- did not produce a score; requesting it must succeed.
+            case filterScoringSets ["PEF", "ECS", "FAILED"] ["FAILED"] sampleLBR of
+                Right (Object km) -> do
+                    KM.lookup (fromText "scoringResults") km
+                        `shouldBe` Just (object [])
+                    KM.lookup (fromText "scoringUnits") km
+                        `shouldBe` Just (object ["FAILED" .= ("Pt" :: Text)])
+                Right v -> expectationFailure ("expected Object, got " <> show v)
+                Left e -> expectationFailure ("unexpected Left: " <> show e)
+
+        it "rejects names not in configured" $
+            filterScoringSets ["PEF", "ECS"] ["typo"] sampleLBR
+                `shouldBe` Left "Unknown scoring set(s): typo. Configured on this collection: PEF, ECS"
+
+        it "restricts all three scoring maps to the requested keys" $ do
+            case filterScoringSets ["PEF", "ECS", "FAILED"] ["PEF"] sampleLBR of
+                Right (Object km) -> do
+                    KM.lookup (fromText "scoringResults") km
+                        `shouldBe` Just (object ["PEF" .= object ["score" .= (1.0 :: Double)]])
+                    KM.lookup (fromText "scoringUnits") km
+                        `shouldBe` Just (object ["PEF" .= ("Pt" :: Text)])
+                    KM.lookup (fromText "scoringIndicators") km
+                        `shouldBe` Just (object ["PEF" .= object []])
+                _ -> expectationFailure "expected an Object"
+
+    describe "filterScoringSetsBatch" $ do
+        it "validates against configured even when results is empty" $ do
+            -- The fix: a score_activities call where every PID is unresolved
+            -- still surfaces an unknown-name filter error instead of silently
+            -- returning a zero-entry response.
+            let emptyBatch = object ["results" .= ([] :: [Value])]
+            filterScoringSetsBatch ["PEF"] ["typo"] emptyBatch
+                `shouldBe` Left "Unknown scoring set(s): typo. Configured on this collection: PEF"
+
+        it "is a no-op when requested is empty" $
+            filterScoringSetsBatch ["PEF"] [] sampleBatch `shouldBe` Right sampleBatch
+
+        it "restricts the impacts subtree of each entry" $ do
+            case filterScoringSetsBatch ["PEF", "ECS", "FAILED"] ["PEF"] sampleBatch of
+                Right (Object km) -> case KM.lookup (fromText "results") km of
+                    Just (Array rs) -> case V.toList rs of
+                        Object e0 : _ -> case KM.lookup (fromText "impacts") e0 of
+                            Just (Object impacts) ->
+                                KM.lookup (fromText "scoringResults") impacts
+                                    `shouldBe` Just (object ["PEF" .= object ["score" .= (1.0 :: Double)]])
+                            _ -> expectationFailure "expected impacts to be an object"
+                        _ -> expectationFailure "expected entries"
+                    _ -> expectationFailure "expected results array"
+                Left e -> expectationFailure ("unexpected Left: " <> show e)
+                _ -> expectationFailure "expected an object"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -8,6 +8,7 @@ import Test.Hspec
 
 import qualified AutoRelinkSpec
 import qualified BM25Spec
+import qualified BatchImpactsSpec
 import qualified ChemSynonymsSpec
 import qualified CoalescingSolverSpec
 import qualified ConfigSpec
@@ -96,6 +97,7 @@ main = hspec $ do
         describe "openLCA JSON-LD ImpactCategory parser" OlcaSchemaSpec.spec
         describe "Method upload pipeline (JSON-LD)" MethodUploadSpec.spec
         describe "MCP Tool Schemas" MCPSchemaSpec.spec
+        describe "API.BatchImpacts" BatchImpactsSpec.spec
         describe "Search.Normalize" NormalizeSpec.spec
         describe "Search.BM25" BM25Spec.spec
         describe "Search.Fuzzy" FuzzySpec.spec

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -29,6 +29,7 @@ import qualified ILCDParserSpec
 import qualified InventorySpec
 import qualified LicensesSpec
 import qualified LoaderSpec
+import qualified MCPEnrichSpec
 import qualified MCPSchemaSpec
 import qualified MappingSpec
 import qualified MatrixConstructionSpec
@@ -98,6 +99,7 @@ main = hspec $ do
         describe "Method upload pipeline (JSON-LD)" MethodUploadSpec.spec
         describe "MCP Tool Schemas" MCPSchemaSpec.spec
         describe "API.BatchImpacts" BatchImpactsSpec.spec
+        describe "API.MCP.Enrich" MCPEnrichSpec.spec
         describe "Search.Normalize" NormalizeSpec.spec
         describe "Search.BM25" BM25Spec.spec
         describe "Search.Fuzzy" FuzzySpec.spec

--- a/volca.cabal
+++ b/volca.cabal
@@ -218,6 +218,7 @@ test-suite lca-tests
                      , EcoSpold2Spec
                      , MCPSchemaSpec
                      , BatchImpactsSpec
+                     , MCPEnrichSpec
                      , NormalizeSpec
                      , BM25Spec
                      , FuzzySpec

--- a/volca.cabal
+++ b/volca.cabal
@@ -216,6 +216,7 @@ test-suite lca-tests
                      , EcoSpold1Spec
                      , EcoSpold2Spec
                      , MCPSchemaSpec
+                     , BatchImpactsSpec
                      , NormalizeSpec
                      , BM25Spec
                      , FuzzySpec

--- a/volca.cabal
+++ b/volca.cabal
@@ -59,6 +59,7 @@ library
                      , API.DatabaseHandlers
                      , API.Auth
                      , API.MCP
+                     , API.MCP.Enrich
                      , API.OpenApi
                      , API.Resources
                      , API.Licenses

--- a/volca.cabal
+++ b/volca.cabal
@@ -53,6 +53,7 @@ library
                      , Method.ChemSynonyms
                      , Method.FlowResolver
                      , API.Routes
+                     , API.BatchImpacts
                      , API.Types
                      , API.JsonOptions
                      , API.DatabaseHandlers


### PR DESCRIPTION
## Why

A comparative study on 24 activities × 16 LCIA indicators currently needs **432 MCP `get_impacts` round-trips**, because `get_impacts` is one (process, method) at a time and the configured scoring sets aren't exposed through MCP. Scoring sets, per-indicator breakdown, and multi-activity batching all already exist in the REST layer (`LCIABatchResult`, `postImpactsBatch`, `computeAllScoringSets`); the gap was purely MCP exposure.

This PR turns that into **1–3 MCP calls**, zero client-side aggregation.

## What's new

Three MCP tools, all wrapping primitives that already exist in the engine:

| Tool | Replaces | Returns |
|---|---|---|
| `score_activity` | N × `get_impacts` over a collection | full LCIA panel + every configured scoring set + per-indicator breakdown for one activity |
| `score_activities` | N × M × `get_impacts` | same shape per activity, in one MUMPS multi-RHS solve + parallel characterization |
| `list_scoring_sets` | — (discovery) | configured scoring sets with their variables, NF, WF, formulas |

Both `score_*` tools take an optional `scoring_sets` array to restrict the response to specific aggregates (e.g. `["PEF"]`); omitted means every set, an unknown name fails with the list of configured names.

Every response carries a `web_url` deep link (top-level and per-method / per-entry) so a human can click straight through to the matching web UI view to continue exploring.

## Architecture

Two structural commits before the features land:

1. **`refactor(api): hoist lcaServer batch helpers to top level`** — pure code movement, 14 helpers + 2 entry points out of `lcaServer`'s `where`, with `DatabaseManager` (and `classificationPresets` where relevant) as explicit first parameters. Servant routes keep working through two thin where-aliases (`activityLCIABatchCore = activityLCIABatchH dbManager`, same for `postImpactsBatch`). No behaviour change.

2. **`feat(api): typed BatchError wrappers in API.BatchImpacts`** — new module with `runActivityLCIABatch` / `runBatchImpacts` returning `IO (Either BatchError a)`. Delegates to the hoisted Handler entry points via `Servant.runHandler` and translates `ServerError` to `BatchError` (`CollectionNotLoaded` with the live list of loaded collections, `DatabaseNotLoaded`, `ActivityResolutionFailed`, `LinkingIncomplete`, `OtherBatchError`). The "Collection not loaded" / "Database not loaded" body prefixes are imported from `API.Routes` so the two ends share one source of truth — drift one and the build breaks. Anything unrecognised falls through to `OtherBatchError` (status + verbatim body) rather than being silently flattened.

3. **`refactor(mcp): extract JSON enrichment to API.MCP.Enrich`** — the `web_url` decoration and `scoring_sets` filter live in a separate pure module behind small Value combinators (`overObject`, `overArray`, `valueText`), so every Aeson `Value` constructor is enumerated in one place instead of via wildcard fall-throughs at each call site. `filterScoringSets` validates against the collection's configured scoring-set names (read from `mcScoringSets`), not against the keys present in `scoringResults` — a set whose formula failed to evaluate is still a legal filter value. `filterScoringSetsBatch` validates once at the top level, so a `score_activities` call where every PID is unresolved still surfaces a typo'd filter loudly. `scoreActivityWebUrl` percent-encodes every dynamic segment.

## Testing

- **871 examples, 0 failures.**
- **`test/BatchImpactsSpec.hs`** — pure-function table for `translateError` covering every status / body-prefix pair `API.Routes` throws today, plus end-to-end smoke tests on the wrappers against an empty `DatabaseManager` (proving the `Servant.runHandler` boundary maps real failures to the right `BatchError` constructor).
- **`test/MCPEnrichSpec.hs`** — 19 pure tests over the enrichment helpers: `web_url` placement at entry / impacts / per-method level, the no-empty-`impacts`-placeholder invariant, the validation source for `filterScoringSets`, and the empty-results case for `filterScoringSetsBatch`.
- **`test/MCPSchemaSpec.hs`** already auto-iterates `toolDefinitions`, so the three new tools' JSON schemas are validated for free (no test change needed).
- **End-to-end probes** against a live server with Agribalyse loaded confirm: success path returns the full panel + all three scoring sets + per-indicator breakdown + working `web_url`s at every level; `scoring_sets` filter returns just the requested aggregates; unknown filter / DB / collection fail with actionable messages listing what's configured.
