### PR TITLE
LCIA: deterministic regional-projection dedup + single medium canonicalization

### DIFF
--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -734,13 +734,20 @@ projectRegionalResourceFlows synDB bioFlows mappings =
     cfMedium cf = case mcfCompartment cf of
         Just (Compartment m _ _) -> normalizeMedium (T.toLower m)
         Nothing -> ""
+    -- A projection key (group/name, medium, region) drops the subcompartment, so
+    -- two located CFs of the same substance can land on one key. 'M.fromList' would
+    -- then keep whichever came last in 'mappings' — order-dependent and silent.
+    -- Keep the larger (more conservative, never-undercounting) factor instead, the
+    -- same value preference 'buildMethodTables' applies through 'preferBetter'.
+    preferHigherCF a b = if mcfValue a >= mcfValue b then a else b
     -- Located CFs reached two ways: by the matched flow's synonym GROUP — a CF
     -- whose name is bridged to the flow (withdrawal @"river water"@ → @"Water,
     -- river"@) — and by the CF's own NAME — a CF whose name equals the flow's
     -- region-stripped base (the bare @"Water"@ release CF → @"Water, FR"@).
     byGroup :: M.Map (Int, Text, Text) MethodCF
     byGroup =
-        M.fromList
+        M.fromListWith
+            preferHigherCF
             [ ((grp, flowMedium flow, loc), cf)
             | (cf, Just (flow, _)) <- mappings
             , Just loc <- [mcfConsumerLocation cf]
@@ -748,7 +755,8 @@ projectRegionalResourceFlows synDB bioFlows mappings =
             ]
     byName :: M.Map (Text, Text, Text) MethodCF
     byName =
-        M.fromList
+        M.fromListWith
+            preferHigherCF
             [ ((normalizeName (mcfFlowName cf), cfMedium cf, loc), cf)
             | (cf, _) <- mappings
             , Just loc <- [mcfConsumerLocation cf]

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -626,11 +626,7 @@ buildMethodIndex method =
     cfMedium :: MethodCF -> Text
     cfMedium cf = case mcfCompartment cf of
         Nothing -> ""
-        Just (Compartment med _ _) -> normalizeMediumIdx (T.toLower med)
-
-    normalizeMediumIdx m
-        | m == "natural resource" = "resource"
-        | otherwise = m
+        Just (Compartment med _ _) -> normalizeMedium (T.toLower med)
 
 {- | Build 'MethodTables' from raw mappings and a 'CompartmentMap'.
 

--- a/test/ProjectRegionalSpec.hs
+++ b/test/ProjectRegionalSpec.hs
@@ -75,6 +75,18 @@ spec = describe "projectRegionalResourceFlows" $ do
                     }
         runWith [baseFlow, frFlowSlashed] `shouldContain` [frProjection]
 
+    it "dedups colliding located CFs deterministically — higher value wins, order-independent" $ do
+        let cfLo = mkLocatedCF "river water" 6.98 (Just "FR")
+            cfHi = mkLocatedCF "river water" 9.99 (Just "FR")
+            frFlow = mkResourceFlow 14 "Water, river, FR"
+            flows = M.fromList [(bfId f, f) | f <- [baseFlow, frFlow]]
+            run ms = projected (projectRegionalResourceFlows synDB flows ms)
+            mLo = [(cfLo, Just (baseFlow, BySynonym)), (cfHi, Just (baseFlow, BySynonym))]
+            mHi = [(cfHi, Just (baseFlow, BySynonym)), (cfLo, Just (baseFlow, BySynonym))]
+        run mLo `shouldContain` [("Water, river, FR", Nothing, 9.99)]
+        run mHi `shouldContain` [("Water, river, FR", Nothing, 9.99)]
+        run mLo `shouldNotContain` [("Water, river, FR", Nothing, 6.98)]
+
     it "leaves an unlocated method untouched (the SimaPro name-regionalized convention)" $ do
         let cfGlobal = mkLocatedCF "river water" 6.98 Nothing
             frFlow = mkResourceFlow 11 "Water, river, FR"


### PR DESCRIPTION
Two robustness fixes to the regional CF mapping introduced in #160, found in review.

**Deterministic dedup of colliding located CFs.** `projectRegionalResourceFlows` built its `byGroup`/`byName` lookup maps with `M.fromList`. When two located CFs share a projection key — same synonym group (or name), medium and region, differing only in a field the key drops such as subcompartment — `M.fromList` silently keeps whichever appears last in the mapping list, so the projected factor was order-dependent and could drop the stronger CF. Both maps now use `M.fromListWith`, keeping the larger (more conservative) value — the same preference `buildMethodTables` already applies through `preferBetter`. A `ProjectRegionalSpec` case pins the order-independence.

**Single source of truth for medium canonicalization.** `buildMethodIndex` carried a private `normalizeMediumIdx` that was a verbatim copy of the top-level `normalizeMedium`. The method index is written with one and read (regional projection, `findSimilarCFs`) with the other, so any future change to the rule would silently desync the index key from the query key and a flow would miss its CF with no error. The index now routes through the single `normalizeMedium`.

Validated: full suite green (1490 examples, 0 failures); and on the EF-3.1 (JRC) × Agribalyse 3.2 panel the four reference products (yogurt, beef, rapeseed oil, tomato) score identically before and after across ECS, PEF and the regionalized water-use indicator — the dedup removes a latent order-dependence without moving any real score.