### PR TITLE
Automate Haskell formatting and add agent instructions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path'); case \"$f\" in *.hs) fourmolu -i \"$f\" >/dev/null 2>&1 || true ;; esac"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Auto-format staged Haskell with fourmolu before each commit.
+# fourmolu version is pinned in versions.env (FOURMOLU_VERSION).
+# Enable once per clone:  git config core.hooksPath .githooks
+
+files=$(git diff --cached --name-only --diff-filter=ACM -- '*.hs')
+[ -z "$files" ] && exit 0
+
+if ! command -v fourmolu >/dev/null 2>&1; then
+    echo "pre-commit: fourmolu not on PATH — install the version from versions.env (FOURMOLU_VERSION)" >&2
+    exit 1
+fi
+
+for f in $files; do
+    fourmolu -i "$f" || exit 1
+    git add "$f"
+done

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -12,6 +12,12 @@ if ! command -v fourmolu >/dev/null 2>&1; then
 fi
 
 for f in $files; do
+    # A file with unstaged changes is only partially staged; `fourmolu -i` + `git add`
+    # would sweep the unstaged hunks into the commit. Skip it — the Format CI still gates.
+    if ! git diff --quiet -- "$f"; then
+        echo "pre-commit: $f is partially staged — not auto-formatting (run fourmolu on it yourself)" >&2
+        continue
+    fi
     fourmolu -i "$f" || exit 1
     git add "$f"
 done

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,32 @@
+name: Format
+
+# Gate PRs on fourmolu formatting. Fast, build-independent — runs in parallel
+# with the heavy build matrix rather than after it. fourmolu version comes from
+# versions.env so CI, the .githooks/pre-commit hook, and Claude Code's
+# PostToolUse hook all format identically.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: format-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fourmolu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Pin fourmolu version from versions.env
+        run: grep -E '^FOURMOLU_VERSION=' versions.env >> "$GITHUB_ENV"
+      - uses: haskell-actions/run-fourmolu@v12
+        with:
+          version: ${{ env.FOURMOLU_VERSION }}
+          pattern: |
+            src/**/*.hs
+            app/**/*.hs
+            test/**/*.hs
+            bench/**/*.hs

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -30,3 +30,4 @@ jobs:
             app/**/*.hs
             test/**/*.hs
             bench/**/*.hs
+            mumps-hs/**/*.hs

--- a/.gitignore
+++ b/.gitignore
@@ -32,14 +32,6 @@ DBs/
 uploads/
 cache/
 
-# docs
-*.md
-!README.md
-!CHANGELOG.md
-!THIRD_PARTY_LICENSES.md
-!docs/**/*.md
-!scripts/verify-pr41-regression.md
-
 # temporary python stuff (not pyvolca/)
 /pyproject.toml
 **/__pycache__/
@@ -47,14 +39,15 @@ cache/
 pyvolca/build/
 pyvolca/dist/
 
-# hidden files
-.*
-!.gitattributes
-!.gitignore
-!.gitmodules
-!.python-version
-!.github
-!.github/**
+# local agent settings (shared .claude/settings.json IS tracked)
+.claude/settings.local.json
+
+# editor / OS cruft
+.DS_Store
+.vscode/
+.idea/
+.direnv/
+.ghc.environment.*
 
 # debug stuff
 debug/

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,14 @@ pyvolca/dist/
 .direnv/
 .ghc.environment.*
 
+# local secrets / credentials — restores the safety the old blanket `.*` rule
+# gave, without re-ignoring the dot-config we now track on purpose.
+.env*
+.netrc
+
+# agent scratch — todo/lesson notes written under .claude/ during a session
+.claude/tasks/
+
 # debug stuff
 debug/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,101 @@
+# AGENTS.md
+
+Guidance for AI agents working in the VoLCA engine repository.
+
+## What this is
+
+VoLCA is an in-memory Life Cycle Assessment (LCA) engine in Haskell (GHC 9.12.4,
+package `volca`, Apache-2.0). It loads EcoSpold 1/2, SimaPro CSV, ILCD, and Excel
+databases, builds supply-chain dependency trees, computes life-cycle inventories (LCI)
+via sparse-matrix algebra, and applies characterization methods for impact assessment.
+Multiple databases load simultaneously with cross-database flow linking and what-if
+substitutions. It exposes a Servant REST API and an MCP server, plus a CLI/REPL.
+
+See `README.md` for the full feature spec.
+
+## Glossary
+
+- **LCI** — life-cycle inventory: the raw physical flows (emissions, resources) for a product.
+- **LCIA** — impact assessment: LCI flows × characterization factors → impact scores.
+- **CF** — characterization factor: one flow's contribution to one impact category.
+- **Activity / Exchange / Flow** — a process / one input-output line / the substance or product exchanged.
+
+## Commands
+
+```bash
+./gen-version.sh        # Generate src/Version.hs (git metadata) — REQUIRED before a native build
+./build.sh              # Build the engine
+./build.sh --test       # Build + run the test suite
+./build.sh --coverage   # Build + tests + HTML coverage report
+cabal test lca-tests --test-show-details=streaming        # Run tests directly
+cabal test lca-tests --test-options="--match /Inventory/" # Run a single spec group
+```
+
+`src/Version.hs` is generated, not committed — a native `cabal build`/`cabal test`
+fails without running `./gen-version.sh` first. Tests use hspec + hspec-discover;
+spec modules are `*Spec.hs` under `test/` and auto-discovered. New behavior needs a
+`*Spec.hs`; integration fixtures (sample databases, golden values) live in `test-data/`.
+
+## Module spine
+
+| Area | Modules | Role |
+|------|---------|------|
+| Domain | `Types` | Central domain types (Activity, Exchange, Flow, …) |
+| Solve | `Matrix`, `SharedSolver` | Sparse technosphere/biosphere matrices; MUMPS-backed LCI solve |
+| Parsers | `EcoSpold.*`, `SimaPro.*`, `ILCD.*`, `BrightwayExcel.*`, `Method.Parser*` | Database + method format readers |
+| Methods | `Method.Mapping`, `Method.FlowResolver`, `Method.ChemSynonyms` | CF mapping (UUID→CAS→name→synonym cascade), flow resolution |
+| Database | `Database.*` (`Loader`, `CrossLinking`, `MatrixBuild`, `Manager`) | Load, cross-link, build matrices, manage lifecycle |
+| Analysis | `Service`, `Service.Aggregate`, `Tree` | Analysis ops, grouping, supply-chain traversal |
+| Search | `Search.BM25`, `Search.Fuzzy`, `Search.Normalize` | Activity/flow search |
+| API | `API.Routes`, `API.MCP` | Servant REST routes and MCP tool surface (shared resource registry) |
+| CLI | `CLI.*`, `app/Main.hs` | Arg parsing, commands, HTTP client, REPL; entrypoint (server/client/repl modes) |
+
+A Python client lives in `pyvolca/` (own `pyproject.toml`); the MUMPS binding in
+`mumps-hs/`. The core is otherwise pure Haskell.
+
+## Where to start
+
+- **A new MCP tool or REST endpoint** → `API.Routes` holds the shared resource registry that drives *both* REST and MCP; add it once there, not in two places.
+- **A new database format** → a new parser namespace (e.g. `Foo.Parser`), wired into `Database.Loader`.
+- **Wrong or empty LCI numbers** → `Database.MatrixBuild` plus `Matrix` / `SharedSolver`; check supplier resolution in `Database.CrossLinking`.
+- **Characterization mismatches** → `Method.Mapping` (the UUID→CAS→name→synonym cascade) and `Method.FlowResolver`.
+- **Search relevance** → `Search.BM25` / `Search.Fuzzy` / `Search.Normalize`.
+
+## Engineering rules
+
+### Code safety
+- **Make impossible states impossible** — use the type system.
+- **No wildcard patterns on sum types** — exhaustive matches only. They hide incomplete matches from the compiler.
+- **No runtime crashes**: never use `error`, `throw`, `undefined`, or partial functions (`head`, `fromJust`). Functions that can fail must return `Either Text a` or `Maybe a`, never crash.
+- **No silent errors or silent misbehaviour**: never return zero, empty, or a fallback value when a lookup fails, a unit conversion can't be done, or data is missing. Surface it: `Either Text a` propagated to a 4xx/5xx, a `reportProgress Warning` log line, or a `toolError` in MCP. A score that silently undercounts is worse than a clear failure — the consumer can't tell something is wrong.
+- Builds are `-Wall`-clean — introduce no new warnings (incomplete patterns, unused binds). This is what backs the exhaustive-match rule above.
+
+### Code style
+- Prefer short point-free style over explicit case pattern matching.
+- Don't overload functions or write diagonal code (deeply nested, staircase-shaped logic). Extract, share and reuse relevant abstractions.
+- **Pure domain, effectful edges**.
+- Avoid long function signatures. They are a smell — split the function or gather arguments in a product type.
+- Each type should have a sensible domain or technical meaning.
+- Use advanced Haskell patterns when they improve expressivity and reduce line count.
+
+### Design philosophy
+- Think like "Out Of The Tar Pit": most complexity is accidental. Minimize mutable state, keep logic declarative, separate state / control / computation.
+- Simplicity: perfection = nothing left to remove. Avoid over-engineering and cognitive load.
+- **Pre-1.0 (`v0.y.z`): no backward-compatibility obligation yet** — keep wire formats and APIs clean rather than carrying cruft. Reassess at `v1.0.0`.
+- Use language servers for fast diagnostics: HLS for Haskell, pyright for the `pyvolca/` Python client.
+
+### Open-source boundary
+- This engine stands alone — keep deployment/SaaS concerns and any customer- or product-specific names out of code, comments, and PRs.
+- Name things after the standard or format, not the vendor or tool that produces them.
+
+### Formatting
+- Haskell is formatted with `fourmolu` — version pinned in `versions.env` (`FOURMOLU_VERSION`), style in `fourmolu.yaml`. You don't run it by hand:
+  - CI fails any PR with unformatted Haskell.
+  - A repo pre-commit hook auto-formats staged `.hs` — enable once per clone: `git config core.hooksPath .githooks`.
+  - Claude Code also auto-formats `.hs` on edit (`.claude/settings.json`).
+
+### Commits & PRs
+- NEVER use `git add -A` — always add specific files explicitly.
+- **Keep commit messages tight**: explain *why* the change was made and any non-obvious technical choices; don't restate the diff. Subject line + a few short paragraphs max.
+- **Atomic commits — one subject per commit.** If the message needs "and also", split it.
+- One PR = one subject. The PR description explains the why and the final state, not every commit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/bench/Bench/Json.hs
+++ b/bench/Bench/Json.hs
@@ -65,9 +65,10 @@ data BenchResult = BenchResult
     -- ^ 1–3 sentences explaining the operation and why it matters.
     , brUnitOfWork :: !UnitOfWork
     , brMetric :: !Text
-    -- ^ Display hint for the consumer — @"seconds"@ or @"milliseconds"@.
-    -- @brMean@ and @brStddev@ are ALWAYS expressed in seconds regardless of
-    -- this hint; the consumer is expected to format accordingly.
+    {- ^ Display hint for the consumer — @"seconds"@ or @"milliseconds"@.
+    @brMean@ and @brStddev@ are ALWAYS expressed in seconds regardless of
+    this hint; the consumer is expected to format accordingly.
+    -}
     , brFixture :: !Fixture
     , brMean :: !Double
     -- ^ Mean wall-clock time for one full iteration, in __seconds__.

--- a/bench/Bench/Lcia.hs
+++ b/bench/Bench/Lcia.hs
@@ -35,8 +35,8 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import System.Random (mkStdGen, randoms)
 
-import qualified Matrix
 import Matrix (Inventory)
+import qualified Matrix
 import Method.Mapping
 import qualified Method.Parser as MP
 import Method.Types (Method (..), MethodCF (..))
@@ -54,8 +54,8 @@ import Types (
 import qualified UnitConversion as UC
 
 import qualified Bench.Helpers as H
-import qualified Bench.Json as J
 import Bench.Json (BenchSpec (..), UnitOfWork (..))
+import qualified Bench.Json as J
 import qualified Fixtures as F
 
 -- ---------------------------------------------------------------------------
@@ -215,8 +215,9 @@ buildFixture =
             , fxSetTables = setTables
             }
 
--- | Score one inventory against each of the 27 methods, sequentially —
--- mirrors the per-method HTTP route loop without parallelism overhead.
+{- | Score one inventory against each of the 27 methods, sequentially —
+mirrors the per-method HTTP route loop without parallelism overhead.
+-}
 benchFanout :: SynFixture -> [Double]
 benchFanout fx =
     [ loScore $

--- a/bench/Bench/Loader.hs
+++ b/bench/Bench/Loader.hs
@@ -30,8 +30,8 @@ import qualified SynonymDB.Types as Syn
 import Types (cdlTotalInputs, sdbActivities)
 import qualified UnitConversion as UC
 
-import qualified Bench.Json as J
 import Bench.Json (BenchSpec (..), UnitOfWork (..))
+import qualified Bench.Json as J
 import qualified Fixtures as F
 
 register :: IO [BenchSpec]

--- a/bench/Bench/Parsers.hs
+++ b/bench/Bench/Parsers.hs
@@ -39,8 +39,8 @@ import qualified SimaPro.Parser as SP
 import Types (sdbActivities)
 import qualified UnitConversion as UC
 
-import qualified Bench.Json as J
 import Bench.Json (BenchSpec (..), UnitOfWork (..))
+import qualified Bench.Json as J
 import qualified Fixtures as F
 
 -- ---------------------------------------------------------------------------
@@ -107,9 +107,10 @@ registerEcoSpold2 = do
                                         }
                                     ]
 
--- | Ecoinvent's 7z extracts to ./datasets/ inside a sibling .d/ directory.
--- Accept either the dataset directory directly or its parent (so users can
--- point the env var at either).
+{- | Ecoinvent's 7z extracts to ./datasets/ inside a sibling .d/ directory.
+Accept either the dataset directory directly or its parent (so users can
+point the env var at either).
+-}
 locateDatasetsDir :: FilePath -> IO (Maybe FilePath)
 locateDatasetsDir path = do
     isDir <- doesDirectoryExist path
@@ -371,8 +372,9 @@ listFilesByExt ext dir = do
     let matching = sort [n | n <- names, takeExtension n == ext]
     pure (map (dir </>) matching)
 
--- | Parse a list of files in parallel, fully evaluating every result so the
--- bench reflects end-to-end work (XML decode + structure build + force).
+{- | Parse a list of files in parallel, fully evaluating every result so the
+bench reflects end-to-end work (XML decode + structure build + force).
+-}
 parallelParseFiles ::
     (NFData a) =>
     (FilePath -> IO a) ->
@@ -382,9 +384,10 @@ parallelParseFiles parser files = nfIO $ do
     results <- mapConcurrently parser files
     evaluate (results `deepseq` length results)
 
--- | Parse a file's bytes through a pure parser; the file is re-read each
--- iteration so the timing covers both I/O and parsing — what the
--- application does on a fresh request.
+{- | Parse a file's bytes through a pure parser; the file is re-read each
+iteration so the timing covers both I/O and parsing — what the
+application does on a fresh request.
+-}
 parseBytesBench ::
     (NFData a) =>
     (BS.ByteString -> Either String a) ->

--- a/bench/Bench/Solve.hs
+++ b/bench/Bench/Solve.hs
@@ -40,8 +40,8 @@ import Types (
  )
 
 import qualified Bench.Helpers as H
-import qualified Bench.Json as J
 import Bench.Json (BenchSpec (..), UnitOfWork (..))
+import qualified Bench.Json as J
 import qualified Fixtures as F
 
 -- ---------------------------------------------------------------------------
@@ -151,9 +151,10 @@ pickSolveFixture = go [F.Agribalyse, F.Bafu, F.Ecoinvent]
             Just p -> pure (Just (s, p))
             Nothing -> go ss
 
--- | First N ProcessIds in the database (deterministic by matrix ordering).
--- Returns at most as many as the database has; falls back gracefully on
--- small fixtures.
+{- | First N ProcessIds in the database (deterministic by matrix ordering).
+Returns at most as many as the database has; falls back gracefully on
+small fixtures.
+-}
 pickProcessIds :: Database -> Int -> [ProcessId]
 pickProcessIds db n =
     let total = fromIntegral (dbActivityCount db) :: Int

--- a/bench/Fixtures.hs
+++ b/bench/Fixtures.hs
@@ -39,8 +39,9 @@ fixtureEnvVar MethodCsv = "VOLCA_BENCH_METHOD_CSV"
 fixtureEnvVar MethodSimaProCsv = "VOLCA_BENCH_METHOD_SIMAPRO_CSV"
 fixtureEnvVar MethodOlcaJson = "VOLCA_BENCH_METHOD_OLCA_JSON"
 
--- | Stable provenance string emitted into bench-results.json. Does not name a
--- specific version on purpose — the path on disk is what gives the version.
+{- | Stable provenance string emitted into bench-results.json. Does not name a
+specific version on purpose — the path on disk is what gives the version.
+-}
 fixtureSourceLabel :: FixtureSource -> Text
 fixtureSourceLabel Agribalyse = T.pack "agribalyse"
 fixtureSourceLabel Ecoinvent = T.pack "ecoinvent"
@@ -51,9 +52,10 @@ fixtureSourceLabel MethodCsv = T.pack "method-csv"
 fixtureSourceLabel MethodSimaProCsv = T.pack "method-simapro-csv"
 fixtureSourceLabel MethodOlcaJson = T.pack "method-olca-json"
 
--- | Returns the path if the env var is set AND the path exists (file or
--- directory). Prints a single-line « [bench] skipping … » note when absent so
--- the run log makes it obvious which benchs were left out and why.
+{- | Returns the path if the env var is set AND the path exists (file or
+directory). Prints a single-line « [bench] skipping … » note when absent so
+the run log makes it obvious which benchs were left out and why.
+-}
 lookupFixture :: FixtureSource -> IO (Maybe FilePath)
 lookupFixture src = do
     let var = fixtureEnvVar src

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -15,12 +15,12 @@ module Main (main) where
 
 import Control.Exception (SomeException, try)
 import Data.Maybe (fromMaybe)
-import GHC.IO.Exception (ExitCode (ExitSuccess))
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Clock (getCurrentTime)
 import Data.Time.Format.ISO8601 (iso8601Show)
 import GHC.Conc (getNumProcessors)
+import GHC.IO.Exception (ExitCode (ExitSuccess))
 import System.Environment (getArgs, lookupEnv)
 import System.IO (hFlush, stdout)
 import System.Process (readProcessWithExitCode)
@@ -120,17 +120,19 @@ runOne spec = do
             , J.brDerived = J.Derived{J.dItemsPerSecond = ips}
             }
 
--- | Time one full iteration of a 'Benchmarkable', and collect heap so the
--- next iteration starts from a known state.
+{- | Time one full iteration of a 'Benchmarkable', and collect heap so the
+next iteration starts from a known state.
+-}
 runIter :: MeasTypes.Benchmarkable -> IO Double
 runIter act = do
     performMajorGC
     (m, _) <- Meas.measure act 1
     pure (MeasTypes.measTime m)
 
--- | Pick a sample count that balances accuracy with total wall time. Small
--- benches (<100 ms expected) get more samples; heavy ones (>1 s) get
--- fewer to keep the overall run reasonable.
+{- | Pick a sample count that balances accuracy with total wall time. Small
+benches (<100 ms expected) get more samples; heavy ones (>1 s) get
+fewer to keep the overall run reasonable.
+-}
 chooseSampleCount :: J.BenchSpec -> Int
 chooseSampleCount spec = case J.bsMetric spec of
     "milliseconds" -> 11
@@ -207,10 +209,11 @@ readRamGb = do
 -- Helpers
 -- ---------------------------------------------------------------------------
 
--- | Run a sub-process and return its stdout only on @ExitSuccess@. Spawn
--- failures and non-zero exits both collapse to 'Nothing' so the
--- 'Metadata' field stays absent rather than carrying garbage (e.g. an
--- empty string when @git rev-parse HEAD@ fails outside a checkout).
+{- | Run a sub-process and return its stdout only on @ExitSuccess@. Spawn
+failures and non-zero exits both collapse to 'Nothing' so the
+'Metadata' field stays absent rather than carrying garbage (e.g. an
+empty string when @git rev-parse HEAD@ fails outside a checkout).
+-}
 safeRead :: FilePath -> [String] -> IO (Maybe Text)
 safeRead cmd args = do
     r <- try (readProcessWithExitCode cmd args "") :: IO (Either SomeException (ExitCode, String, String))
@@ -225,8 +228,9 @@ safeReadFile path = do
         Right s -> Just s
         Left _ -> Nothing
 
--- | Strip whitespace and demote @Just ""@ to 'Nothing' — handy when the
--- underlying command exits cleanly but prints nothing useful.
+{- | Strip whitespace and demote @Just ""@ to 'Nothing' — handy when the
+underlying command exits cleanly but prints nothing useful.
+-}
 trimResult :: Maybe Text -> Maybe Text
 trimResult m = case T.strip <$> m of
     Just t | not (T.null t) -> Just t

--- a/test/AggregateSpec.hs
+++ b/test/AggregateSpec.hs
@@ -1,12 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Tests for "Service.Aggregate".
---
--- The aggregate API is documented but had zero direct test coverage. We
--- exercise it end-to-end against SAMPLE.min3, focusing on ScopeDirect (no
--- MUMPS solve required) and ScopeBiosphere (driven by mkSolverFromDb), with
--- emphasis on the filter / group-by / aggregate-function semantics that the
--- HTTP layer relies on for correctness.
+{- | Tests for "Service.Aggregate".
+
+The aggregate API is documented but had zero direct test coverage. We
+exercise it end-to-end against SAMPLE.min3, focusing on ScopeDirect (no
+MUMPS solve required) and ScopeBiosphere (driven by mkSolverFromDb), with
+emphasis on the filter / group-by / aggregate-function semantics that the
+HTTP layer relies on for correctness.
+-}
 module AggregateSpec (spec) where
 
 import qualified Data.Set as S
@@ -17,8 +18,8 @@ import qualified API.Types as API
 import qualified Service.Aggregate as Agg
 import qualified SharedSolver as SS
 import TestHelpers (loadSampleDatabase, mkSolverFromDb)
-import qualified Types
 import Types (Database (..), processIdToText)
+import qualified Types
 import qualified UnitConversion as UC
 
 -- A no-op DepSolverLookup — SAMPLE.min3 has no cross-DB deps.

--- a/test/CoalescingSolverSpec.hs
+++ b/test/CoalescingSolverSpec.hs
@@ -77,9 +77,10 @@ spec = do
                 multiBatch = take 6 (cycle (basicDemands db))
             expectedSingles <- mapM (oracleSolve db) singles
             expectedMulti <- mapM (oracleSolve db) multiBatch
-            (actualSingles, actualMulti) <- concurrently
-                (mapConcurrently (solveSparseLinearSystemWithFactorization fact) singles)
-                (solveSparseLinearSystemWithFactorizationMulti fact multiBatch)
+            (actualSingles, actualMulti) <-
+                concurrently
+                    (mapConcurrently (solveSparseLinearSystemWithFactorization fact) singles)
+                    (solveSparseLinearSystemWithFactorizationMulti fact multiBatch)
             actualSingles `shouldSatisfy` allCloseTo expectedSingles
             actualMulti `shouldSatisfy` allCloseTo expectedMulti
 
@@ -99,13 +100,15 @@ spec = do
 -- Fixtures and helpers
 -- ---------------------------------------------------------------------------
 
--- | Cache key shared by every test in this spec. Distinct from the keys used
--- by other specs so they don't clobber each other.
+{- | Cache key shared by every test in this spec. Distinct from the keys used
+by other specs so they don't clobber each other.
+-}
 cacheKey :: T.Text
 cacheKey = "SAMPLE.min3.coalescing"
 
--- | Build a SharedSolver on SAMPLE.min3, trigger factorization (so the
--- coalescing worker is running), and return the bits the tests need.
+{- | Build a SharedSolver on SAMPLE.min3, trigger factorization (so the
+coalescing worker is running), and return the bits the tests need.
+-}
 min3CachedSolver :: IO (SS.SharedSolver, MatrixFactorization, Database)
 min3CachedSolver = do
     db <- loadSampleDatabase "SAMPLE.min3"
@@ -115,8 +118,9 @@ min3CachedSolver = do
     Just fact <- SS.getFactorization solver
     pure (solver, fact, db)
 
--- | A small set of distinct demand vectors that exercise different RHS shapes.
--- Repeating these via 'cycle' gives us many varied (but reproducible) inputs.
+{- | A small set of distinct demand vectors that exercise different RHS shapes.
+Repeating these via 'cycle' gives us many varied (but reproducible) inputs.
+-}
 basicDemands :: Database -> [Vector]
 basicDemands db =
     let n = U.length (buildDemandVectorFromIndex (dbActivityIndex db) 0)
@@ -137,8 +141,9 @@ scaleVec c = U.map (* c)
 addVec :: Vector -> Vector -> Vector
 addVec = U.zipWith (+)
 
--- | Cold-path oracle: assemble (I-A) and solve from scratch via MUMPS.
--- Bypasses the worker entirely — what we compare against.
+{- | Cold-path oracle: assemble (I-A) and solve from scratch via MUMPS.
+Bypasses the worker entirely — what we compare against.
+-}
 oracleSolve :: Database -> Vector -> IO Vector
 oracleSolve db demand =
     let triples =
@@ -161,4 +166,3 @@ allCloseTo :: [Vector] -> [Vector] -> Bool
 allCloseTo expected actual =
     length expected == length actual
         && and (zipWith (\e a -> closeTo (U.toList e) (U.toList a)) expected actual)
-

--- a/test/ConfigWriterSpec.hs
+++ b/test/ConfigWriterSpec.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Tests for "ConfigWriter".
---
--- ConfigWriter is the persistence layer for uploaded databases: it mutates
--- the operator's TOML file. The mutations are atomic (lock + rename) and
--- preserve manually-edited non-database sections — both invariants the test
--- file should pin.
+{- | Tests for "ConfigWriter".
+
+ConfigWriter is the persistence layer for uploaded databases: it mutates
+the operator's TOML file. The mutations are atomic (lock + rename) and
+preserve manually-edited non-database sections — both invariants the test
+file should pin.
+-}
 module ConfigWriterSpec (spec) where
 
 import qualified Data.Map.Strict as M

--- a/test/CrossLinkingSpec.hs
+++ b/test/CrossLinkingSpec.hs
@@ -463,8 +463,9 @@ mkRefExchangeAt loc =
   where
     flowUUID = read "aaaaaaaa-0000-0000-0000-000000000001"
 
--- | One-activity SimpleDatabase with a single reference exchange. The
--- activity is anchored at @actLoc@; the reference exchange carries @exLoc@.
+{- | One-activity SimpleDatabase with a single reference exchange. The
+activity is anchored at @actLoc@; the reference exchange carries @exLoc@.
+-}
 mkSplitLocationDB :: Text -> Text -> SimpleDatabase
 mkSplitLocationDB actLoc exLoc =
     let flowUUID = read "aaaaaaaa-0000-0000-0000-000000000001"

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -166,25 +166,25 @@ activityTypeFixtureXml actType mSpec =
         \  <activityDataset>\n\
         \    <activityDescription>\n\
         \      <activity id=\"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\" activityNameId=\"attr-test\""
-        <> " activityType=\""
-        <> actType
-        <> "\""
-        <> specAttr
-        <> ">\n\
-           \        <activityName xml:lang=\"en\">attr test activity</activityName>\n\
-           \      </activity>\n\
-           \      <geography geographyId=\"TEST\"><shortname xml:lang=\"en\">TEST</shortname></geography>\n\
-           \    </activityDescription>\n\
-           \    <flowData>\n\
-           \      <intermediateExchange id=\"ref\" unitId=\"unit-kg\" amount=\"1.0\"\n\
-           \                           intermediateExchangeId=\"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb\">\n\
-           \        <name xml:lang=\"en\">attr test product</name>\n\
-           \        <unitName xml:lang=\"en\">kg</unitName>\n\
-           \        <outputGroup>0</outputGroup>\n\
-           \      </intermediateExchange>\n\
-           \    </flowData>\n\
-           \  </activityDataset>\n\
-           \</ecoSpold>\n"
+            <> " activityType=\""
+            <> actType
+            <> "\""
+            <> specAttr
+            <> ">\n\
+               \        <activityName xml:lang=\"en\">attr test activity</activityName>\n\
+               \      </activity>\n\
+               \      <geography geographyId=\"TEST\"><shortname xml:lang=\"en\">TEST</shortname></geography>\n\
+               \    </activityDescription>\n\
+               \    <flowData>\n\
+               \      <intermediateExchange id=\"ref\" unitId=\"unit-kg\" amount=\"1.0\"\n\
+               \                           intermediateExchangeId=\"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb\">\n\
+               \        <name xml:lang=\"en\">attr test product</name>\n\
+               \        <unitName xml:lang=\"en\">kg</unitName>\n\
+               \        <outputGroup>0</outputGroup>\n\
+               \      </intermediateExchange>\n\
+               \    </flowData>\n\
+               \  </activityDataset>\n\
+               \</ecoSpold>\n"
 
 withWastePatternsFixture :: ((Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]) -> IO ()) -> IO ()
 withWastePatternsFixture k = withSystemTempDirectory "es2-waste-spec" $ \dir -> do

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -13,8 +13,8 @@ import Method.ChemSynonyms (emptyChemSynonyms, parseChemSynonymsCSV)
 import Method.Mapping
 import Method.Types (Compartment (..), FlowDirection (..), Method (..), MethodCF (..))
 import SynonymDB (buildFromPairs, emptySynonymDB)
-import qualified Types as VT
 import Types (BiosphereFlow (..), Unit (..))
+import qualified Types as VT
 import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig)
 
 -- ---------------------------------------------------------------------------

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -22,10 +22,10 @@ import Test.Hspec
 
 import Matrix (Inventory)
 import Method.Mapping
-import qualified Method.Types as MT
 import Method.Types (Compartment (..), Method (..), MethodCF (..))
-import qualified Types as VT
+import qualified Method.Types as MT
 import Types (BiosphereFlow (..), Database, Unit (..))
+import qualified Types as VT
 import qualified UnitConversion
 
 -- ---------------------------------------------------------------------------

--- a/test/MethodSpec.hs
+++ b/test/MethodSpec.hs
@@ -20,8 +20,8 @@ import Method.ParserNW (parseNormWeightCSVBytes)
 import Method.ParserSimaPro (isSimaProMethodCSV, parseSimaProMethodCSVBytes)
 import Method.Types
 import SynonymDB
-import qualified Types as VT
 import Types (BiosphereFlow (..))
+import qualified Types as VT
 import UnitConversion (defaultUnitConfig)
 
 spec :: Spec

--- a/test/NativeActivityTypeSpec.hs
+++ b/test/NativeActivityTypeSpec.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Roundtrip tests for the flat JSON encoding of NativeActivityType.
---   ToJSON flattens the three variants to a single-shape record; FromJSON
---   reconstructs the right variant from the `source` discriminator.
+{- | Roundtrip tests for the flat JSON encoding of NativeActivityType.
+  ToJSON flattens the three variants to a single-shape record; FromJSON
+  reconstructs the right variant from the `source` discriminator.
+-}
 module NativeActivityTypeSpec (spec) where
 
 import API.Types ()

--- a/test/NumericEdgesSpec.hs
+++ b/test/NumericEdgesSpec.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Pure numeric edge cases for the matrix pipeline.
---
--- These exercise the *pure* helpers in "Matrix" — the ones that run without
--- touching MUMPS — so we can keep them in the fast unit-test tier. The
--- MUMPS-backed paths are already covered by MatrixConstructionSpec /
--- CoalescingSolverSpec via the per-database loaders.
+{- | Pure numeric edge cases for the matrix pipeline.
+
+These exercise the *pure* helpers in "Matrix" — the ones that run without
+touching MUMPS — so we can keep them in the fast unit-test tier. The
+MUMPS-backed paths are already covered by MatrixConstructionSpec /
+CoalescingSolverSpec via the per-database loaders.
+-}
 module NumericEdgesSpec (spec) where
 
 import qualified Data.Text as T

--- a/test/PropertiesSpec.hs
+++ b/test/PropertiesSpec.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | A small set of property-based tests covering invariants that ARE
--- expected to hold on every legitimate input — not just the ones in our
--- fixtures. Property tests catch cases that example-based tests miss
--- because we never thought to write the example down.
+{- | A small set of property-based tests covering invariants that ARE
+expected to hold on every legitimate input — not just the ones in our
+fixtures. Property tests catch cases that example-based tests miss
+because we never thought to write the example down.
+-}
 module PropertiesSpec (spec) where
 
 import qualified Data.Text as T
@@ -14,18 +15,20 @@ import Test.QuickCheck (Arbitrary (..), arbitraryASCIIChar, choose, listOf)
 import qualified Search.Normalize as N
 import qualified UnitConversion as UC
 
--- | An ASCII-only Text generator — keeps the surface small so a failing
--- counterexample is readable and avoids irrelevant unicode noise the
--- normalizer already handles via its own test cases.
+{- | An ASCII-only Text generator — keeps the surface small so a failing
+counterexample is readable and avoids irrelevant unicode noise the
+normalizer already handles via its own test cases.
+-}
 newtype AsciiText = AsciiText {unAscii :: T.Text}
     deriving (Show)
 
 instance Arbitrary AsciiText where
     arbitrary = AsciiText . T.pack <$> listOf arbitraryASCIIChar
 
--- | A positive finite Double bounded so unit conversions don't overflow or
--- underflow to denormals — the actual application domain (kg, MJ, etc.)
--- stays well within these bounds.
+{- | A positive finite Double bounded so unit conversions don't overflow or
+underflow to denormals — the actual application domain (kg, MJ, etc.)
+stays well within these bounds.
+-}
 newtype DomainAmount = DomainAmount {unAmount :: Double}
     deriving (Show)
 
@@ -59,7 +62,6 @@ spec = do
                         Just qBack -> abs (qBack - q) < 1e-9 * abs q + 1e-9
                         Nothing -> False
                     Nothing -> True -- defaultUnitConfig might not know g; that's ok
-
         prop "returns Nothing on dimensionally incompatible conversions (kg → m)" $
             \(DomainAmount q) ->
                 -- kg (mass) → m (length) MUST refuse — this is a correctness

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -23,7 +23,6 @@ import Method.Types (
     FlowDirection (..),
     MethodCF (..),
  )
-import qualified Types as VT
 import Types (
     Activity (..),
     BiosphereFlow (..),
@@ -33,6 +32,7 @@ import Types (
     Unit (..),
     emptyProductIndex,
  )
+import qualified Types as VT
 import UnitConversion (UnitConfig (..), UnitDef (..))
 
 -- ---------------------------------------------------------------------------

--- a/test/RoutesSpec.hs
+++ b/test/RoutesSpec.hs
@@ -3,12 +3,13 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
--- | Integration tests for the HTTP API surface (Servant routes).
---
--- We boot the real volca binary as a subprocess ONCE (via beforeAll +
--- afterAll), threading the bundled resources into each test rather than
--- relying on top-level mutable state. The subprocess listens on an
--- OS-assigned ephemeral port so parallel CI runners do not collide.
+{- | Integration tests for the HTTP API surface (Servant routes).
+
+We boot the real volca binary as a subprocess ONCE (via beforeAll +
+afterAll), threading the bundled resources into each test rather than
+relying on top-level mutable state. The subprocess listens on an
+OS-assigned ephemeral port so parallel CI runners do not collide.
+-}
 module RoutesSpec (spec) where
 
 import Control.Concurrent (threadDelay)
@@ -89,10 +90,11 @@ findVolcaExe = do
         then pure exe
         else error $ "volca executable not found at " <> exe <> ". Run 'cabal build' first."
 
--- | Ask the OS for a free TCP port on 127.0.0.1. There is a small race
--- between closing this socket and the child binding to it, but it is
--- accepted as the cost of avoiding hardcoded ports clashing under
--- concurrent CI on the same host.
+{- | Ask the OS for a free TCP port on 127.0.0.1. There is a small race
+between closing this socket and the child binding to it, but it is
+accepted as the cost of avoiding hardcoded ports clashing under
+concurrent CI on the same host.
+-}
 findFreePort :: IO Int
 findFreePort =
     bracket
@@ -179,9 +181,10 @@ spec = do
     errorMappingSpec
     integrationSpec
 
--- | Pure regression guard for the ServiceError -> HTTP status contract. Lives
--- outside the booted-server block so it runs everywhere (incl. Windows) and
--- needs no loaded database.
+{- | Pure regression guard for the ServiceError -> HTTP status contract. Lives
+outside the booted-server block so it runs everywhere (incl. Windows) and
+needs no loaded database.
+-}
 errorMappingSpec :: Spec
 errorMappingSpec = describe "serviceErrorToServerError (HTTP status contract)" $ do
     it "maps InvalidUUID to 400 (malformed client id, never 5xx)" $

--- a/test/SensitivitySpec.hs
+++ b/test/SensitivitySpec.hs
@@ -11,7 +11,7 @@ full re-factorization of @(I - A')@ would produce, where @A'_ij = A_ij *
 -}
 module SensitivitySpec (spec) where
 
-import API.Types (LCIAResult (..), PerturbedEntry (..), Perturbation (..))
+import API.Types (LCIAResult (..), Perturbation (..), PerturbedEntry (..))
 import Data.Aeson (Value (..), decode, encode)
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KM

--- a/test/ServiceSpec.hs
+++ b/test/ServiceSpec.hs
@@ -27,8 +27,8 @@ import Service (
  )
 import Test.Hspec
 import TestHelpers (loadSampleDatabase)
-import qualified Types as VT
 import Types
+import qualified Types as VT
 
 spec :: Spec
 spec = do
@@ -136,7 +136,7 @@ spec = do
         it "returns False for air emission" $ do
             let flow = mkBioFlow "air"
             isResourceExtraction flow `shouldBe` False
-        -- Technosphere flows can't reach this function under the new type system.
+    -- Technosphere flows can't reach this function under the new type system.
 
     -- -----------------------------------------------------------------------
     -- extractCompartment

--- a/test/StrictPinSpec.hs
+++ b/test/StrictPinSpec.hs
@@ -27,6 +27,7 @@ import qualified Data.UUID as UUID
 import Test.Hspec
 
 import Config (DatabaseConfig (..), defaultConfig)
+import qualified Data.Vector.Unboxed as U
 import Database (buildDatabaseWithMatrices)
 import Database.CrossLinking (buildIndexedDatabaseFromDB)
 import Database.Manager (
@@ -37,6 +38,8 @@ import Database.Manager (
  )
 import SharedSolver (SharedSolver, createSharedSolver)
 import SynonymDB (emptySynonymDB)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
 import Types (
     Activity (..),
     CrossDBLink (..),
@@ -49,51 +52,48 @@ import Types (
     UUID,
     Unit (..),
  )
-import qualified Data.Vector.Unboxed as U
-import System.FilePath ((</>))
-import System.IO.Temp (withSystemTempDirectory)
 import UnitConversion (defaultUnitConfig)
 
 spec :: Spec
 spec = describe "relinkDatabase strict dependency pin" $ do
     it "keeps dbDependsOn at the pinned set and never re-expands to other loaded DBs" $
-      withSystemTempDirectory "volca-strict-pin" $ \tmp -> do
-        -- alpha supplies p1 only; beta supplies p1 and p2.
-        alphaDb <- buildOrFail (supplierDB 100 ["p1"])
-        betaDb <- buildOrFail (supplierDB 200 ["p1", "p2"])
-        -- consumer needs both p1 and p2.
-        consumerDb0 <- buildOrFail (consumerDB 300 ["p1", "p2"])
-        -- Pin the consumer to alpha only, with no links yet — relink populates them.
-        let consumerDb = consumerDb0{dbDependsOn = ["alpha"], dbCrossDBLinks = []}
+        withSystemTempDirectory "volca-strict-pin" $ \tmp -> do
+            -- alpha supplies p1 only; beta supplies p1 and p2.
+            alphaDb <- buildOrFail (supplierDB 100 ["p1"])
+            betaDb <- buildOrFail (supplierDB 200 ["p1", "p2"])
+            -- consumer needs both p1 and p2.
+            consumerDb0 <- buildOrFail (consumerDB 300 ["p1", "p2"])
+            -- Pin the consumer to alpha only, with no links yet — relink populates them.
+            let consumerDb = consumerDb0{dbDependsOn = ["alpha"], dbCrossDBLinks = []}
 
-        manager <- initDatabaseManager defaultConfig True Nothing
-        solver <- mkSolver "consumer" consumerDb
-        let consumerLoaded =
-                LoadedDatabase
-                    { ldDatabase = consumerDb
-                    , ldSharedSolver = solver
-                    , ldConfig = consumerConfig (tmp </> "consumer-data")
-                    }
-        atomically $ do
-            modifyTVar' (dmLoadedDbs manager) (M.insert "consumer" consumerLoaded)
-            modifyTVar' (dmIndexedDbs manager) $
-                M.insert "alpha" (buildIndexedDatabaseFromDB "alpha" emptySynonymDB alphaDb)
-                    . M.insert "beta" (buildIndexedDatabaseFromDB "beta" emptySynonymDB betaDb)
+            manager <- initDatabaseManager defaultConfig True Nothing
+            solver <- mkSolver "consumer" consumerDb
+            let consumerLoaded =
+                    LoadedDatabase
+                        { ldDatabase = consumerDb
+                        , ldSharedSolver = solver
+                        , ldConfig = consumerConfig (tmp </> "consumer-data")
+                        }
+            atomically $ do
+                modifyTVar' (dmLoadedDbs manager) (M.insert "consumer" consumerLoaded)
+                modifyTVar' (dmIndexedDbs manager) $
+                    M.insert "alpha" (buildIndexedDatabaseFromDB "alpha" emptySynonymDB alphaDb)
+                        . M.insert "beta" (buildIndexedDatabaseFromDB "beta" emptySynonymDB betaDb)
 
-        result <- relinkDatabase manager "consumer"
-        result `shouldSatisfy` isRight
+            result <- relinkDatabase manager "consumer"
+            result `shouldSatisfy` isRight
 
-        loaded <- readTVarIO (dmLoadedDbs manager)
-        let relinked = ldDatabase (loaded M.! "consumer")
-            linkSources = S.fromList (map cdlSourceDatabase (dbCrossDBLinks relinked))
+            loaded <- readTVarIO (dmLoadedDbs manager)
+            let relinked = ldDatabase (loaded M.! "consumer")
+                linkSources = S.fromList (map cdlSourceDatabase (dbCrossDBLinks relinked))
 
-        -- The pin is preserved exactly — beta is NOT added even though it is
-        -- loaded and is the only supplier of p2.
-        dbDependsOn relinked `shouldBe` ["alpha"]
-        -- Every resolved link points into the pinned DB; beta never leaks in.
-        linkSources `shouldSatisfy` (`S.isSubsetOf` S.fromList ["alpha"])
-        -- p1 resolves against alpha; p2 (beta-only) stays unresolved.
-        length (dbCrossDBLinks relinked) `shouldBe` 1
+            -- The pin is preserved exactly — beta is NOT added even though it is
+            -- loaded and is the only supplier of p2.
+            dbDependsOn relinked `shouldBe` ["alpha"]
+            -- Every resolved link points into the pinned DB; beta never leaks in.
+            linkSources `shouldSatisfy` (`S.isSubsetOf` S.fromList ["alpha"])
+            -- p1 resolves against alpha; p2 (beta-only) stays unresolved.
+            length (dbCrossDBLinks relinked) `shouldBe` 1
 
 -- ---------------------------------------------------------------------------
 -- Helpers
@@ -136,10 +136,11 @@ consumerConfig path =
 -- Fixture builders (in-memory, single unit "kg", all activities at GLO)
 -- ---------------------------------------------------------------------------
 
-data SimpleParts = SimpleParts
-    (M.Map (UUID, UUID) Activity)
-    (M.Map UUID TechnosphereFlow)
-    (M.Map UUID Unit)
+data SimpleParts
+    = SimpleParts
+        (M.Map (UUID, UUID) Activity)
+        (M.Map UUID TechnosphereFlow)
+        (M.Map UUID Unit)
 
 mkUUID :: Int -> UUID
 mkUUID n = UUID.fromWords64 (fromIntegral n) 0
@@ -172,32 +173,32 @@ supplierDB offset products =
                   flowUUID = mkUUID (offset + 10 * i + 3)
                   flow = mkTechFlow flowUUID name
                   refOut =
-                      TechnosphereExchange
-                          { techFlowId = flowUUID
-                          , techAmount = 1.0
-                          , techUnitId = kgUnitId
-                          , techRole = ReferenceProduct
-                          , techActivityLinkId = actUUID
-                          , techProcessLinkId = Nothing
-                          , techLocation = ""
-                          , techComment = Nothing
-                          , techPedigree = Nothing
-                          }
+                    TechnosphereExchange
+                        { techFlowId = flowUUID
+                        , techAmount = 1.0
+                        , techUnitId = kgUnitId
+                        , techRole = ReferenceProduct
+                        , techActivityLinkId = actUUID
+                        , techProcessLinkId = Nothing
+                        , techLocation = ""
+                        , techComment = Nothing
+                        , techPedigree = Nothing
+                        }
                   act =
-                      Activity
-                          { activityName = "supplier-of-" <> name
-                          , activityDescription = []
-                          , activitySynonyms = M.empty
-                          , activityClassification = M.empty
-                          , activityLocation = "GLO"
-                          , activityUnit = "kg"
-                          , exchanges = [refOut]
-                          , activityParams = M.empty
-                          , activityParamExprs = M.empty
-                          , activityAllocationPercent = Nothing
-                          , activityAllocationFormula = Nothing
-                          , activityNativeType = Nothing
-                          }
+                    Activity
+                        { activityName = "supplier-of-" <> name
+                        , activityDescription = []
+                        , activitySynonyms = M.empty
+                        , activityClassification = M.empty
+                        , activityLocation = "GLO"
+                        , activityUnit = "kg"
+                        , exchanges = [refOut]
+                        , activityParams = M.empty
+                        , activityParamExprs = M.empty
+                        , activityAllocationPercent = Nothing
+                        , activityAllocationFormula = Nothing
+                        , activityNativeType = Nothing
+                        }
                in (((actUUID, prodUUID), act), (flowUUID, flow))
             | (i, name) <- zip [0 ..] products
             ]
@@ -220,44 +221,44 @@ consumerDB offset products =
                   inFlow = mkTechFlow inFlowUUID name
                   outFlow = mkTechFlow outFlowUUID ("consumer-out-" <> name)
                   refOut =
-                      TechnosphereExchange
-                          { techFlowId = outFlowUUID
-                          , techAmount = 1.0
-                          , techUnitId = kgUnitId
-                          , techRole = ReferenceProduct
-                          , techActivityLinkId = actUUID
-                          , techProcessLinkId = Nothing
-                          , techLocation = ""
-                          , techComment = Nothing
-                          , techPedigree = Nothing
-                          }
+                    TechnosphereExchange
+                        { techFlowId = outFlowUUID
+                        , techAmount = 1.0
+                        , techUnitId = kgUnitId
+                        , techRole = ReferenceProduct
+                        , techActivityLinkId = actUUID
+                        , techProcessLinkId = Nothing
+                        , techLocation = ""
+                        , techComment = Nothing
+                        , techPedigree = Nothing
+                        }
                   unlinkedInput =
-                      TechnosphereExchange
-                          { techFlowId = inFlowUUID
-                          , techAmount = 1.0
-                          , techUnitId = kgUnitId
-                          , techRole = Input
-                          , techActivityLinkId = UUID.nil
-                          , techProcessLinkId = Nothing
-                          , techLocation = "GLO"
-                          , techComment = Nothing
-                          , techPedigree = Nothing
-                          }
+                    TechnosphereExchange
+                        { techFlowId = inFlowUUID
+                        , techAmount = 1.0
+                        , techUnitId = kgUnitId
+                        , techRole = Input
+                        , techActivityLinkId = UUID.nil
+                        , techProcessLinkId = Nothing
+                        , techLocation = "GLO"
+                        , techComment = Nothing
+                        , techPedigree = Nothing
+                        }
                   act =
-                      Activity
-                          { activityName = "consumer-" <> name
-                          , activityDescription = []
-                          , activitySynonyms = M.empty
-                          , activityClassification = M.empty
-                          , activityLocation = "GLO"
-                          , activityUnit = "kg"
-                          , exchanges = [refOut, unlinkedInput]
-                          , activityParams = M.empty
-                          , activityParamExprs = M.empty
-                          , activityAllocationPercent = Nothing
-                          , activityAllocationFormula = Nothing
-                          , activityNativeType = Nothing
-                          }
+                    Activity
+                        { activityName = "consumer-" <> name
+                        , activityDescription = []
+                        , activitySynonyms = M.empty
+                        , activityClassification = M.empty
+                        , activityLocation = "GLO"
+                        , activityUnit = "kg"
+                        , exchanges = [refOut, unlinkedInput]
+                        , activityParams = M.empty
+                        , activityParamExprs = M.empty
+                        , activityAllocationPercent = Nothing
+                        , activityAllocationFormula = Nothing
+                        , activityNativeType = Nothing
+                        }
                in (((actUUID, prodUUID), act), [(inFlowUUID, inFlow), (outFlowUUID, outFlow)])
             | (i, name) <- zip [0 ..] products
             ]

--- a/versions.env
+++ b/versions.env
@@ -49,6 +49,10 @@ PYTHON_VERSION=3.12
 # Build tool versions (exact versions for reproducible builds)
 # These are checked at build start - mismatches are warnings, not errors
 GHC_VERSION=9.12.4
+# Fourmolu formatter — single source of truth for CI (format.yml), the
+# .githooks/pre-commit hook, and Claude Code's PostToolUse auto-format.
+# Bump in lockstep: fourmolu output changes between versions.
+FOURMOLU_VERSION=0.19.0.1
 # Bump this to force a cabal-store rebuild without changing volca.cabal /
 # mumps-hs.cabal / cabal.project. The CI workflow `prebuild-cabal-store.yml`
 # writes its output to a GH Release tagged


### PR DESCRIPTION
## Why

fourmolu was configured (`fourmolu.yaml`) but nothing enforced it, so `test/` and `bench/` had drifted out of style while `src/`/`app/` stayed clean. This pins the formatter, enforces it in CI, and makes it automatic locally — and adds a tracked `AGENTS.md` so any agent or new contributor finds the build/test commands, module map, and engineering rules in one place.

## What

- **Reformat `test/` + `bench/`** to fourmolu `0.19.0.1` — the whole tree is now clean, so the check is green from the first run.
- **Pin the formatter** in `versions.env` (`FOURMOLU_VERSION`) — one source of truth for CI and the hooks (fourmolu output changes between versions, so they must match).
- **Enforce + automate**:
  - CI (`.github/workflows/format.yml`) fails any PR with unformatted Haskell.
  - A pre-commit hook (`.githooks/pre-commit`) auto-formats staged `.hs`; enable once per clone with `git config core.hooksPath .githooks`.
  - Editors using Claude Code also auto-format on save (`.claude/settings.json`).
- **Agent instructions**: `AGENTS.md` (canonical, tool-agnostic) + a one-line `CLAUDE.md` that imports it.
- **Simplify `.gitignore`**: drop the blanket `*.md` and `.*` rules and their allow-lists so docs and checked-in dot-config are tracked normally; local settings and editor/OS cruft stay ignored.

## Reviewing

Four atomic commits, in order: reformat → gitignore → automation → docs. The first is mechanical (fourmolu only).