### PR TITLE
feat: global supplier substitution across all consumers

### DIFF
--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -524,7 +524,8 @@ Args:
     substitutions: When provided, the call is upgraded to POST and
         the scaling vector is recomputed with the substituted
         suppliers. Accepts :class:`Substitution` (preferred) or the
-        legacy ``{"from", "to", "consumer"}`` dict form.
+        legacy ``{"from", "to", "consumer"}`` dict form; ``consumer``
+        is optional — omit it for a global swap.
 
 ##### `Client.get_tree(process_id: str) -> dict`
 

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -185,29 +185,34 @@ def _resolve_page_args(
 SubstitutionLike = Substitution | dict
 """A :class:`Substitution` or a legacy ``{"from", "to", "consumer"}`` dict.
 
-The dict form is accepted for backwards-compat one-liner ergonomics; the
-typed form is preferred (catches typos at construction time)."""
+``consumer`` is optional — omit it for a global swap. The dict form is
+accepted for backwards-compat one-liner ergonomics; the typed form is
+preferred (catches typos at construction time)."""
 
 
 def _substitution_body(substitutions: list[SubstitutionLike]) -> dict:
     """Build the request body for substitution endpoints.
 
     Accepts :class:`Substitution` instances or the legacy dict form with
-    ``from`` / ``to`` / ``consumer`` keys.
+    ``from`` / ``to`` keys and an optional ``consumer`` key (omit it for a
+    global swap).
     """
 
     def coerce(s: SubstitutionLike) -> dict:
         if isinstance(s, Substitution):
             return s.to_wire()
-        # dict form — validate the three required keys here so typos like
+        # dict form — validate the required keys here so typos like
         # ``"comsumer"`` fail with a clear error rather than at the engine.
-        missing = {"from", "to", "consumer"} - set(s)
+        missing = {"from", "to"} - set(s)
         if missing:
             raise VoLCAError(
                 f"Substitution dict missing keys: {sorted(missing)}. "
                 "Use a Substitution(from_pid=, to_pid=, consumer=) instead."
             )
-        return {"from": s["from"], "to": s["to"], "consumer": s["consumer"]}
+        body = {"from": s["from"], "to": s["to"]}
+        if "consumer" in s:
+            body["consumer"] = s["consumer"]
+        return body
 
     return {"substitutions": [coerce(s) for s in substitutions]}
 
@@ -736,7 +741,8 @@ class Client:
             substitutions: When provided, the call is upgraded to POST and
                 the scaling vector is recomputed with the substituted
                 suppliers. Accepts :class:`Substitution` (preferred) or the
-                legacy ``{"from", "to", "consumer"}`` dict form.
+                legacy ``{"from", "to", "consumer"}`` dict form; ``consumer``
+                is optional — omit it for a global swap.
         """
         classifications = [f.system for f in classification_filters or []]
         classification_values = [f.value for f in classification_filters or []]

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -1109,10 +1109,11 @@ class AggregateResult:
 class Substitution:
     """Replace one supplier with another in the upstream supply chain.
 
-    All three fields are process_ids. ``consumer`` identifies which downstream
-    consumer's input to rewrite (substitutions are scoped, not global) — the
-    same upstream supplier can be replaced by different alternatives in
-    different parts of the tree.
+    All fields are process_ids. ``consumer`` identifies which downstream
+    consumer's input to rewrite, scoping the swap to one edge — the same
+    upstream supplier can be replaced by different alternatives in different
+    parts of the tree. Omit it (leave ``None``) to apply the swap globally,
+    replacing the supplier on every consumer at once.
 
     Frozen so callers can put it in a set / dict key and re-use the same
     substitution across multiple calls without aliasing risk.
@@ -1120,11 +1121,14 @@ class Substitution:
 
     from_pid: str  # the supplier being replaced (wire: ``from``)
     to_pid: str  # the replacement supplier (wire: ``to``)
-    consumer: str  # the consumer whose input gets rewritten
+    consumer: str | None = None  # the consumer to scope to; None = global swap
 
     def to_wire(self) -> dict:
         """Serialise to the wire shape consumed by SubstitutionRequest."""
-        return {"from": self.from_pid, "to": self.to_pid, "consumer": self.consumer}
+        d = {"from": self.from_pid, "to": self.to_pid}
+        if self.consumer is not None:
+            d["consumer"] = self.consumer
+        return d
 
 
 # ---------------------------------------------------------------------------

--- a/pyvolca/tests/test_typed_returns.py
+++ b/pyvolca/tests/test_typed_returns.py
@@ -187,10 +187,18 @@ class TestSubstitution:
             {"from": "A", "to": "B", "consumer": "C"},
         ]}
 
-    def test_substitution_dict_typo_raises_locally(self):
-        # "comsumer" is a typo — caught before hitting the engine.
+    def test_substitution_consumer_optional_global_swap(self):
+        # Omitting ``consumer`` requests a global swap: the key must be absent
+        # from the wire body (the engine reads absence as "all consumers").
+        typed = _substitution_body([Substitution(from_pid="A", to_pid="B")])
+        assert typed == {"substitutions": [{"from": "A", "to": "B"}]}
+        dict_form = _substitution_body([{"from": "A", "to": "B"}])
+        assert dict_form == {"substitutions": [{"from": "A", "to": "B"}]}
+
+    def test_substitution_dict_missing_required_raises_locally(self):
+        # ``from``/``to`` stay required; a missing one fails before the engine.
         with pytest.raises(VoLCAError, match="missing keys"):
-            _substitution_body([{"from": "A", "to": "B", "comsumer": "C"}])
+            _substitution_body([{"from": "A", "comsumer": "C"}])
 
     def test_substitution_is_frozen_and_hashable(self):
         s = Substitution(from_pid="A", to_pid="B", consumer="C")

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -294,7 +294,7 @@ paramsToSchema ps =
 
     -- Arrays in the 'Param' schema default to items of type string; the
     -- exception is the shared @substitutions@ parameter, whose entries are
-    -- @{from, to, consumer}@ objects. We special-case the name rather than
+    -- @{from, to, consumer?}@ objects. We special-case the name rather than
     -- extending the 'Param' record to avoid touching every call site.
     arrayItemsFor p
         | paramType p /= "array" = []
@@ -308,9 +308,9 @@ paramsToSchema ps =
                 .= object
                     [ "from" .= stringField "Source supplier ProcessId (bare or dbName::pid)"
                     , "to" .= stringField "Replacement supplier ProcessId (bare or dbName::pid)"
-                    , "consumer" .= stringField "Consumer activity ProcessId (root DB only)"
+                    , "consumer" .= stringField "Consumer activity ProcessId. Omit to substitute on every consumer of 'from' at once (global swap; 'from' must be in the root DB)."
                     ]
-            , "required" .= (["from", "to", "consumer"] :: [Text])
+            , "required" .= (["from", "to"] :: [Text])
             ]
     stringField desc = object ["type" .= ("string" :: Text), "description" .= (desc :: Text)]
 
@@ -686,7 +686,7 @@ callGetSupplyChain dbManager rid args = runTool rid $ do
                 -- Substitution-aware: re-solve the root scaling, then build from it.
                 (processId, _) <- liftShow (Service.resolveActivityAndProcessId db pid)
                 (scalingVec, virtualLinks) <-
-                    liftIO (Service.computeScalingVectorWithSubstitutionsCrossDB depLookup db dbName solver processId subs) >>= liftShow
+                    liftIO (Service.computeScalingVectorWithSubstitutionsCrossDB unitCfg depLookup db dbName solver processId subs) >>= liftShow
                 resp <-
                     liftIO (Service.buildSupplyChainFromScalingVectorCrossDB unitCfg depLookup db dbName processId scalingVec virtualLinks scf False) >>= liftShow
                 pure (toJSON resp)

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1260,10 +1260,12 @@ activitySupplyChainCore dbName processIdText nameFilter limitParam minQuantity o
             result <- liftIO $ Service.getSupplyChain unitCfg (DM.mkDepSolverLookup dbManager) db dbName sharedSolver processIdText scf includeEdges
             either throwServiceError pure result
         Just subReq -> do
+            unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
             (processId, _) <- resolveOrThrow db processIdText
             scalingResult <-
                 liftIO $
                     Service.computeScalingVectorWithSubstitutionsCrossDB
+                        unitCfg
                         (DM.mkDepSolverLookup dbManager)
                         db
                         dbName
@@ -1273,7 +1275,6 @@ activitySupplyChainCore dbName processIdText nameFilter limitParam minQuantity o
             case scalingResult of
                 Left err -> throwServiceError err
                 Right (scalingVec, virtualLinks) -> do
-                    unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
                     eResp <-
                         liftIO $
                             Service.buildSupplyChainFromScalingVectorCrossDB

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -802,22 +802,68 @@ newtype SubstitutionRequest = SubstitutionRequest
     deriving (Generic)
     deriving (FromJSON, ToSchema) via (Stripped SubstitutionRequest)
 
+{- | Scope of a supplier substitution.
+
+* 'OneEdge' carries the consumer 'ProcessId' ref and replaces the supplier
+  on that single technosphere edge — the historical per-edge behaviour.
+* 'AllConsumers' replaces @from@ by @to@ on __every__ consumer that sources
+  from @from@, as one rank-1 update. @from@ must live in the root DB.
+
+On the wire the scope is the optional @consumer@ field: present →
+'OneEdge', absent → 'AllConsumers'. Making it a sum type keeps the
+applicator's dispatch total (no "is the consumer empty?" guard).
+-}
+data SubstitutionScope
+    = OneEdge Text
+    | AllConsumers
+
 {- | A single supplier substitution.
 
-Each field is a 'ProcessId' text, either in the bare form
-@"actUUID_prodUUID"@ (resolved in the URL's database, i.e. the root DB)
-or in the cross-DB qualified form @"dbName::actUUID_prodUUID"@ (resolved
-against the named dep DB). See 'parseSubRef'. @subConsumer@ may live in
-the root DB (bare) or in any loaded and reachable dep DB (qualified);
-the per-level applicator will dispatch to the right database.
+@subFrom@/@subTo@ are 'ProcessId' texts, either bare @"actUUID_prodUUID"@
+(resolved in the URL's database, i.e. the root DB) or in the cross-DB
+qualified form @"dbName::actUUID_prodUUID"@ (resolved against the named
+dep DB). See 'parseSubRef'. The 'OneEdge' consumer ref follows the same
+bare/qualified rule and may live in the root DB or any loaded, reachable
+dep DB; the per-level applicator dispatches to the right database.
 -}
 data Substitution = Substitution
     { subFrom :: Text -- Original supplier ProcessId (bare or dbName::pid)
     , subTo :: Text -- Replacement supplier ProcessId (bare or dbName::pid)
-    , subConsumer :: Text -- Consumer activity ProcessId (bare or dbName::pid)
+    , subScope :: SubstitutionScope -- Per-edge consumer, or all consumers
     }
-    deriving (Generic)
-    deriving (FromJSON, ToSchema) via (Stripped Substitution)
+
+{- | The DB-qualified ref that decides which recursion level processes a
+substitution: the consumer for 'OneEdge', the replaced supplier @from@ for
+'AllConsumers' (whose consumers are enumerated where @from@ lives).
+-}
+subAnchorRef :: Substitution -> Text
+subAnchorRef sub = case subScope sub of
+    OneEdge cRef -> cRef
+    AllConsumers -> subFrom sub
+
+-- | @consumer@ present → 'OneEdge'; absent → 'AllConsumers' (global swap).
+instance FromJSON Substitution where
+    parseJSON = withObject "Substitution" $ \o ->
+        Substitution
+            <$> o .: "from"
+            <*> o .: "to"
+            <*> (maybe AllConsumers OneEdge <$> o .:? "consumer")
+
+-- | @from@/@to@ required; @consumer@ optional (omit for a global swap).
+instance ToSchema Substitution where
+    declareNamedSchema _ = do
+        textRef <- declareSchemaRef (Proxy :: Proxy Text)
+        pure $
+            NamedSchema (Just "Substitution") $
+                mempty
+                    & type_ ?~ OpenApiObject
+                    & properties
+                        .~ InsOrdHashMap.fromList
+                            [ ("from", textRef)
+                            , ("to", textRef)
+                            , ("consumer", textRef)
+                            ]
+                    & required .~ ["from", "to"]
 
 {- | A single rank-1 perturbation of a technosphere coefficient @A_ij@.
 

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -841,7 +841,10 @@ subAnchorRef sub = case subScope sub of
     OneEdge cRef -> cRef
     AllConsumers -> subFrom sub
 
--- | @consumer@ present → 'OneEdge'; absent → 'AllConsumers' (global swap).
+{- | @consumer@ present → 'OneEdge'; absent or @null@ → 'AllConsumers' (global
+swap). An empty-string @consumer@ is taken literally as a 'OneEdge' ref and
+fails to resolve, never silently promoted to a global swap.
+-}
 instance FromJSON Substitution where
     parseJSON = withObject "Substitution" $ \o ->
         Substitution

--- a/src/Matrix.hs
+++ b/src/Matrix.hs
@@ -45,7 +45,9 @@ module Matrix (
     computeProcessLCIAContributions,
     perturbA,
     perturbABatch,
+    perturbGlobal,
     applyShermanMorrison,
+    applyShermanMorrisonV,
     buildDemandVectorFromIndex,
     solveSparseLinearSystem,
     applySparseMatrix,
@@ -642,32 +644,74 @@ perturbA ::
 perturbA db mFact x col perturb
     | null perturb = pure (Right x)
     | otherwise = do
-        let n = U.length x
-            u = U.accum (+) (U.replicate n 0.0) perturb
-        z <- case mFact of
-            Just f -> solveSparseLinearSystemWithFactorization f u
-            Nothing -> do
-                let techTriples = dbTechnosphereTriples db
-                    activityCount = dbActivityCount db
-                solveSparseLinearSystem
-                    [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList techTriples]
-                    (fromIntegral activityCount)
-                    u
+        z <- solveRankOneZ db mFact (U.length x) perturb
         pure $ applyShermanMorrison x col z
 
+{- | Solve @z = inv(I-A) * u@ for a sparse supplier-axis perturbation @u@,
+reusing the cached factorization when present. Shared by the per-edge
+('perturbA') and global ('perturbGlobal') rank-1 paths so the back-sub
+plumbing lives in one place.
+-}
+solveRankOneZ :: Database -> Maybe MatrixFactorization -> Int -> [(Int, Double)] -> IO Vector
+solveRankOneZ db mFact n perturb =
+    let u = U.accum (+) (U.replicate n 0.0) perturb
+     in case mFact of
+            Just f -> solveSparseLinearSystemWithFactorization f u
+            Nothing ->
+                solveSparseLinearSystem
+                    [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList (dbTechnosphereTriples db)]
+                    (fromIntegral (dbActivityCount db))
+                    u
+
 {- | Apply the Sherman-Morrison rank-1 formula given the precomputed
-z = inv(I-A) * u. Pure step shared by 'perturbA' and 'perturbABatch'.
+z = inv(I-A) * u, with the left projection fixed at the basis column
+@e_col@. Thin wrapper over 'applyShermanMorrisonV'.
 -}
 applyShermanMorrison :: Vector -> Int -> Vector -> Either T.Text Vector
-applyShermanMorrison x col z =
-    let vtx = x U.! col
-        vtz = z U.! col
-        denom = 1.0 + vtz
+applyShermanMorrison x col = applyShermanMorrisonV x [(col, 1.0)]
+
+{- | Generalized Sherman-Morrison: the left projection @v@ is an arbitrary
+sparse vector rather than a single basis column. The rank-1 update is
+@(I-A) + u·vᵀ@; with @v = e_col@ this is the per-edge update, while a full
+technosphere row @v = row_A(A)@ applies a __global__ supplier swap (every
+consumer of one activity at once) in a single back-substitution. @z =
+inv(I-A)·u@ is supplied by the caller.
+-}
+applyShermanMorrisonV :: Vector -> [(Int, Double)] -> Vector -> Either T.Text Vector
+applyShermanMorrisonV x v z =
+    let dot w = sum [c * (w U.! i) | (i, c) <- v]
+        denom = 1.0 + dot z
      in if abs denom < 1e-12
             then Left "Sherman-Morrison update is singular \x2014 perturbation drives (I-A) into a degenerate state"
             else
-                let scale = vtx / denom
+                let scale = dot x / denom
                  in Right $ U.imap (\i xi -> xi - scale * (z U.! i)) x
+
+{- | Rank-1 update for a __global__ supplier substitution: replace activity
+@A@ by @B@ in every consumer that sources from @A@, in one solve. @u@ is the
+supplier-axis perturbation (@e_A - κ·e_B@ within a DB, or @e_A@ alone when
+@B@ lives in a dependency DB); @v@ is the consumer-axis projection — @A@'s
+technosphere row (its coefficient at each consumer). The single back-sub
+@z = inv(I-A)·u@ replaces the @N@ solves an edge-by-edge expansion needs.
+
+An empty @u@ or @v@ leaves @x@ unchanged; callers surface "A consumed
+nowhere" as an explicit error before reaching here, so an empty @v@ is
+never a silent no-op in practice.
+-}
+perturbGlobal ::
+    Database ->
+    Maybe MatrixFactorization ->
+    Vector ->
+    -- | u : sparse supplier-axis perturbation
+    [(Int, Double)] ->
+    -- | v : sparse consumer-axis projection (A's technosphere row)
+    [(Int, Double)] ->
+    IO (Either T.Text Vector)
+perturbGlobal db mFact x u v
+    | null u || null v = pure (Right x)
+    | otherwise = do
+        z <- solveRankOneZ db mFact (U.length x) u
+        pure $ applyShermanMorrisonV x v z
 
 {- |
 Batched 'perturbA': computes z_k = inv(I-A) * u_k for every non-empty

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -1966,9 +1966,12 @@ getReferenceProductAmount activity =
         (amt : _) -> amt
         [] -> 1.0
 
-{- | Compute a scaling vector with optional Sherman-Morrison substitutions.
-Returns the (possibly modified) scaling vector. When substitutions is empty,
-this is the same as a plain solve.
+{- | Root-only scaling vector: solve @(I-A)x = d@. Substitutions are applied by
+the cross-DB applicator ('applySubstitutionsAt', via
+'computeScalingVectorWithSubstitutionsCrossDB'), never here — this path is only
+ever called with an empty list. A non-empty list is a programmer error, surfaced
+loudly rather than silently mishandled (the previous in-place applicator used a
+'defaultUnitConfig' and could never see the merged unit table).
 -}
 computeScalingVectorWithSubstitutions ::
     Database ->
@@ -1976,61 +1979,14 @@ computeScalingVectorWithSubstitutions ::
     ProcessId ->
     [Substitution] ->
     IO (Either ServiceError (U.Vector Double))
-computeScalingVectorWithSubstitutions db sharedSolver processId subs = do
-    let activityIndex = dbActivityIndex db
-        demandVec = buildDemandVectorFromIndex activityIndex processId
-    originalX <- solveWithSharedSolver sharedSolver demandVec
+computeScalingVectorWithSubstitutions db sharedSolver processId subs =
     case subs of
-        [] -> return $ Right originalX
-        _ -> do
-            mFact <- getFactorization sharedSolver
-            foldSubstitutions originalX subs (applySubstitution mFact)
+        [] -> Right <$> solveWithSharedSolver sharedSolver demandVec
+        _ ->
+            pure . Left . MatrixError $
+                "computeScalingVectorWithSubstitutions: substitutions must be applied via the cross-DB path"
   where
-    -- This root-only path predates cross-DB support and is now only reached
-    -- with an empty sub list; the cross-DB applicator ('applySubstitutionsAt')
-    -- carries the production substitution logic. Both scopes are handled here
-    -- regardless, sharing 'planGlobalWithinDB' so the two paths can't diverge.
-    applySubstitution mFact x sub = case subScope sub of
-        OneEdge cRef ->
-            case ( resolveActivityAndProcessId db (subFrom sub)
-                 , resolveActivityAndProcessId db (subTo sub)
-                 , resolveActivityAndProcessId db cRef
-                 ) of
-                (Left err, _, _) -> return $ Left err
-                (_, Left err, _) -> return $ Left err
-                (_, _, Left err) -> return $ Left err
-                (Right (oldPid, _), Right (newPid, _), Right (consumerPid, _)) ->
-                    case findTechCoefficient db consumerPid oldPid of
-                        Nothing ->
-                            return $
-                                Left $
-                                    MatrixError $
-                                        "No technosphere link from "
-                                            <> processIdToText db consumerPid
-                                            <> " to supplier "
-                                            <> subFrom sub
-                        Just a -> do
-                            -- Symmetric root-only swap: +a at old supplier, -a at new.
-                            let perturb = [(fromIntegral oldPid, a), (fromIntegral newPid, -a)]
-                            smResult <- perturbA db mFact x (fromIntegral consumerPid) perturb
-                            return $ either (Left . MatrixError) Right smResult
-        AllConsumers ->
-            case (resolveActivityAndProcessId db (subFrom sub), resolveActivityAndProcessId db (subTo sub)) of
-                (Left err, _) -> return $ Left err
-                (_, Left err) -> return $ Left err
-                (Right (fromPid, _), Right (toPid, _)) ->
-                    case planGlobalWithinDB defaultUnitConfig db fromPid toPid of
-                        Left err -> return $ Left err
-                        Right gupd -> do
-                            smResult <- perturbGlobal db mFact x (gruU gupd) (gruV gupd)
-                            return $ either (Left . MatrixError) Right smResult
-
-    foldSubstitutions x [] _ = return $ Right x
-    foldSubstitutions x (s : ss) f = do
-        result <- f x s
-        case result of
-            Left err -> return $ Left err
-            Right x' -> foldSubstitutions x' ss f
+    demandVec = buildDemandVectorFromIndex (dbActivityIndex db) processId
 
 {- | Run sensitivity analysis on a process: compute the baseline scaling
 vector @x₀@ once, then resolve every 'Perturbation' to a (consumer column,
@@ -2162,7 +2118,7 @@ inventoryWithSubsAndDeps unitCfg depLookup db rootDbName solver pid subs =
     case globalFromMustLiveInRoot rootDb subs of
         Left e -> pure (Left e)
         Right () -> do
-            eValid <- validateConsumerDbs depLookup db rootDb subs
+            eValid <- validateAnchorDbs depLookup db rootDb subs
             case eValid of
                 Left e -> pure (Left e)
                 Right () -> do
@@ -2179,32 +2135,33 @@ inventoryWithSubsAndDeps unitCfg depLookup db rootDbName solver pid subs =
   where
     rootDb = RootDb rootDbName
 
-{- | Reject substitutions whose consumer is qualified to a DB that is either
+{- | Reject substitutions whose anchor DB (the 'OneEdge' consumer, or the
+'AllConsumers' replaced supplier) is qualified to a DB that is either
 unloaded or not reachable from @rootDbName@ via 'dbCrossDBLinks'. Such
 subs would otherwise be silently filtered at every level of the
-recursion (because the consumer DB never appears as @thisDbName@),
+recursion (because the anchor DB never appears as @thisDbName@),
 which violates the no-silent-errors invariant.
 -}
-validateConsumerDbs ::
+validateAnchorDbs ::
     SharedSolver.DepSolverLookup ->
     Database ->
     RootDb ->
     [Substitution] ->
     IO (Either ServiceError ())
-validateConsumerDbs depLookup rootDbObj rootDb subs = do
+validateAnchorDbs depLookup rootDbObj rootDb subs = do
     let rootDbName = unRootDb rootDb
-        externalConsumerDbs =
+        externalAnchorDbs =
             S.delete rootDbName $
                 S.fromList
                     [ cDb
                     | sub <- subs
                     , let (cDb, _) = parseSubRef rootDb (subAnchorRef sub)
                     ]
-    if S.null externalConsumerDbs
+    if S.null externalAnchorDbs
         then pure (Right ())
         else do
             reachable <- reachableDepDbs depLookup rootDbName rootDbObj
-            let unreachable = externalConsumerDbs `S.difference` reachable
+            let unreachable = externalAnchorDbs `S.difference` reachable
             case S.toList unreachable of
                 [] -> pure (Right ())
                 (d : _) -> do
@@ -2218,7 +2175,7 @@ validateConsumerDbs depLookup rootDbObj rootDb subs = do
 
 {- | BFS the loaded portion of the dep-DB DAG from @rootDbName@. Returns
 the set of DB names that are statically reachable via 'dbCrossDBLinks'
-chains (including unloaded leaves — 'validateConsumerDbs' distinguishes
+chains (including unloaded leaves — 'validateAnchorDbs' distinguishes
 loaded-but-unreachable from unloaded).
 -}
 reachableDepDbs ::
@@ -2346,25 +2303,29 @@ computeScalingVectorWithSubstitutionsCrossDB ::
     ProcessId ->
     [Substitution] ->
     IO (Either ServiceError (U.Vector Double, [CrossDBLink]))
-computeScalingVectorWithSubstitutionsCrossDB unitCfg depLookup db rootDbName solver pid subs = do
-    let rootDb = RootDb rootDbName
-    case firstNonRootAnchor rootDb of
-        Just cDb ->
-            pure $
-                Left $
-                    MatrixError $
-                        "substitution consumer must live in root database (got: " <> cDb <> ")"
-        Nothing -> do
-            let demandVec = buildDemandVectorFromIndex (dbActivityIndex db) pid
-            originalX <- solveWithSharedSolver solver demandVec
-            res <- applySubstitutionsAt unitCfg depLookup db (ThisDb rootDbName) rootDb solver [originalX] subs
-            pure $ case res of
-                Left e -> Left e
-                Right ([x'], links) -> Right (x', links)
-                Right (x' : _, links) -> Right (x', links) -- unreachable: K=1
-                Right ([], _) -> Right (originalX, []) -- unreachable
+computeScalingVectorWithSubstitutionsCrossDB unitCfg depLookup db rootDbName solver pid subs =
+    -- A global @from@ outside root is reported as such (not as a "consumer"
+    -- error); the per-edge consumer guard below then applies only to 'OneEdge'.
+    case globalFromMustLiveInRoot rootDb subs of
+        Left e -> pure (Left e)
+        Right () -> case firstNonRootAnchor of
+            Just cDb ->
+                pure $
+                    Left $
+                        MatrixError $
+                            "substitution consumer must live in root database (got: " <> cDb <> ")"
+            Nothing -> do
+                let demandVec = buildDemandVectorFromIndex (dbActivityIndex db) pid
+                originalX <- solveWithSharedSolver solver demandVec
+                res <- applySubstitutionsAt unitCfg depLookup db (ThisDb rootDbName) rootDb solver [originalX] subs
+                pure $ case res of
+                    Left e -> Left e
+                    Right ([x'], links) -> Right (x', links)
+                    Right (x' : _, links) -> Right (x', links) -- unreachable: K=1
+                    Right ([], _) -> Right (originalX, []) -- unreachable
   where
-    firstNonRootAnchor rootDb =
+    rootDb = RootDb rootDbName
+    firstNonRootAnchor =
         case [ cDb
              | sub <- subs
              , let (cDb, _) = parseSubRef rootDb (subAnchorRef sub)

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -5,7 +5,7 @@
 
 module Service where
 
-import API.Types (ActivityForAPI (..), ActivityInfo (..), ActivityLinks (..), ActivityMetadata (..), ActivityStats (..), ActivitySummary (..), ApiFlow (..), ClassificationSystem (..), ConsumerResult (..), ConsumersResponse (..), CutoffWasteFlow (..), EdgeType (..), ExchangeDetail (..), ExchangeWithUnit (..), ExportNode (..), FlowDetail (..), FlowInfo (..), FlowRole (..), FlowSearchResult (..), FlowSummary (..), GraphEdge (..), GraphExport (..), GraphNode (..), InventoryExport (..), InventoryFlowDetail (..), InventoryMetadata (..), InventoryStatistics (..), NodeType (..), Perturbation (..), RootDb (..), SearchResults (..), Substitution (..), SupplyChainEdge (..), SupplyChainEntry (..), SupplyChainResponse (..), ThisDb (..), TreeEdge (..), TreeExport (..), TreeMetadata (..), apiFlowOfKind, parseSubRef, unresolvedFlowName)
+import API.Types (ActivityForAPI (..), ActivityInfo (..), ActivityLinks (..), ActivityMetadata (..), ActivityStats (..), ActivitySummary (..), ApiFlow (..), ClassificationSystem (..), ConsumerResult (..), ConsumersResponse (..), CutoffWasteFlow (..), EdgeType (..), ExchangeDetail (..), ExchangeWithUnit (..), ExportNode (..), FlowDetail (..), FlowInfo (..), FlowRole (..), FlowSearchResult (..), FlowSummary (..), GraphEdge (..), GraphExport (..), GraphNode (..), InventoryExport (..), InventoryFlowDetail (..), InventoryMetadata (..), InventoryStatistics (..), NodeType (..), Perturbation (..), RootDb (..), SearchResults (..), Substitution (..), SubstitutionScope (..), SupplyChainEdge (..), SupplyChainEntry (..), SupplyChainResponse (..), ThisDb (..), TreeEdge (..), TreeExport (..), TreeMetadata (..), apiFlowOfKind, parseSubRef, subAnchorRef, unresolvedFlowName)
 import CLI.Types (DebugMatricesOptions (..))
 import Control.Applicative ((<|>))
 import Control.Concurrent.Async (mapConcurrently)
@@ -30,7 +30,7 @@ import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import Database (applyStructuredFilters, findActivitiesByFields, findFlowsBySynonym)
-import Matrix (DepDemands, Inventory, accumulateDepDemandsWith, activityNormalizationFactor, applyBiosphereMatrix, applySparseMatrix, buildDemandVectorFromIndex, computeInventoryMatrix, depDemandsToVector, perturbA, perturbABatch, toList)
+import Matrix (DepDemands, Inventory, accumulateDepDemandsWith, activityNormalizationFactor, applyBiosphereMatrix, applySparseMatrix, buildDemandVectorFromIndex, computeInventoryMatrix, depDemandsToVector, perturbA, perturbABatch, perturbGlobal, toList)
 import qualified Matrix.Export as MatrixExport
 import Plugin.Types (Severity (..), ValidateContext (..), ValidateHandle (..), ValidationIssue (..), ValidationPhase (..))
 import qualified Progress
@@ -41,7 +41,7 @@ import SharedSolver (SharedSolver, getFactorization, solveWithSharedSolver)
 import qualified SharedSolver
 import Tree (buildLoopAwareTree)
 import Types
-import UnitConversion (UnitConfig, defaultUnitConfig, unitsCompatible)
+import UnitConversion (UnitConfig, convertUnit, defaultUnitConfig, unitsCompatible)
 
 {- | Fields shared by every activity-oriented endpoint (search, supply chain,
 consumers). Split out from the endpoint-specific filters so each filter
@@ -1986,37 +1986,44 @@ computeScalingVectorWithSubstitutions db sharedSolver processId subs = do
             mFact <- getFactorization sharedSolver
             foldSubstitutions originalX subs (applySubstitution mFact)
   where
-    applySubstitution mFact x sub =
-        case ( resolveActivityAndProcessId db (subFrom sub)
-             , resolveActivityAndProcessId db (subTo sub)
-             , resolveActivityAndProcessId db (subConsumer sub)
-             ) of
-            (Left err, _, _) -> return $ Left err
-            (_, Left err, _) -> return $ Left err
-            (_, _, Left err) -> return $ Left err
-            (Right (oldPid, _), Right (newPid, _), Right (consumerPid, _)) ->
-                case findTechCoefficient db consumerPid oldPid of
-                    Nothing ->
-                        return $
-                            Left $
-                                MatrixError $
-                                    "No technosphere link from "
-                                        <> processIdToText db consumerPid
-                                        <> " to supplier "
-                                        <> subFrom sub
-                    Just a -> do
-                        -- Symmetric root-only swap: +a at old supplier, -a at new.
-                        let perturb = [(fromIntegral oldPid, a), (fromIntegral newPid, -a)]
-                        smResult <-
-                            perturbA
-                                db
-                                mFact
-                                x
-                                (fromIntegral consumerPid)
-                                perturb
-                        return $ case smResult of
-                            Left msg -> Left $ MatrixError msg
-                            Right x' -> Right x'
+    -- This root-only path predates cross-DB support and is now only reached
+    -- with an empty sub list; the cross-DB applicator ('applySubstitutionsAt')
+    -- carries the production substitution logic. Both scopes are handled here
+    -- regardless, sharing 'planGlobalWithinDB' so the two paths can't diverge.
+    applySubstitution mFact x sub = case subScope sub of
+        OneEdge cRef ->
+            case ( resolveActivityAndProcessId db (subFrom sub)
+                 , resolveActivityAndProcessId db (subTo sub)
+                 , resolveActivityAndProcessId db cRef
+                 ) of
+                (Left err, _, _) -> return $ Left err
+                (_, Left err, _) -> return $ Left err
+                (_, _, Left err) -> return $ Left err
+                (Right (oldPid, _), Right (newPid, _), Right (consumerPid, _)) ->
+                    case findTechCoefficient db consumerPid oldPid of
+                        Nothing ->
+                            return $
+                                Left $
+                                    MatrixError $
+                                        "No technosphere link from "
+                                            <> processIdToText db consumerPid
+                                            <> " to supplier "
+                                            <> subFrom sub
+                        Just a -> do
+                            -- Symmetric root-only swap: +a at old supplier, -a at new.
+                            let perturb = [(fromIntegral oldPid, a), (fromIntegral newPid, -a)]
+                            smResult <- perturbA db mFact x (fromIntegral consumerPid) perturb
+                            return $ either (Left . MatrixError) Right smResult
+        AllConsumers ->
+            case (resolveActivityAndProcessId db (subFrom sub), resolveActivityAndProcessId db (subTo sub)) of
+                (Left err, _) -> return $ Left err
+                (_, Left err) -> return $ Left err
+                (Right (fromPid, _), Right (toPid, _)) ->
+                    case planGlobalWithinDB defaultUnitConfig db fromPid toPid of
+                        Left err -> return $ Left err
+                        Right gupd -> do
+                            smResult <- perturbGlobal db mFact x (gruU gupd) (gruV gupd)
+                            return $ either (Left . MatrixError) Right smResult
 
     foldSubstitutions x [] _ = return $ Right x
     foldSubstitutions x (s : ss) f = do
@@ -2110,14 +2117,36 @@ resolveRootOnly db t
 maxSubsDepth :: Int
 maxSubsDepth = 10
 
+{- | A global ('AllConsumers') substitution enumerates the replaced supplier's
+consumers from the __root__ technosphere row, so @from@ must live in the
+root DB. Reject a dep-qualified @from@ up front rather than letting the
+per-level filter route it to a dep level (or silently drop it when that dep
+is never visited). Per-edge ('OneEdge') subs are unaffected — they keep
+their existing cross-DB freedom.
+-}
+globalFromMustLiveInRoot :: RootDb -> [Substitution] -> Either ServiceError ()
+globalFromMustLiveInRoot rootDb subs =
+    case [ fromDb
+         | sub <- subs
+         , AllConsumers <- [subScope sub]
+         , let (fromDb, _) = parseSubRef rootDb (subFrom sub)
+         , fromDb /= unRootDb rootDb
+         ] of
+        [] -> Right ()
+        (d : _) ->
+            Left $
+                MatrixError $
+                    "global substitution requires the replaced activity (from) to live in the root database (got: " <> d <> ")"
+
 {- | What-if inventory with substitutions applied at every DB level of the
 dep graph. Substitutions are filtered at each level by
 'applySubstitutionsAt' — a sub whose consumer lives in a dep DB is
 applied when the recursion reaches that dep DB's solver, not at root.
 
 This generalizes the root-only path: substitutions in @subFrom@/@subTo@
-may live in any loaded database (qualified as @"dbName::pid"@), and
-@subConsumer@ may also be qualified — the filter finds the right level.
+may live in any loaded database (qualified as @"dbName::pid"@), and a
+'OneEdge' consumer may also be qualified — the filter finds the right
+level. Global ('AllConsumers') subs are anchored at their root @from@.
 -}
 inventoryWithSubsAndDeps ::
     UnitConfig ->
@@ -2129,22 +2158,26 @@ inventoryWithSubsAndDeps ::
     ProcessId ->
     [Substitution] ->
     IO (Either ServiceError SharedSolver.CrossDBSolution)
-inventoryWithSubsAndDeps unitCfg depLookup db rootDbName solver pid subs = do
-    let rootDb = RootDb rootDbName
-    eValid <- validateConsumerDbs depLookup db rootDb subs
-    case eValid of
+inventoryWithSubsAndDeps unitCfg depLookup db rootDbName solver pid subs =
+    case globalFromMustLiveInRoot rootDb subs of
         Left e -> pure (Left e)
         Right () -> do
-            let demand = buildDemandVectorFromIndex (dbActivityIndex db) pid
-            res <- goWithSubsAndDeps unitCfg depLookup db (ThisDb rootDbName) rootDb solver [demand] subs 0
-            pure $ case res of
-                Left err -> Left err
-                Right (sol : _) -> Right sol
-                Right [] ->
-                    -- unreachable: K=1 single-demand always yields one solution.
-                    -- Surface as Left rather than fabricate an empty solution
-                    -- with no 'csScalings' (NonEmpty forbids it).
-                    Left $ MatrixError "inventoryWithSubsAndDeps: empty result for single demand"
+            eValid <- validateConsumerDbs depLookup db rootDb subs
+            case eValid of
+                Left e -> pure (Left e)
+                Right () -> do
+                    let demand = buildDemandVectorFromIndex (dbActivityIndex db) pid
+                    res <- goWithSubsAndDeps unitCfg depLookup db (ThisDb rootDbName) rootDb solver [demand] subs 0
+                    pure $ case res of
+                        Left err -> Left err
+                        Right (sol : _) -> Right sol
+                        Right [] ->
+                            -- unreachable: K=1 single-demand always yields one solution.
+                            -- Surface as Left rather than fabricate an empty solution
+                            -- with no 'csScalings' (NonEmpty forbids it).
+                            Left $ MatrixError "inventoryWithSubsAndDeps: empty result for single demand"
+  where
+    rootDb = RootDb rootDbName
 
 {- | Reject substitutions whose consumer is qualified to a DB that is either
 unloaded or not reachable from @rootDbName@ via 'dbCrossDBLinks'. Such
@@ -2165,7 +2198,7 @@ validateConsumerDbs depLookup rootDbObj rootDb subs = do
                 S.fromList
                     [ cDb
                     | sub <- subs
-                    , let (cDb, _) = parseSubRef rootDb (subConsumer sub)
+                    , let (cDb, _) = parseSubRef rootDb (subAnchorRef sub)
                     ]
     if S.null externalConsumerDbs
         then pure (Right ())
@@ -2229,7 +2262,7 @@ goWithSubsAndDeps ::
     IO (Either ServiceError [SharedSolver.CrossDBSolution])
 goWithSubsAndDeps unitCfg depLookup thisDb thisDbName rootDb solver demands allSubs depth = do
     scalings <- SharedSolver.solveMultiWithSharedSolver solver demands
-    eApply <- applySubstitutionsAt depLookup thisDb thisDbName rootDb solver scalings allSubs
+    eApply <- applySubstitutionsAt unitCfg depLookup thisDb thisDbName rootDb solver scalings allSubs
     case eApply of
         Left e -> pure (Left e)
         Right (scalings', virtualLks) -> propagate scalings' virtualLks
@@ -2304,6 +2337,7 @@ an error (the inventory/LCIA path lifts this restriction via
 'goWithSubsAndDeps').
 -}
 computeScalingVectorWithSubstitutionsCrossDB ::
+    UnitConfig ->
     SharedSolver.DepSolverLookup ->
     Database ->
     -- | root DB name
@@ -2312,9 +2346,9 @@ computeScalingVectorWithSubstitutionsCrossDB ::
     ProcessId ->
     [Substitution] ->
     IO (Either ServiceError (U.Vector Double, [CrossDBLink]))
-computeScalingVectorWithSubstitutionsCrossDB depLookup db rootDbName solver pid subs = do
+computeScalingVectorWithSubstitutionsCrossDB unitCfg depLookup db rootDbName solver pid subs = do
     let rootDb = RootDb rootDbName
-    case firstNonRootConsumer rootDb of
+    case firstNonRootAnchor rootDb of
         Just cDb ->
             pure $
                 Left $
@@ -2323,17 +2357,17 @@ computeScalingVectorWithSubstitutionsCrossDB depLookup db rootDbName solver pid 
         Nothing -> do
             let demandVec = buildDemandVectorFromIndex (dbActivityIndex db) pid
             originalX <- solveWithSharedSolver solver demandVec
-            res <- applySubstitutionsAt depLookup db (ThisDb rootDbName) rootDb solver [originalX] subs
+            res <- applySubstitutionsAt unitCfg depLookup db (ThisDb rootDbName) rootDb solver [originalX] subs
             pure $ case res of
                 Left e -> Left e
                 Right ([x'], links) -> Right (x', links)
                 Right (x' : _, links) -> Right (x', links) -- unreachable: K=1
                 Right ([], _) -> Right (originalX, []) -- unreachable
   where
-    firstNonRootConsumer rootDb =
+    firstNonRootAnchor rootDb =
         case [ cDb
              | sub <- subs
-             , let (cDb, _) = parseSubRef rootDb (subConsumer sub)
+             , let (cDb, _) = parseSubRef rootDb (subAnchorRef sub)
              , cDb /= rootDbName
              ] of
             (d : _) -> Just d
@@ -2371,6 +2405,78 @@ data RankOneUpdate = RankOneUpdate
     , ruExtras :: ![CrossDBLink]
     }
 
+{- | A planned __global__ rank-1 update: replace one supplier by another on
+every consumer at once. @gruU@ is the supplier-axis perturbation, @gruV@
+the consumer-axis projection (the replaced supplier's technosphere row),
+and @gruExtras@ the virtual cross-DB links (only when the new supplier
+lives in a dep DB). Consumed by 'perturbGlobal'. See 'planGlobalWithinDB'.
+-}
+data GlobalRankOneUpdate = GlobalRankOneUpdate
+    { gruU :: ![(Int, Double)]
+    , gruV :: ![(Int, Double)]
+    , gruExtras :: ![CrossDBLink]
+    }
+
+{- | The replaced supplier's technosphere row: every consumer that sources
+from @supplier@, paired with the (normalized) coefficient. Index space
+matches 'perturbA' / 'findTechCoefficient' (ProcessId == matrix index).
+Empty when the supplier is consumed nowhere.
+-}
+technosphereRow :: Database -> ProcessId -> [(Int, Double)]
+technosphereRow db supplier =
+    let supplierIdx = fromIntegral supplier :: Int32
+     in [ (fromIntegral col, val)
+        | SparseTriple row col val <- U.toList (dbTechnosphereTriples db)
+        , row == supplierIdx
+        ]
+
+{- | The replaced supplier's row, or 'Left' when it is consumed nowhere — a
+global substitution on such an activity is vacuous, never a silent no-op.
+-}
+requireConsumers :: Database -> ProcessId -> Either ServiceError [(Int, Double)]
+requireConsumers db supplier = case technosphereRow db supplier of
+    [] -> Left $ MatrixError $ "global substitution: activity is consumed nowhere: " <> processIdToText db supplier
+    row -> Right row
+
+-- | Reference-product unit an activity's technosphere column is normalized to.
+referenceProductUnit :: Database -> ProcessId -> Maybe Text
+referenceProductUnit db pid =
+    case [ex | ex <- exchanges (dbActivities db V.! fromIntegral pid), exchangeIsReference ex, not (exchangeIsInput ex)] of
+        (ex : _) -> Just (getUnitNameForExchange (dbUnits db) ex)
+        [] -> Nothing
+
+{- | Unit-conversion factor κ for a within-DB substitution @from → to@: how
+many reference units of @to@'s product equal one of @from@'s, so the
+coefficient @a@ (in @from@'s unit) becomes @a·κ@ on @to@. Identical units
+give @κ = 1@ (matching the per-edge path, which assumes same-unit
+suppliers). 'Left' when the two reference products are dimensionally
+incompatible — never a silently wrong coefficient.
+-}
+substitutionUnitFactor :: UnitConfig -> Database -> ProcessId -> ProcessId -> Either ServiceError Double
+substitutionUnitFactor unitCfg db fromPid toPid = do
+    fromUnit <- maybe (Left $ noRefUnit fromPid) Right $ referenceProductUnit db fromPid
+    toUnit <- maybe (Left $ noRefUnit toPid) Right $ referenceProductUnit db toPid
+    -- Identical units are κ = 1 by definition, independent of the conversion
+    -- table (which may not list every unit). Only differing units need a lookup.
+    if fromUnit == toUnit
+        then Right 1.0
+        else maybe (Left $ incompatible fromUnit toUnit) Right $ convertUnit unitCfg fromUnit toUnit 1.0
+  where
+    noRefUnit pid = MatrixError $ "substitution endpoint has no reference product unit: " <> processIdToText db pid
+    incompatible fu tu =
+        MatrixError $ "global substitution units are incompatible: " <> fu <> " -> " <> tu <> " (no conversion factor)"
+
+{- | Plan a within-DB global swap @from → to@ as a two-sided rank-1 update:
+@u = e_from - κ·e_to@, @v = from@'s technosphere row. The +1 at @from@
+removes it from every consumer; the @-κ@ at @to@ adds the unit-converted
+demand. No virtual links (both suppliers live in this DB).
+-}
+planGlobalWithinDB :: UnitConfig -> Database -> ProcessId -> ProcessId -> Either ServiceError GlobalRankOneUpdate
+planGlobalWithinDB unitCfg db fromPid toPid = do
+    v <- requireConsumers db fromPid
+    kappa <- substitutionUnitFactor unitCfg db fromPid toPid
+    Right $ GlobalRankOneUpdate [(fromIntegral fromPid, 1.0), (fromIntegral toPid, negate kappa)] v []
+
 {- | Apply all substitutions whose consumer lives in @thisDbName@ to the
 given scaling vectors. Substitutions whose consumer lives elsewhere are
 skipped at this level — they'll match at the DB where their consumer
@@ -2394,6 +2500,8 @@ static link surface as 'MatrixError' (no silent fallback — the caller
 maps to 422).
 -}
 applySubstitutionsAt ::
+    -- | unit config (κ for within-DB global swaps)
+    UnitConfig ->
     SharedSolver.DepSolverLookup ->
     -- | THIS DB
     Database ->
@@ -2405,11 +2513,11 @@ applySubstitutionsAt ::
     SharedSolver ->
     -- | K scalings at this level
     [U.Vector Double] ->
-    -- | full sub list (filtered to consumer==this)
+    -- | full sub list (filtered to anchor==this)
     [Substitution] ->
     IO (Either ServiceError ([U.Vector Double], [CrossDBLink]))
-applySubstitutionsAt depLookup thisDb thisDbObj rootDb solver scalings allSubs =
-    case filter consumerLivesHere allSubs of
+applySubstitutionsAt unitCfg depLookup thisDb thisDbObj rootDb solver scalings allSubs =
+    case filter anchorLivesHere allSubs of
         [] -> pure $ Right (scalings, [])
         localSubs -> do
             mFact <- getFactorization solver
@@ -2425,23 +2533,35 @@ applySubstitutionsAt depLookup thisDb thisDbObj rootDb solver scalings allSubs =
     -- exist, and would also misroute bare suppliers in dep-level
     -- recursion. The 'RootDb' newtype on 'parseSubRef' makes the
     -- argument-swap unrepresentable.
-    consumerLivesHere sub =
-        let (cDb, _) = parseSubRef rootDb (subConsumer sub)
-         in cDb == thisDbName
+    anchorLivesHere sub =
+        let (aDb, _) = parseSubRef rootDb (subAnchorRef sub)
+         in aDb == thisDbName
 
-    -- Resolve, plan, and apply one substitution; thread the K scalings
-    -- and the accumulated virtual links. 'from' is resolved before 'to'
-    -- so a failing 'from' wins when both refs are unresolvable.
-    step mFact (xs, links) sub = do
-        let (_, cPidText) = parseSubRef rootDb (subConsumer sub)
-            (fromDb, fromPidText) = parseSubRef rootDb (subFrom sub)
+    -- Resolve, plan, and apply one substitution; thread the K scalings and
+    -- the accumulated virtual links. 'from' is resolved before 'to' so a
+    -- failing 'from' wins when both refs are unresolvable. A 'OneEdge' sub
+    -- swaps the supplier on its single consumer column; an 'AllConsumers'
+    -- sub swaps it on every consumer at once via one global rank-1 update.
+    step mFact (xs, links) sub = case subScope sub of
+        OneEdge cRef -> do
+            let (_, cPidText) = parseSubRef rootDb cRef
+            (cPid, _) <- hoistEither $ resolveActivityAndProcessId thisDb cPidText
+            (fromEp, toEp) <- resolveFromTo sub
+            upd <- hoistEither $ planUpdate sub cPid fromEp toEp
+            (xs', extra) <- ExceptT $ applyRankOne mFact xs upd
+            pure (xs', links ++ extra)
+        AllConsumers -> do
+            (fromEp, toEp) <- resolveFromTo sub
+            gupd <- hoistEither $ planGlobalUpdate fromEp toEp
+            (xs', extra) <- ExceptT $ applyGlobalRankOne mFact xs gupd
+            pure (xs', links ++ extra)
+
+    resolveFromTo sub = do
+        let (fromDb, fromPidText) = parseSubRef rootDb (subFrom sub)
             (toDb, toPidText) = parseSubRef rootDb (subTo sub)
-        (cPid, _) <- hoistEither $ resolveActivityAndProcessId thisDb cPidText
         fromEp <- ExceptT $ resolveEndpoint fromDb fromPidText
         toEp <- ExceptT $ resolveEndpoint toDb toPidText
-        upd <- hoistEither $ planUpdate sub cPid fromEp toEp
-        (xs', extra) <- ExceptT $ applyRankOne mFact xs upd
-        pure (xs', links ++ extra)
+        pure (fromEp, toEp)
 
     hoistEither = ExceptT . pure
 
@@ -2483,6 +2603,24 @@ applySubstitutionsAt depLookup thisDb thisDbObj rootDb solver scalings allSubs =
             newLk = virtualLinkTo cPid toRef aRaw
         Right $ RankOneUpdate cPid [] [cancel, newLk]
 
+    -- Global swap @from → to@ over every consumer of @from@. @from@ must
+    -- live in this (root) DB; @to@ either lives here (within-DB, two-sided
+    -- rank-1 with unit factor κ) or in a dep DB (one-sided removal of @from@
+    -- plus one virtual link per consumer carrying its raw demand to @to@).
+    planGlobalUpdate :: Endpoint -> Endpoint -> Either ServiceError GlobalRankOneUpdate
+    planGlobalUpdate fromEp toEp = case fromEp of
+        Elsewhere _ ->
+            Left $ MatrixError "global substitution requires the replaced activity (from) to live in the root database"
+        Here fromPid _ -> case toEp of
+            Here toPid _ -> planGlobalWithinDB unitCfg thisDb fromPid toPid
+            Elsewhere toRef -> do
+                v <- requireConsumers thisDb fromPid
+                let links =
+                        [ virtualLinkTo (fromIntegral j) toRef (a * activityNormalizationFactor thisDb (fromIntegral j))
+                        | (j, a) <- v
+                        ]
+                Right $ GlobalRankOneUpdate [(fromIntegral fromPid, 1.0)] v links
+
     virtualLinkTo cPid toRef =
         mkVirtualLink thisDb cPid (drDb toRef) (drDbName toRef) (drUUIDs toRef) (drPid toRef)
 
@@ -2504,6 +2642,12 @@ applySubstitutionsAt depLookup thisDb thisDbObj rootDb solver scalings allSubs =
         pure $ case sequence results of
             Left msg -> Left (MatrixError msg)
             Right xs' -> Right (xs', ruExtras upd)
+
+    applyGlobalRankOne mFact xs gupd = do
+        results <- mapM (\x -> perturbGlobal thisDb mFact x (gruU gupd) (gruV gupd)) xs
+        pure $ case sequence results of
+            Left msg -> Left (MatrixError msg)
+            Right xs' -> Right (xs', gruExtras gupd)
 
     noTechLink sub cPid =
         MatrixError $

--- a/test/CrossDBSubstitutionSpec.hs
+++ b/test/CrossDBSubstitutionSpec.hs
@@ -10,7 +10,7 @@ database under two names via 'DepSolverLookup'.
 -}
 module CrossDBSubstitutionSpec (spec) where
 
-import API.Types (RootDb (..), Substitution (..), parseSubRef)
+import API.Types (RootDb (..), Substitution (..), SubstitutionScope (..), parseSubRef)
 import qualified Data.Text as T
 import qualified Data.Vector.Unboxed as U
 import Service (
@@ -47,7 +47,7 @@ spec = do
             db <- loadSampleDatabase "SAMPLE.min3"
             solver <- mkSolver db "root"
             let noDeps _ = pure Nothing
-            res <- computeScalingVectorWithSubstitutionsCrossDB noDeps db "root" solver 0 []
+            res <- computeScalingVectorWithSubstitutionsCrossDB defaultUnitConfig noDeps db "root" solver 0 []
             case res of
                 Right (x, links) -> do
                     U.length x `shouldBe` fromIntegral (dbActivityCount db)
@@ -62,9 +62,9 @@ spec = do
                     Substitution
                         { subFrom = "00000000-0000-0000-0000-000000000000_00000000-0000-0000-0000-000000000000"
                         , subTo = "00000000-0000-0000-0000-000000000000_00000000-0000-0000-0000-000000000000"
-                        , subConsumer = "dep-db::00000000-0000-0000-0000-000000000000_00000000-0000-0000-0000-000000000000"
+                        , subScope = OneEdge "dep-db::00000000-0000-0000-0000-000000000000_00000000-0000-0000-0000-000000000000"
                         }
-            res <- computeScalingVectorWithSubstitutionsCrossDB noDeps db "root" solver 0 [badSub]
+            res <- computeScalingVectorWithSubstitutionsCrossDB defaultUnitConfig noDeps db "root" solver 0 [badSub]
             case res of
                 Left (MatrixError msg) ->
                     msg `shouldSatisfy` T.isInfixOf "consumer must live in root"
@@ -82,9 +82,9 @@ spec = do
                     Substitution
                         { subFrom = "missing-dep::" <> realRootPid
                         , subTo = realRootPid
-                        , subConsumer = realRootPid
+                        , subScope = OneEdge realRootPid
                         }
-            res <- computeScalingVectorWithSubstitutionsCrossDB noDeps db "root" solver 0 [sub]
+            res <- computeScalingVectorWithSubstitutionsCrossDB defaultUnitConfig noDeps db "root" solver 0 [sub]
             case res of
                 Left (MatrixError msg) ->
                     msg `shouldSatisfy` T.isInfixOf "unloaded database"

--- a/test/GlobalSubstitutionSpec.hs
+++ b/test/GlobalSubstitutionSpec.hs
@@ -1,0 +1,204 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Global ('AllConsumers') substitution tests.
+
+Core claim: a global swap @from → to@ is a single Sherman-Morrison rank-1
+update that equals solving the technosphere matrix with @from@'s row
+relocated onto @to@. We prove it by comparing the rank-1 result against a
+fresh factorization of the relocated matrix — NOT against an edge-by-edge
+expansion, which (using the cached factorization per edge) is only an
+approximation of the simultaneous swap.
+
+Plus the guards: identity is a no-op, an unconsumed @from@ fails loudly
+(never a silent no-op), a dep-qualified @from@ is rejected (global needs a
+root supplier), and incompatible reference units fail rather than silently
+reusing the coefficient.
+-}
+module GlobalSubstitutionSpec (spec) where
+
+import API.Types (Substitution (..), SubstitutionScope (..))
+import Data.Either (isLeft)
+import Data.Int (Int32)
+import Data.List (isInfixOf)
+import qualified Data.Map.Strict as M
+import Data.Maybe (listToMaybe)
+import qualified Data.Text as T
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as U
+import Matrix (buildDemandVectorFromIndex)
+import Service (
+    ServiceError (..),
+    computeScalingVectorWithSubstitutionsCrossDB,
+    substitutionUnitFactor,
+    technosphereRow,
+ )
+import SharedSolver (SharedSolver, createSharedSolver, solveWithSharedSolver)
+import Test.Hspec
+import TestHelpers (linkDatabases, loadSampleDatabase, mkDepLookupFromMap, mkSolverFromDb)
+import Types
+import UnitConversion (defaultUnitConfig)
+
+spec :: Spec
+spec = do
+    describe "global substitution (AllConsumers)" $ do
+        it "within-DB swap equals a re-solve of the relocated matrix" $ do
+            db <- loadSampleDatabase "SAMPLE.min3"
+            solver <- mkSolver db "root"
+            let noDeps _ = pure Nothing
+            case pickGlobalAB db of
+                Nothing -> expectationFailure "fixture has no supplier with an off-diagonal consumer"
+                Just (aPid, bPid) -> do
+                    let sub = Substitution (processIdToText db aPid) (processIdToText db bPid) AllConsumers
+                    gRes <- computeScalingVectorWithSubstitutionsCrossDB defaultUnitConfig noDeps db "root" solver 0 [sub]
+                    refSolver <- createSharedSolver "ref" (relocateRow db aPid bPid) (fromIntegral (dbActivityCount db))
+                    xRef <- solveWithSharedSolver refSolver (buildDemandVectorFromIndex (dbActivityIndex db) 0)
+                    case gRes of
+                        Right (xGlobal, links) -> do
+                            links `shouldBe` []
+                            U.toList xGlobal `shouldSatisfy` vecNear (U.toList xRef)
+                        Left e -> expectationFailure ("global swap failed: " <> show e)
+
+        it "identity swap (from == to) is a no-op" $ do
+            db <- loadSampleDatabase "SAMPLE.min3"
+            solver <- mkSolver db "root"
+            let noDeps _ = pure Nothing
+            case pickGlobalAB db of
+                Nothing -> expectationFailure "fixture has no supplier with an off-diagonal consumer"
+                Just (aPid, _) -> do
+                    let ident = Substitution (processIdToText db aPid) (processIdToText db aPid) AllConsumers
+                    base <- computeScalingVectorWithSubstitutionsCrossDB defaultUnitConfig noDeps db "root" solver 0 []
+                    gRes <- computeScalingVectorWithSubstitutionsCrossDB defaultUnitConfig noDeps db "root" solver 0 [ident]
+                    case (base, gRes) of
+                        (Right (x0, _), Right (xg, _)) -> U.toList xg `shouldSatisfy` vecNear (U.toList x0)
+                        _ -> expectationFailure "identity or baseline solve failed"
+
+        it "fails loudly when 'from' is consumed nowhere (no silent no-op)" $ do
+            db <- loadSampleDatabase "SAMPLE.min3"
+            solver <- mkSolver db "root"
+            let noDeps _ = pure Nothing
+            case nonSupplier db of
+                Nothing -> expectationFailure "fixture has no unconsumed activity"
+                Just leaf -> do
+                    let toPid = if leaf == 0 then 1 else 0
+                        sub = Substitution (processIdToText db leaf) (processIdToText db toPid) AllConsumers
+                    res <- computeScalingVectorWithSubstitutionsCrossDB defaultUnitConfig noDeps db "root" solver 0 [sub]
+                    case res of
+                        Left (MatrixError msg) -> T.unpack msg `shouldSatisfy` isInfixOf "consumed nowhere"
+                        other -> expectationFailure ("expected 'consumed nowhere' Left, got " <> show other)
+
+        it "rejects a dep-qualified 'from' (global requires a root supplier)" $ do
+            db <- loadSampleDatabase "SAMPLE.min3"
+            solver <- mkSolver db "root"
+            let noDeps _ = pure Nothing
+                bare = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa_bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+                sub = Substitution ("dep::" <> bare) bare AllConsumers
+            res <- computeScalingVectorWithSubstitutionsCrossDB defaultUnitConfig noDeps db "root" solver 0 [sub]
+            case res of
+                Left (MatrixError msg) -> T.unpack msg `shouldSatisfy` isInfixOf "root"
+                other -> expectationFailure ("expected root-only Left, got " <> show other)
+
+        it "cross-DB swap removes 'from' from the root and emits one link per consumer" $ do
+            -- B lives in a dep DB: the root rank-1 is one-sided (just remove A),
+            -- so the root scaling must match a re-solve with A's row deleted, and
+            -- the demand is carried to the dep by one virtual link per consumer.
+            rootRaw <- loadSampleDatabase "SAMPLE.min3"
+            dep <- loadSampleDatabase "SAMPLE.min3"
+            let root = linkDatabases rootRaw dep "dep" 0.1
+            rootSolver <- mkSolverFromDb root "root"
+            depSolver <- mkSolverFromDb dep "dep"
+            let lookup_ = mkDepLookupFromMap (M.singleton "dep" (dep, depSolver))
+            case pickGlobalAB root of
+                Nothing -> expectationFailure "root fixture has no supplier with a consumer"
+                Just (aPid, _) -> do
+                    let bPid = 0 :: ProcessId
+                        nConsumers = length (technosphereRow root aPid)
+                        sub = Substitution (processIdToText root aPid) ("dep::" <> processIdToText dep bPid) AllConsumers
+                    gRes <- computeScalingVectorWithSubstitutionsCrossDB defaultUnitConfig lookup_ root "root" rootSolver 0 [sub]
+                    refSolver <- createSharedSolver "ref" (deleteRow root aPid) (fromIntegral (dbActivityCount root))
+                    xRef <- solveWithSharedSolver refSolver (buildDemandVectorFromIndex (dbActivityIndex root) 0)
+                    case gRes of
+                        Right (xGlobal, links) -> do
+                            length links `shouldBe` nConsumers
+                            U.toList xGlobal `shouldSatisfy` vecNear (U.toList xRef)
+                        Left e -> expectationFailure ("cross-DB global failed: " <> show e)
+
+    describe "substitutionUnitFactor (κ guard)" $
+        it "κ = 1 for identical units, Left for incompatible reference products" $ do
+            db <- loadSampleDatabase "SAMPLE.units"
+            -- electricity is in MJ, steel in kg — energy vs mass, no conversion.
+            case (activityByInfix db "electricity generation", activityByInfix db "steel production") of
+                (Just elec, Just steel) -> do
+                    substitutionUnitFactor defaultUnitConfig db elec steel `shouldSatisfy` isLeft
+                    substitutionUnitFactor defaultUnitConfig db elec elec `shouldSatisfy` isRightNear 1.0
+                _ -> expectationFailure "SAMPLE.units missing electricity/steel activities"
+
+-- | A fresh 'SharedSolver' over a database's own technosphere triples.
+mkSolver :: Database -> T.Text -> IO SharedSolver
+mkSolver db name =
+    createSharedSolver
+        name
+        [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList (dbTechnosphereTriples db)]
+        (fromIntegral (dbActivityCount db))
+
+{- | Technosphere triples with @from@'s row relocated onto @to@ (κ = 1), i.e.
+every consumer that sourced @from@ now sources @to@ by the same amount.
+This is the ground-truth matrix a global swap must reproduce.
+-}
+relocateRow :: Database -> ProcessId -> ProcessId -> [(Int, Int, Double)]
+relocateRow db aPid bPid =
+    let aIdx = fromIntegral aPid :: Int
+        bIdx = fromIntegral bPid :: Int
+        merged =
+            M.fromListWith
+                (+)
+                [ ((if fromIntegral i == aIdx then bIdx else fromIntegral i, fromIntegral j), v)
+                | SparseTriple i j v <- U.toList (dbTechnosphereTriples db)
+                ]
+     in [(i, j, v) | ((i, j), v) <- M.toList merged]
+
+{- | Technosphere triples with @from@'s row deleted: the ground-truth root
+matrix after a cross-DB global swap, which only removes @from@ on the root
+side (the demand is carried to the dep supplier by virtual links).
+-}
+deleteRow :: Database -> ProcessId -> [(Int, Int, Double)]
+deleteRow db aPid =
+    let aIdx = fromIntegral aPid :: Int
+     in [ (fromIntegral i, fromIntegral j, v)
+        | SparseTriple i j v <- U.toList (dbTechnosphereTriples db)
+        , fromIntegral i /= aIdx
+        ]
+
+{- | First supplier with an off-diagonal consumer, paired with any other
+activity as the replacement. SAMPLE.min3 is single-unit, so κ = 1 holds.
+-}
+pickGlobalAB :: Database -> Maybe (ProcessId, ProcessId)
+pickGlobalAB db =
+    let n = fromIntegral (dbActivityCount db) :: Int
+        suppliers = [fromIntegral i | SparseTriple i j _ <- U.toList (dbTechnosphereTriples db), i /= j]
+     in case suppliers of
+            (a : _) -> (,) a <$> listToMaybe [fromIntegral p | p <- [0 .. n - 1], fromIntegral p /= a]
+            [] -> Nothing
+
+-- | An activity that supplies no consumer (its technosphere row is empty).
+nonSupplier :: Database -> Maybe ProcessId
+nonSupplier db =
+    let n = fromIntegral (dbActivityCount db) :: Int
+        rows = [i | SparseTriple i _ _ <- U.toList (dbTechnosphereTriples db)]
+     in listToMaybe [fromIntegral p | p <- [0 .. n - 1], (fromIntegral p :: Int32) `notElem` rows]
+
+-- | First activity whose name contains the given substring.
+activityByInfix :: Database -> T.Text -> Maybe ProcessId
+activityByInfix db nm =
+    listToMaybe
+        [ fromIntegral i
+        | i <- [0 .. V.length (dbActivities db) - 1]
+        , nm `T.isInfixOf` activityName (dbActivities db V.! i)
+        ]
+
+-- | Elementwise closeness of two scaling vectors.
+vecNear :: [Double] -> [Double] -> Bool
+vecNear ref xs = length ref == length xs && and (zipWith (\a b -> abs (a - b) < 1e-9) ref xs)
+
+-- | 'ServiceError' has no 'Eq' instance, so assert the κ value via a predicate.
+isRightNear :: Double -> Either ServiceError Double -> Bool
+isRightNear target = either (const False) (\k -> abs (k - target) < 1e-9)

--- a/test/NestedSubstitutionSpec.hs
+++ b/test/NestedSubstitutionSpec.hs
@@ -11,7 +11,7 @@ rely on the shared classifier body already covered by
 -}
 module NestedSubstitutionSpec (spec) where
 
-import API.Types (RootDb (..), Substitution (..), SupplyChainEntry (..), SupplyChainResponse (..), ThisDb (..))
+import API.Types (RootDb (..), Substitution (..), SubstitutionScope (..), SupplyChainEntry (..), SupplyChainResponse (..), ThisDb (..))
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import qualified Data.Vector.Unboxed as U
@@ -59,10 +59,10 @@ spec = do
                     Substitution
                         { subFrom = qualifiedPid
                         , subTo = qualifiedPid
-                        , subConsumer = qualifiedPid
+                        , subScope = OneEdge qualifiedPid
                         }
                 noDeps _ = pure Nothing
-            res <- applySubstitutionsAt noDeps db (ThisDb "root") (RootDb "root") solver [baselineX] [sub]
+            res <- applySubstitutionsAt defaultUnitConfig noDeps db (ThisDb "root") (RootDb "root") solver [baselineX] [sub]
             case res of
                 Right ([x'], links) -> do
                     links `shouldBe` []
@@ -77,7 +77,7 @@ spec = do
                 demandVec = buildDemandVectorFromIndex (dbActivityIndex db) pid
             baselineX <- solveWithSharedSolver solver demandVec
             let noDeps _ = pure Nothing
-            res <- applySubstitutionsAt noDeps db (ThisDb "root") (RootDb "root") solver [baselineX] []
+            res <- applySubstitutionsAt defaultUnitConfig noDeps db (ThisDb "root") (RootDb "root") solver [baselineX] []
             case res of
                 Right (xs, links) -> do
                     links `shouldBe` []
@@ -98,10 +98,10 @@ spec = do
                     Substitution
                         { subFrom = qualifiedToRoot
                         , subTo = qualifiedToRoot
-                        , subConsumer = qualifiedToRoot
+                        , subScope = OneEdge qualifiedToRoot
                         }
                 noDeps _ = pure Nothing
-            res <- applySubstitutionsAt noDeps db (ThisDb "dep") (RootDb "root") solver [baselineX, baselineX, baselineX] [sub]
+            res <- applySubstitutionsAt defaultUnitConfig noDeps db (ThisDb "dep") (RootDb "root") solver [baselineX, baselineX, baselineX] [sub]
             case res of
                 Right (xs, _) -> length xs `shouldBe` 3
                 Left e -> expectationFailure ("K>1 filter failed: " <> show e)
@@ -122,10 +122,10 @@ spec = do
                     Substitution
                         { subFrom = bareRootPid
                         , subTo = bareRootPid
-                        , subConsumer = bareRootPid
+                        , subScope = OneEdge bareRootPid
                         }
                 noDeps _ = pure Nothing
-            res <- applySubstitutionsAt noDeps db (ThisDb "dep") (RootDb "root") solver [baselineX] [sub]
+            res <- applySubstitutionsAt defaultUnitConfig noDeps db (ThisDb "dep") (RootDb "root") solver [baselineX] [sub]
             case res of
                 Right ([x'], links) -> do
                     links `shouldBe` []
@@ -164,7 +164,7 @@ spec = do
                     Substitution
                         { subFrom = realRootPid
                         , subTo = realRootPid
-                        , subConsumer = "phantom-dep::" <> realRootPid
+                        , subScope = OneEdge ("phantom-dep::" <> realRootPid)
                         }
             eFiltered <- inventoryWithSubsAndDeps defaultUnitConfig noDeps db "SAMPLE.min3" solver pid [subWithPhantomConsumer]
             case eFiltered of
@@ -190,7 +190,7 @@ spec = do
                     Substitution
                         { subFrom = "dep::" <> processIdToText dep f
                         , subTo = "dep::" <> processIdToText dep t
-                        , subConsumer = "dep::" <> processIdToText dep consumerPid
+                        , subScope = OneEdge ("dep::" <> processIdToText dep consumerPid)
                         }
             eBase <- inventoryWithSubsAndDeps defaultUnitConfig lookup_ root "root" rootSolver 0 []
             eSub <- inventoryWithSubsAndDeps defaultUnitConfig lookup_ root "root" rootSolver 0 [mkDepSub fromPid toPid]
@@ -218,13 +218,13 @@ spec = do
                     Substitution
                         { subFrom = processIdToText root rootFrom
                         , subTo = processIdToText root rootTo
-                        , subConsumer = processIdToText root rootCons
+                        , subScope = OneEdge (processIdToText root rootCons)
                         }
                 depSub =
                     Substitution
                         { subFrom = "dep::" <> processIdToText dep depFrom
                         , subTo = "dep::" <> processIdToText dep depTo
-                        , subConsumer = "dep::" <> processIdToText dep depCons
+                        , subScope = OneEdge ("dep::" <> processIdToText dep depCons)
                         }
             eBase <- inventoryWithSubsAndDeps defaultUnitConfig lookup_ root "root" rootSolver 0 []
             eChain <- inventoryWithSubsAndDeps defaultUnitConfig lookup_ root "root" rootSolver 0 [rootSub, depSub]
@@ -249,7 +249,7 @@ spec = do
                     Substitution
                         { subFrom = "dep::" <> processIdToText dep fromPid
                         , subTo = "dep::" <> processIdToText dep fromPid
-                        , subConsumer = "dep::" <> processIdToText dep consumerPid
+                        , subScope = OneEdge ("dep::" <> processIdToText dep consumerPid)
                         }
             eBase <- inventoryWithSubsAndDeps defaultUnitConfig lookup_ root "root" rootSolver 0 []
             eSub <- inventoryWithSubsAndDeps defaultUnitConfig lookup_ root "root" rootSolver 0 [identitySub]

--- a/test/SubstitutionSpec.hs
+++ b/test/SubstitutionSpec.hs
@@ -15,7 +15,7 @@ which is covered by 'CrossDBInventorySpec'.
 -}
 module SubstitutionSpec (spec) where
 
-import API.Types (Substitution (..))
+import API.Types (Substitution (..), SubstitutionScope (..))
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import qualified Data.Vector.Unboxed as U
@@ -84,7 +84,7 @@ spec = do
                     Substitution
                         { subFrom = bogusPid
                         , subTo = bogusPid
-                        , subConsumer = bogusPid
+                        , subScope = OneEdge bogusPid
                         }
             eSub <- inventoryWithSubsAndDeps defaultUnitConfig noDeps db "SAMPLE.min3" solver pid [badSub]
             case eSub of

--- a/volca.cabal
+++ b/volca.cabal
@@ -247,6 +247,7 @@ test-suite lca-tests
                      , SubstitutionSpec
                      , SensitivitySpec
                      , CrossDBSubstitutionSpec
+                     , GlobalSubstitutionSpec
                      , DatabaseStatusSpec
                      , DependencyChoiceSpec
                      , OlcaSchemaSpec


### PR DESCRIPTION
## What

Adds a **global** substitution scope alongside the existing per-edge one. Today a substitution replaces a supplier on one specific consumer edge (`from`/`to`/`consumer`). Omitting `consumer` now replaces the supplier on **every** consumer that sources from it, in a single pass — the natural "use B instead of A throughout the tree" operation (e.g. swapping an Agribalyse background process for a regionalised one).

## How

A global swap is a single Sherman-Morrison **rank-1 update** over the supplier's whole technosphere row — one back-substitution, not N per-edge updates. (N sequential per-edge updates reuse the cached factorization and only *approximate* the simultaneous swap; the global form is exact.)

- **Within-DB** (`to` in the same database): two-sided update `e_from − κ·e_to`, where κ converts between the two reference-product units.
- **Cross-DB** (`to` in a dependency database): one-sided removal of `from` on the root side, plus one virtual cross-DB link per consumer routing the demand to `to`.

Guardrails — no silent miscounting:
- Incompatible reference-product units (e.g. mass vs energy) → error, never a silently wrong coefficient. Identical units → κ = 1.
- A `from` consumed nowhere → explicit error, not a no-op.
- A global `from` must live in the root database.

Scope is now a sum type (`OneEdge | AllConsumers`); the `consumer` field is optional on the wire. The pure Sherman-Morrison formula is generalised to an arbitrary sparse left projection so the per-edge and global paths share one kernel.

## Tests

New `GlobalSubstitutionSpec` checks the rank-1 result against a fresh re-solve of the relocated matrix (the ground truth) for both within-DB and cross-DB swaps, plus the identity no-op and every guardrail. Full suite: 1148 examples, 0 failures.