### PR TITLE
feat(synonym): single-source the unit-suffix list + warn on uncovered suffixes

### DIFF
--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -182,7 +182,7 @@ import qualified Search.BM25 as BM25
 import SharedSolver (SharedSolver, createSharedSolver)
 import qualified SharedSolver
 import SubstanceRegistry (CASNumber (..), KeyNormalizers (..), NormName (..), SubstanceEdge, casBindingsFromEdges, parseSubstanceEdges)
-import SynonymDB (SynonymDB (..), buildFromCSV, buildFromPairs, emptySynonymDB, loadFromCSVFileWithCache, mergeSynonymDBs, normalizeName, oversizedClasses, synonymCount)
+import SynonymDB (SynonymDB (..), buildFromCSV, buildFromPairs, emptySynonymDB, loadFromCSVFileWithCache, mergeSynonymDBs, normalizeName, oversizedClasses, synonymCount, uncoveredUnitSuffixes)
 import Types (
     Activity (..),
     AttributeFallback (..),
@@ -990,6 +990,26 @@ loadOneDatabase synonymDB unitConfig noCache otherIndexes loadedDbsVar indexedDb
                     <> " with synonyms, "
                     <> show (length pairs)
                     <> " pairs"
+            -- A biosphere flow whose name carries a "/unit" suffix that
+            -- 'normalizeName' does not strip silently misses its CF (the SimaPro
+            -- unit-in-name convention; e.g. a "/MJ" absent from 'unitSuffixes').
+            -- Surface it so the fix — add the unit to 'unitSuffixes' — is visible.
+            let uncoveredUnits =
+                    uncoveredUnitSuffixes
+                        (UnitConversion.isKnownUnit unitConfig)
+                        (map bfName (M.elems bioFlowDb))
+            forM_ (M.toList uncoveredUnits) $ \(unit, egs) ->
+                reportProgress Warning $
+                    "  [UNIT] "
+                        <> T.unpack (dcName dbConfig)
+                        <> ": flow-name suffix /"
+                        <> T.unpack unit
+                        <> " not stripped on "
+                        <> show (length egs)
+                        <> " flows (add \"/"
+                        <> T.unpack (T.toLower unit)
+                        <> "\" to unitSuffixes); e.g. "
+                        <> T.unpack (T.intercalate ", " (take 3 egs))
             autoCreateFlowSynonyms
                 manager
                 (dcName dbConfig)

--- a/src/SynonymDB.hs
+++ b/src/SynonymDB.hs
@@ -23,6 +23,10 @@ module SynonymDB (
     synonymCount,
     oversizedClasses,
 
+    -- * Unit suffixes
+    unitSuffixes,
+    uncoveredUnitSuffixes,
+
     -- * Re-exports
     SynonymDB (..),
     emptySynonymDB,
@@ -183,10 +187,8 @@ normalizeName name =
         t2 = T.unwords $ T.words t1
         -- Strip ", in ground" suffix
         t3 = stripSuffix ", in ground" $ stripSuffix " in ground" t2
-        -- Strip a trailing SimaPro unit suffix (/kg, /m3, /Sm3). SimaPro encodes a
-        -- flow's unit in its name ("Gas, natural/m3"); dropping it lets the unit
-        -- variant share the registry node of the base resource.
-        t4 = foldr stripSuffix t3 ["/kg", "/m3", "/sm3"]
+        -- Strip a trailing SimaPro unit suffix; see 'unitSuffixes'.
+        t4 = foldr stripSuffix t3 unitSuffixes
         -- Remove punctuation. Inlined char predicate: the old version used
         -- @T.filter (`notElem` (",()'\"" :: String))@ which forces 'T.filter'
         -- to traverse a 5-cons-cell @[Char]@ list per input character. With
@@ -205,6 +207,37 @@ normalizeName name =
         if suffix `T.isSuffixOf` txt
             then T.dropEnd (T.length suffix) txt
             else txt
+
+{- | Unit suffixes that 'normalizeName' strips. SimaPro bakes a flow's unit into
+its name (e.g. @"Gas, natural/m3"@); dropping the suffix lets a unit variant
+share the registry node — and thus the CF — of its base resource.
+
+MUST be lowercase: 'normalizeName' lowercases before it strips, so an uppercase
+entry would never fire. Extending this list is the fix when 'uncoveredUnitSuffixes'
+warns that a loaded database carries an un-stripped @/unit@ suffix.
+-}
+unitSuffixes :: [Text]
+unitSuffixes = ["/kg", "/m3", "/sm3"]
+
+{- | Flow names that will silently miss CF matching because they carry a trailing
+@"/unit"@ for a real unit 'unitSuffixes' does not strip. Grouped by the offending
+unit (each value lists example flow names) so a load-time warning is actionable —
+add @"/unit"@ to 'unitSuffixes'. Empty when coverage is complete.
+
+The unit test is supplied by the caller (@UnitConversion.isKnownUnit cfg@), so this
+module stays free of a unit-system dependency.
+-}
+uncoveredUnitSuffixes :: (Text -> Bool) -> [Text] -> M.Map Text [Text]
+uncoveredUnitSuffixes isUnit names =
+    M.fromListWith
+        (<>)
+        [ (seg, [name])
+        | name <- names
+        , let (prefix, seg) = T.breakOnEnd "/" name
+        , not (T.null prefix)
+        , isUnit seg
+        , ("/" <> T.toLower seg) `notElem` unitSuffixes
+        ]
 
 -- | Look up the synonym group ID for a flow name
 lookupSynonymGroup :: SynonymDB -> Text -> Maybe Int

--- a/test/SynonymDBSpec.hs
+++ b/test/SynonymDBSpec.hs
@@ -2,11 +2,12 @@
 
 module SynonymDBSpec (spec) where
 
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
-import Data.Text (pack)
+import Data.Text (Text, pack)
 import Test.Hspec
 
-import SynonymDB (buildFromPairs, getSynonyms, loadFromCSVFileWithCache, lookupSynonymGroup, normalizeName, oversizedClasses)
+import SynonymDB (buildFromPairs, getSynonyms, loadFromCSVFileWithCache, lookupSynonymGroup, normalizeName, oversizedClasses, uncoveredUnitSuffixes)
 
 spec :: Spec
 spec = do
@@ -50,3 +51,23 @@ spec = do
 
         it "leaves a name without a unit suffix unchanged (modulo casing/punctuation)" $
             normalizeName "Gas, natural" `shouldBe` "gas natural"
+
+    describe "uncoveredUnitSuffixes" $ do
+        -- A stand-in unit vocabulary; the real predicate is UnitConversion.isKnownUnit.
+        let knownUnit = (`elem` (["MJ", "kg", "m3", "Sm3", "ha"] :: [Text]))
+            grouped = M.map S.fromList . uncoveredUnitSuffixes knownUnit
+
+        it "flags a flow whose /unit suffix is a real unit not covered by unitSuffixes" $
+            grouped ["Electricity/MJ", "Heat/MJ", "Occupation, pasture/ha"]
+                `shouldBe` M.fromList
+                    [ ("MJ", S.fromList ["Electricity/MJ", "Heat/MJ"])
+                    , ("ha", S.fromList ["Occupation, pasture/ha"])
+                    ]
+
+        it "ignores suffixes already stripped by unitSuffixes (/kg, /m3, /Sm3, any case)" $
+            uncoveredUnitSuffixes knownUnit ["Gas, natural/m3", "Gas/Sm3", "Coal/kg"]
+                `shouldBe` M.empty
+
+        it "ignores a trailing slash that is not a known unit" $
+            uncoveredUnitSuffixes knownUnit ["cis/trans-isomer", "Carbon dioxide"]
+                `shouldBe` M.empty


### PR DESCRIPTION
## What

`normalizeName` strips SimaPro's unit-in-name suffixes (`/kg`, `/m3`, `/Sm3`) so a unit variant like `Gas, natural/m3` shares the registry node — and the CF — of its base resource `Gas, natural`. This:

1. Promotes the inline `["/kg","/m3","/sm3"]` literal to a top-level `unitSuffixes` constant, with the lowercase invariant documented (`normalizeName` lowercases before it strips, so an uppercase entry would never fire). One place to extend.
2. Adds `uncoveredUnitSuffixes` + a load-time `Warning`: a flow name ending in `/unit` for a real unit the list does **not** cover (e.g. `/MJ`, `/ha`) is reported once per database, grouped by the offending unit with example flows and the fix.

## Why

The suffix set is hand-maintained. Today, loading a database that uses a unit suffix we don't strip silently leaves those flows uncharacterized — exactly the kind of silent under-count the engine is meant to surface, not hide. The warning turns that into a visible, actionable signal ("add `/MJ` to `unitSuffixes`") without touching the hot `normalizeName` path: the check runs once at load, where the database's flows and the `UnitConfig` are already in scope, and the unit predicate is injected so `SynonymDB` keeps no unit-system dependency.

No behaviour change to characterization — the constant holds the same three suffixes as before.

## Tests

`SynonymDBSpec`: `uncoveredUnitSuffixes` flags an uncovered `/MJ`/`/ha`, ignores already-covered `/kg,/m3,/Sm3` (any case), and ignores a non-unit trailing slash. Full suite green (1445 examples, 0 failures).