### PR TITLE
Link partial EcoSpold2 imports to their background by activityLinkId UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- A partial EcoSpold2 import (a handful of `.spold` files cut from a full
+  database) now becomes analyzable by loading its matching ecoinvent background
+  as a dependency: each input is linked to the exact background activity it
+  names, by `activityLinkId` identity. Previously only nil-link inputs were
+  resolved, so partial imports stayed unresolved however the background was
+  loaded.
+- When the loaded background is a *different* release than the import was cut
+  from, the exact identity won't be present, so linking falls back to the usual
+  attribute matching (name, location, unit). Those approximate links are flagged
+  on the database setup view (and in the load log) so you can verify the
+  dependency is the release you intended rather than trust a cross-version match
+  as exact.
+
 ## [0.7.0] - 2026-05-29
 
 A month of engine work: a third flow kind for waste, regionalized impact

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It loads EcoSpold2, EcoSpold1, SimaPro CSV, ILCD process, and Brightway Excel da
 
 - **Multiple database formats**: EcoSpold2 (.spold), EcoSpold1 (.xml), SimaPro CSV, ILCD process datasets, Brightway Excel (.xlsx)
 - **Archive support**: Load databases directly from .zip, .7z, .gz, or .xz archives — no manual extraction
-- **Cross-database linking**: Resolve supplier references across databases, with configurable dependencies and topological load ordering
+- **Cross-database linking**: Resolve supplier references across databases, with configurable dependencies and topological load ordering. EcoSpold2 inputs link to a loaded background by exact `activityLinkId` identity (so a partial import resolves against its matching release), falling back to attribute matching — flagged as approximate — when the background is a different release
 - **Cross-DB what-if substitutions**: Swap an upstream activity at any depth — including suppliers in dependency databases — and recompute inventory and impacts through one endpoint
 - **LCIA method collections**: Load ILCD method packages (ZIP or directory), SimaPro method CSV exports, or tabular CSV from config
 - **Normalization and weighting**: Batch LCIA computes normalized and weighted scores per category and a single aggregated score (Pt) when NW data is present in the method collection

--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -43,6 +43,7 @@ module Database.CrossLinking (
     -- * Main Functions
     findSupplierAcrossDatabases,
     findSupplierInIndexedDBs,
+    findSupplierByActivityProduct,
     findWasteTreatmentAcrossDatabases,
     WasteTreatmentMatch (..),
 
@@ -110,6 +111,13 @@ data IndexedDatabase = IndexedDatabase
     , idbWasteTreatmentByCanonicalName :: !(M.Map Text [SupplierEntry])
     {- ^ normalizeText (wfName) → same set, for the name-based fallback when
     two databases use different UUIDs for the same canonical waste flow.
+    -}
+    , idbByActivityProduct :: !(M.Map (UUID, UUID) SupplierEntry)
+    {- ^ (activityUUID, productUUID) → supplier. The exact-identity index for
+    EcoSpold2↔EcoSpold2 linking: an input's @(activityLinkId, flowId)@ is the
+    supplier's @(activityUUID, referenceProductUUID)@ key, so this resolves a
+    partial import's background references with no name/location guessing. One
+    supplier per key (location variants of the same activity coincide here).
     -}
     }
 
@@ -342,13 +350,23 @@ buildIndexedDatabase dbName synDB db =
         wasteEntries = buildWasteTreatmentEntries db
         wasteByUUID = M.fromListWith (++) [(uuid, [entry]) | (uuid, _, entry) <- wasteEntries]
         wasteByName = M.fromListWith (++) [(normalizeText name, [entry]) | (_, name, entry) <- wasteEntries, not (T.null (normalizeText name))]
+        byActProd = indexByActivityProduct entries
      in IndexedDatabase
             { idbName = dbName
             , idbByProductName = byName
             , idbBySynonymGroup = bySynonym
             , idbWasteTreatmentByFlowUUID = wasteByUUID
             , idbWasteTreatmentByCanonicalName = wasteByName
+            , idbByActivityProduct = byActProd
             }
+
+{- | Index supplier entries by their @(activityUUID, productUUID)@ identity.
+Location variants of one activity share that key, so last-wins is harmless —
+they carry the same activity, product, unit and name.
+-}
+indexByActivityProduct :: [(Text, SupplierEntry)] -> M.Map (UUID, UUID) SupplierEntry
+indexByActivityProduct entries =
+    M.fromList [((seActivityUUID e, seProductUUID e), e) | (_, e) <- entries]
 
 {- | Build supplier entries from a SimpleDatabase. Reference exchanges of
 production processes are always technosphere outputs, so the supplier flow
@@ -404,12 +422,14 @@ buildIndexedDatabaseFromDB dbName synDB db =
         wasteEntries = buildWasteTreatmentEntriesFromDB db
         wasteByUUID = M.fromListWith (++) [(uuid, [entry]) | (uuid, _, entry) <- wasteEntries]
         wasteByName = M.fromListWith (++) [(normalizeText name, [entry]) | (_, name, entry) <- wasteEntries, not (T.null (normalizeText name))]
+        byActProd = indexByActivityProduct entries
      in IndexedDatabase
             { idbName = dbName
             , idbByProductName = byName
             , idbBySynonymGroup = bySynonym
             , idbWasteTreatmentByFlowUUID = wasteByUUID
             , idbWasteTreatmentByCanonicalName = wasteByName
+            , idbByActivityProduct = byActProd
             }
 
 {- | Build supplier entries from a full Database. Same invariant as
@@ -670,6 +690,25 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
                 , cdbLocation = seLocation
                 , cdbProductName = seProductName
                 }
+
+{- | Resolve a supplier by exact @(activityUUID, productUUID)@ identity across
+the indexed databases. An EcoSpold2 input's @(activityLinkId, flowId)@ is
+exactly the supplier's @(activityUUID, referenceProductUUID)@ key, so this is
+how a partial import resolves its background references with no name/location
+guessing — the dataset author's own disambiguation, honoured verbatim.
+
+Returns every database that ships the identical activity+product, in the order
+of the indexed-database list. Callers take the head as the supplier and the
+remaining database names as tied alternatives (for minimal-dependency
+pre-selection). Empty when no loaded dependency provides this exact identity —
+the cross-version case, where the caller falls back to attribute matching.
+-}
+findSupplierByActivityProduct :: [IndexedDatabase] -> UUID -> UUID -> [(SupplierEntry, Text)]
+findSupplierByActivityProduct idbs actUUID prodUUID =
+    [ (entry, idbName idb)
+    | idb <- idbs
+    , Just entry <- [M.lookup (actUUID, prodUUID) (idbByActivityProduct idb)]
+    ]
 
 -- | Legacy function for backward compatibility (slower, builds indexes on the fly)
 findSupplierAcrossDatabases ::

--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -361,8 +361,9 @@ buildIndexedDatabase dbName synDB db =
             }
 
 {- | Index supplier entries by their @(activityUUID, productUUID)@ identity.
-Location variants of one activity share that key, so last-wins is harmless —
-they carry the same activity, product, unit and name.
+Each location variant is a distinct activity with its own activity UUID, so
+variants do not collide here; a collision can only be a genuine duplicate of the
+same activity+product, making last-wins harmless.
 -}
 indexByActivityProduct :: [(Text, SupplierEntry)] -> M.Map (UUID, UUID) SupplierEntry
 indexByActivityProduct entries =

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -87,7 +87,7 @@ import Data.Either (partitionEithers)
 import Data.List (sort, sortBy, sortOn)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
-import Data.Maybe (fromMaybe, isNothing)
+import Data.Maybe (fromMaybe, isJust, isNothing)
 import Data.Ord (Down (..))
 import qualified Data.Set as S
 import Data.Store (decodeEx, encode)
@@ -1316,13 +1316,38 @@ countTotalTechInputs db =
         , isSupplierDemand ex
         ]
 
-{- | Consumer @(activityUUID, productUUID, flowId)@ triples already resolved by a
-cross-DB link. A dangling non-nil input whose triple is in this set is supplied
-from a dependency (by identity or attributes) and must not be reported as a gap.
+{- | How many cross-DB links resolve each consumer @(activityUUID, productUUID,
+flowId)@ triple. The engine resolves a demand by @(activityLinkId, flowId)@, so
+one activity can consume the same product flow from several suppliers; counting
+coverage (rather than testing set membership) lets the dangling scan drop exactly
+the covered occurrences and still name a genuinely unresolved sibling.
 -}
-crossDBCoveredFlows :: [CrossDBLink] -> S.Set (UUID.UUID, UUID.UUID, UUID.UUID)
-crossDBCoveredFlows links =
-    S.fromList [(cdlConsumerActUUID l, cdlConsumerProdUUID l, cdlConsumerFlowId l) | l <- links]
+crossDBCoveredCounts :: [CrossDBLink] -> M.Map (UUID.UUID, UUID.UUID, UUID.UUID) Int
+crossDBCoveredCounts links =
+    M.fromListWith (+) [((cdlConsumerActUUID l, cdlConsumerProdUUID l, cdlConsumerFlowId l), 1) | l <- links]
+
+{- | Tally dangling product names from @(consumer-triple, productName)@ pairs,
+dropping per triple as many occurrences as 'crossDBCoveredCounts' already
+covers. Inputs sharing a triple share a product name, so the surplus over the
+covered count is the real gap.
+-}
+tallyDangling ::
+    M.Map (UUID.UUID, UUID.UUID, UUID.UUID) Int ->
+    [((UUID.UUID, UUID.UUID, UUID.UUID), T.Text)] ->
+    M.Map T.Text Int
+tallyDangling covered inputs =
+    M.fromListWith
+        (+)
+        [ (name, surplus)
+        | (triple, (name, n)) <- M.toList byTriple
+        , let surplus = n - M.findWithDefault 0 triple covered
+        , surplus > 0
+        ]
+  where
+    byTriple =
+        M.fromListWith
+            (\(nm, a) (_, b) -> (nm, a + b))
+            [(triple, (name, 1 :: Int)) | (triple, name) <- inputs]
 
 {- | Product names of a *loaded* database's dangling internal links: non-nil
 @activityLinkId@ inputs that 'findProducer' cannot resolve against the
@@ -1333,24 +1358,23 @@ inputs, the cross-DB candidates already tracked in the linking stats.
 
 Sharing 'findProducer' keeps this honest with the matrix even once
 @techProcessLinkId@ is populated: an input whose process link resolves is not
-dangling, however its activity link looks. Excluding 'dbCrossDBLinks' keeps it
-honest the other way: once the matching background is loaded, a UUID- or
-attribute-resolved input is supplied, not missing.
+dangling, however its activity link looks. Subtracting per-triple cross-DB
+coverage ('crossDBCoveredCounts') keeps it honest the other way: once the
+matching background is loaded, a UUID- or attribute-resolved input is supplied,
+not missing.
 -}
 collectDanglingProductNames :: Database -> M.Map T.Text Int
 collectDanglingProductNames db =
-    let covered = crossDBCoveredFlows (dbCrossDBLinks db)
-     in M.fromListWith
-            (+)
-            [ (tfName flow, 1)
-            | ((actUUID, prodUUID), act) <- zip (V.toList (dbProcessIdTable db)) (V.toList (dbActivities db))
-            , ex@TechnosphereExchange{} <- exchanges act
-            , isSupplierDemand ex
-            , isNothing (findProducer (dbProcessIdLookup db) ex)
-            , Just _ <- [exchangeActivityLinkId ex]
-            , S.notMember (actUUID, prodUUID, exchangeFlowId ex) covered
-            , Just flow <- [M.lookup (exchangeFlowId ex) (dbTechFlows db)]
-            ]
+    tallyDangling
+        (crossDBCoveredCounts (dbCrossDBLinks db))
+        [ ((actUUID, prodUUID, exchangeFlowId ex), tfName flow)
+        | ((actUUID, prodUUID), act) <- zip (V.toList (dbProcessIdTable db)) (V.toList (dbActivities db))
+        , ex@TechnosphereExchange{} <- exchanges act
+        , isSupplierDemand ex
+        , isNothing (findProducer (dbProcessIdLookup db) ex)
+        , Just _ <- [exchangeActivityLinkId ex]
+        , Just flow <- [M.lookup (exchangeFlowId ex) (dbTechFlows db)]
+        ]
 
 {- | Staged-path counterpart of 'collectDanglingProductNames' on a
 'SimpleDatabase' plus its just-computed links. A 'SimpleDatabase' has no process
@@ -1359,18 +1383,33 @@ coverage against the supplied links rather than 'dbCrossDBLinks'.
 -}
 collectStagedDanglingProductNames :: SimpleDatabase -> [CrossDBLink] -> M.Map T.Text Int
 collectStagedDanglingProductNames db links =
-    let covered = crossDBCoveredFlows links
-     in M.fromListWith
-            (+)
-            [ (tfName flow, 1)
-            | ((actUUID, prodUUID), act) <- M.toList (sdbActivities db)
-            , ex@TechnosphereExchange{} <- exchanges act
-            , isSupplierDemand ex
-            , not (hasInternalProducer db ex)
-            , Just _ <- [exchangeActivityLinkId ex]
-            , S.notMember (actUUID, prodUUID, exchangeFlowId ex) covered
-            , Just flow <- [M.lookup (exchangeFlowId ex) (sdbTechFlows db)]
-            ]
+    tallyDangling
+        (crossDBCoveredCounts links)
+        [ ((actUUID, prodUUID, exchangeFlowId ex), tfName flow)
+        | ((actUUID, prodUUID), act) <- M.toList (sdbActivities db)
+        , ex@TechnosphereExchange{} <- exchanges act
+        , isSupplierDemand ex
+        , not (hasInternalProducer db ex)
+        , Just _ <- [exchangeActivityLinkId ex]
+        , Just flow <- [M.lookup (exchangeFlowId ex) (sdbTechFlows db)]
+        ]
+
+{- | Per-run linking environment: the cross-DB context, the consumer database's
+own activity-key set (for the internal-resolution gate), and its flow tables.
+Bundled so the per-activity / per-exchange matchers keep short signatures.
+
+@lsOwnKeys@ lets the per-exchange matcher tell a non-nil link that resolves
+*internally* (the matrix builder handles it) from a dangling one that needs a
+cross-DB supplier — so we never emit a redundant cross-DB link for an input
+already satisfied in place.
+-}
+data LinkScan = LinkScan
+    { lsCtx :: !LinkingContext
+    , lsOwnKeys :: !(S.Set (UUID.UUID, UUID.UUID))
+    , lsTechFlows :: !TechFlowDB
+    , lsWasteFlows :: !WasteFlowDB
+    , lsUnits :: !UnitDB
+    }
 
 {- | Find all cross-database links without modifying activities
 Returns statistics including the CrossDBLinks for chained solving
@@ -1383,29 +1422,19 @@ findAllCrossDBLinks ::
     ActivityMap ->
     CrossDBLinkingStats
 findAllCrossDBLinks ctx techFlowDb wasteFlowDb unitDb activities =
-    -- The own-key set lets the per-exchange matcher tell a non-nil link that
-    -- resolves *internally* (the matrix builder handles it) from a dangling
-    -- one that needs a cross-DB supplier — so we never emit a redundant
-    -- cross-DB link for an input already satisfied in place.
-    let !ownKeys = M.keysSet activities
-        results = M.mapWithKey (findActivityCrossDBLinks ctx ownKeys techFlowDb wasteFlowDb unitDb) activities
+    let !scan = LinkScan ctx (M.keysSet activities) techFlowDb wasteFlowDb unitDb
+        results = M.mapWithKey (findActivityCrossDBLinks scan) activities
      in mconcat (M.elems results)
 
 -- | Find cross-database links for one activity's exchanges
 findActivityCrossDBLinks ::
-    LinkingContext ->
-    -- | Activity keys present in this database (for internal-resolution check)
-    S.Set (UUID.UUID, UUID.UUID) ->
-    TechFlowDB ->
-    WasteFlowDB ->
-    UnitDB ->
+    LinkScan ->
     -- | Consumer activity key (actUUID, prodUUID)
     (UUID.UUID, UUID.UUID) ->
     Activity ->
     CrossDBLinkingStats
-findActivityCrossDBLinks ctx ownKeys techFlowDb wasteFlowDb unitDb (consumerActUUID, consumerProdUUID) act =
-    let stats = map (findExchangeCrossDBLink ctx ownKeys techFlowDb wasteFlowDb unitDb consumerActUUID consumerProdUUID) (exchanges act)
-     in mconcat stats
+findActivityCrossDBLinks scan (consumerActUUID, consumerProdUUID) act =
+    mconcat (map (findExchangeCrossDBLink scan consumerActUUID consumerProdUUID) (exchanges act))
 
 {- | Find cross-database link for a single exchange.
 
@@ -1423,28 +1452,27 @@ cascade:
    from every dependency, so the match is a likely cross-version stitch,
    recorded in 'cdlAttributeFallbacks' for the consumer to verify.
 
-A non-nil link whose target *is* in this database resolves in the internal
-matrix; emitting a cross-DB link too would double-count it, so 'ownKeys' gates
-it out. Orphan waste outputs (waIsInput=False, linkId=nil) use the strict
+A link whose target resolves in the internal matrix would be double-counted by
+a cross-DB link too, so 'resolvesInternally' gates it out — mirroring
+'Database.MatrixBuild.findProducer': a populated process link, or a non-nil
+@activityLinkId@ whose @(linkId, flowId)@ key is one of this database's own
+('lsOwnKeys'). Orphan waste outputs (waIsInput=False, linkId=nil) use the strict
 'findWasteTreatmentAcrossDatabases' — no synonym, no widening.
 -}
 findExchangeCrossDBLink ::
-    LinkingContext ->
-    -- | Activity keys present in this database (internal-resolution check)
-    S.Set (UUID.UUID, UUID.UUID) ->
-    TechFlowDB ->
-    WasteFlowDB ->
-    UnitDB ->
+    LinkScan ->
     UUID.UUID ->
     UUID.UUID ->
     Exchange ->
     CrossDBLinkingStats
-findExchangeCrossDBLink ctx ownKeys techFlowDb _wasteFlowDb unitDb consumerActUUID consumerProdUUID ex@TechnosphereExchange{techFlowId = fid, techAmount = amt, techActivityLinkId = linkId, techLocation = loc}
-    | exchangeIsInput ex && not resolvesInternally =
+findExchangeCrossDBLink LinkScan{lsCtx = ctx, lsOwnKeys = ownKeys, lsTechFlows = techFlowDb, lsUnits = unitDb} consumerActUUID consumerProdUUID ex@TechnosphereExchange{techFlowId = fid, techAmount = amt, techActivityLinkId = linkId, techLocation = loc}
+    | isSupplierDemand ex && not resolvesInternally =
         maybe mempty resolveTechInput (M.lookup fid techFlowDb)
     | otherwise = mempty
   where
-    resolvesInternally = linkId /= UUID.nil && S.member (linkId, fid) ownKeys
+    resolvesInternally =
+        isJust (exchangeProcessLinkId ex)
+            || (linkId /= UUID.nil && S.member (linkId, fid) ownKeys)
     mkTechLink supAct supProd supName supLoc srcDb tied flowUnitName =
         CrossDBLink
             { cdlConsumerActUUID = consumerActUUID
@@ -1526,13 +1554,13 @@ findExchangeCrossDBLink ctx ownKeys techFlowDb _wasteFlowDb unitDb consumerActUU
                 { cdlUnresolvedProducts = M.singleton (tfName flow) (1, blocker)
                 , cdlLocationUnresolved = unresolved
                 }
-findExchangeCrossDBLink _ _ _ _ _ _ _ BiosphereExchange{} = mempty
+findExchangeCrossDBLink _ _ _ BiosphereExchange{} = mempty
 -- Cross-DB linking for orphan waste OUTPUTS: strict match only — see
 -- 'findWasteTreatmentAcrossDatabases'. No synonym, no fuzzy name match, no
 -- location widening. Multi-DB matches stay orphan as 'cdlWasteAmbiguous'.
 -- Waste inputs (treatment side) are left alone: they have no clean LCA
 -- semantic as a cross-DB demand.
-findExchangeCrossDBLink ctx _ _ wasteFlowDb _ consumerActUUID consumerProdUUID WasteExchange{waFlowId = fid, waAmount = amt, waActivityLinkId = lid, waIsInput = isInp}
+findExchangeCrossDBLink LinkScan{lsCtx = ctx, lsWasteFlows = wasteFlowDb} consumerActUUID consumerProdUUID WasteExchange{waFlowId = fid, waAmount = amt, waActivityLinkId = lid, waIsInput = isInp}
     | not isInp && lid == UUID.nil =
         let flowName = maybe "" wfName (M.lookup fid wasteFlowDb)
          in case findWasteTreatmentAcrossDatabases ctx fid flowName of

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -54,6 +54,7 @@ module Database.Loader (
     countTotalTechInputs,
     countUnlinkedExchanges,
     collectDanglingProductNames,
+    collectStagedDanglingProductNames,
 
     -- * Internal Linking
     fixSimaProActivityLinks,
@@ -109,6 +110,7 @@ import Database.CrossLinking (
     defaultLinkingThreshold,
     extractProductPrefixes,
     findSupplierAcrossDatabases,
+    findSupplierByActivityProduct,
     findWasteTreatmentAcrossDatabases,
     locationHierarchy,
     normalizeUnicode,
@@ -1314,29 +1316,61 @@ countTotalTechInputs db =
         , isSupplierDemand ex
         ]
 
+{- | Consumer @(activityUUID, productUUID, flowId)@ triples already resolved by a
+cross-DB link. A dangling non-nil input whose triple is in this set is supplied
+from a dependency (by identity or attributes) and must not be reported as a gap.
+-}
+crossDBCoveredFlows :: [CrossDBLink] -> S.Set (UUID.UUID, UUID.UUID, UUID.UUID)
+crossDBCoveredFlows links =
+    S.fromList [(cdlConsumerActUUID l, cdlConsumerProdUUID l, cdlConsumerFlowId l) | l <- links]
+
 {- | Product names of a *loaded* database's dangling internal links: non-nil
 @activityLinkId@ inputs that 'findProducer' cannot resolve against the
-database's own process lookup (the matrix builder silently drops them). The
-loaded-path counterpart that names the supplier gaps a partial EcoSpold2 import
-leaves behind — distinct from nil-link inputs, the cross-DB candidates already
-tracked in the linking stats.
+database's own process lookup (the matrix builder silently drops them) *and*
+that no cross-DB link supplies. The loaded-path counterpart that names the
+supplier gaps a partial EcoSpold2 import leaves behind — distinct from nil-link
+inputs, the cross-DB candidates already tracked in the linking stats.
 
 Sharing 'findProducer' keeps this honest with the matrix even once
 @techProcessLinkId@ is populated: an input whose process link resolves is not
-dangling, however its activity link looks.
+dangling, however its activity link looks. Excluding 'dbCrossDBLinks' keeps it
+honest the other way: once the matching background is loaded, a UUID- or
+attribute-resolved input is supplied, not missing.
 -}
 collectDanglingProductNames :: Database -> M.Map T.Text Int
 collectDanglingProductNames db =
-    M.fromListWith
-        (+)
-        [ (tfName flow, 1)
-        | act <- V.toList (dbActivities db)
-        , ex@TechnosphereExchange{} <- exchanges act
-        , isSupplierDemand ex
-        , isNothing (findProducer (dbProcessIdLookup db) ex)
-        , Just _ <- [exchangeActivityLinkId ex]
-        , Just flow <- [M.lookup (exchangeFlowId ex) (dbTechFlows db)]
-        ]
+    let covered = crossDBCoveredFlows (dbCrossDBLinks db)
+     in M.fromListWith
+            (+)
+            [ (tfName flow, 1)
+            | ((actUUID, prodUUID), act) <- zip (V.toList (dbProcessIdTable db)) (V.toList (dbActivities db))
+            , ex@TechnosphereExchange{} <- exchanges act
+            , isSupplierDemand ex
+            , isNothing (findProducer (dbProcessIdLookup db) ex)
+            , Just _ <- [exchangeActivityLinkId ex]
+            , S.notMember (actUUID, prodUUID, exchangeFlowId ex) covered
+            , Just flow <- [M.lookup (exchangeFlowId ex) (dbTechFlows db)]
+            ]
+
+{- | Staged-path counterpart of 'collectDanglingProductNames' on a
+'SimpleDatabase' plus its just-computed links. A 'SimpleDatabase' has no process
+lookup yet, so internal resolution is checked with 'hasInternalProducer' and
+coverage against the supplied links rather than 'dbCrossDBLinks'.
+-}
+collectStagedDanglingProductNames :: SimpleDatabase -> [CrossDBLink] -> M.Map T.Text Int
+collectStagedDanglingProductNames db links =
+    let covered = crossDBCoveredFlows links
+     in M.fromListWith
+            (+)
+            [ (tfName flow, 1)
+            | ((actUUID, prodUUID), act) <- M.toList (sdbActivities db)
+            , ex@TechnosphereExchange{} <- exchanges act
+            , isSupplierDemand ex
+            , not (hasInternalProducer db ex)
+            , Just _ <- [exchangeActivityLinkId ex]
+            , S.notMember (actUUID, prodUUID, exchangeFlowId ex) covered
+            , Just flow <- [M.lookup (exchangeFlowId ex) (sdbTechFlows db)]
+            ]
 
 {- | Find all cross-database links without modifying activities
 Returns statistics including the CrossDBLinks for chained solving
@@ -1349,12 +1383,19 @@ findAllCrossDBLinks ::
     ActivityMap ->
     CrossDBLinkingStats
 findAllCrossDBLinks ctx techFlowDb wasteFlowDb unitDb activities =
-    let results = M.mapWithKey (findActivityCrossDBLinks ctx techFlowDb wasteFlowDb unitDb) activities
+    -- The own-key set lets the per-exchange matcher tell a non-nil link that
+    -- resolves *internally* (the matrix builder handles it) from a dangling
+    -- one that needs a cross-DB supplier — so we never emit a redundant
+    -- cross-DB link for an input already satisfied in place.
+    let !ownKeys = M.keysSet activities
+        results = M.mapWithKey (findActivityCrossDBLinks ctx ownKeys techFlowDb wasteFlowDb unitDb) activities
      in mconcat (M.elems results)
 
 -- | Find cross-database links for one activity's exchanges
 findActivityCrossDBLinks ::
     LinkingContext ->
+    -- | Activity keys present in this database (for internal-resolution check)
+    S.Set (UUID.UUID, UUID.UUID) ->
     TechFlowDB ->
     WasteFlowDB ->
     UnitDB ->
@@ -1362,21 +1403,35 @@ findActivityCrossDBLinks ::
     (UUID.UUID, UUID.UUID) ->
     Activity ->
     CrossDBLinkingStats
-findActivityCrossDBLinks ctx techFlowDb wasteFlowDb unitDb (consumerActUUID, consumerProdUUID) act =
-    let stats = map (findExchangeCrossDBLink ctx techFlowDb wasteFlowDb unitDb consumerActUUID consumerProdUUID) (exchanges act)
+findActivityCrossDBLinks ctx ownKeys techFlowDb wasteFlowDb unitDb (consumerActUUID, consumerProdUUID) act =
+    let stats = map (findExchangeCrossDBLink ctx ownKeys techFlowDb wasteFlowDb unitDb consumerActUUID consumerProdUUID) (exchanges act)
      in mconcat stats
 
 {- | Find cross-database link for a single exchange.
 
-Two paths:
-* Technosphere inputs whose linkId is nil: use the existing scored matcher
-  ('findSupplierAcrossDatabases').
-* Orphan waste outputs (waIsInput=False, linkId=nil): strict-match only via
-  'findWasteTreatmentAcrossDatabases' — no synonym, no widening; one DB
-  wins or stays orphan, multi-DB matches count as ambiguous.
+Technosphere inputs that need a supplier (nil-link, or a non-nil
+'activityLinkId' to an activity this database does not ship) resolve via a
+cascade:
+
+1. __Exact source identity__ — @(activityLinkId, flowId)@ matched verbatim in a
+   dependency ('findSupplierByActivityProduct'). The same-release case; the
+   dataset author's own disambiguation, no guessing. Nil-link inputs skip this
+   tier (they carry no identity).
+2. __Attribute matching__ — name / location / unit scoring
+   ('findSupplierAcrossDatabases'), the matcher every other cross-link uses.
+   When a *non-nil* input falls through to here its source activity was absent
+   from every dependency, so the match is a likely cross-version stitch,
+   recorded in 'cdlAttributeFallbacks' for the consumer to verify.
+
+A non-nil link whose target *is* in this database resolves in the internal
+matrix; emitting a cross-DB link too would double-count it, so 'ownKeys' gates
+it out. Orphan waste outputs (waIsInput=False, linkId=nil) use the strict
+'findWasteTreatmentAcrossDatabases' — no synonym, no widening.
 -}
 findExchangeCrossDBLink ::
     LinkingContext ->
+    -- | Activity keys present in this database (internal-resolution check)
+    S.Set (UUID.UUID, UUID.UUID) ->
     TechFlowDB ->
     WasteFlowDB ->
     UnitDB ->
@@ -1384,61 +1439,100 @@ findExchangeCrossDBLink ::
     UUID.UUID ->
     Exchange ->
     CrossDBLinkingStats
-findExchangeCrossDBLink ctx techFlowDb _wasteFlowDb unitDb consumerActUUID consumerProdUUID ex@TechnosphereExchange{techFlowId = fid, techAmount = amt, techActivityLinkId = linkId, techLocation = loc}
-    | exchangeIsInput ex && linkId == UUID.nil =
-        case M.lookup fid techFlowDb of
-            Nothing -> mempty
-            Just flow ->
-                let flowUnitName = maybe "" unitName (M.lookup (tfUnitId flow) unitDb)
-                 in case findSupplierAcrossDatabases ctx (tfName flow) loc flowUnitName of
-                        result@CrossDBLinked{} ->
-                            let !crossLink =
-                                    CrossDBLink
-                                        { cdlConsumerActUUID = consumerActUUID
-                                        , cdlConsumerProdUUID = consumerProdUUID
-                                        , cdlConsumerFlowId = fid
-                                        , cdlSupplierActUUID = cdlrActivityUUID result
-                                        , cdlSupplierProdUUID = cdlrProductUUID result
-                                        , cdlCoefficient = amt
-                                        , cdlExchangeUnit = flowUnitName
-                                        , cdlFlowName = cdlrProductName result
-                                        , cdlLocation = cdlrLocation result
-                                        , cdlSourceDatabase = cdlrDatabaseName result
-                                        , cdlTiedAlternatives = cdlrTiedDatabases result
-                                        }
-                                fallbacks =
-                                    [ LocationFallback (cdlrProductName result) req actLoc kind
-                                    | UpperLocationUsed req actLoc kind <- cdlrWarnings result
-                                    ]
-                             in mempty{cdlLinks = [crossLink], cdlLocationFallbacks = fallbacks}
-                        CrossDBNotLinked blocker ->
-                            let unresolved = case blocker of
-                                    LocationRejectedByPolicy req actLoc kind ->
-                                        [ LocationUnresolved
-                                            (tfName flow)
-                                            req
-                                            ( "policy rejected "
-                                                <> locationKindCode kind
-                                                <> " candidate "
-                                                <> actLoc
-                                            )
-                                        ]
-                                    LocationUnavailable req ->
-                                        [LocationUnresolved (tfName flow) req "no candidate above link threshold"]
-                                    NoNameMatch -> []
-                                    UnitIncompatible _ _ -> []
-                             in mempty
-                                    { cdlUnresolvedProducts = M.singleton (tfName flow) (1, blocker)
-                                    , cdlLocationUnresolved = unresolved
-                                    }
+findExchangeCrossDBLink ctx ownKeys techFlowDb _wasteFlowDb unitDb consumerActUUID consumerProdUUID ex@TechnosphereExchange{techFlowId = fid, techAmount = amt, techActivityLinkId = linkId, techLocation = loc}
+    | exchangeIsInput ex && not resolvesInternally =
+        maybe mempty resolveTechInput (M.lookup fid techFlowDb)
     | otherwise = mempty
-findExchangeCrossDBLink _ _ _ _ _ _ BiosphereExchange{} = mempty
+  where
+    resolvesInternally = linkId /= UUID.nil && S.member (linkId, fid) ownKeys
+    mkTechLink supAct supProd supName supLoc srcDb tied flowUnitName =
+        CrossDBLink
+            { cdlConsumerActUUID = consumerActUUID
+            , cdlConsumerProdUUID = consumerProdUUID
+            , cdlConsumerFlowId = fid
+            , cdlSupplierActUUID = supAct
+            , cdlSupplierProdUUID = supProd
+            , cdlCoefficient = amt
+            , cdlExchangeUnit = flowUnitName
+            , cdlFlowName = supName
+            , cdlLocation = supLoc
+            , cdlSourceDatabase = srcDb
+            , cdlTiedAlternatives = tied
+            }
+    resolveTechInput flow =
+        let flowUnitName = maybe "" unitName (M.lookup (tfUnitId flow) unitDb)
+            identityMatches =
+                if linkId == UUID.nil
+                    then []
+                    else findSupplierByActivityProduct (lcIndexedDatabases ctx) linkId fid
+         in case identityMatches of
+                ((entry, srcDb) : rest) ->
+                    let !crossLink =
+                            mkTechLink
+                                (seActivityUUID entry)
+                                (seProductUUID entry)
+                                (seProductName entry)
+                                (seLocation entry)
+                                srcDb
+                                (sort (map snd rest))
+                                flowUnitName
+                     in mempty{cdlLinks = [crossLink]}
+                [] -> attributeMatch flow flowUnitName
+    attributeMatch flow flowUnitName =
+        case findSupplierAcrossDatabases ctx (tfName flow) loc flowUnitName of
+            result@CrossDBLinked{} ->
+                let !crossLink =
+                        mkTechLink
+                            (cdlrActivityUUID result)
+                            (cdlrProductUUID result)
+                            (cdlrProductName result)
+                            (cdlrLocation result)
+                            (cdlrDatabaseName result)
+                            (cdlrTiedDatabases result)
+                            flowUnitName
+                    locFallbacks =
+                        [ LocationFallback (cdlrProductName result) req actLoc kind
+                        | UpperLocationUsed req actLoc kind <- cdlrWarnings result
+                        ]
+                    -- Non-nil input matched only by attributes: its named source
+                    -- activity was in no dependency — flag the cross-version risk.
+                    attrFallbacks =
+                        [ AttributeFallback (tfName flow) loc (cdlrLocation result) (cdlrDatabaseName result)
+                        | linkId /= UUID.nil
+                        ]
+                 in mempty
+                        { cdlLinks = [crossLink]
+                        , cdlLocationFallbacks = locFallbacks
+                        , cdlAttributeFallbacks = attrFallbacks
+                        }
+            CrossDBNotLinked blocker
+                -- Nil-link inputs report a rich blocker; a non-nil dangling input
+                -- (no identity, no attribute match) is left for the dangling scan.
+                | linkId == UUID.nil -> unresolvedStats flow blocker
+                | otherwise -> mempty
+    unresolvedStats flow blocker =
+        let unresolved = case blocker of
+                LocationRejectedByPolicy req actLoc kind ->
+                    [ LocationUnresolved
+                        (tfName flow)
+                        req
+                        ("policy rejected " <> locationKindCode kind <> " candidate " <> actLoc)
+                    ]
+                LocationUnavailable req ->
+                    [LocationUnresolved (tfName flow) req "no candidate above link threshold"]
+                NoNameMatch -> []
+                UnitIncompatible _ _ -> []
+         in mempty
+                { cdlUnresolvedProducts = M.singleton (tfName flow) (1, blocker)
+                , cdlLocationUnresolved = unresolved
+                }
+findExchangeCrossDBLink _ _ _ _ _ _ _ BiosphereExchange{} = mempty
 -- Cross-DB linking for orphan waste OUTPUTS: strict match only — see
 -- 'findWasteTreatmentAcrossDatabases'. No synonym, no fuzzy name match, no
 -- location widening. Multi-DB matches stay orphan as 'cdlWasteAmbiguous'.
 -- Waste inputs (treatment side) are left alone: they have no clean LCA
 -- semantic as a cross-DB demand.
-findExchangeCrossDBLink ctx _ wasteFlowDb _ consumerActUUID consumerProdUUID WasteExchange{waFlowId = fid, waAmount = amt, waActivityLinkId = lid, waIsInput = isInp}
+findExchangeCrossDBLink ctx _ _ wasteFlowDb _ consumerActUUID consumerProdUUID WasteExchange{waFlowId = fid, waAmount = amt, waActivityLinkId = lid, waIsInput = isInp}
     | not isInp && lid == UUID.nil =
         let flowName = maybe "" wfName (M.lookup fid wasteFlowDb)
          in case findWasteTreatmentAcrossDatabases ctx fid flowName of
@@ -1551,6 +1645,24 @@ reportCrossDBLinkingStats nActivities stats = do
                     (T.unpack luProduct)
                     (T.unpack luRequested)
                     (T.unpack luReason)
+
+    -- Attribute fallbacks: source-identity inputs matched by attributes because
+    -- no dependency shipped the exact activity — a likely cross-version stitch.
+    let !uniqueAttrFallbacks = deduplicateAttributeFallbacks (cdlAttributeFallbacks stats)
+        !nAttrFallbacks = length uniqueAttrFallbacks
+    when (nAttrFallbacks > 0) $ do
+        reportProgress Warning $
+            printf
+                "%d background link(s) matched by attributes, not source identity — verify the dependency is the same source release"
+                nAttrFallbacks
+        forM_ uniqueAttrFallbacks $ \AttributeFallback{afProduct, afRequested, afMatched, afSourceDatabase} ->
+            reportProgress Warning $
+                printf
+                    "  - %s [%s] → %s in %s"
+                    (T.unpack afProduct)
+                    (T.unpack afRequested)
+                    (T.unpack afMatched)
+                    (T.unpack afSourceDatabase)
 
 showBlocker :: LinkBlocker -> String
 showBlocker NoNameMatch = "Not found"

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -170,6 +170,7 @@ import qualified SharedSolver
 import SynonymDB (SynonymDB (..), buildFromCSV, buildFromPairs, emptySynonymDB, loadFromCSVFileWithCache, mergeSynonymDBs, synonymCount)
 import Types (
     Activity (..),
+    AttributeFallback (..),
     BioFlowDB,
     BiosphereFlow (..),
     CrossDBLink (..),
@@ -189,6 +190,7 @@ import Types (
     computeMinimalSelectedDeps,
     crossDBBySource,
     crossDBRedundantSources,
+    deduplicateAttributeFallbacks,
     deduplicateFallbacks,
     deduplicateUnresolved,
     exchangeFlowId,
@@ -342,6 +344,11 @@ data DatabaseSetupInfo = DatabaseSetupInfo
     , dsiLocationUnresolved :: ![LocationUnresolved]
     {- ^ Inputs that could not be linked because the database's
     'GeographyPolicy' rejected every candidate (or no candidate existed)
+    -}
+    , dsiAttributeFallbacks :: ![AttributeFallback]
+    {- ^ Source-identity inputs (non-nil 'activityLinkId') matched by attributes
+    because no loaded dependency shipped the exact activity — a likely
+    cross-version stitch the consumer should verify against the source release.
     -}
     , dsiDataPath :: !Text
     -- ^ Current selected data path (relative)
@@ -1749,17 +1756,12 @@ stageUploadedDatabase manager dbConfig = do
                                         simpleDb
                                 return (stats', simpleDb')
 
-                    let fromStats = [(name, cnt, blocker) | (name, (cnt, blocker)) <- M.toList (Loader.cdlUnresolvedProducts finalStats)]
-                        fromScan =
-                            if null fromStats && Loader.crossDBLinksCount finalStats == 0
-                                then [(name, cnt, NoNameMatch) | (name, cnt) <- M.toList (Loader.collectUnlinkedProductNames finalDB)]
-                                else fromStats
-                        staged =
+                    let staged =
                             StagedDatabase
                                 { sdSimpleDB = finalDB
                                 , sdConfig = dbConfig
                                 , sdUnlinkedCount = Loader.unresolvedCount finalStats
-                                , sdMissingProducts = sortOn (\(_, cnt, _) -> Down cnt) fromScan
+                                , sdMissingProducts = stagedMissingProducts finalDB finalStats
                                 , sdSelectedDeps = minimalDeps
                                 , sdCrossDBLinks = Loader.cdlLinks finalStats
                                 , sdLinkingStats = finalStats
@@ -1960,6 +1962,22 @@ buildSetupResult manager dbName = do
                  in return $ Right info{dsiIsLoaded = False}
             Nothing -> return $ Left $ SetupFailed $ "Failed to stage database: " <> dbName
 
+{- | Missing-supplier list for a staged database. Nil-link gaps carry the rich
+blockers the attribute matcher produced ('cdlUnresolvedProducts'); non-nil
+dangling gaps — a partial EcoSpold2 import whose background activities no loaded
+dependency ships, even after UUID + attribute linking — are scanned separately
+and named. The two sets are disjoint (nil vs non-nil), so the concatenation
+never duplicates. Sorted by activity count, descending.
+-}
+stagedMissingProducts :: SimpleDatabase -> CrossDBLinkingStats -> [(Text, Int, LinkBlocker)]
+stagedMissingProducts sdb stats =
+    let fromStats = [(name, cnt, blocker) | (name, (cnt, blocker)) <- M.toList (cdlUnresolvedProducts stats)]
+        fromDangling =
+            [ (name, cnt, NoNameMatch)
+            | (name, cnt) <- M.toList (Loader.collectStagedDanglingProductNames sdb (cdlLinks stats))
+            ]
+     in sortOn (\(_, cnt, _) -> Down cnt) (fromStats <> fromDangling)
+
 {- | Build setup info from a staged database
 dataPath and availablePaths are filled in by buildSetupResult (requires IO)
 -}
@@ -2013,6 +2031,7 @@ buildStagedSetupInfo staged configs indexedDbs =
             , dsiUnknownUnits = S.toList (cdlUnknownUnits stats)
             , dsiLocationFallbacks = deduplicateFallbacks (cdlLocationFallbacks stats)
             , dsiLocationUnresolved = deduplicateUnresolved (cdlLocationUnresolved stats)
+            , dsiAttributeFallbacks = deduplicateAttributeFallbacks (cdlAttributeFallbacks stats)
             , dsiDataPath = T.pack (dcPath (sdConfig staged))
             , dsiAvailablePaths = [] -- Filled in by buildSetupResult (requires IO)
             , dsiIsLoaded = False
@@ -2072,6 +2091,7 @@ buildLoadedSetupInfo config db configs indexedDbs =
             , dsiUnknownUnits = S.toList (cdlUnknownUnits stats)
             , dsiLocationFallbacks = deduplicateFallbacks (cdlLocationFallbacks stats)
             , dsiLocationUnresolved = deduplicateUnresolved (cdlLocationUnresolved stats)
+            , dsiAttributeFallbacks = deduplicateAttributeFallbacks (cdlAttributeFallbacks stats)
             , dsiDataPath = T.pack (dcPath config)
             , dsiAvailablePaths = [] -- No picker for loaded/configured databases
             , dsiIsLoaded = True
@@ -2208,10 +2228,7 @@ restageLoadedDatabase manager dbName ld = do
                 { sdSimpleDB = toSimpleDatabase db
                 , sdConfig = ldConfig ld
                 , sdUnlinkedCount = unresolvedCount stats
-                , sdMissingProducts =
-                    sortOn
-                        (\(_, cnt, _) -> Down cnt)
-                        [(n, cnt, blocker) | (n, (cnt, blocker)) <- M.toList (cdlUnresolvedProducts stats)]
+                , sdMissingProducts = stagedMissingProducts (toSimpleDatabase db) stats
                 , sdSelectedDeps = dbDependsOn db
                 , sdCrossDBLinks = dbCrossDBLinks db
                 , sdLinkingStats = stats
@@ -2272,7 +2289,7 @@ addDependencyToStaged manager dbName depName = do
                             { sdSelectedDeps = newDeps
                             , sdCrossDBLinks = Loader.cdlLinks newStats
                             , sdLinkingStats = newStats
-                            , sdMissingProducts = sortOn (\(_, cnt, _) -> Down cnt) [(name, cnt, blocker) | (name, (cnt, blocker)) <- M.toList (Loader.cdlUnresolvedProducts newStats)]
+                            , sdMissingProducts = stagedMissingProducts (sdSimpleDB staged) newStats
                             }
 
                 -- Save updated staged database
@@ -2311,7 +2328,7 @@ removeDependencyFromStaged manager dbName depName = do
                         { sdSelectedDeps = newDeps
                         , sdCrossDBLinks = Loader.cdlLinks newStats
                         , sdLinkingStats = newStats
-                        , sdMissingProducts = sortOn (\(_, cnt, _) -> Down cnt) [(name, cnt, blocker) | (name, (cnt, blocker)) <- M.toList (Loader.cdlUnresolvedProducts newStats)]
+                        , sdMissingProducts = stagedMissingProducts (sdSimpleDB staged) newStats
                         }
 
             atomically $ modifyTVar' (dmStagedDbs manager) (M.insert dbName updatedStaged)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1155,6 +1155,31 @@ data LocationUnresolved = LocationUnresolved
     deriving (Show, Eq, Generic, NFData, Store)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped LocationUnresolved)
 
+{- | An input that named a specific source supplier by @activityLinkId@ which no
+loaded dependency provides, so it was resolved by attribute matching (name /
+location / unit) instead of exact identity.
+
+This is the cross-version signal: a partial EcoSpold2 import carries the
+activity UUIDs of the exact ecoinvent release it was cut from. Linking it
+against a *different* release leaves those UUIDs unmatched, and the attribute
+matcher stitches an approximate supplier in their place. Surfacing these lets a
+consumer verify the dependency is the intended release rather than trust an
+approximate match as exact. Distinct from nil-link inputs (SimaPro), which never
+had a source identity and whose attribute match is expected, not a caveat.
+-}
+data AttributeFallback = AttributeFallback
+    { afProduct :: !Text
+    -- ^ Consumer-side product name that was matched
+    , afRequested :: !Text
+    -- ^ Location requested by the consumer input
+    , afMatched :: !Text
+    -- ^ Location of the supplier actually linked
+    , afSourceDatabase :: !Text
+    -- ^ Dependency that supplied the attribute match
+    }
+    deriving (Show, Eq, Generic, NFData, Store)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped AttributeFallback)
+
 {- | Statistics from cross-database linking
 Only essential state is stored; counts are derived via accessor functions.
 -}
@@ -1169,6 +1194,8 @@ data CrossDBLinkingStats = CrossDBLinkingStats
     -- ^ Accepted links with widened geography, tagged with 'LocationKind'
     , cdlLocationUnresolved :: ![LocationUnresolved]
     -- ^ Inputs rejected by policy or with no candidate
+    , cdlAttributeFallbacks :: ![AttributeFallback]
+    -- ^ Source-identity inputs matched by attributes instead (cross-version)
     , cdlTotalInputs :: !Int
     -- ^ Total technosphere inputs at time of linking
     , cdlWasteExactLinks :: !Int
@@ -1193,6 +1220,7 @@ instance Semigroup CrossDBLinkingStats where
             , cdlUnknownUnits = cdlUnknownUnits s1 <> cdlUnknownUnits s2
             , cdlLocationFallbacks = cdlLocationFallbacks s1 <> cdlLocationFallbacks s2
             , cdlLocationUnresolved = cdlLocationUnresolved s1 <> cdlLocationUnresolved s2
+            , cdlAttributeFallbacks = cdlAttributeFallbacks s1 <> cdlAttributeFallbacks s2
             , cdlTotalInputs = cdlTotalInputs s1 + cdlTotalInputs s2
             , cdlWasteExactLinks = cdlWasteExactLinks s1 + cdlWasteExactLinks s2
             , cdlWasteAmbiguous = cdlWasteAmbiguous s1 + cdlWasteAmbiguous s2
@@ -1202,7 +1230,7 @@ instance Semigroup CrossDBLinkingStats where
         mergeUnresolved (c1, b) (c2, _) = (c1 + c2, b)
 
 instance Monoid CrossDBLinkingStats where
-    mempty = CrossDBLinkingStats [] M.empty S.empty [] [] 0 0 0 0
+    mempty = CrossDBLinkingStats [] M.empty S.empty [] [] [] 0 0 0 0
 
 -- | Deduplicate location fallbacks by (product, requestedLoc)
 deduplicateFallbacks :: [LocationFallback] -> [LocationFallback]
@@ -1219,6 +1247,14 @@ deduplicateUnresolved =
         . M.toList
         . M.fromListWith (\_ b -> b)
         . map (\u -> ((luProduct u, luRequested u), u))
+
+-- | Deduplicate attribute fallbacks by (product, requestedLoc)
+deduplicateAttributeFallbacks :: [AttributeFallback] -> [AttributeFallback]
+deduplicateAttributeFallbacks =
+    map snd
+        . M.toList
+        . M.fromListWith (\_ b -> b)
+        . map (\a -> ((afProduct a, afRequested a), a))
 
 -- | Number of resolved cross-DB links
 crossDBLinksCount :: CrossDBLinkingStats -> Int

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1230,7 +1230,19 @@ instance Semigroup CrossDBLinkingStats where
         mergeUnresolved (c1, b) (c2, _) = (c1 + c2, b)
 
 instance Monoid CrossDBLinkingStats where
-    mempty = CrossDBLinkingStats [] M.empty S.empty [] [] [] 0 0 0 0
+    mempty =
+        CrossDBLinkingStats
+            { cdlLinks = []
+            , cdlUnresolvedProducts = M.empty
+            , cdlUnknownUnits = S.empty
+            , cdlLocationFallbacks = []
+            , cdlLocationUnresolved = []
+            , cdlAttributeFallbacks = []
+            , cdlTotalInputs = 0
+            , cdlWasteExactLinks = 0
+            , cdlWasteAmbiguous = 0
+            , cdlCutoffWasteCount = 0
+            }
 
 -- | Deduplicate location fallbacks by (product, requestedLoc)
 deduplicateFallbacks :: [LocationFallback] -> [LocationFallback]

--- a/test/CrossDBActivityLinkSpec.hs
+++ b/test/CrossDBActivityLinkSpec.hs
@@ -1,0 +1,187 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Cross-database linking by EcoSpold2 @activityLinkId@ identity.
+
+A partial EcoSpold2 import carries non-nil @activityLinkId@s pointing at
+background activities it does not ship. These tests pin the resolution cascade
+'Database.Loader.findExchangeCrossDBLink' runs for such inputs:
+
+1. exact @(activityLinkId, flowId)@ identity against a loaded dependency;
+2. attribute matching (name/location/unit) when the exact identity is absent —
+   the cross-version case, flagged in 'cdlAttributeFallbacks';
+3. and that an input whose target is present *in the same database* resolves
+   internally and gets no cross-DB link (no double counting).
+-}
+module CrossDBActivityLinkSpec (spec) where
+
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.UUID as UUID
+import Database.CrossLinking (
+    IndexedDatabase,
+    LinkingContext (..),
+    buildIndexedDatabase,
+    defaultLinkingThreshold,
+    findSupplierByActivityProduct,
+    locationHierarchy,
+ )
+import Database.Loader (findAllCrossDBLinks)
+import SynonymDB (emptySynonymDB)
+import Test.Hspec
+import Types
+import UnitConversion (defaultUnitConfig)
+
+-- ---------------------------------------------------------------------------
+-- UUIDs
+-- ---------------------------------------------------------------------------
+
+cAct, cProd, supAct, supProd, oldAct, newAct, supProd2, kgUnit :: UUID.UUID
+cAct = read "c0000000-0000-0000-0000-000000000001"
+cProd = read "c0000000-0000-0000-0000-000000000002"
+supAct = read "50000000-0000-0000-0000-000000000001"
+supProd = read "50000000-0000-0000-0000-000000000002"
+oldAct = read "01d00000-0000-0000-0000-000000000001"
+newAct = read "0ee00000-0000-0000-0000-000000000001"
+supProd2 = read "50000000-0000-0000-0000-000000000003"
+kgUnit = read "00000000-0000-0000-0000-0000000000a1"
+
+-- ---------------------------------------------------------------------------
+-- Fixtures
+-- ---------------------------------------------------------------------------
+
+mkFlow :: UUID.UUID -> Text -> TechnosphereFlow
+mkFlow fid name =
+    TechnosphereFlow
+        { tfId = fid
+        , tfName = name
+        , tfUnitId = kgUnit
+        , tfSynonyms = M.empty
+        , tfCAS = Nothing
+        , tfSubstanceId = Nothing
+        }
+
+mkActivity :: Text -> Text -> [Exchange] -> Activity
+mkActivity name loc exs =
+    Activity
+        { activityName = name
+        , activityDescription = []
+        , activitySynonyms = M.empty
+        , activityClassification = M.empty
+        , activityLocation = loc
+        , activityUnit = "kg"
+        , exchanges = exs
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
+        }
+
+refEx :: UUID.UUID -> Exchange
+refEx fid =
+    TechnosphereExchange
+        { techFlowId = fid
+        , techAmount = 1.0
+        , techUnitId = kgUnit
+        , techRole = ReferenceProduct
+        , techActivityLinkId = UUID.nil
+        , techProcessLinkId = Nothing
+        , techLocation = "GLO"
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+-- | An input for @flowId@, linked to producer activity @linkId@ (nil = unlinked).
+inputEx :: UUID.UUID -> UUID.UUID -> Exchange
+inputEx flowId linkId =
+    TechnosphereExchange
+        { techFlowId = flowId
+        , techAmount = 2.0
+        , techUnitId = kgUnit
+        , techRole = Input
+        , techActivityLinkId = linkId
+        , techProcessLinkId = Nothing
+        , techLocation = "GLO"
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+mkDB :: [((UUID.UUID, UUID.UUID), Activity)] -> [TechnosphereFlow] -> SimpleDatabase
+mkDB acts flows =
+    SimpleDatabase
+        { sdbActivities = M.fromList acts
+        , sdbTechFlows = M.fromList [(tfId f, f) | f <- flows]
+        , sdbBioFlows = M.empty
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton kgUnit (Unit kgUnit "kg" "" "")
+        }
+
+ctxFor :: [IndexedDatabase] -> LinkingContext
+ctxFor idbs =
+    LinkingContext
+        { lcIndexedDatabases = idbs
+        , lcSynonymDB = emptySynonymDB
+        , lcUnitConfig = defaultUnitConfig
+        , lcThreshold = defaultLinkingThreshold
+        , lcLocationHierarchy = locationHierarchy
+        , lcGeographyPolicy = GeoGlobal
+        }
+
+runLinks :: SimpleDatabase -> [IndexedDatabase] -> CrossDBLinkingStats
+runLinks fg idbs =
+    findAllCrossDBLinks (ctxFor idbs) (sdbTechFlows fg) (sdbWasteFlows fg) (sdbUnits fg) (sdbActivities fg)
+
+indexBg :: SimpleDatabase -> IndexedDatabase
+indexBg = buildIndexedDatabase "bg" emptySynonymDB
+
+-- ---------------------------------------------------------------------------
+
+spec :: Spec
+spec = do
+    describe "findSupplierByActivityProduct" $ do
+        let bg = indexBg (mkDB [((supAct, supProd), mkActivity "widget" "GLO" [refEx supProd])] [mkFlow supProd "widget"])
+        it "returns the supplier for an exact (activity, product) identity" $
+            map snd (findSupplierByActivityProduct [bg] supAct supProd) `shouldBe` ["bg"]
+        it "returns empty when no database ships that identity" $
+            null (findSupplierByActivityProduct [bg] oldAct supProd) `shouldBe` True
+
+    describe "findExchangeCrossDBLink (activityLinkId cascade)" $ do
+        it "links a dangling non-nil input to a background supplier by exact identity" $ do
+            let consumer = mkActivity "consumer" "GLO" [refEx cProd, inputEx supProd supAct]
+                fg = mkDB [((cAct, cProd), consumer)] [mkFlow cProd "consumer-product", mkFlow supProd "widget"]
+                bg = indexBg (mkDB [((supAct, supProd), mkActivity "widget" "GLO" [refEx supProd])] [mkFlow supProd "widget"])
+                stats = runLinks fg [bg]
+            map (\l -> (cdlSupplierActUUID l, cdlSupplierProdUUID l, cdlSourceDatabase l)) (cdlLinks stats)
+                `shouldBe` [(supAct, supProd, "bg")]
+            -- Exact identity is not a cross-version stitch.
+            cdlAttributeFallbacks stats `shouldBe` []
+
+        it "does not emit a cross-DB link when the target resolves internally" $ do
+            let consumer = mkActivity "consumer" "GLO" [refEx cProd, inputEx supProd supAct]
+                supplier = mkActivity "widget" "GLO" [refEx supProd]
+                -- supplier present in the SAME database as the consumer
+                fg = mkDB [((cAct, cProd), consumer), ((supAct, supProd), supplier)] [mkFlow cProd "consumer-product", mkFlow supProd "widget"]
+                -- and also offered by a dependency, to prove internal wins
+                bg = indexBg (mkDB [((supAct, supProd), supplier)] [mkFlow supProd "widget"])
+            cdlLinks (runLinks fg [bg]) `shouldBe` []
+
+        it "falls back to attribute matching and flags a cross-version stitch" $ do
+            -- Consumer references a release whose activity UUID (oldAct) the
+            -- background does not ship; the background offers the same product
+            -- under a different activity UUID (newAct).
+            let consumer = mkActivity "consumer" "GLO" [refEx cProd, inputEx supProd oldAct]
+                fg = mkDB [((cAct, cProd), consumer)] [mkFlow cProd "consumer-product", mkFlow supProd "widget"]
+                bg = indexBg (mkDB [((newAct, supProd2), mkActivity "widget" "GLO" [refEx supProd2])] [mkFlow supProd2 "widget"])
+                stats = runLinks fg [bg]
+            map (\l -> (cdlSupplierActUUID l, cdlSupplierProdUUID l, cdlSourceDatabase l)) (cdlLinks stats)
+                `shouldBe` [(newAct, supProd2, "bg")]
+            map (\a -> (afProduct a, afSourceDatabase a)) (cdlAttributeFallbacks stats)
+                `shouldBe` [("widget", "bg")]
+
+        it "does not flag a nil-link input matched by attributes" $ do
+            let consumer = mkActivity "consumer" "GLO" [refEx cProd, inputEx supProd UUID.nil]
+                fg = mkDB [((cAct, cProd), consumer)] [mkFlow cProd "consumer-product", mkFlow supProd "widget"]
+                bg = indexBg (mkDB [((supAct, supProd), mkActivity "widget" "GLO" [refEx supProd])] [mkFlow supProd "widget"])
+                stats = runLinks fg [bg]
+            length (cdlLinks stats) `shouldBe` 1
+            cdlAttributeFallbacks stats `shouldBe` []

--- a/test/CrossDBActivityLinkSpec.hs
+++ b/test/CrossDBActivityLinkSpec.hs
@@ -25,7 +25,7 @@ import Database.CrossLinking (
     findSupplierByActivityProduct,
     locationHierarchy,
  )
-import Database.Loader (findAllCrossDBLinks)
+import Database.Loader (collectStagedDanglingProductNames, findAllCrossDBLinks)
 import SynonymDB (emptySynonymDB)
 import Test.Hspec
 import Types
@@ -185,3 +185,29 @@ spec = do
                 stats = runLinks fg [bg]
             length (cdlLinks stats) `shouldBe` 1
             cdlAttributeFallbacks stats `shouldBe` []
+
+    describe "collectStagedDanglingProductNames (duplicate product flow)" $ do
+        it "still names a residual gap when only one of two same-product inputs is covered" $ do
+            -- One activity consumes "widget" twice, from two suppliers (same
+            -- flowId, different activityLinkId); neither supplier is in the
+            -- database. A single cross-DB link covers one of them — the other
+            -- must still be reported, not masked by the shared (act, prod, flow)
+            -- triple. The engine resolves demands by (activityLinkId, flowId),
+            -- so coverage is counted per occurrence, not tested for membership.
+            let consumer = mkActivity "consumer" "GLO" [refEx cProd, inputEx supProd supAct, inputEx supProd oldAct]
+                fg = mkDB [((cAct, cProd), consumer)] [mkFlow cProd "consumer-product", mkFlow supProd "widget"]
+                coveringLink =
+                    CrossDBLink
+                        { cdlConsumerActUUID = cAct
+                        , cdlConsumerProdUUID = cProd
+                        , cdlConsumerFlowId = supProd
+                        , cdlSupplierActUUID = supAct
+                        , cdlSupplierProdUUID = supProd
+                        , cdlCoefficient = 2.0
+                        , cdlExchangeUnit = "kg"
+                        , cdlFlowName = "widget"
+                        , cdlLocation = "GLO"
+                        , cdlSourceDatabase = "bg"
+                        , cdlTiedAlternatives = []
+                        }
+            collectStagedDanglingProductNames fg [coveringLink] `shouldBe` M.singleton "widget" 1

--- a/test/DependencyChoiceSpec.hs
+++ b/test/DependencyChoiceSpec.hs
@@ -43,6 +43,7 @@ indexedWith name n =
         , idbBySynonymGroup = M.empty
         , idbWasteTreatmentByFlowUUID = M.empty
         , idbWasteTreatmentByCanonicalName = M.empty
+        , idbByActivityProduct = M.empty
         }
   where
     keys :: [Text]

--- a/test/SetupInfoSpec.hs
+++ b/test/SetupInfoSpec.hs
@@ -167,3 +167,36 @@ spec = do
             dsiIsReady info `shouldBe` True
             dsiCompleteness info `shouldBe` 100.0
             dsiMissingSuppliers info `shouldBe` []
+
+    -- The dangling-import shape, but its matching background is loaded as a
+    -- dependency: the input resolves cross-DB by activityLinkId, recorded in
+    -- 'dbCrossDBLinks'. Readiness must follow the matrix — ready at 100% with no
+    -- gaps — not keep reporting the now-supplied product as missing.
+    describe "buildLoadedSetupInfo (partial import + loaded background)" $ do
+        it "reports a cross-DB-supplied background link as ready / 100% / no gaps" $ do
+            let consumer =
+                    minimalActivity
+                        "lyocell fibre"
+                        [refExchange consumerProd, linkedInput missingAct supplierProd]
+                link =
+                    CrossDBLink
+                        { cdlConsumerActUUID = consumerAct
+                        , cdlConsumerProdUUID = consumerProd
+                        , cdlConsumerFlowId = supplierProd
+                        , cdlSupplierActUUID = supplierAct
+                        , cdlSupplierProdUUID = supplierProd
+                        , cdlCoefficient = 0.5
+                        , cdlExchangeUnit = "kg"
+                        , cdlFlowName = "chemical, inorganic"
+                        , cdlLocation = "GLO"
+                        , cdlSourceDatabase = "background"
+                        , cdlTiedAlternatives = []
+                        }
+            db <-
+                buildDb
+                    [((consumerAct, consumerProd), consumer)]
+                    [(consumerProd, "lyocell fibre"), (supplierProd, "chemical, inorganic")]
+            let info = setupInfoFor db{dbCrossDBLinks = [link]}
+            dsiIsReady info `shouldBe` True
+            dsiCompleteness info `shouldBe` 100.0
+            dsiMissingSuppliers info `shouldBe` []

--- a/test/WasteCrossDBSpec.hs
+++ b/test/WasteCrossDBSpec.hs
@@ -39,6 +39,7 @@ spec = describe "findWasteTreatmentAcrossDatabases" $ do
                 , idbBySynonymGroup = M.empty
                 , idbWasteTreatmentByFlowUUID = M.fromListWith (++) [(u, [e]) | (u, e) <- uuidEntries]
                 , idbWasteTreatmentByCanonicalName = M.fromListWith (++) [(n, [e]) | (n, e) <- nameEntries]
+                , idbByActivityProduct = M.empty
                 }
 
         ctxWith :: [IndexedDatabase] -> LinkingContext
@@ -97,6 +98,7 @@ spec = describe "findWasteTreatmentAcrossDatabases" $ do
                     , idbBySynonymGroup = M.empty
                     , idbWasteTreatmentByFlowUUID = M.singleton wasteUUID [entryFR, entryDE]
                     , idbWasteTreatmentByCanonicalName = M.empty
+                    , idbByActivityProduct = M.empty
                     }
             ctx = ctxWith [ecoinventMulti]
         expectNoMatch (findWasteTreatmentAcrossDatabases ctx wasteUUID "Organic carbon")

--- a/volca.cabal
+++ b/volca.cabal
@@ -213,6 +213,7 @@ test-suite lca-tests
                      , TreeSpec
                      , ServiceSpec
                      , CrossLinkingSpec
+                     , CrossDBActivityLinkSpec
                      , MinimalCoverSpec
                      , MinimalCoverIntegrationSpec
                      , StrictPinSpec


### PR DESCRIPTION
## Why

A partial EcoSpold2 import — a handful of `.spold` files cut from a full database — is a foreground whose inputs carry non-nil `activityLinkId`s pointing at background activities it doesn't ship. #126 made the engine report such imports as *not ready* instead of falsely 100%, but they still couldn't be made analyzable: cross-DB linking only attempted **nil-link** inputs, and only **by name**. So loading the matching ecoinvent background as a dependency did nothing for them.

## What

`findExchangeCrossDBLink` now resolves each input through a cascade:

1. **Exact `activityLinkId` identity** — an input's `(activityLinkId, flowId)` is exactly the supplier's `(activityUUID, referenceProductUUID)` key, so a new `idbByActivityProduct` index resolves it verbatim against a loaded dependency. Unambiguous when the dependency is the same release; the dataset author's own disambiguation, no scoring.
2. **Attribute fallback** — when the exact identity isn't present (a *different* release), it falls through to the same name/location/unit matcher every other cross-link already uses.

An own-keys gate skips inputs the internal matrix already resolves, so no edge is double-counted.

## Cross-version honesty

Activity UUIDs drift across releases (product/intermediate-exchange UUIDs are stable master data; activity UUIDs and the activity set are not). So a non-nil input matched by attributes *after* its exact identity was absent is a likely cross-version stitch. Those are recorded in `cdlAttributeFallbacks` and surfaced on `DatabaseSetupInfo.dsiAttributeFallbacks` plus a load-log warning, so a consumer can verify the dependency is the intended release rather than trust an approximate match as exact. Nil-link (SimaPro) inputs matched by attributes are *not* flagged — they never carried a source identity.

Readiness counters and missing-supplier lists are now cross-DB aware (loaded and staged paths), so a partial import + its matching background reads **ready / 100% / no gaps**; a different release links approximately and says so; no background stays not-ready and names the gaps (the #126 guarantee).

## Tests

- `CrossDBActivityLinkSpec`: exact-identity link, internal target → no cross-DB link, cross-version → attribute fallback flagged, nil-link → not flagged.
- `SetupInfoSpec`: a cross-DB-supplied background link reads ready / 100% / no gaps.
- Full suite green (1169 examples).