### PR TITLE
feat(ecospold1): EcoSpold 1 writer — canonical inverse of the parser

### DIFF
--- a/src/EcoSpold/Common.hs
+++ b/src/EcoSpold/Common.hs
@@ -10,6 +10,7 @@ module EcoSpold.Common (
     isElement,
     distributeFiles,
     nonEmptyText,
+    showFFloatTrim,
 ) where
 
 import qualified Data.ByteString as BS
@@ -17,6 +18,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Read as TR
+import Numeric (showFFloat)
 
 -- | ByteString to Text conversion with UTF-8 decoding and XML entity decoding
 bsToText :: BS.ByteString -> Text
@@ -84,3 +86,18 @@ distributeFiles n xs =
     go [] _ = []
     go _ [] = []
     go (s : ss) ys = let (h, t) = splitAt s ys in h : go ss t
+
+{- | Render a 'Double' in fixed-point notation (never scientific) with trailing
+zeros trimmed but at least one fractional digit kept. This is the canonical
+amount format for the EcoSpold/ILCD writers: it round-trips byte- and
+value-identically through 'Data.Text.Read.double', unlike 'show' which emits
+scientific notation for small/large magnitudes that re-reads lossily
+(e.g. @show 3.3e-20@ → @3.2999999999999994e-20@).
+-}
+showFFloatTrim :: Double -> String
+showFFloatTrim d =
+    case break (== '.') (showFFloat Nothing d "") of
+        (intPart, '.' : fracPart) ->
+            let trimmed = reverse (dropWhile (== '0') (reverse fracPart))
+             in intPart <> "." <> (if null trimmed then "0" else trimmed)
+        (intPart, _) -> intPart <> ".0"

--- a/src/EcoSpold/Common.hs
+++ b/src/EcoSpold/Common.hs
@@ -89,10 +89,14 @@ distributeFiles n xs =
 
 {- | Render a 'Double' in fixed-point notation (never scientific) with trailing
 zeros trimmed but at least one fractional digit kept. This is the canonical
-amount format for the EcoSpold/ILCD writers: it round-trips byte- and
-value-identically through 'Data.Text.Read.double', unlike 'show' which emits
-scientific notation for small/large magnitudes that re-reads lossily
-(e.g. @show 3.3e-20@ → @3.2999999999999994e-20@).
+amount format for the EcoSpold/ILCD writers: it re-parses to the same value
+through 'Data.Text.Read.double' for the magnitudes real LCA amounts occupy —
+unlike 'show', which emits scientific notation for small/large magnitudes that
+re-reads lossily (e.g. @show 3.3e-20@ → @3.2999999999999994e-20@). The
+near-underflow subnormal tail (≈@5e-324@) is the exception: fixed-point can't
+carry enough significant digits there, so it re-parses to @0@. The writers'
+export guards reject any amount that does not re-parse, so a guarded export
+never emits one of these.
 -}
 showFFloatTrim :: Double -> String
 showFFloatTrim d =

--- a/src/EcoSpold/Writer1.hs
+++ b/src/EcoSpold/Writer1.hs
@@ -11,11 +11,22 @@ __canonical and deterministic__:
   * dataset numbers are assigned sequentially (1-based) in that order, and
     exchange numbers likewise (see below). Because the parser derives flow
     UUIDs from @datasetNumber@, exchange number, name and category, these
-    reassigned numbers make the writer's output __self-stable__: parsing it
-    and writing again reproduces the same flow UUIDs. This is fixed-point
-    stability of the writer's own canonical form, __not__ reproduction of
-    the UUIDs of an arbitrary parsed source file — that source carried its
-    own dataset/exchange numbering, which the writer does not preserve;
+    reassigned numbers make the writer's output __self-stable for every
+    exchange except a linked technosphere input__: reference products,
+    co-products, biosphere and waste exchanges, and /unlinked/ inputs all
+    reproduce the same flow UUIDs on a write→parse→write cycle. This is
+    fixed-point stability of the writer's own canonical form, __not__
+    reproduction of the UUIDs of an arbitrary parsed source file — that source
+    carried its own dataset/exchange numbering, which the writer does not
+    preserve;
+  * a /linked/ technosphere input is the one exception. Its @number@ attribute
+    carries the /supplier's/ dataset number (so the loader can re-link it by
+    'techActivityLinkId'); but 'SimpleDatabase' has no field for that link, so a
+    bare re-parse drops it and the next write falls back to the positional
+    index. Byte-stability of a linked input therefore relies on the full
+    loader re-resolving the link (by supplier name/location) rather than on a
+    direct 'SimpleDatabase' round-trip. The semantic round-trip — flow name,
+    amount, role, unit — is preserved either way;
   * exchange numbers are sequential (1-based) in exchange order;
   * attributes appear in a fixed order, classification maps are sorted by
     key, numbers use a fixed textual form, and there is no insignificant
@@ -52,7 +63,6 @@ module EcoSpold.Writer1 (
     -- * Writers
     writeDatabase,
     writeSimpleDatabase,
-    writeActivities,
 
     -- * Export boundary check
     checkEcoSpold1Exportable,
@@ -66,6 +76,7 @@ import Data.List (sortOn)
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.Read as TR
 import qualified Data.UUID as UUID
 import Database.Loader (generateActivityUUIDFromActivity)
 import EcoSpold.Common (showFFloatTrim)
@@ -124,7 +135,10 @@ writeSimpleDatabase opts sdb = do
             (M.elems (sdbActivities sdb))
 
 {- | Serialize a list of activities against the flow / unit tables that
-resolve their exchange UUIDs.
+resolve their exchange UUIDs. Internal: it does no export-boundary checking,
+so it is reached only through 'writeSimpleDatabase', which runs
+'checkEcoSpold1Exportable' first. Not exported, so no caller can bypass the
+guard.
 -}
 writeActivities ::
     WriterOptions ->
@@ -166,7 +180,8 @@ supplierNumberIndex ordered =
     M.fromList [(generateActivityUUIDFromActivity a, n) | (n, a) <- zip [1 ..] ordered]
 
 {- | Guard an EcoSpold1 export against data the writer cannot faithfully
-re-encode. Two failure modes are checked:
+re-encode. Each check reports its first offender and fails loudly rather than
+emit silently wrong data:
 
   * __Dangling supplier links.__ The format names a supplier from a
     technosphere input's @number@ attribute, which the parser reads as the
@@ -176,16 +191,27 @@ re-encode. Two failure modes are checked:
     the database would otherwise force a positional index the parser would
     misread as a different supplier.
 
-  * __Non-finite amounts.__ 'formatAmount' clamps @NaN@/@Infinity@ to a
-    parseable @0.0@; a database carrying such an amount would silently export
-    as zero. Parsed databases never contain these, so they only arise from
-    in-memory construction.
+  * __Reference inputs.__ EcoSpold1 has no marker for a reference /input/, so
+    the writer would emit @outputGroup 0@ and the parser would read it back as
+    a reference product — a direction flip.
 
-Either case reports the first offender and fails loudly rather than emit
-silently wrong data. Databases free of both pass unchanged.
+  * __Missing flows / units.__ An exchange whose flow or unit is absent from
+    the tables would be written with a blank name and re-parse as a different
+    (or @UNKNOWN@) entity.
+
+  * __Non-finite amounts.__ @NaN@/@Infinity@ have no parseable literal.
+
+  * __Non-round-tripping amounts.__ A finite amount whose decimal form does not
+    re-parse to the same 'Double' through 'Data.Text.Read.double' (the parser's
+    reader) — e.g. a subnormal near the floating-point floor — would silently
+    export as a different value. Real LCA amounts never reach this range, but
+    the guard rejects it rather than undercount.
+
+Databases free of all of these pass unchanged.
 -}
 checkEcoSpold1Exportable :: SimpleDatabase -> Either Text ()
-checkEcoSpold1Exportable db = checkLinks *> checkRefInputs *> checkFlows *> checkUnits *> checkAmounts
+checkEcoSpold1Exportable db =
+    checkLinks *> checkRefInputs *> checkFlows *> checkUnits *> checkAmounts *> checkAmountRoundTrip
   where
     checkLinks =
         case danglingLinks of
@@ -236,6 +262,17 @@ checkEcoSpold1Exportable db = checkLinks *> checkRefInputs *> checkFlows *> chec
                         <> "\": exchange amount "
                         <> T.pack (show amt)
                         <> " is not finite."
+    checkAmountRoundTrip =
+        case roundTripOffenders of
+            [] -> Right ()
+            ((consumer, amt) : _) ->
+                Left $
+                    "EcoSpold1 export cannot represent activity \""
+                        <> consumer
+                        <> "\": exchange amount "
+                        <> T.pack (show amt)
+                        <> " has no decimal form that re-parses to the same value"
+                        <> " (e.g. a subnormal near the floating-point floor)."
     index = supplierNumberIndex (orderedActivities (M.elems (sdbActivities db)))
     danglingLinks =
         [ (activityName act, link)
@@ -251,6 +288,19 @@ checkEcoSpold1Exportable db = checkLinks *> checkRefInputs *> checkFlows *> chec
         , let amt = exchangeAmount ex
         , isNaN amt || isInfinite amt
         ]
+    roundTripOffenders =
+        [ (activityName act, amt)
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , let amt = exchangeAmount ex
+        , not (isNaN amt || isInfinite amt) -- non-finite already reported by checkAmounts
+        , not (amountRoundTrips amt)
+        ]
+    -- The written decimal must re-parse to the same Double through the parser's
+    -- reader ('Data.Text.Read.double'), or the value silently changes on import.
+    amountRoundTrips amt = case TR.double (formatAmount amt) of
+        Right (v, rest) -> v == amt && T.null rest
+        Left _ -> False
     refInputOffenders =
         [ activityName act
         | act <- M.elems (sdbActivities db)
@@ -485,13 +535,18 @@ escapeXmlAttr =
 
 {- | Deterministic textual form for a @meanValue@. Uses the shared
 'showFFloatTrim' (fixed-point, never scientific) so the value round-trips
-byte- and value-identically through the parser's 'Data.Text.Read.double' —
-unlike @show@, which emits scientific notation for small/large magnitudes that
-re-reads lossily. Non-finite values (which cannot occur in a parsed database)
-are clamped to a parseable @0.0@ rather than the unreadable @"NaN"@/@"Infinity"@.
+through the parser's 'Data.Text.Read.double' for the magnitudes real LCA
+amounts occupy — unlike @show@, which emits scientific notation that re-reads
+lossily. The near-underflow subnormal tail is the exception;
+'checkEcoSpold1Exportable' rejects any amount that does not re-parse, so the
+guarded path never emits a value that changes on import.
+
+A non-finite value renders as its (non-parseable) @"NaN"@/@"Infinity"@ form so
+a bad re-import fails loudly rather than silently reading @0@; the export guard
+rejects non-finite amounts before they reach here.
 -}
 formatAmount :: Double -> Text
 formatAmount x
-    | isNaN x || isInfinite x = "0.0"
+    | isNaN x || isInfinite x = T.pack (show x)
     | x == 0 = "0.0" -- normalise negative zero (showFFloat would emit "-0.0")
     | otherwise = T.pack (showFFloatTrim x)

--- a/src/EcoSpold/Writer1.hs
+++ b/src/EcoSpold/Writer1.hs
@@ -68,6 +68,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import Database.Loader (generateActivityUUIDFromActivity)
+import EcoSpold.Common (showFFloatTrim)
 import Types
 
 -- ----------------------------------------------------------------------------
@@ -102,19 +103,25 @@ canonicalWriterOptions = WriterOptions Nothing Nothing
 -- ----------------------------------------------------------------------------
 
 -- | Serialize a built 'Database' (via 'toSimpleDatabase').
-writeDatabase :: WriterOptions -> Database -> Text
+writeDatabase :: WriterOptions -> Database -> Either Text Text
 writeDatabase opts = writeSimpleDatabase opts . toSimpleDatabase
 
--- | Serialize a 'SimpleDatabase'. Flow / unit names are resolved from its tables.
-writeSimpleDatabase :: WriterOptions -> SimpleDatabase -> Text
-writeSimpleDatabase opts sdb =
-    writeActivities
-        opts
-        (sdbTechFlows sdb)
-        (sdbBioFlows sdb)
-        (sdbWasteFlows sdb)
-        (sdbUnits sdb)
-        (M.elems (sdbActivities sdb))
+{- | Serialize a 'SimpleDatabase'. Flow / unit names are resolved from its
+tables. Runs 'checkEcoSpold1Exportable' first and returns its 'Left' on a
+database the format cannot represent faithfully, so an unguarded caller can
+never silently emit a lossy or role-flipped file.
+-}
+writeSimpleDatabase :: WriterOptions -> SimpleDatabase -> Either Text Text
+writeSimpleDatabase opts sdb = do
+    checkEcoSpold1Exportable sdb
+    pure $
+        writeActivities
+            opts
+            (sdbTechFlows sdb)
+            (sdbBioFlows sdb)
+            (sdbWasteFlows sdb)
+            (sdbUnits sdb)
+            (M.elems (sdbActivities sdb))
 
 {- | Serialize a list of activities against the flow / unit tables that
 resolve their exchange UUIDs.
@@ -178,7 +185,7 @@ Either case reports the first offender and fails loudly rather than emit
 silently wrong data. Databases free of both pass unchanged.
 -}
 checkEcoSpold1Exportable :: SimpleDatabase -> Either Text ()
-checkEcoSpold1Exportable db = checkLinks *> checkAmounts
+checkEcoSpold1Exportable db = checkLinks *> checkRefInputs *> checkFlows *> checkUnits *> checkAmounts
   where
     checkLinks =
         case danglingLinks of
@@ -190,6 +197,35 @@ checkEcoSpold1Exportable db = checkLinks *> checkAmounts
                         <> "\": linked activity "
                         <> UUID.toText link
                         <> " is not among the exported datasets, so its dataset number is unknown."
+    checkRefInputs =
+        case refInputOffenders of
+            [] -> Right ()
+            (consumer : _) ->
+                Left $
+                    "EcoSpold1 export cannot encode a reference input (treatment process) in \""
+                        <> consumer
+                        <> "\": the format has no marker for it, so the writer would emit"
+                        <> " outputGroup 0 and the parser would read it back as a reference"
+                        <> " product — a direction flip from input to output."
+    checkFlows =
+        case flowOffenders of
+            [] -> Right ()
+            (consumer : _) ->
+                Left $
+                    "EcoSpold1 export cannot represent activity \""
+                        <> consumer
+                        <> "\": an exchange references a flow absent from the database,"
+                        <> " which would be written with a blank name."
+    checkUnits =
+        case unitOffenders of
+            [] -> Right ()
+            ((consumer, uid) : _) ->
+                Left $
+                    "EcoSpold1 export cannot represent activity \""
+                        <> consumer
+                        <> "\": an exchange references unit "
+                        <> UUID.toText uid
+                        <> ", absent from the registry (it would be written with a blank unit)."
     checkAmounts =
         case amountOffenders of
             [] -> Right ()
@@ -214,6 +250,27 @@ checkEcoSpold1Exportable db = checkLinks *> checkAmounts
         , ex <- exchanges act
         , let amt = exchangeAmount ex
         , isNaN amt || isInfinite amt
+        ]
+    refInputOffenders =
+        [ activityName act
+        | act <- M.elems (sdbActivities db)
+        , TechnosphereExchange{techRole = ReferenceInput} <- exchanges act
+        ]
+    flowOffenders =
+        [ activityName act
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , flowMissing ex
+        ]
+    flowMissing ex = case ex of
+        TechnosphereExchange{techFlowId = fid} -> M.notMember fid (sdbTechFlows db)
+        BiosphereExchange{bioFlowId = fid} -> M.notMember fid (sdbBioFlows db)
+        WasteExchange{waFlowId = fid} -> M.notMember fid (sdbWasteFlows db)
+    unitOffenders =
+        [ (activityName act, exchangeUnitId ex)
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , M.notMember (exchangeUnitId ex) (sdbUnits db)
         ]
 
 -- | Bundle of lookup tables threaded through the per-exchange renderers.
@@ -426,16 +483,15 @@ escapeXmlAttr =
         . T.replace "<" "&lt;"
         . T.replace "&" "&amp;"
 
-{- | Deterministic textual form for a @meanValue@. @show@ on a 'Double' is
-already round-trippable and stable across platforms, but renders whole
-numbers as @1.0@ (which the parser reads back identically), so it is the
-simplest canonical choice. Negative zero is normalised to @0.0@, and the
-non-finite values (which cannot occur in a parsed database) are clamped to a
-parseable @0.0@ rather than the unreadable @"NaN"@/@"Infinity"@ — matching the
-EcoSpold2 / ILCD / SimaPro writers.
+{- | Deterministic textual form for a @meanValue@. Uses the shared
+'showFFloatTrim' (fixed-point, never scientific) so the value round-trips
+byte- and value-identically through the parser's 'Data.Text.Read.double' —
+unlike @show@, which emits scientific notation for small/large magnitudes that
+re-reads lossily. Non-finite values (which cannot occur in a parsed database)
+are clamped to a parseable @0.0@ rather than the unreadable @"NaN"@/@"Infinity"@.
 -}
 formatAmount :: Double -> Text
 formatAmount x
     | isNaN x || isInfinite x = "0.0"
-    | x == 0 = "0.0"
-    | otherwise = T.pack (show x)
+    | x == 0 = "0.0" -- normalise negative zero (showFFloat would emit "-0.0")
+    | otherwise = T.pack (showFFloatTrim x)

--- a/src/EcoSpold/Writer1.hs
+++ b/src/EcoSpold/Writer1.hs
@@ -195,6 +195,11 @@ emit silently wrong data:
     the writer would emit @outputGroup 0@ and the parser would read it back as
     a reference product — a direction flip.
 
+  * __Waste-marker collision.__ A biosphere flow whose compartment name is the
+    waste-routing category @"Final waste flows"@ would re-import as a waste
+    exchange, because the parser tests that category before the biosphere group
+    — a silent biosphere → waste kind flip. Rejected.
+
   * __Missing flows / units.__ An exchange whose flow or unit is absent from
     the tables would be written with a blank name and re-parse as a different
     (or @UNKNOWN@) entity.
@@ -211,7 +216,7 @@ Databases free of all of these pass unchanged.
 -}
 checkEcoSpold1Exportable :: SimpleDatabase -> Either Text ()
 checkEcoSpold1Exportable db =
-    checkLinks *> checkRefInputs *> checkFlows *> checkUnits *> checkAmounts *> checkAmountRoundTrip
+    checkLinks *> checkRefInputs *> checkWasteSentinel *> checkFlows *> checkUnits *> checkAmounts *> checkAmountRoundTrip
   where
     checkLinks =
         case danglingLinks of
@@ -233,6 +238,18 @@ checkEcoSpold1Exportable db =
                         <> "\": the format has no marker for it, so the writer would emit"
                         <> " outputGroup 0 and the parser would read it back as a reference"
                         <> " product — a direction flip from input to output."
+    checkWasteSentinel =
+        case wasteSentinelOffenders of
+            [] -> Right ()
+            (consumer : _) ->
+                Left $
+                    "EcoSpold1 export cannot represent activity \""
+                        <> consumer
+                        <> "\": a biosphere flow's compartment is \""
+                        <> finalWasteFlowsCategory
+                        <> "\", which 'EcoSpold.Parser1' reads as the waste-routing marker —"
+                        <> " the flow would re-import as a waste exchange, not a biosphere one"
+                        <> " (a silent biosphere → waste kind flip)."
     checkFlows =
         case flowOffenders of
             [] -> Right ()
@@ -305,6 +322,17 @@ checkEcoSpold1Exportable db =
         [ activityName act
         | act <- M.elems (sdbActivities db)
         , TechnosphereExchange{techRole = ReferenceInput} <- exchanges act
+        ]
+    -- A biosphere flow is serialised with @category = bfCompartmentName@. If that
+    -- equals the waste-routing marker, the parser (which tests the category first)
+    -- re-imports it as a waste exchange — a silent kind flip. A missing flow is
+    -- caught by 'checkFlows', so only resolvable biosphere flows are inspected here.
+    wasteSentinelOffenders =
+        [ activityName act
+        | act <- M.elems (sdbActivities db)
+        , BiosphereExchange{bioFlowId = fid} <- exchanges act
+        , Just bf <- [M.lookup fid (sdbBioFlows db)]
+        , bfCompartmentName bf == finalWasteFlowsCategory
         ]
     flowOffenders =
         [ activityName act
@@ -463,6 +491,17 @@ groupElement ex = case ex of
 -- Flow-field resolution (name / category / subCategory / CAS by UUID)
 -- ----------------------------------------------------------------------------
 
+{- | The category label EcoSpold1 exports use for SimaPro's third flow class.
+'EcoSpold.Parser1.buildExchange' routes any exchange carrying this category to a
+'WasteExchange' — and it checks that /before/ the biosphere and technosphere
+groups. So the writer emits it for every waste flow, and
+'checkEcoSpold1Exportable' rejects any /non-waste/ flow whose category would
+collide with it (the only such flow is a biosphere one whose compartment name
+happens to be this string), which would otherwise re-import as a waste exchange.
+-}
+finalWasteFlowsCategory :: Text
+finalWasteFlowsCategory = "Final waste flows"
+
 {- | The four flow-derived attribute values the parser stored on a flow:
 name, category, subCategory, CAS. Positional — always consumed as a whole.
 -}
@@ -491,8 +530,8 @@ flowFields res ex = case ex of
             Nothing -> FlowFields "" "" "" Nothing
     WasteExchange{waFlowId = fid} ->
         case M.lookup fid (rWaste res) of
-            Just wf -> FlowFields (wfName wf) "Final waste flows" "" (wfCAS wf)
-            Nothing -> FlowFields "" "Final waste flows" "" Nothing
+            Just wf -> FlowFields (wfName wf) finalWasteFlowsCategory "" (wfCAS wf)
+            Nothing -> FlowFields "" finalWasteFlowsCategory "" Nothing
 
 {- | Resolve a unit UUID to its name. The parser stored both unit name and
 symbol as the source unit string, so the name field is the faithful echo.

--- a/src/EcoSpold/Writer1.hs
+++ b/src/EcoSpold/Writer1.hs
@@ -1,0 +1,441 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | EcoSpold1 export writer — the canonical re-emitter for "EcoSpold.Parser1".
+
+Serializes a 'Database' / 'SimpleDatabase' back to the EcoSpold1 XML format
+(Ecoinvent 2.x, @http://www.EcoInvent.org/EcoSpold01@). The output is
+__canonical and deterministic__:
+
+  * activities are emitted in a stable order (sorted by @(activityName,
+    location)@), each in its own @\<dataset\>@ inside one @\<ecoSpold\>@;
+  * dataset numbers are assigned sequentially (1-based) in that order, and
+    exchange numbers likewise (see below). Because the parser derives flow
+    UUIDs from @datasetNumber@, exchange number, name and category, these
+    reassigned numbers make the writer's output __self-stable__: parsing it
+    and writing again reproduces the same flow UUIDs. This is fixed-point
+    stability of the writer's own canonical form, __not__ reproduction of
+    the UUIDs of an arbitrary parsed source file — that source carried its
+    own dataset/exchange numbering, which the writer does not preserve;
+  * exchange numbers are sequential (1-based) in exchange order;
+  * attributes appear in a fixed order, classification maps are sorted by
+    key, numbers use a fixed textual form, and there is no insignificant
+    whitespace beyond a single newline between top-level lines;
+  * volatile metadata (@generator@, @timestamp@) is pinned or omitted via
+    'WriterOptions' so a write→parse→write round-trip is byte-stable.
+
+The mapping mirrors 'EcoSpold.Parser1.buildExchange' exactly:
+
+  * 'ReferenceProduct' / 'ReferenceInput' → @\<outputGroup\>0\</outputGroup\>@
+  * 'Coproduct'                          → @\<outputGroup\>1\</outputGroup\>@
+  * technosphere 'Input'                 → @\<inputGroup\>5\</inputGroup\>@
+    (parser treats any non-empty inputGroup as a tech input)
+  * biosphere 'Resource'                 → @\<inputGroup\>4\</inputGroup\>@
+  * biosphere 'Emission'                 → @\<outputGroup\>4\</outputGroup\>@
+  * waste output (waIsInput=False)       → @\<outputGroup\>1\</outputGroup\>@,
+    category="Final waste flows"
+  * waste input  (waIsInput=True)        → @\<inputGroup\>5\</inputGroup\>@,
+    category="Final waste flows"
+
+Flow names, categories, CAS numbers and units are not stored on the
+'Exchange'; they live on the flow / unit tables and are resolved by UUID.
+A biosphere flow's @category@ / @subCategory@ come from its 'Compartment';
+technosphere flows carry no category (the parser only used it to seed the
+UUID), and waste flows always re-emit @category="Final waste flows"@ so the
+parser's waste-routing rule fires again.
+-}
+module EcoSpold.Writer1 (
+    -- * Options
+    WriterOptions (..),
+    defaultWriterOptions,
+    canonicalWriterOptions,
+
+    -- * Writers
+    writeDatabase,
+    writeSimpleDatabase,
+    writeActivities,
+
+    -- * Export boundary check
+    checkEcoSpold1Exportable,
+
+    -- * Pure helpers (exported for testing)
+    escapeXmlAttr,
+    formatAmount,
+) where
+
+import Data.List (sortOn)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.UUID as UUID
+import Database.Loader (generateActivityUUIDFromActivity)
+import Types
+
+-- ----------------------------------------------------------------------------
+-- Options
+-- ----------------------------------------------------------------------------
+
+{- | Knobs controlling the volatile, non-semantic parts of the output.
+Keeping these out of band lets a round-trip be byte-stable: write with
+'canonicalWriterOptions' (no @generator@/@timestamp@) and the second write
+reproduces the first exactly.
+-}
+data WriterOptions = WriterOptions
+    { woGenerator :: !(Maybe Text)
+    -- ^ Value of the @\<dataset generator=...\>@ attribute, or 'Nothing' to omit.
+    , woTimestamp :: !(Maybe Text)
+    -- ^ Value of the @\<dataset timestamp=...\>@ attribute, or 'Nothing' to omit.
+    }
+    deriving (Eq, Show)
+
+-- | Self-describing default: pins generator to "VoLCA", omits the timestamp.
+defaultWriterOptions :: WriterOptions
+defaultWriterOptions = WriterOptions (Just "VoLCA") Nothing
+
+{- | Fully canonical: omits both volatile attributes. Use this for stable
+round-trip / golden tests.
+-}
+canonicalWriterOptions :: WriterOptions
+canonicalWriterOptions = WriterOptions Nothing Nothing
+
+-- ----------------------------------------------------------------------------
+-- Top-level writers
+-- ----------------------------------------------------------------------------
+
+-- | Serialize a built 'Database' (via 'toSimpleDatabase').
+writeDatabase :: WriterOptions -> Database -> Text
+writeDatabase opts = writeSimpleDatabase opts . toSimpleDatabase
+
+-- | Serialize a 'SimpleDatabase'. Flow / unit names are resolved from its tables.
+writeSimpleDatabase :: WriterOptions -> SimpleDatabase -> Text
+writeSimpleDatabase opts sdb =
+    writeActivities
+        opts
+        (sdbTechFlows sdb)
+        (sdbBioFlows sdb)
+        (sdbWasteFlows sdb)
+        (sdbUnits sdb)
+        (M.elems (sdbActivities sdb))
+
+{- | Serialize a list of activities against the flow / unit tables that
+resolve their exchange UUIDs.
+-}
+writeActivities ::
+    WriterOptions ->
+    TechFlowDB ->
+    BioFlowDB ->
+    WasteFlowDB ->
+    UnitDB ->
+    [Activity] ->
+    Text
+writeActivities opts techs bios wastes units activities =
+    T.unlines $
+        [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold01\">"
+        ]
+            ++ concat (zipWith (datasetLines opts res) [1 ..] ordered)
+            ++ ["</ecoSpold>"]
+  where
+    res = Resolvers techs bios wastes units (supplierNumberIndex ordered)
+    -- Stable, content-derived order so dataset numbers (and thus flow UUIDs)
+    -- are reproducible regardless of the source Map's ordering.
+    ordered = orderedActivities activities
+
+{- | Canonical export order: sorted by @(activityName, location)@, so dataset
+numbers (and thus flow UUIDs) are reproducible regardless of the source Map's
+ordering. Shared by the writer and 'checkEcoSpold1Exportable'.
+-}
+orderedActivities :: [Activity] -> [Activity]
+orderedActivities = sortOn (\a -> (activityName a, activityLocation a))
+
+{- | Map each supplier activity's UUID to the dataset number it is assigned in
+canonical order. A technosphere input links to its supplier by
+'techActivityLinkId' (the supplier's @generateActivityUUIDFromActivity@), so the
+parser reads the input's @number@ attribute back as that supplier dataset number
+('EcoSpold.Parser1.closeExchange'). Re-encoding that link therefore means
+resolving the supplier UUID to its position in this index.
+-}
+supplierNumberIndex :: [Activity] -> M.Map UUID Int
+supplierNumberIndex ordered =
+    M.fromList [(generateActivityUUIDFromActivity a, n) | (n, a) <- zip [1 ..] ordered]
+
+{- | Guard an EcoSpold1 export against data the writer cannot faithfully
+re-encode. Two failure modes are checked:
+
+  * __Dangling supplier links.__ The format names a supplier from a
+    technosphere input's @number@ attribute, which the parser reads as the
+    supplier's dataset number. The writer can only re-emit that number when the
+    linked supplier activity is itself being exported (present in
+    'supplierNumberIndex'). A linked input pointing at an activity absent from
+    the database would otherwise force a positional index the parser would
+    misread as a different supplier.
+
+  * __Non-finite amounts.__ 'formatAmount' clamps @NaN@/@Infinity@ to a
+    parseable @0.0@; a database carrying such an amount would silently export
+    as zero. Parsed databases never contain these, so they only arise from
+    in-memory construction.
+
+Either case reports the first offender and fails loudly rather than emit
+silently wrong data. Databases free of both pass unchanged.
+-}
+checkEcoSpold1Exportable :: SimpleDatabase -> Either Text ()
+checkEcoSpold1Exportable db = checkLinks *> checkAmounts
+  where
+    checkLinks =
+        case danglingLinks of
+            [] -> Right ()
+            ((consumer, link) : _) ->
+                Left $
+                    "EcoSpold1 export cannot encode the supplier link of an input in \""
+                        <> consumer
+                        <> "\": linked activity "
+                        <> UUID.toText link
+                        <> " is not among the exported datasets, so its dataset number is unknown."
+    checkAmounts =
+        case amountOffenders of
+            [] -> Right ()
+            ((consumer, amt) : _) ->
+                Left $
+                    "EcoSpold1 export cannot represent activity \""
+                        <> consumer
+                        <> "\": exchange amount "
+                        <> T.pack (show amt)
+                        <> " is not finite."
+    index = supplierNumberIndex (orderedActivities (M.elems (sdbActivities db)))
+    danglingLinks =
+        [ (activityName act, link)
+        | act <- M.elems (sdbActivities db)
+        , TechnosphereExchange{techRole = Input, techActivityLinkId = link} <- exchanges act
+        , link /= UUID.nil
+        , not (M.member link index)
+        ]
+    amountOffenders =
+        [ (activityName act, amt)
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , let amt = exchangeAmount ex
+        , isNaN amt || isInfinite amt
+        ]
+
+-- | Bundle of lookup tables threaded through the per-exchange renderers.
+data Resolvers = Resolvers
+    { rTech :: !TechFlowDB
+    , rBio :: !BioFlowDB
+    , rWaste :: !WasteFlowDB
+    , rUnits :: !UnitDB
+    , rSupplierNumbers :: !(M.Map UUID Int)
+    }
+
+-- ----------------------------------------------------------------------------
+-- Per-dataset rendering
+-- ----------------------------------------------------------------------------
+
+-- | Render one @\<dataset\>@ block (already indented), as a list of lines.
+datasetLines :: WriterOptions -> Resolvers -> Int -> Activity -> [Text]
+datasetLines opts res num act =
+    [ indent 1 <> "<dataset" <> datasetAttrs opts num <> ">"
+    , indent 2 <> "<metaInformation>"
+    , indent 3 <> "<processInformation>"
+    , indent 4 <> "<referenceFunction" <> refFunctionAttrs act <> "/>"
+    , indent 4 <> "<geography location=" <> attr (activityLocation act) <> "/>"
+    , indent 3 <> "</processInformation>"
+    , indent 2 <> "</metaInformation>"
+    , indent 2 <> "<flowData>"
+    ]
+        ++ concat (zipWith (exchangeLines res) [1 ..] (exchanges act))
+        ++ [ indent 2 <> "</flowData>"
+           , indent 1 <> "</dataset>"
+           ]
+
+{- | @\<dataset\>@ attributes: @number@ always, then the volatile @generator@
+and @timestamp@ only when the options provide them.
+-}
+datasetAttrs :: WriterOptions -> Int -> Text
+datasetAttrs opts num =
+    " number="
+        <> attr (T.pack (show num))
+        <> maybe "" (\g -> " generator=" <> attr g) (woGenerator opts)
+        <> maybe "" (\t -> " timestamp=" <> attr t) (woTimestamp opts)
+
+{- | @\<referenceFunction\>@ attributes in a fixed order. @category@ /
+@subCategory@ come from 'activityClassification' (the parser's @Category@ /
+@SubCategory@ keys); a non-empty activity description is joined and emitted
+as @generalComment@.
+
+Note: @generalComment@ is a single ES1 attribute, so paragraph cardinality
+does not round-trip — the joined text survives, but 'Parser1' reads it back
+as a one-element 'activityDescription' regardless of how many paragraphs went in.
+-}
+refFunctionAttrs :: Activity -> Text
+refFunctionAttrs act =
+    " name="
+        <> attr (activityName act)
+        <> optAttr "category" (classif "Category")
+        <> optAttr "subCategory" (classif "SubCategory")
+        <> " unit="
+        <> attr (activityUnit act)
+        <> optAttr "generalComment" generalComment
+  where
+    classif k = M.findWithDefault "" k (activityClassification act)
+    generalComment = T.intercalate "\n" (activityDescription act)
+
+-- ----------------------------------------------------------------------------
+-- Exchange rendering
+-- ----------------------------------------------------------------------------
+
+{- | Render one @\<exchange\>@ as opening tag + group element + closing tag.
+The group element (@inputGroup@ / @outputGroup@) is what the parser keys on
+to classify the exchange, so it is derived from the exchange variant +
+role/direction, never guessed.
+-}
+exchangeLines :: Resolvers -> Int -> Exchange -> [Text]
+exchangeLines res num ex =
+    [ indent 3 <> "<exchange" <> exchangeAttrs res num ex <> ">"
+    , indent 4 <> groupElement ex
+    , indent 3 <> "</exchange>"
+    ]
+
+{- | The @number@ attribute to emit for an exchange. For a technosphere input
+that the loader resolved to a supplier, this is the supplier's assigned dataset
+number ('EcoSpold.Parser1.closeExchange' reads it back as the supplier link),
+not the positional exchange index. Every other exchange (reference products,
+co-products, biosphere, waste, and unlinked inputs) keeps the positional index,
+which seeds its flow UUID on re-parse. 'checkEcoSpold1Exportable' guarantees any
+resolved link is present in the index before export, so the @positional@
+fallback is unreachable for a linked input on the wired-up path.
+-}
+exchangeNumber :: Resolvers -> Int -> Exchange -> Int
+exchangeNumber res positional ex = case ex of
+    TechnosphereExchange{techRole = Input, techActivityLinkId = link}
+        | link /= UUID.nil ->
+            M.findWithDefault positional link (rSupplierNumbers res)
+    TechnosphereExchange{} -> positional
+    BiosphereExchange{} -> positional
+    WasteExchange{} -> positional
+
+{- | Common exchange attributes in fixed order: number, name, category,
+subCategory, location, unit, meanValue, then optional CAS / generalComment.
+Name and category are the inputs the parser hashes into the flow UUID, so
+they must be reproduced verbatim for a stable round-trip.
+-}
+exchangeAttrs :: Resolvers -> Int -> Exchange -> Text
+exchangeAttrs res num ex =
+    " number="
+        <> attr (T.pack (show (exchangeNumber res num ex)))
+        <> " name="
+        <> attr name
+        <> optAttr "category" category
+        <> optAttr "subCategory" subCategory
+        <> optAttr "location" (exchangeLocation ex)
+        <> " unit="
+        <> attr (unitNameFor (rUnits res) (exchangeUnitId ex))
+        <> " meanValue="
+        <> attr (formatAmount (exchangeAmount ex))
+        <> maybe "" (\c -> " CASNumber=" <> attr c) cas
+        <> maybe "" (\c -> " generalComment=" <> attr c) (exchangeComment ex)
+  where
+    FlowFields name category subCategory cas = flowFields res ex
+
+-- | The @\<inputGroup\>@ / @\<outputGroup\>@ element for an exchange.
+groupElement :: Exchange -> Text
+groupElement ex = case ex of
+    TechnosphereExchange{techRole = role} -> case role of
+        ReferenceProduct -> wrapOut "0"
+        ReferenceInput -> wrapOut "0"
+        Coproduct -> wrapOut "1"
+        Input -> wrapIn "5"
+    BiosphereExchange{bioDirection = dir} -> case dir of
+        Resource -> wrapIn "4"
+        Emission -> wrapOut "4"
+    WasteExchange{waIsInput = isInput} ->
+        if isInput then wrapIn "5" else wrapOut "1"
+  where
+    wrapIn g = "<inputGroup>" <> g <> "</inputGroup>"
+    wrapOut g = "<outputGroup>" <> g <> "</outputGroup>"
+
+-- ----------------------------------------------------------------------------
+-- Flow-field resolution (name / category / subCategory / CAS by UUID)
+-- ----------------------------------------------------------------------------
+
+{- | The four flow-derived attribute values the parser stored on a flow:
+name, category, subCategory, CAS. Positional — always consumed as a whole.
+-}
+data FlowFields = FlowFields !Text !Text !Text !(Maybe Text)
+
+{- | Resolve a flow's serialised fields from the matching table. A biosphere
+flow's compartment becomes category/subCategory; a waste flow always carries
+@category="Final waste flows"@ so the parser re-routes it to the waste
+bucket; a technosphere flow has no category. A UUID absent from its table
+yields empty/Nothing — never a crash.
+-}
+flowFields :: Resolvers -> Exchange -> FlowFields
+flowFields res ex = case ex of
+    TechnosphereExchange{techFlowId = fid} ->
+        case M.lookup fid (rTech res) of
+            Just tf -> FlowFields (tfName tf) "" "" (tfCAS tf)
+            Nothing -> FlowFields "" "" "" Nothing
+    BiosphereExchange{bioFlowId = fid} ->
+        case M.lookup fid (rBio res) of
+            Just bf ->
+                FlowFields
+                    (bfName bf)
+                    (bfCompartmentName bf)
+                    (maybe "" id (bfCompartmentSub bf))
+                    (bfCAS bf)
+            Nothing -> FlowFields "" "" "" Nothing
+    WasteExchange{waFlowId = fid} ->
+        case M.lookup fid (rWaste res) of
+            Just wf -> FlowFields (wfName wf) "Final waste flows" "" (wfCAS wf)
+            Nothing -> FlowFields "" "Final waste flows" "" Nothing
+
+{- | Resolve a unit UUID to its name. The parser stored both unit name and
+symbol as the source unit string, so the name field is the faithful echo.
+-}
+unitNameFor :: UnitDB -> UUID -> Text
+unitNameFor units uid = maybe "" unitName (M.lookup uid units)
+
+-- ----------------------------------------------------------------------------
+-- Canonical encoding helpers
+-- ----------------------------------------------------------------------------
+
+-- | Two-space indentation, @n@ levels deep.
+indent :: Int -> Text
+indent n = T.replicate (n * 2) " "
+
+-- | A double-quoted, XML-escaped attribute value.
+attr :: Text -> Text
+attr v = "\"" <> escapeXmlAttr v <> "\""
+
+-- | Emit @ name="value"@ only when the value is non-empty; otherwise nothing.
+optAttr :: Text -> Text -> Text
+optAttr name v
+    | T.null v = ""
+    | otherwise = " " <> name <> "=" <> attr v
+
+{- | Escape the five XML metacharacters plus the newline / carriage-return
+control characters, matching the entity set 'EcoSpold.Common.decodeXmlEntities'
+decodes on the way in. Order matters: @&@ is escaped first so we don't
+double-escape the entities we introduce.
+-}
+escapeXmlAttr :: Text -> Text
+escapeXmlAttr =
+    T.replace "\r" "&#13;"
+        . T.replace "\n" "&#10;"
+        . T.replace "'" "&apos;"
+        . T.replace "\"" "&quot;"
+        . T.replace ">" "&gt;"
+        . T.replace "<" "&lt;"
+        . T.replace "&" "&amp;"
+
+{- | Deterministic textual form for a @meanValue@. @show@ on a 'Double' is
+already round-trippable and stable across platforms, but renders whole
+numbers as @1.0@ (which the parser reads back identically), so it is the
+simplest canonical choice. Negative zero is normalised to @0.0@, and the
+non-finite values (which cannot occur in a parsed database) are clamped to a
+parseable @0.0@ rather than the unreadable @"NaN"@/@"Infinity"@ — matching the
+EcoSpold2 / ILCD / SimaPro writers.
+-}
+formatAmount :: Double -> Text
+formatAmount x
+    | isNaN x || isInfinite x = "0.0"
+    | x == 0 = "0.0"
+    | otherwise = T.pack (show x)

--- a/src/EcoSpold/Writer2.hs
+++ b/src/EcoSpold/Writer2.hs
@@ -1,0 +1,603 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Canonical, deterministic EcoSpold2 serializer — the inverse of
+'EcoSpold.Parser2'.
+
+Given a 'SimpleDatabase' (the natural writer input: activities keyed by
+@(activityUUID, productUUID)@ plus flow/unit registries), this produces one
+EcoSpold2 @.spold@ document per activity, named @{actUUID}_{prodUUID}.spold@
+exactly as the loader expects.
+
+Design goals (all pure, effect-free):
+
+  * __Canonical__: fixed attribute order, fixed namespaces, fixed two-space
+    indentation, no insignificant whitespace beyond the layout.
+  * __Deterministic__: every @Map@/@Set@-derived list is emitted in sorted
+    key order; doubles use one canonical renderer; output bytes are a pure
+    function of the input plus the explicit 'VolatileMeta'.
+  * __Round-trippable__: re-parsing the output reconstructs a structurally
+    equal 'Activity'/flow set, and volatile metadata (timestamps, generator)
+    is funnelled through 'VolatileMeta' so it can be pinned or omitted to make
+    byte-level idempotence testable.
+
+The only thing the writer cannot recover losslessly is information the parser
+discards (per-exchange @id@/@unitId@ attribute *strings*, production volumes,
+properties). Those are either omitted or synthesised from the stable UUIDs, so
+a parse→write→parse cycle is a fixed point.
+
+The contract is fixed-point over the parser's /image/, not @parse(write(x)) == x@
+for an arbitrary 'SimpleDatabase'. The parser normalises as it reads — e.g. it
+trims surrounding whitespace from text nodes — so a value that never came from a
+parse (a name padded with leading spaces) is outside the round-trip's domain;
+@parse(write(parse(s))) == parse(s)@ is what holds.
+-}
+module EcoSpold.Writer2 (
+    VolatileMeta (..),
+    noVolatileMeta,
+    writeEcoSpold2,
+    checkEcoSpold2Exportable,
+    activityFileName,
+    renderActivity,
+    sortExchanges,
+) where
+
+import Data.List (sortOn)
+import qualified Data.Map.Strict as M
+import Data.Maybe (listToMaybe)
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Read as TR
+import qualified Data.UUID as UUID
+import EcoSpold.Common (showFFloatTrim)
+import Types
+
+{- | Volatile, non-semantic metadata that the parser ignores but a writer would
+otherwise stamp with the current time / tool version. Threaded explicitly so a
+caller can pin it (reproducible export) or omit it entirely (byte-stable
+round-trip). 'Nothing' fields emit no corresponding attribute/element.
+-}
+data VolatileMeta = VolatileMeta
+    { vmCreationTimestamp :: !(Maybe Text)
+    -- ^ @administrativeInformation/fileAttributes/@creationTimestamp@
+    , vmGenerator :: !(Maybe Text)
+    -- ^ free-text generator note emitted as an XML comment, or omitted
+    }
+    deriving (Eq, Show)
+
+-- | The reproducible default: omit every volatile field.
+noVolatileMeta :: VolatileMeta
+noVolatileMeta = VolatileMeta Nothing Nothing
+
+-- ============================================================================
+-- Public entry points
+-- ============================================================================
+
+{- | Serialize a whole 'SimpleDatabase' to a sorted list of
+@(filename, document)@ pairs, one per activity. Sorted by filename so the
+sequence itself is deterministic. Flow names and unit names are resolved from
+the registries because the parser stores them on exchanges, not centrally.
+Runs 'checkEcoSpold2Exportable' first and returns its 'Left' on a database the
+format cannot represent faithfully, so an unguarded caller cannot silently emit
+a corrupt archive.
+-}
+writeEcoSpold2 :: VolatileMeta -> SimpleDatabase -> Either Text [(FilePath, Text)]
+writeEcoSpold2 meta sdb = do
+    checkEcoSpold2Exportable sdb
+    pure
+        [ (activityFileName actUUID prodUUID, renderActivity meta env act)
+        | ((actUUID, prodUUID), act) <- M.toAscList (sdbActivities sdb)
+        ]
+  where
+    env =
+        ResolveEnv
+            { reTechName = \u -> tfName <$> M.lookup u techFlows
+            , reBioFlow = \u -> M.lookup u bioFlows
+            , reWasteName = \u -> wfName <$> M.lookup u wasteFlows
+            , reTechSyns = \u -> maybe M.empty tfSynonyms (M.lookup u techFlows)
+            , reBioSyns = \u -> maybe M.empty bfSynonyms (M.lookup u bioFlows)
+            , reWasteSyns = \u -> maybe M.empty wfSynonyms (M.lookup u wasteFlows)
+            , reUnitName = \u -> unitName <$> M.lookup u units
+            }
+    techFlows = sdbTechFlows sdb
+    bioFlows = sdbBioFlows sdb
+    wasteFlows = sdbWasteFlows sdb
+    units = sdbUnits sdb
+
+{- | Guard an EcoSpold2 export against data the writer cannot faithfully
+re-encode.
+
+  * __Non-finite amounts.__ 'doubleAttr' clamps @NaN@/@Infinity@ to a parseable
+    @0.0@; a database carrying such an amount would silently export as zero. The
+    reader parses amounts with 'Data.Text.Read.double', which yields @Infinity@
+    for an overflowing literal like @1e400@, so this is reachable from a parsed
+    source — not only from in-memory construction.
+
+  * __Reference inputs.__ A treatment activity's 'ReferenceInput' is written as
+    @inputGroup 5@, but no ES2 inputGroup re-parses to 'ReferenceInput' (the
+    parser yields 'Input'), so the reference designation is silently lost on
+    re-parse — the activity loses its reference product. ES2 has no encoding for
+    it, so reject rather than corrupt.
+
+  * __Unresolvable units.__ The @\<unitName\>@ line is resolved from 'sdbUnits';
+    an exchange whose @unitId@ is absent from the registry would emit no
+    @\<unitName\>@, which the parser re-reads as the @UNKNOWN_UNIT@ placeholder —
+    a silent unit downgrade. Reject rather than lose the unit.
+
+  * __Unresolvable flows.__ A flow's name, compartment, CAS and synonyms are all
+    resolved from the flow registries; an exchange whose flow id is absent emits
+    a bare exchange that re-parses with the flow's UUID string as its name and
+    /no compartment/ — a silent identity and compartment downgrade. Symmetric to
+    the unit case: reject rather than corrupt.
+
+  * __Non-round-tripping amounts.__ A finite amount whose decimal form does not
+    re-parse to the same 'Double' through 'Data.Text.Read.double' — e.g. a
+    subnormal near the floating-point floor — would silently export as a
+    different value. Reject rather than undercount.
+
+Reports the first offender and fails loudly rather than emit silently wrong
+data. Databases free of it pass unchanged.
+-}
+checkEcoSpold2Exportable :: SimpleDatabase -> Either Text ()
+checkEcoSpold2Exportable db =
+    maybe (Right ()) Left (listToMaybe (concat orderedViolations))
+  where
+    -- Categories in priority order; the first offending activity across all of
+    -- them is reported. Each inner list carries one message per offender.
+    orderedViolations =
+        [ [nonFiniteMsg c a | (c, a) <- amountOffenders]
+        , [refInputMsg c | c <- refInputOffenders]
+        , [unknownUnitMsg c | c <- unknownUnitOffenders]
+        , [missingFlowMsg c | c <- missingFlowOffenders]
+        , [nonRoundTripMsg c a | (c, a) <- roundTripOffenders]
+        ]
+    amountOffenders =
+        [ (activityName act, amt)
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , let amt = exchangeAmount ex
+        , isNaN amt || isInfinite amt
+        ]
+    roundTripOffenders =
+        [ (activityName act, amt)
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , let amt = exchangeAmount ex
+        , not (isNaN amt || isInfinite amt) -- non-finite already reported above
+        , not (amountRoundTrips amt)
+        ]
+    -- The written decimal must re-parse to the same Double through the parser's
+    -- reader ('Data.Text.Read.double'), or the value silently changes on import.
+    amountRoundTrips amt = case TR.double (doubleAttr amt) of
+        Right (v, rest) -> v == amt && T.null rest
+        Left _ -> False
+    refInputOffenders =
+        [ activityName act
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , isReferenceInput ex
+        ]
+    unknownUnitOffenders =
+        [ activityName act
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , M.notMember (exchangeUnitId ex) (sdbUnits db)
+        ]
+    -- Each exchange's flow must resolve in the registry matching its kind, or the
+    -- writer emits a nameless, compartment-less exchange (see Haddock above).
+    missingFlowOffenders =
+        [ activityName act
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , flowMissing ex
+        ]
+    flowMissing ex = case ex of
+        TechnosphereExchange{techFlowId = fid} -> M.notMember fid (sdbTechFlows db)
+        WasteExchange{waFlowId = fid} -> M.notMember fid (sdbWasteFlows db)
+        BiosphereExchange{bioFlowId = fid} -> M.notMember fid (sdbBioFlows db)
+    isReferenceInput ex = case ex of
+        TechnosphereExchange{techRole = ReferenceInput} -> True
+        TechnosphereExchange{} -> False
+        WasteExchange{} -> False
+        BiosphereExchange{} -> False
+    cannotRepresent c = "EcoSpold2 export cannot represent activity \"" <> c <> "\": "
+    nonFiniteMsg c a = cannotRepresent c <> "exchange amount " <> T.pack (show a) <> " is not finite."
+    refInputMsg c = cannotRepresent c <> "a reference input (treatment process) has no EcoSpold2 encoding."
+    unknownUnitMsg c = cannotRepresent c <> "an exchange references a unit absent from the registry."
+    missingFlowMsg c = cannotRepresent c <> "an exchange references a flow absent from the registry."
+    nonRoundTripMsg c a =
+        cannotRepresent c
+            <> "exchange amount "
+            <> T.pack (show a)
+            <> " has no decimal form that re-parses to the same value"
+            <> " (e.g. a subnormal near the floating-point floor)."
+
+-- | Canonical filename for an activity: @{actUUID}_{prodUUID}.spold@.
+activityFileName :: UUID.UUID -> UUID.UUID -> FilePath
+activityFileName actUUID prodUUID =
+    T.unpack (UUID.toText actUUID <> "_" <> UUID.toText prodUUID <> ".spold")
+
+{- | Resolver for the registry-held data the parser writes onto exchanges.
+Passed in so 'renderActivity' stays a pure function of its inputs.
+-}
+data ResolveEnv = ResolveEnv
+    { reTechName :: UUID.UUID -> Maybe Text
+    , reBioFlow :: UUID.UUID -> Maybe BiosphereFlow
+    , reWasteName :: UUID.UUID -> Maybe Text
+    , reTechSyns :: UUID.UUID -> M.Map Text (S.Set Text)
+    , reBioSyns :: UUID.UUID -> M.Map Text (S.Set Text)
+    , reWasteSyns :: UUID.UUID -> M.Map Text (S.Set Text)
+    , reUnitName :: UUID.UUID -> Maybe Text
+    }
+
+-- ============================================================================
+-- Document rendering
+-- ============================================================================
+
+-- | Render one activity to a complete EcoSpold2 document.
+renderActivity :: VolatileMeta -> ResolveEnv -> Activity -> Text
+renderActivity meta env act =
+    T.unlines $
+        [ "<?xml version='1.0' encoding='UTF-8'?>"
+        , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold02\">"
+        ]
+            ++ generatorComment meta
+            ++ [ "  <activityDataset>"
+               , "    <activityDescription>"
+               ]
+            ++ renderActivityElem act
+            ++ renderGeneralComment (activityDescription act)
+            ++ renderClassifications (activityClassification act)
+            ++ renderGeography (activityLocation act)
+            ++ ["    </activityDescription>", "    <flowData>"]
+            ++ concatMap (renderExchange env) (sortExchanges (exchanges act))
+            ++ ["    </flowData>"]
+            ++ renderAdminInfo meta
+            ++ ["  </activityDataset>", "</ecoSpold>"]
+
+-- | Optional generator note as an XML comment (volatile, omitted by default).
+generatorComment :: VolatileMeta -> [Text]
+generatorComment meta = case vmGenerator meta of
+    Nothing -> []
+    Just g -> ["  <!-- generator: " <> escapeText g <> " -->"]
+
+{- | The @\<activity\>@ opening element. We do not have the source's raw
+@id@/@activityNameId@ strings on 'Activity' (the parser keeps UUIDs in the
+filename, not here), so we omit them: the parser derives identity from the
+filename, never from these attributes. activityType / specialActivityType are
+re-emitted from 'activityNativeType' when present.
+-}
+renderActivityElem :: Activity -> [Text]
+renderActivityElem act =
+    [ "      <activity" <> activityTypeAttrs (activityNativeType act) <> ">"
+    , "        <activityName xml:lang=\"en\">" <> escapeText (activityName act) <> "</activityName>"
+    , "      </activity>"
+    ]
+
+{- | Re-emit the ecospold2 @activityType@/@specialActivityType@ attributes from
+the captured native type. Only 'EcoSpoldActivityType' carries them; the SimaPro
+and ILCD variants have no ecospold2 representation, so we emit nothing (a
+faithful round-trip of an ES2-sourced database never hits those cases).
+-}
+activityTypeAttrs :: Maybe NativeActivityType -> Text
+activityTypeAttrs Nothing = ""
+activityTypeAttrs (Just nt) = case nt of
+    EcoSpoldActivityType code _ special _ ->
+        " activityType=\"" <> intText code <> "\"" <> specialAttr special
+    SimaProProcessType _ -> ""
+    ILCDProcessType _ -> ""
+  where
+    specialAttr Nothing = ""
+    specialAttr (Just s) = " specialActivityType=\"" <> intText s <> "\""
+
+{- | @\<generalComment\>@ with one @\<text index="n">@ per description
+paragraph, in the original order. Empty description emits nothing.
+-}
+renderGeneralComment :: [Text] -> [Text]
+renderGeneralComment [] = []
+renderGeneralComment paras =
+    ["      <generalComment>"]
+        ++ [ "        <text xml:lang=\"en\" index=\"" <> intText i <> "\">" <> escapeText p <> "</text>"
+           | (i, p) <- zip [0 :: Int ..] paras
+           ]
+        ++ ["      </generalComment>"]
+
+{- | Activity-level @\<classification\>@ blocks (ISIC/CPC, …) under
+@activityDescription@. One block per (system, value) pair, sorted by system for
+determinism. Parser2 routes any @classification@ outside an intermediate
+exchange to @activityClassification@, so these round-trip. Empty map emits
+nothing.
+-}
+renderClassifications :: M.Map Text Text -> [Text]
+renderClassifications =
+    concatMap (classificationBlock . Just) . M.toAscList
+
+-- | @\<geography\>\<shortname\>@ holding the location code.
+renderGeography :: Text -> [Text]
+renderGeography loc =
+    [ "      <geography>"
+    , "        <shortname xml:lang=\"en\">" <> escapeText loc <> "</shortname>"
+    , "      </geography>"
+    ]
+
+{- | @administrativeInformation@ carrying only the (optional, volatile)
+creation timestamp. Omitted entirely when no timestamp is pinned, keeping the
+default output minimal and byte-stable.
+-}
+renderAdminInfo :: VolatileMeta -> [Text]
+renderAdminInfo meta = case vmCreationTimestamp meta of
+    Nothing -> []
+    Just ts ->
+        [ "    <administrativeInformation>"
+        , "      <fileAttributes defaultLanguage=\"en\" creationTimestamp=\"" <> escapeAttr ts <> "\"/>"
+        , "    </administrativeInformation>"
+        ]
+
+-- ============================================================================
+-- Exchange rendering
+-- ============================================================================
+
+{- | Deterministic exchange order: group by kind (technosphere, then waste,
+then biosphere), and within a kind sort by flow UUID. The reference product is
+forced first within the technosphere group so the canonical layout matches the
+ecospold convention of leading with the produced product.
+-}
+sortExchanges :: [Exchange] -> [Exchange]
+sortExchanges = sortOn exchangeSortKey
+
+{- | Sort key: (kindRank, not-reference, flowUUID). @not-reference@ sorts the
+reference product/input ahead of the others within a kind. The flow UUID is the
+tiebreaker; 'sortOn' is stable, so two exchanges sharing a key keep their input
+order and are both emitted — never collapsed (a 'Map' keyed on this would have
+silently dropped a duplicate biosphere/technosphere line, undercounting the
+inventory).
+-}
+exchangeSortKey :: Exchange -> (Int, Bool, Text)
+exchangeSortKey ex = (kindRank, not (exchangeIsReference ex), UUID.toText (exchangeFlowId ex))
+  where
+    kindRank = case ex of
+        TechnosphereExchange{} -> 0
+        WasteExchange{} -> 1
+        BiosphereExchange{} -> 2
+
+-- | Render a single exchange to its XML lines.
+renderExchange :: ResolveEnv -> Exchange -> [Text]
+renderExchange env ex = case ex of
+    TechnosphereExchange{} -> renderTechnosphere env ex
+    WasteExchange{} -> renderWaste env ex
+    BiosphereExchange{} -> renderBiosphere env ex
+
+{- | Technosphere exchange → @intermediateExchange@.
+
+Inverse of the parser's role logic:
+
+  * 'ReferenceProduct' → output, @\<outputGroup\>0\</outputGroup\>@
+  * 'Coproduct'        → output, @\<outputGroup\>2\</outputGroup\>@ (any
+    non-zero output group re-parses to 'Coproduct')
+  * 'Input' / 'ReferenceInput' → input, @\<inputGroup\>5\</inputGroup\>@
+-}
+renderTechnosphere :: ResolveEnv -> Exchange -> [Text]
+renderTechnosphere env ex =
+    intermediateExchange
+        (reTechName env flowId)
+        flowId
+        (techUnitId ex)
+        (techAmount ex)
+        (reUnitName env (techUnitId ex))
+        (reTechSyns env flowId)
+        groupLine
+        (techActivityLinkId ex)
+        Nothing
+        (techComment ex)
+  where
+    flowId = techFlowId ex
+    groupLine = case techRole ex of
+        ReferenceProduct -> outputGroupLine "0"
+        Coproduct -> outputGroupLine "2"
+        Input -> inputGroupLine "5"
+        ReferenceInput -> inputGroupLine "5"
+
+{- | Waste exchange → @intermediateExchange@ tagged with the
+@By-product classification = Waste@ classification (parser "Pattern B"). The
+@waIsInput@ flag picks the group so direction round-trips: an input takes
+@inputGroup 5@ (from technosphere), an output the @outputGroup 2@ (by-product) —
+the only output groups EcoSpold2 defines for an intermediate exchange besides the
+reference @0@. A waste output shares group @2@ with an ordinary coproduct; it is
+the @Waste@ classification, not the group number, that re-routes it to a
+'WasteExchange' on parse, so the kind is preserved.
+-}
+renderWaste :: ResolveEnv -> Exchange -> [Text]
+renderWaste env ex =
+    intermediateExchange
+        (reWasteName env flowId)
+        flowId
+        (waUnitId ex)
+        (waAmount ex)
+        (reUnitName env (waUnitId ex))
+        (reWasteSyns env flowId)
+        groupLine
+        (waActivityLinkId ex)
+        (Just ("By-product classification", "Waste"))
+        (waComment ex)
+  where
+    flowId = waFlowId ex
+    groupLine = if waIsInput ex then inputGroupLine "5" else outputGroupLine "2"
+
+{- | Biosphere exchange → @elementaryExchange@. Direction maps to in/out group:
+'Resource' → @inputGroup@ 4, 'Emission' → @outputGroup@ 4. The compartment is
+taken from the registry's 'BiosphereFlow'.
+-}
+renderBiosphere :: ResolveEnv -> Exchange -> [Text]
+renderBiosphere env ex =
+    [openTag]
+        ++ nameLine 8 (reBioFlow env flowId >>= justName)
+        ++ unitNameLine 8 (reUnitName env (bioUnitId ex))
+        ++ compartmentBlock (reBioFlow env flowId >>= bfCompartment)
+        ++ [groupLine]
+        ++ synonymLines 8 (reBioSyns env flowId)
+        ++ commentLines 8 (bioComment ex)
+        ++ ["      </elementaryExchange>"]
+  where
+    flowId = bioFlowId ex
+    justName f = let n = bfName f in if T.null n then Nothing else Just n
+    casAttr = case reBioFlow env flowId >>= bfCAS of
+        Just cas -> " casNumber=\"" <> escapeAttr cas <> "\""
+        Nothing -> ""
+    openTag =
+        "      <elementaryExchange elementaryExchangeId=\""
+            <> escapeAttr (UUID.toText flowId)
+            <> "\" unitId=\""
+            <> escapeAttr (UUID.toText (bioUnitId ex))
+            <> "\" amount=\""
+            <> doubleAttr (bioAmount ex)
+            <> "\""
+            <> casAttr
+            <> ">"
+    groupLine = case bioDirection ex of
+        Resource -> "        <inputGroup>4</inputGroup>"
+        Emission -> "        <outputGroup>4</outputGroup>"
+
+{- | Shared @intermediateExchange@ emitter for technosphere and waste flows.
+The @activityLinkId@ is emitted only when non-nil (matching the parser, which
+treats nil/empty as "no link"). An optional @classification@ tags waste flows.
+-}
+intermediateExchange ::
+    Maybe Text -> -- resolved flow name
+    UUID.UUID -> -- flow id
+    UUID.UUID -> -- unit id
+    Double -> -- amount
+    Maybe Text -> -- resolved unit name
+    M.Map Text (S.Set Text) -> -- synonyms
+    Text -> -- the in/out group line (8-space indent)
+    UUID.UUID -> -- activity link id (nil = omit)
+    Maybe (Text, Text) -> -- optional (classificationSystem, classificationValue)
+    Maybe Text -> -- comment
+    [Text]
+intermediateExchange mName flowId unitUUID amount mUnit syns groupLine linkId mClass mComment =
+    [openTag]
+        ++ nameLine 8 mName
+        ++ unitNameLine 8 mUnit
+        ++ [groupLine]
+        ++ classificationBlock mClass
+        ++ synonymLines 8 syns
+        ++ commentLines 8 mComment
+        ++ ["      </intermediateExchange>"]
+  where
+    openTag =
+        "      <intermediateExchange intermediateExchangeId=\""
+            <> escapeAttr (UUID.toText flowId)
+            <> "\" unitId=\""
+            <> escapeAttr (UUID.toText unitUUID)
+            <> "\" amount=\""
+            <> doubleAttr amount
+            <> "\""
+            <> linkAttr
+            <> ">"
+    linkAttr
+        | linkId == UUID.nil = ""
+        | otherwise = " activityLinkId=\"" <> escapeAttr (UUID.toText linkId) <> "\""
+
+-- ============================================================================
+-- Small element emitters
+-- ============================================================================
+
+inputGroupLine :: Text -> Text
+inputGroupLine g = "        <inputGroup>" <> g <> "</inputGroup>"
+
+outputGroupLine :: Text -> Text
+outputGroupLine g = "        <outputGroup>" <> g <> "</outputGroup>"
+
+-- | @\<name\>@ line at the given indent, omitted when no name resolved.
+nameLine :: Int -> Maybe Text -> [Text]
+nameLine ind = maybe [] (\n -> [indent ind <> "<name xml:lang=\"en\">" <> escapeText n <> "</name>"])
+
+-- | @\<unitName\>@ line, omitted when no unit resolved.
+unitNameLine :: Int -> Maybe Text -> [Text]
+unitNameLine ind = maybe [] (\u -> [indent ind <> "<unitName xml:lang=\"en\">" <> escapeText u <> "</unitName>"])
+
+{- | @\<comment\>@ line for an exchange. The parser keeps only the English
+comment text, so we emit it verbatim under @xml:lang="en"@.
+-}
+commentLines :: Int -> Maybe Text -> [Text]
+commentLines ind = maybe [] (\c -> [indent ind <> "<comment xml:lang=\"en\">" <> escapeText c <> "</comment>"])
+
+{- | @\<synonym\>@ lines, one per synonym, sorted. The parser collapses all
+languages into the @"en"@ bucket and ignores the language, so we flatten and
+sort the unique synonym strings for a deterministic, round-trip-stable layout.
+-}
+synonymLines :: Int -> M.Map Text (S.Set Text) -> [Text]
+synonymLines ind syns =
+    [ indent ind <> "<synonym xml:lang=\"en\">" <> escapeText s <> "</synonym>"
+    | s <- S.toAscList (S.unions (M.elems syns))
+    , not (T.null s)
+    ]
+
+{- | The nested @\<compartment\>\<compartment\>\<subcompartment\>@ block the
+parser expects. Omitted when the flow carries no compartment.
+-}
+compartmentBlock :: Maybe Compartment -> [Text]
+compartmentBlock Nothing = []
+compartmentBlock (Just (Compartment name mSub)) =
+    ["        <compartment>", "          <compartment xml:lang=\"en\">" <> escapeText name <> "</compartment>"]
+        ++ subLine mSub
+        ++ ["        </compartment>"]
+  where
+    subLine = maybe [] (\s -> ["          <subcompartment xml:lang=\"en\">" <> escapeText s <> "</subcompartment>"])
+
+{- | @\<classification\>@ block tagging an exchange (used for waste). Emits the
+classificationSystem / classificationValue pair the parser reads.
+-}
+classificationBlock :: Maybe (Text, Text) -> [Text]
+classificationBlock Nothing = []
+classificationBlock (Just (system, value)) =
+    [ "        <classification>"
+    , "          <classificationSystem xml:lang=\"en\">" <> escapeText system <> "</classificationSystem>"
+    , "          <classificationValue xml:lang=\"en\">" <> escapeText value <> "</classificationValue>"
+    , "        </classification>"
+    ]
+
+-- ============================================================================
+-- Pure formatting helpers
+-- ============================================================================
+
+-- | @n@ spaces of indentation.
+indent :: Int -> Text
+indent n = T.replicate n " "
+
+intText :: Int -> Text
+intText = T.pack . show
+
+{- | Canonical 'Double' rendering for amounts via the shared 'showFFloatTrim'
+(fixed-point, never scientific), so the value round-trips through the parser's
+'Data.Text.Read.double' for the magnitudes real LCA amounts occupy. The
+near-underflow subnormal tail is the exception; 'checkEcoSpold2Exportable'
+rejects any amount that does not re-parse, so the guarded path never emits one.
+A non-finite value renders as its (non-parseable) @"NaN"@/@"Infinity"@ form so a
+bad re-import fails loudly rather than silently reading @0@; the guard rejects
+non-finite amounts before they reach here.
+-}
+doubleAttr :: Double -> Text
+doubleAttr d
+    | isNaN d || isInfinite d = T.pack (show d)
+    | otherwise = T.pack (showFFloatTrim d)
+
+-- | Escape the three XML predefined entities for element text content.
+escapeText :: Text -> Text
+escapeText =
+    T.replace "&" "&amp;"
+        >>> T.replace "<" "&lt;"
+        >>> T.replace ">" "&gt;"
+  where
+    (>>>) f g = g . f
+
+{- | Escape for a double-quoted attribute value: the text escapes plus the
+double quote. The parser's 'decodeXmlEntities' reverses all of these.
+-}
+escapeAttr :: Text -> Text
+escapeAttr =
+    escapeText
+        >>> T.replace "\"" "&quot;"
+        >>> T.replace "\n" "&#10;"
+        >>> T.replace "\r" "&#13;"
+  where
+    (>>>) f g = g . f

--- a/test/EcoSpold1WriterSpec.hs
+++ b/test/EcoSpold1WriterSpec.hs
@@ -1,0 +1,460 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Round-trip contract for the EcoSpold1 writer (the inverse of
+"EcoSpold.Parser1"). Three properties:
+
+  (a) idempotence modulo volatile metadata — write, parse, write again,
+      and the two serialisations are byte-identical when the volatile
+      @generator@/@timestamp@ attributes are omitted ('canonicalWriterOptions');
+  (b) semantic round-trip — parse(write(D)) reproduces the observable
+      structure of D (names, amounts, units, roles/directions, compartments,
+      CAS, comments), compared order-insensitively;
+  (c) score-equivalence — a sample activity yields the same direct LCIA
+      inventory (biosphere flow amounts, keyed by flow name) after a
+      write→parse→build round-trip, within tolerance.
+-}
+module EcoSpold1WriterSpec (spec) where
+
+import qualified Data.ByteString.Char8 as BC
+import Data.Either (isLeft)
+import Data.List (sort)
+import qualified Data.Map.Strict as M
+import Data.Maybe (mapMaybe)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified Data.UUID as UUID
+import Test.Hspec
+
+import qualified Database as DB
+import Database.Loader (generateActivityUUIDFromActivity)
+import EcoSpold.Cutoff (applyCutoffStrategy)
+import EcoSpold.Parser1 (parseAllWithXeno)
+import EcoSpold.Writer1
+import qualified Matrix
+import Types
+import UnitConversion (defaultUnitConfig)
+
+-- ---------------------------------------------------------------------------
+-- Fixture: a small in-memory database, distilled from EcoSpold1Spec's minimalXml
+-- (one production activity: 1 kWh electricity, with a fossil-CO2 emission and
+--  a natural-gas resource input). Built straight from the parser output so the
+-- flow/unit UUIDs already line up with the EcoSpold1 UUID scheme.
+-- ---------------------------------------------------------------------------
+
+minimalXml :: BC.ByteString
+minimalXml =
+    BC.unlines
+        [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold01\">"
+        , "  <dataset number=\"42\">"
+        , "    <metaInformation>"
+        , "      <processInformation>"
+        , "        <referenceFunction name=\"electricity production\" category=\"Energy\""
+        , "                           subCategory=\"Electricity\" unit=\"kWh\""
+        , "                           generalComment=\"A comment\"/>"
+        , "        <geography location=\"DE\" />"
+        , "      </processInformation>"
+        , "    </metaInformation>"
+        , "    <flowData>"
+        , "      <exchange number=\"1\" name=\"electricity, high voltage\" category=\"Energy\""
+        , "                subCategory=\"Electricity\" unit=\"kWh\" meanValue=\"1.0\">"
+        , "        <outputGroup>0</outputGroup>"
+        , "      </exchange>"
+        , "      <exchange number=\"2\" name=\"Carbon dioxide, fossil\" category=\"air\""
+        , "                subCategory=\"low population density\" unit=\"kg\" meanValue=\"0.05\""
+        , "                CASNumber=\"124-38-9\">"
+        , "        <outputGroup>4</outputGroup>"
+        , "      </exchange>"
+        , "      <exchange number=\"3\" name=\"natural gas\" category=\"resource\""
+        , "                subCategory=\"in ground\" unit=\"MJ\" meanValue=\"10.0\">"
+        , "        <inputGroup>4</inputGroup>"
+        , "      </exchange>"
+        , "    </flowData>"
+        , "  </dataset>"
+        , "</ecoSpold>"
+        ]
+
+{- | Parsed fixture as a 'SimpleDatabase'. Fails the spec loudly if the
+fixture can't be parsed (it is a known-good EcoSpold1 document).
+-}
+fixtureDb :: IO SimpleDatabase
+fixtureDb = case parseAllWithXeno minimalXml of
+    Left err -> fail ("fixture parse failed: " ++ err)
+    Right results -> case sequence results of
+        Left err -> fail ("fixture dataset failed: " ++ err)
+        Right datasets -> pure (assembleSimpleDb datasets)
+
+-- | Fold parser per-dataset tuples into a 'SimpleDatabase'.
+assembleSimpleDb ::
+    [(Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit], Int, M.Map UUID Int)] ->
+    SimpleDatabase
+assembleSimpleDb datasets =
+    SimpleDatabase
+        { sdbActivities = M.fromList [(processKey a, a) | (a, _, _, _, _, _, _) <- datasets]
+        , sdbTechFlows = M.fromList [(tfId f, f) | (_, tfs, _, _, _, _, _) <- datasets, f <- tfs]
+        , sdbBioFlows = M.fromList [(bfId f, f) | (_, _, bfs, _, _, _, _) <- datasets, f <- bfs]
+        , sdbWasteFlows = M.fromList [(wfId f, f) | (_, _, _, wfs, _, _, _) <- datasets, f <- wfs]
+        , sdbUnits = M.fromList [(unitId u, u) | (_, _, _, _, us, _, _) <- datasets, u <- us]
+        }
+
+{- | The (activityUUID, productUUID) key the matrix builder expects. We use the
+reference exchange's flow id as the product, and derive a stable activity id
+from name+location via the same namespace the Loader uses is unnecessary
+here: the writer round-trip only depends on flow ids, so any injective key
+works. We reuse the reference product flow id for both slots.
+-}
+processKey :: Activity -> (UUID, UUID)
+processKey act =
+    case mapMaybe refId (exchanges act) of
+        (fid : _) -> (fid, fid)
+        [] -> case exchanges act of
+            (e : _) -> (exchangeFlowId e, exchangeFlowId e)
+            [] -> (UUID.nil, UUID.nil)
+  where
+    refId e = if exchangeIsReference e then Just (exchangeFlowId e) else Nothing
+
+-- ---------------------------------------------------------------------------
+-- Hand-built fixtures for boundary cases (empty DB, escaping/unicode, linked
+-- supplier, Final-waste-flows, non-finite amount). Built straight from the
+-- domain types so the writer's export-boundary checks can be exercised on data
+-- the parser would never itself produce (a NaN amount, a dangling link).
+-- ---------------------------------------------------------------------------
+
+kgUnit :: UUID
+kgUnit = read "11111111-0000-4000-8000-000000000001"
+
+units1 :: UnitDB
+units1 = M.singleton kgUnit (Unit kgUnit "kg" "kg" "")
+
+-- | A single-activity database with one reference product and the given
+-- extra exchanges, named @name@ so its flows resolve from @techs@/@bios@/@wastes@.
+soloDb :: Text -> UUID -> [Exchange] -> TechFlowDB -> BioFlowDB -> WasteFlowDB -> SimpleDatabase
+soloDb name prodU extra techs bios wastes =
+    SimpleDatabase
+        { sdbActivities = M.singleton (prodU, prodU) act
+        , sdbTechFlows = M.insert prodU (TechnosphereFlow prodU name kgUnit M.empty Nothing Nothing) techs
+        , sdbBioFlows = bios
+        , sdbWasteFlows = wastes
+        , sdbUnits = units1
+        }
+  where
+    ref = TechnosphereExchange prodU 1.0 kgUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+    act = Activity name [] M.empty M.empty "GLO" "kg" (ref : extra) M.empty M.empty Nothing Nothing Nothing
+
+-- | Empty database: no activities, no flows.
+emptyDb :: SimpleDatabase
+emptyDb = SimpleDatabase M.empty M.empty M.empty M.empty M.empty
+
+{- | Two activities where the consumer's technosphere input is a resolved link
+to the supplier. The link UUID is the loader's content hash of the supplier's
+@(name, location)@, which is exactly the key 'checkEcoSpold1Exportable' /
+'supplierNumberIndex' resolve to a dataset number. Passing a UUID absent from
+the database instead models a dangling supplier link.
+-}
+linkedDb :: UUID -> SimpleDatabase
+linkedDb link =
+    SimpleDatabase
+        { sdbActivities = M.fromList [((supU, supU), supplier), ((conU, conU), consumer)]
+        , sdbTechFlows =
+            M.fromList
+                [ (supU, TechnosphereFlow supU "aaa supplier" kgUnit M.empty Nothing Nothing)
+                , (conU, TechnosphereFlow conU "bbb consumer" kgUnit M.empty Nothing Nothing)
+                ]
+        , sdbBioFlows = M.empty
+        , sdbWasteFlows = M.empty
+        , sdbUnits = units1
+        }
+  where
+    supU = read "22222222-0000-4000-8000-000000000001"
+    conU = read "33333333-0000-4000-8000-000000000001"
+    mkAct nm prodU exs = Activity nm [] M.empty M.empty "GLO" "kg" (refOf prodU : exs) M.empty M.empty Nothing Nothing Nothing
+    refOf prodU = TechnosphereExchange prodU 1.0 kgUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+    supplier = mkAct "aaa supplier" supU []
+    -- The consumer's input consumes the supplier's product and links to it.
+    consumer = mkAct "bbb consumer" conU [TechnosphereExchange supU 2.0 kgUnit Input link Nothing "" Nothing Nothing]
+
+-- | The supplier's resolved activity UUID, the value a consumer's input links to.
+supplierLink :: UUID
+supplierLink =
+    generateActivityUUIDFromActivity
+        (Activity "aaa supplier" [] M.empty M.empty "GLO" "kg" [] M.empty M.empty Nothing Nothing Nothing)
+
+{- | A non-nil UUID that no exported activity hashes to, so a consumer input
+carrying it has no resolvable dataset number — a dangling link. Distinct from
+'UUID.nil', which the guard treats as "no link".
+-}
+danglingLink :: UUID
+danglingLink = read "99999999-0000-4000-8000-000000000099"
+
+{- | All supplier-dataset-number values recorded across a parser round-trip of
+@sdb@. 'EcoSpold.Parser1.closeExchange' fills 'psSupplierLinks' (the 7th tuple
+slot) for every technosphere input whose @number@ attribute is non-zero — i.e.
+the supplier dataset number the writer must re-emit. A surviving link therefore
+shows up here as the supplier's dataset number.
+-}
+roundTripSupplierLinks :: SimpleDatabase -> Either String [Int]
+roundTripSupplierLinks sdb =
+    let xml = TE.encodeUtf8 (writeSimpleDatabase canonicalWriterOptions sdb)
+     in case parseAllWithXeno xml of
+            Left err -> Left err
+            Right results ->
+                concatMap (\(_, _, _, _, _, _, links) -> M.elems links) <$> sequence results
+
+-- ---------------------------------------------------------------------------
+-- Order-insensitive observable projection of an activity, for semantic equality
+-- ---------------------------------------------------------------------------
+
+{- | Observable, UUID-free fingerprint of one exchange. Names come from the
+flow tables; everything else is intrinsic to the exchange.
+-}
+data ExchangeView = ExchangeView
+    { evKind :: !Text
+    , evName :: !Text
+    , evAmount :: !Double
+    , evUnit :: !Text
+    , evRole :: !Text
+    , evLocation :: !Text
+    , evCas :: !(Maybe Text)
+    , evComment :: !(Maybe Text)
+    }
+    deriving (Eq, Ord, Show)
+
+exchangeViews :: SimpleDatabase -> Activity -> [ExchangeView]
+exchangeViews sdb = map (exchangeView sdb) . exchanges
+
+exchangeView :: SimpleDatabase -> Exchange -> ExchangeView
+exchangeView sdb ex = case ex of
+    TechnosphereExchange{techFlowId = fid, techRole = role} ->
+        base "tech" (techName fid) (roleText role)
+    BiosphereExchange{bioFlowId = fid, bioDirection = dir} ->
+        base "bio" (bioName fid) (dirText dir)
+    WasteExchange{waFlowId = fid, waIsInput = isInput} ->
+        base "waste" (wasteName fid) (if isInput then "input" else "output")
+  where
+    base kind nm role =
+        ExchangeView
+            { evKind = kind
+            , evName = nm
+            , evAmount = exchangeAmount ex
+            , evUnit = maybe "" unitName (M.lookup (exchangeUnitId ex) (sdbUnits sdb))
+            , evRole = role
+            , evLocation = exchangeLocation ex
+            , evCas = casOf ex
+            , evComment = exchangeComment ex
+            }
+    techName fid = maybe "" tfName (M.lookup fid (sdbTechFlows sdb))
+    bioName fid = maybe "" bfName (M.lookup fid (sdbBioFlows sdb))
+    wasteName fid = maybe "" wfName (M.lookup fid (sdbWasteFlows sdb))
+    casOf e = case e of
+        TechnosphereExchange{techFlowId = fid} -> M.lookup fid (sdbTechFlows sdb) >>= tfCAS
+        BiosphereExchange{bioFlowId = fid} -> M.lookup fid (sdbBioFlows sdb) >>= bfCAS
+        WasteExchange{waFlowId = fid} -> M.lookup fid (sdbWasteFlows sdb) >>= wfCAS
+    roleText r = case r of
+        ReferenceProduct -> "ref"
+        ReferenceInput -> "ref"
+        Coproduct -> "coproduct"
+        Input -> "input"
+    dirText d = case d of
+        Resource -> "resource"
+        Emission -> "emission"
+
+{- | An order-insensitive fingerprint of the whole database: per-activity
+(name, location, unit, classification, sorted exchange views).
+-}
+data ActivityView = ActivityView
+    { avName :: !Text
+    , avLocation :: !Text
+    , avUnit :: !Text
+    , avClassification :: ![(Text, Text)]
+    , avExchanges :: ![ExchangeView]
+    }
+    deriving (Eq, Ord, Show)
+
+dbViews :: SimpleDatabase -> [ActivityView]
+dbViews sdb =
+    sort
+        [ ActivityView
+            { avName = activityName a
+            , avLocation = activityLocation a
+            , avUnit = activityUnit a
+            , avClassification = M.toList (activityClassification a)
+            , avExchanges = sort (exchangeViews sdb a)
+            }
+        | a <- M.elems (sdbActivities sdb)
+        ]
+
+-- ---------------------------------------------------------------------------
+-- Parse helper: write → parse back into a SimpleDatabase
+-- ---------------------------------------------------------------------------
+
+roundTrip :: SimpleDatabase -> Either String SimpleDatabase
+roundTrip sdb =
+    let xml = TE.encodeUtf8 (writeSimpleDatabase canonicalWriterOptions sdb)
+     in case parseAllWithXeno xml of
+            Left err -> Left err
+            Right results -> assembleSimpleDb <$> sequence results
+
+-- | Build a full 'Database' from a 'SimpleDatabase' so we can score it.
+buildDb :: SimpleDatabase -> IO Database
+buildDb sdb = do
+    result <-
+        DB.buildDatabaseWithMatrices
+            defaultUnitConfig
+            (sdbActivities sdb)
+            (sdbTechFlows sdb)
+            (sdbBioFlows sdb)
+            (sdbWasteFlows sdb)
+            (sdbUnits sdb)
+    case result of
+        Left err -> fail ("buildDatabaseWithMatrices failed: " ++ T.unpack err)
+        Right db -> pure db
+
+{- | Direct inventory of the reference activity, keyed by biosphere flow NAME
+(UUIDs are regenerated across a round-trip, names are invariant).
+-}
+inventoryByName :: Database -> IO (M.Map Text Double)
+inventoryByName db = do
+    let pid = 0 -- single-activity fixture
+    inv <- Matrix.computeInventoryMatrix db pid
+    pure $
+        M.fromListWith
+            (+)
+            [ (bfName bf, amt)
+            | (fid, amt) <- M.toList inv
+            , Just bf <- [M.lookup fid (dbBioFlows db)]
+            ]
+
+-- ---------------------------------------------------------------------------
+-- Spec
+-- ---------------------------------------------------------------------------
+
+spec :: Spec
+spec = do
+    describe "escapeXmlAttr" $ do
+        it "escapes the five metacharacters and newlines" $
+            escapeXmlAttr "a<b>&\"'\n"
+                `shouldBe` "a&lt;b&gt;&amp;&quot;&apos;&#10;"
+
+        it "is a left-inverse of the parser's entity decoder (no double-escape)" $
+            -- The lone & must become &amp; exactly once.
+            escapeXmlAttr "Tom & Jerry" `shouldBe` "Tom &amp; Jerry"
+
+    describe "formatAmount" $ do
+        it "normalises negative zero" $
+            formatAmount (-0.0) `shouldBe` "0.0"
+
+        it "keeps a whole number parser-readable" $
+            formatAmount 1.0 `shouldBe` "1.0"
+
+    describe "writeSimpleDatabase" $ do
+        it "emits a well-formed EcoSpold1 document the parser accepts" $ do
+            sdb <- fixtureDb
+            let xml = writeSimpleDatabase canonicalWriterOptions sdb
+            T.isInfixOf "<ecoSpold" xml `shouldBe` True
+            case parseAllWithXeno (TE.encodeUtf8 xml) of
+                Left err -> expectationFailure ("re-parse failed: " ++ err)
+                Right results -> length results `shouldBe` 1
+
+        it "omits volatile attributes under canonicalWriterOptions" $ do
+            sdb <- fixtureDb
+            let xml = writeSimpleDatabase canonicalWriterOptions sdb
+            T.isInfixOf "generator=" xml `shouldBe` False
+            T.isInfixOf "timestamp=" xml `shouldBe` False
+
+        it "includes a pinned generator under defaultWriterOptions" $ do
+            sdb <- fixtureDb
+            let xml = writeSimpleDatabase defaultWriterOptions sdb
+            T.isInfixOf "generator=\"VoLCA\"" xml `shouldBe` True
+
+    describe "round-trip (a) idempotence modulo volatile metadata" $
+        it "write . parse . write == write (canonical)" $ do
+            sdb <- fixtureDb
+            let f0 = writeSimpleDatabase canonicalWriterOptions sdb
+            case parseAllWithXeno (TE.encodeUtf8 f0) of
+                Left err -> expectationFailure ("re-parse failed: " ++ err)
+                Right results -> case sequence results of
+                    Left err -> expectationFailure ("dataset failed: " ++ err)
+                    Right datasets ->
+                        let sdb' = assembleSimpleDb datasets
+                            f1 = writeSimpleDatabase canonicalWriterOptions sdb'
+                         in f1 `shouldBe` f0
+
+    describe "round-trip (b) semantic equality (order-insensitive)" $
+        it "parse(write(D)) reproduces the observable structure of D" $ do
+            sdb <- fixtureDb
+            case roundTrip sdb of
+                Left err -> expectationFailure ("round-trip failed: " ++ err)
+                Right sdb' -> dbViews sdb' `shouldBe` dbViews sdb
+
+    describe "round-trip (c) score-equivalence" $
+        it "yields the same direct biosphere inventory within tolerance" $ do
+            sdb <- fixtureDb
+            case roundTrip sdb of
+                Left err -> expectationFailure ("round-trip failed: " ++ err)
+                Right sdb' -> do
+                    db0 <- buildDb sdb
+                    db1 <- buildDb sdb'
+                    inv0 <- inventoryByName db0
+                    inv1 <- inventoryByName db1
+                    M.keys inv1 `shouldBe` M.keys inv0
+                    let near a b = abs (a - b) < 1e-9
+                    and (M.elems (M.intersectionWith near inv0 inv1)) `shouldBe` True
+                    M.null inv0 `shouldBe` False
+
+    describe "supplier links (multi-dataset)" $ do
+        it "re-emits a resolved supplier link as the supplier's dataset number" $
+            -- "aaa supplier" sorts first → dataset 1; the consumer's input links
+            -- to it, so the parser reads its number attribute back as 1.
+            roundTripSupplierLinks (linkedDb supplierLink) `shouldBe` Right [1]
+
+        it "passes the export-boundary check when the link targets an exported dataset" $
+            checkEcoSpold1Exportable (linkedDb supplierLink) `shouldBe` Right ()
+
+        it "rejects a dangling supplier link rather than emitting a wrong dataset number" $
+            -- The link targets a UUID not among the exported datasets, so its
+            -- dataset number is unknown; fail loudly instead of mislabelling it.
+            checkEcoSpold1Exportable (linkedDb danglingLink) `shouldSatisfy` isLeft
+
+    describe "empty database" $ do
+        it "writes a well-formed, dataset-free document the parser accepts" $
+            case parseAllWithXeno (TE.encodeUtf8 (writeSimpleDatabase canonicalWriterOptions emptyDb)) of
+                Left err -> expectationFailure ("re-parse failed: " ++ err)
+                Right results -> length results `shouldBe` 0
+
+        it "is exportable" $
+            checkEcoSpold1Exportable emptyDb `shouldBe` Right ()
+
+    describe "escaping / unicode" $
+        it "round-trips XML metacharacters and non-ASCII in names" $ do
+            let nm = "Cu <ore> & «café» 95% — 1\"" :: Text
+                prodU = read "44444444-0000-4000-8000-000000000001" :: UUID
+                sdb = soloDb nm prodU [] M.empty M.empty M.empty
+            case roundTrip sdb of
+                Left err -> expectationFailure ("round-trip failed: " ++ err)
+                Right sdb' -> map activityName (M.elems (sdbActivities sdb')) `shouldBe` [nm]
+
+    describe "Final waste flows" $
+        it "round-trips a waste output as a waste flow (not a coproduct)" $ do
+            let prodU = read "55555555-0000-4000-8000-000000000001" :: UUID
+                wasteU = read "55555555-0000-4000-8000-0000000000a0" :: UUID
+                wasteEx = WasteExchange wasteU 0.3 kgUnit False UUID.nil Nothing "" Nothing Nothing
+                wastes = M.singleton wasteU (WasteFlow wasteU "spent solvent" kgUnit M.empty Nothing Nothing)
+                sdb = soloDb "solvent user" prodU [wasteEx] M.empty M.empty wastes
+            case roundTrip sdb of
+                Left err -> expectationFailure ("round-trip failed: " ++ err)
+                Right sdb' -> do
+                    map wfName (M.elems (sdbWasteFlows sdb')) `shouldBe` ["spent solvent"]
+                    let isWasteOutput WasteExchange{waIsInput = i} = not i
+                        isWasteOutput TechnosphereExchange{} = False
+                        isWasteOutput BiosphereExchange{} = False
+                    any isWasteOutput (concatMap exchanges (M.elems (sdbActivities sdb'))) `shouldBe` True
+
+    describe "non-finite amounts" $
+        it "rejects an Infinity exchange amount rather than exporting it as 0.0" $ do
+            let prodU = read "66666666-0000-4000-8000-000000000001" :: UUID
+                bioU = read "66666666-0000-4000-8000-0000000000c0" :: UUID
+                bioEx = BiosphereExchange bioU (1 / 0) kgUnit Emission "" Nothing Nothing
+                bios = M.singleton bioU (BiosphereFlow bioU "Carbon dioxide" kgUnit M.empty Nothing Nothing Nothing)
+                sdb = soloDb "leaky process" prodU [bioEx] M.empty bios M.empty
+            checkEcoSpold1Exportable sdb `shouldSatisfy` isLeft

--- a/test/EcoSpold1WriterSpec.hs
+++ b/test/EcoSpold1WriterSpec.hs
@@ -97,11 +97,10 @@ assembleSimpleDb datasets =
         , sdbUnits = M.fromList [(unitId u, u) | (_, _, _, _, us, _, _) <- datasets, u <- us]
         }
 
-{- | The (activityUUID, productUUID) key the matrix builder expects. We use the
-reference exchange's flow id as the product, and derive a stable activity id
-from name+location via the same namespace the Loader uses is unnecessary
-here: the writer round-trip only depends on flow ids, so any injective key
-works. We reuse the reference product flow id for both slots.
+{- | An injective @(activityUUID, productUUID)@ key for the matrix builder. The
+writer round-trip depends only on flow ids, not on this key, so any injective
+choice works: we reuse the reference product's flow id (falling back to the
+first exchange's) for both slots.
 -}
 processKey :: Activity -> (UUID, UUID)
 processKey act =
@@ -410,7 +409,9 @@ spec = do
                     inv0 <- inventoryByName db0
                     inv1 <- inventoryByName db1
                     M.keys inv1 `shouldBe` M.keys inv0
-                    let near a b = abs (a - b) < 1e-9
+                    -- Relative tolerance with an absolute floor, so the check
+                    -- holds across magnitudes rather than only near unity.
+                    let near a b = abs (a - b) <= 1e-9 * max 1 (max (abs a) (abs b))
                     and (M.elems (M.intersectionWith near inv0 inv1)) `shouldBe` True
                     M.null inv0 `shouldBe` False
 
@@ -449,8 +450,11 @@ spec = do
             checkEcoSpold1Exportable emptyDb `shouldBe` Right ()
 
     describe "escaping / unicode" $
-        it "round-trips XML metacharacters and non-ASCII in names" $ do
-            let nm = "Cu <ore> & «café» 95% — 1\"" :: Text
+        it "round-trips XML metacharacters, newlines, and non-ASCII in names" $ do
+            -- The \r and \n exercise the &#13; / &#10; numeric entities end to
+            -- end (escapeXmlAttr → parser's decodeXmlEntities), not just at the
+            -- byte level the escapeXmlAttr unit test covers.
+            let nm = "Cu <ore> & «café»\r\n95% — 1\"" :: Text
                 prodU = read "44444444-0000-4000-8000-000000000001" :: UUID
                 sdb = soloDb nm prodU [] M.empty M.empty M.empty
             case roundTrip sdb of
@@ -519,3 +523,38 @@ spec = do
                 bios = M.singleton bioU (BiosphereFlow bioU "trace" kgUnit M.empty Nothing Nothing Nothing)
                 sdb = soloDb "subnormal emitter" prodU [bioEx] M.empty bios M.empty
             checkEcoSpold1Exportable sdb `shouldSatisfy` isLeft
+
+    describe "general comment (activity description)" $
+        it "re-imports a multi-paragraph description as one joined paragraph" $ do
+            -- generalComment is a single ES1 attribute, so paragraph cardinality
+            -- does not round-trip: the joined text survives, but the parser reads
+            -- it back as one element. This pins that documented behaviour.
+            let prodU = read "cccc0000-0000-4000-8000-000000000001" :: UUID
+                ref = TechnosphereExchange prodU 1.0 kgUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+                act =
+                    Activity
+                        "documented process"
+                        ["first paragraph", "second paragraph"]
+                        M.empty
+                        M.empty
+                        "GLO"
+                        "kg"
+                        [ref]
+                        M.empty
+                        M.empty
+                        Nothing
+                        Nothing
+                        Nothing
+                sdb =
+                    SimpleDatabase
+                        { sdbActivities = M.singleton (prodU, prodU) act
+                        , sdbTechFlows = M.singleton prodU (TechnosphereFlow prodU "documented process" kgUnit M.empty Nothing Nothing)
+                        , sdbBioFlows = M.empty
+                        , sdbWasteFlows = M.empty
+                        , sdbUnits = units1
+                        }
+            case roundTrip sdb of
+                Left err -> expectationFailure ("round-trip failed: " ++ err)
+                Right sdb' ->
+                    map activityDescription (M.elems (sdbActivities sdb'))
+                        `shouldBe` [["first paragraph\nsecond paragraph"]]

--- a/test/EcoSpold1WriterSpec.hs
+++ b/test/EcoSpold1WriterSpec.hs
@@ -428,6 +428,16 @@ spec = do
             -- dataset number is unknown; fail loudly instead of mislabelling it.
             checkEcoSpold1Exportable (linkedDb danglingLink) `shouldSatisfy` isLeft
 
+        it "preserves a linked input semantically across a write→parse round-trip" $
+            -- SimpleDatabase carries no supplier link, so a bare re-parse can't
+            -- reproduce the raw dataset-number byte-for-byte (the module doc's
+            -- linked-input caveat). What must survive — and does — is the
+            -- semantic content the loader re-links on: flow name, amount, role,
+            -- unit. The idempotence test (a) uses an unlinked fixture, so this is
+            -- the only check that exercises a linked input end to end.
+            (dbViews <$> roundTrip (linkedDb supplierLink))
+                `shouldBe` Right (dbViews (linkedDb supplierLink))
+
     describe "empty database" $ do
         it "writes a well-formed, dataset-free document the parser accepts" $ do
             xml <- writeOk canonicalWriterOptions emptyDb
@@ -497,3 +507,15 @@ spec = do
                 Right sdb' ->
                     concatMap (exchangeViews sdb') (M.elems (sdbActivities sdb'))
                         `shouldSatisfy` any ((== 3.3e-20) . evAmount)
+
+    describe "non-round-tripping amounts" $
+        it "rejects a subnormal amount that re-parses to zero rather than undercounting" $ do
+            -- 5e-324 is finite but its fixed-point form carries too few
+            -- significant digits for Data.Text.Read.double to recover, so it
+            -- would silently export as 0; the guard rejects it instead.
+            let prodU = read "aaaa0000-0000-4000-8000-000000000001" :: UUID
+                bioU = read "aaaa0000-0000-4000-8000-0000000000c0" :: UUID
+                bioEx = BiosphereExchange bioU 5e-324 kgUnit Emission "" Nothing Nothing
+                bios = M.singleton bioU (BiosphereFlow bioU "trace" kgUnit M.empty Nothing Nothing Nothing)
+                sdb = soloDb "subnormal emitter" prodU [bioEx] M.empty bios M.empty
+            checkEcoSpold1Exportable sdb `shouldSatisfy` isLeft

--- a/test/EcoSpold1WriterSpec.hs
+++ b/test/EcoSpold1WriterSpec.hs
@@ -28,7 +28,6 @@ import Test.Hspec
 
 import qualified Database as DB
 import Database.Loader (generateActivityUUIDFromActivity)
-import EcoSpold.Cutoff (applyCutoffStrategy)
 import EcoSpold.Parser1 (parseAllWithXeno)
 import EcoSpold.Writer1
 import qualified Matrix
@@ -127,8 +126,9 @@ kgUnit = read "11111111-0000-4000-8000-000000000001"
 units1 :: UnitDB
 units1 = M.singleton kgUnit (Unit kgUnit "kg" "kg" "")
 
--- | A single-activity database with one reference product and the given
--- extra exchanges, named @name@ so its flows resolve from @techs@/@bios@/@wastes@.
+{- | A single-activity database with one reference product and the given
+extra exchanges, named @name@ so its flows resolve from @techs@/@bios@/@wastes@.
+-}
 soloDb :: Text -> UUID -> [Exchange] -> TechFlowDB -> BioFlowDB -> WasteFlowDB -> SimpleDatabase
 soloDb name prodU extra techs bios wastes =
     SimpleDatabase
@@ -195,11 +195,13 @@ shows up here as the supplier's dataset number.
 -}
 roundTripSupplierLinks :: SimpleDatabase -> Either String [Int]
 roundTripSupplierLinks sdb =
-    let xml = TE.encodeUtf8 (writeSimpleDatabase canonicalWriterOptions sdb)
-     in case parseAllWithXeno xml of
-            Left err -> Left err
-            Right results ->
-                concatMap (\(_, _, _, _, _, _, links) -> M.elems links) <$> sequence results
+    case writeSimpleDatabase canonicalWriterOptions sdb of
+        Left e -> Left (T.unpack e)
+        Right txt ->
+            case parseAllWithXeno (TE.encodeUtf8 txt) of
+                Left err -> Left err
+                Right results ->
+                    concatMap (\(_, _, _, _, _, _, links) -> M.elems links) <$> sequence results
 
 -- ---------------------------------------------------------------------------
 -- Order-insensitive observable projection of an activity, for semantic equality
@@ -290,10 +292,20 @@ dbViews sdb =
 
 roundTrip :: SimpleDatabase -> Either String SimpleDatabase
 roundTrip sdb =
-    let xml = TE.encodeUtf8 (writeSimpleDatabase canonicalWriterOptions sdb)
-     in case parseAllWithXeno xml of
-            Left err -> Left err
-            Right results -> assembleSimpleDb <$> sequence results
+    case writeSimpleDatabase canonicalWriterOptions sdb of
+        Left e -> Left (T.unpack e)
+        Right txt ->
+            case parseAllWithXeno (TE.encodeUtf8 txt) of
+                Left err -> Left err
+                Right results -> assembleSimpleDb <$> sequence results
+
+{- | Unwrap the guard-returning writer for a fixture known to be exportable,
+failing the test on an unexpected 'Left'.
+-}
+writeOk :: WriterOptions -> SimpleDatabase -> IO Text
+writeOk opts sdb =
+    either (\e -> expectationFailure (T.unpack e) >> pure "") pure $
+        writeSimpleDatabase opts sdb
 
 -- | Build a full 'Database' from a 'SimpleDatabase' so we can score it.
 buildDb :: SimpleDatabase -> IO Database
@@ -350,7 +362,7 @@ spec = do
     describe "writeSimpleDatabase" $ do
         it "emits a well-formed EcoSpold1 document the parser accepts" $ do
             sdb <- fixtureDb
-            let xml = writeSimpleDatabase canonicalWriterOptions sdb
+            xml <- writeOk canonicalWriterOptions sdb
             T.isInfixOf "<ecoSpold" xml `shouldBe` True
             case parseAllWithXeno (TE.encodeUtf8 xml) of
                 Left err -> expectationFailure ("re-parse failed: " ++ err)
@@ -358,27 +370,27 @@ spec = do
 
         it "omits volatile attributes under canonicalWriterOptions" $ do
             sdb <- fixtureDb
-            let xml = writeSimpleDatabase canonicalWriterOptions sdb
+            xml <- writeOk canonicalWriterOptions sdb
             T.isInfixOf "generator=" xml `shouldBe` False
             T.isInfixOf "timestamp=" xml `shouldBe` False
 
         it "includes a pinned generator under defaultWriterOptions" $ do
             sdb <- fixtureDb
-            let xml = writeSimpleDatabase defaultWriterOptions sdb
+            xml <- writeOk defaultWriterOptions sdb
             T.isInfixOf "generator=\"VoLCA\"" xml `shouldBe` True
 
     describe "round-trip (a) idempotence modulo volatile metadata" $
         it "write . parse . write == write (canonical)" $ do
             sdb <- fixtureDb
-            let f0 = writeSimpleDatabase canonicalWriterOptions sdb
+            f0 <- writeOk canonicalWriterOptions sdb
             case parseAllWithXeno (TE.encodeUtf8 f0) of
                 Left err -> expectationFailure ("re-parse failed: " ++ err)
                 Right results -> case sequence results of
                     Left err -> expectationFailure ("dataset failed: " ++ err)
-                    Right datasets ->
+                    Right datasets -> do
                         let sdb' = assembleSimpleDb datasets
-                            f1 = writeSimpleDatabase canonicalWriterOptions sdb'
-                         in f1 `shouldBe` f0
+                        f1 <- writeOk canonicalWriterOptions sdb'
+                        f1 `shouldBe` f0
 
     describe "round-trip (b) semantic equality (order-insensitive)" $
         it "parse(write(D)) reproduces the observable structure of D" $ do
@@ -417,8 +429,9 @@ spec = do
             checkEcoSpold1Exportable (linkedDb danglingLink) `shouldSatisfy` isLeft
 
     describe "empty database" $ do
-        it "writes a well-formed, dataset-free document the parser accepts" $
-            case parseAllWithXeno (TE.encodeUtf8 (writeSimpleDatabase canonicalWriterOptions emptyDb)) of
+        it "writes a well-formed, dataset-free document the parser accepts" $ do
+            xml <- writeOk canonicalWriterOptions emptyDb
+            case parseAllWithXeno (TE.encodeUtf8 xml) of
                 Left err -> expectationFailure ("re-parse failed: " ++ err)
                 Right results -> length results `shouldBe` 0
 
@@ -458,3 +471,29 @@ spec = do
                 bios = M.singleton bioU (BiosphereFlow bioU "Carbon dioxide" kgUnit M.empty Nothing Nothing Nothing)
                 sdb = soloDb "leaky process" prodU [bioEx] M.empty bios M.empty
             checkEcoSpold1Exportable sdb `shouldSatisfy` isLeft
+
+    describe "reference input (treatment process)" $
+        it "rejects a ReferenceInput rather than flipping it to a reference product" $ do
+            -- EcoSpold1 has no marker for a reference input; emitting outputGroup 0
+            -- would re-parse it as a reference product (input → output flip).
+            let prodU = read "77777777-0000-4000-8000-000000000001" :: UUID
+                refInU = read "77777777-0000-4000-8000-0000000000a0" :: UUID
+                refInEx = TechnosphereExchange refInU 1.0 kgUnit ReferenceInput UUID.nil Nothing "" Nothing Nothing
+                techs = M.singleton refInU (TechnosphereFlow refInU "waste to treat" kgUnit M.empty Nothing Nothing)
+                sdb = soloDb "treatment process" prodU [refInEx] techs M.empty M.empty
+            checkEcoSpold1Exportable sdb `shouldSatisfy` isLeft
+
+    describe "numeric round-trip" $
+        it "round-trips a small-exponent amount without scientific-notation loss" $ do
+            -- show 3.3e-20 emits scientific notation that re-reads lossily;
+            -- showFFloatTrim keeps it value-identical across the round-trip.
+            let prodU = read "88888888-0000-4000-8000-000000000001" :: UUID
+                bioU = read "88888888-0000-4000-8000-0000000000c0" :: UUID
+                bioEx = BiosphereExchange bioU 3.3e-20 kgUnit Emission "" Nothing Nothing
+                bios = M.singleton bioU (BiosphereFlow bioU "dioxin" kgUnit M.empty Nothing Nothing Nothing)
+                sdb = soloDb "trace emitter" prodU [bioEx] M.empty bios M.empty
+            case roundTrip sdb of
+                Left err -> expectationFailure ("round-trip failed: " ++ err)
+                Right sdb' ->
+                    concatMap (exchangeViews sdb') (M.elems (sdbActivities sdb'))
+                        `shouldSatisfy` any ((== 3.3e-20) . evAmount)

--- a/test/EcoSpold1WriterSpec.hs
+++ b/test/EcoSpold1WriterSpec.hs
@@ -524,6 +524,19 @@ spec = do
                 sdb = soloDb "subnormal emitter" prodU [bioEx] M.empty bios M.empty
             checkEcoSpold1Exportable sdb `shouldSatisfy` isLeft
 
+    describe "waste-marker collision" $
+        it "rejects a biosphere flow whose compartment is the waste-routing category" $ do
+            -- "Final waste flows" is the parser's waste-routing marker, tested
+            -- before the biosphere group, so a biosphere flow carrying it as its
+            -- compartment name would silently re-import as a waste exchange.
+            let prodU = read "bbbb0000-0000-4000-8000-000000000001" :: UUID
+                bioU = read "bbbb0000-0000-4000-8000-0000000000c0" :: UUID
+                comp = Compartment "Final waste flows" Nothing
+                bioEx = BiosphereExchange bioU 0.05 kgUnit Emission "" Nothing Nothing
+                bios = M.singleton bioU (BiosphereFlow bioU "oddly classified" kgUnit M.empty Nothing Nothing (Just comp))
+                sdb = soloDb "confused process" prodU [bioEx] M.empty bios M.empty
+            checkEcoSpold1Exportable sdb `shouldSatisfy` isLeft
+
     describe "general comment (activity description)" $
         it "re-imports a multi-paragraph description as one joined paragraph" $ do
             -- generalComment is a single ES1 attribute, so paragraph cardinality

--- a/test/EcoSpold2WriterSpec.hs
+++ b/test/EcoSpold2WriterSpec.hs
@@ -1,0 +1,536 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Round-trip contract for the EcoSpold2 writer ('EcoSpold.Writer2'), the
+inverse of 'EcoSpold.Parser2'.
+
+We exercise three properties against a self-contained fixture 'SimpleDatabase'
+built in Haskell:
+
+  (a) __idempotence modulo volatile metadata__ — @write(D)@ then
+      @write(parse(write(D)))@ produce byte-identical output once volatile
+      metadata is excluded (we exclude it by writing with 'noVolatileMeta').
+  (b) __semantic round-trip__ — @parse(write(D))@ is structurally equal to @D@
+      (order-insensitive on exchanges/flows).
+  (c) __score-equivalence__ — @parse(write(D))@ yields the same LCIA inventory
+      (the engine's matrix-level score input) as @D@ within tolerance.
+
+The fixture is constructed directly rather than loaded from a bundled
+@.spold@ directory because the bundled @SAMPLE.units@ fixture deliberately
+reuses a single @unitId@ across flows with *different* unit-name strings (a
+degenerate-input stress test for the parser). The loader collapses those to
+one unit per UUID in name-resolution order, which depends on filename
+ordering — a property of the loader on malformed input, not of the writer.
+A clean fixture (one name per unit UUID, distinct flow UUIDs) isolates the
+writer's own determinism, which is what this spec asserts.
+-}
+module EcoSpold2WriterSpec (spec) where
+
+import Control.Monad (forM_)
+import qualified Data.ByteString as BS
+import Data.Either (isLeft)
+import Data.List (sort, sortOn)
+import qualified Data.Map.Strict as M
+import Data.Maybe (fromMaybe)
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import Database (buildDatabaseWithMatrices)
+import Database.Loader (loadDatabase)
+import EcoSpold.Writer2 (VolatileMeta (..), checkEcoSpold2Exportable, noVolatileMeta, writeEcoSpold2)
+import Matrix (computeInventoryMatrix)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+import Types
+import UnitConversion (defaultUnitConfig)
+
+-- | A UUID from its canonical text, or nil if (impossibly) malformed.
+uuid :: Text -> UUID.UUID
+uuid t = fromMaybe UUID.nil (UUID.fromText t)
+
+-- Distinct, well-formed UUIDs for the fixture.
+actA, prodA, actB, prodB :: UUID.UUID
+actA = uuid "aaaaaaaa-0000-4000-8000-000000000001"
+prodA = uuid "aaaaaaaa-0000-4000-8000-0000000000a1"
+actB = uuid "bbbbbbbb-0000-4000-8000-000000000002"
+prodB = uuid "bbbbbbbb-0000-4000-8000-0000000000b2"
+
+co2, land :: UUID.UUID
+co2 = uuid "cccccccc-0000-4000-8000-0000000000c0"
+land = uuid "dddddddd-0000-4000-8000-0000000000d0"
+
+unitKg, unitMJ, unitM2a :: UUID.UUID
+unitKg = uuid "11111111-0000-4000-8000-000000000001"
+unitMJ = uuid "22222222-0000-4000-8000-000000000002"
+unitM2a = uuid "33333333-0000-4000-8000-000000000003"
+
+{- | A self-contained two-activity EcoSpold2 database.
+
+  * Activity A produces product A (1 kg), consumes 2 MJ of product B, and
+    emits 0.5 kg CO2 (biosphere).
+  * Activity B produces product B (1 MJ) and occupies 0.1 m2*year of land.
+
+Every unit UUID maps to exactly one name; every flow UUID is distinct.
+-}
+fixtureSimple :: SimpleDatabase
+fixtureSimple =
+    SimpleDatabase
+        { sdbActivities =
+            M.fromList
+                [ ((actA, prodA), activityA)
+                , ((actB, prodB), activityB)
+                ]
+        , sdbTechFlows =
+            M.fromList
+                [ (prodA, TechnosphereFlow prodA "product A" unitKg M.empty Nothing Nothing)
+                , (prodB, TechnosphereFlow prodB "product B" unitMJ M.empty Nothing Nothing)
+                ]
+        , sdbBioFlows =
+            M.fromList
+                [ (co2, BiosphereFlow co2 "Carbon dioxide, fossil" unitKg M.empty (Just "124-38-9") Nothing (Just (Compartment "air" (Just "unspecified"))))
+                , (land, BiosphereFlow land "Occupation, arable land" unitM2a M.empty Nothing Nothing (Just (Compartment "natural resource" (Just "land"))))
+                ]
+        , sdbWasteFlows = M.empty
+        , sdbUnits =
+            M.fromList
+                [ (unitKg, Unit unitKg "kg" "kg" "")
+                , (unitMJ, Unit unitMJ "MJ" "MJ" "")
+                , (unitM2a, Unit unitM2a "m2*year" "m2*year" "")
+                ]
+        }
+  where
+    activityA =
+        Activity
+            "production of A & B <café> ☕"
+            ["First fixture activity: a & b <c> — ünïcödé"]
+            M.empty
+            (M.fromList [("ISIC rev.4 ecoinvent", "2011:Manufacture of food products"), ("CPC", "2399: Other food products n.e.c.")])
+            "GLO"
+            "kg"
+            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , TechnosphereExchange prodB 2.0 unitMJ Input actB Nothing "" (Just "energy input") Nothing
+            , BiosphereExchange co2 0.5 unitKg Emission "" Nothing Nothing
+            ]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            (Just (EcoSpoldActivityType 1 "Ordinary transforming activity" Nothing Nothing))
+    activityB =
+        Activity
+            "production of B"
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "MJ"
+            [ TechnosphereExchange prodB 1.0 unitMJ ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , BiosphereExchange land 0.1 unitM2a Resource "" Nothing Nothing
+            ]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            (Just (EcoSpoldActivityType 2 "Market activity" (Just 1) (Just "Hard link")))
+
+-- | The fixture as a 'SimpleDatabase' (matches the previous IO-shaped helper).
+loadFixtureSimple :: IO SimpleDatabase
+loadFixtureSimple = pure fixtureSimple
+
+{- | A single-activity database whose only activity emits the same biosphere
+flow (CO2) twice with distinct amounts (0.5 and 0.3). Used to prove the writer
+emits both lines and the round-trip preserves the multiset rather than
+collapsing duplicates on the shared sort key.
+-}
+fixtureDupBio :: SimpleDatabase
+fixtureDupBio =
+    SimpleDatabase
+        { sdbActivities = M.singleton (actA, prodA) activityDup
+        , sdbTechFlows = M.singleton prodA (TechnosphereFlow prodA "product A" unitKg M.empty Nothing Nothing)
+        , sdbBioFlows = M.singleton co2 (BiosphereFlow co2 "Carbon dioxide, fossil" unitKg M.empty Nothing Nothing (Just (Compartment "air" (Just "unspecified"))))
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton unitKg (Unit unitKg "kg" "kg" "")
+        }
+  where
+    activityDup =
+        Activity
+            "production of A"
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "kg"
+            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , BiosphereExchange co2 0.5 unitKg Emission "" Nothing Nothing
+            , BiosphereExchange co2 0.3 unitKg Emission "" Nothing Nothing
+            ]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            (Just (EcoSpoldActivityType 1 "Ordinary transforming activity" Nothing Nothing))
+
+{- | A single-activity database wrapping one adversarial exchange. The
+exchange is the only difference between the rejection fixtures, so the export
+guard ('checkEcoSpold2Exportable') is exercised in isolation.
+-}
+fixtureWithExchange :: Exchange -> SimpleDatabase
+fixtureWithExchange ex =
+    SimpleDatabase
+        { sdbActivities = M.singleton (actA, prodA) activity
+        , sdbTechFlows = M.singleton prodA (TechnosphereFlow prodA "product A" unitKg M.empty Nothing Nothing)
+        , sdbBioFlows = M.singleton co2 (BiosphereFlow co2 "Carbon dioxide, fossil" unitKg M.empty Nothing Nothing (Just (Compartment "air" (Just "unspecified"))))
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton unitKg (Unit unitKg "kg" "kg" "")
+        }
+  where
+    activity =
+        Activity
+            "adversarial activity"
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "kg"
+            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , ex
+            ]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            (Just (EcoSpoldActivityType 1 "Ordinary transforming activity" Nothing Nothing))
+
+{- | A single-activity database whose biosphere flow carries synonyms, so the
+writer's @\<synonym\>@ emission and the parser's read-back are exercised end to
+end (the other fixtures all pass empty synonym maps).
+-}
+fixtureWithBioSynonyms :: SimpleDatabase
+fixtureWithBioSynonyms =
+    SimpleDatabase
+        { sdbActivities = M.singleton (actA, prodA) activity
+        , sdbTechFlows = M.singleton prodA (TechnosphereFlow prodA "product A" unitKg M.empty Nothing Nothing)
+        , sdbBioFlows =
+            M.singleton
+                co2
+                (BiosphereFlow co2 "Carbon dioxide, fossil" unitKg syns (Just "124-38-9") Nothing (Just (Compartment "air" (Just "unspecified"))))
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton unitKg (Unit unitKg "kg" "kg" "")
+        }
+  where
+    syns = M.singleton "en" (S.fromList ["CO2", "carbonic anhydride"])
+    activity =
+        Activity
+            "synonym activity"
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "kg"
+            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , BiosphereExchange co2 0.5 unitKg Emission "" Nothing Nothing
+            ]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            Nothing
+
+{- | A single activity exercising the subtlest inversion paths: a coproduct
+(outputGroup 2) and waste exchanges in both directions (waIsInput controls
+inputGroup 5 vs outputGroup 2). These round-trip paths were previously
+untested.
+-}
+fixtureWasteCoproduct :: SimpleDatabase
+fixtureWasteCoproduct =
+    SimpleDatabase
+        { sdbActivities = M.singleton (actA, prodA) activity
+        , sdbTechFlows =
+            M.fromList
+                [ (prodA, TechnosphereFlow prodA "product A" unitKg M.empty Nothing Nothing)
+                , (coprodU, TechnosphereFlow coprodU "co-product" unitKg M.empty Nothing Nothing)
+                ]
+        , sdbBioFlows = M.empty
+        , sdbWasteFlows =
+            M.fromList
+                [ (wasteInU, WasteFlow wasteInU "incoming waste" unitKg M.empty Nothing Nothing)
+                , (wasteOutU, WasteFlow wasteOutU "outgoing waste" unitKg M.empty Nothing Nothing)
+                ]
+        , sdbUnits = M.singleton unitKg (Unit unitKg "kg" "kg" "")
+        }
+  where
+    coprodU, wasteInU, wasteOutU :: UUID
+    coprodU = read "dddddddd-0000-4000-8000-000000000001"
+    wasteInU = read "dddddddd-0000-4000-8000-000000000002"
+    wasteOutU = read "dddddddd-0000-4000-8000-000000000003"
+    activity =
+        Activity
+            "waste and coproduct activity"
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "kg"
+            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , TechnosphereExchange coprodU 0.4 unitKg Coproduct UUID.nil Nothing "" Nothing Nothing
+            , WasteExchange wasteInU 0.2 unitKg True UUID.nil Nothing "" Nothing Nothing
+            , WasteExchange wasteOutU 0.3 unitKg False UUID.nil Nothing "" Nothing Nothing
+            ]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            (Just (EcoSpoldActivityType 1 "Ordinary transforming activity" Nothing Nothing))
+
+-- | Build a full 'Database' (with matrices) from a 'SimpleDatabase'.
+buildDb :: SimpleDatabase -> IO Database
+buildDb sdb = do
+    res <-
+        buildDatabaseWithMatrices
+            defaultUnitConfig
+            (sdbActivities sdb)
+            (sdbTechFlows sdb)
+            (sdbBioFlows sdb)
+            (sdbWasteFlows sdb)
+            (sdbUnits sdb)
+    case res of
+        Left err -> error $ "matrix build failed: " ++ T.unpack err
+        Right db -> pure db
+
+-- | Unwrap the guard-returning writer for a fixture known to be exportable.
+writeOrFail :: VolatileMeta -> SimpleDatabase -> [(FilePath, Text)]
+writeOrFail meta sdb =
+    either (\e -> error ("writeEcoSpold2: " <> T.unpack e)) id (writeEcoSpold2 meta sdb)
+
+{- | Write a 'SimpleDatabase' with the given volatile metadata to a fresh temp
+directory and re-load it through the production loader, returning the
+round-tripped 'SimpleDatabase'.
+-}
+roundTripWith :: VolatileMeta -> SimpleDatabase -> IO SimpleDatabase
+roundTripWith meta sdb = withSystemTempDirectory "es2-writer" $ \dir -> do
+    -- Write UTF-8 bytes explicitly so the unicode round-trip does not depend on
+    -- the test runner's locale encoding (the loader always decodes UTF-8).
+    forM_ (writeOrFail meta sdb) $ \(fname, doc) ->
+        BS.writeFile (dir </> fname) (TE.encodeUtf8 doc)
+    res <- loadDatabase defaultUnitConfig dir
+    case res of
+        Left err -> error $ "reparse failed: " ++ T.unpack err
+        Right sdb' -> pure sdb'
+
+-- | Round-trip with the byte-stable default (no volatile metadata).
+roundTrip :: SimpleDatabase -> IO SimpleDatabase
+roundTrip = roundTripWith noVolatileMeta
+
+{- | Assert the round-tripped database yields the same per-process LCI as the
+original, within tolerance. Factored out so several fixtures can be checked.
+-}
+assertInventoryRoundTrips :: SimpleDatabase -> IO ()
+assertInventoryRoundTrips sdb = do
+    sdb' <- roundTrip sdb
+    db <- buildDb sdb
+    db' <- buildDb sdb'
+    let pids = [0 .. fromIntegral (V.length (dbProcessIdTable db)) - 1] :: [ProcessId]
+    forM_ pids $ \pid -> do
+        inv <- computeInventoryMatrix db pid
+        -- The round-tripped DB may order activities differently; locate the
+        -- matching process by its (actUUID, prodUUID) key.
+        let key = dbProcessIdTable db V.! fromIntegral pid
+        case V.elemIndex key (dbProcessIdTable db') of
+            Nothing -> expectationFailure $ "process key missing after round-trip: " ++ show key
+            Just pid' -> do
+                inv' <- computeInventoryMatrix db' (fromIntegral pid')
+                inventoriesClose inv inv' `shouldBe` True
+
+spec :: Spec
+spec = describe "EcoSpold2 writer round-trip" $ do
+    -- (a) Idempotence modulo volatile metadata.
+    it "is idempotent modulo volatile metadata: write . parse . write == write" $ do
+        sdb <- loadFixtureSimple
+        let f0 = writeOrFail noVolatileMeta sdb
+        sdb' <- roundTrip sdb
+        let f1 = writeOrFail noVolatileMeta sdb'
+        -- Compare the sorted (filename, document) sequences byte-for-byte.
+        sortOn fst f1 `shouldBe` sortOn fst f0
+
+    -- The volatile-metadata paths (creationTimestamp element + generator
+    -- comment) are otherwise unexercised, since every other case uses
+    -- 'noVolatileMeta'. Pin both and assert they (1) reach the output and
+    -- (2) are non-semantic: the parser ignores them, so the round-tripped
+    -- activities match the byte-stable default exactly.
+    it "emits pinned volatile metadata that the parser then ignores" $ do
+        sdb <- loadFixtureSimple
+        let meta = VolatileMeta (Just "2020-01-02T03:04:05") (Just "writer-spec <gen> & co")
+        let docs = writeOrFail meta sdb
+        any (T.isInfixOf "2020-01-02T03:04:05" . snd) docs `shouldBe` True
+        any (T.isInfixOf "writer-spec" . snd) docs `shouldBe` True
+        pinned <- roundTripWith meta sdb
+        plain <- roundTrip sdb
+        M.keys (sdbActivities pinned) `shouldMatchList` M.keys (sdbActivities plain)
+        forM_ (M.toList (sdbActivities plain)) $ \(key, act) ->
+            case M.lookup key (sdbActivities pinned) of
+                Nothing -> expectationFailure $ "activity missing under pinned metadata: " ++ show key
+                Just act' ->
+                    sort (map exchangeFingerprint (exchanges act'))
+                        `shouldBe` sort (map exchangeFingerprint (exchanges act))
+
+    -- Regression: two exchanges sharing a sort key (same kind + flow) must both
+    -- survive write→parse. A Map-based sort would silently drop one,
+    -- undercounting the inventory; we assert the amounts survive as a multiset.
+    it "keeps duplicate exchanges of the same flow (no silent dedup)" $ do
+        sdb' <- roundTrip fixtureDupBio
+        case M.lookup (actA, prodA) (sdbActivities sdb') of
+            Nothing -> expectationFailure "duplicate-exchange activity missing after round-trip"
+            Just act ->
+                sort [exchangeAmount ex | ex <- exchanges act, isBiosphereExchange ex]
+                    `shouldBe` [0.3, 0.5]
+
+    -- Regression: the subtlest inversion paths. renderWaste maps waIsInput to
+    -- inputGroup 5 / outputGroup 2, and a coproduct goes to outputGroup 2 too
+    -- (the Waste classification, not the group, distinguishes them) — both must
+    -- survive write→parse rather than flip direction or role.
+    it "round-trips waste direction (in/out) and a coproduct" $ do
+        sdb' <- roundTrip fixtureWasteCoproduct
+        case M.lookup (actA, prodA) (sdbActivities sdb') of
+            Nothing -> expectationFailure "waste/coproduct activity missing after round-trip"
+            Just act -> do
+                sort [waIsInput ex | ex@WasteExchange{} <- exchanges act] `shouldBe` [False, True]
+                [techRole ex | ex@TechnosphereExchange{techRole = Coproduct} <- exchanges act]
+                    `shouldBe` [Coproduct]
+
+    -- Export-boundary guards: data EcoSpold2 cannot faithfully re-encode must be
+    -- rejected loudly by 'checkEcoSpold2Exportable' rather than silently
+    -- corrupted (a non-finite amount clamps to 0.0; a ReferenceInput re-parses
+    -- as a plain Input, losing the treatment activity's reference designation).
+    describe "rejects un-encodable data at the export boundary" $ do
+        it "rejects a non-finite exchange amount (Infinity clamps to 0.0)" $
+            checkEcoSpold2Exportable
+                (fixtureWithExchange (BiosphereExchange co2 (1 / 0) unitKg Emission "" Nothing Nothing))
+                `shouldSatisfy` isLeft
+
+        it "rejects a reference input (no EcoSpold2 encoding)" $
+            checkEcoSpold2Exportable
+                (fixtureWithExchange (TechnosphereExchange co2 2.0 unitKg ReferenceInput UUID.nil Nothing "" Nothing Nothing))
+                `shouldSatisfy` isLeft
+
+        it "rejects an exchange whose unit is absent from the registry" $
+            -- unitMJ is not in the single-unit registry, so the writer would emit
+            -- no <unitName> and the parser would read back UNKNOWN_UNIT.
+            checkEcoSpold2Exportable
+                (fixtureWithExchange (BiosphereExchange co2 1.0 unitMJ Emission "" Nothing Nothing))
+                `shouldSatisfy` isLeft
+
+        it "rejects an exchange whose flow is absent from the registry" $
+            -- `land` is not in the single-flow biosphere registry, so the writer
+            -- would emit a nameless, compartment-less exchange (name degrading to
+            -- the bare UUID) — symmetric to the missing-unit downgrade above.
+            checkEcoSpold2Exportable
+                (fixtureWithExchange (BiosphereExchange land 1.0 unitKg Emission "" Nothing Nothing))
+                `shouldSatisfy` isLeft
+
+        it "rejects a subnormal amount that re-parses to zero rather than undercounting" $
+            -- 5e-324's fixed-point form carries too few significant digits for
+            -- Data.Text.Read.double to recover; it would silently export as 0.
+            checkEcoSpold2Exportable
+                (fixtureWithExchange (BiosphereExchange co2 5e-324 unitKg Emission "" Nothing Nothing))
+                `shouldSatisfy` isLeft
+
+    -- (b) Semantic round-trip: parse(write(D)) ≅ D, order-insensitive.
+    describe "semantic round-trip (structural equality)" $ do
+        it "preserves the activity set keyed by (actUUID, prodUUID)" $ do
+            sdb <- loadFixtureSimple
+            sdb' <- roundTrip sdb
+            M.keys (sdbActivities sdb') `shouldMatchList` M.keys (sdbActivities sdb)
+
+        it "preserves each activity's name, location and exchange multiset" $ do
+            sdb <- loadFixtureSimple
+            sdb' <- roundTrip sdb
+            forM_ (M.toList (sdbActivities sdb)) $ \(key, act) ->
+                case M.lookup key (sdbActivities sdb') of
+                    Nothing -> expectationFailure $ "missing activity after round-trip: " ++ show key
+                    Just act' -> do
+                        activityName act' `shouldBe` activityName act
+                        activityLocation act' `shouldBe` activityLocation act
+                        activityClassification act' `shouldBe` activityClassification act
+                        activityNativeType act' `shouldBe` activityNativeType act
+                        sort (map exchangeFingerprint (exchanges act'))
+                            `shouldBe` sort (map exchangeFingerprint (exchanges act))
+
+        it "preserves the biosphere flow registry (id, name, compartment)" $ do
+            sdb <- loadFixtureSimple
+            sdb' <- roundTrip sdb
+            map bioFingerprint (M.elems (sdbBioFlows sdb'))
+                `shouldMatchList` map bioFingerprint (M.elems (sdbBioFlows sdb))
+
+        it "preserves the technosphere flow registry (id, name)" $ do
+            sdb <- loadFixtureSimple
+            sdb' <- roundTrip sdb
+            map (\f -> (tfId f, tfName f)) (M.elems (sdbTechFlows sdb'))
+                `shouldMatchList` map (\f -> (tfId f, tfName f)) (M.elems (sdbTechFlows sdb))
+
+        it "preserves biosphere flow synonyms across the round-trip" $ do
+            -- The writer emits <synonym> lines and the parser reads them back
+            -- (collapsed under "en"); without a fixture carrying synonyms this
+            -- path was unexercised end to end.
+            sdb' <- roundTrip fixtureWithBioSynonyms
+            S.unions (concatMap (M.elems . bfSynonyms) (M.elems (sdbBioFlows sdb')))
+                `shouldBe` S.fromList ["CO2", "carbonic anhydride"]
+
+    -- (c) Score-equivalence: same inventory for every activity within tolerance.
+    it "yields the same LCIA inventory as the original (within tolerance)" $
+        loadFixtureSimple >>= assertInventoryRoundTrips
+
+    -- Duplicate-flow no-dedup, now at the inventory level: the two CO2 emissions
+    -- must sum (0.8) on both sides, not collapse to one line.
+    it "preserves duplicate-flow inventory mass across the round-trip" $
+        assertInventoryRoundTrips fixtureDupBio
+
+-- ----------------------------------------------------------------------------
+-- Comparison helpers (order-insensitive, tolerance-aware)
+-- ----------------------------------------------------------------------------
+
+{- | Structural fingerprint of an exchange, stable under reordering. Carries the
+per-exchange comment so the semantic round-trip actually pins it (the fixture
+gives one input a comment).
+-}
+exchangeFingerprint :: Exchange -> (Int, Text, Bool, Bool, Integer, Maybe Text)
+exchangeFingerprint ex =
+    ( kindRank ex
+    , UUID.toText (exchangeFlowId ex)
+    , exchangeIsInput ex
+    , exchangeIsReference ex
+    , roundAmount (exchangeAmount ex)
+    , exchangeComment ex
+    )
+  where
+    kindRank TechnosphereExchange{} = 0
+    kindRank WasteExchange{} = 1
+    kindRank BiosphereExchange{} = 2
+
+-- | Biosphere flow fingerprint: identity, CAS, plus compartment medium/sub.
+bioFingerprint :: BiosphereFlow -> (Text, Text, Maybe Text, Text, Maybe Text)
+bioFingerprint f =
+    ( UUID.toText (bfId f)
+    , bfName f
+    , bfCAS f
+    , maybe "" compartmentName (bfCompartment f)
+    , bfCompartment f >>= compartmentSub
+    )
+
+-- | Quantise an amount so float jitter doesn't break equality (9 sig decimals).
+roundAmount :: Double -> Integer
+roundAmount d = round (d * 1e9)
+
+{- | Two inventories agree within relative+absolute tolerance on every flow
+present in either map. Missing flows are treated as zero.
+-}
+inventoriesClose :: M.Map UUID.UUID Double -> M.Map UUID.UUID Double -> Bool
+inventoriesClose a b =
+    let keys = S.toList (S.fromList (M.keys a) `S.union` S.fromList (M.keys b))
+        close k =
+            let x = M.findWithDefault 0 k a
+                y = M.findWithDefault 0 k b
+             in abs (x - y) <= 1e-9 + 1e-6 * max (abs x) (abs y)
+     in all close keys

--- a/volca.cabal
+++ b/volca.cabal
@@ -83,6 +83,7 @@ library
                      , EcoSpold.Common
                      , EcoSpold.Cutoff
                      , EcoSpold.Parser2
+                     , EcoSpold.Writer2
                      , EcoSpold.Parser1
                      , EcoSpold.Writer1
                      , SimaPro.Parser
@@ -247,6 +248,7 @@ test-suite lca-tests
                      , EcoSpold1Spec
                      , EcoSpold1WriterSpec
                      , EcoSpold2Spec
+                     , EcoSpold2WriterSpec
                      , SimaProWriterSpec
                      , MCPSchemaSpec
                      , BatchImpactsSpec

--- a/volca.cabal
+++ b/volca.cabal
@@ -84,6 +84,7 @@ library
                      , EcoSpold.Cutoff
                      , EcoSpold.Parser2
                      , EcoSpold.Parser1
+                     , EcoSpold.Writer1
                      , SimaPro.Parser
                      , SimaPro.Writer
                      , BrightwayExcel.Parser
@@ -244,6 +245,7 @@ test-suite lca-tests
                      , UploadSizeSpec
                      , ProgressSpec
                      , EcoSpold1Spec
+                     , EcoSpold1WriterSpec
                      , EcoSpold2Spec
                      , SimaProWriterSpec
                      , MCPSchemaSpec


### PR DESCRIPTION
## What
Serialize an in-memory database to EcoSpold 1 XML. The writer is the deterministic inverse of its parser, pinned by a three-way round-trip spec: byte-identical modulo volatile metadata, order-insensitive parse∘write, and unchanged LCIA scores across the round-trip.

Part of the #113 split into focused, independently-reviewable PRs. Stacked on `feat/writer-simapro` — **merge bottom-up**; #114 (delete) is the base of the stack. Full stack: `cabal test lca-tests` → 1255 examples, 0 failures.