### PR TITLE
fix(simapro): keep name-less multi-product blocks as one activity

### DIFF
--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -889,14 +889,17 @@ processBlockToActivity unitCfg GlobalParams{..} ProcessBlock{..} =
             effUnitName = unitName productUnit
             allocPercent = resolveAmount env (prAllocRaw prod) (prAllocation prod)
             allocFraction = allocPercent / 100.0
-            (_, locFromProduct) = extractLocation (prName prod)
+            (cleanProductName, locFromProduct) = extractLocation (prName prod)
             -- Activity name = Process name when present, otherwise the reference
             -- product's name (with its location) — never the coproduct's own,
             -- so all coproducts of a name-less block share one activityUUID.
-            (effectiveActivityName, effectiveLoc) =
-                if T.null processNameTrimmed
-                    then (fallbackName, if T.null location then fallbackLoc else location)
-                    else (processNameTrimmed, if T.null location then locFromProduct else location)
+            -- A blank reference name (malformed row) must not blank the whole
+            -- block: degrade per-product, as before the shared fallback.
+            (effectiveActivityName, locFallback)
+                | not (T.null processNameTrimmed) = (processNameTrimmed, locFromProduct)
+                | not (T.null fallbackName) = (fallbackName, fallbackLoc)
+                | otherwise = (cleanProductName, locFromProduct)
+            effectiveLoc = if T.null location then locFallback else location
             allocFormula = mfilter (not . isNumericFormula) (nonEmptyText (prAllocRaw prod))
             activity =
                 Activity

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -825,8 +825,19 @@ processBlockToActivity ::
     ProcessBlock ->
     [(Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit])]
 processBlockToActivity unitCfg GlobalParams{..} ProcessBlock{..} =
-    map makeActivity pbProducts
+    map makeActivity productsInFileOrder
   where
+    -- pbProducts is accumulated by prepending; restore file order so the
+    -- first row is the reference (main) product of the block.
+    productsInFileOrder = reverse pbProducts
+
+    -- Shared fallback identity when the "Process name" field is empty: every
+    -- coproduct inherits the reference product's name and location, so a
+    -- multi-product block still collapses onto one activityUUID (which is
+    -- derived from name + location) instead of splitting into N activities.
+    (fallbackName, fallbackLoc) = case productsInFileOrder of
+        (p : _) -> extractLocation (prName p)
+        [] -> ("", "")
     (env, exprMap) =
         buildParamEnv
             (reverse <$> [gpDbInput, gpProjInput, pbInputParams])
@@ -878,13 +889,14 @@ processBlockToActivity unitCfg GlobalParams{..} ProcessBlock{..} =
             effUnitName = unitName productUnit
             allocPercent = resolveAmount env (prAllocRaw prod) (prAllocation prod)
             allocFraction = allocPercent / 100.0
-            (cleanProductName, locFromProduct) = extractLocation (prName prod)
-            effectiveLoc = if T.null location then locFromProduct else location
-            -- Activity name = Process name when present (so coproducts of the same
-            -- Process share one activityUUID via generateActivityUUID), otherwise
-            -- fall back to product name (mono-product blocks with empty field).
-            effectiveActivityName =
-                if T.null processNameTrimmed then cleanProductName else processNameTrimmed
+            (_, locFromProduct) = extractLocation (prName prod)
+            -- Activity name = Process name when present, otherwise the reference
+            -- product's name (with its location) — never the coproduct's own,
+            -- so all coproducts of a name-less block share one activityUUID.
+            (effectiveActivityName, effectiveLoc) =
+                if T.null processNameTrimmed
+                    then (fallbackName, if T.null location then fallbackLoc else location)
+                    else (processNameTrimmed, if T.null location then locFromProduct else location)
             allocFormula = mfilter (not . isNumericFormula) (nonEmptyText (prAllocRaw prod))
             activity =
                 Activity

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -1017,7 +1017,7 @@ spec = do
             (activities, _, _, _, _) <-
                 parseProductsCSV
                     "Horticultural fleece, at plant (WFLDB)/m2/CH"
-                    "Horticultural fleece, at plant (WFLDB)/m2/GLO U;m2;1;100;not defined;material;"
+                    ["Horticultural fleece, at plant (WFLDB)/m2/GLO U;m2;1;100;not defined;material;"]
             length activities `shouldBe` 1
             let act = head activities
             activityLocation act `shouldBe` "CH"
@@ -1119,7 +1119,12 @@ spec = do
             -- Agribalyse 4.0 fishing blocks (e.g. yellowfin tuna) declare two
             -- coproducts but leave "Process name" blank; both must land on the
             -- reference product's activity, not split into two activities.
-            (activities, _, _, _, _) <- parseNoNameCoproductCSV
+            (activities, _, _, _, _) <-
+                parseProductsCSV
+                    ""
+                    [ "Tuna, main product {FR} U;kg;1;91;not defined;material;"
+                    , "Tuna by-products {FR} U;kg;1;9;not defined;material;"
+                    ]
             length activities `shouldBe` 2
             S.size (S.fromList (map generateActivityUUID activities)) `shouldBe` 1
             S.fromList (map activityName activities)
@@ -1172,9 +1177,9 @@ parseSectionCSV :: [BS.ByteString] -> IO ([Activity], M.Map UUID TechnosphereFlo
 parseSectionCSV sectionLines =
     parseNamedCSV "Test process" sectionLines
 
--- | Build a minimal process CSV with a custom Process name and Products row.
-parseProductsCSV :: BS.ByteString -> BS.ByteString -> IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)
-parseProductsCSV procName productsRow =
+-- | Build a minimal process CSV with a custom Process name and Products rows.
+parseProductsCSV :: BS.ByteString -> [BS.ByteString] -> IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)
+parseProductsCSV procName productsRows =
     withSystemTempFile "products-test.csv" $ \path handle -> do
         let content =
                 BS.intercalate "\r\n" $
@@ -1194,10 +1199,11 @@ parseProductsCSV procName productsRow =
                     , "Unit process"
                     , ""
                     , "Products"
-                    , productsRow
-                    , ""
-                    , "End"
                     ]
+                        ++ productsRows
+                        ++ [ ""
+                           , "End"
+                           ]
         BS.hPut handle content
         hClose handle
         parseSimaProCSV defaultUnitConfig path
@@ -1368,48 +1374,6 @@ multiCoproductCSV =
 parseMultiCoproductCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)
 parseMultiCoproductCSV = withSystemTempFile "multi-coproduct.csv" $ \path handle -> do
     BS.hPut handle multiCoproductCSV
-    hClose handle
-    parseSimaProCSV defaultUnitConfig path
-
-{- | Two-coproduct block with an empty Process name field (Agribalyse 4.0
-fishing pattern): both coproducts must inherit the reference (first) product's
-name and location so they share one activityUUID.
--}
-noNameCoproductCSV :: BS.ByteString
-noNameCoproductCSV =
-    BS.intercalate
-        "\r\n"
-        [ "{SimaPro 9.6.0.1}"
-        , "{CSV separator: semicolon}"
-        , "{Decimal separator: .}"
-        , ""
-        , "Process"
-        , ""
-        , "Category type"
-        , "material"
-        , ""
-        , "Process name"
-        , ""
-        , ""
-        , "Type"
-        , "Unit process"
-        , ""
-        , "Geography"
-        , "Unspecified"
-        , ""
-        , "Products"
-        , "Tuna, main product {FR} U;kg;1;91;not defined;material;"
-        , "Tuna by-products {FR} U;kg;1;9;not defined;material;"
-        , ""
-        , "Materials/fuels"
-        , "Upstream feedstock;kg;1;Undefined;;;;;;"
-        , ""
-        , "End"
-        ]
-
-parseNoNameCoproductCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)
-parseNoNameCoproductCSV = withSystemTempFile "no-name-coproduct.csv" $ \path handle -> do
-    BS.hPut handle noNameCoproductCSV
     hClose handle
     parseSimaProCSV defaultUnitConfig path
 

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -1115,6 +1115,16 @@ spec = do
             let total = sum perActivity
             abs (total - 1.0) `shouldSatisfy` (< 0.001)
 
+        it "shares one activityUUID across coproducts when Process name is empty" $ do
+            -- Agribalyse 4.0 fishing blocks (e.g. yellowfin tuna) declare two
+            -- coproducts but leave "Process name" blank; both must land on the
+            -- reference product's activity, not split into two activities.
+            (activities, _, _, _, _) <- parseNoNameCoproductCSV
+            length activities `shouldBe` 2
+            S.size (S.fromList (map generateActivityUUID activities)) `shouldBe` 1
+            S.fromList (map activityName activities)
+                `shouldBe` S.singleton "Tuna, main product {FR} U"
+
     describe "SimaPro Process name fallback" $ do
         it "falls back to product name when Process name field is empty" $ do
             (activities, _, _, _, _) <- parseNoProcessNameCSV
@@ -1358,6 +1368,48 @@ multiCoproductCSV =
 parseMultiCoproductCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)
 parseMultiCoproductCSV = withSystemTempFile "multi-coproduct.csv" $ \path handle -> do
     BS.hPut handle multiCoproductCSV
+    hClose handle
+    parseSimaProCSV defaultUnitConfig path
+
+{- | Two-coproduct block with an empty Process name field (Agribalyse 4.0
+fishing pattern): both coproducts must inherit the reference (first) product's
+name and location so they share one activityUUID.
+-}
+noNameCoproductCSV :: BS.ByteString
+noNameCoproductCSV =
+    BS.intercalate
+        "\r\n"
+        [ "{SimaPro 9.6.0.1}"
+        , "{CSV separator: semicolon}"
+        , "{Decimal separator: .}"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , ""
+        , ""
+        , "Type"
+        , "Unit process"
+        , ""
+        , "Geography"
+        , "Unspecified"
+        , ""
+        , "Products"
+        , "Tuna, main product {FR} U;kg;1;91;not defined;material;"
+        , "Tuna by-products {FR} U;kg;1;9;not defined;material;"
+        , ""
+        , "Materials/fuels"
+        , "Upstream feedstock;kg;1;Undefined;;;;;;"
+        , ""
+        , "End"
+        ]
+
+parseNoNameCoproductCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)
+parseNoNameCoproductCSV = withSystemTempFile "no-name-coproduct.csv" $ \path handle -> do
+    BS.hPut handle noNameCoproductCSV
     hClose handle
     parseSimaProCSV defaultUnitConfig path
 

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -1130,6 +1130,19 @@ spec = do
             S.fromList (map activityName activities)
                 `shouldBe` S.singleton "Tuna, main product {FR} U"
 
+        it "does not blank the whole block when the reference product name is empty" $ do
+            -- Malformed export: name-less block whose first Products row has an
+            -- empty name cell. The blank must stay confined to that row; other
+            -- coproducts keep their own name instead of inheriting "".
+            (activities, _, _, _, _) <-
+                parseProductsCSV
+                    ""
+                    [ ";kg;1;91;not defined;material;"
+                    , "Tuna by-products {FR} U;kg;1;9;not defined;material;"
+                    ]
+            S.fromList (map activityName activities)
+                `shouldBe` S.fromList ["", "Tuna by-products {FR} U"]
+
     describe "SimaPro Process name fallback" $ do
         it "falls back to product name when Process name field is empty" $ do
             (activities, _, _, _, _) <- parseNoProcessNameCSV


### PR DESCRIPTION
## Problem

In Agribalyse 4.0, the yellowfin tuna process (`AGRIBALU000009084602653`) appears in SimaPro as **one** process with two coproducts (main product 91% / fish by-products 9%, economic allocation). VoLCA showed it as **two unrelated activities**.

Cause: these fishing blocks (and a few oil-milling ones — 24 multi-product processes in total in the file) leave the SimaPro "Process name" field blank. The parser fell back to each coproduct's own product name, and since the activity UUID is derived from name + location, the block split into N activities instead of one activity with N products.

## Fix

When "Process name" is empty, every coproduct now inherits the reference (first) product's name and location, so the whole block shares one activityUUID — the same grouping SimaPro displays. `pbProducts` is also restored to file order so "first product" is the block's reference product.

Unchanged: mono-product blocks (fallback resolves to the same name/location as before), blocks with a Process name, and the main product's activity UUID (verified on the real Agribalyse block: both coproducts now land on the pre-existing `fc3f2fcd-…` activity).

Regression test added with the two-coproduct name-less pattern; full suite green (1449 examples).