### PR TITLE
feat(export): serialize a loaded database to any of the five formats

### DIFF
--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -411,6 +411,23 @@ Returns the ``DeleteSelectionResponse`` dict
 (``{"success", "message", "deleted"}``); raises VoLCAError on
 ``success=false``.
 
+##### `Client.export_database(fmt: str, db_name: str | None = None) -> bytes`
+
+Export a loaded database, returning the serialized bytes.
+
+``fmt`` is one of ``simapro|ecospold1|ecospold2|ilcd|brightway`` —
+validated client-side; an unknown value raises VoLCAError before any
+request. Single-file formats carry their bytes directly; EcoSpold 2 /
+ILCD multi-file trees come back zipped.
+
+The engine returns the payload base64-encoded in the ``data`` field;
+this method base64-decodes it and returns the raw bytes. Raises
+VoLCAError on ``success=false`` or a missing ``data`` field.
+
+##### `Client.export_to_file(fmt: str, out_path: str, db_name: str | None = None) -> None`
+
+Export a database (see :meth:`export_database`) and write it to a file.
+
 ##### `Client.get_activity(process_id: str) -> ActivityDetail`
 
 Fetch an activity's full detail.

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -39,6 +39,7 @@ variants in the Servant API.
 
 from __future__ import annotations
 
+import base64
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -117,6 +118,16 @@ def _candidate_wire_names(py_name: str) -> list[str]:
         if cand not in seen:
             seen.append(cand)
     return seen
+
+
+_EXPORT_FORMATS = frozenset(
+    {"simapro", "ecospold1", "ecospold2", "ilcd", "brightway"}
+)
+"""Target keywords accepted by ``POST /api/v1/db/{dbName}/export``.
+
+Mirrors the engine's ``parseExportFormat`` (case-folded). Validated
+client-side so a typo fails before the round-trip with the same message
+shape the engine would have returned."""
 
 
 _FORMATTED_SCALARS = (str, int, float)
@@ -726,6 +737,47 @@ class Client:
         """Read a mapping CSV file and call :meth:`relink` with its text."""
         csv_text = Path(mapping_path).read_text(encoding="utf-8")
         return self.relink(dep_db, csv_text, db_name=db_name)
+
+    def export_database(self, fmt: str, db_name: str | None = None) -> bytes:
+        """Export a loaded database, returning the serialized bytes.
+
+        ``fmt`` is one of ``simapro|ecospold1|ecospold2|ilcd|brightway`` —
+        validated client-side; an unknown value raises VoLCAError before any
+        request. Single-file formats carry their bytes directly; EcoSpold 2 /
+        ILCD multi-file trees come back zipped.
+
+        The engine returns the payload base64-encoded in the ``data`` field;
+        this method base64-decodes it and returns the raw bytes. Raises
+        VoLCAError on ``success=false`` or a missing ``data`` field.
+        """
+        fmt_norm = fmt.strip().lower()
+        if fmt_norm not in _EXPORT_FORMATS:
+            raise VoLCAError(
+                f"unknown export format: {fmt!r} "
+                f"(expected {'|'.join(sorted(_EXPORT_FORMATS))})"
+            )
+        target = self._db(db_name)
+        payload = self._require_success(
+            self._json(
+                self._session.post(
+                    f"{self.base_url}/api/v1/db/{target}/export",
+                    json={"format": fmt_norm},
+                )
+            ),
+            "export_database",
+        )
+        data = payload.get("data")
+        if data is None:
+            raise VoLCAError(
+                "export_database succeeded but the response carried no data field."
+            )
+        return base64.b64decode(data)
+
+    def export_to_file(
+        self, fmt: str, out_path: str, db_name: str | None = None
+    ) -> None:
+        """Export a database (see :meth:`export_database`) and write it to a file."""
+        Path(out_path).write_bytes(self.export_database(fmt, db_name=db_name))
 
     def add_dependency(self, dep_name: str, db_name: str | None = None) -> dict:
         """Declare ``dep_name`` as a dependency of the target database.

--- a/pyvolca/tests/test_db_write.py
+++ b/pyvolca/tests/test_db_write.py
@@ -10,6 +10,8 @@ engine: they mock ``Client._session`` and assert on the wire shape
 
 from __future__ import annotations
 
+import base64
+
 import pytest
 
 from volca.client import Client, VoLCAError
@@ -181,3 +183,73 @@ class TestDependencies:
         client.remove_dependency("dep", db_name="other")
         url = session.post.call_args[0][0]
         assert url == "http://test.local/api/v1/db/other/remove-dependency/dep"
+
+
+# ---------------------------------------------------------------------------
+# export
+# ---------------------------------------------------------------------------
+
+
+class TestExport:
+    def test_base64_decode_returns_raw_bytes(self, mocked_client):
+        client, session = mocked_client
+        raw = b"PK\x03\x04 zipped db bytes"
+        _ok(session, {"success": True, "message": "ok",
+                      "data": base64.b64encode(raw).decode()})
+        out = client.export_database("ecospold2")
+        assert out == raw
+        url = session.post.call_args[0][0]
+        assert url == "http://test.local/api/v1/db/testdb/export"
+        assert session.post.call_args[1]["json"] == {"format": "ecospold2"}
+
+    def test_format_normalized_before_send(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": True, "message": "ok",
+                      "data": base64.b64encode(b"x").decode()})
+        client.export_database("  SimaPro  ")
+        assert session.post.call_args[1]["json"] == {"format": "simapro"}
+
+    def test_unknown_format_raises_before_request(self, mocked_client):
+        client, session = mocked_client
+        with pytest.raises(VoLCAError, match="unknown export format"):
+            client.export_database("parquet")
+        session.post.assert_not_called()
+
+    def test_in_band_failure_raises(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": False, "message": "not loaded", "data": None})
+        with pytest.raises(VoLCAError, match="not loaded"):
+            client.export_database("simapro")
+
+    def test_missing_data_raises(self, mocked_client):
+        client, session = mocked_client
+        _ok(session, {"success": True, "message": "ok", "data": None})
+        with pytest.raises(VoLCAError, match="no data field"):
+            client.export_database("simapro")
+
+    def test_to_file_writes_decoded_bytes(self, mocked_client, tmp_path):
+        client, session = mocked_client
+        raw = b"hello bytes"
+        _ok(session, {"success": True, "message": "ok",
+                      "data": base64.b64encode(raw).decode()})
+        out = tmp_path / "export.csv"
+        client.export_to_file("simapro", str(out))
+        assert out.read_bytes() == raw
+
+
+# ---------------------------------------------------------------------------
+# default-db guard
+# ---------------------------------------------------------------------------
+
+
+class TestNoDefaultDb:
+    def _client(self):
+        return Client(base_url="http://test.local", db="")
+
+    def test_copy_without_db_raises(self):
+        with pytest.raises(VoLCAError, match="No database specified"):
+            self._client().copy_database("clone")
+
+    def test_export_without_db_raises(self):
+        with pytest.raises(VoLCAError, match="No database specified"):
+            self._client().export_database("simapro")

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -62,7 +62,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as T
 import Data.Word (Word64)
-import Servant (Header, Headers, addHeader, err400, err404, err500, errBody, throwError)
+import Servant (Header, Headers, ServerError, addHeader, err400, err404, err500, errBody, throwError)
 import qualified System.Directory
 import System.FilePath ((</>))
 
@@ -278,26 +278,21 @@ deleteActivitiesHandler dbName req = do
 
 {- | Export a loaded database, returning the serialized bytes base64-encoded.
 EcoSpold 2 / ILCD multi-file trees are zipped; single-file formats carry their
-bytes directly. Mirrors the upload endpoint's base64 convention.
+bytes directly. Mirrors the upload endpoint's base64 convention. Failures surface
+as HTTP errors — 400 for an unknown format or data the target format cannot
+represent, 404 for a database that is not loaded — never a 200 with a failure flag.
 -}
 exportDatabaseHandler :: Text -> ExportRequest -> AppM ExportResponse
 exportDatabaseHandler dbName req = do
     dbManager <- asks aeDbManager
-    case parseExportFormat (exrFormat req) of
-        Left err -> return (ExportResponse False err Nothing)
-        Right fmt -> do
-            mLoaded <- liftIO (getDatabase dbManager dbName)
-            case mLoaded of
-                Nothing -> return (ExportResponse False ("Database not loaded: " <> dbName) Nothing)
-                Just ld ->
-                    case serializeDatabase fmt (ldDatabase ld) of
-                        Left err -> return (ExportResponse False err Nothing)
-                        Right bytes ->
-                            return $
-                                ExportResponse
-                                    True
-                                    ("Exported " <> dbName)
-                                    (Just (T.decodeUtf8 (B64.encode (BSL.toStrict bytes))))
+    fmt <- either (httpErr err400) pure (parseExportFormat (exrFormat req))
+    mLoaded <- liftIO (getDatabase dbManager dbName)
+    ld <- maybe (httpErr err404 ("Database not loaded: " <> dbName)) pure mLoaded
+    bytes <- either (httpErr err400) pure (serializeDatabase fmt (ldDatabase ld))
+    pure (ExportResponse (T.decodeUtf8 (B64.encode (BSL.toStrict bytes))))
+  where
+    httpErr :: ServerError -> Text -> AppM a
+    httpErr status msg = throwError status{errBody = BSL.fromStrict (T.encodeUtf8 msg)}
 
 {- | Enforce the hosting upload-size policy on a decoded payload.
 Local/CLI mode (no hosting config) is unlimited. A configured limit of 0

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -19,6 +19,7 @@ module API.DatabaseHandlers (
     copyDatabaseHandler,
     deleteDatabaseHandler,
     deleteActivitiesHandler,
+    exportDatabaseHandler,
     uploadDatabaseHandler,
     uploadMethodHandler,
     deleteMethodHandler,
@@ -79,6 +80,8 @@ import API.Types (
     DeleteClassFilter (..),
     DeleteSelectionRequest (..),
     DeleteSelectionResponse (..),
+    ExportRequest (..),
+    ExportResponse (..),
     LoadDatabaseResponse (..),
     RefDataListResponse (..),
     RefDataStatusAPI (..),
@@ -98,6 +101,7 @@ import qualified Data.Aeson.KeyMap as KM
 import Data.Maybe (fromMaybe)
 import qualified Data.Vector as V
 import Database.Edit (copyDatabase, deleteActivitiesInDB)
+import Database.Export (serializeDatabase)
 import Database.Manager (
     DatabaseLoadStatus (..),
     DatabaseManager (..),
@@ -114,6 +118,7 @@ import Database.Manager (
     addMethodCollection,
     addUnitDefs,
     finalizeDatabase,
+    getDatabase,
     getDatabaseSetupInfo,
     getFlowSynonymGroups,
     listCompartmentMappings,
@@ -146,6 +151,7 @@ import Database.Upload (
     findMethodDirectory,
     handleUpload,
  )
+import qualified Database.Upload as Upload
 import qualified Database.UploadedDatabase as UploadedDB
 import Types (Database (..), GeographyPolicy (..), unresolvedCount)
 
@@ -269,6 +275,39 @@ deleteActivitiesHandler dbName req = do
                     True
                     ("Deleted " <> T.pack (show deleted) <> " activities from " <> dbName)
                     deleted
+
+-- | Parse the export-format keyword into a 'DatabaseFormat'.
+parseExportFormat :: Text -> Either Text Upload.DatabaseFormat
+parseExportFormat raw = case T.toLower (T.strip raw) of
+    "simapro" -> Right Upload.SimaProCSV
+    "ecospold1" -> Right Upload.EcoSpold1
+    "ecospold2" -> Right Upload.EcoSpold2
+    "ilcd" -> Right Upload.ILCDProcess
+    "brightway" -> Right Upload.BrightwayExcel
+    other -> Left ("unknown export format: " <> other <> " (expected simapro|ecospold1|ecospold2|ilcd|brightway)")
+
+{- | Export a loaded database, returning the serialized bytes base64-encoded.
+EcoSpold 2 / ILCD multi-file trees are zipped; single-file formats carry their
+bytes directly. Mirrors the upload endpoint's base64 convention.
+-}
+exportDatabaseHandler :: Text -> ExportRequest -> AppM ExportResponse
+exportDatabaseHandler dbName req = do
+    dbManager <- asks aeDbManager
+    case parseExportFormat (exrFormat req) of
+        Left err -> return (ExportResponse False err Nothing)
+        Right fmt -> do
+            mLoaded <- liftIO (getDatabase dbManager dbName)
+            case mLoaded of
+                Nothing -> return (ExportResponse False ("Database not loaded: " <> dbName) Nothing)
+                Just ld ->
+                    case serializeDatabase fmt (ldDatabase ld) of
+                        Left err -> return (ExportResponse False err Nothing)
+                        Right bytes ->
+                            return $
+                                ExportResponse
+                                    True
+                                    ("Exported " <> dbName)
+                                    (Just (T.decodeUtf8 (B64.encode (BSL.toStrict bytes))))
 
 {- | Enforce the hosting upload-size policy on a decoded payload.
 Local/CLI mode (no hosting config) is unlimited. A configured limit of 0

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -101,7 +101,7 @@ import qualified Data.Aeson.KeyMap as KM
 import Data.Maybe (fromMaybe)
 import qualified Data.Vector as V
 import Database.Edit (copyDatabase, deleteActivitiesInDB)
-import Database.Export (serializeDatabase)
+import Database.Export (parseExportFormat, serializeDatabase)
 import Database.Manager (
     DatabaseLoadStatus (..),
     DatabaseManager (..),
@@ -275,16 +275,6 @@ deleteActivitiesHandler dbName req = do
                     True
                     ("Deleted " <> T.pack (show deleted) <> " activities from " <> dbName)
                     deleted
-
--- | Parse the export-format keyword into a 'DatabaseFormat'.
-parseExportFormat :: Text -> Either Text Upload.DatabaseFormat
-parseExportFormat raw = case T.toLower (T.strip raw) of
-    "simapro" -> Right Upload.SimaProCSV
-    "ecospold1" -> Right Upload.EcoSpold1
-    "ecospold2" -> Right Upload.EcoSpold2
-    "ilcd" -> Right Upload.ILCDProcess
-    "brightway" -> Right Upload.BrightwayExcel
-    other -> Left ("unknown export format: " <> other <> " (expected simapro|ecospold1|ecospold2|ilcd|brightway)")
 
 {- | Export a loaded database, returning the serialized bytes base64-encoded.
 EcoSpold 2 / ILCD multi-file trees are zipped; single-file formats carry their

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -151,7 +151,6 @@ import Database.Upload (
     findMethodDirectory,
     handleUpload,
  )
-import qualified Database.Upload as Upload
 import qualified Database.UploadedDatabase as UploadedDB
 import Types (Database (..), GeographyPolicy (..), unresolvedCount)
 

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -10,7 +10,7 @@ module API.Routes where
 import API.DatabaseHandlers (simpleAction)
 import qualified API.DatabaseHandlers as DBHandlers
 import qualified API.OpenApi
-import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadRequest (..), UploadResponse (..), apiFlowOfKind)
+import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExportRequest (..), ExportResponse (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadRequest (..), UploadResponse (..), apiFlowOfKind)
 import App.Env (AppEnv (..), AppM, runApp)
 import qualified Config
 import Control.Concurrent.Async (mapConcurrently)
@@ -126,6 +126,8 @@ type LCAAPI =
                 :<|> "db" :> Capture "dbName" Text :> Delete '[JSON] ActivateResponse
                 -- Delete the whole filtered set of activities (selection in JSON body)
                 :<|> "db" :> Capture "dbName" Text :> "delete" :> ReqBody '[JSON] DeleteSelectionRequest :> Post '[JSON] DeleteSelectionResponse
+                -- Export a loaded database to a serialized (base64) file in the requested format
+                :<|> "db" :> Capture "dbName" Text :> "export" :> ReqBody '[JSON] ExportRequest :> Post '[JSON] ExportResponse
                 -- Upload endpoint (base64-encoded ZIP in JSON body)
                 :<|> "db" :> "upload" :> ReqBody '[JSON] UploadRequest :> Post '[JSON] UploadResponse
                 -- Database setup endpoints (for cross-DB linking configuration)
@@ -1959,6 +1961,7 @@ lcaServer env = hoistServer lcaAPI (runApp env) handlers
             :<|> DBHandlers.copyDatabaseHandler
             :<|> DBHandlers.deleteDatabaseHandler
             :<|> DBHandlers.deleteActivitiesHandler
+            :<|> DBHandlers.exportDatabaseHandler
             :<|> DBHandlers.uploadDatabaseHandler
             :<|> DBHandlers.getDatabaseSetupHandler
             :<|> DBHandlers.addDependencyHandler

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -805,14 +805,14 @@ newtype ExportRequest = ExportRequest
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped ExportRequest)
 
-{- | Response for database export. The serialized database is base64-encoded
-(single-file formats carry their bytes directly; EcoSpold 2 / ILCD are zipped),
-mirroring the upload endpoint's base64 convention.
+{- | Response for a successful database export: the serialized database,
+base64-encoded (single-file formats carry their bytes directly; EcoSpold 2 /
+ILCD are zipped), mirroring the upload endpoint's base64 convention. Failures are
+HTTP errors (400 bad format / unexportable data, 404 not loaded), never a
+success flag in a 200 body — so the type cannot represent "success with no data".
 -}
-data ExportResponse = ExportResponse
-    { exrespSuccess :: Bool
-    , exrespMessage :: Text
-    , exrespData :: Maybe Text -- Base64-encoded serialized database (if successful)
+newtype ExportResponse = ExportResponse
+    { exrespData :: Text -- Base64-encoded serialized database
     }
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped ExportResponse)

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -796,6 +796,27 @@ data DeleteSelectionResponse = DeleteSelectionResponse
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped DeleteSelectionResponse)
 
+{- | Request for database export. @exrFormat@ is the target-format keyword
+(@simapro|ecospold1|ecospold2|ilcd|brightway@), matching the CLI.
+-}
+newtype ExportRequest = ExportRequest
+    { exrFormat :: Text
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped ExportRequest)
+
+{- | Response for database export. The serialized database is base64-encoded
+(single-file formats carry their bytes directly; EcoSpold 2 / ILCD are zipped),
+mirroring the upload endpoint's base64 convention.
+-}
+data ExportResponse = ExportResponse
+    { exrespSuccess :: Bool
+    , exrespMessage :: Text
+    , exrespData :: Maybe Text -- Base64-encoded serialized database (if successful)
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped ExportResponse)
+
 -- | Response for database upload
 data UploadResponse = UploadResponse
     { uprSuccess :: Bool

--- a/src/CLI/Client.hs
+++ b/src/CLI/Client.hs
@@ -11,7 +11,7 @@ module CLI.Client (
 import CLI.Types
 import Config (Config (..), ServerConfig (..))
 import Control.Exception (IOException, try)
-import Data.Aeson (Value (..), decode, encode, object, (.:), (.:?), (.=))
+import Data.Aeson (Value (..), decode, encode, object, (.:), (.=))
 import Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KM
@@ -284,20 +284,19 @@ executeRemoteExport :: Manager -> RemoteConfig -> OutputFormat -> Maybe Text -> 
 executeRemoteExport mgr rc fmt jp args = do
     resp <- apiPost mgr rc ("/api/v1/db/" ++ T.unpack (deaDb args) ++ "/export") (object ["format" .= deaFormat args])
     case resp of
+        -- A failed export (bad format, db not loaded, unexportable data) arrives
+        -- as a non-2xx HTTP status, surfaced here as 'Left'.
         Left err -> reportError err >> exitFailure
-        Right val -> case parseMaybe parseExportResponse val of
+        Right val -> case parseMaybe parseExportData val of
             Nothing -> reportError "export: malformed server response" >> exitFailure
-            Just (False, msg, _) -> reportError ("export failed: " ++ T.unpack msg) >> exitFailure
-            Just (True, _, Nothing) -> reportError "export: server reported success but returned no data" >> exitFailure
-            Just (True, _, Just b64) -> case B64.decode (T.encodeUtf8 b64) of
+            Just b64 -> case B64.decode (T.encodeUtf8 b64) of
                 Left derr -> reportError ("export: invalid base64 from server: " ++ derr) >> exitFailure
                 Right bytes -> do
                     C8.writeFile (deaOut args) bytes
                     output fmt jp (Right (object ["database" .= deaDb args, "format" .= deaFormat args, "out" .= deaOut args]))
   where
-    parseExportResponse :: Value -> Parser (Bool, Text, Maybe Text)
-    parseExportResponse = withObject "ExportResponse" $ \o ->
-        (,,) <$> o .: "success" <*> o .: "message" <*> o .:? "data"
+    parseExportData :: Value -> Parser Text
+    parseExportData = withObject "ExportResponse" $ \o -> o .: "data"
 
 -- | Build query string from optional parameters
 buildQuery :: [(String, Maybe String)] -> String

--- a/src/CLI/Client.hs
+++ b/src/CLI/Client.hs
@@ -11,7 +11,7 @@ module CLI.Client (
 import CLI.Types
 import Config (Config (..), ServerConfig (..))
 import Control.Exception (IOException, try)
-import Data.Aeson (Value (..), decode, encode, object, (.:), (.=))
+import Data.Aeson (Value (..), decode, encode, object, (.:), (.:?), (.=))
 import Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KM
@@ -107,6 +107,8 @@ executeRemoteCommand mgr rc globalOpts cmd = do
                         ("/api/v1/db/" ++ T.unpack (draDb args) ++ "/relink")
                         (relinkMappingBody (draToDep args) csv)
                         >>= output fmt jp
+        Database (DbExport args) ->
+            executeRemoteExport mgr rc fmt jp args
         Method McList ->
             apiGet mgr rc "/api/v1/method-collections" >>= output fmt jp
         Method (McUpload args) ->
@@ -272,6 +274,30 @@ relinkMappingBody depDb csv =
         [ "depDb" .= depDb
         , "mappingCsv" .= csv
         ]
+
+{- | Remote export: POST the target format, base64-decode the bytes the server
+returns (serialization happens server-side), and write them to @--out@. Mirrors
+the local export's output summary. Failures (bad format, db not loaded, invalid
+base64) surface loudly rather than writing a partial/empty file.
+-}
+executeRemoteExport :: Manager -> RemoteConfig -> OutputFormat -> Maybe Text -> DbExportArgs -> IO ()
+executeRemoteExport mgr rc fmt jp args = do
+    resp <- apiPost mgr rc ("/api/v1/db/" ++ T.unpack (deaDb args) ++ "/export") (object ["format" .= deaFormat args])
+    case resp of
+        Left err -> reportError err >> exitFailure
+        Right val -> case parseMaybe parseExportResponse val of
+            Nothing -> reportError "export: malformed server response" >> exitFailure
+            Just (False, msg, _) -> reportError ("export failed: " ++ T.unpack msg) >> exitFailure
+            Just (True, _, Nothing) -> reportError "export: server reported success but returned no data" >> exitFailure
+            Just (True, _, Just b64) -> case B64.decode (T.encodeUtf8 b64) of
+                Left derr -> reportError ("export: invalid base64 from server: " ++ derr) >> exitFailure
+                Right bytes -> do
+                    C8.writeFile (deaOut args) bytes
+                    output fmt jp (Right (object ["database" .= deaDb args, "format" .= deaFormat args, "out" .= deaOut args]))
+  where
+    parseExportResponse :: Value -> Parser (Bool, Text, Maybe Text)
+    parseExportResponse = withObject "ExportResponse" $ \o ->
+        (,,) <$> o .: "success" <*> o .: "message" <*> o .:? "data"
 
 -- | Build query string from optional parameters
 buildQuery :: [(String, Maybe String)] -> String

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -3,7 +3,7 @@
 
 module CLI.Command where
 
-import CLI.Types (CLIConfig (..), Command (..), DatabaseAction (..), DbDeleteArgs (..), DbRelinkArgs (..), DebugMatricesOptions (..), FlowSubCommand (..), GlobalOptions (..), LCIAOptions (..), MappingOptions (..), MethodAction (..), OutputFormat (..), PluginAction (..), SearchActivitiesOptions (..), SearchFlowsOptions (..), UploadArgs (..))
+import CLI.Types (CLIConfig (..), Command (..), DatabaseAction (..), DbDeleteArgs (..), DbExportArgs (..), DbRelinkArgs (..), DebugMatricesOptions (..), FlowSubCommand (..), GlobalOptions (..), LCIAOptions (..), MappingOptions (..), MethodAction (..), OutputFormat (..), PluginAction (..), SearchActivitiesOptions (..), SearchFlowsOptions (..), UploadArgs (..))
 import Config (DatabaseConfig (..), MethodConfig (..))
 import Control.Concurrent.STM (readTVarIO)
 import Data.Aeson (Value, encode, object, toJSON, (.=))
@@ -17,10 +17,11 @@ import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import Database.Edit (copyDatabase, deleteActivitiesInDB)
+import Database.Export (exportDatabase)
 import Database.Manager (DatabaseManager (..), LoadedDatabase (..), RelinkResult (..), addDatabase, addMethodCollection)
 import qualified Database.Manager as DM
 import Database.RelinkMapping (relinkWithMappingFile)
-import Database.Upload (UploadData (..), UploadResult (..), findMethodDirectory, handleUpload)
+import Database.Upload (DatabaseFormat (..), UploadData (..), UploadResult (..), findMethodDirectory, handleUpload)
 import qualified Database.Upload
 import qualified Database.UploadedDatabase as UploadedDB
 import Method.Mapping (MappingStats (..), MatchStrategy (..), computeMappingStats, mapMethodToFlows)
@@ -106,6 +107,8 @@ executeCommand (CLIConfig globalOpts _) cmd manager = do
             executeDbCopy registry outputFormat manager srcName newName
         Database (DbRelinkMapping args) ->
             executeDbRelinkMapping registry outputFormat manager args
+        Database (DbExport args) ->
+            executeDbExport registry outputFormat manager args
         Method McList ->
             DM.listMethodCollections manager >>= out . toJSON
         Method (McUpload args) ->
@@ -552,6 +555,40 @@ executeDbRelinkMapping registry fmt manager args = do
                     , "cross_db_links" .= rresCrossDBLinks r
                     , "depends_on" .= rresDepsLoaded r
                     ]
+
+-- | Parse the @--format@ keyword for export into a 'DatabaseFormat'.
+parseExportFormat :: Text -> Either Text DatabaseFormat
+parseExportFormat raw = case T.toLower (T.strip raw) of
+    "simapro" -> Right SimaProCSV
+    "ecospold1" -> Right EcoSpold1
+    "ecospold2" -> Right EcoSpold2
+    "ilcd" -> Right ILCDProcess
+    "brightway" -> Right BrightwayExcel
+    other -> Left $ "unknown export format: " <> other <> " (expected simapro|ecospold1|ecospold2|ilcd|brightway)"
+
+-- | Execute database export: serialize a loaded database to a file.
+executeDbExport :: PluginRegistry -> OutputFormat -> DatabaseManager -> DbExportArgs -> IO ()
+executeDbExport registry fmt manager args =
+    case parseExportFormat (deaFormat args) of
+        Left err -> reportError (T.unpack err) >> exitFailure
+        Right dbFmt -> do
+            mLoaded <- DM.getDatabase manager (deaDb args)
+            case mLoaded of
+                Nothing -> do
+                    reportError $ "Database '" ++ T.unpack (deaDb args) ++ "' not loaded"
+                    exitFailure
+                Just ld -> do
+                    result <- exportDatabase dbFmt (ldDatabase ld) (deaOut args)
+                    case result of
+                        Left err -> reportError (T.unpack err) >> exitFailure
+                        Right () -> do
+                            reportProgress Info $ "Exported " ++ T.unpack (deaDb args) ++ " -> " ++ deaOut args
+                            outputResult registry fmt $
+                                object
+                                    [ "database" .= deaDb args
+                                    , "format" .= deaFormat args
+                                    , "out" .= deaOut args
+                                    ]
 
 -- | Execute method delete command
 executeMcDelete :: PluginRegistry -> OutputFormat -> DatabaseManager -> Text -> IO ()

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -17,7 +17,7 @@ import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import Database.Edit (copyDatabase, deleteActivitiesInDB)
-import Database.Export (exportDatabase)
+import Database.Export (exportDatabase, parseExportFormat)
 import Database.Manager (DatabaseManager (..), LoadedDatabase (..), RelinkResult (..), addDatabase, addMethodCollection)
 import qualified Database.Manager as DM
 import Database.RelinkMapping (relinkWithMappingFile)
@@ -555,16 +555,6 @@ executeDbRelinkMapping registry fmt manager args = do
                     , "cross_db_links" .= rresCrossDBLinks r
                     , "depends_on" .= rresDepsLoaded r
                     ]
-
--- | Parse the @--format@ keyword for export into a 'DatabaseFormat'.
-parseExportFormat :: Text -> Either Text DatabaseFormat
-parseExportFormat raw = case T.toLower (T.strip raw) of
-    "simapro" -> Right SimaProCSV
-    "ecospold1" -> Right EcoSpold1
-    "ecospold2" -> Right EcoSpold2
-    "ilcd" -> Right ILCDProcess
-    "brightway" -> Right BrightwayExcel
-    other -> Left $ "unknown export format: " <> other <> " (expected simapro|ecospold1|ecospold2|ilcd|brightway)"
 
 -- | Execute database export: serialize a loaded database to a file.
 executeDbExport :: PluginRegistry -> OutputFormat -> DatabaseManager -> DbExportArgs -> IO ()

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -21,7 +21,7 @@ import Database.Export (exportDatabase, parseExportFormat)
 import Database.Manager (DatabaseManager (..), LoadedDatabase (..), RelinkResult (..), addDatabase, addMethodCollection)
 import qualified Database.Manager as DM
 import Database.RelinkMapping (relinkWithMappingFile)
-import Database.Upload (DatabaseFormat (..), UploadData (..), UploadResult (..), findMethodDirectory, handleUpload)
+import Database.Upload (UploadData (..), UploadResult (..), findMethodDirectory, handleUpload)
 import qualified Database.Upload
 import qualified Database.UploadedDatabase as UploadedDB
 import Method.Mapping (MappingStats (..), MatchStrategy (..), computeMappingStats, mapMethodToFlows)

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -119,6 +119,7 @@ databaseParser =
                     <> OA.command "delete-activities" (info (DbDeleteActivities <$> deleteActivitiesArgsParser <**> helper) (progDesc "Delete the whole filtered set of activities from a loaded database"))
                     <> OA.command "copy" (info (copyArgsParser <**> helper) (progDesc "Copy a loaded database under a new name"))
                     <> OA.command "relink" (info (DbRelinkMapping <$> relinkArgsParser <**> helper) (progDesc "Relink a database to a dependency using a name->name supplier alias CSV"))
+                    <> OA.command "export" (info (DbExport <$> exportArgsParser <**> helper) (progDesc "Export a loaded database to a file"))
                 )
             )
 
@@ -138,6 +139,16 @@ relinkArgsParser =
         <$> textArg "DB" "Name of the loaded database to relink"
         <*> textOpt "to" Nothing "DEP_DB" "Dependency database to link against"
         <*> strOpt "mapping" Nothing "CSV" "Path to the name->name supplier alias CSV"
+
+{- | Export parser: positional DB, @--format@ keyword, @--out@ file path.
+Mirrors @db export <db> --format <fmt> --out <file>@.
+-}
+exportArgsParser :: Parser DbExportArgs
+exportArgsParser =
+    DbExportArgs
+        <$> textArg "DB" "Name of the loaded database to export"
+        <*> textOpt "format" Nothing "FMT" "Target format: simapro|ecospold1|ecospold2|ilcd|brightway"
+        <*> strOpt "out" Nothing "FILE" "Output file path"
 
 {- | Delete-by-selection parser: positional DB plus filter options. @--keep@ and
 @--add@ may be repeated; they spare or add individual ProcessIds.

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -73,6 +73,19 @@ data DatabaseAction
       alias mapping loaded from a local CSV: @db@, @--to depDb@, @--mapping csv@.
       -}
       DbRelinkMapping DbRelinkArgs
+    | -- | Export a loaded database to a file: @db@, @--format fmt@, @--out file@.
+      DbExport DbExportArgs
+    deriving (Eq, Show, Generic)
+
+-- | Arguments for @database export@.
+data DbExportArgs = DbExportArgs
+    { deaDb :: Text
+    -- ^ Database to export
+    , deaFormat :: Text
+    -- ^ Target format keyword (@--format@): simapro|ecospold1|ecospold2|ilcd|brightway
+    , deaOut :: FilePath
+    -- ^ Output file path (@--out@)
+    }
     deriving (Eq, Show, Generic)
 
 -- | Arguments for @database relink@ with a name→name supplier alias mapping.

--- a/src/Database/Export.hs
+++ b/src/Database/Export.hs
@@ -14,6 +14,7 @@ has no writer and 'UnknownFormat' is not a real target, so both fail loudly
 module Database.Export (
     serializeDatabase,
     exportDatabase,
+    parseExportFormat,
 ) where
 
 import qualified Codec.Archive.Zip as Zip
@@ -37,27 +38,32 @@ writer.
 -}
 serializeDatabase :: DatabaseFormat -> Database -> Either Text BL.ByteString
 serializeDatabase fmt db = case fmt of
-    SimaProCSV -> do
-        SP.checkSimaProExportable sdb
-        Right (BL.fromStrict (SP.serializeSimaProCSV SP.defaultWriterConfig sdb))
-    EcoSpold1 -> do
-        ES1.checkEcoSpold1Exportable sdb
-        Right (BL.fromStrict (TE.encodeUtf8 (ES1.writeDatabase ES1.canonicalWriterOptions db)))
-    EcoSpold2 -> do
-        ES2.checkEcoSpold2Exportable sdb
-        Right (zipText (ES2.writeEcoSpold2 ES2.noVolatileMeta sdb))
-    ILCDProcess -> do
-        ILCD.checkILCDExportable sdb
-        Right (ILCD.writeILCDArchive ILCD.defaultWriteOptions sdb)
-    BrightwayExcel -> do
-        BE.checkBrightwayExportable sdb
-        Right (BE.renderWorkbook BE.defaultWriterConfig sdb)
+    -- Each writer runs its own check*Exportable and returns 'Left' on a database
+    -- the format cannot represent faithfully, so the guard is unskippable.
+    SimaProCSV -> BL.fromStrict <$> SP.serializeSimaProCSV SP.defaultWriterConfig sdb
+    EcoSpold1 -> BL.fromStrict . TE.encodeUtf8 <$> ES1.writeDatabase ES1.canonicalWriterOptions db
+    EcoSpold2 -> zipText <$> ES2.writeEcoSpold2 ES2.noVolatileMeta sdb
+    ILCDProcess -> ILCD.writeILCDArchive ILCD.defaultWriteOptions sdb
+    BrightwayExcel -> BE.renderWorkbook BE.defaultWriterConfig sdb
     OpenLcaJsonLd ->
         Left "openLCA JSON-LD export is not supported"
     UnknownFormat ->
         Left "cannot export to an unknown format"
   where
     sdb = toSimpleDatabase db
+
+{- | Parse a user-facing export-format name (case- and whitespace-insensitive)
+to a 'DatabaseFormat'. Shared by the CLI and the HTTP handler so the accepted
+spellings and the error message stay in one place.
+-}
+parseExportFormat :: Text -> Either Text DatabaseFormat
+parseExportFormat raw = case T.toLower (T.strip raw) of
+    "simapro" -> Right SimaProCSV
+    "ecospold1" -> Right EcoSpold1
+    "ecospold2" -> Right EcoSpold2
+    "ilcd" -> Right ILCDProcess
+    "brightway" -> Right BrightwayExcel
+    other -> Left ("unknown export format: " <> other <> " (expected simapro|ecospold1|ecospold2|ilcd|brightway)")
 
 -- | Serialize a database and write it to @path@.
 exportDatabase :: DatabaseFormat -> Database -> FilePath -> IO (Either Text ())

--- a/src/Database/Export.hs
+++ b/src/Database/Export.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Format dispatch for database export.
+
+Inverts the upload/parse path: given an in-memory 'Database', serialize it to
+bytes in one of the supported formats by delegating to the per-format writer.
+
+Single-file formats (SimaPro CSV, EcoSpold 1, Brightway Excel) serialize to one
+byte stream. Multi-file formats (EcoSpold 2, ILCD) are inherently directory
+trees, so they are packaged into a deterministic zip archive. 'OpenLcaJsonLd'
+has no writer and 'UnknownFormat' is not a real target, so both fail loudly
+('Left') rather than emit a silent empty file.
+-}
+module Database.Export (
+    serializeDatabase,
+    exportDatabase,
+) where
+
+import qualified Codec.Archive.Zip as Zip
+import Control.Exception (SomeException, try)
+import qualified Data.ByteString.Lazy as BL
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+
+import qualified BrightwayExcel.Writer as BE
+import Database.Upload (DatabaseFormat (..))
+import qualified EcoSpold.Writer1 as ES1
+import qualified EcoSpold.Writer2 as ES2
+import qualified ILCD.Writer as ILCD
+import qualified SimaPro.Writer as SP
+import Types (Database, toSimpleDatabase)
+
+{- | Serialize a database to a single byte stream in the requested format. Pure:
+the multi-file formats are zipped in-memory. Fails loudly for formats without a
+writer.
+-}
+serializeDatabase :: DatabaseFormat -> Database -> Either Text BL.ByteString
+serializeDatabase fmt db = case fmt of
+    SimaProCSV -> do
+        SP.checkSimaProExportable sdb
+        Right (BL.fromStrict (SP.serializeSimaProCSV SP.defaultWriterConfig sdb))
+    EcoSpold1 -> do
+        ES1.checkEcoSpold1Exportable sdb
+        Right (BL.fromStrict (TE.encodeUtf8 (ES1.writeDatabase ES1.canonicalWriterOptions db)))
+    EcoSpold2 -> do
+        ES2.checkEcoSpold2Exportable sdb
+        Right (zipText (ES2.writeEcoSpold2 ES2.noVolatileMeta sdb))
+    ILCDProcess -> do
+        ILCD.checkILCDExportable sdb
+        Right (ILCD.writeILCDArchive ILCD.defaultWriteOptions sdb)
+    BrightwayExcel -> do
+        BE.checkBrightwayExportable sdb
+        Right (BE.renderWorkbook BE.defaultWriterConfig sdb)
+    OpenLcaJsonLd ->
+        Left "openLCA JSON-LD export is not supported"
+    UnknownFormat ->
+        Left "cannot export to an unknown format"
+  where
+    sdb = toSimpleDatabase db
+
+-- | Serialize a database and write it to @path@.
+exportDatabase :: DatabaseFormat -> Database -> FilePath -> IO (Either Text ())
+exportDatabase fmt db path = case serializeDatabase fmt db of
+    Left err -> pure (Left err)
+    Right bytes -> either (Left . renderErr) Right <$> try (BL.writeFile path bytes)
+  where
+    renderErr :: SomeException -> Text
+    renderErr e = "export failed: " <> T.pack (show e)
+
+-- | Pack @(path, text)@ entries into a deterministic zip (epoch-0 mtimes).
+zipText :: [(FilePath, Text)] -> BL.ByteString
+zipText = Zip.fromArchive . foldl addOne Zip.emptyArchive
+  where
+    addOne arc (p, t) =
+        Zip.addEntryToArchive
+            (Zip.toEntry p 0 (BL.fromStrict (TE.encodeUtf8 t)))
+            arc

--- a/test/ExportHandlerSpec.hs
+++ b/test/ExportHandlerSpec.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Tests for the HTTP export handler's error mapping. A failed export must
+surface as the right HTTP status (400 bad format / unexportable data, 404 not
+loaded), never as a 200 body carrying a success flag — the @ExportResponse@ type
+can no longer represent the latter.
+
+The cheapest fixture that still drives the @Servant.runHandler@ boundary is an
+empty 'Database.Manager.DatabaseManager' (no databases loaded), exactly as
+"BatchImpactsSpec" does for its handlers.
+-}
+module ExportHandlerSpec (spec) where
+
+import API.DatabaseHandlers (exportDatabaseHandler)
+import API.Types (ExportRequest (..), ExportResponse)
+import App.Env (AppEnv (..), runApp)
+import Config (defaultConfig)
+import Data.Text (Text)
+import Database.Manager (initDatabaseManager)
+import Servant (ServerError, errHTTPCode, runHandler)
+import Test.Hspec
+
+{- | Run the export handler against an empty database manager. 'ExportResponse'
+has no Eq/Show, but the tests only inspect the 'Left', and the @Right _@
+pattern never forces it.
+-}
+runExport :: Text -> Text -> IO (Either ServerError ExportResponse)
+runExport dbName fmt = do
+    dbm <- initDatabaseManager defaultConfig True Nothing
+    let env =
+            AppEnv
+                { aeDbManager = dbm
+                , aeMaxTreeDepth = 10
+                , aePassword = Nothing
+                , aeHostingConfig = Nothing
+                , aeClassificationPresets = []
+                }
+    runHandler (runApp env (exportDatabaseHandler dbName (ExportRequest fmt)))
+
+spec :: Spec
+spec = describe "exportDatabaseHandler (HTTP error mapping)" $ do
+    it "returns 404 when the database is not loaded" $ do
+        res <- runExport "no-such-db" "simapro"
+        case res of
+            Left e -> errHTTPCode e `shouldBe` 404
+            Right _ -> expectationFailure "expected a 404, got a successful export"
+
+    it "returns 400 for an unknown export format" $ do
+        res <- runExport "no-such-db" "not-a-format"
+        case res of
+            Left e -> errHTTPCode e `shouldBe` 400
+            Right _ -> expectationFailure "expected a 400, got a successful export"

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Tests for the export dispatcher ('Database.Export.serializeDatabase').
+
+The dispatcher is the single entry point the CLI and HTTP handler use to turn an
+in-memory 'Database' into bytes. It must: wire every writable format, fail loudly
+(never emit empty bytes) for the formats with no writer, and propagate a writer's
+own export-guard 'Left' rather than swallow it.
+-}
+module ExportSpec (spec) where
+
+import Control.Monad (forM_)
+import qualified Data.ByteString.Lazy as BL
+import Data.Either (isLeft)
+import qualified Data.Map.Strict as M
+import qualified Data.Text as T
+import qualified Data.UUID as UUID
+import Test.Hspec
+
+import qualified Database as DB
+import Database.Export (serializeDatabase)
+import Database.Upload (DatabaseFormat (..))
+import Types
+import UnitConversion (defaultUnitConfig)
+
+spec :: Spec
+spec = describe "Database.Export dispatcher" $ do
+    it "serializes a simple database to every writable format" $ do
+        db <- buildFixture (Compartment "air" (Just "unspecified"))
+        forM_ [SimaProCSV, EcoSpold1, EcoSpold2, ILCDProcess, BrightwayExcel] $ \fmt ->
+            case serializeDatabase fmt db of
+                Left err -> expectationFailure (show fmt <> ": " <> T.unpack err)
+                Right bytes -> BL.null bytes `shouldBe` False
+
+    it "fails loudly for formats with no writer (never a silent empty file)" $ do
+        db <- buildFixture (Compartment "air" (Just "unspecified"))
+        serializeDatabase OpenLcaJsonLd db `shouldSatisfy` isLeft
+        serializeDatabase UnknownFormat db `shouldSatisfy` isLeft
+
+    it "propagates a writer's export-guard failure" $ do
+        -- A "raw" emission compartment has no faithful SimaPro section, so the
+        -- SimaPro writer's own guard rejects it; the dispatcher must surface that
+        -- Left rather than emit a corrupt file.
+        db <- buildFixture (Compartment "raw" Nothing)
+        serializeDatabase SimaProCSV db `shouldSatisfy` isLeft
+
+{- | One activity: a reference product and a single biosphere emission whose
+compartment is @comp@ (air for the all-formats case, "raw" for the guard case).
+-}
+buildFixture :: Compartment -> IO Database
+buildFixture comp = do
+    r <-
+        DB.buildDatabaseWithMatrices
+            defaultUnitConfig
+            (M.singleton (actU, prodU) act)
+            (M.singleton prodU (TechnosphereFlow prodU "product" unitU M.empty Nothing Nothing))
+            (M.singleton co2U (BiosphereFlow co2U "Carbon dioxide" unitU M.empty Nothing Nothing (Just comp)))
+            M.empty
+            (M.singleton unitU (Unit unitU "kg" "kg" ""))
+    either (fail . ("buildDatabaseWithMatrices: " <>) . T.unpack) pure r
+  where
+    actU, prodU, co2U, unitU :: UUID
+    actU = read "eeeeeeee-0000-4000-8000-000000000001"
+    prodU = read "eeeeeeee-0000-4000-8000-0000000000a1"
+    co2U = read "eeeeeeee-0000-4000-8000-0000000000c1"
+    unitU = read "22222222-0000-4000-8000-000000000099"
+    act =
+        Activity
+            "maker"
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "kg"
+            [ TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , BiosphereExchange co2U 0.5 unitU Emission "" Nothing Nothing
+            ]
+            M.empty
+            M.empty
+            Nothing
+            Nothing
+            Nothing

--- a/volca.cabal
+++ b/volca.cabal
@@ -93,6 +93,7 @@ library
                      , Expr
                      , ILCD.Parser
                      , ILCD.Writer
+                     , Database.Export
                      , Plugin.Types
                      , Plugin.Builtin
                      , Plugin.Bridge

--- a/volca.cabal
+++ b/volca.cabal
@@ -282,6 +282,7 @@ test-suite lca-tests
                      , CopySpec
                      , DeleteSelectionSpec
                      , ExportSpec
+                     , ExportHandlerSpec
                      , PropertiesSpec
   build-depends:       base >=4.14 && <5
                      , volca

--- a/volca.cabal
+++ b/volca.cabal
@@ -281,6 +281,7 @@ test-suite lca-tests
                      , ConfigWriterSpec
                      , CopySpec
                      , DeleteSelectionSpec
+                     , ExportSpec
                      , PropertiesSpec
   build-depends:       base >=4.14 && <5
                      , volca


### PR DESCRIPTION
## What
`Database.Export`, a format dispatch that serializes an in-memory database to bytes via the per-format writer. Single-file formats return one stream; multi-file (EcoSpold 2, ILCD) are packaged as a deterministic zip. openLCA JSON-LD and unknown formats fail loudly rather than emit an empty file.

Exposed over CLI (`db export --format --out`), HTTP (`POST /db/{db}/export`, base64 like upload) and pyvolca (`export_database` / `export_to_file`).

Final piece of the #113 split into focused, independently-reviewable PRs. The delete primitive and all five writers it builds on are now merged, so this rebases directly onto `main` — no remaining stack. `cabal test lca-tests` → 1322 examples, 0 failures.