### PR TITLE
Configurable upload size limit

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -36,6 +36,8 @@ import Network.HTTP.Client (defaultManagerSettings, newManager)
 import Progress
 
 -- For server mode
+
+import API.DatabaseHandlers (uploadBodyCeiling)
 import API.Licenses (licensesResponse)
 import API.MCP (mcpApp, toolDefinitions)
 import API.Routes (lcaAPI, lcaServer, volcaOpenApi)
@@ -47,9 +49,10 @@ import qualified Data.ByteString.Lazy.Char8 as BSL
 import Data.String (fromString)
 import Network.HTTP.Types (status200)
 import Network.HTTP.Types.Header (hCacheControl, hContentType, hPragma)
-import Network.Wai (Application, Request (..), Response, ResponseReceived, mapResponseHeaders, pathInfo, rawPathInfo, rawQueryString, requestHeaders, requestMethod, responseLBS, responseStream)
+import Network.Wai (Application, Middleware, Request (..), Response, ResponseReceived, mapResponseHeaders, pathInfo, rawPathInfo, rawQueryString, requestHeaders, requestMethod, responseLBS, responseStream)
 import Network.Wai.Application.Static (StaticSettings, defaultWebAppSettings, ssIndices, staticApp)
 import Network.Wai.Handler.Warp (defaultSettings, runSettings, setPort, setTimeout)
+import Network.Wai.Middleware.RequestSizeLimit (defaultRequestSizeLimitSettings, requestSizeLimitMiddleware, setMaxLengthForRequest)
 import Servant (serve)
 import WaiAppStatic.Types (MaxAge (..), ssMaxAge, unsafeToPiece)
 
@@ -200,6 +203,18 @@ wrapWithMiddleware password lastRequestRef idleActiveRef baseApp =
             Just pwd -> authMiddleware (C8.pack pwd) withIdleAndShutdown
             Nothing -> withIdleAndShutdown
 
+{- | Reject oversized upload requests at the HTTP layer, before the body is
+buffered into memory. The per-request ceiling comes from 'uploadBodyCeiling',
+so the unlimited tier is never bounded and only the policy-governed upload
+routes are capped. This backstops the in-handler 'checkUploadSize'.
+-}
+uploadSizeLimitMiddleware :: Maybe HostingConfig -> Middleware
+uploadSizeLimitMiddleware hostingConfig =
+    requestSizeLimitMiddleware $
+        setMaxLengthForRequest
+            (pure . uploadBodyCeiling hostingConfig . pathInfo)
+            defaultRequestSizeLimitSettings
+
 -- | Run server with multi-database configuration file
 runServerWithConfig :: CLIConfig -> ServerOptions -> FilePath -> IO ()
 runServerWithConfig cliConfig serverOpts cfgFile = do
@@ -222,7 +237,9 @@ runServerWithConfig cliConfig serverOpts cfgFile = do
             password
             (cfgHosting config)
             (cfgClassificationPresets config)
-    let finalApp = wrapWithMiddleware password lastRequestRef idleActiveRef baseApp
+    let finalApp =
+            uploadSizeLimitMiddleware (cfgHosting config) $
+                wrapWithMiddleware password lastRequestRef idleActiveRef baseApp
         settings = setTimeout 600 (setPort port defaultSettings)
     runSettings settings finalApp
 

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -43,6 +43,7 @@ module API.DatabaseHandlers (
     simpleAction,
     formatToText,
     checkUploadSize,
+    uploadBodyCeiling,
 ) where
 
 import Control.Exception (SomeException, try)
@@ -56,6 +57,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as T
+import Data.Word (Word64)
 import Servant (Header, Headers, addHeader, err400, err404, err500, errBody, throwError)
 import qualified System.Directory
 import System.FilePath ((</>))
@@ -79,8 +81,10 @@ import API.Types (
     UploadRequest (..),
     UploadResponse (..),
  )
+import App.Env (AppEnv (..), AppM)
 import Config (DatabaseConfig (..), HostingConfig (..), MethodConfig (..), RefDataConfig (..))
 import Control.Concurrent.STM (readTVarIO)
+import Control.Monad.Reader (asks)
 import Data.Aeson (Value, toJSON)
 import qualified Data.Aeson as A
 import qualified Data.Aeson.KeyMap as KM
@@ -133,8 +137,6 @@ import Database.Upload (
  )
 import qualified Database.UploadedDatabase as UploadedDB
 import Types (Database (..), GeographyPolicy (..), unresolvedCount)
-import App.Env (AppEnv (..), AppM)
-import Control.Monad.Reader (asks)
 
 -- | List all databases
 getDatabases :: AppM DatabaseListResponse
@@ -209,6 +211,37 @@ checkUploadSize (Just hc) sizeBytes =
                         <> T.pack (show limitMb)
                         <> " MB."
             | otherwise -> Right ()
+
+{- | The WAI-level request-body ceiling (in bytes) for a request path, or
+'Nothing' for no limit. This is the outer, pre-buffering backstop for
+'checkUploadSize': only the database and method upload routes are bounded, and
+only when the hosting config sets a positive cap. base64 inflates the payload by
+~4/3 and the JSON envelope adds a little more, so we admit 2x the policy limit at
+the HTTP layer — files between the real limit and that ceiling still reach the
+handler, which returns the precise 'checkUploadSize' error. Unlimited (-1),
+disabled (0), and local/CLI (no config) are left unbounded here: neither
+unlimited nor disabled is a size bound, and the handler still rejects disabled
+uploads.
+-}
+uploadBodyCeiling :: Maybe HostingConfig -> [Text] -> Maybe Word64
+uploadBodyCeiling hostingConfig path
+    | not (isPolicyUploadPath path) = Nothing
+    | otherwise = case hostingConfig of
+        Nothing -> Nothing
+        Just hc
+            | hcMaxUploadMb hc > 0 -> Just (fromIntegral (hcMaxUploadMb hc) * 2 * 1024 * 1024)
+            | otherwise -> Nothing
+
+{- | The upload routes governed by the size policy. These mirror the @db/upload@
+and @method-collections/upload@ endpoints in "API.Routes"; the reference-data CSV
+upload routes are intentionally excluded (small files, outside the policy).
+-}
+isPolicyUploadPath :: [Text] -> Bool
+isPolicyUploadPath path =
+    path
+        `elem` [ ["api", "v1", "db", "upload"]
+               , ["api", "v1", "method-collections", "upload"]
+               ]
 
 {- | Decode the base64 upload payload and enforce the hosting size policy,
 then hand the raw bytes to the continuation. Shared by the database and

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -42,10 +42,12 @@ module API.DatabaseHandlers (
     convertDbStatus,
     simpleAction,
     formatToText,
+    checkUploadSize,
 ) where
 
 import Control.Exception (SomeException, try)
 import Control.Monad.IO.Class (liftIO)
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.Lazy as BSL
 import Data.List (isPrefixOf)
@@ -77,7 +79,7 @@ import API.Types (
     UploadRequest (..),
     UploadResponse (..),
  )
-import Config (DatabaseConfig (..), MethodConfig (..), RefDataConfig (..))
+import Config (DatabaseConfig (..), HostingConfig (..), MethodConfig (..), RefDataConfig (..))
 import Control.Concurrent.STM (readTVarIO)
 import Data.Aeson (Value, toJSON)
 import qualified Data.Aeson as A
@@ -187,68 +189,99 @@ deleteDatabaseHandler dbName = do
     dbManager <- asks aeDbManager
     simpleAction (removeDatabase dbManager dbName) ("Deleted database: " <> dbName)
 
--- | Upload a new database
-uploadDatabaseHandler :: UploadRequest -> AppM UploadResponse
-uploadDatabaseHandler req = do
-    dbManager <- asks aeDbManager
-    -- Decode base64 ZIP data
-    let zipDataResult = B64.decode $ T.encodeUtf8 $ urFileData req
-    case zipDataResult of
+{- | Enforce the hosting upload-size policy on a decoded payload.
+Local/CLI mode (no hosting config) is unlimited. A configured limit of 0
+disables uploads; a negative limit is unlimited; a positive limit caps the
+size in megabytes. Returns the failure message to surface, or () to proceed.
+-}
+checkUploadSize :: Maybe HostingConfig -> Int -> Either Text ()
+checkUploadSize Nothing _ = Right ()
+checkUploadSize (Just hc) sizeBytes =
+    case hcMaxUploadMb hc of
+        0 -> Left "Uploads are disabled on this plan."
+        limitMb
+            | limitMb < 0 -> Right ()
+            | sizeBytes > limitMb * 1024 * 1024 ->
+                Left $
+                    "File too large ("
+                        <> T.pack (show (sizeBytes `div` (1024 * 1024)))
+                        <> " MB). The upload limit on this plan is "
+                        <> T.pack (show limitMb)
+                        <> " MB."
+            | otherwise -> Right ()
+
+{- | Decode the base64 upload payload and enforce the hosting size policy,
+then hand the raw bytes to the continuation. Shared by the database and
+method upload handlers so both gate on one rule.
+-}
+withUploadBytes :: UploadRequest -> (BS.ByteString -> AppM UploadResponse) -> AppM UploadResponse
+withUploadBytes req k =
+    case B64.decode (T.encodeUtf8 (urFileData req)) of
         Left err -> return $ UploadResponse False ("Invalid base64 data: " <> T.pack err) Nothing Nothing
         Right zipBytes -> do
-            let uploadData =
-                    UploadData
-                        { udName = urName req
-                        , udDescription = urDescription req
-                        , udZipData = BSL.fromStrict zipBytes
-                        }
-            -- Handle the upload (extract, detect format)
-            uploadsDir <- liftIO UploadedDB.getDatabaseUploadsDir
-            result <- liftIO $ handleUpload uploadsDir uploadData (\_ -> return ())
+            hostingConfig <- asks aeHostingConfig
+            case checkUploadSize hostingConfig (BS.length zipBytes) of
+                Left rejection -> return $ UploadResponse False rejection Nothing Nothing
+                Right () -> k zipBytes
 
-            case result of
-                Left err ->
-                    return $ UploadResponse False err Nothing Nothing
-                Right uploadResult -> do
-                    let uploadDir = uploadsDir </> T.unpack (urSlug uploadResult)
+-- | Upload a new database
+uploadDatabaseHandler :: UploadRequest -> AppM UploadResponse
+uploadDatabaseHandler req =
+    withUploadBytes req $ \zipBytes -> do
+        dbManager <- asks aeDbManager
+        let uploadData =
+                UploadData
+                    { udName = urName req
+                    , udDescription = urDescription req
+                    , udZipData = BSL.fromStrict zipBytes
+                    }
+        -- Handle the upload (extract, detect format)
+        uploadsDir <- liftIO UploadedDB.getDatabaseUploadsDir
+        result <- liftIO $ handleUpload uploadsDir uploadData (\_ -> return ())
 
-                    -- Create meta.toml for self-describing upload
-                    let meta =
-                            UploadedDB.UploadMeta
-                                { UploadedDB.umVersion = 1
-                                , UploadedDB.umDisplayName = urName req
-                                , UploadedDB.umDescription = urDescription req
-                                , UploadedDB.umFormat = urFormat uploadResult -- Types are now unified
-                                , UploadedDB.umDataPath = makeRelative uploadDir (urPath uploadResult)
-                                }
-                    liftIO $ UploadedDB.writeUploadMeta uploadDir meta
+        case result of
+            Left err ->
+                return $ UploadResponse False err Nothing Nothing
+            Right uploadResult -> do
+                let uploadDir = uploadsDir </> T.unpack (urSlug uploadResult)
 
-                    -- Create database config for in-memory manager
-                    let dbConfig =
-                            DatabaseConfig
-                                { dcName = urSlug uploadResult
-                                , dcDisplayName = urName req
-                                , dcPath = urPath uploadResult
-                                , dcDescription = urDescription req
-                                , dcLoad = False -- Don't auto-load
-                                , dcDefault = False
-                                , dcDepends = []
-                                , dcLocationAliases = M.empty
-                                , dcFormat = Just (urFormat uploadResult)
-                                , dcIsUploaded = True -- Freshly uploaded database
-                                , dcDeletable = True
-                                , dcGeographyPolicy = GeoGlobal
-                                }
+                -- Create meta.toml for self-describing upload
+                let meta =
+                        UploadedDB.UploadMeta
+                            { UploadedDB.umVersion = 1
+                            , UploadedDB.umDisplayName = urName req
+                            , UploadedDB.umDescription = urDescription req
+                            , UploadedDB.umFormat = urFormat uploadResult -- Types are now unified
+                            , UploadedDB.umDataPath = makeRelative uploadDir (urPath uploadResult)
+                            }
+                liftIO $ UploadedDB.writeUploadMeta uploadDir meta
 
-                    -- Add to manager
-                    liftIO $ addDatabase dbManager dbConfig
+                -- Create database config for in-memory manager
+                let dbConfig =
+                        DatabaseConfig
+                            { dcName = urSlug uploadResult
+                            , dcDisplayName = urName req
+                            , dcPath = urPath uploadResult
+                            , dcDescription = urDescription req
+                            , dcLoad = False -- Don't auto-load
+                            , dcDefault = False
+                            , dcDepends = []
+                            , dcLocationAliases = M.empty
+                            , dcFormat = Just (urFormat uploadResult)
+                            , dcIsUploaded = True -- Freshly uploaded database
+                            , dcDeletable = True
+                            , dcGeographyPolicy = GeoGlobal
+                            }
 
-                    return $
-                        UploadResponse
-                            True
-                            "Database uploaded successfully"
-                            (Just $ urSlug uploadResult)
-                            (Just $ formatToText $ urFormat uploadResult)
+                -- Add to manager
+                liftIO $ addDatabase dbManager dbConfig
+
+                return $
+                    UploadResponse
+                        True
+                        "Database uploaded successfully"
+                        (Just $ urSlug uploadResult)
+                        (Just $ formatToText $ urFormat uploadResult)
 
 -- | Convert DatabaseManager.DatabaseStatus to API.DatabaseStatusAPI
 convertDbStatus :: DatabaseStatus -> DatabaseStatusAPI
@@ -383,59 +416,56 @@ finalizeDatabaseHandler dbName = do
 Same flow as database upload but creates MethodConfig entry
 -}
 uploadMethodHandler :: UploadRequest -> AppM UploadResponse
-uploadMethodHandler req = do
-    dbManager <- asks aeDbManager
-    let zipDataResult = B64.decode $ T.encodeUtf8 $ urFileData req
-    case zipDataResult of
-        Left err -> return $ UploadResponse False ("Invalid base64 data: " <> T.pack err) Nothing Nothing
-        Right zipBytes -> do
-            let uploadData =
-                    UploadData
-                        { udName = urName req
-                        , udDescription = urDescription req
-                        , udZipData = BSL.fromStrict zipBytes
-                        }
-            uploadsDir <- liftIO UploadedDB.getMethodUploadsDir
-            result <- liftIO $ handleUpload uploadsDir uploadData (\_ -> return ())
-            case result of
-                Left err ->
-                    return $ UploadResponse False err Nothing Nothing
-                Right uploadResult -> do
-                    let uploadDir = uploadsDir </> T.unpack (urSlug uploadResult)
+uploadMethodHandler req =
+    withUploadBytes req $ \zipBytes -> do
+        dbManager <- asks aeDbManager
+        let uploadData =
+                UploadData
+                    { udName = urName req
+                    , udDescription = urDescription req
+                    , udZipData = BSL.fromStrict zipBytes
+                    }
+        uploadsDir <- liftIO UploadedDB.getMethodUploadsDir
+        result <- liftIO $ handleUpload uploadsDir uploadData (\_ -> return ())
+        case result of
+            Left err ->
+                return $ UploadResponse False err Nothing Nothing
+            Right uploadResult -> do
+                let uploadDir = uploadsDir </> T.unpack (urSlug uploadResult)
 
-                    -- Find the actual method XML directory (e.g. ILCD/lciamethods/)
-                    methodDir <- liftIO $ findMethodDirectory uploadDir
+                -- Find the actual method XML directory (e.g. ILCD/lciamethods/)
+                methodDir <- liftIO $ findMethodDirectory uploadDir
 
-                    -- Create meta.toml (store path relative to upload dir)
-                    let meta =
-                            UploadedDB.UploadMeta
-                                { UploadedDB.umVersion = 1
-                                , UploadedDB.umDisplayName = urName req
-                                , UploadedDB.umDescription = urDescription req
-                                , UploadedDB.umFormat = urFormat uploadResult
-                                , UploadedDB.umDataPath = makeRelative uploadDir methodDir
-                                }
-                    liftIO $ UploadedDB.writeUploadMeta uploadDir meta
+                -- Create meta.toml (store path relative to upload dir)
+                let meta =
+                        UploadedDB.UploadMeta
+                            { UploadedDB.umVersion = 1
+                            , UploadedDB.umDisplayName = urName req
+                            , UploadedDB.umDescription = urDescription req
+                            , UploadedDB.umFormat = urFormat uploadResult
+                            , UploadedDB.umDataPath = makeRelative uploadDir methodDir
+                            }
+                liftIO $ UploadedDB.writeUploadMeta uploadDir meta
 
-                    -- Create MethodConfig and add to manager
-                    let mc =
-                            MethodConfig
-                                { mcName = urName req
-                                , mcPath = methodDir
-                                , mcActive = False
-                                , mcIsUploaded = True
-                                , mcDescription = urDescription req
-                                , mcFormat = Just $ formatToText $ urFormat uploadResult
-                                , mcScoringSets = []
-                                }
-                    liftIO $ addMethodCollection dbManager mc
+                -- Create MethodConfig and add to manager
+                let mc =
+                        MethodConfig
+                            { mcName = urName req
+                            , mcPath = methodDir
+                            , mcActive = False
+                            , mcIsUploaded = True
+                            , mcDescription = urDescription req
+                            , mcFormat = Just $ formatToText $ urFormat uploadResult
+                            , mcScoringSets = []
+                            }
+                liftIO $ addMethodCollection dbManager mc
 
-                    return $
-                        UploadResponse
-                            True
-                            "Method uploaded successfully"
-                            (Just $ urSlug uploadResult)
-                            (Just $ formatToText $ urFormat uploadResult)
+                return $
+                    UploadResponse
+                        True
+                        "Method uploaded successfully"
+                        (Just $ urSlug uploadResult)
+                        (Just $ formatToText $ urFormat uploadResult)
 
 -- | Delete an uploaded method collection
 deleteMethodHandler :: Text -> AppM ActivateResponse

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1066,6 +1066,7 @@ getHosting = do
             object
                 [ "is_hosted" .= True
                 , "max_uploads" .= Config.hcMaxUploads hc
+                , "max_upload_mb" .= Config.hcMaxUploadMb hc
                 , "api_access" .= Config.hcApiAccess hc
                 , "upgrade_upload" .= Config.hcUpgradeUpload hc
                 , "upgrade_api" .= Config.hcUpgradeApi hc
@@ -1075,6 +1076,7 @@ getHosting = do
             object
                 [ "is_hosted" .= False
                 , "max_uploads" .= (-1 :: Int)
+                , "max_upload_mb" .= (-1 :: Int)
                 , "api_access" .= True
                 , "upgrade_upload" .= ("" :: Text)
                 , "upgrade_api" .= ("" :: Text)

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -82,6 +82,7 @@ data Config = Config
 -- | Hosting configuration for managed VoLCA instances
 data HostingConfig = HostingConfig
     { hcMaxUploads :: !Int -- Max database uploads (-1 = unlimited, 0 = disabled)
+    , hcMaxUploadMb :: !Int -- Max upload size in MB (-1 = unlimited, 0 = disabled)
     , hcApiAccess :: !Bool -- Programmatic API access allowed
     , hcUpgradeUpload :: !Text -- Upgrade message when upload restricted
     , hcUpgradeApi :: !Text -- Upgrade message when API restricted
@@ -263,6 +264,7 @@ instance DecodeTOML RefDataConfig where
 instance DecodeTOML HostingConfig where
     tomlDecoder = do
         hcMaxUploads <- fromMaybe (-1) <$> getFieldOpt "max_uploads"
+        hcMaxUploadMb <- fromMaybe 100 <$> getFieldOpt "max_upload_mb"
         hcApiAccess <- fromMaybe True <$> getFieldOpt "api_access"
         hcUpgradeUpload <- fromMaybe "" <$> getFieldOpt "upgrade_upload"
         hcUpgradeApi <- fromMaybe "" <$> getFieldOpt "upgrade_api"

--- a/test/UploadSizeSpec.hs
+++ b/test/UploadSizeSpec.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module UploadSizeSpec (spec) where
+
+import API.DatabaseHandlers (checkUploadSize)
+import Config (HostingConfig (..))
+import Data.Either (isLeft)
+import Test.Hspec
+
+-- | A hosting config with the given upload-size limit (in MB); other fields are irrelevant here.
+hostingWithLimit :: Int -> HostingConfig
+hostingWithLimit limitMb =
+    HostingConfig
+        { hcMaxUploads = -1
+        , hcMaxUploadMb = limitMb
+        , hcApiAccess = True
+        , hcUpgradeUpload = ""
+        , hcUpgradeApi = ""
+        , hcUpgradeVmSize = ""
+        }
+
+mb :: Int -> Int
+mb n = n * 1024 * 1024
+
+spec :: Spec
+spec = describe "checkUploadSize" $ do
+    it "allows any size with no hosting config (local / CLI / desktop)" $
+        checkUploadSize Nothing (mb 5000) `shouldBe` Right ()
+
+    it "is unlimited when the configured limit is negative" $
+        checkUploadSize (Just (hostingWithLimit (-1))) (mb 5000) `shouldBe` Right ()
+
+    it "disables uploads entirely when the limit is zero" $
+        checkUploadSize (Just (hostingWithLimit 0)) 1
+            `shouldBe` Left "Uploads are disabled on this plan."
+
+    it "accepts a file exactly at the limit" $
+        checkUploadSize (Just (hostingWithLimit 100)) (mb 100) `shouldBe` Right ()
+
+    it "rejects a file one byte over the limit" $
+        checkUploadSize (Just (hostingWithLimit 100)) (mb 100 + 1) `shouldSatisfy` isLeft

--- a/test/UploadSizeSpec.hs
+++ b/test/UploadSizeSpec.hs
@@ -2,9 +2,10 @@
 
 module UploadSizeSpec (spec) where
 
-import API.DatabaseHandlers (checkUploadSize)
+import API.DatabaseHandlers (checkUploadSize, uploadBodyCeiling)
 import Config (HostingConfig (..))
 import Data.Either (isLeft)
+import Data.Word (Word64)
 import Test.Hspec
 
 -- | A hosting config with the given upload-size limit (in MB); other fields are irrelevant here.
@@ -23,19 +24,47 @@ mb :: Int -> Int
 mb n = n * 1024 * 1024
 
 spec :: Spec
-spec = describe "checkUploadSize" $ do
-    it "allows any size with no hosting config (local / CLI / desktop)" $
-        checkUploadSize Nothing (mb 5000) `shouldBe` Right ()
+spec = do
+    describe "checkUploadSize" $ do
+        it "allows any size with no hosting config (local / CLI / desktop)" $
+            checkUploadSize Nothing (mb 5000) `shouldBe` Right ()
 
-    it "is unlimited when the configured limit is negative" $
-        checkUploadSize (Just (hostingWithLimit (-1))) (mb 5000) `shouldBe` Right ()
+        it "is unlimited when the configured limit is negative" $
+            checkUploadSize (Just (hostingWithLimit (-1))) (mb 5000) `shouldBe` Right ()
 
-    it "disables uploads entirely when the limit is zero" $
-        checkUploadSize (Just (hostingWithLimit 0)) 1
-            `shouldBe` Left "Uploads are disabled on this plan."
+        it "disables uploads entirely when the limit is zero" $
+            checkUploadSize (Just (hostingWithLimit 0)) 1
+                `shouldBe` Left "Uploads are disabled on this plan."
 
-    it "accepts a file exactly at the limit" $
-        checkUploadSize (Just (hostingWithLimit 100)) (mb 100) `shouldBe` Right ()
+        it "accepts a file exactly at the limit" $
+            checkUploadSize (Just (hostingWithLimit 100)) (mb 100) `shouldBe` Right ()
 
-    it "rejects a file one byte over the limit" $
-        checkUploadSize (Just (hostingWithLimit 100)) (mb 100 + 1) `shouldSatisfy` isLeft
+        it "rejects a file one byte over the limit" $
+            checkUploadSize (Just (hostingWithLimit 100)) (mb 100 + 1) `shouldSatisfy` isLeft
+
+    describe "uploadBodyCeiling" $ do
+        let dbUpload = ["api", "v1", "db", "upload"]
+            methodUpload = ["api", "v1", "method-collections", "upload"]
+
+        it "does not bound non-upload paths" $
+            uploadBodyCeiling (Just (hostingWithLimit 100)) ["api", "v1", "search"] `shouldBe` Nothing
+
+        it "does not bound the reference-data CSV upload routes (out of policy)" $
+            uploadBodyCeiling (Just (hostingWithLimit 100)) ["api", "v1", "units", "upload"] `shouldBe` Nothing
+
+        it "does not bound uploads with no hosting config (local / CLI)" $
+            uploadBodyCeiling Nothing dbUpload `shouldBe` Nothing
+
+        it "does not bound uploads on the unlimited tier" $
+            uploadBodyCeiling (Just (hostingWithLimit (-1))) dbUpload `shouldBe` Nothing
+
+        it "does not bound at the HTTP layer when uploads are disabled (handler rejects)" $
+            uploadBodyCeiling (Just (hostingWithLimit 0)) dbUpload `shouldBe` Nothing
+
+        it "caps the db upload route at 2x the policy limit (base64 + JSON slack)" $
+            uploadBodyCeiling (Just (hostingWithLimit 100)) dbUpload
+                `shouldBe` Just (200 * 1024 * 1024 :: Word64)
+
+        it "caps the method upload route the same way" $
+            uploadBodyCeiling (Just (hostingWithLimit 50)) methodUpload
+                `shouldBe` Just (100 * 1024 * 1024 :: Word64)

--- a/volca.cabal
+++ b/volca.cabal
@@ -164,6 +164,7 @@ executable volca
                      , time
                      , warp
                      , wai
+                     , wai-extra >=3.1.1
                      , wai-app-static
                      , servant
                      , servant-server

--- a/volca.cabal
+++ b/volca.cabal
@@ -224,6 +224,7 @@ test-suite lca-tests
                      , MethodSetTablesSpec
                      , ChemSynonymsSpec
                      , UploadedDatabaseSpec
+                     , UploadSizeSpec
                      , ProgressSpec
                      , EcoSpold1Spec
                      , EcoSpold2Spec


### PR DESCRIPTION
## What

Makes the upload size limit configurable per hosting instance instead of being a client-only cap.

- New `max_upload_mb` field in the hosting config:
  - `100` — default when omitted
  - `-1` — unlimited
  - `0` — uploads disabled
- Enforced server-side in the database **and** method upload handlers via a shared pure `checkUploadSize` helper, behind a `withUploadBytes` front-door that also DRYs the base64 decode.
- Surfaced in `GET /api/v1/hosting` so clients can adapt (cap files, or hide the upload UI when disabled).
- With no hosting config (local / CLI), uploads remain unlimited.

## Why

Previously the engine accepted uploads of any size; the only limit lived in the web client. Operators of managed instances need a real, enforceable per-instance limit (and a way to turn uploads off).

## Tests

New `UploadSizeSpec` covers unlimited / disabled / within-limit / over-limit / no-config. Full suite: 1135 examples, 0 failures.