### PR TITLE
feat(simapro): SimaPro CSV writer — canonical inverse of the parser

### DIFF
--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -28,6 +28,7 @@ module SimaPro.Parser (
     parseTechRow,
     parseBioRow,
     parsePedigreePrefix,
+    isMetadataKey,
     decodeBS,
 ) where
 

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -224,38 +224,26 @@ checkSimaProExportable db =
     metaKeyOffenders =
         [ (activityName act, val)
         | act <- M.elems (sdbActivities db)
-        , val <- emittedMetaValues act
+        , val <- map snd (activityMetaLines act)
         , not (T.null val)
         , isMetadataKey (TE.encodeUtf8 (T.strip val))
         ]
-    -- The metadata values the writer emits as bare value lines (see
-    -- 'serializeActivity'). Each must not collide with a SimaPro metadata key.
-    emittedMetaValues act =
-        [ M.findWithDefault "" "Category type" (activityClassification act)
-        , activityName act
-        , typeLabelOf (activityNativeType act)
-        , activityLocation act
-        , T.intercalate " " (activityDescription act)
-        ]
     hasNewline = T.any (\c -> c == '\n' || c == '\r')
+    -- Every text field that lands in the output verbatim: the bare metadata
+    -- value lines (so a newline in any of them — the Type label included — is
+    -- caught), the "Category" product-column value, exchange comments, and all
+    -- flow names. The line-based parser splits on physical newlines /before/
+    -- CSV parsing, so even a quoted newline tears a row apart; reject upstream.
+    activityTexts act =
+        map snd (activityMetaLines act)
+            ++ M.elems (activityClassification act)
+            ++ [cmt | ex <- exchanges act, Just cmt <- [exchangeComment ex]]
     newlineOffenders =
         filter hasNewline $
-            concat
-                [ activityName act : activityLocation act : activityDescription act
-                | act <- M.elems (sdbActivities db)
-                ]
-                ++ [ v
-                   | act <- M.elems (sdbActivities db)
-                   , v <- M.elems (activityClassification act)
-                   ]
+            concatMap activityTexts (M.elems (sdbActivities db))
                 ++ map tfName (M.elems (sdbTechFlows db))
                 ++ map bfName (M.elems (sdbBioFlows db))
                 ++ map wfName (M.elems (sdbWasteFlows db))
-                ++ [ cmt
-                   | act <- M.elems (sdbActivities db)
-                   , ex <- exchanges act
-                   , Just cmt <- [exchangeComment ex]
-                   ]
 
 -- ============================================================================
 -- Constants
@@ -367,6 +355,32 @@ typeLabelOf mnt = case mnt of
     Just (EcoSpoldActivityType{eatLabel = lbl}) -> lbl
     Just (ILCDProcessType lbl) -> lbl
     Nothing -> ""
+
+{- | The metadata @key/value@ pairs the writer emits as bare @key⏎value⏎@ lines
+in a @Process@ block. Single source of truth shared by 'serializeActivity'
+(which writes them) and 'checkSimaProExportable' (which guards every value
+against the two hazards a bare value line is prone to): an embedded newline,
+which the line-based parser would split across rows, and a value equal to a
+SimaPro metadata key, which the parser would mistake for a new field. Empty
+values are dropped on emission by 'serializeActivity'’s @meta@, but kept here so
+the guards still inspect exactly what /would/ be written.
+
+The "Category" classification value is intentionally absent: it rides the
+@Products@ row's category column, not a bare metadata line. Multi-paragraph
+descriptions are flattened to one space-joined "Comment" line; the re-parse
+reads them back as a single description entry, losing the paragraph boundaries —
+an accepted limitation of SimaPro's single-line "Comment" field. A missing
+native type yields an empty "Type" value, so @meta@ omits the line and a
+re-parse yields 'Nothing' again rather than drifting to "Unit process".
+-}
+activityMetaLines :: Activity -> [(Text, Text)]
+activityMetaLines Activity{..} =
+    [ ("Category type", M.findWithDefault "" "Category type" activityClassification)
+    , ("Process name", activityName)
+    , ("Type", typeLabelOf activityNativeType)
+    , ("Geography", activityLocation)
+    , ("Comment", T.intercalate " " activityDescription)
+    ]
 
 -- | Render the comment column, re-attaching a pedigree prefix when present.
 renderComment :: Maybe Pedigree -> Maybe Text -> Text
@@ -550,18 +564,8 @@ respective DBs; exchanges whose flow is missing are dropped (the matrix
 builder is the authority on unknown flows, not the serializer).
 -}
 serializeActivity :: Catalogs -> Activity -> [Text]
-serializeActivity cats Activity{..} =
-    let catType = M.findWithDefault "" "Category type" activityClassification
-        category = M.findWithDefault "" "Category" activityClassification
-        -- No native type → omit the Type line entirely (meta drops empty values),
-        -- so a re-parse yields Nothing again rather than drifting to "Unit process".
-        typeLabel = typeLabelOf activityNativeType
-        -- SimaPro's "Comment" is a single value line emitted unescaped, so it
-        -- cannot carry newlines (a paragraph break would corrupt re-parsing).
-        -- Multi-paragraph descriptions are flattened to one space-joined line;
-        -- the re-parse reads them back as a single description entry, losing the
-        -- paragraph boundaries. Accepted limitation of the SimaPro format.
-        comment = T.intercalate " " activityDescription
+serializeActivity cats act@Activity{..} =
+    let category = M.findWithDefault "" "Category" activityClassification
 
         -- The parser scales every shared exchange (everything but the reference
         -- product) by allocFraction = allocPercent/100 on import. To be its exact
@@ -586,15 +590,9 @@ serializeActivity cats Activity{..} =
             , Just l <- [bioLine cats ex]
             ]
         wasteLines = mapMaybe (wasteLine cats) unscaledExchanges
-
-        meta key val = if T.null val then [] else [key, val, ""]
      in concat
             [ ["Process", ""]
-            , meta "Category type" catType
-            , meta "Process name" activityName
-            , meta "Type" typeLabel
-            , meta "Geography" activityLocation
-            , meta "Comment" comment
+            , concatMap (uncurry meta) (activityMetaLines act)
             , -- Products section is always present (an activity has a reference).
               -- Coproducts go to "Avoided products" so the parser reads them back
               -- as coproducts, not as extra reference-product activities.
@@ -611,6 +609,10 @@ serializeActivity cats Activity{..} =
             , ["End", ""]
             ]
   where
+    -- A metadata line is emitted only when its value is non-empty; an empty
+    -- value drops the whole key/value/blank triple so a re-parse yields the
+    -- absent field again rather than an empty string.
+    meta key val = if T.null val then [] else [key, val, ""]
     -- Append a blank separator line after a non-empty section.
     withBlank [] = []
     withBlank ls = ls ++ [""]

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -30,6 +30,37 @@ Encoding/layout mirrors the parser's expectations:
 Field shapes are kept aligned with the parser's row parsers
 ('parseProductRow', 'parseTechRow', 'parseBioRow') so a faithful round-trip is
 possible. CSV escaping reuses the same rule as 'Matrix.Export.escapeCsvField'.
+
+== Known lossy round-trips
+
+The writer is a faithful inverse for /SimaPro-origin/ databases: a
+@parse → write → parse@ cycle preserves activities, flows, units, and the LCIA
+inventory exactly (pinned by "SimaProWriterSpec"). It writes /resolved numeric/
+amounts and only the metadata SimaPro itself carries, so a few things present in
+databases imported from /other/ formats are dropped — always score-preserving
+(the numbers that drive the matrix are kept), never silently wrong:
+
+  * parameter provenance — @Input@ / @Calculated parameters@ sections and any
+    per-exchange raw formula expression are flattened to their resolved
+    'Double'; 'activityAllocationFormula' likewise re-parses as 'Nothing' (the
+    numeric allocation percentage is preserved);
+  * classification keys other than @Category type@ / @Category@ (e.g. ISIC/CPC
+    from an EcoSpold import) are not emitted;
+  * reference- and co-product comments are dropped (SimaPro product rows carry a
+    comment column, but a SimaPro parse never populates it);
+  * an emission with an empty (unspecified) medium is written to
+    @Emissions to air@ and re-parses as @air@ — SimaPro has no
+    unspecified-emission section. This shifts the flow's medium (and hence its
+    generated UUID), so it is the one lossy case that can affect characterisation
+    for a cross-format export; air/water/soil media and all SimaPro-origin
+    emissions are unaffected;
+  * multi-paragraph descriptions are joined into the single-line @Comment@ field.
+
+Anything the format /cannot/ represent without silently corrupting the data on
+re-import (non-finite amounts, a zero allocation, a missing unit, newlines in a
+field, a pedigree-shaped comment, a metadata-key collision, an activity without
+exactly one reference product) is rejected outright by 'checkSimaProExportable'
+rather than written lossily.
 -}
 module SimaPro.Writer (
     WriterConfig (..),
@@ -326,6 +357,12 @@ formatAmount x
 {- | Escape a field for semicolon-delimited CSV. Same rule as
 'Matrix.Export.escapeCsvField': quote only when the field contains the
 delimiter, a quote, or a newline, doubling embedded quotes.
+
+The newline case is kept only for parity with 'Matrix.Export.escapeCsvField':
+it never fires in practice because 'checkSimaProExportable' rejects newlines
+upstream, and quoting would not help anyway — the parser splits the file on
+physical lines /before/ CSV parsing, so an embedded newline tears the row apart
+regardless of quoting.
 -}
 escapeField :: Text -> Text
 escapeField text

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -1,0 +1,504 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+{- | SimaPro CSV Writer for volca — the inverse of "SimaPro.Parser".
+
+Serializes an in-memory 'Database' / 'SimpleDatabase' back to a SimaPro CSV
+export. The output is /canonical/ and /deterministic/: given the same database
+(modulo a pinned header version) it always produces byte-identical bytes.
+
+Determinism is achieved by:
+
+  * sorting every activity by (name, location) and every section's rows by
+    (flow name, unit, signed amount), so 'Map'/'Set' iteration order never
+    leaks into the output;
+  * a single fixed numeric formatter ('formatAmount') that round-trips through
+    the parser's 'parseAmount' / 'Expr.normalizeExpr';
+  * pinning the only volatile header field — the SimaPro version banner — via
+    'WriterConfig'. No export timestamp or generator line is emitted, so a
+    write→parse→write cycle is stable.
+
+Encoding/layout mirrors the parser's expectations:
+
+  * semicolon-separated fields, CRLF line endings;
+  * dot decimal separator (matching @{Decimal separator: .}@);
+  * the @{SimaPro …}@ / @{CSV separator: Semicolon}@ / @{Decimal separator: .}@
+    header block;
+  * one @Process … End@ block per activity, with the metadata keys and section
+    headers the parser recognises.
+
+Field shapes are kept aligned with the parser's row parsers
+('parseProductRow', 'parseTechRow', 'parseBioRow') so a faithful round-trip is
+possible. CSV escaping reuses the same rule as 'Matrix.Export.escapeCsvField'.
+-}
+module SimaPro.Writer (
+    WriterConfig (..),
+    defaultWriterConfig,
+    writeSimaProCSV,
+    serializeSimaProCSV,
+    checkSimaProExportable,
+
+    -- * Pure helpers (exposed for testing)
+    escapeField,
+    formatAmount,
+) where
+
+import qualified Data.ByteString as BS
+import Data.List (sortOn)
+import qualified Data.Map.Strict as M
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Types
+
+-- ============================================================================
+-- Configuration
+-- ============================================================================
+
+{- | Writer knobs. The only volatile field a SimaPro export normally carries is
+the version banner; pinning it here keeps a round-trip byte-stable. We
+deliberately omit the export-date / generator lines entirely (the parser
+ignores them anyway) so there is no timestamp to normalise away.
+-}
+newtype WriterConfig = WriterConfig
+    { wcVersion :: Text
+    -- ^ Value of the @{SimaPro …}@ banner line.
+    }
+    deriving (Eq, Show)
+
+-- | Default config: a fixed, neutral version banner (no timestamp).
+defaultWriterConfig :: WriterConfig
+defaultWriterConfig = WriterConfig{wcVersion = "SimaPro 9.6.0.1"}
+
+-- ============================================================================
+-- Export guard
+-- ============================================================================
+
+{- | SimaPro CSV files emissions into air / water / soil sections only. An
+emission whose compartment medium is some other non-empty value has no faithful
+section, so report it rather than silently filing it under @Emissions to air@.
+An unspecified (empty) medium is allowed — it carries no medium to lose and
+follows SimaPro's air default. Resources are bucketed by direction, not medium,
+so they never offend.
+
+Amounts must also be finite: a NaN or ±Infinity has no parseable literal, so
+'formatAmount' would otherwise flatten it to @0@ and silently undercount the
+inventory. Report it here instead. This is the export-boundary check;
+'serializeSimaProCSV' itself stays pure and total.
+
+Names and comments must also be free of newline characters. 'escapeField'
+RFC-4180-quotes them, but the parser splits the file on physical lines
+('BS8.lines') /before/ CSV parsing, so an embedded @\\n@ or @\\r@ tears the row
+apart and corrupts or drops it. Reject such fields rather than emit a row the
+parser cannot read back.
+-}
+checkSimaProExportable :: SimpleDatabase -> Either Text ()
+checkSimaProExportable db = checkMedia *> checkAmounts *> checkNewlines
+  where
+    checkMedia =
+        case mediumOffenders of
+            [] -> Right ()
+            ((name, medium) : _) ->
+                Left $
+                    "SimaPro export cannot represent emission \""
+                        <> name
+                        <> "\": compartment medium \""
+                        <> medium
+                        <> "\" is not one of air, water, soil."
+    checkAmounts =
+        case amountOffenders of
+            [] -> Right ()
+            ((name, amt) : _) ->
+                Left $
+                    "SimaPro export cannot represent activity \""
+                        <> name
+                        <> "\": exchange amount "
+                        <> T.pack (show amt)
+                        <> " is not finite."
+    checkNewlines =
+        case newlineOffenders of
+            [] -> Right ()
+            (field : _) ->
+                Left $
+                    "SimaPro export cannot represent field \""
+                        <> field
+                        <> "\": it contains a newline, which the line-based parser"
+                        <> " would split across rows."
+    mediumOffenders =
+        [ (bfName flow, bfCompartmentName flow)
+        | act <- M.elems (sdbActivities db)
+        , ex@BiosphereExchange{bioDirection = Emission} <- exchanges act
+        , Just flow <- [M.lookup (exchangeFlowId ex) (sdbBioFlows db)]
+        , let medium = T.toLower (bfCompartmentName flow)
+        , not (T.null medium)
+        , medium `notElem` ["air", "water", "soil"]
+        ]
+    amountOffenders =
+        [ (activityName act, amt)
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , let amt = exchangeAmount ex
+        , isNaN amt || isInfinite amt
+        ]
+    hasNewline = T.any (\c -> c == '\n' || c == '\r')
+    newlineOffenders =
+        filter hasNewline $
+            concat
+                [ activityName act : activityDescription act
+                | act <- M.elems (sdbActivities db)
+                ]
+                ++ map tfName (M.elems (sdbTechFlows db))
+                ++ map bfName (M.elems (sdbBioFlows db))
+                ++ map wfName (M.elems (sdbWasteFlows db))
+                ++ [ cmt
+                   | act <- M.elems (sdbActivities db)
+                   , ex <- exchanges act
+                   , Just cmt <- [exchangeComment ex]
+                   ]
+
+-- ============================================================================
+-- Constants
+-- ============================================================================
+
+-- | Field delimiter — semicolon, matching @{CSV separator: Semicolon}@.
+delim :: Text
+delim = ";"
+
+-- | Line terminator — SimaPro exports use Windows CRLF.
+crlf :: Text
+crlf = "\r\n"
+
+-- ============================================================================
+-- Numeric formatting
+-- ============================================================================
+
+{- | Canonical numeric formatter. Produces a dot-decimal literal that the
+parser's 'parseAmount' / 'Expr.normalizeExpr' read back to the same 'Double'.
+
+Integral values are written without a trailing @.0@ (e.g. @100@, not
+@100.0@) so allocation percentages match the parser's @"100"@ raw form;
+all other values use Haskell's 'show', which is dot-decimal and exact
+enough to round-trip a 'Double'.
+-}
+formatAmount :: Double -> Text
+formatAmount x
+    | isNaN x || isInfinite x = "0"
+    | x == fromIntegral (round x :: Integer) =
+        T.pack (show (round x :: Integer))
+    | otherwise = T.pack (show x)
+
+-- ============================================================================
+-- CSV escaping
+-- ============================================================================
+
+{- | Escape a field for semicolon-delimited CSV. Same rule as
+'Matrix.Export.escapeCsvField': quote only when the field contains the
+delimiter, a quote, or a newline, doubling embedded quotes.
+-}
+escapeField :: Text -> Text
+escapeField text
+    | T.any (\c -> c == ';' || c == '"' || c == '\n' || c == '\r') text =
+        "\"" <> T.replace "\"" "\"\"" text <> "\""
+    | otherwise = text
+
+-- | Join fields with the delimiter (each escaped).
+row :: [Text] -> Text
+row = T.intercalate delim . map escapeField
+
+-- ============================================================================
+-- Flow / unit name resolution
+-- ============================================================================
+
+{- | Resolve a unit UUID to its name via the unit DB, falling back to the empty
+string when absent (a missing unit is surfaced downstream by the matrix
+builder, not silently defaulted to a wrong unit here).
+-}
+unitNameOf :: UnitDB -> UUID -> Text
+unitNameOf units uid = maybe "" unitName (M.lookup uid units)
+
+-- ============================================================================
+-- Process block serialization
+-- ============================================================================
+
+{- | A single technosphere/biosphere/waste exchange projected to the
+(name, unit, compartment, amount, comment) tuple the writer needs, plus a
+sort key. Keeping this intermediate makes the per-section sorting and
+formatting uniform.
+-}
+data Line = Line
+    { lName :: !Text
+    , lCompartment :: !Text -- sub-compartment for bio rows; "" otherwise
+    , lUnit :: !Text
+    , lAmount :: !Double
+    , lComment :: !Text
+    }
+
+-- | Deterministic ordering key for a section's lines.
+lineKey :: Line -> (Text, Text, Text, Double)
+lineKey l = (lName l, lCompartment l, lUnit l, lAmount l)
+
+-- | Render the comment column, re-attaching a pedigree prefix when present.
+renderComment :: Maybe Pedigree -> Maybe Text -> Text
+renderComment ped cmt =
+    let pedTxt = maybe "" renderPedigree ped
+        cmtTxt = fromMaybe "" cmt
+     in case (pedTxt, cmtTxt) of
+            ("", c) -> c
+            (p, "") -> p <> ","
+            (p, c) -> p <> "," <> c
+
+-- | @(r,c,t,g,f)@ pedigree quintuple, matching 'parsePedigreePrefix'.
+renderPedigree :: Pedigree -> Text
+renderPedigree Pedigree{..} =
+    "("
+        <> T.intercalate
+            ","
+            (map (T.pack . show) [pedReliability, pedCompleteness, pedTemporal, pedGeographical, pedTechnological])
+        <> ")"
+
+{- | Build a 'Line' for a technosphere input exchange. Returns 'Nothing' for
+the reference/coproduct outputs (those go to the Products section) and for
+exchanges whose flow is unknown to the tech-flow DB.
+-}
+techInputLine :: TechFlowDB -> UnitDB -> Exchange -> Maybe Line
+techInputLine techDB units ex@TechnosphereExchange{..} =
+    if exchangeIsReference ex
+        then Nothing
+        else case M.lookup techFlowId techDB of
+            Nothing -> Nothing
+            Just flow ->
+                Just
+                    Line
+                        { lName = tfName flow
+                        , lCompartment = ""
+                        , lUnit = unitNameOf units techUnitId
+                        , lAmount = techAmount
+                        , lComment = renderComment techPedigree techComment
+                        }
+techInputLine _ _ BiosphereExchange{} = Nothing
+techInputLine _ _ WasteExchange{} = Nothing
+
+-- | Build a 'Line' for a biosphere exchange (resource or emission).
+bioLine :: BioFlowDB -> UnitDB -> Exchange -> Maybe Line
+bioLine bioDB units BiosphereExchange{..} =
+    case M.lookup bioFlowId bioDB of
+        Nothing -> Nothing
+        Just flow ->
+            Just
+                Line
+                    { lName = bfName flow
+                    , lCompartment = fromMaybe "" (bfCompartmentSub flow)
+                    , lUnit = unitNameOf units bioUnitId
+                    , lAmount = bioAmount
+                    , lComment = renderComment bioPedigree bioComment
+                    }
+bioLine _ _ TechnosphereExchange{} = Nothing
+bioLine _ _ WasteExchange{} = Nothing
+
+-- | Build a 'Line' for a waste exchange (Final waste flows section).
+wasteLine :: WasteFlowDB -> UnitDB -> Exchange -> Maybe Line
+wasteLine wasteDB units WasteExchange{..} =
+    case M.lookup waFlowId wasteDB of
+        Nothing -> Nothing
+        Just flow ->
+            Just
+                Line
+                    { lName = wfName flow
+                    , lCompartment = ""
+                    , lUnit = unitNameOf units waUnitId
+                    , lAmount = waAmount
+                    , lComment = renderComment waPedigree waComment
+                    }
+wasteLine _ _ TechnosphereExchange{} = Nothing
+wasteLine _ _ BiosphereExchange{} = Nothing
+
+{- | The medium a biosphere exchange belongs to, derived from the flow's
+compartment name. SimaPro splits biosphere rows into four sections keyed on
+the medium: Resources, Emissions to air/water/soil. Resources are the
+'Resource' direction; emissions are bucketed by compartment name.
+-}
+bioSection :: BioFlowDB -> Exchange -> Maybe BioSec
+bioSection bioDB ex@BiosphereExchange{bioDirection = dir} =
+    case dir of
+        Resource -> Just SecRes
+        Emission -> case M.lookup (exchangeFlowId ex) bioDB of
+            Nothing -> Just SecAir -- unknown medium → air (parser default-ish); flow itself dropped anyway
+            Just flow -> case T.toLower (bfCompartmentName flow) of
+                "water" -> Just SecWater
+                "soil" -> Just SecSoil
+                "air" -> Just SecAir
+                "" -> Just SecAir
+                -- Any other medium has no faithful SimaPro section.
+                -- 'checkSimaProExportable' rejects it at the export boundary, so
+                -- this air fallback only ever fires for a direct (un-guarded) caller.
+                _ -> Just SecAir
+bioSection _ TechnosphereExchange{} = Nothing
+bioSection _ WasteExchange{} = Nothing
+
+data BioSec = SecRes | SecAir | SecWater | SecSoil
+    deriving (Eq)
+
+{- | Output rows (@name;unit;amount;allocation;waste_type;category;comment@) for
+the technosphere outputs matching @keep@. Used for both the @Products@ section
+(references) and the @Avoided products@ section (coproducts) — the two are
+rendered identically but the parser routes them to different exchange roles, so
+they must be emitted under their own headers, never merged.
+-}
+productLines :: (Exchange -> Bool) -> TechFlowDB -> UnitDB -> Maybe Double -> Text -> [Exchange] -> [Text]
+productLines keep techDB units allocPct category exchs =
+    let alloc = formatAmount (fromMaybe 100 allocPct)
+        -- Extract the row fields in the comprehension, where the exchange is
+        -- known to be a TechnosphereExchange — so mkRow is total (no unreachable
+        -- blank-row arm). Sort by (name, unit, amount) for determinism.
+        entries =
+            [ (tfName flow, unitNameOf units (exchangeUnitId ex), exchangeAmount ex)
+            | ex@TechnosphereExchange{} <- exchs
+            , keep ex
+            , Just flow <- [M.lookup (exchangeFlowId ex) techDB]
+            ]
+        mkRow (nm, unit, amt) = row [nm, unit, formatAmount amt, alloc, "not defined", category, ""]
+     in map mkRow (sortOn id entries)
+
+-- | A coproduct technosphere output (SimaPro @Avoided products@ section, which
+-- the parser reads back as a 'Coproduct' role).
+isCoproduct :: Exchange -> Bool
+isCoproduct ex = case ex of
+    TechnosphereExchange{techRole = Coproduct} -> True
+    TechnosphereExchange{} -> False
+    BiosphereExchange{} -> False
+    WasteExchange{} -> False
+
+{- | Prepend the @Avoided products@ header to coproduct rows, or emit nothing
+when there are none (an empty section would be noise the parser ignores).
+-}
+avoidedHeader :: [Text] -> [Text]
+avoidedHeader [] = []
+avoidedHeader rows = "Avoided products" : rows
+
+{- | Render one section: a header line followed by its sorted rows. Emits
+nothing when there are no rows, matching the parser (it tolerates absent
+sections).
+-}
+section :: Text -> (Line -> Text) -> [Line] -> [Text]
+section _ _ [] = []
+section header render ls = header : map render (sortOn lineKey ls)
+
+-- | Render a technosphere input row: name;unit;amount;Undefined;0;0;0;comment
+-- The parser skips three distribution columns after the uncertainty type
+-- (parseTechRow: name:unit:amount:unc:_:_:_:rest), so the comment/pedigree must
+-- sit in the eighth column or it lands in a placeholder and is dropped on parse-back.
+techRowText :: Line -> Text
+techRowText Line{..} =
+    row [lName, lUnit, formatAmount lAmount, "Undefined", "0", "0", "0", lComment]
+
+-- | Render a biosphere/waste row: name;compartment;unit;amount;Undefined;;;;;;comment
+-- The parser skips three distribution columns after the uncertainty type
+-- (parseBioRow: name:compartment:unit:amount:unc:_:_:_:rest), so the
+-- comment/pedigree must land past the eighth column or it is dropped on
+-- parse-back. Pad with five empty distribution columns to mirror the parser's
+-- expected layout.
+bioRowText :: Line -> Text
+bioRowText Line{..} =
+    row [lName, lCompartment, lUnit, formatAmount lAmount, "Undefined", "", "", "", "", "", lComment]
+
+{- | Serialize a single activity to a @Process … End@ block (list of lines,
+without trailing terminator). Flow/unit names are resolved through the
+respective DBs; exchanges whose flow is missing are dropped (the matrix
+builder is the authority on unknown flows, not the serializer).
+-}
+serializeActivity ::
+    TechFlowDB ->
+    BioFlowDB ->
+    WasteFlowDB ->
+    UnitDB ->
+    Activity ->
+    [Text]
+serializeActivity techDB bioDB wasteDB units Activity{..} =
+    let catType = M.findWithDefault "" "Category type" activityClassification
+        category = M.findWithDefault "" "Category" activityClassification
+        -- No native type → omit the Type line entirely (meta drops empty values),
+        -- so a re-parse yields Nothing again rather than drifting to "Unit process".
+        typeLabel = case activityNativeType of
+            Just (SimaProProcessType lbl) -> lbl
+            Just (EcoSpoldActivityType{eatLabel = lbl}) -> lbl
+            Just (ILCDProcessType lbl) -> lbl
+            Nothing -> ""
+        -- SimaPro's "Comment" is a single value line emitted unescaped, so it
+        -- cannot carry newlines (a paragraph break would corrupt re-parsing).
+        -- Multi-paragraph descriptions are flattened to one space-joined line;
+        -- the re-parse reads them back as a single description entry, losing the
+        -- paragraph boundaries. Accepted limitation of the SimaPro format.
+        comment = T.intercalate " " activityDescription
+
+        techLines = mapMaybe (techInputLine techDB units) exchanges
+        bioByName name = [l | (sec, l) <- bioPaired, sec == name]
+        bioPaired =
+            [ (sec, l)
+            | ex@BiosphereExchange{} <- exchanges
+            , Just sec <- [bioSection bioDB ex]
+            , Just l <- [bioLine bioDB units ex]
+            ]
+        wasteLines = mapMaybe (wasteLine wasteDB units) exchanges
+
+        meta key val = if T.null val then [] else [key, val, ""]
+     in concat
+            [ ["Process", ""]
+            , meta "Category type" catType
+            , meta "Process name" activityName
+            , meta "Type" typeLabel
+            , meta "Geography" activityLocation
+            , meta "Comment" comment
+            , -- Products section is always present (an activity has a reference).
+              -- Coproducts go to "Avoided products" so the parser reads them back
+              -- as coproducts, not as extra reference-product activities.
+              "Products" : productLines exchangeIsReference techDB units activityAllocationPercent category exchanges
+            , [""]
+            , withBlank (avoidedHeader (productLines isCoproduct techDB units activityAllocationPercent category exchanges))
+            , -- Inputs.
+              withBlank (section "Materials/fuels" techRowText techLines)
+            , withBlank (section "Resources" bioRowText (bioByName SecRes))
+            , withBlank (section "Emissions to air" bioRowText (bioByName SecAir))
+            , withBlank (section "Emissions to water" bioRowText (bioByName SecWater))
+            , withBlank (section "Emissions to soil" bioRowText (bioByName SecSoil))
+            , withBlank (section "Final waste flows" bioRowText wasteLines)
+            , ["End", ""]
+            ]
+  where
+    -- Append a blank separator line after a non-empty section.
+    withBlank [] = []
+    withBlank ls = ls ++ [""]
+
+-- ============================================================================
+-- Header
+-- ============================================================================
+
+-- | The fixed SimaPro header block. No timestamp / generator line is emitted.
+headerLines :: WriterConfig -> [Text]
+headerLines cfg =
+    [ "{" <> wcVersion cfg <> "}"
+    , "{CSV separator: Semicolon}"
+    , "{Decimal separator: .}"
+    , "{Date separator: /}"
+    , "{Short date format: dd/MM/yyyy}"
+    , ""
+    ]
+
+-- ============================================================================
+-- Top-level serialization
+-- ============================================================================
+
+{- | Serialize a 'SimpleDatabase' to canonical SimaPro CSV bytes (UTF-8, CRLF).
+Activities are sorted by (name, location) so the byte stream is independent
+of the underlying 'Map' iteration order.
+-}
+serializeSimaProCSV :: WriterConfig -> SimpleDatabase -> BS.ByteString
+serializeSimaProCSV cfg SimpleDatabase{..} =
+    let acts = sortOn (\a -> (activityName a, activityLocation a)) (M.elems sdbActivities)
+        blocks = concatMap (serializeActivity sdbTechFlows sdbBioFlows sdbWasteFlows sdbUnits) acts
+        allLines = headerLines cfg ++ blocks
+     in TE.encodeUtf8 (T.intercalate crlf allLines <> crlf)
+
+-- | Write canonical SimaPro CSV bytes to a file.
+writeSimaProCSV :: WriterConfig -> FilePath -> SimpleDatabase -> IO ()
+writeSimaProCSV cfg path = BS.writeFile path . serializeSimaProCSV cfg

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -323,6 +323,18 @@ builder, not silently defaulted to a wrong unit here).
 unitNameOf :: UnitDB -> UUID -> Text
 unitNameOf units uid = maybe "" unitName (M.lookup uid units)
 
+{- | The four flow/unit catalogs an activity is serialized against, gathered
+into one record so the per-section helpers take a single argument instead of
+threading four maps positionally (which invites silent arg-swaps between maps
+of the same shape).
+-}
+data Catalogs = Catalogs
+    { catTech :: !TechFlowDB
+    , catBio :: !BioFlowDB
+    , catWaste :: !WasteFlowDB
+    , catUnits :: !UnitDB
+    }
+
 -- ============================================================================
 -- Process block serialization
 -- ============================================================================
@@ -379,71 +391,71 @@ renderPedigree Pedigree{..} =
 the reference/coproduct outputs (those go to the Products section) and for
 exchanges whose flow is unknown to the tech-flow DB.
 -}
-techInputLine :: TechFlowDB -> UnitDB -> Exchange -> Maybe Line
-techInputLine techDB units ex@TechnosphereExchange{..} =
+techInputLine :: Catalogs -> Exchange -> Maybe Line
+techInputLine cats ex@TechnosphereExchange{..} =
     if exchangeIsReference ex
         then Nothing
-        else case M.lookup techFlowId techDB of
+        else case M.lookup techFlowId (catTech cats) of
             Nothing -> Nothing
             Just flow ->
                 Just
                     Line
                         { lName = tfName flow
                         , lCompartment = ""
-                        , lUnit = unitNameOf units techUnitId
+                        , lUnit = unitNameOf (catUnits cats) techUnitId
                         , lAmount = techAmount
                         , lComment = renderComment techPedigree techComment
                         }
-techInputLine _ _ BiosphereExchange{} = Nothing
-techInputLine _ _ WasteExchange{} = Nothing
+techInputLine _ BiosphereExchange{} = Nothing
+techInputLine _ WasteExchange{} = Nothing
 
 -- | Build a 'Line' for a biosphere exchange (resource or emission).
-bioLine :: BioFlowDB -> UnitDB -> Exchange -> Maybe Line
-bioLine bioDB units BiosphereExchange{..} =
-    case M.lookup bioFlowId bioDB of
+bioLine :: Catalogs -> Exchange -> Maybe Line
+bioLine cats BiosphereExchange{..} =
+    case M.lookup bioFlowId (catBio cats) of
         Nothing -> Nothing
         Just flow ->
             Just
                 Line
                     { lName = bfName flow
                     , lCompartment = fromMaybe "" (bfCompartmentSub flow)
-                    , lUnit = unitNameOf units bioUnitId
+                    , lUnit = unitNameOf (catUnits cats) bioUnitId
                     , lAmount = bioAmount
                     , lComment = renderComment bioPedigree bioComment
                     }
-bioLine _ _ TechnosphereExchange{} = Nothing
-bioLine _ _ WasteExchange{} = Nothing
+bioLine _ TechnosphereExchange{} = Nothing
+bioLine _ WasteExchange{} = Nothing
 
 -- | Build a 'Line' for a waste exchange (Final waste flows section).
-wasteLine :: WasteFlowDB -> UnitDB -> Exchange -> Maybe Line
-wasteLine wasteDB units WasteExchange{..} =
-    case M.lookup waFlowId wasteDB of
+wasteLine :: Catalogs -> Exchange -> Maybe Line
+wasteLine cats WasteExchange{..} =
+    case M.lookup waFlowId (catWaste cats) of
         Nothing -> Nothing
         Just flow ->
             Just
                 Line
                     { lName = wfName flow
                     , lCompartment = ""
-                    , lUnit = unitNameOf units waUnitId
+                    , lUnit = unitNameOf (catUnits cats) waUnitId
                     , lAmount = waAmount
                     , lComment = renderComment waPedigree waComment
                     }
-wasteLine _ _ TechnosphereExchange{} = Nothing
-wasteLine _ _ BiosphereExchange{} = Nothing
+wasteLine _ TechnosphereExchange{} = Nothing
+wasteLine _ BiosphereExchange{} = Nothing
 
 {- | The medium a biosphere exchange belongs to, derived from the flow's
 compartment name. SimaPro splits biosphere rows into four sections keyed on
 the medium: Resources, Emissions to air/water/soil. Resources are the
 'Resource' direction; emissions are bucketed by compartment name.
 -}
-bioSection :: BioFlowDB -> Exchange -> Maybe BioSec
-bioSection bioDB ex@BiosphereExchange{bioDirection = dir} =
+bioSection :: Catalogs -> Exchange -> Maybe BioSec
+bioSection cats ex@BiosphereExchange{bioDirection = dir} =
     case dir of
         Resource -> Just SecRes
         -- Unknown flow → Nothing, mirroring 'bioLine' so an emission keeps a
         -- section only when it also keeps a row (the two are paired in
         -- 'serializeActivity'); no dead "unknown → air" arm.
-        Emission -> sectionForMedium . bfCompartmentName <$> M.lookup (exchangeFlowId ex) bioDB
+        Emission -> sectionForMedium . bfCompartmentName <$> M.lookup (exchangeFlowId ex) (catBio cats)
   where
     sectionForMedium name = case T.toLower name of
         "water" -> SecWater
@@ -464,17 +476,17 @@ the technosphere outputs matching @keep@. Used for both the @Products@ section
 rendered identically but the parser routes them to different exchange roles, so
 they must be emitted under their own headers, never merged.
 -}
-productLines :: (Exchange -> Bool) -> TechFlowDB -> UnitDB -> Maybe Double -> Text -> [Exchange] -> [Text]
-productLines keep techDB units allocPct category exchs =
+productLines :: (Exchange -> Bool) -> Catalogs -> Maybe Double -> Text -> [Exchange] -> [Text]
+productLines keep cats allocPct category exchs =
     let alloc = formatAmount (fromMaybe 100 allocPct)
         -- Extract the row fields in the comprehension, where the exchange is
         -- known to be a TechnosphereExchange — so mkRow is total (no unreachable
         -- blank-row arm). Sort by (name, unit, amount) for determinism.
         entries =
-            [ (tfName flow, unitNameOf units (exchangeUnitId ex), exchangeAmount ex)
+            [ (tfName flow, unitNameOf (catUnits cats) (exchangeUnitId ex), exchangeAmount ex)
             | ex@TechnosphereExchange{} <- exchs
             , keep ex
-            , Just flow <- [M.lookup (exchangeFlowId ex) techDB]
+            , Just flow <- [M.lookup (exchangeFlowId ex) (catTech cats)]
             ]
         mkRow (nm, unit, amt) = row [nm, unit, formatAmount amt, alloc, "not defined", category, ""]
      in map mkRow (sortOn id entries)
@@ -537,14 +549,8 @@ without trailing terminator). Flow/unit names are resolved through the
 respective DBs; exchanges whose flow is missing are dropped (the matrix
 builder is the authority on unknown flows, not the serializer).
 -}
-serializeActivity ::
-    TechFlowDB ->
-    BioFlowDB ->
-    WasteFlowDB ->
-    UnitDB ->
-    Activity ->
-    [Text]
-serializeActivity techDB bioDB wasteDB units Activity{..} =
+serializeActivity :: Catalogs -> Activity -> [Text]
+serializeActivity cats Activity{..} =
     let catType = M.findWithDefault "" "Category type" activityClassification
         category = M.findWithDefault "" "Category" activityClassification
         -- No native type → omit the Type line entirely (meta drops empty values),
@@ -571,15 +577,15 @@ serializeActivity techDB bioDB wasteDB units Activity{..} =
             | otherwise = scaleExchangeAmount (1 / allocFraction) ex
         unscaledExchanges = map unscale exchanges
 
-        techLines = mapMaybe (techInputLine techDB units) unscaledExchanges
+        techLines = mapMaybe (techInputLine cats) unscaledExchanges
         bioByName name = [l | (sec, l) <- bioPaired, sec == name]
         bioPaired =
             [ (sec, l)
             | ex@BiosphereExchange{} <- unscaledExchanges
-            , Just sec <- [bioSection bioDB ex]
-            , Just l <- [bioLine bioDB units ex]
+            , Just sec <- [bioSection cats ex]
+            , Just l <- [bioLine cats ex]
             ]
-        wasteLines = mapMaybe (wasteLine wasteDB units) unscaledExchanges
+        wasteLines = mapMaybe (wasteLine cats) unscaledExchanges
 
         meta key val = if T.null val then [] else [key, val, ""]
      in concat
@@ -592,9 +598,9 @@ serializeActivity techDB bioDB wasteDB units Activity{..} =
             , -- Products section is always present (an activity has a reference).
               -- Coproducts go to "Avoided products" so the parser reads them back
               -- as coproducts, not as extra reference-product activities.
-              "Products" : productLines exchangeIsReference techDB units activityAllocationPercent category unscaledExchanges
+              "Products" : productLines exchangeIsReference cats activityAllocationPercent category unscaledExchanges
             , [""]
-            , withBlank (avoidedHeader (productLines isCoproduct techDB units activityAllocationPercent category unscaledExchanges))
+            , withBlank (avoidedHeader (productLines isCoproduct cats activityAllocationPercent category unscaledExchanges))
             , -- Inputs.
               withBlank (section "Materials/fuels" techRowText techLines)
             , withBlank (section "Resources" bioRowText (bioByName SecRes))
@@ -637,8 +643,9 @@ byte stream is independent of the underlying 'Map' iteration order.
 serializeSimaProCSV :: WriterConfig -> SimpleDatabase -> Either Text BS.ByteString
 serializeSimaProCSV cfg db@SimpleDatabase{..} = do
     checkSimaProExportable db
-    let acts = sortOn (\a -> (activityName a, activityLocation a)) (M.elems sdbActivities)
-        blocks = concatMap (serializeActivity sdbTechFlows sdbBioFlows sdbWasteFlows sdbUnits) acts
+    let cats = Catalogs sdbTechFlows sdbBioFlows sdbWasteFlows sdbUnits
+        acts = sortOn (\a -> (activityName a, activityLocation a)) (M.elems sdbActivities)
+        blocks = concatMap (serializeActivity cats) acts
         allLines = headerLines cfg ++ blocks
     pure (TE.encodeUtf8 (T.intercalate crlf allLines <> crlf))
 

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -76,7 +76,14 @@ defaultWriterConfig = WriterConfig{wcVersion = "SimaPro 9.6.0.1"}
 -- Export guard
 -- ============================================================================
 
-{- | SimaPro CSV files emissions into air / water / soil sections only. An
+{- | Every activity must have exactly one reference product. The writer emits
+one @Process@ block per activity, with one @Products@ row per reference output;
+zero references would leave an empty @Products@ section that the parser discards
+(it keeps a block only if it has a product), and more than one would re-parse
+into a separate activity per row. Reject either rather than silently drop or
+split the activity on re-import.
+
+SimaPro CSV files emissions into air / water / soil sections only. An
 emission whose compartment medium is some other non-empty value has no faithful
 section, so report it rather than silently filing it under @Emissions to air@.
 An unspecified (empty) medium is allowed — it carries no medium to lose and
@@ -109,8 +116,28 @@ Both are rejected here rather than emitted as a row the parser misreads.
 -}
 checkSimaProExportable :: SimpleDatabase -> Either Text ()
 checkSimaProExportable db =
-    checkMedia *> checkAmounts *> checkAllocation *> checkUnits *> checkNewlines *> checkComments *> checkMetaKeys
+    checkReferences
+        *> checkMedia
+        *> checkAmounts
+        *> checkAllocation
+        *> checkUnits
+        *> checkNewlines
+        *> checkComments
+        *> checkMetaKeys
   where
+    checkReferences =
+        case referenceOffenders of
+            [] -> Right ()
+            ((name, n) : _) ->
+                Left $
+                    "SimaPro export cannot represent activity \""
+                        <> name
+                        <> "\": it has "
+                        <> T.pack (show n)
+                        <> " reference products, but a faithful round-trip needs exactly"
+                        <> " one — zero would drop the whole Process block on re-import"
+                        <> " (the parser keeps a block only if it has a product), and more"
+                        <> " than one would split it into separate activities."
     checkMedia =
         case mediumOffenders of
             [] -> Right ()
@@ -185,6 +212,16 @@ checkSimaProExportable db =
                         <> val
                         <> "\" collides with a SimaPro metadata key, so the parser would"
                         <> " mistake it for a new field and drop it on import."
+    -- Each activity must have exactly one reference product. The writer emits
+    -- one Process block per activity with one Products row per reference; zero
+    -- references → an empty Products section → the parser drops the block, and
+    -- >1 → several Products rows → the parser splits it into one activity each.
+    referenceOffenders =
+        [ (activityName act, n)
+        | act <- M.elems (sdbActivities db)
+        , let n = length (filter exchangeIsReference (exchanges act))
+        , n /= 1
+        ]
     mediumOffenders =
         [ (bfName flow, bfCompartmentName flow)
         | act <- M.elems (sdbActivities db)

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -94,7 +94,7 @@ apart and corrupts or drops it. Reject such fields rather than emit a row the
 parser cannot read back.
 -}
 checkSimaProExportable :: SimpleDatabase -> Either Text ()
-checkSimaProExportable db = checkMedia *> checkAmounts *> checkNewlines
+checkSimaProExportable db = checkMedia *> checkAmounts *> checkAllocation *> checkUnits *> checkNewlines
   where
     checkMedia =
         case mediumOffenders of
@@ -125,6 +125,29 @@ checkSimaProExportable db = checkMedia *> checkAmounts *> checkNewlines
                         <> field
                         <> "\": it contains a newline, which the line-based parser"
                         <> " would split across rows."
+    checkAllocation =
+        case allocationOffenders of
+            [] -> Right ()
+            ((name, pct) : _) ->
+                Left $
+                    "SimaPro export cannot represent activity \""
+                        <> name
+                        <> "\": allocation percentage "
+                        <> T.pack (show pct)
+                        <> " is not a usable positive number — the writer divides the"
+                        <> " allocation-scaled amounts back out, so 0 (or non-finite)"
+                        <> " would lose them on re-import."
+    checkUnits =
+        case unitOffenders of
+            [] -> Right ()
+            ((name, uid) : _) ->
+                Left $
+                    "SimaPro export cannot represent activity \""
+                        <> name
+                        <> "\": an exchange references unit "
+                        <> T.pack (show uid)
+                        <> ", which is absent from the unit registry (it would be"
+                        <> " written as a blank unit and re-parsed as UNKNOWN)."
     mediumOffenders =
         [ (bfName flow, bfCompartmentName flow)
         | act <- M.elems (sdbActivities db)
@@ -141,13 +164,29 @@ checkSimaProExportable db = checkMedia *> checkAmounts *> checkNewlines
         , let amt = exchangeAmount ex
         , isNaN amt || isInfinite amt
         ]
+    allocationOffenders =
+        [ (activityName act, pct)
+        | act <- M.elems (sdbActivities db)
+        , let pct = fromMaybe 100 (activityAllocationPercent act)
+        , isNaN pct || isInfinite pct || pct == 0
+        ]
+    unitOffenders =
+        [ (activityName act, exchangeUnitId ex)
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , M.notMember (exchangeUnitId ex) (sdbUnits db)
+        ]
     hasNewline = T.any (\c -> c == '\n' || c == '\r')
     newlineOffenders =
         filter hasNewline $
             concat
-                [ activityName act : activityDescription act
+                [ activityName act : activityLocation act : activityDescription act
                 | act <- M.elems (sdbActivities db)
                 ]
+                ++ [ v
+                   | act <- M.elems (sdbActivities db)
+                   , v <- M.elems (activityClassification act)
+                   ]
                 ++ map tfName (M.elems (sdbTechFlows db))
                 ++ map bfName (M.elems (sdbBioFlows db))
                 ++ map wfName (M.elems (sdbWasteFlows db))
@@ -360,8 +399,9 @@ productLines keep techDB units allocPct category exchs =
         mkRow (nm, unit, amt) = row [nm, unit, formatAmount amt, alloc, "not defined", category, ""]
      in map mkRow (sortOn id entries)
 
--- | A coproduct technosphere output (SimaPro @Avoided products@ section, which
--- the parser reads back as a 'Coproduct' role).
+{- | A coproduct technosphere output (SimaPro @Avoided products@ section, which
+the parser reads back as a 'Coproduct' role).
+-}
 isCoproduct :: Exchange -> Bool
 isCoproduct ex = case ex of
     TechnosphereExchange{techRole = Coproduct} -> True
@@ -384,23 +424,33 @@ section :: Text -> (Line -> Text) -> [Line] -> [Text]
 section _ _ [] = []
 section header render ls = header : map render (sortOn lineKey ls)
 
--- | Render a technosphere input row: name;unit;amount;Undefined;0;0;0;comment
--- The parser skips three distribution columns after the uncertainty type
--- (parseTechRow: name:unit:amount:unc:_:_:_:rest), so the comment/pedigree must
--- sit in the eighth column or it lands in a placeholder and is dropped on parse-back.
+{- | Render a technosphere input row: name;unit;amount;Undefined;0;0;0;comment
+The parser skips three distribution columns after the uncertainty type
+(parseTechRow: name:unit:amount:unc:_:_:_:rest), so the comment/pedigree must
+sit in the eighth column or it lands in a placeholder and is dropped on parse-back.
+-}
 techRowText :: Line -> Text
 techRowText Line{..} =
     row [lName, lUnit, formatAmount lAmount, "Undefined", "0", "0", "0", lComment]
 
--- | Render a biosphere/waste row: name;compartment;unit;amount;Undefined;;;;;;comment
--- The parser skips three distribution columns after the uncertainty type
--- (parseBioRow: name:compartment:unit:amount:unc:_:_:_:rest), so the
--- comment/pedigree must land past the eighth column or it is dropped on
--- parse-back. Pad with five empty distribution columns to mirror the parser's
--- expected layout.
+{- | Render a biosphere/waste row: name;compartment;unit;amount;Undefined;;;;;;comment
+The parser skips three distribution columns after the uncertainty type
+(parseBioRow: name:compartment:unit:amount:unc:_:_:_:rest), so the
+comment/pedigree must land past the eighth column or it is dropped on
+parse-back. Pad with five empty distribution columns to mirror the parser's
+expected layout.
+-}
 bioRowText :: Line -> Text
 bioRowText Line{..} =
     row [lName, lCompartment, lUnit, formatAmount lAmount, "Undefined", "", "", "", "", "", lComment]
+
+{- | Scale an exchange's amount by a factor — the inverse of the parser's
+allocation scaling (see 'serializeActivity').
+-}
+scaleExchangeAmount :: Double -> Exchange -> Exchange
+scaleExchangeAmount f ex@TechnosphereExchange{} = ex{techAmount = techAmount ex * f}
+scaleExchangeAmount f ex@BiosphereExchange{} = ex{bioAmount = bioAmount ex * f}
+scaleExchangeAmount f ex@WasteExchange{} = ex{waAmount = waAmount ex * f}
 
 {- | Serialize a single activity to a @Process … End@ block (list of lines,
 without trailing terminator). Flow/unit names are resolved through the
@@ -431,15 +481,29 @@ serializeActivity techDB bioDB wasteDB units Activity{..} =
         -- paragraph boundaries. Accepted limitation of the SimaPro format.
         comment = T.intercalate " " activityDescription
 
-        techLines = mapMaybe (techInputLine techDB units) exchanges
+        -- The parser scales every shared exchange (everything but the reference
+        -- product) by allocFraction = allocPercent/100 on import. To be its exact
+        -- inverse, emit the *pre-allocation* amounts: divide the shared exchanges
+        -- back out so the re-import lands on the stored amounts again (emitting
+        -- them as-is would let the parser scale a second time). The reference
+        -- product is never scaled, so it passes through untouched.
+        -- 'checkSimaProExportable' rejects a zero/non-finite allocation, so the
+        -- division is finite for any export-validated database.
+        allocFraction = fromMaybe 100 activityAllocationPercent / 100
+        unscale ex
+            | exchangeIsReference ex = ex
+            | otherwise = scaleExchangeAmount (1 / allocFraction) ex
+        unscaledExchanges = map unscale exchanges
+
+        techLines = mapMaybe (techInputLine techDB units) unscaledExchanges
         bioByName name = [l | (sec, l) <- bioPaired, sec == name]
         bioPaired =
             [ (sec, l)
-            | ex@BiosphereExchange{} <- exchanges
+            | ex@BiosphereExchange{} <- unscaledExchanges
             , Just sec <- [bioSection bioDB ex]
             , Just l <- [bioLine bioDB units ex]
             ]
-        wasteLines = mapMaybe (wasteLine wasteDB units) exchanges
+        wasteLines = mapMaybe (wasteLine wasteDB units) unscaledExchanges
 
         meta key val = if T.null val then [] else [key, val, ""]
      in concat
@@ -452,9 +516,9 @@ serializeActivity techDB bioDB wasteDB units Activity{..} =
             , -- Products section is always present (an activity has a reference).
               -- Coproducts go to "Avoided products" so the parser reads them back
               -- as coproducts, not as extra reference-product activities.
-              "Products" : productLines exchangeIsReference techDB units activityAllocationPercent category exchanges
+              "Products" : productLines exchangeIsReference techDB units activityAllocationPercent category unscaledExchanges
             , [""]
-            , withBlank (avoidedHeader (productLines isCoproduct techDB units activityAllocationPercent category exchanges))
+            , withBlank (avoidedHeader (productLines isCoproduct techDB units activityAllocationPercent category unscaledExchanges))
             , -- Inputs.
               withBlank (section "Materials/fuels" techRowText techLines)
             , withBlank (section "Resources" bioRowText (bioByName SecRes))
@@ -489,16 +553,22 @@ headerLines cfg =
 -- ============================================================================
 
 {- | Serialize a 'SimpleDatabase' to canonical SimaPro CSV bytes (UTF-8, CRLF).
-Activities are sorted by (name, location) so the byte stream is independent
-of the underlying 'Map' iteration order.
+Runs 'checkSimaProExportable' first and returns its 'Left' on a database the
+format cannot represent faithfully, so an unguarded caller can never silently
+emit a corrupt or lossy file. Activities are sorted by (name, location) so the
+byte stream is independent of the underlying 'Map' iteration order.
 -}
-serializeSimaProCSV :: WriterConfig -> SimpleDatabase -> BS.ByteString
-serializeSimaProCSV cfg SimpleDatabase{..} =
+serializeSimaProCSV :: WriterConfig -> SimpleDatabase -> Either Text BS.ByteString
+serializeSimaProCSV cfg db@SimpleDatabase{..} = do
+    checkSimaProExportable db
     let acts = sortOn (\a -> (activityName a, activityLocation a)) (M.elems sdbActivities)
         blocks = concatMap (serializeActivity sdbTechFlows sdbBioFlows sdbWasteFlows sdbUnits) acts
         allLines = headerLines cfg ++ blocks
-     in TE.encodeUtf8 (T.intercalate crlf allLines <> crlf)
+    pure (TE.encodeUtf8 (T.intercalate crlf allLines <> crlf))
 
--- | Write canonical SimaPro CSV bytes to a file.
-writeSimaProCSV :: WriterConfig -> FilePath -> SimpleDatabase -> IO ()
-writeSimaProCSV cfg path = BS.writeFile path . serializeSimaProCSV cfg
+-- | Write canonical SimaPro CSV bytes to a file, or return the guard's 'Left'.
+writeSimaProCSV :: WriterConfig -> FilePath -> SimpleDatabase -> IO (Either Text ())
+writeSimaProCSV cfg path db =
+    case serializeSimaProCSV cfg db of
+        Left err -> pure (Left err)
+        Right bytes -> Right <$> BS.writeFile path bytes

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -46,10 +46,11 @@ module SimaPro.Writer (
 import qualified Data.ByteString as BS
 import Data.List (sortOn)
 import qualified Data.Map.Strict as M
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
+import SimaPro.Parser (isMetadataKey, parsePedigreePrefix)
 import Types
 
 -- ============================================================================
@@ -92,9 +93,23 @@ RFC-4180-quotes them, but the parser splits the file on physical lines
 ('BS8.lines') /before/ CSV parsing, so an embedded @\\n@ or @\\r@ tears the row
 apart and corrupts or drops it. Reject such fields rather than emit a row the
 parser cannot read back.
+
+Two more round-trip hazards are specific to SimaPro's textual layout, and bite
+only for databases imported from other formats (a SimaPro parse can't produce
+them):
+
+  * a pedigree-less exchange whose comment /begins/ with a @(r,c,t,g,f)@
+    quintuple — 'parsePedigreePrefix' would read it back as a 'Pedigree' and
+    strip it, fabricating a data-quality score; and
+  * a metadata value (activity name, location, …) equal to a SimaPro metadata
+    key — the parser checks 'isMetadataKey' before reading a value line, so it
+    would mistake the value for a new field and silently drop it.
+
+Both are rejected here rather than emitted as a row the parser misreads.
 -}
 checkSimaProExportable :: SimpleDatabase -> Either Text ()
-checkSimaProExportable db = checkMedia *> checkAmounts *> checkAllocation *> checkUnits *> checkNewlines
+checkSimaProExportable db =
+    checkMedia *> checkAmounts *> checkAllocation *> checkUnits *> checkNewlines *> checkComments *> checkMetaKeys
   where
     checkMedia =
         case mediumOffenders of
@@ -148,6 +163,28 @@ checkSimaProExportable db = checkMedia *> checkAmounts *> checkAllocation *> che
                         <> T.pack (show uid)
                         <> ", which is absent from the unit registry (it would be"
                         <> " written as a blank unit and re-parsed as UNKNOWN)."
+    checkComments =
+        case commentOffenders of
+            [] -> Right ()
+            ((name, cmt) : _) ->
+                Left $
+                    "SimaPro export cannot represent activity \""
+                        <> name
+                        <> "\": the comment \""
+                        <> cmt
+                        <> "\" begins with a pedigree-shaped (r,c,t,g,f) quintuple, so the"
+                        <> " parser would re-read it as a data-quality pedigree on import."
+    checkMetaKeys =
+        case metaKeyOffenders of
+            [] -> Right ()
+            ((name, val) : _) ->
+                Left $
+                    "SimaPro export cannot represent activity \""
+                        <> name
+                        <> "\": the metadata value \""
+                        <> val
+                        <> "\" collides with a SimaPro metadata key, so the parser would"
+                        <> " mistake it for a new field and drop it on import."
     mediumOffenders =
         [ (bfName flow, bfCompartmentName flow)
         | act <- M.elems (sdbActivities db)
@@ -175,6 +212,30 @@ checkSimaProExportable db = checkMedia *> checkAmounts *> checkAllocation *> che
         | act <- M.elems (sdbActivities db)
         , ex <- exchanges act
         , M.notMember (exchangeUnitId ex) (sdbUnits db)
+        ]
+    commentOffenders =
+        [ (activityName act, cmt)
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , Nothing <- [exchangePedigree ex]
+        , Just cmt <- [exchangeComment ex]
+        , isJust (fst (parsePedigreePrefix cmt))
+        ]
+    metaKeyOffenders =
+        [ (activityName act, val)
+        | act <- M.elems (sdbActivities db)
+        , val <- emittedMetaValues act
+        , not (T.null val)
+        , isMetadataKey (TE.encodeUtf8 (T.strip val))
+        ]
+    -- The metadata values the writer emits as bare value lines (see
+    -- 'serializeActivity'). Each must not collide with a SimaPro metadata key.
+    emittedMetaValues act =
+        [ M.findWithDefault "" "Category type" (activityClassification act)
+        , activityName act
+        , typeLabelOf (activityNativeType act)
+        , activityLocation act
+        , T.intercalate " " (activityDescription act)
         ]
     hasNewline = T.any (\c -> c == '\n' || c == '\r')
     newlineOffenders =
@@ -219,10 +280,16 @@ Integral values are written without a trailing @.0@ (e.g. @100@, not
 @100.0@) so allocation percentages match the parser's @"100"@ raw form;
 all other values use Haskell's 'show', which is dot-decimal and exact
 enough to round-trip a 'Double'.
+
+A non-finite value has no parseable literal: it renders as its (non-parseable)
+@"NaN"@/@"Infinity"@ form so a re-import fails loudly rather than silently
+reading @0@. 'checkSimaProExportable' rejects non-finite amounts at the export
+boundary, so this never fires for a validated database — but the formatter
+stays honest for any direct caller.
 -}
 formatAmount :: Double -> Text
 formatAmount x
-    | isNaN x || isInfinite x = "0"
+    | isNaN x || isInfinite x = T.pack (show x)
     | x == fromIntegral (round x :: Integer) =
         T.pack (show (round x :: Integer))
     | otherwise = T.pack (show x)
@@ -276,6 +343,18 @@ data Line = Line
 -- | Deterministic ordering key for a section's lines.
 lineKey :: Line -> (Text, Text, Text, Double)
 lineKey l = (lName l, lCompartment l, lUnit l, lAmount l)
+
+{- | The @Type@ metadata value the writer emits for an activity's native type,
+or @""@ when there is none (so the line is omitted). Shared between
+'serializeActivity' and 'checkSimaProExportable' so the export guard inspects
+exactly the value that gets written.
+-}
+typeLabelOf :: Maybe NativeActivityType -> Text
+typeLabelOf mnt = case mnt of
+    Just (SimaProProcessType lbl) -> lbl
+    Just (EcoSpoldActivityType{eatLabel = lbl}) -> lbl
+    Just (ILCDProcessType lbl) -> lbl
+    Nothing -> ""
 
 -- | Render the comment column, re-attaching a pedigree prefix when present.
 renderComment :: Maybe Pedigree -> Maybe Text -> Text
@@ -361,17 +440,18 @@ bioSection :: BioFlowDB -> Exchange -> Maybe BioSec
 bioSection bioDB ex@BiosphereExchange{bioDirection = dir} =
     case dir of
         Resource -> Just SecRes
-        Emission -> case M.lookup (exchangeFlowId ex) bioDB of
-            Nothing -> Just SecAir -- unknown medium → air (parser default-ish); flow itself dropped anyway
-            Just flow -> case T.toLower (bfCompartmentName flow) of
-                "water" -> Just SecWater
-                "soil" -> Just SecSoil
-                "air" -> Just SecAir
-                "" -> Just SecAir
-                -- Any other medium has no faithful SimaPro section.
-                -- 'checkSimaProExportable' rejects it at the export boundary, so
-                -- this air fallback only ever fires for a direct (un-guarded) caller.
-                _ -> Just SecAir
+        -- Unknown flow → Nothing, mirroring 'bioLine' so an emission keeps a
+        -- section only when it also keeps a row (the two are paired in
+        -- 'serializeActivity'); no dead "unknown → air" arm.
+        Emission -> sectionForMedium . bfCompartmentName <$> M.lookup (exchangeFlowId ex) bioDB
+  where
+    sectionForMedium name = case T.toLower name of
+        "water" -> SecWater
+        "soil" -> SecSoil
+        -- air, unspecified, or any other medium → air. 'checkSimaProExportable'
+        -- rejects non air/water/soil media at the export boundary, so a real
+        -- export only ever lands air or empty here.
+        _ -> SecAir
 bioSection _ TechnosphereExchange{} = Nothing
 bioSection _ WasteExchange{} = Nothing
 
@@ -469,11 +549,7 @@ serializeActivity techDB bioDB wasteDB units Activity{..} =
         category = M.findWithDefault "" "Category" activityClassification
         -- No native type → omit the Type line entirely (meta drops empty values),
         -- so a re-parse yields Nothing again rather than drifting to "Unit process".
-        typeLabel = case activityNativeType of
-            Just (SimaProProcessType lbl) -> lbl
-            Just (EcoSpoldActivityType{eatLabel = lbl}) -> lbl
-            Just (ILCDProcessType lbl) -> lbl
-            Nothing -> ""
+        typeLabel = typeLabelOf activityNativeType
         -- SimaPro's "Comment" is a single value line emitted unescaped, so it
         -- cannot carry newlines (a paragraph break would corrupt re-parsing).
         -- Multi-paragraph descriptions are flattened to one space-joined line;

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -466,6 +466,16 @@ spec = describe "SimaPro.Writer round-trip" $ do
             -- (it is derived from the same 'activityMetaLines' as the emitter).
             checkSimaProExportable (guardDb Nothing (Just (SimaProProcessType "Unit\nprocess")) [refProd])
                 `shouldSatisfy` isLeft
+
+        it "rejects an activity with no reference product" $
+            -- An empty Products section makes the parser discard the whole block.
+            checkSimaProExportable (guardDb Nothing Nothing [matInput])
+                `shouldSatisfy` isLeft
+
+        it "rejects an activity with more than one reference product" $
+            -- Two Products rows re-parse into two separate activities.
+            checkSimaProExportable (guardDb Nothing Nothing [refProd, refProd2])
+                `shouldSatisfy` isLeft
   where
     activitiesOf (acts, _, _, _, _) = acts
 
@@ -649,6 +659,14 @@ gUnit = testUUID 0x53
 -- | A valid reference product output for the catalog above.
 refProd :: Exchange
 refProd = TechnosphereExchange gProd 1.0 gUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+
+-- | A second reference product (on the material flow) — an invalid second head.
+refProd2 :: Exchange
+refProd2 = TechnosphereExchange gMat 1.0 gUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+
+-- | A plain material input (no reference product in the activity).
+matInput :: Exchange
+matInput = TechnosphereExchange gMat 2.0 gUnit Input UUID.nil Nothing "" Nothing Nothing
 
 {- | A one-activity database whose exchanges are supplied verbatim, against a
 fixed catalog (a reference product flow, a material flow, an emission flow, and

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -1,0 +1,448 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+{- | Round-trip contract for "SimaPro.Writer", the inverse of
+"SimaPro.Parser".
+
+The original database @D@ is built by parsing a small in-line SimaPro CSV with
+'parseSimaProCSV'. That guarantees @D@ already lives in the parser's canonical
+internal form (canonical units, resolved amounts, generated UUIDs), so the
+write→parse cycle has a fair fixed point to land on.
+
+Three properties are pinned:
+
+  (a) idempotence modulo volatile metadata — @write(D)@ then
+      @write(parse(write(D)))@ produce byte-identical output (the version
+      banner is the only volatile field and it is pinned by 'WriterConfig');
+
+  (b) semantic round-trip — @parse(write(D))@ is structurally equal to @D@,
+      order-insensitively, on activities, flows and units;
+
+  (c) score-equivalence — @parse(write(D))@ yields the same biosphere
+      inventory (the LCIA-precursor vector) as @D@ within tolerance, via the
+      engine's 'computeInventoryMatrix'.
+-}
+module SimaProWriterSpec (spec) where
+
+import qualified Data.ByteString as BS
+import Data.List (sort)
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import Database (buildDatabaseWithMatrices)
+import Matrix (computeInventoryMatrix)
+import SimaPro.Parser (parseSimaProCSV)
+import SimaPro.Writer (
+    checkSimaProExportable,
+    defaultWriterConfig,
+    escapeField,
+    formatAmount,
+    serializeSimaProCSV,
+ )
+import System.IO (hClose)
+import System.IO.Temp (withSystemTempFile)
+import Test.Hspec
+import Types
+import UnitConversion (defaultUnitConfig)
+
+-- ---------------------------------------------------------------------------
+-- Fixture: a small SimaPro CSV exercising every section the writer emits
+-- ---------------------------------------------------------------------------
+
+fixtureCSV :: BS.ByteString
+fixtureCSV =
+    BS.intercalate
+        "\r\n"
+        [ "{SimaPro 9.6.0.1}"
+        , "{CSV separator: Semicolon}"
+        , "{Decimal separator: .}"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , "Butter production"
+        , ""
+        , "Type"
+        , "Unit process"
+        , ""
+        , "Geography"
+        , "FR"
+        , ""
+        , "Products"
+        , "Butter;kg;1;100;not defined;material;"
+        , ""
+        , "Materials/fuels"
+        , -- name;unit;amount;Undefined;0;0;0;<pedigree>,<comment>
+          "Cow milk;kg;20.53;Undefined;0;0;0;(3,3,2,1,2),farm milk"
+        , ""
+        , "Resources"
+        , -- name;compartment;unit;amount;Undefined;;;;;;<comment>
+          "Water, river;in water;m3;0.1;Undefined;;;;;;river withdrawal"
+        , ""
+        , "Emissions to air"
+        , "Carbon dioxide, fossil;high. pop.;kg;0.5;Undefined;;;;;;(2,4,3,3,1),combustion"
+        , ""
+        , "Emissions to water"
+        , "Phosphate;river;kg;0.01;Undefined;;;;;;"
+        , ""
+        , "End"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , "Cow milk supply"
+        , ""
+        , "Type"
+        , "Unit process"
+        , ""
+        , "Geography"
+        , "FR"
+        , ""
+        , "Products"
+        , "Cow milk;kg;1;100;not defined;material;"
+        , ""
+        , "Emissions to air"
+        , "Methane, fossil;high. pop.;kg;0.02;Undefined;0;0;"
+        , ""
+        , "End"
+        ]
+
+-- | A single process with one reference product and one coproduct (in the
+-- @Avoided products@ section, which the parser reads back as a 'Coproduct').
+coproductCSV :: BS.ByteString
+coproductCSV =
+    BS.intercalate
+        "\r\n"
+        [ "{SimaPro 9.6.0.1}"
+        , "{CSV separator: Semicolon}"
+        , "{Decimal separator: .}"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , "Margarine production"
+        , ""
+        , "Type"
+        , "Unit process"
+        , ""
+        , "Geography"
+        , "FR"
+        , ""
+        , "Products"
+        , "Margarine;kg;1;100;not defined;material;"
+        , ""
+        , "Avoided products"
+        , "Butter;kg;0.3;100;not defined;material;"
+        , ""
+        , "End"
+        ]
+
+-- | A process with no @Type@ line, so the parser yields @activityNativeType = Nothing@.
+noTypeCSV :: BS.ByteString
+noTypeCSV =
+    BS.intercalate
+        "\r\n"
+        [ "{SimaPro 9.6.0.1}"
+        , "{CSV separator: Semicolon}"
+        , "{Decimal separator: .}"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , "Untyped process"
+        , ""
+        , "Geography"
+        , "FR"
+        , ""
+        , "Products"
+        , "Thing;kg;1;100;not defined;material;"
+        , ""
+        , "End"
+        ]
+
+-- | Parse a SimaPro CSV blob through a temp file.
+parseBytes :: BS.ByteString -> IO ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB)
+parseBytes bytes = withSystemTempFile "writer-spec.csv" $ \path h -> do
+    BS.hPut h bytes
+    hClose h
+    parseSimaProCSV defaultUnitConfig path
+
+-- | Wrap parser output in a 'SimpleDatabase' keyed by generated UUIDs.
+toSimple :: ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB) -> SimpleDatabase
+toSimple (acts, tech, bio, waste, units) =
+    SimpleDatabase
+        { sdbActivities = M.fromList [(activityKey a, a) | a <- acts]
+        , sdbTechFlows = tech
+        , sdbBioFlows = bio
+        , sdbWasteFlows = waste
+        , sdbUnits = units
+        }
+
+{- | Stable key for an activity: its reference product flow UUID paired with a
+synthetic activity UUID derived from name+location. The parser does not hand
+back the (UUID,UUID) keys directly, so we mint a deterministic pair from
+fields we control; this only needs to be injective across the fixture.
+-}
+activityKey :: Activity -> (UUID, UUID)
+activityKey a =
+    case [exchangeFlowId ex | ex <- exchanges a, exchangeIsReference ex] of
+        (prod : _) -> (prod, prod)
+        [] -> (UUID.nil, UUID.nil)
+
+-- Re-export of nil without importing the whole module qualifier dance.
+-- (Types re-exports UUID; nil lives in Data.UUID.)
+
+-- ---------------------------------------------------------------------------
+-- Structural comparison helpers (order-insensitive)
+-- ---------------------------------------------------------------------------
+
+-- | Normalised, order-insensitive view of an activity for structural equality.
+activityShape :: TechFlowDB -> BioFlowDB -> WasteFlowDB -> UnitDB -> Activity -> ActivityShape
+activityShape tech bio waste units a =
+    ActivityShape
+        { asName = activityName a
+        , asLocation = activityLocation a
+        , asUnit = activityUnit a
+        , asExchanges = sort (map (exchangeShape tech bio waste units) (exchanges a))
+        }
+
+data ActivityShape = ActivityShape
+    { asName :: Text
+    , asLocation :: Text
+    , asUnit :: Text
+    , asExchanges :: [ExchangeShape]
+    }
+    deriving (Eq, Ord, Show)
+
+-- | (kind, flow-name, unit-name, rounded-amount, is-input, is-reference,
+-- comment, pedigree). Comment and pedigree are carried so the semantic
+-- round-trip (property b) actually pins them — without them the per-exchange
+-- metadata could be silently dropped on parse-back and the test would not notice.
+data ExchangeShape = ExchangeShape
+    { esKind :: Text
+    , esFlow :: Text
+    , esUnit :: Text
+    , esAmount :: Double
+    , esInput :: Bool
+    , esRef :: Bool
+    , esComment :: Maybe Text
+    , esPedigree :: Maybe (Int, Int, Int, Int, Int)
+    }
+    deriving (Eq, Ord, Show)
+
+-- | Flatten a pedigree to a sortable quintuple so 'ExchangeShape' can derive 'Ord'.
+pedigreeTuple :: Pedigree -> (Int, Int, Int, Int, Int)
+pedigreeTuple Pedigree{..} =
+    (pedReliability, pedCompleteness, pedTemporal, pedGeographical, pedTechnological)
+
+exchangeShape :: TechFlowDB -> BioFlowDB -> WasteFlowDB -> UnitDB -> Exchange -> ExchangeShape
+exchangeShape tech bio waste units ex =
+    let unitNm uid = maybe "" unitName (M.lookup uid units)
+        roundAmt v = fromIntegral (round (v * 1e6) :: Integer) / 1e6 :: Double
+        meta kind flow uid amt =
+            ExchangeShape
+                kind
+                flow
+                (unitNm uid)
+                (roundAmt amt)
+                (exchangeIsInput ex)
+                (exchangeIsReference ex)
+                (exchangeComment ex)
+                (pedigreeTuple <$> exchangePedigree ex)
+     in case ex of
+            TechnosphereExchange{techFlowId = fid, techAmount = amt, techUnitId = uid} ->
+                meta "tech" (maybe "?" tfName (M.lookup fid tech)) uid amt
+            BiosphereExchange{bioFlowId = fid, bioAmount = amt, bioUnitId = uid} ->
+                meta "bio" (maybe "?" bfName (M.lookup fid bio)) uid amt
+            WasteExchange{waFlowId = fid, waAmount = amt, waUnitId = uid} ->
+                meta "waste" (maybe "?" wfName (M.lookup fid waste)) uid amt
+
+shapeSet :: ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB) -> S.Set ActivityShape
+shapeSet (acts, tech, bio, waste, units) =
+    S.fromList (map (activityShape tech bio waste units) acts)
+
+-- ---------------------------------------------------------------------------
+-- Inventory (score-equivalence) helper
+-- ---------------------------------------------------------------------------
+
+{- | Build a Database from parser output and compute the inventory of the
+activity whose name matches, keyed by biosphere flow NAME (UUIDs are stable
+across the round-trip, but keying by name is robust either way).
+-}
+inventoryByName :: ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB) -> Text -> IO (M.Map Text Double)
+inventoryByName (acts, tech, bio, waste, units) target = do
+    let actMap = M.fromList [(activityKey a, a) | a <- acts]
+    built <- buildDatabaseWithMatrices defaultUnitConfig actMap tech bio waste units
+    case built of
+        Left err -> expectationFailure (T.unpack err) >> pure M.empty
+        Right db -> do
+            let pidFor =
+                    [ pid
+                    | (pid, (actU, _)) <- zip [0 ..] (V.toList (dbProcessIdTable db))
+                    , Just act <- [activityAtUUID db actU]
+                    , activityName act == target
+                    ]
+            case pidFor of
+                (pid : _) -> do
+                    inv <- computeInventoryMatrix db pid
+                    pure (M.mapKeys (flowName db) inv)
+                [] -> expectationFailure ("no activity named " <> T.unpack target) >> pure M.empty
+
+flowName :: Database -> UUID -> Text
+flowName db uid = maybe (T.pack (show uid)) bfName (M.lookup uid (dbBioFlows db))
+
+activityAtUUID :: Database -> UUID -> Maybe Activity
+activityAtUUID db actU =
+    case [i | (i, (a, _)) <- zip [0 ..] (V.toList (dbProcessIdTable db)), a == actU] of
+        (i : _) -> Just (dbActivities db V.! i)
+        [] -> Nothing
+
+-- ---------------------------------------------------------------------------
+-- Spec
+-- ---------------------------------------------------------------------------
+
+spec :: Spec
+spec = describe "SimaPro.Writer round-trip" $ do
+    it "(pure) formatAmount round-trips integral and fractional values" $ do
+        formatAmount 100 `shouldBe` "100"
+        formatAmount 1 `shouldBe` "1"
+        formatAmount 0.5 `shouldBe` "0.5"
+        formatAmount 20.53 `shouldBe` "20.53"
+        formatAmount (-1.5) `shouldBe` "-1.5"
+
+    it "(pure) escapeField quotes only when needed" $ do
+        escapeField "Butter" `shouldBe` "Butter"
+        escapeField "a;b" `shouldBe` "\"a;b\""
+        escapeField "say \"hi\"" `shouldBe` "\"say \"\"hi\"\"\""
+
+    it "produces a parseable CSV with the pinned header" $ do
+        original <- parseBytes fixtureCSV
+        let bytes = serializeSimaProCSV defaultWriterConfig (toSimple original)
+        BS.take 16 bytes `shouldSatisfy` (\b -> "{SimaPro" `BS.isInfixOf` b)
+        reparsed <- parseBytes bytes
+        let (acts, _, _, _, _) = reparsed
+        length acts `shouldBe` 2
+
+    it "(a) is idempotent modulo the volatile version banner" $ do
+        original <- parseBytes fixtureCSV
+        let f0 = serializeSimaProCSV defaultWriterConfig (toSimple original)
+        d' <- parseBytes f0
+        let f1 = serializeSimaProCSV defaultWriterConfig (toSimple d')
+        f1 `shouldBe` f0
+
+    it "(b) semantic round-trip: parse(write(D)) is structurally equal to D" $ do
+        original <- parseBytes fixtureCSV
+        let f0 = serializeSimaProCSV defaultWriterConfig (toSimple original)
+        reparsed <- parseBytes f0
+        -- The shape now carries esComment/esPedigree, so the structural equality
+        -- below also pins per-exchange comment and pedigree across the round-trip.
+        shapeSet reparsed `shouldBe` shapeSet original
+        -- Guard against a vacuous pass (both sides dropping the metadata): the
+        -- fixture deliberately carries a pedigree quintuple and free-text
+        -- comments, so the original parse must actually surface them.
+        let origExchanges = concatMap exchanges (activitiesOf original)
+        map exchangeComment origExchanges `shouldSatisfy` elem (Just "farm milk")
+        map exchangePedigree origExchanges `shouldSatisfy` elem (Just (Pedigree 3 3 2 1 2))
+
+    it "(c) score-equivalence: same inventory for a sample activity within tolerance" $ do
+        original <- parseBytes fixtureCSV
+        let f0 = serializeSimaProCSV defaultWriterConfig (toSimple original)
+        reparsed <- parseBytes f0
+        invOrig <- inventoryByName original "Butter production"
+        invRound <- inventoryByName reparsed "Butter production"
+        M.keysSet invOrig `shouldBe` M.keysSet invRound
+        let diffs =
+                [ abs (a - b)
+                | (k, a) <- M.toList invOrig
+                , let b = M.findWithDefault 0 k invRound
+                ]
+        all (< 1e-9) diffs `shouldBe` True
+
+    it "(regression) routes coproducts to Avoided products, not Products" $ do
+        original <- parseBytes coproductCSV
+        let f0 = serializeSimaProCSV defaultWriterConfig (toSimple original)
+        reparsed <- parseBytes f0
+        let acts0 = activitiesOf original
+            acts1 = activitiesOf reparsed
+            roles = [techRole e | a <- acts1, e@TechnosphereExchange{} <- exchanges a]
+        -- A coproduct written to "Products" would re-parse into a second
+        -- reference-product activity; routing it to "Avoided products" keeps the
+        -- activity count stable and preserves the Coproduct role.
+        length acts1 `shouldBe` length acts0
+        (Coproduct `elem` roles) `shouldBe` True
+
+    it "(regression) omits the Type line for an activity with no native type" $ do
+        original <- parseBytes noTypeCSV
+        let f0 = serializeSimaProCSV defaultWriterConfig (toSimple original)
+        reparsed <- parseBytes f0
+        -- No Type line written → re-parse yields Nothing again, not the
+        -- invented "Unit process".
+        map activityNativeType (activitiesOf reparsed) `shouldBe` [Nothing]
+
+    describe "checkSimaProExportable (emission-medium guard)" $ do
+        it "accepts air / water / soil emissions" $
+            checkSimaProExportable (emissionDb (Compartment "air" Nothing))
+                `shouldBe` Right ()
+
+        it "rejects an emission whose medium has no faithful SimaPro section" $
+            -- A "raw" medium would otherwise be silently filed under
+            -- "Emissions to air" and re-parse as air; reject it loudly instead.
+            checkSimaProExportable (emissionDb (Compartment "raw" Nothing))
+                `shouldSatisfy` either (const True) (const False)
+  where
+    activitiesOf (acts, _, _, _, _) = acts
+
+-- ---------------------------------------------------------------------------
+-- Emission-medium guard fixture
+-- ---------------------------------------------------------------------------
+
+{- | One activity emitting a single biosphere flow whose compartment is @comp@.
+Used to exercise 'checkSimaProExportable': air/water/soil pass, anything else is
+rejected.
+-}
+emissionDb :: Compartment -> SimpleDatabase
+emissionDb comp =
+    SimpleDatabase
+        { sdbActivities = M.singleton (actU, prodU) act
+        , sdbTechFlows = M.singleton prodU (TechnosphereFlow prodU "thing" unitU M.empty Nothing Nothing)
+        , sdbBioFlows = M.singleton bioU (BiosphereFlow bioU "Some emission" unitU M.empty Nothing Nothing (Just comp))
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton unitU (Unit unitU "kg" "kg" "")
+        }
+  where
+    actU, prodU, bioU, unitU :: UUID
+    actU = read "aaaaaaaa-0000-4000-8000-000000000010"
+    prodU = read "aaaaaaaa-0000-4000-8000-0000000000a0"
+    bioU = read "cccccccc-0000-4000-8000-0000000000c0"
+    unitU = read "11111111-0000-4000-8000-000000000001"
+    act =
+        Activity
+            "thing maker"
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "kg"
+            [ TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , BiosphereExchange bioU 0.5 unitU Emission "" Nothing Nothing
+            ]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            Nothing

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -25,6 +25,7 @@ Three properties are pinned:
 module SimaProWriterSpec (spec) where
 
 import qualified Data.ByteString as BS
+import Data.Either (isLeft)
 import Data.List (sort)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
@@ -452,6 +453,19 @@ spec = describe "SimaPro.Writer round-trip" $ do
         it "accepts an ordinary activity name" $
             checkSimaProExportable (namedDb "Butter production")
                 `shouldBe` Right ()
+
+    describe "checkSimaProExportable (field-shape guards)" $ do
+        it "accepts a baseline single-reference activity" $
+            checkSimaProExportable (guardDb Nothing Nothing [refProd])
+                `shouldBe` Right ()
+
+        it "rejects a newline in the native-type (Type) label" $
+            -- The Type label is emitted as a bare metadata value line, so a
+            -- newline would split the Process block across physical rows on
+            -- re-import. Regression: the newline guard now covers the Type label
+            -- (it is derived from the same 'activityMetaLines' as the emitter).
+            checkSimaProExportable (guardDb Nothing (Just (SimaProProcessType "Unit\nprocess")) [refProd])
+                `shouldSatisfy` isLeft
   where
     activitiesOf (acts, _, _, _, _) = acts
 
@@ -620,3 +634,41 @@ namedDb name =
             Nothing
             Nothing
             Nothing
+
+-- ---------------------------------------------------------------------------
+-- Field-shape guard fixtures (shared by the field-shape guard specs)
+-- ---------------------------------------------------------------------------
+
+-- | Catalog UUIDs shared by every 'guardDb' fixture.
+gProd, gMat, gBio, gUnit :: UUID
+gProd = testUUID 0x50
+gMat = testUUID 0x51
+gBio = testUUID 0x52
+gUnit = testUUID 0x53
+
+-- | A valid reference product output for the catalog above.
+refProd :: Exchange
+refProd = TechnosphereExchange gProd 1.0 gUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+
+{- | A one-activity database whose exchanges are supplied verbatim, against a
+fixed catalog (a reference product flow, a material flow, an emission flow, and
+a kg unit). Lets the field-shape guard specs vary allocation, native type, and
+the exchange list while keeping every flow/unit resolvable.
+-}
+guardDb :: Maybe Double -> Maybe NativeActivityType -> [Exchange] -> SimpleDatabase
+guardDb alloc ntype exs =
+    SimpleDatabase
+        { sdbActivities = M.singleton (testUUID 0x5f, gProd) act
+        , sdbTechFlows =
+            M.fromList
+                [ (gProd, TechnosphereFlow gProd "main product" gUnit M.empty Nothing Nothing)
+                , (gMat, TechnosphereFlow gMat "some material" gUnit M.empty Nothing Nothing)
+                ]
+        , sdbBioFlows =
+            M.singleton gBio (BiosphereFlow gBio "an emission" gUnit M.empty Nothing Nothing (Just (Compartment "air" Nothing)))
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton gUnit (Unit gUnit "kg" "kg" "")
+        }
+  where
+    act =
+        Activity "guard maker" [] M.empty M.empty "GLO" "kg" exs M.empty M.empty alloc Nothing ntype

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -178,6 +178,36 @@ noTypeCSV =
         , "End"
         ]
 
+-- | A process with a @Final waste flows@ section, exercising the waste path.
+wasteCSV :: BS.ByteString
+wasteCSV =
+    BS.intercalate
+        "\r\n"
+        [ "{SimaPro 9.6.0.1}"
+        , "{CSV separator: Semicolon}"
+        , "{Decimal separator: .}"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , "Landfill process"
+        , ""
+        , "Geography"
+        , "FR"
+        , ""
+        , "Products"
+        , "Treated waste;kg;1;100;not defined;material;"
+        , ""
+        , "Final waste flows"
+        , -- name;compartment;unit;amount;Undefined;;;;;;<comment>
+          "Municipal solid waste;;kg;0.5;Undefined;;;;;;to landfill"
+        , ""
+        , "End"
+        ]
+
 -- | Parse a SimaPro CSV blob through a temp file.
 parseBytes :: BS.ByteString -> IO ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB)
 parseBytes bytes = withSystemTempFile "writer-spec.csv" $ \path h -> do
@@ -418,6 +448,16 @@ spec = describe "SimaPro.Writer round-trip" $ do
                 activityAllocationPercent a `shouldBe` Just 50
             other -> expectationFailure ("expected one activity, got " <> show (length other))
 
+    it "(regression) round-trips a Final waste flows section" $ do
+        original <- parseBytes wasteCSV
+        f0 <- serBytes (toSimple original)
+        reparsed <- parseBytes f0
+        shapeSet reparsed `shouldBe` shapeSet original
+        -- Guard against a vacuous pass: the original must actually carry a waste
+        -- exchange, so the structural equality above is pinning something.
+        let kinds = [esKind ex | ash <- S.toList (shapeSet original), ex <- asExchanges ash]
+        kinds `shouldSatisfy` elem "waste"
+
     describe "checkSimaProExportable (emission-medium guard)" $ do
         it "accepts air / water / soil emissions" $
             checkSimaProExportable (emissionDb (Compartment "air" Nothing))
@@ -475,6 +515,23 @@ spec = describe "SimaPro.Writer round-trip" $ do
         it "rejects an activity with more than one reference product" $
             -- Two Products rows re-parse into two separate activities.
             checkSimaProExportable (guardDb Nothing Nothing [refProd, refProd2])
+                `shouldSatisfy` isLeft
+
+        it "rejects a non-finite exchange amount" $
+            -- NaN/±Infinity has no parseable literal; 'formatAmount' would flatten
+            -- it to a number and silently mis-state the inventory.
+            checkSimaProExportable (guardDb Nothing Nothing [refProd, bioInf])
+                `shouldSatisfy` isLeft
+
+        it "rejects a zero allocation percentage" $
+            -- The writer divides shared amounts by allocFraction; a 0 would make
+            -- that division non-finite and lose the amounts on re-import.
+            checkSimaProExportable (guardDb (Just 0) Nothing [refProd])
+                `shouldSatisfy` isLeft
+
+        it "rejects an exchange whose unit is absent from the registry" $
+            -- A missing unit would be written blank and re-parsed as UNKNOWN.
+            checkSimaProExportable (guardDb Nothing Nothing [refProd, matMissingUnit])
                 `shouldSatisfy` isLeft
   where
     activitiesOf (acts, _, _, _, _) = acts
@@ -667,6 +724,14 @@ refProd2 = TechnosphereExchange gMat 1.0 gUnit ReferenceProduct UUID.nil Nothing
 -- | A plain material input (no reference product in the activity).
 matInput :: Exchange
 matInput = TechnosphereExchange gMat 2.0 gUnit Input UUID.nil Nothing "" Nothing Nothing
+
+-- | An emission carrying a non-finite (+Infinity) amount.
+bioInf :: Exchange
+bioInf = BiosphereExchange gBio (1 / 0) gUnit Emission "" Nothing Nothing
+
+-- | A material input referencing a unit UUID absent from the unit registry.
+matMissingUnit :: Exchange
+matMissingUnit = TechnosphereExchange gMat 2.0 (testUUID 0xbad) Input UUID.nil Nothing "" Nothing Nothing
 
 {- | A one-activity database whose exchanges are supplied verbatim, against a
 fixed catalog (a reference product flow, a material flow, an emission flow, and

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -116,8 +116,9 @@ fixtureCSV =
         , "End"
         ]
 
--- | A single process with one reference product and one coproduct (in the
--- @Avoided products@ section, which the parser reads back as a 'Coproduct').
+{- | A single process with one reference product and one coproduct (in the
+@Avoided products@ section, which the parser reads back as a 'Coproduct').
+-}
 coproductCSV :: BS.ByteString
 coproductCSV =
     BS.intercalate
@@ -229,10 +230,11 @@ data ActivityShape = ActivityShape
     }
     deriving (Eq, Ord, Show)
 
--- | (kind, flow-name, unit-name, rounded-amount, is-input, is-reference,
--- comment, pedigree). Comment and pedigree are carried so the semantic
--- round-trip (property b) actually pins them — without them the per-exchange
--- metadata could be silently dropped on parse-back and the test would not notice.
+{- | (kind, flow-name, unit-name, rounded-amount, is-input, is-reference,
+comment, pedigree). Comment and pedigree are carried so the semantic
+round-trip (property b) actually pins them — without them the per-exchange
+metadata could be silently dropped on parse-back and the test would not notice.
+-}
 data ExchangeShape = ExchangeShape
     { esKind :: Text
     , esFlow :: Text
@@ -316,6 +318,12 @@ activityAtUUID db actU =
 -- Spec
 -- ---------------------------------------------------------------------------
 
+-- | Serialize through the guard-returning writer, failing the test on a 'Left'.
+serBytes :: SimpleDatabase -> IO BS.ByteString
+serBytes db =
+    either (\e -> expectationFailure (T.unpack e) >> pure BS.empty) pure $
+        serializeSimaProCSV defaultWriterConfig db
+
 spec :: Spec
 spec = describe "SimaPro.Writer round-trip" $ do
     it "(pure) formatAmount round-trips integral and fractional values" $ do
@@ -332,7 +340,7 @@ spec = describe "SimaPro.Writer round-trip" $ do
 
     it "produces a parseable CSV with the pinned header" $ do
         original <- parseBytes fixtureCSV
-        let bytes = serializeSimaProCSV defaultWriterConfig (toSimple original)
+        bytes <- serBytes (toSimple original)
         BS.take 16 bytes `shouldSatisfy` (\b -> "{SimaPro" `BS.isInfixOf` b)
         reparsed <- parseBytes bytes
         let (acts, _, _, _, _) = reparsed
@@ -340,14 +348,14 @@ spec = describe "SimaPro.Writer round-trip" $ do
 
     it "(a) is idempotent modulo the volatile version banner" $ do
         original <- parseBytes fixtureCSV
-        let f0 = serializeSimaProCSV defaultWriterConfig (toSimple original)
+        f0 <- serBytes (toSimple original)
         d' <- parseBytes f0
-        let f1 = serializeSimaProCSV defaultWriterConfig (toSimple d')
+        f1 <- serBytes (toSimple d')
         f1 `shouldBe` f0
 
     it "(b) semantic round-trip: parse(write(D)) is structurally equal to D" $ do
         original <- parseBytes fixtureCSV
-        let f0 = serializeSimaProCSV defaultWriterConfig (toSimple original)
+        f0 <- serBytes (toSimple original)
         reparsed <- parseBytes f0
         -- The shape now carries esComment/esPedigree, so the structural equality
         -- below also pins per-exchange comment and pedigree across the round-trip.
@@ -361,7 +369,7 @@ spec = describe "SimaPro.Writer round-trip" $ do
 
     it "(c) score-equivalence: same inventory for a sample activity within tolerance" $ do
         original <- parseBytes fixtureCSV
-        let f0 = serializeSimaProCSV defaultWriterConfig (toSimple original)
+        f0 <- serBytes (toSimple original)
         reparsed <- parseBytes f0
         invOrig <- inventoryByName original "Butter production"
         invRound <- inventoryByName reparsed "Butter production"
@@ -375,7 +383,7 @@ spec = describe "SimaPro.Writer round-trip" $ do
 
     it "(regression) routes coproducts to Avoided products, not Products" $ do
         original <- parseBytes coproductCSV
-        let f0 = serializeSimaProCSV defaultWriterConfig (toSimple original)
+        f0 <- serBytes (toSimple original)
         reparsed <- parseBytes f0
         let acts0 = activitiesOf original
             acts1 = activitiesOf reparsed
@@ -388,11 +396,25 @@ spec = describe "SimaPro.Writer round-trip" $ do
 
     it "(regression) omits the Type line for an activity with no native type" $ do
         original <- parseBytes noTypeCSV
-        let f0 = serializeSimaProCSV defaultWriterConfig (toSimple original)
+        f0 <- serBytes (toSimple original)
         reparsed <- parseBytes f0
         -- No Type line written → re-parse yields Nothing again, not the
         -- invented "Unit process".
         map activityNativeType (activitiesOf reparsed) `shouldBe` [Nothing]
+
+    it "(regression) allocation ≠ 100% round-trips without double-scaling inputs" $ do
+        -- The in-memory amounts are already allocation-scaled (the parser scales
+        -- shared exchanges by allocFraction on import). A 50%-allocated activity
+        -- stores its 20 kg input as 10 kg; the writer must emit 20 kg again so the
+        -- re-import lands back on 10 kg, not 5 kg (the double-allocation bug).
+        bytes <- serBytes allocationDb
+        (acts, _, _, _, _) <- parseBytes bytes
+        case acts of
+            [a] -> do
+                [techAmount e | e@TechnosphereExchange{techRole = Input} <- exchanges a]
+                    `shouldBe` [10.0]
+                activityAllocationPercent a `shouldBe` Just 50
+            other -> expectationFailure ("expected one activity, got " <> show (length other))
 
     describe "checkSimaProExportable (emission-medium guard)" $ do
         it "accepts air / water / soil emissions" $
@@ -444,5 +466,50 @@ emissionDb comp =
             M.empty
             M.empty
             Nothing
+            Nothing
+            Nothing
+
+-- ---------------------------------------------------------------------------
+-- Allocation round-trip fixture
+-- ---------------------------------------------------------------------------
+
+{- | One 50%-allocated activity: a reference product (never scaled) and a
+material input stored at its allocation-scaled amount (10 kg = 20 kg × 0.5).
+A correct writer emits the 20 kg pre-allocation amount so the parser's re-scale
+returns 10 kg.
+-}
+allocationDb :: SimpleDatabase
+allocationDb =
+    SimpleDatabase
+        { sdbActivities = M.singleton (actU, prodU) act
+        , sdbTechFlows =
+            M.fromList
+                [ (prodU, TechnosphereFlow prodU "main product" unitU M.empty Nothing Nothing)
+                , (matU, TechnosphereFlow matU "some material" unitU M.empty Nothing Nothing)
+                ]
+        , sdbBioFlows = M.empty
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton unitU (Unit unitU "kg" "kg" "")
+        }
+  where
+    actU, prodU, matU, unitU :: UUID
+    actU = read "aaaaaaaa-0000-4000-8000-000000000020"
+    prodU = read "aaaaaaaa-0000-4000-8000-0000000000b0"
+    matU = read "aaaaaaaa-0000-4000-8000-0000000000b1"
+    unitU = read "11111111-0000-4000-8000-000000000002"
+    act =
+        Activity
+            "alloc maker"
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "kg"
+            [ TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , TechnosphereExchange matU 10.0 unitU Input UUID.nil Nothing "" Nothing Nothing
+            ]
+            M.empty
+            M.empty
+            (Just 50)
             Nothing
             Nothing

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -32,6 +32,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
+import Data.Word (Word32)
 import Database (buildDatabaseWithMatrices)
 import Matrix (computeInventoryMatrix)
 import SimaPro.Parser (parseSimaProCSV)
@@ -426,12 +427,43 @@ spec = describe "SimaPro.Writer round-trip" $ do
             -- "Emissions to air" and re-parse as air; reject it loudly instead.
             checkSimaProExportable (emissionDb (Compartment "raw" Nothing))
                 `shouldSatisfy` either (const True) (const False)
+
+    describe "checkSimaProExportable (round-trip guards)" $ do
+        it "accepts a pedigree-less exchange with an ordinary comment" $
+            checkSimaProExportable (commentDb Nothing (Just "ordinary free text"))
+                `shouldBe` Right ()
+
+        it "rejects a pedigree-less comment that begins with a pedigree quintuple" $
+            -- Written verbatim, "(3,3,2,1,2),free text" would re-parse as a
+            -- fabricated Pedigree with a truncated comment; reject it loudly.
+            checkSimaProExportable (commentDb Nothing (Just "(3,3,2,1,2),free text"))
+                `shouldSatisfy` either (const True) (const False)
+
+        it "still accepts a genuine pedigree (it is emitted as its own prefix)" $
+            checkSimaProExportable (commentDb (Just (Pedigree 3 3 2 1 2)) (Just "free text"))
+                `shouldBe` Right ()
+
+        it "rejects an activity name that collides with a SimaPro metadata key" $
+            -- An activity named "Comment" would be read back as a new metadata
+            -- field, silently dropping the name; reject it at the boundary.
+            checkSimaProExportable (namedDb "Comment")
+                `shouldSatisfy` either (const True) (const False)
+
+        it "accepts an ordinary activity name" $
+            checkSimaProExportable (namedDb "Butter production")
+                `shouldBe` Right ()
   where
     activitiesOf (acts, _, _, _, _) = acts
 
 -- ---------------------------------------------------------------------------
 -- Emission-medium guard fixture
 -- ---------------------------------------------------------------------------
+
+{- | A distinct, valid UUID for a fixture, built totally from a tag — no partial
+'read' that would crash the suite on a typo.
+-}
+testUUID :: Word32 -> UUID
+testUUID n = UUID.fromWords n 0x4000 0x8000 1
 
 {- | One activity emitting a single biosphere flow whose compartment is @comp@.
 Used to exercise 'checkSimaProExportable': air/water/soil pass, anything else is
@@ -448,10 +480,10 @@ emissionDb comp =
         }
   where
     actU, prodU, bioU, unitU :: UUID
-    actU = read "aaaaaaaa-0000-4000-8000-000000000010"
-    prodU = read "aaaaaaaa-0000-4000-8000-0000000000a0"
-    bioU = read "cccccccc-0000-4000-8000-0000000000c0"
-    unitU = read "11111111-0000-4000-8000-000000000001"
+    actU = testUUID 0x10
+    prodU = testUUID 0xa0
+    bioU = testUUID 0xc0
+    unitU = testUUID 0x01
     act =
         Activity
             "thing maker"
@@ -493,10 +525,10 @@ allocationDb =
         }
   where
     actU, prodU, matU, unitU :: UUID
-    actU = read "aaaaaaaa-0000-4000-8000-000000000020"
-    prodU = read "aaaaaaaa-0000-4000-8000-0000000000b0"
-    matU = read "aaaaaaaa-0000-4000-8000-0000000000b1"
-    unitU = read "11111111-0000-4000-8000-000000000002"
+    actU = testUUID 0x20
+    prodU = testUUID 0xb0
+    matU = testUUID 0xb1
+    unitU = testUUID 0x02
     act =
         Activity
             "alloc maker"
@@ -511,5 +543,80 @@ allocationDb =
             M.empty
             M.empty
             (Just 50)
+            Nothing
+            Nothing
+
+-- ---------------------------------------------------------------------------
+-- Round-trip guard fixtures (comment-as-pedigree, metadata-key collision)
+-- ---------------------------------------------------------------------------
+
+{- | One activity with a reference product and a single technosphere input
+carrying the given pedigree/comment. Exercises the comment-as-pedigree guard.
+-}
+commentDb :: Maybe Pedigree -> Maybe Text -> SimpleDatabase
+commentDb ped cmt =
+    SimpleDatabase
+        { sdbActivities = M.singleton (actU, prodU) act
+        , sdbTechFlows =
+            M.fromList
+                [ (prodU, TechnosphereFlow prodU "main product" unitU M.empty Nothing Nothing)
+                , (matU, TechnosphereFlow matU "some material" unitU M.empty Nothing Nothing)
+                ]
+        , sdbBioFlows = M.empty
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton unitU (Unit unitU "kg" "kg" "")
+        }
+  where
+    actU, prodU, matU, unitU :: UUID
+    actU = testUUID 0x30
+    prodU = testUUID 0xd0
+    matU = testUUID 0xd1
+    unitU = testUUID 0x03
+    act =
+        Activity
+            "comment maker"
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "kg"
+            [ TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , TechnosphereExchange matU 2.0 unitU Input UUID.nil Nothing "" cmt ped
+            ]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            Nothing
+
+{- | One activity with the given name and a single reference product. Exercises
+the metadata-key collision guard: a name equal to a SimaPro key is rejected.
+-}
+namedDb :: Text -> SimpleDatabase
+namedDb name =
+    SimpleDatabase
+        { sdbActivities = M.singleton (actU, prodU) act
+        , sdbTechFlows = M.singleton prodU (TechnosphereFlow prodU "main product" unitU M.empty Nothing Nothing)
+        , sdbBioFlows = M.empty
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton unitU (Unit unitU "kg" "kg" "")
+        }
+  where
+    actU, prodU, unitU :: UUID
+    actU = testUUID 0x40
+    prodU = testUUID 0xe0
+    unitU = testUUID 0x04
+    act =
+        Activity
+            name
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "kg"
+            [TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing]
+            M.empty
+            M.empty
+            Nothing
             Nothing
             Nothing

--- a/volca.cabal
+++ b/volca.cabal
@@ -85,6 +85,7 @@ library
                      , EcoSpold.Parser2
                      , EcoSpold.Parser1
                      , SimaPro.Parser
+                     , SimaPro.Writer
                      , BrightwayExcel.Parser
                      , Expr
                      , ILCD.Parser
@@ -243,6 +244,7 @@ test-suite lca-tests
                      , ProgressSpec
                      , EcoSpold1Spec
                      , EcoSpold2Spec
+                     , SimaProWriterSpec
                      , MCPSchemaSpec
                      , BatchImpactsSpec
                      , MCPEnrichSpec


### PR DESCRIPTION
## What
Serialize an in-memory database to a SimaPro CSV. An emission whose medium has no faithful air/water/soil section fails loudly rather than being silently refiled as air. The writer is the deterministic inverse of its parser, pinned by a three-way round-trip spec: byte-identical modulo volatile metadata, order-insensitive parse∘write, and unchanged LCIA scores across the round-trip.

Part of the #113 split into focused, independently-reviewable PRs. Stacked on `feat/db-relink` — **merge bottom-up**; #114 (delete) is the base of the stack. Full stack: `cabal test lca-tests` → 1255 examples, 0 failures.