### PR TITLE
feat(edit): relink against one dependency via a name→name alias map

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ active = true
 
 The `depends` field ensures dependency databases load first and their flows are available for cross-database linking. Setting `load = true` on a database transitively loads all its dependencies.
 
-A database's dependency set is **pinned**: it is seeded automatically when the database is first staged (the minimal set of supplier databases needed to resolve its links), and from then on it is authoritative. `relink` re-resolves links *within* the pinned set only — it never silently adds another loaded database. Edit the pin explicitly with `add-dependency` / `remove-dependency`, then `finalize`; the new set is written to the matrix cache and reused on every later open. This is how you restrict a consumer (e.g. an inventory built against a single Agribalyse version) to exactly the supplier databases it should depend on, even while other versions stay loaded for other consumers.
+A database's dependency set is **pinned**: it is seeded automatically when the database is first staged (the minimal set of supplier databases needed to resolve its links), and from then on it is authoritative. A plain `relink` re-resolves links *within* the pinned set only — it never silently adds another loaded database. Edit the pin explicitly with `add-dependency` / `remove-dependency`, then `finalize`; the new set is written to the matrix cache and reused on every later open. This is how you restrict a consumer (e.g. an inventory built against a single Agribalyse version) to exactly the supplier databases it should depend on, even while other versions stay loaded for other consumers. (The one exception is a *mapping* relink — `relink` with a `depDb` and an alias CSV — which pins that chosen dependency in-memory if it isn't already, so a `copy → delete → relink` pipeline composes in one pass; links to the other pinned dependencies are preserved, not dropped.)
 
 ---
 
@@ -199,7 +199,7 @@ GET    /api/v1/db                                                        List da
 POST   /api/v1/db/upload                                                 Upload a database archive
 POST   /api/v1/db/{dbName}/load                                          Load a configured database
 POST   /api/v1/db/{dbName}/unload                                        Unload (keep config, free memory)
-POST   /api/v1/db/{dbName}/relink                                        Re-resolve cross-DB links
+POST   /api/v1/db/{dbName}/relink                                        Re-resolve cross-DB links (optional JSON body: depDb + mappingCsv for an alias relink)
 POST   /api/v1/db/{dbName}/finalize                                      Finalize cross-DB linking
 DELETE /api/v1/db/{dbName}                                               Delete a database
 GET    /api/v1/db/{dbName}/setup                                         Setup info (path, dependencies)

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -358,6 +358,13 @@ supplier — fast::
 
 #### Methods
 
+##### `Client.add_dependency(dep_name: str, db_name: str | None = None) -> dict`
+
+Declare ``dep_name`` as a dependency of the target database.
+
+Returns the engine's ``DatabaseSetupInfo`` dict describing the updated
+dependency topology.
+
 ##### `Client.aggregate(process_id: str, scope: AggregateScope | str, *, is_input: bool | None = None, max_depth: int | None = None, filter_name: str | None = None, filter_name_not: list[str] | str | None = None, filter_unit: str | None = None, preset: str | None = None, filter_classification: list[ClassificationFilter] | None = None, filter_target_name: str | None = None, filter_is_reference: bool | None = None, group_by: str | None = None, aggregate: AggregateOp | str | None = None) -> AggregateResult`
 
 SQL-group-by aggregation over direct exchanges, supply chain, or biosphere flows.
@@ -606,6 +613,25 @@ Fetch the OpenAPI spec from the server and refresh the dispatch table.
 Also regenerates the `.pyi` type stubs in the installed pyvolca
 package directory so IDE autocomplete reflects the current engine.
 Useful when the engine is upgraded without reinstalling pyvolca.
+
+##### `Client.relink(dep_db: str, mapping_csv: str, db_name: str | None = None) -> dict`
+
+Re-link a database against a dependency using a name→name alias CSV.
+
+``mapping_csv`` is the CSV *text* (header row + source/target columns),
+sent inline so the engine needs no filesystem access. Returns the
+``RelinkResponse`` dict (``{"dbName", "unresolvedBefore",
+"unresolvedAfter", "crossDBLinks", "dependsOn"}``).
+
+##### `Client.relink_from_file(dep_db: str, mapping_path: str, db_name: str | None = None) -> dict`
+
+Read a mapping CSV file and call :meth:`relink` with its text.
+
+##### `Client.remove_dependency(dep_name: str, db_name: str | None = None) -> dict`
+
+Remove ``dep_name`` from the target database's dependencies.
+
+Returns the updated ``DatabaseSetupInfo`` dict.
 
 ##### `Client.search_activities(name: str | None = None, *, geo: str | None = None, product: str | None = None, preset: str | None = None, classification: str | None = None, classification_value: str | None = None, page: int | None = None, page_size: int | None = None, limit: int | None = None, offset: int | None = None, exact: bool = False) -> SearchResults[Activity]`
 

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -40,6 +40,7 @@ variants in the Servant API.
 from __future__ import annotations
 
 from enum import Enum
+from pathlib import Path
 from typing import Any
 
 import requests
@@ -700,6 +701,56 @@ class Client:
             )
         )
         return self._require_success(payload, "delete_activities")
+
+    def relink(
+        self, dep_db: str, mapping_csv: str, db_name: str | None = None
+    ) -> dict:
+        """Re-link a database against a dependency using a name→name alias CSV.
+
+        ``mapping_csv`` is the CSV *text* (header row + source/target columns),
+        sent inline so the engine needs no filesystem access. Returns the
+        ``RelinkResponse`` dict (``{"dbName", "unresolvedBefore",
+        "unresolvedAfter", "crossDBLinks", "dependsOn"}``).
+        """
+        target = self._db(db_name)
+        body = {"depDb": dep_db, "mappingCsv": mapping_csv}
+        return self._json(
+            self._session.post(
+                f"{self.base_url}/api/v1/db/{target}/relink", json=body
+            )
+        )
+
+    def relink_from_file(
+        self, dep_db: str, mapping_path: str, db_name: str | None = None
+    ) -> dict:
+        """Read a mapping CSV file and call :meth:`relink` with its text."""
+        csv_text = Path(mapping_path).read_text(encoding="utf-8")
+        return self.relink(dep_db, csv_text, db_name=db_name)
+
+    def add_dependency(self, dep_name: str, db_name: str | None = None) -> dict:
+        """Declare ``dep_name`` as a dependency of the target database.
+
+        Returns the engine's ``DatabaseSetupInfo`` dict describing the updated
+        dependency topology.
+        """
+        target = self._db(db_name)
+        return self._json(
+            self._session.post(
+                f"{self.base_url}/api/v1/db/{target}/add-dependency/{dep_name}"
+            )
+        )
+
+    def remove_dependency(self, dep_name: str, db_name: str | None = None) -> dict:
+        """Remove ``dep_name`` from the target database's dependencies.
+
+        Returns the updated ``DatabaseSetupInfo`` dict.
+        """
+        target = self._db(db_name)
+        return self._json(
+            self._session.post(
+                f"{self.base_url}/api/v1/db/{target}/remove-dependency/{dep_name}"
+            )
+        )
 
     def list_presets(self) -> list[Preset]:
         """List classification presets configured in this instance.

--- a/pyvolca/tests/test_db_write.py
+++ b/pyvolca/tests/test_db_write.py
@@ -124,3 +124,60 @@ class TestCopy:
         _ok(session, {"success": False, "message": "already exists"})
         with pytest.raises(VoLCAError, match="already exists"):
             client.copy_database("clone")
+
+
+# ---------------------------------------------------------------------------
+# relink
+# ---------------------------------------------------------------------------
+
+
+class TestRelink:
+    def test_body_and_url(self, mocked_client):
+        client, session = mocked_client
+        _ok(
+            session,
+            {
+                "dbName": "testdb",
+                "unresolvedBefore": 10,
+                "unresolvedAfter": 2,
+                "crossDBLinks": 8,
+                "dependsOn": ["ecoinvent-3.9"],
+            },
+        )
+        result = client.relink("ecoinvent-3.9", "src,dst\nfoo,bar\n")
+        assert result["unresolvedAfter"] == 2
+        url = session.post.call_args[0][0]
+        assert url == "http://test.local/api/v1/db/testdb/relink"
+        body = session.post.call_args[1]["json"]
+        assert body == {"depDb": "ecoinvent-3.9", "mappingCsv": "src,dst\nfoo,bar\n"}
+
+    def test_from_file_reads_text(self, mocked_client, tmp_path):
+        client, session = mocked_client
+        _ok(session, {"dbName": "testdb", "unresolvedBefore": 0,
+                      "unresolvedAfter": 0, "crossDBLinks": 0, "dependsOn": []})
+        csv = tmp_path / "map.csv"
+        csv.write_text("src,dst\nfoo,bar\n", encoding="utf-8")
+        client.relink_from_file("dep", str(csv))
+        body = session.post.call_args[1]["json"]
+        assert body == {"depDb": "dep", "mappingCsv": "src,dst\nfoo,bar\n"}
+
+
+# ---------------------------------------------------------------------------
+# dependencies
+# ---------------------------------------------------------------------------
+
+
+class TestDependencies:
+    def test_add_dependency_url(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"dependsOn": ["dep"]})
+        client.add_dependency("dep")
+        url = session.post.call_args[0][0]
+        assert url == "http://test.local/api/v1/db/testdb/add-dependency/dep"
+
+    def test_remove_dependency_url(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"dependsOn": []})
+        client.remove_dependency("dep", db_name="other")
+        url = session.post.call_args[0][0]
+        assert url == "http://test.local/api/v1/db/other/remove-dependency/dep"

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -82,6 +82,7 @@ import API.Types (
     LoadDatabaseResponse (..),
     RefDataListResponse (..),
     RefDataStatusAPI (..),
+    RelinkRequest (..),
     RelinkResponse (..),
     SynonymGroupsResponse (..),
     UploadRequest (..),
@@ -124,6 +125,7 @@ import Database.Manager (
     loadFlowSynonyms,
     loadUnitDefs,
     relinkDatabase,
+    relinkDatabaseWithMapping,
     removeCompartmentMappings,
     removeDatabase,
     removeDependencyFromStaged,
@@ -136,6 +138,7 @@ import Database.Manager (
     unloadFlowSynonyms,
     unloadUnitDefs,
  )
+import Database.RelinkMapping (buildAliasMap, parseAliasCSV)
 import Database.Upload (
     DatabaseFormat (..),
     UploadData (..),
@@ -173,25 +176,47 @@ unloadDatabaseHandler dbName = do
     dbManager <- asks aeDbManager
     simpleAction (unloadDatabase dbManager dbName) ("Unloaded database: " <> dbName)
 
-{- | Re-run cross-DB linking for a loaded database against the currently-loaded
-dependency databases. Lets the user recover from loads that happened in a
-suboptimal order without reloading the whole database.
+{- | Re-run cross-DB linking for a loaded database. An empty @{}@ body
+re-resolves links within the existing dependency pin (plain relink) — letting
+the user recover from loads that happened in a suboptimal order without
+reloading. A body carrying both @depDb@ and @mappingCsv@ switches to mapping
+mode: relink against that one dependency using an inline name→name
+supplier-alias CSV, so an Ecoinvent-named background (e.g. Agribalyse) resolves
+against a differently-named dependency (e.g. BAFU). A loaded-but-undeclared
+dependency is auto-pinned in-memory rather than rejected. Supplying exactly one
+of the two is a client error. Parse/validation failures surface as 4xx rather
+than a silent no-op; the only 404 from this path is an unloaded database or
+dependency.
 -}
-relinkDatabaseHandler :: Text -> AppM RelinkResponse
-relinkDatabaseHandler dbName = do
+relinkDatabaseHandler :: Text -> RelinkRequest -> AppM RelinkResponse
+relinkDatabaseHandler dbName req = do
     dbManager <- asks aeDbManager
-    res <- liftIO $ relinkDatabase dbManager dbName
-    case res of
-        Left err -> throwError err404{errBody = BSL.fromStrict $ T.encodeUtf8 err}
-        Right r ->
-            return
-                RelinkResponse
-                    { rrDbName = rresDbName r
-                    , rrUnresolvedBefore = rresUnresolvedBefore r
-                    , rrUnresolvedAfter = rresUnresolvedAfter r
-                    , rrCrossDBLinks = rresCrossDBLinks r
-                    , rrDependsOn = rresDepsLoaded r
-                    }
+    case (rmrDepDb req, rmrMappingCsv req) of
+        (Nothing, Nothing) ->
+            runRelink (relinkDatabase dbManager dbName)
+        (Just depDb, Just csv) ->
+            case parseAliasCSV (BSL.fromStrict (T.encodeUtf8 csv)) >>= buildAliasMap of
+                Left err -> throwError err400{errBody = BSL.fromStrict $ T.encodeUtf8 err}
+                Right aliases -> runRelink (relinkDatabaseWithMapping dbManager dbName depDb aliases)
+        (Just _, Nothing) -> incomplete
+        (Nothing, Just _) -> incomplete
+  where
+    incomplete =
+        throwError err400{errBody = "relink: depDb and mappingCsv must be supplied together"}
+    runRelink :: IO (Either Text RelinkResult) -> AppM RelinkResponse
+    runRelink act = do
+        res <- liftIO act
+        case res of
+            Left err -> throwError err404{errBody = BSL.fromStrict $ T.encodeUtf8 err}
+            Right r ->
+                return
+                    RelinkResponse
+                        { rrDbName = rresDbName r
+                        , rrUnresolvedBefore = rresUnresolvedBefore r
+                        , rrUnresolvedAfter = rresUnresolvedAfter r
+                        , rrCrossDBLinks = rresCrossDBLinks r
+                        , rrDependsOn = rresDepsLoaded r
+                        }
 
 {- | Copy a loaded database under a new name. The copy is an independent
 in-memory database registered under @newName@; the source is untouched.

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -138,7 +138,7 @@ import Database.Manager (
     unloadFlowSynonyms,
     unloadUnitDefs,
  )
-import Database.RelinkMapping (buildAliasMap, parseAliasCSV)
+import Database.RelinkMapping (buildAliasMap, parseAliasCSV, rejectEmpty)
 import Database.Upload (
     DatabaseFormat (..),
     UploadData (..),
@@ -195,7 +195,7 @@ relinkDatabaseHandler dbName req = do
         (Nothing, Nothing) ->
             runRelink (relinkDatabase dbManager dbName)
         (Just depDb, Just csv) ->
-            case parseAliasCSV (BSL.fromStrict (T.encodeUtf8 csv)) >>= buildAliasMap of
+            case parseAliasCSV (BSL.fromStrict (T.encodeUtf8 csv)) >>= buildAliasMap >>= rejectEmpty of
                 Left err -> throwError err400{errBody = BSL.fromStrict $ T.encodeUtf8 err}
                 Right aliases -> runRelink (relinkDatabaseWithMapping dbManager dbName depDb aliases)
         (Just _, Nothing) -> incomplete

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -10,7 +10,7 @@ module API.Routes where
 import API.DatabaseHandlers (simpleAction)
 import qualified API.DatabaseHandlers as DBHandlers
 import qualified API.OpenApi
-import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), RefDataListResponse (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadRequest (..), UploadResponse (..), apiFlowOfKind)
+import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadRequest (..), UploadResponse (..), apiFlowOfKind)
 import App.Env (AppEnv (..), AppM, runApp)
 import qualified Config
 import Control.Concurrent.Async (mapConcurrently)
@@ -120,7 +120,8 @@ type LCAAPI =
                 -- Load/Unload/Delete endpoints
                 :<|> "db" :> Capture "dbName" Text :> "load" :> Post '[JSON] LoadDatabaseResponse
                 :<|> "db" :> Capture "dbName" Text :> "unload" :> Post '[JSON] ActivateResponse
-                :<|> "db" :> Capture "dbName" Text :> "relink" :> Post '[JSON] RelinkResponse
+                -- Relink: empty {} body = plain relink; {depDb,mappingCsv} = mapping relink
+                :<|> "db" :> Capture "dbName" Text :> "relink" :> ReqBody '[JSON] RelinkRequest :> Post '[JSON] RelinkResponse
                 :<|> "db" :> Capture "dbName" Text :> "copy" :> Capture "newName" Text :> Post '[JSON] ActivateResponse
                 :<|> "db" :> Capture "dbName" Text :> Delete '[JSON] ActivateResponse
                 -- Delete the whole filtered set of activities (selection in JSON body)
@@ -199,7 +200,7 @@ requireDatabaseByName dbName = do
         Nothing -> throwError err404{errBody = notLoadedBody databaseNotLoadedPrefix dbName}
 
 {- | Refuse LCIA when the DB still has unresolved cross-DB products. Forces
-the user to load the missing dep DBs (or POST /relink) rather than
+the user to load the missing dep DBs (or POST {} to /relink) rather than
 silently undercounting impacts.
 -}
 requireFullyLinked :: Text -> Database -> AppM ()
@@ -218,7 +219,7 @@ requireFullyLinked dbName db =
                                     <> " unresolved cross-DB products. Load the missing dependency "
                                     <> "databases (see GET /api/v1/db/"
                                     <> dbName
-                                    <> "/setup) then POST /api/v1/db/"
+                                    <> "/setup) then POST {} to /api/v1/db/"
                                     <> dbName
                                     <> "/relink."
                     }

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -718,6 +718,22 @@ data RelinkResponse = RelinkResponse
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped RelinkResponse)
 
+{- | Request body for the relink endpoint. Both fields absent (an empty @{}@
+body) means a plain relink — re-resolve links within the existing pin. Both
+present switches to mapping mode: relink against @rmrDepDb@ using the inline
+name→name supplier-alias CSV in @rmrMappingCsv@ (sent inline so the client can
+forward a local file without the server needing filesystem access). Supplying
+exactly one is rejected — they are only meaningful together.
+-}
+data RelinkRequest = RelinkRequest
+    { rmrDepDb :: Maybe Text
+    -- ^ Dependency database to link against (must be a declared dependency)
+    , rmrMappingCsv :: Maybe Text
+    -- ^ Mapping CSV content (header row + source/target columns)
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped RelinkRequest)
+
 -- | Result of auto-loading a single dependency
 data DepLoadResult
     = DepLoaded {dlrName :: Text}

--- a/src/CLI/Client.hs
+++ b/src/CLI/Client.hs
@@ -10,7 +10,7 @@ module CLI.Client (
 
 import CLI.Types
 import Config (Config (..), ServerConfig (..))
-import Control.Exception (try)
+import Control.Exception (IOException, try)
 import Data.Aeson (Value (..), decode, encode, object, (.:), (.=))
 import Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.Aeson.Key as Key
@@ -25,6 +25,7 @@ import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import qualified Data.Text.IO as TIO
 import qualified Data.Vector as V
 import Network.HTTP.Client (
     HttpException (..),
@@ -93,6 +94,19 @@ executeRemoteCommand mgr rc globalOpts cmd = do
                 ("/api/v1/db/" ++ T.unpack srcName ++ "/copy/" ++ T.unpack newName)
                 (object [])
                 >>= outputStatus fmt jp "copy"
+        Database (DbRelinkMapping args) -> do
+            readResult <- try (TIO.readFile (draMappingCsv args)) :: IO (Either IOException Text)
+            case readResult of
+                Left _ -> do
+                    reportError $ "cannot read mapping file " ++ draMappingCsv args
+                    exitFailure
+                Right csv ->
+                    apiPost
+                        mgr
+                        rc
+                        ("/api/v1/db/" ++ T.unpack (draDb args) ++ "/relink")
+                        (relinkMappingBody (draToDep args) csv)
+                        >>= output fmt jp
         Method McList ->
             apiGet mgr rc "/api/v1/method-collections" >>= output fmt jp
         Method (McUpload args) ->
@@ -246,6 +260,18 @@ deleteSelectionBody args =
         (Just sys, Just val) ->
             [object ["system" .= sys, "value" .= val, "exact" .= ddaExact args]]
         _ -> [] :: [Value]
+
+{- | Body for POST /api/v1/db/{db}/relink with an inline alias mapping.
+Keys mirror 'API.Types.RelinkRequest' after the @Stripped@ prefix transform
+(@rmrDepDb@ → @depDb@, @rmrMappingCsv@ → @mappingCsv@); both are populated here,
+which the handler reads as mapping mode (an empty @{}@ body is a plain relink).
+-}
+relinkMappingBody :: Text -> Text -> Value
+relinkMappingBody depDb csv =
+    object
+        [ "depDb" .= depDb
+        , "mappingCsv" .= csv
+        ]
 
 -- | Build query string from optional parameters
 buildQuery :: [(String, Maybe String)] -> String

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -3,7 +3,7 @@
 
 module CLI.Command where
 
-import CLI.Types (CLIConfig (..), Command (..), DatabaseAction (..), DbDeleteArgs (..), DebugMatricesOptions (..), FlowSubCommand (..), GlobalOptions (..), LCIAOptions (..), MappingOptions (..), MethodAction (..), OutputFormat (..), PluginAction (..), SearchActivitiesOptions (..), SearchFlowsOptions (..), UploadArgs (..))
+import CLI.Types (CLIConfig (..), Command (..), DatabaseAction (..), DbDeleteArgs (..), DbRelinkArgs (..), DebugMatricesOptions (..), FlowSubCommand (..), GlobalOptions (..), LCIAOptions (..), MappingOptions (..), MethodAction (..), OutputFormat (..), PluginAction (..), SearchActivitiesOptions (..), SearchFlowsOptions (..), UploadArgs (..))
 import Config (DatabaseConfig (..), MethodConfig (..))
 import Control.Concurrent.STM (readTVarIO)
 import Data.Aeson (Value, encode, object, toJSON, (.=))
@@ -17,8 +17,9 @@ import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import Database.Edit (copyDatabase, deleteActivitiesInDB)
-import Database.Manager (DatabaseManager (..), LoadedDatabase (..), addDatabase, addMethodCollection)
+import Database.Manager (DatabaseManager (..), LoadedDatabase (..), RelinkResult (..), addDatabase, addMethodCollection)
 import qualified Database.Manager as DM
+import Database.RelinkMapping (relinkWithMappingFile)
 import Database.Upload (UploadData (..), UploadResult (..), findMethodDirectory, handleUpload)
 import qualified Database.Upload
 import qualified Database.UploadedDatabase as UploadedDB
@@ -103,6 +104,8 @@ executeCommand (CLIConfig globalOpts _) cmd manager = do
             executeDbDeleteActivities registry outputFormat manager args
         Database (DbCopy srcName newName) ->
             executeDbCopy registry outputFormat manager srcName newName
+        Database (DbRelinkMapping args) ->
+            executeDbRelinkMapping registry outputFormat manager args
         Method McList ->
             DM.listMethodCollections manager >>= out . toJSON
         Method (McUpload args) ->
@@ -521,6 +524,34 @@ executeDbCopy registry fmt manager srcName newName = do
         Right () -> do
             reportProgress Info $ "Copied database: " ++ T.unpack srcName ++ " -> " ++ T.unpack newName
             outputResult registry fmt $ object ["source" .= srcName, "copy" .= newName]
+
+-- | Execute relink-with-mapping: relink a DB to a dependency via an alias CSV.
+executeDbRelinkMapping :: PluginRegistry -> OutputFormat -> DatabaseManager -> DbRelinkArgs -> IO ()
+executeDbRelinkMapping registry fmt manager args = do
+    result <- relinkWithMappingFile manager (draDb args) (draToDep args) (draMappingCsv args)
+    case result of
+        Left err -> do
+            reportError $ "Relink failed: " ++ T.unpack err
+            exitFailure
+        Right r -> do
+            reportProgress Info $
+                "Re-linked "
+                    ++ T.unpack (rresDbName r)
+                    ++ ": "
+                    ++ show (rresUnresolvedBefore r)
+                    ++ " -> "
+                    ++ show (rresUnresolvedAfter r)
+                    ++ " unresolved ("
+                    ++ show (rresCrossDBLinks r)
+                    ++ " cross-DB links)"
+            outputResult registry fmt $
+                object
+                    [ "database" .= rresDbName r
+                    , "unresolved_before" .= rresUnresolvedBefore r
+                    , "unresolved_after" .= rresUnresolvedAfter r
+                    , "cross_db_links" .= rresCrossDBLinks r
+                    , "depends_on" .= rresDepsLoaded r
+                    ]
 
 -- | Execute method delete command
 executeMcDelete :: PluginRegistry -> OutputFormat -> DatabaseManager -> Text -> IO ()

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -118,6 +118,7 @@ databaseParser =
                     <> OA.command "delete" (info (DbDelete <$> deleteNameParser) (progDesc "Delete a database"))
                     <> OA.command "delete-activities" (info (DbDeleteActivities <$> deleteActivitiesArgsParser <**> helper) (progDesc "Delete the whole filtered set of activities from a loaded database"))
                     <> OA.command "copy" (info (copyArgsParser <**> helper) (progDesc "Copy a loaded database under a new name"))
+                    <> OA.command "relink" (info (DbRelinkMapping <$> relinkArgsParser <**> helper) (progDesc "Relink a database to a dependency using a name->name supplier alias CSV"))
                 )
             )
 
@@ -127,6 +128,16 @@ copyArgsParser =
     DbCopy
         <$> textArg "SRC" "Name of the loaded database to copy"
         <*> textArg "NEW_NAME" "Name for the copy"
+
+{- | Relink-with-mapping parser: positional DB, @--to@ dependency, @--mapping@
+CSV path. Mirrors @db relink <db> --to <depDb> --mapping <csv>@.
+-}
+relinkArgsParser :: Parser DbRelinkArgs
+relinkArgsParser =
+    DbRelinkArgs
+        <$> textArg "DB" "Name of the loaded database to relink"
+        <*> textOpt "to" Nothing "DEP_DB" "Dependency database to link against"
+        <*> strOpt "mapping" Nothing "CSV" "Path to the name->name supplier alias CSV"
 
 {- | Delete-by-selection parser: positional DB plus filter options. @--keep@ and
 @--add@ may be repeated; they spare or add individual ProcessIds.

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -69,6 +69,21 @@ data DatabaseAction
       DbDeleteActivities DbDeleteArgs
     | -- | Copy a loaded database (source name → new name)
       DbCopy Text Text
+    | {- | Relink a database against one dependency using a name→name supplier
+      alias mapping loaded from a local CSV: @db@, @--to depDb@, @--mapping csv@.
+      -}
+      DbRelinkMapping DbRelinkArgs
+    deriving (Eq, Show, Generic)
+
+-- | Arguments for @database relink@ with a name→name supplier alias mapping.
+data DbRelinkArgs = DbRelinkArgs
+    { draDb :: Text
+    -- ^ Database to relink
+    , draToDep :: Text
+    -- ^ Dependency database to link against (@--to@)
+    , draMappingCsv :: FilePath
+    -- ^ Path to the mapping CSV (@--mapping@)
+    }
     deriving (Eq, Show, Generic)
 
 {- | Arguments for delete-by-selection. The filter fields mirror the activity

--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -569,9 +569,7 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
         -- win over the mapping.
         aliasOf nm = case lcSupplierAliases of
             Nothing -> Nothing
-            Just aliases -> case M.lookup nm aliases of
-                Just target -> Just target
-                Nothing -> M.lookup (normalizeText nm) aliases
+            Just aliases -> M.lookup nm aliases
         aliasCandidates = case aliasOf productName of
             Nothing -> []
             Just aliasName -> firstNonEmpty [tryName aliasName, tryPrefixes (extractProductPrefixes aliasName)]

--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -149,6 +149,15 @@ data LinkingContext = LinkingContext
     -- ^ Location hierarchy (code → parent codes)
     , lcGeographyPolicy :: !GeographyPolicy
     -- ^ How aggressively to widen geography when no exact match is found
+    , lcSupplierAliases :: !(Maybe (M.Map Text Text))
+    {- ^ Optional consumer-flow-name → supplier-name aliases. When a
+    consumer's input flow name does not match any supplier directly, the
+    matcher retries with its alias from this map (e.g. an Ecoinvent-named
+    input rewritten to the BAFU activity name). 'Nothing' disables the
+    feature entirely (the common case for ordinary loads); 'Just' an empty
+    map is equivalent. Keys are matched on the raw (un-normalized) flow
+    name, falling back to 'normalizeText'.
+    -}
     }
 
 -- | A candidate supplier from another database
@@ -553,6 +562,19 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
         --   1. Exact product-name match across all indexed DBs.
         --   2. Synonym-group match if exact yielded nothing.
         --   3. Prefix-splitting fallback for compound names (e.g. SimaPro).
+        -- Alias retry: when the consumer's flow name only matches the target
+        -- supplier under an explicit name→name mapping (e.g. Ecoinvent name →
+        -- BAFU activity name), look the alias up and run the same
+        -- exact/synonym sub-cascade on it. Tried last, so direct matches always
+        -- win over the mapping.
+        aliasOf nm = case lcSupplierAliases of
+            Nothing -> Nothing
+            Just aliases -> case M.lookup nm aliases of
+                Just target -> Just target
+                Nothing -> M.lookup (normalizeText nm) aliases
+        aliasCandidates = case aliasOf productName of
+            Nothing -> []
+            Just aliasName -> firstNonEmpty [tryName aliasName, tryPrefixes (extractProductPrefixes aliasName)]
         allCandidates =
             firstNonEmpty
                 [ concatMap (lookupExact normalizedName) lcIndexedDatabases
@@ -560,6 +582,7 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
                     Just groupId -> concatMap (lookupBySynonym groupId) lcIndexedDatabases
                     Nothing -> []
                 , tryPrefixes (extractProductPrefixes productName)
+                , aliasCandidates
                 ]
         -- Effective location: if raw location is empty, try extracting from compound name
         effectiveLocation =
@@ -637,19 +660,21 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
     firstNonEmpty :: [[a]] -> [a]
     firstNonEmpty = fromMaybe [] . find (not . null)
 
+    -- Run the (exact, then synonym) sub-cascade on a single candidate name.
+    tryName :: Text -> [(Text, SupplierEntry)]
+    tryName p =
+        let normalized = normalizeText p
+            byExact = concatMap (lookupExact normalized) lcIndexedDatabases
+            bySynonym = case lookupSynonymGroup lcSynonymDB (normalizeName p) of
+                Just groupId -> concatMap (lookupBySynonym groupId) lcIndexedDatabases
+                Nothing -> []
+         in firstNonEmpty [byExact, bySynonym]
+
     -- Try each prefix from compound name splitting; for each prefix run the
     -- same (exact, then synonym) sub-cascade; return the first prefix that
     -- yields anything.
     tryPrefixes :: [Text] -> [(Text, SupplierEntry)]
-    tryPrefixes = firstNonEmpty . map candidatesFor
-      where
-        candidatesFor p =
-            let normalized = normalizeText p
-                byExact = concatMap (lookupExact normalized) lcIndexedDatabases
-                bySynonym = case lookupSynonymGroup lcSynonymDB (normalizeName p) of
-                    Just groupId -> concatMap (lookupBySynonym groupId) lcIndexedDatabases
-                    Nothing -> []
-             in firstNonEmpty [byExact, bySynonym]
+    tryPrefixes = firstNonEmpty . map tryName
 
     classifyEntry :: Text -> (Text, SupplierEntry) -> Maybe ((Text, SupplierEntry), LocationKind)
     classifyEntry queryLoc entry@(_, SupplierEntry{seLocation}) =

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -43,6 +43,7 @@ module Database.Loader (
 
     -- * Cross-Database Linking
     fixActivityLinksWithCrossDB,
+    relinkSimpleDatabase,
     findAllCrossDBLinks,
     CrossDBLinkingStats (..),
     crossDBLinksCount,
@@ -1309,6 +1310,35 @@ hasInternalProducer db ex =
     case exchangeActivityLinkId ex of
         Nothing -> False
         Just actUUID -> M.member (actUUID, exchangeFlowId ex) (sdbActivities db)
+
+{- | Re-resolve the cross-DB links of a 'SimpleDatabase' against the given
+dependencies, optionally aliasing supplier names. Unlike
+'fixActivityLinksWithCrossDB' this always recomputes — a relink must re-resolve
+already-linked exchanges, e.g. to apply a new alias map — and threads @aliases@
+into 'lcSupplierAliases', so a staged relink behaves exactly like the loaded one.
+-}
+relinkSimpleDatabase ::
+    [IndexedDatabase] ->
+    SynonymDB ->
+    UC.UnitConfig ->
+    M.Map T.Text [T.Text] ->
+    GeographyPolicy ->
+    Maybe (M.Map T.Text T.Text) ->
+    SimpleDatabase ->
+    CrossDBLinkingStats
+relinkSimpleDatabase indexedDbs synonymDB unitConfig locationHier policy aliases db =
+    let ctx =
+            LinkingContext
+                { lcIndexedDatabases = indexedDbs
+                , lcSynonymDB = synonymDB
+                , lcUnitConfig = unitConfig
+                , lcThreshold = defaultLinkingThreshold
+                , lcLocationHierarchy = if M.null locationHier then locationHierarchy else locationHier
+                , lcGeographyPolicy = policy
+                , lcSupplierAliases = aliases
+                }
+        stats = findAllCrossDBLinks ctx (sdbTechFlows db) (sdbWasteFlows db) (sdbUnits db) (sdbActivities db)
+     in stats{cdlTotalInputs = countTotalTechInputs db}
 
 {- | Product names of technosphere demands with no resolved internal producer —
 the supplier gaps surfaced on the setup page. Covers both nil-link inputs and

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -1250,6 +1250,7 @@ fixActivityLinksWithCrossDB indexedDbs synonymDB unitConfig locationHier policy 
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = if M.null locationHier then locationHierarchy else locationHier
                         , lcGeographyPolicy = policy
+                        , lcSupplierAliases = Nothing
                         }
 
             -- Process all activities to find cross-DB links

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1490,16 +1490,17 @@ even though we already know the answer. The save is skipped when the
 relink is a no-op (no change vs. the in-memory state).
 -}
 relinkDatabase :: DatabaseManager -> Text -> IO (Either Text RelinkResult)
-relinkDatabase manager dbName = relinkDatabaseWith manager dbName Nothing Nothing Nothing
+relinkDatabase manager dbName = relinkDatabaseWith manager dbName Nothing Nothing
 
-{- | Re-link a loaded DB against a single chosen dependency, applying a
-name→name supplier-alias map. Restricts candidate suppliers to @depDb@ and
-threads the aliases into the matcher so a consumer's input flow name that only
-matches a target supplier under the mapping still links. If @depDb@ is loaded
-but not yet in the database's declared dependency set, it is pinned in-memory
-first — so an in-memory pipeline (copy → delete → relink) composes without
-restaging (which would unload the live database). Same persistence/no-op
-semantics as 'relinkDatabase'. Errors (DB or dep not loaded) surface as 'Left'.
+{- | Re-link a loaded DB across its full pinned dependency set, applying a
+name→name supplier-alias map. The aliases let a consumer's input flow name that
+only matches a target supplier (typically in @depDb@) under the mapping still
+link; links to the other pinned dependencies are re-resolved unchanged rather
+than dropped. If @depDb@ is loaded but not yet in the database's declared
+dependency set, it is pinned in-memory first — so an in-memory pipeline
+(copy → delete → relink) composes without restaging (which would unload the
+live database). Same persistence/no-op semantics as 'relinkDatabase'. Errors
+(DB or dep not loaded) surface as 'Left'.
 -}
 relinkDatabaseWithMapping ::
     DatabaseManager ->
@@ -1528,16 +1529,22 @@ relinkDatabaseWithMapping manager dbName depDb aliases = do
                 unless (depDb `elem` persistedDeps) $
                     atomically $
                         modifyTVar' (dmLoadedDbs manager) (M.adjust (addPinnedDep depDb) dbName)
-                relinkDatabaseWith manager dbName (Just [depDb]) (Just aliases) (Just persistedDeps)
+                relinkDatabaseWith manager dbName (Just aliases) (Just persistedDeps)
   where
+    -- Idempotent: a concurrent relink may have pinned the dep between the
+    -- snapshot above and this transaction, so never prepend a duplicate.
     addPinnedDep dep ld =
         let db = ldDatabase ld
-         in ld{ldDatabase = db{dbDependsOn = dep : dbDependsOn db}}
+         in if dep `elem` dbDependsOn db
+                then ld
+                else ld{ldDatabase = db{dbDependsOn = dep : dbDependsOn db}}
 
-{- | Shared relink core. @depOverride@ restricts the candidate dependency set
-to the given names (still intersected with the declared pin); 'Nothing' uses
-the full pin. @aliases@ feeds 'lcSupplierAliases'. The dependency set stored
-on the database ('dbDependsOn') is never mutated here.
+{- | Shared relink core. Candidates are the database's full declared pin
+('dbDependsOn'); relink recomputes the links within it but never grows or
+shrinks the set. @aliases@ feeds 'lcSupplierAliases' — a mapping relink passes
+the user's name→name map (which retargets a chosen dependency without dropping
+links to the others), a plain relink passes 'Nothing'. The dependency set
+stored on the database is never mutated here.
 
 @persistedDeps@ is the dependency set as it stands in the matrix cache on disk
 ('Just' when the caller pinned a new dep in-memory before calling). The cache
@@ -1548,11 +1555,10 @@ that divergence. 'Nothing' means the pin is unchanged from disk.
 relinkDatabaseWith ::
     DatabaseManager ->
     Text ->
-    Maybe [Text] ->
     Maybe (M.Map Text Text) ->
     Maybe [Text] ->
     IO (Either Text RelinkResult)
-relinkDatabaseWith manager dbName depOverride aliases persistedDeps = do
+relinkDatabaseWith manager dbName aliases persistedDeps = do
     loadedDbs <- readTVarIO (dmLoadedDbs manager)
     case M.lookup dbName loadedDbs of
         Nothing -> return $ Left $ "Database not loaded: " <> dbName
@@ -1561,13 +1567,11 @@ relinkDatabaseWith manager dbName depOverride aliases persistedDeps = do
             -- Strict pin: candidates are restricted to the database's declared
             -- dependency set ('dbDependsOn'), never the full set of loaded DBs.
             -- This keeps the user's explicit selection authoritative — relink
-            -- recomputes links *within* the pin but never expands or shrinks it.
-            -- An optional 'depOverride' narrows further to a single chosen dep.
+            -- recomputes links *within* the whole pin (so a mapping relink against
+            -- one dependency re-resolves the others unchanged instead of dropping
+            -- them) but never expands or shrinks the set.
             let pinnedDeps = dbDependsOn (ldDatabase loaded)
-                candidateDeps = case depOverride of
-                    Nothing -> pinnedDeps
-                    Just chosen -> filter (`elem` chosen) pinnedDeps
-                otherIndexes = [idb | (n, idb) <- M.toList indexedDbs, n /= dbName, n `elem` candidateDeps]
+                otherIndexes = [idb | (n, idb) <- M.toList indexedDbs, n /= dbName, n `elem` pinnedDeps]
             synonymDB <- getMergedSynonymDB manager
             unitConfig <- getMergedUnitConfig manager
             let db = ldDatabase loaded

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -38,6 +38,7 @@ module Database.Manager (
     loadDatabase,
     unloadDatabase,
     relinkDatabase,
+    relinkDatabaseWithMapping,
     RelinkResult (..),
     addDatabase,
     removeDatabase,
@@ -1489,7 +1490,69 @@ even though we already know the answer. The save is skipped when the
 relink is a no-op (no change vs. the in-memory state).
 -}
 relinkDatabase :: DatabaseManager -> Text -> IO (Either Text RelinkResult)
-relinkDatabase manager dbName = do
+relinkDatabase manager dbName = relinkDatabaseWith manager dbName Nothing Nothing Nothing
+
+{- | Re-link a loaded DB against a single chosen dependency, applying a
+name→name supplier-alias map. Restricts candidate suppliers to @depDb@ and
+threads the aliases into the matcher so a consumer's input flow name that only
+matches a target supplier under the mapping still links. If @depDb@ is loaded
+but not yet in the database's declared dependency set, it is pinned in-memory
+first — so an in-memory pipeline (copy → delete → relink) composes without
+restaging (which would unload the live database). Same persistence/no-op
+semantics as 'relinkDatabase'. Errors (DB or dep not loaded) surface as 'Left'.
+-}
+relinkDatabaseWithMapping ::
+    DatabaseManager ->
+    -- | database to relink
+    Text ->
+    -- | dependency database to link against
+    Text ->
+    -- | consumer-flow-name → supplier-name aliases
+    M.Map Text Text ->
+    IO (Either Text RelinkResult)
+relinkDatabaseWithMapping manager dbName depDb aliases = do
+    loadedDbs <- readTVarIO (dmLoadedDbs manager)
+    case M.lookup dbName loadedDbs of
+        Nothing -> return $ Left $ "Database not loaded: " <> dbName
+        Just loaded
+            | not (M.member depDb loadedDbs) ->
+                return $ Left $ "Dependency database not loaded: " <> depDb <> " (load it first)"
+            | otherwise -> do
+                -- Declare the dependency in-memory if it isn't already pinned, so an
+                -- in-memory pipeline (copy → delete → relink) composes in one pass
+                -- without restaging — which would unload the live database. The pin
+                -- set on disk is the current one *before* this in-memory addition;
+                -- pass it so 'relinkDatabaseWith' persists the cache when the pin
+                -- diverges from disk even if no new links are discovered.
+                let persistedDeps = dbDependsOn (ldDatabase loaded)
+                unless (depDb `elem` persistedDeps) $
+                    atomically $
+                        modifyTVar' (dmLoadedDbs manager) (M.adjust (addPinnedDep depDb) dbName)
+                relinkDatabaseWith manager dbName (Just [depDb]) (Just aliases) (Just persistedDeps)
+  where
+    addPinnedDep dep ld =
+        let db = ldDatabase ld
+         in ld{ldDatabase = db{dbDependsOn = dep : dbDependsOn db}}
+
+{- | Shared relink core. @depOverride@ restricts the candidate dependency set
+to the given names (still intersected with the declared pin); 'Nothing' uses
+the full pin. @aliases@ feeds 'lcSupplierAliases'. The dependency set stored
+on the database ('dbDependsOn') is never mutated here.
+
+@persistedDeps@ is the dependency set as it stands in the matrix cache on disk
+('Just' when the caller pinned a new dep in-memory before calling). The cache
+is the only durable store of 'dbDependsOn', so a pin that yields zero new links
+must still be written; comparing the live pin against @persistedDeps@ surfaces
+that divergence. 'Nothing' means the pin is unchanged from disk.
+-}
+relinkDatabaseWith ::
+    DatabaseManager ->
+    Text ->
+    Maybe [Text] ->
+    Maybe (M.Map Text Text) ->
+    Maybe [Text] ->
+    IO (Either Text RelinkResult)
+relinkDatabaseWith manager dbName depOverride aliases persistedDeps = do
     loadedDbs <- readTVarIO (dmLoadedDbs manager)
     case M.lookup dbName loadedDbs of
         Nothing -> return $ Left $ "Database not loaded: " <> dbName
@@ -1499,8 +1562,12 @@ relinkDatabase manager dbName = do
             -- dependency set ('dbDependsOn'), never the full set of loaded DBs.
             -- This keeps the user's explicit selection authoritative — relink
             -- recomputes links *within* the pin but never expands or shrinks it.
+            -- An optional 'depOverride' narrows further to a single chosen dep.
             let pinnedDeps = dbDependsOn (ldDatabase loaded)
-                otherIndexes = [idb | (n, idb) <- M.toList indexedDbs, n /= dbName, n `elem` pinnedDeps]
+                candidateDeps = case depOverride of
+                    Nothing -> pinnedDeps
+                    Just chosen -> filter (`elem` chosen) pinnedDeps
+                otherIndexes = [idb | (n, idb) <- M.toList indexedDbs, n /= dbName, n `elem` candidateDeps]
             synonymDB <- getMergedSynonymDB manager
             unitConfig <- getMergedUnitConfig manager
             let db = ldDatabase loaded
@@ -1520,6 +1587,7 @@ relinkDatabase manager dbName = do
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = M.map snd (dmGeographies manager)
                         , lcGeographyPolicy = dcGeographyPolicy (ldConfig loaded)
+                        , lcSupplierAliases = aliases
                         }
                 !totalInputs = Loader.countTotalTechInputs (toSimpleDatabase db)
                 rawStats =
@@ -1546,6 +1614,12 @@ relinkDatabase manager dbName = do
                 -- change can only be in the links. Compare as sets: link order is
                 -- not significant and must not trigger a redundant cache write.
                 linksChanged = not (sameSet newLinks beforeLinks)
+                -- A caller may have pinned a new dependency in-memory before this
+                -- call. The cache is the only durable store of 'dbDependsOn', so
+                -- if the live pin diverges from what is on disk the cache must be
+                -- rewritten even when no new links were discovered.
+                depsChanged = maybe False (not . sameSet newDeps) persistedDeps
+                cacheChanged = linksChanged || depsChanged
             atomically $ do
                 modifyTVar' (dmLoadedDbs manager) (M.insert dbName loaded')
                 modifyTVar'
@@ -1553,8 +1627,9 @@ relinkDatabase manager dbName = do
                     (M.insert dbName (buildIndexedDatabaseFromDB dbName synonymDB db'))
             clearMethodMappingCacheForDb manager dbName
             -- Persist the relinked Database back to its matrix cache so the
-            -- next startup doesn't have to re-discover the same links.
-            when linksChanged $
+            -- next startup doesn't have to re-discover the same links or lose
+            -- the pin.
+            when cacheChanged $
                 Loader.saveCachedDatabaseWithMatrices
                     dbName
                     (dcPath (ldConfig loaded'))
@@ -1563,7 +1638,7 @@ relinkDatabase manager dbName = do
             -- and deps already matched the in-memory state. This is the
             -- common case for warm Loads after the previous commits and
             -- carries no information worth a log line.
-            when linksChanged $
+            when cacheChanged $
                 reportProgress Info $
                     "Re-linked "
                         <> T.unpack dbName

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1514,7 +1514,7 @@ relinkDatabaseWithMapping ::
 relinkDatabaseWithMapping manager dbName depDb aliases = do
     loadedDbs <- readTVarIO (dmLoadedDbs manager)
     case M.lookup dbName loadedDbs of
-        Nothing -> return $ Left $ "Database not loaded: " <> dbName
+        Nothing -> relinkStaged manager dbName (Just depDb) (Just aliases)
         Just loaded
             | not (M.member depDb loadedDbs) ->
                 return $ Left $ "Dependency database not loaded: " <> depDb <> " (load it first)"
@@ -1539,6 +1539,61 @@ relinkDatabaseWithMapping manager dbName depDb aliases = do
                 then ld
                 else ld{ldDatabase = db{dbDependsOn = dep : dbDependsOn db}}
 
+{- | Relink a *staged* (parsed-but-not-finalized) database, mirroring
+'relinkDatabaseWith' on the staged 'SimpleDatabase' via the shared
+'Loader.relinkSimpleDatabase'. This lets the relink endpoint work from the setup
+page before a database is finalized. @maybeDepDb@ pins a chosen dependency (a
+mapping relink); @aliases@ feeds the supplier-alias map.
+-}
+relinkStaged :: DatabaseManager -> Text -> Maybe Text -> Maybe (M.Map Text Text) -> IO (Either Text RelinkResult)
+relinkStaged manager dbName maybeDepDb aliases = do
+    stagedDbs <- readTVarIO (dmStagedDbs manager)
+    case M.lookup dbName stagedDbs of
+        Nothing -> return $ Left $ "Database not loaded: " <> dbName
+        Just staged -> do
+            indexedDbs <- readTVarIO (dmIndexedDbs manager)
+            case maybeDepDb of
+                Just dep | not (M.member dep indexedDbs) ->
+                    return $ Left $ "Dependency database not loaded: " <> dep <> " (load it first)"
+                _ -> do
+                    synonymDB <- getMergedSynonymDB manager
+                    unitConfig <- getMergedUnitConfig manager
+                    let pinnedDeps = case maybeDepDb of
+                            Just dep | dep `notElem` sdSelectedDeps staged -> dep : sdSelectedDeps staged
+                            _ -> sdSelectedDeps staged
+                        selectedIndexes = [idx | (n, idx) <- M.toList indexedDbs, n `elem` pinnedDeps]
+                        beforeLinks = sdCrossDBLinks staged
+                        newStats =
+                            Loader.relinkSimpleDatabase
+                                selectedIndexes
+                                synonymDB
+                                unitConfig
+                                (M.map snd (dmGeographies manager))
+                                (dcGeographyPolicy (sdConfig staged))
+                                aliases
+                                (sdSimpleDB staged)
+                        newLinks = Loader.cdlLinks newStats
+                        updatedStaged =
+                            staged
+                                { sdSelectedDeps = pinnedDeps
+                                , sdCrossDBLinks = newLinks
+                                , sdLinkingStats = newStats
+                                , sdMissingProducts =
+                                    sortOn (\(_, cnt, _) -> Down cnt)
+                                        [(name, cnt, blocker) | (name, (cnt, blocker)) <- M.toList (Loader.cdlUnresolvedProducts newStats)]
+                                }
+                    atomically $ modifyTVar' (dmStagedDbs manager) (M.insert dbName updatedStaged)
+                    return $
+                        Right
+                            RelinkResult
+                                { rresDbName = dbName
+                                , rresUnresolvedBefore = unresolvedCount (sdLinkingStats staged)
+                                , rresUnresolvedAfter = unresolvedCount newStats
+                                , rresCrossDBLinks = length newLinks
+                                , rresDepsLoaded = pinnedDeps
+                                , rresLinksChanged = not (sameSet newLinks beforeLinks)
+                                }
+
 {- | Shared relink core. Candidates are the database's full declared pin
 ('dbDependsOn'); relink recomputes the links within it but never grows or
 shrinks the set. @aliases@ feeds 'lcSupplierAliases' — a mapping relink passes
@@ -1561,7 +1616,7 @@ relinkDatabaseWith ::
 relinkDatabaseWith manager dbName aliases persistedDeps = do
     loadedDbs <- readTVarIO (dmLoadedDbs manager)
     case M.lookup dbName loadedDbs of
-        Nothing -> return $ Left $ "Database not loaded: " <> dbName
+        Nothing -> relinkStaged manager dbName Nothing aliases
         Just loaded -> do
             indexedDbs <- readTVarIO (dmIndexedDbs manager)
             -- Strict pin: candidates are restricted to the database's declared

--- a/src/Database/RelinkMapping.hs
+++ b/src/Database/RelinkMapping.hs
@@ -25,6 +25,7 @@ module Database.RelinkMapping (
     AliasRow (..),
     parseAliasCSV,
     buildAliasMap,
+    rejectEmpty,
     loadAliasMap,
 
     -- * Relink entry
@@ -157,10 +158,15 @@ loadAliasMap path = do
     case result of
         Left e -> pure $ Left $ "cannot read mapping file " <> T.pack path <> ": " <> T.pack (show e)
         Right bytes -> pure (parseAliasCSV bytes >>= buildAliasMap >>= rejectEmpty)
-  where
-    rejectEmpty m
-        | M.null m = Left "mapping file contains no usable source→target rows"
-        | otherwise = Right m
+
+{- | Reject an alias map with no usable rows (header-only / all-blank). Such a
+map would relink as a silent no-op, so both the CLI ('loadAliasMap') and the
+HTTP relink handler reject it loudly rather than return 200 with no effect.
+-}
+rejectEmpty :: Map Text Text -> Either Text (Map Text Text)
+rejectEmpty m
+    | M.null m = Left "mapping file contains no usable source→target rows"
+    | otherwise = Right m
 
 {- | Relink @dbName@ against @depDb@ using the alias mapping in @csvPath@.
 Loads + validates the CSV, then delegates to 'relinkDatabaseWithMapping'.

--- a/src/Database/RelinkMapping.hs
+++ b/src/Database/RelinkMapping.hs
@@ -1,0 +1,184 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Relink-with-mapping: re-link an (unlinked) database to a chosen background
+dependency using a name→name alias mapping loaded from a CSV.
+
+Agribalyse carries Ecoinvent-named background inputs; the BAFU database names
+the same activities differently. A curated CSV maps the source (consumer)
+input-flow name to the target (BAFU) activity name, so the existing cross-DB
+matcher resolves the link even though the raw names differ.
+
+The CSV is header-based (cassava 'decodeByName'). Recognized columns:
+
+  * @source@ (or @source_name@ / @from@) — required: the consumer's input flow name
+  * @target@ (or @target_name@ / @to@)  — required: the supplier activity name
+  * @source_location@ / @target_location@ — optional, currently informational
+
+Only the (source → target) name pair drives linking; location is matched by
+the existing geography policy, not by this map. Unit-incompatible or
+consumed-nowhere outcomes are not silently dropped — they surface through the
+relink's 'CrossDBLinkingStats' (unresolved products carry a 'LinkBlocker') and
+through the returned 'RelinkResult'.
+-}
+module Database.RelinkMapping (
+    -- * CSV mapping
+    AliasRow (..),
+    parseAliasCSV,
+    buildAliasMap,
+    loadAliasMap,
+
+    -- * Relink entry
+    relinkWithMappingFile,
+) where
+
+import Control.Applicative ((<|>))
+import Control.Monad (mfilter)
+import qualified Data.ByteString.Lazy as BL
+import Data.Csv (FromNamedRecord (..), (.:))
+import qualified Data.Csv as Csv
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Vector as V
+
+import Control.Exception (SomeException, try)
+import Database.Manager (DatabaseManager, RelinkResult, relinkDatabaseWithMapping)
+
+{- | One row of the alias mapping. Locations are parsed when present but are
+not (yet) used to disambiguate the link — the cross-DB matcher applies the
+database's geography policy independently.
+-}
+data AliasRow = AliasRow
+    { arSource :: !Text
+    , arTarget :: !Text
+    , arSourceLocation :: !(Maybe Text)
+    , arTargetLocation :: !(Maybe Text)
+    }
+    deriving (Show, Eq)
+
+{- | Header-tolerant decoding: accept the primary column name or any documented
+synonym. The two name columns are required; location columns are optional.
+-}
+instance FromNamedRecord AliasRow where
+    parseNamedRecord r =
+        AliasRow
+            <$> firstField r ["source", "source_name", "from"]
+            <*> firstField r ["target", "target_name", "to"]
+            <*> optField r ["source_location", "source_geo"]
+            <*> optField r ["target_location", "target_geo"]
+
+{- | Parse the first present column among @names@; fail if none is found.
+Each candidate is tried via cassava's '(.:)' (which fails on a missing key),
+falling through with '(<|>)'.
+-}
+firstField :: Csv.NamedRecord -> [Text] -> Csv.Parser Text
+firstField r names =
+    foldr (\nm acc -> (r .: enc nm) <|> acc) noColumn names
+  where
+    noColumn =
+        fail $
+            "missing required column (one of: "
+                <> T.unpack (T.intercalate ", " names)
+                <> ")"
+
+{- | Parse the first present column among @names@ as optional. A present but
+blank (whitespace-only) cell normalizes to 'Nothing' so "absent" has a single
+representation before any consumer relies on it.
+-}
+optField :: Csv.NamedRecord -> [Text] -> Csv.Parser (Maybe Text)
+optField r names =
+    foldr (\nm acc -> (blankToNothing <$> r .: enc nm) <|> acc) (pure Nothing) names
+  where
+    blankToNothing = mfilter (not . T.null) . Just . T.strip
+
+enc :: Text -> Csv.Name
+enc = Csv.toField
+
+{- | Parse alias rows from CSV bytes. A fully-blank source/target row is a
+no-op and skipped; a half-specified row (exactly one side blank) is a curation
+mistake and rejected loudly rather than silently dropped.
+-}
+parseAliasCSV :: BL.ByteString -> Either Text [AliasRow]
+parseAliasCSV bytes =
+    case Csv.decodeByName bytes of
+        Left err -> Left $ "alias CSV parse error: " <> T.pack err
+        Right (_, rows) ->
+            fmap concat . traverse classify . zip [1 :: Int ..] $
+                V.toList (rows :: V.Vector AliasRow)
+  where
+    classify (n, row) =
+        let src = T.strip (arSource row)
+            tgt = T.strip (arTarget row)
+            halfBlank side =
+                Left $
+                    "alias CSV row "
+                        <> T.pack (show n)
+                        <> ": "
+                        <> side
+                        <> " is blank (rows must specify both source and target, or neither)"
+         in case (T.null src, T.null tgt) of
+                (True, True) -> Right []
+                (True, False) -> halfBlank "source"
+                (False, True) -> halfBlank "target"
+                (False, False) -> Right [row{arSource = src, arTarget = tgt}]
+
+{- | Build the source-name → target-name alias map. On a duplicate source name
+with conflicting targets, fail rather than silently pick one. Identical
+duplicates collapse harmlessly.
+-}
+buildAliasMap :: [AliasRow] -> Either Text (Map Text Text)
+buildAliasMap rows =
+    foldr step (Right M.empty) rows
+  where
+    step row acc = do
+        m <- acc
+        let src = arSource row
+            tgt = arTarget row
+        case M.lookup src m of
+            Just existing
+                | existing /= tgt ->
+                    Left $
+                        "conflicting alias for "
+                            <> src
+                            <> ": "
+                            <> existing
+                            <> " vs "
+                            <> tgt
+            _ -> Right (M.insert src tgt m)
+
+{- | Load and validate an alias map from a CSV file path. An alias map with no
+usable rows (header-only / all-blank) would relink as a silent no-op, so it is
+rejected loudly.
+-}
+loadAliasMap :: FilePath -> IO (Either Text (Map Text Text))
+loadAliasMap path = do
+    result <- try (BL.readFile path) :: IO (Either SomeException BL.ByteString)
+    case result of
+        Left e -> pure $ Left $ "cannot read mapping file " <> T.pack path <> ": " <> T.pack (show e)
+        Right bytes -> pure (parseAliasCSV bytes >>= buildAliasMap >>= rejectEmpty)
+  where
+    rejectEmpty m
+        | M.null m = Left "mapping file contains no usable source→target rows"
+        | otherwise = Right m
+
+{- | Relink @dbName@ against @depDb@ using the alias mapping in @csvPath@.
+Loads + validates the CSV, then delegates to 'relinkDatabaseWithMapping'.
+Guardrails (unit-incompatible / consumed-nowhere) are not swallowed: they are
+reflected in the resulting 'RelinkResult' (unresolved counts) and the
+database's linking stats.
+-}
+relinkWithMappingFile ::
+    DatabaseManager ->
+    -- | database to relink
+    Text ->
+    -- | dependency database to link against
+    Text ->
+    -- | mapping CSV path
+    FilePath ->
+    IO (Either Text RelinkResult)
+relinkWithMappingFile manager dbName depDb csvPath = do
+    aliasResult <- loadAliasMap csvPath
+    case aliasResult of
+        Left err -> pure (Left err)
+        Right aliases -> relinkDatabaseWithMapping manager dbName depDb aliases

--- a/test/CrossDBActivityLinkSpec.hs
+++ b/test/CrossDBActivityLinkSpec.hs
@@ -125,6 +125,7 @@ ctxFor idbs =
         , lcThreshold = defaultLinkingThreshold
         , lcLocationHierarchy = locationHierarchy
         , lcGeographyPolicy = GeoGlobal
+        , lcSupplierAliases = Nothing
         }
 
 runLinks :: SimpleDatabase -> [IndexedDatabase] -> CrossDBLinkingStats

--- a/test/CrossLinkingSpec.hs
+++ b/test/CrossLinkingSpec.hs
@@ -253,6 +253,7 @@ spec = do
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
                         , lcGeographyPolicy = GeoGlobal
+                        , lcSupplierAliases = Nothing
                         }
             case findSupplierInIndexedDBs ctx "product Y" "GLO" "kg" of
                 CrossDBLinked{cdlrScore = score} -> score `shouldSatisfy` (>= defaultLinkingThreshold)
@@ -268,6 +269,7 @@ spec = do
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
                         , lcGeographyPolicy = GeoGlobal
+                        , lcSupplierAliases = Nothing
                         }
             case findSupplierInIndexedDBs ctx "no such product" "GLO" "kg" of
                 CrossDBNotLinked _ -> return ()
@@ -283,6 +285,7 @@ spec = do
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
                         , lcGeographyPolicy = GeoGlobal
+                        , lcSupplierAliases = Nothing
                         }
             -- "product Y" exists in kg; asking for m3 should fail unit check
             case findSupplierInIndexedDBs ctx "product Y" "GLO" "m3" of
@@ -302,6 +305,7 @@ spec = do
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
                         , lcGeographyPolicy = GeoGlobal
+                        , lcSupplierAliases = Nothing
                         }
             -- Synonym lookup: "producto y" → group containing "product y" → supplier
             case findSupplierInIndexedDBs ctx "producto y" "GLO" "kg" of
@@ -318,6 +322,7 @@ spec = do
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
                         , lcGeographyPolicy = GeoGlobal
+                        , lcSupplierAliases = Nothing
                         }
             -- "product Y {GLO}" compound name with empty location arg
             -- extractBracketedLocation will find "GLO"
@@ -368,6 +373,7 @@ spec = do
                     , lcThreshold = defaultLinkingThreshold
                     , lcLocationHierarchy = locationHierarchy
                     , lcGeographyPolicy = policy
+                    , lcSupplierAliases = Nothing
                     }
 
         it "GeoGlobal accepts FR query against a GLO candidate" $ do

--- a/test/RelinkMappingSpec.hs
+++ b/test/RelinkMappingSpec.hs
@@ -1,0 +1,212 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Relink-with-mapping tests.
+
+A small target ("BAFU") database is indexed as a cross-DB supplier. A consumer
+input flow whose name only matches the target *via* an alias from the mapping
+CSV must link once the alias map is threaded into the 'LinkingContext'; without
+it the same lookup yields 'NoNameMatch'. Unit incompatibility surfaces as an
+error rather than being silently dropped, and the post-link score matches the
+expected name+location total.
+-}
+module RelinkMappingSpec (spec) where
+
+import qualified Data.ByteString.Lazy.Char8 as BLC
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.UUID as UUID
+import System.IO.Temp (withSystemTempFile)
+import System.IO (hClose)
+import Test.Hspec
+
+import Database.CrossLinking (
+    CrossDBLinkResult (..),
+    IndexedDatabase,
+    LinkingContext (..),
+    buildIndexedDatabase,
+    defaultLinkingThreshold,
+    findSupplierInIndexedDBs,
+    locationHierarchy,
+ )
+import Database.RelinkMapping (
+    AliasRow (..),
+    buildAliasMap,
+    loadAliasMap,
+    parseAliasCSV,
+ )
+import SynonymDB (emptySynonymDB)
+import Types (
+    Activity (..),
+    Exchange (..),
+    GeographyPolicy (..),
+    LinkBlocker (..),
+    SimpleDatabase (..),
+    TechRole (..),
+    TechnosphereFlow (..),
+ )
+import UnitConversion (defaultUnitConfig)
+
+-- ---------------------------------------------------------------------------
+-- Target ("BAFU") fixture: one activity, "wheat production" @ FR, in kg.
+-- ---------------------------------------------------------------------------
+
+targetIndexed :: IndexedDatabase
+targetIndexed = buildIndexedDatabase "BAFU" emptySynonymDB targetDB
+
+targetDB :: SimpleDatabase
+targetDB =
+    let flowUUID = read "aaaaaaaa-0000-0000-0000-000000000001"
+        actUUID = read "cccccccc-0000-0000-0000-000000000001"
+        ex =
+            TechnosphereExchange
+                { techFlowId = flowUUID
+                , techAmount = 1.0
+                , techUnitId = UUID.nil
+                , techRole = ReferenceProduct
+                , techActivityLinkId = UUID.nil
+                , techProcessLinkId = Nothing
+                , techLocation = ""
+                , techComment = Nothing
+                , techPedigree = Nothing
+                }
+        act =
+            Activity
+                { activityName = "wheat production"
+                , activityDescription = []
+                , activitySynonyms = M.empty
+                , activityClassification = M.empty
+                , activityLocation = "FR"
+                , activityUnit = "kg"
+                , exchanges = [ex]
+                , activityParams = M.empty
+                , activityParamExprs = M.empty
+                , activityAllocationPercent = Nothing
+                , activityAllocationFormula = Nothing
+                , activityNativeType = Nothing
+                }
+        flow =
+            TechnosphereFlow
+                { tfId = flowUUID
+                , tfName = "wheat production"
+                , tfUnitId = UUID.nil
+                , tfSynonyms = M.empty
+                , tfCAS = Nothing
+                , tfSubstanceId = Nothing
+                }
+     in SimpleDatabase
+            { sdbActivities = M.singleton (actUUID, flowUUID) act
+            , sdbTechFlows = M.singleton flowUUID flow
+            , sdbBioFlows = M.empty
+            , sdbWasteFlows = M.empty
+            , sdbUnits = M.empty
+            }
+
+-- | Linking context against the target, with an optional alias map.
+mkCtx :: Maybe (M.Map Text Text) -> LinkingContext
+mkCtx aliases =
+    LinkingContext
+        { lcIndexedDatabases = [targetIndexed]
+        , lcSynonymDB = emptySynonymDB
+        , lcUnitConfig = defaultUnitConfig
+        , lcThreshold = defaultLinkingThreshold
+        , lcLocationHierarchy = locationHierarchy
+        , lcGeographyPolicy = GeoGlobal
+        , lcSupplierAliases = aliases
+        }
+
+-- | The consumer's Ecoinvent-style name that only resolves via the alias.
+consumerName :: Text
+consumerName = "wheat, ecoinvent name"
+
+aliasMap :: M.Map Text Text
+aliasMap = M.singleton consumerName "wheat production"
+
+-- ---------------------------------------------------------------------------
+
+spec :: Spec
+spec = do
+    describe "alias CSV loading" $ do
+        it "parses source/target columns and builds the map" $ do
+            -- The source name contains a comma, so it must be CSV-quoted.
+            let csv = BLC.pack "source,target\n\"wheat, ecoinvent name\",wheat production\n"
+            rows <- either (fail . show) pure (parseAliasCSV csv)
+            map arSource rows `shouldBe` [consumerName]
+            map arTarget rows `shouldBe` ["wheat production"]
+            buildAliasMap rows `shouldBe` Right aliasMap
+
+        it "accepts the from/to column synonyms and optional locations" $ do
+            let csv = BLC.pack "from,to,source_location\na,b,FR\n"
+            rows <- either (fail . show) pure (parseAliasCSV csv)
+            map arSourceLocation rows `shouldBe` [Just "FR"]
+            buildAliasMap rows `shouldBe` Right (M.singleton "a" "b")
+
+        it "rejects a conflicting alias for the same source" $ do
+            let rows =
+                    [ AliasRow "x" "y" Nothing Nothing
+                    , AliasRow "x" "z" Nothing Nothing
+                    ]
+            buildAliasMap rows `shouldSatisfy` either (const True) (const False)
+
+        it "fails when a required column is missing" $ do
+            let csv = BLC.pack "source\nfoo\n"
+            parseAliasCSV csv `shouldSatisfy` either (const True) (const False)
+
+        it "rejects a present-but-blank target as a half-specified row" $ do
+            -- Source filled, target blank: a curation mistake, not a no-op,
+            -- so it must fail loudly rather than be silently dropped.
+            let csv = BLC.pack "source,target\nwheat production,\n"
+            parseAliasCSV csv `shouldSatisfy` either (const True) (const False)
+
+        it "rejects a header-only file as having no usable rows" $
+            withSystemTempFile "relink-empty.csv" $ \path h -> do
+                BLC.hPut h (BLC.pack "source,target\n")
+                hClose h
+                result <- loadAliasMap path
+                result `shouldSatisfy` either (const True) (const False)
+
+        it "collapses two identical duplicate rows harmlessly" $ do
+            let rows =
+                    [ AliasRow "x" "y" Nothing Nothing
+                    , AliasRow "x" "y" Nothing Nothing
+                    ]
+            buildAliasMap rows `shouldBe` Right (M.singleton "x" "y")
+
+        it "round-trips a quoted target that contains a comma" $ do
+            -- The target name contains a comma, so it must be CSV-quoted.
+            let csv = BLC.pack "source,target\nwheat,\"production, FR\"\n"
+            rows <- either (fail . show) pure (parseAliasCSV csv)
+            buildAliasMap rows `shouldBe` Right (M.singleton "wheat" "production, FR")
+
+    describe "findSupplierInIndexedDBs with supplier aliases" $ do
+        it "does NOT link the aliased consumer name without the alias map" $
+            case findSupplierInIndexedDBs (mkCtx Nothing) consumerName "FR" "kg" of
+                CrossDBNotLinked NoNameMatch -> pure ()
+                CrossDBNotLinked other -> expectationFailure $ "Expected NoNameMatch, got: " ++ show other
+                CrossDBLinked{} -> expectationFailure "Expected no link without alias map"
+
+        it "links the aliased consumer name to the target via the alias map" $
+            case findSupplierInIndexedDBs (mkCtx (Just aliasMap)) consumerName "FR" "kg" of
+                CrossDBLinked{cdlrProductName = name, cdlrDatabaseName = db} -> do
+                    name `shouldBe` "wheat production"
+                    db `shouldBe` "BAFU"
+                CrossDBNotLinked reason -> expectationFailure $ "Expected link, got: " ++ show reason
+
+        it "scores name(50) + exact-location(30) = 80 for an FR→FR alias link" $
+            case findSupplierInIndexedDBs (mkCtx (Just aliasMap)) consumerName "FR" "kg" of
+                CrossDBLinked{cdlrScore = score} -> score `shouldBe` 80
+                CrossDBNotLinked reason -> expectationFailure $ "Expected link, got: " ++ show reason
+
+        it "surfaces a unit mismatch as UnitIncompatible, never a silent drop" $
+            case findSupplierInIndexedDBs (mkCtx (Just aliasMap)) consumerName "FR" "m3" of
+                CrossDBNotLinked (UnitIncompatible req got) -> do
+                    req `shouldBe` "m3"
+                    got `shouldBe` "kg"
+                CrossDBNotLinked other -> expectationFailure $ "Expected UnitIncompatible, got: " ++ show other
+                CrossDBLinked{} -> expectationFailure "Expected unit mismatch to block the link"
+
+        it "still prefers a direct name match over the alias map" $
+            -- The target's own canonical name resolves directly; the alias is
+            -- only a last-resort retry, so a direct lookup must not depend on it.
+            case findSupplierInIndexedDBs (mkCtx (Just aliasMap)) "wheat production" "FR" "kg" of
+                CrossDBLinked{cdlrScore = score} -> score `shouldBe` 80
+                CrossDBNotLinked reason -> expectationFailure $ "Expected direct link, got: " ++ show reason

--- a/test/RelinkMappingSpec.hs
+++ b/test/RelinkMappingSpec.hs
@@ -15,8 +15,8 @@ import qualified Data.ByteString.Lazy.Char8 as BLC
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.UUID as UUID
-import System.IO.Temp (withSystemTempFile)
 import System.IO (hClose)
+import System.IO.Temp (withSystemTempFile)
 import Test.Hspec
 
 import Database.CrossLinking (
@@ -33,6 +33,7 @@ import Database.RelinkMapping (
     buildAliasMap,
     loadAliasMap,
     parseAliasCSV,
+    rejectEmpty,
  )
 import SynonymDB (emptySynonymDB)
 import Types (
@@ -163,6 +164,12 @@ spec = do
                 hClose h
                 result <- loadAliasMap path
                 result `shouldSatisfy` either (const True) (const False)
+
+        it "rejectEmpty rejects an empty map and passes a non-empty one" $ do
+            -- The HTTP relink handler relies on this so a header-only CSV is a 4xx,
+            -- not a silent 200 no-op (matching the CLI's loadAliasMap).
+            rejectEmpty M.empty `shouldSatisfy` either (const True) (const False)
+            rejectEmpty (M.singleton "a" "b") `shouldBe` Right (M.singleton "a" "b")
 
         it "collapses two identical duplicate rows harmlessly" $ do
             let rows =

--- a/test/StrictPinSpec.hs
+++ b/test/StrictPinSpec.hs
@@ -35,6 +35,7 @@ import Database.Manager (
     LoadedDatabase (..),
     initDatabaseManager,
     relinkDatabase,
+    relinkDatabaseWithMapping,
  )
 import SharedSolver (SharedSolver, createSharedSolver)
 import SynonymDB (emptySynonymDB)
@@ -95,6 +96,44 @@ spec = describe "relinkDatabase strict dependency pin" $ do
             -- p1 resolves against alpha; p2 (beta-only) stays unresolved.
             length (dbCrossDBLinks relinked) `shouldBe` 1
 
+    it "a mapping relink against one dependency preserves links to the others" $
+        withSystemTempDirectory "volca-relink-multidep" $ \tmp -> do
+            -- alpha supplies p1, beta supplies p2; consumer is pinned to both.
+            alphaDb <- buildOrFail (supplierDB 100 ["p1"])
+            betaDb <- buildOrFail (supplierDB 200 ["p2"])
+            consumerDb0 <- buildOrFail (consumerDB 300 ["p1", "p2"])
+            let consumerDb = consumerDb0{dbDependsOn = ["alpha", "beta"], dbCrossDBLinks = []}
+
+            manager <- initDatabaseManager defaultConfig True Nothing
+            consumerSolver <- mkSolver "consumer" consumerDb
+            alphaSolver <- mkSolver "alpha" alphaDb
+            betaSolver <- mkSolver "beta" betaDb
+            -- The deps must be loaded (mapping relink requires depDb loaded) and
+            -- indexed (the matcher scans indexed deps).
+            atomically $ do
+                modifyTVar' (dmLoadedDbs manager) $
+                    M.insert "consumer" (loadedFor consumerDb consumerSolver (consumerConfig (tmp </> "consumer-data")))
+                        . M.insert "alpha" (loadedFor alphaDb alphaSolver (supplierLoadedConfig "alpha"))
+                        . M.insert "beta" (loadedFor betaDb betaSolver (supplierLoadedConfig "beta"))
+                modifyTVar' (dmIndexedDbs manager) $
+                    M.insert "alpha" (buildIndexedDatabaseFromDB "alpha" emptySynonymDB alphaDb)
+                        . M.insert "beta" (buildIndexedDatabaseFromDB "beta" emptySynonymDB betaDb)
+
+            -- Populate the links first: p1 → alpha, p2 → beta.
+            _ <- relinkDatabase manager "consumer"
+            -- A mapping relink scoped to beta must re-resolve the whole pin, not
+            -- drop the alpha link. (The alias is inert here; it only exercises the
+            -- mapping path.)
+            result <- relinkDatabaseWithMapping manager "consumer" "beta" (M.singleton "no-such-input" "no-such-supplier")
+            result `shouldSatisfy` isRight
+
+            loaded <- readTVarIO (dmLoadedDbs manager)
+            let relinked = ldDatabase (loaded M.! "consumer")
+                linkSources = S.fromList (map cdlSourceDatabase (dbCrossDBLinks relinked))
+            -- Both dependency links survive; the alpha link is not silently dropped.
+            linkSources `shouldBe` S.fromList ["alpha", "beta"]
+            length (dbCrossDBLinks relinked) `shouldBe` 2
+
 -- ---------------------------------------------------------------------------
 -- Helpers
 -- ---------------------------------------------------------------------------
@@ -102,6 +141,15 @@ spec = describe "relinkDatabase strict dependency pin" $ do
 isRight :: Either a b -> Bool
 isRight (Right _) = True
 isRight (Left _) = False
+
+loadedFor :: Database -> SharedSolver -> DatabaseConfig -> LoadedDatabase
+loadedFor db solver cfg =
+    LoadedDatabase{ldDatabase = db, ldSharedSolver = solver, ldConfig = cfg}
+
+-- | A minimal loaded-supplier config (no own dependencies, no cache path).
+supplierLoadedConfig :: Text -> DatabaseConfig
+supplierLoadedConfig name =
+    (consumerConfig ""){dcName = name, dcDisplayName = name, dcDepends = []}
 
 buildOrFail :: SimpleParts -> IO Database
 buildOrFail (SimpleParts acts flows units) = do

--- a/test/WasteCrossDBSpec.hs
+++ b/test/WasteCrossDBSpec.hs
@@ -51,6 +51,7 @@ spec = describe "findWasteTreatmentAcrossDatabases" $ do
                 , lcThreshold = defaultLinkingThreshold
                 , lcLocationHierarchy = M.empty
                 , lcGeographyPolicy = GeoExact
+                , lcSupplierAliases = Nothing
                 }
 
         wasteUUID = UUID.fromWords 0xa 0xb 0xc 0xd

--- a/volca.cabal
+++ b/volca.cabal
@@ -46,6 +46,7 @@ library
                      , Database.Edit
                      , Database.Loader
                      , Database.CrossLinking
+                     , Database.RelinkMapping
                      , Database.MatrixBuild
                      , Database.Upload
                      , Database.UploadedDatabase
@@ -199,6 +200,7 @@ test-suite lca-tests
   other-modules:       TestHelpers
                      , GoldenData
                      , AutoRelinkSpec
+                     , RelinkMappingSpec
                      , MatrixConstructionSpec
                      , InventorySpec
                      , MatrixExportSpec


### PR DESCRIPTION
## What
**Relink-with-mapping**: re-resolve a database's cross-DB links against a single chosen dependency using a supplier-alias CSV (consumer-flow-name → supplier-name), so an Ecoinvent-named background resolves against a differently-named dependency (e.g. Agribalyse → BAFU). The alias threads through `LinkingContext` and is retried only when the direct name lookup misses.

The HTTP relink endpoint is collapsed into one route taking an optional body: empty `{}` is a plain relink, `{depDb,mappingCsv}` is a mapping relink, exactly one of the two is a 400. A loaded-but-undeclared dependency is auto-pinned in-memory so an in-memory copy → delete → relink pipeline composes without restaging.

Exposed over CLI (`db relink --to --mapping`) and pyvolca (`relink` / `relink_from_file` + `add_dependency` / `remove_dependency`).

Part of the #113 split into focused, independently-reviewable PRs. Stacked on `feat/db-copy` — **merge bottom-up**; #114 (delete) is the base of the stack. Full stack: `cabal test lca-tests` → 1255 examples, 0 failures.