### PR TITLE
refactor(solver): dedup factorization caching and cross-DB dep helpers

### DIFF
--- a/src/Matrix.hs
+++ b/src/Matrix.hs
@@ -33,6 +33,8 @@ Performance characteristics:
 module Matrix (
     Vector,
     Inventory,
+    SupplierDemands,
+    DepDemands,
     computeScalingVector,
     applyBiosphereMatrix,
     computeInventoryMatrix,
@@ -94,6 +96,13 @@ type Vector = U.Vector Double
 
 -- | Final inventory vector mapping biosphere flow UUIDs to quantities.
 type Inventory = M.Map UUID Double
+
+-- | Demand a consumer DB places on one supplier @(activityUUID, productUUID)@:
+-- the amount plus the consumer's exchange unit (for cross-DB unit conversion).
+type SupplierDemands = M.Map (UUID, UUID) (Double, Text)
+
+-- | Per-dependency-DB supplier demands, keyed by source database name.
+type DepDemands = M.Map Text SupplierDemands
 
 {- | Per-database coalescing solver. A single worker thread owns the MUMPS
 handle and drains a queue of solve requests, batching whatever has piled up
@@ -727,7 +736,7 @@ before accumulating.
 accumulateDepDemands ::
     Database ->
     Vector ->
-    M.Map Text (M.Map (UUID, UUID) (Double, Text))
+    DepDemands
 accumulateDepDemands db = accumulateDepDemandsWith db []
 
 {- | Same as 'accumulateDepDemands' but folds over an additional list of
@@ -743,7 +752,7 @@ accumulateDepDemandsWith ::
     Database ->
     [CrossDBLink] ->
     Vector ->
-    M.Map Text (M.Map (UUID, UUID) (Double, Text))
+    DepDemands
 accumulateDepDemandsWith db extraLinks scalingVec =
     foldr step M.empty (dbCrossDBLinks db ++ extraLinks)
   where
@@ -818,7 +827,7 @@ depDemandsToVector ::
     -- | dep DB name, for error messages
     Text ->
     Database ->
-    M.Map (UUID, UUID) (Double, Text) ->
+    SupplierDemands ->
     Either Text Vector
 depDemandsToVector unitConfig depDbName depDb demands = do
     converted <- traverse convertEntry (M.toList demands)

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -30,7 +30,7 @@ import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import Database (applyStructuredFilters, findActivitiesByFields, findFlowsBySynonym)
-import Matrix (Inventory, accumulateDepDemandsWith, activityNormalizationFactor, applyBiosphereMatrix, applySparseMatrix, buildDemandVectorFromIndex, computeInventoryMatrix, depDemandsToVector, perturbA, perturbABatch, toList)
+import Matrix (DepDemands, Inventory, accumulateDepDemandsWith, activityNormalizationFactor, applyBiosphereMatrix, applySparseMatrix, buildDemandVectorFromIndex, computeInventoryMatrix, depDemandsToVector, perturbA, perturbABatch, toList)
 import qualified Matrix.Export as MatrixExport
 import Plugin.Types (Severity (..), ValidateContext (..), ValidateHandle (..), ValidationIssue (..), ValidationPhase (..))
 import qualified Progress
@@ -2277,7 +2277,7 @@ resolveDepWithSubs ::
     SharedSolver.DepSolverLookup ->
     -- | ROOT DB's name (default for bare consumer/from/to refs)
     RootDb ->
-    [M.Map Text (M.Map (UUID, UUID) (Double, Text))] ->
+    [DepDemands] ->
     [Substitution] ->
     Int ->
     Int ->
@@ -2291,13 +2291,11 @@ resolveDepWithSubs unitCfg depLookup rootDb perRootDepDemands allSubs depth k de
             -- contributes 'Nothing' at every root; dropped before merge.
             pure (Right (replicate k Nothing))
         Just (depDb, depSolver) ->
-            let demandsPerRoot = map (M.findWithDefault M.empty depDbName) perRootDepDemands
-                depVecsE = traverse (depDemandsToVector unitCfg depDbName depDb) demandsPerRoot
-             in case depVecsE of
-                    Left err -> pure (Left (MatrixError err))
-                    Right depDemandVecs -> do
-                        sols <- goWithSubsAndDeps unitCfg depLookup depDb (ThisDb depDbName) rootDb depSolver depDemandVecs allSubs (depth + 1)
-                        pure $ fmap (map Just) sols
+            case SharedSolver.prepareDepDemandVecs unitCfg depDbName depDb perRootDepDemands of
+                Left err -> pure (Left (MatrixError err))
+                Right depDemandVecs -> do
+                    sols <- goWithSubsAndDeps unitCfg depLookup depDb (ThisDb depDbName) rootDb depSolver depDemandVecs allSubs (depth + 1)
+                    pure $ fmap (map Just) sols
 
 {- | Cross-DB substitution resolver (root-only path, used by supply-chain).
 

--- a/src/SharedSolver.hs
+++ b/src/SharedSolver.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 {- |
@@ -33,13 +34,14 @@ module SharedSolver (
     computeInventoryMatrixBatchWithDepsCached,
     goWithDepsFromScalings,
     mergeSolutions,
+    prepareDepDemandVecs,
     crossDBProcessContributions,
 ) where
 
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Concurrent.MVar (MVar, modifyMVar, modifyMVar_, newMVar, readMVar, withMVar)
-import Control.Exception (SomeException, catch)
-import Data.List (transpose)
+import Control.Exception (SomeException, try)
+import Data.List (foldl', transpose)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
@@ -47,6 +49,7 @@ import Data.Maybe (catMaybes)
 import qualified Data.Set as S
 import Data.Text (Text)
 import Matrix (
+    DepDemands,
     Inventory,
     Vector,
     accumulateDepDemands,
@@ -89,40 +92,36 @@ createSharedSolver dbName techTriples activityCount = do
     factVar <- newMVar Nothing
     return $ SharedSolver lock factVar techTriples activityCount dbName
 
+{- | Compute the factorization and cache it. Assumes 'solverLock' is held and
+the cache is empty (i.e. only called on a miss). Shared by the first-solve
+path and 'ensureFactorization'.
+-}
+computeAndStoreFactorization :: SharedSolver -> IO MatrixFactorization
+computeAndStoreFactorization solver = do
+    reportProgress Info $ "Factorizing '" ++ show (solverDbName solver) ++ "' on first use"
+    fact <-
+        precomputeMatrixFactorization
+            (solverDbName solver)
+            (solverTechTriples solver)
+            (solverActivityCount solver)
+    modifyMVar_ (solverFactorizationVar solver) (const (pure (Just fact)))
+    pure fact
+
 -- | Solve using shared solver. On first call, triggers lazy factorization.
 solveWithSharedSolver :: SharedSolver -> Vector -> IO Vector
-solveWithSharedSolver solver demandVector = do
-    withMVar (solverLock solver) $ \_ -> do
-        maybeFact <- readMVar (solverFactorizationVar solver)
-        case maybeFact of
-            Just factorization -> do
+solveWithSharedSolver solver demandVector =
+    withMVar (solverLock solver) $ \_ ->
+        readMVar (solverFactorizationVar solver) >>= \case
+            Just fact -> do
                 reportProgress Solver "Using cached factorization for sub-second solve"
-                solveSparseLinearSystemWithFactorization factorization demandVector
-            Nothing -> do
-                -- First solve: factorize, cache, then solve
-                reportProgress Info $ "First solve for '" ++ show (solverDbName solver) ++ "' — computing factorization..."
-                factResult <-
-                    catch
-                        ( do
-                            factorization <-
-                                precomputeMatrixFactorization
-                                    (solverDbName solver)
-                                    (solverTechTriples solver)
-                                    (solverActivityCount solver)
-                            -- Store for subsequent solves (replace the MVar contents)
-                            _ <- modifyMVar (solverFactorizationVar solver) $ \_ -> return (Just factorization, ())
-                            reportProgress Info "Factorization complete — solving"
-                            result <- solveSparseLinearSystemWithFactorization factorization demandVector
-                            return (Just result)
-                        )
-                        ( \e -> do
-                            reportProgress Solver $ "Factorization failed: " ++ show (e :: SomeException) ++ " — using fallback solver"
-                            return Nothing
-                        )
-                case factResult of
-                    Just result -> return result
-                    Nothing ->
-                        solveSparseLinearSystem (solverTechTriples solver) (solverActivityCount solver) demandVector
+                solveSparseLinearSystemWithFactorization fact demandVector
+            Nothing ->
+                try (computeAndStoreFactorization solver >>= flip solveSparseLinearSystemWithFactorization demandVector)
+                    >>= either fallback pure
+  where
+    fallback e = do
+        reportProgress Solver $ "Factorization failed: " ++ show (e :: SomeException) ++ " — using fallback solver"
+        solveSparseLinearSystem (solverTechTriples solver) (solverActivityCount solver) demandVector
 
 -- | Read the cached factorization without solving. Returns Nothing until the first solve.
 getFactorization :: SharedSolver -> IO (Maybe MatrixFactorization)
@@ -132,19 +131,10 @@ getFactorization solver = readMVar (solverFactorizationVar solver)
 Safe to call from multiple threads: the solverLock serializes first-time factorization.
 -}
 ensureFactorization :: SharedSolver -> IO MatrixFactorization
-ensureFactorization solver = withMVar (solverLock solver) $ \_ -> do
-    maybeFact <- readMVar (solverFactorizationVar solver)
-    case maybeFact of
+ensureFactorization solver = withMVar (solverLock solver) $ \_ ->
+    readMVar (solverFactorizationVar solver) >>= \case
         Just fact -> pure fact
-        Nothing -> do
-            reportProgress Info $ "Factorizing '" ++ show (solverDbName solver) ++ "' on first use"
-            fact <-
-                precomputeMatrixFactorization
-                    (solverDbName solver)
-                    (solverTechTriples solver)
-                    (solverActivityCount solver)
-            modifyMVar_ (solverFactorizationVar solver) $ \_ -> pure (Just fact)
-            pure fact
+        Nothing -> computeAndStoreFactorization solver
 
 {- | Solve with multiple RHS vectors in one MUMPS call, using the cached factorization.
 Forces factorization on first call. Subsequent calls reuse the cached LU.
@@ -203,6 +193,16 @@ data CrossDBSolution = CrossDBSolution
     { csInventory :: !Inventory
     , csScalings :: !(NonEmpty (Text, Database, Vector))
     }
+
+{- | Combine two cross-DB solutions: sum their inventories and concatenate
+their visited-DB scalings. Associative; folding from a base preserves the
+base-first, deps-in-order BFS layout 'csScalings' documents.
+-}
+instance Semigroup CrossDBSolution where
+    a <> b =
+        CrossDBSolution
+            (M.unionWith (+) (csInventory a) (csInventory b))
+            (csScalings a <> csScalings b)
 
 {- |
 Batch inventory with cross-DB back-substitution. Multi-RHS is preserved at
@@ -320,7 +320,7 @@ goWithDepsFromScalings unitConfig depLookup db dbName extraLinks scalings depth 
         then pure (Right baseSolutions)
         else do
             let perRootDepDemands = map (accumulateDepDemandsWith db extraLinks) scalings
-                allDepDbs = S.toList $ S.unions $ map M.keysSet perRootDepDemands
+                allDepDbs = depDbsOf perRootDepDemands
             if null allDepDbs
                 then pure (Right baseSolutions)
                 else do
@@ -352,20 +352,25 @@ Exported so the substitution-aware solver ('Service.goWithSubsAndDeps')
 reuses the same merge shape as the plain cross-DB solver.
 -}
 mergeSolutions :: CrossDBSolution -> [CrossDBSolution] -> CrossDBSolution
-mergeSolutions base depSols =
-    CrossDBSolution
-        { csInventory =
-            foldr (M.unionWith (+)) (csInventory base) (map csInventory depSols)
-        , csScalings =
-            NE.appendList
-                (csScalings base)
-                (concatMap (NE.toList . csScalings) depSols)
-        }
+mergeSolutions = foldl' (<>)
+
+-- | Every dependency DB referenced across a level's per-root demand maps.
+depDbsOf :: [DepDemands] -> [Text]
+depDbsOf = S.toList . S.unions . map M.keysSet
+
+{- | Turn a level's per-root demand maps into the dep DB's per-root demand
+vectors, performing unit conversion. Picks out @depDbName@'s share of each
+root's demands. Shared by every dep resolver (inventory, contributions, and
+the substitution-aware path in 'Service').
+-}
+prepareDepDemandVecs :: UnitConfig -> Text -> Database -> [DepDemands] -> Either Text [Vector]
+prepareDepDemandVecs unitConfig depDbName depDb =
+    traverse (depDemandsToVector unitConfig depDbName depDb . M.findWithDefault M.empty depDbName)
 
 resolveDep ::
     UnitConfig ->
     DepSolverLookup ->
-    [M.Map Text (M.Map (UUID, UUID) (Double, Text))] ->
+    [DepDemands] ->
     -- | current depth (for recursion)
     Int ->
     -- | K (so absent-dep returns the right number of 'Nothing' padding)
@@ -383,13 +388,11 @@ resolveDep unitConfig depLookup perRootDepDemands depth k depDbName = do
             -- materialising one (which the NonEmpty type forbids).
             pure (Right (replicate k Nothing))
         Just (depDb, depSolver) ->
-            let demandsPerRoot = map (M.findWithDefault M.empty depDbName) perRootDepDemands
-                depVecsE = traverse (depDemandsToVector unitConfig depDbName depDb) demandsPerRoot
-             in case depVecsE of
-                    Left err -> pure (Left err)
-                    Right depDemandVecs -> do
-                        sols <- goWithDeps unitConfig depLookup depDb depDbName depSolver depDemandVecs (depth + 1)
-                        pure $ fmap (map Just) sols
+            case prepareDepDemandVecs unitConfig depDbName depDb perRootDepDemands of
+                Left err -> pure (Left err)
+                Right depDemandVecs -> do
+                    sols <- goWithDeps unitConfig depLookup depDb depDbName depSolver depDemandVecs (depth + 1)
+                    pure $ fmap (map Just) sols
 
 {- | Cross-DB per-activity LCIA contributions. Walks the same dep graph as
 'goWithDeps' but attributes contributions per @(dbName, localPid)@ instead
@@ -442,7 +445,7 @@ crossDBProcessContributions unitConfig unitDB flowDB depLookup rootDb rootName r
             then pure (Right localTagged)
             else do
                 let perRootDepDemands = map (accumulateDepDemands db) scalings
-                    allDepDbs = S.toList $ S.unions $ map M.keysSet perRootDepDemands
+                    allDepDbs = depDbsOf perRootDepDemands
                 if null allDepDbs
                     then pure (Right localTagged)
                     else do
@@ -453,7 +456,7 @@ crossDBProcessContributions unitConfig unitDB flowDB depLookup rootDb rootName r
                                 Right $ foldr (M.unionWith (+)) localTagged depMaps
 
     resolveDepContribs ::
-        [M.Map Text (M.Map (UUID, UUID) (Double, Text))] ->
+        [DepDemands] ->
         Int ->
         Text ->
         IO (Either Text (M.Map (Text, ProcessId) Double))
@@ -462,8 +465,6 @@ crossDBProcessContributions unitConfig unitDB flowDB depLookup rootDb rootName r
         case depM of
             Nothing -> pure (Right M.empty) -- dep DB not loaded; root-level gate should have caught this
             Just (depDb, depSolver) ->
-                let demandsPerRoot = map (M.findWithDefault M.empty depDbName) perRootDepDemands
-                    depVecsE = traverse (depDemandsToVector unitConfig depDbName depDb) demandsPerRoot
-                 in case depVecsE of
-                        Left err -> pure (Left err)
-                        Right depDemandVecs -> go depDb depDbName depSolver depDemandVecs (depth + 1)
+                case prepareDepDemandVecs unitConfig depDbName depDb perRootDepDemands of
+                    Left err -> pure (Left err)
+                    Right depDemandVecs -> go depDb depDbName depSolver depDemandVecs (depth + 1)

--- a/src/SharedSolver.hs
+++ b/src/SharedSolver.hs
@@ -39,9 +39,9 @@ module SharedSolver (
 ) where
 
 import Control.Concurrent.Async (mapConcurrently)
-import Control.Concurrent.MVar (MVar, modifyMVar, modifyMVar_, newMVar, readMVar, withMVar)
+import Control.Concurrent.MVar (MVar, modifyMVar_, newMVar, readMVar, withMVar)
 import Control.Exception (SomeException, try)
-import Data.List (foldl', transpose)
+import Data.List (transpose)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M


### PR DESCRIPTION
## Summary

A readability pass over `SharedSolver.hs` that removes duplicated logic without changing behaviour.

- **Factorization caching deduped.** The lazy MUMPS factorization was computed-and-cached in two near-identical blocks (`solveWithSharedSolver`, `ensureFactorization`). Extracted `computeAndStoreFactorization` so the precompute + store lives once; the dense-solver fallback stays scoped to the first-solve (cache-miss) path exactly as before.
- **Shared dep-demand helpers.** The per-root dep-demand → demand-vector conversion was copied byte-for-byte in three resolvers (`resolveDep`, `resolveDepContribs`, and `Service.resolveDepWithSubs`). Extracted `prepareDepDemandVecs`, plus `depDbsOf` for the "DBs referenced at this level" set.
- **`Semigroup CrossDBSolution`.** `mergeSolutions` is now `foldl' (<>)` — same summed inventory and base-first / BFS-ordered scalings as the hand-written version.
- **Named map types.** Introduced `SupplierDemands` / `DepDemands` aliases in `Matrix` (where the type is produced) and used them across the affected signatures, replacing the verbose nested-`Map` spelling.

We deliberately stopped short of unifying the two dependency-graph walks (inventory vs. contributions) behind a generic interpreter: it barely reduces line count, would rely on a K=1 invariant the types don't enforce, and can't absorb the third walk in `Service.hs`.

## Test plan

- [x] `./gen-version.sh && cabal build` — clean (only two pre-existing, unrelated `API/MCP.hs` warnings).
- [x] `cabal run lca-tests` — 1107 examples, 0 failures, 1 pending.
- [x] Rebased onto current `advanced_haskell`; rebuilt and re-ran the full suite green on the rebased tree.