### PR TITLE
refactor(ecospold): extract shared cut-off strategy into EcoSpold.Cutoff

### DIFF
--- a/src/EcoSpold/Cutoff.hs
+++ b/src/EcoSpold/Cutoff.hs
@@ -68,7 +68,7 @@ isProductionExchange TechnosphereExchange{techRole = Coproduct} = True
 isProductionExchange TechnosphereExchange{techRole = Input} = False
 isProductionExchange TechnosphereExchange{techRole = ReferenceInput} = False
 isProductionExchange BiosphereExchange{} = False
-isProductionExchange WasteExchange{} = False
+isProductionExchange WasteExchange{} = False -- waste outputs aren't "production" in the SimaPro sense
 
 -- | Update reference product flag for the specified exchange
 updateReferenceProduct :: Exchange -> Exchange -> Exchange
@@ -80,7 +80,7 @@ updateReferenceProduct target current
 markAsReference :: Exchange -> Exchange
 markAsReference ex@TechnosphereExchange{} = ex{techRole = ReferenceProduct}
 markAsReference ex@BiosphereExchange{} = ex
-markAsReference ex@WasteExchange{} = ex
+markAsReference ex@WasteExchange{} = ex -- waste flows can't be promoted to reference product
 
 -- | Demote a reference role back to non-reference (preserving input/output direction)
 unmarkAsReference :: Exchange -> Exchange

--- a/src/EcoSpold/Cutoff.hs
+++ b/src/EcoSpold/Cutoff.hs
@@ -1,0 +1,94 @@
+{- | Cut-off allocation strategy shared by the EcoSpold1 and EcoSpold2 parsers.
+
+Post-processing applied once per parsed activity (outside the SAX fold):
+reduce a multi-output dataset to a single reference product so the downstream
+engine sees a single-output process.
+-}
+module EcoSpold.Cutoff (
+    applyCutoffStrategy,
+    hasReferenceProduct,
+    removeZeroAmountCoproducts,
+    assignSingleProductAsReference,
+    isProductionExchange,
+) where
+
+import qualified Data.Text as T
+import Types
+
+{- | Apply cut-off strategy
+1. Remove zero-amount production exchanges (co-products)
+2. Assign single non-zero product as reference product
+3. Ensure single-output process structure
+4. VALIDATION: Fail if no reference product can be established
+-}
+applyCutoffStrategy :: Activity -> Either String Activity
+applyCutoffStrategy activity =
+    let filteredExchanges = removeZeroAmountCoproducts (exchanges activity)
+        updatedActivity = activity{exchanges = filteredExchanges}
+        finalActivity =
+            if hasReferenceProduct updatedActivity
+                then updatedActivity
+                else assignSingleProductAsReference updatedActivity
+     in if hasReferenceProduct finalActivity
+            then Right finalActivity
+            else Left $ "Activity has no reference product: " ++ T.unpack (activityName activity)
+
+-- | Check if activity has any reference product
+hasReferenceProduct :: Activity -> Bool
+hasReferenceProduct activity = any exchangeIsReference (exchanges activity)
+
+-- | Remove production exchanges with zero amounts
+removeZeroAmountCoproducts :: [Exchange] -> [Exchange]
+removeZeroAmountCoproducts = filter keepExchange
+  where
+    keepExchange TechnosphereExchange{techRole = ReferenceProduct} = True
+    keepExchange TechnosphereExchange{techRole = ReferenceInput} = True
+    keepExchange TechnosphereExchange{techRole = Input} = True
+    keepExchange TechnosphereExchange{techRole = Coproduct, techAmount = amount} = amount /= 0.0
+    keepExchange BiosphereExchange{} = True
+    keepExchange WasteExchange{} = True
+
+-- | Assign single product as reference product
+assignSingleProductAsReference :: Activity -> Activity
+assignSingleProductAsReference activity =
+    let productionExchanges = [ex | ex <- exchanges activity, isProductionExchange ex]
+        nonZeroProduction = [ex | ex <- productionExchanges, exchangeAmount ex /= 0.0]
+     in case nonZeroProduction of
+            [singleProduct] ->
+                -- Update the single product to be reference product
+                let updatedExchanges = map (updateReferenceProduct singleProduct) (exchanges activity)
+                 in activity{exchanges = updatedExchanges}
+            [] -> activity -- No production exchanges, leave as-is
+            _ -> activity -- Multiple production exchanges, leave as-is (shouldn't happen after cutoff)
+
+-- | Check if exchange is production exchange (technosphere output)
+isProductionExchange :: Exchange -> Bool
+isProductionExchange TechnosphereExchange{techRole = ReferenceProduct} = True
+isProductionExchange TechnosphereExchange{techRole = Coproduct} = True
+isProductionExchange TechnosphereExchange{techRole = Input} = False
+isProductionExchange TechnosphereExchange{techRole = ReferenceInput} = False
+isProductionExchange BiosphereExchange{} = False
+isProductionExchange WasteExchange{} = False
+
+-- | Update reference product flag for the specified exchange
+updateReferenceProduct :: Exchange -> Exchange -> Exchange
+updateReferenceProduct target current
+    | exchangeFlowId target == exchangeFlowId current = markAsReference current
+    | otherwise = unmarkAsReference current
+
+-- | Promote a production exchange to reference product
+markAsReference :: Exchange -> Exchange
+markAsReference ex@TechnosphereExchange{} = ex{techRole = ReferenceProduct}
+markAsReference ex@BiosphereExchange{} = ex
+markAsReference ex@WasteExchange{} = ex
+
+-- | Demote a reference role back to non-reference (preserving input/output direction)
+unmarkAsReference :: Exchange -> Exchange
+unmarkAsReference ex@TechnosphereExchange{techRole = role} = ex{techRole = demote role}
+  where
+    demote ReferenceProduct = Coproduct
+    demote ReferenceInput = Input
+    demote Coproduct = Coproduct
+    demote Input = Input
+unmarkAsReference ex@BiosphereExchange{} = ex
+unmarkAsReference ex@WasteExchange{} = ex

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -17,11 +17,6 @@ module EcoSpold.Parser1 (
     -- * Pure helpers (exported for testing)
     generateFlowUUID,
     generateUnitUUID,
-    applyCutoffStrategy,
-    hasReferenceProduct,
-    removeZeroAmountCoproducts,
-    assignSingleProductAsReference,
-    isProductionExchange,
 ) where
 
 import Control.Monad (forM_)
@@ -36,6 +31,7 @@ import qualified Data.Text.Encoding as TE
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V5 as UUID5
 import EcoSpold.Common (bsToDouble, bsToInt, bsToText, isElement, nonEmptyText)
+import EcoSpold.Cutoff (applyCutoffStrategy)
 import Progress (ProgressLevel (..), reportProgress)
 import Types
 import qualified Xeno.SAX as X
@@ -481,77 +477,6 @@ streamParseActivityAndFlowsFromFile1 :: FilePath -> IO (Either String (Activity,
 streamParseActivityAndFlowsFromFile1 path = do
     !xmlContent <- BS.readFile path
     return (parseWithXeno xmlContent)
-
--- | Apply cut-off strategy (same logic as EcoSpold2)
-applyCutoffStrategy :: Activity -> Either String Activity
-applyCutoffStrategy activity =
-    let filteredExchanges = removeZeroAmountCoproducts (exchanges activity)
-        updatedActivity = activity{exchanges = filteredExchanges}
-        finalActivity =
-            if hasReferenceProduct updatedActivity
-                then updatedActivity
-                else assignSingleProductAsReference updatedActivity
-     in if hasReferenceProduct finalActivity
-            then Right finalActivity
-            else Left $ "Activity has no reference product: " ++ T.unpack (activityName activity)
-
--- | Check if activity has any reference product
-hasReferenceProduct :: Activity -> Bool
-hasReferenceProduct act = any exchangeIsReference (exchanges act)
-
--- | Remove production exchanges with zero amounts
-removeZeroAmountCoproducts :: [Exchange] -> [Exchange]
-removeZeroAmountCoproducts = filter keepExchange
-  where
-    keepExchange TechnosphereExchange{techRole = ReferenceProduct} = True
-    keepExchange TechnosphereExchange{techRole = ReferenceInput} = True
-    keepExchange TechnosphereExchange{techRole = Input} = True
-    keepExchange TechnosphereExchange{techRole = Coproduct, techAmount = amount} = amount /= 0.0
-    keepExchange BiosphereExchange{} = True
-    keepExchange WasteExchange{} = True
-
--- | Assign single product as reference product
-assignSingleProductAsReference :: Activity -> Activity
-assignSingleProductAsReference act =
-    let productionExchanges = [ex | ex <- exchanges act, isProductionExchange ex]
-        nonZeroProduction = [ex | ex <- productionExchanges, exchangeAmount ex /= 0.0]
-     in case nonZeroProduction of
-            [singleProduct] ->
-                let updatedExchanges = map (updateReferenceProduct singleProduct) (exchanges act)
-                 in act{exchanges = updatedExchanges}
-            _ -> act
-
--- | Check if exchange is production exchange (technosphere output)
-isProductionExchange :: Exchange -> Bool
-isProductionExchange TechnosphereExchange{techRole = ReferenceProduct} = True
-isProductionExchange TechnosphereExchange{techRole = Coproduct} = True
-isProductionExchange TechnosphereExchange{techRole = Input} = False
-isProductionExchange TechnosphereExchange{techRole = ReferenceInput} = False
-isProductionExchange BiosphereExchange{} = False
-isProductionExchange WasteExchange{} = False -- waste outputs aren't "production" in the SimaPro sense
-
--- | Update reference product flag
-updateReferenceProduct :: Exchange -> Exchange -> Exchange
-updateReferenceProduct target current
-    | exchangeFlowId target == exchangeFlowId current = markAsReference current
-    | otherwise = unmarkAsReference current
-
--- | Promote a production exchange to reference product
-markAsReference :: Exchange -> Exchange
-markAsReference ex@TechnosphereExchange{} = ex{techRole = ReferenceProduct}
-markAsReference ex@BiosphereExchange{} = ex
-markAsReference ex@WasteExchange{} = ex -- waste flows can't be promoted to reference product
-
--- | Demote a reference role back to non-reference (preserving input/output direction)
-unmarkAsReference :: Exchange -> Exchange
-unmarkAsReference ex@TechnosphereExchange{techRole = role} = ex{techRole = demote role}
-  where
-    demote ReferenceProduct = Coproduct
-    demote ReferenceInput = Input
-    demote Coproduct = Coproduct
-    demote Input = Input
-unmarkAsReference ex@BiosphereExchange{} = ex
-unmarkAsReference ex@WasteExchange{} = ex
 
 -- ============================================================================
 -- Multi-dataset file support

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -15,6 +15,7 @@ import qualified Data.Text.Encoding as TE
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V5 as UUID5
 import EcoSpold.Common (bsToDouble, bsToInt, bsToIntMaybe, bsToText, isElement)
+import EcoSpold.Cutoff (applyCutoffStrategy)
 import Progress (ProgressLevel (..), reportProgress)
 import System.FilePath (takeBaseName)
 import Types
@@ -675,81 +676,3 @@ streamParseActivityAndFlowsFromFile path = do
             Right (result, warnings) -> do
                 mapM_ (reportProgress Warning) warnings
                 return $ Right result
-
-{- | Apply cut-off strategy
-1. Remove zero-amount production exchanges (co-products)
-2. Assign single non-zero product as reference product
-3. Ensure single-output process structure
-4. VALIDATION: Fail if no reference product can be established
--}
-applyCutoffStrategy :: Activity -> Either String Activity
-applyCutoffStrategy activity =
-    let filteredExchanges = removeZeroAmountCoproducts (exchanges activity)
-        updatedActivity = activity{exchanges = filteredExchanges}
-        finalActivity =
-            if hasReferenceProduct updatedActivity
-                then updatedActivity
-                else assignSingleProductAsReference updatedActivity
-     in if hasReferenceProduct finalActivity
-            then Right finalActivity
-            else Left $ "Activity has no reference product: " ++ T.unpack (activityName activity)
-
--- | Check if activity has any reference product
-hasReferenceProduct :: Activity -> Bool
-hasReferenceProduct activity = any exchangeIsReference (exchanges activity)
-
--- | Remove production exchanges with zero amounts
-removeZeroAmountCoproducts :: [Exchange] -> [Exchange]
-removeZeroAmountCoproducts = filter keepExchange
-  where
-    keepExchange TechnosphereExchange{techRole = ReferenceProduct} = True
-    keepExchange TechnosphereExchange{techRole = ReferenceInput} = True
-    keepExchange TechnosphereExchange{techRole = Input} = True
-    keepExchange TechnosphereExchange{techRole = Coproduct, techAmount = amount} = amount /= 0.0
-    keepExchange BiosphereExchange{} = True
-    keepExchange WasteExchange{} = True
-
--- | Assign single product as reference product
-assignSingleProductAsReference :: Activity -> Activity
-assignSingleProductAsReference activity =
-    let productionExchanges = [ex | ex <- exchanges activity, isProductionExchange ex]
-        nonZeroProduction = [ex | ex <- productionExchanges, exchangeAmount ex /= 0.0]
-     in case nonZeroProduction of
-            [singleProduct] ->
-                -- Update the single product to be reference product
-                let updatedExchanges = map (updateReferenceProduct singleProduct) (exchanges activity)
-                 in activity{exchanges = updatedExchanges}
-            [] -> activity -- No production exchanges, leave as-is
-            _ -> activity -- Multiple production exchanges, leave as-is (shouldn't happen after cutoff)
-
--- | Check if exchange is production exchange (technosphere output)
-isProductionExchange :: Exchange -> Bool
-isProductionExchange TechnosphereExchange{techRole = ReferenceProduct} = True
-isProductionExchange TechnosphereExchange{techRole = Coproduct} = True
-isProductionExchange TechnosphereExchange{techRole = Input} = False
-isProductionExchange TechnosphereExchange{techRole = ReferenceInput} = False
-isProductionExchange BiosphereExchange{} = False
-isProductionExchange WasteExchange{} = False
-
--- | Update reference product flag for the specified exchange
-updateReferenceProduct :: Exchange -> Exchange -> Exchange
-updateReferenceProduct target current
-    | exchangeFlowId target == exchangeFlowId current = markAsReference current
-    | otherwise = unmarkAsReference current
-
--- | Promote a production exchange to reference product
-markAsReference :: Exchange -> Exchange
-markAsReference ex@TechnosphereExchange{} = ex{techRole = ReferenceProduct}
-markAsReference ex@BiosphereExchange{} = ex
-markAsReference ex@WasteExchange{} = ex
-
--- | Demote a reference role back to non-reference (preserving input/output direction)
-unmarkAsReference :: Exchange -> Exchange
-unmarkAsReference ex@TechnosphereExchange{techRole = role} = ex{techRole = demote role}
-  where
-    demote ReferenceProduct = Coproduct
-    demote ReferenceInput = Input
-    demote Coproduct = Coproduct
-    demote Input = Input
-unmarkAsReference ex@BiosphereExchange{} = ex
-unmarkAsReference ex@WasteExchange{} = ex

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -7,6 +7,7 @@ import qualified Data.Map.Strict as M
 import Data.UUID (nil)
 import Test.Hspec
 
+import EcoSpold.Cutoff
 import EcoSpold.Parser1
 import Types
 

--- a/volca.cabal
+++ b/volca.cabal
@@ -73,6 +73,7 @@ library
                      , CLI.Client
                      , CLI.Repl
                      , EcoSpold.Common
+                     , EcoSpold.Cutoff
                      , EcoSpold.Parser2
                      , EcoSpold.Parser1
                      , SimaPro.Parser


### PR DESCRIPTION
## What

The cut-off post-processing — reducing a multi-output dataset to a single reference product so the engine sees a single-output process — was duplicated **verbatim** between the EcoSpold1 and EcoSpold2 parsers (~70 lines, the same eight-function chain in each). This moves that block into one shared `EcoSpold.Cutoff` module that both parsers import.

This is the last remaining piece of the EcoSpold refactor series (after the Parser2 split #97 and the Parser1 fold dedup #94), which left the cut-off block still copy-pasted in both files.

## Changes

- **New `src/EcoSpold/Cutoff.hs`** — holds `applyCutoffStrategy`, `hasReferenceProduct`, `removeZeroAmountCoproducts`, `assignSingleProductAsReference`, `isProductionExchange` (exported) plus the internal `updateReferenceProduct` / `markAsReference` / `unmarkAsReference`.
- **`Parser1.hs` / `Parser2.hs`** — delete the duplicated block, `import EcoSpold.Cutoff (applyCutoffStrategy)`. Parser1 drops its "exported for testing" cut-off helpers.
- **`EcoSpold1Spec.hs`** — imports the cut-off helpers from `EcoSpold.Cutoff` instead of the old `EcoSpold.Parser1` re-export.
- **`volca.cabal`** — registers the new library module.

Pure post-fold logic, runs once per activity (not in the SAX loop), so no behaviour or throughput change. Net: ~154 duplicated lines removed across the two parsers, replaced by one ~95-line module.

## Verification

- `cabal build lib:volca` + `exe:volca`: clean (only pre-existing unrelated MCP warnings).
- `cabal test lca-tests`: **1107 examples, 0 failures, 1 pending** — including the EcoSpold1 cut-off-helper tests now resolving against the new module.