### PR TITLE
LCIA: auto-extracted synonyms become an opt-in candidate set

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -261,7 +261,7 @@ lookups, so scoring itself is a fast dot product over the inventory `g`.
 | `Tree.hs`                   | Supply-chain tree construction (loop-aware)                         |
 | `Expr.hs`                   | Exchange formula / parameter evaluation                             |
 | `UnitConversion.hs`         | Unit conversion                                                     |
-| `SynonymDB.hs`              | Synonyms auto-extracted from databases and methods                  |
+| `SynonymDB.hs`              | Flow-name synonym registry (curated CSV; auto-extracted candidates are opt-in) |
 | `Plugin/Bridge.hs`          | Bridge to external plugins via JSON over stdin/stdout               |
 | `Progress.hs`               | Structured progress logs and reports                                |
 

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -59,6 +59,7 @@ module Database.Manager (
     parseGeographiesCSV,
 
     -- * Reference Data Operations
+    autoCreateFlowSynonyms,
     listFlowSynonyms,
     loadFlowSynonyms,
     unloadFlowSynonyms,
@@ -590,10 +591,9 @@ with the database's synonym fan-out and the configured substance edges.
 Diagnostics (flow-mapping endpoints, coverage audits) must read THIS rather
 than the raw cascade, or they under-report what the score tables contain.
 
-Uses the database's frozen-at-load-time synonym DB (curated-only;
-auto-extracted method synonyms enter 'dmLoadedFlowSyns' after databases are
-loaded, so 'getMergedSynonymDB' would surface them and pollute the fan-out
-with thousands of generic PubChem synonyms like "water" → "4-aminophenol").
+Uses the database's frozen-at-load-time synonym DB, which holds the curated
+registry plus any source the user had explicitly activated at load time
+(auto-extracted candidates are persisted but never loaded by the engine).
 -}
 effectiveMethodMappings :: DatabaseManager -> Text -> Text -> Database -> Method -> IO [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]
 effectiveMethodMappings manager dbName collection db method = do
@@ -3555,18 +3555,22 @@ EF 3.1) and the first genuine flow name used as a synonym (~17 flows).
 maxSynonymFlowFrequency :: Int
 maxSynonymFlowFrequency = 25
 
-{- | Auto-create flow synonyms from extracted pairs.
-Writes CSV to uploads/flow-synonyms/auto-{source}/data.csv,
-registers and auto-loads the synonym set.
+{- | Persist auto-extracted synonym pairs as an opt-in candidate set.
+Writes CSV to uploads/flow-synonyms/auto-{source}/data.csv and registers it
+inactive. The pairs never enter the matching: flow matching trusts only the
+curated registry (data/flows.csv) plus sources the user explicitly activates —
+DB-embedded synonyms are a bootstrap input for offline curation, not a runtime
+one. To regenerate a stale candidate, remove the source and reload.
 -}
 autoCreateFlowSynonyms :: DatabaseManager -> Text -> Text -> [(Text, Text)] -> IO ()
 autoCreateFlowSynonyms _ _ _ [] = return ()
 autoCreateFlowSynonyms manager sourceName description pairs = do
     let slug = "auto-" <> sourceName
-    -- Skip if already loaded (persisted CSV from previous run, loaded by autoLoadRefData)
-    alreadyLoaded <- atomically $ M.member slug <$> readTVar (dmLoadedFlowSyns manager)
-    if alreadyLoaded
-        then reportProgress Info $ "  [AUTO] " <> T.unpack slug <> ": already loaded (cached)"
+    -- Skip if already registered (persisted candidate from a previous run,
+    -- discovered at startup, or extracted earlier this session)
+    alreadyExtracted <- atomically $ M.member slug <$> readTVar (dmAvailableFlowSyns manager)
+    if alreadyExtracted
+        then reportProgress Info $ "  [AUTO] " <> T.unpack slug <> ": candidate already extracted"
         else do
             let (nonJunkPairs, junkTokens) = excludeJunkSynonyms pairs
                 (keptPairs, excludedSyns) =
@@ -3604,13 +3608,11 @@ autoCreateFlowSynonyms manager sourceName description pairs = do
                         , rdDescription = Just description
                         }
             addFlowSynonyms manager rd
-            -- Build SynonymDB directly from pairs (skip CSV round-trip). The pairs
-            -- are CAS-typed at extraction ('extractFromILCDFlows'): a name carried
-            -- by flows of more than one distinct CAS is an ambiguous bridge and is
-            -- dropped, so the transitive closure can no longer fuse unrelated
-            -- substances into a junk hub. Any residual oversized class is surfaced.
+            -- Close the candidate set only to audit its quality: an oversized
+            -- class means the transitive closure fused unrelated substances
+            -- through an ambiguous bridge (a junk hub) — surface it so the
+            -- curator sees it before ever activating the source.
             let !synDB = buildFromPairs keptPairs
-            atomically $ modifyTVar' (dmLoadedFlowSyns manager) (M.insert slug synDB)
             forM_ (oversizedClasses 100 synDB) $ \cls ->
                 reportProgress Warning $
                     "  [AUTO] "
@@ -3624,4 +3626,4 @@ autoCreateFlowSynonyms manager sourceName description pairs = do
                     <> T.unpack slug
                     <> ": "
                     <> show (length keptPairs)
-                    <> " synonym pairs"
+                    <> " candidate synonym pairs (opt-in, not loaded)"

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -185,7 +185,7 @@ import qualified Search.BM25 as BM25
 import SharedSolver (SharedSolver, createSharedSolver)
 import qualified SharedSolver
 import SubstanceRegistry (CASNumber (..), KeyNormalizers (..), NormName (..), SubstanceEdge, casBindingsFromEdges, parseSubstanceEdges)
-import SynonymDB (SynonymDB (..), buildFromCSV, buildFromPairs, emptySynonymDB, excludeJunkSynonyms, excludeOverFrequentSynonyms, loadFromCSVFileWithCache, mergeSynonymDBs, normalizeName, oversizedClasses, synonymCount, uncoveredUnitSuffixes)
+import SynonymDB (SynonymDB (..), buildFromCSV, emptySynonymDB, excludeJunkSynonyms, excludeOverFrequentSynonyms, loadFromCSVFileWithCache, mergeSynonymDBs, normalizeName, oversizedClasses, synonymCount, uncoveredUnitSuffixes)
 import Types (
     Activity (..),
     AttributeFallback (..),
@@ -3612,8 +3612,7 @@ autoCreateFlowSynonyms manager sourceName description pairs = do
             -- class means the transitive closure fused unrelated substances
             -- through an ambiguous bridge (a junk hub) — surface it so the
             -- curator sees it before ever activating the source.
-            let !synDB = buildFromPairs keptPairs
-            forM_ (oversizedClasses 100 synDB) $ \cls ->
+            forM_ (oversizedClasses 100 keptPairs) $ \cls ->
                 reportProgress Warning $
                     "  [AUTO] "
                         <> T.unpack slug

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -3558,7 +3558,8 @@ maxSynonymFlowFrequency = 25
 {- | Persist auto-extracted synonym pairs as an opt-in candidate set.
 Writes CSV to uploads/flow-synonyms/auto-{source}/data.csv and registers it
 inactive. The pairs never enter the matching: flow matching trusts only the
-curated registry (data/flows.csv) plus sources the user explicitly activates —
+curated registry (data/flows.csv) plus sources the user explicitly activates
+(activation lasts for the session and only reaches databases loaded after it) —
 DB-embedded synonyms are a bootstrap input for offline curation, not a runtime
 one. To regenerate a stale candidate, remove the source and reload.
 -}

--- a/src/SynonymDB.hs
+++ b/src/SynonymDB.hs
@@ -82,17 +82,18 @@ buildFromPairs :: [(Text, Text)] -> SynonymDB
 buildFromPairs raws =
     let normd = normalizePairs raws
      in (fromClasses (equivalenceClasses normd)){synEdges = normd}
-  where
-    normalizePairs :: [(Text, Text)] -> [(Text, Text)]
-    normalizePairs rs =
-        [ (n1, n2)
-        | (raw1, raw2) <- rs
-        , let n1 = normalizeName raw1
-        , let n2 = normalizeName raw2
-        , not (T.null n1)
-        , not (T.null n2)
-        , n1 /= n2
-        ]
+
+-- | Normalize both ends of each pair, dropping empty names and self-pairs.
+normalizePairs :: [(Text, Text)] -> [(Text, Text)]
+normalizePairs rs =
+    [ (n1, n2)
+    | (raw1, raw2) <- rs
+    , let n1 = normalizeName raw1
+    , let n2 = normalizeName raw2
+    , not (T.null n1)
+    , not (T.null n2)
+    , n1 /= n2
+    ]
 
 -- | Number a list of name classes into the bidirectional SynonymDB lookup tables.
 fromClasses :: [[Text]] -> SynonymDB
@@ -178,14 +179,15 @@ mergeSynonymDBs dbs = (fromClasses (equivalenceClasses edges)){synEdges = edges}
 synonymCount :: SynonymDB -> Int
 synonymCount = M.size . synNameToId
 
-{- | Synonym classes with more than @maxSize@ members. Transitive closure has no
-degree cap (a hub no longer silently truncates at 50), so an implausibly large
-class — a junk hub that fused unrelated substances through one bad pair — must be
-surfaced rather than silently polluting the synonym fan-out. The loader warns on
-whatever this returns; an empty result means the closure stayed plausible.
+{- | Synonym classes with more than @maxSize@ members, computed straight from
+the raw pairs. Transitive closure has no degree cap (a hub no longer silently
+truncates at 50), so an implausibly large class — a junk hub that fused
+unrelated substances through one bad pair — must be surfaced rather than
+silently polluting the synonym fan-out. The loader warns on whatever this
+returns; an empty result means the closure stayed plausible.
 -}
-oversizedClasses :: Int -> SynonymDB -> [[Text]]
-oversizedClasses maxSize = filter ((> maxSize) . length) . M.elems . synIdToNames
+oversizedClasses :: Int -> [(Text, Text)] -> [[Text]]
+oversizedClasses maxSize = filter ((> maxSize) . length) . equivalenceClasses . normalizePairs
 
 {- | Drop synonym pairs whose synonym (the second element) is carried by more
 than @maxFlows@ distinct base names (the first element). An over-frequent

--- a/test/AutoSynonymsSpec.hs
+++ b/test/AutoSynonymsSpec.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Locks the runtime contract of auto-extracted flow synonyms: they are a
+persisted, opt-in CANDIDATE set for offline curation — the engine registers
+them but never feeds them into flow matching. Flow matching trusts only the
+curated registry plus explicitly activated sources.
+-}
+module AutoSynonymsSpec (spec) where
+
+import Control.Concurrent.STM (readTVarIO)
+import Control.Exception (finally)
+import qualified Data.Map.Strict as M
+import System.Directory (doesFileExist, getCurrentDirectory, setCurrentDirectory)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+
+import Config (defaultConfig)
+import Database.Manager (
+    DatabaseLoadStatus (..),
+    DatabaseManager (..),
+    RefDataStatus (..),
+    autoCreateFlowSynonyms,
+    initDatabaseManager,
+    listFlowSynonyms,
+ )
+
+{- | Run an action with a fresh manager in a temp working directory, so the
+uploads/ tree the extraction persists to never touches the repo.
+-}
+withTempManager :: (DatabaseManager -> IO a) -> IO a
+withTempManager action =
+    withSystemTempDirectory "volca-auto-syns" $ \tmp -> do
+        oldCwd <- getCurrentDirectory
+        setCurrentDirectory tmp
+        (initDatabaseManager defaultConfig True Nothing >>= action)
+            `finally` setCurrentDirectory oldCwd
+
+spec :: Spec
+spec = describe "autoCreateFlowSynonyms" $ do
+    it "persists and registers the candidate set but never loads it into matching" $
+        withTempManager $ \manager -> do
+            autoCreateFlowSynonyms manager "test-method" "desc" [("alpha", "beta")]
+            loaded <- readTVarIO (dmLoadedFlowSyns manager)
+            M.member "auto-test-method" loaded `shouldBe` False
+            statuses <- listFlowSynonyms manager
+            let entry = [s | s <- statuses, rdsName s == "auto-test-method"]
+            map rdsStatus entry `shouldBe` [Unloaded]
+            map rdsIsAuto entry `shouldBe` [True]
+            doesFileExist ("uploads/flow-synonyms" </> "auto-test-method" </> "data.csv")
+                `shouldReturn` True
+
+    it "skips re-extraction when the candidate is already registered" $
+        withTempManager $ \manager -> do
+            autoCreateFlowSynonyms manager "test-method" "desc" [("alpha", "beta")]
+            autoCreateFlowSynonyms manager "test-method" "desc" [("gamma", "delta")]
+            available <- readTVarIO (dmAvailableFlowSyns manager)
+            M.size (M.filterWithKey (\k _ -> k == "auto-test-method") available)
+                `shouldBe` 1

--- a/test/AutoSynonymsSpec.hs
+++ b/test/AutoSynonymsSpec.hs
@@ -54,6 +54,7 @@ spec = describe "autoCreateFlowSynonyms" $ do
         withTempManager $ \manager -> do
             autoCreateFlowSynonyms manager "test-method" "desc" [("alpha", "beta")]
             autoCreateFlowSynonyms manager "test-method" "desc" [("gamma", "delta")]
-            available <- readTVarIO (dmAvailableFlowSyns manager)
-            M.size (M.filterWithKey (\k _ -> k == "auto-test-method") available)
-                `shouldBe` 1
+            -- The persisted CSV must still hold the first extraction: registry
+            -- membership alone cannot tell a skip from a silent overwrite.
+            readFile ("uploads/flow-synonyms" </> "auto-test-method" </> "data.csv")
+                `shouldReturn` "name1,name2\nalpha,beta\n"

--- a/test/SynonymDBSpec.hs
+++ b/test/SynonymDBSpec.hs
@@ -34,13 +34,13 @@ spec = do
 
     describe "oversizedClasses" $ do
         -- A junk hub fuses everything it touches into one transitive class.
-        let hub = buildFromPairs [("hub", "s" <> pack (show i)) | i <- [1 :: Int .. 12]]
+        let hub = [("hub", "s" <> pack (show i)) | i <- [1 :: Int .. 12]]
 
         it "flags a class larger than the bound (a closure that fused a junk hub)" $
             map length (oversizedClasses 10 hub) `shouldBe` [13]
 
         it "stays silent when every class is within the bound" $
-            oversizedClasses 10 (buildFromPairs [("alpha", "beta"), ("beta", "gamma")])
+            oversizedClasses 10 [("alpha", "beta"), ("beta", "gamma")]
                 `shouldBe` []
 
     describe "excludeOverFrequentSynonyms" $ do

--- a/volca.cabal
+++ b/volca.cabal
@@ -212,6 +212,7 @@ test-suite lca-tests
                      , DetectFormatSpec
                      , AmountSpec
                      , AutoRelinkSpec
+                     , AutoSynonymsSpec
                      , RelinkMappingSpec
                      , MatrixConstructionSpec
                      , WasteTreatmentSignSpec
@@ -245,6 +246,7 @@ test-suite lca-tests
                      , CrossDBRegionalLCIASubsSpec
                      , CrossDBRegionalLCIASensitivitySpec
                      , RegionalLCIASpec
+                     , ProjectRegionalSpec
                      , SharedCASCoverageSpec
                      , EnergyDensityCFSpec
                      , SharedSolverSpec


### PR DESCRIPTION
## Why

Flow matching is meant to trust the curated synonym registry (`data/flows.csv`); auto-extracted synonym sets are registered inactive for that reason. But `autoCreateFlowSynonyms` also inserted the freshly extracted `SynonymDB` straight into the loaded flow synonyms, so DB-embedded synonyms (ILCD othernames, EcoSpold2 synonyms) still reached matching in any session that loaded an ILCD method or EcoSpold2 database. Worse, the effect depended on load order: a database loaded *after* a method froze the auto pairs into its synonym DB, one loaded *before* did not.

## What

Extraction still runs, still filters (junk / over-frequent / CAS-ambiguous), still persists the candidate CSV under `uploads/flow-synonyms/auto-*/data.csv` and registers it inactive, and still warns on oversized closure classes — but it no longer feeds matching. Matching now deterministically uses the curated registry plus sources the user explicitly activates. The re-extraction skip is keyed on "already registered" instead of "already loaded"; regenerating a stale candidate = remove the source and reload.

A new `AutoSynonymsSpec` locks the contract: the candidate is persisted and listed `Unloaded`, and never enters the loaded synonyms.

## Validation

- Full suite: 1492 examples, 0 failures.
- EF-3.1 (JRC) 4-product Agribalyse panel, main vs branch binaries in the same environment: water use identical to the decimal on all four products; ECS/PEF shift 0.1–0.5%, the expected size of the ozone-depletion and freshwater-ecotoxicity auto bridges.

Merge after #164 — its curated CFC/pesticide bridges are what make curated-only matching cover those two categories.