### PR TITLE
Return ActivityNotFound for a well-formed but absent ProcessId

### DIFF
--- a/src/Service.hs
+++ b/src/Service.hs
@@ -136,13 +136,6 @@ validateUUID uuidText = case UUID.fromText uuidText of
     Just uuid -> Right uuid
     Nothing -> Left $ InvalidUUID $ "Invalid UUID format: " <> uuidText
 
--- | Parse ProcessId from text (activity_uuid_product_uuid format)
-parseProcessIdFromText :: Database -> Text -> Either ServiceError ProcessId
-parseProcessIdFromText db text =
-    case parseProcessId db text of
-        Just processId -> Right processId
-        Nothing -> Left $ InvalidProcessId $ "Invalid ProcessId format (expected activity_uuid_product_uuid): " <> text
-
 -- | Find activity by ProcessId using direct Vector access
 findActivityByProcessId :: Database -> ProcessId -> Maybe Activity
 findActivityByProcessId db processId =
@@ -162,22 +155,19 @@ This is the preferred function when you need the ProcessId (e.g., for matrix ope
 -}
 resolveActivityAndProcessId :: Database -> Text -> Either ServiceError (ProcessId, Activity)
 resolveActivityAndProcessId db queryText =
-    case parseProcessIdFromText db queryText of
-        Right processId ->
-            case findActivityByProcessId db processId of
-                Just activity -> Right (processId, activity)
-                Nothing -> Left $ ActivityNotFound queryText
-        Left _ ->
-            -- Fallback: try as bare UUID for ECOINVENT data compatibility
-            case UUID.fromText queryText of
-                Just uuid ->
-                    case findProcessIdByActivityUUID db uuid of
-                        Just processId ->
-                            case findActivityByProcessId db processId of
-                                Just activity -> Right (processId, activity)
-                                Nothing -> Left $ ActivityNotFound queryText
-                        Nothing -> Left $ InvalidProcessId $ "Query must be ProcessId format (activity_uuid_product_uuid) or valid UUID: " <> queryText
-                Nothing -> Left $ InvalidProcessId $ "Invalid UUID format: " <> queryText
+    findPid >>= resolveActivity
+  where
+    notFound = ActivityNotFound queryText
+    -- A syntactically valid identifier that does not resolve is not-found, not
+    -- a format error. Only genuinely malformed input is 'InvalidProcessId'.
+    findPid
+        | Just (a, p) <- parseUUIDPair queryText = maybe (Left notFound) Right (findProcessId db a p)
+        -- Bare activity UUID fallback (EcoInvent compatibility).
+        | Just uuid <- UUID.fromText queryText = maybe (Left notFound) Right (findProcessIdByActivityUUID db uuid)
+        | otherwise =
+            Left $ InvalidProcessId $ "Query must be a ProcessId (activityUUID_productUUID) or a valid UUID: " <> queryText
+    resolveActivity pid =
+        maybe (Left notFound) (\act -> Right (pid, act)) (findActivityByProcessId db pid)
 
 {- | Validate that a ProcessId exists in the matrix activity index
 This check ensures we fail fast with clear error messages before expensive matrix operations
@@ -2427,9 +2417,9 @@ applySubstitutionsAt depLookup thisDb thisDbObj rootDb solver scalings allSubs =
     -- Bare consumer/from/to refs all default to the root DB (per the
     -- 'Substitution' docstring), not whichever DB the recursive walker
     -- happens to be visiting. Using 'thisDb' instead would cause a bare
-    -- consumer to be retried in every dep DB and fail with a misleading
-    -- "Invalid UUID format" on the first dep where the activity does
-    -- not exist, and would also misroute bare suppliers in dep-level
+    -- consumer to be retried in every dep DB and fail with a spurious
+    -- 'ActivityNotFound' on the first dep where the activity does not
+    -- exist, and would also misroute bare suppliers in dep-level
     -- recursion. The 'RootDb' newtype on 'parseSubRef' makes the
     -- argument-swap unrepresentable.
     consumerLivesHere sub =

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -924,13 +924,15 @@ processIdToText db pid =
         Just (actUUID, prodUUID) -> UUID.toText actUUID <> "_" <> UUID.toText prodUUID
         Nothing -> "invalid-process-id-" <> T.pack (show pid)
 
--- | Parse ProcessId from filename stem (requires Database for lookup)
-parseProcessId :: Database -> Text -> Maybe ProcessId
-parseProcessId db filename = case T.splitOn "_" filename of
-    [actUUIDText, prodUUIDText] | not (T.null actUUIDText) && not (T.null prodUUIDText) ->
-        case (UUID.fromText actUUIDText, UUID.fromText prodUUIDText) of
-            (Just actUUID, Just prodUUID) -> findProcessId db actUUID prodUUID
-            _ -> Nothing
+{- | Pure syntactic parse of a ProcessId reference (activityUUID_productUUID).
+Returns the UUID pair when the text has the expected shape, regardless of
+whether that pair exists in any database. 'Nothing' is a genuine format
+error — callers treat a well-formed-but-absent pair as not-found, not malformed.
+-}
+parseUUIDPair :: Text -> Maybe (UUID, UUID)
+parseUUIDPair t = case T.splitOn "_" t of
+    [actText, prodText] | not (T.null actText), not (T.null prodText) ->
+        (,) <$> UUID.fromText actText <*> UUID.fromText prodText
     _ -> Nothing
 
 -- | Add SynonymDB to a Database (used after loading from cache)

--- a/test/NestedSubstitutionSpec.hs
+++ b/test/NestedSubstitutionSpec.hs
@@ -111,7 +111,7 @@ spec = do
             -- Substitution docstring). Before this fix, the per-level filter
             -- used 'thisDbName' as the parseSubRef default — so bare consumers
             -- were treated as living in EVERY DB the walker visited, and the
-            -- subsequent resolve in a dep DB threw "Invalid UUID format".
+            -- subsequent resolve in a dep DB failed with a spurious not-found.
             db <- loadSampleDatabase "SAMPLE.min3"
             solver <- mkSolver db "dep"
             let pid = 0

--- a/test/ServiceSpec.hs
+++ b/test/ServiceSpec.hs
@@ -21,7 +21,6 @@ import Service (
     extractCompartment,
     filterTreeExport,
     isResourceExtraction,
-    parseProcessIdFromText,
     resolveActivityAndProcessId,
     validateProcessIdInMatrixIndex,
     validateUUID,
@@ -56,32 +55,6 @@ spec = do
             case validateUUID "aaaaaaaa-aaaa-aaaa-aaaa" of
                 Left (InvalidUUID _) -> return ()
                 _ -> expectationFailure "Expected InvalidUUID"
-
-    -- -----------------------------------------------------------------------
-    -- parseProcessIdFromText (requires DB)
-    -- -----------------------------------------------------------------------
-    describe "parseProcessIdFromText" $ do
-        it "parses a valid ProcessId text from SAMPLE.min3" $ do
-            db <- loadSampleDatabase "SAMPLE.min3"
-            let pidText = processIdToText db 0
-            case parseProcessIdFromText db pidText of
-                Right 0 -> return ()
-                Right n -> expectationFailure $ "Expected ProcessId 0 but got " ++ show n
-                Left e -> expectationFailure $ "Expected Right but got: " ++ show e
-
-        it "returns InvalidProcessId for garbage text" $ do
-            db <- loadSampleDatabase "SAMPLE.min3"
-            case parseProcessIdFromText db "not-a-process-id" of
-                Left (InvalidProcessId _) -> return ()
-                _ -> expectationFailure "Expected InvalidProcessId"
-
-        it "returns InvalidProcessId for a single UUID (missing product part)" $ do
-            db <- loadSampleDatabase "SAMPLE.min3"
-            case parseProcessIdFromText db "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" of
-                Left (InvalidProcessId _) -> return ()
-                -- bare UUID fallback is in resolveActivityAndProcessId, not here
-                Left _ -> return ()
-                Right _ -> expectationFailure "Expected Left"
 
     -- -----------------------------------------------------------------------
     -- validateProcessIdInMatrixIndex
@@ -125,13 +98,28 @@ spec = do
                 Right (_, act) -> activityName act `shouldBe` "production of product X"
                 Left err -> expectationFailure $ "Expected Right but got: " ++ show err
 
-        it "returns ActivityNotFound for a non-existent ProcessId text" $ do
+        it "returns ActivityNotFound for a well-formed but non-existent ProcessId text" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
             -- Valid UUID pair format but not in DB
             let ghost = "99999999-9999-9999-9999-999999999999_99999999-9999-9999-9999-999999999999"
             case resolveActivityAndProcessId db ghost of
-                Left _ -> return ()
-                Right _ -> expectationFailure "Expected Left for unknown process"
+                Left (ActivityNotFound _) -> return ()
+                Left err -> expectationFailure $ "Expected ActivityNotFound but got: " ++ show err
+                Right _ -> expectationFailure "Expected ActivityNotFound but got a hit"
+
+        it "returns ActivityNotFound for a valid but absent bare UUID" $ do
+            db <- loadSampleDatabase "SAMPLE.min3"
+            case resolveActivityAndProcessId db "99999999-9999-9999-9999-999999999999" of
+                Left (ActivityNotFound _) -> return ()
+                Left err -> expectationFailure $ "Expected ActivityNotFound but got: " ++ show err
+                Right _ -> expectationFailure "Expected ActivityNotFound but got a hit"
+
+        it "returns InvalidProcessId for a genuinely malformed query" $ do
+            db <- loadSampleDatabase "SAMPLE.min3"
+            case resolveActivityAndProcessId db "not-a-process-id" of
+                Left (InvalidProcessId _) -> return ()
+                Left err -> expectationFailure $ "Expected InvalidProcessId but got: " ++ show err
+                Right _ -> expectationFailure "Expected InvalidProcessId but got a hit"
 
     -- -----------------------------------------------------------------------
     -- isResourceExtraction


### PR DESCRIPTION
## Problem

Resolving an activity by a **syntactically valid but non-existent** ProcessId (shape `activityUUID_productUUID`, both UUIDs well-formed) returned the wrong error:

- HTTP API → **400 Bad Request** ("Invalid ProcessId format") instead of **404 Not Found**
- MCP tools → an error text literally reading *"Invalid UUID format"* for a perfectly well-formed query

The message sent users hunting for a syntax problem that did not exist.

## Root cause

`parseProcessId` collapsed two genuinely different outcomes into a single `Nothing`:

1. text not in `activityUUID_productUUID` shape — a real **format error**, and
2. a valid UUID pair whose lookup missed — a real **not-found**.

`resolveActivityAndProcessId` therefore couldn't distinguish them. On the `Nothing` it fell through to a bare-UUID attempt; for a `uuid_uuid` string `UUID.fromText` fails on the embedded `_`, ending at `InvalidProcessId "Invalid UUID format"`.

## Fix

Separate the **syntactic parse** from the **lookup**:

- `parseUUIDPair` (new, in `Types`) does the shape-only parse, independent of any DB — its `Nothing` means *only* "malformed".
- `resolveActivityAndProcessId` is rewritten as a flat guard chain classifying the query into: valid PID pair, bare activity UUID (EcoInvent compatibility), or malformed. A syntactically valid identifier that does not resolve is now `ActivityNotFound`; only genuinely malformed input is `InvalidProcessId`.

This retires the now-redundant `parseProcessIdFromText` / `parseProcessId` chain, which was private to the resolver.

No downstream changes were needed — `serviceErrorToServerError` already maps `ActivityNotFound → 404` and `InvalidProcessId → 400`, and the inline route handlers already match `ActivityNotFound` explicitly.

## Tests

`ServiceSpec` now asserts, at the resolver layer:
- well-formed but absent PID → `ActivityNotFound` (regression guard for this bug)
- valid but absent bare UUID → `ActivityNotFound`
- genuinely malformed query → `InvalidProcessId`

Full suite: **1142 examples, 0 failures**.