### PR TITLE
test(server): poll for process exit instead of fixed sleeps

### DIFF
--- a/test/ServerSpec.hs
+++ b/test/ServerSpec.hs
@@ -97,6 +97,27 @@ waitForReady mgr remaining = do
     alive <- isAlive mgr
     if alive then return True else waitForReady mgr (remaining - 1)
 
+{- | Poll 'getProcessExitCode' until the process exits or budget runs out.
+Returns the exit code if it exited within budget, 'Nothing' otherwise.
+Budget is in 200ms ticks.
+
+Why: shutdown is asynchronous — the endpoint returns immediately and the
+RTS finishes teardown some hundreds of ms later. A fixed sleep is racy
+on slow CI runners; polling lets the test pass as soon as the process
+actually exits and bounds the worst case at a clear upper limit.
+
+How to apply: probe the process, NOT the HTTP socket. Hitting @isAlive@
+in a tight loop would count as activity and reset the idle timer the
+@idle-timeout@ test depends on.
+-}
+waitForExit :: ProcessHandle -> Int -> IO (Maybe ExitCode)
+waitForExit _ 0 = pure Nothing
+waitForExit ph remaining = do
+    mCode <- getProcessExitCode ph
+    case mCode of
+        Just _ -> pure mCode
+        Nothing -> threadDelay 200000 >> waitForExit ph (remaining - 1)
+
 -- | Check if server is reachable
 isAlive :: Manager -> IO Bool
 isAlive mgr = do
@@ -135,34 +156,30 @@ serverSpecs = do
         it "POST /api/v1/shutdown stops the server" $ do
             withMinimalConfig $ \cfgPath ->
                 withServer cfgPath $ \ph mgr -> do
-                    -- Server should be alive
                     isAlive mgr `shouldReturn` True
-                    -- Send shutdown
                     code <- postEndpoint mgr "/api/v1/shutdown"
                     code `shouldBe` 200
-                    -- Wait for server to die
-                    threadDelay 1000000 -- 1s
-                    isAlive mgr `shouldReturn` False
-                    -- Process should have exited
-                    mCode <- getProcessExitCode ph
+                    -- Poll for process exit, up to 5s (25 * 200ms).
+                    mCode <- waitForExit ph 25
                     mCode `shouldBe` Just ExitSuccess
+                    isAlive mgr `shouldReturn` False
 
     describe "Server idle timeout" $ do
         it "POST /api/v1/idle-timeout/N shuts down after N seconds" $ do
             withMinimalConfig $ \cfgPath ->
                 withServer cfgPath $ \ph mgr -> do
-                    -- Server should be alive
                     isAlive mgr `shouldReturn` True
-                    -- Activate 2-second idle timeout
                     code <- postEndpoint mgr "/api/v1/idle-timeout/2"
                     code `shouldBe` 200
-                    -- Still alive immediately
+                    -- The idle timer resets on each HTTP hit, so the next
+                    -- check is the last activity before the quiet window.
                     isAlive mgr `shouldReturn` True
-                    -- Wait for timeout + buffer
-                    threadDelay 3500000 -- 3.5s
-                    -- Should be dead
-                    isAlive mgr `shouldReturn` False
-                    mCode <- getProcessExitCode ph
+                    -- Then stay quiet for the full timer + a small grace,
+                    -- then poll the *process* (not the socket) for exit.
+                    -- Budget: 6s of polling after a 2s quiet window covers
+                    -- generous CI scheduling slop.
+                    threadDelay 2200000 -- 2.2s — let the 2s timer fire
+                    mCode <- waitForExit ph 30
                     mCode `shouldBe` Just ExitSuccess
 
         it "POST /api/v1/idle-timeout/0 cancels timeout" $ do


### PR DESCRIPTION
## Summary

- `test/ServerSpec.hs` slept a fixed 1s / 3.5s then checked the server was gone. Under CI load the margin between timer fire and assertion was sometimes too tight, producing intermittent failures like the one on PR #73's linux-amd64 job:
  ```
  test/ServerSpec.hs:164:33:
    POST /api/v1/idle-timeout/N shuts down after N seconds
         expected: False
          but got: True
  ```
- New `waitForExit` helper polls `getProcessExitCode` every 200ms up to a clear upper bound — happy path is faster, worst case is bounded.

## Why this shape

Two things the haddock now documents so the next person doesn't repeat them:

1. **Probe the process, not the HTTP socket.** An `isAlive` poll would count as activity and reset the idle timer the test is supposed to verify. First draft of this fix had exactly that bug — caught it locally before push.
2. **The idle-timeout test still needs a quiet window.** The timer resets on every request, including the `isAlive` existence check that precedes it; so the spec keeps a 2.2s deliberate sleep before polling.

## Test plan

- [x] `cabal test lca-tests --test-options='--match "Server Lifecycle"'` — 3/3 pass
- [x] Stress: 5 consecutive runs, all green
- [x] Full suite local pass on `main` is unaffected (only ServerSpec touched)