### PR TITLE
feat(linker): drop redundant DBs from cross-link preselection

### DIFF
--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -124,10 +124,20 @@ data CrossDBCandidate = CrossDBCandidate
 
 -- | Result of cross-database linking attempt
 data CrossDBLinkResult
-    = -- | Success: actUUID, prodUUID, dbName, score, productName, location, warnings
-      CrossDBLinked !UUID !UUID !Text !Int !Text !Text ![LinkWarning]
-    | -- | Failed: reason for failure
-      CrossDBNotLinked !LinkBlocker
+    = CrossDBLinked
+        { cdlrActivityUUID :: !UUID
+        , cdlrProductUUID :: !UUID
+        , cdlrDatabaseName :: !Text
+        , cdlrScore :: !Int
+        , cdlrProductName :: !Text
+        , cdlrLocation :: !Text
+        , cdlrWarnings :: ![LinkWarning]
+        , cdlrTiedDatabases :: ![Text]
+        {- ^ Other databases whose best candidate ties the winner's score.
+        Used to detect redundant dependencies at staging time.
+        -}
+        }
+    | CrossDBNotLinked !LinkBlocker
 
 -- | Non-blocking warning: link succeeded but with caveats
 data LinkWarning
@@ -298,9 +308,10 @@ buildIndexedDatabase dbName synDB db =
             , idbBySynonymGroup = bySynonym
             }
 
--- | Build supplier entries from a SimpleDatabase. Reference exchanges of
--- production processes are always technosphere outputs, so the supplier flow
--- lives in `sdbTechFlows`.
+{- | Build supplier entries from a SimpleDatabase. Reference exchanges of
+production processes are always technosphere outputs, so the supplier flow
+lives in `sdbTechFlows`.
+-}
 buildSupplierEntries :: SimpleDatabase -> [(Text, SupplierEntry)]
 buildSupplierEntries db =
     [ (tfName flow, SupplierEntry actUUID prodUUID (activityLocation act) (activityUnit act) (tfName flow))
@@ -339,8 +350,9 @@ buildIndexedDatabaseFromDB dbName synDB db =
             , idbBySynonymGroup = bySynonym
             }
 
--- | Build supplier entries from a full Database. Same invariant as
--- 'buildSupplierEntries' above: reference exchanges are technosphere.
+{- | Build supplier entries from a full Database. Same invariant as
+'buildSupplierEntries' above: reference exchanges are technosphere.
+-}
 buildSupplierEntriesFromDB :: Database -> [(Text, SupplierEntry)]
 buildSupplierEntriesFromDB db =
     [ (tfName flow, SupplierEntry actUUID prodUUID (activityLocation act) (activityUnit act) (tfName flow))
@@ -398,18 +410,32 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
                             -- Score by effective location
                             let scoredCandidates = map (scoreEntry effectiveLocation) unitCompatible
                                 !best = maximumBy (comparing cdbScore) scoredCandidates
+                                -- Other databases whose best candidate matches the winner's score.
+                                -- Dedup by DB name to avoid counting multiple intra-DB ties.
+                                tied =
+                                    let winnerDB = cdbDatabaseName best
+                                        winnerScore = cdbScore best
+                                        sameScoreDBs =
+                                            [ cdbDatabaseName c
+                                            | c <- scoredCandidates
+                                            , cdbScore c == winnerScore
+                                            , cdbDatabaseName c /= winnerDB
+                                            ]
+                                     in M.keys (M.fromList [(d, ()) | d <- sameScoreDBs])
                              in if cdbScore best >= lcThreshold
                                     then
                                         -- Build warnings (only when original location was explicit)
                                         let warnings = if T.null location then [] else buildWarnings effectiveLocation (cdbLocation best)
                                          in CrossDBLinked
-                                                (cdbActivityUUID best)
-                                                (cdbProductUUID best)
-                                                (cdbDatabaseName best)
-                                                (cdbScore best)
-                                                (cdbProductName best)
-                                                (cdbLocation best)
-                                                warnings
+                                                { cdlrActivityUUID = cdbActivityUUID best
+                                                , cdlrProductUUID = cdbProductUUID best
+                                                , cdlrDatabaseName = cdbDatabaseName best
+                                                , cdlrScore = cdbScore best
+                                                , cdlrProductName = cdbProductName best
+                                                , cdlrLocation = cdbLocation best
+                                                , cdlrWarnings = warnings
+                                                , cdlrTiedDatabases = tied
+                                                }
                                     else CrossDBNotLinked (LocationUnavailable effectiveLocation)
   where
     lookupExact :: Text -> IndexedDatabase -> [(Text, SupplierEntry)]

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -1278,20 +1278,21 @@ findExchangeCrossDBLink ctx techFlowDb unitDb consumerActUUID consumerProdUUID e
             Just flow ->
                 let flowUnitName = maybe "" unitName (M.lookup (tfUnitId flow) unitDb)
                  in case findSupplierAcrossDatabases ctx (tfName flow) loc flowUnitName of
-                        CrossDBLinked supplierActUUID supplierProdUUID dbName _score prodName supplierLoc warnings ->
+                        result@CrossDBLinked{} ->
                             let !crossLink =
                                     CrossDBLink
                                         { cdlConsumerActUUID = consumerActUUID
                                         , cdlConsumerProdUUID = consumerProdUUID
-                                        , cdlSupplierActUUID = supplierActUUID
-                                        , cdlSupplierProdUUID = supplierProdUUID
+                                        , cdlSupplierActUUID = cdlrActivityUUID result
+                                        , cdlSupplierProdUUID = cdlrProductUUID result
                                         , cdlCoefficient = amt
                                         , cdlExchangeUnit = flowUnitName
-                                        , cdlFlowName = prodName
-                                        , cdlLocation = supplierLoc
-                                        , cdlSourceDatabase = dbName
+                                        , cdlFlowName = cdlrProductName result
+                                        , cdlLocation = cdlrLocation result
+                                        , cdlSourceDatabase = cdlrDatabaseName result
+                                        , cdlTiedAlternatives = cdlrTiedDatabases result
                                         }
-                                fallbacks = [(prodName, req, actLoc) | UpperLocationUsed req actLoc <- warnings]
+                                fallbacks = [(cdlrProductName result, req, actLoc) | UpperLocationUsed req actLoc <- cdlrWarnings result]
                              in CrossDBLinkingStats [crossLink] M.empty S.empty fallbacks 0
                         CrossDBNotLinked blocker ->
                             CrossDBLinkingStats [] (M.singleton (tfName flow) (1, blocker)) S.empty [] 0

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -104,7 +104,7 @@ import qualified Data.Aeson as A
 import Data.Bifunctor (first)
 import Data.Char (toLower)
 import Data.Either (lefts, rights)
-import Data.List (isPrefixOf, nub, sortOn, unsnoc)
+import Data.List (isPrefixOf, sortOn, unsnoc)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import Data.Maybe (catMaybes, fromMaybe, isJust)
@@ -158,7 +158,7 @@ import qualified Search.BM25 as BM25
 import SharedSolver (SharedSolver, createSharedSolver)
 import qualified SharedSolver
 import SynonymDB (SynonymDB (..), buildFromCSV, buildFromPairs, emptySynonymDB, loadFromCSVFileWithCache, mergeSynonymDBs, synonymCount)
-import Types (Activity (..), BioFlowDB, BiosphereFlow (..), CrossDBLink (..), CrossDBLinkingStats (..), Database (..), LinkBlocker (..), SimpleDatabase (..), SparseTriple (..), UUID, Unit (..), UnitDB, bfCompartmentName, bfCompartmentSub, crossDBBySource, deduplicateFallbacks, exchangeFlowId, exchangeIsReference, initializeRuntimeFields, toSimpleDatabase, unresolvedCount)
+import Types (Activity (..), BioFlowDB, BiosphereFlow (..), CrossDBLink (..), CrossDBLinkingStats (..), Database (..), LinkBlocker (..), SimpleDatabase (..), SparseTriple (..), UUID, Unit (..), UnitDB, bfCompartmentName, bfCompartmentSub, computeMinimalSelectedDeps, crossDBBySource, crossDBRedundantSources, deduplicateFallbacks, exchangeFlowId, exchangeIsReference, initializeRuntimeFields, toSimpleDatabase, unresolvedCount)
 import qualified UnitConversion
 
 -- CrossDBLinkingStats is now in Types, re-exported from Database.Loader
@@ -267,6 +267,11 @@ data DatabaseSetupInfo = DatabaseSetupInfo
     -- ^ Top missing suppliers
     , dsiSelectedDeps :: ![Text]
     -- ^ Currently selected dependencies
+    , dsiRedundantDeps :: ![Text]
+    {- ^ Databases that match links but are redundant under the minimal cover
+    (every link they win can be re-supplied by another selected DB at the
+    same score). Surfaced to the UI to explain why they were not pre-selected.
+    -}
     , dsiSuggestions :: ![DependencySuggestion]
     -- ^ Suggested dependencies
     , dsiIsReady :: !Bool
@@ -297,6 +302,7 @@ instance ToJSON DatabaseSetupInfo where
             , "unresolvedLinks" .= dsiUnresolvedLinks
             , "missingSuppliers" .= dsiMissingSuppliers
             , "selectedDependencies" .= dsiSelectedDeps
+            , "redundantDependencies" .= dsiRedundantDeps
             , "suggestions" .= dsiSuggestions
             , "isReady" .= dsiIsReady
             , "unknownUnits" .= dsiUnknownUnits
@@ -1648,25 +1654,51 @@ stageUploadedDatabase manager dbConfig = do
             case loadResult of
                 Left err -> return $ Left err
                 Right (simpleDb, stats) -> do
-                    -- Create staged database
-                    let fromStats = [(name, cnt, blocker) | (name, (cnt, blocker)) <- M.toList (Loader.cdlUnresolvedProducts stats)]
+                    -- Minimal-cover pre-selection: drop DBs whose links are all
+                    -- substitutable by another DB at the same score. If that
+                    -- shrinks the dependency set, re-run linking restricted to
+                    -- the chosen DBs so sdCrossDBLinks stays consistent with
+                    -- sdSelectedDeps (no dangling supplier UUIDs at finalize).
+                    let minimalDeps = computeMinimalSelectedDeps (Loader.cdlLinks stats)
+                        contributingDeps = M.keys (Loader.crossDBBySource stats)
+                    (finalStats, finalDB) <-
+                        if S.fromList minimalDeps == S.fromList contributingDeps
+                            then return (stats, simpleDb)
+                            else do
+                                let selectedSet = S.fromList minimalDeps
+                                    restrictedIndexes =
+                                        [idx | (n, idx) <- M.toList indexedDbs, S.member n selectedSet]
+                                reportProgress Info $
+                                    "  Minimal cover: dropping redundant deps "
+                                        <> show (S.toList (S.fromList contributingDeps `S.difference` selectedSet))
+                                        <> ", re-linking against "
+                                        <> show minimalDeps
+                                (simpleDb', stats') <-
+                                    Loader.fixActivityLinksWithCrossDB
+                                        restrictedIndexes
+                                        synonymDB
+                                        unitConfig
+                                        (M.map snd (dmGeographies manager))
+                                        simpleDb
+                                return (stats', simpleDb')
+
+                    let fromStats = [(name, cnt, blocker) | (name, (cnt, blocker)) <- M.toList (Loader.cdlUnresolvedProducts finalStats)]
                         fromScan =
-                            if null fromStats && Loader.crossDBLinksCount stats == 0
-                                then [(name, cnt, NoNameMatch) | (name, cnt) <- M.toList (Loader.collectUnlinkedProductNames simpleDb)]
+                            if null fromStats && Loader.crossDBLinksCount finalStats == 0
+                                then [(name, cnt, NoNameMatch) | (name, cnt) <- M.toList (Loader.collectUnlinkedProductNames finalDB)]
                                 else fromStats
                         staged =
                             StagedDatabase
-                                { sdSimpleDB = simpleDb
+                                { sdSimpleDB = finalDB
                                 , sdConfig = dbConfig
-                                , sdUnlinkedCount = Loader.unresolvedCount stats
+                                , sdUnlinkedCount = Loader.unresolvedCount finalStats
                                 , sdMissingProducts = sortOn (\(_, cnt, _) -> Down cnt) fromScan
-                                , sdSelectedDeps = nub $ M.keys (Loader.crossDBBySource stats)
-                                , sdCrossDBLinks = Loader.cdlLinks stats
-                                , sdLinkingStats = stats
+                                , sdSelectedDeps = minimalDeps
+                                , sdCrossDBLinks = Loader.cdlLinks finalStats
+                                , sdLinkingStats = finalStats
                                 , sdCachedDB = Nothing
                                 }
 
-                    -- Store in staged map
                     atomically $ modifyTVar' (dmStagedDbs manager) (M.insert dbName staged)
                     reportProgress Info $ "  [OK] Staged: " <> T.unpack (dcDisplayName dbConfig)
                     return $ Right ()
@@ -1907,6 +1939,7 @@ buildStagedSetupInfo staged configs indexedDbs =
             , dsiUnresolvedLinks = unresolvedLinks
             , dsiMissingSuppliers = missingSuppliers
             , dsiSelectedDeps = sdSelectedDeps staged
+            , dsiRedundantDeps = crossDBRedundantSources (cdlLinks stats) (sdSelectedDeps staged)
             , dsiSuggestions = suggestions
             , dsiIsReady = isReady
             , dsiUnknownUnits = S.toList (cdlUnknownUnits stats)
@@ -1949,6 +1982,7 @@ buildLoadedSetupInfo config db =
             , dsiUnresolvedLinks = nUnresolved
             , dsiMissingSuppliers = missingSuppliers
             , dsiSelectedDeps = dbDependsOn db
+            , dsiRedundantDeps = [] -- Finalized DBs have no redundant deps to surface
             , dsiSuggestions = [] -- No suggestions for loaded databases
             , dsiIsReady = True
             , dsiUnknownUnits = S.toList (cdlUnknownUnits stats)
@@ -2579,9 +2613,10 @@ regionalized scoring path (see 'Method.Mapping.computeRegionalizedLCIAScore').
 getLocationHierarchy :: DatabaseManager -> IO (M.Map Text [Text])
 getLocationHierarchy manager = pure (M.map snd (dmGeographies manager))
 
--- | Merged biosphere flow metadata + units across all loaded DBs. Technosphere
--- flows are not merged here because characterization (the only consumer of
--- this cache) targets biosphere flows exclusively.
+{- | Merged biosphere flow metadata + units across all loaded DBs. Technosphere
+flows are not merged here because characterization (the only consumer of
+this cache) targets biosphere flows exclusively.
+-}
 getMergedFlowMetadata :: DatabaseManager -> IO (BioFlowDB, UnitDB)
 getMergedFlowMetadata manager = do
     cached <- readTVarIO (dmMergedFlowMetadataCache manager)

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -796,12 +796,13 @@ getFlowUsageCount db flowUUID =
         Nothing -> 0
         Just activityUUIDs -> length activityUUIDs
 
--- | Get flows used by an activity as lightweight summaries. Each exchange
--- lookup is resolved against the appropriate side (tech vs bio) and wrapped
--- in 'ApiFlow' to preserve the discriminator for downstream JSON encoders.
--- An exchange whose flow UUID resolves on neither side becomes an
--- 'ApiUnresolvedFlow' entry rather than being silently dropped — so the
--- consumer never sees a shorter list than the activity actually carries.
+{- | Get flows used by an activity as lightweight summaries. Each exchange
+lookup is resolved against the appropriate side (tech vs bio) and wrapped
+in 'ApiFlow' to preserve the discriminator for downstream JSON encoders.
+An exchange whose flow UUID resolves on neither side becomes an
+'ApiUnresolvedFlow' entry rather than being silently dropped — so the
+consumer never sees a shorter list than the activity actually carries.
+-}
 getActivityFlowSummaries :: Database -> Activity -> [FlowSummary]
 getActivityFlowSummaries db activity = map mkSummary (exchanges activity)
   where
@@ -1043,7 +1044,8 @@ convertActivityForAPI unitCfg db processId activity =
         Nothing -> M.empty
 
     convertExchangeWithUnit exchange =
-        let -- Look up the flow in the appropriate side (tech vs bio) based on exchange variant.
+        let
+            -- Look up the flow in the appropriate side (tech vs bio) based on exchange variant.
             techFlowInfo = case exchange of
                 TechnosphereExchange{techFlowId = fid} -> M.lookup fid (dbTechFlows db)
                 BiosphereExchange{} -> Nothing
@@ -1087,7 +1089,8 @@ convertActivityForAPI unitCfg db processId activity =
                 (_, Just bf) -> bfName bf
                 _ -> "<unresolved flow " <> UUID.toText (exchangeFlowId exchange) <> ">"
             compartment = bfCompartment =<< bioFlowInfo
-         in ExchangeWithUnit
+         in
+            ExchangeWithUnit
                 { ewuExchange = exchange
                 , ewuUnitName = getUnitNameForExchange (dbUnits db) exchange
                 , ewuFlowName = flowNameTxt
@@ -1099,8 +1102,9 @@ convertActivityForAPI unitCfg db processId activity =
                 , ewuPedigree = exchangePedigree exchange
                 }
 
--- | Get reference product name from activity exchanges. Reference products
--- are always technosphere.
+{- | Get reference product name from activity exchanges. Reference products
+are always technosphere.
+-}
 getReferenceProductName :: TechFlowDB -> Activity -> Maybe Text
 getReferenceProductName flows activity =
     case [ex | ex <- exchanges activity, exchangeIsReference ex] of
@@ -1160,8 +1164,9 @@ getTargetActivity db exchange = do
             , prsAllocationFormula = activityAllocationFormula targetActivity
             }
 
--- | Get reference product as FlowDetail (if exists). Reference products are
--- technosphere by definition.
+{- | Get reference product as FlowDetail (if exists). Reference products are
+technosphere by definition.
+-}
 getActivityReferenceProductDetail :: Database -> Activity -> Maybe FlowDetail
 getActivityReferenceProductDetail db activity = do
     refExchange <- case filter exchangeIsReference (exchanges activity) of
@@ -1302,8 +1307,9 @@ getFlowInfo db flowIdText = do
                             Right $ toJSON $ FlowDetail (ApiBioFlow flow) (getUnitNameForBioFlow (dbUnits db) flow) usageCount
                         Nothing -> Left $ FlowNotFound flowIdText
 
--- | Get activities that use a specific flow as JSON (for CLI). Resolves
--- against either flow side so biosphere flow IDs work too.
+{- | Get activities that use a specific flow as JSON (for CLI). Resolves
+against either flow side so biosphere flow IDs work too.
+-}
 getFlowActivities :: Database -> Text -> Either ServiceError Value
 getFlowActivities db flowIdText = do
     case UUID.fromText flowIdText of
@@ -2471,6 +2477,7 @@ mkVirtualLink rootDb consumerPid depDb depDbName supUUIDs supPid coef =
             , cdlFlowName = activityName supAct
             , cdlLocation = activityLocation supAct
             , cdlSourceDatabase = depDbName
+            , cdlTiedAlternatives = []
             }
 
 {- | Find the static 'CrossDBLink' matching @(rootConsumer, depDbName, depSupplierUUIDs)@.

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -65,14 +65,16 @@ data Compartment = Compartment
     }
     deriving (Eq, Show, Generic, NFData, Store)
 
--- | The biosphere flow's medium (air | water | soil | …), or @""@ when the
--- source dataset omitted the compartment. Use 'bfCompartment' directly when
--- you need to distinguish "absent" from "empty string".
+{- | The biosphere flow's medium (air | water | soil | …), or @""@ when the
+source dataset omitted the compartment. Use 'bfCompartment' directly when
+you need to distinguish "absent" from "empty string".
+-}
 bfCompartmentName :: BiosphereFlow -> Text
 bfCompartmentName = maybe "" compartmentName . bfCompartment
 
--- | The biosphere flow's sub-compartment (e.g. "high. pop."), or @Nothing@
--- when neither the source nor the medium recorded one.
+{- | The biosphere flow's sub-compartment (e.g. "high. pop."), or @Nothing@
+when neither the source nor the medium recorded one.
+-}
 bfCompartmentSub :: BiosphereFlow -> Maybe Text
 bfCompartmentSub = (>>= compartmentSub) . bfCompartment
 
@@ -144,11 +146,12 @@ data BiosphereFlow = BiosphereFlow
     , bfSynonyms :: !(M.Map Text (S.Set Text))
     , bfCAS :: !(Maybe Text)
     , bfSubstanceId :: !(Maybe Int)
-    , -- | The source dataset's compartment (medium + optional sub) for this
-      -- flow, or @Nothing@ when the source omitted it. Distinguishing
-      -- "no compartment recorded" from "the empty string" is required to
-      -- avoid silently broadening LCIA matches in 'Method.Mapping'.
-      bfCompartment :: !(Maybe Compartment)
+    , bfCompartment :: !(Maybe Compartment)
+    {- ^ The source dataset's compartment (medium + optional sub) for this
+    flow, or @Nothing@ when the source omitted it. Distinguishing
+    "no compartment recorded" from "the empty string" is required to
+    avoid silently broadening LCIA matches in 'Method.Mapping'.
+    -}
     }
     deriving (Generic, NFData, Store)
 
@@ -903,6 +906,39 @@ unresolvedCount = sum . map fst . M.elems . cdlUnresolvedProducts
 crossDBBySource :: CrossDBLinkingStats -> M.Map Text Int
 crossDBBySource = M.fromListWith (+) . map (\l -> (cdlSourceDatabase l, 1)) . cdlLinks
 
+{- | Minimal set of source databases needed to preserve every link's best
+supplier choice. A DB is included iff at least one link cannot be supplied
+by any already-included DB at the same score (its tied set is disjoint
+from the running selection). Ties between equally-valid DBs are broken
+alphabetically for determinism.
+
+This is the canonical pre-selection rule: any DB that wins links only
+"by tie-break" against an already-needed DB is dropped as redundant.
+-}
+computeMinimalSelectedDeps :: [CrossDBLink] -> [Text]
+computeMinimalSelectedDeps links =
+    let tiedSets = [S.insert (cdlSourceDatabase l) (S.fromList (cdlTiedAlternatives l)) | l <- links]
+        essential = S.unions [s | s <- tiedSets, S.size s == 1]
+        uncovered = filter (S.null . S.intersection essential) tiedSets
+     in S.toAscList (greedyCover essential uncovered)
+  where
+    greedyCover :: S.Set Text -> [S.Set Text] -> S.Set Text
+    greedyCover covered [] = covered
+    greedyCover covered uncov =
+        let pick = S.findMin (S.unions uncov)
+            covered' = S.insert pick covered
+            uncov' = filter (S.notMember pick) uncov
+         in greedyCover covered' uncov'
+
+{- | Databases that contributed at least one resolved link but are redundant
+under 'computeMinimalSelectedDeps'. Useful to surface in the setup UI as
+"available but not needed".
+-}
+crossDBRedundantSources :: [CrossDBLink] -> [Text] -> [Text]
+crossDBRedundantSources links selected =
+    let winners = S.fromList (map cdlSourceDatabase links)
+     in S.toAscList (winners `S.difference` S.fromList selected)
+
 {- | Cross-database link: records that an exchange in this database
 sources from a supplier in another database.
 
@@ -932,6 +968,11 @@ data CrossDBLink = CrossDBLink
     -- ^ Supplier location (for display)
     , cdlSourceDatabase :: !Text
     -- ^ Source database name
+    , cdlTiedAlternatives :: ![Text]
+    {- ^ Other source databases whose best candidate matched the winner's score.
+    A non-empty list means this link could equivalently be supplied from
+    another database — used to compute the minimal dependency pre-selection.
+    -}
     }
     deriving (Generic, NFData, Store, Show, Eq)
 

--- a/test/CrossDBRegionalLCIAFixture.hs
+++ b/test/CrossDBRegionalLCIAFixture.hs
@@ -53,8 +53,8 @@ import qualified Data.Vector.Unboxed as U
 
 import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, fillBroadcastVector, fillRegionalActivityWeights)
 import Method.Types (FlowDirection (..), MethodCF (..))
-import qualified Types as VT
 import Types
+import qualified Types as VT
 import UnitConversion (UnitConfig (..), UnitDef (..))
 
 -- | One biosphere flow shared by both DBs (cross-DB merging keys on UUID).
@@ -187,6 +187,7 @@ linkAt consumerDb supplierDb supplierName supIdx coeff =
                 , cdlFlowName = "x-link"
                 , cdlLocation = activityLocation (dbActivities supplierDb V.! supIdx)
                 , cdlSourceDatabase = supplierName
+                , cdlTiedAlternatives = []
                 }
      in consumerDb{dbCrossDBLinks = link : dbCrossDBLinks consumerDb}
 

--- a/test/CrossLinkingSpec.hs
+++ b/test/CrossLinkingSpec.hs
@@ -229,7 +229,7 @@ spec = do
                         , lcLocationHierarchy = locationHierarchy
                         }
             case findSupplierInIndexedDBs ctx "product Y" "GLO" "kg" of
-                CrossDBLinked _ _ _ score _ _ _ -> score `shouldSatisfy` (>= defaultLinkingThreshold)
+                CrossDBLinked{cdlrScore = score} -> score `shouldSatisfy` (>= defaultLinkingThreshold)
                 CrossDBNotLinked reason -> expectationFailure $ "Expected link but got: " ++ show reason
 
         it "returns NoNameMatch for an unknown product" $ do
@@ -276,7 +276,7 @@ spec = do
                         }
             -- Synonym lookup: "producto y" → group containing "product y" → supplier
             case findSupplierInIndexedDBs ctx "producto y" "GLO" "kg" of
-                CrossDBLinked _ _ _ score _ _ _ -> score `shouldSatisfy` (>= defaultLinkingThreshold)
+                CrossDBLinked{cdlrScore = score} -> score `shouldSatisfy` (>= defaultLinkingThreshold)
                 CrossDBNotLinked _ -> pendingWith "synonym linking requires index to be built with synDB"
 
         it "uses empty location from compound name when location arg is empty" $ do
@@ -292,7 +292,7 @@ spec = do
             -- "product Y {GLO}" compound name with empty location arg
             -- extractBracketedLocation will find "GLO"
             case findSupplierInIndexedDBs ctx "product Y {GLO}" "" "kg" of
-                CrossDBLinked _ _ _ score _ _ _ -> score `shouldSatisfy` (>= defaultLinkingThreshold)
+                CrossDBLinked{cdlrScore = score} -> score `shouldSatisfy` (>= defaultLinkingThreshold)
                 CrossDBNotLinked _ -> pendingWith "Compound name location extraction may not match"
 
 -- ---------------------------------------------------------------------------

--- a/test/MinimalCoverIntegrationSpec.hs
+++ b/test/MinimalCoverIntegrationSpec.hs
@@ -1,0 +1,228 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Integration test for the minimal-cover staging path.
+
+Exercises the exact sequence that 'Database.Manager.stageUploadedDatabase'
+runs when the minimal cover shrinks the dependency set:
+
+    1. link against all candidate supplier DBs
+    2. computeMinimalSelectedDeps on the resulting links
+    3. re-link restricted to the chosen DBs
+
+The invariant under test: after the restricted re-link, every link's
+'cdlSourceDatabase' is a member of the minimal dependency set
+(no dangling cross-DB references to dropped DBs).
+-}
+module MinimalCoverIntegrationSpec (spec) where
+
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.UUID as UUID
+import Database.CrossLinking (buildIndexedDatabase, locationHierarchy)
+import Database.Loader (fixActivityLinksWithCrossDB)
+import SynonymDB (emptySynonymDB)
+import Test.Hspec
+import Types (
+    Activity (..),
+    CrossDBLink (..),
+    CrossDBLinkingStats (..),
+    Exchange (..),
+    SimpleDatabase (..),
+    TechRole (..),
+    TechnosphereFlow (..),
+    UUID,
+    Unit (..),
+    computeMinimalSelectedDeps,
+    crossDBRedundantSources,
+ )
+import UnitConversion (defaultUnitConfig)
+
+spec :: Spec
+spec = describe "minimal-cover staging integration" $ do
+    it "re-links against the minimal cover so every cdlSourceDatabase is in sdSelectedDeps" $ do
+        let supplierAlpha = supplierDB 100
+            supplierBeta = supplierDB 200
+            consumer = consumerDB 300 3 -- 3 unlinked inputs for the shared product
+            idxAlpha = buildIndexedDatabase "alpha" emptySynonymDB supplierAlpha
+            idxBeta = buildIndexedDatabase "beta" emptySynonymDB supplierBeta
+
+        -- Stage 1: link against both candidate DBs.
+        (_, initialStats) <-
+            fixActivityLinksWithCrossDB
+                [idxAlpha, idxBeta]
+                emptySynonymDB
+                defaultUnitConfig
+                locationHierarchy
+                consumer
+
+        -- Both supplier DBs tie on every link: each link records the
+        -- non-winner as a tied alternative.
+        length (cdlLinks initialStats) `shouldBe` 3
+        any (null . cdlTiedAlternatives) (cdlLinks initialStats) `shouldBe` False
+
+        -- Stage 2: minimal cover picks one DB (alphabetical tie-break).
+        let minimalDeps = computeMinimalSelectedDeps (cdlLinks initialStats)
+        minimalDeps `shouldBe` ["alpha"]
+        crossDBRedundantSources (cdlLinks initialStats) minimalDeps `shouldBe` ["beta"]
+
+        -- Stage 3: re-link restricted to the minimal cover.
+        let restricted = [idx | (n, idx) <- [("alpha", idxAlpha), ("beta", idxBeta)], n `elem` minimalDeps]
+        (_, finalStats) <-
+            fixActivityLinksWithCrossDB
+                restricted
+                emptySynonymDB
+                defaultUnitConfig
+                locationHierarchy
+                consumer
+
+        -- Invariant: every resolved link's source is in the minimal cover.
+        length (cdlLinks finalStats) `shouldBe` length (cdlLinks initialStats)
+        S.fromList (map cdlSourceDatabase (cdlLinks finalStats))
+            `shouldSatisfy` (`S.isSubsetOf` S.fromList minimalDeps)
+        -- And no redundant sources remain after the restricted re-link.
+        crossDBRedundantSources (cdlLinks finalStats) minimalDeps `shouldBe` []
+
+-- ---------------------------------------------------------------------------
+-- Fixture builders
+-- ---------------------------------------------------------------------------
+
+mkUUID :: Int -> UUID
+mkUUID n = UUID.fromWords64 (fromIntegral n) 0
+
+kgUnitId :: UUID
+kgUnitId = mkUUID 0
+
+kgUnit :: Unit
+kgUnit = Unit{unitId = kgUnitId, unitName = "kg", unitSymbol = "kg", unitComment = ""}
+
+sharedProductName :: Text
+sharedProductName = "shared product"
+
+{- | One supplier DB with a single activity producing 'sharedProductName' at GLO.
+The activity carries a reference output exchange, which is what
+'buildSupplierEntries' indexes.
+-}
+supplierDB :: Int -> SimpleDatabase
+supplierDB offset =
+    let actUUID = mkUUID (offset + 1)
+        prodUUID = mkUUID (offset + 2)
+        flowUUID = mkUUID (offset + 3)
+        techFlow =
+            TechnosphereFlow
+                { tfId = flowUUID
+                , tfName = sharedProductName
+                , tfUnitId = kgUnitId
+                , tfSynonyms = M.empty
+                , tfCAS = Nothing
+                , tfSubstanceId = Nothing
+                }
+        refExchange =
+            TechnosphereExchange
+                { techFlowId = flowUUID
+                , techAmount = 1.0
+                , techUnitId = kgUnitId
+                , techRole = ReferenceProduct
+                , techActivityLinkId = actUUID
+                , techProcessLinkId = Nothing
+                , techLocation = ""
+                , techComment = Nothing
+                , techPedigree = Nothing
+                }
+        act =
+            Activity
+                { activityName = "supplier-of-shared-product"
+                , activityDescription = []
+                , activitySynonyms = M.empty
+                , activityClassification = M.empty
+                , activityLocation = "GLO"
+                , activityUnit = "kg"
+                , exchanges = [refExchange]
+                , activityParams = M.empty
+                , activityParamExprs = M.empty
+                , activityAllocationPercent = Nothing
+                , activityAllocationFormula = Nothing
+                }
+     in SimpleDatabase
+            { sdbActivities = M.singleton (actUUID, prodUUID) act
+            , sdbTechFlows = M.singleton flowUUID techFlow
+            , sdbBioFlows = M.empty
+            , sdbUnits = M.singleton kgUnitId kgUnit
+            }
+
+{- | A consumer DB with @n@ activities, each having one unlinked technosphere
+input for the shared product. The flow is in the consumer's own
+'sdbTechFlows' (that's where the linker reads the flow name from).
+-}
+consumerDB :: Int -> Int -> SimpleDatabase
+consumerDB offset n =
+    let flowUUID = mkUUID (offset + 1)
+        techFlow =
+            TechnosphereFlow
+                { tfId = flowUUID
+                , tfName = sharedProductName
+                , tfUnitId = kgUnitId
+                , tfSynonyms = M.empty
+                , tfCAS = Nothing
+                , tfSubstanceId = Nothing
+                }
+        refOutFlowUUID i = mkUUID (offset + 100 + i)
+        refOutFlow i =
+            TechnosphereFlow
+                { tfId = refOutFlowUUID i
+                , tfName = "consumer-out"
+                , tfUnitId = kgUnitId
+                , tfSynonyms = M.empty
+                , tfCAS = Nothing
+                , tfSubstanceId = Nothing
+                }
+        mkConsumer i =
+            let actUUID = mkUUID (offset + 200 + i)
+                prodUUID = mkUUID (offset + 300 + i)
+                refOut =
+                    TechnosphereExchange
+                        { techFlowId = refOutFlowUUID i
+                        , techAmount = 1.0
+                        , techUnitId = kgUnitId
+                        , techRole = ReferenceProduct
+                        , techActivityLinkId = actUUID
+                        , techProcessLinkId = Nothing
+                        , techLocation = ""
+                        , techComment = Nothing
+                        , techPedigree = Nothing
+                        }
+                unlinkedInput =
+                    TechnosphereExchange
+                        { techFlowId = flowUUID
+                        , techAmount = 1.0
+                        , techUnitId = kgUnitId
+                        , techRole = Input
+                        , techActivityLinkId = UUID.nil -- unlinked → triggers cross-DB lookup
+                        , techProcessLinkId = Nothing
+                        , techLocation = "GLO"
+                        , techComment = Nothing
+                        , techPedigree = Nothing
+                        }
+                act =
+                    Activity
+                        { activityName = "consumer"
+                        , activityDescription = []
+                        , activitySynonyms = M.empty
+                        , activityClassification = M.empty
+                        , activityLocation = "GLO"
+                        , activityUnit = "kg"
+                        , exchanges = [refOut, unlinkedInput]
+                        , activityParams = M.empty
+                        , activityParamExprs = M.empty
+                        , activityAllocationPercent = Nothing
+                        , activityAllocationFormula = Nothing
+                        }
+             in ((actUUID, prodUUID), act)
+        activities = M.fromList [mkConsumer i | i <- [1 .. n]]
+        flows = M.fromList $ (flowUUID, techFlow) : [(refOutFlowUUID i, refOutFlow i) | i <- [1 .. n]]
+     in SimpleDatabase
+            { sdbActivities = activities
+            , sdbTechFlows = flows
+            , sdbBioFlows = M.empty
+            , sdbUnits = M.singleton kgUnitId kgUnit
+            }

--- a/test/MinimalCoverSpec.hs
+++ b/test/MinimalCoverSpec.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module MinimalCoverSpec (spec) where
+
+import Data.Text (Text)
+import qualified Data.UUID as UUID
+import Test.Hspec
+import Types (CrossDBLink (..), computeMinimalSelectedDeps, crossDBRedundantSources)
+
+spec :: Spec
+spec = do
+    describe "computeMinimalSelectedDeps" $ do
+        it "returns [] for no cross-DB links" $
+            computeMinimalSelectedDeps [] `shouldBe` []
+
+        it "keeps a single contributing DB" $
+            computeMinimalSelectedDeps [mkLink "agribalyse-3-2" []]
+                `shouldBe` ["agribalyse-3-2"]
+
+        it "keeps a DB that is the only supplier for at least one link" $ do
+            -- A wins one link with no alternative → A is essential. B wins
+            -- another link with A as a tied alternative → already covered.
+            let links =
+                    [ mkLink "agribalyse-3-2" []
+                    , mkLink "wfldb" ["agribalyse-3-2"]
+                    ]
+            computeMinimalSelectedDeps links `shouldBe` ["agribalyse-3-2"]
+
+        it "drops a fully-redundant DB (PastoEco-shaped case)" $ do
+            -- 168 links resolved uniquely by agribalyse, 1 link tied between
+            -- wfldb (winner) and agribalyse → wfldb is redundant.
+            let agriLinks = replicate 168 (mkLink "agribalyse-3-2" [])
+                tiedLink = mkLink "wfldb" ["agribalyse-3-2"]
+            computeMinimalSelectedDeps (agriLinks ++ [tiedLink])
+                `shouldBe` ["agribalyse-3-2"]
+
+        it "picks one representative deterministically when DBs only cover each other (D1 trap)" $ do
+            -- Every link has tied set {A, B}, neither is uniquely essential.
+            -- Greedy alphabetical pick → A only, not both.
+            let links =
+                    [ mkLink "alpha" ["beta"]
+                    , mkLink "beta" ["alpha"]
+                    , mkLink "alpha" ["beta"]
+                    ]
+            computeMinimalSelectedDeps links `shouldBe` ["alpha"]
+
+        it "keeps both DBs when each is essential for at least one link" $ do
+            let links =
+                    [ mkLink "agribalyse-3-2" [] -- only agribalyse covers this
+                    , mkLink "wfldb" [] -- only wfldb covers this
+                    ]
+            computeMinimalSelectedDeps links `shouldBe` ["agribalyse-3-2", "wfldb"]
+
+        it "expands beyond essentials when a tied link uses none of them" $ do
+            -- A is essential. A separate link is tied between {C, D} — neither
+            -- A nor any essential covers it, so pick C alphabetically.
+            let links =
+                    [ mkLink "agribalyse-3-2" []
+                    , mkLink "ginko" ["wfldb"] -- tied between ginko and wfldb
+                    ]
+            computeMinimalSelectedDeps links `shouldBe` ["agribalyse-3-2", "ginko"]
+
+    describe "crossDBRedundantSources" $ do
+        it "returns winners that are not in the selected set" $ do
+            let links =
+                    [ mkLink "agribalyse-3-2" []
+                    , mkLink "wfldb" ["agribalyse-3-2"]
+                    ]
+                selected = ["agribalyse-3-2"]
+            crossDBRedundantSources links selected `shouldBe` ["wfldb"]
+
+        it "is empty when every winner is selected" $ do
+            let links = [mkLink "agribalyse-3-2" []]
+            crossDBRedundantSources links ["agribalyse-3-2"] `shouldBe` []
+
+{- | Build a minimal CrossDBLink whose only meaningful fields here are
+cdlSourceDatabase and cdlTiedAlternatives.
+-}
+mkLink :: Text -> [Text] -> CrossDBLink
+mkLink src tied =
+    CrossDBLink
+        { cdlConsumerActUUID = UUID.nil
+        , cdlConsumerProdUUID = UUID.nil
+        , cdlSupplierActUUID = UUID.nil
+        , cdlSupplierProdUUID = UUID.nil
+        , cdlCoefficient = 0
+        , cdlExchangeUnit = ""
+        , cdlFlowName = ""
+        , cdlLocation = ""
+        , cdlSourceDatabase = src
+        , cdlTiedAlternatives = tied
+        }

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -37,6 +37,7 @@ import qualified MatrixExportSpec
 import qualified MethodSetTablesSpec
 import qualified MethodSpec
 import qualified MethodUploadSpec
+import qualified MinimalCoverSpec
 import qualified NestedSubstitutionSpec
 import qualified NormalizeSpec
 import qualified OlcaSchemaSpec
@@ -74,6 +75,7 @@ main = hspec $ do
         describe "Loop-Aware Tree" TreeSpec.spec
         describe "Service Layer" ServiceSpec.spec
         describe "Cross-Database Linking" CrossLinkingSpec.spec
+        describe "Minimal Dependency Cover" MinimalCoverSpec.spec
         describe "Cross-DB Inventory" CrossDBInventorySpec.spec
         describe "Cross-DB Regional LCIA" CrossDBRegionalLCIASpec.spec
         describe "Cross-DB Regional LCIA (substitution path)" CrossDBRegionalLCIASubsSpec.spec

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -37,6 +37,7 @@ import qualified MatrixExportSpec
 import qualified MethodSetTablesSpec
 import qualified MethodSpec
 import qualified MethodUploadSpec
+import qualified MinimalCoverIntegrationSpec
 import qualified MinimalCoverSpec
 import qualified NestedSubstitutionSpec
 import qualified NormalizeSpec
@@ -76,6 +77,7 @@ main = hspec $ do
         describe "Service Layer" ServiceSpec.spec
         describe "Cross-Database Linking" CrossLinkingSpec.spec
         describe "Minimal Dependency Cover" MinimalCoverSpec.spec
+        describe "Minimal Dependency Cover (integration)" MinimalCoverIntegrationSpec.spec
         describe "Cross-DB Inventory" CrossDBInventorySpec.spec
         describe "Cross-DB Regional LCIA" CrossDBRegionalLCIASpec.spec
         describe "Cross-DB Regional LCIA (substitution path)" CrossDBRegionalLCIASubsSpec.spec

--- a/test/TestHelpers.hs
+++ b/test/TestHelpers.hs
@@ -124,5 +124,6 @@ linkDatabases consumerDb supplierDb supplierName coeff =
                 , cdlFlowName = "synthetic-test-link"
                 , cdlLocation = "GLO"
                 , cdlSourceDatabase = supplierName
+                , cdlTiedAlternatives = []
                 }
      in consumerDb{dbCrossDBLinks = link : dbCrossDBLinks consumerDb}

--- a/volca.cabal
+++ b/volca.cabal
@@ -198,6 +198,7 @@ test-suite lca-tests
                      , ServiceSpec
                      , CrossLinkingSpec
                      , MinimalCoverSpec
+                     , MinimalCoverIntegrationSpec
                      , CrossDBInventorySpec
                      , CrossDBRegionalLCIASpec
                      , CrossDBRegionalLCIAFixture

--- a/volca.cabal
+++ b/volca.cabal
@@ -197,6 +197,7 @@ test-suite lca-tests
                      , TreeSpec
                      , ServiceSpec
                      , CrossLinkingSpec
+                     , MinimalCoverSpec
                      , CrossDBInventorySpec
                      , CrossDBRegionalLCIASpec
                      , CrossDBRegionalLCIAFixture


### PR DESCRIPTION
## Summary

- A DB that won cross-DB links only by `maximumBy` tie-break order is no longer pre-selected as a dependency: `computeMinimalSelectedDeps` keeps only the DBs that are strictly necessary, with alphabetical tie-break for determinism.
- The linker now records each winner's tied-score peers (`cdlTiedAlternatives`) so the staging step can detect substitutability locally, without re-linking against every subset.
- When the minimal cover shrinks the dependency set, linking is re-run restricted to the chosen DBs so `cdlSourceDatabase` stays consistent with `sdSelectedDeps` at finalize time.
- `DatabaseSetupInfo` exposes `dsiRedundantDeps` (JSON: `redundantDependencies`) so UIs can surface "available but not needed" databases.

### Concrete effect

Loading a database whose 173 inputs are all resolvable from `agribalyse-3-2` alone — but where a handful of `agribalyse-3-2` candidates happen to tie a `wfldb` candidate at the same geographic score — used to pre-select `["agribalyse-3-2", "wfldb"]`. Now it pre-selects `["agribalyse-3-2"]` and reports `wfldb` as redundant. A DB that wins even a single link with no equal-score alternative is still kept.

### Cache format

`CrossDBLink`'s `Store` format changed. Existing matrix caches will be rebuilt on next load.

## Test plan

- [x] `cabal test` — 881 examples, 0 failures
- [x] New `MinimalCoverSpec` covers: trivial, single-essential, fully-redundant (PastoEco shape), D1 trap (DBs that only cover each other → pick one, never both), mixed essential+tied
- [ ] Reload a database that previously selected both `agribalyse-3-2` and `wfldb`; confirm `selectedDependencies` shrinks to the necessary set and `redundantDependencies` lists the dropped DB