### PR TITLE
fix(lcia): correct EF-3.1 over-counting (flow units + synonym hub)

### DIFF
--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -57,7 +57,7 @@ import Data.Bifunctor (first)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as BL
-import Data.Char (chr, isAsciiUpper, ord, toUpper)
+import Data.Char (isAsciiUpper, ord, toUpper)
 import Data.List (find, findIndex, partition)
 import qualified Data.Map.Strict as M
 import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing, listToMaybe, mapMaybe, maybeToList)
@@ -68,6 +68,7 @@ import qualified Data.Text.Encoding.Error as TEE
 import qualified Data.Text.Read as TR
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
+import EcoSpold.Common (numericRefChar)
 import Progress (ProgressLevel (..), reportProgress)
 import SimaPro.Parser (
     generateFlowUUID,
@@ -643,10 +644,5 @@ decodeEntities t
         | e == "amp" = Just "&"
         | e == "quot" = Just "\""
         | e == "apos" = Just "'"
-        | Just hex <- T.stripPrefix "#x" e = charFrom TR.hexadecimal hex
-        | Just hex <- T.stripPrefix "#X" e = charFrom TR.hexadecimal hex
-        | Just dec <- T.stripPrefix "#" e = charFrom TR.decimal dec
+        | Just numBody <- T.stripPrefix "#" e = T.singleton <$> numericRefChar numBody
         | otherwise = Nothing
-    charFrom reader s = case reader s of
-        Right (n, rest) | T.null rest && n >= 0 && n <= 0x10FFFF -> Just (T.singleton (chr n))
-        _ -> Nothing

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -182,7 +182,7 @@ import qualified Search.BM25 as BM25
 import SharedSolver (SharedSolver, createSharedSolver)
 import qualified SharedSolver
 import SubstanceRegistry (CASNumber (..), KeyNormalizers (..), NormName (..), SubstanceEdge, casBindingsFromEdges, parseSubstanceEdges)
-import SynonymDB (SynonymDB (..), buildFromCSV, buildFromPairs, emptySynonymDB, loadFromCSVFileWithCache, mergeSynonymDBs, normalizeName, oversizedClasses, synonymCount, uncoveredUnitSuffixes)
+import SynonymDB (SynonymDB (..), buildFromCSV, buildFromPairs, emptySynonymDB, excludeOverFrequentSynonyms, loadFromCSVFileWithCache, mergeSynonymDBs, normalizeName, oversizedClasses, synonymCount, uncoveredUnitSuffixes)
 import Types (
     Activity (..),
     AttributeFallback (..),
@@ -3518,6 +3518,14 @@ removeUploadedRefData baseDir name = do
             Right () ->
                 reportProgress Info $ "Deleted: " <> uploadDir
 
+{- | A synonym carried by more distinct flows than this is a classification label
+or stop-word (e.g. @"organic"@), not a true synonym — 'excludeOverFrequentSynonyms'
+drops it. The bound sits in the gap between the class-label hubs (≥187 flows in
+EF 3.1) and the first genuine flow name used as a synonym (~17 flows).
+-}
+maxSynonymFlowFrequency :: Int
+maxSynonymFlowFrequency = 25
+
 {- | Auto-create flow synonyms from extracted pairs.
 Writes CSV to uploads/flow-synonyms/auto-{source}/data.csv,
 registers and auto-loads the synonym set.
@@ -3531,10 +3539,23 @@ autoCreateFlowSynonyms manager sourceName description pairs = do
     if alreadyLoaded
         then reportProgress Info $ "  [AUTO] " <> T.unpack slug <> ": already loaded (cached)"
         else do
+            let (keptPairs, excludedSyns) =
+                    excludeOverFrequentSynonyms maxSynonymFlowFrequency pairs
+            unless (null excludedSyns) $
+                reportProgress Info $
+                    "  [AUTO] "
+                        <> T.unpack slug
+                        <> ": excluded "
+                        <> show (length excludedSyns)
+                        <> " over-frequent synonym tokens (class labels/stop-words): "
+                        <> T.unpack
+                            ( T.intercalate ", " $
+                                map (\(tok, n) -> tok <> "(" <> T.pack (show n) <> ")") (take 8 excludedSyns)
+                            )
             let dir = "uploads/flow-synonyms" </> T.unpack slug
                 path = dir </> "data.csv"
             createDirectoryIfMissing True dir
-            BL.writeFile path (synonymPairsToCSV pairs)
+            BL.writeFile path (synonymPairsToCSV keptPairs)
             let rd =
                     RefDataConfig
                         { rdName = slug
@@ -3546,7 +3567,7 @@ autoCreateFlowSynonyms manager sourceName description pairs = do
                         }
             addFlowSynonyms manager rd
             -- Build SynonymDB directly from pairs (skip CSV round-trip)
-            let !synDB = buildFromPairs pairs
+            let !synDB = buildFromPairs keptPairs
             atomically $ modifyTVar' (dmLoadedFlowSyns manager) (M.insert slug synDB)
             -- Transitive closure has no degree cap, so a junk hub that fused
             -- unrelated substances would silently pollute the fan-out. Surface
@@ -3564,5 +3585,5 @@ autoCreateFlowSynonyms manager sourceName description pairs = do
                 "  [AUTO] "
                     <> T.unpack slug
                     <> ": "
-                    <> show (length pairs)
+                    <> show (length keptPairs)
                     <> " synonym pairs"

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -182,7 +182,7 @@ import qualified Search.BM25 as BM25
 import SharedSolver (SharedSolver, createSharedSolver)
 import qualified SharedSolver
 import SubstanceRegistry (CASNumber (..), KeyNormalizers (..), NormName (..), SubstanceEdge, casBindingsFromEdges, parseSubstanceEdges)
-import SynonymDB (SynonymDB (..), buildFromCSV, buildFromPairs, emptySynonymDB, excludeOverFrequentSynonyms, loadFromCSVFileWithCache, mergeSynonymDBs, normalizeName, oversizedClasses, synonymCount, uncoveredUnitSuffixes)
+import SynonymDB (SynonymDB (..), buildFromCSV, buildFromPairs, emptySynonymDB, excludeJunkSynonyms, excludeOverFrequentSynonyms, loadFromCSVFileWithCache, mergeSynonymDBs, normalizeName, oversizedClasses, synonymCount, uncoveredUnitSuffixes)
 import Types (
     Activity (..),
     AttributeFallback (..),
@@ -3539,8 +3539,17 @@ autoCreateFlowSynonyms manager sourceName description pairs = do
     if alreadyLoaded
         then reportProgress Info $ "  [AUTO] " <> T.unpack slug <> ": already loaded (cached)"
         else do
-            let (keptPairs, excludedSyns) =
-                    excludeOverFrequentSynonyms maxSynonymFlowFrequency pairs
+            let (nonJunkPairs, junkTokens) = excludeJunkSynonyms pairs
+                (keptPairs, excludedSyns) =
+                    excludeOverFrequentSynonyms maxSynonymFlowFrequency nonJunkPairs
+            unless (null junkTokens) $
+                reportProgress Info $
+                    "  [AUTO] "
+                        <> T.unpack slug
+                        <> ": dropped "
+                        <> show (length junkTokens)
+                        <> " placeholder/non-substance synonym tokens: "
+                        <> T.unpack (T.intercalate ", " (take 8 junkTokens))
             unless (null excludedSyns) $
                 reportProgress Info $
                     "  [AUTO] "

--- a/src/EcoSpold/Common.hs
+++ b/src/EcoSpold/Common.hs
@@ -34,21 +34,24 @@ attribute values (e.g. @generalComment="text&#10;"@) and the @&#039;@/@&#034;@
 apostrophe/quote refs that otherwise truncate chemical-name synonyms when the
 ILCD synonym text is split on @;@.
 
-@&amp;@ is resolved LAST (leftmost in the composition runs last), the exact
-inverse of the writers escaping @&@ FIRST. Resolving it first would turn an
-escaped literal @"&lt;"@ (written as @"&amp;lt;"@) back into @"<"@ instead of
-@"&lt;"@ — a silent round-trip corruption for entity-like text. Numeric refs run
-first (rightmost) for the same reason: a literal @&#039;@ written @&amp;#039;@
-survives the numeric pass, and only the final @&amp;@ step unescapes it.
+Order is load-bearing. The named entities resolve before @&amp;@, so an escaped
+literal @"&lt;"@ (written @"&amp;lt;"@) round-trips to @"&lt;"@ rather than @"<"@
+— the inverse of writers escaping @&@ first. Numeric refs resolve LAST, after
+@&amp;@: the ILCD flow data double-encodes apostrophes/quotes as @&amp;#039;@, so
+the @&amp;@ step must first expose the @&#039;@ for the numeric pass to turn it
+into @'@. Run earlier it sees no @&#@, @&amp;@ then leaves a bare @&#039;@, and
+the @;@-split truncates the synonym into junk. The trade: a literal @&#039;@-as-
+text (were it written @&amp;#039;@) decodes instead of surviving — the flow data
+carries no such literals, only double-encoded characters.
 -}
 decodeXmlEntities :: Text -> Text
 decodeXmlEntities =
-    T.replace "&amp;" "&"
+    decodeNumericRefs
+        . T.replace "&amp;" "&"
         . T.replace "&lt;" "<"
         . T.replace "&gt;" ">"
         . T.replace "&quot;" "\""
         . T.replace "&apos;" "'"
-        . decodeNumericRefs
 
 {- | Decode XML numeric character references — decimal @&#NNN;@ and hex
 @&#xHH;@ — to their characters. A malformed or out-of-range reference is left

--- a/src/EcoSpold/Common.hs
+++ b/src/EcoSpold/Common.hs
@@ -15,6 +15,7 @@ module EcoSpold.Common (
 
 import Amount (readAmount)
 import qualified Data.ByteString as BS
+import Data.Char (chr)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -26,17 +27,20 @@ import Numeric (showFFloat)
 bsToText :: BS.ByteString -> Text
 bsToText = decodeXmlEntities . TE.decodeUtf8
 
-{- | Decode common XML entities that Xeno doesn't decode
-Xeno is a fast SAX parser but doesn't handle entity references.
-We also decode the two numeric character references (line feed and
-carriage return) that frequently appear inside attribute values in
-EcoSpold exports (e.g. `generalComment="text&#10;"`).
--}
+{- | Decode the XML entities Xeno (a fast SAX parser) leaves intact: the five
+named entities plus any numeric character reference via 'decodeNumericRefs'.
+The numeric pass subsumes the line-feed/carriage-return refs in EcoSpold
+attribute values (e.g. @generalComment="text&#10;"@) and the @&#039;@/@&#034;@
+apostrophe/quote refs that otherwise truncate chemical-name synonyms when the
+ILCD synonym text is split on @;@.
 
--- @&amp;@ is resolved LAST (leftmost in the composition runs last), the exact
--- inverse of the writers escaping @&@ FIRST. Resolving it first would turn an
--- escaped literal @"&lt;"@ (written as @"&amp;lt;"@) back into @"<"@ instead of
--- @"&lt;"@ — a silent round-trip corruption for entity-like text.
+@&amp;@ is resolved LAST (leftmost in the composition runs last), the exact
+inverse of the writers escaping @&@ FIRST. Resolving it first would turn an
+escaped literal @"&lt;"@ (written as @"&amp;lt;"@) back into @"<"@ instead of
+@"&lt;"@ — a silent round-trip corruption for entity-like text. Numeric refs run
+first (rightmost) for the same reason: a literal @&#039;@ written @&amp;#039;@
+survives the numeric pass, and only the final @&amp;@ step unescapes it.
+-}
 decodeXmlEntities :: Text -> Text
 decodeXmlEntities =
     T.replace "&amp;" "&"
@@ -44,8 +48,36 @@ decodeXmlEntities =
         . T.replace "&gt;" ">"
         . T.replace "&quot;" "\""
         . T.replace "&apos;" "'"
-        . T.replace "&#10;" "\n"
-        . T.replace "&#13;" "\r"
+        . decodeNumericRefs
+
+{- | Decode XML numeric character references — decimal @&#NNN;@ and hex
+@&#xHH;@ — to their characters. A malformed or out-of-range reference is left
+verbatim rather than crashing (no partial 'chr' on bad input); 'Integer' parsing
+avoids overflow on absurdly long digit runs.
+-}
+decodeNumericRefs :: Text -> Text
+decodeNumericRefs t =
+    case T.breakOn "&#" t of
+        (before, rest)
+            | T.null rest -> before
+            | otherwise ->
+                let (body, semi) = T.span (/= ';') (T.drop 2 rest)
+                 in case (refChar body, T.null semi) of
+                        (Just c, False) ->
+                            before <> T.singleton c <> decodeNumericRefs (T.drop 1 semi)
+                        _ ->
+                            before <> "&#" <> decodeNumericRefs (T.drop 2 rest)
+  where
+    refChar :: Text -> Maybe Char
+    refChar body = case T.uncons body of
+        Just (x, hexits)
+            | x == 'x' || x == 'X' -> readRef TR.hexadecimal hexits
+        _ -> readRef TR.decimal body
+    readRef :: TR.Reader Integer -> Text -> Maybe Char
+    readRef reader digits = case reader digits of
+        Right (n, leftover)
+            | T.null leftover, n >= 0, n <= 0x10FFFF -> Just (chr (fromInteger n))
+        _ -> Nothing
 
 -- | ByteString to Double conversion (strict - errors on parse failure)
 bsToDouble :: BS.ByteString -> Double

--- a/src/EcoSpold/Common.hs
+++ b/src/EcoSpold/Common.hs
@@ -5,6 +5,7 @@ module EcoSpold.Common (
     bsToText,
     decodeXmlEntities,
     decodeXmlEntitiesFull,
+    numericRefChar,
     bsToDouble,
     bsToInt,
     bsToIntMaybe,
@@ -28,49 +29,51 @@ import Numeric (showFFloat)
 bsToText :: BS.ByteString -> Text
 bsToText = decodeXmlEntities . TE.decodeUtf8
 
-{- | Decode the XML entities Xeno (a fast SAX parser) leaves intact: the five
-named entities plus any numeric character reference via 'decodeNumericRefs'.
-The numeric pass subsumes the line-feed/carriage-return refs in EcoSpold
-attribute values (e.g. @generalComment="text&#10;"@) and the @&#039;@/@&#034;@
-apostrophe/quote refs that otherwise truncate chemical-name synonyms when the
-ILCD synonym text is split on @;@.
+{- | Decode the common XML entities Xeno (a fast SAX parser) leaves intact: the
+five named entities plus the line-feed/carriage-return numeric refs that appear
+inside EcoSpold attribute values (e.g. @generalComment="text&#10;"@).
 
-Order is load-bearing. The named entities resolve before @&amp;@, so an escaped
-literal @"&lt;"@ (written @"&amp;lt;"@) round-trips to @"&lt;"@ rather than @"<"@
-— the inverse of writers escaping @&@ first. Numeric refs resolve LAST, after
-@&amp;@: the ILCD flow data double-encodes apostrophes/quotes as @&amp;#039;@, so
-the @&amp;@ step must first expose the @&#039;@ for the numeric pass to turn it
-into @'@. Run earlier it sees no @&#@, @&amp;@ then leaves a bare @&#039;@, and
-the @;@-split truncates the synonym into junk. The trade: a literal @&#039;@-as-
-text (were it written @&amp;#039;@) decodes instead of surviving — the flow data
-carries no such literals, only double-encoded characters.
+Deliberately limited to those two numeric refs. This runs on the whole 'bsToText'
+read path, so decoding arbitrary @&#NNN;@ here would collapse a double-encoded
+literal @&amp;#NNN;@ to a control character instead of round-tripping it to the
+literal @&#NNN;@. Full numeric decoding lives in 'decodeXmlEntitiesFull', applied
+only where the text is afterwards split on @;@ (ILCD synonyms).
 -}
+
+-- @&amp;@ is resolved LAST (leftmost in the composition runs last), the exact
+-- inverse of the writers escaping @&@ FIRST. Resolving it first would turn an
+-- escaped literal @"&lt;"@ (written as @"&amp;lt;"@) back into @"<"@ instead of
+-- @"&lt;"@ — a silent round-trip corruption for entity-like text.
 decodeXmlEntities :: Text -> Text
 decodeXmlEntities =
-    decodeNumericRefs
-        . T.replace "&amp;" "&"
+    T.replace "&amp;" "&"
         . T.replace "&lt;" "<"
         . T.replace "&gt;" ">"
         . T.replace "&quot;" "\""
         . T.replace "&apos;" "'"
+        . T.replace "&#10;" "\n"
+        . T.replace "&#13;" "\r"
 
-{- | Fully decode XML entities, iterating 'decodeXmlEntities' to a fixed point.
-The ILCD flow data double-encodes entities (@&amp;#039;@, @&amp;lt;@), so a single
-pass leaves a half-decoded @&#039;@ / @&lt;@ behind; repeating until stable resolves
-it to the character. Use this only on free text that is afterwards split on @;@
-(ILCD synonyms), where a surviving entity's own @;@ would otherwise be taken for a
-separator. Not for the general read path: it collapses an escaped literal that the
-round-trip-safe 'decodeXmlEntities' deliberately preserves.
+{- | Fully decode XML entities, including arbitrary numeric character references,
+iterating to a fixed point. The ILCD flow data double-encodes entities
+(@&amp;#039;@, @&amp;lt;@): one 'decodeXmlEntities' pass exposes the inner
+@&#039;@ / @&lt;@, 'decodeNumericRefs' (composed in here, NOT on the general read
+path) resolves @&#039;@ to its character, and repeating until stable finishes the
+named half. Use this only on free text afterwards split on @;@ (ILCD synonyms),
+where a surviving entity's own @;@ would be taken for a separator — not on the
+general read path, where it would collapse an escaped literal that
+'decodeXmlEntities' deliberately preserves.
 -}
 decodeXmlEntitiesFull :: Text -> Text
-decodeXmlEntitiesFull t =
-    let t' = decodeXmlEntities t
-     in if t' == t then t else decodeXmlEntitiesFull t'
+decodeXmlEntitiesFull = go
+  where
+    go t =
+        let t' = decodeNumericRefs (decodeXmlEntities t)
+         in if t' == t then t else go t'
 
-{- | Decode XML numeric character references — decimal @&#NNN;@ and hex
-@&#xHH;@ — to their characters. A malformed or out-of-range reference is left
-verbatim rather than crashing (no partial 'chr' on bad input); 'Integer' parsing
-avoids overflow on absurdly long digit runs.
+{- | Decode every XML numeric character reference in a text — decimal @&#NNN;@
+and hex @&#xHH;@ — to its character, via 'numericRefChar'. A malformed or
+out-of-range reference is left verbatim rather than crashing.
 -}
 decodeNumericRefs :: Text -> Text
 decodeNumericRefs t =
@@ -79,17 +82,24 @@ decodeNumericRefs t =
             | T.null rest -> before
             | otherwise ->
                 let (body, semi) = T.span (/= ';') (T.drop 2 rest)
-                 in case (refChar body, T.null semi) of
+                 in case (numericRefChar body, T.null semi) of
                         (Just c, False) ->
                             before <> T.singleton c <> decodeNumericRefs (T.drop 1 semi)
                         _ ->
                             before <> "&#" <> decodeNumericRefs (T.drop 2 rest)
+
+{- | Decode the body of a single XML numeric character reference — the text
+between @&#@ and @;@ — to its character. Decimal by default, hexadecimal when
+prefixed @x@/@X@. 'Nothing' on a malformed or out-of-range value (no partial
+'chr' on bad input); 'Integer' parsing avoids overflow on absurdly long digit
+runs. Shared with "BrightwayExcel.Parser".
+-}
+numericRefChar :: Text -> Maybe Char
+numericRefChar body = case T.uncons body of
+    Just (x, hexits)
+        | x == 'x' || x == 'X' -> readRef TR.hexadecimal hexits
+    _ -> readRef TR.decimal body
   where
-    refChar :: Text -> Maybe Char
-    refChar body = case T.uncons body of
-        Just (x, hexits)
-            | x == 'x' || x == 'X' -> readRef TR.hexadecimal hexits
-        _ -> readRef TR.decimal body
     readRef :: TR.Reader Integer -> Text -> Maybe Char
     readRef reader digits = case reader digits of
         Right (n, leftover)

--- a/src/EcoSpold/Common.hs
+++ b/src/EcoSpold/Common.hs
@@ -4,6 +4,7 @@
 module EcoSpold.Common (
     bsToText,
     decodeXmlEntities,
+    decodeXmlEntitiesFull,
     bsToDouble,
     bsToInt,
     bsToIntMaybe,
@@ -52,6 +53,19 @@ decodeXmlEntities =
         . T.replace "&gt;" ">"
         . T.replace "&quot;" "\""
         . T.replace "&apos;" "'"
+
+{- | Fully decode XML entities, iterating 'decodeXmlEntities' to a fixed point.
+The ILCD flow data double-encodes entities (@&amp;#039;@, @&amp;lt;@), so a single
+pass leaves a half-decoded @&#039;@ / @&lt;@ behind; repeating until stable resolves
+it to the character. Use this only on free text that is afterwards split on @;@
+(ILCD synonyms), where a surviving entity's own @;@ would otherwise be taken for a
+separator. Not for the general read path: it collapses an escaped literal that the
+round-trip-safe 'decodeXmlEntities' deliberately preserves.
+-}
+decodeXmlEntitiesFull :: Text -> Text
+decodeXmlEntitiesFull t =
+    let t' = decodeXmlEntities t
+     in if t' == t then t else decodeXmlEntitiesFull t'
 
 {- | Decode XML numeric character references — decimal @&#NNN;@ and hex
 @&#xHH;@ — to their characters. A malformed or out-of-range reference is left

--- a/src/Method/FlowResolver.hs
+++ b/src/Method/FlowResolver.hs
@@ -178,16 +178,17 @@ initialFlowState = FlowParseState "" "" "" [] [] [] False [] False False "" 0 (-
 
 {- | Split an ILCD @<synonyms>@ blob into individual names. The EF flow data packs
 several names into one element separated by @;@, double-encodes entities
-(@&amp;#039;@, @&amp;lt;@), and sometimes glues two names together with the literal
-label @"othernames"@ and no separator. Fully decode first ('decodeXmlEntitiesFull')
-so an entity's own @;@ is not mistaken for a separator, then split on @;@ and on the
-@"othernames"@ pseudo-delimiter.
+(@&amp;#039;@, @&amp;lt;@), and sometimes glues two names with the spaced literal
+label @" othernames "@ in place of a @;@. Fully decode first
+('decodeXmlEntitiesFull') so an entity's own @;@ is not mistaken for a separator,
+then split on @;@ and on the word-bounded @" othernames "@ pseudo-delimiter — the
+surrounding spaces keep a name that merely contains the substring intact.
 -}
 splitIlcdSynonyms :: Text -> [Text]
 splitIlcdSynonyms =
     filter (not . T.null)
         . map T.strip
-        . concatMap (T.splitOn "othernames")
+        . concatMap (T.splitOn " othernames ")
         . T.splitOn ";"
         . decodeXmlEntitiesFull
 

--- a/src/Method/FlowResolver.hs
+++ b/src/Method/FlowResolver.hs
@@ -22,6 +22,7 @@ module Method.FlowResolver (
 
     -- * Pure helpers (exported for testing)
     parseCompartment,
+    splitIlcdSynonyms,
 ) where
 
 import qualified Codec.Compression.Zstd as Zstd
@@ -43,7 +44,7 @@ import System.Directory (doesDirectoryExist, doesFileExist, getModificationTime,
 import System.FilePath (takeExtension, (</>))
 import qualified Xeno.SAX as X
 
-import EcoSpold.Common (bsToText, distributeFiles, isElement)
+import EcoSpold.Common (bsToText, decodeXmlEntitiesFull, distributeFiles, isElement)
 import EcoSpold.Parser2 (normalizeCAS)
 import Method.Types (Compartment (..))
 import Progress (ProgressLevel (..), reportProgress)
@@ -175,6 +176,18 @@ data FlowParseState = FlowParseState
 initialFlowState :: FlowParseState
 initialFlowState = FlowParseState "" "" "" [] [] [] False [] False False "" 0 (-1) Nothing False
 
+{- | Split an ILCD @<synonyms>@ blob into individual names. The EF flow data packs
+several names into one element separated by @;@ and double-encodes entities
+(@&amp;#039;@, @&amp;lt;@). Fully decode first ('decodeXmlEntitiesFull') so an
+entity's own @;@ is not mistaken for a separator, then split on @;@.
+-}
+splitIlcdSynonyms :: Text -> [Text]
+splitIlcdSynonyms =
+    filter (not . T.null)
+        . map T.strip
+        . T.splitOn ";"
+        . decodeXmlEntitiesFull
+
 -- | Parse a single ILCD flow XML from bytes
 parseFlowXML :: BS.ByteString -> Maybe (UUID, ILCDFlowInfo)
 parseFlowXML bytes =
@@ -246,7 +259,7 @@ parseFlowXML bytes =
         | isElement tag "synonyms" =
             let !syns =
                     if fpsLangIsEn s
-                        then filter (not . T.null) $ map T.strip $ T.splitOn ";" (accum s)
+                        then splitIlcdSynonyms (accum s)
                         else []
              in s
                     { fpsPath = dropPath s

--- a/src/Method/FlowResolver.hs
+++ b/src/Method/FlowResolver.hs
@@ -177,14 +177,17 @@ initialFlowState :: FlowParseState
 initialFlowState = FlowParseState "" "" "" [] [] [] False [] False False "" 0 (-1) Nothing False
 
 {- | Split an ILCD @<synonyms>@ blob into individual names. The EF flow data packs
-several names into one element separated by @;@ and double-encodes entities
-(@&amp;#039;@, @&amp;lt;@). Fully decode first ('decodeXmlEntitiesFull') so an
-entity's own @;@ is not mistaken for a separator, then split on @;@.
+several names into one element separated by @;@, double-encodes entities
+(@&amp;#039;@, @&amp;lt;@), and sometimes glues two names together with the literal
+label @"othernames"@ and no separator. Fully decode first ('decodeXmlEntitiesFull')
+so an entity's own @;@ is not mistaken for a separator, then split on @;@ and on the
+@"othernames"@ pseudo-delimiter.
 -}
 splitIlcdSynonyms :: Text -> [Text]
 splitIlcdSynonyms =
     filter (not . T.null)
         . map T.strip
+        . concatMap (T.splitOn "othernames")
         . T.splitOn ";"
         . decodeXmlEntitiesFull
 

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -589,26 +589,28 @@ expandSynonymMappings ::
 expandSynonymMappings synDB flowsByName mappings =
     mappings ++ concatMap expand mappings
   where
-    -- One-shot inverse index: normalized name → set of direct partners
-    -- (union of all groups containing the name, without recursing). Stays
-    -- inside 'SynonymDB''s star-topology semantics — no chained
-    -- inferences across hubs — but does see every direct pair, which
-    -- 'lookupSynonymGroup' alone misses when many pairs converge on the
-    -- same hub name and @M.fromList@ keeps only the last-inserted group.
-    directPeers :: M.Map Text (S.Set Text)
-    directPeers =
-        M.fromListWith
-            S.union
-            [ (normalizeName m, S.fromList (map normalizeName members))
-            | members <- M.elems (synIdToNames synDB)
-            , m <- members
-            ]
+    -- De-fan-out (M): restrict the synonym relation to USED flow names — the
+    -- DB's own flow-name index ∪ this method's CF names — then re-close on that
+    -- induced subgraph. Generic source-synonym tokens that are not flow names
+    -- (e.g. @organic@, listed on tens of thousands of ILCD flows) drop out, so
+    -- they stop fusing unrelated substances into one giant junk-hub class. The
+    -- global closure has already merged such a hub and cannot be re-split, so we
+    -- re-close from 'synEdges' (the original pairs) against the used set here.
+    used :: S.Set Text
+    used =
+        foldr
+            (S.insert . normalizeName . mcfFlowName . fst)
+            (S.fromList (M.keys flowsByName))
+            mappings
+
+    inducedDB :: SynonymDB
+    inducedDB =
+        buildFromPairs [e | e@(a, b) <- synEdges synDB, S.member a used, S.member b used]
 
     expand (cf, _) =
-        let cfName = normalizeName (mcfFlowName cf)
-            peers = M.findWithDefault S.empty cfName directPeers
+        let peers = fromMaybe [] (getSynonyms inducedDB =<< lookupSynonymGroup inducedDB (mcfFlowName cf))
          in [ (cf, Just (flow, BySynonym))
-            | syn <- S.toList peers
+            | syn <- peers
             , flow <- M.findWithDefault [] syn flowsByName
             ]
 

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -102,7 +102,7 @@ import qualified SubstanceRegistry as SR
 import SynonymDB
 import Types (Activity (..), BioFlowDB, BiosphereFlow (..), Database (..), ProcessId, SparseTriple (..), Unit (..), UnitDB)
 import qualified Types as VT
-import UnitConversion (UnitConfig, UnitDef (..), convertUnit, isKnownUnit, lookupUnitDef, normalizeUnit)
+import UnitConversion (UnitConfig, UnitDef (..), convertUnit, isKnownUnit, lookupUnitDef, normalizeToCanonical, normalizeUnit)
 
 -- | Matching strategy used to find a flow
 data MatchStrategy
@@ -896,23 +896,28 @@ buildMethodTables cmap energyDensities mappings =
         Just (flow, ByProxy) -> bfName flow
         _ -> mcfFlowName cf
 
-{- | Convert @qty@ from @flowUnit@ to @cfUnit@ for characterization.
+{- | Convert the inventory @qty@ (in @flowUnit@) to the basis the CF value
+expects, for characterization.
 
-Bypass cases (returns @qty@ unchanged):
-  * Units match by name, or either side has no unit metadata.
-  * Either unit is unknown to the 'UnitConfig' (e.g. LCIA result expressions
-    like "kg CO2 eq"). The CF author already chose values consistent with
-    their declared unit; we trust them rather than penalize.
-
-Hard fail (returns @0@): both units are known to the 'UnitConfig' but
-dimensionally incompatible (e.g. flow in @m@, CF in @kg@). Silently using
-@qty@ here would inject wrong-dimension data into the score; we refuse.
+  * Units match, or the flow carries no unit → @qty@ unchanged.
+  * Both units known to the 'UnitConfig' → ordinary same-dimension conversion;
+    a dimensional mismatch (flow @m@, CF @kg@) hard-fails to @0@ rather than
+    injecting wrong-dimension data into the score.
+  * The CF unit is a result expression unknown to the 'UnitConfig' (e.g.
+    @"kg CO2 eq"@ — the common ILCD/EF case, where 'mcfUnit' carries the impact
+    unit, not the flow's reference unit) → the CF value is defined per the
+    flow's canonical base unit, so we normalize @qty@ to that base unit
+    ('normalizeToCanonical'). A flow already in its base unit (kg) is left as
+    is; a flow in @g@/@mg@ is scaled to kg. Without this, grams would be
+    characterized as if they were kilograms (a ×1000 / ×1e6 over-count).
+  * The flow unit itself is unknown → @qty@ unchanged (no base to normalize to).
 -}
 convertForCharacterization :: UnitConfig -> Text -> Text -> Double -> Double
 convertForCharacterization cfg flowUnit cfUnit qty
     | flowUnit == cfUnit || T.null cfUnit || T.null flowUnit = qty
-    | not (isKnownUnit cfg flowUnit) || not (isKnownUnit cfg cfUnit) = qty
-    | otherwise = fromMaybe 0 (convertUnit cfg flowUnit cfUnit qty)
+    | not (isKnownUnit cfg flowUnit) = qty
+    | isKnownUnit cfg cfUnit = fromMaybe 0 (convertUnit cfg flowUnit cfUnit qty)
+    | otherwise = maybe qty snd (normalizeToCanonical cfg flowUnit qty)
 
 {- | Pre-compute the broadcast CF Map: each flow UUID covered by the method maps
 to its effective CF (CF value × flow-unit→CF-unit conversion). Collapses the

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -911,7 +911,11 @@ expects, for characterization.
     flow's canonical base unit, so we normalize @qty@ to that base unit
     ('normalizeToCanonical'). A flow already in its base unit (kg) is left as
     is; a flow in @g@/@mg@ is scaled to kg. Without this, grams would be
-    characterized as if they were kilograms (a ×1000 / ×1e6 over-count).
+    characterized as if they were kilograms (a ×1000 / ×1e6 over-count). If the
+    flow's dimension defines no canonical base (a 'UnitConfig' defect),
+    'normalizeToCanonical' returns 'Nothing' and we hard-fail to @0@ — as in the
+    dimensional-mismatch case — rather than silently scoring the un-normalized
+    amount.
   * The flow unit itself is unknown → @qty@ unchanged (no base to normalize to).
 -}
 convertForCharacterization :: UnitConfig -> Text -> Text -> Double -> Double
@@ -919,7 +923,7 @@ convertForCharacterization cfg flowUnit cfUnit qty
     | flowUnit == cfUnit || T.null cfUnit || T.null flowUnit = qty
     | not (isKnownUnit cfg flowUnit) = qty
     | isKnownUnit cfg cfUnit = fromMaybe 0 (convertUnit cfg flowUnit cfUnit qty)
-    | otherwise = maybe qty snd (normalizeToCanonical cfg flowUnit qty)
+    | otherwise = maybe 0 snd (normalizeToCanonical cfg flowUnit qty)
 
 {- | Pre-compute the broadcast CF Map: each flow UUID covered by the method maps
 to its effective CF (CF value × flow-unit→CF-unit conversion). Collapses the

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -596,6 +596,14 @@ expandSynonymMappings synDB flowsByName mappings =
     -- they stop fusing unrelated substances into one giant junk-hub class. The
     -- global closure has already merged such a hub and cannot be re-split, so we
     -- re-close from 'synEdges' (the original pairs) against the used set here.
+    --
+    -- Trade-off: a synonym whose name is neither a flow nor a CF is dropped, so a
+    -- substance bridged ONLY through such an intermediate would be lost. Measured
+    -- on JRC EF-3.1 × BAFU (all 25 categories), the dropped matches are junk-hub
+    -- fan-out (e.g. @arsenic → {butanol, acetone, aluminium, …}@) plus correct
+    -- CO₂/CH₄/land-use subtype discrimination (a @…, land use change@ CF must not
+    -- reach the generic @carbon dioxide@ flow); no genuine same-substance match
+    -- was lost. The restriction is sound in practice.
     used :: S.Set Text
     used =
         foldr

--- a/src/SynonymDB.hs
+++ b/src/SynonymDB.hs
@@ -14,6 +14,8 @@ module SynonymDB (
     buildFromCSV,
     buildFromPairs,
     excludeOverFrequentSynonyms,
+    excludeJunkSynonyms,
+    isJunkSynonymName,
     starEdges,
     loadFromCSVFileWithCache,
 
@@ -204,6 +206,51 @@ excludeOverFrequentSynonyms maxFlows pairs = (kept, excluded)
     overFrequent = M.filter (> maxFlows) (M.map S.size flowsPerSynonym)
     kept = [p | (p, _, ns) <- normed, not (ns `M.member` overFrequent)]
     excluded = sortOn (negate . snd) (M.toList overFrequent)
+
+{- | Is this name an obvious non-synonym — a REACH/ILCD dossier placeholder
+(@"not available"@, @"unknown"@, @"active matter"@, an ECHA id stub) rather than a
+substance name? These survive 'excludeOverFrequentSynonyms' (each is carried by
+few flows) yet act as cut-vertices that fuse unrelated substances through long
+chains, so they are dropped by string shape instead of frequency.
+
+Deliberately conservative — it matches only forms that no real substance name
+takes. In particular @"mixture"@ and digit-heavy names are NOT matched: both are
+common in genuine names (@"toluenediisocyanate (mixture)"@, @"pcb-1254"@). The
+@echa-@ check is anchored so it cannot fire on the @echa@ inside a word (e.g.
+French @"huile de chauffage"@).
+-}
+isJunkSynonymName :: Text -> Bool
+isJunkSynonymName name =
+    n `elem` exactStops
+        || any (`T.isInfixOf` n) infixStops
+        || "unknown" `T.isPrefixOf` n
+        || "echa-" `T.isPrefixOf` n
+        || "echa_" `T.isPrefixOf` n
+  where
+    n = normalizeName name
+    exactStops = ["none", "no data", "not applicable", "not assigned", "not specified"]
+    infixStops =
+        [ "available"
+        , "confidential"
+        , "active matter"
+        , "activematter"
+        , "active substance"
+        , "activesubstance"
+        , "active ingredient"
+        , "activeingredient"
+        ]
+
+{- | Drop synonym pairs touching a junk placeholder name ('isJunkSynonymName').
+Returns the kept pairs and the distinct (normalized) junk tokens dropped, so the
+caller can surface them rather than discard them silently.
+-}
+excludeJunkSynonyms :: [(Text, Text)] -> ([(Text, Text)], [Text])
+excludeJunkSynonyms pairs = (kept, excluded)
+  where
+    kept = [p | p@(a, b) <- pairs, not (isJunkSynonymName a), not (isJunkSynonymName b)]
+    excluded =
+        S.toList . S.fromList $
+            [normalizeName x | (a, b) <- pairs, x <- [a, b], isJunkSynonymName x]
 
 {- | Normalize a name for lookup in the synonym database
 

--- a/src/SynonymDB.hs
+++ b/src/SynonymDB.hs
@@ -13,6 +13,7 @@ module SynonymDB (
     -- * Building
     buildFromCSV,
     buildFromPairs,
+    starEdges,
     loadFromCSVFileWithCache,
 
     -- * Lookup
@@ -72,12 +73,14 @@ hub that would fuse unrelated substances — surfaces through 'oversizedClasses'
 relations (SOx ⊃ SO₂) belong in the typed-edge layer, not as @SameAs@.
 -}
 buildFromPairs :: [(Text, Text)] -> SynonymDB
-buildFromPairs = fromClasses . equivalenceClasses . normalizePairs
+buildFromPairs raws =
+    let normd = normalizePairs raws
+     in (fromClasses (equivalenceClasses normd)){synEdges = normd}
   where
     normalizePairs :: [(Text, Text)] -> [(Text, Text)]
-    normalizePairs raws =
+    normalizePairs rs =
         [ (n1, n2)
-        | (raw1, raw2) <- raws
+        | (raw1, raw2) <- rs
         , let n1 = normalizeName raw1
         , let n2 = normalizeName raw2
         , not (T.null n1)
@@ -91,7 +94,16 @@ fromClasses classes =
     let numbered = zip [0 ..] classes
         nameToId = M.fromList [(name, gid) | (gid, members) <- numbered, name <- members]
         idToNames = M.fromList numbered
-     in SynonymDB nameToId idToNames
+     in SynonymDB nameToId idToNames (starEdges classes)
+
+{- | Star edges for a set of name classes: connect each class's members to its
+first member. Their transitive closure is exactly the classes — enough to
+re-close the relation. 'buildFromPairs' overrides this with the original pairs,
+for a faithful induced-subgraph restriction: a star centred on a node that the
+restriction later drops would lose links the original topology preserves.
+-}
+starEdges :: [[Text]] -> [(Text, Text)]
+starEdges classes = [(m0, m) | (m0 : ms) <- classes, m <- ms]
 
 {- | Load a SynonymDB from a CSV file, using a binary cache for speed.
   On first load: parse CSV → build SynonymDB → save .cache.zst
@@ -142,18 +154,19 @@ loadFromCSVFileWithCache csvPath = do
             (\(_ :: SomeException) -> return ())
 
 {- | Merge multiple SynonymDBs into one, re-closing across them: if one source
-declares A=B and another B=C, the merged DB groups {A,B,C}. Each group is
-reconnected by a star to its first member (enough to preserve its connectivity),
-then the whole edge set is closed again.
+declares A=B and another B=C, the merged DB groups {A,B,C}. The sources' own
+@synEdges@ are concatenated and the whole edge set is closed again, so the merged
+DB carries the union of the original pairs (not a lossy star reconstruction).
 -}
 mergeSynonymDBs :: [SynonymDB] -> SynonymDB
 mergeSynonymDBs [] = emptySynonymDB
 mergeSynonymDBs [db] = db
-mergeSynonymDBs dbs = fromClasses (equivalenceClasses edges)
+mergeSynonymDBs dbs = (fromClasses (equivalenceClasses edges)){synEdges = edges}
   where
-    edges = concatMap groupEdges (concatMap (M.elems . synIdToNames) dbs)
-    groupEdges [] = []
-    groupEdges (m0 : ms) = [(normalizeName m0, normalizeName m) | m <- ms]
+    -- Re-close from each source's own (already normalized) pairs rather than
+    -- reconstructing stars from its classes, so the merged 'synEdges' keeps the
+    -- faithful topology the induced-subgraph restriction needs.
+    edges = concatMap synEdges dbs
 
 -- | Number of synonym names in the database.
 synonymCount :: SynonymDB -> Int

--- a/src/SynonymDB.hs
+++ b/src/SynonymDB.hs
@@ -13,6 +13,7 @@ module SynonymDB (
     -- * Building
     buildFromCSV,
     buildFromPairs,
+    excludeOverFrequentSynonyms,
     starEdges,
     loadFromCSVFileWithCache,
 
@@ -39,7 +40,9 @@ import Control.Exception (SomeException, catch, evaluate)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import Data.Csv (HasHeader (..), decode)
+import Data.List (sortOn)
 import qualified Data.Map.Strict as M
+import qualified Data.Set as S
 import Data.Store (decodeEx, encode)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -180,6 +183,27 @@ whatever this returns; an empty result means the closure stayed plausible.
 -}
 oversizedClasses :: Int -> SynonymDB -> [[Text]]
 oversizedClasses maxSize = filter ((> maxSize) . length) . M.elems . synIdToNames
+
+{- | Drop synonym pairs whose synonym (the second element) is carried by more
+than @maxFlows@ distinct base names (the first element). An over-frequent
+"synonym" is a classification label or stop-word — e.g. @"organic"@ (carried by
+thousands of flows), @"inorganic"@, @"petroleum product"@ — not a true synonym,
+which is ~1:1 with a substance and binds a handful of names at most.
+
+Counting is directional and on normalized names, so a real flow that merely HAS
+many synonyms (high out-degree, e.g. @"acetaminophen"@ with its trade names) is
+never touched — only a name that ACTS as a synonym for many distinct flows is.
+Returns the kept pairs and the excluded tokens with their flow counts
+(descending), so the caller can surface the exclusion list, not drop it silently.
+-}
+excludeOverFrequentSynonyms :: Int -> [(Text, Text)] -> ([(Text, Text)], [(Text, Int)])
+excludeOverFrequentSynonyms maxFlows pairs = (kept, excluded)
+  where
+    normed = [(p, normalizeName base, normalizeName syn) | p@(base, syn) <- pairs]
+    flowsPerSynonym = M.fromListWith S.union [(ns, S.singleton nb) | (_, nb, ns) <- normed]
+    overFrequent = M.filter (> maxFlows) (M.map S.size flowsPerSynonym)
+    kept = [p | (p, _, ns) <- normed, not (ns `M.member` overFrequent)]
+    excluded = sortOn (negate . snd) (M.toList overFrequent)
 
 {- | Normalize a name for lookup in the synonym database
 

--- a/src/SynonymDB/Extract.hs
+++ b/src/SynonymDB/Extract.hs
@@ -38,42 +38,23 @@ extractFromEcoSpold2 bioFlowDB =
             , syn /= bfName f
             ]
 
-{- | Extract synonym pairs from ILCD flow definitions.
-Two sources:
-1. Direct: baseName ↔ each synonym from <common:synonyms>
-2. CAS grouping: flows sharing a CAS are chained as synonyms
+{- | Extract synonym pairs from ILCD flow definitions: the direct
+@<common:synonyms>@ of each flow (baseName ↔ each synonym).
+
+CAS-based equivalence is deliberately NOT emitted as synonym pairs. Flows
+sharing a CAS are already matched by the CAS cascade (@mtCasCF@) at lookup time,
+so chaining same-CAS names here adds no new match — it only injects transitive
+bridges that fuse unrelated substances into oversized closure classes (one
+shared or blank CAS can connect hundreds of names through a single chain).
 -}
 extractFromILCDFlows :: M.Map UUID ILCDFlowInfo -> [(Text, Text)]
 extractFromILCDFlows flowInfo =
-    S.toList (S.union directSet casSet)
-  where
-    infos = M.elems flowInfo
-
-    -- 1. Direct synonyms from <common:synonyms>
-    directSet =
+    S.toList $
         S.fromList
             [ (ilcdBaseName info, syn)
-            | info <- infos
+            | info <- M.elems flowInfo
             , syn <- ilcdSynonyms info
             , syn /= ilcdBaseName info
-            ]
-
-    -- 2. CAS grouping: chain distinct baseNames sharing the same CAS
-    -- Use Set to collect unique names per CAS, then chain (not all-pairs)
-    casSet =
-        S.fromList
-            [ (n1, n2)
-            | names <- M.elems casByName
-            , let unique = S.toAscList names
-            , (n1, n2) <- zip unique (drop 1 unique)
-            ]
-    casByName =
-        M.fromListWith
-            S.union
-            [ (cas, S.singleton (ilcdBaseName info))
-            | info <- infos
-            , Just cas <- [ilcdCAS info]
-            , not (T.null cas)
             ]
 
 -- | Render synonym pairs as CSV with header.

--- a/src/SynonymDB/Types.hs
+++ b/src/SynonymDB/Types.hs
@@ -19,13 +19,18 @@ import GHC.Generics (Generic)
 
 - @synNameToId@: Maps normalized flow names to synonym group IDs
 - @synIdToNames@: Maps group IDs back to all names in that group
+- @synEdges@: the normalized @SameAs@ pairs the classes were closed from, kept
+  so the relation can be re-closed on a restricted node set (an induced
+  subgraph on the used flow names) at fan-out time — a closed class cannot be
+  re-split once its internal edges are gone.
 -}
 data SynonymDB = SynonymDB
     { synNameToId :: !(Map Text Int)
     , synIdToNames :: !(Map Int [Text])
+    , synEdges :: ![(Text, Text)]
     }
     deriving (Eq, Show, Generic, NFData, Store)
 
 -- | Empty synonym database
 emptySynonymDB :: SynonymDB
-emptySynonymDB = SynonymDB M.empty M.empty
+emptySynonymDB = SynonymDB M.empty M.empty []

--- a/src/Tools/SynonymsCompiler.hs
+++ b/src/Tools/SynonymsCompiler.hs
@@ -42,7 +42,7 @@ import System.IO (hPutStrLn, stderr)
 import Text.Printf (printf)
 
 import EcoSpold.Parser2 (normalizeCAS)
-import SynonymDB (normalizeName)
+import SynonymDB (normalizeName, starEdges)
 import SynonymDB.Types (SynonymDB (..))
 
 -- | Shared output options
@@ -120,7 +120,7 @@ parseJSONToSynonymDB (A.Object obj) = do
             Right
             (KM.lookup "id_to_synonyms" obj)
     idToNames <- parseIdToSynonyms idToSynValue
-    Right $ SynonymDB{synNameToId = nameToId, synIdToNames = idToNames}
+    Right $ SynonymDB{synNameToId = nameToId, synIdToNames = idToNames, synEdges = starEdges (M.elems idToNames)}
 parseJSONToSynonymDB _ = Left "Expected JSON object at top level"
 
 parseNameToId :: A.Value -> Either String (M.Map T.Text Int)
@@ -326,7 +326,7 @@ buildSynonymDB casGroups namePairs =
         -- Step 3: Build maps, enforcing size cap
         (nameToId, idToNames) = buildMaps allGroups
      in
-        SynonymDB{synNameToId = nameToId, synIdToNames = idToNames}
+        SynonymDB{synNameToId = nameToId, synIdToNames = idToNames, synEdges = starEdges (M.elems idToNames)}
 
 -- | Merge name pairs into existing groups using simple Union-Find on Map
 mergeNamePairs :: [SynonymPair] -> [[T.Text]] -> [[T.Text]]

--- a/test/FlowResolverSpec.hs
+++ b/test/FlowResolverSpec.hs
@@ -4,6 +4,7 @@ module FlowResolverSpec (spec) where
 
 import Data.ByteString (ByteString)
 import qualified Data.UUID as UUID
+import EcoSpold.Common (decodeXmlEntities)
 import EcoSpold.Parser2 (normalizeCAS)
 import Method.FlowResolver (ILCDFlowInfo (..), parseFlowXML)
 import Method.Types (Compartment (..))
@@ -11,6 +12,22 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    -- -----------------------------------------------------------------------
+    -- decodeXmlEntities (pure, from EcoSpold.Common) — order is load-bearing
+    -- -----------------------------------------------------------------------
+    describe "decodeXmlEntities" $ do
+        it "fully decodes a double-encoded numeric ref (the ILCD data's form)" $
+            decodeXmlEntities "&amp;#039;" `shouldBe` "'"
+
+        it "decodes a single-encoded numeric ref" $
+            decodeXmlEntities "&#039;" `shouldBe` "'"
+
+        it "preserves an escaped-literal named entity (round-trip)" $
+            decodeXmlEntities "&amp;lt;" `shouldBe` "&lt;"
+
+        it "unescapes a lone ampersand" $
+            decodeXmlEntities "&amp;" `shouldBe` "&"
+
     -- -----------------------------------------------------------------------
     -- normalizeCAS (pure, from EcoSpold.Parser2)
     -- -----------------------------------------------------------------------
@@ -61,7 +78,7 @@ spec = do
                 Just (_, info) ->
                     ilcdSynonyms info `shouldContain` ["CO2"]
 
-        it "decodes numeric entity refs in synonyms without splitting on the entity's semicolon" $ do
+        it "decodes double-encoded entity refs in synonyms without splitting on the entity's semicolon" $ do
             case parseFlowXML flowWithEntitySynonyms of
                 Nothing -> expectationFailure "Expected Just result"
                 Just (_, info) ->
@@ -158,10 +175,11 @@ flowWithSynonyms =
     \</flowInformation>\
     \</flowDataSet>"
 
--- Synonym text carrying a numeric character reference (@&#039;@ = apostrophe).
--- The ';' inside the entity must NOT be treated as the synonym separator, and
--- the entity must decode to a real apostrophe — otherwise the second synonym
--- splits into the truncated "…1,1&#039" plus a stray "-biphenyl".
+-- Synonym text carrying a DOUBLE-encoded apostrophe (@&amp;#039;@) — the form
+-- the ILCD flow data actually uses. The @&amp;@ must decode first to expose
+-- @&#039;@, which then decodes to a real apostrophe; otherwise the half-decoded
+-- @&#039;@ reaches the ';'-split and truncates the second synonym into the
+-- "…1,1&#039" fragment plus a stray "-biphenyl".
 flowWithEntitySynonyms :: ByteString
 flowWithEntitySynonyms =
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
@@ -172,7 +190,7 @@ flowWithEntitySynonyms =
     \<common:UUID>12345678-1234-1234-1234-123456789abc</common:UUID>\
     \<name>\
     \<baseName xml:lang=\"en\">Biphenyl derivative</baseName>\
-    \<common:synonyms xml:lang=\"en\">PCB; (1-methylethyl)-1,1&#039;-biphenyl</common:synonyms>\
+    \<common:synonyms xml:lang=\"en\">PCB; (1-methylethyl)-1,1&amp;#039;-biphenyl</common:synonyms>\
     \</name>\
     \</dataSetInformation>\
     \</flowInformation>\

--- a/test/FlowResolverSpec.hs
+++ b/test/FlowResolverSpec.hs
@@ -4,9 +4,9 @@ module FlowResolverSpec (spec) where
 
 import Data.ByteString (ByteString)
 import qualified Data.UUID as UUID
-import EcoSpold.Common (decodeXmlEntities)
+import EcoSpold.Common (decodeXmlEntities, decodeXmlEntitiesFull)
 import EcoSpold.Parser2 (normalizeCAS)
-import Method.FlowResolver (ILCDFlowInfo (..), parseFlowXML)
+import Method.FlowResolver (ILCDFlowInfo (..), parseFlowXML, splitIlcdSynonyms)
 import Method.Types (Compartment (..))
 import Test.Hspec
 
@@ -27,6 +27,19 @@ spec = do
 
         it "unescapes a lone ampersand" $
             decodeXmlEntities "&amp;" `shouldBe` "&"
+
+        it "decodeXmlEntitiesFull collapses the round-trip to the character (&amp;lt; -> <)" $
+            decodeXmlEntitiesFull "&amp;lt;" `shouldBe` "<"
+
+    describe "splitIlcdSynonyms" $ do
+        it "splits an ILCD synonyms blob on ';' separators" $
+            splitIlcdSynonyms "a;b;c" `shouldBe` ["a", "b", "c"]
+
+        it "fully decodes a double-encoded named entity, so no &lt fragment survives the split" $
+            splitIlcdSynonyms "solvent &amp;lt;c9&amp;gt;" `shouldBe` ["solvent <c9>"]
+
+        it "fully decodes a double-encoded numeric entity and does not split on its semicolon" $
+            splitIlcdSynonyms "x&amp;#039;y" `shouldBe` ["x'y"]
 
     -- -----------------------------------------------------------------------
     -- normalizeCAS (pure, from EcoSpold.Parser2)

--- a/test/FlowResolverSpec.hs
+++ b/test/FlowResolverSpec.hs
@@ -41,6 +41,9 @@ spec = do
         it "fully decodes a double-encoded numeric entity and does not split on its semicolon" $
             splitIlcdSynonyms "x&amp;#039;y" `shouldBe` ["x'y"]
 
+        it "splits on the 'othernames' pseudo-delimiter the source glues names with" $
+            splitIlcdSynonyms "a;b othernames c" `shouldBe` ["a", "b", "c"]
+
     -- -----------------------------------------------------------------------
     -- normalizeCAS (pure, from EcoSpold.Parser2)
     -- -----------------------------------------------------------------------

--- a/test/FlowResolverSpec.hs
+++ b/test/FlowResolverSpec.hs
@@ -13,22 +13,29 @@ import Test.Hspec
 spec :: Spec
 spec = do
     -- -----------------------------------------------------------------------
-    -- decodeXmlEntities (pure, from EcoSpold.Common) — order is load-bearing
+    -- decodeXmlEntities (general read path) vs decodeXmlEntitiesFull (synonyms)
     -- -----------------------------------------------------------------------
     describe "decodeXmlEntities" $ do
-        it "fully decodes a double-encoded numeric ref (the ILCD data's form)" $
-            decodeXmlEntities "&amp;#039;" `shouldBe` "'"
-
-        it "decodes a single-encoded numeric ref" $
-            decodeXmlEntities "&#039;" `shouldBe` "'"
-
         it "preserves an escaped-literal named entity (round-trip)" $
             decodeXmlEntities "&amp;lt;" `shouldBe` "&lt;"
 
         it "unescapes a lone ampersand" $
             decodeXmlEntities "&amp;" `shouldBe` "&"
 
-        it "decodeXmlEntitiesFull collapses the round-trip to the character (&amp;lt; -> <)" $
+        it "decodes the line-feed numeric ref that EcoSpold attributes carry" $
+            decodeXmlEntities "a&#10;b" `shouldBe` "a\nb"
+
+        it "preserves a double-encoded numeric ref on the general read path (no collapse)" $
+            decodeXmlEntities "&amp;#13;" `shouldBe` "&#13;"
+
+    describe "decodeXmlEntitiesFull" $ do
+        it "fully decodes a double-encoded numeric ref (the ILCD data's form)" $
+            decodeXmlEntitiesFull "&amp;#039;" `shouldBe` "'"
+
+        it "decodes a single-encoded numeric ref" $
+            decodeXmlEntitiesFull "&#039;" `shouldBe` "'"
+
+        it "collapses the double-encoded named round-trip to the character (&amp;lt; -> <)" $
             decodeXmlEntitiesFull "&amp;lt;" `shouldBe` "<"
 
     describe "splitIlcdSynonyms" $ do

--- a/test/FlowResolverSpec.hs
+++ b/test/FlowResolverSpec.hs
@@ -61,6 +61,12 @@ spec = do
                 Just (_, info) ->
                     ilcdSynonyms info `shouldContain` ["CO2"]
 
+        it "decodes numeric entity refs in synonyms without splitting on the entity's semicolon" $ do
+            case parseFlowXML flowWithEntitySynonyms of
+                Nothing -> expectationFailure "Expected Just result"
+                Just (_, info) ->
+                    ilcdSynonyms info `shouldBe` ["PCB", "(1-methylethyl)-1,1'-biphenyl"]
+
         it "returns Nothing for XML with no UUID" $
             case parseFlowXML xmlNoUUID of
                 Nothing -> return ()
@@ -147,6 +153,26 @@ flowWithSynonyms =
     \<name>\
     \<baseName xml:lang=\"en\">Carbon dioxide, fossil</baseName>\
     \<common:synonyms xml:lang=\"en\">CO2; carbon dioxide</common:synonyms>\
+    \</name>\
+    \</dataSetInformation>\
+    \</flowInformation>\
+    \</flowDataSet>"
+
+-- Synonym text carrying a numeric character reference (@&#039;@ = apostrophe).
+-- The ';' inside the entity must NOT be treated as the synonym separator, and
+-- the entity must decode to a real apostrophe — otherwise the second synonym
+-- splits into the truncated "…1,1&#039" plus a stray "-biphenyl".
+flowWithEntitySynonyms :: ByteString
+flowWithEntitySynonyms =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+    \<flowDataSet xmlns=\"http://lca.jrc.it/ILCD/Flow\" \
+    \xmlns:common=\"http://lca.jrc.it/ILCD/Common\">\
+    \<flowInformation>\
+    \<dataSetInformation>\
+    \<common:UUID>12345678-1234-1234-1234-123456789abc</common:UUID>\
+    \<name>\
+    \<baseName xml:lang=\"en\">Biphenyl derivative</baseName>\
+    \<common:synonyms xml:lang=\"en\">PCB; (1-methylethyl)-1,1&#039;-biphenyl</common:synonyms>\
     \</name>\
     \</dataSetInformation>\
     \</flowInformation>\

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -68,6 +68,17 @@ gKgUnitConfig =
         , ucOriginalKeys = M.fromList [("kg", "kg"), ("g", "g")]
         }
 
+-- | UnitConfig whose mass dimension has NO canonical base (g only, no kg at
+-- factor 1.0), so 'normalizeToCanonical' fails — exercises the result-expression
+-- branch's hard-fail to 0.
+gOnlyUnitConfig :: UnitConfig
+gOnlyUnitConfig =
+    UnitConfig
+        { ucDimensionOrder = ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
+        , ucUnits = M.fromList [("g", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 0.001)]
+        , ucOriginalKeys = M.fromList [("g", "g")]
+        }
+
 -- ---------------------------------------------------------------------------
 -- Spec
 -- ---------------------------------------------------------------------------
@@ -366,13 +377,15 @@ spec = do
         -- flow unit), refuse cross-dimension injection (→ 0), apply the factor
         -- when both units are known, and — when the CF unit is a result
         -- expression unknown to the UnitConfig — normalize the flow to its
-        -- canonical base unit (a kg flow is unchanged; a g flow scales to kg).
+        -- canonical base unit (a kg flow is unchanged; a g flow scales to kg), or
+        -- hard-fail to 0 when that dimension defines no canonical base.
         let cases =
                 [ ("units match by name", defaultUnitConfig, "kg", "kg", 5.0, 5.0)
                 , ("cfUnit empty (method without unit)", defaultUnitConfig, "kg", "", 7.0, 7.0)
                 , ("flowUnit empty (no metadata)", defaultUnitConfig, "", "kg", 9.0, 9.0)
                 , ("LCIA-expression CF unit, flow already canonical → unchanged", defaultUnitConfig, "kg", "kg CO2 eq", 3.0, 3.0)
                 , ("LCIA-expression CF unit, g flow → normalized to canonical kg", gKgUnitConfig, "g", "kg CO2 eq", 1000.0, 1.0)
+                , ("LCIA-expression CF unit, flow dimension has no canonical base → 0", gOnlyUnitConfig, "g", "kg CO2 eq", 1000.0, 0.0)
                 , ("dimensionally incompatible → 0", defaultUnitConfig, "m", "kg", 100.0, 0.0)
                 , ("compatible units differ → apply factor (1000 g → 1.0 kg)", gKgUnitConfig, "g", "kg", 1000.0, 1.0)
                 ]

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -362,14 +362,17 @@ spec = do
 
     describe "convertForCharacterization" $ do
         -- Each row encodes a (flowUnit, cfUnit, qty) → expected mapping under a
-        -- specific UnitConfig. The semantic groups: pass-through (matching or
-        -- unknown units, trust the CF author), refuse cross-dimension injection
-        -- by returning 0, apply factor when compatible.
+        -- specific UnitConfig. Semantic groups: pass-through (units match, or no
+        -- flow unit), refuse cross-dimension injection (→ 0), apply the factor
+        -- when both units are known, and — when the CF unit is a result
+        -- expression unknown to the UnitConfig — normalize the flow to its
+        -- canonical base unit (a kg flow is unchanged; a g flow scales to kg).
         let cases =
                 [ ("units match by name", defaultUnitConfig, "kg", "kg", 5.0, 5.0)
                 , ("cfUnit empty (method without unit)", defaultUnitConfig, "kg", "", 7.0, 7.0)
                 , ("flowUnit empty (no metadata)", defaultUnitConfig, "", "kg", 9.0, 9.0)
-                , ("cfUnit is an LCIA expression unknown to UnitConfig", defaultUnitConfig, "kg", "kg CO2 eq", 3.0, 3.0)
+                , ("LCIA-expression CF unit, flow already canonical → unchanged", defaultUnitConfig, "kg", "kg CO2 eq", 3.0, 3.0)
+                , ("LCIA-expression CF unit, g flow → normalized to canonical kg", gKgUnitConfig, "g", "kg CO2 eq", 1000.0, 1.0)
                 , ("dimensionally incompatible → 0", defaultUnitConfig, "m", "kg", 100.0, 0.0)
                 , ("compatible units differ → apply factor (1000 g → 1.0 kg)", gKgUnitConfig, "g", "kg", 1000.0, 1.0)
                 ]

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -68,9 +68,10 @@ gKgUnitConfig =
         , ucOriginalKeys = M.fromList [("kg", "kg"), ("g", "g")]
         }
 
--- | UnitConfig whose mass dimension has NO canonical base (g only, no kg at
--- factor 1.0), so 'normalizeToCanonical' fails — exercises the result-expression
--- branch's hard-fail to 0.
+{- | UnitConfig whose mass dimension has NO canonical base (g only, no kg at
+factor 1.0), so 'normalizeToCanonical' fails — exercises the result-expression
+branch's hard-fail to 0.
+-}
 gOnlyUnitConfig :: UnitConfig
 gOnlyUnitConfig =
     UnitConfig

--- a/test/SynonymDBSpec.hs
+++ b/test/SynonymDBSpec.hs
@@ -7,7 +7,7 @@ import qualified Data.Set as S
 import Data.Text (Text, pack)
 import Test.Hspec
 
-import SynonymDB (buildFromPairs, getSynonyms, loadFromCSVFileWithCache, lookupSynonymGroup, normalizeName, oversizedClasses, uncoveredUnitSuffixes)
+import SynonymDB (buildFromPairs, excludeOverFrequentSynonyms, getSynonyms, loadFromCSVFileWithCache, lookupSynonymGroup, normalizeName, oversizedClasses, uncoveredUnitSuffixes)
 
 spec :: Spec
 spec = do
@@ -42,6 +42,30 @@ spec = do
         it "stays silent when every class is within the bound" $
             oversizedClasses 10 (buildFromPairs [("alpha", "beta"), ("beta", "gamma")])
                 `shouldBe` []
+
+    describe "excludeOverFrequentSynonyms" $ do
+        -- "organic" acts as a synonym for 3 distinct flows -> a class label, dropped.
+        -- "acetaminophen" merely HAS 3 synonyms (out-degree) -> a real flow, kept.
+        let pairs =
+                [ ("benzene", "organic")
+                , ("toluene", "organic")
+                , ("phenol", "organic")
+                , ("acetaminophen", "paracetamol")
+                , ("acetaminophen", "tylenol")
+                , ("acetaminophen", "apap")
+                ]
+            (kept, excluded) = excludeOverFrequentSynonyms 2 pairs
+
+        it "drops the over-frequent synonym and surfaces it with its flow count" $ do
+            excluded `shouldBe` [("organic", 3)]
+            ("organic" `elem` map snd kept) `shouldBe` False
+
+        it "keeps a real flow that merely has many synonyms (out-degree, not in-degree)" $
+            kept `shouldMatchList` [("acetaminophen", s) | s <- ["paracetamol", "tylenol", "apap"]]
+
+        it "counts case/punctuation variants of a synonym together (normalized)" $
+            snd (excludeOverFrequentSynonyms 2 [("a", "Organic"), ("b", "organic"), ("c", "ORGANIC")])
+                `shouldBe` [("organic", 3)]
 
     describe "normalizeName" $ do
         it "strips a trailing SimaPro unit suffix (/kg, /m3, /Sm3) so unit variants share a node" $ do

--- a/test/SynonymDBSpec.hs
+++ b/test/SynonymDBSpec.hs
@@ -7,7 +7,7 @@ import qualified Data.Set as S
 import Data.Text (Text, pack)
 import Test.Hspec
 
-import SynonymDB (buildFromPairs, excludeOverFrequentSynonyms, getSynonyms, loadFromCSVFileWithCache, lookupSynonymGroup, normalizeName, oversizedClasses, uncoveredUnitSuffixes)
+import SynonymDB (buildFromPairs, excludeJunkSynonyms, excludeOverFrequentSynonyms, getSynonyms, isJunkSynonymName, loadFromCSVFileWithCache, lookupSynonymGroup, normalizeName, oversizedClasses, uncoveredUnitSuffixes)
 
 spec :: Spec
 spec = do
@@ -66,6 +66,39 @@ spec = do
         it "counts case/punctuation variants of a synonym together (normalized)" $
             snd (excludeOverFrequentSynonyms 2 [("a", "Organic"), ("b", "organic"), ("c", "ORGANIC")])
                 `shouldBe` [("organic", 3)]
+
+    describe "excludeJunkSynonyms" $ do
+        -- Dossier placeholders / id stubs are dropped; real substances survive,
+        -- including names that contain "(mixture)" or are digit-heavy.
+        let pairs =
+                [ ("arsenic", "not available")
+                , ("benzene", "unknown")
+                , ("sodium hydroxide", "98%activematter")
+                , ("n-butane", "echa-8600dbe1-6174-49ec-b025-9cd03d318e49")
+                , ("toluene diisocyanate", "2,4/2,6-toluenediisocyanate (mixture)")
+                , ("hexachlorocyclohexane", "pcb-1254")
+                ]
+            (kept, dropped) = excludeJunkSynonyms pairs
+
+        it "drops pairs touching a placeholder/id-stub token, keeps real ones" $
+            kept
+                `shouldMatchList` [ ("toluene diisocyanate", "2,4/2,6-toluenediisocyanate (mixture)")
+                                  , ("hexachlorocyclohexane", "pcb-1254")
+                                  ]
+
+        it "surfaces the distinct dropped tokens" $
+            length dropped `shouldBe` 4
+
+        it "flags dossier prose and ECHA id stubs" $ do
+            isJunkSynonymName "not available" `shouldBe` True
+            isJunkSynonymName "unknown atom or ion" `shouldBe` True
+            isJunkSynonymName "100%activematter" `shouldBe` True
+            isJunkSynonymName "echa-8600dbe1-6174-49ec-b025-9cd03d318e49" `shouldBe` True
+
+        it "spares real names with 'mixture', digits, or an inner 'echa'" $ do
+            isJunkSynonymName "2,4/2,6-toluenediisocyanate (mixture)" `shouldBe` False
+            isJunkSynonymName "pcb-1254" `shouldBe` False
+            isJunkSynonymName "huile de chauffage" `shouldBe` False
 
     describe "normalizeName" $ do
         it "strips a trailing SimaPro unit suffix (/kg, /m3, /Sm3) so unit variants share a node" $ do

--- a/test/SynonymExtractSpec.hs
+++ b/test/SynonymExtractSpec.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module SynonymExtractSpec (spec) where
+
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
+import Method.FlowResolver (ILCDFlowInfo (..))
+import SynonymDB.Extract (extractFromILCDFlows)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "extractFromILCDFlows" $ do
+    it "emits baseName↔synonym pairs from <common:synonyms>" $ do
+        let flows = M.fromList [(uuidA, mkFlow "Carbon dioxide" Nothing ["CO2", "carbonic anhydride"])]
+        extractFromILCDFlows flows
+            `shouldMatchList` [("Carbon dioxide", "CO2"), ("Carbon dioxide", "carbonic anhydride")]
+
+    it "does not chain same-CAS flows into synonym pairs (CAS is matched by the cascade)" $ do
+        -- Two distinct substances sharing one CAS, neither carrying <synonyms>.
+        -- The old CAS grouping would emit ("Substance A","Substance B"); now nothing.
+        let flows =
+                M.fromList
+                    [ (uuidA, mkFlow "Substance A" (Just "100-00-0") [])
+                    , (uuidB, mkFlow "Substance B" (Just "100-00-0") [])
+                    ]
+        extractFromILCDFlows flows `shouldBe` []
+
+mkFlow :: Text -> Maybe Text -> [Text] -> ILCDFlowInfo
+mkFlow name cas syns =
+    ILCDFlowInfo
+        { ilcdBaseName = name
+        , ilcdCompartment = Nothing
+        , ilcdCAS = cas
+        , ilcdSynonyms = syns
+        , ilcdFlowType = "Elementary flow"
+        , ilcdFlowPropertyRef = Nothing
+        }
+
+uuidA, uuidB :: UUID
+uuidA = mkUUID "11111111-1111-1111-1111-111111111111"
+uuidB = mkUUID "22222222-2222-2222-2222-222222222222"
+
+mkUUID :: String -> UUID
+mkUUID s = case UUID.fromString s of
+    Just u -> u
+    Nothing -> error ("bad test UUID: " <> s)

--- a/volca.cabal
+++ b/volca.cabal
@@ -250,6 +250,7 @@ test-suite lca-tests
                      , SharedSolverSpec
                      , CoalescingSolverSpec
                      , FlowResolverSpec
+                     , SynonymExtractSpec
                      , PluginConfigSpec
                      , ConfigSpec
                      , LoaderSpec


### PR DESCRIPTION
## Problem

Scoring the JRC EF-3.1 (ILCD) method on a SimaPro-sourced database (Agribalyse 3.2)
over-counted impacts by orders of magnitude — a yogurt's climate-change score came
out roughly 78x the SimaPro-adapted EF-3.1 reference.

Two independent bugs compounded; both are fixed here.

## 1. Flow unit ignored when the CF carries a result-expression unit

`convertForCharacterization` kept a flow's native amount whenever the CF unit was
unknown to the unit system. ILCD/EF characterization factors carry the **impact
result** unit (`"kg CO2 eq"`), not the flow's reference unit (which is unknown), so
any matched flow expressed in `g`/`mg` was scored as if it were `kg` (x1000 / x1e6).

Fix: when the CF unit is an unknown result-expression but the flow unit is known,
normalize the flow amount to its dimension's canonical base unit before applying the
(per-base-unit) factor.

## 2. Synonym fan-out matched through a junk hub

Synonyms auto-extracted from ILCD flows collapse into one giant transitive class: a
few garbage tokens (a classification label such as `organic`, listed on ~35k flows;
truncated XML-entity fragments; glued labels) bridge tens of thousands of unrelated
substances. The CF fan-out closed each factor over its full synonym class, so a
factor landed on many wrong flows.

Fix: keep the original `SameAs` pairs and re-close them, at fan-out time, on the
**induced subgraph of names actually used** as flows or CFs. Non-flow garbage tokens
are not in that set, so the spurious bridges vanish while genuine flow-to-flow
synonyms survive.

## Result

Yogurt climate-change, EF-3.1 vs the SimaPro-adapted EF-3.1 reference:
**1.03 vs 1.14 kg CO2-eq** (ratio 0.90) — converged.

## Synonym data-quality cleanups

The diagnosis surfaced several source-data warts in the auto-extracted ILCD
synonyms. These are cleaned at extraction, and the dropped tokens are logged (never
silently discarded):

- **Entity decoding** — the source double-encodes XML entities (`&amp;#039;`,
  `&amp;lt;`). They were left half-decoded, then truncated by the `;`-split into junk
  fragments. Now decoded fully (numeric and named) before the split.
- **Classification labels** — a "synonym" carried by more distinct flows than a real
  substance ever could (`organic`, `inorganic`, `petroleum product`, ...) is a class
  label, not a synonym; dropped by document frequency, directionally (a flow that
  merely *has* many synonyms is untouched).
- **Glued names** — the source joins two names with a literal `othernames` label and
  no separator; split into usable synonyms.

The remaining transitive closure is still large, but held by diffuse, low-signal
bridges that source filtering cannot single out; the induced-subgraph fan-out
(fix 2) neutralizes them for scoring.

## Reviewer note

Fix 1 (flow units) is orthogonal to the synonym work and is a single commit
(`fix(lcia): normalize flow to its canonical unit ...`); it can be split into its own
PR if preferred. The two are kept together here because they are the two compounding
causes of the same observed over-count.
