### PR TITLE
docs(pyvolca): stop version-dependent drift in the generated API reference

### DIFF
--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -309,6 +309,7 @@ Pyvolca dispatches dynamically against the engine's OpenAPI spec, so it ships wi
 ## API reference
 
 <!-- BEGIN: api-reference -->
+
 _This reference is generated from the installed package. Run `python scripts/gen_api_md.py` to regenerate._
 
 ## Classes
@@ -1332,10 +1333,11 @@ platform triple the binary was compiled for (e.g. ``"x86_64-linux"``).
 
 Replace one supplier with another in the upstream supply chain.
 
-All three fields are process_ids. ``consumer`` identifies which downstream
-consumer's input to rewrite (substitutions are scoped, not global) — the
-same upstream supplier can be replaced by different alternatives in
-different parts of the tree.
+All fields are process_ids. ``consumer`` identifies which downstream
+consumer's input to rewrite, scoping the swap to one edge — the same
+upstream supplier can be replaced by different alternatives in different
+parts of the tree. Omit it (leave ``None``) to apply the swap globally,
+replacing the supplier on every consumer at once.
 
 Frozen so callers can put it in a set / dict key and re-use the same
 substitution across multiple calls without aliasing risk.
@@ -1344,7 +1346,7 @@ substitution across multiple calls without aliasing risk.
 |-------|------|---------|
 | `from_pid` | `str` | — |
 | `to_pid` | `str` | — |
-| `consumer` | `str` | — |
+| `consumer` | `str \| None` | None |
 
 ### `SupplyChain`
 
@@ -1479,6 +1481,7 @@ Returns:
 ### `Exchange`
 
 Type alias: `Union[TechnosphereExchange, BiosphereExchange, WasteExchange]`.
+
 <!-- END: api-reference -->
 
 ## See also

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -322,8 +322,6 @@ How values are reduced within a bucket.
 matching entries. ``SHARE`` — each bucket's percentage of the filtered
 total (0..100).
 
-**Constructor**: `AggregateOp(*values)`
-
 ### `AggregateScope`
 
 What the ``/aggregate`` primitive groups over.
@@ -332,16 +330,12 @@ What the ``/aggregate`` primitive groups over.
 upstream activities reachable via cumulative flow. ``BIOSPHERE`` — only
 biosphere flows in the supply chain.
 
-**Constructor**: `AggregateScope(*values)`
-
 ### `BioDirection`
 
 Direction of a biosphere exchange.
 
 ``RESOURCE`` — extraction from the environment (input).
 ``EMISSION`` — release to the environment (output).
-
-**Constructor**: `BioDirection(*values)`
 
 ### `Client`
 
@@ -659,8 +653,6 @@ not be resolved against currently-loaded dependencies.
 Inherits from :class:`str`, so ``dataclasses.asdict(db)["status"]``
 serialises as the bare wire string.
 
-**Constructor**: `DatabaseStatus(*values)`
-
 ### `MatchMode`
 
 How a :class:`ClassificationFilter` value is compared against the entry.
@@ -669,8 +661,6 @@ How a :class:`ClassificationFilter` value is compared against the entry.
 substring. Inherits from :class:`str` so ``json.dumps(MatchMode.EXACT)``
 and ``dataclasses.asdict(filter)["mode"]`` both serialise as the bare
 string ``"exact"`` / ``"contains"``.
-
-**Constructor**: `MatchMode(*values)`
 
 ### `Server`
 
@@ -722,8 +712,6 @@ Role a technosphere exchange plays within its host activity.
 ``COPRODUCT`` — a secondary output (in allocated activities).
 ``REFERENCE_INPUT`` — the reference input (in waste-treatment activities).
 ``INPUT`` — any other technosphere input.
-
-**Constructor**: `TechRole(*values)`
 
 ## Exceptions
 

--- a/pyvolca/scripts/gen_api_md.py
+++ b/pyvolca/scripts/gen_api_md.py
@@ -15,6 +15,7 @@ Stdlib only — pyvolca's only dependency stays ``requests``.
 from __future__ import annotations
 
 import dataclasses
+import enum
 import inspect
 import io
 import sys
@@ -149,11 +150,16 @@ def render_class(cls: type, buf: io.StringIO) -> None:
     cls_doc = inspect.getdoc(cls)
     if cls_doc:
         buf.write(cls_doc + "\n\n")
-    try:
-        init_sig = _format_signature(inspect.signature(cls))
-        buf.write(f"**Constructor**: `{cls.__name__}{init_sig}`\n\n")
-    except (TypeError, ValueError):
-        pass
+    # Enum members are referenced as ``Cls.MEMBER``, never constructed, and
+    # their introspected constructor signature is Python-version-dependent
+    # (``EnumMeta.__call__`` on ≤3.11, ``(*values)`` on 3.12+), so it only adds
+    # noise and spurious regeneration diffs.
+    if not issubclass(cls, enum.Enum):
+        try:
+            init_sig = _format_signature(inspect.signature(cls))
+            buf.write(f"**Constructor**: `{cls.__name__}{init_sig}`\n\n")
+        except (TypeError, ValueError):
+            pass
     methods, properties = _public_members(cls)
     if properties:
         buf.write("#### Properties\n\n")

--- a/pyvolca/scripts/gen_api_md.py
+++ b/pyvolca/scripts/gen_api_md.py
@@ -1,23 +1,28 @@
 #!/usr/bin/env python3
 """Generate the pyvolca API reference as markdown.
 
-Walks every name in ``volca.__all__`` and emits a structured reference.
-The output is appended to README.md (between BEGIN/END markers) so PyPI
-sees it, and also written as a standalone artifact under
-``www/generated/pyvolca/`` so the Starlight guide can pull it in.
+Walks every name in ``volca.__all__`` and emits a structured reference,
+spliced into README.md between the api-reference markers so PyPI sees the
+full package reference. The same body is also written as a standalone
+artifact under ``www/generated/pyvolca/`` so the Starlight guide can pull
+it in.
 
 Usage:
-    python scripts/gen_api_md.py        # writes to stdout
+    python scripts/gen_api_md.py            # write the reference block to stdout
+    python scripts/gen_api_md.py --write    # splice it into README.md in place
+    python scripts/gen_api_md.py --check    # exit non-zero if README.md is stale
 
 Stdlib only — pyvolca's only dependency stays ``requests``.
 """
 
 from __future__ import annotations
 
+import argparse
 import dataclasses
 import enum
 import inspect
 import io
+import re
 import sys
 import typing
 from pathlib import Path
@@ -27,6 +32,12 @@ ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "src"))
 
 import volca  # noqa: E402
+
+# The README hosts the generated reference between these markers; the
+# generator owns the splice so the on-disk copy can't drift from the source.
+README = ROOT / "README.md"
+BEGIN_MARKER = "<!-- BEGIN: api-reference -->"
+END_MARKER = "<!-- END: api-reference -->"
 
 
 def _first_line(doc: str | None) -> str:
@@ -244,7 +255,8 @@ def categorize(name: str) -> tuple[str, object]:
     return "alias", value
 
 
-def main() -> int:
+def render_reference() -> str:
+    """Render the full api-reference block as markdown (no surrounding markers)."""
     buf = io.StringIO()
     buf.write(
         "_This reference is generated from the installed package. "
@@ -295,7 +307,54 @@ def main() -> int:
         for name, alias in aliases:
             render_alias(name, alias, buf)
 
-    sys.stdout.write(buf.getvalue())
+    return buf.getvalue()
+
+
+def splice_readme(readme_text: str, body: str) -> str:
+    """Replace the api-reference block between the markers with ``body``.
+
+    Pure: returns the rewritten text and raises ``ValueError`` if the markers
+    are missing (a corrupt README must fail loudly, never silently no-op).
+    """
+    pattern = re.compile(
+        re.escape(BEGIN_MARKER) + r".*?" + re.escape(END_MARKER), re.DOTALL
+    )
+    if pattern.search(readme_text) is None:
+        raise ValueError(f"{BEGIN_MARKER} / {END_MARKER} markers missing from README")
+    replacement = f"{BEGIN_MARKER}\n\n{body.rstrip()}\n\n{END_MARKER}"
+    return pattern.sub(lambda _m: replacement, readme_text)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate the pyvolca API reference.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--write", action="store_true", help="splice the reference into README.md in place"
+    )
+    mode.add_argument(
+        "--check",
+        action="store_true",
+        help="exit non-zero if README.md's reference block is stale (no write)",
+    )
+    ns = parser.parse_args(argv)
+
+    body = render_reference()
+    if not (ns.write or ns.check):
+        sys.stdout.write(body)
+        return 0
+
+    current = README.read_text(encoding="utf-8")
+    updated = splice_readme(current, body)
+    if ns.check:
+        if updated != current:
+            sys.stderr.write(
+                "README.md api-reference block is stale — run "
+                "`python scripts/gen_api_md.py --write` and commit the result.\n"
+            )
+            return 1
+        return 0
+    if updated != current:
+        README.write_text(updated, encoding="utf-8")
     return 0
 
 

--- a/pyvolca/tests/test_api_reference_drift.py
+++ b/pyvolca/tests/test_api_reference_drift.py
@@ -1,0 +1,29 @@
+"""The README api-reference block must stay in sync with the generator.
+
+``scripts/gen_api_md.py`` produces the block; this test asserts the committed
+README already reflects that output, so a stale block — or a reintroduced
+version-dependent signature — fails CI instead of silently shipping. Pure
+Python introspection: no engine binary required.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+# The generator lives in scripts/, outside the importable package, so load it
+# by path rather than via a regular import.
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "gen_api_md.py"
+_spec = importlib.util.spec_from_file_location("gen_api_md", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+gen_api_md = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gen_api_md)
+
+
+def test_readme_api_reference_in_sync() -> None:
+    readme = gen_api_md.README.read_text(encoding="utf-8")
+    expected = gen_api_md.splice_readme(readme, gen_api_md.render_reference())
+    assert expected == readme, (
+        "pyvolca/README.md api-reference block is stale. Run "
+        "`python scripts/gen_api_md.py --write` and commit the result."
+    )


### PR DESCRIPTION
The generated pyvolca API reference drifts on every regeneration depending on which Python interpreter runs the generator: `inspect.signature()` on an `Enum` subclass returns `EnumMeta.__call__`'s long parameter list on Python ≤3.11 but `(*values)` on 3.12+. That left builds with a dirty working tree and spurious diffs each time the docs were regenerated.

**Fix** (`scripts/gen_api_md.py`): skip the `**Constructor**` line for `Enum` subclasses. Enum members are referenced as `Cls.MEMBER` and never constructed, so the line carried no useful information — and removing it makes the output interpreter-independent.

**Also** (first commit): the README's embedded reference had lagged the global-substitution change — the substitution edge's `consumer` field is now optional (`str | None`). Regenerated to resync with the current source.

Regeneration is idempotent after this change. Split into two atomic commits: the source-resync, then the generator fix.