### PR TITLE
LCIA: subcompartment gating, generalized density bridge, ore-grade resource fallback

### DIFF
--- a/data/energy_density.csv
+++ b/data/energy_density.csv
@@ -5,3 +5,4 @@ flow_name,value,energy_unit,native_unit
 "Gas, natural",36.0,MJ,Sm3
 Peat,9.76,MJ,kg
 Uranium,560000,MJ,kg
+"Water",0.001,m3,kg

--- a/data/energy_density.csv
+++ b/data/energy_density.csv
@@ -1,4 +1,4 @@
-flow_name,value,energy_unit,native_unit
+flow_name,value,target_unit,native_unit
 "Coal, hard",18.01,MJ,kg
 "Coal, brown",9.41,MJ,kg
 "Oil, crude",43.2,MJ,kg

--- a/data/units.csv
+++ b/data/units.csv
@@ -225,3 +225,4 @@ kg no3-n/ha.year,mass/length/length,1.0e-4
 kg p2o5/ha,mass/length/length,1.0e-4
 kg po4/ha,mass/length/length,1.0e-4
 kg nh3-n,mass/length/length,1.0e-4
+m3-world equivalents,volume,1.0

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -676,7 +676,7 @@ buildMethodTablesFor manager dbName collection db hier method = do
     -- question; a method whose CFs are all region-tagged would be left with none.
     -- The config loader warns when a 'global-methods' name matches no method.
     globalMethods <- maybe [] mcGlobalMethods . M.lookup collection <$> readTVarIO (dmAvailableMethods manager)
-    let !raw0 = buildMethodTables cmap energyDensities expanded
+    let !raw0 = buildMethodTables (methodUnit method) cmap energyDensities expanded
         !raw =
             if methodName method `elem` globalMethods
                 then raw0{mtRegionalizedCF = M.empty}

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -176,6 +176,7 @@ import Method.Types (
     ScoringSet (..),
     buildCompartmentMapFromCSV,
     buildEnergyDensityMapFromCSV,
+    cfFamily,
     compartmentMapSize,
     energyDensityMapSize,
  )
@@ -676,7 +677,7 @@ buildMethodTablesFor manager dbName collection db hier method = do
     -- question; a method whose CFs are all region-tagged would be left with none.
     -- The config loader warns when a 'global-methods' name matches no method.
     globalMethods <- maybe [] mcGlobalMethods . M.lookup collection <$> readTVarIO (dmAvailableMethods manager)
-    let !raw0 = buildMethodTables (methodUnit method) cmap energyDensities expanded
+    let !raw0 = buildMethodTables (cfFamily (methodUnit method)) cmap energyDensities expanded
         !raw =
             if methodName method `elem` globalMethods
                 then raw0{mtRegionalizedCF = M.empty}

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -1153,12 +1153,12 @@ buildMethodTables methodFamily cmap energyDensities mappings =
                 Compartment _ flowSubRaw _ =
                     normalizeCompartment cmap (Compartment rawMed rawSub T.empty)
                 !flowSubN = T.toLower (T.strip flowSubRaw)
-             in -- A wildcard (unspecified) CF matches any subcompartment except a
-                -- foreign medium (sea/ocean): a freshwater CF must not reach a
-                -- sea-water flow via the regionalized wildcard, mirroring the
-                -- 'lookupCascadeCF' gate for the non-regional path. An explicit
-                -- same-sub CF still matches.
-                (isUnspecifiedSub cfSubN && not (isForeignMediumSub (Subcompartment flowSubN)))
+             in -- A wildcard (unspecified) CF matches any subcompartment except
+                -- the ones the 'lookupCascadeCF' gate excludes on the
+                -- non-regional path — both tiers: a foreign medium (sea/ocean)
+                -- never borrows a freshwater CF, and groundwater borrows no
+                -- surface USEtox CF. An explicit same-sub CF still matches.
+                (isUnspecifiedSub cfSubN && wildcardReachesSub methodFamily (Subcompartment flowSubN))
                     || cfSubN == flowSubN
 
     preferBetter (v1, u1, s1) (v2, u2, s2)
@@ -1654,9 +1654,8 @@ lookupCascadeCF tables flowDB fid =
             -- water, so the method characterizes it). An explicit exact-sub CF and
             -- the method's own long-term default are never gated.
             gate mcf
-                | isForeignMediumSub normSub = Nothing
-                | isDetachedSub normSub && mtCFFamily tables == USEtoxFamily = Nothing
-                | otherwise = mcf
+                | wildcardReachesSub (mtCFFamily tables) normSub = mcf
+                | otherwise = Nothing
          in -- UUID/name miss → fall back to the flow's own CAS + medium, so
             -- every flow sharing a CAS in a compartment is characterized, not
             -- just the one a CF resolved to at build time. A long-term (delayed)
@@ -1782,6 +1781,16 @@ isDetachedSub (Subcompartment s) = "groundwater" `T.isPrefixOf` s
 
 isForeignMediumSub :: Subcompartment -> Bool
 isForeignMediumSub (Subcompartment s) = s `elem` ["ocean", "sea water", "sea"]
+
+{- | Whether a medium-level (wildcard / fallback) CF may reach the given
+subcompartment — both tiers above, combined. Shared by the read-path
+'lookupCascadeCF' gate and the build-time regionalized wildcard match so the
+two scoring paths apply the same rule and can't drift.
+-}
+wildcardReachesSub :: CFFamily -> Subcompartment -> Bool
+wildcardReachesSub family sub =
+    not (isForeignMediumSub sub)
+        && not (isDetachedSub sub && family == USEtoxFamily)
 
 {- | A subcompartment that names the long-term catch-all: @"unspecified
 (long-term)"@, @"(long-term)"@ — i.e. unspecified once the time-horizon marker is

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -440,6 +440,13 @@ data MethodTables = MethodTables
     Empty for non-regionalized methods. When non-empty, callers should dispatch
     to the regionalized scoring path (see 'Matrix.computeRegionalizedLCIAScore').
     -}
+    , mtMethodUnit :: !Text
+    {- ^ The method's result unit (e.g. @"CTUe"@, @"kg P eq"@). Carries the CF
+    family the individual CF units can't: the SimaPro-adapted collection stores
+    every CF unit as the flow unit (@"kg"@), so the read-path subcompartment gate
+    keys off this — a USEtox toxicity method ('isUSEtoxUnit') doesn't characterize
+    groundwater, a nutrient method does.
+    -}
     , mtCompartmentMap :: !CompartmentMap
     {- ^ Compartment-normalization rules (e.g. @"Emissions to air" → "air"@).
     Applied to both CF compartments at build time and database flow
@@ -929,8 +936,8 @@ strategyPriority ByFuzzy = 4
 strategyPriority ByProxy = 4
 strategyPriority NoMatch = 4
 
-buildMethodTables :: CompartmentMap -> EnergyDensityMap -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> MethodTables
-buildMethodTables cmap energyDensities mappings =
+buildMethodTables :: Text -> CompartmentMap -> EnergyDensityMap -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> MethodTables
+buildMethodTables methodUnitText cmap energyDensities mappings =
     MethodTables
         { mtUuidCF =
             -- Non-regionalized rows only, like the name tables below: a
@@ -1089,6 +1096,7 @@ buildMethodTables cmap energyDensities mappings =
                 , cfSubcompMatchesFlow cf flow
                 , Just loc <- [mcfConsumerLocation cf]
                 ]
+        , mtMethodUnit = methodUnitText
         , mtCompartmentMap = cmap
         , mtEnergyDensities = energyDensities
         , mtBroadcast = M.empty -- fill via 'fillBroadcastVector' to enable the fast path
@@ -1145,7 +1153,12 @@ buildMethodTables cmap energyDensities mappings =
                 Compartment _ flowSubRaw _ =
                     normalizeCompartment cmap (Compartment rawMed rawSub T.empty)
                 !flowSubN = T.toLower (T.strip flowSubRaw)
-             in isUnspecifiedSub cfSubN
+             in -- A wildcard (unspecified) CF matches any subcompartment except a
+                -- foreign medium (sea/ocean): a freshwater CF must not reach a
+                -- sea-water flow via the regionalized wildcard, mirroring the
+                -- 'lookupCascadeCF' gate for the non-regional path. An explicit
+                -- same-sub CF still matches.
+                (isUnspecifiedSub cfSubN && not (isForeignMediumSub (Subcompartment flowSubN)))
                     || cfSubN == flowSubN
 
     preferBetter (v1, u1, s1) (v2, u2, s2)
@@ -1438,7 +1451,7 @@ computeLCIAScoreFromTables unitConfig unitDB flowDB inventory tables =
 -}
 computeLCIAScore :: UnitConfig -> UnitDB -> BioFlowDB -> Inventory -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> LCIAOutcome
 computeLCIAScore unitConfig unitDB flowDB inventory mappings =
-    computeLCIAScoreFromTables unitConfig unitDB flowDB inventory (buildMethodTables M.empty M.empty mappings)
+    computeLCIAScoreFromTables unitConfig unitDB flowDB inventory (buildMethodTables "" M.empty M.empty mappings)
 
 {- | LCIA score with automatic dispatch.
 
@@ -1629,19 +1642,30 @@ lookupCascadeCF tables flowDB fid =
     byNameOrCas flow =
         let name = SR.NormName (normalizeName (bfName flow))
             (baseMed, normSub) = flowMediumSub (mtCompartmentMap tables) flow
+            -- The medium-level / CAS / sub-blind fallbacks all stand for a
+            -- surface, immediate emission, so gate a resolved one by the flow's
+            -- subcompartment: a foreign medium (sea/ocean) gets no freshwater CF
+            -- at all; a detached sub (groundwater) drops a surface-freshwater-fate
+            -- USEtox CF (CTUe/CTUh) — those methods don't model groundwater — but
+            -- keeps a nutrient/other freshwater CF (phosphate migrates to surface
+            -- water, so the method characterizes it). An explicit exact-sub CF and
+            -- the method's own long-term default are never gated.
+            gate mcf
+                | isForeignMediumSub normSub = Nothing
+                | isDetachedSub normSub && isUSEtoxUnit (mtMethodUnit tables) = Nothing
+                | otherwise = mcf
          in -- UUID/name miss → fall back to the flow's own CAS + medium, so
             -- every flow sharing a CAS in a compartment is characterized, not
             -- just the one a CF resolved to at build time. A long-term (delayed)
             -- emission first tries the method's long-term default
             -- ('mtLongTermFallbackCF') so it inherits the long-term factor, not
-            -- the immediate-emission one; if the method has none it still falls
-            -- through to the ordinary fallbacks.
+            -- the immediate-emission one; if the method has none it falls through.
             M.lookup (name, baseMed, normSub) (mtExactCF tables)
                 <|> (if isLongTermSub normSub then M.lookup (name, baseMed) (mtLongTermFallbackCF tables) else Nothing)
-                <|> M.lookup (name, baseMed) (mtFallbackCF tables)
-                <|> (bfCAS flow >>= \cas -> M.lookup (SR.CASNumber cas, baseMed) (mtCasCF tables))
-                <|> M.lookup (name, baseMed) (mtSubBlindCF tables)
-                <|> regionBaseFallback flow baseMed normSub
+                <|> gate (M.lookup (name, baseMed) (mtFallbackCF tables))
+                <|> gate (bfCAS flow >>= \cas -> M.lookup (SR.CASNumber cas, baseMed) (mtCasCF tables))
+                <|> gate (M.lookup (name, baseMed) (mtSubBlindCF tables))
+                <|> gate (regionBaseFallback flow baseMed normSub)
                 <|> energyResourceFallback flow baseMed normSub
 
     -- A SimaPro region-suffixed flow ("Ammonia, FR") whose region the method
@@ -1714,6 +1738,38 @@ long-term emission than for its immediate one.
 -}
 isLongTermSub :: Subcompartment -> Bool
 isLongTermSub (Subcompartment s) = "long-term" `T.isInfixOf` s || "long term" `T.isInfixOf` s
+
+{- | A subcompartment that names a different fate than the surface / immediate
+emission a method's unspecified (medium-level) CF stands for, so that CF must
+not silently reach it. Two tiers, gated differently in 'lookupCascadeCF':
+
+  * 'isDetachedSub' — emissions to groundwater (immediate or long-term). A
+    surface-freshwater-fate USEtox CF ('isUSEtoxUnit') does not apply (metals to
+    groundwater are out of scope for ecotoxicity/human toxicity — EF leaves them
+    uncharacterized), but a nutrient/other freshwater CF does (phosphate migrates
+    to surface water, so the method characterizes it). Scoped to groundwater, NOT
+    every long-term sub: a "river, long-term" release is still surface freshwater
+    and stays characterized.
+  * 'isForeignMediumSub' — the sea/ocean, a different receiving medium
+    altogether: a freshwater CF does not apply at all (water released to the sea
+    is not freshwater depletion; EF ships a distinct, uncharacterized sea-water
+    flow).
+
+Names are the post-'normalizeCompartment' lower-cased subcompartment.
+-}
+isDetachedSub :: Subcompartment -> Bool
+isDetachedSub (Subcompartment s) = "groundwater" `T.isPrefixOf` s
+
+isForeignMediumSub :: Subcompartment -> Bool
+isForeignMediumSub (Subcompartment s) = s `elem` ["ocean", "sea water", "sea"]
+
+{- | True for a USEtox toxicity CF (unit CTUe for ecotoxicity, CTUh for human
+toxicity). Their fate model is surface freshwater, so a groundwater emission is
+out of scope and must not borrow the surface CF — unlike a nutrient CF (kg P eq)
+which does characterize groundwater, since phosphate migrates to surface water.
+-}
+isUSEtoxUnit :: Text -> Bool
+isUSEtoxUnit u = T.toLower (T.strip u) `elem` ["ctue", "ctuh"]
 
 {- | A subcompartment that names the long-term catch-all: @"unspecified
 (long-term)"@, @"(long-term)"@ — i.e. unspecified once the time-horizon marker is

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -1720,11 +1720,16 @@ lookupCascadeCF tables flowDB fid =
     -- takes that element's resource CF. Without this the whole ore-grade family
     -- scores zero and mineral/metal depletion silently under-counts (copper- and
     -- gold-intensive products by 100×+). Resource medium only; base = the element
-    -- before the first comma. Self-scoping and last in the cascade: 'resourceCF'
-    -- returns Nothing for a non-metal resource the method doesn't characterize
-    -- ("Calcite, in ground"), so it only fires where the base element has a CF.
+    -- before the first comma; the "%" requirement pins the fallback to
+    -- grade-bearing variants — every ore-grade name encodes its grade as a
+    -- percentage — so an ordinary comma-qualified resource ("Water, salt,
+    -- ocean", "Coal, 18 MJ per kg") never borrows the base CF, and in
+    -- particular an ambiguity 'energyResourceFallback' refused to resolve
+    -- stays unresolved. Self-scoping and last in the cascade: 'resourceCF'
+    -- returns Nothing when the base element has no CF in the method.
     resourceBaseNameFallback flow baseMed@(Medium med) normSub
         | med == "resource"
+        , "%" `T.isInfixOf` bfName flow
         , (base, rest) <- T.breakOn "," (bfName flow)
         , not (T.null rest) =
             resourceCF (SR.NormName (normalizeName base)) baseMed normSub

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -454,12 +454,13 @@ data MethodTables = MethodTables
     canonical form. Empty map = identity, no normalization.
     -}
     , mtEnergyDensities :: !EnergyDensityMap
-    {- ^ Normalized flow name → energy density (MJ per native flow unit).
-    Lets an energy-denominated CF (dimension @energy@, e.g. a JRC fossil CF in
-    MJ) characterize a mass/volume inventory flow (kg, Sm3): the flow quantity
-    is converted to energy via its density before the CF multiply. Flows with
-    no entry behave exactly as before — an energy CF vs. a mass flow still
-    yields a zero effective CF. Empty map = feature inactive.
+    {- ^ Normalized flow name → physical content per native flow unit (a
+    calorific value in MJ/kg, a mass density in m³/kg). Lets a CF denominated
+    in the content's target unit (a JRC fossil CF in MJ, a water-scarcity CF
+    in m³) characterize an inventory flow of another dimension (kg, Sm3): the
+    flow quantity is bridged into the target unit before the CF multiply.
+    Flows with no entry behave exactly as before — a cross-dimensional CF
+    still yields a zero effective CF. Empty map = feature inactive.
     -}
     , mtBroadcast :: !(M.Map UUID Double)
     {- ^ Pre-multiplied broadcast CFs: flow UUID → effective CF (CF value × flow→CF unit conversion).

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -19,6 +19,8 @@ module Method.Mapping (
     buildMapContext,
 
     -- * LCIA scoring
+    CFFamily (..),
+    cfFamily,
     MethodTables (..),
     MethodIndex (..),
     LCIAOutcome (..),
@@ -440,12 +442,10 @@ data MethodTables = MethodTables
     Empty for non-regionalized methods. When non-empty, callers should dispatch
     to the regionalized scoring path (see 'Matrix.computeRegionalizedLCIAScore').
     -}
-    , mtMethodUnit :: !Text
-    {- ^ The method's result unit (e.g. @"CTUe"@, @"kg P eq"@). Carries the CF
-    family the individual CF units can't: the SimaPro-adapted collection stores
-    every CF unit as the flow unit (@"kg"@), so the read-path subcompartment gate
-    keys off this — a USEtox toxicity method ('isUSEtoxUnit') doesn't characterize
-    groundwater, a nutrient method does.
+    , mtCFFamily :: !CFFamily
+    {- ^ The CF family the method's result unit implies (see 'cfFamily'). The
+    subcompartment gates key off this — a USEtox toxicity method
+    ('USEtoxFamily') doesn't characterize groundwater, a nutrient method does.
     -}
     , mtCompartmentMap :: !CompartmentMap
     {- ^ Compartment-normalization rules (e.g. @"Emissions to air" → "air"@).
@@ -936,8 +936,8 @@ strategyPriority ByFuzzy = 4
 strategyPriority ByProxy = 4
 strategyPriority NoMatch = 4
 
-buildMethodTables :: Text -> CompartmentMap -> EnergyDensityMap -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> MethodTables
-buildMethodTables methodUnitText cmap energyDensities mappings =
+buildMethodTables :: CFFamily -> CompartmentMap -> EnergyDensityMap -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> MethodTables
+buildMethodTables methodFamily cmap energyDensities mappings =
     MethodTables
         { mtUuidCF =
             -- Non-regionalized rows only, like the name tables below: a
@@ -1096,7 +1096,7 @@ buildMethodTables methodUnitText cmap energyDensities mappings =
                 , cfSubcompMatchesFlow cf flow
                 , Just loc <- [mcfConsumerLocation cf]
                 ]
-        , mtMethodUnit = methodUnitText
+        , mtCFFamily = methodFamily
         , mtCompartmentMap = cmap
         , mtEnergyDensities = energyDensities
         , mtBroadcast = M.empty -- fill via 'fillBroadcastVector' to enable the fast path
@@ -1446,12 +1446,15 @@ computeLCIAScoreFromTables unitConfig unitDB flowDB inventory tables =
         Nothing -> Nothing
         Just cfTuple -> Just (convertAndMultiply unitConfig unitDB (mtEnergyDensities tables) (M.lookup fid flowDB) cfTuple qty)
 
-{- | Back-compat wrapper: build tables on the fly. Prefer the cached path
-('mapMethodToTablesCached' + 'computeLCIAScoreFromTables') in hot loops.
+{- | Back-compat wrapper: build tables on the fly, with no compartment map,
+energy densities, or CF-family gating ('OtherCFFamily'). Prefer the cached path
+('mapMethodToTablesCached' + 'computeLCIAScoreFromTables') in hot loops, and
+'buildMethodTables' with the method's real 'cfFamily' wherever the method is
+in hand.
 -}
 computeLCIAScore :: UnitConfig -> UnitDB -> BioFlowDB -> Inventory -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> LCIAOutcome
 computeLCIAScore unitConfig unitDB flowDB inventory mappings =
-    computeLCIAScoreFromTables unitConfig unitDB flowDB inventory (buildMethodTables "" M.empty M.empty mappings)
+    computeLCIAScoreFromTables unitConfig unitDB flowDB inventory (buildMethodTables OtherCFFamily M.empty M.empty mappings)
 
 {- | LCIA score with automatic dispatch.
 
@@ -1652,7 +1655,7 @@ lookupCascadeCF tables flowDB fid =
             -- the method's own long-term default are never gated.
             gate mcf
                 | isForeignMediumSub normSub = Nothing
-                | isDetachedSub normSub && isUSEtoxUnit (mtMethodUnit tables) = Nothing
+                | isDetachedSub normSub && mtCFFamily tables == USEtoxFamily = Nothing
                 | otherwise = mcf
          in -- UUID/name miss → fall back to the flow's own CAS + medium, so
             -- every flow sharing a CAS in a compartment is characterized, not
@@ -1761,7 +1764,7 @@ emission a method's unspecified (medium-level) CF stands for, so that CF must
 not silently reach it. Two tiers, gated differently in 'lookupCascadeCF':
 
   * 'isDetachedSub' — emissions to groundwater (immediate or long-term). A
-    surface-freshwater-fate USEtox CF ('isUSEtoxUnit') does not apply (metals to
+    surface-freshwater-fate USEtox CF ('USEtoxFamily') does not apply (metals to
     groundwater are out of scope for ecotoxicity/human toxicity — EF leaves them
     uncharacterized), but a nutrient/other freshwater CF does (phosphate migrates
     to surface water, so the method characterizes it). Scoped to groundwater, NOT
@@ -1779,14 +1782,6 @@ isDetachedSub (Subcompartment s) = "groundwater" `T.isPrefixOf` s
 
 isForeignMediumSub :: Subcompartment -> Bool
 isForeignMediumSub (Subcompartment s) = s `elem` ["ocean", "sea water", "sea"]
-
-{- | True for a USEtox toxicity CF (unit CTUe for ecotoxicity, CTUh for human
-toxicity). Their fate model is surface freshwater, so a groundwater emission is
-out of scope and must not borrow the surface CF — unlike a nutrient CF (kg P eq)
-which does characterize groundwater, since phosphate migrates to surface water.
--}
-isUSEtoxUnit :: Text -> Bool
-isUSEtoxUnit u = T.toLower (T.strip u) `elem` ["ctue", "ctuh"]
 
 {- | A subcompartment that names the long-term catch-all: @"unspecified
 (long-term)"@, @"(long-term)"@ — i.e. unspecified once the time-horizon marker is

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -1667,6 +1667,7 @@ lookupCascadeCF tables flowDB fid =
                 <|> gate (M.lookup (name, baseMed) (mtSubBlindCF tables))
                 <|> gate (regionBaseFallback flow baseMed normSub)
                 <|> energyResourceFallback flow baseMed normSub
+                <|> resourceBaseNameFallback flow baseMed normSub
 
     -- A SimaPro region-suffixed flow ("Ammonia, FR") whose region the method
     -- doesn't tag falls back to the base substance's CF: an unregionalized CF
@@ -1710,6 +1711,22 @@ lookupCascadeCF tables flowDB fid =
     resourceCF rname baseMed normSub =
         M.lookup (rname, baseMed, normSub) (mtExactCF tables)
             <|> M.lookup (rname, baseMed) (mtFallbackCF tables)
+
+    -- An ecoinvent metal-ore resource flow ("Copper, 0.99% in sulfide, Cu 0.36%
+    -- …, in ground", "Gold, Au 7.1E-4%, in ore") carries no CAS and matches no CF
+    -- of its own, but its reference amount is the mass of the base element, so it
+    -- takes that element's resource CF. Without this the whole ore-grade family
+    -- scores zero and mineral/metal depletion silently under-counts (copper- and
+    -- gold-intensive products by 100×+). Resource medium only; base = the element
+    -- before the first comma. Self-scoping and last in the cascade: 'resourceCF'
+    -- returns Nothing for a non-metal resource the method doesn't characterize
+    -- ("Calcite, in ground"), so it only fires where the base element has a CF.
+    resourceBaseNameFallback flow baseMed@(Medium med) normSub
+        | med == "resource"
+        , (base, rest) <- T.breakOn "," (bfName flow)
+        , not (T.null rest) =
+            resourceCF (SR.NormName (normalizeName base)) baseMed normSub
+        | otherwise = Nothing
 
     firstWord = T.takeWhile (/= ' ') . T.strip
 

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -107,7 +107,7 @@ import qualified SubstanceRegistry as SR
 import SynonymDB
 import Types (Activity (..), BioFlowDB, BiosphereFlow (..), Database (..), ProcessId, SparseTriple (..), Unit (..), UnitDB)
 import qualified Types as VT
-import UnitConversion (UnitConfig, UnitDef (..), convertUnit, isKnownUnit, lookupUnitDef, normalizeToCanonical, normalizeUnit)
+import UnitConversion (UnitConfig, convertUnit, isKnownUnit, normalizeToCanonical, normalizeUnit, unitsCompatible)
 
 -- | Matching strategy used to find a flow
 data MatchStrategy
@@ -1807,16 +1807,6 @@ flowMediumSub cmap flow =
             normalizeCompartment cmap (Compartment rawMed rawSub T.empty)
      in (Medium (normalizeMedium normMedRaw), Subcompartment normSub)
 
-{- | True when @unit@ is dimensionally an energy unit (same exponent vector as
-the reference @mj@). Used to detect the energy-CF-vs-non-energy-flow case the
-energy-density bridge targets, without hardcoding any unit string.
--}
-isEnergyUnit :: UnitConfig -> Text -> Bool
-isEnergyUnit cfg unit =
-    case (lookupUnitDef cfg unit, lookupUnitDef cfg "MJ") of
-        (Just a, Just energyRef) -> udDimension a == udDimension energyRef
-        _ -> False
-
 {- | Flow→CF conversion factor for @qty@ units of flow, applying the
 energy-density bridge when it is needed and available.
 
@@ -1835,12 +1825,19 @@ to 'convertForCharacterization', so flows without a density are unchanged.
 energyAwareConversion :: UnitConfig -> Text -> Text -> Maybe EnergyDensity -> Double -> Double
 energyAwareConversion cfg flowUnit cfUnit mDensity qty =
     case mDensity of
-        Just (EnergyDensity ev energyUnit nativeUnit)
-            | isEnergyUnit cfg cfUnit
-            , not (isEnergyUnit cfg flowUnit) ->
+        -- The bridge fires when the CF is denominated in the density's target
+        -- unit (MJ for a calorific value, m³ for a mass density) and the flow is
+        -- a different dimension (mass). Generalizing the guard from "energy" to
+        -- "same dimension as the density unit" lets one mechanism serve both the
+        -- fossil energy CF (kg → MJ via calorific value) and the water-scarcity
+        -- CF (kg → m³ via density), which are the two cases where a per-physical-
+        -- quantity CF meets a mass inventory flow.
+        Just (EnergyDensity ev densityUnit nativeUnit)
+            | unitsCompatible cfg cfUnit densityUnit
+            , not (unitsCompatible cfg cfUnit flowUnit) ->
                 fromMaybe 0 $ do
                     qtyNative <- toNativeQty flowUnit nativeUnit
-                    factor <- convertUnit cfg energyUnit cfUnit ev
+                    factor <- convertUnit cfg densityUnit cfUnit ev
                     pure (qtyNative * factor)
         _ -> convertForCharacterization cfg flowUnit cfUnit qty
   where

--- a/src/Method/Types.hs
+++ b/src/Method/Types.hs
@@ -16,6 +16,8 @@ module Method.Types (
     Compartment (..),
     Medium (..),
     Subcompartment (..),
+    CFFamily (..),
+    cfFamily,
 
     -- * Method Collection (with normalization/weighting)
     MethodCollection (..),
@@ -342,6 +344,27 @@ normalizeCompartment cmap (Compartment med sub qual) =
 -- | Number of entries in the compartment map.
 compartmentMapSize :: CompartmentMap -> Int
 compartmentMapSize = M.size
+
+{- | The CF family a method's result unit implies, for read-path gating.
+
+USEtox toxicity methods (ecotoxicity in CTUe, human toxicity in CTUh) model a
+surface-freshwater fate only, so their medium-level CFs must not reach a
+groundwater emission; every other family (e.g. nutrients in kg P eq) keeps
+characterizing groundwater, since phosphate migrates to surface water.
+Classified once from 'methodUnit' — the individual CF units can't carry the
+distinction (the SimaPro-adapted collection stores every CF unit as the flow
+unit, @"kg"@).
+-}
+data CFFamily = USEtoxFamily | OtherCFFamily
+    deriving (Eq, Show, Generic)
+
+instance NFData CFFamily
+
+-- | Classify a method's result unit ('methodUnit') into its 'CFFamily'.
+cfFamily :: Text -> CFFamily
+cfFamily u
+    | T.toLower (T.strip u) `elem` map T.pack ["ctue", "ctuh"] = USEtoxFamily
+    | otherwise = OtherCFFamily
 
 {- | Energy content of a flow, used to characterize an energy-denominated CF
 (e.g. a JRC fossil-resource CF in MJ) against an inventory flow given in mass or

--- a/src/Method/Types.hs
+++ b/src/Method/Types.hs
@@ -366,21 +366,23 @@ cfFamily u
     | T.toLower (T.strip u) `elem` map T.pack ["ctue", "ctuh"] = USEtoxFamily
     | otherwise = OtherCFFamily
 
-{- | Energy content of a flow, used to characterize an energy-denominated CF
-(e.g. a JRC fossil-resource CF in MJ) against an inventory flow given in mass or
-volume (kg, Sm3, …).
+{- | Physical content of a flow per native unit — a calorific value (MJ per kg
+of coal) or a mass density (m³ per kg of water) — used to characterize a CF
+denominated in that target unit against an inventory flow given in another
+dimension (kg, Sm3, …).
 
-A row @Coal, hard,18.01,MJ,kg@ reads: 1 kg of @Coal, hard@ carries 18.01 MJ.
-'edEnergyUnit' is the unit of the energy amount (converted to the CF's unit at
-score time); 'edNativeUnit' is the unit the content is denominated against, so
-the inventory quantity is brought into that unit before the density is applied.
-Naming the native unit keeps the bridge dimensionally honest: a flow reported in
-a different but compatible unit (g, t) still scores correctly, and one whose
-unit can't be converted to the native unit scores 0 instead of by a wrong basis.
+A row @Coal, hard,18.01,MJ,kg@ reads: 1 kg of @Coal, hard@ carries 18.01 MJ;
+@Water,0.001,m3,kg@ reads: 1 kg of water occupies 0.001 m³. 'edTargetUnit' is
+the unit of the content amount (converted to the CF's unit at score time);
+'edNativeUnit' is the unit the content is denominated against, so the inventory
+quantity is brought into that unit before the density is applied. Naming the
+native unit keeps the bridge dimensionally honest: a flow reported in a
+different but compatible unit (g, t) still scores correctly, and one whose unit
+can't be converted to the native unit scores 0 instead of by a wrong basis.
 -}
 data EnergyDensity = EnergyDensity
     { edValue :: !Double
-    , edEnergyUnit :: !Text
+    , edTargetUnit :: !Text
     , edNativeUnit :: !Text
     }
     deriving (Eq, Show, Generic)
@@ -394,7 +396,7 @@ already use for CF matching.
 type EnergyDensityMap = M.Map Text EnergyDensity
 
 {- | Build an 'EnergyDensityMap' from CSV content.
-CSV columns (with header): @flow_name, value, energy_unit, native_unit@ — e.g.
+CSV columns (with header): @flow_name, value, target_unit, native_unit@ — e.g.
 @Coal, hard,18.01,MJ,kg@. Keys are normalized at parse time so the union of
 active CSVs and the read-path lookups agree. Each row is validated: a
 non-positive value or a missing unit is a load error, never a silently inert or
@@ -407,13 +409,13 @@ buildEnergyDensityMapFromCSV csvData =
         Right rows ->
             M.fromList <$> traverse toEntry (V.toList (rows :: V.Vector (Text, Double, Text, Text)))
   where
-    toEntry (name, value, energyUnit, nativeUnit)
+    toEntry (name, value, targetUnit, nativeUnit)
         | value <= 0 =
-            Left $ "energy density must be positive (flow: " <> T.unpack name <> ")"
-        | T.null (T.strip energyUnit) || T.null (T.strip nativeUnit) =
-            Left $ "energy density needs an energy unit and a native unit (flow: " <> T.unpack name <> ")"
+            Left $ "density must be positive (flow: " <> T.unpack name <> ")"
+        | T.null (T.strip targetUnit) || T.null (T.strip nativeUnit) =
+            Left $ "density needs a target unit and a native unit (flow: " <> T.unpack name <> ")"
         | otherwise =
-            Right (normalizeName name, EnergyDensity value (T.strip energyUnit) (T.strip nativeUnit))
+            Right (normalizeName name, EnergyDensity value (T.strip targetUnit) (T.strip nativeUnit))
 
 -- | Number of entries in the energy-density map.
 energyDensityMapSize :: EnergyDensityMap -> Int

--- a/src/Plugin/Builtin.hs
+++ b/src/Plugin/Builtin.hs
@@ -367,7 +367,7 @@ hotspotAnalyzer =
     -- Characterization uses the merged flow/unit snapshot the caller built.
     analyzeMethod flowDB unitDB mapCtx inv topN method = do
         mappings <- Mapping.mapMethodFlows defaultMappers mapCtx method
-        let tables = Mapping.buildMethodTables M.empty M.empty mappings
+        let tables = Mapping.buildMethodTables (methodUnit method) M.empty M.empty mappings
             (rawContribs, _) = Mapping.inventoryContributions UnitConversion.defaultUnitConfig unitDB flowDB inv tables
             sorted = take topN $ sortOn (\(_, _, c) -> negate (abs c)) rawContribs
             total = Mapping.loScore (Mapping.computeLCIAScoreFromTables UnitConversion.defaultUnitConfig unitDB flowDB inv tables)

--- a/src/Plugin/Builtin.hs
+++ b/src/Plugin/Builtin.hs
@@ -60,7 +60,7 @@ import Matrix (Inventory)
 import qualified Matrix.Export as MatrixExport
 import Method.Mapping (MatchStrategy)
 import qualified Method.Mapping as Mapping
-import Method.Types (Method (..), MethodCF (..))
+import Method.Types (Method (..), MethodCF (..), cfFamily)
 import SynonymDB (emptySynonymDB)
 import System.Directory (doesDirectoryExist, doesFileExist, listDirectory)
 import System.FilePath (takeExtension, (</>))
@@ -367,7 +367,7 @@ hotspotAnalyzer =
     -- Characterization uses the merged flow/unit snapshot the caller built.
     analyzeMethod flowDB unitDB mapCtx inv topN method = do
         mappings <- Mapping.mapMethodFlows defaultMappers mapCtx method
-        let tables = Mapping.buildMethodTables (methodUnit method) M.empty M.empty mappings
+        let tables = Mapping.buildMethodTables (cfFamily (methodUnit method)) M.empty M.empty mappings
             (rawContribs, _) = Mapping.inventoryContributions UnitConversion.defaultUnitConfig unitDB flowDB inv tables
             sorted = take topN $ sortOn (\(_, _, c) -> negate (abs c)) rawContribs
             total = Mapping.loScore (Mapping.computeLCIAScoreFromTables UnitConversion.defaultUnitConfig unitDB flowDB inv tables)

--- a/src/Plugin/Builtin.hs
+++ b/src/Plugin/Builtin.hs
@@ -188,11 +188,15 @@ lciaAnalyzer =
                 mapM
                     ( \m -> do
                         mappings <- Mapping.mapMethodFlows defaultMappers mapCtx m
+                        -- Build the tables with the method's CF family so the
+                        -- subcompartment gates apply here exactly as on the
+                        -- Database.Manager scoring path.
+                        let tables = Mapping.buildMethodTables (cfFamily (methodUnit m)) M.empty M.empty mappings
                         pure $
                             toJSON $
                                 M.fromList
                                     [ ("method" :: String, toJSON (show m))
-                                    , ("score", toJSON (Mapping.loScore (Mapping.computeLCIAScore UnitConversion.defaultUnitConfig (acUnitDB ctx) (acBioFlowDB ctx) inv mappings)))
+                                    , ("score", toJSON (Mapping.loScore (Mapping.computeLCIAScoreFromTables UnitConversion.defaultUnitConfig (acUnitDB ctx) (acBioFlowDB ctx) inv tables)))
                                     ]
                     )
                     methods

--- a/test/CrossDBInventorySpec.hs
+++ b/test/CrossDBInventorySpec.hs
@@ -179,6 +179,7 @@ spec = do
                     , mtCasCF = M.empty
                     , mtRegionalCasCF = M.empty
                     , mtRegionalizedCF = M.empty
+                    , mtMethodUnit = ""
                     , mtCompartmentMap = M.empty
                     , mtEnergyDensities = M.empty
                     , mtBroadcast = M.empty

--- a/test/CrossDBInventorySpec.hs
+++ b/test/CrossDBInventorySpec.hs
@@ -24,6 +24,7 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import Matrix (accumulateDepDemands, depDemandsToVector)
 import Method.Mapping (MethodTables (..), inventoryContributions)
+import Method.Types (CFFamily (..))
 import qualified Method.Mapping as Mapping
 import SharedSolver (
     computeInventoryMatrixBatchCached,
@@ -179,7 +180,7 @@ spec = do
                     , mtCasCF = M.empty
                     , mtRegionalCasCF = M.empty
                     , mtRegionalizedCF = M.empty
-                    , mtMethodUnit = ""
+                    , mtCFFamily = OtherCFFamily
                     , mtCompartmentMap = M.empty
                     , mtEnergyDensities = M.empty
                     , mtBroadcast = M.empty

--- a/test/CrossDBInventorySpec.hs
+++ b/test/CrossDBInventorySpec.hs
@@ -24,8 +24,8 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import Matrix (accumulateDepDemands, depDemandsToVector)
 import Method.Mapping (MethodTables (..), inventoryContributions)
-import Method.Types (CFFamily (..))
 import qualified Method.Mapping as Mapping
+import Method.Types (CFFamily (..))
 import SharedSolver (
     computeInventoryMatrixBatchCached,
     computeInventoryMatrixBatchWithDepsCached,

--- a/test/CrossDBRegionalLCIAFixture.hs
+++ b/test/CrossDBRegionalLCIAFixture.hs
@@ -52,7 +52,7 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 
 import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, fillBroadcastVector, fillRegionalActivityWeights)
-import Method.Types (FlowDirection (..), MethodCF (..))
+import Method.Types (CFFamily (..), FlowDirection (..), MethodCF (..))
 import Types
 import qualified Types as VT
 import UnitConversion (UnitConfig (..), UnitDef (..))
@@ -211,7 +211,7 @@ regionalMappings = map (\(loc, v) -> (cf loc v, Just (testFlow, ByName)))
 
 buildTables :: Database -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> MethodTables
 buildTables db mappings =
-    let raw = buildMethodTables "" M.empty M.empty mappings
+    let raw = buildMethodTables OtherCFFamily M.empty M.empty mappings
         withBroadcast = fillBroadcastVector kgUnitConfig (dbUnits db) (dbBioFlows db) raw
      in fillRegionalActivityWeights
             kgUnitConfig

--- a/test/CrossDBRegionalLCIAFixture.hs
+++ b/test/CrossDBRegionalLCIAFixture.hs
@@ -211,7 +211,7 @@ regionalMappings = map (\(loc, v) -> (cf loc v, Just (testFlow, ByName)))
 
 buildTables :: Database -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> MethodTables
 buildTables db mappings =
-    let raw = buildMethodTables M.empty M.empty mappings
+    let raw = buildMethodTables "" M.empty M.empty mappings
         withBroadcast = fillBroadcastVector kgUnitConfig (dbUnits db) (dbBioFlows db) raw
      in fillRegionalActivityWeights
             kgUnitConfig

--- a/test/EnergyDensityCFSpec.hs
+++ b/test/EnergyDensityCFSpec.hs
@@ -116,6 +116,21 @@ massCF = energyCF{mcfValue = 3.0, mcfUnit = "kg"}
 coalDensities :: EnergyDensityMap
 coalDensities = M.fromList [(normalizeName "Coal, hard", EnergyDensity 26.4 "MJ" "kg")]
 
+-- A water resource flow in a chosen unit, for the mass→volume bridge.
+waterId :: UUID
+waterId = UUID.fromWords64 11 0
+
+waterFlowIn :: UUID -> BiosphereFlow
+waterFlowIn unitId = (coalFlowIn unitId){bfId = waterId, bfName = "Water"}
+
+-- A volume-denominated CF (an AWARE-style water-scarcity factor per m³).
+volumeCF :: MethodCF
+volumeCF = energyCF{mcfFlowRef = waterId, mcfFlowName = "Water", mcfValue = 42.95, mcfUnit = "m3"}
+
+-- Mass density of water: 0.001 m³ per kg — same shape as a calorific value.
+waterDensities :: EnergyDensityMap
+waterDensities = M.fromList [(normalizeName "Water", EnergyDensity 0.001 "m3" "kg")]
+
 -- Build tables (with broadcast) for a flow + energy-density set + CF.
 tablesFor :: BiosphereFlow -> EnergyDensityMap -> MethodCF -> MethodTables
 tablesFor flow densities cf =
@@ -175,6 +190,26 @@ spec = do
             let flow = coalFlowIn uidKg
             broadcastShouldBeNear (tablesFor flow coalDensities massCF) 3.0
             broadcastShouldBeNear (tablesFor flow M.empty massCF) 3.0
+
+    describe "Density bridge generalized: volume CF vs. mass flow (water)" $ do
+        -- Same mechanism, different dimension pair: a water-scarcity CF is
+        -- denominated per m³ but ecoinvent water emissions come in kg. A
+        -- "Water" density row (0.001 m³/kg) must bridge kg → m³ exactly like a
+        -- calorific value bridges kg → MJ.
+        it "applies the mass density to a per-m3 CF (1 kg water → 0.001 × CF)" $ do
+            let flow = waterFlowIn uidKg
+                tables = tablesFor flow waterDensities volumeCF
+            scoreFlow flow 1.0 tables `shouldSatisfy` near (0.001 * 42.95)
+
+        it "leaves a flow already declared in m3 untouched (no double conversion)" $ do
+            let flow = waterFlowIn uidM3
+                tables = tablesFor flow waterDensities volumeCF
+            scoreFlow flow 1.0 tables `shouldSatisfy` near 42.95
+
+        it "still scores 0 without a density (cross-dimensional, no bridge)" $ do
+            let flow = waterFlowIn uidKg
+                tables = tablesFor flow M.empty volumeCF
+            scoreFlow flow 1.0 tables `shouldSatisfy` near 0
 
     describe "buildEnergyDensityMapFromCSV" $ do
         it "parses a valid row, keyed by normalized flow name" $

--- a/test/EnergyDensityCFSpec.hs
+++ b/test/EnergyDensityCFSpec.hs
@@ -120,7 +120,7 @@ coalDensities = M.fromList [(normalizeName "Coal, hard", EnergyDensity 26.4 "MJ"
 tablesFor :: BiosphereFlow -> EnergyDensityMap -> MethodCF -> MethodTables
 tablesFor flow densities cf =
     let fdb = M.singleton (bfId flow) flow
-        raw = buildMethodTables M.empty densities [(cf, Just (flow, ByUUID))]
+        raw = buildMethodTables "" M.empty densities [(cf, Just (flow, ByUUID))]
      in fillBroadcastVector unitConfig unitDB fdb raw
 
 -- Score a @qty@-unit inventory of @flow@ against the given tables.

--- a/test/EnergyDensityCFSpec.hs
+++ b/test/EnergyDensityCFSpec.hs
@@ -135,7 +135,7 @@ waterDensities = M.fromList [(normalizeName "Water", EnergyDensity 0.001 "m3" "k
 tablesFor :: BiosphereFlow -> EnergyDensityMap -> MethodCF -> MethodTables
 tablesFor flow densities cf =
     let fdb = M.singleton (bfId flow) flow
-        raw = buildMethodTables "" M.empty densities [(cf, Just (flow, ByUUID))]
+        raw = buildMethodTables OtherCFFamily M.empty densities [(cf, Just (flow, ByUUID))]
      in fillBroadcastVector unitConfig unitDB fdb raw
 
 -- Score a @qty@-unit inventory of @flow@ against the given tables.

--- a/test/EnergyDensityCFSpec.hs
+++ b/test/EnergyDensityCFSpec.hs
@@ -213,14 +213,14 @@ spec = do
 
     describe "buildEnergyDensityMapFromCSV" $ do
         it "parses a valid row, keyed by normalized flow name" $
-            case buildEnergyDensityMapFromCSV (BLC.pack "flow_name,value,energy_unit,native_unit\n\"Coal, hard\",18.01,MJ,kg\n") of
+            case buildEnergyDensityMapFromCSV (BLC.pack "flow_name,value,target_unit,native_unit\n\"Coal, hard\",18.01,MJ,kg\n") of
                 Left err -> expectationFailure err
                 Right m -> M.lookup (normalizeName "Coal, hard") m `shouldBe` Just (EnergyDensity 18.01 "MJ" "kg")
 
         it "rejects a non-positive value" $
-            buildEnergyDensityMapFromCSV (BLC.pack "flow_name,value,energy_unit,native_unit\nPeat,0,MJ,kg\n")
+            buildEnergyDensityMapFromCSV (BLC.pack "flow_name,value,target_unit,native_unit\nPeat,0,MJ,kg\n")
                 `shouldSatisfy` isLeft
 
         it "rejects a missing native unit" $
-            buildEnergyDensityMapFromCSV (BLC.pack "flow_name,value,energy_unit,native_unit\nPeat,9.76,MJ,\n")
+            buildEnergyDensityMapFromCSV (BLC.pack "flow_name,value,target_unit,native_unit\nPeat,9.76,MJ,\n")
                 `shouldSatisfy` isLeft

--- a/test/EnergyResourceFillSpec.hs
+++ b/test/EnergyResourceFillSpec.hs
@@ -47,7 +47,7 @@ mkFlow i name =
 -- engine knows coal is an energy resource (an energy_density entry).
 coalTables :: EnergyDensityMap -> MethodTables
 coalTables eds =
-    buildMethodTables M.empty eds [(resourceCF "Coal, hard" 1.0, Just (mkFlow 1 "Coal, hard", ByName))]
+    buildMethodTables "" M.empty eds [(resourceCF "Coal, hard" 1.0, Just (mkFlow 1 "Coal, hard", ByName))]
 
 coalDensity :: EnergyDensityMap
 coalDensity = M.singleton (normalizeName "Coal, hard") (EnergyDensity 18.01 "MJ" "kg")
@@ -57,6 +57,7 @@ coalDensity = M.singleton (normalizeName "Coal, hard") (EnergyDensity 18.01 "MJ"
 disagreeingCoalTables :: MethodTables
 disagreeingCoalTables =
     buildMethodTables
+        ""
         M.empty
         ( M.fromList
             [ (normalizeName "Coal, hard", EnergyDensity 18 "MJ" "kg")

--- a/test/EnergyResourceFillSpec.hs
+++ b/test/EnergyResourceFillSpec.hs
@@ -9,7 +9,7 @@ import qualified Data.UUID as UUID
 import Test.Hspec
 
 import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, lookupCFForFlow)
-import Method.Types (Compartment (..), EnergyDensity (..), EnergyDensityMap, FlowDirection (..), MethodCF (..), parseEnergyDensitySuffix)
+import Method.Types (CFFamily (..), Compartment (..), EnergyDensity (..), EnergyDensityMap, FlowDirection (..), MethodCF (..), parseEnergyDensitySuffix)
 import SynonymDB (normalizeName)
 import Types (BiosphereFlow (..))
 import qualified Types as VT
@@ -47,7 +47,7 @@ mkFlow i name =
 -- engine knows coal is an energy resource (an energy_density entry).
 coalTables :: EnergyDensityMap -> MethodTables
 coalTables eds =
-    buildMethodTables "" M.empty eds [(resourceCF "Coal, hard" 1.0, Just (mkFlow 1 "Coal, hard", ByName))]
+    buildMethodTables OtherCFFamily M.empty eds [(resourceCF "Coal, hard" 1.0, Just (mkFlow 1 "Coal, hard", ByName))]
 
 coalDensity :: EnergyDensityMap
 coalDensity = M.singleton (normalizeName "Coal, hard") (EnergyDensity 18.01 "MJ" "kg")
@@ -57,7 +57,7 @@ coalDensity = M.singleton (normalizeName "Coal, hard") (EnergyDensity 18.01 "MJ"
 disagreeingCoalTables :: MethodTables
 disagreeingCoalTables =
     buildMethodTables
-        ""
+        OtherCFFamily
         M.empty
         ( M.fromList
             [ (normalizeName "Coal, hard", EnergyDensity 18 "MJ" "kg")

--- a/test/EnergyResourceFillSpec.hs
+++ b/test/EnergyResourceFillSpec.hs
@@ -66,6 +66,9 @@ disagreeingCoalTables =
         )
         [ (resourceCF "Coal, hard" 1.0, Just (mkFlow 1 "Coal, hard", ByName))
         , (resourceCF "Coal, brown" 2.0, Just (mkFlow 2 "Coal, brown", ByName))
+        , -- A bare base-element CF too: the ore-grade base-name fallback must
+          -- not grab it for a density variant the family refusal just dropped.
+          (resourceCF "Coal" 5.0, Just (mkFlow 3 "Coal", ByName))
         ]
 
 -- Borrowed raw CF (the density is applied later by convertAndMultiply).

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -341,7 +341,7 @@ spec = do
             fid <- nextRandom
             let flow = mkFlow fid "ammonia" "emissions to air/low. pop." Nothing
                 cf = mkCFComp "ammonia" "air" "low. pop." 0.747
-                tables = buildMethodTables "" M.empty M.empty [(cf, Nothing)]
+                tables = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Nothing)]
                 inventory = M.singleton fid 10.0
                 flowDB = M.singleton fid flow
                 score = loScore (computeLCIAScoreFromTables defaultUnitConfig M.empty flowDB inventory tables)
@@ -352,7 +352,7 @@ spec = do
             let flow = mkFlow fid "ammonia" "emissions to air/low. pop." Nothing
                 cf = mkCFComp "ammonia" "air" "low. pop." 0.747
                 cmap = M.singleton ("emissions to air", "", "") (Compartment "air" "" "")
-                tables = buildMethodTables "" cmap M.empty [(cf, Nothing)]
+                tables = buildMethodTables OtherCFFamily cmap M.empty [(cf, Nothing)]
                 inventory = M.singleton fid 10.0
                 flowDB = M.singleton fid flow
                 score = loScore (computeLCIAScoreFromTables defaultUnitConfig M.empty flowDB inventory tables)
@@ -367,7 +367,7 @@ spec = do
                     M.singleton
                         ("emissions to air", "low. pop.", "")
                         (Compartment "air" "non-urban air or from high stacks" "")
-                tables = buildMethodTables "" cmap M.empty [(cf, Nothing)]
+                tables = buildMethodTables OtherCFFamily cmap M.empty [(cf, Nothing)]
                 inventory = M.singleton fid 10.0
                 flowDB = M.singleton fid flow
                 score = loScore (computeLCIAScoreFromTables defaultUnitConfig M.empty flowDB inventory tables)
@@ -405,7 +405,7 @@ spec = do
             fid <- nextRandom
             let flow = mkFlow fid "co2" "air" Nothing
                 cf = mkCF "co2" Nothing 1.0
-                tables = buildMethodTables "" M.empty M.empty [(cf, Just (flow, ByUUID))]
+                tables = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flow, ByUUID))]
                 inventory = M.singleton fid 100.0
                 flowDB = M.singleton fid flow
                 unitDB = M.singleton nil (unitNamed "m")
@@ -489,7 +489,7 @@ spec = do
             uidKg <- nextRandom
             let flow = (mkFlow fid "co2" "air" Nothing){bfUnitId = uidKg}
                 cf = (mkCF "co2" Nothing 2.5){mcfUnit = "kg"}
-                rawTables = buildMethodTables "" M.empty M.empty [(cf, Just (flow, ByUUID))]
+                rawTables = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flow, ByUUID))]
                 flowDB = M.singleton fid flow
                 unitDB = M.singleton uidKg (mkUnit uidKg "kg")
                 inv = M.fromList [(fid, 4.0 :: Double)]
@@ -516,7 +516,7 @@ spec = do
             uidKg <- nextRandom
             let flow = (mkFlow fid "co2" "air" Nothing){bfUnitId = uidKg}
                 cf = (mkCF "co2" Nothing 1.0e-3){mcfUnit = "g"}
-                tables0 = buildMethodTables "" M.empty M.empty [(cf, Just (flow, ByUUID))]
+                tables0 = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flow, ByUUID))]
                 flowDB = M.singleton fid flow
                 unitDB = M.singleton uidKg (mkUnit uidKg "kg")
                 inv = M.fromList [(fid, 1.0 :: Double)]
@@ -535,7 +535,7 @@ spec = do
             uidKg <- nextRandom
             let flow = (mkFlow fid "co2" "air" (Just "high pop")){bfUnitId = uidKg}
                 cf = (mkCFComp "co2" "air" "high pop" 3.0){mcfUnit = "kg"}
-                tables0 = buildMethodTables "" M.empty M.empty [(cf, Just (flow, ByName))]
+                tables0 = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flow, ByName))]
                 flowDB = M.singleton fid flow
                 unitDB = M.singleton uidKg (mkUnit uidKg "kg")
                 inv = M.fromList [(fid, 2.0 :: Double)]
@@ -551,7 +551,7 @@ spec = do
             -- Flow has subcomp "high pop", but CF only has medium-level entry (subcomp "")
             let flow = (mkFlow fid "co2" "air" (Just "high pop")){bfUnitId = uidKg}
                 cf = (mkCFComp "co2" "air" "" 5.0){mcfUnit = "kg"}
-                tables0 = buildMethodTables "" M.empty M.empty [(cf, Just (flow, ByName))]
+                tables0 = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flow, ByName))]
                 flowDB = M.singleton fid flow
                 unitDB = M.singleton uidKg (mkUnit uidKg "kg")
                 inv = M.fromList [(fid, 1.0 :: Double)]
@@ -567,7 +567,7 @@ spec = do
             uidKg <- nextRandom
             let flowLocal = (mkFlow fidLocal "co2" "air" Nothing){bfUnitId = uidKg}
                 cf = (mkCF "co2" Nothing 1.5){mcfUnit = "kg"}
-                tables0 = buildMethodTables "" M.empty M.empty [(cf, Just (flowLocal, ByUUID))]
+                tables0 = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flowLocal, ByUUID))]
                 flowDBAtBuild = M.singleton fidLocal flowLocal
                 unitDB = M.singleton uidKg (mkUnit uidKg "kg")
                 filled = fillBroadcastVector defaultUnitConfig unitDB flowDBAtBuild tables0
@@ -664,7 +664,7 @@ spec = do
             fid <- nextRandom
             let flow = mkFlow fid "co2" "air" Nothing
                 inv = M.singleton fid 100.0
-                tables = buildMethodTables "" M.empty M.empty []
+                tables = buildMethodTables OtherCFFamily M.empty M.empty []
                 idx = buildMethodIndex (mkMethod [])
                 opts = defaultUncharacterizedOpts{uoMaxFlows = 0}
             findUncharacterized
@@ -685,7 +685,7 @@ spec = do
                 smallFlow = mkFlow small "huge stuff" "air" Nothing
                 inv = M.fromList [(big, 999.0), (small, 1.0)]
                 flowDB = M.fromList [(big, bigFlow), (small, smallFlow)]
-                tables = buildMethodTables "" M.empty M.empty []
+                tables = buildMethodTables OtherCFFamily M.empty M.empty []
                 idx = buildMethodIndex (mkMethod [])
                 opts = defaultUncharacterizedOpts{uoMinAbsWeight = 0.5}
                 result =
@@ -705,7 +705,7 @@ spec = do
             fid <- nextRandom
             let flow = mkFlow fid "co2" "air" Nothing
                 cf = (mkCF "co2" Nothing 1.0){mcfFlowRef = fid}
-                tables = buildMethodTables "" M.empty M.empty [(cf, Just (flow, ByUUID))]
+                tables = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flow, ByUUID))]
                 idx = buildMethodIndex (mkMethod [cf])
                 inv = M.singleton fid 100.0
                 flowDB = M.singleton fid flow
@@ -719,6 +719,16 @@ spec = do
                 idx
                 defaultUncharacterizedOpts
                 `shouldBe` []
+
+    describe "cfFamily" $ do
+        it "classifies USEtox toxicity units, case/whitespace-insensitively" $ do
+            cfFamily "CTUe" `shouldBe` USEtoxFamily
+            cfFamily "CTUh" `shouldBe` USEtoxFamily
+            cfFamily " ctue " `shouldBe` USEtoxFamily
+        it "classifies every other unit (incl. unknown/empty) as OtherCFFamily" $ do
+            cfFamily "kg P eq" `shouldBe` OtherCFFamily
+            cfFamily "unknown" `shouldBe` OtherCFFamily
+            cfFamily "" `shouldBe` OtherCFFamily
 
 tShow :: (Show a) => a -> Text
 tShow = T.pack . show

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -341,7 +341,7 @@ spec = do
             fid <- nextRandom
             let flow = mkFlow fid "ammonia" "emissions to air/low. pop." Nothing
                 cf = mkCFComp "ammonia" "air" "low. pop." 0.747
-                tables = buildMethodTables M.empty M.empty [(cf, Nothing)]
+                tables = buildMethodTables "" M.empty M.empty [(cf, Nothing)]
                 inventory = M.singleton fid 10.0
                 flowDB = M.singleton fid flow
                 score = loScore (computeLCIAScoreFromTables defaultUnitConfig M.empty flowDB inventory tables)
@@ -352,7 +352,7 @@ spec = do
             let flow = mkFlow fid "ammonia" "emissions to air/low. pop." Nothing
                 cf = mkCFComp "ammonia" "air" "low. pop." 0.747
                 cmap = M.singleton ("emissions to air", "", "") (Compartment "air" "" "")
-                tables = buildMethodTables cmap M.empty [(cf, Nothing)]
+                tables = buildMethodTables "" cmap M.empty [(cf, Nothing)]
                 inventory = M.singleton fid 10.0
                 flowDB = M.singleton fid flow
                 score = loScore (computeLCIAScoreFromTables defaultUnitConfig M.empty flowDB inventory tables)
@@ -367,7 +367,7 @@ spec = do
                     M.singleton
                         ("emissions to air", "low. pop.", "")
                         (Compartment "air" "non-urban air or from high stacks" "")
-                tables = buildMethodTables cmap M.empty [(cf, Nothing)]
+                tables = buildMethodTables "" cmap M.empty [(cf, Nothing)]
                 inventory = M.singleton fid 10.0
                 flowDB = M.singleton fid flow
                 score = loScore (computeLCIAScoreFromTables defaultUnitConfig M.empty flowDB inventory tables)
@@ -405,7 +405,7 @@ spec = do
             fid <- nextRandom
             let flow = mkFlow fid "co2" "air" Nothing
                 cf = mkCF "co2" Nothing 1.0
-                tables = buildMethodTables M.empty M.empty [(cf, Just (flow, ByUUID))]
+                tables = buildMethodTables "" M.empty M.empty [(cf, Just (flow, ByUUID))]
                 inventory = M.singleton fid 100.0
                 flowDB = M.singleton fid flow
                 unitDB = M.singleton nil (unitNamed "m")
@@ -489,7 +489,7 @@ spec = do
             uidKg <- nextRandom
             let flow = (mkFlow fid "co2" "air" Nothing){bfUnitId = uidKg}
                 cf = (mkCF "co2" Nothing 2.5){mcfUnit = "kg"}
-                rawTables = buildMethodTables M.empty M.empty [(cf, Just (flow, ByUUID))]
+                rawTables = buildMethodTables "" M.empty M.empty [(cf, Just (flow, ByUUID))]
                 flowDB = M.singleton fid flow
                 unitDB = M.singleton uidKg (mkUnit uidKg "kg")
                 inv = M.fromList [(fid, 4.0 :: Double)]
@@ -516,7 +516,7 @@ spec = do
             uidKg <- nextRandom
             let flow = (mkFlow fid "co2" "air" Nothing){bfUnitId = uidKg}
                 cf = (mkCF "co2" Nothing 1.0e-3){mcfUnit = "g"}
-                tables0 = buildMethodTables M.empty M.empty [(cf, Just (flow, ByUUID))]
+                tables0 = buildMethodTables "" M.empty M.empty [(cf, Just (flow, ByUUID))]
                 flowDB = M.singleton fid flow
                 unitDB = M.singleton uidKg (mkUnit uidKg "kg")
                 inv = M.fromList [(fid, 1.0 :: Double)]
@@ -535,7 +535,7 @@ spec = do
             uidKg <- nextRandom
             let flow = (mkFlow fid "co2" "air" (Just "high pop")){bfUnitId = uidKg}
                 cf = (mkCFComp "co2" "air" "high pop" 3.0){mcfUnit = "kg"}
-                tables0 = buildMethodTables M.empty M.empty [(cf, Just (flow, ByName))]
+                tables0 = buildMethodTables "" M.empty M.empty [(cf, Just (flow, ByName))]
                 flowDB = M.singleton fid flow
                 unitDB = M.singleton uidKg (mkUnit uidKg "kg")
                 inv = M.fromList [(fid, 2.0 :: Double)]
@@ -551,7 +551,7 @@ spec = do
             -- Flow has subcomp "high pop", but CF only has medium-level entry (subcomp "")
             let flow = (mkFlow fid "co2" "air" (Just "high pop")){bfUnitId = uidKg}
                 cf = (mkCFComp "co2" "air" "" 5.0){mcfUnit = "kg"}
-                tables0 = buildMethodTables M.empty M.empty [(cf, Just (flow, ByName))]
+                tables0 = buildMethodTables "" M.empty M.empty [(cf, Just (flow, ByName))]
                 flowDB = M.singleton fid flow
                 unitDB = M.singleton uidKg (mkUnit uidKg "kg")
                 inv = M.fromList [(fid, 1.0 :: Double)]
@@ -567,7 +567,7 @@ spec = do
             uidKg <- nextRandom
             let flowLocal = (mkFlow fidLocal "co2" "air" Nothing){bfUnitId = uidKg}
                 cf = (mkCF "co2" Nothing 1.5){mcfUnit = "kg"}
-                tables0 = buildMethodTables M.empty M.empty [(cf, Just (flowLocal, ByUUID))]
+                tables0 = buildMethodTables "" M.empty M.empty [(cf, Just (flowLocal, ByUUID))]
                 flowDBAtBuild = M.singleton fidLocal flowLocal
                 unitDB = M.singleton uidKg (mkUnit uidKg "kg")
                 filled = fillBroadcastVector defaultUnitConfig unitDB flowDBAtBuild tables0
@@ -664,7 +664,7 @@ spec = do
             fid <- nextRandom
             let flow = mkFlow fid "co2" "air" Nothing
                 inv = M.singleton fid 100.0
-                tables = buildMethodTables M.empty M.empty []
+                tables = buildMethodTables "" M.empty M.empty []
                 idx = buildMethodIndex (mkMethod [])
                 opts = defaultUncharacterizedOpts{uoMaxFlows = 0}
             findUncharacterized
@@ -685,7 +685,7 @@ spec = do
                 smallFlow = mkFlow small "huge stuff" "air" Nothing
                 inv = M.fromList [(big, 999.0), (small, 1.0)]
                 flowDB = M.fromList [(big, bigFlow), (small, smallFlow)]
-                tables = buildMethodTables M.empty M.empty []
+                tables = buildMethodTables "" M.empty M.empty []
                 idx = buildMethodIndex (mkMethod [])
                 opts = defaultUncharacterizedOpts{uoMinAbsWeight = 0.5}
                 result =
@@ -705,7 +705,7 @@ spec = do
             fid <- nextRandom
             let flow = mkFlow fid "co2" "air" Nothing
                 cf = (mkCF "co2" Nothing 1.0){mcfFlowRef = fid}
-                tables = buildMethodTables M.empty M.empty [(cf, Just (flow, ByUUID))]
+                tables = buildMethodTables "" M.empty M.empty [(cf, Just (flow, ByUUID))]
                 idx = buildMethodIndex (mkMethod [cf])
                 inv = M.singleton fid 100.0
                 flowDB = M.singleton fid flow

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -468,6 +468,28 @@ spec = do
                 tables = buildMethodTables OtherCFFamily M.empty M.empty [(cfUnspecified, Just (flowOcean, ByName))]
             M.lookup (fid, "DE") (mtRegionalizedCF tables) `shouldBe` Nothing
 
+        it "does not let a wildcard CF reach a groundwater flow for a USEtox method" $ do
+            -- The USEtox fate model is surface freshwater: a groundwater metal
+            -- emission must not borrow the surface CF via the regionalized
+            -- wildcard — same rule as the non-regional cascade gate. A
+            -- non-USEtox (e.g. nutrient) method keeps characterizing
+            -- groundwater, since phosphate migrates to surface water.
+            let fid = mkUuid 131
+                uidKg = mkUuid 200
+                flowGw =
+                    (mkFlow fid "nickel" uidKg)
+                        { bfCompartment = Just (VT.Compartment "water" (Just "groundwater"))
+                        }
+                cfUnspecified =
+                    (mkCF fid 7.0)
+                        { mcfFlowName = "nickel"
+                        , mcfCompartment = Just (Compartment "water" "(unspecified)" "")
+                        , mcfConsumerLocation = Just "DE"
+                        }
+                tablesFor fam = buildMethodTables fam M.empty M.empty [(cfUnspecified, Just (flowGw, ByName))]
+            M.lookup (fid, "DE") (mtRegionalizedCF (tablesFor USEtoxFamily)) `shouldBe` Nothing
+            M.lookup (fid, "DE") (mtRegionalizedCF (tablesFor OtherCFFamily)) `shouldBe` Just (7.0, "kg")
+
         it "keeps CF when mcfCompartment is Nothing (no subcomp info)" $ do
             let fid = mkUuid 120
                 uidKg = mkUuid 200

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -94,7 +94,7 @@ spec = do
                 uidKg = mkUuid 200
                 cf = mkCF fid 1.0
                 m1 = mkMethod 1 "m1" [cf]
-                tables0 = buildMethodTables "" M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))]
+                tables0 = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))]
                 fdb = M.singleton fid (mkFlow fid "co2" uidKg)
                 udb = M.singleton uidKg (mkUnit uidKg "kg")
                 filled = fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb tables0
@@ -110,7 +110,7 @@ spec = do
                 uidKg = mkUuid 200
                 cf = mkCF fid 1.0
                 tables0 =
-                    (buildMethodTables "" M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))])
+                    (buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))])
                         { mtRegionalizedCF = M.singleton (fid, "FR") (2.0, "kg")
                         }
                 m1 = mkMethod 1 "m1" [cf]
@@ -143,9 +143,9 @@ spec = do
                 mC = mkMethod 3 "C" [cfC1]
 
                 fill ts = fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb ts
-                tA = fill (buildMethodTables "" M.empty M.empty [(cfA1, Just (flow1, ByUUID))])
-                tB = fill (buildMethodTables "" M.empty M.empty [(cfB1, Just (flow1, ByUUID)), (cfB2, Just (flow2, ByUUID))])
-                tC = fill (buildMethodTables "" M.empty M.empty [(cfC1, Just (flow1, ByUUID))])
+                tA = fill (buildMethodTables OtherCFFamily M.empty M.empty [(cfA1, Just (flow1, ByUUID))])
+                tB = fill (buildMethodTables OtherCFFamily M.empty M.empty [(cfB1, Just (flow1, ByUUID)), (cfB2, Just (flow2, ByUUID))])
+                tC = fill (buildMethodTables OtherCFFamily M.empty M.empty [(cfC1, Just (flow1, ByUUID))])
 
                 mst = buildMethodSetTables [(mA, tA), (mB, tB), (mC, tC)]
 
@@ -185,7 +185,7 @@ spec = do
                 fdb = M.singleton fid (mkFlow fid "co2" uidKg)
                 udb = M.singleton uidKg (mkUnit uidKg "kg")
                 fill ts = fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb ts
-                t = fill (buildMethodTables "" M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))])
+                t = fill (buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))])
                 mst = buildMethodSetTables [(m1, t), (m2, t)]
                 results =
                     computeLCIAScoreSetFromTables
@@ -210,7 +210,7 @@ spec = do
                 udb = M.singleton uidKg (mkUnit uidKg "kg")
                 t =
                     fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb $
-                        buildMethodTables "" M.empty M.empty [(cf, Just (mkFlow fidIn "co2" uidKg, ByUUID))]
+                        buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (mkFlow fidIn "co2" uidKg, ByUUID))]
                 mst = buildMethodSetTables [(m1, t)]
                 inv = M.fromList [(fidIn, 2.0), (fidOut, 100.0)]
                 results =
@@ -253,7 +253,7 @@ spec = do
                 t =
                     fillBroadcastVector UnitConversion.defaultUnitConfig udb buildFlowDB $
                         buildMethodTables
-                            ""
+                            OtherCFFamily
                             M.empty
                             M.empty
                             [ (cfBuild, Just (mkFlow fidBuild "co2" uidKg, ByUUID))
@@ -281,7 +281,7 @@ spec = do
                 udb = M.singleton uidKg (mkUnit uidKg "kg")
                 t =
                     fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb $
-                        buildMethodTables "" M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))]
+                        buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))]
                 mB = mkMethod 2 "B" [cf]
                 mA = mkMethod 1 "A" [cf]
                 mC = mkMethod 3 "C" [cf]
@@ -313,17 +313,17 @@ spec = do
                 cf3a = mkCF fid1 1.0
                 cf3b = (mkCF fid2 25.0){mcfFlowName = "ch4"}
                 tNonRegio1 =
-                    fill (buildMethodTables "" M.empty M.empty [(cf1a, Just (flow1, ByUUID))])
+                    fill (buildMethodTables OtherCFFamily M.empty M.empty [(cf1a, Just (flow1, ByUUID))])
                 tRegio =
                     fill
-                        ( (buildMethodTables "" M.empty M.empty [(cf2a, Just (flow1, ByUUID))])
+                        ( (buildMethodTables OtherCFFamily M.empty M.empty [(cf2a, Just (flow1, ByUUID))])
                             { mtRegionalizedCF = M.singleton (fid1, "FR") (7.0, "kg")
                             }
                         )
                 tNonRegio2 =
                     fill
                         ( buildMethodTables
-                            ""
+                            OtherCFFamily
                             M.empty
                             M.empty
                             [ (cf3a, Just (flow1, ByUUID))
@@ -402,7 +402,7 @@ spec = do
                     , (cfOcean, Just (flowUns, ByName))
                     , (cfOcean, Just (flowOcean, ByName))
                     ]
-                tables = buildMethodTables "" M.empty M.empty mappings
+                tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
                 regio = mtRegionalizedCF tables
             -- Pre-fix: this was (0.0, "kg") — clobbered by cfOcean. The
             -- filter drops (cfOcean, flowUns) so the wildcard cfUns survives.
@@ -441,9 +441,9 @@ spec = do
                         , mcfCompartment = Just (Compartment "water" "unspecified" "")
                         , mcfConsumerLocation = Just "DE"
                         }
-                tEmpty = buildMethodTables "" M.empty M.empty [(cfEmpty, Just (flowRiver, ByName))]
-                tUnspec = buildMethodTables "" M.empty M.empty [(cfUnspecified, Just (flowRiver, ByName))]
-                tUnspecBare = buildMethodTables "" M.empty M.empty [(cfUnspecBare, Just (flowRiver, ByName))]
+                tEmpty = buildMethodTables OtherCFFamily M.empty M.empty [(cfEmpty, Just (flowRiver, ByName))]
+                tUnspec = buildMethodTables OtherCFFamily M.empty M.empty [(cfUnspecified, Just (flowRiver, ByName))]
+                tUnspecBare = buildMethodTables OtherCFFamily M.empty M.empty [(cfUnspecBare, Just (flowRiver, ByName))]
             -- All three wildcard forms apply to a specific-subcomp flow.
             M.lookup (fid, "DE") (mtRegionalizedCF tEmpty) `shouldBe` Just (2.0, "kg")
             M.lookup (fid, "DE") (mtRegionalizedCF tUnspec) `shouldBe` Just (7.0, "kg")
@@ -465,7 +465,7 @@ spec = do
                         , mcfCompartment = Just (Compartment "water" "(unspecified)" "")
                         , mcfConsumerLocation = Just "DE"
                         }
-                tables = buildMethodTables "" M.empty M.empty [(cfUnspecified, Just (flowOcean, ByName))]
+                tables = buildMethodTables OtherCFFamily M.empty M.empty [(cfUnspecified, Just (flowOcean, ByName))]
             M.lookup (fid, "DE") (mtRegionalizedCF tables) `shouldBe` Nothing
 
         it "keeps CF when mcfCompartment is Nothing (no subcomp info)" $ do
@@ -481,5 +481,5 @@ spec = do
                         , mcfCompartment = Nothing
                         , mcfConsumerLocation = Just "IT"
                         }
-                tables = buildMethodTables "" M.empty M.empty [(cf, Just (flowAny, ByName))]
+                tables = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flowAny, ByName))]
             M.lookup (fid, "IT") (mtRegionalizedCF tables) `shouldBe` Just (4.0, "kg")

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -94,7 +94,7 @@ spec = do
                 uidKg = mkUuid 200
                 cf = mkCF fid 1.0
                 m1 = mkMethod 1 "m1" [cf]
-                tables0 = buildMethodTables M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))]
+                tables0 = buildMethodTables "" M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))]
                 fdb = M.singleton fid (mkFlow fid "co2" uidKg)
                 udb = M.singleton uidKg (mkUnit uidKg "kg")
                 filled = fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb tables0
@@ -110,7 +110,7 @@ spec = do
                 uidKg = mkUuid 200
                 cf = mkCF fid 1.0
                 tables0 =
-                    (buildMethodTables M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))])
+                    (buildMethodTables "" M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))])
                         { mtRegionalizedCF = M.singleton (fid, "FR") (2.0, "kg")
                         }
                 m1 = mkMethod 1 "m1" [cf]
@@ -143,9 +143,9 @@ spec = do
                 mC = mkMethod 3 "C" [cfC1]
 
                 fill ts = fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb ts
-                tA = fill (buildMethodTables M.empty M.empty [(cfA1, Just (flow1, ByUUID))])
-                tB = fill (buildMethodTables M.empty M.empty [(cfB1, Just (flow1, ByUUID)), (cfB2, Just (flow2, ByUUID))])
-                tC = fill (buildMethodTables M.empty M.empty [(cfC1, Just (flow1, ByUUID))])
+                tA = fill (buildMethodTables "" M.empty M.empty [(cfA1, Just (flow1, ByUUID))])
+                tB = fill (buildMethodTables "" M.empty M.empty [(cfB1, Just (flow1, ByUUID)), (cfB2, Just (flow2, ByUUID))])
+                tC = fill (buildMethodTables "" M.empty M.empty [(cfC1, Just (flow1, ByUUID))])
 
                 mst = buildMethodSetTables [(mA, tA), (mB, tB), (mC, tC)]
 
@@ -185,7 +185,7 @@ spec = do
                 fdb = M.singleton fid (mkFlow fid "co2" uidKg)
                 udb = M.singleton uidKg (mkUnit uidKg "kg")
                 fill ts = fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb ts
-                t = fill (buildMethodTables M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))])
+                t = fill (buildMethodTables "" M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))])
                 mst = buildMethodSetTables [(m1, t), (m2, t)]
                 results =
                     computeLCIAScoreSetFromTables
@@ -210,7 +210,7 @@ spec = do
                 udb = M.singleton uidKg (mkUnit uidKg "kg")
                 t =
                     fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb $
-                        buildMethodTables M.empty M.empty [(cf, Just (mkFlow fidIn "co2" uidKg, ByUUID))]
+                        buildMethodTables "" M.empty M.empty [(cf, Just (mkFlow fidIn "co2" uidKg, ByUUID))]
                 mst = buildMethodSetTables [(m1, t)]
                 inv = M.fromList [(fidIn, 2.0), (fidOut, 100.0)]
                 results =
@@ -253,6 +253,7 @@ spec = do
                 t =
                     fillBroadcastVector UnitConversion.defaultUnitConfig udb buildFlowDB $
                         buildMethodTables
+                            ""
                             M.empty
                             M.empty
                             [ (cfBuild, Just (mkFlow fidBuild "co2" uidKg, ByUUID))
@@ -280,7 +281,7 @@ spec = do
                 udb = M.singleton uidKg (mkUnit uidKg "kg")
                 t =
                     fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb $
-                        buildMethodTables M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))]
+                        buildMethodTables "" M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))]
                 mB = mkMethod 2 "B" [cf]
                 mA = mkMethod 1 "A" [cf]
                 mC = mkMethod 3 "C" [cf]
@@ -312,16 +313,17 @@ spec = do
                 cf3a = mkCF fid1 1.0
                 cf3b = (mkCF fid2 25.0){mcfFlowName = "ch4"}
                 tNonRegio1 =
-                    fill (buildMethodTables M.empty M.empty [(cf1a, Just (flow1, ByUUID))])
+                    fill (buildMethodTables "" M.empty M.empty [(cf1a, Just (flow1, ByUUID))])
                 tRegio =
                     fill
-                        ( (buildMethodTables M.empty M.empty [(cf2a, Just (flow1, ByUUID))])
+                        ( (buildMethodTables "" M.empty M.empty [(cf2a, Just (flow1, ByUUID))])
                             { mtRegionalizedCF = M.singleton (fid1, "FR") (7.0, "kg")
                             }
                         )
                 tNonRegio2 =
                     fill
                         ( buildMethodTables
+                            ""
                             M.empty
                             M.empty
                             [ (cf3a, Just (flow1, ByUUID))
@@ -400,7 +402,7 @@ spec = do
                     , (cfOcean, Just (flowUns, ByName))
                     , (cfOcean, Just (flowOcean, ByName))
                     ]
-                tables = buildMethodTables M.empty M.empty mappings
+                tables = buildMethodTables "" M.empty M.empty mappings
                 regio = mtRegionalizedCF tables
             -- Pre-fix: this was (0.0, "kg") — clobbered by cfOcean. The
             -- filter drops (cfOcean, flowUns) so the wildcard cfUns survives.
@@ -413,9 +415,9 @@ spec = do
         it "treats CFs with empty / (unspecified) subcomp as wildcards" $ do
             let fid = mkUuid 110
                 uidKg = mkUuid 200
-                flowOcean =
+                flowRiver =
                     (mkFlow fid "water" uidKg)
-                        { bfCompartment = Just (VT.Compartment "water" (Just "ocean"))
+                        { bfCompartment = Just (VT.Compartment "water" (Just "river"))
                         }
                 cfEmpty =
                     (mkCF fid 2.0)
@@ -439,13 +441,32 @@ spec = do
                         , mcfCompartment = Just (Compartment "water" "unspecified" "")
                         , mcfConsumerLocation = Just "DE"
                         }
-                tEmpty = buildMethodTables M.empty M.empty [(cfEmpty, Just (flowOcean, ByName))]
-                tUnspec = buildMethodTables M.empty M.empty [(cfUnspecified, Just (flowOcean, ByName))]
-                tUnspecBare = buildMethodTables M.empty M.empty [(cfUnspecBare, Just (flowOcean, ByName))]
+                tEmpty = buildMethodTables "" M.empty M.empty [(cfEmpty, Just (flowRiver, ByName))]
+                tUnspec = buildMethodTables "" M.empty M.empty [(cfUnspecified, Just (flowRiver, ByName))]
+                tUnspecBare = buildMethodTables "" M.empty M.empty [(cfUnspecBare, Just (flowRiver, ByName))]
             -- All three wildcard forms apply to a specific-subcomp flow.
             M.lookup (fid, "DE") (mtRegionalizedCF tEmpty) `shouldBe` Just (2.0, "kg")
             M.lookup (fid, "DE") (mtRegionalizedCF tUnspec) `shouldBe` Just (7.0, "kg")
             M.lookup (fid, "DE") (mtRegionalizedCF tUnspecBare) `shouldBe` Just (9.0, "kg")
+
+        it "does not let a wildcard CF reach a sea/ocean flow (foreign medium)" $ do
+            -- A freshwater CF must not characterize a sea-water release via the
+            -- regionalized wildcard: EF ships a distinct, uncharacterized
+            -- sea-water flow, so water-to-ocean stays uncharacterized here.
+            let fid = mkUuid 130
+                uidKg = mkUuid 200
+                flowOcean =
+                    (mkFlow fid "water" uidKg)
+                        { bfCompartment = Just (VT.Compartment "water" (Just "ocean"))
+                        }
+                cfUnspecified =
+                    (mkCF fid 7.0)
+                        { mcfFlowName = "water"
+                        , mcfCompartment = Just (Compartment "water" "(unspecified)" "")
+                        , mcfConsumerLocation = Just "DE"
+                        }
+                tables = buildMethodTables "" M.empty M.empty [(cfUnspecified, Just (flowOcean, ByName))]
+            M.lookup (fid, "DE") (mtRegionalizedCF tables) `shouldBe` Nothing
 
         it "keeps CF when mcfCompartment is Nothing (no subcomp info)" $ do
             let fid = mkUuid 120
@@ -460,5 +481,5 @@ spec = do
                         , mcfCompartment = Nothing
                         , mcfConsumerLocation = Just "IT"
                         }
-                tables = buildMethodTables M.empty M.empty [(cf, Just (flowAny, ByName))]
+                tables = buildMethodTables "" M.empty M.empty [(cf, Just (flowAny, ByName))]
             M.lookup (fid, "IT") (mtRegionalizedCF tables) `shouldBe` Just (4.0, "kg")

--- a/test/OlcaSchemaSpec.hs
+++ b/test/OlcaSchemaSpec.hs
@@ -147,5 +147,5 @@ spec = do
                 Left err -> expectationFailure ("parse failed: " ++ err)
                 Right method -> do
                     let mappings = [(cf, Nothing) | cf <- methodFactors method]
-                        tables = buildMethodTables M.empty M.empty mappings
+                        tables = buildMethodTables "" M.empty M.empty mappings
                     M.size (mtRegionalizedCF tables) `shouldBe` 0

--- a/test/OlcaSchemaSpec.hs
+++ b/test/OlcaSchemaSpec.hs
@@ -147,5 +147,5 @@ spec = do
                 Left err -> expectationFailure ("parse failed: " ++ err)
                 Right method -> do
                     let mappings = [(cf, Nothing) | cf <- methodFactors method]
-                        tables = buildMethodTables "" M.empty M.empty mappings
+                        tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
                     M.size (mtRegionalizedCF tables) `shouldBe` 0

--- a/test/ProxyEdgeSpec.hs
+++ b/test/ProxyEdgeSpec.hs
@@ -17,7 +17,7 @@ import Method.Mapping (
     expandProxyEdges,
     lookupCFForFlow,
  )
-import Method.Types (Compartment (..), FlowDirection (..), MethodCF (..))
+import Method.Types (CFFamily (..), Compartment (..), FlowDirection (..), MethodCF (..))
 import qualified SubstanceRegistry as SR
 import Types (BiosphereFlow (..))
 import qualified Types as VT
@@ -119,8 +119,8 @@ spec = describe "expandProxyEdges" $ do
     -- lookup, exactly as a real score queries it.
     it "characterizes an otherwise-uncharacterized flow through the method tables" $ do
         let edges = [proxyEdge (nameKey "phosphorus") (nameKey "phosphate") 0.5]
-            tablesNoProxy = buildMethodTables "" M.empty M.empty baseMappings
-            tablesProxy = buildMethodTables "" M.empty M.empty (expandProxyEdges byNameTargets edges baseMappings)
+            tablesNoProxy = buildMethodTables OtherCFFamily M.empty M.empty baseMappings
+            tablesProxy = buildMethodTables OtherCFFamily M.empty M.empty (expandProxyEdges byNameTargets edges baseMappings)
             lookup' ts = lookupCFForFlow ts (bfId phosphateFlow) (Just phosphateFlow)
         lookup' tablesNoProxy `shouldBe` Nothing
         fmap fst (lookup' tablesProxy) `shouldBe` Just 1.0 -- 2.0 * 0.5

--- a/test/ProxyEdgeSpec.hs
+++ b/test/ProxyEdgeSpec.hs
@@ -119,8 +119,8 @@ spec = describe "expandProxyEdges" $ do
     -- lookup, exactly as a real score queries it.
     it "characterizes an otherwise-uncharacterized flow through the method tables" $ do
         let edges = [proxyEdge (nameKey "phosphorus") (nameKey "phosphate") 0.5]
-            tablesNoProxy = buildMethodTables M.empty M.empty baseMappings
-            tablesProxy = buildMethodTables M.empty M.empty (expandProxyEdges byNameTargets edges baseMappings)
+            tablesNoProxy = buildMethodTables "" M.empty M.empty baseMappings
+            tablesProxy = buildMethodTables "" M.empty M.empty (expandProxyEdges byNameTargets edges baseMappings)
             lookup' ts = lookupCFForFlow ts (bfId phosphateFlow) (Just phosphateFlow)
         lookup' tablesNoProxy `shouldBe` Nothing
         fmap fst (lookup' tablesProxy) `shouldBe` Just 1.0 -- 2.0 * 0.5

--- a/test/RegionFallbackSpec.hs
+++ b/test/RegionFallbackSpec.hs
@@ -47,7 +47,7 @@ situation a non-regionalized method (e.g. EF v3.1 JRC ILCD) produces.
 -}
 tablesFor :: Text -> Double -> MethodTables
 tablesFor base val =
-    buildMethodTables M.empty M.empty [(baseCF base val, Just (mkFlow 1 base, ByName))]
+    buildMethodTables "" M.empty M.empty [(baseCF base val, Just (mkFlow 1 base, ByName))]
 
 -- | Score a flow of the given name against those tables.
 scoreOf :: Text -> Double -> Text -> Maybe Double

--- a/test/RegionFallbackSpec.hs
+++ b/test/RegionFallbackSpec.hs
@@ -9,7 +9,7 @@ import qualified Data.UUID as UUID
 import Test.Hspec
 
 import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, lookupCFForFlow)
-import Method.Types (Compartment (..), FlowDirection (..), MethodCF (..), extractLocationSuffix)
+import Method.Types (CFFamily (..), Compartment (..), FlowDirection (..), MethodCF (..), extractLocationSuffix)
 import Types (BiosphereFlow (..))
 import qualified Types as VT
 
@@ -47,7 +47,7 @@ situation a non-regionalized method (e.g. EF v3.1 JRC ILCD) produces.
 -}
 tablesFor :: Text -> Double -> MethodTables
 tablesFor base val =
-    buildMethodTables "" M.empty M.empty [(baseCF base val, Just (mkFlow 1 base, ByName))]
+    buildMethodTables OtherCFFamily M.empty M.empty [(baseCF base val, Just (mkFlow 1 base, ByName))]
 
 -- | Score a flow of the given name against those tables.
 scoreOf :: Text -> Double -> Text -> Maybe Double

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -159,7 +159,7 @@ buildTables ::
     [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] ->
     MethodTables
 buildTables db hier mappings =
-    let raw = buildMethodTables M.empty M.empty mappings
+    let raw = buildMethodTables "" M.empty M.empty mappings
         withBroadcast =
             fillBroadcastVector kgUnitConfig (dbUnits db) (dbBioFlows db) raw
      in fillRegionalActivityWeights

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -159,7 +159,7 @@ buildTables ::
     [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] ->
     MethodTables
 buildTables db hier mappings =
-    let raw = buildMethodTables "" M.empty M.empty mappings
+    let raw = buildMethodTables OtherCFFamily M.empty M.empty mappings
         withBroadcast =
             fillBroadcastVector kgUnitConfig (dbUnits db) (dbBioFlows db) raw
      in fillRegionalActivityWeights

--- a/test/SharedCASCoverageSpec.hs
+++ b/test/SharedCASCoverageSpec.hs
@@ -158,7 +158,7 @@ mapCtx =
 buildTablesFor :: Method -> IO MethodTables
 buildTablesFor method = do
     mappings <- mapMethodFlows defaultMappers mapCtx method
-    let raw = buildMethodTables M.empty M.empty mappings
+    let raw = buildMethodTables "" M.empty M.empty mappings
     pure (fillBroadcastVector defaultUnitConfig M.empty flowDB raw)
 
 buildTables :: IO MethodTables
@@ -237,7 +237,7 @@ carbonSynonyms =
 buildCarbonTables :: IO MethodTables
 buildCarbonTables = do
     mappings <- mapMethodFlows defaultMappers carbonSynonyms biogenicMethaneMethod
-    let raw = buildMethodTables M.empty M.empty mappings
+    let raw = buildMethodTables "" M.empty M.empty mappings
     pure (fillBroadcastVector defaultUnitConfig M.empty carbonFlows raw)
 
 -- ---------------------------------------------------------------------------
@@ -350,7 +350,7 @@ fallbackCtx =
 buildFallbackTables :: IO MethodTables
 buildFallbackTables = do
     mappings <- mapMethodFlows defaultMappers fallbackCtx fallbackMethod
-    let raw = buildMethodTables M.empty M.empty mappings
+    let raw = buildMethodTables "" M.empty M.empty mappings
     pure (fillBroadcastVector defaultUnitConfig M.empty fallbackFlowDB raw)
 
 -- ---------------------------------------------------------------------------
@@ -463,14 +463,14 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
     describe "regionalized rows stay out of the global tables" $ do
         it "routes a location-bearing CAS-matched CF to mtRegionalCasCF only" $ do
             mappings <- mapMethodFlows defaultMappers mapCtx regionalCasMethod
-            let tables = buildMethodTables M.empty M.empty mappings
+            let tables = buildMethodTables "" M.empty M.empty mappings
             M.lookup (CASNumber waterCAS, Medium "resource") (mtRegionalCasCF tables)
                 `shouldBe` Just (M.fromList [("FR", (9, "m3"))])
             M.member (CASNumber waterCAS, Medium "resource") (mtCasCF tables) `shouldBe` False
 
         it "keeps regionalized UUID-matched rows out of mtUuidCF" $ do
             mappings <- mapMethodFlows defaultMappers mapCtx uuidRegionalMethod
-            let tables = buildMethodTables M.empty M.empty mappings
+            let tables = buildMethodTables "" M.empty M.empty mappings
             -- The global row stands; the location row lives in the regional
             -- table instead of clobbering the flow's universal value.
             M.lookup (bfId river) (mtUuidCF tables) `shouldBe` Just (5, "m3")
@@ -508,7 +508,7 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
                 Left err -> expectationFailure ("Parse failed: " ++ err)
                 Right coll -> do
                     mappings <- concat <$> mapM (mapMethodFlows defaultMappers mapCtx) (mcMethods coll)
-                    let tables = buildMethodTables M.empty M.empty mappings
+                    let tables = buildMethodTables "" M.empty M.empty mappings
                     -- Only the region-less rows may broadcast through the
                     -- name-blind bridge, on both the withdrawal and release
                     -- sides (the negative release default keeps AWARE's
@@ -539,13 +539,13 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
     describe "CAS bridge broadcasts the unspecified value, not the niche max" $ do
         it "keeps the unspecified factor when subcompartment CFs diverge" $ do
             mappings <- mapMethodFlows defaultMappers acrCtx acrMethod
-            let tables = buildMethodTables M.empty M.empty mappings
+            let tables = buildMethodTables "" M.empty M.empty mappings
             -- indoor air is 100x; the bridge must not broadcast it.
             M.lookup (CASNumber acrCAS, Medium "air") (mtCasCF tables) `shouldBe` Just (1, "kg")
 
         it "reaches the flow with the unspecified factor, not the indoor max" $ do
             mappings <- mapMethodFlows defaultMappers acrCtx acrMethod
-            let raw = buildMethodTables M.empty M.empty mappings
+            let raw = buildMethodTables "" M.empty M.empty mappings
                 tables = fillBroadcastVector defaultUnitConfig M.empty (mcBioFlowsByUUID acrCtx) raw
             M.lookup (bfId acrFlow) (mtBroadcast tables) `shouldBe` Just 1
 
@@ -554,6 +554,6 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
             -- regionalized bridge must keep the medium-level default, not the
             -- niche max — same rule as the non-regional 'mtCasCF'.
             mappings <- mapMethodFlows defaultMappers acrCtx acrRegionalMethod
-            let tables = buildMethodTables M.empty M.empty mappings
+            let tables = buildMethodTables "" M.empty M.empty mappings
             M.lookup (CASNumber acrCAS, Medium "air") (mtRegionalCasCF tables)
                 `shouldBe` Just (M.fromList [("FR", (1, "kg"))])

--- a/test/SharedCASCoverageSpec.hs
+++ b/test/SharedCASCoverageSpec.hs
@@ -158,7 +158,7 @@ mapCtx =
 buildTablesFor :: Method -> IO MethodTables
 buildTablesFor method = do
     mappings <- mapMethodFlows defaultMappers mapCtx method
-    let raw = buildMethodTables "" M.empty M.empty mappings
+    let raw = buildMethodTables OtherCFFamily M.empty M.empty mappings
     pure (fillBroadcastVector defaultUnitConfig M.empty flowDB raw)
 
 buildTables :: IO MethodTables
@@ -237,7 +237,7 @@ carbonSynonyms =
 buildCarbonTables :: IO MethodTables
 buildCarbonTables = do
     mappings <- mapMethodFlows defaultMappers carbonSynonyms biogenicMethaneMethod
-    let raw = buildMethodTables "" M.empty M.empty mappings
+    let raw = buildMethodTables OtherCFFamily M.empty M.empty mappings
     pure (fillBroadcastVector defaultUnitConfig M.empty carbonFlows raw)
 
 -- ---------------------------------------------------------------------------
@@ -350,7 +350,7 @@ fallbackCtx =
 buildFallbackTables :: IO MethodTables
 buildFallbackTables = do
     mappings <- mapMethodFlows defaultMappers fallbackCtx fallbackMethod
-    let raw = buildMethodTables "" M.empty M.empty mappings
+    let raw = buildMethodTables OtherCFFamily M.empty M.empty mappings
     pure (fillBroadcastVector defaultUnitConfig M.empty fallbackFlowDB raw)
 
 -- ---------------------------------------------------------------------------
@@ -463,14 +463,14 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
     describe "regionalized rows stay out of the global tables" $ do
         it "routes a location-bearing CAS-matched CF to mtRegionalCasCF only" $ do
             mappings <- mapMethodFlows defaultMappers mapCtx regionalCasMethod
-            let tables = buildMethodTables "" M.empty M.empty mappings
+            let tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
             M.lookup (CASNumber waterCAS, Medium "resource") (mtRegionalCasCF tables)
                 `shouldBe` Just (M.fromList [("FR", (9, "m3"))])
             M.member (CASNumber waterCAS, Medium "resource") (mtCasCF tables) `shouldBe` False
 
         it "keeps regionalized UUID-matched rows out of mtUuidCF" $ do
             mappings <- mapMethodFlows defaultMappers mapCtx uuidRegionalMethod
-            let tables = buildMethodTables "" M.empty M.empty mappings
+            let tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
             -- The global row stands; the location row lives in the regional
             -- table instead of clobbering the flow's universal value.
             M.lookup (bfId river) (mtUuidCF tables) `shouldBe` Just (5, "m3")
@@ -508,7 +508,7 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
                 Left err -> expectationFailure ("Parse failed: " ++ err)
                 Right coll -> do
                     mappings <- concat <$> mapM (mapMethodFlows defaultMappers mapCtx) (mcMethods coll)
-                    let tables = buildMethodTables "" M.empty M.empty mappings
+                    let tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
                     -- Only the region-less rows may broadcast through the
                     -- name-blind bridge, on both the withdrawal and release
                     -- sides (the negative release default keeps AWARE's
@@ -539,13 +539,13 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
     describe "CAS bridge broadcasts the unspecified value, not the niche max" $ do
         it "keeps the unspecified factor when subcompartment CFs diverge" $ do
             mappings <- mapMethodFlows defaultMappers acrCtx acrMethod
-            let tables = buildMethodTables "" M.empty M.empty mappings
+            let tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
             -- indoor air is 100x; the bridge must not broadcast it.
             M.lookup (CASNumber acrCAS, Medium "air") (mtCasCF tables) `shouldBe` Just (1, "kg")
 
         it "reaches the flow with the unspecified factor, not the indoor max" $ do
             mappings <- mapMethodFlows defaultMappers acrCtx acrMethod
-            let raw = buildMethodTables "" M.empty M.empty mappings
+            let raw = buildMethodTables OtherCFFamily M.empty M.empty mappings
                 tables = fillBroadcastVector defaultUnitConfig M.empty (mcBioFlowsByUUID acrCtx) raw
             M.lookup (bfId acrFlow) (mtBroadcast tables) `shouldBe` Just 1
 
@@ -554,6 +554,6 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
             -- regionalized bridge must keep the medium-level default, not the
             -- niche max — same rule as the non-regional 'mtCasCF'.
             mappings <- mapMethodFlows defaultMappers acrCtx acrRegionalMethod
-            let tables = buildMethodTables "" M.empty M.empty mappings
+            let tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
             M.lookup (CASNumber acrCAS, Medium "air") (mtRegionalCasCF tables)
                 `shouldBe` Just (M.fromList [("FR", (1, "kg"))])

--- a/test/SubBlindCFSpec.hs
+++ b/test/SubBlindCFSpec.hs
@@ -9,7 +9,7 @@ import qualified Data.UUID as UUID
 import Test.Hspec
 
 import Method.Mapping (MatchStrategy (..), buildMethodTables, lookupCFForFlow)
-import Method.Types (Compartment (..), FlowDirection (..), MethodCF (..))
+import Method.Types (CFFamily (..), Compartment (..), FlowDirection (..), MethodCF (..))
 import Types (BiosphereFlow (..))
 import qualified Types as VT
 
@@ -44,7 +44,7 @@ mkFlow i name sub =
 
 score :: [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> BiosphereFlow -> Maybe Double
 score mappings flow =
-    fmap fst (lookupCFForFlow (buildMethodTables "" M.empty M.empty mappings) (bfId flow) (Just flow))
+    fmap fst (lookupCFForFlow (buildMethodTables OtherCFFamily M.empty M.empty mappings) (bfId flow) (Just flow))
 
 spec :: Spec
 spec = describe "sub-blind CF fallback" $ do

--- a/test/SubBlindCFSpec.hs
+++ b/test/SubBlindCFSpec.hs
@@ -64,3 +64,23 @@ spec = describe "sub-blind CF fallback" $ do
                 , (mkCF 2 "Mercury" "in water" 2.0, Just (mkFlow 2 "Mercury" (Just "in water"), ByName))
                 ]
         score mappings (mkFlow 99 "Mercury" Nothing) `shouldBe` Nothing
+
+    describe "resource base-name fallback (ore-grade variants)" $ do
+        -- The method characterizes the base element; ecoinvent supplies dozens
+        -- of ore-grade variants ("Copper, 0.99% in sulfide, Cu 0.36% …, in
+        -- ground") that carry no CAS and match no CF of their own. Their
+        -- reference amount is the mass of the element, so they take its CF.
+        let copperCF = mkCF 1 "Copper" "in ground" 1.37e-6
+            copperMapping = [(copperCF, Just (mkFlow 1 "Copper" (Just "in ground"), ByName))]
+
+        it "characterizes an ore-grade variant with the base element's CF" $
+            score copperMapping (mkFlow 99 "Copper, 0.99% in sulfide, Cu 0.36% and Mo 8.2E-3% in crude ore" (Just "in ground"))
+                `shouldBe` Just 1.37e-6
+
+        it "leaves a variant alone when the method has no CF for the base" $
+            score copperMapping (mkFlow 99 "Calcite, in ground" Nothing)
+                `shouldBe` Nothing
+
+        it "does not fire for a comma-less resource name" $
+            score copperMapping (mkFlow 99 "Gravel" (Just "in ground"))
+                `shouldBe` Nothing

--- a/test/SubBlindCFSpec.hs
+++ b/test/SubBlindCFSpec.hs
@@ -44,7 +44,7 @@ mkFlow i name sub =
 
 score :: [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> BiosphereFlow -> Maybe Double
 score mappings flow =
-    fmap fst (lookupCFForFlow (buildMethodTables M.empty M.empty mappings) (bfId flow) (Just flow))
+    fmap fst (lookupCFForFlow (buildMethodTables "" M.empty M.empty mappings) (bfId flow) (Just flow))
 
 spec :: Spec
 spec = describe "sub-blind CF fallback" $ do

--- a/test/SubBlindCFSpec.hs
+++ b/test/SubBlindCFSpec.hs
@@ -84,3 +84,11 @@ spec = describe "sub-blind CF fallback" $ do
         it "does not fire for a comma-less resource name" $
             score copperMapping (mkFlow 99 "Gravel" (Just "in ground"))
                 `shouldBe` Nothing
+
+        it "does not fire for a comma-qualified name without a grade marker" $ do
+            -- The "%" pins the fallback to ore-grade variants: an ordinary
+            -- comma-qualified resource must not borrow the base CF (a
+            -- salt-water withdrawal is not freshwater scarcity).
+            let waterMapping = [(mkCF 1 "Water" "in water" 42.0, Just (mkFlow 1 "Water" (Just "in water"), ByName))]
+            score waterMapping (mkFlow 99 "Water, salt, ocean" (Just "in water"))
+                `shouldBe` Nothing


### PR DESCRIPTION
Three characterization-cascade fixes found by validating EF 3.1 scores (both the JRC ILCD collection and a SimaPro-adapted export) against an official LCIA-results reference over an ecoinvent-derived database. Each was a silent systematic bias — no error surfaced, just wrong numbers.

## Subcompartment gate on surface-freshwater fallbacks

The medium-level fallbacks (`mtFallbackCF`, `mtCasCF`, `mtSubBlindCF`, region-base) stand for a surface, immediate emission, but the cascade let them reach any subcompartment:

- **sea/ocean** releases borrowed freshwater CFs (EF intentionally ships a distinct, uncharacterized sea-water flow) — over-credited water use;
- **groundwater** metal emissions borrowed surface USEtox CFs — ecotoxicity and human-toxicity over-counted by up to two orders of magnitude on metal-intensive products, while nutrient CFs (kg P eq) *must* keep characterizing groundwater (phosphate migrates to surface water).

The USEtox distinction can't be read off the CF unit (SimaPro-adapted exports store every CF unit as `"kg"`), so a new `mtMethodUnit` field carries the method's result unit (CTUe/CTUh) through `buildMethodTables`. The regionalized wildcard match gets the same sea/ocean gate. Exact-subcompartment CFs and the method's own long-term default are never gated.

## Density bridge generalized to any same-dimension pair

The energy-density bridge only fired for energy-denominated CFs, so a per-m³ water-scarcity CF met a kg water emission cross-dimensionally and scored kg as m³ — a ×1000 over-count on every mass-declared water flow. The guard is now "CF unit compatible with the density's target unit", letting one mechanism serve the calorific bridge (kg → MJ) and a mass density (kg → m³, new `Water` row). The ILCD result unit `m3-world equivalents` is registered as a volume.

## Ore-grade resource variants score via the base element

Ecoinvent supplies mineral resources as ore-grade variants (`Copper, 0.99% in sulfide, Cu 0.36% …, in ground`) that carry no CAS and match no CF, so the whole family scored zero — mineral/metal depletion under-counted copper- and gold-intensive products by 100×+. A last-resort cascade step takes the base element's resource CF (name before the first comma, resource medium only); a base the method doesn't characterize still resolves to nothing.

## Validation

- Test suite: 1545 examples, 0 failures — new specs for the volume bridge, the ore-grade fallback, and the ocean gate.
- Against the reference LCIA results (120 products, median deviation): minerals & metals 63% → **0.04%**, fossils ∞ (zero) → **0.33%**, water ×10⁹ → correct magnitude, freshwater eutrophication preserved at **0%**, human tox non-cancer → **9%** (JRC).

Note: the density bridge only activates when an `[[energy-densities]]` source is configured; existing deployments without one are unchanged.