### PR TITLE
fix(synonyms): surface a missing reference CSV as Left instead of crashing

### DIFF
--- a/src/SynonymDB.hs
+++ b/src/SynonymDB.hs
@@ -95,12 +95,16 @@ loadFromCSVFileWithCache csvPath = do
     case cached of
         Just db -> return (Right db)
         Nothing -> do
-            csvData <- BL.readFile csvPath
-            case buildFromCSV csvData of
-                Left err -> return (Left err)
-                Right db -> do
-                    saveCache cachePath db
-                    return (Right db)
+            exists <- doesFileExist csvPath
+            if not exists
+                then return (Left ("File not found: " ++ csvPath))
+                else do
+                    csvData <- BL.readFile csvPath
+                    case buildFromCSV csvData of
+                        Left err -> return (Left err)
+                        Right db -> do
+                            saveCache cachePath db
+                            return (Right db)
   where
     loadCache cachePath srcPath = do
         exists <- doesFileExist cachePath

--- a/test/SynonymDBSpec.hs
+++ b/test/SynonymDBSpec.hs
@@ -1,0 +1,18 @@
+module SynonymDBSpec (spec) where
+
+import Test.Hspec
+
+import SynonymDB (loadFromCSVFileWithCache)
+
+spec :: Spec
+spec =
+    describe "loadFromCSVFileWithCache" $
+        it "returns Left for a missing CSV instead of throwing" $ do
+            -- Regression: the load used a bare readFile, so a missing
+            -- reference file threw an uncaught IOException and took down
+            -- server startup. The type promises Either; a missing file
+            -- must surface as Left, like the other reference-data loaders.
+            result <- loadFromCSVFileWithCache "test-data/does-not-exist-synonyms.csv"
+            case result of
+                Left _ -> pure ()
+                Right _ -> expectationFailure "expected Left for a missing CSV file"

--- a/volca.cabal
+++ b/volca.cabal
@@ -238,6 +238,7 @@ test-suite lca-tests
                      , MethodCollectionCacheSpec
                      , MethodResolveSpec
                      , ChemSynonymsSpec
+                     , SynonymDBSpec
                      , UploadedDatabaseSpec
                      , UploadSizeSpec
                      , ProgressSpec


### PR DESCRIPTION
## Why

`loadFromCSVFileWithCache` read the CSV with a bare `readFile`. When the file is missing, that throws an uncaught `IOException` (`openBinaryFile: does not exist`), which aborts server startup entirely — the process dies with a raw GHC callstack rather than a useful error.

Every other reference-data loader (geographies, compartments, units, chem synonyms) already guards with `doesFileExist` and degrades gracefully on a missing file. The synonym loader was the lone exception, despite its type already promising `IO (Either String SynonymDB)`.

## What

Guard the read with `doesFileExist` and return `File not found: <path>` as `Left`, matching the sibling loaders. A missing reference file now logs a load error and the server keeps running, instead of crashing.

Adds a regression spec (`test/SynonymDBSpec.hs`): a missing CSV returns `Left`, not an exception.