### PR TITLE
feat(pyvolca): expose classification match mode on search_activities

### DIFF
--- a/pyvolca/CHANGELOG.md
+++ b/pyvolca/CHANGELOG.md
@@ -18,6 +18,15 @@ git cliff --unreleased --tag pyvolca-v0.X.Y   # render as a released section
 
 Then paste the rendered block at the top of this file and tighten wording.
 
+## [0.7.2] - 2026-07-08
+
+### Added
+
+- `Client.search_activities` gains a `classification_match` argument
+  (`MatchMode.CONTAINS` default, or `MatchMode.EXACT`). A classification filter
+  can now require exact equality instead of substring — the match mode the
+  engine and MCP already accept, finally reachable from the typed client.
+
 ## [0.7.1] - 2026-07-07
 
 ### Fixed

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -26,7 +26,7 @@ pyvolca speaks one revision of the engine's JSON wire format; the engine adverti
 
 _Generated from `volca._compat` — run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.7.1** speaks wire format **1** and requires a VoLCA engine **≥ v0.8.0**.
+This build of **pyvolca 0.7.2** speaks wire format **1** and requires a VoLCA engine **≥ v0.8.0**.
 
 <!-- END: compatibility -->
 
@@ -672,7 +672,7 @@ Remove ``dep_name`` from the target database's dependencies.
 
 Returns the updated ``DatabaseSetupInfo`` dict.
 
-##### `Client.search_activities(name: str | None = None, *, geo: str | None = None, product: str | None = None, preset: str | None = None, classification: str | None = None, classification_value: str | None = None, page: int | None = None, page_size: int | None = None, limit: int | None = None, offset: int | None = None, exact: bool = False) -> SearchResults[Activity]`
+##### `Client.search_activities(name: str | None = None, *, geo: str | None = None, product: str | None = None, preset: str | None = None, classification: str | None = None, classification_value: str | None = None, classification_match: MatchModeLike | None = None, page: int | None = None, page_size: int | None = None, limit: int | None = None, offset: int | None = None, exact: bool = False) -> SearchResults[Activity]`
 
 Search activities in the current database.
 
@@ -691,6 +691,10 @@ Args:
     preset: Apply a named classification preset configured in the engine.
     classification: System name (``"ISIC rev.4 ecoinvent"``).
     classification_value: Substring within that system's value.
+    classification_match: How ``classification_value`` is compared —
+        :class:`MatchMode.CONTAINS` (default, substring) or
+        :class:`MatchMode.EXACT` (case-insensitive equality). Ignored
+        when ``classification`` is unset.
     page: 1-based page number. Must be paired with ``page_size`` —
         offset cannot be derived from page alone.
     page_size: Items per page (becomes the wire-level ``limit``).

--- a/pyvolca/pyproject.toml
+++ b/pyvolca/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvolca"
-version = "0.7.1"
+version = "0.7.2"
 description = "Python client for VoLCA — Life Cycle Assessment engine"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -67,6 +67,7 @@ from .types import (
     LCIABatchResult,
     LCIAResult,
     MatchMode,
+    MatchModeLike,
     Method,
     PathResult,
     Preset,
@@ -849,6 +850,7 @@ class Client:
         preset: str | None = None,
         classification: str | None = None,
         classification_value: str | None = None,
+        classification_match: MatchModeLike | None = None,
         page: int | None = None,
         page_size: int | None = None,
         limit: int | None = None,
@@ -872,6 +874,10 @@ class Client:
             preset: Apply a named classification preset configured in the engine.
             classification: System name (``"ISIC rev.4 ecoinvent"``).
             classification_value: Substring within that system's value.
+            classification_match: How ``classification_value`` is compared —
+                :class:`MatchMode.CONTAINS` (default, substring) or
+                :class:`MatchMode.EXACT` (case-insensitive equality). Ignored
+                when ``classification`` is unset.
             page: 1-based page number. Must be paired with ``page_size`` —
                 offset cannot be derived from page alone.
             page_size: Items per page (becomes the wire-level ``limit``).
@@ -891,6 +897,11 @@ class Client:
             preset=preset,
             classification=classification,
             classification_value=classification_value,
+            classification_mode=(
+                MatchMode(classification_match).value
+                if classification_match is not None
+                else None
+            ),
             exact=exact,
         )
 

--- a/pyvolca/tests/conftest.py
+++ b/pyvolca/tests/conftest.py
@@ -57,6 +57,7 @@ def fixture_spec() -> dict[str, Any]:
                         {"name": "preset", "in": "query", "required": False, "schema": {"type": "string"}},
                         {"name": "classification", "in": "query", "required": False, "schema": {"type": "string"}},
                         {"name": "classification-value", "in": "query", "required": False, "schema": {"type": "string"}},
+                        {"name": "classification-mode", "in": "query", "required": False, "schema": {"type": "string"}},
                         {"name": "limit", "in": "query", "required": False, "schema": {"type": "integer"}},
                         {"name": "offset", "in": "query", "required": False, "schema": {"type": "integer"}},
                     ],

--- a/pyvolca/tests/test_dispatch.py
+++ b/pyvolca/tests/test_dispatch.py
@@ -145,6 +145,29 @@ class TestDispatcher:
         assert "geo" not in params
         assert "limit" not in params
 
+    def test_search_activities_classification_match_sends_mode(self, mocked_client, make_response, empty_envelope):
+        """classification_match reaches the wire as ``classification-mode``."""
+        client, session = mocked_client
+        session.get.return_value = make_response(empty_envelope())
+        client.search_activities(classification="Category", classification_value="Food", classification_match="exact")
+        params = dict(session.get.call_args[1]["params"])
+        assert params["classification-value"] == "Food"
+        assert params["classification-mode"] == "exact"
+
+    def test_search_activities_omits_mode_by_default(self, mocked_client, make_response, empty_envelope):
+        """No classification_match → no ``classification-mode`` query param (server default: contains)."""
+        client, session = mocked_client
+        session.get.return_value = make_response(empty_envelope())
+        client.search_activities(classification="Category", classification_value="Food")
+        params = dict(session.get.call_args[1]["params"])
+        assert "classification-mode" not in params
+
+    def test_search_activities_rejects_bad_match_mode(self, mocked_client):
+        """A typo'd match mode fails client-side before any HTTP call."""
+        client, _ = mocked_client
+        with pytest.raises(ValueError):
+            client.search_activities(classification="Category", classification_value="Food", classification_match="exct")
+
     def test_search_activities_page_kwargs_compute_offset(self, mocked_client, make_response, empty_envelope):
         """page=3 + page_size=20 must translate to offset=40, limit=20."""
         client, session = mocked_client


### PR DESCRIPTION
The typed client could filter `search_activities` by a classification value, but always as a case-insensitive substring — there was no way to ask for exact equality. The engine and the MCP tool already accept a match-mode parameter for the same search; only the Python client left it out.

`search_activities` now takes `classification_match` (a `MatchMode`, default `CONTAINS`). Setting it to `MatchMode.EXACT` restricts the filter to entries whose classification value equals the given string exactly. The default is unchanged, so existing calls behave identically.

This mirrors what `get_supply_chain` and `get_consumers` already do through `ClassificationFilter.mode`; here it is threaded through the flat `classification` / `classification_value` arguments that `search_activities` uses.

Verified end-to-end against a real database: on Agribalyse, `classification_value="Recipes"` matches 763 processes with the default substring mode and 0 with exact mode, while the exact full path `Agricultural\Food\Recipes` matches the 763 again — confirming the mode reaches the engine.

Ships as pyvolca 0.7.2. The generated README API reference is regenerated to match; full test suite green (187 passed, 7 skipped).