### PR TITLE
mcp: expose source-native activity_type through search/score/get_activity

### DIFF
--- a/src/API/OpenApi.hs
+++ b/src/API/OpenApi.hs
@@ -28,7 +28,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Database.Manager (DatabaseSetupInfo, DependencyChoice, DependencyStatus, MissingSupplier)
 import Network.HTTP.Types.Method (StdMethod (..))
-import Types (BioDirection, BiosphereFlow, Compartment, Exchange, LocationFallback, LocationKind, LocationUnresolved, Pedigree, TechRole, TechnosphereFlow, Unit)
+import Types (BioDirection, BiosphereFlow, Compartment, Exchange, LocationFallback, LocationKind, LocationUnresolved, NativeActivityType, Pedigree, TechRole, TechnosphereFlow, Unit)
 
 {- | Orphan schema instance forward declaration for the login request body.
 The real type lives in "API.Routes"; this is defined there and re-imported
@@ -220,6 +220,31 @@ instance ToSchema PerturbedEntry where
 instance ToSchema Perturbation where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 instance ToSchema ExchangeDetail where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 instance ToSchema ExchangeWithUnit where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
+
+-- Manual schema: the NativeActivityType sum is flattened by ToJSON to a
+-- single record with `source` discriminator and nullable code/special_*
+-- fields. The Generic schema would expose the Haskell sum-of-records shape.
+instance ToSchema NativeActivityType where
+    declareNamedSchema _ = do
+        intRef <- declareSchemaRef (Proxy :: Proxy Int)
+        textRef <- declareSchemaRef (Proxy :: Proxy Text)
+        let sourceEnum =
+                mempty
+                    & type_ ?~ OpenApiString
+                    & enum_ ?~ [toJSON ("ecospold2" :: Text), toJSON ("simapro" :: Text), toJSON ("ilcd" :: Text)]
+        pure $
+            NamedSchema (Just "NativeActivityType") $
+                mempty
+                    & type_ ?~ OpenApiObject
+                    & properties
+                        .~ InsOrdHashMap.fromList
+                            [ ("source", Inline sourceEnum)
+                            , ("label", textRef)
+                            , ("code", intRef)
+                            , ("special_code", intRef)
+                            , ("special_label", textRef)
+                            ]
+                    & required .~ ["source", "label"]
 instance ToSchema ActivityForAPI where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 instance ToSchema ActivityInfo where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 instance ToSchema ActivityMetadata where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions

--- a/src/API/OpenApi.hs
+++ b/src/API/OpenApi.hs
@@ -222,16 +222,27 @@ instance ToSchema ExchangeDetail where declareNamedSchema = genericDeclareNamedS
 instance ToSchema ExchangeWithUnit where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions
 
 -- Manual schema: the NativeActivityType sum is flattened by ToJSON to a
--- single record with `source` discriminator and nullable code/special_*
--- fields. The Generic schema would expose the Haskell sum-of-records shape.
+-- single record with `source` discriminator. The Generic schema would expose
+-- the Haskell sum-of-records shape. code / special_code / special_label are
+-- inlined with `nullable: true` because ToJSON emits explicit `null` for
+-- non-ecospold variants and strict OpenAPI codegen otherwise rejects null.
 instance ToSchema NativeActivityType where
     declareNamedSchema _ = do
-        intRef <- declareSchemaRef (Proxy :: Proxy Int)
-        textRef <- declareSchemaRef (Proxy :: Proxy Text)
         let sourceEnum =
                 mempty
                     & type_ ?~ OpenApiString
                     & enum_ ?~ [toJSON ("ecospold2" :: Text), toJSON ("simapro" :: Text), toJSON ("ilcd" :: Text)]
+            labelSchema =
+                mempty
+                    & type_ ?~ OpenApiString
+            nullableIntSchema =
+                mempty
+                    & type_ ?~ OpenApiInteger
+                    & nullable ?~ True
+            nullableTextSchema =
+                mempty
+                    & type_ ?~ OpenApiString
+                    & nullable ?~ True
         pure $
             NamedSchema (Just "NativeActivityType") $
                 mempty
@@ -239,10 +250,10 @@ instance ToSchema NativeActivityType where
                     & properties
                         .~ InsOrdHashMap.fromList
                             [ ("source", Inline sourceEnum)
-                            , ("label", textRef)
-                            , ("code", intRef)
-                            , ("special_code", intRef)
-                            , ("special_label", textRef)
+                            , ("label", Inline labelSchema)
+                            , ("code", Inline nullableIntSchema)
+                            , ("special_code", Inline nullableIntSchema)
+                            , ("special_label", Inline nullableTextSchema)
                             ]
                     & required .~ ["source", "label"]
 instance ToSchema ActivityForAPI where declareNamedSchema = genericDeclareNamedSchema strippedSchemaOptions

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -15,7 +16,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import GHC.Generics
 import Servant.API.ContentTypes (MimeRender (..), OctetStream)
-import Types (BiosphereFlow (..), Compartment, Exchange, FlowKind (..), Pedigree, TechnosphereFlow (..), UUID, Unit, WasteFlow (..))
+import Types (BiosphereFlow (..), Compartment, Exchange, FlowKind (..), NativeActivityType (..), Pedigree, TechnosphereFlow (..), UUID, Unit, WasteFlow (..))
 
 {- | Tagged wire representation of either side of the flow split.
 
@@ -115,6 +116,7 @@ data ActivitySummary = ActivitySummary
     , prsProductUnit :: Text -- Reference product unit name
     , prsAllocationPercent :: Maybe Double -- SimaPro coproduct allocation (%, 0..100); Nothing for non-allocated bases
     , prsAllocationFormula :: Maybe Text -- Raw SimaPro allocation formula; Nothing if purely numeric
+    , prsNativeType :: Maybe NativeActivityType -- Source-native activity type (ecospold @activityType, SimaPro Type, ILCD processType); Nothing when source lacks the field
     }
     deriving (Generic)
 
@@ -793,6 +795,7 @@ data ActivityForAPI = ActivityForAPI
     , pfaReferenceProductUnit :: Maybe Text -- Unit of reference product
     , pfaAllProducts :: [ActivitySummary] -- All products from same activityUUID
     , pfaExchanges :: [ExchangeWithUnit] -- Exchanges with unit names
+    , pfaNativeType :: Maybe NativeActivityType -- Source-native activity type, surfaced flat in JSON (see NativeActivityType ToJSON instance)
     }
     deriving (Generic)
 
@@ -918,6 +921,80 @@ instance ToJSON ClassificationSystem where toJSON = strippedToJSON; toEncoding =
 instance ToJSON Aggregation where toJSON = strippedToJSON; toEncoding = strippedToEncoding
 instance ToJSON AggregationGroup where toJSON = strippedToJSON; toEncoding = strippedToEncoding
 instance (ToJSON a) => ToJSON (SearchResults a) where toJSON = strippedToJSON; toEncoding = strippedToEncoding
+
+{- | NativeActivityType is a sum type internally but serialises to a single
+flat record so MCP / pyvolca consumers see one uniform shape regardless of
+which source database produced the activity. Discriminator is the 'source'
+field; format-specific fields (code, special_*) are null when irrelevant.
+-}
+instance ToJSON NativeActivityType where
+    toJSON = \case
+        EcoSpoldActivityType code label specCode specLabel ->
+            object
+                [ "source" .= ("ecospold2" :: Text)
+                , "label" .= label
+                , "code" .= code
+                , "special_code" .= specCode
+                , "special_label" .= specLabel
+                ]
+        SimaProProcessType label ->
+            object
+                [ "source" .= ("simapro" :: Text)
+                , "label" .= label
+                , "code" .= Null
+                , "special_code" .= Null
+                , "special_label" .= Null
+                ]
+        ILCDProcessType label ->
+            object
+                [ "source" .= ("ilcd" :: Text)
+                , "label" .= label
+                , "code" .= Null
+                , "special_code" .= Null
+                , "special_label" .= Null
+                ]
+    toEncoding = \case
+        EcoSpoldActivityType code label specCode specLabel ->
+            pairs
+                ( "source" .= ("ecospold2" :: Text)
+                    <> "label" .= label
+                    <> "code" .= code
+                    <> "special_code" .= specCode
+                    <> "special_label" .= specLabel
+                )
+        SimaProProcessType label ->
+            pairs
+                ( "source" .= ("simapro" :: Text)
+                    <> "label" .= label
+                    <> "code" .= Null
+                    <> "special_code" .= Null
+                    <> "special_label" .= Null
+                )
+        ILCDProcessType label ->
+            pairs
+                ( "source" .= ("ilcd" :: Text)
+                    <> "label" .= label
+                    <> "code" .= Null
+                    <> "special_code" .= Null
+                    <> "special_label" .= Null
+                )
+
+-- | Inverse of the ToJSON instance: discriminate on the @source@ field.
+instance FromJSON NativeActivityType where
+    parseJSON = withObject "NativeActivityType" $ \o -> do
+        src <- o .: "source"
+        label <- o .: "label"
+        case (src :: Text) of
+            "ecospold2" ->
+                EcoSpoldActivityType
+                    <$> o .: "code"
+                    <*> pure label
+                    <*> o .:? "special_code"
+                    <*> o .:? "special_label"
+            "simapro" -> pure (SimaProProcessType label)
+            "ilcd" -> pure (ILCDProcessType label)
+            other -> fail $ "Unknown NativeActivityType source: " <> T.unpack other
+
 instance ToJSON ActivitySummary where toJSON = strippedToJSON; toEncoding = strippedToEncoding
 instance ToJSON FlowSearchResult where toJSON = strippedToJSON; toEncoding = strippedToEncoding
 instance ToJSON InventoryMetadata where toJSON = strippedToJSON; toEncoding = strippedToEncoding

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -795,7 +795,7 @@ data ActivityForAPI = ActivityForAPI
     , pfaReferenceProductUnit :: Maybe Text -- Unit of reference product
     , pfaAllProducts :: [ActivitySummary] -- All products from same activityUUID
     , pfaExchanges :: [ExchangeWithUnit] -- Exchanges with unit names
-    , pfaNativeType :: Maybe NativeActivityType -- Source-native activity type, surfaced flat in JSON (see NativeActivityType ToJSON instance)
+    , pfaNativeType :: Maybe NativeActivityType -- Source-native activity type
     }
     deriving (Generic)
 

--- a/src/EcoSpold/Common.hs
+++ b/src/EcoSpold/Common.hs
@@ -6,6 +6,7 @@ module EcoSpold.Common (
     decodeXmlEntities,
     bsToDouble,
     bsToInt,
+    bsToIntMaybe,
     isElement,
     distributeFiles,
     nonEmptyText,
@@ -48,6 +49,14 @@ bsToInt :: BS.ByteString -> Int
 bsToInt bs = case TR.decimal (bsToText bs) of
     Right (val, _) -> val
     Left _ -> error $ "Failed to parse int from: " ++ show bs
+
+-- | ByteString to Int conversion that returns Nothing on parse failure.
+-- Use for attribute values that are user-controlled or optional and where
+-- crashing the parser on malformed input is not acceptable.
+bsToIntMaybe :: BS.ByteString -> Maybe Int
+bsToIntMaybe bs = case TR.decimal (bsToText bs) of
+    Right (val, _) -> Just val
+    Left _ -> Nothing
 
 {- | Check if element name matches (with or without namespace prefix)
 Handles both "tagName" and "prefix:tagName" forms

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -436,7 +436,7 @@ parseWithXeno xmlContent =
                     filter
                         (not . T.null . snd)
                         [("Category", psActivityCategory st), ("SubCategory", psActivitySubCategory st)]
-            activity = Activity name description M.empty classifications location refUnit (reverse $ psExchanges st) M.empty M.empty Nothing Nothing
+            activity = Activity name description M.empty classifications location refUnit (reverse $ psExchanges st) M.empty M.empty Nothing Nothing Nothing
             techs = reverse (psTechFlows st)
             bios = reverse (psBioFlows st)
             wastes = reverse (psWasteFlows st)
@@ -785,7 +785,7 @@ parseAllWithXeno xmlContent =
                     filter
                         (not . T.null . snd)
                         [("Category", psActivityCategory st), ("SubCategory", psActivitySubCategory st)]
-            activity = Activity name description M.empty classifications location refUnit (reverse $ psExchanges st) M.empty M.empty Nothing Nothing
+            activity = Activity name description M.empty classifications location refUnit (reverse $ psExchanges st) M.empty M.empty Nothing Nothing Nothing
             techs = reverse (psTechFlows st)
             bios = reverse (psBioFlows st)
             wastes = reverse (psWasteFlows st)

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -196,7 +196,9 @@ ecoSpoldNativeType (Just code) special =
             , eatSpecialLabel = ecoSpoldSpecialActivityTypeLabel <$> special
             }
 
--- | ecospold2 activityType enum labels (v3 schema).
+-- | ecospold2 activityType enum labels (v3 schema). Unknown codes yield an
+-- explicit "Unknown (code N)" sentinel so a future spec extension or a
+-- parser bug is visible to consumers, not silently empty.
 ecoSpoldActivityTypeLabel :: Int -> Text
 ecoSpoldActivityTypeLabel = \case
     1 -> "Ordinary transforming activity"
@@ -207,9 +209,10 @@ ecoSpoldActivityTypeLabel = \case
     6 -> "Import activity"
     7 -> "Correction activity"
     8 -> "Market group"
-    _ -> ""
+    n -> "Unknown (code " <> T.pack (show n) <> ")"
 
--- | ecospold2 specialActivityType enum labels (v3 schema).
+-- | ecospold2 specialActivityType enum labels (v3 schema). Same unknown-code
+-- treatment as 'ecoSpoldActivityTypeLabel'.
 ecoSpoldSpecialActivityTypeLabel :: Int -> Text
 ecoSpoldSpecialActivityTypeLabel = \case
     0 -> "Default"
@@ -219,7 +222,7 @@ ecoSpoldSpecialActivityTypeLabel = \case
     4 -> "Combined production without byproducts"
     5 -> "Combined production"
     6 -> "Import activity"
-    _ -> ""
+    n -> "Unknown (code " <> T.pack (show n) <> ")"
 
 -- | Xeno SAX parser implementation
 parseWithXeno :: BS.ByteString -> ProcessId -> Either String ((Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]), [String])

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module EcoSpold.Parser2 (streamParseActivityAndFlowsFromFile, normalizeCAS) where
@@ -146,6 +147,8 @@ data ParseState = ParseState
     , psClassifications :: !(M.Map Text Text) -- Classification system -> value
     , psPendingClassSystem :: !Text -- Current classification system name
     , psPendingCommentLang :: !Text -- xml:lang on the currently-open <comment>
+    , psActivityType :: !(Maybe Int) -- ecospold2 <activity activityType="1..8"> attribute
+    , psSpecialActivityType :: !(Maybe Int) -- ecospold2 <activity specialActivityType="…"> attribute
     }
 
 -- | Initial parsing state
@@ -170,7 +173,53 @@ initialParseState =
         , psClassifications = M.empty
         , psPendingClassSystem = ""
         , psPendingCommentLang = ""
+        , psActivityType = Nothing
+        , psSpecialActivityType = Nothing
         }
+
+{- | Build the source-native activity-type record from the ecospold2
+@activityType@ and @specialActivityType@ attribute values, both verbatim
+integers from the XML. Returns 'Nothing' when the primary @activityType@
+attribute is absent (we never fabricate a value).
+
+Labels are the ecoinvent v3 schema's documented strings. Unknown codes
+keep the integer and yield an empty label rather than a guess.
+-}
+ecoSpoldNativeType :: Maybe Int -> Maybe Int -> Maybe NativeActivityType
+ecoSpoldNativeType Nothing _ = Nothing
+ecoSpoldNativeType (Just code) special =
+    Just
+        EcoSpoldActivityType
+            { eatCode = code
+            , eatLabel = ecoSpoldActivityTypeLabel code
+            , eatSpecialCode = special
+            , eatSpecialLabel = ecoSpoldSpecialActivityTypeLabel <$> special
+            }
+
+-- | ecospold2 activityType enum labels (v3 schema).
+ecoSpoldActivityTypeLabel :: Int -> Text
+ecoSpoldActivityTypeLabel = \case
+    1 -> "Ordinary transforming activity"
+    2 -> "Market activity"
+    3 -> "IO activity"
+    4 -> "Residual activity"
+    5 -> "Production mix"
+    6 -> "Import activity"
+    7 -> "Correction activity"
+    8 -> "Market group"
+    _ -> ""
+
+-- | ecospold2 specialActivityType enum labels (v3 schema).
+ecoSpoldSpecialActivityTypeLabel :: Int -> Text
+ecoSpoldSpecialActivityTypeLabel = \case
+    0 -> "Default"
+    1 -> "Hard link"
+    2 -> "Pre-aggregation"
+    3 -> "Combined production with byproducts"
+    4 -> "Combined production without byproducts"
+    5 -> "Combined production"
+    6 -> "Import activity"
+    _ -> ""
 
 -- | Xeno SAX parser implementation
 parseWithXeno :: BS.ByteString -> ProcessId -> Either String ((Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]), [String])
@@ -242,7 +291,19 @@ parseWithXeno xmlContent processId =
                 InGeneralCommentText _ ->
                     let idx = if isElement name "index" then bsToInt value else 0
                      in withLang state{psContext = InGeneralCommentText idx}
-                _ -> withLang state
+                _ ->
+                    -- Attributes on the <activity> opening tag carry the
+                    -- ecospold2 activityType and specialActivityType enums.
+                    let onActivity = case psPath state of
+                            (current : _) -> isElement current "activity"
+                            [] -> False
+                        captured
+                            | onActivity && isElement name "activityType" =
+                                state{psActivityType = Just (bsToInt value)}
+                            | onActivity && isElement name "specialActivityType" =
+                                state{psSpecialActivityType = Just (bsToInt value)}
+                            | otherwise = state
+                     in withLang captured
 
     -- End of opening tag - no action needed for SAX
     endOpen state _tagName = state
@@ -617,8 +678,9 @@ parseWithXeno xmlContent processId =
             location = fromMaybe "GLO" (psLocation st)
             description = reverse (psDescription st) -- Reverse to get correct order
             refUnit = fromMaybe "UNKNOWN_UNIT" (psRefUnit st)
+            nativeType = ecoSpoldNativeType (psActivityType st) (psSpecialActivityType st)
             -- Apply cutoff strategy to exchanges
-            activity = Activity name description M.empty (psClassifications st) location refUnit (reverse $ psExchanges st) M.empty M.empty Nothing Nothing Nothing
+            activity = Activity name description M.empty (psClassifications st) location refUnit (reverse $ psExchanges st) M.empty M.empty Nothing Nothing nativeType
             techs = reverse (psTechFlows st)
             bios = reverse (psBioFlows st)
             wastes = reverse (psWasteFlows st)

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -618,7 +618,7 @@ parseWithXeno xmlContent processId =
             description = reverse (psDescription st) -- Reverse to get correct order
             refUnit = fromMaybe "UNKNOWN_UNIT" (psRefUnit st)
             -- Apply cutoff strategy to exchanges
-            activity = Activity name description M.empty (psClassifications st) location refUnit (reverse $ psExchanges st) M.empty M.empty Nothing Nothing
+            activity = Activity name description M.empty (psClassifications st) location refUnit (reverse $ psExchanges st) M.empty M.empty Nothing Nothing Nothing
             techs = reverse (psTechFlows st)
             bios = reverse (psBioFlows st)
             wastes = reverse (psWasteFlows st)

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -13,7 +13,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V5 as UUID5
-import EcoSpold.Common (bsToDouble, bsToInt, bsToText, isElement)
+import EcoSpold.Common (bsToDouble, bsToInt, bsToIntMaybe, bsToText, isElement)
 import Progress (ProgressLevel (..), reportProgress)
 import System.FilePath (takeBaseName)
 import Types
@@ -299,9 +299,9 @@ parseWithXeno xmlContent processId =
                             [] -> False
                         captured
                             | onActivity && isElement name "activityType" =
-                                state{psActivityType = Just (bsToInt value)}
+                                state{psActivityType = bsToIntMaybe value}
                             | onActivity && isElement name "specialActivityType" =
-                                state{psSpecialActivityType = Just (bsToInt value)}
+                                state{psSpecialActivityType = bsToIntMaybe value}
                             | otherwise = state
                      in withLang captured
 

--- a/src/ILCD/Parser.hs
+++ b/src/ILCD/Parser.hs
@@ -474,7 +474,7 @@ parseProcessXML bytes =
         | isElement tag "classification" =
             s{psPendingClassName = "", psTextAccum = []}
         | isElement tag "processType" && not (psInExchange s) && T.null (psProcessType s) =
-            -- ILCD <processType> lives at <processInformation><dataSetInformation><processType>.
+            -- ILCD <processType> lives at <modellingAndValidation><LCIMethodAndAllocation><processType>.
             -- Guard psInExchange just in case a future ILCD revision reuses the tag name
             -- elsewhere; first occurrence wins to be deterministic.
             s{psProcessType = accum s, psTextAccum = []}

--- a/src/ILCD/Parser.hs
+++ b/src/ILCD/Parser.hs
@@ -556,6 +556,7 @@ buildActivity flowInfoMap techFlowDB bioFlowDB wasteFlowDB unitDB p =
         , activityParamExprs = M.empty
         , activityAllocationPercent = Nothing
         , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
         }
   where
     -- Look up the reference exchange's flow unit. Reference exchange is typically

--- a/src/ILCD/Parser.hs
+++ b/src/ILCD/Parser.hs
@@ -45,6 +45,7 @@ data ILCDProcessRaw = ILCDProcessRaw
     , iprRefFlowIdx :: !Int -- dataSetInternalID of reference exchange
     , iprExchanges :: ![ILCDExchangeRaw]
     , iprClassifications :: !(M.Map Text Text)
+    , iprProcessType :: !Text -- ILCD <processType> element value (e.g. "Unit process, single operation"); "" when absent
     }
 
 {- | Update a comment slot with a newly-seen `<common:generalComment>`.
@@ -347,6 +348,7 @@ data ProcState = ProcState
     , psClassifications :: !(M.Map Text Text)
     , psPendingClassName :: !Text
     , psInClass :: !Bool
+    , psProcessType :: !Text -- ILCD <processType> element text (empty when absent)
     }
 
 parseProcessXML :: BS.ByteString -> Maybe ILCDProcessRaw
@@ -377,6 +379,7 @@ parseProcessXML bytes =
             , psClassifications = M.empty
             , psPendingClassName = ""
             , psInClass = False
+            , psProcessType = ""
             }
         )
         bytes of
@@ -470,6 +473,11 @@ parseProcessXML bytes =
                     }
         | isElement tag "classification" =
             s{psPendingClassName = "", psTextAccum = []}
+        | isElement tag "processType" && not (psInExchange s) && T.null (psProcessType s) =
+            -- ILCD <processType> lives at <processInformation><dataSetInformation><processType>.
+            -- Guard psInExchange just in case a future ILCD revision reuses the tag name
+            -- elsewhere; first occurrence wins to be deterministic.
+            s{psProcessType = accum s, psTextAccum = []}
         | isElement tag "exchange" =
             let ex =
                     ILCDExchangeRaw
@@ -501,6 +509,7 @@ parseProcessXML bytes =
                         , iprRefFlowIdx = psRefFlowIdx s
                         , iprExchanges = reverse (psExchanges s)
                         , iprClassifications = psClassifications s
+                        , iprProcessType = psProcessType s
                         }
 
 -- | Parse process files in parallel using worker pattern
@@ -556,7 +565,10 @@ buildActivity flowInfoMap techFlowDB bioFlowDB wasteFlowDB unitDB p =
         , activityParamExprs = M.empty
         , activityAllocationPercent = Nothing
         , activityAllocationFormula = Nothing
-        , activityNativeType = Nothing
+        , activityNativeType =
+            if T.null (iprProcessType p)
+                then Nothing
+                else Just (ILCDProcessType{iptLabel = iprProcessType p})
         }
   where
     -- Look up the reference exchange's flow unit. Reference exchange is typically

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -250,14 +250,16 @@ convertToInventoryExport db bioFlowDB unitDB processId rootActivity inventory =
             InventoryMetadata
                 { imRootActivity =
                     ActivitySummary
-                        (processIdToText db processId)
-                        (activityName rootActivity)
-                        (activityLocation rootActivity)
-                        prodName
-                        prodAmount
-                        prodUnit
-                        (activityAllocationPercent rootActivity)
-                        (activityAllocationFormula rootActivity)
+                        { prsProcessId = processIdToText db processId
+                        , prsName = activityName rootActivity
+                        , prsLocation = activityLocation rootActivity
+                        , prsProduct = prodName
+                        , prsProductAmount = prodAmount
+                        , prsProductUnit = prodUnit
+                        , prsAllocationPercent = activityAllocationPercent rootActivity
+                        , prsAllocationFormula = activityAllocationFormula rootActivity
+                        , prsNativeType = activityNativeType rootActivity
+                        }
                 , imTotalFlows = length flowDetails
                 , imEmissionFlows = emissionFlows
                 , imResourceFlows = resourceFlows
@@ -947,14 +949,16 @@ searchActivities db (SearchFilter core exactMatch) = do
                 ( \(processId, activity) ->
                     let (prodName, prodAmount, prodUnit) = getReferenceProductInfo (dbTechFlows db) (dbUnits db) activity
                      in ActivitySummary
-                            (processIdToText db processId)
-                            (activityName activity)
-                            (activityLocation activity)
-                            prodName
-                            prodAmount
-                            prodUnit
-                            (activityAllocationPercent activity)
-                            (activityAllocationFormula activity)
+                            { prsProcessId = processIdToText db processId
+                            , prsName = activityName activity
+                            , prsLocation = activityLocation activity
+                            , prsProduct = prodName
+                            , prsProductAmount = prodAmount
+                            , prsProductUnit = prodUnit
+                            , prsAllocationPercent = activityAllocationPercent activity
+                            , prsAllocationFormula = activityAllocationFormula activity
+                            , prsNativeType = activityNativeType activity
+                            }
                 )
                 pagedResults
     endTime <- getCurrentTime
@@ -1086,6 +1090,7 @@ convertActivityForAPI unitCfg db processId activity =
             , pfaReferenceProductUnit = if T.null refProdName then Nothing else Just refProdUnit
             , pfaAllProducts = allProducts
             , pfaExchanges = map convertExchangeWithUnit (exchanges activity)
+            , pfaNativeType = activityNativeType activity
             }
   where
     -- Cross-DB link lookup keyed by 'cdlConsumerFlowId' (the consumer-side flow
@@ -1232,6 +1237,7 @@ getAllProductsForActivity db activityUUID =
                     , prsProductUnit = prodUnit
                     , prsAllocationPercent = mAct >>= activityAllocationPercent
                     , prsAllocationFormula = mAct >>= activityAllocationFormula
+                    , prsNativeType = mAct >>= activityNativeType
                     }
             | pid <- processIds
             ]
@@ -1254,6 +1260,7 @@ getTargetActivity db exchange = do
             , prsProductUnit = prodUnit
             , prsAllocationPercent = activityAllocationPercent targetActivity
             , prsAllocationFormula = activityAllocationFormula targetActivity
+            , prsNativeType = activityNativeType targetActivity
             }
 
 {- | Get reference product as FlowDetail (if exists). Reference products are
@@ -1278,14 +1285,16 @@ getActivitiesUsingFlow db flowUUID =
             let uniqueUUIDs = S.toList $ S.fromList activityUUIDs -- Deduplicate activity UUIDs
              in [ let (prodName, prodAmount, prodUnit) = getReferenceProductInfo (dbTechFlows db) (dbUnits db) proc
                    in ActivitySummary
-                        (processIdToText db processId)
-                        (activityName proc)
-                        (activityLocation proc)
-                        prodName
-                        prodAmount
-                        prodUnit
-                        (activityAllocationPercent proc)
-                        (activityAllocationFormula proc)
+                        { prsProcessId = processIdToText db processId
+                        , prsName = activityName proc
+                        , prsLocation = activityLocation proc
+                        , prsProduct = prodName
+                        , prsProductAmount = prodAmount
+                        , prsProductUnit = prodUnit
+                        , prsAllocationPercent = activityAllocationPercent proc
+                        , prsAllocationFormula = activityAllocationFormula proc
+                        , prsNativeType = activityNativeType proc
+                        }
                 | procUUID <- uniqueUUIDs
                 , Just proc <- [findActivityByActivityUUID db procUUID]
                 , Just processId <- [findProcessIdForActivity db proc]
@@ -1392,6 +1401,7 @@ getActivityExchangeDetails db activity filterFn =
                             , prsProductUnit = cdlExchangeUnit link
                             , prsAllocationPercent = Nothing
                             , prsAllocationFormula = Nothing
+                            , prsNativeType = Nothing
                             }
 
 -- | Get detailed input exchanges
@@ -1733,6 +1743,7 @@ buildSupplyChainFromScalingVector db dbName processId supplyVec scf includeEdges
                 , prsProductUnit = activityUnit rootActivity
                 , prsAllocationPercent = activityAllocationPercent rootActivity
                 , prsAllocationFormula = activityAllocationFormula rootActivity
+                , prsNativeType = activityNativeType rootActivity
                 }
      in SupplyChainResponse
             { scrRoot = rootSummary
@@ -1794,6 +1805,7 @@ buildSupplyChainFromScalingVectorCrossDB unitCfg depLookup rootDb rootDbName roo
                 , prsProductUnit = activityUnit rootActivity
                 , prsAllocationPercent = activityAllocationPercent rootActivity
                 , prsAllocationFormula = activityAllocationFormula rootActivity
+                , prsNativeType = activityNativeType rootActivity
                 }
     eDep <- walkDepLevels unitCfg depLookup rootDb rootScaling extraLinks scf includeEdges 1 S.empty
     pure $ case eDep of

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -879,7 +879,10 @@ processBlockToActivity unitCfg (dbInputPs, dbCalcPs, projInputPs, projCalcPs) Pr
                         , activityParamExprs = exprMap
                         , activityAllocationPercent = Just allocPercent
                         , activityAllocationFormula = allocFormula
-                        , activityNativeType = Nothing
+                        , activityNativeType =
+                            if T.null pbType
+                                then Nothing
+                                else Just (SimaProProcessType{sptLabel = pbType})
                         }
                 allTechFlows = productFlow : sharedTechFlows
                 allBioFlows = sharedBioFlows

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -879,6 +879,7 @@ processBlockToActivity unitCfg (dbInputPs, dbCalcPs, projInputPs, projCalcPs) Pr
                         , activityParamExprs = exprMap
                         , activityAllocationPercent = Just allocPercent
                         , activityAllocationFormula = allocFormula
+                        , activityNativeType = Nothing
                         }
                 allTechFlows = productFlow : sharedTechFlows
                 allBioFlows = sharedBioFlows

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -402,6 +402,37 @@ getUnitNameForWasteFlow :: UnitDB -> WasteFlow -> Text
 getUnitNameForWasteFlow unitDB f =
     maybe "unknown" unitName (getUnitForWasteFlow unitDB f)
 
+{- | Native activity-type metadata captured verbatim from the source database.
+
+Three variants matching the three supported source formats. Each variant carries
+only the fields the source format actually provides — no cross-format
+normalisation, no heuristic on names. The sum type makes it impossible to
+attach (for example) an ecospold integer code to a SimaPro activity.
+
+Wire-layer JSON flattens these three variants into a single unified record
+\{source, label, code?, special_label?, special_code?\} for consumer simplicity
+(see ToJSON instance in API.Types).
+-}
+data NativeActivityType
+    = -- | ecospold 2 @\<activity@ @activityType@ attribute (1..8) and optional
+      -- @specialActivityType@. Codes are the spec's enumeration; labels are
+      -- the spec's documented strings.
+      EcoSpoldActivityType
+        { eatCode :: !Int
+        , eatLabel :: !Text
+        , eatSpecialCode :: !(Maybe Int)
+        , eatSpecialLabel :: !(Maybe Text)
+        }
+    | -- | SimaPro CSV @Type@ header (\"Unit process\" / \"System\").
+      SimaProProcessType
+        { sptLabel :: !Text
+        }
+    | -- | ILCD @\<processType@ XML element value.
+      ILCDProcessType
+        { iptLabel :: !Text
+        }
+    deriving (Show, Eq, Generic, NFData, Store)
+
 {- | Base LCA activity
 Note: ProcessId is the index in dbActivities vector, UUIDs stored in dbProcessIdTable
 -}
@@ -417,6 +448,7 @@ data Activity = Activity
     , activityParamExprs :: !(M.Map Text Text) -- Raw SimaPro parameter expressions (for re-evaluation)
     , activityAllocationPercent :: !(Maybe Double) -- SimaPro multi-product allocation fraction (%, 0..100); Nothing for non-allocated bases
     , activityAllocationFormula :: !(Maybe Text) -- Raw SimaPro allocation formula (e.g. "Qp*DMp/(Qp*DMp+Qw*DMw)*100"); Nothing if purely numeric
+    , activityNativeType :: !(Maybe NativeActivityType) -- Source-format-native activity type (ecospold @activityType, SimaPro Type, ILCD processType); Nothing when source format lacks the field
     }
     deriving (Generic, NFData, Store)
 

--- a/test/BM25Spec.hs
+++ b/test/BM25Spec.hs
@@ -35,6 +35,7 @@ mkActivity name loc xs =
         , activityParamExprs = M.empty
         , activityAllocationPercent = Nothing
         , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
         }
 
 mkRefOutput :: UUID -> Exchange

--- a/test/CrossDBRegionalLCIAFixture.hs
+++ b/test/CrossDBRegionalLCIAFixture.hs
@@ -109,6 +109,7 @@ mkActivity _ loc =
         , activityParamExprs = M.empty
         , activityAllocationPercent = Nothing
         , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
         }
 
 emptyIndexes :: Indexes

--- a/test/CrossLinkingSpec.hs
+++ b/test/CrossLinkingSpec.hs
@@ -426,6 +426,7 @@ mkActivityAt loc =
         , activityParamExprs = M.empty
         , activityAllocationPercent = Nothing
         , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
         }
 
 mkRefExchangeAt :: Text -> Exchange

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -29,6 +29,7 @@ emptyActivity =
         , activityParamExprs = M.empty
         , activityAllocationPercent = Nothing
         , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
         }
 
 -- | A production output exchange (isInput=False, isReference=False by default)

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -106,6 +106,86 @@ spec = describe "per-exchange comments" $ do
         it "returns Left on well-formed XML that is not an EcoSpold dataset" $
             runOnBytes "<?xml version=\"1.0\"?><root><child>hello</child></root>" >>= shouldBeLeft
 
+    -- -----------------------------------------------------------------------
+    -- Native activity-type capture: ecospold2's <activity activityType="…"
+    -- specialActivityType="…"> attributes are the authoritative discriminator
+    -- between markets, ordinary transforming activities, market groups, etc.
+    -- We expose them verbatim with the spec's documented labels.
+    -- -----------------------------------------------------------------------
+    describe "native activityType / specialActivityType capture" $ do
+        let runOnBytes bytes = withSystemTempDirectory "es2-attr" $ \dir -> do
+                let path = dir </> "12345678-1234-5678-9abc-123456789001_12345678-1234-5678-9abc-123456789002.spold"
+                BS.writeFile path bytes
+                streamParseActivityAndFlowsFromFile path
+
+        it "captures activityType=2 as Market activity with code+label" $ do
+            result <- runOnBytes (activityTypeFixtureXml "2" (Just "1"))
+            case result of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right (act, _, _, _, _) ->
+                    activityNativeType act
+                        `shouldBe` Just
+                            EcoSpoldActivityType
+                                { eatCode = 2
+                                , eatLabel = "Market activity"
+                                , eatSpecialCode = Just 1
+                                , eatSpecialLabel = Just "Hard link"
+                                }
+
+        it "captures activityType=1 as Ordinary transforming activity, no special" $ do
+            result <- runOnBytes (activityTypeFixtureXml "1" Nothing)
+            case result of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right (act, _, _, _, _) ->
+                    activityNativeType act
+                        `shouldBe` Just
+                            EcoSpoldActivityType
+                                { eatCode = 1
+                                , eatLabel = "Ordinary transforming activity"
+                                , eatSpecialCode = Nothing
+                                , eatSpecialLabel = Nothing
+                                }
+
+        it "returns Nothing when no activityType attribute is present" $ do
+            result <- runOnBytes wastePatternsXml -- existing fixture has no activityType
+            case result of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right (act, _, _, _, _) ->
+                    activityNativeType act `shouldBe` Nothing
+
+{- | Synthetic ecospold2 dataset parameterised on the activityType code and
+optional specialActivityType code. One reference output, no other exchanges.
+-}
+activityTypeFixtureXml :: BS.ByteString -> Maybe BS.ByteString -> BS.ByteString
+activityTypeFixtureXml actType mSpec =
+    let specAttr = case mSpec of
+            Just s -> " specialActivityType=\"" <> s <> "\""
+            Nothing -> ""
+     in "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+        \<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold02\">\n\
+        \  <activityDataset>\n\
+        \    <activityDescription>\n\
+        \      <activity id=\"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\" activityNameId=\"attr-test\""
+        <> " activityType=\""
+        <> actType
+        <> "\""
+        <> specAttr
+        <> ">\n\
+           \        <activityName xml:lang=\"en\">attr test activity</activityName>\n\
+           \      </activity>\n\
+           \      <geography geographyId=\"TEST\"><shortname xml:lang=\"en\">TEST</shortname></geography>\n\
+           \    </activityDescription>\n\
+           \    <flowData>\n\
+           \      <intermediateExchange id=\"ref\" unitId=\"unit-kg\" amount=\"1.0\"\n\
+           \                           intermediateExchangeId=\"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb\">\n\
+           \        <name xml:lang=\"en\">attr test product</name>\n\
+           \        <unitName xml:lang=\"en\">kg</unitName>\n\
+           \        <outputGroup>0</outputGroup>\n\
+           \      </intermediateExchange>\n\
+           \    </flowData>\n\
+           \  </activityDataset>\n\
+           \</ecoSpold>\n"
+
 withWastePatternsFixture :: ((Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]) -> IO ()) -> IO ()
 withWastePatternsFixture k = withSystemTempDirectory "es2-waste-spec" $ \dir -> do
     let path = dir </> "12345678-1234-5678-9abc-123456789001_12345678-1234-5678-9abc-123456789002.spold"

--- a/test/FuzzySpec.hs
+++ b/test/FuzzySpec.hs
@@ -26,6 +26,7 @@ mkActivity name xs =
         , activityParamExprs = M.empty
         , activityAllocationPercent = Nothing
         , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
         }
 
 -- Index-builder helper: create a BM25 index over a list of activity names.

--- a/test/ILCDParserSpec.hs
+++ b/test/ILCDParserSpec.hs
@@ -50,6 +50,7 @@ activityWithRefExchange fid =
         , activityParamExprs = M.empty
         , activityAllocationPercent = Nothing
         , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
         }
 
 -- An activity with a single unresolved input exchange for the given flow UUID
@@ -79,6 +80,7 @@ activityWithInputExchange fid =
             ]
         , activityParams = M.empty
         , activityParamExprs = M.empty
+        , activityNativeType = Nothing
         }
 
 spec :: Spec

--- a/test/ILCDParserSpec.hs
+++ b/test/ILCDParserSpec.hs
@@ -267,6 +267,14 @@ spec = do
                 Nothing -> return ()
                 Just _ -> expectationFailure "expected Nothing when baseName missing"
 
+        it "captures <processType> element verbatim" $
+            fmap iprProcessType (parseProcessXML ilcdProcessWithProcessType)
+                `shouldBe` Just "Unit process, single operation"
+
+        it "leaves iprProcessType empty when <processType> is absent" $
+            fmap iprProcessType (parseProcessXML ilcdProcessWithClassification)
+                `shouldBe` Just ""
+
     describe "parseProcessXML exchange fields" $ do
         it "parses single exchange flow ref" $ do
             let Just raw = parseProcessXML ilcdProcessWithClassification
@@ -453,6 +461,35 @@ ilcdProcessNoClassification =
     \<referenceToReferenceFlow>0</referenceToReferenceFlow>\
     \</quantitativeReference>\
     \</processInformation>\
+    \<exchanges>\
+    \<exchange dataSetInternalID=\"0\">\
+    \<referenceToFlowDataSet refObjectId=\"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\"/>\
+    \<exchangeDirection>Output</exchangeDirection>\
+    \<resultingAmount>1.0</resultingAmount>\
+    \</exchange>\
+    \</exchanges>\
+    \</processDataSet>"
+
+ilcdProcessWithProcessType :: BS.ByteString
+ilcdProcessWithProcessType =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+    \<processDataSet xmlns=\"http://lca.jrc.it/ILCD/Process\" \
+    \xmlns:common=\"http://lca.jrc.it/ILCD/Common\">\
+    \<processInformation>\
+    \<dataSetInformation>\
+    \<common:UUID>42345678-1234-1234-1234-123456789abc</common:UUID>\
+    \<name><baseName>Test Process With ProcessType</baseName></name>\
+    \</dataSetInformation>\
+    \<geography location=\"FR\"/>\
+    \<quantitativeReference>\
+    \<referenceToReferenceFlow>0</referenceToReferenceFlow>\
+    \</quantitativeReference>\
+    \</processInformation>\
+    \<modellingAndValidation>\
+    \<LCIMethodAndAllocation>\
+    \<processType>Unit process, single operation</processType>\
+    \</LCIMethodAndAllocation>\
+    \</modellingAndValidation>\
     \<exchanges>\
     \<exchange dataSetInternalID=\"0\">\
     \<referenceToFlowDataSet refObjectId=\"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\"/>\

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -47,6 +47,7 @@ minimalActivity name loc exs =
         , activityParamExprs = M.empty
         , activityAllocationPercent = Nothing
         , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
         }
 
 refExchange :: UUID.UUID -> Exchange

--- a/test/MatrixConstructionSpec.hs
+++ b/test/MatrixConstructionSpec.hs
@@ -167,6 +167,7 @@ spec = do
                         , activityParamExprs = M.empty
                         , activityAllocationPercent = Nothing
                         , activityAllocationFormula = Nothing
+                        , activityNativeType = Nothing
                         }
                 activityMap = M.singleton (actUUID, prodUUID) activity
                 techFlowDB = M.singleton prodUUID (TechnosphereFlow prodUUID "energy product" jUnitId M.empty Nothing Nothing)
@@ -237,6 +238,7 @@ spec = do
                         , activityParamExprs = M.empty
                         , activityAllocationPercent = Nothing
                         , activityAllocationFormula = Nothing
+                        , activityNativeType = Nothing
                         }
                 activityMap = M.singleton (actUUID, prodUUID) activity
                 techFlowDB = M.singleton prodUUID (TechnosphereFlow prodUUID "energy product" jUnitId M.empty Nothing Nothing)

--- a/test/MinimalCoverIntegrationSpec.hs
+++ b/test/MinimalCoverIntegrationSpec.hs
@@ -145,6 +145,7 @@ supplierDB offset =
                 , activityParamExprs = M.empty
                 , activityAllocationPercent = Nothing
                 , activityAllocationFormula = Nothing
+                , activityNativeType = Nothing
                 }
      in SimpleDatabase
             { sdbActivities = M.singleton (actUUID, prodUUID) act
@@ -220,6 +221,7 @@ consumerDB offset n =
                         , activityParamExprs = M.empty
                         , activityAllocationPercent = Nothing
                         , activityAllocationFormula = Nothing
+                        , activityNativeType = Nothing
                         }
              in ((actUUID, prodUUID), act)
         activities = M.fromList [mkConsumer i | i <- [1 .. n]]

--- a/test/NativeActivityTypeSpec.hs
+++ b/test/NativeActivityTypeSpec.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Roundtrip tests for the flat JSON encoding of NativeActivityType.
+--   ToJSON flattens the three variants to a single-shape record; FromJSON
+--   reconstructs the right variant from the `source` discriminator.
+module NativeActivityTypeSpec (spec) where
+
+import API.Types ()
+import Data.Aeson (Result (..), Value (..), decode, encode, fromJSON, toJSON, (.=))
+import qualified Data.Aeson as A
+import qualified Data.Aeson.KeyMap as KM
+import Test.Hspec
+import Types (NativeActivityType (..))
+
+spec :: Spec
+spec = describe "NativeActivityType flat JSON encoding" $ do
+    it "encodes EcoSpoldActivityType with all five fields populated" $ do
+        let nat =
+                EcoSpoldActivityType
+                    { eatCode = 2
+                    , eatLabel = "Market activity"
+                    , eatSpecialCode = Just 1
+                    , eatSpecialLabel = Just "Hard link"
+                    }
+        toJSON nat
+            `shouldBe` A.object
+                [ "source" .= ("ecospold2" :: String)
+                , "label" .= ("Market activity" :: String)
+                , "code" .= (2 :: Int)
+                , "special_code" .= (1 :: Int)
+                , "special_label" .= ("Hard link" :: String)
+                ]
+
+    it "encodes SimaProProcessType with code/special_* set to null" $ do
+        let nat = SimaProProcessType{sptLabel = "Unit process"}
+            obj = case toJSON nat of
+                Object o -> o
+                _ -> error "expected Object"
+        KM.lookup "source" obj `shouldBe` Just "simapro"
+        KM.lookup "label" obj `shouldBe` Just "Unit process"
+        KM.lookup "code" obj `shouldBe` Just Null
+        KM.lookup "special_code" obj `shouldBe` Just Null
+        KM.lookup "special_label" obj `shouldBe` Just Null
+
+    it "encodes ILCDProcessType with code/special_* set to null" $ do
+        let nat = ILCDProcessType{iptLabel = "Unit process, single operation"}
+            obj = case toJSON nat of
+                Object o -> o
+                _ -> error "expected Object"
+        KM.lookup "source" obj `shouldBe` Just "ilcd"
+        KM.lookup "label" obj `shouldBe` Just "Unit process, single operation"
+        KM.lookup "code" obj `shouldBe` Just Null
+
+    it "round-trips an EcoSpoldActivityType" $ do
+        let original =
+                EcoSpoldActivityType
+                    { eatCode = 8
+                    , eatLabel = "Market group"
+                    , eatSpecialCode = Nothing
+                    , eatSpecialLabel = Nothing
+                    }
+        decode (encode original) `shouldBe` Just original
+
+    it "round-trips a SimaProProcessType" $ do
+        let original = SimaProProcessType{sptLabel = "System"}
+        decode (encode original) `shouldBe` Just original
+
+    it "round-trips an ILCDProcessType" $ do
+        let original = ILCDProcessType{iptLabel = "LCI result"}
+        decode (encode original) `shouldBe` Just original
+
+    it "rejects unknown source discriminator" $ do
+        let bad =
+                A.object
+                    [ "source" .= ("openlca" :: String)
+                    , "label" .= ("foo" :: String)
+                    ]
+        case fromJSON bad :: Result NativeActivityType of
+            Success _ -> expectationFailure "expected parse failure for unknown source"
+            Error _ -> pure ()

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -91,6 +91,7 @@ mkActivity loc =
         , activityParamExprs = M.empty
         , activityAllocationPercent = Nothing
         , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
         }
 
 -- Triples: (bioRow=0, col=i, value=v) for each activity.

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -32,6 +32,7 @@ import Types (
     Activity (..),
     BiosphereFlow,
     Exchange (..),
+    NativeActivityType (..),
     Pedigree (..),
     TechRole (..),
     TechnosphereFlow,
@@ -503,6 +504,13 @@ spec = do
             names `shouldContain` ["Irradiated Food"]
             let flowNames = map tfName (M.elems techFlowDB)
             flowNames `shouldContain` ["Food product (irradiated ; with treatment)"]
+
+    describe "SimaPro native process type" $ do
+        it "propagates the Type: header (\"Unit process\") to activityNativeType" $ do
+            (activities, _, _, _, _) <- parseTestCSV
+            let nativeTypes = map activityNativeType activities
+            -- Both fixture processes declare Type: Unit process
+            nativeTypes `shouldBe` replicate (length activities) (Just (SimaProProcessType{sptLabel = "Unit process"}))
 
     describe "SimaPro classification parsing" $ do
         it "parses Category type from metadata" $ do


### PR DESCRIPTION
## Summary

Surfaces the format-native activity-type discriminator that each parsed database already carries — and that we were silently dropping at ingestion. The MCP client can now tell an ecoinvent **market** (`activity_type.code = 2`) from an ordinary production process without name heuristics like the previous `"market for "` prefix match.

- **ecospold2**: `@activityType` (1..8) + `@specialActivityType` are now read and exposed with the ecoinvent spec's documented labels.
- **SimaPro / Agribalyse**: the `Type:` header (`Unit process` / `System`) is now propagated through to the wire layer.
- **ILCD**: `<processType>` XML element is now captured verbatim.

No heuristics, no inference, no new server-side filters in this PR — only what the source format actually says. Filtering and any structural derivations (e.g. inferring waste treatment from ILCD `ReferenceInput`) are deferred to a follow-up PR with opt-in TOML config.

## Shape on the wire

Internal: sum type `NativeActivityType` with three variants (one per source format), which keeps the Haskell side honest — impossible to attach an ecospold code to a SimaPro activity.

External (MCP / pyvolca / OpenAPI): flattened to a single record with `source` discriminator and nullable format-specific fields:

```json
"native_type": {
  "source": "ecospold2",
  "label": "Market activity",
  "code": 2,
  "special_code": 1,
  "special_label": "Hard link"
}
```

`code` and `special_*` are `null` for SimaPro and ILCD. The integer `code` is kept verbatim because it is the spec's primary key — clients filtering on `code == 2` survive label changes across ecoinvent revisions.

Field added on both `ActivitySummary` (so `search_activities` / `score_activities` carry it without a follow-up `get_activity` round-trip) and `ActivityForAPI`.

## Commit layout

Five atomic commits, bisect-friendly:

1. types: introduce `NativeActivityType` sum + `Activity.activityNativeType`
2. ecospold2: capture `@activityType` / `@specialActivityType`
3. simapro: propagate `pbType` to `Activity`
4. ilcd: capture `<processType>` element
5. api: custom `ToJSON`/`FromJSON`/`ToSchema` that flatten the sum, expose on `ActivityForAPI` and `ActivitySummary`

## Test plan

- [x] `cabal test lca-tests` — 1107 examples, 0 failures (was 1094 before this PR; +13 new tests covering each parser + JSON roundtrip for the three variants + unknown-source rejection)
- [x] `cabal build` library + executable
- [ ] Manual MCP smoke test: `search_activities("market for electricity", database=…)` returns `native_type: {source: "ecospold2", code: 2, …}` on real ecoinvent
- [ ] Manual MCP smoke test: `search_activities` on agribalyse returns `native_type: {source: "simapro", label: "Unit process"}`
- [ ] pyvolca update: add the `NativeActivityType` dataclass in a follow-up release

## Out of scope (follow-up PRs)

- Server-side `activity_type` filter parameter on `search_activities` (now possible since the field exists)
- Opt-in TOML `[derivations]` block for structural inferences (e.g. ILCD treatment from `ReferenceInput`)
- Removal of the existing name-prefix `attachMarketHintByName` once clients consume `native_type.code`
- Agribalyse market/production distinction — not in the SimaPro CSV source; needs upstream restoration via MeansInOut, outside this engine