### PR TITLE
Add macos-intel (x86_64) engine build target

### DIFF
--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -111,6 +111,12 @@ jobs:
           - name: macos-arm64
             runner: macos-15
             os: macos
+          # Intel macOS via GitHub's last x86_64 hosted label. GitHub retires
+          # x86_64 macOS entirely in Aug 2027 — migrate to arm64-only or a
+          # self-hosted Intel runner before then.
+          - name: macos-intel
+            runner: macos-15-intel
+            os: macos
     env:
       MACOSX_DEPLOYMENT_TARGET: ${{ needs.versions.outputs.macos_target }}
       # Skip the brew formula refresh and post-install cleanup on every

--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -218,8 +218,13 @@ jobs:
           TAG="mumps-prebuilt-${MUMPS_VERSION}-r${MUMPS_PREBUILT_REVISION:-1}"
           PLATFORM='${{ matrix.name }}'
           ASSET="mumps-prebuilt-${PLATFORM}.tar.gz"
-          if ! gh release view "$TAG" -R "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-            echo "::warning::Prebuilt MUMPS release $TAG not found — falling back to source build (or cache). Trigger prebuild-mumps.yml to populate."
+          # Probe the asset, not just the release: a newly-added platform's
+          # asset may be absent from an existing release (e.g. first macos-intel
+          # build before prebuild-mumps.yml has published its tarball). Missing
+          # asset → fall through to the source build instead of failing here.
+          if ! gh release view "$TAG" -R "${GITHUB_REPOSITORY}" --json assets \
+                 --jq '.assets[].name' 2>/dev/null | grep -qx "$ASSET"; then
+            echo "::warning::Prebuilt MUMPS asset $ASSET (tag $TAG) not found — falling back to source build (or cache). Trigger prebuild-mumps.yml to populate."
             echo "populated=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -279,8 +284,12 @@ jobs:
           TAG="cabal-store-prebuilt-ghc${GHC_VERSION}-${HASH8}-r${REV}"
           PLATFORM='${{ matrix.name }}'
           ASSET="cabal-store-${PLATFORM}.tar.gz"
-          if ! gh release view "$TAG" -R "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-            echo "::warning::Cabal-store prebuilt $TAG not found — falling back to source build (or cache). Trigger prebuild-cabal-store.yml to populate."
+          # Probe the asset, not just the release (see MUMPS step): a newly-added
+          # platform's asset may be missing from an existing release. Missing
+          # asset → fall through to the source build instead of failing here.
+          if ! gh release view "$TAG" -R "${GITHUB_REPOSITORY}" --json assets \
+                 --jq '.assets[].name' 2>/dev/null | grep -qx "$ASSET"; then
+            echo "::warning::Cabal-store prebuilt asset $ASSET (tag $TAG) not found — falling back to source build (or cache). Trigger prebuild-cabal-store.yml to populate."
             echo "populated=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/prebuild-cabal-store.yml
+++ b/.github/workflows/prebuild-cabal-store.yml
@@ -66,6 +66,10 @@ jobs:
           - name: macos-arm64
             runner: macos-15
             os: macos
+          # Intel macOS — GitHub's last x86_64 hosted label (retires Aug 2027).
+          - name: macos-intel
+            runner: macos-15-intel
+            os: macos
     env:
       MACOSX_DEPLOYMENT_TARGET: ${{ needs.versions.outputs.macos_target }}
       HOMEBREW_NO_AUTO_UPDATE: '1'

--- a/.github/workflows/prebuild-mumps.yml
+++ b/.github/workflows/prebuild-mumps.yml
@@ -61,6 +61,10 @@ jobs:
           - name: macos-arm64
             runner: macos-15
             os: macos
+          # Intel macOS — GitHub's last x86_64 hosted label (retires Aug 2027).
+          - name: macos-intel
+            runner: macos-15-intel
+            os: macos
     env:
       MACOSX_DEPLOYMENT_TARGET: ${{ needs.versions.outputs.macos_target }}
       HOMEBREW_NO_AUTO_UPDATE: '1'

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 #   curl -fsSL https://raw.githubusercontent.com/ccomb/volca/main/install.sh | sh -s -- v0.7.0
 #
 # What it does:
-#   1. Detects platform (linux-amd64, linux-arm64, macos-arm64)
+#   1. Detects platform (linux-amd64, linux-arm64, macos-arm64, macos-intel)
 #   2. Downloads volca-<version>-<platform>.tar.gz from the GH Release
 #   3. Downloads volca-data-<data-version>.tar.gz (the reference data bundle)
 #   4. Verifies both against SHA256SUMS
@@ -55,7 +55,7 @@ case "$UNAME_S" in
         OS=macos
         case "$UNAME_M" in
             arm64) ARCH=arm64 ;;
-            x86_64) err "macOS x86_64 is not built — use macos-arm64 (Apple Silicon)" ;;
+            x86_64) ARCH=intel ;;
             *) err "unsupported macOS arch: $UNAME_M" ;;
         esac
         ;;


### PR DESCRIPTION
## What

Adds an Intel macOS (`macos-intel`, x86_64) build of the engine.

- New `macos-intel` row in the engine build matrix (`_build-matrix.yml`) and both prebuild workflows (`prebuild-mumps.yml`, `prebuild-cabal-store.yml`), on GitHub's `macos-15-intel` hosted runner.
- `install.sh` now resolves x86_64 Macs to the `macos-intel` asset instead of erroring out.

## Why

Intel Macs were explicitly unsupported. The macOS build scripts already resolve Homebrew via `brew --prefix`, so they pick up Intel's `/usr/local` prefix with no change; `MACOSX_DEPLOYMENT_TARGET=13.0` is arch-agnostic.

## Notes

- `macos-15-intel` is GitHub's last x86_64 hosted label; **GitHub drops x86_64 macOS support in Aug 2027** (noted inline in each matrix). Revisit then.
- Trigger `prebuild-mumps.yml` then `prebuild-cabal-store.yml` for `macos-intel` before the first release so the build doesn't cold-compile deps on the Intel runner (source-build fallback works regardless).