### PR TITLE
docs: add engine architecture overview

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,8 +72,8 @@ of the system; the CLI and REPL are just thin HTTP clients.
 | `volca server`            | Launches the HTTP server (Warp + Servant), loads databases into memory |
 | `volca repl`              | Interactive REPL — auto-starts the server if needed               |
 | `volca <command>`         | Thin CLI client: queries the server over HTTP (~0.2 s/command)    |
-| `volca --dump-openapi`    | Emits the OpenAPI specification on stdout                         |
-| `volca --dump-mcp-tools`  | Emits the MCP tool definitions on stdout                         |
+| `volca dump-openapi`      | Emits the OpenAPI specification on stdout                         |
+| `volca dump-mcp-tools`    | Emits the MCP tool definitions on stdout                         |
 | `volca stop`              | Stops the running server                                         |
 
 ## Two key flows

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,279 @@
+# VoLCA Engine Architecture
+
+VoLCA is a Life Cycle Assessment (LCA) engine written in Haskell. It loads LCA
+databases (EcoSpold2, EcoSpold1, SimaPro CSV, ILCD, Brightway Excel), builds sparse
+technosphere/biosphere matrices, and computes life-cycle inventories (LCI) and impact
+scores (LCIA) — **entirely in memory**.
+
+The project compiles into a **single binary** (`volca`). The HTTP server is the heart
+of the system; the CLI and REPL are just thin HTTP clients.
+
+## Overview
+
+```
+                                  CLIENTS
+   ┌──────────┬───────────┬──────────────┬──────────────┬──────────────┐
+   │   CLI    │   REPL    │  any custom  │  MCP client  │  pyvolca /   │
+   │  (HTTP)  │  (HTTP)   │   web UI     │ (Claude/GPT) │  curl        │
+   └────┬─────┴─────┬─────┴──────┬───────┴──────┬───────┴──────┬───────┘
+        └───────────┴────────────┴──── HTTP ────┴──────────────┘
+                                   │
+ ══════════════════════════════════▼══════════════ "volca server" process
+   ┌─────────────────────────────────────────────────────────────────┐
+   │  EDGE      API.Auth  — session cookie, single-code login (opt.) │
+   ├──────────────┬─────────────┬───────────────┬────────────────────┤
+   │ API          │ MCP server  │ Static files  │ OpenAPI / licenses │
+   │ /api/v1/*    │ API.MCP     │ for embedded  │ API.OpenApi        │
+   │ API.Routes   │ (AI tools)  │ custom web UI │                    │
+   └──────┬───────┴──────┬──────┴───────────────┴────────────────────┘
+          └──────────────┘
+                  │
+   ┌──────────────▼──────────────────────────────────────────────────┐
+   │  SERVICE     Service.hs · Service/Aggregate.hs                  │
+   │  inventory · impacts · tree · graph · supply-chain · consumers  │
+   │  contributions · what-if (substitutions) · batch                │
+   └──────────────┬──────────────────────────────────────────────────┘
+                  │
+   ┌──────────────▼──────────────────────────────────────────────────┐
+   │ ENGINE CORE   (in memory, with Software Transactional Memory)   │
+   │                                                                 │
+   │ Database.Manager ──► TVar [LoadedDatabase]   ◄── Config (TOML)  │
+   │        │                                                        │
+   │        ├─ Types.hs        domain model (Activity/Flow/Exchange) │
+   │        ├─ Database.hs     builds the sparse A / B matrices      │
+   │        ├─ Matrix + SharedSolver   (I−A)⁻¹·f = s   then   B·s = g│
+   │        ├─ Method.Mapping  LCIA: CF cascade UUID→CAS→name→synonym│
+   │        ├─ Search          BM25 (full-text) + Fuzzy (trigrams)   │
+   │        ├─ Tree / Expr / UnitConversion / SynonymDB              │
+   │        └─ CrossLinking    cross-database supplier resolution    │
+   └─────┬─────────────────────────────────────────────────┬─────────┘
+         │ at load                                         │ at solve
+   ┌─────▼──────────────────────────────────┐     ┌────────▼──────────┐
+   │  INGESTION                             │     │  NATIVE           │
+   │  Parsers : EcoSpold2 · EcoSpold1 ·     │     │  Direct sparse    │
+   │   SimaPro CSV · ILCD · Brightway .xlsx │     │  MUMPS solver     │
+   │  Methods : ILCD / CSV / olca packages  │     │  (Fortran)        │
+   │  Archives : zip · 7z · gz · xz         │     │  via mumps-hs     │
+   │  Cache : Data.Store, schema-invalidated│     │  (FFI / cbits)    │
+   └────────────────────────────────────────┘     └───────────────────┘
+
+   ┌──────────────────── CROSS-CUTTING ───────────────────────────────┐
+   │  Plugin.Bridge → external plugins (Python/shell, JSON over stdio)│
+   │  Progress (structured logs)   ·   Version                        │
+   └──────────────────────────────────────────────────────────────────┘
+```
+
+## Entry points
+
+`app/Main.hs` dispatches on the command:
+
+| Command                   | Role                                                              |
+|---------------------------|-------------------------------------------------------------------|
+| `volca server`            | Launches the HTTP server (Warp + Servant), loads databases into memory |
+| `volca repl`              | Interactive REPL — auto-starts the server if needed               |
+| `volca <command>`         | Thin CLI client: queries the server over HTTP (~0.2 s/command)    |
+| `volca --dump-openapi`    | Emits the OpenAPI specification on stdout                         |
+| `volca --dump-mcp-tools`  | Emits the MCP tool definitions on stdout                         |
+| `volca stop`              | Stops the running server                                         |
+
+## Two key flows
+
+### 1 — Startup / loading a database
+
+`volca.toml` → `Database.Manager` → for each database: archive extraction →
+format parser → domain model → `Database.hs` assembles the sparse **A** (technosphere)
+and **B** (biosphere) triples → `Data.Store` serialisation into a cache co-located
+with the source file.
+
+The cache is invalidated automatically when the schema changes. Measured on
+a +25k activities database: **~50 s cold** vs. **~4 s warm**.
+
+### 2 — Computing an impact
+
+HTTP request → `API.Auth` → Servant handler (`API.Routes`) → `Service` → `SharedSolver`.
+
+The **MUMPS LU factorisation is lazy**: it is computed only on the first `solve`,
+guarded by an `MVar` for thread safety, then reused for the whole lifetime of the
+server. We solve the scaling vector `s`, then the inventory `g = B·s`, then
+`Method.Mapping` applies the characterisation factors (CFs) to obtain the LCIA score.
+
+Equations solved:
+
+```
+(I − A)⁻¹ · f = s      A = technosphere matrix, f = final demand, s = scaling
+        B · s = g      B = biosphere matrix,    g = inventory (LCI)
+       CF · g = score  characterisation factors → impact (LCIA)
+```
+
+## Zoom: inside the core engine
+
+The core engine is where databases live in memory and where every LCA number is
+produced. It has two halves: an **immutable, cacheable data model** (`Database`) and
+a small amount of **mutable runtime state** (`Database.Manager` + `SharedSolver`).
+
+### State model
+
+```
+ Database.Manager  ──  mutable state hub, every field an STM TVar
+ ┌────────────────────────────────────────────────────────────────────────────┐
+ │  dmLoadedDbs        TVar (Map Text LoadedDatabase)  one entry per loaded DB│
+ │  dmLoadedMethods    TVar (Map Text MethodCollection) parsed CFs + NW data  │
+ │  dmIndexedDbs       TVar (Map Text IndexedDatabase)  cross-DB link indexes │
+ │  dmStagedDbs        TVar (Map Text StagedDatabase)   parsed, not yet linked│
+ │  dmLoaded{FlowSyns,CompMaps,UnitDefs}   reference data (toggleable)        │
+ │  dmMethod{Mapping,Tables,SetTables}Cache  memoised LCIA lookup tables      │
+ │  dmPlugins  PluginRegistry        dmGeographies  Map code → (name, parents)│
+ └─────────────────────────────────┬──────────────────────────────────────────┘
+                                   │  one value per loaded database
+                                   ▼
+ ┌──────────────────────────  LoadedDatabase  ──────────────────────────────┐
+ │                                                                          │
+ │  ┌──────────────  Database  (immutable · serialised to cache)  ────────┐ │
+ │  │  DOMAIN        dbActivities : Vector Activity                       │ │
+ │  │                dbBioFlows · dbTechFlows · dbUnits                   │ │
+ │  │  INTERNING     dbProcessIdTable : ProcessId ↔ (activityUUID,        │ │
+ │  │                productUUID)   — Int32 keys for matrix indexing      │ │
+ │  │  INDEXES       dbIndexes : by name / geo / flow / category          │ │
+ │  │                dbBM25Index · dbProductSearchIndex   (built at load) │ │
+ │  │  SPARSE        dbTechnosphereTriples → A   (activities × activities)│ │
+ │  │  MATRICES      dbBiosphereTriples    → B   (bioflows  × activities) │ │
+ │  │  CROSS-DB      dbCrossDBLinks · dbDependsOn · dbLinkingStats        │ │
+ │  │  LCIA HELPERS  dbFlowsByName · dbFlowsByCAS · dbSynonymDB (runtime) │ │
+ │  └─────────────────────────────────────────────────────────────────────┘ │
+ │                                                                          │
+ │  ┌──────────────  SharedSolver  (mutable · runtime only)  ─────────────┐ │
+ │  │  solverLock             : MVar ()      serialises factorisation     │ │
+ │  │  solverFactorizationVar : MVar (Maybe MatrixFactorization)          │ │
+ │  │      └─ lazy LU factorisation of the (I − A) system matrix,         │ │
+ │  │         computed on first solve, then reused for the process life   │ │
+ │  └─────────────────────────────────────────────────────────────────────┘ │
+ │                                                                          │
+ │  ldConfig : DatabaseConfig                                               │
+ └──────────────────────────────────────────────────────────────────────────┘
+```
+
+Only the `Database` fields above the dashed line are serialised by the `Data.Store`
+cache. Runtime-only fields (factorisation, synonym DB, name/CAS indexes, BM25 index)
+are rebuilt on load — cheap compared to parsing.
+
+### Computation pipeline
+
+A single impact request walks the LCA equations left to right. The MUMPS
+factorisation is built once (lazily) and every later request reuses it.
+
+```
+ ProcessId  (Int32, interned from the activity/product UUID pair)
+    │
+    │  buildDemandVectorFromIndex
+    ▼
+  f   final demand vector  (1.0 at the target activity, 0 elsewhere)
+    │
+    │  SharedSolver.solveWithSharedSolver          A = technosphere matrix
+    │     ⇒  (I − A) · s = f       solved by MUMPS LU factorisation (reused)
+    ▼
+  s   scaling vector        (how much each activity must run)
+    │
+    │  applyBiosphereMatrix                        B = biosphere matrix
+    │     ⇒  g = B · s
+    ▼
+  g   life-cycle inventory (LCI)  ───────────────────────────► InventoryExport
+    │
+    │  Method.Mapping.computeLCIAScoreFromTables
+    │     ⇒  score = Σ  CF(flow) · g(flow)
+    ▼
+  LCIA score  (+ per-flow / per-activity contributions) ─────► LCIAResult
+```
+
+`Service.hs` orchestrates this; `Matrix.hs` owns the linear algebra; `SharedSolver.hs`
+guards the factorisation and exposes cached scaling/inventory helpers. Batch requests
+take the same path with a single multi-RHS solve (`computeInventoryMatrixBatch`).
+
+### LCIA mapping cascade
+
+A method collection ships characterisation factors (CFs) keyed by its own flow
+nomenclature. They must be matched to the loaded database's biosphere flows. The
+match is a **first-hit-wins cascade** (`Method.Mapping`, default `UUID → CAS → Name
+→ Synonym`):
+
+```
+  MethodCF  (one CF from the method collection)        DB biosphere flows
+       │                                                      │
+       ▼                                                      ▼
+   ┌────────────────────  Method.Mapping cascade  ──────────────────────┐
+   │  ① ByUUID     CF target UUID == flow UUID      (dbBioFlows)        │
+   │  ② ByCAS      CAS number match                 (dbFlowsByCAS)      │
+   │  ③ ByName     normalised-name match            (dbFlowsByName)     │
+   │  ④ BySynonym  synonym expansion then name match (dbSynonymDB)      │
+   └─────────────────────────────────┬───────────────────────────────────┘
+       first strategy that hits wins → (Flow, MatchStrategy)
+                                     │  computeMappingStats → coverage %
+                                     ▼
+   MethodTables   mtExactCF · mtFallbackCF · mtRegionalizedCF · mtBroadcast
+       │  built once by buildMethodTables, memoised in dmMethodTablesCache
+       ▼
+   score = Σ  CF(flow) · g(flow)
+```
+
+`MethodTables` collapses the cascade and absorbs unit conversion into plain `Map`
+lookups, so scoring itself is a fast dot product over the inventory `g`.
+
+### What-if and cross-database solving
+
+- **What-if substitution** — `Matrix.perturbA` / `perturbABatch` apply an upstream
+  activity swap to the `A` matrix and the system is re-solved, yielding a modified
+  inventory and impacts in one call (~120 ms) without touching the original database.
+- **Cross-DB solving** — when a database declares `dbCrossDBLinks` (e.g. a sector
+  database referencing Agribalyse), the root scaling vector feeds supplier demand
+  vectors into each dependency database. Each dependency runs its own multi-RHS
+  solve; `SharedSolver` recurses through the dependency DAG (depth-capped at 10) and
+  merges per-database inventories with `M.unionWith (+)`.
+
+## Module reference
+
+| Module / folder             | Role                                                                 |
+|------------------------------|----------------------------------------------------------------------|
+| `app/Main.hs`               | Entry point: CLI / server / REPL dispatch                            |
+| `API/Routes.hs`             | Servant `/api/v1/*` route definitions and handlers                  |
+| `API/Auth.hs`               | Authentication middleware (session cookie, single-code login)        |
+| `API/MCP.hs`                | MCP server: tools exposed to AI assistants                          |
+| `API/OpenApi.hs`            | OpenAPI specification generation                                    |
+| `CLI/`                      | HTTP client, argument parser, REPL                                  |
+| `Config.hs`                 | TOML configuration loading                                          |
+| `Service.hs`, `Service/`    | Orchestration: inventory, impacts, tree, graph, supply-chain, etc.   |
+| `Database/Manager.hs`       | Loaded-database state (`TVar`), load/unload, methods, refdata        |
+| `Database/Loader.hs`        | Loading and dispatch to parsers                                     |
+| `Database/CrossLinking.hs`  | Cross-database supplier resolution, topological order               |
+| `Database/Upload.hs`        | Database upload via the API                                         |
+| `Database.hs`               | Sparse A / B matrix construction, normalisation                     |
+| `Types.hs`                  | Domain model (Activity, Flow, Exchange, Database) — sum types        |
+| `Matrix.hs`                 | Matrix LCA computations via the MUMPS solver                        |
+| `SharedSolver.hs`           | Lazy thread-safe LU factorisation, caches, back-substitution        |
+| `mumps-hs/`                 | FFI bindings to the MUMPS direct sparse solver (Fortran)            |
+| `EcoSpold/Parser2.hs`       | EcoSpold2 parser (`.spold`)                                         |
+| `EcoSpold/Parser1.hs`       | EcoSpold1 parser (`.xml`)                                           |
+| `SimaPro/Parser.hs`         | SimaPro CSV parser                                                  |
+| `ILCD/Parser.hs`            | ILCD process dataset parser                                         |
+| `BrightwayExcel/Parser.hs`  | Brightway Excel (`.xlsx`) inventory parser                          |
+| `Method/Parser*.hs`         | Method collection loading (ILCD, CSV, SimaPro, olca)                |
+| `Method/Mapping.hs`         | CF matching cascade (UUID → CAS → name → synonym), LCIA scoring     |
+| `Search/BM25.hs`            | BM25 full-text search index                                         |
+| `Search/Fuzzy.hs`           | Trigram fuzzy search                                                |
+| `Tree.hs`                   | Supply-chain tree construction (loop-aware)                         |
+| `Expr.hs`                   | Exchange formula / parameter evaluation                             |
+| `UnitConversion.hs`         | Unit conversion                                                     |
+| `SynonymDB.hs`              | Synonyms auto-extracted from databases and methods                  |
+| `Plugin/Bridge.hs`          | Bridge to external plugins via JSON over stdin/stdout               |
+| `Progress.hs`               | Structured progress logs and reports                                |
+
+## Structuring principles
+
+- **Pure core, effects at the edges** — parsers, the MUMPS FFI and I/O are confined;
+  the computation is pure.
+- **Impossible states made impossible** — loading statuses, domain model and states
+  as sum types, with no `wildcard` pattern on sums.
+- **Zero crashes** — `Either Text a` / `Maybe` propagated; no `error`, `undefined`,
+  or partial function. No silent fallback value: missing data surfaces as an explicit
+  error.
+- **Simultaneous multi-database** — several databases loaded in parallel, with
+  cross-nomenclature flow linking (`CrossLinking`).
+- **Schema-invalidated cache** — co-located with the source, transparent.


### PR DESCRIPTION
## What

Adds `docs/architecture.md` — a top-level architecture overview of the VoLCA engine.

## Why

The README documents the feature spec and AGENTS.md guides agents, but neither gives a "how it all fits together" map. This fills that gap:

- **Single-binary layout** — the HTTP server is the core; CLI, REPL, MCP and web UI are thin clients.
- **Two key flows** — database load (parse → sparse A/B matrices → schema-invalidated `Data.Store` cache) and impact solve (lazy MUMPS LU factorisation, computed once and reused for the server's lifetime).
- **In-memory state model** — `Database.Manager` TVars, the immutable/cacheable `Database`, and the runtime-only `SharedSolver`.
- **LCIA characterisation cascade** — UUID → CAS → name → synonym, first-hit-wins.
- **What-if and cross-database solving**, plus a module reference table.

Written entirely in English and covers all five database formats, including Brightway Excel (`.xlsx`). Content verified against the current engine sources.