### PR TITLE
fix(lcia): SimaPro CFs are name-regionalized, not consumer-location

### DIFF
--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -944,8 +944,15 @@ buildMethodTables cmap energyDensities mappings =
             -- Subcompartment-blind on purpose: a resource flow and the CF that
             -- characterizes it routinely disagree on subcompartment, so a
             -- subcomp-strict bridge would zero whole resource categories.
-            -- Non-regionalized CFs only; the regionalized ones go to
-            -- 'mtRegionalCasCF'.
+            -- Regionalized CFs stay out, whichever way they carry their
+            -- region: consumer-located rows go to 'mtRegionalCasCF', and
+            -- name-regionalized rows ("Water, CH" — the SimaPro convention)
+            -- are dropped via 'extractLocationSuffix'. The bridge is
+            -- name-blind, so a region-specific row would collide with the
+            -- region-less default on the one (CAS, medium) key and the
+            -- magnitude tie-break would broadcast an arbitrary region's
+            -- value (an arid ~100 over AWARE's region-less 42.95) to every
+            -- uncovered same-CAS flow.
             --
             -- Only CFs that matched by CAS populate this table. A CF whose name
             -- or synonym pinned a specific flow (e.g. "methane (biogenic)" →
@@ -966,6 +973,7 @@ buildMethodTables cmap energyDensities mappings =
                     , Just cas <- [mcfCAS cf]
                     , not (T.null cas)
                     , Nothing <- [mcfConsumerLocation cf]
+                    , (_, Nothing) <- [extractLocationSuffix (mcfFlowName cf)]
                     , Just comp <- [mcfCompartment cf]
                     , let Compartment normMedRaw normSub _ = normalizeCompartment cmap comp
                     , let normMed = normalizeMedium (T.toLower normMedRaw)

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -9,7 +9,7 @@
 
 Maps characterization factor flows from LCIA methods to database flows
 using a configurable cascade of MapperHandles (plugin architecture).
-Default cascade: UUID → CAS → Name → Synonym.
+Default cascade: UUID → Name → Synonym → CAS.
 -}
 module Method.Mapping (
     -- * Mapping functions

--- a/src/Method/ParserSimaPro.hs
+++ b/src/Method/ParserSimaPro.hs
@@ -291,12 +291,16 @@ parseCFRow cfg line =
             let !rawName = decodeBS (BS8.strip name)
                 -- Keep the full suffixed name so the CF's 'mcfFlowRef' UUID
                 -- matches the suffixed biosphere flow UUID parsed by
-                -- 'SimaPro.Parser.bioRowToExchange'. The location is also
-                -- exposed via 'mcfConsumerLocation' for regional dispatch on
-                -- engines that key CFs by activity location (openLCA JSON-LD);
-                -- SimaPro CSV CFs are already region-tagged in the name, so
-                -- dual storage is correct.
-                !mLoc = snd (extractLocationSuffix rawName)
+                -- 'SimaPro.Parser.bioRowToExchange'. SimaPro CSV CFs are
+                -- name-regionalized: each region is a distinct elementary flow
+                -- carrying its own CF (as Brightway matches them), NOT
+                -- consumer-location regionalized. So the CF resolves by full
+                -- name/UUID and 'mcfConsumerLocation' stays 'Nothing'. Setting
+                -- it routed region-tagged flows into the consumer-location
+                -- dispatch, which resolves C[f, loc(activity)] and — the flow's
+                -- region living in its name, not the activity's location —
+                -- fell back to the region-less default (AWARE water 42.95 for
+                -- every region instead of e.g. CH's 1.34, a ~54x over-count).
                 !cfUnitT = decodeBS (BS8.strip cfUnit)
                 -- UUID hashed via the shared 'generateFlowUUID' +
                 -- 'normalizeSimaProCompartment' so the CF side and
@@ -316,7 +320,7 @@ parseCFRow cfg line =
                         , mcfCompartment = mkCompartment comp sub
                         , mcfCAS = normalizeCAS (decodeBS (BS8.strip cas))
                         , mcfUnit = cfUnitT
-                        , mcfConsumerLocation = mLoc
+                        , mcfConsumerLocation = Nothing
                         }
              in Just cf
         _ -> Nothing

--- a/src/Plugin/Builtin.hs
+++ b/src/Plugin/Builtin.hs
@@ -90,7 +90,7 @@ defaultRegistry =
                 ]
         }
 
--- | The default mapper cascade: UUID → CAS → Name → Synonym
+-- | The default mapper cascade: UUID → Name → Synonym → CAS
 defaultMappers :: [MapperHandle]
 -- Specific identity (UUID, then name, then synonym) before the generic CAS
 -- bridge. A CF whose flow name/synonym pins a specific DB flow (e.g. EF's

--- a/test/MethodSpec.hs
+++ b/test/MethodSpec.hs
@@ -855,6 +855,43 @@ spec = do
                     mcfDirection waterCF `shouldBe` Input
                     mcfCompartment waterCF `shouldBe` Just (Compartment "natural resource" "" "")
 
+        it "keeps region-suffixed water CFs name-regionalized (no consumer-location)" $ do
+            -- A SimaPro AWARE water flow carries its region in the flow name
+            -- ("…, CH"): each region is a distinct elementary flow with its own
+            -- CF, matched by name/UUID — NOT consumer-location regionalized.
+            -- Extracting the suffix into 'mcfConsumerLocation' routed the flow
+            -- through the activity-location dispatch, which fell back to the
+            -- region-less default (42.95) for every region instead of CH's 1.34
+            -- — a ~54x water over-count on hydro-heavy supply chains.
+            let csv =
+                    BC.pack $
+                        unlines
+                            [ "{SimaPro 10.2.0.0}"
+                            , "{methods}"
+                            , "{CSV separator: Semicolon}"
+                            , "{Decimal separator: .}"
+                            , ""
+                            , "Impact category"
+                            , "Water use;m3 depriv."
+                            , "Substances"
+                            , "Raw;(unspecified);Water, turbine use, unspecified natural origin, CH;007732-18-5;1.34;m3"
+                            , "Raw;(unspecified);Water, turbine use, unspecified natural origin;007732-18-5;42.95;m3"
+                            , "End"
+                            ]
+            case parseSimaProMethodCSVBytes csv of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right coll -> do
+                    let factors = methodFactors (head (mcMethods coll))
+                        byName n = [cf | cf <- factors, mcfFlowName cf == n]
+                    case byName "Water, turbine use, unspecified natural origin, CH" of
+                        [chCF] -> do
+                            mcfConsumerLocation chCF `shouldBe` Nothing
+                            mcfValue chCF `shouldBe` 1.34
+                        _ -> expectationFailure "expected exactly one CH-suffixed turbine CF"
+                    -- the region-less default stays a distinct name-keyed factor
+                    map mcfValue (byName "Water, turbine use, unspecified natural origin")
+                        `shouldBe` [42.95]
+
         it "normalizes CAS numbers (strips leading zeros)" $ do
             csv <- BS.readFile "test/data/simapro_method.csv"
             case parseSimaProMethodCSVBytes csv of

--- a/test/SharedCASCoverageSpec.hs
+++ b/test/SharedCASCoverageSpec.hs
@@ -26,6 +26,7 @@ only non-regionalized CFs.
 -}
 module SharedCASCoverageSpec (spec) where
 
+import qualified Data.ByteString.Char8 as BC
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import Data.UUID (UUID)
@@ -33,7 +34,8 @@ import qualified Data.UUID as UUID
 import Test.Hspec
 
 import Method.Mapping
-import Method.Types (Compartment (..), FlowDirection (..), Medium (..), Method (..), MethodCF (..))
+import Method.ParserSimaPro (parseSimaProMethodCSVBytes)
+import Method.Types (Compartment (..), FlowDirection (..), Medium (..), Method (..), MethodCF (..), MethodCollection (..))
 import Plugin.Builtin (defaultMappers)
 import Plugin.Types (MapContext (..))
 import SubstanceRegistry (CASNumber (..))
@@ -473,6 +475,48 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
             -- table instead of clobbering the flow's universal value.
             M.lookup (bfId river) (mtUuidCF tables) `shouldBe` Just (5, "m3")
             M.lookup (bfId river, "IN") (mtRegionalizedCF tables) `shouldBe` Just (100, "m3")
+
+        it "keeps name-regionalized SimaPro rows out of mtCasCF (parser path)" $ do
+            -- End-to-end through the real parser: 'parseCFRow' leaves
+            -- 'mcfConsumerLocation' Nothing for SimaPro CFs (the region lives
+            -- in the flow name), so the consumer-location gate cannot exclude
+            -- them from the CAS bridge. Against an inventory that shares the
+            -- CAS but none of the suffixed names ('mcBioFlowsByName' is
+            -- empty), every row falls back to ByCAS — and without the
+            -- name-suffix filter the magnitude tie-break would broadcast the
+            -- arid ±100 rows instead of the region-less default.
+            let csv =
+                    BC.pack $
+                        unlines
+                            [ "{SimaPro 10.2.0.0}"
+                            , "{methods}"
+                            , "{CSV separator: Semicolon}"
+                            , "{Decimal separator: .}"
+                            , ""
+                            , "Impact category"
+                            , "Water use;m3 depriv."
+                            , "Substances"
+                            , "Raw;(unspecified);Water, turbine use, unspecified natural origin, CH;007732-18-5;1.34;m3"
+                            , "Raw;(unspecified);Water, turbine use, unspecified natural origin, IN;007732-18-5;100;m3"
+                            , "Raw;(unspecified);Water, turbine use, unspecified natural origin;007732-18-5;42.95;m3"
+                            , "Water;(unspecified);Water, CH;007732-18-5;-1.34;m3"
+                            , "Water;(unspecified);Water, IN;007732-18-5;-100;m3"
+                            , "Water;(unspecified);Water;007732-18-5;-42.95;m3"
+                            , "End"
+                            ]
+            case parseSimaProMethodCSVBytes csv of
+                Left err -> expectationFailure ("Parse failed: " ++ err)
+                Right coll -> do
+                    mappings <- concat <$> mapM (mapMethodFlows defaultMappers mapCtx) (mcMethods coll)
+                    let tables = buildMethodTables M.empty M.empty mappings
+                    -- Only the region-less rows may broadcast through the
+                    -- name-blind bridge, on both the withdrawal and release
+                    -- sides (the negative release default keeps AWARE's
+                    -- netting on the CAS-fallback path).
+                    M.lookup (CASNumber waterCAS, Medium "resource") (mtCasCF tables)
+                        `shouldBe` Just (42.95, "m3")
+                    M.lookup (CASNumber waterCAS, Medium "water") (mtCasCF tables)
+                        `shouldBe` Just (-42.95, "m3")
 
     describe "unspecified subcompartment is the medium-level fallback" $ do
         it "an uncovered subcompartment falls back to the unspecified CF" $ do


### PR DESCRIPTION
## Problem

SimaPro CSV methods tag each region as its own elementary flow carrying its own CF — e.g. AWARE water scarcity has `Water, turbine use, unspecified natural origin, CH` = 1.34 and `…, FR` = 6.98, distinct from the region-less `…` = 42.95. These CFs are **name-regionalized**: the region is part of the flow identity and must be matched by name/UUID.

The SimaPro method parser instead extracted the trailing region code into `mcfConsumerLocation`, which routes a CF through the **activity-location** regional dispatch (it resolves `C[flow, loc(activity)]`). But the region lives in the flow name, not in the consuming activity's location, so the exact regional cell never matched and every region collapsed onto the region-less default. Every water-resource flow sharing CAS `7732-18-5` ended up with a single CF (42.95).

## Impact

For `Honey, raw, … {CH} - Adapted from WFLDB` (Agribalyse 3.2, EF 3.1 adapted): the turbine water that should score 1.34 scored 42.95 (×32 on the dominant flow), and the paired negative release CFs that make AWARE's input/output netting balance were dropped as well. Water use came out **74.2 m³ depriv.** instead of ~1.4 — an independent implementation of the same method gives **1.37** — and dominated the aggregate single score. A spot-check panel (yogurt/beef/rapeseed/tomato) showed the same 20–220× water inflation.

## Fix

Leave `mcfConsumerLocation` empty for SimaPro CSV CFs so they resolve by their full region-suffixed name/UUID. openLCA/ILCD methods keep consumer-location — they carry a real `location` field, so their regionalization is genuine and the shared regional path still serves them.

- **Water use only**: every other impact category is bit-identical before/after (verified across all 25 categories on the honey inventory).
- **Netting restored**: the positive turbine withdrawal now cancels the negative release.
- Honey Water use **74.2 → 2.28 m³ depriv.** A small residual (2.28 vs ~1.37) remains from release regionalization of aggregate regions (e.g. `Water, Europe without Switzerland`), tracked separately.
- Adds a parser lock test.


## Follow-up: CAS-bridge guard

Review caught a side effect of the parser change: `mcfConsumerLocation = Just loc` was also the gate keeping region-suffixed rows out of `mtCasCF`, the name-blind CAS bridge. With it gone, any region CF the inventory doesn't carry by exact name/UUID falls back to `ByCAS`, collides with the region-less default on the one `(CAS, medium)` key, and the magnitude tie-break broadcasts an arbitrary region's value (an arid ~100 instead of the region-less 42.95) to every uncovered same-CAS flow — on both the withdrawal and release sides.

Fixed by filtering name-regionalized CFs out of `mtCasCF` with `extractLocationSuffix` (the same classifier the parser previously used), so the bridge holds exactly what it held before the parser fix. A second lock test drives the real parser + mapper cascade with an empty name index to force `ByCAS`; without the guard it reads 100/-100.
