### PR TITLE
Load Brightway Excel (.xlsx) inventories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **VoLCA** is a Life Cycle Assessment engine that turns LCA databases into inspectable, queryable answers — fast.
 
-It loads EcoSpold2, EcoSpold1, SimaPro CSV, and ILCD process databases, builds supply chain dependency trees, computes life cycle inventories using sparse matrix algebra, and applies characterization methods for impact assessment. Everything runs in-memory against your own data.
+It loads EcoSpold2, EcoSpold1, SimaPro CSV, ILCD process, and Brightway Excel databases, builds supply chain dependency trees, computes life cycle inventories using sparse matrix algebra, and applies characterization methods for impact assessment. Everything runs in-memory against your own data.
 
 ## What It Does
 
@@ -19,7 +19,7 @@ It loads EcoSpold2, EcoSpold1, SimaPro CSV, and ILCD process databases, builds s
 
 ## Key Features
 
-- **Multiple database formats**: EcoSpold2 (.spold), EcoSpold1 (.xml), SimaPro CSV, ILCD process datasets
+- **Multiple database formats**: EcoSpold2 (.spold), EcoSpold1 (.xml), SimaPro CSV, ILCD process datasets, Brightway Excel (.xlsx)
 - **Archive support**: Load databases directly from .zip, .7z, .gz, or .xz archives — no manual extraction
 - **Cross-database linking**: Resolve supplier references across databases, with configurable dependencies and topological load ordering
 - **Cross-DB what-if substitutions**: Swap an upstream activity at any depth — including suppliers in dependency databases — and recompute inventory and impacts through one endpoint
@@ -555,7 +555,7 @@ docker run -p 8080:8080 -v /path/to/data:/data volca
 cabal test --test-show-details=streaming
 ```
 
-Tests cover matrix construction (sign convention), inventory calculation (golden values), parsers (EcoSpold1/2, ILCD, SimaPro, classification fields), and matrix export format compliance.
+Tests cover matrix construction (sign convention), inventory calculation (golden values), parsers (EcoSpold1/2, ILCD, SimaPro, Brightway Excel, classification fields), and matrix export format compliance.
 
 ---
 

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -305,6 +305,7 @@ formatToText EcoSpold1 = "ecospold1"
 formatToText EcoSpold2 = "ecospold2"
 formatToText ILCDProcess = "ilcd"
 formatToText OpenLcaJsonLd = "openlca-jsonld"
+formatToText BrightwayExcel = "brightway-excel"
 formatToText UnknownFormat = "unknown"
 
 --------------------------------------------------------------------------------

--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -1,0 +1,621 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Parser for the Brightway Excel (@.xlsx@) inventory interchange format.
+
+The layout is the one produced and consumed by Brightway's @bw2io@ @ExcelImporter@:
+a single (or multiple) worksheet holding a linear stream of blocks separated by
+blank rows —
+
+@
+Database              <database name>
+Activity              <activity name>
+production amount     1
+reference product     <product>
+location              GLO
+unit                  megajoule
+Exchanges
+name   amount   reference product   location   unit   categories   type           database
+...    1        <product>           GLO        MJ                  production     <db>
+...    0.5      <ecoinvent product> RoW        MJ                  technosphere   ecoinvent-...
+Water  1.6e-4                       GLO        m3     air          biosphere      ecoinvent-...
+@
+
+Section keywords live in column A (case-insensitive); a blank row terminates a
+section; an @Exchanges@ row introduces a labelled table whose first row is the
+column headers. Columns are addressed by header label, not position, because the
+column order varies between files.
+
+The reader is deliberately small: @.xlsx@ is a zip of XML parts, unzipped with
+@zip-archive@ and parsed with the @xeno@ DOM already used elsewhere in the
+engine. openpyxl (Brightway's writer) emits inline strings (@t="inlineStr"@),
+so there is usually no shared-string table; we still resolve one if present.
+
+Domain construction reuses the SimaPro helpers (UUID generation, compartment
+normalization, unit canonicalization) so Brightway activities, flows and units
+hash identically to the other importers and link through the same name-based
+cross-database pass.
+-}
+module BrightwayExcel.Parser (
+    parseBrightwayExcel,
+
+    -- * Exposed for testing
+    CellValue (..),
+    Row,
+    readSheets,
+    parseSheetXml,
+    sheetToActivities,
+    splitCategories,
+) where
+
+import Codec.Archive.Zip (Archive, findEntryByPath, fromEntry, toArchiveOrFail)
+import Control.Applicative ((<|>))
+import Data.Bifunctor (first)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy as BL
+import Data.Char (chr, isAsciiUpper, ord, toUpper)
+import Data.List (find, findIndex)
+import qualified Data.Map.Strict as M
+import Data.Maybe (catMaybes, fromMaybe, isJust, listToMaybe, mapMaybe, maybeToList)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified Data.Text.Encoding.Error as TEE
+import qualified Data.Text.Read as TR
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import Progress (ProgressLevel (..), reportProgress)
+import SimaPro.Parser (
+    generateFlowUUID,
+    generateUnitUUID,
+    normalizeSimaProCompartment,
+ )
+import Types
+import qualified UnitConversion as UC
+import Xeno.DOM (Content (..), Node)
+import qualified Xeno.DOM as X
+
+-- ---------------------------------------------------------------------------
+-- Cell / row model
+-- ---------------------------------------------------------------------------
+
+-- | A spreadsheet cell value, already typed at read time.
+data CellValue
+    = CellText !Text
+    | CellNumber !Double
+    deriving (Eq, Show)
+
+{- | A row is a sparse map from 0-based column index to value. Empty cells are
+absent, so an empty 'M.Map' is an empty row (Brightway's @is_empty_line@).
+-}
+type Row = M.Map Int CellValue
+
+cellText :: CellValue -> Maybe Text
+cellText = \case
+    CellText t -> let s = T.strip t in if T.null s then Nothing else Just s
+    CellNumber _ -> Nothing
+
+cellNum :: CellValue -> Maybe Double
+cellNum = \case
+    CellNumber d -> Just d
+    CellText t -> case TR.double (T.strip t) of
+        Right (d, rest) | T.null (T.strip rest) -> Just d
+        _ -> Nothing
+
+textAt :: Int -> Row -> Maybe Text
+textAt i row = cellText =<< M.lookup i row
+
+-- ---------------------------------------------------------------------------
+-- Top-level entry point
+-- ---------------------------------------------------------------------------
+
+{- | Parse a Brightway Excel workbook into the same 5-tuple the other importers
+return: activities plus the deduplicated technosphere / biosphere / waste flow
+and unit databases. Cross-database links are resolved later by the shared
+name-based pass in "Database.Loader" / "Database.Manager".
+-}
+parseBrightwayExcel ::
+    UC.UnitConfig ->
+    FilePath ->
+    IO (Either Text ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB))
+parseBrightwayExcel cfg path = do
+    raw <- BL.readFile path
+    case readSheets raw of
+        Left err -> pure (Left ("Brightway Excel: " <> err))
+        Right sheets -> do
+            let results = concatMap (sheetToActivities cfg) (filter validFirstCell sheets)
+                activities = [a | (a, _, _, _, _) <- results]
+                techFlows = concat [fs | (_, fs, _, _, _) <- results]
+                bioFlows = concat [fs | (_, _, fs, _, _) <- results]
+                units = concat [us | (_, _, _, us, _) <- results]
+                warnings = concat [ws | (_, _, _, _, ws) <- results]
+            mapM_ (reportProgress Warning . T.unpack) warnings
+            pure $
+                Right
+                    ( activities
+                    , M.fromList [(tfId f, f) | f <- techFlows]
+                    , M.fromList [(bfId f, f) | f <- bioFlows]
+                    , M.empty
+                    , M.fromList [(unitId u, u) | u <- units]
+                    )
+
+{- | A worksheet is imported only when its first cell (A1) is a non-empty string
+that is not the sentinel @"skip"@ (matches @bw2io@'s @valid_first_cell@).
+-}
+validFirstCell :: [Row] -> Bool
+validFirstCell rows = case listToMaybe rows >>= textAt 0 of
+    Just t -> T.toLower t /= "skip"
+    Nothing -> False
+
+-- ---------------------------------------------------------------------------
+-- Block grammar (pure)
+-- ---------------------------------------------------------------------------
+
+{- | A parsed activity block: its name, metadata key/value pairs, the exchange
+table header (column index → lowercased label) and the data rows.
+-}
+data RawActivity = RawActivity
+    { raName :: !Text
+    , raMeta :: !(M.Map Text CellValue)
+    , raHeaders :: ![(Int, Text)]
+    , raRows :: ![Row]
+    , raHasParams :: !Bool
+    }
+
+sectionKeyword :: Row -> Maybe Text
+sectionKeyword row = T.toLower . T.strip <$> textAt 0 row
+
+isSectionStart :: Row -> Bool
+isSectionStart row = sectionKeyword row `elem` map Just ["activity", "database", "project parameters"]
+
+isActivityStart :: Row -> Bool
+isActivityStart row = sectionKeyword row == Just "activity" && M.member 1 row
+
+rowKeyIs :: Text -> Row -> Bool
+rowKeyIs kw row = sectionKeyword row == Just kw
+
+{- | Split a sheet into activity blocks: each starts at an @Activity@ row and runs
+up to (not including) the next section start.
+-}
+activityBlocks :: [Row] -> [[Row]]
+activityBlocks = go
+  where
+    go [] = []
+    go (r : rs)
+        | isActivityStart r =
+            let (blk, rest) = break isSectionStart rs
+             in (r : blk) : go rest
+        | otherwise = go rs
+
+{- | Parse one block into a 'RawActivity', dropping blank rows first (Brightway
+strips empty lines within an activity before locating its sub-sections).
+-}
+parseBlock :: [Row] -> Maybe RawActivity
+parseBlock block0 = do
+    let block = filter (not . M.null) block0
+    actRow <- listToMaybe block
+    name <- textAt 1 actRow
+    let excIdx = findIndex (rowKeyIs "exchanges") block
+        parIdx = findIndex (rowKeyIs "parameters") block
+        metaEnd = minimum (length block : catMaybes [excIdx, parIdx])
+        metaRows = take (metaEnd - 1) (drop 1 block)
+        meta =
+            M.fromList
+                [ (T.toLower (T.strip k), v)
+                | row <- metaRows
+                , Just k <- [textAt 0 row]
+                , Just v <- [M.lookup 1 row]
+                ]
+        (headers, dataRows) = case excIdx of
+            Nothing -> ([], [])
+            Just i -> case drop (i + 1) block of
+                (h : rest) -> (rowHeaders h, rest)
+                [] -> ([], [])
+    pure
+        RawActivity
+            { raName = T.strip name
+            , raMeta = meta
+            , raHeaders = headers
+            , raRows = dataRows
+            , raHasParams = isJust parIdx
+            }
+
+-- | Column index → lowercased header label for the non-empty header cells.
+rowHeaders :: Row -> [(Int, Text)]
+rowHeaders row =
+    [ (i, T.toLower lbl)
+    | (i, cv) <- M.toList row
+    , Just lbl <- [cellText cv]
+    ]
+
+-- | Project a data row onto its labelled fields.
+rowFields :: [(Int, Text)] -> Row -> M.Map Text CellValue
+rowFields headers row =
+    M.fromList [(lbl, v) | (i, lbl) <- headers, Just v <- [M.lookup i row]]
+
+-- ---------------------------------------------------------------------------
+-- Domain construction (pure)
+-- ---------------------------------------------------------------------------
+
+-- | The exchange (if any), flows and units produced by one row, plus warnings.
+data RowOut = RowOut
+    { roExch :: !(Maybe Exchange)
+    , roTech :: ![TechnosphereFlow]
+    , roBio :: ![BiosphereFlow]
+    , roUnit :: ![Unit]
+    , roWarn :: ![Text]
+    }
+
+emptyRowOut :: RowOut
+emptyRowOut = RowOut Nothing [] [] [] []
+
+-- | All activities (with their flows/units/warnings) from one worksheet.
+sheetToActivities ::
+    UC.UnitConfig ->
+    [Row] ->
+    [(Activity, [TechnosphereFlow], [BiosphereFlow], [Unit], [Text])]
+sheetToActivities cfg = map (rawToActivity cfg) . mapMaybe parseBlock . activityBlocks
+
+rawToActivity ::
+    UC.UnitConfig ->
+    RawActivity ->
+    (Activity, [TechnosphereFlow], [BiosphereFlow], [Unit], [Text])
+rawToActivity cfg ra =
+    (activity, techFlows, bioFlows, units, warnings)
+  where
+    meta = raMeta ra
+    fieldRows = map (rowFields (raHeaders ra)) (raRows ra)
+    isType t r = (T.toLower <$> fieldText r "type") == Just t
+    prodRows = filter (isType "production") fieldRows
+    otherRows = filter (not . isType "production") fieldRows
+
+    prodOuts = case prodRows of
+        [] -> [productRowOut cfg meta True M.empty | M.member "reference product" meta]
+        (r : rs) -> productRowOut cfg meta True r : map (productRowOut cfg meta False) rs
+    otherOuts = map (exchangeRowOut cfg (raName ra)) otherRows
+    allOuts = prodOuts ++ otherOuts
+
+    exchanges' = mapMaybe roExch allOuts
+    techFlows = concatMap roTech allOuts
+    bioFlows = concatMap roBio allOuts
+    units = concatMap roUnit allOuts
+
+    refExch = find exchangeIsReference exchanges'
+    refUnitName = case refExch of
+        Just ex -> maybe metaUnit unitName (find ((== exchUnitId ex) . unitId) units)
+        Nothing -> metaUnit
+    metaUnit = fromMaybe "" (metaText meta "unit")
+
+    warnings =
+        concatMap roWarn allOuts
+            ++ [ "activity '" <> raName ra <> "': parameters section ignored (not supported)"
+               | raHasParams ra
+               ]
+            ++ [ "activity '" <> raName ra <> "': no reference product; activity will not be scoreable"
+               | not (any exchangeIsReference exchanges')
+               ]
+
+    activity =
+        Activity
+            { activityName = raName ra
+            , activityDescription = maybeToList (metaText meta "comment")
+            , activitySynonyms = M.empty
+            , activityClassification = M.empty
+            , activityLocation = fromMaybe "" (metaText meta "location")
+            , activityUnit = refUnitName
+            , exchanges = exchanges'
+            , activityParams = M.empty
+            , activityParamExprs = M.empty
+            , activityAllocationPercent = Nothing
+            , activityAllocationFormula = Nothing
+            , activityNativeType = Nothing
+            }
+
+{- | Build the reference-product (or coproduct) exchange from a @production@ row,
+falling back to the activity metadata for any field the row omits. The
+reference product is normalized to its canonical base unit at ingest, exactly
+like the SimaPro importer.
+-}
+productRowOut :: UC.UnitConfig -> M.Map Text CellValue -> Bool -> M.Map Text CellValue -> RowOut
+productRowOut cfg meta isRef f =
+    RowOut (Just exch) [flow] [] [unit] []
+  where
+    name =
+        fromMaybe "(unknown product)" $
+            fieldText f "reference product" <|> fieldText f "name" <|> metaText meta "reference product"
+    rawUnit = fromMaybe "" (fieldText f "unit" <|> metaText meta "unit")
+    rawAmount = fromMaybe 1 (fieldNum f "amount" <|> metaNum meta "production amount")
+    (effUnit, effAmount)
+        | isRef = fromMaybe (rawUnit, rawAmount) (UC.normalizeToCanonical cfg rawUnit rawAmount)
+        | otherwise = (rawUnit, rawAmount)
+    flowUUID = generateFlowUUID name "" effUnit
+    unitUUID = generateUnitUUID effUnit
+    exch =
+        TechnosphereExchange
+            { techFlowId = flowUUID
+            , techAmount = effAmount
+            , techUnitId = unitUUID
+            , techRole = if isRef then ReferenceProduct else Coproduct
+            , techActivityLinkId = UUID.nil
+            , techProcessLinkId = Nothing
+            , techLocation = fromMaybe "" (fieldText f "location" <|> metaText meta "location")
+            , techComment = Nothing
+            , techPedigree = Nothing
+            }
+    flow = TechnosphereFlow flowUUID name unitUUID M.empty Nothing Nothing
+    unit = Unit unitUUID effUnit effUnit ""
+
+-- | Build a technosphere or biosphere exchange from a non-production row.
+exchangeRowOut :: UC.UnitConfig -> Text -> M.Map Text CellValue -> RowOut
+exchangeRowOut _cfg actName f =
+    case T.toLower <$> fieldText f "type" of
+        Just "technosphere" -> technosphereRowOut actName f
+        Just "biosphere" -> biosphereRowOut actName f
+        Just other ->
+            emptyRowOut{roWarn = ["activity '" <> actName <> "': skipped exchange with unrecognized type '" <> other <> "'"]}
+        Nothing ->
+            emptyRowOut{roWarn = ["activity '" <> actName <> "': skipped exchange row with no type"]}
+
+{- | A technosphere input keyed by the supplier's /reference product/ name (the
+key 'Database.Loader.buildSupplierIndexByName' matches against), with the
+supplier location preserved for geography-aware cross-DB linking. Zero-amount
+rows are dropped (parity with the SimaPro importer).
+-}
+technosphereRowOut :: Text -> M.Map Text CellValue -> RowOut
+technosphereRowOut actName f
+    | T.null name = emptyRowOut{roWarn = ["activity '" <> actName <> "': skipped technosphere row with no name"]}
+    | amount == 0 = emptyRowOut
+    | otherwise = RowOut (Just exch) [flow] [] [unit] []
+  where
+    name = fromMaybe "" (fieldText f "reference product" <|> fieldText f "name")
+    unitName' = fromMaybe "" (fieldText f "unit")
+    amount = fromMaybe 0 (fieldNum f "amount")
+    flowUUID = generateFlowUUID name "" unitName'
+    unitUUID = generateUnitUUID unitName'
+    exch =
+        TechnosphereExchange
+            { techFlowId = flowUUID
+            , techAmount = amount
+            , techUnitId = unitUUID
+            , techRole = Input
+            , techActivityLinkId = UUID.nil
+            , techProcessLinkId = Nothing
+            , techLocation = fromMaybe "" (fieldText f "location")
+            , techComment = fieldText f "comment"
+            , techPedigree = Nothing
+            }
+    flow = TechnosphereFlow flowUUID name unitUUID M.empty Nothing Nothing
+    unit = Unit unitUUID unitName' unitName' ""
+
+{- | A biosphere exchange. @categories@ (split on @::@) becomes the compartment;
+a @natural resource@ compartment is read as an extraction ('Resource'),
+everything else as an 'Emission'. Flow UUIDs use the same normalized
+compartment string as the SimaPro importer so LCIA characterization matches.
+-}
+biosphereRowOut :: Text -> M.Map Text CellValue -> RowOut
+biosphereRowOut actName f
+    | T.null name = emptyRowOut{roWarn = ["activity '" <> actName <> "': skipped biosphere row with no name"]}
+    | otherwise = RowOut (Just exch) [] [flow] [unit] []
+  where
+    name = fromMaybe "" (fieldText f "name")
+    unitName' = fromMaybe "" (fieldText f "unit")
+    amount = fromMaybe 0 (fieldNum f "amount")
+    (comp, sub) = splitCategories (fromMaybe "" (fieldText f "categories"))
+    flowUUID = generateFlowUUID name (normalizeSimaProCompartment comp sub) unitName'
+    unitUUID = generateUnitUUID unitName'
+    exch =
+        BiosphereExchange
+            { bioFlowId = flowUUID
+            , bioAmount = amount
+            , bioUnitId = unitUUID
+            , bioDirection = if isResourceCompartment comp then Resource else Emission
+            , bioLocation = ""
+            , bioComment = fieldText f "comment"
+            , bioPedigree = Nothing
+            }
+    flow =
+        BiosphereFlow
+            { bfId = flowUUID
+            , bfName = name
+            , bfUnitId = unitUUID
+            , bfSynonyms = M.empty
+            , bfCAS = Nothing
+            , bfSubstanceId = Nothing
+            , bfCompartment = Just (Compartment comp (if T.null sub then Nothing else Just sub))
+            }
+    unit = Unit unitUUID unitName' unitName' ""
+
+{- | Split a Brightway @categories@ cell (@"air"@, @"air::urban air"@) into
+(compartment, subcompartment).
+-}
+splitCategories :: Text -> (Text, Text)
+splitCategories cats = case T.splitOn "::" cats of
+    [] -> ("", "")
+    [a] -> (T.strip a, "")
+    (a : rest) -> (T.strip a, T.strip (T.intercalate "::" rest))
+
+isResourceCompartment :: Text -> Bool
+isResourceCompartment comp =
+    T.toLower (T.strip comp) `elem` ["natural resource", "resource", "resources", "raw"]
+
+exchUnitId :: Exchange -> UUID.UUID
+exchUnitId = \case
+    TechnosphereExchange{techUnitId = u} -> u
+    BiosphereExchange{bioUnitId = u} -> u
+    WasteExchange{waUnitId = u} -> u
+
+fieldText :: M.Map Text CellValue -> Text -> Maybe Text
+fieldText m k = cellText =<< M.lookup k m
+
+fieldNum :: M.Map Text CellValue -> Text -> Maybe Double
+fieldNum m k = cellNum =<< M.lookup k m
+
+metaText :: M.Map Text CellValue -> Text -> Maybe Text
+metaText = fieldText
+
+metaNum :: M.Map Text CellValue -> Text -> Maybe Double
+metaNum = fieldNum
+
+-- ---------------------------------------------------------------------------
+-- Workbook reader (zip + XML)
+-- ---------------------------------------------------------------------------
+
+-- | Unzip an @.xlsx@ and return its worksheets, in workbook order, as row lists.
+readSheets :: BL.ByteString -> Either Text [[Row]]
+readSheets raw = do
+    archive <- first T.pack (toArchiveOrFail raw)
+    workbook <- parseXml =<< entry archive "xl/workbook.xml"
+    rels <- parseXml =<< entry archive "xl/_rels/workbook.xml.rels"
+    let relMap =
+            M.fromList
+                [ (TE.decodeUtf8 i, TE.decodeUtf8 tgt)
+                | r <- childrenNamed "Relationship" rels
+                , Just i <- [attr "Id" r]
+                , Just tgt <- [attr "Target" r]
+                ]
+        sharedStrings = parseSharedStrings <$> entryMaybe archive "xl/sharedStrings.xml"
+        sheetRefs =
+            [ TE.decodeUtf8 rid
+            | sheetsNode <- maybeToList (firstChildNamed "sheets" workbook)
+            , s <- childrenNamed "sheet" sheetsNode
+            , Just rid <- [attr "r:id" s]
+            ]
+    traverse (loadSheet archive relMap sharedStrings) sheetRefs
+
+loadSheet :: Archive -> M.Map Text Text -> Maybe (V.Vector Text) -> Text -> Either Text [Row]
+loadSheet archive relMap sharedStrings rid = do
+    target <- maybe (Left ("unknown worksheet relationship " <> rid)) Right (M.lookup rid relMap)
+    bytes <- entry archive (resolveTarget target)
+    parseSheetXml sharedStrings bytes
+
+{- | Resolve a relationship @Target@ to a zip entry path. Absolute targets
+(leading @/@) are package-root relative; everything else is relative to the
+@xl/@ directory that holds @workbook.xml@.
+-}
+resolveTarget :: Text -> FilePath
+resolveTarget target = case T.stripPrefix "/" target of
+    Just rooted -> T.unpack rooted
+    Nothing -> "xl/" <> T.unpack target
+
+entry :: Archive -> FilePath -> Either Text BS.ByteString
+entry archive path =
+    maybe (Left ("missing zip entry: " <> T.pack path)) Right (entryMaybe archive path)
+
+entryMaybe :: Archive -> FilePath -> Maybe BS.ByteString
+entryMaybe archive path = BL.toStrict . fromEntry <$> findEntryByPath path archive
+
+-- | Parse a worksheet XML part into rows.
+parseSheetXml :: Maybe (V.Vector Text) -> BS.ByteString -> Either Text [Row]
+parseSheetXml sharedStrings bs = do
+    root <- parseXml bs
+    pure
+        [ parseRow sharedStrings row
+        | sheetData <- maybeToList (firstChildNamed "sheetData" root)
+        , row <- childrenNamed "row" sheetData
+        ]
+
+parseRow :: Maybe (V.Vector Text) -> Node -> Row
+parseRow sharedStrings row =
+    M.fromList
+        [ (col, value)
+        | c <- childrenNamed "c" row
+        , Just ref <- [attr "r" c]
+        , Just col <- [columnIndex ref]
+        , Just value <- [cellValue sharedStrings c]
+        ]
+
+-- | Decode one @\<c\>@ cell, honouring its @t@ type attribute.
+cellValue :: Maybe (V.Vector Text) -> Node -> Maybe CellValue
+cellValue sharedStrings c = case TE.decodeUtf8 <$> attr "t" c of
+    Just "inlineStr" -> nonEmptyText . nodeText =<< firstChildNamed "is" c
+    Just "s" -> do
+        idx <- readInt . nodeText =<< firstChildNamed "v" c
+        table <- sharedStrings
+        nonEmptyText =<< (table V.!? idx)
+    Just "str" -> nonEmptyText . nodeText =<< firstChildNamed "v" c
+    Just "b" -> CellText . nodeText <$> firstChildNamed "v" c
+    _ -> do
+        v <- firstChildNamed "v" c
+        let txt = nodeText v
+        case TR.double txt of
+            Right (d, rest) | T.null (T.strip rest) -> Just (CellNumber d)
+            _ -> nonEmptyText txt
+
+nonEmptyText :: Text -> Maybe CellValue
+nonEmptyText t = let s = T.strip t in if T.null s then Nothing else Just (CellText s)
+
+readInt :: Text -> Maybe Int
+readInt t = case TR.decimal (T.strip t) of
+    Right (n, rest) | T.null rest -> Just n
+    _ -> Nothing
+
+-- | Shared-string table: each @\<si\>@ maps to its concatenated text.
+parseSharedStrings :: BS.ByteString -> V.Vector Text
+parseSharedStrings bs = case X.parse bs of
+    Left _ -> V.empty
+    Right sst -> V.fromList [nodeText si | si <- childrenNamed "si" sst]
+
+-- ---------------------------------------------------------------------------
+-- xeno DOM helpers
+-- ---------------------------------------------------------------------------
+
+parseXml :: BS.ByteString -> Either Text Node
+parseXml = first (T.pack . show) . X.parse
+
+childrenNamed :: BS.ByteString -> Node -> [Node]
+childrenNamed n = filter ((== n) . X.name) . X.children
+
+firstChildNamed :: BS.ByteString -> Node -> Maybe Node
+firstChildNamed n = listToMaybe . childrenNamed n
+
+attr :: BS.ByteString -> Node -> Maybe BS.ByteString
+attr k = lookup k . X.attributes
+
+{- | All text under a node (recursively), UTF-8 decoded with XML entities
+expanded. xeno returns raw byte ranges, so entity expansion is on us.
+-}
+nodeText :: Node -> Text
+nodeText = decodeEntities . TE.decodeUtf8With TEE.lenientDecode . BS.concat . go
+  where
+    go node = concatMap content (X.contents node)
+    content = \case
+        Text t -> [t]
+        CData t -> [t]
+        Element e -> go e
+
+columnIndex :: BS.ByteString -> Maybe Int
+columnIndex ref =
+    let letters = BS8.takeWhile isAsciiUpper (BS8.map toUpper ref)
+     in if BS.null letters
+            then Nothing
+            else Just (BS8.foldl' (\acc ch -> acc * 26 + (ord ch - ord 'A' + 1)) 0 letters - 1)
+
+-- | Expand the five predefined XML entities and numeric character references.
+decodeEntities :: Text -> Text
+decodeEntities t
+    | T.isInfixOf "&" t = go t
+    | otherwise = t
+  where
+    go s =
+        let (before, rest) = T.breakOn "&" s
+         in if T.null rest
+                then before
+                else
+                    let (ent, after) = T.breakOn ";" rest
+                     in case decodeOne (T.drop 1 ent) of
+                            Just c | not (T.null after) -> before <> c <> go (T.drop 1 after)
+                            _ -> before <> "&" <> go (T.drop 1 rest)
+    decodeOne e
+        | e == "lt" = Just "<"
+        | e == "gt" = Just ">"
+        | e == "amp" = Just "&"
+        | e == "quot" = Just "\""
+        | e == "apos" = Just "'"
+        | Just hex <- T.stripPrefix "#x" e = charFrom TR.hexadecimal hex
+        | Just hex <- T.stripPrefix "#X" e = charFrom TR.hexadecimal hex
+        | Just dec <- T.stripPrefix "#" e = charFrom TR.decimal dec
+        | otherwise = Nothing
+    charFrom reader s = case reader s of
+        Right (n, rest) | T.null rest && n >= 0 && n <= 0x10FFFF -> Just (T.singleton (chr n))
+        _ -> Nothing

--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -207,6 +207,10 @@ parseBlock block0 = do
                 , Just k <- [textAt 0 row]
                 , Just v <- [M.lookup 1 row]
                 ]
+        -- Everything after the Exchanges header is taken as exchange data. This
+        -- assumes a @parameters@ section (if any) precedes Exchanges, as bw2io
+        -- writes it; a trailing parameters block would be read as exchange rows
+        -- and rejected by their missing @type@ (a warning, never a silent drop).
         (headers, dataRows) = case excIdx of
             Nothing -> ([], [])
             Just i -> case drop (i + 1) block of
@@ -283,7 +287,7 @@ rawToActivity cfg ra =
 
     refExch = find exchangeIsReference exchanges'
     refUnitName = case refExch of
-        Just ex -> maybe metaUnit unitName (find ((== exchUnitId ex) . unitId) units)
+        Just ex -> maybe metaUnit unitName (find ((== exchangeUnitId ex) . unitId) units)
         Nothing -> metaUnit
     metaUnit = fromMaybe "" (metaText meta "unit")
 
@@ -291,6 +295,9 @@ rawToActivity cfg ra =
         concatMap roWarn allOuts
             ++ [ "activity '" <> raName ra <> "': parameters section ignored (not supported)"
                | raHasParams ra
+               ]
+            ++ [ "activity '" <> raName ra <> "': multiple production rows; coproducts are emitted without allocation"
+               | length prodRows > 1
                ]
             ++ [ "activity '" <> raName ra <> "': no reference product; activity will not be scoreable"
                | not (any exchangeIsReference exchanges')
@@ -439,12 +446,6 @@ isResourceCompartment :: Text -> Bool
 isResourceCompartment comp =
     T.toLower (T.strip comp) `elem` ["natural resource", "resource", "resources", "raw"]
 
-exchUnitId :: Exchange -> UUID.UUID
-exchUnitId = \case
-    TechnosphereExchange{techUnitId = u} -> u
-    BiosphereExchange{bioUnitId = u} -> u
-    WasteExchange{waUnitId = u} -> u
-
 fieldText :: M.Map Text CellValue -> Text -> Maybe Text
 fieldText m k = cellText =<< M.lookup k m
 
@@ -467,6 +468,7 @@ readSheets raw = do
     archive <- first T.pack (toArchiveOrFail raw)
     workbook <- parseXml =<< entry archive "xl/workbook.xml"
     rels <- parseXml =<< entry archive "xl/_rels/workbook.xml.rels"
+    sharedStrings <- traverse parseSharedStrings (entryMaybe archive "xl/sharedStrings.xml")
     let relMap =
             M.fromList
                 [ (TE.decodeUtf8 i, TE.decodeUtf8 tgt)
@@ -474,7 +476,6 @@ readSheets raw = do
                 , Just i <- [attr "Id" r]
                 , Just tgt <- [attr "Target" r]
                 ]
-        sharedStrings = parseSharedStrings <$> entryMaybe archive "xl/sharedStrings.xml"
         sheetRefs =
             [ TE.decodeUtf8 rid
             | sheetsNode <- maybeToList (firstChildNamed "sheets" workbook)
@@ -550,11 +551,14 @@ readInt t = case TR.decimal (T.strip t) of
     Right (n, rest) | T.null rest -> Just n
     _ -> Nothing
 
--- | Shared-string table: each @\<si\>@ maps to its concatenated text.
-parseSharedStrings :: BS.ByteString -> V.Vector Text
+{- | Shared-string table: each @\<si\>@ maps to its concatenated text. A present
+but unparseable table is surfaced rather than silently treated as empty,
+which would drop every @t="s"@ cell without trace.
+-}
+parseSharedStrings :: BS.ByteString -> Either Text (V.Vector Text)
 parseSharedStrings bs = case X.parse bs of
-    Left _ -> V.empty
-    Right sst -> V.fromList [nodeText si | si <- childrenNamed "si" sst]
+    Left err -> Left ("shared strings: " <> T.pack (show err))
+    Right sst -> Right (V.fromList [nodeText si | si <- childrenNamed "si" sst])
 
 -- ---------------------------------------------------------------------------
 -- xeno DOM helpers

--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -45,6 +45,7 @@ module BrightwayExcel.Parser (
     readSheets,
     parseSheetXml,
     sheetToActivities,
+    skippedSheetWarning,
     splitCategories,
 ) where
 
@@ -55,9 +56,9 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as BL
 import Data.Char (chr, isAsciiUpper, ord, toUpper)
-import Data.List (find, findIndex)
+import Data.List (find, findIndex, partition)
 import qualified Data.Map.Strict as M
-import Data.Maybe (catMaybes, fromMaybe, isJust, listToMaybe, mapMaybe, maybeToList)
+import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing, listToMaybe, mapMaybe, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
@@ -124,12 +125,13 @@ parseBrightwayExcel cfg path = do
     case readSheets raw of
         Left err -> pure (Left ("Brightway Excel: " <> err))
         Right sheets -> do
-            let results = concatMap (sheetToActivities cfg) (filter validFirstCell sheets)
+            let (dataSheets, skipped) = partition (validFirstCell . snd) sheets
+                results = concatMap (sheetToActivities cfg . snd) dataSheets
                 activities = [a | (a, _, _, _, _) <- results]
                 techFlows = concat [fs | (_, fs, _, _, _) <- results]
                 bioFlows = concat [fs | (_, _, fs, _, _) <- results]
                 units = concat [us | (_, _, _, us, _) <- results]
-                warnings = concat [ws | (_, _, _, _, ws) <- results]
+                warnings = concat [ws | (_, _, _, _, ws) <- results] ++ mapMaybe skippedSheetWarning skipped
             mapM_ (reportProgress Warning . T.unpack) warnings
             pure $
                 Right
@@ -147,6 +149,21 @@ validFirstCell :: [Row] -> Bool
 validFirstCell rows = case listToMaybe rows >>= textAt 0 of
     Just t -> T.toLower t /= "skip"
     Nothing -> False
+
+{- | Warn when a worksheet that /carries data/ is dropped because its first cell
+(A1) is blank. Brightway ignores the whole sheet on a blank A1, so a mistyped
+or shifted header silently loses every activity below it — surface it instead.
+The deliberate @"skip"@ sentinel and genuinely empty sheets are left silent.
+-}
+skippedSheetWarning :: (Text, [Row]) -> Maybe Text
+skippedSheetWarning (name, rows)
+    | isNothing (listToMaybe rows >>= textAt 0) && not (all M.null rows) =
+        Just $
+            "worksheet '"
+                <> name
+                <> "' ignored: its first cell (A1) is blank, so the whole sheet is skipped; "
+                <> "set A1 to 'Database' or 'Activity' to import it"
+    | otherwise = Nothing
 
 -- ---------------------------------------------------------------------------
 -- Block grammar (pure)
@@ -462,8 +479,10 @@ metaNum = fieldNum
 -- Workbook reader (zip + XML)
 -- ---------------------------------------------------------------------------
 
--- | Unzip an @.xlsx@ and return its worksheets, in workbook order, as row lists.
-readSheets :: BL.ByteString -> Either Text [[Row]]
+{- | Unzip an @.xlsx@ and return its worksheets, in workbook order, paired with
+their declared names (so a skipped sheet can be named in a warning).
+-}
+readSheets :: BL.ByteString -> Either Text [(Text, [Row])]
 readSheets raw = do
     archive <- first T.pack (toArchiveOrFail raw)
     workbook <- parseXml =<< entry archive "xl/workbook.xml"
@@ -477,12 +496,13 @@ readSheets raw = do
                 , Just tgt <- [attr "Target" r]
                 ]
         sheetRefs =
-            [ TE.decodeUtf8 rid
+            [ (sheetName, TE.decodeUtf8 rid)
             | sheetsNode <- maybeToList (firstChildNamed "sheets" workbook)
             , s <- childrenNamed "sheet" sheetsNode
             , Just rid <- [attr "r:id" s]
+            , let sheetName = maybe (TE.decodeUtf8 rid) TE.decodeUtf8 (attr "name" s)
             ]
-    traverse (loadSheet archive relMap sharedStrings) sheetRefs
+    traverse (\(name, rid) -> (,) name <$> loadSheet archive relMap sharedStrings rid) sheetRefs
 
 loadSheet :: Archive -> M.Map Text Text -> Maybe (V.Vector Text) -> Text -> Either Text [Row]
 loadSheet archive relMap sharedStrings rid = do

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -75,6 +75,7 @@ module Database.Loader (
     fixExchangeLinkByName,
 ) where
 
+import qualified BrightwayExcel.Parser as BrightwayExcel
 import qualified Codec.Compression.Zstd as Zstd
 import Control.Concurrent.Async
 import Control.DeepSeq (force)
@@ -509,6 +510,7 @@ loadDatabaseWithLocationAliases unitConfig locationAliases path = do
         then case map toLower (takeExtension path) of
             ".csv" -> loadSimaProCSV unitConfig path
             ".xml" -> loadSingleEcoSpold1File locationAliases path
+            ".xlsx" -> loadBrightwayExcel unitConfig path
             _ -> return $ Left $ T.pack $ "Unsupported file type: " ++ path
         else
             if isDir
@@ -540,6 +542,30 @@ loadSimaProCSV unitConfig csvPath = do
 
             -- Fix activity links using supplier lookup (same as EcoSpold1)
             Right <$> fixSimaProActivityLinks simpleDb
+
+{- | Load a Brightway Excel (.xlsx) inventory.
+
+Mirrors 'loadSimaProCSV': the parser returns the same 5-tuple, activities are
+keyed @(activityUUID, referenceProductUUID)@, and within-file supplier
+references are resolved by the shared name-based pass. Cross-database links to a
+background database (e.g. ecoinvent) are resolved later by
+'fixActivityLinksWithCrossDB', exactly as for SimaPro and EcoSpold.
+-}
+loadBrightwayExcel :: UC.UnitConfig -> FilePath -> IO (Either T.Text SimpleDatabase)
+loadBrightwayExcel unitConfig xlsxPath = do
+    parsed <- BrightwayExcel.parseBrightwayExcel unitConfig xlsxPath
+    case parsed of
+        Left err -> return $ Left err
+        Right (activities, techFlowDB, bioFlowDB, wasteFlowDB, unitDB)
+            | null activities -> return $ Left "No activities found in Brightway Excel file."
+            | otherwise -> do
+                let procMap =
+                        M.fromList
+                            [ ((SimaPro.generateActivityUUID act, getReferenceProductUUID act), act)
+                            | act <- activities
+                            ]
+                    simpleDb = SimpleDatabase procMap techFlowDB bioFlowDB wasteFlowDB unitDB
+                Right <$> fixSimaProActivityLinks simpleDb
 
 {- | Fix SimaPro activity links by resolving supplier references
 Uses name-only matching (no location required) for SimaPro technosphere inputs

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -2080,6 +2080,7 @@ discoverCandidatePaths dbConfig = do
                 Upload.SimaProCSV -> "SimaPro CSV"
                 Upload.ILCDProcess -> "ILCD"
                 Upload.OpenLcaJsonLd -> "openLCA JSON-LD"
+                Upload.BrightwayExcel -> "Brightway Excel"
                 Upload.UnknownFormat -> "Unknown"
         return (T.pack rel, label, count)
   where

--- a/src/Database/Upload.hs
+++ b/src/Database/Upload.hs
@@ -60,6 +60,7 @@ data DatabaseFormat
     | EcoSpold2 -- EcoSpold v2 XML format
     | ILCDProcess -- ILCD process dataset format
     | OpenLcaJsonLd -- openLCA JSON-LD (single ImpactCategory document)
+    | BrightwayExcel -- Brightway Excel (.xlsx) inventory format
     | UnknownFormat -- Could not detect format
     deriving (Show, Eq, Generic)
 
@@ -69,6 +70,7 @@ instance ToJSON DatabaseFormat where
     toJSON SimaProCSV = A.String "SimaPro CSV"
     toJSON ILCDProcess = A.String "ILCD"
     toJSON OpenLcaJsonLd = A.String "openLCA JSON-LD"
+    toJSON BrightwayExcel = A.String "Brightway Excel"
     toJSON UnknownFormat = A.String ""
 
 instance FromJSON DatabaseFormat where
@@ -78,6 +80,7 @@ instance FromJSON DatabaseFormat where
         "SimaPro CSV" -> pure SimaProCSV
         "ILCD" -> pure ILCDProcess
         "openLCA JSON-LD" -> pure OpenLcaJsonLd
+        "Brightway Excel" -> pure BrightwayExcel
         _ -> pure UnknownFormat
 
 -- | Progress event for upload/loading operations
@@ -623,6 +626,7 @@ countDataFiles d format = do
     isDataFile EcoSpold2 f = ".spold" `isSuffixOf` map toLower f
     isDataFile ILCDProcess f = ".xml" `isSuffixOf` map toLower f
     isDataFile OpenLcaJsonLd f = ".json" `isSuffixOf` map toLower f
+    isDataFile BrightwayExcel f = ".xlsx" `isSuffixOf` map toLower f
     isDataFile UnknownFormat _ = True
 
 -- | Recursively list all files in a directory
@@ -648,6 +652,7 @@ detectDatabaseFormat path = do
             let ext = map toLower (takeExtension path)
             case ext of
                 ".spold" -> return EcoSpold2
+                ".xlsx" -> return BrightwayExcel
                 ".xml" -> do
                     isEcoSpold1 <- checkForEcoSpold1 [path]
                     return $ if isEcoSpold1 then EcoSpold1 else UnknownFormat
@@ -669,26 +674,30 @@ detectDatabaseFormat path = do
                             fs <- listDirectoryRecursive path
                             let extensions = map (map toLower . takeExtension) fs
                             let hasSpold = ".spold" `elem` extensions
+                                hasXlsx = ".xlsx" `elem` extensions
                                 hasXml = ".xml" `elem` extensions
                                 hasCsv = ".csv" `elem` extensions
                                 jsonFiles = [f | f <- fs, map toLower (takeExtension f) == ".json"]
                             if hasSpold
                                 then return EcoSpold2
                                 else
-                                    if hasXml
-                                        then do
-                                            isEcoSpold1 <- checkForEcoSpold1 fs
-                                            return $ if isEcoSpold1 then EcoSpold1 else UnknownFormat
+                                    if hasXlsx
+                                        then return BrightwayExcel
                                         else
-                                            if hasCsv
+                                            if hasXml
                                                 then do
-                                                    isSimaPro <- checkForSimaProCSV fs
-                                                    return $ if isSimaPro then SimaProCSV else UnknownFormat
-                                                else case jsonFiles of
-                                                    [] -> return UnknownFormat
-                                                    (j : _) -> do
-                                                        isOlca <- isOlcaJsonFile j
-                                                        return $ if isOlca then OpenLcaJsonLd else UnknownFormat
+                                                    isEcoSpold1 <- checkForEcoSpold1 fs
+                                                    return $ if isEcoSpold1 then EcoSpold1 else UnknownFormat
+                                                else
+                                                    if hasCsv
+                                                        then do
+                                                            isSimaPro <- checkForSimaProCSV fs
+                                                            return $ if isSimaPro then SimaProCSV else UnknownFormat
+                                                        else case jsonFiles of
+                                                            [] -> return UnknownFormat
+                                                            (j : _) -> do
+                                                                isOlca <- isOlcaJsonFile j
+                                                                return $ if isOlca then OpenLcaJsonLd else UnknownFormat
                 else return UnknownFormat
 
 -- | Check if XML files are EcoSpold1 format

--- a/src/Database/Upload.hs
+++ b/src/Database/Upload.hs
@@ -31,6 +31,7 @@ module Database.Upload (
     slugify,
 ) where
 
+import Codec.Archive.Zip (findEntryByPath, toArchiveOrFail)
 import Control.Exception (SomeException, try)
 import Control.Monad (filterM, forM)
 import Data.Aeson (FromJSON (..), ToJSON (..), withText)
@@ -39,6 +40,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import Data.Char (isAlphaNum, toLower)
 import Data.List (isPrefixOf, isSuffixOf, sortOn)
+import Data.Maybe (isJust)
 import Data.Ord (Down (..))
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -166,6 +168,7 @@ handleUpload uploadsDir UploadData{..} reportProgress = do
 -- | Supported archive format (detected by magic bytes)
 data ArchiveFormat
     = ArchiveZip -- ZIP: 50 4B (PK)
+    | ArchiveXlsx -- Brightway Excel .xlsx: an OOXML zip (50 4B) carrying xl/workbook.xml
     | Archive7z -- 7z:  37 7A BC AF 27 1C
     | ArchiveGzip -- gzip (tar.gz): 1F 8B
     | ArchiveXz -- XZ (tar.xz): FD 37 7A 58 5A 00
@@ -179,7 +182,7 @@ data ArchiveFormat
 detectArchiveFormat :: BL.ByteString -> ArchiveFormat
 detectArchiveFormat content
     | BL.null content = ArchiveUnknown
-    | matchesMagic [0x50, 0x4B] = ArchiveZip
+    | matchesMagic [0x50, 0x4B] = if isXlsx then ArchiveXlsx else ArchiveZip
     | matchesMagic [0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C] = Archive7z
     | matchesMagic [0x1F, 0x8B] = ArchiveGzip
     | matchesMagic [0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00] = ArchiveXz
@@ -190,6 +193,13 @@ detectArchiveFormat content
   where
     bytes = BL.unpack (BL.take 10 content)
     matchesMagic magic = take (length magic) bytes == magic
+    -- An .xlsx is a zip (same PK magic as a database archive), so it can only be
+    -- told apart by its contents: openpyxl/bw2io always writes xl/workbook.xml.
+    -- Routing it here keeps the package intact instead of letting extractZip
+    -- explode it into XML parts that detectDatabaseFormat can't recognise.
+    isXlsx = case toArchiveOrFail content of
+        Left _ -> False
+        Right archive -> isJust (findEntryByPath "xl/workbook.xml" archive)
     -- Check for XML declaration "<?xml" (0x3C 0x3F 0x78 0x6D 0x6C)
     -- or "<ecoSpold" (0x3C 0x65 0x63 0x6F)
     -- or UTF-8 BOM (0xEF 0xBB 0xBF) followed by "<?xml"
@@ -240,6 +250,12 @@ extractUpload content targetDir = do
         ArchivePlainCSV -> do
             -- Plain CSV: write directly
             BL.writeFile (targetDir </> "data.csv") content
+            return $ Right ()
+        ArchiveXlsx -> do
+            -- Brightway Excel: keep the .xlsx (an OOXML zip) intact so the loader
+            -- dispatches on the extension; extracting it would scatter the XML
+            -- parts and detectDatabaseFormat would fall through to UnknownFormat.
+            BL.writeFile (targetDir </> "data.xlsx") content
             return $ Right ()
         ArchiveUnknown ->
             return $ Left "Unsupported file format. Please upload a ZIP, 7z, tar.gz, tar.xz archive, XML, CSV, or openLCA JSON-LD file."
@@ -409,6 +425,7 @@ extractArchive format archiveData targetDir = do
             ArchiveGzip -> ".tar.gz"
             ArchiveXz -> ".tar.xz"
             ArchiveZip -> ".tar"
+            ArchiveXlsx -> ".tar"
             Archive7z -> ".tar"
             ArchivePlainXML -> ".tar"
             ArchivePlainJSON -> ".tar"
@@ -436,6 +453,7 @@ extractArchive format archiveData targetDir = do
         ArchiveGzip -> "tar.gz"
         ArchiveXz -> "tar.xz"
         ArchiveZip -> "archive"
+        ArchiveXlsx -> "archive"
         Archive7z -> "archive"
         ArchivePlainXML -> "archive"
         ArchivePlainJSON -> "archive"

--- a/src/Database/UploadedDatabase.hs
+++ b/src/Database/UploadedDatabase.hs
@@ -174,6 +174,7 @@ formatMetaToml UploadMeta{..} =
     formatToText SimaProCSV = "simapro"
     formatToText ILCDProcess = "ilcd"
     formatToText OpenLcaJsonLd = "openlca-jsonld"
+    formatToText BrightwayExcel = "brightway-excel"
     formatToText UnknownFormat = "unknown"
 
 -- | Scan a directory for subdirectories with meta.toml

--- a/test/BrightwayExcelSpec.hs
+++ b/test/BrightwayExcelSpec.hs
@@ -23,6 +23,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.UUID as UUID
 import Database.Loader (loadDatabase)
+import Database.Upload (ArchiveFormat (..), detectArchiveFormat)
 import System.IO (hClose)
 import System.IO.Temp (withSystemTempFile)
 import Test.Hspec
@@ -131,6 +132,12 @@ spec = describe "BrightwayExcel.Parser" $ do
                         -- Widget consumes the file's own "electricity, high voltage";
                         -- the name-based pass must resolve that supplier.
                         any (/= UUID.nil) links `shouldBe` True
+
+    describe "upload format detection" $
+        it "routes a Brightway .xlsx to ArchiveXlsx, not generic ArchiveZip" $
+            -- An .xlsx is a PK zip; without this the upload extractor would unzip
+            -- it and detectDatabaseFormat would fall through to UnknownFormat.
+            detectArchiveFormat fixtureBytes `shouldBe` ArchiveXlsx
 
 -- ---------------------------------------------------------------------------
 -- Assertions helpers

--- a/test/BrightwayExcelSpec.hs
+++ b/test/BrightwayExcelSpec.hs
@@ -11,13 +11,13 @@ header, biosphere categories (with @::@), and within-file supplier linking.
 -}
 module BrightwayExcelSpec (spec) where
 
-import BrightwayExcel.Parser (CellValue (..), parseBrightwayExcel, parseSheetXml, splitCategories)
+import BrightwayExcel.Parser (CellValue (..), parseBrightwayExcel, parseSheetXml, skippedSheetWarning, splitCategories)
 import Codec.Archive.Zip (addEntryToArchive, emptyArchive, fromArchive, toEntry)
 import qualified Data.ByteString.Lazy as BL
 import Data.Char (chr, ord)
 import Data.List (find)
 import qualified Data.Map.Strict as M
-import Data.Maybe (listToMaybe, mapMaybe)
+import Data.Maybe (isJust, listToMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
@@ -139,6 +139,43 @@ spec = describe "BrightwayExcel.Parser" $ do
             -- it and detectDatabaseFormat would fall through to UnknownFormat.
             detectArchiveFormat fixtureBytes `shouldBe` ArchiveXlsx
 
+    describe "multi-sheet workbooks" $ do
+        it "imports one activity per sheet across many sheets" $ do
+            let bytes =
+                    buildWorkbook
+                        [ ("alpha", activitySheet "Alpha activity" "alpha product")
+                        , ("beta", activitySheet "Beta activity" "beta product")
+                        , ("gamma", activitySheet "Gamma activity" "gamma product")
+                        ]
+            withWorkbook bytes $ \path -> do
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right (acts, _, _, _, _) ->
+                        map activityName acts
+                            `shouldMatchList` ["Alpha activity", "Beta activity", "Gamma activity"]
+
+        it "skips a sheet whose first cell (A1) is blank, keeping the valid ones" $ do
+            let bytes =
+                    buildWorkbook
+                        [ ("kept", activitySheet "Kept activity" "kept product")
+                        , -- a leading blank row makes A1 empty, so bw2io ignores the sheet
+                          ("blankA1", [] : activitySheet "Dropped activity" "dropped product")
+                        ]
+            withWorkbook bytes $ \path -> do
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right (acts, _, _, _, _) ->
+                        map activityName acts `shouldMatchList` ["Kept activity"]
+
+    describe "skippedSheetWarning" $ do
+        it "flags a sheet that holds data but whose A1 is blank" $
+            skippedSheetWarning ("Inventory", [M.empty, M.singleton 0 (CellText "Activity")])
+                `shouldSatisfy` isJust
+        it "stays silent on the deliberate 'skip' sentinel" $
+            skippedSheetWarning ("Notes", [M.singleton 0 (CellText "skip")]) `shouldBe` Nothing
+        it "stays silent on an entirely empty sheet" $
+            skippedSheetWarning ("Empty", [M.empty]) `shouldBe` Nothing
+
 -- ---------------------------------------------------------------------------
 -- Assertions helpers
 -- ---------------------------------------------------------------------------
@@ -198,50 +235,71 @@ directionOf bioDB acts name =
 -- Fixture workbook (generated in-memory)
 -- ---------------------------------------------------------------------------
 
-withFixture :: (FilePath -> IO a) -> IO a
-withFixture action =
+withWorkbook :: BL.ByteString -> (FilePath -> IO a) -> IO a
+withWorkbook bytes action =
     withSystemTempFile "brightway-fixture.xlsx" $ \path h -> do
-        BL.hPut h fixtureBytes
+        BL.hPut h bytes
         hClose h
         action path
 
+withFixture :: (FilePath -> IO a) -> IO a
+withFixture = withWorkbook fixtureBytes
+
 fixtureBytes :: BL.ByteString
-fixtureBytes =
+fixtureBytes = buildWorkbook [("data", sheet1Rows), ("reordered", sheet2Rows)]
+
+{- | Assemble a minimal @.xlsx@ from named sheets, wiring the workbook/rels parts
+so that worksheet N lives at @xl/worksheets/sheetN.xml@.
+-}
+buildWorkbook :: [(Text, [[Cell]])] -> BL.ByteString
+buildWorkbook sheets =
     fromArchive $
-        foldr
-            addEntryToArchive
-            emptyArchive
-            [ toEntry "xl/workbook.xml" 0 (enc workbookXml)
-            , toEntry "xl/_rels/workbook.xml.rels" 0 (enc relsXml)
-            , toEntry "xl/worksheets/sheet1.xml" 0 (enc (sheetXml sheet1Rows))
-            , toEntry "xl/worksheets/sheet2.xml" 0 (enc (sheetXml sheet2Rows))
-            ]
+        foldr addEntryToArchive emptyArchive $
+            toEntry "xl/workbook.xml" 0 (enc (workbookXml (map fst sheets)))
+                : toEntry "xl/_rels/workbook.xml.rels" 0 (enc (relsXml (length sheets)))
+                : [ toEntry ("xl/worksheets/sheet" <> show i <> ".xml") 0 (enc (sheetXml rows))
+                  | (i, (_, rows)) <- zip [1 :: Int ..] sheets
+                  ]
   where
     enc = BL.fromStrict . TE.encodeUtf8
 
-workbookXml :: Text
-workbookXml =
+-- | A single-activity worksheet (standard column order) for multi-sheet tests.
+activitySheet :: Text -> Text -> [[Cell]]
+activitySheet actName prodName =
+    [ [CT "Activity", CT actName]
+    , [CT "production amount", CN 1]
+    , [CT "reference product", CT prodName]
+    , [CT "location", CT "GLO"]
+    , [CT "unit", CT "kilogram"]
+    , [CT "Exchanges"]
+    , [CT "name", CT "amount", CT "reference product", CT "location", CT "unit", CT "categories", CT "type", CT "database"]
+    , [CT actName, CN 1, CT prodName, CT "GLO", CT "kilogram", CE, CT "production", CT "DB"]
+    ]
+
+workbookXml :: [Text] -> Text
+workbookXml names =
     "<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\""
         <> " xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">"
         <> "<sheets>"
-        <> "<sheet name=\"data\" sheetId=\"1\" r:id=\"rId1\"/>"
-        <> "<sheet name=\"reordered\" sheetId=\"2\" r:id=\"rId2\"/>"
+        <> T.concat
+            [ "<sheet name=\"" <> nm <> "\" sheetId=\"" <> tshow i <> "\" r:id=\"rId" <> tshow i <> "\"/>"
+            | (i, nm) <- zip [1 :: Int ..] names
+            ]
         <> "</sheets></workbook>"
 
-relsXml :: Text
-relsXml =
+relsXml :: Int -> Text
+relsXml n =
     "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">"
-        <> rel "rId1" "worksheets/sheet1.xml"
-        <> rel "rId2" "worksheets/sheet2.xml"
+        <> T.concat [rel i | i <- [1 .. n]]
         <> "</Relationships>"
   where
-    rel i tgt =
-        "<Relationship Id=\""
-            <> i
+    rel i =
+        "<Relationship Id=\"rId"
+            <> tshow i
             <> "\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\""
-            <> " Target=\""
-            <> tgt
-            <> "\"/>"
+            <> " Target=\"worksheets/sheet"
+            <> tshow i
+            <> ".xml\"/>"
 
 {- | Sheet 1: standard column order, two activities. Widget consumes the file's
 own electricity product, so its supplier link must resolve within the file.

--- a/test/BrightwayExcelSpec.hs
+++ b/test/BrightwayExcelSpec.hs
@@ -1,0 +1,324 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Tests for the Brightway Excel (.xlsx) importer.
+
+The fixture workbook is generated in-memory (zip of inline-string XML, the
+shape openpyxl/bw2io emits) so no third-party inventory data is committed
+into the open-source engine. It exercises: inline strings, sparse columns
+addressed by cell reference, XML entity decoding, a reordered exchange
+header, biosphere categories (with @::@), and within-file supplier linking.
+-}
+module BrightwayExcelSpec (spec) where
+
+import BrightwayExcel.Parser (CellValue (..), parseBrightwayExcel, parseSheetXml, splitCategories)
+import Codec.Archive.Zip (addEntryToArchive, emptyArchive, fromArchive, toEntry)
+import qualified Data.ByteString.Lazy as BL
+import Data.Char (chr, ord)
+import Data.List (find)
+import qualified Data.Map.Strict as M
+import Data.Maybe (listToMaybe, mapMaybe)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified Data.UUID as UUID
+import Database.Loader (loadDatabase)
+import System.IO (hClose)
+import System.IO.Temp (withSystemTempFile)
+import Test.Hspec
+import Types (
+    Activity (..),
+    BioDirection (..),
+    BiosphereFlow (..),
+    Compartment (..),
+    Exchange (..),
+    SimpleDatabase (..),
+    TechRole (..),
+    TechnosphereFlow (..),
+    exchangeFlowId,
+    exchangeIsReference,
+ )
+import UnitConversion (defaultUnitConfig)
+
+spec :: Spec
+spec = describe "BrightwayExcel.Parser" $ do
+    describe "splitCategories" $ do
+        it "splits a compartment::subcompartment pair" $
+            splitCategories "air::urban air close to ground" `shouldBe` ("air", "urban air close to ground")
+        it "treats a single level as compartment with no sub" $
+            splitCategories "air" `shouldBe` ("air", "")
+
+    describe "parseSheetXml" $ do
+        it "decodes XML entities in inline strings" $ do
+            let xml =
+                    "<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">"
+                        <> "<sheetData><row r=\"1\">"
+                        <> "<c r=\"A1\" t=\"inlineStr\"><is><t>furnace &gt;100kW &amp; up</t></is></c>"
+                        <> "</row></sheetData></worksheet>"
+            case parseSheetXml Nothing (TE.encodeUtf8 xml) of
+                Right [row] -> M.lookup 0 row `shouldBe` Just (CellText "furnace >100kW & up")
+                other -> expectationFailure ("unexpected parse: " <> show other)
+        it "addresses cells by column reference, skipping gaps" $ do
+            let xml =
+                    "<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">"
+                        <> "<sheetData><row r=\"1\">"
+                        <> "<c r=\"A1\" t=\"inlineStr\"><is><t>name</t></is></c>"
+                        <> "<c r=\"C1\" t=\"n\"><v>0.5</v></c>"
+                        <> "</row></sheetData></worksheet>"
+            case parseSheetXml Nothing (TE.encodeUtf8 xml) of
+                Right [row] -> do
+                    M.lookup 0 row `shouldBe` Just (CellText "name")
+                    M.lookup 1 row `shouldBe` Nothing
+                    M.lookup 2 row `shouldBe` Just (CellNumber 0.5)
+                other -> expectationFailure ("unexpected parse: " <> show other)
+
+    describe "parseBrightwayExcel" $ do
+        it "parses all activities across sheets" $ withFixture $ \path -> do
+            parseBrightwayExcel defaultUnitConfig path >>= \case
+                Left err -> expectationFailure (T.unpack err)
+                Right (acts, _, _, _, _) ->
+                    map activityName acts
+                        `shouldMatchList` [ "Electricity production, natural gas"
+                                          , "Widget manufacturing"
+                                          , "Cotton fibre production"
+                                          ]
+
+        it "keys the reference product by its product name" $ withFixture $ \path -> do
+            parseBrightwayExcel defaultUnitConfig path >>= \case
+                Left err -> expectationFailure (T.unpack err)
+                Right (acts, techDB, _, _, _) -> do
+                    elec <- requireActivity acts "Electricity production, natural gas"
+                    referenceProductName techDB elec `shouldBe` Just "electricity, high voltage"
+
+        it "keys a technosphere input by the supplier reference product, preserving amount" $ withFixture $ \path -> do
+            parseBrightwayExcel defaultUnitConfig path >>= \case
+                Left err -> expectationFailure (T.unpack err)
+                Right (acts, techDB, _, _, _) -> do
+                    elec <- requireActivity acts "Electricity production, natural gas"
+                    let gas = listToMaybe [ex | ex <- inputExchanges elec, flowName techDB ex == Just "natural gas, high pressure"]
+                    fmap techAmount gas `shouldBe` Just 8.5
+
+        it "splits biosphere categories into compartment + sub and direction" $ withFixture $ \path -> do
+            parseBrightwayExcel defaultUnitConfig path >>= \case
+                Left err -> expectationFailure (T.unpack err)
+                Right (acts, _, bioDB, _, _) -> do
+                    co2 <- requireBioFlow bioDB "Carbon dioxide, fossil"
+                    bfCompartment co2 `shouldBe` Just (Compartment "air" Nothing)
+                    water <- requireBioFlow bioDB "Water"
+                    bfCompartment water `shouldBe` Just (Compartment "natural resource" (Just "in water"))
+                    directionOf bioDB acts "Carbon dioxide, fossil" `shouldBe` Just Emission
+                    directionOf bioDB acts "Water" `shouldBe` Just Resource
+
+        it "reads a reordered exchange header by label" $ withFixture $ \path -> do
+            parseBrightwayExcel defaultUnitConfig path >>= \case
+                Left err -> expectationFailure (T.unpack err)
+                Right (acts, techDB, _, _, _) -> do
+                    cotton <- requireActivity acts "Cotton fibre production"
+                    referenceProductName techDB cotton `shouldBe` Just "cotton fibre"
+                    let irrigation = listToMaybe [ex | ex <- inputExchanges cotton, flowName techDB ex == Just "water, irrigation"]
+                    fmap techAmount irrigation `shouldBe` Just 3.2
+
+    describe "loadDatabase dispatch" $
+        it "resolves within-file technosphere links" $
+            withFixture $ \path -> do
+                loadDatabase defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right db -> do
+                        let links =
+                                mapMaybe
+                                    inputLink
+                                    (concatMap exchanges (M.elems (sdbActivities db)))
+                        -- Widget consumes the file's own "electricity, high voltage";
+                        -- the name-based pass must resolve that supplier.
+                        any (/= UUID.nil) links `shouldBe` True
+
+-- ---------------------------------------------------------------------------
+-- Assertions helpers
+-- ---------------------------------------------------------------------------
+
+requireActivity :: [Activity] -> Text -> IO Activity
+requireActivity acts name =
+    maybe (fail ("missing activity: " <> T.unpack name)) pure (find ((== name) . activityName) acts)
+
+requireBioFlow :: M.Map UUID.UUID BiosphereFlow -> Text -> IO BiosphereFlow
+requireBioFlow bioDB name =
+    maybe (fail ("missing biosphere flow: " <> T.unpack name)) pure (find ((== name) . bfName) (M.elems bioDB))
+
+referenceProductName :: M.Map UUID.UUID TechnosphereFlow -> Activity -> Maybe Text
+referenceProductName techDB act =
+    listToMaybe
+        [ tfName f
+        | ex <- exchanges act
+        , exchangeIsReference ex
+        , Just f <- [M.lookup (exchangeFlowId ex) techDB]
+        ]
+
+flowName :: M.Map UUID.UUID TechnosphereFlow -> Exchange -> Maybe Text
+flowName techDB ex = tfName <$> M.lookup (exchangeFlowId ex) techDB
+
+inputExchanges :: Activity -> [Exchange]
+inputExchanges = filter isInput . exchanges
+  where
+    isInput e = case e of
+        TechnosphereExchange{techRole = Input} -> True
+        TechnosphereExchange{} -> False
+        BiosphereExchange{} -> False
+        WasteExchange{} -> False
+
+inputLink :: Exchange -> Maybe UUID.UUID
+inputLink e = case e of
+    TechnosphereExchange{techRole = Input, techActivityLinkId = l} -> Just l
+    TechnosphereExchange{} -> Nothing
+    BiosphereExchange{} -> Nothing
+    WasteExchange{} -> Nothing
+
+directionOf :: M.Map UUID.UUID BiosphereFlow -> [Activity] -> Text -> Maybe BioDirection
+directionOf bioDB acts name =
+    listToMaybe
+        [ d
+        | ex <- concatMap exchanges acts
+        , Just (fid, d) <- [bioDir ex]
+        , Just f <- [M.lookup fid bioDB]
+        , bfName f == name
+        ]
+  where
+    bioDir e = case e of
+        BiosphereExchange{bioFlowId = fid, bioDirection = d} -> Just (fid, d)
+        TechnosphereExchange{} -> Nothing
+        WasteExchange{} -> Nothing
+
+-- ---------------------------------------------------------------------------
+-- Fixture workbook (generated in-memory)
+-- ---------------------------------------------------------------------------
+
+withFixture :: (FilePath -> IO a) -> IO a
+withFixture action =
+    withSystemTempFile "brightway-fixture.xlsx" $ \path h -> do
+        BL.hPut h fixtureBytes
+        hClose h
+        action path
+
+fixtureBytes :: BL.ByteString
+fixtureBytes =
+    fromArchive $
+        foldr
+            addEntryToArchive
+            emptyArchive
+            [ toEntry "xl/workbook.xml" 0 (enc workbookXml)
+            , toEntry "xl/_rels/workbook.xml.rels" 0 (enc relsXml)
+            , toEntry "xl/worksheets/sheet1.xml" 0 (enc (sheetXml sheet1Rows))
+            , toEntry "xl/worksheets/sheet2.xml" 0 (enc (sheetXml sheet2Rows))
+            ]
+  where
+    enc = BL.fromStrict . TE.encodeUtf8
+
+workbookXml :: Text
+workbookXml =
+    "<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\""
+        <> " xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">"
+        <> "<sheets>"
+        <> "<sheet name=\"data\" sheetId=\"1\" r:id=\"rId1\"/>"
+        <> "<sheet name=\"reordered\" sheetId=\"2\" r:id=\"rId2\"/>"
+        <> "</sheets></workbook>"
+
+relsXml :: Text
+relsXml =
+    "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">"
+        <> rel "rId1" "worksheets/sheet1.xml"
+        <> rel "rId2" "worksheets/sheet2.xml"
+        <> "</Relationships>"
+  where
+    rel i tgt =
+        "<Relationship Id=\""
+            <> i
+            <> "\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\""
+            <> " Target=\""
+            <> tgt
+            <> "\"/>"
+
+{- | Sheet 1: standard column order, two activities. Widget consumes the file's
+own electricity product, so its supplier link must resolve within the file.
+-}
+sheet1Rows :: [[Cell]]
+sheet1Rows =
+    [ [CT "Database", CT "Test_Inventory_DB"]
+    , []
+    , [CT "Activity", CT "Electricity production, natural gas"]
+    , [CT "production amount", CN 1]
+    , [CT "comment"]
+    , [CT "reference product", CT "electricity, high voltage"]
+    , [CT "location", CT "GLO"]
+    , [CT "unit", CT "kilowatt hour"]
+    , [CT "Exchanges"]
+    , excHeader
+    , [CT "Electricity production, natural gas", CN 1, CT "electricity, high voltage", CT "GLO", CT "kilowatt hour", CE, CT "production", CT "Test_Inventory_DB"]
+    , [CT "natural gas, burned >100kW", CN 8.5, CT "natural gas, high pressure", CT "RoW", CT "cubic meter", CE, CT "technosphere", CT "ecoinvent-3.12-cutoff"]
+    , [CT "Carbon dioxide, fossil", CN 0.5, CE, CT "GLO", CT "kilogram", CT "air", CT "biosphere", CT "ecoinvent-3.12-biosphere"]
+    , []
+    , [CT "Activity", CT "Widget manufacturing"]
+    , [CT "production amount", CN 1]
+    , [CT "reference product", CT "widget"]
+    , [CT "location", CT "GLO"]
+    , [CT "unit", CT "kilogram"]
+    , [CT "Exchanges"]
+    , excHeader
+    , [CT "Widget manufacturing", CN 1, CT "widget", CT "GLO", CT "kilogram", CE, CT "production", CT "Test_Inventory_DB"]
+    , [CT "Electricity production, natural gas", CN 2.5, CT "electricity, high voltage", CT "GLO", CT "kilowatt hour", CE, CT "technosphere", CT "Test_Inventory_DB"]
+    , [CT "Water", CN 1.0e-3, CE, CT "GLO", CT "cubic meter", CT "natural resource::in water", CT "biosphere", CT "ecoinvent-3.12-biosphere"]
+    ]
+  where
+    excHeader =
+        [CT "name", CT "amount", CT "reference product", CT "location", CT "unit", CT "categories", CT "type", CT "database"]
+
+{- | Sheet 2: a reordered exchange header (type/unit/amount first), starting with
+an Activity row (no Database section), to exercise label-based column lookup
+and multi-sheet handling.
+-}
+sheet2Rows :: [[Cell]]
+sheet2Rows =
+    [ [CT "Activity", CT "Cotton fibre production"]
+    , [CT "production amount", CN 1]
+    , [CT "reference product", CT "cotton fibre"]
+    , [CT "location", CT "IN"]
+    , [CT "unit", CT "kilogram"]
+    , [CT "Exchanges"]
+    , [CT "type", CT "unit", CT "amount", CT "reference product", CT "name", CT "location", CT "categories", CT "database"]
+    , [CT "production", CT "kilogram", CN 1, CT "cotton fibre", CT "Cotton fibre production", CT "IN", CE, CT "Reordered_DB"]
+    , [CT "technosphere", CT "cubic meter", CN 3.2, CT "water, irrigation", CT "market for irrigation", CT "IN", CE, CT "ecoinvent-3.12-cutoff"]
+    ]
+
+-- ---------------------------------------------------------------------------
+-- Minimal SpreadsheetML emitter
+-- ---------------------------------------------------------------------------
+
+data Cell = CT Text | CN Double | CE
+
+sheetXml :: [[Cell]] -> Text
+sheetXml rows =
+    "<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"><sheetData>"
+        <> T.concat [rowXml n r | (n, r) <- zip [1 ..] rows]
+        <> "</sheetData></worksheet>"
+
+rowXml :: Int -> [Cell] -> Text
+rowXml n cells =
+    "<row r=\""
+        <> tshow n
+        <> "\">"
+        <> T.concat [cellXml c n cell | (c, cell) <- zip [0 ..] cells]
+        <> "</row>"
+
+cellXml :: Int -> Int -> Cell -> Text
+cellXml _ _ CE = ""
+cellXml col n (CN d) =
+    "<c r=\"" <> cellRef col n <> "\" t=\"n\"><v>" <> tshow d <> "</v></c>"
+cellXml col n (CT t) =
+    "<c r=\"" <> cellRef col n <> "\" t=\"inlineStr\"><is><t>" <> escapeXml t <> "</t></is></c>"
+
+cellRef :: Int -> Int -> Text
+cellRef col n = T.singleton (chr (ord 'A' + col)) <> tshow n
+
+escapeXml :: Text -> Text
+escapeXml = T.replace ">" "&gt;" . T.replace "<" "&lt;" . T.replace "&" "&amp;"
+
+tshow :: (Show a) => a -> Text
+tshow = T.pack . show

--- a/volca.cabal
+++ b/volca.cabal
@@ -73,6 +73,7 @@ library
                      , EcoSpold.Parser2
                      , EcoSpold.Parser1
                      , SimaPro.Parser
+                     , BrightwayExcel.Parser
                      , Expr
                      , ILCD.Parser
                      , Plugin.Types
@@ -89,6 +90,7 @@ library
                      , text
                      , containers
                      , xeno
+                     , zip-archive
                      , filepath
                      , directory
                      , mtl
@@ -190,6 +192,7 @@ test-suite lca-tests
                      , MatrixExportSpec
                      , MethodSpec
                      , SimaProParserSpec
+                     , BrightwayExcelSpec
                      , UnitConversionSpec
                      , PluginSpec
                      , ServerSpec
@@ -251,6 +254,7 @@ test-suite lca-tests
                      , containers
                      , vector
                      , bytestring
+                     , zip-archive
                      , temporary
                      , time
                      , aeson


### PR DESCRIPTION
## What

Adds support for loading **Brightway Excel** (`.xlsx`) inventory databases, alongside the existing EcoSpold 2/1, SimaPro CSV and ILCD loaders. This is the generic interchange format that Brightway's `bw2io` reads and writes (its importer class is `ExcelImporter`, `format = "Excel"`).

A `.xlsx` file now loads like any other database — the format is detected from the extension, no config change required.

## How it works

- **Reading**: `.xlsx` is a zip of XML parts. It's unzipped with `zip-archive` and the inner parts parsed with the `xeno` DOM already used elsewhere. openpyxl (the writer) emits *inline strings* with *sparse cells*, so each cell is placed by its column reference rather than position, and the five XML entities are expanded.
- **Grammar**: single-sheet block stream — `Database` → `Activity` (metadata rows) → `Exchanges` labelled table. The exchange table is addressed **by header label**, because column order varies between real files. Exchange `type ∈ {production, technosphere, biosphere}`; `categories` split on `::` into compartment/sub.
- **Linking**: domain construction reuses the SimaPro UUID / compartment / unit helpers, so flows and units hash identically and resolve through the **existing** name-based within-DB and cross-DB passes — no new linking code. Technosphere inputs are keyed by the supplier's *reference product* (the key the supplier index matches on), with location preserved for geography-aware matching.
- **No silent drops**: unsupported parameter sections and activities lacking a reference product surface as warnings.

## Limitations (documented)

- Brightway parameter/formula sections are ignored (none present in the inventories tested).
- One `.xlsx` → one database; a file bundling several sub-databases merges into one.
- Biosphere flows match LCIA by name + compartment + unit — the same coverage caveat as every importer.

## Verification

- `cabal build` clean; full suite green.
- The new `BrightwayExcelSpec` exercises the parser on a **synthetic** in-memory workbook (inline strings, sparse columns, entity decoding, reordered headers, biosphere categories, within-file linking) — no third-party data committed.
- Activity counts match Brightway's own `bw2io` reference reader exactly on real exports (9/9 files); a full real-file load resolves within-file supplier links as expected.