### PR TITLE
Import and score ecoinvent waste-treatment activities correctly

### DIFF
--- a/src/Database/MatrixBuild.hs
+++ b/src/Database/MatrixBuild.hs
@@ -82,10 +82,13 @@ collectBioFlowOrder activities =
         ]
 
 {- | Divide-by-zero guard for normalization factors. Activities with no
-reference output normalize by 1.0 instead of a near-zero denominator.
+reference output normalize by 1.0 instead of a near-zero denominator. Guards on
+magnitude, not sign: a waste-treatment reference is a NEGATIVE production (e.g.
+-1 kg of the treated waste), and that sign must be preserved through the
+normalization — collapsing it to 1.0 silently flips the activity's inventory.
 -}
 safeDenom :: Double -> Double
-safeDenom f = if f > 1e-15 then f else 1.0
+safeDenom f = if abs f > 1e-15 then f else 1.0
 
 {- | Producer cascade for technosphere exchanges: prefer the resolved process
 link, else look up the (activityUUID, flowUUID) pair. This is the

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -521,14 +521,20 @@ parseWithXeno xmlContent processId = do
                                 , waPedigree = Nothing
                                 }
                         wasteFlow = WasteFlow flowUUID resolvedFlowName unitUUID (idSynonyms idata) Nothing Nothing
-                        -- Reference product unit only when the flow stays in the technosphere
-                        -- (waste outputs are never the reference product of a producing process).
+                        -- A waste-classified flow normally routes to the waste axis. The one
+                        -- exception is the reference flow of a waste-treatment / market-for-waste
+                        -- activity: it is itself waste (negative amount, outputGroup="0") yet it
+                        -- IS the reference product. Diverting it to the waste axis leaves the
+                        -- activity with no reference product, so 'applyCutoffStrategy' rejects it
+                        -- and the whole dataset is dropped — silently severing every input that
+                        -- links into the treatment subsystem.
+                        refOnWasteAxis = isWasteFlow && not isReferenceProduct
                         newRefUnit =
-                            if isReferenceProduct && not isWasteFlow && not (T.null (idUnitName idata))
+                            if isReferenceProduct && not (T.null (idUnitName idata))
                                 then Just (idUnitName idata)
                                 else psRefUnit state
                         base = (finishExchange unit warns state){psRefUnit = newRefUnit}
-                     in if isWasteFlow
+                     in if refOnWasteAxis
                             then addExchange wasteExchange (addWasteFlow wasteFlow base)
                             else addExchange techExchange (addTechFlow techFlow base)
         | isElement tagName "elementaryExchange" =

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -370,8 +370,13 @@ activityNormFactor act (actUUID, prodUUID) =
                 , not (exchangeIsReference ex)
                 , isSelfLoop ex
                 ]
-        netOutput = if refOutputs > 1e-15 then refOutputs - internalConsumption else 0.0
-     in if netOutput > 1e-15
+        -- Magnitude, not sign, decides whether a reference output is real: a
+        -- waste-treatment / market-for-waste activity has a NEGATIVE reference
+        -- output (e.g. -1 kg of the waste it treats). Its signed net output must
+        -- flow through as the normalization factor; forcing a positive fallback
+        -- here flips the sign of the activity's entire inventory contribution.
+        netOutput = if abs refOutputs > 1e-15 then refOutputs - internalConsumption else 0.0
+     in if abs netOutput > 1e-15
             then netOutput
             else
                 if refInputs > 1e-15

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -80,6 +80,35 @@ spec = describe "per-exchange comments" $ do
                 length wasteInputs `shouldBe` 1
                 length wasteOutputs `shouldBe` 1
 
+    -- Regression: e17dc21 established "all 25,412 ecoinvent .spold parse"; the
+    -- WasteFlow axis (#83) silently re-broke it. A treatment / market-for-waste
+    -- activity's reference flow is itself waste (negative amount, outputGroup="0",
+    -- By-product classification=Waste). Routing it to the waste axis leaves the
+    -- activity reference-less, so applyCutoffStrategy drops it (≈4,619 ecoinvent
+    -- datasets) and every input into the treatment subsystem silently goes
+    -- unresolved. The reference must stay the technosphere reference product.
+    describe "waste-classified reference flow (treatment / market-for-waste)" $ do
+        it "does not drop the activity" $ do
+            result <- parseWasteReference
+            case result of
+                Left err -> expectationFailure $ "activity was dropped: " ++ err
+                Right _ -> pure ()
+
+        it "keeps the reference on the technosphere axis, not the waste axis" $
+            withWasteReferenceFixture $ \(act, techs, _, wastes, _) -> do
+                [techRole e | e@TechnosphereExchange{} <- exchanges act] `shouldBe` [ReferenceProduct]
+                length [() | WasteExchange{} <- exchanges act] `shouldBe` 0
+                length techs `shouldBe` 1 -- reference registered as a TechnosphereFlow
+                length wastes `shouldBe` 0 -- and not as a WasteFlow
+        it "carries the reference unit through (not UNKNOWN_UNIT)" $
+            withWasteReferenceFixture $ \(act, _, _, _, _) ->
+                activityUnit act `shouldBe` "kg"
+
+        it "preserves the negative reference amount for the matrix diagonal" $
+            withWasteReferenceFixture $ \(act, _, _, _, _) ->
+                [exchangeAmount e | e@TechnosphereExchange{techRole = ReferenceProduct} <- exchanges act]
+                    `shouldBe` [-1.0]
+
     -- -----------------------------------------------------------------------
     -- Robustness: malformed input should never crash; we expect a clean Left.
     -- The byte-level fuzzing inputs are the ones the parser actually sees in
@@ -257,3 +286,46 @@ wastePatternsXml =
     \    </flowData>\n\
     \  </activityDataset>\n\
     \</ecoSpold>\n"
+
+{- | A waste-treatment / market-for-waste activity whose reference flow is itself
+waste: negative amount, outputGroup="0", tagged By-product classification=Waste.
+This is the ecoinvent EcoSpold2 shape (e.g. "market for refinery sludge") that
+the WasteFlow axis silently dropped. The reference must remain the technosphere
+reference product so the activity loads and its consumers' links resolve.
+-}
+wasteReferenceXml :: BS.ByteString
+wasteReferenceXml =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+    \<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold02\">\n\
+    \  <activityDataset>\n\
+    \    <activityDescription>\n\
+    \      <activity id=\"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\" activityNameId=\"market-for-waste\">\n\
+    \        <activityName xml:lang=\"en\">market for refinery sludge</activityName>\n\
+    \      </activity>\n\
+    \      <geography geographyId=\"GLO\"><shortname xml:lang=\"en\">GLO</shortname></geography>\n\
+    \    </activityDescription>\n\
+    \    <flowData>\n\
+    \      <intermediateExchange id=\"ref\" unitId=\"unit-kg\" amount=\"-1.0\"\n\
+    \                           intermediateExchangeId=\"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb\"\n\
+    \                           productionVolumeAmount=\"1000.0\">\n\
+    \        <name xml:lang=\"en\">refinery sludge</name>\n\
+    \        <unitName xml:lang=\"en\">kg</unitName>\n\
+    \        <classification classificationId=\"bp-waste\">\n\
+    \          <classificationSystem xml:lang=\"en\">By-product classification</classificationSystem>\n\
+    \          <classificationValue xml:lang=\"en\">Waste</classificationValue>\n\
+    \        </classification>\n\
+    \        <outputGroup>0</outputGroup>\n\
+    \      </intermediateExchange>\n\
+    \    </flowData>\n\
+    \  </activityDataset>\n\
+    \</ecoSpold>\n"
+
+parseWasteReference :: IO (Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]))
+parseWasteReference = withSystemTempDirectory "es2-waste-ref" $ \dir -> do
+    let path = dir </> "12345678-1234-5678-9abc-123456789001_12345678-1234-5678-9abc-123456789002.spold"
+    BS.writeFile path wasteReferenceXml
+    streamParseActivityAndFlowsFromFile path
+
+withWasteReferenceFixture :: ((Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]) -> IO ()) -> IO ()
+withWasteReferenceFixture k =
+    parseWasteReference >>= either (expectationFailure . ("Parse failed: " ++)) k

--- a/test/MatrixConstructionSpec.hs
+++ b/test/MatrixConstructionSpec.hs
@@ -2,12 +2,14 @@
 
 module MatrixConstructionSpec (spec) where
 
+import Data.List (elemIndex)
 import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU
 import Database (buildDatabaseWithMatrices)
+import Matrix (computeInventoryMatrix)
 import Test.Hspec
 import TestHelpers
 import Types
@@ -254,3 +256,113 @@ spec = do
                 Left err -> expectationFailure $ "buildDatabaseWithMatrices failed: " <> T.unpack err
                 Right db ->
                     VU.length (dbBiosphereTriples db) `shouldBe` 0
+
+    describe "Waste-treatment scoring sign (negative reference)" $ do
+        -- A waste-treatment / market-for-waste activity's reference flow is a
+        -- NEGATIVE production (here -1 kg of the waste it treats). A producer that
+        -- sends 3 kg of that waste to treatment must pick up +3× the treatment's
+        -- burden, not -3×. Before the activityNormFactor / safeDenom sign fix the
+        -- normalization collapsed the -1 reference to +1, flipping every linked
+        -- treatment burden negative — so treating waste spuriously *reduced* impact.
+        it "adds the treatment burden with a positive sign to the waste producer" $ do
+            let tA = mkUUID "11111111-1111-1111-1111-111111111111"
+                wW = mkUUID "22222222-2222-2222-2222-222222222222"
+                pA = mkUUID "33333333-3333-3333-3333-333333333333"
+                yY = mkUUID "44444444-4444-4444-4444-444444444444"
+                co2 = mkUUID "55555555-5555-5555-5555-555555555555"
+                kgU = mkUUID "66666666-6666-6666-6666-666666666666"
+                tRef =
+                    TechnosphereExchange
+                        { techFlowId = wW
+                        , techAmount = -1.0 -- treats 1 kg of waste W (negative production)
+                        , techUnitId = kgU
+                        , techRole = ReferenceProduct
+                        , techActivityLinkId = UUID.nil
+                        , techProcessLinkId = Nothing
+                        , techLocation = ""
+                        , techComment = Nothing
+                        , techPedigree = Nothing
+                        }
+                tCO2 =
+                    BiosphereExchange
+                        { bioFlowId = co2
+                        , bioAmount = 2.0 -- 2 kg CO2 per kg treated
+                        , bioUnitId = kgU
+                        , bioDirection = Emission
+                        , bioLocation = ""
+                        , bioComment = Nothing
+                        , bioPedigree = Nothing
+                        }
+                treatment =
+                    Activity
+                        { activityName = "treatment of waste W"
+                        , activityDescription = []
+                        , activitySynonyms = M.empty
+                        , activityClassification = M.empty
+                        , activityLocation = "GLO"
+                        , activityUnit = "kg"
+                        , exchanges = [tRef, tCO2]
+                        , activityParams = M.empty
+                        , activityParamExprs = M.empty
+                        , activityAllocationPercent = Nothing
+                        , activityAllocationFormula = Nothing
+                        , activityNativeType = Nothing
+                        }
+                pRef =
+                    TechnosphereExchange
+                        { techFlowId = yY
+                        , techAmount = 1.0
+                        , techUnitId = kgU
+                        , techRole = ReferenceProduct
+                        , techActivityLinkId = UUID.nil
+                        , techProcessLinkId = Nothing
+                        , techLocation = ""
+                        , techComment = Nothing
+                        , techPedigree = Nothing
+                        }
+                pWaste =
+                    WasteExchange
+                        { waFlowId = wW
+                        , waAmount = 3.0 -- produces 3 kg of waste W, sent to treatment
+                        , waUnitId = kgU
+                        , waIsInput = False
+                        , waActivityLinkId = tA
+                        , waProcessLinkId = Nothing
+                        , waLocation = ""
+                        , waComment = Nothing
+                        , waPedigree = Nothing
+                        }
+                producer =
+                    Activity
+                        { activityName = "producer of Y"
+                        , activityDescription = []
+                        , activitySynonyms = M.empty
+                        , activityClassification = M.empty
+                        , activityLocation = "GLO"
+                        , activityUnit = "kg"
+                        , exchanges = [pRef, pWaste]
+                        , activityParams = M.empty
+                        , activityParamExprs = M.empty
+                        , activityAllocationPercent = Nothing
+                        , activityAllocationFormula = Nothing
+                        , activityNativeType = Nothing
+                        }
+                activityMap = M.fromList [((tA, wW), treatment), ((pA, yY), producer)]
+                techFlowDB =
+                    M.fromList
+                        [ (wW, TechnosphereFlow wW "waste W" kgU M.empty Nothing Nothing)
+                        , (yY, TechnosphereFlow yY "product Y" kgU M.empty Nothing Nothing)
+                        ]
+                bioFlowDB = M.singleton co2 (BiosphereFlow co2 "carbon dioxide" kgU M.empty Nothing Nothing (Just (Compartment "air" Nothing)))
+                wasteFlowDB = M.singleton wW (WasteFlow wW "waste W" kgU M.empty Nothing Nothing)
+                unitDB = M.singleton kgU (Unit kgU "kg" "kg" "")
+
+            result <- buildDatabaseWithMatrices defaultUnitConfig activityMap techFlowDB bioFlowDB wasteFlowDB unitDB
+            case result of
+                Left err -> expectationFailure $ "buildDatabaseWithMatrices failed: " <> T.unpack err
+                Right db -> case elemIndex (pA, yY) (V.toList (dbProcessIdTable db)) of
+                    Nothing -> expectationFailure "producer activity was not interned"
+                    Just ix -> do
+                        inv <- computeInventoryMatrix db (fromIntegral ix)
+                        -- 3 kg waste × 2 kg CO2/kg treated = +6 kg CO2 (positive!)
+                        withinTolerance 1.0e-9 6.0 (M.findWithDefault 0.0 co2 inv) `shouldBe` True


### PR DESCRIPTION
## Problem

Importing the full ecoinvent 3.11 cutoff EcoSpold2 release reported only ~85.6% supply-chain completeness with ~35,575 "unresolved" inputs and zero cross-database links — as if a large background dependency were missing. It isn't: all 25,412 datasets ship in the archive, and every unresolved input's producer is one of them.

The cause is in the importer. A waste-treatment / market-for-waste activity's reference flow is itself waste — a negative-amount intermediate exchange with `outputGroup="0"` carrying `By-product classification = Waste`. The parser routed every waste-classified intermediate exchange to the waste axis unconditionally, including the reference flow. That left those activities with no reference product, so `applyCutoffStrategy` rejected them and they were dropped at load (logged only as a Warning). On ecoinvent 3.11 cutoff this silently dropped ~4,619 of 25,412 datasets (18%); every input linking into the treatment subsystem was then counted as an unresolved background link against a phantom dependency.

Fixing the drop surfaced a second, latent bug. A waste-treatment activity has a *negative* reference output (e.g. −1 kg of the waste it treats), and the matrix normalization discarded that sign: `activityNormFactor` fell back to `+1.0` for a negative reference output, and `safeDenom` collapsed negative denominators to `1.0`. Linked waste treatment then scored with a flipped sign — treating waste *reduced* impact instead of adding it.

## Fix

- **Parser:** route a waste-classified flow to the waste axis only when it is **not** the reference product; the reference stays a technosphere `ReferenceProduct`. All 25,412 datasets now parse, and inputs into the treatment subsystem resolve internally.
- **Matrix:** guard `activityNormFactor` and `safeDenom` on **magnitude**, not sign, so a negative reference amount flows through as the normalization factor.

## Verification

- All 25,412 ecoinvent 3.11 cutoff `.spold` files parse (0 dropped).
- A synthetic producer sending 3 kg of waste to a treatment activity (reference −1.0, 2 kg CO₂/kg treated) now scores **+6 kg CO₂** (was −6).
- Full suite green (1327 examples, 0 failures). New regression tests cover the waste-reference parse shape ("market for refinery sludge") and the scoring-sign case.

## Notes

- EcoSpold 1 is unaffected — its "Final waste flows" are input-side markers (`inputGroup=5`), never the reference.
- The cross-database waste-treatment indexer (`buildWasteTreatmentEntries`) only yields entries once a flow is registered as both a technosphere reference and a waste flow, so it effectively activates with this change. A dedicated pass on that path is a sensible follow-up.

A note on history: this restores the "all 25,412 parse" invariant that commit e17dc21 established but never locked with a test; the WasteFlow axis (#83) silently re-broke it. The two regression tests added here guard it now.
