### PR TITLE
Open 0.9.2 development

### DIFF
--- a/volca.cabal
+++ b/volca.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                volca
-version:             0.9.1
+version:             0.9.2-dev
 build-type:          Simple
 
 license:             Apache-2.0


### PR DESCRIPTION
Resume the `-dev` suffix on the cabal version now that v0.9.1 is tagged, so main advertises 0.9.2-dev until the next release.