### PR TITLE
Release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.8.1] - 2026-06-24
+
+### Fixed
+- Aggregate single scores (e.g. a PEF score) now compute correctly on JRC ILCD
+  method collections such as EF 3.1. They previously failed with `Unknown
+  variable` whenever a collection held several methods sharing one coarse
+  damage category — for EF 3.1 the four climate-change methods, the freshwater
+  ecotoxicity methods, and the resource-depletion methods each collapsed
+  together, so their per-method scoring variables could not resolve.
+  SimaPro-adapted methods were never affected.
+
 ## [0.8.0] - 2026-06-24
 
 ### Added

--- a/volca.cabal
+++ b/volca.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                volca
-version:             0.8.0
+version:             0.8.1
 build-type:          Simple
 
 license:             Apache-2.0


### PR DESCRIPTION
Patch release. The only engine change since v0.8.0 is the #151 scoring fix:
aggregate single scores (e.g. PEF) failed with `Unknown variable` on JRC ILCD
method collections such as EF 3.1, because methods sharing a coarse damage
category collapsed in the scoring input map. #151 keys that map by method name,
so the per-method scoring variables resolve.

- Bump `volca.cabal` 0.8.0 → 0.8.1
- Add `## [0.8.1]` CHANGELOG section

#150 is also on main since v0.8.0 but is pyvolca-only (already shipped on its own
`pyvolca-v0.7.0` tag) and adds no engine surface, so this stays a patch, not a minor.