### PR TITLE
Replace dual selectedDeps/suggestions with DependencyChoice sum

### DIFF
--- a/src/API/OpenApi.hs
+++ b/src/API/OpenApi.hs
@@ -26,7 +26,7 @@ import qualified Data.OpenApi.Lens as OA
 import Data.Proxy (Proxy (..))
 import Data.Text (Text)
 import qualified Data.Text as T
-import Database.Manager (DatabaseSetupInfo, DependencySuggestion, MissingSupplier)
+import Database.Manager (DatabaseSetupInfo, DependencyChoice, DependencyStatus, MissingSupplier)
 import Network.HTTP.Types.Method (StdMethod (..))
 import Types (BioDirection, BiosphereFlow, Compartment, Exchange, Pedigree, TechRole, TechnosphereFlow, Unit)
 
@@ -52,7 +52,8 @@ instance ToSchema Exchange where declareNamedSchema = genericDeclareNamedSchema 
 
 -- Database.Manager types
 instance ToSchema MissingSupplier
-instance ToSchema DependencySuggestion
+instance ToSchema DependencyStatus
+instance ToSchema DependencyChoice
 instance ToSchema DatabaseSetupInfo
 
 -- API.Types — every record type uses strippedSchemaOptions so the generated

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -15,7 +15,8 @@ module Database.Manager (
     DatabaseSetupInfo (..),
     SetupError (..),
     MissingSupplier (..),
-    DependencySuggestion (..),
+    DependencyChoice (..),
+    DependencyStatus (..),
     MethodCollectionStatus (..),
     RefDataStatus (..),
 
@@ -231,21 +232,30 @@ instance ToJSON MissingSupplier where
             , "detail" .= msDetail
             ]
 
--- | Suggestion for a dependency database
-data DependencySuggestion = DependencySuggestion
-    { dsgDatabaseName :: !Text
-    , dsgDisplayName :: !Text
-    , dsgMatchCount :: !Int
-    -- ^ How many missing suppliers it can provide
+-- | Whether a candidate dependency is currently selected or merely available
+data DependencyStatus = SelectedDep | AvailableDep
+    deriving (Show, Eq, Generic)
+
+instance ToJSON DependencyStatus where
+    toJSON SelectedDep = A.String "selected"
+    toJSON AvailableDep = A.String "available"
+
+-- | A candidate dependency database in either selected or available state
+data DependencyChoice = DependencyChoice
+    { dchStatus :: !DependencyStatus
+    , dchDatabaseName :: !Text
+    , dchDisplayName :: !Text
+    , dchMatchCount :: !Int
     }
     deriving (Show, Eq, Generic)
 
-instance ToJSON DependencySuggestion where
-    toJSON DependencySuggestion{..} =
+instance ToJSON DependencyChoice where
+    toJSON DependencyChoice{..} =
         A.object
-            [ "databaseName" .= dsgDatabaseName
-            , "displayName" .= dsgDisplayName
-            , "matchCount" .= dsgMatchCount
+            [ "status" .= dchStatus
+            , "databaseName" .= dchDatabaseName
+            , "displayName" .= dchDisplayName
+            , "matchCount" .= dchMatchCount
             ]
 
 -- | Setup info for a database (for the setup page)
@@ -265,10 +275,8 @@ data DatabaseSetupInfo = DatabaseSetupInfo
     -- ^ Still unresolved
     , dsiMissingSuppliers :: ![MissingSupplier]
     -- ^ Top missing suppliers
-    , dsiSelectedDeps :: ![Text]
-    -- ^ Currently selected dependencies
-    , dsiSuggestions :: ![DependencySuggestion]
-    -- ^ Suggested dependencies
+    , dsiDependencies :: ![DependencyChoice]
+    -- ^ Candidate dependencies (selected + available) in one alpha-sorted list
     , dsiIsReady :: !Bool
     -- ^ True if can be finalized
     , dsiUnknownUnits :: ![Text]
@@ -296,8 +304,7 @@ instance ToJSON DatabaseSetupInfo where
             , "crossDBLinks" .= dsiCrossDBLinks
             , "unresolvedLinks" .= dsiUnresolvedLinks
             , "missingSuppliers" .= dsiMissingSuppliers
-            , "selectedDependencies" .= dsiSelectedDeps
-            , "suggestions" .= dsiSuggestions
+            , "dependencies" .= dsiDependencies
             , "isReady" .= dsiIsReady
             , "unknownUnits" .= dsiUnknownUnits
             , "locationFallbacks" .= map encodeFallback dsiLocationFallbacks
@@ -1855,14 +1862,15 @@ buildSetupResult manager dbName = do
         Nothing -> case M.lookup dbName loadedDbs of
             Just loaded ->
                 let info = buildLoadedSetupInfo (ldConfig loaded) (ldDatabase loaded)
-                    suggestions = buildDependencySuggestions' availableDbs indexedDbs
+                    selected = dbDependsOn (ldDatabase loaded)
+                    dependencies = buildDependencyChoices dbName selected availableDbs indexedDbs
                     nUnresolved = unresolvedCount (dbLinkingStats (ldDatabase loaded))
                  in return $
                         Right
                             info
                                 { dsiIsLoaded = False
                                 , dsiIsReady = nUnresolved == 0
-                                , dsiSuggestions = suggestions
+                                , dsiDependencies = dependencies
                                 }
             Nothing -> return $ Left $ SetupFailed $ "Failed to stage database: " <> dbName
 
@@ -1891,8 +1899,13 @@ buildStagedSetupInfo staged configs indexedDbs =
                     UnitIncompatible q s -> ("unit_incompatible", Just (q <> " vs " <> s))
                     LocationUnavailable loc -> ("location_unavailable", Just loc)
              in MissingSupplier name cnt Nothing reason detail
-        -- Build suggestions from available databases
-        suggestions = buildDependencySuggestions staged configs indexedDbs
+        -- Combined dependencies list (selected + available, alpha sorted)
+        dependencies =
+            buildDependencyChoices
+                (dcName (sdConfig staged))
+                (sdSelectedDeps staged)
+                configs
+                indexedDbs
         -- Database is ready only when it has activities and all inputs are resolved
         activityCount = M.size (sdbActivities (sdSimpleDB staged))
         isReady = activityCount > 0 && unresolvedLinks == 0
@@ -1906,8 +1919,7 @@ buildStagedSetupInfo staged configs indexedDbs =
             , dsiCrossDBLinks = crossDBLinks
             , dsiUnresolvedLinks = unresolvedLinks
             , dsiMissingSuppliers = missingSuppliers
-            , dsiSelectedDeps = sdSelectedDeps staged
-            , dsiSuggestions = suggestions
+            , dsiDependencies = dependencies
             , dsiIsReady = isReady
             , dsiUnknownUnits = S.toList (cdlUnknownUnits stats)
             , dsiLocationFallbacks = deduplicateFallbacks (cdlLocationFallbacks stats)
@@ -1948,8 +1960,15 @@ buildLoadedSetupInfo config db =
             , dsiCrossDBLinks = nCrossDBLinks
             , dsiUnresolvedLinks = nUnresolved
             , dsiMissingSuppliers = missingSuppliers
-            , dsiSelectedDeps = dbDependsOn db
-            , dsiSuggestions = [] -- No suggestions for loaded databases
+            , dsiDependencies =
+                [ DependencyChoice
+                    { dchStatus = SelectedDep
+                    , dchDatabaseName = name
+                    , dchDisplayName = name
+                    , dchMatchCount = 0
+                    }
+                | name <- dbDependsOn db
+                ]
             , dsiIsReady = True
             , dsiUnknownUnits = S.toList (cdlUnknownUnits stats)
             , dsiLocationFallbacks = deduplicateFallbacks (cdlLocationFallbacks stats)
@@ -2040,20 +2059,36 @@ setDataPath manager dbName newRelPath = do
                             Left err -> return $ Left $ setupErrorMessage err
                             Right info -> return $ Right info
 
--- | Build dependency suggestions from available indexed databases
-buildDependencySuggestions' :: Map Text DatabaseConfig -> Map Text IndexedDatabase -> [DependencySuggestion]
-buildDependencySuggestions' configs indexedDbs =
-    [ DependencySuggestion
-        { dsgDatabaseName = name
-        , dsgDisplayName = maybe name dcDisplayName (M.lookup name configs)
-        , dsgMatchCount = M.size (Database.CrossLinking.idbByProductName idx)
-        }
-    | (name, idx) <- M.toList indexedDbs
-    ]
-
--- | Build dependency suggestions for a staged database
-buildDependencySuggestions :: StagedDatabase -> Map Text DatabaseConfig -> Map Text IndexedDatabase -> [DependencySuggestion]
-buildDependencySuggestions _staged = buildDependencySuggestions'
+{- | Build the combined list of dependency choices.
+Excludes the current database, tags entries as Selected/Available based on
+the selected set, and sorts the result alphabetically by database name.
+-}
+buildDependencyChoices ::
+    -- | Current database name (excluded from the result)
+    Text ->
+    -- | Names currently selected as dependencies
+    [Text] ->
+    Map Text DatabaseConfig ->
+    Map Text IndexedDatabase ->
+    [DependencyChoice]
+buildDependencyChoices currentName selected configs indexedDbs =
+    let selectedSet = S.fromList selected
+        mkChoice (name, idx) =
+            DependencyChoice
+                { dchStatus =
+                    if S.member name selectedSet
+                        then SelectedDep
+                        else AvailableDep
+                , dchDatabaseName = name
+                , dchDisplayName = maybe name dcDisplayName (M.lookup name configs)
+                , dchMatchCount = M.size (Database.CrossLinking.idbByProductName idx)
+                }
+     in sortOn
+            dchDatabaseName
+            [ mkChoice (name, idx)
+            | (name, idx) <- M.toList indexedDbs
+            , name /= currentName
+            ]
 
 {- | Re-stage a loaded database for dependency editing
 Moves from dmLoadedDbs → dmStagedDbs, cleans up solver
@@ -2579,9 +2614,10 @@ regionalized scoring path (see 'Method.Mapping.computeRegionalizedLCIAScore').
 getLocationHierarchy :: DatabaseManager -> IO (M.Map Text [Text])
 getLocationHierarchy manager = pure (M.map snd (dmGeographies manager))
 
--- | Merged biosphere flow metadata + units across all loaded DBs. Technosphere
--- flows are not merged here because characterization (the only consumer of
--- this cache) targets biosphere flows exclusively.
+{- | Merged biosphere flow metadata + units across all loaded DBs. Technosphere
+flows are not merged here because characterization (the only consumer of
+this cache) targets biosphere flows exclusively.
+-}
 getMergedFlowMetadata :: DatabaseManager -> IO (BioFlowDB, UnitDB)
 getMergedFlowMetadata manager = do
     cached <- readTVarIO (dmMergedFlowMetadataCache manager)

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -93,6 +93,9 @@ module Database.Manager (
 
     -- * Internal (for tests: lowest-level loader, exposes the cache-hit flag)
     loadDatabaseRawWithCrossDB,
+
+    -- * Internal (for tests: pure dependency-list builder)
+    buildDependencyChoices,
 ) where
 
 import Control.Concurrent.Async (mapConcurrently, mapConcurrently_)

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1861,16 +1861,13 @@ buildSetupResult manager dbName = do
                 else return $ Right info
         Nothing -> case M.lookup dbName loadedDbs of
             Just loaded ->
-                let info = buildLoadedSetupInfo (ldConfig loaded) (ldDatabase loaded)
-                    selected = dbDependsOn (ldDatabase loaded)
-                    dependencies = buildDependencyChoices dbName selected availableDbs indexedDbs
+                let info = buildLoadedSetupInfo (ldConfig loaded) (ldDatabase loaded) availableDbs indexedDbs
                     nUnresolved = unresolvedCount (dbLinkingStats (ldDatabase loaded))
                  in return $
                         Right
                             info
                                 { dsiIsLoaded = False
                                 , dsiIsReady = nUnresolved == 0
-                                , dsiDependencies = dependencies
                                 }
             Nothing -> return $ Left $ SetupFailed $ "Failed to stage database: " <> dbName
 
@@ -1931,8 +1928,8 @@ buildStagedSetupInfo staged configs indexedDbs =
 {- | Build setup info from a loaded database (already finalized)
 Uses dbLinkingStats for real completeness/fallback data
 -}
-buildLoadedSetupInfo :: DatabaseConfig -> Database -> DatabaseSetupInfo
-buildLoadedSetupInfo config db =
+buildLoadedSetupInfo :: DatabaseConfig -> Database -> Map Text DatabaseConfig -> Map Text IndexedDatabase -> DatabaseSetupInfo
+buildLoadedSetupInfo config db configs indexedDbs =
     let stats = dbLinkingStats db
         totalInputs = cdlTotalInputs stats
         nCrossDBLinks = length (dbCrossDBLinks db)
@@ -1960,15 +1957,7 @@ buildLoadedSetupInfo config db =
             , dsiCrossDBLinks = nCrossDBLinks
             , dsiUnresolvedLinks = nUnresolved
             , dsiMissingSuppliers = missingSuppliers
-            , dsiDependencies =
-                [ DependencyChoice
-                    { dchStatus = SelectedDep
-                    , dchDatabaseName = name
-                    , dchDisplayName = name
-                    , dchMatchCount = 0
-                    }
-                | name <- dbDependsOn db
-                ]
+            , dsiDependencies = buildDependencyChoices (dcName config) (dbDependsOn db) configs indexedDbs
             , dsiIsReady = True
             , dsiUnknownUnits = S.toList (cdlUnknownUnits stats)
             , dsiLocationFallbacks = deduplicateFallbacks (cdlLocationFallbacks stats)

--- a/test/DependencyChoiceSpec.hs
+++ b/test/DependencyChoiceSpec.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module DependencyChoiceSpec (spec) where
+
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import Test.Hspec
+
+import Config (DatabaseConfig (..))
+import Database.CrossLinking (IndexedDatabase (..))
+import Database.Manager (
+    DependencyChoice (..),
+    DependencyStatus (..),
+    buildDependencyChoices,
+ )
+
+cfg :: Text -> Text -> DatabaseConfig
+cfg name display =
+    DatabaseConfig
+        { dcName = name
+        , dcDisplayName = display
+        , dcPath = ""
+        , dcDescription = Nothing
+        , dcLoad = False
+        , dcDefault = False
+        , dcDepends = []
+        , dcLocationAliases = M.empty
+        , dcFormat = Nothing
+        , dcIsUploaded = False
+        , dcDeletable = False
+        }
+
+-- IndexedDatabase whose idbByProductName has 'n' distinct dummy keys, so
+-- M.size returns 'n' (only field buildDependencyChoices reads from it).
+indexedWith :: Text -> Int -> IndexedDatabase
+indexedWith name n =
+    IndexedDatabase
+        { idbName = name
+        , idbByProductName = M.fromList [(name <> "-" <> k, []) | k <- take n keys]
+        , idbBySynonymGroup = M.empty
+        }
+  where
+    keys :: [Text]
+    keys = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
+
+configs :: Map Text DatabaseConfig
+configs =
+    M.fromList
+        [ ("agribalyse", cfg "agribalyse" "Agribalyse 3.2")
+        , ("ecoinvent", cfg "ecoinvent" "Ecoinvent 3.9")
+        , ("wfldb", cfg "wfldb" "WFLDB")
+        ]
+
+indexed :: Map Text IndexedDatabase
+indexed =
+    M.fromList
+        [ ("agribalyse", indexedWith "agribalyse" 3)
+        , ("ecoinvent", indexedWith "ecoinvent" 7)
+        , ("wfldb", indexedWith "wfldb" 2)
+        ]
+
+spec :: Spec
+spec = do
+    describe "buildDependencyChoices" $ do
+        it "excludes the current database from the result" $ do
+            let result = buildDependencyChoices "agribalyse" [] configs indexed
+            map dchDatabaseName result `shouldBe` ["ecoinvent", "wfldb"]
+
+        it "sorts results alphabetically by database name" $ do
+            let result = buildDependencyChoices "wfldb" [] configs indexed
+            map dchDatabaseName result `shouldBe` ["agribalyse", "ecoinvent"]
+
+        it "tags entries selected vs available based on the selected set" $ do
+            let result = buildDependencyChoices "agribalyse" ["ecoinvent"] configs indexed
+            [(dchDatabaseName d, dchStatus d) | d <- result]
+                `shouldBe` [("ecoinvent", SelectedDep), ("wfldb", AvailableDep)]
+
+        it "flips status in place without changing order when an entry is toggled" $ do
+            let before = buildDependencyChoices "agribalyse" [] configs indexed
+                after = buildDependencyChoices "agribalyse" ["wfldb"] configs indexed
+            map dchDatabaseName before `shouldBe` map dchDatabaseName after
+            map dchStatus after `shouldBe` [AvailableDep, SelectedDep]
+
+        it "populates matchCount from idbByProductName size" $ do
+            let result = buildDependencyChoices "agribalyse" [] configs indexed
+                byName = M.fromList [(dchDatabaseName d, dchMatchCount d) | d <- result]
+            M.lookup "ecoinvent" byName `shouldBe` Just 7
+            M.lookup "wfldb" byName `shouldBe` Just 2
+
+        it "falls back to the database name when no config is present" $ do
+            let result = buildDependencyChoices "agribalyse" [] M.empty indexed
+                byName = M.fromList [(dchDatabaseName d, dchDisplayName d) | d <- result]
+            M.lookup "ecoinvent" byName `shouldBe` Just "ecoinvent"
+            M.lookup "wfldb" byName `shouldBe` Just "wfldb"
+
+        it "uses dcDisplayName from the config when available" $ do
+            let result = buildDependencyChoices "agribalyse" [] configs indexed
+                byName = M.fromList [(dchDatabaseName d, dchDisplayName d) | d <- result]
+            M.lookup "ecoinvent" byName `shouldBe` Just "Ecoinvent 3.9"
+            M.lookup "wfldb" byName `shouldBe` Just "WFLDB"
+
+        it "ignores selected names that are not in the indexed set" $ do
+            let result = buildDependencyChoices "agribalyse" ["ghost-db"] configs indexed
+            map dchStatus result `shouldBe` [AvailableDep, AvailableDep]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -19,6 +19,7 @@ import qualified CrossDBRegionalLCIASubsSpec
 import qualified CrossDBSubstitutionSpec
 import qualified CrossLinkingSpec
 import qualified DatabaseStatusSpec
+import qualified DependencyChoiceSpec
 import qualified EcoSpold1Spec
 import qualified EcoSpold2Spec
 import qualified FlowResolverSpec
@@ -105,6 +106,7 @@ main = hspec $ do
         describe "Search.Fuzzy" FuzzySpec.spec
         describe "Nested Substitutions" NestedSubstitutionSpec.spec
         describe "Database Status (depends_on)" DatabaseStatusSpec.spec
+        describe "DependencyChoice builder" DependencyChoiceSpec.spec
         describe "Licenses Endpoint" LicensesSpec.spec
         describe "Geographies cascade" GeographiesSpec.spec
         describe "Auto-relink on Load (cache hit)" AutoRelinkSpec.spec

--- a/volca.cabal
+++ b/volca.cabal
@@ -227,6 +227,7 @@ test-suite lca-tests
                      , SensitivitySpec
                      , CrossDBSubstitutionSpec
                      , DatabaseStatusSpec
+                     , DependencyChoiceSpec
                      , OlcaSchemaSpec
                      , LicensesSpec
                      , GeographiesSpec


### PR DESCRIPTION
## Summary

The database setup info exposed two parallel fields for cross-database dependencies:

- `selectedDeps :: [Text]` — names already wired in
- `suggestions :: [DependencySuggestion]` — every indexed database

Because the lists were independent, the same database could appear in both at once, and the suggestions builder also re-listed the database being configured. Two parallel structures describing the same set in two states is the classic shape that lets impossible states slip in.

This PR collapses both fields into a single `dependencies :: [DependencyChoice]` where `DependencyChoice` carries a `DependencyStatus` (`SelectedDep` or `AvailableDep`). Overlap is now a type error.

The new builder `buildDependencyChoices` takes the current database name and the selected set, excludes the self-reference, and sorts the result alphabetically by database name so toggling a row does not reorder the list.

JSON shape (under `dependencies`):
```json
{ "status": "selected" | "available", "databaseName", "displayName", "matchCount" }
```

OpenAPI schemas adjusted accordingly.

## Test plan

- [x] `cabal build` clean
- [x] `cabal test` — 872 examples, 0 failures
- [ ] Hit `/api/v1/databases/<name>/setup` on a multi-DB instance: verify single `dependencies` array, `status ∈ {"selected","available"}`, no entry equal to the DB being configured, alphabetical order
- [ ] Add then remove a dependency via the API: confirm the entry's `status` flips in place without reordering