### PR TITLE
LCIA: verbatim-name preference when unit-suffixed CF homonyms collide

### DIFF
--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -961,7 +961,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             stripStrategy $
                 M.fromListWith
                     preferBetter
-                    [ ((SR.NormName (nameKey cf mflow), Medium normMed, Subcompartment normSub), (mcfValue cf, mcfUnit cf, matchStrategy mflow))
+                    [ ((SR.NormName (nameKey cf mflow), Medium normMed, Subcompartment normSub), (mcfValue cf, mcfUnit cf, matchStrategy mflow, rawNameMatches cf mflow))
                     | (cf, mflow) <- mappings
                     , Nothing <- [mcfConsumerLocation cf]
                     , Just comp <- [mcfCompartment cf]
@@ -984,7 +984,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             stripStrategy $
                 M.fromListWith
                     preferBetter
-                    [ ((SR.NormName (nameKey cf mflow), Medium normMed), (mcfValue cf, mcfUnit cf, matchStrategy mflow))
+                    [ ((SR.NormName (nameKey cf mflow), Medium normMed), (mcfValue cf, mcfUnit cf, matchStrategy mflow, rawNameMatches cf mflow))
                     | (cf, mflow) <- mappings
                     , Nothing <- [mcfConsumerLocation cf]
                     , Just comp <- [mcfCompartment cf]
@@ -1002,7 +1002,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             stripStrategy $
                 M.fromListWith
                     preferBetter
-                    [ ((SR.NormName (nameKey cf mflow), Medium normMed), (mcfValue cf, mcfUnit cf, matchStrategy mflow))
+                    [ ((SR.NormName (nameKey cf mflow), Medium normMed), (mcfValue cf, mcfUnit cf, matchStrategy mflow, rawNameMatches cf mflow))
                     | (cf, mflow) <- mappings
                     , Nothing <- [mcfConsumerLocation cf]
                     , Just comp <- [mcfCompartment cf]
@@ -1104,7 +1104,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
         , mtRegionalActivityWeights = Nothing -- fill via 'fillRegionalActivityWeights' for regional fast path
         }
   where
-    stripStrategy = M.map (\(v, u, _) -> (v, u))
+    stripStrategy = M.map (\(v, u, _, _) -> (v, u))
 
     -- All subcompartments of a (name, medium) agree on the CF ⇒ the sub is
     -- irrelevant; return that common value. Disagreement ⇒ Nothing (ambiguous).
@@ -1162,11 +1162,23 @@ buildMethodTables methodFamily cmap energyDensities mappings =
                 (isUnspecifiedSub cfSubN && wildcardReachesSub methodFamily (Subcompartment flowSubN))
                     || cfSubN == flowSubN
 
-    preferBetter (v1, u1, s1) (v2, u2, s2)
-        | strategyPriority s1 < strategyPriority s2 = (v1, u1, s1)
-        | strategyPriority s1 > strategyPriority s2 = (v2, u2, s2)
-        | v1 >= v2 = (v1, u1, s1)
-        | otherwise = (v2, u2, s2)
+    -- Rank colliding CFs for one name key: better match strategy first, then a
+    -- CF whose own (raw) flow name equals the matched DB flow's name — when
+    -- normalization collapses unit-suffixed homonyms ("Gas, natural/kg" and
+    -- "Gas, natural/m3" both normalize to "gas, natural"), the row that matched
+    -- verbatim carries the unit the flow is actually declared in; the other
+    -- variant is dimensionally incompatible and would silently convert to 0.
+    -- Only then the historical higher-value tie-break.
+    preferBetter a@(v1, _, s1, r1) b@(v2, _, s2, r2)
+        | strategyPriority s1 < strategyPriority s2 = a
+        | strategyPriority s1 > strategyPriority s2 = b
+        | r1 /= r2 = if r1 then a else b
+        | v1 >= v2 = a
+        | otherwise = b
+
+    rawNameMatches cf mflow = case mflow of
+        Just (flow, _) -> T.toLower (T.strip (mcfFlowName cf)) == T.toLower (T.strip (bfName flow))
+        Nothing -> False
 
     matchStrategy mflow = case mflow of
         Just (_, s) -> s

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -399,6 +399,36 @@ spec = do
             -- 1000 g → 1.0 kg, * cf 2.0 = 2.0
             score `shouldBe` 2.0
 
+    describe "buildMethodTables unit-suffixed homonym collision" $ do
+        -- SimaPro-style methods carry one CF row per denominator unit for the
+        -- same substance ("Gas, natural/kg" = 43.1 MJ/kg and "Gas, natural/m3"
+        -- = 34.5 MJ/m3). normalizeName strips the suffix, so both rows collide
+        -- on one name key. The row whose raw name equals the flow's raw name
+        -- must win: the other variant is dimensionally incompatible with the
+        -- flow and would silently convert to 0.
+        let kgDef = UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0
+            m3Def = UnitDef [0, 3, 0, 0, 0, 0, 0, 0] 1.0
+            cfg =
+                UnitConfig
+                    { ucDimensionOrder = []
+                    , ucUnits = M.fromList [("kg", kgDef), ("m3", m3Def)]
+                    , ucOriginalKeys = M.fromList [("kg", "kg"), ("m3", "m3")]
+                    }
+            cfPerKg = (mkCFComp "Gas, natural/kg" "natural resource" "" 43.1){mcfUnit = "kg"}
+            cfPerM3 = (mkCFComp "Gas, natural/m3" "natural resource" "" 34.5){mcfUnit = "m3"}
+
+        it "the verbatim-named CF wins over the higher-valued homonym" $ do
+            fid <- nextRandom
+            uidM3 <- nextRandom
+            let flow = (mkFlow fid "Gas, natural/m3" "natural resource" (Just "in ground")){bfUnitId = uidM3}
+                mappings = [(cfPerKg, Just (flow, ByName)), (cfPerM3, Just (flow, ByName))]
+                unitDB = M.singleton uidM3 Unit{unitId = uidM3, unitName = "m3", unitSymbol = "m3", unitComment = ""}
+                flowDB = M.singleton fid flow
+                score ms = loScore (computeLCIAScoreFromTables cfg unitDB flowDB (M.singleton fid 2.0) (buildMethodTables OtherCFFamily M.empty M.empty ms))
+            score mappings `shouldBe` 2.0 * 34.5
+            -- insertion order must not matter
+            score (reverse mappings) `shouldBe` 2.0 * 34.5
+
     describe "inventoryContributions" $ do
         -- Regression: same fallback bug as computeLCIAScoreFromTables.
         it "yields zero contribution when unit conversion fails" $ do


### PR DESCRIPTION
SimaPro-style method exports carry one CF row per denominator unit for the same substance — `Gas, natural/kg` = 43.1 MJ/kg and `Gas, natural/m3` = 34.5 MJ/m3. `normalizeName` strips the unit suffix, so both rows collapse onto one name-table key, and `preferBetter`'s higher-value tie-break crowned the `/kg` row. Applied to a flow declared in m³, that CF is dimensionally incompatible and silently converts to 0: natural gas (and coal-mine gas) scored **zero** on "Resource use, fossils" for every SimaPro-adapted EF 3.1 export. On a gas-fired district-heat process the missing gas accounted for 100.0% of a 13× undercount.

The fix: at equal match-strategy priority, prefer the CF whose **raw flow name equals the matched flow's raw name** — when normalization collapses unit-suffixed homonyms, the verbatim row is the one denominated in the unit the flow is actually declared in. The historical higher-value tie-break is unchanged otherwise.

Validated against official reference LCIA results over an ecoinvent-derived database (92 scored products, median deviation on "Resource use, fossils"): SimaPro-adapted collection 21.6% → **1.04%** on the same method version, **0.12%** against the reference's own method export. Regression test added (collision resolves to the verbatim row regardless of insertion order); suite 1550 examples, 0 failures.