### PR TITLE
feat(api): stream uploads as octet-stream instead of base64-in-JSON

### DIFF
--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -45,12 +46,13 @@ module API.DatabaseHandlers (
     convertDbStatus,
     simpleAction,
     formatToText,
-    checkUploadSize,
+    uploadSizeCap,
     uploadBodyCeiling,
+    streamToTempFile,
 ) where
 
 import Control.Exception (SomeException, try)
-import Control.Monad (mfilter)
+import Control.Monad (mfilter, void)
 import Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64 as B64
@@ -62,9 +64,11 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as T
 import Data.Word (Word64)
-import Servant (Header, Headers, ServerError, addHeader, err400, err404, err500, errBody, throwError)
+import Servant (Header, Headers, ServerError, SourceIO, addHeader, err400, err404, err500, errBody, throwError)
+import qualified Servant.Types.SourceT as S
 import qualified System.Directory
 import System.FilePath ((</>))
+import System.IO (hClose, openBinaryTempFile)
 
 -- Flow synonyms
 
@@ -88,7 +92,7 @@ import API.Types (
     RelinkRequest (..),
     RelinkResponse (..),
     SynonymGroupsResponse (..),
-    UploadRequest (..),
+    UploadChunk (..),
     UploadResponse (..),
  )
 import App.Env (AppEnv (..), AppM)
@@ -293,37 +297,31 @@ exportDatabaseHandler dbName req = do
     httpErr :: ServerError -> Text -> AppM a
     httpErr status msg = throwError status{errBody = BSL.fromStrict (T.encodeUtf8 msg)}
 
-{- | Enforce the hosting upload-size policy on a decoded payload.
+{- | Resolve the hosting upload-size policy into a streaming byte cap.
 Local/CLI mode (no hosting config) is unlimited. A configured limit of 0
 disables uploads; a negative limit is unlimited; a positive limit caps the
-size in megabytes. Returns the failure message to surface, or () to proceed.
+size in megabytes. 'Left' rejects the upload outright (disabled plan); 'Right
+Nothing' means no cap; 'Right (Just n)' caps the streamed body at n bytes.
 -}
-checkUploadSize :: Maybe HostingConfig -> Int -> Either Text ()
-checkUploadSize Nothing _ = Right ()
-checkUploadSize (Just hc) sizeBytes =
+uploadSizeCap :: Maybe HostingConfig -> Either Text (Maybe Int)
+uploadSizeCap Nothing = Right Nothing
+uploadSizeCap (Just hc) =
     case hcMaxUploadMb hc of
         0 -> Left "Uploads are disabled on this plan."
         limitMb
-            | limitMb < 0 -> Right ()
-            | sizeBytes > limitMb * 1024 * 1024 ->
-                Left $
-                    "File too large ("
-                        <> T.pack (show (sizeBytes `div` (1024 * 1024)))
-                        <> " MB). The upload limit on this plan is "
-                        <> T.pack (show limitMb)
-                        <> " MB."
-            | otherwise -> Right ()
+            | limitMb < 0 -> Right Nothing
+            | otherwise -> Right (Just (limitMb * 1024 * 1024))
 
 {- | The WAI-level request-body ceiling (in bytes) for a request path, or
-'Nothing' for no limit. This is the outer, pre-buffering backstop for
-'checkUploadSize': only the database and method upload routes are bounded, and
-only when the hosting config sets a positive cap. base64 inflates the payload by
-~4/3 and the JSON envelope adds a little more, so we admit 2x the policy limit at
-the HTTP layer — files between the real limit and that ceiling still reach the
-handler, which returns the precise 'checkUploadSize' error. Unlimited (-1),
-disabled (0), and local/CLI (no config) are left unbounded here: neither
-unlimited nor disabled is a size bound, and the handler still rejects disabled
-uploads.
+'Nothing' for no limit. This is the outer, hard backstop for the in-handler
+streaming size check ('withStreamedUpload'): only the database and method upload
+routes are bounded, and only when the hosting config sets a positive cap. The
+body is now a raw octet-stream (no base64 inflation, no JSON envelope), so we
+admit the policy limit plus 1 MiB of slack — files between the real limit and
+that ceiling still reach the handler, which streams and returns the precise
+rejection. Unlimited (-1), disabled (0), and local/CLI (no config) are left
+unbounded here: neither unlimited nor disabled is a size bound, and the handler
+still rejects disabled uploads.
 -}
 uploadBodyCeiling :: Maybe HostingConfig -> [Text] -> Maybe Word64
 uploadBodyCeiling hostingConfig path
@@ -331,7 +329,7 @@ uploadBodyCeiling hostingConfig path
     | otherwise = case hostingConfig of
         Nothing -> Nothing
         Just hc
-            | hcMaxUploadMb hc > 0 -> Just (fromIntegral (hcMaxUploadMb hc) * 2 * 1024 * 1024)
+            | hcMaxUploadMb hc > 0 -> Just ((fromIntegral (hcMaxUploadMb hc) + 1) * 1024 * 1024)
             | otherwise -> Nothing
 
 {- | The upload routes governed by the size policy. These mirror the @db/upload@
@@ -345,30 +343,79 @@ isPolicyUploadPath path =
                , ["api", "v1", "method-collections", "upload"]
                ]
 
-{- | Decode the base64 upload payload and enforce the hosting size policy,
-then hand the raw bytes to the continuation. Shared by the database and
-method upload handlers so both gate on one rule.
+{- | Stream an octet-stream upload body to a temp file, enforcing the hosting
+size policy as the bytes arrive, then hand @(name, description, file bytes)@ to
+the continuation. Shared by the database and method upload handlers so both
+gate on one rule and never buffer the whole payload in memory. The name is
+required (it travels as the @?name=@ query parameter).
 -}
-withUploadBytes :: UploadRequest -> (BS.ByteString -> AppM UploadResponse) -> AppM UploadResponse
-withUploadBytes req k =
-    case B64.decode (T.encodeUtf8 (urFileData req)) of
-        Left err -> return $ UploadResponse False ("Invalid base64 data: " <> T.pack err) Nothing Nothing
-        Right zipBytes -> do
+withStreamedUpload ::
+    Maybe Text ->
+    Maybe Text ->
+    SourceIO UploadChunk ->
+    (Text -> Maybe Text -> BSL.ByteString -> AppM UploadResponse) ->
+    AppM UploadResponse
+withStreamedUpload mName mDesc src k =
+    case mfilter (not . T.null) (T.strip <$> mName) of
+        Nothing -> return (rejectUpload "Missing upload name. Pass it as the ?name= query parameter.")
+        Just name -> do
             hostingConfig <- asks aeHostingConfig
-            case checkUploadSize hostingConfig (BS.length zipBytes) of
-                Left rejection -> return $ UploadResponse False rejection Nothing Nothing
-                Right () -> k zipBytes
+            case uploadSizeCap hostingConfig of
+                Left rejection -> return (rejectUpload rejection)
+                Right mCap -> do
+                    streamed <- liftIO (streamToTempFile mCap src)
+                    case streamed of
+                        Left rejection -> return (rejectUpload rejection)
+                        Right tmpPath -> do
+                            bytes <- liftIO (BSL.readFile tmpPath)
+                            resp <- k name mDesc bytes
+                            liftIO (void (try (System.Directory.removeFile tmpPath) :: IO (Either SomeException ())))
+                            return resp
+  where
+    rejectUpload msg = UploadResponse False msg Nothing Nothing
 
--- | Upload a new database
-uploadDatabaseHandler :: UploadRequest -> AppM UploadResponse
-uploadDatabaseHandler req =
-    withUploadBytes req $ \zipBytes -> do
+{- | Fold a streamed octet-stream body into a fresh temp file, aborting with a
+'Left' rejection if the running byte count exceeds the cap. Returns the temp
+file path on success (the caller deletes it). Bytes are written chunk-by-chunk
+and never held whole in memory.
+-}
+streamToTempFile :: Maybe Int -> SourceIO UploadChunk -> IO (Either Text FilePath)
+streamToTempFile mCap src = do
+    tmpDir <- System.Directory.getTemporaryDirectory
+    (tmpPath, h) <- openBinaryTempFile tmpDir "volca-upload-.bin"
+    result <- try (S.unSourceT src (go h 0)) :: IO (Either SomeException (Either Text ()))
+    hClose h
+    case result of
+        Left e -> removeQuietly tmpPath >> return (Left ("Upload stream error: " <> T.pack (show e)))
+        Right (Left msg) -> removeQuietly tmpPath >> return (Left msg)
+        Right (Right ()) -> return (Right tmpPath)
+  where
+    removeQuietly p = void (try (System.Directory.removeFile p) :: IO (Either SomeException ()))
+    tooLarge cap =
+        "File too large. The upload limit on this plan is "
+            <> T.pack (show (cap `div` (1024 * 1024)))
+            <> " MB."
+    go h !n step = case step of
+        S.Stop -> return (Right ())
+        S.Error e -> return (Left ("Upload stream error: " <> T.pack e))
+        S.Skip s -> go h n s
+        S.Effect ms -> ms >>= go h n
+        S.Yield chunk s ->
+            let !n' = n + BS.length (unUploadChunk chunk)
+             in case mCap of
+                    Just cap | n' > cap -> return (Left (tooLarge cap))
+                    _ -> BS.hPut h (unUploadChunk chunk) >> go h n' s
+
+-- | Upload a new database (streamed octet-stream body; metadata in query params)
+uploadDatabaseHandler :: Maybe Text -> Maybe Text -> SourceIO UploadChunk -> AppM UploadResponse
+uploadDatabaseHandler mName mDesc src =
+    withStreamedUpload mName mDesc src $ \name mDescription zipBytes -> do
         dbManager <- asks aeDbManager
         let uploadData =
                 UploadData
-                    { udName = urName req
-                    , udDescription = urDescription req
-                    , udZipData = BSL.fromStrict zipBytes
+                    { udName = name
+                    , udDescription = mDescription
+                    , udZipData = zipBytes
                     }
         -- Handle the upload (extract, detect format)
         uploadsDir <- liftIO UploadedDB.getDatabaseUploadsDir
@@ -384,8 +431,8 @@ uploadDatabaseHandler req =
                 let meta =
                         UploadedDB.UploadMeta
                             { UploadedDB.umVersion = 1
-                            , UploadedDB.umDisplayName = urName req
-                            , UploadedDB.umDescription = urDescription req
+                            , UploadedDB.umDisplayName = name
+                            , UploadedDB.umDescription = mDescription
                             , UploadedDB.umFormat = urFormat uploadResult -- Types are now unified
                             , UploadedDB.umDataPath = makeRelative uploadDir (urPath uploadResult)
                             }
@@ -395,9 +442,9 @@ uploadDatabaseHandler req =
                 let dbConfig =
                         DatabaseConfig
                             { dcName = urSlug uploadResult
-                            , dcDisplayName = urName req
+                            , dcDisplayName = name
                             , dcPath = urPath uploadResult
-                            , dcDescription = urDescription req
+                            , dcDescription = mDescription
                             , dcLoad = False -- Don't auto-load
                             , dcDefault = False
                             , dcDepends = []
@@ -550,15 +597,15 @@ finalizeDatabaseHandler dbName = do
 {- | Upload a new method collection
 Same flow as database upload but creates MethodConfig entry
 -}
-uploadMethodHandler :: UploadRequest -> AppM UploadResponse
-uploadMethodHandler req =
-    withUploadBytes req $ \zipBytes -> do
+uploadMethodHandler :: Maybe Text -> Maybe Text -> SourceIO UploadChunk -> AppM UploadResponse
+uploadMethodHandler mName mDesc src =
+    withStreamedUpload mName mDesc src $ \name mDescription zipBytes -> do
         dbManager <- asks aeDbManager
         let uploadData =
                 UploadData
-                    { udName = urName req
-                    , udDescription = urDescription req
-                    , udZipData = BSL.fromStrict zipBytes
+                    { udName = name
+                    , udDescription = mDescription
+                    , udZipData = zipBytes
                     }
         uploadsDir <- liftIO UploadedDB.getMethodUploadsDir
         result <- liftIO $ handleUpload uploadsDir uploadData (\_ -> return ())
@@ -575,8 +622,8 @@ uploadMethodHandler req =
                 let meta =
                         UploadedDB.UploadMeta
                             { UploadedDB.umVersion = 1
-                            , UploadedDB.umDisplayName = urName req
-                            , UploadedDB.umDescription = urDescription req
+                            , UploadedDB.umDisplayName = name
+                            , UploadedDB.umDescription = mDescription
                             , UploadedDB.umFormat = urFormat uploadResult
                             , UploadedDB.umDataPath = makeRelative uploadDir methodDir
                             }
@@ -585,11 +632,11 @@ uploadMethodHandler req =
                 -- Create MethodConfig and add to manager
                 let mc =
                         MethodConfig
-                            { mcName = urName req
+                            { mcName = name
                             , mcPath = methodDir
                             , mcActive = False
                             , mcIsUploaded = True
-                            , mcDescription = urDescription req
+                            , mcDescription = mDescription
                             , mcFormat = Just $ formatToText $ urFormat uploadResult
                             , mcScoringSets = []
                             }
@@ -689,42 +736,39 @@ deleteRefData kind name = do
     let (_, _, _, _, removeFn, _) = rdOps kind
     simpleAction (removeFn dbManager name) ("Deleted: " <> name)
 
-uploadRefData :: RefDataKind -> UploadRequest -> AppM UploadResponse
-uploadRefData kind req = do
-    dbManager <- asks aeDbManager
-    let (_, _, _, addFn, _, subdir) = rdOps kind
-    let csvDataResult = B64.decode $ T.encodeUtf8 $ urFileData req
-    case csvDataResult of
-        Left err -> return $ UploadResponse False ("Invalid base64 data: " <> T.pack err) Nothing Nothing
-        Right csvBytes -> do
-            baseDir <- liftIO UploadedDB.getDataDir
-            let slug = T.toLower $ T.intercalate "-" $ T.words $ urName req
-                uploadDir = baseDir </> "uploads" </> T.unpack subdir </> T.unpack slug
-                csvPath = uploadDir </> "data.csv"
-            liftIO $ do
-                System.Directory.createDirectoryIfMissing True uploadDir
-                BSL.writeFile csvPath (BSL.fromStrict csvBytes)
-                let metaContent =
-                        T.intercalate
-                            "\n"
-                            [ "[meta]"
-                            , "version = 1"
-                            , "displayName = " <> quote (urName req)
-                            , maybe "" (\d -> "description = " <> quote d) (urDescription req)
-                            , ""
-                            ]
-                T.writeFile (uploadDir </> "meta.toml") metaContent
-            let rd =
-                    RefDataConfig
-                        { rdName = urName req
-                        , rdPath = csvPath
-                        , rdActive = False
-                        , rdIsUploaded = True
-                        , rdIsAuto = False
-                        , rdDescription = urDescription req
-                        }
-            liftIO $ addFn dbManager rd
-            return $ UploadResponse True "Uploaded successfully" (Just slug) Nothing
+uploadRefData :: RefDataKind -> Maybe Text -> Maybe Text -> SourceIO UploadChunk -> AppM UploadResponse
+uploadRefData kind mName mDesc src =
+    withStreamedUpload mName mDesc src $ \name mDescription csvBytes -> do
+        dbManager <- asks aeDbManager
+        let (_, _, _, addFn, _, subdir) = rdOps kind
+        baseDir <- liftIO UploadedDB.getDataDir
+        let slug = T.toLower $ T.intercalate "-" $ T.words name
+            uploadDir = baseDir </> "uploads" </> T.unpack subdir </> T.unpack slug
+            csvPath = uploadDir </> "data.csv"
+        liftIO $ do
+            System.Directory.createDirectoryIfMissing True uploadDir
+            BSL.writeFile csvPath csvBytes
+            let metaContent =
+                    T.intercalate
+                        "\n"
+                        [ "[meta]"
+                        , "version = 1"
+                        , "displayName = " <> quote name
+                        , maybe "" (\d -> "description = " <> quote d) mDescription
+                        , ""
+                        ]
+            T.writeFile (uploadDir </> "meta.toml") metaContent
+        let rd =
+                RefDataConfig
+                    { rdName = name
+                    , rdPath = csvPath
+                    , rdActive = False
+                    , rdIsUploaded = True
+                    , rdIsAuto = False
+                    , rdDescription = mDescription
+                    }
+        liftIO $ addFn dbManager rd
+        return $ UploadResponse True "Uploaded successfully" (Just slug) Nothing
   where
     quote t = "\"" <> T.replace "\"" "\\\"" t <> "\""
 

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -53,6 +53,7 @@ module API.DatabaseHandlers (
 
 import Control.Exception (SomeException, try)
 import Control.Monad (mfilter, void)
+import Control.Monad.Catch (finally)
 import Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64 as B64
@@ -366,11 +367,12 @@ withStreamedUpload mName mDesc src k =
                     streamed <- liftIO (streamToTempFile mCap src)
                     case streamed of
                         Left rejection -> return (rejectUpload rejection)
-                        Right tmpPath -> do
-                            bytes <- liftIO (BSL.readFile tmpPath)
-                            resp <- k name mDesc bytes
-                            liftIO (void (try (System.Directory.removeFile tmpPath) :: IO (Either SomeException ())))
-                            return resp
+                        Right tmpPath ->
+                            -- The read is lazy, so an uncapped (local/desktop) upload is never
+                            -- buffered whole; 'finally' guarantees the temp file is deleted even
+                            -- if the extract/detect continuation throws.
+                            (liftIO (BSL.readFile tmpPath) >>= k name mDesc)
+                                `finally` liftIO (removeQuietly tmpPath)
   where
     rejectUpload msg = UploadResponse False msg Nothing Nothing
 
@@ -390,7 +392,6 @@ streamToTempFile mCap src = do
         Right (Left msg) -> removeQuietly tmpPath >> return (Left msg)
         Right (Right ()) -> return (Right tmpPath)
   where
-    removeQuietly p = void (try (System.Directory.removeFile p) :: IO (Either SomeException ()))
     tooLarge cap =
         "File too large. The upload limit on this plan is "
             <> T.pack (show (cap `div` (1024 * 1024)))
@@ -405,6 +406,10 @@ streamToTempFile mCap src = do
              in case mCap of
                     Just cap | n' > cap -> return (Left (tooLarge cap))
                     _ -> BS.hPut h (unUploadChunk chunk) >> go h n' s
+
+-- | Delete a file, swallowing any error — best-effort temp-file cleanup.
+removeQuietly :: FilePath -> IO ()
+removeQuietly p = void (try (System.Directory.removeFile p) :: IO (Either SomeException ()))
 
 -- | Upload a new database (streamed octet-stream body; metadata in query params)
 uploadDatabaseHandler :: Maybe Text -> Maybe Text -> SourceIO UploadChunk -> AppM UploadResponse

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -10,7 +10,7 @@ module API.Routes where
 import API.DatabaseHandlers (simpleAction)
 import qualified API.DatabaseHandlers as DBHandlers
 import qualified API.OpenApi
-import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExportRequest (..), ExportResponse (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadRequest (..), UploadResponse (..), apiFlowOfKind)
+import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExportRequest (..), ExportResponse (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadChunk (..), UploadResponse (..), apiFlowOfKind)
 import App.Env (AppEnv (..), AppM, runApp)
 import qualified Config
 import Control.Concurrent.Async (mapConcurrently)
@@ -128,8 +128,8 @@ type LCAAPI =
                 :<|> "db" :> Capture "dbName" Text :> "delete" :> ReqBody '[JSON] DeleteSelectionRequest :> Post '[JSON] DeleteSelectionResponse
                 -- Export a loaded database to a serialized (base64) file in the requested format
                 :<|> "db" :> Capture "dbName" Text :> "export" :> ReqBody '[JSON] ExportRequest :> Post '[JSON] ExportResponse
-                -- Upload endpoint (base64-encoded ZIP in JSON body)
-                :<|> "db" :> "upload" :> ReqBody '[JSON] UploadRequest :> Post '[JSON] UploadResponse
+                -- Upload endpoint (streamed octet-stream body; metadata in query params)
+                :<|> "db" :> "upload" :> QueryParam "name" Text :> QueryParam "description" Text :> StreamBody NoFraming OctetStream (SourceIO UploadChunk) :> Post '[JSON] UploadResponse
                 -- Database setup endpoints (for cross-DB linking configuration)
                 :<|> "db" :> Capture "dbName" Text :> "setup" :> Get '[JSON] DatabaseSetupInfo
                 :<|> "db" :> Capture "dbName" Text :> "add-dependency" :> Capture "depName" Text :> Post '[JSON] DatabaseSetupInfo
@@ -141,25 +141,25 @@ type LCAAPI =
                 :<|> "method-collections" :> Capture "name" Text :> "load" :> Post '[JSON] ActivateResponse
                 :<|> "method-collections" :> Capture "name" Text :> "unload" :> Post '[JSON] ActivateResponse
                 :<|> "method-collections" :> Capture "name" Text :> Delete '[JSON] ActivateResponse
-                :<|> "method-collections" :> "upload" :> ReqBody '[JSON] UploadRequest :> Post '[JSON] UploadResponse
+                :<|> "method-collections" :> "upload" :> QueryParam "name" Text :> QueryParam "description" Text :> StreamBody NoFraming OctetStream (SourceIO UploadChunk) :> Post '[JSON] UploadResponse
                 -- Reference data endpoints (flow synonyms, compartment mappings, units)
                 :<|> "flow-synonyms" :> Get '[JSON] RefDataListResponse
                 :<|> "flow-synonyms" :> Capture "name" Text :> "load" :> Post '[JSON] ActivateResponse
                 :<|> "flow-synonyms" :> Capture "name" Text :> "unload" :> Post '[JSON] ActivateResponse
                 :<|> "flow-synonyms" :> Capture "name" Text :> Delete '[JSON] ActivateResponse
-                :<|> "flow-synonyms" :> "upload" :> ReqBody '[JSON] UploadRequest :> Post '[JSON] UploadResponse
+                :<|> "flow-synonyms" :> "upload" :> QueryParam "name" Text :> QueryParam "description" Text :> StreamBody NoFraming OctetStream (SourceIO UploadChunk) :> Post '[JSON] UploadResponse
                 :<|> "flow-synonyms" :> Capture "name" Text :> "groups" :> Get '[JSON] SynonymGroupsResponse
                 :<|> "flow-synonyms" :> Capture "name" Text :> "download" :> Get '[OctetStream] (Headers '[Header "Content-Disposition" Text] BinaryContent)
                 :<|> "compartment-mappings" :> Get '[JSON] RefDataListResponse
                 :<|> "compartment-mappings" :> Capture "name" Text :> "load" :> Post '[JSON] ActivateResponse
                 :<|> "compartment-mappings" :> Capture "name" Text :> "unload" :> Post '[JSON] ActivateResponse
                 :<|> "compartment-mappings" :> Capture "name" Text :> Delete '[JSON] ActivateResponse
-                :<|> "compartment-mappings" :> "upload" :> ReqBody '[JSON] UploadRequest :> Post '[JSON] UploadResponse
+                :<|> "compartment-mappings" :> "upload" :> QueryParam "name" Text :> QueryParam "description" Text :> StreamBody NoFraming OctetStream (SourceIO UploadChunk) :> Post '[JSON] UploadResponse
                 :<|> "units" :> Get '[JSON] RefDataListResponse
                 :<|> "units" :> Capture "name" Text :> "load" :> Post '[JSON] ActivateResponse
                 :<|> "units" :> Capture "name" Text :> "unload" :> Post '[JSON] ActivateResponse
                 :<|> "units" :> Capture "name" Text :> Delete '[JSON] ActivateResponse
-                :<|> "units" :> "upload" :> ReqBody '[JSON] UploadRequest :> Post '[JSON] UploadResponse
+                :<|> "units" :> "upload" :> QueryParam "name" Text :> QueryParam "description" Text :> StreamBody NoFraming OctetStream (SourceIO UploadChunk) :> Post '[JSON] UploadResponse
                 -- Log endpoint
                 :<|> "logs" :> QueryParam "since" Int :> Get '[JSON] Value
                 -- Auth endpoint (login)

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -13,17 +13,18 @@ import API.JsonOptions (Stripped (..))
 import Control.Lens ((&), (.~), (?~))
 import Data.Aeson
 import Data.Aeson.Types (Parser)
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.HashMap.Strict.InsOrd as InsOrdHashMap
 import qualified Data.Map as M
-import Data.OpenApi (NamedSchema (..), OpenApiType (..), Referenced (..), ToSchema (..), declareSchemaRef, enum_, format, nullable, properties, required, type_)
+import Data.OpenApi (NamedSchema (..), OpenApiType (..), Referenced (..), ToSchema (..), binarySchema, declareSchemaRef, enum_, format, nullable, properties, required, type_)
 import qualified Data.OpenApi.Lens as OA
 import Data.Proxy (Proxy (..))
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import GHC.Generics
-import Servant.API.ContentTypes (MimeRender (..), OctetStream)
+import Servant.API.ContentTypes (MimeRender (..), MimeUnrender (..), OctetStream)
 import Types (BiosphereFlow (..), Compartment, Exchange, FlowKind (..), NativeActivityType (..), Pedigree, TechnosphereFlow (..), UUID, Unit, WasteFlow (..))
 
 {- | Tagged wire representation of either side of the flow split.
@@ -748,15 +749,6 @@ data LoadDatabaseResponse
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped LoadDatabaseResponse)
 
--- | Request for database upload (base64-encoded ZIP)
-data UploadRequest = UploadRequest
-    { urName :: Text -- Display name for the database
-    , urDescription :: Maybe Text -- Optional description
-    , urFileData :: Text -- Base64-encoded ZIP file content
-    }
-    deriving (Generic)
-    deriving (ToJSON, FromJSON, ToSchema) via (Stripped UploadRequest)
-
 {- | One classification filter in a delete request: the @system@ to match, the
 @value@ to look for, and whether the match is exact (else token-contains).
 Mirrors the search endpoint's classification query parameters so the deleted
@@ -1351,3 +1343,17 @@ newtype BinaryContent = BinaryContent BSL.ByteString
 
 instance MimeRender OctetStream BinaryContent where
     mimeRender _ (BinaryContent bs) = bs
+
+{- | One raw chunk of a streamed octet-stream upload request body.
+
+A newtype around strict 'BS.ByteString' for two reasons: openapi3 refuses a
+'ToSchema' for a bare 'ByteString' (we give it a binary schema here), and the
+'StreamBody' decoder needs a 'MimeUnrender' target for the chunk type.
+-}
+newtype UploadChunk = UploadChunk {unUploadChunk :: BS.ByteString}
+
+instance MimeUnrender OctetStream UploadChunk where
+    mimeUnrender _ = Right . UploadChunk . BSL.toStrict
+
+instance ToSchema UploadChunk where
+    declareNamedSchema _ = pure $ NamedSchema (Just "UploadChunk") binarySchema

--- a/src/App/Env.hs
+++ b/src/App/Env.hs
@@ -11,6 +11,7 @@ module App.Env (
 ) where
 
 import qualified Config
+import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
 import Control.Monad.Except (MonadError)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Reader (MonadReader, ReaderT (..))
@@ -27,7 +28,7 @@ data AppEnv = AppEnv
     }
 
 newtype AppM a = AppM {unAppM :: ReaderT AppEnv Handler a}
-    deriving newtype (Functor, Applicative, Monad, MonadIO, MonadReader AppEnv, MonadError ServerError)
+    deriving newtype (Functor, Applicative, Monad, MonadIO, MonadReader AppEnv, MonadError ServerError, MonadThrow, MonadCatch, MonadMask)
 
 runApp :: AppEnv -> AppM a -> Handler a
 runApp env (AppM m) = runReaderT m env

--- a/src/CLI/Client.hs
+++ b/src/CLI/Client.hs
@@ -16,6 +16,7 @@ import Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KM
 import Data.Aeson.Types (Parser, parseMaybe, withArray, withObject)
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.Char8 as C8
 import qualified Data.ByteString.Lazy as BL
@@ -37,11 +38,13 @@ import Network.HTTP.Client (
     parseRequest,
     responseBody,
     responseStatus,
+    setQueryString,
  )
 import Network.HTTP.Types.Status (statusCode)
 import Progress (reportError)
 import System.Environment (lookupEnv)
 import System.Exit (exitFailure)
+import System.IO (IOMode (ReadMode), hFileSize, withBinaryFile)
 
 -- | Configuration for connecting to a remote VoLCA server
 data RemoteConfig = RemoteConfig
@@ -319,16 +322,49 @@ buildQuery params =
 
 -- | Execute an upload command (database or method collection)
 executeUpload :: Manager -> RemoteConfig -> OutputFormat -> Maybe Text -> String -> UploadArgs -> IO ()
-executeUpload mgr rc fmt jp path args = do
-    fileData <- BL.readFile (uaFile args)
-    let encoded = T.decodeLatin1 $ B64.encode (BL.toStrict fileData)
-        body =
-            object
-                [ "urName" .= uaName args
-                , "urDescription" .= uaDescription args
-                , "urFileData" .= encoded
-                ]
-    apiPost mgr rc path body >>= output fmt jp
+executeUpload mgr rc fmt jp path args = apiUploadFile mgr rc path args >>= output fmt jp
+
+{- | Stream a file to an upload endpoint as a raw octet-stream body, carrying the
+display name and optional description as query parameters. The body is streamed
+from disk in constant memory (no base64, no whole-file buffering).
+-}
+apiUploadFile :: Manager -> RemoteConfig -> String -> UploadArgs -> IO (Either String Value)
+apiUploadFile mgr rc path args = do
+    body <- fileRequestBody (uaFile args)
+    let url = rcBaseUrl rc ++ path
+        query =
+            ("name", Just (T.encodeUtf8 (uaName args)))
+                : [("description", Just (T.encodeUtf8 d)) | Just d <- [uaDescription args]]
+    result <- try $ do
+        req0 <- parseRequest url
+        let req1 =
+                setQueryString query $
+                    req0
+                        { Network.HTTP.Client.method = "POST"
+                        , requestHeaders =
+                            authHeaders ++ [("Content-Type", "application/octet-stream")] ++ requestHeaders req0
+                        , requestBody = body
+                        }
+        httpLbs req1 mgr
+    case result of
+        Left e -> return $ Left (formatHttpError (rcBaseUrl rc) e)
+        Right resp ->
+            let status = statusCode (responseStatus resp)
+                respBody = responseBody resp
+             in if status >= 200 && status < 300
+                    then return $ Right $ fromMaybe (object []) (decode respBody)
+                    else return $ Left $ formatApiError status respBody
+  where
+    authHeaders = case rcAuth rc of
+        Just pwd -> [("Authorization", "Bearer " <> C8.pack pwd)]
+        Nothing -> []
+
+-- | Build a constant-memory streaming request body from a file on disk.
+fileRequestBody :: FilePath -> IO RequestBody
+fileRequestBody fp = do
+    size <- withBinaryFile fp ReadMode hFileSize
+    return $ RequestBodyStream (fromIntegral size) $ \needsPopper ->
+        withBinaryFile fp ReadMode $ \h -> needsPopper (BS.hGetSome h 65536)
 
 {- | Output a response whose body carries an in-band @{"success",..,"message"}@
 status (the handlers return HTTP 200 even on failure, so a bare 'output' would

--- a/test/UploadSizeSpec.hs
+++ b/test/UploadSizeSpec.hs
@@ -2,10 +2,14 @@
 
 module UploadSizeSpec (spec) where
 
-import API.DatabaseHandlers (checkUploadSize, uploadBodyCeiling)
+import API.DatabaseHandlers (streamToTempFile, uploadBodyCeiling, uploadSizeCap)
+import API.Types (UploadChunk (..))
 import Config (HostingConfig (..))
+import qualified Data.ByteString as BS
 import Data.Either (isLeft)
 import Data.Word (Word64)
+import qualified Servant.Types.SourceT as S
+import System.Directory (removeFile)
 import Test.Hspec
 
 -- | A hosting config with the given upload-size limit (in MB); other fields are irrelevant here.
@@ -25,22 +29,19 @@ mb n = n * 1024 * 1024
 
 spec :: Spec
 spec = do
-    describe "checkUploadSize" $ do
-        it "allows any size with no hosting config (local / CLI / desktop)" $
-            checkUploadSize Nothing (mb 5000) `shouldBe` Right ()
+    describe "uploadSizeCap" $ do
+        it "is unlimited with no hosting config (local / CLI / desktop)" $
+            uploadSizeCap Nothing `shouldBe` Right Nothing
 
         it "is unlimited when the configured limit is negative" $
-            checkUploadSize (Just (hostingWithLimit (-1))) (mb 5000) `shouldBe` Right ()
+            uploadSizeCap (Just (hostingWithLimit (-1))) `shouldBe` Right Nothing
 
         it "disables uploads entirely when the limit is zero" $
-            checkUploadSize (Just (hostingWithLimit 0)) 1
+            uploadSizeCap (Just (hostingWithLimit 0))
                 `shouldBe` Left "Uploads are disabled on this plan."
 
-        it "accepts a file exactly at the limit" $
-            checkUploadSize (Just (hostingWithLimit 100)) (mb 100) `shouldBe` Right ()
-
-        it "rejects a file one byte over the limit" $
-            checkUploadSize (Just (hostingWithLimit 100)) (mb 100 + 1) `shouldSatisfy` isLeft
+        it "caps the streamed body at the policy limit in bytes" $
+            uploadSizeCap (Just (hostingWithLimit 100)) `shouldBe` Right (Just (mb 100))
 
     describe "uploadBodyCeiling" $ do
         let dbUpload = ["api", "v1", "db", "upload"]
@@ -61,10 +62,33 @@ spec = do
         it "does not bound at the HTTP layer when uploads are disabled (handler rejects)" $
             uploadBodyCeiling (Just (hostingWithLimit 0)) dbUpload `shouldBe` Nothing
 
-        it "caps the db upload route at 2x the policy limit (base64 + JSON slack)" $
+        it "caps the db upload route at the policy limit + 1 MiB slack (raw octet-stream)" $
             uploadBodyCeiling (Just (hostingWithLimit 100)) dbUpload
-                `shouldBe` Just (200 * 1024 * 1024 :: Word64)
+                `shouldBe` Just (101 * 1024 * 1024 :: Word64)
 
         it "caps the method upload route the same way" $
             uploadBodyCeiling (Just (hostingWithLimit 50)) methodUpload
-                `shouldBe` Just (100 * 1024 * 1024 :: Word64)
+                `shouldBe` Just (51 * 1024 * 1024 :: Word64)
+
+    describe "streamToTempFile" $ do
+        let chunks = map (UploadChunk . BS.pack) [[1, 2, 3], [4, 5], [6, 7, 8, 9]] -- 9 bytes total
+            source = S.source chunks
+
+        it "streams all chunks to a temp file when under the cap" $ do
+            result <- streamToTempFile (Just 100) source
+            case result of
+                Left err -> expectationFailure ("unexpected rejection: " <> show err)
+                Right path -> do
+                    written <- BS.readFile path
+                    written `shouldBe` BS.pack [1, 2, 3, 4, 5, 6, 7, 8, 9]
+                    removeFile path
+
+        it "streams with no cap (unlimited tier)" $ do
+            result <- streamToTempFile Nothing source
+            case result of
+                Left err -> expectationFailure ("unexpected rejection: " <> show err)
+                Right path -> BS.readFile path >>= (`shouldBe` BS.pack [1 .. 9]) >> removeFile path
+
+        it "rejects and cleans up when the running size exceeds the cap" $ do
+            result <- streamToTempFile (Just 4) source -- 9 bytes > 4
+            result `shouldSatisfy` isLeft

--- a/volca.cabal
+++ b/volca.cabal
@@ -309,6 +309,7 @@ test-suite lca-tests
                      , warp
                      , wai
                      , servant-server
+                     , servant
                      , network-uri
                      , base64-bytestring
                      , optparse-applicative

--- a/volca.cabal
+++ b/volca.cabal
@@ -113,6 +113,7 @@ library
                      , filepath
                      , directory
                      , mtl
+                     , exceptions
                      , bytestring
                      , deepseq
                      , parallel


### PR DESCRIPTION
## What
All five upload endpoints (`db/upload`, `method-collections/upload`, and the three reference-data uploads) now accept a streamed `application/octet-stream` body, with the display name and description as query parameters, instead of a base64-encoded payload inside a JSON object.

## Why
The base64-in-JSON shape buffers the whole file — plus ~4/3 base64 inflation and the JSON envelope — in memory on both ends. That makes large packages (e.g. a full ILCD method archive, hundreds of MB) impractical to upload.

## How
- Routes use `StreamBody NoFraming OctetStream (SourceIO UploadChunk)`.
- A shared `withStreamedUpload` folds the request body chunk-by-chunk into a temp file, enforcing the size policy as it streams (`uploadSizeCap` applied during the fold, replacing the post-decode `checkUploadSize`), then hands the file to the existing extract/detect path.
- `UploadChunk` is a newtype with a binary schema so openapi3 can describe the request body (it refuses a bare `ByteString`).
- The WAI request-body ceiling drops the 2x base64 slack to limit + 1 MiB.
- The CLI streams the file from disk in constant memory (`RequestBodyStream`).
- `UploadRequest` is removed (no longer referenced).

## Tests
`UploadSizeSpec` covers `uploadSizeCap`, `uploadBodyCeiling` and `streamToTempFile` (cap enforcement + temp-file write). Full suite green; a manual HTTP smoke test confirms the streamed round-trip (name required, content-type agnostic).