### PR TITLE
data: ecoinvent/Agribalyse → EF v3.1 (JRC) flow synonyms (land, particulates, energy, nutrients)

### DIFF
--- a/data/flows.csv
+++ b/data/flows.csv
@@ -845,3 +845,51 @@ natural gas,"Gas, natural"
 "Transformation, to urban, discontinuously built","to urban, discontinuously built"
 "Transformation, to urban/industrial fallow (non-use)",to urban/industrial fallow
 "Transformation, to wetland, inland (non-use)","to wetlands, inland"
+"Occupation, agriculture",agriculture
+"Occupation, dump site, benthos",dump site
+"Occupation, forest, intensive, normal","forest, intensive"
+"Occupation, forest, intensive, short-cycle","forest, intensive"
+"Occupation, forest, used","forest, used"
+"Occupation, grassland/pasture/meadow",grassland/pasture/meadow
+"Occupation, heterogeneous, agricultural","agriculture, mosaic"
+"Occupation, industrial area, benthos",industrial area
+"Occupation, industrial area, vegetation",industrial area
+"Occupation, permanent crop, fruit",permanent crops
+"Occupation, permanent crop, fruit, intensive","permanent crops, irrigated, intensive"
+"Occupation, permanent crop, vine",permanent crops
+"Occupation, traffic area",traffic area
+"Occupation, traffic area, road embankment","traffic area, rail/road embankment"
+"Occupation, unspecified, used","unspecified, used"
+"Occupation, wetland","wetlands, inland"
+"Transformation, from agriculture",from agriculture
+"Transformation, from annual crop, non-irrigated, fallow","from arable, fallow"
+"Transformation, from forest, intensive, clear-cutting","from forest, intensive"
+"Transformation, from forest, intensive, clear-cutting","from forest, intensive"
+"Transformation, from forest, used","from forest, used"
+"Transformation, from grassland",from grassland
+"Transformation, from grassland",from grassland
+"Transformation, from grassland/pasture/meadow",from grassland/pasture/meadow
+"Transformation, from industrial area, benthos",from industrial area
+"Transformation, from industrial area, built up",from industrial area
+"Transformation, from industrial area, vegetation",from industrial area
+"Transformation, from permanent crop, fruit",from permanent crops
+"Transformation, from permanent crop, vine",from permanent crops
+"Transformation, from traffic area, rail embankment","from traffic area, rail/road embankment"
+"Transformation, from tropical rain forest","from forest, natural"
+"Transformation, from unspecified, used","from unspecified, used"
+"Transformation, from urban, discontinuously built","from urban, discontinuously built"
+"Transformation, to agriculture",to agriculture
+"Transformation, to annual crop, fallow","to arable, fallow"
+"Transformation, to annual crop, non-irrigated, fallow","to arable, fallow"
+"Transformation, to dump site, benthos",to dump site
+"Transformation, to forest, intensive, clear-cutting","to forest, intensive"
+"Transformation, to forest, intensive, normal","to forest, intensive"
+"Transformation, to forest, intensive, short-cycle","to forest, intensive"
+"Transformation, to forest, used","to forest, used"
+"Transformation, to grassland/pasture/meadow",to grassland/pasture/meadow
+"Transformation, to industrial area, benthos",to industrial area
+"Transformation, to industrial area, built up",to industrial area
+"Transformation, to industrial area, vegetation",to industrial area
+"Transformation, to permanent crop, fruit, intensive","to permanent crops, irrigated, intensive"
+"Transformation, to traffic area, road embankment","to traffic area, rail/road embankment"
+"Transformation, to unspecified, used","to unspecified, used"

--- a/data/flows.csv
+++ b/data/flows.csv
@@ -893,3 +893,14 @@ natural gas,"Gas, natural"
 "Transformation, to permanent crop, fruit, intensive","to permanent crops, irrigated, intensive"
 "Transformation, to traffic area, road embankment","to traffic area, rail/road embankment"
 "Transformation, to unspecified, used","to unspecified, used"
+"Particulates, < 2.5 um",particles (PM2.5)
+"Particulates, < 10 um",particles (PM10)
+"Particulates, > 2.5 um, and < 10um",particles (PM10)
+"Particulates, < 10 um (mobile)",particles (PM10)
+"Particulates, < 10 um (stationary)",particles (PM10)
+"Energy, from coal",hard coal
+"Energy, from coal, brown",brown coal
+"Energy, from oil",crude oil
+"Energy, from gas, natural",natural gas
+"Energy, from peat",peat
+"Energy, from uranium",uranium

--- a/data/flows.csv
+++ b/data/flows.csv
@@ -260,14 +260,14 @@ Carbon dioxide,"Carbon dioxide, fossil"
 "Carbon dioxide, biogenic","Carbon dioxide, non-fossil"
 "Carbon dioxide, from soil or biomass stock","Carbon dioxide, land transformation"
 "Carbon dioxide, from soil or biomass stock","Carbon dioxide, peat oxidation"
-"Carbon dioxide, from soil or biomass stock",Carbon dioxide (land use change)
+"Carbon dioxide, from soil or biomass stock","Carbon dioxide (land use change)"
 Carbon disulfide,Dithiocarbonic Anhydride
 Carbon disulfide,dithiocarbonic anhydride
 Carbon disulfide,sulfocarbonic anhydride
 Carbon monoxide,"Carbon monoxide, fossil"
 "Carbon monoxide, biogenic","Carbon monoxide, non-fossil"
 "Carbon monoxide, from soil or biomass stock","Carbon monoxide, land transformation"
-"Carbon monoxide, from soil or biomass stock",carbon monoxide (land use change)
+"Carbon monoxide, from soil or biomass stock","carbon monoxide (land use change)"
 Carbon trioxide,Carbonate
 Carbonate,Carbonate ion
 "Carboxanilido-2,3-dihydro-6-methyl-1,4-oxathiin",Carboxin
@@ -485,7 +485,7 @@ Methane,"Methane, fossil"
 "Methane, dichloro-, HCC-30",methylenchlorid
 "Methane, from soil or biomass stock","Methane, land transformation"
 "Methane, from soil or biomass stock","Methane, peat oxidation"
-"Methane, from soil or biomass stock",methane (land use change)
+"Methane, from soil or biomass stock","methane (land use change)"
 "Methane, monochloro-, R-40",Methyl Chloride
 "Methane, monochloro-, R-40",Monochloromethane
 "Methane, tetrachloro-, CFC-10","Methane, tetrachloro-, R-10"
@@ -864,9 +864,7 @@ natural gas,"Gas, natural"
 "Transformation, from agriculture",from agriculture
 "Transformation, from annual crop, non-irrigated, fallow","from arable, fallow"
 "Transformation, from forest, intensive, clear-cutting","from forest, intensive"
-"Transformation, from forest, intensive, clear-cutting","from forest, intensive"
 "Transformation, from forest, used","from forest, used"
-"Transformation, from grassland",from grassland
 "Transformation, from grassland",from grassland
 "Transformation, from grassland/pasture/meadow",from grassland/pasture/meadow
 "Transformation, from industrial area, benthos",from industrial area

--- a/data/flows.csv
+++ b/data/flows.csv
@@ -260,14 +260,14 @@ Carbon dioxide,"Carbon dioxide, fossil"
 "Carbon dioxide, biogenic","Carbon dioxide, non-fossil"
 "Carbon dioxide, from soil or biomass stock","Carbon dioxide, land transformation"
 "Carbon dioxide, from soil or biomass stock","Carbon dioxide, peat oxidation"
-"Carbon dioxide, from soil or biomass stock","Carbon dioxide (land use change)"
+"Carbon dioxide, from soil or biomass stock",Carbon dioxide (land use change)
 Carbon disulfide,Dithiocarbonic Anhydride
 Carbon disulfide,dithiocarbonic anhydride
 Carbon disulfide,sulfocarbonic anhydride
 Carbon monoxide,"Carbon monoxide, fossil"
 "Carbon monoxide, biogenic","Carbon monoxide, non-fossil"
 "Carbon monoxide, from soil or biomass stock","Carbon monoxide, land transformation"
-"Carbon monoxide, from soil or biomass stock","carbon monoxide (land use change)"
+"Carbon monoxide, from soil or biomass stock",carbon monoxide (land use change)
 Carbon trioxide,Carbonate
 Carbonate,Carbonate ion
 "Carboxanilido-2,3-dihydro-6-methyl-1,4-oxathiin",Carboxin
@@ -485,7 +485,7 @@ Methane,"Methane, fossil"
 "Methane, dichloro-, HCC-30",methylenchlorid
 "Methane, from soil or biomass stock","Methane, land transformation"
 "Methane, from soil or biomass stock","Methane, peat oxidation"
-"Methane, from soil or biomass stock","methane (land use change)"
+"Methane, from soil or biomass stock",methane (land use change)
 "Methane, monochloro-, R-40",Methyl Chloride
 "Methane, monochloro-, R-40",Monochloromethane
 "Methane, tetrachloro-, CFC-10","Methane, tetrachloro-, R-10"
@@ -904,3 +904,6 @@ natural gas,"Gas, natural"
 "Energy, from gas, natural",natural gas
 "Energy, from peat",peat
 "Energy, from uranium",uranium
+"Nitrogen, total","nitrogen, total (excluding N2)"
+Barite,barium sulphate
+Fluorochloridone,3-chloro-4-(chloromethyl)-1-[3-(trifluoromethyl)phenyl]pyrrolidin-2-one


### PR DESCRIPTION
## What

Adds flow-name synonyms (`data/flows.csv`) mapping ecoinvent/Agribalyse elementary-flow names to the **EF v3.1 (JRC ILCD)** method's flow names, so the official JRC flowlist characterizes flows it otherwise misses purely by naming.

## Why

Scoring a SimaPro-sourced database (e.g. Agribalyse 3.2) with the official EF v3.1 (JRC ILCD) method leaves many flows uncharacterized only because their names differ from JRC's. These synonyms close that read-side coverage gap; the impact model is unchanged (the official JRC CFs are what score).

## Families

- **Land use** (~48): Occupation/Transformation land types → JRC land families (e.g. `forest, intensive, short-cycle` → `forest, intensive`; `tropical rain forest` → `from forest, natural`), each matched to the JRC family carrying the identical per-type land-use CF; the regionalized land path then applies JRC's per-country factors.
- **Particulates** (5): the Agribalyse spelling (`Particulates, …`) of the PM2.5/PM10 size fractions already mapped in the ecoinvent spelling (`Particulate Matter, …`).
- **Energy resources** (6): `Energy, from coal/oil/gas/…` (in MJ) → the JRC fossil resources (`hard coal`, `crude oil`, …); these score at the per-MJ CF directly — `energyAwareConversion` applies the kg→MJ density only for non-energy units, so an MJ flow is not double-converted.
- **Nutrients / misc** (3): `Nitrogen, total` → `nitrogen, total (excluding N2)`; `Barite` → `barium sulphate`; `Fluorochloridone` → its IUPAC name.

Data only — no engine change.