### PR TITLE
LCIA: curated CFC & pesticide name bridges (ozone depletion + freshwater ecotoxicity)

### DIFF
--- a/data/flows.csv
+++ b/data/flows.csv
@@ -914,3 +914,13 @@ ground water,"Water, well"
 Water to turbine,"Water, turbine use, unspecified natural origin"
 Water to Cooling,"Water, cooling, unspecified natural origin"
 freshwater,"Water, unspecified natural origin"
+CFC-10,"Methane, tetrachloro-, CFC-10"
+CFC-11,"Methane, trichlorofluoro-, CFC-11"
+CFC-12,"Methane, dichlorodifluoro-, CFC-12"
+"1,1,2-trichlorotrifluoroethane","Ethane, 1,1,2-trichloro-1,2,2-trifluoro-, CFC-113"
+HCFC-22,"Methane, chlorodifluoro-, HCFC-22"
+"2-chloro-N-[[[4-(trifluoromethoxy)phenyl]amino]carbonyl]benzamide",Triflumuron
+"mesotrione (iso); 2-[4-(methylsulfonyl)-2-nitrobenzoyl]-1,3-cyclohexanedione",Mesotrione
+tebupirimfos,Tebupirimphos
+chloramide,Chloramine
+"2-chloro-N-(2,6-dimethylphenyl)-N-(2-methoxyethyl)acetamide",Dimethachlor


### PR DESCRIPTION
## What

The JRC ILCD distribution of EF 3.1 names several characterization factors in a
way the flow cascade cannot reach from the Agribalyse inventory:

- **Ozone depletion** names its CFs by the bare industrial token — `CFC-10`,
  `HCFC-22` — whereas the inventory flow uses the systematic name
  (`Methane, tetrachloro-, CFC-10`).
- **Freshwater ecotoxicity** names several pesticide CFs by pure IUPAC — e.g.
  Triflumuron as `2-chloro-N-[[[4-(trifluoromethoxy)phenyl]amino]carbonyl]benzamide`.

The inventory flows carry no CAS number, so neither the exact-name nor the CAS
tier of the CF cascade bridges them, and the factor is silently missed. Ozone
depletion undercounts to 13–62 % of the reference distribution across four
products.

This adds ten explicit curated name bridges to `data/flows.csv` (five CFC/HCFC,
five pesticides).

## Result

Ozone depletion converges to 1.00 across four reference products (dairy, meat,
oilseed, vegetable) using **only the curated synonym set** — with no dependence
on synonyms auto-extracted from the loaded databases. Freshwater ecotoxicity
converges where a curated species is material (beef, via Triflumuron).

One residual is left untouched on purpose: the reference distribution
characterizes Dimethenamid-P with a dedicated factor the ILCD distribution lacks
(it carries only the racemic Dimethenamid, ~12× lower). Bridging the two would be
a different substance and would undercount, so that single flow stays divergent
rather than be given a fabricated factor.
