### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.8.0] - 2026-06-24
 
 ### Added
 - A loaded database can be exported to any of the five supported formats —


### PR DESCRIPTION
Cuts the **v0.8.0** engine release — the first minor release since `v0.7.0`.

`volca.cabal` is already at `0.8.0`, so this PR only finalizes the changelog: rename `[Unreleased]` → `[0.8.0] - 2026-06-24`. The release pipeline's verify-tag job asserts the pushed tag equals `v` + the cabal version, so the dated section just needs to land before tagging.

After merge: tag `v0.8.0` on the merge commit → `release.yml` builds the 5-platform assets + `SHA256SUMS` and publishes the GH Release.

Headline scope since v0.7.0 (see CHANGELOG for the grouped list): full five-format database export + in-place edit (copy / delete-by-selection / relink), the `activity_name` / `product_name` split, partial-EcoSpold2 linking by `activityLinkId`, `wireVersion` on `/api/v1/version`, far broader EF 3.1 coverage, raw-bytes upload streaming, and the ecoinvent waste-treatment scoring fix.