### PR TITLE
pyvolca 0.4.0 — WasteExchange support + realign with current wire format

### DIFF
--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -22,6 +22,45 @@ permissions:
   contents: read
 
 jobs:
+  # Detect pyvolca-only PRs so the heavy build can no-op while still
+  # reporting `build / <platform>` as success. Branch protection's
+  # required-check list does not honour `paths-ignore`: a workflow that
+  # never runs leaves the check pending, blocking merge forever. The
+  # only safe way to skip the build is to keep the job running and
+  # short-circuit every step inside it — that is what `skip=true`
+  # signals to the matrix below.
+  preflight:
+    name: Detect pyvolca-only diff
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.s.outputs.skip }}
+    steps:
+      - id: s
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" != "pull_request" ]]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          base='${{ github.event.pull_request.base.sha }}'
+          head='${{ github.event.pull_request.head.sha }}'
+          # Compare via API instead of a heavyweight fetch — we only need
+          # filenames. Empty list (e.g. compare across unrelated histories)
+          # falls through to skip=false to stay on the safe side.
+          changed=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${base}...${head}" --jq '.files[].filename' 2>/dev/null || true)
+          if [[ -z "$changed" ]]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if echo "$changed" | grep -qvE '^pyvolca/'; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::pyvolca-only diff — build matrix will report success without compiling."
+          fi
+
   # Single source of truth for toolchain pins. Each downstream job
   # references needs.versions.outputs.* so a versions.env edit propagates
   # everywhere without touching workflow YAML.
@@ -42,7 +81,7 @@ jobs:
 
   build:
     name: ${{ matrix.name }}
-    needs: versions
+    needs: [preflight, versions]
     runs-on: ${{ matrix.runner }}
     # Linux jobs run in an Alpine container so the released binary links
     # against musl libc — truly portable across distros (vs. glibc-static,
@@ -83,6 +122,16 @@ jobs:
       run:
         shell: ${{ matrix.os == 'windows' && 'msys2 {0}' || 'bash' }}
     steps:
+      # Surfaces the no-op in the job log when the preflight has decided
+      # this is a pyvolca-only PR. Every step below is gated on
+      # `needs.preflight.outputs.skip != 'true'` so the job lands as
+      # "success" with no real work done — satisfies the four required
+      # `build / <platform>` checks without paying the cold compile.
+      - name: Pyvolca-only PR — skipping Haskell build
+        if: needs.preflight.outputs.skip == 'true'
+        shell: bash
+        run: echo "::notice::Pyvolca-only diff (per preflight); reporting success without building."
+
       # GitHub's JavaScript actions (checkout, cache, …) ship a glibc-linked
       # Node binary which refuses to run in an Alpine container on ARM64
       # ("JavaScript Actions in Alpine containers are only supported on x64
@@ -91,15 +140,17 @@ jobs:
       # Alpine. The action's own `runner.arch == 'ARM64'` guard makes it a
       # no-op on amd64. Every Linux matrix row runs in Alpine; future
       # non-Alpine Linux rows would need a separate selector.
-      - if: matrix.os == 'linux'
+      - if: needs.preflight.outputs.skip != 'true' && matrix.os == 'linux'
         uses: laverdet/alpine-arm64@v1
-      - uses: actions/checkout@v4
+      - if: needs.preflight.outputs.skip != 'true'
+        uses: actions/checkout@v4
 
       # POSIX `sh` here — bash isn't preinstalled in the Alpine container
       # we now use for Linux jobs (setup-haskell-env apk-installs it below).
       # All the work these two steps do is POSIX-compatible already.
       - name: Read pinned versions
         id: versions
+        if: needs.preflight.outputs.skip != 'true'
         shell: sh
         run: |
           # `./` so dash (Ubuntu /bin/sh) doesn't PATH-search for the file —
@@ -111,6 +162,7 @@ jobs:
 
       - name: Read engine version from cabal
         id: cabal-version
+        if: needs.preflight.outputs.skip != 'true'
         shell: sh
         run: |
           ver=$(awk '/^version:/ {print $2; exit}' volca.cabal)
@@ -118,6 +170,7 @@ jobs:
 
       - name: Setup Haskell build environment
         id: setup-haskell
+        if: needs.preflight.outputs.skip != 'true'
         uses: ./.github/actions/setup-haskell-env
         with:
           matrix-os: ${{ matrix.os }}
@@ -147,6 +200,7 @@ jobs:
 
       - name: Download prebuilt MUMPS (if release exists)
         id: download-mumps
+        if: needs.preflight.outputs.skip != 'true'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -180,7 +234,7 @@ jobs:
 
       - name: Restore MUMPS local build (fallback when prebuilt missing)
         id: cache-mumps
-        if: steps.download-mumps.outputs.populated != 'true'
+        if: needs.preflight.outputs.skip != 'true' && steps.download-mumps.outputs.populated != 'true'
         uses: actions/cache/restore@v4
         with:
           path: deps/mumps
@@ -202,6 +256,7 @@ jobs:
 
       - name: Download prebuilt cabal store (if release exists)
         id: download-cabal
+        if: needs.preflight.outputs.skip != 'true'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -241,7 +296,7 @@ jobs:
 
       - name: Restore Cabal store
         id: cache-cabal
-        if: steps.download-cabal.outputs.populated != 'true'
+        if: needs.preflight.outputs.skip != 'true' && steps.download-cabal.outputs.populated != 'true'
         uses: actions/cache/restore@v4
         with:
           # GHCup-installed cabal on Windows uses C:\cabal\store, not the
@@ -266,6 +321,7 @@ jobs:
             cabal-${{ matrix.name }}-
 
       - name: Build and test
+        if: needs.preflight.outputs.skip != 'true'
         run: |
           # Windows: re-source GHCup env in this MSYS2 shell since the wrapper
           # does not inherit PATH from the previous step.
@@ -295,7 +351,7 @@ jobs:
         # Catches the case where build-mumps.sh (or someone's local edit)
         # introduces dynamic MUMPS deps, including any future variant that
         # enables Scotch and ends up linking the system libscotch.so.
-        if: matrix.os == 'linux'
+        if: needs.preflight.outputs.skip != 'true' && matrix.os == 'linux'
         run: |
           VOLCA_BIN=$(cabal list-bin exe:volca)
           # Decompress UPX wrapper so ldd can read the dynamic section
@@ -319,7 +375,7 @@ jobs:
         # so the uploaded artifact is meaningfully smaller. Then verify it
         # still launches before upload — if a future UPX path is re-enabled
         # in build.sh and breaks the binary, this catches it loudly.
-        if: matrix.os == 'macos'
+        if: needs.preflight.outputs.skip != 'true' && matrix.os == 'macos'
         run: |
           ./build.sh --optimize-only
           VOLCA_BIN=$(cabal list-bin exe:volca)
@@ -334,6 +390,7 @@ jobs:
         # cache key namespace.
         if: |
           always() &&
+          needs.preflight.outputs.skip != 'true' &&
           steps.download-mumps.outputs.populated != 'true' &&
           steps.cache-mumps.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
@@ -349,7 +406,7 @@ jobs:
         # risk of caching a partial ~/.ghcup. (Contrast with the Windows
         # pattern, which is split across multiple steps and prefers the
         # safer no-always policy.)
-        if: always() && (matrix.os == 'linux' || matrix.os == 'macos') && steps.setup-haskell.outputs.ghcup-cache-hit != 'true'
+        if: always() && needs.preflight.outputs.skip != 'true' && (matrix.os == 'linux' || matrix.os == 'macos') && steps.setup-haskell.outputs.ghcup-cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: ~/.ghcup
@@ -375,7 +432,7 @@ jobs:
         # Key is inlined (not steps.cache-cabal.outputs.cache-primary-key)
         # because Restore Cabal store is skipped on the prebuilt-win path,
         # so its outputs are unset and we'd save with an empty key.
-        if: always() && steps.cache-cabal.outputs.cache-hit != 'true'
+        if: always() && needs.preflight.outputs.skip != 'true' && steps.cache-cabal.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: |
@@ -385,7 +442,7 @@ jobs:
           key: cabal-${{ matrix.name }}-ghc${{ steps.versions.outputs.ghc }}-${{ hashFiles('volca.cabal', 'mumps-hs/mumps-hs.cabal', 'cabal.project') }}-v2
 
       - name: Package release tarball
-        if: inputs.release
+        if: needs.preflight.outputs.skip != 'true' && inputs.release
         # Same `cabal list-bin` trick the macOS optimize step uses — handles
         # both opt/build and build paths regardless of optimization level.
         run: |
@@ -409,7 +466,7 @@ jobs:
           echo "ARTIFACT_PATH=${ARTIFACT}" >> "$GITHUB_ENV"
 
       - name: Upload binary (build mode)
-        if: ${{ !inputs.release }}
+        if: ${{ needs.preflight.outputs.skip != 'true' && !inputs.release }}
         uses: actions/upload-artifact@v4
         with:
           name: volca-${{ matrix.name }}
@@ -424,7 +481,7 @@ jobs:
           retention-days: 14
 
       - name: Upload tarball (release mode)
-        if: inputs.release
+        if: needs.preflight.outputs.skip != 'true' && inputs.release
         uses: actions/upload-artifact@v4
         with:
           name: volca-${{ matrix.name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,20 +9,18 @@ name: Build
 #     prebuilt usually masks this, but only when its hash matches; cache
 #     fallback is what catches the hash-changed case.
 #
-# Pyvolca PRs are skipped: pyvolca dispatches dynamically against the
-# engine's OpenAPI spec, so its changes don't affect the Haskell build —
-# running the full 4-platform cabal compile (~30 min on Windows cold)
-# is pure waste. Pyvolca has its own CI in pyvolca.yml.
+# Pyvolca-only PRs short-circuit inside _build-matrix.yml: a preflight
+# job detects a pyvolca-only diff and every matrix step no-ops, so the
+# four required `build / *` checks still report success without burning
+# the ~30 min cold-cabal compile. (A `paths-ignore: pyvolca/**` here
+# would skip the workflow entirely, leaving the required checks pending
+# forever — branch protection treats missing required checks as blocked.)
 
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'pyvolca/**'
   push:
     branches: [main]
-    paths-ignore:
-      - 'pyvolca/**'
 
 # Cancel any older in-flight runs for the same PR when a new commit is
 # pushed. Keeps queue depth bounded — Windows cold builds are 30 min

--- a/pyvolca/CHANGELOG.md
+++ b/pyvolca/CHANGELOG.md
@@ -1,0 +1,106 @@
+# Changelog
+
+All notable changes to **pyvolca** are documented here. Versions follow
+[semver](https://semver.org/); breaking changes bump the minor while we're
+in 0.x.
+
+The next-release section is **drafted by [git-cliff](https://git-cliff.org/)**
+from commits that touched `pyvolca/` since the last `pyvolca-v*` tag, then
+hand-edited for narrative and breaking-change callouts (`cliff.toml` only
+groups commits by Conventional Commits prefix — it doesn't know which renames
+are user-visible breaks). Workflow:
+
+```bash
+cd pyvolca
+git cliff --unreleased                        # preview against current HEAD
+git cliff --unreleased --tag pyvolca-v0.X.Y   # render as a released section
+```
+
+Then paste the rendered block at the top of this file and tighten wording.
+
+## [0.4.0] - 2026-05-26
+
+Engine wire format changed in three independent PRs since 0.3.1 — this
+release realigns the client. **Any pyvolca ≤ 0.3.1 will raise `KeyError`
+on most `get_activity` calls against a current engine.**
+
+### Breaking changes
+
+- **`TechnosphereExchange.is_input` / `is_reference` are now derived
+  properties**, computed from the new `role: TechRole` field
+  (`"ReferenceProduct" | "Coproduct" | "ReferenceInput" | "Input"`).
+  Constructors take `role=` instead. (#73, #76)
+- **`BiosphereExchange.is_input` is now a derived property**, computed
+  from the new `direction: BioDirection` field
+  (`"Resource" | "Emission"`). Constructors take `direction=` instead.
+  The `flow_category` field is gone — biosphere flows now carry a
+  structured `compartment: Compartment | None` (medium + optional
+  subcompartment). (#73, #76)
+- **`TechnosphereExchange.flow_category` removed.** Product taxonomy
+  lives on the producing activity's classifications, not on the exchange.
+  (#73)
+- **`ExchangeDetail.flow` is now a tagged sum**:
+  `{"kind": "technosphere" | "biosphere" | "waste", "flow": <flow>}`.
+  Hand-rolled callers that walked `ed["flow"]` flat must unwrap one level.
+  (#76, #83)
+- **`list_methods` returns `id` instead of `methodId`** on each method
+  dict — the rename mirrors the engine's stripped JSON convention. (#73)
+- **Download / install root moved** from `user_cache_dir("pyvolca")` to
+  `user_data_dir("volca", appauthor=False)`, shared with the shell and
+  PowerShell installers. Helpers `cached_binary` / `cached_data_dir` are
+  renamed `installed_binary` / `installed_data_dir`. `$VOLCA_HOME`
+  overrides the auto-detected root. (#21)
+
+### Added
+
+- **`WasteExchange`** — third top-level `Exchange` variant matching the
+  engine's `WasteFlow`. Activities containing waste exchanges (typical in
+  EcoSpold2, ILCD, and SimaPro `Final waste flows`) now parse without a
+  `ValueError`. Carries `flow_name`, `amount`, `unit`, `is_input`,
+  `target_activity`, `target_location`, `target_process_id`, `comment`,
+  plus `is_waste = True` for duck-typing dispatch. Exported from
+  `volca`. (#83)
+- **`Compartment`** dataclass (frozen, hashable) and **`TechRole`** /
+  `BioDirection` literal aliases exported from `volca`, so callers can
+  match on roles / directions without redefining the type. (#73)
+- **`installed_binary()` semver scan** — falls back to scanning
+  `$VOLCA_HOME` for the highest `X.Y.Z` dir containing the binary when
+  `latest.json` is absent. Lets `Server()` pick up engines installed via
+  `install.sh` / `install.ps1`, which don't write a manifest. (#21)
+
+### Changed
+
+- Internal: `parse_exchange_detail` validates that the flow envelope's
+  `kind` matches the inner `Exchange` tag and raises if they disagree,
+  instead of silently dropping the discriminator. (#76)
+- README rewritten to lead with the "hosted server vs local engine"
+  choice and explain where artefacts are installed. (#21)
+
+## [0.3.1] - 2026-04-29
+
+### Added
+
+- `download()` helper fetches the matching VoLCA engine binary + data
+  bundle from GitHub Releases, verifies SHA-256, and extracts under the
+  per-user cache. Idempotent + concurrency-safe (one fcntl/msvcrt lock
+  per cache root). `Server()` picks up the cached binary automatically.
+  (#7)
+
+## [0.3.0] - 2026-04-24
+
+### Added
+
+- PyPI packaging metadata (`pyproject.toml`, classifiers, LICENSE,
+  trusted publishing). (#3, #4)
+- Dedicated CI workflow for the pyvolca package.
+
+## [0.2.0] - earlier
+
+### Added
+
+- `VoLCAError` with clear diagnostics for non-JSON responses.
+- Typed dataclasses for the API surface (`Activity`, `ActivityDetail`,
+  `SupplyChain`, `LCIAResult`, `LCIABatchResult`, …).
+- `compare_activities` helper.
+- Agribalyse decompose helpers.
+- `Server` child-process wrapper.

--- a/pyvolca/cliff.toml
+++ b/pyvolca/cliff.toml
@@ -1,0 +1,60 @@
+# git-cliff config — pyvolca-scoped changelog generation.
+#
+# Usage:
+#   cd pyvolca
+#   git cliff --unreleased                              # preview next section
+#   git cliff --unreleased --prepend CHANGELOG.md       # prepend to file
+#   git cliff --tag pyvolca-v0.5.0 --unreleased         # cut a release
+#
+# The `include_path` filter keeps engine-only commits out of the pyvolca
+# log. The `tag_pattern` makes git-cliff treat `pyvolca-vX.Y.Z` tags as
+# the release boundaries, ignoring engine tags entirely.
+
+[changelog]
+header = """
+# Changelog\n
+All notable changes to **pyvolca** are documented here. Versions follow
+[semver](https://semver.org/); breaking changes bump the minor while we're
+in 0.x.\n
+"""
+body = """
+{% if version %}
+## [{{ version | trim_start_matches(pat="pyvolca-v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}
+## [Unreleased]
+{% endif %}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for c in commits %}
+- {{ c.message | split(pat="\n") | first | trim | upper_first }}{% if c.breaking %} **(BREAKING)**{% endif %}\
+{% endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = false  # keep unprefixed PR titles ("Add X ...") visible
+commit_parsers = [
+    { message = "^feat\\(pyvolca\\)", group = "Added" },
+    { message = "^feat", group = "Added" },
+    { message = "^fix\\(pyvolca\\)", group = "Fixed" },
+    { message = "^fix", group = "Fixed" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Changed" },
+    { message = "^docs\\(pyvolca\\)", group = "Documentation" },
+    { message = "^docs", skip = true },                       # engine docs only
+    { message = "^test", skip = true },
+    { message = "^chore", skip = true },
+    { message = "^ci", skip = true },
+    { message = "^style", skip = true },
+    { body = "BREAKING CHANGE", group = "Breaking changes" },
+    # Catch-all for unprefixed PR-merge subjects so a PR like
+    # "Add WasteFlow / WasteExchange ..." still shows up.
+    { message = ".*", group = "Other" },
+]
+filter_commits = true
+tag_pattern = "pyvolca-v[0-9]+\\.[0-9]+\\.[0-9]+"
+sort_commits = "newest"
+include_path = ["pyvolca/**"]

--- a/pyvolca/pyproject.toml
+++ b/pyvolca/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvolca"
-version = "0.3.1"
+version = "0.4.0"
 description = "Python client for VoLCA — Life Cycle Assessment engine"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/pyvolca/src/volca/__init__.py
+++ b/pyvolca/src/volca/__init__.py
@@ -30,6 +30,7 @@ from .types import (
     SupplyChainEntry,
     TechRole,
     TechnosphereExchange,
+    WasteExchange,
 )
 
 __all__ = [
@@ -62,6 +63,7 @@ __all__ = [
     "TechRole",
     "TechnosphereExchange",
     "VoLCAError",
+    "WasteExchange",
     "compare_activities",
     "download",
 ]

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -376,6 +376,7 @@ class TechnosphereExchange:
     comment: str | None = None
 
     is_biosphere: bool = False  # discriminator for callers using duck typing
+    is_waste: bool = False
 
     @property
     def is_input(self) -> bool:
@@ -419,6 +420,7 @@ class BiosphereExchange:
     comment: str | None = None
 
     is_biosphere: bool = True  # discriminator for callers using duck typing
+    is_waste: bool = False
 
     @property
     def is_input(self) -> bool:
@@ -437,30 +439,74 @@ class BiosphereExchange:
         )
 
 
-Exchange = Union[TechnosphereExchange, BiosphereExchange]
+@dataclass
+class WasteExchange:
+    """An exchange of a waste flow with a treatment activity.
+
+    Shares the technosphere matrix with product flows but tracked as its own
+    kind so callers can tell a "waste sent to landfill" output apart from a
+    product input. Orphan waste (no linked treatment) contributes zero impact
+    — same cut-off semantics as an orphan technosphere input.
+    """
+
+    flow_name: str
+    amount: float
+    unit: str
+    is_input: bool  # True = consumed by treatment process; False = generated (typical case)
+    target_activity: str | None
+    target_location: str | None
+    target_process_id: str | None
+    comment: str | None = None
+
+    is_biosphere: bool = False
+    is_waste: bool = True
+
+    @property
+    def is_reference(self) -> bool:
+        return False
+
+    @classmethod
+    def from_json(cls, ewu: dict) -> "WasteExchange":
+        inner = ewu["exchange"]
+        return cls(
+            flow_name=ewu["flowName"],
+            amount=inner["amount"],
+            unit=ewu["unitName"],
+            is_input=inner["isInput"],
+            target_activity=ewu.get("targetActivity"),
+            target_location=ewu.get("targetLocation"),
+            target_process_id=ewu.get("targetProcessId"),
+            comment=_exchange_comment(ewu, inner),
+        )
+
+
+Exchange = Union[TechnosphereExchange, BiosphereExchange, WasteExchange]
 
 
 def parse_exchange(ewu: dict) -> Exchange:
     """Parse an `ExchangeWithUnit` JSON dict (as returned by GET /activity).
 
     The inner `exchange` object is tagged with a `"tag"` discriminator
-    (``"TechnosphereExchange"`` or ``"BiosphereExchange"``) and carries all
-    variant-specific fields flat at the same level.
+    (``"TechnosphereExchange"``, ``"BiosphereExchange"`` or
+    ``"WasteExchange"``) and carries all variant-specific fields flat at the
+    same level.
     """
     tag = ewu["exchange"].get("tag")
     if tag == "TechnosphereExchange":
         return TechnosphereExchange.from_json(ewu)
     if tag == "BiosphereExchange":
         return BiosphereExchange.from_json(ewu)
+    if tag == "WasteExchange":
+        return WasteExchange.from_json(ewu)
     raise ValueError(f"Unknown exchange variant tag: {tag!r}")
 
 
 def parse_exchange_detail(ed: dict) -> Exchange:
     """Parse an ``ExchangeDetail`` JSON dict (returned by GET /activity/{pid}/inputs|outputs).
 
-    The flow is a tagged sum: ``{"kind": "technosphere", "flow": <techFlow>}``
-    or ``{"kind": "biosphere", "flow": <bioFlow>}``. The flow's ``kind`` lines
-    up with the exchange variant tag.
+    The flow is a tagged sum: ``{"kind": "technosphere"|"biosphere"|"waste",
+    "flow": <flow>}``. The flow's ``kind`` lines up with the exchange variant
+    tag.
     """
     inner = ed["exchange"]
     flow_outer = ed.get("flow") or {}
@@ -496,6 +542,22 @@ def parse_exchange_detail(ed: dict) -> Exchange:
             amount=inner["amount"],
             unit=unit,
             direction=inner["direction"],
+            comment=comment,
+        )
+    if tag == "WasteExchange":
+        if flow_kind not in (None, "waste"):
+            raise ValueError(
+                f"WasteExchange carried flow kind {flow_kind!r}"
+            )
+        target = ed.get("targetActivity") or {}
+        return WasteExchange(
+            flow_name=flow_payload.get("name", ""),
+            amount=inner["amount"],
+            unit=unit,
+            is_input=inner["isInput"],
+            target_activity=target.get("name"),
+            target_location=target.get("location"),
+            target_process_id=target.get("processId"),
             comment=comment,
         )
     raise ValueError(f"Unknown exchange variant tag: {tag!r}")

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -426,6 +426,10 @@ class BiosphereExchange:
     def is_input(self) -> bool:
         return _direction_is_input(self.direction)
 
+    @property
+    def is_reference(self) -> bool:
+        return False
+
     @classmethod
     def from_json(cls, ewu: dict) -> "BiosphereExchange":
         inner = ewu["exchange"]

--- a/pyvolca/tests/test_exchange_comment.py
+++ b/pyvolca/tests/test_exchange_comment.py
@@ -15,21 +15,27 @@ from __future__ import annotations
 from volca.types import (
     BiosphereExchange,
     TechnosphereExchange,
+    WasteExchange,
     parse_exchange,
     parse_exchange_detail,
 )
 
 
+def _inner(tag: str) -> dict:
+    """Variant-specific inner-exchange skeleton (no comment yet)."""
+    base: dict = {"tag": tag, "amount": 1.0}
+    if tag == "TechnosphereExchange":
+        base["role"] = "Input"
+    elif tag == "BiosphereExchange":
+        base["direction"] = "Resource"
+    elif tag == "WasteExchange":
+        base["isInput"] = False
+    return base
+
+
 def _ewu(tag: str, *, ex_comment: str | None, inner_comment: str | None) -> dict:
     """Build a minimal ExchangeWithUnit payload."""
-    inner: dict = {
-        "tag": tag,
-        "amount": 1.0,
-    }
-    if tag == "TechnosphereExchange":
-        inner["role"] = "Input"
-    else:
-        inner["direction"] = "Resource"
+    inner = _inner(tag)
     if inner_comment is not None:
         inner["comment"] = inner_comment
     out: dict = {
@@ -49,14 +55,7 @@ def _ewu(tag: str, *, ex_comment: str | None, inner_comment: str | None) -> dict
 
 def _ed(tag: str, *, inner_comment: str | None, ex_comment: str | None = None) -> dict:
     """Build a minimal ExchangeDetail payload."""
-    inner: dict = {
-        "tag": tag,
-        "amount": 1.0,
-    }
-    if tag == "TechnosphereExchange":
-        inner["role"] = "Input"
-    else:
-        inner["direction"] = "Resource"
+    inner = _inner(tag)
     if inner_comment is not None:
         inner["comment"] = inner_comment
     out: dict = {
@@ -65,8 +64,10 @@ def _ed(tag: str, *, inner_comment: str | None, ex_comment: str | None = None) -
     }
     if tag == "TechnosphereExchange":
         out["flow"] = {"kind": "technosphere", "flow": {"name": "wheat"}}
-    else:
+    elif tag == "BiosphereExchange":
         out["flow"] = {"kind": "biosphere", "flow": {"name": "wheat", "compartment": {"name": "air", "sub": None}}}
+    elif tag == "WasteExchange":
+        out["flow"] = {"kind": "waste", "flow": {"name": "wheat"}}
     if ex_comment is not None:
         out["exComment"] = ex_comment
     return out
@@ -82,6 +83,11 @@ class TestExchangeWithUnitComment:
         ex = parse_exchange(_ewu("BiosphereExchange", ex_comment="measured", inner_comment=None))
         assert isinstance(ex, BiosphereExchange)
         assert ex.comment == "measured"
+
+    def test_flat_excomment_is_picked_up_on_waste(self):
+        ex = parse_exchange(_ewu("WasteExchange", ex_comment="landfill", inner_comment=None))
+        assert isinstance(ex, WasteExchange)
+        assert ex.comment == "landfill"
 
     def test_falls_back_to_inner_comment_when_flat_absent(self):
         ex = parse_exchange(_ewu("TechnosphereExchange", ex_comment=None, inner_comment="legacy"))
@@ -106,6 +112,11 @@ class TestExchangeDetailComment:
         ex = parse_exchange_detail(_ed("BiosphereExchange", inner_comment="measured"))
         assert isinstance(ex, BiosphereExchange)
         assert ex.comment == "measured"
+
+    def test_inner_comment_is_picked_up_on_waste(self):
+        ex = parse_exchange_detail(_ed("WasteExchange", inner_comment="landfill"))
+        assert isinstance(ex, WasteExchange)
+        assert ex.comment == "landfill"
 
     def test_none_when_inner_absent(self):
         ex = parse_exchange_detail(_ed("TechnosphereExchange", inner_comment=None))

--- a/pyvolca/tests/test_waste_exchange.py
+++ b/pyvolca/tests/test_waste_exchange.py
@@ -109,6 +109,24 @@ class TestParseExchangeWaste:
         assert isinstance(tech, TechnosphereExchange) and tech.is_waste is False
         assert isinstance(bio, BiosphereExchange) and bio.is_waste is False
 
+    def test_is_reference_is_defined_on_every_variant(self):
+        """All three variants expose `is_reference` so duck-typing callers
+        never trip on AttributeError when iterating mixed exchanges."""
+        tech = parse_exchange({
+            "exchange": {"tag": "TechnosphereExchange", "amount": 1.0, "role": "Input"},
+            "flowName": "wheat", "unitName": "kg",
+            "targetActivity": None, "targetLocation": None, "targetProcessId": None,
+        })
+        bio = parse_exchange({
+            "exchange": {"tag": "BiosphereExchange", "amount": 1.0, "direction": "Emission"},
+            "flowName": "CO2", "unitName": "kg",
+            "compartment": {"name": "air", "sub": None},
+        })
+        waste = parse_exchange(_waste_ewu(is_input=False))
+        assert tech.is_reference is False
+        assert bio.is_reference is False
+        assert waste.is_reference is False
+
 
 class TestParseExchangeDetailWaste:
     def test_waste_kind_flow_envelope_parses(self):

--- a/pyvolca/tests/test_waste_exchange.py
+++ b/pyvolca/tests/test_waste_exchange.py
@@ -156,3 +156,23 @@ class TestParseExchangeDetailWaste:
         bad["flow"]["kind"] = "biosphere"
         with pytest.raises(ValueError, match="WasteExchange carried flow kind 'biosphere'"):
             parse_exchange_detail(bad)
+
+    def test_waste_flow_envelope_rejected_on_technosphere_tag(self):
+        """A waste-kind flow paired with a TechnosphereExchange tag is a
+        wire-format bug — refuse it rather than parsing as a product input."""
+        bad = {
+            "exchange": {"tag": "TechnosphereExchange", "amount": 1.0, "role": "Input"},
+            "exchangeUnitName": "kg",
+            "flow": {"kind": "waste", "flow": {"name": "wheat"}},
+        }
+        with pytest.raises(ValueError, match="TechnosphereExchange carried flow kind 'waste'"):
+            parse_exchange_detail(bad)
+
+    def test_waste_flow_envelope_rejected_on_biosphere_tag(self):
+        bad = {
+            "exchange": {"tag": "BiosphereExchange", "amount": 1.0, "direction": "Emission"},
+            "exchangeUnitName": "kg",
+            "flow": {"kind": "waste", "flow": {"name": "CO2"}},
+        }
+        with pytest.raises(ValueError, match="BiosphereExchange carried flow kind 'waste'"):
+            parse_exchange_detail(bad)

--- a/pyvolca/tests/test_waste_exchange.py
+++ b/pyvolca/tests/test_waste_exchange.py
@@ -1,0 +1,140 @@
+"""WasteExchange parsing — third top-level Exchange variant.
+
+The engine emits waste flows as their own kind (PR #83): they share the
+technosphere matrix with product flows but are tagged separately so callers
+can distinguish "waste sent to landfill" from a product input. Orphan waste
+(``activityLinkId == nil``, ``targetActivity == null``) is the typical case
+for SimaPro "Final waste flows".
+
+This module covers the wire shape for both envelopes:
+
+* ``ExchangeWithUnit`` — inner ``{tag: "WasteExchange", isInput, ...}`` plus
+  target fields at the envelope level when the cross-DB linker resolved the
+  waste output to a treatment activity.
+* ``ExchangeDetail`` — same inner shape, but the flow is carried as a
+  ``{kind: "waste", flow: <wasteFlow>}`` tagged sum.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from volca.types import (
+    BiosphereExchange,
+    TechnosphereExchange,
+    WasteExchange,
+    parse_exchange,
+    parse_exchange_detail,
+)
+
+
+def _waste_ewu(*, is_input: bool, target: dict | None = None) -> dict:
+    out: dict = {
+        "exchange": {
+            "tag": "WasteExchange",
+            "amount": 2.5,
+            "isInput": is_input,
+        },
+        "flowName": "Organic carbon, placed in landfill",
+        "unitName": "kg",
+        "targetActivity": (target or {}).get("name"),
+        "targetLocation": (target or {}).get("location"),
+        "targetProcessId": (target or {}).get("processId"),
+    }
+    return out
+
+
+def _waste_ed(*, is_input: bool, target: dict | None = None) -> dict:
+    out: dict = {
+        "exchange": {
+            "tag": "WasteExchange",
+            "amount": 2.5,
+            "isInput": is_input,
+        },
+        "exchangeUnitName": "kg",
+        "flow": {
+            "kind": "waste",
+            "flow": {"name": "Organic carbon, placed in landfill"},
+        },
+    }
+    if target is not None:
+        out["targetActivity"] = target
+    return out
+
+
+class TestParseExchangeWaste:
+    def test_orphan_waste_output_maps_to_waste_variant(self):
+        ex = parse_exchange(_waste_ewu(is_input=False))
+        assert isinstance(ex, WasteExchange)
+        assert ex.flow_name == "Organic carbon, placed in landfill"
+        assert ex.amount == 2.5
+        assert ex.unit == "kg"
+        assert ex.is_input is False
+        assert ex.target_activity is None
+        assert ex.target_location is None
+        assert ex.target_process_id is None
+
+    def test_linked_waste_input_carries_treatment_target(self):
+        target = {
+            "name": "Landfill of organic waste, FR",
+            "location": "FR",
+            "processId": "tttt0000-aaaa-bbbb-cccc-111122223333_pppp1111-eeee-ffff-aaaa-444455556666",
+        }
+        ex = parse_exchange(_waste_ewu(is_input=True, target=target))
+        assert isinstance(ex, WasteExchange)
+        assert ex.is_input is True
+        assert ex.target_activity == "Landfill of organic waste, FR"
+        assert ex.target_location == "FR"
+        assert ex.target_process_id == target["processId"]
+
+    def test_discriminator_flags_set_correctly(self):
+        """Duck-typing flags must place waste alongside neither tech nor bio."""
+        ex = parse_exchange(_waste_ewu(is_input=False))
+        assert ex.is_waste is True
+        assert ex.is_biosphere is False
+        # is_reference is always False on waste — there's no reference-waste concept.
+        assert ex.is_reference is False
+
+    def test_other_variants_are_not_waste(self):
+        tech = parse_exchange({
+            "exchange": {"tag": "TechnosphereExchange", "amount": 1.0, "role": "Input"},
+            "flowName": "wheat", "unitName": "kg",
+            "targetActivity": None, "targetLocation": None, "targetProcessId": None,
+        })
+        bio = parse_exchange({
+            "exchange": {"tag": "BiosphereExchange", "amount": 1.0, "direction": "Emission"},
+            "flowName": "CO2", "unitName": "kg",
+            "compartment": {"name": "air", "sub": None},
+        })
+        assert isinstance(tech, TechnosphereExchange) and tech.is_waste is False
+        assert isinstance(bio, BiosphereExchange) and bio.is_waste is False
+
+
+class TestParseExchangeDetailWaste:
+    def test_waste_kind_flow_envelope_parses(self):
+        ex = parse_exchange_detail(_waste_ed(is_input=False))
+        assert isinstance(ex, WasteExchange)
+        assert ex.flow_name == "Organic carbon, placed in landfill"
+        assert ex.is_input is False
+        assert ex.target_activity is None
+
+    def test_waste_with_linked_treatment_target(self):
+        target = {
+            "name": "Treatment, municipal solid waste, sanitary landfill",
+            "location": "CH",
+            "processId": "wwww1111-aaaa-bbbb-cccc-111122223333_qqqq2222-eeee-ffff-aaaa-444455556666",
+        }
+        ex = parse_exchange_detail(_waste_ed(is_input=True, target=target))
+        assert isinstance(ex, WasteExchange)
+        assert ex.is_input is True
+        assert ex.target_activity == target["name"]
+        assert ex.target_location == "CH"
+
+    def test_mismatched_flow_kind_rejected(self):
+        """If the engine ever ships a WasteExchange paired with a non-waste
+        flow envelope, surface it loudly instead of silently dropping the
+        type information."""
+        bad = _waste_ed(is_input=False)
+        bad["flow"]["kind"] = "biosphere"
+        with pytest.raises(ValueError, match="WasteExchange carried flow kind 'biosphere'"):
+            parse_exchange_detail(bad)


### PR DESCRIPTION
## Summary

- Adds `WasteExchange` as the third top-level `Exchange` variant, matching engine PR #83. Activities containing waste flows (typical for EcoSpold2, SimaPro `Final waste flows`, ILCD) no longer crash `get_activity` with `ValueError`.
- Bumps pyvolca to **0.4.0**. The PyPI 0.3.1 is broken against any current engine: the role/direction/compartment refactor (#73, #76) and the tagged `ApiFlow` envelope (#76) all shipped without a matching client release.
- Introduces `pyvolca/CHANGELOG.md` (the engine `CHANGELOG.md` at repo root only tracks the moteur) and `pyvolca/cliff.toml` so future bumps can draft their section via `git cliff --unreleased --tag pyvolca-vX.Y.Z`.

## Why 0.4.0 and not 0.3.2

Public surface renames are breaking:
- `TechnosphereExchange.is_input` / `is_reference` → derived from new `role: TechRole`
- `BiosphereExchange.is_input` → derived from new `direction: BioDirection`; gains `compartment: Compartment | None`; loses `flow_category`
- `ExchangeDetail.flow` is now `{"kind": ..., "flow": ...}` (was flat)
- `list_methods()` returns `id` (was `methodId`)
- `cached_binary` / `cached_data_dir` → `installed_binary` / `installed_data_dir`; install root moved from `user_cache_dir("pyvolca")` to `user_data_dir("volca")` (shared with `install.sh` / `install.ps1`)

## Commits

1. **`feat(pyvolca): parse WasteExchange as third Exchange variant`** — parser, exports, tests for both envelopes.
2. **`chore(pyvolca): release 0.4.0 — CHANGELOG + git-cliff config`** — version bump, changelog, automation wiring.

## Test plan

- [x] `pytest pyvolca/tests/` — 69 passed, 7 skipped (skips are pre-existing live-binary / network tests)
- [x] `git cliff --unreleased --tag pyvolca-v0.4.0` renders a coherent draft from history
- [ ] Manual: hit a SimaPro Agribalyse activity with `Final waste flows` and confirm `get_activity` returns `WasteExchange` entries with the expected `is_input` / `target_activity`
- [ ] Push `pyvolca-v0.4.0` tag → PyPI publish via Trusted Publishing