### PR TITLE
feat: database write toolkit — export writers, copy, delete, relink

### DIFF
--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -39,7 +39,9 @@ variants in the Servant API.
 
 from __future__ import annotations
 
+import base64
 from enum import Enum
+from pathlib import Path
 from typing import Any
 
 import requests
@@ -118,6 +120,16 @@ def _candidate_wire_names(py_name: str) -> list[str]:
     return seen
 
 
+_EXPORT_FORMATS = frozenset(
+    {"simapro", "ecospold1", "ecospold2", "ilcd", "brightway"}
+)
+"""Target keywords accepted by ``POST /api/v1/db/{dbName}/export``.
+
+Mirrors the engine's ``parseExportFormat`` (case-folded). Validated
+client-side so a typo fails before the round-trip with the same message
+shape the engine would have returned."""
+
+
 _FORMATTED_SCALARS = (str, int, float)
 
 
@@ -140,6 +152,39 @@ def _format_query_value(value: Any) -> Any:
     if isinstance(value, list):
         return [_format_query_value(v) for v in value]
     return str(value)
+
+
+def _coerce_class_filter(c: dict | tuple) -> dict:
+    """Normalize one classification filter to the wire ``DeleteClassFilter``.
+
+    Accepts a ``{"system", "value", "exact"?}`` dict or a
+    ``(system, value, exact?)`` tuple. ``exact`` defaults to False. Raises
+    VoLCAError on a malformed entry rather than silently dropping fields.
+    """
+    if isinstance(c, dict):
+        missing = {"system", "value"} - set(c)
+        if missing:
+            raise VoLCAError(
+                f"Classification filter missing keys: {sorted(missing)}. "
+                "Expected {'system', 'value', 'exact'?}."
+            )
+        return {
+            "system": c["system"],
+            "value": c["value"],
+            "exact": bool(c.get("exact", False)),
+        }
+    if isinstance(c, (tuple, list)):
+        if len(c) not in (2, 3):
+            raise VoLCAError(
+                f"Classification filter tuple must be (system, value[, exact]); "
+                f"got {len(c)} items."
+            )
+        system, value = c[0], c[1]
+        exact = bool(c[2]) if len(c) == 3 else False
+        return {"system": system, "value": value, "exact": exact}
+    raise VoLCAError(
+        f"Classification filter must be a dict or tuple, got {type(c).__name__}."
+    )
 
 
 def _resolve_page_args(
@@ -567,6 +612,194 @@ class Client:
     def unload_database(self, db_name: str) -> dict:
         """Unload a database from memory to free RAM. The disk copy is kept."""
         return self._json(self._session.post(f"{self.base_url}/api/v1/db/{db_name}/unload"))
+
+    # -- Database write operations --
+    #
+    # These mutate a loaded database (copy / delete / relink / export /
+    # dependency wiring). The engine does NOT register them as Resources, so
+    # they carry no operationId and are unreachable through the OpenAPI
+    # dispatcher. Each method therefore builds its URL directly, exactly like
+    # load_database / unload_database above.
+    #
+    # The engine reports failures in-band as ``{"success": false, ...}`` (HTTP
+    # 200) for some of these handlers, so _require_success surfaces those as
+    # VoLCAError rather than letting a failed call look like a success.
+
+    def _db(self, db_name: str | None) -> str:
+        """Resolve the target database, falling back to ``self.db``.
+
+        Raises VoLCAError when neither an explicit ``db_name`` nor a
+        client-level default is available — never silently targets ``""``.
+        """
+        name = db_name or self.db
+        if not name:
+            raise VoLCAError(
+                "No database specified and Client(db=...) is empty. "
+                "Pass db_name= or construct the client with db=...."
+            )
+        return name
+
+    @staticmethod
+    def _require_success(payload: dict, action: str) -> dict:
+        """Raise VoLCAError if the engine reported an in-band failure.
+
+        Handlers that return ``{"success": false, "message": ...}`` with HTTP
+        200 would otherwise look like a success. Surface the engine's own
+        message instead of silently returning the failure envelope.
+        """
+        if payload.get("success") is False:
+            raise VoLCAError(
+                f"{action} failed: {payload.get('message', 'no message')}"
+            )
+        return payload
+
+    def copy_database(self, new_name: str, db_name: str | None = None) -> dict:
+        """Copy a loaded database in memory under a new name.
+
+        ``new_name`` is a path segment; the source defaults to ``self.db``.
+        Returns the engine's ``ActivateResponse`` dict
+        (``{"success", "message", "database"?}``). Raises VoLCAError if the
+        engine reports ``success=false``.
+        """
+        src = self._db(db_name)
+        payload = self._json(
+            self._session.post(f"{self.base_url}/api/v1/db/{src}/copy/{new_name}")
+        )
+        return self._require_success(payload, "copy_database")
+
+    def delete_activities(
+        self,
+        *,
+        name: str = "",
+        location: str = "",
+        product: str = "",
+        classifications: list[dict | tuple] | None = None,
+        exact: bool = False,
+        keep: list[str] | None = None,
+        extra: list[str] | None = None,
+        db_name: str | None = None,
+    ) -> dict:
+        """Delete activities selected by filter, sparing/adding explicit ids.
+
+        Builds a ``DeleteSelectionRequest``: the filter fields select the whole
+        matching set, ``keep`` spares matched process ids, and ``extra`` adds
+        ones the filter missed. ``classifications`` is a list of
+        ``{"system", "value", "exact"}`` dicts or ``(system, value, exact)``
+        tuples.
+
+        Returns the ``DeleteSelectionResponse`` dict
+        (``{"success", "message", "deleted"}``); raises VoLCAError on
+        ``success=false``.
+        """
+        body = {
+            "name": name,
+            "location": location,
+            "product": product,
+            "classifications": [
+                _coerce_class_filter(c) for c in (classifications or [])
+            ],
+            "exact": exact,
+            "keep": keep or [],
+            "extra": extra or [],
+        }
+        target = self._db(db_name)
+        payload = self._json(
+            self._session.post(
+                f"{self.base_url}/api/v1/db/{target}/delete", json=body
+            )
+        )
+        return self._require_success(payload, "delete_activities")
+
+    def relink(
+        self, dep_db: str, mapping_csv: str, db_name: str | None = None
+    ) -> dict:
+        """Re-link a database against a dependency using a name→name alias CSV.
+
+        ``mapping_csv`` is the CSV *text* (header row + source/target columns),
+        sent inline so the engine needs no filesystem access. Returns the
+        ``RelinkResponse`` dict (``{"dbName", "unresolvedBefore",
+        "unresolvedAfter", "crossDBLinks", "dependsOn"}``).
+        """
+        target = self._db(db_name)
+        body = {"depDb": dep_db, "mappingCsv": mapping_csv}
+        return self._json(
+            self._session.post(
+                f"{self.base_url}/api/v1/db/{target}/relink", json=body
+            )
+        )
+
+    def relink_from_file(
+        self, dep_db: str, mapping_path: str, db_name: str | None = None
+    ) -> dict:
+        """Read a mapping CSV file and call :meth:`relink` with its text."""
+        csv_text = Path(mapping_path).read_text(encoding="utf-8")
+        return self.relink(dep_db, csv_text, db_name=db_name)
+
+    def export_database(self, fmt: str, db_name: str | None = None) -> bytes:
+        """Export a loaded database, returning the serialized bytes.
+
+        ``fmt`` is one of ``simapro|ecospold1|ecospold2|ilcd|brightway`` —
+        validated client-side; an unknown value raises VoLCAError before any
+        request. Single-file formats carry their bytes directly; EcoSpold 2 /
+        ILCD multi-file trees come back zipped.
+
+        The engine returns the payload base64-encoded in the ``data`` field;
+        this method base64-decodes it and returns the raw bytes. Raises
+        VoLCAError on ``success=false`` or a missing ``data`` field.
+        """
+        fmt_norm = fmt.strip().lower()
+        if fmt_norm not in _EXPORT_FORMATS:
+            raise VoLCAError(
+                f"unknown export format: {fmt!r} "
+                f"(expected {'|'.join(sorted(_EXPORT_FORMATS))})"
+            )
+        target = self._db(db_name)
+        payload = self._require_success(
+            self._json(
+                self._session.post(
+                    f"{self.base_url}/api/v1/db/{target}/export",
+                    json={"format": fmt_norm},
+                )
+            ),
+            "export_database",
+        )
+        data = payload.get("data")
+        if data is None:
+            raise VoLCAError(
+                "export_database succeeded but the response carried no data field."
+            )
+        return base64.b64decode(data)
+
+    def export_to_file(
+        self, fmt: str, out_path: str, db_name: str | None = None
+    ) -> None:
+        """Export a database (see :meth:`export_database`) and write it to a file."""
+        Path(out_path).write_bytes(self.export_database(fmt, db_name=db_name))
+
+    def add_dependency(self, dep_name: str, db_name: str | None = None) -> dict:
+        """Declare ``dep_name`` as a dependency of the target database.
+
+        Returns the engine's ``DatabaseSetupInfo`` dict describing the updated
+        dependency topology.
+        """
+        target = self._db(db_name)
+        return self._json(
+            self._session.post(
+                f"{self.base_url}/api/v1/db/{target}/add-dependency/{dep_name}"
+            )
+        )
+
+    def remove_dependency(self, dep_name: str, db_name: str | None = None) -> dict:
+        """Remove ``dep_name`` from the target database's dependencies.
+
+        Returns the updated ``DatabaseSetupInfo`` dict.
+        """
+        target = self._db(db_name)
+        return self._json(
+            self._session.post(
+                f"{self.base_url}/api/v1/db/{target}/remove-dependency/{dep_name}"
+            )
+        )
 
     def list_presets(self) -> list[Preset]:
         """List classification presets configured in this instance.

--- a/pyvolca/tests/test_db_write.py
+++ b/pyvolca/tests/test_db_write.py
@@ -1,0 +1,241 @@
+"""Offline request-shaping tests for the database write operations.
+
+These endpoints (copy / delete / relink / export / add-/remove-dependency)
+carry no operationId — they bypass the OpenAPI dispatcher and build their
+URLs directly, like ``load_database`` / ``unload_database``. They also do
+not exist in any released engine binary, so these tests never touch a live
+engine: they mock ``Client._session`` and assert on the wire shape
+(URL, JSON body, base64 decoding, format validation, error surfacing).
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from volca.client import Client, VoLCAError
+
+
+def _ok(session, json_body: dict) -> None:
+    """Wire the mocked session's POST to return a 200 with ``json_body``."""
+    from tests.conftest import _make_response
+
+    session.post.return_value = _make_response(json_body)
+
+
+# ---------------------------------------------------------------------------
+# copy
+# ---------------------------------------------------------------------------
+
+
+class TestCopy:
+    def test_url_and_default_db(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": True, "message": "copied", "database": None})
+        client.copy_database("clone")
+        url = session.post.call_args[0][0]
+        assert url == "http://test.local/api/v1/db/testdb/copy/clone"
+
+    def test_explicit_db_override(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": True, "message": "ok"})
+        client.copy_database("clone", db_name="other")
+        url = session.post.call_args[0][0]
+        assert url == "http://test.local/api/v1/db/other/copy/clone"
+
+    def test_in_band_failure_raises(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": False, "message": "already exists"})
+        with pytest.raises(VoLCAError, match="already exists"):
+            client.copy_database("clone")
+
+
+# ---------------------------------------------------------------------------
+# delete
+# ---------------------------------------------------------------------------
+
+
+class TestDelete:
+    def test_body_shape_with_dict_classifications(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": True, "message": "ok", "deleted": 3})
+        result = client.delete_activities(
+            name="wheat",
+            location="FR",
+            classifications=[{"system": "ISIC", "value": "01", "exact": True}],
+            exact=True,
+            keep=["a_b"],
+            extra=["c_d"],
+        )
+        assert result["deleted"] == 3
+        url = session.post.call_args[0][0]
+        assert url == "http://test.local/api/v1/db/testdb/delete"
+        body = session.post.call_args[1]["json"]
+        assert body == {
+            "name": "wheat",
+            "location": "FR",
+            "product": "",
+            "classifications": [{"system": "ISIC", "value": "01", "exact": True}],
+            "exact": True,
+            "keep": ["a_b"],
+            "extra": ["c_d"],
+        }
+
+    def test_tuple_classifications_coerced(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": True, "message": "ok", "deleted": 0})
+        client.delete_activities(classifications=[("CPC", "012"), ("ISIC", "01", True)])
+        body = session.post.call_args[1]["json"]
+        assert body["classifications"] == [
+            {"system": "CPC", "value": "012", "exact": False},
+            {"system": "ISIC", "value": "01", "exact": True},
+        ]
+
+    def test_defaults_are_empty(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": True, "message": "ok", "deleted": 0})
+        client.delete_activities(name="x")
+        body = session.post.call_args[1]["json"]
+        assert body["classifications"] == []
+        assert body["keep"] == []
+        assert body["extra"] == []
+        assert body["exact"] is False
+
+    def test_malformed_classification_dict_raises(self, mocked_client):
+        client, _ = mocked_client
+        with pytest.raises(VoLCAError, match="missing keys"):
+            client.delete_activities(classifications=[{"system": "ISIC"}])
+
+    def test_in_band_failure_raises(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": False, "message": "nothing matched"})
+        with pytest.raises(VoLCAError, match="nothing matched"):
+            client.delete_activities(name="x")
+
+
+# ---------------------------------------------------------------------------
+# relink
+# ---------------------------------------------------------------------------
+
+
+class TestRelink:
+    def test_body_and_url(self, mocked_client):
+        client, session = mocked_client
+        _ok(
+            session,
+            {
+                "dbName": "testdb",
+                "unresolvedBefore": 10,
+                "unresolvedAfter": 2,
+                "crossDBLinks": 8,
+                "dependsOn": ["ecoinvent-3.9"],
+            },
+        )
+        result = client.relink("ecoinvent-3.9", "src,dst\nfoo,bar\n")
+        assert result["unresolvedAfter"] == 2
+        url = session.post.call_args[0][0]
+        assert url == "http://test.local/api/v1/db/testdb/relink"
+        body = session.post.call_args[1]["json"]
+        assert body == {"depDb": "ecoinvent-3.9", "mappingCsv": "src,dst\nfoo,bar\n"}
+
+    def test_from_file_reads_text(self, mocked_client, tmp_path):
+        client, session = mocked_client
+        _ok(session, {"dbName": "testdb", "unresolvedBefore": 0,
+                      "unresolvedAfter": 0, "crossDBLinks": 0, "dependsOn": []})
+        csv = tmp_path / "map.csv"
+        csv.write_text("src,dst\nfoo,bar\n", encoding="utf-8")
+        client.relink_from_file("dep", str(csv))
+        body = session.post.call_args[1]["json"]
+        assert body == {"depDb": "dep", "mappingCsv": "src,dst\nfoo,bar\n"}
+
+
+# ---------------------------------------------------------------------------
+# export
+# ---------------------------------------------------------------------------
+
+
+class TestExport:
+    def test_base64_decode_returns_raw_bytes(self, mocked_client):
+        client, session = mocked_client
+        raw = b"PK\x03\x04 zipped db bytes"
+        _ok(session, {"success": True, "message": "ok",
+                      "data": base64.b64encode(raw).decode()})
+        out = client.export_database("ecospold2")
+        assert out == raw
+        url = session.post.call_args[0][0]
+        assert url == "http://test.local/api/v1/db/testdb/export"
+        assert session.post.call_args[1]["json"] == {"format": "ecospold2"}
+
+    def test_format_normalized_before_send(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": True, "message": "ok",
+                      "data": base64.b64encode(b"x").decode()})
+        client.export_database("  SimaPro  ")
+        assert session.post.call_args[1]["json"] == {"format": "simapro"}
+
+    def test_unknown_format_raises_before_request(self, mocked_client):
+        client, session = mocked_client
+        with pytest.raises(VoLCAError, match="unknown export format"):
+            client.export_database("parquet")
+        session.post.assert_not_called()
+
+    def test_in_band_failure_raises(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": False, "message": "not loaded", "data": None})
+        with pytest.raises(VoLCAError, match="not loaded"):
+            client.export_database("simapro")
+
+    def test_missing_data_raises(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": True, "message": "ok", "data": None})
+        with pytest.raises(VoLCAError, match="no data field"):
+            client.export_database("simapro")
+
+    def test_to_file_writes_decoded_bytes(self, mocked_client, tmp_path):
+        client, session = mocked_client
+        raw = b"hello bytes"
+        _ok(session, {"success": True, "message": "ok",
+                      "data": base64.b64encode(raw).decode()})
+        out = tmp_path / "export.csv"
+        client.export_to_file("simapro", str(out))
+        assert out.read_bytes() == raw
+
+
+# ---------------------------------------------------------------------------
+# dependencies
+# ---------------------------------------------------------------------------
+
+
+class TestDependencies:
+    def test_add_dependency_url(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"dependsOn": ["dep"]})
+        client.add_dependency("dep")
+        url = session.post.call_args[0][0]
+        assert url == "http://test.local/api/v1/db/testdb/add-dependency/dep"
+
+    def test_remove_dependency_url(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"dependsOn": []})
+        client.remove_dependency("dep", db_name="other")
+        url = session.post.call_args[0][0]
+        assert url == "http://test.local/api/v1/db/other/remove-dependency/dep"
+
+
+# ---------------------------------------------------------------------------
+# default-db guard
+# ---------------------------------------------------------------------------
+
+
+class TestNoDefaultDb:
+    def _client(self):
+        return Client(base_url="http://test.local", db="")
+
+    def test_copy_without_db_raises(self):
+        with pytest.raises(VoLCAError, match="No database specified"):
+            self._client().copy_database("clone")
+
+    def test_export_without_db_raises(self):
+        with pytest.raises(VoLCAError, match="No database specified"):
+            self._client().export_database("simapro")

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -16,7 +16,6 @@ module API.DatabaseHandlers (
     loadDatabaseHandler,
     unloadDatabaseHandler,
     relinkDatabaseHandler,
-    relinkDatabaseWithMappingHandler,
     copyDatabaseHandler,
     deleteDatabaseHandler,
     deleteActivitiesHandler,
@@ -85,7 +84,7 @@ import API.Types (
     LoadDatabaseResponse (..),
     RefDataListResponse (..),
     RefDataStatusAPI (..),
-    RelinkMappingRequest (..),
+    RelinkRequest (..),
     RelinkResponse (..),
     SynonymGroupsResponse (..),
     UploadRequest (..),
@@ -182,51 +181,45 @@ unloadDatabaseHandler dbName = do
     dbManager <- asks aeDbManager
     simpleAction (unloadDatabase dbManager dbName) ("Unloaded database: " <> dbName)
 
-{- | Re-run cross-DB linking for a loaded database against the currently-loaded
-dependency databases. Lets the user recover from loads that happened in a
-suboptimal order without reloading the whole database.
+{- | Re-run cross-DB linking for a loaded database. An empty @{}@ body
+re-resolves links within the existing dependency pin (plain relink) — letting
+the user recover from loads that happened in a suboptimal order without
+reloading. A body carrying both @depDb@ and @mappingCsv@ switches to mapping
+mode: relink against that one dependency using an inline name→name
+supplier-alias CSV, so an Ecoinvent-named background (e.g. Agribalyse) resolves
+against a differently-named dependency (e.g. BAFU). Supplying exactly one of the
+two is a client error. Parse/validation failures and "not a declared
+dependency" surface as 4xx rather than a silent no-op.
 -}
-relinkDatabaseHandler :: Text -> AppM RelinkResponse
-relinkDatabaseHandler dbName = do
+relinkDatabaseHandler :: Text -> RelinkRequest -> AppM RelinkResponse
+relinkDatabaseHandler dbName req = do
     dbManager <- asks aeDbManager
-    res <- liftIO $ relinkDatabase dbManager dbName
-    case res of
-        Left err -> throwError err404{errBody = BSL.fromStrict $ T.encodeUtf8 err}
-        Right r ->
-            return
-                RelinkResponse
-                    { rrDbName = rresDbName r
-                    , rrUnresolvedBefore = rresUnresolvedBefore r
-                    , rrUnresolvedAfter = rresUnresolvedAfter r
-                    , rrCrossDBLinks = rresCrossDBLinks r
-                    , rrDependsOn = rresDepsLoaded r
-                    }
-
-{- | Re-link a loaded database against one chosen dependency using a name→name
-supplier-alias mapping supplied inline as CSV. Lets an Ecoinvent-named
-background (e.g. Agribalyse) resolve against a differently-named dependency
-(e.g. BAFU). Parse/validation failures and "not a declared dependency"
-surface as 4xx rather than a silent no-op.
--}
-relinkDatabaseWithMappingHandler :: Text -> RelinkMappingRequest -> AppM RelinkResponse
-relinkDatabaseWithMappingHandler dbName req = do
-    dbManager <- asks aeDbManager
-    let csvBytes = BSL.fromStrict (T.encodeUtf8 (rmrMappingCsv req))
-    case parseAliasCSV csvBytes >>= buildAliasMap of
-        Left err -> throwError err400{errBody = BSL.fromStrict $ T.encodeUtf8 err}
-        Right aliases -> do
-            res <- liftIO $ relinkDatabaseWithMapping dbManager dbName (rmrDepDb req) aliases
-            case res of
-                Left err -> throwError err404{errBody = BSL.fromStrict $ T.encodeUtf8 err}
-                Right r ->
-                    return
-                        RelinkResponse
-                            { rrDbName = rresDbName r
-                            , rrUnresolvedBefore = rresUnresolvedBefore r
-                            , rrUnresolvedAfter = rresUnresolvedAfter r
-                            , rrCrossDBLinks = rresCrossDBLinks r
-                            , rrDependsOn = rresDepsLoaded r
-                            }
+    case (rmrDepDb req, rmrMappingCsv req) of
+        (Nothing, Nothing) ->
+            runRelink (relinkDatabase dbManager dbName)
+        (Just depDb, Just csv) ->
+            case parseAliasCSV (BSL.fromStrict (T.encodeUtf8 csv)) >>= buildAliasMap of
+                Left err -> throwError err400{errBody = BSL.fromStrict $ T.encodeUtf8 err}
+                Right aliases -> runRelink (relinkDatabaseWithMapping dbManager dbName depDb aliases)
+        (Just _, Nothing) -> incomplete
+        (Nothing, Just _) -> incomplete
+  where
+    incomplete =
+        throwError err400{errBody = "relink: depDb and mappingCsv must be supplied together"}
+    runRelink :: IO (Either Text RelinkResult) -> AppM RelinkResponse
+    runRelink act = do
+        res <- liftIO act
+        case res of
+            Left err -> throwError err404{errBody = BSL.fromStrict $ T.encodeUtf8 err}
+            Right r ->
+                return
+                    RelinkResponse
+                        { rrDbName = rresDbName r
+                        , rrUnresolvedBefore = rresUnresolvedBefore r
+                        , rrUnresolvedAfter = rresUnresolvedAfter r
+                        , rrCrossDBLinks = rresCrossDBLinks r
+                        , rrDependsOn = rresDepsLoaded r
+                        }
 
 {- | Copy a loaded database under a new name. The copy is an independent
 in-memory database registered under @newName@; the source is untouched.

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -16,7 +16,11 @@ module API.DatabaseHandlers (
     loadDatabaseHandler,
     unloadDatabaseHandler,
     relinkDatabaseHandler,
+    relinkDatabaseWithMappingHandler,
+    copyDatabaseHandler,
     deleteDatabaseHandler,
+    deleteActivitiesHandler,
+    exportDatabaseHandler,
     uploadDatabaseHandler,
     uploadMethodHandler,
     deleteMethodHandler,
@@ -73,9 +77,15 @@ import API.Types (
     BinaryContent (..),
     DatabaseListResponse (..),
     DatabaseStatusAPI (..),
+    DeleteClassFilter (..),
+    DeleteSelectionRequest (..),
+    DeleteSelectionResponse (..),
+    ExportRequest (..),
+    ExportResponse (..),
     LoadDatabaseResponse (..),
     RefDataListResponse (..),
     RefDataStatusAPI (..),
+    RelinkMappingRequest (..),
     RelinkResponse (..),
     SynonymGroupsResponse (..),
     UploadRequest (..),
@@ -88,7 +98,10 @@ import Control.Monad.Reader (asks)
 import Data.Aeson (Value, toJSON)
 import qualified Data.Aeson as A
 import qualified Data.Aeson.KeyMap as KM
+import Data.Maybe (fromMaybe)
 import qualified Data.Vector as V
+import Database.Edit (copyDatabase, deleteActivitiesInDB)
+import Database.Export (serializeDatabase)
 import Database.Manager (
     DatabaseLoadStatus (..),
     DatabaseManager (..),
@@ -105,6 +118,7 @@ import Database.Manager (
     addMethodCollection,
     addUnitDefs,
     finalizeDatabase,
+    getDatabase,
     getDatabaseSetupInfo,
     getFlowSynonymGroups,
     listCompartmentMappings,
@@ -116,6 +130,7 @@ import Database.Manager (
     loadFlowSynonyms,
     loadUnitDefs,
     relinkDatabase,
+    relinkDatabaseWithMapping,
     removeCompartmentMappings,
     removeDatabase,
     removeDependencyFromStaged,
@@ -128,6 +143,7 @@ import Database.Manager (
     unloadFlowSynonyms,
     unloadUnitDefs,
  )
+import Database.RelinkMapping (buildAliasMap, parseAliasCSV)
 import Database.Upload (
     DatabaseFormat (..),
     UploadData (..),
@@ -135,6 +151,7 @@ import Database.Upload (
     findMethodDirectory,
     handleUpload,
  )
+import qualified Database.Upload as Upload
 import qualified Database.UploadedDatabase as UploadedDB
 import Types (Database (..), GeographyPolicy (..), unresolvedCount)
 
@@ -185,11 +202,108 @@ relinkDatabaseHandler dbName = do
                     , rrDependsOn = rresDepsLoaded r
                     }
 
+{- | Re-link a loaded database against one chosen dependency using a name→name
+supplier-alias mapping supplied inline as CSV. Lets an Ecoinvent-named
+background (e.g. Agribalyse) resolve against a differently-named dependency
+(e.g. BAFU). Parse/validation failures and "not a declared dependency"
+surface as 4xx rather than a silent no-op.
+-}
+relinkDatabaseWithMappingHandler :: Text -> RelinkMappingRequest -> AppM RelinkResponse
+relinkDatabaseWithMappingHandler dbName req = do
+    dbManager <- asks aeDbManager
+    let csvBytes = BSL.fromStrict (T.encodeUtf8 (rmrMappingCsv req))
+    case parseAliasCSV csvBytes >>= buildAliasMap of
+        Left err -> throwError err400{errBody = BSL.fromStrict $ T.encodeUtf8 err}
+        Right aliases -> do
+            res <- liftIO $ relinkDatabaseWithMapping dbManager dbName (rmrDepDb req) aliases
+            case res of
+                Left err -> throwError err404{errBody = BSL.fromStrict $ T.encodeUtf8 err}
+                Right r ->
+                    return
+                        RelinkResponse
+                            { rrDbName = rresDbName r
+                            , rrUnresolvedBefore = rresUnresolvedBefore r
+                            , rrUnresolvedAfter = rresUnresolvedAfter r
+                            , rrCrossDBLinks = rresCrossDBLinks r
+                            , rrDependsOn = rresDepsLoaded r
+                            }
+
+{- | Copy a loaded database under a new name. The copy is an independent
+in-memory database registered under @newName@; the source is untouched.
+-}
+copyDatabaseHandler :: Text -> Text -> AppM ActivateResponse
+copyDatabaseHandler dbName newName = do
+    dbManager <- asks aeDbManager
+    simpleAction (copyDatabase dbManager dbName newName) ("Copied database: " <> dbName <> " -> " <> newName)
+
 -- | Delete an uploaded database (move to trash)
 deleteDatabaseHandler :: Text -> AppM ActivateResponse
 deleteDatabaseHandler dbName = do
     dbManager <- asks aeDbManager
     simpleAction (removeDatabase dbManager dbName) ("Deleted database: " <> dbName)
+
+{- | Delete the whole filtered set of activities from a loaded database, in
+place. The filter selects the full matching set (pagination ignored); the
+keep/extra lists adjust the set individually. Rebuilds matrices and unlinks
+surviving references; returns the count removed.
+-}
+deleteActivitiesHandler :: Text -> DeleteSelectionRequest -> AppM DeleteSelectionResponse
+deleteActivitiesHandler dbName req = do
+    dbManager <- asks aeDbManager
+    let classFilters = [(dcfSystem f, dcfValue f, dcfExact f) | f <- dsqClassifications req]
+    result <-
+        liftIO $
+            deleteActivitiesInDB
+                dbManager
+                dbName
+                (dsqName req)
+                (dsqLocation req)
+                (dsqProduct req)
+                classFilters
+                (fromMaybe False (dsqExact req))
+                (dsqKeep req)
+                (dsqExtra req)
+    case result of
+        Left err -> return $ DeleteSelectionResponse False err 0
+        Right deleted ->
+            return $
+                DeleteSelectionResponse
+                    True
+                    ("Deleted " <> T.pack (show deleted) <> " activities from " <> dbName)
+                    deleted
+
+-- | Parse the export-format keyword into a 'DatabaseFormat'.
+parseExportFormat :: Text -> Either Text Upload.DatabaseFormat
+parseExportFormat raw = case T.toLower (T.strip raw) of
+    "simapro" -> Right Upload.SimaProCSV
+    "ecospold1" -> Right Upload.EcoSpold1
+    "ecospold2" -> Right Upload.EcoSpold2
+    "ilcd" -> Right Upload.ILCDProcess
+    "brightway" -> Right Upload.BrightwayExcel
+    other -> Left ("unknown export format: " <> other <> " (expected simapro|ecospold1|ecospold2|ilcd|brightway)")
+
+{- | Export a loaded database, returning the serialized bytes base64-encoded.
+EcoSpold 2 / ILCD multi-file trees are zipped; single-file formats carry their
+bytes directly. Mirrors the upload endpoint's base64 convention.
+-}
+exportDatabaseHandler :: Text -> ExportRequest -> AppM ExportResponse
+exportDatabaseHandler dbName req = do
+    dbManager <- asks aeDbManager
+    case parseExportFormat (exrFormat req) of
+        Left err -> return (ExportResponse False err Nothing)
+        Right fmt -> do
+            mLoaded <- liftIO (getDatabase dbManager dbName)
+            case mLoaded of
+                Nothing -> return (ExportResponse False ("Database not loaded: " <> dbName) Nothing)
+                Just ld ->
+                    case serializeDatabase fmt (ldDatabase ld) of
+                        Left err -> return (ExportResponse False err Nothing)
+                        Right bytes ->
+                            return $
+                                ExportResponse
+                                    True
+                                    ("Exported " <> dbName)
+                                    (Just (T.decodeUtf8 (B64.encode (BSL.toStrict bytes))))
 
 {- | Enforce the hosting upload-size policy on a decoded payload.
 Local/CLI mode (no hosting config) is unlimited. A configured limit of 0

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -202,7 +202,7 @@ requireDatabaseByName dbName = do
         Nothing -> throwError err404{errBody = notLoadedBody databaseNotLoadedPrefix dbName}
 
 {- | Refuse LCIA when the DB still has unresolved cross-DB products. Forces
-the user to load the missing dep DBs (or POST /relink) rather than
+the user to load the missing dep DBs (or POST {} to /relink) rather than
 silently undercounting impacts.
 -}
 requireFullyLinked :: Text -> Database -> AppM ()
@@ -221,7 +221,7 @@ requireFullyLinked dbName db =
                                     <> " unresolved cross-DB products. Load the missing dependency "
                                     <> "databases (see GET /api/v1/db/"
                                     <> dbName
-                                    <> "/setup) then POST /api/v1/db/"
+                                    <> "/setup) then POST {} to /api/v1/db/"
                                     <> dbName
                                     <> "/relink."
                     }

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -10,7 +10,7 @@ module API.Routes where
 import API.DatabaseHandlers (simpleAction)
 import qualified API.DatabaseHandlers as DBHandlers
 import qualified API.OpenApi
-import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExportRequest (..), ExportResponse (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), RefDataListResponse (..), RelinkMappingRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadRequest (..), UploadResponse (..), apiFlowOfKind)
+import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExportRequest (..), ExportResponse (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadRequest (..), UploadResponse (..), apiFlowOfKind)
 import App.Env (AppEnv (..), AppM, runApp)
 import qualified Config
 import Control.Concurrent.Async (mapConcurrently)
@@ -120,8 +120,8 @@ type LCAAPI =
                 -- Load/Unload/Delete endpoints
                 :<|> "db" :> Capture "dbName" Text :> "load" :> Post '[JSON] LoadDatabaseResponse
                 :<|> "db" :> Capture "dbName" Text :> "unload" :> Post '[JSON] ActivateResponse
-                :<|> "db" :> Capture "dbName" Text :> "relink" :> Post '[JSON] RelinkResponse
-                :<|> "db" :> Capture "dbName" Text :> "relink" :> ReqBody '[JSON] RelinkMappingRequest :> Post '[JSON] RelinkResponse
+                -- Relink: empty {} body = plain relink; {depDb,mappingCsv} = mapping relink
+                :<|> "db" :> Capture "dbName" Text :> "relink" :> ReqBody '[JSON] RelinkRequest :> Post '[JSON] RelinkResponse
                 :<|> "db" :> Capture "dbName" Text :> "copy" :> Capture "newName" Text :> Post '[JSON] ActivateResponse
                 :<|> "db" :> Capture "dbName" Text :> Delete '[JSON] ActivateResponse
                 -- Delete the whole filtered set of activities (selection in JSON body)
@@ -1935,7 +1935,6 @@ lcaServer env = hoistServer lcaAPI (runApp env) handlers
             :<|> DBHandlers.loadDatabaseHandler
             :<|> DBHandlers.unloadDatabaseHandler
             :<|> DBHandlers.relinkDatabaseHandler
-            :<|> DBHandlers.relinkDatabaseWithMappingHandler
             :<|> DBHandlers.copyDatabaseHandler
             :<|> DBHandlers.deleteDatabaseHandler
             :<|> DBHandlers.deleteActivitiesHandler

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -10,7 +10,7 @@ module API.Routes where
 import API.DatabaseHandlers (simpleAction)
 import qualified API.DatabaseHandlers as DBHandlers
 import qualified API.OpenApi
-import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), ExchangeDetail (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), RefDataListResponse (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadRequest (..), UploadResponse (..), apiFlowOfKind)
+import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExportRequest (..), ExportResponse (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), RefDataListResponse (..), RelinkMappingRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadRequest (..), UploadResponse (..), apiFlowOfKind)
 import App.Env (AppEnv (..), AppM, runApp)
 import qualified Config
 import Control.Concurrent.Async (mapConcurrently)
@@ -121,7 +121,13 @@ type LCAAPI =
                 :<|> "db" :> Capture "dbName" Text :> "load" :> Post '[JSON] LoadDatabaseResponse
                 :<|> "db" :> Capture "dbName" Text :> "unload" :> Post '[JSON] ActivateResponse
                 :<|> "db" :> Capture "dbName" Text :> "relink" :> Post '[JSON] RelinkResponse
+                :<|> "db" :> Capture "dbName" Text :> "relink" :> ReqBody '[JSON] RelinkMappingRequest :> Post '[JSON] RelinkResponse
+                :<|> "db" :> Capture "dbName" Text :> "copy" :> Capture "newName" Text :> Post '[JSON] ActivateResponse
                 :<|> "db" :> Capture "dbName" Text :> Delete '[JSON] ActivateResponse
+                -- Delete the whole filtered set of activities (selection in JSON body)
+                :<|> "db" :> Capture "dbName" Text :> "delete" :> ReqBody '[JSON] DeleteSelectionRequest :> Post '[JSON] DeleteSelectionResponse
+                -- Export a loaded database to a serialized (base64) file in the requested format
+                :<|> "db" :> Capture "dbName" Text :> "export" :> ReqBody '[JSON] ExportRequest :> Post '[JSON] ExportResponse
                 -- Upload endpoint (base64-encoded ZIP in JSON body)
                 :<|> "db" :> "upload" :> ReqBody '[JSON] UploadRequest :> Post '[JSON] UploadResponse
                 -- Database setup endpoints (for cross-DB linking configuration)
@@ -1929,7 +1935,11 @@ lcaServer env = hoistServer lcaAPI (runApp env) handlers
             :<|> DBHandlers.loadDatabaseHandler
             :<|> DBHandlers.unloadDatabaseHandler
             :<|> DBHandlers.relinkDatabaseHandler
+            :<|> DBHandlers.relinkDatabaseWithMappingHandler
+            :<|> DBHandlers.copyDatabaseHandler
             :<|> DBHandlers.deleteDatabaseHandler
+            :<|> DBHandlers.deleteActivitiesHandler
+            :<|> DBHandlers.exportDatabaseHandler
             :<|> DBHandlers.uploadDatabaseHandler
             :<|> DBHandlers.getDatabaseSetupHandler
             :<|> DBHandlers.addDependencyHandler

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -718,19 +718,21 @@ data RelinkResponse = RelinkResponse
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped RelinkResponse)
 
-{- | Request body for the relink-with-mapping endpoint. Re-links the captured
-database against @rmrDepDb@ using a name→name supplier-alias mapping. The
-mapping travels inline as CSV text (@rmrMappingCsv@) so the client can send a
-local file without the server needing filesystem access to it.
+{- | Request body for the relink endpoint. Both fields absent (an empty @{}@
+body) means a plain relink — re-resolve links within the existing pin. Both
+present switches to mapping mode: relink against @rmrDepDb@ using the inline
+name→name supplier-alias CSV in @rmrMappingCsv@ (sent inline so the client can
+forward a local file without the server needing filesystem access). Supplying
+exactly one is rejected — they are only meaningful together.
 -}
-data RelinkMappingRequest = RelinkMappingRequest
-    { rmrDepDb :: Text
+data RelinkRequest = RelinkRequest
+    { rmrDepDb :: Maybe Text
     -- ^ Dependency database to link against (must be a declared dependency)
-    , rmrMappingCsv :: Text
+    , rmrMappingCsv :: Maybe Text
     -- ^ Mapping CSV content (header row + source/target columns)
     }
     deriving (Generic)
-    deriving (ToJSON, FromJSON, ToSchema) via (Stripped RelinkMappingRequest)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped RelinkRequest)
 
 -- | Result of auto-loading a single dependency
 data DepLoadResult

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -718,6 +718,20 @@ data RelinkResponse = RelinkResponse
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped RelinkResponse)
 
+{- | Request body for the relink-with-mapping endpoint. Re-links the captured
+database against @rmrDepDb@ using a name→name supplier-alias mapping. The
+mapping travels inline as CSV text (@rmrMappingCsv@) so the client can send a
+local file without the server needing filesystem access to it.
+-}
+data RelinkMappingRequest = RelinkMappingRequest
+    { rmrDepDb :: Text
+    -- ^ Dependency database to link against (must be a declared dependency)
+    , rmrMappingCsv :: Text
+    -- ^ Mapping CSV content (header row + source/target columns)
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped RelinkMappingRequest)
+
 -- | Result of auto-loading a single dependency
 data DepLoadResult
     = DepLoaded {dlrName :: Text}
@@ -740,6 +754,66 @@ data UploadRequest = UploadRequest
     }
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped UploadRequest)
+
+{- | One classification filter in a delete request: the @system@ to match, the
+@value@ to look for, and whether the match is exact (else token-contains).
+Mirrors the search endpoint's classification query parameters so the deleted
+set is exactly the searched set.
+-}
+data DeleteClassFilter = DeleteClassFilter
+    { dcfSystem :: Text
+    , dcfValue :: Text
+    , dcfExact :: Bool
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped DeleteClassFilter)
+
+{- | Request for delete-by-selection. The filter fields select the whole
+matching set (pagination ignored); @dsqKeep@ spares matched process ids and
+@dsqExtra@ adds ones the filter missed. Process ids are the canonical
+@activityUUID_productUUID@ strings the UI/CLI carry, not matrix indices.
+-}
+data DeleteSelectionRequest = DeleteSelectionRequest
+    { dsqName :: Maybe Text -- Filter by activity name
+    , dsqLocation :: Maybe Text -- Filter by location
+    , dsqProduct :: Maybe Text -- Filter by reference product
+    , dsqClassifications :: [DeleteClassFilter] -- Classification filters (AND across systems)
+    , dsqExact :: Maybe Bool -- Exact name match (default False)
+    , dsqKeep :: [Text] -- Process-id strings to spare from deletion
+    , dsqExtra :: [Text] -- Process-id strings to add to deletion
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped DeleteSelectionRequest)
+
+-- | Response for delete-by-selection: count of activities removed.
+data DeleteSelectionResponse = DeleteSelectionResponse
+    { dsrSuccess :: Bool
+    , dsrMessage :: Text
+    , dsrDeleted :: Int
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped DeleteSelectionResponse)
+
+{- | Request for database export. @exrFormat@ is the target-format keyword
+(@simapro|ecospold1|ecospold2|ilcd|brightway@), matching the CLI.
+-}
+newtype ExportRequest = ExportRequest
+    { exrFormat :: Text
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped ExportRequest)
+
+{- | Response for database export. The serialized database is base64-encoded
+(single-file formats carry their bytes directly; EcoSpold 2 / ILCD are zipped),
+mirroring the upload endpoint's base64 convention.
+-}
+data ExportResponse = ExportResponse
+    { exrespSuccess :: Bool
+    , exrespMessage :: Text
+    , exrespData :: Maybe Text -- Base64-encoded serialized database (if successful)
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped ExportResponse)
 
 -- | Response for database upload
 data UploadResponse = UploadResponse

--- a/src/BrightwayExcel/Writer.hs
+++ b/src/BrightwayExcel/Writer.hs
@@ -197,10 +197,14 @@ isCoproduct = \case
     BiosphereExchange{} -> False
     WasteExchange{} -> False
 
+-- | Ordinary technosphere inputs only. 'ReferenceInput' is intentionally
+-- excluded: it already belongs to the reference group ('exchangeIsReference'),
+-- so matching it here too would emit the exchange twice — double-counting its
+-- coefficient when the workbook is re-imported and duplicate (i,j) entries are
+-- summed. Each role thus lands in exactly one group.
 isTechInput :: Exchange -> Bool
 isTechInput = \case
     TechnosphereExchange{techRole = Input} -> True
-    TechnosphereExchange{techRole = ReferenceInput} -> True
     TechnosphereExchange{} -> False
     BiosphereExchange{} -> False
     WasteExchange{} -> False

--- a/src/BrightwayExcel/Writer.hs
+++ b/src/BrightwayExcel/Writer.hs
@@ -1,0 +1,394 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Writer for the Brightway Excel (@.xlsx@) inventory interchange format — the
+inverse of "BrightwayExcel.Parser".
+
+It serializes a 'SimpleDatabase' (the natural writer input, obtained from a
+'Database' via 'toSimpleDatabase') back into the linear block-stream layout that
+@bw2io@'s @ExcelImporter@ — and our own parser — consumes:
+
+@
+Database              <database name>
+
+Activity              <activity name>
+production amount     1
+reference product     <product>
+location              GLO
+unit                  kilogram
+Exchanges
+name   amount   reference product   location   unit   categories   type           database
+...    1        <product>           GLO        kg                  production     <db>
+...    0.5      <supplier product>  RoW        kg                  technosphere   <db>
+Water  1.6e-4                       GLO        m3     air           biosphere      <db>
+
+@
+
+== Determinism
+
+The output is canonical and deterministic: activities are emitted sorted by
+@(name, location)@, exchanges in a fixed role order (reference product, then
+coproducts, then technosphere inputs, then biosphere flows — each group sorted
+by flow name), and a single fixed @Exchanges@ column order is used regardless of
+how the source file was laid out. Numbers are rendered with 'formatAmount' so
+@1.0@ and @8.5@ are stable. The only volatile field — the workbook-level
+database name — is supplied explicitly via 'WriterConfig', so a round-trip never
+depends on ambient state (timestamps, tool version, machine).
+
+== Encoding
+
+An @.xlsx@ is a zip of XML parts. We mirror the parser's toolchain exactly
+(@zip-archive@ + hand-built SpreadsheetML, the same shape openpyxl/bw2io emit),
+rather than pulling in a new dependency: one worksheet @xl/worksheets/sheet1.xml@
+of inline-string / numeric cells, wired through @xl/workbook.xml@ and its rels.
+Inline strings (@t="inlineStr"@) are used throughout, so no shared-string table
+is needed — and the parser already resolves either form.
+
+Byte-identical round-trips are not a goal (zip stores per-entry metadata): the
+contract proven by the spec is /logical-cell/ idempotence — re-exporting the
+parsed content yields the same workbook, and 'parseBrightwayExcel' of the output
+is structurally equal to the input.
+-}
+module BrightwayExcel.Writer (
+    WriterConfig (..),
+    defaultWriterConfig,
+    writeBrightwayExcel,
+    renderWorkbook,
+
+    -- * Exposed for testing
+    Cell (..),
+    activityRows,
+    formatAmount,
+    renderCategories,
+) where
+
+import Codec.Archive.Zip (addEntryToArchive, emptyArchive, fromArchive, toEntry)
+import qualified Data.ByteString.Lazy as BL
+import Data.Char (chr, ord)
+import Data.List (sortOn)
+import qualified Data.Map.Strict as M
+import Data.Maybe (mapMaybe, maybeToList)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Types
+
+-- ---------------------------------------------------------------------------
+-- Configuration
+-- ---------------------------------------------------------------------------
+
+{- | The only export-time choice that is not derived from the database content:
+the workbook-level @Database@ name written at the top of the sheet and into each
+exchange's @database@ column. Pinning it here (rather than reading a clock or a
+build version) is what makes round-trips reproducible.
+-}
+newtype WriterConfig = WriterConfig
+    { wcDatabaseName :: Text
+    }
+    deriving (Eq, Show)
+
+-- | A neutral default name for ad-hoc exports.
+defaultWriterConfig :: WriterConfig
+defaultWriterConfig = WriterConfig{wcDatabaseName = "exported-database"}
+
+-- ---------------------------------------------------------------------------
+-- Cell model (mirrors the parser's CellValue / the spec emitter)
+-- ---------------------------------------------------------------------------
+
+-- | A cell to emit: text, a number, or an empty (omitted) cell.
+data Cell
+    = CText !Text
+    | CNum !Double
+    | CEmpty
+    deriving (Eq, Show)
+
+-- ---------------------------------------------------------------------------
+-- Top-level
+-- ---------------------------------------------------------------------------
+
+{- | Serialize a 'SimpleDatabase' to a Brightway @.xlsx@ workbook on disk. Pure
+construction ('renderWorkbook') wrapped in a single write effect.
+-}
+writeBrightwayExcel :: WriterConfig -> SimpleDatabase -> FilePath -> IO ()
+writeBrightwayExcel cfg db = flip BL.writeFile (renderWorkbook cfg db)
+
+-- | Pure: assemble the full @.xlsx@ byte stream from the database.
+renderWorkbook :: WriterConfig -> SimpleDatabase -> BL.ByteString
+renderWorkbook cfg db =
+    fromArchive $
+        foldr
+            addEntryToArchive
+            emptyArchive
+            [ toEntry "xl/workbook.xml" 0 (enc workbookXml)
+            , toEntry "xl/_rels/workbook.xml.rels" 0 (enc relsXml)
+            , toEntry "xl/worksheets/sheet1.xml" 0 (enc (sheetXml (sheetRows cfg db)))
+            ]
+  where
+    enc = BL.fromStrict . TE.encodeUtf8
+
+-- ---------------------------------------------------------------------------
+-- Sheet content (pure)
+-- ---------------------------------------------------------------------------
+
+{- | The whole worksheet as a list of rows. A leading @Database@ section, then
+one activity block per activity, separated by blank rows. Activities are sorted
+by @(name, location)@ for determinism.
+-}
+sheetRows :: WriterConfig -> SimpleDatabase -> [[Cell]]
+sheetRows cfg db =
+    [ [CText "Database", CText (wcDatabaseName cfg)]
+    , []
+    ]
+        ++ concatMap (\a -> activityRows cfg db a ++ [[]]) sortedActivities
+  where
+    sortedActivities =
+        sortOn (\a -> (activityName a, activityLocation a)) (M.elems (sdbActivities db))
+
+-- | The fixed canonical @Exchanges@ table header.
+exchangeHeader :: [Cell]
+exchangeHeader =
+    map
+        CText
+        ["name", "amount", "reference product", "location", "unit", "categories", "type", "database"]
+
+{- | One activity block: the @Activity@ row, metadata key/value rows, the
+@Exchanges@ header, then one row per exchange in canonical order. The metadata
+@unit@ / @reference product@ are taken from the activity's reference exchange so
+a parse → write round-trip reproduces them.
+-}
+activityRows :: WriterConfig -> SimpleDatabase -> Activity -> [[Cell]]
+activityRows cfg db act =
+    [ [CText "Activity", CText (activityName act)]
+    , [CText "production amount", CNum 1]
+    ]
+        ++ [[CText "reference product", CText p] | p <- maybeToList refProduct]
+        ++ [[CText "location", CText (activityLocation act)]]
+        ++ [[CText "unit", CText u] | u <- maybeToList refUnit, not (T.null u)]
+        ++ [[CText "comment", CText c] | c <- take 1 (activityDescription act)]
+        ++ [[CText "Exchanges"], exchangeHeader]
+        ++ exchangeDataRows
+  where
+    ordered = orderedExchanges (exchanges act)
+    exchangeDataRows = mapMaybe (exchangeRow cfg db) ordered
+    refExchange = lookup' exchangeIsReference ordered
+    refProduct = refExchange >>= flowNameOf db
+    refUnit = (`unitNameOf` db) . exchangeUnitId =<< refExchange
+
+{- | Canonical exchange order: reference product first, then coproducts, then
+ordinary technosphere inputs, then biosphere flows — each group sorted by flow
+name. This is what makes two databases with the same content serialize byte-for
+-byte identically.
+-}
+orderedExchanges :: [Exchange] -> [Exchange]
+orderedExchanges exs = concatMap (sortOn sortKey) groups
+  where
+    groups = [refs, coproducts, techInputs, bios, wastes]
+    refs = filter exchangeIsReference exs
+    coproducts = filter isCoproduct exs
+    techInputs = filter isTechInput exs
+    bios = filter isBio exs
+    wastes = filter isWaste exs
+    sortKey = exchangeFlowId
+
+isCoproduct :: Exchange -> Bool
+isCoproduct = \case
+    TechnosphereExchange{techRole = Coproduct} -> True
+    TechnosphereExchange{} -> False
+    BiosphereExchange{} -> False
+    WasteExchange{} -> False
+
+isTechInput :: Exchange -> Bool
+isTechInput = \case
+    TechnosphereExchange{techRole = Input} -> True
+    TechnosphereExchange{techRole = ReferenceInput} -> True
+    TechnosphereExchange{} -> False
+    BiosphereExchange{} -> False
+    WasteExchange{} -> False
+
+isBio :: Exchange -> Bool
+isBio = \case
+    BiosphereExchange{} -> True
+    TechnosphereExchange{} -> False
+    WasteExchange{} -> False
+
+isWaste :: Exchange -> Bool
+isWaste = \case
+    WasteExchange{} -> True
+    TechnosphereExchange{} -> False
+    BiosphereExchange{} -> False
+
+{- | Render one exchange to a data row aligned to 'exchangeHeader'. Returns
+'Nothing' for an exchange whose flow or unit is missing from the database (it
+cannot be written faithfully, so it is dropped rather than emitted with blanks
+that would re-parse into a different flow). The @name@ and @reference product@
+columns both carry the flow name so the parser reconstructs the same flow UUID.
+-}
+exchangeRow :: WriterConfig -> SimpleDatabase -> Exchange -> Maybe [Cell]
+exchangeRow cfg db = \case
+    ex@TechnosphereExchange{techAmount = amt, techRole = role, techLocation = loc} -> do
+        name <- flowNameOf db ex
+        unit <- unitNameOf (exchangeUnitId ex) db
+        Just
+            [ CText name
+            , CNum amt
+            , CText name
+            , locCell loc
+            , CText unit
+            , CEmpty
+            , CText (techTypeLabel role)
+            , CText (wcDatabaseName cfg)
+            ]
+    ex@BiosphereExchange{bioAmount = amt, bioLocation = loc} -> do
+        flow <- M.lookup (exchangeFlowId ex) (sdbBioFlows db)
+        unit <- unitNameOf (exchangeUnitId ex) db
+        Just
+            [ CText (bfName flow)
+            , CNum amt
+            , CEmpty
+            , locCell loc
+            , CText unit
+            , CText (renderCategories (bfCompartment flow))
+            , CText "biosphere"
+            , CText (wcDatabaseName cfg)
+            ]
+    ex@WasteExchange{waAmount = amt, waLocation = loc} -> do
+        name <- flowNameOf db ex
+        unit <- unitNameOf (exchangeUnitId ex) db
+        -- Brightway has no native waste type; emit as a technosphere input so the
+        -- amount and supplier link survive the round-trip.
+        Just
+            [ CText name
+            , CNum amt
+            , CText name
+            , locCell loc
+            , CText unit
+            , CEmpty
+            , CText "technosphere"
+            , CText (wcDatabaseName cfg)
+            ]
+  where
+    locCell l = if T.null l then CEmpty else CText l
+
+-- | Brightway @type@ label for a technosphere role.
+techTypeLabel :: TechRole -> Text
+techTypeLabel = \case
+    ReferenceProduct -> "production"
+    Coproduct -> "production"
+    ReferenceInput -> "technosphere"
+    Input -> "technosphere"
+
+{- | Render a 'Compartment' to a Brightway @categories@ cell (@"air"@ or
+@"natural resource::in water"@). 'Nothing' (no compartment recorded) and an
+empty medium both become an empty cell — the inverse of 'splitCategories'.
+-}
+renderCategories :: Maybe Compartment -> Text
+renderCategories = \case
+    Nothing -> ""
+    Just (Compartment comp sub) -> case sub of
+        Just s | not (T.null (T.strip s)) -> comp <> "::" <> s
+        _ -> comp
+
+-- ---------------------------------------------------------------------------
+-- Lookups (pure)
+-- ---------------------------------------------------------------------------
+
+-- | Resolve the display name of a technosphere/waste exchange's flow.
+flowNameOf :: SimpleDatabase -> Exchange -> Maybe Text
+flowNameOf db = \case
+    ex@TechnosphereExchange{} -> tfName <$> M.lookup (exchangeFlowId ex) (sdbTechFlows db)
+    ex@WasteExchange{} -> wfName <$> M.lookup (exchangeFlowId ex) (sdbWasteFlows db)
+    ex@BiosphereExchange{} -> bfName <$> M.lookup (exchangeFlowId ex) (sdbBioFlows db)
+
+unitNameOf :: UUID -> SimpleDatabase -> Maybe Text
+unitNameOf uid db = unitName <$> M.lookup uid (sdbUnits db)
+
+-- | First element matching a predicate (total; no partial 'head').
+lookup' :: (a -> Bool) -> [a] -> Maybe a
+lookup' p = foldr (\x acc -> if p x then Just x else acc) Nothing
+
+-- ---------------------------------------------------------------------------
+-- Numeric formatting (pure, deterministic)
+-- ---------------------------------------------------------------------------
+
+{- | Canonical numeric rendering for amount cells. Integers print without a
+decimal point (@1@, not @1.0@); everything else uses the shortest round-tripping
+'show' for a 'Double'. Both forms re-parse via @Data.Text.Read.double@, so the
+written cell reconstructs the same 'Double'.
+-}
+formatAmount :: Double -> Text
+formatAmount d
+    | isNaN d || isInfinite d = T.pack (show d)
+    | d == fromIntegral i && abs d < 1.0e15 = T.pack (show i)
+    | otherwise = T.pack (show d)
+  where
+    i = round d :: Integer
+
+-- ---------------------------------------------------------------------------
+-- SpreadsheetML emitter (hand-built, mirrors the parser's reader)
+-- ---------------------------------------------------------------------------
+
+workbookXml :: Text
+workbookXml =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        <> "<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\""
+        <> " xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">"
+        <> "<sheets><sheet name=\"data\" sheetId=\"1\" r:id=\"rId1\"/></sheets>"
+        <> "</workbook>"
+
+relsXml :: Text
+relsXml =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        <> "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">"
+        <> "<Relationship Id=\"rId1\""
+        <> " Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\""
+        <> " Target=\"worksheets/sheet1.xml\"/>"
+        <> "</Relationships>"
+
+sheetXml :: [[Cell]] -> Text
+sheetXml rows =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        <> "<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"><sheetData>"
+        <> T.concat [rowXml n r | (n, r) <- zip [1 ..] rows]
+        <> "</sheetData></worksheet>"
+
+rowXml :: Int -> [Cell] -> Text
+rowXml n cells =
+    "<row r=\""
+        <> tshow n
+        <> "\">"
+        <> T.concat [cellXml col n cell | (col, cell) <- zip [0 ..] cells]
+        <> "</row>"
+
+-- | Empty cells are omitted entirely (sparse rows, like the parser expects).
+cellXml :: Int -> Int -> Cell -> Text
+cellXml _ _ CEmpty = ""
+cellXml col n (CNum d) =
+    "<c r=\"" <> cellRef col n <> "\" t=\"n\"><v>" <> formatAmount d <> "</v></c>"
+cellXml col n (CText t) =
+    "<c r=\""
+        <> cellRef col n
+        <> "\" t=\"inlineStr\"><is><t xml:space=\"preserve\">"
+        <> escapeXml t
+        <> "</t></is></c>"
+
+-- | A1-style cell reference. Columns beyond Z use multi-letter references.
+cellRef :: Int -> Int -> Text
+cellRef col n = columnLetters col <> tshow n
+
+columnLetters :: Int -> Text
+columnLetters = T.pack . reverse . go
+  where
+    go c =
+        let (q, r) = (c `div` 26, c `mod` 26)
+            letter = chr (ord 'A' + r)
+         in letter : if q == 0 then [] else go (q - 1)
+
+escapeXml :: Text -> Text
+escapeXml =
+    T.replace "\"" "&quot;"
+        . T.replace ">" "&gt;"
+        . T.replace "<" "&lt;"
+        . T.replace "&" "&amp;"
+
+tshow :: (Show a) => a -> Text
+tshow = T.pack . show

--- a/src/BrightwayExcel/Writer.hs
+++ b/src/BrightwayExcel/Writer.hs
@@ -317,11 +317,13 @@ lookup' p = foldr (\x acc -> if p x then Just x else acc) Nothing
 {- | Canonical numeric rendering for amount cells. Integers print without a
 decimal point (@1@, not @1.0@); everything else uses the shortest round-tripping
 'show' for a 'Double'. Both forms re-parse via @Data.Text.Read.double@, so the
-written cell reconstructs the same 'Double'.
+written cell reconstructs the same 'Double'. Non-finite values (which cannot
+occur in a parsed database) are clamped to a parseable @0@ rather than the
+unreadable @"NaN"@/@"Infinity"@ in a numeric cell — matching the other writers.
 -}
 formatAmount :: Double -> Text
 formatAmount d
-    | isNaN d || isInfinite d = T.pack (show d)
+    | isNaN d || isInfinite d = "0"
     | d == fromIntegral i && abs d < 1.0e15 = T.pack (show i)
     | otherwise = T.pack (show d)
   where

--- a/src/CLI/Client.hs
+++ b/src/CLI/Client.hs
@@ -25,6 +25,7 @@ import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import qualified Data.Text.IO as TIO
 import qualified Data.Vector as V
 import Network.HTTP.Client (
     HttpException (..),
@@ -81,6 +82,17 @@ executeRemoteCommand mgr rc globalOpts cmd = do
             executeUpload mgr rc fmt jp "/api/v1/db/upload" args
         Database (DbDelete name) ->
             apiDelete mgr rc ("/api/v1/db/" ++ T.unpack name) >>= output fmt jp
+        Database (DbDeleteActivities args) ->
+            apiPost mgr rc ("/api/v1/db/" ++ T.unpack (ddaDb args) ++ "/delete") (deleteSelectionBody args)
+                >>= output fmt jp
+        Database (DbRelinkMapping args) -> do
+            csv <- TIO.readFile (draMappingCsv args)
+            apiPost
+                mgr
+                rc
+                ("/api/v1/db/" ++ T.unpack (draDb args) ++ "/relink")
+                (relinkMappingBody (draToDep args) csv)
+                >>= output fmt jp
         Method McList ->
             apiGet mgr rc "/api/v1/method-collections" >>= output fmt jp
         Method (McUpload args) ->
@@ -217,7 +229,37 @@ extractLoadedDbNames = fromMaybe [] . parseMaybe go
 dbPath :: Text -> String
 dbPath name = "/api/v1/db/" ++ T.unpack name
 
--- | Build query string from optional parameters
+{- | Build query string from optional parameters
+| JSON body for the delete-by-selection endpoint (field names match the API).
+-}
+deleteSelectionBody :: DbDeleteArgs -> Value
+deleteSelectionBody args =
+    object
+        [ "name" .= ddaName args
+        , "location" .= ddaLocation args
+        , "product" .= ddaProduct args
+        , "classifications" .= classifications
+        , "exact" .= ddaExact args
+        , "keep" .= ddaKeep args
+        , "extra" .= ddaExtra args
+        ]
+  where
+    classifications = case (ddaClassSystem args, ddaClassValue args) of
+        (Just sys, Just val) ->
+            [object ["system" .= sys, "value" .= val, "exact" .= ddaExact args]]
+        _ -> [] :: [Value]
+
+{- | Body for POST /api/v1/db/{db}/relink with an inline alias mapping.
+Keys mirror 'API.Types.RelinkMappingRequest' after the @Stripped@ prefix
+transform (@rmrDepDb@ → @depDb@, @rmrMappingCsv@ → @mappingCsv@).
+-}
+relinkMappingBody :: Text -> Text -> Value
+relinkMappingBody depDb csv =
+    object
+        [ "depDb" .= depDb
+        , "mappingCsv" .= csv
+        ]
+
 buildQuery :: [(String, Maybe String)] -> String
 buildQuery params =
     case [(k, v) | (k, Just v) <- params] of

--- a/src/CLI/Client.hs
+++ b/src/CLI/Client.hs
@@ -250,8 +250,9 @@ deleteSelectionBody args =
         _ -> [] :: [Value]
 
 {- | Body for POST /api/v1/db/{db}/relink with an inline alias mapping.
-Keys mirror 'API.Types.RelinkMappingRequest' after the @Stripped@ prefix
-transform (@rmrDepDb@ → @depDb@, @rmrMappingCsv@ → @mappingCsv@).
+Keys mirror 'API.Types.RelinkRequest' after the @Stripped@ prefix transform
+(@rmrDepDb@ → @depDb@, @rmrMappingCsv@ → @mappingCsv@); both are populated here,
+which the handler reads as mapping mode (an empty @{}@ body is a plain relink).
 -}
 relinkMappingBody :: Text -> Text -> Value
 relinkMappingBody depDb csv =

--- a/src/CLI/Client.hs
+++ b/src/CLI/Client.hs
@@ -240,9 +240,7 @@ extractLoadedDbNames = fromMaybe [] . parseMaybe go
 dbPath :: Text -> String
 dbPath name = "/api/v1/db/" ++ T.unpack name
 
-{- | Build query string from optional parameters
-| JSON body for the delete-by-selection endpoint (field names match the API).
--}
+-- | JSON body for the delete-by-selection endpoint (field names match the API).
 deleteSelectionBody :: DbDeleteArgs -> Value
 deleteSelectionBody args =
     object
@@ -296,6 +294,7 @@ executeRemoteExport mgr rc fmt jp args = do
     parseExportResponse = withObject "ExportResponse" $ \o ->
         (,,) <$> o .: "success" <*> o .: "message" <*> o .:? "data"
 
+-- | Build query string from optional parameters
 buildQuery :: [(String, Maybe String)] -> String
 buildQuery params =
     case [(k, v) | (k, Just v) <- params] of

--- a/src/CLI/Client.hs
+++ b/src/CLI/Client.hs
@@ -11,7 +11,7 @@ module CLI.Client (
 import CLI.Types
 import Config (Config (..), ServerConfig (..))
 import Control.Exception (try)
-import Data.Aeson (Value (..), decode, encode, object, (.:), (.=))
+import Data.Aeson (Value (..), decode, encode, object, (.:), (.:?), (.=))
 import Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KM
@@ -93,6 +93,17 @@ executeRemoteCommand mgr rc globalOpts cmd = do
                 ("/api/v1/db/" ++ T.unpack (draDb args) ++ "/relink")
                 (relinkMappingBody (draToDep args) csv)
                 >>= output fmt jp
+        Database (DbCopy srcName newName) ->
+            -- The copy endpoint takes no body (newName is a path capture); the
+            -- empty object is ignored server-side.
+            apiPost
+                mgr
+                rc
+                ("/api/v1/db/" ++ T.unpack srcName ++ "/copy/" ++ T.unpack newName)
+                (object [])
+                >>= output fmt jp
+        Database (DbExport args) ->
+            executeRemoteExport mgr rc fmt jp args
         Method McList ->
             apiGet mgr rc "/api/v1/method-collections" >>= output fmt jp
         Method (McUpload args) ->
@@ -260,6 +271,30 @@ relinkMappingBody depDb csv =
         [ "depDb" .= depDb
         , "mappingCsv" .= csv
         ]
+
+{- | Remote export: POST the target format, base64-decode the bytes the server
+returns (serialization happens server-side), and write them to @--out@. Mirrors
+the local export's output summary. Failures (bad format, db not loaded, invalid
+base64) surface loudly rather than writing a partial/empty file.
+-}
+executeRemoteExport :: Manager -> RemoteConfig -> OutputFormat -> Maybe Text -> DbExportArgs -> IO ()
+executeRemoteExport mgr rc fmt jp args = do
+    resp <- apiPost mgr rc ("/api/v1/db/" ++ T.unpack (deaDb args) ++ "/export") (object ["format" .= deaFormat args])
+    case resp of
+        Left err -> reportError err >> exitFailure
+        Right val -> case parseMaybe parseExportResponse val of
+            Nothing -> reportError "export: malformed server response" >> exitFailure
+            Just (False, msg, _) -> reportError ("export failed: " ++ T.unpack msg) >> exitFailure
+            Just (True, _, Nothing) -> reportError "export: server reported success but returned no data" >> exitFailure
+            Just (True, _, Just b64) -> case B64.decode (T.encodeUtf8 b64) of
+                Left derr -> reportError ("export: invalid base64 from server: " ++ derr) >> exitFailure
+                Right bytes -> do
+                    C8.writeFile (deaOut args) bytes
+                    output fmt jp (Right (object ["database" .= deaDb args, "format" .= deaFormat args, "out" .= deaOut args]))
+  where
+    parseExportResponse :: Value -> Parser (Bool, Text, Maybe Text)
+    parseExportResponse = withObject "ExportResponse" $ \o ->
+        (,,) <$> o .: "success" <*> o .: "message" <*> o .:? "data"
 
 buildQuery :: [(String, Maybe String)] -> String
 buildQuery params =

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -3,7 +3,7 @@
 
 module CLI.Command where
 
-import CLI.Types (CLIConfig (..), Command (..), DatabaseAction (..), DebugMatricesOptions (..), FlowSubCommand (..), GlobalOptions (..), LCIAOptions (..), MappingOptions (..), MethodAction (..), OutputFormat (..), PluginAction (..), SearchActivitiesOptions (..), SearchFlowsOptions (..), UploadArgs (..))
+import CLI.Types (CLIConfig (..), Command (..), DatabaseAction (..), DbDeleteArgs (..), DbExportArgs (..), DbRelinkArgs (..), DebugMatricesOptions (..), FlowSubCommand (..), GlobalOptions (..), LCIAOptions (..), MappingOptions (..), MethodAction (..), OutputFormat (..), PluginAction (..), SearchActivitiesOptions (..), SearchFlowsOptions (..), UploadArgs (..))
 import Config (DatabaseConfig (..), MethodConfig (..))
 import Control.Concurrent.STM (readTVarIO)
 import Data.Aeson (Value, encode, object, toJSON, (.=))
@@ -16,9 +16,12 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
-import Database.Manager (DatabaseManager (..), LoadedDatabase (..), addDatabase, addMethodCollection)
+import Database.Edit (copyDatabase, deleteActivitiesInDB)
+import Database.Export (exportDatabase)
+import Database.Manager (DatabaseManager (..), LoadedDatabase (..), RelinkResult (..), addDatabase, addMethodCollection)
 import qualified Database.Manager as DM
-import Database.Upload (UploadData (..), UploadResult (..), findMethodDirectory, handleUpload)
+import Database.RelinkMapping (relinkWithMappingFile)
+import Database.Upload (DatabaseFormat (..), UploadData (..), UploadResult (..), findMethodDirectory, handleUpload)
 import qualified Database.Upload
 import qualified Database.UploadedDatabase as UploadedDB
 import Method.Mapping (MappingStats (..), MatchStrategy (..), computeMappingStats, mapMethodToFlows)
@@ -98,6 +101,14 @@ executeCommand (CLIConfig globalOpts _) cmd manager = do
             executeDbUpload registry outputFormat manager args
         Database (DbDelete name) ->
             executeDbDelete registry outputFormat manager name
+        Database (DbDeleteActivities args) ->
+            executeDbDeleteActivities registry outputFormat manager args
+        Database (DbCopy srcName newName) ->
+            executeDbCopy registry outputFormat manager srcName newName
+        Database (DbRelinkMapping args) ->
+            executeDbRelinkMapping registry outputFormat manager args
+        Database (DbExport args) ->
+            executeDbExport registry outputFormat manager args
         Method McList ->
             DM.listMethodCollections manager >>= out . toJSON
         Method (McUpload args) ->
@@ -477,6 +488,107 @@ executeDbDelete registry fmt manager name = do
         Right () -> do
             reportProgress Info $ "Deleted database: " ++ T.unpack name
             outputResult registry fmt $ object ["deleted" .= name]
+
+-- | Execute database copy command
+executeDbCopy :: PluginRegistry -> OutputFormat -> DatabaseManager -> Text -> Text -> IO ()
+executeDbCopy registry fmt manager srcName newName = do
+    result <- copyDatabase manager srcName newName
+    case result of
+        Left err -> do
+            reportError $ "Copy failed: " ++ T.unpack err
+            exitFailure
+        Right () -> do
+            reportProgress Info $ "Copied database: " ++ T.unpack srcName ++ " -> " ++ T.unpack newName
+            outputResult registry fmt $ object ["source" .= srcName, "copy" .= newName]
+
+-- | Execute relink-with-mapping: relink a DB to a dependency via an alias CSV.
+executeDbRelinkMapping :: PluginRegistry -> OutputFormat -> DatabaseManager -> DbRelinkArgs -> IO ()
+executeDbRelinkMapping registry fmt manager args = do
+    result <- relinkWithMappingFile manager (draDb args) (draToDep args) (draMappingCsv args)
+    case result of
+        Left err -> do
+            reportError $ "Relink failed: " ++ T.unpack err
+            exitFailure
+        Right r -> do
+            reportProgress Info $
+                "Re-linked "
+                    ++ T.unpack (rresDbName r)
+                    ++ ": "
+                    ++ show (rresUnresolvedBefore r)
+                    ++ " -> "
+                    ++ show (rresUnresolvedAfter r)
+                    ++ " unresolved ("
+                    ++ show (rresCrossDBLinks r)
+                    ++ " cross-DB links)"
+            outputResult registry fmt $
+                object
+                    [ "database" .= rresDbName r
+                    , "unresolved_before" .= rresUnresolvedBefore r
+                    , "unresolved_after" .= rresUnresolvedAfter r
+                    , "cross_db_links" .= rresCrossDBLinks r
+                    , "depends_on" .= rresDepsLoaded r
+                    ]
+
+-- | Parse the @--format@ keyword for export into a 'DatabaseFormat'.
+parseExportFormat :: Text -> Either Text DatabaseFormat
+parseExportFormat raw = case T.toLower (T.strip raw) of
+    "simapro" -> Right SimaProCSV
+    "ecospold1" -> Right EcoSpold1
+    "ecospold2" -> Right EcoSpold2
+    "ilcd" -> Right ILCDProcess
+    "brightway" -> Right BrightwayExcel
+    other -> Left $ "unknown export format: " <> other <> " (expected simapro|ecospold1|ecospold2|ilcd|brightway)"
+
+-- | Execute database export: serialize a loaded database to a file.
+executeDbExport :: PluginRegistry -> OutputFormat -> DatabaseManager -> DbExportArgs -> IO ()
+executeDbExport registry fmt manager args =
+    case parseExportFormat (deaFormat args) of
+        Left err -> reportError (T.unpack err) >> exitFailure
+        Right dbFmt -> do
+            mLoaded <- DM.getDatabase manager (deaDb args)
+            case mLoaded of
+                Nothing -> do
+                    reportError $ "Database '" ++ T.unpack (deaDb args) ++ "' not loaded"
+                    exitFailure
+                Just ld -> do
+                    result <- exportDatabase dbFmt (ldDatabase ld) (deaOut args)
+                    case result of
+                        Left err -> reportError (T.unpack err) >> exitFailure
+                        Right () -> do
+                            reportProgress Info $ "Exported " ++ T.unpack (deaDb args) ++ " -> " ++ deaOut args
+                            outputResult registry fmt $
+                                object
+                                    [ "database" .= deaDb args
+                                    , "format" .= deaFormat args
+                                    , "out" .= deaOut args
+                                    ]
+
+{- | Execute delete-by-selection: deletes the whole filtered set (pagination
+ignored) plus the explicit @--add@ ProcessIds, sparing @--keep@.
+-}
+executeDbDeleteActivities :: PluginRegistry -> OutputFormat -> DatabaseManager -> DbDeleteArgs -> IO ()
+executeDbDeleteActivities registry fmt manager args = do
+    let classFilters = case (ddaClassSystem args, ddaClassValue args) of
+            (Just sys, Just val) -> [(sys, val, ddaExact args)]
+            _ -> []
+    result <-
+        deleteActivitiesInDB
+            manager
+            (ddaDb args)
+            (ddaName args)
+            (ddaLocation args)
+            (ddaProduct args)
+            classFilters
+            (ddaExact args)
+            (ddaKeep args)
+            (ddaExtra args)
+    case result of
+        Left err -> do
+            reportError $ "Delete failed: " ++ T.unpack err
+            exitFailure
+        Right deleted -> do
+            reportProgress Info $ "Deleted " ++ show deleted ++ " activities from " ++ T.unpack (ddaDb args)
+            outputResult registry fmt $ object ["database" .= ddaDb args, "deleted" .= deleted]
 
 -- | Execute method delete command
 executeMcDelete :: PluginRegistry -> OutputFormat -> DatabaseManager -> Text -> IO ()

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -116,8 +116,55 @@ databaseParser =
                 ( OA.command "list" (info (pure DbList) (progDesc "List databases"))
                     <> OA.command "upload" (info (DbUpload <$> uploadArgsParser) (progDesc "Upload a database from a local file"))
                     <> OA.command "delete" (info (DbDelete <$> deleteNameParser) (progDesc "Delete a database"))
+                    <> OA.command "delete-activities" (info (DbDeleteActivities <$> deleteActivitiesArgsParser <**> helper) (progDesc "Delete the whole filtered set of activities from a loaded database"))
+                    <> OA.command "copy" (info (copyArgsParser <**> helper) (progDesc "Copy a loaded database under a new name"))
+                    <> OA.command "relink" (info (DbRelinkMapping <$> relinkArgsParser <**> helper) (progDesc "Relink a database to a dependency using a name->name supplier alias CSV"))
+                    <> OA.command "export" (info (DbExport <$> exportArgsParser <**> helper) (progDesc "Export a loaded database to a file"))
                 )
             )
+
+-- | Copy arguments parser (positional SRC and NEW_NAME)
+copyArgsParser :: Parser DatabaseAction
+copyArgsParser =
+    DbCopy
+        <$> textArg "SRC" "Name of the loaded database to copy"
+        <*> textArg "NEW_NAME" "Name for the copy"
+
+{- | Relink-with-mapping parser: positional DB, @--to@ dependency, @--mapping@
+CSV path. Mirrors @db relink <db> --to <depDb> --mapping <csv>@.
+-}
+relinkArgsParser :: Parser DbRelinkArgs
+relinkArgsParser =
+    DbRelinkArgs
+        <$> textArg "DB" "Name of the loaded database to relink"
+        <*> textOpt "to" Nothing "DEP_DB" "Dependency database to link against"
+        <*> strOpt "mapping" Nothing "CSV" "Path to the name->name supplier alias CSV"
+
+{- | Export parser: positional DB, @--format@ keyword, @--out@ file path.
+Mirrors @db export <db> --format <fmt> --out <file>@.
+-}
+exportArgsParser :: Parser DbExportArgs
+exportArgsParser =
+    DbExportArgs
+        <$> textArg "DB" "Name of the loaded database to export"
+        <*> textOpt "format" Nothing "FMT" "Target format: simapro|ecospold1|ecospold2|ilcd|brightway"
+        <*> strOpt "out" Nothing "FILE" "Output file path"
+
+{- | Delete-by-selection parser: positional DB plus filter options. @--keep@ and
+@--add@ may be repeated; they spare or add individual ProcessIds.
+-}
+deleteActivitiesArgsParser :: Parser DbDeleteArgs
+deleteActivitiesArgsParser =
+    DbDeleteArgs
+        <$> textArg "DB" "Name of the loaded database to edit"
+        <*> optTextOpt "name" Nothing "NAME" "Filter by activity name"
+        <*> optTextOpt "location" Nothing "GEO" "Filter by location"
+        <*> optTextOpt "product" Nothing "PRODUCT" "Filter by reference product name"
+        <*> optTextOpt "class-system" Nothing "SYSTEM" "Classification system to filter on"
+        <*> optTextOpt "class-value" Nothing "VALUE" "Classification value to filter on"
+        <*> switch (long "exact" <> help "Exact (case-insensitive) name match instead of token-contains")
+        <*> many (textOpt "keep" Nothing "PID" "Process id (activityUUID_productUUID) to spare from deletion (repeatable)")
+        <*> many (textOpt "add" Nothing "PID" "Process id to add to deletion (repeatable)")
 
 -- | Method command parser with optional subcommand (defaults to list)
 methodParser :: Parser Command

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -63,6 +63,57 @@ data DatabaseAction
     = DbList
     | DbUpload UploadArgs
     | DbDelete Text
+    | {- | Delete the activities matched by a filter (the whole matching set,
+      pagination ignored), keeping/adding explicit ProcessIds.
+      -}
+      DbDeleteActivities DbDeleteArgs
+    | -- | Copy a loaded database (source name → new name)
+      DbCopy Text Text
+    | {- | Relink a database against one dependency using a name→name supplier
+      alias mapping loaded from a local CSV: @db@, @--to depDb@, @--mapping csv@.
+      -}
+      DbRelinkMapping DbRelinkArgs
+    | -- | Export a loaded database to a file: @db@, @--format fmt@, @--out file@.
+      DbExport DbExportArgs
+    deriving (Eq, Show, Generic)
+
+-- | Arguments for @database export@.
+data DbExportArgs = DbExportArgs
+    { deaDb :: Text
+    -- ^ Database to export
+    , deaFormat :: Text
+    -- ^ Target format keyword (@--format@): simapro|ecospold1|ecospold2|ilcd|brightway
+    , deaOut :: FilePath
+    -- ^ Output file path (@--out@)
+    }
+    deriving (Eq, Show, Generic)
+
+-- | Arguments for @database relink@ with a name→name supplier alias mapping.
+data DbRelinkArgs = DbRelinkArgs
+    { draDb :: Text
+    -- ^ Database to relink
+    , draToDep :: Text
+    -- ^ Dependency database to link against (@--to@)
+    , draMappingCsv :: FilePath
+    -- ^ Path to the mapping CSV (@--mapping@)
+    }
+    deriving (Eq, Show, Generic)
+
+{- | Arguments for delete-by-selection. The filter fields mirror the activity
+search filter; @ddaKeep@ spares matched ProcessIds and @ddaExtra@ adds ones
+the filter missed.
+-}
+data DbDeleteArgs = DbDeleteArgs
+    { ddaDb :: Text
+    , ddaName :: Maybe Text
+    , ddaLocation :: Maybe Text
+    , ddaProduct :: Maybe Text
+    , ddaClassSystem :: Maybe Text
+    , ddaClassValue :: Maybe Text
+    , ddaExact :: Bool
+    , ddaKeep :: [Text]
+    , ddaExtra :: [Text]
+    }
     deriving (Eq, Show, Generic)
 
 -- | Plugin management actions

--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -141,6 +141,15 @@ data LinkingContext = LinkingContext
     -- ^ Location hierarchy (code → parent codes)
     , lcGeographyPolicy :: !GeographyPolicy
     -- ^ How aggressively to widen geography when no exact match is found
+    , lcSupplierAliases :: !(Maybe (M.Map Text Text))
+    {- ^ Optional consumer-flow-name → supplier-name aliases. When a
+    consumer's input flow name does not match any supplier directly, the
+    matcher retries with its alias from this map (e.g. an Ecoinvent-named
+    input rewritten to the BAFU activity name). 'Nothing' disables the
+    feature entirely (the common case for ordinary loads); 'Just' an empty
+    map is equivalent. Keys are matched on the raw (un-normalized) flow
+    name, falling back to 'normalizeText'.
+    -}
     }
 
 -- | A candidate supplier from another database
@@ -532,6 +541,19 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
         --   1. Exact product-name match across all indexed DBs.
         --   2. Synonym-group match if exact yielded nothing.
         --   3. Prefix-splitting fallback for compound names (e.g. SimaPro).
+        -- Alias retry: when the consumer's flow name only matches the target
+        -- supplier under an explicit name→name mapping (e.g. Ecoinvent name →
+        -- BAFU activity name), look the alias up and run the same
+        -- exact/synonym sub-cascade on it. Tried last, so direct matches always
+        -- win over the mapping.
+        aliasOf nm = case lcSupplierAliases of
+            Nothing -> Nothing
+            Just aliases -> case M.lookup nm aliases of
+                Just target -> Just target
+                Nothing -> M.lookup (normalizeText nm) aliases
+        aliasCandidates = case aliasOf productName of
+            Nothing -> []
+            Just aliasName -> firstNonEmpty [tryName aliasName, tryPrefixes (extractProductPrefixes aliasName)]
         allCandidates =
             firstNonEmpty
                 [ concatMap (lookupExact normalizedName) lcIndexedDatabases
@@ -539,6 +561,7 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
                     Just groupId -> concatMap (lookupBySynonym groupId) lcIndexedDatabases
                     Nothing -> []
                 , tryPrefixes (extractProductPrefixes productName)
+                , aliasCandidates
                 ]
         -- Effective location: if raw location is empty, try extracting from compound name
         effectiveLocation =
@@ -616,19 +639,21 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
     firstNonEmpty :: [[a]] -> [a]
     firstNonEmpty = fromMaybe [] . find (not . null)
 
+    -- Run the (exact, then synonym) sub-cascade on a single candidate name.
+    tryName :: Text -> [(Text, SupplierEntry)]
+    tryName p =
+        let normalized = normalizeText p
+            byExact = concatMap (lookupExact normalized) lcIndexedDatabases
+            bySynonym = case lookupSynonymGroup lcSynonymDB (normalizeName p) of
+                Just groupId -> concatMap (lookupBySynonym groupId) lcIndexedDatabases
+                Nothing -> []
+         in firstNonEmpty [byExact, bySynonym]
+
     -- Try each prefix from compound name splitting; for each prefix run the
     -- same (exact, then synonym) sub-cascade; return the first prefix that
     -- yields anything.
     tryPrefixes :: [Text] -> [(Text, SupplierEntry)]
-    tryPrefixes = firstNonEmpty . map candidatesFor
-      where
-        candidatesFor p =
-            let normalized = normalizeText p
-                byExact = concatMap (lookupExact normalized) lcIndexedDatabases
-                bySynonym = case lookupSynonymGroup lcSynonymDB (normalizeName p) of
-                    Just groupId -> concatMap (lookupBySynonym groupId) lcIndexedDatabases
-                    Nothing -> []
-             in firstNonEmpty [byExact, bySynonym]
+    tryPrefixes = firstNonEmpty . map tryName
 
     classifyEntry :: Text -> (Text, SupplierEntry) -> Maybe ((Text, SupplierEntry), LocationKind)
     classifyEntry queryLoc entry@(_, SupplierEntry{seLocation}) =

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -1,0 +1,426 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{- |
+Module      : Database.Edit
+Description : In-memory database editing primitives (copy, delete-by-selection)
+
+Shared home for operations that produce a *new* loaded database from an
+existing one without touching disk.
+
+COPY is construction, not mutation. 'Database' is a pure, immutable value
+(see "Types"), so duplicating it is just sharing the same persistent
+structure under a second registry key: nothing observable can alias because
+nothing is mutable. The only fresh allocation is the solver (it holds an
+'MVar' factorization cache keyed by name); reusing the source solver would
+let the two registry entries share a factorization cache, so the copy gets
+its own.
+
+DELETE is reconstruction, not mutation either. 'deleteActivities' drops a set
+of activities and rebuilds every dependent structure (interning tables,
+indexes, sparse matrices, product index) from the surviving activities. The
+rebuild reuses the exact pure builders that back a freshly-loaded database
+('buildInterningTables' / 'buildTechTriples' / 'buildBioTriples' /
+'buildProductIndex' / 'buildIndexesWithProcessIds'), so a deleted-from
+database is byte-for-byte indistinguishable from one that never carried the
+removed rows. Exchanges in surviving activities that referenced a deleted
+activity are UNLINKED (their activity link reset to nil), leaving the value
+ready for relinking — never silently dropped.
+
+Memory cost (copy): the copy keeps the source 'Database' alive for as long as
+it is loaded. Structural sharing means we don't re-allocate the activity/flow
+vectors, but a large database that would otherwise be unloaded stays resident
+while any copy of it is loaded.
+-}
+module Database.Edit (
+    copyDatabaseAs,
+    copyDatabase,
+    deleteActivities,
+    deleteActivitiesWith,
+    resolveDeleteSelection,
+    DeleteSelection (..),
+    deleteActivitiesInDB,
+) where
+
+import Control.Concurrent.STM (atomically, modifyTVar', readTVarIO)
+import qualified Data.IntSet as IS
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as U
+
+import Config (DatabaseConfig (..))
+import Database (
+    buildIndexesWithProcessIds,
+    buildProductIndex,
+    findActivitiesByFields,
+ )
+import Database.CrossLinking (buildIndexedDatabaseFromDB)
+import Database.Manager (
+    DatabaseManager (..),
+    LoadedDatabase (..),
+    clearMethodMappingCacheForDb,
+    getDatabase,
+    getMergedSynonymDB,
+    getMergedUnitConfig,
+ )
+import Database.MatrixBuild (
+    InterningTables (..),
+    buildBioTriples,
+    buildInterningTables,
+    buildSupplierRefUnits,
+    buildTechTriples,
+    collectBioFlowOrder,
+ )
+import qualified Search.BM25 as BM25
+import SharedSolver (createSharedSolver)
+import Types (
+    Activity (..),
+    Database (..),
+    Exchange (..),
+    ProcessId,
+    SparseTriple (..),
+    UUID,
+    findProcessId,
+    findProcessIdByActivityUUID,
+    initializeRuntimeFields,
+    parseUUIDPair,
+ )
+import UnitConversion (UnitConfig, defaultUnitConfig)
+
+{- | Produce a copy of a loaded database under a new internal name.
+
+The returned 'Database' is the source value unchanged — it carries no
+self-name (the name lives in the registry 'DatabaseConfig'), and because the
+value is immutable the copy is automatically independent of the source. The
+@newName@ is the registry identity the copy will be inserted under; see
+'copyDatabase' for the effectful registration that applies it.
+
+Kept as a named, total function so the rename intent is explicit at call
+sites and so future deep-edit primitives (which *will* transform the value)
+share this entry point.
+-}
+copyDatabaseAs :: Text -> Database -> Database
+copyDatabaseAs _newName = id
+
+{- | Copy a loaded database into the runtime registry under @newName@.
+
+Looks up the loaded source, builds an independent 'LoadedDatabase' (renamed
+config + fresh solver, see module note), and inserts it into the loaded /
+available / indexed maps. Fails (Left) when the source is not loaded or when
+@newName@ already names a loaded or configured database — a copy must never
+silently overwrite an existing entry.
+-}
+copyDatabase :: DatabaseManager -> Text -> Text -> IO (Either Text ())
+copyDatabase manager srcName newName = do
+    loadedDbs <- readTVarIO (dmLoadedDbs manager)
+    availableDbs <- readTVarIO (dmAvailableDbs manager)
+    if M.member newName loadedDbs || M.member newName availableDbs
+        then pure $ Left $ "Database already exists: " <> newName
+        else
+            getDatabase manager srcName >>= \case
+                Nothing -> pure $ Left $ "Database not loaded: " <> srcName
+                Just src -> do
+                    let copiedDb = copyDatabaseAs newName (ldDatabase src)
+                        newConfig = renameConfig newName (ldConfig src)
+                    -- Fresh solver: a distinct name keys a distinct factorization cache.
+                    let techTriplesInt =
+                            [ (fromIntegral i, fromIntegral j, v)
+                            | SparseTriple i j v <- U.toList (dbTechnosphereTriples copiedDb)
+                            ]
+                    solver <-
+                        createSharedSolver
+                            newName
+                            techTriplesInt
+                            (fromIntegral (dbActivityCount copiedDb))
+                    let copied =
+                            LoadedDatabase
+                                { ldDatabase = copiedDb
+                                , ldSharedSolver = solver
+                                , ldConfig = newConfig
+                                }
+                    synonymDB <- getMergedSynonymDB manager
+                    let indexedDb = buildIndexedDatabaseFromDB newName synonymDB copiedDb
+                    atomically $ do
+                        modifyTVar' (dmLoadedDbs manager) (M.insert newName copied)
+                        modifyTVar' (dmAvailableDbs manager) (M.insert newName newConfig)
+                        modifyTVar' (dmIndexedDbs manager) (M.insert newName indexedDb)
+                    clearMethodMappingCacheForDb manager newName
+                    pure $ Right ()
+
+{- | Rename a config for the copy: new internal name, derived display name, and
+forced deletable/uploaded so the copy can be removed again via the normal
+delete path (the source may be a TOML-pinned, non-deletable database).
+-}
+renameConfig :: Text -> DatabaseConfig -> DatabaseConfig
+renameConfig newName cfg =
+    cfg
+        { dcName = newName
+        , dcDisplayName = newName
+        , dcIsUploaded = True
+        , dcDeletable = True
+        }
+
+-- ---------------------------------------------------------------------------
+-- Delete by selection
+-- ---------------------------------------------------------------------------
+
+{- | Remove a set of activities (by 'ProcessId') and rebuild every dependent
+structure. Uses 'defaultUnitConfig'; effectful call sites that carry a merged
+unit config (the only place where non-SI conversions matter) should call
+'deleteActivitiesWith' instead so a coefficient is never silently dropped on
+an unknown-unit conversion.
+-}
+deleteActivities :: [ProcessId] -> Database -> Either Text Database
+deleteActivities = deleteActivitiesWith defaultUnitConfig
+
+{- | 'deleteActivities' with an explicit 'UnitConfig'.
+
+Steps, all pure:
+
+  1. Resolve the delete set to the @(activityUUID, productUUID)@ keys it
+     occupies in 'dbProcessIdTable', validating that every requested
+     'ProcessId' exists (no silent skip).
+  2. Drop those keys; for every surviving activity, UNLINK any technosphere /
+     waste exchange whose @(activityLink, flow)@ pointed at a deleted key —
+     reset its activity link to 'UUID.nil' and clear the stale process link.
+  3. Rebuild interning tables, indexes, matrices and the product index from
+     the surviving activity map via the shared loader builders.
+
+Fails (Left) when an out-of-range 'ProcessId' is requested, when the result
+would be empty, or when matrix construction reports an inconsistency (e.g. an
+unknown unit conversion under the given config).
+-}
+deleteActivitiesWith :: UnitConfig -> [ProcessId] -> Database -> Either Text Database
+deleteActivitiesWith unitConfig pids db = do
+    deletedKeys <- resolveDeleteKeys db pids
+    let survivors = surviving db deletedKeys
+        survivingKeys = M.keysSet survivors
+        unlinkedMap = M.map (unlinkActivity survivingKeys) survivors
+    if M.null unlinkedMap
+        then Left "Refusing to delete: the result would have no activities"
+        else rebuildFromActivities unitConfig db unlinkedMap
+
+{- | Resolve each requested 'ProcessId' to its @(activityUUID, productUUID)@ key.
+Every id must be in range — an out-of-range id is a caller error, surfaced as
+'Left' rather than silently ignored. The result is a 'Set' so membership tests
+during unlinking are @O(log n)@.
+-}
+resolveDeleteKeys :: Database -> [ProcessId] -> Either Text (S.Set (UUID, UUID))
+resolveDeleteKeys db = fmap S.fromList . traverse keyOf
+  where
+    table = dbProcessIdTable db
+    n = V.length table
+    keyOf pid
+        | i >= 0 && i < n = Right (table V.! i)
+        | otherwise = Left ("Delete: ProcessId out of range: " <> T.pack (show pid))
+      where
+        i = fromIntegral pid
+
+-- | The activity map keyed by @(activityUUID, productUUID)@, minus the deleted keys.
+surviving :: Database -> S.Set (UUID, UUID) -> M.Map (UUID, UUID) Activity
+surviving db deletedKeys =
+    M.fromList
+        [ (key, dbActivities db V.! i)
+        | i <- [0 .. V.length (dbActivities db) - 1]
+        , let key = dbProcessIdTable db V.! i
+        , not (S.member key deletedKeys)
+        ]
+
+{- | Reset technosphere / waste exchanges on a surviving activity whose producer
+link no longer resolves to a surviving @(activityUUID, productUUID)@ key.
+
+The link target is exactly that pair: 'findProducer' resolves
+@(activityLink, flowId)@ against the interning table, so a multi-product
+activity that keeps at least one product stays a valid target for exchanges
+pointing at a *surviving* product, while exchanges pointing at a deleted
+product are unlinked. A biosphere exchange has no producer link and is
+returned unchanged. The stale 'ProcessId' link is always cleared because
+deletion renumbers every 'ProcessId'. An already-orphan link
+(@activityLink == nil@) stays orphan.
+-}
+unlinkActivity :: S.Set (UUID, UUID) -> Activity -> Activity
+unlinkActivity survivingKeys act =
+    act{exchanges = map unlinkExchange (exchanges act)}
+  where
+    dangling link flow = link /= UUID.nil && not (S.member (link, flow) survivingKeys)
+    unlinkExchange ex = case ex of
+        BiosphereExchange{} -> ex
+        TechnosphereExchange{techActivityLinkId = link, techFlowId = flow}
+            | dangling link flow ->
+                ex{techActivityLinkId = UUID.nil, techProcessLinkId = Nothing}
+            | otherwise -> ex{techProcessLinkId = Nothing}
+        WasteExchange{waActivityLinkId = link, waFlowId = flow}
+            | dangling link flow ->
+                ex{waActivityLinkId = UUID.nil, waProcessLinkId = Nothing}
+            | otherwise -> ex{waProcessLinkId = Nothing}
+
+{- | Rebuild a 'Database' from a surviving activity map, reusing the exact pure
+builders that back a freshly-loaded database. Flow / unit tables are carried
+over unchanged: deletion removes activities, never the flow or unit
+vocabulary, so a relink can still resolve the surviving links. Runtime fields
+(synonym, flow-name, BM25 indexes) are reset to their unloaded state; the
+effectful caller re-attaches them with the merged synonym DB.
+-}
+rebuildFromActivities :: UnitConfig -> Database -> M.Map (UUID, UUID) Activity -> Either Text Database
+rebuildFromActivities unitConfig db activityMap =
+    let tables = buildInterningTables activityMap
+        supplierRefUnits = buildSupplierRefUnits (dbUnits db) (itActivities tables)
+        indexes = buildIndexesWithProcessIds (itActivities tables) (itProcessIdTable tables)
+        bioFlowUUIDs = collectBioFlowOrder (itActivities tables)
+        bioTriples = buildBioTriples bioFlowUUIDs tables
+        productIndex = buildProductIndex (itActivities tables) (itProcessIdTable tables) (dbTechFlows db)
+     in case buildTechTriples unitConfig (dbUnits db) tables supplierRefUnits of
+            Left err -> Left err
+            Right (techTriples, _warnings) ->
+                Right
+                    db
+                        { dbProcessIdTable = itProcessIdTable tables
+                        , dbProcessIdLookup = itProcessIdLookup tables
+                        , dbActivityUUIDIndex = itActivityUUIDIndex tables
+                        , dbActivityProductsIndex = itActivityProductsIndex tables
+                        , dbProductIndex = productIndex
+                        , dbActivities = itActivities tables
+                        , dbIndexes = indexes
+                        , dbTechnosphereTriples = techTriples
+                        , dbBiosphereTriples = bioTriples
+                        , dbActivityIndex = V.generate (fromIntegral (itActivityCount tables)) fromIntegral
+                        , dbBiosphereOrder = bioFlowUUIDs
+                        , dbActivityCount = itActivityCount tables
+                        , dbBiosphereCount = fromIntegral (V.length bioFlowUUIDs)
+                        , -- Cross-DB links may now reference deleted activities; clear so a
+                          -- subsequent relink rebuilds them against the surviving set.
+                          dbCrossDBLinks = []
+                        , -- Runtime-only indexes are reset; re-attached by the effectful caller.
+                          dbSynonymDB = Nothing
+                        , dbFlowsByName = M.empty
+                        , dbFlowsByCAS = M.empty
+                        , dbProductSearchIndex = M.empty
+                        , dbBM25Index = Nothing
+                        }
+
+-- ---------------------------------------------------------------------------
+-- Selection resolver
+-- ---------------------------------------------------------------------------
+
+{- | A deletion request: the whole set matched by a filter, plus explicit
+adjustments. @dsKeep@ rescues individuals the filter matched (checkbox
+unticked); @dsExtra@ adds individuals the filter missed (checkbox ticked on a
+row outside the current filter). 'ProcessId' lists, never paginated.
+-}
+data DeleteSelection = DeleteSelection
+    { dsFiltered :: [ProcessId]
+    -- ^ the full filtered set (pagination ignored)
+    , dsKeep :: [ProcessId]
+    -- ^ individuals to spare from deletion
+    , dsExtra :: [ProcessId]
+    -- ^ individuals to add to deletion
+    }
+
+{- | Final delete set = (filtered ∪ extra) \\ keep. Deduplicated; @keep@ wins
+over both @filtered@ and @extra@ so an unticked checkbox always spares a row.
+Order is not significant — the result is consumed as a set by
+'deleteActivities'.
+-}
+resolveDeleteSelection :: DeleteSelection -> [ProcessId]
+resolveDeleteSelection sel =
+    map fromIntegral . IS.toList $
+        IS.difference
+            (IS.union (toSet (dsFiltered sel)) (toSet (dsExtra sel)))
+            (toSet (dsKeep sel))
+  where
+    toSet = IS.fromList . map fromIntegral
+
+{- | Resolve a filter to the full set of matching 'ProcessId's, ignoring
+pagination. Mirrors the non-BM25 structured-filter path of
+'Service.searchActivities' (name / location / product / classification), which
+is the set the UI's "delete the whole filtered set" button acts on.
+-}
+filteredProcessIds ::
+    Database ->
+    Maybe Text -> -- name
+    Maybe Text -> -- location
+    Maybe Text -> -- product
+    [(Text, Text, Bool)] -> -- classification (system, value, isExact)
+    Bool -> -- exact name match
+    [ProcessId]
+filteredProcessIds db nameP geoP prodP classFilters exactMatch =
+    map fst (findActivitiesByFields db nameP geoP prodP classFilters exactMatch)
+
+-- ---------------------------------------------------------------------------
+-- Effectful entry point (registry swap)
+-- ---------------------------------------------------------------------------
+
+{- | Resolve a process-id string to its 'ProcessId'. Accepts the canonical
+@activityUUID_productUUID@ form and the bare-activity-UUID fallback (when the
+activity has a unique reference product), mirroring
+'Service.resolveActivityAndProcessId'. The UI and CLI carry these textual ids,
+so keep/extra adjustments are expressed in the same currency as the rows the
+user sees — not the volatile integer matrix index. Unresolvable ids fail loudly
+rather than being silently dropped.
+-}
+resolvePid :: Database -> Text -> Either Text ProcessId
+resolvePid db queryText =
+    maybe (Left ("Unknown process id: " <> queryText)) Right $ case parseUUIDPair queryText of
+        Just (a, p) -> findProcessId db a p
+        Nothing -> UUID.fromText queryText >>= findProcessIdByActivityUUID db
+
+{- | Delete a selection from a loaded database, in place under the same name.
+
+Resolves the filter to its full matching set, resolves the explicit
+keep/extra process-id strings, applies the adjustments, deletes + rebuilds
+with the manager's merged unit config, re-attaches runtime indexes with the
+merged synonym DB, swaps a fresh solver in, and updates the loaded / indexed
+registry maps. Returns the number of activities removed. Fails (Left) when the
+database is not loaded, a keep/extra id is unknown, or the rebuild reports an
+inconsistency.
+-}
+deleteActivitiesInDB ::
+    DatabaseManager ->
+    Text -> -- database name
+    Maybe Text -> -- filter: name
+    Maybe Text -> -- filter: location
+    Maybe Text -> -- filter: product
+    [(Text, Text, Bool)] -> -- filter: classification
+    Bool -> -- exact name match
+    [Text] -> -- explicit keep (process-id strings)
+    [Text] -> -- explicit extra (process-id strings)
+    IO (Either Text Int)
+deleteActivitiesInDB manager dbName nameP geoP prodP classFilters exactMatch keep extra =
+    getDatabase manager dbName >>= \case
+        Nothing -> pure $ Left $ "Database not loaded: " <> dbName
+        Just loaded -> do
+            let db = ldDatabase loaded
+            case (,) <$> traverse (resolvePid db) keep <*> traverse (resolvePid db) extra of
+                Left err -> pure $ Left err
+                Right (keepPids, extraPids) -> do
+                    let filtered = filteredProcessIds db nameP geoP prodP classFilters exactMatch
+                        toDelete =
+                            resolveDeleteSelection
+                                DeleteSelection{dsFiltered = filtered, dsKeep = keepPids, dsExtra = extraPids}
+                    unitConfig <- getMergedUnitConfig manager
+                    case deleteActivitiesWith unitConfig toDelete db of
+                        Left err -> pure $ Left err
+                        Right rebuilt -> do
+                            synonymDB <- getMergedSynonymDB manager
+                            let withRuntime = BM25.addBM25Index (initializeRuntimeFields rebuilt synonymDB)
+                                techTriplesInt =
+                                    [ (fromIntegral i, fromIntegral j, v)
+                                    | SparseTriple i j v <- U.toList (dbTechnosphereTriples withRuntime)
+                                    ]
+                            solver <-
+                                createSharedSolver
+                                    dbName
+                                    techTriplesInt
+                                    (fromIntegral (dbActivityCount withRuntime))
+                            let loaded' = loaded{ldDatabase = withRuntime, ldSharedSolver = solver}
+                                indexedDb = buildIndexedDatabaseFromDB dbName synonymDB withRuntime
+                            atomically $ do
+                                modifyTVar' (dmLoadedDbs manager) (M.insert dbName loaded')
+                                modifyTVar' (dmIndexedDbs manager) (M.insert dbName indexedDb)
+                            clearMethodMappingCacheForDb manager dbName
+                            pure $ Right (length toDelete)

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -76,6 +76,7 @@ import Database.MatrixBuild (
     buildTechTriples,
     collectBioFlowOrder,
  )
+import Matrix (clearCachedSolver)
 import qualified Search.BM25 as BM25
 import SharedSolver (createSharedSolver)
 import Types (
@@ -295,6 +296,10 @@ rebuildFromActivities unitConfig db activityMap =
                         , -- Cross-DB links may now reference deleted activities; clear so a
                           -- subsequent relink rebuilds them against the surviving set.
                           dbCrossDBLinks = []
+                        , -- Linking stats describe the pre-delete set (input count, completeness,
+                          -- missing suppliers); reset to the fresh-load default so the setup/status
+                          -- endpoint never reports stale numbers until the next relink.
+                          dbLinkingStats = mempty
                         , -- Runtime-only indexes are reset; re-attached by the effectful caller.
                           dbSynonymDB = Nothing
                         , dbFlowsByName = M.empty
@@ -412,6 +417,12 @@ deleteActivitiesInDB manager dbName nameP geoP prodP classFilters exactMatch kee
                                     [ (fromIntegral i, fromIntegral j, v)
                                     | SparseTriple i j v <- U.toList (dbTechnosphereTriples withRuntime)
                                     ]
+                            -- The MUMPS solver cached under this name is now stale (old
+                            -- dimensions/factorization); drain + destroy it as unload/remove do,
+                            -- before installing the rebuilt one — otherwise the first post-delete
+                            -- solve overwrites the map entry and leaks a worker thread + native
+                            -- instance.
+                            clearCachedSolver dbName
                             solver <-
                                 createSharedSolver
                                     dbName

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -60,6 +60,7 @@ import Database (
     findActivitiesByFields,
  )
 import Database.CrossLinking (buildIndexedDatabaseFromDB)
+import Database.Loader (invalidateMatrixCache)
 import Database.Manager (
     DatabaseManager (..),
     LoadedDatabase (..),
@@ -434,4 +435,9 @@ deleteActivitiesInDB manager dbName nameP geoP prodP classFilters exactMatch kee
                                 modifyTVar' (dmLoadedDbs manager) (M.insert dbName loaded')
                                 modifyTVar' (dmIndexedDbs manager) (M.insert dbName indexedDb)
                             clearMethodMappingCacheForDb manager dbName
+                            -- The live matrices were rebuilt above, but the on-disk
+                            -- matrix cache still reflects the pre-delete activity set.
+                            -- Drop it so a later unload/reload can't resurrect the
+                            -- deleted activities from a stale cache.
+                            invalidateMatrixCache dbName (dcPath (ldConfig loaded))
                             pure $ Right (length toDelete)

--- a/src/Database/Export.hs
+++ b/src/Database/Export.hs
@@ -37,13 +37,15 @@ writer.
 -}
 serializeDatabase :: DatabaseFormat -> Database -> Either Text BL.ByteString
 serializeDatabase fmt db = case fmt of
-    SimaProCSV ->
+    SimaProCSV -> do
+        SP.checkSimaProExportable sdb
         Right (BL.fromStrict (SP.serializeSimaProCSV SP.defaultWriterConfig sdb))
     EcoSpold1 ->
         Right (BL.fromStrict (TE.encodeUtf8 (ES1.writeDatabase ES1.canonicalWriterOptions db)))
     EcoSpold2 ->
         Right (zipText (ES2.writeEcoSpold2 ES2.noVolatileMeta sdb))
-    ILCDProcess ->
+    ILCDProcess -> do
+        ILCD.checkILCDExportable sdb
         Right (ILCD.writeILCDArchive ILCD.defaultWriteOptions sdb)
     BrightwayExcel ->
         Right (BE.renderWorkbook BE.defaultWriterConfig sdb)

--- a/src/Database/Export.hs
+++ b/src/Database/Export.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Format dispatch for database export.
+
+Inverts the upload/parse path: given an in-memory 'Database', serialize it to
+bytes in one of the supported formats by delegating to the per-format writer.
+
+Single-file formats (SimaPro CSV, EcoSpold 1, Brightway Excel) serialize to one
+byte stream. Multi-file formats (EcoSpold 2, ILCD) are inherently directory
+trees, so they are packaged into a deterministic zip archive. 'OpenLcaJsonLd'
+has no writer and 'UnknownFormat' is not a real target, so both fail loudly
+('Left') rather than emit a silent empty file.
+-}
+module Database.Export (
+    serializeDatabase,
+    exportDatabase,
+) where
+
+import qualified Codec.Archive.Zip as Zip
+import Control.Exception (SomeException, try)
+import qualified Data.ByteString.Lazy as BL
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+
+import qualified BrightwayExcel.Writer as BE
+import Database.Upload (DatabaseFormat (..))
+import qualified EcoSpold.Writer1 as ES1
+import qualified EcoSpold.Writer2 as ES2
+import qualified ILCD.Writer as ILCD
+import qualified SimaPro.Writer as SP
+import Types (Database, toSimpleDatabase)
+
+{- | Serialize a database to a single byte stream in the requested format. Pure:
+the multi-file formats are zipped in-memory. Fails loudly for formats without a
+writer.
+-}
+serializeDatabase :: DatabaseFormat -> Database -> Either Text BL.ByteString
+serializeDatabase fmt db = case fmt of
+    SimaProCSV ->
+        Right (BL.fromStrict (SP.serializeSimaProCSV SP.defaultWriterConfig sdb))
+    EcoSpold1 ->
+        Right (BL.fromStrict (TE.encodeUtf8 (ES1.writeDatabase ES1.canonicalWriterOptions db)))
+    EcoSpold2 ->
+        Right (zipText (ES2.writeEcoSpold2 ES2.noVolatileMeta sdb))
+    ILCDProcess ->
+        Right (ILCD.writeILCDArchive ILCD.defaultWriteOptions sdb)
+    BrightwayExcel ->
+        Right (BE.renderWorkbook BE.defaultWriterConfig sdb)
+    OpenLcaJsonLd ->
+        Left "openLCA JSON-LD export is not supported"
+    UnknownFormat ->
+        Left "cannot export to an unknown format"
+  where
+    sdb = toSimpleDatabase db
+
+-- | Serialize a database and write it to @path@.
+exportDatabase :: DatabaseFormat -> Database -> FilePath -> IO (Either Text ())
+exportDatabase fmt db path = case serializeDatabase fmt db of
+    Left err -> pure (Left err)
+    Right bytes -> either (Left . renderErr) Right <$> try (BL.writeFile path bytes)
+  where
+    renderErr :: SomeException -> Text
+    renderErr e = "export failed: " <> T.pack (show e)
+
+-- | Pack @(path, text)@ entries into a deterministic zip (epoch-0 mtimes).
+zipText :: [(FilePath, Text)] -> BL.ByteString
+zipText = Zip.fromArchive . foldl addOne Zip.emptyArchive
+  where
+    addOne arc (p, t) =
+        Zip.addEntryToArchive
+            (Zip.toEntry p 0 (BL.fromStrict (TE.encodeUtf8 t)))
+            arc

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -38,6 +38,7 @@ module Database.Loader (
     -- * Cache Operations
     loadCachedDatabaseWithMatrices,
     saveCachedDatabaseWithMatrices,
+    invalidateMatrixCache,
     loadDatabaseFromCacheFile,
     generateMatrixCacheFilename,
 
@@ -898,6 +899,25 @@ generateMatrixCacheFilename dbName sourcePath = do
         cacheDir = takeDirectory sourcePath
     createDirectoryIfMissing True cacheDir
     return $ cacheDir </> cacheFilename
+
+{- |
+Invalidate (remove) the on-disk matrix cache for a database.
+
+In-memory edits that change the activity set — notably 'deleteActivitiesInDB'
+— rebuild the live matrices but leave the @.zst@ matrix cache untouched. A
+later unload/reload would then resurrect the pre-edit activity set from the
+stale cache. Removing the cache here forces the next load to rebuild from
+source (or from a freshly-written cache), keeping disk and memory in agreement.
+No-op when no cache file is present.
+-}
+invalidateMatrixCache :: T.Text -> FilePath -> IO ()
+invalidateMatrixCache dbName sourcePath = do
+    cacheFile <- generateMatrixCacheFilename dbName sourcePath
+    mapM_ removeIfExists [cacheFile, cacheFile ++ ".zst"]
+  where
+    removeIfExists f = do
+        exists <- doesFileExist f
+        when exists $ removeFile f
 
 {- |
 Validate cache file integrity before attempting to decode.

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -215,9 +215,12 @@ getReferenceProductUUID act =
 type SupplierIndex = M.Map (T.Text, T.Text) (UUID.UUID, UUID.UUID)
 
 {- | Type alias for name-only supplier lookup (for SimaPro)
-Maps normalizedProductName → (activityUUID, productUUID)
+Maps normalizedProductName → (activityUUID, productUUID, referenceProductUnit).
+The reference-product unit lets the linker reject a candidate whose unit is
+dimensionally incompatible with the consumer exchange (which the matrix builder
+could not convert), instead of forming a link that aborts the whole load.
 -}
-type NameOnlyIndex = M.Map T.Text (UUID.UUID, UUID.UUID)
+type NameOnlyIndex = M.Map T.Text (UUID.UUID, UUID.UUID, T.Text)
 
 {- | Type alias for name-only supplier lookup with location (for EcoSpold1)
 Maps normalizedProductName → (activityUUID, productUUID, location)
@@ -312,10 +315,10 @@ buildSupplierIndex activities techFlowDb =
 Uses the normalized product name + extracted prefixes (no location required).
 Exact names take priority via M.union.
 -}
-buildSupplierIndexByName :: ActivityMap -> TechFlowDB -> NameOnlyIndex
-buildSupplierIndexByName activities techFlowDb =
+buildSupplierIndexByName :: UnitDB -> ActivityMap -> TechFlowDB -> NameOnlyIndex
+buildSupplierIndexByName unitDB activities techFlowDb =
     let entries =
-            [ (tfName flow, (actUUID, prodUUID))
+            [ (tfName flow, (actUUID, prodUUID, getUnitNameForExchange unitDB ex))
             | ((actUUID, prodUUID), act) <- M.toList activities
             , ex <- exchanges act
             , exchangeIsReference ex
@@ -534,7 +537,7 @@ loadSimaProCSV unitConfig csvPath = do
             let simpleDb = SimpleDatabase procMap techFlowDB bioFlowDB wasteFlowDB unitDB
 
             -- Fix activity links using supplier lookup (same as EcoSpold1)
-            Right <$> fixSimaProActivityLinks simpleDb
+            Right <$> fixSimaProActivityLinks unitConfig simpleDb
 
 {- | Load a Brightway Excel (.xlsx) inventory.
 
@@ -558,18 +561,18 @@ loadBrightwayExcel unitConfig xlsxPath = do
                             | act <- activities
                             ]
                     simpleDb = SimpleDatabase procMap techFlowDB bioFlowDB wasteFlowDB unitDB
-                Right <$> fixSimaProActivityLinks simpleDb
+                Right <$> fixSimaProActivityLinks unitConfig simpleDb
 
 {- | Fix SimaPro activity links by resolving supplier references
 Uses name-only matching (no location required) for SimaPro technosphere inputs
 -}
-fixSimaProActivityLinks :: SimpleDatabase -> IO SimpleDatabase
-fixSimaProActivityLinks db = do
-    let nameIndex = buildSupplierIndexByName (sdbActivities db) (sdbTechFlows db)
+fixSimaProActivityLinks :: UC.UnitConfig -> SimpleDatabase -> IO SimpleDatabase
+fixSimaProActivityLinks unitConfig db = do
+    let nameIndex = buildSupplierIndexByName (sdbUnits db) (sdbActivities db) (sdbTechFlows db)
     reportProgress Info $ printf "Built name-only supplier index with %d entries for SimaPro linking" (M.size nameIndex)
 
     -- Count and report statistics
-    let (fixedActivities, summary) = fixAllActivitiesByName nameIndex (sdbTechFlows db) (sdbActivities db)
+    let (fixedActivities, summary) = fixAllActivitiesByName unitConfig (sdbUnits db) nameIndex (sdbTechFlows db) (sdbActivities db)
 
     reportProgress Info $
         printf
@@ -585,39 +588,66 @@ fixSimaProActivityLinks db = do
     return $ db{sdbActivities = fixedActivities}
 
 -- | Fix all activities using name-only matching
-fixAllActivitiesByName :: NameOnlyIndex -> TechFlowDB -> ActivityMap -> (ActivityMap, UnlinkedSummary)
-fixAllActivitiesByName idx techFlowDb activities =
-    let results = M.map (fixActivityExchangesByName idx techFlowDb) activities
+fixAllActivitiesByName :: UC.UnitConfig -> UnitDB -> NameOnlyIndex -> TechFlowDB -> ActivityMap -> (ActivityMap, UnlinkedSummary)
+fixAllActivitiesByName unitConfig unitDB idx techFlowDb activities =
+    let results = M.map (fixActivityExchangesByName unitConfig unitDB idx techFlowDb) activities
         summaries = map snd $ M.elems results
         combinedSummary = mconcat summaries
         fixedActivities = M.map fst results
      in (fixedActivities, combinedSummary)
 
 -- | Fix activity exchanges using name-only matching
-fixActivityExchangesByName :: NameOnlyIndex -> TechFlowDB -> Activity -> (Activity, UnlinkedSummary)
-fixActivityExchangesByName idx techFlowDb act =
-    let (fixedExchanges, summaries) = unzip $ map (fixExchangeLinkByName idx techFlowDb (activityName act)) (exchanges act)
+fixActivityExchangesByName :: UC.UnitConfig -> UnitDB -> NameOnlyIndex -> TechFlowDB -> Activity -> (Activity, UnlinkedSummary)
+fixActivityExchangesByName unitConfig unitDB idx techFlowDb act =
+    let (fixedExchanges, summaries) = unzip $ map (fixExchangeLinkByName unitConfig unitDB idx techFlowDb (activityName act)) (exchanges act)
         combinedSummary = mconcat summaries
      in (act{exchanges = fixedExchanges}, combinedSummary)
 
+{- | A name-based supplier link is admissible only when the matrix builder could
+later convert the consumer's exchange unit to the supplier's reference-product
+unit. This mirrors the builder's own rule exactly (see 'Database.MatrixBuild'):
+a conversion is needed only when the two units differ and both are non-empty,
+and it must then succeed. So a link is safe when the units are identical, when
+either side is empty, or when they are dimensionally compatible. Forming any
+other link would abort the whole load — better to leave the input unlinked.
+-}
+linkUnitsCompatible :: UC.UnitConfig -> T.Text -> T.Text -> Bool
+linkUnitsCompatible unitConfig consumerUnit supplierUnit =
+    let cu = T.toLower (T.strip consumerUnit)
+        su = T.toLower (T.strip supplierUnit)
+     in cu == su
+            || T.null cu
+            || T.null su
+            || UC.unitsCompatible unitConfig consumerUnit supplierUnit
+
 {- | Fix a single exchange's activity link using name-only matching.
 Inputs and non-reference outputs (coproducts / avoided-production credits)
-are eligible for relinking. Returns (fixed exchange, UnlinkedSummary).
+are eligible for relinking. A candidate is accepted only if its
+reference-product unit is dimensionally compatible with the consumer exchange
+('linkUnitsCompatible'); an incompatible candidate is skipped (falling through
+to the prefix fallback, then to unlinked) rather than forming a link the matrix
+builder cannot convert — which would otherwise abort the whole load. Returns
+(fixed exchange, UnlinkedSummary).
 -}
-fixExchangeLinkByName :: NameOnlyIndex -> TechFlowDB -> T.Text -> Exchange -> (Exchange, UnlinkedSummary)
-fixExchangeLinkByName idx techFlowDb consumerName ex@TechnosphereExchange{techFlowId = fid, techRole = role, techLocation = loc}
+fixExchangeLinkByName :: UC.UnitConfig -> UnitDB -> NameOnlyIndex -> TechFlowDB -> T.Text -> Exchange -> (Exchange, UnlinkedSummary)
+fixExchangeLinkByName unitConfig unitDB idx techFlowDb consumerName ex@TechnosphereExchange{techFlowId = fid, techRole = role, techLocation = loc}
     | role == Input || role == ReferenceInput || role == Coproduct =
         case M.lookup fid techFlowDb of
             Just flow ->
                 let key = normalizeText (tfName flow)
+                    consumerUnit = getUnitNameForExchange unitDB ex
                     relink actUUID prodUUID = ex{techFlowId = prodUUID, techActivityLinkId = actUUID}
-                 in case M.lookup key idx of
+                    -- Accept a candidate only when its reference unit can convert.
+                    accept (actUUID, prodUUID, supplierUnit)
+                        | linkUnitsCompatible unitConfig consumerUnit supplierUnit = Just (actUUID, prodUUID)
+                        | otherwise = Nothing
+                 in case M.lookup key idx >>= accept of
                         Just (actUUID, prodUUID) ->
                             (relink actUUID prodUUID, UnlinkedSummary M.empty 1 1 0)
                         Nothing ->
                             let prefixes = extractProductPrefixes (tfName flow)
                                 tryPrefix [] = Nothing
-                                tryPrefix (p : ps) = case M.lookup (normalizeText p) idx of
+                                tryPrefix (p : ps) = case M.lookup (normalizeText p) idx >>= accept of
                                     Just result -> Just result
                                     Nothing -> tryPrefix ps
                              in case tryPrefix prefixes of
@@ -631,9 +661,9 @@ fixExchangeLinkByName idx techFlowDb consumerName ex@TechnosphereExchange{techFl
                 -- Flow not in technosphere map — shouldn't happen but be safe
                 (ex, UnlinkedSummary M.empty 1 0 1)
     | otherwise = (ex, mempty) -- Reference products: nothing to relink
-fixExchangeLinkByName _ _ _ ex@BiosphereExchange{} = (ex, mempty)
+fixExchangeLinkByName _ _ _ _ _ ex@BiosphereExchange{} = (ex, mempty)
 -- Waste link resolution is deferred to the cross-DB linker path.
-fixExchangeLinkByName _ _ _ ex@WasteExchange{} = (ex, mempty)
+fixExchangeLinkByName _ _ _ _ _ ex@WasteExchange{} = (ex, mempty)
 
 -- | Load EcoSpold files from directory
 loadEcoSpoldDirectory :: M.Map T.Text T.Text -> FilePath -> IO (Either T.Text SimpleDatabase)

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -1215,6 +1215,7 @@ fixActivityLinksWithCrossDB indexedDbs synonymDB unitConfig locationHier policy 
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = if M.null locationHier then locationHierarchy else locationHier
                         , lcGeographyPolicy = policy
+                        , lcSupplierAliases = Nothing
                         }
 
             -- Process all activities to find cross-DB links

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -32,11 +32,13 @@ module Database.Manager (
     getDatabase,
     mkDepSolverLookup,
     listDatabases,
+    clearMethodMappingCacheForDb,
 
     -- * Load/Unload
     loadDatabase,
     unloadDatabase,
     relinkDatabase,
+    relinkDatabaseWithMapping,
     RelinkResult (..),
     addDatabase,
     removeDatabase,
@@ -1475,7 +1477,54 @@ even though we already know the answer. The save is skipped when the
 relink is a no-op (no change vs. the in-memory state).
 -}
 relinkDatabase :: DatabaseManager -> Text -> IO (Either Text RelinkResult)
-relinkDatabase manager dbName = do
+relinkDatabase manager dbName = relinkDatabaseWith manager dbName Nothing Nothing
+
+{- | Re-link a loaded DB against a single chosen dependency, applying a
+name→name supplier-alias map. Restricts candidate suppliers to @depDb@
+(which must be in the database's declared dependency set) and threads the
+aliases into the matcher so a consumer's input flow name that only matches a
+target supplier under the mapping still links. Same persistence/no-op
+semantics as 'relinkDatabase'. Errors (DB or dep not loaded, dep not a
+declared dependency) surface as 'Left'.
+-}
+relinkDatabaseWithMapping ::
+    DatabaseManager ->
+    -- | database to relink
+    Text ->
+    -- | dependency database to link against
+    Text ->
+    -- | consumer-flow-name → supplier-name aliases
+    M.Map Text Text ->
+    IO (Either Text RelinkResult)
+relinkDatabaseWithMapping manager dbName depDb aliases = do
+    loadedDbs <- readTVarIO (dmLoadedDbs manager)
+    case M.lookup dbName loadedDbs of
+        Nothing -> return $ Left $ "Database not loaded: " <> dbName
+        Just loaded
+            | depDb `notElem` dbDependsOn (ldDatabase loaded) ->
+                return $
+                    Left $
+                        "Not a declared dependency of "
+                            <> dbName
+                            <> ": "
+                            <> depDb
+                            <> " (add it first with add-dependency)"
+            | not (M.member depDb loadedDbs) ->
+                return $ Left $ "Dependency database not loaded: " <> depDb
+            | otherwise -> relinkDatabaseWith manager dbName (Just [depDb]) (Just aliases)
+
+{- | Shared relink core. @depOverride@ restricts the candidate dependency set
+to the given names (still intersected with the declared pin); 'Nothing' uses
+the full pin. @aliases@ feeds 'lcSupplierAliases'. The dependency set stored
+on the database ('dbDependsOn') is never mutated here.
+-}
+relinkDatabaseWith ::
+    DatabaseManager ->
+    Text ->
+    Maybe [Text] ->
+    Maybe (M.Map Text Text) ->
+    IO (Either Text RelinkResult)
+relinkDatabaseWith manager dbName depOverride aliases = do
     loadedDbs <- readTVarIO (dmLoadedDbs manager)
     case M.lookup dbName loadedDbs of
         Nothing -> return $ Left $ "Database not loaded: " <> dbName
@@ -1485,8 +1534,12 @@ relinkDatabase manager dbName = do
             -- dependency set ('dbDependsOn'), never the full set of loaded DBs.
             -- This keeps the user's explicit selection authoritative — relink
             -- recomputes links *within* the pin but never expands or shrinks it.
+            -- An optional 'depOverride' narrows further to a single chosen dep.
             let pinnedDeps = dbDependsOn (ldDatabase loaded)
-                otherIndexes = [idb | (n, idb) <- M.toList indexedDbs, n /= dbName, n `elem` pinnedDeps]
+                candidateDeps = case depOverride of
+                    Nothing -> pinnedDeps
+                    Just chosen -> filter (`elem` chosen) pinnedDeps
+                otherIndexes = [idb | (n, idb) <- M.toList indexedDbs, n /= dbName, n `elem` candidateDeps]
             synonymDB <- getMergedSynonymDB manager
             unitConfig <- getMergedUnitConfig manager
             let db = ldDatabase loaded
@@ -1506,6 +1559,7 @@ relinkDatabase manager dbName = do
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = M.map snd (dmGeographies manager)
                         , lcGeographyPolicy = dcGeographyPolicy (ldConfig loaded)
+                        , lcSupplierAliases = aliases
                         }
                 !totalInputs = Loader.countTotalTechInputs (toSimpleDatabase db)
                 rawStats =

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1480,12 +1480,13 @@ relinkDatabase :: DatabaseManager -> Text -> IO (Either Text RelinkResult)
 relinkDatabase manager dbName = relinkDatabaseWith manager dbName Nothing Nothing
 
 {- | Re-link a loaded DB against a single chosen dependency, applying a
-name→name supplier-alias map. Restricts candidate suppliers to @depDb@
-(which must be in the database's declared dependency set) and threads the
-aliases into the matcher so a consumer's input flow name that only matches a
-target supplier under the mapping still links. Same persistence/no-op
-semantics as 'relinkDatabase'. Errors (DB or dep not loaded, dep not a
-declared dependency) surface as 'Left'.
+name→name supplier-alias map. Restricts candidate suppliers to @depDb@ and
+threads the aliases into the matcher so a consumer's input flow name that only
+matches a target supplier under the mapping still links. If @depDb@ is loaded
+but not yet in the database's declared dependency set, it is pinned in-memory
+first — so an in-memory pipeline (copy → delete → relink) composes without
+restaging (which would unload the live database). Same persistence/no-op
+semantics as 'relinkDatabase'. Errors (DB or dep not loaded) surface as 'Left'.
 -}
 relinkDatabaseWithMapping ::
     DatabaseManager ->
@@ -1501,17 +1502,21 @@ relinkDatabaseWithMapping manager dbName depDb aliases = do
     case M.lookup dbName loadedDbs of
         Nothing -> return $ Left $ "Database not loaded: " <> dbName
         Just loaded
-            | depDb `notElem` dbDependsOn (ldDatabase loaded) ->
-                return $
-                    Left $
-                        "Not a declared dependency of "
-                            <> dbName
-                            <> ": "
-                            <> depDb
-                            <> " (add it first with add-dependency)"
             | not (M.member depDb loadedDbs) ->
-                return $ Left $ "Dependency database not loaded: " <> depDb
-            | otherwise -> relinkDatabaseWith manager dbName (Just [depDb]) (Just aliases)
+                return $ Left $ "Dependency database not loaded: " <> depDb <> " (load it first)"
+            | otherwise -> do
+                -- Declare the dependency in-memory if it isn't already pinned, so an
+                -- in-memory pipeline (copy → delete → relink) composes in one pass
+                -- without restaging — which would unload the live database. The new
+                -- pin is persisted by 'relinkDatabaseWith' when links change.
+                unless (depDb `elem` dbDependsOn (ldDatabase loaded)) $
+                    atomically $
+                        modifyTVar' (dmLoadedDbs manager) (M.adjust (addPinnedDep depDb) dbName)
+                relinkDatabaseWith manager dbName (Just [depDb]) (Just aliases)
+  where
+    addPinnedDep dep ld =
+        let db = ldDatabase ld
+         in ld{ldDatabase = db{dbDependsOn = dep : dbDependsOn db}}
 
 {- | Shared relink core. @depOverride@ restricts the candidate dependency set
 to the given names (still intersected with the declared pin); 'Nothing' uses

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1305,7 +1305,7 @@ loadDatabaseRawWithCrossDB dbName locationAliases sourcePath noCache synonymDB u
                 (activities, techFlowDB, bioFlowDB, wasteFlowDB, unitDB) <- SimaPro.parseSimaProCSV unitConfig csvFile
                 reportProgress Info $ "Building database from " <> show (length activities) <> " activities"
                 let simpleDb = SimpleDatabase (buildActivityMap activities) techFlowDB bioFlowDB wasteFlowDB unitDB
-                linkedDb <- Loader.fixSimaProActivityLinks simpleDb
+                linkedDb <- Loader.fixSimaProActivityLinks unitConfig simpleDb
                 dbResult <- buildDatabaseWithMatrices unitConfig (sdbActivities linkedDb) techFlowDB bioFlowDB (sdbWasteFlows linkedDb) unitDB
                 case dbResult of
                     Left err -> return $ Left err

--- a/src/Database/RelinkMapping.hs
+++ b/src/Database/RelinkMapping.hs
@@ -1,0 +1,161 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Relink-with-mapping: re-link an (unlinked) database to a chosen background
+dependency using a name→name alias mapping loaded from a CSV.
+
+Agribalyse carries Ecoinvent-named background inputs; the BAFU database names
+the same activities differently. A curated CSV maps the source (consumer)
+input-flow name to the target (BAFU) activity name, so the existing cross-DB
+matcher resolves the link even though the raw names differ.
+
+The CSV is header-based (cassava 'decodeByName'). Recognized columns:
+
+  * @source@ (or @source_name@ / @from@) — required: the consumer's input flow name
+  * @target@ (or @target_name@ / @to@)  — required: the supplier activity name
+  * @source_location@ / @target_location@ — optional, currently informational
+
+Only the (source → target) name pair drives linking; location is matched by
+the existing geography policy, not by this map. Unit-incompatible or
+consumed-nowhere outcomes are not silently dropped — they surface through the
+relink's 'CrossDBLinkingStats' (unresolved products carry a 'LinkBlocker') and
+through the returned 'RelinkResult'.
+-}
+module Database.RelinkMapping (
+    -- * CSV mapping
+    AliasRow (..),
+    parseAliasCSV,
+    buildAliasMap,
+    loadAliasMap,
+
+    -- * Relink entry
+    relinkWithMappingFile,
+) where
+
+import Control.Applicative ((<|>))
+import qualified Data.ByteString.Lazy as BL
+import Data.Csv (FromNamedRecord (..), (.:))
+import qualified Data.Csv as Csv
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Vector as V
+
+import Control.Exception (SomeException, try)
+import Database.Manager (DatabaseManager, RelinkResult, relinkDatabaseWithMapping)
+
+{- | One row of the alias mapping. Locations are parsed when present but are
+not (yet) used to disambiguate the link — the cross-DB matcher applies the
+database's geography policy independently.
+-}
+data AliasRow = AliasRow
+    { arSource :: !Text
+    , arTarget :: !Text
+    , arSourceLocation :: !(Maybe Text)
+    , arTargetLocation :: !(Maybe Text)
+    }
+    deriving (Show, Eq)
+
+{- | Header-tolerant decoding: accept the primary column name or any documented
+synonym. The two name columns are required; location columns are optional.
+-}
+instance FromNamedRecord AliasRow where
+    parseNamedRecord r =
+        AliasRow
+            <$> firstField r ["source", "source_name", "from"]
+            <*> firstField r ["target", "target_name", "to"]
+            <*> optField r ["source_location", "source_geo"]
+            <*> optField r ["target_location", "target_geo"]
+
+{- | Parse the first present column among @names@; fail if none is found.
+Each candidate is tried via cassava's '(.:)' (which fails on a missing key),
+falling through with '(<|>)'.
+-}
+firstField :: Csv.NamedRecord -> [Text] -> Csv.Parser Text
+firstField r names =
+    foldr (\nm acc -> (r .: enc nm) <|> acc) noColumn names
+  where
+    noColumn =
+        fail $
+            "missing required column (one of: "
+                <> T.unpack (T.intercalate ", " names)
+                <> ")"
+
+-- | Parse the first present column among @names@ as optional.
+optField :: Csv.NamedRecord -> [Text] -> Csv.Parser (Maybe Text)
+optField r names =
+    foldr (\nm acc -> (Just <$> r .: enc nm) <|> acc) (pure Nothing) names
+
+enc :: Text -> Csv.Name
+enc = Csv.toField
+
+{- | Parse alias rows from CSV bytes. Blank source/target rows are rejected
+(they would create a useless or ambiguous mapping).
+-}
+parseAliasCSV :: BL.ByteString -> Either Text [AliasRow]
+parseAliasCSV bytes =
+    case Csv.decodeByName bytes of
+        Left err -> Left $ "alias CSV parse error: " <> T.pack err
+        Right (_, rows) ->
+            let cleaned =
+                    [ row{arSource = src, arTarget = tgt}
+                    | row <- V.toList (rows :: V.Vector AliasRow)
+                    , let src = T.strip (arSource row)
+                    , let tgt = T.strip (arTarget row)
+                    , not (T.null src)
+                    , not (T.null tgt)
+                    ]
+             in Right cleaned
+
+{- | Build the source-name → target-name alias map. On a duplicate source name
+with conflicting targets, fail rather than silently pick one. Identical
+duplicates collapse harmlessly.
+-}
+buildAliasMap :: [AliasRow] -> Either Text (Map Text Text)
+buildAliasMap rows =
+    foldr step (Right M.empty) rows
+  where
+    step row acc = do
+        m <- acc
+        let src = arSource row
+            tgt = arTarget row
+        case M.lookup src m of
+            Just existing
+                | existing /= tgt ->
+                    Left $
+                        "conflicting alias for "
+                            <> src
+                            <> ": "
+                            <> existing
+                            <> " vs "
+                            <> tgt
+            _ -> Right (M.insert src tgt m)
+
+-- | Load and validate an alias map from a CSV file path.
+loadAliasMap :: FilePath -> IO (Either Text (Map Text Text))
+loadAliasMap path = do
+    result <- try (BL.readFile path) :: IO (Either SomeException BL.ByteString)
+    case result of
+        Left e -> pure $ Left $ "cannot read mapping file " <> T.pack path <> ": " <> T.pack (show e)
+        Right bytes -> pure (parseAliasCSV bytes >>= buildAliasMap)
+
+{- | Relink @dbName@ against @depDb@ using the alias mapping in @csvPath@.
+Loads + validates the CSV, then delegates to 'relinkDatabaseWithMapping'.
+Guardrails (unit-incompatible / consumed-nowhere) are not swallowed: they are
+reflected in the resulting 'RelinkResult' (unresolved counts) and the
+database's linking stats.
+-}
+relinkWithMappingFile ::
+    DatabaseManager ->
+    -- | database to relink
+    Text ->
+    -- | dependency database to link against
+    Text ->
+    -- | mapping CSV path
+    FilePath ->
+    IO (Either Text RelinkResult)
+relinkWithMappingFile manager dbName depDb csvPath = do
+    aliasResult <- loadAliasMap csvPath
+    case aliasResult of
+        Left err -> pure (Left err)
+        Right aliases -> relinkDatabaseWithMapping manager dbName depDb aliases

--- a/src/EcoSpold/Writer1.hs
+++ b/src/EcoSpold/Writer1.hs
@@ -58,7 +58,6 @@ import Data.List (sortOn)
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
-import Numeric (showFFloat)
 import Types
 
 -- ----------------------------------------------------------------------------
@@ -321,10 +320,13 @@ escapeXmlAttr =
 {- | Deterministic textual form for a @meanValue@. @show@ on a 'Double' is
 already round-trippable and stable across platforms, but renders whole
 numbers as @1.0@ (which the parser reads back identically), so it is the
-simplest canonical choice. Negative zero is normalised to @0.0@.
+simplest canonical choice. Negative zero is normalised to @0.0@, and the
+non-finite values (which cannot occur in a parsed database) are clamped to a
+parseable @0.0@ rather than the unreadable @"NaN"@/@"Infinity"@ — matching the
+EcoSpold2 / ILCD / SimaPro writers.
 -}
 formatAmount :: Double -> Text
 formatAmount x
+    | isNaN x || isInfinite x = "0.0"
     | x == 0 = "0.0"
-    | isNaN x || isInfinite x = T.pack (showFFloat Nothing x "")
     | otherwise = T.pack (show x)

--- a/src/EcoSpold/Writer1.hs
+++ b/src/EcoSpold/Writer1.hs
@@ -1,0 +1,330 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | EcoSpold1 export writer — the inverse of "EcoSpold.Parser1".
+
+Serializes a 'Database' / 'SimpleDatabase' back to the EcoSpold1 XML format
+(Ecoinvent 2.x, @http://www.EcoInvent.org/EcoSpold01@). The output is
+__canonical and deterministic__:
+
+  * activities are emitted in a stable order (sorted by @(activityName,
+    location)@), each in its own @\<dataset\>@ inside one @\<ecoSpold\>@;
+  * dataset numbers are assigned sequentially (1-based) in that order so a
+    re-parse regenerates the exact same flow UUIDs (the parser derives
+    flow UUIDs from @datasetNumber@, exchange number, name and category);
+  * exchange numbers are sequential (1-based) in exchange order;
+  * attributes appear in a fixed order, classification maps are sorted by
+    key, numbers use a fixed textual form, and there is no insignificant
+    whitespace beyond a single newline between top-level lines;
+  * volatile metadata (@generator@, @timestamp@) is pinned or omitted via
+    'WriterOptions' so a write→parse→write round-trip is byte-stable.
+
+The mapping mirrors 'EcoSpold.Parser1.buildExchange' exactly:
+
+  * 'ReferenceProduct' / 'ReferenceInput' → @\<outputGroup\>0\</outputGroup\>@
+  * 'Coproduct'                          → @\<outputGroup\>1\</outputGroup\>@
+  * technosphere 'Input'                 → @\<inputGroup\>5\</inputGroup\>@
+    (parser treats any non-empty inputGroup as a tech input)
+  * biosphere 'Resource'                 → @\<inputGroup\>4\</inputGroup\>@
+  * biosphere 'Emission'                 → @\<outputGroup\>4\</outputGroup\>@
+  * waste output (waIsInput=False)       → @\<outputGroup\>1\</outputGroup\>@,
+    category="Final waste flows"
+  * waste input  (waIsInput=True)        → @\<inputGroup\>5\</inputGroup\>@,
+    category="Final waste flows"
+
+Flow names, categories, CAS numbers and units are not stored on the
+'Exchange'; they live on the flow / unit tables and are resolved by UUID.
+A biosphere flow's @category@ / @subCategory@ come from its 'Compartment';
+technosphere flows carry no category (the parser only used it to seed the
+UUID), and waste flows always re-emit @category="Final waste flows"@ so the
+parser's waste-routing rule fires again.
+-}
+module EcoSpold.Writer1 (
+    -- * Options
+    WriterOptions (..),
+    defaultWriterOptions,
+    canonicalWriterOptions,
+
+    -- * Writers
+    writeDatabase,
+    writeSimpleDatabase,
+    writeActivities,
+
+    -- * Pure helpers (exported for testing)
+    escapeXmlAttr,
+    formatAmount,
+) where
+
+import Data.List (sortOn)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import Numeric (showFFloat)
+import Types
+
+-- ----------------------------------------------------------------------------
+-- Options
+-- ----------------------------------------------------------------------------
+
+{- | Knobs controlling the volatile, non-semantic parts of the output.
+Keeping these out of band lets a round-trip be byte-stable: write with
+'canonicalWriterOptions' (no @generator@/@timestamp@) and the second write
+reproduces the first exactly.
+-}
+data WriterOptions = WriterOptions
+    { woGenerator :: !(Maybe Text)
+    -- ^ Value of the @\<dataset generator=...\>@ attribute, or 'Nothing' to omit.
+    , woTimestamp :: !(Maybe Text)
+    -- ^ Value of the @\<dataset timestamp=...\>@ attribute, or 'Nothing' to omit.
+    }
+    deriving (Eq, Show)
+
+-- | Self-describing default: pins generator to "VoLCA", omits the timestamp.
+defaultWriterOptions :: WriterOptions
+defaultWriterOptions = WriterOptions (Just "VoLCA") Nothing
+
+{- | Fully canonical: omits both volatile attributes. Use this for stable
+round-trip / golden tests.
+-}
+canonicalWriterOptions :: WriterOptions
+canonicalWriterOptions = WriterOptions Nothing Nothing
+
+-- ----------------------------------------------------------------------------
+-- Top-level writers
+-- ----------------------------------------------------------------------------
+
+-- | Serialize a built 'Database' (via 'toSimpleDatabase').
+writeDatabase :: WriterOptions -> Database -> Text
+writeDatabase opts = writeSimpleDatabase opts . toSimpleDatabase
+
+-- | Serialize a 'SimpleDatabase'. Flow / unit names are resolved from its tables.
+writeSimpleDatabase :: WriterOptions -> SimpleDatabase -> Text
+writeSimpleDatabase opts sdb =
+    writeActivities
+        opts
+        (sdbTechFlows sdb)
+        (sdbBioFlows sdb)
+        (sdbWasteFlows sdb)
+        (sdbUnits sdb)
+        (M.elems (sdbActivities sdb))
+
+{- | Serialize a list of activities against the flow / unit tables that
+resolve their exchange UUIDs.
+-}
+writeActivities ::
+    WriterOptions ->
+    TechFlowDB ->
+    BioFlowDB ->
+    WasteFlowDB ->
+    UnitDB ->
+    [Activity] ->
+    Text
+writeActivities opts techs bios wastes units activities =
+    T.unlines $
+        [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold01\">"
+        ]
+            ++ concat (zipWith (datasetLines opts res) [1 ..] ordered)
+            ++ ["</ecoSpold>"]
+  where
+    res = Resolvers techs bios wastes units
+    -- Stable, content-derived order so dataset numbers (and thus flow UUIDs)
+    -- are reproducible regardless of the source Map's ordering.
+    ordered = sortOn (\a -> (activityName a, activityLocation a)) activities
+
+-- | Bundle of lookup tables threaded through the per-exchange renderers.
+data Resolvers = Resolvers
+    { rTech :: !TechFlowDB
+    , rBio :: !BioFlowDB
+    , rWaste :: !WasteFlowDB
+    , rUnits :: !UnitDB
+    }
+
+-- ----------------------------------------------------------------------------
+-- Per-dataset rendering
+-- ----------------------------------------------------------------------------
+
+-- | Render one @\<dataset\>@ block (already indented), as a list of lines.
+datasetLines :: WriterOptions -> Resolvers -> Int -> Activity -> [Text]
+datasetLines opts res num act =
+    [ indent 1 <> "<dataset" <> datasetAttrs opts num <> ">"
+    , indent 2 <> "<metaInformation>"
+    , indent 3 <> "<processInformation>"
+    , indent 4 <> "<referenceFunction" <> refFunctionAttrs act <> "/>"
+    , indent 4 <> "<geography location=" <> attr (activityLocation act) <> "/>"
+    , indent 3 <> "</processInformation>"
+    , indent 2 <> "</metaInformation>"
+    , indent 2 <> "<flowData>"
+    ]
+        ++ concat (zipWith (exchangeLines res) [1 ..] (exchanges act))
+        ++ [ indent 2 <> "</flowData>"
+           , indent 1 <> "</dataset>"
+           ]
+
+{- | @\<dataset\>@ attributes: @number@ always, then the volatile @generator@
+and @timestamp@ only when the options provide them.
+-}
+datasetAttrs :: WriterOptions -> Int -> Text
+datasetAttrs opts num =
+    " number="
+        <> attr (T.pack (show num))
+        <> maybe "" (\g -> " generator=" <> attr g) (woGenerator opts)
+        <> maybe "" (\t -> " timestamp=" <> attr t) (woTimestamp opts)
+
+{- | @\<referenceFunction\>@ attributes in a fixed order. @category@ /
+@subCategory@ come from 'activityClassification' (the parser's @Category@ /
+@SubCategory@ keys); a non-empty activity description is joined and emitted
+as @generalComment@.
+-}
+refFunctionAttrs :: Activity -> Text
+refFunctionAttrs act =
+    " name="
+        <> attr (activityName act)
+        <> optAttr "category" (classif "Category")
+        <> optAttr "subCategory" (classif "SubCategory")
+        <> " unit="
+        <> attr (activityUnit act)
+        <> optAttr "generalComment" generalComment
+  where
+    classif k = M.findWithDefault "" k (activityClassification act)
+    generalComment = T.intercalate "\n" (activityDescription act)
+
+-- ----------------------------------------------------------------------------
+-- Exchange rendering
+-- ----------------------------------------------------------------------------
+
+{- | Render one @\<exchange\>@ as opening tag + group element + closing tag.
+The group element (@inputGroup@ / @outputGroup@) is what the parser keys on
+to classify the exchange, so it is derived from the exchange variant +
+role/direction, never guessed.
+-}
+exchangeLines :: Resolvers -> Int -> Exchange -> [Text]
+exchangeLines res num ex =
+    [ indent 3 <> "<exchange" <> exchangeAttrs res num ex <> ">"
+    , indent 4 <> groupElement ex
+    , indent 3 <> "</exchange>"
+    ]
+
+{- | Common exchange attributes in fixed order: number, name, category,
+subCategory, location, unit, meanValue, then optional CAS / generalComment.
+Name and category are the inputs the parser hashes into the flow UUID, so
+they must be reproduced verbatim for a stable round-trip.
+-}
+exchangeAttrs :: Resolvers -> Int -> Exchange -> Text
+exchangeAttrs res num ex =
+    " number="
+        <> attr (T.pack (show num))
+        <> " name="
+        <> attr name
+        <> optAttr "category" category
+        <> optAttr "subCategory" subCategory
+        <> optAttr "location" (exchangeLocation ex)
+        <> " unit="
+        <> attr (unitNameFor (rUnits res) (exchangeUnitId ex))
+        <> " meanValue="
+        <> attr (formatAmount (exchangeAmount ex))
+        <> maybe "" (\c -> " CASNumber=" <> attr c) cas
+        <> maybe "" (\c -> " generalComment=" <> attr c) (exchangeComment ex)
+  where
+    FlowFields name category subCategory cas = flowFields res ex
+
+-- | The @\<inputGroup\>@ / @\<outputGroup\>@ element for an exchange.
+groupElement :: Exchange -> Text
+groupElement ex = case ex of
+    TechnosphereExchange{techRole = role} -> case role of
+        ReferenceProduct -> wrapOut "0"
+        ReferenceInput -> wrapOut "0"
+        Coproduct -> wrapOut "1"
+        Input -> wrapIn "5"
+    BiosphereExchange{bioDirection = dir} -> case dir of
+        Resource -> wrapIn "4"
+        Emission -> wrapOut "4"
+    WasteExchange{waIsInput = isInput} ->
+        if isInput then wrapIn "5" else wrapOut "1"
+  where
+    wrapIn g = "<inputGroup>" <> g <> "</inputGroup>"
+    wrapOut g = "<outputGroup>" <> g <> "</outputGroup>"
+
+-- ----------------------------------------------------------------------------
+-- Flow-field resolution (name / category / subCategory / CAS by UUID)
+-- ----------------------------------------------------------------------------
+
+{- | The four flow-derived attribute values the parser stored on a flow:
+name, category, subCategory, CAS. Positional — always consumed as a whole.
+-}
+data FlowFields = FlowFields !Text !Text !Text !(Maybe Text)
+
+{- | Resolve a flow's serialised fields from the matching table. A biosphere
+flow's compartment becomes category/subCategory; a waste flow always carries
+@category="Final waste flows"@ so the parser re-routes it to the waste
+bucket; a technosphere flow has no category. A UUID absent from its table
+yields empty/Nothing — never a crash.
+-}
+flowFields :: Resolvers -> Exchange -> FlowFields
+flowFields res ex = case ex of
+    TechnosphereExchange{techFlowId = fid} ->
+        case M.lookup fid (rTech res) of
+            Just tf -> FlowFields (tfName tf) "" "" (tfCAS tf)
+            Nothing -> FlowFields "" "" "" Nothing
+    BiosphereExchange{bioFlowId = fid} ->
+        case M.lookup fid (rBio res) of
+            Just bf ->
+                FlowFields
+                    (bfName bf)
+                    (bfCompartmentName bf)
+                    (maybe "" id (bfCompartmentSub bf))
+                    (bfCAS bf)
+            Nothing -> FlowFields "" "" "" Nothing
+    WasteExchange{waFlowId = fid} ->
+        case M.lookup fid (rWaste res) of
+            Just wf -> FlowFields (wfName wf) "Final waste flows" "" (wfCAS wf)
+            Nothing -> FlowFields "" "Final waste flows" "" Nothing
+
+{- | Resolve a unit UUID to its name. The parser stored both unit name and
+symbol as the source unit string, so the name field is the faithful echo.
+-}
+unitNameFor :: UnitDB -> UUID -> Text
+unitNameFor units uid = maybe "" unitName (M.lookup uid units)
+
+-- ----------------------------------------------------------------------------
+-- Canonical encoding helpers
+-- ----------------------------------------------------------------------------
+
+-- | Two-space indentation, @n@ levels deep.
+indent :: Int -> Text
+indent n = T.replicate (n * 2) " "
+
+-- | A double-quoted, XML-escaped attribute value.
+attr :: Text -> Text
+attr v = "\"" <> escapeXmlAttr v <> "\""
+
+-- | Emit @ name="value"@ only when the value is non-empty; otherwise nothing.
+optAttr :: Text -> Text -> Text
+optAttr name v
+    | T.null v = ""
+    | otherwise = " " <> name <> "=" <> attr v
+
+{- | Escape the five XML metacharacters plus the newline / carriage-return
+control characters, matching the entity set 'EcoSpold.Common.decodeXmlEntities'
+decodes on the way in. Order matters: @&@ is escaped first so we don't
+double-escape the entities we introduce.
+-}
+escapeXmlAttr :: Text -> Text
+escapeXmlAttr =
+    T.replace "\r" "&#13;"
+        . T.replace "\n" "&#10;"
+        . T.replace "'" "&apos;"
+        . T.replace "\"" "&quot;"
+        . T.replace ">" "&gt;"
+        . T.replace "<" "&lt;"
+        . T.replace "&" "&amp;"
+
+{- | Deterministic textual form for a @meanValue@. @show@ on a 'Double' is
+already round-trippable and stable across platforms, but renders whole
+numbers as @1.0@ (which the parser reads back identically), so it is the
+simplest canonical choice. Negative zero is normalised to @0.0@.
+-}
+formatAmount :: Double -> Text
+formatAmount x
+    | x == 0 = "0.0"
+    | isNaN x || isInfinite x = T.pack (showFFloat Nothing x "")
+    | otherwise = T.pack (show x)

--- a/src/EcoSpold/Writer2.hs
+++ b/src/EcoSpold/Writer2.hs
@@ -31,8 +31,10 @@ module EcoSpold.Writer2 (
     writeEcoSpold2,
     activityFileName,
     renderActivity,
+    sortExchanges,
 ) where
 
+import Data.List (sortOn)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.Text (Text)
@@ -208,15 +210,14 @@ forced first within the technosphere group so the canonical layout matches the
 ecospold convention of leading with the produced product.
 -}
 sortExchanges :: [Exchange] -> [Exchange]
-sortExchanges =
-    sortOnKey exchangeSortKey
-  where
-    sortOnKey f = map snd . M.toAscList . M.fromList . map (\e -> (f e, e))
+sortExchanges = sortOn exchangeSortKey
 
 {- | Sort key: (kindRank, not-reference, flowUUID). @not-reference@ sorts the
 reference product/input ahead of the others within a kind. The flow UUID is the
-stable tiebreaker. Distinct keys are guaranteed because no activity holds two
-exchanges of the same kind referencing the same flow.
+tiebreaker; 'sortOn' is stable, so two exchanges sharing a key keep their input
+order and are both emitted — never collapsed (a 'Map' keyed on this would have
+silently dropped a duplicate biosphere/technosphere line, undercounting the
+inventory).
 -}
 exchangeSortKey :: Exchange -> (Int, Bool, Text)
 exchangeSortKey ex = (kindRank, not (exchangeIsReference ex), UUID.toText (exchangeFlowId ex))

--- a/src/EcoSpold/Writer2.hs
+++ b/src/EcoSpold/Writer2.hs
@@ -1,0 +1,470 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Canonical, deterministic EcoSpold2 serializer — the inverse of
+'EcoSpold.Parser2'.
+
+Given a 'SimpleDatabase' (the natural writer input: activities keyed by
+@(activityUUID, productUUID)@ plus flow/unit registries), this produces one
+EcoSpold2 @.spold@ document per activity, named @{actUUID}_{prodUUID}.spold@
+exactly as the loader expects.
+
+Design goals (all pure, effect-free):
+
+  * __Canonical__: fixed attribute order, fixed namespaces, fixed two-space
+    indentation, no insignificant whitespace beyond the layout.
+  * __Deterministic__: every @Map@/@Set@-derived list is emitted in sorted
+    key order; doubles use one canonical renderer; output bytes are a pure
+    function of the input plus the explicit 'VolatileMeta'.
+  * __Round-trippable__: re-parsing the output reconstructs a structurally
+    equal 'Activity'/flow set, and volatile metadata (timestamps, generator)
+    is funnelled through 'VolatileMeta' so it can be pinned or omitted to make
+    byte-level idempotence testable.
+
+The only thing the writer cannot recover losslessly is information the parser
+discards (per-exchange @id@/@unitId@ attribute *strings*, production volumes,
+properties). Those are either omitted or synthesised from the stable UUIDs, so
+a parse→write→parse cycle is a fixed point.
+-}
+module EcoSpold.Writer2 (
+    VolatileMeta (..),
+    noVolatileMeta,
+    writeEcoSpold2,
+    activityFileName,
+    renderActivity,
+) where
+
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.UUID as UUID
+import Numeric (showFFloat)
+import Types
+
+{- | Volatile, non-semantic metadata that the parser ignores but a writer would
+otherwise stamp with the current time / tool version. Threaded explicitly so a
+caller can pin it (reproducible export) or omit it entirely (byte-stable
+round-trip). 'Nothing' fields emit no corresponding attribute/element.
+-}
+data VolatileMeta = VolatileMeta
+    { vmCreationTimestamp :: !(Maybe Text)
+    -- ^ @administrativeInformation/fileAttributes/@creationTimestamp@
+    , vmGenerator :: !(Maybe Text)
+    -- ^ free-text generator note emitted as an XML comment, or omitted
+    }
+    deriving (Eq, Show)
+
+-- | The reproducible default: omit every volatile field.
+noVolatileMeta :: VolatileMeta
+noVolatileMeta = VolatileMeta Nothing Nothing
+
+-- ============================================================================
+-- Public entry points
+-- ============================================================================
+
+{- | Serialize a whole 'SimpleDatabase' to a sorted list of
+@(filename, document)@ pairs, one per activity. Sorted by filename so the
+sequence itself is deterministic. Flow names and unit names are resolved from
+the registries because the parser stores them on exchanges, not centrally.
+-}
+writeEcoSpold2 :: VolatileMeta -> SimpleDatabase -> [(FilePath, Text)]
+writeEcoSpold2 meta sdb =
+    [ (activityFileName actUUID prodUUID, renderActivity meta env act)
+    | ((actUUID, prodUUID), act) <- M.toAscList (sdbActivities sdb)
+    ]
+  where
+    env =
+        ResolveEnv
+            { reTechName = \u -> tfName <$> M.lookup u techFlows
+            , reBioFlow = \u -> M.lookup u bioFlows
+            , reWasteName = \u -> wfName <$> M.lookup u wasteFlows
+            , reTechSyns = \u -> maybe M.empty tfSynonyms (M.lookup u techFlows)
+            , reBioSyns = \u -> maybe M.empty bfSynonyms (M.lookup u bioFlows)
+            , reWasteSyns = \u -> maybe M.empty wfSynonyms (M.lookup u wasteFlows)
+            , reUnitName = \u -> unitName <$> M.lookup u units
+            }
+    techFlows = sdbTechFlows sdb
+    bioFlows = sdbBioFlows sdb
+    wasteFlows = sdbWasteFlows sdb
+    units = sdbUnits sdb
+
+-- | Canonical filename for an activity: @{actUUID}_{prodUUID}.spold@.
+activityFileName :: UUID.UUID -> UUID.UUID -> FilePath
+activityFileName actUUID prodUUID =
+    T.unpack (UUID.toText actUUID <> "_" <> UUID.toText prodUUID <> ".spold")
+
+{- | Resolver for the registry-held data the parser writes onto exchanges.
+Passed in so 'renderActivity' stays a pure function of its inputs.
+-}
+data ResolveEnv = ResolveEnv
+    { reTechName :: UUID.UUID -> Maybe Text
+    , reBioFlow :: UUID.UUID -> Maybe BiosphereFlow
+    , reWasteName :: UUID.UUID -> Maybe Text
+    , reTechSyns :: UUID.UUID -> M.Map Text (S.Set Text)
+    , reBioSyns :: UUID.UUID -> M.Map Text (S.Set Text)
+    , reWasteSyns :: UUID.UUID -> M.Map Text (S.Set Text)
+    , reUnitName :: UUID.UUID -> Maybe Text
+    }
+
+-- ============================================================================
+-- Document rendering
+-- ============================================================================
+
+-- | Render one activity to a complete EcoSpold2 document.
+renderActivity :: VolatileMeta -> ResolveEnv -> Activity -> Text
+renderActivity meta env act =
+    T.unlines $
+        [ "<?xml version='1.0' encoding='UTF-8'?>"
+        , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold02\">"
+        ]
+            ++ generatorComment meta
+            ++ [ "  <activityDataset>"
+               , "    <activityDescription>"
+               ]
+            ++ renderActivityElem act
+            ++ renderGeneralComment (activityDescription act)
+            ++ renderGeography (activityLocation act)
+            ++ ["    </activityDescription>", "    <flowData>"]
+            ++ concatMap (renderExchange env) (sortExchanges (exchanges act))
+            ++ ["    </flowData>"]
+            ++ renderAdminInfo meta
+            ++ ["  </activityDataset>", "</ecoSpold>"]
+
+-- | Optional generator note as an XML comment (volatile, omitted by default).
+generatorComment :: VolatileMeta -> [Text]
+generatorComment meta = case vmGenerator meta of
+    Nothing -> []
+    Just g -> ["  <!-- generator: " <> escapeText g <> " -->"]
+
+{- | The @\<activity\>@ opening element. We do not have the source's raw
+@id@/@activityNameId@ strings on 'Activity' (the parser keeps UUIDs in the
+filename, not here), so we omit them: the parser derives identity from the
+filename, never from these attributes. activityType / specialActivityType are
+re-emitted from 'activityNativeType' when present.
+-}
+renderActivityElem :: Activity -> [Text]
+renderActivityElem act =
+    [ "      <activity" <> activityTypeAttrs (activityNativeType act) <> ">"
+    , "        <activityName xml:lang=\"en\">" <> escapeText (activityName act) <> "</activityName>"
+    , "      </activity>"
+    ]
+
+{- | Re-emit the ecospold2 @activityType@/@specialActivityType@ attributes from
+the captured native type. Only 'EcoSpoldActivityType' carries them; the SimaPro
+and ILCD variants have no ecospold2 representation, so we emit nothing (a
+faithful round-trip of an ES2-sourced database never hits those cases).
+-}
+activityTypeAttrs :: Maybe NativeActivityType -> Text
+activityTypeAttrs Nothing = ""
+activityTypeAttrs (Just nt) = case nt of
+    EcoSpoldActivityType code _ special _ ->
+        " activityType=\"" <> intText code <> "\"" <> specialAttr special
+    SimaProProcessType _ -> ""
+    ILCDProcessType _ -> ""
+  where
+    specialAttr Nothing = ""
+    specialAttr (Just s) = " specialActivityType=\"" <> intText s <> "\""
+
+{- | @\<generalComment\>@ with one @\<text index="n">@ per description
+paragraph, in the original order. Empty description emits nothing.
+-}
+renderGeneralComment :: [Text] -> [Text]
+renderGeneralComment [] = []
+renderGeneralComment paras =
+    ["      <generalComment>"]
+        ++ [ "        <text xml:lang=\"en\" index=\"" <> intText i <> "\">" <> escapeText p <> "</text>"
+           | (i, p) <- zip [0 :: Int ..] paras
+           ]
+        ++ ["      </generalComment>"]
+
+-- | @\<geography\>\<shortname\>@ holding the location code.
+renderGeography :: Text -> [Text]
+renderGeography loc =
+    [ "      <geography>"
+    , "        <shortname xml:lang=\"en\">" <> escapeText loc <> "</shortname>"
+    , "      </geography>"
+    ]
+
+{- | @administrativeInformation@ carrying only the (optional, volatile)
+creation timestamp. Omitted entirely when no timestamp is pinned, keeping the
+default output minimal and byte-stable.
+-}
+renderAdminInfo :: VolatileMeta -> [Text]
+renderAdminInfo meta = case vmCreationTimestamp meta of
+    Nothing -> []
+    Just ts ->
+        [ "    <administrativeInformation>"
+        , "      <fileAttributes defaultLanguage=\"en\" creationTimestamp=\"" <> escapeAttr ts <> "\"/>"
+        , "    </administrativeInformation>"
+        ]
+
+-- ============================================================================
+-- Exchange rendering
+-- ============================================================================
+
+{- | Deterministic exchange order: group by kind (technosphere, then waste,
+then biosphere), and within a kind sort by flow UUID. The reference product is
+forced first within the technosphere group so the canonical layout matches the
+ecospold convention of leading with the produced product.
+-}
+sortExchanges :: [Exchange] -> [Exchange]
+sortExchanges =
+    sortOnKey exchangeSortKey
+  where
+    sortOnKey f = map snd . M.toAscList . M.fromList . map (\e -> (f e, e))
+
+{- | Sort key: (kindRank, not-reference, flowUUID). @not-reference@ sorts the
+reference product/input ahead of the others within a kind. The flow UUID is the
+stable tiebreaker. Distinct keys are guaranteed because no activity holds two
+exchanges of the same kind referencing the same flow.
+-}
+exchangeSortKey :: Exchange -> (Int, Bool, Text)
+exchangeSortKey ex = (kindRank, not (exchangeIsReference ex), UUID.toText (exchangeFlowId ex))
+  where
+    kindRank = case ex of
+        TechnosphereExchange{} -> 0
+        WasteExchange{} -> 1
+        BiosphereExchange{} -> 2
+
+-- | Render a single exchange to its XML lines.
+renderExchange :: ResolveEnv -> Exchange -> [Text]
+renderExchange env ex = case ex of
+    TechnosphereExchange{} -> renderTechnosphere env ex
+    WasteExchange{} -> renderWaste env ex
+    BiosphereExchange{} -> renderBiosphere env ex
+
+{- | Technosphere exchange → @intermediateExchange@.
+
+Inverse of the parser's role logic:
+
+  * 'ReferenceProduct' → output, @\<outputGroup\>0\</outputGroup\>@
+  * 'Coproduct'        → output, @\<outputGroup\>2\</outputGroup\>@ (any
+    non-zero output group re-parses to 'Coproduct')
+  * 'Input' / 'ReferenceInput' → input, @\<inputGroup\>5\</inputGroup\>@
+-}
+renderTechnosphere :: ResolveEnv -> Exchange -> [Text]
+renderTechnosphere env ex =
+    intermediateExchange
+        (reTechName env flowId)
+        flowId
+        (techUnitId ex)
+        (techAmount ex)
+        (reUnitName env (techUnitId ex))
+        (reTechSyns env flowId)
+        groupLine
+        (techActivityLinkId ex)
+        Nothing
+        (techComment ex)
+  where
+    flowId = techFlowId ex
+    groupLine = case techRole ex of
+        ReferenceProduct -> outputGroupLine "0"
+        Coproduct -> outputGroupLine "2"
+        Input -> inputGroupLine "5"
+        ReferenceInput -> inputGroupLine "5"
+
+{- | Waste exchange → @intermediateExchange@ tagged with the
+@By-product classification = Waste@ classification (parser "Pattern B"). The
+@waIsInput@ flag picks input vs output group so direction round-trips. This
+re-parses to a 'WasteExchange', preserving the kind.
+-}
+renderWaste :: ResolveEnv -> Exchange -> [Text]
+renderWaste env ex =
+    intermediateExchange
+        (reWasteName env flowId)
+        flowId
+        (waUnitId ex)
+        (waAmount ex)
+        (reUnitName env (waUnitId ex))
+        (reWasteSyns env flowId)
+        groupLine
+        (waActivityLinkId ex)
+        (Just ("By-product classification", "Waste"))
+        (waComment ex)
+  where
+    flowId = waFlowId ex
+    groupLine = if waIsInput ex then inputGroupLine "5" else outputGroupLine "4"
+
+{- | Biosphere exchange → @elementaryExchange@. Direction maps to in/out group:
+'Resource' → @inputGroup@ 4, 'Emission' → @outputGroup@ 4. The compartment is
+taken from the registry's 'BiosphereFlow'.
+-}
+renderBiosphere :: ResolveEnv -> Exchange -> [Text]
+renderBiosphere env ex =
+    [openTag]
+        ++ nameLine 8 (reBioFlow env flowId >>= justName)
+        ++ unitNameLine 8 (reUnitName env (bioUnitId ex))
+        ++ compartmentBlock (reBioFlow env flowId >>= bfCompartment)
+        ++ [groupLine]
+        ++ synonymLines 8 (reBioSyns env flowId)
+        ++ commentLines 8 (bioComment ex)
+        ++ ["      </elementaryExchange>"]
+  where
+    flowId = bioFlowId ex
+    justName f = let n = bfName f in if T.null n then Nothing else Just n
+    openTag =
+        "      <elementaryExchange elementaryExchangeId=\""
+            <> escapeAttr (UUID.toText flowId)
+            <> "\" unitId=\""
+            <> escapeAttr (UUID.toText (bioUnitId ex))
+            <> "\" amount=\""
+            <> doubleAttr (bioAmount ex)
+            <> "\">"
+    groupLine = case bioDirection ex of
+        Resource -> "        <inputGroup>4</inputGroup>"
+        Emission -> "        <outputGroup>4</outputGroup>"
+
+{- | Shared @intermediateExchange@ emitter for technosphere and waste flows.
+The @activityLinkId@ is emitted only when non-nil (matching the parser, which
+treats nil/empty as "no link"). An optional @classification@ tags waste flows.
+-}
+intermediateExchange ::
+    Maybe Text -> -- resolved flow name
+    UUID.UUID -> -- flow id
+    UUID.UUID -> -- unit id
+    Double -> -- amount
+    Maybe Text -> -- resolved unit name
+    M.Map Text (S.Set Text) -> -- synonyms
+    Text -> -- the in/out group line (8-space indent)
+    UUID.UUID -> -- activity link id (nil = omit)
+    Maybe (Text, Text) -> -- optional (classificationSystem, classificationValue)
+    Maybe Text -> -- comment
+    [Text]
+intermediateExchange mName flowId unitUUID amount mUnit syns groupLine linkId mClass mComment =
+    [openTag]
+        ++ nameLine 8 mName
+        ++ unitNameLine 8 mUnit
+        ++ [groupLine]
+        ++ classificationBlock mClass
+        ++ synonymLines 8 syns
+        ++ commentLines 8 mComment
+        ++ ["      </intermediateExchange>"]
+  where
+    openTag =
+        "      <intermediateExchange intermediateExchangeId=\""
+            <> escapeAttr (UUID.toText flowId)
+            <> "\" unitId=\""
+            <> escapeAttr (UUID.toText unitUUID)
+            <> "\" amount=\""
+            <> doubleAttr amount
+            <> "\""
+            <> linkAttr
+            <> ">"
+    linkAttr
+        | linkId == UUID.nil = ""
+        | otherwise = " activityLinkId=\"" <> escapeAttr (UUID.toText linkId) <> "\""
+
+-- ============================================================================
+-- Small element emitters
+-- ============================================================================
+
+inputGroupLine :: Text -> Text
+inputGroupLine g = "        <inputGroup>" <> g <> "</inputGroup>"
+
+outputGroupLine :: Text -> Text
+outputGroupLine g = "        <outputGroup>" <> g <> "</outputGroup>"
+
+-- | @\<name\>@ line at the given indent, omitted when no name resolved.
+nameLine :: Int -> Maybe Text -> [Text]
+nameLine ind = maybe [] (\n -> [indent ind <> "<name xml:lang=\"en\">" <> escapeText n <> "</name>"])
+
+-- | @\<unitName\>@ line, omitted when no unit resolved.
+unitNameLine :: Int -> Maybe Text -> [Text]
+unitNameLine ind = maybe [] (\u -> [indent ind <> "<unitName xml:lang=\"en\">" <> escapeText u <> "</unitName>"])
+
+{- | @\<comment\>@ line for an exchange. The parser keeps only the English
+comment text, so we emit it verbatim under @xml:lang="en"@.
+-}
+commentLines :: Int -> Maybe Text -> [Text]
+commentLines ind = maybe [] (\c -> [indent ind <> "<comment xml:lang=\"en\">" <> escapeText c <> "</comment>"])
+
+{- | @\<synonym\>@ lines, one per synonym, sorted. The parser collapses all
+languages into the @"en"@ bucket and ignores the language, so we flatten and
+sort the unique synonym strings for a deterministic, round-trip-stable layout.
+-}
+synonymLines :: Int -> M.Map Text (S.Set Text) -> [Text]
+synonymLines ind syns =
+    [ indent ind <> "<synonym xml:lang=\"en\">" <> escapeText s <> "</synonym>"
+    | s <- S.toAscList (S.unions (M.elems syns))
+    , not (T.null s)
+    ]
+
+{- | The nested @\<compartment\>\<compartment\>\<subcompartment\>@ block the
+parser expects. Omitted when the flow carries no compartment.
+-}
+compartmentBlock :: Maybe Compartment -> [Text]
+compartmentBlock Nothing = []
+compartmentBlock (Just (Compartment name mSub)) =
+    ["        <compartment>", "          <compartment xml:lang=\"en\">" <> escapeText name <> "</compartment>"]
+        ++ subLine mSub
+        ++ ["        </compartment>"]
+  where
+    subLine = maybe [] (\s -> ["          <subcompartment xml:lang=\"en\">" <> escapeText s <> "</subcompartment>"])
+
+{- | @\<classification\>@ block tagging an exchange (used for waste). Emits the
+classificationSystem / classificationValue pair the parser reads.
+-}
+classificationBlock :: Maybe (Text, Text) -> [Text]
+classificationBlock Nothing = []
+classificationBlock (Just (system, value)) =
+    [ "        <classification>"
+    , "          <classificationSystem xml:lang=\"en\">" <> escapeText system <> "</classificationSystem>"
+    , "          <classificationValue xml:lang=\"en\">" <> escapeText value <> "</classificationValue>"
+    , "        </classification>"
+    ]
+
+-- ============================================================================
+-- Pure formatting helpers
+-- ============================================================================
+
+-- | @n@ spaces of indentation.
+indent :: Int -> Text
+indent n = T.replicate n " "
+
+intText :: Int -> Text
+intText = T.pack . show
+
+{- | Canonical 'Double' rendering for amounts. 'show' gives a stable,
+round-trippable decimal for finite values; the parser reads it back with
+'Data.Text.Read.double'. Non-finite values are clamped to a parseable @0.0@
+(they cannot occur in a parsed database, but we never emit @Infinity@/@NaN@
+which would break re-parsing).
+-}
+doubleAttr :: Double -> Text
+doubleAttr d
+    | isNaN d || isInfinite d = "0.0"
+    | otherwise = T.pack (showFFloatTrim d)
+
+{- | Fixed-notation double without an exponent, trailing-zero-trimmed but always
+keeping at least one fractional digit (so @1@ renders as @"1.0"@, matching the
+fixtures and staying unambiguous to the reader).
+-}
+showFFloatTrim :: Double -> String
+showFFloatTrim d =
+    let full = showFFloat Nothing d ""
+     in case break (== '.') full of
+            (intPart, '.' : fracPart) ->
+                let trimmed = reverse (dropWhile (== '0') (reverse fracPart))
+                 in intPart <> "." <> (if null trimmed then "0" else trimmed)
+            (intPart, _) -> intPart <> ".0"
+
+-- | Escape the five XML predefined entities for element text content.
+escapeText :: Text -> Text
+escapeText =
+    T.replace "&" "&amp;"
+        >>> T.replace "<" "&lt;"
+        >>> T.replace ">" "&gt;"
+  where
+    (>>>) f g = g . f
+
+{- | Escape for a double-quoted attribute value: the text escapes plus the
+double quote. The parser's 'decodeXmlEntities' reverses all of these.
+-}
+escapeAttr :: Text -> Text
+escapeAttr =
+    escapeText
+        >>> T.replace "\"" "&quot;"
+        >>> T.replace "\n" "&#10;"
+        >>> T.replace "\r" "&#13;"
+  where
+    (>>>) f g = g . f

--- a/src/ILCD/Writer.hs
+++ b/src/ILCD/Writer.hs
@@ -44,6 +44,7 @@ module ILCD.Writer (
     writeILCDDatabase,
     writeILCDArchive,
     ilcdFiles,
+    checkILCDExportable,
 
     -- * Pure helpers (exported for testing)
     escapeXml,
@@ -120,6 +121,36 @@ ilcdFiles opts db = sortOn fst (processes ++ flows ++ flowProps ++ unitGroups)
 
     -- Render the list of lines to canonical UTF-8 bytes.
     render = TE.encodeUtf8 . renderLines
+
+{- | Guard an ILCD export against multi-output activities. ILCD identifies a
+process by a single dataset UUID with one process per file, keyed here on the
+activity UUID alone. A multi-output activity — several @(actUUID, prodUUID)@
+entries sharing one @actUUID@ — would therefore write two processes to the same
+filename and the same @common:UUID@, and re-import could only keep one. Rather
+than silently dropping all but one product's process dataset, report the first
+offending activity so the caller can fail loudly. Single-output databases (every
+@actUUID@ unique) pass unchanged.
+-}
+checkILCDExportable :: SimpleDatabase -> Either Text ()
+checkILCDExportable db =
+    case M.toList collisions of
+        [] -> Right ()
+        ((actUUID, n) : _) ->
+            Left $
+                "ILCD export cannot represent multi-output activity \""
+                    <> nameOf actUUID
+                    <> "\" (UUID "
+                    <> uuidText actUUID
+                    <> "): "
+                    <> T.pack (show n)
+                    <> " reference products share one activity UUID, which ILCD keys a process by."
+  where
+    counts = M.fromListWith (+) [(actUUID, 1 :: Int) | (actUUID, _prodUUID) <- M.keys (sdbActivities db)]
+    collisions = M.filter (> 1) counts
+    nameOf actUUID =
+        case [activityName act | ((a, _), act) <- M.toList (sdbActivities db), a == actUUID] of
+            (nm : _) -> nm
+            [] -> "?"
 
 -- | Write the ILCD package as a directory tree rooted at @dir@.
 writeILCDDatabase :: WriteOptions -> FilePath -> SimpleDatabase -> IO ()

--- a/src/ILCD/Writer.hs
+++ b/src/ILCD/Writer.hs
@@ -1,0 +1,481 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{- | Serialize a VoLCA 'Database'/'SimpleDatabase' to an ILCD process-dataset
+package — the inverse of "ILCD.Parser".
+
+The output is a canonical, deterministic ILCD directory tree (and, optionally,
+a zip of it) with four subdirectories:
+
+@
+  processes/      one XML per activity (keyed by activity UUID)
+  flows/          one XML per tech/bio/waste flow
+  flowproperties/ one XML per unit group (1:1 with units)
+  unitgroups/     one XML per unit
+@
+
+Determinism is the contract:
+
+* every Map/Set-derived list is sorted by key before emission;
+* every 'Double' is formatted through one fixed formatter ('formatDouble');
+* the only volatile field an ILCD reader/writer round-trip could disagree on
+  — the export timestamp / generator string — is /omitted/ entirely unless a
+  caller passes one explicitly via 'WriteOptions'. We never inject @now@, so
+  @write (parse (write d)) == write d@ holds byte-for-byte.
+
+What round-trips: process UUID, name, location, classifications, processType,
+every exchange (flow ref, direction, amount, per-exchange comment), and the
+full flow + unit catalog (names, CAS, biosphere compartment, flow type, the
+flow→unit reference). These are exactly the fields "ILCD.Parser" reads back;
+fields the parser drops (activity description, synonyms, params, allocation,
+pedigree) are not representable in this ILCD profile and are not emitted.
+
+The flow→unit indirection mirrors the parser's resolution chain
+@flow → flowProperty → unitGroup@: we emit one flowProperty and one unitGroup
+per VoLCA unit, all sharing the unit's UUID, so the parser reconstructs the
+same unit key.
+-}
+module ILCD.Writer (
+    -- * Options
+    WriteOptions (..),
+    defaultWriteOptions,
+
+    -- * Writing
+    writeILCDDatabase,
+    writeILCDArchive,
+    ilcdFiles,
+
+    -- * Pure helpers (exported for testing)
+    escapeXml,
+    formatDouble,
+    processXML,
+    flowXML,
+    flowPropertyXML,
+    unitGroupXML,
+) where
+
+import Codec.Archive.Zip (addEntryToArchive, emptyArchive, fromArchive, toEntry)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BL
+import Data.List (sortOn)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified Data.UUID as UUID
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath ((</>))
+
+import Types
+
+--------------------------------------------------------------------------------
+-- Options
+--------------------------------------------------------------------------------
+
+{- | Knobs that pin or omit volatile metadata. Defaults omit everything
+volatile, so a write→parse→write round-trip is byte-stable.
+-}
+data WriteOptions = WriteOptions
+    { woTimestamp :: !(Maybe Text)
+    {- ^ Pinned export timestamp, emitted as @<common:timeStamp>@. 'Nothing'
+    omits the element entirely (the parser ignores it either way).
+    -}
+    , woGenerator :: !(Maybe Text)
+    -- ^ Pinned generator / tool-version string. 'Nothing' omits it.
+    }
+
+-- | Omit all volatile metadata. The right default for reproducible exports.
+defaultWriteOptions :: WriteOptions
+defaultWriteOptions = WriteOptions{woTimestamp = Nothing, woGenerator = Nothing}
+
+--------------------------------------------------------------------------------
+-- Top-level: directory / archive
+--------------------------------------------------------------------------------
+
+{- | Produce the full set of @(relativePath, contents)@ pairs for the ILCD
+package. Pure and deterministic. The result is sorted by path.
+-}
+ilcdFiles :: WriteOptions -> SimpleDatabase -> [(FilePath, BS.ByteString)]
+ilcdFiles opts db = sortOn fst (processes ++ flows ++ flowProps ++ unitGroups)
+  where
+    processes =
+        [ ("processes" </> uuidStr actUUID <> ".xml", render (processXML opts db key act))
+        | (key@(actUUID, _prodUUID), act) <- M.toAscList (sdbActivities db)
+        ]
+
+    flows =
+        [ ("flows" </> uuidStr (flowKindId fk) <> ".xml", render (flowXML fk unitRef))
+        | (fk, unitRef) <- allFlows db
+        ]
+
+    flowProps =
+        [ ("flowproperties" </> uuidStr uid <> ".xml", render (flowPropertyXML u))
+        | (uid, u) <- M.toAscList (sdbUnits db)
+        ]
+
+    unitGroups =
+        [ ("unitgroups" </> uuidStr uid <> ".xml", render (unitGroupXML u))
+        | (uid, u) <- M.toAscList (sdbUnits db)
+        ]
+
+    -- Render the list of lines to canonical UTF-8 bytes.
+    render = TE.encodeUtf8 . renderLines
+
+-- | Write the ILCD package as a directory tree rooted at @dir@.
+writeILCDDatabase :: WriteOptions -> FilePath -> SimpleDatabase -> IO ()
+writeILCDDatabase opts dir db = do
+    createDirectoryIfMissing True (dir </> "processes")
+    createDirectoryIfMissing True (dir </> "flows")
+    createDirectoryIfMissing True (dir </> "flowproperties")
+    createDirectoryIfMissing True (dir </> "unitgroups")
+    mapM_ (\(rel, bytes) -> BS.writeFile (dir </> rel) bytes) (ilcdFiles opts db)
+
+{- | Build a deterministic zip 'Archive' of the ILCD package and return its
+serialized bytes. Entry modification times are pinned to epoch 0 so the
+archive bytes are reproducible.
+-}
+writeILCDArchive :: WriteOptions -> SimpleDatabase -> BL.ByteString
+writeILCDArchive opts db = fromArchive (buildArchive (ilcdFiles opts db))
+  where
+    buildArchive = foldl addOne emptyArchive
+    -- Fixed epoch (0) keeps archive bytes stable across runs.
+    addOne arc (path, bytes) =
+        addEntryToArchive (toEntry path 0 (BL.fromStrict bytes)) arc
+
+--------------------------------------------------------------------------------
+-- Flow enumeration (tech ∪ bio ∪ waste), tagged with their unit id
+--------------------------------------------------------------------------------
+
+-- | All flows in the database as 'FlowKind' + unit id, sorted by flow UUID.
+allFlows :: SimpleDatabase -> [(FlowKind, UUID)]
+allFlows db =
+    sortOn (flowKindId . fst) $
+        [(TechKind f, tfUnitId f) | f <- M.elems (sdbTechFlows db)]
+            ++ [(BioKind f, bfUnitId f) | f <- M.elems (sdbBioFlows db)]
+            ++ [(WasteKind f, wfUnitId f) | f <- M.elems (sdbWasteFlows db)]
+
+--------------------------------------------------------------------------------
+-- Process XML
+--------------------------------------------------------------------------------
+
+{- | Render one ILCD process dataset for an activity. The reference exchange
+gets @dataSetInternalID@ matching @referenceToReferenceFlow@; remaining
+exchanges follow in their list order, so the parser reads them back in the
+same order it would re-serialize.
+-}
+processXML :: WriteOptions -> SimpleDatabase -> (UUID, UUID) -> Activity -> [Text]
+processXML opts _db (actUUID, _prodUUID) act =
+    [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    , "<processDataSet xmlns=\"http://lca.jrc.it/ILCD/Process\" xmlns:common=\"http://lca.jrc.it/ILCD/Common\">"
+    , "  <processInformation>"
+    , "    <dataSetInformation>"
+    , elem' "common:UUID" (uuidText actUUID)
+    , "      <name>"
+    , attrElem "baseName" [("xml:lang", "en")] (activityName act)
+    , "      </name>"
+    ]
+        ++ classificationBlock (activityClassification act)
+        ++ [ "    </dataSetInformation>"
+           , attrOnly "geography" [("location", activityLocation act)]
+           , "    <quantitativeReference>"
+           , elem' "referenceToReferenceFlow" (T.pack (show refIdx))
+           , "    </quantitativeReference>"
+           ]
+        ++ timeStampBlock opts
+        ++ [ "  </processInformation>"
+           ]
+        ++ processTypeBlock (activityNativeType act)
+        ++ generatorBlock opts
+        ++ ["  <exchanges>"]
+        ++ concatMap (uncurry exchangeXML) indexedExchanges
+        ++ [ "  </exchanges>"
+           , "</processDataSet>"
+           ]
+  where
+    -- Exchanges are emitted in list order; reference index is the position of
+    -- the (first) reference exchange, defaulting to 0 when none is marked.
+    indexedExchanges = zip [0 ..] (exchanges act)
+    refIdx :: Int
+    refIdx = case [i | (i, ex) <- indexedExchanges, exchangeIsReference ex] of
+        (i : _) -> i
+        [] -> 0
+
+-- | One @<exchange>@ block. @i@ is the @dataSetInternalID@.
+exchangeXML :: Int -> Exchange -> [Text]
+exchangeXML i ex =
+    [ "    <exchange dataSetInternalID=\"" <> T.pack (show i) <> "\">"
+    , attrOnly "referenceToFlowDataSet" [("refObjectId", uuidText (exchangeFlowId ex)), ("type", "flow data set")]
+    , elem' "exchangeDirection" direction
+    , elem' "resultingAmount" (formatDouble (exchangeAmount ex))
+    ]
+        ++ commentBlock (exchangeComment ex)
+        ++ ["    </exchange>"]
+  where
+    direction = if exchangeIsInput ex then "Input" else "Output"
+
+-- | Per-exchange comment, English-tagged to match the parser's preference.
+commentBlock :: Maybe Text -> [Text]
+commentBlock Nothing = []
+commentBlock (Just c) = [attrElem "common:generalComment" [("xml:lang", "en")] c]
+
+{- | Classification block. Each classification system becomes one
+@<common:classification name="...">@ with one @<common:class>@ per
+"/"-joined level, preserving the parser's join semantics. Systems are
+sorted by name for determinism.
+-}
+classificationBlock :: M.Map Text Text -> [Text]
+classificationBlock cls
+    | M.null cls = []
+    | otherwise =
+        ["      <classificationInformation>"]
+            ++ concatMap system (M.toAscList cls)
+            ++ ["      </classificationInformation>"]
+  where
+    system (name, value) =
+        [attrOnlyOpen "common:classification" [("name", name)]]
+            ++ [ attrElem "common:class" [("level", T.pack (show lvl))] part
+               | (lvl :: Int, part) <- zip [0 ..] (T.splitOn "/" value)
+               ]
+            ++ ["        </common:classification>"]
+
+{- | ILCD @<processType>@, nested where the parser expects it. Omitted unless
+the activity's native type is an ILCD process type.
+-}
+processTypeBlock :: Maybe NativeActivityType -> [Text]
+processTypeBlock nt = case nt of
+    Just (ILCDProcessType label)
+        | not (T.null label) ->
+            [ "  <modellingAndValidation>"
+            , "    <LCIMethodAndAllocation>"
+            , elem' "processType" label
+            , "    </LCIMethodAndAllocation>"
+            , "  </modellingAndValidation>"
+            ]
+    Just (ILCDProcessType _) -> []
+    Just (EcoSpoldActivityType{}) -> []
+    Just (SimaProProcessType{}) -> []
+    Nothing -> []
+
+-- | Optional pinned timestamp inside @<processInformation>@ (omitted by default).
+timeStampBlock :: WriteOptions -> [Text]
+timeStampBlock opts = case woTimestamp opts of
+    Nothing -> []
+    Just ts -> [elem' "common:timeStamp" ts]
+
+-- | Optional pinned generator string (omitted by default).
+generatorBlock :: WriteOptions -> [Text]
+generatorBlock opts = case woGenerator opts of
+    Nothing -> []
+    Just g ->
+        [ "  <administrativeInformation>"
+        , "    <dataGenerator>"
+        , elem' "common:referenceToDataGenerator" g
+        , "    </dataGenerator>"
+        , "  </administrativeInformation>"
+        ]
+
+--------------------------------------------------------------------------------
+-- Flow XML
+--------------------------------------------------------------------------------
+
+{- | Render one ILCD flow dataset. @typeOfDataSet@ is set so the parser's
+'classifyFlowType' re-buckets the flow into the same kind. Biosphere flows
+carry their compartment categories; CAS round-trips when present.
+-}
+flowXML :: FlowKind -> UUID -> [Text]
+flowXML fk unitRef =
+    [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    , "<flowDataSet xmlns=\"http://lca.jrc.it/ILCD/Flow\" xmlns:common=\"http://lca.jrc.it/ILCD/Common\">"
+    , "  <flowInformation>"
+    , "    <dataSetInformation>"
+    , elem' "common:UUID" (uuidText (flowKindId fk))
+    , "      <name>"
+    , attrElem "baseName" [("xml:lang", "en")] (flowKindName fk)
+    , "      </name>"
+    ]
+        ++ compartmentBlock (flowKindCompartment fk)
+        ++ casBlock (flowKindCAS fk)
+        ++ [ "    </dataSetInformation>"
+           , "    <quantitativeReference>"
+           , elem' "referenceToReferenceFlowProperty" "0"
+           , "    </quantitativeReference>"
+           , "  </flowInformation>"
+           , "  <modellingAndValidation>"
+           , "    <LCIMethod>"
+           , elem' "typeOfDataSet" (flowTypeText fk)
+           , "    </LCIMethod>"
+           , "  </modellingAndValidation>"
+           , "  <flowProperties>"
+           , "    <flowProperty dataSetInternalID=\"0\">"
+           , attrOnly "referenceToFlowPropertyDataSet" [("refObjectId", uuidText unitRef), ("type", "flow property data set")]
+           , elem' "meanValue" "1"
+           , "    </flowProperty>"
+           , "  </flowProperties>"
+           , "</flowDataSet>"
+           ]
+
+-- | CAS accessor across flow kinds (parser reads it for biosphere flows).
+flowKindCAS :: FlowKind -> Maybe Text
+flowKindCAS (TechKind f) = tfCAS f
+flowKindCAS (BioKind f) = bfCAS f
+flowKindCAS (WasteKind f) = wfCAS f
+
+-- | @typeOfDataSet@ string mirroring 'ILCD.Parser.classifyFlowType'.
+flowTypeText :: FlowKind -> Text
+flowTypeText (TechKind _) = "Product flow"
+flowTypeText (BioKind _) = "Elementary flow"
+flowTypeText (WasteKind _) = "Waste flow"
+
+casBlock :: Maybe Text -> [Text]
+casBlock Nothing = []
+casBlock (Just cas)
+    | T.null cas = []
+    | otherwise = [elem' "CASNumber" cas]
+
+{- | Emit the biosphere @elementaryFlowCategorization@. We reverse the parser's
+'parseCompartment': level 0 is "Emissions"/"Resources", level 1 names the
+medium, level 2 (when a sub-compartment exists) is "<medium-phrase>, <sub>".
+-}
+compartmentBlock :: Maybe Compartment -> [Text]
+compartmentBlock Nothing = []
+compartmentBlock (Just (Compartment medium sub)) =
+    [ "      <classificationInformation>"
+    , "        <common:elementaryFlowCategorization>"
+    , attrElem "common:category" [("level", "0")] level0
+    , attrElem "common:category" [("level", "1")] level1
+    ]
+        ++ level2
+        ++ [ "        </common:elementaryFlowCategorization>"
+           , "      </classificationInformation>"
+           ]
+  where
+    isResource = medium == "natural resource"
+    level0 = if isResource then "Resources" else "Emissions"
+    mediumWord = case medium of
+        "natural resource" -> "natural resource"
+        other -> other
+    level1
+        | isResource = "Resources"
+        | otherwise = "Emissions to " <> mediumWord
+    level2 = case sub of
+        Nothing -> []
+        Just s
+            | T.null s -> []
+            | isResource -> [attrElem "common:category" [("level", "2")] ("Resources " <> s)]
+            | otherwise -> [attrElem "common:category" [("level", "2")] ("Emissions to " <> mediumWord <> ", " <> s)]
+
+--------------------------------------------------------------------------------
+-- FlowProperty XML  (one per unit; shares the unit's UUID)
+--------------------------------------------------------------------------------
+
+flowPropertyXML :: Unit -> [Text]
+flowPropertyXML u =
+    [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    , "<flowPropertyDataSet xmlns=\"http://lca.jrc.it/ILCD/FlowProperty\" xmlns:common=\"http://lca.jrc.it/ILCD/Common\">"
+    , "  <flowPropertiesInformation>"
+    , "    <dataSetInformation>"
+    , elem' "common:UUID" (uuidText (unitId u))
+    , attrElem "common:name" [("xml:lang", "en")] (unitName u)
+    , "    </dataSetInformation>"
+    , "    <quantitativeReference>"
+    , attrOnly "referenceToReferenceUnitGroup" [("refObjectId", uuidText (unitId u)), ("type", "unit group data set")]
+    , "    </quantitativeReference>"
+    , "  </flowPropertiesInformation>"
+    , "</flowPropertyDataSet>"
+    ]
+
+--------------------------------------------------------------------------------
+-- UnitGroup XML  (one per unit; shares the unit's UUID; single reference unit)
+--------------------------------------------------------------------------------
+
+unitGroupXML :: Unit -> [Text]
+unitGroupXML u =
+    [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    , "<unitGroupDataSet xmlns=\"http://lca.jrc.it/ILCD/UnitGroup\" xmlns:common=\"http://lca.jrc.it/ILCD/Common\">"
+    , "  <unitGroupInformation>"
+    , "    <dataSetInformation>"
+    , elem' "common:UUID" (uuidText (unitId u))
+    , attrElem "common:name" [("xml:lang", "en")] (unitName u)
+    , "    </dataSetInformation>"
+    , "    <quantitativeReference>"
+    , elem' "referenceToReferenceUnit" "0"
+    , "    </quantitativeReference>"
+    , "  </unitGroupInformation>"
+    , "  <units>"
+    , "    <unit dataSetInternalID=\"0\">"
+    , elem' "name" (unitName u)
+    , elem' "meanValue" "1"
+    , "    </unit>"
+    , "  </units>"
+    , "</unitGroupDataSet>"
+    ]
+
+--------------------------------------------------------------------------------
+-- XML primitives
+--------------------------------------------------------------------------------
+
+-- | Join the rendered lines with newlines and a trailing newline.
+renderLines :: [Text] -> Text
+renderLines = (<> "\n") . T.intercalate "\n"
+{-# INLINE renderLines #-}
+
+-- | @<tag>escaped-text</tag>@ on one indented line.
+elem' :: Text -> Text -> Text
+elem' tag txt = "      <" <> tag <> ">" <> escapeXml txt <> "</" <> tag <> ">"
+
+-- | @<tag a=\"v\" ...>escaped</tag>@ on one indented line.
+attrElem :: Text -> [(Text, Text)] -> Text -> Text
+attrElem tag attrs txt =
+    "      <" <> tag <> attrsText attrs <> ">" <> escapeXml txt <> "</" <> tag <> ">"
+
+-- | Self-closing @<tag a=\"v\" .../>@.
+attrOnly :: Text -> [(Text, Text)] -> Text
+attrOnly tag attrs = "      <" <> tag <> attrsText attrs <> "/>"
+
+-- | Open-only @<tag a=\"v\" ...>@ (caller emits the close).
+attrOnlyOpen :: Text -> [(Text, Text)] -> Text
+attrOnlyOpen tag attrs = "        <" <> tag <> attrsText attrs <> ">"
+
+attrsText :: [(Text, Text)] -> Text
+attrsText = T.concat . map (\(k, v) -> " " <> k <> "=\"" <> escapeXmlAttr v <> "\"")
+
+{- | XML text-node escaping. Covers the five predefined entities. The parser
+(Xeno SAX) un-escapes these, so escaping here keeps the round-trip faithful
+for names/comments containing @&@, @<@, etc.
+-}
+escapeXml :: Text -> Text
+escapeXml =
+    T.replace ">" "&gt;"
+        . T.replace "<" "&lt;"
+        . T.replace "&" "&amp;"
+
+-- | Attribute-value escaping: text entities plus the quote characters.
+escapeXmlAttr :: Text -> Text
+escapeXmlAttr =
+    T.replace "'" "&apos;"
+        . T.replace "\"" "&quot;"
+        . escapeXml
+
+{- | Canonical 'Double' formatting. Integral values print without a trailing
+@.0@-noise beyond a single @.0@ is avoided by emitting whole numbers as
+integers (matching how the fixtures write @1@ for unit mean values), and
+fractional values use 'show', which is round-trippable through
+'Data.Text.Read.double' (the parser's reader). The two together make
+write→parse→write stable.
+-}
+formatDouble :: Double -> Text
+formatDouble x
+    | isNaN x = "0"
+    | isInfinite x = "0"
+    | x == fromIntegral (round x :: Integer) = T.pack (show (round x :: Integer))
+    | otherwise = T.pack (show x)
+
+--------------------------------------------------------------------------------
+-- UUID rendering
+--------------------------------------------------------------------------------
+
+uuidText :: UUID -> Text
+uuidText = UUID.toText
+
+uuidStr :: UUID -> FilePath
+uuidStr = UUID.toString

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -249,18 +249,22 @@ bioSection _ WasteExchange{} = Nothing
 data BioSec = SecRes | SecAir | SecWater | SecSoil
     deriving (Eq)
 
--- | Reference + coproduct output rows for the Products section.
-productLines :: TechFlowDB -> UnitDB -> Maybe Double -> Text -> [Exchange] -> [Text]
-productLines techDB units allocPct category exchs =
+{- | Output rows (@name;unit;amount;allocation;waste_type;category;comment@) for
+the technosphere outputs matching @keep@. Used for both the @Products@ section
+(references) and the @Avoided products@ section (coproducts) — the two are
+rendered identically but the parser routes them to different exchange roles, so
+they must be emitted under their own headers, never merged.
+-}
+productLines :: (Exchange -> Bool) -> TechFlowDB -> UnitDB -> Maybe Double -> Text -> [Exchange] -> [Text]
+productLines keep techDB units allocPct category exchs =
     let outputs =
             [ (flow, ex)
             | ex@TechnosphereExchange{} <- exchs
-            , exchangeIsReference ex || isCoproduct ex
+            , keep ex
             , Just flow <- [M.lookup (exchangeFlowId ex) techDB]
             ]
         alloc = formatAmount (fromMaybe 100 allocPct)
         mkRow (flow, TechnosphereExchange{..}) =
-            -- name;unit;amount;allocation;waste_type;category;comment
             row
                 [ tfName flow
                 , unitNameOf units techUnitId
@@ -273,9 +277,22 @@ productLines techDB units allocPct category exchs =
         mkRow (_, _) = ""
         sortKey (flow, ex) = (tfName flow, unitNameOf units (exchangeUnitId ex), exchangeAmount ex)
      in map mkRow (sortOn sortKey outputs)
-  where
-    isCoproduct TechnosphereExchange{techRole = Coproduct} = True
-    isCoproduct _ = False
+
+-- | A coproduct technosphere output (SimaPro @Avoided products@ section, which
+-- the parser reads back as a 'Coproduct' role).
+isCoproduct :: Exchange -> Bool
+isCoproduct ex = case ex of
+    TechnosphereExchange{techRole = Coproduct} -> True
+    TechnosphereExchange{} -> False
+    BiosphereExchange{} -> False
+    WasteExchange{} -> False
+
+{- | Prepend the @Avoided products@ header to coproduct rows, or emit nothing
+when there are none (an empty section would be noise the parser ignores).
+-}
+avoidedHeader :: [Text] -> [Text]
+avoidedHeader [] = []
+avoidedHeader rows = "Avoided products" : rows
 
 {- | Render one section: a header line followed by its sorted rows. Emits
 nothing when there are no rows, matching the parser (it tolerates absent
@@ -336,8 +353,11 @@ serializeActivity techDB bioDB wasteDB units Activity{..} =
             , meta "Geography" activityLocation
             , meta "Comment" comment
             , -- Products section is always present (an activity has a reference).
-              "Products" : productLines techDB units activityAllocationPercent category exchanges
+              -- Coproducts go to "Avoided products" so the parser reads them back
+              -- as coproducts, not as extra reference-product activities.
+              "Products" : productLines exchangeIsReference techDB units activityAllocationPercent category exchanges
             , [""]
+            , withBlank (avoidedHeader (productLines isCoproduct techDB units activityAllocationPercent category exchanges))
             , -- Inputs.
               withBlank (section "Materials/fuels" techRowText techLines)
             , withBlank (section "Resources" bioRowText (bioByName SecRes))

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -36,6 +36,7 @@ module SimaPro.Writer (
     defaultWriterConfig,
     writeSimaProCSV,
     serializeSimaProCSV,
+    checkSimaProExportable,
 
     -- * Pure helpers (exposed for testing)
     escapeField,
@@ -69,6 +70,40 @@ newtype WriterConfig = WriterConfig
 -- | Default config: a fixed, neutral version banner (no timestamp).
 defaultWriterConfig :: WriterConfig
 defaultWriterConfig = WriterConfig{wcVersion = "SimaPro 9.6.0.1"}
+
+-- ============================================================================
+-- Export guard
+-- ============================================================================
+
+{- | SimaPro CSV files emissions into air / water / soil sections only. An
+emission whose compartment medium is some other non-empty value has no faithful
+section, so report it rather than silently filing it under @Emissions to air@.
+An unspecified (empty) medium is allowed — it carries no medium to lose and
+follows SimaPro's air default. Resources are bucketed by direction, not medium,
+so they never offend. This is the export-boundary check; 'serializeSimaProCSV'
+itself stays pure and total.
+-}
+checkSimaProExportable :: SimpleDatabase -> Either Text ()
+checkSimaProExportable db =
+    case offenders of
+        [] -> Right ()
+        ((name, medium) : _) ->
+            Left $
+                "SimaPro export cannot represent emission \""
+                    <> name
+                    <> "\": compartment medium \""
+                    <> medium
+                    <> "\" is not one of air, water, soil."
+  where
+    offenders =
+        [ (bfName flow, bfCompartmentName flow)
+        | act <- M.elems (sdbActivities db)
+        , ex@BiosphereExchange{bioDirection = Emission} <- exchanges act
+        , Just flow <- [M.lookup (exchangeFlowId ex) (sdbBioFlows db)]
+        , let medium = T.toLower (bfCompartmentName flow)
+        , not (T.null medium)
+        , medium `notElem` ["air", "water", "soil"]
+        ]
 
 -- ============================================================================
 -- Constants
@@ -242,6 +277,9 @@ bioSection bioDB ex@BiosphereExchange{bioDirection = dir} =
                 "soil" -> Just SecSoil
                 "air" -> Just SecAir
                 "" -> Just SecAir
+                -- Any other medium has no faithful SimaPro section.
+                -- 'checkSimaProExportable' rejects it at the export boundary, so
+                -- this air fallback only ever fires for a direct (un-guarded) caller.
                 _ -> Just SecAir
 bioSection _ TechnosphereExchange{} = Nothing
 bioSection _ WasteExchange{} = Nothing

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -1,0 +1,387 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+{- | SimaPro CSV Writer for volca — the inverse of "SimaPro.Parser".
+
+Serializes an in-memory 'Database' / 'SimpleDatabase' back to a SimaPro CSV
+export. The output is /canonical/ and /deterministic/: given the same database
+(modulo a pinned header version) it always produces byte-identical bytes.
+
+Determinism is achieved by:
+
+  * sorting every activity by (name, location) and every section's rows by
+    (flow name, unit, signed amount), so 'Map'/'Set' iteration order never
+    leaks into the output;
+  * a single fixed numeric formatter ('formatAmount') that round-trips through
+    the parser's 'parseAmount' / 'Expr.normalizeExpr';
+  * pinning the only volatile header field — the SimaPro version banner — via
+    'WriterConfig'. No export timestamp or generator line is emitted, so a
+    write→parse→write cycle is stable.
+
+Encoding/layout mirrors the parser's expectations:
+
+  * semicolon-separated fields, CRLF line endings;
+  * dot decimal separator (matching @{Decimal separator: .}@);
+  * the @{SimaPro …}@ / @{CSV separator: Semicolon}@ / @{Decimal separator: .}@
+    header block;
+  * one @Process … End@ block per activity, with the metadata keys and section
+    headers the parser recognises.
+
+Field shapes are kept aligned with the parser's row parsers
+('parseProductRow', 'parseTechRow', 'parseBioRow') so a faithful round-trip is
+possible. CSV escaping reuses the same rule as 'Matrix.Export.escapeCsvField'.
+-}
+module SimaPro.Writer (
+    WriterConfig (..),
+    defaultWriterConfig,
+    writeSimaProCSV,
+    serializeSimaProCSV,
+
+    -- * Pure helpers (exposed for testing)
+    escapeField,
+    formatAmount,
+) where
+
+import qualified Data.ByteString as BS
+import Data.List (sortOn)
+import qualified Data.Map.Strict as M
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Types
+
+-- ============================================================================
+-- Configuration
+-- ============================================================================
+
+{- | Writer knobs. The only volatile field a SimaPro export normally carries is
+the version banner; pinning it here keeps a round-trip byte-stable. We
+deliberately omit the export-date / generator lines entirely (the parser
+ignores them anyway) so there is no timestamp to normalise away.
+-}
+newtype WriterConfig = WriterConfig
+    { wcVersion :: Text
+    -- ^ Value of the @{SimaPro …}@ banner line.
+    }
+    deriving (Eq, Show)
+
+-- | Default config: a fixed, neutral version banner (no timestamp).
+defaultWriterConfig :: WriterConfig
+defaultWriterConfig = WriterConfig{wcVersion = "SimaPro 9.6.0.1"}
+
+-- ============================================================================
+-- Constants
+-- ============================================================================
+
+-- | Field delimiter — semicolon, matching @{CSV separator: Semicolon}@.
+delim :: Text
+delim = ";"
+
+-- | Line terminator — SimaPro exports use Windows CRLF.
+crlf :: Text
+crlf = "\r\n"
+
+-- ============================================================================
+-- Numeric formatting
+-- ============================================================================
+
+{- | Canonical numeric formatter. Produces a dot-decimal literal that the
+parser's 'parseAmount' / 'Expr.normalizeExpr' read back to the same 'Double'.
+
+Integral values are written without a trailing @.0@ (e.g. @100@, not
+@100.0@) so allocation percentages match the parser's @"100"@ raw form;
+all other values use Haskell's 'show', which is dot-decimal and exact
+enough to round-trip a 'Double'.
+-}
+formatAmount :: Double -> Text
+formatAmount x
+    | isNaN x || isInfinite x = "0"
+    | x == fromIntegral (round x :: Integer) =
+        T.pack (show (round x :: Integer))
+    | otherwise = T.pack (show x)
+
+-- ============================================================================
+-- CSV escaping
+-- ============================================================================
+
+{- | Escape a field for semicolon-delimited CSV. Same rule as
+'Matrix.Export.escapeCsvField': quote only when the field contains the
+delimiter, a quote, or a newline, doubling embedded quotes.
+-}
+escapeField :: Text -> Text
+escapeField text
+    | T.any (\c -> c == ';' || c == '"' || c == '\n' || c == '\r') text =
+        "\"" <> T.replace "\"" "\"\"" text <> "\""
+    | otherwise = text
+
+-- | Join fields with the delimiter (each escaped).
+row :: [Text] -> Text
+row = T.intercalate delim . map escapeField
+
+-- ============================================================================
+-- Flow / unit name resolution
+-- ============================================================================
+
+{- | Resolve a unit UUID to its name via the unit DB, falling back to the empty
+string when absent (a missing unit is surfaced downstream by the matrix
+builder, not silently defaulted to a wrong unit here).
+-}
+unitNameOf :: UnitDB -> UUID -> Text
+unitNameOf units uid = maybe "" unitName (M.lookup uid units)
+
+-- ============================================================================
+-- Process block serialization
+-- ============================================================================
+
+{- | A single technosphere/biosphere/waste exchange projected to the
+(name, unit, compartment, amount, comment) tuple the writer needs, plus a
+sort key. Keeping this intermediate makes the per-section sorting and
+formatting uniform.
+-}
+data Line = Line
+    { lName :: !Text
+    , lCompartment :: !Text -- sub-compartment for bio rows; "" otherwise
+    , lUnit :: !Text
+    , lAmount :: !Double
+    , lComment :: !Text
+    }
+
+-- | Deterministic ordering key for a section's lines.
+lineKey :: Line -> (Text, Text, Text, Double)
+lineKey l = (lName l, lCompartment l, lUnit l, lAmount l)
+
+-- | Render the comment column, re-attaching a pedigree prefix when present.
+renderComment :: Maybe Pedigree -> Maybe Text -> Text
+renderComment ped cmt =
+    let pedTxt = maybe "" renderPedigree ped
+        cmtTxt = fromMaybe "" cmt
+     in case (pedTxt, cmtTxt) of
+            ("", c) -> c
+            (p, "") -> p <> ","
+            (p, c) -> p <> "," <> c
+
+-- | @(r,c,t,g,f)@ pedigree quintuple, matching 'parsePedigreePrefix'.
+renderPedigree :: Pedigree -> Text
+renderPedigree Pedigree{..} =
+    "("
+        <> T.intercalate
+            ","
+            (map (T.pack . show) [pedReliability, pedCompleteness, pedTemporal, pedGeographical, pedTechnological])
+        <> ")"
+
+{- | Build a 'Line' for a technosphere input exchange. Returns 'Nothing' for
+the reference/coproduct outputs (those go to the Products section) and for
+exchanges whose flow is unknown to the tech-flow DB.
+-}
+techInputLine :: TechFlowDB -> UnitDB -> Exchange -> Maybe Line
+techInputLine techDB units ex@TechnosphereExchange{..} =
+    if exchangeIsReference ex
+        then Nothing
+        else case M.lookup techFlowId techDB of
+            Nothing -> Nothing
+            Just flow ->
+                Just
+                    Line
+                        { lName = tfName flow
+                        , lCompartment = ""
+                        , lUnit = unitNameOf units techUnitId
+                        , lAmount = techAmount
+                        , lComment = renderComment techPedigree techComment
+                        }
+techInputLine _ _ BiosphereExchange{} = Nothing
+techInputLine _ _ WasteExchange{} = Nothing
+
+-- | Build a 'Line' for a biosphere exchange (resource or emission).
+bioLine :: BioFlowDB -> UnitDB -> Exchange -> Maybe Line
+bioLine bioDB units BiosphereExchange{..} =
+    case M.lookup bioFlowId bioDB of
+        Nothing -> Nothing
+        Just flow ->
+            Just
+                Line
+                    { lName = bfName flow
+                    , lCompartment = fromMaybe "" (bfCompartmentSub flow)
+                    , lUnit = unitNameOf units bioUnitId
+                    , lAmount = bioAmount
+                    , lComment = renderComment bioPedigree bioComment
+                    }
+bioLine _ _ TechnosphereExchange{} = Nothing
+bioLine _ _ WasteExchange{} = Nothing
+
+-- | Build a 'Line' for a waste exchange (Final waste flows section).
+wasteLine :: WasteFlowDB -> UnitDB -> Exchange -> Maybe Line
+wasteLine wasteDB units WasteExchange{..} =
+    case M.lookup waFlowId wasteDB of
+        Nothing -> Nothing
+        Just flow ->
+            Just
+                Line
+                    { lName = wfName flow
+                    , lCompartment = ""
+                    , lUnit = unitNameOf units waUnitId
+                    , lAmount = waAmount
+                    , lComment = renderComment waPedigree waComment
+                    }
+wasteLine _ _ TechnosphereExchange{} = Nothing
+wasteLine _ _ BiosphereExchange{} = Nothing
+
+{- | The medium a biosphere exchange belongs to, derived from the flow's
+compartment name. SimaPro splits biosphere rows into four sections keyed on
+the medium: Resources, Emissions to air/water/soil. Resources are the
+'Resource' direction; emissions are bucketed by compartment name.
+-}
+bioSection :: BioFlowDB -> Exchange -> Maybe BioSec
+bioSection bioDB ex@BiosphereExchange{bioDirection = dir} =
+    case dir of
+        Resource -> Just SecRes
+        Emission -> case M.lookup (exchangeFlowId ex) bioDB of
+            Nothing -> Just SecAir -- unknown medium → air (parser default-ish); flow itself dropped anyway
+            Just flow -> case T.toLower (bfCompartmentName flow) of
+                "water" -> Just SecWater
+                "soil" -> Just SecSoil
+                "air" -> Just SecAir
+                "" -> Just SecAir
+                _ -> Just SecAir
+bioSection _ TechnosphereExchange{} = Nothing
+bioSection _ WasteExchange{} = Nothing
+
+data BioSec = SecRes | SecAir | SecWater | SecSoil
+    deriving (Eq)
+
+-- | Reference + coproduct output rows for the Products section.
+productLines :: TechFlowDB -> UnitDB -> Maybe Double -> Text -> [Exchange] -> [Text]
+productLines techDB units allocPct category exchs =
+    let outputs =
+            [ (flow, ex)
+            | ex@TechnosphereExchange{} <- exchs
+            , exchangeIsReference ex || isCoproduct ex
+            , Just flow <- [M.lookup (exchangeFlowId ex) techDB]
+            ]
+        alloc = formatAmount (fromMaybe 100 allocPct)
+        mkRow (flow, TechnosphereExchange{..}) =
+            -- name;unit;amount;allocation;waste_type;category;comment
+            row
+                [ tfName flow
+                , unitNameOf units techUnitId
+                , formatAmount techAmount
+                , alloc
+                , "not defined"
+                , category
+                , ""
+                ]
+        mkRow (_, _) = ""
+        sortKey (flow, ex) = (tfName flow, unitNameOf units (exchangeUnitId ex), exchangeAmount ex)
+     in map mkRow (sortOn sortKey outputs)
+  where
+    isCoproduct TechnosphereExchange{techRole = Coproduct} = True
+    isCoproduct _ = False
+
+{- | Render one section: a header line followed by its sorted rows. Emits
+nothing when there are no rows, matching the parser (it tolerates absent
+sections).
+-}
+section :: Text -> (Line -> Text) -> [Line] -> [Text]
+section _ _ [] = []
+section header render ls = header : map render (sortOn lineKey ls)
+
+-- | Render a technosphere input row: name;unit;amount;Undefined;0;0;comment
+techRowText :: Line -> Text
+techRowText Line{..} =
+    row [lName, lUnit, formatAmount lAmount, "Undefined", "0", "0", lComment]
+
+-- | Render a biosphere row: name;compartment;unit;amount;Undefined;0;0;comment
+bioRowText :: Line -> Text
+bioRowText Line{..} =
+    row [lName, lCompartment, lUnit, formatAmount lAmount, "Undefined", "0", "0", lComment]
+
+{- | Serialize a single activity to a @Process … End@ block (list of lines,
+without trailing terminator). Flow/unit names are resolved through the
+respective DBs; exchanges whose flow is missing are dropped (the matrix
+builder is the authority on unknown flows, not the serializer).
+-}
+serializeActivity ::
+    TechFlowDB ->
+    BioFlowDB ->
+    WasteFlowDB ->
+    UnitDB ->
+    Activity ->
+    [Text]
+serializeActivity techDB bioDB wasteDB units Activity{..} =
+    let catType = M.findWithDefault "" "Category type" activityClassification
+        category = M.findWithDefault "" "Category" activityClassification
+        typeLabel = case activityNativeType of
+            Just (SimaProProcessType lbl) -> lbl
+            Just (EcoSpoldActivityType{eatLabel = lbl}) -> lbl
+            Just (ILCDProcessType lbl) -> lbl
+            Nothing -> "Unit process"
+        comment = T.intercalate " " activityDescription
+
+        techLines = mapMaybe (techInputLine techDB units) exchanges
+        bioByName name = [l | (sec, l) <- bioPaired, sec == name]
+        bioPaired =
+            [ (sec, l)
+            | ex@BiosphereExchange{} <- exchanges
+            , Just sec <- [bioSection bioDB ex]
+            , Just l <- [bioLine bioDB units ex]
+            ]
+        wasteLines = mapMaybe (wasteLine wasteDB units) exchanges
+
+        meta key val = if T.null val then [] else [key, val, ""]
+     in concat
+            [ ["Process", ""]
+            , meta "Category type" catType
+            , meta "Process name" activityName
+            , meta "Type" typeLabel
+            , meta "Geography" activityLocation
+            , meta "Comment" comment
+            , -- Products section is always present (an activity has a reference).
+              "Products" : productLines techDB units activityAllocationPercent category exchanges
+            , [""]
+            , -- Inputs.
+              withBlank (section "Materials/fuels" techRowText techLines)
+            , withBlank (section "Resources" bioRowText (bioByName SecRes))
+            , withBlank (section "Emissions to air" bioRowText (bioByName SecAir))
+            , withBlank (section "Emissions to water" bioRowText (bioByName SecWater))
+            , withBlank (section "Emissions to soil" bioRowText (bioByName SecSoil))
+            , withBlank (section "Final waste flows" bioRowText wasteLines)
+            , ["End", ""]
+            ]
+  where
+    -- Append a blank separator line after a non-empty section.
+    withBlank [] = []
+    withBlank ls = ls ++ [""]
+
+-- ============================================================================
+-- Header
+-- ============================================================================
+
+-- | The fixed SimaPro header block. No timestamp / generator line is emitted.
+headerLines :: WriterConfig -> [Text]
+headerLines cfg =
+    [ "{" <> wcVersion cfg <> "}"
+    , "{CSV separator: Semicolon}"
+    , "{Decimal separator: .}"
+    , "{Date separator: /}"
+    , "{Short date format: dd/MM/yyyy}"
+    , ""
+    ]
+
+-- ============================================================================
+-- Top-level serialization
+-- ============================================================================
+
+{- | Serialize a 'SimpleDatabase' to canonical SimaPro CSV bytes (UTF-8, CRLF).
+Activities are sorted by (name, location) so the byte stream is independent
+of the underlying 'Map' iteration order.
+-}
+serializeSimaProCSV :: WriterConfig -> SimpleDatabase -> BS.ByteString
+serializeSimaProCSV cfg SimpleDatabase{..} =
+    let acts = sortOn (\a -> (activityName a, activityLocation a)) (M.elems sdbActivities)
+        blocks = concatMap (serializeActivity sdbTechFlows sdbBioFlows sdbWasteFlows sdbUnits) acts
+        allLines = headerLines cfg ++ blocks
+     in TE.encodeUtf8 (T.intercalate crlf allLines <> crlf)
+
+-- | Write canonical SimaPro CSV bytes to a file.
+writeSimaProCSV :: WriterConfig -> FilePath -> SimpleDatabase -> IO ()
+writeSimaProCSV cfg path = BS.writeFile path . serializeSimaProCSV cfg

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -257,26 +257,18 @@ they must be emitted under their own headers, never merged.
 -}
 productLines :: (Exchange -> Bool) -> TechFlowDB -> UnitDB -> Maybe Double -> Text -> [Exchange] -> [Text]
 productLines keep techDB units allocPct category exchs =
-    let outputs =
-            [ (flow, ex)
+    let alloc = formatAmount (fromMaybe 100 allocPct)
+        -- Extract the row fields in the comprehension, where the exchange is
+        -- known to be a TechnosphereExchange — so mkRow is total (no unreachable
+        -- blank-row arm). Sort by (name, unit, amount) for determinism.
+        entries =
+            [ (tfName flow, unitNameOf units (exchangeUnitId ex), exchangeAmount ex)
             | ex@TechnosphereExchange{} <- exchs
             , keep ex
             , Just flow <- [M.lookup (exchangeFlowId ex) techDB]
             ]
-        alloc = formatAmount (fromMaybe 100 allocPct)
-        mkRow (flow, TechnosphereExchange{..}) =
-            row
-                [ tfName flow
-                , unitNameOf units techUnitId
-                , formatAmount techAmount
-                , alloc
-                , "not defined"
-                , category
-                , ""
-                ]
-        mkRow (_, _) = ""
-        sortKey (flow, ex) = (tfName flow, unitNameOf units (exchangeUnitId ex), exchangeAmount ex)
-     in map mkRow (sortOn sortKey outputs)
+        mkRow (nm, unit, amt) = row [nm, unit, formatAmount amt, alloc, "not defined", category, ""]
+     in map mkRow (sortOn id entries)
 
 -- | A coproduct technosphere output (SimaPro @Avoided products@ section, which
 -- the parser reads back as a 'Coproduct' role).
@@ -327,11 +319,13 @@ serializeActivity ::
 serializeActivity techDB bioDB wasteDB units Activity{..} =
     let catType = M.findWithDefault "" "Category type" activityClassification
         category = M.findWithDefault "" "Category" activityClassification
+        -- No native type → omit the Type line entirely (meta drops empty values),
+        -- so a re-parse yields Nothing again rather than drifting to "Unit process".
         typeLabel = case activityNativeType of
             Just (SimaProProcessType lbl) -> lbl
             Just (EcoSpoldActivityType{eatLabel = lbl}) -> lbl
             Just (ILCDProcessType lbl) -> lbl
-            Nothing -> "Unit process"
+            Nothing -> ""
         comment = T.intercalate " " activityDescription
 
         techLines = mapMaybe (techInputLine techDB units) exchanges

--- a/test/BrightwayExcelWriterSpec.hs
+++ b/test/BrightwayExcelWriterSpec.hs
@@ -1,0 +1,335 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Round-trip tests for the Brightway Excel (.xlsx) /writer/, the inverse of
+"BrightwayExcel.Parser".
+
+The fixture 'SimpleDatabase' is built in Haskell using the very UUID generators
+the parser feeds its flows/units/activities through ('generateFlowUUID',
+'generateUnitUUID', 'generateActivityUUID'), so @parse (write D)@ reconstructs
+the same identities — no committed binary fixture, and no dependence on the
+cross-database link pass (technosphere links are left @nil@, exactly the state
+the parser produces for a freshly imported workbook).
+
+Three contracts are proven:
+
+  (a) /logical-cell idempotence/ — re-exporting the parsed content yields the
+      same worksheet rows. Byte identity is not attempted (zip metadata is
+      volatile); we compare the parsed-then-rewritten logical cells.
+  (b) /semantic round-trip/ — @parse (write D)@ is structurally equal to @D@,
+      order-insensitively (activities, exchanges, flows, units).
+  (c) /score equivalence/ — the biosphere inventory of a sample activity is
+      preserved across the round-trip, within tolerance, using the engine's
+      matrix solver.
+-}
+module BrightwayExcelWriterSpec (spec) where
+
+import BrightwayExcel.Parser (parseBrightwayExcel)
+import BrightwayExcel.Writer (
+    Cell (..),
+    WriterConfig (..),
+    activityRows,
+    formatAmount,
+    renderCategories,
+    renderWorkbook,
+ )
+import qualified Data.ByteString.Lazy as BL
+import Data.List (find, sortOn)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.UUID as UUID
+import Database (buildDatabaseWithMatrices)
+import Database.Loader (getReferenceProductUUID)
+import Matrix (computeInventoryMatrix)
+import SimaPro.Parser (generateActivityUUID, generateFlowUUID, generateUnitUUID)
+import System.IO (hClose)
+import System.IO.Temp (withSystemTempFile)
+import Test.Hspec
+import Types
+import UnitConversion (defaultUnitConfig)
+
+spec :: Spec
+spec = describe "BrightwayExcel.Writer" $ do
+    describe "formatAmount" $ do
+        it "prints integers without a decimal point" $
+            formatAmount 1 `shouldBe` "1"
+        it "prints fractions with full precision" $
+            formatAmount 8.5 `shouldBe` "8.5"
+        it "round-trips a small scientific value" $
+            (read (T.unpack (formatAmount 1.0e-3)) :: Double) `shouldBe` 1.0e-3
+
+    describe "renderCategories" $ do
+        it "joins compartment and subcompartment with ::" $
+            renderCategories (Just (Compartment "natural resource" (Just "in water")))
+                `shouldBe` "natural resource::in water"
+        it "emits the bare medium when there is no sub" $
+            renderCategories (Just (Compartment "air" Nothing)) `shouldBe` "air"
+        it "emits empty for no recorded compartment" $
+            renderCategories Nothing `shouldBe` ""
+
+    describe "round-trip" $ do
+        it "(b) parse (write D) is structurally equal to D" $
+            withWritten fixtureDb $ \path -> do
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right parsed -> normalizeParsed parsed `shouldBe` expectedNormalized
+
+        it "(a) re-exporting the parsed content yields the same logical cells" $
+            withWritten fixtureDb $ \path -> do
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right parsed -> do
+                        let db' = rebuild parsed
+                        logicalCells db' `shouldBe` logicalCells fixtureDb
+
+        it "(c) preserves a biosphere inventory amount across the round-trip" $
+            withWritten fixtureDb $ \path -> do
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right parsed -> do
+                        before <- co2Inventory fixtureDb
+                        after <- co2Inventory (rebuild parsed)
+                        case (before, after) of
+                            (Right (Just b), Right (Just a)) ->
+                                abs (a - b) < 1.0e-9 `shouldBe` True
+                            other -> expectationFailure ("CO2 inventory missing: " <> show other)
+
+-- ---------------------------------------------------------------------------
+-- Fixture database, built with the parser's UUID conventions
+-- ---------------------------------------------------------------------------
+
+cfg :: WriterConfig
+cfg = WriterConfig{wcDatabaseName = "Test_Inventory_DB"}
+
+-- One activity producing electricity, consuming gas, emitting CO2.
+fixtureDb :: SimpleDatabase
+fixtureDb =
+    SimpleDatabase
+        { sdbActivities = M.singleton (generateActivityUUID elec, getReferenceProductUUID elec) elec
+        , sdbTechFlows = M.fromList [(tfId f, f) | f <- [elecFlow, gasFlow]]
+        , sdbBioFlows = M.fromList [(bfId co2, co2)]
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.fromList [(unitId u, u) | u <- [kwh, m3, kg]]
+        }
+
+elec :: Activity
+elec =
+    Activity
+        { activityName = "Electricity production, natural gas"
+        , activityDescription = []
+        , activitySynonyms = M.empty
+        , activityClassification = M.empty
+        , activityLocation = "GLO"
+        , activityUnit = "kilowatt hour"
+        , exchanges = [prodExch, gasExch, co2Exch]
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
+        }
+
+prodExch :: Exchange
+prodExch =
+    TechnosphereExchange
+        { techFlowId = generateFlowUUID "electricity, high voltage" "" "kilowatt hour"
+        , techAmount = 1
+        , techUnitId = generateUnitUUID "kilowatt hour"
+        , techRole = ReferenceProduct
+        , techActivityLinkId = UUID.nil
+        , techProcessLinkId = Nothing
+        , techLocation = "GLO"
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+gasExch :: Exchange
+gasExch =
+    TechnosphereExchange
+        { techFlowId = generateFlowUUID "natural gas, high pressure" "" "cubic meter"
+        , techAmount = 8.5
+        , techUnitId = generateUnitUUID "cubic meter"
+        , techRole = Input
+        , techActivityLinkId = UUID.nil
+        , techProcessLinkId = Nothing
+        , techLocation = "RoW"
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+co2Exch :: Exchange
+co2Exch =
+    BiosphereExchange
+        { bioFlowId = bfId co2
+        , bioAmount = 0.5
+        , bioUnitId = generateUnitUUID "kilogram"
+        , bioDirection = Emission
+        , bioLocation = ""
+        , bioComment = Nothing
+        , bioPedigree = Nothing
+        }
+
+elecFlow :: TechnosphereFlow
+elecFlow =
+    TechnosphereFlow
+        (generateFlowUUID "electricity, high voltage" "" "kilowatt hour")
+        "electricity, high voltage"
+        (generateUnitUUID "kilowatt hour")
+        M.empty
+        Nothing
+        Nothing
+
+gasFlow :: TechnosphereFlow
+gasFlow =
+    TechnosphereFlow
+        (generateFlowUUID "natural gas, high pressure" "" "cubic meter")
+        "natural gas, high pressure"
+        (generateUnitUUID "cubic meter")
+        M.empty
+        Nothing
+        Nothing
+
+co2 :: BiosphereFlow
+co2 =
+    BiosphereFlow
+        { bfId = generateFlowUUID "Carbon dioxide, fossil" "air" "kilogram"
+        , bfName = "Carbon dioxide, fossil"
+        , bfUnitId = generateUnitUUID "kilogram"
+        , bfSynonyms = M.empty
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfCompartment = Just (Compartment "air" Nothing)
+        }
+
+kwh, m3, kg :: Unit
+kwh = mkUnit "kilowatt hour"
+m3 = mkUnit "cubic meter"
+kg = mkUnit "kilogram"
+
+mkUnit :: Text -> Unit
+mkUnit n = Unit (generateUnitUUID n) n n ""
+
+-- ---------------------------------------------------------------------------
+-- Structural comparison (order-insensitive)
+-- ---------------------------------------------------------------------------
+
+{- | A normalized, comparable projection of a parsed database: activity names
+each with their reference product, sorted technosphere inputs, and sorted
+biosphere flows (name, amount, compartment, direction). This captures the
+semantic content the format can carry without depending on Map/Set ordering or
+on fields the format does not represent (links, pedigree).
+-}
+data NormActivity = NormActivity
+    { nName :: Text
+    , nLocation :: Text
+    , nRefProduct :: Maybe Text
+    , nInputs :: [(Text, Double, Text)]
+    , nBio :: [(Text, Double, Text, BioDirection)]
+    }
+    deriving (Eq, Show)
+
+type Parsed = ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB)
+
+normalizeParsed :: Parsed -> [NormActivity]
+normalizeParsed (acts, techDB, bioDB, _waste, unitDB) =
+    sortOn nName (map norm acts)
+  where
+    norm a =
+        NormActivity
+            { nName = activityName a
+            , nLocation = activityLocation a
+            , nRefProduct = listTo [tfName f | ex <- exchanges a, exchangeIsReference ex, Just f <- [M.lookup (exchangeFlowId ex) techDB]]
+            , nInputs =
+                sortOn (\(n, _, _) -> n) $
+                    [ (tfName f, techAmount ex, unitNameOf (techUnitId ex))
+                    | ex@TechnosphereExchange{techRole = Input} <- exchanges a
+                    , Just f <- [M.lookup (techFlowId ex) techDB]
+                    ]
+            , nBio =
+                sortOn (\(n, _, _, _) -> n) $
+                    [ (bfName f, bioAmount ex, bfCompartmentName f, bioDirection ex)
+                    | ex@BiosphereExchange{} <- exchanges a
+                    , Just f <- [M.lookup (bioFlowId ex) bioDB]
+                    ]
+            }
+    unitNameOf uid = maybe "" unitName (M.lookup uid unitDB)
+    listTo = \case
+        (x : _) -> Just x
+        [] -> Nothing
+
+-- | The same projection over the original fixture database.
+expectedNormalized :: [NormActivity]
+expectedNormalized =
+    normalizeParsed
+        ( M.elems (sdbActivities fixtureDb)
+        , sdbTechFlows fixtureDb
+        , sdbBioFlows fixtureDb
+        , sdbWasteFlows fixtureDb
+        , sdbUnits fixtureDb
+        )
+
+-- ---------------------------------------------------------------------------
+-- Logical-cell extraction (for idempotence)
+-- ---------------------------------------------------------------------------
+
+{- | Re-export the parsed 5-tuple to the writer's input shape. Activities are
+keyed exactly as 'Database.Loader.loadBrightwayExcel' keys them.
+-}
+rebuild :: Parsed -> SimpleDatabase
+rebuild (acts, techDB, bioDB, wasteDB, unitDB) =
+    SimpleDatabase
+        { sdbActivities = M.fromList [((generateActivityUUID a, getReferenceProductUUID a), a) | a <- acts]
+        , sdbTechFlows = techDB
+        , sdbBioFlows = bioDB
+        , sdbWasteFlows = wasteDB
+        , sdbUnits = unitDB
+        }
+
+{- | The deterministic logical cells the writer would emit for a database: the
+per-activity 'activityRows' (which already carry every value the format records,
+addressed by column). Comparing these is the logical-cell idempotence contract —
+byte identity of the zip is deliberately not required.
+-}
+logicalCells :: SimpleDatabase -> [[[Cell]]]
+logicalCells db =
+    [ activityRows cfg db a
+    | a <- sortOn (\x -> (activityName x, activityLocation x)) (M.elems (sdbActivities db))
+    ]
+
+-- ---------------------------------------------------------------------------
+-- Scoring (c)
+-- ---------------------------------------------------------------------------
+
+-- | CO2 biosphere inventory for the electricity activity (ProcessId 0).
+co2Inventory :: SimpleDatabase -> IO (Either Text (Maybe Double))
+co2Inventory sdb = do
+    built <-
+        buildDatabaseWithMatrices
+            defaultUnitConfig
+            (sdbActivities sdb)
+            (sdbTechFlows sdb)
+            (sdbBioFlows sdb)
+            (sdbWasteFlows sdb)
+            (sdbUnits sdb)
+    case built of
+        Left err -> pure (Left err)
+        Right db -> do
+            inv <- computeInventoryMatrix db 0
+            pure (Right (lookupCo2 db inv))
+  where
+    lookupCo2 db inv =
+        case find ((== "Carbon dioxide, fossil") . bfName) (M.elems (dbBioFlows db)) of
+            Just f -> M.lookup (bfId f) inv
+            Nothing -> Nothing
+
+-- ---------------------------------------------------------------------------
+-- File helper
+-- ---------------------------------------------------------------------------
+
+withWritten :: SimpleDatabase -> (FilePath -> IO a) -> IO a
+withWritten db action =
+    withSystemTempFile "brightway-writer.xlsx" $ \path h -> do
+        BL.hPut h (renderWorkbook cfg db)
+        hClose h
+        action path

--- a/test/BrightwayExcelWriterSpec.hs
+++ b/test/BrightwayExcelWriterSpec.hs
@@ -95,6 +95,15 @@ spec = describe "BrightwayExcel.Writer" $ do
                                 abs (a - b) < 1.0e-9 `shouldBe` True
                             other -> expectationFailure ("CO2 inventory missing: " <> show other)
 
+    describe "ReferenceInput regression" $
+        it "emits a reference-input exchange exactly once (not double-counted)" $ do
+            -- A ReferenceInput belongs only to the reference group; before the
+            -- fix it also matched the technosphere-input group and was written
+            -- twice, doubling its coefficient on re-import.
+            let dataRows = activityRows cfg refInputDb refInputAct
+                solventRows = length [() | (CText "spent solvent" : _) <- dataRows]
+            solventRows `shouldBe` 1
+
 -- ---------------------------------------------------------------------------
 -- Fixture database, built with the parser's UUID conventions
 -- ---------------------------------------------------------------------------
@@ -189,6 +198,45 @@ gasFlow =
         M.empty
         Nothing
         Nothing
+
+-- Regression fixtures: a treatment-style activity whose reference is a
+-- technosphere *input* (ReferenceInput), which must serialize as a single row.
+solventFlow :: TechnosphereFlow
+solventFlow =
+    TechnosphereFlow
+        (generateFlowUUID "spent solvent" "" "kilogram")
+        "spent solvent"
+        (generateUnitUUID "kilogram")
+        M.empty
+        Nothing
+        Nothing
+
+refInputAct :: Activity
+refInputAct =
+    elec
+        { activityName = "Solvent treatment"
+        , activityUnit = "kilogram"
+        , exchanges =
+            [ TechnosphereExchange
+                { techFlowId = tfId solventFlow
+                , techAmount = 1
+                , techUnitId = generateUnitUUID "kilogram"
+                , techRole = ReferenceInput
+                , techActivityLinkId = UUID.nil
+                , techProcessLinkId = Nothing
+                , techLocation = "GLO"
+                , techComment = Nothing
+                , techPedigree = Nothing
+                }
+            ]
+        }
+
+refInputDb :: SimpleDatabase
+refInputDb =
+    fixtureDb
+        { sdbTechFlows = M.singleton (tfId solventFlow) solventFlow
+        , sdbUnits = M.singleton (unitId kg) kg
+        }
 
 co2 :: BiosphereFlow
 co2 =

--- a/test/CopySpec.hs
+++ b/test/CopySpec.hs
@@ -1,0 +1,249 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Tests for the COPY primitive ('Database.Edit.copyDatabase' and the pure
+'Database.Edit.copyDatabaseAs').
+
+A copy is a second, independent registry entry over an immutable 'Database'
+value:
+
+* it is registered under the new name in the loaded / available maps;
+* its config is renamed (dcName / dcDisplayName);
+* mutating or dropping the copy leaves the source untouched, and dropping the
+  source leaves the copy fully intact — the value is immutable, so there is no
+  aliasing to break;
+* copying onto an existing name, or from an unloaded source, fails loudly.
+-}
+module CopySpec (spec) where
+
+import Control.Concurrent.STM (atomically, modifyTVar', readTVarIO)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import Test.Hspec
+
+import Config (DatabaseConfig (..), defaultConfig)
+import qualified Data.Vector.Unboxed as U
+import Database (buildDatabaseWithMatrices)
+import Database.Edit (copyDatabase, copyDatabaseAs)
+import Database.Manager (
+    DatabaseManager (..),
+    LoadedDatabase (..),
+    initDatabaseManager,
+ )
+import SharedSolver (SharedSolver, createSharedSolver)
+import Types (
+    Activity (..),
+    Database (..),
+    Exchange (..),
+    GeographyPolicy (..),
+    SparseTriple (..),
+    TechRole (..),
+    TechnosphereFlow (..),
+    UUID,
+    Unit (..),
+ )
+import UnitConversion (defaultUnitConfig)
+
+spec :: Spec
+spec = describe "Database.Edit copy primitive" $ do
+    it "registers an independent copy under the new name" $ do
+        manager <- initDatabaseManager defaultConfig True Nothing
+        srcDb <- buildOrFail (supplierDB 100 ["p1", "p2"])
+        installLoaded manager "source" srcDb
+
+        result <- copyDatabase manager "source" "mycopy"
+        result `shouldBe` Right ()
+
+        loaded <- readTVarIO (dmLoadedDbs manager)
+        available <- readTVarIO (dmAvailableDbs manager)
+        M.keys loaded `shouldMatchList` ["source", "mycopy"]
+        M.member "mycopy" available `shouldBe` True
+
+        let copy = loaded M.! "mycopy"
+        -- Renamed config.
+        dcName (ldConfig copy) `shouldBe` "mycopy"
+        dcDisplayName (ldConfig copy) `shouldBe` "mycopy"
+        -- Same data: identical activity count to the source.
+        V.length (dbActivities (ldDatabase copy))
+            `shouldBe` V.length (dbActivities srcDb)
+
+    it "is a deep, independent value — dropping the copy does not touch the source" $ do
+        manager <- initDatabaseManager defaultConfig True Nothing
+        srcDb <- buildOrFail (supplierDB 200 ["p1", "p2", "p3"])
+        installLoaded manager "source" srcDb
+        _ <- copyDatabase manager "source" "mycopy"
+
+        before <- readTVarIO (dmLoadedDbs manager)
+        let srcCount = V.length (dbActivities (ldDatabase (before M.! "source")))
+
+        -- Delete the copy outright from every registry map.
+        atomically $ do
+            modifyTVar' (dmLoadedDbs manager) (M.delete "mycopy")
+            modifyTVar' (dmAvailableDbs manager) (M.delete "mycopy")
+            modifyTVar' (dmIndexedDbs manager) (M.delete "mycopy")
+
+        after <- readTVarIO (dmLoadedDbs manager)
+        M.member "mycopy" after `shouldBe` False
+        M.member "source" after `shouldBe` True
+        V.length (dbActivities (ldDatabase (after M.! "source"))) `shouldBe` srcCount
+
+    it "is a deep, independent value — dropping the source leaves the copy intact" $ do
+        manager <- initDatabaseManager defaultConfig True Nothing
+        srcDb <- buildOrFail (supplierDB 300 ["p1", "p2"])
+        installLoaded manager "source" srcDb
+        _ <- copyDatabase manager "source" "mycopy"
+
+        let srcCount = V.length (dbActivities srcDb)
+        atomically $ do
+            modifyTVar' (dmLoadedDbs manager) (M.delete "source")
+            modifyTVar' (dmAvailableDbs manager) (M.delete "source")
+            modifyTVar' (dmIndexedDbs manager) (M.delete "source")
+
+        after <- readTVarIO (dmLoadedDbs manager)
+        M.member "source" after `shouldBe` False
+        V.length (dbActivities (ldDatabase (after M.! "mycopy"))) `shouldBe` srcCount
+
+    it "refuses to overwrite an existing database name" $ do
+        manager <- initDatabaseManager defaultConfig True Nothing
+        srcDb <- buildOrFail (supplierDB 400 ["p1"])
+        otherDb <- buildOrFail (supplierDB 500 ["q1"])
+        installLoaded manager "source" srcDb
+        installLoaded manager "taken" otherDb
+
+        result <- copyDatabase manager "source" "taken"
+        result `shouldBe` Left "Database already exists: taken"
+
+    it "fails when the source is not loaded" $ do
+        manager <- initDatabaseManager defaultConfig True Nothing
+        result <- copyDatabase manager "ghost" "mycopy"
+        result `shouldBe` Left "Database not loaded: ghost"
+
+    it "copyDatabaseAs preserves the source value structurally" $ do
+        srcDb <- buildOrFail (supplierDB 600 ["p1", "p2"])
+        let copied = copyDatabaseAs "whatever" srcDb
+        V.length (dbActivities copied) `shouldBe` V.length (dbActivities srcDb)
+        dbActivityCount copied `shouldBe` dbActivityCount srcDb
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+
+{- | Install a built database as a LoadedDatabase under @name@: solver,
+config, loaded map, and available map. Mirrors what the load path does, but
+without disk I/O.
+-}
+installLoaded :: DatabaseManager -> Text -> Database -> IO ()
+installLoaded manager name db = do
+    solver <- mkSolver name db
+    let loaded =
+            LoadedDatabase
+                { ldDatabase = db
+                , ldSharedSolver = solver
+                , ldConfig = mkConfig name
+                }
+    atomically $ do
+        modifyTVar' (dmLoadedDbs manager) (M.insert name loaded)
+        modifyTVar' (dmAvailableDbs manager) (M.insert name (mkConfig name))
+
+mkSolver :: Text -> Database -> IO SharedSolver
+mkSolver name db =
+    let triples = [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList (dbTechnosphereTriples db)]
+     in createSharedSolver name triples (fromIntegral (dbActivityCount db))
+
+mkConfig :: Text -> DatabaseConfig
+mkConfig name =
+    DatabaseConfig
+        { dcName = name
+        , dcDisplayName = name
+        , dcPath = ""
+        , dcDescription = Nothing
+        , dcLoad = True
+        , dcDefault = False
+        , dcDepends = []
+        , dcLocationAliases = M.empty
+        , dcFormat = Nothing
+        , dcIsUploaded = False
+        , dcDeletable = False
+        , dcGeographyPolicy = GeoGlobal
+        }
+
+buildOrFail :: SimpleParts -> IO Database
+buildOrFail (SimpleParts acts flows units) = do
+    r <- buildDatabaseWithMatrices defaultUnitConfig acts flows M.empty M.empty units
+    case r of
+        Right db -> pure db
+        Left err -> fail ("buildDatabaseWithMatrices: " <> show err)
+
+-- ---------------------------------------------------------------------------
+-- Fixture builders (single unit "kg", all activities at GLO)
+-- ---------------------------------------------------------------------------
+
+data SimpleParts
+    = SimpleParts
+        (M.Map (UUID, UUID) Activity)
+        (M.Map UUID TechnosphereFlow)
+        (M.Map UUID Unit)
+
+mkUUID :: Int -> UUID
+mkUUID n = UUID.fromWords64 (fromIntegral n) 0
+
+kgUnitId :: UUID
+kgUnitId = mkUUID 0
+
+kgUnit :: Unit
+kgUnit = Unit{unitId = kgUnitId, unitName = "kg", unitSymbol = "kg", unitComment = ""}
+
+mkTechFlow :: UUID -> Text -> TechnosphereFlow
+mkTechFlow fid name =
+    TechnosphereFlow
+        { tfId = fid
+        , tfName = name
+        , tfUnitId = kgUnitId
+        , tfSynonyms = M.empty
+        , tfCAS = Nothing
+        , tfSubstanceId = Nothing
+        }
+
+-- | One self-producing activity per product name. 'offset' keeps UUIDs disjoint.
+supplierDB :: Int -> [Text] -> SimpleParts
+supplierDB offset products =
+    let entries =
+            [ let actUUID = mkUUID (offset + 10 * i + 1)
+                  prodUUID = mkUUID (offset + 10 * i + 2)
+                  flowUUID = mkUUID (offset + 10 * i + 3)
+                  flow = mkTechFlow flowUUID name
+                  refOut =
+                    TechnosphereExchange
+                        { techFlowId = flowUUID
+                        , techAmount = 1.0
+                        , techUnitId = kgUnitId
+                        , techRole = ReferenceProduct
+                        , techActivityLinkId = actUUID
+                        , techProcessLinkId = Nothing
+                        , techLocation = ""
+                        , techComment = Nothing
+                        , techPedigree = Nothing
+                        }
+                  act =
+                    Activity
+                        { activityName = "supplier-of-" <> name
+                        , activityDescription = []
+                        , activitySynonyms = M.empty
+                        , activityClassification = M.empty
+                        , activityLocation = "GLO"
+                        , activityUnit = "kg"
+                        , exchanges = [refOut]
+                        , activityParams = M.empty
+                        , activityParamExprs = M.empty
+                        , activityAllocationPercent = Nothing
+                        , activityAllocationFormula = Nothing
+                        , activityNativeType = Nothing
+                        }
+               in (((actUUID, prodUUID), act), (flowUUID, flow))
+            | (i, name) <- zip [0 ..] products
+            ]
+     in SimpleParts
+            (M.fromList (map fst entries))
+            (M.fromList (map snd entries))
+            (M.singleton kgUnitId kgUnit)

--- a/test/CrossLinkingSpec.hs
+++ b/test/CrossLinkingSpec.hs
@@ -253,6 +253,7 @@ spec = do
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
                         , lcGeographyPolicy = GeoGlobal
+                        , lcSupplierAliases = Nothing
                         }
             case findSupplierInIndexedDBs ctx "product Y" "GLO" "kg" of
                 CrossDBLinked{cdlrScore = score} -> score `shouldSatisfy` (>= defaultLinkingThreshold)
@@ -268,6 +269,7 @@ spec = do
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
                         , lcGeographyPolicy = GeoGlobal
+                        , lcSupplierAliases = Nothing
                         }
             case findSupplierInIndexedDBs ctx "no such product" "GLO" "kg" of
                 CrossDBNotLinked _ -> return ()
@@ -283,6 +285,7 @@ spec = do
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
                         , lcGeographyPolicy = GeoGlobal
+                        , lcSupplierAliases = Nothing
                         }
             -- "product Y" exists in kg; asking for m3 should fail unit check
             case findSupplierInIndexedDBs ctx "product Y" "GLO" "m3" of
@@ -302,6 +305,7 @@ spec = do
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
                         , lcGeographyPolicy = GeoGlobal
+                        , lcSupplierAliases = Nothing
                         }
             -- Synonym lookup: "producto y" → group containing "product y" → supplier
             case findSupplierInIndexedDBs ctx "producto y" "GLO" "kg" of
@@ -318,6 +322,7 @@ spec = do
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
                         , lcGeographyPolicy = GeoGlobal
+                        , lcSupplierAliases = Nothing
                         }
             -- "product Y {GLO}" compound name with empty location arg
             -- extractBracketedLocation will find "GLO"
@@ -368,6 +373,7 @@ spec = do
                     , lcThreshold = defaultLinkingThreshold
                     , lcLocationHierarchy = locationHierarchy
                     , lcGeographyPolicy = policy
+                    , lcSupplierAliases = Nothing
                     }
 
         it "GeoGlobal accepts FR query against a GLO candidate" $ do
@@ -463,8 +469,9 @@ mkRefExchangeAt loc =
   where
     flowUUID = read "aaaaaaaa-0000-0000-0000-000000000001"
 
--- | One-activity SimpleDatabase with a single reference exchange. The
--- activity is anchored at @actLoc@; the reference exchange carries @exLoc@.
+{- | One-activity SimpleDatabase with a single reference exchange. The
+activity is anchored at @actLoc@; the reference exchange carries @exLoc@.
+-}
 mkSplitLocationDB :: Text -> Text -> SimpleDatabase
 mkSplitLocationDB actLoc exLoc =
     let flowUUID = read "aaaaaaaa-0000-0000-0000-000000000001"

--- a/test/DeleteSelectionSpec.hs
+++ b/test/DeleteSelectionSpec.hs
@@ -1,0 +1,408 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Tests for the DELETE-BY-SELECTION primitive
+('Database.Edit.deleteActivities', 'Database.Edit.resolveDeleteSelection' and
+the effectful 'Database.Edit.deleteActivitiesInDB').
+
+Delete is reconstruction over an immutable 'Database':
+
+* deleting a set of ProcessIds drops exactly those activities and renumbers the
+  survivors, rebuilding the interning tables, indexes, and sparse matrices;
+* an exchange in a surviving activity that pointed at a deleted activity is
+  UNLINKED (activity link reset to nil), never silently dropped — the database
+  is left ready for relinking;
+* the selection resolver computes @(filtered ∪ extra) \\ keep@, so the UI's
+  "delete the whole filtered set" honours per-row checkbox overrides;
+* deleting by filter removes the WHOLE matching set, independent of pagination.
+-}
+module DeleteSelectionSpec (spec) where
+
+import Control.Concurrent.STM (atomically, modifyTVar', readTVarIO)
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as U
+import Test.Hspec
+
+import Config (DatabaseConfig (..), defaultConfig)
+import Database (buildDatabaseWithMatrices)
+import Database.Edit (
+    DeleteSelection (..),
+    deleteActivities,
+    deleteActivitiesInDB,
+    resolveDeleteSelection,
+ )
+import Database.Manager (
+    DatabaseManager (..),
+    LoadedDatabase (..),
+    initDatabaseManager,
+ )
+import SharedSolver (SharedSolver, createSharedSolver)
+import Types (
+    Activity (..),
+    Database (..),
+    Exchange (..),
+    GeographyPolicy (..),
+    ProcessId,
+    SparseTriple (..),
+    TechRole (..),
+    TechnosphereFlow (..),
+    UUID,
+    Unit (..),
+    findProcessId,
+    processIdToText,
+ )
+import UnitConversion (defaultUnitConfig)
+
+spec :: Spec
+spec = describe "Database.Edit delete-by-selection primitive" $ do
+    describe "resolveDeleteSelection" $ do
+        it "deletes the whole filtered set when there are no overrides" $
+            S.fromList (resolveDeleteSelection (DeleteSelection [0, 1, 2, 3] [] []))
+                `shouldBe` S.fromList [0, 1, 2, 3]
+
+        it "spares the explicit keep set (unticked checkboxes)" $
+            S.fromList (resolveDeleteSelection (DeleteSelection [0, 1, 2, 3] [1, 2] []))
+                `shouldBe` S.fromList [0, 3]
+
+        it "adds the explicit extra set (ticked rows outside the filter)" $
+            S.fromList (resolveDeleteSelection (DeleteSelection [0, 1] [] [5, 6]))
+                `shouldBe` S.fromList [0, 1, 5, 6]
+
+        it "lets keep win over both filtered and extra" $
+            S.fromList (resolveDeleteSelection (DeleteSelection [0, 1] [1, 5] [5, 6]))
+                `shouldBe` S.fromList [0, 6]
+
+    describe "deleteActivities (pure rebuild)" $ do
+        it "removes exactly the requested activities and renumbers survivors" $ do
+            db <- buildOrFail (chainDB 100)
+            dbActivityCount db `shouldBe` 3
+            -- Delete the leaf supplier (index 0 = "supplier" sorts first).
+            let supplierPid = pidFor db 100 0
+            case deleteActivities [supplierPid] db of
+                Left err -> expectationFailure ("deleteActivities failed: " <> show err)
+                Right db' -> do
+                    dbActivityCount db' `shouldBe` 2
+                    V.length (dbActivities db') `shouldBe` 2
+                    -- ProcessId table and lookup agree after renumbering.
+                    V.length (dbProcessIdTable db') `shouldBe` 2
+                    M.size (dbProcessIdLookup db') `shouldBe` 2
+                    -- The biosphere/tech matrices were rebuilt: the deleted
+                    -- supplier's row no longer contributes any tech triple.
+                    U.length (dbTechnosphereTriples db')
+                        `shouldSatisfy` (< U.length (dbTechnosphereTriples db))
+
+        it "unlinks surviving exchanges that pointed at a deleted activity" $ do
+            db <- buildOrFail (chainDB 200)
+            let supplierPid = pidFor db 200 0
+            case deleteActivities [supplierPid] db of
+                Left err -> expectationFailure ("deleteActivities failed: " <> show err)
+                Right db' -> do
+                    -- The mid activity kept its input exchange, but the link to
+                    -- the deleted supplier is now nil — ready for relinking.
+                    let supplierLinks =
+                            [ techActivityLinkId ex
+                            | act <- V.toList (dbActivities db')
+                            , ex@TechnosphereExchange{} <- exchanges act
+                            ]
+                    supplierLinks `shouldSatisfy` all (== UUID.nil) . filter (== mkUUID (200 + 1))
+
+        it "keeps a multi-product link target when only one product is deleted" $ do
+            db <- buildOrFail (multiProductDB 300)
+            -- supplier exposes two products; delete only product B.
+            let prodBPid = pidFor2 db (mkUUID 301) (mkUUID 303)
+            case deleteActivities [prodBPid] db of
+                Left err -> expectationFailure ("deleteActivities failed: " <> show err)
+                Right db' -> do
+                    dbActivityCount db' `shouldBe` 2
+                    -- The consumer linking to product A (a surviving key) keeps its link.
+                    let consumerLinks =
+                            [ techActivityLinkId ex
+                            | act <- V.toList (dbActivities db')
+                            , activityName act == "consumer-A"
+                            , ex@TechnosphereExchange{techRole = Input} <- exchanges act
+                            ]
+                    consumerLinks `shouldBe` [mkUUID 301]
+
+        it "fails loudly on an out-of-range ProcessId" $ do
+            db <- buildOrFail (chainDB 400)
+            case deleteActivities [999] db of
+                Left _ -> pure ()
+                Right _ -> expectationFailure "expected out-of-range ProcessId to fail"
+
+        it "refuses to delete every activity" $ do
+            db <- buildOrFail (chainDB 500)
+            let allPids = [0 .. dbActivityCount db - 1]
+            case deleteActivities allPids db of
+                Left _ -> pure ()
+                Right _ -> expectationFailure "expected delete-all to be refused"
+
+    describe "deleteActivitiesInDB (filter-driven, in-place)" $ do
+        it "deletes the whole filtered set ignoring pagination, and respects keep" $ do
+            manager <- initDatabaseManager defaultConfig True Nothing
+            db <- buildOrFail (classifiedDB 600)
+            installLoaded manager "edit-me" db
+            -- Filter matches the two "food" activities; keep one by its
+            -- canonical process-id string (the value the UI carries).
+            let foodA = processIdToText db (pidFor2 db (mkUUID 601) (mkUUID 601))
+            r <-
+                deleteActivitiesInDB
+                    manager
+                    "edit-me"
+                    Nothing
+                    Nothing
+                    Nothing
+                    [("category", "food", False)]
+                    False
+                    [foodA] -- keep
+                    [] -- extra
+            case r of
+                Left err -> expectationFailure ("deleteActivitiesInDB failed: " <> show err)
+                Right deleted -> do
+                    deleted `shouldBe` 1 -- two matched, one kept
+                    loaded <- readTVarIO (dmLoadedDbs manager)
+                    let db' = ldDatabase (loaded M.! "edit-me")
+                    dbActivityCount db' `shouldBe` 2
+                    -- The kept food activity and the non-food activity survive.
+                    map activityName (V.toList (dbActivities db'))
+                        `shouldSatisfy` elem "food-A"
+
+        it "fails loudly on an unknown keep process id" $ do
+            manager <- initDatabaseManager defaultConfig True Nothing
+            db <- buildOrFail (classifiedDB 700)
+            installLoaded manager "edit-me-2" db
+            r <-
+                deleteActivitiesInDB
+                    manager
+                    "edit-me-2"
+                    Nothing
+                    Nothing
+                    Nothing
+                    [("category", "food", False)]
+                    False
+                    ["not-a-real-process-id"]
+                    []
+            case r of
+                Left _ -> pure ()
+                Right _ -> expectationFailure "expected unknown keep id to fail"
+
+        it "fails when the database is not loaded" $ do
+            manager <- initDatabaseManager defaultConfig True Nothing
+            r <- deleteActivitiesInDB manager "ghost" Nothing Nothing Nothing [] False [] []
+            r `shouldBe` Left "Database not loaded: ghost"
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+
+pidFor :: Database -> Int -> Int -> ProcessId
+pidFor db offset i = pidFor2 db (mkUUID (offset + 10 * i + 1)) (mkUUID (offset + 10 * i + 1))
+
+pidFor2 :: Database -> UUID -> UUID -> ProcessId
+pidFor2 db actUUID prodUUID =
+    maybe (error "pidFor2: key not found") id (findProcessId db actUUID prodUUID)
+
+installLoaded :: DatabaseManager -> Text -> Database -> IO ()
+installLoaded manager name db = do
+    solver <- mkSolver name db
+    let loaded =
+            LoadedDatabase
+                { ldDatabase = db
+                , ldSharedSolver = solver
+                , ldConfig = mkConfig name
+                }
+    atomically $ do
+        modifyTVar' (dmLoadedDbs manager) (M.insert name loaded)
+        modifyTVar' (dmAvailableDbs manager) (M.insert name (mkConfig name))
+
+mkSolver :: Text -> Database -> IO SharedSolver
+mkSolver name db =
+    let triples = [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList (dbTechnosphereTriples db)]
+     in createSharedSolver name triples (fromIntegral (dbActivityCount db))
+
+mkConfig :: Text -> DatabaseConfig
+mkConfig name =
+    DatabaseConfig
+        { dcName = name
+        , dcDisplayName = name
+        , dcPath = ""
+        , dcDescription = Nothing
+        , dcLoad = True
+        , dcDefault = False
+        , dcDepends = []
+        , dcLocationAliases = M.empty
+        , dcFormat = Nothing
+        , dcIsUploaded = True
+        , dcDeletable = True
+        , dcGeographyPolicy = GeoGlobal
+        }
+
+buildOrFail :: SimpleParts -> IO Database
+buildOrFail (SimpleParts acts flows units) = do
+    r <- buildDatabaseWithMatrices defaultUnitConfig acts flows M.empty M.empty units
+    case r of
+        Right db -> pure db
+        Left err -> fail ("buildDatabaseWithMatrices: " <> show err)
+
+-- ---------------------------------------------------------------------------
+-- Fixtures
+-- ---------------------------------------------------------------------------
+
+data SimpleParts
+    = SimpleParts
+        (M.Map (UUID, UUID) Activity)
+        (M.Map UUID TechnosphereFlow)
+        (M.Map UUID Unit)
+
+mkUUID :: Int -> UUID
+mkUUID n = UUID.fromWords64 (fromIntegral n) 0
+
+kgUnitId :: UUID
+kgUnitId = mkUUID 0
+
+kgUnit :: Unit
+kgUnit = Unit{unitId = kgUnitId, unitName = "kg", unitSymbol = "kg", unitComment = ""}
+
+mkTechFlow :: UUID -> Text -> TechnosphereFlow
+mkTechFlow fid name =
+    TechnosphereFlow
+        { tfId = fid
+        , tfName = name
+        , tfUnitId = kgUnitId
+        , tfSynonyms = M.empty
+        , tfCAS = Nothing
+        , tfSubstanceId = Nothing
+        }
+
+{- | A reference-product output exchange whose product UUID equals its flow UUID
+(so @(actUUID, prodUUID)@ is also the @(actUUID, flowId)@ link key).
+-}
+refOut :: UUID -> UUID -> Exchange
+refOut actUUID prodUUID =
+    TechnosphereExchange
+        { techFlowId = prodUUID
+        , techAmount = 1.0
+        , techUnitId = kgUnitId
+        , techRole = ReferenceProduct
+        , techActivityLinkId = actUUID
+        , techProcessLinkId = Nothing
+        , techLocation = ""
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+-- | An input exchange linking to a supplier's @(supplierActUUID, supplierProdUUID)@.
+inputFrom :: UUID -> UUID -> Exchange
+inputFrom supplierActUUID supplierProdUUID =
+    TechnosphereExchange
+        { techFlowId = supplierProdUUID
+        , techAmount = 0.5
+        , techUnitId = kgUnitId
+        , techRole = Input
+        , techActivityLinkId = supplierActUUID
+        , techProcessLinkId = Nothing
+        , techLocation = ""
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+mkActivity :: Text -> Text -> M.Map Text Text -> [Exchange] -> Activity
+mkActivity name loc classif exs =
+    Activity
+        { activityName = name
+        , activityDescription = []
+        , activitySynonyms = M.empty
+        , activityClassification = classif
+        , activityLocation = loc
+        , activityUnit = "kg"
+        , exchanges = exs
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
+        }
+
+units :: M.Map UUID Unit
+units = M.singleton kgUnitId kgUnit
+
+{- | A three-activity chain: top → mid → supplier. UUIDs are
+@offset + 10*i + 1@ for activity i (i: 0=supplier, 1=mid, 2=top), with product
+UUID equal to the activity UUID for simple linking.
+-}
+chainDB :: Int -> SimpleParts
+chainDB offset =
+    let supA = mkUUID (offset + 1)
+        midA = mkUUID (offset + 11)
+        topA = mkUUID (offset + 21)
+        supplier = mkActivity "supplier" "GLO" M.empty [refOut supA supA]
+        mid = mkActivity "mid" "GLO" M.empty [refOut midA midA, inputFrom supA supA]
+        top = mkActivity "top" "GLO" M.empty [refOut topA topA, inputFrom midA midA]
+     in SimpleParts
+            ( M.fromList
+                [ ((supA, supA), supplier)
+                , ((midA, midA), mid)
+                , ((topA, topA), top)
+                ]
+            )
+            ( M.fromList
+                [ (supA, mkTechFlow supA "supplier-product")
+                , (midA, mkTechFlow midA "mid-product")
+                , (topA, mkTechFlow topA "top-product")
+                ]
+            )
+            units
+
+{- | A supplier exposing two products (A, B) plus a consumer linking to product
+A only. Deleting product B must keep the consumer's link to A intact.
+-}
+multiProductDB :: Int -> SimpleParts
+multiProductDB offset =
+    let supA = mkUUID (offset + 1)
+        prodA = mkUUID (offset + 2)
+        prodB = mkUUID (offset + 3)
+        consA = mkUUID (offset + 11)
+        supplierA = mkActivity "supplier" "GLO" M.empty [refOut supA prodA]
+        supplierB = mkActivity "supplier" "GLO" M.empty [refOut supA prodB]
+        consumer = mkActivity "consumer-A" "GLO" M.empty [refOut consA consA, inputFrom supA prodA]
+     in SimpleParts
+            ( M.fromList
+                [ ((supA, prodA), supplierA)
+                , ((supA, prodB), supplierB)
+                , ((consA, consA), consumer)
+                ]
+            )
+            ( M.fromList
+                [ (prodA, mkTechFlow prodA "product-A")
+                , (prodB, mkTechFlow prodB "product-B")
+                , (consA, mkTechFlow consA "consumer-product")
+                ]
+            )
+            units
+
+{- | Two "food" activities and one "energy" activity, classified under the
+@category@ system so a classification filter selects the food pair.
+-}
+classifiedDB :: Int -> SimpleParts
+classifiedDB offset =
+    let foodA = mkUUID (offset + 1)
+        foodB = mkUUID (offset + 11)
+        energ = mkUUID (offset + 21)
+        food = M.singleton "category" "food"
+        energy = M.singleton "category" "energy"
+     in SimpleParts
+            ( M.fromList
+                [ ((foodA, foodA), mkActivity "food-A" "GLO" food [refOut foodA foodA])
+                , ((foodB, foodB), mkActivity "food-B" "GLO" food [refOut foodB foodB])
+                , ((energ, energ), mkActivity "energy" "GLO" energy [refOut energ energ])
+                ]
+            )
+            ( M.fromList
+                [ (foodA, mkTechFlow foodA "food-a")
+                , (foodB, mkTechFlow foodB "food-b")
+                , (energ, mkTechFlow energ "energy")
+                ]
+            )
+            units

--- a/test/EcoSpold1WriterSpec.hs
+++ b/test/EcoSpold1WriterSpec.hs
@@ -1,0 +1,314 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Round-trip contract for the EcoSpold1 writer (the inverse of
+"EcoSpold.Parser1"). Three properties:
+
+  (a) idempotence modulo volatile metadata — write, parse, write again,
+      and the two serialisations are byte-identical when the volatile
+      @generator@/@timestamp@ attributes are omitted ('canonicalWriterOptions');
+  (b) semantic round-trip — parse(write(D)) reproduces the observable
+      structure of D (names, amounts, units, roles/directions, compartments,
+      CAS, comments), compared order-insensitively;
+  (c) score-equivalence — a sample activity yields the same direct LCIA
+      inventory (biosphere flow amounts, keyed by flow name) after a
+      write→parse→build round-trip, within tolerance.
+-}
+module EcoSpold1WriterSpec (spec) where
+
+import qualified Data.ByteString.Char8 as BC
+import Data.List (sort)
+import qualified Data.Map.Strict as M
+import Data.Maybe (mapMaybe)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified Data.UUID as UUID
+import Test.Hspec
+
+import qualified Database as DB
+import EcoSpold.Cutoff (applyCutoffStrategy)
+import EcoSpold.Parser1 (parseAllWithXeno)
+import EcoSpold.Writer1
+import qualified Matrix
+import Types
+import UnitConversion (defaultUnitConfig)
+
+-- ---------------------------------------------------------------------------
+-- Fixture: a small in-memory database, distilled from EcoSpold1Spec's minimalXml
+-- (one production activity: 1 kWh electricity, with a fossil-CO2 emission and
+--  a natural-gas resource input). Built straight from the parser output so the
+-- flow/unit UUIDs already line up with the EcoSpold1 UUID scheme.
+-- ---------------------------------------------------------------------------
+
+minimalXml :: BC.ByteString
+minimalXml =
+    BC.unlines
+        [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold01\">"
+        , "  <dataset number=\"42\">"
+        , "    <metaInformation>"
+        , "      <processInformation>"
+        , "        <referenceFunction name=\"electricity production\" category=\"Energy\""
+        , "                           subCategory=\"Electricity\" unit=\"kWh\""
+        , "                           generalComment=\"A comment\"/>"
+        , "        <geography location=\"DE\" />"
+        , "      </processInformation>"
+        , "    </metaInformation>"
+        , "    <flowData>"
+        , "      <exchange number=\"1\" name=\"electricity, high voltage\" category=\"Energy\""
+        , "                subCategory=\"Electricity\" unit=\"kWh\" meanValue=\"1.0\">"
+        , "        <outputGroup>0</outputGroup>"
+        , "      </exchange>"
+        , "      <exchange number=\"2\" name=\"Carbon dioxide, fossil\" category=\"air\""
+        , "                subCategory=\"low population density\" unit=\"kg\" meanValue=\"0.05\""
+        , "                CASNumber=\"124-38-9\">"
+        , "        <outputGroup>4</outputGroup>"
+        , "      </exchange>"
+        , "      <exchange number=\"3\" name=\"natural gas\" category=\"resource\""
+        , "                subCategory=\"in ground\" unit=\"MJ\" meanValue=\"10.0\">"
+        , "        <inputGroup>4</inputGroup>"
+        , "      </exchange>"
+        , "    </flowData>"
+        , "  </dataset>"
+        , "</ecoSpold>"
+        ]
+
+{- | Parsed fixture as a 'SimpleDatabase'. Fails the spec loudly if the
+fixture can't be parsed (it is a known-good EcoSpold1 document).
+-}
+fixtureDb :: IO SimpleDatabase
+fixtureDb = case parseAllWithXeno minimalXml of
+    Left err -> fail ("fixture parse failed: " ++ err)
+    Right results -> case sequence results of
+        Left err -> fail ("fixture dataset failed: " ++ err)
+        Right datasets -> pure (assembleSimpleDb datasets)
+
+-- | Fold parser per-dataset tuples into a 'SimpleDatabase'.
+assembleSimpleDb ::
+    [(Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit], Int, M.Map UUID Int)] ->
+    SimpleDatabase
+assembleSimpleDb datasets =
+    SimpleDatabase
+        { sdbActivities = M.fromList [(processKey a, a) | (a, _, _, _, _, _, _) <- datasets]
+        , sdbTechFlows = M.fromList [(tfId f, f) | (_, tfs, _, _, _, _, _) <- datasets, f <- tfs]
+        , sdbBioFlows = M.fromList [(bfId f, f) | (_, _, bfs, _, _, _, _) <- datasets, f <- bfs]
+        , sdbWasteFlows = M.fromList [(wfId f, f) | (_, _, _, wfs, _, _, _) <- datasets, f <- wfs]
+        , sdbUnits = M.fromList [(unitId u, u) | (_, _, _, _, us, _, _) <- datasets, u <- us]
+        }
+
+{- | The (activityUUID, productUUID) key the matrix builder expects. We use the
+reference exchange's flow id as the product, and derive a stable activity id
+from name+location via the same namespace the Loader uses is unnecessary
+here: the writer round-trip only depends on flow ids, so any injective key
+works. We reuse the reference product flow id for both slots.
+-}
+processKey :: Activity -> (UUID, UUID)
+processKey act =
+    case mapMaybe refId (exchanges act) of
+        (fid : _) -> (fid, fid)
+        [] -> case exchanges act of
+            (e : _) -> (exchangeFlowId e, exchangeFlowId e)
+            [] -> (UUID.nil, UUID.nil)
+  where
+    refId e = if exchangeIsReference e then Just (exchangeFlowId e) else Nothing
+
+-- ---------------------------------------------------------------------------
+-- Order-insensitive observable projection of an activity, for semantic equality
+-- ---------------------------------------------------------------------------
+
+{- | Observable, UUID-free fingerprint of one exchange. Names come from the
+flow tables; everything else is intrinsic to the exchange.
+-}
+data ExchangeView = ExchangeView
+    { evKind :: !Text
+    , evName :: !Text
+    , evAmount :: !Double
+    , evUnit :: !Text
+    , evRole :: !Text
+    , evLocation :: !Text
+    , evCas :: !(Maybe Text)
+    , evComment :: !(Maybe Text)
+    }
+    deriving (Eq, Ord, Show)
+
+exchangeViews :: SimpleDatabase -> Activity -> [ExchangeView]
+exchangeViews sdb = map (exchangeView sdb) . exchanges
+
+exchangeView :: SimpleDatabase -> Exchange -> ExchangeView
+exchangeView sdb ex = case ex of
+    TechnosphereExchange{techFlowId = fid, techRole = role} ->
+        base "tech" (techName fid) (roleText role)
+    BiosphereExchange{bioFlowId = fid, bioDirection = dir} ->
+        base "bio" (bioName fid) (dirText dir)
+    WasteExchange{waFlowId = fid, waIsInput = isInput} ->
+        base "waste" (wasteName fid) (if isInput then "input" else "output")
+  where
+    base kind nm role =
+        ExchangeView
+            { evKind = kind
+            , evName = nm
+            , evAmount = exchangeAmount ex
+            , evUnit = maybe "" unitName (M.lookup (exchangeUnitId ex) (sdbUnits sdb))
+            , evRole = role
+            , evLocation = exchangeLocation ex
+            , evCas = casOf ex
+            , evComment = exchangeComment ex
+            }
+    techName fid = maybe "" tfName (M.lookup fid (sdbTechFlows sdb))
+    bioName fid = maybe "" bfName (M.lookup fid (sdbBioFlows sdb))
+    wasteName fid = maybe "" wfName (M.lookup fid (sdbWasteFlows sdb))
+    casOf e = case e of
+        TechnosphereExchange{techFlowId = fid} -> M.lookup fid (sdbTechFlows sdb) >>= tfCAS
+        BiosphereExchange{bioFlowId = fid} -> M.lookup fid (sdbBioFlows sdb) >>= bfCAS
+        WasteExchange{waFlowId = fid} -> M.lookup fid (sdbWasteFlows sdb) >>= wfCAS
+    roleText r = case r of
+        ReferenceProduct -> "ref"
+        ReferenceInput -> "ref"
+        Coproduct -> "coproduct"
+        Input -> "input"
+    dirText d = case d of
+        Resource -> "resource"
+        Emission -> "emission"
+
+{- | An order-insensitive fingerprint of the whole database: per-activity
+(name, location, unit, classification, sorted exchange views).
+-}
+data ActivityView = ActivityView
+    { avName :: !Text
+    , avLocation :: !Text
+    , avUnit :: !Text
+    , avClassification :: ![(Text, Text)]
+    , avExchanges :: ![ExchangeView]
+    }
+    deriving (Eq, Ord, Show)
+
+dbViews :: SimpleDatabase -> [ActivityView]
+dbViews sdb =
+    sort
+        [ ActivityView
+            { avName = activityName a
+            , avLocation = activityLocation a
+            , avUnit = activityUnit a
+            , avClassification = M.toList (activityClassification a)
+            , avExchanges = sort (exchangeViews sdb a)
+            }
+        | a <- M.elems (sdbActivities sdb)
+        ]
+
+-- ---------------------------------------------------------------------------
+-- Parse helper: write → parse back into a SimpleDatabase
+-- ---------------------------------------------------------------------------
+
+roundTrip :: SimpleDatabase -> Either String SimpleDatabase
+roundTrip sdb =
+    let xml = TE.encodeUtf8 (writeSimpleDatabase canonicalWriterOptions sdb)
+     in case parseAllWithXeno xml of
+            Left err -> Left err
+            Right results -> assembleSimpleDb <$> sequence results
+
+-- | Build a full 'Database' from a 'SimpleDatabase' so we can score it.
+buildDb :: SimpleDatabase -> IO Database
+buildDb sdb = do
+    result <-
+        DB.buildDatabaseWithMatrices
+            defaultUnitConfig
+            (sdbActivities sdb)
+            (sdbTechFlows sdb)
+            (sdbBioFlows sdb)
+            (sdbWasteFlows sdb)
+            (sdbUnits sdb)
+    case result of
+        Left err -> fail ("buildDatabaseWithMatrices failed: " ++ T.unpack err)
+        Right db -> pure db
+
+{- | Direct inventory of the reference activity, keyed by biosphere flow NAME
+(UUIDs are regenerated across a round-trip, names are invariant).
+-}
+inventoryByName :: Database -> IO (M.Map Text Double)
+inventoryByName db = do
+    let pid = 0 -- single-activity fixture
+    inv <- Matrix.computeInventoryMatrix db pid
+    pure $
+        M.fromListWith
+            (+)
+            [ (bfName bf, amt)
+            | (fid, amt) <- M.toList inv
+            , Just bf <- [M.lookup fid (dbBioFlows db)]
+            ]
+
+-- ---------------------------------------------------------------------------
+-- Spec
+-- ---------------------------------------------------------------------------
+
+spec :: Spec
+spec = do
+    describe "escapeXmlAttr" $ do
+        it "escapes the five metacharacters and newlines" $
+            escapeXmlAttr "a<b>&\"'\n"
+                `shouldBe` "a&lt;b&gt;&amp;&quot;&apos;&#10;"
+
+        it "is a left-inverse of the parser's entity decoder (no double-escape)" $
+            -- The lone & must become &amp; exactly once.
+            escapeXmlAttr "Tom & Jerry" `shouldBe` "Tom &amp; Jerry"
+
+    describe "formatAmount" $ do
+        it "normalises negative zero" $
+            formatAmount (-0.0) `shouldBe` "0.0"
+
+        it "keeps a whole number parser-readable" $
+            formatAmount 1.0 `shouldBe` "1.0"
+
+    describe "writeSimpleDatabase" $ do
+        it "emits a well-formed EcoSpold1 document the parser accepts" $ do
+            sdb <- fixtureDb
+            let xml = writeSimpleDatabase canonicalWriterOptions sdb
+            T.isInfixOf "<ecoSpold" xml `shouldBe` True
+            case parseAllWithXeno (TE.encodeUtf8 xml) of
+                Left err -> expectationFailure ("re-parse failed: " ++ err)
+                Right results -> length results `shouldBe` 1
+
+        it "omits volatile attributes under canonicalWriterOptions" $ do
+            sdb <- fixtureDb
+            let xml = writeSimpleDatabase canonicalWriterOptions sdb
+            T.isInfixOf "generator=" xml `shouldBe` False
+            T.isInfixOf "timestamp=" xml `shouldBe` False
+
+        it "includes a pinned generator under defaultWriterOptions" $ do
+            sdb <- fixtureDb
+            let xml = writeSimpleDatabase defaultWriterOptions sdb
+            T.isInfixOf "generator=\"VoLCA\"" xml `shouldBe` True
+
+    describe "round-trip (a) idempotence modulo volatile metadata" $
+        it "write . parse . write == write (canonical)" $ do
+            sdb <- fixtureDb
+            let f0 = writeSimpleDatabase canonicalWriterOptions sdb
+            case parseAllWithXeno (TE.encodeUtf8 f0) of
+                Left err -> expectationFailure ("re-parse failed: " ++ err)
+                Right results -> case sequence results of
+                    Left err -> expectationFailure ("dataset failed: " ++ err)
+                    Right datasets ->
+                        let sdb' = assembleSimpleDb datasets
+                            f1 = writeSimpleDatabase canonicalWriterOptions sdb'
+                         in f1 `shouldBe` f0
+
+    describe "round-trip (b) semantic equality (order-insensitive)" $
+        it "parse(write(D)) reproduces the observable structure of D" $ do
+            sdb <- fixtureDb
+            case roundTrip sdb of
+                Left err -> expectationFailure ("round-trip failed: " ++ err)
+                Right sdb' -> dbViews sdb' `shouldBe` dbViews sdb
+
+    describe "round-trip (c) score-equivalence" $
+        it "yields the same direct biosphere inventory within tolerance" $ do
+            sdb <- fixtureDb
+            case roundTrip sdb of
+                Left err -> expectationFailure ("round-trip failed: " ++ err)
+                Right sdb' -> do
+                    db0 <- buildDb sdb
+                    db1 <- buildDb sdb'
+                    inv0 <- inventoryByName db0
+                    inv1 <- inventoryByName db1
+                    M.keys inv1 `shouldBe` M.keys inv0
+                    let near a b = abs (a - b) < 1e-9
+                    and (M.elems (M.intersectionWith near inv0 inv1)) `shouldBe` True
+                    M.null inv0 `shouldBe` False

--- a/test/EcoSpold2WriterSpec.hs
+++ b/test/EcoSpold2WriterSpec.hs
@@ -37,7 +37,7 @@ import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import Database (buildDatabaseWithMatrices)
 import Database.Loader (loadDatabase)
-import EcoSpold.Writer2 (noVolatileMeta, writeEcoSpold2)
+import EcoSpold.Writer2 (noVolatileMeta, sortExchanges, writeEcoSpold2)
 import Matrix (computeInventoryMatrix)
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
@@ -175,6 +175,14 @@ spec = describe "EcoSpold2 writer round-trip" $ do
         let f1 = writeEcoSpold2 noVolatileMeta sdb'
         -- Compare the sorted (filename, document) sequences byte-for-byte.
         sortOn fst f1 `shouldBe` sortOn fst f0
+
+    -- Regression: two exchanges sharing a sort key (same kind + flow) must both
+    -- survive ordering. The previous Map-based sort silently dropped one,
+    -- undercounting the inventory.
+    it "keeps duplicate exchanges of the same flow (no silent dedup)" $ do
+        let e1 = BiosphereExchange co2 0.5 unitKg Emission "" Nothing Nothing
+            e2 = BiosphereExchange co2 0.3 unitKg Emission "" Nothing Nothing
+        length (sortExchanges [e1, e2]) `shouldBe` 2
 
     -- (b) Semantic round-trip: parse(write(D)) ≅ D, order-insensitive.
     describe "semantic round-trip (structural equality)" $ do

--- a/test/EcoSpold2WriterSpec.hs
+++ b/test/EcoSpold2WriterSpec.hs
@@ -1,0 +1,271 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Round-trip contract for the EcoSpold2 writer ('EcoSpold.Writer2'), the
+inverse of 'EcoSpold.Parser2'.
+
+We exercise three properties against a self-contained fixture 'SimpleDatabase'
+built in Haskell:
+
+  (a) __idempotence modulo volatile metadata__ — @write(D)@ then
+      @write(parse(write(D)))@ produce byte-identical output once volatile
+      metadata is excluded (we exclude it by writing with 'noVolatileMeta').
+  (b) __semantic round-trip__ — @parse(write(D))@ is structurally equal to @D@
+      (order-insensitive on exchanges/flows).
+  (c) __score-equivalence__ — @parse(write(D))@ yields the same LCIA inventory
+      (the engine's matrix-level score input) as @D@ within tolerance.
+
+The fixture is constructed directly rather than loaded from a bundled
+@.spold@ directory because the bundled @SAMPLE.units@ fixture deliberately
+reuses a single @unitId@ across flows with *different* unit-name strings (a
+degenerate-input stress test for the parser). The loader collapses those to
+one unit per UUID in name-resolution order, which depends on filename
+ordering — a property of the loader on malformed input, not of the writer.
+A clean fixture (one name per unit UUID, distinct flow UUIDs) isolates the
+writer's own determinism, which is what this spec asserts.
+-}
+module EcoSpold2WriterSpec (spec) where
+
+import Control.Monad (forM_)
+import Data.List (sort, sortOn)
+import qualified Data.Map.Strict as M
+import Data.Maybe (fromMaybe)
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.IO as TIO
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import Database (buildDatabaseWithMatrices)
+import Database.Loader (loadDatabase)
+import EcoSpold.Writer2 (noVolatileMeta, writeEcoSpold2)
+import Matrix (computeInventoryMatrix)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+import Types
+import UnitConversion (defaultUnitConfig)
+
+-- | A UUID from its canonical text, or nil if (impossibly) malformed.
+uuid :: Text -> UUID.UUID
+uuid t = fromMaybe UUID.nil (UUID.fromText t)
+
+-- Distinct, well-formed UUIDs for the fixture.
+actA, prodA, actB, prodB :: UUID.UUID
+actA = uuid "aaaaaaaa-0000-4000-8000-000000000001"
+prodA = uuid "aaaaaaaa-0000-4000-8000-0000000000a1"
+actB = uuid "bbbbbbbb-0000-4000-8000-000000000002"
+prodB = uuid "bbbbbbbb-0000-4000-8000-0000000000b2"
+
+co2, land :: UUID.UUID
+co2 = uuid "cccccccc-0000-4000-8000-0000000000c0"
+land = uuid "dddddddd-0000-4000-8000-0000000000d0"
+
+unitKg, unitMJ, unitM2a :: UUID.UUID
+unitKg = uuid "11111111-0000-4000-8000-000000000001"
+unitMJ = uuid "22222222-0000-4000-8000-000000000002"
+unitM2a = uuid "33333333-0000-4000-8000-000000000003"
+
+{- | A self-contained two-activity EcoSpold2 database.
+
+  * Activity A produces product A (1 kg), consumes 2 MJ of product B, and
+    emits 0.5 kg CO2 (biosphere).
+  * Activity B produces product B (1 MJ) and occupies 0.1 m2*year of land.
+
+Every unit UUID maps to exactly one name; every flow UUID is distinct.
+-}
+fixtureSimple :: SimpleDatabase
+fixtureSimple =
+    SimpleDatabase
+        { sdbActivities =
+            M.fromList
+                [ ((actA, prodA), activityA)
+                , ((actB, prodB), activityB)
+                ]
+        , sdbTechFlows =
+            M.fromList
+                [ (prodA, TechnosphereFlow prodA "product A" unitKg M.empty Nothing Nothing)
+                , (prodB, TechnosphereFlow prodB "product B" unitMJ M.empty Nothing Nothing)
+                ]
+        , sdbBioFlows =
+            M.fromList
+                [ (co2, BiosphereFlow co2 "Carbon dioxide, fossil" unitKg M.empty Nothing Nothing (Just (Compartment "air" (Just "unspecified"))))
+                , (land, BiosphereFlow land "Occupation, arable land" unitM2a M.empty Nothing Nothing (Just (Compartment "natural resource" (Just "land"))))
+                ]
+        , sdbWasteFlows = M.empty
+        , sdbUnits =
+            M.fromList
+                [ (unitKg, Unit unitKg "kg" "kg" "")
+                , (unitMJ, Unit unitMJ "MJ" "MJ" "")
+                , (unitM2a, Unit unitM2a "m2*year" "m2*year" "")
+                ]
+        }
+  where
+    activityA =
+        Activity
+            "production of A"
+            ["First fixture activity"]
+            M.empty
+            M.empty
+            "GLO"
+            "kg"
+            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , TechnosphereExchange prodB 2.0 unitMJ Input actB Nothing "" (Just "energy input") Nothing
+            , BiosphereExchange co2 0.5 unitKg Emission "" Nothing Nothing
+            ]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            (Just (EcoSpoldActivityType 1 "Ordinary transforming activity" Nothing Nothing))
+    activityB =
+        Activity
+            "production of B"
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "MJ"
+            [ TechnosphereExchange prodB 1.0 unitMJ ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , BiosphereExchange land 0.1 unitM2a Resource "" Nothing Nothing
+            ]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            (Just (EcoSpoldActivityType 2 "Market activity" (Just 1) (Just "Hard link")))
+
+-- | The fixture as a 'SimpleDatabase' (matches the previous IO-shaped helper).
+loadFixtureSimple :: IO SimpleDatabase
+loadFixtureSimple = pure fixtureSimple
+
+-- | Build a full 'Database' (with matrices) from a 'SimpleDatabase'.
+buildDb :: SimpleDatabase -> IO Database
+buildDb sdb = do
+    res <-
+        buildDatabaseWithMatrices
+            defaultUnitConfig
+            (sdbActivities sdb)
+            (sdbTechFlows sdb)
+            (sdbBioFlows sdb)
+            (sdbWasteFlows sdb)
+            (sdbUnits sdb)
+    case res of
+        Left err -> error $ "matrix build failed: " ++ T.unpack err
+        Right db -> pure db
+
+{- | Write a 'SimpleDatabase' to a fresh temp directory and re-load it through
+the production loader, returning the round-tripped 'SimpleDatabase'.
+-}
+roundTrip :: SimpleDatabase -> IO SimpleDatabase
+roundTrip sdb = withSystemTempDirectory "es2-writer" $ \dir -> do
+    forM_ (writeEcoSpold2 noVolatileMeta sdb) $ \(fname, doc) ->
+        TIO.writeFile (dir </> fname) doc
+    res <- loadDatabase defaultUnitConfig dir
+    case res of
+        Left err -> error $ "reparse failed: " ++ T.unpack err
+        Right sdb' -> pure sdb'
+
+spec :: Spec
+spec = describe "EcoSpold2 writer round-trip" $ do
+    -- (a) Idempotence modulo volatile metadata.
+    it "is idempotent modulo volatile metadata: write . parse . write == write" $ do
+        sdb <- loadFixtureSimple
+        let f0 = writeEcoSpold2 noVolatileMeta sdb
+        sdb' <- roundTrip sdb
+        let f1 = writeEcoSpold2 noVolatileMeta sdb'
+        -- Compare the sorted (filename, document) sequences byte-for-byte.
+        sortOn fst f1 `shouldBe` sortOn fst f0
+
+    -- (b) Semantic round-trip: parse(write(D)) ≅ D, order-insensitive.
+    describe "semantic round-trip (structural equality)" $ do
+        it "preserves the activity set keyed by (actUUID, prodUUID)" $ do
+            sdb <- loadFixtureSimple
+            sdb' <- roundTrip sdb
+            M.keys (sdbActivities sdb') `shouldMatchList` M.keys (sdbActivities sdb)
+
+        it "preserves each activity's name, location and exchange multiset" $ do
+            sdb <- loadFixtureSimple
+            sdb' <- roundTrip sdb
+            forM_ (M.toList (sdbActivities sdb)) $ \(key, act) ->
+                case M.lookup key (sdbActivities sdb') of
+                    Nothing -> expectationFailure $ "missing activity after round-trip: " ++ show key
+                    Just act' -> do
+                        activityName act' `shouldBe` activityName act
+                        activityLocation act' `shouldBe` activityLocation act
+                        activityNativeType act' `shouldBe` activityNativeType act
+                        sort (map exchangeFingerprint (exchanges act'))
+                            `shouldBe` sort (map exchangeFingerprint (exchanges act))
+
+        it "preserves the biosphere flow registry (id, name, compartment)" $ do
+            sdb <- loadFixtureSimple
+            sdb' <- roundTrip sdb
+            map bioFingerprint (M.elems (sdbBioFlows sdb'))
+                `shouldMatchList` map bioFingerprint (M.elems (sdbBioFlows sdb))
+
+        it "preserves the technosphere flow registry (id, name)" $ do
+            sdb <- loadFixtureSimple
+            sdb' <- roundTrip sdb
+            map (\f -> (tfId f, tfName f)) (M.elems (sdbTechFlows sdb'))
+                `shouldMatchList` map (\f -> (tfId f, tfName f)) (M.elems (sdbTechFlows sdb))
+
+    -- (c) Score-equivalence: same inventory for every activity within tolerance.
+    it "yields the same LCIA inventory as the original (within tolerance)" $ do
+        sdb <- loadFixtureSimple
+        sdb' <- roundTrip sdb
+        db <- buildDb sdb
+        db' <- buildDb sdb'
+        -- Compare inventories for every process id present in the original.
+        let pids = [0 .. fromIntegral (V.length (dbProcessIdTable db)) - 1] :: [ProcessId]
+        forM_ pids $ \pid -> do
+            inv <- computeInventoryMatrix db pid
+            -- The round-tripped DB may order activities differently; locate the
+            -- matching process by its (actUUID, prodUUID) key.
+            let key = dbProcessIdTable db V.! fromIntegral pid
+            case V.elemIndex key (dbProcessIdTable db') of
+                Nothing -> expectationFailure $ "process key missing after round-trip: " ++ show key
+                Just pid' -> do
+                    inv' <- computeInventoryMatrix db' (fromIntegral pid')
+                    inventoriesClose inv inv' `shouldBe` True
+
+-- ----------------------------------------------------------------------------
+-- Comparison helpers (order-insensitive, tolerance-aware)
+-- ----------------------------------------------------------------------------
+
+-- | Structural fingerprint of an exchange, stable under reordering.
+exchangeFingerprint :: Exchange -> (Int, Text, Bool, Bool, Integer)
+exchangeFingerprint ex =
+    ( kindRank ex
+    , UUID.toText (exchangeFlowId ex)
+    , exchangeIsInput ex
+    , exchangeIsReference ex
+    , roundAmount (exchangeAmount ex)
+    )
+  where
+    kindRank TechnosphereExchange{} = 0
+    kindRank WasteExchange{} = 1
+    kindRank BiosphereExchange{} = 2
+
+-- | Biosphere flow fingerprint: identity plus compartment medium/sub.
+bioFingerprint :: BiosphereFlow -> (Text, Text, Text, Maybe Text)
+bioFingerprint f =
+    ( UUID.toText (bfId f)
+    , bfName f
+    , maybe "" compartmentName (bfCompartment f)
+    , bfCompartment f >>= compartmentSub
+    )
+
+-- | Quantise an amount so float jitter doesn't break equality (9 sig decimals).
+roundAmount :: Double -> Integer
+roundAmount d = round (d * 1e9)
+
+{- | Two inventories agree within relative+absolute tolerance on every flow
+present in either map. Missing flows are treated as zero.
+-}
+inventoriesClose :: M.Map UUID.UUID Double -> M.Map UUID.UUID Double -> Bool
+inventoriesClose a b =
+    let keys = S.toList (S.fromList (M.keys a) `S.union` S.fromList (M.keys b))
+        close k =
+            let x = M.findWithDefault 0 k a
+                y = M.findWithDefault 0 k b
+             in abs (x - y) <= 1e-9 + 1e-6 * max (abs x) (abs y)
+     in all close keys

--- a/test/ILCDWriterSpec.hs
+++ b/test/ILCDWriterSpec.hs
@@ -1,0 +1,255 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Round-trip contract for "ILCD.Writer", the inverse of "ILCD.Parser".
+
+The original database @D@ is obtained by parsing the @SAMPLE.ilcd@ fixture with
+'parseILCDDirectory'. That guarantees @D@ already lives in the parser's
+canonical internal form (resolved units, classified flows, linked exchanges),
+so the write→parse cycle has a fair fixed point to land on.
+
+Three properties are pinned, exactly as for the SimaPro/Brightway writers:
+
+  (a) idempotence modulo volatile metadata — @write(D)@ then
+      @write(parse(write(D)))@ produce byte-identical output. The only volatile
+      fields (export timestamp, generator string) are /omitted/ by
+      'defaultWriteOptions', so this holds without any normalization;
+
+  (b) semantic round-trip — @parse(write(D))@ is structurally equal to @D@,
+      order-insensitively, over activities, exchanges and the flow catalog;
+
+  (c) score-equivalence — @parse(write(D))@ yields the same biosphere inventory
+      (the LCIA-precursor vector; an LCIA score is linear in it) as @D@ within
+      tolerance, via the engine's 'computeInventoryMatrix'.
+-}
+module ILCDWriterSpec (spec) where
+
+import Data.List (isPrefixOf, sort)
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Vector as V
+import Database (buildDatabaseWithMatrices)
+import ILCD.Parser (parseILCDDirectory)
+import ILCD.Writer (
+    defaultWriteOptions,
+    escapeXml,
+    formatDouble,
+    ilcdFiles,
+    writeILCDDatabase,
+ )
+import Matrix (computeInventoryMatrix)
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+import Types
+import UnitConversion (defaultUnitConfig)
+
+fixtureDir :: FilePath
+fixtureDir = "test-data/SAMPLE.ilcd"
+
+-- | Parse the fixture into a 'SimpleDatabase' (fails the test on Left).
+loadFixture :: IO SimpleDatabase
+loadFixture = do
+    r <- parseILCDDirectory fixtureDir
+    case r of
+        Left err -> error ("fixture parse failed: " <> T.unpack err)
+        Right db -> pure db
+
+{- | Write a 'SimpleDatabase' to a fresh temp ILCD tree and parse it back.
+A fresh directory per call avoids the parser's on-disk flow cache leaking
+between round-trips.
+-}
+roundTrip :: SimpleDatabase -> IO SimpleDatabase
+roundTrip db = withSystemTempDirectory "ilcd-writer-spec" $ \dir -> do
+    writeILCDDatabase defaultWriteOptions dir db
+    r <- parseILCDDirectory dir
+    case r of
+        Left err -> error ("round-trip parse failed: " <> T.unpack err)
+        Right db' -> pure db'
+
+-- ---------------------------------------------------------------------------
+-- Structural comparison (order-insensitive)
+-- ---------------------------------------------------------------------------
+
+data ActivityShape = ActivityShape
+    { asName :: Text
+    , asLocation :: Text
+    , asClass :: [(Text, Text)]
+    , asNative :: Maybe Text
+    , asExchanges :: [ExchangeShape]
+    }
+    deriving (Eq, Ord, Show)
+
+data ExchangeShape = ExchangeShape
+    { esKind :: Text
+    , esFlow :: Text
+    , esUnit :: Text
+    , esAmount :: Double
+    , esInput :: Bool
+    , esRef :: Bool
+    , esComment :: Maybe Text
+    }
+    deriving (Eq, Ord, Show)
+
+exchangeShape :: SimpleDatabase -> Exchange -> ExchangeShape
+exchangeShape db ex =
+    let unitNm uid = maybe "" unitName (M.lookup uid (sdbUnits db))
+        roundAmt v = fromIntegral (round (v * 1e9) :: Integer) / 1e9 :: Double
+     in case ex of
+            TechnosphereExchange{techFlowId = fid, techAmount = amt, techUnitId = uid, techComment = c} ->
+                ExchangeShape
+                    "tech"
+                    (maybe "?" tfName (M.lookup fid (sdbTechFlows db)))
+                    (unitNm uid)
+                    (roundAmt amt)
+                    (exchangeIsInput ex)
+                    (exchangeIsReference ex)
+                    c
+            BiosphereExchange{bioFlowId = fid, bioAmount = amt, bioUnitId = uid, bioComment = c} ->
+                ExchangeShape
+                    "bio"
+                    (maybe "?" bfName (M.lookup fid (sdbBioFlows db)))
+                    (unitNm uid)
+                    (roundAmt amt)
+                    (exchangeIsInput ex)
+                    (exchangeIsReference ex)
+                    c
+            WasteExchange{waFlowId = fid, waAmount = amt, waUnitId = uid, waComment = c} ->
+                ExchangeShape
+                    "waste"
+                    (maybe "?" wfName (M.lookup fid (sdbWasteFlows db)))
+                    (unitNm uid)
+                    (roundAmt amt)
+                    (exchangeIsInput ex)
+                    (exchangeIsReference ex)
+                    c
+
+activityShape :: SimpleDatabase -> Activity -> ActivityShape
+activityShape db a =
+    ActivityShape
+        { asName = activityName a
+        , asLocation = activityLocation a
+        , asClass = M.toAscList (activityClassification a)
+        , asNative = nativeLabel (activityNativeType a)
+        , asExchanges = sort (map (exchangeShape db) (exchanges a))
+        }
+
+nativeLabel :: Maybe NativeActivityType -> Maybe Text
+nativeLabel nt = case nt of
+    Just (ILCDProcessType l) -> Just l
+    Just (SimaProProcessType l) -> Just l
+    Just (EcoSpoldActivityType{}) -> Nothing
+    Nothing -> Nothing
+
+activityShapes :: SimpleDatabase -> S.Set ActivityShape
+activityShapes db = S.fromList (map (activityShape db) (M.elems (sdbActivities db)))
+
+-- | Order-insensitive view of the flow catalog: (kind, name, unit, cas).
+data FlowShape = FlowShape Text Text Text (Maybe Text)
+    deriving (Eq, Ord, Show)
+
+flowShapes :: SimpleDatabase -> S.Set FlowShape
+flowShapes db =
+    S.fromList $
+        [FlowShape "tech" (tfName f) (unitNm (tfUnitId f)) (tfCAS f) | f <- M.elems (sdbTechFlows db)]
+            ++ [FlowShape "bio" (bfName f) (unitNm (bfUnitId f)) (bfCAS f) | f <- M.elems (sdbBioFlows db)]
+            ++ [FlowShape "waste" (wfName f) (unitNm (wfUnitId f)) (wfCAS f) | f <- M.elems (sdbWasteFlows db)]
+  where
+    unitNm uid = maybe "" unitName (M.lookup uid (sdbUnits db))
+
+-- ---------------------------------------------------------------------------
+-- Inventory (score-equivalence) helper
+-- ---------------------------------------------------------------------------
+
+{- | Build a Database from a 'SimpleDatabase' and compute the inventory of the
+named activity, keyed by biosphere flow name.
+-}
+inventoryByName :: SimpleDatabase -> Text -> IO (M.Map Text Double)
+inventoryByName db target = do
+    built <-
+        buildDatabaseWithMatrices
+            defaultUnitConfig
+            (sdbActivities db)
+            (sdbTechFlows db)
+            (sdbBioFlows db)
+            (sdbWasteFlows db)
+            (sdbUnits db)
+    case built of
+        Left err -> expectationFailure (T.unpack err) >> pure M.empty
+        Right d -> do
+            let pids =
+                    [ pid
+                    | (pid, (actU, _)) <- zip [0 ..] (V.toList (dbProcessIdTable d))
+                    , Just act <- [activityAtUUID d actU]
+                    , activityName act == target
+                    ]
+            case pids of
+                (pid : _) -> do
+                    inv <- computeInventoryMatrix d pid
+                    pure (M.mapKeys (flowName d) inv)
+                [] -> expectationFailure ("no activity named " <> T.unpack target) >> pure M.empty
+  where
+    flowName d uid = maybe (T.pack (show uid)) bfName (M.lookup uid (dbBioFlows d))
+    activityAtUUID d actU =
+        case [i | (i, (a, _)) <- zip [0 ..] (V.toList (dbProcessIdTable d)), a == actU] of
+            (i : _) -> Just (dbActivities d V.! i)
+            [] -> Nothing
+
+-- ---------------------------------------------------------------------------
+-- Spec
+-- ---------------------------------------------------------------------------
+
+spec :: Spec
+spec = describe "ILCD.Writer round-trip" $ do
+    it "(pure) formatDouble round-trips integral and fractional values" $ do
+        formatDouble 1.0 `shouldBe` "1"
+        formatDouble 2.5 `shouldBe` "2.5"
+        formatDouble 0.001 `shouldBe` "1.0e-3"
+        formatDouble (-3.0) `shouldBe` "-3"
+
+    it "(pure) escapeXml escapes the predefined entities" $ do
+        escapeXml "a & b < c > d" `shouldBe` "a &amp; b &lt; c &gt; d"
+        escapeXml "plain" `shouldBe` "plain"
+
+    it "emits one process file per activity" $ do
+        db <- loadFixture
+        let procFiles = [p | (p, _) <- ilcdFiles defaultWriteOptions db, "processes/" `isPrefixOfFp` p]
+        length procFiles `shouldBe` M.size (sdbActivities db)
+
+    it "produces a parseable ILCD tree with the same activity count" $ do
+        db <- loadFixture
+        db' <- roundTrip db
+        M.size (sdbActivities db') `shouldBe` M.size (sdbActivities db)
+
+    it "(a) is idempotent modulo volatile metadata" $ do
+        db <- loadFixture
+        let f0 = ilcdFiles defaultWriteOptions db
+        db' <- roundTrip db
+        let f1 = ilcdFiles defaultWriteOptions db'
+        f1 `shouldBe` f0
+
+    it "(b) semantic round-trip: activities are structurally equal" $ do
+        db <- loadFixture
+        db' <- roundTrip db
+        activityShapes db' `shouldBe` activityShapes db
+
+    it "(b) semantic round-trip: the flow catalog is structurally equal" $ do
+        db <- loadFixture
+        db' <- roundTrip db
+        flowShapes db' `shouldBe` flowShapes db
+
+    it "(c) score-equivalence: same inventory for the sample activity within tolerance" $ do
+        db <- loadFixture
+        db' <- roundTrip db
+        invOrig <- inventoryByName db "Coal extraction"
+        invRound <- inventoryByName db' "Coal extraction"
+        M.keysSet invRound `shouldBe` M.keysSet invOrig
+        let diffs =
+                [ abs (a - b)
+                | (k, a) <- M.toList invOrig
+                , let b = M.findWithDefault 0 k invRound
+                ]
+        all (< 1e-9) diffs `shouldBe` True
+
+isPrefixOfFp :: String -> FilePath -> Bool
+isPrefixOfFp = isPrefixOf

--- a/test/ILCDWriterSpec.hs
+++ b/test/ILCDWriterSpec.hs
@@ -23,15 +23,18 @@ Three properties are pinned, exactly as for the SimaPro/Brightway writers:
 -}
 module ILCDWriterSpec (spec) where
 
+import Data.Either (isLeft)
 import Data.List (isPrefixOf, sort)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import Database (buildDatabaseWithMatrices)
 import ILCD.Parser (parseILCDDirectory)
 import ILCD.Writer (
+    checkILCDExportable,
     defaultWriteOptions,
     escapeXml,
     formatDouble,
@@ -216,6 +219,16 @@ spec = describe "ILCD.Writer round-trip" $ do
         let procFiles = [p | (p, _) <- ilcdFiles defaultWriteOptions db, "processes/" `isPrefixOfFp` p]
         length procFiles `shouldBe` M.size (sdbActivities db)
 
+    describe "checkILCDExportable (multi-output guard)" $ do
+        it "accepts a single-output database" $ do
+            db <- loadFixture
+            checkILCDExportable db `shouldBe` Right ()
+
+        it "rejects a multi-output activity rather than silently dropping a product" $
+            -- Two reference products share one activity UUID, so both would write
+            -- to the same processes/<actUUID>.xml. The guard must fail loudly.
+            checkILCDExportable multiOutputDb `shouldSatisfy` isLeft
+
     it "produces a parseable ILCD tree with the same activity count" $ do
         db <- loadFixture
         db' <- roundTrip db
@@ -253,3 +266,53 @@ spec = describe "ILCD.Writer round-trip" $ do
 
 isPrefixOfFp :: String -> FilePath -> Bool
 isPrefixOfFp = isPrefixOf
+
+-- ---------------------------------------------------------------------------
+-- Multi-output fixture (two products sharing one activity UUID)
+-- ---------------------------------------------------------------------------
+
+{- | A degenerate database where one activity UUID exposes two reference
+products — the shape an ES2/SimaPro multi-output activity takes internally.
+ILCD cannot represent it (one process per UUID), so 'checkILCDExportable'
+rejects it.
+-}
+multiOutputDb :: SimpleDatabase
+multiOutputDb =
+    SimpleDatabase
+        { sdbActivities =
+            M.fromList
+                [ ((actU, prodA), prodAct "co-product A" prodA)
+                , ((actU, prodB), prodAct "co-product B" prodB)
+                ]
+        , sdbTechFlows =
+            M.fromList
+                [ (prodA, techFlow prodA "product A")
+                , (prodB, techFlow prodB "product B")
+                ]
+        , sdbBioFlows = M.empty
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton unitU (Unit unitU "kg" "kg" "")
+        }
+  where
+    actU, prodA, prodB, unitU :: UUID
+    actU = read "aaaaaaaa-0000-4000-8000-000000000001"
+    prodA = read "aaaaaaaa-0000-4000-8000-0000000000a1"
+    prodB = read "aaaaaaaa-0000-4000-8000-0000000000b2"
+    unitU = read "11111111-0000-4000-8000-000000000001"
+    techFlow :: UUID -> Text -> TechnosphereFlow
+    techFlow fid nm = TechnosphereFlow fid nm unitU M.empty Nothing Nothing
+    prodAct :: Text -> UUID -> Activity
+    prodAct nm prod =
+        Activity
+            nm
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "kg"
+            [TechnosphereExchange prod 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            Nothing

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -12,6 +12,7 @@ import Test.Hspec
 import Database.Loader
 import TestHelpers (loadSampleDatabase)
 import Types
+import UnitConversion (defaultUnitConfig)
 
 -- ---------------------------------------------------------------------------
 -- Minimal fixtures
@@ -206,8 +207,9 @@ spec = do
                         [refExchange flowUUID1]
                 acts = M.fromList [((actUUID1, flowUUID1), act)]
                 flows = M.fromList [(flowUUID1, minimalFlow flowUUID1 "Wheat Production")]
-                idx = buildSupplierIndexByName acts flows
-            M.lookup "wheat production" idx `shouldBe` Just (actUUID1, flowUUID1)
+                idx = buildSupplierIndexByName M.empty acts flows
+            -- empty UnitDB → reference unit resolves to the "unknown" sentinel
+            M.lookup "wheat production" idx `shouldBe` Just (actUUID1, flowUUID1, "unknown")
 
         it "does not index non-reference exchanges" $ do
             let act =
@@ -217,7 +219,7 @@ spec = do
                         [inputExchange flowUUID1 "GLO"]
                 acts = M.fromList [((actUUID1, flowUUID1), act)]
                 flows = M.fromList [(flowUUID1, minimalFlow flowUUID1 "Wheat")]
-                idx = buildSupplierIndexByName acts flows
+                idx = buildSupplierIndexByName M.empty acts flows
             M.null idx `shouldBe` True
 
     -- -----------------------------------------------------------------------
@@ -226,9 +228,9 @@ spec = do
     describe "fixExchangeLinkByName" $ do
         it "resolves input exchange when supplier in index" $ do
             let flows = M.fromList [(flowUUID1, minimalFlow flowUUID1 "wheat")]
-                idx = M.fromList [("wheat", (actUUID1, flowUUID2))]
+                idx = M.fromList [("wheat", (actUUID1, flowUUID2, ""))]
                 ex = inputExchange flowUUID1 "GLO"
-                (fixed, summary) = fixExchangeLinkByName idx flows "consumer" ex
+                (fixed, summary) = fixExchangeLinkByName defaultUnitConfig M.empty idx flows "consumer" ex
             techActivityLinkId fixed `shouldBe` actUUID1
             usFoundLinks summary `shouldBe` 1
             usMissingLinks summary `shouldBe` 0
@@ -237,7 +239,7 @@ spec = do
             let flows = M.fromList [(flowUUID1, minimalFlow flowUUID1 "wheat")]
                 idx = M.empty
                 ex = inputExchange flowUUID1 "GLO"
-                (fixed, summary) = fixExchangeLinkByName idx flows "consumer" ex
+                (fixed, summary) = fixExchangeLinkByName defaultUnitConfig M.empty idx flows "consumer" ex
             techActivityLinkId fixed `shouldBe` UUID.nil
             usMissingLinks summary `shouldBe` 1
 
@@ -245,15 +247,15 @@ spec = do
             let flows = M.empty
                 idx = M.empty
                 ex = inputExchange flowUUID1 "GLO"
-                (fixed, summary) = fixExchangeLinkByName idx flows "consumer" ex
+                (fixed, summary) = fixExchangeLinkByName defaultUnitConfig M.empty idx flows "consumer" ex
             techActivityLinkId fixed `shouldBe` UUID.nil
             usMissingLinks summary `shouldBe` 1
 
         it "does not touch output reference exchanges" $ do
             let flows = M.fromList [(flowUUID1, minimalFlow flowUUID1 "wheat")]
-                idx = M.fromList [("wheat", (actUUID1, flowUUID2))]
+                idx = M.fromList [("wheat", (actUUID1, flowUUID2, ""))]
                 ex = refExchange flowUUID1
-                (fixed, summary) = fixExchangeLinkByName idx flows "producer" ex
+                (fixed, summary) = fixExchangeLinkByName defaultUnitConfig M.empty idx flows "producer" ex
             techActivityLinkId fixed `shouldBe` UUID.nil -- unchanged
             usTotalLinks summary `shouldBe` 0 -- not counted
         it "does not touch biosphere exchanges" $ do
@@ -269,10 +271,42 @@ spec = do
                         , bioComment = Nothing
                         , bioPedigree = Nothing
                         }
-                (fixed, summary) = fixExchangeLinkByName idx flows "act" bioEx
+                (fixed, summary) = fixExchangeLinkByName defaultUnitConfig M.empty idx flows "act" bioEx
             -- BiosphereExchange is returned unchanged: verify it is still biosphere
             isBiosphereExchange fixed `shouldBe` True
             usTotalLinks summary `shouldBe` 0
+
+        -- Regression: a candidate whose reference-product unit is in a different
+        -- dimension than the consumer exchange must NOT be linked — the matrix
+        -- builder could not convert it, and forming the link aborts the whole
+        -- load. (This is what 'delete then re-export' surfaced on real data: a
+        -- piece-counted input fuzzy-matched a mass-counted survivor.)
+        it "rejects a dimensionally-incompatible candidate (count input vs mass supplier)" $ do
+            let unitItemUUID = read "dddddddd-0000-0000-0000-00000000000a" :: UUID.UUID
+                unitKgUUID = read "dddddddd-0000-0000-0000-00000000000b" :: UUID.UUID
+                unitDB =
+                    M.fromList
+                        [ (unitItemUUID, Unit unitItemUUID "item" "item" "")
+                        , (unitKgUUID, Unit unitKgUUID "kg" "kg" "")
+                        ]
+                flows = M.fromList [(flowUUID1, minimalFlow flowUUID1 "pump")]
+                -- supplier indexed with a mass (kg) reference unit
+                idx = M.fromList [("pump", (actUUID1, flowUUID2, "kg"))]
+                -- consumer wants the pump by the piece (item)
+                ex = (inputExchange flowUUID1 "GLO"){techUnitId = unitItemUUID}
+                (fixed, summary) = fixExchangeLinkByName defaultUnitConfig unitDB idx flows "consumer" ex
+            techActivityLinkId fixed `shouldBe` UUID.nil
+            usMissingLinks summary `shouldBe` 1
+
+        it "links a dimensionally-compatible candidate (mass input vs mass supplier)" $ do
+            let unitKgUUID = read "dddddddd-0000-0000-0000-00000000000b" :: UUID.UUID
+                unitDB = M.fromList [(unitKgUUID, Unit unitKgUUID "kg" "kg" "")]
+                flows = M.fromList [(flowUUID1, minimalFlow flowUUID1 "pump")]
+                idx = M.fromList [("pump", (actUUID1, flowUUID2, "kg"))]
+                ex = (inputExchange flowUUID1 "GLO"){techUnitId = unitKgUUID}
+                (fixed, summary) = fixExchangeLinkByName defaultUnitConfig unitDB idx flows "consumer" ex
+            techActivityLinkId fixed `shouldBe` actUUID1
+            usFoundLinks summary `shouldBe` 1
 
     -- -----------------------------------------------------------------------
     -- countTotalTechInputs / countUnlinkedExchanges / collectUnlinkedProductNames

--- a/test/RelinkMappingSpec.hs
+++ b/test/RelinkMappingSpec.hs
@@ -1,0 +1,183 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Relink-with-mapping tests.
+
+A small target ("BAFU") database is indexed as a cross-DB supplier. A consumer
+input flow whose name only matches the target *via* an alias from the mapping
+CSV must link once the alias map is threaded into the 'LinkingContext'; without
+it the same lookup yields 'NoNameMatch'. Unit incompatibility surfaces as an
+error rather than being silently dropped, and the post-link score matches the
+expected name+location total.
+-}
+module RelinkMappingSpec (spec) where
+
+import qualified Data.ByteString.Lazy.Char8 as BLC
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.UUID as UUID
+import Test.Hspec
+
+import Database.CrossLinking (
+    CrossDBLinkResult (..),
+    IndexedDatabase,
+    LinkingContext (..),
+    buildIndexedDatabase,
+    defaultLinkingThreshold,
+    findSupplierInIndexedDBs,
+    locationHierarchy,
+ )
+import Database.RelinkMapping (
+    AliasRow (..),
+    buildAliasMap,
+    parseAliasCSV,
+ )
+import SynonymDB (emptySynonymDB)
+import Types (
+    Activity (..),
+    Exchange (..),
+    GeographyPolicy (..),
+    LinkBlocker (..),
+    SimpleDatabase (..),
+    TechRole (..),
+    TechnosphereFlow (..),
+ )
+import UnitConversion (defaultUnitConfig)
+
+-- ---------------------------------------------------------------------------
+-- Target ("BAFU") fixture: one activity, "wheat production" @ FR, in kg.
+-- ---------------------------------------------------------------------------
+
+targetIndexed :: IndexedDatabase
+targetIndexed = buildIndexedDatabase "BAFU" emptySynonymDB targetDB
+
+targetDB :: SimpleDatabase
+targetDB =
+    let flowUUID = read "aaaaaaaa-0000-0000-0000-000000000001"
+        actUUID = read "cccccccc-0000-0000-0000-000000000001"
+        ex =
+            TechnosphereExchange
+                { techFlowId = flowUUID
+                , techAmount = 1.0
+                , techUnitId = UUID.nil
+                , techRole = ReferenceProduct
+                , techActivityLinkId = UUID.nil
+                , techProcessLinkId = Nothing
+                , techLocation = ""
+                , techComment = Nothing
+                , techPedigree = Nothing
+                }
+        act =
+            Activity
+                { activityName = "wheat production"
+                , activityDescription = []
+                , activitySynonyms = M.empty
+                , activityClassification = M.empty
+                , activityLocation = "FR"
+                , activityUnit = "kg"
+                , exchanges = [ex]
+                , activityParams = M.empty
+                , activityParamExprs = M.empty
+                , activityAllocationPercent = Nothing
+                , activityAllocationFormula = Nothing
+                , activityNativeType = Nothing
+                }
+        flow =
+            TechnosphereFlow
+                { tfId = flowUUID
+                , tfName = "wheat production"
+                , tfUnitId = UUID.nil
+                , tfSynonyms = M.empty
+                , tfCAS = Nothing
+                , tfSubstanceId = Nothing
+                }
+     in SimpleDatabase
+            { sdbActivities = M.singleton (actUUID, flowUUID) act
+            , sdbTechFlows = M.singleton flowUUID flow
+            , sdbBioFlows = M.empty
+            , sdbWasteFlows = M.empty
+            , sdbUnits = M.empty
+            }
+
+-- | Linking context against the target, with an optional alias map.
+mkCtx :: Maybe (M.Map Text Text) -> LinkingContext
+mkCtx aliases =
+    LinkingContext
+        { lcIndexedDatabases = [targetIndexed]
+        , lcSynonymDB = emptySynonymDB
+        , lcUnitConfig = defaultUnitConfig
+        , lcThreshold = defaultLinkingThreshold
+        , lcLocationHierarchy = locationHierarchy
+        , lcGeographyPolicy = GeoGlobal
+        , lcSupplierAliases = aliases
+        }
+
+-- | The consumer's Ecoinvent-style name that only resolves via the alias.
+consumerName :: Text
+consumerName = "wheat, ecoinvent name"
+
+aliasMap :: M.Map Text Text
+aliasMap = M.singleton consumerName "wheat production"
+
+-- ---------------------------------------------------------------------------
+
+spec :: Spec
+spec = do
+    describe "alias CSV loading" $ do
+        it "parses source/target columns and builds the map" $ do
+            -- The source name contains a comma, so it must be CSV-quoted.
+            let csv = BLC.pack "source,target\n\"wheat, ecoinvent name\",wheat production\n"
+            rows <- either (fail . show) pure (parseAliasCSV csv)
+            map arSource rows `shouldBe` [consumerName]
+            map arTarget rows `shouldBe` ["wheat production"]
+            buildAliasMap rows `shouldBe` Right aliasMap
+
+        it "accepts the from/to column synonyms and optional locations" $ do
+            let csv = BLC.pack "from,to,source_location\na,b,FR\n"
+            rows <- either (fail . show) pure (parseAliasCSV csv)
+            map arSourceLocation rows `shouldBe` [Just "FR"]
+            buildAliasMap rows `shouldBe` Right (M.singleton "a" "b")
+
+        it "rejects a conflicting alias for the same source" $ do
+            let rows =
+                    [ AliasRow "x" "y" Nothing Nothing
+                    , AliasRow "x" "z" Nothing Nothing
+                    ]
+            buildAliasMap rows `shouldSatisfy` either (const True) (const False)
+
+        it "fails when a required column is missing" $ do
+            let csv = BLC.pack "source\nfoo\n"
+            parseAliasCSV csv `shouldSatisfy` either (const True) (const False)
+
+    describe "findSupplierInIndexedDBs with supplier aliases" $ do
+        it "does NOT link the aliased consumer name without the alias map" $
+            case findSupplierInIndexedDBs (mkCtx Nothing) consumerName "FR" "kg" of
+                CrossDBNotLinked NoNameMatch -> pure ()
+                CrossDBNotLinked other -> expectationFailure $ "Expected NoNameMatch, got: " ++ show other
+                CrossDBLinked{} -> expectationFailure "Expected no link without alias map"
+
+        it "links the aliased consumer name to the target via the alias map" $
+            case findSupplierInIndexedDBs (mkCtx (Just aliasMap)) consumerName "FR" "kg" of
+                CrossDBLinked{cdlrProductName = name, cdlrDatabaseName = db} -> do
+                    name `shouldBe` "wheat production"
+                    db `shouldBe` "BAFU"
+                CrossDBNotLinked reason -> expectationFailure $ "Expected link, got: " ++ show reason
+
+        it "scores name(50) + exact-location(30) = 80 for an FR→FR alias link" $
+            case findSupplierInIndexedDBs (mkCtx (Just aliasMap)) consumerName "FR" "kg" of
+                CrossDBLinked{cdlrScore = score} -> score `shouldBe` 80
+                CrossDBNotLinked reason -> expectationFailure $ "Expected link, got: " ++ show reason
+
+        it "surfaces a unit mismatch as UnitIncompatible, never a silent drop" $
+            case findSupplierInIndexedDBs (mkCtx (Just aliasMap)) consumerName "FR" "m3" of
+                CrossDBNotLinked (UnitIncompatible req got) -> do
+                    req `shouldBe` "m3"
+                    got `shouldBe` "kg"
+                CrossDBNotLinked other -> expectationFailure $ "Expected UnitIncompatible, got: " ++ show other
+                CrossDBLinked{} -> expectationFailure "Expected unit mismatch to block the link"
+
+        it "still prefers a direct name match over the alias map" $
+            -- The target's own canonical name resolves directly; the alias is
+            -- only a last-resort retry, so a direct lookup must not depend on it.
+            case findSupplierInIndexedDBs (mkCtx (Just aliasMap)) "wheat production" "FR" "kg" of
+                CrossDBLinked{cdlrScore = score} -> score `shouldBe` 80
+                CrossDBNotLinked reason -> expectationFailure $ "Expected direct link, got: " ++ show reason

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -112,6 +112,39 @@ fixtureCSV =
         , "End"
         ]
 
+-- | A single process with one reference product and one coproduct (in the
+-- @Avoided products@ section, which the parser reads back as a 'Coproduct').
+coproductCSV :: BS.ByteString
+coproductCSV =
+    BS.intercalate
+        "\r\n"
+        [ "{SimaPro 9.6.0.1}"
+        , "{CSV separator: Semicolon}"
+        , "{Decimal separator: .}"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , "Margarine production"
+        , ""
+        , "Type"
+        , "Unit process"
+        , ""
+        , "Geography"
+        , "FR"
+        , ""
+        , "Products"
+        , "Margarine;kg;1;100;not defined;material;"
+        , ""
+        , "Avoided products"
+        , "Butter;kg;0.3;100;not defined;material;"
+        , ""
+        , "End"
+        ]
+
 -- | Parse a SimaPro CSV blob through a temp file.
 parseBytes :: BS.ByteString -> IO ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB)
 parseBytes bytes = withSystemTempFile "writer-spec.csv" $ \path h -> do
@@ -299,3 +332,18 @@ spec = describe "SimaPro.Writer round-trip" $ do
                 , let b = M.findWithDefault 0 k invRound
                 ]
         all (< 1e-9) diffs `shouldBe` True
+
+    it "(regression) routes coproducts to Avoided products, not Products" $ do
+        original <- parseBytes coproductCSV
+        let f0 = serializeSimaProCSV defaultWriterConfig (toSimple original)
+        reparsed <- parseBytes f0
+        let acts0 = activitiesOf original
+            acts1 = activitiesOf reparsed
+            roles = [techRole e | a <- acts1, e@TechnosphereExchange{} <- exchanges a]
+        -- A coproduct written to "Products" would re-parse into a second
+        -- reference-product activity; routing it to "Avoided products" keeps the
+        -- activity count stable and preserves the Coproduct role.
+        length acts1 `shouldBe` length acts0
+        (Coproduct `elem` roles) `shouldBe` True
+  where
+    activitiesOf (acts, _, _, _, _) = acts

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -1,0 +1,301 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Round-trip contract for "SimaPro.Writer", the inverse of
+"SimaPro.Parser".
+
+The original database @D@ is built by parsing a small in-line SimaPro CSV with
+'parseSimaProCSV'. That guarantees @D@ already lives in the parser's canonical
+internal form (canonical units, resolved amounts, generated UUIDs), so the
+write→parse cycle has a fair fixed point to land on.
+
+Three properties are pinned:
+
+  (a) idempotence modulo volatile metadata — @write(D)@ then
+      @write(parse(write(D)))@ produce byte-identical output (the version
+      banner is the only volatile field and it is pinned by 'WriterConfig');
+
+  (b) semantic round-trip — @parse(write(D))@ is structurally equal to @D@,
+      order-insensitively, on activities, flows and units;
+
+  (c) score-equivalence — @parse(write(D))@ yields the same biosphere
+      inventory (the LCIA-precursor vector) as @D@ within tolerance, via the
+      engine's 'computeInventoryMatrix'.
+-}
+module SimaProWriterSpec (spec) where
+
+import qualified Data.ByteString as BS
+import Data.List (sort)
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import Database (buildDatabaseWithMatrices)
+import Matrix (computeInventoryMatrix)
+import SimaPro.Parser (parseSimaProCSV)
+import SimaPro.Writer (
+    defaultWriterConfig,
+    escapeField,
+    formatAmount,
+    serializeSimaProCSV,
+ )
+import System.IO (hClose)
+import System.IO.Temp (withSystemTempFile)
+import Test.Hspec
+import Types
+import UnitConversion (defaultUnitConfig)
+
+-- ---------------------------------------------------------------------------
+-- Fixture: a small SimaPro CSV exercising every section the writer emits
+-- ---------------------------------------------------------------------------
+
+fixtureCSV :: BS.ByteString
+fixtureCSV =
+    BS.intercalate
+        "\r\n"
+        [ "{SimaPro 9.6.0.1}"
+        , "{CSV separator: Semicolon}"
+        , "{Decimal separator: .}"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , "Butter production"
+        , ""
+        , "Type"
+        , "Unit process"
+        , ""
+        , "Geography"
+        , "FR"
+        , ""
+        , "Products"
+        , "Butter;kg;1;100;not defined;material;"
+        , ""
+        , "Materials/fuels"
+        , "Cow milk;kg;20.53;Undefined;0;0;ingredient"
+        , ""
+        , "Resources"
+        , "Water, river;in water;m3;0.1;Undefined;0;0;"
+        , ""
+        , "Emissions to air"
+        , "Carbon dioxide, fossil;high. pop.;kg;0.5;Undefined;0;0;"
+        , ""
+        , "Emissions to water"
+        , "Phosphate;river;kg;0.01;Undefined;0;0;"
+        , ""
+        , "End"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , "Cow milk supply"
+        , ""
+        , "Type"
+        , "Unit process"
+        , ""
+        , "Geography"
+        , "FR"
+        , ""
+        , "Products"
+        , "Cow milk;kg;1;100;not defined;material;"
+        , ""
+        , "Emissions to air"
+        , "Methane, fossil;high. pop.;kg;0.02;Undefined;0;0;"
+        , ""
+        , "End"
+        ]
+
+-- | Parse a SimaPro CSV blob through a temp file.
+parseBytes :: BS.ByteString -> IO ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB)
+parseBytes bytes = withSystemTempFile "writer-spec.csv" $ \path h -> do
+    BS.hPut h bytes
+    hClose h
+    parseSimaProCSV defaultUnitConfig path
+
+-- | Wrap parser output in a 'SimpleDatabase' keyed by generated UUIDs.
+toSimple :: ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB) -> SimpleDatabase
+toSimple (acts, tech, bio, waste, units) =
+    SimpleDatabase
+        { sdbActivities = M.fromList [(activityKey a, a) | a <- acts]
+        , sdbTechFlows = tech
+        , sdbBioFlows = bio
+        , sdbWasteFlows = waste
+        , sdbUnits = units
+        }
+
+{- | Stable key for an activity: its reference product flow UUID paired with a
+synthetic activity UUID derived from name+location. The parser does not hand
+back the (UUID,UUID) keys directly, so we mint a deterministic pair from
+fields we control; this only needs to be injective across the fixture.
+-}
+activityKey :: Activity -> (UUID, UUID)
+activityKey a =
+    case [exchangeFlowId ex | ex <- exchanges a, exchangeIsReference ex] of
+        (prod : _) -> (prod, prod)
+        [] -> (UUID.nil, UUID.nil)
+
+-- Re-export of nil without importing the whole module qualifier dance.
+-- (Types re-exports UUID; nil lives in Data.UUID.)
+
+-- ---------------------------------------------------------------------------
+-- Structural comparison helpers (order-insensitive)
+-- ---------------------------------------------------------------------------
+
+-- | Normalised, order-insensitive view of an activity for structural equality.
+activityShape :: TechFlowDB -> BioFlowDB -> WasteFlowDB -> UnitDB -> Activity -> ActivityShape
+activityShape tech bio waste units a =
+    ActivityShape
+        { asName = activityName a
+        , asLocation = activityLocation a
+        , asUnit = activityUnit a
+        , asExchanges = sort (map (exchangeShape tech bio waste units) (exchanges a))
+        }
+
+data ActivityShape = ActivityShape
+    { asName :: Text
+    , asLocation :: Text
+    , asUnit :: Text
+    , asExchanges :: [ExchangeShape]
+    }
+    deriving (Eq, Ord, Show)
+
+-- | (kind, flow-name, unit-name, rounded-amount, is-input, is-reference)
+data ExchangeShape = ExchangeShape
+    { esKind :: Text
+    , esFlow :: Text
+    , esUnit :: Text
+    , esAmount :: Double
+    , esInput :: Bool
+    , esRef :: Bool
+    }
+    deriving (Eq, Ord, Show)
+
+exchangeShape :: TechFlowDB -> BioFlowDB -> WasteFlowDB -> UnitDB -> Exchange -> ExchangeShape
+exchangeShape tech bio waste units ex =
+    let unitNm uid = maybe "" unitName (M.lookup uid units)
+        roundAmt v = fromIntegral (round (v * 1e6) :: Integer) / 1e6 :: Double
+     in case ex of
+            TechnosphereExchange{techFlowId = fid, techAmount = amt, techUnitId = uid} ->
+                ExchangeShape
+                    "tech"
+                    (maybe "?" tfName (M.lookup fid tech))
+                    (unitNm uid)
+                    (roundAmt amt)
+                    (exchangeIsInput ex)
+                    (exchangeIsReference ex)
+            BiosphereExchange{bioFlowId = fid, bioAmount = amt, bioUnitId = uid} ->
+                ExchangeShape
+                    "bio"
+                    (maybe "?" bfName (M.lookup fid bio))
+                    (unitNm uid)
+                    (roundAmt amt)
+                    (exchangeIsInput ex)
+                    (exchangeIsReference ex)
+            WasteExchange{waFlowId = fid, waAmount = amt, waUnitId = uid} ->
+                ExchangeShape
+                    "waste"
+                    (maybe "?" wfName (M.lookup fid waste))
+                    (unitNm uid)
+                    (roundAmt amt)
+                    (exchangeIsInput ex)
+                    (exchangeIsReference ex)
+
+shapeSet :: ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB) -> S.Set ActivityShape
+shapeSet (acts, tech, bio, waste, units) =
+    S.fromList (map (activityShape tech bio waste units) acts)
+
+-- ---------------------------------------------------------------------------
+-- Inventory (score-equivalence) helper
+-- ---------------------------------------------------------------------------
+
+{- | Build a Database from parser output and compute the inventory of the
+activity whose name matches, keyed by biosphere flow NAME (UUIDs are stable
+across the round-trip, but keying by name is robust either way).
+-}
+inventoryByName :: ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB) -> Text -> IO (M.Map Text Double)
+inventoryByName (acts, tech, bio, waste, units) target = do
+    let actMap = M.fromList [(activityKey a, a) | a <- acts]
+    built <- buildDatabaseWithMatrices defaultUnitConfig actMap tech bio waste units
+    case built of
+        Left err -> expectationFailure (T.unpack err) >> pure M.empty
+        Right db -> do
+            let pidFor =
+                    [ pid
+                    | (pid, (actU, _)) <- zip [0 ..] (V.toList (dbProcessIdTable db))
+                    , Just act <- [activityAtUUID db actU]
+                    , activityName act == target
+                    ]
+            case pidFor of
+                (pid : _) -> do
+                    inv <- computeInventoryMatrix db pid
+                    pure (M.mapKeys (flowName db) inv)
+                [] -> expectationFailure ("no activity named " <> T.unpack target) >> pure M.empty
+
+flowName :: Database -> UUID -> Text
+flowName db uid = maybe (T.pack (show uid)) bfName (M.lookup uid (dbBioFlows db))
+
+activityAtUUID :: Database -> UUID -> Maybe Activity
+activityAtUUID db actU =
+    case [i | (i, (a, _)) <- zip [0 ..] (V.toList (dbProcessIdTable db)), a == actU] of
+        (i : _) -> Just (dbActivities db V.! i)
+        [] -> Nothing
+
+-- ---------------------------------------------------------------------------
+-- Spec
+-- ---------------------------------------------------------------------------
+
+spec :: Spec
+spec = describe "SimaPro.Writer round-trip" $ do
+    it "(pure) formatAmount round-trips integral and fractional values" $ do
+        formatAmount 100 `shouldBe` "100"
+        formatAmount 1 `shouldBe` "1"
+        formatAmount 0.5 `shouldBe` "0.5"
+        formatAmount 20.53 `shouldBe` "20.53"
+        formatAmount (-1.5) `shouldBe` "-1.5"
+
+    it "(pure) escapeField quotes only when needed" $ do
+        escapeField "Butter" `shouldBe` "Butter"
+        escapeField "a;b" `shouldBe` "\"a;b\""
+        escapeField "say \"hi\"" `shouldBe` "\"say \"\"hi\"\"\""
+
+    it "produces a parseable CSV with the pinned header" $ do
+        original <- parseBytes fixtureCSV
+        let bytes = serializeSimaProCSV defaultWriterConfig (toSimple original)
+        BS.take 16 bytes `shouldSatisfy` (\b -> "{SimaPro" `BS.isInfixOf` b)
+        reparsed <- parseBytes bytes
+        let (acts, _, _, _, _) = reparsed
+        length acts `shouldBe` 2
+
+    it "(a) is idempotent modulo the volatile version banner" $ do
+        original <- parseBytes fixtureCSV
+        let f0 = serializeSimaProCSV defaultWriterConfig (toSimple original)
+        d' <- parseBytes f0
+        let f1 = serializeSimaProCSV defaultWriterConfig (toSimple d')
+        f1 `shouldBe` f0
+
+    it "(b) semantic round-trip: parse(write(D)) is structurally equal to D" $ do
+        original <- parseBytes fixtureCSV
+        let f0 = serializeSimaProCSV defaultWriterConfig (toSimple original)
+        reparsed <- parseBytes f0
+        shapeSet reparsed `shouldBe` shapeSet original
+
+    it "(c) score-equivalence: same inventory for a sample activity within tolerance" $ do
+        original <- parseBytes fixtureCSV
+        let f0 = serializeSimaProCSV defaultWriterConfig (toSimple original)
+        reparsed <- parseBytes f0
+        invOrig <- inventoryByName original "Butter production"
+        invRound <- inventoryByName reparsed "Butter production"
+        M.keysSet invOrig `shouldBe` M.keysSet invRound
+        let diffs =
+                [ abs (a - b)
+                | (k, a) <- M.toList invOrig
+                , let b = M.findWithDefault 0 k invRound
+                ]
+        all (< 1e-9) diffs `shouldBe` True

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -145,6 +145,32 @@ coproductCSV =
         , "End"
         ]
 
+-- | A process with no @Type@ line, so the parser yields @activityNativeType = Nothing@.
+noTypeCSV :: BS.ByteString
+noTypeCSV =
+    BS.intercalate
+        "\r\n"
+        [ "{SimaPro 9.6.0.1}"
+        , "{CSV separator: Semicolon}"
+        , "{Decimal separator: .}"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , "Untyped process"
+        , ""
+        , "Geography"
+        , "FR"
+        , ""
+        , "Products"
+        , "Thing;kg;1;100;not defined;material;"
+        , ""
+        , "End"
+        ]
+
 -- | Parse a SimaPro CSV blob through a temp file.
 parseBytes :: BS.ByteString -> IO ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB)
 parseBytes bytes = withSystemTempFile "writer-spec.csv" $ \path h -> do
@@ -345,5 +371,13 @@ spec = describe "SimaPro.Writer round-trip" $ do
         -- activity count stable and preserves the Coproduct role.
         length acts1 `shouldBe` length acts0
         (Coproduct `elem` roles) `shouldBe` True
+
+    it "(regression) omits the Type line for an activity with no native type" $ do
+        original <- parseBytes noTypeCSV
+        let f0 = serializeSimaProCSV defaultWriterConfig (toSimple original)
+        reparsed <- parseBytes f0
+        -- No Type line written → re-parse yields Nothing again, not the
+        -- invented "Unit process".
+        map activityNativeType (activitiesOf reparsed) `shouldBe` [Nothing]
   where
     activitiesOf (acts, _, _, _, _) = acts

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -35,6 +35,7 @@ import Database (buildDatabaseWithMatrices)
 import Matrix (computeInventoryMatrix)
 import SimaPro.Parser (parseSimaProCSV)
 import SimaPro.Writer (
+    checkSimaProExportable,
     defaultWriterConfig,
     escapeField,
     formatAmount,
@@ -379,5 +380,56 @@ spec = describe "SimaPro.Writer round-trip" $ do
         -- No Type line written → re-parse yields Nothing again, not the
         -- invented "Unit process".
         map activityNativeType (activitiesOf reparsed) `shouldBe` [Nothing]
+
+    describe "checkSimaProExportable (emission-medium guard)" $ do
+        it "accepts air / water / soil emissions" $
+            checkSimaProExportable (emissionDb (Compartment "air" Nothing))
+                `shouldBe` Right ()
+
+        it "rejects an emission whose medium has no faithful SimaPro section" $
+            -- A "raw" medium would otherwise be silently filed under
+            -- "Emissions to air" and re-parse as air; reject it loudly instead.
+            checkSimaProExportable (emissionDb (Compartment "raw" Nothing))
+                `shouldSatisfy` either (const True) (const False)
   where
     activitiesOf (acts, _, _, _, _) = acts
+
+-- ---------------------------------------------------------------------------
+-- Emission-medium guard fixture
+-- ---------------------------------------------------------------------------
+
+{- | One activity emitting a single biosphere flow whose compartment is @comp@.
+Used to exercise 'checkSimaProExportable': air/water/soil pass, anything else is
+rejected.
+-}
+emissionDb :: Compartment -> SimpleDatabase
+emissionDb comp =
+    SimpleDatabase
+        { sdbActivities = M.singleton (actU, prodU) act
+        , sdbTechFlows = M.singleton prodU (TechnosphereFlow prodU "thing" unitU M.empty Nothing Nothing)
+        , sdbBioFlows = M.singleton bioU (BiosphereFlow bioU "Some emission" unitU M.empty Nothing Nothing (Just comp))
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton unitU (Unit unitU "kg" "kg" "")
+        }
+  where
+    actU, prodU, bioU, unitU :: UUID
+    actU = read "aaaaaaaa-0000-4000-8000-000000000010"
+    prodU = read "aaaaaaaa-0000-4000-8000-0000000000a0"
+    bioU = read "cccccccc-0000-4000-8000-0000000000c0"
+    unitU = read "11111111-0000-4000-8000-000000000001"
+    act =
+        Activity
+            "thing maker"
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "kg"
+            [ TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , BiosphereExchange bioU 0.5 unitU Emission "" Nothing Nothing
+            ]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            Nothing

--- a/test/WasteCrossDBSpec.hs
+++ b/test/WasteCrossDBSpec.hs
@@ -50,6 +50,7 @@ spec = describe "findWasteTreatmentAcrossDatabases" $ do
                 , lcThreshold = defaultLinkingThreshold
                 , lcLocationHierarchy = M.empty
                 , lcGeographyPolicy = GeoExact
+                , lcSupplierAliases = Nothing
                 }
 
         wasteUUID = UUID.fromWords 0xa 0xb 0xc 0xd

--- a/volca.cabal
+++ b/volca.cabal
@@ -43,8 +43,10 @@ library
                      , SharedSolver
                      , Database
                      , Database.Manager
+                     , Database.Edit
                      , Database.Loader
                      , Database.CrossLinking
+                     , Database.RelinkMapping
                      , Database.MatrixBuild
                      , Database.Upload
                      , Database.UploadedDatabase
@@ -81,11 +83,17 @@ library
                      , EcoSpold.Common
                      , EcoSpold.Cutoff
                      , EcoSpold.Parser2
+                     , EcoSpold.Writer2
                      , EcoSpold.Parser1
+                     , EcoSpold.Writer1
                      , SimaPro.Parser
+                     , SimaPro.Writer
                      , BrightwayExcel.Parser
+                     , BrightwayExcel.Writer
                      , Expr
                      , ILCD.Parser
+                     , ILCD.Writer
+                     , Database.Export
                      , Plugin.Types
                      , Plugin.Builtin
                      , Plugin.Bridge
@@ -198,6 +206,7 @@ test-suite lca-tests
   other-modules:       TestHelpers
                      , GoldenData
                      , AutoRelinkSpec
+                     , RelinkMappingSpec
                      , MatrixConstructionSpec
                      , InventorySpec
                      , MatrixExportSpec
@@ -235,7 +244,12 @@ test-suite lca-tests
                      , UploadSizeSpec
                      , ProgressSpec
                      , EcoSpold1Spec
+                     , EcoSpold1WriterSpec
                      , EcoSpold2Spec
+                     , EcoSpold2WriterSpec
+                     , SimaProWriterSpec
+                     , ILCDWriterSpec
+                     , BrightwayExcelWriterSpec
                      , MCPSchemaSpec
                      , BatchImpactsSpec
                      , MCPEnrichSpec
@@ -260,6 +274,8 @@ test-suite lca-tests
                      , NumericEdgesSpec
                      , AggregateSpec
                      , ConfigWriterSpec
+                     , CopySpec
+                     , DeleteSelectionSpec
                      , PropertiesSpec
   build-depends:       base >=4.14 && <5
                      , volca


### PR DESCRIPTION
## What

The engine parsed five inventory formats but could not write any back, and loaded databases were immutable at runtime. This adds the inverse direction (database **writers**) plus in-place **editing** primitives, so a database can be copied, pruned, relinked to a different background, and re-exported.

## Export writers (all five formats)

`Database.Export` dispatches to a canonical, deterministic writer per format — SimaPro CSV, EcoSpold 1, EcoSpold 2, ILCD, Brightway Excel — each the inverse of its parser. Multi-file formats (EcoSpold 2, ILCD) are packaged as a deterministic (epoch-0) zip; formats without a writer fail loudly rather than emit an empty file.

Every writer ships a round-trip spec proving:
- **(a) idempotence modulo volatile metadata** — `write∘parse∘write == write` after pinning/omitting export timestamp & generator (relaxed to logical-cell idempotence for the xlsx zip container);
- **(b) semantic round-trip** — `parse∘write` is structurally equal to the source (order-insensitive);
- **(c) score equivalence** — LCIA scores are unchanged across the round-trip.

## Editing primitives (registry; pure core + CLI + HTTP)

- **copy** — duplicate a loaded database under a new name.
- **delete-by-selection** — remove activities matching a search filter (the whole matching set, independent of pagination) plus explicit keep/extra; rebuilds matrices and orphans dangling links so the result is ready to relink.
- **relink-with-mapping** — relink to a chosen dependency using a `name→name` alias CSV (optional `lcSupplierAliases` on `LinkingContext`).

## Tests

`cabal test lca-tests` → **1214 examples, 0 failures, 1 pending**.

## Follow-ups (non-blocking)
- `Database.Export` has no dedicated spec yet (it is exercised indirectly by each writer's round-trip spec and the CLI/endpoint compile).
- The export HTTP endpoint returns the file base64-encoded in JSON (mirrors the upload convention); a streaming octet-stream download could be added later.


## Review fixes (follow-up commits)
- **Export guards** — ILCD multi-output activities and SimaPro emissions outside air/water/soil now fail loudly at the export boundary (`checkILCDExportable` / `checkSimaProExportable`) instead of silently dropping a process or re-filing the flow as air. New specs cover both.
- **Numeric** — EcoSpold1 / Brightway writers clamp `NaN`/`Infinity` to a parseable value, matching the other writers.
- **Docs** — relink recovery hints now say `POST {}` (the endpoint takes a body); fixed a mis-merged CLI haddock.
