### PR TITLE
loader: accept a bare .csv method file; honest unsupported-type error

### DIFF
--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -2884,7 +2884,8 @@ loadMethodCollectionFromConfig mc = do
     let hasExt e = map toLower (takeExtension resolvedPath) == e
         isSingleJson = isFile && hasExt ".json"
         isSingleCsv = isFile && hasExt ".csv"
-    if not isDir && not isSingleJson && not isSingleCsv
+        isBareFile = isSingleJson || isSingleCsv
+    if not isDir && not isBareFile
         then
             return . Left $
                 if isFile
@@ -2892,7 +2893,7 @@ loadMethodCollectionFromConfig mc = do
                     else "Method path not found: " <> T.pack (mcPath mc)
         else do
             (dir, xmlFiles, csvFiles, jsonFiles) <-
-                if isSingleJson || isSingleCsv
+                if isBareFile
                     then
                         return
                             ( takeDirectory resolvedPath
@@ -2911,8 +2912,14 @@ loadMethodCollectionFromConfig mc = do
             if null xmlFiles && null csvFiles && null jsonFiles
                 then return $ Left $ "No method files (.xml/.csv/.json) found in: " <> T.pack dir
                 else do
-                    -- Try to find sibling flows/ directory for CF enrichment
-                    mFlowsDir <- FlowResolver.resolveFlowDirectory dir
+                    -- A bare method file (.csv/.json) carries its own CFs and has no
+                    -- ILCD flows/ sibling; only a real ILCD directory does. Scanning a
+                    -- coincidental neighbouring flows/ would parse unrelated flow XMLs
+                    -- and register foreign synonyms under this collection's name.
+                    mFlowsDir <-
+                        if isBareFile
+                            then return Nothing
+                            else FlowResolver.resolveFlowDirectory dir
                     flowInfo <- case mFlowsDir of
                         Nothing -> do
                             reportProgress Info "  No flows/ directory found, using shortDescription fallback"

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1296,6 +1296,10 @@ loadDatabaseFromConfig dbConfig synonymDB noCache =
         (fmap fst)
         (loadDatabaseFromConfigWithCrossDB dbConfig synonymDB UnitConversion.defaultUnitConfig noCache [] M.empty)
 
+-- | File extensions 'resolveDataPath' knows how to extract as archives.
+archiveExtensions :: [String]
+archiveExtensions = [".zip", ".7z", ".gz", ".xz"]
+
 {- | Resolve a database path: if it's an archive, extract it first.
 Extracts to "{archivePath}.d/" and finds the actual data directory inside.
 Plain files/directories pass through unchanged.
@@ -1311,7 +1315,7 @@ resolveDataPath path = do
                 then return path -- missing: let caller handle
                 else
                     let ext = map toLower (takeExtension path)
-                     in if ext `elem` [".zip", ".7z", ".gz", ".xz"]
+                     in if ext `elem` archiveExtensions
                             then extractAndFind path
                             else return path
   where
@@ -2881,16 +2885,21 @@ loadMethodCollectionFromConfig mc = do
     resolvedPath <- resolveDataPath (mcPath mc)
     isDir <- doesDirectoryExist resolvedPath
     isFile <- doesFileExist resolvedPath
-    let hasExt e = map toLower (takeExtension resolvedPath) == e
-        isSingleJson = isFile && hasExt ".json"
-        isSingleCsv = isFile && hasExt ".csv"
+    let ext = map toLower (takeExtension resolvedPath)
+        isSingleJson = isFile && ext == ".json"
+        isSingleCsv = isFile && ext == ".csv"
         isBareFile = isSingleJson || isSingleCsv
     if not isDir && not isBareFile
         then
             return . Left $
-                if isFile
-                    then "Unsupported method file type (expected a directory, archive, .csv, or .json): " <> T.pack (mcPath mc)
-                    else "Method path not found: " <> T.pack (mcPath mc)
+                if not isFile
+                    then "Method path not found: " <> T.pack (mcPath mc)
+                    else
+                        if ext `elem` archiveExtensions
+                            -- resolveDataPath returns the archive path unchanged when
+                            -- extraction failed, so an archive reaching here means that.
+                            then "Archive could not be extracted (see log above): " <> T.pack (mcPath mc)
+                            else "Unsupported method file type (expected a directory, archive, .csv, or .json): " <> T.pack (mcPath mc)
         else do
             (dir, xmlFiles, csvFiles, jsonFiles) <-
                 if isBareFile

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -2875,19 +2875,31 @@ and enriches CFs from ILCD flow XMLs when available.
 -}
 loadMethodCollectionFromConfig :: MethodConfig -> IO (Either Text (MethodCollection, M.Map UUID ILCDFlowInfo))
 loadMethodCollectionFromConfig mc = do
-    -- Resolve archives (ZIP → extracted directory). Single .json files (openLCA
-    -- JSON-LD ImpactCategory documents) are accepted directly without a wrapping
-    -- directory or archive.
+    -- Resolve archives (ZIP → extracted directory). Single .json (openLCA
+    -- JSON-LD ImpactCategory) and .csv (SimaPro method export) files are
+    -- accepted directly without a wrapping directory or archive.
     resolvedPath <- resolveDataPath (mcPath mc)
     isDir <- doesDirectoryExist resolvedPath
     isFile <- doesFileExist resolvedPath
-    let isSingleJson = isFile && map toLower (takeExtension resolvedPath) == ".json"
-    if not isDir && not isSingleJson
-        then return $ Left $ "Method path not found: " <> T.pack (mcPath mc)
+    let hasExt e = map toLower (takeExtension resolvedPath) == e
+        isSingleJson = isFile && hasExt ".json"
+        isSingleCsv = isFile && hasExt ".csv"
+    if not isDir && not isSingleJson && not isSingleCsv
+        then
+            return . Left $
+                if isFile
+                    then "Unsupported method file type (expected a directory, archive, .csv, or .json): " <> T.pack (mcPath mc)
+                    else "Method path not found: " <> T.pack (mcPath mc)
         else do
             (dir, xmlFiles, csvFiles, jsonFiles) <-
-                if isSingleJson
-                    then return (takeDirectory resolvedPath, [], [], [takeFileName resolvedPath])
+                if isSingleJson || isSingleCsv
+                    then
+                        return
+                            ( takeDirectory resolvedPath
+                            , []
+                            , [takeFileName resolvedPath | isSingleCsv]
+                            , [takeFileName resolvedPath | isSingleJson]
+                            )
                     else do
                         -- Find method directory (handles nested ILCD structures)
                         d <- findMethodDirectory resolvedPath

--- a/test/MethodUploadSpec.hs
+++ b/test/MethodUploadSpec.hs
@@ -154,6 +154,19 @@ spec = do
             case loaded of
                 Left err -> err `shouldSatisfy` T.isInfixOf "Method path not found"
                 Right _ -> expectationFailure "expected a Left for a missing path"
+
+        -- A .zip is a supported wrapper, so a failed extraction must not be
+        -- reported as an unsupported file type (that message even lists 'archive').
+        it "reports an unextractable archive as an extraction failure, not an unsupported type" $
+            withSystemTempDirectory "volca-method-load" $ \tmp -> do
+                let path = tmp </> "broken.zip"
+                -- Binary garbage: recognised as no known archive format, so extraction
+                -- fails and resolveDataPath hands the .zip path back unchanged.
+                BL.writeFile path (BL.pack [0, 1, 2, 3, 4, 5, 6, 7])
+                loaded <- loadMethodCollectionFromConfig (bareConfig path)
+                case loaded of
+                    Left err -> err `shouldSatisfy` T.isInfixOf "Archive could not be extracted"
+                    Right _ -> expectationFailure "expected a Left for an unextractable .zip"
   where
     bareConfig path =
         MethodConfig

--- a/test/MethodUploadSpec.hs
+++ b/test/MethodUploadSpec.hs
@@ -10,6 +10,7 @@ module MethodUploadSpec (spec) where
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as BLC
 import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
 import System.Directory (createDirectoryIfMissing, doesFileExist, listDirectory)
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
@@ -129,3 +130,39 @@ spec = do
                         methodName (head methods) `shouldBe` "Test category"
                         fromMaybe "" (methodMethodology (head methods))
                             `shouldBe` "openLCA JSON-LD"
+
+    describe "loadMethodCollectionFromConfig on a bare file path" $ do
+        -- SimaPro exports a method as a single .csv; requiring users to wrap it
+        -- in a zip or directory is pure friction, so the loader takes it as-is.
+        it "loads a single SimaPro method .csv directly" $ do
+            loaded <- loadMethodCollectionFromConfig (bareConfig "test/data/simapro_method.csv")
+            case loaded of
+                Left err -> expectationFailure ("load failed: " ++ show err)
+                Right (collection, _) -> mcMethods collection `shouldSatisfy` (not . null)
+
+        it "reports an existing file of unsupported type as such, not as missing" $
+            withSystemTempDirectory "volca-method-load" $ \tmp -> do
+                let path = tmp </> "not-a-method.txt"
+                BL.writeFile path (BLC.pack "hello")
+                loaded <- loadMethodCollectionFromConfig (bareConfig path)
+                case loaded of
+                    Left err -> err `shouldSatisfy` T.isInfixOf "Unsupported method file type"
+                    Right _ -> expectationFailure "expected a Left for a .txt file"
+
+        it "still reports a missing path as not found" $ do
+            loaded <- loadMethodCollectionFromConfig (bareConfig "test/data/no-such-method.csv")
+            case loaded of
+                Left err -> err `shouldSatisfy` T.isInfixOf "Method path not found"
+                Right _ -> expectationFailure "expected a Left for a missing path"
+  where
+    bareConfig path =
+        MethodConfig
+            { mcName = "bare"
+            , mcPath = path
+            , mcActive = False
+            , mcIsUploaded = False
+            , mcDescription = Nothing
+            , mcFormat = Nothing
+            , mcScoringSets = []
+            , mcGlobalMethods = []
+            }


### PR DESCRIPTION
SimaPro exports a method as a single `.csv` file, but `loadMethodCollectionFromConfig` only accepted a directory, an archive, or a bare `.json` (openLCA JSON-LD). Pointing the config at a bare `.csv` failed — and worse, with **"Method path not found"** even though the file exists, sending the user hunting for a path typo instead of zipping the file.

Two changes:
- a single `.csv` is accepted directly, symmetric with the single-`.json` branch;
- an existing file of unsupported type now reports *"Unsupported method file type (expected a directory, archive, .csv, or .json)"*, keeping "not found" for genuinely missing paths.

Found while loading a federal-agency SimaPro method export that had to be zipped first. Three new specs (bare .csv loads; unsupported type message; missing path message); suite 1552 examples, 0 failures.