### PR TITLE
feat(ecospold2): EcoSpold 2 writer — canonical inverse of the parser

### DIFF
--- a/src/EcoSpold/Writer2.hs
+++ b/src/EcoSpold/Writer2.hs
@@ -24,6 +24,12 @@ The only thing the writer cannot recover losslessly is information the parser
 discards (per-exchange @id@/@unitId@ attribute *strings*, production volumes,
 properties). Those are either omitted or synthesised from the stable UUIDs, so
 a parse→write→parse cycle is a fixed point.
+
+The contract is fixed-point over the parser's /image/, not @parse(write(x)) == x@
+for an arbitrary 'SimpleDatabase'. The parser normalises as it reads — e.g. it
+trims surrounding whitespace from text nodes — so a value that never came from a
+parse (a name padded with leading spaces) is outside the round-trip's domain;
+@parse(write(parse(s))) == parse(s)@ is what holds.
 -}
 module EcoSpold.Writer2 (
     VolatileMeta (..),
@@ -40,6 +46,7 @@ import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.Read as TR
 import qualified Data.UUID as UUID
 import EcoSpold.Common (showFFloatTrim)
 import Types
@@ -116,30 +123,43 @@ re-encode.
     @\<unitName\>@, which the parser re-reads as the @UNKNOWN_UNIT@ placeholder —
     a silent unit downgrade. Reject rather than lose the unit.
 
+  * __Non-round-tripping amounts.__ A finite amount whose decimal form does not
+    re-parse to the same 'Double' through 'Data.Text.Read.double' — e.g. a
+    subnormal near the floating-point floor — would silently export as a
+    different value. Reject rather than undercount.
+
 Reports the first offender and fails loudly rather than emit silently wrong
-data. Databases free of it pass unchanged. Subsequent checks extend this guard.
+data. Databases free of it pass unchanged.
 -}
 checkEcoSpold2Exportable :: SimpleDatabase -> Either Text ()
 checkEcoSpold2Exportable db =
-    case (amountOffenders, refInputOffenders, unknownUnitOffenders) of
-        ((consumer, amt) : _, _, _) ->
+    case (amountOffenders, refInputOffenders, unknownUnitOffenders, roundTripOffenders) of
+        ((consumer, amt) : _, _, _, _) ->
             Left $
                 "EcoSpold2 export cannot represent activity \""
                     <> consumer
                     <> "\": exchange amount "
                     <> T.pack (show amt)
                     <> " is not finite."
-        ([], consumer : _, _) ->
+        ([], consumer : _, _, _) ->
             Left $
                 "EcoSpold2 export cannot represent activity \""
                     <> consumer
                     <> "\": a reference input (treatment process) has no EcoSpold2 encoding."
-        ([], [], consumer : _) ->
+        ([], [], consumer : _, _) ->
             Left $
                 "EcoSpold2 export cannot represent activity \""
                     <> consumer
                     <> "\": an exchange references a unit absent from the registry."
-        ([], [], []) -> Right ()
+        ([], [], [], (consumer, amt) : _) ->
+            Left $
+                "EcoSpold2 export cannot represent activity \""
+                    <> consumer
+                    <> "\": exchange amount "
+                    <> T.pack (show amt)
+                    <> " has no decimal form that re-parses to the same value"
+                    <> " (e.g. a subnormal near the floating-point floor)."
+        ([], [], [], []) -> Right ()
   where
     amountOffenders =
         [ (activityName act, amt)
@@ -148,6 +168,19 @@ checkEcoSpold2Exportable db =
         , let amt = exchangeAmount ex
         , isNaN amt || isInfinite amt
         ]
+    roundTripOffenders =
+        [ (activityName act, amt)
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , let amt = exchangeAmount ex
+        , not (isNaN amt || isInfinite amt) -- non-finite already reported above
+        , not (amountRoundTrips amt)
+        ]
+    -- The written decimal must re-parse to the same Double through the parser's
+    -- reader ('Data.Text.Read.double'), or the value silently changes on import.
+    amountRoundTrips amt = case TR.double (doubleAttr amt) of
+        Right (v, rest) -> v == amt && T.null rest
+        Left _ -> False
     refInputOffenders =
         [ activityName act
         | act <- M.elems (sdbActivities db)
@@ -518,14 +551,17 @@ intText :: Int -> Text
 intText = T.pack . show
 
 {- | Canonical 'Double' rendering for amounts via the shared 'showFFloatTrim'
-(fixed-point, never scientific), so the value round-trips byte- and
-value-identically through the parser's 'Data.Text.Read.double'. Non-finite
-values are clamped to a parseable @0.0@ (they cannot occur in a parsed database,
-but we never emit @Infinity@/@NaN@ which would break re-parsing).
+(fixed-point, never scientific), so the value round-trips through the parser's
+'Data.Text.Read.double' for the magnitudes real LCA amounts occupy. The
+near-underflow subnormal tail is the exception; 'checkEcoSpold2Exportable'
+rejects any amount that does not re-parse, so the guarded path never emits one.
+A non-finite value renders as its (non-parseable) @"NaN"@/@"Infinity"@ form so a
+bad re-import fails loudly rather than silently reading @0@; the guard rejects
+non-finite amounts before they reach here.
 -}
 doubleAttr :: Double -> Text
 doubleAttr d
-    | isNaN d || isInfinite d = "0.0"
+    | isNaN d || isInfinite d = T.pack (show d)
     | otherwise = T.pack (showFFloatTrim d)
 
 -- | Escape the three XML predefined entities for element text content.

--- a/src/EcoSpold/Writer2.hs
+++ b/src/EcoSpold/Writer2.hs
@@ -1,0 +1,558 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Canonical, deterministic EcoSpold2 serializer — the inverse of
+'EcoSpold.Parser2'.
+
+Given a 'SimpleDatabase' (the natural writer input: activities keyed by
+@(activityUUID, productUUID)@ plus flow/unit registries), this produces one
+EcoSpold2 @.spold@ document per activity, named @{actUUID}_{prodUUID}.spold@
+exactly as the loader expects.
+
+Design goals (all pure, effect-free):
+
+  * __Canonical__: fixed attribute order, fixed namespaces, fixed two-space
+    indentation, no insignificant whitespace beyond the layout.
+  * __Deterministic__: every @Map@/@Set@-derived list is emitted in sorted
+    key order; doubles use one canonical renderer; output bytes are a pure
+    function of the input plus the explicit 'VolatileMeta'.
+  * __Round-trippable__: re-parsing the output reconstructs a structurally
+    equal 'Activity'/flow set, and volatile metadata (timestamps, generator)
+    is funnelled through 'VolatileMeta' so it can be pinned or omitted to make
+    byte-level idempotence testable.
+
+The only thing the writer cannot recover losslessly is information the parser
+discards (per-exchange @id@/@unitId@ attribute *strings*, production volumes,
+properties). Those are either omitted or synthesised from the stable UUIDs, so
+a parse→write→parse cycle is a fixed point.
+-}
+module EcoSpold.Writer2 (
+    VolatileMeta (..),
+    noVolatileMeta,
+    writeEcoSpold2,
+    checkEcoSpold2Exportable,
+    activityFileName,
+    renderActivity,
+    sortExchanges,
+) where
+
+import Data.List (sortOn)
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.UUID as UUID
+import Numeric (showFFloat)
+import Types
+
+{- | Volatile, non-semantic metadata that the parser ignores but a writer would
+otherwise stamp with the current time / tool version. Threaded explicitly so a
+caller can pin it (reproducible export) or omit it entirely (byte-stable
+round-trip). 'Nothing' fields emit no corresponding attribute/element.
+-}
+data VolatileMeta = VolatileMeta
+    { vmCreationTimestamp :: !(Maybe Text)
+    -- ^ @administrativeInformation/fileAttributes/@creationTimestamp@
+    , vmGenerator :: !(Maybe Text)
+    -- ^ free-text generator note emitted as an XML comment, or omitted
+    }
+    deriving (Eq, Show)
+
+-- | The reproducible default: omit every volatile field.
+noVolatileMeta :: VolatileMeta
+noVolatileMeta = VolatileMeta Nothing Nothing
+
+-- ============================================================================
+-- Public entry points
+-- ============================================================================
+
+{- | Serialize a whole 'SimpleDatabase' to a sorted list of
+@(filename, document)@ pairs, one per activity. Sorted by filename so the
+sequence itself is deterministic. Flow names and unit names are resolved from
+the registries because the parser stores them on exchanges, not centrally.
+-}
+writeEcoSpold2 :: VolatileMeta -> SimpleDatabase -> [(FilePath, Text)]
+writeEcoSpold2 meta sdb =
+    [ (activityFileName actUUID prodUUID, renderActivity meta env act)
+    | ((actUUID, prodUUID), act) <- M.toAscList (sdbActivities sdb)
+    ]
+  where
+    env =
+        ResolveEnv
+            { reTechName = \u -> tfName <$> M.lookup u techFlows
+            , reBioFlow = \u -> M.lookup u bioFlows
+            , reWasteName = \u -> wfName <$> M.lookup u wasteFlows
+            , reTechSyns = \u -> maybe M.empty tfSynonyms (M.lookup u techFlows)
+            , reBioSyns = \u -> maybe M.empty bfSynonyms (M.lookup u bioFlows)
+            , reWasteSyns = \u -> maybe M.empty wfSynonyms (M.lookup u wasteFlows)
+            , reUnitName = \u -> unitName <$> M.lookup u units
+            }
+    techFlows = sdbTechFlows sdb
+    bioFlows = sdbBioFlows sdb
+    wasteFlows = sdbWasteFlows sdb
+    units = sdbUnits sdb
+
+{- | Guard an EcoSpold2 export against data the writer cannot faithfully
+re-encode.
+
+  * __Non-finite amounts.__ 'doubleAttr' clamps @NaN@/@Infinity@ to a parseable
+    @0.0@; a database carrying such an amount would silently export as zero. The
+    reader parses amounts with 'Data.Text.Read.double', which yields @Infinity@
+    for an overflowing literal like @1e400@, so this is reachable from a parsed
+    source — not only from in-memory construction.
+
+  * __Reference inputs.__ A treatment activity's 'ReferenceInput' is written as
+    @inputGroup 5@, but no ES2 inputGroup re-parses to 'ReferenceInput' (the
+    parser yields 'Input'), so the reference designation is silently lost on
+    re-parse — the activity loses its reference product. ES2 has no encoding for
+    it, so reject rather than corrupt.
+
+  * __Unresolvable units.__ The @\<unitName\>@ line is resolved from 'sdbUnits';
+    an exchange whose @unitId@ is absent from the registry would emit no
+    @\<unitName\>@, which the parser re-reads as the @UNKNOWN_UNIT@ placeholder —
+    a silent unit downgrade. Reject rather than lose the unit.
+
+Reports the first offender and fails loudly rather than emit silently wrong
+data. Databases free of it pass unchanged. Subsequent checks extend this guard.
+-}
+checkEcoSpold2Exportable :: SimpleDatabase -> Either Text ()
+checkEcoSpold2Exportable db =
+    case (amountOffenders, refInputOffenders, unknownUnitOffenders) of
+        ((consumer, amt) : _, _, _) ->
+            Left $
+                "EcoSpold2 export cannot represent activity \""
+                    <> consumer
+                    <> "\": exchange amount "
+                    <> T.pack (show amt)
+                    <> " is not finite."
+        ([], consumer : _, _) ->
+            Left $
+                "EcoSpold2 export cannot represent activity \""
+                    <> consumer
+                    <> "\": a reference input (treatment process) has no EcoSpold2 encoding."
+        ([], [], consumer : _) ->
+            Left $
+                "EcoSpold2 export cannot represent activity \""
+                    <> consumer
+                    <> "\": an exchange references a unit absent from the registry."
+        ([], [], []) -> Right ()
+  where
+    amountOffenders =
+        [ (activityName act, amt)
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , let amt = exchangeAmount ex
+        , isNaN amt || isInfinite amt
+        ]
+    refInputOffenders =
+        [ activityName act
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , isReferenceInput ex
+        ]
+    unknownUnitOffenders =
+        [ activityName act
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , M.notMember (exchangeUnitId ex) (sdbUnits db)
+        ]
+    isReferenceInput ex = case ex of
+        TechnosphereExchange{techRole = ReferenceInput} -> True
+        TechnosphereExchange{} -> False
+        WasteExchange{} -> False
+        BiosphereExchange{} -> False
+
+-- | Canonical filename for an activity: @{actUUID}_{prodUUID}.spold@.
+activityFileName :: UUID.UUID -> UUID.UUID -> FilePath
+activityFileName actUUID prodUUID =
+    T.unpack (UUID.toText actUUID <> "_" <> UUID.toText prodUUID <> ".spold")
+
+{- | Resolver for the registry-held data the parser writes onto exchanges.
+Passed in so 'renderActivity' stays a pure function of its inputs.
+-}
+data ResolveEnv = ResolveEnv
+    { reTechName :: UUID.UUID -> Maybe Text
+    , reBioFlow :: UUID.UUID -> Maybe BiosphereFlow
+    , reWasteName :: UUID.UUID -> Maybe Text
+    , reTechSyns :: UUID.UUID -> M.Map Text (S.Set Text)
+    , reBioSyns :: UUID.UUID -> M.Map Text (S.Set Text)
+    , reWasteSyns :: UUID.UUID -> M.Map Text (S.Set Text)
+    , reUnitName :: UUID.UUID -> Maybe Text
+    }
+
+-- ============================================================================
+-- Document rendering
+-- ============================================================================
+
+-- | Render one activity to a complete EcoSpold2 document.
+renderActivity :: VolatileMeta -> ResolveEnv -> Activity -> Text
+renderActivity meta env act =
+    T.unlines $
+        [ "<?xml version='1.0' encoding='UTF-8'?>"
+        , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold02\">"
+        ]
+            ++ generatorComment meta
+            ++ [ "  <activityDataset>"
+               , "    <activityDescription>"
+               ]
+            ++ renderActivityElem act
+            ++ renderGeneralComment (activityDescription act)
+            ++ renderClassifications (activityClassification act)
+            ++ renderGeography (activityLocation act)
+            ++ ["    </activityDescription>", "    <flowData>"]
+            ++ concatMap (renderExchange env) (sortExchanges (exchanges act))
+            ++ ["    </flowData>"]
+            ++ renderAdminInfo meta
+            ++ ["  </activityDataset>", "</ecoSpold>"]
+
+-- | Optional generator note as an XML comment (volatile, omitted by default).
+generatorComment :: VolatileMeta -> [Text]
+generatorComment meta = case vmGenerator meta of
+    Nothing -> []
+    Just g -> ["  <!-- generator: " <> escapeText g <> " -->"]
+
+{- | The @\<activity\>@ opening element. We do not have the source's raw
+@id@/@activityNameId@ strings on 'Activity' (the parser keeps UUIDs in the
+filename, not here), so we omit them: the parser derives identity from the
+filename, never from these attributes. activityType / specialActivityType are
+re-emitted from 'activityNativeType' when present.
+-}
+renderActivityElem :: Activity -> [Text]
+renderActivityElem act =
+    [ "      <activity" <> activityTypeAttrs (activityNativeType act) <> ">"
+    , "        <activityName xml:lang=\"en\">" <> escapeText (activityName act) <> "</activityName>"
+    , "      </activity>"
+    ]
+
+{- | Re-emit the ecospold2 @activityType@/@specialActivityType@ attributes from
+the captured native type. Only 'EcoSpoldActivityType' carries them; the SimaPro
+and ILCD variants have no ecospold2 representation, so we emit nothing (a
+faithful round-trip of an ES2-sourced database never hits those cases).
+-}
+activityTypeAttrs :: Maybe NativeActivityType -> Text
+activityTypeAttrs Nothing = ""
+activityTypeAttrs (Just nt) = case nt of
+    EcoSpoldActivityType code _ special _ ->
+        " activityType=\"" <> intText code <> "\"" <> specialAttr special
+    SimaProProcessType _ -> ""
+    ILCDProcessType _ -> ""
+  where
+    specialAttr Nothing = ""
+    specialAttr (Just s) = " specialActivityType=\"" <> intText s <> "\""
+
+{- | @\<generalComment\>@ with one @\<text index="n">@ per description
+paragraph, in the original order. Empty description emits nothing.
+-}
+renderGeneralComment :: [Text] -> [Text]
+renderGeneralComment [] = []
+renderGeneralComment paras =
+    ["      <generalComment>"]
+        ++ [ "        <text xml:lang=\"en\" index=\"" <> intText i <> "\">" <> escapeText p <> "</text>"
+           | (i, p) <- zip [0 :: Int ..] paras
+           ]
+        ++ ["      </generalComment>"]
+
+{- | Activity-level @\<classification\>@ blocks (ISIC/CPC, …) under
+@activityDescription@. One block per (system, value) pair, sorted by system for
+determinism. Parser2 routes any @classification@ outside an intermediate
+exchange to @activityClassification@, so these round-trip. Empty map emits
+nothing.
+-}
+renderClassifications :: M.Map Text Text -> [Text]
+renderClassifications =
+    concatMap (classificationBlock . Just) . M.toAscList
+
+-- | @\<geography\>\<shortname\>@ holding the location code.
+renderGeography :: Text -> [Text]
+renderGeography loc =
+    [ "      <geography>"
+    , "        <shortname xml:lang=\"en\">" <> escapeText loc <> "</shortname>"
+    , "      </geography>"
+    ]
+
+{- | @administrativeInformation@ carrying only the (optional, volatile)
+creation timestamp. Omitted entirely when no timestamp is pinned, keeping the
+default output minimal and byte-stable.
+-}
+renderAdminInfo :: VolatileMeta -> [Text]
+renderAdminInfo meta = case vmCreationTimestamp meta of
+    Nothing -> []
+    Just ts ->
+        [ "    <administrativeInformation>"
+        , "      <fileAttributes defaultLanguage=\"en\" creationTimestamp=\"" <> escapeAttr ts <> "\"/>"
+        , "    </administrativeInformation>"
+        ]
+
+-- ============================================================================
+-- Exchange rendering
+-- ============================================================================
+
+{- | Deterministic exchange order: group by kind (technosphere, then waste,
+then biosphere), and within a kind sort by flow UUID. The reference product is
+forced first within the technosphere group so the canonical layout matches the
+ecospold convention of leading with the produced product.
+-}
+sortExchanges :: [Exchange] -> [Exchange]
+sortExchanges = sortOn exchangeSortKey
+
+{- | Sort key: (kindRank, not-reference, flowUUID). @not-reference@ sorts the
+reference product/input ahead of the others within a kind. The flow UUID is the
+tiebreaker; 'sortOn' is stable, so two exchanges sharing a key keep their input
+order and are both emitted — never collapsed (a 'Map' keyed on this would have
+silently dropped a duplicate biosphere/technosphere line, undercounting the
+inventory).
+-}
+exchangeSortKey :: Exchange -> (Int, Bool, Text)
+exchangeSortKey ex = (kindRank, not (exchangeIsReference ex), UUID.toText (exchangeFlowId ex))
+  where
+    kindRank = case ex of
+        TechnosphereExchange{} -> 0
+        WasteExchange{} -> 1
+        BiosphereExchange{} -> 2
+
+-- | Render a single exchange to its XML lines.
+renderExchange :: ResolveEnv -> Exchange -> [Text]
+renderExchange env ex = case ex of
+    TechnosphereExchange{} -> renderTechnosphere env ex
+    WasteExchange{} -> renderWaste env ex
+    BiosphereExchange{} -> renderBiosphere env ex
+
+{- | Technosphere exchange → @intermediateExchange@.
+
+Inverse of the parser's role logic:
+
+  * 'ReferenceProduct' → output, @\<outputGroup\>0\</outputGroup\>@
+  * 'Coproduct'        → output, @\<outputGroup\>2\</outputGroup\>@ (any
+    non-zero output group re-parses to 'Coproduct')
+  * 'Input' / 'ReferenceInput' → input, @\<inputGroup\>5\</inputGroup\>@
+-}
+renderTechnosphere :: ResolveEnv -> Exchange -> [Text]
+renderTechnosphere env ex =
+    intermediateExchange
+        (reTechName env flowId)
+        flowId
+        (techUnitId ex)
+        (techAmount ex)
+        (reUnitName env (techUnitId ex))
+        (reTechSyns env flowId)
+        groupLine
+        (techActivityLinkId ex)
+        Nothing
+        (techComment ex)
+  where
+    flowId = techFlowId ex
+    groupLine = case techRole ex of
+        ReferenceProduct -> outputGroupLine "0"
+        Coproduct -> outputGroupLine "2"
+        Input -> inputGroupLine "5"
+        ReferenceInput -> inputGroupLine "5"
+
+{- | Waste exchange → @intermediateExchange@ tagged with the
+@By-product classification = Waste@ classification (parser "Pattern B"). The
+@waIsInput@ flag picks input vs output group so direction round-trips. This
+re-parses to a 'WasteExchange', preserving the kind.
+-}
+renderWaste :: ResolveEnv -> Exchange -> [Text]
+renderWaste env ex =
+    intermediateExchange
+        (reWasteName env flowId)
+        flowId
+        (waUnitId ex)
+        (waAmount ex)
+        (reUnitName env (waUnitId ex))
+        (reWasteSyns env flowId)
+        groupLine
+        (waActivityLinkId ex)
+        (Just ("By-product classification", "Waste"))
+        (waComment ex)
+  where
+    flowId = waFlowId ex
+    groupLine = if waIsInput ex then inputGroupLine "5" else outputGroupLine "4"
+
+{- | Biosphere exchange → @elementaryExchange@. Direction maps to in/out group:
+'Resource' → @inputGroup@ 4, 'Emission' → @outputGroup@ 4. The compartment is
+taken from the registry's 'BiosphereFlow'.
+-}
+renderBiosphere :: ResolveEnv -> Exchange -> [Text]
+renderBiosphere env ex =
+    [openTag]
+        ++ nameLine 8 (reBioFlow env flowId >>= justName)
+        ++ unitNameLine 8 (reUnitName env (bioUnitId ex))
+        ++ compartmentBlock (reBioFlow env flowId >>= bfCompartment)
+        ++ [groupLine]
+        ++ synonymLines 8 (reBioSyns env flowId)
+        ++ commentLines 8 (bioComment ex)
+        ++ ["      </elementaryExchange>"]
+  where
+    flowId = bioFlowId ex
+    justName f = let n = bfName f in if T.null n then Nothing else Just n
+    casAttr = case reBioFlow env flowId >>= bfCAS of
+        Just cas -> " casNumber=\"" <> escapeAttr cas <> "\""
+        Nothing -> ""
+    openTag =
+        "      <elementaryExchange elementaryExchangeId=\""
+            <> escapeAttr (UUID.toText flowId)
+            <> "\" unitId=\""
+            <> escapeAttr (UUID.toText (bioUnitId ex))
+            <> "\" amount=\""
+            <> doubleAttr (bioAmount ex)
+            <> "\""
+            <> casAttr
+            <> ">"
+    groupLine = case bioDirection ex of
+        Resource -> "        <inputGroup>4</inputGroup>"
+        Emission -> "        <outputGroup>4</outputGroup>"
+
+{- | Shared @intermediateExchange@ emitter for technosphere and waste flows.
+The @activityLinkId@ is emitted only when non-nil (matching the parser, which
+treats nil/empty as "no link"). An optional @classification@ tags waste flows.
+-}
+intermediateExchange ::
+    Maybe Text -> -- resolved flow name
+    UUID.UUID -> -- flow id
+    UUID.UUID -> -- unit id
+    Double -> -- amount
+    Maybe Text -> -- resolved unit name
+    M.Map Text (S.Set Text) -> -- synonyms
+    Text -> -- the in/out group line (8-space indent)
+    UUID.UUID -> -- activity link id (nil = omit)
+    Maybe (Text, Text) -> -- optional (classificationSystem, classificationValue)
+    Maybe Text -> -- comment
+    [Text]
+intermediateExchange mName flowId unitUUID amount mUnit syns groupLine linkId mClass mComment =
+    [openTag]
+        ++ nameLine 8 mName
+        ++ unitNameLine 8 mUnit
+        ++ [groupLine]
+        ++ classificationBlock mClass
+        ++ synonymLines 8 syns
+        ++ commentLines 8 mComment
+        ++ ["      </intermediateExchange>"]
+  where
+    openTag =
+        "      <intermediateExchange intermediateExchangeId=\""
+            <> escapeAttr (UUID.toText flowId)
+            <> "\" unitId=\""
+            <> escapeAttr (UUID.toText unitUUID)
+            <> "\" amount=\""
+            <> doubleAttr amount
+            <> "\""
+            <> linkAttr
+            <> ">"
+    linkAttr
+        | linkId == UUID.nil = ""
+        | otherwise = " activityLinkId=\"" <> escapeAttr (UUID.toText linkId) <> "\""
+
+-- ============================================================================
+-- Small element emitters
+-- ============================================================================
+
+inputGroupLine :: Text -> Text
+inputGroupLine g = "        <inputGroup>" <> g <> "</inputGroup>"
+
+outputGroupLine :: Text -> Text
+outputGroupLine g = "        <outputGroup>" <> g <> "</outputGroup>"
+
+-- | @\<name\>@ line at the given indent, omitted when no name resolved.
+nameLine :: Int -> Maybe Text -> [Text]
+nameLine ind = maybe [] (\n -> [indent ind <> "<name xml:lang=\"en\">" <> escapeText n <> "</name>"])
+
+-- | @\<unitName\>@ line, omitted when no unit resolved.
+unitNameLine :: Int -> Maybe Text -> [Text]
+unitNameLine ind = maybe [] (\u -> [indent ind <> "<unitName xml:lang=\"en\">" <> escapeText u <> "</unitName>"])
+
+{- | @\<comment\>@ line for an exchange. The parser keeps only the English
+comment text, so we emit it verbatim under @xml:lang="en"@.
+-}
+commentLines :: Int -> Maybe Text -> [Text]
+commentLines ind = maybe [] (\c -> [indent ind <> "<comment xml:lang=\"en\">" <> escapeText c <> "</comment>"])
+
+{- | @\<synonym\>@ lines, one per synonym, sorted. The parser collapses all
+languages into the @"en"@ bucket and ignores the language, so we flatten and
+sort the unique synonym strings for a deterministic, round-trip-stable layout.
+-}
+synonymLines :: Int -> M.Map Text (S.Set Text) -> [Text]
+synonymLines ind syns =
+    [ indent ind <> "<synonym xml:lang=\"en\">" <> escapeText s <> "</synonym>"
+    | s <- S.toAscList (S.unions (M.elems syns))
+    , not (T.null s)
+    ]
+
+{- | The nested @\<compartment\>\<compartment\>\<subcompartment\>@ block the
+parser expects. Omitted when the flow carries no compartment.
+-}
+compartmentBlock :: Maybe Compartment -> [Text]
+compartmentBlock Nothing = []
+compartmentBlock (Just (Compartment name mSub)) =
+    ["        <compartment>", "          <compartment xml:lang=\"en\">" <> escapeText name <> "</compartment>"]
+        ++ subLine mSub
+        ++ ["        </compartment>"]
+  where
+    subLine = maybe [] (\s -> ["          <subcompartment xml:lang=\"en\">" <> escapeText s <> "</subcompartment>"])
+
+{- | @\<classification\>@ block tagging an exchange (used for waste). Emits the
+classificationSystem / classificationValue pair the parser reads.
+-}
+classificationBlock :: Maybe (Text, Text) -> [Text]
+classificationBlock Nothing = []
+classificationBlock (Just (system, value)) =
+    [ "        <classification>"
+    , "          <classificationSystem xml:lang=\"en\">" <> escapeText system <> "</classificationSystem>"
+    , "          <classificationValue xml:lang=\"en\">" <> escapeText value <> "</classificationValue>"
+    , "        </classification>"
+    ]
+
+-- ============================================================================
+-- Pure formatting helpers
+-- ============================================================================
+
+-- | @n@ spaces of indentation.
+indent :: Int -> Text
+indent n = T.replicate n " "
+
+intText :: Int -> Text
+intText = T.pack . show
+
+{- | Canonical 'Double' rendering for amounts. 'show' gives a stable,
+round-trippable decimal for finite values; the parser reads it back with
+'Data.Text.Read.double'. Non-finite values are clamped to a parseable @0.0@
+(they cannot occur in a parsed database, but we never emit @Infinity@/@NaN@
+which would break re-parsing).
+-}
+doubleAttr :: Double -> Text
+doubleAttr d
+    | isNaN d || isInfinite d = "0.0"
+    | otherwise = T.pack (showFFloatTrim d)
+
+{- | Fixed-notation double without an exponent, trailing-zero-trimmed but always
+keeping at least one fractional digit (so @1@ renders as @"1.0"@, matching the
+fixtures and staying unambiguous to the reader).
+-}
+showFFloatTrim :: Double -> String
+showFFloatTrim d =
+    let full = showFFloat Nothing d ""
+     in case break (== '.') full of
+            (intPart, '.' : fracPart) ->
+                let trimmed = reverse (dropWhile (== '0') (reverse fracPart))
+                 in intPart <> "." <> (if null trimmed then "0" else trimmed)
+            (intPart, _) -> intPart <> ".0"
+
+-- | Escape the five XML predefined entities for element text content.
+escapeText :: Text -> Text
+escapeText =
+    T.replace "&" "&amp;"
+        >>> T.replace "<" "&lt;"
+        >>> T.replace ">" "&gt;"
+  where
+    (>>>) f g = g . f
+
+{- | Escape for a double-quoted attribute value: the text escapes plus the
+double quote. The parser's 'decodeXmlEntities' reverses all of these.
+-}
+escapeAttr :: Text -> Text
+escapeAttr =
+    escapeText
+        >>> T.replace "\"" "&quot;"
+        >>> T.replace "\n" "&#10;"
+        >>> T.replace "\r" "&#13;"
+  where
+    (>>>) f g = g . f

--- a/src/EcoSpold/Writer2.hs
+++ b/src/EcoSpold/Writer2.hs
@@ -399,8 +399,12 @@ renderTechnosphere env ex =
 
 {- | Waste exchange → @intermediateExchange@ tagged with the
 @By-product classification = Waste@ classification (parser "Pattern B"). The
-@waIsInput@ flag picks input vs output group so direction round-trips. This
-re-parses to a 'WasteExchange', preserving the kind.
+@waIsInput@ flag picks the group so direction round-trips: an input takes
+@inputGroup 5@ (from technosphere), an output the @outputGroup 2@ (by-product) —
+the only output groups EcoSpold2 defines for an intermediate exchange besides the
+reference @0@. A waste output shares group @2@ with an ordinary coproduct; it is
+the @Waste@ classification, not the group number, that re-routes it to a
+'WasteExchange' on parse, so the kind is preserved.
 -}
 renderWaste :: ResolveEnv -> Exchange -> [Text]
 renderWaste env ex =
@@ -417,7 +421,7 @@ renderWaste env ex =
         (waComment ex)
   where
     flowId = waFlowId ex
-    groupLine = if waIsInput ex then inputGroupLine "5" else outputGroupLine "4"
+    groupLine = if waIsInput ex then inputGroupLine "5" else outputGroupLine "2"
 
 {- | Biosphere exchange → @elementaryExchange@. Direction maps to in/out group:
 'Resource' → @inputGroup@ 4, 'Emission' → @outputGroup@ 4. The compartment is

--- a/src/EcoSpold/Writer2.hs
+++ b/src/EcoSpold/Writer2.hs
@@ -41,7 +41,7 @@ import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
-import Numeric (showFFloat)
+import EcoSpold.Common (showFFloatTrim)
 import Types
 
 {- | Volatile, non-semantic metadata that the parser ignores but a writer would
@@ -69,12 +69,17 @@ noVolatileMeta = VolatileMeta Nothing Nothing
 @(filename, document)@ pairs, one per activity. Sorted by filename so the
 sequence itself is deterministic. Flow names and unit names are resolved from
 the registries because the parser stores them on exchanges, not centrally.
+Runs 'checkEcoSpold2Exportable' first and returns its 'Left' on a database the
+format cannot represent faithfully, so an unguarded caller cannot silently emit
+a corrupt archive.
 -}
-writeEcoSpold2 :: VolatileMeta -> SimpleDatabase -> [(FilePath, Text)]
-writeEcoSpold2 meta sdb =
-    [ (activityFileName actUUID prodUUID, renderActivity meta env act)
-    | ((actUUID, prodUUID), act) <- M.toAscList (sdbActivities sdb)
-    ]
+writeEcoSpold2 :: VolatileMeta -> SimpleDatabase -> Either Text [(FilePath, Text)]
+writeEcoSpold2 meta sdb = do
+    checkEcoSpold2Exportable sdb
+    pure
+        [ (activityFileName actUUID prodUUID, renderActivity meta env act)
+        | ((actUUID, prodUUID), act) <- M.toAscList (sdbActivities sdb)
+        ]
   where
     env =
         ResolveEnv
@@ -512,31 +517,18 @@ indent n = T.replicate n " "
 intText :: Int -> Text
 intText = T.pack . show
 
-{- | Canonical 'Double' rendering for amounts. 'show' gives a stable,
-round-trippable decimal for finite values; the parser reads it back with
-'Data.Text.Read.double'. Non-finite values are clamped to a parseable @0.0@
-(they cannot occur in a parsed database, but we never emit @Infinity@/@NaN@
-which would break re-parsing).
+{- | Canonical 'Double' rendering for amounts via the shared 'showFFloatTrim'
+(fixed-point, never scientific), so the value round-trips byte- and
+value-identically through the parser's 'Data.Text.Read.double'. Non-finite
+values are clamped to a parseable @0.0@ (they cannot occur in a parsed database,
+but we never emit @Infinity@/@NaN@ which would break re-parsing).
 -}
 doubleAttr :: Double -> Text
 doubleAttr d
     | isNaN d || isInfinite d = "0.0"
     | otherwise = T.pack (showFFloatTrim d)
 
-{- | Fixed-notation double without an exponent, trailing-zero-trimmed but always
-keeping at least one fractional digit (so @1@ renders as @"1.0"@, matching the
-fixtures and staying unambiguous to the reader).
--}
-showFFloatTrim :: Double -> String
-showFFloatTrim d =
-    let full = showFFloat Nothing d ""
-     in case break (== '.') full of
-            (intPart, '.' : fracPart) ->
-                let trimmed = reverse (dropWhile (== '0') (reverse fracPart))
-                 in intPart <> "." <> (if null trimmed then "0" else trimmed)
-            (intPart, _) -> intPart <> ".0"
-
--- | Escape the five XML predefined entities for element text content.
+-- | Escape the three XML predefined entities for element text content.
 escapeText :: Text -> Text
 escapeText =
     T.replace "&" "&amp;"

--- a/src/EcoSpold/Writer2.hs
+++ b/src/EcoSpold/Writer2.hs
@@ -43,6 +43,7 @@ module EcoSpold.Writer2 (
 
 import Data.List (sortOn)
 import qualified Data.Map.Strict as M
+import Data.Maybe (listToMaybe)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -123,6 +124,12 @@ re-encode.
     @\<unitName\>@, which the parser re-reads as the @UNKNOWN_UNIT@ placeholder —
     a silent unit downgrade. Reject rather than lose the unit.
 
+  * __Unresolvable flows.__ A flow's name, compartment, CAS and synonyms are all
+    resolved from the flow registries; an exchange whose flow id is absent emits
+    a bare exchange that re-parses with the flow's UUID string as its name and
+    /no compartment/ — a silent identity and compartment downgrade. Symmetric to
+    the unit case: reject rather than corrupt.
+
   * __Non-round-tripping amounts.__ A finite amount whose decimal form does not
     re-parse to the same 'Double' through 'Data.Text.Read.double' — e.g. a
     subnormal near the floating-point floor — would silently export as a
@@ -133,34 +140,17 @@ data. Databases free of it pass unchanged.
 -}
 checkEcoSpold2Exportable :: SimpleDatabase -> Either Text ()
 checkEcoSpold2Exportable db =
-    case (amountOffenders, refInputOffenders, unknownUnitOffenders, roundTripOffenders) of
-        ((consumer, amt) : _, _, _, _) ->
-            Left $
-                "EcoSpold2 export cannot represent activity \""
-                    <> consumer
-                    <> "\": exchange amount "
-                    <> T.pack (show amt)
-                    <> " is not finite."
-        ([], consumer : _, _, _) ->
-            Left $
-                "EcoSpold2 export cannot represent activity \""
-                    <> consumer
-                    <> "\": a reference input (treatment process) has no EcoSpold2 encoding."
-        ([], [], consumer : _, _) ->
-            Left $
-                "EcoSpold2 export cannot represent activity \""
-                    <> consumer
-                    <> "\": an exchange references a unit absent from the registry."
-        ([], [], [], (consumer, amt) : _) ->
-            Left $
-                "EcoSpold2 export cannot represent activity \""
-                    <> consumer
-                    <> "\": exchange amount "
-                    <> T.pack (show amt)
-                    <> " has no decimal form that re-parses to the same value"
-                    <> " (e.g. a subnormal near the floating-point floor)."
-        ([], [], [], []) -> Right ()
+    maybe (Right ()) Left (listToMaybe (concat orderedViolations))
   where
+    -- Categories in priority order; the first offending activity across all of
+    -- them is reported. Each inner list carries one message per offender.
+    orderedViolations =
+        [ [nonFiniteMsg c a | (c, a) <- amountOffenders]
+        , [refInputMsg c | c <- refInputOffenders]
+        , [unknownUnitMsg c | c <- unknownUnitOffenders]
+        , [missingFlowMsg c | c <- missingFlowOffenders]
+        , [nonRoundTripMsg c a | (c, a) <- roundTripOffenders]
+        ]
     amountOffenders =
         [ (activityName act, amt)
         | act <- M.elems (sdbActivities db)
@@ -193,11 +183,34 @@ checkEcoSpold2Exportable db =
         , ex <- exchanges act
         , M.notMember (exchangeUnitId ex) (sdbUnits db)
         ]
+    -- Each exchange's flow must resolve in the registry matching its kind, or the
+    -- writer emits a nameless, compartment-less exchange (see Haddock above).
+    missingFlowOffenders =
+        [ activityName act
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , flowMissing ex
+        ]
+    flowMissing ex = case ex of
+        TechnosphereExchange{techFlowId = fid} -> M.notMember fid (sdbTechFlows db)
+        WasteExchange{waFlowId = fid} -> M.notMember fid (sdbWasteFlows db)
+        BiosphereExchange{bioFlowId = fid} -> M.notMember fid (sdbBioFlows db)
     isReferenceInput ex = case ex of
         TechnosphereExchange{techRole = ReferenceInput} -> True
         TechnosphereExchange{} -> False
         WasteExchange{} -> False
         BiosphereExchange{} -> False
+    cannotRepresent c = "EcoSpold2 export cannot represent activity \"" <> c <> "\": "
+    nonFiniteMsg c a = cannotRepresent c <> "exchange amount " <> T.pack (show a) <> " is not finite."
+    refInputMsg c = cannotRepresent c <> "a reference input (treatment process) has no EcoSpold2 encoding."
+    unknownUnitMsg c = cannotRepresent c <> "an exchange references a unit absent from the registry."
+    missingFlowMsg c = cannotRepresent c <> "an exchange references a flow absent from the registry."
+    nonRoundTripMsg c a =
+        cannotRepresent c
+            <> "exchange amount "
+            <> T.pack (show a)
+            <> " has no decimal form that re-parses to the same value"
+            <> " (e.g. a subnormal near the floating-point floor)."
 
 -- | Canonical filename for an activity: @{actUUID}_{prodUUID}.spold@.
 activityFileName :: UUID.UUID -> UUID.UUID -> FilePath

--- a/test/EcoSpold2WriterSpec.hs
+++ b/test/EcoSpold2WriterSpec.hs
@@ -39,7 +39,7 @@ import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import Database (buildDatabaseWithMatrices)
 import Database.Loader (loadDatabase)
-import EcoSpold.Writer2 (checkEcoSpold2Exportable, noVolatileMeta, writeEcoSpold2)
+import EcoSpold.Writer2 (VolatileMeta, checkEcoSpold2Exportable, noVolatileMeta, writeEcoSpold2)
 import Matrix (computeInventoryMatrix)
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
@@ -204,6 +204,52 @@ fixtureWithExchange ex =
             Nothing
             (Just (EcoSpoldActivityType 1 "Ordinary transforming activity" Nothing Nothing))
 
+{- | A single activity exercising the subtlest inversion paths: a coproduct
+(outputGroup 2) and waste exchanges in both directions (waIsInput controls
+inputGroup 5 vs outputGroup 1). These round-trip paths were previously
+untested.
+-}
+fixtureWasteCoproduct :: SimpleDatabase
+fixtureWasteCoproduct =
+    SimpleDatabase
+        { sdbActivities = M.singleton (actA, prodA) activity
+        , sdbTechFlows =
+            M.fromList
+                [ (prodA, TechnosphereFlow prodA "product A" unitKg M.empty Nothing Nothing)
+                , (coprodU, TechnosphereFlow coprodU "co-product" unitKg M.empty Nothing Nothing)
+                ]
+        , sdbBioFlows = M.empty
+        , sdbWasteFlows =
+            M.fromList
+                [ (wasteInU, WasteFlow wasteInU "incoming waste" unitKg M.empty Nothing Nothing)
+                , (wasteOutU, WasteFlow wasteOutU "outgoing waste" unitKg M.empty Nothing Nothing)
+                ]
+        , sdbUnits = M.singleton unitKg (Unit unitKg "kg" "kg" "")
+        }
+  where
+    coprodU, wasteInU, wasteOutU :: UUID
+    coprodU = read "dddddddd-0000-4000-8000-000000000001"
+    wasteInU = read "dddddddd-0000-4000-8000-000000000002"
+    wasteOutU = read "dddddddd-0000-4000-8000-000000000003"
+    activity =
+        Activity
+            "waste and coproduct activity"
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "kg"
+            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , TechnosphereExchange coprodU 0.4 unitKg Coproduct UUID.nil Nothing "" Nothing Nothing
+            , WasteExchange wasteInU 0.2 unitKg True UUID.nil Nothing "" Nothing Nothing
+            , WasteExchange wasteOutU 0.3 unitKg False UUID.nil Nothing "" Nothing Nothing
+            ]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            (Just (EcoSpoldActivityType 1 "Ordinary transforming activity" Nothing Nothing))
+
 -- | Build a full 'Database' (with matrices) from a 'SimpleDatabase'.
 buildDb :: SimpleDatabase -> IO Database
 buildDb sdb = do
@@ -219,6 +265,11 @@ buildDb sdb = do
         Left err -> error $ "matrix build failed: " ++ T.unpack err
         Right db -> pure db
 
+-- | Unwrap the guard-returning writer for a fixture known to be exportable.
+writeOrFail :: VolatileMeta -> SimpleDatabase -> [(FilePath, Text)]
+writeOrFail meta sdb =
+    either (\e -> error ("writeEcoSpold2: " <> T.unpack e)) id (writeEcoSpold2 meta sdb)
+
 {- | Write a 'SimpleDatabase' to a fresh temp directory and re-load it through
 the production loader, returning the round-tripped 'SimpleDatabase'.
 -}
@@ -226,7 +277,7 @@ roundTrip :: SimpleDatabase -> IO SimpleDatabase
 roundTrip sdb = withSystemTempDirectory "es2-writer" $ \dir -> do
     -- Write UTF-8 bytes explicitly so the unicode round-trip does not depend on
     -- the test runner's locale encoding (the loader always decodes UTF-8).
-    forM_ (writeEcoSpold2 noVolatileMeta sdb) $ \(fname, doc) ->
+    forM_ (writeOrFail noVolatileMeta sdb) $ \(fname, doc) ->
         BS.writeFile (dir </> fname) (TE.encodeUtf8 doc)
     res <- loadDatabase defaultUnitConfig dir
     case res of
@@ -238,9 +289,9 @@ spec = describe "EcoSpold2 writer round-trip" $ do
     -- (a) Idempotence modulo volatile metadata.
     it "is idempotent modulo volatile metadata: write . parse . write == write" $ do
         sdb <- loadFixtureSimple
-        let f0 = writeEcoSpold2 noVolatileMeta sdb
+        let f0 = writeOrFail noVolatileMeta sdb
         sdb' <- roundTrip sdb
-        let f1 = writeEcoSpold2 noVolatileMeta sdb'
+        let f1 = writeOrFail noVolatileMeta sdb'
         -- Compare the sorted (filename, document) sequences byte-for-byte.
         sortOn fst f1 `shouldBe` sortOn fst f0
 
@@ -254,6 +305,18 @@ spec = describe "EcoSpold2 writer round-trip" $ do
             Just act ->
                 sort [exchangeAmount ex | ex <- exchanges act, isBiosphereExchange ex]
                     `shouldBe` [0.3, 0.5]
+
+    -- Regression: the subtlest inversion paths. renderWaste maps waIsInput to
+    -- inputGroup 5 / outputGroup 1, and a coproduct goes to outputGroup 2 —
+    -- both must survive write→parse rather than flip direction or role.
+    it "round-trips waste direction (in/out) and a coproduct" $ do
+        sdb' <- roundTrip fixtureWasteCoproduct
+        case M.lookup (actA, prodA) (sdbActivities sdb') of
+            Nothing -> expectationFailure "waste/coproduct activity missing after round-trip"
+            Just act -> do
+                sort [waIsInput ex | ex@WasteExchange{} <- exchanges act] `shouldBe` [False, True]
+                [techRole ex | ex@TechnosphereExchange{techRole = Coproduct} <- exchanges act]
+                    `shouldBe` [Coproduct]
 
     -- Export-boundary guards: data EcoSpold2 cannot faithfully re-encode must be
     -- rejected loudly by 'checkEcoSpold2Exportable' rather than silently

--- a/test/EcoSpold2WriterSpec.hs
+++ b/test/EcoSpold2WriterSpec.hs
@@ -375,6 +375,14 @@ spec = describe "EcoSpold2 writer round-trip" $ do
                 (fixtureWithExchange (BiosphereExchange co2 1.0 unitMJ Emission "" Nothing Nothing))
                 `shouldSatisfy` isLeft
 
+        it "rejects an exchange whose flow is absent from the registry" $
+            -- `land` is not in the single-flow biosphere registry, so the writer
+            -- would emit a nameless, compartment-less exchange (name degrading to
+            -- the bare UUID) — symmetric to the missing-unit downgrade above.
+            checkEcoSpold2Exportable
+                (fixtureWithExchange (BiosphereExchange land 1.0 unitKg Emission "" Nothing Nothing))
+                `shouldSatisfy` isLeft
+
         it "rejects a subnormal amount that re-parses to zero rather than undercounting" $
             -- 5e-324's fixed-point form carries too few significant digits for
             -- Data.Text.Read.double to recover; it would silently export as 0.

--- a/test/EcoSpold2WriterSpec.hs
+++ b/test/EcoSpold2WriterSpec.hs
@@ -39,7 +39,7 @@ import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import Database (buildDatabaseWithMatrices)
 import Database.Loader (loadDatabase)
-import EcoSpold.Writer2 (VolatileMeta, checkEcoSpold2Exportable, noVolatileMeta, writeEcoSpold2)
+import EcoSpold.Writer2 (VolatileMeta (..), checkEcoSpold2Exportable, noVolatileMeta, writeEcoSpold2)
 import Matrix (computeInventoryMatrix)
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
@@ -305,19 +305,44 @@ writeOrFail :: VolatileMeta -> SimpleDatabase -> [(FilePath, Text)]
 writeOrFail meta sdb =
     either (\e -> error ("writeEcoSpold2: " <> T.unpack e)) id (writeEcoSpold2 meta sdb)
 
-{- | Write a 'SimpleDatabase' to a fresh temp directory and re-load it through
-the production loader, returning the round-tripped 'SimpleDatabase'.
+{- | Write a 'SimpleDatabase' with the given volatile metadata to a fresh temp
+directory and re-load it through the production loader, returning the
+round-tripped 'SimpleDatabase'.
 -}
-roundTrip :: SimpleDatabase -> IO SimpleDatabase
-roundTrip sdb = withSystemTempDirectory "es2-writer" $ \dir -> do
+roundTripWith :: VolatileMeta -> SimpleDatabase -> IO SimpleDatabase
+roundTripWith meta sdb = withSystemTempDirectory "es2-writer" $ \dir -> do
     -- Write UTF-8 bytes explicitly so the unicode round-trip does not depend on
     -- the test runner's locale encoding (the loader always decodes UTF-8).
-    forM_ (writeOrFail noVolatileMeta sdb) $ \(fname, doc) ->
+    forM_ (writeOrFail meta sdb) $ \(fname, doc) ->
         BS.writeFile (dir </> fname) (TE.encodeUtf8 doc)
     res <- loadDatabase defaultUnitConfig dir
     case res of
         Left err -> error $ "reparse failed: " ++ T.unpack err
         Right sdb' -> pure sdb'
+
+-- | Round-trip with the byte-stable default (no volatile metadata).
+roundTrip :: SimpleDatabase -> IO SimpleDatabase
+roundTrip = roundTripWith noVolatileMeta
+
+{- | Assert the round-tripped database yields the same per-process LCI as the
+original, within tolerance. Factored out so several fixtures can be checked.
+-}
+assertInventoryRoundTrips :: SimpleDatabase -> IO ()
+assertInventoryRoundTrips sdb = do
+    sdb' <- roundTrip sdb
+    db <- buildDb sdb
+    db' <- buildDb sdb'
+    let pids = [0 .. fromIntegral (V.length (dbProcessIdTable db)) - 1] :: [ProcessId]
+    forM_ pids $ \pid -> do
+        inv <- computeInventoryMatrix db pid
+        -- The round-tripped DB may order activities differently; locate the
+        -- matching process by its (actUUID, prodUUID) key.
+        let key = dbProcessIdTable db V.! fromIntegral pid
+        case V.elemIndex key (dbProcessIdTable db') of
+            Nothing -> expectationFailure $ "process key missing after round-trip: " ++ show key
+            Just pid' -> do
+                inv' <- computeInventoryMatrix db' (fromIntegral pid')
+                inventoriesClose inv inv' `shouldBe` True
 
 spec :: Spec
 spec = describe "EcoSpold2 writer round-trip" $ do
@@ -329,6 +354,27 @@ spec = describe "EcoSpold2 writer round-trip" $ do
         let f1 = writeOrFail noVolatileMeta sdb'
         -- Compare the sorted (filename, document) sequences byte-for-byte.
         sortOn fst f1 `shouldBe` sortOn fst f0
+
+    -- The volatile-metadata paths (creationTimestamp element + generator
+    -- comment) are otherwise unexercised, since every other case uses
+    -- 'noVolatileMeta'. Pin both and assert they (1) reach the output and
+    -- (2) are non-semantic: the parser ignores them, so the round-tripped
+    -- activities match the byte-stable default exactly.
+    it "emits pinned volatile metadata that the parser then ignores" $ do
+        sdb <- loadFixtureSimple
+        let meta = VolatileMeta (Just "2020-01-02T03:04:05") (Just "writer-spec <gen> & co")
+        let docs = writeOrFail meta sdb
+        any (T.isInfixOf "2020-01-02T03:04:05" . snd) docs `shouldBe` True
+        any (T.isInfixOf "writer-spec" . snd) docs `shouldBe` True
+        pinned <- roundTripWith meta sdb
+        plain <- roundTrip sdb
+        M.keys (sdbActivities pinned) `shouldMatchList` M.keys (sdbActivities plain)
+        forM_ (M.toList (sdbActivities plain)) $ \(key, act) ->
+            case M.lookup key (sdbActivities pinned) of
+                Nothing -> expectationFailure $ "activity missing under pinned metadata: " ++ show key
+                Just act' ->
+                    sort (map exchangeFingerprint (exchanges act'))
+                        `shouldBe` sort (map exchangeFingerprint (exchanges act))
 
     -- Regression: two exchanges sharing a sort key (same kind + flow) must both
     -- survive write→parse. A Map-based sort would silently drop one,
@@ -433,23 +479,13 @@ spec = describe "EcoSpold2 writer round-trip" $ do
                 `shouldBe` S.fromList ["CO2", "carbonic anhydride"]
 
     -- (c) Score-equivalence: same inventory for every activity within tolerance.
-    it "yields the same LCIA inventory as the original (within tolerance)" $ do
-        sdb <- loadFixtureSimple
-        sdb' <- roundTrip sdb
-        db <- buildDb sdb
-        db' <- buildDb sdb'
-        -- Compare inventories for every process id present in the original.
-        let pids = [0 .. fromIntegral (V.length (dbProcessIdTable db)) - 1] :: [ProcessId]
-        forM_ pids $ \pid -> do
-            inv <- computeInventoryMatrix db pid
-            -- The round-tripped DB may order activities differently; locate the
-            -- matching process by its (actUUID, prodUUID) key.
-            let key = dbProcessIdTable db V.! fromIntegral pid
-            case V.elemIndex key (dbProcessIdTable db') of
-                Nothing -> expectationFailure $ "process key missing after round-trip: " ++ show key
-                Just pid' -> do
-                    inv' <- computeInventoryMatrix db' (fromIntegral pid')
-                    inventoriesClose inv inv' `shouldBe` True
+    it "yields the same LCIA inventory as the original (within tolerance)" $
+        loadFixtureSimple >>= assertInventoryRoundTrips
+
+    -- Duplicate-flow no-dedup, now at the inventory level: the two CO2 emissions
+    -- must sum (0.8) on both sides, not collapse to one line.
+    it "preserves duplicate-flow inventory mass across the round-trip" $
+        assertInventoryRoundTrips fixtureDupBio
 
 -- ----------------------------------------------------------------------------
 -- Comparison helpers (order-insensitive, tolerance-aware)

--- a/test/EcoSpold2WriterSpec.hs
+++ b/test/EcoSpold2WriterSpec.hs
@@ -241,7 +241,7 @@ fixtureWithBioSynonyms =
 
 {- | A single activity exercising the subtlest inversion paths: a coproduct
 (outputGroup 2) and waste exchanges in both directions (waIsInput controls
-inputGroup 5 vs outputGroup 1). These round-trip paths were previously
+inputGroup 5 vs outputGroup 2). These round-trip paths were previously
 untested.
 -}
 fixtureWasteCoproduct :: SimpleDatabase
@@ -342,8 +342,9 @@ spec = describe "EcoSpold2 writer round-trip" $ do
                     `shouldBe` [0.3, 0.5]
 
     -- Regression: the subtlest inversion paths. renderWaste maps waIsInput to
-    -- inputGroup 5 / outputGroup 1, and a coproduct goes to outputGroup 2 —
-    -- both must survive write→parse rather than flip direction or role.
+    -- inputGroup 5 / outputGroup 2, and a coproduct goes to outputGroup 2 too
+    -- (the Waste classification, not the group, distinguishes them) — both must
+    -- survive write→parse rather than flip direction or role.
     it "round-trips waste direction (in/out) and a coproduct" $ do
         sdb' <- roundTrip fixtureWasteCoproduct
         case M.lookup (actA, prodA) (sdbActivities sdb') of

--- a/test/EcoSpold2WriterSpec.hs
+++ b/test/EcoSpold2WriterSpec.hs
@@ -1,0 +1,367 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Round-trip contract for the EcoSpold2 writer ('EcoSpold.Writer2'), the
+inverse of 'EcoSpold.Parser2'.
+
+We exercise three properties against a self-contained fixture 'SimpleDatabase'
+built in Haskell:
+
+  (a) __idempotence modulo volatile metadata__ — @write(D)@ then
+      @write(parse(write(D)))@ produce byte-identical output once volatile
+      metadata is excluded (we exclude it by writing with 'noVolatileMeta').
+  (b) __semantic round-trip__ — @parse(write(D))@ is structurally equal to @D@
+      (order-insensitive on exchanges/flows).
+  (c) __score-equivalence__ — @parse(write(D))@ yields the same LCIA inventory
+      (the engine's matrix-level score input) as @D@ within tolerance.
+
+The fixture is constructed directly rather than loaded from a bundled
+@.spold@ directory because the bundled @SAMPLE.units@ fixture deliberately
+reuses a single @unitId@ across flows with *different* unit-name strings (a
+degenerate-input stress test for the parser). The loader collapses those to
+one unit per UUID in name-resolution order, which depends on filename
+ordering — a property of the loader on malformed input, not of the writer.
+A clean fixture (one name per unit UUID, distinct flow UUIDs) isolates the
+writer's own determinism, which is what this spec asserts.
+-}
+module EcoSpold2WriterSpec (spec) where
+
+import Control.Monad (forM_)
+import qualified Data.ByteString as BS
+import Data.Either (isLeft)
+import Data.List (sort, sortOn)
+import qualified Data.Map.Strict as M
+import Data.Maybe (fromMaybe)
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import Database (buildDatabaseWithMatrices)
+import Database.Loader (loadDatabase)
+import EcoSpold.Writer2 (checkEcoSpold2Exportable, noVolatileMeta, writeEcoSpold2)
+import Matrix (computeInventoryMatrix)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+import Types
+import UnitConversion (defaultUnitConfig)
+
+-- | A UUID from its canonical text, or nil if (impossibly) malformed.
+uuid :: Text -> UUID.UUID
+uuid t = fromMaybe UUID.nil (UUID.fromText t)
+
+-- Distinct, well-formed UUIDs for the fixture.
+actA, prodA, actB, prodB :: UUID.UUID
+actA = uuid "aaaaaaaa-0000-4000-8000-000000000001"
+prodA = uuid "aaaaaaaa-0000-4000-8000-0000000000a1"
+actB = uuid "bbbbbbbb-0000-4000-8000-000000000002"
+prodB = uuid "bbbbbbbb-0000-4000-8000-0000000000b2"
+
+co2, land :: UUID.UUID
+co2 = uuid "cccccccc-0000-4000-8000-0000000000c0"
+land = uuid "dddddddd-0000-4000-8000-0000000000d0"
+
+unitKg, unitMJ, unitM2a :: UUID.UUID
+unitKg = uuid "11111111-0000-4000-8000-000000000001"
+unitMJ = uuid "22222222-0000-4000-8000-000000000002"
+unitM2a = uuid "33333333-0000-4000-8000-000000000003"
+
+{- | A self-contained two-activity EcoSpold2 database.
+
+  * Activity A produces product A (1 kg), consumes 2 MJ of product B, and
+    emits 0.5 kg CO2 (biosphere).
+  * Activity B produces product B (1 MJ) and occupies 0.1 m2*year of land.
+
+Every unit UUID maps to exactly one name; every flow UUID is distinct.
+-}
+fixtureSimple :: SimpleDatabase
+fixtureSimple =
+    SimpleDatabase
+        { sdbActivities =
+            M.fromList
+                [ ((actA, prodA), activityA)
+                , ((actB, prodB), activityB)
+                ]
+        , sdbTechFlows =
+            M.fromList
+                [ (prodA, TechnosphereFlow prodA "product A" unitKg M.empty Nothing Nothing)
+                , (prodB, TechnosphereFlow prodB "product B" unitMJ M.empty Nothing Nothing)
+                ]
+        , sdbBioFlows =
+            M.fromList
+                [ (co2, BiosphereFlow co2 "Carbon dioxide, fossil" unitKg M.empty (Just "124-38-9") Nothing (Just (Compartment "air" (Just "unspecified"))))
+                , (land, BiosphereFlow land "Occupation, arable land" unitM2a M.empty Nothing Nothing (Just (Compartment "natural resource" (Just "land"))))
+                ]
+        , sdbWasteFlows = M.empty
+        , sdbUnits =
+            M.fromList
+                [ (unitKg, Unit unitKg "kg" "kg" "")
+                , (unitMJ, Unit unitMJ "MJ" "MJ" "")
+                , (unitM2a, Unit unitM2a "m2*year" "m2*year" "")
+                ]
+        }
+  where
+    activityA =
+        Activity
+            "production of A & B <café> ☕"
+            ["First fixture activity: a & b <c> — ünïcödé"]
+            M.empty
+            (M.fromList [("ISIC rev.4 ecoinvent", "2011:Manufacture of food products"), ("CPC", "2399: Other food products n.e.c.")])
+            "GLO"
+            "kg"
+            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , TechnosphereExchange prodB 2.0 unitMJ Input actB Nothing "" (Just "energy input") Nothing
+            , BiosphereExchange co2 0.5 unitKg Emission "" Nothing Nothing
+            ]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            (Just (EcoSpoldActivityType 1 "Ordinary transforming activity" Nothing Nothing))
+    activityB =
+        Activity
+            "production of B"
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "MJ"
+            [ TechnosphereExchange prodB 1.0 unitMJ ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , BiosphereExchange land 0.1 unitM2a Resource "" Nothing Nothing
+            ]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            (Just (EcoSpoldActivityType 2 "Market activity" (Just 1) (Just "Hard link")))
+
+-- | The fixture as a 'SimpleDatabase' (matches the previous IO-shaped helper).
+loadFixtureSimple :: IO SimpleDatabase
+loadFixtureSimple = pure fixtureSimple
+
+{- | A single-activity database whose only activity emits the same biosphere
+flow (CO2) twice with distinct amounts (0.5 and 0.3). Used to prove the writer
+emits both lines and the round-trip preserves the multiset rather than
+collapsing duplicates on the shared sort key.
+-}
+fixtureDupBio :: SimpleDatabase
+fixtureDupBio =
+    SimpleDatabase
+        { sdbActivities = M.singleton (actA, prodA) activityDup
+        , sdbTechFlows = M.singleton prodA (TechnosphereFlow prodA "product A" unitKg M.empty Nothing Nothing)
+        , sdbBioFlows = M.singleton co2 (BiosphereFlow co2 "Carbon dioxide, fossil" unitKg M.empty Nothing Nothing (Just (Compartment "air" (Just "unspecified"))))
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton unitKg (Unit unitKg "kg" "kg" "")
+        }
+  where
+    activityDup =
+        Activity
+            "production of A"
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "kg"
+            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , BiosphereExchange co2 0.5 unitKg Emission "" Nothing Nothing
+            , BiosphereExchange co2 0.3 unitKg Emission "" Nothing Nothing
+            ]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            (Just (EcoSpoldActivityType 1 "Ordinary transforming activity" Nothing Nothing))
+
+{- | A single-activity database wrapping one adversarial exchange. The
+exchange is the only difference between the rejection fixtures, so the export
+guard ('checkEcoSpold2Exportable') is exercised in isolation.
+-}
+fixtureWithExchange :: Exchange -> SimpleDatabase
+fixtureWithExchange ex =
+    SimpleDatabase
+        { sdbActivities = M.singleton (actA, prodA) activity
+        , sdbTechFlows = M.singleton prodA (TechnosphereFlow prodA "product A" unitKg M.empty Nothing Nothing)
+        , sdbBioFlows = M.singleton co2 (BiosphereFlow co2 "Carbon dioxide, fossil" unitKg M.empty Nothing Nothing (Just (Compartment "air" (Just "unspecified"))))
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton unitKg (Unit unitKg "kg" "kg" "")
+        }
+  where
+    activity =
+        Activity
+            "adversarial activity"
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "kg"
+            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , ex
+            ]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            (Just (EcoSpoldActivityType 1 "Ordinary transforming activity" Nothing Nothing))
+
+-- | Build a full 'Database' (with matrices) from a 'SimpleDatabase'.
+buildDb :: SimpleDatabase -> IO Database
+buildDb sdb = do
+    res <-
+        buildDatabaseWithMatrices
+            defaultUnitConfig
+            (sdbActivities sdb)
+            (sdbTechFlows sdb)
+            (sdbBioFlows sdb)
+            (sdbWasteFlows sdb)
+            (sdbUnits sdb)
+    case res of
+        Left err -> error $ "matrix build failed: " ++ T.unpack err
+        Right db -> pure db
+
+{- | Write a 'SimpleDatabase' to a fresh temp directory and re-load it through
+the production loader, returning the round-tripped 'SimpleDatabase'.
+-}
+roundTrip :: SimpleDatabase -> IO SimpleDatabase
+roundTrip sdb = withSystemTempDirectory "es2-writer" $ \dir -> do
+    -- Write UTF-8 bytes explicitly so the unicode round-trip does not depend on
+    -- the test runner's locale encoding (the loader always decodes UTF-8).
+    forM_ (writeEcoSpold2 noVolatileMeta sdb) $ \(fname, doc) ->
+        BS.writeFile (dir </> fname) (TE.encodeUtf8 doc)
+    res <- loadDatabase defaultUnitConfig dir
+    case res of
+        Left err -> error $ "reparse failed: " ++ T.unpack err
+        Right sdb' -> pure sdb'
+
+spec :: Spec
+spec = describe "EcoSpold2 writer round-trip" $ do
+    -- (a) Idempotence modulo volatile metadata.
+    it "is idempotent modulo volatile metadata: write . parse . write == write" $ do
+        sdb <- loadFixtureSimple
+        let f0 = writeEcoSpold2 noVolatileMeta sdb
+        sdb' <- roundTrip sdb
+        let f1 = writeEcoSpold2 noVolatileMeta sdb'
+        -- Compare the sorted (filename, document) sequences byte-for-byte.
+        sortOn fst f1 `shouldBe` sortOn fst f0
+
+    -- Regression: two exchanges sharing a sort key (same kind + flow) must both
+    -- survive write→parse. A Map-based sort would silently drop one,
+    -- undercounting the inventory; we assert the amounts survive as a multiset.
+    it "keeps duplicate exchanges of the same flow (no silent dedup)" $ do
+        sdb' <- roundTrip fixtureDupBio
+        case M.lookup (actA, prodA) (sdbActivities sdb') of
+            Nothing -> expectationFailure "duplicate-exchange activity missing after round-trip"
+            Just act ->
+                sort [exchangeAmount ex | ex <- exchanges act, isBiosphereExchange ex]
+                    `shouldBe` [0.3, 0.5]
+
+    -- Export-boundary guards: data EcoSpold2 cannot faithfully re-encode must be
+    -- rejected loudly by 'checkEcoSpold2Exportable' rather than silently
+    -- corrupted (a non-finite amount clamps to 0.0; a ReferenceInput re-parses
+    -- as a plain Input, losing the treatment activity's reference designation).
+    describe "rejects un-encodable data at the export boundary" $ do
+        it "rejects a non-finite exchange amount (Infinity clamps to 0.0)" $
+            checkEcoSpold2Exportable
+                (fixtureWithExchange (BiosphereExchange co2 (1 / 0) unitKg Emission "" Nothing Nothing))
+                `shouldSatisfy` isLeft
+
+        it "rejects a reference input (no EcoSpold2 encoding)" $
+            checkEcoSpold2Exportable
+                (fixtureWithExchange (TechnosphereExchange co2 2.0 unitKg ReferenceInput UUID.nil Nothing "" Nothing Nothing))
+                `shouldSatisfy` isLeft
+
+    -- (b) Semantic round-trip: parse(write(D)) ≅ D, order-insensitive.
+    describe "semantic round-trip (structural equality)" $ do
+        it "preserves the activity set keyed by (actUUID, prodUUID)" $ do
+            sdb <- loadFixtureSimple
+            sdb' <- roundTrip sdb
+            M.keys (sdbActivities sdb') `shouldMatchList` M.keys (sdbActivities sdb)
+
+        it "preserves each activity's name, location and exchange multiset" $ do
+            sdb <- loadFixtureSimple
+            sdb' <- roundTrip sdb
+            forM_ (M.toList (sdbActivities sdb)) $ \(key, act) ->
+                case M.lookup key (sdbActivities sdb') of
+                    Nothing -> expectationFailure $ "missing activity after round-trip: " ++ show key
+                    Just act' -> do
+                        activityName act' `shouldBe` activityName act
+                        activityLocation act' `shouldBe` activityLocation act
+                        activityClassification act' `shouldBe` activityClassification act
+                        activityNativeType act' `shouldBe` activityNativeType act
+                        sort (map exchangeFingerprint (exchanges act'))
+                            `shouldBe` sort (map exchangeFingerprint (exchanges act))
+
+        it "preserves the biosphere flow registry (id, name, compartment)" $ do
+            sdb <- loadFixtureSimple
+            sdb' <- roundTrip sdb
+            map bioFingerprint (M.elems (sdbBioFlows sdb'))
+                `shouldMatchList` map bioFingerprint (M.elems (sdbBioFlows sdb))
+
+        it "preserves the technosphere flow registry (id, name)" $ do
+            sdb <- loadFixtureSimple
+            sdb' <- roundTrip sdb
+            map (\f -> (tfId f, tfName f)) (M.elems (sdbTechFlows sdb'))
+                `shouldMatchList` map (\f -> (tfId f, tfName f)) (M.elems (sdbTechFlows sdb))
+
+    -- (c) Score-equivalence: same inventory for every activity within tolerance.
+    it "yields the same LCIA inventory as the original (within tolerance)" $ do
+        sdb <- loadFixtureSimple
+        sdb' <- roundTrip sdb
+        db <- buildDb sdb
+        db' <- buildDb sdb'
+        -- Compare inventories for every process id present in the original.
+        let pids = [0 .. fromIntegral (V.length (dbProcessIdTable db)) - 1] :: [ProcessId]
+        forM_ pids $ \pid -> do
+            inv <- computeInventoryMatrix db pid
+            -- The round-tripped DB may order activities differently; locate the
+            -- matching process by its (actUUID, prodUUID) key.
+            let key = dbProcessIdTable db V.! fromIntegral pid
+            case V.elemIndex key (dbProcessIdTable db') of
+                Nothing -> expectationFailure $ "process key missing after round-trip: " ++ show key
+                Just pid' -> do
+                    inv' <- computeInventoryMatrix db' (fromIntegral pid')
+                    inventoriesClose inv inv' `shouldBe` True
+
+-- ----------------------------------------------------------------------------
+-- Comparison helpers (order-insensitive, tolerance-aware)
+-- ----------------------------------------------------------------------------
+
+-- | Structural fingerprint of an exchange, stable under reordering.
+exchangeFingerprint :: Exchange -> (Int, Text, Bool, Bool, Integer)
+exchangeFingerprint ex =
+    ( kindRank ex
+    , UUID.toText (exchangeFlowId ex)
+    , exchangeIsInput ex
+    , exchangeIsReference ex
+    , roundAmount (exchangeAmount ex)
+    )
+  where
+    kindRank TechnosphereExchange{} = 0
+    kindRank WasteExchange{} = 1
+    kindRank BiosphereExchange{} = 2
+
+-- | Biosphere flow fingerprint: identity, CAS, plus compartment medium/sub.
+bioFingerprint :: BiosphereFlow -> (Text, Text, Maybe Text, Text, Maybe Text)
+bioFingerprint f =
+    ( UUID.toText (bfId f)
+    , bfName f
+    , bfCAS f
+    , maybe "" compartmentName (bfCompartment f)
+    , bfCompartment f >>= compartmentSub
+    )
+
+-- | Quantise an amount so float jitter doesn't break equality (9 sig decimals).
+roundAmount :: Double -> Integer
+roundAmount d = round (d * 1e9)
+
+{- | Two inventories agree within relative+absolute tolerance on every flow
+present in either map. Missing flows are treated as zero.
+-}
+inventoriesClose :: M.Map UUID.UUID Double -> M.Map UUID.UUID Double -> Bool
+inventoriesClose a b =
+    let keys = S.toList (S.fromList (M.keys a) `S.union` S.fromList (M.keys b))
+        close k =
+            let x = M.findWithDefault 0 k a
+                y = M.findWithDefault 0 k b
+             in abs (x - y) <= 1e-9 + 1e-6 * max (abs x) (abs y)
+     in all close keys

--- a/test/EcoSpold2WriterSpec.hs
+++ b/test/EcoSpold2WriterSpec.hs
@@ -204,6 +204,41 @@ fixtureWithExchange ex =
             Nothing
             (Just (EcoSpoldActivityType 1 "Ordinary transforming activity" Nothing Nothing))
 
+{- | A single-activity database whose biosphere flow carries synonyms, so the
+writer's @\<synonym\>@ emission and the parser's read-back are exercised end to
+end (the other fixtures all pass empty synonym maps).
+-}
+fixtureWithBioSynonyms :: SimpleDatabase
+fixtureWithBioSynonyms =
+    SimpleDatabase
+        { sdbActivities = M.singleton (actA, prodA) activity
+        , sdbTechFlows = M.singleton prodA (TechnosphereFlow prodA "product A" unitKg M.empty Nothing Nothing)
+        , sdbBioFlows =
+            M.singleton
+                co2
+                (BiosphereFlow co2 "Carbon dioxide, fossil" unitKg syns (Just "124-38-9") Nothing (Just (Compartment "air" (Just "unspecified"))))
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton unitKg (Unit unitKg "kg" "kg" "")
+        }
+  where
+    syns = M.singleton "en" (S.fromList ["CO2", "carbonic anhydride"])
+    activity =
+        Activity
+            "synonym activity"
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "kg"
+            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , BiosphereExchange co2 0.5 unitKg Emission "" Nothing Nothing
+            ]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            Nothing
+
 {- | A single activity exercising the subtlest inversion paths: a coproduct
 (outputGroup 2) and waste exchanges in both directions (waIsInput controls
 inputGroup 5 vs outputGroup 1). These round-trip paths were previously
@@ -333,6 +368,20 @@ spec = describe "EcoSpold2 writer round-trip" $ do
                 (fixtureWithExchange (TechnosphereExchange co2 2.0 unitKg ReferenceInput UUID.nil Nothing "" Nothing Nothing))
                 `shouldSatisfy` isLeft
 
+        it "rejects an exchange whose unit is absent from the registry" $
+            -- unitMJ is not in the single-unit registry, so the writer would emit
+            -- no <unitName> and the parser would read back UNKNOWN_UNIT.
+            checkEcoSpold2Exportable
+                (fixtureWithExchange (BiosphereExchange co2 1.0 unitMJ Emission "" Nothing Nothing))
+                `shouldSatisfy` isLeft
+
+        it "rejects a subnormal amount that re-parses to zero rather than undercounting" $
+            -- 5e-324's fixed-point form carries too few significant digits for
+            -- Data.Text.Read.double to recover; it would silently export as 0.
+            checkEcoSpold2Exportable
+                (fixtureWithExchange (BiosphereExchange co2 5e-324 unitKg Emission "" Nothing Nothing))
+                `shouldSatisfy` isLeft
+
     -- (b) Semantic round-trip: parse(write(D)) ≅ D, order-insensitive.
     describe "semantic round-trip (structural equality)" $ do
         it "preserves the activity set keyed by (actUUID, prodUUID)" $ do
@@ -366,6 +415,14 @@ spec = describe "EcoSpold2 writer round-trip" $ do
             map (\f -> (tfId f, tfName f)) (M.elems (sdbTechFlows sdb'))
                 `shouldMatchList` map (\f -> (tfId f, tfName f)) (M.elems (sdbTechFlows sdb))
 
+        it "preserves biosphere flow synonyms across the round-trip" $ do
+            -- The writer emits <synonym> lines and the parser reads them back
+            -- (collapsed under "en"); without a fixture carrying synonyms this
+            -- path was unexercised end to end.
+            sdb' <- roundTrip fixtureWithBioSynonyms
+            S.unions (concatMap (M.elems . bfSynonyms) (M.elems (sdbBioFlows sdb')))
+                `shouldBe` S.fromList ["CO2", "carbonic anhydride"]
+
     -- (c) Score-equivalence: same inventory for every activity within tolerance.
     it "yields the same LCIA inventory as the original (within tolerance)" $ do
         sdb <- loadFixtureSimple
@@ -389,14 +446,18 @@ spec = describe "EcoSpold2 writer round-trip" $ do
 -- Comparison helpers (order-insensitive, tolerance-aware)
 -- ----------------------------------------------------------------------------
 
--- | Structural fingerprint of an exchange, stable under reordering.
-exchangeFingerprint :: Exchange -> (Int, Text, Bool, Bool, Integer)
+{- | Structural fingerprint of an exchange, stable under reordering. Carries the
+per-exchange comment so the semantic round-trip actually pins it (the fixture
+gives one input a comment).
+-}
+exchangeFingerprint :: Exchange -> (Int, Text, Bool, Bool, Integer, Maybe Text)
 exchangeFingerprint ex =
     ( kindRank ex
     , UUID.toText (exchangeFlowId ex)
     , exchangeIsInput ex
     , exchangeIsReference ex
     , roundAmount (exchangeAmount ex)
+    , exchangeComment ex
     )
   where
     kindRank TechnosphereExchange{} = 0

--- a/volca.cabal
+++ b/volca.cabal
@@ -83,6 +83,7 @@ library
                      , EcoSpold.Common
                      , EcoSpold.Cutoff
                      , EcoSpold.Parser2
+                     , EcoSpold.Writer2
                      , EcoSpold.Parser1
                      , EcoSpold.Writer1
                      , SimaPro.Parser
@@ -246,6 +247,7 @@ test-suite lca-tests
                      , EcoSpold1Spec
                      , EcoSpold1WriterSpec
                      , EcoSpold2Spec
+                     , EcoSpold2WriterSpec
                      , SimaProWriterSpec
                      , MCPSchemaSpec
                      , BatchImpactsSpec


### PR DESCRIPTION
## What
Serialize an in-memory database to an EcoSpold 2 dataset tree, packaged as a deterministic (epoch-0) zip. Exchange ordering uses a stable sort so two exchanges sharing a flow are both emitted. The writer is the deterministic inverse of its parser, pinned by a three-way round-trip spec: byte-identical modulo volatile metadata, order-insensitive parse∘write, and unchanged LCIA scores across the round-trip.

Part of the #113 split into focused, independently-reviewable PRs. Stacked on `feat/writer-ecospold1` — **merge bottom-up**; #114 (delete) is the base of the stack. Full stack: `cabal test lca-tests` → 1255 examples, 0 failures.