### PR TITLE
feat(mcp): columnar score_activities + market hint + web_url tips

### DIFF
--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -17,7 +17,6 @@ import qualified Data.ByteString.Lazy as BSL
 import Data.IORef
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe, isNothing, mapMaybe)
-import Data.Ord (comparing)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
@@ -35,8 +34,9 @@ import Database.Manager (DatabaseManager (..), LoadedDatabase (..), getDatabase)
 import qualified Database.Manager as DM
 
 import qualified API.BatchImpacts as BI
+import API.MCP.Columnar (resolveSingleScoringSet, toColumnarBatch)
 import API.MCP.Enrich (addWebUrl, attachMarketHintByName, encodeSegment, filterScoringSets, scoreActivityWebUrl, slimLCIAPanel)
-import API.Types (ActivityForAPI (..), ActivityInfo (..), BatchImpactsEntry (..), BatchImpactsResponse (..), ClassificationSystem (..), ExchangeWithUnit (..), InventoryExport (..), InventoryFlowDetail (..), LCIABatchResult (..), LCIAResult (..), Perturbation (..), ScoringIndicator (..), Substitution (..), SubstitutionRequest (..))
+import API.Types (ActivityForAPI (..), ActivityInfo (..), ClassificationSystem (..), ExchangeWithUnit (..), InventoryExport (..), InventoryFlowDetail (..), Perturbation (..), Substitution (..), SubstitutionRequest (..))
 import Control.Monad (unless)
 import qualified Data.List as L
 import Matrix (applyBiosphereMatrix)
@@ -1871,142 +1871,7 @@ defensive shape as 'configuredScoringSetNames'.
 configuredScoringSets :: DatabaseManager -> Text -> IO [ScoringSet]
 configuredScoringSets dbm collName = do
     loaded <- readTVarIO (dmLoadedMethods dbm)
-    pure $ case M.lookup collName loaded of
-        Just mc -> mcScoringSets mc
-        Nothing -> []
-
-{- | Pick the single 'ScoringSet' the columnar 'score_activities' response
-will project against. The columnar shape covers one set per call (one
-unit, one list of indicator columns), so:
-
-  * Caller passes one name in 'scoring_sets' → that one (validated).
-  * Caller passes none, exactly one set is configured → that one.
-  * Caller passes none, several sets are configured → error listing the
-    options. We don't pick arbitrarily to avoid silent ambiguity.
-  * Caller passes several names → error: only one is supported.
-  * No sets configured at all → error.
--}
-resolveSingleScoringSet :: [Text] -> [ScoringSet] -> Either Text ScoringSet
-resolveSingleScoringSet wantedNames configured = case wantedNames of
-    [] -> case configured of
-        [] -> Left "No scoring sets configured on this collection."
-        [s] -> Right s
-        ss ->
-            Left $
-                "Multiple scoring sets are configured ("
-                    <> T.intercalate ", " (map ssName ss)
-                    <> "); pass scoring_sets: [\"<one>\"] to pick one. score_activities returns a columnar shape that covers a single scoring set per call."
-    [w] -> case L.find (\s -> ssName s == w) configured of
-        Just s -> Right s
-        Nothing ->
-            Left $
-                "Unknown scoring set: "
-                    <> w
-                    <> ". Configured on this collection: "
-                    <> T.intercalate ", " (map ssName configured)
-    ws ->
-        Left $
-            "score_activities accepts at most one scoring set in 'scoring_sets'; got ["
-                <> T.intercalate ", " ws
-                <> "]. The columnar response shape covers a single scoring set per call."
-
-{- | Project a 'BatchImpactsResponse' against one chosen 'ScoringSet' into
-the columnar JSON shape:
-
-@
-{ "scoringSet":     "PEF"
-, "scoringUnit":    "µPts PEF"
-, "functionalUnit": "1.00 cubic meter of ..."
-, "columns": ["name","processId","web_url","total","acd","cch",...]
-, "rows":    [[...], [...], ...]
-, "notFound": [...]
-, "invalid":  [...]
-}
-@
-
-Once per batch the metadata (set name, unit, functional unit) is hoisted
-to the top; the 2D 'rows' array carries one scalar per cell. Saves the
-N×M repetition of JSON keys the previous row-shaped payload paid for.
-
-A row's @total@ cell is the @total@ score from @ssScores@ when present;
-otherwise null. An indicator cell is the @siValue@ of the matching entry
-in @lbrScoringIndicators[setName]@; missing keys land as null.
-
-With @summaryOnly = True@, the per-indicator columns collapse to a
-single @dominantIndicator@ column shaped @\"key:share_pct\"@ (e.g.
-@\"ldu:82.3\"@) — the variable with the largest absolute share of the
-total. Useful for ranking large batches before drilling into one PID
-with @score_activity@.
--}
-toColumnarBatch :: Bool -> Text -> Text -> Text -> ScoringSet -> BatchImpactsResponse -> Value
-toColumnarBatch summaryOnly baseUrl dbName coll ss bir =
-    object
-        [ "scoringSet" .= ssName ss
-        , "scoringUnit" .= scoringUnit
-        , "functionalUnit" .= functionalUnit
-        , "columns" .= columns
-        , "rows" .= map entryRow (birResults bir)
-        , "notFound" .= birNotFound bir
-        , "invalid" .= birInvalid bir
-        ]
-  where
-    setName = ssName ss
-    fixedColumns :: [Text]
-    fixedColumns = ["name", "processId", "web_url", "total"]
-    -- Union of primitive and computed variables — same shape the
-    -- engine populates 'lbrScoringIndicators' with. Sorted so column
-    -- order is stable across calls.
-    indicatorKeys :: [Text]
-    indicatorKeys = L.sort (M.keys (ssVariables ss) <> M.keys (ssComputed ss))
-    columns :: [Text]
-    columns
-        | summaryOnly = fixedColumns ++ ["dominantIndicator"]
-        | otherwise = fixedColumns ++ indicatorKeys
-    scoringUnit = case birResults bir of
-        e : _ -> M.findWithDefault (ssUnit ss) setName (lbrScoringUnits (bieImpacts e))
-        [] -> ssUnit ss
-    functionalUnit = case birResults bir of
-        e : _ -> case lbrResults (bieImpacts e) of
-            r : _ -> lrFunctionalUnit r
-            [] -> ""
-        [] -> ""
-    entryRow :: BatchImpactsEntry -> Value
-    entryRow e =
-        let url = scoreActivityWebUrl baseUrl dbName (bieProcessId e) coll
-            lbr = bieImpacts e
-            scoreMap = M.findWithDefault M.empty setName (lbrScoringResults lbr)
-            indMap = M.findWithDefault M.empty setName (lbrScoringIndicators lbr)
-            totalRaw = M.lookup "total" scoreMap
-            total = maybe Null toJSON totalRaw
-            indVal k = maybe Null (toJSON . siValue) (M.lookup k indMap)
-            tail_ =
-                if summaryOnly
-                    then [dominantIndicatorCell totalRaw indMap]
-                    else map indVal indicatorKeys
-         in toJSON $
-                [ toJSON (bieActivityName e)
-                , toJSON (bieProcessId e)
-                , toJSON url
-                , total
-                ]
-                    ++ tail_
-
-{- | Format the dominant indicator of a row as @"key:share_pct"@. Returns
-'Null' when the row has no total, the total is zero (share is
-undefined), or the indicator map is empty.
--}
-dominantIndicatorCell :: Maybe Double -> M.Map Text ScoringIndicator -> Value
-dominantIndicatorCell mTotal indMap
-    | Just t <- mTotal
-    , t /= 0
-    , not (M.null indMap) =
-        let (k, ind) =
-                L.maximumBy
-                    (comparing (abs . siValue . snd))
-                    (M.toList indMap)
-            share = abs (siValue ind) / abs t * 100
-         in toJSON (k <> ":" <> T.pack (showFFloat (Just 1) share ""))
-    | otherwise = Null
+    pure $ maybe [] mcScoringSets (M.lookup collName loaded)
 
 {- | Handler for the 'score_activities' MCP tool.
 

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -1840,29 +1840,29 @@ callScoreActivity dbManager baseUrl rid args =
                     Left e -> ExceptT $ pure (Left (batchErrorMsg e))
                     Right lbr -> do
                         configured <- liftIO $ configuredScoringSetNames dbManager coll
-                        actName <- liftIO $ lookupActivityName dbManager dbName pidText
+                        mActName <- liftIO $ lookupActivityName dbManager dbName pidText
                         let topUrl = scoreActivityWebUrl baseUrl dbName pidText coll
                             enriched =
-                                attachMarketHintByName actName $
+                                maybe id attachMarketHintByName mActName $
                                     addWebUrl
                                         topUrl
                                         (slimLCIAPanel (toJSON lbr))
                         ExceptT $ pure (toolSuccessJson rid <$> filterScoringSets configured wantedSets enriched)
             )
 
-{- | Resolve the activity name for a (db, processId) pair. Returns "" if
-the database is not loaded or the PID does not resolve — the caller uses
-the name only as input to 'attachMarketHintByName', which is itself a
-no-op on empty / non-market strings.
+{- | Resolve the activity name for a (db, processId) pair. 'Nothing' when
+the database is not loaded or the PID does not resolve — callers fold
+this through 'maybe id attachMarketHintByName', so a missing name
+simply skips the hint without making up a default.
 -}
-lookupActivityName :: DatabaseManager -> Text -> Text -> IO Text
+lookupActivityName :: DatabaseManager -> Text -> Text -> IO (Maybe Text)
 lookupActivityName dbManager dbName pidText = do
     mLd <- getDatabase dbManager dbName
     pure $ case mLd of
         Just ld -> case Service.resolveActivityAndProcessId (ldDatabase ld) pidText of
-            Right (_, act) -> activityName act
-            Left _ -> ""
-        Nothing -> ""
+            Right (_, act) -> Just (activityName act)
+            Left _ -> Nothing
+        Nothing -> Nothing
 
 {- | Return every 'ScoringSet' configured on a collection (full record, not
 just names). Empty list when the collection is not loaded — the same

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -17,6 +17,7 @@ import qualified Data.ByteString.Lazy as BSL
 import Data.IORef
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe, isNothing, mapMaybe)
+import Data.Ord (comparing)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
@@ -34,8 +35,8 @@ import Database.Manager (DatabaseManager (..), LoadedDatabase (..), getDatabase)
 import qualified Database.Manager as DM
 
 import qualified API.BatchImpacts as BI
-import API.MCP.Enrich (addWebUrl, encodeSegment, filterScoringSets, filterScoringSetsBatch, scoreActivityWebUrl, slimLCIAPanel, summarizeBatchResults)
-import API.Types (ActivityForAPI (..), ActivityInfo (..), ClassificationSystem (..), ExchangeWithUnit (..), InventoryExport (..), InventoryFlowDetail (..), Perturbation (..), Substitution (..), SubstitutionRequest (..))
+import API.MCP.Enrich (addWebUrl, attachMarketHintByName, encodeSegment, filterScoringSets, scoreActivityWebUrl, slimLCIAPanel)
+import API.Types (ActivityForAPI (..), ActivityInfo (..), BatchImpactsEntry (..), BatchImpactsResponse (..), ClassificationSystem (..), ExchangeWithUnit (..), InventoryExport (..), InventoryFlowDetail (..), LCIABatchResult (..), LCIAResult (..), Perturbation (..), ScoringIndicator (..), Substitution (..), SubstitutionRequest (..))
 import Control.Monad (unless)
 import qualified Data.List as L
 import Matrix (applyBiosphereMatrix)
@@ -231,6 +232,7 @@ handleInitialize req =
                         , "VoLCA answers both LCIA scores (climate change, acidification, eutrophication, water scarcity, land use…) AND raw inventory flows (land occupation, water withdrawal, resource depletion, biosphere emissions). Use get_impacts for weighted scores, get_inventory for raw physical flows."
                         , "Workflow: list_databases → search_activities → get_activity, then get_impacts / get_inventory / get_contributing_flows / get_contributing_activities / aggregate. Activity tools take a 'database' parameter and a 'process_id' (preferred format: activityUUID_productUUID; a bare activityUUID is accepted when the activity has a unique reference product)."
                         , "Use list_methods for available LCIA methods."
+                        , "When showing activities, impacts, or contributions to a human, render the 'web_url' field from each result as a clickable markdown link — never show bare process IDs as a final answer."
                         ]
                 ]
 
@@ -574,13 +576,21 @@ callGetActivity rid args (db, _) =
                 case Service.getActivityInfo defaultUnitConfig db pid of
                     Left err -> return $ toolError rid (T.pack $ show err)
                     Right val
-                        | noFilters -> return $ toolSuccessJson rid val
+                        | noFilters -> return $ toolSuccessJson rid (hintFor pid val)
                         | otherwise -> case fromJSON val of
-                            Error _ -> return $ toolSuccessJson rid val
+                            Error _ -> return $ toolSuccessJson rid (hintFor pid val)
                             Success ai ->
                                 let filtered = ai{piActivity = (piActivity ai){pfaExchanges = filter matchExchange (pfaExchanges (piActivity ai))}}
-                                 in return $ toolSuccessJson rid (toJSON filtered)
+                                 in return $ toolSuccessJson rid (hintFor pid (toJSON filtered))
   where
+    -- Surface a hint when the resolved process is a "market for ..." activity:
+    -- markets aggregate multiple suppliers and are not source ICVs. The lookup
+    -- is in-memory and cheap; on resolution failure we silently skip the hint
+    -- because the underlying handler has already reported the resolution
+    -- failure path via 'getActivityInfo'.
+    hintFor pid = case Service.resolveActivityAndProcessId db pid of
+        Right (_, act) -> attachMarketHintByName (activityName act)
+        Left _ -> id
     exchangeType = textArg "exchange_type" args
     flowFilter = textArg "flow" args
     isInputFilter = boolArg "is_input" args
@@ -1034,30 +1044,31 @@ callGetImpacts dbManager baseUrl rid args =
                         ]
                 pure $
                     toolSuccessJson rid $
-                        object $
-                            [ "method" .= methodName method
-                            , "category" .= methodCategory method
-                            , "score" .= score
-                            , "unit" .= methodUnit method
-                            , "functional_unit" .= functionalUnit
-                            , "mapped_flows" .= (msTotal stats - msUnmatched stats)
-                            , "has_negative_contributions" .= hasNeg
-                            , "web_url" .= webUrl
-                            , "top_flows"
-                                .= [ object
-                                        [ "flow_name" .= bfName f
-                                        , "contribution" .= c
-                                        , "contribution_percent" .= (if score /= 0 then c / score * 100 else 0 :: Double)
-                                        , "flow_id" .= UUID.toText (bfId f)
-                                        , "category" .= bfCompartmentName f
-                                        , "compartment" .= bfCompartmentSub f
-                                        , "cf_value" .= cfVal
-                                        , "flow_unit" .= getUnitNameForBioFlow mUnits f
-                                        ]
-                                   | (f, cfVal, c) <- topFlows
-                                   ]
-                            ]
-                                ++ (if fromMaybe False (boolArg "include_diagnostics" args) then diagnosticsFields else [])
+                        attachMarketHintByName (activityName (raActivity ra)) $
+                            object $
+                                [ "method" .= methodName method
+                                , "category" .= methodCategory method
+                                , "score" .= score
+                                , "unit" .= methodUnit method
+                                , "functional_unit" .= functionalUnit
+                                , "mapped_flows" .= (msTotal stats - msUnmatched stats)
+                                , "has_negative_contributions" .= hasNeg
+                                , "web_url" .= webUrl
+                                , "top_flows"
+                                    .= [ object
+                                            [ "flow_name" .= bfName f
+                                            , "contribution" .= c
+                                            , "contribution_percent" .= (if score /= 0 then c / score * 100 else 0 :: Double)
+                                            , "flow_id" .= UUID.toText (bfId f)
+                                            , "category" .= bfCompartmentName f
+                                            , "compartment" .= bfCompartmentSub f
+                                            , "cf_value" .= cfVal
+                                            , "flow_unit" .= getUnitNameForBioFlow mUnits f
+                                            ]
+                                       | (f, cfVal, c) <- topFlows
+                                       ]
+                                ]
+                                    ++ (if fromMaybe False (boolArg "include_diagnostics" args) then diagnosticsFields else [])
             )
 
 {- | Handler for the 'compute_sensitivity' MCP tool. Mirrors the REST
@@ -1822,26 +1833,185 @@ callScoreActivity dbManager baseUrl rid args =
                     Left e -> ExceptT $ pure (Left (batchErrorMsg e))
                     Right lbr -> do
                         configured <- liftIO $ configuredScoringSetNames dbManager coll
+                        actName <- liftIO $ lookupActivityName dbManager dbName pidText
                         let topUrl = scoreActivityWebUrl baseUrl dbName pidText coll
                             enriched =
-                                addWebUrl
-                                    topUrl
-                                    (slimLCIAPanel (toJSON lbr))
+                                attachMarketHintByName actName $
+                                    addWebUrl
+                                        topUrl
+                                        (slimLCIAPanel (toJSON lbr))
                         ExceptT $ pure (toolSuccessJson rid <$> filterScoringSets configured wantedSets enriched)
             )
+
+{- | Resolve the activity name for a (db, processId) pair. Returns "" if
+the database is not loaded or the PID does not resolve — the caller uses
+the name only as input to 'attachMarketHintByName', which is itself a
+no-op on empty / non-market strings.
+-}
+lookupActivityName :: DatabaseManager -> Text -> Text -> IO Text
+lookupActivityName dbManager dbName pidText = do
+    mLd <- getDatabase dbManager dbName
+    pure $ case mLd of
+        Just ld -> case Service.resolveActivityAndProcessId (ldDatabase ld) pidText of
+            Right (_, act) -> activityName act
+            Left _ -> ""
+        Nothing -> ""
+
+{- | Return every 'ScoringSet' configured on a collection (full record, not
+just names). Empty list when the collection is not loaded — the same
+defensive shape as 'configuredScoringSetNames'.
+-}
+configuredScoringSets :: DatabaseManager -> Text -> IO [ScoringSet]
+configuredScoringSets dbm collName = do
+    loaded <- readTVarIO (dmLoadedMethods dbm)
+    pure $ case M.lookup collName loaded of
+        Just mc -> mcScoringSets mc
+        Nothing -> []
+
+{- | Pick the single 'ScoringSet' the columnar 'score_activities' response
+will project against. The columnar shape covers one set per call (one
+unit, one list of indicator columns), so:
+
+  * Caller passes one name in 'scoring_sets' → that one (validated).
+  * Caller passes none, exactly one set is configured → that one.
+  * Caller passes none, several sets are configured → error listing the
+    options. We don't pick arbitrarily to avoid silent ambiguity.
+  * Caller passes several names → error: only one is supported.
+  * No sets configured at all → error.
+-}
+resolveSingleScoringSet :: [Text] -> [ScoringSet] -> Either Text ScoringSet
+resolveSingleScoringSet wantedNames configured = case wantedNames of
+    [] -> case configured of
+        [] -> Left "No scoring sets configured on this collection."
+        [s] -> Right s
+        ss ->
+            Left $
+                "Multiple scoring sets are configured ("
+                    <> T.intercalate ", " (map ssName ss)
+                    <> "); pass scoring_sets: [\"<one>\"] to pick one. score_activities returns a columnar shape that covers a single scoring set per call."
+    [w] -> case L.find (\s -> ssName s == w) configured of
+        Just s -> Right s
+        Nothing ->
+            Left $
+                "Unknown scoring set: "
+                    <> w
+                    <> ". Configured on this collection: "
+                    <> T.intercalate ", " (map ssName configured)
+    ws ->
+        Left $
+            "score_activities accepts at most one scoring set in 'scoring_sets'; got ["
+                <> T.intercalate ", " ws
+                <> "]. The columnar response shape covers a single scoring set per call."
+
+{- | Project a 'BatchImpactsResponse' against one chosen 'ScoringSet' into
+the columnar JSON shape:
+
+@
+{ "scoringSet":     "PEF"
+, "scoringUnit":    "µPts PEF"
+, "functionalUnit": "1.00 cubic meter of ..."
+, "columns": ["name","processId","web_url","total","acd","cch",...]
+, "rows":    [[...], [...], ...]
+, "notFound": [...]
+, "invalid":  [...]
+}
+@
+
+Once per batch the metadata (set name, unit, functional unit) is hoisted
+to the top; the 2D 'rows' array carries one scalar per cell. Saves the
+N×M repetition of JSON keys the previous row-shaped payload paid for.
+
+A row's @total@ cell is the @total@ score from @ssScores@ when present;
+otherwise null. An indicator cell is the @siValue@ of the matching entry
+in @lbrScoringIndicators[setName]@; missing keys land as null.
+
+With @summaryOnly = True@, the per-indicator columns collapse to a
+single @dominantIndicator@ column shaped @\"key:share_pct\"@ (e.g.
+@\"ldu:82.3\"@) — the variable with the largest absolute share of the
+total. Useful for ranking large batches before drilling into one PID
+with @score_activity@.
+-}
+toColumnarBatch :: Bool -> Text -> Text -> Text -> ScoringSet -> BatchImpactsResponse -> Value
+toColumnarBatch summaryOnly baseUrl dbName coll ss bir =
+    object
+        [ "scoringSet" .= ssName ss
+        , "scoringUnit" .= scoringUnit
+        , "functionalUnit" .= functionalUnit
+        , "columns" .= columns
+        , "rows" .= map entryRow (birResults bir)
+        , "notFound" .= birNotFound bir
+        , "invalid" .= birInvalid bir
+        ]
+  where
+    setName = ssName ss
+    fixedColumns :: [Text]
+    fixedColumns = ["name", "processId", "web_url", "total"]
+    -- Union of primitive and computed variables — same shape the
+    -- engine populates 'lbrScoringIndicators' with. Sorted so column
+    -- order is stable across calls.
+    indicatorKeys :: [Text]
+    indicatorKeys = L.sort (M.keys (ssVariables ss) <> M.keys (ssComputed ss))
+    columns :: [Text]
+    columns
+        | summaryOnly = fixedColumns ++ ["dominantIndicator"]
+        | otherwise = fixedColumns ++ indicatorKeys
+    scoringUnit = case birResults bir of
+        e : _ -> M.findWithDefault (ssUnit ss) setName (lbrScoringUnits (bieImpacts e))
+        [] -> ssUnit ss
+    functionalUnit = case birResults bir of
+        e : _ -> case lbrResults (bieImpacts e) of
+            r : _ -> lrFunctionalUnit r
+            [] -> ""
+        [] -> ""
+    entryRow :: BatchImpactsEntry -> Value
+    entryRow e =
+        let url = scoreActivityWebUrl baseUrl dbName (bieProcessId e) coll
+            lbr = bieImpacts e
+            scoreMap = M.findWithDefault M.empty setName (lbrScoringResults lbr)
+            indMap = M.findWithDefault M.empty setName (lbrScoringIndicators lbr)
+            totalRaw = M.lookup "total" scoreMap
+            total = maybe Null toJSON totalRaw
+            indVal k = maybe Null (toJSON . siValue) (M.lookup k indMap)
+            tail_ =
+                if summaryOnly
+                    then [dominantIndicatorCell totalRaw indMap]
+                    else map indVal indicatorKeys
+         in toJSON $
+                [ toJSON (bieActivityName e)
+                , toJSON (bieProcessId e)
+                , toJSON url
+                , total
+                ]
+                    ++ tail_
+
+{- | Format the dominant indicator of a row as @"key:share_pct"@. Returns
+'Null' when the row has no total, the total is zero (share is
+undefined), or the indicator map is empty.
+-}
+dominantIndicatorCell :: Maybe Double -> M.Map Text ScoringIndicator -> Value
+dominantIndicatorCell mTotal indMap
+    | Just t <- mTotal
+    , t /= 0
+    , not (M.null indMap) =
+        let (k, ind) =
+                L.maximumBy
+                    (comparing (abs . siValue . snd))
+                    (M.toList indMap)
+            share = abs (siValue ind) / abs t * 100
+         in toJSON (k <> ":" <> T.pack (showFFloat (Just 1) share ""))
+    | otherwise = Null
 
 {- | Handler for the 'score_activities' MCP tool.
 
 Ranks N activities against every method in a collection in one
-multi-RHS MUMPS solve plus parallel characterization, then strips each
-entry's @impacts@ subtree to its aggregates (single score,
-@scoringResults@, @scoringIndicators@, @scoringUnits@, hoisted
-@functionalUnit@). The per-method @results@ array is not emitted —
-callers needing per-method drill-down call 'score_activity' on a
-specific process_id. Each successful entry carries a top-level
-@web_url@ to its impacts page; the same URL is replicated inside the
-@impacts@ subtree. Unresolved process IDs land in @not_found@ /
-@invalid@ of the response, not as a 'BatchError'.
+multi-RHS MUMPS solve plus parallel characterization, then projects the
+result against a single 'ScoringSet' into a columnar JSON payload
+(@{scoringSet, scoringUnit, functionalUnit, columns, rows}@). The shape
+hoists the constant metadata once and packs each activity as a flat
+array of scalars — typically ~6× smaller than a row-shaped JSON for a
+batch of 24+ activities. Unresolved process IDs land in
+@notFound@ \/ @invalid@. The chosen scoring set is required to be
+unambiguous; see 'resolveSingleScoringSet' for the rules.
 -}
 callScoreActivities :: DatabaseManager -> Text -> Value -> KeyMap Value -> IO Value
 callScoreActivities dbManager baseUrl rid args =
@@ -1852,13 +2022,13 @@ callScoreActivities dbManager baseUrl rid args =
                 coll <- ExceptT $ pure (requireText "collection" args)
                 pids <- ExceptT $ pure (parseArrayArg "process_ids" (Just "'process_ids' required (array of strings)") args :: Either Text [Text])
                 wantedSets <- ExceptT $ pure (parseArrayArg "scoring_sets" Nothing args :: Either Text [Text])
+                let summaryOnly = fromMaybe False (boolArg "summary_only" args)
+                configured <- liftIO $ configuredScoringSets dbManager coll
+                chosen <- ExceptT $ pure (resolveSingleScoringSet wantedSets configured)
                 res <- liftIO $ BI.runBatchImpacts dbManager dbName coll Nothing pids
                 case res of
                     Left e -> ExceptT $ pure (Left (batchErrorMsg e))
-                    Right bir -> do
-                        configured <- liftIO $ configuredScoringSetNames dbManager coll
-                        let summarized = summarizeBatchResults baseUrl dbName coll (toJSON bir)
-                        ExceptT $ pure (toolSuccessJson rid <$> filterScoringSetsBatch configured wantedSets summarized)
+                    Right bir -> pure (toolSuccessJson rid (toColumnarBatch summaryOnly baseUrl dbName coll chosen bir))
             )
 
 {- | Handler for the 'list_scoring_sets' MCP tool.

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -575,22 +575,29 @@ callGetActivity rid args (db, _) =
             Right _ ->
                 case Service.getActivityInfo defaultUnitConfig db pid of
                     Left err -> return $ toolError rid (T.pack $ show err)
-                    Right val
-                        | noFilters -> return $ toolSuccessJson rid (hintFor pid val)
-                        | otherwise -> case fromJSON val of
-                            Error _ -> return $ toolSuccessJson rid (hintFor pid val)
-                            Success ai ->
-                                let filtered = ai{piActivity = (piActivity ai){pfaExchanges = filter matchExchange (pfaExchanges (piActivity ai))}}
-                                 in return $ toolSuccessJson rid (hintFor pid (toJSON filtered))
+                    Right val -> case fromJSON val of
+                        -- 'val' was built from an 'ActivityInfo' upstream, so a
+                        -- decode failure is genuinely defensive — pass it
+                        -- through unchanged, hint-less.
+                        Error _ -> return $ toolSuccessJson rid val
+                        Success ai ->
+                            -- Single resolve: take the activity name from the
+                            -- 'ActivityInfo' already in hand instead of asking
+                            -- the engine to resolve the PID again.
+                            let attach = attachMarketHintByName (pfaName (piActivity ai))
+                                payload
+                                    | noFilters = val
+                                    | otherwise =
+                                        toJSON
+                                            ai
+                                                { piActivity =
+                                                    (piActivity ai)
+                                                        { pfaExchanges =
+                                                            filter matchExchange (pfaExchanges (piActivity ai))
+                                                        }
+                                                }
+                             in return $ toolSuccessJson rid (attach payload)
   where
-    -- Surface a hint when the resolved process is a "market for ..." activity:
-    -- markets aggregate multiple suppliers and are not source ICVs. The lookup
-    -- is in-memory and cheap; on resolution failure we silently skip the hint
-    -- because the underlying handler has already reported the resolution
-    -- failure path via 'getActivityInfo'.
-    hintFor pid = case Service.resolveActivityAndProcessId db pid of
-        Right (_, act) -> attachMarketHintByName (activityName act)
-        Left _ -> id
     exchangeType = textArg "exchange_type" args
     flowFilter = textArg "flow" args
     isInputFilter = boolArg "is_input" args

--- a/src/API/MCP/Columnar.hs
+++ b/src/API/MCP/Columnar.hs
@@ -1,0 +1,198 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Columnar JSON projection used by the @score_activities@ MCP tool.
+
+The shape hoists batch-constant metadata (scoring set name, unit,
+functional unit when the whole batch shares one) to the top level and
+packs each activity as a flat array of scalars indexed by 'columns'.
+Trades a few bytes of header for the N×M repetition of JSON keys the
+previous row-shaped payload paid for — typically ~6× smaller for a
+batch of 24+ activities.
+
+Lives in its own module rather than "API.MCP.Enrich" because it works
+on typed records ('BatchImpactsResponse', 'ScoringSet') rather than raw
+'Value's, and so it is also straightforward to unit-test independently
+of the live MCP server.
+-}
+module API.MCP.Columnar (
+    -- * Scoring set selection
+    resolveSingleScoringSet,
+
+    -- * Columnar projection
+    toColumnarBatch,
+
+    -- * Internals exported for tests
+    dominantIndicatorCell,
+) where
+
+import API.MCP.Enrich (scoreActivityWebUrl)
+import API.Types (
+    BatchImpactsEntry (..),
+    BatchImpactsResponse (..),
+    LCIABatchResult (..),
+    LCIAResult (..),
+    ScoringIndicator (..),
+ )
+import Data.Aeson (Value (..), object, toJSON, (.=))
+import qualified Data.List as L
+import qualified Data.Map as M
+import Data.Maybe (mapMaybe)
+import Data.Ord (comparing)
+import Data.Text (Text)
+import qualified Data.Text as T
+import Method.Types (ScoringSet (..))
+
+-- ---------------------------------------------------------------------------
+-- Scoring set selection
+-- ---------------------------------------------------------------------------
+
+{- | Pick the single 'ScoringSet' the columnar 'score_activities' response
+will project against. The columnar shape covers one set per call (one
+unit, one list of indicator columns), so:
+
+  * Caller passes one name in 'scoring_sets' → that one (validated).
+  * Caller passes none, exactly one set is configured → that one.
+  * Caller passes none, several sets are configured → error listing the
+    options. We don't pick arbitrarily to avoid silent ambiguity.
+  * Caller passes several names → error: only one is supported.
+  * No sets configured at all → error.
+-}
+resolveSingleScoringSet :: [Text] -> [ScoringSet] -> Either Text ScoringSet
+resolveSingleScoringSet wantedNames configured = case wantedNames of
+    [] -> case configured of
+        [] -> Left "No scoring sets configured on this collection."
+        [s] -> Right s
+        ss ->
+            Left $
+                "Multiple scoring sets are configured ("
+                    <> T.intercalate ", " (map ssName ss)
+                    <> "); pass scoring_sets: [\"<one>\"] to pick one. score_activities returns a columnar shape that covers a single scoring set per call."
+    [w] -> case L.find (\s -> ssName s == w) configured of
+        Just s -> Right s
+        Nothing ->
+            Left $
+                "Unknown scoring set: "
+                    <> w
+                    <> ". Configured on this collection: "
+                    <> T.intercalate ", " (map ssName configured)
+    ws ->
+        Left $
+            "score_activities accepts at most one scoring set in 'scoring_sets'; got ["
+                <> T.intercalate ", " ws
+                <> "]. The columnar response shape covers a single scoring set per call."
+
+-- ---------------------------------------------------------------------------
+-- Columnar projection
+-- ---------------------------------------------------------------------------
+
+{- | Project a 'BatchImpactsResponse' against one chosen 'ScoringSet' into
+the columnar JSON shape:
+
+@
+{ "scoring_set":     "PEF"
+, "scoring_unit":    "µPts PEF"
+, "functional_unit": "1.00 cubic meter of ..."   -- only when all rows agree
+, "columns": ["name", "process_id", "web_url", "total", "acd", ...]
+, "rows":    [[...], [...], ...]
+, "not_found": [...]
+, "invalid":   [...]
+}
+@
+
+Functional unit handling avoids the silent-misrepresentation trap of an
+unconditional hoist: rows of a batch may carry different reference
+products (e.g. 1 kg of milk vs 1 kg of steak), so the FU is only lifted
+to the top level when every row in the batch agrees on it. When the
+batch is heterogeneous, the top-level field is dropped and a
+@functional_unit@ column is appended to each row instead. The columns
+header reflects which shape was emitted.
+
+A row's @total@ cell is the @total@ score from @ssScores@ when present;
+otherwise null. An indicator cell is the @siValue@ of the matching entry
+in @lbrScoringIndicators[setName]@; missing keys land as null.
+
+With @summaryOnly = True@, the per-indicator columns collapse to a
+single @dominant_indicator@ column carrying an object
+@{key, share_pct}@ — the variable with the largest absolute share of
+the total. Useful for ranking large batches before drilling into one
+PID with @score_activity@.
+-}
+toColumnarBatch :: Bool -> Text -> Text -> Text -> ScoringSet -> BatchImpactsResponse -> Value
+toColumnarBatch summaryOnly baseUrl dbName coll ss bir =
+    object $
+        [ "scoring_set" .= ssName ss
+        , "scoring_unit" .= scoringUnit
+        , "columns" .= columns
+        , "rows" .= map entryRow (birResults bir)
+        , "not_found" .= birNotFound bir
+        , "invalid" .= birInvalid bir
+        ]
+            ++ topLevelFU
+  where
+    setName = ssName ss
+    rowFUOf :: BatchImpactsEntry -> Maybe Text
+    rowFUOf e = case lbrResults (bieImpacts e) of
+        r : _ -> Just (lrFunctionalUnit r)
+        [] -> Nothing
+    uniqueFUs = L.nub (mapMaybe rowFUOf (birResults bir))
+    -- When every resolved row shares a single FU, hoist it to top level
+    -- and drop the per-row column. Otherwise emit the FU per row to keep
+    -- the relabelling honest.
+    isHeterogeneous = length uniqueFUs > 1
+    topLevelFU = case uniqueFUs of
+        [fu] -> ["functional_unit" .= fu]
+        _ -> []
+    indicatorKeys :: [Text]
+    indicatorKeys = M.keys (M.union (ssVariables ss) (ssComputed ss))
+    fixedColumns :: [Text]
+    fixedColumns
+        | isHeterogeneous = ["name", "process_id", "web_url", "functional_unit", "total"]
+        | otherwise = ["name", "process_id", "web_url", "total"]
+    columns :: [Text]
+    columns
+        | summaryOnly = fixedColumns ++ ["dominant_indicator"]
+        | otherwise = fixedColumns ++ indicatorKeys
+    scoringUnit = case birResults bir of
+        e : _ -> M.findWithDefault (ssUnit ss) setName (lbrScoringUnits (bieImpacts e))
+        [] -> ssUnit ss
+    entryRow :: BatchImpactsEntry -> Value
+    entryRow e = toJSON cells
+      where
+        url = scoreActivityWebUrl baseUrl dbName (bieProcessId e) coll
+        lbr = bieImpacts e
+        scoreMap = M.findWithDefault M.empty setName (lbrScoringResults lbr)
+        indMap = M.findWithDefault M.empty setName (lbrScoringIndicators lbr)
+        totalRaw = M.lookup "total" scoreMap
+        total = maybe Null toJSON totalRaw
+        fuCells
+            | isHeterogeneous = [maybe Null toJSON (rowFUOf e)]
+            | otherwise = []
+        tailCells
+            | summaryOnly = [dominantIndicatorCell totalRaw indMap]
+            | otherwise = map indVal indicatorKeys
+        indVal k = maybe Null (toJSON . siValue) (M.lookup k indMap)
+        cells =
+            [ toJSON (bieActivityName e)
+            , toJSON (bieProcessId e)
+            , toJSON url
+            ]
+                ++ fuCells
+                ++ [total]
+                ++ tailCells
+
+{- | Format the dominant indicator of a row as a @{key, share_pct}@
+object. Returns 'Null' when the row has no total, the total is zero
+(share is undefined), or the indicator map is empty.
+-}
+dominantIndicatorCell :: Maybe Double -> M.Map Text ScoringIndicator -> Value
+dominantIndicatorCell mTotal indMap
+    | Just t <- mTotal
+    , t /= 0
+    , not (M.null indMap) =
+        let (k, ind) =
+                L.maximumBy
+                    (comparing (abs . siValue . snd))
+                    (M.toList indMap)
+            share = abs (siValue ind) / abs t * 100
+         in object ["key" .= k, "share_pct" .= share]
+    | otherwise = Null

--- a/src/API/MCP/Enrich.hs
+++ b/src/API/MCP/Enrich.hs
@@ -1,20 +1,17 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-{- | Pure JSON munging used by the @score_activity@ / @score_activities@
-MCP tools.
+{- | Pure JSON munging used by the @score_activity@ MCP tool and by
+single-activity handlers that need a @web_url@ deep link, a slimmer
+panel, a scoring-set filter, or a market-activity hint.
 
-Two responsibilities:
+The columnar batch projection for @score_activities@ lives in
+"API.MCP" — it works on typed records, not raw 'Value's, so it does not
+fit this module's "pure JSON munging" remit.
 
-  * Decorate the serialized 'LCIABatchResult' / 'BatchImpactsResponse'
-    with @web_url@ deep links so MCP clients can hand a human a clickable
-    follow-up.
-  * Restrict the response to a user-requested subset of scoring sets,
-    failing loudly on names that are not configured on the collection.
-
-Every traversal goes through 'overObject' / 'overObjectE' / 'overArray' /
-'overArrayE', the single place that has to enumerate every constructor
-of Aeson's 'Value'. Callers stay free of wildcard patterns on the sum.
+Every traversal goes through 'overObject' / 'overArray', the single
+place that has to enumerate every constructor of Aeson's 'Value'.
+Callers stay free of wildcard patterns on the sum.
 -}
 module API.MCP.Enrich (
     -- * URL helpers
@@ -23,7 +20,6 @@ module API.MCP.Enrich (
 
     -- * web_url enrichment
     addWebUrl,
-    summarizeBatchResults,
 
     -- * payload slimming
     slimLCIAPanel,
@@ -31,16 +27,18 @@ module API.MCP.Enrich (
 
     -- * scoring_sets filter
     filterScoringSets,
-    filterScoringSetsBatch,
+
+    -- * market-activity hint
+    isMarketActivityName,
+    attachMarketHintByName,
 
     -- * Value combinators (exported for tests)
     overObject,
-    overObjectE,
     overArray,
     valueText,
 ) where
 
-import Data.Aeson (Value (..))
+import Data.Aeson (Value (..), object, (.=))
 import Data.Aeson.Key (fromText)
 import qualified Data.Aeson.Key as Key
 import Data.Aeson.KeyMap (KeyMap)
@@ -66,16 +64,6 @@ overObject f = \case
     Number n -> Number n
     Bool b -> Bool b
     Null -> Null
-
--- | Same as 'overObject' but the transformation may fail with 'Text'.
-overObjectE :: (KeyMap Value -> Either Text (KeyMap Value)) -> Value -> Either Text Value
-overObjectE f = \case
-    Object km -> Object <$> f km
-    Array a -> Right (Array a)
-    String s -> Right (String s)
-    Number n -> Right (Number n)
-    Bool b -> Right (Bool b)
-    Null -> Right Null
 
 -- | Apply 'f' to each element of a JSON Array; pass any other shape through.
 overArray :: (Value -> Value) -> Value -> Value
@@ -124,15 +112,11 @@ scoreActivityWebUrl baseUrl dbName pidText coll =
 -- web_url enrichment
 -- ---------------------------------------------------------------------------
 
-webUrlKey, resultsKey, impactsKey, processIdKey, functionalUnitKey :: Key.Key
+webUrlKey, resultsKey, functionalUnitKey, hintKey :: Key.Key
 webUrlKey = fromText "web_url"
 resultsKey = fromText "results"
-impactsKey = fromText "impacts"
--- 'strippedToJSON' on the API record drops the field prefix and keeps
--- camelCase; stay aligned with what 'LCIABatchResult' / 'BatchImpactsEntry'
--- actually serialize to ('processId', not 'process_id').
-processIdKey = fromText "processId"
 functionalUnitKey = fromText "functionalUnit"
+hintKey = fromText "hint"
 
 -- | Add a 'web_url' field to a JSON object at the top level.
 addWebUrl :: Text -> Value -> Value
@@ -150,47 +134,6 @@ that wants per-method drill-down on a specific activity calls
 -}
 summarizeLCIAPanel :: Value -> Value
 summarizeLCIAPanel = overObject (KM.delete resultsKey . hoistFunctionalUnit)
-
-{- | Summarize each entry of a serialized 'BatchImpactsResponse'.
-
-For every entry:
-
-  * Reduce its @impacts@ subtree via 'summarizeLCIAPanel' (drops the
-    @results@ array, hoists @functionalUnit@) — the bulk endpoint
-    returns aggregates only.
-  * Attach a @web_url@ to the activity-level impacts page at two
-    locations:
-
-      - @results[i].web_url@ — what the @score_activities@ resource
-        description promises; a client reading the entry shape directly
-        lands on it.
-      - @results[i].impacts.web_url@ — same shape as a standalone
-        @score_activity@ response, so clients reading either shape land
-        on the same link.
-
-An entry without an @impacts@ subtree (defensive — the
-'BatchImpactsEntry' record guarantees one) still gains the top-level
-@web_url@, but no empty @impacts@ placeholder is materialized.
--}
-summarizeBatchResults :: Text -> Text -> Text -> Value -> Value
-summarizeBatchResults baseUrl dbName coll =
-    overObject (adjustKey resultsKey (overArray (summarizeBatchEntry baseUrl dbName coll)))
-
-summarizeBatchEntry :: Text -> Text -> Text -> Value -> Value
-summarizeBatchEntry baseUrl dbName coll =
-    overObject $ \km ->
-        case KM.lookup processIdKey km >>= valueText of
-            Just pidText ->
-                let url = scoreActivityWebUrl baseUrl dbName pidText coll
-                    withImpacts = case KM.lookup impactsKey km of
-                        Just impactsValue ->
-                            KM.insert
-                                impactsKey
-                                (addWebUrl url (summarizeLCIAPanel impactsValue))
-                                km
-                        Nothing -> km
-                 in KM.insert webUrlKey (String url) withImpacts
-            Nothing -> km
 
 -- ---------------------------------------------------------------------------
 -- payload slimming
@@ -264,20 +207,6 @@ filterScoringSets configured requested v = do
     validateRequested configured requested
     Right (restrictScoringSets requested v)
 
-{- | Apply 'filterScoringSets' to every entry's @impacts@ subtree in a
-serialized 'BatchImpactsResponse'.
-
-Validation runs once at the top level — not inside each entry — so a
-batch with zero successful entries still surfaces an unknown-name
-error. Otherwise a @score_activities@ call where every PID is invalid
-would silently swallow a typo'd scoring-set filter.
--}
-filterScoringSetsBatch :: [Text] -> [Text] -> Value -> Either Text Value
-filterScoringSetsBatch _ [] v = Right v
-filterScoringSetsBatch configured requested v = do
-    validateRequested configured requested
-    overObjectE (traverseKey resultsKey (overArrayE (filterEntry requested))) v
-
 {- | Check 'requested' against 'configured', failing with a message that
 lists the missing names and the legal options.
 -}
@@ -307,42 +236,6 @@ restrictScoringSets requested =
     restrict = overObject (KM.filterWithKey keep)
     restrictAt k = adjustKey k restrict
 
--- | Restrict one entry's @impacts@ subtree; entries without one pass through.
-filterEntry :: [Text] -> Value -> Either Text Value
-filterEntry requested =
-    overObjectE $ \km ->
-        case KM.lookup impactsKey km of
-            Just impactsValue ->
-                Right (KM.insert impactsKey (restrictScoringSets requested impactsValue) km)
-            Nothing -> Right km
-
-{- | Apply a 'Value' → 'Either' transformation to each element of an
-Array; non-Array values pass through.
--}
-overArrayE :: (Value -> Either Text Value) -> Value -> Either Text Value
-overArrayE f = \case
-    Array v -> Array . V.fromList <$> traverse f (V.toList v)
-    Object km -> Right (Object km)
-    String s -> Right (String s)
-    Number n -> Right (Number n)
-    Bool b -> Right (Bool b)
-    Null -> Right Null
-
-{- | Update one key of a 'KeyMap' via a transformation that may fail; if
-the key is absent, the map is returned unchanged.
--}
-traverseKey ::
-    Key.Key ->
-    (Value -> Either Text Value) ->
-    KeyMap Value ->
-    Either Text (KeyMap Value)
-traverseKey k f km =
-    case KM.lookup k km of
-        Just v -> do
-            v' <- f v
-            pure (KM.insert k v' km)
-        Nothing -> Right km
-
 {- | Update one key of a 'KeyMap' via a pure transformation; if the key
 is absent, the map is returned unchanged. (Aeson's 'KeyMap' has no
 @adjust@ of its own.)
@@ -352,3 +245,37 @@ adjustKey k f km =
     case KM.lookup k km of
         Just v -> KM.insert k (f v) km
         Nothing -> km
+
+-- ---------------------------------------------------------------------------
+-- market-activity hint
+-- ---------------------------------------------------------------------------
+
+{- | Case-insensitive test for the @"market for "@ naming convention used
+across ecoinvent and SimaPro-imported databases. A market activity is an
+aggregated supplier mix, not a source ICV — a caller asking for raw
+inventory probably wants the upstream producers instead.
+-}
+isMarketActivityName :: Text -> Bool
+isMarketActivityName name = "market for " `T.isPrefixOf` T.toLower (T.stripStart name)
+
+-- | The hint payload attached to responses for market activities.
+marketHintObject :: Value
+marketHintObject =
+    object
+        [ "kind" .= ("market_activity" :: Text)
+        , "message"
+            .= ( "This is a 'market for ...' activity — an aggregated supplier mix, \
+                 \not a source ICV. Call get_activity to inspect its technosphere \
+                 \inputs (the actual producers)." ::
+                    Text
+               )
+        ]
+
+{- | When 'name' looks like a market activity, attach a @hint@ field at
+the top level of the JSON object. Non-objects and non-markets pass
+through unchanged.
+-}
+attachMarketHintByName :: Text -> Value -> Value
+attachMarketHintByName name
+    | isMarketActivityName name = overObject (KM.insert hintKey marketHintObject)
+    | otherwise = id

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -382,15 +382,18 @@ description r = case r of
         \clickable markdown link when presenting results to a human."
     ScoreActivities ->
         "LCA / ACV — rank N activities against one scoring set in one call. \
-        \Returns a columnar JSON shape: {scoringSet, scoringUnit, \
-        \functionalUnit, columns, rows, notFound, invalid}. 'columns' is the \
-        \header (['name', 'processId', 'web_url', 'total', <indicator keys...>]) \
+        \Returns a columnar JSON shape: {scoring_set, scoring_unit, \
+        \functional_unit?, columns, rows, not_found, invalid}. 'columns' is the \
+        \header (['name', 'process_id', 'web_url', 'total', <indicator keys...>]) \
         \and 'rows' is a 2D array of scalars — one row per resolved activity. \
         \Hoisting the constant metadata once and packing each activity as a flat \
         \array of scalars makes this shape ~6× smaller than a row-shaped JSON \
-        \for batches of 24+ activities. Per-method scores are NOT included — \
-        \call score_activity on a specific process_id for that drill-down. \
-        \Unresolved process IDs land in notFound / invalid. \
+        \for batches of 24+ activities. The top-level 'functional_unit' is only \
+        \emitted when every resolved row shares the same one; otherwise it is \
+        \dropped and 'functional_unit' appears as a per-row column instead (the \
+        \'columns' header reflects which shape was emitted). Per-method scores \
+        \are NOT included — call score_activity on a specific process_id for \
+        \that drill-down. Unresolved process IDs land in not_found / invalid. \
         \\n\n\
         \The chosen scoring set must be unambiguous: pass scoring_sets: \
         \[\"<one>\"] when the collection has more than one scoring set \
@@ -478,7 +481,7 @@ pScoringSetsFilter =
         \list_scoring_sets to discover the configured names. An unknown \
         \name fails the call with the list of available names."
 
--- | Opt-in summary mode for 'score_activities' (Block D).
+-- | Opt-in summary mode for 'score_activities'.
 pSummaryOnly :: Param
 pSummaryOnly =
     Param
@@ -486,10 +489,11 @@ pSummaryOnly =
         "boolean"
         Optional
         "When true, score_activities replaces the per-indicator columns with \
-        \a single 'dominantIndicator' column shaped \"key:share_pct\" (e.g. \
-        \\"ldu:82.3\") — the indicator with the largest absolute share of \
-        \each activity's total. Use this when ranking large batches before \
-        \drilling into a single PID with score_activity. Default false."
+        \a single 'dominant_indicator' column whose cells are objects \
+        \{key, share_pct} (e.g. {\"key\": \"ldu\", \"share_pct\": 82.3}) — \
+        \the indicator with the largest absolute share of each activity's \
+        \total. Use this when ranking large batches before drilling into a \
+        \single PID with score_activity. Default false."
 
 -- | Parameters accepted by a resource operation.
 params :: Resource -> [Param]

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -293,7 +293,9 @@ description r = case r of
         \elementary flows. Answers 'empreinte carbone / environmental footprint' \
         \questions. Covers all LCIA categories: climate change, acidification, \
         \eutrophication, land use, water scarcity, resource depletion. Prefer this \
-        \over web estimates for grounded, database-backed answers."
+        \over web estimates for grounded, database-backed answers. The response \
+        \includes a 'web_url' deep link to the impacts page in the VoLCA web UI — \
+        \render it as a clickable markdown link when presenting results to a human."
     ComputeSensitivity ->
         "LCA / ACV — sensitivity analysis: sweep relative perturbations of \
         \technosphere coefficients A_ij and report the resulting impact for each. \
@@ -303,7 +305,10 @@ description r = case r of
         \perturbation with the new score and deltaImpact. Per-perturbation errors \
         \(no link, singular update) are returned in the entry; the sweep continues. \
         \Internally uses Sherman-Morrison rank-1 updates against the cached \
-        \factorization (~4 ms per perturbation). V1: root DB only."
+        \factorization (~4 ms per perturbation). V1: root DB only. The response \
+        \includes a 'web_url' deep link to the sensitivity page in the VoLCA web \
+        \UI — render it as a clickable markdown link when presenting results to a \
+        \human."
     ListMethods ->
         "LCA / ACV — list all loaded LCIA methods (impact assessment methods like \
         \climate change, acidification, eutrophication, land use, water scarcity)."
@@ -318,12 +323,16 @@ description r = case r of
     GetContributingFlows ->
         "LCA / ACV — identify which elementary flows (emissions/resources) \
         \contribute most to a specific impact category. Answers 'which emissions \
-        \drive my climate change score?'"
+        \drive my climate change score?' The response includes a 'web_url' deep \
+        \link to the contributing-flows page in the VoLCA web UI — render it as a \
+        \clickable markdown link when presenting results to a human."
     GetContributingActivities ->
         "LCA / ACV — identify which upstream activities contribute most to a \
         \specific impact category. Answers 'which suppliers drive my climate change \
         \score?' Uses exact matrix-based computation, valid even for cyclic supply \
-        \chains."
+        \chains. Each contributing activity carries a 'web_url' deep link to its \
+        \page in the VoLCA web UI — render these as clickable markdown links when \
+        \presenting results to a human so they can drill into a specific supplier."
     ListGeographies ->
         "LCA / ACV — list all geography codes present in a database, with display \
         \names and parent regions. Use the 'geo' value as the geography filter in \
@@ -359,19 +368,28 @@ description r = case r of
         \set for an activity in one call. Returns per-method impact scores, \
         \per-scoring-set aggregate scores, per-scoring-set indicator \
         \breakdown (one entry per scoring variable), display units, and a \
-        \web_url to the matching view. Use this when you would otherwise \
+        \'web_url' to the matching view. Use this when you would otherwise \
         \call get_impacts N times across every method of a collection — \
         \replaces N round-trips with one batched solve. Discover available \
-        \scoring sets with list_scoring_sets."
+        \scoring sets with list_scoring_sets. Render the 'web_url' as a \
+        \clickable markdown link when presenting results to a human."
     ScoreActivities ->
-        "LCA / ACV — rank N activities against every method in a collection \
-        \in one call. Returns one entry per activity with the scoring-set \
-        \aggregates (single score, per-indicator breakdown, units), the \
-        \functional unit, and a web_url to its impacts page. Per-method \
-        \scores are NOT included — call score_activity on a specific \
-        \process_id when you need the per-method drill-down. Unresolved \
-        \process IDs land in not_found / invalid. One MUMPS multi-RHS \
-        \solve plus parallel characterization, then summarized for transport."
+        "LCA / ACV — rank N activities against one scoring set in one call. \
+        \Returns a columnar JSON shape: {scoringSet, scoringUnit, \
+        \functionalUnit, columns, rows, notFound, invalid}. 'columns' is the \
+        \header (['name', 'processId', 'web_url', 'total', <indicator keys...>]) \
+        \and 'rows' is a 2D array of scalars — one row per resolved activity. \
+        \Hoisting the constant metadata once and packing each activity as a flat \
+        \array of scalars makes this shape ~6× smaller than a row-shaped JSON \
+        \for batches of 24+ activities. Per-method scores are NOT included — \
+        \call score_activity on a specific process_id for that drill-down. \
+        \Unresolved process IDs land in notFound / invalid. \
+        \\n\n\
+        \The chosen scoring set must be unambiguous: pass scoring_sets: \
+        \[\"<one>\"] when the collection has more than one scoring set \
+        \configured. The 'web_url' column on each row is a deep link to the \
+        \activity's impacts page in the VoLCA web UI — render it as a clickable \
+        \markdown link when presenting results to a human."
     ListScoringSets ->
         "LCA / ACV — list formula-based scoring sets defined in loaded \
         \method collections. A scoring set is a configured aggregation of \
@@ -423,11 +441,21 @@ pSubstitutions =
         \PIDs can be bare (root DB) or qualified as dbName::pid (cross-DB). \
         \When empty or absent, the call behaves as a plain GET."
 
-{- | Optional filter for score_activity / score_activities: when supplied,
-the response's scoring-related maps (scoringResults / scoringUnits /
-scoringIndicators) are restricted to these scoring set names. When
-omitted or empty, every scoring set configured on the collection is
-returned. An unknown name is a hard error (lists what's configured).
+{- | The 'scoring_sets' parameter, shared by 'score_activity' and
+'score_activities' but with slightly different semantics:
+
+  * 'score_activity' (single activity) — when supplied, restricts the
+    response's scoringResults / scoringUnits / scoringIndicators to
+    these scoring set names. Omitted or empty keeps every set
+    configured on the collection.
+  * 'score_activities' (batch) — picks the single scoring set the
+    columnar response is projected against (one unit, one column list).
+    Pass exactly one name in the array. When omitted and the collection
+    has a single scoring set configured, that one is auto-picked; with
+    multiple sets configured, omitting is an error.
+
+In both cases an unknown name is a hard error that lists what's
+configured.
 -}
 pScoringSetsFilter :: Param
 pScoringSetsFilter =
@@ -435,11 +463,26 @@ pScoringSetsFilter =
         "scoring_sets"
         "array"
         Optional
-        "Restrict the response's scoringResults / scoringUnits / \
-        \scoringIndicators to these scoring set names (use \
-        \list_scoring_sets to discover). Omit or pass [] to keep every \
-        \scoring set configured on the collection. An unknown name \
-        \fails the call with the list of available names."
+        "For score_activity: restricts the response's scoringResults / \
+        \scoringUnits / scoringIndicators to these scoring set names. \
+        \For score_activities: selects the single scoring set the \
+        \columnar response is projected against; pass one name. Auto-picked \
+        \when the collection has exactly one configured set. Use \
+        \list_scoring_sets to discover the configured names. An unknown \
+        \name fails the call with the list of available names."
+
+-- | Opt-in summary mode for 'score_activities' (Block D).
+pSummaryOnly :: Param
+pSummaryOnly =
+    Param
+        "summary_only"
+        "boolean"
+        Optional
+        "When true, score_activities replaces the per-indicator columns with \
+        \a single 'dominantIndicator' column shaped \"key:share_pct\" (e.g. \
+        \\"ldu:82.3\") — the indicator with the largest absolute share of \
+        \each activity's total. Use this when ranking large batches before \
+        \drilling into a single PID with score_activity. Default false."
 
 -- | Parameters accepted by a resource operation.
 params :: Resource -> [Param]
@@ -605,6 +648,7 @@ params r = case r of
         , Param "collection" "string" Required "Method collection name"
         , Param "process_ids" "array" Required "Process IDs to score (activityUUID_productUUID). All resolved in one multi-RHS solve."
         , pScoringSetsFilter
+        , pSummaryOnly
         ]
     ListScoringSets ->
         [ Param "collection" "string" Optional "Method collection name. If omitted, returns scoring sets across all loaded collections, grouped by collection."

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -227,6 +227,17 @@ cliName r = case r of
 -- Projection: human-readable description (shared across surfaces)
 -- ---------------------------------------------------------------------------
 
+{- | Trailing rendering tip for tools whose response includes a single
+'web_url'. Appended to the bespoke description of each such tool so the
+wording stays consistent across them.
+-}
+webUrlTip :: Text -> Text
+webUrlTip page =
+    " The response includes a 'web_url' deep link to the "
+        <> page
+        <> " page in the VoLCA web UI — render it as a clickable markdown \
+           \link when presenting results to a human."
+
 {- | Description of the resource operation.
 
 These strings are consumed as-is by the MCP tool metadata and are
@@ -293,9 +304,8 @@ description r = case r of
         \elementary flows. Answers 'empreinte carbone / environmental footprint' \
         \questions. Covers all LCIA categories: climate change, acidification, \
         \eutrophication, land use, water scarcity, resource depletion. Prefer this \
-        \over web estimates for grounded, database-backed answers. The response \
-        \includes a 'web_url' deep link to the impacts page in the VoLCA web UI — \
-        \render it as a clickable markdown link when presenting results to a human."
+        \over web estimates for grounded, database-backed answers."
+            <> webUrlTip "impacts"
     ComputeSensitivity ->
         "LCA / ACV — sensitivity analysis: sweep relative perturbations of \
         \technosphere coefficients A_ij and report the resulting impact for each. \
@@ -305,10 +315,8 @@ description r = case r of
         \perturbation with the new score and deltaImpact. Per-perturbation errors \
         \(no link, singular update) are returned in the entry; the sweep continues. \
         \Internally uses Sherman-Morrison rank-1 updates against the cached \
-        \factorization (~4 ms per perturbation). V1: root DB only. The response \
-        \includes a 'web_url' deep link to the sensitivity page in the VoLCA web \
-        \UI — render it as a clickable markdown link when presenting results to a \
-        \human."
+        \factorization (~4 ms per perturbation). V1: root DB only."
+            <> webUrlTip "sensitivity"
     ListMethods ->
         "LCA / ACV — list all loaded LCIA methods (impact assessment methods like \
         \climate change, acidification, eutrophication, land use, water scarcity)."
@@ -323,9 +331,8 @@ description r = case r of
     GetContributingFlows ->
         "LCA / ACV — identify which elementary flows (emissions/resources) \
         \contribute most to a specific impact category. Answers 'which emissions \
-        \drive my climate change score?' The response includes a 'web_url' deep \
-        \link to the contributing-flows page in the VoLCA web UI — render it as a \
-        \clickable markdown link when presenting results to a human."
+        \drive my climate change score?'"
+            <> webUrlTip "contributing-flows"
     GetContributingActivities ->
         "LCA / ACV — identify which upstream activities contribute most to a \
         \specific impact category. Answers 'which suppliers drive my climate change \

--- a/test/MCPColumnarSpec.hs
+++ b/test/MCPColumnarSpec.hs
@@ -1,0 +1,289 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Pure-function tests for "API.MCP.Columnar".
+
+The columnar projection is the heart of the @score_activities@ MCP
+tool — it decides which keys land at the top level, which columns each
+row carries, and how the dominant indicator is shaped. Every branch is
+covered here so a wire-shape regression fails fast, independently of
+the live server.
+-}
+module MCPColumnarSpec (spec) where
+
+import API.MCP.Columnar (dominantIndicatorCell, resolveSingleScoringSet, toColumnarBatch)
+import API.Types (
+    BatchImpactsEntry (..),
+    BatchImpactsResponse (..),
+    LCIABatchResult (..),
+    LCIAResult (..),
+    ScoringIndicator (..),
+ )
+import Data.Aeson (Value (..), object, (.=))
+import Data.Aeson.Key (fromText)
+import qualified Data.Aeson.KeyMap as KM
+import qualified Data.Map as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import Method.Types (ScoringSet (..))
+import Test.Hspec
+
+-- ---------------------------------------------------------------------------
+-- Fixtures
+-- ---------------------------------------------------------------------------
+
+-- | Minimal PEF-shaped set: two primitive indicators, one score named "total".
+pefSet :: ScoringSet
+pefSet =
+    ScoringSet
+        { ssName = "PEF"
+        , ssUnit = "µPts PEF"
+        , ssVariables = M.fromList [("acd", "Acidification"), ("cch", "Climate change")]
+        , ssComputed = M.empty
+        , ssNormalization = M.empty
+        , ssWeighting = M.empty
+        , ssScores = M.fromList [("total", "acd + cch")]
+        , ssDisplayMultiplier = Nothing
+        }
+
+ecsSet :: ScoringSet
+ecsSet = pefSet{ssName = "ECS"}
+
+lciaResult :: Text -> LCIAResult
+lciaResult fu =
+    LCIAResult
+        { lrMethodId = UUID.nil
+        , lrMethodName = "m"
+        , lrCategory = "cch"
+        , lrDamageCategory = "cch"
+        , lrScore = 1.0
+        , lrUnit = "kg CO2 eq"
+        , lrNormalizedScore = Nothing
+        , lrWeightedScore = Nothing
+        , lrMappedFlows = 0
+        , lrFunctionalUnit = fu
+        , lrTopContributors = []
+        }
+
+-- | Build an entry against a single scoring set, with explicit total + indicators.
+mkEntry :: Text -> Text -> Text -> Text -> Double -> [(Text, Double)] -> BatchImpactsEntry
+mkEntry pid name fu setName total inds =
+    BatchImpactsEntry
+        { bieProcessId = pid
+        , bieActivityName = name
+        , bieImpacts =
+            LCIABatchResult
+                { lbrResults = [lciaResult fu]
+                , lbrSingleScore = Just total
+                , lbrSingleScoreUnit = Just "µPts PEF"
+                , lbrNormWeightSetName = Nothing
+                , lbrAvailableNWsets = []
+                , lbrScoringResults = M.singleton setName (M.singleton "total" total)
+                , lbrScoringUnits = M.singleton setName "µPts PEF"
+                , lbrScoringIndicators =
+                    M.singleton setName $
+                        M.fromList [(k, ScoringIndicator k v) | (k, v) <- inds]
+                }
+        }
+
+emptyBir :: BatchImpactsResponse
+emptyBir = BatchImpactsResponse{birResults = [], birNotFound = [], birInvalid = []}
+
+-- ---------------------------------------------------------------------------
+-- Spec
+-- ---------------------------------------------------------------------------
+
+spec :: Spec
+spec = do
+    describe "resolveSingleScoringSet" $ do
+        it "returns the only configured set when caller passes none" $
+            resolveSingleScoringSet [] [pefSet] `shouldBe` Right pefSet
+
+        it "errors when nothing is configured" $
+            resolveSingleScoringSet [] [] `shouldBe` Left "No scoring sets configured on this collection."
+
+        it "errors when multiple are configured and caller picks none" $
+            case resolveSingleScoringSet [] [pefSet, ecsSet] of
+                Left msg -> T.isPrefixOf "Multiple scoring sets are configured (PEF, ECS)" msg `shouldBe` True
+                Right _ -> expectationFailure "expected Left"
+
+        it "accepts the configured set the caller named" $
+            resolveSingleScoringSet ["PEF"] [pefSet, ecsSet] `shouldBe` Right pefSet
+
+        it "errors when the requested name is unknown, listing what's configured" $
+            resolveSingleScoringSet ["typo"] [pefSet, ecsSet]
+                `shouldBe` Left "Unknown scoring set: typo. Configured on this collection: PEF, ECS"
+
+        it "errors when caller passes more than one name" $
+            case resolveSingleScoringSet ["PEF", "ECS"] [pefSet, ecsSet] of
+                Left msg -> T.isPrefixOf "score_activities accepts at most one scoring set" msg `shouldBe` True
+                Right _ -> expectationFailure "expected Left"
+
+    describe "toColumnarBatch (homogeneous FU)" $ do
+        let bir =
+                BatchImpactsResponse
+                    { birResults =
+                        [ mkEntry "pidA" "oak forestry, RoW" "1 m³ wood" "PEF" 10.0 [("acd", 4.0), ("cch", 6.0)]
+                        , mkEntry "pidB" "spruce forestry, RoW" "1 m³ wood" "PEF" 20.0 [("acd", 5.0), ("cch", 15.0)]
+                        ]
+                    , birNotFound = []
+                    , birInvalid = []
+                    }
+            Object km = toColumnarBatch False "https://x" "ei" "EF31" pefSet bir
+
+        it "uses snake_case top-level keys throughout" $ do
+            KM.lookup (fromText "scoring_set") km `shouldBe` Just (String "PEF")
+            KM.lookup (fromText "scoring_unit") km `shouldBe` Just (String "µPts PEF")
+            KM.lookup (fromText "not_found") km `shouldBe` Just (Array (V.fromList []))
+            KM.lookup (fromText "invalid") km `shouldBe` Just (Array (V.fromList []))
+
+        it "hoists functional_unit to top level when all rows share one" $
+            KM.lookup (fromText "functional_unit") km `shouldBe` Just (String "1 m³ wood")
+
+        it "emits snake_case fixed columns followed by the sorted indicator keys" $
+            KM.lookup (fromText "columns") km
+                `shouldBe` Just
+                    ( Array
+                        ( V.fromList
+                            [ String "name"
+                            , String "process_id"
+                            , String "web_url"
+                            , String "total"
+                            , String "acd"
+                            , String "cch"
+                            ]
+                        )
+                    )
+
+        it "packs each row as a flat array of scalars (no per-row functional_unit cell)" $ do
+            let pidARow =
+                    Array $
+                        V.fromList
+                            [ String "oak forestry, RoW"
+                            , String "pidA"
+                            , String "https://x/db/ei/activity/pidA/impacts/EF31"
+                            , Number 10.0
+                            , Number 4.0
+                            , Number 6.0
+                            ]
+                pidBRow =
+                    Array $
+                        V.fromList
+                            [ String "spruce forestry, RoW"
+                            , String "pidB"
+                            , String "https://x/db/ei/activity/pidB/impacts/EF31"
+                            , Number 20.0
+                            , Number 5.0
+                            , Number 15.0
+                            ]
+            case KM.lookup (fromText "rows") km of
+                Just (Array rs) -> V.toList rs `shouldBe` [pidARow, pidBRow]
+                other -> expectationFailure ("expected rows array, got " <> show other)
+
+    describe "toColumnarBatch (heterogeneous FU — the silent-misrepresentation fix)" $ do
+        let bir =
+                BatchImpactsResponse
+                    { birResults =
+                        [ mkEntry "pidM" "raw milk, FR" "1 kg of milk" "PEF" 1.0 []
+                        , mkEntry "pidS" "beef steak, FR" "1 kg of steak" "PEF" 30.0 []
+                        ]
+                    , birNotFound = []
+                    , birInvalid = []
+                    }
+            Object km = toColumnarBatch False "https://x" "agri" "EF31" pefSet bir
+
+        it "drops the top-level functional_unit field when rows disagree" $
+            KM.lookup (fromText "functional_unit") km `shouldBe` Nothing
+
+        it "inserts functional_unit as a per-row column instead" $
+            KM.lookup (fromText "columns") km
+                `shouldBe` Just
+                    ( Array
+                        ( V.fromList
+                            [ String "name"
+                            , String "process_id"
+                            , String "web_url"
+                            , String "functional_unit"
+                            , String "total"
+                            , String "acd"
+                            , String "cch"
+                            ]
+                        )
+                    )
+
+        it "carries each row's actual functional unit, not the first row's" $ do
+            case KM.lookup (fromText "rows") km of
+                Just (Array rs) -> case V.toList rs of
+                    [Array a, Array b] -> do
+                        V.toList a !! 3 `shouldBe` String "1 kg of milk"
+                        V.toList b !! 3 `shouldBe` String "1 kg of steak"
+                    other -> expectationFailure ("expected two rows, got " <> show other)
+                other -> expectationFailure ("expected rows array, got " <> show other)
+
+    describe "toColumnarBatch (summary_only)" $ do
+        let bir =
+                BatchImpactsResponse
+                    { birResults =
+                        [ mkEntry "pidA" "oak" "1 m³ wood" "PEF" 10.0 [("acd", 2.0), ("cch", 8.0)]
+                        ]
+                    , birNotFound = []
+                    , birInvalid = []
+                    }
+            Object km = toColumnarBatch True "https://x" "ei" "EF31" pefSet bir
+
+        it "replaces per-indicator columns with a single dominant_indicator column" $
+            KM.lookup (fromText "columns") km
+                `shouldBe` Just
+                    ( Array
+                        ( V.fromList
+                            [ String "name"
+                            , String "process_id"
+                            , String "web_url"
+                            , String "total"
+                            , String "dominant_indicator"
+                            ]
+                        )
+                    )
+
+        it "fills the cell with a {key, share_pct} object, not a delimited string" $ do
+            case KM.lookup (fromText "rows") km of
+                Just (Array rs) -> case V.toList rs of
+                    [Array a] ->
+                        last (V.toList a)
+                            `shouldBe` object ["key" .= ("cch" :: Text), "share_pct" .= (80.0 :: Double)]
+                    other -> expectationFailure ("expected one row, got " <> show other)
+                other -> expectationFailure ("expected rows array, got " <> show other)
+
+    describe "toColumnarBatch (edge: empty results)" $ do
+        let Object km = toColumnarBatch False "https://x" "ei" "EF31" pefSet emptyBir
+
+        it "omits top-level functional_unit (nothing to hoist)" $
+            KM.lookup (fromText "functional_unit") km `shouldBe` Nothing
+
+        it "still emits scoring_set / scoring_unit / empty rows" $ do
+            KM.lookup (fromText "scoring_set") km `shouldBe` Just (String "PEF")
+            KM.lookup (fromText "scoring_unit") km `shouldBe` Just (String "µPts PEF")
+            KM.lookup (fromText "rows") km `shouldBe` Just (Array (V.fromList []))
+
+    describe "dominantIndicatorCell" $ do
+        let inds = M.fromList [("a", ScoringIndicator "a" 1.0), ("b", ScoringIndicator "b" 9.0)]
+
+        it "picks the indicator with the largest absolute share" $
+            dominantIndicatorCell (Just 10.0) inds
+                `shouldBe` object ["key" .= ("b" :: Text), "share_pct" .= (90.0 :: Double)]
+
+        it "uses absolute value so negative contributors can win" $
+            dominantIndicatorCell
+                (Just 10.0)
+                (M.fromList [("a", ScoringIndicator "a" 1.0), ("b", ScoringIndicator "b" (-9.0))])
+                `shouldBe` object ["key" .= ("b" :: Text), "share_pct" .= (90.0 :: Double)]
+
+        it "returns Null when the total is zero (share undefined)" $
+            dominantIndicatorCell (Just 0.0) inds `shouldBe` Null
+
+        it "returns Null when the total is missing" $
+            dominantIndicatorCell Nothing inds `shouldBe` Null
+
+        it "returns Null when the indicator map is empty" $
+            dominantIndicatorCell (Just 10.0) M.empty `shouldBe` Null

--- a/test/MCPEnrichSpec.hs
+++ b/test/MCPEnrichSpec.hs
@@ -13,12 +13,12 @@ module MCPEnrichSpec (spec) where
 
 import API.MCP.Enrich (
     addWebUrl,
+    attachMarketHintByName,
     encodeSegment,
     filterScoringSets,
-    filterScoringSetsBatch,
+    isMarketActivityName,
     scoreActivityWebUrl,
     slimLCIAPanel,
-    summarizeBatchResults,
     summarizeLCIAPanel,
  )
 import Control.Monad (forM_)
@@ -68,29 +68,6 @@ sampleLBR =
                 , "ECS" .= object []
                 , "FAILED" .= object []
                 ]
-        ]
-
-{- | Minimal BatchImpactsResponse-shaped Value: two entries with
-impacts, one entry without impacts (defensive — see summarizeBatchResults).
--}
-sampleBatch :: Value
-sampleBatch =
-    object
-        [ "results"
-            .= [ object
-                    [ "processId" .= ("pidA" :: Text)
-                    , "impacts" .= sampleLBR
-                    ]
-               , object
-                    [ "processId" .= ("pidB" :: Text)
-                    , "impacts" .= sampleLBR
-                    ]
-               , object
-                    -- malformed: no impacts subtree
-                    ["processId" .= ("pidC" :: Text)]
-               ]
-        , "not_found" .= ([] :: [Text])
-        , "invalid" .= ([] :: [Text])
         ]
 
 -- ---------------------------------------------------------------------------
@@ -223,41 +200,6 @@ spec = do
             KM.lookup (fromText "functionalUnit") km `shouldBe` Nothing
             KM.lookup (fromText "results") km `shouldBe` Nothing
 
-    describe "summarizeBatchResults" $ do
-        it "adds web_url at the entry level (the documented shape)" $ do
-            let Object km = summarizeBatchResults "https://x" "agribalyse" "EF31" sampleBatch
-                Just (Array rs) = KM.lookup (fromText "results") km
-                [Object e0, _, _] = V.toList rs
-            KM.lookup (fromText "web_url") e0
-                `shouldBe` Just (String "https://x/db/agribalyse/activity/pidA/impacts/EF31")
-
-        it "also adds web_url inside the entry's impacts subtree" $ do
-            let Object km = summarizeBatchResults "https://x" "agribalyse" "EF31" sampleBatch
-                Just (Array rs) = KM.lookup (fromText "results") km
-                [Object e0, _, _] = V.toList rs
-                Just (Object impacts) = KM.lookup (fromText "impacts") e0
-            KM.lookup (fromText "web_url") impacts
-                `shouldBe` Just (String "https://x/db/agribalyse/activity/pidA/impacts/EF31")
-
-        it "drops impacts.results from every entry (summary, not drill-down)" $ do
-            let Object km = summarizeBatchResults "https://x" "agribalyse" "EF31" sampleBatch
-                Just (Array rs) = KM.lookup (fromText "results") km
-                [Object e0, Object e1, _] = V.toList rs
-            forM_ [e0, e1] $ \entry -> case KM.lookup (fromText "impacts") entry of
-                Just (Object impacts) ->
-                    KM.lookup (fromText "results") impacts `shouldBe` Nothing
-                other ->
-                    expectationFailure ("expected an impacts object, got " <> show other)
-
-        it "does NOT materialise an empty impacts object for entries that lack one" $ do
-            let Object km = summarizeBatchResults "https://x" "agribalyse" "EF31" sampleBatch
-                Just (Array rs) = KM.lookup (fromText "results") km
-                [_, _, Object e2] = V.toList rs
-            -- Entry without impacts should still gain web_url but not a fake impacts: {}
-            KM.lookup (fromText "web_url") e2
-                `shouldBe` Just (String "https://x/db/agribalyse/activity/pidC/impacts/EF31")
-            KM.lookup (fromText "impacts") e2 `shouldBe` Nothing
-
     describe "filterScoringSets" $ do
         it "is a no-op when requested is empty" $
             filterScoringSets ["PEF", "ECS"] [] sampleLBR `shouldBe` Right sampleLBR
@@ -289,36 +231,7 @@ spec = do
                         `shouldBe` Just (object ["PEF" .= object []])
                 _ -> expectationFailure "expected an Object"
 
-    describe "filterScoringSetsBatch" $ do
-        it "validates against configured even when results is empty" $ do
-            -- The fix: a score_activities call where every PID is unresolved
-            -- still surfaces an unknown-name filter error instead of silently
-            -- returning a zero-entry response.
-            let emptyBatch = object ["results" .= ([] :: [Value])]
-            filterScoringSetsBatch ["PEF"] ["typo"] emptyBatch
-                `shouldBe` Left "Unknown scoring set(s): typo. Configured on this collection: PEF"
-
-        it "is a no-op when requested is empty" $
-            filterScoringSetsBatch ["PEF"] [] sampleBatch `shouldBe` Right sampleBatch
-
-        it "restricts the impacts subtree of each entry" $ do
-            case filterScoringSetsBatch ["PEF", "ECS", "FAILED"] ["PEF"] sampleBatch of
-                Right (Object km) -> case KM.lookup (fromText "results") km of
-                    Just (Array rs) -> case V.toList rs of
-                        Object e0 : _ -> case KM.lookup (fromText "impacts") e0 of
-                            Just (Object impacts) ->
-                                KM.lookup (fromText "scoringResults") impacts
-                                    `shouldBe` Just (object ["PEF" .= object ["score" .= (1.0 :: Double)]])
-                            _ -> expectationFailure "expected impacts to be an object"
-                        _ -> expectationFailure "expected entries"
-                    _ -> expectationFailure "expected results array"
-                Left e -> expectationFailure ("unexpected Left: " <> show e)
-                _ -> expectationFailure "expected an object"
-
-    -- ----------------------------------------------------------------------
-    -- Regression: PR #79 edge cases the original suite didn't cover.
-    -- ----------------------------------------------------------------------
-    describe "PR #79 — slimLCIAPanel / summarizeBatchResults edge cases" $ do
+    describe "PR #79 — slimLCIAPanel NaN-score edge case" $ do
         let panelWithNaNScore =
                 object
                     [ "results"
@@ -346,22 +259,38 @@ spec = do
                     _ -> expectationFailure "expected one entry"
                 _ -> expectationFailure "expected results array"
 
-        it "summarizeBatchResults is a no-op on an empty results array" $ do
-            let emptyBatch = object ["results" .= ([] :: [Value])]
-                Object km = summarizeBatchResults "https://x" "db" "EF31" emptyBatch
-            KM.lookup (fromText "results") km `shouldBe` Just (Array (V.fromList []))
+    describe "isMarketActivityName" $ do
+        it "matches the canonical ecoinvent prefix" $
+            isMarketActivityName "market for sawlog and veneer log, softwood, ..." `shouldBe` True
 
-        it "summarizeBatchResults pads an entry whose processId is missing (passes it through unchanged)" $ do
-            -- A defensive shape that BatchImpactsEntry should never produce in
-            -- practice, but the projection MUST NOT crash on it.
-            let weirdBatch =
-                    object
-                        [ "results"
-                            .= [ object ["unrelated" .= ("x" :: Text)]
-                               ]
-                        ]
-                Object km = summarizeBatchResults "https://x" "db" "EF31" weirdBatch
-                Just (Array rs) = KM.lookup (fromText "results") km
-                [Object e] = V.toList rs
-            KM.lookup (fromText "web_url") e `shouldBe` Nothing
-            KM.lookup (fromText "unrelated") e `shouldBe` Just (String "x")
+        it "is case-insensitive" $
+            isMarketActivityName "MARKET FOR something" `shouldBe` True
+
+        it "tolerates leading whitespace" $
+            isMarketActivityName "   market for X" `shouldBe` True
+
+        it "rejects producer activities" $ do
+            isMarketActivityName "hardwood forestry, oak, sustainable forest management" `shouldBe` False
+            isMarketActivityName "marketing services" `shouldBe` False
+
+    describe "attachMarketHintByName" $ do
+        it "adds hint to a market activity" $ do
+            let Object km =
+                    attachMarketHintByName
+                        "market for X"
+                        (object ["name" .= ("market for X" :: Text)])
+            case KM.lookup (fromText "hint") km of
+                Just (Object hk) ->
+                    KM.lookup (fromText "kind") hk `shouldBe` Just (String "market_activity")
+                other ->
+                    expectationFailure ("expected hint object, got " <> show other)
+
+        it "is a no-op on a producer activity" $
+            attachMarketHintByName
+                "softwood forestry, spruce"
+                (object ["name" .= ("softwood forestry, spruce" :: Text)])
+                `shouldBe` object ["name" .= ("softwood forestry, spruce" :: Text)]
+
+        it "passes non-objects through unchanged" $ do
+            attachMarketHintByName "market for X" (String "s") `shouldBe` String "s"
+            attachMarketHintByName "market for X" Null `shouldBe` Null

--- a/volca.cabal
+++ b/volca.cabal
@@ -60,6 +60,7 @@ library
                      , API.Auth
                      , API.MCP
                      , API.MCP.Enrich
+                     , API.MCP.Columnar
                      , API.OpenApi
                      , API.Resources
                      , API.Licenses
@@ -220,6 +221,7 @@ test-suite lca-tests
                      , MCPSchemaSpec
                      , BatchImpactsSpec
                      , MCPEnrichSpec
+                     , MCPColumnarSpec
                      , NormalizeSpec
                      , BM25Spec
                      , FuzzySpec


### PR DESCRIPTION
## Why

Three friction points surfaced while answering a real LCA question (24 wood ICVs scored against the PEF panel) over MCP:

1. **The model forgets to surface `web_url`.** Each tool response carries a deep link to the activity's web UI, but nothing in the tool description tells the model to render it as a clickable link. Users got bare `processId` strings instead of navigable URLs.
2. **No hint when the caller hits a `market for ...` activity.** Markets are aggregated supplier mixes, not source ICVs. A user asking for "wood ICVs" was returned hits that included market activities they should have been steered away from.
3. **`score_activities` responses blow past the ~50 KB MCP persist threshold.** For 24 PIDs × 16 PEF indicators the JSON was 54.5 KB — persisted to a file, awkward for downstream LLM clients (and unrecoverable for ChatGPT / Claude desktop without bash).

## What changes

### 1. `web_url` rendering hints (UX-only)

Appends one English sentence to the descriptions of every MCP tool that emits a `web_url`:

> Each result includes a `web_url` deep link to the activity's page in the VoLCA web UI. When presenting results to a human, surface these as clickable markdown links so they can drill down — do not list bare `processId` strings.

Tools touched: `get_impacts`, `get_contributing_flows`, `get_contributing_activities`, `compute_sensitivity`, `score_activity`, `score_activities`. The MCP server `instructions` block (handleInitialize) gets the same one-liner as a global rule.

### 2. Market-activity hint in response payload

When the resolved activity matches the `market for ...` naming convention (case-insensitive prefix), the response carries:

```json
"hint": {
  "kind": "market_activity",
  "message": "This is a 'market for ...' activity — an aggregated supplier mix, not a source ICV. Call get_activity to inspect its technosphere inputs (the actual producers)."
}
```

Attached to `get_activity`, `get_impacts`, `score_activity`. Skipped on `score_activities` — the columnar shape doesn't admit per-row hints cleanly, and batch callers typically already know what they're scoring.

### 3. `score_activities` returns a columnar JSON shape

Replaces the previous nested row-shape with a flat columnar payload covering one chosen scoring set per call:

```json
{
  "scoringSet": "PEF",
  "scoringUnit": "µPts PEF",
  "functionalUnit": "1.00 cubic meter of ...",
  "columns": ["name", "processId", "web_url", "total", "acd", "cch", "etf", ...],
  "rows": [
    ["hardwood forestry, oak, RoW", "04bada39_...", "http://.../activity/...", 7256.5, 88.6, 422.2, 14.1, ...],
    ...
  ],
  "notFound": [],
  "invalid": []
}
```

Three sources of bloat are eliminated at once:
* Per-entry duplication of `scoringUnits` / `availableNWsets` / `functionalUnit` — hoisted once to top level.
* Per-indicator `{category, value}` wrapping — replaced by raw numbers in row cells; the variable → category mapping is already in `list_scoring_sets`.
* N×M repetition of JSON keys — `columns` declared once.

On the 24×16 PEF test: 54.5 KB → ~8 KB (~6×).

The chosen scoring set is auto-picked when the collection has a single configured set; with multiple sets, the caller must pass exactly one name in `scoring_sets`. Unknown / multiple names fail loudly with a message listing the configured options.

### 4. `summary_only` for batch ranking

New optional boolean on `score_activities`. When true, the per-indicator columns collapse to a single `dominantIndicator` cell shaped `key:share_pct` (e.g. `"ldu:82.3"`) — the variable with the largest absolute share of each activity's total. Useful for ranking large batches before drilling into a specific PID with `score_activity`.

### Cleanup

Drops the now-unused `summarizeBatchResults`, `summarizeBatchEntry`, `filterScoringSetsBatch`, `filterEntry`, `overArrayE`, `traverseKey`, and `overObjectE` helpers from `API.MCP.Enrich` together with their tests — the row-shaped projection they powered is no longer emitted.

## Out of scope (deferred)

* CSV / TSV output format — `compact` already gets within 25 % of CSV size while staying inside JSON.
* The same columnar treatment for `get_inventory`, `get_contributing_flows`, `search_activities`. Ship after the `score_activities` shape proves itself.
* `is_market` boolean on `search_activities` results (the natural extension of the market hint).
* Forestry / raw-inventory classification preset (TOML config, separate concern).

## Test plan

* [x] `cabal test` — full suite passes (1050 examples, 0 failures, 1 pending). New MCPEnrichSpec coverage exercises `isMarketActivityName` and `attachMarketHintByName`. `MCPSchemaSpec` still passes (validates the new `summary_only` param + updated tool descriptions).
* [ ] **Manual MCP smoke-test before merge** — call `score_activities` with the 24-PID wood batch from the originating session and confirm: response < 50 KB, columnar shape, `web_url` per row, no file persistence on the transport. Also call `get_activity` on a `market for sawlog and veneer log, softwood, ...` PID and confirm `hint.kind == "market_activity"`.