### PR TITLE
Geography policy follow-up: consistent kind code + exhaustive LinkBlocker + schema fixes

### DIFF
--- a/src/API/OpenApi.hs
+++ b/src/API/OpenApi.hs
@@ -54,10 +54,27 @@ instance ToSchema Exchange where declareNamedSchema = genericDeclareNamedSchema 
 instance ToSchema MissingSupplier
 instance ToSchema DependencyStatus
 instance ToSchema DependencyChoice
-instance ToSchema LocationKind
+
+-- Manual schema for LocationKind: ToJSON in Database.Manager.encodeFallback
+-- emits lowercase wire codes (exact / parent / global / unrelated) via
+-- Types.locationKindCode. The generic schema would otherwise advertise the
+-- raw Haskell constructor names.
+instance ToSchema LocationKind where
+    declareNamedSchema _ =
+        pure $
+            NamedSchema (Just "LocationKind") $
+                mempty
+                    & type_ ?~ OpenApiString
+                    & enum_
+                        ?~ [ toJSON ("exact" :: Text)
+                           , toJSON ("parent" :: Text)
+                           , toJSON ("global" :: Text)
+                           , toJSON ("unrelated" :: Text)
+                           ]
+
 instance ToSchema LocationFallback where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 instance ToSchema LocationUnresolved where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
-instance ToSchema DatabaseSetupInfo
+instance ToSchema DatabaseSetupInfo where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 
 -- API.Types — every record type uses strippedSchemaOptions so the generated
 -- OpenAPI spec matches the wire JSON keys produced by API.JsonOptions.stripLowerPrefix.

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -1310,7 +1310,7 @@ findExchangeCrossDBLink ctx techFlowDb unitDb consumerActUUID consumerProdUUID e
                                             (tfName flow)
                                             req
                                             ( "policy rejected "
-                                                <> T.pack (show kind)
+                                                <> locationKindCode kind
                                                 <> " candidate "
                                                 <> actLoc
                                             )
@@ -1384,7 +1384,7 @@ reportCrossDBLinkingStats nActivities stats = do
                     (T.unpack lfProduct)
                     (T.unpack lfRequested)
                     (T.unpack lfActual)
-                    (show lfKind)
+                    (T.unpack (locationKindCode lfKind))
 
     -- Inputs rejected by geography_policy (deduplicated)
     let !uniqueUnresolved = deduplicateUnresolved (cdlLocationUnresolved stats)
@@ -1405,4 +1405,4 @@ showBlocker NoNameMatch = "Not found"
 showBlocker (UnitIncompatible q s) = printf "Unit: %s vs %s" (T.unpack q) (T.unpack s)
 showBlocker (LocationUnavailable loc) = printf "Location: %s" (T.unpack loc)
 showBlocker (LocationRejectedByPolicy req act kind) =
-    printf "Rejected by policy: %s → %s (%s)" (T.unpack req) (T.unpack act) (show kind)
+    printf "Rejected by policy: %s → %s (%s)" (T.unpack req) (T.unpack act) (T.unpack (locationKindCode kind))

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -1317,7 +1317,8 @@ findExchangeCrossDBLink ctx techFlowDb unitDb consumerActUUID consumerProdUUID e
                                         ]
                                     LocationUnavailable req ->
                                         [LocationUnresolved (tfName flow) req "no candidate above link threshold"]
-                                    _ -> []
+                                    NoNameMatch -> []
+                                    UnitIncompatible _ _ -> []
                              in CrossDBLinkingStats [] (M.singleton (tfName flow) (1, blocker)) S.empty [] unresolved 0
     | otherwise = emptyCrossDBLinkingStats
 findExchangeCrossDBLink _ _ _ _ _ BiosphereExchange{} = emptyCrossDBLinkingStats

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1947,8 +1947,8 @@ buildStagedSetupInfo staged configs indexedDbs =
                     NoNameMatch -> ("no_name_match", Nothing)
                     UnitIncompatible q s -> ("unit_incompatible", Just (q <> " vs " <> s))
                     LocationUnavailable loc -> ("location_unavailable", Just loc)
-                    LocationRejectedByPolicy req act _ ->
-                        ("location_rejected", Just (req <> " ↛ " <> act))
+                    LocationRejectedByPolicy req act kind ->
+                        ("location_rejected", Just (req <> " ↛ " <> act <> " (" <> locationKindCode kind <> ")"))
              in MissingSupplier name cnt Nothing reason detail
         -- Combined dependencies list (selected + available, alpha sorted)
         dependencies =
@@ -2001,8 +2001,8 @@ buildLoadedSetupInfo config db configs indexedDbs =
                     NoNameMatch -> ("no_name_match", Nothing)
                     UnitIncompatible q s -> ("unit_incompatible", Just (q <> " vs " <> s))
                     LocationUnavailable loc -> ("location_unavailable", Just loc)
-                    LocationRejectedByPolicy req act _ ->
-                        ("location_rejected", Just (req <> " ↛ " <> act))
+                    LocationRejectedByPolicy req act kind ->
+                        ("location_rejected", Just (req <> " ↛ " <> act <> " (" <> locationKindCode kind <> ")"))
              in MissingSupplier name cnt Nothing reason detail
      in DatabaseSetupInfo
             { dsiName = dcName config

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -173,7 +173,6 @@ import Types (
     GeographyPolicy (..),
     LinkBlocker (..),
     LocationFallback (..),
-    LocationKind (..),
     LocationUnresolved (..),
     SimpleDatabase (..),
     SparseTriple (..),
@@ -188,6 +187,7 @@ import Types (
     exchangeFlowId,
     exchangeIsReference,
     initializeRuntimeFields,
+    locationKindCode,
     toSimpleDatabase,
     unresolvedCount,
  )
@@ -354,7 +354,7 @@ instance ToJSON DatabaseSetupInfo where
                 [ "product" .= lfProduct
                 , "requested" .= lfRequested
                 , "actual" .= lfActual
-                , "kind" .= encodeKind lfKind
+                , "kind" .= locationKindCode lfKind
                 ]
         encodeUnresolved LocationUnresolved{luProduct, luRequested, luReason} =
             A.object
@@ -362,11 +362,6 @@ instance ToJSON DatabaseSetupInfo where
                 , "requested" .= luRequested
                 , "reason" .= luReason
                 ]
-        encodeKind :: LocationKind -> Text
-        encodeKind ExactLoc = "exact"
-        encodeKind ParentLoc = "parent"
-        encodeKind GlobalLoc = "global"
-        encodeKind UnrelatedLoc = "unrelated"
         encodeCandidate (path, fmt, cnt) =
             A.object
                 ["path" .= path, "format" .= fmt, "fileCount" .= cnt]

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -887,6 +887,16 @@ data LocationKind
       UnrelatedLoc
     deriving (Show, Eq, Generic, NFData, Store)
 
+{- | Stable lowercase wire code for a 'LocationKind'. Single source of truth
+shared by the JSON encoder and the human-readable rejection reason, so the UI
+never sees raw Haskell constructor names like @"ParentLoc"@.
+-}
+locationKindCode :: LocationKind -> Text
+locationKindCode ExactLoc = "exact"
+locationKindCode ParentLoc = "parent"
+locationKindCode GlobalLoc = "global"
+locationKindCode UnrelatedLoc = "unrelated"
+
 -- | A product whose supplier was found at a wider geography than requested.
 data LocationFallback = LocationFallback
     { lfProduct :: !Text

--- a/test/CrossLinkingSpec.hs
+++ b/test/CrossLinkingSpec.hs
@@ -329,6 +329,51 @@ spec = do
             it (label ++ " — parent") $ acceptableLocation GeoParent hier req cand `shouldBe` expParent
             it (label ++ " — global") $ acceptableLocation GeoGlobal hier req cand `shouldBe` expGlobal
 
+    -- -----------------------------------------------------------------------
+    -- findSupplierInIndexedDBs — geography_policy enforcement
+    -- The SAMPLE.min3 fixture has "product Y" at GLO. Querying for FR
+    -- exercises each (policy, candidate-kind) decision: GLO accepts only
+    -- under GeoGlobal, and the rejection path must surface as
+    -- LocationRejectedByPolicy carrying the actual kind.
+    -- -----------------------------------------------------------------------
+    describe "findSupplierInIndexedDBs (geography policy)" $ do
+        let mkCtx policy idb =
+                LinkingContext
+                    { lcIndexedDatabases = [idb]
+                    , lcSynonymDB = emptySynonymDB
+                    , lcUnitConfig = defaultUnitConfig
+                    , lcThreshold = defaultLinkingThreshold
+                    , lcLocationHierarchy = locationHierarchy
+                    , lcGeographyPolicy = policy
+                    }
+
+        it "GeoGlobal accepts FR query against a GLO candidate" $ do
+            idb <- loadMin3IndexedDB
+            case findSupplierInIndexedDBs (mkCtx GeoGlobal idb) "product Y" "FR" "kg" of
+                CrossDBLinked _ _ _ _ _ loc _ -> loc `shouldBe` "GLO"
+                CrossDBNotLinked reason ->
+                    expectationFailure $ "Expected link under GeoGlobal but got: " ++ show reason
+
+        it "GeoExact rejects FR query against a GLO candidate with kind=GlobalLoc" $ do
+            idb <- loadMin3IndexedDB
+            case findSupplierInIndexedDBs (mkCtx GeoExact idb) "product Y" "FR" "kg" of
+                CrossDBNotLinked (LocationRejectedByPolicy req actLoc kind) -> do
+                    req `shouldBe` "FR"
+                    actLoc `shouldBe` "GLO"
+                    kind `shouldBe` GlobalLoc
+                CrossDBNotLinked reason ->
+                    expectationFailure $ "Expected LocationRejectedByPolicy but got: " ++ show reason
+                CrossDBLinked{} -> expectationFailure "Expected rejection under GeoExact"
+
+        it "GeoParent also rejects a GLO candidate (parent-only does not include global)" $ do
+            idb <- loadMin3IndexedDB
+            case findSupplierInIndexedDBs (mkCtx GeoParent idb) "product Y" "FR" "kg" of
+                CrossDBNotLinked (LocationRejectedByPolicy _ _ kind) ->
+                    kind `shouldBe` GlobalLoc
+                CrossDBNotLinked reason ->
+                    expectationFailure $ "Expected LocationRejectedByPolicy GlobalLoc but got: " ++ show reason
+                CrossDBLinked{} -> expectationFailure "Expected rejection under GeoParent"
+
 -- ---------------------------------------------------------------------------
 -- Helper: load SAMPLE.min3 as IndexedDatabase
 -- ---------------------------------------------------------------------------


### PR DESCRIPTION
Post-merge follow-up to PR #80.

## Summary

- Introduce `Types.locationKindCode` as the single source of truth for the lowercase wire codes (`exact` / `parent` / `global` / `unrelated`). `Database.Loader` was composing `LocationUnresolved.reason` via `T.pack (show kind)`, leaking raw constructor names (`"ParentLoc"`) into the JSON consumed by the setup view; `Database.Manager` re-implemented the same mapping locally as `encodeKind`. Both now share the helper.
- Make the `LinkBlocker` case in `findExchangeCrossDBLink` exhaustive — the wildcard branch silently covered `NoNameMatch` and `UnitIncompatible`, hiding any future constructor from `-Wincomplete-patterns`.
- Fix the OpenAPI schema for `LocationKind`: the generic instance advertised `ExactLoc / ParentLoc / GlobalLoc / UnrelatedLoc`, but the hand-rolled JSON emits the lowercase form. A manual `ToSchema` now enumerates the four wire strings. Also switch `DatabaseSetupInfo` to `strippedSchemaOptions` so its schema field names (`name`, `locationFallbacks`, …) match the hand-rolled `toJSON` keys instead of the `dsi`-prefixed Haskell labels (pre-existing drift, but the right time to fix it).
- Surface the `LocationKind` in the `MissingSupplier.detail` string — `blockerToMissingSupplier` was throwing the kind away, so the setup view's missing-suppliers list could no longer tell a parent fallback from a global one.
- Add three integration tests through `findSupplierInIndexedDBs` exercising the three policies against a GLO candidate, covering the rejection path and the `LocationRejectedByPolicy` payload that the setup view consumes.

## Test plan

- [x] `cabal test` — 928 examples, 0 failures (3 new + the 925 already in main)
- [x] `cabal build` clean (only pre-existing hints unrelated to this diff)