### PR TITLE
fix(loader): load EcoSpold packages whose datasets sit in a subdirectory

### DIFF
--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -34,6 +34,7 @@ module Database.Loader (
     loadDatabase,
     loadDatabaseWithLocationAliases,
     loadDatabaseWithCrossDBLinking,
+    findFilesByExtRecursive,
 
     -- * Cache Operations
     loadCachedDatabaseWithMatrices,
@@ -671,13 +672,31 @@ fixExchangeLinkByName _ _ _ _ _ ex@BiosphereExchange{} = (ex, mempty)
 -- Waste link resolution is deferred to the cross-DB linker path.
 fixExchangeLinkByName _ _ _ _ _ ex@WasteExchange{} = (ex, mempty)
 
+{- | Recursively collect files under @dir@ whose lowercased extension matches
+@ext@. Lets an EcoSpold package load from its root even when the .spold datasets
+sit in a subdirectory (e.g. ecoinvent's datasets/).
+-}
+findFilesByExtRecursive :: String -> FilePath -> IO [FilePath]
+findFilesByExtRecursive ext = go
+  where
+    go d = do
+        entries <- listDirectory d
+        fmap concat $ forM entries $ \e -> do
+            let p = d </> e
+            isDir <- doesDirectoryExist p
+            if isDir
+                then go p
+                else pure [p | map toLower (takeExtension p) == ext]
+
 -- | Load EcoSpold files from directory
 loadEcoSpoldDirectory :: M.Map T.Text T.Text -> FilePath -> IO (Either T.Text SimpleDatabase)
 loadEcoSpoldDirectory locationAliases dir = do
     reportProgress Info "Scanning directory for EcoSpold files"
     files <- listDirectory dir
-    -- Support both EcoSpold2 (.spold) and EcoSpold1 (.XML/.xml) files
-    let spold2Files = [dir </> f | f <- files, takeExtension f == ".spold"]
+    -- .spold datasets may live in a subdirectory (e.g. ecoinvent's datasets/),
+    -- so find them recursively. .xml (EcoSpold1) stays top-level to avoid
+    -- sweeping up MasterData/metadata XML that sits beside the datasets.
+    spold2Files <- findFilesByExtRecursive ".spold" dir
     let spold1Files = [dir </> f | f <- files, map toLower (takeExtension f) == ".xml"]
 
     -- Determine which format to use based on what's found

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -118,6 +118,7 @@ import Database.CrossLinking (
     normalizeUnicode,
  )
 import Database.MatrixBuild (findProducer)
+import Database.Upload (listDirectoryRecursive)
 import EcoSpold.Common (distributeFiles)
 import EcoSpold.Parser1 (streamParseActivityAndFlowsFromFile1, streamParseAllDatasetsFromFile1)
 import EcoSpold.Parser2 (streamParseActivityAndFlowsFromFile)
@@ -677,16 +678,8 @@ fixExchangeLinkByName _ _ _ _ _ ex@WasteExchange{} = (ex, mempty)
 sit in a subdirectory (e.g. ecoinvent's datasets/).
 -}
 findFilesByExtRecursive :: String -> FilePath -> IO [FilePath]
-findFilesByExtRecursive ext = go
-  where
-    go d = do
-        entries <- listDirectory d
-        fmap concat $ forM entries $ \e -> do
-            let p = d </> e
-            isDir <- doesDirectoryExist p
-            if isDir
-                then go p
-                else pure [p | map toLower (takeExtension p) == ext]
+findFilesByExtRecursive ext =
+    fmap (filter ((== ext) . map toLower . takeExtension)) . listDirectoryRecursive
 
 -- | Load EcoSpold files from directory
 loadEcoSpoldDirectory :: M.Map T.Text T.Text -> FilePath -> IO (Either T.Text SimpleDatabase)

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -21,6 +21,10 @@ module Database.Manager (
     DependencyStatus (..),
     MethodCollectionStatus (..),
     RefDataStatus (..),
+    DirectoryFormat (..),
+
+    -- * Format detection
+    detectDirectoryFormat,
 
     -- * Re-exports
     DepLoadResult (..),
@@ -1198,12 +1202,19 @@ detectDirectoryFormat path = do
                     if hasProcesses
                         then return FormatILCD
                         else do
-                            files <- listDirectory path
-                            let extensions = map (map toLower . takeExtension) files
-                            -- Check for different formats (in order of preference)
-                            if ".spold" `elem` extensions
+                            -- EcoSpold packages keep their datasets in a
+                            -- subdirectory (e.g. ecoinvent's datasets/*.spold),
+                            -- so probe for .spold recursively. Otherwise a
+                            -- sibling FilenameToActivityLookup.csv at the package
+                            -- root masks them and the database misdetects as
+                            -- SimaPro CSV, silently loading zero activities.
+                            hasSpold <- containsExtensionDeep ".spold" path
+                            if hasSpold
                                 then return FormatSpold
-                                else
+                                else do
+                                    files <- listDirectory path
+                                    let extensions = map (map toLower . takeExtension) files
+                                    -- Check for remaining formats (in order of preference)
                                     if ".csv" `elem` extensions
                                         then return FormatCSV
                                         else
@@ -1211,6 +1222,23 @@ detectDirectoryFormat path = do
                                                 then return FormatXML
                                                 else return FormatUnknown
                 else return FormatUnknown
+
+{- | Recursively test whether the directory tree rooted at @path@ contains at
+least one file with the given (lowercased) extension, stopping at the first hit.
+Lets dataset files in a subdirectory drive format detection even when an
+unrelated file sits at the package root.
+-}
+containsExtensionDeep :: String -> FilePath -> IO Bool
+containsExtensionDeep ext = go
+  where
+    go dir = listDirectory dir >>= anyM probe . map (dir </>)
+    probe p =
+        doesDirectoryExist p >>= \isDir ->
+            if isDir
+                then go p
+                else pure (map toLower (takeExtension p) == ext)
+    anyM _ [] = pure False
+    anyM f (x : xs) = f x >>= \b -> if b then pure True else anyM f xs
 
 -- | Find CSV files in a directory
 findCSVFiles :: FilePath -> IO [FilePath]

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -213,7 +213,7 @@ import qualified UnitConversion
 import API.Types (DepLoadResult (..))
 import qualified Data.Text.IO as TIO
 import Database.CrossLinking (IndexedDatabase (..), LinkingContext (..), buildIndexedDatabaseFromDB, defaultLinkingThreshold)
-import Database.Upload (DatabaseFormat (..), findMethodDirectory)
+import Database.Upload (DatabaseFormat (..), findMethodDirectory, listDirectoryRecursive)
 import qualified Database.Upload as Upload
 import qualified Database.UploadedDatabase as UploadedDB
 import Method.FlowResolver (ILCDFlowInfo)
@@ -1224,21 +1224,13 @@ detectDirectoryFormat path = do
                 else return FormatUnknown
 
 {- | Recursively test whether the directory tree rooted at @path@ contains at
-least one file with the given (lowercased) extension, stopping at the first hit.
-Lets dataset files in a subdirectory drive format detection even when an
-unrelated file sits at the package root.
+least one file with the given (lowercased) extension. Lets dataset files in a
+subdirectory drive format detection even when an unrelated file sits at the
+package root (e.g. ecoinvent's datasets/*.spold beside a root CSV).
 -}
 containsExtensionDeep :: String -> FilePath -> IO Bool
-containsExtensionDeep ext = go
-  where
-    go dir = listDirectory dir >>= anyM probe . map (dir </>)
-    probe p =
-        doesDirectoryExist p >>= \isDir ->
-            if isDir
-                then go p
-                else pure (map toLower (takeExtension p) == ext)
-    anyM _ [] = pure False
-    anyM f (x : xs) = f x >>= \b -> if b then pure True else anyM f xs
+containsExtensionDeep ext =
+    fmap (any ((== ext) . map toLower . takeExtension)) . listDirectoryRecursive
 
 -- | Find CSV files in a directory
 findCSVFiles :: FilePath -> IO [FilePath]

--- a/src/Database/Upload.hs
+++ b/src/Database/Upload.hs
@@ -23,6 +23,9 @@ module Database.Upload (
     countDataFilesIn,
     anyDataFilesIn,
 
+    -- * Filesystem helpers
+    listDirectoryRecursive,
+
     -- * Method directory detection
     findMethodDirectory,
     findAllMethodDirectories,

--- a/src/Plugin/Builtin.hs
+++ b/src/Plugin/Builtin.hs
@@ -55,6 +55,7 @@ import Plugin.Types
 import Data.Char (toLower)
 import Data.List (sortOn)
 import Data.Maybe (fromMaybe)
+import Database.Upload (listDirectoryRecursive)
 import Matrix (Inventory)
 import qualified Matrix.Export as MatrixExport
 import Method.Mapping (MatchStrategy)
@@ -197,7 +198,7 @@ ecospold2Importer =
     ImportHandle
         { ihName = "ecospold2"
         , ihBackend = Builtin
-        , ihCanRead = hasFilesWithExt ".spold"
+        , ihCanRead = hasFilesWithExtDeep ".spold"
         , ihRead = \_ _ -> pure $ Left "Use Database.Manager for full loading with caching"
         }
 
@@ -232,19 +233,32 @@ ilcdImporter =
         , ihRead = \_ _ -> pure $ Left "Use Database.Manager for full loading with caching"
         }
 
--- | Check if path contains files with a given extension
-hasFilesWithExt :: String -> FilePath -> IO Bool
-hasFilesWithExt ext path = do
+{- | Check if @path@ is, or (for a directory) contains, a file with the given
+extension. The directory walk is parameterised so callers pick the depth:
+'hasFilesWithExt' stays top-level, 'hasFilesWithExtDeep' recurses.
+-}
+hasFilesWithExtBy :: (FilePath -> IO [FilePath]) -> String -> FilePath -> IO Bool
+hasFilesWithExtBy listFiles ext path = do
     isFile <- doesFileExist path
     if isFile
-        then pure $ map toLower (takeExtension path) == ext
+        then pure (matches path)
         else do
             isDir <- doesDirectoryExist path
             if isDir
-                then do
-                    files <- listDirectory path
-                    pure $ any (\f -> map toLower (takeExtension f) == ext) files
+                then any matches <$> listFiles path
                 else pure False
+  where
+    matches f = map toLower (takeExtension f) == ext
+
+-- | Top-level extension probe — .xml/.csv detection stays shallow, matching the loader.
+hasFilesWithExt :: String -> FilePath -> IO Bool
+hasFilesWithExt = hasFilesWithExtBy listDirectory
+
+{- | Recursive extension probe — EcoSpold2 datasets may sit in a subdirectory
+below the package root (e.g. ecoinvent's datasets/*.spold).
+-}
+hasFilesWithExtDeep :: String -> FilePath -> IO Bool
+hasFilesWithExtDeep = hasFilesWithExtBy listDirectoryRecursive
 
 -- ──────────────────────────────────────────────
 -- Search handles (wrap Database search functions)

--- a/test/DetectFormatSpec.hs
+++ b/test/DetectFormatSpec.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module DetectFormatSpec (spec) where
+
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+
+import Database.Manager (DirectoryFormat (..), detectDirectoryFormat)
+
+spec :: Spec
+spec = describe "detectDirectoryFormat" $ do
+    it "detects EcoSpold2 when .spold datasets sit in a subdirectory beside a root CSV" $
+        -- Native ecoinvent layout: datasets/*.spold plus a top-level
+        -- FilenameToActivityLookup.csv that must not mask the .spold files
+        -- (otherwise the package misdetects as SimaPro CSV and loads nothing).
+        withSystemTempDirectory "ecospold-detect" $ \dir -> do
+            createDirectoryIfMissing True (dir </> "datasets")
+            writeFile (dir </> "datasets" </> "a_b.spold") "<x/>"
+            writeFile (dir </> "FilenameToActivityLookup.csv") "Filename;ActivityName\n"
+            detectDirectoryFormat dir `shouldReturn` FormatSpold
+
+    it "still detects SimaPro CSV for a directory of only CSV files" $
+        withSystemTempDirectory "csv-detect" $ \dir -> do
+            writeFile (dir </> "export.csv") "{ SimaPro\n"
+            detectDirectoryFormat dir `shouldReturn` FormatCSV

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -7,6 +7,9 @@ import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
 import Database.Loader
@@ -107,6 +110,20 @@ simpleDBOf acts flows =
 
 spec :: Spec
 spec = do
+    -- -----------------------------------------------------------------------
+    -- findFilesByExtRecursive
+    -- -----------------------------------------------------------------------
+    describe "findFilesByExtRecursive" $ do
+        it "finds .spold datasets in a subdirectory beside a root CSV" $
+            -- Native ecoinvent layout: datasets/*.spold plus a top-level
+            -- FilenameToActivityLookup.csv. The package must load from its root.
+            withSystemTempDirectory "ecospold-load" $ \dir -> do
+                createDirectoryIfMissing True (dir </> "datasets")
+                writeFile (dir </> "datasets" </> "a_b.spold") "<x/>"
+                writeFile (dir </> "FilenameToActivityLookup.csv") "Filename;ActivityName\n"
+                found <- findFilesByExtRecursive ".spold" dir
+                found `shouldBe` [dir </> "datasets" </> "a_b.spold"]
+
     -- -----------------------------------------------------------------------
     -- normalizeText
     -- -----------------------------------------------------------------------

--- a/test/PluginSpec.hs
+++ b/test/PluginSpec.hs
@@ -4,6 +4,9 @@ module PluginSpec (spec) where
 
 import qualified Data.Map.Strict as M
 import Data.UUID (nil)
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
 import Method.Types (FlowDirection (..), MethodCF (..))
@@ -144,6 +147,20 @@ spec = do
             results <- searchWithPlugins [s1, s2] db query
             length results `shouldBe` 1 -- Deduplicated by UUID
             srScore (head results) `shouldBe` 0.9 -- Higher score kept
+    describe "Import handle detection" $ do
+        it "ecospold2 handle reads packages whose .spold datasets sit in a subdirectory" $
+            -- Native ecoinvent layout: datasets/*.spold below the package root.
+            withSystemTempDirectory "ecospold2-canread" $ \dir -> do
+                createDirectoryIfMissing True (dir </> "datasets")
+                writeFile (dir </> "datasets" </> "a_b.spold") "<x/>"
+                ihCanRead ecospold2Importer dir `shouldReturn` True
+
+        it "ecospold1 handle stays top-level and ignores .xml under subdirectories" $
+            -- EcoSpold1 detection must not descend into MasterData/ metadata XML.
+            withSystemTempDirectory "ecospold1-canread" $ \dir -> do
+                createDirectoryIfMissing True (dir </> "MasterData")
+                writeFile (dir </> "MasterData" </> "units.xml") "<x/>"
+                ihCanRead ecospold1Importer dir `shouldReturn` False
 
 -- Re-export validation functions from Service for testing
 runPreComputeValidation :: [ValidateHandle] -> Database -> IO [ValidationIssue]

--- a/volca.cabal
+++ b/volca.cabal
@@ -208,6 +208,7 @@ test-suite lca-tests
   main-is:             Spec.hs
   other-modules:       TestHelpers
                      , GoldenData
+                     , DetectFormatSpec
                      , AmountSpec
                      , AutoRelinkSpec
                      , RelinkMappingSpec


### PR DESCRIPTION
## Problem

Pointing a database at the **root** of an ecoinvent EcoSpold2 package silently loaded **zero** activities while reporting `[OK] Loaded`. The package keeps its 25,412 `.spold` datasets under `datasets/`, with a `FilenameToActivityLookup.csv` at the package root. Both the config-load format detector (`detectDirectoryFormat`) and the EcoSpold directory loader (`loadEcoSpoldDirectory`) scanned only the top level — so they found no `.spold`, saw the root CSV, misdetected the package as SimaPro CSV, and parsed nothing. A silent zero-activity load is worse than a clear failure: the consumer can't tell anything is wrong.

## Fix

Probe for `.spold` **recursively** in both places, so an EcoSpold package loads from its root regardless of whether the datasets sit in a subdirectory. EcoSpold1 (`.xml`) detection stays top-level on purpose, to avoid sweeping up the `MasterData/` metadata XML beside the datasets.

## Result

Pointing a database at the package root now loads all 25,412 activities (verified end-to-end against ecoinvent 3.11 cutoff). Full suite green (1,348 examples). New regression tests: `DetectFormatSpec` (detection) and a `findFilesByExtRecursive` case in `LoaderSpec` (recursive scan).