### PR TITLE
ci: extend hlint coverage to app/ and test/

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -25,5 +25,5 @@ jobs:
       - uses: haskell-actions/hlint-setup@v2
         with:
           version: ${{ env.HLINT_VERSION }}
-      - name: Lint src/
-        run: hlint src/
+      - name: Lint src, app, test
+        run: hlint src app test

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,13 +1,22 @@
 # HLint configuration for the VoLCA engine.
 #
 # Its presence activates the hlint step in CI, which otherwise skips when no config is
-# found. Run locally with: hlint src/
+# found. Run locally with: hlint src app test
 #
 # The hygiene pass either *fixes* a hint or *baselines* it here with a one-line reason.
-# All default hints on src/ are fixed; the single baseline below is a deliberate
-# exception where the suggested rewrite conflicts with a stronger code-safety rule.
+# src, app and test are all hint-clean; the baselines below are deliberate exceptions
+# where the suggested rewrite conflicts with a stronger rule (code safety, the
+# formatter, or the point of the test).
 
 # `cells !! 0` is guarded by `length cells > colIdx + 2`, so it never fails — but the
 # suggested `head cells` is a partial function we ban project-wide. Keep the guarded
 # indexing rather than reintroduce `head`.
 - ignore: {name: "Use head", within: Method.ParserCSV}
+
+# fourmolu's `single-constraint-parens: always` writes `(HasCallStack) =>`, which hlint
+# reads as a redundant bracket. The formatter wins, so silence the lint on this helper.
+- ignore: {name: "Redundant bracket", within: SimaProParserSpec.findByName}
+
+# This test's whole point is the right-identity law `s <> mempty`; hlint would simplify
+# it to `s` and delete exactly what's under test. Keep the law spelled out.
+- ignore: {name: "Monoid law, right identity", within: LoaderSpec}

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -367,7 +367,7 @@ createServerApp dbManager maxTreeDepth staticDir desktopMode password hostingCon
 handleLogStream :: Request -> (Response -> IO ResponseReceived) -> IO ResponseReceived
 handleLogStream req respond = do
     let lastEventId = lookup "Last-Event-ID" (requestHeaders req)
-        since = maybe 0 (\v -> fromMaybe 0 (readMaybe (C8.unpack v))) lastEventId
+        since = maybe 0 (fromMaybe 0 . readMaybe . C8.unpack) lastEventId
     respond
         $ responseStream
             status200

--- a/test/BrightwayExcelWriterSpec.hs
+++ b/test/BrightwayExcelWriterSpec.hs
@@ -36,6 +36,7 @@ import BrightwayExcel.Writer (
     renderWorkbook,
     wasteManifest,
  )
+import Control.Monad ((>=>))
 import qualified Data.ByteString.Lazy as BL
 import Data.Either (isLeft, isRight)
 import Data.List (find, sortOn)
@@ -111,8 +112,8 @@ spec = describe "BrightwayExcel.Writer" $ do
             -- names carry all four predefined entities plus accented and CJK
             -- characters proves the two halves are inverses, not that the cells
             -- merely store raw strings.
-            withWritten specialDb $ \path ->
-                parseBrightwayExcel defaultUnitConfig path >>= \case
+            withWritten specialDb $
+                parseBrightwayExcel defaultUnitConfig >=> \case
                     Left err -> expectationFailure (T.unpack err)
                     Right parsed -> normalizeParsed parsed `shouldBe` specialNormalized
 
@@ -122,8 +123,8 @@ spec = describe "BrightwayExcel.Writer" $ do
             -- Coproduct. Asserting the parsed roles and amounts proves the
             -- multi-output activity survives, where 'normalizeParsed' (which only
             -- projects reference + Input rows) cannot see the coproduct.
-            withWritten coproductDb $ \path ->
-                parseBrightwayExcel defaultUnitConfig path >>= \case
+            withWritten coproductDb $
+                parseBrightwayExcel defaultUnitConfig >=> \case
                     Left err -> expectationFailure (T.unpack err)
                     Right (acts, _, _, _, _) -> case acts of
                         [a] -> do
@@ -136,8 +137,8 @@ spec = describe "BrightwayExcel.Writer" $ do
         it "(f) round-trips an empty database to no activities" $
             -- The writer still emits the Database header sheet; the parser reads
             -- it back as a valid, activity-free import rather than erroring.
-            withWritten emptyDb $ \path ->
-                parseBrightwayExcel defaultUnitConfig path >>= \case
+            withWritten emptyDb $
+                parseBrightwayExcel defaultUnitConfig >=> \case
                     Left err -> expectationFailure (T.unpack err)
                     Right (acts, _, _, _, _) -> length acts `shouldBe` 0
 
@@ -145,11 +146,11 @@ spec = describe "BrightwayExcel.Writer" $ do
             -- At 1e15 'formatAmount' crosses from integer to fixed-point rendering;
             -- the parser reads it back through TR.double. The amount must survive
             -- the format switch exactly.
-            withWritten bigAmountDb $ \path ->
-                parseBrightwayExcel defaultUnitConfig path >>= \case
+            withWritten bigAmountDb $
+                parseBrightwayExcel defaultUnitConfig >=> \case
                     Left err -> expectationFailure (T.unpack err)
                     Right (acts, _, _, _, _) -> case acts of
-                        [a] -> map techAmount [ex | ex@TechnosphereExchange{techRole = Input} <- exchanges a] `shouldBe` [1.0e15]
+                        [a] -> [techAmount ex | ex@TechnosphereExchange{techRole = Input} <- exchanges a] `shouldBe` [1.0e15]
                         other -> expectationFailure ("expected one activity, got " <> show (length other))
 
         it "(h) round-trips exchange-level comments, including the reference product" $
@@ -157,8 +158,8 @@ spec = describe "BrightwayExcel.Writer" $ do
             -- through 'productRowOut' (the same path coproducts take), which once
             -- dropped it. Assert the product, input, and biosphere comments all
             -- survive.
-            withWritten commentDb $ \path ->
-                parseBrightwayExcel defaultUnitConfig path >>= \case
+            withWritten commentDb $
+                parseBrightwayExcel defaultUnitConfig >=> \case
                     Left err -> expectationFailure (T.unpack err)
                     Right (acts, _, _, _, _) -> case acts of
                         [a] -> do
@@ -175,13 +176,13 @@ spec = describe "BrightwayExcel.Writer" $ do
             -- ingest (g→kg here, scaling 1000→1). So parse(write D) ≠ D for a
             -- non-canonical reference unit — the contract is fixed-point over the
             -- parser's image: a second round-trip reproduces the first exactly.
-            withWritten gramRefDb $ \path ->
-                parseBrightwayExcel gramConfig path >>= \case
+            withWritten gramRefDb $
+                parseBrightwayExcel gramConfig >=> \case
                     Left err -> expectationFailure (T.unpack err)
                     Right parsed1 -> do
                         refUnitAmount parsed1 `shouldBe` Just ("kg", 1.0)
-                        withWritten (rebuild parsed1) $ \path2 ->
-                            parseBrightwayExcel gramConfig path2 >>= \case
+                        withWritten (rebuild parsed1) $
+                            parseBrightwayExcel gramConfig >=> \case
                                 Left err -> expectationFailure (T.unpack err)
                                 Right parsed2 -> refUnitAmount parsed2 `shouldBe` refUnitAmount parsed1
 
@@ -190,8 +191,8 @@ spec = describe "BrightwayExcel.Writer" $ do
             -- the format allows; the parser reads it back as a one-element list.
             -- A single paragraph is therefore a fixed point — the realistic case,
             -- since the parser's own image has ≤1 element (see 'activityRows').
-            withWritten describedDb $ \path ->
-                parseBrightwayExcel defaultUnitConfig path >>= \case
+            withWritten describedDb $
+                parseBrightwayExcel defaultUnitConfig >=> \case
                     Left err -> expectationFailure (T.unpack err)
                     Right (acts, _, _, _, _) -> case acts of
                         [a] -> activityDescription a `shouldBe` ["a milling note"]

--- a/test/CopySpec.hs
+++ b/test/CopySpec.hs
@@ -124,10 +124,10 @@ spec = describe "Database.Edit copy primitive" $ do
         -- Force the source solver's lazy factorization via a first solve.
         _ <- solveWithSharedSolver srcSolver (buildDemandVectorFromIndex (dbActivityIndex srcDb) 0)
         -- MatrixFactorization has no Show instance, so assert on the Bool.
-        (isJust <$> getFactorization srcSolver) >>= (`shouldBe` True)
+        getFactorization srcSolver >>= (`shouldBe` True) . isJust
 
         -- A shared MVar would have warmed the copy too; a distinct one stays empty.
-        (isNothing <$> getFactorization copySolver) >>= (`shouldBe` True)
+        getFactorization copySolver >>= (`shouldBe` True) . isNothing
 
     it "refuses to overwrite an existing database name" $ do
         manager <- initDatabaseManager defaultConfig True Nothing

--- a/test/DeleteSelectionSpec.hs
+++ b/test/DeleteSelectionSpec.hs
@@ -19,6 +19,7 @@ module DeleteSelectionSpec (spec) where
 
 import Control.Concurrent.STM (atomically, modifyTVar', readTVarIO)
 import qualified Data.Map.Strict as M
+import Data.Maybe (fromMaybe)
 import qualified Data.Set as S
 import Data.Text (Text, isInfixOf)
 import qualified Data.UUID as UUID
@@ -245,7 +246,7 @@ pidFor db offset i = pidFor2 db (mkUUID (offset + 10 * i + 1)) (mkUUID (offset +
 
 pidFor2 :: Database -> UUID -> UUID -> ProcessId
 pidFor2 db actUUID prodUUID =
-    maybe (error "pidFor2: key not found") id (findProcessId db actUUID prodUUID)
+    fromMaybe (error "pidFor2: key not found") (findProcessId db actUUID prodUUID)
 
 installLoaded :: DatabaseManager -> Text -> Database -> IO ()
 installLoaded manager name db = do

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module EcoSpold1Spec (spec) where
@@ -394,7 +395,7 @@ spec = do
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
                 Right (act, _, _, _, _, _, _) ->
-                    let bios = filter (\e -> case e of BiosphereExchange{} -> True; _ -> False) (exchanges act)
+                    let bios = filter (\case BiosphereExchange{} -> True; _ -> False) (exchanges act)
                      in length bios `shouldBe` 2 -- CO2 output + natural gas input (inputGroup 4)
         it "parses flow with CAS number" $
             case parseWithXeno minimalXml of

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -46,7 +46,7 @@ spec = describe "per-exchange comments" $ do
     it "comments contain no &-entity artefacts" $
         withFixture $ \(act, _, _, _, _) ->
             let comments = [c | ex <- exchanges act, Just c <- [exchangeComment ex]]
-             in all (not . T.isInfixOf "&") comments `shouldBe` True
+             in not (any (T.isInfixOf "&") comments) `shouldBe` True
 
     -- Critical correctness test: <property> children of an exchange may carry
     -- their own <comment> describing the property (e.g. "dry mass on a kg

--- a/test/EnergyDensityCFSpec.hs
+++ b/test/EnergyDensityCFSpec.hs
@@ -26,7 +26,7 @@ Plus the CSV reader: it keys by normalized name and rejects malformed rows.
 module EnergyDensityCFSpec (spec) where
 
 import qualified Data.ByteString.Lazy.Char8 as BLC
-import Data.Either (isLeft)
+import Data.Either (fromRight, isLeft)
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import Data.UUID (UUID)
@@ -49,7 +49,7 @@ import UnitConversion (UnitConfig, buildFromCSV, defaultUnitConfig)
 -- bridge can't fire against it. Mirrors how production loads data/units.csv.
 unitConfig :: UnitConfig
 unitConfig =
-    either (const defaultUnitConfig) id $
+    fromRight defaultUnitConfig $
         buildFromCSV (BLC.pack "name,dimension,factor\nkg,mass,1.0\ntonne,mass,1000.0\nm3,volume,1.0\nmj,energy,1.0e6\n")
 
 uidKg, uidTonne, uidM3 :: UUID

--- a/test/LongTermExclusionSpec.hs
+++ b/test/LongTermExclusionSpec.hs
@@ -20,6 +20,7 @@ track the engine's actual behaviour rather than a re-implementation:
 module LongTermExclusionSpec (spec) where
 
 import qualified Data.ByteString.Lazy.Char8 as BLC
+import Data.Either (fromRight)
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import Data.UUID (UUID)
@@ -40,7 +41,7 @@ import UnitConversion (UnitConfig, buildFromCSV, defaultUnitConfig)
 
 unitConfig :: UnitConfig
 unitConfig =
-    either (const defaultUnitConfig) id $
+    fromRight defaultUnitConfig $
         buildFromCSV (BLC.pack "name,dimension,factor\nkg,mass,1.0\n")
 
 uidKg :: UUID

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -142,7 +142,7 @@ spec = do
                 mB = mkMethod 2 "B" [cfB1, cfB2]
                 mC = mkMethod 3 "C" [cfC1]
 
-                fill ts = fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb ts
+                fill = fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb
                 tA = fill (buildMethodTables OtherCFFamily M.empty M.empty [(cfA1, Just (flow1, ByUUID))])
                 tB = fill (buildMethodTables OtherCFFamily M.empty M.empty [(cfB1, Just (flow1, ByUUID)), (cfB2, Just (flow2, ByUUID))])
                 tC = fill (buildMethodTables OtherCFFamily M.empty M.empty [(cfC1, Just (flow1, ByUUID))])
@@ -184,7 +184,7 @@ spec = do
                 m2 = mkMethod 2 "m2" [cf]
                 fdb = M.singleton fid (mkFlow fid "co2" uidKg)
                 udb = M.singleton uidKg (mkUnit uidKg "kg")
-                fill ts = fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb ts
+                fill = fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb
                 t = fill (buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))])
                 mst = buildMethodSetTables [(m1, t), (m2, t)]
                 results =
@@ -305,7 +305,7 @@ spec = do
                 flow2 = mkFlow fid2 "ch4" uidKg
                 fdb = M.fromList [(fid1, flow1), (fid2, flow2)]
                 udb = M.singleton uidKg (mkUnit uidKg "kg")
-                fill ts = fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb ts
+                fill = fillBroadcastVector UnitConversion.defaultUnitConfig udb fdb
                 -- Two non-regional CFs (m1 on fid1; m3 on fid1+fid2) and a
                 -- regional one (m2 with a per-location override on fid1).
                 cf1a = mkCF fid1 2.0
@@ -356,8 +356,11 @@ spec = do
             -- method alone via computeLCIAScoreFromTables.
             let s1 = loScore (computeLCIAScoreFromTables UnitConversion.defaultUnitConfig udb fdb inv tNonRegio1)
                 s3 = loScore (computeLCIAScoreFromTables UnitConversion.defaultUnitConfig udb fdb inv tNonRegio2)
-            map snd results !! 0 `shouldBe` Right s1
-            map snd results !! 2 `shouldBe` Right s3
+            case map snd results of
+                r1 : _ : r3 : _ -> do
+                    r1 `shouldBe` Right s1
+                    r3 `shouldBe` Right s3
+                _ -> expectationFailure "expected at least three scored results"
 
     describe "buildMethodTables mtRegionalizedCF subcomp filter" $ do
         -- Regression for the niche-subcomp clobber: ByName / synonym fan-out

--- a/test/MethodSpec.hs
+++ b/test/MethodSpec.hs
@@ -4,6 +4,7 @@
 module MethodSpec (spec) where
 
 import qualified Data.Map.Strict as M
+import Data.Maybe (isJust)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.UUID as UUID
@@ -73,7 +74,7 @@ spec = do
                     Left err -> expectationFailure $ "Parse failed: " ++ err
                     Right db -> do
                         let result = lookupSynonymGroup db "carbon dioxide"
-                        result `shouldSatisfy` maybe False (const True)
+                        result `shouldSatisfy` isJust
 
             it "maps 'co2' to same group as 'carbon dioxide' (transitive)" $ do
                 let csv = "name1,name2\ncarbon dioxide,co2\n"
@@ -860,7 +861,7 @@ spec = do
             case parseSimaProMethodCSVBytes csv of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
                 Right coll -> do
-                    let ch4 = (methodFactors (head (mcMethods coll))) !! 1
+                    let ch4 = methodFactors (head (mcMethods coll)) !! 1
                     mcfFlowName ch4 `shouldBe` "Methane, fossil"
                     mcfValue ch4 `shouldBe` 29.8
 
@@ -869,7 +870,7 @@ spec = do
             case parseSimaProMethodCSVBytes csv of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
                 Right coll -> do
-                    let wu = (mcMethods coll) !! 2
+                    let wu = mcMethods coll !! 2
                     methodName wu `shouldBe` "Water use"
                     methodUnit wu `shouldBe` "m3 depriv."
                     let waterCF = head (methodFactors wu)
@@ -918,7 +919,7 @@ spec = do
             case parseSimaProMethodCSVBytes csv of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
                 Right coll -> do
-                    let nh3 = head (methodFactors ((mcMethods coll) !! 1))
+                    let nh3 = head (methodFactors (mcMethods coll !! 1))
                     mcfCAS nh3 `shouldBe` Just "7664-41-7"
 
         it "produces deterministic UUIDs" $ do

--- a/test/ProgressSpec.hs
+++ b/test/ProgressSpec.hs
@@ -101,7 +101,7 @@ spec = do
             concatLines newLines `shouldSatisfy` ("[SOLVER]" `isInfixOf`)
 
 concatLines :: [String] -> String
-concatLines = concatMap (\l -> l ++ "\n")
+concatLines = unlines
 
 isInfixOf :: String -> String -> Bool
 isInfixOf needle haystack = any (needle `isPrefixOf'`) (tails' haystack)

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -901,10 +901,10 @@ spec = do
     -- non-kg or '(unspecified)'-sub CF through the slower name cascade.
     -- -----------------------------------------------------------------------
     describe "CF / biosphere flow UUID alignment" $ do
-        let cfSide name comp sub unit =
-                generateFlowUUID name (normalizeSimaProCompartment comp sub) unit
-            bioSide name comp sub unit =
-                generateFlowUUID name (normalizeSimaProCompartment comp sub) unit
+        let cfSide name comp sub =
+                generateFlowUUID name (normalizeSimaProCompartment comp sub)
+            bioSide name comp sub =
+                generateFlowUUID name (normalizeSimaProCompartment comp sub)
 
         it "regional water in m³: CF 'Raw'/'(unspecified)' matches bio 'resource'/blank" $
             cfSide "Water, FR" "Raw" "(unspecified)" "m3"
@@ -1097,7 +1097,7 @@ spec = do
             -- Multi-coproduct allocations are of the form 'Sx /(...)*100',
             -- so the formula field should be populated for each coproduct.
             let formulas = [activityAllocationFormula a | a <- activities]
-            all (/= Nothing) formulas `shouldBe` True
+            notElem Nothing formulas `shouldBe` True
 
         it "scales shared exchanges by the per-coproduct allocation fraction" $ do
             (activities, _, _, _, _) <- parseMultiCoproductCSV
@@ -1187,8 +1187,8 @@ spec = do
 
 -- | Build a minimal process CSV with extra section lines inserted
 parseSectionCSV :: [BS.ByteString] -> IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)
-parseSectionCSV sectionLines =
-    parseNamedCSV "Test process" sectionLines
+parseSectionCSV =
+    parseNamedCSV "Test process"
 
 -- | Build a minimal process CSV with a custom Process name and Products rows.
 parseProductsCSV :: BS.ByteString -> [BS.ByteString] -> IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)

--- a/test/SupplyChainSpec.hs
+++ b/test/SupplyChainSpec.hs
@@ -220,7 +220,7 @@ spec = do
             let pidZ = processIdToText db 2
             case getConsumers db "test-db" pidZ emptyConsumer of
                 Left err -> expectationFailure $ "getConsumers failed: " ++ show err
-                Right cr -> all (not . M.null . crClassifications) (srResults (crrResults cr)) `shouldBe` True
+                Right cr -> not (any (M.null . crClassifications) (srResults (crrResults cr))) `shouldBe` True
 
     describe "Edges on consumers (include-edges)" $ do
         let loadWithIndex = fmap BM25.addBM25Index (loadSampleDatabase "SAMPLE.min3")

--- a/test/TestHelpers.hs
+++ b/test/TestHelpers.hs
@@ -28,7 +28,7 @@ import UnitConversion (defaultUnitConfig)
 
 -- | Load a SAMPLE database for testing
 loadSampleDatabase :: String -> IO Database
-loadSampleDatabase sampleName = loadSampleDatabaseWithPath sampleName
+loadSampleDatabase = loadSampleDatabaseWithPath
 
 -- | Load database from a specific path
 loadSampleDatabaseWithPath :: String -> IO Database

--- a/test/TreeSpec.hs
+++ b/test/TreeSpec.hs
@@ -70,7 +70,7 @@ spec = do
                 case tree of
                     TreeNode _ [(_, _, child)] ->
                         case child of
-                            TreeLoop _ _ _ -> return ()
+                            TreeLoop{} -> return ()
                             _ -> expectationFailure "Expected TreeLoop for Y at depth 1"
                     _ -> expectationFailure "Expected TreeNode for X"
 
@@ -79,7 +79,7 @@ spec = do
                 let Just xUUID = UUID.fromString sampleMin3ActivityX
                     tree = buildLoopAwareTree defaultUnitConfig db xUUID 0
                 case tree of
-                    TreeLoop _ _ _ -> return ()
+                    TreeLoop{} -> return ()
                     _ -> expectationFailure "Expected TreeLoop for X at maxDepth=0"
 
             it "depth=2 — Z becomes a TreeLoop at depth 2" $ do
@@ -89,7 +89,7 @@ spec = do
                 case tree of
                     TreeNode _ [(_, _, TreeNode _ [(_, _, leaf)])] ->
                         case leaf of
-                            TreeLoop _ _ _ -> return ()
+                            TreeLoop{} -> return ()
                             _ -> expectationFailure "Expected TreeLoop for Z at depth 2"
                     _ -> expectationFailure "Unexpected tree shape"
 
@@ -142,10 +142,10 @@ findActivityUUIDByName db name =
 
 treeContainsLoop :: LoopAwareTree -> Bool
 treeContainsLoop (TreeLeaf _) = False
-treeContainsLoop (TreeLoop _ _ _) = True
+treeContainsLoop (TreeLoop{}) = True
 treeContainsLoop (TreeNode _ children) = any (\(_, _, t) -> treeContainsLoop t) children
 
 countNodes :: LoopAwareTree -> Int
 countNodes (TreeLeaf _) = 1
-countNodes (TreeLoop _ _ _) = 1
+countNodes (TreeLoop{}) = 1
 countNodes (TreeNode _ children) = 1 + sum (map (\(_, _, t) -> countNodes t) children)

--- a/test/WasteTreatmentSignSpec.hs
+++ b/test/WasteTreatmentSignSpec.hs
@@ -24,6 +24,7 @@ module WasteTreatmentSignSpec (spec) where
 import Data.List (elemIndex)
 import qualified Data.Map as M
 import qualified Data.Map.Strict as MS
+import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
@@ -40,9 +41,7 @@ import UnitConversion (defaultUnitConfig)
 
 -- | A deterministic UUID from its canonical string form.
 mkUUID :: String -> UUID
-mkUUID s = case UUID.fromString s of
-    Just u -> u
-    Nothing -> UUID.nil
+mkUUID s = fromMaybe UUID.nil (UUID.fromString s)
 
 -- Shared identifiers.
 kgU, co2, wW, yY, tA, pA :: UUID

--- a/versions.env
+++ b/versions.env
@@ -54,7 +54,7 @@ GHC_VERSION=9.12.4
 # Bump in lockstep: fourmolu output changes between versions.
 FOURMOLU_VERSION=0.19.0.1
 # HLint linter — consumed by the hlint.yml CI gate (installs this exact
-# version, then runs `hlint src/`). Pinned so a new hlint release can't add
+# version, then runs `hlint src app test`). Pinned so a new hlint release can't add
 # a hint that reddens CI without a deliberate bump. Baselined exceptions
 # live in .hlint.yaml.
 HLINT_VERSION=3.5


### PR DESCRIPTION
Stacked on #188, which introduces the hlint gate. Merge #188 first; GitHub retargets this to `main` automatically once #188 lands.

#188 gated `hlint src/` because only `src/` was hint-clean. `app/` and `test/` carried 41 default-hint findings, so the gate stopped at the library. This clears them and widens the gate to the whole tree.

- **app/ + test/ hint fixes** — mechanical throughout: eta reduction, De Morgan hoisting of `not`, redundant brackets, record patterns, Kleisli `>=>`, isJust / fromRight / notElem. One `!! 0` that hlint wanted to turn into `head` is rewritten as a total pattern match rather than reintroducing a banned partial function.
- **Two baselined hints** (`.hlint.yaml`, each with a one-line reason): the redundant-bracket on `(HasCallStack)` conflicts with fourmolu's `single-constraint-parens: always`, and the right-identity `s <> mempty` is exactly what its test asserts.
- **Gate widened** — `hlint src/` → `hlint src app test`, with the `versions.env` pin comment updated to match.

Green on arrival: `hlint src app test` reports no hints, fourmolu is clean, and the suite is 1513 examples / 0 failures.