### PR TITLE
fix(simapro): expose split-location products to cross-DB linker

### DIFF
--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -76,6 +76,7 @@ import SynonymDB (SynonymDB, lookupSynonymGroup, normalizeName)
 import Types (
     Activity (..),
     Database (..),
+    Exchange,
     GeographyPolicy (..),
     LinkBlocker (..),
     LocationKind (..),
@@ -83,6 +84,7 @@ import Types (
     TechnosphereFlow (..),
     exchangeFlowId,
     exchangeIsReference,
+    exchangeLocation,
     exchanges,
     getActivity,
  )
@@ -335,11 +337,12 @@ lives in `sdbTechFlows`.
 -}
 buildSupplierEntries :: SimpleDatabase -> [(Text, SupplierEntry)]
 buildSupplierEntries db =
-    [ (tfName flow, SupplierEntry actUUID prodUUID (activityLocation act) (activityUnit act) (tfName flow))
+    [ (tfName flow, SupplierEntry actUUID prodUUID loc (activityUnit act) (tfName flow))
     | ((actUUID, prodUUID), act) <- M.toList (sdbActivities db)
     , ex <- exchanges act
     , exchangeIsReference ex
     , Just flow <- [M.lookup (exchangeFlowId ex) (sdbTechFlows db)]
+    , loc <- supplierLocations act ex
     ]
 
 {- | Build an indexed database from a full Database (used when loading from cache)
@@ -376,13 +379,29 @@ buildIndexedDatabaseFromDB dbName synDB db =
 -}
 buildSupplierEntriesFromDB :: Database -> [(Text, SupplierEntry)]
 buildSupplierEntriesFromDB db =
-    [ (tfName flow, SupplierEntry actUUID prodUUID (activityLocation act) (activityUnit act) (tfName flow))
+    [ (tfName flow, SupplierEntry actUUID prodUUID loc (activityUnit act) (tfName flow))
     | (pid, (actUUID, prodUUID)) <- zip ([0 ..] :: [Int]) (V.toList (dbProcessIdTable db))
     , Just act <- [getActivity db (fromIntegral pid)]
     , ex <- exchanges act
     , exchangeIsReference ex
     , Just flow <- [M.lookup (exchangeFlowId ex) (dbTechFlows db)]
+    , loc <- supplierLocations act ex
     ]
+
+{- | Locations under which an activity should be indexed as a supplier.
+
+Always includes 'activityLocation'. Adds the reference exchange's
+'techLocation' when it is non-empty and distinct — this surfaces SimaPro
+products whose Products row declares a wider geographic scope than the
+enclosing Process name (typically WFLDB: process @ /CH, product @ /GLO).
+-}
+supplierLocations :: Activity -> Exchange -> [Text]
+supplierLocations act ex =
+    let actLoc = activityLocation act
+        exLoc = exchangeLocation ex
+     in if not (T.null exLoc) && exLoc /= actLoc
+            then [actLoc, exLoc]
+            else [actLoc]
 
 {- | Find a supplier across all loaded databases (using pre-built indexes)
 This is the fast O(1) lookup version

--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -37,6 +37,8 @@ module Database.CrossLinking (
     -- * Index Building
     buildIndexedDatabase,
     buildIndexedDatabaseFromDB,
+    buildSupplierEntries,
+    supplierLocations,
 
     -- * Main Functions
     findSupplierAcrossDatabases,
@@ -394,6 +396,9 @@ Always includes 'activityLocation'. Adds the reference exchange's
 'techLocation' when it is non-empty and distinct — this surfaces SimaPro
 products whose Products row declares a wider geographic scope than the
 enclosing Process name (typically WFLDB: process @ /CH, product @ /GLO).
+
+Design note: the activity table stays at 'activityLocation' (honest about
+data-collection provenance); only the cross-DB lookup gets the alias.
 -}
 supplierLocations :: Activity -> Exchange -> [Text]
 supplierLocations act ex =

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -917,7 +917,7 @@ unknown-unit errors with a clear message).
 -}
 productToExchange :: UnitConversion.UnitConfig -> M.Map Text Double -> Bool -> ProductRow -> (Exchange, TechnosphereFlow, Unit)
 productToExchange unitCfg env isRef ProductRow{..} =
-    let cleanName = fst (extractLocation prName)
+    let (cleanName, prodRowLoc) = extractLocation prName
         rawAmount = resolveAmount env prAmountRaw prAmount
         (effUnitName, amount) =
             if isRef
@@ -935,7 +935,13 @@ productToExchange unitCfg env isRef ProductRow{..} =
                 , techRole = if isRef then ReferenceProduct else Coproduct
                 , techActivityLinkId = UUID.nil
                 , techProcessLinkId = Nothing
-                , techLocation = ""
+                , -- Preserve the location encoded on the Products row (e.g.
+                  -- WFLDB writes "Product (WFLDB)/m2/GLO U" while the
+                  -- enclosing Process name may be "/CH"). The activity's
+                  -- own location is set independently in makeActivity; this
+                  -- field lets the cross-DB supplier index expose the
+                  -- product under its declared geographic scope as well.
+                  techLocation = prodRowLoc
                 , techComment = Nothing
                 , techPedigree = Nothing
                 }

--- a/test/CrossLinkingSpec.hs
+++ b/test/CrossLinkingSpec.hs
@@ -3,11 +3,16 @@
 module CrossLinkingSpec (spec) where
 
 import Control.Monad (forM_)
+import Data.List (sort)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.UUID as UUID
 import Database.CrossLinking
 import Database.Loader (loadDatabase)
 import SynonymDB (buildFromPairs, emptySynonymDB)
 import Test.Hspec
+import Types
 import UnitConversion (defaultUnitConfig)
 
 spec :: Spec
@@ -373,6 +378,96 @@ spec = do
                 CrossDBNotLinked reason ->
                     expectationFailure $ "Expected LocationRejectedByPolicy GlobalLoc but got: " ++ show reason
                 CrossDBLinked{} -> expectationFailure "Expected rejection under GeoParent"
+
+    -- -----------------------------------------------------------------------
+    -- supplierLocations & buildSupplierEntries — split-location indexing.
+    -- Guards the WFLDB case where Process name @ /CH but Products row @ /GLO:
+    -- the supplier index must expose the product under both locations so a
+    -- consumer requesting it at GLO can still resolve it cross-DB.
+    -- -----------------------------------------------------------------------
+    describe "supplierLocations" $ do
+        it "returns one entry when the exchange has no location" $
+            supplierLocations (mkActivityAt "CH") (mkRefExchangeAt "") `shouldBe` ["CH"]
+
+        it "returns one entry when activity and exchange locations match" $
+            supplierLocations (mkActivityAt "CH") (mkRefExchangeAt "CH") `shouldBe` ["CH"]
+
+        it "returns both entries when activity and exchange locations differ" $
+            supplierLocations (mkActivityAt "CH") (mkRefExchangeAt "GLO") `shouldBe` ["CH", "GLO"]
+
+    describe "buildSupplierEntries (split-location)" $ do
+        it "indexes a product at both activity and exchange locations when they differ" $ do
+            let entries = buildSupplierEntries (mkSplitLocationDB "CH" "GLO")
+            sort [seLocation se | (_, se) <- entries] `shouldBe` ["CH", "GLO"]
+
+        it "indexes a product at the activity location only when the exchange location is empty" $ do
+            let entries = buildSupplierEntries (mkSplitLocationDB "CH" "")
+            [seLocation se | (_, se) <- entries] `shouldBe` ["CH"]
+
+        it "indexes a product once when activity and exchange locations match" $ do
+            let entries = buildSupplierEntries (mkSplitLocationDB "CH" "CH")
+            [seLocation se | (_, se) <- entries] `shouldBe` ["CH"]
+
+-- ---------------------------------------------------------------------------
+-- Fixtures for supplierLocations / buildSupplierEntries tests
+-- ---------------------------------------------------------------------------
+
+mkActivityAt :: Text -> Activity
+mkActivityAt loc =
+    Activity
+        { activityName = "test product"
+        , activityDescription = []
+        , activitySynonyms = M.empty
+        , activityClassification = M.empty
+        , activityLocation = loc
+        , activityUnit = "kg"
+        , exchanges = []
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
+        }
+
+mkRefExchangeAt :: Text -> Exchange
+mkRefExchangeAt loc =
+    TechnosphereExchange
+        { techFlowId = flowUUID
+        , techAmount = 1.0
+        , techUnitId = UUID.nil
+        , techRole = ReferenceProduct
+        , techActivityLinkId = UUID.nil
+        , techProcessLinkId = Nothing
+        , techLocation = loc
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+  where
+    flowUUID = read "aaaaaaaa-0000-0000-0000-000000000001"
+
+-- | One-activity SimpleDatabase with a single reference exchange. The
+-- activity is anchored at @actLoc@; the reference exchange carries @exLoc@.
+mkSplitLocationDB :: Text -> Text -> SimpleDatabase
+mkSplitLocationDB actLoc exLoc =
+    let flowUUID = read "aaaaaaaa-0000-0000-0000-000000000001"
+        actUUID = read "cccccccc-0000-0000-0000-000000000001"
+        ex = (mkRefExchangeAt exLoc){techFlowId = flowUUID}
+        act = (mkActivityAt actLoc){exchanges = [ex]}
+        flow =
+            TechnosphereFlow
+                { tfId = flowUUID
+                , tfName = "test product"
+                , tfUnitId = UUID.nil
+                , tfSynonyms = M.empty
+                , tfCAS = Nothing
+                , tfSubstanceId = Nothing
+                }
+     in SimpleDatabase
+            { sdbActivities = M.singleton (actUUID, flowUUID) act
+            , sdbTechFlows = M.singleton flowUUID flow
+            , sdbBioFlows = M.empty
+            , sdbWasteFlows = M.empty
+            , sdbUnits = M.empty
+            }
 
 -- ---------------------------------------------------------------------------
 -- Helper: load SAMPLE.min3 as IndexedDatabase

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -999,6 +999,23 @@ spec = do
             let a = head activities
             activityLocation a `shouldBe` "GLO"
 
+        -- WFLDB convention: the Process name carries the data-collection
+        -- country (/CH) while the Products row carries the geographic scope
+        -- of the product itself (/GLO U). The activity stays at CH (truthful
+        -- about provenance) but the reference exchange must preserve GLO so
+        -- the cross-DB supplier index can expose this product to consumers
+        -- requesting a global proxy.
+        it "preserves Products-row location on reference exchange when it differs from activity location" $ do
+            (activities, _, _, _, _) <-
+                parseProductsCSV
+                    "Horticultural fleece, at plant (WFLDB)/m2/CH"
+                    "Horticultural fleece, at plant (WFLDB)/m2/GLO U;m2;1;100;not defined;material;"
+            length activities `shouldBe` 1
+            let act = head activities
+            activityLocation act `shouldBe` "CH"
+            let refExs = [techLocation e | e@TechnosphereExchange{} <- exchanges act, exchangeIsReference e]
+            refExs `shouldBe` ["GLO"]
+
     describe "SimaPro comma CSV separator" $ do
         it "parses comma-separated CSV" $ do
             (activities, _, _, _, _) <- parseCommaCSV
@@ -1136,6 +1153,36 @@ spec = do
 parseSectionCSV :: [BS.ByteString] -> IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)
 parseSectionCSV sectionLines =
     parseNamedCSV "Test process" sectionLines
+
+-- | Build a minimal process CSV with a custom Process name and Products row.
+parseProductsCSV :: BS.ByteString -> BS.ByteString -> IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)
+parseProductsCSV procName productsRow =
+    withSystemTempFile "products-test.csv" $ \path handle -> do
+        let content =
+                BS.intercalate "\r\n" $
+                    [ "{SimaPro 9.6.0.1}"
+                    , "{CSV separator: semicolon}"
+                    , "{Decimal separator: .}"
+                    , ""
+                    , "Process"
+                    , ""
+                    , "Category type"
+                    , "material"
+                    , ""
+                    , "Process name"
+                    , procName
+                    , ""
+                    , "Type"
+                    , "Unit process"
+                    , ""
+                    , "Products"
+                    , productsRow
+                    , ""
+                    , "End"
+                    ]
+        BS.hPut handle content
+        hClose handle
+        parseSimaProCSV defaultUnitConfig path
 
 parseNamedCSV :: BS.ByteString -> [BS.ByteString] -> IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)
 parseNamedCSV procName sectionLines =


### PR DESCRIPTION
## Problem

WFLDB uses two different locations on a single process: the **Process name** carries the data-collection country, while the **Products row** carries the product's geographic scope. Example:

    Process name:  Horticultural fleece, at plant (WFLDB)/m2/CH
    Products row:  Horticultural fleece, at plant (WFLDB)/m2/GLO U

The SimaPro parser anchored the activity to `/CH` (truthful about provenance) but **discarded the `/GLO` from the Products row**. The cross-DB supplier index then exposed the product only at `CH`. Any consumer requesting it at `GLO` failed with `LocationUnavailable` — even though WFLDB's authors had explicitly tagged it as a global proxy.

In Ecoplus this surfaced as three permanently-unresolved WFLDB inputs:

- `Horticultural fleece, at plant (WFLDB)/m2` @ GLO
- `Kerosene, burned in airplane (WFLDB)/kg` @ GLO
- `Petrol, unleaded, burned in motor mower (WFLDB)/kg` @ GLO

## Fix

Two minimal changes:

1. **Parser** (`src/SimaPro/Parser.hs`) — `productToExchange` now sets `techLocation` to the Products-row location (was unconditionally `""`). `activityLocation` is unchanged.
2. **Indexer** (`src/Database/CrossLinking.hs`) — `buildSupplierEntries` and `buildSupplierEntriesFromDB` emit one extra `SupplierEntry` at the reference exchange's `techLocation` when it differs from `activityLocation`, pointing at the same activity UUID. New `supplierLocations` helper encapsulates the rule.

The activity table is intentionally untouched: `/api/v1/db/wfldb/activities` still reports the data-collection country, which is honest. Only the cross-DB lookup table gets the alias.

## Cache compatibility

No schema change — just a non-empty value where `""` used to live. Old binaries can read new caches; new binaries can read old caches, but the fix only takes effect once the cache is rebuilt from source.

## Test plan

- [x] `cabal test` — 1053/1053 pass (+1 new regression test asserting the parser preserves the Products-row location on the reference exchange when it differs from the activity location).
- [x] End-to-end on a real Ecoplus upload staged against fresh WFLDB:
  - before: `crossDBLinks=6793`, `unresolvedLinks=9677`, the 3 WFLDB-GLO products in `missingSuppliers`/`locationUnresolved`
  - after: `crossDBLinks=6796` (+3), `unresolvedLinks=9674` (−3), all 3 absent from both lists, resolved as `ExactLoc` links
- [x] `/api/v1/db/wfldb/activities?name=Horticultural%20fleece...` still returns `location: CH` (no regression on the activity-facing API).