### PR TITLE
ci: gate hlint and -Werror in engine CI

### DIFF
--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -406,12 +406,17 @@ jobs:
           #   sign, so any test that spawns volca times out. Skip strip+UPX
           #   for the CI test run (the artifact is larger but usable).
           # - Linux: nothing special needed.
+          # --werror on Linux only: -Wall-clean is a project rule, but only the
+          # Linux compile is verified warning-free (it mirrors the local ci.sh
+          # gate). Windows/macOS keep -Wall without -Werror so a platform-only
+          # warning we can't yet reproduce doesn't block every merge; promote
+          # them once each is confirmed clean.
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             timeout --foreground 1500 ./build.sh --test
           elif [[ "$RUNNER_OS" == "macOS" ]]; then
             ./build.sh --test --no-optimize
           else
-            ./build.sh --test
+            ./build.sh --test --werror
           fi
 
       - name: Verify static MUMPS link (Linux)

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -1,0 +1,29 @@
+name: HLint
+
+# Gate PRs on hlint. Fast, build-independent — runs in parallel with the heavy
+# build matrix, mirroring the Format workflow. hlint auto-discovers .hlint.yaml
+# at the repo root, so the baselined exceptions there apply. The version comes
+# from versions.env so a new hlint release can't silently redden CI.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: hlint-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  hlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Pin hlint version from versions.env
+        run: grep -E '^HLINT_VERSION=' versions.env >> "$GITHUB_ENV"
+      - uses: haskell-actions/hlint-setup@v2
+        with:
+          version: ${{ env.HLINT_VERSION }}
+      - name: Lint src/
+        run: hlint src/

--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,8 @@
 #   --all               Force clean rebuild
 #   --test              Run tests after building
 #   --coverage          Run tests with coverage and generate HTML report (implies --test)
+#   --werror            Treat warnings as errors (-Werror) when compiling — the
+#                       strict gate CI uses; -Wall-clean is a hard project rule
 #   --static            Build a statically-linked binary
 #   --no-optimize       Skip strip + UPX (preserves dylib load commands so
 #                       downstream tooling like dylibbundler / install_name_tool
@@ -140,6 +142,7 @@ COVERAGE=false
 STATIC_BUILD=false
 SKIP_OPTIMIZE=false
 OPTIMIZE_ONLY=false
+WERROR=false
 
 # -----------------------------------------------------------------------------
 # Parse arguments
@@ -167,6 +170,10 @@ while [[ $# -gt 0 ]]; do
             RUN_TESTS=true
             shift
             ;;
+        --werror)
+            WERROR=true
+            shift
+            ;;
         --static)
             STATIC_BUILD=true
             shift
@@ -186,6 +193,14 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# -Wall-clean is a hard project rule; --werror turns it into a build failure.
+# Kept out of the .cabal file on purpose: a stray warning shouldn't block an
+# everyday local `cabal build`, only the CI gate (and anyone opting in here).
+STRICT_OPTS=()
+if [[ "$WERROR" == "true" ]]; then
+    STRICT_OPTS=(--ghc-options=-Werror)
+fi
 
 echo ""
 log_info "Build configuration:"
@@ -481,7 +496,7 @@ if [[ "$SKIP_OPTIMIZE" == "true" ]]; then
     fi
 fi
 
-cabal build -j
+cabal build -j "${STRICT_OPTS[@]}"
 
 VOLCA_BIN_PATH=$(cabal list-bin exe:volca 2>/dev/null || true)
 if [[ -n "$VOLCA_BIN_PATH" && -f "$VOLCA_BIN_PATH" ]]; then
@@ -505,7 +520,7 @@ if [[ "$RUN_TESTS" == "true" ]]; then
     cd "$SCRIPT_DIR"
     if [[ "$COVERAGE" == "true" ]]; then
         log_info "Coverage enabled — instrumenting code..."
-        cabal test --enable-coverage --test-show-details=streaming
+        cabal test --enable-coverage --test-show-details=streaming "${STRICT_OPTS[@]}"
 
         log_info "Generating coverage report..."
         TIX_FILE=$(find "$SCRIPT_DIR/dist-newstyle" -name "lca-tests.tix" -path "*/hpc/*" 2>/dev/null | head -1)
@@ -551,7 +566,7 @@ if [[ "$RUN_TESTS" == "true" ]]; then
                 export VOLCA_EXE="$VOLCA_EXE_RESOLVED"
             fi
         fi
-        cabal test --test-show-details=streaming "${EXTRA_TEST_OPTS[@]}"
+        cabal test --test-show-details=streaming "${EXTRA_TEST_OPTS[@]}" "${STRICT_OPTS[@]}"
     fi
     log_success "Tests passed"
     echo ""

--- a/versions.env
+++ b/versions.env
@@ -53,6 +53,11 @@ GHC_VERSION=9.12.4
 # .githooks/pre-commit hook, and Claude Code's PostToolUse auto-format.
 # Bump in lockstep: fourmolu output changes between versions.
 FOURMOLU_VERSION=0.19.0.1
+# HLint linter — consumed by the hlint.yml CI gate (installs this exact
+# version, then runs `hlint src/`). Pinned so a new hlint release can't add
+# a hint that reddens CI without a deliberate bump. Baselined exceptions
+# live in .hlint.yaml.
+HLINT_VERSION=3.5
 # Bump this to force a cabal-store rebuild without changing volca.cabal /
 # mumps-hs.cabal / cabal.project. The CI workflow `prebuild-cabal-store.yml`
 # writes its output to a GH Release tagged


### PR DESCRIPTION
Two Haskell static checks the local release script already runs were missing from PR CI, so a lint regression or a new warning could merge green and only surface later.

**hlint** — the repo ships a `.hlint.yaml` (with one baselined guarded-index exception) but no workflow ran hlint on PRs. Adds an `hlint.yml` shaped like the existing Format workflow: installs the pinned hlint and runs `hlint src/`, which auto-discovers the root config so the baseline is honoured. Version pinned in `versions.env` so a new hlint release can't redden CI without a deliberate bump.

**-Werror** — CI compiled with plain `-Wall` even though `-Wall`-clean is a hard project rule. Adds a `--werror` flag to `build.sh` (injected as `--ghc-options=-Werror` at the build and test sites) and passes it from the Linux matrix row. Kept out of the `.cabal` file on purpose: an everyday local build shouldn't fail on a transient warning — only the CI gate opts in.

Scope note: `-Werror` is Linux-only for now. The Linux compile is verified warning-free (it mirrors the local gate); Windows/macOS keep `-Wall` until each is confirmed clean, so a platform-only warning we can't yet reproduce doesn't block every merge.

Both gates are green on arrival: `hlint src/` reports no hints and the engine compiles `-Werror`-clean.