### PR TITLE
fix(export): make a loaded database exportable to every format

### DIFF
--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -101,7 +101,7 @@ import qualified Data.Aeson.KeyMap as KM
 import Data.Maybe (fromMaybe)
 import qualified Data.Vector as V
 import Database.Edit (copyDatabase, deleteActivitiesInDB)
-import Database.Export (parseExportFormat, serializeDatabase)
+import Database.Export (exportWarnings, parseExportFormat, serializeDatabase)
 import Database.Manager (
     DatabaseLoadStatus (..),
     DatabaseManager (..),
@@ -288,7 +288,7 @@ exportDatabaseHandler dbName req = do
     mLoaded <- liftIO (getDatabase dbManager dbName)
     ld <- maybe (httpErr err404 ("Database not loaded: " <> dbName)) pure mLoaded
     bytes <- either (httpErr err400) pure (serializeDatabase fmt (ldDatabase ld))
-    pure (ExportResponse (T.decodeUtf8 (B64.encode (BSL.toStrict bytes))))
+    pure (ExportResponse (T.decodeUtf8 (B64.encode (BSL.toStrict bytes))) (exportWarnings fmt (ldDatabase ld)))
   where
     httpErr :: ServerError -> Text -> AppM a
     httpErr status msg = throwError status{errBody = BSL.fromStrict (T.encodeUtf8 msg)}

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -101,7 +101,7 @@ import qualified Data.Aeson.KeyMap as KM
 import Data.Maybe (fromMaybe)
 import qualified Data.Vector as V
 import Database.Edit (copyDatabase, deleteActivitiesInDB)
-import Database.Export (exportWarnings, parseExportFormat, serializeDatabase)
+import Database.Export (parseExportFormat, serializeDatabase)
 import Database.Manager (
     DatabaseLoadStatus (..),
     DatabaseManager (..),
@@ -287,8 +287,8 @@ exportDatabaseHandler dbName req = do
     fmt <- either (httpErr err400) pure (parseExportFormat (exrFormat req))
     mLoaded <- liftIO (getDatabase dbManager dbName)
     ld <- maybe (httpErr err404 ("Database not loaded: " <> dbName)) pure mLoaded
-    bytes <- either (httpErr err400) pure (serializeDatabase fmt (ldDatabase ld))
-    pure (ExportResponse (T.decodeUtf8 (B64.encode (BSL.toStrict bytes))) (exportWarnings fmt (ldDatabase ld)))
+    (bytes, warnings) <- either (httpErr err400) pure (serializeDatabase fmt (ldDatabase ld))
+    pure (ExportResponse (T.decodeUtf8 (B64.encode (BSL.toStrict bytes))) warnings)
   where
     httpErr :: ServerError -> Text -> AppM a
     httpErr status msg = throwError status{errBody = BSL.fromStrict (T.encodeUtf8 msg)}

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -811,8 +811,9 @@ ILCD are zipped), mirroring the upload endpoint's base64 convention. Failures ar
 HTTP errors (400 bad format / unexportable data, 404 not loaded), never a
 success flag in a 200 body — so the type cannot represent "success with no data".
 -}
-newtype ExportResponse = ExportResponse
+data ExportResponse = ExportResponse
     { exrespData :: Text -- Base64-encoded serialized database
+    , exrespWarnings :: [Text] -- Best-effort approximations; empty on a faithful export
     }
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped ExportResponse)

--- a/src/Amount.hs
+++ b/src/Amount.hs
@@ -9,10 +9,10 @@ guards mirror what import will actually do.
 -}
 module Amount (readAmount) where
 
+import qualified Data.Attoparsec.Text as A
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
-import Text.Read (readMaybe)
 
 {- | Parse a decimal amount to a 'Double' with correct round-to-nearest
 rounding — the exact inverse of 'EcoSpold.Common.showFFloatTrim'.
@@ -21,23 +21,36 @@ rounding — the exact inverse of 'EcoSpold.Common.showFFloatTrim'.
 ULP on perfectly ordinary magnitudes (e.g. @"0.0000010897906999999999"@ parses
 to @1.0897907e-6@, a different 'Double'). On import that silently corrupts
 amounts; on the writers' round-trip guards it rejects values the format can
-represent. 'read' builds the value through @fromRational@ of the exact decimal,
-which /is/ correctly rounded, so every finite 'Double' round-trips — including
-subnormals.
+represent.
 
-Accepts the same forms 'Data.Text.Read.double' does — surrounding whitespace, a
-leading @\'+\'@, and a bare leading or trailing decimal point (@".5"@, @"1."@) —
-but rejects trailing garbage and the non-finite literals @Infinity@/@NaN@, which
-are never valid LCA amounts and must surface rather than slip in silently.
+We tokenize with attoparsec's fast 'A.scientific', which yields an /exact/
+'Data.Scientific.Scientific' (an arbitrary-precision decimal), then convert with
+@fromRational . toRational@. 'toRational' is exact and 'fromRational' is
+correctly rounded by the Report, so every finite 'Double' round-trips —
+subnormals included. (We deliberately avoid 'Data.Scientific.toRealFloat', whose
+underflow/overflow short-circuits are version-dependent and can lose a subnormal
+to @0@.) An out-of-range literal like @"1e400"@ converts to 'Infinity' and is
+rejected here, alongside @NaN@, since a non-finite value is never a valid LCA
+amount and must surface rather than slip in silently.
+
+Accepts the forms 'Data.Text.Read.double' does — surrounding whitespace, a
+leading sign, scientific notation, and a bare leading or trailing decimal point
+(@".5"@, @"1."@) — but rejects trailing garbage (@A.endOfInput@).
 -}
 readAmount :: Text -> Maybe Double
-readAmount t = case readMaybe (T.unpack (normalize t)) :: Maybe Double of
-    Just d | not (isNaN d || isInfinite d) -> Just d
-    _ -> Nothing
+readAmount t = case A.parseOnly (A.scientific <* A.endOfInput) (normalize t) of
+    Right s -> finite (fromRational (toRational s))
+    Left _ -> Nothing
   where
-    normalize = padLeadingDot . padTrailingDot . dropLeadingPlus . T.strip
+    -- attoparsec's 'scientific' handles a leading sign, a trailing dot and an
+    -- exponent itself; it only needs a digit before the point, so pad a bare
+    -- leading dot (".5" / "-.5"). The '+' is stripped so that padding stays a
+    -- two-case match.
+    finite d
+        | isNaN d || isInfinite d = Nothing
+        | otherwise = Just d
+    normalize = padLeadingDot . dropLeadingPlus . T.strip
     dropLeadingPlus s = fromMaybe s (T.stripPrefix "+" s)
-    padTrailingDot s = if "." `T.isSuffixOf` s then s <> "0" else s
     padLeadingDot s = case T.uncons s of
         Just ('.', _) -> "0" <> s
         Just ('-', r) | "." `T.isPrefixOf` r -> "-0" <> r

--- a/src/Amount.hs
+++ b/src/Amount.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Correctly-rounded parsing of decimal amounts.
+
+This is the read side of the amount round-trip whose write side is
+'EcoSpold.Common.showFFloatTrim'. Keeping the reader in one place lets every
+importer and every export round-trip guard share the exact same parse, so the
+guards mirror what import will actually do.
+-}
+module Amount (readAmount) where
+
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as T
+import Text.Read (readMaybe)
+
+{- | Parse a decimal amount to a 'Double' with correct round-to-nearest
+rounding — the exact inverse of 'EcoSpold.Common.showFFloatTrim'.
+
+'Data.Text.Read.double' is /not/ correctly rounded: it can be off by up to one
+ULP on perfectly ordinary magnitudes (e.g. @"0.0000010897906999999999"@ parses
+to @1.0897907e-6@, a different 'Double'). On import that silently corrupts
+amounts; on the writers' round-trip guards it rejects values the format can
+represent. 'read' builds the value through @fromRational@ of the exact decimal,
+which /is/ correctly rounded, so every finite 'Double' round-trips — including
+subnormals.
+
+Accepts the same forms 'Data.Text.Read.double' does — surrounding whitespace, a
+leading @\'+\'@, and a bare leading or trailing decimal point (@".5"@, @"1."@) —
+but rejects trailing garbage and the non-finite literals @Infinity@/@NaN@, which
+are never valid LCA amounts and must surface rather than slip in silently.
+-}
+readAmount :: Text -> Maybe Double
+readAmount t = case readMaybe (T.unpack (normalize t)) :: Maybe Double of
+    Just d | not (isNaN d || isInfinite d) -> Just d
+    _ -> Nothing
+  where
+    normalize = padLeadingDot . padTrailingDot . dropLeadingPlus . T.strip
+    dropLeadingPlus s = fromMaybe s (T.stripPrefix "+" s)
+    padTrailingDot s = if "." `T.isSuffixOf` s then s <> "0" else s
+    padLeadingDot s = case T.uncons s of
+        Just ('.', _) -> "0" <> s
+        Just ('-', r) | "." `T.isPrefixOf` r -> "-0" <> r
+        _ -> s

--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -50,6 +50,7 @@ module BrightwayExcel.Parser (
     isResourceCompartment,
 ) where
 
+import Amount (readAmount)
 import Codec.Archive.Zip (Archive, findEntryByPath, fromEntry, toArchiveOrFail)
 import Control.Applicative ((<|>))
 import Data.Bifunctor (first)
@@ -101,9 +102,7 @@ cellText = \case
 cellNum :: CellValue -> Maybe Double
 cellNum = \case
     CellNumber d -> Just d
-    CellText t -> case TR.double (T.strip t) of
-        Right (d, rest) | T.null (T.strip rest) -> Just d
-        _ -> Nothing
+    CellText t -> readAmount t
 
 textAt :: Int -> Row -> Maybe Text
 textAt i row = cellText =<< M.lookup i row
@@ -567,9 +566,9 @@ cellValue sharedStrings c = case TE.decodeUtf8 <$> attr "t" c of
     _ -> do
         v <- firstChildNamed "v" c
         let txt = nodeText v
-        case TR.double txt of
-            Right (d, rest) | T.null (T.strip rest) -> Just (CellNumber d)
-            _ -> nonEmptyText txt
+        case readAmount txt of
+            Just d -> Just (CellNumber d)
+            Nothing -> nonEmptyText txt
 
 nonEmptyText :: Text -> Maybe CellValue
 nonEmptyText t = let s = T.strip t in if T.null s then Nothing else Just (CellText s)

--- a/src/BrightwayExcel/Writer.hs
+++ b/src/BrightwayExcel/Writer.hs
@@ -68,7 +68,7 @@ import qualified Data.ByteString.Lazy as BL
 import Data.Char (chr, ord)
 import Data.List (sortOn)
 import qualified Data.Map.Strict as M
-import Data.Maybe (mapMaybe, maybeToList)
+import Data.Maybe (catMaybes, listToMaybe, mapMaybe, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
@@ -165,42 +165,31 @@ direction recoverable, and whose amounts all re-parse pass unchanged.
 -}
 checkBrightwayExportable :: SimpleDatabase -> Either Text ()
 checkBrightwayExportable db =
-    case (flowOffenders, unitOffenders, wasteOffenders, refInputOffenders, directionOffenders, roundTripOffenders) of
-        (consumer : _, _, _, _, _, _) ->
-            Left $
-                "Brightway Excel export cannot represent activity \""
-                    <> consumer
-                    <> "\": an exchange references a flow absent from the database."
-        ([], consumer : _, _, _, _, _) ->
-            Left $
-                "Brightway Excel export cannot represent activity \""
-                    <> consumer
-                    <> "\": an exchange references a unit absent from the registry."
-        ([], [], consumer : _, _, _, _) ->
-            Left $
-                "Brightway Excel export cannot represent activity \""
-                    <> consumer
-                    <> "\": it has a waste exchange, which Brightway has no type for."
-        ([], [], [], consumer : _, _, _) ->
-            Left $
-                "Brightway Excel export cannot represent activity \""
-                    <> consumer
-                    <> "\": a reference input (treatment process) has no Brightway encoding;"
-                    <> " it would round-trip to a duplicated, role-flipped exchange."
-        ([], [], [], [], consumer : _, _) ->
-            Left $
-                "Brightway Excel export cannot represent activity \""
-                    <> consumer
-                    <> "\": a resource biosphere flow's compartment would re-parse as an emission."
-        ([], [], [], [], [], (consumer, amt) : _) ->
-            Left $
-                "Brightway Excel export cannot represent activity \""
-                    <> consumer
-                    <> "\": exchange amount "
-                    <> tshow amt
-                    <> " does not re-parse to the same value (a non-finite amount)."
-        ([], [], [], [], [], []) -> Right ()
+    case catMaybes
+        [ flowMsg <$> listToMaybe flowOffenders
+        , unitMsg <$> listToMaybe unitOffenders
+        , wasteMsg <$> listToMaybe wasteOffenders
+        , refInputMsg <$> listToMaybe refInputOffenders
+        , directionMsg <$> listToMaybe directionOffenders
+        , roundTripMsg <$> listToMaybe roundTripOffenders
+        ] of
+        [] -> Right ()
+        violations -> Left (T.intercalate "\n\n" violations)
   where
+    cannot consumer = "Brightway Excel export cannot represent activity \"" <> consumer <> "\": "
+    flowMsg consumer = cannot consumer <> "an exchange references a flow absent from the database."
+    unitMsg consumer = cannot consumer <> "an exchange references a unit absent from the registry."
+    wasteMsg consumer = cannot consumer <> "it has a waste exchange, which Brightway has no type for."
+    refInputMsg consumer =
+        cannot consumer
+            <> "a reference input (treatment process) has no Brightway encoding;"
+            <> " it would round-trip to a duplicated, role-flipped exchange."
+    directionMsg consumer = cannot consumer <> "a resource biosphere flow's compartment would re-parse as an emission."
+    roundTripMsg (consumer, amt) =
+        cannot consumer
+            <> "exchange amount "
+            <> tshow amt
+            <> " does not re-parse to the same value (a non-finite amount)."
     -- Names of activities with at least one exchange satisfying @p@. Only the
     -- first offender is ever reported, so one entry per activity (not per
     -- exchange) is equivalent — and lets every guard share one comprehension.

--- a/src/BrightwayExcel/Writer.hs
+++ b/src/BrightwayExcel/Writer.hs
@@ -69,7 +69,7 @@ import qualified Data.ByteString.Lazy as BL
 import Data.Char (chr, ord)
 import Data.List (sortOn)
 import qualified Data.Map.Strict as M
-import Data.Maybe (catMaybes, listToMaybe, mapMaybe, maybeToList)
+import Data.Maybe (catMaybes, isJust, listToMaybe, mapMaybe, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
@@ -144,11 +144,13 @@ silently losing an amount-bearing exchange. This check rejects such a database a
 the export boundary instead, reporting the first offending activity and whether a
 flow or a unit is missing.
 
-Brightway also has no native waste exchange type. Emitting a 'WasteExchange' as
-@technosphere@ would discard its waste identity and, on re-parse, reconstruct the
-direction from the technosphere convention — turning an output waste into a
-positive technosphere input. Since that link cannot survive faithfully, a
-database carrying any waste exchange is rejected here too.
+Brightway also has no native waste exchange type. A 'WasteExchange' that links to
+a producer is emitted as @technosphere@ only at the cost of its sign: the matrix
+gives a waste /output/ a negative coefficient ('Database.MatrixBuild.techTriple'),
+but the re-parsed technosphere row is read back as a positive 'Input', inverting
+it. A /linked/ waste exchange is therefore rejected here. An /orphan/ waste
+exchange (no producer link) never enters the matrix, so 'exchangeRow' instead
+best-efforts it as technosphere and 'wasteManifest' reports it.
 
 A biosphere exchange's 'BioDirection' is likewise never written: the parser
 re-derives it from the @categories@ compartment, reading 'Resource' only when the
@@ -161,30 +163,52 @@ re-parse through 'Amount.readAmount' (the importer's correctly-rounded reader);
 every finite amount does, so this rejects only the non-finite @NaN@/@Infinity@
 that would otherwise substitute a different value on re-import.
 
-Databases whose exchanges all resolve, carry no waste, keep every resource
+Databases whose exchanges all resolve, carry no linked waste, keep every resource
 direction recoverable, and whose amounts all re-parse pass unchanged.
 -}
 
-{- | Best-effort export note for a database with waste exchanges. Brightway has
-no waste type, so 'exchangeRow' writes each waste exchange as a technosphere flow
-('checkBrightwayExportable' no longer rejects it). The matrix treats a waste
-exchange exactly like a technosphere flow ('Database.MatrixBuild.techTriple'), so
-the inventory result is preserved — only the waste classification is lost on
-re-import. Report which activities that affects so the loss is never silent.
+{- | A waste exchange that resolves to a producer in the technosphere matrix.
+'Database.MatrixBuild.findProducer' locates a producer via the process link or a
+non-nil activity link, and 'techTriple' then emits a signed triple — with the
+negative sign of a waste /output/ ('exchangeIsInput' is 'False'). Re-imported, the
+technosphere row 'exchangeRow' writes is read back as a positive 'Input',
+inverting that sign. So a linked waste exchange cannot be best-efforted as
+technosphere; 'checkBrightwayExportable' rejects it.
+-}
+linkedWaste :: Exchange -> Bool
+linkedWaste ex =
+    isWasteExchange ex
+        && (isJust (exchangeProcessLinkId ex) || isJust (exchangeActivityLinkId ex))
+
+{- | A waste exchange with no producer link: matrix-invisible, so 'exchangeRow'
+rewrites it as a technosphere flow (best-effort) rather than rejecting it.
+-}
+orphanWaste :: Exchange -> Bool
+orphanWaste ex = isWasteExchange ex && not (linkedWaste ex)
+
+{- | Best-effort export note for a database with /orphan/ waste exchanges —
+end-of-life waste outputs that carry no producer link. Brightway has no waste
+type, so 'exchangeRow' writes each as a technosphere flow. Such an exchange never
+participates in the technosphere matrix ('Database.MatrixBuild.findProducer'
+returns 'Nothing'), so the rewrite is inventory-neutral; only the waste
+classification is lost on re-import. (A /linked/ waste exchange would invert its
+sign and is rejected by 'checkBrightwayExportable', so it never reaches here.)
+Report which activities are affected so the loss is never silent.
 -}
 wasteManifest :: SimpleDatabase -> [Text]
 wasteManifest db = case wasteActs of
     [] -> []
     _ -> [summary]
   where
-    wasteActs = [activityName a | a <- M.elems (sdbActivities db), any isWasteExchange (exchanges a)]
+    wasteActs = [activityName a | a <- M.elems (sdbActivities db), any orphanWaste (exchanges a)]
     summary =
         tshow (length wasteActs)
             <> " activit"
             <> (if length wasteActs == 1 then "y" else "ies")
-            <> " with waste exchanges were written as technosphere flows (Brightway has"
-            <> " no waste type); the inventory result is preserved, but the waste"
-            <> " classification is lost on re-import: "
+            <> " with end-of-life waste exchanges: Brightway has no waste type, so each"
+            <> " was written as a technosphere flow. These outputs carry no producer link,"
+            <> " so the inventory result is unchanged — only the waste classification is"
+            <> " lost on re-import: "
             <> T.intercalate ", " (take 10 wasteActs)
             <> (if length wasteActs > 10 then ", … and " <> tshow (length wasteActs - 10) <> " more" else "")
 
@@ -193,6 +217,7 @@ checkBrightwayExportable db =
     case catMaybes
         [ flowMsg <$> listToMaybe flowOffenders
         , unitMsg <$> listToMaybe unitOffenders
+        , wasteMsg <$> listToMaybe wasteOffenders
         , refInputMsg <$> listToMaybe refInputOffenders
         , directionMsg <$> listToMaybe directionOffenders
         , roundTripMsg <$> listToMaybe roundTripOffenders
@@ -203,6 +228,10 @@ checkBrightwayExportable db =
     cannot consumer = "Brightway Excel export cannot represent activity \"" <> consumer <> "\": "
     flowMsg consumer = cannot consumer <> "an exchange references a flow absent from the database."
     unitMsg consumer = cannot consumer <> "an exchange references a unit absent from the registry."
+    wasteMsg consumer =
+        cannot consumer
+            <> "a waste exchange links to a producer; Brightway has no waste type,"
+            <> " and rewriting it as a technosphere flow would invert its sign on re-import."
     refInputMsg consumer =
         cannot consumer
             <> "a reference input (treatment process) has no Brightway encoding;"
@@ -220,6 +249,7 @@ checkBrightwayExportable db =
         [activityName act | act <- M.elems (sdbActivities db), any p (exchanges act)]
     flowOffenders = activitiesWith (not . flowResolvable db)
     unitOffenders = activitiesWith (\ex -> M.notMember (exchangeUnitId ex) (sdbUnits db))
+    wasteOffenders = activitiesWith linkedWaste
     refInputOffenders = activitiesWith isReferenceInput
     directionOffenders = activitiesWith (resourceDirectionLost db)
     roundTripOffenders =
@@ -412,11 +442,11 @@ exchangeRow cfg db = \case
     ex@WasteExchange{waAmount = amt, waLocation = loc} -> do
         name <- flowNameOf db ex
         unit <- unitNameOf (exchangeUnitId ex) db
-        -- Best-effort: Brightway has no waste type, so a waste exchange is written
-        -- as a technosphere flow with the same amount. The matrix treats the two
-        -- identically ('Database.MatrixBuild.techTriple'), so the inventory result
-        -- is preserved; only the waste classification is lost on re-import.
-        -- 'wasteManifest' reports the affected activities.
+        -- Best-effort: Brightway has no waste type. Only orphan waste reaches here
+        -- ('checkBrightwayExportable' rejects linked waste, which would sign-invert),
+        -- and an orphan waste exchange never enters the technosphere matrix, so
+        -- writing it as a technosphere flow is inventory-neutral; only the waste
+        -- classification is lost on re-import. 'wasteManifest' reports the activities.
         Just
             [ CText name
             , CNum amt

--- a/src/BrightwayExcel/Writer.hs
+++ b/src/BrightwayExcel/Writer.hs
@@ -55,6 +55,7 @@ module BrightwayExcel.Writer (
     writeBrightwayExcel,
     renderWorkbook,
     checkBrightwayExportable,
+    wasteManifest,
 
     -- * Exposed for testing
     Cell (..),
@@ -163,12 +164,35 @@ that would otherwise substitute a different value on re-import.
 Databases whose exchanges all resolve, carry no waste, keep every resource
 direction recoverable, and whose amounts all re-parse pass unchanged.
 -}
+
+{- | Best-effort export note for a database with waste exchanges. Brightway has
+no waste type, so 'exchangeRow' writes each waste exchange as a technosphere flow
+('checkBrightwayExportable' no longer rejects it). The matrix treats a waste
+exchange exactly like a technosphere flow ('Database.MatrixBuild.techTriple'), so
+the inventory result is preserved — only the waste classification is lost on
+re-import. Report which activities that affects so the loss is never silent.
+-}
+wasteManifest :: SimpleDatabase -> [Text]
+wasteManifest db = case wasteActs of
+    [] -> []
+    _ -> [summary]
+  where
+    wasteActs = [activityName a | a <- M.elems (sdbActivities db), any isWasteExchange (exchanges a)]
+    summary =
+        tshow (length wasteActs)
+            <> " activit"
+            <> (if length wasteActs == 1 then "y" else "ies")
+            <> " with waste exchanges were written as technosphere flows (Brightway has"
+            <> " no waste type); the inventory result is preserved, but the waste"
+            <> " classification is lost on re-import: "
+            <> T.intercalate ", " (take 10 wasteActs)
+            <> (if length wasteActs > 10 then ", … and " <> tshow (length wasteActs - 10) <> " more" else "")
+
 checkBrightwayExportable :: SimpleDatabase -> Either Text ()
 checkBrightwayExportable db =
     case catMaybes
         [ flowMsg <$> listToMaybe flowOffenders
         , unitMsg <$> listToMaybe unitOffenders
-        , wasteMsg <$> listToMaybe wasteOffenders
         , refInputMsg <$> listToMaybe refInputOffenders
         , directionMsg <$> listToMaybe directionOffenders
         , roundTripMsg <$> listToMaybe roundTripOffenders
@@ -179,7 +203,6 @@ checkBrightwayExportable db =
     cannot consumer = "Brightway Excel export cannot represent activity \"" <> consumer <> "\": "
     flowMsg consumer = cannot consumer <> "an exchange references a flow absent from the database."
     unitMsg consumer = cannot consumer <> "an exchange references a unit absent from the registry."
-    wasteMsg consumer = cannot consumer <> "it has a waste exchange, which Brightway has no type for."
     refInputMsg consumer =
         cannot consumer
             <> "a reference input (treatment process) has no Brightway encoding;"
@@ -197,7 +220,6 @@ checkBrightwayExportable db =
         [activityName act | act <- M.elems (sdbActivities db), any p (exchanges act)]
     flowOffenders = activitiesWith (not . flowResolvable db)
     unitOffenders = activitiesWith (\ex -> M.notMember (exchangeUnitId ex) (sdbUnits db))
-    wasteOffenders = activitiesWith isWasteExchange
     refInputOffenders = activitiesWith isReferenceInput
     directionOffenders = activitiesWith (resourceDirectionLost db)
     roundTripOffenders =
@@ -390,11 +412,11 @@ exchangeRow cfg db = \case
     ex@WasteExchange{waAmount = amt, waLocation = loc} -> do
         name <- flowNameOf db ex
         unit <- unitNameOf (exchangeUnitId ex) db
-        -- Unreachable on any guarded path: 'checkBrightwayExportable' (run by
-        -- 'renderWorkbook' before serialization) rejects every database carrying a
-        -- waste exchange, precisely because re-parsing it as technosphere would
-        -- invert an output waste into a positive input. This branch only keeps
-        -- 'exchangeRow' total without a silent drop; it never reaches the workbook.
+        -- Best-effort: Brightway has no waste type, so a waste exchange is written
+        -- as a technosphere flow with the same amount. The matrix treats the two
+        -- identically ('Database.MatrixBuild.techTriple'), so the inventory result
+        -- is preserved; only the waste classification is lost on re-import.
+        -- 'wasteManifest' reports the affected activities.
         Just
             [ CText name
             , CNum amt

--- a/src/BrightwayExcel/Writer.hs
+++ b/src/BrightwayExcel/Writer.hs
@@ -72,8 +72,8 @@ import Data.Maybe (mapMaybe, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-import qualified Data.Text.Read as TR
 
+import Amount (readAmount)
 import BrightwayExcel.Parser (isResourceCompartment)
 import EcoSpold.Common (showFFloatTrim)
 import Types
@@ -155,10 +155,10 @@ compartment matches 'isResourceCompartment'. A 'Resource' flow whose compartment
 is outside that whitelist would round-trip as an 'Emission' — a sign flip, since
 the two directions act as input vs output. Such a flow is rejected here too.
 
-An amount that does not re-parse to itself is rejected: a non-finite
-@NaN@/@Infinity@ (which the parser can propagate from an out-of-range literal),
-or a subnormal near @5e-324@ that 'formatAmount' collapses to @0@. Either would
-silently substitute a different value on re-import.
+An amount that does not re-parse to itself is rejected. The written decimal must
+re-parse through 'Amount.readAmount' (the importer's correctly-rounded reader);
+every finite amount does, so this rejects only the non-finite @NaN@/@Infinity@
+that would otherwise substitute a different value on re-import.
 
 Databases whose exchanges all resolve, carry no waste, keep every resource
 direction recoverable, and whose amounts all re-parse pass unchanged.
@@ -198,7 +198,7 @@ checkBrightwayExportable db =
                     <> consumer
                     <> "\": exchange amount "
                     <> tshow amt
-                    <> " does not re-parse to the same value (non-finite or near-underflow subnormal)."
+                    <> " does not re-parse to the same value (a non-finite amount)."
         ([], [], [], [], [], []) -> Right ()
   where
     -- Names of activities with at least one exchange satisfying @p@. Only the
@@ -218,9 +218,7 @@ checkBrightwayExportable db =
         , let amt = exchangeAmount ex
         , not (amountRoundTrips amt)
         ]
-    amountRoundTrips amt = case TR.double (formatAmount amt) of
-        Right (v, rest) -> v == amt && T.null rest
-        Left _ -> False
+    amountRoundTrips amt = readAmount (formatAmount amt) == Just amt
 
 {- | A 'Resource' biosphere exchange whose compartment would not re-parse as a
 resource: the writer never records the direction, so the parser reconstructs
@@ -466,12 +464,10 @@ lookup' p = foldr (\x acc -> if p x then Just x else acc) Nothing
 
 {- | Canonical numeric rendering for amount cells. Integers print without a
 decimal point (@1@, not @1.0@); every other value uses the shared fixed-point
-'showFFloatTrim' (never scientific), so it re-parses through the parser's
-'Data.Text.Read.double' — unlike @show@, whose scientific notation re-reads
-lossily for small magnitudes (e.g. @show 3.3e-20@ → @3.2999999999999994e-20@).
-The near-underflow subnormal tail (≈@5e-324@) cannot survive fixed-point, and a
-non-finite value has no numeric-cell form; 'checkBrightwayExportable' rejects
-both, so the guarded path never emits one. A non-finite value still renders as
+'showFFloatTrim' (never scientific), the exact inverse of 'Amount.readAmount':
+every finite amount re-parses through that correctly-rounded reader. A
+non-finite value has no numeric-cell form; 'checkBrightwayExportable' rejects it,
+so the guarded path never emits one. A non-finite value still renders as
 its (non-parseable) @"NaN"@/@"Infinity"@ form so a stray re-import fails loudly
 rather than reading a misleading number.
 -}

--- a/src/Database/Export.hs
+++ b/src/Database/Export.hs
@@ -13,7 +13,6 @@ has no writer and 'UnknownFormat' is not a real target, so both fail loudly
 -}
 module Database.Export (
     serializeDatabase,
-    exportWarnings,
     exportDatabase,
     parseExportFormat,
 ) where
@@ -33,35 +32,33 @@ import qualified ILCD.Writer as ILCD
 import qualified SimaPro.Writer as SP
 import Types (Database, toSimpleDatabase)
 
-{- | Serialize a database to a single byte stream in the requested format. Pure:
-the multi-file formats are zipped in-memory. Fails loudly for formats without a
-writer.
+{- | Serialize a database to a single byte stream in the requested format, paired
+with any best-effort approximation warnings. Pure: the multi-file formats are
+zipped in-memory. Fails loudly for formats without a writer.
+
+The warning list is empty for a faithful export and non-empty when a writer had
+to approximate. Currently only the Brightway writer approximates: it has no waste
+type, so it rewrites /orphan/ waste exchanges as technosphere flows
+(inventory-neutral, but the waste tag is lost on re-import) and reports the
+affected activities. Returning bytes and warnings together shares the one
+'toSimpleDatabase' conversion and keeps them from drifting apart.
 -}
-serializeDatabase :: DatabaseFormat -> Database -> Either Text BL.ByteString
+serializeDatabase :: DatabaseFormat -> Database -> Either Text (BL.ByteString, [Text])
 serializeDatabase fmt db = case fmt of
     -- Each writer runs its own check*Exportable and returns 'Left' on a database
     -- the format cannot represent faithfully, so the guard is unskippable.
-    SimaProCSV -> BL.fromStrict <$> SP.serializeSimaProCSV SP.defaultWriterConfig sdb
-    EcoSpold1 -> BL.fromStrict . TE.encodeUtf8 <$> ES1.writeDatabase ES1.canonicalWriterOptions db
-    EcoSpold2 -> zipText <$> ES2.writeEcoSpold2 ES2.noVolatileMeta sdb
-    ILCDProcess -> ILCD.writeILCDArchive ILCD.defaultWriteOptions sdb
-    BrightwayExcel -> BE.renderWorkbook BE.defaultWriterConfig sdb
+    SimaProCSV -> noWarn (BL.fromStrict <$> SP.serializeSimaProCSV SP.defaultWriterConfig sdb)
+    EcoSpold1 -> noWarn (BL.fromStrict . TE.encodeUtf8 <$> ES1.writeDatabase ES1.canonicalWriterOptions db)
+    EcoSpold2 -> noWarn (zipText <$> ES2.writeEcoSpold2 ES2.noVolatileMeta sdb)
+    ILCDProcess -> noWarn (ILCD.writeILCDArchive ILCD.defaultWriteOptions sdb)
+    BrightwayExcel -> (\bytes -> (bytes, BE.wasteManifest sdb)) <$> BE.renderWorkbook BE.defaultWriterConfig sdb
     OpenLcaJsonLd ->
         Left "openLCA JSON-LD export is not supported"
     UnknownFormat ->
         Left "cannot export to an unknown format"
   where
     sdb = toSimpleDatabase db
-
-{- | Best-effort approximations made when serializing @db@ to @fmt@. Empty for a
-faithful export; non-empty when a writer had to approximate. Currently only the
-Brightway writer approximates: it has no waste type, so it rewrites waste
-exchanges as technosphere flows (inventory-preserving, but the waste tag is lost
-on re-import) and reports the affected activities here.
--}
-exportWarnings :: DatabaseFormat -> Database -> [Text]
-exportWarnings BrightwayExcel db = BE.wasteManifest (toSimpleDatabase db)
-exportWarnings _ _ = []
+    noWarn = fmap (\bytes -> (bytes, []))
 
 {- | Parse a user-facing export-format name (case- and whitespace-insensitive)
 to a 'DatabaseFormat'. Shared by the CLI and the HTTP handler so the accepted
@@ -80,7 +77,7 @@ parseExportFormat raw = case T.toLower (T.strip raw) of
 exportDatabase :: DatabaseFormat -> Database -> FilePath -> IO (Either Text ())
 exportDatabase fmt db path = case serializeDatabase fmt db of
     Left err -> pure (Left err)
-    Right bytes -> either (Left . renderErr) Right <$> try (BL.writeFile path bytes)
+    Right (bytes, _warnings) -> either (Left . renderErr) Right <$> try (BL.writeFile path bytes)
   where
     renderErr :: SomeException -> Text
     renderErr e = "export failed: " <> T.pack (show e)

--- a/src/Database/Export.hs
+++ b/src/Database/Export.hs
@@ -13,6 +13,7 @@ has no writer and 'UnknownFormat' is not a real target, so both fail loudly
 -}
 module Database.Export (
     serializeDatabase,
+    exportWarnings,
     exportDatabase,
     parseExportFormat,
 ) where
@@ -51,6 +52,16 @@ serializeDatabase fmt db = case fmt of
         Left "cannot export to an unknown format"
   where
     sdb = toSimpleDatabase db
+
+{- | Best-effort approximations made when serializing @db@ to @fmt@. Empty for a
+faithful export; non-empty when a writer had to approximate. Currently only the
+Brightway writer approximates: it has no waste type, so it rewrites waste
+exchanges as technosphere flows (inventory-preserving, but the waste tag is lost
+on re-import) and reports the affected activities here.
+-}
+exportWarnings :: DatabaseFormat -> Database -> [Text]
+exportWarnings BrightwayExcel db = BE.wasteManifest (toSimpleDatabase db)
+exportWarnings _ _ = []
 
 {- | Parse a user-facing export-format name (case- and whitespace-insensitive)
 to a 'DatabaseFormat'. Shared by the CLI and the HTTP handler so the accepted

--- a/src/EcoSpold/Common.hs
+++ b/src/EcoSpold/Common.hs
@@ -13,7 +13,9 @@ module EcoSpold.Common (
     showFFloatTrim,
 ) where
 
+import Amount (readAmount)
 import qualified Data.ByteString as BS
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
@@ -47,9 +49,7 @@ decodeXmlEntities =
 
 -- | ByteString to Double conversion (strict - errors on parse failure)
 bsToDouble :: BS.ByteString -> Double
-bsToDouble bs = case TR.double (bsToText bs) of
-    Right (val, _) -> val
-    Left _ -> error $ "Failed to parse double from: " ++ show bs
+bsToDouble bs = fromMaybe (error $ "Failed to parse double from: " ++ show bs) (readAmount (bsToText bs))
 
 -- | ByteString to Int conversion (strict - errors on parse failure)
 bsToInt :: BS.ByteString -> Int
@@ -94,14 +94,12 @@ distributeFiles n xs =
 
 {- | Render a 'Double' in fixed-point notation (never scientific) with trailing
 zeros trimmed but at least one fractional digit kept. This is the canonical
-amount format for the EcoSpold/ILCD writers: it re-parses to the same value
-through 'Data.Text.Read.double' for the magnitudes real LCA amounts occupy —
-unlike 'show', which emits scientific notation for small/large magnitudes that
-re-reads lossily (e.g. @show 3.3e-20@ → @3.2999999999999994e-20@). The
-near-underflow subnormal tail (≈@5e-324@) is the exception: fixed-point can't
-carry enough significant digits there, so it re-parses to @0@. The writers'
-export guards reject any amount that does not re-parse, so a guarded export
-never emits one of these.
+amount format for the EcoSpold/ILCD/Brightway writers and the exact inverse of
+'Amount.readAmount': through that correctly-rounded reader every finite 'Double'
+— subnormals included — re-parses to the same value. Fixed-point is also the
+form these exchange formats and their external readers expect. The writers'
+export guards reject any amount that does not re-parse, which now leaves only the
+non-finite @Infinity@/@NaN@.
 -}
 showFFloatTrim :: Double -> String
 showFFloatTrim d =

--- a/src/EcoSpold/Writer1.hs
+++ b/src/EcoSpold/Writer1.hs
@@ -72,11 +72,11 @@ module EcoSpold.Writer1 (
     formatAmount,
 ) where
 
+import Amount (readAmount)
 import Data.List (sortOn)
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
-import qualified Data.Text.Read as TR
 import qualified Data.UUID as UUID
 import Database.Loader (generateActivityUUIDFromActivity)
 import EcoSpold.Common (showFFloatTrim)
@@ -206,11 +206,10 @@ emit silently wrong data:
 
   * __Non-finite amounts.__ @NaN@/@Infinity@ have no parseable literal.
 
-  * __Non-round-tripping amounts.__ A finite amount whose decimal form does not
-    re-parse to the same 'Double' through 'Data.Text.Read.double' (the parser's
-    reader) — e.g. a subnormal near the floating-point floor — would silently
-    export as a different value. Real LCA amounts never reach this range, but
-    the guard rejects it rather than undercount.
+  * __Non-round-tripping amounts.__ A defensive check that the written decimal
+    re-parses to the same 'Double' through 'Amount.readAmount' (the importer's
+    correctly-rounded reader). Every finite amount round-trips, so this guards
+    the formatter↔reader contract against future drift.
 
 Databases free of all of these pass unchanged.
 -}
@@ -288,8 +287,7 @@ checkEcoSpold1Exportable db =
                         <> consumer
                         <> "\": exchange amount "
                         <> T.pack (show amt)
-                        <> " has no decimal form that re-parses to the same value"
-                        <> " (e.g. a subnormal near the floating-point floor)."
+                        <> " has no decimal form that re-parses to the same value."
     index = supplierNumberIndex (orderedActivities (M.elems (sdbActivities db)))
     danglingLinks =
         [ (activityName act, link)
@@ -313,11 +311,10 @@ checkEcoSpold1Exportable db =
         , not (isNaN amt || isInfinite amt) -- non-finite already reported by checkAmounts
         , not (amountRoundTrips amt)
         ]
-    -- The written decimal must re-parse to the same Double through the parser's
-    -- reader ('Data.Text.Read.double'), or the value silently changes on import.
-    amountRoundTrips amt = case TR.double (formatAmount amt) of
-        Right (v, rest) -> v == amt && T.null rest
-        Left _ -> False
+    -- The written decimal must re-parse to the same Double through the importer's
+    -- correctly-rounded reader ('Amount.readAmount'), or the value would change
+    -- on re-import.
+    amountRoundTrips amt = readAmount (formatAmount amt) == Just amt
     refInputOffenders =
         [ activityName act
         | act <- M.elems (sdbActivities db)
@@ -573,12 +570,10 @@ escapeXmlAttr =
         . T.replace "&" "&amp;"
 
 {- | Deterministic textual form for a @meanValue@. Uses the shared
-'showFFloatTrim' (fixed-point, never scientific) so the value round-trips
-through the parser's 'Data.Text.Read.double' for the magnitudes real LCA
-amounts occupy — unlike @show@, which emits scientific notation that re-reads
-lossily. The near-underflow subnormal tail is the exception;
-'checkEcoSpold1Exportable' rejects any amount that does not re-parse, so the
-guarded path never emits a value that changes on import.
+'showFFloatTrim' (fixed-point, never scientific), the exact inverse of
+'Amount.readAmount': every finite amount round-trips through that
+correctly-rounded reader. 'checkEcoSpold1Exportable' rejects any amount that does
+not re-parse, which now leaves only the non-finite.
 
 A non-finite value renders as its (non-parseable) @"NaN"@/@"Infinity"@ form so
 a bad re-import fails loudly rather than silently reading @0@; the export guard

--- a/src/EcoSpold/Writer1.hs
+++ b/src/EcoSpold/Writer1.hs
@@ -78,7 +78,6 @@ import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
-import Database.Loader (generateActivityUUIDFromActivity)
 import EcoSpold.Common (showFFloatTrim)
 import Types
 
@@ -132,9 +131,9 @@ writeSimpleDatabase opts sdb = do
             (sdbBioFlows sdb)
             (sdbWasteFlows sdb)
             (sdbUnits sdb)
-            (M.elems (sdbActivities sdb))
+            (sdbActivities sdb)
 
-{- | Serialize a list of activities against the flow / unit tables that
+{- | Serialize the database's activities against the flow / unit tables that
 resolve their exchange UUIDs. Internal: it does no export-boundary checking,
 so it is reached only through 'writeSimpleDatabase', which runs
 'checkEcoSpold1Exportable' first. Not exported, so no caller can bypass the
@@ -146,14 +145,14 @@ writeActivities ::
     BioFlowDB ->
     WasteFlowDB ->
     UnitDB ->
-    [Activity] ->
+    ActivityMap ->
     Text
 writeActivities opts techs bios wastes units activities =
     T.unlines $
         [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold01\">"
         ]
-            ++ concat (zipWith (datasetLines opts res) [1 ..] ordered)
+            ++ concat (zipWith (datasetLines opts res) [1 ..] (map snd ordered))
             ++ ["</ecoSpold>"]
   where
     res = Resolvers techs bios wastes units (supplierNumberIndex ordered)
@@ -161,23 +160,30 @@ writeActivities opts techs bios wastes units activities =
     -- are reproducible regardless of the source Map's ordering.
     ordered = orderedActivities activities
 
-{- | Canonical export order: sorted by @(activityName, location)@, so dataset
+{- | Canonical export order: sorted by @(activityName, location)@ so dataset
 numbers (and thus flow UUIDs) are reproducible regardless of the source Map's
-ordering. Shared by the writer and 'checkEcoSpold1Exportable'.
+ordering. Each activity is paired with the stored activity UUID — the first
+component of its 'sdbActivities' key — that a technosphere input's
+'techActivityLinkId' points at. Shared by the writer and
+'checkEcoSpold1Exportable'.
 -}
-orderedActivities :: [Activity] -> [Activity]
-orderedActivities = sortOn (\a -> (activityName a, activityLocation a))
+orderedActivities :: ActivityMap -> [(UUID, Activity)]
+orderedActivities =
+    sortOn (\(_, a) -> (activityName a, activityLocation a))
+        . map (\((actU, _), a) -> (actU, a))
+        . M.toList
 
-{- | Map each supplier activity's UUID to the dataset number it is assigned in
-canonical order. A technosphere input links to its supplier by
-'techActivityLinkId' (the supplier's @generateActivityUUIDFromActivity@), so the
-parser reads the input's @number@ attribute back as that supplier dataset number
-('EcoSpold.Parser1.closeExchange'). Re-encoding that link therefore means
-resolving the supplier UUID to its position in this index.
+{- | Map each supplier activity's stored UUID to the dataset number it is assigned
+in canonical order. A technosphere input links to its supplier by
+'techActivityLinkId' — the supplier's stored activity UUID, the first component of
+its 'sdbActivities' key — and the parser reads the input's @number@ attribute back
+as that supplier dataset number ('EcoSpold.Parser1.closeExchange'). Keying by the
+stored UUID rather than re-deriving one lets a link resolve whatever namespace the
+source format minted the UUID in.
 -}
-supplierNumberIndex :: [Activity] -> M.Map UUID Int
+supplierNumberIndex :: [(UUID, Activity)] -> M.Map UUID Int
 supplierNumberIndex ordered =
-    M.fromList [(generateActivityUUIDFromActivity a, n) | (n, a) <- zip [1 ..] ordered]
+    M.fromList [(actU, n) | (n, (actU, _)) <- zip [1 ..] ordered]
 
 {- | Guard an EcoSpold1 export against data the writer cannot faithfully
 re-encode. Each check reports its first offender and fails loudly rather than
@@ -288,7 +294,7 @@ checkEcoSpold1Exportable db =
                         <> "\": exchange amount "
                         <> T.pack (show amt)
                         <> " has no decimal form that re-parses to the same value."
-    index = supplierNumberIndex (orderedActivities (M.elems (sdbActivities db)))
+    index = supplierNumberIndex (orderedActivities (sdbActivities db))
     danglingLinks =
         [ (activityName act, link)
         | act <- M.elems (sdbActivities db)

--- a/src/EcoSpold/Writer1.hs
+++ b/src/EcoSpold/Writer1.hs
@@ -73,6 +73,7 @@ module EcoSpold.Writer1 (
 ) where
 
 import Amount (readAmount)
+import Data.Either (lefts)
 import Data.List (sortOn)
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
@@ -221,7 +222,9 @@ Databases free of all of these pass unchanged.
 -}
 checkEcoSpold1Exportable :: SimpleDatabase -> Either Text ()
 checkEcoSpold1Exportable db =
-    checkLinks *> checkRefInputs *> checkWasteSentinel *> checkFlows *> checkUnits *> checkAmounts *> checkAmountRoundTrip
+    case lefts [checkLinks, checkRefInputs, checkWasteSentinel, checkFlows, checkUnits, checkAmounts, checkAmountRoundTrip] of
+        [] -> Right ()
+        violations -> Left (T.intercalate "\n\n" violations)
   where
     checkLinks =
         case danglingLinks of

--- a/src/EcoSpold/Writer2.hs
+++ b/src/EcoSpold/Writer2.hs
@@ -41,13 +41,13 @@ module EcoSpold.Writer2 (
     sortExchanges,
 ) where
 
+import Amount (readAmount)
 import Data.List (sortOn)
 import qualified Data.Map.Strict as M
 import Data.Maybe (listToMaybe)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
-import qualified Data.Text.Read as TR
 import qualified Data.UUID as UUID
 import EcoSpold.Common (showFFloatTrim)
 import Types
@@ -107,11 +107,11 @@ writeEcoSpold2 meta sdb = do
 {- | Guard an EcoSpold2 export against data the writer cannot faithfully
 re-encode.
 
-  * __Non-finite amounts.__ 'doubleAttr' clamps @NaN@/@Infinity@ to a parseable
-    @0.0@; a database carrying such an amount would silently export as zero. The
-    reader parses amounts with 'Data.Text.Read.double', which yields @Infinity@
-    for an overflowing literal like @1e400@, so this is reachable from a parsed
-    source — not only from in-memory construction.
+  * __Non-finite amounts.__ 'doubleAttr' renders @NaN@/@Infinity@ as their
+    non-parseable literal forms; the guard rejects such an amount rather than
+    emit one. 'Amount.readAmount' also refuses non-finite and overflowing
+    literals (e.g. @1e400@) on import, so an in-memory non-finite can only arise
+    from programmatic construction.
 
   * __Reference inputs.__ A treatment activity's 'ReferenceInput' is written as
     @inputGroup 5@, but no ES2 inputGroup re-parses to 'ReferenceInput' (the
@@ -130,10 +130,10 @@ re-encode.
     /no compartment/ — a silent identity and compartment downgrade. Symmetric to
     the unit case: reject rather than corrupt.
 
-  * __Non-round-tripping amounts.__ A finite amount whose decimal form does not
-    re-parse to the same 'Double' through 'Data.Text.Read.double' — e.g. a
-    subnormal near the floating-point floor — would silently export as a
-    different value. Reject rather than undercount.
+  * __Non-round-tripping amounts.__ A defensive check that the written decimal
+    re-parses to the same 'Double' through 'Amount.readAmount' (the importer's
+    correctly-rounded reader). Every finite amount round-trips, so this guards
+    the formatter↔reader contract against future drift.
 
 Reports the first offender and fails loudly rather than emit silently wrong
 data. Databases free of it pass unchanged.
@@ -166,11 +166,10 @@ checkEcoSpold2Exportable db =
         , not (isNaN amt || isInfinite amt) -- non-finite already reported above
         , not (amountRoundTrips amt)
         ]
-    -- The written decimal must re-parse to the same Double through the parser's
-    -- reader ('Data.Text.Read.double'), or the value silently changes on import.
-    amountRoundTrips amt = case TR.double (doubleAttr amt) of
-        Right (v, rest) -> v == amt && T.null rest
-        Left _ -> False
+    -- The written decimal must re-parse to the same Double through the importer's
+    -- correctly-rounded reader ('Amount.readAmount'), or the value would change
+    -- on re-import.
+    amountRoundTrips amt = readAmount (doubleAttr amt) == Just amt
     refInputOffenders =
         [ activityName act
         | act <- M.elems (sdbActivities db)
@@ -209,8 +208,7 @@ checkEcoSpold2Exportable db =
         cannotRepresent c
             <> "exchange amount "
             <> T.pack (show a)
-            <> " has no decimal form that re-parses to the same value"
-            <> " (e.g. a subnormal near the floating-point floor)."
+            <> " has no decimal form that re-parses to the same value."
 
 -- | Canonical filename for an activity: @{actUUID}_{prodUUID}.spold@.
 activityFileName :: UUID.UUID -> UUID.UUID -> FilePath
@@ -568,11 +566,11 @@ intText :: Int -> Text
 intText = T.pack . show
 
 {- | Canonical 'Double' rendering for amounts via the shared 'showFFloatTrim'
-(fixed-point, never scientific), so the value round-trips through the parser's
-'Data.Text.Read.double' for the magnitudes real LCA amounts occupy. The
-near-underflow subnormal tail is the exception; 'checkEcoSpold2Exportable'
-rejects any amount that does not re-parse, so the guarded path never emits one.
-A non-finite value renders as its (non-parseable) @"NaN"@/@"Infinity"@ form so a
+(fixed-point, never scientific), the exact inverse of 'Amount.readAmount': every
+finite amount round-trips through that correctly-rounded reader.
+'checkEcoSpold2Exportable' rejects any amount that does not re-parse, which now
+leaves only the non-finite. A non-finite value renders as its (non-parseable)
+@"NaN"@/@"Infinity"@ form so a
 bad re-import fails loudly rather than silently reading @0@; the guard rejects
 non-finite amounts before they reach here.
 -}

--- a/src/EcoSpold/Writer2.hs
+++ b/src/EcoSpold/Writer2.hs
@@ -44,7 +44,7 @@ module EcoSpold.Writer2 (
 import Amount (readAmount)
 import Data.List (sortOn)
 import qualified Data.Map.Strict as M
-import Data.Maybe (listToMaybe)
+import Data.Maybe (listToMaybe, mapMaybe)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -140,10 +140,12 @@ data. Databases free of it pass unchanged.
 -}
 checkEcoSpold2Exportable :: SimpleDatabase -> Either Text ()
 checkEcoSpold2Exportable db =
-    maybe (Right ()) Left (listToMaybe (concat orderedViolations))
+    case mapMaybe listToMaybe orderedViolations of
+        [] -> Right ()
+        violations -> Left (T.intercalate "\n\n" violations)
   where
-    -- Categories in priority order; the first offending activity across all of
-    -- them is reported. Each inner list carries one message per offender.
+    -- Categories in priority order; the first offending activity of each is
+    -- reported. Each inner list carries one message per offender.
     orderedViolations =
         [ [nonFiniteMsg c a | (c, a) <- amountOffenders]
         , [refInputMsg c | c <- refInputOffenders]

--- a/src/ILCD/Parser.hs
+++ b/src/ILCD/Parser.hs
@@ -15,6 +15,7 @@ module ILCD.Parser (
     fixActivityExchanges,
 ) where
 
+import Amount (readAmount)
 import Control.Applicative ((<|>))
 import Control.Concurrent (getNumCapabilities)
 import Control.Concurrent.Async (mapConcurrently)
@@ -494,7 +495,7 @@ parseProcessXML bytes =
     cdata = txt
     accum s = T.strip $ T.concat $ reverse $ map bsToText (psTextAccum s)
 
-    parseDouble t = case TR.double t of Right (v, _) -> v; Left _ -> 0
+    parseDouble t = Data.Maybe.fromMaybe 0 (readAmount t)
 
     buildProcess s = do
         uuid <- UUID.fromText (psUUID s)

--- a/src/ILCD/Writer.hs
+++ b/src/ILCD/Writer.hs
@@ -59,6 +59,7 @@ module ILCD.Writer (
 import Codec.Archive.Zip (addEntryToArchive, emptyArchive, fromArchive, toEntry)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
+import Data.Either (lefts)
 import Data.List (sortOn)
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
@@ -163,7 +164,9 @@ unchanged.
 -}
 checkILCDExportable :: SimpleDatabase -> Either Text ()
 checkILCDExportable db =
-    checkMedia >> checkMultiOutput >> checkClassifications >> checkAmounts
+    case lefts [checkMedia, checkMultiOutput, checkClassifications, checkAmounts] of
+        [] -> Right ()
+        violations -> Left (T.intercalate "\n\n" violations)
   where
     -- Media the parser's @extractMedium@ inverts back, after canonicalising
     -- aliases like "resource" → "natural resource".

--- a/src/ILCD/Writer.hs
+++ b/src/ILCD/Writer.hs
@@ -165,7 +165,8 @@ checkILCDExportable :: SimpleDatabase -> Either Text ()
 checkILCDExportable db =
     checkMedia >> checkMultiOutput >> checkClassifications >> checkAmounts
   where
-    -- Media the parser's @extractMedium@ inverts back to the same string.
+    -- Media the parser's @extractMedium@ inverts back, after canonicalising
+    -- aliases like "resource" → "natural resource".
     canonicalMedia = ["air", "water", "soil", "natural resource"]
     checkMedia =
         case [f | f <- M.elems (sdbBioFlows db), notInvertible f] of
@@ -182,7 +183,7 @@ checkILCDExportable db =
                         <> "only air, water, soil and natural resource round-trip."
     notInvertible f = case bfCompartment f of
         Nothing -> False
-        Just c -> compartmentName c `notElem` canonicalMedia
+        Just c -> canonicalMedium (compartmentName c) `notElem` canonicalMedia
 
     checkMultiOutput =
         case M.toList collisions of
@@ -497,6 +498,15 @@ casBlock (Just cas)
 'parseCompartment': level 0 is "Emissions"/"Resources", level 1 names the
 medium, level 2 (when a sub-compartment exists) is "<medium-phrase>, <sub>".
 -}
+
+{- | Canonicalise a biosphere compartment medium to the spelling ILCD's
+classification — and the parser's 'extractMedium' — round-trips. SimaPro-sourced
+databases label natural-resource flows "resource"; ILCD uses "natural resource".
+-}
+canonicalMedium :: Text -> Text
+canonicalMedium "resource" = "natural resource"
+canonicalMedium m = m
+
 compartmentBlock :: Maybe Compartment -> [Text]
 compartmentBlock Nothing = []
 compartmentBlock (Just (Compartment medium sub)) =
@@ -510,17 +520,18 @@ compartmentBlock (Just (Compartment medium sub)) =
            , "      </classificationInformation>"
            ]
   where
-    isResource = medium == "natural resource"
+    m = canonicalMedium medium
+    isResource = m == "natural resource"
     level0 = if isResource then "Resources" else "Emissions"
     level1
         | isResource = "Resources"
-        | otherwise = "Emissions to " <> medium
+        | otherwise = "Emissions to " <> m
     level2 = case sub of
         Nothing -> []
         Just s
             | T.null s -> []
             | isResource -> [attrElem "common:category" [("level", "2")] ("Resources " <> s)]
-            | otherwise -> [attrElem "common:category" [("level", "2")] ("Emissions to " <> medium <> ", " <> s)]
+            | otherwise -> [attrElem "common:category" [("level", "2")] ("Emissions to " <> m <> ", " <> s)]
 
 --------------------------------------------------------------------------------
 -- FlowProperty XML  (one per unit; shares the unit's UUID)

--- a/src/ILCD/Writer.hs
+++ b/src/ILCD/Writer.hs
@@ -64,11 +64,11 @@ import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-import qualified Data.Text.Read as TR
 import qualified Data.UUID as UUID
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath (joinPath, splitDirectories, (</>))
 
+import Amount (readAmount)
 import EcoSpold.Common (showFFloatTrim)
 import Types
 
@@ -150,11 +150,10 @@ ilcdFiles opts db = sortOn fst (processes ++ flows ++ flowProps ++ unitGroups)
   — @""@ (key vanishes), or @"a//b"@ \/ @"a/"@ (collapses to @"a/b"@ \/ @"a"@) —
   therefore does not round-trip.
 
-* /Amounts that do not re-parse./ 'formatDouble' is fixed-point, so a non-finite
-  amount (@NaN@\/@Infinity@, which the parser can propagate from an out-of-range
-  literal like @"1e400"@) or a subnormal near @5e-324@ would re-import as a
-  different number (or fail to parse), silently shifting LCIA scores. We reject
-  any amount that does not re-parse to itself.
+* /Amounts that do not re-parse./ The written decimal must re-parse to the same
+  'Double' through 'Amount.readAmount' (the importer's correctly-rounded
+  reader). Every finite amount does, so this rejects only the non-finite
+  (@NaN@\/@Infinity@) that would otherwise shift LCIA scores on re-import.
 
 Rather than silently corrupting any of these, report the first offending flow,
 activity or exchange so the caller can fail loudly. Databases whose activity
@@ -226,9 +225,9 @@ checkILCDExportable db =
                         <> "): an empty classification level does not round-trip "
                         <> "because the ILCD parser drops empty levels."
 
-    -- An amount round-trips only when its fixed-point rendering re-parses to the
-    -- same value through the parser's 'Data.Text.Read.double' (consuming all of
-    -- it). Rejects non-finite amounts and the subnormal tail near 5e-324.
+    -- An amount round-trips when its fixed-point rendering re-parses to the same
+    -- value through 'Amount.readAmount' (the importer's correctly-rounded
+    -- reader). Every finite amount does, so this rejects only the non-finite.
     checkAmounts =
         case [ (actUUID, exchangeAmount ex)
              | ((actUUID, _), act) <- M.toList (sdbActivities db)
@@ -245,10 +244,8 @@ checkILCDExportable db =
                         <> "\" (UUID "
                         <> uuidText actUUID
                         <> "): it does not re-parse to the same value through the "
-                        <> "ILCD parser (non-finite or near-underflow subnormal)."
-    amountRoundTrips amt = case TR.double (formatDouble amt) of
-        Right (v, rest) -> v == amt && T.null rest
-        Left _ -> False
+                        <> "ILCD parser (a non-finite amount)."
+    amountRoundTrips amt = readAmount (formatDouble amt) == Just amt
 
 {- | Write the ILCD package as a directory tree rooted at @dir@, or return the
 export guard's 'Left' without touching disk.
@@ -625,13 +622,10 @@ escapeXmlAttr =
         . escapeXml
 
 {- | Canonical 'Double' formatting via the shared 'showFFloatTrim' (fixed-point,
-never scientific), so the value round-trips through the parser's
-'Data.Text.Read.double' for the magnitudes real LCA amounts occupy — unlike
-@show@, which emits scientific notation that re-reads lossily (e.g. @show 3.3e-20@
-→ @3.2999999999999994e-20@). The near-underflow subnormal tail (≈@5e-324@) is the
-exception (fixed-point can't carry enough digits, so it re-parses to @0@);
-'checkILCDExportable' rejects any amount that does not re-parse, so the guarded
-path never emits one. A non-finite value renders as its (non-parseable)
+never scientific), the exact inverse of 'Amount.readAmount': every finite amount
+round-trips through that correctly-rounded reader. 'checkILCDExportable' rejects
+any amount that does not re-parse, which now leaves only the non-finite. A
+non-finite value renders as its (non-parseable)
 @"NaN"@/@"Infinity"@ form so a bad re-import fails loudly rather than silently
 reading @0@; the guard rejects non-finite amounts first. Negative zero is
 normalised to @0.0@.

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -32,6 +32,7 @@ module SimaPro.Parser (
     decodeBS,
 ) where
 
+import Amount (readAmount)
 import Control.Concurrent.Async (mapConcurrently)
 import Control.DeepSeq (NFData, force)
 import Control.Exception (evaluate)
@@ -43,13 +44,12 @@ import Data.Char (isUpper, toLower)
 import qualified Data.Csv as Csv
 import Data.List (dropWhileEnd)
 import qualified Data.Map.Strict as M
-import Data.Maybe (catMaybes, isNothing, maybeToList)
+import Data.Maybe (catMaybes, isJust, isNothing, maybeToList)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Encoding.Error as TEE
-import qualified Data.Text.Read as TR
 import Data.Time (diffUTCTime, getCurrentTime)
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V5 as UUID5
@@ -791,9 +791,9 @@ extractLocation name =
 resolveAmount :: M.Map Text Double -> Text -> Double -> Double
 resolveAmount env raw fallback
     | T.null raw = fallback
-    | otherwise = case TR.double raw of
-        Right (v, rest) | T.null (T.strip rest) -> v
-        _ -> case Expr.evaluate env raw of
+    | otherwise = case readAmount raw of
+        Just v -> v
+        Nothing -> case Expr.evaluate env raw of
             Right v -> v
             Left _ -> fallback
 
@@ -915,9 +915,7 @@ processBlockToActivity unitCfg GlobalParams{..} ProcessBlock{..} =
 
 -- | True when the raw allocation cell is a plain decimal literal (no formula).
 isNumericFormula :: Text -> Bool
-isNumericFormula t = case TR.double t of
-    Right (_, rest) -> T.null (T.strip rest)
-    Left _ -> False
+isNumericFormula = isJust . readAmount
 
 -- | Scale an exchange amount by a factor (for allocation)
 scaleExchange :: Double -> Exchange -> Exchange

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -207,9 +207,9 @@ checkSimaProExportable db =
                         <> name
                         <> "\": allocation percentage "
                         <> T.pack (show pct)
-                        <> " is not a usable positive number — the writer divides the"
-                        <> " allocation-scaled amounts back out, so 0 (or non-finite)"
-                        <> " would lose them on re-import."
+                        <> " is not finite — the writer divides the allocation-scaled"
+                        <> " amounts back out, so a non-finite percentage would lose"
+                        <> " them on re-import."
     checkUnits =
         case unitOffenders of
             [] -> Right ()
@@ -273,7 +273,7 @@ checkSimaProExportable db =
         [ (activityName act, pct)
         | act <- M.elems (sdbActivities db)
         , let pct = fromMaybe 100 (activityAllocationPercent act)
-        , isNaN pct || isInfinite pct || pct == 0
+        , isNaN pct || isInfinite pct
         ]
     unitOffenders =
         [ (activityName act, exchangeUnitId ex)
@@ -647,11 +647,14 @@ serializeActivity cats act@Activity{..} =
         -- back out so the re-import lands on the stored amounts again (emitting
         -- them as-is would let the parser scale a second time). The reference
         -- product is never scaled, so it passes through untouched.
-        -- 'checkSimaProExportable' rejects a zero/non-finite allocation, so the
-        -- division is finite for any export-validated database.
+        -- A 0% allocation is the degenerate case: the parser scaled every shared
+        -- amount to 0, so there is nothing to divide back out — emit the stored
+        -- zeros as-is and the re-import scales 0 by 0 again. 'checkSimaProExportable'
+        -- still rejects a non-finite allocation, so the division below is finite.
         allocFraction = fromMaybe 100 activityAllocationPercent / 100
         unscale ex
             | exchangeIsReference ex = ex
+            | allocFraction == 0 = ex
             | otherwise = scaleExchangeAmount (1 / allocFraction) ex
         unscaledExchanges = map unscale exchanges
 

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -75,6 +75,7 @@ module SimaPro.Writer (
 ) where
 
 import qualified Data.ByteString as BS
+import Data.Either (lefts)
 import Data.List (sortOn)
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, isJust, mapMaybe)
@@ -147,14 +148,18 @@ Both are rejected here rather than emitted as a row the parser misreads.
 -}
 checkSimaProExportable :: SimpleDatabase -> Either Text ()
 checkSimaProExportable db =
-    checkReferences
-        *> checkMedia
-        *> checkAmounts
-        *> checkAllocation
-        *> checkUnits
-        *> checkNewlines
-        *> checkComments
-        *> checkMetaKeys
+    case lefts
+        [ checkReferences
+        , checkMedia
+        , checkAmounts
+        , checkAllocation
+        , checkUnits
+        , checkNewlines
+        , checkComments
+        , checkMetaKeys
+        ] of
+        [] -> Right ()
+        violations -> Left (T.intercalate "\n\n" violations)
   where
     checkReferences =
         case referenceOffenders of

--- a/test/AmountSpec.hs
+++ b/test/AmountSpec.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module AmountSpec (spec) where
+
+import Amount (readAmount)
+import qualified Data.Text as T
+import EcoSpold.Common (showFFloatTrim)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Amount.readAmount" $ do
+    describe "correct rounding (the inverse of showFFloatTrim)" $ do
+        it "recovers a value Data.Text.Read.double rounds off by a ULP" $
+            -- 0.0000010897906999999999 is 1.0897906999999999e-6 exactly; the old
+            -- reader parsed it to 1.0897907e-6, a different Double.
+            readAmount "0.0000010897906999999999" `shouldBe` Just 1.0897906999999999e-6
+
+        it "round-trips every finite magnitude through showFFloatTrim, subnormals included" $
+            mapM_
+                roundTrips
+                [ 1.0897906999999999e-6
+                , 3.3e-20
+                , 5.0e-324 -- smallest positive subnormal
+                , 4.9e-324
+                , 1.0e308
+                , 123456.789
+                , -2.5
+                , 0
+                ]
+
+    describe "grammar (a superset of Data.Text.Read.double)" $ do
+        it "accepts a bare leading or trailing decimal point and a leading plus" $ do
+            readAmount ".5" `shouldBe` Just 0.5
+            readAmount "1." `shouldBe` Just 1.0
+            readAmount "+1.5" `shouldBe` Just 1.5
+            readAmount "-.5" `shouldBe` Just (-0.5)
+        it "accepts surrounding whitespace and scientific notation" $ do
+            readAmount " 7.0 " `shouldBe` Just 7.0
+            readAmount "1.5E-6" `shouldBe` Just 1.5e-6
+
+    describe "rejection (surfaced rather than silently mis-parsed)" $ do
+        it "rejects the non-finite literals" $ do
+            readAmount "Infinity" `shouldBe` Nothing
+            readAmount "NaN" `shouldBe` Nothing
+        it "rejects an overflowing literal rather than admitting Infinity" $
+            readAmount "1e400" `shouldBe` Nothing
+        it "rejects trailing garbage and non-numbers" $ do
+            readAmount "1.5abc" `shouldBe` Nothing
+            readAmount "2*3" `shouldBe` Nothing
+            readAmount "" `shouldBe` Nothing
+  where
+    roundTrips x = readAmount (T.pack (showFFloatTrim x)) `shouldBe` Just x

--- a/test/BrightwayExcelWriterSpec.hs
+++ b/test/BrightwayExcelWriterSpec.hs
@@ -35,7 +35,7 @@ import BrightwayExcel.Writer (
     renderWorkbook,
  )
 import qualified Data.ByteString.Lazy as BL
-import Data.Either (isLeft)
+import Data.Either (isLeft, isRight)
 import Data.List (find, sortOn)
 import qualified Data.Map.Strict as M
 import Data.Maybe (listToMaybe)
@@ -204,10 +204,11 @@ spec = describe "BrightwayExcel.Writer" $ do
             -- A non-finite amount has no numeric-cell form that re-parses; the
             -- guard rejects the database instead of emitting a misleading value.
             checkBrightwayExportable nonFiniteDb `shouldSatisfy` isLeft
-        it "rejects a subnormal amount that fixed-point cannot round-trip" $
-            -- 5e-324 (smallest positive subnormal) collapses to 0 through
-            -- fixed-point, an undetectable shift; reject it at the boundary.
-            checkBrightwayExportable subnormalDb `shouldSatisfy` isLeft
+        it "accepts a subnormal amount, which round-trips through the correctly-rounded reader" $
+            -- 5e-324 (smallest positive subnormal) re-parses exactly through
+            -- Amount.readAmount (Data.Text.Read.double used to lose it to 0), so it
+            -- is faithfully representable; the guard must not reject it.
+            checkBrightwayExportable subnormalDb `shouldSatisfy` isRight
 
     describe "ReferenceInput regression" $
         it "rejects a reference input rather than round-tripping it to a duplicated row" $ do

--- a/test/BrightwayExcelWriterSpec.hs
+++ b/test/BrightwayExcelWriterSpec.hs
@@ -30,9 +30,11 @@ import BrightwayExcel.Writer (
     WriterConfig (..),
     activityRows,
     checkBrightwayExportable,
+    defaultWriterConfig,
     formatAmount,
     renderCategories,
     renderWorkbook,
+    wasteManifest,
  )
 import qualified Data.ByteString.Lazy as BL
 import Data.Either (isLeft, isRight)
@@ -196,10 +198,13 @@ spec = describe "BrightwayExcel.Writer" $ do
                         other -> expectationFailure ("expected one activity, got " <> show (length other))
 
     describe "export guard" $ do
-        it "rejects a waste exchange (Brightway has no waste type)" $
-            -- Per the export boundary: emitting a WasteExchange would re-parse as a
-            -- positive technosphere input, inverting an output waste. Reject loudly.
-            checkBrightwayExportable wasteDb `shouldSatisfy` isLeft
+        it "best-efforts a waste exchange as technosphere instead of rejecting it" $ do
+            -- Brightway has no waste type; the writer rewrites a waste exchange as a
+            -- technosphere flow (inventory-preserving — the matrix treats them the
+            -- same) and records it in the manifest, rather than refusing the export.
+            checkBrightwayExportable wasteDb `shouldBe` Right ()
+            wasteManifest wasteDb `shouldSatisfy` (not . null)
+            renderWorkbook defaultWriterConfig wasteDb `shouldSatisfy` isRight
         it "rejects a non-finite amount" $
             -- A non-finite amount has no numeric-cell form that re-parses; the
             -- guard rejects the database instead of emitting a misleading value.
@@ -628,8 +633,9 @@ refUnitAmount (acts, _tech, _bio, _waste, unitDB) = do
 -- Export-guard fixtures (rejected at the boundary)
 -- ---------------------------------------------------------------------------
 
-{- | A database whose activity carries a waste exchange (B4): rejected, since
-Brightway has no native waste type and would invert it on re-parse.
+{- | A database whose activity carries a waste exchange (B4): Brightway has no
+native waste type, so the writer best-efforts it as a technosphere flow and
+records it in 'wasteManifest'.
 -}
 wasteDb :: SimpleDatabase
 wasteDb =

--- a/test/BrightwayExcelWriterSpec.hs
+++ b/test/BrightwayExcelWriterSpec.hs
@@ -198,13 +198,20 @@ spec = describe "BrightwayExcel.Writer" $ do
                         other -> expectationFailure ("expected one activity, got " <> show (length other))
 
     describe "export guard" $ do
-        it "best-efforts a waste exchange as technosphere instead of rejecting it" $ do
-            -- Brightway has no waste type; the writer rewrites a waste exchange as a
-            -- technosphere flow (inventory-preserving — the matrix treats them the
-            -- same) and records it in the manifest, rather than refusing the export.
+        it "best-efforts an orphan waste exchange as technosphere instead of rejecting it" $ do
+            -- Brightway has no waste type. An orphan waste exchange (no producer link)
+            -- never enters the matrix, so the writer rewrites it as a technosphere flow
+            -- (inventory-neutral) and records it in the manifest, rather than refusing.
             checkBrightwayExportable wasteDb `shouldBe` Right ()
             wasteManifest wasteDb `shouldSatisfy` (not . null)
             renderWorkbook defaultWriterConfig wasteDb `shouldSatisfy` isRight
+        it "rejects a linked waste exchange, which would invert its sign on re-import" $ do
+            -- A waste exchange that resolves to a producer contributes a negative
+            -- coefficient to the matrix; written as technosphere it re-imports as a
+            -- positive Input, inverting the inventory. The guard must reject it, and
+            -- it is not best-efforted (so it never appears in the manifest).
+            checkBrightwayExportable linkedWasteDb `shouldSatisfy` isLeft
+            wasteManifest linkedWasteDb `shouldBe` []
         it "rejects a non-finite amount" $
             -- A non-finite amount has no numeric-cell form that re-parses; the
             -- guard rejects the database instead of emitting a misleading value.
@@ -633,9 +640,10 @@ refUnitAmount (acts, _tech, _bio, _waste, unitDB) = do
 -- Export-guard fixtures (rejected at the boundary)
 -- ---------------------------------------------------------------------------
 
-{- | A database whose activity carries a waste exchange (B4): Brightway has no
-native waste type, so the writer best-efforts it as a technosphere flow and
-records it in 'wasteManifest'.
+{- | A database whose activity carries an /orphan/ waste exchange (B4): no
+producer link, so it never enters the matrix. Brightway has no native waste type,
+so the writer best-efforts it as a technosphere flow and records it in
+'wasteManifest'.
 -}
 wasteDb :: SimpleDatabase
 wasteDb =
@@ -670,6 +678,19 @@ scrapExch =
         , waComment = Nothing
         , waPedigree = Nothing
         }
+
+{- | 'wasteDb' but the waste exchange links to a producer (a non-nil activity
+link), so it would contribute a signed coefficient to the matrix. Brightway
+cannot encode that without inverting the sign on re-import, so the guard rejects
+it rather than best-efforting it.
+-}
+linkedWasteDb :: SimpleDatabase
+linkedWasteDb =
+    wasteDb
+        { sdbActivities = M.singleton (generateActivityUUID act, getReferenceProductUUID act) act
+        }
+  where
+    act = elec{exchanges = [prodExch, scrapExch{waActivityLinkId = generateActivityUUID elec}]}
 
 {- | A database whose input exchange carries a non-finite amount: rejected, since
 it has no numeric-cell form that re-parses to the same value.

--- a/test/EcoSpold1WriterSpec.hs
+++ b/test/EcoSpold1WriterSpec.hs
@@ -16,7 +16,7 @@
 module EcoSpold1WriterSpec (spec) where
 
 import qualified Data.ByteString.Char8 as BC
-import Data.Either (isLeft)
+import Data.Either (isLeft, isRight)
 import Data.List (sort)
 import qualified Data.Map.Strict as M
 import Data.Maybe (mapMaybe)
@@ -512,17 +512,17 @@ spec = do
                     concatMap (exchangeViews sdb') (M.elems (sdbActivities sdb'))
                         `shouldSatisfy` any ((== 3.3e-20) . evAmount)
 
-    describe "non-round-tripping amounts" $
-        it "rejects a subnormal amount that re-parses to zero rather than undercounting" $ do
-            -- 5e-324 is finite but its fixed-point form carries too few
-            -- significant digits for Data.Text.Read.double to recover, so it
-            -- would silently export as 0; the guard rejects it instead.
+    describe "subnormal amounts" $
+        it "accepts a subnormal amount, which round-trips through the correctly-rounded reader" $ do
+            -- 5e-324 is finite and re-parses exactly through Amount.readAmount
+            -- (Data.Text.Read.double used to lose it to 0), so it is faithfully
+            -- representable and the guard must not reject it.
             let prodU = read "aaaa0000-0000-4000-8000-000000000001" :: UUID
                 bioU = read "aaaa0000-0000-4000-8000-0000000000c0" :: UUID
                 bioEx = BiosphereExchange bioU 5e-324 kgUnit Emission "" Nothing Nothing
                 bios = M.singleton bioU (BiosphereFlow bioU "trace" kgUnit M.empty Nothing Nothing Nothing)
                 sdb = soloDb "subnormal emitter" prodU [bioEx] M.empty bios M.empty
-            checkEcoSpold1Exportable sdb `shouldSatisfy` isLeft
+            checkEcoSpold1Exportable sdb `shouldSatisfy` isRight
 
     describe "waste-marker collision" $
         it "rejects a biosphere flow whose compartment is the waste-routing category" $ do

--- a/test/EcoSpold1WriterSpec.hs
+++ b/test/EcoSpold1WriterSpec.hs
@@ -27,7 +27,6 @@ import qualified Data.UUID as UUID
 import Test.Hspec
 
 import qualified Database as DB
-import Database.Loader (generateActivityUUIDFromActivity)
 import EcoSpold.Parser1 (parseAllWithXeno)
 import EcoSpold.Writer1
 import qualified Matrix
@@ -146,10 +145,10 @@ emptyDb :: SimpleDatabase
 emptyDb = SimpleDatabase M.empty M.empty M.empty M.empty M.empty
 
 {- | Two activities where the consumer's technosphere input is a resolved link
-to the supplier. The link UUID is the loader's content hash of the supplier's
-@(name, location)@, which is exactly the key 'checkEcoSpold1Exportable' /
-'supplierNumberIndex' resolve to a dataset number. Passing a UUID absent from
-the database instead models a dangling supplier link.
+to the supplier. The link UUID is the supplier's stored activity UUID
+('supplierLink' — the first component of its 'sdbActivities' key), which
+'checkEcoSpold1Exportable' / 'supplierNumberIndex' resolve to a dataset number.
+Passing a UUID absent from the database instead models a dangling supplier link.
 -}
 linkedDb :: UUID -> SimpleDatabase
 linkedDb link =
@@ -165,7 +164,7 @@ linkedDb link =
         , sdbUnits = units1
         }
   where
-    supU = read "22222222-0000-4000-8000-000000000001"
+    supU = supplierLink
     conU = read "33333333-0000-4000-8000-000000000001"
     mkAct nm prodU exs = Activity nm [] M.empty M.empty "GLO" "kg" (refOf prodU : exs) M.empty M.empty Nothing Nothing Nothing
     refOf prodU = TechnosphereExchange prodU 1.0 kgUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing
@@ -173,11 +172,14 @@ linkedDb link =
     -- The consumer's input consumes the supplier's product and links to it.
     consumer = mkAct "bbb consumer" conU [TechnosphereExchange supU 2.0 kgUnit Input link Nothing "" Nothing Nothing]
 
--- | The supplier's resolved activity UUID, the value a consumer's input links to.
+{- | The supplier's stored activity UUID — the first component of its
+'sdbActivities' key, and the value a solver-resolved input carries in
+'techActivityLinkId'. Deliberately a literal in a different namespace from
+'generateActivityUUIDFromActivity' (mirroring a non-EcoSpold1-origin database),
+so the export must resolve the link by this stored UUID, not by re-deriving one.
+-}
 supplierLink :: UUID
-supplierLink =
-    generateActivityUUIDFromActivity
-        (Activity "aaa supplier" [] M.empty M.empty "GLO" "kg" [] M.empty M.empty Nothing Nothing Nothing)
+supplierLink = read "22222222-0000-4000-8000-000000000001"
 
 {- | A non-nil UUID that no exported activity hashes to, so a consumer input
 carrying it has no resolvable dataset number — a dangling link. Distinct from
@@ -418,7 +420,9 @@ spec = do
     describe "supplier links (multi-dataset)" $ do
         it "re-emits a resolved supplier link as the supplier's dataset number" $
             -- "aaa supplier" sorts first → dataset 1; the consumer's input links
-            -- to it, so the parser reads its number attribute back as 1.
+            -- to its stored UUID (which differs from generateActivityUUIDFromActivity),
+            -- so the index must key on the stored UUID for the parser to read its
+            -- number attribute back as 1.
             roundTripSupplierLinks (linkedDb supplierLink) `shouldBe` Right [1]
 
         it "passes the export-boundary check when the link targets an exported dataset" $

--- a/test/EcoSpold2WriterSpec.hs
+++ b/test/EcoSpold2WriterSpec.hs
@@ -27,7 +27,7 @@ module EcoSpold2WriterSpec (spec) where
 
 import Control.Monad (forM_)
 import qualified Data.ByteString as BS
-import Data.Either (isLeft)
+import Data.Either (isLeft, isRight)
 import Data.List (sort, sortOn)
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe)
@@ -430,12 +430,13 @@ spec = describe "EcoSpold2 writer round-trip" $ do
                 (fixtureWithExchange (BiosphereExchange land 1.0 unitKg Emission "" Nothing Nothing))
                 `shouldSatisfy` isLeft
 
-        it "rejects a subnormal amount that re-parses to zero rather than undercounting" $
-            -- 5e-324's fixed-point form carries too few significant digits for
-            -- Data.Text.Read.double to recover; it would silently export as 0.
+        it "accepts a subnormal amount, which round-trips through the correctly-rounded reader" $
+            -- 5e-324's fixed-point form re-parses exactly through Amount.readAmount
+            -- (Data.Text.Read.double used to lose it to 0), so it is faithfully
+            -- representable and the guard must not reject it.
             checkEcoSpold2Exportable
                 (fixtureWithExchange (BiosphereExchange co2 5e-324 unitKg Emission "" Nothing Nothing))
-                `shouldSatisfy` isLeft
+                `shouldSatisfy` isRight
 
     -- (b) Semantic round-trip: parse(write(D)) ≅ D, order-insensitive.
     describe "semantic round-trip (structural equality)" $ do

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -30,7 +30,7 @@ spec = describe "Database.Export dispatcher" $ do
         forM_ [SimaProCSV, EcoSpold1, EcoSpold2, ILCDProcess, BrightwayExcel] $ \fmt ->
             case serializeDatabase fmt db of
                 Left err -> expectationFailure (show fmt <> ": " <> T.unpack err)
-                Right bytes -> BL.null bytes `shouldBe` False
+                Right (bytes, _warnings) -> BL.null bytes `shouldBe` False
 
     it "fails loudly for formats with no writer (never a silent empty file)" $ do
         db <- buildFixture (Compartment "air" (Just "unspecified"))

--- a/test/ILCDWriterSpec.hs
+++ b/test/ILCDWriterSpec.hs
@@ -376,6 +376,15 @@ spec = describe "ILCD.Writer round-trip" $ do
         it "accepts a canonical biosphere medium" $
             checkILCDExportable (bioMediumDb "air") `shouldBe` Right ()
 
+        it "accepts and canonicalises the SimaPro \"resource\" medium to \"natural resource\"" $ do
+            -- SimaPro labels natural-resource flows "resource"; the writer maps it
+            -- to ILCD's "natural resource", which the parser reads back — so the
+            -- flow is representable rather than rejected.
+            checkILCDExportable (bioMediumDb "resource") `shouldBe` Right ()
+            db' <- roundTrip (bioMediumDb "resource")
+            map (fmap compartmentName . bfCompartment) (M.elems (sdbBioFlows db'))
+                `shouldBe` [Just "natural resource"]
+
         it "preserves the no-reference state on a reference-less activity" $ do
             checkILCDExportable noRefDb `shouldBe` Right ()
             db' <- roundTrip noRefDb
@@ -542,8 +551,9 @@ richDb =
         ]
 
 {- | One activity with a single biosphere emission under the given medium.
-A non-canonical medium ("fresh water", "resource", …) is what
-'checkILCDExportable' must reject; a canonical one passes.
+A non-canonical medium ("fresh water", …) is what 'checkILCDExportable' must
+reject; a canonical one — or an alias the writer canonicalises, like
+"resource" → "natural resource" — passes.
 -}
 bioMediumDb :: Text -> SimpleDatabase
 bioMediumDb medium =

--- a/test/ILCDWriterSpec.hs
+++ b/test/ILCDWriterSpec.hs
@@ -25,7 +25,7 @@ module ILCDWriterSpec (spec) where
 
 import Codec.Archive.Zip (ZipOption (OptDestination), extractFilesFromArchive, toArchive)
 import qualified Data.ByteString.Lazy as BL
-import Data.Either (isLeft)
+import Data.Either (isLeft, isRight)
 import Data.List (isPrefixOf, sort)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
@@ -395,10 +395,11 @@ spec = describe "ILCD.Writer round-trip" $ do
             checkILCDExportable (nonFiniteDb (1 / 0)) `shouldSatisfy` isLeft
             checkILCDExportable (nonFiniteDb (0 / 0)) `shouldSatisfy` isLeft
 
-        it "rejects a subnormal amount that fixed-point cannot round-trip" $
-            -- 5e-324 (smallest positive subnormal) re-parses to 0 through
-            -- fixed-point, an undetectable LCIA shift; reject it at the boundary.
-            checkILCDExportable (nonFiniteDb 5.0e-324) `shouldSatisfy` isLeft
+        it "accepts a subnormal amount, which round-trips through the correctly-rounded reader" $
+            -- 5e-324 (smallest positive subnormal) re-parses exactly through
+            -- Amount.readAmount (Data.Text.Read.double used to lose it to 0), so it
+            -- is faithfully representable; the guard must not reject it.
+            checkILCDExportable (nonFiniteDb 5.0e-324) `shouldSatisfy` isRight
 
 isPrefixOfFp :: String -> FilePath -> Bool
 isPrefixOfFp = isPrefixOf

--- a/test/ILCDWriterSpec.hs
+++ b/test/ILCDWriterSpec.hs
@@ -385,6 +385,19 @@ spec = describe "ILCD.Writer round-trip" $ do
             map (fmap compartmentName . bfCompartment) (M.elems (sdbBioFlows db'))
                 `shouldBe` [Just "natural resource"]
 
+        it "reports every violation category in one message, not just the first" $ do
+            -- A flow with both a non-canonical medium and a non-finite amount trips
+            -- two independent checks; the collected report must carry both.
+            let db =
+                    oneActivityDb
+                        (M.singleton fEmitU (fEmission{bfCompartment = Just (Compartment "fresh water" Nothing)}))
+                        [BiosphereExchange fEmitU (1 / 0) fUnitU Emission "" Nothing Nothing, refProductEx]
+            case checkILCDExportable db of
+                Left msg -> do
+                    msg `shouldSatisfy` T.isInfixOf "fresh water"
+                    msg `shouldSatisfy` T.isInfixOf "non-finite"
+                Right () -> expectationFailure "expected violations"
+
         it "preserves the no-reference state on a reference-less activity" $ do
             checkILCDExportable noRefDb `shouldBe` Right ()
             db' <- roundTrip noRefDb

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -25,7 +25,7 @@ Three properties are pinned:
 module SimaProWriterSpec (spec) where
 
 import qualified Data.ByteString as BS
-import Data.Either (isLeft)
+import Data.Either (isLeft, isRight)
 import Data.List (sort)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
@@ -448,6 +448,13 @@ spec = describe "SimaPro.Writer round-trip" $ do
                 activityAllocationPercent a `shouldBe` Just 50
             other -> expectationFailure ("expected one activity, got " <> show (length other))
 
+    it "(regression) serializes a 0%-allocated activity without a divide-by-zero" $ do
+        -- The parser scaled the 0%-allocated co-product's shared amounts to 0; the
+        -- writer emits those zeros as-is rather than dividing by zero, so nothing
+        -- non-finite leaks into the file.
+        bytes <- serBytes zeroAllocationDb
+        ("NaN" `BS.isInfixOf` bytes || "Infinity" `BS.isInfixOf` bytes) `shouldBe` False
+
     it "(regression) round-trips a Final waste flows section" $ do
         original <- parseBytes wasteCSV
         f0 <- serBytes (toSimple original)
@@ -523,10 +530,17 @@ spec = describe "SimaPro.Writer round-trip" $ do
             checkSimaProExportable (guardDb Nothing Nothing [refProd, bioInf])
                 `shouldSatisfy` isLeft
 
-        it "rejects a zero allocation percentage" $
-            -- The writer divides shared amounts by allocFraction; a 0 would make
-            -- that division non-finite and lose the amounts on re-import.
+        it "accepts a zero allocation percentage" $
+            -- A 0% co-product carries 0% of the shared burden; the parser already
+            -- scaled its shared amounts to 0, so the writer emits those zeros as-is
+            -- (no divide-by-zero) and the round-trip is faithful.
             checkSimaProExportable (guardDb (Just 0) Nothing [refProd])
+                `shouldSatisfy` isRight
+
+        it "rejects a non-finite allocation percentage" $
+            -- A non-finite percentage cannot be written as a number and would
+            -- corrupt the divide-back-out, so it is rejected.
+            checkSimaProExportable (guardDb (Just (1 / 0)) Nothing [refProd])
                 `shouldSatisfy` isLeft
 
         it "rejects an exchange whose unit is absent from the registry" $
@@ -624,6 +638,46 @@ allocationDb =
             M.empty
             M.empty
             (Just 50)
+            Nothing
+            Nothing
+
+{- | A 0%-allocated activity: its shared material input is stored at 0 (the parser
+scaled every shared amount by allocFraction = 0 on import). A correct writer emits
+that 0 as-is — no divide-by-zero — so the re-import scales 0 by 0 back to 0.
+-}
+zeroAllocationDb :: SimpleDatabase
+zeroAllocationDb =
+    SimpleDatabase
+        { sdbActivities = M.singleton (actU, prodU) act
+        , sdbTechFlows =
+            M.fromList
+                [ (prodU, TechnosphereFlow prodU "main product" unitU M.empty Nothing Nothing)
+                , (matU, TechnosphereFlow matU "some material" unitU M.empty Nothing Nothing)
+                ]
+        , sdbBioFlows = M.empty
+        , sdbWasteFlows = M.empty
+        , sdbUnits = M.singleton unitU (Unit unitU "kg" "kg" "")
+        }
+  where
+    actU, prodU, matU, unitU :: UUID
+    actU = testUUID 0x21
+    prodU = testUUID 0xb2
+    matU = testUUID 0xb3
+    unitU = testUUID 0x02
+    act =
+        Activity
+            "zero alloc maker"
+            []
+            M.empty
+            M.empty
+            "GLO"
+            "kg"
+            [ TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+            , TechnosphereExchange matU 0.0 unitU Input UUID.nil Nothing "" Nothing Nothing
+            ]
+            M.empty
+            M.empty
+            (Just 0)
             Nothing
             Nothing
 

--- a/volca.cabal
+++ b/volca.cabal
@@ -33,6 +33,7 @@ library
                      , Data.Validation
                      , Progress
                      , UnitConversion
+                     , Amount
                      , Config
                      , ConfigWriter
                      , Service
@@ -205,6 +206,7 @@ test-suite lca-tests
   main-is:             Spec.hs
   other-modules:       TestHelpers
                      , GoldenData
+                     , AmountSpec
                      , AutoRelinkSpec
                      , RelinkMappingSpec
                      , MatrixConstructionSpec

--- a/volca.cabal
+++ b/volca.cabal
@@ -131,6 +131,7 @@ library
                      , aeson
                      , aeson-pretty
                      , scientific
+                     , attoparsec
                      , wai
                      , wai-cors
                      , wai-app-static


### PR DESCRIPTION
A loaded database — a SimaPro-sourced one in particular — failed to export, or silently corrupted data, across all five writers. This fixes the root causes so the strict round-trip contract holds, and adds a best-effort path for the one case a format genuinely cannot represent faithfully.

## Fixes
- **Correct amount rounding.** `Data.Text.Read.double` is not correctly rounded — it parses `0.0000010897906999999999` to a *different* `Double`. On import that silently corrupts amounts; in the export round-trip guards it rejects values the format can represent. A new `Amount.readAmount` tokenises with attoparsec's `scientific` (an exact `Scientific`) and converts via `fromRational . toRational` — correctly rounded, fast, and avoiding `toRealFloat` whose underflow handling can drop a subnormal to `0`. It is used on every amount-import path and in all four guards, so a guard mirrors its importer by construction. Every finite `Double` round-trips, subnormals included.
- **EcoSpold1 supplier links.** The supplier index re-derived each supplier's UUID in the EcoSpold1 namespace, so a database that minted UUIDs in another namespace (e.g. SimaPro CSV) had every internal supplier link wrongly rejected as dangling. Key the index on the stored activity UUID the solver already resolves against.
- **ILCD "resource" compartment.** Canonicalise the `resource` medium to `natural resource`, which the parser reads back.
- **SimaPro 0% allocation.** A 0%-allocated activity made the writer divide by zero; its shared amounts are already 0, so emit them as-is.

## UX
- **Report all un-representable records**, not just the first, so one export attempt surfaces everything blocking a format.
- **Brightway waste, best-effort — orphan only.** Brightway has no waste type. An *orphan* waste output (no producer link) never enters the technosphere matrix, so it is written as a technosphere flow — inventory-neutral — and reported via the export response's new `warnings` field. A *linked* waste exchange is different: the matrix gives a waste output a negative coefficient, but a re-parsed technosphere row is a positive input, so writing it would silently invert its sign. Linked waste is therefore rejected like the other un-representable cases, never best-efforted.

All fixes are covered by tests; the suite is green (1334 examples, 0 failures).