### PR TITLE
fix(scoring): resolve scoring variables by method name, not category

### DIFF
--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -776,7 +776,7 @@ buildLCIABatchResultCached dbManager dbName collectionName db actPid activity co
                         , lrTopContributors = topContributors
                         }
     results <- traverse mkResultIO ctxs
-    let rawScoreMap = M.fromList [(lrCategory r, lrScore r) | r <- results]
+    let rawScoreMap = rawScoreMapByName results
     (scoringResults, scoringIndicators) <-
         computeAllScoringSets (mcScoringSets collection) rawScoreMap
     pure (mkLCIABatchResult results mNW nwSets scoringResults (mcScoringSets collection) scoringIndicators (Service.buildCutoffWaste db activity))
@@ -824,7 +824,7 @@ activityLCIABatchH dbName processIdText collectionName mSub = do
                 (\m -> computeCategoryResult dbManager dbName collectionName db sol activity 5 (M.lookup (methodId m) scoreMap) m)
                 methods
     let results = map (enrichWithNW dcLookup mNW) rawResults
-        rawScoreMap = M.fromList [(lrCategory r, lrScore r) | r <- rawResults]
+        rawScoreMap = rawScoreMapByName rawResults
     (scoringResults, scoringIndicators) <- liftIO $ computeAllScoringSets scoringSets rawScoreMap
     when (isNothing mSub) $
         liftIO $ do
@@ -2018,6 +2018,17 @@ lcaServer env = hoistServer lcaAPI (runApp env) handlers
             :<|> getStats
             :<|> getClassificationPresets
             :<|> getOpenApiSpec
+
+{- | Build the scoring input map (impact method name → raw score) from LCIA
+results. Keyed by method NAME, which is unique per collection — not by
+'lrCategory', which for ILCD methods is the coarse damage class (e.g. all four
+"Climate change-*" methods share category "Climate change"; the three freshwater
+ecotoxicity methods share "Aquatic eco-toxicity"). Keying by category collapses
+such methods and breaks single-score resolution ("Unknown variable: …"). For
+SimaPro-adapted methods name == category, so their scoring is unchanged.
+-}
+rawScoreMapByName :: [LCIAResult] -> M.Map Text Double
+rawScoreMapByName results = M.fromList [(lrMethodName r, lrScore r) | r <- results]
 
 {- | Evaluate every scoring set against the raw impact score map.
 Returns (setName → scoreName → value, setName → varName → ScoringIndicator).

--- a/test/ScoringKeySpec.hs
+++ b/test/ScoringKeySpec.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module ScoringKeySpec (spec) where
+
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.UUID as UUID
+import Test.Hspec
+
+import API.Routes (rawScoreMapByName)
+import API.Types (LCIAResult (..))
+
+-- | Minimal LCIAResult for keying tests (only name/category/score matter here).
+mkR :: Text -> Text -> Double -> LCIAResult
+mkR name category score =
+    LCIAResult
+        { lrMethodId = UUID.nil
+        , lrMethodName = name
+        , lrCategory = category
+        , lrDamageCategory = category
+        , lrScore = score
+        , lrUnit = ""
+        , lrNormalizedScore = Nothing
+        , lrWeightedScore = Nothing
+        , lrMappedFlows = 0
+        , lrFunctionalUnit = ""
+        , lrTopContributors = []
+        }
+
+spec :: Spec
+spec = describe "rawScoreMapByName" $ do
+    it "keys by method name, retaining methods that share a coarse category" $ do
+        -- Mirrors JRC ILCD EF 3.1: fossils and minerals both sit under the
+        -- "Abiotic resource depletion" damage category. Keying by category
+        -- would drop one; keying by name keeps both so single-score variables
+        -- (mapped to method names) resolve.
+        let results =
+                [ mkR "Climate change" "Climate change" 10
+                , mkR "Resource use, fossils" "Abiotic resource depletion" 5
+                , mkR "Resource use, minerals and metals" "Abiotic resource depletion" 3
+                ]
+            m = rawScoreMapByName results
+        M.lookup "Resource use, fossils" m `shouldBe` Just 5
+        M.lookup "Resource use, minerals and metals" m `shouldBe` Just 3
+        M.lookup "Climate change" m `shouldBe` Just 10
+        M.size m `shouldBe` 3
+
+    it "is identical to category-keying when name == category (SimaPro case)" $ do
+        let results =
+                [ mkR "Acidification" "Acidification" 2
+                , mkR "Water use" "Water use" 7
+                ]
+        rawScoreMapByName results
+            `shouldBe` M.fromList [("Acidification", 2), ("Water use", 7)]

--- a/volca.cabal
+++ b/volca.cabal
@@ -291,6 +291,7 @@ test-suite lca-tests
                      , AuthSpec
                      , CLISpec
                      , RoutesSpec
+                     , ScoringKeySpec
                      , NumericEdgesSpec
                      , AggregateSpec
                      , ConfigWriterSpec


### PR DESCRIPTION
## Problem
`[methods.scoring]` single scores (e.g. PEF) fail on **JRC ILCD** methods with `Unknown variable: <impact>`, while they work on SimaPro-adapted methods.

## Cause
The raw-score map passed to the formula evaluator is built keyed by **`methodCategory`** (`API/Routes.hs`, two sites). For ILCD methods `methodCategory` is the coarse ILCD damage class, which **collides**:
- 4× `Climate change-*` → `Climate change`
- 3× freshwater ecotoxicity → `Aquatic eco-toxicity`
- fossils + minerals → `Abiotic resource depletion`
- fresh + marine eutrophication → `Aquatic Eutrophication`

`M.fromList` keeps one score per key, so per-impact scoring variables (which name specific impacts) can't resolve.

## Fix
Key the map by **method name** (unique within a collection) via a `rawScoreMapByName` helper, used at both call sites. `methodCategory` is left untouched for damage-category grouping. For SimaPro-adapted methods `name == category`, so the map — and every existing single score — is byte-for-byte identical (no regression).

`ScoringKeySpec` covers the colliding-category case and the `name == category` equivalence.
