### PR TITLE
feat(lcia): characterize energy-denominated CFs via per-flow energy density

### DIFF
--- a/data/energy_density.csv
+++ b/data/energy_density.csv
@@ -1,0 +1,7 @@
+flow_name,value,energy_unit,native_unit
+"Coal, hard",18.01,MJ,kg
+"Coal, brown",9.41,MJ,kg
+"Oil, crude",43.4,MJ,kg
+"Gas, natural",36.0,MJ,Sm3
+Peat,9.76,MJ,kg
+Uranium,560000,MJ,kg

--- a/data/flows.csv
+++ b/data/flows.csv
@@ -718,3 +718,7 @@ tribenuron,Tribenuron-methyl
 "Transformation, to annual crop, non-irrigated","to arable, non-irrigated"
 "Transformation, from pasture, man made",from pasture/meadow
 "Occupation, industrial area, built up",industrial area
+brown coal,"Coal, brown"
+crude oil,"Oil, crude"
+hard coal,"Coal, hard"
+natural gas,"Gas, natural"

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -71,6 +71,7 @@ data Config = Config
     , cfgFlowSynonyms :: ![RefDataConfig]
     , cfgCompartmentMappings :: ![RefDataConfig]
     , cfgUnits :: ![RefDataConfig]
+    , cfgEnergyDensities :: ![RefDataConfig]
     , cfgPlugins :: ![PluginConfig]
     , cfgHosting :: !(Maybe HostingConfig)
     , cfgGeographies :: !(Maybe FilePath) -- Path to geographies CSV (code,display_name,parents)
@@ -172,6 +173,7 @@ defaultConfig =
         , cfgFlowSynonyms = []
         , cfgCompartmentMappings = []
         , cfgUnits = []
+        , cfgEnergyDensities = []
         , cfgPlugins = []
         , cfgHosting = Nothing
         , cfgGeographies = Nothing
@@ -189,6 +191,7 @@ instance DecodeTOML Config where
         cfgFlowSynonyms <- fromMaybe [] <$> getFieldOptWith (getArrayOf tomlDecoder) "flow-synonyms"
         cfgCompartmentMappings <- fromMaybe [] <$> getFieldOptWith (getArrayOf tomlDecoder) "compartment-mappings"
         cfgUnits <- fromMaybe [] <$> getFieldOptWith (getArrayOf tomlDecoder) "units"
+        cfgEnergyDensities <- fromMaybe [] <$> getFieldOptWith (getArrayOf tomlDecoder) "energy-densities"
         cfgPlugins <- fromMaybe [] <$> getFieldOptWith (getArrayOf tomlDecoder) "plugin"
         cfgHosting <- getFieldOptWith tomlDecoder "hosting"
         cfgGeographies <- getFieldOpt "geographies"
@@ -343,6 +346,7 @@ applyDataDir mDataDir cfg =
         , cfgFlowSynonyms = map (mapPath resolve) (cfgFlowSynonyms cfg)
         , cfgCompartmentMappings = map (mapPath resolve) (cfgCompartmentMappings cfg)
         , cfgUnits = map (mapPath resolve) (cfgUnits cfg)
+        , cfgEnergyDensities = map (mapPath resolve) (cfgEnergyDensities cfg)
         }
   where
     resolve = redirectIntoDataDir mDataDir

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -78,6 +78,7 @@ module Database.Manager (
     getFlowSynonymGroups,
     getMergedSynonymDB,
     getMergedCompartmentMap,
+    getMergedEnergyDensities,
     getMergedUnitConfig,
     getMergedFlowMetadata,
     getLocationHierarchy,
@@ -160,12 +161,15 @@ import Method.Mapping (
  )
 import Method.Types (
     CompartmentMap,
+    EnergyDensityMap,
     Method (..),
     MethodCF,
     MethodCollection (..),
     ScoringSet (..),
     buildCompartmentMapFromCSV,
+    buildEnergyDensityMapFromCSV,
     compartmentMapSize,
+    energyDensityMapSize,
  )
 import Plugin.Config (buildRegistry)
 import Plugin.Types (PluginRegistry (..), TransformContext (..), TransformHandle (..), TransformResult (..))
@@ -492,6 +496,9 @@ data DatabaseManager = DatabaseManager
     , -- Reference data: unit definitions
       dmAvailableUnitDefs :: !(TVar (Map Text RefDataConfig))
     , dmLoadedUnitDefs :: !(TVar (Map Text UnitConversion.UnitConfig))
+    , -- Reference data: energy densities (mass/volume → energy for energy-denominated CFs)
+      dmAvailableEnergyDensities :: !(TVar (Map Text RefDataConfig))
+    , dmLoadedEnergyDensities :: !(TVar (Map Text EnergyDensityMap))
     , dmNoCache :: !Bool -- Caching disabled flag
     , dmPlugins :: !PluginRegistry -- Plugin registry (built-in + external)
     , dmGeographies :: !(Map Text (Text, [Text])) -- code → (display_name, parent_codes)
@@ -577,6 +584,7 @@ mapMethodToTablesCachedWithHier manager dbName collection db hier method = do
         Nothing -> do
             mappings <- mapMethodToFlowsCached manager dbName collection db method
             cmap <- getMergedCompartmentMap manager
+            energyDensities <- getMergedEnergyDensities manager
             unitConfig <- getMergedUnitConfig manager
             (mFlows, mUnits) <- getMergedFlowMetadata manager
             -- Use the database's frozen-at-load-time synonym DB (curated-only;
@@ -586,7 +594,7 @@ mapMethodToTablesCachedWithHier manager dbName collection db hier method = do
             -- synonyms like "water" → "4-aminophenol").
             let synDB = fromMaybe emptySynonymDB (dbSynonymDB db)
                 expanded = expandSynonymMappings synDB (dbFlowsByName db) mappings
-                !raw = buildMethodTables cmap expanded
+                !raw = buildMethodTables cmap energyDensities expanded
                 !withBroadcast = fillBroadcastVector unitConfig mUnits mFlows raw
                 -- Precompute per-activity weights for regionalized methods so
                 -- subsequent scoring is a dot product instead of one full
@@ -736,17 +744,21 @@ initDatabaseManager config noCache configPath = do
     uploadedFlowSyns <- discoverUploadedRefData "uploads/flow-synonyms"
     uploadedCompMaps <- discoverUploadedRefData "uploads/compartment-mappings"
     uploadedUnitDefs <- discoverUploadedRefData "uploads/units"
+    uploadedEnergyDensities <- discoverUploadedRefData "uploads/energy-densities"
     -- Resolve reference data paths relative to config directory
     let resolveRdPath rd = rd{rdPath = resolveRelative (rdPath rd)}
     let allFlowSyns = map resolveRdPath (cfgFlowSynonyms config) ++ uploadedFlowSyns
         allCompMaps = map resolveRdPath (cfgCompartmentMappings config) ++ uploadedCompMaps
         allUnitDefs = map resolveRdPath (cfgUnits config) ++ uploadedUnitDefs
+        allEnergyDensities = map resolveRdPath (cfgEnergyDensities config) ++ uploadedEnergyDensities
     availableFlowSynsVar <- newTVarIO $ M.fromList [(rdName rd, rd) | rd <- allFlowSyns]
     loadedFlowSynsVar <- newTVarIO M.empty
     availableCompMapsVar <- newTVarIO $ M.fromList [(rdName rd, rd) | rd <- allCompMaps]
     loadedCompMapsVar <- newTVarIO M.empty
     availableUnitDefsVar <- newTVarIO $ M.fromList [(rdName rd, rd) | rd <- allUnitDefs]
     loadedUnitDefsVar <- newTVarIO M.empty
+    availableEnergyDensitiesVar <- newTVarIO $ M.fromList [(rdName rd, rd) | rd <- allEnergyDensities]
+    loadedEnergyDensitiesVar <- newTVarIO M.empty
 
     geographies <- case cfgGeographies config of
         Nothing -> return M.empty
@@ -783,6 +795,8 @@ initDatabaseManager config noCache configPath = do
                 , dmLoadedCompMaps = loadedCompMapsVar
                 , dmAvailableUnitDefs = availableUnitDefsVar
                 , dmLoadedUnitDefs = loadedUnitDefsVar
+                , dmAvailableEnergyDensities = availableEnergyDensitiesVar
+                , dmLoadedEnergyDensities = loadedEnergyDensitiesVar
                 , dmNoCache = noCache
                 , dmPlugins = buildRegistry (cfgPlugins config)
                 , dmGeographies = geographies
@@ -805,6 +819,7 @@ initDatabaseManager config noCache configPath = do
     autoLoadFlowSynonyms loadedFlowSynsVar allFlowSyns
     autoLoadRefData compMapOps loadedCompMapsVar allCompMaps
     autoLoadRefData unitDefOps loadedUnitDefsVar allUnitDefs
+    autoLoadRefData energyDensityOps loadedEnergyDensitiesVar allEnergyDensities
 
     totalStart <- getCurrentTime
 
@@ -2876,6 +2891,14 @@ getMergedCompartmentMap manager = do
     loaded <- readTVarIO (dmLoadedCompMaps manager)
     return $ M.unions (M.elems loaded)
 
+{- | Get the merged 'EnergyDensityMap' from all loaded energy-density sets.
+First-wins union over active CSVs, mirroring 'getMergedCompartmentMap'.
+-}
+getMergedEnergyDensities :: DatabaseManager -> IO EnergyDensityMap
+getMergedEnergyDensities manager = do
+    loaded <- readTVarIO (dmLoadedEnergyDensities manager)
+    return $ M.unions (M.elems loaded)
+
 {- | Get the merged UnitConfig from all loaded unit definitions.
 Memoized: pure over the loaded-unit-def set, invalidated on mutation.
 -}
@@ -3041,6 +3064,17 @@ unitDefOps =
         UnitConversion.unitCount
         "units"
         "uploads/units"
+        rdIsUploaded
+
+energyDensityOps :: RefDataOps EnergyDensityMap
+energyDensityOps =
+    RefDataOps
+        dmAvailableEnergyDensities
+        dmLoadedEnergyDensities
+        (first T.pack . buildEnergyDensityMapFromCSV)
+        energyDensityMapSize
+        "energy densities"
+        "uploads/energy-densities"
         rdIsUploaded
 
 listRefDataG :: RefDataOps a -> DatabaseManager -> IO [RefDataStatus]

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -97,7 +97,7 @@ import Plugin.Types (MapContext (..), MapQuery (..), MapResult (..), MapperHandl
 import SynonymDB
 import Types (Activity (..), BioFlowDB, BiosphereFlow (..), Database (..), ProcessId, SparseTriple (..), Unit (..), UnitDB)
 import qualified Types as VT
-import UnitConversion (UnitConfig, convertUnit, isKnownUnit)
+import UnitConversion (UnitConfig, UnitDef (..), convertUnit, isKnownUnit, lookupUnitDef, normalizeUnit)
 
 -- | Matching strategy used to find a flow
 data MatchStrategy
@@ -328,6 +328,14 @@ data MethodTables = MethodTables
     Applied to both CF compartments at build time and database flow
     compartments at query time, so both sides converge to the same
     canonical form. Empty map = identity, no normalization.
+    -}
+    , mtEnergyDensities :: !EnergyDensityMap
+    {- ^ Normalized flow name → energy density (MJ per native flow unit).
+    Lets an energy-denominated CF (dimension @energy@, e.g. a JRC fossil CF in
+    MJ) characterize a mass/volume inventory flow (kg, Sm3): the flow quantity
+    is converted to energy via its density before the CF multiply. Flows with
+    no entry behave exactly as before — an energy CF vs. a mass flow still
+    yields a zero effective CF. Empty map = feature inactive.
     -}
     , mtBroadcast :: !(M.Map UUID Double)
     {- ^ Pre-multiplied broadcast CFs: flow UUID → effective CF (CF value × flow→CF unit conversion).
@@ -590,8 +598,8 @@ expandSynonymMappings synDB flowsByName mappings =
 -- @resources/land@ via the compartment map), so it's simpler to let
 -- the table keys do the filtering.
 
-buildMethodTables :: CompartmentMap -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> MethodTables
-buildMethodTables cmap mappings =
+buildMethodTables :: CompartmentMap -> EnergyDensityMap -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> MethodTables
+buildMethodTables cmap energyDensities mappings =
     MethodTables
         { mtUuidCF =
             -- Non-regionalized rows only, like the name tables below: a
@@ -687,6 +695,7 @@ buildMethodTables cmap mappings =
                 , cfSubcompMatchesFlow cf flow
                 ]
         , mtCompartmentMap = cmap
+        , mtEnergyDensities = energyDensities
         , mtBroadcast = M.empty -- fill via 'fillBroadcastVector' to enable the fast path
         , mtRegionalActivityWeights = Nothing -- fill via 'fillRegionalActivityWeights' for regional fast path
         }
@@ -793,7 +802,7 @@ fillBroadcastVector unitConfig unitDB flowDB tables =
   where
     buildEntry fid flow = case lookupCascadeCF tables flowDB fid of
         Nothing -> Nothing
-        Just cfTuple -> Just (convertAndMultiply unitConfig unitDB (Just flow) cfTuple 1.0)
+        Just cfTuple -> Just (convertAndMultiply unitConfig unitDB (mtEnergyDensities tables) (Just flow) cfTuple 1.0)
 
 {- | Precompute per-activity-column contributions for a regionalized method.
 
@@ -919,6 +928,7 @@ fillRegionalActivityWeights unitCfg unitDB flowDB db hier tables
                             convertAndMultiply
                                 unitCfg
                                 unitDB
+                                (mtEnergyDensities tables)
                                 (M.lookup flowUUID flowDB)
                                 cfTuple
                                 bioVal
@@ -1013,14 +1023,14 @@ computeLCIAScoreFromTables unitConfig unitDB flowDB inventory tables =
 
     legacyScoreFlow fid qty = case lookupCascadeCF tables flowDB fid of
         Nothing -> Nothing
-        Just cfTuple -> Just (convertAndMultiply unitConfig unitDB (M.lookup fid flowDB) cfTuple qty)
+        Just cfTuple -> Just (convertAndMultiply unitConfig unitDB (mtEnergyDensities tables) (M.lookup fid flowDB) cfTuple qty)
 
 {- | Back-compat wrapper: build tables on the fly. Prefer the cached path
 ('mapMethodToTablesCached' + 'computeLCIAScoreFromTables') in hot loops.
 -}
 computeLCIAScore :: UnitConfig -> UnitDB -> BioFlowDB -> Inventory -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> LCIAOutcome
 computeLCIAScore unitConfig unitDB flowDB inventory mappings =
-    computeLCIAScoreFromTables unitConfig unitDB flowDB inventory (buildMethodTables M.empty mappings)
+    computeLCIAScoreFromTables unitConfig unitDB flowDB inventory (buildMethodTables M.empty M.empty mappings)
 
 {- | LCIA score with automatic dispatch.
 
@@ -1244,17 +1254,64 @@ flowMediumSub cmap flow =
             normalizeCompartment cmap (Compartment rawMed rawSub T.empty)
      in (normalizeMedium normMedRaw, normSub)
 
+{- | True when @unit@ is dimensionally an energy unit (same exponent vector as
+the reference @mj@). Used to detect the energy-CF-vs-non-energy-flow case the
+energy-density bridge targets, without hardcoding any unit string.
+-}
+isEnergyUnit :: UnitConfig -> Text -> Bool
+isEnergyUnit cfg unit =
+    case (lookupUnitDef cfg unit, lookupUnitDef cfg "MJ") of
+        (Just a, Just energyRef) -> udDimension a == udDimension energyRef
+        _ -> False
+
+{- | Flow→CF conversion factor for @qty@ units of flow, applying the
+energy-density bridge when it is needed and available.
+
+The bridge fires only when the CF is energy-denominated, the flow is __not__
+(its unit isn't an energy unit), and the flow carries an 'EnergyDensity'. The
+inventory quantity is first brought into the density's native unit, then turned
+into energy: @qNative × E@, where @E@ is the density value converted from its
+declared energy unit into the CF's unit. Either conversion failing — the flow
+unit can't reach the native unit, or the energy unit can't reach the CF unit —
+yields @0@: we refuse a wrong-basis or wrong-dimension factor rather than
+silently using the raw value.
+
+Every other case (matching dimensions, no density, or an energy flow) defers
+to 'convertForCharacterization', so flows without a density are unchanged.
+-}
+energyAwareConversion :: UnitConfig -> Text -> Text -> Maybe EnergyDensity -> Double -> Double
+energyAwareConversion cfg flowUnit cfUnit mDensity qty =
+    case mDensity of
+        Just (EnergyDensity ev energyUnit nativeUnit)
+            | isEnergyUnit cfg cfUnit
+            , not (isEnergyUnit cfg flowUnit) ->
+                fromMaybe 0 $ do
+                    qtyNative <- toNativeQty flowUnit nativeUnit
+                    factor <- convertUnit cfg energyUnit cfUnit ev
+                    pure (qtyNative * factor)
+        _ -> convertForCharacterization cfg flowUnit cfUnit qty
+  where
+    -- Bring the inventory quantity into the unit the density is denominated
+    -- against: identical units need no table entry, otherwise a same-dimension
+    -- conversion. An incompatible or unknown unit yields 'Nothing' → 0.
+    toNativeQty fu nu
+        | normalizeUnit fu == normalizeUnit nu = Just qty
+        | otherwise = convertUnit cfg fu nu qty
+
 {- | Apply the flow→CF unit conversion factor and multiply by the CF value.
 
-Delegates to 'convertForCharacterization' for the conversion step, so a
-dimensional mismatch between flow and CF units lands an effective @0@
-(refuse to score wrong-dimension data) rather than silently passing the
-unconverted quantity through. Pass @qty = 1.0@ to obtain the effective-CF
-factor used at build time; pass an actual quantity for inline scoring.
+Delegates to 'energyAwareConversion', which falls back to
+'convertForCharacterization' unless the energy-density bridge applies — so a
+dimensional mismatch between flow and CF units lands an effective @0@ (refuse
+to score wrong-dimension data) rather than silently passing the unconverted
+quantity through. Pass @qty = 1.0@ to obtain the effective-CF factor used at
+build time; pass an actual quantity for inline scoring.
 -}
 convertAndMultiply ::
     UnitConfig ->
     UnitDB ->
+    -- | Normalized-flow-name → energy density, for the energy-CF bridge.
+    EnergyDensityMap ->
     {- | Pre-resolved flow if the caller already has it; @Nothing@ defaults to
     the identity factor (no flow record means no flow unit known).
     -}
@@ -1263,9 +1320,10 @@ convertAndMultiply ::
     (Double, Text) ->
     Double ->
     Double
-convertAndMultiply unitConfig unitDB mflow (cfVal, cfUnit) qty =
+convertAndMultiply unitConfig unitDB energyDensities mflow (cfVal, cfUnit) qty =
     let flowUnit = maybe "" unitName (mflow >>= \f -> M.lookup (bfUnitId f) unitDB)
-        converted = convertForCharacterization unitConfig flowUnit cfUnit qty
+        mDensity = mflow >>= \f -> M.lookup (normalizeName (bfName f)) energyDensities
+        converted = energyAwareConversion unitConfig flowUnit cfUnit mDensity qty
      in converted * cfVal
 
 {- | Per-flow contributions over an 'Inventory', keyed by flow UUID (possibly
@@ -1309,7 +1367,7 @@ inventoryContributions unitConfig unitDB flowDB inventory tables =
             Just flow -> case lookupCascadeCF tables flowDB fid of
                 Nothing -> (contribs, unknowns) -- no CF match — legitimately uncharacterized
                 Just cfTuple@(cfVal, _) ->
-                    let !contribution = convertAndMultiply unitConfig unitDB (Just flow) cfTuple qty
+                    let !contribution = convertAndMultiply unitConfig unitDB (mtEnergyDensities tables) (Just flow) cfTuple qty
                      in ((flow, cfVal, contribution) : contribs, unknowns)
 
 {- | Per-process LCIA contributions for one DB + one method, driven by
@@ -1350,7 +1408,7 @@ processContributionsFromTables unitConfig unitDB flowDB db scalingVec tables =
                 Nothing -> 0
                 Just _ -> case lookupCascadeCF tables flowDB flowUUID of
                     Nothing -> 0
-                    Just cfTuple -> convertAndMultiply unitConfig unitDB mflow cfTuple 1.0
+                    Just cfTuple -> convertAndMultiply unitConfig unitDB (mtEnergyDensities tables) mflow cfTuple 1.0
 
     -- Invert dbActivityIndex (pid -> col) into (col -> pid) as an unboxed
     -- vector for O(1) per-triple lookup. Assumes matrix cols are dense in
@@ -1591,7 +1649,7 @@ scoreBatched unitCfg unitDB flowDB bt inventory
                 case lookupCascadeCF tables flowDB uuid of
                     Nothing -> 0
                     Just cfTuple ->
-                        convertAndMultiply unitCfg unitDB (M.lookup uuid flowDB) cfTuple qty
+                        convertAndMultiply unitCfg unitDB (mtEnergyDensities tables) (M.lookup uuid flowDB) cfTuple qty
             scores = U.create $ do
                 mv <- MU.replicate nMethods (0.0 :: Double)
                 mapM_

--- a/src/Method/Types.hs
+++ b/src/Method/Types.hs
@@ -31,6 +31,12 @@ module Method.Types (
     normalizeCompartment,
     compartmentMapSize,
 
+    -- * Energy density (mass/volume → energy for energy-denominated CFs)
+    EnergyDensity (..),
+    EnergyDensityMap,
+    buildEnergyDensityMapFromCSV,
+    energyDensityMapSize,
+
     -- * Flow Mapping
     FlowMapping (..),
     MatchType (..),
@@ -51,6 +57,7 @@ import Data.UUID (UUID)
 import qualified Data.Vector as V
 import qualified Expr
 import GHC.Generics (Generic)
+import SynonymDB (normalizeName)
 
 -- | Direction of a biosphere flow (input from or output to environment)
 data FlowDirection
@@ -306,6 +313,59 @@ normalizeCompartment cmap (Compartment med sub qual) =
 -- | Number of entries in the compartment map.
 compartmentMapSize :: CompartmentMap -> Int
 compartmentMapSize = M.size
+
+{- | Energy content of a flow, used to characterize an energy-denominated CF
+(e.g. a JRC fossil-resource CF in MJ) against an inventory flow given in mass or
+volume (kg, Sm3, …).
+
+A row @Coal, hard,18.01,MJ,kg@ reads: 1 kg of @Coal, hard@ carries 18.01 MJ.
+'edEnergyUnit' is the unit of the energy amount (converted to the CF's unit at
+score time); 'edNativeUnit' is the unit the content is denominated against, so
+the inventory quantity is brought into that unit before the density is applied.
+Naming the native unit keeps the bridge dimensionally honest: a flow reported in
+a different but compatible unit (g, t) still scores correctly, and one whose
+unit can't be converted to the native unit scores 0 instead of by a wrong basis.
+-}
+data EnergyDensity = EnergyDensity
+    { edValue :: !Double
+    , edEnergyUnit :: !Text
+    , edNativeUnit :: !Text
+    }
+    deriving (Eq, Show, Generic)
+
+instance NFData EnergyDensity
+
+{- | Normalized flow name → energy density. Keyed by 'SynonymDB.normalizeName'
+so the scoring read paths can look a flow up by the same canonical name they
+already use for CF matching.
+-}
+type EnergyDensityMap = M.Map Text EnergyDensity
+
+{- | Build an 'EnergyDensityMap' from CSV content.
+CSV columns (with header): @flow_name, value, energy_unit, native_unit@ — e.g.
+@Coal, hard,18.01,MJ,kg@. Keys are normalized at parse time so the union of
+active CSVs and the read-path lookups agree. Each row is validated: a
+non-positive value or a missing unit is a load error, never a silently inert or
+wrong-dimension entry.
+-}
+buildEnergyDensityMapFromCSV :: BL.ByteString -> Either String EnergyDensityMap
+buildEnergyDensityMapFromCSV csvData =
+    case decode HasHeader csvData of
+        Left err -> Left $ "CSV parse error: " <> err
+        Right rows ->
+            M.fromList <$> traverse toEntry (V.toList (rows :: V.Vector (Text, Double, Text, Text)))
+  where
+    toEntry (name, value, energyUnit, nativeUnit)
+        | value <= 0 =
+            Left $ "energy density must be positive (flow: " <> T.unpack name <> ")"
+        | T.null (T.strip energyUnit) || T.null (T.strip nativeUnit) =
+            Left $ "energy density needs an energy unit and a native unit (flow: " <> T.unpack name <> ")"
+        | otherwise =
+            Right (normalizeName name, EnergyDensity value (T.strip energyUnit) (T.strip nativeUnit))
+
+-- | Number of entries in the energy-density map.
+energyDensityMapSize :: EnergyDensityMap -> Int
+energyDensityMapSize = M.size
 
 -- | How a method flow was matched to a database flow
 data MatchType

--- a/src/Plugin/Builtin.hs
+++ b/src/Plugin/Builtin.hs
@@ -369,7 +369,7 @@ hotspotAnalyzer =
     -- Characterization uses the merged flow/unit snapshot the caller built.
     analyzeMethod flowDB unitDB mapCtx inv topN method = do
         mappings <- Mapping.mapMethodFlows defaultMappers mapCtx method
-        let tables = Mapping.buildMethodTables M.empty mappings
+        let tables = Mapping.buildMethodTables M.empty M.empty mappings
             (rawContribs, _) = Mapping.inventoryContributions UnitConversion.defaultUnitConfig unitDB flowDB inv tables
             sorted = take topN $ sortOn (\(_, _, c) -> negate (abs c)) rawContribs
             total = Mapping.loScore (Mapping.computeLCIAScoreFromTables UnitConversion.defaultUnitConfig unitDB flowDB inv tables)

--- a/test/CrossDBInventorySpec.hs
+++ b/test/CrossDBInventorySpec.hs
@@ -178,6 +178,7 @@ spec = do
                     , mtRegionalCasCF = M.empty
                     , mtRegionalizedCF = M.empty
                     , mtCompartmentMap = M.empty
+                    , mtEnergyDensities = M.empty
                     , mtBroadcast = M.empty
                     , mtRegionalActivityWeights = Nothing
                     }

--- a/test/CrossDBRegionalLCIAFixture.hs
+++ b/test/CrossDBRegionalLCIAFixture.hs
@@ -211,7 +211,7 @@ regionalMappings = map (\(loc, v) -> (cf loc v, Just (testFlow, ByName)))
 
 buildTables :: Database -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> MethodTables
 buildTables db mappings =
-    let raw = buildMethodTables M.empty mappings
+    let raw = buildMethodTables M.empty M.empty mappings
         withBroadcast = fillBroadcastVector kgUnitConfig (dbUnits db) (dbBioFlows db) raw
      in fillRegionalActivityWeights
             kgUnitConfig

--- a/test/EnergyDensityCFSpec.hs
+++ b/test/EnergyDensityCFSpec.hs
@@ -1,0 +1,191 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | The energy-density bridge: characterize an energy-denominated CF (a JRC
+fossil-resource CF in MJ, where the method assumes the inventory is already in
+energy units) against an inventory flow given in mass or volume (kg, Sm3).
+
+Native ecoinvent supplies fossil resources by mass/volume, but the EF v3.1
+"Resource use, fossils" CFs are denominated in MJ with value 1.0. Without a
+per-flow energy density the flow/CF unit pair is cross-dimensional, so
+'convertForCharacterization' returns 0 and every fossil flow scores 0. Supplying
+an energy density E (MJ per native unit) brings the flow's quantity into the
+density's native unit and contributes @qNative * E@ MJ, matching the energy CF.
+
+The fixtures drive the real table build + broadcast fill + scoring so they track
+the engine's actual behaviour:
+  * a kg flow + an energy CF + a density of 26.4 MJ/kg yields an effective CF of
+    26.4 (not 0), and a 1 kg inventory scores 26.4;
+  * a flow declared in a *different but compatible* unit (tonne) is converted
+    into the density's native unit first, so 1 t scores 1000 × 26.4;
+  * a flow whose unit is *dimensionally incompatible* with the native unit (m3
+    vs kg) scores 0 — refuse a wrong basis rather than multiply blindly;
+  * the SAME flow WITHOUT a density still yields 0 (no regression);
+  * a same-dimension pair (mass flow + mass CF) is untouched by the machinery.
+Plus the CSV reader: it keys by normalized name and rejects malformed rows.
+-}
+module EnergyDensityCFSpec (spec) where
+
+import qualified Data.ByteString.Lazy.Char8 as BLC
+import Data.Either (isLeft)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
+import Test.Hspec
+
+import Method.Mapping
+import Method.Types (Compartment (..), EnergyDensity (..), EnergyDensityMap, FlowDirection (..), MethodCF (..), buildEnergyDensityMapFromCSV)
+import SynonymDB (normalizeName)
+import Types (BiosphereFlow (..), Unit (..), UnitDB)
+import qualified Types as VT
+import UnitConversion (UnitConfig, buildFromCSV, defaultUnitConfig)
+
+-- ---------------------------------------------------------------------------
+-- Unit metadata: a UnitConfig + a UnitDB that know kg, tonne, m3 and MJ
+-- ---------------------------------------------------------------------------
+
+-- A UnitConfig that knows two mass units (kg, tonne), a volume unit (m3) and an
+-- energy unit (MJ); the shipped 'defaultUnitConfig' has no energy units, so the
+-- bridge can't fire against it. Mirrors how production loads data/units.csv.
+unitConfig :: UnitConfig
+unitConfig =
+    either (const defaultUnitConfig) id $
+        buildFromCSV (BLC.pack "name,dimension,factor\nkg,mass,1.0\ntonne,mass,1000.0\nm3,volume,1.0\nmj,energy,1.0e6\n")
+
+uidKg, uidTonne, uidM3 :: UUID
+uidKg = UUID.fromWords64 1 0
+uidTonne = UUID.fromWords64 2 0
+uidM3 = UUID.fromWords64 3 0
+
+mkUnit :: UUID -> Text -> Unit
+mkUnit uid name = Unit{unitId = uid, unitName = name, unitSymbol = name, unitComment = ""}
+
+-- UnitDB so each flow's bfUnitId resolves to its declared unit.
+unitDB :: UnitDB
+unitDB =
+    M.fromList
+        [ (uidKg, mkUnit uidKg "kg")
+        , (uidTonne, mkUnit uidTonne "tonne")
+        , (uidM3, mkUnit uidM3 "m3")
+        ]
+
+-- ---------------------------------------------------------------------------
+-- Flow + CF fixtures
+-- ---------------------------------------------------------------------------
+
+-- All coal-flow variants share this UUID so the energy CF matches by UUID
+-- regardless of the declared unit; only 'bfUnitId' differs between them.
+coalId :: UUID
+coalId = UUID.fromWords64 10 0
+
+-- A fossil-resource flow (like ecoinvent's "Coal, hard") in a chosen unit.
+coalFlowIn :: UUID -> BiosphereFlow
+coalFlowIn unitId =
+    BiosphereFlow
+        { bfId = coalId
+        , bfName = "Coal, hard"
+        , bfUnitId = unitId
+        , bfSynonyms = M.empty
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfCompartment = Just (VT.Compartment "natural resource" Nothing)
+        }
+
+-- An energy-denominated CF (value 1.0, unit MJ) matched to the coal flow by
+-- UUID, so it lands in 'mtUuidCF' and reaches the flow through the cascade.
+energyCF :: MethodCF
+energyCF =
+    MethodCF
+        { mcfFlowRef = coalId
+        , mcfFlowName = "Coal, hard"
+        , mcfDirection = Input
+        , mcfValue = 1.0
+        , mcfCompartment = Just (Compartment "natural resource" "" "")
+        , mcfCAS = Nothing
+        , mcfUnit = "MJ"
+        , mcfConsumerLocation = Nothing
+        }
+
+-- A same-dimension CF (mass, kg) on the same flow — the control: the
+-- energy-density machinery must not perturb it.
+massCF :: MethodCF
+massCF = energyCF{mcfValue = 3.0, mcfUnit = "kg"}
+
+-- Energy density for "Coal, hard": 26.4 MJ per kg. Keyed exactly as
+-- 'buildEnergyDensityMapFromCSV' keys a data/energy_density.csv row.
+coalDensities :: EnergyDensityMap
+coalDensities = M.fromList [(normalizeName "Coal, hard", EnergyDensity 26.4 "MJ" "kg")]
+
+-- Build tables (with broadcast) for a flow + energy-density set + CF.
+tablesFor :: BiosphereFlow -> EnergyDensityMap -> MethodCF -> MethodTables
+tablesFor flow densities cf =
+    let fdb = M.singleton (bfId flow) flow
+        raw = buildMethodTables M.empty densities [(cf, Just (flow, ByUUID))]
+     in fillBroadcastVector unitConfig unitDB fdb raw
+
+-- Score a @qty@-unit inventory of @flow@ against the given tables.
+scoreFlow :: BiosphereFlow -> Double -> MethodTables -> Double
+scoreFlow flow qty tables =
+    loScore (computeLCIAScoreFromTables unitConfig unitDB (M.singleton (bfId flow) flow) (M.singleton (bfId flow) qty) tables)
+
+-- Effective (broadcast) CF for the coal flow, asserted within tolerance to
+-- avoid IEEE-754 surprises on the conversion factors.
+broadcastShouldBeNear :: MethodTables -> Double -> Expectation
+broadcastShouldBeNear tables expected =
+    case M.lookup coalId (mtBroadcast tables) of
+        Just v -> v `shouldSatisfy` near expected
+        Nothing -> expectationFailure "expected a broadcast entry for the coal flow"
+
+near :: Double -> Double -> Bool
+near expected v = abs (v - expected) < 1e-6
+
+-- ---------------------------------------------------------------------------
+-- Spec
+-- ---------------------------------------------------------------------------
+
+spec :: Spec
+spec = do
+    describe "Energy-density bridge: energy CF vs. mass or volume flow" $ do
+        it "applies the energy density to the effective CF (26.4, not 0)" $
+            broadcastShouldBeNear (tablesFor (coalFlowIn uidKg) coalDensities energyCF) 26.4
+
+        it "scores 1 kg of coal as 26.4 MJ" $
+            scoreFlow (coalFlowIn uidKg) 1.0 (tablesFor (coalFlowIn uidKg) coalDensities energyCF)
+                `shouldSatisfy` near 26.4
+
+        it "converts a flow declared in tonne into the density's native kg first (1 t → 26400)" $ do
+            let flow = coalFlowIn uidTonne
+                tables = tablesFor flow coalDensities energyCF
+            broadcastShouldBeNear tables 26400
+            scoreFlow flow 1.0 tables `shouldSatisfy` near 26400
+
+        it "refuses a flow whose unit is dimensionally incompatible with the native unit (m3 vs kg → 0)" $ do
+            let flow = coalFlowIn uidM3
+                tables = tablesFor flow coalDensities energyCF
+            broadcastShouldBeNear tables 0
+            scoreFlow flow 1.0 tables `shouldSatisfy` near 0
+
+        it "leaves the energy CF at 0 when the flow has no energy density (regression guard)" $ do
+            let flow = coalFlowIn uidKg
+                tables = tablesFor flow M.empty energyCF
+            broadcastShouldBeNear tables 0
+            scoreFlow flow 1.0 tables `shouldSatisfy` near 0
+
+        it "does not perturb a same-dimension (mass) CF, with or without a density" $ do
+            let flow = coalFlowIn uidKg
+            broadcastShouldBeNear (tablesFor flow coalDensities massCF) 3.0
+            broadcastShouldBeNear (tablesFor flow M.empty massCF) 3.0
+
+    describe "buildEnergyDensityMapFromCSV" $ do
+        it "parses a valid row, keyed by normalized flow name" $
+            case buildEnergyDensityMapFromCSV (BLC.pack "flow_name,value,energy_unit,native_unit\n\"Coal, hard\",18.01,MJ,kg\n") of
+                Left err -> expectationFailure err
+                Right m -> M.lookup (normalizeName "Coal, hard") m `shouldBe` Just (EnergyDensity 18.01 "MJ" "kg")
+
+        it "rejects a non-positive value" $
+            buildEnergyDensityMapFromCSV (BLC.pack "flow_name,value,energy_unit,native_unit\nPeat,0,MJ,kg\n")
+                `shouldSatisfy` isLeft
+
+        it "rejects a missing native unit" $
+            buildEnergyDensityMapFromCSV (BLC.pack "flow_name,value,energy_unit,native_unit\nPeat,9.76,MJ,\n")
+                `shouldSatisfy` isLeft

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -287,7 +287,7 @@ spec = do
             fid <- nextRandom
             let flow = mkFlow fid "ammonia" "emissions to air/low. pop." Nothing
                 cf = mkCFComp "ammonia" "air" "low. pop." 0.747
-                tables = buildMethodTables M.empty [(cf, Nothing)]
+                tables = buildMethodTables M.empty M.empty [(cf, Nothing)]
                 inventory = M.singleton fid 10.0
                 flowDB = M.singleton fid flow
                 score = loScore (computeLCIAScoreFromTables defaultUnitConfig M.empty flowDB inventory tables)
@@ -298,7 +298,7 @@ spec = do
             let flow = mkFlow fid "ammonia" "emissions to air/low. pop." Nothing
                 cf = mkCFComp "ammonia" "air" "low. pop." 0.747
                 cmap = M.singleton ("emissions to air", "", "") (Compartment "air" "" "")
-                tables = buildMethodTables cmap [(cf, Nothing)]
+                tables = buildMethodTables cmap M.empty [(cf, Nothing)]
                 inventory = M.singleton fid 10.0
                 flowDB = M.singleton fid flow
                 score = loScore (computeLCIAScoreFromTables defaultUnitConfig M.empty flowDB inventory tables)
@@ -313,7 +313,7 @@ spec = do
                     M.singleton
                         ("emissions to air", "low. pop.", "")
                         (Compartment "air" "non-urban air or from high stacks" "")
-                tables = buildMethodTables cmap [(cf, Nothing)]
+                tables = buildMethodTables cmap M.empty [(cf, Nothing)]
                 inventory = M.singleton fid 10.0
                 flowDB = M.singleton fid flow
                 score = loScore (computeLCIAScoreFromTables defaultUnitConfig M.empty flowDB inventory tables)
@@ -351,7 +351,7 @@ spec = do
             fid <- nextRandom
             let flow = mkFlow fid "co2" "air" Nothing
                 cf = mkCF "co2" Nothing 1.0
-                tables = buildMethodTables M.empty [(cf, Just (flow, ByUUID))]
+                tables = buildMethodTables M.empty M.empty [(cf, Just (flow, ByUUID))]
                 inventory = M.singleton fid 100.0
                 flowDB = M.singleton fid flow
                 unitDB = M.singleton nil (unitNamed "m")
@@ -430,7 +430,7 @@ spec = do
             uidKg <- nextRandom
             let flow = (mkFlow fid "co2" "air" Nothing){bfUnitId = uidKg}
                 cf = (mkCF "co2" Nothing 2.5){mcfUnit = "kg"}
-                rawTables = buildMethodTables M.empty [(cf, Just (flow, ByUUID))]
+                rawTables = buildMethodTables M.empty M.empty [(cf, Just (flow, ByUUID))]
                 flowDB = M.singleton fid flow
                 unitDB = M.singleton uidKg (mkUnit uidKg "kg")
                 inv = M.fromList [(fid, 4.0 :: Double)]
@@ -457,7 +457,7 @@ spec = do
             uidKg <- nextRandom
             let flow = (mkFlow fid "co2" "air" Nothing){bfUnitId = uidKg}
                 cf = (mkCF "co2" Nothing 1.0e-3){mcfUnit = "g"}
-                tables0 = buildMethodTables M.empty [(cf, Just (flow, ByUUID))]
+                tables0 = buildMethodTables M.empty M.empty [(cf, Just (flow, ByUUID))]
                 flowDB = M.singleton fid flow
                 unitDB = M.singleton uidKg (mkUnit uidKg "kg")
                 inv = M.fromList [(fid, 1.0 :: Double)]
@@ -476,7 +476,7 @@ spec = do
             uidKg <- nextRandom
             let flow = (mkFlow fid "co2" "air" (Just "high pop")){bfUnitId = uidKg}
                 cf = (mkCFComp "co2" "air" "high pop" 3.0){mcfUnit = "kg"}
-                tables0 = buildMethodTables M.empty [(cf, Just (flow, ByName))]
+                tables0 = buildMethodTables M.empty M.empty [(cf, Just (flow, ByName))]
                 flowDB = M.singleton fid flow
                 unitDB = M.singleton uidKg (mkUnit uidKg "kg")
                 inv = M.fromList [(fid, 2.0 :: Double)]
@@ -492,7 +492,7 @@ spec = do
             -- Flow has subcomp "high pop", but CF only has medium-level entry (subcomp "")
             let flow = (mkFlow fid "co2" "air" (Just "high pop")){bfUnitId = uidKg}
                 cf = (mkCFComp "co2" "air" "" 5.0){mcfUnit = "kg"}
-                tables0 = buildMethodTables M.empty [(cf, Just (flow, ByName))]
+                tables0 = buildMethodTables M.empty M.empty [(cf, Just (flow, ByName))]
                 flowDB = M.singleton fid flow
                 unitDB = M.singleton uidKg (mkUnit uidKg "kg")
                 inv = M.fromList [(fid, 1.0 :: Double)]
@@ -508,7 +508,7 @@ spec = do
             uidKg <- nextRandom
             let flowLocal = (mkFlow fidLocal "co2" "air" Nothing){bfUnitId = uidKg}
                 cf = (mkCF "co2" Nothing 1.5){mcfUnit = "kg"}
-                tables0 = buildMethodTables M.empty [(cf, Just (flowLocal, ByUUID))]
+                tables0 = buildMethodTables M.empty M.empty [(cf, Just (flowLocal, ByUUID))]
                 flowDBAtBuild = M.singleton fidLocal flowLocal
                 unitDB = M.singleton uidKg (mkUnit uidKg "kg")
                 filled = fillBroadcastVector defaultUnitConfig unitDB flowDBAtBuild tables0
@@ -605,7 +605,7 @@ spec = do
             fid <- nextRandom
             let flow = mkFlow fid "co2" "air" Nothing
                 inv = M.singleton fid 100.0
-                tables = buildMethodTables M.empty []
+                tables = buildMethodTables M.empty M.empty []
                 idx = buildMethodIndex (mkMethod [])
                 opts = defaultUncharacterizedOpts{uoMaxFlows = 0}
             findUncharacterized
@@ -626,7 +626,7 @@ spec = do
                 smallFlow = mkFlow small "huge stuff" "air" Nothing
                 inv = M.fromList [(big, 999.0), (small, 1.0)]
                 flowDB = M.fromList [(big, bigFlow), (small, smallFlow)]
-                tables = buildMethodTables M.empty []
+                tables = buildMethodTables M.empty M.empty []
                 idx = buildMethodIndex (mkMethod [])
                 opts = defaultUncharacterizedOpts{uoMinAbsWeight = 0.5}
                 result =
@@ -646,7 +646,7 @@ spec = do
             fid <- nextRandom
             let flow = mkFlow fid "co2" "air" Nothing
                 cf = (mkCF "co2" Nothing 1.0){mcfFlowRef = fid}
-                tables = buildMethodTables M.empty [(cf, Just (flow, ByUUID))]
+                tables = buildMethodTables M.empty M.empty [(cf, Just (flow, ByUUID))]
                 idx = buildMethodIndex (mkMethod [cf])
                 inv = M.singleton fid 100.0
                 flowDB = M.singleton fid flow

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -94,7 +94,7 @@ spec = do
                 uidKg = mkUuid 200
                 cf = mkCF fid 1.0
                 m1 = mkMethod 1 "m1" [cf]
-                tables0 = buildMethodTables M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))]
+                tables0 = buildMethodTables M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))]
                 fdb = M.singleton fid (mkFlow fid "co2" uidKg)
                 udb = M.singleton uidKg (mkUnit uidKg "kg")
                 filled = fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb tables0
@@ -110,7 +110,7 @@ spec = do
                 uidKg = mkUuid 200
                 cf = mkCF fid 1.0
                 tables0 =
-                    (buildMethodTables M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))])
+                    (buildMethodTables M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))])
                         { mtRegionalizedCF = M.singleton (fid, "FR") (2.0, "kg")
                         }
                 m1 = mkMethod 1 "m1" [cf]
@@ -143,9 +143,9 @@ spec = do
                 mC = mkMethod 3 "C" [cfC1]
 
                 fill ts = fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb ts
-                tA = fill (buildMethodTables M.empty [(cfA1, Just (flow1, ByUUID))])
-                tB = fill (buildMethodTables M.empty [(cfB1, Just (flow1, ByUUID)), (cfB2, Just (flow2, ByUUID))])
-                tC = fill (buildMethodTables M.empty [(cfC1, Just (flow1, ByUUID))])
+                tA = fill (buildMethodTables M.empty M.empty [(cfA1, Just (flow1, ByUUID))])
+                tB = fill (buildMethodTables M.empty M.empty [(cfB1, Just (flow1, ByUUID)), (cfB2, Just (flow2, ByUUID))])
+                tC = fill (buildMethodTables M.empty M.empty [(cfC1, Just (flow1, ByUUID))])
 
                 mst = buildMethodSetTables [(mA, tA), (mB, tB), (mC, tC)]
 
@@ -185,7 +185,7 @@ spec = do
                 fdb = M.singleton fid (mkFlow fid "co2" uidKg)
                 udb = M.singleton uidKg (mkUnit uidKg "kg")
                 fill ts = fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb ts
-                t = fill (buildMethodTables M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))])
+                t = fill (buildMethodTables M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))])
                 mst = buildMethodSetTables [(m1, t), (m2, t)]
                 results =
                     computeLCIAScoreSetFromTables
@@ -210,7 +210,7 @@ spec = do
                 udb = M.singleton uidKg (mkUnit uidKg "kg")
                 t =
                     fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb $
-                        buildMethodTables M.empty [(cf, Just (mkFlow fidIn "co2" uidKg, ByUUID))]
+                        buildMethodTables M.empty M.empty [(cf, Just (mkFlow fidIn "co2" uidKg, ByUUID))]
                 mst = buildMethodSetTables [(m1, t)]
                 inv = M.fromList [(fidIn, 2.0), (fidOut, 100.0)]
                 results =
@@ -254,6 +254,7 @@ spec = do
                     fillBroadcastVector UnitConversion.defaultUnitConfig udb buildFlowDB $
                         buildMethodTables
                             M.empty
+                            M.empty
                             [ (cfBuild, Just (mkFlow fidBuild "co2" uidKg, ByUUID))
                             , (cfCross, Just (mkFlow fidCrossDB "co2" uidKg, ByUUID))
                             ]
@@ -279,7 +280,7 @@ spec = do
                 udb = M.singleton uidKg (mkUnit uidKg "kg")
                 t =
                     fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb $
-                        buildMethodTables M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))]
+                        buildMethodTables M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))]
                 mB = mkMethod 2 "B" [cf]
                 mA = mkMethod 1 "A" [cf]
                 mC = mkMethod 3 "C" [cf]
@@ -311,16 +312,17 @@ spec = do
                 cf3a = mkCF fid1 1.0
                 cf3b = (mkCF fid2 25.0){mcfFlowName = "ch4"}
                 tNonRegio1 =
-                    fill (buildMethodTables M.empty [(cf1a, Just (flow1, ByUUID))])
+                    fill (buildMethodTables M.empty M.empty [(cf1a, Just (flow1, ByUUID))])
                 tRegio =
                     fill
-                        ( (buildMethodTables M.empty [(cf2a, Just (flow1, ByUUID))])
+                        ( (buildMethodTables M.empty M.empty [(cf2a, Just (flow1, ByUUID))])
                             { mtRegionalizedCF = M.singleton (fid1, "FR") (7.0, "kg")
                             }
                         )
                 tNonRegio2 =
                     fill
                         ( buildMethodTables
+                            M.empty
                             M.empty
                             [ (cf3a, Just (flow1, ByUUID))
                             , (cf3b, Just (flow2, ByUUID))
@@ -398,7 +400,7 @@ spec = do
                     , (cfOcean, Just (flowUns, ByName))
                     , (cfOcean, Just (flowOcean, ByName))
                     ]
-                tables = buildMethodTables M.empty mappings
+                tables = buildMethodTables M.empty M.empty mappings
                 regio = mtRegionalizedCF tables
             -- Pre-fix: this was (0.0, "kg") — clobbered by cfOcean. The
             -- filter drops (cfOcean, flowUns) so the wildcard cfUns survives.
@@ -427,8 +429,8 @@ spec = do
                         , mcfCompartment = Just (Compartment "water" "(unspecified)" "")
                         , mcfConsumerLocation = Just "DE"
                         }
-                tEmpty = buildMethodTables M.empty [(cfEmpty, Just (flowOcean, ByName))]
-                tUnspec = buildMethodTables M.empty [(cfUnspecified, Just (flowOcean, ByName))]
+                tEmpty = buildMethodTables M.empty M.empty [(cfEmpty, Just (flowOcean, ByName))]
+                tUnspec = buildMethodTables M.empty M.empty [(cfUnspecified, Just (flowOcean, ByName))]
             -- Both wildcard forms apply to a specific-subcomp flow.
             M.lookup (fid, "DE") (mtRegionalizedCF tEmpty) `shouldBe` Just (2.0, "kg")
             M.lookup (fid, "DE") (mtRegionalizedCF tUnspec) `shouldBe` Just (7.0, "kg")
@@ -446,5 +448,5 @@ spec = do
                         , mcfCompartment = Nothing
                         , mcfConsumerLocation = Just "IT"
                         }
-                tables = buildMethodTables M.empty [(cf, Just (flowAny, ByName))]
+                tables = buildMethodTables M.empty M.empty [(cf, Just (flowAny, ByName))]
             M.lookup (fid, "IT") (mtRegionalizedCF tables) `shouldBe` Just (4.0, "kg")

--- a/test/OlcaSchemaSpec.hs
+++ b/test/OlcaSchemaSpec.hs
@@ -147,5 +147,5 @@ spec = do
                 Left err -> expectationFailure ("parse failed: " ++ err)
                 Right method -> do
                     let mappings = [(cf, Nothing) | cf <- methodFactors method]
-                        tables = buildMethodTables M.empty mappings
+                        tables = buildMethodTables M.empty M.empty mappings
                     M.size (mtRegionalizedCF tables) `shouldBe` 0

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -159,7 +159,7 @@ buildTables ::
     [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] ->
     MethodTables
 buildTables db hier mappings =
-    let raw = buildMethodTables M.empty mappings
+    let raw = buildMethodTables M.empty M.empty mappings
         withBroadcast =
             fillBroadcastVector kgUnitConfig (dbUnits db) (dbBioFlows db) raw
      in fillRegionalActivityWeights

--- a/test/SharedCASCoverageSpec.hs
+++ b/test/SharedCASCoverageSpec.hs
@@ -154,7 +154,7 @@ mapCtx =
 buildTablesFor :: Method -> IO MethodTables
 buildTablesFor method = do
     mappings <- mapMethodFlows defaultMappers mapCtx method
-    let raw = buildMethodTables M.empty mappings
+    let raw = buildMethodTables M.empty M.empty mappings
     pure (fillBroadcastVector defaultUnitConfig M.empty flowDB raw)
 
 buildTables :: IO MethodTables
@@ -232,7 +232,7 @@ carbonSynonyms =
 buildCarbonTables :: IO MethodTables
 buildCarbonTables = do
     mappings <- mapMethodFlows defaultMappers carbonSynonyms biogenicMethaneMethod
-    let raw = buildMethodTables M.empty mappings
+    let raw = buildMethodTables M.empty M.empty mappings
     pure (fillBroadcastVector defaultUnitConfig M.empty carbonFlows raw)
 
 -- ---------------------------------------------------------------------------
@@ -323,14 +323,14 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
     describe "regionalized rows stay out of the global tables" $ do
         it "routes a location-bearing CAS-matched CF to mtRegionalCasCF only" $ do
             mappings <- mapMethodFlows defaultMappers mapCtx regionalCasMethod
-            let tables = buildMethodTables M.empty mappings
+            let tables = buildMethodTables M.empty M.empty mappings
             M.lookup (waterCAS, "resource") (mtRegionalCasCF tables)
                 `shouldBe` Just (M.fromList [("FR", (9, "m3"))])
             M.member (waterCAS, "resource") (mtCasCF tables) `shouldBe` False
 
         it "keeps regionalized UUID-matched rows out of mtUuidCF" $ do
             mappings <- mapMethodFlows defaultMappers mapCtx uuidRegionalMethod
-            let tables = buildMethodTables M.empty mappings
+            let tables = buildMethodTables M.empty M.empty mappings
             -- The global row stands; the location row lives in the regional
             -- table instead of clobbering the flow's universal value.
             M.lookup (bfId river) (mtUuidCF tables) `shouldBe` Just (5, "m3")

--- a/volca.cabal
+++ b/volca.cabal
@@ -240,6 +240,7 @@ test-suite lca-tests
                      , CrossDBRegionalLCIASensitivitySpec
                      , RegionalLCIASpec
                      , SharedCASCoverageSpec
+                     , EnergyDensityCFSpec
                      , SharedSolverSpec
                      , CoalescingSolverSpec
                      , FlowResolverSpec

--- a/volca.toml
+++ b/volca.toml
@@ -85,6 +85,11 @@ name = "Default units"
 path = "data/units.csv"
 active = true
 
+[[energy-densities]]
+name = "Default energy densities"
+path = "data/energy_density.csv"
+active = true
+
 # ── Classification Presets ───────────────────────────────────────────
 #
 # Named filter shortcuts that appear as options in the Activities page


### PR DESCRIPTION
## Why

Some impact methods denominate a characterization factor in **energy** while the inventory reports the flow in **mass or volume**. The EF v3.1 fossil-resource CFs are `1.0` per MJ, but native ecoinvent gives `Coal, hard` in kg and `Gas, natural` in m³. The flow→CF unit conversion is dimensional, so kg→MJ was refused and **every fossil flow silently scored 0** — the whole "Resource use, fossils" category was uncharacterized.

## What

A generic engine capability: a new `[[energy-densities]]` reference CSV maps a flow to its energy content as `value, energy_unit, native_unit` (e.g. `Coal, hard,18.01,MJ,kg`). When a CF is energy-dimensioned and the flow is not, the inventory quantity is **brought into the density's native unit**, then converted to energy via the density, before characterization.

Anchoring to a *declared* native unit keeps the bridge dimensionally honest:
- a flow reported in a compatible unit (g, t) is converted first, so it still scores correctly;
- a flow whose unit can't reach the native unit yields **0**, never a wrong-basis factor;
- rows are **validated at load time** — a non-positive value or a missing unit is a parse error, not a silently inert entry.

The density map rides on `MethodTables` like the compartment map and is applied in both CF read paths, so single, batch, and regionalized scoring stay consistent. Reference data is auto-loaded from config/uploads; runtime list/load/upload endpoints are intentionally left out (no sibling UI to drive them yet — a focused follow-up if needed).

The data commit seeds the six fossil energy contents (from ecoinvent's published EF v3.1 factors) and four word-order synonyms so the flows match by name.

## Result

Validated against ecoinvent's own published EF v3.1 scores over all 25,412 activities: **Resource use, fossils** goes from uncharacterized → median **0.997×**, within-20% **0.00 → 1.00**, with **no other category affected**. The native-unit anchoring is behaviour-preserving for native ecoinvent (mass flows are kg, gas is m³ — each converts identity-valued into its declared base). Hermetic `EnergyDensityCFSpec` covers the bridge, the cross-unit conversion, the refuse-incompatible path, and CSV validation; build `-Wall`-clean, full suite green.

Peat remains uncharacterized (ecoinvent files it under the `biotic` subcompartment, which the in-ground energy CFs don't reach); its category weight is negligible.
