### PR TITLE
Update LICENSE + CI build-speed and reliability fixes

### DIFF
--- a/.github/actions/setup-haskell-env/action.yml
+++ b/.github/actions/setup-haskell-env/action.yml
@@ -139,7 +139,10 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: ~/.ghcup
-        key: ghcup-${{ inputs.matrix-name }}-ghc${{ inputs.ghc-version }}-v4
+        # -v5: the saved tree is now slimmed (see the trim at the end of the
+        # install step). Old -v4 snapshots are the full ~2-3 GB tree whose
+        # restore times out on macOS — bumping forces a fresh lean save.
+        key: ghcup-${{ inputs.matrix-name }}-ghc${{ inputs.ghc-version }}-v5
 
     # Bootstrap or restore GHCup into ~/.ghcup. We avoid haskell-actions/setup
     # because it symlinks to the runner's preinstalled /usr/local/.ghcup,
@@ -188,3 +191,17 @@ runs:
         # always refresh — cold installs need it, warm runs need a
         # current view for the solver.
         "$HOME/.ghcup/bin/cabal" update
+        # Slim ~/.ghcup before the caller caches it. The full tree (~2-3 GB,
+        # tens of thousands of small files) was overflowing the actions/cache
+        # macOS restore timeout, so every run fell back to a cold 4-5 min GHC
+        # reinstall — defeating the cache entirely. None of the removed bytes
+        # are needed to *build* a non-profiled binary:
+        #   cache/   ghcup's downloaded install tarballs (already unpacked)
+        #   tmp/     leftover unpack scratch dirs
+        #   share/doc GHC's bundled HTML/PDF documentation
+        #   *.p_o / *_p.a  profiling objects/libs (CI never builds profiled)
+        # Runs on warm restores too — a near-noop, since the saved tree is
+        # already slim. Best-effort: missing paths must not fail the build.
+        rm -rf "$HOME/.ghcup/cache" "$HOME/.ghcup/tmp" || true
+        rm -rf "$HOME/.ghcup/ghc/$GHC_VER/share/doc" || true
+        find "$HOME/.ghcup/ghc/$GHC_VER" \( -name '*.p_o' -o -name '*_p.a' \) -delete 2>/dev/null || true

--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -279,7 +279,11 @@ jobs:
           # Hash matches the prebuild-cabal-store.yml publish step exactly,
           # so a content change in any of these files always misses the
           # prebuilt and falls through to the cache + source build path.
-          HASH8=$(cat volca.cabal mumps-hs/mumps-hs.cabal cabal.project | sha256sum | cut -c1-8)
+          # volca.cabal's version/synopsis/description are stripped: they
+          # never affect the dependency closure, so a release bump must NOT
+          # invalidate the store (otherwise every `vX.Y.Z` PR forces a full
+          # 5-platform re-prebuild). Keep this filter identical in both files.
+          HASH8=$( { grep -vE '^(version|synopsis|description):' volca.cabal; cat mumps-hs/mumps-hs.cabal cabal.project; } | sha256sum | cut -c1-8)
           REV="${CABAL_PREBUILT_REVISION:-1}"
           TAG="cabal-store-prebuilt-ghc${GHC_VERSION}-${HASH8}-r${REV}"
           PLATFORM='${{ matrix.name }}'

--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -215,6 +215,21 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           source versions.env
+          # Retry `gh release view` so a transient API hiccup isn't read as a
+          # missing asset. Prints the asset list (rc 0) on a successful query;
+          # rc 1 only when every attempt failed (API error or release absent).
+          # Kept identical in the cabal-store probe step below.
+          gh_list_assets() {
+            local tag="$1" out
+            for attempt in 1 2 3; do
+              if out=$(gh release view "$tag" -R "${GITHUB_REPOSITORY}" --json assets --jq '.assets[].name' 2>/dev/null); then
+                printf '%s\n' "$out"; return 0
+              fi
+              echo "::notice::Querying release $tag failed (attempt $attempt/3) — retrying in 4s" >&2
+              sleep 4
+            done
+            return 1
+          }
           TAG="mumps-prebuilt-${MUMPS_VERSION}-r${MUMPS_PREBUILT_REVISION:-1}"
           PLATFORM='${{ matrix.name }}'
           ASSET="mumps-prebuilt-${PLATFORM}.tar.gz"
@@ -222,9 +237,20 @@ jobs:
           # asset may be absent from an existing release (e.g. first macos-intel
           # build before prebuild-mumps.yml has published its tarball). Missing
           # asset → fall through to the source build instead of failing here.
-          if ! gh release view "$TAG" -R "${GITHUB_REPOSITORY}" --json assets \
-                 --jq '.assets[].name' 2>/dev/null | grep -qx "$ASSET"; then
-            echo "::warning::Prebuilt MUMPS asset $ASSET (tag $TAG) not found — falling back to source build (or cache). Trigger prebuild-mumps.yml to populate."
+          #
+          # Distinguish a genuine absence from a transient API failure: piping
+          # `gh ... 2>/dev/null` straight into grep conflates the two, so a
+          # flaky `gh release view` silently downgraded the job to the slow
+          # source build even when the asset existed (observed on macos-arm64
+          # against a release that had it). Retry the query; only a *successful*
+          # query with the asset missing is a real miss.
+          if ! assets=$(gh_list_assets "$TAG"); then
+            echo "::warning::Could not query release $TAG after retries (API error or release absent) — falling back to source build (or cache)."
+            echo "populated=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! grep -qx "$ASSET" <<<"$assets"; then
+            echo "::warning::Prebuilt MUMPS asset $ASSET (tag $TAG) absent on the release — falling back to source build (or cache). Trigger prebuild-mumps.yml to populate."
             echo "populated=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -276,6 +302,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           source versions.env
+          # Retry `gh release view` so a transient API hiccup isn't read as a
+          # missing asset (see the MUMPS step above — kept identical here).
+          gh_list_assets() {
+            local tag="$1" out
+            for attempt in 1 2 3; do
+              if out=$(gh release view "$tag" -R "${GITHUB_REPOSITORY}" --json assets --jq '.assets[].name' 2>/dev/null); then
+                printf '%s\n' "$out"; return 0
+              fi
+              echo "::notice::Querying release $tag failed (attempt $attempt/3) — retrying in 4s" >&2
+              sleep 4
+            done
+            return 1
+          }
           # Hash matches the prebuild-cabal-store.yml publish step exactly,
           # so a content change in any of these files always misses the
           # prebuilt and falls through to the cache + source build path.
@@ -291,9 +330,13 @@ jobs:
           # Probe the asset, not just the release (see MUMPS step): a newly-added
           # platform's asset may be missing from an existing release. Missing
           # asset → fall through to the source build instead of failing here.
-          if ! gh release view "$TAG" -R "${GITHUB_REPOSITORY}" --json assets \
-                 --jq '.assets[].name' 2>/dev/null | grep -qx "$ASSET"; then
-            echo "::warning::Cabal-store prebuilt asset $ASSET (tag $TAG) not found — falling back to source build (or cache). Trigger prebuild-cabal-store.yml to populate."
+          if ! assets=$(gh_list_assets "$TAG"); then
+            echo "::warning::Could not query release $TAG after retries (API error or release absent) — falling back to source build (or cache)."
+            echo "populated=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! grep -qx "$ASSET" <<<"$assets"; then
+            echo "::warning::Cabal-store prebuilt asset $ASSET (tag $TAG) absent on the release — falling back to source build (or cache). Trigger prebuild-cabal-store.yml to populate."
             echo "populated=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -344,6 +344,12 @@ jobs:
 
       - name: Build and test
         if: needs.preflight.outputs.skip != 'true'
+        # PR/smoke builds compile volca's own code at -O1 (gen-cabal-config.sh
+        # turns this into a per-package override; deps stay -O2 so the prebuilt
+        # store still matches). Release builds keep -O2 — the packaged binary
+        # is built in this very step, so the level must be right here.
+        env:
+          VOLCA_OPT_LEVEL: ${{ inputs.release && '2' || '1' }}
         run: |
           # Windows: re-source GHCup env in this MSYS2 shell since the wrapper
           # does not inherit PATH from the previous step.

--- a/.github/workflows/prebuild-cabal-store.yml
+++ b/.github/workflows/prebuild-cabal-store.yml
@@ -186,14 +186,17 @@ jobs:
 
       - name: Read versions + cabal hash
         id: meta
-        # Hash inputs identical to _build-matrix.yml's cabal-store cache
-        # key, so content change there always implies a new prebuilt.
+        # Hash inputs identical to _build-matrix.yml's cabal-store probe, so
+        # content change there always implies a new prebuilt. version/synopsis/
+        # description are stripped from volca.cabal — they don't affect deps,
+        # so a release bump reuses the store. Keep this filter byte-identical
+        # to the one in _build-matrix.yml.
         shell: bash
         run: |
           source versions.env
           echo "ghc=$GHC_VERSION" >> "$GITHUB_OUTPUT"
           echo "rev=${CABAL_PREBUILT_REVISION:-1}" >> "$GITHUB_OUTPUT"
-          echo "hash=$(cat volca.cabal mumps-hs/mumps-hs.cabal cabal.project | sha256sum | cut -c1-8)" >> "$GITHUB_OUTPUT"
+          echo "hash=$( { grep -vE '^(version|synopsis|description):' volca.cabal; cat mumps-hs/mumps-hs.cabal cabal.project; } | sha256sum | cut -c1-8)" >> "$GITHUB_OUTPUT"
 
       - uses: ./.github/actions/publish-prebuilt-release
         with:

--- a/LICENSE
+++ b/LICENSE
@@ -32,28 +32,36 @@
       not limited to compiled object code, generated documentation,
       and conversions to other media types.
 
-      "Work" shall mean the work of authorship made available under
-      the License, as indicated by a copyright notice that is included in
-      or attached to the work (an example is provided in the Appendix below).
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
       "Derivative Works" shall mean any work, whether in Source or Object
       form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other transformations
+      editorial revisions, annotations, elaborations, or other modifications
       represent, as a whole, an original work of authorship. For the purposes
       of this License, Derivative Works shall not include works that remain
       separable from, or merely link (or bind by name) to the interfaces of,
       the Work and Derivative Works thereof.
 
-      "Contribution" shall mean any work of authorship, including the
-      original version of the Work and any modifications or additions to
-      that Work or Derivative Works of the Work, that is intentionally
-      submitted to the Licensor for inclusion in the Work by the copyright
-      owner or by an individual or Legal Entity authorized to submit on
-      behalf of the copyright owner.
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-      "Contributor" shall mean Licensor and any Legal Entity on behalf of
-      whom a Contribution has been received by the Licensor and incorporated
-      within the Work.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
    2. Grant of Copyright License. Subject to the terms and conditions of
       this License, each Contributor hereby grants to You a perpetual,
@@ -67,13 +75,15 @@
       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
       (except as stated in this section) patent license to make, have made,
       use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those Contributions made by
-      such Contributor as patent licenses necessarily infringed by their
-      Contribution(s) alone or by the combined work. If You institute patent
-      litigation against any entity (including a cross-claim or counterclaim
-      in a lawsuit) alleging that the Work or any related Contribution
-      constitutes patent or contributory patent infringement, then any patent
-      licenses granted to You under this License for that Work shall terminate
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
       as of the date such litigation is filed.
 
    4. Redistribution. You may reproduce and distribute copies of the
@@ -81,8 +91,8 @@
       modifications, and in Source or Object form, provided that You
       meet the following conditions:
 
-      (a) You must give any other recipients of the Work or Derivative
-          Works a copy of this License; and
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
       (b) You must cause any modified files to carry prominent notices
           stating that You changed the files; and
@@ -94,19 +104,28 @@
           the Derivative Works; and
 
       (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, You must include a readable copy of the
-          attribution notices contained within such NOTICE file, in
-          at least one of the following places: within a NOTICE text
-          file distributed as part of the Derivative Works; within
-          the Source form or documentation, if provided along with the
-          Derivative Works; or, within a display generated by the
-          Derivative Works, if and wherever such third-party notices
-          normally appear. The contents of the NOTICE file are for
-          informational purposes only and do not modify the License.
-          You may add Your own attribution notices within Derivative
-          Works that You distribute, alongside or in addition to the
-          NOTICE text from the Work, provided that such additional
-          attribution notices cannot be construed as modifying the License.
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
    5. Submission of Contributions. Unless You explicitly state otherwise,
       any Contribution intentionally submitted for inclusion in the Work
@@ -128,7 +147,7 @@
       implied, including, without limitation, any warranties or conditions
       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
       PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or reproducing the Work and assume any
+      appropriateness of using or redistributing the Work and assume any
       risks associated with Your exercise of permissions under this License.
 
    8. Limitation of Liability. In no event and under no legal theory,
@@ -136,23 +155,38 @@
       unless required by applicable law (such as deliberate and grossly
       negligent acts) or agreed to in writing, shall any Contributor be
       liable to You for damages, including any direct, indirect, special,
-      incidental, or exemplary damages of any character arising as a
+      incidental, or consequential damages of any character arising as a
       result of this License or out of the use or inability to use the
       Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or all other
-      commercial damages or losses), even if such Contributor has been
-      advised of the possibility of such damages.
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
    9. Accepting Warranty or Additional Liability. While redistributing
       the Work or Derivative Works thereof, You may choose to offer,
       and charge a fee for, acceptance of support, warranty, indemnity,
       or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may offer only
-      conditions consistent with this License.
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2025 Christophe Combelles
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/gen-cabal-config.sh
+++ b/gen-cabal-config.sh
@@ -17,6 +17,14 @@ MUMPS_INCLUDE_DIR="${MUMPS_INCLUDE_DIR:-/usr/include}"
 LINK_MODE="${LINK_MODE:-dynamic}"
 OUTPUT="${OUTPUT_DIR:-.}/cabal.project.local"
 
+# Optimization level for volca's own code, as a per-package override of the
+# global `optimization: 2` (which must stay 2 so the prebuilt cabal store's
+# deps keep matching). Default 2 — shipped artifacts (Docker, release, local
+# builds) are unaffected. CI PR/test builds export VOLCA_OPT_LEVEL=1 to halve
+# the cold compile of volca's ~100 modules; -O2 buys runtime speed the smoke
+# build doesn't need. Deps stay -O2 either way.
+VOLCA_OPT_LEVEL="${VOLCA_OPT_LEVEL:-2}"
+
 # Parallelism preamble shared by every LINK_MODE.
 # Lives in cabal.project.local (not cabal.project) so that Docker builds —
 # which copy only volca.cabal + mumps-hs/ into the build context and write a
@@ -38,6 +46,9 @@ optimization: 2
 
 extra-lib-dirs: $MUMPS_LIB_DIR
 extra-include-dirs: $MUMPS_INCLUDE_DIR
+
+package volca
+  optimization: $VOLCA_OPT_LEVEL
 EOF
         ;;
 
@@ -84,6 +95,7 @@ extra-lib-dirs: $MUMPS_LIB_DIR
 extra-include-dirs: $MUMPS_INCLUDE_DIR
 
 package volca
+  optimization: $VOLCA_OPT_LEVEL
   ghc-options: $MUSL_LINK_FLAGS
 EOF
         ;;
@@ -114,6 +126,7 @@ package mumps-hs
   ghc-options: $DARWIN_LINK_FLAGS
 
 package volca
+  optimization: $VOLCA_OPT_LEVEL
   ghc-options: $DARWIN_LINK_FLAGS
 EOF
         ;;
@@ -151,6 +164,7 @@ extra-lib-dirs: $MUMPS_LIB_DIR
 extra-include-dirs: $MUMPS_INCLUDE_DIR
 
 package volca
+  optimization: $VOLCA_OPT_LEVEL
   ghc-options: -optl-Wl,--allow-multiple-definition -optl-L$GCC_LIB_DIR -optl-L$MSYS2_LIB_DIR -optl-L$MUMPS_LIB_DIR -optl-ldmumps_seq -optl-lmumps_common_seq -optl-lpord_seq -optl-lmpiseq_seq -optl-lopenblas -optl-lgfortran -optl-lgcc -optl-lquadmath -optl-lmingwex -optl-lpthread -optl-lmsvcrt
 EOF
         ;;

--- a/versions.env
+++ b/versions.env
@@ -53,6 +53,7 @@ GHC_VERSION=9.12.4
 # mumps-hs.cabal / cabal.project. The CI workflow `prebuild-cabal-store.yml`
 # writes its output to a GH Release tagged
 # `cabal-store-prebuilt-ghc${GHC_VERSION}-${HASH8}-r${CABAL_PREBUILT_REVISION}`
-# (where HASH8 is the first 8 chars of sha256 of those three files), and
-# `_build-matrix.yml` downloads from that exact tag.
+# (where HASH8 is the first 8 chars of sha256 of those three files, with
+# volca.cabal's version/synopsis/description lines stripped so a release bump
+# reuses the store), and `_build-matrix.yml` downloads from that exact tag.
 CABAL_PREBUILT_REVISION=3

--- a/volca.cabal
+++ b/volca.cabal
@@ -14,7 +14,13 @@ description:         This project is a Life Cycle Assessment (LCA) engine.
 extra-source-files:  README.md CHANGELOG.md
 
 common warnings
-  ghc-options:         -Wall -O2
+  -- Optimization is set in cabal.project.local (see gen-cabal-config.sh):
+  -- global `optimization: 2` keeps deps at -O2, and a per-package override
+  -- sets volca itself from $VOLCA_OPT_LEVEL (default 2; CI PR builds drop it
+  -- to 1 for faster compiles). A hardcoded -O2 here would win over that
+  -- per-package setting (ghc-options beat the project optimization flag), so
+  -- it lives in the project file, not here.
+  ghc-options:         -Wall
 
 common rtsdefaults
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N


### PR DESCRIPTION
Started as a `LICENSE` refresh (so the GitHub API reports the right license); now also carries four CI fixes that came out of profiling the macOS build (~20 min on `macos-arm64`, ~16 min on `macos-intel`).

## LICENSE
- Updated `LICENSE` file.

## CI build-speed & reliability (one commit each)

**1. Exclude `version`/`synopsis`/`description` from the cabal-store hash** (`086e507`)
The prebuilt cabal-store tag is keyed on `sha256(volca.cabal + mumps-hs.cabal + cabal.project)`. Because `volca.cabal` carries the `version:` line, every release bump changed the hash and missed the store — so cutting `vX.Y.Z` forced a full 5-platform re-prebuild even though the version has no effect on the dependency closure. The filter is kept byte-identical in the `_build-matrix.yml` probe and the `prebuild-cabal-store.yml` publish step.

**2. Slim `~/.ghcup` before caching → fixes the macOS restore timeout** (`b14967a`)
The single biggest macOS sink: the GHCup cache key *hit* but the restore exceeded the actions/cache timeout (`operation cannot be completed in timeout`), so every run fell back to a cold ~4-5 min GHC reinstall. We now drop the bytes not needed to build a non-profiled binary (install tarballs, unpack scratch, GHC docs, profiling libs) and bump the key to `-v5`.

**3. Compile volca at `-O1` for PR builds, keep `-O2` for shipped artifacts** (`6458c15`)
volca's ~100 modules were compiled at `-O2` on every run, including the PR smoke build. Optimization becomes a per-package override in `gen-cabal-config.sh`: global `optimization: 2` stays (so the prebuilt store's deps still match) while volca itself follows `VOLCA_OPT_LEVEL` (default 2). `_build-matrix.yml` exports `1` for PR builds, `2` for release builds (where the packaged binary is produced). **Docker and local builds are unchanged.**

**4. Don't mistake a transient `gh` API error for a missing prebuilt asset** (`ed4e975`)
The MUMPS and cabal-store probes piped `gh release view 2>/dev/null` into `grep`, so a flaky API call read as "asset absent" and silently dropped the job to the cold source build (observed on `macos-arm64` reporting the MUMPS asset missing 3 h after it was published). Probes now go through a retry helper that separates a genuine absence from a query failure.

## After merge
- The hash change shifts the cabal-store tag once. Re-run **`prebuild-cabal-store.yml`** to publish under the new hash `17491f85` (covers `0.6.1.0` and `0.7.0` alike). No `CABAL_PREBUILT_REVISION` bump needed.