### PR TITLE
Report partial EcoSpold2 imports honestly (unresolved background links)

### DIFF
--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -53,6 +53,7 @@ module Database.Loader (
     -- * Database Analysis
     countTotalTechInputs,
     countUnlinkedExchanges,
+    collectDanglingProductNames,
 
     -- * Internal Linking
     fixSimaProActivityLinks,
@@ -85,7 +86,7 @@ import Data.Either (partitionEithers)
 import Data.List (sort, sortBy, sortOn)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isNothing)
 import Data.Ord (Down (..))
 import qualified Data.Set as S
 import Data.Store (decodeEx, encode)
@@ -95,6 +96,7 @@ import Data.Time (UTCTime, diffUTCTime, getCurrentTime)
 import Data.Typeable (typeOf, typeRepFingerprint)
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V5 as UUID5
+import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU
 import Data.Word (Word64)
 import Database.CrossLinking (
@@ -111,6 +113,7 @@ import Database.CrossLinking (
     locationHierarchy,
     normalizeUnicode,
  )
+import Database.MatrixBuild (findProducer)
 import EcoSpold.Common (distributeFiles)
 import EcoSpold.Parser1 (streamParseActivityAndFlowsFromFile1, streamParseAllDatasetsFromFile1)
 import EcoSpold.Parser2 (streamParseActivityAndFlowsFromFile)
@@ -1235,56 +1238,105 @@ fixActivityLinksWithCrossDB indexedDbs synonymDB unitConfig locationHier policy 
             -- The links will be stored in the Database.dbCrossDBLinks field later
             return (db, stats')
 
--- | Collect unlinked product names from a database (for databases without cross-DB linking)
+{- | Inputs that demand a supplier — the exact set the matrix builder tries to
+resolve in 'Database.MatrixBuild.techTriple'.
+
+Biosphere flows need no supplier. Reference exchanges sit on the diagonal of
+@(I-A)@ and are skipped by the matrix builder, so a treatment process's
+'ReferenceInput' is a self-edge, not a supplier demand — counting it would drag
+completeness below 100% for a perfectly solvable database. Waste *outputs* (the
+typical SimaPro 'Final waste flows' case) are end-of-life markers, also not
+demands; only waste/technosphere *inputs* remain.
+-}
+isSupplierDemand :: Exchange -> Bool
+isSupplierDemand ex =
+    not (isBiosphereExchange ex)
+        && exchangeIsInput ex
+        && not (exchangeIsReference ex)
+
+{- | True when a staged input resolves to a producer activity present in the
+same database — the @(activityLinkId, flowId)@ branch of
+'Database.MatrixBuild.findProducer'.
+
+The process-link branch is deliberately omitted: a 'ProcessId' is an interned
+index assigned only when matrices are built, so it never exists on a
+'SimpleDatabase' (it is always 'Nothing' here). The loaded-database counterpart
+'collectDanglingProductNames' has the real lookup and calls 'findProducer'
+directly, honouring both branches.
+
+A nil @activityLinkId@ (SimaPro inputs awaiting cross-DB linking, or a genuine
+orphan) is never an internal producer. A *non-nil* link to an activity absent
+from this database — e.g. a partial EcoSpold2 import that references ecoinvent
+background activities it doesn't ship — is unresolved too: the matrix builder
+silently drops such an exchange, so it must count as unlinked rather than
+masquerade as a resolved internal link.
+-}
+hasInternalProducer :: SimpleDatabase -> Exchange -> Bool
+hasInternalProducer db ex =
+    case exchangeActivityLinkId ex of
+        Nothing -> False
+        Just actUUID -> M.member (actUUID, exchangeFlowId ex) (sdbActivities db)
+
+{- | Product names of technosphere demands with no resolved internal producer —
+the supplier gaps surfaced on the setup page. Covers both nil-link inputs and
+non-nil links whose target activity is absent (partial EcoSpold2 imports).
+-}
 collectUnlinkedProductNames :: SimpleDatabase -> M.Map T.Text Int
 collectUnlinkedProductNames db =
     M.fromListWith
         (+)
         [ (tfName flow, 1)
         | act <- M.elems (sdbActivities db)
-        , ex@TechnosphereExchange{techFlowId = fid, techActivityLinkId = linkId} <- exchanges act
-        , exchangeIsInput ex
-        , linkId == UUID.nil
-        , Just flow <- [M.lookup fid (sdbTechFlows db)]
+        , ex@TechnosphereExchange{} <- exchanges act
+        , isSupplierDemand ex
+        , not (hasInternalProducer db ex)
+        , Just flow <- [M.lookup (exchangeFlowId ex) (sdbTechFlows db)]
         ]
 
--- | Count unlinked technosphere exchanges in a database
+-- | Count supplier demands with no resolved internal producer.
 countUnlinkedExchanges :: SimpleDatabase -> Int
 countUnlinkedExchanges db =
-    sum
-        [ 1
+    length
+        [ ()
         | act <- M.elems (sdbActivities db)
         , ex <- exchanges act
-        , isUnlinkedTechInput ex
+        , isSupplierDemand ex
+        , not (hasInternalProducer db ex)
         ]
-  where
-    isUnlinkedTechInput :: Exchange -> Bool
-    isUnlinkedTechInput ex@TechnosphereExchange{techActivityLinkId = linkId} =
-        exchangeIsInput ex && linkId == UUID.nil
-    isUnlinkedTechInput BiosphereExchange{} = False
-    -- A waste exchange counts as an unlinked "tech input" only when it is
-    -- consumed (treatment side) and has no supplier yet. Waste *outputs*
-    -- (the typical SimaPro 'Final waste flows' case) are end-of-life
-    -- markers, not demands — they shouldn't inflate the missing-supplier
-    -- tally.
-    isUnlinkedTechInput ex@WasteExchange{waActivityLinkId = linkId} =
-        exchangeIsInput ex && linkId == UUID.nil
 
--- | Count total technosphere input exchanges in a database
+-- | Count total supplier demands — the completeness denominator.
 countTotalTechInputs :: SimpleDatabase -> Int
 countTotalTechInputs db =
-    sum
-        [ 1
+    length
+        [ ()
         | act <- M.elems (sdbActivities db)
         , ex <- exchanges act
-        , isTechInput ex
+        , isSupplierDemand ex
         ]
-  where
-    isTechInput :: Exchange -> Bool
-    isTechInput ex@TechnosphereExchange{} = exchangeIsInput ex
-    isTechInput BiosphereExchange{} = False
-    -- Mirror isUnlinkedTechInput: only waste *inputs* (treatment side) count.
-    isTechInput ex@WasteExchange{} = exchangeIsInput ex
+
+{- | Product names of a *loaded* database's dangling internal links: non-nil
+@activityLinkId@ inputs that 'findProducer' cannot resolve against the
+database's own process lookup (the matrix builder silently drops them). The
+loaded-path counterpart that names the supplier gaps a partial EcoSpold2 import
+leaves behind — distinct from nil-link inputs, the cross-DB candidates already
+tracked in the linking stats.
+
+Sharing 'findProducer' keeps this honest with the matrix even once
+@techProcessLinkId@ is populated: an input whose process link resolves is not
+dangling, however its activity link looks.
+-}
+collectDanglingProductNames :: Database -> M.Map T.Text Int
+collectDanglingProductNames db =
+    M.fromListWith
+        (+)
+        [ (tfName flow, 1)
+        | act <- V.toList (dbActivities db)
+        , ex@TechnosphereExchange{} <- exchanges act
+        , isSupplierDemand ex
+        , isNothing (findProducer (dbProcessIdLookup db) ex)
+        , Just _ <- [exchangeActivityLinkId ex]
+        , Just flow <- [M.lookup (exchangeFlowId ex) (dbTechFlows db)]
+        ]
 
 {- | Find all cross-database links without modifying activities
 Returns statistics including the CrossDBLinks for chained solving

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -79,6 +79,7 @@ module Database.Manager (
     -- * Staged Database Operations
     getStagedDatabase,
     getDatabaseSetupInfo,
+    buildLoadedSetupInfo,
     addDependencyToStaged,
     removeDependencyFromStaged,
     setDataPath,
@@ -1947,14 +1948,11 @@ buildSetupResult manager dbName = do
                 else return $ Right info
         Nothing -> case M.lookup dbName loadedDbs of
             Just loaded ->
+                -- 'buildLoadedSetupInfo' already derives dsiIsReady honestly
+                -- (it sees dangling internal links); only the loaded flag needs
+                -- flipping here.
                 let info = buildLoadedSetupInfo (ldConfig loaded) (ldDatabase loaded) availableDbs indexedDbs
-                    nUnresolved = unresolvedCount (dbLinkingStats (ldDatabase loaded))
-                 in return $
-                        Right
-                            info
-                                { dsiIsLoaded = False
-                                , dsiIsReady = nUnresolved == 0
-                                }
+                 in return $ Right info{dsiIsLoaded = False}
             Nothing -> return $ Left $ SetupFailed $ "Failed to stage database: " <> dbName
 
 {- | Build setup info from a staged database
@@ -2015,22 +2013,31 @@ buildStagedSetupInfo staged configs indexedDbs =
             , dsiIsLoaded = False
             }
 
-{- | Build setup info from a loaded database (already finalized)
-Uses dbLinkingStats for real completeness/fallback data
+{- | Build setup info from a loaded database (already finalized).
+
+Counts are recomputed from the activity set via the same predicate as the
+staged path ('Loader.countUnlinkedExchanges'), not read from 'dbLinkingStats':
+the stats only track nil-link / cross-DB resolution and are blind to dangling
+internal links (non-nil 'activityLinkId' pointing at an activity the database
+doesn't ship). A database bulk-loaded from config bypasses the finalize gate,
+so without this it would report a partial EcoSpold2 import as 100% ready while
+the matrix silently drops those inputs. Rich blocker reasons still come from
+the stats; dangling links are appended.
 -}
 buildLoadedSetupInfo :: DatabaseConfig -> Database -> Map Text DatabaseConfig -> Map Text IndexedDatabase -> DatabaseSetupInfo
 buildLoadedSetupInfo config db configs indexedDbs =
-    let stats = dbLinkingStats db
-        totalInputs = cdlTotalInputs stats
+    let sdb = toSimpleDatabase db
+        stats = dbLinkingStats db
+        totalInputs = Loader.countTotalTechInputs sdb
+        unlinked = Loader.countUnlinkedExchanges sdb
         nCrossDBLinks = length (dbCrossDBLinks db)
-        nUnresolved = unresolvedCount stats
-        resolved = totalInputs - nUnresolved
+        internalLinks = max 0 (totalInputs - unlinked)
+        unresolvedLinks = max 0 (unlinked - nCrossDBLinks)
+        resolved = internalLinks + nCrossDBLinks
         completeness =
             if totalInputs > 0
                 then 100.0 * fromIntegral resolved / fromIntegral totalInputs
                 else 100.0
-        internalLinks = max 0 (resolved - nCrossDBLinks)
-        missingSuppliers = take 10 $ map blockerToMissingSupplier (M.toList (cdlUnresolvedProducts stats))
         blockerToMissingSupplier (name, (cnt, blocker)) =
             let (reason, detail) = case blocker of
                     NoNameMatch -> ("no_name_match", Nothing)
@@ -2039,6 +2046,12 @@ buildLoadedSetupInfo config db configs indexedDbs =
                     LocationRejectedByPolicy req act kind ->
                         ("location_rejected", Just (req <> " ↛ " <> act <> " (" <> locationKindCode kind <> ")"))
              in MissingSupplier name cnt Nothing reason detail
+        statsSuppliers = map blockerToMissingSupplier (M.toList (cdlUnresolvedProducts stats))
+        danglingSuppliers =
+            [ MissingSupplier name cnt Nothing "no_name_match" Nothing
+            | (name, cnt) <- M.toList (Loader.collectDanglingProductNames db)
+            ]
+        missingSuppliers = take 10 (statsSuppliers ++ danglingSuppliers)
      in DatabaseSetupInfo
             { dsiName = dcName config
             , dsiDisplayName = dcDisplayName config
@@ -2047,10 +2060,10 @@ buildLoadedSetupInfo config db configs indexedDbs =
             , dsiCompleteness = completeness
             , dsiInternalLinks = internalLinks
             , dsiCrossDBLinks = nCrossDBLinks
-            , dsiUnresolvedLinks = nUnresolved
+            , dsiUnresolvedLinks = unresolvedLinks
             , dsiMissingSuppliers = missingSuppliers
             , dsiDependencies = buildDependencyChoices (dcName config) (dbDependsOn db) [] configs indexedDbs
-            , dsiIsReady = True
+            , dsiIsReady = dbActivityCount db > 0 && unresolvedLinks == 0
             , dsiUnknownUnits = S.toList (cdlUnknownUnits stats)
             , dsiLocationFallbacks = deduplicateFallbacks (cdlLocationFallbacks stats)
             , dsiLocationUnresolved = deduplicateUnresolved (cdlLocationUnresolved stats)

--- a/src/Database/MatrixBuild.hs
+++ b/src/Database/MatrixBuild.hs
@@ -14,6 +14,7 @@ module Database.MatrixBuild (
     collectBioFlowOrder,
     buildTechTriples,
     buildBioTriples,
+    findProducer,
 ) where
 
 import Control.Applicative ((<|>))

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -78,6 +78,30 @@ inputExchange fid loc =
         , techPedigree = Nothing
         }
 
+actUUID2, missingActUUID :: UUID.UUID
+actUUID2 = read "cccccccc-0000-0000-0000-000000000002"
+missingActUUID = read "dddddddd-0000-0000-0000-000000000099"
+
+-- | An input linked (non-nil) to producer activity @actId@ producing @prodId@.
+linkedInput :: UUID.UUID -> UUID.UUID -> Exchange
+linkedInput actId prodId = (inputExchange prodId "GLO"){techActivityLinkId = actId}
+
+{- | A treatment process's reference input (the waste it treats): an input-side
+reference exchange that the matrix builder skips, so it is no supplier demand.
+-}
+referenceInput :: UUID.UUID -> Exchange
+referenceInput fid = (inputExchange fid "GLO"){techRole = ReferenceInput}
+
+simpleDBOf :: [((UUID.UUID, UUID.UUID), Activity)] -> [(UUID.UUID, Text)] -> SimpleDatabase
+simpleDBOf acts flows =
+    SimpleDatabase
+        { sdbActivities = M.fromList acts
+        , sdbTechFlows = M.fromList [(fid, minimalFlow fid name) | (fid, name) <- flows]
+        , sdbBioFlows = M.empty
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.empty
+        }
+
 -- ---------------------------------------------------------------------------
 
 spec :: Spec
@@ -295,6 +319,45 @@ spec = do
             db <- loadSampleDatabase "SAMPLE.min3"
             let sdb = Types.toSimpleDatabase db
             M.null (collectUnlinkedProductNames sdb) `shouldBe` True
+
+    -- A partial EcoSpold2 import carries non-nil activityLinkIds that point at
+    -- background activities it doesn't ship. Those links must read as unlinked,
+    -- not silently masquerade as resolved internal links (the matrix builder
+    -- drops them, so the score would otherwise undercount with no warning).
+    describe "countUnlinkedExchanges (producer presence)" $ do
+        it "counts a non-nil link to an absent activity as unlinked" $ do
+            let consumer = minimalActivity "lyocell fibre" "GLO" [refExchange flowUUID1, linkedInput missingActUUID flowUUID2]
+                sdb = simpleDBOf [((actUUID1, flowUUID1), consumer)] [(flowUUID1, "lyocell fibre"), (flowUUID2, "chemical, inorganic")]
+            countUnlinkedExchanges sdb `shouldBe` 1
+
+        it "does not count a non-nil link to a present activity" $ do
+            let consumer = minimalActivity "lyocell fibre" "GLO" [refExchange flowUUID1, linkedInput actUUID2 flowUUID2]
+                supplier = minimalActivity "chemical, inorganic" "GLO" [refExchange flowUUID2]
+                sdb = simpleDBOf [((actUUID1, flowUUID1), consumer), ((actUUID2, flowUUID2), supplier)] [(flowUUID1, "lyocell fibre"), (flowUUID2, "chemical, inorganic")]
+            countUnlinkedExchanges sdb `shouldBe` 0
+
+    describe "collectUnlinkedProductNames (producer presence)" $ do
+        it "surfaces the product of a dangling non-nil link" $ do
+            let consumer = minimalActivity "lyocell fibre" "GLO" [refExchange flowUUID1, linkedInput missingActUUID flowUUID2]
+                sdb = simpleDBOf [((actUUID1, flowUUID1), consumer)] [(flowUUID1, "lyocell fibre"), (flowUUID2, "chemical, inorganic")]
+            collectUnlinkedProductNames sdb `shouldBe` M.fromList [("chemical, inorganic", 1)]
+
+    -- A treatment process's reference input (ReferenceInput) is a self-edge the
+    -- matrix builder skips, not a supplier demand. Counting it would drag a
+    -- solvable treatment database below 100% complete and wrongly refuse
+    -- finalize, so it must stay out of both the total and the unlinked tally.
+    describe "reference inputs are not supplier demands" $ do
+        it "excludes a treatment ReferenceInput from the input total" $ do
+            let treatment = minimalActivity "waste treatment" "GLO" [referenceInput flowUUID1, linkedInput actUUID2 flowUUID2]
+                supplier = minimalActivity "electricity" "GLO" [refExchange flowUUID2]
+                sdb = simpleDBOf [((actUUID1, flowUUID1), treatment), ((actUUID2, flowUUID2), supplier)] [(flowUUID1, "waste"), (flowUUID2, "electricity")]
+            -- only the linked electricity input is a demand; the ReferenceInput is not
+            countTotalTechInputs sdb `shouldBe` 1
+
+        it "does not count a nil-link ReferenceInput as unlinked" $ do
+            let treatment = minimalActivity "waste treatment" "GLO" [referenceInput flowUUID1]
+                sdb = simpleDBOf [((actUUID1, flowUUID1), treatment)] [(flowUUID1, "waste")]
+            countUnlinkedExchanges sdb `shouldBe` 0
 
     -- ---------------------------------------------------------------------
     -- activityNormFactor — exercises every TechRole branch so the

--- a/test/SetupInfoSpec.hs
+++ b/test/SetupInfoSpec.hs
@@ -1,0 +1,169 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module SetupInfoSpec (spec) where
+
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.UUID as UUID
+import Test.Hspec
+
+import Config (DatabaseConfig (..))
+import Database (buildDatabaseWithMatrices)
+import Database.Manager (
+    DatabaseSetupInfo (..),
+    MissingSupplier (..),
+    buildLoadedSetupInfo,
+ )
+import Types
+import UnitConversion (defaultUnitConfig)
+
+-- ---------------------------------------------------------------------------
+-- Minimal fixtures
+-- ---------------------------------------------------------------------------
+
+consumerAct, consumerProd, supplierAct, supplierProd, missingAct :: UUID.UUID
+consumerAct = read "cccccccc-0000-0000-0000-000000000001"
+consumerProd = read "aaaaaaaa-0000-0000-0000-000000000001"
+supplierAct = read "cccccccc-0000-0000-0000-000000000002"
+supplierProd = read "bbbbbbbb-0000-0000-0000-000000000002"
+missingAct = read "dddddddd-0000-0000-0000-000000000099"
+
+minimalFlow :: UUID.UUID -> Text -> TechnosphereFlow
+minimalFlow fid name =
+    TechnosphereFlow
+        { tfId = fid
+        , tfName = name
+        , tfUnitId = UUID.nil
+        , tfSynonyms = M.empty
+        , tfCAS = Nothing
+        , tfSubstanceId = Nothing
+        }
+
+minimalActivity :: Text -> [Exchange] -> Activity
+minimalActivity name exs =
+    Activity
+        { activityName = name
+        , activityDescription = []
+        , activitySynonyms = M.empty
+        , activityClassification = M.empty
+        , activityLocation = "GLO"
+        , activityUnit = "kg"
+        , exchanges = exs
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
+        }
+
+refExchange :: UUID.UUID -> Exchange
+refExchange fid =
+    TechnosphereExchange
+        { techFlowId = fid
+        , techAmount = 1.0
+        , techUnitId = UUID.nil
+        , techRole = ReferenceProduct
+        , techActivityLinkId = UUID.nil
+        , techProcessLinkId = Nothing
+        , techLocation = "GLO"
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+-- | A technosphere input for @prodId@ linked to producer activity @actId@.
+linkedInput :: UUID.UUID -> UUID.UUID -> Exchange
+linkedInput actId prodId =
+    TechnosphereExchange
+        { techFlowId = prodId
+        , techAmount = 0.5
+        , techUnitId = UUID.nil
+        , techRole = Input
+        , techActivityLinkId = actId
+        , techProcessLinkId = Nothing
+        , techLocation = "GLO"
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+{- | A loaded database has no UI picker; only its name/path matter to the setup
+info, so a permissive stub config suffices.
+-}
+stubConfig :: DatabaseConfig
+stubConfig =
+    DatabaseConfig
+        { dcName = "test"
+        , dcDisplayName = "Test DB"
+        , dcPath = ""
+        , dcDescription = Nothing
+        , dcLoad = True
+        , dcDefault = False
+        , dcDepends = []
+        , dcLocationAliases = M.empty
+        , dcFormat = Nothing
+        , dcIsUploaded = False
+        , dcDeletable = False
+        , dcGeographyPolicy = GeoGlobal
+        }
+
+buildDb :: [((UUID.UUID, UUID.UUID), Activity)] -> [(UUID.UUID, Text)] -> IO Database
+buildDb acts flows = do
+    res <-
+        buildDatabaseWithMatrices
+            defaultUnitConfig
+            (M.fromList acts)
+            (M.fromList [(fid, minimalFlow fid name) | (fid, name) <- flows])
+            M.empty
+            M.empty
+            M.empty
+    case res of
+        Left err -> error ("buildDatabaseWithMatrices failed: " <> show err)
+        Right db -> pure db
+
+-- | Setup info for a self-contained loaded database (no deps, no other DBs).
+setupInfoFor :: Database -> DatabaseSetupInfo
+setupInfoFor db = buildLoadedSetupInfo stubConfig db M.empty M.empty
+
+-- ---------------------------------------------------------------------------
+
+spec :: Spec
+spec = do
+    -- A single-.spold import: the foreground consumer carries a non-nil
+    -- activityLinkId to a background activity it doesn't ship. The matrix
+    -- builder drops that input, so a loaded database (which bypasses the
+    -- finalize gate) must report as not-ready with 0% completeness and name the
+    -- missing background product — never a green "ready" badge over a silently
+    -- zero score.
+    describe "buildLoadedSetupInfo (partial EcoSpold2 import)" $ do
+        it "reports a dangling background link as not ready / 0% / named" $ do
+            let consumer =
+                    minimalActivity
+                        "lyocell fibre"
+                        [refExchange consumerProd, linkedInput missingAct supplierProd]
+            db <-
+                buildDb
+                    [((consumerAct, consumerProd), consumer)]
+                    [(consumerProd, "lyocell fibre"), (supplierProd, "chemical, inorganic")]
+            let info = setupInfoFor db
+            dsiIsReady info `shouldBe` False
+            dsiCompleteness info `shouldBe` 0.0
+            map msProductName (dsiMissingSuppliers info) `shouldBe` ["chemical, inorganic"]
+
+    -- The same shape, but the background activity is present: every input
+    -- resolves internally, so the database stays ready at 100% with no gaps.
+    describe "buildLoadedSetupInfo (well-formed self-contained database)" $ do
+        it "reports a fully resolved database as ready / 100% / no gaps" $ do
+            let consumer =
+                    minimalActivity
+                        "lyocell fibre"
+                        [refExchange consumerProd, linkedInput supplierAct supplierProd]
+                supplier = minimalActivity "chemical, inorganic" [refExchange supplierProd]
+            db <-
+                buildDb
+                    [ ((consumerAct, consumerProd), consumer)
+                    , ((supplierAct, supplierProd), supplier)
+                    ]
+                    [(consumerProd, "lyocell fibre"), (supplierProd, "chemical, inorganic")]
+            let info = setupInfoFor db
+            dsiIsReady info `shouldBe` True
+            dsiCompleteness info `shouldBe` 100.0
+            dsiMissingSuppliers info `shouldBe` []

--- a/volca.cabal
+++ b/volca.cabal
@@ -228,6 +228,7 @@ test-suite lca-tests
                      , PluginConfigSpec
                      , ConfigSpec
                      , LoaderSpec
+                     , SetupInfoSpec
                      , MappingSpec
                      , MethodSetTablesSpec
                      , ChemSynonymsSpec


### PR DESCRIPTION
## Problem

Importing a single `.spold` (a foreground process whose intermediate inputs reference background activities it doesn't ship) reported **100% complete / ready for analysis**, yet every impact came back **zero**. EcoSpold2 inputs always carry a non-nil `activityLinkId`, and the completeness counters equated "has a link" with "resolved" — so 18 dangling links were counted as internal/resolved while the matrix builder silently dropped them. A clear case of silent undercount behind a green "ready" badge.

## Fix

Make the completeness counters agree with the matrix builder's ground truth (`findProducer`): an input is resolved **iff its `(activityLinkId, flowId)` producer activity is actually present**. A non-nil link to an absent activity is now counted as unlinked, not as a resolved internal link.

- A shared `isSupplierDemand` predicate defines exactly the set the matrix resolves — non-reference, non-biosphere inputs — so a treatment process's reference input (a diagonal self-edge the matrix skips) no longer inflates the tally.
- `countUnlinkedExchanges` / `collectUnlinkedProductNames` keyed on producer presence.
- `buildLoadedSetupInfo` recomputes from the activity set rather than trusting the cross-DB linking stats (which only track nil-link / cross-DB resolution and are blind to dangling links) — this closes the config-load entry point, which bypasses the finalize gate. Its dangling-link detection reuses `findProducer` directly, so it stays honest with the matrix even once process links are populated.

## Result (single-spold import)

| | before | after |
|---|---|---|
| completeness | 100% | **0%** |
| unresolved inputs | 0 | **18** |
| ready | true | **false** |
| missing suppliers | empty | the actual background products listed |

Finalize is now correctly refused for such a database with a clear message, and the activity detail surfaces no resolvable target for the dropped inputs.

## Tests

`LoaderSpec` pins producer-presence counting (a non-nil link to an absent activity counts as unlinked and is surfaced by name; a link to a present activity still resolves — no regression for well-formed databases) and that a treatment process's reference input is not a supplier demand. `SetupInfoSpec` covers the loaded setup path end-to-end: a dangling background link → not-ready / 0% / named; a well-formed self-contained database → ready / 100% / no gaps. Full suite green (1155 examples).

## Follow-up (not in this PR)

Cross-DB linking is name-based and only attempts nil-link inputs, so a partial EcoSpold2 import can't yet be resolved by loading its matching ecoinvent background — that needs cross-DB linking **by `activityLinkId` UUID** between two EcoSpold2 databases.
