### PR TITLE
Surface orphan-waste gap + exact-match cross-DB waste linker

### DIFF
--- a/src/API/OpenApi.hs
+++ b/src/API/OpenApi.hs
@@ -103,6 +103,7 @@ instance ToSchema GraphEdge where declareNamedSchema = genericDeclareNamedSchema
 instance ToSchema LCIAResult where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 instance ToSchema ScoringIndicator where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 instance ToSchema LCIABatchResult where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
+instance ToSchema CutoffWasteFlow where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 instance ToSchema BatchImpactsRequest where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 instance ToSchema BatchImpactsEntry where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 instance ToSchema BatchImpactsResponse where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -9,7 +9,7 @@ module API.Routes where
 import API.DatabaseHandlers (simpleAction)
 import qualified API.DatabaseHandlers as DBHandlers
 import qualified API.OpenApi
-import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), DatabaseListResponse (..), ExchangeDetail (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), RefDataListResponse (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadRequest (..), UploadResponse (..), apiFlowOfKind)
+import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), ExchangeDetail (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), RefDataListResponse (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadRequest (..), UploadResponse (..), apiFlowOfKind)
 import qualified Config
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Concurrent.STM (readTVarIO)
@@ -427,8 +427,9 @@ mkLCIABatchResult ::
     M.Map Text (M.Map Text Double) ->
     [ScoringSet] ->
     M.Map Text (M.Map Text ScoringIndicator) ->
+    [CutoffWasteFlow] ->
     LCIABatchResult
-mkLCIABatchResult results mNW nwSets scoringResults scoringSets scoringIndicators =
+mkLCIABatchResult results mNW nwSets scoringResults scoringSets scoringIndicators cutoffWaste =
     LCIABatchResult
         { lbrResults = results
         , lbrSingleScore = Nothing
@@ -438,6 +439,7 @@ mkLCIABatchResult results mNW nwSets scoringResults scoringSets scoringIndicator
         , lbrScoringResults = scoringResults
         , lbrScoringUnits = M.fromList [(ssName ss, ssUnit ss) | ss <- scoringSets]
         , lbrScoringIndicators = scoringIndicators
+        , lbrCutoffWaste = cutoffWaste
         }
 
 -- | Per-category single-line log within a batch.
@@ -768,7 +770,7 @@ buildLCIABatchResultCached dbManager dbName db actPid activity collection sol ct
     let rawScoreMap = M.fromList [(lrCategory r, lrScore r) | r <- results]
     (scoringResults, scoringIndicators) <-
         computeAllScoringSets (mcScoringSets collection) rawScoreMap
-    pure (mkLCIABatchResult results mNW nwSets scoringResults (mcScoringSets collection) scoringIndicators)
+    pure (mkLCIABatchResult results mNW nwSets scoringResults (mcScoringSets collection) scoringIndicators (Service.buildCutoffWaste db activity))
 
 {- | Top-level LCIA batch entry point — Handler-returning. Used by the Servant
 routes (via thin where-aliases) and by API.BatchImpacts.
@@ -831,7 +833,7 @@ activityLCIABatchH dbManager dbName processIdText collectionName mSub = do
                         <> T.unpack name
                         <> "': "
                         <> intercalate ", " [T.unpack k <> "=" <> showFFloat (Just 6) v "" | (k, v) <- M.toList scores]
-    pure (mkLCIABatchResult results mNW nwSets scoringResults scoringSets scoringIndicators)
+    pure (mkLCIABatchResult results mNW nwSets scoringResults scoringSets scoringIndicators (Service.buildCutoffWaste db activity))
 
 {- | Top-level multi-activity batch impacts. One MUMPS multi-RHS solve for all
 valid PIDs, parallel characterization. Used by the Servant POST route and

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -477,7 +477,10 @@ and no other loaded database provides an explicit match either. The score
 excludes it; this record makes that exclusion visible.
 -}
 data CutoffWasteFlow = CutoffWasteFlow
-    { cwfFlowName :: Text
+    { cwfFlowId :: UUID
+    -- ^ Waste flow UUID — lets consumers programmatically address the
+    -- cut-off (e.g. to propose a treatment activity that would close it).
+    , cwfFlowName :: Text
     , cwfAmount :: Double
     , cwfUnit :: Text
     }

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -464,6 +464,22 @@ data LCIABatchResult = LCIABatchResult
     -- ^ Scoring set name → display unit (e.g., "Pts", "µPts PEF")
     , lbrScoringIndicators :: M.Map Text (M.Map Text ScoringIndicator)
     -- ^ Scoring set name → (variable name → indicator). One row per scoring variable.
+    , lbrCutoffWaste :: [CutoffWasteFlow]
+    -- ^ Orphan waste exchanges on the scored activity — flows the dataset author
+    -- left unmodelled. They contribute 0 to the score; surfacing them lets
+    -- consumers see what's excluded rather than silently undercounting.
+    }
+    deriving (Generic)
+
+{- | A single orphan waste exchange on a scored activity: the dataset author
+declared this waste output but did not link it to a treatment activity,
+and no other loaded database provides an explicit match either. The score
+excludes it; this record makes that exclusion visible.
+-}
+data CutoffWasteFlow = CutoffWasteFlow
+    { cwfFlowName :: Text
+    , cwfAmount :: Double
+    , cwfUnit :: Text
     }
     deriving (Generic)
 
@@ -791,7 +807,8 @@ data ActivityMetadata = ActivityMetadata
     { pmTotalFlows :: Int -- Number of unique flows used
     , pmTechnosphereInputs :: Int -- Count of technosphere inputs
     , pmBiosphereExchanges :: Int -- Count of biosphere exchanges (strict: excludes waste)
-    , pmWasteExchanges :: Int -- Count of waste exchanges (third flow kind)
+    , pmWasteExchangesLinked :: Int -- Waste exchanges resolved to a treatment activity
+    , pmWasteExchangesOrphan :: Int -- Cut-off waste exchanges (no modelled treatment)
     , pmHasReferenceProduct :: Bool -- Whether activity has reference product
     , pmReferenceProductFlow :: Maybe UUID -- Flow ID of reference product
     }
@@ -934,6 +951,7 @@ instance ToJSON FlowContributionEntry where toJSON = strippedToJSON; toEncoding 
 instance ToJSON LCIAResult where toJSON = strippedToJSON; toEncoding = strippedToEncoding
 instance ToJSON ScoringIndicator where toJSON = strippedToJSON; toEncoding = strippedToEncoding
 instance ToJSON LCIABatchResult where toJSON = strippedToJSON; toEncoding = strippedToEncoding
+instance ToJSON CutoffWasteFlow where toJSON = strippedToJSON; toEncoding = strippedToEncoding
 instance ToJSON BatchImpactsEntry where toJSON = strippedToJSON; toEncoding = strippedToEncoding
 instance ToJSON BatchImpactsResponse where toJSON = strippedToJSON; toEncoding = strippedToEncoding
 instance FromJSON BatchImpactsRequest where parseJSON = strippedParseJSON

--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -43,6 +43,8 @@ module Database.CrossLinking (
     -- * Main Functions
     findSupplierAcrossDatabases,
     findSupplierInIndexedDBs,
+    findWasteTreatmentAcrossDatabases,
+    WasteTreatmentMatch (..),
 
     -- * Scoring Functions
     matchProductName,
@@ -84,6 +86,7 @@ import Types (
     LocationKind (..),
     SimpleDatabase (..),
     TechnosphereFlow (..),
+    WasteFlow (..),
     exchangeFlowId,
     exchangeIsReference,
     exchangeLocation,
@@ -99,6 +102,12 @@ data IndexedDatabase = IndexedDatabase
     { idbName :: !Text
     , idbByProductName :: !(M.Map Text [SupplierEntry]) -- Normalized product name → suppliers
     , idbBySynonymGroup :: !(M.Map Int [SupplierEntry]) -- Synonym group ID → suppliers
+    , idbWasteTreatmentByFlowUUID :: !(M.Map UUID [SupplierEntry])
+    -- ^ Waste flow UUID → activities whose reference product is that waste
+    -- (treatment activities). Strict-matched only — no synonym, no scoring.
+    , idbWasteTreatmentByCanonicalName :: !(M.Map Text [SupplierEntry])
+    -- ^ normalizeText (wfName) → same set, for the name-based fallback when
+    -- two databases use different UUIDs for the same canonical waste flow.
     }
 
 {- | Entry in the supplier index
@@ -327,10 +336,15 @@ buildIndexedDatabase dbName synDB db =
                 | (prodName, entry) <- entries
                 , Just groupId <- [lookupSynonymGroup synDB (normalizeName prodName)]
                 ]
+        wasteEntries = buildWasteTreatmentEntries db
+        wasteByUUID = M.fromListWith (++) [(uuid, [entry]) | (uuid, _, entry) <- wasteEntries]
+        wasteByName = M.fromListWith (++) [(normalizeText name, [entry]) | (_, name, entry) <- wasteEntries, not (T.null (normalizeText name))]
      in IndexedDatabase
             { idbName = dbName
             , idbByProductName = byName
             , idbBySynonymGroup = bySynonym
+            , idbWasteTreatmentByFlowUUID = wasteByUUID
+            , idbWasteTreatmentByCanonicalName = wasteByName
             }
 
 {- | Build supplier entries from a SimpleDatabase. Reference exchanges of
@@ -345,6 +359,20 @@ buildSupplierEntries db =
     , exchangeIsReference ex
     , Just flow <- [M.lookup (exchangeFlowId ex) (sdbTechFlows db)]
     , loc <- supplierLocations act ex
+    ]
+
+{- | Treatment-activity entries from a SimpleDatabase: an activity is a waste
+treatment supplier iff its reference exchange's flow is in 'sdbWasteFlows'
+(the dataset author declared a waste flow as the activity's reference
+product). One tuple per (waste flow UUID, waste flow name, entry).
+-}
+buildWasteTreatmentEntries :: SimpleDatabase -> [(UUID, Text, SupplierEntry)]
+buildWasteTreatmentEntries db =
+    [ (wfId flow, wfName flow, SupplierEntry actUUID prodUUID (activityLocation act) (activityUnit act) (wfName flow))
+    | ((actUUID, prodUUID), act) <- M.toList (sdbActivities db)
+    , ex <- exchanges act
+    , exchangeIsReference ex
+    , Just flow <- [M.lookup (exchangeFlowId ex) (sdbWasteFlows db)]
     ]
 
 {- | Build an indexed database from a full Database (used when loading from cache)
@@ -370,10 +398,15 @@ buildIndexedDatabaseFromDB dbName synDB db =
                 | (prodName, entry) <- entries
                 , Just groupId <- [lookupSynonymGroup synDB (normalizeName prodName)]
                 ]
+        wasteEntries = buildWasteTreatmentEntriesFromDB db
+        wasteByUUID = M.fromListWith (++) [(uuid, [entry]) | (uuid, _, entry) <- wasteEntries]
+        wasteByName = M.fromListWith (++) [(normalizeText name, [entry]) | (_, name, entry) <- wasteEntries, not (T.null (normalizeText name))]
      in IndexedDatabase
             { idbName = dbName
             , idbByProductName = byName
             , idbBySynonymGroup = bySynonym
+            , idbWasteTreatmentByFlowUUID = wasteByUUID
+            , idbWasteTreatmentByCanonicalName = wasteByName
             }
 
 {- | Build supplier entries from a full Database. Same invariant as
@@ -407,6 +440,73 @@ supplierLocations act ex =
      in if not (T.null exLoc) && exLoc /= actLoc
             then [actLoc, exLoc]
             else [actLoc]
+
+-- | Treatment-activity entries from a full Database. Mirrors 'buildWasteTreatmentEntries'.
+buildWasteTreatmentEntriesFromDB :: Database -> [(UUID, Text, SupplierEntry)]
+buildWasteTreatmentEntriesFromDB db =
+    [ (wfId flow, wfName flow, SupplierEntry actUUID prodUUID (activityLocation act) (activityUnit act) (wfName flow))
+    | (pid, (actUUID, prodUUID)) <- zip ([0 ..] :: [Int]) (V.toList (dbProcessIdTable db))
+    , Just act <- [getActivity db (fromIntegral pid)]
+    , ex <- exchanges act
+    , exchangeIsReference ex
+    , Just flow <- [M.lookup (exchangeFlowId ex) (dbWasteFlows db)]
+    ]
+
+{- | Outcome of a strict cross-DB waste-treatment lookup.
+
+The matcher is intentionally narrow: it succeeds only when the dataset
+author has provided an explicit alignment (same flow UUID, or — as a
+fallback — byte-exact normalized flow name) and exactly one database in
+the pool offers a candidate. Two databases offering a match resolves to
+'WasteAmbiguous', never to a first-wins auto-pick. There is no synonym
+graph, no compound-name extraction, no location widening, and no scoring
+threshold — those would cross from honoring explicit intent into
+fabricating links.
+-}
+data WasteTreatmentMatch
+    = WasteMatched !SupplierEntry !Text -- ^ entry + source database name
+    | WasteAmbiguous ![Text] -- ^ databases that all offered a candidate
+    | WasteNoMatch
+
+{- | Strict cross-DB waste-treatment lookup. Honors author-provided alignment
+only — see 'WasteTreatmentMatch' for the semantics.
+
+Resolution order: flow UUID first, then byte-exact normalized name. Within
+each tier, a match is accepted iff exactly one database in 'lcIndexedDatabases'
+contains a candidate. Multiple within-DB candidates count as one match for
+that database (treatment by region selection is the database author's
+choice; if it ships per-region treatments, we don't pick).
+-}
+findWasteTreatmentAcrossDatabases ::
+    LinkingContext ->
+    -- | Orphan waste flow UUID
+    UUID ->
+    -- | Canonical waste flow name (for the name-based fallback)
+    Text ->
+    WasteTreatmentMatch
+findWasteTreatmentAcrossDatabases LinkingContext{lcIndexedDatabases} flowUUID flowName =
+    case lookupSingleDB (M.lookup flowUUID . idbWasteTreatmentByFlowUUID) of
+        match@WasteMatched{} -> match
+        WasteAmbiguous dbs -> WasteAmbiguous dbs
+        WasteNoMatch ->
+            let normalized = normalizeText flowName
+             in if T.null normalized
+                    then WasteNoMatch
+                    else lookupSingleDB (M.lookup normalized . idbWasteTreatmentByCanonicalName)
+  where
+    lookupSingleDB :: (IndexedDatabase -> Maybe [SupplierEntry]) -> WasteTreatmentMatch
+    lookupSingleDB lookupKey =
+        let perDB =
+                [ (idbName idb, entries)
+                | idb <- lcIndexedDatabases
+                , Just entries <- [lookupKey idb]
+                , not (null entries)
+                ]
+         in case perDB of
+                [(dbN, [entry])] -> WasteMatched entry dbN
+                [_] -> WasteNoMatch -- single DB with multiple candidates: stay orphan
+                [] -> WasteNoMatch
+                manyDbs -> WasteAmbiguous (map fst manyDbs)
 
 {- | Find a supplier across all loaded databases (using pre-built indexes)
 This is the fast O(1) lookup version

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -104,9 +104,12 @@ import Database.CrossLinking (
     IndexedDatabase (..),
     LinkWarning (..),
     LinkingContext (..),
+    SupplierEntry (..),
+    WasteTreatmentMatch (..),
     defaultLinkingThreshold,
     extractProductPrefixes,
     findSupplierAcrossDatabases,
+    findWasteTreatmentAcrossDatabases,
     locationHierarchy,
     normalizeUnicode,
  )
@@ -1201,6 +1204,7 @@ fixActivityLinksWithCrossDB indexedDbs synonymDB unitConfig locationHier policy 
                     findAllCrossDBLinks
                         linkingCtx
                         (sdbTechFlows db)
+                        (sdbWasteFlows db)
                         (sdbUnits db)
                         (sdbActivities db)
 
@@ -1269,41 +1273,47 @@ Returns statistics including the CrossDBLinks for chained solving
 findAllCrossDBLinks ::
     LinkingContext ->
     TechFlowDB ->
+    WasteFlowDB ->
     UnitDB ->
     ActivityMap ->
     CrossDBLinkingStats
-findAllCrossDBLinks ctx techFlowDb unitDb activities =
-    let results = M.mapWithKey (findActivityCrossDBLinks ctx techFlowDb unitDb) activities
+findAllCrossDBLinks ctx techFlowDb wasteFlowDb unitDb activities =
+    let results = M.mapWithKey (findActivityCrossDBLinks ctx techFlowDb wasteFlowDb unitDb) activities
      in foldr mergeCrossDBStats emptyCrossDBLinkingStats (M.elems results)
 
 -- | Find cross-database links for one activity's exchanges
 findActivityCrossDBLinks ::
     LinkingContext ->
     TechFlowDB ->
+    WasteFlowDB ->
     UnitDB ->
     -- | Consumer activity key (actUUID, prodUUID)
     (UUID.UUID, UUID.UUID) ->
     Activity ->
     CrossDBLinkingStats
-findActivityCrossDBLinks ctx techFlowDb unitDb (consumerActUUID, consumerProdUUID) act =
-    let stats = map (findExchangeCrossDBLink ctx techFlowDb unitDb consumerActUUID consumerProdUUID) (exchanges act)
+findActivityCrossDBLinks ctx techFlowDb wasteFlowDb unitDb (consumerActUUID, consumerProdUUID) act =
+    let stats = map (findExchangeCrossDBLink ctx techFlowDb wasteFlowDb unitDb consumerActUUID consumerProdUUID) (exchanges act)
      in foldr mergeCrossDBStats emptyCrossDBLinkingStats stats
 
 {- | Find cross-database link for a single exchange.
 
-Only attempts cross-DB linking if:
-1. Exchange is a technosphere input (or reference input on a treatment process)
-2. Exchange is currently unlinked (activityLinkId is nil)
+Two paths:
+* Technosphere inputs whose linkId is nil: use the existing scored matcher
+  ('findSupplierAcrossDatabases').
+* Orphan waste outputs (waIsInput=False, linkId=nil): strict-match only via
+  'findWasteTreatmentAcrossDatabases' — no synonym, no widening; one DB
+  wins or stays orphan, multi-DB matches count as ambiguous.
 -}
 findExchangeCrossDBLink ::
     LinkingContext ->
     TechFlowDB ->
+    WasteFlowDB ->
     UnitDB ->
     UUID.UUID ->
     UUID.UUID ->
     Exchange ->
     CrossDBLinkingStats
-findExchangeCrossDBLink ctx techFlowDb unitDb consumerActUUID consumerProdUUID ex@TechnosphereExchange{techFlowId = fid, techAmount = amt, techActivityLinkId = linkId, techLocation = loc}
+findExchangeCrossDBLink ctx techFlowDb _wasteFlowDb unitDb consumerActUUID consumerProdUUID ex@TechnosphereExchange{techFlowId = fid, techAmount = amt, techActivityLinkId = linkId, techLocation = loc}
     | exchangeIsInput ex && linkId == UUID.nil =
         case M.lookup fid techFlowDb of
             Nothing -> emptyCrossDBLinkingStats
@@ -1328,7 +1338,7 @@ findExchangeCrossDBLink ctx techFlowDb unitDb consumerActUUID consumerProdUUID e
                                     [ LocationFallback (cdlrProductName result) req actLoc kind
                                     | UpperLocationUsed req actLoc kind <- cdlrWarnings result
                                     ]
-                             in CrossDBLinkingStats [crossLink] M.empty S.empty fallbacks [] 0
+                             in CrossDBLinkingStats [crossLink] M.empty S.empty fallbacks [] 0 0 0 0
                         CrossDBNotLinked blocker ->
                             let unresolved = case blocker of
                                     LocationRejectedByPolicy req actLoc kind ->
@@ -1345,14 +1355,36 @@ findExchangeCrossDBLink ctx techFlowDb unitDb consumerActUUID consumerProdUUID e
                                         [LocationUnresolved (tfName flow) req "no candidate above link threshold"]
                                     NoNameMatch -> []
                                     UnitIncompatible _ _ -> []
-                             in CrossDBLinkingStats [] (M.singleton (tfName flow) (1, blocker)) S.empty [] unresolved 0
+                             in CrossDBLinkingStats [] (M.singleton (tfName flow) (1, blocker)) S.empty [] unresolved 0 0 0 0
     | otherwise = emptyCrossDBLinkingStats
-findExchangeCrossDBLink _ _ _ _ _ BiosphereExchange{} = emptyCrossDBLinkingStats
--- Cross-DB linking for waste flows is deferred: orphan waste outputs are
--- end-of-life markers (no demand on another DB), and waste *inputs* that
--- require a treatment supplier would need a dedicated lookup keyed on
--- WasteFlow rather than TechnosphereFlow. Pure no-op until that path lands.
-findExchangeCrossDBLink _ _ _ _ _ WasteExchange{} = emptyCrossDBLinkingStats
+findExchangeCrossDBLink _ _ _ _ _ _ BiosphereExchange{} = emptyCrossDBLinkingStats
+-- Cross-DB linking for orphan waste OUTPUTS: strict match only — see
+-- 'findWasteTreatmentAcrossDatabases'. No synonym, no fuzzy name match, no
+-- location widening. Multi-DB matches stay orphan as 'cdlWasteAmbiguous'.
+-- Waste inputs (treatment side) are left alone: they have no clean LCA
+-- semantic as a cross-DB demand.
+findExchangeCrossDBLink ctx _ wasteFlowDb _ consumerActUUID consumerProdUUID WasteExchange{waFlowId = fid, waAmount = amt, waActivityLinkId = lid, waIsInput = isInp}
+    | not isInp && lid == UUID.nil =
+        let flowName = maybe "" wfName (M.lookup fid wasteFlowDb)
+         in case findWasteTreatmentAcrossDatabases ctx fid flowName of
+                WasteMatched entry dbN ->
+                    let !crossLink =
+                            CrossDBLink
+                                { cdlConsumerActUUID = consumerActUUID
+                                , cdlConsumerProdUUID = consumerProdUUID
+                                , cdlSupplierActUUID = seActivityUUID entry
+                                , cdlSupplierProdUUID = seProductUUID entry
+                                , cdlCoefficient = amt
+                                , cdlExchangeUnit = seUnit entry
+                                , cdlFlowName = seProductName entry
+                                , cdlLocation = seLocation entry
+                                , cdlSourceDatabase = dbN
+                                , cdlTiedAlternatives = []
+                                }
+                     in CrossDBLinkingStats [crossLink] M.empty S.empty [] [] 0 1 0 0
+                WasteAmbiguous _ -> CrossDBLinkingStats [] M.empty S.empty [] [] 0 0 1 0
+                WasteNoMatch -> CrossDBLinkingStats [] M.empty S.empty [] [] 0 0 0 1
+    | otherwise = emptyCrossDBLinkingStats
 
 -- | Report cross-database linking statistics
 reportCrossDBLinkingStats :: Int -> CrossDBLinkingStats -> IO ()
@@ -1384,6 +1416,18 @@ reportCrossDBLinkingStats nActivities stats = do
     forM_ (M.toList (crossDBBySource stats)) $ \(srcDb, count) ->
         reportProgress Info $
             printf "  - %s: %d links" (T.unpack srcDb) count
+
+    -- Waste exchange resolution (only printed when this DB has any waste activity)
+    let !wExact = cdlWasteExactLinks stats
+        !wAmbig = cdlWasteAmbiguous stats
+        !wCutoff = cdlCutoffWasteCount stats
+    when (wExact + wAmbig + wCutoff > 0) $
+        reportProgress Info $
+            printf
+                "Waste: %d linked (exact), %d ambiguous, %d cut-off (treatment not modelled)"
+                wExact
+                wAmbig
+                wCutoff
 
     -- Missing suppliers
     let !missing = sortOn (\(_, (cnt, _)) -> Down cnt) $ M.toList (cdlUnresolvedProducts stats)

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -1325,6 +1325,7 @@ findExchangeCrossDBLink ctx techFlowDb _wasteFlowDb unitDb consumerActUUID consu
                                     CrossDBLink
                                         { cdlConsumerActUUID = consumerActUUID
                                         , cdlConsumerProdUUID = consumerProdUUID
+                                        , cdlConsumerFlowId = fid
                                         , cdlSupplierActUUID = cdlrActivityUUID result
                                         , cdlSupplierProdUUID = cdlrProductUUID result
                                         , cdlCoefficient = amt
@@ -1338,7 +1339,7 @@ findExchangeCrossDBLink ctx techFlowDb _wasteFlowDb unitDb consumerActUUID consu
                                     [ LocationFallback (cdlrProductName result) req actLoc kind
                                     | UpperLocationUsed req actLoc kind <- cdlrWarnings result
                                     ]
-                             in CrossDBLinkingStats [crossLink] M.empty S.empty fallbacks [] 0 0 0 0
+                             in emptyCrossDBLinkingStats{cdlLinks = [crossLink], cdlLocationFallbacks = fallbacks}
                         CrossDBNotLinked blocker ->
                             let unresolved = case blocker of
                                     LocationRejectedByPolicy req actLoc kind ->
@@ -1355,7 +1356,10 @@ findExchangeCrossDBLink ctx techFlowDb _wasteFlowDb unitDb consumerActUUID consu
                                         [LocationUnresolved (tfName flow) req "no candidate above link threshold"]
                                     NoNameMatch -> []
                                     UnitIncompatible _ _ -> []
-                             in CrossDBLinkingStats [] (M.singleton (tfName flow) (1, blocker)) S.empty [] unresolved 0 0 0 0
+                             in emptyCrossDBLinkingStats
+                                    { cdlUnresolvedProducts = M.singleton (tfName flow) (1, blocker)
+                                    , cdlLocationUnresolved = unresolved
+                                    }
     | otherwise = emptyCrossDBLinkingStats
 findExchangeCrossDBLink _ _ _ _ _ _ BiosphereExchange{} = emptyCrossDBLinkingStats
 -- Cross-DB linking for orphan waste OUTPUTS: strict match only — see
@@ -1372,6 +1376,7 @@ findExchangeCrossDBLink ctx _ wasteFlowDb _ consumerActUUID consumerProdUUID Was
                             CrossDBLink
                                 { cdlConsumerActUUID = consumerActUUID
                                 , cdlConsumerProdUUID = consumerProdUUID
+                                , cdlConsumerFlowId = fid
                                 , cdlSupplierActUUID = seActivityUUID entry
                                 , cdlSupplierProdUUID = seProductUUID entry
                                 , cdlCoefficient = amt
@@ -1381,9 +1386,9 @@ findExchangeCrossDBLink ctx _ wasteFlowDb _ consumerActUUID consumerProdUUID Was
                                 , cdlSourceDatabase = dbN
                                 , cdlTiedAlternatives = []
                                 }
-                     in CrossDBLinkingStats [crossLink] M.empty S.empty [] [] 0 1 0 0
-                WasteAmbiguous _ -> CrossDBLinkingStats [] M.empty S.empty [] [] 0 0 1 0
-                WasteNoMatch -> CrossDBLinkingStats [] M.empty S.empty [] [] 0 0 0 1
+                     in emptyCrossDBLinkingStats{cdlLinks = [crossLink], cdlWasteExactLinks = 1}
+                WasteAmbiguous _ -> emptyCrossDBLinkingStats{cdlWasteAmbiguous = 1}
+                WasteNoMatch -> emptyCrossDBLinkingStats{cdlCutoffWasteCount = 1}
     | otherwise = emptyCrossDBLinkingStats
 
 -- | Report cross-database linking statistics

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1520,6 +1520,7 @@ relinkDatabase manager dbName = do
                     Loader.findAllCrossDBLinks
                         ctx
                         (dbTechFlows db)
+                        (dbWasteFlows db)
                         (dbUnits db)
                         activityMap
                 newStats = rawStats{cdlTotalInputs = totalInputs}

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -16,7 +16,7 @@ import qualified Data.IntSet as IS
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
-import Data.Maybe (catMaybes, fromMaybe)
+import Data.Maybe (catMaybes, fromMaybe, isJust)
 import Data.Sequence (Seq (..), (|>))
 import qualified Data.Set as S
 import Data.Text (Text)
@@ -973,37 +973,64 @@ getClassifications db =
         | (sys, vals) <- L.sortOn fst (M.toList bySystem)
         ]
 
+{- | Consumer-side flow UUIDs on @activity@ that the load-time cross-DB linker
+has explicitly resolved via 'dbCrossDBLinks'. Used to distinguish a *true*
+cut-off / orphan from an exchange whose demand is routed to a supplier in
+another loaded database (and therefore contributes to the score via the
+matrix path). Empty when the activity has no entry in the process-id table.
+-}
+crossDBResolvedFlowIds :: Database -> Activity -> S.Set UUID
+crossDBResolvedFlowIds db activity =
+    case findProcessIdForActivity db activity >>= processIdToUUIDs db of
+        Nothing -> S.empty
+        Just (actUUID, _) ->
+            S.fromList
+                [ cdlConsumerFlowId link
+                | link <- dbCrossDBLinks db
+                , cdlConsumerActUUID link == actUUID
+                , cdlConsumerFlowId link /= UUID.nil
+                ]
+
 {- | Build the list of orphan waste exchanges on an activity — waste flows the
-dataset author left unmodelled (no link to a treatment activity, and no
-explicit match in any other loaded database). These contribute 0 to LCIA
-scores; surfacing them lets consumers see what is excluded rather than
-silently undercounting.
+dataset author left unmodelled (no in-database link to a treatment activity,
+and no explicit cross-DB match either). These contribute 0 to LCIA scores;
+surfacing them lets consumers see what is excluded rather than silently
+undercounting. Waste exchanges already routed to another database via
+'dbCrossDBLinks' are excluded — they do contribute to the score and are
+therefore not cut-offs.
 -}
 buildCutoffWaste :: Database -> Activity -> [CutoffWasteFlow]
 buildCutoffWaste db activity =
-    [ CutoffWasteFlow
-        { cwfFlowName = maybe (unresolvedName fid) wfName mFlow
-        , cwfAmount = amt
-        , cwfUnit = maybe "" (lookupUnitName . wfUnitId) mFlow
-        }
-    | WasteExchange{waActivityLinkId = lid, waFlowId = fid, waAmount = amt} <- exchanges activity
-    , lid == UUID.nil
-    , let mFlow = M.lookup fid (dbWasteFlows db)
-    ]
+    let resolved = crossDBResolvedFlowIds db activity
+     in [ CutoffWasteFlow
+            { cwfFlowId = fid
+            , cwfFlowName = maybe (unresolvedName fid) wfName mFlow
+            , cwfAmount = amt
+            , cwfUnit = maybe "" (lookupUnitName . wfUnitId) mFlow
+            }
+        | WasteExchange{waActivityLinkId = lid, waIsInput = False, waFlowId = fid, waAmount = amt} <- exchanges activity
+        , lid == UUID.nil
+        , not (S.member fid resolved)
+        , let mFlow = M.lookup fid (dbWasteFlows db)
+        ]
   where
     unresolvedName fid = "<unresolved waste " <> UUID.toText fid <> ">"
     lookupUnitName uid = maybe "" unitName (M.lookup uid (dbUnits db))
 
--- | Calculate extended metadata for an activity
+{- | Extended metadata for an activity. Cross-DB-resolved waste exchanges count
+as @pmWasteExchangesLinked@, not @pmWasteExchangesOrphan@, so the metric
+matches what the score actually consumes.
+-}
 calculateActivityMetadata :: Database -> Activity -> ActivityMetadata
-calculateActivityMetadata _db activity =
+calculateActivityMetadata db activity =
     let allExchanges = exchanges activity
         uniqueFlows = length $ M.fromList [(exchangeFlowId ex, ()) | ex <- allExchanges]
         techInputs = length [ex | ex <- allExchanges, isTechnosphereExchange ex, exchangeIsInput ex, not (exchangeIsReference ex)]
         bioExchanges = length [ex | ex <- allExchanges, isBiosphereExchange ex]
-        wasteLinkIds = [linkId | WasteExchange{waActivityLinkId = linkId} <- allExchanges]
-        wasteLinked = length (filter (/= UUID.nil) wasteLinkIds)
-        wasteOrphan = length wasteLinkIds - wasteLinked
+        resolved = crossDBResolvedFlowIds db activity
+        wasteExchanges = [(fid, linkId) | WasteExchange{waFlowId = fid, waActivityLinkId = linkId} <- allExchanges]
+        wasteLinked = length [() | (fid, linkId) <- wasteExchanges, linkId /= UUID.nil || S.member fid resolved]
+        wasteOrphan = length wasteExchanges - wasteLinked
         refProduct = case [ex | ex <- allExchanges, exchangeIsReference ex] of
             [] -> Nothing
             (ex : _) -> Just (exchangeFlowId ex)
@@ -1013,7 +1040,7 @@ calculateActivityMetadata _db activity =
             , pmBiosphereExchanges = bioExchanges
             , pmWasteExchangesLinked = wasteLinked
             , pmWasteExchangesOrphan = wasteOrphan
-            , pmHasReferenceProduct = refProduct /= Nothing
+            , pmHasReferenceProduct = isJust refProduct
             , pmReferenceProductFlow = refProduct
             }
 
@@ -1061,13 +1088,17 @@ convertActivityForAPI unitCfg db processId activity =
             , pfaExchanges = map convertExchangeWithUnit (exchanges activity)
             }
   where
-    -- Build cross-DB link lookup by normalized flow name for this consumer activity
+    -- Cross-DB link lookup keyed by 'cdlConsumerFlowId' (the consumer-side flow
+    -- UUID). UUIDs are unique across flow kinds, so a tech "X" link and a waste
+    -- "X" link on the same activity cannot collide here.
+    crossDBLinkMap :: M.Map UUID CrossDBLink
     crossDBLinkMap = case processIdToUUIDs db processId of
         Just (actUUID, _) ->
             M.fromList
-                [ (T.toLower (cdlFlowName link), link)
+                [ (cdlConsumerFlowId link, link)
                 | link <- dbCrossDBLinks db
                 , cdlConsumerActUUID link == actUUID
+                , cdlConsumerFlowId link /= UUID.nil
                 ]
         Nothing -> M.empty
 
@@ -1102,7 +1133,7 @@ convertActivityForAPI unitCfg db processId activity =
                                 | Just act <- getActivity db pid ->
                                     (Just (activityName act), Just (activityLocation act), Just (processIdToText db pid))
                             _ ->
-                                case techFlowInfo >>= \flow -> M.lookup (T.toLower (tfName flow)) crossDBLinkMap of
+                                case M.lookup fId crossDBLinkMap of
                                     Just link ->
                                         let crossPid =
                                                 cdlSourceDatabase link
@@ -1127,9 +1158,9 @@ convertActivityForAPI unitCfg db processId activity =
                                     processIdText = fmap (processIdToText db) maybeProcessId
                                  in (Just (activityName targetActivity), Just (activityLocation targetActivity), processIdText)
                             Nothing -> (Nothing, Nothing, Nothing)
-                WasteExchange{waActivityLinkId = linkId, waIsInput = False}
+                WasteExchange{waActivityLinkId = linkId, waIsInput = False, waFlowId = fid}
                     | linkId == UUID.nil ->
-                        case wasteFlowInfo >>= \flow -> M.lookup (T.toLower (wfName flow)) crossDBLinkMap of
+                        case M.lookup fid crossDBLinkMap of
                             Just link ->
                                 let crossPid =
                                         cdlSourceDatabase link
@@ -1287,7 +1318,7 @@ getActivityExchangeDetails db activity filterFn =
                             (getUnitNameForTechFlow (dbUnits db) flow)
                             unitForExchange
                             exUnitName
-                            (resolveTechTarget exchange flow)
+                            (resolveCrossDBTarget exchange)
                     Nothing -> unresolved (ApiUnresolvedFlow fid)
                 BiosphereExchange{} -> case M.lookup fid (dbBioFlows db) of
                     Just flow ->
@@ -1307,7 +1338,7 @@ getActivityExchangeDetails db activity filterFn =
                             (getUnitNameForWasteFlow (dbUnits db) flow)
                             unitForExchange
                             exUnitName
-                            (resolveWasteTarget exchange flow)
+                            (resolveCrossDBTarget exchange)
                     Nothing -> unresolved (ApiUnresolvedFlow fid)
 
     -- Sentinel returned only when the exchange's unit UUID itself failed
@@ -1316,33 +1347,33 @@ getActivityExchangeDetails db activity filterFn =
     -- in both the structured Unit and the exUnitName string.
     unresolvedUnit = Unit{unitId = UUID.nil, unitName = "<unresolved unit>", unitSymbol = "", unitComment = ""}
 
-    -- Cross-DB link lookup by consumer's flow name, built once per activity
-    -- for O(log n) per-exchange resolution.
-    crossLinkByFlow :: M.Map Text CrossDBLink
+    -- Cross-DB link lookup keyed by the consumer-side flow UUID
+    -- ('cdlConsumerFlowId'). Built once per activity; O(log n) per-exchange
+    -- resolution. Keying by UUID — rather than normalized flow name — avoids
+    -- the collision where a tech "X" link and a waste "X" link on the same
+    -- activity would overwrite each other in a name-keyed map.
+    crossLinkByFlow :: M.Map UUID CrossDBLink
     crossLinkByFlow = case findProcessIdForActivity db activity >>= processIdToUUIDs db of
         Just (actUUID, _) ->
             M.fromList
-                [ (T.toLower (cdlFlowName link), link)
+                [ (cdlConsumerFlowId link, link)
                 | link <- dbCrossDBLinks db
                 , cdlConsumerActUUID link == actUUID
+                , cdlConsumerFlowId link /= UUID.nil
                 ]
         Nothing -> M.empty
 
-    resolveTechTarget exchange flow =
+    -- Resolves a target activity for a technosphere or waste exchange. Orphan
+    -- waste outputs resolved by the exact-match cross-DB linker share the same
+    -- 'crossLinkByFlow' path as technosphere inputs; both are keyed on the
+    -- consumer-side flow UUID.
+    resolveCrossDBTarget exchange =
         case getTargetActivity db exchange of
             Just s -> Just s
-            Nothing -> crossDBTarget (tfName flow)
+            Nothing -> crossDBTarget (exchangeFlowId exchange)
 
-    -- Orphan waste outputs resolved by the exact-match cross-DB linker share
-    -- the same crossLinkByFlow path as technosphere inputs; both index by
-    -- normalized flow name.
-    resolveWasteTarget exchange flow =
-        case getTargetActivity db exchange of
-            Just s -> Just s
-            Nothing -> crossDBTarget (wfName flow)
-
-    crossDBTarget flowName =
-        case M.lookup (T.toLower flowName) crossLinkByFlow of
+    crossDBTarget consumerFlowId =
+        case M.lookup consumerFlowId crossLinkByFlow of
             Nothing -> Nothing
             Just link ->
                 let qualifiedPid =
@@ -2549,6 +2580,10 @@ mkVirtualLink rootDb consumerPid depDb depDbName supUUIDs supPid coef =
      in CrossDBLink
             { cdlConsumerActUUID = cActU
             , cdlConsumerProdUUID = cProdU
+            -- Substitution links never enter 'dbCrossDBLinks' and the API
+            -- surface only indexes load-time links by 'cdlConsumerFlowId',
+            -- so the discriminator is unused for synthetic links.
+            , cdlConsumerFlowId = UUID.nil
             , cdlSupplierActUUID = supActU
             , cdlSupplierProdUUID = supProdU
             , cdlCoefficient = coef

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -4,7 +4,7 @@
 
 module Service where
 
-import API.Types (ActivityForAPI (..), ActivityInfo (..), ActivityLinks (..), ActivityMetadata (..), ActivityStats (..), ActivitySummary (..), ApiFlow (..), ClassificationSystem (..), ConsumerResult (..), ConsumersResponse (..), EdgeType (..), ExchangeDetail (..), ExchangeWithUnit (..), ExportNode (..), FlowDetail (..), FlowInfo (..), FlowRole (..), FlowSearchResult (..), FlowSummary (..), GraphEdge (..), GraphExport (..), GraphNode (..), InventoryExport (..), InventoryFlowDetail (..), InventoryMetadata (..), InventoryStatistics (..), NodeType (..), Perturbation (..), RootDb (..), SearchResults (..), Substitution (..), SupplyChainEdge (..), SupplyChainEntry (..), SupplyChainResponse (..), ThisDb (..), TreeEdge (..), TreeExport (..), TreeMetadata (..), parseSubRef, unresolvedFlowName)
+import API.Types (ActivityForAPI (..), ActivityInfo (..), ActivityLinks (..), ActivityMetadata (..), ActivityStats (..), ActivitySummary (..), ApiFlow (..), ClassificationSystem (..), ConsumerResult (..), ConsumersResponse (..), CutoffWasteFlow (..), EdgeType (..), ExchangeDetail (..), ExchangeWithUnit (..), ExportNode (..), FlowDetail (..), FlowInfo (..), FlowRole (..), FlowSearchResult (..), FlowSummary (..), GraphEdge (..), GraphExport (..), GraphNode (..), InventoryExport (..), InventoryFlowDetail (..), InventoryMetadata (..), InventoryStatistics (..), NodeType (..), Perturbation (..), RootDb (..), SearchResults (..), Substitution (..), SupplyChainEdge (..), SupplyChainEntry (..), SupplyChainResponse (..), ThisDb (..), TreeEdge (..), TreeExport (..), TreeMetadata (..), parseSubRef, unresolvedFlowName)
 import CLI.Types (DebugMatricesOptions (..))
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Exception (SomeException, try)
@@ -973,6 +973,27 @@ getClassifications db =
         | (sys, vals) <- L.sortOn fst (M.toList bySystem)
         ]
 
+{- | Build the list of orphan waste exchanges on an activity — waste flows the
+dataset author left unmodelled (no link to a treatment activity, and no
+explicit match in any other loaded database). These contribute 0 to LCIA
+scores; surfacing them lets consumers see what is excluded rather than
+silently undercounting.
+-}
+buildCutoffWaste :: Database -> Activity -> [CutoffWasteFlow]
+buildCutoffWaste db activity =
+    [ CutoffWasteFlow
+        { cwfFlowName = maybe (unresolvedName fid) wfName mFlow
+        , cwfAmount = amt
+        , cwfUnit = maybe "" (lookupUnitName . wfUnitId) mFlow
+        }
+    | WasteExchange{waActivityLinkId = lid, waFlowId = fid, waAmount = amt} <- exchanges activity
+    , lid == UUID.nil
+    , let mFlow = M.lookup fid (dbWasteFlows db)
+    ]
+  where
+    unresolvedName fid = "<unresolved waste " <> UUID.toText fid <> ">"
+    lookupUnitName uid = maybe "" unitName (M.lookup uid (dbUnits db))
+
 -- | Calculate extended metadata for an activity
 calculateActivityMetadata :: Database -> Activity -> ActivityMetadata
 calculateActivityMetadata _db activity =
@@ -980,7 +1001,9 @@ calculateActivityMetadata _db activity =
         uniqueFlows = length $ M.fromList [(exchangeFlowId ex, ()) | ex <- allExchanges]
         techInputs = length [ex | ex <- allExchanges, isTechnosphereExchange ex, exchangeIsInput ex, not (exchangeIsReference ex)]
         bioExchanges = length [ex | ex <- allExchanges, isBiosphereExchange ex]
-        wasteExchanges = length [ex | ex <- allExchanges, isWasteExchange ex]
+        wasteLinkIds = [linkId | WasteExchange{waActivityLinkId = linkId} <- allExchanges]
+        wasteLinked = length (filter (/= UUID.nil) wasteLinkIds)
+        wasteOrphan = length wasteLinkIds - wasteLinked
         refProduct = case [ex | ex <- allExchanges, exchangeIsReference ex] of
             [] -> Nothing
             (ex : _) -> Just (exchangeFlowId ex)
@@ -988,7 +1011,8 @@ calculateActivityMetadata _db activity =
             { pmTotalFlows = uniqueFlows
             , pmTechnosphereInputs = techInputs
             , pmBiosphereExchanges = bioExchanges
-            , pmWasteExchanges = wasteExchanges
+            , pmWasteExchangesLinked = wasteLinked
+            , pmWasteExchangesOrphan = wasteOrphan
             , pmHasReferenceProduct = refProduct /= Nothing
             , pmReferenceProductFlow = refProduct
             }
@@ -1092,8 +1116,9 @@ convertActivityForAPI unitCfg db processId activity =
                 BiosphereExchange{} -> (Nothing, Nothing, Nothing)
                 -- A waste exchange consumed by a treatment activity links the
                 -- generator to that treatment, same shape as a technosphere
-                -- Input. Orphan waste outputs (the bulk of Final waste flows)
-                -- have nil linkId and stay unresolved on this surface.
+                -- Input. Orphan waste outputs that the exact-match cross-DB
+                -- linker resolved show up via 'crossDBLinkMap' keyed on the
+                -- waste flow name. The remaining orphans stay unresolved.
                 WasteExchange{waActivityLinkId = linkId, waIsInput = True}
                     | linkId /= UUID.nil ->
                         case findActivityByActivityUUID db linkId of
@@ -1101,6 +1126,18 @@ convertActivityForAPI unitCfg db processId activity =
                                 let maybeProcessId = findProcessIdByActivityUUID db linkId
                                     processIdText = fmap (processIdToText db) maybeProcessId
                                  in (Just (activityName targetActivity), Just (activityLocation targetActivity), processIdText)
+                            Nothing -> (Nothing, Nothing, Nothing)
+                WasteExchange{waActivityLinkId = linkId, waIsInput = False}
+                    | linkId == UUID.nil ->
+                        case wasteFlowInfo >>= \flow -> M.lookup (T.toLower (wfName flow)) crossDBLinkMap of
+                            Just link ->
+                                let crossPid =
+                                        cdlSourceDatabase link
+                                            <> "::"
+                                            <> UUID.toText (cdlSupplierActUUID link)
+                                            <> "_"
+                                            <> UUID.toText (cdlSupplierProdUUID link)
+                                 in (Just (cdlFlowName link), Just (cdlLocation link), Just crossPid)
                             Nothing -> (Nothing, Nothing, Nothing)
                 WasteExchange{} -> (Nothing, Nothing, Nothing)
             -- When the exchange's flow UUID resolves on none of the three sides
@@ -1270,10 +1307,7 @@ getActivityExchangeDetails db activity filterFn =
                             (getUnitNameForWasteFlow (dbUnits db) flow)
                             unitForExchange
                             exUnitName
-                            -- Linked-treatment-activity resolution is deferred
-                            -- to the cross-DB linker; orphan waste outputs (the
-                            -- typical SimaPro Final waste flow) carry no target.
-                            Nothing
+                            (resolveWasteTarget exchange flow)
                     Nothing -> unresolved (ApiUnresolvedFlow fid)
 
     -- Sentinel returned only when the exchange's unit UUID itself failed
@@ -1297,10 +1331,18 @@ getActivityExchangeDetails db activity filterFn =
     resolveTechTarget exchange flow =
         case getTargetActivity db exchange of
             Just s -> Just s
-            Nothing -> crossDBTarget flow
+            Nothing -> crossDBTarget (tfName flow)
 
-    crossDBTarget flow =
-        case M.lookup (T.toLower (tfName flow)) crossLinkByFlow of
+    -- Orphan waste outputs resolved by the exact-match cross-DB linker share
+    -- the same crossLinkByFlow path as technosphere inputs; both index by
+    -- normalized flow name.
+    resolveWasteTarget exchange flow =
+        case getTargetActivity db exchange of
+            Just s -> Just s
+            Nothing -> crossDBTarget (wfName flow)
+
+    crossDBTarget flowName =
+        case M.lookup (T.toLower flowName) crossLinkByFlow of
             Nothing -> Nothing
             Just link ->
                 let qualifiedPid =

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1058,7 +1058,7 @@ Only essential state is stored; counts are derived via accessor functions.
 -}
 data CrossDBLinkingStats = CrossDBLinkingStats
     { cdlLinks :: ![CrossDBLink]
-    -- ^ Resolved cross-DB links
+    -- ^ Resolved cross-DB links (technosphere + waste)
     , cdlUnresolvedProducts :: !(M.Map Text (Int, LinkBlocker))
     -- ^ Product name -> (count, reason)
     , cdlUnknownUnits :: !(S.Set Text)
@@ -1069,12 +1069,18 @@ data CrossDBLinkingStats = CrossDBLinkingStats
     -- ^ Inputs rejected by policy or with no candidate
     , cdlTotalInputs :: !Int
     -- ^ Total technosphere inputs at time of linking
+    , cdlWasteExactLinks :: !Int
+    -- ^ Orphan waste exchanges resolved by exact UUID / canonical-name match
+    , cdlWasteAmbiguous :: !Int
+    -- ^ Orphan waste exchanges with matches in 2+ databases (stayed orphan)
+    , cdlCutoffWasteCount :: !Int
+    -- ^ Orphan waste exchanges with no match in any DB (true cut-offs)
     }
     deriving (Generic, NFData, Store)
 
 -- | Empty stats
 emptyCrossDBLinkingStats :: CrossDBLinkingStats
-emptyCrossDBLinkingStats = CrossDBLinkingStats [] M.empty S.empty [] [] 0
+emptyCrossDBLinkingStats = CrossDBLinkingStats [] M.empty S.empty [] [] 0 0 0 0
 
 -- | Merge two CrossDBLinkingStats
 mergeCrossDBStats :: CrossDBLinkingStats -> CrossDBLinkingStats -> CrossDBLinkingStats
@@ -1086,6 +1092,9 @@ mergeCrossDBStats s1 s2 =
         , cdlLocationFallbacks = cdlLocationFallbacks s1 ++ cdlLocationFallbacks s2
         , cdlLocationUnresolved = cdlLocationUnresolved s1 ++ cdlLocationUnresolved s2
         , cdlTotalInputs = cdlTotalInputs s1 + cdlTotalInputs s2
+        , cdlWasteExactLinks = cdlWasteExactLinks s1 + cdlWasteExactLinks s2
+        , cdlWasteAmbiguous = cdlWasteAmbiguous s1 + cdlWasteAmbiguous s2
+        , cdlCutoffWasteCount = cdlCutoffWasteCount s1 + cdlCutoffWasteCount s2
         }
   where
     mergeUnresolved (c1, b) (c2, _) = (c1 + c2, b)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1175,6 +1175,14 @@ data CrossDBLink = CrossDBLink
     -- ^ Consumer activity UUID (in this database)
     , cdlConsumerProdUUID :: !UUID
     -- ^ Consumer product UUID (in this database)
+    , cdlConsumerFlowId :: !UUID
+    {- ^ Consumer-side flow UUID that this link resolves. For technosphere
+    inputs this is the tech-flow UUID; for orphan waste outputs it is the
+    waste-flow UUID. Used as the keying discriminator on the API surface so
+    a tech "X" link and a waste "X" link on the same activity cannot
+    collide. 'UUID.nil' for synthetic substitution links built by
+    'mkVirtualLink', which never enter 'dbCrossDBLinks'.
+    -}
     , cdlSupplierActUUID :: !UUID
     -- ^ Supplier activity UUID (in another database)
     , cdlSupplierProdUUID :: !UUID

--- a/test/CrossDBRegionalLCIAFixture.hs
+++ b/test/CrossDBRegionalLCIAFixture.hs
@@ -181,6 +181,7 @@ linkAt consumerDb supplierDb supplierName supIdx coeff =
             CrossDBLink
                 { cdlConsumerActUUID = consumerAct
                 , cdlConsumerProdUUID = consumerProd
+                , cdlConsumerFlowId = UUID.nil
                 , cdlSupplierActUUID = supplierAct
                 , cdlSupplierProdUUID = supplierProd
                 , cdlCoefficient = coeff

--- a/test/DependencyChoiceSpec.hs
+++ b/test/DependencyChoiceSpec.hs
@@ -41,6 +41,8 @@ indexedWith name n =
         { idbName = name
         , idbByProductName = M.fromList [(name <> "-" <> k, []) | k <- take n keys]
         , idbBySynonymGroup = M.empty
+        , idbWasteTreatmentByFlowUUID = M.empty
+        , idbWasteTreatmentByCanonicalName = M.empty
         }
   where
     keys :: [Text]

--- a/test/MCPColumnarSpec.hs
+++ b/test/MCPColumnarSpec.hs
@@ -84,6 +84,7 @@ mkEntry pid name fu setName total inds =
                 , lbrScoringIndicators =
                     M.singleton setName $
                         M.fromList [(k, ScoringIndicator k v) | (k, v) <- inds]
+                , lbrCutoffWaste = []
                 }
         }
 

--- a/test/MinimalCoverSpec.hs
+++ b/test/MinimalCoverSpec.hs
@@ -81,6 +81,7 @@ mkLink src tied =
     CrossDBLink
         { cdlConsumerActUUID = UUID.nil
         , cdlConsumerProdUUID = UUID.nil
+        , cdlConsumerFlowId = UUID.nil
         , cdlSupplierActUUID = UUID.nil
         , cdlSupplierProdUUID = UUID.nil
         , cdlCoefficient = 0

--- a/test/TestHelpers.hs
+++ b/test/TestHelpers.hs
@@ -17,6 +17,7 @@ import qualified Data.Map as M
 import qualified Data.Map.Strict as MS
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import Database (buildDatabaseWithMatrices)
@@ -117,6 +118,7 @@ linkDatabases consumerDb supplierDb supplierName coeff =
             CrossDBLink
                 { cdlConsumerActUUID = consumerAct
                 , cdlConsumerProdUUID = consumerProd
+                , cdlConsumerFlowId = UUID.nil
                 , cdlSupplierActUUID = supplierAct
                 , cdlSupplierProdUUID = supplierProd
                 , cdlCoefficient = coeff

--- a/test/WasteCrossDBSpec.hs
+++ b/test/WasteCrossDBSpec.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module WasteCrossDBSpec (spec) where
+
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.UUID as UUID
+import Database.CrossLinking
+import SynonymDB (emptySynonymDB)
+import Test.Hspec
+import qualified UnitConversion as UC
+
+{- | Unit tests for the exact-match cross-DB waste-treatment linker.
+
+The linker honors only author-provided alignment: same flow UUID or
+byte-exact normalized name on the supplier's reference product. There is
+no synonym graph, no compound-name extraction, no widening, no scoring.
+Multiple databases offering a candidate resolves to 'WasteAmbiguous',
+never to a first-wins auto-pick.
+-}
+spec :: Spec
+spec = describe "findWasteTreatmentAcrossDatabases" $ do
+    let supplierFor :: Text -> SupplierEntry
+        supplierFor nm =
+            SupplierEntry
+                { seActivityUUID = UUID.fromWords 1 1 1 1
+                , seProductUUID = UUID.fromWords 2 2 2 2
+                , seLocation = "RoW"
+                , seUnit = "kg"
+                , seProductName = nm
+                }
+
+        idbWith :: Text -> [(UUID.UUID, SupplierEntry)] -> [(Text, SupplierEntry)] -> IndexedDatabase
+        idbWith name uuidEntries nameEntries =
+            IndexedDatabase
+                { idbName = name
+                , idbByProductName = M.empty
+                , idbBySynonymGroup = M.empty
+                , idbWasteTreatmentByFlowUUID = M.fromListWith (++) [(u, [e]) | (u, e) <- uuidEntries]
+                , idbWasteTreatmentByCanonicalName = M.fromListWith (++) [(n, [e]) | (n, e) <- nameEntries]
+                }
+
+        ctxWith :: [IndexedDatabase] -> LinkingContext
+        ctxWith dbs =
+            LinkingContext
+                { lcIndexedDatabases = dbs
+                , lcSynonymDB = emptySynonymDB
+                , lcUnitConfig = UC.defaultUnitConfig
+                , lcThreshold = defaultLinkingThreshold
+                , lcLocationHierarchy = M.empty
+                , lcGeographyPolicy = GeoExact
+                }
+
+        wasteUUID = UUID.fromWords 0xa 0xb 0xc 0xd
+        entry = supplierFor "Organic carbon, placed in landfill"
+
+        expectMatched dbExpected = \case
+            WasteMatched _ dbN -> dbN `shouldBe` dbExpected
+            WasteAmbiguous dbs -> expectationFailure $ "expected match in " <> show dbExpected <> ", got ambiguous across " <> show dbs
+            WasteNoMatch -> expectationFailure $ "expected match in " <> show dbExpected <> ", got no match"
+
+        expectNoMatch = \case
+            WasteNoMatch -> pure ()
+            WasteMatched _ dbN -> expectationFailure $ "expected no match, got match in " <> show dbN
+            WasteAmbiguous dbs -> expectationFailure $ "expected no match, got ambiguous across " <> show dbs
+
+    it "matches exactly when a single DB offers a UUID-aligned treatment" $ do
+        let ctx = ctxWith [idbWith "ecoinvent" [(wasteUUID, entry)] []]
+        expectMatched "ecoinvent" (findWasteTreatmentAcrossDatabases ctx wasteUUID "Organic carbon, placed in landfill")
+
+    it "matches via byte-exact canonical name when UUIDs differ" $ do
+        let otherUUID = UUID.fromWords 99 99 99 99
+            ctx = ctxWith [idbWith "ecoinvent" [(otherUUID, entry)] [("organic carbon, placed in landfill", entry)]]
+        expectMatched "ecoinvent" (findWasteTreatmentAcrossDatabases ctx wasteUUID "Organic carbon, placed in landfill")
+
+    it "name fallback is case- and whitespace-tolerant via normalizeText" $ do
+        let otherUUID = UUID.fromWords 77 77 77 77
+            ctx = ctxWith [idbWith "ecoinvent" [(otherUUID, entry)] [("organic carbon, placed in landfill", entry)]]
+        expectMatched "ecoinvent" (findWasteTreatmentAcrossDatabases ctx wasteUUID "  Organic Carbon, Placed in Landfill  ")
+
+    it "stays orphan when no DB knows the waste flow" $ do
+        let ctx = ctxWith [idbWith "ecoinvent" [] []]
+        expectNoMatch (findWasteTreatmentAcrossDatabases ctx wasteUUID "Plastic, waste, landfill")
+
+    it "stays orphan when only a similar-but-not-equal name exists (no fuzzy)" $ do
+        let ctx = ctxWith [idbWith "ecoinvent" [] [("organic carbon, landfill", entry)]]
+        expectNoMatch (findWasteTreatmentAcrossDatabases ctx wasteUUID "Organic carbon, placed in landfill")
+
+    it "stays orphan when one DB offers multiple within-DB candidates (author must pick)" $ do
+        let entryFR = (supplierFor "Organic carbon, landfill, FR"){seLocation = "FR"}
+            entryDE = (supplierFor "Organic carbon, landfill, DE"){seLocation = "DE"}
+            ecoinventMulti =
+                IndexedDatabase
+                    { idbName = "ecoinvent"
+                    , idbByProductName = M.empty
+                    , idbBySynonymGroup = M.empty
+                    , idbWasteTreatmentByFlowUUID = M.singleton wasteUUID [entryFR, entryDE]
+                    , idbWasteTreatmentByCanonicalName = M.empty
+                    }
+            ctx = ctxWith [ecoinventMulti]
+        expectNoMatch (findWasteTreatmentAcrossDatabases ctx wasteUUID "Organic carbon")
+
+    it "reports WasteAmbiguous when two databases each offer a single candidate" $ do
+        let ctx =
+                ctxWith
+                    [ idbWith "ecoinvent" [(wasteUUID, entry)] []
+                    , idbWith "wfldb" [(wasteUUID, entry)] []
+                    ]
+        case findWasteTreatmentAcrossDatabases ctx wasteUUID "Organic carbon, placed in landfill" of
+            WasteAmbiguous dbs -> do
+                length dbs `shouldBe` 2
+                ("ecoinvent" `elem` dbs) `shouldBe` True
+                ("wfldb" `elem` dbs) `shouldBe` True
+            WasteMatched _ dbN -> expectationFailure $ "expected ambiguous, got match in " <> show dbN
+            WasteNoMatch -> expectationFailure "expected ambiguous, got no match"
+
+    it "prefers UUID over name when a UUID match wins in one DB and only a name match exists in another" $ do
+        let ctx =
+                ctxWith
+                    [ idbWith "ecoinvent" [(wasteUUID, entry)] []
+                    , idbWith "wfldb" [] [("organic carbon, placed in landfill", entry)]
+                    ]
+        expectMatched "ecoinvent" (findWasteTreatmentAcrossDatabases ctx wasteUUID "Organic carbon, placed in landfill")


### PR DESCRIPTION
## Summary

Follow-up to #83. PR #83 introduced `WasteFlow` / `WasteExchange` and made SimaPro *Final waste flows* stop counting as missing suppliers, but deliberately left three TODO no-ops for cross-DB waste resolution.

This change makes orphan waste a first-class **observable** and honors author-provided alignment between databases — without introducing any heuristic linking. Four additive surfaces; ~+340 / -35 LOC; all 1060 specs green (existing 1052 + 8 new).

## Why exact-match only (no synonym / fuzzy / widening)

SimaPro *Final waste flows* are authorial cut-off markers, not unresolved demands. Auto-linking them via name heuristics would override the dataset author's modelling decision and silently fabricate numbers that look authoritative. The engine reports the gap; the database author closes it by providing a treatment activity with the aligned flow UUID (or byte-exact name).

**Gap-closing belongs to the database builder, not to the engine.**

## What changed

### 1. ActivityMetadata: split waste count
`pmWasteExchanges :: Int` → `pmWasteExchangesLinked :: Int` + `pmWasteExchangesOrphan :: Int`, partitioned on `waActivityLinkId == UUID.nil`. Breaking wire change (no-backward-compat for now).

### 2. Score response carries cut-off list
`LCIABatchResult.lbrCutoffWaste :: [CutoffWasteFlow]` — every orphan waste exchange on the scored activity, with flow name + amount + unit. Built by `Service.buildCutoffWaste` and attached at both call sites of `mkLCIABatchResult`. The batched `score_activities` form inherits it via the existing `BatchImpactsEntry` shape. `slimLCIAPanel` / `summarizeLCIAPanel` preserve the field (top-level, not inside `results`).

### 3. Exact-match cross-DB waste-treatment linker
`IndexedDatabase` gains `idbWasteTreatmentByFlowUUID` + `idbWasteTreatmentByCanonicalName`, populated from activities whose reference product is a `WasteFlow`. New `findWasteTreatmentAcrossDatabases` replaces the no-op at `Database/Loader.hs:1355`:

- Flow UUID match first, then byte-exact `normalizeText` name fallback.
- Succeeds only when **exactly one DB** has **exactly one candidate**.
- 2+ DBs with candidates → `WasteAmbiguous` (stays orphan).
- 1 DB with 2+ candidates → stays orphan (author must pick).

`Service.hs` API surface (`convertActivityForAPI` + `ExchangeDetail` builder) reads the resulting `CrossDBLink` rows the same way the technosphere path does, so a cross-DB waste link appears under the activity's exchange like any other link.

### 4. Stats output
`CrossDBLinkingStats` gains `cdlWasteExactLinks` / `cdlWasteAmbiguous` / `cdlCutoffWasteCount`. `reportCrossDBLinkingStats` prints one waste line per DB:

```
Waste: 7 linked (exact), 1 ambiguous, 12 cut-off (treatment not modelled)
```

Omitted when all three are zero (no false alarm on databases without any waste activity).

## What stays unchanged

- No heuristic waste linking — no `matchProductName`, no `SynonymDB`, no compound-name extraction, no location widening, no score threshold.
- `findAllUnlinkedTechInputs` semantics unchanged.
- Matrix construction unchanged. Explicitly-matched waste flows through the matrix exactly the same way technosphere cross-DB links do.

## Tests

`test/WasteCrossDBSpec.hs` (8 cases):
- exact UUID match
- byte-exact name fallback (different UUIDs, same canonical name)
- whitespace/case tolerance via `normalizeText`
- no-fuzzy-match guard (similar-but-not-equal names stay orphan)
- single-DB multi-candidate stays orphan
- 2-DB matches → `WasteAmbiguous`
- UUID-beats-name resolution order
- baseline: unknown waste flow stays orphan

## Test plan

- [x] `cabal test` — 1060 / 0 failures, 1 pending (was 1052)
- [x] `./build.sh` — full Haskell + Elm build clean
- [ ] Load a SimaPro export with *Final waste flows* (e.g. an ecobalyse dataset). Stats log should print a `Waste: 0 linked, 0 ambiguous, N cut-off` line.
- [ ] Add a second DB with a treatment activity whose reference product UUID matches one of the cut-off waste flows; reload and verify the stats line now reads `Waste: 1 linked (exact), 0 ambiguous, N-1 cut-off`.
- [ ] `curl /api/v1/db/<db>/activity/<pid> | jq '.metadata.pmWasteExchangesOrphan'` returns > 0 on an activity with cut-off waste.
- [ ] MCP `score_activity` on that activity returns a non-empty `cutoffWaste` array with the expected flow names + amounts.