### PR TITLE
fix(synonym): strip /m3 and /Sm3 unit suffixes in normalizeName

### DIFF
--- a/src/SynonymDB.hs
+++ b/src/SynonymDB.hs
@@ -171,7 +171,7 @@ Normalization rules:
 - Strip leading/trailing whitespace
 - Collapse multiple spaces to single space
 - Strip ", in ground" suffix (ecoinvent resource naming)
-- Strip "/kg" suffix (SimaPro unit convention)
+- Strip a trailing SimaPro unit suffix ("/kg", "/m3", "/Sm3")
 - Remove punctuation: commas, parentheses, quotes
 -}
 normalizeName :: Text -> Text
@@ -183,8 +183,10 @@ normalizeName name =
         t2 = T.unwords $ T.words t1
         -- Strip ", in ground" suffix
         t3 = stripSuffix ", in ground" $ stripSuffix " in ground" t2
-        -- Strip "/kg" suffix
-        t4 = stripSuffix "/kg" t3
+        -- Strip a trailing SimaPro unit suffix (/kg, /m3, /Sm3). SimaPro encodes a
+        -- flow's unit in its name ("Gas, natural/m3"); dropping it lets the unit
+        -- variant share the registry node of the base resource.
+        t4 = foldr stripSuffix t3 ["/kg", "/m3", "/sm3"]
         -- Remove punctuation. Inlined char predicate: the old version used
         -- @T.filter (`notElem` (",()'\"" :: String))@ which forces 'T.filter'
         -- to traverse a 5-cons-cell @[Char]@ list per input character. With

--- a/test/SynonymDBSpec.hs
+++ b/test/SynonymDBSpec.hs
@@ -6,7 +6,7 @@ import qualified Data.Set as S
 import Data.Text (pack)
 import Test.Hspec
 
-import SynonymDB (buildFromPairs, getSynonyms, loadFromCSVFileWithCache, lookupSynonymGroup, oversizedClasses)
+import SynonymDB (buildFromPairs, getSynonyms, loadFromCSVFileWithCache, lookupSynonymGroup, normalizeName, oversizedClasses)
 
 spec :: Spec
 spec = do
@@ -41,3 +41,12 @@ spec = do
         it "stays silent when every class is within the bound" $
             oversizedClasses 10 (buildFromPairs [("alpha", "beta"), ("beta", "gamma")])
                 `shouldBe` []
+
+    describe "normalizeName" $ do
+        it "strips a trailing SimaPro unit suffix (/kg, /m3, /Sm3) so unit variants share a node" $ do
+            normalizeName "Gas, natural/m3" `shouldBe` "gas natural"
+            normalizeName "Gas, natural/Sm3" `shouldBe` "gas natural"
+            normalizeName "Coal, hard/kg" `shouldBe` "coal hard"
+
+        it "leaves a name without a unit suffix unchanged (modulo casing/punctuation)" $
+            normalizeName "Gas, natural" `shouldBe` "gas natural"


### PR DESCRIPTION
## What

`normalizeName` already strips a trailing `/kg` (SimaPro encodes a flow's unit in its name); this extends it to `/m3` and `/Sm3`.

## Why

A SimaPro volume-unit variant like `Gas, natural/m3` normalized to `gas natural/m3`, so it did **not** share the registry node of its base resource `Gas, natural` — it missed both the resource's CF and the energy-density bridge (`energyAwareConversion`), and stayed uncharacterized. Dropping the unit suffix (symmetric to the existing `/kg` rule) lets the variant resolve like its base.

Added `SynonymDBSpec` cases for `/kg`, `/m3`, `/Sm3`.