### PR TITLE
feat(brightway): Brightway Excel writer — canonical inverse of the parser

### DIFF
--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -47,6 +47,7 @@ module BrightwayExcel.Parser (
     sheetToActivities,
     skippedSheetWarning,
     splitCategories,
+    isResourceCompartment,
 ) where
 
 import Codec.Archive.Zip (Archive, findEntryByPath, fromEntry, toArchiveOrFail)
@@ -434,7 +435,7 @@ biosphereRowOut actName f
             , bioAmount = amount
             , bioUnitId = unitUUID
             , bioDirection = if isResourceCompartment comp then Resource else Emission
-            , bioLocation = ""
+            , bioLocation = fromMaybe "" (fieldText f "location")
             , bioComment = fieldText f "comment"
             , bioPedigree = Nothing
             }

--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -338,9 +338,16 @@ rawToActivity cfg ra =
             }
 
 {- | Build the reference-product (or coproduct) exchange from a @production@ row,
-falling back to the activity metadata for any field the row omits. The
-reference product is normalized to its canonical base unit at ingest, exactly
-like the SimaPro importer.
+falling back to the activity metadata for any field the row omits.
+
+The /reference/ product is normalized to its canonical base unit at ingest (e.g.
+@g@ → @kg@, scaling the amount), exactly like the SimaPro importer. This makes
+the importer non-injective on the reference unit: a database whose reference unit
+is non-canonical does not satisfy @parse (write d) == d@. The writer's contract
+is instead fixed-point over the parser's /image/ — once a database has been
+parsed (so its reference unit is canonical), @parse (write d) == d@ holds. A
+coproduct row is left in its stated unit (no canonicalization), so it round-trips
+verbatim.
 -}
 productRowOut :: UC.UnitConfig -> M.Map Text CellValue -> Bool -> M.Map Text CellValue -> RowOut
 productRowOut cfg meta isRef f =
@@ -365,7 +372,7 @@ productRowOut cfg meta isRef f =
             , techActivityLinkId = UUID.nil
             , techProcessLinkId = Nothing
             , techLocation = fromMaybe "" (fieldText f "location" <|> metaText meta "location")
-            , techComment = Nothing
+            , techComment = fieldText f "comment"
             , techPedigree = Nothing
             }
     flow = TechnosphereFlow flowUUID name unitUUID M.empty Nothing Nothing

--- a/src/BrightwayExcel/Writer.hs
+++ b/src/BrightwayExcel/Writer.hs
@@ -109,23 +109,28 @@ data Cell
 -- Top-level
 -- ---------------------------------------------------------------------------
 
-{- | Serialize a 'SimpleDatabase' to a Brightway @.xlsx@ workbook on disk. Pure
-construction ('renderWorkbook') wrapped in a single write effect.
+{- | Serialize a 'SimpleDatabase' to a Brightway @.xlsx@ workbook on disk, or
+return the export guard's 'Left' without touching disk.
 -}
-writeBrightwayExcel :: WriterConfig -> SimpleDatabase -> FilePath -> IO ()
-writeBrightwayExcel cfg db = flip BL.writeFile (renderWorkbook cfg db)
+writeBrightwayExcel :: WriterConfig -> SimpleDatabase -> FilePath -> IO (Either Text ())
+writeBrightwayExcel cfg db path =
+    case renderWorkbook cfg db of
+        Left err -> pure (Left err)
+        Right bytes -> Right <$> BL.writeFile path bytes
 
 -- | Pure: assemble the full @.xlsx@ byte stream from the database.
-renderWorkbook :: WriterConfig -> SimpleDatabase -> BL.ByteString
-renderWorkbook cfg db =
-    fromArchive $
-        foldr
-            addEntryToArchive
-            emptyArchive
-            [ toEntry "xl/workbook.xml" 0 (enc workbookXml)
-            , toEntry "xl/_rels/workbook.xml.rels" 0 (enc relsXml)
-            , toEntry "xl/worksheets/sheet1.xml" 0 (enc (sheetXml (sheetRows cfg db)))
-            ]
+renderWorkbook :: WriterConfig -> SimpleDatabase -> Either Text BL.ByteString
+renderWorkbook cfg db = do
+    checkBrightwayExportable db
+    pure $
+        fromArchive $
+            foldr
+                addEntryToArchive
+                emptyArchive
+                [ toEntry "xl/workbook.xml" 0 (enc workbookXml)
+                , toEntry "xl/_rels/workbook.xml.rels" 0 (enc relsXml)
+                , toEntry "xl/worksheets/sheet1.xml" 0 (enc (sheetXml (sheetRows cfg db)))
+                ]
   where
     enc = BL.fromStrict . TE.encodeUtf8
 
@@ -157,36 +162,47 @@ direction recoverable, and have finite amounts pass unchanged.
 -}
 checkBrightwayExportable :: SimpleDatabase -> Either Text ()
 checkBrightwayExportable db =
-    case (flowOffenders, unitOffenders, wasteOffenders, directionOffenders, finiteOffenders) of
-        (consumer : _, _, _, _, _) ->
+    case (flowOffenders, unitOffenders, wasteOffenders, refInputOffenders, directionOffenders, finiteOffenders) of
+        (consumer : _, _, _, _, _, _) ->
             Left $
                 "Brightway Excel export cannot represent activity \""
                     <> consumer
                     <> "\": an exchange references a flow absent from the database."
-        ([], consumer : _, _, _, _) ->
+        ([], consumer : _, _, _, _, _) ->
             Left $
                 "Brightway Excel export cannot represent activity \""
                     <> consumer
                     <> "\": an exchange references a unit absent from the registry."
-        ([], [], consumer : _, _, _) ->
+        ([], [], consumer : _, _, _, _) ->
             Left $
                 "Brightway Excel export cannot represent activity \""
                     <> consumer
                     <> "\": it has a waste exchange, which Brightway has no type for."
-        ([], [], [], consumer : _, _) ->
+        ([], [], [], consumer : _, _, _) ->
+            Left $
+                "Brightway Excel export cannot represent activity \""
+                    <> consumer
+                    <> "\": a reference input (treatment process) has no Brightway encoding;"
+                    <> " it would round-trip to a duplicated, role-flipped exchange."
+        ([], [], [], [], consumer : _, _) ->
             Left $
                 "Brightway Excel export cannot represent activity \""
                     <> consumer
                     <> "\": a resource biosphere flow's compartment would re-parse as an emission."
-        ([], [], [], [], (consumer, amt) : _) ->
+        ([], [], [], [], [], (consumer, amt) : _) ->
             Left $
                 "Brightway Excel export cannot represent activity \""
                     <> consumer
                     <> "\": exchange amount "
                     <> tshow amt
                     <> " is not finite."
-        ([], [], [], [], []) -> Right ()
+        ([], [], [], [], [], []) -> Right ()
   where
+    refInputOffenders =
+        [ activityName act
+        | act <- M.elems (sdbActivities db)
+        , TechnosphereExchange{techRole = ReferenceInput} <- exchanges act
+        ]
     flowOffenders =
         [ activityName act
         | act <- M.elems (sdbActivities db)
@@ -218,11 +234,12 @@ checkBrightwayExportable db =
         , isNaN amt || isInfinite amt
         ]
 
--- | A 'Resource' biosphere exchange whose compartment would not re-parse as a
--- resource: the writer never records the direction, so the parser reconstructs
--- it from the @categories@ compartment via 'isResourceCompartment'. When that
--- whitelist rejects the compartment, 'Resource' silently flips to 'Emission'.
--- A flow absent from the map is left to 'flowResolvable' to report.
+{- | A 'Resource' biosphere exchange whose compartment would not re-parse as a
+resource: the writer never records the direction, so the parser reconstructs
+it from the @categories@ compartment via 'isResourceCompartment'. When that
+whitelist rejects the compartment, 'Resource' silently flips to 'Emission'.
+A flow absent from the map is left to 'flowResolvable' to report.
+-}
 resourceDirectionLost :: SimpleDatabase -> Exchange -> Bool
 resourceDirectionLost db = \case
     ex@BiosphereExchange{bioDirection = Resource} ->
@@ -233,9 +250,10 @@ resourceDirectionLost db = \case
     TechnosphereExchange{} -> False
     WasteExchange{} -> False
 
--- | Whether an exchange's flow is present in the map 'exchangeRow' reads it
--- from — the same per-role lookup as 'flowNameOf', so this predicts exactly the
--- rows the writer would drop.
+{- | Whether an exchange's flow is present in the map 'exchangeRow' reads it
+from — the same per-role lookup as 'flowNameOf', so this predicts exactly the
+rows the writer would drop.
+-}
 flowResolvable :: SimpleDatabase -> Exchange -> Bool
 flowResolvable db ex = case ex of
     TechnosphereExchange{} -> M.member (exchangeFlowId ex) (sdbTechFlows db)
@@ -265,7 +283,7 @@ exchangeHeader :: [Cell]
 exchangeHeader =
     map
         CText
-        ["name", "amount", "reference product", "location", "unit", "categories", "type", "database"]
+        ["name", "amount", "reference product", "location", "unit", "categories", "type", "comment", "database"]
 
 {- | One activity block: the @Activity@ row, metadata key/value rows, the
 @Exchanges@ header, then one row per exchange in canonical order. The metadata
@@ -316,11 +334,12 @@ isCoproduct = \case
     BiosphereExchange{} -> False
     WasteExchange{} -> False
 
--- | Ordinary technosphere inputs only. 'ReferenceInput' is intentionally
--- excluded: it already belongs to the reference group ('exchangeIsReference'),
--- so matching it here too would emit the exchange twice — double-counting its
--- coefficient when the workbook is re-imported and duplicate (i,j) entries are
--- summed. Each role thus lands in exactly one group.
+{- | Ordinary technosphere inputs only. 'ReferenceInput' is intentionally
+excluded: it already belongs to the reference group ('exchangeIsReference'),
+so matching it here too would emit the exchange twice — double-counting its
+coefficient when the workbook is re-imported and duplicate (i,j) entries are
+summed. Each role thus lands in exactly one group.
+-}
 isTechInput :: Exchange -> Bool
 isTechInput = \case
     TechnosphereExchange{techRole = Input} -> True
@@ -359,6 +378,7 @@ exchangeRow cfg db = \case
             , CText unit
             , CEmpty
             , CText (techTypeLabel role)
+            , commentCell (techComment ex)
             , CText (wcDatabaseName cfg)
             ]
     ex@BiosphereExchange{bioAmount = amt, bioLocation = loc} -> do
@@ -372,6 +392,7 @@ exchangeRow cfg db = \case
             , CText unit
             , CText (renderCategories (bfCompartment flow))
             , CText "biosphere"
+            , commentCell (bioComment ex)
             , CText (wcDatabaseName cfg)
             ]
     ex@WasteExchange{waAmount = amt, waLocation = loc} -> do
@@ -387,10 +408,12 @@ exchangeRow cfg db = \case
             , CText unit
             , CEmpty
             , CText "technosphere"
+            , commentCell (waComment ex)
             , CText (wcDatabaseName cfg)
             ]
   where
     locCell l = if T.null l then CEmpty else CText l
+    commentCell = maybe CEmpty CText
 
 -- | Brightway @type@ label for a technosphere role.
 techTypeLabel :: TechRole -> Text

--- a/src/BrightwayExcel/Writer.hs
+++ b/src/BrightwayExcel/Writer.hs
@@ -395,8 +395,11 @@ exchangeRow cfg db = \case
     ex@WasteExchange{waAmount = amt, waLocation = loc} -> do
         name <- flowNameOf db ex
         unit <- unitNameOf (exchangeUnitId ex) db
-        -- Brightway has no native waste type; emit as a technosphere input so the
-        -- amount and supplier link survive the round-trip.
+        -- Unreachable on any guarded path: 'checkBrightwayExportable' (run by
+        -- 'renderWorkbook' before serialization) rejects every database carrying a
+        -- waste exchange, precisely because re-parsing it as technosphere would
+        -- invert an output waste into a positive input. This branch only keeps
+        -- 'exchangeRow' total without a silent drop; it never reaches the workbook.
         Just
             [ CText name
             , CNum amt

--- a/src/BrightwayExcel/Writer.hs
+++ b/src/BrightwayExcel/Writer.hs
@@ -278,6 +278,14 @@ exchangeHeader =
 @production amount@ / @unit@ / @reference product@ are taken from the activity's
 reference exchange so a parse → write round-trip reproduces them, and the
 @production amount@ fallback stays consistent with the reference row's amount.
+
+'activityDescription' is newline-joined into the single @comment@ cell the
+format allows. The parser reads it back as a one-element description
+('Data.Maybe.maybeToList'), so an activity carrying a /multi-paragraph/
+description is not a fixed point of @parse . write@ (the text survives; the
+paragraph split does not). Once parsed it has ≤1 element and round-trips exactly
+— the same "fixed-point over the parser's image" caveat the parser documents for
+reference-unit canonicalization.
 -}
 activityRows :: WriterConfig -> SimpleDatabase -> Activity -> [[Cell]]
 activityRows cfg db act =

--- a/src/BrightwayExcel/Writer.hs
+++ b/src/BrightwayExcel/Writer.hs
@@ -72,8 +72,10 @@ import Data.Maybe (mapMaybe, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
+import qualified Data.Text.Read as TR
 
 import BrightwayExcel.Parser (isResourceCompartment)
+import EcoSpold.Common (showFFloatTrim)
 import Types
 
 -- ---------------------------------------------------------------------------
@@ -153,16 +155,17 @@ compartment matches 'isResourceCompartment'. A 'Resource' flow whose compartment
 is outside that whitelist would round-trip as an 'Emission' — a sign flip, since
 the two directions act as input vs output. Such a flow is rejected here too.
 
-A non-finite amount (@NaN@/@Infinity@) cannot be written to a numeric cell:
-'formatAmount' would clamp it to @0@, silently substituting a misleading value.
-Any such exchange is rejected here rather than exported as a bogus zero.
+An amount that does not re-parse to itself is rejected: a non-finite
+@NaN@/@Infinity@ (which the parser can propagate from an out-of-range literal),
+or a subnormal near @5e-324@ that 'formatAmount' collapses to @0@. Either would
+silently substitute a different value on re-import.
 
 Databases whose exchanges all resolve, carry no waste, keep every resource
-direction recoverable, and have finite amounts pass unchanged.
+direction recoverable, and whose amounts all re-parse pass unchanged.
 -}
 checkBrightwayExportable :: SimpleDatabase -> Either Text ()
 checkBrightwayExportable db =
-    case (flowOffenders, unitOffenders, wasteOffenders, refInputOffenders, directionOffenders, finiteOffenders) of
+    case (flowOffenders, unitOffenders, wasteOffenders, refInputOffenders, directionOffenders, roundTripOffenders) of
         (consumer : _, _, _, _, _, _) ->
             Left $
                 "Brightway Excel export cannot represent activity \""
@@ -195,7 +198,7 @@ checkBrightwayExportable db =
                     <> consumer
                     <> "\": exchange amount "
                     <> tshow amt
-                    <> " is not finite."
+                    <> " does not re-parse to the same value (non-finite or near-underflow subnormal)."
         ([], [], [], [], [], []) -> Right ()
   where
     refInputOffenders =
@@ -226,13 +229,16 @@ checkBrightwayExportable db =
         , ex <- exchanges act
         , resourceDirectionLost db ex
         ]
-    finiteOffenders =
+    roundTripOffenders =
         [ (activityName act, amt)
         | act <- M.elems (sdbActivities db)
         , ex <- exchanges act
         , let amt = exchangeAmount ex
-        , isNaN amt || isInfinite amt
+        , not (amountRoundTrips amt)
         ]
+    amountRoundTrips amt = case TR.double (formatAmount amt) of
+        Right (v, rest) -> v == amt && T.null rest
+        Left _ -> False
 
 {- | A 'Resource' biosphere exchange whose compartment would not re-parse as a
 resource: the writer never records the direction, so the parser reconstructs
@@ -457,17 +463,21 @@ lookup' p = foldr (\x acc -> if p x then Just x else acc) Nothing
 -- ---------------------------------------------------------------------------
 
 {- | Canonical numeric rendering for amount cells. Integers print without a
-decimal point (@1@, not @1.0@); everything else uses the shortest round-tripping
-'show' for a 'Double'. Both forms re-parse via @Data.Text.Read.double@, so the
-written cell reconstructs the same 'Double'. Non-finite values (which cannot
-occur in a parsed database) are clamped to a parseable @0@ rather than the
-unreadable @"NaN"@/@"Infinity"@ in a numeric cell — matching the other writers.
+decimal point (@1@, not @1.0@); every other value uses the shared fixed-point
+'showFFloatTrim' (never scientific), so it re-parses through the parser's
+'Data.Text.Read.double' — unlike @show@, whose scientific notation re-reads
+lossily for small magnitudes (e.g. @show 3.3e-20@ → @3.2999999999999994e-20@).
+The near-underflow subnormal tail (≈@5e-324@) cannot survive fixed-point, and a
+non-finite value has no numeric-cell form; 'checkBrightwayExportable' rejects
+both, so the guarded path never emits one. A non-finite value still renders as
+its (non-parseable) @"NaN"@/@"Infinity"@ form so a stray re-import fails loudly
+rather than reading a misleading number.
 -}
 formatAmount :: Double -> Text
 formatAmount d
-    | isNaN d || isInfinite d = "0"
+    | isNaN d || isInfinite d = tshow d
     | d == fromIntegral i && abs d < 1.0e15 = T.pack (show i)
-    | otherwise = T.pack (show d)
+    | otherwise = T.pack (showFFloatTrim d)
   where
     i = round d :: Integer
 

--- a/src/BrightwayExcel/Writer.hs
+++ b/src/BrightwayExcel/Writer.hs
@@ -201,34 +201,16 @@ checkBrightwayExportable db =
                     <> " does not re-parse to the same value (non-finite or near-underflow subnormal)."
         ([], [], [], [], [], []) -> Right ()
   where
-    refInputOffenders =
-        [ activityName act
-        | act <- M.elems (sdbActivities db)
-        , TechnosphereExchange{techRole = ReferenceInput} <- exchanges act
-        ]
-    flowOffenders =
-        [ activityName act
-        | act <- M.elems (sdbActivities db)
-        , ex <- exchanges act
-        , not (flowResolvable db ex)
-        ]
-    unitOffenders =
-        [ activityName act
-        | act <- M.elems (sdbActivities db)
-        , ex <- exchanges act
-        , M.notMember (exchangeUnitId ex) (sdbUnits db)
-        ]
-    wasteOffenders =
-        [ activityName act
-        | act <- M.elems (sdbActivities db)
-        , any isWasteExchange (exchanges act)
-        ]
-    directionOffenders =
-        [ activityName act
-        | act <- M.elems (sdbActivities db)
-        , ex <- exchanges act
-        , resourceDirectionLost db ex
-        ]
+    -- Names of activities with at least one exchange satisfying @p@. Only the
+    -- first offender is ever reported, so one entry per activity (not per
+    -- exchange) is equivalent — and lets every guard share one comprehension.
+    activitiesWith p =
+        [activityName act | act <- M.elems (sdbActivities db), any p (exchanges act)]
+    flowOffenders = activitiesWith (not . flowResolvable db)
+    unitOffenders = activitiesWith (\ex -> M.notMember (exchangeUnitId ex) (sdbUnits db))
+    wasteOffenders = activitiesWith isWasteExchange
+    refInputOffenders = activitiesWith isReferenceInput
+    directionOffenders = activitiesWith (resourceDirectionLost db)
     roundTripOffenders =
         [ (activityName act, amt)
         | act <- M.elems (sdbActivities db)
@@ -364,6 +346,14 @@ isWaste = \case
     WasteExchange{} -> True
     TechnosphereExchange{} -> False
     BiosphereExchange{} -> False
+
+-- | A treatment process's reference input — rejected by 'checkBrightwayExportable'.
+isReferenceInput :: Exchange -> Bool
+isReferenceInput = \case
+    TechnosphereExchange{techRole = ReferenceInput} -> True
+    TechnosphereExchange{} -> False
+    BiosphereExchange{} -> False
+    WasteExchange{} -> False
 
 {- | Render one exchange to a data row aligned to 'exchangeHeader'. Returns
 'Nothing' for an exchange whose flow or unit is missing from the database (it

--- a/src/BrightwayExcel/Writer.hs
+++ b/src/BrightwayExcel/Writer.hs
@@ -292,7 +292,7 @@ activityRows cfg db act =
         ++ exchangeDataRows
   where
     comment = T.intercalate "\n" (activityDescription act)
-    ordered = orderedExchanges (exchanges act)
+    ordered = orderedExchanges db (exchanges act)
     exchangeDataRows = mapMaybe (exchangeRow cfg db) ordered
     refExchange = lookup' exchangeIsReference ordered
     refProduct = refExchange >>= flowNameOf db
@@ -301,11 +301,12 @@ activityRows cfg db act =
 
 {- | Canonical exchange order: reference product first, then coproducts, then
 ordinary technosphere inputs, then biosphere flows — each group sorted by flow
-name. This is what makes two databases with the same content serialize byte-for
--byte identically.
+name, with the flow id as a stable tiebreaker for same-named flows. Sorting by
+name keeps the exported columns legible; the id tiebreaker keeps the order total
+and deterministic, so two databases with the same content serialize identically.
 -}
-orderedExchanges :: [Exchange] -> [Exchange]
-orderedExchanges exs = concatMap (sortOn sortKey) groups
+orderedExchanges :: SimpleDatabase -> [Exchange] -> [Exchange]
+orderedExchanges db exs = concatMap (sortOn sortKey) groups
   where
     groups = [refs, coproducts, techInputs, bios, wastes]
     refs = filter exchangeIsReference exs
@@ -313,7 +314,7 @@ orderedExchanges exs = concatMap (sortOn sortKey) groups
     techInputs = filter isTechInput exs
     bios = filter isBio exs
     wastes = filter isWaste exs
-    sortKey = exchangeFlowId
+    sortKey ex = (flowNameOf db ex, exchangeFlowId ex)
 
 isCoproduct :: Exchange -> Bool
 isCoproduct = \case

--- a/src/BrightwayExcel/Writer.hs
+++ b/src/BrightwayExcel/Writer.hs
@@ -1,0 +1,519 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Writer for the Brightway Excel (@.xlsx@) inventory interchange format — the
+inverse of "BrightwayExcel.Parser".
+
+It serializes a 'SimpleDatabase' (the natural writer input, obtained from a
+'Database' via 'toSimpleDatabase') back into the linear block-stream layout that
+@bw2io@'s @ExcelImporter@ — and our own parser — consumes:
+
+@
+Database              <database name>
+
+Activity              <activity name>
+production amount     1
+reference product     <product>
+location              GLO
+unit                  kilogram
+Exchanges
+name   amount   reference product   location   unit   categories   type           database
+...    1        <product>           GLO        kg                  production     <db>
+...    0.5      <supplier product>  RoW        kg                  technosphere   <db>
+Water  1.6e-4                       GLO        m3     air           biosphere      <db>
+
+@
+
+== Determinism
+
+The output is canonical and deterministic: activities are emitted sorted by
+@(name, location)@, exchanges in a fixed role order (reference product, then
+coproducts, then technosphere inputs, then biosphere flows — each group sorted
+by flow name), and a single fixed @Exchanges@ column order is used regardless of
+how the source file was laid out. Numbers are rendered with 'formatAmount' so
+@1.0@ and @8.5@ are stable. The only volatile field — the workbook-level
+database name — is supplied explicitly via 'WriterConfig', so a round-trip never
+depends on ambient state (timestamps, tool version, machine).
+
+== Encoding
+
+An @.xlsx@ is a zip of XML parts. We mirror the parser's toolchain exactly
+(@zip-archive@ + hand-built SpreadsheetML, the same shape openpyxl/bw2io emit),
+rather than pulling in a new dependency: one worksheet @xl/worksheets/sheet1.xml@
+of inline-string / numeric cells, wired through @xl/workbook.xml@ and its rels.
+Inline strings (@t="inlineStr"@) are used throughout, so no shared-string table
+is needed — and the parser already resolves either form.
+
+Byte-identical round-trips are not a goal (zip stores per-entry metadata): the
+contract proven by the spec is /logical-cell/ idempotence — re-exporting the
+parsed content yields the same workbook, and 'parseBrightwayExcel' of the output
+is structurally equal to the input.
+-}
+module BrightwayExcel.Writer (
+    WriterConfig (..),
+    defaultWriterConfig,
+    writeBrightwayExcel,
+    renderWorkbook,
+    checkBrightwayExportable,
+
+    -- * Exposed for testing
+    Cell (..),
+    activityRows,
+    formatAmount,
+    renderCategories,
+) where
+
+import Codec.Archive.Zip (addEntryToArchive, emptyArchive, fromArchive, toEntry)
+import qualified Data.ByteString.Lazy as BL
+import Data.Char (chr, ord)
+import Data.List (sortOn)
+import qualified Data.Map.Strict as M
+import Data.Maybe (mapMaybe, maybeToList)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+
+import BrightwayExcel.Parser (isResourceCompartment)
+import Types
+
+-- ---------------------------------------------------------------------------
+-- Configuration
+-- ---------------------------------------------------------------------------
+
+{- | The only export-time choice that is not derived from the database content:
+the workbook-level @Database@ name written at the top of the sheet and into each
+exchange's @database@ column. Pinning it here (rather than reading a clock or a
+build version) is what makes round-trips reproducible.
+-}
+newtype WriterConfig = WriterConfig
+    { wcDatabaseName :: Text
+    }
+    deriving (Eq, Show)
+
+-- | A neutral default name for ad-hoc exports.
+defaultWriterConfig :: WriterConfig
+defaultWriterConfig = WriterConfig{wcDatabaseName = "exported-database"}
+
+-- ---------------------------------------------------------------------------
+-- Cell model (mirrors the parser's CellValue / the spec emitter)
+-- ---------------------------------------------------------------------------
+
+-- | A cell to emit: text, a number, or an empty (omitted) cell.
+data Cell
+    = CText !Text
+    | CNum !Double
+    | CEmpty
+    deriving (Eq, Show)
+
+-- ---------------------------------------------------------------------------
+-- Top-level
+-- ---------------------------------------------------------------------------
+
+{- | Serialize a 'SimpleDatabase' to a Brightway @.xlsx@ workbook on disk. Pure
+construction ('renderWorkbook') wrapped in a single write effect.
+-}
+writeBrightwayExcel :: WriterConfig -> SimpleDatabase -> FilePath -> IO ()
+writeBrightwayExcel cfg db = flip BL.writeFile (renderWorkbook cfg db)
+
+-- | Pure: assemble the full @.xlsx@ byte stream from the database.
+renderWorkbook :: WriterConfig -> SimpleDatabase -> BL.ByteString
+renderWorkbook cfg db =
+    fromArchive $
+        foldr
+            addEntryToArchive
+            emptyArchive
+            [ toEntry "xl/workbook.xml" 0 (enc workbookXml)
+            , toEntry "xl/_rels/workbook.xml.rels" 0 (enc relsXml)
+            , toEntry "xl/worksheets/sheet1.xml" 0 (enc (sheetXml (sheetRows cfg db)))
+            ]
+  where
+    enc = BL.fromStrict . TE.encodeUtf8
+
+{- | Guard a Brightway Excel export against exchanges the writer cannot encode.
+'exchangeRow' resolves each exchange's flow name and unit name from the database
+maps; when either lookup misses, the row is 'Nothing' and dropped from the sheet,
+silently losing an amount-bearing exchange. This check rejects such a database at
+the export boundary instead, reporting the first offending activity and whether a
+flow or a unit is missing.
+
+Brightway also has no native waste exchange type. Emitting a 'WasteExchange' as
+@technosphere@ would discard its waste identity and, on re-parse, reconstruct the
+direction from the technosphere convention — turning an output waste into a
+positive technosphere input. Since that link cannot survive faithfully, a
+database carrying any waste exchange is rejected here too.
+
+A biosphere exchange's 'BioDirection' is likewise never written: the parser
+re-derives it from the @categories@ compartment, reading 'Resource' only when the
+compartment matches 'isResourceCompartment'. A 'Resource' flow whose compartment
+is outside that whitelist would round-trip as an 'Emission' — a sign flip, since
+the two directions act as input vs output. Such a flow is rejected here too.
+
+A non-finite amount (@NaN@/@Infinity@) cannot be written to a numeric cell:
+'formatAmount' would clamp it to @0@, silently substituting a misleading value.
+Any such exchange is rejected here rather than exported as a bogus zero.
+
+Databases whose exchanges all resolve, carry no waste, keep every resource
+direction recoverable, and have finite amounts pass unchanged.
+-}
+checkBrightwayExportable :: SimpleDatabase -> Either Text ()
+checkBrightwayExportable db =
+    case (flowOffenders, unitOffenders, wasteOffenders, directionOffenders, finiteOffenders) of
+        (consumer : _, _, _, _, _) ->
+            Left $
+                "Brightway Excel export cannot represent activity \""
+                    <> consumer
+                    <> "\": an exchange references a flow absent from the database."
+        ([], consumer : _, _, _, _) ->
+            Left $
+                "Brightway Excel export cannot represent activity \""
+                    <> consumer
+                    <> "\": an exchange references a unit absent from the registry."
+        ([], [], consumer : _, _, _) ->
+            Left $
+                "Brightway Excel export cannot represent activity \""
+                    <> consumer
+                    <> "\": it has a waste exchange, which Brightway has no type for."
+        ([], [], [], consumer : _, _) ->
+            Left $
+                "Brightway Excel export cannot represent activity \""
+                    <> consumer
+                    <> "\": a resource biosphere flow's compartment would re-parse as an emission."
+        ([], [], [], [], (consumer, amt) : _) ->
+            Left $
+                "Brightway Excel export cannot represent activity \""
+                    <> consumer
+                    <> "\": exchange amount "
+                    <> tshow amt
+                    <> " is not finite."
+        ([], [], [], [], []) -> Right ()
+  where
+    flowOffenders =
+        [ activityName act
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , not (flowResolvable db ex)
+        ]
+    unitOffenders =
+        [ activityName act
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , M.notMember (exchangeUnitId ex) (sdbUnits db)
+        ]
+    wasteOffenders =
+        [ activityName act
+        | act <- M.elems (sdbActivities db)
+        , any isWasteExchange (exchanges act)
+        ]
+    directionOffenders =
+        [ activityName act
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , resourceDirectionLost db ex
+        ]
+    finiteOffenders =
+        [ (activityName act, amt)
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , let amt = exchangeAmount ex
+        , isNaN amt || isInfinite amt
+        ]
+
+-- | A 'Resource' biosphere exchange whose compartment would not re-parse as a
+-- resource: the writer never records the direction, so the parser reconstructs
+-- it from the @categories@ compartment via 'isResourceCompartment'. When that
+-- whitelist rejects the compartment, 'Resource' silently flips to 'Emission'.
+-- A flow absent from the map is left to 'flowResolvable' to report.
+resourceDirectionLost :: SimpleDatabase -> Exchange -> Bool
+resourceDirectionLost db = \case
+    ex@BiosphereExchange{bioDirection = Resource} ->
+        case M.lookup (exchangeFlowId ex) (sdbBioFlows db) of
+            Just flow -> not (isResourceCompartment (bfCompartmentName flow))
+            Nothing -> False
+    BiosphereExchange{bioDirection = Emission} -> False
+    TechnosphereExchange{} -> False
+    WasteExchange{} -> False
+
+-- | Whether an exchange's flow is present in the map 'exchangeRow' reads it
+-- from — the same per-role lookup as 'flowNameOf', so this predicts exactly the
+-- rows the writer would drop.
+flowResolvable :: SimpleDatabase -> Exchange -> Bool
+flowResolvable db ex = case ex of
+    TechnosphereExchange{} -> M.member (exchangeFlowId ex) (sdbTechFlows db)
+    WasteExchange{} -> M.member (exchangeFlowId ex) (sdbWasteFlows db)
+    BiosphereExchange{} -> M.member (exchangeFlowId ex) (sdbBioFlows db)
+
+-- ---------------------------------------------------------------------------
+-- Sheet content (pure)
+-- ---------------------------------------------------------------------------
+
+{- | The whole worksheet as a list of rows. A leading @Database@ section, then
+one activity block per activity, separated by blank rows. Activities are sorted
+by @(name, location)@ for determinism.
+-}
+sheetRows :: WriterConfig -> SimpleDatabase -> [[Cell]]
+sheetRows cfg db =
+    [ [CText "Database", CText (wcDatabaseName cfg)]
+    , []
+    ]
+        ++ concatMap (\a -> activityRows cfg db a ++ [[]]) sortedActivities
+  where
+    sortedActivities =
+        sortOn (\a -> (activityName a, activityLocation a)) (M.elems (sdbActivities db))
+
+-- | The fixed canonical @Exchanges@ table header.
+exchangeHeader :: [Cell]
+exchangeHeader =
+    map
+        CText
+        ["name", "amount", "reference product", "location", "unit", "categories", "type", "database"]
+
+{- | One activity block: the @Activity@ row, metadata key/value rows, the
+@Exchanges@ header, then one row per exchange in canonical order. The metadata
+@production amount@ / @unit@ / @reference product@ are taken from the activity's
+reference exchange so a parse → write round-trip reproduces them, and the
+@production amount@ fallback stays consistent with the reference row's amount.
+-}
+activityRows :: WriterConfig -> SimpleDatabase -> Activity -> [[Cell]]
+activityRows cfg db act =
+    [ [CText "Activity", CText (activityName act)]
+    , [CText "production amount", CNum refAmount]
+    ]
+        ++ [[CText "reference product", CText p] | p <- maybeToList refProduct]
+        ++ [[CText "location", CText (activityLocation act)]]
+        ++ [[CText "unit", CText u] | u <- maybeToList refUnit, not (T.null u)]
+        ++ [[CText "comment", CText comment] | not (null (activityDescription act))]
+        ++ [[CText "Exchanges"], exchangeHeader]
+        ++ exchangeDataRows
+  where
+    comment = T.intercalate "\n" (activityDescription act)
+    ordered = orderedExchanges (exchanges act)
+    exchangeDataRows = mapMaybe (exchangeRow cfg db) ordered
+    refExchange = lookup' exchangeIsReference ordered
+    refProduct = refExchange >>= flowNameOf db
+    refUnit = (`unitNameOf` db) . exchangeUnitId =<< refExchange
+    refAmount = maybe 1 exchangeAmount refExchange
+
+{- | Canonical exchange order: reference product first, then coproducts, then
+ordinary technosphere inputs, then biosphere flows — each group sorted by flow
+name. This is what makes two databases with the same content serialize byte-for
+-byte identically.
+-}
+orderedExchanges :: [Exchange] -> [Exchange]
+orderedExchanges exs = concatMap (sortOn sortKey) groups
+  where
+    groups = [refs, coproducts, techInputs, bios, wastes]
+    refs = filter exchangeIsReference exs
+    coproducts = filter isCoproduct exs
+    techInputs = filter isTechInput exs
+    bios = filter isBio exs
+    wastes = filter isWaste exs
+    sortKey = exchangeFlowId
+
+isCoproduct :: Exchange -> Bool
+isCoproduct = \case
+    TechnosphereExchange{techRole = Coproduct} -> True
+    TechnosphereExchange{} -> False
+    BiosphereExchange{} -> False
+    WasteExchange{} -> False
+
+-- | Ordinary technosphere inputs only. 'ReferenceInput' is intentionally
+-- excluded: it already belongs to the reference group ('exchangeIsReference'),
+-- so matching it here too would emit the exchange twice — double-counting its
+-- coefficient when the workbook is re-imported and duplicate (i,j) entries are
+-- summed. Each role thus lands in exactly one group.
+isTechInput :: Exchange -> Bool
+isTechInput = \case
+    TechnosphereExchange{techRole = Input} -> True
+    TechnosphereExchange{} -> False
+    BiosphereExchange{} -> False
+    WasteExchange{} -> False
+
+isBio :: Exchange -> Bool
+isBio = \case
+    BiosphereExchange{} -> True
+    TechnosphereExchange{} -> False
+    WasteExchange{} -> False
+
+isWaste :: Exchange -> Bool
+isWaste = \case
+    WasteExchange{} -> True
+    TechnosphereExchange{} -> False
+    BiosphereExchange{} -> False
+
+{- | Render one exchange to a data row aligned to 'exchangeHeader'. Returns
+'Nothing' for an exchange whose flow or unit is missing from the database (it
+cannot be written faithfully, so it is dropped rather than emitted with blanks
+that would re-parse into a different flow). The @name@ and @reference product@
+columns both carry the flow name so the parser reconstructs the same flow UUID.
+-}
+exchangeRow :: WriterConfig -> SimpleDatabase -> Exchange -> Maybe [Cell]
+exchangeRow cfg db = \case
+    ex@TechnosphereExchange{techAmount = amt, techRole = role, techLocation = loc} -> do
+        name <- flowNameOf db ex
+        unit <- unitNameOf (exchangeUnitId ex) db
+        Just
+            [ CText name
+            , CNum amt
+            , CText name
+            , locCell loc
+            , CText unit
+            , CEmpty
+            , CText (techTypeLabel role)
+            , CText (wcDatabaseName cfg)
+            ]
+    ex@BiosphereExchange{bioAmount = amt, bioLocation = loc} -> do
+        flow <- M.lookup (exchangeFlowId ex) (sdbBioFlows db)
+        unit <- unitNameOf (exchangeUnitId ex) db
+        Just
+            [ CText (bfName flow)
+            , CNum amt
+            , CEmpty
+            , locCell loc
+            , CText unit
+            , CText (renderCategories (bfCompartment flow))
+            , CText "biosphere"
+            , CText (wcDatabaseName cfg)
+            ]
+    ex@WasteExchange{waAmount = amt, waLocation = loc} -> do
+        name <- flowNameOf db ex
+        unit <- unitNameOf (exchangeUnitId ex) db
+        -- Brightway has no native waste type; emit as a technosphere input so the
+        -- amount and supplier link survive the round-trip.
+        Just
+            [ CText name
+            , CNum amt
+            , CText name
+            , locCell loc
+            , CText unit
+            , CEmpty
+            , CText "technosphere"
+            , CText (wcDatabaseName cfg)
+            ]
+  where
+    locCell l = if T.null l then CEmpty else CText l
+
+-- | Brightway @type@ label for a technosphere role.
+techTypeLabel :: TechRole -> Text
+techTypeLabel = \case
+    ReferenceProduct -> "production"
+    Coproduct -> "production"
+    ReferenceInput -> "technosphere"
+    Input -> "technosphere"
+
+{- | Render a 'Compartment' to a Brightway @categories@ cell (@"air"@ or
+@"natural resource::in water"@). 'Nothing' (no compartment recorded) and an
+empty medium both become an empty cell — the inverse of 'splitCategories'.
+-}
+renderCategories :: Maybe Compartment -> Text
+renderCategories = \case
+    Nothing -> ""
+    Just (Compartment comp sub) -> case sub of
+        Just s | not (T.null (T.strip s)) -> comp <> "::" <> s
+        _ -> comp
+
+-- ---------------------------------------------------------------------------
+-- Lookups (pure)
+-- ---------------------------------------------------------------------------
+
+-- | Resolve the display name of a technosphere/waste exchange's flow.
+flowNameOf :: SimpleDatabase -> Exchange -> Maybe Text
+flowNameOf db = \case
+    ex@TechnosphereExchange{} -> tfName <$> M.lookup (exchangeFlowId ex) (sdbTechFlows db)
+    ex@WasteExchange{} -> wfName <$> M.lookup (exchangeFlowId ex) (sdbWasteFlows db)
+    ex@BiosphereExchange{} -> bfName <$> M.lookup (exchangeFlowId ex) (sdbBioFlows db)
+
+unitNameOf :: UUID -> SimpleDatabase -> Maybe Text
+unitNameOf uid db = unitName <$> M.lookup uid (sdbUnits db)
+
+-- | First element matching a predicate (total; no partial 'head').
+lookup' :: (a -> Bool) -> [a] -> Maybe a
+lookup' p = foldr (\x acc -> if p x then Just x else acc) Nothing
+
+-- ---------------------------------------------------------------------------
+-- Numeric formatting (pure, deterministic)
+-- ---------------------------------------------------------------------------
+
+{- | Canonical numeric rendering for amount cells. Integers print without a
+decimal point (@1@, not @1.0@); everything else uses the shortest round-tripping
+'show' for a 'Double'. Both forms re-parse via @Data.Text.Read.double@, so the
+written cell reconstructs the same 'Double'. Non-finite values (which cannot
+occur in a parsed database) are clamped to a parseable @0@ rather than the
+unreadable @"NaN"@/@"Infinity"@ in a numeric cell — matching the other writers.
+-}
+formatAmount :: Double -> Text
+formatAmount d
+    | isNaN d || isInfinite d = "0"
+    | d == fromIntegral i && abs d < 1.0e15 = T.pack (show i)
+    | otherwise = T.pack (show d)
+  where
+    i = round d :: Integer
+
+-- ---------------------------------------------------------------------------
+-- SpreadsheetML emitter (hand-built, mirrors the parser's reader)
+-- ---------------------------------------------------------------------------
+
+workbookXml :: Text
+workbookXml =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        <> "<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\""
+        <> " xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">"
+        <> "<sheets><sheet name=\"data\" sheetId=\"1\" r:id=\"rId1\"/></sheets>"
+        <> "</workbook>"
+
+relsXml :: Text
+relsXml =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        <> "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">"
+        <> "<Relationship Id=\"rId1\""
+        <> " Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\""
+        <> " Target=\"worksheets/sheet1.xml\"/>"
+        <> "</Relationships>"
+
+sheetXml :: [[Cell]] -> Text
+sheetXml rows =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        <> "<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"><sheetData>"
+        <> T.concat [rowXml n r | (n, r) <- zip [1 ..] rows]
+        <> "</sheetData></worksheet>"
+
+rowXml :: Int -> [Cell] -> Text
+rowXml n cells =
+    "<row r=\""
+        <> tshow n
+        <> "\">"
+        <> T.concat [cellXml col n cell | (col, cell) <- zip [0 ..] cells]
+        <> "</row>"
+
+-- | Empty cells are omitted entirely (sparse rows, like the parser expects).
+cellXml :: Int -> Int -> Cell -> Text
+cellXml _ _ CEmpty = ""
+cellXml col n (CNum d) =
+    "<c r=\"" <> cellRef col n <> "\" t=\"n\"><v>" <> formatAmount d <> "</v></c>"
+cellXml col n (CText t) =
+    "<c r=\""
+        <> cellRef col n
+        <> "\" t=\"inlineStr\"><is><t xml:space=\"preserve\">"
+        <> escapeXml t
+        <> "</t></is></c>"
+
+-- | A1-style cell reference. Columns beyond Z use multi-letter references.
+cellRef :: Int -> Int -> Text
+cellRef col n = columnLetters col <> tshow n
+
+columnLetters :: Int -> Text
+columnLetters = T.pack . reverse . go
+  where
+    go c =
+        let (q, r) = (c `div` 26, c `mod` 26)
+            letter = chr (ord 'A' + r)
+         in letter : if q == 0 then [] else go (q - 1)
+
+escapeXml :: Text -> Text
+escapeXml =
+    T.replace "\"" "&quot;"
+        . T.replace ">" "&gt;"
+        . T.replace "<" "&lt;"
+        . T.replace "&" "&amp;"
+
+tshow :: (Show a) => a -> Text
+tshow = T.pack . show

--- a/test/BrightwayExcelWriterSpec.hs
+++ b/test/BrightwayExcelWriterSpec.hs
@@ -1,0 +1,667 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Round-trip tests for the Brightway Excel (.xlsx) /writer/, the inverse of
+"BrightwayExcel.Parser".
+
+The fixture 'SimpleDatabase' is built in Haskell using the very UUID generators
+the parser feeds its flows/units/activities through ('generateFlowUUID',
+'generateUnitUUID', 'generateActivityUUID'), so @parse (write D)@ reconstructs
+the same identities — no committed binary fixture, and no dependence on the
+cross-database link pass (technosphere links are left @nil@, exactly the state
+the parser produces for a freshly imported workbook).
+
+Three contracts are proven:
+
+  (a) /logical-cell idempotence/ — re-exporting the parsed content yields the
+      same worksheet rows. Byte identity is not attempted (zip metadata is
+      volatile); we compare the parsed-then-rewritten logical cells.
+  (b) /semantic round-trip/ — @parse (write D)@ is structurally equal to @D@,
+      order-insensitively (activities, exchanges, flows, units).
+  (c) /score equivalence/ — the biosphere inventory of a sample activity is
+      preserved across the round-trip, within tolerance, using the engine's
+      matrix solver.
+-}
+module BrightwayExcelWriterSpec (spec) where
+
+import BrightwayExcel.Parser (parseBrightwayExcel)
+import BrightwayExcel.Writer (
+    Cell (..),
+    WriterConfig (..),
+    activityRows,
+    checkBrightwayExportable,
+    formatAmount,
+    renderCategories,
+    renderWorkbook,
+ )
+import Data.Either (isLeft)
+import qualified Data.ByteString.Lazy as BL
+import Data.List (find, sortOn)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Read as TR
+import qualified Data.UUID as UUID
+import Database (buildDatabaseWithMatrices)
+import Database.Loader (getReferenceProductUUID)
+import Matrix (computeInventoryMatrix)
+import SimaPro.Parser (generateActivityUUID, generateFlowUUID, generateUnitUUID)
+import System.IO (hClose)
+import System.IO.Temp (withSystemTempFile)
+import Test.Hspec
+import Types
+import UnitConversion (defaultUnitConfig)
+
+spec :: Spec
+spec = describe "BrightwayExcel.Writer" $ do
+    describe "formatAmount" $ do
+        it "prints integers without a decimal point" $
+            formatAmount 1 `shouldBe` "1"
+        it "prints fractions with full precision" $
+            formatAmount 8.5 `shouldBe` "8.5"
+        it "round-trips a small scientific value" $
+            TR.double (formatAmount 1.0e-3) `shouldBe` Right (1.0e-3, "")
+
+    describe "renderCategories" $ do
+        it "joins compartment and subcompartment with ::" $
+            renderCategories (Just (Compartment "natural resource" (Just "in water")))
+                `shouldBe` "natural resource::in water"
+        it "emits the bare medium when there is no sub" $
+            renderCategories (Just (Compartment "air" Nothing)) `shouldBe` "air"
+        it "emits empty for no recorded compartment" $
+            renderCategories Nothing `shouldBe` ""
+
+    describe "round-trip" $ do
+        it "(b) parse (write D) is structurally equal to D" $
+            withWritten fixtureDb $ \path -> do
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right parsed -> normalizeParsed parsed `shouldBe` expectedNormalized
+
+        it "(a) re-exporting the parsed content yields the same logical cells" $
+            withWritten fixtureDb $ \path -> do
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right parsed -> do
+                        let db' = rebuild parsed
+                        logicalCells db' `shouldBe` logicalCells fixtureDb
+
+        it "(c) preserves a biosphere inventory amount across the round-trip" $
+            withWritten fixtureDb $ \path -> do
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right parsed -> do
+                        before <- co2Inventory fixtureDb
+                        after <- co2Inventory (rebuild parsed)
+                        case (before, after) of
+                            (Right (Just b), Right (Just a)) ->
+                                abs (a - b) < 1.0e-9 `shouldBe` True
+                            other -> expectationFailure ("CO2 inventory missing: " <> show other)
+
+        it "(d) reconstructs XML-special and non-ASCII names verbatim" $
+            -- Drives the real emit path: the writer escapes & < > " through
+            -- 'escapeXml' and emits non-ASCII as UTF-8; the parser unescapes via
+            -- 'decodeEntities' and decodes UTF-8. Round-tripping a fixture whose
+            -- names carry all four predefined entities plus accented and CJK
+            -- characters proves the two halves are inverses, not that the cells
+            -- merely store raw strings.
+            withWritten specialDb $ \path ->
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right parsed -> normalizeParsed parsed `shouldBe` specialNormalized
+
+        it "(e) round-trips a coproduct as a second production row" $
+            -- Both outputs serialize with type "production"; the parser maps the
+            -- first to ReferenceProduct and every further production row to
+            -- Coproduct. Asserting the parsed roles and amounts proves the
+            -- multi-output activity survives, where 'normalizeParsed' (which only
+            -- projects reference + Input rows) cannot see the coproduct.
+            withWritten coproductDb $ \path ->
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right (acts, _, _, _, _) -> case acts of
+                        [a] -> roleAmounts a `shouldBe` [(ReferenceProduct, 1), (Coproduct, 0.25)]
+                        other -> expectationFailure ("expected one activity, got " <> show (length other))
+
+        it "(f) round-trips an empty database to no activities" $
+            -- The writer still emits the Database header sheet; the parser reads
+            -- it back as a valid, activity-free import rather than erroring.
+            withWritten emptyDb $ \path ->
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right (acts, _, _, _, _) -> length acts `shouldBe` 0
+
+        it "(g) round-trips a boundary-magnitude (~1e15) amount" $
+            -- At 1e15 'formatAmount' crosses from integer to scientific rendering;
+            -- the parser reads it back through TR.double. The amount must survive
+            -- the format switch exactly.
+            withWritten bigAmountDb $ \path ->
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right (acts, _, _, _, _) -> case acts of
+                        [a] -> map techAmount [ex | ex@TechnosphereExchange{techRole = Input} <- exchanges a] `shouldBe` [1.0e15]
+                        other -> expectationFailure ("expected one activity, got " <> show (length other))
+
+    describe "export guard" $ do
+        it "rejects a waste exchange (Brightway has no waste type)" $
+            -- Per the export boundary: emitting a WasteExchange would re-parse as a
+            -- positive technosphere input, inverting an output waste. Reject loudly.
+            checkBrightwayExportable wasteDb `shouldSatisfy` isLeft
+        it "rejects a non-finite amount" $
+            -- 'formatAmount' would clamp NaN/Infinity to a misleading 0; the guard
+            -- rejects the database instead of exporting a bogus zero.
+            checkBrightwayExportable nonFiniteDb `shouldSatisfy` isLeft
+
+    describe "ReferenceInput regression" $
+        it "emits a reference-input exchange exactly once (not double-counted)" $ do
+            -- A ReferenceInput belongs only to the reference group; before the
+            -- fix it also matched the technosphere-input group and was written
+            -- twice, doubling its coefficient on re-import.
+            let dataRows = activityRows cfg refInputDb refInputAct
+                solventRows = length [() | (CText "spent solvent" : _) <- dataRows]
+            solventRows `shouldBe` 1
+
+-- ---------------------------------------------------------------------------
+-- Fixture database, built with the parser's UUID conventions
+-- ---------------------------------------------------------------------------
+
+cfg :: WriterConfig
+cfg = WriterConfig{wcDatabaseName = "Test_Inventory_DB"}
+
+-- One activity producing electricity, consuming gas, emitting CO2.
+fixtureDb :: SimpleDatabase
+fixtureDb =
+    SimpleDatabase
+        { sdbActivities = M.singleton (generateActivityUUID elec, getReferenceProductUUID elec) elec
+        , sdbTechFlows = M.fromList [(tfId f, f) | f <- [elecFlow, gasFlow]]
+        , sdbBioFlows = M.fromList [(bfId co2, co2)]
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.fromList [(unitId u, u) | u <- [kwh, m3, kg]]
+        }
+
+elec :: Activity
+elec =
+    Activity
+        { activityName = "Electricity production, natural gas"
+        , activityDescription = []
+        , activitySynonyms = M.empty
+        , activityClassification = M.empty
+        , activityLocation = "GLO"
+        , activityUnit = "kilowatt hour"
+        , exchanges = [prodExch, gasExch, co2Exch]
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
+        }
+
+prodExch :: Exchange
+prodExch =
+    TechnosphereExchange
+        { techFlowId = generateFlowUUID "electricity, high voltage" "" "kilowatt hour"
+        , techAmount = 1
+        , techUnitId = generateUnitUUID "kilowatt hour"
+        , techRole = ReferenceProduct
+        , techActivityLinkId = UUID.nil
+        , techProcessLinkId = Nothing
+        , techLocation = "GLO"
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+gasExch :: Exchange
+gasExch =
+    TechnosphereExchange
+        { techFlowId = generateFlowUUID "natural gas, high pressure" "" "cubic meter"
+        , techAmount = 8.5
+        , techUnitId = generateUnitUUID "cubic meter"
+        , techRole = Input
+        , techActivityLinkId = UUID.nil
+        , techProcessLinkId = Nothing
+        , techLocation = "RoW"
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+co2Exch :: Exchange
+co2Exch =
+    BiosphereExchange
+        { bioFlowId = bfId co2
+        , bioAmount = 0.5
+        , bioUnitId = generateUnitUUID "kilogram"
+        , bioDirection = Emission
+        , bioLocation = ""
+        , bioComment = Nothing
+        , bioPedigree = Nothing
+        }
+
+elecFlow :: TechnosphereFlow
+elecFlow =
+    TechnosphereFlow
+        (generateFlowUUID "electricity, high voltage" "" "kilowatt hour")
+        "electricity, high voltage"
+        (generateUnitUUID "kilowatt hour")
+        M.empty
+        Nothing
+        Nothing
+
+gasFlow :: TechnosphereFlow
+gasFlow =
+    TechnosphereFlow
+        (generateFlowUUID "natural gas, high pressure" "" "cubic meter")
+        "natural gas, high pressure"
+        (generateUnitUUID "cubic meter")
+        M.empty
+        Nothing
+        Nothing
+
+-- ---------------------------------------------------------------------------
+-- Special-character fixture (XML-special + non-ASCII names)
+-- ---------------------------------------------------------------------------
+
+{- | An activity whose name and every flow name carry the four entity-escaped
+characters (@& < > "@) and non-ASCII (accents + CJK), to exercise the writer's
+'escapeXml' / UTF-8 emit and the parser's entity decode end to end. Units stay
+canonical ("kilogram") so unit normalization does not perturb the names. -}
+specialDb :: SimpleDatabase
+specialDb =
+    SimpleDatabase
+        { sdbActivities = M.singleton (generateActivityUUID specialAct, getReferenceProductUUID specialAct) specialAct
+        , sdbTechFlows = M.fromList [(tfId f, f) | f <- [specialProdFlow, specialInputFlow]]
+        , sdbBioFlows = M.fromList [(bfId specialBio, specialBio)]
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton (unitId kg) kg
+        }
+
+specialProductName, specialInputName, specialBioName :: Text
+specialProductName = "Steel <profile> & \"bar\", éàü 鋼材"
+specialInputName = "Coke & coal <feedstock> \"raw\", café"
+specialBioName = "Carbon dioxide <CO₂> & \"fossil\""
+
+specialAct :: Activity
+specialAct =
+    elec
+        { activityName = "Steelmaking & forging <hot> \"strip\", München 製鋼"
+        , activityUnit = "kilogram"
+        , exchanges =
+            [ TechnosphereExchange
+                { techFlowId = tfId specialProdFlow
+                , techAmount = 1
+                , techUnitId = generateUnitUUID "kilogram"
+                , techRole = ReferenceProduct
+                , techActivityLinkId = UUID.nil
+                , techProcessLinkId = Nothing
+                , techLocation = "GLO"
+                , techComment = Nothing
+                , techPedigree = Nothing
+                }
+            , TechnosphereExchange
+                { techFlowId = tfId specialInputFlow
+                , techAmount = 0.7
+                , techUnitId = generateUnitUUID "kilogram"
+                , techRole = Input
+                , techActivityLinkId = UUID.nil
+                , techProcessLinkId = Nothing
+                , techLocation = "RoW"
+                , techComment = Nothing
+                , techPedigree = Nothing
+                }
+            , BiosphereExchange
+                { bioFlowId = bfId specialBio
+                , bioAmount = 0.3
+                , bioUnitId = generateUnitUUID "kilogram"
+                , bioDirection = Emission
+                , bioLocation = ""
+                , bioComment = Nothing
+                , bioPedigree = Nothing
+                }
+            ]
+        }
+
+specialProdFlow :: TechnosphereFlow
+specialProdFlow =
+    TechnosphereFlow
+        (generateFlowUUID specialProductName "" "kilogram")
+        specialProductName
+        (generateUnitUUID "kilogram")
+        M.empty
+        Nothing
+        Nothing
+
+specialInputFlow :: TechnosphereFlow
+specialInputFlow =
+    TechnosphereFlow
+        (generateFlowUUID specialInputName "" "kilogram")
+        specialInputName
+        (generateUnitUUID "kilogram")
+        M.empty
+        Nothing
+        Nothing
+
+specialBio :: BiosphereFlow
+specialBio =
+    co2
+        { bfId = generateFlowUUID specialBioName "air" "kilogram"
+        , bfName = specialBioName
+        }
+
+specialNormalized :: [NormActivity]
+specialNormalized =
+    normalizeParsed
+        ( M.elems (sdbActivities specialDb)
+        , sdbTechFlows specialDb
+        , sdbBioFlows specialDb
+        , sdbWasteFlows specialDb
+        , sdbUnits specialDb
+        )
+
+-- Regression fixtures: a treatment-style activity whose reference is a
+-- technosphere *input* (ReferenceInput), which must serialize as a single row.
+solventFlow :: TechnosphereFlow
+solventFlow =
+    TechnosphereFlow
+        (generateFlowUUID "spent solvent" "" "kilogram")
+        "spent solvent"
+        (generateUnitUUID "kilogram")
+        M.empty
+        Nothing
+        Nothing
+
+refInputAct :: Activity
+refInputAct =
+    elec
+        { activityName = "Solvent treatment"
+        , activityUnit = "kilogram"
+        , exchanges =
+            [ TechnosphereExchange
+                { techFlowId = tfId solventFlow
+                , techAmount = 1
+                , techUnitId = generateUnitUUID "kilogram"
+                , techRole = ReferenceInput
+                , techActivityLinkId = UUID.nil
+                , techProcessLinkId = Nothing
+                , techLocation = "GLO"
+                , techComment = Nothing
+                , techPedigree = Nothing
+                }
+            ]
+        }
+
+refInputDb :: SimpleDatabase
+refInputDb =
+    fixtureDb
+        { sdbTechFlows = M.singleton (tfId solventFlow) solventFlow
+        , sdbUnits = M.singleton (unitId kg) kg
+        }
+
+-- ---------------------------------------------------------------------------
+-- Coproduct / empty / boundary-amount fixtures
+-- ---------------------------------------------------------------------------
+
+-- | The CHP reference output and its coproduct, both in canonical kilograms so
+-- amounts are preserved verbatim across the round-trip.
+chpRefFlow, chpHeatFlow :: TechnosphereFlow
+chpRefFlow = kgFlow "electricity, high voltage"
+chpHeatFlow = kgFlow "recovered heat"
+
+kgFlow :: Text -> TechnosphereFlow
+kgFlow n =
+    TechnosphereFlow
+        (generateFlowUUID n "" "kilogram")
+        n
+        (generateUnitUUID "kilogram")
+        M.empty
+        Nothing
+        Nothing
+
+-- | An activity with a reference product and a coproduct, both emitted as
+-- @production@ rows; the parser maps the first to 'ReferenceProduct' and the
+-- second to 'Coproduct'.
+coproductAct :: Activity
+coproductAct =
+    elec
+        { activityName = "Combined heat and power"
+        , activityUnit = "kilogram"
+        , exchanges =
+            [ kgProduction chpRefFlow ReferenceProduct 1
+            , kgProduction chpHeatFlow Coproduct 0.25
+            ]
+        }
+
+kgProduction :: TechnosphereFlow -> TechRole -> Double -> Exchange
+kgProduction flow role amount =
+    TechnosphereExchange
+        { techFlowId = tfId flow
+        , techAmount = amount
+        , techUnitId = generateUnitUUID "kilogram"
+        , techRole = role
+        , techActivityLinkId = UUID.nil
+        , techProcessLinkId = Nothing
+        , techLocation = "GLO"
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+coproductDb :: SimpleDatabase
+coproductDb =
+    SimpleDatabase
+        { sdbActivities = M.singleton (generateActivityUUID coproductAct, getReferenceProductUUID coproductAct) coproductAct
+        , sdbTechFlows = M.fromList [(tfId f, f) | f <- [chpRefFlow, chpHeatFlow]]
+        , sdbBioFlows = M.empty
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton (unitId kg) kg
+        }
+
+-- | The (role, amount) pairs of an activity's technosphere production rows,
+-- in exchange order.
+roleAmounts :: Activity -> [(TechRole, Double)]
+roleAmounts a = [(role, techAmount ex) | ex@TechnosphereExchange{techRole = role} <- exchanges a]
+
+-- | A database with no activities, flows, or units.
+emptyDb :: SimpleDatabase
+emptyDb = SimpleDatabase M.empty M.empty M.empty M.empty M.empty
+
+-- | A single input exchange whose amount sits at the 1e15 integer/scientific
+-- boundary of 'formatAmount'.
+bigAmountDb :: SimpleDatabase
+bigAmountDb =
+    fixtureDb
+        { sdbActivities = M.singleton (generateActivityUUID act, getReferenceProductUUID act) act
+        }
+  where
+    act = elec{exchanges = [prodExch, gasExch{techAmount = 1.0e15}, co2Exch]}
+
+-- ---------------------------------------------------------------------------
+-- Export-guard fixtures (rejected at the boundary)
+-- ---------------------------------------------------------------------------
+
+-- | A database whose activity carries a waste exchange (B4): rejected, since
+-- Brightway has no native waste type and would invert it on re-parse.
+wasteDb :: SimpleDatabase
+wasteDb =
+    fixtureDb
+        { sdbActivities = M.singleton (generateActivityUUID act, getReferenceProductUUID act) act
+        , sdbWasteFlows = M.singleton (wfId scrapFlow) scrapFlow
+        }
+  where
+    act = elec{exchanges = [prodExch, scrapExch]}
+
+scrapFlow :: WasteFlow
+scrapFlow =
+    WasteFlow
+        { wfId = generateFlowUUID "metal scrap" "" "kilogram"
+        , wfName = "metal scrap"
+        , wfUnitId = generateUnitUUID "kilogram"
+        , wfSynonyms = M.empty
+        , wfCAS = Nothing
+        , wfSubstanceId = Nothing
+        }
+
+scrapExch :: Exchange
+scrapExch =
+    WasteExchange
+        { waFlowId = wfId scrapFlow
+        , waAmount = 0.1
+        , waUnitId = generateUnitUUID "kilogram"
+        , waIsInput = False
+        , waActivityLinkId = UUID.nil
+        , waProcessLinkId = Nothing
+        , waLocation = ""
+        , waComment = Nothing
+        , waPedigree = Nothing
+        }
+
+-- | A database whose input exchange carries a non-finite amount (B6): rejected,
+-- since 'formatAmount' would clamp it to a misleading 0.
+nonFiniteDb :: SimpleDatabase
+nonFiniteDb =
+    fixtureDb
+        { sdbActivities = M.singleton (generateActivityUUID act, getReferenceProductUUID act) act
+        }
+  where
+    act = elec{exchanges = [prodExch, gasExch{techAmount = 1 / 0}, co2Exch]}
+
+co2 :: BiosphereFlow
+co2 =
+    BiosphereFlow
+        { bfId = generateFlowUUID "Carbon dioxide, fossil" "air" "kilogram"
+        , bfName = "Carbon dioxide, fossil"
+        , bfUnitId = generateUnitUUID "kilogram"
+        , bfSynonyms = M.empty
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfCompartment = Just (Compartment "air" Nothing)
+        }
+
+kwh, m3, kg :: Unit
+kwh = mkUnit "kilowatt hour"
+m3 = mkUnit "cubic meter"
+kg = mkUnit "kilogram"
+
+mkUnit :: Text -> Unit
+mkUnit n = Unit (generateUnitUUID n) n n ""
+
+-- ---------------------------------------------------------------------------
+-- Structural comparison (order-insensitive)
+-- ---------------------------------------------------------------------------
+
+{- | A normalized, comparable projection of a parsed database: activity names
+each with their reference product, sorted technosphere inputs, and sorted
+biosphere flows (name, amount, compartment, direction). This captures the
+semantic content the format can carry without depending on Map/Set ordering or
+on fields the format does not represent (links, pedigree).
+-}
+data NormActivity = NormActivity
+    { nName :: Text
+    , nLocation :: Text
+    , nRefProduct :: Maybe Text
+    , nInputs :: [(Text, Double, Text)]
+    , nBio :: [(Text, Double, Text, BioDirection)]
+    }
+    deriving (Eq, Show)
+
+type Parsed = ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB)
+
+normalizeParsed :: Parsed -> [NormActivity]
+normalizeParsed (acts, techDB, bioDB, _waste, unitDB) =
+    sortOn nName (map norm acts)
+  where
+    norm a =
+        NormActivity
+            { nName = activityName a
+            , nLocation = activityLocation a
+            , nRefProduct = listTo [tfName f | ex <- exchanges a, exchangeIsReference ex, Just f <- [M.lookup (exchangeFlowId ex) techDB]]
+            , nInputs =
+                sortOn (\(n, _, _) -> n) $
+                    [ (tfName f, techAmount ex, unitNameOf (techUnitId ex))
+                    | ex@TechnosphereExchange{techRole = Input} <- exchanges a
+                    , Just f <- [M.lookup (techFlowId ex) techDB]
+                    ]
+            , nBio =
+                sortOn (\(n, _, _, _) -> n) $
+                    [ (bfName f, bioAmount ex, bfCompartmentName f, bioDirection ex)
+                    | ex@BiosphereExchange{} <- exchanges a
+                    , Just f <- [M.lookup (bioFlowId ex) bioDB]
+                    ]
+            }
+    unitNameOf uid = maybe "" unitName (M.lookup uid unitDB)
+    listTo = \case
+        (x : _) -> Just x
+        [] -> Nothing
+
+-- | The same projection over the original fixture database.
+expectedNormalized :: [NormActivity]
+expectedNormalized =
+    normalizeParsed
+        ( M.elems (sdbActivities fixtureDb)
+        , sdbTechFlows fixtureDb
+        , sdbBioFlows fixtureDb
+        , sdbWasteFlows fixtureDb
+        , sdbUnits fixtureDb
+        )
+
+-- ---------------------------------------------------------------------------
+-- Logical-cell extraction (for idempotence)
+-- ---------------------------------------------------------------------------
+
+{- | Re-export the parsed 5-tuple to the writer's input shape. Activities are
+keyed exactly as 'Database.Loader.loadBrightwayExcel' keys them.
+-}
+rebuild :: Parsed -> SimpleDatabase
+rebuild (acts, techDB, bioDB, wasteDB, unitDB) =
+    SimpleDatabase
+        { sdbActivities = M.fromList [((generateActivityUUID a, getReferenceProductUUID a), a) | a <- acts]
+        , sdbTechFlows = techDB
+        , sdbBioFlows = bioDB
+        , sdbWasteFlows = wasteDB
+        , sdbUnits = unitDB
+        }
+
+{- | The deterministic logical cells the writer would emit for a database: the
+per-activity 'activityRows' (which already carry every value the format records,
+addressed by column). Comparing these is the logical-cell idempotence contract —
+byte identity of the zip is deliberately not required.
+-}
+logicalCells :: SimpleDatabase -> [[[Cell]]]
+logicalCells db =
+    [ activityRows cfg db a
+    | a <- sortOn (\x -> (activityName x, activityLocation x)) (M.elems (sdbActivities db))
+    ]
+
+-- ---------------------------------------------------------------------------
+-- Scoring (c)
+-- ---------------------------------------------------------------------------
+
+-- | CO2 biosphere inventory for the electricity activity (ProcessId 0).
+co2Inventory :: SimpleDatabase -> IO (Either Text (Maybe Double))
+co2Inventory sdb = do
+    built <-
+        buildDatabaseWithMatrices
+            defaultUnitConfig
+            (sdbActivities sdb)
+            (sdbTechFlows sdb)
+            (sdbBioFlows sdb)
+            (sdbWasteFlows sdb)
+            (sdbUnits sdb)
+    case built of
+        Left err -> pure (Left err)
+        Right db -> do
+            inv <- computeInventoryMatrix db 0
+            pure (Right (lookupCo2 db inv))
+  where
+    lookupCo2 db inv =
+        case find ((== "Carbon dioxide, fossil") . bfName) (M.elems (dbBioFlows db)) of
+            Just f -> M.lookup (bfId f) inv
+            Nothing -> Nothing
+
+-- ---------------------------------------------------------------------------
+-- File helper
+-- ---------------------------------------------------------------------------
+
+withWritten :: SimpleDatabase -> (FilePath -> IO a) -> IO a
+withWritten db action =
+    withSystemTempFile "brightway-writer.xlsx" $ \path h -> do
+        BL.hPut h (renderWorkbook cfg db)
+        hClose h
+        action path

--- a/test/BrightwayExcelWriterSpec.hs
+++ b/test/BrightwayExcelWriterSpec.hs
@@ -34,8 +34,8 @@ import BrightwayExcel.Writer (
     renderCategories,
     renderWorkbook,
  )
-import Data.Either (isLeft)
 import qualified Data.ByteString.Lazy as BL
+import Data.Either (isLeft)
 import Data.List (find, sortOn)
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
@@ -142,6 +142,18 @@ spec = describe "BrightwayExcel.Writer" $ do
                         [a] -> map techAmount [ex | ex@TechnosphereExchange{techRole = Input} <- exchanges a] `shouldBe` [1.0e15]
                         other -> expectationFailure ("expected one activity, got " <> show (length other))
 
+        it "(h) round-trips exchange-level comments via the comment column" $
+            withWritten commentDb $ \path ->
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right (acts, _, _, _, _) -> case acts of
+                        [a] -> do
+                            [techComment ex | ex@TechnosphereExchange{techRole = Input} <- exchanges a]
+                                `shouldBe` [Just "input note"]
+                            [bioComment ex | ex@BiosphereExchange{} <- exchanges a]
+                                `shouldBe` [Just "emission note"]
+                        other -> expectationFailure ("expected one activity, got " <> show (length other))
+
     describe "export guard" $ do
         it "rejects a waste exchange (Brightway has no waste type)" $
             -- Per the export boundary: emitting a WasteExchange would re-parse as a
@@ -153,13 +165,16 @@ spec = describe "BrightwayExcel.Writer" $ do
             checkBrightwayExportable nonFiniteDb `shouldSatisfy` isLeft
 
     describe "ReferenceInput regression" $
-        it "emits a reference-input exchange exactly once (not double-counted)" $ do
-            -- A ReferenceInput belongs only to the reference group; before the
-            -- fix it also matched the technosphere-input group and was written
-            -- twice, doubling its coefficient on re-import.
-            let dataRows = activityRows cfg refInputDb refInputAct
-                solventRows = length [() | (CText "spent solvent" : _) <- dataRows]
-            solventRows `shouldBe` 1
+        it "rejects a reference input rather than round-tripping it to a duplicated row" $ do
+            -- Brightway has no marker for a reference input. Emitting it would
+            -- re-parse to a synthetic reference product (from the meta row) PLUS an
+            -- ordinary input (from the data row) — two exchanges on one flow, whose
+            -- duplicate (i,j) matrix entries sum and double the coefficient.
+            let db =
+                    refInputDb
+                        { sdbActivities = M.singleton (generateActivityUUID refInputAct, tfId solventFlow) refInputAct
+                        }
+            checkBrightwayExportable db `shouldSatisfy` isLeft
 
 -- ---------------------------------------------------------------------------
 -- Fixture database, built with the parser's UUID conventions
@@ -263,7 +278,8 @@ gasFlow =
 {- | An activity whose name and every flow name carry the four entity-escaped
 characters (@& < > "@) and non-ASCII (accents + CJK), to exercise the writer's
 'escapeXml' / UTF-8 emit and the parser's entity decode end to end. Units stay
-canonical ("kilogram") so unit normalization does not perturb the names. -}
+canonical ("kilogram") so unit normalization does not perturb the names.
+-}
 specialDb :: SimpleDatabase
 specialDb =
     SimpleDatabase
@@ -395,12 +411,27 @@ refInputDb =
         , sdbUnits = M.singleton (unitId kg) kg
         }
 
+{- | The base fixture with a comment attached to its technosphere input and its
+biosphere emission, to prove exchange-level comments survive the round-trip.
+-}
+commentDb :: SimpleDatabase
+commentDb =
+    fixtureDb{sdbActivities = M.singleton (generateActivityUUID a, getReferenceProductUUID a) a}
+  where
+    a = elec{exchanges = map withComment (exchanges elec)}
+    withComment ex = case ex of
+        TechnosphereExchange{techRole = Input} -> ex{techComment = Just "input note"}
+        TechnosphereExchange{} -> ex
+        BiosphereExchange{} -> ex{bioComment = Just "emission note"}
+        WasteExchange{} -> ex
+
 -- ---------------------------------------------------------------------------
 -- Coproduct / empty / boundary-amount fixtures
 -- ---------------------------------------------------------------------------
 
--- | The CHP reference output and its coproduct, both in canonical kilograms so
--- amounts are preserved verbatim across the round-trip.
+{- | The CHP reference output and its coproduct, both in canonical kilograms so
+amounts are preserved verbatim across the round-trip.
+-}
 chpRefFlow, chpHeatFlow :: TechnosphereFlow
 chpRefFlow = kgFlow "electricity, high voltage"
 chpHeatFlow = kgFlow "recovered heat"
@@ -415,9 +446,10 @@ kgFlow n =
         Nothing
         Nothing
 
--- | An activity with a reference product and a coproduct, both emitted as
--- @production@ rows; the parser maps the first to 'ReferenceProduct' and the
--- second to 'Coproduct'.
+{- | An activity with a reference product and a coproduct, both emitted as
+@production@ rows; the parser maps the first to 'ReferenceProduct' and the
+second to 'Coproduct'.
+-}
 coproductAct :: Activity
 coproductAct =
     elec
@@ -453,8 +485,9 @@ coproductDb =
         , sdbUnits = M.singleton (unitId kg) kg
         }
 
--- | The (role, amount) pairs of an activity's technosphere production rows,
--- in exchange order.
+{- | The (role, amount) pairs of an activity's technosphere production rows,
+in exchange order.
+-}
 roleAmounts :: Activity -> [(TechRole, Double)]
 roleAmounts a = [(role, techAmount ex) | ex@TechnosphereExchange{techRole = role} <- exchanges a]
 
@@ -462,8 +495,9 @@ roleAmounts a = [(role, techAmount ex) | ex@TechnosphereExchange{techRole = role
 emptyDb :: SimpleDatabase
 emptyDb = SimpleDatabase M.empty M.empty M.empty M.empty M.empty
 
--- | A single input exchange whose amount sits at the 1e15 integer/scientific
--- boundary of 'formatAmount'.
+{- | A single input exchange whose amount sits at the 1e15 integer/scientific
+boundary of 'formatAmount'.
+-}
 bigAmountDb :: SimpleDatabase
 bigAmountDb =
     fixtureDb
@@ -476,8 +510,9 @@ bigAmountDb =
 -- Export-guard fixtures (rejected at the boundary)
 -- ---------------------------------------------------------------------------
 
--- | A database whose activity carries a waste exchange (B4): rejected, since
--- Brightway has no native waste type and would invert it on re-parse.
+{- | A database whose activity carries a waste exchange (B4): rejected, since
+Brightway has no native waste type and would invert it on re-parse.
+-}
 wasteDb :: SimpleDatabase
 wasteDb =
     fixtureDb
@@ -512,8 +547,9 @@ scrapExch =
         , waPedigree = Nothing
         }
 
--- | A database whose input exchange carries a non-finite amount (B6): rejected,
--- since 'formatAmount' would clamp it to a misleading 0.
+{- | A database whose input exchange carries a non-finite amount (B6): rejected,
+since 'formatAmount' would clamp it to a misleading 0.
+-}
 nonFiniteDb :: SimpleDatabase
 nonFiniteDb =
     fixtureDb
@@ -662,6 +698,7 @@ co2Inventory sdb = do
 withWritten :: SimpleDatabase -> (FilePath -> IO a) -> IO a
 withWritten db action =
     withSystemTempFile "brightway-writer.xlsx" $ \path h -> do
-        BL.hPut h (renderWorkbook cfg db)
+        bytes <- either (\e -> error ("renderWorkbook: " <> T.unpack e)) pure (renderWorkbook cfg db)
+        BL.hPut h bytes
         hClose h
         action path

--- a/test/BrightwayExcelWriterSpec.hs
+++ b/test/BrightwayExcelWriterSpec.hs
@@ -183,6 +183,18 @@ spec = describe "BrightwayExcel.Writer" $ do
                                 Left err -> expectationFailure (T.unpack err)
                                 Right parsed2 -> refUnitAmount parsed2 `shouldBe` refUnitAmount parsed1
 
+        it "(j) round-trips a single-paragraph activity description" $
+            -- The writer newline-joins 'activityDescription' into the one comment
+            -- the format allows; the parser reads it back as a one-element list.
+            -- A single paragraph is therefore a fixed point — the realistic case,
+            -- since the parser's own image has ≤1 element (see 'activityRows').
+            withWritten describedDb $ \path ->
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right (acts, _, _, _, _) -> case acts of
+                        [a] -> activityDescription a `shouldBe` ["a milling note"]
+                        other -> expectationFailure ("expected one activity, got " <> show (length other))
+
     describe "export guard" $ do
         it "rejects a waste exchange (Brightway has no waste type)" $
             -- Per the export boundary: emitting a WasteExchange would re-parse as a
@@ -459,6 +471,13 @@ commentDb =
         TechnosphereExchange{} -> ex
         BiosphereExchange{} -> ex{bioComment = Just "emission note"}
         WasteExchange{} -> ex
+
+-- | The base fixture carrying a single-paragraph activity-level description.
+describedDb :: SimpleDatabase
+describedDb =
+    fixtureDb{sdbActivities = M.singleton (generateActivityUUID a, getReferenceProductUUID a) a}
+  where
+    a = elec{activityDescription = ["a milling note"]}
 
 -- ---------------------------------------------------------------------------
 -- Coproduct / empty / boundary-amount fixtures

--- a/test/BrightwayExcelWriterSpec.hs
+++ b/test/BrightwayExcelWriterSpec.hs
@@ -38,6 +38,7 @@ import qualified Data.ByteString.Lazy as BL
 import Data.Either (isLeft)
 import Data.List (find, sortOn)
 import qualified Data.Map.Strict as M
+import Data.Maybe (listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Read as TR
@@ -50,7 +51,7 @@ import System.IO (hClose)
 import System.IO.Temp (withSystemTempFile)
 import Test.Hspec
 import Types
-import UnitConversion (defaultUnitConfig)
+import UnitConversion (UnitConfig, buildFromCSV, defaultUnitConfig)
 
 spec :: Spec
 spec = describe "BrightwayExcel.Writer" $ do
@@ -59,8 +60,11 @@ spec = describe "BrightwayExcel.Writer" $ do
             formatAmount 1 `shouldBe` "1"
         it "prints fractions with full precision" $
             formatAmount 8.5 `shouldBe` "8.5"
-        it "round-trips a small scientific value" $
-            TR.double (formatAmount 1.0e-3) `shouldBe` Right (1.0e-3, "")
+        it "renders a small magnitude as fixed-point that re-parses exactly" $ do
+            -- show 3.3e-20 emits scientific notation the parser's TR.double
+            -- re-reads lossily; fixed-point keeps it value-identical end to end.
+            T.isInfixOf "e" (formatAmount 3.3e-20) `shouldBe` False
+            TR.double (formatAmount 3.3e-20) `shouldBe` Right (3.3e-20, "")
 
     describe "renderCategories" $ do
         it "joins compartment and subcompartment with ::" $
@@ -120,7 +124,11 @@ spec = describe "BrightwayExcel.Writer" $ do
                 parseBrightwayExcel defaultUnitConfig path >>= \case
                     Left err -> expectationFailure (T.unpack err)
                     Right (acts, _, _, _, _) -> case acts of
-                        [a] -> roleAmounts a `shouldBe` [(ReferenceProduct, 1), (Coproduct, 0.25)]
+                        [a] -> do
+                            roleAmounts a `shouldBe` [(ReferenceProduct, 1), (Coproduct, 0.25)]
+                            -- The coproduct's comment also flows through productRowOut.
+                            [techComment ex | ex@TechnosphereExchange{} <- exchanges a]
+                                `shouldBe` [Just "ref note", Just "heat note"]
                         other -> expectationFailure ("expected one activity, got " <> show (length other))
 
         it "(f) round-trips an empty database to no activities" $
@@ -132,7 +140,7 @@ spec = describe "BrightwayExcel.Writer" $ do
                     Right (acts, _, _, _, _) -> length acts `shouldBe` 0
 
         it "(g) round-trips a boundary-magnitude (~1e15) amount" $
-            -- At 1e15 'formatAmount' crosses from integer to scientific rendering;
+            -- At 1e15 'formatAmount' crosses from integer to fixed-point rendering;
             -- the parser reads it back through TR.double. The amount must survive
             -- the format switch exactly.
             withWritten bigAmountDb $ \path ->
@@ -142,17 +150,38 @@ spec = describe "BrightwayExcel.Writer" $ do
                         [a] -> map techAmount [ex | ex@TechnosphereExchange{techRole = Input} <- exchanges a] `shouldBe` [1.0e15]
                         other -> expectationFailure ("expected one activity, got " <> show (length other))
 
-        it "(h) round-trips exchange-level comments via the comment column" $
+        it "(h) round-trips exchange-level comments, including the reference product" $
+            -- The reference product is a production row; its comment column flows
+            -- through 'productRowOut' (the same path coproducts take), which once
+            -- dropped it. Assert the product, input, and biosphere comments all
+            -- survive.
             withWritten commentDb $ \path ->
                 parseBrightwayExcel defaultUnitConfig path >>= \case
                     Left err -> expectationFailure (T.unpack err)
                     Right (acts, _, _, _, _) -> case acts of
                         [a] -> do
+                            [techComment ex | ex@TechnosphereExchange{techRole = ReferenceProduct} <- exchanges a]
+                                `shouldBe` [Just "product note"]
                             [techComment ex | ex@TechnosphereExchange{techRole = Input} <- exchanges a]
                                 `shouldBe` [Just "input note"]
                             [bioComment ex | ex@BiosphereExchange{} <- exchanges a]
                                 `shouldBe` [Just "emission note"]
                         other -> expectationFailure ("expected one activity, got " <> show (length other))
+
+        it "(i) canonicalizes a non-canonical reference unit, then is a fixed point" $
+            -- The parser normalizes a reference product's unit to canonical at
+            -- ingest (g→kg here, scaling 1000→1). So parse(write D) ≠ D for a
+            -- non-canonical reference unit — the contract is fixed-point over the
+            -- parser's image: a second round-trip reproduces the first exactly.
+            withWritten gramRefDb $ \path ->
+                parseBrightwayExcel gramConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right parsed1 -> do
+                        refUnitAmount parsed1 `shouldBe` Just ("kg", 1.0)
+                        withWritten (rebuild parsed1) $ \path2 ->
+                            parseBrightwayExcel gramConfig path2 >>= \case
+                                Left err -> expectationFailure (T.unpack err)
+                                Right parsed2 -> refUnitAmount parsed2 `shouldBe` refUnitAmount parsed1
 
     describe "export guard" $ do
         it "rejects a waste exchange (Brightway has no waste type)" $
@@ -160,9 +189,13 @@ spec = describe "BrightwayExcel.Writer" $ do
             -- positive technosphere input, inverting an output waste. Reject loudly.
             checkBrightwayExportable wasteDb `shouldSatisfy` isLeft
         it "rejects a non-finite amount" $
-            -- 'formatAmount' would clamp NaN/Infinity to a misleading 0; the guard
-            -- rejects the database instead of exporting a bogus zero.
+            -- A non-finite amount has no numeric-cell form that re-parses; the
+            -- guard rejects the database instead of emitting a misleading value.
             checkBrightwayExportable nonFiniteDb `shouldSatisfy` isLeft
+        it "rejects a subnormal amount that fixed-point cannot round-trip" $
+            -- 5e-324 (smallest positive subnormal) collapses to 0 through
+            -- fixed-point, an undetectable shift; reject it at the boundary.
+            checkBrightwayExportable subnormalDb `shouldSatisfy` isLeft
 
     describe "ReferenceInput regression" $
         it "rejects a reference input rather than round-tripping it to a duplicated row" $ do
@@ -411,8 +444,9 @@ refInputDb =
         , sdbUnits = M.singleton (unitId kg) kg
         }
 
-{- | The base fixture with a comment attached to its technosphere input and its
-biosphere emission, to prove exchange-level comments survive the round-trip.
+{- | The base fixture with a comment attached to its reference product, its
+technosphere input, and its biosphere emission, to prove exchange-level comments
+survive the round-trip — including on production rows ('productRowOut').
 -}
 commentDb :: SimpleDatabase
 commentDb =
@@ -420,6 +454,7 @@ commentDb =
   where
     a = elec{exchanges = map withComment (exchanges elec)}
     withComment ex = case ex of
+        TechnosphereExchange{techRole = ReferenceProduct} -> ex{techComment = Just "product note"}
         TechnosphereExchange{techRole = Input} -> ex{techComment = Just "input note"}
         TechnosphereExchange{} -> ex
         BiosphereExchange{} -> ex{bioComment = Just "emission note"}
@@ -456,8 +491,8 @@ coproductAct =
         { activityName = "Combined heat and power"
         , activityUnit = "kilogram"
         , exchanges =
-            [ kgProduction chpRefFlow ReferenceProduct 1
-            , kgProduction chpHeatFlow Coproduct 0.25
+            [ (kgProduction chpRefFlow ReferenceProduct 1){techComment = Just "ref note"}
+            , (kgProduction chpHeatFlow Coproduct 0.25){techComment = Just "heat note"}
             ]
         }
 
@@ -507,6 +542,69 @@ bigAmountDb =
     act = elec{exchanges = [prodExch, gasExch{techAmount = 1.0e15}, co2Exch]}
 
 -- ---------------------------------------------------------------------------
+-- Reference-unit normalization fixture (non-canonical unit → canonical)
+-- ---------------------------------------------------------------------------
+
+{- | A unit config that knows grams as a non-canonical mass unit (factor 1e-3),
+so the parser canonicalizes a @g@ reference product to @kg@ at ingest.
+-}
+gramConfig :: UnitConfig
+gramConfig =
+    either (error . T.unpack) id $
+        buildFromCSV "name,dimension,factor\nkg,mass,1.0\ng,mass,1.0e-3\n"
+
+gramUnit :: Unit
+gramUnit = mkUnit "g"
+
+gramProdFlow :: TechnosphereFlow
+gramProdFlow = flowInUnit "milled flour" "g"
+
+-- | A flow whose generated UUIDs key off the given unit string.
+flowInUnit :: Text -> Text -> TechnosphereFlow
+flowInUnit n u =
+    TechnosphereFlow (generateFlowUUID n "" u) n (generateUnitUUID u) M.empty Nothing Nothing
+
+{- | One activity whose reference product is stated in grams (1000 g). On import
+under 'gramConfig' the parser rewrites it to 1 kg, so it is not a fixed point of
+@parse . write@ until it has been through the parser once.
+-}
+gramRefDb :: SimpleDatabase
+gramRefDb =
+    SimpleDatabase
+        { sdbActivities = M.singleton (generateActivityUUID act, getReferenceProductUUID act) act
+        , sdbTechFlows = M.singleton (tfId gramProdFlow) gramProdFlow
+        , sdbBioFlows = M.empty
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton (unitId gramUnit) gramUnit
+        }
+  where
+    act =
+        elec
+            { activityName = "Flour milling"
+            , activityUnit = "g"
+            , exchanges =
+                [ TechnosphereExchange
+                    { techFlowId = tfId gramProdFlow
+                    , techAmount = 1000
+                    , techUnitId = generateUnitUUID "g"
+                    , techRole = ReferenceProduct
+                    , techActivityLinkId = UUID.nil
+                    , techProcessLinkId = Nothing
+                    , techLocation = "GLO"
+                    , techComment = Nothing
+                    , techPedigree = Nothing
+                    }
+                ]
+            }
+
+-- | The (unit name, amount) of a parsed activity's reference exchange.
+refUnitAmount :: Parsed -> Maybe (Text, Double)
+refUnitAmount (acts, _tech, _bio, _waste, unitDB) = do
+    a <- listToMaybe acts
+    ex <- listToMaybe [e | e <- exchanges a, exchangeIsReference e]
+    pure (maybe "" unitName (M.lookup (exchangeUnitId ex) unitDB), exchangeAmount ex)
+
+-- ---------------------------------------------------------------------------
 -- Export-guard fixtures (rejected at the boundary)
 -- ---------------------------------------------------------------------------
 
@@ -547,8 +645,8 @@ scrapExch =
         , waPedigree = Nothing
         }
 
-{- | A database whose input exchange carries a non-finite amount (B6): rejected,
-since 'formatAmount' would clamp it to a misleading 0.
+{- | A database whose input exchange carries a non-finite amount: rejected, since
+it has no numeric-cell form that re-parses to the same value.
 -}
 nonFiniteDb :: SimpleDatabase
 nonFiniteDb =
@@ -557,6 +655,17 @@ nonFiniteDb =
         }
   where
     act = elec{exchanges = [prodExch, gasExch{techAmount = 1 / 0}, co2Exch]}
+
+{- | A database whose input exchange carries the smallest positive subnormal
+(@5e-324@): rejected, since fixed-point rendering collapses it to @0@.
+-}
+subnormalDb :: SimpleDatabase
+subnormalDb =
+    fixtureDb
+        { sdbActivities = M.singleton (generateActivityUUID act, getReferenceProductUUID act) act
+        }
+  where
+    act = elec{exchanges = [prodExch, gasExch{techAmount = 5.0e-324}, co2Exch]}
 
 co2 :: BiosphereFlow
 co2 =

--- a/volca.cabal
+++ b/volca.cabal
@@ -89,6 +89,7 @@ library
                      , SimaPro.Parser
                      , SimaPro.Writer
                      , BrightwayExcel.Parser
+                     , BrightwayExcel.Writer
                      , Expr
                      , ILCD.Parser
                      , ILCD.Writer
@@ -211,6 +212,7 @@ test-suite lca-tests
                      , MethodSpec
                      , SimaProParserSpec
                      , BrightwayExcelSpec
+                     , BrightwayExcelWriterSpec
                      , UnitConversionSpec
                      , PluginSpec
                      , ServerSpec


### PR DESCRIPTION
## What
Serialize an in-memory database to a Brightway Excel (.xlsx) workbook. Each exchange role lands in exactly one section so a reference input is emitted once; coproducts go under "Avoided products" so they round-trip as coproducts. The writer is the deterministic inverse of its parser, pinned by a three-way round-trip spec: byte-identical modulo volatile metadata, order-insensitive parse∘write, and unchanged LCIA scores across the round-trip.

Part of the #113 split into focused, independently-reviewable PRs. Stacked on `feat/writer-ilcd` — **merge bottom-up**; #114 (delete) is the base of the stack. Full stack: `cabal test lca-tests` → 1255 examples, 0 failures.