### PR TITLE
Write the product name as VoLCA

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Volca Docker image: fully-static musl binary on Alpine.
+# VoLCA Docker image: fully-static musl binary on Alpine.
 #
 # The binary is statically linked against musl libc, so it runs on any Linux
 # distro without a runtime libc dependency. Used both as a server image and


### PR DESCRIPTION
Normalise la seule occurrence affichée du nom en « VoLCA » (commentaire de tête du Dockerfile). Les identifiants de code (`VolcaExe`) et l'en-tête réseau `X-Volca-Export-Warnings` restent inchangés.