### PR TITLE
docs: document conventions instead of inventories, fix drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,12 +47,12 @@ spec modules are `*Spec.hs` under `test/` and auto-discovered. New behavior need
 |------|---------|------|
 | Domain | `Types` | Central domain types (Activity, Exchange, Flow, …) |
 | Solve | `Matrix`, `SharedSolver` | Sparse technosphere/biosphere matrices; MUMPS-backed LCI solve |
-| Parsers | `EcoSpold.*`, `SimaPro.*`, `ILCD.*`, `BrightwayExcel.*`, `Method.Parser*` | Database + method format readers |
-| Methods | `Method.Mapping`, `Method.FlowResolver`, `Method.ChemSynonyms` | CF mapping (UUID→CAS→name→synonym cascade), flow resolution |
+| Formats | `EcoSpold.*`, `SimaPro.*`, `ILCD.*`, `BrightwayExcel.*`, `Method.Parser*` | One namespace per database format, each with a `Parser` (wired into `Database.Loader`) and a `Writer` (wired into `Database.Export`); method readers are `Method.Parser*` |
+| Methods | `Method.Mapping`, `Method.FlowResolver`, `Method.ChemSynonyms` | CF mapping (UUID→name→synonym→CAS cascade), flow resolution |
 | Database | `Database.*` (`Loader`, `CrossLinking`, `MatrixBuild`, `Manager`) | Load, cross-link, build matrices, manage lifecycle |
 | Analysis | `Service`, `Service.Aggregate`, `Tree` | Analysis ops, grouping, supply-chain traversal |
 | Search | `Search.BM25`, `Search.Fuzzy`, `Search.Normalize` | Activity/flow search |
-| API | `API.Routes`, `API.MCP` | Servant REST routes and MCP tool surface (shared resource registry) |
+| API | `API.Resources`, `API.Routes`, `API.MCP` | `API.Resources` holds the resource registry (one `Resource` per operation); REST routes, MCP tools and OpenAPI derive from it |
 | CLI | `CLI.*`, `app/Main.hs` | Arg parsing, commands, HTTP client, REPL; entrypoint (server/client/repl modes) |
 
 A Python client lives in `pyvolca/` (own `pyproject.toml`); the MUMPS binding in
@@ -60,10 +60,10 @@ A Python client lives in `pyvolca/` (own `pyproject.toml`); the MUMPS binding in
 
 ## Where to start
 
-- **A new MCP tool or REST endpoint** → `API.Routes` holds the shared resource registry that drives *both* REST and MCP; add it once there, not in two places.
-- **A new database format** → a new parser namespace (e.g. `Foo.Parser`), wired into `Database.Loader`.
+- **A new MCP tool or REST endpoint** → `API.Resources` holds the resource registry that drives REST, MCP and OpenAPI; add one `Resource` there (a drift test enforces the wiring), not in N places.
+- **A new database format** → a new namespace with its `Parser` / `Writer` pair (e.g. `Foo.Parser`, `Foo.Writer`), wired into `Database.Loader` and `Database.Export`.
 - **Wrong or empty LCI numbers** → `Database.MatrixBuild` plus `Matrix` / `SharedSolver`; check supplier resolution in `Database.CrossLinking`.
-- **Characterization mismatches** → `Method.Mapping` (the UUID→CAS→name→synonym cascade) and `Method.FlowResolver`.
+- **Characterization mismatches** → `Method.Mapping` (the UUID→name→synonym→CAS cascade) and `Method.FlowResolver`.
 - **Search relevance** → `Search.BM25` / `Search.Fuzzy` / `Search.Normalize`.
 
 ## Engineering rules
@@ -100,6 +100,10 @@ A Python client lives in `pyvolca/` (own `pyproject.toml`); the MUMPS binding in
   - CI fails any PR with unformatted Haskell.
   - A repo pre-commit hook auto-formats staged `.hs` — enable once per clone: `git config core.hooksPath .githooks`.
   - Claude Code also auto-formats `.hs` on edit (`.claude/settings.json`).
+
+### Documentation
+- **Re-read this file + README before each PR.** Update them when: (a) you hit a statement contradicting the code, (b) a new convention appears, (c) a command or a config key changes. NON-trigger: adding a module, tool, or endpoint that follows the stated conventions — the rules cover it, no list to grow.
+- Never write hand-maintained counts, versions, or enumerations the code already knows — state the naming rule and point at the source of truth (`versions.env`, `API.Resources`, `volca dump-mcp-tools`).
 
 ### Commits & PRs
 - NEVER use `git add -A` — always add specific files explicitly.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It loads EcoSpold2, EcoSpold1, SimaPro CSV, ILCD process, and Brightway Excel da
 - **Compute** life cycle inventories (LCI) and impact scores (LCIA) — single method or whole collection — with per-flow and per-activity contribution breakdowns
 - **What-if substitutions** — swap an upstream activity (or a cross-database supplier) and recompute inventory and impacts in a single call
 - **Normalize and weight** LCIA results with Raw / Normalized / Weighted view toggle; compute a single-score in Pt when normalization-weighting data is available
-- **Map** method characterization factors to database flows with a 4-step cascade (UUID → CAS → name → synonym) and coverage statistics
+- **Map** method characterization factors to database flows with a 4-step cascade (UUID → name → synonym → CAS) and coverage statistics
 - **Link** databases across nomenclatures (e.g., a sector database referencing Agribalyse)
 - **Upload** databases and method collections via the API, without touching config files
 
@@ -26,13 +26,13 @@ It loads EcoSpold2, EcoSpold1, SimaPro CSV, ILCD process, and Brightway Excel da
 - **LCIA method collections**: Load ILCD method packages (ZIP or directory), SimaPro method CSV exports, or tabular CSV from config
 - **Normalization and weighting**: Batch LCIA computes normalized and weighted scores per category and a single aggregated score (Pt) when NW data is present in the method collection
 - **Contribution analysis**: Per-flow and per-activity contributions to any LCIA score, ranked by share
-- **Flow mapping engine**: 4-step matching cascade (UUID → CAS → name → synonym) with per-strategy coverage statistics
+- **Flow mapping engine**: 4-step matching cascade (UUID → name → synonym → CAS) with per-strategy coverage statistics
 - **Activity classifications**: ISIC, CPC, and category fields parsed from EcoSpold1/2 and ILCD, with named TOML presets for common filter bundles
 - **Per-exchange comments**: Free-text exchange comments extracted from EcoSpold1/2, SimaPro, and ILCD and surfaced in API responses
 - **Fuzzy search**: Trigram-based typo and stem tolerance on activity and supply-chain name filters
 - **Auto-extracted synonyms**: Synonym pairs extracted automatically from loaded databases and method packages, available for toggling and download
 - **Reference data management**: Flow synonyms, compartment mappings, and unit definitions can be configured in TOML, uploaded via the API, or toggled independently
-- **Fast cache**: Per-database cache co-located with the source path, with automatic schema-based invalidation; large databases (26k activities) load in ~47s cold, ~3.4s cached
+- **Fast cache**: Per-database cache co-located with the source path, with automatic schema-based invalidation (figures in the Performance table below)
 - **Optional access control**: Single-code login with cookie-based session
 
 ---
@@ -121,6 +121,10 @@ displayName = "Sector DB"
 path = "DBs/sector.CSV"
 depends = ["agribalyse-3.2"]   # loads agribalyse first, then links
 load = true
+default = false                # preselected database in the UI
+deletable = false              # allow deletion via the API
+geography_policy = "global"    # CF regionalization: exact | parent | global
+# locationAliases = { "FR" = "France" }   # per-database location renames
 
 [[methods]]
 name = "EF-3.1"
@@ -128,6 +132,27 @@ path = "DBs/EF-v3.1.zip"      # ILCD method package (ZIP or directory)
 
 # SimaPro method CSV exports and tabular CSV are also accepted:
 # path = "DBs/EF3.1_methods.csv"
+
+# Optional scoring sets on a method collection: named variables per impact
+# category, computed expressions, then normalization + weighting factors
+# producing a single score (see "Normalization and weighting" above).
+#   [[methods.scoring]]
+#   name = "my-score"
+#   unit = "Pt"
+#   displayMultiplier = 1e6
+#     [methods.scoring.variables]      # var = exact category name
+#     cch = "Climate change"
+#     [methods.scoring.computed]       # derived variables (expressions)
+#     etf = "2 * etfo + etfi"
+#     [methods.scoring.normalization]  # per-variable factors
+#     cch = 7553.08
+#     [methods.scoring.weighting]
+#     cch = 0.2106
+#
+# global-methods = ["Water use", ...] de-regionalizes the named methods:
+# their region-tagged CFs are dropped so the method's global (unlocated)
+# CF is the single answer — for matching references that flattened
+# spatial factors. A name matching no method logs a warning.
 
 [[flow-synonyms]]
 name = "Default flow synonyms"
@@ -143,6 +168,25 @@ active = true
 name = "Default units"
 path = "data/units.csv"
 active = true
+
+[[energy-densities]]
+name = "Default energy densities"
+path = "data/energy_densities.csv"
+active = true
+
+[[classification-presets]]     # named filter bundles for classifications
+name = "agriculture"
+label = "Agriculture"
+filters = [{ system = "ISIC", value = "01", mode = "contains" }]  # mode: exact | contains
+
+# Single-path reference data (all optional):
+# geographies = "data/geographies.csv"        # code,display_name,parents
+# chem-synonyms = "data/chem_synonyms.csv"    # PubChem snapshot for the suggester
+# substance-edges = "data/substance_edges.csv" # typed flow-correspondence edges
+
+# [hosting] tunes upload/API limits when the engine runs behind a manager:
+# max_uploads, max_upload_mb, api_access, upgrade_upload, upgrade_api,
+# upgrade_vm_size
 ```
 
 The `depends` field ensures dependency databases load first and their flows are available for cross-database linking. Setting `load = true` on a database transitively loads all its dependencies.
@@ -265,7 +309,7 @@ Configure it in your MCP client:
 }
 ```
 
-Available tools (auto-derived from a single resource registry shared with the REST API and OpenAPI spec, so the three surfaces never drift):
+Available tools — auto-derived at runtime from the single resource registry (`src/API/Resources.hs`) shared with the REST API and OpenAPI spec, so the three *served* surfaces never drift. This table is a hand-written copy; `volca dump-mcp-tools` prints the authoritative list:
 
 | Tool | Description |
 |------|-------------|
@@ -357,7 +401,7 @@ commands.
 # Summary: how well does a method match a database?
 volca --db agribalyse mapping METHOD_UUID
 
-# See every mapped CF with its match strategy (uuid/cas/name/synonym)
+# See every mapped CF with its match strategy (uuid/name/synonym/cas)
 volca --db agribalyse mapping METHOD_UUID --matched
 
 # List CFs that found no DB flow
@@ -377,6 +421,13 @@ volca --db agribalyse mapping METHOD_UUID --matched --format json
 volca database                                  # list (default)
 volca database upload mydb.7z --name "My DB"    # upload
 volca database delete my-db                     # delete
+
+# Edit and export loaded databases
+volca database copy my-db my-db-v2              # copy under a new name
+volca database relink my-db --to bg-db --mapping aliases.csv
+volca database delete-activities my-db --name "electricity"  # delete filtered set
+volca database export my-db --format simapro --out out.csv
+#   formats: simapro | ecospold1 | ecospold2 | ilcd | brightway
 
 # List, upload, delete method collections
 volca method                                    # list (default)
@@ -421,8 +472,11 @@ volca method delete ef-31                        # delete
 | List databases | `GET /db` | `database` |
 | Upload database | `POST /db/upload` | `database upload FILE --name NAME` |
 | Load / unload | `POST /db/{name}/(load\|unload)` | — (use config `load = true`) |
-| Relink / finalize | `POST /db/{name}/(relink\|finalize)` | — |
+| Relink / finalize | `POST /db/{name}/(relink\|finalize)` | `database relink DB --to DEP --mapping CSV` |
 | Setup / dependencies | `GET /db/{name}/setup`, `POST .../{add,remove}-dependency/{dep}`, `POST .../set-data-path` | — |
+| Copy database | `POST /db/{name}/copy/{newName}` | `database copy SRC NEW_NAME` |
+| Delete activities (filtered set) | `POST /db/{name}/delete` | `database delete-activities DB [filters]` |
+| Export database | `POST /db/{name}/export` | `database export DB --format FMT --out FILE` |
 | Delete database | `DELETE /db/{name}` | `database delete NAME` |
 | **Method Management** | | |
 | List methods | `GET /methods` | `methods` |
@@ -507,7 +561,7 @@ ghcup install ghc 9.12.4 --set
 ghcup install cabal latest
 source ~/.ghcup/env
 
-./build.sh              # Build (sources MUMPS 5.8.1, ~3 min one-time)
+./build.sh              # Build (compiles MUMPS from source, ~3 min one-time)
 ./build.sh --test       # Build and run tests
 ```
 
@@ -563,7 +617,8 @@ VoLCA is licensed under the **Apache License 2.0** — see [LICENSE](LICENSE).
 
 Third-party components bundled with or linked into VoLCA are inventoried in
 [NOTICE](NOTICE) and [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md). The
-notable ones are MUMPS 5.8.1 (CeCILL-C), BLAS/LAPACK (BSD-3), and a number of
+notable ones are MUMPS (CeCILL-C, version pinned in `versions.env`),
+BLAS/LAPACK (BSD-3), and a number of
 Haskell libraries (predominantly BSD-3 and MIT).
 
 A running engine also exposes the same inventory as JSON at

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,9 +40,9 @@ of the system; the CLI and REPL are just thin HTTP clients.
    │ Database.Manager ──► TVar [LoadedDatabase]   ◄── Config (TOML)  │
    │        │                                                        │
    │        ├─ Types.hs        domain model (Activity/Flow/Exchange) │
-   │        ├─ Database.hs     builds the sparse A / B matrices      │
+   │        ├─ Database.MatrixBuild  builds the sparse A / B matrices│
    │        ├─ Matrix + SharedSolver   (I−A)⁻¹·f = s   then   B·s = g│
-   │        ├─ Method.Mapping  LCIA: CF cascade UUID→CAS→name→synonym│
+   │        ├─ Method.Mapping  LCIA: CF cascade UUID→name→synonym→CAS│
    │        ├─ Search          BM25 (full-text) + Fuzzy (trigrams)   │
    │        ├─ Tree / Expr / UnitConversion / SynonymDB              │
    │        └─ CrossLinking    cross-database supplier resolution    │
@@ -80,12 +80,13 @@ of the system; the CLI and REPL are just thin HTTP clients.
 ### 1 — Startup / loading a database
 
 `volca.toml` → `Database.Manager` → for each database: archive extraction →
-format parser → domain model → `Database.hs` assembles the sparse **A** (technosphere)
-and **B** (biosphere) triples → `Data.Store` serialisation into a cache co-located
+format parser → domain model → `Database.MatrixBuild` assembles the sparse **A**
+(technosphere) and **B** (biosphere) triples (`Database.hs` composes the builders
+and adds progress reporting) → `Data.Store` serialisation into a cache co-located
 with the source file.
 
-The cache is invalidated automatically when the schema changes. Measured on
-a +25k activities database: **~50 s cold** vs. **~4 s warm**.
+The cache is invalidated automatically when the schema changes. Cold vs. warm
+figures live in the README's Performance table (single source for benchmarks).
 
 ### 2 — Computing an impact
 
@@ -191,8 +192,8 @@ take the same path with a single multi-RHS solve (`computeInventoryMatrixBatch`)
 
 A method collection ships characterisation factors (CFs) keyed by its own flow
 nomenclature. They must be matched to the loaded database's biosphere flows. The
-match is a **first-hit-wins cascade** (`Method.Mapping`, default `UUID → CAS → Name
-→ Synonym`):
+match is a **first-hit-wins cascade** (`Method.Mapping`, default `UUID → Name
+→ Synonym → CAS`, the CAS number as last resort):
 
 ```
   MethodCF  (one CF from the method collection)        DB biosphere flows
@@ -200,9 +201,9 @@ match is a **first-hit-wins cascade** (`Method.Mapping`, default `UUID → CAS �
        ▼                                                      ▼
    ┌────────────────────  Method.Mapping cascade  ──────────────────────┐
    │  ① ByUUID     CF target UUID == flow UUID      (dbBioFlows)        │
-   │  ② ByCAS      CAS number match                 (dbFlowsByCAS)      │
-   │  ③ ByName     normalised-name match            (dbFlowsByName)     │
-   │  ④ BySynonym  synonym expansion then name match (dbSynonymDB)      │
+   │  ② ByName     normalised-name match            (dbFlowsByName)     │
+   │  ③ BySynonym  synonym expansion then name match (dbSynonymDB)      │
+   │  ④ ByCAS      CAS number match                 (dbFlowsByCAS)      │
    └─────────────────────────────────┬───────────────────────────────────┘
        first strategy that hits wins → (Flow, MatchStrategy)
                                      │  computeMappingStats → coverage %
@@ -215,6 +216,27 @@ match is a **first-hit-wins cascade** (`Method.Mapping`, default `UUID → CAS �
 
 `MethodTables` collapses the cascade and absorbs unit conversion into plain `Map`
 lookups, so scoring itself is a fast dot product over the inventory `g`.
+
+### Normalization, weighting and single scores
+
+Two mechanisms turn per-category LCIA results into comparable numbers:
+
+- **Built-in NW sets** — a method collection may ship its own
+  normalization/weighting data (`mcNormWeightSets`, parsed by
+  `Method.ParserNW`); batch LCIA then returns Raw / Normalized / Weighted
+  views and an aggregated single score (Pt).
+- **Formula-based scoring sets** — configured per collection in TOML
+  (`[[methods.scoring]]`, decoded in `Config`, stored as `mcScoringSets`).
+  `Method.Types.computeFormulaScores` evaluates one against the raw
+  category scores: ① bind short variables to category names, ② resolve
+  computed variables (`Expr` formulas, e.g. `etf = "2 * etfo + etfi"`),
+  ③ apply `raw / normalization × weighting` per variable, ④ evaluate the
+  score formulas over that environment, and scale everything by
+  `displayMultiplier`. Missing data surfaces as an error, never as a
+  silent zero.
+
+Scoring sets are what `list_scoring_sets` / `score_activity` /
+`score_activities` expose over REST and MCP.
 
 ### What-if and cross-database solving
 
@@ -232,6 +254,7 @@ lookups, so scoring itself is a fast dot product over the inventory `g`.
 | Module / folder             | Role                                                                 |
 |------------------------------|----------------------------------------------------------------------|
 | `app/Main.hs`               | Entry point: CLI / server / REPL dispatch                            |
+| `API/Resources.hs`          | Resource registry: one `Resource` per operation; REST, MCP and OpenAPI derive from it |
 | `API/Routes.hs`             | Servant `/api/v1/*` route definitions and handlers                  |
 | `API/Auth.hs`               | Authentication middleware (session cookie, single-code login)        |
 | `API/MCP.hs`                | MCP server: tools exposed to AI assistants                          |
@@ -243,18 +266,18 @@ lookups, so scoring itself is a fast dot product over the inventory `g`.
 | `Database/Loader.hs`        | Loading and dispatch to parsers                                     |
 | `Database/CrossLinking.hs`  | Cross-database supplier resolution, topological order               |
 | `Database/Upload.hs`        | Database upload via the API                                         |
-| `Database.hs`               | Sparse A / B matrix construction, normalisation                     |
+| `Database/MatrixBuild.hs`   | Sparse A / B matrix construction, normalisation (all numerical work) |
+| `Database.hs`               | Composes the matrix builders, adds progress reporting               |
 | `Types.hs`                  | Domain model (Activity, Flow, Exchange, Database) — sum types        |
 | `Matrix.hs`                 | Matrix LCA computations via the MUMPS solver                        |
 | `SharedSolver.hs`           | Lazy thread-safe LU factorisation, caches, back-substitution        |
 | `mumps-hs/`                 | FFI bindings to the MUMPS direct sparse solver (Fortran)            |
-| `EcoSpold/Parser2.hs`       | EcoSpold2 parser (`.spold`)                                         |
-| `EcoSpold/Parser1.hs`       | EcoSpold1 parser (`.xml`)                                           |
-| `SimaPro/Parser.hs`         | SimaPro CSV parser                                                  |
-| `ILCD/Parser.hs`            | ILCD process dataset parser                                         |
-| `BrightwayExcel/Parser.hs`  | Brightway Excel (`.xlsx`) inventory parser                          |
+| `EcoSpold/`, `SimaPro/`, `ILCD/`, `BrightwayExcel/` | One namespace per database format, each with a `Parser` (read, wired into `Database/Loader.hs`) and a `Writer` (export, wired into `Database/Export.hs`) |
 | `Method/Parser*.hs`         | Method collection loading (ILCD, CSV, SimaPro, olca)                |
-| `Method/Mapping.hs`         | CF matching cascade (UUID → CAS → name → synonym), LCIA scoring     |
+| `Method/FlowResolver.hs`    | Parses ILCD flow XMLs to enrich MethodCFs (name, compartment, CAS)  |
+| `Database/Edit.hs`, `Database/Export.hs`, `Database/RelinkMapping.hs` | Database write toolkit: delete/copy, export to any format, relink via alias CSV |
+| `SubstanceRegistry.hs`      | Canonical flow registry: equivalence classes over flow-identity assertions |
+| `Method/Mapping.hs`         | CF matching cascade (UUID → name → synonym → CAS), LCIA scoring     |
 | `Search/BM25.hs`            | BM25 full-text search index                                         |
 | `Search/Fuzzy.hs`           | Trigram fuzzy search                                                |
 | `Tree.hs`                   | Supply-chain tree construction (loop-aware)                         |


### PR DESCRIPTION
## Why

Every claim in README.md, AGENTS.md and docs/architecture.md was re-read against the code. Several were wrong, and the worst one mis-taught the core algorithm:

- **The LCIA mapping cascade order was wrong everywhere** — all three docs said `UUID → CAS → name → synonym` (~10 occurrences, including the authoritative numbered diagram in architecture.md). The code tries CAS **last**: `UUID → name → synonym → CAS` (`Method.Mapping.resolveCF`, and its own header comment agrees).
- The README hardcoded "MUMPS 5.8.1" twice while `versions.env` (the single source of truth) pins 5.9.0.
- Sparse A/B matrix construction was attributed to `Database.hs`; the numerical work lives in `Database.MatrixBuild` (`Database.hs` composes the builders and adds progress reporting).
- AGENTS.md sent new endpoints to `API.Routes`; the resource registry is `API.Resources` (one `Resource` per operation, REST/MCP/OpenAPI derive from it, a drift test enforces the wiring).

A hand-written inventory can't be verified, only maintained. So it drifts.

## What this PR does

**Rules replace lists.** Each database format is one namespace with a `Parser` (wired into `Database.Loader`) and a `Writer` (wired into `Database.Export`) — the per-parser module rows made the Writers invisible. Benchmark figures now live only in the README's Performance table; the other two copies (three inconsistent numbers for the same benchmark) point there. The MCP tool table stays for readers but now names `volca dump-mcp-tools` as its authoritative source.

**Undocumented surface is documented.** The TOML config example gains the missing sections (`energy-densities`, `classification-presets`, `geographies`, `chem-synonyms`, `substance-edges`, `hosting`), the missing `[[databases]]` keys (`default`, `deletable`, `geography_policy`, `locationAliases`), and the `[[methods.scoring]]` / `global-methods` blocks. The CLI section and feature matrix gain `database copy / relink / delete-activities / export`. A new architecture chapter explains normalization, weighting and formula-based single scores (`computeFormulaScores`: variables → computed expressions → raw/norm×weight → score formulas), a headline feature that had no conceptual documentation.

**A doc consigne** in AGENTS.md: re-read the docs before each PR; update on contradiction, new convention, or command change — and its non-trigger: adding a module, tool or endpoint that follows the stated conventions is not a doc change, the rules cover it.

## Verification

Each modified statement was re-read against the cited code. That pass caught two errors in my own first draft: a classification-preset `mode = "prefix"` that doesn't exist (`exact | contains` only, `Config.hs`), and a wrong description of `global-methods` (it de-regionalizes named methods — drops their region-tagged CFs so the global CF answers — nothing to do with scoring, `Database/Manager.hs`). Non-regression greps for the old cascade order and the hardcoded MUMPS version match nothing.

Documentation only, no code touched.