### PR TITLE
LCIA: region fallback chain for name-regionalized water flows

### DIFF
--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -755,8 +755,9 @@ name-regionalized @"Water, river, FR"@ CF (the SimaPro convention) does today.
 
 Restricted to the water dimensions — the resource (withdrawal/input) and water
 (release/output) media; air and soil stay global so a method compared against an
-unregionalized reference is left untouched there. A method whose CFs are all
-unlocated (e.g. the name-regionalized SimaPro one) is left alone.
+unregionalized reference is left untouched there. A method with no located CF
+in those media — all-unlocated (e.g. the name-regionalized SimaPro one) or
+located only on air/soil — is left alone.
 
 The flow's region resolves through a fallback chain: its exact located CF,
 then the parent country's (@"CN-SC"@ → @"CN"@), then the method's own
@@ -799,49 +800,28 @@ projectRegionalResourceFlows synDB bioFlows mappings =
     -- river"@) never lets a release flow inherit a withdrawal CF. On untyped data
     -- both views coincide, so this preserves today's grouping.
     dirView med = viewFor (if med == "water" then Output else Input) synDB
-    -- Located CFs reached two ways: by the matched flow's synonym GROUP — a CF
-    -- whose name is bridged to the flow (withdrawal @"river water"@ → @"Water,
+    -- CFs reached two ways: by the matched flow's synonym GROUP — a CF whose
+    -- name is bridged to the flow (withdrawal @"river water"@ → @"Water,
     -- river"@) — and by the CF's own NAME — a CF whose name equals the flow's
     -- region-stripped base (the bare @"Water"@ release CF → @"Water, FR"@).
-    byGroup :: M.Map (Int, Text, Text) MethodCF
+    -- Keyed by 'Maybe' region: 'Just' entries are the located factors,
+    -- 'Nothing' the method's own location-less (world-average) ones — the
+    -- last step of the fallback chain.
+    byGroup :: M.Map (Int, Text, Maybe Text) MethodCF
     byGroup =
         M.fromListWith
             preferHigherCF
-            [ ((grp, med, loc), cf)
+            [ ((grp, med, mcfConsumerLocation cf), cf)
             | (cf, Just (flow, _)) <- mappings
-            , Just loc <- [mcfConsumerLocation cf]
             , let med = flowMedium flow
             , Just grp <- [lookupSynonymGroup (dirView med) (bfName flow)]
             ]
-    byName :: M.Map (Text, Text, Text) MethodCF
+    byName :: M.Map (Text, Text, Maybe Text) MethodCF
     byName =
         M.fromListWith
             preferHigherCF
-            [ ((normalizeName (mcfFlowName cf), cfMedium cf, loc), cf)
+            [ ((normalizeName (mcfFlowName cf), cfMedium cf, mcfConsumerLocation cf), cf)
             | (cf, _) <- mappings
-            , Just loc <- [mcfConsumerLocation cf]
-            ]
-    -- The method's own location-less (world-average) factors, same two
-    -- keyings minus the region — the last step of the fallback chain. Lazy
-    -- bindings guarded by the 'byName' gate below, so an unlocated method
-    -- never builds them.
-    genByGroup :: M.Map (Int, Text) MethodCF
-    genByGroup =
-        M.fromListWith
-            preferHigherCF
-            [ ((grp, med), cf)
-            | (cf, Just (flow, _)) <- mappings
-            , Nothing <- [mcfConsumerLocation cf]
-            , let med = flowMedium flow
-            , Just grp <- [lookupSynonymGroup (dirView med) (bfName flow)]
-            ]
-    genByName :: M.Map (Text, Text) MethodCF
-    genByName =
-        M.fromListWith
-            preferHigherCF
-            [ ((normalizeName (mcfFlowName cf), cfMedium cf), cf)
-            | (cf, _) <- mappings
-            , Nothing <- [mcfConsumerLocation cf]
             ]
     -- @"CN-SC"@ → @"CN"@; a region without a hyphen has no parent.
     parentRegion loc = case T.breakOn "-" loc of
@@ -851,24 +831,29 @@ projectRegionalResourceFlows synDB bioFlows mappings =
     -- water (release/output) media. Excludes air/soil — acidification and PM
     -- carry located CFs too, but they must stay GLOBAL to match an unregionalized
     -- reference, so projecting their region-tagged flows would wrongly regionalize
-    -- them. Most methods carry no located CF; skip the flow walk for them.
+    -- them.
+    isWaterMedium med = med == "resource" || med == "water"
+    -- The walk runs only for a method with located CFs in the water media: a
+    -- location on an air/soil CF alone must not open the water fallback, and a
+    -- method whose CFs are all unlocated (the name-regionalized SimaPro
+    -- convention) is left alone. The predicate short-circuits without building
+    -- the maps, so most methods skip the flow walk for free.
+    hasLocatedWaterCF =
+        any (\(cf, _) -> isJust (mcfConsumerLocation cf) && isWaterMedium (cfMedium cf)) mappings
     projected
-        | M.null byName = []
+        | not hasLocatedWaterCF = []
         | otherwise =
             [ (cf{mcfConsumerLocation = Nothing}, Just (flow, BySynonym))
             | flow <- M.elems bioFlows
             , let med = flowMedium flow
-            , med == "resource" || med == "water"
+            , isWaterMedium med
             , (base, Just loc) <- [extractLocationSuffix (bfName flow)]
             , let bname = normalizeName base
                   grp = lookupSynonymGroup (dirView med) base
                   atLoc l =
                     M.lookup (bname, med, l) byName
                         <|> (grp >>= \g -> M.lookup (g, med, l) byGroup)
-                  generic =
-                    M.lookup (bname, med) genByName
-                        <|> (grp >>= \g -> M.lookup (g, med) genByGroup)
-            , Just cf <- [atLoc loc <|> (parentRegion loc >>= atLoc) <|> generic]
+            , Just cf <- [atLoc (Just loc) <|> (parentRegion loc >>= atLoc . Just) <|> atLoc Nothing]
             ]
 
 -- No compartment filter here on purpose: 'buildMethodTables' keys

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -755,10 +755,20 @@ name-regionalized @"Water, river, FR"@ CF (the SimaPro convention) does today.
 
 Restricted to the water dimensions — the resource (withdrawal/input) and water
 (release/output) media; air and soil stay global so a method compared against an
-unregionalized reference is left untouched there. Only located CFs are indexed,
-so a method whose CFs are unlocated (e.g. the name-regionalized SimaPro one) is
-left alone; the region must match exactly, so no region's factor is broadcast
-onto another.
+unregionalized reference is left untouched there. A method whose CFs are all
+unlocated (e.g. the name-regionalized SimaPro one) is left alone.
+
+The flow's region resolves through a fallback chain: its exact located CF,
+then the parent country's (@"CN-SC"@ → @"CN"@), then the method's own
+location-less (world-average) factor. A sibling region's factor is never
+borrowed. The generic step matters for sign correctness: ILCD AWARE tabulates
+locations by ISO-2 country only, while inventory names also carry sub-national
+codes and aggregates (@"RoW"@, @"GLO"@, @"WEU"@). Without it, the release side
+of such a water balance is fully counted — the bare @"Water"@ release CF is
+reachable by name at score time — while the withdrawal side of the same volume
+scores zero (its base name only resolves through a synonym bridge, which the
+score-time region fallback does not traverse), flipping the sign of net water
+use.
 -}
 projectRegionalResourceFlows ::
     SynonymDB ->
@@ -811,6 +821,32 @@ projectRegionalResourceFlows synDB bioFlows mappings =
             | (cf, _) <- mappings
             , Just loc <- [mcfConsumerLocation cf]
             ]
+    -- The method's own location-less (world-average) factors, same two
+    -- keyings minus the region — the last step of the fallback chain. Lazy
+    -- bindings guarded by the 'byName' gate below, so an unlocated method
+    -- never builds them.
+    genByGroup :: M.Map (Int, Text) MethodCF
+    genByGroup =
+        M.fromListWith
+            preferHigherCF
+            [ ((grp, med), cf)
+            | (cf, Just (flow, _)) <- mappings
+            , Nothing <- [mcfConsumerLocation cf]
+            , let med = flowMedium flow
+            , Just grp <- [lookupSynonymGroup (dirView med) (bfName flow)]
+            ]
+    genByName :: M.Map (Text, Text) MethodCF
+    genByName =
+        M.fromListWith
+            preferHigherCF
+            [ ((normalizeName (mcfFlowName cf), cfMedium cf), cf)
+            | (cf, _) <- mappings
+            , Nothing <- [mcfConsumerLocation cf]
+            ]
+    -- @"CN-SC"@ → @"CN"@; a region without a hyphen has no parent.
+    parentRegion loc = case T.breakOn "-" loc of
+        (parent, rest) | not (T.null rest), not (T.null parent) -> Just parent
+        _ -> Nothing
     -- Scope to the water dimensions only: the resource (withdrawal/input) and
     -- water (release/output) media. Excludes air/soil — acidification and PM
     -- carry located CFs too, but they must stay GLOBAL to match an unregionalized
@@ -824,10 +860,15 @@ projectRegionalResourceFlows synDB bioFlows mappings =
             , let med = flowMedium flow
             , med == "resource" || med == "water"
             , (base, Just loc) <- [extractLocationSuffix (bfName flow)]
-            , Just cf <-
-                [ M.lookup (normalizeName base, med, loc) byName
-                    <|> (lookupSynonymGroup (dirView med) base >>= \grp -> M.lookup (grp, med, loc) byGroup)
-                ]
+            , let bname = normalizeName base
+                  grp = lookupSynonymGroup (dirView med) base
+                  atLoc l =
+                    M.lookup (bname, med, l) byName
+                        <|> (grp >>= \g -> M.lookup (g, med, l) byGroup)
+                  generic =
+                    M.lookup (bname, med) genByName
+                        <|> (grp >>= \g -> M.lookup (g, med) genByGroup)
+            , Just cf <- [atLoc loc <|> (parentRegion loc >>= atLoc) <|> generic]
             ]
 
 -- No compartment filter here on purpose: 'buildMethodTables' keys

--- a/test/ProjectRegionalSpec.hs
+++ b/test/ProjectRegionalSpec.hs
@@ -64,9 +64,44 @@ spec = describe "projectRegionalResourceFlows" $ do
         runWith [baseFlow, mkResourceFlow 11 "Water, river, FR"]
             `shouldContain` [frProjection]
 
-    it "does not project a region that has no located CF" $
+    it "does not borrow a sibling region's located CF" $
         runWith [baseFlow, mkResourceFlow 12 "Water, river, ZZ"]
             `shouldNotContain` [("Water, river, ZZ", Nothing, 6.98)]
+
+    it "falls a sub-national region back to its parent country's located CF" $ do
+        let cfCN = mkLocatedCF "river water" 42.4 (Just "CN")
+            cnSC = mkResourceFlow 15 "Water, river, CN-SC"
+            flows = M.fromList [(bfId f, f) | f <- [baseFlow, cnSC]]
+        projected (projectRegionalResourceFlows synDB flows [(cfFR, Just (baseFlow, BySynonym)), (cfCN, Just (baseFlow, BySynonym))])
+            `shouldContain` [("Water, river, CN-SC", Nothing, 42.4)]
+
+    it "falls an untabulated region back to the method's location-less CF through the synonym bridge" $ do
+        let cfGeneric = mkLocatedCF "river water" 42.95 Nothing
+            rowFlow = mkResourceFlow 16 "Water, river, RoW"
+            flows = M.fromList [(bfId f, f) | f <- [baseFlow, rowFlow]]
+        projected (projectRegionalResourceFlows synDB flows [(cfFR, Just (baseFlow, BySynonym)), (cfGeneric, Just (baseFlow, BySynonym))])
+            `shouldContain` [("Water, river, RoW", Nothing, 42.95)]
+
+    it "prefers the exact located region over the parent and generic fallbacks" $ do
+        let cfSC = mkLocatedCF "river water" 39.9 (Just "CN-SC")
+            cfCN = mkLocatedCF "river water" 42.4 (Just "CN")
+            cfGeneric = mkLocatedCF "river water" 42.95 Nothing
+            cnSC = mkResourceFlow 17 "Water, river, CN-SC"
+            flows = M.fromList [(bfId f, f) | f <- [baseFlow, cnSC]]
+            ms = [(cf, Just (baseFlow, BySynonym)) | cf <- [cfSC, cfCN, cfGeneric]]
+        projected (projectRegionalResourceFlows synDB flows ms)
+            `shouldContain` [("Water, river, CN-SC", Nothing, 39.9)]
+
+    it "does not route the generic fallback through an input-only bridge for a release flow" $ do
+        let inSynDB = buildFromEdges [SynEdge "river water" "Water, river" BridgeInput]
+            cfGeneric = mkLocatedCF "river water" 42.95 Nothing
+            rowRelease =
+                (mkResourceFlow 18 "Water, river, RoW")
+                    { bfCompartment = Just (VT.Compartment "water" Nothing)
+                    }
+            flows = M.fromList [(bfId f, f) | f <- [baseFlow, rowRelease]]
+        projected (projectRegionalResourceFlows inSynDB flows [(cfFR, Just (baseFlow, BySynonym)), (cfGeneric, Just (baseFlow, BySynonym))])
+            `shouldNotContain` [("Water, river, RoW", Nothing, 42.95)]
 
     it "derives the medium across a 'medium/sub' category, so a slash-encoded resource flow still projects" $ do
         let frFlowSlashed =

--- a/test/ProjectRegionalSpec.hs
+++ b/test/ProjectRegionalSpec.hs
@@ -103,6 +103,17 @@ spec = describe "projectRegionalResourceFlows" $ do
         projected (projectRegionalResourceFlows inSynDB flows [(cfFR, Just (baseFlow, BySynonym)), (cfGeneric, Just (baseFlow, BySynonym))])
             `shouldNotContain` [("Water, river, RoW", Nothing, 42.95)]
 
+    it "does not let a located CF in another medium open the water fallback" $ do
+        let airCF =
+                (mkLocatedCF "Sulfur dioxide" 1.5 (Just "FR"))
+                    { mcfCompartment = Just (Compartment "air" "" "")
+                    }
+            cfGeneric = mkLocatedCF "river water" 42.95 Nothing
+            rowFlow = mkResourceFlow 24 "Water, river, RoW"
+            flows = M.fromList [(bfId f, f) | f <- [baseFlow, rowFlow]]
+        projected (projectRegionalResourceFlows synDB flows [(airCF, Nothing), (cfGeneric, Just (baseFlow, BySynonym))])
+            `shouldNotContain` [("Water, river, RoW", Nothing, 42.95)]
+
     it "derives the medium across a 'medium/sub' category, so a slash-encoded resource flow still projects" $ do
         let frFlowSlashed =
                 (mkResourceFlow 13 "Water, river, FR")


### PR DESCRIPTION
## What

An ILCD method regionalized by consumer location (AWARE Water use) tabulates
ISO-2 countries only, while SimaPro-derived inventories tag water flows with
the region **in the name**, in three nomenclatures: ISO-2 (`FR`), sub-national
(`CN-SC`, `CA-QC`), and aggregates (`RoW`, `GLO`, `WEU`). The regional
projection bridged exact ISO-2 matches only, and the miss was asymmetric:

- a **release** (`Water, RoW` → base `Water`) still resolved at score time,
  because the bare release CF name is reachable by name — every release was
  counted at the world-average factor;
- the matching **withdrawal** (`Water, turbine use, unspecified natural
  origin, RoW`) resolves only through a synonym bridge, which the score-time
  region fallback does not traverse — it scored **zero**.

On hydropower-heavy inventories, turbined water enters and leaves in
near-equal volumes; counting the release without the withdrawal flipped net
water use hard negative (Agribalyse 3.2 yogurt: 68% of withdrawal volume sits
in non-ISO regions).

`projectRegionalResourceFlows` now resolves a flow's region through a
fallback chain: **exact located CF → parent country (`CN-SC` → `CN`) → the
method's own location-less (world-average) factor** — never a sibling
region's. This is the same resolution the name-regionalized SimaPro
convention pre-applies in its flow names: the ILCD source's `CN` factor
(42.4) and generic factor (42.95) are exactly the values the SimaPro
distribution assigns to `CN-SC` and `RoW`. The chain stays gated to the
resource/water media and to methods that carry located CFs, and routes
through the direction-typed synonym views, so a release can never inherit a
withdrawal factor through an input-only bridge.

## Validation

- Test suite: 1517 examples, 0 failures — 5 new `ProjectRegionalSpec`
  examples lock the chain (parent-country fallback, generic-through-synonym
  fallback, exact-region precedence, no sibling-region borrowing, no release
  routing through an input-only bridge).
- 4-product Agribalyse 3.2 panel (dairy, meat, oilseed, vegetable), both
  EF 3.1 distributions, same harness and environment, main vs branch:
  **all 13 non-water categories bit-identical**; Water use flips from hard
  negative to the reference's sign and scale (yogurt −606 → +7.5 weighted vs
  reference +27.7), and the EF 3.1 single scores converge from −1.60..0.85
  to **0.89–1.02** of the reference across all four products.
- Residual: the Water-use category itself remains below the reference
  (it is now a small net of two large, nearly cancelling sides); flows whose
  region is a long-form descriptor ("Europe without Switzerland") are not
  strippable as location suffixes and stay symmetric misses, surfaced by the
  existing missing-pair warnings.