### PR TITLE
fix(synonyms): drop CAS-ambiguous bridges from method-extracted synonyms

### DIFF
--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -3575,13 +3575,13 @@ autoCreateFlowSynonyms manager sourceName description pairs = do
                         , rdDescription = Just description
                         }
             addFlowSynonyms manager rd
-            -- Build SynonymDB directly from pairs (skip CSV round-trip)
+            -- Build SynonymDB directly from pairs (skip CSV round-trip). The pairs
+            -- are CAS-typed at extraction ('extractFromILCDFlows'): a name carried
+            -- by flows of more than one distinct CAS is an ambiguous bridge and is
+            -- dropped, so the transitive closure can no longer fuse unrelated
+            -- substances into a junk hub. Any residual oversized class is surfaced.
             let !synDB = buildFromPairs keptPairs
             atomically $ modifyTVar' (dmLoadedFlowSyns manager) (M.insert slug synDB)
-            -- Transitive closure has no degree cap, so a junk hub that fused
-            -- unrelated substances would silently pollute the fan-out. Surface
-            -- any implausibly large class (threshold 100, matching the offline
-            -- synonyms compiler) instead of dropping it silently.
             forM_ (oversizedClasses 100 synDB) $ \cls ->
                 reportProgress Warning $
                     "  [AUTO] "

--- a/src/SynonymDB/Extract.hs
+++ b/src/SynonymDB/Extract.hs
@@ -55,7 +55,27 @@ extractFromILCDFlows flowInfo =
             | info <- M.elems flowInfo
             , syn <- ilcdSynonyms info
             , syn /= ilcdBaseName info
+            , not (norm syn `S.member` casAmbiguous)
             ]
+  where
+    norm = T.toLower . T.strip
+    -- A name listed by flows of more than one distinct CAS is an ambiguous
+    -- bridge — e.g. "sodium", carried both by the element flow and by hundreds
+    -- of sodium-salt flows. Emitting it as a synonym lets the transitive closure
+    -- fuse those unrelated substances into one junk hub, which then leaks an
+    -- organic compound's characterization factor onto the inorganic element.
+    -- Typed by CAS: drop such names so they cannot bridge across substances.
+    casOfName :: M.Map Text (S.Set Text)
+    casOfName =
+        M.fromListWith
+            S.union
+            [ (norm nm, S.singleton cas)
+            | info <- M.elems flowInfo
+            , Just cas <- [ilcdCAS info]
+            , not (T.null cas)
+            , nm <- ilcdBaseName info : ilcdSynonyms info
+            ]
+    casAmbiguous = M.keysSet (M.filter ((> 1) . S.size) casOfName)
 
 -- | Render synonym pairs as CSV with header.
 synonymPairsToCSV :: [(Text, Text)] -> BL.ByteString

--- a/src/SynonymDB/Extract.hs
+++ b/src/SynonymDB/Extract.hs
@@ -11,6 +11,7 @@ module SynonymDB.Extract (
     synonymPairsToCSV,
 ) where
 
+import Control.Monad (mfilter)
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as BLC
 import qualified Data.Map.Strict as M
@@ -21,6 +22,7 @@ import qualified Data.Text.Encoding as T
 import Data.UUID (UUID)
 
 import Method.FlowResolver (ILCDFlowInfo (..))
+import SynonymDB (normalizeName)
 import Types (BioFlowDB, BiosphereFlow (..))
 
 {- | Extract synonym pairs from EcoSpold2 biosphere flows.
@@ -51,31 +53,38 @@ extractFromILCDFlows :: M.Map UUID ILCDFlowInfo -> [(Text, Text)]
 extractFromILCDFlows flowInfo =
     S.toList $
         S.fromList
-            [ (ilcdBaseName info, syn)
+            [ (base, syn)
             | info <- M.elems flowInfo
+            , let base = ilcdBaseName info
             , syn <- ilcdSynonyms info
-            , syn /= ilcdBaseName info
-            , not (norm syn `S.member` casAmbiguous)
+            , syn /= base
+            , not (ambiguous base || ambiguous syn)
             ]
   where
-    norm = T.toLower . T.strip
-    -- A name listed by flows of more than one distinct CAS is an ambiguous
-    -- bridge — e.g. "sodium", carried both by the element flow and by hundreds
-    -- of sodium-salt flows. Emitting it as a synonym lets the transitive closure
-    -- fuse those unrelated substances into one junk hub, which then leaks an
-    -- organic compound's characterization factor onto the inorganic element.
-    -- Typed by CAS: drop such names so they cannot bridge across substances.
-    casOfName :: M.Map Text (S.Set Text)
-    casOfName =
+    -- Test a name with the SAME normalization the closure keys by
+    -- ('SynonymDB.buildFromPairs' → 'normalizeName'): the name the closure would
+    -- fuse into one node is exactly the name whose ambiguity we check. A weaker
+    -- local normalizer (lower+strip only) leaves punctuation/whitespace/unit
+    -- variants under distinct keys, so a junk hub slips past the filter.
+    ambiguous nm = normalizeName nm `S.member` casAmbiguous
+    -- A name is an ambiguous bridge when the flows carrying it span more than one
+    -- substance identity. Identity is the flow's CAS, or 'Nothing' when it has
+    -- none: an un-annotated flow cannot be proven to be the same substance, so a
+    -- name shared by a CAS-less flow and a CAS-bearing one still counts as a
+    -- bridge. Dropping it stops the transitive closure from fusing unrelated
+    -- substances into one junk hub (which then leaks a characterization factor
+    -- across them); same-CAS flows lose nothing, as the CAS cascade ('mtCasCF')
+    -- already matches them at lookup time. Both endpoints of every pair are
+    -- checked, so an ambiguous baseName is dropped too, not just a synonym.
+    identityOfName :: M.Map Text (S.Set (Maybe Text))
+    identityOfName =
         M.fromListWith
             S.union
-            [ (norm nm, S.singleton cas)
+            [ (normalizeName nm, S.singleton (mfilter (not . T.null) (ilcdCAS info)))
             | info <- M.elems flowInfo
-            , Just cas <- [ilcdCAS info]
-            , not (T.null cas)
             , nm <- ilcdBaseName info : ilcdSynonyms info
             ]
-    casAmbiguous = M.keysSet (M.filter ((> 1) . S.size) casOfName)
+    casAmbiguous = M.keysSet (M.filter ((> 1) . S.size) identityOfName)
 
 -- | Render synonym pairs as CSV with header.
 synonymPairsToCSV :: [(Text, Text)] -> BL.ByteString

--- a/test/SynonymExtractSpec.hs
+++ b/test/SynonymExtractSpec.hs
@@ -27,6 +27,38 @@ spec = describe "extractFromILCDFlows" $ do
                     ]
         extractFromILCDFlows flows `shouldBe` []
 
+    it "drops a name shared by a CAS-less flow and a CAS-bearing flow (absence is its own identity)" $ do
+        -- "shared ion" is carried by an element flow with no CAS and by a salt flow
+        -- with a CAS. The two cannot be proven the same substance, so the bridge is
+        -- dropped rather than fused — even though only one side carries a CAS.
+        let flows =
+                M.fromList
+                    [ (uuidA, mkFlow "Sodium" Nothing ["shared ion"])
+                    , (uuidB, mkFlow "Sodium chloride" (Just "7647-14-5") ["shared ion"])
+                    ]
+        extractFromILCDFlows flows `shouldBe` []
+
+    it "drops pairs whose baseName is CAS-ambiguous, not only ambiguous synonyms" $ do
+        -- One baseName "Cresol" is carried by two isomers (distinct CAS), each with a
+        -- unique synonym. The shared baseName is the bridge, so both pairs drop.
+        let flows =
+                M.fromList
+                    [ (uuidA, mkFlow "Cresol" (Just "95-48-7") ["o-cresol"])
+                    , (uuidB, mkFlow "Cresol" (Just "108-39-4") ["m-cresol"])
+                    ]
+        extractFromILCDFlows flows `shouldBe` []
+
+    it "keys ambiguity by the closure's normalization, so punctuation variants share an identity" $ do
+        -- "foo, bar" and "foo bar" are one node to the closure (normalizeName drops
+        -- the comma); carried by two distinct-CAS flows they form a bridge, so a
+        -- weaker lower+strip key must not let them slip through as separate names.
+        let flows =
+                M.fromList
+                    [ (uuidA, mkFlow "Substance R" (Just "1-1-1") ["foo, bar"])
+                    , (uuidB, mkFlow "Substance S" (Just "2-2-2") ["foo bar"])
+                    ]
+        extractFromILCDFlows flows `shouldBe` []
+
 mkFlow :: Text -> Maybe Text -> [Text] -> ILCDFlowInfo
 mkFlow name cas syns =
     ILCDFlowInfo


### PR DESCRIPTION
## Why

When synonym pairs are extracted from ILCD flow definitions, the transitive
closure over those pairs can fuse unrelated substances. A name like "sodium" is
listed both by the sodium *element* flow and by hundreds of sodium-*salt* flows
that each carry a different CAS. Emitting "sodium" as a synonym chains all of
them into a single oversized closure class — a junk hub. Once fused, a
characterization factor leaks across substances: an organic compound's
freshwater-ecotoxicity factor lands on the inorganic element.

The loader already warns about these oversized classes but still builds them.

## What

`extractFromILCDFlows` now types candidate synonyms by CAS: a name carried by
flows of more than one distinct CAS is an ambiguous bridge and is dropped, so
the closure can no longer span distinct substances. Names genuinely shared by a
single substance (one CAS) are kept.

CAS-based equivalence is deliberately *not* emitted as synonym pairs at all —
flows sharing a CAS are already matched by the CAS cascade at lookup time, so
chaining them here adds no match, only junk bridges.

## Effect

On Agribalyse 3.2 scored with the JRC EF-3.1 (ILCD) collection, the massive
freshwater-ecotoxicity over-count on inorganic ion flows (sodium/iron ions
inheriting an organic toxicant's factor) collapses to near parity with the
adapted EF-3.1 reference. Full local test suite green.
