### PR TITLE
Bump to 0.9.1-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.9.0] - 2026-07-06
 
 A characterization-accuracy release. EF 3.1 scores on Agribalyse and ecoinvent

--- a/volca.cabal
+++ b/volca.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                volca
-version:             0.9.0
+version:             0.9.1-dev
 build-type:          Simple
 
 license:             Apache-2.0


### PR DESCRIPTION
Follow-up to the v0.9.0 release. Bumps `volca.cabal` to `0.9.1-dev` and reopens an `[Unreleased]` CHANGELOG section, so main is marked in-flight rather than sitting on the released 0.9.0 version.