### PR TITLE
feat(ilcd): ILCD writer — canonical inverse of the parser

### DIFF
--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -47,6 +47,7 @@ module BrightwayExcel.Parser (
     sheetToActivities,
     skippedSheetWarning,
     splitCategories,
+    isResourceCompartment,
 ) where
 
 import Codec.Archive.Zip (Archive, findEntryByPath, fromEntry, toArchiveOrFail)
@@ -337,9 +338,16 @@ rawToActivity cfg ra =
             }
 
 {- | Build the reference-product (or coproduct) exchange from a @production@ row,
-falling back to the activity metadata for any field the row omits. The
-reference product is normalized to its canonical base unit at ingest, exactly
-like the SimaPro importer.
+falling back to the activity metadata for any field the row omits.
+
+The /reference/ product is normalized to its canonical base unit at ingest (e.g.
+@g@ → @kg@, scaling the amount), exactly like the SimaPro importer. This makes
+the importer non-injective on the reference unit: a database whose reference unit
+is non-canonical does not satisfy @parse (write d) == d@. The writer's contract
+is instead fixed-point over the parser's /image/ — once a database has been
+parsed (so its reference unit is canonical), @parse (write d) == d@ holds. A
+coproduct row is left in its stated unit (no canonicalization), so it round-trips
+verbatim.
 -}
 productRowOut :: UC.UnitConfig -> M.Map Text CellValue -> Bool -> M.Map Text CellValue -> RowOut
 productRowOut cfg meta isRef f =
@@ -364,7 +372,7 @@ productRowOut cfg meta isRef f =
             , techActivityLinkId = UUID.nil
             , techProcessLinkId = Nothing
             , techLocation = fromMaybe "" (fieldText f "location" <|> metaText meta "location")
-            , techComment = Nothing
+            , techComment = fieldText f "comment"
             , techPedigree = Nothing
             }
     flow = TechnosphereFlow flowUUID name unitUUID M.empty Nothing Nothing
@@ -434,7 +442,7 @@ biosphereRowOut actName f
             , bioAmount = amount
             , bioUnitId = unitUUID
             , bioDirection = if isResourceCompartment comp then Resource else Emission
-            , bioLocation = ""
+            , bioLocation = fromMaybe "" (fieldText f "location")
             , bioComment = fieldText f "comment"
             , bioPedigree = Nothing
             }

--- a/src/BrightwayExcel/Writer.hs
+++ b/src/BrightwayExcel/Writer.hs
@@ -1,0 +1,554 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Writer for the Brightway Excel (@.xlsx@) inventory interchange format — the
+inverse of "BrightwayExcel.Parser".
+
+It serializes a 'SimpleDatabase' (the natural writer input, obtained from a
+'Database' via 'toSimpleDatabase') back into the linear block-stream layout that
+@bw2io@'s @ExcelImporter@ — and our own parser — consumes:
+
+@
+Database              <database name>
+
+Activity              <activity name>
+production amount     1
+reference product     <product>
+location              GLO
+unit                  kilogram
+Exchanges
+name   amount   reference product   location   unit   categories   type           database
+...    1        <product>           GLO        kg                  production     <db>
+...    0.5      <supplier product>  RoW        kg                  technosphere   <db>
+Water  1.6e-4                       GLO        m3     air           biosphere      <db>
+
+@
+
+== Determinism
+
+The output is canonical and deterministic: activities are emitted sorted by
+@(name, location)@, exchanges in a fixed role order (reference product, then
+coproducts, then technosphere inputs, then biosphere flows — each group sorted
+by flow name), and a single fixed @Exchanges@ column order is used regardless of
+how the source file was laid out. Numbers are rendered with 'formatAmount' so
+@1.0@ and @8.5@ are stable. The only volatile field — the workbook-level
+database name — is supplied explicitly via 'WriterConfig', so a round-trip never
+depends on ambient state (timestamps, tool version, machine).
+
+== Encoding
+
+An @.xlsx@ is a zip of XML parts. We mirror the parser's toolchain exactly
+(@zip-archive@ + hand-built SpreadsheetML, the same shape openpyxl/bw2io emit),
+rather than pulling in a new dependency: one worksheet @xl/worksheets/sheet1.xml@
+of inline-string / numeric cells, wired through @xl/workbook.xml@ and its rels.
+Inline strings (@t="inlineStr"@) are used throughout, so no shared-string table
+is needed — and the parser already resolves either form.
+
+Byte-identical round-trips are not a goal (zip stores per-entry metadata): the
+contract proven by the spec is /logical-cell/ idempotence — re-exporting the
+parsed content yields the same workbook, and 'parseBrightwayExcel' of the output
+is structurally equal to the input.
+-}
+module BrightwayExcel.Writer (
+    WriterConfig (..),
+    defaultWriterConfig,
+    writeBrightwayExcel,
+    renderWorkbook,
+    checkBrightwayExportable,
+
+    -- * Exposed for testing
+    Cell (..),
+    activityRows,
+    formatAmount,
+    renderCategories,
+) where
+
+import Codec.Archive.Zip (addEntryToArchive, emptyArchive, fromArchive, toEntry)
+import qualified Data.ByteString.Lazy as BL
+import Data.Char (chr, ord)
+import Data.List (sortOn)
+import qualified Data.Map.Strict as M
+import Data.Maybe (mapMaybe, maybeToList)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified Data.Text.Read as TR
+
+import BrightwayExcel.Parser (isResourceCompartment)
+import EcoSpold.Common (showFFloatTrim)
+import Types
+
+-- ---------------------------------------------------------------------------
+-- Configuration
+-- ---------------------------------------------------------------------------
+
+{- | The only export-time choice that is not derived from the database content:
+the workbook-level @Database@ name written at the top of the sheet and into each
+exchange's @database@ column. Pinning it here (rather than reading a clock or a
+build version) is what makes round-trips reproducible.
+-}
+newtype WriterConfig = WriterConfig
+    { wcDatabaseName :: Text
+    }
+    deriving (Eq, Show)
+
+-- | A neutral default name for ad-hoc exports.
+defaultWriterConfig :: WriterConfig
+defaultWriterConfig = WriterConfig{wcDatabaseName = "exported-database"}
+
+-- ---------------------------------------------------------------------------
+-- Cell model (mirrors the parser's CellValue / the spec emitter)
+-- ---------------------------------------------------------------------------
+
+-- | A cell to emit: text, a number, or an empty (omitted) cell.
+data Cell
+    = CText !Text
+    | CNum !Double
+    | CEmpty
+    deriving (Eq, Show)
+
+-- ---------------------------------------------------------------------------
+-- Top-level
+-- ---------------------------------------------------------------------------
+
+{- | Serialize a 'SimpleDatabase' to a Brightway @.xlsx@ workbook on disk, or
+return the export guard's 'Left' without touching disk.
+-}
+writeBrightwayExcel :: WriterConfig -> SimpleDatabase -> FilePath -> IO (Either Text ())
+writeBrightwayExcel cfg db path =
+    case renderWorkbook cfg db of
+        Left err -> pure (Left err)
+        Right bytes -> Right <$> BL.writeFile path bytes
+
+-- | Pure: assemble the full @.xlsx@ byte stream from the database.
+renderWorkbook :: WriterConfig -> SimpleDatabase -> Either Text BL.ByteString
+renderWorkbook cfg db = do
+    checkBrightwayExportable db
+    pure $
+        fromArchive $
+            foldr
+                addEntryToArchive
+                emptyArchive
+                [ toEntry "xl/workbook.xml" 0 (enc workbookXml)
+                , toEntry "xl/_rels/workbook.xml.rels" 0 (enc relsXml)
+                , toEntry "xl/worksheets/sheet1.xml" 0 (enc (sheetXml (sheetRows cfg db)))
+                ]
+  where
+    enc = BL.fromStrict . TE.encodeUtf8
+
+{- | Guard a Brightway Excel export against exchanges the writer cannot encode.
+'exchangeRow' resolves each exchange's flow name and unit name from the database
+maps; when either lookup misses, the row is 'Nothing' and dropped from the sheet,
+silently losing an amount-bearing exchange. This check rejects such a database at
+the export boundary instead, reporting the first offending activity and whether a
+flow or a unit is missing.
+
+Brightway also has no native waste exchange type. Emitting a 'WasteExchange' as
+@technosphere@ would discard its waste identity and, on re-parse, reconstruct the
+direction from the technosphere convention — turning an output waste into a
+positive technosphere input. Since that link cannot survive faithfully, a
+database carrying any waste exchange is rejected here too.
+
+A biosphere exchange's 'BioDirection' is likewise never written: the parser
+re-derives it from the @categories@ compartment, reading 'Resource' only when the
+compartment matches 'isResourceCompartment'. A 'Resource' flow whose compartment
+is outside that whitelist would round-trip as an 'Emission' — a sign flip, since
+the two directions act as input vs output. Such a flow is rejected here too.
+
+An amount that does not re-parse to itself is rejected: a non-finite
+@NaN@/@Infinity@ (which the parser can propagate from an out-of-range literal),
+or a subnormal near @5e-324@ that 'formatAmount' collapses to @0@. Either would
+silently substitute a different value on re-import.
+
+Databases whose exchanges all resolve, carry no waste, keep every resource
+direction recoverable, and whose amounts all re-parse pass unchanged.
+-}
+checkBrightwayExportable :: SimpleDatabase -> Either Text ()
+checkBrightwayExportable db =
+    case (flowOffenders, unitOffenders, wasteOffenders, refInputOffenders, directionOffenders, roundTripOffenders) of
+        (consumer : _, _, _, _, _, _) ->
+            Left $
+                "Brightway Excel export cannot represent activity \""
+                    <> consumer
+                    <> "\": an exchange references a flow absent from the database."
+        ([], consumer : _, _, _, _, _) ->
+            Left $
+                "Brightway Excel export cannot represent activity \""
+                    <> consumer
+                    <> "\": an exchange references a unit absent from the registry."
+        ([], [], consumer : _, _, _, _) ->
+            Left $
+                "Brightway Excel export cannot represent activity \""
+                    <> consumer
+                    <> "\": it has a waste exchange, which Brightway has no type for."
+        ([], [], [], consumer : _, _, _) ->
+            Left $
+                "Brightway Excel export cannot represent activity \""
+                    <> consumer
+                    <> "\": a reference input (treatment process) has no Brightway encoding;"
+                    <> " it would round-trip to a duplicated, role-flipped exchange."
+        ([], [], [], [], consumer : _, _) ->
+            Left $
+                "Brightway Excel export cannot represent activity \""
+                    <> consumer
+                    <> "\": a resource biosphere flow's compartment would re-parse as an emission."
+        ([], [], [], [], [], (consumer, amt) : _) ->
+            Left $
+                "Brightway Excel export cannot represent activity \""
+                    <> consumer
+                    <> "\": exchange amount "
+                    <> tshow amt
+                    <> " does not re-parse to the same value (non-finite or near-underflow subnormal)."
+        ([], [], [], [], [], []) -> Right ()
+  where
+    -- Names of activities with at least one exchange satisfying @p@. Only the
+    -- first offender is ever reported, so one entry per activity (not per
+    -- exchange) is equivalent — and lets every guard share one comprehension.
+    activitiesWith p =
+        [activityName act | act <- M.elems (sdbActivities db), any p (exchanges act)]
+    flowOffenders = activitiesWith (not . flowResolvable db)
+    unitOffenders = activitiesWith (\ex -> M.notMember (exchangeUnitId ex) (sdbUnits db))
+    wasteOffenders = activitiesWith isWasteExchange
+    refInputOffenders = activitiesWith isReferenceInput
+    directionOffenders = activitiesWith (resourceDirectionLost db)
+    roundTripOffenders =
+        [ (activityName act, amt)
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , let amt = exchangeAmount ex
+        , not (amountRoundTrips amt)
+        ]
+    amountRoundTrips amt = case TR.double (formatAmount amt) of
+        Right (v, rest) -> v == amt && T.null rest
+        Left _ -> False
+
+{- | A 'Resource' biosphere exchange whose compartment would not re-parse as a
+resource: the writer never records the direction, so the parser reconstructs
+it from the @categories@ compartment via 'isResourceCompartment'. When that
+whitelist rejects the compartment, 'Resource' silently flips to 'Emission'.
+A flow absent from the map is left to 'flowResolvable' to report.
+-}
+resourceDirectionLost :: SimpleDatabase -> Exchange -> Bool
+resourceDirectionLost db = \case
+    ex@BiosphereExchange{bioDirection = Resource} ->
+        case M.lookup (exchangeFlowId ex) (sdbBioFlows db) of
+            Just flow -> not (isResourceCompartment (bfCompartmentName flow))
+            Nothing -> False
+    BiosphereExchange{bioDirection = Emission} -> False
+    TechnosphereExchange{} -> False
+    WasteExchange{} -> False
+
+{- | Whether an exchange's flow is present in the map 'exchangeRow' reads it
+from — the same per-role lookup as 'flowNameOf', so this predicts exactly the
+rows the writer would drop.
+-}
+flowResolvable :: SimpleDatabase -> Exchange -> Bool
+flowResolvable db ex = case ex of
+    TechnosphereExchange{} -> M.member (exchangeFlowId ex) (sdbTechFlows db)
+    WasteExchange{} -> M.member (exchangeFlowId ex) (sdbWasteFlows db)
+    BiosphereExchange{} -> M.member (exchangeFlowId ex) (sdbBioFlows db)
+
+-- ---------------------------------------------------------------------------
+-- Sheet content (pure)
+-- ---------------------------------------------------------------------------
+
+{- | The whole worksheet as a list of rows. A leading @Database@ section, then
+one activity block per activity, separated by blank rows. Activities are sorted
+by @(name, location)@ for determinism.
+-}
+sheetRows :: WriterConfig -> SimpleDatabase -> [[Cell]]
+sheetRows cfg db =
+    [ [CText "Database", CText (wcDatabaseName cfg)]
+    , []
+    ]
+        ++ concatMap (\a -> activityRows cfg db a ++ [[]]) sortedActivities
+  where
+    sortedActivities =
+        sortOn (\a -> (activityName a, activityLocation a)) (M.elems (sdbActivities db))
+
+-- | The fixed canonical @Exchanges@ table header.
+exchangeHeader :: [Cell]
+exchangeHeader =
+    map
+        CText
+        ["name", "amount", "reference product", "location", "unit", "categories", "type", "comment", "database"]
+
+{- | One activity block: the @Activity@ row, metadata key/value rows, the
+@Exchanges@ header, then one row per exchange in canonical order. The metadata
+@production amount@ / @unit@ / @reference product@ are taken from the activity's
+reference exchange so a parse → write round-trip reproduces them, and the
+@production amount@ fallback stays consistent with the reference row's amount.
+
+'activityDescription' is newline-joined into the single @comment@ cell the
+format allows. The parser reads it back as a one-element description
+('Data.Maybe.maybeToList'), so an activity carrying a /multi-paragraph/
+description is not a fixed point of @parse . write@ (the text survives; the
+paragraph split does not). Once parsed it has ≤1 element and round-trips exactly
+— the same "fixed-point over the parser's image" caveat the parser documents for
+reference-unit canonicalization.
+-}
+activityRows :: WriterConfig -> SimpleDatabase -> Activity -> [[Cell]]
+activityRows cfg db act =
+    [ [CText "Activity", CText (activityName act)]
+    , [CText "production amount", CNum refAmount]
+    ]
+        ++ [[CText "reference product", CText p] | p <- maybeToList refProduct]
+        ++ [[CText "location", CText (activityLocation act)]]
+        ++ [[CText "unit", CText u] | u <- maybeToList refUnit, not (T.null u)]
+        ++ [[CText "comment", CText comment] | not (null (activityDescription act))]
+        ++ [[CText "Exchanges"], exchangeHeader]
+        ++ exchangeDataRows
+  where
+    comment = T.intercalate "\n" (activityDescription act)
+    ordered = orderedExchanges db (exchanges act)
+    exchangeDataRows = mapMaybe (exchangeRow cfg db) ordered
+    refExchange = lookup' exchangeIsReference ordered
+    refProduct = refExchange >>= flowNameOf db
+    refUnit = (`unitNameOf` db) . exchangeUnitId =<< refExchange
+    refAmount = maybe 1 exchangeAmount refExchange
+
+{- | Canonical exchange order: reference product first, then coproducts, then
+ordinary technosphere inputs, then biosphere flows — each group sorted by flow
+name, with the flow id as a stable tiebreaker for same-named flows. Sorting by
+name keeps the exported columns legible; the id tiebreaker keeps the order total
+and deterministic, so two databases with the same content serialize identically.
+-}
+orderedExchanges :: SimpleDatabase -> [Exchange] -> [Exchange]
+orderedExchanges db exs = concatMap (sortOn sortKey) groups
+  where
+    groups = [refs, coproducts, techInputs, bios, wastes]
+    refs = filter exchangeIsReference exs
+    coproducts = filter isCoproduct exs
+    techInputs = filter isTechInput exs
+    bios = filter isBio exs
+    wastes = filter isWaste exs
+    sortKey ex = (flowNameOf db ex, exchangeFlowId ex)
+
+isCoproduct :: Exchange -> Bool
+isCoproduct = \case
+    TechnosphereExchange{techRole = Coproduct} -> True
+    TechnosphereExchange{} -> False
+    BiosphereExchange{} -> False
+    WasteExchange{} -> False
+
+{- | Ordinary technosphere inputs only. 'ReferenceInput' is intentionally
+excluded: it already belongs to the reference group ('exchangeIsReference'),
+so matching it here too would emit the exchange twice — double-counting its
+coefficient when the workbook is re-imported and duplicate (i,j) entries are
+summed. Each role thus lands in exactly one group.
+-}
+isTechInput :: Exchange -> Bool
+isTechInput = \case
+    TechnosphereExchange{techRole = Input} -> True
+    TechnosphereExchange{} -> False
+    BiosphereExchange{} -> False
+    WasteExchange{} -> False
+
+isBio :: Exchange -> Bool
+isBio = \case
+    BiosphereExchange{} -> True
+    TechnosphereExchange{} -> False
+    WasteExchange{} -> False
+
+isWaste :: Exchange -> Bool
+isWaste = \case
+    WasteExchange{} -> True
+    TechnosphereExchange{} -> False
+    BiosphereExchange{} -> False
+
+-- | A treatment process's reference input — rejected by 'checkBrightwayExportable'.
+isReferenceInput :: Exchange -> Bool
+isReferenceInput = \case
+    TechnosphereExchange{techRole = ReferenceInput} -> True
+    TechnosphereExchange{} -> False
+    BiosphereExchange{} -> False
+    WasteExchange{} -> False
+
+{- | Render one exchange to a data row aligned to 'exchangeHeader'. Returns
+'Nothing' for an exchange whose flow or unit is missing from the database (it
+cannot be written faithfully, so it is dropped rather than emitted with blanks
+that would re-parse into a different flow). The @name@ and @reference product@
+columns both carry the flow name so the parser reconstructs the same flow UUID.
+-}
+exchangeRow :: WriterConfig -> SimpleDatabase -> Exchange -> Maybe [Cell]
+exchangeRow cfg db = \case
+    ex@TechnosphereExchange{techAmount = amt, techRole = role, techLocation = loc} -> do
+        name <- flowNameOf db ex
+        unit <- unitNameOf (exchangeUnitId ex) db
+        Just
+            [ CText name
+            , CNum amt
+            , CText name
+            , locCell loc
+            , CText unit
+            , CEmpty
+            , CText (techTypeLabel role)
+            , commentCell (techComment ex)
+            , CText (wcDatabaseName cfg)
+            ]
+    ex@BiosphereExchange{bioAmount = amt, bioLocation = loc} -> do
+        flow <- M.lookup (exchangeFlowId ex) (sdbBioFlows db)
+        unit <- unitNameOf (exchangeUnitId ex) db
+        Just
+            [ CText (bfName flow)
+            , CNum amt
+            , CEmpty
+            , locCell loc
+            , CText unit
+            , CText (renderCategories (bfCompartment flow))
+            , CText "biosphere"
+            , commentCell (bioComment ex)
+            , CText (wcDatabaseName cfg)
+            ]
+    ex@WasteExchange{waAmount = amt, waLocation = loc} -> do
+        name <- flowNameOf db ex
+        unit <- unitNameOf (exchangeUnitId ex) db
+        -- Unreachable on any guarded path: 'checkBrightwayExportable' (run by
+        -- 'renderWorkbook' before serialization) rejects every database carrying a
+        -- waste exchange, precisely because re-parsing it as technosphere would
+        -- invert an output waste into a positive input. This branch only keeps
+        -- 'exchangeRow' total without a silent drop; it never reaches the workbook.
+        Just
+            [ CText name
+            , CNum amt
+            , CText name
+            , locCell loc
+            , CText unit
+            , CEmpty
+            , CText "technosphere"
+            , commentCell (waComment ex)
+            , CText (wcDatabaseName cfg)
+            ]
+  where
+    locCell l = if T.null l then CEmpty else CText l
+    commentCell = maybe CEmpty CText
+
+-- | Brightway @type@ label for a technosphere role.
+techTypeLabel :: TechRole -> Text
+techTypeLabel = \case
+    ReferenceProduct -> "production"
+    Coproduct -> "production"
+    ReferenceInput -> "technosphere"
+    Input -> "technosphere"
+
+{- | Render a 'Compartment' to a Brightway @categories@ cell (@"air"@ or
+@"natural resource::in water"@). 'Nothing' (no compartment recorded) and an
+empty medium both become an empty cell — the inverse of 'splitCategories'.
+-}
+renderCategories :: Maybe Compartment -> Text
+renderCategories = \case
+    Nothing -> ""
+    Just (Compartment comp sub) -> case sub of
+        Just s | not (T.null (T.strip s)) -> comp <> "::" <> s
+        _ -> comp
+
+-- ---------------------------------------------------------------------------
+-- Lookups (pure)
+-- ---------------------------------------------------------------------------
+
+-- | Resolve the display name of a technosphere/waste exchange's flow.
+flowNameOf :: SimpleDatabase -> Exchange -> Maybe Text
+flowNameOf db = \case
+    ex@TechnosphereExchange{} -> tfName <$> M.lookup (exchangeFlowId ex) (sdbTechFlows db)
+    ex@WasteExchange{} -> wfName <$> M.lookup (exchangeFlowId ex) (sdbWasteFlows db)
+    ex@BiosphereExchange{} -> bfName <$> M.lookup (exchangeFlowId ex) (sdbBioFlows db)
+
+unitNameOf :: UUID -> SimpleDatabase -> Maybe Text
+unitNameOf uid db = unitName <$> M.lookup uid (sdbUnits db)
+
+-- | First element matching a predicate (total; no partial 'head').
+lookup' :: (a -> Bool) -> [a] -> Maybe a
+lookup' p = foldr (\x acc -> if p x then Just x else acc) Nothing
+
+-- ---------------------------------------------------------------------------
+-- Numeric formatting (pure, deterministic)
+-- ---------------------------------------------------------------------------
+
+{- | Canonical numeric rendering for amount cells. Integers print without a
+decimal point (@1@, not @1.0@); every other value uses the shared fixed-point
+'showFFloatTrim' (never scientific), so it re-parses through the parser's
+'Data.Text.Read.double' — unlike @show@, whose scientific notation re-reads
+lossily for small magnitudes (e.g. @show 3.3e-20@ → @3.2999999999999994e-20@).
+The near-underflow subnormal tail (≈@5e-324@) cannot survive fixed-point, and a
+non-finite value has no numeric-cell form; 'checkBrightwayExportable' rejects
+both, so the guarded path never emits one. A non-finite value still renders as
+its (non-parseable) @"NaN"@/@"Infinity"@ form so a stray re-import fails loudly
+rather than reading a misleading number.
+-}
+formatAmount :: Double -> Text
+formatAmount d
+    | isNaN d || isInfinite d = tshow d
+    | d == fromIntegral i && abs d < 1.0e15 = T.pack (show i)
+    | otherwise = T.pack (showFFloatTrim d)
+  where
+    i = round d :: Integer
+
+-- ---------------------------------------------------------------------------
+-- SpreadsheetML emitter (hand-built, mirrors the parser's reader)
+-- ---------------------------------------------------------------------------
+
+workbookXml :: Text
+workbookXml =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        <> "<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\""
+        <> " xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">"
+        <> "<sheets><sheet name=\"data\" sheetId=\"1\" r:id=\"rId1\"/></sheets>"
+        <> "</workbook>"
+
+relsXml :: Text
+relsXml =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        <> "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">"
+        <> "<Relationship Id=\"rId1\""
+        <> " Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\""
+        <> " Target=\"worksheets/sheet1.xml\"/>"
+        <> "</Relationships>"
+
+sheetXml :: [[Cell]] -> Text
+sheetXml rows =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        <> "<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"><sheetData>"
+        <> T.concat [rowXml n r | (n, r) <- zip [1 ..] rows]
+        <> "</sheetData></worksheet>"
+
+rowXml :: Int -> [Cell] -> Text
+rowXml n cells =
+    "<row r=\""
+        <> tshow n
+        <> "\">"
+        <> T.concat [cellXml col n cell | (col, cell) <- zip [0 ..] cells]
+        <> "</row>"
+
+-- | Empty cells are omitted entirely (sparse rows, like the parser expects).
+cellXml :: Int -> Int -> Cell -> Text
+cellXml _ _ CEmpty = ""
+cellXml col n (CNum d) =
+    "<c r=\"" <> cellRef col n <> "\" t=\"n\"><v>" <> formatAmount d <> "</v></c>"
+cellXml col n (CText t) =
+    "<c r=\""
+        <> cellRef col n
+        <> "\" t=\"inlineStr\"><is><t xml:space=\"preserve\">"
+        <> escapeXml t
+        <> "</t></is></c>"
+
+-- | A1-style cell reference. Columns beyond Z use multi-letter references.
+cellRef :: Int -> Int -> Text
+cellRef col n = columnLetters col <> tshow n
+
+columnLetters :: Int -> Text
+columnLetters = T.pack . reverse . go
+  where
+    go c =
+        let (q, r) = (c `div` 26, c `mod` 26)
+            letter = chr (ord 'A' + r)
+         in letter : if q == 0 then [] else go (q - 1)
+
+escapeXml :: Text -> Text
+escapeXml =
+    T.replace "\"" "&quot;"
+        . T.replace ">" "&gt;"
+        . T.replace "<" "&lt;"
+        . T.replace "&" "&amp;"
+
+tshow :: (Show a) => a -> Text
+tshow = T.pack . show

--- a/src/EcoSpold/Common.hs
+++ b/src/EcoSpold/Common.hs
@@ -30,11 +30,16 @@ We also decode the two numeric character references (line feed and
 carriage return) that frequently appear inside attribute values in
 EcoSpold exports (e.g. `generalComment="text&#10;"`).
 -}
+
+-- @&amp;@ is resolved LAST (leftmost in the composition runs last), the exact
+-- inverse of the writers escaping @&@ FIRST. Resolving it first would turn an
+-- escaped literal @"&lt;"@ (written as @"&amp;lt;"@) back into @"<"@ instead of
+-- @"&lt;"@ — a silent round-trip corruption for entity-like text.
 decodeXmlEntities :: Text -> Text
 decodeXmlEntities =
-    T.replace "&lt;" "<"
+    T.replace "&amp;" "&"
+        . T.replace "&lt;" "<"
         . T.replace "&gt;" ">"
-        . T.replace "&amp;" "&"
         . T.replace "&quot;" "\""
         . T.replace "&apos;" "'"
         . T.replace "&#10;" "\n"

--- a/src/ILCD/Writer.hs
+++ b/src/ILCD/Writer.hs
@@ -24,7 +24,7 @@ Determinism is the contract:
   @write (parse (write d)) == write d@ holds byte-for-byte.
 
 What round-trips: process UUID, name, location, classifications, processType,
-every exchange (flow ref, direction, amount, per-exchange comment), and the
+every exchange (flow ref, direction, amount, location, per-exchange comment), and the
 full flow + unit catalog (names, CAS, biosphere compartment, flow type, the
 flow→unit reference). These are exactly the fields "ILCD.Parser" reads back;
 fields the parser drops (activity description, synonyms, params, allocation,
@@ -343,10 +343,20 @@ exchangeXML i ex =
     , elem' "exchangeDirection" direction
     , elem' "resultingAmount" (formatDouble (exchangeAmount ex))
     ]
+        ++ locationBlock (exchangeLocation ex)
         ++ commentBlock (exchangeComment ex)
         ++ ["    </exchange>"]
   where
     direction = if exchangeIsInput ex then "Input" else "Output"
+
+{- | Per-exchange @<location>@, which the parser reads back into the exchange's
+location field. Omitted when empty — the common case, since ILCD geography lives
+at the process level — so it never perturbs the byte-stable round-trip.
+-}
+locationBlock :: Text -> [Text]
+locationBlock loc
+    | T.null loc = []
+    | otherwise = [elem' "location" loc]
 
 -- | Per-exchange comment, English-tagged to match the parser's preference.
 commentBlock :: Maybe Text -> [Text]

--- a/src/ILCD/Writer.hs
+++ b/src/ILCD/Writer.hs
@@ -64,6 +64,7 @@ import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
+import qualified Data.Text.Read as TR
 import qualified Data.UUID as UUID
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath ((</>))
@@ -143,13 +144,21 @@ ilcdFiles opts db = sortOn fst (processes ++ flows ++ flowProps ++ unitGroups)
   — @""@ (key vanishes), or @"a//b"@ \/ @"a/"@ (collapses to @"a/b"@ \/ @"a"@) —
   therefore does not round-trip.
 
-Rather than silently corrupting either, report the first offending flow or
-activity so the caller can fail loudly. Databases whose activity UUIDs are all
-unique, whose biosphere media are all canonical and whose classification levels
-are all non-empty pass unchanged.
+* /Amounts that do not re-parse./ 'formatDouble' is fixed-point, so a non-finite
+  amount (@NaN@\/@Infinity@, which the parser can propagate from an out-of-range
+  literal like @"1e400"@) or a subnormal near @5e-324@ would re-import as a
+  different number (or fail to parse), silently shifting LCIA scores. We reject
+  any amount that does not re-parse to itself.
+
+Rather than silently corrupting any of these, report the first offending flow,
+activity or exchange so the caller can fail loudly. Databases whose activity
+UUIDs are all unique, whose biosphere media are all canonical, whose
+classification levels are all non-empty and whose amounts all re-parse pass
+unchanged.
 -}
 checkILCDExportable :: SimpleDatabase -> Either Text ()
-checkILCDExportable db = checkMedia >> checkMultiOutput >> checkClassifications
+checkILCDExportable db =
+    checkMedia >> checkMultiOutput >> checkClassifications >> checkAmounts
   where
     -- Media the parser's @extractMedium@ inverts back to the same string.
     canonicalMedia = ["air", "water", "soil", "natural resource"]
@@ -210,6 +219,30 @@ checkILCDExportable db = checkMedia >> checkMultiOutput >> checkClassifications
                         <> uuidText actUUID
                         <> "): an empty classification level does not round-trip "
                         <> "because the ILCD parser drops empty levels."
+
+    -- An amount round-trips only when its fixed-point rendering re-parses to the
+    -- same value through the parser's 'Data.Text.Read.double' (consuming all of
+    -- it). Rejects non-finite amounts and the subnormal tail near 5e-324.
+    checkAmounts =
+        case [ (actUUID, exchangeAmount ex)
+             | ((actUUID, _), act) <- M.toList (sdbActivities db)
+             , ex <- exchanges act
+             , not (amountRoundTrips (exchangeAmount ex))
+             ] of
+            [] -> Right ()
+            ((actUUID, amt) : _) ->
+                Left $
+                    "ILCD export cannot represent amount "
+                        <> T.pack (show amt)
+                        <> " on activity \""
+                        <> nameOf actUUID
+                        <> "\" (UUID "
+                        <> uuidText actUUID
+                        <> "): it does not re-parse to the same value through the "
+                        <> "ILCD parser (non-finite or near-underflow subnormal)."
+    amountRoundTrips amt = case TR.double (formatDouble amt) of
+        Right (v, rest) -> v == amt && T.null rest
+        Left _ -> False
 
 {- | Write the ILCD package as a directory tree rooted at @dir@, or return the
 export guard's 'Left' without touching disk.
@@ -573,16 +606,20 @@ escapeXmlAttr =
         . escapeXml
 
 {- | Canonical 'Double' formatting via the shared 'showFFloatTrim' (fixed-point,
-never scientific), so the value round-trips byte- and value-identically through
-the parser's 'Data.Text.Read.double' — unlike @show@, which emits scientific
-notation for small/large magnitudes that re-reads lossily (e.g. @show 3.3e-20@ →
-@3.2999999999999994e-20@, and @5.0e-324@ → @0@). Non-finite values (which cannot
-occur in a parsed database) are clamped to a parseable @0.0@; negative zero is
+never scientific), so the value round-trips through the parser's
+'Data.Text.Read.double' for the magnitudes real LCA amounts occupy — unlike
+@show@, which emits scientific notation that re-reads lossily (e.g. @show 3.3e-20@
+→ @3.2999999999999994e-20@). The near-underflow subnormal tail (≈@5e-324@) is the
+exception (fixed-point can't carry enough digits, so it re-parses to @0@);
+'checkILCDExportable' rejects any amount that does not re-parse, so the guarded
+path never emits one. A non-finite value renders as its (non-parseable)
+@"NaN"@/@"Infinity"@ form so a bad re-import fails loudly rather than silently
+reading @0@; the guard rejects non-finite amounts first. Negative zero is
 normalised to @0.0@.
 -}
 formatDouble :: Double -> Text
 formatDouble x
-    | isNaN x || isInfinite x = "0.0"
+    | isNaN x || isInfinite x = T.pack (show x)
     | x == 0 = "0.0"
     | otherwise = T.pack (showFFloatTrim x)
 

--- a/src/ILCD/Writer.hs
+++ b/src/ILCD/Writer.hs
@@ -103,8 +103,8 @@ ilcdFiles :: WriteOptions -> SimpleDatabase -> [(FilePath, BS.ByteString)]
 ilcdFiles opts db = sortOn fst (processes ++ flows ++ flowProps ++ unitGroups)
   where
     processes =
-        [ ("processes" </> uuidStr actUUID <> ".xml", render (processXML opts db key act))
-        | (key@(actUUID, _prodUUID), act) <- M.toAscList (sdbActivities db)
+        [ ("processes" </> uuidStr actUUID <> ".xml", render (processXML opts actUUID act))
+        | ((actUUID, _prodUUID), act) <- M.toAscList (sdbActivities db)
         ]
 
     flows =
@@ -282,10 +282,9 @@ writeILCDArchive opts db = do
 -- | All flows in the database as 'FlowKind' + unit id, sorted by flow UUID.
 allFlows :: SimpleDatabase -> [(FlowKind, UUID)]
 allFlows db =
-    sortOn (flowKindId . fst) $
-        [(TechKind f, tfUnitId f) | f <- M.elems (sdbTechFlows db)]
-            ++ [(BioKind f, bfUnitId f) | f <- M.elems (sdbBioFlows db)]
-            ++ [(WasteKind f, wfUnitId f) | f <- M.elems (sdbWasteFlows db)]
+    [(TechKind f, tfUnitId f) | f <- M.elems (sdbTechFlows db)]
+        ++ [(BioKind f, bfUnitId f) | f <- M.elems (sdbBioFlows db)]
+        ++ [(WasteKind f, wfUnitId f) | f <- M.elems (sdbWasteFlows db)]
 
 --------------------------------------------------------------------------------
 -- Process XML
@@ -296,8 +295,8 @@ gets @dataSetInternalID@ matching @referenceToReferenceFlow@; remaining
 exchanges follow in their list order, so the parser reads them back in the
 same order it would re-serialize.
 -}
-processXML :: WriteOptions -> SimpleDatabase -> (UUID, UUID) -> Activity -> [Text]
-processXML opts _db (actUUID, _prodUUID) act =
+processXML :: WriteOptions -> UUID -> Activity -> [Text]
+processXML opts actUUID act =
     [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
     , "<processDataSet xmlns=\"http://lca.jrc.it/ILCD/Process\" xmlns:common=\"http://lca.jrc.it/ILCD/Common\">"
     , "  <processInformation>"

--- a/src/ILCD/Writer.hs
+++ b/src/ILCD/Writer.hs
@@ -1,0 +1,580 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{- | Serialize a VoLCA 'Database'/'SimpleDatabase' to an ILCD process-dataset
+package — the inverse of "ILCD.Parser".
+
+The output is a canonical, deterministic ILCD directory tree (and, optionally,
+a zip of it) with four subdirectories:
+
+@
+  processes/      one XML per activity (keyed by activity UUID)
+  flows/          one XML per tech/bio/waste flow
+  flowproperties/ one XML per unit group (1:1 with units)
+  unitgroups/     one XML per unit
+@
+
+Determinism is the contract:
+
+* every Map/Set-derived list is sorted by key before emission;
+* every 'Double' is formatted through one fixed formatter ('formatDouble');
+* the only volatile field an ILCD reader/writer round-trip could disagree on
+  — the export timestamp / generator string — is /omitted/ entirely unless a
+  caller passes one explicitly via 'WriteOptions'. We never inject @now@, so
+  @write (parse (write d)) == write d@ holds byte-for-byte.
+
+What round-trips: process UUID, name, location, classifications, processType,
+every exchange (flow ref, direction, amount, per-exchange comment), and the
+full flow + unit catalog (names, CAS, biosphere compartment, flow type, the
+flow→unit reference). These are exactly the fields "ILCD.Parser" reads back;
+fields the parser drops (activity description, synonyms, params, allocation,
+pedigree) are not representable in this ILCD profile and are not emitted.
+
+The flow→unit indirection mirrors the parser's resolution chain
+@flow → flowProperty → unitGroup@: we emit one flowProperty and one unitGroup
+per VoLCA unit, all sharing the unit's UUID, so the parser reconstructs the
+same unit key.
+-}
+module ILCD.Writer (
+    -- * Options
+    WriteOptions (..),
+    defaultWriteOptions,
+
+    -- * Writing
+    writeILCDDatabase,
+    writeILCDArchive,
+    ilcdFiles,
+    checkILCDExportable,
+
+    -- * Pure helpers (exported for testing)
+    escapeXml,
+    formatDouble,
+    processXML,
+    flowXML,
+    flowPropertyXML,
+    unitGroupXML,
+) where
+
+import Codec.Archive.Zip (addEntryToArchive, emptyArchive, fromArchive, toEntry)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BL
+import Data.List (sortOn)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified Data.UUID as UUID
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath ((</>))
+
+import Types
+
+--------------------------------------------------------------------------------
+-- Options
+--------------------------------------------------------------------------------
+
+{- | Knobs that pin or omit volatile metadata. Defaults omit everything
+volatile, so a write→parse→write round-trip is byte-stable.
+-}
+data WriteOptions = WriteOptions
+    { woTimestamp :: !(Maybe Text)
+    {- ^ Pinned export timestamp, emitted as @<common:timeStamp>@. 'Nothing'
+    omits the element entirely (the parser ignores it either way).
+    -}
+    , woGenerator :: !(Maybe Text)
+    -- ^ Pinned generator / tool-version string. 'Nothing' omits it.
+    }
+
+-- | Omit all volatile metadata. The right default for reproducible exports.
+defaultWriteOptions :: WriteOptions
+defaultWriteOptions = WriteOptions{woTimestamp = Nothing, woGenerator = Nothing}
+
+--------------------------------------------------------------------------------
+-- Top-level: directory / archive
+--------------------------------------------------------------------------------
+
+{- | Produce the full set of @(relativePath, contents)@ pairs for the ILCD
+package. Pure and deterministic. The result is sorted by path.
+-}
+ilcdFiles :: WriteOptions -> SimpleDatabase -> [(FilePath, BS.ByteString)]
+ilcdFiles opts db = sortOn fst (processes ++ flows ++ flowProps ++ unitGroups)
+  where
+    processes =
+        [ ("processes" </> uuidStr actUUID <> ".xml", render (processXML opts db key act))
+        | (key@(actUUID, _prodUUID), act) <- M.toAscList (sdbActivities db)
+        ]
+
+    flows =
+        [ ("flows" </> uuidStr (flowKindId fk) <> ".xml", render (flowXML fk unitRef))
+        | (fk, unitRef) <- allFlows db
+        ]
+
+    flowProps =
+        [ ("flowproperties" </> uuidStr uid <> ".xml", render (flowPropertyXML u))
+        | (uid, u) <- M.toAscList (sdbUnits db)
+        ]
+
+    unitGroups =
+        [ ("unitgroups" </> uuidStr uid <> ".xml", render (unitGroupXML u))
+        | (uid, u) <- M.toAscList (sdbUnits db)
+        ]
+
+    -- Render the list of lines to canonical UTF-8 bytes.
+    render = TE.encodeUtf8 . renderLines
+
+{- | Guard an ILCD export against data the parser cannot read back losslessly:
+
+* /Multi-output activities./ ILCD identifies a process by a single dataset UUID
+  with one process per file, keyed here on the activity UUID alone. A
+  multi-output activity — several @(actUUID, prodUUID)@ entries sharing one
+  @actUUID@ — would therefore write two processes to the same filename and the
+  same @common:UUID@, and re-import could only keep one.
+
+* /Non-canonical biosphere media./ 'compartmentBlock' emits @"Emissions to
+  <medium>"@ for any non-resource medium, but the parser's @extractMedium@ only
+  inverts the canonical air\/water\/soil\/natural-resource phrasings; any other
+  medium (e.g. @"resource"@ from ES1\/ES2, or @"fresh water"@) re-imports under a
+  different compartment, silently shifting LCIA scores.
+
+* /Empty classification levels./ 'classificationBlock' joins levels with @"/"@
+  and the parser splits on it, dropping empty parts. A value with an empty level
+  — @""@ (key vanishes), or @"a//b"@ \/ @"a/"@ (collapses to @"a/b"@ \/ @"a"@) —
+  therefore does not round-trip.
+
+Rather than silently corrupting either, report the first offending flow or
+activity so the caller can fail loudly. Databases whose activity UUIDs are all
+unique, whose biosphere media are all canonical and whose classification levels
+are all non-empty pass unchanged.
+-}
+checkILCDExportable :: SimpleDatabase -> Either Text ()
+checkILCDExportable db = checkMedia >> checkMultiOutput >> checkClassifications
+  where
+    -- Media the parser's @extractMedium@ inverts back to the same string.
+    canonicalMedia = ["air", "water", "soil", "natural resource"]
+    checkMedia =
+        case [f | f <- M.elems (sdbBioFlows db), notInvertible f] of
+            [] -> Right ()
+            (f : _) ->
+                Left $
+                    "ILCD export cannot represent biosphere flow \""
+                        <> bfName f
+                        <> "\" (UUID "
+                        <> uuidText (bfId f)
+                        <> "): compartment medium \""
+                        <> bfCompartmentName f
+                        <> "\" is not one the ILCD parser can read back; "
+                        <> "only air, water, soil and natural resource round-trip."
+    notInvertible f = case bfCompartment f of
+        Nothing -> False
+        Just c -> compartmentName c `notElem` canonicalMedia
+
+    checkMultiOutput =
+        case M.toList collisions of
+            [] -> Right ()
+            ((actUUID, n) : _) ->
+                Left $
+                    "ILCD export cannot represent multi-output activity \""
+                        <> nameOf actUUID
+                        <> "\" (UUID "
+                        <> uuidText actUUID
+                        <> "): "
+                        <> T.pack (show n)
+                        <> " reference products share one activity UUID, which ILCD keys a process by."
+    counts = M.fromListWith (+) [(actUUID, 1 :: Int) | (actUUID, _prodUUID) <- M.keys (sdbActivities db)]
+    collisions = M.filter (> 1) counts
+    nameOf actUUID =
+        case [activityName act | ((a, _), act) <- M.toList (sdbActivities db), a == actUUID] of
+            (nm : _) -> nm
+            [] -> "?"
+
+    -- A classification value round-trips only when none of its "/"-joined levels
+    -- is empty; the parser splits on "/" and drops empty parts.
+    checkClassifications =
+        case [ (actUUID, name, value)
+             | ((actUUID, _), act) <- M.toList (sdbActivities db)
+             , (name, value) <- M.toList (activityClassification act)
+             , any T.null (T.splitOn "/" value)
+             ] of
+            [] -> Right ()
+            ((actUUID, name, value) : _) ->
+                Left $
+                    "ILCD export cannot represent classification \""
+                        <> name
+                        <> "\" = \""
+                        <> value
+                        <> "\" on activity \""
+                        <> nameOf actUUID
+                        <> "\" (UUID "
+                        <> uuidText actUUID
+                        <> "): an empty classification level does not round-trip "
+                        <> "because the ILCD parser drops empty levels."
+
+-- | Write the ILCD package as a directory tree rooted at @dir@.
+writeILCDDatabase :: WriteOptions -> FilePath -> SimpleDatabase -> IO ()
+writeILCDDatabase opts dir db = do
+    createDirectoryIfMissing True (dir </> "processes")
+    createDirectoryIfMissing True (dir </> "flows")
+    createDirectoryIfMissing True (dir </> "flowproperties")
+    createDirectoryIfMissing True (dir </> "unitgroups")
+    mapM_ (\(rel, bytes) -> BS.writeFile (dir </> rel) bytes) (ilcdFiles opts db)
+
+{- | Build a deterministic zip 'Archive' of the ILCD package and return its
+serialized bytes. Entry modification times are pinned to epoch 0 so the
+archive bytes are reproducible.
+-}
+writeILCDArchive :: WriteOptions -> SimpleDatabase -> BL.ByteString
+writeILCDArchive opts db = fromArchive (buildArchive (ilcdFiles opts db))
+  where
+    buildArchive = foldl addOne emptyArchive
+    -- Fixed epoch (0) keeps archive bytes stable across runs.
+    addOne arc (path, bytes) =
+        addEntryToArchive (toEntry path 0 (BL.fromStrict bytes)) arc
+
+--------------------------------------------------------------------------------
+-- Flow enumeration (tech ∪ bio ∪ waste), tagged with their unit id
+--------------------------------------------------------------------------------
+
+-- | All flows in the database as 'FlowKind' + unit id, sorted by flow UUID.
+allFlows :: SimpleDatabase -> [(FlowKind, UUID)]
+allFlows db =
+    sortOn (flowKindId . fst) $
+        [(TechKind f, tfUnitId f) | f <- M.elems (sdbTechFlows db)]
+            ++ [(BioKind f, bfUnitId f) | f <- M.elems (sdbBioFlows db)]
+            ++ [(WasteKind f, wfUnitId f) | f <- M.elems (sdbWasteFlows db)]
+
+--------------------------------------------------------------------------------
+-- Process XML
+--------------------------------------------------------------------------------
+
+{- | Render one ILCD process dataset for an activity. The reference exchange
+gets @dataSetInternalID@ matching @referenceToReferenceFlow@; remaining
+exchanges follow in their list order, so the parser reads them back in the
+same order it would re-serialize.
+-}
+processXML :: WriteOptions -> SimpleDatabase -> (UUID, UUID) -> Activity -> [Text]
+processXML opts _db (actUUID, _prodUUID) act =
+    [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    , "<processDataSet xmlns=\"http://lca.jrc.it/ILCD/Process\" xmlns:common=\"http://lca.jrc.it/ILCD/Common\">"
+    , "  <processInformation>"
+    , "    <dataSetInformation>"
+    , elem' "common:UUID" (uuidText actUUID)
+    , "      <name>"
+    , attrElem "baseName" [("xml:lang", "en")] (activityName act)
+    , "      </name>"
+    ]
+        ++ classificationBlock (activityClassification act)
+        ++ [ "    </dataSetInformation>"
+           , attrOnly "geography" [("location", activityLocation act)]
+           , "    <quantitativeReference>"
+           , elem' "referenceToReferenceFlow" (T.pack (show refIdx))
+           , "    </quantitativeReference>"
+           ]
+        ++ timeStampBlock opts
+        ++ [ "  </processInformation>"
+           ]
+        ++ processTypeBlock (activityNativeType act)
+        ++ generatorBlock opts
+        ++ ["  <exchanges>"]
+        ++ concatMap (uncurry exchangeXML) indexedExchanges
+        ++ [ "  </exchanges>"
+           , "</processDataSet>"
+           ]
+  where
+    -- Exchanges are emitted in list order; reference index is the position of
+    -- the (first) reference exchange. When none is marked, emit a sentinel past
+    -- the last internalID so the parser's findRefExchange matches no exchange
+    -- and preserves the "no reference" state instead of fabricating one at 0.
+    indexedExchanges = zip [0 ..] (exchanges act)
+    refIdx :: Int
+    refIdx = case [i | (i, ex) <- indexedExchanges, exchangeIsReference ex] of
+        (i : _) -> i
+        [] -> length indexedExchanges
+
+-- | One @<exchange>@ block. @i@ is the @dataSetInternalID@.
+exchangeXML :: Int -> Exchange -> [Text]
+exchangeXML i ex =
+    [ "    <exchange dataSetInternalID=\"" <> T.pack (show i) <> "\">"
+    , attrOnly "referenceToFlowDataSet" [("refObjectId", uuidText (exchangeFlowId ex)), ("type", "flow data set")]
+    , elem' "exchangeDirection" direction
+    , elem' "resultingAmount" (formatDouble (exchangeAmount ex))
+    ]
+        ++ commentBlock (exchangeComment ex)
+        ++ ["    </exchange>"]
+  where
+    direction = if exchangeIsInput ex then "Input" else "Output"
+
+-- | Per-exchange comment, English-tagged to match the parser's preference.
+commentBlock :: Maybe Text -> [Text]
+commentBlock Nothing = []
+commentBlock (Just c) = [attrElem "common:generalComment" [("xml:lang", "en")] c]
+
+{- | Classification block. Each classification system becomes one
+@<common:classification name="...">@ with one @<common:class>@ per
+"/"-joined level, preserving the parser's join semantics. Systems are
+sorted by name for determinism.
+-}
+classificationBlock :: M.Map Text Text -> [Text]
+classificationBlock cls
+    | M.null cls = []
+    | otherwise =
+        ["      <classificationInformation>"]
+            ++ concatMap system (M.toAscList cls)
+            ++ ["      </classificationInformation>"]
+  where
+    system (name, value) =
+        [attrOnlyOpen "common:classification" [("name", name)]]
+            ++ [ attrElem "common:class" [("level", T.pack (show lvl))] part
+               | (lvl :: Int, part) <- zip [0 ..] (T.splitOn "/" value)
+               ]
+            ++ ["        </common:classification>"]
+
+{- | ILCD @<processType>@, nested where the parser expects it. @<processType>@
+is free text, so a foreign native-type label (SimaPro @Type@, ecospold
+@activityType@) is carried through rather than dropped. Omitted when no native
+type is set or its label is empty.
+-}
+processTypeBlock :: Maybe NativeActivityType -> [Text]
+processTypeBlock nt = case nativeTypeLabel nt of
+    Just label
+        | not (T.null label) ->
+            [ "  <modellingAndValidation>"
+            , "    <LCIMethodAndAllocation>"
+            , elem' "processType" label
+            , "    </LCIMethodAndAllocation>"
+            , "  </modellingAndValidation>"
+            ]
+    Just _ -> []
+    Nothing -> []
+
+-- | Native-type display label, across all source formats (the value carried
+-- into @<processType>@). 'Nothing' when no native type is set.
+nativeTypeLabel :: Maybe NativeActivityType -> Maybe Text
+nativeTypeLabel nt = case nt of
+    Just (ILCDProcessType label) -> Just label
+    Just (SimaProProcessType label) -> Just label
+    Just (EcoSpoldActivityType{eatLabel = label}) -> Just label
+    Nothing -> Nothing
+
+-- | Optional pinned timestamp inside @<processInformation>@ (omitted by default).
+timeStampBlock :: WriteOptions -> [Text]
+timeStampBlock opts = case woTimestamp opts of
+    Nothing -> []
+    Just ts -> [elem' "common:timeStamp" ts]
+
+-- | Optional pinned generator string (omitted by default).
+generatorBlock :: WriteOptions -> [Text]
+generatorBlock opts = case woGenerator opts of
+    Nothing -> []
+    Just g ->
+        [ "  <administrativeInformation>"
+        , "    <dataGenerator>"
+        , elem' "common:referenceToDataGenerator" g
+        , "    </dataGenerator>"
+        , "  </administrativeInformation>"
+        ]
+
+--------------------------------------------------------------------------------
+-- Flow XML
+--------------------------------------------------------------------------------
+
+{- | Render one ILCD flow dataset. @typeOfDataSet@ is set so the parser's
+'classifyFlowType' re-buckets the flow into the same kind. Biosphere flows
+carry their compartment categories; CAS round-trips when present.
+-}
+flowXML :: FlowKind -> UUID -> [Text]
+flowXML fk unitRef =
+    [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    , "<flowDataSet xmlns=\"http://lca.jrc.it/ILCD/Flow\" xmlns:common=\"http://lca.jrc.it/ILCD/Common\">"
+    , "  <flowInformation>"
+    , "    <dataSetInformation>"
+    , elem' "common:UUID" (uuidText (flowKindId fk))
+    , "      <name>"
+    , attrElem "baseName" [("xml:lang", "en")] (flowKindName fk)
+    , "      </name>"
+    ]
+        ++ compartmentBlock (flowKindCompartment fk)
+        ++ casBlock (flowKindCAS fk)
+        ++ [ "    </dataSetInformation>"
+           , "    <quantitativeReference>"
+           , elem' "referenceToReferenceFlowProperty" "0"
+           , "    </quantitativeReference>"
+           , "  </flowInformation>"
+           , "  <modellingAndValidation>"
+           , "    <LCIMethod>"
+           , elem' "typeOfDataSet" (flowTypeText fk)
+           , "    </LCIMethod>"
+           , "  </modellingAndValidation>"
+           , "  <flowProperties>"
+           , "    <flowProperty dataSetInternalID=\"0\">"
+           , attrOnly "referenceToFlowPropertyDataSet" [("refObjectId", uuidText unitRef), ("type", "flow property data set")]
+           , elem' "meanValue" "1"
+           , "    </flowProperty>"
+           , "  </flowProperties>"
+           , "</flowDataSet>"
+           ]
+
+-- | CAS accessor across flow kinds (parser reads it for biosphere flows).
+flowKindCAS :: FlowKind -> Maybe Text
+flowKindCAS (TechKind f) = tfCAS f
+flowKindCAS (BioKind f) = bfCAS f
+flowKindCAS (WasteKind f) = wfCAS f
+
+-- | @typeOfDataSet@ string mirroring 'ILCD.Parser.classifyFlowType'.
+flowTypeText :: FlowKind -> Text
+flowTypeText (TechKind _) = "Product flow"
+flowTypeText (BioKind _) = "Elementary flow"
+flowTypeText (WasteKind _) = "Waste flow"
+
+casBlock :: Maybe Text -> [Text]
+casBlock Nothing = []
+casBlock (Just cas)
+    | T.null cas = []
+    | otherwise = [elem' "CASNumber" cas]
+
+{- | Emit the biosphere @elementaryFlowCategorization@. We reverse the parser's
+'parseCompartment': level 0 is "Emissions"/"Resources", level 1 names the
+medium, level 2 (when a sub-compartment exists) is "<medium-phrase>, <sub>".
+-}
+compartmentBlock :: Maybe Compartment -> [Text]
+compartmentBlock Nothing = []
+compartmentBlock (Just (Compartment medium sub)) =
+    [ "      <classificationInformation>"
+    , "        <common:elementaryFlowCategorization>"
+    , attrElem "common:category" [("level", "0")] level0
+    , attrElem "common:category" [("level", "1")] level1
+    ]
+        ++ level2
+        ++ [ "        </common:elementaryFlowCategorization>"
+           , "      </classificationInformation>"
+           ]
+  where
+    isResource = medium == "natural resource"
+    level0 = if isResource then "Resources" else "Emissions"
+    mediumWord = case medium of
+        "natural resource" -> "natural resource"
+        other -> other
+    level1
+        | isResource = "Resources"
+        | otherwise = "Emissions to " <> mediumWord
+    level2 = case sub of
+        Nothing -> []
+        Just s
+            | T.null s -> []
+            | isResource -> [attrElem "common:category" [("level", "2")] ("Resources " <> s)]
+            | otherwise -> [attrElem "common:category" [("level", "2")] ("Emissions to " <> mediumWord <> ", " <> s)]
+
+--------------------------------------------------------------------------------
+-- FlowProperty XML  (one per unit; shares the unit's UUID)
+--------------------------------------------------------------------------------
+
+flowPropertyXML :: Unit -> [Text]
+flowPropertyXML u =
+    [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    , "<flowPropertyDataSet xmlns=\"http://lca.jrc.it/ILCD/FlowProperty\" xmlns:common=\"http://lca.jrc.it/ILCD/Common\">"
+    , "  <flowPropertiesInformation>"
+    , "    <dataSetInformation>"
+    , elem' "common:UUID" (uuidText (unitId u))
+    , attrElem "common:name" [("xml:lang", "en")] (unitName u)
+    , "    </dataSetInformation>"
+    , "    <quantitativeReference>"
+    , attrOnly "referenceToReferenceUnitGroup" [("refObjectId", uuidText (unitId u)), ("type", "unit group data set")]
+    , "    </quantitativeReference>"
+    , "  </flowPropertiesInformation>"
+    , "</flowPropertyDataSet>"
+    ]
+
+--------------------------------------------------------------------------------
+-- UnitGroup XML  (one per unit; shares the unit's UUID; single reference unit)
+--------------------------------------------------------------------------------
+
+unitGroupXML :: Unit -> [Text]
+unitGroupXML u =
+    [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    , "<unitGroupDataSet xmlns=\"http://lca.jrc.it/ILCD/UnitGroup\" xmlns:common=\"http://lca.jrc.it/ILCD/Common\">"
+    , "  <unitGroupInformation>"
+    , "    <dataSetInformation>"
+    , elem' "common:UUID" (uuidText (unitId u))
+    , attrElem "common:name" [("xml:lang", "en")] (unitName u)
+    , "    </dataSetInformation>"
+    , "    <quantitativeReference>"
+    , elem' "referenceToReferenceUnit" "0"
+    , "    </quantitativeReference>"
+    , "  </unitGroupInformation>"
+    , "  <units>"
+    , "    <unit dataSetInternalID=\"0\">"
+    , elem' "name" (unitName u)
+    , elem' "meanValue" "1"
+    , "    </unit>"
+    , "  </units>"
+    , "</unitGroupDataSet>"
+    ]
+
+--------------------------------------------------------------------------------
+-- XML primitives
+--------------------------------------------------------------------------------
+
+-- | Join the rendered lines with newlines and a trailing newline.
+renderLines :: [Text] -> Text
+renderLines = (<> "\n") . T.intercalate "\n"
+{-# INLINE renderLines #-}
+
+-- | @<tag>escaped-text</tag>@ on one indented line.
+elem' :: Text -> Text -> Text
+elem' tag txt = "      <" <> tag <> ">" <> escapeXml txt <> "</" <> tag <> ">"
+
+-- | @<tag a=\"v\" ...>escaped</tag>@ on one indented line.
+attrElem :: Text -> [(Text, Text)] -> Text -> Text
+attrElem tag attrs txt =
+    "      <" <> tag <> attrsText attrs <> ">" <> escapeXml txt <> "</" <> tag <> ">"
+
+-- | Self-closing @<tag a=\"v\" .../>@.
+attrOnly :: Text -> [(Text, Text)] -> Text
+attrOnly tag attrs = "      <" <> tag <> attrsText attrs <> "/>"
+
+-- | Open-only @<tag a=\"v\" ...>@ (caller emits the close).
+attrOnlyOpen :: Text -> [(Text, Text)] -> Text
+attrOnlyOpen tag attrs = "        <" <> tag <> attrsText attrs <> ">"
+
+attrsText :: [(Text, Text)] -> Text
+attrsText = T.concat . map (\(k, v) -> " " <> k <> "=\"" <> escapeXmlAttr v <> "\"")
+
+{- | XML text-node escaping. Covers the five predefined entities. The parser
+(Xeno SAX) un-escapes these, so escaping here keeps the round-trip faithful
+for names/comments containing @&@, @<@, etc.
+-}
+escapeXml :: Text -> Text
+escapeXml =
+    T.replace ">" "&gt;"
+        . T.replace "<" "&lt;"
+        . T.replace "&" "&amp;"
+
+-- | Attribute-value escaping: text entities plus the quote characters.
+escapeXmlAttr :: Text -> Text
+escapeXmlAttr =
+    T.replace "'" "&apos;"
+        . T.replace "\"" "&quot;"
+        . escapeXml
+
+{- | Canonical 'Double' formatting. Integral values print without a trailing
+@.0@-noise beyond a single @.0@ is avoided by emitting whole numbers as
+integers (matching how the fixtures write @1@ for unit mean values), and
+fractional values use 'show', which is round-trippable through
+'Data.Text.Read.double' (the parser's reader). The two together make
+write→parse→write stable.
+-}
+formatDouble :: Double -> Text
+formatDouble x
+    | isNaN x = "0"
+    | isInfinite x = "0"
+    | x == fromIntegral (round x :: Integer) = T.pack (show (round x :: Integer))
+    | otherwise = T.pack (show x)
+
+--------------------------------------------------------------------------------
+-- UUID rendering
+--------------------------------------------------------------------------------
+
+uuidText :: UUID -> Text
+uuidText = UUID.toText
+
+uuidStr :: UUID -> FilePath
+uuidStr = UUID.toString

--- a/src/ILCD/Writer.hs
+++ b/src/ILCD/Writer.hs
@@ -67,7 +67,7 @@ import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Read as TR
 import qualified Data.UUID as UUID
 import System.Directory (createDirectoryIfMissing)
-import System.FilePath ((</>))
+import System.FilePath (joinPath, splitDirectories, (</>))
 
 import EcoSpold.Common (showFFloatTrim)
 import Types
@@ -98,27 +98,33 @@ defaultWriteOptions = WriteOptions{woTimestamp = Nothing, woGenerator = Nothing}
 
 {- | Produce the full set of @(relativePath, contents)@ pairs for the ILCD
 package. Pure and deterministic. The result is sorted by path.
+
+Paths use a forward slash on every OS: the ILCD package layout and the zip
+archive both mandate @/@ regardless of host (a backslash from
+'System.FilePath.</>' on Windows would yield a non-portable archive and break
+the @processes/@ prefix the parser keys on). 'writeILCDDatabase' maps them to
+the native separator before touching disk.
 -}
 ilcdFiles :: WriteOptions -> SimpleDatabase -> [(FilePath, BS.ByteString)]
 ilcdFiles opts db = sortOn fst (processes ++ flows ++ flowProps ++ unitGroups)
   where
     processes =
-        [ ("processes" </> uuidStr actUUID <> ".xml", render (processXML opts actUUID act))
+        [ ("processes/" <> uuidStr actUUID <> ".xml", render (processXML opts actUUID act))
         | ((actUUID, _prodUUID), act) <- M.toAscList (sdbActivities db)
         ]
 
     flows =
-        [ ("flows" </> uuidStr (flowKindId fk) <> ".xml", render (flowXML fk unitRef))
+        [ ("flows/" <> uuidStr (flowKindId fk) <> ".xml", render (flowXML fk unitRef))
         | (fk, unitRef) <- allFlows db
         ]
 
     flowProps =
-        [ ("flowproperties" </> uuidStr uid <> ".xml", render (flowPropertyXML u))
+        [ ("flowproperties/" <> uuidStr uid <> ".xml", render (flowPropertyXML u))
         | (uid, u) <- M.toAscList (sdbUnits db)
         ]
 
     unitGroups =
-        [ ("unitgroups" </> uuidStr uid <> ".xml", render (unitGroupXML u))
+        [ ("unitgroups/" <> uuidStr uid <> ".xml", render (unitGroupXML u))
         | (uid, u) <- M.toAscList (sdbUnits db)
         ]
 
@@ -256,8 +262,12 @@ writeILCDDatabase opts dir db =
             createDirectoryIfMissing True (dir </> "flows")
             createDirectoryIfMissing True (dir </> "flowproperties")
             createDirectoryIfMissing True (dir </> "unitgroups")
-            mapM_ (\(rel, bytes) -> BS.writeFile (dir </> rel) bytes) (ilcdFiles opts db)
+            mapM_ (\(rel, bytes) -> BS.writeFile (dir </> nativePath rel) bytes) (ilcdFiles opts db)
             pure (Right ())
+  where
+    -- ilcdFiles yields forward-slash package paths; rejoin with the native
+    -- separator so the on-disk write is correct on Windows too.
+    nativePath = joinPath . splitDirectories
 
 {- | Build a deterministic zip 'Archive' of the ILCD package and return its
 serialized bytes. Entry modification times are pinned to epoch 0 so the

--- a/src/ILCD/Writer.hs
+++ b/src/ILCD/Writer.hs
@@ -48,6 +48,7 @@ module ILCD.Writer (
 
     -- * Pure helpers (exported for testing)
     escapeXml,
+    escapeXmlAttr,
     formatDouble,
     processXML,
     flowXML,
@@ -67,6 +68,7 @@ import qualified Data.UUID as UUID
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath ((</>))
 
+import EcoSpold.Common (showFFloatTrim)
 import Types
 
 --------------------------------------------------------------------------------
@@ -209,21 +211,31 @@ checkILCDExportable db = checkMedia >> checkMultiOutput >> checkClassifications
                         <> "): an empty classification level does not round-trip "
                         <> "because the ILCD parser drops empty levels."
 
--- | Write the ILCD package as a directory tree rooted at @dir@.
-writeILCDDatabase :: WriteOptions -> FilePath -> SimpleDatabase -> IO ()
-writeILCDDatabase opts dir db = do
-    createDirectoryIfMissing True (dir </> "processes")
-    createDirectoryIfMissing True (dir </> "flows")
-    createDirectoryIfMissing True (dir </> "flowproperties")
-    createDirectoryIfMissing True (dir </> "unitgroups")
-    mapM_ (\(rel, bytes) -> BS.writeFile (dir </> rel) bytes) (ilcdFiles opts db)
+{- | Write the ILCD package as a directory tree rooted at @dir@, or return the
+export guard's 'Left' without touching disk.
+-}
+writeILCDDatabase :: WriteOptions -> FilePath -> SimpleDatabase -> IO (Either Text ())
+writeILCDDatabase opts dir db =
+    case checkILCDExportable db of
+        Left err -> pure (Left err)
+        Right () -> do
+            createDirectoryIfMissing True (dir </> "processes")
+            createDirectoryIfMissing True (dir </> "flows")
+            createDirectoryIfMissing True (dir </> "flowproperties")
+            createDirectoryIfMissing True (dir </> "unitgroups")
+            mapM_ (\(rel, bytes) -> BS.writeFile (dir </> rel) bytes) (ilcdFiles opts db)
+            pure (Right ())
 
 {- | Build a deterministic zip 'Archive' of the ILCD package and return its
 serialized bytes. Entry modification times are pinned to epoch 0 so the
-archive bytes are reproducible.
+archive bytes are reproducible. Runs 'checkILCDExportable' first and returns its
+'Left' on a database the format cannot represent faithfully, so an unguarded
+caller cannot silently emit a corrupt archive.
 -}
-writeILCDArchive :: WriteOptions -> SimpleDatabase -> BL.ByteString
-writeILCDArchive opts db = fromArchive (buildArchive (ilcdFiles opts db))
+writeILCDArchive :: WriteOptions -> SimpleDatabase -> Either Text BL.ByteString
+writeILCDArchive opts db = do
+    checkILCDExportable db
+    pure (fromArchive (buildArchive (ilcdFiles opts db)))
   where
     buildArchive = foldl addOne emptyArchive
     -- Fixed epoch (0) keeps archive bytes stable across runs.
@@ -346,8 +358,9 @@ processTypeBlock nt = case nativeTypeLabel nt of
     Just _ -> []
     Nothing -> []
 
--- | Native-type display label, across all source formats (the value carried
--- into @<processType>@). 'Nothing' when no native type is set.
+{- | Native-type display label, across all source formats (the value carried
+into @<processType>@). 'Nothing' when no native type is set.
+-}
 nativeTypeLabel :: Maybe NativeActivityType -> Maybe Text
 nativeTypeLabel nt = case nt of
     Just (ILCDProcessType label) -> Just label
@@ -450,18 +463,15 @@ compartmentBlock (Just (Compartment medium sub)) =
   where
     isResource = medium == "natural resource"
     level0 = if isResource then "Resources" else "Emissions"
-    mediumWord = case medium of
-        "natural resource" -> "natural resource"
-        other -> other
     level1
         | isResource = "Resources"
-        | otherwise = "Emissions to " <> mediumWord
+        | otherwise = "Emissions to " <> medium
     level2 = case sub of
         Nothing -> []
         Just s
             | T.null s -> []
             | isResource -> [attrElem "common:category" [("level", "2")] ("Resources " <> s)]
-            | otherwise -> [attrElem "common:category" [("level", "2")] ("Emissions to " <> mediumWord <> ", " <> s)]
+            | otherwise -> [attrElem "common:category" [("level", "2")] ("Emissions to " <> medium <> ", " <> s)]
 
 --------------------------------------------------------------------------------
 -- FlowProperty XML  (one per unit; shares the unit's UUID)
@@ -538,9 +548,9 @@ attrOnlyOpen tag attrs = "        <" <> tag <> attrsText attrs <> ">"
 attrsText :: [(Text, Text)] -> Text
 attrsText = T.concat . map (\(k, v) -> " " <> k <> "=\"" <> escapeXmlAttr v <> "\"")
 
-{- | XML text-node escaping. Covers the five predefined entities. The parser
-(Xeno SAX) un-escapes these, so escaping here keeps the round-trip faithful
-for names/comments containing @&@, @<@, etc.
+{- | XML text-node escaping. Covers the three entities that matter in element
+content (@&@, @<@, @>@). The parser (Xeno SAX) un-escapes these, so escaping
+here keeps the round-trip faithful for names/comments containing @&@, @<@, etc.
 -}
 escapeXml :: Text -> Text
 escapeXml =
@@ -548,26 +558,33 @@ escapeXml =
         . T.replace "<" "&lt;"
         . T.replace "&" "&amp;"
 
--- | Attribute-value escaping: text entities plus the quote characters.
+{- | Attribute-value escaping: the text entities, the quote characters, and the
+newline/carriage-return control characters. A raw @\\n@/@\\r@ inside an attribute
+value is normalised to a space by XML parsers, so encode it as a numeric
+character reference (matching the EcoSpold2 writer) to keep it verbatim across a
+round trip.
+-}
 escapeXmlAttr :: Text -> Text
 escapeXmlAttr =
-    T.replace "'" "&apos;"
+    T.replace "\r" "&#13;"
+        . T.replace "\n" "&#10;"
+        . T.replace "'" "&apos;"
         . T.replace "\"" "&quot;"
         . escapeXml
 
-{- | Canonical 'Double' formatting. Integral values print without a trailing
-@.0@-noise beyond a single @.0@ is avoided by emitting whole numbers as
-integers (matching how the fixtures write @1@ for unit mean values), and
-fractional values use 'show', which is round-trippable through
-'Data.Text.Read.double' (the parser's reader). The two together make
-write→parse→write stable.
+{- | Canonical 'Double' formatting via the shared 'showFFloatTrim' (fixed-point,
+never scientific), so the value round-trips byte- and value-identically through
+the parser's 'Data.Text.Read.double' — unlike @show@, which emits scientific
+notation for small/large magnitudes that re-reads lossily (e.g. @show 3.3e-20@ →
+@3.2999999999999994e-20@, and @5.0e-324@ → @0@). Non-finite values (which cannot
+occur in a parsed database) are clamped to a parseable @0.0@; negative zero is
+normalised to @0.0@.
 -}
 formatDouble :: Double -> Text
 formatDouble x
-    | isNaN x = "0"
-    | isInfinite x = "0"
-    | x == fromIntegral (round x :: Integer) = T.pack (show (round x :: Integer))
-    | otherwise = T.pack (show x)
+    | isNaN x || isInfinite x = "0.0"
+    | x == 0 = "0.0"
+    | otherwise = T.pack (showFFloatTrim x)
 
 --------------------------------------------------------------------------------
 -- UUID rendering

--- a/test/BrightwayExcelWriterSpec.hs
+++ b/test/BrightwayExcelWriterSpec.hs
@@ -1,0 +1,832 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Round-trip tests for the Brightway Excel (.xlsx) /writer/, the inverse of
+"BrightwayExcel.Parser".
+
+The fixture 'SimpleDatabase' is built in Haskell using the very UUID generators
+the parser feeds its flows/units/activities through ('generateFlowUUID',
+'generateUnitUUID', 'generateActivityUUID'), so @parse (write D)@ reconstructs
+the same identities — no committed binary fixture, and no dependence on the
+cross-database link pass (technosphere links are left @nil@, exactly the state
+the parser produces for a freshly imported workbook).
+
+Three contracts are proven:
+
+  (a) /logical-cell idempotence/ — re-exporting the parsed content yields the
+      same worksheet rows. Byte identity is not attempted (zip metadata is
+      volatile); we compare the parsed-then-rewritten logical cells.
+  (b) /semantic round-trip/ — @parse (write D)@ is structurally equal to @D@,
+      order-insensitively (activities, exchanges, flows, units).
+  (c) /score equivalence/ — the biosphere inventory of a sample activity is
+      preserved across the round-trip, within tolerance, using the engine's
+      matrix solver.
+-}
+module BrightwayExcelWriterSpec (spec) where
+
+import BrightwayExcel.Parser (parseBrightwayExcel)
+import BrightwayExcel.Writer (
+    Cell (..),
+    WriterConfig (..),
+    activityRows,
+    checkBrightwayExportable,
+    formatAmount,
+    renderCategories,
+    renderWorkbook,
+ )
+import qualified Data.ByteString.Lazy as BL
+import Data.Either (isLeft)
+import Data.List (find, sortOn)
+import qualified Data.Map.Strict as M
+import Data.Maybe (listToMaybe)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Read as TR
+import qualified Data.UUID as UUID
+import Database (buildDatabaseWithMatrices)
+import Database.Loader (getReferenceProductUUID)
+import Matrix (computeInventoryMatrix)
+import SimaPro.Parser (generateActivityUUID, generateFlowUUID, generateUnitUUID)
+import System.IO (hClose)
+import System.IO.Temp (withSystemTempFile)
+import Test.Hspec
+import Types
+import UnitConversion (UnitConfig, buildFromCSV, defaultUnitConfig)
+
+spec :: Spec
+spec = describe "BrightwayExcel.Writer" $ do
+    describe "formatAmount" $ do
+        it "prints integers without a decimal point" $
+            formatAmount 1 `shouldBe` "1"
+        it "prints fractions with full precision" $
+            formatAmount 8.5 `shouldBe` "8.5"
+        it "renders a small magnitude as fixed-point that re-parses exactly" $ do
+            -- show 3.3e-20 emits scientific notation the parser's TR.double
+            -- re-reads lossily; fixed-point keeps it value-identical end to end.
+            T.isInfixOf "e" (formatAmount 3.3e-20) `shouldBe` False
+            TR.double (formatAmount 3.3e-20) `shouldBe` Right (3.3e-20, "")
+
+    describe "renderCategories" $ do
+        it "joins compartment and subcompartment with ::" $
+            renderCategories (Just (Compartment "natural resource" (Just "in water")))
+                `shouldBe` "natural resource::in water"
+        it "emits the bare medium when there is no sub" $
+            renderCategories (Just (Compartment "air" Nothing)) `shouldBe` "air"
+        it "emits empty for no recorded compartment" $
+            renderCategories Nothing `shouldBe` ""
+
+    describe "round-trip" $ do
+        it "(b) parse (write D) is structurally equal to D" $
+            withWritten fixtureDb $ \path -> do
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right parsed -> normalizeParsed parsed `shouldBe` expectedNormalized
+
+        it "(a) re-exporting the parsed content yields the same logical cells" $
+            withWritten fixtureDb $ \path -> do
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right parsed -> do
+                        let db' = rebuild parsed
+                        logicalCells db' `shouldBe` logicalCells fixtureDb
+
+        it "(c) preserves a biosphere inventory amount across the round-trip" $
+            withWritten fixtureDb $ \path -> do
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right parsed -> do
+                        before <- co2Inventory fixtureDb
+                        after <- co2Inventory (rebuild parsed)
+                        case (before, after) of
+                            (Right (Just b), Right (Just a)) ->
+                                abs (a - b) < 1.0e-9 `shouldBe` True
+                            other -> expectationFailure ("CO2 inventory missing: " <> show other)
+
+        it "(d) reconstructs XML-special and non-ASCII names verbatim" $
+            -- Drives the real emit path: the writer escapes & < > " through
+            -- 'escapeXml' and emits non-ASCII as UTF-8; the parser unescapes via
+            -- 'decodeEntities' and decodes UTF-8. Round-tripping a fixture whose
+            -- names carry all four predefined entities plus accented and CJK
+            -- characters proves the two halves are inverses, not that the cells
+            -- merely store raw strings.
+            withWritten specialDb $ \path ->
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right parsed -> normalizeParsed parsed `shouldBe` specialNormalized
+
+        it "(e) round-trips a coproduct as a second production row" $
+            -- Both outputs serialize with type "production"; the parser maps the
+            -- first to ReferenceProduct and every further production row to
+            -- Coproduct. Asserting the parsed roles and amounts proves the
+            -- multi-output activity survives, where 'normalizeParsed' (which only
+            -- projects reference + Input rows) cannot see the coproduct.
+            withWritten coproductDb $ \path ->
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right (acts, _, _, _, _) -> case acts of
+                        [a] -> do
+                            roleAmounts a `shouldBe` [(ReferenceProduct, 1), (Coproduct, 0.25)]
+                            -- The coproduct's comment also flows through productRowOut.
+                            [techComment ex | ex@TechnosphereExchange{} <- exchanges a]
+                                `shouldBe` [Just "ref note", Just "heat note"]
+                        other -> expectationFailure ("expected one activity, got " <> show (length other))
+
+        it "(f) round-trips an empty database to no activities" $
+            -- The writer still emits the Database header sheet; the parser reads
+            -- it back as a valid, activity-free import rather than erroring.
+            withWritten emptyDb $ \path ->
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right (acts, _, _, _, _) -> length acts `shouldBe` 0
+
+        it "(g) round-trips a boundary-magnitude (~1e15) amount" $
+            -- At 1e15 'formatAmount' crosses from integer to fixed-point rendering;
+            -- the parser reads it back through TR.double. The amount must survive
+            -- the format switch exactly.
+            withWritten bigAmountDb $ \path ->
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right (acts, _, _, _, _) -> case acts of
+                        [a] -> map techAmount [ex | ex@TechnosphereExchange{techRole = Input} <- exchanges a] `shouldBe` [1.0e15]
+                        other -> expectationFailure ("expected one activity, got " <> show (length other))
+
+        it "(h) round-trips exchange-level comments, including the reference product" $
+            -- The reference product is a production row; its comment column flows
+            -- through 'productRowOut' (the same path coproducts take), which once
+            -- dropped it. Assert the product, input, and biosphere comments all
+            -- survive.
+            withWritten commentDb $ \path ->
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right (acts, _, _, _, _) -> case acts of
+                        [a] -> do
+                            [techComment ex | ex@TechnosphereExchange{techRole = ReferenceProduct} <- exchanges a]
+                                `shouldBe` [Just "product note"]
+                            [techComment ex | ex@TechnosphereExchange{techRole = Input} <- exchanges a]
+                                `shouldBe` [Just "input note"]
+                            [bioComment ex | ex@BiosphereExchange{} <- exchanges a]
+                                `shouldBe` [Just "emission note"]
+                        other -> expectationFailure ("expected one activity, got " <> show (length other))
+
+        it "(i) canonicalizes a non-canonical reference unit, then is a fixed point" $
+            -- The parser normalizes a reference product's unit to canonical at
+            -- ingest (g→kg here, scaling 1000→1). So parse(write D) ≠ D for a
+            -- non-canonical reference unit — the contract is fixed-point over the
+            -- parser's image: a second round-trip reproduces the first exactly.
+            withWritten gramRefDb $ \path ->
+                parseBrightwayExcel gramConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right parsed1 -> do
+                        refUnitAmount parsed1 `shouldBe` Just ("kg", 1.0)
+                        withWritten (rebuild parsed1) $ \path2 ->
+                            parseBrightwayExcel gramConfig path2 >>= \case
+                                Left err -> expectationFailure (T.unpack err)
+                                Right parsed2 -> refUnitAmount parsed2 `shouldBe` refUnitAmount parsed1
+
+        it "(j) round-trips a single-paragraph activity description" $
+            -- The writer newline-joins 'activityDescription' into the one comment
+            -- the format allows; the parser reads it back as a one-element list.
+            -- A single paragraph is therefore a fixed point — the realistic case,
+            -- since the parser's own image has ≤1 element (see 'activityRows').
+            withWritten describedDb $ \path ->
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right (acts, _, _, _, _) -> case acts of
+                        [a] -> activityDescription a `shouldBe` ["a milling note"]
+                        other -> expectationFailure ("expected one activity, got " <> show (length other))
+
+    describe "export guard" $ do
+        it "rejects a waste exchange (Brightway has no waste type)" $
+            -- Per the export boundary: emitting a WasteExchange would re-parse as a
+            -- positive technosphere input, inverting an output waste. Reject loudly.
+            checkBrightwayExportable wasteDb `shouldSatisfy` isLeft
+        it "rejects a non-finite amount" $
+            -- A non-finite amount has no numeric-cell form that re-parses; the
+            -- guard rejects the database instead of emitting a misleading value.
+            checkBrightwayExportable nonFiniteDb `shouldSatisfy` isLeft
+        it "rejects a subnormal amount that fixed-point cannot round-trip" $
+            -- 5e-324 (smallest positive subnormal) collapses to 0 through
+            -- fixed-point, an undetectable shift; reject it at the boundary.
+            checkBrightwayExportable subnormalDb `shouldSatisfy` isLeft
+
+    describe "ReferenceInput regression" $
+        it "rejects a reference input rather than round-tripping it to a duplicated row" $ do
+            -- Brightway has no marker for a reference input. Emitting it would
+            -- re-parse to a synthetic reference product (from the meta row) PLUS an
+            -- ordinary input (from the data row) — two exchanges on one flow, whose
+            -- duplicate (i,j) matrix entries sum and double the coefficient.
+            let db =
+                    refInputDb
+                        { sdbActivities = M.singleton (generateActivityUUID refInputAct, tfId solventFlow) refInputAct
+                        }
+            checkBrightwayExportable db `shouldSatisfy` isLeft
+
+-- ---------------------------------------------------------------------------
+-- Fixture database, built with the parser's UUID conventions
+-- ---------------------------------------------------------------------------
+
+cfg :: WriterConfig
+cfg = WriterConfig{wcDatabaseName = "Test_Inventory_DB"}
+
+-- One activity producing electricity, consuming gas, emitting CO2.
+fixtureDb :: SimpleDatabase
+fixtureDb =
+    SimpleDatabase
+        { sdbActivities = M.singleton (generateActivityUUID elec, getReferenceProductUUID elec) elec
+        , sdbTechFlows = M.fromList [(tfId f, f) | f <- [elecFlow, gasFlow]]
+        , sdbBioFlows = M.fromList [(bfId co2, co2)]
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.fromList [(unitId u, u) | u <- [kwh, m3, kg]]
+        }
+
+elec :: Activity
+elec =
+    Activity
+        { activityName = "Electricity production, natural gas"
+        , activityDescription = []
+        , activitySynonyms = M.empty
+        , activityClassification = M.empty
+        , activityLocation = "GLO"
+        , activityUnit = "kilowatt hour"
+        , exchanges = [prodExch, gasExch, co2Exch]
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
+        }
+
+prodExch :: Exchange
+prodExch =
+    TechnosphereExchange
+        { techFlowId = generateFlowUUID "electricity, high voltage" "" "kilowatt hour"
+        , techAmount = 1
+        , techUnitId = generateUnitUUID "kilowatt hour"
+        , techRole = ReferenceProduct
+        , techActivityLinkId = UUID.nil
+        , techProcessLinkId = Nothing
+        , techLocation = "GLO"
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+gasExch :: Exchange
+gasExch =
+    TechnosphereExchange
+        { techFlowId = generateFlowUUID "natural gas, high pressure" "" "cubic meter"
+        , techAmount = 8.5
+        , techUnitId = generateUnitUUID "cubic meter"
+        , techRole = Input
+        , techActivityLinkId = UUID.nil
+        , techProcessLinkId = Nothing
+        , techLocation = "RoW"
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+co2Exch :: Exchange
+co2Exch =
+    BiosphereExchange
+        { bioFlowId = bfId co2
+        , bioAmount = 0.5
+        , bioUnitId = generateUnitUUID "kilogram"
+        , bioDirection = Emission
+        , bioLocation = ""
+        , bioComment = Nothing
+        , bioPedigree = Nothing
+        }
+
+elecFlow :: TechnosphereFlow
+elecFlow =
+    TechnosphereFlow
+        (generateFlowUUID "electricity, high voltage" "" "kilowatt hour")
+        "electricity, high voltage"
+        (generateUnitUUID "kilowatt hour")
+        M.empty
+        Nothing
+        Nothing
+
+gasFlow :: TechnosphereFlow
+gasFlow =
+    TechnosphereFlow
+        (generateFlowUUID "natural gas, high pressure" "" "cubic meter")
+        "natural gas, high pressure"
+        (generateUnitUUID "cubic meter")
+        M.empty
+        Nothing
+        Nothing
+
+-- ---------------------------------------------------------------------------
+-- Special-character fixture (XML-special + non-ASCII names)
+-- ---------------------------------------------------------------------------
+
+{- | An activity whose name and every flow name carry the four entity-escaped
+characters (@& < > "@) and non-ASCII (accents + CJK), to exercise the writer's
+'escapeXml' / UTF-8 emit and the parser's entity decode end to end. Units stay
+canonical ("kilogram") so unit normalization does not perturb the names.
+-}
+specialDb :: SimpleDatabase
+specialDb =
+    SimpleDatabase
+        { sdbActivities = M.singleton (generateActivityUUID specialAct, getReferenceProductUUID specialAct) specialAct
+        , sdbTechFlows = M.fromList [(tfId f, f) | f <- [specialProdFlow, specialInputFlow]]
+        , sdbBioFlows = M.fromList [(bfId specialBio, specialBio)]
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton (unitId kg) kg
+        }
+
+specialProductName, specialInputName, specialBioName :: Text
+specialProductName = "Steel <profile> & \"bar\", éàü 鋼材"
+specialInputName = "Coke & coal <feedstock> \"raw\", café"
+specialBioName = "Carbon dioxide <CO₂> & \"fossil\""
+
+specialAct :: Activity
+specialAct =
+    elec
+        { activityName = "Steelmaking & forging <hot> \"strip\", München 製鋼"
+        , activityUnit = "kilogram"
+        , exchanges =
+            [ TechnosphereExchange
+                { techFlowId = tfId specialProdFlow
+                , techAmount = 1
+                , techUnitId = generateUnitUUID "kilogram"
+                , techRole = ReferenceProduct
+                , techActivityLinkId = UUID.nil
+                , techProcessLinkId = Nothing
+                , techLocation = "GLO"
+                , techComment = Nothing
+                , techPedigree = Nothing
+                }
+            , TechnosphereExchange
+                { techFlowId = tfId specialInputFlow
+                , techAmount = 0.7
+                , techUnitId = generateUnitUUID "kilogram"
+                , techRole = Input
+                , techActivityLinkId = UUID.nil
+                , techProcessLinkId = Nothing
+                , techLocation = "RoW"
+                , techComment = Nothing
+                , techPedigree = Nothing
+                }
+            , BiosphereExchange
+                { bioFlowId = bfId specialBio
+                , bioAmount = 0.3
+                , bioUnitId = generateUnitUUID "kilogram"
+                , bioDirection = Emission
+                , bioLocation = ""
+                , bioComment = Nothing
+                , bioPedigree = Nothing
+                }
+            ]
+        }
+
+specialProdFlow :: TechnosphereFlow
+specialProdFlow =
+    TechnosphereFlow
+        (generateFlowUUID specialProductName "" "kilogram")
+        specialProductName
+        (generateUnitUUID "kilogram")
+        M.empty
+        Nothing
+        Nothing
+
+specialInputFlow :: TechnosphereFlow
+specialInputFlow =
+    TechnosphereFlow
+        (generateFlowUUID specialInputName "" "kilogram")
+        specialInputName
+        (generateUnitUUID "kilogram")
+        M.empty
+        Nothing
+        Nothing
+
+specialBio :: BiosphereFlow
+specialBio =
+    co2
+        { bfId = generateFlowUUID specialBioName "air" "kilogram"
+        , bfName = specialBioName
+        }
+
+specialNormalized :: [NormActivity]
+specialNormalized =
+    normalizeParsed
+        ( M.elems (sdbActivities specialDb)
+        , sdbTechFlows specialDb
+        , sdbBioFlows specialDb
+        , sdbWasteFlows specialDb
+        , sdbUnits specialDb
+        )
+
+-- Regression fixtures: a treatment-style activity whose reference is a
+-- technosphere *input* (ReferenceInput), which must serialize as a single row.
+solventFlow :: TechnosphereFlow
+solventFlow =
+    TechnosphereFlow
+        (generateFlowUUID "spent solvent" "" "kilogram")
+        "spent solvent"
+        (generateUnitUUID "kilogram")
+        M.empty
+        Nothing
+        Nothing
+
+refInputAct :: Activity
+refInputAct =
+    elec
+        { activityName = "Solvent treatment"
+        , activityUnit = "kilogram"
+        , exchanges =
+            [ TechnosphereExchange
+                { techFlowId = tfId solventFlow
+                , techAmount = 1
+                , techUnitId = generateUnitUUID "kilogram"
+                , techRole = ReferenceInput
+                , techActivityLinkId = UUID.nil
+                , techProcessLinkId = Nothing
+                , techLocation = "GLO"
+                , techComment = Nothing
+                , techPedigree = Nothing
+                }
+            ]
+        }
+
+refInputDb :: SimpleDatabase
+refInputDb =
+    fixtureDb
+        { sdbTechFlows = M.singleton (tfId solventFlow) solventFlow
+        , sdbUnits = M.singleton (unitId kg) kg
+        }
+
+{- | The base fixture with a comment attached to its reference product, its
+technosphere input, and its biosphere emission, to prove exchange-level comments
+survive the round-trip — including on production rows ('productRowOut').
+-}
+commentDb :: SimpleDatabase
+commentDb =
+    fixtureDb{sdbActivities = M.singleton (generateActivityUUID a, getReferenceProductUUID a) a}
+  where
+    a = elec{exchanges = map withComment (exchanges elec)}
+    withComment ex = case ex of
+        TechnosphereExchange{techRole = ReferenceProduct} -> ex{techComment = Just "product note"}
+        TechnosphereExchange{techRole = Input} -> ex{techComment = Just "input note"}
+        TechnosphereExchange{} -> ex
+        BiosphereExchange{} -> ex{bioComment = Just "emission note"}
+        WasteExchange{} -> ex
+
+-- | The base fixture carrying a single-paragraph activity-level description.
+describedDb :: SimpleDatabase
+describedDb =
+    fixtureDb{sdbActivities = M.singleton (generateActivityUUID a, getReferenceProductUUID a) a}
+  where
+    a = elec{activityDescription = ["a milling note"]}
+
+-- ---------------------------------------------------------------------------
+-- Coproduct / empty / boundary-amount fixtures
+-- ---------------------------------------------------------------------------
+
+{- | The CHP reference output and its coproduct, both in canonical kilograms so
+amounts are preserved verbatim across the round-trip.
+-}
+chpRefFlow, chpHeatFlow :: TechnosphereFlow
+chpRefFlow = kgFlow "electricity, high voltage"
+chpHeatFlow = kgFlow "recovered heat"
+
+kgFlow :: Text -> TechnosphereFlow
+kgFlow n =
+    TechnosphereFlow
+        (generateFlowUUID n "" "kilogram")
+        n
+        (generateUnitUUID "kilogram")
+        M.empty
+        Nothing
+        Nothing
+
+{- | An activity with a reference product and a coproduct, both emitted as
+@production@ rows; the parser maps the first to 'ReferenceProduct' and the
+second to 'Coproduct'.
+-}
+coproductAct :: Activity
+coproductAct =
+    elec
+        { activityName = "Combined heat and power"
+        , activityUnit = "kilogram"
+        , exchanges =
+            [ (kgProduction chpRefFlow ReferenceProduct 1){techComment = Just "ref note"}
+            , (kgProduction chpHeatFlow Coproduct 0.25){techComment = Just "heat note"}
+            ]
+        }
+
+kgProduction :: TechnosphereFlow -> TechRole -> Double -> Exchange
+kgProduction flow role amount =
+    TechnosphereExchange
+        { techFlowId = tfId flow
+        , techAmount = amount
+        , techUnitId = generateUnitUUID "kilogram"
+        , techRole = role
+        , techActivityLinkId = UUID.nil
+        , techProcessLinkId = Nothing
+        , techLocation = "GLO"
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+coproductDb :: SimpleDatabase
+coproductDb =
+    SimpleDatabase
+        { sdbActivities = M.singleton (generateActivityUUID coproductAct, getReferenceProductUUID coproductAct) coproductAct
+        , sdbTechFlows = M.fromList [(tfId f, f) | f <- [chpRefFlow, chpHeatFlow]]
+        , sdbBioFlows = M.empty
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton (unitId kg) kg
+        }
+
+{- | The (role, amount) pairs of an activity's technosphere production rows,
+in exchange order.
+-}
+roleAmounts :: Activity -> [(TechRole, Double)]
+roleAmounts a = [(role, techAmount ex) | ex@TechnosphereExchange{techRole = role} <- exchanges a]
+
+-- | A database with no activities, flows, or units.
+emptyDb :: SimpleDatabase
+emptyDb = SimpleDatabase M.empty M.empty M.empty M.empty M.empty
+
+{- | A single input exchange whose amount sits at the 1e15 integer/scientific
+boundary of 'formatAmount'.
+-}
+bigAmountDb :: SimpleDatabase
+bigAmountDb =
+    fixtureDb
+        { sdbActivities = M.singleton (generateActivityUUID act, getReferenceProductUUID act) act
+        }
+  where
+    act = elec{exchanges = [prodExch, gasExch{techAmount = 1.0e15}, co2Exch]}
+
+-- ---------------------------------------------------------------------------
+-- Reference-unit normalization fixture (non-canonical unit → canonical)
+-- ---------------------------------------------------------------------------
+
+{- | A unit config that knows grams as a non-canonical mass unit (factor 1e-3),
+so the parser canonicalizes a @g@ reference product to @kg@ at ingest.
+-}
+gramConfig :: UnitConfig
+gramConfig =
+    either (error . T.unpack) id $
+        buildFromCSV "name,dimension,factor\nkg,mass,1.0\ng,mass,1.0e-3\n"
+
+gramUnit :: Unit
+gramUnit = mkUnit "g"
+
+gramProdFlow :: TechnosphereFlow
+gramProdFlow = flowInUnit "milled flour" "g"
+
+-- | A flow whose generated UUIDs key off the given unit string.
+flowInUnit :: Text -> Text -> TechnosphereFlow
+flowInUnit n u =
+    TechnosphereFlow (generateFlowUUID n "" u) n (generateUnitUUID u) M.empty Nothing Nothing
+
+{- | One activity whose reference product is stated in grams (1000 g). On import
+under 'gramConfig' the parser rewrites it to 1 kg, so it is not a fixed point of
+@parse . write@ until it has been through the parser once.
+-}
+gramRefDb :: SimpleDatabase
+gramRefDb =
+    SimpleDatabase
+        { sdbActivities = M.singleton (generateActivityUUID act, getReferenceProductUUID act) act
+        , sdbTechFlows = M.singleton (tfId gramProdFlow) gramProdFlow
+        , sdbBioFlows = M.empty
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton (unitId gramUnit) gramUnit
+        }
+  where
+    act =
+        elec
+            { activityName = "Flour milling"
+            , activityUnit = "g"
+            , exchanges =
+                [ TechnosphereExchange
+                    { techFlowId = tfId gramProdFlow
+                    , techAmount = 1000
+                    , techUnitId = generateUnitUUID "g"
+                    , techRole = ReferenceProduct
+                    , techActivityLinkId = UUID.nil
+                    , techProcessLinkId = Nothing
+                    , techLocation = "GLO"
+                    , techComment = Nothing
+                    , techPedigree = Nothing
+                    }
+                ]
+            }
+
+-- | The (unit name, amount) of a parsed activity's reference exchange.
+refUnitAmount :: Parsed -> Maybe (Text, Double)
+refUnitAmount (acts, _tech, _bio, _waste, unitDB) = do
+    a <- listToMaybe acts
+    ex <- listToMaybe [e | e <- exchanges a, exchangeIsReference e]
+    pure (maybe "" unitName (M.lookup (exchangeUnitId ex) unitDB), exchangeAmount ex)
+
+-- ---------------------------------------------------------------------------
+-- Export-guard fixtures (rejected at the boundary)
+-- ---------------------------------------------------------------------------
+
+{- | A database whose activity carries a waste exchange (B4): rejected, since
+Brightway has no native waste type and would invert it on re-parse.
+-}
+wasteDb :: SimpleDatabase
+wasteDb =
+    fixtureDb
+        { sdbActivities = M.singleton (generateActivityUUID act, getReferenceProductUUID act) act
+        , sdbWasteFlows = M.singleton (wfId scrapFlow) scrapFlow
+        }
+  where
+    act = elec{exchanges = [prodExch, scrapExch]}
+
+scrapFlow :: WasteFlow
+scrapFlow =
+    WasteFlow
+        { wfId = generateFlowUUID "metal scrap" "" "kilogram"
+        , wfName = "metal scrap"
+        , wfUnitId = generateUnitUUID "kilogram"
+        , wfSynonyms = M.empty
+        , wfCAS = Nothing
+        , wfSubstanceId = Nothing
+        }
+
+scrapExch :: Exchange
+scrapExch =
+    WasteExchange
+        { waFlowId = wfId scrapFlow
+        , waAmount = 0.1
+        , waUnitId = generateUnitUUID "kilogram"
+        , waIsInput = False
+        , waActivityLinkId = UUID.nil
+        , waProcessLinkId = Nothing
+        , waLocation = ""
+        , waComment = Nothing
+        , waPedigree = Nothing
+        }
+
+{- | A database whose input exchange carries a non-finite amount: rejected, since
+it has no numeric-cell form that re-parses to the same value.
+-}
+nonFiniteDb :: SimpleDatabase
+nonFiniteDb =
+    fixtureDb
+        { sdbActivities = M.singleton (generateActivityUUID act, getReferenceProductUUID act) act
+        }
+  where
+    act = elec{exchanges = [prodExch, gasExch{techAmount = 1 / 0}, co2Exch]}
+
+{- | A database whose input exchange carries the smallest positive subnormal
+(@5e-324@): rejected, since fixed-point rendering collapses it to @0@.
+-}
+subnormalDb :: SimpleDatabase
+subnormalDb =
+    fixtureDb
+        { sdbActivities = M.singleton (generateActivityUUID act, getReferenceProductUUID act) act
+        }
+  where
+    act = elec{exchanges = [prodExch, gasExch{techAmount = 5.0e-324}, co2Exch]}
+
+co2 :: BiosphereFlow
+co2 =
+    BiosphereFlow
+        { bfId = generateFlowUUID "Carbon dioxide, fossil" "air" "kilogram"
+        , bfName = "Carbon dioxide, fossil"
+        , bfUnitId = generateUnitUUID "kilogram"
+        , bfSynonyms = M.empty
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfCompartment = Just (Compartment "air" Nothing)
+        }
+
+kwh, m3, kg :: Unit
+kwh = mkUnit "kilowatt hour"
+m3 = mkUnit "cubic meter"
+kg = mkUnit "kilogram"
+
+mkUnit :: Text -> Unit
+mkUnit n = Unit (generateUnitUUID n) n n ""
+
+-- ---------------------------------------------------------------------------
+-- Structural comparison (order-insensitive)
+-- ---------------------------------------------------------------------------
+
+{- | A normalized, comparable projection of a parsed database: activity names
+each with their reference product, sorted technosphere inputs, and sorted
+biosphere flows (name, amount, compartment, direction). This captures the
+semantic content the format can carry without depending on Map/Set ordering or
+on fields the format does not represent (links, pedigree).
+-}
+data NormActivity = NormActivity
+    { nName :: Text
+    , nLocation :: Text
+    , nRefProduct :: Maybe Text
+    , nInputs :: [(Text, Double, Text)]
+    , nBio :: [(Text, Double, Text, BioDirection)]
+    }
+    deriving (Eq, Show)
+
+type Parsed = ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB)
+
+normalizeParsed :: Parsed -> [NormActivity]
+normalizeParsed (acts, techDB, bioDB, _waste, unitDB) =
+    sortOn nName (map norm acts)
+  where
+    norm a =
+        NormActivity
+            { nName = activityName a
+            , nLocation = activityLocation a
+            , nRefProduct = listTo [tfName f | ex <- exchanges a, exchangeIsReference ex, Just f <- [M.lookup (exchangeFlowId ex) techDB]]
+            , nInputs =
+                sortOn (\(n, _, _) -> n) $
+                    [ (tfName f, techAmount ex, unitNameOf (techUnitId ex))
+                    | ex@TechnosphereExchange{techRole = Input} <- exchanges a
+                    , Just f <- [M.lookup (techFlowId ex) techDB]
+                    ]
+            , nBio =
+                sortOn (\(n, _, _, _) -> n) $
+                    [ (bfName f, bioAmount ex, bfCompartmentName f, bioDirection ex)
+                    | ex@BiosphereExchange{} <- exchanges a
+                    , Just f <- [M.lookup (bioFlowId ex) bioDB]
+                    ]
+            }
+    unitNameOf uid = maybe "" unitName (M.lookup uid unitDB)
+    listTo = \case
+        (x : _) -> Just x
+        [] -> Nothing
+
+-- | The same projection over the original fixture database.
+expectedNormalized :: [NormActivity]
+expectedNormalized =
+    normalizeParsed
+        ( M.elems (sdbActivities fixtureDb)
+        , sdbTechFlows fixtureDb
+        , sdbBioFlows fixtureDb
+        , sdbWasteFlows fixtureDb
+        , sdbUnits fixtureDb
+        )
+
+-- ---------------------------------------------------------------------------
+-- Logical-cell extraction (for idempotence)
+-- ---------------------------------------------------------------------------
+
+{- | Re-export the parsed 5-tuple to the writer's input shape. Activities are
+keyed exactly as 'Database.Loader.loadBrightwayExcel' keys them.
+-}
+rebuild :: Parsed -> SimpleDatabase
+rebuild (acts, techDB, bioDB, wasteDB, unitDB) =
+    SimpleDatabase
+        { sdbActivities = M.fromList [((generateActivityUUID a, getReferenceProductUUID a), a) | a <- acts]
+        , sdbTechFlows = techDB
+        , sdbBioFlows = bioDB
+        , sdbWasteFlows = wasteDB
+        , sdbUnits = unitDB
+        }
+
+{- | The deterministic logical cells the writer would emit for a database: the
+per-activity 'activityRows' (which already carry every value the format records,
+addressed by column). Comparing these is the logical-cell idempotence contract —
+byte identity of the zip is deliberately not required.
+-}
+logicalCells :: SimpleDatabase -> [[[Cell]]]
+logicalCells db =
+    [ activityRows cfg db a
+    | a <- sortOn (\x -> (activityName x, activityLocation x)) (M.elems (sdbActivities db))
+    ]
+
+-- ---------------------------------------------------------------------------
+-- Scoring (c)
+-- ---------------------------------------------------------------------------
+
+-- | CO2 biosphere inventory for the electricity activity (ProcessId 0).
+co2Inventory :: SimpleDatabase -> IO (Either Text (Maybe Double))
+co2Inventory sdb = do
+    built <-
+        buildDatabaseWithMatrices
+            defaultUnitConfig
+            (sdbActivities sdb)
+            (sdbTechFlows sdb)
+            (sdbBioFlows sdb)
+            (sdbWasteFlows sdb)
+            (sdbUnits sdb)
+    case built of
+        Left err -> pure (Left err)
+        Right db -> do
+            inv <- computeInventoryMatrix db 0
+            pure (Right (lookupCo2 db inv))
+  where
+    lookupCo2 db inv =
+        case find ((== "Carbon dioxide, fossil") . bfName) (M.elems (dbBioFlows db)) of
+            Just f -> M.lookup (bfId f) inv
+            Nothing -> Nothing
+
+-- ---------------------------------------------------------------------------
+-- File helper
+-- ---------------------------------------------------------------------------
+
+withWritten :: SimpleDatabase -> (FilePath -> IO a) -> IO a
+withWritten db action =
+    withSystemTempFile "brightway-writer.xlsx" $ \path h -> do
+        bytes <- either (\e -> error ("renderWorkbook: " <> T.unpack e)) pure (renderWorkbook cfg db)
+        BL.hPut h bytes
+        hClose h
+        action path

--- a/test/ILCDWriterSpec.hs
+++ b/test/ILCDWriterSpec.hs
@@ -1,0 +1,515 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Round-trip contract for "ILCD.Writer", the inverse of "ILCD.Parser".
+
+The original database @D@ is obtained by parsing the @SAMPLE.ilcd@ fixture with
+'parseILCDDirectory'. That guarantees @D@ already lives in the parser's
+canonical internal form (resolved units, classified flows, linked exchanges),
+so the write→parse cycle has a fair fixed point to land on.
+
+Three properties are pinned, exactly as for the SimaPro/Brightway writers:
+
+  (a) idempotence modulo volatile metadata — @write(D)@ then
+      @write(parse(write(D)))@ produce byte-identical output. The only volatile
+      fields (export timestamp, generator string) are /omitted/ by
+      'defaultWriteOptions', so this holds without any normalization;
+
+  (b) semantic round-trip — @parse(write(D))@ is structurally equal to @D@,
+      order-insensitively, over activities, exchanges and the flow catalog;
+
+  (c) score-equivalence — @parse(write(D))@ yields the same biosphere inventory
+      (the LCIA-precursor vector; an LCIA score is linear in it) as @D@ within
+      tolerance, via the engine's 'computeInventoryMatrix'.
+-}
+module ILCDWriterSpec (spec) where
+
+import Codec.Archive.Zip (ZipOption (OptDestination), extractFilesFromArchive, toArchive)
+import qualified Data.ByteString.Lazy as BL
+import Data.Either (isLeft)
+import Data.List (isPrefixOf, sort)
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import Database (buildDatabaseWithMatrices)
+import ILCD.Parser (parseILCDDirectory)
+import ILCD.Writer (
+    checkILCDExportable,
+    defaultWriteOptions,
+    escapeXml,
+    formatDouble,
+    ilcdFiles,
+    writeILCDArchive,
+    writeILCDDatabase,
+ )
+import Matrix (computeInventoryMatrix)
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+import Types
+import UnitConversion (defaultUnitConfig)
+
+fixtureDir :: FilePath
+fixtureDir = "test-data/SAMPLE.ilcd"
+
+-- | Parse the fixture into a 'SimpleDatabase' (fails the test on Left).
+loadFixture :: IO SimpleDatabase
+loadFixture = do
+    r <- parseILCDDirectory fixtureDir
+    case r of
+        Left err -> error ("fixture parse failed: " <> T.unpack err)
+        Right db -> pure db
+
+{- | Write a 'SimpleDatabase' to a fresh temp ILCD tree and parse it back.
+A fresh directory per call avoids the parser's on-disk flow cache leaking
+between round-trips.
+-}
+roundTrip :: SimpleDatabase -> IO SimpleDatabase
+roundTrip db = withSystemTempDirectory "ilcd-writer-spec" $ \dir -> do
+    writeILCDDatabase defaultWriteOptions dir db
+    r <- parseILCDDirectory dir
+    case r of
+        Left err -> error ("round-trip parse failed: " <> T.unpack err)
+        Right db' -> pure db'
+
+{- | Round-trip through the production zip export path: serialize with
+'writeILCDArchive', extract the archive to a fresh temp tree and parse it back.
+This is the byte stream 'Database.Export' ships to clients.
+-}
+archiveRoundTrip :: SimpleDatabase -> IO SimpleDatabase
+archiveRoundTrip db = withSystemTempDirectory "ilcd-archive-spec" $ \dir -> do
+    extractFilesFromArchive [OptDestination dir] (toArchive (writeILCDArchive defaultWriteOptions db))
+    r <- parseILCDDirectory dir
+    case r of
+        Left err -> error ("archive round-trip parse failed: " <> T.unpack err)
+        Right db' -> pure db'
+
+-- ---------------------------------------------------------------------------
+-- Structural comparison (order-insensitive)
+-- ---------------------------------------------------------------------------
+
+data ActivityShape = ActivityShape
+    { asName :: Text
+    , asLocation :: Text
+    , asClass :: [(Text, Text)]
+    , asNative :: Maybe Text
+    , asExchanges :: [ExchangeShape]
+    }
+    deriving (Eq, Ord, Show)
+
+data ExchangeShape = ExchangeShape
+    { esKind :: Text
+    , esFlow :: Text
+    , esUnit :: Text
+    , esAmount :: Double
+    , esInput :: Bool
+    , esRef :: Bool
+    , esComment :: Maybe Text
+    }
+    deriving (Eq, Ord, Show)
+
+exchangeShape :: SimpleDatabase -> Exchange -> ExchangeShape
+exchangeShape db ex =
+    let unitNm uid = maybe "" unitName (M.lookup uid (sdbUnits db))
+        roundAmt v = fromIntegral (round (v * 1e9) :: Integer) / 1e9 :: Double
+     in case ex of
+            TechnosphereExchange{techFlowId = fid, techAmount = amt, techUnitId = uid, techComment = c} ->
+                ExchangeShape
+                    "tech"
+                    (maybe "?" tfName (M.lookup fid (sdbTechFlows db)))
+                    (unitNm uid)
+                    (roundAmt amt)
+                    (exchangeIsInput ex)
+                    (exchangeIsReference ex)
+                    c
+            BiosphereExchange{bioFlowId = fid, bioAmount = amt, bioUnitId = uid, bioComment = c} ->
+                ExchangeShape
+                    "bio"
+                    (maybe "?" bfName (M.lookup fid (sdbBioFlows db)))
+                    (unitNm uid)
+                    (roundAmt amt)
+                    (exchangeIsInput ex)
+                    (exchangeIsReference ex)
+                    c
+            WasteExchange{waFlowId = fid, waAmount = amt, waUnitId = uid, waComment = c} ->
+                ExchangeShape
+                    "waste"
+                    (maybe "?" wfName (M.lookup fid (sdbWasteFlows db)))
+                    (unitNm uid)
+                    (roundAmt amt)
+                    (exchangeIsInput ex)
+                    (exchangeIsReference ex)
+                    c
+
+activityShape :: SimpleDatabase -> Activity -> ActivityShape
+activityShape db a =
+    ActivityShape
+        { asName = activityName a
+        , asLocation = activityLocation a
+        , asClass = M.toAscList (activityClassification a)
+        , asNative = nativeLabel (activityNativeType a)
+        , asExchanges = sort (map (exchangeShape db) (exchanges a))
+        }
+
+nativeLabel :: Maybe NativeActivityType -> Maybe Text
+nativeLabel nt = case nt of
+    Just (ILCDProcessType l) -> Just l
+    Just (SimaProProcessType l) -> Just l
+    Just (EcoSpoldActivityType{}) -> Nothing
+    Nothing -> Nothing
+
+activityShapes :: SimpleDatabase -> S.Set ActivityShape
+activityShapes db = S.fromList (map (activityShape db) (M.elems (sdbActivities db)))
+
+-- | Order-insensitive view of the flow catalog: (kind, name, unit, cas).
+data FlowShape = FlowShape Text Text Text (Maybe Text)
+    deriving (Eq, Ord, Show)
+
+flowShapes :: SimpleDatabase -> S.Set FlowShape
+flowShapes db =
+    S.fromList $
+        [FlowShape "tech" (tfName f) (unitNm (tfUnitId f)) (tfCAS f) | f <- M.elems (sdbTechFlows db)]
+            ++ [FlowShape "bio" (bfName f) (unitNm (bfUnitId f)) (bfCAS f) | f <- M.elems (sdbBioFlows db)]
+            ++ [FlowShape "waste" (wfName f) (unitNm (wfUnitId f)) (wfCAS f) | f <- M.elems (sdbWasteFlows db)]
+  where
+    unitNm uid = maybe "" unitName (M.lookup uid (sdbUnits db))
+
+-- ---------------------------------------------------------------------------
+-- Inventory (score-equivalence) helper
+-- ---------------------------------------------------------------------------
+
+{- | Build a Database from a 'SimpleDatabase' and compute the inventory of the
+named activity, keyed by biosphere flow name.
+-}
+inventoryByName :: SimpleDatabase -> Text -> IO (M.Map Text Double)
+inventoryByName db target = do
+    built <-
+        buildDatabaseWithMatrices
+            defaultUnitConfig
+            (sdbActivities db)
+            (sdbTechFlows db)
+            (sdbBioFlows db)
+            (sdbWasteFlows db)
+            (sdbUnits db)
+    case built of
+        Left err -> expectationFailure (T.unpack err) >> pure M.empty
+        Right d -> do
+            let pids =
+                    [ pid
+                    | (pid, (actU, _)) <- zip [0 ..] (V.toList (dbProcessIdTable d))
+                    , Just act <- [activityAtUUID d actU]
+                    , activityName act == target
+                    ]
+            case pids of
+                (pid : _) -> do
+                    inv <- computeInventoryMatrix d pid
+                    pure (M.mapKeys (flowName d) inv)
+                [] -> expectationFailure ("no activity named " <> T.unpack target) >> pure M.empty
+  where
+    flowName d uid = maybe (T.pack (show uid)) bfName (M.lookup uid (dbBioFlows d))
+    activityAtUUID d actU =
+        case [i | (i, (a, _)) <- zip [0 ..] (V.toList (dbProcessIdTable d)), a == actU] of
+            (i : _) -> Just (dbActivities d V.! i)
+            [] -> Nothing
+
+-- ---------------------------------------------------------------------------
+-- Spec
+-- ---------------------------------------------------------------------------
+
+spec :: Spec
+spec = describe "ILCD.Writer round-trip" $ do
+    it "(pure) formatDouble round-trips integral and fractional values" $ do
+        formatDouble 1.0 `shouldBe` "1"
+        formatDouble 2.5 `shouldBe` "2.5"
+        formatDouble 0.001 `shouldBe` "1.0e-3"
+        formatDouble (-3.0) `shouldBe` "-3"
+
+    it "(pure) escapeXml escapes the predefined entities" $ do
+        escapeXml "a & b < c > d" `shouldBe` "a &amp; b &lt; c &gt; d"
+        escapeXml "plain" `shouldBe` "plain"
+
+    it "emits one process file per activity" $ do
+        db <- loadFixture
+        let procFiles = [p | (p, _) <- ilcdFiles defaultWriteOptions db, "processes/" `isPrefixOfFp` p]
+        length procFiles `shouldBe` M.size (sdbActivities db)
+
+    describe "checkILCDExportable (multi-output guard)" $ do
+        it "accepts a single-output database" $ do
+            db <- loadFixture
+            checkILCDExportable db `shouldBe` Right ()
+
+        it "rejects a multi-output activity rather than silently dropping a product" $
+            -- Two reference products share one activity UUID, so both would write
+            -- to the same processes/<actUUID>.xml. The guard must fail loudly.
+            checkILCDExportable multiOutputDb `shouldSatisfy` isLeft
+
+    it "produces a parseable ILCD tree with the same activity count" $ do
+        db <- loadFixture
+        db' <- roundTrip db
+        M.size (sdbActivities db') `shouldBe` M.size (sdbActivities db)
+
+    it "(a) is idempotent modulo volatile metadata" $ do
+        db <- loadFixture
+        let f0 = ilcdFiles defaultWriteOptions db
+        db' <- roundTrip db
+        let f1 = ilcdFiles defaultWriteOptions db'
+        f1 `shouldBe` f0
+
+    it "(b) semantic round-trip: activities are structurally equal" $ do
+        db <- loadFixture
+        db' <- roundTrip db
+        activityShapes db' `shouldBe` activityShapes db
+
+    it "(b) semantic round-trip: the flow catalog is structurally equal" $ do
+        db <- loadFixture
+        db' <- roundTrip db
+        flowShapes db' `shouldBe` flowShapes db
+
+    describe "writeILCDArchive (production export path)" $ do
+        it "is byte-deterministic across runs (epoch-0 mtimes)" $ do
+            db <- loadFixture
+            let bytes = writeILCDArchive defaultWriteOptions db
+            writeILCDArchive defaultWriteOptions db `shouldBe` bytes
+            BL.null bytes `shouldBe` False
+
+        it "extracts and reparses to a structurally equal database" $ do
+            db <- loadFixture
+            db' <- archiveRoundTrip db
+            activityShapes db' `shouldBe` activityShapes db
+            flowShapes db' `shouldBe` flowShapes db
+
+    it "(c) score-equivalence: same inventory for the sample activity within tolerance" $ do
+        db <- loadFixture
+        db' <- roundTrip db
+        invOrig <- inventoryByName db "Coal extraction"
+        invRound <- inventoryByName db' "Coal extraction"
+        M.keysSet invRound `shouldBe` M.keysSet invOrig
+        let diffs =
+                [ abs (a - b)
+                | (k, a) <- M.toList invOrig
+                , let b = M.findWithDefault 0 k invRound
+                ]
+        all (< 1e-9) diffs `shouldBe` True
+
+    describe "feature round-trip and export guards" $ do
+        it "round-trips a bio subcompartment, a natural-resource flow and a non-zero reference index" $ do
+            db' <- roundTrip richDb
+            -- Emission medium + sub, resource medium, and the special-char
+            -- name/comment all survive via the shared structural views.
+            activityShapes db' `shouldBe` activityShapes richDb
+            flowShapes db' `shouldBe` flowShapes richDb
+            -- Compartment sub is not part of FlowShape, so assert it directly.
+            map bfCompartment (M.elems (sdbBioFlows db'))
+                `shouldMatchList` map bfCompartment (M.elems (sdbBioFlows richDb))
+
+        it "round-trips a name and comment with & < > \" and unicode verbatim" $ do
+            db' <- roundTrip richDb
+            let names = map activityName (M.elems (sdbActivities db'))
+            names `shouldBe` [specialText]
+            let comments =
+                    [ c
+                    | act <- M.elems (sdbActivities db')
+                    , ex <- exchanges act
+                    , Just c <- [exchangeComment ex]
+                    ]
+            comments `shouldContain` [specialText]
+
+        it "places the reference at a non-zero index after round-trip" $ do
+            db' <- roundTrip richDb
+            let refIdxs =
+                    [ i
+                    | act <- M.elems (sdbActivities db')
+                    , (i, ex) <- zip [0 :: Int ..] (exchanges act)
+                    , exchangeIsReference ex
+                    ]
+            refIdxs `shouldBe` [2]
+
+        it "rejects a non-canonical biosphere medium at the export boundary" $
+            checkILCDExportable (bioMediumDb "fresh water") `shouldSatisfy` isLeft
+
+        it "accepts a canonical biosphere medium" $
+            checkILCDExportable (bioMediumDb "air") `shouldBe` Right ()
+
+        it "preserves the no-reference state on a reference-less activity" $ do
+            checkILCDExportable noRefDb `shouldBe` Right ()
+            db' <- roundTrip noRefDb
+            let refs =
+                    [ ()
+                    | act <- M.elems (sdbActivities db')
+                    , ex <- exchanges act
+                    , exchangeIsReference ex
+                    ]
+            refs `shouldBe` []
+
+        it "clamps a NaN or Infinity amount to zero on export" $ do
+            formatDouble (0 / 0) `shouldBe` "0"
+            formatDouble (1 / 0) `shouldBe` "0"
+            db' <- roundTrip (nonFiniteDb (1 / 0))
+            let amounts =
+                    [ exchangeAmount ex
+                    | act <- M.elems (sdbActivities db')
+                    , ex <- exchanges act
+                    , isBiosphereExchange ex
+                    ]
+            amounts `shouldBe` [0]
+
+isPrefixOfFp :: String -> FilePath -> Bool
+isPrefixOfFp = isPrefixOf
+
+-- ---------------------------------------------------------------------------
+-- Multi-output fixture (two products sharing one activity UUID)
+-- ---------------------------------------------------------------------------
+
+{- | A degenerate database where one activity UUID exposes two reference
+products — the shape an ES2/SimaPro multi-output activity takes internally.
+ILCD cannot represent it (one process per UUID), so 'checkILCDExportable'
+rejects it.
+-}
+multiOutputDb :: SimpleDatabase
+multiOutputDb =
+    SimpleDatabase
+        { sdbActivities =
+            M.fromList
+                [ ((actU, prodA), prodAct "co-product A" prodA)
+                , ((actU, prodB), prodAct "co-product B" prodB)
+                ]
+        , sdbTechFlows =
+            M.fromList
+                [ (prodA, techFlow prodA "product A")
+                , (prodB, techFlow prodB "product B")
+                ]
+        , sdbBioFlows = M.empty
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton unitU (Unit unitU "kg" "kg" "")
+        }
+  where
+    actU, prodA, prodB, unitU :: UUID
+    actU = read "aaaaaaaa-0000-4000-8000-000000000001"
+    prodA = read "aaaaaaaa-0000-4000-8000-0000000000a1"
+    prodB = read "aaaaaaaa-0000-4000-8000-0000000000b2"
+    unitU = read "11111111-0000-4000-8000-000000000001"
+    techFlow :: UUID -> Text -> TechnosphereFlow
+    techFlow fid nm = TechnosphereFlow fid nm unitU M.empty Nothing Nothing
+    prodAct :: Text -> UUID -> Activity
+    prodAct nm prod =
+        Activity
+            nm
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "kg"
+            [TechnosphereExchange prod 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            Nothing
+
+-- ---------------------------------------------------------------------------
+-- Feature fixtures (single-output, exercising the recent ILCD writer fixes)
+-- ---------------------------------------------------------------------------
+
+-- | A name/comment carrying every XML-significant char plus non-ASCII text.
+specialText :: Text
+specialText = "Name & <tag> \"q\" café ☕"
+
+{- | UUIDs shared by the feature fixtures. Distinct constructors keep each flow
+addressable; the reference product is deliberately the /third/ exchange so a
+non-zero reference index has to survive the round-trip.
+-}
+fActU, fProdU, fEmitU, fResU, fUnitU :: UUID
+fActU = read "bbbbbbbb-0000-4000-8000-000000000001"
+fProdU = read "bbbbbbbb-0000-4000-8000-0000000000c1"
+fEmitU = read "bbbbbbbb-0000-4000-8000-0000000000e1"
+fResU = read "bbbbbbbb-0000-4000-8000-0000000000d1"
+fUnitU = read "22222222-0000-4000-8000-000000000001"
+
+fUnits :: M.Map UUID Unit
+fUnits = M.singleton fUnitU (Unit fUnitU "kg" "kg" "")
+
+fProduct :: TechnosphereFlow
+fProduct = TechnosphereFlow fProdU "product P" fUnitU M.empty Nothing Nothing
+
+fEmission :: BiosphereFlow
+fEmission =
+    BiosphereFlow fEmitU "Carbon dioxide" fUnitU M.empty Nothing Nothing $
+        Just (Compartment "air" (Just "high. pop."))
+
+fResource :: BiosphereFlow
+fResource =
+    BiosphereFlow fResU "Iron ore" fUnitU M.empty Nothing Nothing $
+        Just (Compartment "natural resource" (Just "in ground"))
+
+{- | A one-activity database wrapping the given biosphere catalog and exchanges,
+sharing one technosphere product flow and one unit. The activity name carries
+'specialText' so XML-significant chars are exercised on every round-trip.
+-}
+oneActivityDb :: M.Map UUID BiosphereFlow -> [Exchange] -> SimpleDatabase
+oneActivityDb bios exs =
+    SimpleDatabase
+        { sdbActivities = M.singleton (fActU, fProdU) act
+        , sdbTechFlows = M.singleton fProdU fProduct
+        , sdbBioFlows = bios
+        , sdbWasteFlows = M.empty
+        , sdbUnits = fUnits
+        }
+  where
+    act =
+        Activity
+            { activityName = specialText
+            , activityDescription = []
+            , activitySynonyms = M.empty
+            , activityClassification = M.empty
+            , activityLocation = "GLO"
+            , activityUnit = "kg"
+            , exchanges = exs
+            , activityParams = M.empty
+            , activityParamExprs = M.empty
+            , activityAllocationPercent = Nothing
+            , activityAllocationFormula = Nothing
+            , activityNativeType = Nothing
+            }
+
+refProductEx :: Exchange
+refProductEx = TechnosphereExchange fProdU 1.0 fUnitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+
+{- | The reference product sits at index 2, after an air emission with a
+subcompartment and a natural-resource input. One exchange comment carries
+'specialText', so names and comments are exercised together.
+-}
+richDb :: SimpleDatabase
+richDb =
+    oneActivityDb
+        (M.fromList [(fEmitU, fEmission), (fResU, fResource)])
+        [ BiosphereExchange fEmitU 2.0 fUnitU Emission "" (Just specialText) Nothing
+        , BiosphereExchange fResU 3.0 fUnitU Resource "" Nothing Nothing
+        , refProductEx
+        ]
+
+{- | One activity with a single biosphere emission under the given medium.
+A non-canonical medium ("fresh water", "resource", …) is what
+'checkILCDExportable' must reject; a canonical one passes.
+-}
+bioMediumDb :: Text -> SimpleDatabase
+bioMediumDb medium =
+    oneActivityDb
+        (M.singleton fEmitU (fEmission{bfCompartment = Just (Compartment medium Nothing)}))
+        [BiosphereExchange fEmitU 1.0 fUnitU Emission "" Nothing Nothing, refProductEx]
+
+-- | An activity with no exchange marked as reference (preserve-no-reference path).
+noRefDb :: SimpleDatabase
+noRefDb =
+    oneActivityDb
+        (M.singleton fEmitU fEmission)
+        [BiosphereExchange fEmitU 1.0 fUnitU Emission "" Nothing Nothing]
+
+{- | One activity whose single biosphere amount is the given (non-finite) value.
+'formatDouble' clamps NaN/Infinity to 0, so the amount re-imports as 0.
+-}
+nonFiniteDb :: Double -> SimpleDatabase
+nonFiniteDb amt =
+    oneActivityDb
+        (M.singleton fEmitU fEmission)
+        [BiosphereExchange fEmitU amt fUnitU Emission "" Nothing Nothing]

--- a/test/ILCDWriterSpec.hs
+++ b/test/ILCDWriterSpec.hs
@@ -36,9 +36,11 @@ import qualified Data.Vector as V
 import Database (buildDatabaseWithMatrices)
 import ILCD.Parser (parseILCDDirectory)
 import ILCD.Writer (
+    WriteOptions,
     checkILCDExportable,
     defaultWriteOptions,
     escapeXml,
+    escapeXmlAttr,
     formatDouble,
     ilcdFiles,
     writeILCDArchive,
@@ -68,10 +70,16 @@ between round-trips.
 roundTrip :: SimpleDatabase -> IO SimpleDatabase
 roundTrip db = withSystemTempDirectory "ilcd-writer-spec" $ \dir -> do
     writeILCDDatabase defaultWriteOptions dir db
+        >>= either (\e -> error ("ILCD write failed: " <> T.unpack e)) pure
     r <- parseILCDDirectory dir
     case r of
         Left err -> error ("round-trip parse failed: " <> T.unpack err)
         Right db' -> pure db'
+
+-- | Unwrap the guard-returning archive writer for a fixture known to be exportable.
+archiveOrFail :: WriteOptions -> SimpleDatabase -> BL.ByteString
+archiveOrFail opts db =
+    either (\e -> error ("writeILCDArchive: " <> T.unpack e)) id (writeILCDArchive opts db)
 
 {- | Round-trip through the production zip export path: serialize with
 'writeILCDArchive', extract the archive to a fresh temp tree and parse it back.
@@ -79,7 +87,7 @@ This is the byte stream 'Database.Export' ships to clients.
 -}
 archiveRoundTrip :: SimpleDatabase -> IO SimpleDatabase
 archiveRoundTrip db = withSystemTempDirectory "ilcd-archive-spec" $ \dir -> do
-    extractFilesFromArchive [OptDestination dir] (toArchive (writeILCDArchive defaultWriteOptions db))
+    extractFilesFromArchive [OptDestination dir] (toArchive (archiveOrFail defaultWriteOptions db))
     r <- parseILCDDirectory dir
     case r of
         Left err -> error ("archive round-trip parse failed: " <> T.unpack err)
@@ -219,15 +227,38 @@ inventoryByName db target = do
 
 spec :: Spec
 spec = describe "ILCD.Writer round-trip" $ do
-    it "(pure) formatDouble round-trips integral and fractional values" $ do
-        formatDouble 1.0 `shouldBe` "1"
+    it "(pure) formatDouble emits fixed-point (never scientific) doubles" $ do
+        formatDouble 1.0 `shouldBe` "1.0"
         formatDouble 2.5 `shouldBe` "2.5"
-        formatDouble 0.001 `shouldBe` "1.0e-3"
-        formatDouble (-3.0) `shouldBe` "-3"
+        formatDouble (-3.0) `shouldBe` "-3.0"
+        formatDouble (-0.0) `shouldBe` "0.0"
+        -- The fix: small magnitudes stay fixed-point so they re-read losslessly.
+        T.isInfixOf "e" (formatDouble 3.3e-20) `shouldBe` False
 
     it "(pure) escapeXml escapes the predefined entities" $ do
         escapeXml "a & b < c > d" `shouldBe` "a &amp; b &lt; c &gt; d"
         escapeXml "plain" `shouldBe` "plain"
+
+    it "(pure) escapeXmlAttr encodes newlines so they survive in an attribute" $
+        -- A raw \n/\r in an attribute value is normalised to a space by XML
+        -- parsers; encode it as a numeric character reference instead.
+        escapeXmlAttr "line1\nline2\rx" `shouldBe` "line1&#10;line2&#13;x"
+
+    it "round-trips a small-exponent amount without scientific-notation loss" $ do
+        -- show 3.3e-20 emits scientific notation the parser re-reads lossily;
+        -- showFFloatTrim keeps it value-identical end-to-end through the writer.
+        let sdb =
+                oneActivityDb
+                    (M.singleton fEmitU fEmission)
+                    [ TechnosphereExchange fProdU 1.0 fUnitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+                    , BiosphereExchange fEmitU 3.3e-20 fUnitU Emission "" Nothing Nothing
+                    ]
+        db' <- roundTrip sdb
+        [ bioAmount ex
+          | a <- M.elems (sdbActivities db')
+          , ex@BiosphereExchange{} <- exchanges a
+          ]
+            `shouldSatisfy` elem 3.3e-20
 
     it "emits one process file per activity" $ do
         db <- loadFixture
@@ -269,8 +300,8 @@ spec = describe "ILCD.Writer round-trip" $ do
     describe "writeILCDArchive (production export path)" $ do
         it "is byte-deterministic across runs (epoch-0 mtimes)" $ do
             db <- loadFixture
-            let bytes = writeILCDArchive defaultWriteOptions db
-            writeILCDArchive defaultWriteOptions db `shouldBe` bytes
+            let bytes = archiveOrFail defaultWriteOptions db
+            archiveOrFail defaultWriteOptions db `shouldBe` bytes
             BL.null bytes `shouldBe` False
 
         it "extracts and reparses to a structurally equal database" $ do
@@ -343,8 +374,8 @@ spec = describe "ILCD.Writer round-trip" $ do
             refs `shouldBe` []
 
         it "clamps a NaN or Infinity amount to zero on export" $ do
-            formatDouble (0 / 0) `shouldBe` "0"
-            formatDouble (1 / 0) `shouldBe` "0"
+            formatDouble (0 / 0) `shouldBe` "0.0"
+            formatDouble (1 / 0) `shouldBe` "0.0"
             db' <- roundTrip (nonFiniteDb (1 / 0))
             let amounts =
                     [ exchangeAmount ex

--- a/test/ILCDWriterSpec.hs
+++ b/test/ILCDWriterSpec.hs
@@ -113,6 +113,7 @@ data ExchangeShape = ExchangeShape
     , esAmount :: Double
     , esInput :: Bool
     , esRef :: Bool
+    , esLocation :: Text
     , esComment :: Maybe Text
     }
     deriving (Eq, Ord, Show)
@@ -130,6 +131,7 @@ exchangeShape db ex =
                     (roundAmt amt)
                     (exchangeIsInput ex)
                     (exchangeIsReference ex)
+                    (exchangeLocation ex)
                     c
             BiosphereExchange{bioFlowId = fid, bioAmount = amt, bioUnitId = uid, bioComment = c} ->
                 ExchangeShape
@@ -139,6 +141,7 @@ exchangeShape db ex =
                     (roundAmt amt)
                     (exchangeIsInput ex)
                     (exchangeIsReference ex)
+                    (exchangeLocation ex)
                     c
             WasteExchange{waFlowId = fid, waAmount = amt, waUnitId = uid, waComment = c} ->
                 ExchangeShape
@@ -148,6 +151,7 @@ exchangeShape db ex =
                     (roundAmt amt)
                     (exchangeIsInput ex)
                     (exchangeIsReference ex)
+                    (exchangeLocation ex)
                     c
 
 activityShape :: SimpleDatabase -> Activity -> ActivityShape
@@ -346,6 +350,16 @@ spec = describe "ILCD.Writer round-trip" $ do
                     ]
             comments `shouldContain` [specialText]
 
+        it "round-trips a non-empty per-exchange location verbatim" $ do
+            db' <- roundTrip richDb
+            let locs =
+                    [ exchangeLocation ex
+                    | act <- M.elems (sdbActivities db')
+                    , ex <- exchanges act
+                    , not (T.null (exchangeLocation ex))
+                    ]
+            locs `shouldBe` ["RER"]
+
         it "places the reference at a non-zero index after round-trip" $ do
             db' <- roundTrip richDb
             let refIdxs =
@@ -513,14 +527,15 @@ refProductEx :: Exchange
 refProductEx = TechnosphereExchange fProdU 1.0 fUnitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing
 
 {- | The reference product sits at index 2, after an air emission with a
-subcompartment and a natural-resource input. One exchange comment carries
-'specialText', so names and comments are exercised together.
+subcompartment and a natural-resource input. One exchange carries a non-empty
+location and a comment of 'specialText', so location, names and comments are all
+exercised together.
 -}
 richDb :: SimpleDatabase
 richDb =
     oneActivityDb
         (M.fromList [(fEmitU, fEmission), (fResU, fResource)])
-        [ BiosphereExchange fEmitU 2.0 fUnitU Emission "" (Just specialText) Nothing
+        [ BiosphereExchange fEmitU 2.0 fUnitU Emission "RER" (Just specialText) Nothing
         , BiosphereExchange fResU 3.0 fUnitU Resource "" Nothing Nothing
         , refProductEx
         ]

--- a/test/ILCDWriterSpec.hs
+++ b/test/ILCDWriterSpec.hs
@@ -334,7 +334,7 @@ spec = describe "ILCD.Writer round-trip" $ do
             map bfCompartment (M.elems (sdbBioFlows db'))
                 `shouldMatchList` map bfCompartment (M.elems (sdbBioFlows richDb))
 
-        it "round-trips a name and comment with & < > \" and unicode verbatim" $ do
+        it "round-trips a name and comment with & < > \", entity literals and unicode verbatim" $ do
             db' <- roundTrip richDb
             let names = map activityName (M.elems (sdbActivities db'))
             names `shouldBe` [specialText]
@@ -373,17 +373,18 @@ spec = describe "ILCD.Writer round-trip" $ do
                     ]
             refs `shouldBe` []
 
-        it "clamps a NaN or Infinity amount to zero on export" $ do
-            formatDouble (0 / 0) `shouldBe` "0.0"
-            formatDouble (1 / 0) `shouldBe` "0.0"
-            db' <- roundTrip (nonFiniteDb (1 / 0))
-            let amounts =
-                    [ exchangeAmount ex
-                    | act <- M.elems (sdbActivities db')
-                    , ex <- exchanges act
-                    , isBiosphereExchange ex
-                    ]
-            amounts `shouldBe` [0]
+        it "rejects a non-finite amount rather than silently clamping it to zero" $ do
+            -- formatDouble renders the non-parseable form so a bad re-import
+            -- fails loudly; the export guard rejects it before that can happen.
+            formatDouble (0 / 0) `shouldBe` "NaN"
+            formatDouble (1 / 0) `shouldBe` "Infinity"
+            checkILCDExportable (nonFiniteDb (1 / 0)) `shouldSatisfy` isLeft
+            checkILCDExportable (nonFiniteDb (0 / 0)) `shouldSatisfy` isLeft
+
+        it "rejects a subnormal amount that fixed-point cannot round-trip" $
+            -- 5e-324 (smallest positive subnormal) re-parses to 0 through
+            -- fixed-point, an undetectable LCIA shift; reject it at the boundary.
+            checkILCDExportable (nonFiniteDb 5.0e-324) `shouldSatisfy` isLeft
 
 isPrefixOfFp :: String -> FilePath -> Bool
 isPrefixOfFp = isPrefixOf
@@ -442,9 +443,14 @@ multiOutputDb =
 -- Feature fixtures (single-output, exercising the recent ILCD writer fixes)
 -- ---------------------------------------------------------------------------
 
--- | A name/comment carrying every XML-significant char plus non-ASCII text.
+{- | A name/comment carrying every XML-significant char plus non-ASCII text.
+The literal entity references @&lt;@ and @&amp;@ are deliberate: the writer
+escapes their @&@ to @&amp;@ (so @&lt;@ → @&amp;lt;@), and a decoder that resolves
+@&amp;@ before @&lt;@ would corrupt them back to @<@/@&@. They guard that
+asymmetry.
+-}
 specialText :: Text
-specialText = "Name & <tag> \"q\" café ☕"
+specialText = "Name & <tag> \"q\" &lt; &amp; café ☕"
 
 {- | UUIDs shared by the feature fixtures. Distinct constructors keep each flow
 addressable; the reference product is deliberately the /third/ exchange so a
@@ -536,8 +542,9 @@ noRefDb =
         (M.singleton fEmitU fEmission)
         [BiosphereExchange fEmitU 1.0 fUnitU Emission "" Nothing Nothing]
 
-{- | One activity whose single biosphere amount is the given (non-finite) value.
-'formatDouble' clamps NaN/Infinity to 0, so the amount re-imports as 0.
+{- | One activity whose single biosphere amount is the given value. Used with a
+non-finite or subnormal amount that 'checkILCDExportable' must reject because it
+does not re-parse to itself through 'formatDouble'.
 -}
 nonFiniteDb :: Double -> SimpleDatabase
 nonFiniteDb amt =

--- a/volca.cabal
+++ b/volca.cabal
@@ -89,6 +89,7 @@ library
                      , SimaPro.Parser
                      , SimaPro.Writer
                      , BrightwayExcel.Parser
+                     , BrightwayExcel.Writer
                      , Expr
                      , ILCD.Parser
                      , ILCD.Writer
@@ -211,6 +212,7 @@ test-suite lca-tests
                      , MethodSpec
                      , SimaProParserSpec
                      , BrightwayExcelSpec
+                     , BrightwayExcelWriterSpec
                      , UnitConversionSpec
                      , PluginSpec
                      , ServerSpec

--- a/volca.cabal
+++ b/volca.cabal
@@ -91,6 +91,7 @@ library
                      , BrightwayExcel.Parser
                      , Expr
                      , ILCD.Parser
+                     , ILCD.Writer
                      , Plugin.Types
                      , Plugin.Builtin
                      , Plugin.Bridge
@@ -250,6 +251,7 @@ test-suite lca-tests
                      , EcoSpold2Spec
                      , EcoSpold2WriterSpec
                      , SimaProWriterSpec
+                     , ILCDWriterSpec
                      , MCPSchemaSpec
                      , BatchImpactsSpec
                      , MCPEnrichSpec


### PR DESCRIPTION
## What
Serialize an in-memory database to an ILCD process dataset tree, packaged as a deterministic zip. A multi-output activity (which ILCD keys by activity UUID alone) fails loudly rather than overwriting one process with another. The writer is the deterministic inverse of its parser, pinned by a three-way round-trip spec: byte-identical modulo volatile metadata, order-insensitive parse∘write, and unchanged LCIA scores across the round-trip.

Part of the #113 split into focused, independently-reviewable PRs. Stacked on `feat/writer-ecospold2` — **merge bottom-up**; #114 (delete) is the base of the stack. Full stack: `cabal test lca-tests` → 1255 examples, 0 failures.