### PR TITLE
feat(api): advertise wireVersion on /api/v1/version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
   on the database setup view (and in the load log) so you can verify the
   dependency is the release you intended rather than trust a cross-version match
   as exact.
+- `/api/v1/version` now reports a `wireVersion` integer. Clients read it at
+  connect time to confirm they speak this engine's JSON format, so a version
+  mismatch fails with a clear message instead of a confusing decode error.
 
 ## [0.7.0] - 2026-05-29
 

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1083,6 +1083,13 @@ withActivityAndMethod dbName collectionName processIdText methodIdText k = do
 getOpenApiSpec :: AppM Value
 getOpenApiSpec = return $ toJSON volcaOpenApi
 
+{- | Wire-format revision advertised on /api/v1/version. BUMP this whenever a
+breaking change to the JSON wire shape lands (field rename/removal, type
+narrowing, newly-required field). Clients compare it to decide compatibility.
+-}
+currentWireVersion :: Int
+currentWireVersion = 1
+
 getVersion :: AppM Value
 getVersion =
     return $
@@ -1091,6 +1098,7 @@ getVersion =
             , "gitHash" .= Version.gitHash
             , "gitTag" .= Version.gitTag
             , "buildTarget" .= Version.buildTarget
+            , "wireVersion" .= currentWireVersion
             ]
 
 getHosting :: AppM Value

--- a/test/RoutesSpec.hs
+++ b/test/RoutesSpec.hs
@@ -233,6 +233,19 @@ routeSpecs = do
                 Just (Object km) -> KM.member "version" km
                 _ -> False
 
+        it "GET /api/v1/version advertises an integer 'wireVersion'" $ \b -> do
+            -- wireVersion is the field clients read to detect a JSON wire-format
+            -- mismatch at connect time; a rename, removal, or retype silently
+            -- breaks that check, so assert both presence and that it decodes as
+            -- a JSON number rather than just 'body length > 0'.
+            resp <- doGet b "/api/v1/version"
+            statusCode (responseStatus resp) `shouldBe` 200
+            decode (responseBody resp) `shouldSatisfy` \case
+                Just (Object km) -> case KM.lookup "wireVersion" km of
+                    Just (Number _) -> True
+                    _ -> False
+                _ -> False
+
         it "GET /api/v1/openapi.json returns an OpenAPI 3 document with 'paths'" $ \b -> do
             -- The OpenAPI spec is served at /api/v1/openapi.json (not /openapi).
             -- We check the actual contract (openapi+paths keys), not the byte


### PR DESCRIPTION
## Why

The JSON wire shape changed with the `activity_name` / `product_name` rename, but nothing told a client at runtime whether an engine speaks the wire it expects — an older engine just produced an opaque decode failure.

## What

`/api/v1/version` now advertises an integer `wireVersion` (= 1, the first labelled wire). Clients read it at connect time to decide compatibility and fail with a clear message on a mismatch. Bump `currentWireVersion` on any future breaking wire change.

The companion client work (pyvolca consumes this field) is in a separate PR.

Verified: built the engine, ran the server, `curl /api/v1/version` → `…,"wireVersion":1}`.