### PR TITLE
data(flows): treat an unspecified chromium emission as trivalent

### DIFF
--- a/data/flows.csv
+++ b/data/flows.csv
@@ -282,7 +282,7 @@ Chlorosulfonic acid,"chlorosulphuric acid, chloridosulfonic acid, sulfuric chlor
 Chlorothalonil,tetrachloroisophthalonitrile
 Chlorotoluron,Chlortoluron
 Chromium,"Chromium, in ground"
-Chromium,"Chromium, ion"
+Chromium,"Chromium (III)",,,EF 3.1 characterizes an unspecified chromium emission as trivalent; the hexavalent CF applies only to an explicit Chromium VI flow
 Chrysotile,"Chrysotile, in ground"
 Cinnabar,"Cinnabar, in ground"
 "Clay, bentonite","Clay, bentonite, in ground"


### PR DESCRIPTION
## What

An unspecified elemental `Chromium` emission is trivalent by convention; only an explicit `Chromium VI` flow carries the carcinogenic hexavalent characterization factor. The curated flow bridge previously routed elemental `Chromium` to `Chromium, ion` (= Cr VI), so every unspecified chromium emission was scored at the hexavalent cancer CF.

This re-targets the bridge to `Chromium (III)`.

## Why it matters

Against the BAFU EF 3.1 reference results, this over-characterized *Human toxicity, cancer - inorganics* by ~57% (median across products): chromium alone was ~49% of that category's score, almost all of it from unspecified emissions wrongly treated as hexavalent.

The `Chromium (III)` target is not a silent zero — the method carries real trivalent factors (≈0 for cancer, but non-zero for ecotoxicity), so the flow stays characterized, just correctly.

## Effect (validated on the BAFU 2026 reference)

- Human toxicity, cancer - inorganics: **57% → 1.4%** median deviation
- Human toxicity, cancer (total): **23% → 0.7%**
- No change to ecotoxicity (chromium is a ~1% contributor there), to non-cancer, or to resource use (the `Chromium, in ground` resource bridge is untouched)
- Registry lint green (≤1 CAS per class, valid check digits); full suite 1549/0