### PR TITLE
feat(edit): copy a loaded database under a new name

### DIFF
--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -381,6 +381,15 @@ Returns the raw JSON (no dataclass wrapping). Use this for
 operations that don't have an ergonomic wrapper yet, or for new
 endpoints added after the installed pyvolca was released.
 
+##### `Client.copy_database(new_name: str, db_name: str | None = None) -> dict`
+
+Copy a loaded database in memory under a new name.
+
+``new_name`` is a path segment; the source defaults to ``self.db``.
+Returns the engine's ``ActivateResponse`` dict
+(``{"success", "message", "database"?}``). Raises VoLCAError if the
+engine reports ``success=false``.
+
 ##### `Client.delete_activities(*, name: str = '', location: str = '', product: str = '', classifications: list[dict | tuple] | None = None, exact: bool = False, keep: list[str] | None = None, extra: list[str] | None = None, db_name: str | None = None) -> dict`
 
 Delete activities selected by filter, sparing/adding explicit ids.

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -641,6 +641,20 @@ class Client:
             )
         return payload
 
+    def copy_database(self, new_name: str, db_name: str | None = None) -> dict:
+        """Copy a loaded database in memory under a new name.
+
+        ``new_name`` is a path segment; the source defaults to ``self.db``.
+        Returns the engine's ``ActivateResponse`` dict
+        (``{"success", "message", "database"?}``). Raises VoLCAError if the
+        engine reports ``success=false``.
+        """
+        src = self._db(db_name)
+        payload = self._json(
+            self._session.post(f"{self.base_url}/api/v1/db/{src}/copy/{new_name}")
+        )
+        return self._require_success(payload, "copy_database")
+
     def delete_activities(
         self,
         *,

--- a/pyvolca/tests/test_db_write.py
+++ b/pyvolca/tests/test_db_write.py
@@ -97,3 +97,30 @@ class TestDelete:
         _ok(session, {"success": False, "message": "nothing matched"})
         with pytest.raises(VoLCAError, match="nothing matched"):
             client.delete_activities(name="x")
+
+
+# ---------------------------------------------------------------------------
+# copy
+# ---------------------------------------------------------------------------
+
+
+class TestCopy:
+    def test_url_and_default_db(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": True, "message": "copied", "database": None})
+        client.copy_database("clone")
+        url = session.post.call_args[0][0]
+        assert url == "http://test.local/api/v1/db/testdb/copy/clone"
+
+    def test_explicit_db_override(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": True, "message": "ok"})
+        client.copy_database("clone", db_name="other")
+        url = session.post.call_args[0][0]
+        assert url == "http://test.local/api/v1/db/other/copy/clone"
+
+    def test_in_band_failure_raises(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": False, "message": "already exists"})
+        with pytest.raises(VoLCAError, match="already exists"):
+            client.copy_database("clone")

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -16,6 +16,7 @@ module API.DatabaseHandlers (
     loadDatabaseHandler,
     unloadDatabaseHandler,
     relinkDatabaseHandler,
+    copyDatabaseHandler,
     deleteDatabaseHandler,
     deleteActivitiesHandler,
     uploadDatabaseHandler,
@@ -95,7 +96,7 @@ import qualified Data.Aeson as A
 import qualified Data.Aeson.KeyMap as KM
 import Data.Maybe (fromMaybe)
 import qualified Data.Vector as V
-import Database.Edit (deleteActivitiesInDB)
+import Database.Edit (copyDatabase, deleteActivitiesInDB)
 import Database.Manager (
     DatabaseLoadStatus (..),
     DatabaseManager (..),
@@ -191,6 +192,14 @@ relinkDatabaseHandler dbName = do
                     , rrCrossDBLinks = rresCrossDBLinks r
                     , rrDependsOn = rresDepsLoaded r
                     }
+
+{- | Copy a loaded database under a new name. The copy is an independent
+in-memory database registered under @newName@; the source is untouched.
+-}
+copyDatabaseHandler :: Text -> Text -> AppM ActivateResponse
+copyDatabaseHandler dbName newName = do
+    dbManager <- asks aeDbManager
+    simpleAction (copyDatabase dbManager dbName newName) ("Copied database: " <> dbName <> " -> " <> newName)
 
 -- | Delete an uploaded database (move to trash)
 deleteDatabaseHandler :: Text -> AppM ActivateResponse

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -121,6 +121,7 @@ type LCAAPI =
                 :<|> "db" :> Capture "dbName" Text :> "load" :> Post '[JSON] LoadDatabaseResponse
                 :<|> "db" :> Capture "dbName" Text :> "unload" :> Post '[JSON] ActivateResponse
                 :<|> "db" :> Capture "dbName" Text :> "relink" :> Post '[JSON] RelinkResponse
+                :<|> "db" :> Capture "dbName" Text :> "copy" :> Capture "newName" Text :> Post '[JSON] ActivateResponse
                 :<|> "db" :> Capture "dbName" Text :> Delete '[JSON] ActivateResponse
                 -- Delete the whole filtered set of activities (selection in JSON body)
                 :<|> "db" :> Capture "dbName" Text :> "delete" :> ReqBody '[JSON] DeleteSelectionRequest :> Post '[JSON] DeleteSelectionResponse
@@ -1954,6 +1955,7 @@ lcaServer env = hoistServer lcaAPI (runApp env) handlers
             :<|> DBHandlers.loadDatabaseHandler
             :<|> DBHandlers.unloadDatabaseHandler
             :<|> DBHandlers.relinkDatabaseHandler
+            :<|> DBHandlers.copyDatabaseHandler
             :<|> DBHandlers.deleteDatabaseHandler
             :<|> DBHandlers.deleteActivitiesHandler
             :<|> DBHandlers.uploadDatabaseHandler

--- a/src/CLI/Client.hs
+++ b/src/CLI/Client.hs
@@ -84,6 +84,15 @@ executeRemoteCommand mgr rc globalOpts cmd = do
         Database (DbDeleteActivities args) ->
             apiPost mgr rc ("/api/v1/db/" ++ T.unpack (ddaDb args) ++ "/delete") (deleteSelectionBody args)
                 >>= outputStatus fmt jp "delete"
+        Database (DbCopy srcName newName) ->
+            -- The copy endpoint takes no body (newName is a path capture); the
+            -- empty object is ignored server-side.
+            apiPost
+                mgr
+                rc
+                ("/api/v1/db/" ++ T.unpack srcName ++ "/copy/" ++ T.unpack newName)
+                (object [])
+                >>= outputStatus fmt jp "copy"
         Method McList ->
             apiGet mgr rc "/api/v1/method-collections" >>= output fmt jp
         Method (McUpload args) ->
@@ -272,8 +281,8 @@ executeUpload mgr rc fmt jp path args = do
 
 {- | Output a response whose body carries an in-band @{"success",..,"message"}@
 status (the handlers return HTTP 200 even on failure, so a bare 'output' would
-exit 0 on a failed delete). Inspect the @success@ field and fail loudly when it
-is false; otherwise render normally. Covers both 'ActivateResponse' and
+exit 0 on a failed copy/delete). Inspect the @success@ field and fail loudly
+when it is false; otherwise render normally. Covers both 'ActivateResponse' and
 'DeleteSelectionResponse', which share these keys after the @Stripped@ transform.
 -}
 outputStatus :: OutputFormat -> Maybe Text -> String -> Either String Value -> IO ()

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -16,7 +16,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
-import Database.Edit (deleteActivitiesInDB)
+import Database.Edit (copyDatabase, deleteActivitiesInDB)
 import Database.Manager (DatabaseManager (..), LoadedDatabase (..), addDatabase, addMethodCollection)
 import qualified Database.Manager as DM
 import Database.Upload (UploadData (..), UploadResult (..), findMethodDirectory, handleUpload)
@@ -101,6 +101,8 @@ executeCommand (CLIConfig globalOpts _) cmd manager = do
             executeDbDelete registry outputFormat manager name
         Database (DbDeleteActivities args) ->
             executeDbDeleteActivities registry outputFormat manager args
+        Database (DbCopy srcName newName) ->
+            executeDbCopy registry outputFormat manager srcName newName
         Method McList ->
             DM.listMethodCollections manager >>= out . toJSON
         Method (McUpload args) ->
@@ -507,6 +509,18 @@ executeDbDeleteActivities registry fmt manager args = do
         Right deleted -> do
             reportProgress Info $ "Deleted " ++ show deleted ++ " activities from " ++ T.unpack (ddaDb args)
             outputResult registry fmt $ object ["database" .= ddaDb args, "deleted" .= deleted]
+
+-- | Execute database copy command
+executeDbCopy :: PluginRegistry -> OutputFormat -> DatabaseManager -> Text -> Text -> IO ()
+executeDbCopy registry fmt manager srcName newName = do
+    result <- copyDatabase manager srcName newName
+    case result of
+        Left err -> do
+            reportError $ "Copy failed: " ++ T.unpack err
+            exitFailure
+        Right () -> do
+            reportProgress Info $ "Copied database: " ++ T.unpack srcName ++ " -> " ++ T.unpack newName
+            outputResult registry fmt $ object ["source" .= srcName, "copy" .= newName]
 
 -- | Execute method delete command
 executeMcDelete :: PluginRegistry -> OutputFormat -> DatabaseManager -> Text -> IO ()

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -117,8 +117,16 @@ databaseParser =
                     <> OA.command "upload" (info (DbUpload <$> uploadArgsParser) (progDesc "Upload a database from a local file"))
                     <> OA.command "delete" (info (DbDelete <$> deleteNameParser) (progDesc "Delete a database"))
                     <> OA.command "delete-activities" (info (DbDeleteActivities <$> deleteActivitiesArgsParser <**> helper) (progDesc "Delete the whole filtered set of activities from a loaded database"))
+                    <> OA.command "copy" (info (copyArgsParser <**> helper) (progDesc "Copy a loaded database under a new name"))
                 )
             )
+
+-- | Copy arguments parser (positional SRC and NEW_NAME)
+copyArgsParser :: Parser DatabaseAction
+copyArgsParser =
+    DbCopy
+        <$> textArg "SRC" "Name of the loaded database to copy"
+        <*> textArg "NEW_NAME" "Name for the copy"
 
 {- | Delete-by-selection parser: positional DB plus filter options. @--keep@ and
 @--add@ may be repeated; they spare or add individual ProcessIds.

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -67,6 +67,8 @@ data DatabaseAction
       pagination ignored), keeping/adding explicit ProcessIds.
       -}
       DbDeleteActivities DbDeleteArgs
+    | -- | Copy a loaded database (source name → new name)
+      DbCopy Text Text
     deriving (Eq, Show, Generic)
 
 {- | Arguments for delete-by-selection. The filter fields mirror the activity

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -4,10 +4,18 @@
 
 {- |
 Module      : Database.Edit
-Description : In-memory database editing primitives (delete-by-selection)
+Description : In-memory database editing primitives (copy, delete-by-selection)
 
 Shared home for operations that produce a *new* loaded database from an
 existing one without touching disk.
+
+COPY is construction, not mutation. 'Database' is a pure, immutable value
+(see "Types"), so duplicating it is just sharing the same persistent
+structure under a second registry key: nothing observable can alias because
+nothing is mutable. The only fresh allocation is the solver (it holds an
+'MVar' factorization cache keyed by name); reusing the source solver would
+let the two registry entries share a factorization cache, so the copy gets
+its own.
 
 DELETE is reconstruction, not mutation either. 'deleteActivities' drops a set
 of activities and rebuilds every dependent structure (interning tables,
@@ -19,8 +27,15 @@ database is byte-for-byte indistinguishable from one that never carried the
 removed rows. Exchanges in surviving activities that referenced a deleted
 activity are UNLINKED (their activity link reset to nil), leaving the value
 ready for relinking — never silently dropped.
+
+Memory cost (copy): the copy keeps the source 'Database' alive for as long as
+it is loaded. Structural sharing means we don't re-allocate the activity/flow
+vectors, but a large database that would otherwise be unloaded stays resident
+while any copy of it is loaded.
 -}
 module Database.Edit (
+    copyDatabaseAs,
+    copyDatabase,
     deleteActivities,
     deleteActivitiesWith,
     resolveDeleteSelection,
@@ -38,6 +53,7 @@ import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 
+import Config (DatabaseConfig (..))
 import Database (
     applyStructuredFilters,
     buildIndexesWithProcessIds,
@@ -78,6 +94,79 @@ import Types (
     parseUUIDPair,
  )
 import UnitConversion (UnitConfig, defaultUnitConfig)
+
+{- | Produce a copy of a loaded database under a new internal name.
+
+The returned 'Database' is the source value unchanged — it carries no
+self-name (the name lives in the registry 'DatabaseConfig'), and because the
+value is immutable the copy is automatically independent of the source. The
+@newName@ is the registry identity the copy will be inserted under; see
+'copyDatabase' for the effectful registration that applies it.
+
+Kept as a named, total function so the rename intent is explicit at call
+sites and so future deep-edit primitives (which *will* transform the value)
+share this entry point.
+-}
+copyDatabaseAs :: Text -> Database -> Database
+copyDatabaseAs _newName = id
+
+{- | Copy a loaded database into the runtime registry under @newName@.
+
+Looks up the loaded source, builds an independent 'LoadedDatabase' (renamed
+config + fresh solver, see module note), and inserts it into the loaded /
+available / indexed maps. Fails (Left) when the source is not loaded or when
+@newName@ already names a loaded or configured database — a copy must never
+silently overwrite an existing entry.
+-}
+copyDatabase :: DatabaseManager -> Text -> Text -> IO (Either Text ())
+copyDatabase manager srcName newName = do
+    loadedDbs <- readTVarIO (dmLoadedDbs manager)
+    availableDbs <- readTVarIO (dmAvailableDbs manager)
+    if M.member newName loadedDbs || M.member newName availableDbs
+        then pure $ Left $ "Database already exists: " <> newName
+        else
+            getDatabase manager srcName >>= \case
+                Nothing -> pure $ Left $ "Database not loaded: " <> srcName
+                Just src -> do
+                    let copiedDb = copyDatabaseAs newName (ldDatabase src)
+                        newConfig = renameConfig newName (ldConfig src)
+                    -- Fresh solver: a distinct name keys a distinct factorization cache.
+                    let techTriplesInt =
+                            [ (fromIntegral i, fromIntegral j, v)
+                            | SparseTriple i j v <- U.toList (dbTechnosphereTriples copiedDb)
+                            ]
+                    solver <-
+                        createSharedSolver
+                            newName
+                            techTriplesInt
+                            (fromIntegral (dbActivityCount copiedDb))
+                    let copied =
+                            LoadedDatabase
+                                { ldDatabase = copiedDb
+                                , ldSharedSolver = solver
+                                , ldConfig = newConfig
+                                }
+                    synonymDB <- getMergedSynonymDB manager
+                    let indexedDb = buildIndexedDatabaseFromDB newName synonymDB copiedDb
+                    atomically $ do
+                        modifyTVar' (dmLoadedDbs manager) (M.insert newName copied)
+                        modifyTVar' (dmAvailableDbs manager) (M.insert newName newConfig)
+                        modifyTVar' (dmIndexedDbs manager) (M.insert newName indexedDb)
+                    clearMethodMappingCacheForDb manager newName
+                    pure $ Right ()
+
+{- | Rename a config for the copy: new internal name, derived display name, and
+forced deletable/uploaded so the copy can be removed again via the normal
+delete path (the source may be a TOML-pinned, non-deletable database).
+-}
+renameConfig :: Text -> DatabaseConfig -> DatabaseConfig
+renameConfig newName cfg =
+    cfg
+        { dcName = newName
+        , dcDisplayName = newName
+        , dcIsUploaded = True
+        , dcDeletable = True
+        }
 
 -- ---------------------------------------------------------------------------
 -- Delete by selection

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -34,7 +34,6 @@ vectors, but a large database that would otherwise be unloaded stays resident
 while any copy of it is loaded.
 -}
 module Database.Edit (
-    copyDatabaseAs,
     copyDatabase,
     deleteActivities,
     deleteActivitiesWith,
@@ -43,7 +42,8 @@ module Database.Edit (
     deleteActivitiesInDB,
 ) where
 
-import Control.Concurrent.STM (atomically, modifyTVar', readTVarIO)
+import Control.Concurrent.STM (atomically, modifyTVar', readTVar, readTVarIO)
+import Control.Exception (finally)
 import qualified Data.IntSet as IS
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
@@ -77,6 +77,7 @@ import Database.MatrixBuild (
     buildTechTriples,
     collectBioFlowOrder,
  )
+import Database.Upload (slugify)
 import Matrix (clearCachedSolver)
 import qualified Search.BM25 as BM25
 import Service (bm25Retrieve)
@@ -95,65 +96,78 @@ import Types (
  )
 import UnitConversion (UnitConfig, defaultUnitConfig)
 
-{- | Produce a copy of a loaded database under a new internal name.
-
-The returned 'Database' is the source value unchanged — it carries no
-self-name (the name lives in the registry 'DatabaseConfig'), and because the
-value is immutable the copy is automatically independent of the source. The
-@newName@ is the registry identity the copy will be inserted under; see
-'copyDatabase' for the effectful registration that applies it.
-
-Kept as a named, total function so the rename intent is explicit at call
-sites and so future deep-edit primitives (which *will* transform the value)
-share this entry point.
--}
-copyDatabaseAs :: Text -> Database -> Database
-copyDatabaseAs _newName = id
-
-{- | Copy a loaded database into the runtime registry under @newName@.
+{- | Copy a loaded database into the runtime registry under the slugified
+@newName@.
 
 Looks up the loaded source, builds an independent 'LoadedDatabase' (renamed
-config + fresh solver, see module note), and inserts it into the loaded /
-available / indexed maps. Fails (Left) when the source is not loaded or when
-@newName@ already names a loaded or configured database — a copy must never
-silently overwrite an existing entry.
+config + fresh solver — 'Database' is immutable, so the value itself is shared
+safely) and inserts it into the loaded / available / indexed maps.
+
+@newName@ is slugified to the same charset as uploaded databases: the copy is
+registered as uploaded (see 'renameConfig'), and uploaded databases are later
+deleted by name via 'removeDirectoryRecursive', so an unsanitised name (e.g.
+@"../x"@ or @""@) would let the eventual delete escape the uploads directory.
+
+Fails (Left) when the source is not loaded, when @newName@ slugifies to empty,
+or when the name already designates a loaded, configured, or in-flight
+database — a copy must never silently overwrite an existing entry. The name is
+reserved atomically (in 'dmStagingDbs') across the slow solver build, so two
+concurrent copies of the same name cannot both pass the existence check.
 -}
 copyDatabase :: DatabaseManager -> Text -> Text -> IO (Either Text ())
 copyDatabase manager srcName newName = do
-    loadedDbs <- readTVarIO (dmLoadedDbs manager)
-    availableDbs <- readTVarIO (dmAvailableDbs manager)
-    if M.member newName loadedDbs || M.member newName availableDbs
-        then pure $ Left $ "Database already exists: " <> newName
+    let slug = slugify newName
+    if T.null slug
+        then pure $ Left $ "Invalid copy name (no usable characters): " <> newName
         else
             getDatabase manager srcName >>= \case
                 Nothing -> pure $ Left $ "Database not loaded: " <> srcName
                 Just src -> do
-                    let copiedDb = copyDatabaseAs newName (ldDatabase src)
-                        newConfig = renameConfig newName (ldConfig src)
-                    -- Fresh solver: a distinct name keys a distinct factorization cache.
-                    let techTriplesInt =
-                            [ (fromIntegral i, fromIntegral j, v)
-                            | SparseTriple i j v <- U.toList (dbTechnosphereTriples copiedDb)
-                            ]
-                    solver <-
-                        createSharedSolver
-                            newName
-                            techTriplesInt
-                            (fromIntegral (dbActivityCount copiedDb))
-                    let copied =
-                            LoadedDatabase
-                                { ldDatabase = copiedDb
-                                , ldSharedSolver = solver
-                                , ldConfig = newConfig
-                                }
-                    synonymDB <- getMergedSynonymDB manager
-                    let indexedDb = buildIndexedDatabaseFromDB newName synonymDB copiedDb
-                    atomically $ do
-                        modifyTVar' (dmLoadedDbs manager) (M.insert newName copied)
-                        modifyTVar' (dmAvailableDbs manager) (M.insert newName newConfig)
-                        modifyTVar' (dmIndexedDbs manager) (M.insert newName indexedDb)
-                    clearMethodMappingCacheForDb manager newName
-                    pure $ Right ()
+                    reserved <- atomically $ do
+                        loadedDbs <- readTVar (dmLoadedDbs manager)
+                        availableDbs <- readTVar (dmAvailableDbs manager)
+                        stagingDbs <- readTVar (dmStagingDbs manager)
+                        if M.member slug loadedDbs || M.member slug availableDbs || S.member slug stagingDbs
+                            then pure (Left ("Database already exists: " <> slug))
+                            else Right () <$ modifyTVar' (dmStagingDbs manager) (S.insert slug)
+                    case reserved of
+                        Left err -> pure (Left err)
+                        Right () ->
+                            finally
+                                (registerCopy manager slug src)
+                                (atomically $ modifyTVar' (dmStagingDbs manager) (S.delete slug))
+
+{- | Build the copy's solver/index and insert it under @slug@. Caller holds the
+'dmStagingDbs' reservation for @slug@.
+-}
+registerCopy :: DatabaseManager -> Text -> LoadedDatabase -> IO (Either Text ())
+registerCopy manager slug src = do
+    let copiedDb = ldDatabase src
+        newConfig = renameConfig slug (ldConfig src)
+        -- Fresh solver: a distinct name keys a distinct factorization cache.
+        techTriplesInt =
+            [ (fromIntegral i, fromIntegral j, v)
+            | SparseTriple i j v <- U.toList (dbTechnosphereTriples copiedDb)
+            ]
+    solver <-
+        createSharedSolver
+            slug
+            techTriplesInt
+            (fromIntegral (dbActivityCount copiedDb))
+    synonymDB <- getMergedSynonymDB manager
+    let copied =
+            LoadedDatabase
+                { ldDatabase = copiedDb
+                , ldSharedSolver = solver
+                , ldConfig = newConfig
+                }
+        indexedDb = buildIndexedDatabaseFromDB slug synonymDB copiedDb
+    atomically $ do
+        modifyTVar' (dmLoadedDbs manager) (M.insert slug copied)
+        modifyTVar' (dmAvailableDbs manager) (M.insert slug newConfig)
+        modifyTVar' (dmIndexedDbs manager) (M.insert slug indexedDb)
+    clearMethodMappingCacheForDb manager slug
+    pure $ Right ()
 
 {- | Rename a config for the copy: new internal name, derived display name, and
 forced deletable/uploaded so the copy can be removed again via the normal

--- a/test/CopySpec.hs
+++ b/test/CopySpec.hs
@@ -1,0 +1,274 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Tests for the COPY primitive ('Database.Edit.copyDatabase' and the pure
+'Database.Edit.copyDatabaseAs').
+
+A copy is a second, independent registry entry over an immutable 'Database'
+value:
+
+* it is registered under the new name in the loaded / available maps;
+* its config is renamed (dcName / dcDisplayName);
+* mutating or dropping the copy leaves the source untouched, and dropping the
+  source leaves the copy fully intact — the value is immutable, so there is no
+  aliasing to break;
+* copying onto an existing name, or from an unloaded source, fails loudly.
+-}
+module CopySpec (spec) where
+
+import Control.Concurrent.STM (atomically, modifyTVar', readTVarIO)
+import qualified Data.Map.Strict as M
+import Data.Maybe (isJust, isNothing)
+import Data.Text (Text)
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import Test.Hspec
+
+import Config (DatabaseConfig (..), defaultConfig)
+import qualified Data.Vector.Unboxed as U
+import Database (buildDatabaseWithMatrices)
+import Database.Edit (copyDatabase, copyDatabaseAs)
+import Database.Manager (
+    DatabaseManager (..),
+    LoadedDatabase (..),
+    initDatabaseManager,
+ )
+import Matrix (buildDemandVectorFromIndex)
+import SharedSolver (
+    SharedSolver,
+    createSharedSolver,
+    getFactorization,
+    solveWithSharedSolver,
+ )
+import Types (
+    Activity (..),
+    Database (..),
+    Exchange (..),
+    GeographyPolicy (..),
+    SparseTriple (..),
+    TechRole (..),
+    TechnosphereFlow (..),
+    UUID,
+    Unit (..),
+ )
+import UnitConversion (defaultUnitConfig)
+
+spec :: Spec
+spec = describe "Database.Edit copy primitive" $ do
+    it "registers an independent copy under the new name" $ do
+        manager <- initDatabaseManager defaultConfig True Nothing
+        srcDb <- buildOrFail (supplierDB 100 ["p1", "p2"])
+        installLoaded manager "source" srcDb
+
+        result <- copyDatabase manager "source" "mycopy"
+        result `shouldBe` Right ()
+
+        loaded <- readTVarIO (dmLoadedDbs manager)
+        available <- readTVarIO (dmAvailableDbs manager)
+        M.keys loaded `shouldMatchList` ["source", "mycopy"]
+        M.member "mycopy" available `shouldBe` True
+
+        let copy = loaded M.! "mycopy"
+        -- Renamed config.
+        dcName (ldConfig copy) `shouldBe` "mycopy"
+        dcDisplayName (ldConfig copy) `shouldBe` "mycopy"
+        -- Same data: identical activity count to the source.
+        V.length (dbActivities (ldDatabase copy))
+            `shouldBe` V.length (dbActivities srcDb)
+
+    it "is a deep, independent value — dropping the copy does not touch the source" $ do
+        manager <- initDatabaseManager defaultConfig True Nothing
+        srcDb <- buildOrFail (supplierDB 200 ["p1", "p2", "p3"])
+        installLoaded manager "source" srcDb
+        _ <- copyDatabase manager "source" "mycopy"
+
+        before <- readTVarIO (dmLoadedDbs manager)
+        let srcCount = V.length (dbActivities (ldDatabase (before M.! "source")))
+
+        -- Delete the copy outright from every registry map.
+        atomically $ do
+            modifyTVar' (dmLoadedDbs manager) (M.delete "mycopy")
+            modifyTVar' (dmAvailableDbs manager) (M.delete "mycopy")
+            modifyTVar' (dmIndexedDbs manager) (M.delete "mycopy")
+
+        after <- readTVarIO (dmLoadedDbs manager)
+        M.member "mycopy" after `shouldBe` False
+        M.member "source" after `shouldBe` True
+        V.length (dbActivities (ldDatabase (after M.! "source"))) `shouldBe` srcCount
+
+    it "is a deep, independent value — dropping the source leaves the copy intact" $ do
+        manager <- initDatabaseManager defaultConfig True Nothing
+        srcDb <- buildOrFail (supplierDB 300 ["p1", "p2"])
+        installLoaded manager "source" srcDb
+        _ <- copyDatabase manager "source" "mycopy"
+
+        let srcCount = V.length (dbActivities srcDb)
+        atomically $ do
+            modifyTVar' (dmLoadedDbs manager) (M.delete "source")
+            modifyTVar' (dmAvailableDbs manager) (M.delete "source")
+            modifyTVar' (dmIndexedDbs manager) (M.delete "source")
+
+        after <- readTVarIO (dmLoadedDbs manager)
+        M.member "source" after `shouldBe` False
+        V.length (dbActivities (ldDatabase (after M.! "mycopy"))) `shouldBe` srcCount
+
+    it "gives the copy its own solver — factorizing the source does not warm the copy's cache" $ do
+        manager <- initDatabaseManager defaultConfig True Nothing
+        srcDb <- buildOrFail (supplierDB 700 ["p1", "p2"])
+        installLoaded manager "source" srcDb
+        _ <- copyDatabase manager "source" "mycopy"
+
+        loaded <- readTVarIO (dmLoadedDbs manager)
+        let srcSolver = ldSharedSolver (loaded M.! "source")
+            copySolver = ldSharedSolver (loaded M.! "mycopy")
+
+        -- Force the source solver's lazy factorization via a first solve.
+        _ <- solveWithSharedSolver srcSolver (buildDemandVectorFromIndex (dbActivityIndex srcDb) 0)
+        -- MatrixFactorization has no Show instance, so assert on the Bool.
+        (isJust <$> getFactorization srcSolver) >>= (`shouldBe` True)
+
+        -- A shared MVar would have warmed the copy too; a distinct one stays empty.
+        (isNothing <$> getFactorization copySolver) >>= (`shouldBe` True)
+
+    it "refuses to overwrite an existing database name" $ do
+        manager <- initDatabaseManager defaultConfig True Nothing
+        srcDb <- buildOrFail (supplierDB 400 ["p1"])
+        otherDb <- buildOrFail (supplierDB 500 ["q1"])
+        installLoaded manager "source" srcDb
+        installLoaded manager "taken" otherDb
+
+        result <- copyDatabase manager "source" "taken"
+        result `shouldBe` Left "Database already exists: taken"
+
+    it "fails when the source is not loaded" $ do
+        manager <- initDatabaseManager defaultConfig True Nothing
+        result <- copyDatabase manager "ghost" "mycopy"
+        result `shouldBe` Left "Database not loaded: ghost"
+
+    it "copyDatabaseAs preserves the source value structurally" $ do
+        srcDb <- buildOrFail (supplierDB 600 ["p1", "p2"])
+        let copied = copyDatabaseAs "whatever" srcDb
+        V.length (dbActivities copied) `shouldBe` V.length (dbActivities srcDb)
+        dbActivityCount copied `shouldBe` dbActivityCount srcDb
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+
+{- | Install a built database as a LoadedDatabase under @name@: solver,
+config, loaded map, and available map. Mirrors what the load path does, but
+without disk I/O.
+-}
+installLoaded :: DatabaseManager -> Text -> Database -> IO ()
+installLoaded manager name db = do
+    solver <- mkSolver name db
+    let loaded =
+            LoadedDatabase
+                { ldDatabase = db
+                , ldSharedSolver = solver
+                , ldConfig = mkConfig name
+                }
+    atomically $ do
+        modifyTVar' (dmLoadedDbs manager) (M.insert name loaded)
+        modifyTVar' (dmAvailableDbs manager) (M.insert name (mkConfig name))
+
+mkSolver :: Text -> Database -> IO SharedSolver
+mkSolver name db =
+    let triples = [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList (dbTechnosphereTriples db)]
+     in createSharedSolver name triples (fromIntegral (dbActivityCount db))
+
+mkConfig :: Text -> DatabaseConfig
+mkConfig name =
+    DatabaseConfig
+        { dcName = name
+        , dcDisplayName = name
+        , dcPath = ""
+        , dcDescription = Nothing
+        , dcLoad = True
+        , dcDefault = False
+        , dcDepends = []
+        , dcLocationAliases = M.empty
+        , dcFormat = Nothing
+        , dcIsUploaded = False
+        , dcDeletable = False
+        , dcGeographyPolicy = GeoGlobal
+        }
+
+buildOrFail :: SimpleParts -> IO Database
+buildOrFail (SimpleParts acts flows units) = do
+    r <- buildDatabaseWithMatrices defaultUnitConfig acts flows M.empty M.empty units
+    case r of
+        Right db -> pure db
+        Left err -> fail ("buildDatabaseWithMatrices: " <> show err)
+
+-- ---------------------------------------------------------------------------
+-- Fixture builders (single unit "kg", all activities at GLO)
+-- ---------------------------------------------------------------------------
+
+data SimpleParts
+    = SimpleParts
+        (M.Map (UUID, UUID) Activity)
+        (M.Map UUID TechnosphereFlow)
+        (M.Map UUID Unit)
+
+mkUUID :: Int -> UUID
+mkUUID n = UUID.fromWords64 (fromIntegral n) 0
+
+kgUnitId :: UUID
+kgUnitId = mkUUID 0
+
+kgUnit :: Unit
+kgUnit = Unit{unitId = kgUnitId, unitName = "kg", unitSymbol = "kg", unitComment = ""}
+
+mkTechFlow :: UUID -> Text -> TechnosphereFlow
+mkTechFlow fid name =
+    TechnosphereFlow
+        { tfId = fid
+        , tfName = name
+        , tfUnitId = kgUnitId
+        , tfSynonyms = M.empty
+        , tfCAS = Nothing
+        , tfSubstanceId = Nothing
+        }
+
+-- | One self-producing activity per product name. 'offset' keeps UUIDs disjoint.
+supplierDB :: Int -> [Text] -> SimpleParts
+supplierDB offset products =
+    let entries =
+            [ let actUUID = mkUUID (offset + 10 * i + 1)
+                  prodUUID = mkUUID (offset + 10 * i + 2)
+                  flowUUID = mkUUID (offset + 10 * i + 3)
+                  flow = mkTechFlow flowUUID name
+                  refOut =
+                    TechnosphereExchange
+                        { techFlowId = flowUUID
+                        , techAmount = 1.0
+                        , techUnitId = kgUnitId
+                        , techRole = ReferenceProduct
+                        , techActivityLinkId = actUUID
+                        , techProcessLinkId = Nothing
+                        , techLocation = ""
+                        , techComment = Nothing
+                        , techPedigree = Nothing
+                        }
+                  act =
+                    Activity
+                        { activityName = "supplier-of-" <> name
+                        , activityDescription = []
+                        , activitySynonyms = M.empty
+                        , activityClassification = M.empty
+                        , activityLocation = "GLO"
+                        , activityUnit = "kg"
+                        , exchanges = [refOut]
+                        , activityParams = M.empty
+                        , activityParamExprs = M.empty
+                        , activityAllocationPercent = Nothing
+                        , activityAllocationFormula = Nothing
+                        , activityNativeType = Nothing
+                        }
+               in (((actUUID, prodUUID), act), (flowUUID, flow))
+            | (i, name) <- zip [0 ..] products
+            ]
+     in SimpleParts
+            (M.fromList (map fst entries))
+            (M.fromList (map snd entries))
+            (M.singleton kgUnitId kgUnit)

--- a/test/CopySpec.hs
+++ b/test/CopySpec.hs
@@ -18,7 +18,7 @@ module CopySpec (spec) where
 import Control.Concurrent.STM (atomically, modifyTVar', readTVarIO)
 import qualified Data.Map.Strict as M
 import Data.Maybe (isJust, isNothing)
-import Data.Text (Text)
+import Data.Text (Text, isInfixOf)
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import Test.Hspec
@@ -26,7 +26,7 @@ import Test.Hspec
 import Config (DatabaseConfig (..), defaultConfig)
 import qualified Data.Vector.Unboxed as U
 import Database (buildDatabaseWithMatrices)
-import Database.Edit (copyDatabase, copyDatabaseAs)
+import Database.Edit (copyDatabase)
 import Database.Manager (
     DatabaseManager (..),
     LoadedDatabase (..),
@@ -144,11 +144,28 @@ spec = describe "Database.Edit copy primitive" $ do
         result <- copyDatabase manager "ghost" "mycopy"
         result `shouldBe` Left "Database not loaded: ghost"
 
-    it "copyDatabaseAs preserves the source value structurally" $ do
-        srcDb <- buildOrFail (supplierDB 600 ["p1", "p2"])
-        let copied = copyDatabaseAs "whatever" srcDb
-        V.length (dbActivities copied) `shouldBe` V.length (dbActivities srcDb)
-        dbActivityCount copied `shouldBe` dbActivityCount srcDb
+    it "slugifies a path-traversal copy name to a filesystem-safe slug" $ do
+        -- The copy is registered as an uploaded database and later deleted by
+        -- name via removeDirectoryRecursive, so the name must never carry a
+        -- path separator or parent ref that could escape the uploads directory.
+        manager <- initDatabaseManager defaultConfig True Nothing
+        srcDb <- buildOrFail (supplierDB 800 ["p1", "p2"])
+        installLoaded manager "source" srcDb
+        result <- copyDatabase manager "source" "../../etc/passwd"
+        result `shouldBe` Right ()
+        loaded <- readTVarIO (dmLoadedDbs manager)
+        let copyNames = filter (/= "source") (M.keys loaded)
+        copyNames `shouldSatisfy` (not . null)
+        copyNames `shouldSatisfy` all (\n -> not ("/" `isInfixOf` n) && not (".." `isInfixOf` n))
+
+    it "rejects a copy name with no usable characters" $ do
+        manager <- initDatabaseManager defaultConfig True Nothing
+        srcDb <- buildOrFail (supplierDB 900 ["p1", "p2"])
+        installLoaded manager "source" srcDb
+        result <- copyDatabase manager "source" "///"
+        case result of
+            Left msg -> msg `shouldSatisfy` isInfixOf "Invalid copy name"
+            Right () -> expectationFailure "expected empty-slug copy name to be rejected"
 
 -- ---------------------------------------------------------------------------
 -- Helpers

--- a/volca.cabal
+++ b/volca.cabal
@@ -265,6 +265,7 @@ test-suite lca-tests
                      , NumericEdgesSpec
                      , AggregateSpec
                      , ConfigWriterSpec
+                     , CopySpec
                      , DeleteSelectionSpec
                      , PropertiesSpec
   build-depends:       base >=4.14 && <5


### PR DESCRIPTION
## What
Duplicate a loaded database into the registry under a fresh name. Because a `Database` is an immutable value, the copy shares the source's persistent structure; the only fresh allocation is the solver, which gets its own factorization cache (keyed by the new name) so the two registry entries never share one. The copy's config is forced uploaded/deletable so it can be removed via the normal delete path even when the source is TOML-pinned.

Exposed over CLI (`db copy`), HTTP (`POST /db/{db}/copy/{newName}`) and pyvolca (`copy_database`); a name clash is refused rather than silently overwritten.

Part of the #113 split into focused, independently-reviewable PRs. Stacked on `feat/db-delete` — **merge bottom-up**; #114 (delete) is the base of the stack. Full stack: `cabal test lca-tests` → 1255 examples, 0 failures.