### PR TITLE
fix(crosslink): score cross-DB waste treatment with the right sign

### DIFF
--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -89,6 +89,7 @@ import Types (
     SimpleDatabase (..),
     TechnosphereFlow (..),
     WasteFlow (..),
+    activityNormFactor,
     exchangeFlowId,
     exchangeIsReference,
     exchangeLocation,
@@ -130,6 +131,14 @@ data SupplierEntry = SupplierEntry
     , seLocation :: !Text
     , seUnit :: !Text
     , seProductName :: !Text -- Product name for display/debugging
+    , seRefSign :: !Double
+    {- ^ Sign of the supplier's reference production: @+1@ for a normal product
+    output, @-1@ for a negative-output waste treatment (the EcoSpold2
+    convention; ILCD treatments keep @+1@ via their positive 'ReferenceInput').
+    A cross-DB waste link multiplies its coefficient by this so the dependency
+    solve drives the treatment in its waste-removing direction regardless of
+    which reference convention the supplier database uses.
+    -}
     }
 
 -- | Context for cross-database linking (with pre-built indexes)
@@ -384,7 +393,7 @@ lives in `sdbTechFlows`.
 -}
 buildSupplierEntries :: SimpleDatabase -> [(Text, SupplierEntry)]
 buildSupplierEntries db =
-    [ (tfName flow, SupplierEntry actUUID prodUUID loc (activityUnit act) (tfName flow))
+    [ (tfName flow, SupplierEntry actUUID prodUUID loc (activityUnit act) (tfName flow) 1.0)
     | ((actUUID, prodUUID), act) <- M.toList (sdbActivities db)
     , ex <- exchanges act
     , exchangeIsReference ex
@@ -399,7 +408,7 @@ product). One tuple per (waste flow UUID, waste flow name, entry).
 -}
 buildWasteTreatmentEntries :: SimpleDatabase -> [(UUID, Text, SupplierEntry)]
 buildWasteTreatmentEntries db =
-    [ (wfId flow, wfName flow, SupplierEntry actUUID prodUUID (activityLocation act) (activityUnit act) (wfName flow))
+    [ (wfId flow, wfName flow, SupplierEntry actUUID prodUUID (activityLocation act) (activityUnit act) (wfName flow) (signum (activityNormFactor act (actUUID, prodUUID))))
     | ((actUUID, prodUUID), act) <- M.toList (sdbActivities db)
     , ex <- exchanges act
     , exchangeIsReference ex
@@ -447,7 +456,7 @@ buildIndexedDatabaseFromDB dbName synDB db =
 -}
 buildSupplierEntriesFromDB :: Database -> [(Text, SupplierEntry)]
 buildSupplierEntriesFromDB db =
-    [ (tfName flow, SupplierEntry actUUID prodUUID loc (activityUnit act) (tfName flow))
+    [ (tfName flow, SupplierEntry actUUID prodUUID loc (activityUnit act) (tfName flow) 1.0)
     | (pid, (actUUID, prodUUID)) <- zip ([0 ..] :: [Int]) (V.toList (dbProcessIdTable db))
     , Just act <- [getActivity db (fromIntegral pid)]
     , ex <- exchanges act
@@ -477,7 +486,7 @@ supplierLocations act ex =
 -- | Treatment-activity entries from a full Database. Mirrors 'buildWasteTreatmentEntries'.
 buildWasteTreatmentEntriesFromDB :: Database -> [(UUID, Text, SupplierEntry)]
 buildWasteTreatmentEntriesFromDB db =
-    [ (wfId flow, wfName flow, SupplierEntry actUUID prodUUID (activityLocation act) (activityUnit act) (wfName flow))
+    [ (wfId flow, wfName flow, SupplierEntry actUUID prodUUID (activityLocation act) (activityUnit act) (wfName flow) (signum (activityNormFactor act (actUUID, prodUUID))))
     | (pid, (actUUID, prodUUID)) <- zip ([0 ..] :: [Int]) (V.toList (dbProcessIdTable db))
     , Just act <- [getActivity db (fromIntegral pid)]
     , ex <- exchanges act

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -1626,21 +1626,31 @@ findExchangeCrossDBLink LinkScan{lsCtx = ctx, lsWasteFlows = wasteFlowDb} consum
         let flowName = maybe "" wfName (M.lookup fid wasteFlowDb)
          in case findWasteTreatmentAcrossDatabases ctx fid flowName of
                 WasteMatched entry dbN ->
-                    let !crossLink =
+                    let
+                        -- The dep-demand solve drives the matched treatment in
+                        -- its OWN reference convention: an EcoSpold2 treatment
+                        -- has a negative-output reference ('seRefSign' = -1),
+                        -- an ILCD one a positive 'ReferenceInput' (+1). The
+                        -- consumer's waste-output amount is positive, so we
+                        -- carry the treatment's sign into the coefficient —
+                        -- without it a negative-reference background treatment
+                        -- scores the treated waste's burden with a flipped sign.
+                        !crossLink =
                             CrossDBLink
                                 { cdlConsumerActUUID = consumerActUUID
                                 , cdlConsumerProdUUID = consumerProdUUID
                                 , cdlConsumerFlowId = fid
                                 , cdlSupplierActUUID = seActivityUUID entry
                                 , cdlSupplierProdUUID = seProductUUID entry
-                                , cdlCoefficient = amt
+                                , cdlCoefficient = amt * seRefSign entry
                                 , cdlExchangeUnit = seUnit entry
                                 , cdlFlowName = seProductName entry
                                 , cdlLocation = seLocation entry
                                 , cdlSourceDatabase = dbN
                                 , cdlTiedAlternatives = []
                                 }
-                     in mempty{cdlLinks = [crossLink], cdlWasteExactLinks = 1}
+                     in
+                        mempty{cdlLinks = [crossLink], cdlWasteExactLinks = 1}
                 WasteAmbiguous _ -> mempty{cdlWasteAmbiguous = 1}
                 WasteNoMatch -> mempty{cdlCutoffWasteCount = 1}
     | otherwise = mempty

--- a/test/WasteCrossDBSpec.hs
+++ b/test/WasteCrossDBSpec.hs
@@ -29,6 +29,7 @@ spec = describe "findWasteTreatmentAcrossDatabases" $ do
                 , seLocation = "RoW"
                 , seUnit = "kg"
                 , seProductName = nm
+                , seRefSign = 1.0
                 }
 
         idbWith :: Text -> [(UUID.UUID, SupplierEntry)] -> [(Text, SupplierEntry)] -> IndexedDatabase

--- a/test/WasteTreatmentSignSpec.hs
+++ b/test/WasteTreatmentSignSpec.hs
@@ -1,0 +1,238 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Sign correctness for waste-treatment scoring across the two reference
+conventions VoLCA's parsers emit:
+
+  * EcoSpold2 (ecoinvent): a treatment's reference is a NEGATIVE technosphere
+    output (e.g. -1 kg of the waste it treats) → 'activityNormFactor' = -1.
+  * ILCD: a treatment's reference is a POSITIVE 'ReferenceInput' (+1 kg of the
+    waste it consumes) → 'activityNormFactor' = +1 (refInputs is abs-summed).
+
+Each convention is self-consistent on its own. Within a single database the
+convention is uniform, so the only realistic way to mix them is
+cross-database: an ecoinvent-style orphan waste OUTPUT resolved to a
+background treatment in another DB via 'findWasteTreatmentAcrossDatabases'.
+That path scores through the dep-demand solve ('accumulateDepDemandsWith'),
+NOT the static technosphere triples — and the dep-demand path applies no
+input/output sign, only 'cdlCoefficient'.
+
+A correctly treated 3 kg of waste at 2 kg CO2 / kg MUST contribute +6 kg CO2 in
+every case — treating waste adds burden, it never subtracts it.
+-}
+module WasteTreatmentSignSpec (spec) where
+
+import Data.List (elemIndex)
+import qualified Data.Map as M
+import qualified Data.Map.Strict as MS
+import qualified Data.Text as T
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import Database (buildDatabaseWithMatrices)
+import Database.CrossLinking (LinkingContext (..), buildIndexedDatabaseFromDB, defaultLinkingThreshold)
+import Database.Loader (findAllCrossDBLinks)
+import Matrix (computeInventoryMatrix)
+import SharedSolver (CrossDBSolution (..), computeInventoryMatrixWithDepsCached)
+import SynonymDB (emptySynonymDB)
+import Test.Hspec
+import TestHelpers (mkDepLookupFromMap, mkSolverFromDb, withinTolerance)
+import Types
+import UnitConversion (defaultUnitConfig)
+
+-- | A deterministic UUID from its canonical string form.
+mkUUID :: String -> UUID
+mkUUID s = case UUID.fromString s of
+    Just u -> u
+    Nothing -> UUID.nil
+
+-- Shared identifiers.
+kgU, co2, wW, yY, tA, pA :: UUID
+kgU = mkUUID "66666666-6666-6666-6666-666666666666"
+co2 = mkUUID "55555555-5555-5555-5555-555555555555"
+wW = mkUUID "22222222-2222-2222-2222-222222222222"
+yY = mkUUID "44444444-4444-4444-4444-444444444444"
+tA = mkUUID "11111111-1111-1111-1111-111111111111"
+pA = mkUUID "33333333-3333-3333-3333-333333333333"
+
+emptyActivity :: Activity
+emptyActivity =
+    Activity
+        { activityName = ""
+        , activityDescription = []
+        , activitySynonyms = M.empty
+        , activityClassification = M.empty
+        , activityLocation = "GLO"
+        , activityUnit = "kg"
+        , exchanges = []
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
+        }
+
+techEx :: UUID -> Double -> TechRole -> UUID -> Exchange
+techEx flow amt role link =
+    TechnosphereExchange
+        { techFlowId = flow
+        , techAmount = amt
+        , techUnitId = kgU
+        , techRole = role
+        , techActivityLinkId = link
+        , techProcessLinkId = Nothing
+        , techLocation = ""
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+co2Emission :: Double -> Exchange
+co2Emission amt =
+    BiosphereExchange
+        { bioFlowId = co2
+        , bioAmount = amt
+        , bioUnitId = kgU
+        , bioDirection = Emission
+        , bioLocation = ""
+        , bioComment = Nothing
+        , bioPedigree = Nothing
+        }
+
+wasteEx :: Bool -> UUID -> Double -> Exchange
+wasteEx isInput link amt =
+    WasteExchange
+        { waFlowId = wW
+        , waAmount = amt
+        , waUnitId = kgU
+        , waIsInput = isInput
+        , waActivityLinkId = link
+        , waProcessLinkId = Nothing
+        , waLocation = ""
+        , waComment = Nothing
+        , waPedigree = Nothing
+        }
+
+{- | A treatment of waste W: reference of W (role + signed amount vary by
+convention), emitting 2 kg CO2 per kg treated.
+-}
+treatment :: TechRole -> Double -> Activity
+treatment role amt =
+    emptyActivity
+        { activityName = "treatment of waste W"
+        , exchanges = [techEx wW amt role UUID.nil, co2Emission 2.0]
+        }
+
+{- | A producer of Y that also emits 3 kg of waste W. @waste@ supplies the
+waste exchange (intra-DB link, or orphan for the cross-DB cases).
+-}
+producer :: Exchange -> Activity
+producer waste =
+    emptyActivity
+        { activityName = "producer of Y"
+        , exchanges = [techEx yY 1.0 ReferenceProduct UUID.nil, waste]
+        }
+
+co2Flow :: BiosphereFlow
+co2Flow = BiosphereFlow co2 "carbon dioxide" kgU M.empty Nothing Nothing (Just (Compartment "air" Nothing))
+
+wasteFlowDB :: M.Map UUID WasteFlow
+wasteFlowDB = M.singleton wW (WasteFlow wW "waste W" kgU M.empty Nothing Nothing)
+
+techFlowDB :: M.Map UUID TechnosphereFlow
+techFlowDB =
+    M.fromList
+        [ (wW, TechnosphereFlow wW "waste W" kgU M.empty Nothing Nothing)
+        , (yY, TechnosphereFlow yY "product Y" kgU M.empty Nothing Nothing)
+        ]
+
+buildDB :: T.Text -> M.Map (UUID, UUID) Activity -> IO Database
+buildDB name acts =
+    buildDatabaseWithMatrices
+        defaultUnitConfig
+        acts
+        techFlowDB
+        (M.singleton co2 co2Flow)
+        wasteFlowDB
+        (M.singleton kgU (Unit kgU "kg" "kg" ""))
+        >>= either (\e -> fail (T.unpack name <> ": " <> T.unpack e)) pure
+
+co2Of :: M.Map UUID Double -> Double
+co2Of = M.findWithDefault 0.0 co2
+
+processIdOf :: Database -> (UUID, UUID) -> Maybe ProcessId
+processIdOf db key = fromIntegral <$> elemIndex key (V.toList (dbProcessIdTable db))
+
+-- | Intra-DB scoring of the producer's CO2 (single database, static triples).
+scoreIntra :: T.Text -> M.Map (UUID, UUID) Activity -> IO Double
+scoreIntra name acts = do
+    db <- buildDB name acts
+    case processIdOf db (pA, yY) of
+        Nothing -> fail "producer not interned"
+        Just pid -> co2Of <$> computeInventoryMatrix db (fromIntegral pid)
+
+{- | Cross-DB scoring: a root DB whose orphan waste OUTPUT is resolved — by the
+real linker ('findAllCrossDBLinks' → 'findWasteTreatmentAcrossDatabases') — to a
+treatment in a separate dependency DB, then scored through the dep-demand solve.
+Going through the linker (rather than a hand-built 'CrossDBLink') is the point:
+that is where the treatment's reference-sign correction is applied.
+-}
+scoreCross :: T.Text -> TechRole -> Double -> IO Double
+scoreCross depName depRole depRefAmount = do
+    let rootActs = M.singleton (pA, yY) (producer (wasteEx False UUID.nil 3.0))
+    rootBase <- buildDB "root" rootActs
+    depDB <- buildDB depName (M.singleton (tA, wW) (treatment depRole depRefAmount))
+    let ctx =
+            LinkingContext
+                { lcIndexedDatabases = [buildIndexedDatabaseFromDB depName emptySynonymDB depDB]
+                , lcSynonymDB = emptySynonymDB
+                , lcUnitConfig = defaultUnitConfig
+                , lcThreshold = defaultLinkingThreshold
+                , lcLocationHierarchy = M.empty
+                , lcGeographyPolicy = GeoExact
+                , lcSupplierAliases = Nothing
+                }
+        links = cdlLinks (findAllCrossDBLinks ctx techFlowDB wasteFlowDB (M.singleton kgU (Unit kgU "kg" "kg" "")) rootActs)
+        rootDB = rootBase{dbCrossDBLinks = links}
+    if null links
+        then fail "linker created no cross-DB waste link (matcher did not fire)"
+        else do
+            rootSolver <- mkSolverFromDb rootDB "root"
+            depSolver <- mkSolverFromDb depDB depName
+            let depLookup = mkDepLookupFromMap (MS.singleton depName (depDB, depSolver))
+            case processIdOf rootDB (pA, yY) of
+                Nothing -> fail "producer not interned"
+                Just pid -> do
+                    res <- computeInventoryMatrixWithDepsCached defaultUnitConfig depLookup rootDB "root" rootSolver pid
+                    case res of
+                        Left err -> fail (T.unpack err)
+                        Right sol -> pure (co2Of (csInventory sol))
+
+spec :: Spec
+spec = describe "Waste-treatment scoring sign across reference conventions" $ do
+    it "intra-DB ecoinvent (negative ReferenceProduct output) scores +6" $ do
+        score <-
+            scoreIntra
+                "intra-eco"
+                ( M.fromList
+                    [ ((pA, yY), producer (wasteEx False tA 3.0))
+                    , ((tA, wW), treatment ReferenceProduct (-1.0))
+                    ]
+                )
+        withinTolerance 1.0e-9 6.0 score `shouldBe` True
+
+    it "intra-DB ILCD (positive ReferenceInput) scores +6" $ do
+        score <-
+            scoreIntra
+                "intra-ilcd"
+                ( M.fromList
+                    [ ((pA, yY), producer (wasteEx True tA 3.0))
+                    , ((tA, wW), treatment ReferenceInput 1.0)
+                    ]
+                )
+        withinTolerance 1.0e-9 6.0 score `shouldBe` True
+
+    it "cross-DB to an ILCD (positive ReferenceInput) treatment scores +6" $ do
+        score <- scoreCross "ilcd-dep" ReferenceInput 1.0
+        withinTolerance 1.0e-9 6.0 score `shouldBe` True
+
+    it "cross-DB to an ecoinvent (negative ReferenceProduct) treatment scores +6" $ do
+        score <- scoreCross "eco-dep" ReferenceProduct (-1.0)
+        withinTolerance 1.0e-9 6.0 score `shouldBe` True

--- a/volca.cabal
+++ b/volca.cabal
@@ -211,6 +211,7 @@ test-suite lca-tests
                      , AutoRelinkSpec
                      , RelinkMappingSpec
                      , MatrixConstructionSpec
+                     , WasteTreatmentSignSpec
                      , InventorySpec
                      , MatrixExportSpec
                      , MethodSpec


### PR DESCRIPTION
## Problem

A process whose orphan waste output is treated by a background process in *another* loaded database links across DBs via `findWasteTreatmentAcrossDatabases`. That cross-DB demand is scored through the dependency-demand solve (`accumulateDepDemandsWith`), which applies the link's `cdlCoefficient` with **no** input/output sign — unlike the intra-DB technosphere path, which signs a waste output as −1.

A treatment's reference flow is signed by convention: EcoSpold2 uses a *negative* `ReferenceProduct` output (normFactor −1); ILCD uses a *positive* `ReferenceInput` (normFactor +1). With a fixed positive coefficient, a negative-reference background treatment scored the treated waste's burden with a **flipped sign** — treating waste *reduced* impact instead of adding it. Since ecoinvent is the usual background, this is the common case; cross-DB → ILCD treatments were already correct.

Within a single database the convention is uniform, so only the cross-database mix is affected. The same treatment can be consumed both by an intra-DB positive-input demand (which needs a positive normalization) and by a cross-DB waste output (which needs a negative one), so the correction has to live on the cross-DB edge, not on `activityNormFactor`.

## Fix

- Carry the supplier treatment's reference sign on `SupplierEntry` (`seRefSign` = signum of its normFactor; +1 for a normal product, −1 for a negative-output treatment).
- `findExchangeCrossDBLink` multiplies the waste link coefficient by it, so the dependency solve drives the treatment in its waste-removing direction regardless of the background DB's convention. ILCD treatments stay +1; EcoSpold2 ones flip to −1.

## Verification

New `WasteTreatmentSignSpec` drives the real linker (`findAllCrossDBLinks`) and covers all four combinations — intra-DB and cross-DB, each against an EcoSpold2 and an ILCD treatment. A correctly treated 3 kg of waste at 2 kg CO₂/kg is **+6 kg CO₂** in every case; the cross-DB → EcoSpold2 case was **−6** before this change. Full suite green.

## Notes

A normal technosphere input that matched a treatment's negative-output reference via the product-name index would flip the same way; the technosphere cross-link site does not apply this sign (product entries are +1). Left as a follow-up — it needs its own reproduction and the demand semantics differ.