### PR TITLE
LCIA: typed direction on flow-name synonym bridges

### DIFF
--- a/data/flows.csv
+++ b/data/flows.csv
@@ -1,4 +1,4 @@
-name1,name2
+name1,name2,direction
 "(+-)-2-ethoxy-2,3-dihydro-3,3-dimethylbenzofuran-5-yl methanesufonate",Ethofumesate
 "(+-)-cis-4-[3-(4-tert-butylphenyl)-2-methylpropyl]-2,6-dimethylmorpholine",Fenpropimorph
 "(2,4-dichlorophenoxy)acetic acid","2,4-D"
@@ -908,12 +908,12 @@ Fluorochloridone,3-chloro-4-(chloromethyl)-1-[3-(trifluoromethyl)phenyl]pyrrolid
 non-methane volatile organic compounds,"NMVOC, non-methane volatile organic compounds"
 Carbon dioxide (land use change),"Carbon dioxide, land transformation"
 sulphuric acid,Sulfuric acid
-river water,"Water, river"
-lake water,"Water, lake"
-ground water,"Water, well"
-Water to turbine,"Water, turbine use, unspecified natural origin"
-Water to Cooling,"Water, cooling, unspecified natural origin"
-freshwater,"Water, unspecified natural origin"
+river water,"Water, river",input
+lake water,"Water, lake",input
+ground water,"Water, well",input
+Water to turbine,"Water, turbine use, unspecified natural origin",input
+Water to Cooling,"Water, cooling, unspecified natural origin",input
+freshwater,"Water, unspecified natural origin",input
 CFC-10,"Methane, tetrachloro-, CFC-10"
 CFC-11,"Methane, trichlorofluoro-, CFC-11"
 CFC-12,"Methane, dichlorodifluoro-, CFC-12"

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -185,7 +185,7 @@ import qualified Search.BM25 as BM25
 import SharedSolver (SharedSolver, createSharedSolver)
 import qualified SharedSolver
 import SubstanceRegistry (CASNumber (..), KeyNormalizers (..), NormName (..), SubstanceEdge, casBindingsFromEdges, parseSubstanceEdges)
-import SynonymDB (SynonymDB (..), buildFromCSV, emptySynonymDB, excludeJunkSynonyms, excludeOverFrequentSynonyms, loadFromCSVFileWithCache, mergeSynonymDBs, normalizeName, oversizedClasses, synonymCount, uncoveredUnitSuffixes)
+import SynonymDB (BridgeDirection (..), SynEdge (..), SynonymDB (..), buildFromCSV, emptySynonymDB, excludeJunkSynonyms, excludeOverFrequentSynonyms, loadFromCSVFileWithCache, mergeSynonymDBs, normalizeName, oversizedClasses, reopenedBridges, synonymCount, uncoveredUnitSuffixes)
 import Types (
     Activity (..),
     AttributeFallback (..),
@@ -987,6 +987,7 @@ initDatabaseManager config noCache configPath = do
         Left err -> reportError $ "Dependency resolution failed: " <> T.unpack err
         Right loadOrder -> do
             synonymDB <- getMergedSynonymDB manager
+            warnReopenedBridges synonymDB
             unitConfig <- getMergedUnitConfig manager
             let dbsToLoad = [configMap M.! name | name <- loadOrder, M.member name configMap]
                 levels = computeDepLevels configMap loadOrder
@@ -1632,6 +1633,7 @@ loadDatabaseSingleFromConfig manager dbName = do
                     currentIndexedDbs <- readTVarIO (dmIndexedDbs manager)
                     let otherIndexes = M.elems currentIndexedDbs
                     synonymDB <- getMergedSynonymDB manager
+                    warnReopenedBridges synonymDB
                     unitConfig <- getMergedUnitConfig manager
                     let transforms = prTransforms (dmPlugins manager)
                     eitherResult <-
@@ -3090,6 +3092,30 @@ getMergedSynonymDB manager = do
         if M.null loaded
             then emptySynonymDB
             else mergeSynonymDBs (M.elems loaded)
+
+{- | Surface one-way synonym bridges whose direction constraint is void in the
+(merged) set — re-linked in the opposite view by an untyped transitive chain or
+a contradictory row ('reopenedBridges'). 'demoteDuplicates' only drops the exact
+duplicate pair, so this residue would otherwise silently widen a curated
+one-way bridge back to both directions. Called where the merged set is about to
+drive a database load, not on the request-path getters, so it fires once per
+load rather than per query.
+-}
+warnReopenedBridges :: SynonymDB -> IO ()
+warnReopenedBridges synDB =
+    forM_ (reopenedBridges synDB) $ \e ->
+        reportProgress Warning $
+            "Flow synonyms: one-way bridge "
+                <> show (seA e)
+                <> " = "
+                <> show (seB e)
+                <> " ("
+                <> dirLabel (seDir e)
+                <> ") is re-linked in the opposite direction's view by other rows; its direction restriction is void"
+  where
+    dirLabel BridgeBoth = "both"
+    dirLabel BridgeInput = "input"
+    dirLabel BridgeOutput = "output"
 
 -- | Get the merged CompartmentMap from all loaded compartment mappings.
 getMergedCompartmentMap :: DatabaseManager -> IO CompartmentMap

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -157,6 +157,7 @@ import Method.Mapping (
     buildMethodIndex,
     buildMethodSetTables,
     buildMethodTables,
+    directionExcludedCFs,
     expandProxyEdges,
     expandSynonymMappings,
     fillBroadcastVector,
@@ -170,7 +171,7 @@ import Method.Types (
     CompartmentMap,
     EnergyDensityMap,
     Method (..),
-    MethodCF,
+    MethodCF (..),
     MethodCollection (..),
     ScoringSet (..),
     buildCompartmentMapFromCSV,
@@ -647,6 +648,22 @@ buildMethodTablesFor ::
     DatabaseManager -> Text -> Text -> Database -> M.Map Text [Text] -> Method -> IO MethodTables
 buildMethodTablesFor manager dbName collection db hier method = do
     expanded <- effectiveMethodMappings manager dbName collection db method
+    -- A CF matchable through the union synonym tables but not through its own
+    -- direction's view was excluded by the direction restriction alone — the
+    -- usual cause is a method whose parser defaulted the direction (no
+    -- metadata). Warn so the loss is distinguishable from a genuinely
+    -- uncharacterized flow.
+    let dirExcluded =
+            directionExcludedCFs (fromMaybe emptySynonymDB (dbSynonymDB db)) (dbFlowsByName db) expanded
+    unless (null dirExcluded) $
+        reportProgress Warning $
+            "[LCIA "
+                <> T.unpack (methodName method)
+                <> "] "
+                <> show (length dirExcluded)
+                <> " CF(s) match a synonym bridge only outside their flow direction "
+                <> "(direction metadata may be missing from the method). Samples: "
+                <> show (take 3 (map mcfFlowName dirExcluded))
     cmap <- getMergedCompartmentMap manager
     energyDensities <- getMergedEnergyDensities manager
     unitConfig <- getMergedUnitConfig manager

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -286,47 +286,62 @@ findFlowBySynonymComp synDB flowsByName name mComp =
   where
     lookupFlows fbn syn = M.findWithDefault [] (normalizeName syn) fbn
 
+{- | The synonym view a CF resolves against: input-only bridges apply to INPUT
+(resource) CFs, output-only to OUTPUT (emission) CFs. On untyped data both
+views coincide with the union tables, so this is a no-op.
+-}
+viewFor :: FlowDirection -> SynonymDB -> SynonymDB
+viewFor Input = inputView
+viewFor Output = outputView
+
 {- | Synonym match that reads a precomputed group → flows memo. When
 'mapMethodFlows' has expanded this CF's group (the common path), the resolution
 is a single map lookup plus the compartment pick; otherwise it falls back to
 'findFlowBySynonymComp'. The memoized flow list is exactly that function's
 inline @concatMap@ (same elements, same order), so the pick — and the flow it
-returns — is identical: a pure speedup.
+returns — is identical: a pure speedup. The group is resolved in the CF's
+direction view, and the memo is keyed by @(direction, group id)@ because the two
+views number their groups independently.
 -}
 findFlowBySynonymMemo ::
+    FlowDirection ->
     SynonymDB ->
-    M.Map Int [BiosphereFlow] ->
+    M.Map (FlowDirection, Int) [BiosphereFlow] ->
     M.Map Text [BiosphereFlow] ->
     Text ->
     Maybe Compartment ->
     Maybe BiosphereFlow
-findFlowBySynonymMemo synDB memo flowsByName name mComp =
-    case lookupSynonymGroup synDB name of
+findFlowBySynonymMemo dir synDB memo flowsByName name mComp =
+    case lookupSynonymGroup (viewFor dir synDB) name of
         Nothing -> Nothing
-        Just gid -> case M.lookup gid memo of
+        Just gid -> case M.lookup (dir, gid) memo of
             Just flows -> pickByCompartment flows mComp
-            Nothing -> findFlowBySynonymComp synDB flowsByName name mComp
+            Nothing -> findFlowBySynonymComp (viewFor dir synDB) flowsByName name mComp
 
-{- | Expand, once per synonym group, the candidate flows reachable from that
-group's names — for exactly the groups the given CFs reference. 'mapMethodFlows'
-runs this before resolving a method's CFs, so the synonym matcher reads a shared
-(often large) group's flows from the memo instead of re-expanding it per CF. The
-per-group value is identical to 'findFlowBySynonymComp''s inline @concatMap@.
+{- | Expand, once per @(direction, synonym group)@, the candidate flows reachable
+from that group's names — for exactly the groups the given CFs reference.
+'mapMethodFlows' runs this before resolving a method's CFs, so the synonym matcher
+reads a shared (often large) group's flows from the memo instead of re-expanding
+it per CF. The per-group value is identical to 'findFlowBySynonymComp''s inline
+@concatMap@. Keyed by direction because a CF resolves against its direction's view.
 -}
-buildSynGroupFlows :: MapContext -> [MethodCF] -> M.Map Int [BiosphereFlow]
+buildSynGroupFlows :: MapContext -> [MethodCF] -> M.Map (FlowDirection, Int) [BiosphereFlow]
 buildSynGroupFlows ctx cfs =
     M.fromList
-        [ (gid, maybe [] (concatMap groupFlows) (getSynonyms synDB gid))
-        | gid <- gids
+        [ ((dir, gid), maybe [] (concatMap groupFlows) (getSynonyms (viewFor dir synDB) gid))
+        | (dir, gid) <- keys
         ]
   where
     synDB = mcSynonymDB ctx
     flowsByName = mcBioFlowsByName ctx
     groupFlows syn = M.findWithDefault [] (normalizeName syn) flowsByName
-    gids =
+    keys =
         S.toList $
             S.fromList
-                [gid | cf <- cfs, Just gid <- [lookupSynonymGroup synDB (mcfFlowName cf)]]
+                [ (mcfDirection cf, gid)
+                | cf <- cfs
+                , Just gid <- [lookupSynonymGroup (viewFor (mcfDirection cf) synDB) (mcfFlowName cf)]
+                ]
 
 {- | Pick the best flow match based on compartment preference. The flow's own
 compartment now lives in 'bfCompartment' as a structured 'Types.Compartment'
@@ -686,12 +701,16 @@ expandSynonymMappings synDB flowsByName mappings =
             (S.fromList (M.keys flowsByName))
             mappings
 
+    -- Re-close the direction tags survive: 'buildFromEdges' keeps 'SynEdge's, so
+    -- the induced DB carries the same directional views as the source. A CF then
+    -- fans out only through bridges valid for its direction.
     inducedDB :: SynonymDB
     inducedDB =
-        buildFromPairs [e | e@(a, b) <- synEdges synDB, S.member a used, S.member b used]
+        buildFromEdges [e | e <- synEdges synDB, S.member (seA e) used, S.member (seB e) used]
 
     expand (cf, _) =
-        let peers = fromMaybe [] (getSynonyms inducedDB =<< lookupSynonymGroup inducedDB (mcfFlowName cf))
+        let dirDB = viewFor (mcfDirection cf) inducedDB
+            peers = fromMaybe [] (getSynonyms dirDB =<< lookupSynonymGroup dirDB (mcfFlowName cf))
          in [ (cf, Just (flow, BySynonym))
             | syn <- peers
             , flow <- M.findWithDefault [] syn flowsByName
@@ -740,6 +759,12 @@ projectRegionalResourceFlows synDB bioFlows mappings =
     -- Keep the larger (more conservative, never-undercounting) factor instead, the
     -- same value preference 'buildMethodTables' applies through 'preferBetter'.
     preferHigherCF a b = if mcfValue a >= mcfValue b then a else b
+    -- The synonym view a resource/water flow bridges through: a withdrawal
+    -- (resource-medium) flow uses the input view, a release (water-medium) flow
+    -- the output view, so an input-only bridge (@"river water"@ → @"Water,
+    -- river"@) never lets a release flow inherit a withdrawal CF. On untyped data
+    -- both views coincide, so this preserves today's grouping.
+    dirView med = viewFor (if med == "water" then Output else Input) synDB
     -- Located CFs reached two ways: by the matched flow's synonym GROUP — a CF
     -- whose name is bridged to the flow (withdrawal @"river water"@ → @"Water,
     -- river"@) — and by the CF's own NAME — a CF whose name equals the flow's
@@ -748,10 +773,11 @@ projectRegionalResourceFlows synDB bioFlows mappings =
     byGroup =
         M.fromListWith
             preferHigherCF
-            [ ((grp, flowMedium flow, loc), cf)
+            [ ((grp, med, loc), cf)
             | (cf, Just (flow, _)) <- mappings
             , Just loc <- [mcfConsumerLocation cf]
-            , Just grp <- [lookupSynonymGroup synDB (bfName flow)]
+            , let med = flowMedium flow
+            , Just grp <- [lookupSynonymGroup (dirView med) (bfName flow)]
             ]
     byName :: M.Map (Text, Text, Text) MethodCF
     byName =
@@ -776,7 +802,7 @@ projectRegionalResourceFlows synDB bioFlows mappings =
             , (base, Just loc) <- [extractLocationSuffix (bfName flow)]
             , Just cf <-
                 [ M.lookup (normalizeName base, med, loc) byName
-                    <|> (lookupSynonymGroup synDB base >>= \grp -> M.lookup (grp, med, loc) byGroup)
+                    <|> (lookupSynonymGroup (dirView med) base >>= \grp -> M.lookup (grp, med, loc) byGroup)
                 ]
             ]
 

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -302,22 +302,21 @@ is a single map lookup plus the compartment pick; otherwise it falls back to
 inline @concatMap@ (same elements, same order), so the pick — and the flow it
 returns — is identical: a pure speedup. The group is resolved in the CF's
 direction view, and the memo is keyed by @(direction, group id)@ because the two
-views number their groups independently.
+views number their groups independently. Takes the CF and context whole so
+direction, name and compartment can never be mixed from different CFs.
 -}
-findFlowBySynonymMemo ::
-    FlowDirection ->
-    SynonymDB ->
-    M.Map (FlowDirection, Int) [BiosphereFlow] ->
-    M.Map Text [BiosphereFlow] ->
-    Text ->
-    Maybe Compartment ->
-    Maybe BiosphereFlow
-findFlowBySynonymMemo dir synDB memo flowsByName name mComp =
-    case lookupSynonymGroup (viewFor dir synDB) name of
+findFlowBySynonymMemo :: MapContext -> MethodCF -> Maybe BiosphereFlow
+findFlowBySynonymMemo ctx cf =
+    case lookupSynonymGroup dirDB name of
         Nothing -> Nothing
-        Just gid -> case M.lookup (dir, gid) memo of
+        Just gid -> case M.lookup (dir, gid) (mcSynGroupFlows ctx) of
             Just flows -> pickByCompartment flows mComp
-            Nothing -> findFlowBySynonymComp (viewFor dir synDB) flowsByName name mComp
+            Nothing -> findFlowBySynonymComp dirDB (mcBioFlowsByName ctx) name mComp
+  where
+    dir = mcfDirection cf
+    dirDB = viewFor dir (mcSynonymDB ctx)
+    name = mcfFlowName cf
+    mComp = mcfCompartment cf
 
 {- | Expand, once per @(direction, synonym group)@, the candidate flows reachable
 from that group's names — for exactly the groups the given CFs reference.

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -701,12 +701,14 @@ expandSynonymMappings synDB flowsByName mappings =
             (S.fromList (M.keys flowsByName))
             mappings
 
-    -- Re-close the direction tags survive: 'buildFromEdges' keeps 'SynEdge's, so
-    -- the induced DB carries the same directional views as the source. A CF then
-    -- fans out only through bridges valid for its direction.
+    -- Re-close so the direction tags survive: the induced DB is rebuilt from
+    -- 'SynEdge's, so it carries the same directional views as the source. A CF
+    -- then fans out only through bridges valid for its direction. The stored
+    -- edges are already normalized — re-closing must NOT re-normalize them
+    -- ('normalizeName' is not idempotent), hence 'buildFromNormalizedEdges'.
     inducedDB :: SynonymDB
     inducedDB =
-        buildFromEdges [e | e <- synEdges synDB, S.member (seA e) used, S.member (seB e) used]
+        buildFromNormalizedEdges [e | e <- synEdges synDB, S.member (seA e) used, S.member (seB e) used]
 
     expand (cf, _) =
         let dirDB = viewFor (mcfDirection cf) inducedDB

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -45,6 +45,7 @@ module Method.Mapping (
     lookupCFForFlow,
     convertForCharacterization,
     expandSynonymMappings,
+    directionExcludedCFs,
     projectRegionalResourceFlows,
     ProxyTargets (..),
     expandProxyEdges,
@@ -84,7 +85,7 @@ import Data.List (find, nub, sortOn)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
-import Data.Maybe (fromMaybe, isNothing)
+import Data.Maybe (fromMaybe, isJust, isNothing)
 import Data.Ord (Down (..))
 import Data.STRef (modifySTRef', newSTRef, readSTRef)
 import qualified Data.Set as S
@@ -717,6 +718,28 @@ expandSynonymMappings synDB flowsByName mappings =
             | syn <- peers
             , flow <- M.findWithDefault [] syn flowsByName
             ]
+
+{- | Unmapped CFs whose name matches through the UNION synonym tables but not
+through their own direction's view: the direction restriction alone stands
+between them and a synonym match. Empty on untyped data, where the views
+coincide. The typical cause is a parser that defaulted 'mcfDirection' (the
+method carried no direction metadata), making a one-way bridge unreachable —
+the loader surfaces these so the loss is distinguishable from a genuinely
+uncharacterized flow, per the no-silent-misbehaviour rule.
+-}
+directionExcludedCFs ::
+    SynonymDB ->
+    M.Map Text [BiosphereFlow] ->
+    [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] ->
+    [MethodCF]
+directionExcludedCFs synDB flowsByName mappings =
+    [ cf
+    | (cf, Nothing) <- mappings
+    , isJust (matchIn synDB cf)
+    , isNothing (matchIn (viewFor (mcfDirection cf) synDB) cf)
+    ]
+  where
+    matchIn db cf = findFlowBySynonymComp db flowsByName (mcfFlowName cf) (mcfCompartment cf)
 
 {- | Project a region-tagged resource (withdrawal) flow onto its region's located
 CF, in the GLOBAL name tables. An ILCD method whose CFs carry a consumer location

--- a/src/Method/ParserCSV.hs
+++ b/src/Method/ParserCSV.hs
@@ -125,11 +125,17 @@ mkMethod methodology catName impactName unit colIdx rows delim =
 csvMethodNamespace :: UUID
 csvMethodNamespace = UUID5.generateNamed UUID5.namespaceURL (BS.unpack $ TE.encodeUtf8 "volca:csv-method")
 
--- | Direction: "resources" → Input, everything else → Output.
+{- | Direction: a resource compartment → Input, everything else → Output. Reads
+the same spellings as the SimaPro parser (@Resources@, @Raw@, @Raw materials@,
+@Resources from ground@…): a resource CF mis-defaulted to Output would resolve
+against the output synonym view and silently lose input-only bridges.
+-}
 directionFromCompartment :: Text -> FlowDirection
 directionFromCompartment comp
-    | T.toCaseFold comp == "resources" = Input
+    | lc == "resources" || "raw" `T.isPrefixOf` lc || "resources " `T.isPrefixOf` lc = Input
     | otherwise = Output
+  where
+    lc = T.toCaseFold comp
 
 {- | Parse compartment from CSV compartment column.
 Format: "Emissions to air", "Emissions to fresh water", "Resources", etc.

--- a/src/Method/Types.hs
+++ b/src/Method/Types.hs
@@ -72,7 +72,7 @@ data FlowDirection
       Input
     | -- | Emission to environment (e.g., CO2, pollutants)
       Output
-    deriving (Eq, Show, Generic, NFData, ToJSON, FromJSON)
+    deriving (Eq, Ord, Show, Generic, NFData, ToJSON, FromJSON)
 
 {- | Compartment triple: (medium, subcompartment, qualifier)
 medium: "air", "water", "soil", "natural resource"

--- a/src/Plugin/Builtin.hs
+++ b/src/Plugin/Builtin.hs
@@ -158,7 +158,7 @@ synonymMapper =
         , mhMatch = \ctx query -> pure $ case query of
             MatchCF cf ->
                 (\f -> MapResult (bfId f) "synonym" 0.8)
-                    <$> Mapping.findFlowBySynonymMemo (mcfDirection cf) (mcSynonymDB ctx) (mcSynGroupFlows ctx) (mcBioFlowsByName ctx) (mcfFlowName cf) (mcfCompartment cf)
+                    <$> Mapping.findFlowBySynonymMemo ctx cf
             _ -> Nothing
         }
 

--- a/src/Plugin/Builtin.hs
+++ b/src/Plugin/Builtin.hs
@@ -158,7 +158,7 @@ synonymMapper =
         , mhMatch = \ctx query -> pure $ case query of
             MatchCF cf ->
                 (\f -> MapResult (bfId f) "synonym" 0.8)
-                    <$> Mapping.findFlowBySynonymMemo (mcSynonymDB ctx) (mcSynGroupFlows ctx) (mcBioFlowsByName ctx) (mcfFlowName cf) (mcfCompartment cf)
+                    <$> Mapping.findFlowBySynonymMemo (mcfDirection cf) (mcSynonymDB ctx) (mcSynGroupFlows ctx) (mcBioFlowsByName ctx) (mcfFlowName cf) (mcfCompartment cf)
             _ -> Nothing
         }
 

--- a/src/Plugin/Types.hs
+++ b/src/Plugin/Types.hs
@@ -56,7 +56,7 @@ import Data.Text (Text)
 import Data.UUID (UUID)
 
 import Matrix (Inventory)
-import Method.Types (Method, MethodCF)
+import Method.Types (FlowDirection, Method, MethodCF)
 import SynonymDB (SynonymDB)
 import Types (Activity, ActivityMap, BioFlowDB, BiosphereFlow, Database, SimpleDatabase, TechFlowDB, UnitDB)
 
@@ -142,12 +142,13 @@ data MapContext = MapContext
     , mcBioFlowsByCAS :: !(Map Text [BiosphereFlow])
     , mcSynonymDB :: !SynonymDB
     , mcActivities :: !(Map Text [Activity])
-    , mcSynGroupFlows :: !(Map Int [BiosphereFlow])
-    {- ^ Memoized synonym-group id → candidate flows, precomputed once per
-    method by 'mapMethodFlows'. The synonym matcher resolves a CF whose name
-    lands in a shared (often large) synonym group via a single lookup here,
-    instead of re-expanding that group for every such CF. Empty when the
-    cascade runs without the precompute; the matcher then falls back to
+    , mcSynGroupFlows :: !(Map (FlowDirection, Int) [BiosphereFlow])
+    {- ^ Memoized @(direction, synonym-group id)@ → candidate flows, precomputed
+    once per method by 'mapMethodFlows'. The synonym matcher resolves a CF whose
+    name lands in a shared (often large) synonym group via a single lookup here,
+    instead of re-expanding that group for every such CF. Keyed by direction
+    because input-only and output-only bridges yield different groups. Empty when
+    the cascade runs without the precompute; the matcher then falls back to
     expanding the group per call, so the result is unchanged either way.
     -}
     }

--- a/src/SynonymDB.hs
+++ b/src/SynonymDB.hs
@@ -143,11 +143,17 @@ buildFromNormalizedEdges es =
             | all ((== BridgeBoth) . seDir) normd = AllBoth
             | otherwise =
                 DirectedViews
-                    (buildTables (edgesFor BridgeInput normd))
-                    (buildTables (edgesFor BridgeOutput normd))
+                    (viewTables (edgesFor BridgeInput normd))
+                    (viewTables (edgesFor BridgeOutput normd))
      in base{synViews = views}
   where
     edgesFor dir = filter (\e -> seDir e == BridgeBoth || seDir e == dir)
+    -- Views are terminal: nothing re-closes them (merge and the induced
+    -- restriction read the TOP-level 'synEdges'), so a view's own edge list is
+    -- dead weight in memory and in the serialized cache — store the lookup
+    -- tables only.
+    viewTables = clearEdges . buildTables
+    clearEdges t = t{synEdges = []}
 
 {- | Normalize an edge's endpoints, dropping empty/self edges (as
 'buildFromPairs' did). Direction is preserved.

--- a/src/SynonymDB.hs
+++ b/src/SynonymDB.hs
@@ -14,6 +14,7 @@ module SynonymDB (
     buildFromPairs,
     buildFromEdges,
     buildFromNormalizedEdges,
+    fromClassMaps,
     excludeOverFrequentSynonyms,
     excludeJunkSynonyms,
     isJunkSynonymName,
@@ -199,6 +200,20 @@ buildTables edges =
         nameToId = M.fromList [(name, gid) | (gid, members) <- numbered, name <- members]
         idToNames = M.fromList numbered
      in SynonymDB nameToId idToNames edges AllBoth
+
+{- | Wrap externally-numbered class tables (the synonyms-compiler's JSON import
+and capped group builder) into a SynonymDB, reconstructing untyped star edges so
+the relation stays re-closable. The one place those construction sites share, so
+a new 'SynonymDB' field lands here instead of in every tool.
+-}
+fromClassMaps :: M.Map Text Int -> M.Map Int [Text] -> SynonymDB
+fromClassMaps nameToId idToNames =
+    SynonymDB
+        { synNameToId = nameToId
+        , synIdToNames = idToNames
+        , synEdges = [SynEdge a b BridgeBoth | (a, b) <- starEdges (M.elems idToNames)]
+        , synViews = AllBoth
+        }
 
 {- | Star edges for a set of name classes: connect each class's members to its
 first member. Their transitive closure is exactly the classes — enough to

--- a/src/SynonymDB.hs
+++ b/src/SynonymDB.hs
@@ -13,6 +13,7 @@ module SynonymDB (
     buildFromCSV,
     buildFromPairs,
     buildFromEdges,
+    buildFromNormalizedEdges,
     excludeOverFrequentSynonyms,
     excludeJunkSynonyms,
     isJunkSynonymName,
@@ -122,8 +123,19 @@ surfaces through 'oversizedClasses' (the loader warns) rather than being silentl
 dropped.
 -}
 buildFromEdges :: [SynEdge] -> SynonymDB
-buildFromEdges raws =
-    let normd = demoteDuplicates (normalizeEdges raws)
+buildFromEdges = buildFromNormalizedEdges . normalizeEdges
+
+{- | Build from edges whose endpoints already carry 'normalizeName''s output —
+the invariant every built DB's 'synEdges' satisfies. Merging and the
+induced-subgraph restriction re-close through HERE, not 'buildFromEdges':
+'normalizeName' is not idempotent (a suffix exposed by punctuation removal —
+@"Zinc in ground,"@ → @"zinc in ground"@ → @"zinc"@ — strips only on a second
+pass), so re-normalizing stored edges would key the rebuilt tables away from
+the single-pass normalization every lookup applies.
+-}
+buildFromNormalizedEdges :: [SynEdge] -> SynonymDB
+buildFromNormalizedEdges es =
+    let normd = demoteDuplicates es
         base = buildTables normd
         views
             | all ((== BridgeBoth) . seDir) normd = AllBoth
@@ -276,11 +288,12 @@ declares A=B and another B=C, the merged DB groups {A,B,C}. The sources' own
 @synEdges@ are concatenated and the whole edge set is closed again (directional
 views rebuilt, 'demoteDuplicates' applied across sources), so the merged DB
 carries the union of the original directed edges, not a lossy star reconstruction.
+Stored edges are already normalized, hence 'buildFromNormalizedEdges'.
 -}
 mergeSynonymDBs :: [SynonymDB] -> SynonymDB
 mergeSynonymDBs [] = emptySynonymDB
 mergeSynonymDBs [db] = db
-mergeSynonymDBs dbs = buildFromEdges (concatMap synEdges dbs)
+mergeSynonymDBs dbs = buildFromNormalizedEdges (concatMap synEdges dbs)
 
 -- | Number of synonym names in the database.
 synonymCount :: SynonymDB -> Int

--- a/src/SynonymDB.hs
+++ b/src/SynonymDB.hs
@@ -27,6 +27,7 @@ module SynonymDB (
     mergeSynonymDBs,
     synonymCount,
     oversizedClasses,
+    reopenedBridges,
 
     -- * Directional views
     inputView,
@@ -174,9 +175,11 @@ normalizePairs rs =
     ]
 
 {- | Drop the 'BridgeBoth' copy of an unordered pair that also has a directional
-edge. Without this, an untyped duplicate (e.g. a merged auto-extracted
-@freshwater = water…@ pair) would silently reopen a curated input-only bridge in
-the output view — the direction constraint would quietly stop working.
+edge, so an untyped duplicate of that exact pair (e.g. a merged auto-extracted
+@freshwater = water…@ row) cannot silently reopen a curated one-way bridge in
+the other view. The guard is pair-local only: an untyped transitive chain
+between the same endpoints (@a=x@, @x=b@) still re-links them in the closed
+view — 'reopenedBridges' detects that residue so the loader can surface it.
 -}
 demoteDuplicates :: [SynEdge] -> [SynEdge]
 demoteDuplicates es =
@@ -308,6 +311,29 @@ returns; an empty result means the closure stayed plausible.
 -}
 oversizedClasses :: Int -> [(Text, Text)] -> [[Text]]
 oversizedClasses maxSize = filter ((> maxSize) . length) . equivalenceClasses . normalizePairs
+
+{- | Directed edges whose one-way constraint is void: their endpoints are also
+connected in the OPPOSITE direction's view. 'demoteDuplicates' removes only the
+exact untyped duplicate of a directed pair; an untyped transitive chain
+(@a=x@, @x=b@) or a contradictory opposite-direction row re-links the endpoints
+anyway, silently widening the bridge back to both directions. That may be
+intended (two one-way assertions do compose) but is more likely curation drift
+in a merged source, so the loader surfaces whatever this returns rather than
+letting a direction restriction quietly stop working.
+-}
+reopenedBridges :: SynonymDB -> [SynEdge]
+reopenedBridges db = filter voided (synEdges db)
+  where
+    voided e = case seDir e of
+        BridgeBoth -> False
+        BridgeInput -> linkedIn (outputView db) e
+        BridgeOutput -> linkedIn (inputView db) e
+    -- Endpoints are already normalized ('normalizeEdges'), so probe the tables
+    -- directly — 'lookupSynonymGroup' would re-normalize, and 'normalizeName'
+    -- is not idempotent.
+    linkedIn v e =
+        ((==) <$> M.lookup (seA e) (synNameToId v) <*> M.lookup (seB e) (synNameToId v))
+            == Just True
 
 {- | Drop synonym pairs whose synonym (the second element) is carried by more
 than @maxFlows@ distinct base names (the first element). An over-frequent

--- a/src/SynonymDB.hs
+++ b/src/SynonymDB.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -13,6 +12,7 @@ module SynonymDB (
     -- * Building
     buildFromCSV,
     buildFromPairs,
+    buildFromEdges,
     excludeOverFrequentSynonyms,
     excludeJunkSynonyms,
     isJunkSynonymName,
@@ -27,12 +27,19 @@ module SynonymDB (
     synonymCount,
     oversizedClasses,
 
+    -- * Directional views
+    inputView,
+    outputView,
+
     -- * Unit suffixes
     unitSuffixes,
     uncoveredUnitSuffixes,
 
     -- * Re-exports
     SynonymDB (..),
+    BridgeDirection (..),
+    SynEdge (..),
+    SynViews (..),
     emptySynonymDB,
 ) where
 
@@ -42,7 +49,7 @@ import Control.Exception (SomeException, catch, evaluate)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import Data.Char (isDigit)
-import Data.Csv (HasHeader (..), decode)
+import Data.Csv (FromRecord (..), HasHeader (..), Parser, decode, (.!))
 import Data.List (sortOn)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
@@ -50,38 +57,97 @@ import Data.Store (decodeEx, encode)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Vector as V
+import Data.Word (Word32)
 import System.Directory (doesFileExist, getModificationTime)
 
 import SubstanceRegistry (equivalenceClasses)
-import SynonymDB.Types (SynonymDB (..), emptySynonymDB)
+import SynonymDB.Types (
+    BridgeDirection (..),
+    SynEdge (..),
+    SynViews (..),
+    SynonymDB (..),
+    emptySynonymDB,
+ )
 
-{- | Build a SynonymDB from CSV content (two columns: name1, name2).
-Each row declares two names as @SameAs@. Names are grouped by transitive
-closure (see 'buildFromPairs'): A↔B and B↔C ⟹ one class {A,B,C}.
+{- | One CSV row of the synonym registry: two @SameAs@ names and an optional
+direction. Accepts arity 2 (@name1,name2@ — direction 'BridgeBoth') or arity 3
+(@name1,name2,direction@ where direction is @input@, @output@, or empty). Any
+other direction token is a parse error (surfaced, never silently coerced), and
+any other arity is rejected.
+-}
+data SynRow = SynRow !Text !Text !BridgeDirection
+
+instance FromRecord SynRow where
+    parseRecord v = case V.length v of
+        2 -> SynRow <$> v .! 0 <*> v .! 1 <*> pure BridgeBoth
+        3 -> SynRow <$> v .! 0 <*> v .! 1 <*> (v .! 2 >>= parseDir)
+        n -> fail $ "expected 2 or 3 columns (name1,name2[,direction]), got " <> show n
+      where
+        parseDir :: Text -> Parser BridgeDirection
+        parseDir t = case T.toLower (T.strip t) of
+            "" -> pure BridgeBoth
+            "input" -> pure BridgeInput
+            "output" -> pure BridgeOutput
+            other -> fail $ "invalid direction " <> show other <> " (expected input|output|empty)"
+
+{- | Build a SynonymDB from CSV content. Columns: @name1,name2[,direction]@.
+Each row declares two names as @SameAs@ (see 'buildFromPairs'/'buildFromEdges');
+the optional third column restricts the bridge to one flow direction.
 -}
 buildFromCSV :: BL.ByteString -> Either String SynonymDB
 buildFromCSV csvData =
     case decode HasHeader csvData of
         Left err -> Left $ "CSV parse error: " <> err
-        Right rows -> Right $ buildFromPairs (V.toList (rows :: V.Vector (Text, Text)))
+        Right rows -> Right $ buildFromEdges [SynEdge a b d | SynRow a b d <- V.toList rows]
 
-{- | Build a SynonymDB from @SameAs@ name pairs.
+{- | Build a SynonymDB from untyped @SameAs@ name pairs (all 'BridgeBoth').
+The direction-agnostic entry point kept for callers that do not carry direction
+(auto-extraction, JSON import); delegates to 'buildFromEdges'.
+-}
+buildFromPairs :: [(Text, Text)] -> SynonymDB
+buildFromPairs raws = buildFromEdges [SynEdge a b BridgeBoth | (a, b) <- raws]
+
+{- | Build a SynonymDB from directed @SameAs@ edges.
 
 Names are normalized, then grouped into equivalence classes by transitive
 closure (connected components) — the "set of sets" of the canonical flow
-registry. A↔B and B↔C therefore land A, B and C in one class.
+registry. A↔B and B↔C therefore land A, B and C in one class. The top-level
+tables are the UNION closure (all directions), so direction-agnostic consumers
+see today's behavior. When any edge is directional, two extra views are
+materialized ('SynViews'): the input view closes @both ∪ input@, the output view
+@both ∪ output@ — the matching layer picks one by the CF's direction.
 
-Closure is taken honestly, with no silent degree cap. Measured on the current
-reference data, no class exceeds a handful of members (the feared
-sulfate→…→carbonate chain does not occur), so closure is safe. Bad data — a junk
-hub that would fuse unrelated substances — surfaces through 'oversizedClasses'
-(the loader warns) rather than being silently dropped, and genuinely-broader
-relations (SOx ⊃ SO₂) belong in the typed-edge layer, not as @SameAs@.
+Closure is taken honestly, with no silent degree cap; an implausibly large class
+surfaces through 'oversizedClasses' (the loader warns) rather than being silently
+dropped.
 -}
-buildFromPairs :: [(Text, Text)] -> SynonymDB
-buildFromPairs raws =
-    let normd = normalizePairs raws
-     in (fromClasses (equivalenceClasses normd)){synEdges = normd}
+buildFromEdges :: [SynEdge] -> SynonymDB
+buildFromEdges raws =
+    let normd = demoteDuplicates (normalizeEdges raws)
+        base = buildTables normd
+        views
+            | all ((== BridgeBoth) . seDir) normd = AllBoth
+            | otherwise =
+                DirectedViews
+                    (buildTables (edgesFor BridgeInput normd))
+                    (buildTables (edgesFor BridgeOutput normd))
+     in base{synViews = views}
+  where
+    edgesFor dir = filter (\e -> seDir e == BridgeBoth || seDir e == dir)
+
+{- | Normalize an edge's endpoints, dropping empty/self edges (as
+'buildFromPairs' did). Direction is preserved.
+-}
+normalizeEdges :: [SynEdge] -> [SynEdge]
+normalizeEdges es =
+    [ SynEdge n1 n2 (seDir e)
+    | e <- es
+    , let n1 = normalizeName (seA e)
+    , let n2 = normalizeName (seB e)
+    , not (T.null n1)
+    , not (T.null n2)
+    , n1 /= n2
+    ]
 
 -- | Normalize both ends of each pair, dropping empty names and self-pairs.
 normalizePairs :: [(Text, Text)] -> [(Text, Text)]
@@ -95,13 +161,29 @@ normalizePairs rs =
     , n1 /= n2
     ]
 
--- | Number a list of name classes into the bidirectional SynonymDB lookup tables.
-fromClasses :: [[Text]] -> SynonymDB
-fromClasses classes =
-    let numbered = zip [0 ..] classes
+{- | Drop the 'BridgeBoth' copy of an unordered pair that also has a directional
+edge. Without this, an untyped duplicate (e.g. a merged auto-extracted
+@freshwater = water…@ pair) would silently reopen a curated input-only bridge in
+the output view — the direction constraint would quietly stop working.
+-}
+demoteDuplicates :: [SynEdge] -> [SynEdge]
+demoteDuplicates es =
+    [e | e <- es, not (seDir e == BridgeBoth && S.member (key e) directedPairs)]
+  where
+    key e = if seA e <= seB e then (seA e, seB e) else (seB e, seA e)
+    directedPairs = S.fromList [key e | e <- es, seDir e /= BridgeBoth]
+
+{- | Number name classes into the bidirectional lookup tables, closed from the
+given edges. The result's 'synViews' is 'AllBoth' — 'buildFromEdges' attaches
+directional views when needed (a view is itself an 'AllBoth' table).
+-}
+buildTables :: [SynEdge] -> SynonymDB
+buildTables edges =
+    let classes = equivalenceClasses [(seA e, seB e) | e <- edges]
+        numbered = zip [0 ..] classes
         nameToId = M.fromList [(name, gid) | (gid, members) <- numbered, name <- members]
         idToNames = M.fromList numbered
-     in SynonymDB nameToId idToNames (starEdges classes)
+     in SynonymDB nameToId idToNames edges AllBoth
 
 {- | Star edges for a set of name classes: connect each class's members to its
 first member. Their transitive closure is exactly the classes — enough to
@@ -111,6 +193,21 @@ restriction later drops would lose links the original topology preserves.
 -}
 starEdges :: [[Text]] -> [(Text, Text)]
 starEdges classes = [(m0, m) | (m0 : ms) <- classes, m <- ms]
+
+{- | The synonym view to use for INPUT (resource) CFs: the closure of the
+bidirectional and input-only bridges. Identical to the union tables when no
+directional edge exists.
+-}
+inputView :: SynonymDB -> SynonymDB
+inputView db = case synViews db of
+    AllBoth -> db
+    DirectedViews i _ -> i
+
+-- | The synonym view to use for OUTPUT (emission) CFs (see 'inputView').
+outputView :: SynonymDB -> SynonymDB
+outputView db = case synViews db of
+    AllBoth -> db
+    DirectedViews _ o -> o
 
 {- | Load a SynonymDB from a CSV file, using a binary cache for speed.
   On first load: parse CSV → build SynonymDB → save .cache.zst
@@ -149,31 +246,41 @@ loadFromCSVFileWithCache csvPath = do
                                 compressed <- BS.readFile cachePath
                                 case Zstd.decompress compressed of
                                     Zstd.Decompress raw -> do
-                                        let !db = decodeEx raw
-                                        result <- evaluate (force db)
-                                        return (Just result)
+                                        -- Version-tagged payload: a cache written by
+                                        -- an older schema (different 'SynonymDB' Store
+                                        -- shape) fails the version check or the decode,
+                                        -- so it is reparsed rather than trusted.
+                                        let (ver, db) = decodeEx raw
+                                        if ver /= synonymDBCacheVersion
+                                            then return Nothing
+                                            else do
+                                                result <- evaluate (force (db :: SynonymDB))
+                                                return (Just result)
                                     _ -> return Nothing
                     )
                     (\(_ :: SomeException) -> return Nothing)
     saveCache cachePath db =
         catch
-            (BS.writeFile cachePath (Zstd.compress 1 (encode db)))
+            (BS.writeFile cachePath (Zstd.compress 1 (encode (synonymDBCacheVersion, db))))
             (\(_ :: SomeException) -> return ())
+
+{- | Schema version of the serialized 'SynonymDB' cache. Bump when the 'Store'
+shape of 'SynonymDB' changes so stale @.cache.zst@ files are reparsed instead of
+mis-decoded. (v2: directional edges + views.)
+-}
+synonymDBCacheVersion :: Word32
+synonymDBCacheVersion = 2
 
 {- | Merge multiple SynonymDBs into one, re-closing across them: if one source
 declares A=B and another B=C, the merged DB groups {A,B,C}. The sources' own
-@synEdges@ are concatenated and the whole edge set is closed again, so the merged
-DB carries the union of the original pairs (not a lossy star reconstruction).
+@synEdges@ are concatenated and the whole edge set is closed again (directional
+views rebuilt, 'demoteDuplicates' applied across sources), so the merged DB
+carries the union of the original directed edges, not a lossy star reconstruction.
 -}
 mergeSynonymDBs :: [SynonymDB] -> SynonymDB
 mergeSynonymDBs [] = emptySynonymDB
 mergeSynonymDBs [db] = db
-mergeSynonymDBs dbs = (fromClasses (equivalenceClasses edges)){synEdges = edges}
-  where
-    -- Re-close from each source's own (already normalized) pairs rather than
-    -- reconstructing stars from its classes, so the merged 'synEdges' keeps the
-    -- faithful topology the induced-subgraph restriction needs.
-    edges = concatMap synEdges dbs
+mergeSynonymDBs dbs = buildFromEdges (concatMap synEdges dbs)
 
 -- | Number of synonym names in the database.
 synonymCount :: SynonymDB -> Int

--- a/src/SynonymDB/Types.hs
+++ b/src/SynonymDB/Types.hs
@@ -5,6 +5,9 @@
 -- | Types for the synonym database used for flow matching.
 module SynonymDB.Types (
     SynonymDB (..),
+    BridgeDirection (..),
+    SynEdge (..),
+    SynViews (..),
     emptySynonymDB,
 ) where
 
@@ -15,22 +18,61 @@ import Data.Store (Store)
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
+{- | Which flow direction a synonym bridge is valid for. Most bridges are pure
+substance identity and apply to both directions ('BridgeBoth'). Some hold only
+one way: a water @withdrawal@ name ("river water") bridges to a resource flow
+only for an INPUT CF; letting an OUTPUT (release) CF inherit it would apply a
+withdrawal scarcity factor to a release, wrong in sign or magnitude.
+-}
+data BridgeDirection = BridgeBoth | BridgeInput | BridgeOutput
+    deriving (Eq, Ord, Show, Generic, NFData, Store)
+
+{- | A normalized @SameAs@ edge carrying the direction it is valid for. Kept in
+'synEdges' so the relation can be re-closed (merge, induced-subgraph restriction)
+without losing the direction constraint.
+-}
+data SynEdge = SynEdge
+    { seA :: !Text
+    , seB :: !Text
+    , seDir :: !BridgeDirection
+    }
+    deriving (Eq, Show, Generic, NFData, Store)
+
+{- | Direction-restricted views of a 'SynonymDB', precomputed at build time.
+
+'AllBoth' is the common case — no directed edge exists, so the input and output
+views both coincide with the union tables; no view is materialized (zero cost
+for large untyped sets). 'DirectedViews' holds the closure of @both ∪ input@ and
+of @both ∪ output@ separately, because a direction restriction can SPLIT a group
+(@a-b [input]@, @b-c [both]@ ⇒ input {a,b,c} but output {b,c}) — a split that the
+union tables cannot recover at lookup time. Views are terminal: their own
+'synViews' is 'AllBoth'.
+-}
+data SynViews
+    = AllBoth
+    | DirectedViews !SynonymDB !SynonymDB
+    deriving (Eq, Show, Generic, NFData, Store)
+
 {- | Synonym database with bidirectional lookups.
 
-- @synNameToId@: Maps normalized flow names to synonym group IDs
-- @synIdToNames@: Maps group IDs back to all names in that group
-- @synEdges@: the normalized @SameAs@ pairs the classes were closed from, kept
-  so the relation can be re-closed on a restricted node set (an induced
-  subgraph on the used flow names) at fan-out time — a closed class cannot be
-  re-split once its internal edges are gone.
+- @synNameToId@: normalized flow name → synonym group ID (union closure)
+- @synIdToNames@: group ID → all names in that group (union closure)
+- @synEdges@: the normalized 'SynEdge's the classes were closed from, kept so the
+  relation can be re-closed on a restricted node set (an induced subgraph on the
+  used flow names) at fan-out time — a closed class cannot be re-split once its
+  internal edges are gone.
+- @synViews@: direction-restricted views (see 'SynViews'). The top-level tables
+  stay the union closure so direction-agnostic consumers are unchanged; the
+  matching layer selects a view by the CF's direction.
 -}
 data SynonymDB = SynonymDB
     { synNameToId :: !(Map Text Int)
     , synIdToNames :: !(Map Int [Text])
-    , synEdges :: ![(Text, Text)]
+    , synEdges :: ![SynEdge]
+    , synViews :: !SynViews
     }
     deriving (Eq, Show, Generic, NFData, Store)
 
 -- | Empty synonym database
 emptySynonymDB :: SynonymDB
-emptySynonymDB = SynonymDB M.empty M.empty []
+emptySynonymDB = SynonymDB M.empty M.empty [] AllBoth

--- a/src/SynonymDB/Types.hs
+++ b/src/SynonymDB/Types.hs
@@ -46,7 +46,8 @@ for large untyped sets). 'DirectedViews' holds the closure of @both ∪ input@ a
 of @both ∪ output@ separately, because a direction restriction can SPLIT a group
 (@a-b [input]@, @b-c [both]@ ⇒ input {a,b,c} but output {b,c}) — a split that the
 union tables cannot recover at lookup time. Views are terminal: their own
-'synViews' is 'AllBoth'.
+'synViews' is 'AllBoth' and their 'synEdges' is empty — nothing re-closes a
+view, so only its lookup tables are materialized (and serialized).
 -}
 data SynViews
     = AllBoth

--- a/src/Tools/SynonymsCompiler.hs
+++ b/src/Tools/SynonymsCompiler.hs
@@ -42,8 +42,8 @@ import System.IO (hPutStrLn, stderr)
 import Text.Printf (printf)
 
 import EcoSpold.Parser2 (normalizeCAS)
-import SynonymDB (normalizeName, starEdges)
-import SynonymDB.Types (BridgeDirection (..), SynEdge (..), SynViews (..), SynonymDB (..))
+import SynonymDB (fromClassMaps, normalizeName)
+import SynonymDB.Types (SynonymDB (..))
 
 -- | Shared output options
 data OutputOpts = OutputOpts
@@ -120,13 +120,7 @@ parseJSONToSynonymDB (A.Object obj) = do
             Right
             (KM.lookup "id_to_synonyms" obj)
     idToNames <- parseIdToSynonyms idToSynValue
-    Right $
-        SynonymDB
-            { synNameToId = nameToId
-            , synIdToNames = idToNames
-            , synEdges = [SynEdge a b BridgeBoth | (a, b) <- starEdges (M.elems idToNames)]
-            , synViews = AllBoth
-            }
+    Right $ fromClassMaps nameToId idToNames
 parseJSONToSynonymDB _ = Left "Expected JSON object at top level"
 
 parseNameToId :: A.Value -> Either String (M.Map T.Text Int)
@@ -332,12 +326,7 @@ buildSynonymDB casGroups namePairs =
         -- Step 3: Build maps, enforcing size cap
         (nameToId, idToNames) = buildMaps allGroups
      in
-        SynonymDB
-            { synNameToId = nameToId
-            , synIdToNames = idToNames
-            , synEdges = [SynEdge a b BridgeBoth | (a, b) <- starEdges (M.elems idToNames)]
-            , synViews = AllBoth
-            }
+        fromClassMaps nameToId idToNames
 
 -- | Merge name pairs into existing groups using simple Union-Find on Map
 mergeNamePairs :: [SynonymPair] -> [[T.Text]] -> [[T.Text]]

--- a/src/Tools/SynonymsCompiler.hs
+++ b/src/Tools/SynonymsCompiler.hs
@@ -43,7 +43,7 @@ import Text.Printf (printf)
 
 import EcoSpold.Parser2 (normalizeCAS)
 import SynonymDB (normalizeName, starEdges)
-import SynonymDB.Types (SynonymDB (..))
+import SynonymDB.Types (BridgeDirection (..), SynEdge (..), SynViews (..), SynonymDB (..))
 
 -- | Shared output options
 data OutputOpts = OutputOpts
@@ -120,7 +120,13 @@ parseJSONToSynonymDB (A.Object obj) = do
             Right
             (KM.lookup "id_to_synonyms" obj)
     idToNames <- parseIdToSynonyms idToSynValue
-    Right $ SynonymDB{synNameToId = nameToId, synIdToNames = idToNames, synEdges = starEdges (M.elems idToNames)}
+    Right $
+        SynonymDB
+            { synNameToId = nameToId
+            , synIdToNames = idToNames
+            , synEdges = [SynEdge a b BridgeBoth | (a, b) <- starEdges (M.elems idToNames)]
+            , synViews = AllBoth
+            }
 parseJSONToSynonymDB _ = Left "Expected JSON object at top level"
 
 parseNameToId :: A.Value -> Either String (M.Map T.Text Int)
@@ -326,7 +332,12 @@ buildSynonymDB casGroups namePairs =
         -- Step 3: Build maps, enforcing size cap
         (nameToId, idToNames) = buildMaps allGroups
      in
-        SynonymDB{synNameToId = nameToId, synIdToNames = idToNames, synEdges = starEdges (M.elems idToNames)}
+        SynonymDB
+            { synNameToId = nameToId
+            , synIdToNames = idToNames
+            , synEdges = [SynEdge a b BridgeBoth | (a, b) <- starEdges (M.elems idToNames)]
+            , synViews = AllBoth
+            }
 
 -- | Merge name pairs into existing groups using simple Union-Find on Map
 mergeNamePairs :: [SynonymPair] -> [[T.Text]] -> [[T.Text]]

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -215,6 +215,27 @@ spec = do
             fid <- nextRandom
             fannedIds outputCF fid `shouldBe` []
 
+    describe "directionExcludedCFs" $ do
+        -- An unmapped CF whose name matches through the UNION synonym tables but
+        -- not through its own direction's view was excluded by the direction
+        -- restriction alone — e.g. a parser defaulted the direction when the
+        -- method carried none. The loader surfaces these so the loss is
+        -- distinguishable from a genuinely uncharacterized flow.
+        let synDB = buildFromEdges [SynEdge "freshwater" "Water, unspecified natural origin" BridgeInput]
+            flowsByName fid = M.singleton "water unspecified natural origin" [mkFlow fid "Water, unspecified natural origin" "natural resource" Nothing]
+            inputCF = (mkCF "freshwater" Nothing 1.0){mcfDirection = Input}
+            outputCF = (mkCF "freshwater" Nothing 1.0){mcfDirection = Output}
+
+        it "flags an unmapped CF whose synonym match exists only outside its direction view" $ do
+            fid <- nextRandom
+            map mcfFlowName (directionExcludedCFs synDB (flowsByName fid) [(outputCF, Nothing)])
+                `shouldBe` ["freshwater"]
+
+        it "does not flag a CF its own direction view still matches, nor a genuinely unmatched one" $ do
+            fid <- nextRandom
+            directionExcludedCFs synDB (flowsByName fid) [(inputCF, Nothing)] `shouldSatisfy` null
+            directionExcludedCFs synDB (flowsByName fid) [(mkCF "unrelated" Nothing 1.0, Nothing)] `shouldSatisfy` null
+
     describe "computeMappingStats" $ do
         it "counts totals and strategies correctly" $ do
             fid1 <- nextRandom

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -12,7 +12,7 @@ import Test.Hspec
 import Method.ChemSynonyms (emptyChemSynonyms, parseChemSynonymsCSV)
 import Method.Mapping
 import Method.Types (Compartment (..), FlowDirection (..), Method (..), MethodCF (..))
-import SynonymDB (buildFromPairs, emptySynonymDB)
+import SynonymDB (BridgeDirection (..), SynEdge (..), buildFromEdges, buildFromPairs, emptySynonymDB)
 import Types (BiosphereFlow (..), Unit (..))
 import qualified Types as VT
 import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig)
@@ -193,6 +193,27 @@ spec = do
             let synDB = buildFromPairs [("CO2", "Carbon dioxide")]
             fmap bfId (findFlowBySynonymComp synDB M.empty "CO2" Nothing)
                 `shouldBe` Nothing
+
+    describe "expandSynonymMappings direction" $ do
+        -- The water withdrawal bridge "freshwater" → resource flow applies to an
+        -- INPUT (withdrawal) CF only. An OUTPUT (release) CF named "freshwater"
+        -- must not fan out onto the resource flow through it — else a release
+        -- inherits a withdrawal scarcity factor (wrong sign/magnitude).
+        let synDB = buildFromEdges [SynEdge "freshwater" "Water, unspecified natural origin" BridgeInput]
+            resourceFlow fid = mkFlow fid "Water, unspecified natural origin" "natural resource" Nothing
+            flowsByName fid = M.singleton "water unspecified natural origin" [resourceFlow fid]
+            inputCF = (mkCF "freshwater" Nothing 1.0){mcfDirection = Input}
+            outputCF = (mkCF "freshwater" Nothing 1.0){mcfDirection = Output}
+            fannedIds cf fid =
+                [bfId flow | (_, Just (flow, _)) <- drop 1 (expandSynonymMappings synDB (flowsByName fid) [(cf, Nothing)])]
+
+        it "fans an INPUT CF out onto the withdrawal resource flow" $ do
+            fid <- nextRandom
+            fannedIds inputCF fid `shouldBe` [fid]
+
+        it "does NOT fan an OUTPUT CF through the input-only bridge" $ do
+            fid <- nextRandom
+            fannedIds outputCF fid `shouldBe` []
 
     describe "computeMappingStats" $ do
         it "counts totals and strategies correctly" $ do

--- a/test/MethodSpec.hs
+++ b/test/MethodSpec.hs
@@ -657,6 +657,27 @@ spec = do
                 Left err -> expectationFailure $ "Parse failed: " ++ err
                 Right methods -> length methods `shouldBe` 4
 
+        it "reads raw-materials compartment spellings as Input direction" $ do
+            -- A resource CF mis-read as Output resolves against the output
+            -- synonym view and silently loses input-only bridges, so every
+            -- resource compartment spelling must map to Input.
+            let csv =
+                    BC.unlines
+                        [ ";;Method A"
+                        , ";;kg eq"
+                        , "substance;compartment;"
+                        , "Crude oil;Raw materials;1.0"
+                        , "freshwater;Resources from ground;2.0"
+                        , "CO2;air;3.0"
+                        ]
+            case parseMethodCSVBytes csv of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right methods -> do
+                    let dirs = [(mcfFlowName cf, mcfDirection cf) | m <- methods, cf <- methodFactors m]
+                    lookup "Crude oil" dirs `shouldBe` Just Input
+                    lookup "freshwater" dirs `shouldBe` Just Input
+                    lookup "CO2" dirs `shouldBe` Just Output
+
         it "returns Left when fewer than 3 header rows" $ do
             let csv =
                     BC.unlines

--- a/test/ProjectRegionalSpec.hs
+++ b/test/ProjectRegionalSpec.hs
@@ -10,7 +10,7 @@ import Test.Hspec
 
 import Method.Mapping (MatchStrategy (..), projectRegionalResourceFlows)
 import Method.Types (Compartment (..), FlowDirection (..), MethodCF (..))
-import SynonymDB (buildFromPairs)
+import SynonymDB (BridgeDirection (..), SynEdge (..), buildFromEdges, buildFromPairs)
 import Types (BiosphereFlow (..))
 import qualified Types as VT
 
@@ -92,6 +92,18 @@ spec = describe "projectRegionalResourceFlows" $ do
             frFlow = mkResourceFlow 11 "Water, river, FR"
         projected
             (projectRegionalResourceFlows synDB (M.fromList [(bfId frFlow, frFlow)]) [(cfGlobal, Just (baseFlow, BySynonym))])
+            `shouldNotContain` [frProjection]
+
+    it "projects a resource withdrawal through an INPUT-only bridge (resource medium picks the input view)" $ do
+        let inSynDB = buildFromEdges [SynEdge "river water" "Water, river" BridgeInput]
+            frFlow = mkResourceFlow 11 "Water, river, FR"
+        projected (projectRegionalResourceFlows inSynDB (M.fromList [(bfId frFlow, frFlow)]) baseMappings)
+            `shouldContain` [frProjection]
+
+    it "does not project a resource withdrawal through an OUTPUT-only bridge (view selection is real)" $ do
+        let outSynDB = buildFromEdges [SynEdge "river water" "Water, river" BridgeOutput]
+            frFlow = mkResourceFlow 11 "Water, river, FR"
+        projected (projectRegionalResourceFlows outSynDB (M.fromList [(bfId frFlow, frFlow)]) baseMappings)
             `shouldNotContain` [frProjection]
 
     it "projects a release CF onto a region-tagged water emission flow by its own name" $ do

--- a/test/SynonymDBSpec.hs
+++ b/test/SynonymDBSpec.hs
@@ -8,7 +8,7 @@ import qualified Data.Set as S
 import Data.Text (Text, pack)
 import Test.Hspec
 
-import SynonymDB (BridgeDirection (..), SynEdge (..), SynViews (..), buildFromCSV, buildFromEdges, buildFromPairs, excludeJunkSynonyms, excludeOverFrequentSynonyms, getSynonyms, inputView, isJunkSynonymName, loadFromCSVFileWithCache, lookupSynonymGroup, mergeSynonymDBs, normalizeName, outputView, oversizedClasses, synEdges, synViews, uncoveredUnitSuffixes)
+import SynonymDB (BridgeDirection (..), SynEdge (..), SynViews (..), buildFromCSV, buildFromEdges, buildFromPairs, excludeJunkSynonyms, excludeOverFrequentSynonyms, getSynonyms, inputView, isJunkSynonymName, loadFromCSVFileWithCache, lookupSynonymGroup, mergeSynonymDBs, normalizeName, outputView, oversizedClasses, reopenedBridges, synEdges, synViews, uncoveredUnitSuffixes)
 
 spec :: Spec
 spec = do
@@ -95,7 +95,8 @@ spec = do
         it "loads the shipped data/flows.csv and keeps its water bridges input-only" $ do
             -- Guards the real curated registry: it must parse (3-column direction
             -- schema), and the water withdrawal bridges must reach their resource
-            -- flow only in the input view, never the output view.
+            -- flow only in the input view, never the output view — and no untyped
+            -- row may void a one-way constraint ('reopenedBridges').
             loaded <- loadFromCSVFileWithCache "data/flows.csv"
             case loaded of
                 Left e -> expectationFailure e
@@ -103,6 +104,28 @@ spec = do
                     lookupSynonymGroup (inputView db) "freshwater" `shouldSatisfy` (/= Nothing)
                     lookupSynonymGroup (outputView db) "freshwater" `shouldBe` Nothing
                     lookupSynonymGroup (outputView db) "river water" `shouldBe` Nothing
+                    reopenedBridges db `shouldBe` []
+
+    describe "reopenedBridges" $ do
+        it "flags a one-way bridge reopened by an untyped transitive chain" $ do
+            -- 'demoteDuplicates' removes only the exact duplicate pair; a chain of
+            -- untyped edges through an intermediate re-links the endpoints in the
+            -- view the direction was meant to close. That must be surfaced.
+            let db =
+                    buildFromEdges
+                        [ SynEdge "freshwater" "Water unspecified" BridgeInput
+                        , SynEdge "freshwater" "surface water" BridgeBoth
+                        , SynEdge "surface water" "Water unspecified" BridgeBoth
+                        ]
+            reopenedBridges db `shouldBe` [SynEdge "freshwater" "water unspecified" BridgeInput]
+
+        it "flags a pair typed both input and output (contradictory curation widens to both)" $ do
+            let db = buildFromEdges [SynEdge "a" "b" BridgeInput, SynEdge "a" "b" BridgeOutput]
+            length (reopenedBridges db) `shouldBe` 2
+
+        it "stays silent on consistent data" $ do
+            let db = buildFromEdges [SynEdge "river water" "Water river" BridgeInput, SynEdge "x" "y" BridgeBoth]
+            reopenedBridges db `shouldBe` []
 
     describe "oversizedClasses" $ do
         -- A junk hub fuses everything it touches into one transitive class.

--- a/test/SynonymDBSpec.hs
+++ b/test/SynonymDBSpec.hs
@@ -2,12 +2,13 @@
 
 module SynonymDBSpec (spec) where
 
+import qualified Data.ByteString.Lazy.Char8 as BLC
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.Text (Text, pack)
 import Test.Hspec
 
-import SynonymDB (buildFromPairs, excludeJunkSynonyms, excludeOverFrequentSynonyms, getSynonyms, isJunkSynonymName, loadFromCSVFileWithCache, lookupSynonymGroup, normalizeName, oversizedClasses, uncoveredUnitSuffixes)
+import SynonymDB (BridgeDirection (..), SynEdge (..), SynViews (..), buildFromCSV, buildFromEdges, buildFromPairs, excludeJunkSynonyms, excludeOverFrequentSynonyms, getSynonyms, inputView, isJunkSynonymName, loadFromCSVFileWithCache, lookupSynonymGroup, mergeSynonymDBs, normalizeName, outputView, oversizedClasses, synEdges, synViews, uncoveredUnitSuffixes)
 
 spec :: Spec
 spec = do
@@ -31,6 +32,68 @@ spec = do
 
         it "gives both ends of the chain the same group id" $
             lookupSynonymGroup db "alpha" `shouldBe` lookupSynonymGroup db "gamma"
+
+    describe "directional bridges" $ do
+        let groupIn db name = S.fromList <$> (lookupSynonymGroup (inputView db) name >>= getSynonyms (inputView db))
+            groupOut db name = S.fromList <$> (lookupSynonymGroup (outputView db) name >>= getSynonyms (outputView db))
+
+        it "leaves untyped data with coinciding views (AllBoth, no duplication)" $ do
+            let db = buildFromPairs [("alpha", "beta")]
+            synViews db `shouldBe` AllBoth
+            inputView db `shouldBe` db
+            outputView db `shouldBe` db
+
+        it "parses a 2-column CSV as all-both, a 3-column CSV with a direction" $ do
+            let two = buildFromCSV (BLC.pack "name1,name2\nalpha,beta\n")
+                three = buildFromCSV (BLC.pack "name1,name2,direction\nriver water,Water river,input\n")
+            fmap synViews two `shouldBe` Right AllBoth
+            case three of
+                Left e -> expectationFailure e
+                Right db -> do
+                    groupIn db "river water" `shouldBe` Just (S.fromList ["river water", "water river"])
+                    groupOut db "river water" `shouldBe` Nothing
+
+        it "treats an empty direction column as both" $
+            case buildFromCSV (BLC.pack "name1,name2,direction\nalpha,beta,\n") of
+                Left e -> expectationFailure e
+                Right db -> synViews db `shouldBe` AllBoth
+
+        it "rejects an unknown direction token instead of silently coercing it" $
+            case buildFromCSV (BLC.pack "name1,name2,direction\nalpha,beta,sideways\n") of
+                Left _ -> pure ()
+                Right _ -> expectationFailure "expected Left for an invalid direction token"
+
+        it "splits a group along direction: an input edge chained to a both edge" $ do
+            -- a-b [input], b-c [both]. Input view fuses {a,b,c}; output view, missing
+            -- the a-b link, keeps only {b,c} — a split the union tables cannot recover.
+            let db = buildFromEdges [SynEdge "a" "b" BridgeInput, SynEdge "b" "c" BridgeBoth]
+            groupIn db "a" `shouldBe` Just (S.fromList ["a", "b", "c"])
+            groupOut db "a" `shouldBe` Nothing
+            groupOut db "b" `shouldBe` Just (S.fromList ["b", "c"])
+
+        it "keeps direction tags through a merge" $ do
+            let merged = mergeSynonymDBs [buildFromEdges [SynEdge "river water" "Water river" BridgeInput], buildFromPairs [("x", "y")]]
+            groupIn merged "river water" `shouldBe` Just (S.fromList ["river water", "water river"])
+            groupOut merged "river water" `shouldBe` Nothing
+
+        it "demotes a both-duplicate of a directed pair so it cannot reopen the bridge" $ do
+            -- A merged untyped duplicate of an input-only pair must NOT resurface it
+            -- in the output view.
+            let db = buildFromEdges [SynEdge "river water" "Water river" BridgeInput, SynEdge "river water" "Water river" BridgeBoth]
+            length (synEdges db) `shouldBe` 1
+            groupOut db "river water" `shouldBe` Nothing
+
+        it "loads the shipped data/flows.csv and keeps its water bridges input-only" $ do
+            -- Guards the real curated registry: it must parse (3-column direction
+            -- schema), and the water withdrawal bridges must reach their resource
+            -- flow only in the input view, never the output view.
+            loaded <- loadFromCSVFileWithCache "data/flows.csv"
+            case loaded of
+                Left e -> expectationFailure e
+                Right db -> do
+                    lookupSynonymGroup (inputView db) "freshwater" `shouldSatisfy` (/= Nothing)
+                    lookupSynonymGroup (outputView db) "freshwater" `shouldBe` Nothing
+                    lookupSynonymGroup (outputView db) "river water" `shouldBe` Nothing
 
     describe "oversizedClasses" $ do
         -- A junk hub fuses everything it touches into one transitive class.

--- a/test/SynonymDBSpec.hs
+++ b/test/SynonymDBSpec.hs
@@ -76,6 +76,15 @@ spec = do
             groupIn merged "river water" `shouldBe` Just (S.fromList ["river water", "water river"])
             groupOut merged "river water" `shouldBe` Nothing
 
+        it "does not re-normalize stored edges on merge (normalizeName is not idempotent)" $ do
+            -- "Zinc in ground," single-pass-normalizes to "zinc in ground" (the
+            -- trailing comma hides the suffix until the punctuation pass); a second
+            -- application would strip it to "zinc". The merged tables must stay
+            -- keyed by the single-pass form every lookup applies.
+            let merged = mergeSynonymDBs [buildFromPairs [("Zinc in ground,", "Zn")], buildFromPairs [("alpha", "beta")]]
+            lookupSynonymGroup merged "Zinc in ground," `shouldSatisfy` (/= Nothing)
+            lookupSynonymGroup merged "Zn" `shouldBe` lookupSynonymGroup merged "Zinc in ground,"
+
         it "demotes a both-duplicate of a directed pair so it cannot reopen the bridge" $ do
             -- A merged untyped duplicate of an input-only pair must NOT resurface it
             -- in the output view.


### PR DESCRIPTION
## Why

Some curated flow-name synonym bridges are valid in one flow direction only. The canonical case is **water**: a withdrawal name (`river water`, `freshwater`) bridges to a resource flow for an **input** (withdrawal) CF, but letting an **output** (release) CF inherit that bridge applies a withdrawal scarcity factor to a release — wrong in sign or magnitude. `mcfDirection` was parsed on a CF but never consulted in the matching cascade, so an untyped bridge crossed directions freely (review finding #6 on #160).

## What

A synonym edge now carries a `BridgeDirection` (`both` / `input` / `output`).

- The top-level `SynonymDB` tables stay the **union closure**, so the ~30 direction-agnostic consumers (cross-linking, loader, edit) are unchanged. Two directional views are precomputed alongside — the closure of `both ∪ input` and of `both ∪ output` — because a direction restriction can *split* a group, which the union tables cannot recover at lookup time. Untyped data yields `AllBoth` (both views are the union tables; zero duplication for large auto sets). Views hold only their lookup tables — nothing ever re-closes a view, so no edge copies are materialized or cached.
- The matching layer (`findFlowBySynonymMemo`, `buildSynGroupFlows`, `expandSynonymMappings`, `projectRegionalResourceFlows`) selects a view by the CF's direction — for regional projection, by the flow's medium (resource→input, water→output). On untyped data every view coincides with the union tables, so behavior is bit-identical.
- The CSV gains an optional third column (`input`/`output`, empty = both); 2-column files parse unchanged. An unknown token is a **parse error**, not a silent coercion. A `both`-duplicate of a directed pair is demoted; that guard is pair-local, so when other rows re-link a one-way bridge's endpoints in the closed view (an untyped transitive chain in a merged source, a contradictory opposite-direction row) the loader **warns** instead of the restriction quietly not working. The cache carries an explicit schema version so a stale `.cache.zst` is reparsed.
- The six water withdrawal bridges in `data/flows.csv` are tagged `input`.

Making direction real in the cascade exposed three silent-loss paths, closed here too:

- Merging synonym sources (and the induced-subgraph re-close) re-normalized stored edges; `normalizeName` is not idempotent (a suffix hidden behind trailing punctuation strips only on a second pass), which could silently re-key merged tables away from what lookups compute. Re-closing now goes through `buildFromNormalizedEdges`, which never re-normalizes.
- A CF whose parser defaulted its direction (openLCA JSON without `direction`, coarse CSV compartments) would resolve against the wrong view and silently lose a one-way bridge. The generic CSV parser now reads the same resource-compartment spellings as the SimaPro one (`Raw materials`, `Resources from ground`, …), and the method-table build **warns** about any CF that matches a synonym bridge only outside its own direction — distinguishable from a genuinely uncharacterized flow.

## Validation

- Full suite **1513 examples, 0 failures** (new: direction parse/split/merge/demote, a water-direction regression via `expandSynonymMappings`, input/output-only projection in `ProjectRegionalSpec`, a load test on the shipped `data/flows.csv`, merge non-renormalization, reopened-bridge detection, direction-excluded CF detection, CSV resource-compartment directions). `-Wall`-clean.
- **Code score-neutral**: EF-3.1 (JRC) 4-product Agribalyse panel, branch binary vs main binary in the same environment (both reading an untyped `flows.csv`) — identical to the decimal on both EF 3.1 single scores/water use.
- **Tagged data score-neutral**: the branch binary reading the tagged `data/flows.csv` loads it cleanly (1302 entries, no parse error) and scores identically, water use included — tagging the withdrawal bridges input-only keeps the withdrawal match and only closes the cross-direction misroute.
