### PR TITLE
LCIA: backfill name-variant flow bridges from the auto-dependence audit

### DIFF
--- a/data/flows.csv
+++ b/data/flows.csv
@@ -924,3 +924,121 @@ HCFC-22,"Methane, chlorodifluoro-, HCFC-22",,75-45-6
 tebupirimfos,Tebupirimphos,,96182-53-5
 chloramide,Chloramine,,10599-90-3
 "2-chloro-N-(2,6-dimethylphenyl)-N-(2-methoxyethyl)acetamide",Dimethachlor,,50563-36-5
+1-Naphthaleneacetic acid,1-naphthylacetic acid
+1-Pentanol,pentan-1-ol
+"1H-Purin-6-amine, n-(phenylmethyl)-",benzyl(purin-6-yl)amine
+2-Chloroacetophenone,2-chloro-1-phenylethanone
+2-Propanol,isopropanol
+4-Methyl-2-pentanol,4-methylpentan-2-ol
+4-Methyl-2-pentanone,methyl isobutyl ketone
+8-Quinolinol,quinolin-8-ol
+Acrinathrin,"(s)-cyano(3-phenoxyphenyl)methyl (1r,3s)-3-[(1z)-3-[(1,1,1,3,3,3-hexafluoropropan-2-yl)oxy]-3-oxoprop-1-en-1-yl]-2,2-dimethylcyclopropane-1-carboxylate"
+Acrylonitrile,acryolonitrile
+Alachlor,lasso
+Ametryn,ametryne
+Azaconazol,azaconazole
+Benfluralin,benefin
+Benoxacor,"2,2-Dichloro-1-(3-methyl-2,3-dihydro-4h-1,4-benzoxazin-4-yl)ethanone"
+Bensulfuron methyl ester,londax
+"Benzene, 1,2,4-trimethyl-","1,2,4-trimethylbenzene"
+"Benzene, 1,3,5-trimethyl-","1,3,5-trimethylbenzene"
+"Benzene, 1-methyl-2-nitro-",2-nitrotoluene
+"Benzene, 1-methyl-4-(1-methylethyl)-",p-cymene
+"Benzene, chloro-",chlorobenzene
+"Benzene, ethyl-",ethyl benzene
+"Benzene, hexachloro-",hexachlorobenzene
+"Benzene, pentachloro-",pentachlorobenzene
+"Benzene, pentachloronitro-",pentachloronitrobenzene
+Benzo(a)anthracene,benzo[a]anthracene
+Benzo(a)pyrene,benzo[a]pyrene
+Benzo(b)fluoranthene,benzo[b]fluoranthene
+"Benzo(b,j,k)fluoranthene",benzo[b]fluoranthene,,,sum parameter; representative isomer benzo[b]fluoranthene
+"Benzo(g,h,i)perylene","benzo[g,h,i]perylene"
+Benzo(k)fluoranthene,benzo[k]fluoranthene
+Bitertanol,"β-([1,1'-biphenyl]-4-yloxy)-α-tert-butyl-1H-1,2,4-triazol-1-ethanol"
+Brodifacoum,"4-hydroxy-3-(3-(4'-bromo-4-biphenylyl)-1,2,3,4-tetrahydro-1-naphthyl)coumarin"
+Bromadiolone,"3-[3-(4'-Bromo[1,1'-biphenyl]-4-yl)-3-hydroxy-1-phenylpropyl]-4-hydroxy-2-benzopyrone"
+Bupirimate,5-butyl-2-ethylamino-6-methylpyrimidin-4-yldimethylsulphamate
+Butafenacil,"(2-allyloxy-1,1-dimethyl-2-oxo-ethyl) 2-chloro-5-[3,6-dihydro-3-methyl-2,6-dioxo-4-(trifluoromethyl)-1(2h)-pyrimidin-1-yl]benzoate"
+Butyl acetate,n-butyl-acetate
+"Butyric acid, 4-(2,4-dichlorophenoxy)-","4-(2,4-dichlorophenoxy)butanoic acid"
+Butyrolactone,γ-butyrolactone
+"Carbamic acid, [(dibutylamino)thio]methyl-, 2,3-dihydro-2,2-dimethyl-7-benzofuranyl ester","2,3-dihydro-2,2-dimethyl-[(dibutylamino)thio]methyl carbamic acid"
+Carbon disulfide,carbon disulphide
+Chlorfenvinphos,chlorfenvinfos
+Chlormequat,Chlormequat chloride
+Chloroethylene,vinyl chloride
+Chlorosulfonic acid,chlorosulphuric acid
+Chlorpyrifos methyl,chlorpyrifos-methyl
+Coumafos,coumaphos
+Cyazofamid,"4-chloro-2-cyano-n,n-dimethyl-5-p-tolylimidazole-1-sulfonamide"
+Cyflufenamid,"n-[(1z)-[(cyclopropylmethoxy)imino][2,3-difluoro-6-(trifluoromethyl)phenyl]methyl]-2-phenylacetamide"
+Dialifor,dialifos
+"Dibenz(a,h)anthracene","dibenz[a,h]anthracene"
+Dichlorprop,dichloroprop
+Dicrotophos,Bidrin
+Difenacoum,"3-(3-biphenyl-4-yl-1,2,3,4-tetrahydro-1-naphthyl)-4-hydroxycoumarin"
+Diisobutyl ketone,"2,6-dimethylheptan-4-one"
+Dimethyl ether,methyl ether
+Dimethyldichlorosilane,dichloro(dimethyl)silane
+Dipropylthiocarbamic acid S-ethyl ester,s-ethyl dipropylthiocarbamate
+Ethane thiol,ethanethiol
+"Ethane, 1,1,2-trichloro-","1,1,2-trichloroethane"
+"Ethane, 1,1-difluoro-, HFC-152a",HFC-152a
+"Ethane, 1,2-dibromo-","1,2-dibromoethane"
+"Ethane, 1,2-dichloro-","1,2-dichloroethane"
+"Ethane, chloro-",chloroethane
+"Ethane, hexachloro-",hexachloroethane
+Ethoprop,ethoprophos
+Ethylamine,ethyl amine
+Ethylene diamine,ethylenediamine
+Ethyne,acetylene
+Fenoxaprop ethyl ester,fenoxaprop-ethyl
+Fenpyroximate,fenpyroximate (iso)
+Flazasulfuron,"1-(4,6-dimethoxypyrimidin-2-yl)-3-(3-trifluoromethyl-2-pyridylsulfonyl)urea"
+Flonicamid,n-(cyanomethyl)-4-(trifluoromethyl)pyridine-3-carboxamide
+Fluazifop,2-(4-{[5-(trifluoromethyl)pyridin-2-yl]oxy}phenoxy)propanoic acid
+Fluoroglycofen,"Benzoic acid, 5-[2-chloro-4-(trifluoromethyl)phenoxy]-2-nitro-, carboxymethyl ester"
+Fluoxastrobin,"(e)-[(2-{[6-(2-chlorophenoxy)-5-fluoropyrimidin-4-yl]oxy}phenyl)(5,6-dihydro-1,4,2-dioxazin-3-yl)methylidene](methoxy)amine"
+Fomesafen,5-[2-chloro-4-(trifluoromethyl)phenoxy]-N-(methylsulphonyl)-2-nitrobenzamide
+Fosetyl-aluminium,fosetyl-aluminum
+Haloxyfop-ethoxyethyl,haloxyfop ethoxyethyl ester
+Hexazinone,"3-cyclohexyl-6-dimethylamino-1-methyl-1,2,3,4-tetrahydro-1,3,5-triazine-2,4-dione"
+"Hydrazine, methyl-",methylhydrazine
+Hydrogen cyanide,hydrocyanic acid
+Imazethapyr,pursuit
+Kresoxim-methyl,kresoxim methyl
+Maleic hydrazide,maleic hydrazide acid
+Metalaxyl-M,mefenoxam
+"Methane, dichlorofluoro-, HCFC-21",HCFC-21
+Methyl lactate,Methyl (R)-lactate,,,enantiomer-agnostic; characterized as methyl (R)-lactate
+Mevinfos,mevinphos
+Monosodium acid methanearsonate,sodium methylarsonate
+Myclobutanil,systhane
+N-Nitrodimethylamine,dimethylnitramine
+N-octane,octane
+"Naphthalene, 2-methyl-",2-methylnaphthalene
+Oxydemeton methyl,demeton-s-methyl sulfoxide
+Oxyfluorfen,oxyfluorofen
+Penconazole,"1-[2-(2,4-dichlorophenyl)pentyl]-1H-1,2,4-triazole"
+Pencycuron,1-[(4-chlorophenyl)methyl]-1-cyclopentyl-3-phenylurea
+"Pentane, 2,2,4-trimethyl-","2,2,4-trimethylpentane"
+"Pentane, 2-methyl-",2-methylpentane
+"Pentane, 3-methyl-",3-methylpentane
+"Phenol, 2,4-dimethyl-","2,4-dimethylphenol"
+Piperonyl butoxide,2-(2-butoxyethoxy)ethyl 6-propylpiperonyl ether
+Procymidone,"3-(3,5-dichlorophenyl)-1,5-dimethyl-3-azabicyclo[3.1.0]hexane-2,4-dione"
+Profenofos,O-(4-bromo-2-chlorophenyl) O-ethyl S-propyl phosphorothioate
+"Propane, 1,2-dichloro-","1,2-dichloropropane"
+Proquinazid,6-iodo-2-propoxy-3-propylquinazolin-4(3h)-one
+Sulfur hexafluoride,sulphur hexafluoride
+"Sulfuric acid, dimethyl ester",dimethyl sulphate
+t-Butyl methyl ether,tert-butyl methyl ether
+t-Butylamine,tert-butylamine
+Tetrachloroethylene,tetrachloroethene
+Tolyfluanide,dichloro-N-[(dimethylamino)sulphonyl]fluoro-N-(p-tolyl)methanesulphenamide
+Tribufos,tributylphosphorotrithioate
+Trichlorfon,trichlorofon
+Trichloroethylene,trichloroethene
+Triclopyr,"[(3,5,6-trichloropyridin-2-yl)oxy]acetic acid"
+Triticonazole,"(RS)-(E)-5-(4-Chlorobenzylidene)-2,2-dimethyl-1-(1h-1,2,4-triazol-1-ylmethyl)cyclopentanol"


### PR DESCRIPTION
## Backfill name-variant flow bridges surfaced by the auto-dependence audit

Since #165 the auto-extracted synonym corpus is opt-in only. That raised a gate
question: did removing it from runtime matching silently drop characterization
for real flows? An exhaustive **flow-mapping diff** — every Agribalyse biosphere
flow × all 50 EF-3.1 sub-methods, curated-only vs curated+auto — answered it:
**135** flows were characterized only by the auto layer.

This PR curates the **118** that are legitimate name variants the registry
lacked:
- IUPAC vs common (`tetrachloroethene` / `Tetrachloroethylene`)
- US/UK spelling (`sulphur` / `Sulfur hexafluoride`, `fosetyl-aluminum` / `-aluminium`)
- source typos (`trichlorofon`, `acryolonitrile`)
- bracket-notation PAHs (`benzo[a]pyrene`)
- ISO vs trade names the method flow lists themselves use (`lasso`, `pursuit`, `systhane`)

They cluster in ecotoxicity, human toxicity, photochemical ozone and halocarbon
climate, and several sit on very large CFs (trichlorfon 1.5e7, fluoroglycofen
1e7) — so their absence silently undercounted pesticide-heavy products.

### The 17 deliberately left out
Not every auto match is a clean substance identity. These stay unbridged
because the method treats each as **distinct**:
- **N₂O₄ / NO₂** — distinct toxicity CFs (ecotox 11.96 vs 3.84); one global
  synonym would collapse them via first-match-wins.
- **CO₂ fossil / biogenic / bare** — carbon-origin qualifiers the methods split
  on purpose (bare CO₂ → biogenic would even zero out fossil CO₂).
- **zeta-cypermethrin / cypermethrin, metsulfuron / metsulfuron-methyl,
  diquat / diquat dibromide** — the method assigns the acid/ester/isomer forms
  their **own distinct CFs** (cypermethrin 1.0e8 vs zeta 1.9e4), so equating
  them routes a flow through the closure to a contested value. These three were
  caught by the offline proposal tool's collision check (see the companion PR),
  after a first hand pass had wrongly kept them.
- **1-pentene / 2-methyl-2-butene** (different C₅H₁₀ isomers); **Uranium /
  U-238** (isotope, not a name variant); **7 region-suffixed NO₂ flows**
  (matched via the regional path, not synonyms).

Two isomer/enantiomer approximations (benzo(b,j,k)fluoranthene, methyl lactate)
carry an inline `note`.

### Validation
- Registry lint green (class size ≤ 12, no carbon-origin fusion, CAS check digit).
- Full suite green (1525 examples).
- Re-run flow-mapping diff on curated+patch: the **118 restore exactly** the
  intended matches, the rest stay omitted, and **zero CF changed** on any
  already-characterized flow (no accidental fusion, no regression).

### Measured impact (60 processes that emit the top-CF bridged flows, EF-3.1)
Restoring these bridges raises exactly the toxicity categories the pesticides
drive, and leaves the rest untouched:
- **Aquatic eco-toxicity** — pesticide-dominated processes move most (raw
  herbicide-emission unit process ×149, alfalfa animal-feed ×20, walnut ×5),
  while mainstream crops move <1–11% (metals still dominate their ecotox).
- **Cancer human health effects** — large relative rise on the emitters, small
  absolute (1e-12..1e-8 CTUh).
- **Every other category** (climate, non-cancer, acidification, eutrophication,
  resources…) moves <0.1% — the fix is surgical.

Stacked on #167 (the `cas`/`note` schema + offline lint these rows rely on).
Merge #167 first.
