### PR TITLE
style: fourmolu the relinkStaged code in Manager.hs (#116 follow-up)

### DIFF
--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1553,8 +1553,9 @@ relinkStaged manager dbName maybeDepDb aliases = do
         Just staged -> do
             indexedDbs <- readTVarIO (dmIndexedDbs manager)
             case maybeDepDb of
-                Just dep | not (M.member dep indexedDbs) ->
-                    return $ Left $ "Dependency database not loaded: " <> dep <> " (load it first)"
+                Just dep
+                    | not (M.member dep indexedDbs) ->
+                        return $ Left $ "Dependency database not loaded: " <> dep <> " (load it first)"
                 _ -> do
                     synonymDB <- getMergedSynonymDB manager
                     unitConfig <- getMergedUnitConfig manager
@@ -1579,7 +1580,8 @@ relinkStaged manager dbName maybeDepDb aliases = do
                                 , sdCrossDBLinks = newLinks
                                 , sdLinkingStats = newStats
                                 , sdMissingProducts =
-                                    sortOn (\(_, cnt, _) -> Down cnt)
+                                    sortOn
+                                        (\(_, cnt, _) -> Down cnt)
                                         [(name, cnt, blocker) | (name, (cnt, blocker)) <- M.toList (Loader.cdlUnresolvedProducts newStats)]
                                 }
                     atomically $ modifyTVar' (dmStagedDbs manager) (M.insert dbName updatedStaged)


### PR DESCRIPTION
#116 merged with a failing fourmolu check. The staged-relink code in `Manager.hs` (`relinkStaged`) wasn't run through the formatter: fourmolu wants the multi-way guard and the `sortOn` argument on their own lines. Formatting only — no behaviour change; the tree builds and the relink/cross-linking specs pass (54 examples, 0 failures).