### PR TITLE
Bump the wire version to 2 for the raw-bytes export download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
 ### Changed
+- The wire-format revision advertised on `/api/v1/version` is now `2`, because
+  the export download changed shape (below). pyvolca ≥ 0.7.2 requires an engine
+  ≥ v0.9.1 and refuses older ones with a clear message; an older pyvolca gets a
+  warning telling it to upgrade.
 - Database exports download as raw bytes instead of base64-encoded JSON,
   matching how uploads already work — a third less data on the wire and far
   less memory on both ends for big files. Any export approximation warnings

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -20,13 +20,14 @@ pyvolca speaks one revision of the engine's JSON wire format; the engine adverti
 | pyvolca | wire | compatible engine |
 |---------|------|-------------------|
 | `0.5.x` | (pre-`wireVersion`) | `v0.5.0` … `v0.7.x` |
-| `0.6.x` | `1` | `≥ v0.8.0` |
+| `0.6.0` … `0.7.1` | `1` | `v0.8.0` … `v0.9.0` |
+| `≥ 0.7.2` | `2` | `≥ v0.9.1` |
 
 <!-- BEGIN: compatibility -->
 
 _Generated from `volca._compat` — run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.7.2** speaks wire format **1** and requires a VoLCA engine **≥ v0.8.0**.
+This build of **pyvolca 0.7.2** speaks wire format **2** and requires a VoLCA engine **≥ v0.9.1**.
 
 <!-- END: compatibility -->
 

--- a/pyvolca/src/volca/_compat.py
+++ b/pyvolca/src/volca/_compat.py
@@ -19,10 +19,10 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .types import ServerVersion
 
-REQUIRED_WIRE = 1
+REQUIRED_WIRE = 2
 """The JSON wire-format revision this pyvolca speaks."""
 
-MIN_ENGINE_HINT = "0.8.0"
+MIN_ENGINE_HINT = "0.9.1"
 """First engine release that advertises :data:`REQUIRED_WIRE`. Used only for the
 error message and the release preflight — it is not, by itself, a runtime gate
 (the engine's ``wireVersion`` is)."""
@@ -50,7 +50,7 @@ def check(sv: ServerVersion) -> None:
         raise VoLCAError(
             f"This engine (v{sv.version}) speaks an older wire than pyvolca "
             f"needs (wire {spoken} < {REQUIRED_WIRE}). Upgrade the engine to "
-            f">= v{MIN_ENGINE_HINT}, or `pip install 'pyvolca<0.6'`."
+            f">= v{MIN_ENGINE_HINT}, or `pip install 'pyvolca<0.7.2'`."
         )
     if w > REQUIRED_WIRE:
         warnings.warn(

--- a/pyvolca/tests/test_compat.py
+++ b/pyvolca/tests/test_compat.py
@@ -45,7 +45,7 @@ def test_check_rejects_too_old_wire(wire: int | None) -> None:
         _compat.check(_sv(wire))
     # names the engine to upgrade to, and an older-pyvolca fallback
     assert f"v{_compat.MIN_ENGINE_HINT}" in str(exc.value)
-    assert "pyvolca<0.6" in str(exc.value)
+    assert "pyvolca<0.7.2" in str(exc.value)
 
 
 def test_check_message_distinguishes_absent_from_zero() -> None:

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1094,7 +1094,7 @@ breaking change to the JSON wire shape lands (field rename/removal, type
 narrowing, newly-required field). Clients compare it to decide compatibility.
 -}
 currentWireVersion :: Int
-currentWireVersion = 1
+currentWireVersion = 2
 
 getVersion :: AppM Value
 getVersion =


### PR DESCRIPTION
The export endpoint changed shape in #191: the response went from a JSON envelope (base64 `data` + `warnings` array) to `application/octet-stream` with warnings in the `X-Volca-Export-Warnings` header. That is breaking in both directions — in particular pyvolca ≥ 0.7.2 talking to a v0.9.0 engine saves the JSON envelope bytes as the exported file **without raising**.

This bumps `currentWireVersion` and `REQUIRED_WIRE` to 2 so both stale pairings get a clear signal instead of silent corruption: a newer client refuses an older engine with an actionable error, an older client warns against a newer engine. `MIN_ENGINE_HINT` points at v0.9.1, the first release that will advertise wire 2. The README compatibility table and its generated block are regenerated, and the compat test's expected downgrade hint updated.

Verified: engine builds under `-Werror` with the full test suite green, and the pyvolca suite passes (187 tests) including the README drift check.