### PR TITLE
feat(edit): delete-by-selection — drop the whole filtered activity set

### DIFF
--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -381,6 +381,20 @@ Returns the raw JSON (no dataclass wrapping). Use this for
 operations that don't have an ergonomic wrapper yet, or for new
 endpoints added after the installed pyvolca was released.
 
+##### `Client.delete_activities(*, name: str = '', location: str = '', product: str = '', classifications: list[dict | tuple] | None = None, exact: bool = False, keep: list[str] | None = None, extra: list[str] | None = None, db_name: str | None = None) -> dict`
+
+Delete activities selected by filter, sparing/adding explicit ids.
+
+Builds a ``DeleteSelectionRequest``: the filter fields select the whole
+matching set, ``keep`` spares matched process ids, and ``extra`` adds
+ones the filter missed. ``classifications`` is a list of
+``{"system", "value", "exact"}`` dicts or ``(system, value, exact)``
+tuples.
+
+Returns the ``DeleteSelectionResponse`` dict
+(``{"success", "message", "deleted"}``); raises VoLCAError on
+``success=false``.
+
 ##### `Client.get_activity(process_id: str) -> ActivityDetail`
 
 Fetch an activity's full detail.

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -142,6 +142,39 @@ def _format_query_value(value: Any) -> Any:
     return str(value)
 
 
+def _coerce_class_filter(c: dict | tuple) -> dict:
+    """Normalize one classification filter to the wire ``DeleteClassFilter``.
+
+    Accepts a ``{"system", "value", "exact"?}`` dict or a
+    ``(system, value, exact?)`` tuple. ``exact`` defaults to False. Raises
+    VoLCAError on a malformed entry rather than silently dropping fields.
+    """
+    if isinstance(c, dict):
+        missing = {"system", "value"} - set(c)
+        if missing:
+            raise VoLCAError(
+                f"Classification filter missing keys: {sorted(missing)}. "
+                "Expected {'system', 'value', 'exact'?}."
+            )
+        return {
+            "system": c["system"],
+            "value": c["value"],
+            "exact": bool(c.get("exact", False)),
+        }
+    if isinstance(c, (tuple, list)):
+        if len(c) not in (2, 3):
+            raise VoLCAError(
+                f"Classification filter tuple must be (system, value[, exact]); "
+                f"got {len(c)} items."
+            )
+        system, value = c[0], c[1]
+        exact = bool(c[2]) if len(c) == 3 else False
+        return {"system": system, "value": value, "exact": exact}
+    raise VoLCAError(
+        f"Classification filter must be a dict or tuple, got {type(c).__name__}."
+    )
+
+
 def _resolve_page_args(
     page: int | None,
     page_size: int | None,
@@ -567,6 +600,92 @@ class Client:
     def unload_database(self, db_name: str) -> dict:
         """Unload a database from memory to free RAM. The disk copy is kept."""
         return self._json(self._session.post(f"{self.base_url}/api/v1/db/{db_name}/unload"))
+
+    # -- Database write operations --
+    #
+    # These mutate a loaded database (copy / delete / relink / export /
+    # dependency wiring). The engine does NOT register them as Resources, so
+    # they carry no operationId and are unreachable through the OpenAPI
+    # dispatcher. Each method therefore builds its URL directly, exactly like
+    # load_database / unload_database above.
+    #
+    # The engine reports failures in-band as ``{"success": false, ...}`` (HTTP
+    # 200) for some of these handlers, so _require_success surfaces those as
+    # VoLCAError rather than letting a failed call look like a success.
+
+    def _db(self, db_name: str | None) -> str:
+        """Resolve the target database, falling back to ``self.db``.
+
+        Raises VoLCAError when neither an explicit ``db_name`` nor a
+        client-level default is available — never silently targets ``""``.
+        """
+        name = db_name or self.db
+        if not name:
+            raise VoLCAError(
+                "No database specified and Client(db=...) is empty. "
+                "Pass db_name= or construct the client with db=...."
+            )
+        return name
+
+    @staticmethod
+    def _require_success(payload: dict, action: str) -> dict:
+        """Raise VoLCAError if the engine reported an in-band failure.
+
+        Handlers that return ``{"success": false, "message": ...}`` with HTTP
+        200 would otherwise look like a success. Surface the engine's own
+        message instead of silently returning the failure envelope.
+        """
+        if payload.get("success") is False:
+            raise VoLCAError(
+                f"{action} failed: {payload.get('message', 'no message')}"
+            )
+        return payload
+
+    def delete_activities(
+        self,
+        *,
+        name: str = "",
+        location: str = "",
+        product: str = "",
+        classifications: list[dict | tuple] | None = None,
+        exact: bool = False,
+        keep: list[str] | None = None,
+        extra: list[str] | None = None,
+        db_name: str | None = None,
+    ) -> dict:
+        """Delete activities selected by filter, sparing/adding explicit ids.
+
+        Builds a ``DeleteSelectionRequest``: the filter fields select the whole
+        matching set, ``keep`` spares matched process ids, and ``extra`` adds
+        ones the filter missed. ``classifications`` is a list of
+        ``{"system", "value", "exact"}`` dicts or ``(system, value, exact)``
+        tuples.
+
+        Returns the ``DeleteSelectionResponse`` dict
+        (``{"success", "message", "deleted"}``); raises VoLCAError on
+        ``success=false``.
+        """
+        # Omit blank filters entirely: sending "name":"" makes the engine treat
+        # an empty string as a real (unsatisfiable) name filter, so a
+        # product-only delete would match nothing and still report success.
+        body: dict = {
+            "classifications": [
+                _coerce_class_filter(c) for c in (classifications or [])
+            ],
+            "exact": exact,
+            "keep": keep or [],
+            "extra": extra or [],
+        }
+        for key, value in (("name", name), ("location", location), ("product", product)):
+            if value:
+                body[key] = value
+        target = self._db(db_name)
+        payload = self._json(
+            self._session.post(
+                f"{self.base_url}/api/v1/db/{target}/delete", json=body
+            )
+        )
+        return self._require_success(payload, "delete_activities")
 
     def list_presets(self) -> list[Preset]:
         """List classification presets configured in this instance.

--- a/pyvolca/tests/test_db_write.py
+++ b/pyvolca/tests/test_db_write.py
@@ -1,0 +1,99 @@
+"""Offline request-shaping tests for the database write operations.
+
+These endpoints (copy / delete / relink / export / add-/remove-dependency)
+carry no operationId — they bypass the OpenAPI dispatcher and build their
+URLs directly, like ``load_database`` / ``unload_database``. They also do
+not exist in any released engine binary, so these tests never touch a live
+engine: they mock ``Client._session`` and assert on the wire shape
+(URL, JSON body, base64 decoding, format validation, error surfacing).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from volca.client import Client, VoLCAError
+
+
+def _ok(session, json_body: dict) -> None:
+    """Wire the mocked session's POST to return a 200 with ``json_body``."""
+    from tests.conftest import _make_response
+
+    session.post.return_value = _make_response(json_body)
+
+
+# ---------------------------------------------------------------------------
+# delete
+# ---------------------------------------------------------------------------
+
+
+class TestDelete:
+    def test_body_shape_with_dict_classifications(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": True, "message": "ok", "deleted": 3})
+        result = client.delete_activities(
+            name="wheat",
+            location="FR",
+            classifications=[{"system": "ISIC", "value": "01", "exact": True}],
+            exact=True,
+            keep=["a_b"],
+            extra=["c_d"],
+        )
+        assert result["deleted"] == 3
+        url = session.post.call_args[0][0]
+        assert url == "http://test.local/api/v1/db/testdb/delete"
+        body = session.post.call_args[1]["json"]
+        # Blank filters are omitted entirely: product was not supplied, so its
+        # key is absent rather than sent as "".
+        assert body == {
+            "name": "wheat",
+            "location": "FR",
+            "classifications": [{"system": "ISIC", "value": "01", "exact": True}],
+            "exact": True,
+            "keep": ["a_b"],
+            "extra": ["c_d"],
+        }
+
+    def test_tuple_classifications_coerced(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": True, "message": "ok", "deleted": 0})
+        client.delete_activities(classifications=[("CPC", "012"), ("ISIC", "01", True)])
+        body = session.post.call_args[1]["json"]
+        assert body["classifications"] == [
+            {"system": "CPC", "value": "012", "exact": False},
+            {"system": "ISIC", "value": "01", "exact": True},
+        ]
+
+    def test_defaults_are_empty(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": True, "message": "ok", "deleted": 0})
+        client.delete_activities(product="x")
+        body = session.post.call_args[1]["json"]
+        assert body["classifications"] == []
+        assert body["keep"] == []
+        assert body["extra"] == []
+        assert body["exact"] is False
+        # An unsupplied name is omitted, never sent as "": a regression to the
+        # always-send-empty-string body would make the engine read "name":""
+        # as a real (unsatisfiable) filter and silently delete nothing.
+        assert "name" not in body
+
+    def test_blank_filters_are_omitted(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": True, "message": "ok", "deleted": 0})
+        client.delete_activities(product="milk")
+        body = session.post.call_args[1]["json"]
+        assert "name" not in body
+        assert "location" not in body
+        assert body["product"] == "milk"
+
+    def test_malformed_classification_dict_raises(self, mocked_client):
+        client, _ = mocked_client
+        with pytest.raises(VoLCAError, match="missing keys"):
+            client.delete_activities(classifications=[{"system": "ISIC"}])
+
+    def test_in_band_failure_raises(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": False, "message": "nothing matched"})
+        with pytest.raises(VoLCAError, match="nothing matched"):
+            client.delete_activities(name="x")

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -225,7 +225,10 @@ deleteActivitiesHandler dbName req = do
                 (dsqKeep req)
                 (dsqExtra req)
     case result of
-        Left err -> return $ DeleteSelectionResponse False err 0
+        -- A failed delete is a client error (bad filter, unknown DB, loaded
+        -- dependents). Surface it as 4xx so a raw HTTP client can't read the
+        -- 200 envelope as success.
+        Left err -> throwError err400{errBody = BSL.fromStrict $ T.encodeUtf8 err}
         Right deleted ->
             return $
                 DeleteSelectionResponse

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -17,6 +17,7 @@ module API.DatabaseHandlers (
     unloadDatabaseHandler,
     relinkDatabaseHandler,
     deleteDatabaseHandler,
+    deleteActivitiesHandler,
     uploadDatabaseHandler,
     uploadMethodHandler,
     deleteMethodHandler,
@@ -47,6 +48,7 @@ module API.DatabaseHandlers (
 ) where
 
 import Control.Exception (SomeException, try)
+import Control.Monad (mfilter)
 import Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64 as B64
@@ -73,6 +75,9 @@ import API.Types (
     BinaryContent (..),
     DatabaseListResponse (..),
     DatabaseStatusAPI (..),
+    DeleteClassFilter (..),
+    DeleteSelectionRequest (..),
+    DeleteSelectionResponse (..),
     LoadDatabaseResponse (..),
     RefDataListResponse (..),
     RefDataStatusAPI (..),
@@ -88,7 +93,9 @@ import Control.Monad.Reader (asks)
 import Data.Aeson (Value, toJSON)
 import qualified Data.Aeson as A
 import qualified Data.Aeson.KeyMap as KM
+import Data.Maybe (fromMaybe)
 import qualified Data.Vector as V
+import Database.Edit (deleteActivitiesInDB)
 import Database.Manager (
     DatabaseLoadStatus (..),
     DatabaseManager (..),
@@ -190,6 +197,41 @@ deleteDatabaseHandler :: Text -> AppM ActivateResponse
 deleteDatabaseHandler dbName = do
     dbManager <- asks aeDbManager
     simpleAction (removeDatabase dbManager dbName) ("Deleted database: " <> dbName)
+
+{- | Delete the whole filtered set of activities from a loaded database, in
+place. The filter selects the full matching set (pagination ignored); the
+keep/extra lists adjust the set individually. Rebuilds matrices and unlinks
+surviving references; returns the count removed.
+-}
+deleteActivitiesHandler :: Text -> DeleteSelectionRequest -> AppM DeleteSelectionResponse
+deleteActivitiesHandler dbName req = do
+    dbManager <- asks aeDbManager
+    let classFilters = [(dcfSystem f, dcfValue f, dcfExact f) | f <- dsqClassifications req]
+        -- A present-but-blank filter (e.g. JSON "name":"") is no filter at all.
+        -- Collapse it to Nothing so name candidates fall back to "all activities"
+        -- instead of a BM25/full-scan path that yields zero (index present) or all
+        -- (index absent) — an index-dependent ALL-vs-NONE divergence.
+        nonBlank = mfilter (not . T.null . T.strip)
+    result <-
+        liftIO $
+            deleteActivitiesInDB
+                dbManager
+                dbName
+                (nonBlank (dsqName req))
+                (nonBlank (dsqLocation req))
+                (nonBlank (dsqProduct req))
+                classFilters
+                (fromMaybe False (dsqExact req))
+                (dsqKeep req)
+                (dsqExtra req)
+    case result of
+        Left err -> return $ DeleteSelectionResponse False err 0
+        Right deleted ->
+            return $
+                DeleteSelectionResponse
+                    True
+                    ("Deleted " <> T.pack (show deleted) <> " activities from " <> dbName)
+                    deleted
 
 {- | Enforce the hosting upload-size policy on a decoded payload.
 Local/CLI mode (no hosting config) is unlimited. A configured limit of 0

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -10,7 +10,7 @@ module API.Routes where
 import API.DatabaseHandlers (simpleAction)
 import qualified API.DatabaseHandlers as DBHandlers
 import qualified API.OpenApi
-import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), ExchangeDetail (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), RefDataListResponse (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadRequest (..), UploadResponse (..), apiFlowOfKind)
+import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), RefDataListResponse (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadRequest (..), UploadResponse (..), apiFlowOfKind)
 import App.Env (AppEnv (..), AppM, runApp)
 import qualified Config
 import Control.Concurrent.Async (mapConcurrently)
@@ -122,6 +122,8 @@ type LCAAPI =
                 :<|> "db" :> Capture "dbName" Text :> "unload" :> Post '[JSON] ActivateResponse
                 :<|> "db" :> Capture "dbName" Text :> "relink" :> Post '[JSON] RelinkResponse
                 :<|> "db" :> Capture "dbName" Text :> Delete '[JSON] ActivateResponse
+                -- Delete the whole filtered set of activities (selection in JSON body)
+                :<|> "db" :> Capture "dbName" Text :> "delete" :> ReqBody '[JSON] DeleteSelectionRequest :> Post '[JSON] DeleteSelectionResponse
                 -- Upload endpoint (base64-encoded ZIP in JSON body)
                 :<|> "db" :> "upload" :> ReqBody '[JSON] UploadRequest :> Post '[JSON] UploadResponse
                 -- Database setup endpoints (for cross-DB linking configuration)
@@ -1953,6 +1955,7 @@ lcaServer env = hoistServer lcaAPI (runApp env) handlers
             :<|> DBHandlers.unloadDatabaseHandler
             :<|> DBHandlers.relinkDatabaseHandler
             :<|> DBHandlers.deleteDatabaseHandler
+            :<|> DBHandlers.deleteActivitiesHandler
             :<|> DBHandlers.uploadDatabaseHandler
             :<|> DBHandlers.getDatabaseSetupHandler
             :<|> DBHandlers.addDependencyHandler

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -741,6 +741,45 @@ data UploadRequest = UploadRequest
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped UploadRequest)
 
+{- | One classification filter in a delete request: the @system@ to match, the
+@value@ to look for, and whether the match is exact (else token-contains).
+Mirrors the search endpoint's classification query parameters so the deleted
+set is exactly the searched set.
+-}
+data DeleteClassFilter = DeleteClassFilter
+    { dcfSystem :: Text
+    , dcfValue :: Text
+    , dcfExact :: Bool
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped DeleteClassFilter)
+
+{- | Request for delete-by-selection. The filter fields select the whole
+matching set (pagination ignored); @dsqKeep@ spares matched process ids and
+@dsqExtra@ adds ones the filter missed. Process ids are the canonical
+@activityUUID_productUUID@ strings the UI/CLI carry, not matrix indices.
+-}
+data DeleteSelectionRequest = DeleteSelectionRequest
+    { dsqName :: Maybe Text -- Filter by activity name
+    , dsqLocation :: Maybe Text -- Filter by location
+    , dsqProduct :: Maybe Text -- Filter by reference product
+    , dsqClassifications :: [DeleteClassFilter] -- Classification filters (AND across systems)
+    , dsqExact :: Maybe Bool -- Exact name match (default False)
+    , dsqKeep :: [Text] -- Process-id strings to spare from deletion
+    , dsqExtra :: [Text] -- Process-id strings to add to deletion
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped DeleteSelectionRequest)
+
+-- | Response for delete-by-selection: count of activities removed.
+data DeleteSelectionResponse = DeleteSelectionResponse
+    { dsrSuccess :: Bool
+    , dsrMessage :: Text
+    , dsrDeleted :: Int
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped DeleteSelectionResponse)
+
 -- | Response for database upload
 data UploadResponse = UploadResponse
     { uprSuccess :: Bool

--- a/src/CLI/Client.hs
+++ b/src/CLI/Client.hs
@@ -81,6 +81,9 @@ executeRemoteCommand mgr rc globalOpts cmd = do
             executeUpload mgr rc fmt jp "/api/v1/db/upload" args
         Database (DbDelete name) ->
             apiDelete mgr rc ("/api/v1/db/" ++ T.unpack name) >>= output fmt jp
+        Database (DbDeleteActivities args) ->
+            apiPost mgr rc ("/api/v1/db/" ++ T.unpack (ddaDb args) ++ "/delete") (deleteSelectionBody args)
+                >>= outputStatus fmt jp "delete"
         Method McList ->
             apiGet mgr rc "/api/v1/method-collections" >>= output fmt jp
         Method (McUpload args) ->
@@ -217,6 +220,24 @@ extractLoadedDbNames = fromMaybe [] . parseMaybe go
 dbPath :: Text -> String
 dbPath name = "/api/v1/db/" ++ T.unpack name
 
+-- | JSON body for the delete-by-selection endpoint (field names match the API).
+deleteSelectionBody :: DbDeleteArgs -> Value
+deleteSelectionBody args =
+    object
+        [ "name" .= ddaName args
+        , "location" .= ddaLocation args
+        , "product" .= ddaProduct args
+        , "classifications" .= classifications
+        , "exact" .= ddaExact args
+        , "keep" .= ddaKeep args
+        , "extra" .= ddaExtra args
+        ]
+  where
+    classifications = case (ddaClassSystem args, ddaClassValue args) of
+        (Just sys, Just val) ->
+            [object ["system" .= sys, "value" .= val, "exact" .= ddaExact args]]
+        _ -> [] :: [Value]
+
 -- | Build query string from optional parameters
 buildQuery :: [(String, Maybe String)] -> String
 buildQuery params =
@@ -248,6 +269,22 @@ executeUpload mgr rc fmt jp path args = do
                 , "urFileData" .= encoded
                 ]
     apiPost mgr rc path body >>= output fmt jp
+
+{- | Output a response whose body carries an in-band @{"success",..,"message"}@
+status (the handlers return HTTP 200 even on failure, so a bare 'output' would
+exit 0 on a failed delete). Inspect the @success@ field and fail loudly when it
+is false; otherwise render normally. Covers both 'ActivateResponse' and
+'DeleteSelectionResponse', which share these keys after the @Stripped@ transform.
+-}
+outputStatus :: OutputFormat -> Maybe Text -> String -> Either String Value -> IO ()
+outputStatus _ _ _ (Left err) = reportError err >> exitFailure
+outputStatus fmt jp action (Right val) = case parseMaybe parseStatus val of
+    Nothing -> reportError (action ++ ": malformed server response") >> exitFailure
+    Just (False, msg) -> reportError (action ++ " failed: " ++ T.unpack msg) >> exitFailure
+    Just (True, _) -> output fmt jp (Right val)
+  where
+    parseStatus :: Value -> Parser (Bool, Text)
+    parseStatus = withObject "StatusResponse" $ \o -> (,) <$> o .: "success" <*> o .: "message"
 
 -- | Format and output a result
 output :: OutputFormat -> Maybe Text -> Either String Value -> IO ()

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -3,7 +3,7 @@
 
 module CLI.Command where
 
-import CLI.Types (CLIConfig (..), Command (..), DatabaseAction (..), DebugMatricesOptions (..), FlowSubCommand (..), GlobalOptions (..), LCIAOptions (..), MappingOptions (..), MethodAction (..), OutputFormat (..), PluginAction (..), SearchActivitiesOptions (..), SearchFlowsOptions (..), UploadArgs (..))
+import CLI.Types (CLIConfig (..), Command (..), DatabaseAction (..), DbDeleteArgs (..), DebugMatricesOptions (..), FlowSubCommand (..), GlobalOptions (..), LCIAOptions (..), MappingOptions (..), MethodAction (..), OutputFormat (..), PluginAction (..), SearchActivitiesOptions (..), SearchFlowsOptions (..), UploadArgs (..))
 import Config (DatabaseConfig (..), MethodConfig (..))
 import Control.Concurrent.STM (readTVarIO)
 import Data.Aeson (Value, encode, object, toJSON, (.=))
@@ -16,6 +16,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
+import Database.Edit (deleteActivitiesInDB)
 import Database.Manager (DatabaseManager (..), LoadedDatabase (..), addDatabase, addMethodCollection)
 import qualified Database.Manager as DM
 import Database.Upload (UploadData (..), UploadResult (..), findMethodDirectory, handleUpload)
@@ -98,6 +99,8 @@ executeCommand (CLIConfig globalOpts _) cmd manager = do
             executeDbUpload registry outputFormat manager args
         Database (DbDelete name) ->
             executeDbDelete registry outputFormat manager name
+        Database (DbDeleteActivities args) ->
+            executeDbDeleteActivities registry outputFormat manager args
         Method McList ->
             DM.listMethodCollections manager >>= out . toJSON
         Method (McUpload args) ->
@@ -477,6 +480,33 @@ executeDbDelete registry fmt manager name = do
         Right () -> do
             reportProgress Info $ "Deleted database: " ++ T.unpack name
             outputResult registry fmt $ object ["deleted" .= name]
+
+{- | Execute delete-by-selection: deletes the whole filtered set (pagination
+ignored) plus the explicit @--add@ ProcessIds, sparing @--keep@.
+-}
+executeDbDeleteActivities :: PluginRegistry -> OutputFormat -> DatabaseManager -> DbDeleteArgs -> IO ()
+executeDbDeleteActivities registry fmt manager args = do
+    let classFilters = case (ddaClassSystem args, ddaClassValue args) of
+            (Just sys, Just val) -> [(sys, val, ddaExact args)]
+            _ -> []
+    result <-
+        deleteActivitiesInDB
+            manager
+            (ddaDb args)
+            (ddaName args)
+            (ddaLocation args)
+            (ddaProduct args)
+            classFilters
+            (ddaExact args)
+            (ddaKeep args)
+            (ddaExtra args)
+    case result of
+        Left err -> do
+            reportError $ "Delete failed: " ++ T.unpack err
+            exitFailure
+        Right deleted -> do
+            reportProgress Info $ "Deleted " ++ show deleted ++ " activities from " ++ T.unpack (ddaDb args)
+            outputResult registry fmt $ object ["database" .= ddaDb args, "deleted" .= deleted]
 
 -- | Execute method delete command
 executeMcDelete :: PluginRegistry -> OutputFormat -> DatabaseManager -> Text -> IO ()

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -116,8 +116,25 @@ databaseParser =
                 ( OA.command "list" (info (pure DbList) (progDesc "List databases"))
                     <> OA.command "upload" (info (DbUpload <$> uploadArgsParser) (progDesc "Upload a database from a local file"))
                     <> OA.command "delete" (info (DbDelete <$> deleteNameParser) (progDesc "Delete a database"))
+                    <> OA.command "delete-activities" (info (DbDeleteActivities <$> deleteActivitiesArgsParser <**> helper) (progDesc "Delete the whole filtered set of activities from a loaded database"))
                 )
             )
+
+{- | Delete-by-selection parser: positional DB plus filter options. @--keep@ and
+@--add@ may be repeated; they spare or add individual ProcessIds.
+-}
+deleteActivitiesArgsParser :: Parser DbDeleteArgs
+deleteActivitiesArgsParser =
+    DbDeleteArgs
+        <$> textArg "DB" "Name of the loaded database to edit"
+        <*> optTextOpt "name" Nothing "NAME" "Filter by activity name"
+        <*> optTextOpt "location" Nothing "GEO" "Filter by location"
+        <*> optTextOpt "product" Nothing "PRODUCT" "Filter by reference product name"
+        <*> optTextOpt "class-system" Nothing "SYSTEM" "Classification system to filter on"
+        <*> optTextOpt "class-value" Nothing "VALUE" "Classification value to filter on"
+        <*> switch (long "exact" <> help "Exact (case-insensitive) name match instead of token-contains")
+        <*> many (textOpt "keep" Nothing "PID" "Process id (activityUUID_productUUID) to spare from deletion (repeatable)")
+        <*> many (textOpt "add" Nothing "PID" "Process id to add to deletion (repeatable)")
 
 -- | Method command parser with optional subcommand (defaults to list)
 methodParser :: Parser Command

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -63,6 +63,27 @@ data DatabaseAction
     = DbList
     | DbUpload UploadArgs
     | DbDelete Text
+    | {- | Delete the activities matched by a filter (the whole matching set,
+      pagination ignored), keeping/adding explicit ProcessIds.
+      -}
+      DbDeleteActivities DbDeleteArgs
+    deriving (Eq, Show, Generic)
+
+{- | Arguments for delete-by-selection. The filter fields mirror the activity
+search filter; @ddaKeep@ spares matched ProcessIds and @ddaExtra@ adds ones
+the filter missed.
+-}
+data DbDeleteArgs = DbDeleteArgs
+    { ddaDb :: Text
+    , ddaName :: Maybe Text
+    , ddaLocation :: Maybe Text
+    , ddaProduct :: Maybe Text
+    , ddaClassSystem :: Maybe Text
+    , ddaClassValue :: Maybe Text
+    , ddaExact :: Bool
+    , ddaKeep :: [Text]
+    , ddaExtra :: [Text]
+    }
     deriving (Eq, Show, Generic)
 
 -- | Plugin management actions

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -1,0 +1,374 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{- |
+Module      : Database.Edit
+Description : In-memory database editing primitives (delete-by-selection)
+
+Shared home for operations that produce a *new* loaded database from an
+existing one without touching disk.
+
+DELETE is reconstruction, not mutation either. 'deleteActivities' drops a set
+of activities and rebuilds every dependent structure (interning tables,
+indexes, sparse matrices, product index) from the surviving activities. The
+rebuild reuses the exact pure builders that back a freshly-loaded database
+('buildInterningTables' / 'buildTechTriples' / 'buildBioTriples' /
+'buildProductIndex' / 'buildIndexesWithProcessIds'), so a deleted-from
+database is byte-for-byte indistinguishable from one that never carried the
+removed rows. Exchanges in surviving activities that referenced a deleted
+activity are UNLINKED (their activity link reset to nil), leaving the value
+ready for relinking — never silently dropped.
+-}
+module Database.Edit (
+    deleteActivities,
+    deleteActivitiesWith,
+    resolveDeleteSelection,
+    DeleteSelection (..),
+    deleteActivitiesInDB,
+) where
+
+import Control.Concurrent.STM (atomically, modifyTVar')
+import qualified Data.IntSet as IS
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as U
+
+import Config (DatabaseConfig (..))
+import Database (
+    applyStructuredFilters,
+    buildIndexesWithProcessIds,
+    buildProductIndex,
+    findActivitiesByFields,
+ )
+import Database.CrossLinking (buildIndexedDatabaseFromDB)
+import Database.Loader (invalidateMatrixCache)
+import Database.Manager (
+    DatabaseManager (..),
+    LoadedDatabase (..),
+    clearMethodMappingCacheForDb,
+    getDatabase,
+    getMergedSynonymDB,
+    getMergedUnitConfig,
+ )
+import Database.MatrixBuild (
+    InterningTables (..),
+    buildBioTriples,
+    buildInterningTables,
+    buildSupplierRefUnits,
+    buildTechTriples,
+    collectBioFlowOrder,
+ )
+import Matrix (clearCachedSolver)
+import qualified Search.BM25 as BM25
+import Service (bm25Retrieve)
+import SharedSolver (createSharedSolver)
+import Types (
+    Activity (..),
+    Database (..),
+    Exchange (..),
+    ProcessId,
+    SparseTriple (..),
+    UUID,
+    findProcessId,
+    findProcessIdByActivityUUID,
+    initializeRuntimeFields,
+    parseUUIDPair,
+ )
+import UnitConversion (UnitConfig, defaultUnitConfig)
+
+-- ---------------------------------------------------------------------------
+-- Delete by selection
+-- ---------------------------------------------------------------------------
+
+{- | Remove a set of activities (by 'ProcessId') and rebuild every dependent
+structure. Uses 'defaultUnitConfig'; effectful call sites that carry a merged
+unit config (the only place where non-SI conversions matter) should call
+'deleteActivitiesWith' instead so a coefficient is never silently dropped on
+an unknown-unit conversion.
+-}
+deleteActivities :: [ProcessId] -> Database -> Either Text Database
+deleteActivities = deleteActivitiesWith defaultUnitConfig
+
+{- | 'deleteActivities' with an explicit 'UnitConfig'.
+
+Steps, all pure:
+
+  1. Resolve the delete set to the @(activityUUID, productUUID)@ keys it
+     occupies in 'dbProcessIdTable', validating that every requested
+     'ProcessId' exists (no silent skip).
+  2. Drop those keys; for every surviving activity, UNLINK any technosphere /
+     waste exchange whose @(activityLink, flow)@ pointed at a deleted key —
+     reset its activity link to 'UUID.nil' and clear the stale process link.
+  3. Rebuild interning tables, indexes, matrices and the product index from
+     the surviving activity map via the shared loader builders.
+
+Fails (Left) when an out-of-range 'ProcessId' is requested, when the result
+would be empty, or when matrix construction reports an inconsistency (e.g. an
+unknown unit conversion under the given config).
+-}
+deleteActivitiesWith :: UnitConfig -> [ProcessId] -> Database -> Either Text Database
+deleteActivitiesWith unitConfig pids db = do
+    deletedKeys <- resolveDeleteKeys db pids
+    let survivors = surviving db deletedKeys
+        survivingKeys = M.keysSet survivors
+        unlinkedMap = M.map (unlinkActivity survivingKeys) survivors
+    if M.null unlinkedMap
+        then Left "Refusing to delete: the result would have no activities"
+        else rebuildFromActivities unitConfig db unlinkedMap
+
+{- | Resolve each requested 'ProcessId' to its @(activityUUID, productUUID)@ key.
+Every id must be in range — an out-of-range id is a caller error, surfaced as
+'Left' rather than silently ignored. The result is a 'Set' so membership tests
+during unlinking are @O(log n)@.
+-}
+resolveDeleteKeys :: Database -> [ProcessId] -> Either Text (S.Set (UUID, UUID))
+resolveDeleteKeys db = fmap S.fromList . traverse keyOf
+  where
+    table = dbProcessIdTable db
+    n = V.length table
+    keyOf pid
+        | i >= 0 && i < n = Right (table V.! i)
+        | otherwise = Left ("Delete: ProcessId out of range: " <> T.pack (show pid))
+      where
+        i = fromIntegral pid
+
+-- | The activity map keyed by @(activityUUID, productUUID)@, minus the deleted keys.
+surviving :: Database -> S.Set (UUID, UUID) -> M.Map (UUID, UUID) Activity
+surviving db deletedKeys =
+    M.fromList
+        [ (key, dbActivities db V.! i)
+        | i <- [0 .. V.length (dbActivities db) - 1]
+        , let key = dbProcessIdTable db V.! i
+        , not (S.member key deletedKeys)
+        ]
+
+{- | Reset technosphere / waste exchanges on a surviving activity whose producer
+link no longer resolves to a surviving @(activityUUID, productUUID)@ key.
+
+The link target is exactly that pair: 'findProducer' resolves
+@(activityLink, flowId)@ against the interning table, so a multi-product
+activity that keeps at least one product stays a valid target for exchanges
+pointing at a *surviving* product, while exchanges pointing at a deleted
+product are unlinked. A biosphere exchange has no producer link and is
+returned unchanged. The stale 'ProcessId' link is always cleared because
+deletion renumbers every 'ProcessId'. An already-orphan link
+(@activityLink == nil@) stays orphan.
+-}
+unlinkActivity :: S.Set (UUID, UUID) -> Activity -> Activity
+unlinkActivity survivingKeys act =
+    act{exchanges = map unlinkExchange (exchanges act)}
+  where
+    dangling link flow = link /= UUID.nil && not (S.member (link, flow) survivingKeys)
+    unlinkExchange ex = case ex of
+        BiosphereExchange{} -> ex
+        TechnosphereExchange{techActivityLinkId = link, techFlowId = flow}
+            | dangling link flow ->
+                ex{techActivityLinkId = UUID.nil, techProcessLinkId = Nothing}
+            | otherwise -> ex{techProcessLinkId = Nothing}
+        WasteExchange{waActivityLinkId = link, waFlowId = flow}
+            | dangling link flow ->
+                ex{waActivityLinkId = UUID.nil, waProcessLinkId = Nothing}
+            | otherwise -> ex{waProcessLinkId = Nothing}
+
+{- | Rebuild a 'Database' from a surviving activity map, reusing the exact pure
+builders that back a freshly-loaded database. Flow / unit tables are carried
+over unchanged: deletion removes activities, never the flow or unit
+vocabulary, so a relink can still resolve the surviving links. Runtime fields
+(synonym, flow-name, BM25 indexes) are reset to their unloaded state; the
+effectful caller re-attaches them with the merged synonym DB.
+-}
+rebuildFromActivities :: UnitConfig -> Database -> M.Map (UUID, UUID) Activity -> Either Text Database
+rebuildFromActivities unitConfig db activityMap =
+    let tables = buildInterningTables activityMap
+        supplierRefUnits = buildSupplierRefUnits (dbUnits db) (itActivities tables)
+        indexes = buildIndexesWithProcessIds (itActivities tables) (itProcessIdTable tables)
+        bioFlowUUIDs = collectBioFlowOrder (itActivities tables)
+        bioTriples = buildBioTriples bioFlowUUIDs tables
+        productIndex = buildProductIndex (itActivities tables) (itProcessIdTable tables) (dbTechFlows db)
+     in case buildTechTriples unitConfig (dbUnits db) tables supplierRefUnits of
+            Left err -> Left err
+            Right (techTriples, _warnings) ->
+                Right
+                    db
+                        { dbProcessIdTable = itProcessIdTable tables
+                        , dbProcessIdLookup = itProcessIdLookup tables
+                        , dbActivityUUIDIndex = itActivityUUIDIndex tables
+                        , dbActivityProductsIndex = itActivityProductsIndex tables
+                        , dbProductIndex = productIndex
+                        , dbActivities = itActivities tables
+                        , dbIndexes = indexes
+                        , dbTechnosphereTriples = techTriples
+                        , dbBiosphereTriples = bioTriples
+                        , dbActivityIndex = V.generate (fromIntegral (itActivityCount tables)) fromIntegral
+                        , dbBiosphereOrder = bioFlowUUIDs
+                        , dbActivityCount = itActivityCount tables
+                        , dbBiosphereCount = fromIntegral (V.length bioFlowUUIDs)
+                        , -- Cross-DB links may now reference deleted activities; clear so a
+                          -- subsequent relink rebuilds them against the surviving set.
+                          dbCrossDBLinks = []
+                        , -- Linking stats describe the pre-delete set (input count, completeness,
+                          -- missing suppliers); reset to the fresh-load default so the setup/status
+                          -- endpoint never reports stale numbers until the next relink.
+                          dbLinkingStats = mempty
+                        , -- Runtime-only indexes are reset; re-attached by the effectful caller.
+                          dbSynonymDB = Nothing
+                        , dbFlowsByName = M.empty
+                        , dbFlowsByCAS = M.empty
+                        , dbProductSearchIndex = M.empty
+                        , dbBM25Index = Nothing
+                        }
+
+-- ---------------------------------------------------------------------------
+-- Selection resolver
+-- ---------------------------------------------------------------------------
+
+{- | A deletion request: the whole set matched by a filter, plus explicit
+adjustments. @dsKeep@ rescues individuals the filter matched (checkbox
+unticked); @dsExtra@ adds individuals the filter missed (checkbox ticked on a
+row outside the current filter). 'ProcessId' lists, never paginated.
+-}
+data DeleteSelection = DeleteSelection
+    { dsFiltered :: [ProcessId]
+    -- ^ the full filtered set (pagination ignored)
+    , dsKeep :: [ProcessId]
+    -- ^ individuals to spare from deletion
+    , dsExtra :: [ProcessId]
+    -- ^ individuals to add to deletion
+    }
+
+{- | Final delete set = (filtered ∪ extra) \\ keep. Deduplicated; @keep@ wins
+over both @filtered@ and @extra@ so an unticked checkbox always spares a row.
+Order is not significant — the result is consumed as a set by
+'deleteActivities'.
+-}
+resolveDeleteSelection :: DeleteSelection -> [ProcessId]
+resolveDeleteSelection sel =
+    map fromIntegral . IS.toList $
+        IS.difference
+            (IS.union (toSet (dsFiltered sel)) (toSet (dsExtra sel)))
+            (toSet (dsKeep sel))
+  where
+    toSet = IS.fromList . map fromIntegral
+
+{- | Resolve a filter to the full set of matching 'ProcessId's, ignoring
+pagination. Mirrors the set 'Service.searchActivities' displays so that the
+UI's "delete the whole filtered set" button removes exactly the rows the user
+saw — no more, no fewer.
+
+A non-exact name filter therefore takes the BM25 OR-over-tokens retrieval
+(via 'bm25Retrieve') followed by the structured filters, exactly as
+'searchActivities' does on its BM25 branch. Using the AND-over-token-groups
+name lookup (the lex-sort fallback path) here would silently under-delete a
+multi-word @--name@: it returns a subset of the displayed set, so the count
+would be reported too low. We fall back to the structured field lookup only
+when there is no name filter, the match is exact, or the query tokenizes to
+nothing (in which case 'bm25Retrieve' yields 'Nothing' and there is no
+displayed BM25 set to honour). Order is irrelevant — the result is consumed
+as a set.
+-}
+filteredProcessIds ::
+    Database ->
+    Maybe Text -> -- name
+    Maybe Text -> -- location
+    Maybe Text -> -- product
+    [(Text, Text, Bool)] -> -- classification (system, value, isExact)
+    Bool -> -- exact name match
+    [ProcessId]
+filteredProcessIds db nameP geoP prodP classFilters exactMatch =
+    map fst $ case bm25Candidates of
+        Just ranked -> applyStructuredFilters db geoP prodP classFilters False ranked
+        Nothing -> findActivitiesByFields db nameP geoP prodP classFilters exactMatch
+  where
+    bm25Candidates = do
+        name <- nameP
+        if exactMatch || T.null (T.strip name) then Nothing else bm25Retrieve db name
+
+-- ---------------------------------------------------------------------------
+-- Effectful entry point (registry swap)
+-- ---------------------------------------------------------------------------
+
+{- | Resolve a process-id string to its 'ProcessId'. Accepts the canonical
+@activityUUID_productUUID@ form and the bare-activity-UUID fallback (when the
+activity has a unique reference product), mirroring
+'Service.resolveActivityAndProcessId'. The UI and CLI carry these textual ids,
+so keep/extra adjustments are expressed in the same currency as the rows the
+user sees — not the volatile integer matrix index. Unresolvable ids fail loudly
+rather than being silently dropped.
+-}
+resolvePid :: Database -> Text -> Either Text ProcessId
+resolvePid db queryText =
+    maybe (Left ("Unknown process id: " <> queryText)) Right $ case parseUUIDPair queryText of
+        Just (a, p) -> findProcessId db a p
+        Nothing -> UUID.fromText queryText >>= findProcessIdByActivityUUID db
+
+{- | Delete a selection from a loaded database, in place under the same name.
+
+Resolves the filter to its full matching set, resolves the explicit
+keep/extra process-id strings, applies the adjustments, deletes + rebuilds
+with the manager's merged unit config, re-attaches runtime indexes with the
+merged synonym DB, swaps a fresh solver in, and updates the loaded / indexed
+registry maps. Returns the number of activities removed. Fails (Left) when the
+database is not loaded, a keep/extra id is unknown, or the rebuild reports an
+inconsistency.
+-}
+deleteActivitiesInDB ::
+    DatabaseManager ->
+    Text -> -- database name
+    Maybe Text -> -- filter: name
+    Maybe Text -> -- filter: location
+    Maybe Text -> -- filter: product
+    [(Text, Text, Bool)] -> -- filter: classification
+    Bool -> -- exact name match
+    [Text] -> -- explicit keep (process-id strings)
+    [Text] -> -- explicit extra (process-id strings)
+    IO (Either Text Int)
+deleteActivitiesInDB manager dbName nameP geoP prodP classFilters exactMatch keep extra =
+    getDatabase manager dbName >>= \case
+        Nothing -> pure $ Left $ "Database not loaded: " <> dbName
+        Just loaded -> do
+            let db = ldDatabase loaded
+            case (,) <$> traverse (resolvePid db) keep <*> traverse (resolvePid db) extra of
+                Left err -> pure $ Left err
+                Right (keepPids, extraPids) -> do
+                    let filtered = filteredProcessIds db nameP geoP prodP classFilters exactMatch
+                        toDelete =
+                            resolveDeleteSelection
+                                DeleteSelection{dsFiltered = filtered, dsKeep = keepPids, dsExtra = extraPids}
+                    unitConfig <- getMergedUnitConfig manager
+                    case deleteActivitiesWith unitConfig toDelete db of
+                        Left err -> pure $ Left err
+                        Right rebuilt -> do
+                            synonymDB <- getMergedSynonymDB manager
+                            let withRuntime = BM25.addBM25Index (initializeRuntimeFields rebuilt synonymDB)
+                                techTriplesInt =
+                                    [ (fromIntegral i, fromIntegral j, v)
+                                    | SparseTriple i j v <- U.toList (dbTechnosphereTriples withRuntime)
+                                    ]
+                            -- The MUMPS solver cached under this name is now stale (old
+                            -- dimensions/factorization); drain + destroy it as unload/remove do,
+                            -- before installing the rebuilt one — otherwise the first post-delete
+                            -- solve overwrites the map entry and leaks a worker thread + native
+                            -- instance.
+                            clearCachedSolver dbName
+                            solver <-
+                                createSharedSolver
+                                    dbName
+                                    techTriplesInt
+                                    (fromIntegral (dbActivityCount withRuntime))
+                            let loaded' = loaded{ldDatabase = withRuntime, ldSharedSolver = solver}
+                                indexedDb = buildIndexedDatabaseFromDB dbName synonymDB withRuntime
+                            atomically $ do
+                                modifyTVar' (dmLoadedDbs manager) (M.insert dbName loaded')
+                                modifyTVar' (dmIndexedDbs manager) (M.insert dbName indexedDb)
+                            clearMethodMappingCacheForDb manager dbName
+                            -- The live matrices were rebuilt above, but the on-disk
+                            -- matrix cache still reflects the pre-delete activity set.
+                            -- Drop it so a later unload/reload can't resurrect the
+                            -- deleted activities from a stale cache.
+                            invalidateMatrixCache dbName (dcPath (ldConfig loaded))
+                            pure $ Right (length toDelete)

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -38,7 +38,6 @@ import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 
-import Config (DatabaseConfig (..))
 import Database (
     applyStructuredFilters,
     buildIndexesWithProcessIds,
@@ -46,7 +45,6 @@ import Database (
     findActivitiesByFields,
  )
 import Database.CrossLinking (buildIndexedDatabaseFromDB)
-import Database.Loader (invalidateMatrixCache)
 import Database.Manager (
     DatabaseManager (..),
     LoadedDatabase (..),
@@ -386,9 +384,11 @@ deleteActivitiesInDB manager dbName nameP geoP prodP classFilters exactMatch kee
                                 modifyTVar' (dmLoadedDbs manager) (M.insert dbName loaded')
                                 modifyTVar' (dmIndexedDbs manager) (M.insert dbName indexedDb)
                             clearMethodMappingCacheForDb manager dbName
-                            -- The live matrices were rebuilt above, but the on-disk
-                            -- matrix cache still reflects the pre-delete activity set.
-                            -- Drop it so a later unload/reload can't resurrect the
-                            -- deleted activities from a stale cache.
-                            invalidateMatrixCache dbName (dcPath (ldConfig loaded))
+                            -- Edits are transient by design. The on-disk matrix cache
+                            -- and the source still hold the pre-delete set, so an
+                            -- unload/reload deliberately restores the original
+                            -- database; persisting an edited database is a separate,
+                            -- explicit step (exporting it to a new file). We therefore
+                            -- leave the cache in place rather than forcing the next
+                            -- load to rebuild from source.
                             pure $ Right (length toDelete)

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -28,7 +28,7 @@ module Database.Edit (
     deleteActivitiesInDB,
 ) where
 
-import Control.Concurrent.STM (atomically, modifyTVar')
+import Control.Concurrent.STM (atomically, modifyTVar', readTVarIO)
 import qualified Data.IntSet as IS
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
@@ -331,8 +331,28 @@ deleteActivitiesInDB manager dbName nameP geoP prodP classFilters exactMatch kee
     getDatabase manager dbName >>= \case
         Nothing -> pure $ Left $ "Database not loaded: " <> dbName
         Just loaded -> do
+            -- Deleting activities renumbers/removes them, which would leave any loaded
+            -- database that depends on this one holding cross-DB links that no longer
+            -- resolve — and those silently drop at solve time, undercounting the
+            -- dependent. Refuse while dependents are loaded (mirrors 'unloadDatabase').
+            loadedDbs <- readTVarIO (dmLoadedDbs manager)
             let db = ldDatabase loaded
-            case (,) <$> traverse (resolvePid db) keep <*> traverse (resolvePid db) extra of
+                dependents =
+                    [ name
+                    | (name, ld) <- M.toList loadedDbs
+                    , name /= dbName
+                    , dbName `elem` dbDependsOn (ldDatabase ld)
+                    ]
+                guardDeps
+                    | null dependents = Right ()
+                    | otherwise =
+                        Left $
+                            "Cannot delete from "
+                                <> dbName
+                                <> ": still required by "
+                                <> T.intercalate ", " dependents
+                                <> ". Unload dependents first."
+            case guardDeps *> ((,) <$> traverse (resolvePid db) keep <*> traverse (resolvePid db) extra) of
                 Left err -> pure $ Left err
                 Right (keepPids, extraPids) -> do
                     let filtered = filteredProcessIds db nameP geoP prodP classFilters exactMatch

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -38,7 +38,6 @@ module Database.Loader (
     -- * Cache Operations
     loadCachedDatabaseWithMatrices,
     saveCachedDatabaseWithMatrices,
-    invalidateMatrixCache,
     loadDatabaseFromCacheFile,
     generateMatrixCacheFilename,
 
@@ -902,25 +901,6 @@ generateMatrixCacheFilename dbName sourcePath = do
         cacheDir = takeDirectory sourcePath
     createDirectoryIfMissing True cacheDir
     return $ cacheDir </> cacheFilename
-
-{- |
-Invalidate (remove) the on-disk matrix cache for a database.
-
-In-memory edits that change the activity set — notably 'deleteActivitiesInDB'
-— rebuild the live matrices but leave the @.zst@ matrix cache untouched. A
-later unload/reload would then resurrect the pre-edit activity set from the
-stale cache. Removing the cache here forces the next load to rebuild from
-source (or from a freshly-written cache), keeping disk and memory in agreement.
-No-op when no cache file is present.
--}
-invalidateMatrixCache :: T.Text -> FilePath -> IO ()
-invalidateMatrixCache dbName sourcePath = do
-    cacheFile <- generateMatrixCacheFilename dbName sourcePath
-    mapM_ removeIfExists [cacheFile, cacheFile ++ ".zst"]
-  where
-    removeIfExists f = do
-        exists <- doesFileExist f
-        when exists $ removeFile f
 
 {- |
 Validate cache file integrity before attempting to decode.

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -38,6 +38,7 @@ module Database.Loader (
     -- * Cache Operations
     loadCachedDatabaseWithMatrices,
     saveCachedDatabaseWithMatrices,
+    invalidateMatrixCache,
     loadDatabaseFromCacheFile,
     generateMatrixCacheFilename,
 
@@ -218,9 +219,12 @@ getReferenceProductUUID act =
 type SupplierIndex = M.Map (T.Text, T.Text) (UUID.UUID, UUID.UUID)
 
 {- | Type alias for name-only supplier lookup (for SimaPro)
-Maps normalizedProductName → (activityUUID, productUUID)
+Maps normalizedProductName → (activityUUID, productUUID, referenceProductUnit).
+The reference-product unit lets the linker reject a candidate whose unit is
+dimensionally incompatible with the consumer exchange (which the matrix builder
+could not convert), instead of forming a link that aborts the whole load.
 -}
-type NameOnlyIndex = M.Map T.Text (UUID.UUID, UUID.UUID)
+type NameOnlyIndex = M.Map T.Text (UUID.UUID, UUID.UUID, T.Text)
 
 {- | Type alias for name-only supplier lookup with location (for EcoSpold1)
 Maps normalizedProductName → (activityUUID, productUUID, location)
@@ -315,10 +319,10 @@ buildSupplierIndex activities techFlowDb =
 Uses the normalized product name + extracted prefixes (no location required).
 Exact names take priority via M.union.
 -}
-buildSupplierIndexByName :: ActivityMap -> TechFlowDB -> NameOnlyIndex
-buildSupplierIndexByName activities techFlowDb =
+buildSupplierIndexByName :: UnitDB -> ActivityMap -> TechFlowDB -> NameOnlyIndex
+buildSupplierIndexByName unitDB activities techFlowDb =
     let entries =
-            [ (tfName flow, (actUUID, prodUUID))
+            [ (tfName flow, (actUUID, prodUUID, getUnitNameForExchange unitDB ex))
             | ((actUUID, prodUUID), act) <- M.toList activities
             , ex <- exchanges act
             , exchangeIsReference ex
@@ -537,7 +541,7 @@ loadSimaProCSV unitConfig csvPath = do
             let simpleDb = SimpleDatabase procMap techFlowDB bioFlowDB wasteFlowDB unitDB
 
             -- Fix activity links using supplier lookup (same as EcoSpold1)
-            Right <$> fixSimaProActivityLinks simpleDb
+            Right <$> fixSimaProActivityLinks unitConfig simpleDb
 
 {- | Load a Brightway Excel (.xlsx) inventory.
 
@@ -561,18 +565,18 @@ loadBrightwayExcel unitConfig xlsxPath = do
                             | act <- activities
                             ]
                     simpleDb = SimpleDatabase procMap techFlowDB bioFlowDB wasteFlowDB unitDB
-                Right <$> fixSimaProActivityLinks simpleDb
+                Right <$> fixSimaProActivityLinks unitConfig simpleDb
 
 {- | Fix SimaPro activity links by resolving supplier references
 Uses name-only matching (no location required) for SimaPro technosphere inputs
 -}
-fixSimaProActivityLinks :: SimpleDatabase -> IO SimpleDatabase
-fixSimaProActivityLinks db = do
-    let nameIndex = buildSupplierIndexByName (sdbActivities db) (sdbTechFlows db)
+fixSimaProActivityLinks :: UC.UnitConfig -> SimpleDatabase -> IO SimpleDatabase
+fixSimaProActivityLinks unitConfig db = do
+    let nameIndex = buildSupplierIndexByName (sdbUnits db) (sdbActivities db) (sdbTechFlows db)
     reportProgress Info $ printf "Built name-only supplier index with %d entries for SimaPro linking" (M.size nameIndex)
 
     -- Count and report statistics
-    let (fixedActivities, summary) = fixAllActivitiesByName nameIndex (sdbTechFlows db) (sdbActivities db)
+    let (fixedActivities, summary) = fixAllActivitiesByName unitConfig (sdbUnits db) nameIndex (sdbTechFlows db) (sdbActivities db)
 
     reportProgress Info $
         printf
@@ -588,39 +592,66 @@ fixSimaProActivityLinks db = do
     return $ db{sdbActivities = fixedActivities}
 
 -- | Fix all activities using name-only matching
-fixAllActivitiesByName :: NameOnlyIndex -> TechFlowDB -> ActivityMap -> (ActivityMap, UnlinkedSummary)
-fixAllActivitiesByName idx techFlowDb activities =
-    let results = M.map (fixActivityExchangesByName idx techFlowDb) activities
+fixAllActivitiesByName :: UC.UnitConfig -> UnitDB -> NameOnlyIndex -> TechFlowDB -> ActivityMap -> (ActivityMap, UnlinkedSummary)
+fixAllActivitiesByName unitConfig unitDB idx techFlowDb activities =
+    let results = M.map (fixActivityExchangesByName unitConfig unitDB idx techFlowDb) activities
         summaries = map snd $ M.elems results
         combinedSummary = mconcat summaries
         fixedActivities = M.map fst results
      in (fixedActivities, combinedSummary)
 
 -- | Fix activity exchanges using name-only matching
-fixActivityExchangesByName :: NameOnlyIndex -> TechFlowDB -> Activity -> (Activity, UnlinkedSummary)
-fixActivityExchangesByName idx techFlowDb act =
-    let (fixedExchanges, summaries) = unzip $ map (fixExchangeLinkByName idx techFlowDb (activityName act)) (exchanges act)
+fixActivityExchangesByName :: UC.UnitConfig -> UnitDB -> NameOnlyIndex -> TechFlowDB -> Activity -> (Activity, UnlinkedSummary)
+fixActivityExchangesByName unitConfig unitDB idx techFlowDb act =
+    let (fixedExchanges, summaries) = unzip $ map (fixExchangeLinkByName unitConfig unitDB idx techFlowDb (activityName act)) (exchanges act)
         combinedSummary = mconcat summaries
      in (act{exchanges = fixedExchanges}, combinedSummary)
 
+{- | A name-based supplier link is admissible only when the matrix builder could
+later convert the consumer's exchange unit to the supplier's reference-product
+unit. This mirrors the builder's own rule exactly (see 'Database.MatrixBuild'):
+a conversion is needed only when the two units differ and both are non-empty,
+and it must then succeed. So a link is safe when the units are identical, when
+either side is empty, or when they are dimensionally compatible. Forming any
+other link would abort the whole load — better to leave the input unlinked.
+-}
+linkUnitsCompatible :: UC.UnitConfig -> T.Text -> T.Text -> Bool
+linkUnitsCompatible unitConfig consumerUnit supplierUnit =
+    let cu = T.toLower (T.strip consumerUnit)
+        su = T.toLower (T.strip supplierUnit)
+     in cu == su
+            || T.null cu
+            || T.null su
+            || UC.unitsCompatible unitConfig consumerUnit supplierUnit
+
 {- | Fix a single exchange's activity link using name-only matching.
 Inputs and non-reference outputs (coproducts / avoided-production credits)
-are eligible for relinking. Returns (fixed exchange, UnlinkedSummary).
+are eligible for relinking. A candidate is accepted only if its
+reference-product unit is dimensionally compatible with the consumer exchange
+('linkUnitsCompatible'); an incompatible candidate is skipped (falling through
+to the prefix fallback, then to unlinked) rather than forming a link the matrix
+builder cannot convert — which would otherwise abort the whole load. Returns
+(fixed exchange, UnlinkedSummary).
 -}
-fixExchangeLinkByName :: NameOnlyIndex -> TechFlowDB -> T.Text -> Exchange -> (Exchange, UnlinkedSummary)
-fixExchangeLinkByName idx techFlowDb consumerName ex@TechnosphereExchange{techFlowId = fid, techRole = role, techLocation = loc}
+fixExchangeLinkByName :: UC.UnitConfig -> UnitDB -> NameOnlyIndex -> TechFlowDB -> T.Text -> Exchange -> (Exchange, UnlinkedSummary)
+fixExchangeLinkByName unitConfig unitDB idx techFlowDb consumerName ex@TechnosphereExchange{techFlowId = fid, techRole = role, techLocation = loc}
     | role == Input || role == ReferenceInput || role == Coproduct =
         case M.lookup fid techFlowDb of
             Just flow ->
                 let key = normalizeText (tfName flow)
+                    consumerUnit = getUnitNameForExchange unitDB ex
                     relink actUUID prodUUID = ex{techFlowId = prodUUID, techActivityLinkId = actUUID}
-                 in case M.lookup key idx of
+                    -- Accept a candidate only when its reference unit can convert.
+                    accept (actUUID, prodUUID, supplierUnit)
+                        | linkUnitsCompatible unitConfig consumerUnit supplierUnit = Just (actUUID, prodUUID)
+                        | otherwise = Nothing
+                 in case M.lookup key idx >>= accept of
                         Just (actUUID, prodUUID) ->
                             (relink actUUID prodUUID, UnlinkedSummary M.empty 1 1 0)
                         Nothing ->
                             let prefixes = extractProductPrefixes (tfName flow)
                                 tryPrefix [] = Nothing
-                                tryPrefix (p : ps) = case M.lookup (normalizeText p) idx of
+                                tryPrefix (p : ps) = case M.lookup (normalizeText p) idx >>= accept of
                                     Just result -> Just result
                                     Nothing -> tryPrefix ps
                              in case tryPrefix prefixes of
@@ -634,9 +665,9 @@ fixExchangeLinkByName idx techFlowDb consumerName ex@TechnosphereExchange{techFl
                 -- Flow not in technosphere map — shouldn't happen but be safe
                 (ex, UnlinkedSummary M.empty 1 0 1)
     | otherwise = (ex, mempty) -- Reference products: nothing to relink
-fixExchangeLinkByName _ _ _ ex@BiosphereExchange{} = (ex, mempty)
+fixExchangeLinkByName _ _ _ _ _ ex@BiosphereExchange{} = (ex, mempty)
 -- Waste link resolution is deferred to the cross-DB linker path.
-fixExchangeLinkByName _ _ _ ex@WasteExchange{} = (ex, mempty)
+fixExchangeLinkByName _ _ _ _ _ ex@WasteExchange{} = (ex, mempty)
 
 -- | Load EcoSpold files from directory
 loadEcoSpoldDirectory :: M.Map T.Text T.Text -> FilePath -> IO (Either T.Text SimpleDatabase)
@@ -871,6 +902,25 @@ generateMatrixCacheFilename dbName sourcePath = do
         cacheDir = takeDirectory sourcePath
     createDirectoryIfMissing True cacheDir
     return $ cacheDir </> cacheFilename
+
+{- |
+Invalidate (remove) the on-disk matrix cache for a database.
+
+In-memory edits that change the activity set — notably 'deleteActivitiesInDB'
+— rebuild the live matrices but leave the @.zst@ matrix cache untouched. A
+later unload/reload would then resurrect the pre-edit activity set from the
+stale cache. Removing the cache here forces the next load to rebuild from
+source (or from a freshly-written cache), keeping disk and memory in agreement.
+No-op when no cache file is present.
+-}
+invalidateMatrixCache :: T.Text -> FilePath -> IO ()
+invalidateMatrixCache dbName sourcePath = do
+    cacheFile <- generateMatrixCacheFilename dbName sourcePath
+    mapM_ removeIfExists [cacheFile, cacheFile ++ ".zst"]
+  where
+    removeIfExists f = do
+        exists <- doesFileExist f
+        when exists $ removeFile f
 
 {- |
 Validate cache file integrity before attempting to decode.

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -32,6 +32,7 @@ module Database.Manager (
     getDatabase,
     mkDepSolverLookup,
     listDatabases,
+    clearMethodMappingCacheForDb,
 
     -- * Load/Unload
     loadDatabase,
@@ -1309,7 +1310,7 @@ loadDatabaseRawWithCrossDB dbName locationAliases sourcePath noCache synonymDB u
                 (activities, techFlowDB, bioFlowDB, wasteFlowDB, unitDB) <- SimaPro.parseSimaProCSV unitConfig csvFile
                 reportProgress Info $ "Building database from " <> show (length activities) <> " activities"
                 let simpleDb = SimpleDatabase (buildActivityMap activities) techFlowDB bioFlowDB wasteFlowDB unitDB
-                linkedDb <- Loader.fixSimaProActivityLinks simpleDb
+                linkedDb <- Loader.fixSimaProActivityLinks unitConfig simpleDb
                 dbResult <- buildDatabaseWithMatrices unitConfig (sdbActivities linkedDb) techFlowDB bioFlowDB (sdbWasteFlows linkedDb) unitDB
                 case dbResult of
                     Left err -> return $ Left err

--- a/test/DeleteSelectionSpec.hs
+++ b/test/DeleteSelectionSpec.hs
@@ -20,7 +20,7 @@ module DeleteSelectionSpec (spec) where
 import Control.Concurrent.STM (atomically, modifyTVar', readTVarIO)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
-import Data.Text (Text)
+import Data.Text (Text, isInfixOf)
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
@@ -211,6 +211,30 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
             manager <- initDatabaseManager defaultConfig True Nothing
             r <- deleteActivitiesInDB manager "ghost" Nothing Nothing Nothing [] False [] []
             r `shouldBe` Left "Database not loaded: ghost"
+
+        it "refuses to delete while a loaded database depends on it" $ do
+            -- Deleting from "base" would renumber/remove activities that the loaded
+            -- "dependent" links to across databases; those links would then silently
+            -- drop at solve time. The delete must be refused, mirroring unloadDatabase.
+            manager <- initDatabaseManager defaultConfig True Nothing
+            base <- buildOrFail (classifiedDB 800)
+            installLoaded manager "base" base
+            dep <- buildOrFail (classifiedDB 900)
+            installLoaded manager "dependent" dep{dbDependsOn = ["base"]}
+            r <-
+                deleteActivitiesInDB
+                    manager
+                    "base"
+                    Nothing
+                    Nothing
+                    Nothing
+                    [("category", "food", False)]
+                    False
+                    []
+                    []
+            case r of
+                Left err -> err `shouldSatisfy` isInfixOf "still required by"
+                Right _ -> expectationFailure "expected delete to be refused while a dependent is loaded"
 
 -- ---------------------------------------------------------------------------
 -- Helpers

--- a/test/DeleteSelectionSpec.hs
+++ b/test/DeleteSelectionSpec.hs
@@ -1,0 +1,468 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Tests for the DELETE-BY-SELECTION primitive
+('Database.Edit.deleteActivities', 'Database.Edit.resolveDeleteSelection' and
+the effectful 'Database.Edit.deleteActivitiesInDB').
+
+Delete is reconstruction over an immutable 'Database':
+
+* deleting a set of ProcessIds drops exactly those activities and renumbers the
+  survivors, rebuilding the interning tables, indexes, and sparse matrices;
+* an exchange in a surviving activity that pointed at a deleted activity is
+  UNLINKED (activity link reset to nil), never silently dropped — the database
+  is left ready for relinking;
+* the selection resolver computes @(filtered ∪ extra) \\ keep@, so the UI's
+  "delete the whole filtered set" honours per-row checkbox overrides;
+* deleting by filter removes the WHOLE matching set, independent of pagination.
+-}
+module DeleteSelectionSpec (spec) where
+
+import Control.Concurrent.STM (atomically, modifyTVar', readTVarIO)
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as U
+import Test.Hspec
+
+import Config (DatabaseConfig (..), defaultConfig)
+import Database (buildDatabaseWithMatrices)
+import Database.Edit (
+    DeleteSelection (..),
+    deleteActivities,
+    deleteActivitiesInDB,
+    resolveDeleteSelection,
+ )
+import Database.Manager (
+    DatabaseManager (..),
+    LoadedDatabase (..),
+    initDatabaseManager,
+ )
+import SharedSolver (SharedSolver, createSharedSolver)
+import Types (
+    Activity (..),
+    Database (..),
+    Exchange (..),
+    GeographyPolicy (..),
+    ProcessId,
+    SparseTriple (..),
+    TechRole (..),
+    TechnosphereFlow (..),
+    UUID,
+    Unit (..),
+    findProcessId,
+    processIdToText,
+ )
+import UnitConversion (defaultUnitConfig)
+
+spec :: Spec
+spec = describe "Database.Edit delete-by-selection primitive" $ do
+    describe "resolveDeleteSelection" $ do
+        it "deletes the whole filtered set when there are no overrides" $
+            S.fromList (resolveDeleteSelection (DeleteSelection [0, 1, 2, 3] [] []))
+                `shouldBe` S.fromList [0, 1, 2, 3]
+
+        it "spares the explicit keep set (unticked checkboxes)" $
+            S.fromList (resolveDeleteSelection (DeleteSelection [0, 1, 2, 3] [1, 2] []))
+                `shouldBe` S.fromList [0, 3]
+
+        it "adds the explicit extra set (ticked rows outside the filter)" $
+            S.fromList (resolveDeleteSelection (DeleteSelection [0, 1] [] [5, 6]))
+                `shouldBe` S.fromList [0, 1, 5, 6]
+
+        it "lets keep win over both filtered and extra" $
+            S.fromList (resolveDeleteSelection (DeleteSelection [0, 1] [1, 5] [5, 6]))
+                `shouldBe` S.fromList [0, 6]
+
+    describe "deleteActivities (pure rebuild)" $ do
+        it "removes exactly the requested activities and renumbers survivors" $ do
+            db <- buildOrFail (chainDB 100)
+            dbActivityCount db `shouldBe` 3
+            -- Delete the leaf supplier (index 0 = "supplier" sorts first).
+            let supplierPid = pidFor db 100 0
+            case deleteActivities [supplierPid] db of
+                Left err -> expectationFailure ("deleteActivities failed: " <> show err)
+                Right db' -> do
+                    dbActivityCount db' `shouldBe` 2
+                    V.length (dbActivities db') `shouldBe` 2
+                    -- ProcessId table and lookup agree after renumbering.
+                    V.length (dbProcessIdTable db') `shouldBe` 2
+                    M.size (dbProcessIdLookup db') `shouldBe` 2
+                    -- The biosphere/tech matrices were rebuilt: the deleted
+                    -- supplier's row no longer contributes any tech triple.
+                    U.length (dbTechnosphereTriples db')
+                        `shouldSatisfy` (< U.length (dbTechnosphereTriples db))
+
+        it "unlinks surviving exchanges that pointed at a deleted activity" $ do
+            db <- buildOrFail (chainDB 200)
+            let supplierPid = pidFor db 200 0
+            case deleteActivities [supplierPid] db of
+                Left err -> expectationFailure ("deleteActivities failed: " <> show err)
+                Right db' -> do
+                    -- The mid activity kept its input exchange, but the link to
+                    -- the deleted supplier is now nil — ready for relinking.
+                    let midInputLinks =
+                            [ (techActivityLinkId ex, techProcessLinkId ex)
+                            | act <- V.toList (dbActivities db')
+                            , activityName act == "mid"
+                            , ex@TechnosphereExchange{techRole = Input} <- exchanges act
+                            ]
+                    midInputLinks `shouldBe` [(UUID.nil, Nothing)]
+
+        it "keeps a multi-product link target when only one product is deleted" $ do
+            db <- buildOrFail (multiProductDB 300)
+            -- supplier exposes two products; delete only product B.
+            let prodBPid = pidFor2 db (mkUUID 301) (mkUUID 303)
+            case deleteActivities [prodBPid] db of
+                Left err -> expectationFailure ("deleteActivities failed: " <> show err)
+                Right db' -> do
+                    dbActivityCount db' `shouldBe` 2
+                    -- The consumer linking to product A (a surviving key) keeps its link.
+                    let consumerLinks =
+                            [ techActivityLinkId ex
+                            | act <- V.toList (dbActivities db')
+                            , activityName act == "consumer-A"
+                            , ex@TechnosphereExchange{techRole = Input} <- exchanges act
+                            ]
+                    consumerLinks `shouldBe` [mkUUID 301]
+
+        it "unlinks a surviving waste generator when its treatment is deleted" $ do
+            db <- buildOrFail (wasteDB 350)
+            -- The treatment activity sorts first; delete it.
+            let treatmentPid = pidFor db 350 0
+            case deleteActivities [treatmentPid] db of
+                Left err -> expectationFailure ("deleteActivities failed: " <> show err)
+                Right db' -> do
+                    dbActivityCount db' `shouldBe` 1
+                    -- The surviving generator's waste output no longer resolves to
+                    -- the deleted treatment: the link is nil, ready for relinking.
+                    let generatorLinks =
+                            [ (waActivityLinkId ex, waProcessLinkId ex)
+                            | act <- V.toList (dbActivities db')
+                            , activityName act == "generator"
+                            , ex@WasteExchange{} <- exchanges act
+                            ]
+                    generatorLinks `shouldBe` [(UUID.nil, Nothing)]
+
+        it "fails loudly on an out-of-range ProcessId" $ do
+            db <- buildOrFail (chainDB 400)
+            case deleteActivities [999] db of
+                Left _ -> pure ()
+                Right _ -> expectationFailure "expected out-of-range ProcessId to fail"
+
+        it "refuses to delete every activity" $ do
+            db <- buildOrFail (chainDB 500)
+            let allPids = [0 .. dbActivityCount db - 1]
+            case deleteActivities allPids db of
+                Left _ -> pure ()
+                Right _ -> expectationFailure "expected delete-all to be refused"
+
+    describe "deleteActivitiesInDB (filter-driven, in-place)" $ do
+        it "deletes the whole filtered set and respects keep" $ do
+            manager <- initDatabaseManager defaultConfig True Nothing
+            db <- buildOrFail (classifiedDB 600)
+            installLoaded manager "edit-me" db
+            -- Filter matches the two "food" activities; keep one by its
+            -- canonical process-id string (the value the UI carries).
+            let foodA = processIdToText db (pidFor2 db (mkUUID 601) (mkUUID 601))
+            r <-
+                deleteActivitiesInDB
+                    manager
+                    "edit-me"
+                    Nothing
+                    Nothing
+                    Nothing
+                    [("category", "food", False)]
+                    False
+                    [foodA] -- keep
+                    [] -- extra
+            case r of
+                Left err -> expectationFailure ("deleteActivitiesInDB failed: " <> show err)
+                Right deleted -> do
+                    deleted `shouldBe` 1 -- two matched, one kept
+                    loaded <- readTVarIO (dmLoadedDbs manager)
+                    let db' = ldDatabase (loaded M.! "edit-me")
+                    dbActivityCount db' `shouldBe` 2
+                    -- The kept food activity and the non-food activity survive.
+                    map activityName (V.toList (dbActivities db'))
+                        `shouldSatisfy` elem "food-A"
+
+        it "fails loudly on an unknown keep process id" $ do
+            manager <- initDatabaseManager defaultConfig True Nothing
+            db <- buildOrFail (classifiedDB 700)
+            installLoaded manager "edit-me-2" db
+            r <-
+                deleteActivitiesInDB
+                    manager
+                    "edit-me-2"
+                    Nothing
+                    Nothing
+                    Nothing
+                    [("category", "food", False)]
+                    False
+                    ["not-a-real-process-id"]
+                    []
+            case r of
+                Left _ -> pure ()
+                Right _ -> expectationFailure "expected unknown keep id to fail"
+
+        it "fails when the database is not loaded" $ do
+            manager <- initDatabaseManager defaultConfig True Nothing
+            r <- deleteActivitiesInDB manager "ghost" Nothing Nothing Nothing [] False [] []
+            r `shouldBe` Left "Database not loaded: ghost"
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+
+pidFor :: Database -> Int -> Int -> ProcessId
+pidFor db offset i = pidFor2 db (mkUUID (offset + 10 * i + 1)) (mkUUID (offset + 10 * i + 1))
+
+pidFor2 :: Database -> UUID -> UUID -> ProcessId
+pidFor2 db actUUID prodUUID =
+    maybe (error "pidFor2: key not found") id (findProcessId db actUUID prodUUID)
+
+installLoaded :: DatabaseManager -> Text -> Database -> IO ()
+installLoaded manager name db = do
+    solver <- mkSolver name db
+    let loaded =
+            LoadedDatabase
+                { ldDatabase = db
+                , ldSharedSolver = solver
+                , ldConfig = mkConfig name
+                }
+    atomically $ do
+        modifyTVar' (dmLoadedDbs manager) (M.insert name loaded)
+        modifyTVar' (dmAvailableDbs manager) (M.insert name (mkConfig name))
+
+mkSolver :: Text -> Database -> IO SharedSolver
+mkSolver name db =
+    let triples = [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList (dbTechnosphereTriples db)]
+     in createSharedSolver name triples (fromIntegral (dbActivityCount db))
+
+mkConfig :: Text -> DatabaseConfig
+mkConfig name =
+    DatabaseConfig
+        { dcName = name
+        , dcDisplayName = name
+        , dcPath = ""
+        , dcDescription = Nothing
+        , dcLoad = True
+        , dcDefault = False
+        , dcDepends = []
+        , dcLocationAliases = M.empty
+        , dcFormat = Nothing
+        , dcIsUploaded = True
+        , dcDeletable = True
+        , dcGeographyPolicy = GeoGlobal
+        }
+
+buildOrFail :: SimpleParts -> IO Database
+buildOrFail (SimpleParts acts flows units) = do
+    r <- buildDatabaseWithMatrices defaultUnitConfig acts flows M.empty M.empty units
+    case r of
+        Right db -> pure db
+        Left err -> fail ("buildDatabaseWithMatrices: " <> show err)
+
+-- ---------------------------------------------------------------------------
+-- Fixtures
+-- ---------------------------------------------------------------------------
+
+data SimpleParts
+    = SimpleParts
+        (M.Map (UUID, UUID) Activity)
+        (M.Map UUID TechnosphereFlow)
+        (M.Map UUID Unit)
+
+mkUUID :: Int -> UUID
+mkUUID n = UUID.fromWords64 (fromIntegral n) 0
+
+kgUnitId :: UUID
+kgUnitId = mkUUID 0
+
+kgUnit :: Unit
+kgUnit = Unit{unitId = kgUnitId, unitName = "kg", unitSymbol = "kg", unitComment = ""}
+
+mkTechFlow :: UUID -> Text -> TechnosphereFlow
+mkTechFlow fid name =
+    TechnosphereFlow
+        { tfId = fid
+        , tfName = name
+        , tfUnitId = kgUnitId
+        , tfSynonyms = M.empty
+        , tfCAS = Nothing
+        , tfSubstanceId = Nothing
+        }
+
+{- | A reference-product output exchange whose product UUID equals its flow UUID
+(so @(actUUID, prodUUID)@ is also the @(actUUID, flowId)@ link key).
+-}
+refOut :: UUID -> UUID -> Exchange
+refOut actUUID prodUUID =
+    TechnosphereExchange
+        { techFlowId = prodUUID
+        , techAmount = 1.0
+        , techUnitId = kgUnitId
+        , techRole = ReferenceProduct
+        , techActivityLinkId = actUUID
+        , techProcessLinkId = Nothing
+        , techLocation = ""
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+-- | An input exchange linking to a supplier's @(supplierActUUID, supplierProdUUID)@.
+inputFrom :: UUID -> UUID -> Exchange
+inputFrom supplierActUUID supplierProdUUID =
+    TechnosphereExchange
+        { techFlowId = supplierProdUUID
+        , techAmount = 0.5
+        , techUnitId = kgUnitId
+        , techRole = Input
+        , techActivityLinkId = supplierActUUID
+        , techProcessLinkId = Nothing
+        , techLocation = ""
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+{- | A waste output linking to a treatment activity's
+@(treatmentActUUID, treatmentProdUUID)@ — the same @(activityLink, flowId)@
+key resolution a technosphere input uses.
+-}
+wasteOut :: UUID -> UUID -> Exchange
+wasteOut treatmentActUUID treatmentProdUUID =
+    WasteExchange
+        { waFlowId = treatmentProdUUID
+        , waAmount = 0.5
+        , waUnitId = kgUnitId
+        , waIsInput = False
+        , waActivityLinkId = treatmentActUUID
+        , waProcessLinkId = Nothing
+        , waLocation = ""
+        , waComment = Nothing
+        , waPedigree = Nothing
+        }
+
+mkActivity :: Text -> Text -> M.Map Text Text -> [Exchange] -> Activity
+mkActivity name loc classif exs =
+    Activity
+        { activityName = name
+        , activityDescription = []
+        , activitySynonyms = M.empty
+        , activityClassification = classif
+        , activityLocation = loc
+        , activityUnit = "kg"
+        , exchanges = exs
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
+        }
+
+units :: M.Map UUID Unit
+units = M.singleton kgUnitId kgUnit
+
+{- | A three-activity chain: top → mid → supplier. UUIDs are
+@offset + 10*i + 1@ for activity i (i: 0=supplier, 1=mid, 2=top), with product
+UUID equal to the activity UUID for simple linking.
+-}
+chainDB :: Int -> SimpleParts
+chainDB offset =
+    let supA = mkUUID (offset + 1)
+        midA = mkUUID (offset + 11)
+        topA = mkUUID (offset + 21)
+        supplier = mkActivity "supplier" "GLO" M.empty [refOut supA supA]
+        mid = mkActivity "mid" "GLO" M.empty [refOut midA midA, inputFrom supA supA]
+        top = mkActivity "top" "GLO" M.empty [refOut topA topA, inputFrom midA midA]
+     in SimpleParts
+            ( M.fromList
+                [ ((supA, supA), supplier)
+                , ((midA, midA), mid)
+                , ((topA, topA), top)
+                ]
+            )
+            ( M.fromList
+                [ (supA, mkTechFlow supA "supplier-product")
+                , (midA, mkTechFlow midA "mid-product")
+                , (topA, mkTechFlow topA "top-product")
+                ]
+            )
+            units
+
+{- | A supplier exposing two products (A, B) plus a consumer linking to product
+A only. Deleting product B must keep the consumer's link to A intact.
+-}
+multiProductDB :: Int -> SimpleParts
+multiProductDB offset =
+    let supA = mkUUID (offset + 1)
+        prodA = mkUUID (offset + 2)
+        prodB = mkUUID (offset + 3)
+        consA = mkUUID (offset + 11)
+        supplierA = mkActivity "supplier" "GLO" M.empty [refOut supA prodA]
+        supplierB = mkActivity "supplier" "GLO" M.empty [refOut supA prodB]
+        consumer = mkActivity "consumer-A" "GLO" M.empty [refOut consA consA, inputFrom supA prodA]
+     in SimpleParts
+            ( M.fromList
+                [ ((supA, prodA), supplierA)
+                , ((supA, prodB), supplierB)
+                , ((consA, consA), consumer)
+                ]
+            )
+            ( M.fromList
+                [ (prodA, mkTechFlow prodA "product-A")
+                , (prodB, mkTechFlow prodB "product-B")
+                , (consA, mkTechFlow consA "consumer-product")
+                ]
+            )
+            units
+
+{- | A waste generator wired to a treatment activity via a 'WasteExchange'.
+UUIDs are @offset + 10*i + 1@ (i: 0=treatment, 1=generator) so the treatment
+sorts first. Deleting the treatment must unlink the generator's waste output.
+-}
+wasteDB :: Int -> SimpleParts
+wasteDB offset =
+    let treatA = mkUUID (offset + 1)
+        genA = mkUUID (offset + 11)
+        treatment = mkActivity "treatment" "GLO" M.empty [refOut treatA treatA]
+        generator = mkActivity "generator" "GLO" M.empty [refOut genA genA, wasteOut treatA treatA]
+     in SimpleParts
+            ( M.fromList
+                [ ((treatA, treatA), treatment)
+                , ((genA, genA), generator)
+                ]
+            )
+            ( M.fromList
+                [ (treatA, mkTechFlow treatA "treatment-product")
+                , (genA, mkTechFlow genA "generator-product")
+                ]
+            )
+            units
+
+{- | Two "food" activities and one "energy" activity, classified under the
+@category@ system so a classification filter selects the food pair.
+-}
+classifiedDB :: Int -> SimpleParts
+classifiedDB offset =
+    let foodA = mkUUID (offset + 1)
+        foodB = mkUUID (offset + 11)
+        energ = mkUUID (offset + 21)
+        food = M.singleton "category" "food"
+        energy = M.singleton "category" "energy"
+     in SimpleParts
+            ( M.fromList
+                [ ((foodA, foodA), mkActivity "food-A" "GLO" food [refOut foodA foodA])
+                , ((foodB, foodB), mkActivity "food-B" "GLO" food [refOut foodB foodB])
+                , ((energ, energ), mkActivity "energy" "GLO" energy [refOut energ energ])
+                ]
+            )
+            ( M.fromList
+                [ (foodA, mkTechFlow foodA "food-a")
+                , (foodB, mkTechFlow foodB "food-b")
+                , (energ, mkTechFlow energ "energy")
+                ]
+            )
+            units

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -12,6 +12,7 @@ import Test.Hspec
 import Database.Loader
 import TestHelpers (loadSampleDatabase)
 import Types
+import UnitConversion (defaultUnitConfig)
 
 -- ---------------------------------------------------------------------------
 -- Minimal fixtures
@@ -230,8 +231,9 @@ spec = do
                         [refExchange flowUUID1]
                 acts = M.fromList [((actUUID1, flowUUID1), act)]
                 flows = M.fromList [(flowUUID1, minimalFlow flowUUID1 "Wheat Production")]
-                idx = buildSupplierIndexByName acts flows
-            M.lookup "wheat production" idx `shouldBe` Just (actUUID1, flowUUID1)
+                idx = buildSupplierIndexByName M.empty acts flows
+            -- empty UnitDB → reference unit resolves to the "unknown" sentinel
+            M.lookup "wheat production" idx `shouldBe` Just (actUUID1, flowUUID1, "unknown")
 
         it "does not index non-reference exchanges" $ do
             let act =
@@ -241,7 +243,7 @@ spec = do
                         [inputExchange flowUUID1 "GLO"]
                 acts = M.fromList [((actUUID1, flowUUID1), act)]
                 flows = M.fromList [(flowUUID1, minimalFlow flowUUID1 "Wheat")]
-                idx = buildSupplierIndexByName acts flows
+                idx = buildSupplierIndexByName M.empty acts flows
             M.null idx `shouldBe` True
 
     -- -----------------------------------------------------------------------
@@ -250,9 +252,9 @@ spec = do
     describe "fixExchangeLinkByName" $ do
         it "resolves input exchange when supplier in index" $ do
             let flows = M.fromList [(flowUUID1, minimalFlow flowUUID1 "wheat")]
-                idx = M.fromList [("wheat", (actUUID1, flowUUID2))]
+                idx = M.fromList [("wheat", (actUUID1, flowUUID2, ""))]
                 ex = inputExchange flowUUID1 "GLO"
-                (fixed, summary) = fixExchangeLinkByName idx flows "consumer" ex
+                (fixed, summary) = fixExchangeLinkByName defaultUnitConfig M.empty idx flows "consumer" ex
             techActivityLinkId fixed `shouldBe` actUUID1
             usFoundLinks summary `shouldBe` 1
             usMissingLinks summary `shouldBe` 0
@@ -261,7 +263,7 @@ spec = do
             let flows = M.fromList [(flowUUID1, minimalFlow flowUUID1 "wheat")]
                 idx = M.empty
                 ex = inputExchange flowUUID1 "GLO"
-                (fixed, summary) = fixExchangeLinkByName idx flows "consumer" ex
+                (fixed, summary) = fixExchangeLinkByName defaultUnitConfig M.empty idx flows "consumer" ex
             techActivityLinkId fixed `shouldBe` UUID.nil
             usMissingLinks summary `shouldBe` 1
 
@@ -269,15 +271,15 @@ spec = do
             let flows = M.empty
                 idx = M.empty
                 ex = inputExchange flowUUID1 "GLO"
-                (fixed, summary) = fixExchangeLinkByName idx flows "consumer" ex
+                (fixed, summary) = fixExchangeLinkByName defaultUnitConfig M.empty idx flows "consumer" ex
             techActivityLinkId fixed `shouldBe` UUID.nil
             usMissingLinks summary `shouldBe` 1
 
         it "does not touch output reference exchanges" $ do
             let flows = M.fromList [(flowUUID1, minimalFlow flowUUID1 "wheat")]
-                idx = M.fromList [("wheat", (actUUID1, flowUUID2))]
+                idx = M.fromList [("wheat", (actUUID1, flowUUID2, ""))]
                 ex = refExchange flowUUID1
-                (fixed, summary) = fixExchangeLinkByName idx flows "producer" ex
+                (fixed, summary) = fixExchangeLinkByName defaultUnitConfig M.empty idx flows "producer" ex
             techActivityLinkId fixed `shouldBe` UUID.nil -- unchanged
             usTotalLinks summary `shouldBe` 0 -- not counted
         it "does not touch biosphere exchanges" $ do
@@ -293,10 +295,42 @@ spec = do
                         , bioComment = Nothing
                         , bioPedigree = Nothing
                         }
-                (fixed, summary) = fixExchangeLinkByName idx flows "act" bioEx
+                (fixed, summary) = fixExchangeLinkByName defaultUnitConfig M.empty idx flows "act" bioEx
             -- BiosphereExchange is returned unchanged: verify it is still biosphere
             isBiosphereExchange fixed `shouldBe` True
             usTotalLinks summary `shouldBe` 0
+
+        -- Regression: a candidate whose reference-product unit is in a different
+        -- dimension than the consumer exchange must NOT be linked — the matrix
+        -- builder could not convert it, and forming the link aborts the whole
+        -- load. (This is what 'delete then re-export' surfaced on real data: a
+        -- piece-counted input fuzzy-matched a mass-counted survivor.)
+        it "rejects a dimensionally-incompatible candidate (count input vs mass supplier)" $ do
+            let unitItemUUID = read "dddddddd-0000-0000-0000-00000000000a" :: UUID.UUID
+                unitKgUUID = read "dddddddd-0000-0000-0000-00000000000b" :: UUID.UUID
+                unitDB =
+                    M.fromList
+                        [ (unitItemUUID, Unit unitItemUUID "item" "item" "")
+                        , (unitKgUUID, Unit unitKgUUID "kg" "kg" "")
+                        ]
+                flows = M.fromList [(flowUUID1, minimalFlow flowUUID1 "pump")]
+                -- supplier indexed with a mass (kg) reference unit
+                idx = M.fromList [("pump", (actUUID1, flowUUID2, "kg"))]
+                -- consumer wants the pump by the piece (item)
+                ex = (inputExchange flowUUID1 "GLO"){techUnitId = unitItemUUID}
+                (fixed, summary) = fixExchangeLinkByName defaultUnitConfig unitDB idx flows "consumer" ex
+            techActivityLinkId fixed `shouldBe` UUID.nil
+            usMissingLinks summary `shouldBe` 1
+
+        it "links a dimensionally-compatible candidate (mass input vs mass supplier)" $ do
+            let unitKgUUID = read "dddddddd-0000-0000-0000-00000000000b" :: UUID.UUID
+                unitDB = M.fromList [(unitKgUUID, Unit unitKgUUID "kg" "kg" "")]
+                flows = M.fromList [(flowUUID1, minimalFlow flowUUID1 "pump")]
+                idx = M.fromList [("pump", (actUUID1, flowUUID2, "kg"))]
+                ex = (inputExchange flowUUID1 "GLO"){techUnitId = unitKgUUID}
+                (fixed, summary) = fixExchangeLinkByName defaultUnitConfig unitDB idx flows "consumer" ex
+            techActivityLinkId fixed `shouldBe` actUUID1
+            usFoundLinks summary `shouldBe` 1
 
     -- -----------------------------------------------------------------------
     -- countTotalTechInputs / countUnlinkedExchanges / collectUnlinkedProductNames

--- a/volca.cabal
+++ b/volca.cabal
@@ -43,6 +43,7 @@ library
                      , SharedSolver
                      , Database
                      , Database.Manager
+                     , Database.Edit
                      , Database.Loader
                      , Database.CrossLinking
                      , Database.MatrixBuild
@@ -263,6 +264,7 @@ test-suite lca-tests
                      , NumericEdgesSpec
                      , AggregateSpec
                      , ConfigWriterSpec
+                     , DeleteSelectionSpec
                      , PropertiesSpec
   build-depends:       base >=4.14 && <5
                      , volca


### PR DESCRIPTION
## What

In-memory **delete-by-selection** on the loaded-database registry: remove the activities matched by a search filter (the whole matching set, independent of pagination) plus explicit keep/extra ids, then rebuild every dependent structure (interning tables, indexes, matrices, product index) from the survivors so the result is indistinguishable from a fresh load. Dangling references in surviving activities are **unlinked, not dropped**, leaving the database ready to relink.

Exposed over CLI (`db delete-activities`), HTTP (`POST /db/{db}/delete`) and pyvolca (`delete_activities`). The handler collapses present-but-blank filters to absent so a product-only delete is never read as an unsatisfiable empty-name filter.

Two loader fixes ride along, both surfaced by deleting a supplier:
- name-link matching rejects a candidate whose reference-product unit is dimensionally incompatible with the consumer exchange (forming such a link aborts the whole load);
- a delete invalidates the on-disk matrix cache so a later reload cannot resurrect the removed rows.

## Why split

This is the first slice of #113 (database write toolkit), split into focused, independently-reviewable PRs.

## Stack (merge bottom-up)

1. **#delete ← you are here** (base `main`)
2. copy → relink → simapro/ecospold1/ecospold2/ilcd/brightway writers → export

## Test

`cabal test lca-tests` → 0 failures (full stack).
