### PR TITLE
fix(lcia): subcompartment fallback + CAS-bridge unspecified default

### DIFF
--- a/data/flows.csv
+++ b/data/flows.csv
@@ -722,3 +722,5 @@ brown coal,"Coal, brown"
 crude oil,"Oil, crude"
 hard coal,"Coal, hard"
 natural gas,"Gas, natural"
+"Particulate Matter, < 2.5 um",particles (PM2.5)
+"Particulate Matter, > 2.5 um and < 10um",particles (PM10)

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -687,17 +687,22 @@ buildMethodTables cmap energyDensities mappings =
                     , let normMed = normalizeMedium (T.toLower normMedRaw)
                     ]
         , mtRegionalCasCF =
-            M.fromListWith
-                (M.unionWith preferLargerMag)
-                [ ((cas, normMed), M.singleton loc (mcfValue cf, mcfUnit cf))
-                | (cf, Just (_, ByCAS)) <- mappings
-                , Just cas <- [mcfCAS cf]
-                , not (T.null cas)
-                , Just loc <- [mcfConsumerLocation cf]
-                , Just comp <- [mcfCompartment cf]
-                , let Compartment normMedRaw _ _ = normalizeCompartment cmap comp
-                , let normMed = normalizeMedium (T.toLower normMedRaw)
-                ]
+            -- Same unspecified-default preference as 'mtCasCF', applied per
+            -- location: when several subcompartment CFs collide on one
+            -- (CAS, medium, location) the medium-level default wins over a
+            -- niche subcompartment, rather than the largest magnitude.
+            M.map (M.map snd) $
+                M.fromListWith
+                    (M.unionWith preferUnspecifiedCas)
+                    [ ((cas, normMed), M.singleton loc (casSubRank normSub, (mcfValue cf, mcfUnit cf)))
+                    | (cf, Just (_, ByCAS)) <- mappings
+                    , Just cas <- [mcfCAS cf]
+                    , not (T.null cas)
+                    , Just loc <- [mcfConsumerLocation cf]
+                    , Just comp <- [mcfCompartment cf]
+                    , let Compartment normMedRaw normSub _ = normalizeCompartment cmap comp
+                    , let normMed = normalizeMedium (T.toLower normMedRaw)
+                    ]
         , mtRegionalizedCF =
             -- Filter: a CF whose own compartment carries a specific subcomp
             -- (e.g. "groundwater, long-term" or "ocean") must only apply to
@@ -720,18 +725,12 @@ buildMethodTables cmap energyDensities mappings =
   where
     stripStrategy = M.map (\(v, u, _) -> (v, u))
 
-    -- Dedup CAS-keyed CFs colliding on one (CAS, medium) key (many same-CAS
-    -- flows collapse to one key, e.g. several name variants of a substance):
-    -- keep the larger-magnitude factor. Deliberately biased toward overstating
-    -- the impact — the bridge is a last-resort fallback and an understated
-    -- factor would be invisible, while an overstated one shows up in validation.
-    preferLargerMag (v1, u1) (v2, u2)
-        | abs v1 >= abs v2 = (v1, u1)
-        | otherwise = (v2, u2)
-
     -- For the CAS bridge: rank the unspecified / empty subcompartment ahead of
     -- any specific one, so 'preferUnspecifiedCas' keeps the medium-level
-    -- default value when several subcompartment CFs share a (CAS, medium).
+    -- default value when several subcompartment CFs collide on one key. On a
+    -- tie (no unspecified CF present) keep the larger magnitude — the bridge is
+    -- a last-resort fallback, so an overstated factor surfaces in validation
+    -- while an understated one would be invisible.
     casSubRank s
         | isUnspecifiedSub s = 0 :: Int
         | otherwise = 1

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -668,17 +668,24 @@ buildMethodTables cmap energyDensities mappings =
             -- "Methane, non-fossil") is name-discriminated: broadcasting it to
             -- every same-CAS flow would leak it onto a sibling the method
             -- distinguishes (fossil methane), so it stays out of the CAS bridge.
-            M.fromListWith
-                preferLargerMag
-                [ ((cas, normMed), (mcfValue cf, mcfUnit cf))
-                | (cf, Just (_, ByCAS)) <- mappings
-                , Just cas <- [mcfCAS cf]
-                , not (T.null cas)
-                , Nothing <- [mcfConsumerLocation cf]
-                , Just comp <- [mcfCompartment cf]
-                , let Compartment normMedRaw _ _ = normalizeCompartment cmap comp
-                , let normMed = normalizeMedium (T.toLower normMedRaw)
-                ]
+            --
+            -- When several CFs share one (CAS, medium), broadcast the
+            -- substance's medium-level default — its unspecified-subcompartment
+            -- factor — rather than the largest. The largest is often a niche
+            -- subcompartment (indoor air can be ~100x the outdoor value) that
+            -- would over-characterize every same-CAS flow the bridge reaches.
+            M.map snd $
+                M.fromListWith
+                    preferUnspecifiedCas
+                    [ ((cas, normMed), (casSubRank normSub, (mcfValue cf, mcfUnit cf)))
+                    | (cf, Just (_, ByCAS)) <- mappings
+                    , Just cas <- [mcfCAS cf]
+                    , not (T.null cas)
+                    , Nothing <- [mcfConsumerLocation cf]
+                    , Just comp <- [mcfCompartment cf]
+                    , let Compartment normMedRaw normSub _ = normalizeCompartment cmap comp
+                    , let normMed = normalizeMedium (T.toLower normMedRaw)
+                    ]
         , mtRegionalCasCF =
             M.fromListWith
                 (M.unionWith preferLargerMag)
@@ -721,6 +728,17 @@ buildMethodTables cmap energyDensities mappings =
     preferLargerMag (v1, u1) (v2, u2)
         | abs v1 >= abs v2 = (v1, u1)
         | otherwise = (v2, u2)
+
+    -- For the CAS bridge: rank the unspecified / empty subcompartment ahead of
+    -- any specific one, so 'preferUnspecifiedCas' keeps the medium-level
+    -- default value when several subcompartment CFs share a (CAS, medium).
+    casSubRank s
+        | T.null s || s == "unspecified" || s == "(unspecified)" = 0 :: Int
+        | otherwise = 1
+    preferUnspecifiedCas a@(ra, (va, _)) b@(rb, (vb, _))
+        | ra /= rb = if ra < rb then a else b
+        | abs va >= abs vb = a
+        | otherwise = b
 
     -- A CF compartment of (unspecified) / empty subcomp is a wildcard. A CF
     -- with a specific subcomp must match the flow's subcomp exactly — otherwise

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -651,7 +651,7 @@ buildMethodTables cmap energyDensities mappings =
                     , Just comp <- [mcfCompartment cf]
                     , let Compartment normMedRaw normSub _ = normalizeCompartment cmap comp
                     , let normMed = normalizeMedium (T.toLower normMedRaw)
-                    , T.null normSub || normSub == "unspecified" || normSub == "(unspecified)"
+                    , isUnspecifiedSub normSub
                     ]
         , mtCasCF =
             -- Keyed by the CF's own CAS + medium (not by a matched flow), so the
@@ -704,8 +704,8 @@ buildMethodTables cmap energyDensities mappings =
             -- flows in that exact subcomp — otherwise a CF=0 set explicitly for
             -- a niche subcomp leaks onto flows in other subcomps via
             -- ByName/synonym fan-out and clobbers the correct (unspecified)
-            -- fallback CF. CFs with subcomp "(unspecified)" / empty are
-            -- wildcards and match any flow subcomp.
+            -- fallback CF. CFs with no specific subcomp ('isUnspecifiedSub')
+            -- are wildcards and match any flow subcomp.
             M.fromList
                 [ ((bfId flow, loc), (mcfValue cf, mcfUnit cf))
                 | (cf, Just (flow, _)) <- mappings
@@ -733,17 +733,18 @@ buildMethodTables cmap energyDensities mappings =
     -- any specific one, so 'preferUnspecifiedCas' keeps the medium-level
     -- default value when several subcompartment CFs share a (CAS, medium).
     casSubRank s
-        | T.null s || s == "unspecified" || s == "(unspecified)" = 0 :: Int
+        | isUnspecifiedSub s = 0 :: Int
         | otherwise = 1
     preferUnspecifiedCas a@(ra, (va, _)) b@(rb, (vb, _))
         | ra /= rb = if ra < rb then a else b
         | abs va >= abs vb = a
         | otherwise = b
 
-    -- A CF compartment of (unspecified) / empty subcomp is a wildcard. A CF
-    -- with a specific subcomp must match the flow's subcomp exactly — otherwise
-    -- an explicit-zero niche-subcomp CF would clobber the correct
-    -- (unspecified) CF for flows in other subcomps via ByName/synonym fan-out.
+    -- A CF whose subcomp names no specific subcompartment ('isUnspecifiedSub')
+    -- is a wildcard. A CF with a specific subcomp must match the flow's subcomp
+    -- exactly — otherwise an explicit-zero niche-subcomp CF would clobber the
+    -- correct (unspecified) CF for flows in other subcomps via ByName/synonym
+    -- fan-out.
     --
     -- Both sides go through 'normalizeCompartment' so a compartments.csv rule
     -- that rewrites a subcomp can't desynchronise the filter from the sibling
@@ -767,8 +768,7 @@ buildMethodTables cmap energyDensities mappings =
                 Compartment _ flowSubRaw _ =
                     normalizeCompartment cmap (Compartment rawMed rawSub T.empty)
                 !flowSubN = T.toLower (T.strip flowSubRaw)
-             in T.null cfSubN
-                    || cfSubN == "(unspecified)"
+             in isUnspecifiedSub cfSubN
                     || cfSubN == flowSubN
 
     preferBetter (v1, u1, s1) (v2, u2, s2)
@@ -1262,6 +1262,18 @@ normalizeMedium :: Text -> Text
 normalizeMedium m
     | m == "natural resource" = "resource"
     | otherwise = m
+
+{- | A subcompartment that names no specific subcompartment — empty, or either
+spelling of unspecified. Such a CF is the medium-level default: it
+characterizes any flow in that medium whose own subcompartment the method
+doesn't cover. The single source of truth for "is this the catch-all subcomp",
+so the fallback table, the CAS-bridge rank, and the regionalized wildcard
+filter can't drift apart on which spellings count (they did: the filter once
+omitted bare @unspecified@). Inputs are expected already lower-cased via
+'normalizeCompartment'.
+-}
+isUnspecifiedSub :: Text -> Bool
+isUnspecifiedSub s = T.null s || s == "unspecified" || s == "(unspecified)"
 
 {- | The @(normalized medium, subcompartment)@ a database flow resolves to after
 compartment normalization. Shared by the name/CAS read path

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -631,6 +631,17 @@ buildMethodTables cmap energyDensities mappings =
                     , not (T.null normSub)
                     ]
         , mtFallbackCF =
+            -- Medium-level default CF for a flow whose specific subcompartment
+            -- has no exact CF. Holds CFs whose own subcompartment is empty or
+            -- "unspecified" — the value a method intends as the catch-all for
+            -- that (name, medium). A flow at an uncovered subcompartment (e.g.
+            -- a radionuclide emitted to "low population density, long-term",
+            -- which EF leaves uncharacterized) thus picks up the unspecified CF,
+            -- as ecoinvent's own implementation does, instead of scoring zero.
+            -- This is safe against the long-term toxicity case: a substance
+            -- that DOES carry a "(long-term)" CF keeps it in 'mtExactCF', which
+            -- is consulted before this fallback, so long-term emissions still
+            -- resolve to their explicit (often zero) factor.
             stripStrategy $
                 M.fromListWith
                     preferBetter
@@ -640,7 +651,7 @@ buildMethodTables cmap energyDensities mappings =
                     , Just comp <- [mcfCompartment cf]
                     , let Compartment normMedRaw normSub _ = normalizeCompartment cmap comp
                     , let normMed = normalizeMedium (T.toLower normMedRaw)
-                    , T.null normSub
+                    , T.null normSub || normSub == "unspecified" || normSub == "(unspecified)"
                     ]
         , mtCasCF =
             -- Keyed by the CF's own CAS + medium (not by a matched flow), so the

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -429,11 +429,23 @@ spec = do
                         , mcfCompartment = Just (Compartment "water" "(unspecified)" "")
                         , mcfConsumerLocation = Just "DE"
                         }
+                -- Bare "unspecified" (no parens) is the spelling 'compartments.csv'
+                -- emits (e.g. "emissions to water,unspecified,long-term,…"); the
+                -- filter once treated only "" / "(unspecified)" as wildcards and
+                -- silently dropped this one. It must also act as a wildcard.
+                cfUnspecBare =
+                    (mkCF fid 9.0)
+                        { mcfFlowName = "water"
+                        , mcfCompartment = Just (Compartment "water" "unspecified" "")
+                        , mcfConsumerLocation = Just "DE"
+                        }
                 tEmpty = buildMethodTables M.empty M.empty [(cfEmpty, Just (flowOcean, ByName))]
                 tUnspec = buildMethodTables M.empty M.empty [(cfUnspecified, Just (flowOcean, ByName))]
-            -- Both wildcard forms apply to a specific-subcomp flow.
+                tUnspecBare = buildMethodTables M.empty M.empty [(cfUnspecBare, Just (flowOcean, ByName))]
+            -- All three wildcard forms apply to a specific-subcomp flow.
             M.lookup (fid, "DE") (mtRegionalizedCF tEmpty) `shouldBe` Just (2.0, "kg")
             M.lookup (fid, "DE") (mtRegionalizedCF tUnspec) `shouldBe` Just (7.0, "kg")
+            M.lookup (fid, "DE") (mtRegionalizedCF tUnspecBare) `shouldBe` Just (9.0, "kg")
 
         it "keeps CF when mcfCompartment is Nothing (no subcomp info)" $ do
             let fid = mkUuid 120

--- a/test/SharedCASCoverageSpec.hs
+++ b/test/SharedCASCoverageSpec.hs
@@ -271,6 +271,83 @@ uuidRegionalMethod =
         }
 
 -- ---------------------------------------------------------------------------
+-- Fixture: unspecified-subcompartment fallback (air emissions)
+-- ---------------------------------------------------------------------------
+
+mkAirFlow :: Integer -> Text -> Text -> BiosphereFlow
+mkAirFlow i name sub =
+    BiosphereFlow
+        { bfId = mkUUID i
+        , bfName = name
+        , bfUnitId = mkUUID 0
+        , bfSynonyms = M.empty
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfCompartment = Just (VT.Compartment "air" (if sub == "" then Nothing else Just sub))
+        }
+
+mkAirCF :: Text -> Text -> Double -> MethodCF
+mkAirCF name sub val =
+    MethodCF
+        { mcfFlowRef = mkUUID 999
+        , mcfFlowName = name
+        , mcfDirection = Output
+        , mcfValue = val
+        , mcfCompartment = Just (Compartment "air" sub "")
+        , mcfCAS = Nothing
+        , mcfUnit = "kg"
+        , mcfConsumerLocation = Nothing
+        }
+
+-- A radionuclide emitted to an uncovered subcompartment (the method has no CF
+-- for "low population density, long-term"), one to a covered subcompartment,
+-- and a toxicant emitted to "unspecified (long-term)" (which the method DOES
+-- cover, with a 0 factor).
+radonLongTerm, radonNonUrban, mercuryLongTerm :: BiosphereFlow
+radonLongTerm = mkAirFlow 11 "Radon-222" "low population density, long-term"
+radonNonUrban = mkAirFlow 12 "Radon-222" "non-urban air or from high stacks"
+mercuryLongTerm = mkAirFlow 13 "Mercury" "unspecified (long-term)"
+
+fallbackFlows :: [BiosphereFlow]
+fallbackFlows = [radonLongTerm, radonNonUrban, mercuryLongTerm]
+
+fallbackFlowDB :: M.Map UUID BiosphereFlow
+fallbackFlowDB = M.fromList [(bfId f, f) | f <- fallbackFlows]
+
+fallbackMethod :: Method
+fallbackMethod =
+    Method
+        { methodId = mkUUID 102
+        , methodName = "Air method"
+        , methodDescription = Nothing
+        , methodUnit = "kg"
+        , methodCategory = "Test"
+        , methodMethodology = Nothing
+        , methodFactors =
+            [ mkAirCF "Radon-222" "unspecified" 10
+            , mkAirCF "Radon-222" "non-urban air or from high stacks" 8
+            , mkAirCF "Mercury" "unspecified" 5
+            , mkAirCF "Mercury" "unspecified (long-term)" 0
+            ]
+        }
+
+fallbackCtx :: MapContext
+fallbackCtx =
+    MapContext
+        { mcBioFlowsByUUID = fallbackFlowDB
+        , mcBioFlowsByName = M.fromListWith (++) [(normalizeName (bfName f), [f]) | f <- fallbackFlows]
+        , mcBioFlowsByCAS = M.empty
+        , mcSynonymDB = emptySynonymDB
+        , mcActivities = M.empty
+        }
+
+buildFallbackTables :: IO MethodTables
+buildFallbackTables = do
+    mappings <- mapMethodFlows defaultMappers fallbackCtx fallbackMethod
+    let raw = buildMethodTables M.empty M.empty mappings
+    pure (fillBroadcastVector defaultUnitConfig M.empty fallbackFlowDB raw)
+
+-- ---------------------------------------------------------------------------
 -- Spec
 -- ---------------------------------------------------------------------------
 
@@ -335,3 +412,21 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
             -- table instead of clobbering the flow's universal value.
             M.lookup (bfId river) (mtUuidCF tables) `shouldBe` Just (5, "m3")
             M.lookup (bfId river, "IN") (mtRegionalizedCF tables) `shouldBe` Just (100, "m3")
+
+    describe "unspecified subcompartment is the medium-level fallback" $ do
+        it "an uncovered subcompartment falls back to the unspecified CF" $ do
+            -- Radon-222 emitted to "low population density, long-term" has no
+            -- exact CF; it picks up the unspecified factor (10) instead of 0.
+            tables <- buildFallbackTables
+            M.lookup (bfId radonLongTerm) (mtBroadcast tables) `shouldBe` Just 10
+
+        it "an exact subcompartment still wins over the fallback" $ do
+            tables <- buildFallbackTables
+            M.lookup (bfId radonNonUrban) (mtBroadcast tables) `shouldBe` Just 8
+
+        it "an explicit (long-term) factor takes precedence over the fallback" $ do
+            -- Mercury to "unspecified (long-term)" must resolve to its own 0
+            -- factor, not the (nonzero) unspecified fallback — so a method that
+            -- deliberately zeroes long-term emissions is honoured.
+            tables <- buildFallbackTables
+            M.lookup (bfId mercuryLongTerm) (mtBroadcast tables) `shouldBe` Just 0

--- a/test/SharedCASCoverageSpec.hs
+++ b/test/SharedCASCoverageSpec.hs
@@ -348,6 +348,44 @@ buildFallbackTables = do
     pure (fillBroadcastVector defaultUnitConfig M.empty fallbackFlowDB raw)
 
 -- ---------------------------------------------------------------------------
+-- Fixture: the CAS bridge broadcasts the unspecified value, not the niche max
+-- ---------------------------------------------------------------------------
+
+acrCAS :: Text
+acrCAS = "107-13-1"
+
+-- An ecoinvent flow reached only via CAS (its name matches no CF — the JRC
+-- method even misspells it), whose CFs diverge wildly by subcompartment:
+-- indoor air is 100x the unspecified value.
+acrFlow :: BiosphereFlow
+acrFlow = (mkAirFlow 21 "Acrylonitrile" "urban air close to ground"){bfCAS = Just acrCAS}
+
+acrMethod :: Method
+acrMethod =
+    Method
+        { methodId = mkUUID 103
+        , methodName = "Tox method"
+        , methodDescription = Nothing
+        , methodUnit = "kg"
+        , methodCategory = "Test"
+        , methodMethodology = Nothing
+        , methodFactors =
+            [ (mkAirCF "acryolonitrile" "indoor" 100){mcfCAS = Just acrCAS}
+            , (mkAirCF "acryolonitrile" "unspecified" 1){mcfCAS = Just acrCAS}
+            ]
+        }
+
+acrCtx :: MapContext
+acrCtx =
+    MapContext
+        { mcBioFlowsByUUID = M.fromList [(bfId acrFlow, acrFlow)]
+        , mcBioFlowsByName = M.empty
+        , mcBioFlowsByCAS = M.fromList [(acrCAS, [acrFlow])]
+        , mcSynonymDB = emptySynonymDB
+        , mcActivities = M.empty
+        }
+
+-- ---------------------------------------------------------------------------
 -- Spec
 -- ---------------------------------------------------------------------------
 
@@ -430,3 +468,16 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
             -- deliberately zeroes long-term emissions is honoured.
             tables <- buildFallbackTables
             M.lookup (bfId mercuryLongTerm) (mtBroadcast tables) `shouldBe` Just 0
+
+    describe "CAS bridge broadcasts the unspecified value, not the niche max" $ do
+        it "keeps the unspecified factor when subcompartment CFs diverge" $ do
+            mappings <- mapMethodFlows defaultMappers acrCtx acrMethod
+            let tables = buildMethodTables M.empty M.empty mappings
+            -- indoor air is 100x; the bridge must not broadcast it.
+            M.lookup (acrCAS, "air") (mtCasCF tables) `shouldBe` Just (1, "kg")
+
+        it "reaches the flow with the unspecified factor, not the indoor max" $ do
+            mappings <- mapMethodFlows defaultMappers acrCtx acrMethod
+            let raw = buildMethodTables M.empty M.empty mappings
+                tables = fillBroadcastVector defaultUnitConfig M.empty (mcBioFlowsByUUID acrCtx) raw
+            M.lookup (bfId acrFlow) (mtBroadcast tables) `shouldBe` Just 1

--- a/test/SharedCASCoverageSpec.hs
+++ b/test/SharedCASCoverageSpec.hs
@@ -385,6 +385,24 @@ acrCtx =
         , mcActivities = M.empty
         }
 
+-- Regionalized analogue of 'acrMethod': both CFs carry a location, so they
+-- land in 'mtRegionalCasCF' rather than 'mtCasCF'. Same divergence — indoor
+-- air is 100x the unspecified value — at one location.
+acrRegionalMethod :: Method
+acrRegionalMethod =
+    Method
+        { methodId = mkUUID 104
+        , methodName = "Tox method (regional)"
+        , methodDescription = Nothing
+        , methodUnit = "kg"
+        , methodCategory = "Test"
+        , methodMethodology = Nothing
+        , methodFactors =
+            [ atLocation "FR" ((mkAirCF "acryolonitrile" "indoor" 100){mcfCAS = Just acrCAS})
+            , atLocation "FR" ((mkAirCF "acryolonitrile" "unspecified" 1){mcfCAS = Just acrCAS})
+            ]
+        }
+
 -- ---------------------------------------------------------------------------
 -- Spec
 -- ---------------------------------------------------------------------------
@@ -481,3 +499,12 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
             let raw = buildMethodTables M.empty M.empty mappings
                 tables = fillBroadcastVector defaultUnitConfig M.empty (mcBioFlowsByUUID acrCtx) raw
             M.lookup (bfId acrFlow) (mtBroadcast tables) `shouldBe` Just 1
+
+        it "the regional bridge keeps the unspecified value per location too" $ do
+            -- FR carries both the indoor (100) and the unspecified (1) CF; the
+            -- regionalized bridge must keep the medium-level default, not the
+            -- niche max — same rule as the non-regional 'mtCasCF'.
+            mappings <- mapMethodFlows defaultMappers acrCtx acrRegionalMethod
+            let tables = buildMethodTables M.empty M.empty mappings
+            M.lookup (acrCAS, "air") (mtRegionalCasCF tables)
+                `shouldBe` Just (M.fromList [("FR", (1, "kg"))])


### PR DESCRIPTION
## Why

Two related subcompartment-matching gaps kept several EF v3.1 categories off 1.0 against ecoinvent's published scores:

1. **Uncovered subcompartments scored zero.** A flow emitted to a subcompartment the method doesn't characterize (e.g. a radionuclide to "low population density, long-term", which EF leaves blank) fell through to zero, while ecoinvent applies the substance's `unspecified` factor. → ionising radiation undercounted ~3x.
2. **The CAS bridge broadcast the niche max.** For a flow whose name matches no CF (the JRC method even misspells some, e.g. "acryolonitrile"), the bridge kept the *largest* same-CAS factor — the indoor-air value, ~100x outdoor — and leaked it onto every same-CAS flow. → human-tox organics overcounted ~4x.

## What

- **Unspecified-subcompartment fallback:** `mtFallbackCF` now also holds `unspecified` CFs, consulted only after the exact `(name, medium, subcompartment)` lookup. Long-term emissions still hit their explicit `(long-term)` factor (often zero) first, so toxicity stays correct.
- **CAS bridge broadcasts the `unspecified` value, not the max** — the medium-level default ecoinvent itself uses. Water/mineral resources (equal same-CAS CFs) are unaffected.
- **Particulate synonyms:** bridge ecoinvent's `Particulate Matter, < 2.5 um` / `> 2.5 um and < 10um` to EF's `particles (PM2.5)` / `particles (PM10)` (no CAS, so no auto-match) — both size fractions, which is what lifts the category from 0.25x to 1.00.

Hermetic tests cover all three (uncovered→unspecified, exact wins, `(long-term)` precedence, CAS-bridge unspecified-not-max).

## Result

Validated against ecoinvent's own published EF v3.1 scores over all 25,412 activities:

| Category | before | after |
|---|---|---|
| EF-particulate Matter | FAIL 0.25x | **PASS 1.00** |
| Ionising radiation | FAIL 0.37x | **PASS 1.00** |
| Human tox non-cancer_organics | FAIL 4.08x | **PASS 1.01** |
| Human tox non-cancer | WARN 1.20x | **PASS 1.01** |
| Ecotoxicity freshwater (+organics) | WARN | **PASS** |

Board moves to **21 PASS / 2 WARN / 2 FAIL**; no category regresses. Full suite green (1368 examples).

## Review follow-ups

Rebased onto `main` now that #136/#137 have merged. Two extra commits address review findings on the *regionalized* CF path, which had not been kept in sync with the non-regional fixes above:

- **`isUnspecifiedSub`** — the "is this the catch-all subcompartment" test was spelled out in three places that had drifted; the regionalized wildcard filter omitted bare `unspecified` (the spelling `compartments.csv` emits). Extracted one predicate so they can't disagree, fixing the filter.
- **Regional CAS bridge** — `mtRegionalCasCF` now broadcasts the unspecified default per location, like `mtCasCF`, instead of the largest magnitude.

Both are covered by hermetic unit tests. The regional change is conservative (it degrades to the old larger-magnitude behaviour when no unspecified CF exists), but it was **not** re-run through the full ecoinvent score board — worth confirming the regionalized methods (water, land, acidification, eutrophication) before merge.
