### PR TITLE
fix(api): surface cross-DB invariant breakages as 4xx, not 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,10 @@
 ## [Unreleased]
 
 ### Changed
-- API: the supply-chain and aggregate endpoints now return HTTP 422 (instead of
-  500) when a process id is parseable but absent from the matrix index, or a
-  matrix solve fails — matching the rest of the cross-DB pipeline.
-- API: the `InvalidProcessId` error body now states the expected
-  `activity_uuid_product_uuid` format instead of a fixed string.
-- OpenAPI: schemas for `MissingSupplier`, `DependencyChoice`, `DependencyStatus`
-  and `DatabaseSetupInfo.availablePaths` (now a `PathCandidate` object rather
-  than a positional tuple) were aligned with the JSON the API already emits; the
-  emitted JSON is unchanged.
+- API: service errors no longer surface as HTTP 5xx. `InvalidUUID` now returns
+  400 and `FlowNotFound` returns 404 (both were 500), so malformed client UUIDs
+  and missing flows are reported as client errors — matching the rest of the
+  cross-DB pipeline.
 
 ## [0.5.0] - 2026-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- API: the supply-chain and aggregate endpoints now return HTTP 422 (instead of
+  500) when a process id is parseable but absent from the matrix index, or a
+  matrix solve fails — matching the rest of the cross-DB pipeline.
+- API: the `InvalidProcessId` error body now states the expected
+  `activity_uuid_product_uuid` format instead of a fixed string.
+- OpenAPI: schemas for `MissingSupplier`, `DependencyChoice`, `DependencyStatus`
+  and `DatabaseSetupInfo.availablePaths` (now a `PathCandidate` object rather
+  than a positional tuple) were aligned with the JSON the API already emits; the
+  emitted JSON is unchanged.
+
 ## [0.5.0] - 2026-02-02
 
 ### Added

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -144,7 +144,7 @@ getDatabases = do
 
 -- | Load a database on demand
 loadDatabaseHandler :: Text -> AppM LoadDatabaseResponse
-loadDatabaseHandler dbName= do
+loadDatabaseHandler dbName = do
     dbManager <- asks aeDbManager
     eitherResult <- liftIO $ try $ loadDatabase dbManager dbName
     case eitherResult of
@@ -166,7 +166,7 @@ dependency databases. Lets the user recover from loads that happened in a
 suboptimal order without reloading the whole database.
 -}
 relinkDatabaseHandler :: Text -> AppM RelinkResponse
-relinkDatabaseHandler dbName= do
+relinkDatabaseHandler dbName = do
     dbManager <- asks aeDbManager
     res <- liftIO $ relinkDatabase dbManager dbName
     case res of
@@ -189,7 +189,7 @@ deleteDatabaseHandler dbName = do
 
 -- | Upload a new database
 uploadDatabaseHandler :: UploadRequest -> AppM UploadResponse
-uploadDatabaseHandler req= do
+uploadDatabaseHandler req = do
     dbManager <- asks aeDbManager
     -- Decode base64 ZIP data
     let zipDataResult = B64.decode $ T.encodeUtf8 $ urFileData req
@@ -323,7 +323,7 @@ formatToText UnknownFormat = "unknown"
 Returns completeness, missing suppliers, and dependency suggestions
 -}
 getDatabaseSetupHandler :: Text -> AppM DatabaseSetupInfo
-getDatabaseSetupHandler dbName= do
+getDatabaseSetupHandler dbName = do
     dbManager <- asks aeDbManager
     eitherResult <- liftIO $ try $ getDatabaseSetupInfo dbManager dbName
     case eitherResult of
@@ -367,7 +367,7 @@ setDataPathHandler dbName body = do
 Builds matrices and makes it ready for queries
 -}
 finalizeDatabaseHandler :: Text -> AppM ActivateResponse
-finalizeDatabaseHandler dbName= do
+finalizeDatabaseHandler dbName = do
     dbManager <- asks aeDbManager
     eitherResult <- liftIO $ try $ finalizeDatabase dbManager dbName
     case eitherResult of
@@ -382,7 +382,7 @@ finalizeDatabaseHandler dbName= do
 Same flow as database upload but creates MethodConfig entry
 -}
 uploadMethodHandler :: UploadRequest -> AppM UploadResponse
-uploadMethodHandler req= do
+uploadMethodHandler req = do
     dbManager <- asks aeDbManager
     let zipDataResult = B64.decode $ T.encodeUtf8 $ urFileData req
     case zipDataResult of

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -479,9 +479,6 @@ resolveOrThrow db processIdText = do
     either throwServiceError pure (Service.validateProcessIdInMatrixIndex db pid)
     pure (pid, act)
 
-{- | Translate a Service-level error into the HTTP status used across the
-cross-DB LCIA paths.
--}
 {- | Pure mapping from a domain 'Service.ServiceError' to the HTTP error it
 surfaces as. Every constructor is a client-supplied invariant breakage, so all
 map to 4xx/422 — never 5xx. Kept pure (and separate from 'throwServiceError')

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -342,8 +342,7 @@ so callers can dispatch on tech vs bio.
 -}
 withValidatedFlow :: Database -> Text -> (FlowKind -> AppM a) -> AppM a
 withValidatedFlow db uuid action = do
-    validUuidText <- either throwServiceError pure (Service.validateUUID uuid)
-    validUuid <- maybe (throwError err400{errBody = "Invalid UUID format"}) pure (UUID.fromText validUuidText)
+    validUuid <- either throwServiceError pure (Service.validateUUID uuid)
     let lookups =
             [ TechKind <$> M.lookup validUuid (dbTechFlows db)
             , BioKind <$> M.lookup validUuid (dbBioFlows db)
@@ -483,15 +482,26 @@ resolveOrThrow db processIdText = do
 {- | Translate a Service-level error into the HTTP status used across the
 cross-DB LCIA paths.
 -}
+{- | Pure mapping from a domain 'Service.ServiceError' to the HTTP error it
+surfaces as. Every constructor is a client-supplied invariant breakage, so all
+map to 4xx/422 — never 5xx. Kept pure (and separate from 'throwServiceError')
+so the status contract is unit-testable without booting a server.
+-}
+serviceErrorToServerError :: Service.ServiceError -> ServerError
+serviceErrorToServerError = \case
+    Service.InvalidUUID msg -> err400{errBody = utf8Body msg}
+    Service.InvalidProcessId msg -> err400{errBody = utf8Body msg}
+    Service.ActivityNotFound _ -> err404{errBody = "Activity not found"}
+    Service.FlowNotFound _ -> err404{errBody = "Flow not found"}
+    -- MatrixError covers singular Sherman-Morrison, missing technosphere links,
+    -- and cross-DB unit-conversion failures — all client-submitted invariant
+    -- breakages. Surface as 422 like the rest of the cross-DB pipeline.
+    Service.MatrixError msg -> err422{errBody = utf8Body msg}
+  where
+    utf8Body = BSL.fromStrict . T.encodeUtf8
+
 throwServiceError :: Service.ServiceError -> AppM a
-throwServiceError (Service.ActivityNotFound _) = throwError err404{errBody = "Activity not found"}
-throwServiceError (Service.InvalidProcessId msg) = throwError err400{errBody = BSL.fromStrict $ T.encodeUtf8 msg}
--- MatrixError covers singular Sherman-Morrison, missing technosphere links,
--- and cross-DB unit-conversion failures — all client-submitted invariant
--- breakages. Surface as 422 like the rest of the cross-DB pipeline.
-throwServiceError (Service.MatrixError msg) = throwError err422{errBody = BSL.fromStrict $ T.encodeUtf8 msg}
-throwServiceError (Service.InvalidUUID _) = throwError err500{errBody = "Internal server error"}
-throwServiceError (Service.FlowNotFound _) = throwError err500{errBody = "Internal server error"}
+throwServiceError = throwError . serviceErrorToServerError
 
 -- | Load a method collection by name from the live DatabaseManager state.
 loadCollection :: Text -> AppM ([Method], [DamageCategory], [NormWeightSet], [ScoringSet])

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -9,7 +9,7 @@
 
 module API.Types where
 
-import API.JsonOptions (Stripped (..), strippedParseJSON, strippedToEncoding, strippedToJSON)
+import API.JsonOptions (Stripped (..))
 import Control.Lens ((&), (.~), (?~))
 import Data.Aeson
 import Data.Aeson.Types (Parser)
@@ -1070,8 +1070,8 @@ data AggregationGroup = AggregationGroup
     deriving (Generic)
     deriving (ToJSON, ToSchema) via (Stripped AggregationGroup)
 
--- JSON instances. All record types use API.JsonOptions.stripLowerPrefix
--- via the strippedToJSON/strippedToEncoding/strippedParseJSON helpers.
+-- JSON instances. Record types derive ToJSON/FromJSON/ToSchema via the
+-- API.JsonOptions.Stripped carrier, which strips the lowercase field prefix.
 -- Sum-only types (NodeType, EdgeType, FlowRole) keep default derivation.
 -- ToJSON / FromJSON / ToSchema for SearchResults a are standalone-derived
 -- alongside the data declaration above (line ~169).

--- a/src/Data/Validation.hs
+++ b/src/Data/Validation.hs
@@ -13,9 +13,7 @@ When both arms fail, the resulting 'Failure' carries both messages.
 module Data.Validation (
     Validation (..),
     toEither,
-    fromEither,
     failure,
-    success,
 ) where
 
 import Data.List.NonEmpty (NonEmpty)
@@ -47,18 +45,7 @@ toEither :: Validation e a -> Either e a
 toEither (Failure e) = Left e
 toEither (Success a) = Right a
 
--- | Inject an 'Either' into 'Validation'. Use 'fromEither' to lift a
--- short-circuiting parser into an accumulating context.
-fromEither :: Either e a -> Validation e a
-fromEither (Left e) = Failure e
-fromEither (Right a) = Success a
-
 -- | Build a singleton-error failure. Convenient for 'NonEmpty'-keyed
 -- validators where each leaf check produces exactly one error message.
 failure :: e -> Validation (NonEmpty e) a
 failure = Failure . NE.singleton
-
--- | Inject a value into 'Success'. Symmetric to 'failure'; useful in
--- chains where readability is helped by an explicit constructor.
-success :: a -> Validation e a
-success = Success

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -282,6 +282,8 @@ computeMappingStats = foldMap (tally . fmap snd . snd)
     tally (Just ByName) = one{msByName = 1}
     tally (Just BySynonym) = one{msBySynonym = 1}
     tally (Just ByFuzzy) = one{msByFuzzy = 1}
+    -- 'NoMatch' is not produced by the current matchers; this row exists only
+    -- to keep the match exhaustive. Counts as unmatched if ever introduced.
     tally (Just NoMatch) = one{msUnmatched = 1}
 
 {- | Precomputed CF lookup tables for one (database, method) pair.

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -129,11 +129,12 @@ data ServiceError
     | MatrixError Text -- Generic error from matrix computations
     deriving (Show)
 
--- | Validate UUID format
-validateUUID :: Text -> Either ServiceError Text
-validateUUID uuidText
-    | Just _ <- UUID.fromText uuidText = Right uuidText
-    | otherwise = Left $ InvalidUUID $ "Invalid UUID format: " <> uuidText
+-- | Validate UUID format, returning the parsed UUID so callers do not have to
+-- re-parse the text afterwards.
+validateUUID :: Text -> Either ServiceError UUID.UUID
+validateUUID uuidText = case UUID.fromText uuidText of
+    Just uuid -> Right uuid
+    Nothing -> Left $ InvalidUUID $ "Invalid UUID format: " <> uuidText
 
 -- | Parse ProcessId from text (activity_uuid_product_uuid format)
 parseProcessIdFromText :: Database -> Text -> Either ServiceError ProcessId

--- a/test/CrossLinkingSpec.hs
+++ b/test/CrossLinkingSpec.hs
@@ -18,6 +18,24 @@ import UnitConversion (defaultUnitConfig)
 spec :: Spec
 spec = do
     -- -----------------------------------------------------------------------
+    -- CrossDBLinkingStats Semigroup / Monoid
+    -- -----------------------------------------------------------------------
+    describe "CrossDBLinkingStats <>" $ do
+        it "sums unresolved-product counts per key and keeps the first blocker" $ do
+            let s1 = mempty{cdlUnresolvedProducts = M.fromList [("wheat", (2, NoNameMatch))]} :: CrossDBLinkingStats
+                s2 = mempty{cdlUnresolvedProducts = M.fromList [("wheat", (3, LocationUnavailable "FR")), ("maize", (1, NoNameMatch))]}
+                merged = s1 <> s2
+            M.lookup "wheat" (cdlUnresolvedProducts merged) `shouldBe` Just (5, NoNameMatch)
+            M.lookup "maize" (cdlUnresolvedProducts merged) `shouldBe` Just (1, NoNameMatch)
+
+        it "adds the scalar counters" $ do
+            let s1 = mempty{cdlTotalInputs = 4, cdlWasteExactLinks = 1} :: CrossDBLinkingStats
+                s2 = mempty{cdlTotalInputs = 6, cdlWasteAmbiguous = 2}
+            cdlTotalInputs (s1 <> s2) `shouldBe` 10
+            cdlWasteExactLinks (s1 <> s2) `shouldBe` 1
+            cdlWasteAmbiguous (s1 <> s2) `shouldBe` 2
+
+    -- -----------------------------------------------------------------------
     -- normalizeText
     -- -----------------------------------------------------------------------
     describe "normalizeText" $ do

--- a/test/RoutesSpec.hs
+++ b/test/RoutesSpec.hs
@@ -62,6 +62,10 @@ import System.Process (
  )
 import Test.Hspec
 
+import API.Routes (serviceErrorToServerError)
+import Servant.Server (errHTTPCode)
+import Service (ServiceError (..))
+
 -- | Resources owned for the lifetime of the spec, threaded via beforeAll.
 data Booted = Booted
     { bManager :: Manager
@@ -171,7 +175,28 @@ doPost b path = do
     httpLbs req (bManager b)
 
 spec :: Spec
-spec
+spec = do
+    errorMappingSpec
+    integrationSpec
+
+-- | Pure regression guard for the ServiceError -> HTTP status contract. Lives
+-- outside the booted-server block so it runs everywhere (incl. Windows) and
+-- needs no loaded database.
+errorMappingSpec :: Spec
+errorMappingSpec = describe "serviceErrorToServerError (HTTP status contract)" $ do
+    it "maps InvalidUUID to 400 (malformed client id, never 5xx)" $
+        errHTTPCode (serviceErrorToServerError (InvalidUUID "x")) `shouldBe` 400
+    it "maps InvalidProcessId to 400" $
+        errHTTPCode (serviceErrorToServerError (InvalidProcessId "x")) `shouldBe` 400
+    it "maps ActivityNotFound to 404" $
+        errHTTPCode (serviceErrorToServerError (ActivityNotFound "x")) `shouldBe` 404
+    it "maps FlowNotFound to 404" $
+        errHTTPCode (serviceErrorToServerError (FlowNotFound "x")) `shouldBe` 404
+    it "maps MatrixError to 422" $
+        errHTTPCode (serviceErrorToServerError (MatrixError "x")) `shouldBe` 422
+
+integrationSpec :: Spec
+integrationSpec
     | Info.os == "mingw32" =
         describe "Routes integration (skipped on Windows)" $
             it "subprocess teardown deadlocks on this platform" pending

--- a/test/ServiceSpec.hs
+++ b/test/ServiceSpec.hs
@@ -14,7 +14,7 @@ import API.Types (
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.Text (Text)
-import Data.UUID (nil)
+import Data.UUID (nil, toText)
 import Service (
     ServiceError (..),
     buildUnitGroups,
@@ -37,9 +37,9 @@ spec = do
     -- validateUUID
     -- -----------------------------------------------------------------------
     describe "validateUUID" $ do
-        it "accepts a well-formed UUID" $
+        it "accepts a well-formed UUID and returns the parsed value" $
             case validateUUID "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" of
-                Right t -> t `shouldBe` "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+                Right u -> toText u `shouldBe` "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
                 Left _ -> expectationFailure "Expected Right"
 
         it "rejects an empty string" $


### PR DESCRIPTION
## What

The `ServiceError → HTTP status` mapping had two constructors falling through to **HTTP 500**: `InvalidUUID` and `FlowNotFound`. Both are client-supplied invariant breakages, so they now return **400** and **404** respectively — no `ServiceError` maps to 5xx anymore.

Also in this slice:
- A pure `serviceErrorToServerError` mapping, so the `ServiceError → HTTP status` contract is unit-testable without booting a server (`RoutesSpec` now has a platform-independent regression guard).
- `validateUUID` returns the parsed `UUID` instead of the original text, removing a double-parse (and a now-unreachable error branch) in `withValidatedFlow`.
- Drive-by cleanup from the same sweep: drop unused `Data.Validation` helpers (`fromEither`, `success`), a comment fix in `API.Types`, an exhaustiveness comment in `Method.Mapping`, and whitespace in `DatabaseHandlers`.

## Why

These were meant to land with the #87 behavior-preserving cleanup sweep but were left uncommitted in the working tree. This is the behavior-*changing* part (status codes), so it's split out into its own PR.

## Tests

`cabal test` → 1114 examples, 0 failures. New `CrossDBLinkingStats` Semigroup/Monoid tests and the `serviceErrorToServerError` status-contract tests included.