### PR TITLE
Scope per-method CF caches by collection

### DIFF
--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -5,7 +5,7 @@ Implements Streamable HTTP transport (MCP spec 2025-03-26).
 POST /mcp handles initialize, tools/list, tools/call (JSON or SSE response).
 GET  /mcp opens an SSE stream for server-initiated messages (stateless: closes immediately).
 -}
-module API.MCP (mcpApp, toolDefinitions) where
+module API.MCP (mcpApp, toolDefinitions, selectMethod) where
 
 import Control.Concurrent.STM (readTVarIO)
 import Data.Aeson
@@ -52,7 +52,7 @@ import qualified Service
 import qualified Service.Aggregate as Agg
 import SharedSolver (SharedSolver, computeInventoryMatrixWithDepsCached, crossDBProcessContributions)
 import qualified SharedSolver
-import Types (Activity (..), BioFlowDB, BiosphereFlow (..), Database (..), Indexes (..), ProcessId, UnitDB, activityLocation, activityName, bfCompartmentName, bfCompartmentSub, exchangeIsInput, getUnitNameForBioFlow, isTechnosphereExchange, processIdToText, unresolvedCount)
+import Types (Activity (..), BioFlowDB, BiosphereFlow (..), Database (..), Indexes (..), ProcessId, UUID, UnitDB, activityLocation, activityName, bfCompartmentName, bfCompartmentSub, exchangeIsInput, getUnitNameForBioFlow, isTechnosphereExchange, processIdToText, unresolvedCount)
 import UnitConversion (defaultUnitConfig)
 
 -- ---------------------------------------------------------------------------
@@ -1231,12 +1231,14 @@ subArgs suffix args = do
     db <- requireSide "database"
     pid <- requireSide "process_id"
     method <- requireSide "method_id"
+    mCol <- optionalText ("collection" <> suffix) args
     pure $
-        KM.fromList
+        KM.fromList $
             [ (fromText "database", String db)
             , (fromText "process_id", String pid)
             , (fromText "method_id", String method)
             ]
+                <> foldMap (\c -> [(fromText "collection", String c)]) mCol
   where
     requireSide key =
         let suffixed = key <> suffix
@@ -1262,9 +1264,9 @@ callListMethods dbManager rid = do
 
 callGetFlowMapping :: DatabaseManager -> Value -> KeyMap Value -> IO Value
 callGetFlowMapping dbManager rid args = runTool rid $ do
-    (dbName, methodIdText) <- except $ (,) <$> requireText "database" args <*> requireText "method_id" args
+    (dbName, methodIdText, mCol) <- except $ (,,) <$> requireText "database" args <*> requireText "method_id" args <*> optionalText "collection" args
     ld <- requireDatabase dbManager dbName
-    (collection, method) <- ExceptT (resolveMethod dbManager methodIdText)
+    (collection, method) <- ExceptT (resolveMethod dbManager mCol methodIdText)
     let db = ldDatabase ld
     mappings <- liftIO $ DM.mapMethodToFlowsCached dbManager dbName collection db method
     let stats = computeMappingStats mappings
@@ -1372,9 +1374,9 @@ buildUnmatchedDbFlows dbManager dbName collection db method args maxN =
 
 callGetCharacterization :: DatabaseManager -> Value -> KeyMap Value -> IO Value
 callGetCharacterization dbManager rid args = runTool rid $ do
-    (dbName, methodIdText) <- except $ (,) <$> requireText "database" args <*> requireText "method_id" args
+    (dbName, methodIdText, mCol) <- except $ (,,) <$> requireText "database" args <*> requireText "method_id" args <*> optionalText "collection" args
     ld <- requireDatabase dbManager dbName
-    (collection, method) <- ExceptT (resolveMethod dbManager methodIdText)
+    (collection, method) <- ExceptT (resolveMethod dbManager mCol methodIdText)
     let db = ldDatabase ld
         lim = fromMaybe 20 (intArg "limit" args)
         flowQ = textArg "flow" args
@@ -1471,16 +1473,52 @@ mkMcpCrossDBEntry dbManager rootDbName mBaseUrl colName methodIdText flowDB unit
             ]
                 ++ webUrlPair
 
--- | Helper: resolve method from UUID text, also returning its collection name
-resolveMethod :: DatabaseManager -> Text -> IO (Either Text (Text, Method))
-resolveMethod dbManager methodIdText =
+{- | Choose the (collection, method) for a UUID from the loaded set, optionally
+restricted to a named collection. A method's engine UUID is a UUIDv5 of its
+name, so the *same* UUID can be loaded under several collections (e.g. two EF
+3.1 versions). Resolving must therefore be loud, not first-match:
+
+  * @Just c@   — resolve within collection @c@; a UUID is unique inside one
+                 collection, so this is unambiguous (or a not-found error).
+  * @Nothing@  — infer. One match resolves; more than one is reported as an
+                 error listing the collections to choose from, rather than
+                 silently picking whichever loaded first.
+
+Pure so the disambiguation is total and testable without a 'DatabaseManager'.
+-}
+selectMethod :: Maybe Text -> UUID -> [(Text, Method)] -> Either Text (Text, Method)
+selectMethod mCollection uuid loaded =
+    case filter keep loaded of
+        [] -> Left notFound
+        [hit] -> Right hit
+        hit : _ -> maybe (Left ambiguous) (const (Right hit)) mCollection
+  where
+    keep (col, m) = methodId m == uuid && maybe True (== col) mCollection
+    uuidText = UUID.toText uuid
+    notFound = case mCollection of
+        Nothing -> "Method not found: " <> uuidText
+        Just c ->
+            "Method "
+                <> uuidText
+                <> " not found in collection '"
+                <> c
+                <> "'. Loaded collections: "
+                <> T.intercalate ", " (L.nub (map fst loaded))
+    ambiguous =
+        "Method UUID "
+            <> uuidText
+            <> " is loaded in multiple collections: "
+            <> T.intercalate ", " (L.nub [col | (col, m) <- loaded, methodId m == uuid])
+            <> ". Pass 'collection' to disambiguate."
+
+{- | Resolve a method UUID (raw text) to its collection name and 'Method',
+optionally pinned to a collection. Thin IO edge over 'selectMethod'.
+-}
+resolveMethod :: DatabaseManager -> Maybe Text -> Text -> IO (Either Text (Text, Method))
+resolveMethod dbManager mCollection methodIdText =
     case UUID.fromText methodIdText of
         Nothing -> return $ Left "Invalid method UUID format"
-        Just uuid -> do
-            loadedMethods <- DM.getLoadedMethods dbManager
-            case filter (\(_, m) -> methodId m == uuid) loadedMethods of
-                [] -> return $ Left "Method not found"
-                ((col, m) : _) -> return $ Right (col, m)
+        Just uuid -> selectMethod mCollection uuid <$> DM.getLoadedMethods dbManager
 
 {- | Raw text + its parsed 'ProcessId' + the looked-up 'Activity'. Bundled so
 the three entities (which must always agree) cannot drift apart: the only
@@ -1512,14 +1550,15 @@ unknown method, unresolvable process id).
 -}
 loadLcaRequest :: DatabaseManager -> KeyMap Value -> ExceptT Text IO LcaRequest
 loadLcaRequest dbManager args = do
-    (dbName, pidText, methodIdText) <-
+    (dbName, pidText, methodIdText, mCol) <-
         except $
-            (,,)
+            (,,,)
                 <$> requireText "database" args
                 <*> requireText "process_id" args
                 <*> requireText "method_id" args
+                <*> optionalText "collection" args
     ld <- requireDatabase dbManager dbName
-    (col, method) <- ExceptT (resolveMethod dbManager methodIdText)
+    (col, method) <- ExceptT (resolveMethod dbManager mCol methodIdText)
     (pid, act) <- liftShow (Service.resolveActivityAndProcessId (ldDatabase ld) pidText)
     pure
         LcaRequest

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -914,6 +914,7 @@ runImpactsRequest dbManager args req = do
         db = ldDatabase ld
         method = lrMethod req
         dbName = lrDbName req
+        collection = lrCollection req
         ra = lrResolved req
     except $ ensureLinked dbName "computing impacts" db
     subs <- except (parseArrayArg "substitutions" Nothing args :: Either Text [Substitution])
@@ -933,8 +934,8 @@ runImpactsRequest dbManager args req = do
                             (ldSharedSolver ld)
                             (raPid ra)
                             subs
-    mappings <- liftIO $ DM.mapMethodToFlowsCached dbManager dbName db method
-    tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName db method
+    mappings <- liftIO $ DM.mapMethodToFlowsCached dbManager dbName collection db method
+    tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName collection db method
     let stats = computeMappingStats mappings
         baseOutcome = computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables
         (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
@@ -946,7 +947,7 @@ runImpactsRequest dbManager args req = do
     outcome <-
         if fromMaybe False (boolArg "include_diagnostics" args)
             then do
-                idx <- liftIO $ DM.mapMethodToIndexCached dbManager dbName method
+                idx <- liftIO $ DM.mapMethodToIndexCached dbManager dbName collection method
                 let opts = defaultUncharacterizedOpts
                     diagnostics =
                         Mapping.findUncharacterized
@@ -1060,6 +1061,7 @@ callComputeSensitivity dbManager mBaseUrl rid args =
             db = ldDatabase ld
             method = lrMethod req
             dbName = lrDbName req
+            collection = lrCollection req
             ra = lrResolved req
         except $ ensureLinked dbName "computing sensitivity" db
         perts <-
@@ -1073,7 +1075,7 @@ callComputeSensitivity dbManager mBaseUrl rid args =
                     )
         unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
         (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
-        tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName db method
+        tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName collection db method
         hier <- liftIO $ DM.getLocationHierarchy dbManager
         eRes <-
             liftIO $
@@ -1262,9 +1264,9 @@ callGetFlowMapping :: DatabaseManager -> Value -> KeyMap Value -> IO Value
 callGetFlowMapping dbManager rid args = runTool rid $ do
     (dbName, methodIdText) <- except $ (,) <$> requireText "database" args <*> requireText "method_id" args
     ld <- requireDatabase dbManager dbName
-    (_, method) <- ExceptT (resolveMethod dbManager methodIdText)
+    (collection, method) <- ExceptT (resolveMethod dbManager methodIdText)
     let db = ldDatabase ld
-    mappings <- liftIO $ DM.mapMethodToFlowsCached dbManager dbName db method
+    mappings <- liftIO $ DM.mapMethodToFlowsCached dbManager dbName collection db method
     let stats = computeMappingStats mappings
         total = msTotal stats
         matched = total - msUnmatched stats
@@ -1290,7 +1292,7 @@ callGetFlowMapping dbManager rid args = runTool rid $ do
                                 ]
                             | (cf, Nothing) <- mappings
                             ]
-                unmatchedFlows <- liftIO $ buildUnmatchedDbFlows dbManager dbName db method args maxUnm
+                unmatchedFlows <- liftIO $ buildUnmatchedDbFlows dbManager dbName collection db method args maxUnm
                 pure
                     [ "unmatched_cfs" .= unmatchedCFs
                     , "unmatched_db_flows" .= unmatchedFlows
@@ -1319,12 +1321,13 @@ process-scoped view turns out to be insufficient in practice.
 buildUnmatchedDbFlows ::
     DatabaseManager ->
     Text ->
+    Text ->
     Database ->
     Method ->
     KeyMap Value ->
     Int ->
     IO [Value]
-buildUnmatchedDbFlows dbManager dbName db method args maxN =
+buildUnmatchedDbFlows dbManager dbName collection db method args maxN =
     case textArg "process_id" args of
         Nothing -> pure [] -- caller didn't pin a process; nothing actionable to rank by
         Just pidText -> do
@@ -1348,8 +1351,8 @@ buildUnmatchedDbFlows dbManager dbName db method args maxN =
                             Left _ -> pure []
                             Right sol -> do
                                 let inventory = SharedSolver.csInventory sol
-                                tables <- DM.mapMethodToTablesCached dbManager dbName db method
-                                idx <- DM.mapMethodToIndexCached dbManager dbName method
+                                tables <- DM.mapMethodToTablesCached dbManager dbName collection db method
+                                idx <- DM.mapMethodToIndexCached dbManager dbName collection method
                                 let opts =
                                         defaultUncharacterizedOpts
                                             { Mapping.uoMaxFlows = maxN
@@ -1371,12 +1374,12 @@ callGetCharacterization :: DatabaseManager -> Value -> KeyMap Value -> IO Value
 callGetCharacterization dbManager rid args = runTool rid $ do
     (dbName, methodIdText) <- except $ (,) <$> requireText "database" args <*> requireText "method_id" args
     ld <- requireDatabase dbManager dbName
-    (_, method) <- ExceptT (resolveMethod dbManager methodIdText)
+    (collection, method) <- ExceptT (resolveMethod dbManager methodIdText)
     let db = ldDatabase ld
         lim = fromMaybe 20 (intArg "limit" args)
         flowQ = textArg "flow" args
         queryLower = fmap T.toLower flowQ
-    mappings <- liftIO $ DM.mapMethodToFlowsCached dbManager dbName db method
+    mappings <- liftIO $ DM.mapMethodToFlowsCached dbManager dbName collection db method
     let matched =
             [ (cf, f, strat)
             | (cf, Just (f, strat)) <- mappings
@@ -1554,6 +1557,7 @@ callGetContributingFlows dbManager mBaseUrl rid args =
             db = ldDatabase ld
             method = lrMethod req
             dbName = lrDbName req
+            collection = lrCollection req
             ra = lrResolved req
             lim = fromMaybe 20 (intArg "limit" args)
             webUrlPair = webUrlField mBaseUrl ("/db/" <> dbName <> "/activity/" <> raText ra <> "/contributing-flows/" <> encodeSegment (lrCollection req) <> "/" <> lrMethodIdText req)
@@ -1570,7 +1574,7 @@ callGetContributingFlows dbManager mBaseUrl rid args =
                     (ldSharedSolver ld)
                     (raPid ra)
         let inventory = SharedSolver.csInventory sol
-        tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName db method
+        tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName collection db method
         let outcome = computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables
             score = loScore outcome
             (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
@@ -1580,7 +1584,7 @@ callGetContributingFlows dbManager mBaseUrl rid args =
         diagnosticsFields <-
             if fromMaybe False (boolArg "include_diagnostics" args)
                 then do
-                    idx <- liftIO $ DM.mapMethodToIndexCached dbManager dbName method
+                    idx <- liftIO $ DM.mapMethodToIndexCached dbManager dbName collection method
                     let opts = defaultUncharacterizedOpts
                         uncharacterized =
                             Mapping.findUncharacterized
@@ -1641,12 +1645,13 @@ callGetContributingActivities dbManager mBaseUrl rid args =
             db = ldDatabase ld
             method = lrMethod req
             dbName = lrDbName req
+            collection = lrCollection req
             ra = lrResolved req
             lim = fromMaybe 10 (intArg "limit" args)
         except $ ensureLinked dbName "computing contributions" db
         unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
         (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
-        tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName db method
+        tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName collection db method
         -- Skip separate inventory compute: contributions sum equals the score.
         contributions <-
             ExceptT $

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -432,6 +432,23 @@ pProcessId =
 pMethodId :: Param
 pMethodId = Param "method_id" "string" Required "Method UUID"
 
+{- | Optional collection disambiguator for the @method_id@-only tools. A method
+UUID is a hash of its name, so the same UUID can be loaded under several
+collections (e.g. two EF 3.1 versions). Only needed then: with a single match
+the collection is inferred, and an ambiguous UUID fails loudly listing the
+collections to choose from.
+-}
+pCollection :: Param
+pCollection =
+    Param
+        "collection"
+        "string"
+        Optional
+        "Method collection name (from list_methods). Only needed when the same \
+        \method UUID is loaded in more than one collection (e.g. two EF 3.1 \
+        \versions); otherwise the single match is used, and an ambiguous UUID \
+        \fails with the list of collections to choose from."
+
 pLimit :: Text -> Param
 pLimit = Param "limit" "integer" Optional
 
@@ -565,6 +582,7 @@ params r = case r of
         [ pDatabase
         , pProcessId
         , pMethodId
+        , pCollection
         , Param "top_flows" "integer" Optional "Number of top contributing flows to return (default 5)"
         , pSubstitutions
         , Param "include_diagnostics" "boolean" Optional "When true, surface uncharacterized inventory flows above 0.1% of total |qty|, each with up to 3 candidate similar CFs (PubChem-expanded Jaccard + CAS bridge). Lets reviewers tell genuine method gaps from mapping bugs."
@@ -573,6 +591,7 @@ params r = case r of
         [ pDatabase
         , pProcessId
         , pMethodId
+        , pCollection
         , Param
             "perturbations"
             "array"
@@ -589,6 +608,7 @@ params r = case r of
     GetFlowMapping ->
         [ pDatabase
         , pMethodId
+        , pCollection
         , Param "verbose" "boolean" Optional "When true, return per-CF and per-flow detail beyond the coverage stats: an unmatched_cfs list (CFs with no DB flow), and an unmatched_db_flows list ranked by inventory contribution to a chosen process when process_id is set."
         , Param "process_id" "string" Optional "Required for the unmatched_db_flows ranking: ranks unmatched flows by their share of this process's inventory."
         , Param "max_unmatched" "integer" Optional "Cap on each unmatched list (default 50)"
@@ -596,6 +616,7 @@ params r = case r of
     GetCharacterization ->
         [ pDatabase
         , pMethodId
+        , pCollection
         , Param "flow" "string" Optional "Filter by flow name (case-insensitive substring, matches both method CF name and database flow name)"
         , pLimit "Max results (default 20)"
         ]
@@ -603,6 +624,7 @@ params r = case r of
         [ pDatabase
         , pProcessId
         , Param "method_id" "string" Required "Method UUID for the impact category"
+        , pCollection
         , pLimit "Max flows to return, sorted by contribution (default 20)"
         , Param "include_diagnostics" "boolean" Optional "When true, surface uncharacterized inventory flows above 0.1% of total |qty|, each with up to 3 candidate similar CFs (PubChem-expanded Jaccard + CAS bridge)."
         ]
@@ -610,6 +632,7 @@ params r = case r of
         [ pDatabase
         , pProcessId
         , Param "method_id" "string" Required "Method UUID for the impact category"
+        , pCollection
         , pLimit "Max processes to return, sorted by contribution (default 10)"
         ]
     ListGeographies ->
@@ -642,9 +665,11 @@ params r = case r of
         [ Param "database_a" "string" Required "First database name"
         , Param "process_id_a" "string" Required "Process ID in database_a (activityUUID_productUUID format)"
         , Param "method_id_a" "string" Required "Method UUID for the A side"
+        , Param "collection_a" "string" Optional "Method collection for the A side; needed only when method_id_a is loaded in more than one collection."
         , Param "database_b" "string" Required "Second database name"
         , Param "process_id_b" "string" Required "Process ID in database_b (activityUUID_productUUID format)"
         , Param "method_id_b" "string" Required "Method UUID for the B side"
+        , Param "collection_b" "string" Optional "Method collection for the B side; needed only when method_id_b is loaded in more than one collection."
         , Param "top_flows" "integer" Optional "Per-side flow drill-down depth (default 10)"
         ]
     ScoreActivity ->

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -537,13 +537,14 @@ solution. Cache-keyed by (dbName, methods).
 -}
 buildPerDbSetTables ::
     DatabaseManager ->
+    Text ->
     NE.NonEmpty (Text, Database, Vector) ->
     [Method] ->
     IO (NE.NonEmpty (Database, Vector, Method.Mapping.MethodSetTables))
-buildPerDbSetTables dbManager scalings methods =
+buildPerDbSetTables dbManager collection scalings methods =
     traverse
         ( \(n, d, sv) -> do
-            mst <- DM.mapMethodSetToTablesCached dbManager n d methods
+            mst <- DM.mapMethodSetToTablesCached dbManager n collection d methods
             pure (d, sv, mst)
         )
         scalings
@@ -554,12 +555,13 @@ single dense matvec (non-regional) plus per-method passes (regional).
 batchedScoresFor ::
     DatabaseManager ->
     Text ->
+    Text ->
     Database ->
     SharedSolver.CrossDBSolution ->
     [Method] ->
     IO (M.Map UUID (Either Text Double))
-batchedScoresFor dbManager _dbName _db sol methods = do
-    perDb <- buildPerDbSetTables dbManager (SharedSolver.csScalings sol) methods
+batchedScoresFor dbManager _dbName collection _db sol methods = do
+    perDb <- buildPerDbSetTables dbManager collection (SharedSolver.csScalings sol) methods
     unitCfg <- getMergedUnitConfig dbManager
     (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
     hier <- DM.getLocationHierarchy dbManager
@@ -576,10 +578,10 @@ batchedScoresFor dbManager _dbName _db sol methods = do
 {- | Pre-warm per-(db, method) cached tables so subsequent 'batchedScoresFor'
 and 'inventoryContributions' calls hit a warm cache.
 -}
-prepMethodCtx :: DatabaseManager -> Text -> Database -> Method -> IO MethodCtx
-prepMethodCtx dbManager dbName db method = do
-    mappings <- DM.mapMethodToFlowsCached dbManager dbName db method
-    _ <- DM.mapMethodToTablesCached dbManager dbName db method
+prepMethodCtx :: DatabaseManager -> Text -> Text -> Database -> Method -> IO MethodCtx
+prepMethodCtx dbManager dbName collection db method = do
+    mappings <- DM.mapMethodToFlowsCached dbManager dbName collection db method
+    _ <- DM.mapMethodToTablesCached dbManager dbName collection db method
     let stats = computeMappingStats mappings
     pure MethodCtx{mctxMethod = method, mctxMappedFlows = msTotal stats - msUnmatched stats}
 
@@ -590,6 +592,7 @@ when a batched matvec result is already available.
 computeCategoryResult ::
     DatabaseManager ->
     Text ->
+    Text ->
     Database ->
     SharedSolver.CrossDBSolution ->
     Activity ->
@@ -597,11 +600,11 @@ computeCategoryResult ::
     Maybe (Either Text Double) ->
     Method ->
     IO LCIAResult
-computeCategoryResult dbManager dbName db sol activity topFlows precomputedScore method = do
+computeCategoryResult dbManager dbName collection db sol activity topFlows precomputedScore method = do
     unitCfg <- getMergedUnitConfig dbManager
     (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
-    mappings <- DM.mapMethodToFlowsCached dbManager dbName db method
-    tables <- DM.mapMethodToTablesCached dbManager dbName db method
+    mappings <- DM.mapMethodToFlowsCached dbManager dbName collection db method
+    tables <- DM.mapMethodToTablesCached dbManager dbName collection db method
     let inventory = SharedSolver.csInventory sol
     let stats = computeMappingStats mappings
     score <- case precomputedScore of
@@ -617,7 +620,7 @@ computeCategoryResult dbManager dbName db sol activity topFlows precomputedScore
                     hier <- DM.getLocationHierarchy dbManager
                     perDb <-
                         forM (NE.toList (SharedSolver.csScalings sol)) $ \(n, d, sv) -> do
-                            tbls <- DM.mapMethodToTablesCached dbManager n d method
+                            tbls <- DM.mapMethodToTablesCached dbManager n collection d method
                             pure (d, sv, tbls)
                     case sumRegionalizedLCIAScoreCrossDB unitCfg mUnits mFlows hier perDb of
                         Right s -> evaluate s
@@ -674,6 +677,7 @@ walk is skipped; when >0, runs 'inventoryContributions' per method.
 buildLCIABatchResultCached ::
     DatabaseManager ->
     Text ->
+    Text ->
     Database ->
     ProcessId ->
     Activity ->
@@ -682,7 +686,7 @@ buildLCIABatchResultCached ::
     [MethodCtx] ->
     Int ->
     IO LCIABatchResult
-buildLCIABatchResultCached dbManager dbName db actPid activity collection sol ctxs topFlows = do
+buildLCIABatchResultCached dbManager dbName collectionName db actPid activity collection sol ctxs topFlows = do
     let damageCats = mcDamageCategories collection
         nwSets = mcNormWeightSets collection
         dcLookup =
@@ -694,7 +698,7 @@ buildLCIABatchResultCached dbManager dbName db actPid activity collection sol ct
         mNW = case nwSets of (nw : _) -> Just nw; [] -> Nothing
         methods = map mctxMethod ctxs
         inventory = SharedSolver.csInventory sol
-    scoreMap <- batchedScoresFor dbManager dbName db sol methods
+    scoreMap <- batchedScoresFor dbManager dbName collectionName db sol methods
     (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
     let unknownUuids =
             [ fid
@@ -733,7 +737,7 @@ buildLCIABatchResultCached dbManager dbName db actPid activity collection sol ct
             topContributors <- case mUnitCfg of
                 Nothing -> pure []
                 Just unitCfg -> do
-                    tables <- DM.mapMethodToTablesCached dbManager dbName db method
+                    tables <- DM.mapMethodToTablesCached dbManager dbName collectionName db method
                     let (rawContribs, _unknownUuids) =
                             inventoryContributions unitCfg mUnits mFlows inventory tables
                         sorted = sortOn (\(_, _, c) -> negate (abs c)) rawContribs
@@ -807,11 +811,11 @@ activityLCIABatchH dbName processIdText collectionName mSub = do
             when (invSize > 0 && invSize <= 5) $
                 reportProgress Info $
                     "  Inventory UUIDs: " <> intercalate ", " (map UUID.toString $ M.keys inventory)
-    scoreMap <- liftIO $ batchedScoresFor dbManager dbName db sol methods
+    scoreMap <- liftIO $ batchedScoresFor dbManager dbName collectionName db sol methods
     rawResults <-
         liftIO $
             mapConcurrently
-                (\m -> computeCategoryResult dbManager dbName db sol activity 5 (M.lookup (methodId m) scoreMap) m)
+                (\m -> computeCategoryResult dbManager dbName collectionName db sol activity 5 (M.lookup (methodId m) scoreMap) m)
                 methods
     let results = map (enrichWithNW dcLookup mNW) rawResults
         rawScoreMap = M.fromList [(lrCategory r, lrScore r) | r <- rawResults]
@@ -862,10 +866,10 @@ batchImpactsH dbName collectionName topFlowsParam req = do
     t0 <- liftIO getCurrentTime
     sols <- solutionsWithDeps dbName db sharedSolver validPidNums
     t1 <- liftIO getCurrentTime
-    ctxs <- liftIO $ mapConcurrently (prepMethodCtx dbManager dbName db) (mcMethods collection)
+    ctxs <- liftIO $ mapConcurrently (prepMethodCtx dbManager dbName collectionName db) (mcMethods collection)
     let topFlows = max 0 (fromMaybe 0 topFlowsParam)
     let mkEntry ((pidText, pidNum, activity), sol) = do
-            impacts <- buildLCIABatchResultCached dbManager dbName db pidNum activity collection sol ctxs topFlows
+            impacts <- buildLCIABatchResultCached dbManager dbName collectionName db pidNum activity collection sol ctxs topFlows
             pure
                 BatchImpactsEntry
                     { bieProcessId = pidText
@@ -1012,29 +1016,48 @@ cfToAPI cf =
 -- AppM helpers
 -- ---------------------------------------------------------------------------
 
--- | Lookup a method by UUID across all loaded collections.
-loadMethodByUUID :: Text -> AppM Method
+{- | Lookup a method by UUID across all loaded collections, returning the
+collection name it was found in alongside the method. The collection name is
+needed to key the per-method CF caches (a UUID alone collides across
+collections that share a method name). First-match on ambiguity, mirroring
+'API.MCP.resolveMethod'.
+-}
+loadMethodByUUID :: Text -> AppM (Text, Method)
 loadMethodByUUID uuidText = do
     dbManager <- asks aeDbManager
     loadedMethods <- liftIO $ DM.getLoadedMethods dbManager
-    let allMethods = map snd loadedMethods
     case UUID.fromText uuidText of
         Nothing -> throwError err400{errBody = "Invalid method UUID format"}
         Just uuid ->
-            case filter (\m -> methodId m == uuid) allMethods of
-                (m : _) -> return m
+            case filter (\(_, m) -> methodId m == uuid) loadedMethods of
+                ((col, m) : _) -> return (col, m)
                 [] -> throwError err404{errBody = "Method not found"}
 
--- | Resolve (db, solver, ProcessId, Activity, Method) and dispatch.
+{- | Resolve a method by UUID *within a named collection*. Unlike
+'loadMethodByUUID' (first-match across all collections), this guarantees the
+method's CFs belong to @collectionName@ — required wherever the result keys a
+collection-scoped cache, so a method's factors and its cache slot never disagree.
+-}
+loadMethodInCollection :: Text -> Text -> AppM Method
+loadMethodInCollection collectionName uuidText = do
+    (methods, _, _, _) <- loadCollection collectionName
+    case UUID.fromText uuidText of
+        Nothing -> throwError err400{errBody = "Invalid method UUID format"}
+        Just uuid -> case filter ((== uuid) . methodId) methods of
+            (m : _) -> pure m
+            [] -> throwError err404{errBody = "Method not found in collection"}
+
+-- | Resolve (db, solver, ProcessId, Activity, Method) within @collectionName@ and dispatch.
 withActivityAndMethod ::
+    Text ->
     Text ->
     Text ->
     Text ->
     (Database -> SharedSolver -> ProcessId -> Activity -> Method -> AppM a) ->
     AppM a
-withActivityAndMethod dbName processIdText methodIdText k = do
+withActivityAndMethod dbName collectionName processIdText methodIdText k = do
     (db, sharedSolver) <- requireDatabaseByName dbName
-    method <- loadMethodByUUID methodIdText
+    method <- loadMethodInCollection collectionName methodIdText
     case Service.resolveActivityAndProcessId db processIdText of
         Left (Service.ActivityNotFound _) -> throwError err404{errBody = "Activity not found"}
         Left (Service.InvalidProcessId _) -> throwError err400{errBody = "Invalid ProcessId format"}
@@ -1386,34 +1409,34 @@ getActivityAggregate dbName processId scopeParam isInputParam maxDepthParam fnam
 {- | LCIA single-method core. GET passes a top-flows param and logs;
 POST carries substitutions instead and skips logging.
 -}
-activityLCIACore :: Text -> Text -> Text -> Maybe Int -> Maybe SubstitutionRequest -> AppM LCIAResult
-activityLCIACore dbName processIdText methodIdText topFlowsParam mSub = do
+activityLCIACore :: Text -> Text -> Text -> Text -> Maybe Int -> Maybe SubstitutionRequest -> AppM LCIAResult
+activityLCIACore dbName processIdText collectionName methodIdText topFlowsParam mSub = do
     dbManager <- asks aeDbManager
     (db, sharedSolver) <- requireDatabaseByName dbName
-    method <- loadMethodByUUID methodIdText
+    method <- loadMethodInCollection collectionName methodIdText
     (processId, activity) <- resolveOrThrow db processIdText
     sol <- crossDBSolutionFor dbName db sharedSolver processId mSub
-    result <- liftIO $ computeCategoryResult dbManager dbName db sol activity (fromMaybe 5 topFlowsParam) Nothing method
+    result <- liftIO $ computeCategoryResult dbManager dbName collectionName db sol activity (fromMaybe 5 topFlowsParam) Nothing method
     when (isNothing mSub) $ liftIO $ logLCIAResult result method
     pure result
 
 getActivityLCIA :: Text -> Text -> Text -> Text -> Maybe Int -> AppM LCIAResult
-getActivityLCIA dbName processIdText _collectionName methodIdText topFlowsParam =
-    activityLCIACore dbName processIdText methodIdText topFlowsParam Nothing
+getActivityLCIA dbName processIdText collectionName methodIdText topFlowsParam =
+    activityLCIACore dbName processIdText collectionName methodIdText topFlowsParam Nothing
 
 postActivityLCIA :: Text -> Text -> Text -> Text -> SubstitutionRequest -> AppM LCIAResult
-postActivityLCIA dbName processIdText _collectionName methodIdText subReq =
-    activityLCIACore dbName processIdText methodIdText Nothing (Just subReq)
+postActivityLCIA dbName processIdText collectionName methodIdText subReq =
+    activityLCIACore dbName processIdText collectionName methodIdText Nothing (Just subReq)
 
 {- | Sensitivity sweep: rank-1 perturbations on the root scaling, scored
 through the cross-DB graph (regional CFs on dep DBs still apply).
 -}
 postActivitySensitivity :: Text -> Text -> Text -> Text -> SensitivityRequest -> AppM SensitivityResponse
-postActivitySensitivity dbName processIdText _collectionName methodIdText senReq = do
+postActivitySensitivity dbName processIdText collectionName methodIdText senReq = do
     dbManager <- asks aeDbManager
     (db, sharedSolver) <- requireDatabaseByName dbName
     requireFullyLinked dbName db
-    method <- loadMethodByUUID methodIdText
+    method <- loadMethodInCollection collectionName methodIdText
     (processId, activity) <- resolveOrThrow db processIdText
     eRes <- liftIO $ Service.computeSensitivities db sharedSolver processId (srPerturbations senReq)
     (baselineX, perResults) <- either throwServiceError pure eRes
@@ -1440,7 +1463,7 @@ postActivitySensitivity dbName processIdText _collectionName methodIdText senReq
                 case eSol of
                     Left err -> pure (PerturbedEntry p (Left err))
                     Right sol -> do
-                        lcia <- computeCategoryResult dbManager dbName db sol activity 5 Nothing method
+                        lcia <- computeCategoryResult dbManager dbName collectionName db sol activity 5 Nothing method
                         pure (PerturbedEntry p (Right (lcia, lrScore lcia - lrScore baselineLcia)))
     eBaselineSol <- liftIO $ scaleToSolution baselineX
     baselineSol <-
@@ -1450,7 +1473,7 @@ postActivitySensitivity dbName processIdText _collectionName methodIdText senReq
             eBaselineSol
     baselineLcia <-
         liftIO $
-            computeCategoryResult dbManager dbName db baselineSol activity 5 Nothing method
+            computeCategoryResult dbManager dbName collectionName db baselineSol activity 5 Nothing method
     perturbed <-
         liftIO $
             mapConcurrently (buildEntry baselineLcia) perResults
@@ -1574,14 +1597,14 @@ getActivityAnalyze dbName processIdText analyzerName = do
                     liftIO $ ahAnalyze analyzer ctx
 
 getContributingFlows :: Text -> Text -> Text -> Text -> Maybe Int -> AppM ContributingFlowsResult
-getContributingFlows dbName processIdText _collectionName methodIdText limitParam =
-    withActivityAndMethod dbName processIdText methodIdText $ \db sharedSolver actProcessId _ method -> do
+getContributingFlows dbName processIdText collectionName methodIdText limitParam =
+    withActivityAndMethod dbName collectionName processIdText methodIdText $ \db sharedSolver actProcessId _ method -> do
         dbManager <- asks aeDbManager
         let lim = fromMaybe 20 limitParam
         unitCfg <- liftIO $ getMergedUnitConfig dbManager
         (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
         inventory <- inventoryWithDeps dbName db sharedSolver actProcessId
-        tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName db method
+        tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName collectionName db method
         let score = loScore (computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables)
             (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
             contribs = sortOn (\(_, _, c) -> negate (abs c)) rawContribs
@@ -1615,14 +1638,14 @@ getContributingFlows dbName processIdText _collectionName methodIdText limitPara
                 }
 
 getContributingActivities :: Text -> Text -> Text -> Text -> Maybe Int -> AppM ContributingActivitiesResult
-getContributingActivities dbName processIdText _collectionName methodIdText limitParam =
-    withActivityAndMethod dbName processIdText methodIdText $ \db sharedSolver actProcessId _ method -> do
+getContributingActivities dbName processIdText collectionName methodIdText limitParam =
+    withActivityAndMethod dbName collectionName processIdText methodIdText $ \db sharedSolver actProcessId _ method -> do
         dbManager <- asks aeDbManager
         let lim = fromMaybe 10 limitParam
         requireFullyLinked dbName db
         unitCfg <- liftIO $ getMergedUnitConfig dbManager
         (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
-        tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName db method
+        tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName collectionName db method
         eContribs <-
             liftIO $
                 SharedSolver.crossDBProcessContributions
@@ -1683,7 +1706,7 @@ getMethods = do
 
 getMethodDetail :: Text -> AppM MethodDetail
 getMethodDetail methodIdText = do
-    method <- loadMethodByUUID methodIdText
+    (_, method) <- loadMethodByUUID methodIdText
     return $
         MethodDetail
             { mdId = methodId method
@@ -1697,15 +1720,15 @@ getMethodDetail methodIdText = do
 
 getMethodFactors :: Text -> AppM [MethodFactorAPI]
 getMethodFactors methodIdText = do
-    method <- loadMethodByUUID methodIdText
+    (_, method) <- loadMethodByUUID methodIdText
     return $ map cfToAPI (methodFactors method)
 
 getMethodMapping :: Text -> Text -> AppM MappingStatus
 getMethodMapping dbName methodIdText = do
     dbManager <- asks aeDbManager
     (db, _) <- requireDatabaseByName dbName
-    method <- loadMethodByUUID methodIdText
-    mappings <- liftIO $ DM.mapMethodToFlowsCached dbManager dbName db method
+    (collectionName, method) <- loadMethodByUUID methodIdText
+    mappings <- liftIO $ DM.mapMethodToFlowsCached dbManager dbName collectionName db method
     let stats = computeMappingStats mappings
         totalFactors = length mappings
         coverage =
@@ -1745,8 +1768,8 @@ getFlowCFMapping :: Text -> Text -> AppM FlowCFMapping
 getFlowCFMapping dbName methodIdText = do
     dbManager <- asks aeDbManager
     (db, _) <- requireDatabaseByName dbName
-    method <- loadMethodByUUID methodIdText
-    mappings <- liftIO $ DM.mapMethodToFlowsCached dbManager dbName db method
+    (collectionName, method) <- loadMethodByUUID methodIdText
+    mappings <- liftIO $ DM.mapMethodToFlowsCached dbManager dbName collectionName db method
     let reverseIndex =
             M.fromList
                 [(bfId f, (cf, strat)) | (cf, Just (f, strat)) <- mappings]
@@ -1765,10 +1788,10 @@ getCharacterization :: Text -> Text -> Maybe Text -> Maybe Int -> AppM Character
 getCharacterization dbName methodIdText flowFilter limitParam = do
     dbManager <- asks aeDbManager
     (db, _) <- requireDatabaseByName dbName
-    method <- loadMethodByUUID methodIdText
+    (collectionName, method) <- loadMethodByUUID methodIdText
     let lim = fromMaybe 50 limitParam
         queryLower = fmap T.toLower flowFilter
-    mappings <- liftIO $ DM.mapMethodToFlowsCached dbManager dbName db method
+    mappings <- liftIO $ DM.mapMethodToFlowsCached dbManager dbName collectionName db method
     let matched =
             [ (cf, f, strat)
             | (cf, Just (f, strat)) <- mappings

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -481,23 +481,27 @@ data DatabaseManager = DatabaseManager
     , dmNoCache :: !Bool -- Caching disabled flag
     , dmPlugins :: !PluginRegistry -- Plugin registry (built-in + external)
     , dmGeographies :: !(Map Text (Text, [Text])) -- code → (display_name, parent_codes)
-    , dmMethodMappingCache :: !(TVar (Map (Text, UUID) [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]))
-    {- ^ Cached flow mappings: (dbName, methodId) → mappings.
-    Invalidated on database/method/synonym reload.
+    , dmMethodMappingCache :: !(TVar (Map (Text, Text, UUID) [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]))
+    {- ^ Cached flow mappings: (dbName, collection, methodId) → mappings.
+    The collection is part of the key because a method UUID is a UUIDv5 of the
+    method name alone, so the same name in two collections collides on UUID
+    while carrying different CF lists. Invalidated on database/method/synonym
+    reload.
     -}
-    , dmMethodTablesCache :: !(TVar (Map (Text, UUID) MethodTables))
+    , dmMethodTablesCache :: !(TVar (Map (Text, Text, UUID) MethodTables))
     {- ^ Cached LCIA-score lookup tables built from mappings.
-    These depend only on (db, method), so building them once per pair
-    saves O(n log n) Map constructions on every LCIA call.
+    These depend only on (db, collection, method), so building them once per
+    triple saves O(n log n) Map constructions on every LCIA call.
     -}
-    , dmMethodSetTablesCache :: !(TVar (Map (Text, [UUID]) MethodSetTables))
+    , dmMethodSetTablesCache :: !(TVar (Map (Text, Text, [UUID]) MethodSetTables))
     {- ^ Cached stacked CF tables for multi-method scoring.
-    Key is (dbName, sortedMethodIds) so subset-arbitrary requests share
-    cache entries with named-collection ones whenever the method ids match.
-    Purged together with 'dmMethodTablesCache' on any reload that
-    invalidates the per-method cache (collection / synonym / DB load).
+    Key is (dbName, collection, sortedMethodIds) so subset-arbitrary requests
+    share cache entries with named-collection ones whenever the method ids
+    match within the same collection. Purged together with
+    'dmMethodTablesCache' on any reload that invalidates the per-method cache
+    (collection / synonym / DB load).
     -}
-    , dmMethodIndexCache :: !(TVar (Map (Text, UUID) MethodIndex))
+    , dmMethodIndexCache :: !(TVar (Map (Text, Text, UUID) MethodIndex))
     {- ^ Cached inverted indices over a method (CF tokens, by-medium, by-CAS).
     Used by the post-scoring suggester to surface candidate matches for
     uncharacterized flows. Keyed identically to the tables cache and
@@ -522,9 +526,9 @@ data DatabaseManager = DatabaseManager
 {- | Cached flow mapping: avoids re-matching method CFs to database flows on every LCIA call.
 The mapping depends only on (database, method), not on the process being evaluated.
 -}
-mapMethodToFlowsCached :: DatabaseManager -> Text -> Database -> Method -> IO [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]
-mapMethodToFlowsCached manager dbName db method = do
-    let key = (dbName, methodId method)
+mapMethodToFlowsCached :: DatabaseManager -> Text -> Text -> Database -> Method -> IO [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]
+mapMethodToFlowsCached manager dbName collection db method = do
+    let key = (dbName, collection, methodId method)
     cache <- readTVarIO (dmMethodMappingCache manager)
     case M.lookup key cache of
         Just cached -> return cached
@@ -534,10 +538,10 @@ mapMethodToFlowsCached manager dbName db method = do
             return result
 
 -- | Cached prepared CF tables: built once per (db, method), reused across inventories.
-mapMethodToTablesCached :: DatabaseManager -> Text -> Database -> Method -> IO MethodTables
-mapMethodToTablesCached manager dbName db method = do
+mapMethodToTablesCached :: DatabaseManager -> Text -> Text -> Database -> Method -> IO MethodTables
+mapMethodToTablesCached manager dbName collection db method = do
     hier <- getLocationHierarchy manager
-    mapMethodToTablesCachedWithHier manager dbName db hier method
+    mapMethodToTablesCachedWithHier manager dbName collection db hier method
 
 {- | Variant of 'mapMethodToTablesCached' that takes the location hierarchy as
 an argument. Lets 'mapMethodSetToTablesCached' fetch it once per request
@@ -546,17 +550,18 @@ instead of once per method in the concurrent fan-out.
 mapMethodToTablesCachedWithHier ::
     DatabaseManager ->
     Text ->
+    Text ->
     Database ->
     M.Map Text [Text] ->
     Method ->
     IO MethodTables
-mapMethodToTablesCachedWithHier manager dbName db hier method = do
-    let key = (dbName, methodId method)
+mapMethodToTablesCachedWithHier manager dbName collection db hier method = do
+    let key = (dbName, collection, methodId method)
     cache <- readTVarIO (dmMethodTablesCache manager)
     case M.lookup key cache of
         Just tables -> pure tables
         Nothing -> do
-            mappings <- mapMethodToFlowsCached manager dbName db method
+            mappings <- mapMethodToFlowsCached manager dbName collection db method
             cmap <- getMergedCompartmentMap manager
             unitConfig <- getMergedUnitConfig manager
             (mFlows, mUnits) <- getMergedFlowMetadata manager
@@ -608,12 +613,12 @@ mapMethodToTablesCachedWithHier manager dbName db hier method = do
 'mapMethodToTablesCached' and re-used; the only set-level work is stacking
 broadcasts into a dense matrix when none of the methods are regionalized.
 -}
-mapMethodSetToTablesCached :: DatabaseManager -> Text -> Database -> [Method] -> IO MethodSetTables
-mapMethodSetToTablesCached manager dbName db methods = do
-    -- Canonical key = (dbName, sorted methodIds). Stable regardless of input
-    -- ordering so subset-arbitrary requests don't fragment the cache.
+mapMethodSetToTablesCached :: DatabaseManager -> Text -> Text -> Database -> [Method] -> IO MethodSetTables
+mapMethodSetToTablesCached manager dbName collection db methods = do
+    -- Canonical key = (dbName, collection, sorted methodIds). Stable regardless
+    -- of input ordering so subset-arbitrary requests don't fragment the cache.
     let sortedMethods = sortOn methodId methods
-        key = (dbName, map methodId sortedMethods)
+        key = (dbName, collection, map methodId sortedMethods)
     cache <- readTVarIO (dmMethodSetTablesCache manager)
     case M.lookup key cache of
         Just mst -> pure mst
@@ -631,7 +636,7 @@ mapMethodSetToTablesCached manager dbName db methods = do
             -- for a ~25-30s parallel one. Concurrent cache writes on the
             -- per-method cache are idempotent under STM (last write wins,
             -- same value).
-            tables <- mapConcurrently (mapMethodToTablesCachedWithHier manager dbName db hier) sortedMethods
+            tables <- mapConcurrently (mapMethodToTablesCachedWithHier manager dbName collection db hier) sortedMethods
             let !mst = buildMethodSetTables (zip sortedMethods tables)
             atomically $ modifyTVar' (dmMethodSetTablesCache manager) (M.insert key mst)
             pure mst
@@ -641,9 +646,9 @@ mapMethodSetToTablesCached manager dbName db methods = do
 'Database' itself — only on the method's CF list — but keyed by (dbName,
 methodId) to share lifetime semantics with the tables cache.
 -}
-mapMethodToIndexCached :: DatabaseManager -> Text -> Method -> IO MethodIndex
-mapMethodToIndexCached manager dbName method = do
-    let key = (dbName, methodId method)
+mapMethodToIndexCached :: DatabaseManager -> Text -> Text -> Method -> IO MethodIndex
+mapMethodToIndexCached manager dbName collection method = do
+    let key = (dbName, collection, methodId method)
     cache <- readTVarIO (dmMethodIndexCache manager)
     case M.lookup key cache of
         Just idx -> pure idx
@@ -670,10 +675,10 @@ still invalidates them fully.
 -}
 clearMethodMappingCacheForDb :: DatabaseManager -> Text -> IO ()
 clearMethodMappingCacheForDb manager dbName = atomically $ do
-    modifyTVar' (dmMethodMappingCache manager) (M.filterWithKey (\(dn, _) _ -> dn /= dbName))
-    modifyTVar' (dmMethodTablesCache manager) (M.filterWithKey (\(dn, _) _ -> dn /= dbName))
-    modifyTVar' (dmMethodSetTablesCache manager) (M.filterWithKey (\(dn, _) _ -> dn /= dbName))
-    modifyTVar' (dmMethodIndexCache manager) (M.filterWithKey (\(dn, _) _ -> dn /= dbName))
+    modifyTVar' (dmMethodMappingCache manager) (M.filterWithKey (\(dn, _, _) _ -> dn /= dbName))
+    modifyTVar' (dmMethodTablesCache manager) (M.filterWithKey (\(dn, _, _) _ -> dn /= dbName))
+    modifyTVar' (dmMethodSetTablesCache manager) (M.filterWithKey (\(dn, _, _) _ -> dn /= dbName))
+    modifyTVar' (dmMethodIndexCache manager) (M.filterWithKey (\(dn, _, _) _ -> dn /= dbName))
     writeTVar (dmMergedFlowMetadataCache manager) Nothing
     writeTVar (dmMergedUnitConfigCache manager) Nothing
 

--- a/test/MethodCollectionCacheSpec.hs
+++ b/test/MethodCollectionCacheSpec.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Regression test for the collection-scoped per-method CF caches.
+
+A method's engine UUID is a UUIDv5 of the method NAME only, so a method with
+the same name in two different LCIA collections (e.g. "Environmental Footprint
+3.1 (adapted) 1.0" vs "… 1.03") collides on UUID while carrying *different* CF
+lists. The per-method lazy caches in 'DatabaseManager' must therefore key on
+(dbName, collection, methodId): if the collection is dropped from the key, the
+first collection to score a (db, UUID) populates the cache and the second
+silently reuses the wrong CF table.
+
+This test drives 'mapMethodToTablesCached' directly with one in-memory database
+and two same-UUID methods that differ only in their UUID-matched CF value. It
+asserts the built 'MethodTables' (specifically 'mtUuidCF') differ per collection
+— which can only hold when the collection is part of the cache key. Without the
+key change, the second lookup returns the first collection's cached tables and
+the assertion fails.
+-}
+module MethodCollectionCacheSpec (spec) where
+
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import Test.Hspec
+
+import Config (defaultConfig)
+import qualified Database.Manager as DM
+import Method.Mapping (mtUuidCF)
+import Method.Types (FlowDirection (..), Method (..), MethodCF (..))
+import Types (UUID)
+
+import CrossDBRegionalLCIAFixture (flowUUID, mkDB, mkUUID)
+
+{- | Shared method UUID — same in both collections, mirroring the UUIDv5-of-name
+collision the cache must disambiguate by collection.
+-}
+sharedMethodId :: UUID
+sharedMethodId = mkUUID 4242
+
+{- | A method named "Resource use, fossils" carrying a single UUID-matched CF on
+the fixture's biosphere flow, with the given CF value.
+-}
+mkFossilsMethod :: Double -> Method
+mkFossilsMethod cfValue =
+    Method
+        { methodId = sharedMethodId
+        , methodName = "Resource use, fossils"
+        , methodDescription = Nothing
+        , methodUnit = "MJ"
+        , methodCategory = "Resource use, fossils"
+        , methodMethodology = Nothing
+        , methodFactors = [fossilsCF cfValue]
+        }
+
+-- | A CF that resolves by UUID against the fixture's single biosphere flow.
+fossilsCF :: Double -> MethodCF
+fossilsCF cfValue =
+    MethodCF
+        { mcfFlowRef = flowUUID
+        , mcfFlowName = "Oil, crude, 43.4 MJ per kg"
+        , mcfDirection = Output
+        , mcfValue = cfValue
+        , mcfCompartment = Nothing
+        , mcfCAS = Nothing
+        , mcfUnit = "MJ"
+        , mcfConsumerLocation = Nothing
+        }
+
+collectionA :: Text
+collectionA = "Environmental Footprint 3.1 (adapted) 1.0"
+
+collectionB :: Text
+collectionB = "Environmental Footprint 3.1 (adapted) 1.03"
+
+{- | CF value distinguishing the two collections (analogous to the missing
+"Oil, crude, 43.4 MJ per kg" CF that only the 1.03 collection defines).
+-}
+cfA, cfB :: Double
+cfA = 43.2
+cfB = 43.4
+
+spec :: Spec
+spec = do
+    describe "mapMethodToTablesCached (collection-scoped cache)" $ do
+        it "returns per-collection CF tables for same-UUID methods (A then B)" $ do
+            mgr <- DM.initDatabaseManager defaultConfig False Nothing
+            let db = mkDB 0 ["FR"] []
+            tablesA <- DM.mapMethodToTablesCached mgr "db" collectionA db (mkFossilsMethod cfA)
+            tablesB <- DM.mapMethodToTablesCached mgr "db" collectionB db (mkFossilsMethod cfB)
+            M.lookup flowUUID (mtUuidCF tablesA) `shouldBe` Just (cfA, "MJ")
+            M.lookup flowUUID (mtUuidCF tablesB) `shouldBe` Just (cfB, "MJ")
+
+        it "returns per-collection CF tables for same-UUID methods (B then A)" $ do
+            mgr <- DM.initDatabaseManager defaultConfig False Nothing
+            let db = mkDB 0 ["FR"] []
+            tablesB <- DM.mapMethodToTablesCached mgr "db" collectionB db (mkFossilsMethod cfB)
+            tablesA <- DM.mapMethodToTablesCached mgr "db" collectionA db (mkFossilsMethod cfA)
+            M.lookup flowUUID (mtUuidCF tablesB) `shouldBe` Just (cfB, "MJ")
+            M.lookup flowUUID (mtUuidCF tablesA) `shouldBe` Just (cfA, "MJ")

--- a/test/MethodResolveSpec.hs
+++ b/test/MethodResolveSpec.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Unit tests for 'selectMethod', the collection-aware method resolver behind
+the @method_id@-only MCP tools.
+
+A method's engine UUID is a UUIDv5 of its name, so the same UUID can be loaded
+under several collections (e.g. two EF 3.1 versions). Resolving must be loud,
+not first-match: an ambiguous UUID has to surface the collections to choose
+from instead of silently picking whichever loaded first.
+-}
+module MethodResolveSpec (spec) where
+
+import Data.Text (Text)
+import qualified Data.Text as T
+import Test.Hspec
+
+import API.MCP (selectMethod)
+import Method.Types (Method (..))
+import Types (UUID)
+
+import CrossDBRegionalLCIAFixture (mkUUID)
+
+sharedId :: UUID
+sharedId = mkUUID 4242
+
+otherId :: UUID
+otherId = mkUUID 777
+
+collA :: Text
+collA = "Environmental Footprint 3.1 (adapted) 1.0"
+
+collB :: Text
+collB = "Environmental Footprint 3.1 (adapted) 1.03"
+
+-- | A bare named method carrying the given UUID; CF list is irrelevant here.
+mkMethod :: UUID -> Method
+mkMethod uuid =
+    Method
+        { methodId = uuid
+        , methodName = "Resource use, fossils"
+        , methodDescription = Nothing
+        , methodUnit = "MJ"
+        , methodCategory = "Resource use, fossils"
+        , methodMethodology = Nothing
+        , methodFactors = []
+        }
+
+-- | Both collections carry the colliding UUID.
+bothLoaded :: [(Text, Method)]
+bothLoaded = [(collA, mkMethod sharedId), (collB, mkMethod sharedId)]
+
+spec :: Spec
+spec = describe "selectMethod" $ do
+    it "infers the single match when only one collection carries the UUID" $
+        fmap fst (selectMethod Nothing sharedId [(collA, mkMethod sharedId)])
+            `shouldBe` Right collA
+
+    it "fails loudly on an ambiguous UUID, naming every collection" $
+        case selectMethod Nothing sharedId bothLoaded of
+            Right _ -> expectationFailure "expected ambiguity error, got a match"
+            Left msg -> do
+                msg `shouldSatisfy` T.isInfixOf collA
+                msg `shouldSatisfy` T.isInfixOf collB
+                msg `shouldSatisfy` T.isInfixOf "collection"
+
+    it "resolves within the pinned collection when the UUID is ambiguous" $
+        fmap fst (selectMethod (Just collB) sharedId bothLoaded)
+            `shouldBe` Right collB
+
+    it "errors when the pinned collection lacks the UUID, listing what is loaded" $
+        case selectMethod (Just "EF 3.1 (adapted) 9.9") sharedId bothLoaded of
+            Right _ -> expectationFailure "expected not-found error, got a match"
+            Left msg -> do
+                msg `shouldSatisfy` T.isInfixOf collA
+                msg `shouldSatisfy` T.isInfixOf collB
+
+    it "reports not-found for a UUID that is loaded nowhere" $
+        selectMethod Nothing otherId [(collA, mkMethod sharedId)]
+            `shouldSatisfy` isLeft
+  where
+    isLeft = either (const True) (const False)

--- a/volca.cabal
+++ b/volca.cabal
@@ -231,6 +231,7 @@ test-suite lca-tests
                      , MappingSpec
                      , MethodSetTablesSpec
                      , MethodCollectionCacheSpec
+                     , MethodResolveSpec
                      , ChemSynonymsSpec
                      , UploadedDatabaseSpec
                      , UploadSizeSpec

--- a/volca.cabal
+++ b/volca.cabal
@@ -230,6 +230,7 @@ test-suite lca-tests
                      , LoaderSpec
                      , MappingSpec
                      , MethodSetTablesSpec
+                     , MethodCollectionCacheSpec
                      , ChemSynonymsSpec
                      , UploadedDatabaseSpec
                      , UploadSizeSpec


### PR DESCRIPTION
## Problem

The per-method characterization caches in `DatabaseManager` were keyed by `(dbName, methodId)`. A method's UUID is derived from its name alone, so two loaded LCIA collections that define a same-named method — e.g. `EF 3.1 (adapted) 1.0` and `1.03`, both with `Resource use, fossils` — collide on that UUID. The first collection to be scored populated the cache; every other collection sharing the UUID silently reused its CF table. So with both versions loaded, scoring one version returned the other's factors (e.g. the `1.03`-only `Oil, crude, 43.4 MJ per kg` CF was never applied).

A second face of the same bug: the `method_id`-only MCP tools resolved a UUID by first-match across all loaded collections, so with both versions loaded they too silently answered from whichever loaded first.

## Fix

**Caches (commit 1).**
- Add the collection name to the four per-method cache keys (`dmMethodTablesCache` and its mapping/set/index siblings) and thread it from the scoring call sites. Co-loaded collections now keep independent CF tables and can be scored and compared side by side.
- The single-method routes carrying a `{collection}` path segment resolved the method across all collections (first match) while keying the cache by the route's collection — which could cache one collection's CFs under another's key. Add `loadMethodInCollection` so those routes resolve the method within the requested collection; factors and cache key can no longer disagree.

**MCP tools (commit 2).**
- The `method_id`-only tools (`get_impacts`, `get_characterization`, `get_contributing_*`, `get_flow_mapping`, `compute_sensitivity`, `compare_impacts`) gain an optional `collection` argument, and resolution is now loud instead of first-match: a single match is still inferred, an ambiguous UUID fails listing the collections to choose from, and a pinned collection resolves within it. The decision lives in a pure `selectMethod` so it is total and unit-tested.

## Test

- `MethodCollectionCacheSpec` drives `mapMethodToTablesCached` with two same-UUID methods (CF 43.2 vs 43.4) under two collections and asserts the built tables differ per collection — it fails without the collection in the key.
- `MethodResolveSpec` covers `selectMethod`: single-match inference, loud ambiguity (naming every collection), pinned-collection resolution, pinned-but-missing, and not-loaded.

## Verification

`./build.sh --test`: full suite 1155 examples, 0 failures (incl. `MCPSchemaSpec`, which validates the new params).
