### PR TITLE
Harden the pyvolca converter example

### DIFF
--- a/examples/convert_database.py
+++ b/examples/convert_database.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import secrets
+import shutil
 import socket
 import tempfile
 import urllib.parse
@@ -44,7 +45,7 @@ def export_bytes(client, server, fmt):
     try:
         return client.export_database(fmt)
     except VoLCAError as error:
-        if "HTTP 406" not in str(error):
+        if not str(error).startswith("export_database failed (HTTP 406)"):
             raise
         request = urllib.request.Request(
             f"{server.base_url}/api/v1/db/{client.db}/export",
@@ -95,45 +96,29 @@ def main():
 
     with tempfile.TemporaryDirectory(prefix="volca-convert-") as raw:
         root, port, password = Path(raw), free_port(), secrets.token_urlsafe(32)
+        db_name = safe_slug(source.stem)
+        local_source = root / source.name
+        shutil.copy2(source, local_source)
         config = root / "volca.toml"
-        config.write_text(f'[server]\nhost="127.0.0.1"\nport={port}\npassword="{password}"\n')
-        previous_data_dir = os.environ.get("VOLCA_DATA_DIR")
-        os.environ["VOLCA_DATA_DIR"] = raw
-        try:
-            with Server(config=str(config), binary=str(installed.binary)) as server:
-                client = Client(server.base_url, password=server.password)
-                uploaded = client.upload_database(source, source.stem)
-                client.db = safe_slug(uploaded["slug"])
-                loaded = False
-                try:
-                    setup = client.get_setup()
-                    if not setup["isReady"]:
-                        raise RuntimeError(
-                            "database needs dependencies: "
-                            + ", ".join(setup["missingSuppliers"])
-                        )
-                    client.finalize_database()
-                    loaded = True
-                    outputs = {
-                        fmt: out / (client.db + EXT[fmt])
-                        for fmt in dict.fromkeys(args.format)
-                    }
-                    if not args.force:
-                        existing = [path for path in outputs.values() if os.path.lexists(path)]
-                        if existing:
-                            raise FileExistsError(existing[0])
-                    for fmt, output in outputs.items():
-                        publish(export_bytes(client, server, fmt), output, args.force)
-                        print(f"{fmt}: {output}")
-                finally:
-                    if loaded:
-                        client.unload_database(client.db)
-                    client.delete_database()
-        finally:
-            if previous_data_dir is None:
-                os.environ.pop("VOLCA_DATA_DIR", None)
-            else:
-                os.environ["VOLCA_DATA_DIR"] = previous_data_dir
+        config.write_text(
+            f'[server]\nhost="127.0.0.1"\nport={port}\npassword="{password}"\n\n'
+            f'[[databases]]\nname={json.dumps(db_name)}\n'
+            f'path={json.dumps(str(local_source))}\nload=false\n'
+        )
+        with Server(config=str(config), binary=str(installed.binary)) as server:
+            client = Client(server.base_url, db=db_name, password=server.password)
+            client.load_database(db_name)
+            outputs = {
+                fmt: out / (db_name + EXT[fmt])
+                for fmt in dict.fromkeys(args.format)
+            }
+            if not args.force:
+                existing = [path for path in outputs.values() if os.path.lexists(path)]
+                if existing:
+                    raise FileExistsError(existing[0])
+            for fmt, output in outputs.items():
+                publish(export_bytes(client, server, fmt), output, args.force)
+                print(f"{fmt}: {output}")
 
 
 if __name__ == "__main__":

--- a/pyvolca/tests/test_examples.py
+++ b/pyvolca/tests/test_examples.py
@@ -62,6 +62,22 @@ def test_pyvolca_080_export_fallback_surfaces_warnings():
         server.server_close()
 
 
+def test_export_fallback_only_handles_the_known_406_prefix():
+    example = load_example()
+
+    class Client:
+        db = "database"
+
+        def export_database(self, _fmt):
+            raise example.VoLCAError("another failure whose body mentions HTTP 406")
+
+    managed = type(
+        "Server", (), {"base_url": "http://127.0.0.1:1", "password": "x"}
+    )()
+    with pytest.raises(example.VoLCAError, match="another failure"):
+        example.export_bytes(Client(), managed, "ilcd")
+
+
 def test_converter_uses_only_public_pyvolca_lifecycle():
     source = EXAMPLE.read_text()
     tree = ast.parse(source)
@@ -78,20 +94,13 @@ def test_converter_uses_only_public_pyvolca_lifecycle():
     }
 
     assert {"Client", "Server", "download"} <= imported
+    assert {"load_database", "export_database"} <= calls
     assert {
         "upload_database",
-        "get_setup",
         "finalize_database",
-        "export_database",
         "unload_database",
         "delete_database",
-    } <= calls
+    }.isdisjoint(calls)
+    assert "[[databases]]" in source
     assert "._session" not in source
     assert "import requests" not in source
-    unload_calls = [
-        node for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "unload_database"
-    ]
-    assert unload_calls and all(call.args for call in unload_calls)


### PR DESCRIPTION
## Summary
- copy the source into the temporary run directory and declare it in `volca.toml` instead of uploading it over a raceable loopback port
- remove explicit unload/delete cleanup that could mask the primary conversion failure; server shutdown and temporary-directory cleanup now own the lifecycle
- narrow the pyvolca 0.8.0 HTTP 406 fallback and retain warning propagation
- add behavioral coverage for fallback matching and warnings

## Verification
- `uv run --with-editable . --with pytest pytest -q` — 226 passed, 7 skipped
- `uv run --with-editable . --with pyright==1.1.411 pyright` — clean
- real pyvolca 0.8.0 / VoLCA 0.9.1 run produced valid ILCD, EcoSpold 1, and EcoSpold 2 outputs