### PR TITLE
Add two EF 3.1 1.03 legacy flow-name synonym bridges

### DIFF
--- a/data/flows.csv
+++ b/data/flows.csv
@@ -391,6 +391,7 @@ Fluorine,"Fluorine, in ground"
 "Fluorine, 4.5% in apatite, 3% in crude ore","Fluorine, 4.5% in apatite, 3% in crude ore, in ground"
 Fluorochloridone,Flurochloridone
 Fluorspar,"Fluorspar, in ground"
+Flupyrsulfuron-methyl sodium,Flupyrsulfuron-methyl
 Flutolanil,N-(3-(1-methylethoxy)phenyl)-2-(trifluoromethyl)benzamide
 Formamide,"methanamide, carbamaldehyde"
 Formate,"formate ion, methanoate ion"
@@ -593,6 +594,7 @@ Protactinium,"Protactinium, in ground"
 Pumice,"Pumice, in ground"
 Pyraclostrobin,Pyraclostrobin (prop)
 Pyrethrin,Pyrethrin II
+Pyrethrins,Pyrethrum
 Pyriproxyfen,S-9318
 Pyrite,"Pyrite, in ground"
 Pyrithiobac sodium salt,pyrithiobac-sodium


### PR DESCRIPTION
## What

Two curated synonym bridges in `data/flows.csv` so EF 3.1 (adapted 1.03) characterizes Agribalyse 4.0 biosphere flows that the method only lists under a sibling name:

- `Flupyrsulfuron-methyl sodium ↔ Flupyrsulfuron-methyl`
- `Pyrethrins ↔ Pyrethrum`

## Why

Verified on the engine (EF 3.1 1.03 × Agribalyse 4.0): the db flow `Flupyrsulfuron-methyl` resolves to no CF and scores zero — a silent freshwater-ecotoxicity undercount, since the method carries a factor only for `Flupyrsulfuron-methyl sodium`. With the bridge it inherits that factor through the name→synonym cascade (`resolveCF`), confirmed via the `characterization` endpoint (`strategy=synonym`).

`Pyrethrins`/`Pyrethrum` share a CAS (8003-34-7), a true alias; added defensively for source databases that use the older name.

Mirrors the legacy-flow handling in [ecobalyse#2395](https://github.com/MTES-MCT/ecobalyse/pull/2395).

## Deliberately not included

`Mecoprop ↔ Mecoprop-P` was considered and rejected: distinct CAS (93-65-2 vs 16484-77-8), i.e. genuinely different substances (racemate vs resolved enantiomer). A synonym bridge asserts substance identity, so it would encode a chemical falsehood — even though it would silence a real 1.03 human-toxicity-non-cancer gap for `Mecoprop-P`. That undercount is left as a documented method limitation.

## Lint

Both new equivalence classes are size 2 with no declared CAS, so `RegistryLintSpec` (class-size ≤ 12, one-CAS-per-class, carbon-origin) passes.