### PR TITLE
mcp: omit web_url when no frontend is bundled

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,8 +14,10 @@ import qualified Data.Text as T
 import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
 import Foreign.C.Types (CInt (..))
 import Options.Applicative
+import System.Directory (doesFileExist)
 import System.Environment (lookupEnv)
 import System.Exit (die, exitFailure)
+import System.FilePath ((</>))
 import System.IO (hFlush, stderr, stdout)
 import Text.Read (readMaybe)
 
@@ -226,7 +228,13 @@ overrideLoad dbNames dbConfig =
 -- | Create a Wai application with DatabaseManager
 createServerApp :: DatabaseManager -> Int -> FilePath -> Bool -> Maybe String -> Maybe HostingConfig -> [ClassificationPreset] -> IO Application
 createServerApp dbManager maxTreeDepth staticDir desktopMode password hostingConfig filterPresets = do
-    mcp <- mcpApp dbManager filterPresets
+    -- The MCP @web_url@ deep links point at Elm SPA routes served from
+    -- 'staticDir'. When the SPA is not bundled (backend-only image), those
+    -- URLs would 404, so we omit 'web_url' from MCP responses entirely.
+    hasFrontend <- doesFileExist (staticDir </> "index.html")
+    unless (desktopMode || hasFrontend) $
+        reportProgress Info "Frontend not bundled — MCP responses will omit 'web_url'"
+    mcp <- mcpApp dbManager filterPresets hasFrontend
     let openApiJson = encode volcaOpenApi
         swaggerHtml =
             "<!DOCTYPE html><html><head><title>volca API</title>\

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -35,7 +35,7 @@ import qualified Database.Manager as DM
 
 import qualified API.BatchImpacts as BI
 import API.MCP.Columnar (resolveSingleScoringSet, toColumnarBatch)
-import API.MCP.Enrich (addWebUrlMaybe, attachMarketHintByName, encodeSegment, filterScoringSets, scoreActivityWebUrl, slimLCIAPanel)
+import API.MCP.Enrich (addWebUrlMaybe, attachMarketHintByName, encodeSegment, filterScoringSets, scoreActivityWebUrl, slimLCIAPanel, webUrlField)
 import API.Types (ActivityForAPI (..), ActivityInfo (..), ClassificationSystem (..), ExchangeWithUnit (..), InventoryExport (..), InventoryFlowDetail (..), Perturbation (..), Substitution (..), SubstitutionRequest (..))
 import Control.Monad (unless)
 import qualified Data.List as L
@@ -237,7 +237,7 @@ handleInitialize req =
                         , "VoLCA answers both LCIA scores (climate change, acidification, eutrophication, water scarcity, land use…) AND raw inventory flows (land occupation, water withdrawal, resource depletion, biosphere emissions). Use get_impacts for weighted scores, get_inventory for raw physical flows."
                         , "Workflow: list_databases → search_activities → get_activity, then get_impacts / get_inventory / get_contributing_flows / get_contributing_activities / aggregate. Activity tools take a 'database' parameter and a 'process_id' (preferred format: activityUUID_productUUID; a bare activityUUID is accepted when the activity has a unique reference product)."
                         , "Use list_methods for available LCIA methods."
-                        , "When showing activities, impacts, or contributions to a human, render the 'web_url' field from each result as a clickable markdown link — never show bare process IDs as a final answer."
+                        , "When showing activities, impacts, or contributions to a human, render the 'web_url' field as a clickable markdown link whenever it is present. If 'web_url' is absent (backend-only deployment), show the activity name and 'process_id' as plain text instead — never invent a link."
                         ]
                 ]
 
@@ -1033,10 +1033,7 @@ callGetImpacts dbManager mBaseUrl rid args =
                             <> irRefProductName ir
                     contribs = irContribs ir
                     topFlows = take topN contribs
-                    webUrlPair = case mBaseUrl of
-                        Just base ->
-                            ["web_url" .= (base <> "/db/" <> dbName <> "/activity/" <> raText ra <> "/impacts/" <> encodeSegment (lrCollection req) <> "/" <> lrMethodIdText req)]
-                        Nothing -> []
+                    webUrlPair = webUrlField mBaseUrl ("/db/" <> dbName <> "/activity/" <> raText ra <> "/impacts/" <> encodeSegment (lrCollection req) <> "/" <> lrMethodIdText req)
                     hasNeg = any (\(_, _, c) -> c < 0) contribs
                     unknownUuids = irUnknownUuids ir
                 liftIO $
@@ -1132,10 +1129,7 @@ callComputeSensitivity dbManager mBaseUrl rid args =
                 baselineScore <- case scoreOf baselineX of
                     Right s -> pure s
                     Left e -> throwE ("baseline scoring failed: " <> e)
-                let webUrlPair = case mBaseUrl of
-                        Just base ->
-                            ["web_url" .= (base <> "/db/" <> dbName <> "/activity/" <> raText ra <> "/sensitivity/" <> encodeSegment (lrCollection req) <> "/" <> lrMethodIdText req)]
-                        Nothing -> []
+                let webUrlPair = webUrlField mBaseUrl ("/db/" <> dbName <> "/activity/" <> raText ra <> "/sensitivity/" <> encodeSegment (lrCollection req) <> "/" <> lrMethodIdText req)
                     pertEntry (p, eitherX) =
                         let base =
                                 [ "perturbation"
@@ -1521,21 +1515,18 @@ mkMcpCrossDBEntry dbManager rootDbName mBaseUrl colName methodIdText flowDB unit
                  in (maybe "" activityName mAct, maybe "" activityLocation mAct, pn, txt)
             Nothing ->
                 ("", "", "", depDbName <> "::<unloaded>")
-        webUrlPair = case mBaseUrl of
-            Just base ->
-                [ "web_url"
-                    .= ( base
-                            <> "/db/"
-                            <> rootDbName
-                            <> "/activity/"
-                            <> pidText
-                            <> "/contributing-activities/"
-                            <> encodeSegment colName
-                            <> "/"
-                            <> methodIdText
-                       )
-                ]
-            Nothing -> []
+        webUrlPair =
+            webUrlField
+                mBaseUrl
+                ( "/db/"
+                    <> rootDbName
+                    <> "/activity/"
+                    <> pidText
+                    <> "/contributing-activities/"
+                    <> encodeSegment colName
+                    <> "/"
+                    <> methodIdText
+                )
     pure $
         object $
             [ "process_id" .= pidText
@@ -1643,10 +1634,7 @@ callGetContributingFlows dbManager mBaseUrl rid args =
                     dbName = lrDbName req
                     ra = lrResolved req
                     lim = fromMaybe 20 (intArg "limit" args)
-                    webUrlPair = case mBaseUrl of
-                        Just base ->
-                            ["web_url" .= (base <> "/db/" <> dbName <> "/activity/" <> raText ra <> "/contributing-flows/" <> encodeSegment (lrCollection req) <> "/" <> lrMethodIdText req)]
-                        Nothing -> []
+                    webUrlPair = webUrlField mBaseUrl ("/db/" <> dbName <> "/activity/" <> raText ra <> "/contributing-flows/" <> encodeSegment (lrCollection req) <> "/" <> lrMethodIdText req)
                 ExceptT $ pure $ ensureLinked dbName "computing contributions" db
                 unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
                 (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -35,7 +35,7 @@ import qualified Database.Manager as DM
 
 import qualified API.BatchImpacts as BI
 import API.MCP.Columnar (resolveSingleScoringSet, toColumnarBatch)
-import API.MCP.Enrich (addWebUrl, attachMarketHintByName, encodeSegment, filterScoringSets, scoreActivityWebUrl, slimLCIAPanel)
+import API.MCP.Enrich (addWebUrlMaybe, attachMarketHintByName, encodeSegment, filterScoringSets, scoreActivityWebUrl, slimLCIAPanel)
 import API.Types (ActivityForAPI (..), ActivityInfo (..), ClassificationSystem (..), ExchangeWithUnit (..), InventoryExport (..), InventoryFlowDetail (..), Perturbation (..), Substitution (..), SubstitutionRequest (..))
 import Control.Monad (unless)
 import qualified Data.List as L
@@ -115,8 +115,8 @@ newtype McpState = McpState
     { mcpSessionId :: Text
     }
 
-mcpApp :: DatabaseManager -> [ClassificationPreset] -> IO Application
-mcpApp dbManager presets = do
+mcpApp :: DatabaseManager -> [ClassificationPreset] -> Bool -> IO Application
+mcpApp dbManager presets hasFrontend = do
     (a, b) <- (,) <$> (randomIO :: IO Int) <*> (randomIO :: IO Int)
     let sessionId = T.pack $ show (abs a) ++ "-" ++ show (abs b)
     stateRef <- newIORef McpState{mcpSessionId = sessionId}
@@ -124,7 +124,12 @@ mcpApp dbManager presets = do
         let method = requestMethod req
             hdrs = requestHeaders req
             hostHeader = fromMaybe "localhost" $ lookup hHost hdrs
-            baseUrl = "http://" <> TE.decodeUtf8 hostHeader
+            -- Only emit 'web_url' when the SPA is bundled to serve those
+            -- routes; otherwise the link would point at a 404.
+            mBaseUrl =
+                if hasFrontend
+                    then Just ("http://" <> TE.decodeUtf8 hostHeader)
+                    else Nothing
             acceptHdr = fromMaybe "" $ lookup hAccept hdrs
             wantsSse = "text/event-stream" `BS.isInfixOf` acceptHdr
         st <- readIORef stateRef
@@ -147,7 +152,7 @@ mcpApp dbManager presets = do
                     Left err ->
                         respond $ jsonResponse (mcpSessionId st) $ rpcError Null (-32700) (T.pack $ "Parse error: " ++ err)
                     Right rpcReq -> do
-                        resp <- handleRpc dbManager presets baseUrl st rpcReq
+                        resp <- handleRpc dbManager presets mBaseUrl st rpcReq
                         case resp of
                             Nothing ->
                                 respond $
@@ -190,12 +195,12 @@ mcpApp dbManager presets = do
 -- RPC dispatch
 -- ---------------------------------------------------------------------------
 
-handleRpc :: DatabaseManager -> [ClassificationPreset] -> Text -> McpState -> RpcRequest -> IO (Maybe Value)
-handleRpc dbManager presets baseUrl _st req = case rpcMethod req of
+handleRpc :: DatabaseManager -> [ClassificationPreset] -> Maybe Text -> McpState -> RpcRequest -> IO (Maybe Value)
+handleRpc dbManager presets mBaseUrl _st req = case rpcMethod req of
     "initialize" -> Just <$> handleInitialize req
     "notifications/initialized" -> return Nothing -- notification, no response
     "tools/list" -> return $ Just $ handleToolsList req
-    "tools/call" -> Just <$> handleToolsCall dbManager presets baseUrl req
+    "tools/call" -> Just <$> handleToolsCall dbManager presets mBaseUrl req
     "ping" -> return $ Just $ rpcResult (rid req) (object [])
     other ->
         return $
@@ -312,12 +317,12 @@ paramsToSchema ps =
 -- tools/call dispatch
 -- ---------------------------------------------------------------------------
 
-handleToolsCall :: DatabaseManager -> [ClassificationPreset] -> Text -> RpcRequest -> IO Value
-handleToolsCall dbManager presets baseUrl req = do
+handleToolsCall :: DatabaseManager -> [ClassificationPreset] -> Maybe Text -> RpcRequest -> IO Value
+handleToolsCall dbManager presets mBaseUrl req = do
     let rid = fromMaybe Null (rpcId req)
     case rpcParams req >>= parseCallParams of
         Nothing -> return $ rpcError rid (-32602) "Invalid params: expected {name, arguments}"
-        Just (toolName, args) -> callTool dbManager presets baseUrl rid toolName args
+        Just (toolName, args) -> callTool dbManager presets mBaseUrl rid toolName args
 
 parseCallParams :: Value -> Maybe (Text, KeyMap Value)
 parseCallParams (Object o) = do
@@ -328,8 +333,8 @@ parseCallParams (Object o) = do
     return (name, args)
 parseCallParams _ = Nothing
 
-callTool :: DatabaseManager -> [ClassificationPreset] -> Text -> Value -> Text -> KeyMap Value -> IO Value
-callTool dbManager presets baseUrl rid name args = case name of
+callTool :: DatabaseManager -> [ClassificationPreset] -> Maybe Text -> Value -> Text -> KeyMap Value -> IO Value
+callTool dbManager presets mBaseUrl rid name args = case name of
     "list_databases" -> callListDatabases dbManager rid
     "list_presets" -> callListPresets presets rid
     "search_activities" -> withDb dbManager rid args $ callSearchActivities presets rid args
@@ -338,20 +343,20 @@ callTool dbManager presets baseUrl rid name args = case name of
     "get_supply_chain" -> callGetSupplyChain dbManager rid args
     "aggregate" -> withDb dbManager rid args $ callAggregate dbManager rid args
     "get_inventory" -> callGetInventory dbManager rid args
-    "get_impacts" -> callGetImpacts dbManager baseUrl rid args
-    "compute_sensitivity" -> callComputeSensitivity dbManager baseUrl rid args
+    "get_impacts" -> callGetImpacts dbManager mBaseUrl rid args
+    "compute_sensitivity" -> callComputeSensitivity dbManager mBaseUrl rid args
     "list_methods" -> callListMethods dbManager rid
     "get_flow_mapping" -> callGetFlowMapping dbManager rid args
     "get_characterization" -> callGetCharacterization dbManager rid args
-    "get_contributing_flows" -> callGetContributingFlows dbManager baseUrl rid args
-    "get_contributing_activities" -> callGetContributingActivities dbManager baseUrl rid args
+    "get_contributing_flows" -> callGetContributingFlows dbManager mBaseUrl rid args
+    "get_contributing_activities" -> callGetContributingActivities dbManager mBaseUrl rid args
     "list_geographies" -> callListGeographies dbManager rid args
     "list_classifications" -> withDb dbManager rid args $ callListClassifications rid args
     "get_path_to" -> withDb dbManager rid args $ callGetPathTo rid args
     "get_consumers" -> withDb dbManager rid args $ callGetConsumers presets rid args
     "compare_impacts" -> callCompareImpacts dbManager rid args
-    "score_activity" -> callScoreActivity dbManager baseUrl rid args
-    "score_activities" -> callScoreActivities dbManager baseUrl rid args
+    "score_activity" -> callScoreActivity dbManager mBaseUrl rid args
+    "score_activities" -> callScoreActivities dbManager mBaseUrl rid args
     "list_scoring_sets" -> callListScoringSets dbManager rid args
     _ -> return $ toolError rid ("Unknown tool: " <> name)
 
@@ -1006,8 +1011,8 @@ Historically named 'get_lcia' — the MCP surface now uses 'impacts'
 per the naming audit; internal Haskell types keep the 'LCIA' acronym
 (LCIAResult, computeLCIAScore) since they're the domain term of art.
 -}
-callGetImpacts :: DatabaseManager -> Text -> Value -> KeyMap Value -> IO Value
-callGetImpacts dbManager baseUrl rid args =
+callGetImpacts :: DatabaseManager -> Maybe Text -> Value -> KeyMap Value -> IO Value
+callGetImpacts dbManager mBaseUrl rid args =
     either (toolError rid) id
         <$> runExceptT
             ( do
@@ -1028,7 +1033,10 @@ callGetImpacts dbManager baseUrl rid args =
                             <> irRefProductName ir
                     contribs = irContribs ir
                     topFlows = take topN contribs
-                    webUrl = baseUrl <> "/db/" <> dbName <> "/activity/" <> raText ra <> "/impacts/" <> encodeSegment (lrCollection req) <> "/" <> lrMethodIdText req
+                    webUrlPair = case mBaseUrl of
+                        Just base ->
+                            ["web_url" .= (base <> "/db/" <> dbName <> "/activity/" <> raText ra <> "/impacts/" <> encodeSegment (lrCollection req) <> "/" <> lrMethodIdText req)]
+                        Nothing -> []
                     hasNeg = any (\(_, _, c) -> c < 0) contribs
                     unknownUuids = irUnknownUuids ir
                 liftIO $
@@ -1060,7 +1068,6 @@ callGetImpacts dbManager baseUrl rid args =
                                 , "functional_unit" .= functionalUnit
                                 , "mapped_flows" .= (msTotal stats - msUnmatched stats)
                                 , "has_negative_contributions" .= hasNeg
-                                , "web_url" .= webUrl
                                 , "top_flows"
                                     .= [ object
                                             [ "flow_name" .= bfName f
@@ -1075,6 +1082,7 @@ callGetImpacts dbManager baseUrl rid args =
                                        | (f, cfVal, c) <- topFlows
                                        ]
                                 ]
+                                    ++ webUrlPair
                                     ++ (if fromMaybe False (boolArg "include_diagnostics" args) then diagnosticsFields else [])
             )
 
@@ -1085,8 +1093,8 @@ for each. Uses 'computeLCIAScoreAuto' so regionalized methods route through the
 location-hierarchy walk; non-regionalized methods stay on the classic
 'computeLCIAScoreFromTables' path.
 -}
-callComputeSensitivity :: DatabaseManager -> Text -> Value -> KeyMap Value -> IO Value
-callComputeSensitivity dbManager baseUrl rid args =
+callComputeSensitivity :: DatabaseManager -> Maybe Text -> Value -> KeyMap Value -> IO Value
+callComputeSensitivity dbManager mBaseUrl rid args =
     either (toolError rid) id
         <$> runExceptT
             ( do
@@ -1124,7 +1132,10 @@ callComputeSensitivity dbManager baseUrl rid args =
                 baselineScore <- case scoreOf baselineX of
                     Right s -> pure s
                     Left e -> throwE ("baseline scoring failed: " <> e)
-                let webUrl = baseUrl <> "/db/" <> dbName <> "/activity/" <> raText ra <> "/sensitivity/" <> encodeSegment (lrCollection req) <> "/" <> lrMethodIdText req
+                let webUrlPair = case mBaseUrl of
+                        Just base ->
+                            ["web_url" .= (base <> "/db/" <> dbName <> "/activity/" <> raText ra <> "/sensitivity/" <> encodeSegment (lrCollection req) <> "/" <> lrMethodIdText req)]
+                        Nothing -> []
                     pertEntry (p, eitherX) =
                         let base =
                                 [ "perturbation"
@@ -1149,14 +1160,14 @@ callComputeSensitivity dbManager baseUrl rid args =
                                             )
                 pure $
                     toolSuccessJson rid $
-                        object
+                        object $
                             [ "method" .= methodName method
                             , "category" .= methodCategory method
                             , "unit" .= methodUnit method
                             , "baseline_score" .= baselineScore
                             , "perturbed" .= map pertEntry perResults
-                            , "web_url" .= webUrl
                             ]
+                                ++ webUrlPair
             )
 
 {- | Cross-database impact comparison for mapping audits.
@@ -1483,8 +1494,8 @@ mkMcpCrossDBEntry ::
     DatabaseManager ->
     -- | root DB name
     Text ->
-    -- | base URL
-    Text ->
+    -- | base URL (Nothing when no frontend is bundled)
+    Maybe Text ->
     -- | method collection name
     Text ->
     -- | method UUID text
@@ -1495,7 +1506,7 @@ mkMcpCrossDBEntry ::
     Double ->
     ((Text, ProcessId), Double) ->
     IO Value
-mkMcpCrossDBEntry dbManager rootDbName baseUrl colName methodIdText flowDB unitDB score ((depDbName, pid), c) = do
+mkMcpCrossDBEntry dbManager rootDbName mBaseUrl colName methodIdText flowDB unitDB score ((depDbName, pid), c) = do
     mLd <- getDatabase dbManager depDbName
     let (actName, actLoc, prodName, pidText) = case mLd of
             Just ld ->
@@ -1510,26 +1521,31 @@ mkMcpCrossDBEntry dbManager rootDbName baseUrl colName methodIdText flowDB unitD
                  in (maybe "" activityName mAct, maybe "" activityLocation mAct, pn, txt)
             Nothing ->
                 ("", "", "", depDbName <> "::<unloaded>")
-        procWebUrl =
-            baseUrl
-                <> "/db/"
-                <> rootDbName
-                <> "/activity/"
-                <> pidText
-                <> "/contributing-activities/"
-                <> encodeSegment colName
-                <> "/"
-                <> methodIdText
+        webUrlPair = case mBaseUrl of
+            Just base ->
+                [ "web_url"
+                    .= ( base
+                            <> "/db/"
+                            <> rootDbName
+                            <> "/activity/"
+                            <> pidText
+                            <> "/contributing-activities/"
+                            <> encodeSegment colName
+                            <> "/"
+                            <> methodIdText
+                       )
+                ]
+            Nothing -> []
     pure $
-        object
+        object $
             [ "process_id" .= pidText
             , "activity_name" .= actName
             , "product_name" .= prodName
             , "location" .= actLoc
             , "contribution" .= c
             , "contribution_percent" .= (if score /= 0 then c / score * 100 else 0 :: Double)
-            , "web_url" .= procWebUrl
             ]
+                ++ webUrlPair
 
 -- | Helper: resolve method from UUID text, also returning its collection name
 resolveMethod :: DatabaseManager -> Text -> IO (Either Text (Text, Method))
@@ -1615,8 +1631,8 @@ ensureLinked dbName op db =
                         <> op
                         <> "."
 
-callGetContributingFlows :: DatabaseManager -> Text -> Value -> KeyMap Value -> IO Value
-callGetContributingFlows dbManager baseUrl rid args =
+callGetContributingFlows :: DatabaseManager -> Maybe Text -> Value -> KeyMap Value -> IO Value
+callGetContributingFlows dbManager mBaseUrl rid args =
     either (toolError rid) id
         <$> runExceptT
             ( do
@@ -1627,7 +1643,10 @@ callGetContributingFlows dbManager baseUrl rid args =
                     dbName = lrDbName req
                     ra = lrResolved req
                     lim = fromMaybe 20 (intArg "limit" args)
-                    webUrl = baseUrl <> "/db/" <> dbName <> "/activity/" <> raText ra <> "/contributing-flows/" <> encodeSegment (lrCollection req) <> "/" <> lrMethodIdText req
+                    webUrlPair = case mBaseUrl of
+                        Just base ->
+                            ["web_url" .= (base <> "/db/" <> dbName <> "/activity/" <> raText ra <> "/contributing-flows/" <> encodeSegment (lrCollection req) <> "/" <> lrMethodIdText req)]
+                        Nothing -> []
                 ExceptT $ pure $ ensureLinked dbName "computing contributions" db
                 unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
                 (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
@@ -1688,7 +1707,6 @@ callGetContributingFlows dbManager baseUrl rid args =
                             , "unit" .= methodUnit method
                             , "total_score" .= score
                             , "has_negative_contributions" .= hasNeg
-                            , "web_url" .= webUrl
                             , "top_flows"
                                 .= [ object
                                         [ "flow_name" .= bfName f
@@ -1702,11 +1720,12 @@ callGetContributingFlows dbManager baseUrl rid args =
                                    | (f, cfVal, c) <- top
                                    ]
                             ]
+                                ++ webUrlPair
                                 ++ diagnosticsFields
             )
 
-callGetContributingActivities :: DatabaseManager -> Text -> Value -> KeyMap Value -> IO Value
-callGetContributingActivities dbManager baseUrl rid args =
+callGetContributingActivities :: DatabaseManager -> Maybe Text -> Value -> KeyMap Value -> IO Value
+callGetContributingActivities dbManager mBaseUrl rid args =
     either (toolError rid) id
         <$> runExceptT
             ( do
@@ -1738,7 +1757,7 @@ callGetContributingActivities dbManager baseUrl rid args =
                     sorted = L.sortOn (\(_, c) -> negate (abs c)) (M.toList contributions)
                     top = take lim sorted
                     hasNeg = any (\(_, c) -> c < 0) top
-                rows <- liftIO $ mapM (mkMcpCrossDBEntry dbManager dbName baseUrl (lrCollection req) (lrMethodIdText req) mFlows mUnits score) top
+                rows <- liftIO $ mapM (mkMcpCrossDBEntry dbManager dbName mBaseUrl (lrCollection req) (lrMethodIdText req) mFlows mUnits score) top
                 pure $
                     toolSuccessJson rid $
                         object
@@ -1824,8 +1843,8 @@ per-method @web_url@s are not emitted: the panel link covers the same
 ground at a fraction of the bytes. Replaces the @N@ round-trips of
 'get_impacts' a comparative study used to need.
 -}
-callScoreActivity :: DatabaseManager -> Text -> Value -> KeyMap Value -> IO Value
-callScoreActivity dbManager baseUrl rid args =
+callScoreActivity :: DatabaseManager -> Maybe Text -> Value -> KeyMap Value -> IO Value
+callScoreActivity dbManager mBaseUrl rid args =
     either (toolError rid) id
         <$> runExceptT
             ( do
@@ -1841,11 +1860,11 @@ callScoreActivity dbManager baseUrl rid args =
                     Right lbr -> do
                         configured <- liftIO $ configuredScoringSetNames dbManager coll
                         mActName <- liftIO $ lookupActivityName dbManager dbName pidText
-                        let topUrl = scoreActivityWebUrl baseUrl dbName pidText coll
+                        let mTopUrl = scoreActivityWebUrl mBaseUrl dbName pidText coll
                             enriched =
                                 maybe id attachMarketHintByName mActName $
-                                    addWebUrl
-                                        topUrl
+                                    addWebUrlMaybe
+                                        mTopUrl
                                         (slimLCIAPanel (toJSON lbr))
                         ExceptT $ pure (toolSuccessJson rid <$> filterScoringSets configured wantedSets enriched)
             )
@@ -1885,8 +1904,8 @@ batch of 24+ activities. Unresolved process IDs land in
 @notFound@ \/ @invalid@. The chosen scoring set is required to be
 unambiguous; see 'resolveSingleScoringSet' for the rules.
 -}
-callScoreActivities :: DatabaseManager -> Text -> Value -> KeyMap Value -> IO Value
-callScoreActivities dbManager baseUrl rid args =
+callScoreActivities :: DatabaseManager -> Maybe Text -> Value -> KeyMap Value -> IO Value
+callScoreActivities dbManager mBaseUrl rid args =
     either (toolError rid) id
         <$> runExceptT
             ( do
@@ -1900,7 +1919,7 @@ callScoreActivities dbManager baseUrl rid args =
                 res <- liftIO $ BI.runBatchImpacts dbManager dbName coll Nothing pids
                 case res of
                     Left e -> ExceptT $ pure (Left (batchErrorMsg e))
-                    Right bir -> pure (toolSuccessJson rid (toColumnarBatch summaryOnly baseUrl dbName coll chosen bir))
+                    Right bir -> pure (toolSuccessJson rid (toColumnarBatch summaryOnly mBaseUrl dbName coll chosen bir))
             )
 
 {- | Handler for the 'list_scoring_sets' MCP tool.

--- a/src/API/MCP/Columnar.hs
+++ b/src/API/MCP/Columnar.hs
@@ -36,7 +36,7 @@ import API.Types (
 import Data.Aeson (Value (..), object, toJSON, (.=))
 import qualified Data.List as L
 import qualified Data.Map as M
-import Data.Maybe (mapMaybe)
+import Data.Maybe (isJust, mapMaybe, maybeToList)
 import Data.Ord (comparing)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -148,10 +148,7 @@ toColumnarBatch summaryOnly mBaseUrl dbName coll ss bir =
         _ -> []
     indicatorKeys :: [Text]
     indicatorKeys = M.keys (M.union (ssVariables ss) (ssComputed ss))
-    hasWebUrl = case mBaseUrl of
-        Just _ -> True
-        Nothing -> False
-    webUrlCol = ["web_url" | hasWebUrl]
+    webUrlCol = ["web_url" | isJust mBaseUrl]
     fixedColumns :: [Text]
     fixedColumns
         | isHeterogeneous = ["name", "process_id"] ++ webUrlCol ++ ["functional_unit", "total"]
@@ -166,9 +163,7 @@ toColumnarBatch summaryOnly mBaseUrl dbName coll ss bir =
     entryRow :: BatchImpactsEntry -> Value
     entryRow e = toJSON cells
       where
-        urlCells = case scoreActivityWebUrl mBaseUrl dbName (bieProcessId e) coll of
-            Just u -> [toJSON u]
-            Nothing -> []
+        urlCells = toJSON <$> maybeToList (scoreActivityWebUrl mBaseUrl dbName (bieProcessId e) coll)
         lbr = bieImpacts e
         scoreMap = M.findWithDefault M.empty setName (lbrScoringResults lbr)
         indMap = M.findWithDefault M.empty setName (lbrScoringIndicators lbr)

--- a/src/API/MCP/Columnar.hs
+++ b/src/API/MCP/Columnar.hs
@@ -116,9 +116,13 @@ single @dominant_indicator@ column carrying an object
 @{key, share_pct}@ — the variable with the largest absolute share of
 the total. Useful for ranking large batches before drilling into one
 PID with @score_activity@.
+
+When the base URL is 'Nothing' (backend-only deployment, no Elm SPA
+bundled), the @web_url@ column is dropped from both the header and
+every row — emitting a column of dead links would be a silent lie.
 -}
-toColumnarBatch :: Bool -> Text -> Text -> Text -> ScoringSet -> BatchImpactsResponse -> Value
-toColumnarBatch summaryOnly baseUrl dbName coll ss bir =
+toColumnarBatch :: Bool -> Maybe Text -> Text -> Text -> ScoringSet -> BatchImpactsResponse -> Value
+toColumnarBatch summaryOnly mBaseUrl dbName coll ss bir =
     object $
         [ "scoring_set" .= ssName ss
         , "scoring_unit" .= scoringUnit
@@ -144,10 +148,14 @@ toColumnarBatch summaryOnly baseUrl dbName coll ss bir =
         _ -> []
     indicatorKeys :: [Text]
     indicatorKeys = M.keys (M.union (ssVariables ss) (ssComputed ss))
+    hasWebUrl = case mBaseUrl of
+        Just _ -> True
+        Nothing -> False
+    webUrlCol = ["web_url" | hasWebUrl]
     fixedColumns :: [Text]
     fixedColumns
-        | isHeterogeneous = ["name", "process_id", "web_url", "functional_unit", "total"]
-        | otherwise = ["name", "process_id", "web_url", "total"]
+        | isHeterogeneous = ["name", "process_id"] ++ webUrlCol ++ ["functional_unit", "total"]
+        | otherwise = ["name", "process_id"] ++ webUrlCol ++ ["total"]
     columns :: [Text]
     columns
         | summaryOnly = fixedColumns ++ ["dominant_indicator"]
@@ -158,7 +166,9 @@ toColumnarBatch summaryOnly baseUrl dbName coll ss bir =
     entryRow :: BatchImpactsEntry -> Value
     entryRow e = toJSON cells
       where
-        url = scoreActivityWebUrl baseUrl dbName (bieProcessId e) coll
+        urlCells = case scoreActivityWebUrl mBaseUrl dbName (bieProcessId e) coll of
+            Just u -> [toJSON u]
+            Nothing -> []
         lbr = bieImpacts e
         scoreMap = M.findWithDefault M.empty setName (lbrScoringResults lbr)
         indMap = M.findWithDefault M.empty setName (lbrScoringIndicators lbr)
@@ -174,8 +184,8 @@ toColumnarBatch summaryOnly baseUrl dbName coll ss bir =
         cells =
             [ toJSON (bieActivityName e)
             , toJSON (bieProcessId e)
-            , toJSON url
             ]
+                ++ urlCells
                 ++ fuCells
                 ++ [total]
                 ++ tailCells

--- a/src/API/MCP/Enrich.hs
+++ b/src/API/MCP/Enrich.hs
@@ -20,6 +20,7 @@ module API.MCP.Enrich (
 
     -- * web_url enrichment
     addWebUrl,
+    addWebUrlMaybe,
 
     -- * payload slimming
     slimLCIAPanel,
@@ -97,16 +98,23 @@ encodeSegment = T.pack . escapeURIString isUnreserved . T.unpack
 Every dynamic segment is percent-encoded so a 'dbName' \/ 'processId' \/
 'collection' that contains @/@ or @?@ does not silently fracture the
 URL.
+
+The 'Maybe' on 'baseUrl' threads frontend availability through callers:
+'Nothing' means the SPA is not bundled (backend-only image), and the
+URL would point at a 404. We propagate the absence rather than emit a
+dead link.
 -}
-scoreActivityWebUrl :: Text -> Text -> Text -> Text -> Text
-scoreActivityWebUrl baseUrl dbName pidText coll =
-    baseUrl
-        <> "/db/"
-        <> encodeSegment dbName
-        <> "/activity/"
-        <> encodeSegment pidText
-        <> "/impacts/"
-        <> encodeSegment coll
+scoreActivityWebUrl :: Maybe Text -> Text -> Text -> Text -> Maybe Text
+scoreActivityWebUrl mBaseUrl dbName pidText coll = do
+    base <- mBaseUrl
+    pure $
+        base
+            <> "/db/"
+            <> encodeSegment dbName
+            <> "/activity/"
+            <> encodeSegment pidText
+            <> "/impacts/"
+            <> encodeSegment coll
 
 -- ---------------------------------------------------------------------------
 -- web_url enrichment
@@ -121,6 +129,13 @@ hintKey = fromText "hint"
 -- | Add a 'web_url' field to a JSON object at the top level.
 addWebUrl :: Text -> Value -> Value
 addWebUrl url = overObject (KM.insert webUrlKey (String url))
+
+{- | Like 'addWebUrl', but a no-op when the URL is 'Nothing'. Lets callers
+thread frontend availability through 'Maybe Text' without case-splitting
+at every emission site.
+-}
+addWebUrlMaybe :: Maybe Text -> Value -> Value
+addWebUrlMaybe = maybe id addWebUrl
 
 {- | Reduce a serialized 'LCIABatchResult' to its aggregates for bulk
 transport: hoist @functionalUnit@ to the top level (same value on

--- a/src/API/MCP/Enrich.hs
+++ b/src/API/MCP/Enrich.hs
@@ -21,6 +21,7 @@ module API.MCP.Enrich (
     -- * web_url enrichment
     addWebUrl,
     addWebUrlMaybe,
+    webUrlField,
 
     -- * payload slimming
     slimLCIAPanel,
@@ -44,6 +45,7 @@ import Data.Aeson.Key (fromText)
 import qualified Data.Aeson.Key as Key
 import Data.Aeson.KeyMap (KeyMap)
 import qualified Data.Aeson.KeyMap as KM
+import Data.Aeson.Types (Pair)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Vector as V
@@ -136,6 +138,16 @@ at every emission site.
 -}
 addWebUrlMaybe :: Maybe Text -> Value -> Value
 addWebUrlMaybe = maybe id addWebUrl
+
+{- | Inline-object companion to 'addWebUrlMaybe' for handlers that build
+their response via @object (fields ++ extras)@.
+
+Yields @["web_url" .= base <> path]@ when a base URL is configured and
+@[]@ otherwise — keeping the "drop the field when no frontend" invariant
+in one place rather than fanning out a 'case' at every emission site.
+-}
+webUrlField :: Maybe Text -> Text -> [Pair]
+webUrlField mBase path = foldMap (\b -> ["web_url" .= (b <> path)]) mBase
 
 {- | Reduce a serialized 'LCIABatchResult' to its aggregates for bulk
 transport: hoist @functionalUnit@ to the top level (same value on

--- a/test/MCPColumnarSpec.hs
+++ b/test/MCPColumnarSpec.hs
@@ -131,7 +131,7 @@ spec = do
                     , birNotFound = []
                     , birInvalid = []
                     }
-            Object km = toColumnarBatch False "https://x" "ei" "EF31" pefSet bir
+            Object km = toColumnarBatch False (Just "https://x") "ei" "EF31" pefSet bir
 
         it "uses snake_case top-level keys throughout" $ do
             KM.lookup (fromText "scoring_set") km `shouldBe` Just (String "PEF")
@@ -192,7 +192,7 @@ spec = do
                     , birNotFound = []
                     , birInvalid = []
                     }
-            Object km = toColumnarBatch False "https://x" "agri" "EF31" pefSet bir
+            Object km = toColumnarBatch False (Just "https://x") "agri" "EF31" pefSet bir
 
         it "drops the top-level functional_unit field when rows disagree" $
             KM.lookup (fromText "functional_unit") km `shouldBe` Nothing
@@ -231,7 +231,7 @@ spec = do
                     , birNotFound = []
                     , birInvalid = []
                     }
-            Object km = toColumnarBatch True "https://x" "ei" "EF31" pefSet bir
+            Object km = toColumnarBatch True (Just "https://x") "ei" "EF31" pefSet bir
 
         it "replaces per-indicator columns with a single dominant_indicator column" $
             KM.lookup (fromText "columns") km
@@ -256,8 +256,48 @@ spec = do
                     other -> expectationFailure ("expected one row, got " <> show other)
                 other -> expectationFailure ("expected rows array, got " <> show other)
 
+    describe "toColumnarBatch (no frontend bundled — Nothing baseUrl)" $ do
+        let bir =
+                BatchImpactsResponse
+                    { birResults =
+                        [ mkEntry "pidA" "oak forestry, RoW" "1 m³ wood" "PEF" 10.0 [("acd", 4.0), ("cch", 6.0)]
+                        ]
+                    , birNotFound = []
+                    , birInvalid = []
+                    }
+            Object km = toColumnarBatch False Nothing "ei" "EF31" pefSet bir
+
+        it "drops the web_url column from the header" $
+            KM.lookup (fromText "columns") km
+                `shouldBe` Just
+                    ( Array
+                        ( V.fromList
+                            [ String "name"
+                            , String "process_id"
+                            , String "total"
+                            , String "acd"
+                            , String "cch"
+                            ]
+                        )
+                    )
+
+        it "drops the web_url cell from each row (no dead-link slot)" $
+            case KM.lookup (fromText "rows") km of
+                Just (Array rs) ->
+                    V.toList rs
+                        `shouldBe` [ Array $
+                                        V.fromList
+                                            [ String "oak forestry, RoW"
+                                            , String "pidA"
+                                            , Number 10.0
+                                            , Number 4.0
+                                            , Number 6.0
+                                            ]
+                                   ]
+                other -> expectationFailure ("expected rows array, got " <> show other)
+
     describe "toColumnarBatch (edge: empty results)" $ do
-        let Object km = toColumnarBatch False "https://x" "ei" "EF31" pefSet emptyBir
+        let Object km = toColumnarBatch False (Just "https://x") "ei" "EF31" pefSet emptyBir
 
         it "omits top-level functional_unit (nothing to hoist)" $
             KM.lookup (fromText "functional_unit") km `shouldBe` Nothing

--- a/test/MCPEnrichSpec.hs
+++ b/test/MCPEnrichSpec.hs
@@ -13,6 +13,7 @@ module MCPEnrichSpec (spec) where
 
 import API.MCP.Enrich (
     addWebUrl,
+    addWebUrlMaybe,
     attachMarketHintByName,
     encodeSegment,
     filterScoringSets,
@@ -78,12 +79,15 @@ spec :: Spec
 spec = do
     describe "scoreActivityWebUrl" $ do
         it "encodes every dynamic segment (no raw slashes leak through)" $
-            scoreActivityWebUrl "https://volca.run" "db/with-slash" "pid/with-slash" "EF 3.1"
-                `shouldBe` "https://volca.run/db/db%2Fwith-slash/activity/pid%2Fwith-slash/impacts/EF%203.1"
+            scoreActivityWebUrl (Just "https://volca.run") "db/with-slash" "pid/with-slash" "EF 3.1"
+                `shouldBe` Just "https://volca.run/db/db%2Fwith-slash/activity/pid%2Fwith-slash/impacts/EF%203.1"
 
         it "round-trips ASCII-safe segments unchanged" $
-            scoreActivityWebUrl "https://x" "agribalyse" "abc_def" "EF31"
-                `shouldBe` "https://x/db/agribalyse/activity/abc_def/impacts/EF31"
+            scoreActivityWebUrl (Just "https://x") "agribalyse" "abc_def" "EF31"
+                `shouldBe` Just "https://x/db/agribalyse/activity/abc_def/impacts/EF31"
+
+        it "yields Nothing when no base URL is configured (no frontend)" $
+            scoreActivityWebUrl Nothing "agribalyse" "abc_def" "EF31" `shouldBe` Nothing
 
     describe "encodeSegment" $
         it "percent-encodes unsafe URL characters" $ do
@@ -103,6 +107,15 @@ spec = do
             addWebUrl "https://x" (Number 42) `shouldBe` Number 42
             addWebUrl "https://x" (Bool True) `shouldBe` Bool True
             addWebUrl "https://x" Null `shouldBe` Null
+
+    describe "addWebUrlMaybe" $ do
+        it "inserts web_url when Just" $
+            addWebUrlMaybe (Just "https://x") (object ["a" .= (1 :: Int)])
+                `shouldBe` object ["a" .= (1 :: Int), "web_url" .= ("https://x" :: Text)]
+
+        it "is a no-op when Nothing" $
+            addWebUrlMaybe Nothing (object ["a" .= (1 :: Int)])
+                `shouldBe` object ["a" .= (1 :: Int)]
 
     describe "slimLCIAPanel" $ do
         let panelWithFnUnit =

--- a/test/MCPEnrichSpec.hs
+++ b/test/MCPEnrichSpec.hs
@@ -21,6 +21,7 @@ import API.MCP.Enrich (
     scoreActivityWebUrl,
     slimLCIAPanel,
     summarizeLCIAPanel,
+    webUrlField,
  )
 import Control.Monad (forM_)
 import Data.Aeson (Value (..), object, (.=))
@@ -116,6 +117,14 @@ spec = do
         it "is a no-op when Nothing" $
             addWebUrlMaybe Nothing (object ["a" .= (1 :: Int)])
                 `shouldBe` object ["a" .= (1 :: Int)]
+
+    describe "webUrlField" $ do
+        it "yields a single web_url pair when a base URL is configured" $
+            object (webUrlField (Just "https://x") "/db/foo/activity/bar/impacts/EF31")
+                `shouldBe` object ["web_url" .= ("https://x/db/foo/activity/bar/impacts/EF31" :: Text)]
+
+        it "yields an empty pair list when no base URL is configured" $
+            webUrlField Nothing "/anything" `shouldBe` []
 
     describe "slimLCIAPanel" $ do
         let panelWithFnUnit =

--- a/volca.cabal
+++ b/volca.cabal
@@ -165,6 +165,8 @@ executable volca
                      , http-client
                      , optparse-applicative
                      , aeson
+                     , directory
+                     , filepath
 
   default-language:    Haskell2010
 


### PR DESCRIPTION
## Summary

The MCP `web_url` field is a deep link to Elm SPA routes like `/db/{db}/activity/{pid}/impacts/{coll}`, not an API endpoint. In backend-only deployments (the `volca` image built without `--with-frontend`), nothing serves those routes — clients following the link land on a 404.

This PR makes `web_url` conditional on the frontend actually being bundled:

- `app/Main.hs` checks `<staticDir>/index.html` once at boot and threads the result into `mcpApp`.
- `Maybe Text` baseUrl propagates through `handleRpc` → `handleToolsCall` → `callTool` → the six MCP handlers that emit `web_url` (`get_impacts`, `compute_sensitivity`, `get_contributing_flows`, `get_contributing_activities`, `score_activity`, `score_activities`).
- When the SPA is absent, `web_url` is simply omitted — both as an object field and (for the columnar `score_activities` shape) as a column **and** the corresponding row cell. No dead links emitted, no silent placeholders.
- `scoreActivityWebUrl` switches to `Maybe Text -> ... -> Maybe Text` and `addWebUrlMaybe` is added — both make the "no frontend" state non-representable rather than guarded by stringly defaults.

The MCP server `instructions` already tells the LLM to render `web_url` as a markdown link "from each result". With this change, results from a backend-only deployment no longer carry one, so the LLM falls back to showing the bare `process_id` instead of pointing the user at a 404.

## Test plan

- [x] `cabal build` — passes
- [x] `cabal test lca-tests` — 1092 examples, 0 failures
- [x] New `MCPEnrichSpec` cases for `scoreActivityWebUrl Nothing` and `addWebUrlMaybe`
- [x] New `MCPColumnarSpec` describe block: with `Nothing` baseUrl, the `web_url` column and per-row cell are both dropped
- [ ] Manual smoke: run `volca server` against a config whose `staticDir` lacks `index.html`, hit `/mcp` with a `tools/call` for `get_impacts`, confirm the response object has no `web_url` key