### PR TITLE
Make cross-DB dependency pin authoritative and persistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ active = true
 
 The `depends` field ensures dependency databases load first and their flows are available for cross-database linking. Setting `load = true` on a database transitively loads all its dependencies.
 
+A database's dependency set is **pinned**: it is seeded automatically when the database is first staged (the minimal set of supplier databases needed to resolve its links), and from then on it is authoritative. `relink` re-resolves links *within* the pinned set only — it never silently adds another loaded database. Edit the pin explicitly with `add-dependency` / `remove-dependency`, then `finalize`; the new set is written to the matrix cache and reused on every later open. This is how you restrict a consumer (e.g. an inventory built against a single Agribalyse version) to exactly the supplier databases it should depend on, even while other versions stay loaded for other consumers.
+
 ---
 
 ## REST API

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1451,9 +1451,11 @@ data RelinkResult = RelinkResult
     }
     deriving (Show, Eq)
 
-{- | Re-run cross-DB linking for an already-loaded DB against the current set
-of loaded dep DBs. Updates 'dbCrossDBLinks' and 'dbLinkingStats' in place
-in the LoadedDatabase record. Does NOT rebuild the technosphere matrix or
+{- | Re-run cross-DB linking for an already-loaded DB against its pinned
+dependency set ('dbDependsOn'), not the full set of loaded DBs. Updates
+'dbCrossDBLinks' and 'dbLinkingStats' in place in the LoadedDatabase record;
+the dependency set itself is left untouched (strict pin — it changes only via
+explicit add/remove-dependency). Does NOT rebuild the technosphere matrix or
 invalidate the MUMPS factorization — cross-DB links are consumed only at
 solve time.
 
@@ -1471,7 +1473,12 @@ relinkDatabase manager dbName = do
         Nothing -> return $ Left $ "Database not loaded: " <> dbName
         Just loaded -> do
             indexedDbs <- readTVarIO (dmIndexedDbs manager)
-            let otherIndexes = [idb | (n, idb) <- M.toList indexedDbs, n /= dbName]
+            -- Strict pin: candidates are restricted to the database's declared
+            -- dependency set ('dbDependsOn'), never the full set of loaded DBs.
+            -- This keeps the user's explicit selection authoritative — relink
+            -- recomputes links *within* the pin but never expands or shrinks it.
+            let pinnedDeps = dbDependsOn (ldDatabase loaded)
+                otherIndexes = [idb | (n, idb) <- M.toList indexedDbs, n /= dbName, n `elem` pinnedDeps]
             synonymDB <- getMergedSynonymDB manager
             unitConfig <- getMergedUnitConfig manager
             let db = ldDatabase loaded
@@ -1502,7 +1509,9 @@ relinkDatabase manager dbName = do
                         activityMap
                 newStats = rawStats{cdlTotalInputs = totalInputs}
                 newLinks = cdlLinks newStats
-                newDeps = M.keys (crossDBBySource newStats)
+                -- Strict pin: the dependency set is the user's selection,
+                -- unchanged by relinking. Only the links within it are refreshed.
+                newDeps = beforeDeps
                 !db' =
                     db
                         { dbCrossDBLinks = newLinks
@@ -2319,8 +2328,21 @@ finalizeDatabase manager dbName = do
                             -- Use pre-built database from cache, or build matrices from scratch
                             buildResult <- case sdCachedDB staged of
                                 Just cachedDb -> do
-                                    let db = BM25.addBM25Index (initializeRuntimeFields cachedDb synonymDB)
-                                    return $ Right (db, True)
+                                    -- The on-disk cache == cachedDb. Carry the
+                                    -- (possibly edited) staged dependency pin and
+                                    -- its recomputed links onto the loaded DB so
+                                    -- the pin is authoritative; flag a re-save
+                                    -- when either diverges from what's on disk.
+                                    let pinned =
+                                            cachedDb
+                                                { dbCrossDBLinks = sdCrossDBLinks staged
+                                                , dbDependsOn = sdSelectedDeps staged
+                                                , dbLinkingStats = sdLinkingStats staged
+                                                }
+                                        needsSave =
+                                            dbDependsOn cachedDb /= sdSelectedDeps staged
+                                                || dbCrossDBLinks cachedDb /= sdCrossDBLinks staged
+                                    return $ Right (BM25.addBM25Index (initializeRuntimeFields pinned synonymDB), needsSave)
                                 Nothing -> do
                                     unitConfig <- getMergedUnitConfig manager
                                     dbResult <-
@@ -2340,11 +2362,12 @@ finalizeDatabase manager dbName = do
                                                         , dbDependsOn = sdSelectedDeps staged
                                                         , dbLinkingStats = sdLinkingStats staged
                                                         }
-                                            return $ Right (BM25.addBM25Index (initializeRuntimeFields dbWithLinks synonymDB), False)
+                                            -- Freshly built matrices: always persist.
+                                            return $ Right (BM25.addBM25Index (initializeRuntimeFields dbWithLinks synonymDB), True)
 
                             case buildResult of
                                 Left err -> return $ Left err
-                                Right (dbWithRuntime, fromCache) -> do
+                                Right (dbWithRuntime, needsSave) -> do
                                     -- Create shared solver with lazy factorization (deferred to first query)
                                     let techTriplesInt = [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList (dbTechnosphereTriples dbWithRuntime)]
                                         activityCountInt = fromIntegral $ dbActivityCount dbWithRuntime
@@ -2374,19 +2397,24 @@ finalizeDatabase manager dbName = do
                                     -- is True) the matrix cache.
                                     relinkOutcome <- relinkDatabase manager dbName
 
-                                    -- Explicit cache save is only needed when
-                                    -- we built matrices fresh AND the relink
-                                    -- didn't already write the cache. The
-                                    -- 'Left' fallback preserves the original
-                                    -- "save iff fresh" behavior if relink
-                                    -- failed for some unexpected reason.
+                                    -- 'needsSave' marks a finalize that changed
+                                    -- something on disk (fresh build, or an
+                                    -- edited dependency pin on a cache hit). The
+                                    -- 'Left' fallback treats a failed relink as
+                                    -- "no relink write happened", so the explicit
+                                    -- save below still fires when needed.
                                     linksChangedAfter <- case relinkOutcome of
                                         Right rr -> return (rresLinksChanged rr)
                                         Left err -> do
                                             reportProgress Warning $
                                                 "Self-relink of " <> T.unpack dbName <> " failed: " <> T.unpack err
                                             return False
-                                    when (not fromCache && not linksChangedAfter) $
+                                    -- Persist when this finalize introduced a
+                                    -- change (fresh build, or an edited pin on a
+                                    -- cache hit) that the relink didn't already
+                                    -- write. relink owns the save whenever it
+                                    -- actually changed the in-memory links.
+                                    when (needsSave && not linksChangedAfter) $
                                         Loader.saveCachedDatabaseWithMatrices dbName (dcPath (sdConfig staged)) dbWithRuntime
 
                                     reportProgress Info $ "  [OK] Finalized: " <> T.unpack dbName

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1443,13 +1443,19 @@ data RelinkResult = RelinkResult
     , rresCrossDBLinks :: !Int
     , rresDepsLoaded :: ![Text]
     , rresLinksChanged :: !Bool
-    {- ^ True iff the relink actually changed 'dbCrossDBLinks' or
-    'dbDependsOn' versus the in-memory state before the call. Callers
-    use this to skip redundant work — e.g. the explicit cache write in
-    'finalizeDatabase' is suppressed when the relink already saved.
+    {- ^ True iff the relink actually changed 'dbCrossDBLinks' (as a set)
+    versus the in-memory state before the call. Callers use this to skip
+    redundant work — e.g. the explicit cache write in 'finalizeDatabase'
+    is suppressed when the relink already saved.
     -}
     }
     deriving (Show, Eq)
+
+-- | Order-insensitive equality for lists that are semantically sets
+-- (cross-DB links, dependency names). Avoids spurious cache re-saves when
+-- only the element order differs.
+sameSet :: Ord a => [a] -> [a] -> Bool
+sameSet xs ys = S.fromList xs == S.fromList ys
 
 {- | Re-run cross-DB linking for an already-loaded DB against its pinned
 dependency set ('dbDependsOn'), not the full set of loaded DBs. Updates
@@ -1461,7 +1467,7 @@ solve time.
 
 Side-effect: persists the updated 'Database' back to its matrix-cache file
 ('Loader.saveCachedDatabaseWithMatrices') whenever the relink actually
-changed 'dbCrossDBLinks' or 'dbDependsOn'. Without this, the next startup
+changed 'dbCrossDBLinks'. Without this, the next startup
 would re-load the stale cache and re-run cross-DB linking from scratch
 even though we already know the answer. The save is skipped when the
 relink is a no-op (no change vs. the in-memory state).
@@ -1520,7 +1526,10 @@ relinkDatabase manager dbName = do
                         }
                 !loaded' = loaded{ldDatabase = db'}
                 afterUnresolved = unresolvedCount newStats
-                linksChanged = newLinks /= beforeLinks || newDeps /= beforeDeps
+                -- The pin is invariant under relink (newDeps == beforeDeps), so a
+                -- change can only be in the links. Compare as sets: link order is
+                -- not significant and must not trigger a redundant cache write.
+                linksChanged = not (sameSet newLinks beforeLinks)
             atomically $ do
                 modifyTVar' (dmLoadedDbs manager) (M.insert dbName loaded')
                 modifyTVar'
@@ -2340,8 +2349,8 @@ finalizeDatabase manager dbName = do
                                                 , dbLinkingStats = sdLinkingStats staged
                                                 }
                                         needsSave =
-                                            dbDependsOn cachedDb /= sdSelectedDeps staged
-                                                || dbCrossDBLinks cachedDb /= sdCrossDBLinks staged
+                                            not (sameSet (dbDependsOn cachedDb) (sdSelectedDeps staged))
+                                                || not (sameSet (dbCrossDBLinks cachedDb) (sdCrossDBLinks staged))
                                     return $ Right (BM25.addBM25Index (initializeRuntimeFields pinned synonymDB), needsSave)
                                 Nothing -> do
                                     unitConfig <- getMergedUnitConfig manager

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1300,7 +1300,7 @@ data CrossDBLink = CrossDBLink
     another database — used to compute the minimal dependency pre-selection.
     -}
     }
-    deriving (Generic, NFData, Store, Show, Eq)
+    deriving (Generic, NFData, Store, Show, Eq, Ord)
 
 -- | Characterization factor (associated with an LCIA method)
 data CF = CF

--- a/test/StrictPinSpec.hs
+++ b/test/StrictPinSpec.hs
@@ -1,0 +1,267 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Regression test for the strict-dependency-pin behavior of
+'Database.Manager.relinkDatabase'.
+
+Before the fix, relink re-discovered cross-DB links against *every* loaded
+database and reset 'dbDependsOn' to whatever produced a link. A database
+opened from cache could therefore never have its dependency set reduced:
+each relink re-expanded it (and rewrote the cache). This was the GINKO
+symptom — pinning a consumer to a single Agribalyse version was impossible
+while other versions stayed loaded.
+
+The fix makes 'dbDependsOn' authoritative: relink restricts its candidate
+suppliers to the pinned set and never grows or shrinks that set. This test
+pins a consumer to @["alpha"]@ while *both* alpha and beta are indexed, and
+gives the consumer an input that only beta can supply. The pre-fix code
+would expand the pin to @["alpha","beta"]@; the fix keeps it at @["alpha"]@
+and leaves the beta-only input unresolved (surfaced, not silently linked).
+-}
+module StrictPinSpec (spec) where
+
+import Control.Concurrent.STM (atomically, modifyTVar', readTVarIO)
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.UUID as UUID
+import Test.Hspec
+
+import Config (DatabaseConfig (..), defaultConfig)
+import Database (buildDatabaseWithMatrices)
+import Database.CrossLinking (buildIndexedDatabaseFromDB)
+import Database.Manager (
+    DatabaseManager (..),
+    LoadedDatabase (..),
+    initDatabaseManager,
+    relinkDatabase,
+ )
+import SharedSolver (SharedSolver, createSharedSolver)
+import SynonymDB (emptySynonymDB)
+import Types (
+    Activity (..),
+    CrossDBLink (..),
+    Database (..),
+    Exchange (..),
+    GeographyPolicy (..),
+    SparseTriple (..),
+    TechRole (..),
+    TechnosphereFlow (..),
+    UUID,
+    Unit (..),
+ )
+import qualified Data.Vector.Unboxed as U
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import UnitConversion (defaultUnitConfig)
+
+spec :: Spec
+spec = describe "relinkDatabase strict dependency pin" $ do
+    it "keeps dbDependsOn at the pinned set and never re-expands to other loaded DBs" $
+      withSystemTempDirectory "volca-strict-pin" $ \tmp -> do
+        -- alpha supplies p1 only; beta supplies p1 and p2.
+        alphaDb <- buildOrFail (supplierDB 100 ["p1"])
+        betaDb <- buildOrFail (supplierDB 200 ["p1", "p2"])
+        -- consumer needs both p1 and p2.
+        consumerDb0 <- buildOrFail (consumerDB 300 ["p1", "p2"])
+        -- Pin the consumer to alpha only, with no links yet — relink populates them.
+        let consumerDb = consumerDb0{dbDependsOn = ["alpha"], dbCrossDBLinks = []}
+
+        manager <- initDatabaseManager defaultConfig True Nothing
+        solver <- mkSolver "consumer" consumerDb
+        let consumerLoaded =
+                LoadedDatabase
+                    { ldDatabase = consumerDb
+                    , ldSharedSolver = solver
+                    , ldConfig = consumerConfig (tmp </> "consumer-data")
+                    }
+        atomically $ do
+            modifyTVar' (dmLoadedDbs manager) (M.insert "consumer" consumerLoaded)
+            modifyTVar' (dmIndexedDbs manager) $
+                M.insert "alpha" (buildIndexedDatabaseFromDB "alpha" emptySynonymDB alphaDb)
+                    . M.insert "beta" (buildIndexedDatabaseFromDB "beta" emptySynonymDB betaDb)
+
+        result <- relinkDatabase manager "consumer"
+        result `shouldSatisfy` isRight
+
+        loaded <- readTVarIO (dmLoadedDbs manager)
+        let relinked = ldDatabase (loaded M.! "consumer")
+            linkSources = S.fromList (map cdlSourceDatabase (dbCrossDBLinks relinked))
+
+        -- The pin is preserved exactly — beta is NOT added even though it is
+        -- loaded and is the only supplier of p2.
+        dbDependsOn relinked `shouldBe` ["alpha"]
+        -- Every resolved link points into the pinned DB; beta never leaks in.
+        linkSources `shouldSatisfy` (`S.isSubsetOf` S.fromList ["alpha"])
+        -- p1 resolves against alpha; p2 (beta-only) stays unresolved.
+        length (dbCrossDBLinks relinked) `shouldBe` 1
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+
+isRight :: Either a b -> Bool
+isRight (Right _) = True
+isRight (Left _) = False
+
+buildOrFail :: SimpleParts -> IO Database
+buildOrFail (SimpleParts acts flows units) = do
+    r <- buildDatabaseWithMatrices defaultUnitConfig acts flows M.empty M.empty units
+    case r of
+        Right db -> pure db
+        Left err -> fail ("buildDatabaseWithMatrices: " <> show err)
+
+mkSolver :: Text -> Database -> IO SharedSolver
+mkSolver name db =
+    let triples = [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList (dbTechnosphereTriples db)]
+     in createSharedSolver name triples (fromIntegral (dbActivityCount db))
+
+consumerConfig :: FilePath -> DatabaseConfig
+consumerConfig path =
+    DatabaseConfig
+        { dcName = "consumer"
+        , dcDisplayName = "consumer"
+        , dcPath = path -- relink writes a cache next to this path when links change
+        , dcDescription = Nothing
+        , dcLoad = True
+        , dcDefault = False
+        , dcDepends = ["alpha"]
+        , dcLocationAliases = M.empty
+        , dcFormat = Nothing
+        , dcIsUploaded = False
+        , dcDeletable = False
+        , dcGeographyPolicy = GeoGlobal
+        }
+
+-- ---------------------------------------------------------------------------
+-- Fixture builders (in-memory, single unit "kg", all activities at GLO)
+-- ---------------------------------------------------------------------------
+
+data SimpleParts = SimpleParts
+    (M.Map (UUID, UUID) Activity)
+    (M.Map UUID TechnosphereFlow)
+    (M.Map UUID Unit)
+
+mkUUID :: Int -> UUID
+mkUUID n = UUID.fromWords64 (fromIntegral n) 0
+
+kgUnitId :: UUID
+kgUnitId = mkUUID 0
+
+kgUnit :: Unit
+kgUnit = Unit{unitId = kgUnitId, unitName = "kg", unitSymbol = "kg", unitComment = ""}
+
+mkTechFlow :: UUID -> Text -> TechnosphereFlow
+mkTechFlow fid name =
+    TechnosphereFlow
+        { tfId = fid
+        , tfName = name
+        , tfUnitId = kgUnitId
+        , tfSynonyms = M.empty
+        , tfCAS = Nothing
+        , tfSubstanceId = Nothing
+        }
+
+{- | A supplier DB: one activity per product name, each producing that
+product (reference output) at GLO. 'offset' keeps UUIDs disjoint across DBs.
+-}
+supplierDB :: Int -> [Text] -> SimpleParts
+supplierDB offset products =
+    let entries =
+            [ let actUUID = mkUUID (offset + 10 * i + 1)
+                  prodUUID = mkUUID (offset + 10 * i + 2)
+                  flowUUID = mkUUID (offset + 10 * i + 3)
+                  flow = mkTechFlow flowUUID name
+                  refOut =
+                      TechnosphereExchange
+                          { techFlowId = flowUUID
+                          , techAmount = 1.0
+                          , techUnitId = kgUnitId
+                          , techRole = ReferenceProduct
+                          , techActivityLinkId = actUUID
+                          , techProcessLinkId = Nothing
+                          , techLocation = ""
+                          , techComment = Nothing
+                          , techPedigree = Nothing
+                          }
+                  act =
+                      Activity
+                          { activityName = "supplier-of-" <> name
+                          , activityDescription = []
+                          , activitySynonyms = M.empty
+                          , activityClassification = M.empty
+                          , activityLocation = "GLO"
+                          , activityUnit = "kg"
+                          , exchanges = [refOut]
+                          , activityParams = M.empty
+                          , activityParamExprs = M.empty
+                          , activityAllocationPercent = Nothing
+                          , activityAllocationFormula = Nothing
+                          , activityNativeType = Nothing
+                          }
+               in (((actUUID, prodUUID), act), (flowUUID, flow))
+            | (i, name) <- zip [0 ..] products
+            ]
+     in SimpleParts
+            (M.fromList (map fst entries))
+            (M.fromList (map snd entries))
+            (M.singleton kgUnitId kgUnit)
+
+{- | A consumer DB: one activity per required product, each with a reference
+output and one unlinked technosphere input for that product (triggers the
+cross-DB lookup).
+-}
+consumerDB :: Int -> [Text] -> SimpleParts
+consumerDB offset products =
+    let entries =
+            [ let actUUID = mkUUID (offset + 10 * i + 1)
+                  prodUUID = mkUUID (offset + 10 * i + 2)
+                  inFlowUUID = mkUUID (offset + 10 * i + 3)
+                  outFlowUUID = mkUUID (offset + 10 * i + 4)
+                  inFlow = mkTechFlow inFlowUUID name
+                  outFlow = mkTechFlow outFlowUUID ("consumer-out-" <> name)
+                  refOut =
+                      TechnosphereExchange
+                          { techFlowId = outFlowUUID
+                          , techAmount = 1.0
+                          , techUnitId = kgUnitId
+                          , techRole = ReferenceProduct
+                          , techActivityLinkId = actUUID
+                          , techProcessLinkId = Nothing
+                          , techLocation = ""
+                          , techComment = Nothing
+                          , techPedigree = Nothing
+                          }
+                  unlinkedInput =
+                      TechnosphereExchange
+                          { techFlowId = inFlowUUID
+                          , techAmount = 1.0
+                          , techUnitId = kgUnitId
+                          , techRole = Input
+                          , techActivityLinkId = UUID.nil
+                          , techProcessLinkId = Nothing
+                          , techLocation = "GLO"
+                          , techComment = Nothing
+                          , techPedigree = Nothing
+                          }
+                  act =
+                      Activity
+                          { activityName = "consumer-" <> name
+                          , activityDescription = []
+                          , activitySynonyms = M.empty
+                          , activityClassification = M.empty
+                          , activityLocation = "GLO"
+                          , activityUnit = "kg"
+                          , exchanges = [refOut, unlinkedInput]
+                          , activityParams = M.empty
+                          , activityParamExprs = M.empty
+                          , activityAllocationPercent = Nothing
+                          , activityAllocationFormula = Nothing
+                          , activityNativeType = Nothing
+                          }
+               in (((actUUID, prodUUID), act), [(inFlowUUID, inFlow), (outFlowUUID, outFlow)])
+            | (i, name) <- zip [0 ..] products
+            ]
+     in SimpleParts
+            (M.fromList (map fst entries))
+            (M.fromList (concatMap snd entries))
+            (M.singleton kgUnitId kgUnit)

--- a/volca.cabal
+++ b/volca.cabal
@@ -208,6 +208,7 @@ test-suite lca-tests
                      , CrossLinkingSpec
                      , MinimalCoverSpec
                      , MinimalCoverIntegrationSpec
+                     , StrictPinSpec
                      , CrossDBInventorySpec
                      , CrossDBRegionalLCIASpec
                      , CrossDBRegionalLCIAFixture


### PR DESCRIPTION
## Problem

A database's cross-DB dependency set could never be reduced and made to stick. Opening a cached database (e.g. an inventory built against a single Agribalyse version) re-loaded *every* version it had ever linked against.

Root cause: `relinkDatabase` re-discovered links against **all** loaded databases and recomputed `dbDependsOn` from whatever produced a link — and that relink runs on **every** load from cache. Unchecking a dependency, or unloading it, never persisted: the next open re-expanded the set and rewrote the matrix cache with it. `autoLoadDeps` then re-loaded the full set from that cache.

## Fix

Treat `dbDependsOn` as a **strict pin**:

- `relinkDatabase` restricts its candidate suppliers to the pinned set and leaves the set itself untouched. Links are refreshed *within* the pin; it is never silently grown or shrunk.
- `finalizeDatabase` carries the staged pin onto the database on a cache hit and re-saves the cache when the pin or its links diverge from disk, so an edited selection survives the next open.

The pin is still seeded automatically at first staging (minimal cover), so fresh uploads keep proposing the right dependencies. Only later relinks defer to the explicit selection, which is edited via `add-dependency` / `remove-dependency` + `finalize`.

Inputs that resolved only through a now-removed dependency become **unresolved** and are surfaced at finalize, rather than re-linked behind the user's back.

## How to restrict an existing database

Open its setup, uncheck the unwanted dependencies, finalize. The new set is written to the matrix cache and reused on every later open — even while other databases stay loaded for other consumers.

## Tests

- New `test/StrictPinSpec.hs`: a consumer pinned to one supplier, with an input only a *second* loaded supplier can satisfy, keeps its pin and leaves that input unresolved instead of absorbing the second supplier. (Pre-fix, the pin would expand to both.)
- Full suite green: 1131 examples, 0 failures.