### PR TITLE
fix(ecospold1): include subCategory in generated flow identity

### DIFF
--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -182,6 +182,10 @@ History of manual bumps:
      the product name). Activity record gained activityAllocationPercent
      and activityAllocationFormula. Old caches have stale per-product
      UUIDs and miss the allocation fields entirely.
+- 8: EcoSpold1 biosphere-flow UUID now includes the subCategory, so an
+     emission to two subcompartments (e.g. river + groundwater, long-term)
+     no longer collapses to one row scored at a single arbitrary
+     subcompartment's CF. Old caches merged those amounts under one flow.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.
@@ -189,7 +193,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeRep (Proxy :: Proxy Database))
-     in hi `xor` lo `xor` 7
+     in hi `xor` lo `xor` 8
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -42,19 +42,30 @@ Using UUID v5 (SHA1-based) with a custom namespace
 ecospold1Namespace :: UUID
 ecospold1Namespace = UUID5.generateNamed UUID5.namespaceURL (BS.unpack $ TE.encodeUtf8 "ecospold1.ecoinvent.org")
 
-{- | Generate deterministic UUID from dataset number and exchange number
-This ensures consistent UUIDs across multiple parses
+{- | Generate deterministic UUID from dataset number, exchange number, and the
+full compartment (category + subCategory).
+
+The subCategory is part of the key because it is part of a flow's identity: an
+emission of one substance to two subcompartments (e.g. a leachate to both
+@river@ and @groundwater, long-term@) is two distinct flows with distinct
+environmental fates and distinct characterization factors. Dropping subCategory
+collapsed them onto one UUID, so the matrix summed their amounts into a single
+row carrying whichever subcompartment label happened to win the flow-map merge —
+silently scoring gated groundwater/ocean mass at a surface-freshwater CF (or the
+reverse). Keying on the full compartment keeps each subcompartment a separate row
+scored at its own CF.
 -}
-generateFlowUUID :: Int -> Int -> Text -> Text -> UUID
-generateFlowUUID datasetNumber exchangeNumber flowName category =
+generateFlowUUID :: Int -> Int -> Text -> Text -> Text -> UUID
+generateFlowUUID datasetNumber exchangeNumber flowName category subCategory =
     let key =
-            T.pack (show datasetNumber)
-                <> ":"
-                <> T.pack (show exchangeNumber)
-                <> ":"
-                <> flowName
-                <> ":"
-                <> category
+            T.intercalate
+                ":"
+                [ T.pack (show datasetNumber)
+                , T.pack (show exchangeNumber)
+                , flowName
+                , category
+                , subCategory
+                ]
      in UUID5.generateNamed ecospold1Namespace (BS.unpack $ TE.encodeUtf8 key)
 
 -- | Generate deterministic UUID for unit from unit name
@@ -358,7 +369,7 @@ buildExchange datasetNum activityLoc edata
     | isBiosphere = (bioEx, ParsedBio bioFlow, unit)
     | otherwise = (techEx, ParsedTech techFlow, unit)
   where
-    flowId = generateFlowUUID datasetNum (exNumber edata) (exName edata) (exCategory edata)
+    flowId = generateFlowUUID datasetNum (exNumber edata) (exName edata) (exCategory edata) (exSubCategory edata)
     unitId = generateUnitUUID (exUnit edata)
     unit = Unit unitId (exUnit edata) (exUnit edata) ""
 

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -220,20 +220,24 @@ spec :: Spec
 spec = do
     describe "generateFlowUUID" $ do
         it "produces a stable UUID for known inputs" $
-            generateFlowUUID 42 1 "CO2" "air"
-                `shouldBe` read "4b869b57-e716-5e42-ae6f-0536cf112615"
+            generateFlowUUID 42 1 "CO2" "air" ""
+                `shouldBe` read "64b107af-792c-5a2a-874f-2a3323510af7"
 
         it "differs when dataset number changes" $
-            generateFlowUUID 1 1 "CO2" "air"
-                `shouldNotBe` generateFlowUUID 2 1 "CO2" "air"
+            generateFlowUUID 1 1 "CO2" "air" ""
+                `shouldNotBe` generateFlowUUID 2 1 "CO2" "air" ""
 
         it "differs when exchange number changes" $
-            generateFlowUUID 1 1 "CO2" "air"
-                `shouldNotBe` generateFlowUUID 1 2 "CO2" "air"
+            generateFlowUUID 1 1 "CO2" "air" ""
+                `shouldNotBe` generateFlowUUID 1 2 "CO2" "air" ""
 
         it "differs when flow name changes" $
-            generateFlowUUID 1 1 "CO2" "air"
-                `shouldNotBe` generateFlowUUID 1 1 "methane" "air"
+            generateFlowUUID 1 1 "CO2" "air" ""
+                `shouldNotBe` generateFlowUUID 1 1 "methane" "air" ""
+
+        it "differs when subcategory changes (river vs groundwater must not collapse)" $
+            generateFlowUUID 1 1 "Hydrogen sulfide" "water" "river"
+                `shouldNotBe` generateFlowUUID 1 1 "Hydrogen sulfide" "water" "groundwater, long-term"
 
     describe "generateUnitUUID" $ do
         it "produces a stable UUID for known inputs" $


### PR DESCRIPTION
## Problem

The synthetic UUID for EcoSpold 1 flows was derived from (dataset, exchange number, name, category) only — the subcompartment was ignored. Two biosphere exchanges of the same substance differing only by subcompartment collapsed into a single flow: quantities summed, compartment label taken from whichever entry won the merge.

Concrete case: a dataset emitting hydrogen sulfide both to *water/groundwater, long-term* (6.78e-7 kg) and to *water/river* (9.63e-9 kg) ends up with one flow labelled *river* carrying 6.88e-7 kg — the exact sum. LCIA then scores the whole mass at the surface-water CF, while most of it should fall under the gated long-term-groundwater treatment (USEtox convention: no characterization). This inflates every USEtox-family category (freshwater ecotoxicity, human toxicity) on any EcoSpold 1 database, independent of the method used.

## Fix

Include subCategory in the flow-identity hash so subcompartment-distinct exchanges stay distinct, each keeping its own compartment and CF resolution. The cache schema salt is bumped so existing EcoSpold 1 caches rebuild with corrected identities.

Measured on a 92-product sample of an EcoSpold 1 database against the publisher's official SimaPro results: median divergence on freshwater-ecotoxicity inorganics drops from ~82% to ~25%; previously-exact categories (climate change, eutrophication, particulate matter) are unchanged at 0%.

## Tests

New regression test locks that flows differing only by subcompartment get distinct UUIDs; the stable-UUID fixture is updated for the new hash input. Full suite: 1545 examples, 0 failures.