### PR TITLE
fix(lcia): characterize ionising radiation against the kBq reference unit

### DIFF
--- a/data/units.csv
+++ b/data/units.csv
@@ -147,10 +147,10 @@ km/h,length/time,0.27778
 kph,length/time,0.27778
 mph,length/time,0.44704
 mile/h,length/time,0.44704
-kbq,/time,1000.0
-kilobecquerel,/time,1000.0
-bq,/time,1.0
-becquerel,/time,1.0
+kbq,/time,1.0
+kilobecquerel,/time,1.0
+bq,/time,0.001
+becquerel,/time,0.001
 m2*year,area*time,1.0
 m²*year,area*time,1.0
 m2.year,area*time,1.0

--- a/src/UnitConversion.hs
+++ b/src/UnitConversion.hs
@@ -116,9 +116,14 @@ convertUnit cfg fromUnit toUnit amount = do
         then Just (amount * factorFrom / factorTo)
         else Nothing
 
-{- | Canonical (base) unit name for the dimension of a given unit.
-The base unit is the one whose factor to SI is 1.0. Returns 'Nothing' if the
-input unit is unknown or if no base unit is defined for its dimension.
+{- | Canonical (reference) unit name for the dimension of a given unit.
+The reference unit is the one whose factor is 1.0 in @units.csv@ — normally the
+SI base, but a dimension may instead pick the unit its characterization factors
+are authored in. Radioactivity uses @kBq@ (not the SI @Bq@) because EF/ILCD
+ionising-radiation CFs are defined per kBq, and 'convertForCharacterization'
+normalizes a flow to this reference before applying a result-expression CF.
+Returns 'Nothing' if the input unit is unknown or its dimension defines no
+reference unit.
 -}
 canonicalUnitFor :: UnitConfig -> Text -> Maybe Text
 canonicalUnitFor cfg unitText = do

--- a/test/UnitConversionSpec.hs
+++ b/test/UnitConversionSpec.hs
@@ -116,6 +116,19 @@ spec = do
                 Just v -> v `shouldSatisfy` (\x -> abs (x - 3.6) < 0.001)
                 Nothing -> expectationFailure "conversion failed"
 
+        it "converts 1 kBq to 1000 Bq" $ do
+            cfg <- loadFullUnitConfig
+            convertUnit cfg "kBq" "Bq" 1.0 `shouldBe` Just 1000.0
+
+        -- Radioactivity's reference unit is kBq, not the SI Bq: EF/ILCD
+        -- ionising-radiation CFs are authored per kBq, and a result-expression
+        -- CF unit ("kBq U235 equivalents") is unknown to the config, so a Bq
+        -- inventory flow must normalize to kBq (÷1000) before the CF applies.
+        -- Guards data/units.csv against reverting to a Bq-canonical /time.
+        it "normalizes Bq to canonical kBq (ionising-radiation CFs are per kBq)" $ do
+            cfg <- loadFullUnitConfig
+            normalizeToCanonical cfg "Bq" 1000.0 `shouldBe` Just ("kbq", 1.0)
+
         it "returns Nothing for incompatible units" $ do
             cfg <- loadFullUnitConfig
             convertUnit cfg "kg" "m" 1.0 `shouldBe` Nothing


### PR DESCRIPTION
## Why

EF/ILCD ionising-radiation characterization factors are authored **per kBq**, but `units.csv` declared **Bq** (the SI base) as the canonical unit of the radioactivity (`/time`) dimension.

When a method's CF carries a result-expression unit unknown to the unit config — the ILCD case, where `mcfUnit` = `"kBq U235 equivalents"` — `convertForCharacterization` normalizes the inventory flow to its dimension's canonical unit before applying the CF. With Bq as canonical, a Radon-222 flow measured in Bq was left in Bq and characterized as if it were kBq: a **×1000 over-count** across the whole ionising-radiation category.

The SimaPro-adapted method was unaffected because its parser stamps the per-flow reference unit `"kBq"`, which the config knows, so the conversion took the direct `convertUnit` path.

## What

Make **kBq** the reference unit of the `/time` dimension in `units.csv` (factor 1.0), so a Bq flow normalizes ÷1000 to kBq. `convertUnit` is ratio-based, so any method that already converts via the known-unit path is **bit-identical** — the only score that moves is the ILCD over-count.

`canonicalUnitFor`'s doc now states that a dimension's reference unit is normally the SI base but may instead be the unit its CFs are authored in (radioactivity → kBq). Two tests in `UnitConversionSpec` lock the production `units.csv` against reverting to a Bq-canonical `/time`.

## Effect

On Agribalyse 3.2, JRC ionising radiation drops from **×1000** the adapted reference to **1.00** across four diverse products (yogurt, beef, rapeseed oil, tomato), every other category unchanged. Full local test suite green (1476 examples).
