### PR TITLE
Release pyvolca 0.8.0

### DIFF
--- a/pyvolca/CHANGELOG.md
+++ b/pyvolca/CHANGELOG.md
@@ -18,6 +18,29 @@ git cliff --unreleased --tag pyvolca-v0.X.Y   # render as a released section
 
 Then paste the rendered block at the top of this file and tighten wording.
 
+## [0.8.0] - 2026-07-14
+
+### Added
+
+- **Upload a database from Python.** `upload_database` streams an archive to a
+  running engine, then `get_setup`, `set_data_path`, `finalize_database`, and
+  `delete_database` drive it through the staged setup — a notebook can now feed
+  the engine and score against its own data without leaving Python.
+- **Batch and sensitivity analysis** to match the MCP tools: `score_activities`
+  scores many processes at once, `compute_sensitivity` varies an input and
+  reports the swing. Both return typed results (`BatchScores`,
+  `SensitivityResult`).
+- **Method collections** — list, load, unload, delete, and upload the
+  characterization-method sets the engine applies.
+- **Reference data** — read and manage flow synonyms, compartment mappings, and
+  units (selected by a validated `kind`), plus synonym groups and a CSV export.
+- **Detail lookups** — `get_flow`, `get_flow_activities`, `get_method`,
+  `get_method_factors`, `get_mapping_status`, and `get_stats` for inspecting a
+  single flow, method, or the loaded databases.
+
+The client now covers the engine's full HTTP surface, closing a gap where 25 of
+roughly 60 endpoints were reachable.
+
 ## [0.7.2] - 2026-07-08
 
 ### Added

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -27,7 +27,7 @@ pyvolca speaks one revision of the engine's JSON wire format; the engine adverti
 
 _Generated from `volca._compat` — run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.7.2** speaks wire format **2** and requires a VoLCA engine **≥ v0.9.1**.
+This build of **pyvolca 0.8.0** speaks wire format **2** and requires a VoLCA engine **≥ v0.9.1**.
 
 <!-- END: compatibility -->
 

--- a/pyvolca/pyproject.toml
+++ b/pyvolca/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvolca"
-version = "0.7.2"
+version = "0.8.0"
 description = "Python client for VoLCA — Life Cycle Assessment engine"
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Why

Cut the pyvolca release for the endpoint-coverage work in #199, which merged with the version bump and CHANGELOG entry deliberately deferred to release time.

## What

- `pyproject.toml`: `0.7.2` → `0.8.0`
- `CHANGELOG.md`: new `[0.8.0]` section — database upload + staged setup, batch scoring, sensitivity, method collections, reference data, and detail lookups. pyvolca now covers the engine's full HTTP surface.
- `README.md`: regenerated compatibility sentinel (now *pyvolca 0.8.0, wire 2, engine ≥ v0.9.1*).

Wire format is unchanged (still 2); `REQUIRED_WIRE` and `MIN_ENGINE_HINT` untouched. Tag `pyvolca-v0.8.0` after merge.