### PR TITLE
fix(pyvolca): substitution wire shape + cross-DB edge endpoints for engine 0.7.0

### DIFF
--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -1205,8 +1205,9 @@ Returned directly by :meth:`Client.get_impacts`, and nested inside
 One LCIA method, returned by :meth:`Client.list_methods`.
 
 Pass ``id`` to :meth:`Client.get_impacts` as ``method_id``. ``collection``
-is the parent method collection (e.g. ``"ef-31"``) — load it with
-:meth:`Client.load_method_collection` if not already loaded.
+is the parent method collection (e.g. ``"ef-31"``), forwarded to
+:meth:`Client.get_impacts` / :meth:`Client.get_impacts_batch` as their
+``collection`` argument.
 
 | Field | Type | Default |
 |-------|------|---------|
@@ -1365,12 +1366,19 @@ lengths by hand.
 
 ### `SupplyChainEdge`
 
-`from`/`to` are Python keywords, so they're stored under from_id/to_id.
+A consumer→supplier link in the supply chain.
+
+``from``/``to`` are Python keywords, so the process ids are stored under
+``from_id``/``to_id``. ``from_db``/``to_db`` carry each endpoint's database
+name, which is required to route edges across databases (the same process
+id can exist in more than one loaded DB).
 
 | Field | Type | Default |
 |-------|------|---------|
 | `from_id` | `str` | — |
+| `from_db` | `str` | — |
 | `to_id` | `str` | — |
+| `to_db` | `str` | — |
 | `amount` | `float` | — |
 
 ### `SupplyChainEntry`
@@ -1470,7 +1478,6 @@ Returns:
 ### `Exchange`
 
 Type alias: `Union[TechnosphereExchange, BiosphereExchange, WasteExchange]`.
-
 <!-- END: api-reference -->
 
 ## See also

--- a/pyvolca/pyproject.toml
+++ b/pyvolca/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvolca"
-version = "0.5.0"
+version = "0.5.1"
 description = "Python client for VoLCA — Life Cycle Assessment engine"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -207,9 +207,9 @@ def _substitution_body(substitutions: list[SubstitutionLike]) -> dict:
                 f"Substitution dict missing keys: {sorted(missing)}. "
                 "Use a Substitution(from_pid=, to_pid=, consumer=) instead."
             )
-        return {"subFrom": s["from"], "subTo": s["to"], "subConsumer": s["consumer"]}
+        return {"from": s["from"], "to": s["to"], "consumer": s["consumer"]}
 
-    return {"srSubstitutions": [coerce(s) for s in substitutions]}
+    return {"substitutions": [coerce(s) for s in substitutions]}
 
 
 # ---------------------------------------------------------------------------

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -1110,7 +1110,7 @@ class Substitution:
 
     def to_wire(self) -> dict:
         """Serialise to the wire shape consumed by SubstitutionRequest."""
-        return {"subFrom": self.from_pid, "subTo": self.to_pid, "subConsumer": self.consumer}
+        return {"from": self.from_pid, "to": self.to_pid, "consumer": self.consumer}
 
 
 # ---------------------------------------------------------------------------

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -545,14 +545,28 @@ class PathResult:
 
 @dataclass
 class SupplyChainEdge:
-    """`from`/`to` are Python keywords, so they're stored under from_id/to_id."""
+    """A consumer→supplier link in the supply chain.
+
+    ``from``/``to`` are Python keywords, so the process ids are stored under
+    ``from_id``/``to_id``. ``from_db``/``to_db`` carry each endpoint's database
+    name, which is required to route edges across databases (the same process
+    id can exist in more than one loaded DB).
+    """
     from_id: str
+    from_db: str
     to_id: str
+    to_db: str
     amount: float
 
     @classmethod
     def from_json(cls, d: dict) -> "SupplyChainEdge":
-        return cls(from_id=d["edgeFrom"], to_id=d["edgeTo"], amount=d["edgeAmount"])
+        return cls(
+            from_id=d["edgeFrom"],
+            from_db=d["edgeFromDb"],
+            to_id=d["edgeTo"],
+            to_db=d["edgeToDb"],
+            amount=d["edgeAmount"],
+        )
 
 
 @dataclass

--- a/pyvolca/tests/test_dispatch.py
+++ b/pyvolca/tests/test_dispatch.py
@@ -271,7 +271,7 @@ class TestDispatcher:
         session.get.assert_not_called()
         body = session.post.call_args[1]["json"]
         assert body == {
-            "srSubstitutions": [{"subFrom": "a", "subTo": "b", "subConsumer": "c"}]
+            "substitutions": [{"from": "a", "to": "b", "consumer": "c"}]
         }
 
     def test_get_impacts_batch_parses_scoring_indicators(self, mocked_client, make_response):
@@ -316,7 +316,7 @@ class TestDispatcher:
         session.get.assert_not_called()
         body = session.post.call_args[1]["json"]
         assert body == {
-            "srSubstitutions": [{"subFrom": "a", "subTo": "b", "subConsumer": "c"}]
+            "substitutions": [{"from": "a", "to": "b", "consumer": "c"}]
         }
 
     def test_get_impacts_batch_requires_db(self, fixture_spec, make_response):

--- a/pyvolca/tests/test_typed_returns.py
+++ b/pyvolca/tests/test_typed_returns.py
@@ -33,6 +33,7 @@ from volca import (
     ServerVersion,
     Substitution,
     SupplyChain,
+    SupplyChainEdge,
     SupplyChainEntry,
     TechRole,
     VoLCAError,
@@ -195,6 +196,25 @@ class TestSubstitution:
         s = Substitution(from_pid="A", to_pid="B", consumer="C")
         # Frozen — can be used as a set/dict key.
         assert {s}  # builds without error
+
+
+class TestSupplyChainEdge:
+    def test_from_json_captures_db_endpoints(self):
+        # edgeFromDb/edgeToDb are required to route edges across databases.
+        edge = SupplyChainEdge.from_json({
+            "edgeFrom": "supplier_pid",
+            "edgeFromDb": "ecoinvent",
+            "edgeTo": "consumer_pid",
+            "edgeToDb": "agribalyse",
+            "edgeAmount": 0.5,
+        })
+        assert edge == SupplyChainEdge(
+            from_id="supplier_pid",
+            from_db="ecoinvent",
+            to_id="consumer_pid",
+            to_db="agribalyse",
+            amount=0.5,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/pyvolca/tests/test_typed_returns.py
+++ b/pyvolca/tests/test_typed_returns.py
@@ -165,25 +165,25 @@ class TestServerVersionTyped:
 
 
 class TestSubstitution:
-    def test_to_wire_uses_servant_keys(self):
+    def test_to_wire_uses_stripped_keys(self):
         s = Substitution(from_pid="old_pid", to_pid="new_pid", consumer="downstream_pid")
         assert s.to_wire() == {
-            "subFrom": "old_pid",
-            "subTo": "new_pid",
-            "subConsumer": "downstream_pid",
+            "from": "old_pid",
+            "to": "new_pid",
+            "consumer": "downstream_pid",
         }
 
     def test_substitution_body_accepts_typed(self):
         s = Substitution(from_pid="A", to_pid="B", consumer="C")
         body = _substitution_body([s])
-        assert body == {"srSubstitutions": [
-            {"subFrom": "A", "subTo": "B", "subConsumer": "C"},
+        assert body == {"substitutions": [
+            {"from": "A", "to": "B", "consumer": "C"},
         ]}
 
     def test_substitution_body_accepts_dict_form(self):
         body = _substitution_body([{"from": "A", "to": "B", "consumer": "C"}])
-        assert body == {"srSubstitutions": [
-            {"subFrom": "A", "subTo": "B", "subConsumer": "C"},
+        assert body == {"substitutions": [
+            {"from": "A", "to": "B", "consumer": "C"},
         ]}
 
     def test_substitution_dict_typo_raises_locally(self):


### PR DESCRIPTION
Two fixes to align pyvolca with the VoLCA engine 0.7.0 wire format. Both are
data-correctness bugs where the client silently lost information.

## Bug #1 — substitutions silently ignored

`Client.get_impacts(substitutions=…)` (and `get_supply_chain`, `get_inventory`,
`get_impacts_batch`) was broken against 0.7.0. The client built the body with the
**raw Haskell field names**, but the engine's `stripLowerPrefix` codec drops the
lowercase type-prefix before parsing, so it reads the *stripped* names:

| raw Haskell field | wire name read by engine |
|-------------------|--------------------------|
| `srSubstitutions` | `substitutions`          |
| `subFrom`         | `from`                   |
| `subTo`           | `to`                     |
| `subConsumer`     | `consumer`               |

pyvolca sent the pre-strip names, so the engine recognised zero fields and dropped
the substitution without error — the score came back identical to a no-substitution
call. Correct shape (proven via raw HTTP):

```json
{ "substitutions": [ { "from": "...", "to": "...", "consumer": "..." } ] }
```

`Substitution.to_wire()` and `_substitution_body()` now emit the stripped keys.

## Bug #2 — SupplyChainEdge dropped the cross-DB columns

The engine's `SupplyChainEdge` carries `edgeFromDb` / `edgeToDb` (each endpoint's
database name) next to the process ids, but `from_json` read only
`edgeFrom` / `edgeTo` / `edgeAmount` and discarded the two DB columns. They're
required to route edges across databases — the same process id can exist in more
than one loaded DB. Added `from_db` / `to_db` to the dataclass and parse them.

## Misc

- Patch bump to 0.5.1.
- Regenerated the README API reference (also absorbs an earlier `Method`-docstring drift).

## Verification

`uv run --extra dev pytest` → 137 passed, 7 skipped. New unit tests cover the
substitution wire shape (typed + dict input) and the edge's DB endpoints.