### PR TITLE
Release 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.9.1] - 2026-07-11
 
 ### Added
 - A characterization method declared in the TOML configuration can carry

--- a/volca.cabal
+++ b/volca.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                volca
-version:             0.9.1-dev
+version:             0.9.1
 build-type:          Simple
 
 license:             Apache-2.0


### PR DESCRIPTION
Cut the 0.9.1 release: date the changelog section and drop the `-dev` suffix from the cabal version.

Since 0.9.0 the engine gained declarative method patches and long-term exclusion on bulk scoring, learned to characterize immediate groundwater emissions again, added two EF 3.1 synonym bridges, and changed database exports to stream as raw bytes. That export change is why the advertised wire revision is now 2; pyvolca 0.7.2 already requires it. The changelog spells each of these out in plain language.

Final state after this merges: main carries the released `0.9.1` version and a dated changelog, ready to tag.