### PR TITLE
feat(lcia): optional exclusion of long-term emissions from scoring

### DIFF
--- a/src/API/BatchImpacts.hs
+++ b/src/API/BatchImpacts.hs
@@ -29,6 +29,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Database.Manager (DatabaseManager (..))
+import Method.Mapping (LongTermMode)
 import Servant (ServerError (..))
 import qualified Servant
 
@@ -76,8 +77,10 @@ runActivityLCIABatch ::
     Text ->
     -- | optional what-if supplier substitutions
     Maybe SubstitutionRequest ->
+    -- | whether to keep or drop delayed long-term emissions
+    LongTermMode ->
     IO (Either BatchError LCIABatchResult)
-runActivityLCIABatch dbm dbName pid coll mSub = do
+runActivityLCIABatch dbm dbName pid coll mSub ltMode = do
     let env =
             AppEnv
                 { aeDbManager = dbm
@@ -86,7 +89,7 @@ runActivityLCIABatch dbm dbName pid coll mSub = do
                 , aeHostingConfig = Nothing
                 , aeClassificationPresets = []
                 }
-    res <- Servant.runHandler (runApp env (activityLCIABatchH dbName pid coll mSub))
+    res <- Servant.runHandler (runApp env (activityLCIABatchH dbName pid coll mSub ltMode))
     case res of
         Right lbr -> pure (Right lbr)
         Left se -> Left <$> translateErrorIO dbm se

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -41,7 +41,7 @@ import API.Types (ActivityForAPI (..), ActivityInfo (..), ClassificationSystem (
 import Control.Monad (unless)
 import qualified Data.List as L
 import Matrix (applyBiosphereMatrix)
-import Method.Mapping (LCIAOutcome (..), MappingStats (..), SimilarCF (..), SimilarReason (..), UncharacterizedFlow (..), computeLCIAScoreAuto, computeLCIAScoreFromTables, computeMappingStats, defaultUncharacterizedOpts, excludeLongTermFlows, inventoryContributions, longTermModeFromExclude)
+import Method.Mapping (LCIAOutcome (..), MappingStats (..), SimilarCF (..), SimilarReason (..), UncharacterizedFlow (..), applyLongTermMode, computeLCIAScoreAuto, computeLCIAScoreFromTables, computeMappingStats, defaultUncharacterizedOpts, inventoryContributions, longTermModeFromExclude)
 import qualified Method.Mapping as Mapping
 import Method.Types (FlowDirection (..), Method (..), MethodCF (..), MethodCollection (..), ScoringSet (..))
 import Network.HTTP.Types.Header (hAccept, hHost)
@@ -968,10 +968,8 @@ runImpactsRequest dbManager args req = do
                             (ldSharedSolver ld)
                             (raPid ra)
                             subs
-    let inventory =
-            if fromMaybe False (boolArg "exclude_long_term" args)
-                then excludeLongTermFlows mFlows solvedInventory
-                else solvedInventory
+    let ltMode = longTermModeFromExclude (fromMaybe False (boolArg "exclude_long_term" args))
+        inventory = applyLongTermMode mFlows ltMode solvedInventory
     mappings <- liftIO $ DM.mapMethodToFlowsCached dbManager dbName collection db method
     tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName collection db method
     let stats = computeMappingStats mappings
@@ -1649,7 +1647,8 @@ callGetContributingFlows dbManager mBaseUrl rid args =
                     dbName
                     (ldSharedSolver ld)
                     (raPid ra)
-        let inventory = SharedSolver.csInventory sol
+        let ltMode = longTermModeFromExclude (fromMaybe False (boolArg "exclude_long_term" args))
+            inventory = applyLongTermMode mFlows ltMode (SharedSolver.csInventory sol)
         tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName collection db method
         let outcome = computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables
             score = loScore outcome
@@ -1724,6 +1723,7 @@ callGetContributingActivities dbManager mBaseUrl rid args =
             collection = lrCollection req
             ra = lrResolved req
             lim = fromMaybe 10 (intArg "limit" args)
+            ltMode = longTermModeFromExclude (fromMaybe False (boolArg "exclude_long_term" args))
         except $ ensureLinked dbName "computing contributions" db
         unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
         (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
@@ -1741,6 +1741,7 @@ callGetContributingActivities dbManager mBaseUrl rid args =
                     (ldSharedSolver ld)
                     (raPid ra)
                     tables
+                    ltMode
         let score = sum (M.elems contributions)
             sorted = L.sortOn (\(_, c) -> negate (abs c)) (M.toList contributions)
             top = take lim sorted

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -41,7 +41,7 @@ import API.Types (ActivityForAPI (..), ActivityInfo (..), ClassificationSystem (
 import Control.Monad (unless)
 import qualified Data.List as L
 import Matrix (applyBiosphereMatrix)
-import Method.Mapping (LCIAOutcome (..), MappingStats (..), SimilarCF (..), SimilarReason (..), UncharacterizedFlow (..), computeLCIAScoreAuto, computeLCIAScoreFromTables, computeMappingStats, defaultUncharacterizedOpts, inventoryContributions)
+import Method.Mapping (LCIAOutcome (..), MappingStats (..), SimilarCF (..), SimilarReason (..), UncharacterizedFlow (..), computeLCIAScoreAuto, computeLCIAScoreFromTables, computeMappingStats, defaultUncharacterizedOpts, excludeLongTermFlows, inventoryContributions, longTermModeFromExclude)
 import qualified Method.Mapping as Mapping
 import Method.Types (FlowDirection (..), Method (..), MethodCF (..), MethodCollection (..), ScoringSet (..))
 import Network.HTTP.Types.Header (hAccept, hHost)
@@ -954,7 +954,7 @@ runImpactsRequest dbManager args req = do
     subs <- except (parseArrayArg "substitutions" Nothing args :: Either Text [Substitution])
     unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
     (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
-    inventory <-
+    solvedInventory <-
         ExceptT $
             if null subs
                 then fmap (fmap SharedSolver.csInventory) (computeInventoryMatrixWithDepsCached unitCfg (DM.mkDepSolverLookup dbManager) db dbName (ldSharedSolver ld) (raPid ra))
@@ -968,6 +968,10 @@ runImpactsRequest dbManager args req = do
                             (ldSharedSolver ld)
                             (raPid ra)
                             subs
+    let inventory =
+            if fromMaybe False (boolArg "exclude_long_term" args)
+                then excludeLongTermFlows mFlows solvedInventory
+                else solvedInventory
     mappings <- liftIO $ DM.mapMethodToFlowsCached dbManager dbName collection db method
     tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName collection db method
     let stats = computeMappingStats mappings
@@ -1830,7 +1834,8 @@ callScoreActivity dbManager mBaseUrl rid args =
         subs <- except (parseArrayArg "substitutions" Nothing args :: Either Text [Substitution])
         wantedSets <- except (parseArrayArg "scoring_sets" Nothing args :: Either Text [Text])
         let mSub = if null subs then Nothing else Just SubstitutionRequest{srSubstitutions = subs}
-        res <- liftIO $ BI.runActivityLCIABatch dbManager dbName pidText coll mSub
+            ltMode = longTermModeFromExclude (fromMaybe False (boolArg "exclude_long_term" args))
+        res <- liftIO $ BI.runActivityLCIABatch dbManager dbName pidText coll mSub ltMode
         case res of
             Left e -> throwE (batchErrorMsg e)
             Right lbr -> do

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -668,6 +668,7 @@ params r = case r of
         , Param "method_id" "string" Required "Method UUID for the impact category"
         , pCollection
         , pLimit "Max flows to return, sorted by contribution (default 20)"
+        , pExcludeLongTerm
         , Param "include_diagnostics" "boolean" Optional "When true, surface uncharacterized inventory flows above 0.1% of total |qty|, each with up to 3 candidate similar CFs (PubChem-expanded Jaccard + CAS bridge)."
         ]
     GetContributingActivities ->
@@ -676,6 +677,7 @@ params r = case r of
         , Param "method_id" "string" Required "Method UUID for the impact category"
         , pCollection
         , pLimit "Max processes to return, sorted by contribution (default 10)"
+        , pExcludeLongTerm
         ]
     ListGeographies ->
         [ pDatabase

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -490,6 +490,23 @@ pSubstitutions =
         \PIDs can be bare (root DB) or qualified as dbName::pid (cross-DB). \
         \When empty or absent, the call behaves as a plain GET."
 
+{- | Optional switch to drop delayed long-term emissions before scoring.
+Shared by 'get_impacts' and 'score_activity'. Long-term flows are always
+emissions (never resources), so excluding them never touches regionalized
+water/land categories.
+-}
+pExcludeLongTerm :: Param
+pExcludeLongTerm =
+    Param
+        "exclude_long_term"
+        "boolean"
+        Optional
+        "When true, drop delayed long-term (> 100 yr) emissions before \
+        \characterization — the score is computed as if those emissions were \
+        \out of scope. Long-term flows are emissions (never resources), so \
+        \regionalized water/land categories are unaffected. Default false \
+        \(keep them, per the ecoinvent/EF convention)."
+
 {- | The 'scoring_sets' parameter, shared by 'score_activity' and
 'score_activities' but with slightly different semantics:
 
@@ -609,6 +626,7 @@ params r = case r of
         , pCollection
         , Param "top_flows" "integer" Optional "Number of top contributing flows to return (default 5)"
         , pSubstitutions
+        , pExcludeLongTerm
         , Param "include_diagnostics" "boolean" Optional "When true, surface uncharacterized inventory flows above 0.1% of total |qty|, each with up to 3 candidate similar CFs (PubChem-expanded Jaccard + CAS bridge). Lets reviewers tell genuine method gaps from mapping bugs."
         ]
     ComputeSensitivity ->
@@ -701,6 +719,7 @@ params r = case r of
         , pProcessId
         , Param "collection" "string" Required "Method collection name (use list_methods to discover)"
         , pSubstitutions
+        , pExcludeLongTerm
         , pScoringSetsFilter
         ]
     ScoreActivities ->

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -42,7 +42,7 @@ import qualified Expr
 import GHC.Generics
 import qualified GHC.Stats
 import Matrix (Inventory, Vector)
-import Method.Mapping (LCIAOutcome (..), LongTermMode (..), MappingStats (..), MatchStrategy (..), MethodTables (..), computeLCIAScoreFromTables, computeLCIAScoreSetFromTables, computeMappingStats, excludeLongTermFlows, inventoryContributions, longTermModeFromExclude, lookupCFForFlow, strategyPriority, sumRegionalizedLCIAScoreCrossDB)
+import Method.Mapping (LCIAOutcome (..), LongTermMode (..), MappingStats (..), MatchStrategy (..), MethodTables (..), applyLongTermMode, computeLCIAScoreFromTables, computeLCIAScoreSetFromTables, computeMappingStats, inventoryContributions, longTermModeFromExclude, lookupCFForFlow, strategyPriority, sumRegionalizedLCIAScoreCrossDB)
 import qualified Method.Mapping
 import Method.Types (DamageCategory (..), Method (..), MethodCF (..), MethodCollection (..), NormWeightSet (..), ScoringEvaluation (..), ScoringSet (..), computeFormulaScores)
 import qualified Method.Types as MT
@@ -101,8 +101,8 @@ type LCAAPI =
                 :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "consumers" :> QueryParam "name" Text :> QueryParam "location" Text :> QueryParam "product" Text :> QueryParam "preset" Text :> QueryParams "classification" Text :> QueryParams "classification-value" Text :> QueryParams "classification-mode" Text :> QueryParam "limit" Int :> QueryParam "offset" Int :> QueryParam "max-depth" Int :> QueryParam "sort" Text :> QueryParam "order" Text :> QueryParam "include-edges" Bool :> Get '[JSON] ConsumersResponse
                 :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "path-to" :> QueryParam "target" Text :> Get '[JSON] Value
                 :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "analyze" :> Capture "analyzerName" Text :> Get '[JSON] Value
-                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "contributing-flows" :> Capture "collection" Text :> Capture "methodId" Text :> QueryParam "limit" Int :> Get '[JSON] ContributingFlowsResult
-                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "contributing-activities" :> Capture "collection" Text :> Capture "methodId" Text :> QueryParam "limit" Int :> Get '[JSON] ContributingActivitiesResult
+                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "contributing-flows" :> Capture "collection" Text :> Capture "methodId" Text :> QueryParam "limit" Int :> QueryParam "exclude-long-term" Bool :> Get '[JSON] ContributingFlowsResult
+                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "contributing-activities" :> Capture "collection" Text :> Capture "methodId" Text :> QueryParam "limit" Int :> QueryParam "exclude-long-term" Bool :> Get '[JSON] ContributingActivitiesResult
                 :<|> "db" :> Capture "dbName" Text :> "flow" :> Capture "flowId" Text :> Get '[JSON] FlowDetail
                 :<|> "db" :> Capture "dbName" Text :> "flow" :> Capture "flowId" Text :> "activities" :> Get '[JSON] [ActivitySummary]
                 :<|> "methods" :> Get '[JSON] [MethodSummary]
@@ -547,7 +547,7 @@ applyLongTermToSolution :: DatabaseManager -> LongTermMode -> SharedSolver.Cross
 applyLongTermToSolution _ IncludeLongTerm sol = pure sol
 applyLongTermToSolution dbManager ExcludeLongTerm sol = do
     (mFlows, _) <- DM.getMergedFlowMetadata dbManager
-    pure sol{SharedSolver.csInventory = excludeLongTermFlows mFlows (SharedSolver.csInventory sol)}
+    pure sol{SharedSolver.csInventory = applyLongTermMode mFlows ExcludeLongTerm (SharedSolver.csInventory sol)}
 
 {- | Look up MethodSetTables for every (DB, scaling) pair in the cross-DB
 solution. Cache-keyed by (dbName, methods).
@@ -1628,14 +1628,15 @@ getActivityAnalyze dbName processIdText analyzerName = do
                                 }
                     liftIO $ ahAnalyze analyzer ctx
 
-getContributingFlows :: Text -> Text -> Text -> Text -> Maybe Int -> AppM ContributingFlowsResult
-getContributingFlows dbName processIdText collectionName methodIdText limitParam =
+getContributingFlows :: Text -> Text -> Text -> Text -> Maybe Int -> Maybe Bool -> AppM ContributingFlowsResult
+getContributingFlows dbName processIdText collectionName methodIdText limitParam mExcludeLT =
     withActivityAndMethod dbName collectionName processIdText methodIdText $ \db sharedSolver actProcessId _ method -> do
         dbManager <- asks aeDbManager
         let lim = fromMaybe 20 limitParam
+            ltMode = longTermModeFromExclude (fromMaybe False mExcludeLT)
         unitCfg <- liftIO $ getMergedUnitConfig dbManager
         (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
-        inventory <- inventoryWithDeps dbName db sharedSolver actProcessId
+        inventory <- applyLongTermMode mFlows ltMode <$> inventoryWithDeps dbName db sharedSolver actProcessId
         tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName collectionName db method
         let score = loScore (computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables)
             (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
@@ -1669,11 +1670,12 @@ getContributingFlows dbName processIdText collectionName methodIdText limitParam
                 , cfrTopFlows = topFlows
                 }
 
-getContributingActivities :: Text -> Text -> Text -> Text -> Maybe Int -> AppM ContributingActivitiesResult
-getContributingActivities dbName processIdText collectionName methodIdText limitParam =
+getContributingActivities :: Text -> Text -> Text -> Text -> Maybe Int -> Maybe Bool -> AppM ContributingActivitiesResult
+getContributingActivities dbName processIdText collectionName methodIdText limitParam mExcludeLT =
     withActivityAndMethod dbName collectionName processIdText methodIdText $ \db sharedSolver actProcessId _ method -> do
         dbManager <- asks aeDbManager
         let lim = fromMaybe 10 limitParam
+            ltMode = longTermModeFromExclude (fromMaybe False mExcludeLT)
         requireFullyLinked dbName db
         unitCfg <- liftIO $ getMergedUnitConfig dbManager
         (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
@@ -1690,6 +1692,7 @@ getContributingActivities dbName processIdText collectionName methodIdText limit
                     sharedSolver
                     actProcessId
                     tables
+                    ltMode
         case eContribs of
             Left err -> throwError err422{errBody = BSL.fromStrict $ T.encodeUtf8 err}
             Right contributions -> do

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -42,7 +42,7 @@ import qualified Expr
 import GHC.Generics
 import qualified GHC.Stats
 import Matrix (Inventory, Vector)
-import Method.Mapping (LCIAOutcome (..), MappingStats (..), MatchStrategy (..), MethodTables (..), computeLCIAScoreFromTables, computeLCIAScoreSetFromTables, computeMappingStats, inventoryContributions, lookupCFForFlow, strategyPriority, sumRegionalizedLCIAScoreCrossDB)
+import Method.Mapping (LCIAOutcome (..), LongTermMode (..), MappingStats (..), MatchStrategy (..), MethodTables (..), computeLCIAScoreFromTables, computeLCIAScoreSetFromTables, computeMappingStats, excludeLongTermFlows, inventoryContributions, longTermModeFromExclude, lookupCFForFlow, strategyPriority, sumRegionalizedLCIAScoreCrossDB)
 import qualified Method.Mapping
 import Method.Types (DamageCategory (..), Method (..), MethodCF (..), MethodCollection (..), NormWeightSet (..), ScoringEvaluation (..), ScoringSet (..), computeFormulaScores)
 import qualified Method.Types as MT
@@ -91,8 +91,8 @@ type LCAAPI =
                     :> QueryParam "group_by" Text
                     :> QueryParam "aggregate" Text
                     :> Get '[JSON] Aggregation
-                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "impacts" :> Capture "collection" Text :> Get '[JSON] LCIABatchResult
-                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "impacts" :> Capture "collection" Text :> ReqBody '[JSON] SubstitutionRequest :> Post '[JSON] LCIABatchResult
+                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "impacts" :> Capture "collection" Text :> QueryParam "exclude-long-term" Bool :> Get '[JSON] LCIABatchResult
+                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "impacts" :> Capture "collection" Text :> QueryParam "exclude-long-term" Bool :> ReqBody '[JSON] SubstitutionRequest :> Post '[JSON] LCIABatchResult
                 :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "impacts" :> Capture "collection" Text :> Capture "methodId" Text :> QueryParam "top-flows" Int :> Get '[JSON] LCIAResult
                 :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "impacts" :> Capture "collection" Text :> Capture "methodId" Text :> ReqBody '[JSON] SubstitutionRequest :> Post '[JSON] LCIAResult
                 :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "sensitivity" :> Capture "collection" Text :> Capture "methodId" Text :> ReqBody '[JSON] SensitivityRequest :> Post '[JSON] SensitivityResponse
@@ -538,6 +538,17 @@ crossDBSolutionFor dbName db solver pid mSub = case mSub of
                     (srSubstitutions subReq)
         either throwServiceError pure eSol
 
+{- | Apply the request's long-term policy to a freshly solved inventory. Drops
+the delayed long-term emission flows when excluding, and is a no-op (with no
+extra work) when including. Every downstream scoring path reads @csInventory@,
+so filtering here once keeps scores and top-contributor breakdowns consistent.
+-}
+applyLongTermToSolution :: DatabaseManager -> LongTermMode -> SharedSolver.CrossDBSolution -> IO SharedSolver.CrossDBSolution
+applyLongTermToSolution _ IncludeLongTerm sol = pure sol
+applyLongTermToSolution dbManager ExcludeLongTerm sol = do
+    (mFlows, _) <- DM.getMergedFlowMetadata dbManager
+    pure sol{SharedSolver.csInventory = excludeLongTermFlows mFlows (SharedSolver.csInventory sol)}
+
 {- | Look up MethodSetTables for every (DB, scaling) pair in the cross-DB
 solution. Cache-keyed by (dbName, methods).
 -}
@@ -789,8 +800,9 @@ activityLCIABatchH ::
     Text ->
     Text ->
     Maybe SubstitutionRequest ->
+    LongTermMode ->
     AppM LCIABatchResult
-activityLCIABatchH dbName processIdText collectionName mSub = do
+activityLCIABatchH dbName processIdText collectionName mSub ltMode = do
     dbManager <- asks aeDbManager
     (db, sharedSolver) <- requireDatabaseByName dbName
     (actProcessId, activity) <- resolveOrThrow db processIdText
@@ -798,7 +810,7 @@ activityLCIABatchH dbName processIdText collectionName mSub = do
     let dcLookup = M.fromList [(subName, dcName dc) | dc <- damageCats, (subName, _) <- dcImpacts dc]
         mNW = case nwSets of (nw : _) -> Just nw; [] -> Nothing
     t0 <- liftIO getCurrentTime
-    sol <- crossDBSolutionFor dbName db sharedSolver actProcessId mSub
+    sol <- crossDBSolutionFor dbName db sharedSolver actProcessId mSub >>= liftIO . applyLongTermToSolution dbManager ltMode
     t1 <- liftIO getCurrentTime
     let inventory = SharedSolver.csInventory sol
         !invSize = M.size inventory
@@ -1499,13 +1511,13 @@ postActivitySensitivity dbName processIdText collectionName methodIdText senReq 
             mapConcurrently (buildEntry baselineLcia) perResults
     pure SensitivityResponse{srBaseline = baselineLcia, srPerturbed = perturbed}
 
-getActivityLCIABatch :: Text -> Text -> Text -> AppM LCIABatchResult
-getActivityLCIABatch dbName processIdText collectionName =
-    activityLCIABatchH dbName processIdText collectionName Nothing
+getActivityLCIABatch :: Text -> Text -> Text -> Maybe Bool -> AppM LCIABatchResult
+getActivityLCIABatch dbName processIdText collectionName mExcludeLT =
+    activityLCIABatchH dbName processIdText collectionName Nothing (longTermModeFromExclude (fromMaybe False mExcludeLT))
 
-postActivityLCIABatch :: Text -> Text -> Text -> SubstitutionRequest -> AppM LCIABatchResult
-postActivityLCIABatch dbName processIdText collectionName subReq =
-    activityLCIABatchH dbName processIdText collectionName (Just subReq)
+postActivityLCIABatch :: Text -> Text -> Text -> Maybe Bool -> SubstitutionRequest -> AppM LCIABatchResult
+postActivityLCIABatch dbName processIdText collectionName mExcludeLT subReq =
+    activityLCIABatchH dbName processIdText collectionName (Just subReq) (longTermModeFromExclude (fromMaybe False mExcludeLT))
 
 postActivityInventory :: Text -> Text -> SubstitutionRequest -> AppM InventoryExport
 postActivityInventory dbName processIdText subReq = activityInventoryCore dbName processIdText (Just subReq)

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -36,6 +36,9 @@ module Method.Mapping (
     RegionalActivityWeights (..),
     computeLCIAScore,
     computeLCIAScoreFromTables,
+    LongTermMode (..),
+    longTermModeFromExclude,
+    excludeLongTermFlows,
     computeLCIAScoreAuto,
     computeRegionalizedLCIAScore,
     sumRegionalizedLCIAScoreCrossDB,
@@ -1825,6 +1828,32 @@ isLongTermUnspecifiedSub s =
             . T.filter (`notElem` ("()" :: String))
             . T.replace "long term" ""
             . T.replace "long-term" ""
+
+{- | Whether delayed long-term (> 100 yr) biosphere emissions count toward the
+impact score. 'IncludeLongTerm' is the default and preserves the standard
+ecoinvent/EF convention; 'ExcludeLongTerm' characterizes the process as if the
+delayed emissions were out of scope.
+-}
+data LongTermMode = IncludeLongTerm | ExcludeLongTerm
+    deriving (Eq, Show)
+
+{- | Read a request/tool @exclude@ flag into a 'LongTermMode'. Absent or false
+means keep the delayed emissions (the convention default).
+-}
+longTermModeFromExclude :: Bool -> LongTermMode
+longTermModeFromExclude excl = if excl then ExcludeLongTerm else IncludeLongTerm
+
+{- | Drop delayed long-term biosphere emissions from an inventory before
+characterization. A flow is long-term when its sub-compartment carries the
+"long-term" marker ('isLongTermSub'). These flows are always emissions, never
+resources, so this never removes a regionalized resource flow (water use / land
+use) — those categories are computed from a separate path and stay untouched.
+-}
+excludeLongTermFlows :: BioFlowDB -> Inventory -> Inventory
+excludeLongTermFlows flowDB = M.filterWithKey (\fid _ -> not (isLongTermFlow fid))
+  where
+    isLongTermFlow = maybe False subIsLongTerm . (`M.lookup` flowDB)
+    subIsLongTerm = maybe False (isLongTermSub . Subcompartment . T.toLower) . VT.bfCompartmentSub
 
 {- | The @(normalized medium, subcompartment)@ a database flow resolves to after
 compartment normalization. Shared by the name/CAS read path

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -39,6 +39,8 @@ module Method.Mapping (
     LongTermMode (..),
     longTermModeFromExclude,
     excludeLongTermFlows,
+    applyLongTermMode,
+    isLongTermFlow,
     computeLCIAScoreAuto,
     computeRegionalizedLCIAScore,
     sumRegionalizedLCIAScoreCrossDB,
@@ -1843,17 +1845,33 @@ means keep the delayed emissions (the convention default).
 longTermModeFromExclude :: Bool -> LongTermMode
 longTermModeFromExclude excl = if excl then ExcludeLongTerm else IncludeLongTerm
 
+{- | Whether a biosphere flow is a delayed long-term emission: it is known to the
+FlowDB and its sub-compartment carries the "long-term" marker ('isLongTermSub').
+An unknown UUID is never treated as long-term (absence of evidence is not
+evidence). Shared by every exclusion path so they all agree on what "long-term"
+means.
+-}
+isLongTermFlow :: BioFlowDB -> UUID -> Bool
+isLongTermFlow flowDB = maybe False subIsLongTerm . (`M.lookup` flowDB)
+  where
+    subIsLongTerm = maybe False (isLongTermSub . Subcompartment . T.toLower) . VT.bfCompartmentSub
+
 {- | Drop delayed long-term biosphere emissions from an inventory before
-characterization. A flow is long-term when its sub-compartment carries the
-"long-term" marker ('isLongTermSub'). These flows are always emissions, never
-resources, so this never removes a regionalized resource flow (water use / land
-use) — those categories are computed from a separate path and stay untouched.
+characterization. These flows are always emissions, never resources, so this
+never removes a regionalized resource flow (water use / land use) — those
+categories are computed from a separate path and stay untouched.
 -}
 excludeLongTermFlows :: BioFlowDB -> Inventory -> Inventory
-excludeLongTermFlows flowDB = M.filterWithKey (\fid _ -> not (isLongTermFlow fid))
-  where
-    isLongTermFlow = maybe False subIsLongTerm . (`M.lookup` flowDB)
-    subIsLongTerm = maybe False (isLongTermSub . Subcompartment . T.toLower) . VT.bfCompartmentSub
+excludeLongTermFlows flowDB = M.filterWithKey (\fid _ -> not (isLongTermFlow flowDB fid))
+
+{- | Apply a 'LongTermMode' to an inventory. 'IncludeLongTerm' is the identity
+(no extra work); 'ExcludeLongTerm' drops the delayed long-term emissions. This
+is the single entry point every score path uses so include/exclude stays
+consistent across the batch, single-method, and contribution surfaces.
+-}
+applyLongTermMode :: BioFlowDB -> LongTermMode -> Inventory -> Inventory
+applyLongTermMode _ IncludeLongTerm = id
+applyLongTermMode flowDB ExcludeLongTerm = excludeLongTermFlows flowDB
 
 {- | The @(normalized medium, subcompartment)@ a database flow resolves to after
 compartment normalization. Shared by the name/CAS read path
@@ -2009,11 +2027,15 @@ processContributionsFromTables ::
     UnitConfig ->
     UnitDB ->
     BioFlowDB ->
+    {- | long-term emission policy: 'ExcludeLongTerm' zeroes the delayed flows so
+    per-activity contributions match a score computed the same way
+    -}
+    LongTermMode ->
     Database ->
     Vector ->
     MethodTables ->
     M.Map ProcessId Double
-processContributionsFromTables unitConfig unitDB flowDB db scalingVec tables =
+processContributionsFromTables unitConfig unitDB flowDB ltMode db scalingVec tables =
     U.foldl' step M.empty (dbBiosphereTriples db)
   where
     actIdx = dbActivityIndex db
@@ -2021,18 +2043,26 @@ processContributionsFromTables unitConfig unitDB flowDB db scalingVec tables =
     nFlows = V.length bioFlows
     nActs = V.length actIdx
 
+    excluded = case ltMode of
+        IncludeLongTerm -> const False
+        ExcludeLongTerm -> isLongTermFlow flowDB
+
     -- Precompute the effective CF (CF value × flow→CF unit conversion factor)
     -- per biosphere-matrix row so the triple loop becomes pure arithmetic.
-    -- O(|bioFlows|) once, vs O(|triples| × map-lookups) before.
+    -- O(|bioFlows|) once, vs O(|triples| × map-lookups) before. A long-term
+    -- flow gets 0 under 'ExcludeLongTerm', dropping it exactly as the inventory
+    -- pre-filter would.
     effectiveCF :: U.Vector Double
     effectiveCF = U.generate nFlows $ \i ->
         let flowUUID = bioFlows V.! i
             mflow = M.lookup flowUUID flowDB
-         in case mflow of
-                Nothing -> 0
-                Just _ -> case lookupCascadeCF tables flowDB flowUUID of
+         in if excluded flowUUID
+                then 0
+                else case mflow of
                     Nothing -> 0
-                    Just cfTuple -> convertAndMultiply unitConfig unitDB (mtEnergyDensities tables) mflow cfTuple 1.0
+                    Just _ -> case lookupCascadeCF tables flowDB flowUUID of
+                        Nothing -> 0
+                        Just cfTuple -> convertAndMultiply unitConfig unitDB (mtEnergyDensities tables) mflow cfTuple 1.0
 
     -- Invert dbActivityIndex (pid -> col) into (col -> pid) as an unboxed
     -- vector for O(1) per-triple lookup. Assumes matrix cols are dense in

--- a/src/SharedSolver.hs
+++ b/src/SharedSolver.hs
@@ -64,7 +64,7 @@ import Matrix (
     solveSparseLinearSystemWithFactorization,
     solveSparseLinearSystemWithFactorizationMulti,
  )
-import Method.Mapping (MethodTables, processContributionsFromTables)
+import Method.Mapping (LongTermMode (..), MethodTables, processContributionsFromTables)
 import Progress
 import Types
 import UnitConversion (UnitConfig)
@@ -419,8 +419,10 @@ crossDBProcessContributions ::
     -- | root functional unit
     ProcessId ->
     MethodTables ->
+    -- | long-term emission policy, forwarded to the per-DB attribution
+    LongTermMode ->
     IO (Either Text (M.Map (Text, ProcessId) Double))
-crossDBProcessContributions unitConfig unitDB flowDB depLookup rootDb rootName rootSolver rootPid tables =
+crossDBProcessContributions unitConfig unitDB flowDB depLookup rootDb rootName rootSolver rootPid tables ltMode =
     go
         rootDb
         rootName
@@ -440,7 +442,7 @@ crossDBProcessContributions unitConfig unitDB flowDB depLookup rootDb rootName r
         -- attribute each root demand's contributions to this DB's activities;
         -- sum across demands (we currently only call with K=1, but keep the
         -- shape aligned with goWithDeps for future batching).
-        let localByRoot = map (\s -> processContributionsFromTables unitConfig unitDB flowDB db s tables) scalings
+        let localByRoot = map (\s -> processContributionsFromTables unitConfig unitDB flowDB ltMode db s tables) scalings
             localTagged = M.mapKeys (dbName,) (foldr (M.unionWith (+)) M.empty localByRoot)
         if depth >= maxDepsDepth
             then pure (Right localTagged)

--- a/test/BatchImpactsSpec.hs
+++ b/test/BatchImpactsSpec.hs
@@ -28,6 +28,7 @@ import Test.Hspec
 
 import qualified API.BatchImpacts as BI
 import Data.Text (Text)
+import Method.Mapping (LongTermMode (..))
 
 {- | Drive 'translateError' with a synthetic 'ServerError' of the given
 status code and body. Picks the canonical err400/404/422/500
@@ -73,7 +74,7 @@ spec = do
     describe "runActivityLCIABatch (empty DatabaseManager)" $ do
         it "returns DatabaseNotLoaded when the requested DB is not loaded" $ do
             dbm <- initDatabaseManager defaultConfig True Nothing
-            res <- runActivityLCIABatch dbm "no-such-db" "no-pid" "no-coll" Nothing
+            res <- runActivityLCIABatch dbm "no-such-db" "no-pid" "no-coll" Nothing IncludeLongTerm
             -- LCIABatchResult has no Show instance, so we pattern-match
             -- rather than rely on 'shouldBe' over the whole Either.
             case res of

--- a/test/LongTermExclusionSpec.hs
+++ b/test/LongTermExclusionSpec.hs
@@ -140,6 +140,14 @@ spec = do
             longTermModeFromExclude True `shouldBe` ExcludeLongTerm
             longTermModeFromExclude False `shouldBe` IncludeLongTerm
 
+    describe "applyLongTermMode" $ do
+        it "is the identity under IncludeLongTerm (long-term flows kept)" $
+            applyLongTermMode flowDB IncludeLongTerm inventory `shouldBe` inventory
+
+        it "drops long-term flows under ExcludeLongTerm (same as excludeLongTermFlows)" $
+            applyLongTermMode flowDB ExcludeLongTerm inventory
+                `shouldBe` excludeLongTermFlows flowDB inventory
+
     describe "scoring with vs without long-term emissions" $ do
         it "full score counts both flows (2·1 + 5·1 = 7)" $
             scoreOf (M.fromList [(ltId, 2.0), (stId, 5.0)]) `shouldSatisfy` near 7.0

--- a/test/LongTermExclusionSpec.hs
+++ b/test/LongTermExclusionSpec.hs
@@ -1,0 +1,151 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Excluding delayed long-term emissions from a score.
+
+Long-term emissions (heavy metals leaching from a landfill over > 100 yr, etc.)
+are flagged by a sub-compartment carrying the "long-term" marker. When a caller
+asks to exclude them, 'excludeLongTermFlows' drops exactly those inventory flows
+before characterization, so the score is computed as if the delayed emissions
+were out of scope.
+
+These fixtures drive the real table build + broadcast fill + scoring, so they
+track the engine's actual behaviour rather than a re-implementation:
+  * the long-term flow is dropped, the immediate one kept;
+  * a flow absent from the FlowDB is kept, never silently dropped (an unknown
+    UUID is not evidence of long-term);
+  * the "long-term" marker is matched case-insensitively across spellings;
+  * scoring the filtered inventory drops by exactly the long-term flow's
+    contribution — the immediate flow's score is untouched.
+-}
+module LongTermExclusionSpec (spec) where
+
+import qualified Data.ByteString.Lazy.Char8 as BLC
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
+import Test.Hspec
+
+import Matrix (Inventory)
+import Method.Mapping
+import Method.Types (Compartment (..), FlowDirection (..), MethodCF (..))
+import Types (BioFlowDB, BiosphereFlow (..), Unit (..), UnitDB)
+import qualified Types as VT
+import UnitConversion (UnitConfig, buildFromCSV, defaultUnitConfig)
+
+-- ---------------------------------------------------------------------------
+-- Unit metadata: a UnitConfig + UnitDB that know kg (CFs and flows share it,
+-- so unit conversion is the identity and the arithmetic stays transparent).
+-- ---------------------------------------------------------------------------
+
+unitConfig :: UnitConfig
+unitConfig =
+    either (const defaultUnitConfig) id $
+        buildFromCSV (BLC.pack "name,dimension,factor\nkg,mass,1.0\n")
+
+uidKg :: UUID
+uidKg = UUID.fromWords64 1 0
+
+unitDB :: UnitDB
+unitDB = M.singleton uidKg (Unit{unitId = uidKg, unitName = "kg", unitSymbol = "kg", unitComment = ""})
+
+-- ---------------------------------------------------------------------------
+-- Flow + CF fixtures: the same substance emitted to water, once as a delayed
+-- long-term emission and once immediately.
+-- ---------------------------------------------------------------------------
+
+ltId, stId, ghostId :: UUID
+ltId = UUID.fromWords64 100 0
+stId = UUID.fromWords64 101 0
+ghostId = UUID.fromWords64 999 0 -- referenced by the inventory but absent from the FlowDB
+
+bioFlow :: UUID -> Maybe Text -> BiosphereFlow
+bioFlow fid sub =
+    BiosphereFlow
+        { bfId = fid
+        , bfName = "Cadmium"
+        , bfUnitId = uidKg
+        , bfSynonyms = M.empty
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfCompartment = Just (VT.Compartment "water" sub)
+        }
+
+ltFlow, stFlow :: BiosphereFlow
+ltFlow = bioFlow ltId (Just "groundwater, long-term")
+stFlow = bioFlow stId (Just "river")
+
+flowDB :: BioFlowDB
+flowDB = M.fromList [(ltId, ltFlow), (stId, stFlow)]
+
+-- Inventory: 2 kg of the long-term emission, 5 kg of the immediate one, plus a
+-- flow the FlowDB does not know about.
+inventory :: Inventory
+inventory = M.fromList [(ltId, 2.0), (stId, 5.0), (ghostId, 7.0)]
+
+-- A unit-CF (1.0 per kg) matched to a flow by UUID.
+cfFor :: BiosphereFlow -> MethodCF
+cfFor flow =
+    MethodCF
+        { mcfFlowRef = bfId flow
+        , mcfFlowName = bfName flow
+        , mcfDirection = Output
+        , mcfValue = 1.0
+        , mcfCompartment = Just (Compartment "water" "" "")
+        , mcfCAS = Nothing
+        , mcfUnit = "kg"
+        , mcfConsumerLocation = Nothing
+        }
+
+-- Tables (with broadcast) that characterize both flows at 1.0 per kg.
+tables :: MethodTables
+tables =
+    fillBroadcastVector unitConfig unitDB flowDB $
+        buildMethodTables OtherCFFamily M.empty M.empty [(cfFor ltFlow, Just (ltFlow, ByUUID)), (cfFor stFlow, Just (stFlow, ByUUID))]
+
+scoreOf :: Inventory -> Double
+scoreOf inv = loScore (computeLCIAScoreFromTables unitConfig unitDB flowDB inv tables)
+
+near :: Double -> Double -> Bool
+near expected v = abs (v - expected) < 1e-9
+
+-- ---------------------------------------------------------------------------
+-- Spec
+-- ---------------------------------------------------------------------------
+
+spec :: Spec
+spec = do
+    describe "excludeLongTermFlows" $ do
+        it "drops the long-term flow and keeps the immediate one" $
+            M.keys (excludeLongTermFlows flowDB (M.fromList [(ltId, 2.0), (stId, 5.0)]))
+                `shouldBe` [stId]
+
+        it "keeps a flow absent from the FlowDB (an unknown UUID is not long-term)" $
+            M.keysSet (excludeLongTermFlows flowDB inventory)
+                `shouldBe` M.keysSet (M.fromList [(stId, 5.0 :: Double), (ghostId, 7.0)])
+
+        it "matches the long-term marker case-insensitively and across spellings" $ do
+            let variants =
+                    [ "Groundwater, LONG-TERM"
+                    , "low. pop., long term"
+                    , "ground-, long-term"
+                    ]
+                oneFlow sub = M.singleton ltId (bioFlow ltId (Just sub))
+            mapM_
+                (\sub -> M.null (excludeLongTermFlows (oneFlow sub) (M.singleton ltId 1.0)) `shouldBe` True)
+                variants
+
+    describe "longTermModeFromExclude" $ do
+        it "maps the exclude flag to the mode, defaulting to include" $ do
+            longTermModeFromExclude True `shouldBe` ExcludeLongTerm
+            longTermModeFromExclude False `shouldBe` IncludeLongTerm
+
+    describe "scoring with vs without long-term emissions" $ do
+        it "full score counts both flows (2·1 + 5·1 = 7)" $
+            scoreOf (M.fromList [(ltId, 2.0), (stId, 5.0)]) `shouldSatisfy` near 7.0
+
+        it "excluding long-term drops by exactly the long-term contribution (7 → 5)" $ do
+            let full = M.fromList [(ltId, 2.0), (stId, 5.0)]
+                cut = excludeLongTermFlows flowDB full
+            scoreOf cut `shouldSatisfy` near 5.0
+            (scoreOf full - scoreOf cut) `shouldSatisfy` near 2.0

--- a/volca.cabal
+++ b/volca.cabal
@@ -249,6 +249,7 @@ test-suite lca-tests
                      , ProjectRegionalSpec
                      , SharedCASCoverageSpec
                      , EnergyDensityCFSpec
+                     , LongTermExclusionSpec
                      , SharedSolverSpec
                      , CoalescingSolverSpec
                      , FlowResolverSpec


### PR DESCRIPTION
## What

A compute-time choice to score a process **with or without** its delayed
long-term (> 100 yr) emissions — the ones a sub-compartment marks "long-term"
(landfill leachate and the like). Excluding them computes the score as if those
emissions were out of scope, which some assessments require.

## How

Scoring is linear over the inventory, so the exclusion is a pure pre-filter.
`excludeLongTermFlows` drops the long-term flows — recognised by the existing
`isLongTermSub` on their sub-compartment — before characterization, applied once
per request so the score and the top-contributor breakdown stay consistent.

Long-term flows are always emissions, never resources, so the regionalized
water- and land-use categories (scored on a separate path) are untouched by
construction. A dedicated `LongTermExclusionSpec` locks the exclusion semantics
(drops long-term, keeps unknown UUIDs rather than silently dropping them,
case-insensitive marker) and the exact score effect.

## Surface

- MCP tools `get_impacts` and `score_activity`: optional `exclude_long_term`
  (declared once in the resource registry, so the tool schema, generated client
  and OpenAPI follow automatically).
- Batch impacts REST route: `?exclude-long-term=true`.
- Default keeps the emissions, per the ecoinvent/EF convention — existing scores
  are unchanged.

Full test suite green (1561 examples).