### PR TITLE
docs(pyvolca): changelog for 0.5.1

### DIFF
--- a/pyvolca/CHANGELOG.md
+++ b/pyvolca/CHANGELOG.md
@@ -18,6 +18,19 @@ git cliff --unreleased --tag pyvolca-v0.X.Y   # render as a released section
 
 Then paste the rendered block at the top of this file and tighten wording.
 
+## [0.5.1] - 2026-05-31
+
+Two bug fixes for engine 0.7.0. No API change — just upgrade.
+
+### Fixes
+
+- Substitutions now reach the engine. The client was sending field names
+  0.7.0 no longer recognised, so substitutions were silently ignored; it
+  now sends the names the engine expects. (#108)
+- Cross-database supply-chain edges now resolve. Each edge keeps its source
+  and target database, so a process id that exists in more than one loaded
+  database is routed to the right one. (#108)
+
 ## [0.5.0] - 2026-05-27
 
 Three convergent themes: surface pagination truthfully (no silent


### PR DESCRIPTION
Adds the missing `0.5.1` section to `pyvolca/CHANGELOG.md`. The 0.5.1 code and
the `pyproject.toml` version bump already landed in #108; this is just the
release notes so we can tag `pyvolca-v0.5.1`.

Both fixes realign the client with engine 0.7.0 (substitution wire keys; cross-DB
supply-chain edge database tags). Patch release — no public API change.