### PR TITLE
perf(lcia): speed up method-table build (parallel cascade + synonym-group memo)

### DIFF
--- a/src/Matrix.hs
+++ b/src/Matrix.hs
@@ -60,6 +60,7 @@ module Matrix (
     solveSparseLinearSystemWithFactorizationMulti,
     computeInventoryMatrixBatch,
     clearCachedSolver,
+    chunksOf,
 ) where
 
 import Control.Concurrent (forkIO)
@@ -419,6 +420,9 @@ solveSparseLinearSystemWithFactorizationMulti factorization demandVecs = do
 multiRhsChunkSize :: Int
 multiRhsChunkSize = 64
 
+{- | Split a list into successive chunks of at most @n@ elements (a non-positive
+@n@ yields the whole list as a single chunk).
+-}
 chunksOf :: Int -> [a] -> [[a]]
 chunksOf n xs
     | n <= 0 = [xs]

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -202,8 +202,12 @@ mapMethodFlows mappers ctx0 method = do
     -- concurrently. 'mapConcurrently' preserves order and the chunks are
     -- concatenated in order, so the result list — and every table built from it
     -- — is identical to the serial 'mapM'; this is a pure speedup, not a
-    -- behaviour change. Chunking (rather than one task per CF) caps the live
-    -- thread count at 'caps' on methods with tens of thousands of CFs.
+    -- behaviour change. Chunking (rather than one task per CF) spawns ~'caps'
+    -- tasks instead of one per CF on methods with tens of thousands of CFs.
+    -- This wins on a cold single-method mapping; the method-set build already
+    -- fans out across methods (see 'Database.Manager.mapMethodSetToTablesCached'),
+    -- which saturates the cores, so there the inner parallelism mostly nests
+    -- under that outer fan-out.
     if caps <= 1 || n < parCfThreshold
         then mapM resolve cfs
         else concat <$> mapConcurrently (mapM resolve) (chunksOf (max 1 ((n + caps - 1) `div` caps)) cfs)

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -97,7 +97,7 @@ import Data.Word (Word8)
 import GHC.Generics (Generic)
 
 import qualified Data.Set as Set
-import Matrix (Inventory, Vector)
+import Matrix (Inventory, Vector, chunksOf)
 import Method.ChemSynonyms (ChemSynonyms, expandedTokens)
 import Method.Types
 import Plugin.Types (MapContext (..), MapQuery (..), MapResult (..), MapperHandle (..))
@@ -209,8 +209,6 @@ mapMethodFlows mappers ctx0 method = do
         else concat <$> mapConcurrently (mapM resolve) (chunksOf (max 1 ((n + caps - 1) `div` caps)) cfs)
   where
     parCfThreshold = 1000
-    chunksOf _ [] = []
-    chunksOf k xs = let (h, t) = splitAt k xs in h : chunksOf k t
 
 {- | Map a single CF using the mapper handle cascade.
 Each mapper is tried in order; the first match wins.

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -72,6 +72,8 @@ module Method.Mapping (
 ) where
 
 import Control.Applicative ((<|>))
+import Control.Concurrent (getNumCapabilities)
+import Control.Concurrent.Async (mapConcurrently)
 import Control.DeepSeq (NFData)
 import Control.Monad.ST (runST)
 import Data.Aeson (ToJSON)
@@ -183,8 +185,25 @@ mapMethodFlows ::
     MapContext ->
     Method ->
     IO [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]
-mapMethodFlows mappers ctx method =
-    mapM (\cf -> fmap (cf,) (mapSingleFlow mappers ctx cf)) (methodFactors method)
+mapMethodFlows mappers ctx method = do
+    caps <- getNumCapabilities
+    let cfs = methodFactors method
+        n = length cfs
+        resolve cf = fmap (cf,) (mapSingleFlow mappers ctx cf)
+    -- Each CF resolves independently (first-matching mapper wins, no cross-CF
+    -- state), so chunk the CFs across capabilities and resolve the chunks
+    -- concurrently. 'mapConcurrently' preserves order and the chunks are
+    -- concatenated in order, so the result list — and every table built from it
+    -- — is identical to the serial 'mapM'; this is a pure speedup, not a
+    -- behaviour change. Chunking (rather than one task per CF) caps the live
+    -- thread count at 'caps' on methods with tens of thousands of CFs.
+    if caps <= 1 || n < parCfThreshold
+        then mapM resolve cfs
+        else concat <$> mapConcurrently (mapM resolve) (chunksOf (max 1 ((n + caps - 1) `div` caps)) cfs)
+  where
+    parCfThreshold = 1000
+    chunksOf _ [] = []
+    chunksOf k xs = let (h, t) = splitAt k xs in h : chunksOf k t
 
 {- | Map a single CF using the mapper handle cascade.
 Each mapper is tried in order; the first match wins.

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -63,6 +63,7 @@ module Method.Mapping (
     findFlowByNameComp,
     findFlowBySynonym,
     findFlowBySynonymComp,
+    findFlowBySynonymMemo,
     findFlowByCAS,
 
     -- * Statistics
@@ -175,6 +176,7 @@ buildMapContext db =
         , mcBioFlowsByCAS = dbFlowsByCAS db
         , mcSynonymDB = fromMaybe emptySynonymDB (dbSynonymDB db)
         , mcActivities = M.empty
+        , mcSynGroupFlows = M.empty
         }
 
 {- | Map all method flows to database flows using mapper handles.
@@ -185,10 +187,15 @@ mapMethodFlows ::
     MapContext ->
     Method ->
     IO [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]
-mapMethodFlows mappers ctx method = do
+mapMethodFlows mappers ctx0 method = do
     caps <- getNumCapabilities
     let cfs = methodFactors method
         n = length cfs
+        -- Precompute the synonym-group → flows memo for the groups this method's
+        -- CFs reference (each group expanded once), then resolve every CF against
+        -- it. Without it the synonym matcher re-expands a shared group — often a
+        -- large closure class — once per CF whose name lands in it.
+        ctx = ctx0{mcSynGroupFlows = buildSynGroupFlows ctx0 cfs}
         resolve cf = fmap (cf,) (mapSingleFlow mappers ctx cf)
     -- Each CF resolves independently (first-matching mapper wins, no cross-CF
     -- state), so chunk the CFs across capabilities and resolve the chunks
@@ -275,6 +282,48 @@ findFlowBySynonymComp synDB flowsByName name mComp =
                 pickByCompartment (concatMap (lookupFlows flowsByName) synonyms) mComp
   where
     lookupFlows fbn syn = M.findWithDefault [] (normalizeName syn) fbn
+
+{- | Synonym match that reads a precomputed group → flows memo. When
+'mapMethodFlows' has expanded this CF's group (the common path), the resolution
+is a single map lookup plus the compartment pick; otherwise it falls back to
+'findFlowBySynonymComp'. The memoized flow list is exactly that function's
+inline @concatMap@ (same elements, same order), so the pick — and the flow it
+returns — is identical: a pure speedup.
+-}
+findFlowBySynonymMemo ::
+    SynonymDB ->
+    M.Map Int [BiosphereFlow] ->
+    M.Map Text [BiosphereFlow] ->
+    Text ->
+    Maybe Compartment ->
+    Maybe BiosphereFlow
+findFlowBySynonymMemo synDB memo flowsByName name mComp =
+    case lookupSynonymGroup synDB name of
+        Nothing -> Nothing
+        Just gid -> case M.lookup gid memo of
+            Just flows -> pickByCompartment flows mComp
+            Nothing -> findFlowBySynonymComp synDB flowsByName name mComp
+
+{- | Expand, once per synonym group, the candidate flows reachable from that
+group's names — for exactly the groups the given CFs reference. 'mapMethodFlows'
+runs this before resolving a method's CFs, so the synonym matcher reads a shared
+(often large) group's flows from the memo instead of re-expanding it per CF. The
+per-group value is identical to 'findFlowBySynonymComp''s inline @concatMap@.
+-}
+buildSynGroupFlows :: MapContext -> [MethodCF] -> M.Map Int [BiosphereFlow]
+buildSynGroupFlows ctx cfs =
+    M.fromList
+        [ (gid, maybe [] (concatMap groupFlows) (getSynonyms synDB gid))
+        | gid <- gids
+        ]
+  where
+    synDB = mcSynonymDB ctx
+    flowsByName = mcBioFlowsByName ctx
+    groupFlows syn = M.findWithDefault [] (normalizeName syn) flowsByName
+    gids =
+        S.toList $
+            S.fromList
+                [gid | cf <- cfs, Just gid <- [lookupSynonymGroup synDB (mcfFlowName cf)]]
 
 {- | Pick the best flow match based on compartment preference. The flow's own
 compartment now lives in 'bfCompartment' as a structured 'Types.Compartment'

--- a/src/Plugin/Builtin.hs
+++ b/src/Plugin/Builtin.hs
@@ -158,7 +158,7 @@ synonymMapper =
         , mhMatch = \ctx query -> pure $ case query of
             MatchCF cf ->
                 (\f -> MapResult (bfId f) "synonym" 0.8)
-                    <$> Mapping.findFlowBySynonymComp (mcSynonymDB ctx) (mcBioFlowsByName ctx) (mcfFlowName cf) (mcfCompartment cf)
+                    <$> Mapping.findFlowBySynonymMemo (mcSynonymDB ctx) (mcSynGroupFlows ctx) (mcBioFlowsByName ctx) (mcfFlowName cf) (mcfCompartment cf)
             _ -> Nothing
         }
 
@@ -182,6 +182,7 @@ lciaAnalyzer =
                         , mcBioFlowsByCAS = dbFlowsByCAS db
                         , mcSynonymDB = fromMaybe emptySynonymDB (dbSynonymDB db)
                         , mcActivities = M.empty
+                        , mcSynGroupFlows = M.empty
                         }
             scores <-
                 mapM

--- a/src/Plugin/Types.hs
+++ b/src/Plugin/Types.hs
@@ -142,6 +142,14 @@ data MapContext = MapContext
     , mcBioFlowsByCAS :: !(Map Text [BiosphereFlow])
     , mcSynonymDB :: !SynonymDB
     , mcActivities :: !(Map Text [Activity])
+    , mcSynGroupFlows :: !(Map Int [BiosphereFlow])
+    {- ^ Memoized synonym-group id → candidate flows, precomputed once per
+    method by 'mapMethodFlows'. The synonym matcher resolves a CF whose name
+    lands in a shared (often large) synonym group via a single lookup here,
+    instead of re-expanding that group for every such CF. Empty when the
+    cascade runs without the precompute; the matcher then falls back to
+    expanding the group per call, so the result is unchanged either way.
+    -}
     }
 
 data MapQuery

--- a/test/PluginSpec.hs
+++ b/test/PluginSpec.hs
@@ -18,7 +18,7 @@ import Types (Database)
 
 -- | A minimal MapContext for testing
 emptyMapCtx :: MapContext
-emptyMapCtx = MapContext M.empty M.empty M.empty emptySynonymDB M.empty
+emptyMapCtx = MapContext M.empty M.empty M.empty emptySynonymDB M.empty M.empty
 
 -- | A test CF with a known UUID
 testCF :: MethodCF

--- a/test/SharedCASCoverageSpec.hs
+++ b/test/SharedCASCoverageSpec.hs
@@ -149,6 +149,7 @@ mapCtx =
         , mcBioFlowsByCAS = M.fromList [(waterCAS, allFlows)]
         , mcSynonymDB = emptySynonymDB
         , mcActivities = M.empty
+        , mcSynGroupFlows = M.empty
         }
 
 -- Build scoring tables through the real mapper + table build + broadcast fill.
@@ -228,6 +229,7 @@ carbonSynonyms =
         , mcBioFlowsByCAS = M.fromList [(methaneCAS, [methaneNonFossil, methaneFossil])]
         , mcSynonymDB = buildFromPairs [("Methane, biogenic", "Methane, non-fossil")]
         , mcActivities = M.empty
+        , mcSynGroupFlows = M.empty
         }
 
 buildCarbonTables :: IO MethodTables
@@ -340,6 +342,7 @@ fallbackCtx =
         , mcBioFlowsByCAS = M.empty
         , mcSynonymDB = emptySynonymDB
         , mcActivities = M.empty
+        , mcSynGroupFlows = M.empty
         }
 
 buildFallbackTables :: IO MethodTables
@@ -384,6 +387,7 @@ acrCtx =
         , mcBioFlowsByCAS = M.fromList [(acrCAS, [acrFlow])]
         , mcSynonymDB = emptySynonymDB
         , mcActivities = M.empty
+        , mcSynGroupFlows = M.empty
         }
 
 -- Regionalized analogue of 'acrMethod': both CFs carry a location, so they


### PR DESCRIPTION
## Problem

Building a method's LCIA lookup tables walks the CF→flow cascade once per
characterization factor. For USETox-based toxicity and ecotoxicity methods —
tens of thousands of CFs, most resolving through the synonym matcher — this one
loop dominates the cost, and building the full EF-3.1 method set over Agribalyse
took minutes.

Two things made it slow:

1. The per-CF resolution ran sequentially.
2. The synonym matcher expanded a CF's whole synonym group on every CF whose name
   lands in it — and the auto-extracted ILCD synonym groups are large closure
   classes (thousands of names), re-walked over and over.

## Changes

- **Parallelize the cascade.** Each CF resolves independently (first matching
  mapper wins, no cross-CF state), so the CFs are chunked across capabilities and
  resolved concurrently. The chunks are concatenated in order, so the result list
  is identical to the serial version.
- **Memoize the synonym-group expansion.** Each method precomputes, once, the
  group → candidate-flows expansion for the groups its CFs reference (each group
  expanded once), then resolves every CF against that memo. The per-group flow
  list is exactly the inline expansion — same elements, same order.

Both are pure speedups: the resolved flows, and every table built from them, are
unchanged.

## Result

Building the full EF-3.1 method set over Agribalyse: **~250s → ~23s**.

Scores are unchanged. The test suite passes, and a per-activity panel diff across
the 25 EF-3.1 categories is bit-identical before/after — the only movement is
~1e-16 float-reduction noise from the parallel linear solver, which varies
run-to-run independently of this change.
