### PR TITLE
Per-database geography_policy for cross-DB linking

### DIFF
--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -130,7 +130,7 @@ import Database.Upload (
     handleUpload,
  )
 import qualified Database.UploadedDatabase as UploadedDB
-import Types (Database (..), unresolvedCount)
+import Types (Database (..), GeographyPolicy (..), unresolvedCount)
 
 -- | List all databases
 getDatabases :: DatabaseManager -> Handler DatabaseListResponse
@@ -229,6 +229,7 @@ uploadDatabaseHandler dbManager req = do
                                 , dcFormat = Just (urFormat uploadResult)
                                 , dcIsUploaded = True -- Freshly uploaded database
                                 , dcDeletable = True
+                                , dcGeographyPolicy = GeoGlobal
                                 }
 
                     -- Add to manager

--- a/src/API/OpenApi.hs
+++ b/src/API/OpenApi.hs
@@ -28,7 +28,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Database.Manager (DatabaseSetupInfo, DependencyChoice, DependencyStatus, MissingSupplier)
 import Network.HTTP.Types.Method (StdMethod (..))
-import Types (BioDirection, BiosphereFlow, Compartment, Exchange, Pedigree, TechRole, TechnosphereFlow, Unit)
+import Types (BioDirection, BiosphereFlow, Compartment, Exchange, LocationFallback, LocationKind, LocationUnresolved, Pedigree, TechRole, TechnosphereFlow, Unit)
 
 {- | Orphan schema instance forward declaration for the login request body.
 The real type lives in "API.Routes"; this is defined there and re-imported
@@ -54,6 +54,9 @@ instance ToSchema Exchange where declareNamedSchema = genericDeclareNamedSchema 
 instance ToSchema MissingSupplier
 instance ToSchema DependencyStatus
 instance ToSchema DependencyChoice
+instance ToSchema LocationKind
+instance ToSchema LocationFallback where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
+instance ToSchema LocationUnresolved where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 instance ToSchema DatabaseSetupInfo
 
 -- API.Types — every record type uses strippedSchemaOptions so the generated

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -387,6 +387,7 @@ executeDbUpload registry fmt manager args = do
                         , dcFormat = Just (urFormat uploadResult)
                         , dcIsUploaded = True
                         , dcDeletable = True
+                        , dcGeographyPolicy = Types.GeoGlobal
                         }
             addDatabase manager dbConfig
             reportProgress Info $ "Database uploaded: " ++ T.unpack slug

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -43,7 +43,8 @@ import Plugin.Config (PluginConfig)
 import System.Directory (doesFileExist)
 import System.Environment (lookupEnv)
 import System.FilePath (takeFileName)
-import TOML (DecodeTOML (..), decodeFile, getArrayOf, getField, getFieldOpt, getFieldOptWith)
+import TOML (DecodeTOML (..), Decoder, decodeFile, getArrayOf, getField, getFieldOpt, getFieldOptWith)
+import Types (GeographyPolicy (..))
 
 -- | A single classification filter entry (system + value)
 data ClassificationEntry = ClassificationEntry
@@ -109,6 +110,7 @@ data DatabaseConfig = DatabaseConfig
     , dcFormat :: !(Maybe DatabaseFormat) -- Detected format (EcoSpold2, EcoSpold1, SimaProCSV)
     , dcIsUploaded :: !Bool -- True for uploaded databases (vs. configured in TOML)
     , dcDeletable :: !Bool -- May the UI delete this entry? Defaults to dcIsUploaded.
+    , dcGeographyPolicy :: !GeographyPolicy -- How aggressively to widen geography when linking suppliers
     }
     deriving (Show, Eq, Generic)
 
@@ -213,7 +215,17 @@ instance DecodeTOML DatabaseConfig where
         let dcFormat = Nothing -- Format is detected at runtime, not stored in config
         let dcIsUploaded = False -- Databases from TOML are not uploaded
         dcDeletable <- fromMaybe dcIsUploaded <$> getFieldOpt "deletable"
+        dcGeographyPolicy <- fromMaybe GeoGlobal <$> getFieldOptWith geographyPolicyDecoder "geography_policy"
         pure DatabaseConfig{..}
+
+geographyPolicyDecoder :: Decoder GeographyPolicy
+geographyPolicyDecoder = do
+    raw <- tomlDecoder :: Decoder Text
+    case T.toLower raw of
+        "exact" -> pure GeoExact
+        "parent" -> pure GeoParent
+        "global" -> pure GeoGlobal
+        other -> fail $ "geography_policy: expected one of exact|parent|global, got: " <> T.unpack other
 
 instance DecodeTOML MethodConfig where
     tomlDecoder = do

--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -25,6 +26,8 @@ module Database.CrossLinking (
     CrossDBLinkResult (..),
     LinkWarning (..),
     LinkBlocker (..),
+    GeographyPolicy (..),
+    LocationKind (..),
     IndexedDatabase (..),
     SupplierEntry (..),
 
@@ -42,6 +45,7 @@ module Database.CrossLinking (
     -- * Scoring Functions
     matchProductName,
     matchLocation,
+    acceptableLocation,
 
     -- * Location Hierarchy
     isSubregionOf,
@@ -61,7 +65,7 @@ module Database.CrossLinking (
 import Data.Char (isAlpha, isUpper)
 import Data.List (maximumBy)
 import qualified Data.Map.Strict as M
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Ord (comparing)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -69,7 +73,19 @@ import Data.UUID (UUID)
 
 import qualified Data.Vector as V
 import SynonymDB (SynonymDB, lookupSynonymGroup, normalizeName)
-import Types (Activity (..), Database (..), LinkBlocker (..), SimpleDatabase (..), TechnosphereFlow (..), exchangeFlowId, exchangeIsReference, exchanges, getActivity)
+import Types (
+    Activity (..),
+    Database (..),
+    GeographyPolicy (..),
+    LinkBlocker (..),
+    LocationKind (..),
+    SimpleDatabase (..),
+    TechnosphereFlow (..),
+    exchangeFlowId,
+    exchangeIsReference,
+    exchanges,
+    getActivity,
+ )
 import qualified UnitConversion as UC
 
 {- | Pre-indexed database for fast cross-DB supplier lookup
@@ -101,9 +117,14 @@ data LinkingContext = LinkingContext
     , lcUnitConfig :: !UC.UnitConfig
     -- ^ For unit compatibility
     , lcThreshold :: !Int
-    -- ^ Minimum score to auto-link (default: 60)
+    {- ^ Minimum score to auto-link (default: 55). Acts as a sanity floor on
+    name+location scoring; geographic acceptability is enforced separately
+    by 'lcGeographyPolicy' via 'acceptableLocation'.
+    -}
     , lcLocationHierarchy :: !(M.Map Text [Text])
     -- ^ Location hierarchy (code → parent codes)
+    , lcGeographyPolicy :: !GeographyPolicy
+    -- ^ How aggressively to widen geography when no exact match is found
     }
 
 -- | A candidate supplier from another database
@@ -131,8 +152,8 @@ data CrossDBLinkResult
 
 -- | Non-blocking warning: link succeeded but with caveats
 data LinkWarning
-    = -- | requestedLoc, actualLoc (e.g. FR → RER)
-      UpperLocationUsed !Text !Text
+    = -- | requestedLoc, actualLoc, kind (e.g. FR → RER, ParentLoc)
+      UpperLocationUsed !Text !Text !LocationKind
     deriving (Show, Eq)
 
 -- | LinkBlocker is defined in Types and re-exported here
@@ -298,9 +319,10 @@ buildIndexedDatabase dbName synDB db =
             , idbBySynonymGroup = bySynonym
             }
 
--- | Build supplier entries from a SimpleDatabase. Reference exchanges of
--- production processes are always technosphere outputs, so the supplier flow
--- lives in `sdbTechFlows`.
+{- | Build supplier entries from a SimpleDatabase. Reference exchanges of
+production processes are always technosphere outputs, so the supplier flow
+lives in `sdbTechFlows`.
+-}
 buildSupplierEntries :: SimpleDatabase -> [(Text, SupplierEntry)]
 buildSupplierEntries db =
     [ (tfName flow, SupplierEntry actUUID prodUUID (activityLocation act) (activityUnit act) (tfName flow))
@@ -339,8 +361,9 @@ buildIndexedDatabaseFromDB dbName synDB db =
             , idbBySynonymGroup = bySynonym
             }
 
--- | Build supplier entries from a full Database. Same invariant as
--- 'buildSupplierEntries' above: reference exchanges are technosphere.
+{- | Build supplier entries from a full Database. Same invariant as
+'buildSupplierEntries' above: reference exchanges are technosphere.
+-}
 buildSupplierEntriesFromDB :: Database -> [(Text, SupplierEntry)]
 buildSupplierEntriesFromDB db =
     [ (tfName flow, SupplierEntry actUUID prodUUID (activityLocation act) (activityUnit act) (tfName flow))
@@ -395,22 +418,36 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
                             -- All candidates failed unit check — report the first supplier's unit
                             CrossDBNotLinked (UnitIncompatible unit (seUnit firstSe))
                         else
-                            -- Score by effective location
-                            let scoredCandidates = map (scoreEntry effectiveLocation) unitCompatible
-                                !best = maximumBy (comparing cdbScore) scoredCandidates
-                             in if cdbScore best >= lcThreshold
-                                    then
-                                        -- Build warnings (only when original location was explicit)
-                                        let warnings = if T.null location then [] else buildWarnings effectiveLocation (cdbLocation best)
-                                         in CrossDBLinked
-                                                (cdbActivityUUID best)
-                                                (cdbProductUUID best)
-                                                (cdbDatabaseName best)
-                                                (cdbScore best)
-                                                (cdbProductName best)
-                                                (cdbLocation best)
-                                                warnings
-                                    else CrossDBNotLinked (LocationUnavailable effectiveLocation)
+                            -- Filter candidates geographically via policy, then rank survivors
+                            let accepted = mapMaybe (classifyEntry effectiveLocation) unitCompatible
+                             in case accepted of
+                                    [] ->
+                                        -- Candidates existed but every one was rejected.
+                                        -- Distinguish "no plausible location" (narrowing only / hierarchy miss)
+                                        -- from "policy rejected an otherwise valid match".
+                                        case rejectionReason effectiveLocation unitCompatible of
+                                            Just (bestLoc, bestKind) ->
+                                                CrossDBNotLinked (LocationRejectedByPolicy effectiveLocation bestLoc bestKind)
+                                            Nothing ->
+                                                CrossDBNotLinked (LocationUnavailable effectiveLocation)
+                                    _ ->
+                                        let scored = map (\(entry, kind) -> (scoreEntry effectiveLocation entry, kind)) accepted
+                                            !(bestCand, bestKind) = maximumBy (comparing (cdbScore . fst)) scored
+                                         in if cdbScore bestCand >= lcThreshold
+                                                then
+                                                    let warnings =
+                                                            if T.null location || bestKind == ExactLoc
+                                                                then []
+                                                                else [UpperLocationUsed effectiveLocation (cdbLocation bestCand) bestKind]
+                                                     in CrossDBLinked
+                                                            (cdbActivityUUID bestCand)
+                                                            (cdbProductUUID bestCand)
+                                                            (cdbDatabaseName bestCand)
+                                                            (cdbScore bestCand)
+                                                            (cdbProductName bestCand)
+                                                            (cdbLocation bestCand)
+                                                            warnings
+                                                else CrossDBNotLinked (LocationUnavailable effectiveLocation)
   where
     lookupExact :: Text -> IndexedDatabase -> [(Text, SupplierEntry)]
     lookupExact name idb =
@@ -435,6 +472,33 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
                         Nothing -> tryPrefixes ps
                 else candidates
 
+    classifyEntry :: Text -> (Text, SupplierEntry) -> Maybe ((Text, SupplierEntry), LocationKind)
+    classifyEntry queryLoc entry@(_, SupplierEntry{seLocation}) =
+        case acceptableLocation lcGeographyPolicy lcLocationHierarchy queryLoc seLocation of
+            Just kind -> Just (entry, kind)
+            Nothing -> Nothing
+
+    -- For the rejected-by-policy case, find the best candidate that *would*
+    -- have been accepted under 'GeoGlobal' but is rejected here, so we can
+    -- report it to the user. Returns Nothing if even GeoGlobal would reject
+    -- (e.g. narrowing only) — caller falls back to LocationUnavailable.
+    rejectionReason :: Text -> [(Text, SupplierEntry)] -> Maybe (Text, LocationKind)
+    rejectionReason queryLoc candidates =
+        let permissive =
+                mapMaybe
+                    ( \(_, SupplierEntry{seLocation}) ->
+                        (\k -> (seLocation, k))
+                            <$> acceptableLocation GeoGlobal lcLocationHierarchy queryLoc seLocation
+                    )
+                    candidates
+            kindOrder ExactLoc = 4 :: Int
+            kindOrder ParentLoc = 3
+            kindOrder GlobalLoc = 2
+            kindOrder UnrelatedLoc = 1
+         in case permissive of
+                [] -> Nothing
+                _ -> Just $ maximumBy (comparing (kindOrder . snd)) permissive
+
     scoreEntry :: Text -> (Text, SupplierEntry) -> CrossDBCandidate
     scoreEntry queryLoc (dbName, SupplierEntry{..}) =
         let locScore = matchLocation lcLocationHierarchy queryLoc seLocation
@@ -448,11 +512,6 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
                 , cdbLocation = seLocation
                 , cdbProductName = seProductName
                 }
-
-    buildWarnings :: Text -> Text -> [LinkWarning]
-    buildWarnings queryLoc actualLoc
-        | queryLoc == actualLoc = []
-        | otherwise = [UpperLocationUsed queryLoc actualLoc]
 
 -- | Legacy function for backward compatibility (slower, builds indexes on the fly)
 findSupplierAcrossDatabases ::
@@ -499,6 +558,53 @@ matchLocation hier queryLoc candidateLoc
     | candidateLoc `elem` ["GLO", "RoW", "Unspecified"] = 10 -- Global fallback
     | isSubregionOf hier candidateLoc queryLoc = 0 -- Narrowing (GLO→FR) — blocked
     | otherwise = 5 -- Unrelated
+
+{- | Classify a candidate location relative to the requested one. Pure
+description, ignoring any policy. Used by 'acceptableLocation' and to label
+fallback warnings.
+
+'GlobalLoc' takes precedence over 'ParentLoc' even when GLO/RoW appears in
+the requested location's parent chain (every country has GLO/RoW listed in
+'locationHierarchy'), because semantically a global fallback is a stronger
+caveat than an honest geographic widening.
+-}
+describeLocation :: M.Map Text [Text] -> Text -> Text -> LocationKind
+describeLocation hier queryLoc candidateLoc
+    | queryLoc == candidateLoc = ExactLoc
+    | candidateLoc `elem` ["GLO", "RoW", "Unspecified"] = GlobalLoc
+    | isSubregionOf hier queryLoc candidateLoc = ParentLoc
+    | otherwise = UnrelatedLoc
+
+{- | Decide whether a candidate location is acceptable for the given policy.
+
+Narrowing (candidate strictly more specific than requested) is always
+rejected: it would invent precision the source dataset does not have.
+-}
+acceptableLocation ::
+    GeographyPolicy ->
+    M.Map Text [Text] ->
+    -- | requested location
+    Text ->
+    -- | candidate location
+    Text ->
+    Maybe LocationKind
+acceptableLocation policy hier queryLoc candidateLoc
+    | isNarrowing = Nothing
+    | otherwise = case (describeLocation hier queryLoc candidateLoc, policy) of
+        (ExactLoc, _) -> Just ExactLoc
+        (ParentLoc, GeoExact) -> Nothing
+        (ParentLoc, _) -> Just ParentLoc
+        (GlobalLoc, GeoGlobal) -> Just GlobalLoc
+        (GlobalLoc, _) -> Nothing
+        (UnrelatedLoc, GeoGlobal) -> Just UnrelatedLoc
+        (UnrelatedLoc, _) -> Nothing
+  where
+    -- candidate is more specific than query, but not when candidate is a
+    -- placeless code (GLO/RoW/Unspecified) — those are wider, not narrower
+    isNarrowing =
+        queryLoc /= candidateLoc
+            && candidateLoc `notElem` ["GLO", "RoW", "Unspecified"]
+            && isSubregionOf hier candidateLoc queryLoc
 
 -- | Check if one location is a subregion of another
 isSubregionOf :: M.Map Text [Text] -> Text -> Text -> Bool

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -1068,10 +1069,12 @@ loadDatabaseWithCrossDBLinking ::
     UC.UnitConfig ->
     -- | Location hierarchy (empty = use built-in)
     M.Map T.Text [T.Text] ->
+    -- | Geography policy for this database
+    GeographyPolicy ->
     -- | Path to load from
     FilePath ->
     IO (Either T.Text (SimpleDatabase, CrossDBLinkingStats))
-loadDatabaseWithCrossDBLinking locationAliases otherIndexes synonymDB unitConfig locationHier path = do
+loadDatabaseWithCrossDBLinking locationAliases otherIndexes synonymDB unitConfig locationHier policy path = do
     result <- loadDatabaseWithLocationAliases unitConfig locationAliases path
     case result of
         Left err -> return $ Left err
@@ -1107,6 +1110,7 @@ loadDatabaseWithCrossDBLinking locationAliases otherIndexes synonymDB unitConfig
                             synonymDB
                             unitConfig
                             locationHier
+                            policy
                             simpleDb
                     return $ Right (linkedDb, stats{cdlUnknownUnits = unknownUnits})
 
@@ -1134,10 +1138,12 @@ fixActivityLinksWithCrossDB ::
     UC.UnitConfig ->
     -- | Location hierarchy (code → parent codes)
     M.Map T.Text [T.Text] ->
+    -- | Geography policy for this database
+    GeographyPolicy ->
     -- | Database to fix
     SimpleDatabase ->
     IO (SimpleDatabase, CrossDBLinkingStats)
-fixActivityLinksWithCrossDB indexedDbs synonymDB unitConfig locationHier db = do
+fixActivityLinksWithCrossDB indexedDbs synonymDB unitConfig locationHier policy db = do
     -- Count unlinked exchanges before
     let unlinkedBefore = countUnlinkedExchanges db
         !totalInputs = countTotalTechInputs db
@@ -1170,6 +1176,7 @@ fixActivityLinksWithCrossDB indexedDbs synonymDB unitConfig locationHier db = do
                         , lcUnitConfig = unitConfig
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = if M.null locationHier then locationHierarchy else locationHier
+                        , lcGeographyPolicy = policy
                         }
 
             -- Process all activities to find cross-DB links
@@ -1291,10 +1298,27 @@ findExchangeCrossDBLink ctx techFlowDb unitDb consumerActUUID consumerProdUUID e
                                         , cdlLocation = supplierLoc
                                         , cdlSourceDatabase = dbName
                                         }
-                                fallbacks = [(prodName, req, actLoc) | UpperLocationUsed req actLoc <- warnings]
-                             in CrossDBLinkingStats [crossLink] M.empty S.empty fallbacks 0
+                                fallbacks =
+                                    [ LocationFallback prodName req actLoc kind
+                                    | UpperLocationUsed req actLoc kind <- warnings
+                                    ]
+                             in CrossDBLinkingStats [crossLink] M.empty S.empty fallbacks [] 0
                         CrossDBNotLinked blocker ->
-                            CrossDBLinkingStats [] (M.singleton (tfName flow) (1, blocker)) S.empty [] 0
+                            let unresolved = case blocker of
+                                    LocationRejectedByPolicy req actLoc kind ->
+                                        [ LocationUnresolved
+                                            (tfName flow)
+                                            req
+                                            ( "policy rejected "
+                                                <> T.pack (show kind)
+                                                <> " candidate "
+                                                <> actLoc
+                                            )
+                                        ]
+                                    LocationUnavailable req ->
+                                        [LocationUnresolved (tfName flow) req "no candidate above link threshold"]
+                                    _ -> []
+                             in CrossDBLinkingStats [] (M.singleton (tfName flow) (1, blocker)) S.empty [] unresolved 0
     | otherwise = emptyCrossDBLinkingStats
 findExchangeCrossDBLink _ _ _ _ _ BiosphereExchange{} = emptyCrossDBLinkingStats
 
@@ -1353,11 +1377,32 @@ reportCrossDBLinkingStats nActivities stats = do
     when (nFallbacks > 0) $ do
         reportProgress Info $
             printf "Location fallbacks: %d unique products matched with different location" nFallbacks
-        forM_ uniqueFallbacks $ \(prod, requested, actual) ->
+        forM_ uniqueFallbacks $ \LocationFallback{lfProduct, lfRequested, lfActual, lfKind} ->
             reportProgress Info $
-                printf "  - %s: %s → %s" (T.unpack prod) (T.unpack requested) (T.unpack actual)
+                printf
+                    "  - %s: %s → %s (%s)"
+                    (T.unpack lfProduct)
+                    (T.unpack lfRequested)
+                    (T.unpack lfActual)
+                    (show lfKind)
+
+    -- Inputs rejected by geography_policy (deduplicated)
+    let !uniqueUnresolved = deduplicateUnresolved (cdlLocationUnresolved stats)
+        !nUnresolved' = length uniqueUnresolved
+    when (nUnresolved' > 0) $ do
+        reportProgress Warning $
+            printf "Location unresolved: %d unique products with no acceptable supplier" nUnresolved'
+        forM_ uniqueUnresolved $ \LocationUnresolved{luProduct, luRequested, luReason} ->
+            reportProgress Warning $
+                printf
+                    "  - %s [%s] — %s"
+                    (T.unpack luProduct)
+                    (T.unpack luRequested)
+                    (T.unpack luReason)
 
 showBlocker :: LinkBlocker -> String
 showBlocker NoNameMatch = "Not found"
 showBlocker (UnitIncompatible q s) = printf "Unit: %s vs %s" (T.unpack q) (T.unpack s)
 showBlocker (LocationUnavailable loc) = printf "Location: %s" (T.unpack loc)
+showBlocker (LocationRejectedByPolicy req act kind) =
+    printf "Rejected by policy: %s → %s (%s)" (T.unpack req) (T.unpack act) (show kind)

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -162,7 +163,34 @@ import qualified Search.BM25 as BM25
 import SharedSolver (SharedSolver, createSharedSolver)
 import qualified SharedSolver
 import SynonymDB (SynonymDB (..), buildFromCSV, buildFromPairs, emptySynonymDB, loadFromCSVFileWithCache, mergeSynonymDBs, synonymCount)
-import Types (Activity (..), BioFlowDB, BiosphereFlow (..), CrossDBLink (..), CrossDBLinkingStats (..), Database (..), LinkBlocker (..), SimpleDatabase (..), SparseTriple (..), UUID, Unit (..), UnitDB, bfCompartmentName, bfCompartmentSub, crossDBBySource, deduplicateFallbacks, exchangeFlowId, exchangeIsReference, initializeRuntimeFields, toSimpleDatabase, unresolvedCount)
+import Types (
+    Activity (..),
+    BioFlowDB,
+    BiosphereFlow (..),
+    CrossDBLink (..),
+    CrossDBLinkingStats (..),
+    Database (..),
+    GeographyPolicy (..),
+    LinkBlocker (..),
+    LocationFallback (..),
+    LocationKind (..),
+    LocationUnresolved (..),
+    SimpleDatabase (..),
+    SparseTriple (..),
+    UUID,
+    Unit (..),
+    UnitDB,
+    bfCompartmentName,
+    bfCompartmentSub,
+    crossDBBySource,
+    deduplicateFallbacks,
+    deduplicateUnresolved,
+    exchangeFlowId,
+    exchangeIsReference,
+    initializeRuntimeFields,
+    toSimpleDatabase,
+    unresolvedCount,
+ )
 import qualified UnitConversion
 
 -- CrossDBLinkingStats is now in Types, re-exported from Database.Loader
@@ -284,8 +312,12 @@ data DatabaseSetupInfo = DatabaseSetupInfo
     -- ^ True if can be finalized
     , dsiUnknownUnits :: ![Text]
     -- ^ Unknown units from sdbUnits
-    , dsiLocationFallbacks :: ![(Text, Text, Text)]
-    -- ^ (product, requestedLoc, actualLoc)
+    , dsiLocationFallbacks :: ![LocationFallback]
+    -- ^ Accepted links with widened geography, tagged with 'LocationKind'
+    , dsiLocationUnresolved :: ![LocationUnresolved]
+    {- ^ Inputs that could not be linked because the database's
+    'GeographyPolicy' rejected every candidate (or no candidate existed)
+    -}
     , dsiDataPath :: !Text
     -- ^ Current selected data path (relative)
     , dsiAvailablePaths :: ![(Text, Text, Int)]
@@ -311,14 +343,30 @@ instance ToJSON DatabaseSetupInfo where
             , "isReady" .= dsiIsReady
             , "unknownUnits" .= dsiUnknownUnits
             , "locationFallbacks" .= map encodeFallback dsiLocationFallbacks
+            , "locationUnresolved" .= map encodeUnresolved dsiLocationUnresolved
             , "dataPath" .= dsiDataPath
             , "availablePaths" .= map encodeCandidate dsiAvailablePaths
             , "isLoaded" .= dsiIsLoaded
             ]
       where
-        encodeFallback (prod, req, act) =
+        encodeFallback LocationFallback{lfProduct, lfRequested, lfActual, lfKind} =
             A.object
-                ["product" .= prod, "requested" .= req, "actual" .= act]
+                [ "product" .= lfProduct
+                , "requested" .= lfRequested
+                , "actual" .= lfActual
+                , "kind" .= encodeKind lfKind
+                ]
+        encodeUnresolved LocationUnresolved{luProduct, luRequested, luReason} =
+            A.object
+                [ "product" .= luProduct
+                , "requested" .= luRequested
+                , "reason" .= luReason
+                ]
+        encodeKind :: LocationKind -> Text
+        encodeKind ExactLoc = "exact"
+        encodeKind ParentLoc = "parent"
+        encodeKind GlobalLoc = "global"
+        encodeKind UnrelatedLoc = "unrelated"
         encodeCandidate (path, fmt, cnt) =
             A.object
                 ["path" .= path, "format" .= fmt, "fileCount" .= cnt]
@@ -922,6 +970,7 @@ uploadMetaToConfig slug dirPath meta =
         , dcFormat = Just (UploadedDB.umFormat meta)
         , dcIsUploaded = True -- Discovered from uploads/ directory
         , dcDeletable = True
+        , dcGeographyPolicy = GeoGlobal -- Uploads can't yet express policy; default to permissive
         }
 
 {- | Discover uploaded methods from uploads/methods/ directory
@@ -1084,7 +1133,7 @@ loadDatabaseFromConfigWithCrossDBAndTransforms transforms dbConfig synonymDB uni
     let sourcePath = dcPath dbConfig
         locationAliases = dcLocationAliases dbConfig
     reportProgress Info $ "Loading database from: " <> sourcePath
-    dbResult <- loadDatabaseRawWithCrossDB (dcName dbConfig) locationAliases sourcePath noCache synonymDB unitConfig otherIndexes locationHier
+    dbResult <- loadDatabaseRawWithCrossDB (dcName dbConfig) locationAliases sourcePath noCache synonymDB unitConfig otherIndexes locationHier (dcGeographyPolicy dbConfig)
 
     case dbResult of
         Left err -> return $ Left err
@@ -1212,12 +1261,14 @@ loadDatabaseRawWithCrossDB ::
     [IndexedDatabase] ->
     -- | Location hierarchy (empty = use built-in)
     M.Map T.Text [T.Text] ->
+    -- | Geography policy for this database
+    GeographyPolicy ->
     {- | (Database, fromCache): True iff the result came from the matrix cache
     as-is, i.e. cross-DB linking was NOT freshly run against 'otherIndexes'.
     Callers use this to decide whether a self-relink is needed.
     -}
     IO (Either Text (Database, Bool))
-loadDatabaseRawWithCrossDB dbName locationAliases sourcePath noCache synonymDB unitConfig otherIndexes locationHier = do
+loadDatabaseRawWithCrossDB dbName locationAliases sourcePath noCache synonymDB unitConfig otherIndexes locationHier policy = do
     mCachedDb <-
         if noCache
             then return Nothing
@@ -1289,6 +1340,7 @@ loadDatabaseRawWithCrossDB dbName locationAliases sourcePath noCache synonymDB u
                 synonymDB
                 unitConfig
                 locationHier
+                policy
                 path
         case loadResult of
             Left err -> return $ Left err
@@ -1457,6 +1509,7 @@ relinkDatabase manager dbName = do
                         , lcUnitConfig = unitConfig
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = M.map snd (dmGeographies manager)
+                        , lcGeographyPolicy = dcGeographyPolicy (ldConfig loaded)
                         }
                 !totalInputs = Loader.countTotalTechInputs (toSimpleDatabase db)
                 rawStats =
@@ -1653,6 +1706,7 @@ stageUploadedDatabase manager dbConfig = do
                     synonymDB
                     unitConfig
                     (M.map snd (dmGeographies manager))
+                    (dcGeographyPolicy dbConfig)
                     loadPath
 
             case loadResult of
@@ -1898,6 +1952,8 @@ buildStagedSetupInfo staged configs indexedDbs =
                     NoNameMatch -> ("no_name_match", Nothing)
                     UnitIncompatible q s -> ("unit_incompatible", Just (q <> " vs " <> s))
                     LocationUnavailable loc -> ("location_unavailable", Just loc)
+                    LocationRejectedByPolicy req act _ ->
+                        ("location_rejected", Just (req <> " ↛ " <> act))
              in MissingSupplier name cnt Nothing reason detail
         -- Combined dependencies list (selected + available, alpha sorted)
         dependencies =
@@ -1923,6 +1979,7 @@ buildStagedSetupInfo staged configs indexedDbs =
             , dsiIsReady = isReady
             , dsiUnknownUnits = S.toList (cdlUnknownUnits stats)
             , dsiLocationFallbacks = deduplicateFallbacks (cdlLocationFallbacks stats)
+            , dsiLocationUnresolved = deduplicateUnresolved (cdlLocationUnresolved stats)
             , dsiDataPath = T.pack (dcPath (sdConfig staged))
             , dsiAvailablePaths = [] -- Filled in by buildSetupResult (requires IO)
             , dsiIsLoaded = False
@@ -1949,6 +2006,8 @@ buildLoadedSetupInfo config db configs indexedDbs =
                     NoNameMatch -> ("no_name_match", Nothing)
                     UnitIncompatible q s -> ("unit_incompatible", Just (q <> " vs " <> s))
                     LocationUnavailable loc -> ("location_unavailable", Just loc)
+                    LocationRejectedByPolicy req act _ ->
+                        ("location_rejected", Just (req <> " ↛ " <> act))
              in MissingSupplier name cnt Nothing reason detail
      in DatabaseSetupInfo
             { dsiName = dcName config
@@ -1964,6 +2023,7 @@ buildLoadedSetupInfo config db configs indexedDbs =
             , dsiIsReady = True
             , dsiUnknownUnits = S.toList (cdlUnknownUnits stats)
             , dsiLocationFallbacks = deduplicateFallbacks (cdlLocationFallbacks stats)
+            , dsiLocationUnresolved = deduplicateUnresolved (cdlLocationUnresolved stats)
             , dsiDataPath = T.pack (dcPath config)
             , dsiAvailablePaths = [] -- No picker for loaded/configured databases
             , dsiIsLoaded = True
@@ -2149,6 +2209,7 @@ addDependencyToStaged manager dbName depName = do
                         synonymDB
                         unitConfig
                         (M.map snd (dmGeographies manager))
+                        (dcGeographyPolicy (sdConfig staged))
                         (sdSimpleDB staged)
 
                 -- Update staged database with new stats and dependency
@@ -2187,6 +2248,7 @@ removeDependencyFromStaged manager dbName depName = do
                     synonymDB
                     unitConfig
                     (M.map snd (dmGeographies manager))
+                    (dcGeographyPolicy (sdConfig staged))
                     (sdSimpleDB staged)
 
             -- Update staged database

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -65,14 +65,16 @@ data Compartment = Compartment
     }
     deriving (Eq, Show, Generic, NFData, Store)
 
--- | The biosphere flow's medium (air | water | soil | …), or @""@ when the
--- source dataset omitted the compartment. Use 'bfCompartment' directly when
--- you need to distinguish "absent" from "empty string".
+{- | The biosphere flow's medium (air | water | soil | …), or @""@ when the
+source dataset omitted the compartment. Use 'bfCompartment' directly when
+you need to distinguish "absent" from "empty string".
+-}
 bfCompartmentName :: BiosphereFlow -> Text
 bfCompartmentName = maybe "" compartmentName . bfCompartment
 
--- | The biosphere flow's sub-compartment (e.g. "high. pop."), or @Nothing@
--- when neither the source nor the medium recorded one.
+{- | The biosphere flow's sub-compartment (e.g. "high. pop."), or @Nothing@
+when neither the source nor the medium recorded one.
+-}
 bfCompartmentSub :: BiosphereFlow -> Maybe Text
 bfCompartmentSub = (>>= compartmentSub) . bfCompartment
 
@@ -144,11 +146,12 @@ data BiosphereFlow = BiosphereFlow
     , bfSynonyms :: !(M.Map Text (S.Set Text))
     , bfCAS :: !(Maybe Text)
     , bfSubstanceId :: !(Maybe Int)
-    , -- | The source dataset's compartment (medium + optional sub) for this
-      -- flow, or @Nothing@ when the source omitted it. Distinguishing
-      -- "no compartment recorded" from "the empty string" is required to
-      -- avoid silently broadening LCIA matches in 'Method.Mapping'.
-      bfCompartment :: !(Maybe Compartment)
+    , bfCompartment :: !(Maybe Compartment)
+    {- ^ The source dataset's compartment (medium + optional sub) for this
+    flow, or @Nothing@ when the source omitted it. Distinguishing
+    "no compartment recorded" from "the empty string" is required to
+    avoid silently broadening LCIA matches in 'Method.Mapping'.
+    -}
     }
     deriving (Generic, NFData, Store)
 
@@ -847,6 +850,61 @@ data LinkBlocker
       UnitIncompatible !Text !Text
     | -- | requestedLoc (no fallback found above threshold)
       LocationUnavailable !Text
+    | {- | requestedLoc, bestCandidateLoc, bestCandidateKind — match existed but the database's
+      geography_policy rejected it
+      -}
+      LocationRejectedByPolicy !Text !Text !LocationKind
+    deriving (Show, Eq, Generic, NFData, Store)
+
+{- | Per-database knob controlling how aggressively geography may be widened when
+linking an exchange to a supplier. Maps to TOML field @geography_policy@.
+
+* 'GeoExact'  — only accept candidates with the exact same location code.
+* 'GeoParent' — also accept any ancestor that names a real region in
+                @locationHierarchy@ (e.g. @Europe@, @RER@). Excludes @GLO@,
+                @RoW@, @Unspecified@ and unrelated locations.
+* 'GeoGlobal' — accept any candidate the linker can match (current behaviour).
+-}
+data GeographyPolicy
+    = GeoExact
+    | GeoParent
+    | GeoGlobal
+    deriving (Show, Eq, Generic, NFData, Store)
+
+{- | Classification of how a candidate's location relates to the requested one.
+Produced by 'Database.CrossLinking.acceptableLocation' and surfaced alongside
+fallback warnings so the UI can distinguish gentle widening (parent region)
+from hard widening (global / unrelated).
+-}
+data LocationKind
+    = -- | Exact code match
+      ExactLoc
+    | -- | Ancestor region in the hierarchy (e.g. FR → Europe / RER)
+      ParentLoc
+    | -- | @GLO@, @RoW@ or @Unspecified@
+      GlobalLoc
+    | -- | Different but not in the hierarchy (e.g. SimaPro "Mixed data")
+      UnrelatedLoc
+    deriving (Show, Eq, Generic, NFData, Store)
+
+-- | A product whose supplier was found at a wider geography than requested.
+data LocationFallback = LocationFallback
+    { lfProduct :: !Text
+    , lfRequested :: !Text
+    , lfActual :: !Text
+    , lfKind :: !LocationKind
+    }
+    deriving (Show, Eq, Generic, NFData, Store)
+
+{- | A product whose supplier could not be linked — either because no candidate
+matched the name/unit, or because every geographic candidate was rejected by
+the database's 'GeographyPolicy'.
+-}
+data LocationUnresolved = LocationUnresolved
+    { luProduct :: !Text
+    , luRequested :: !Text
+    , luReason :: !Text
+    }
     deriving (Show, Eq, Generic, NFData, Store)
 
 {- | Statistics from cross-database linking
@@ -859,8 +917,10 @@ data CrossDBLinkingStats = CrossDBLinkingStats
     -- ^ Product name -> (count, reason)
     , cdlUnknownUnits :: !(S.Set Text)
     -- ^ Unknown units from sdbUnits
-    , cdlLocationFallbacks :: ![(Text, Text, Text)]
-    -- ^ (product, requestedLoc, actualLoc)
+    , cdlLocationFallbacks :: ![LocationFallback]
+    -- ^ Accepted links with widened geography, tagged with 'LocationKind'
+    , cdlLocationUnresolved :: ![LocationUnresolved]
+    -- ^ Inputs rejected by policy or with no candidate
     , cdlTotalInputs :: !Int
     -- ^ Total technosphere inputs at time of linking
     }
@@ -868,7 +928,7 @@ data CrossDBLinkingStats = CrossDBLinkingStats
 
 -- | Empty stats
 emptyCrossDBLinkingStats :: CrossDBLinkingStats
-emptyCrossDBLinkingStats = CrossDBLinkingStats [] M.empty S.empty [] 0
+emptyCrossDBLinkingStats = CrossDBLinkingStats [] M.empty S.empty [] [] 0
 
 -- | Merge two CrossDBLinkingStats
 mergeCrossDBStats :: CrossDBLinkingStats -> CrossDBLinkingStats -> CrossDBLinkingStats
@@ -878,18 +938,27 @@ mergeCrossDBStats s1 s2 =
         , cdlUnresolvedProducts = M.unionWith mergeUnresolved (cdlUnresolvedProducts s1) (cdlUnresolvedProducts s2)
         , cdlUnknownUnits = S.union (cdlUnknownUnits s1) (cdlUnknownUnits s2)
         , cdlLocationFallbacks = cdlLocationFallbacks s1 ++ cdlLocationFallbacks s2
+        , cdlLocationUnresolved = cdlLocationUnresolved s1 ++ cdlLocationUnresolved s2
         , cdlTotalInputs = cdlTotalInputs s1 + cdlTotalInputs s2
         }
   where
     mergeUnresolved (c1, b) (c2, _) = (c1 + c2, b)
 
 -- | Deduplicate location fallbacks by (product, requestedLoc)
-deduplicateFallbacks :: [(Text, Text, Text)] -> [(Text, Text, Text)]
+deduplicateFallbacks :: [LocationFallback] -> [LocationFallback]
 deduplicateFallbacks =
-    map (\((p, r), a) -> (p, r, a))
+    map snd
         . M.toList
         . M.fromListWith (\_ b -> b)
-        . map (\(p, r, a) -> ((p, r), a))
+        . map (\f -> ((lfProduct f, lfRequested f), f))
+
+-- | Deduplicate unresolved entries by (product, requestedLoc)
+deduplicateUnresolved :: [LocationUnresolved] -> [LocationUnresolved]
+deduplicateUnresolved =
+    map snd
+        . M.toList
+        . M.fromListWith (\_ b -> b)
+        . map (\u -> ((luProduct u, luRequested u), u))
 
 -- | Number of resolved cross-DB links
 crossDBLinksCount :: CrossDBLinkingStats -> Int

--- a/test/AutoRelinkSpec.hs
+++ b/test/AutoRelinkSpec.hs
@@ -33,19 +33,22 @@ import Test.Hspec
 
 import Database.Manager (loadDatabaseRawWithCrossDB)
 import SynonymDB (emptySynonymDB)
+import Types (GeographyPolicy (..))
 import UnitConversion (defaultUnitConfig)
 
--- | Copy regular files from one directory into another (non-recursive,
--- which is all the EcoSpold v2 fixtures here need).
+{- | Copy regular files from one directory into another (non-recursive,
+which is all the EcoSpold v2 fixtures here need).
+-}
 copyDirContents :: FilePath -> FilePath -> IO ()
 copyDirContents src dst = do
     createDirectoryIfMissing True dst
     files <- listDirectory src
     forM_ files $ \f -> copyFile (src </> f) (dst </> f)
 
--- | Drive 'loadDatabaseRawWithCrossDB' with the inert defaults that this
--- test cares about. Cross-DB linking is not exercised; we only need the
--- cache-hit detection.
+{- | Drive 'loadDatabaseRawWithCrossDB' with the inert defaults that this
+test cares about. Cross-DB linking is not exercised; we only need the
+cache-hit detection.
+-}
 runRaw :: FilePath -> IO (Either T.Text Bool)
 runRaw dstDir = do
     result <-
@@ -58,6 +61,7 @@ runRaw dstDir = do
             defaultUnitConfig
             []
             M.empty
+            GeoGlobal
     return (fmap snd result)
 
 spec :: Spec

--- a/test/CrossLinkingSpec.hs
+++ b/test/CrossLinkingSpec.hs
@@ -2,6 +2,8 @@
 
 module CrossLinkingSpec (spec) where
 
+import Control.Monad (forM_)
+import qualified Data.Text as T
 import Database.CrossLinking
 import Database.Loader (loadDatabase)
 import SynonymDB (buildFromPairs, emptySynonymDB)
@@ -227,6 +229,7 @@ spec = do
                         , lcUnitConfig = defaultUnitConfig
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
+                        , lcGeographyPolicy = GeoGlobal
                         }
             case findSupplierInIndexedDBs ctx "product Y" "GLO" "kg" of
                 CrossDBLinked _ _ _ score _ _ _ -> score `shouldSatisfy` (>= defaultLinkingThreshold)
@@ -241,6 +244,7 @@ spec = do
                         , lcUnitConfig = defaultUnitConfig
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
+                        , lcGeographyPolicy = GeoGlobal
                         }
             case findSupplierInIndexedDBs ctx "no such product" "GLO" "kg" of
                 CrossDBNotLinked _ -> return ()
@@ -255,6 +259,7 @@ spec = do
                         , lcUnitConfig = defaultUnitConfig
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
+                        , lcGeographyPolicy = GeoGlobal
                         }
             -- "product Y" exists in kg; asking for m3 should fail unit check
             case findSupplierInIndexedDBs ctx "product Y" "GLO" "m3" of
@@ -273,6 +278,7 @@ spec = do
                         , lcUnitConfig = defaultUnitConfig
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
+                        , lcGeographyPolicy = GeoGlobal
                         }
             -- Synonym lookup: "producto y" → group containing "product y" → supplier
             case findSupplierInIndexedDBs ctx "producto y" "GLO" "kg" of
@@ -288,12 +294,40 @@ spec = do
                         , lcUnitConfig = defaultUnitConfig
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
+                        , lcGeographyPolicy = GeoGlobal
                         }
             -- "product Y {GLO}" compound name with empty location arg
             -- extractBracketedLocation will find "GLO"
             case findSupplierInIndexedDBs ctx "product Y {GLO}" "" "kg" of
                 CrossDBLinked _ _ _ score _ _ _ -> score `shouldSatisfy` (>= defaultLinkingThreshold)
                 CrossDBNotLinked _ -> pendingWith "Compound name location extraction may not match"
+
+    -- -----------------------------------------------------------------------
+    -- acceptableLocation — table-driven, one case per (policy, kind) cell
+    -- -----------------------------------------------------------------------
+    describe "acceptableLocation" $ do
+        let hier = locationHierarchy
+            -- Each row: (description, requested, candidate, expected for each policy)
+            cases :: [(String, T.Text, T.Text, Maybe LocationKind, Maybe LocationKind, Maybe LocationKind)]
+            cases =
+                --   description                     requested   candidate           exact            parent              global
+                [ ("exact match preserved", "FR", "FR", Just ExactLoc, Just ExactLoc, Just ExactLoc)
+                , ("parent region (FR→Europe)", "FR", "Europe", Nothing, Just ParentLoc, Just ParentLoc)
+                , ("parent region (FR→RER)", "FR", "RER", Nothing, Just ParentLoc, Just ParentLoc)
+                , ("FR→GLO classified as global", "FR", "GLO", Nothing, Nothing, Just GlobalLoc)
+                , ("FR→RoW classified as global", "FR", "RoW", Nothing, Nothing, Just GlobalLoc)
+                , ("FR→Unspecified is global", "FR", "Unspecified", Nothing, Nothing, Just GlobalLoc)
+                , ("FR→Mixed data is unrelated", "FR", "Mixed data", Nothing, Nothing, Just UnrelatedLoc)
+                , ("FR→South America is unrelated", "FR", "South America", Nothing, Nothing, Just UnrelatedLoc)
+                , ("narrowing GLO→FR always rejected", "GLO", "FR", Nothing, Nothing, Nothing)
+                , ("BR→South America is parent", "BR", "South America", Nothing, Just ParentLoc, Just ParentLoc)
+                , ("BR→Latin America is parent", "BR", "Latin America", Nothing, Just ParentLoc, Just ParentLoc)
+                , ("BR→GLO is global", "BR", "GLO", Nothing, Nothing, Just GlobalLoc)
+                ]
+        forM_ cases $ \(label, req, cand, expExact, expParent, expGlobal) -> do
+            it (label ++ " — exact") $ acceptableLocation GeoExact hier req cand `shouldBe` expExact
+            it (label ++ " — parent") $ acceptableLocation GeoParent hier req cand `shouldBe` expParent
+            it (label ++ " — global") $ acceptableLocation GeoGlobal hier req cand `shouldBe` expGlobal
 
 -- ---------------------------------------------------------------------------
 -- Helper: load SAMPLE.min3 as IndexedDatabase

--- a/test/DependencyChoiceSpec.hs
+++ b/test/DependencyChoiceSpec.hs
@@ -14,6 +14,7 @@ import Database.Manager (
     DependencyStatus (..),
     buildDependencyChoices,
  )
+import Types (GeographyPolicy (..))
 
 cfg :: Text -> Text -> DatabaseConfig
 cfg name display =
@@ -29,6 +30,7 @@ cfg name display =
         , dcFormat = Nothing
         , dcIsUploaded = False
         , dcDeletable = False
+        , dcGeographyPolicy = GeoGlobal
         }
 
 -- IndexedDatabase whose idbByProductName has 'n' distinct dummy keys, so


### PR DESCRIPTION
## Summary

- Add `geography_policy = "exact" | "parent" | "global"` per `[[databases]]` entry. Default `global` preserves current behaviour.
- Replace the implicit 55-pt score threshold with an explicit `acceptableLocation` predicate that returns a tagged `LocationKind` (Exact / Parent / Global / Unrelated). `matchLocation` stays as the ranker between accepted candidates.
- Surface widening in `UpperLocationUsed` warnings with `LocationKind`, and rejections in a new `LocationRejectedByPolicy` blocker — never silently.
- Typed `LocationFallback { product, requested, actual, kind }` and `LocationUnresolved { product, requested, reason }` records replace the prior `(Text, Text, Text)` tuple in `dsiLocationFallbacks`, plus a companion `dsiLocationUnresolved`. JSON encoders + OpenAPI schemas updated.

## Why

Today the cross-DB linker (`Database.CrossLinking.findSupplierInIndexedDBs`) widens geography silently when no exact supplier is found: `FR` happily resolves to `South America` or `Mixed data` and only the cross-DB warning surfaces, not the severity. A study that wants a strict inventory has no knob to ask for it. A user reading the setup page sees a 100 % completeness bar over a diluted supply chain.

The policy is the smallest possible knob (3 values, named for intent, not points) and the predicate makes the contract testable.

## Notable design points

- `GLO` / `RoW` / `Unspecified` are classified as `GlobalLoc` even when they appear in the requested location's parent chain in `locationHierarchy` — global fallback is a stronger caveat than honest geographic widening, and the user-facing semantics should reflect that.
- Narrowing (candidate strictly more specific than requested) is always rejected regardless of policy.
- The policy applies only to **cross-DB** linking in this PR. Intra-DB `fixExchangeLink` Tier-3 fallback (name-only) is unchanged for now — follow-up.

## Test plan

- [x] `cabal test` — 908 examples, 0 failures (36 new acceptableLocation cases × 12 rows × 3 policies)
- [x] Default `global` policy: existing 872 tests still green (regression zero)
- [ ] End-to-end with a sample database that triggers parent / global / unrelated fallbacks — verify JSON payload carries `kind`
- [ ] Try `geography_policy = "exact"` on a database with known cross-DB widening — verify `LocationRejectedByPolicy` blockers appear and supplier links drop