### PR TITLE
Make managed server port allocation atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- `server --port 0 --desktop` now asks the OS to bind an available port and
+  prints the actual `VOLCA_PORT=N` only after the listening socket is reserved.
+  Launchers can therefore avoid reserve-then-release port races.
+
 ## [0.9.1] - 2026-07-11
 
 ### Added

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -50,7 +50,7 @@ import Network.HTTP.Types (status200)
 import Network.HTTP.Types.Header (hCacheControl, hContentType, hPragma)
 import Network.Wai (Application, Middleware, Request (..), Response, ResponseReceived, mapResponseHeaders, pathInfo, rawPathInfo, rawQueryString, requestHeaders, requestMethod, responseLBS, responseStream)
 import Network.Wai.Application.Static (StaticSettings, defaultWebAppSettings, ssIndices, staticApp)
-import Network.Wai.Handler.Warp (defaultSettings, runSettings, setPort, setTimeout)
+import Network.Wai.Handler.Warp (defaultSettings, openFreePort, runSettings, runSettingsSocket, setPort, setTimeout)
 import Network.Wai.Middleware.RequestSizeLimit (defaultRequestSizeLimitSettings, requestSizeLimitMiddleware, setMaxLengthForRequest)
 import Servant (serve)
 import WaiAppStatic.Types (MaxAge (..), ssMaxAge, unsafeToPiece)
@@ -229,7 +229,6 @@ runServerWithConfig cliConfig serverOpts cfgFile = do
     let port = fromMaybe (scPort (cfgServer config)) (serverPort serverOpts)
         staticDir = fromMaybe "web/dist" (serverStaticDir serverOpts)
     password <- resolvePassword (globalOptions cliConfig) (cfgServer config)
-    logServerStartup serverOpts port password
     (lastRequestRef, idleActiveRef) <- setupIdleTimeout serverOpts
     baseApp <-
         createServerApp
@@ -243,8 +242,15 @@ runServerWithConfig cliConfig serverOpts cfgFile = do
     let finalApp =
             uploadSizeLimitMiddleware (cfgHosting config) $
                 wrapWithMiddleware password lastRequestRef idleActiveRef baseApp
-        settings = setTimeout 600 (setPort port defaultSettings)
-    runSettings settings finalApp
+        settings = setTimeout 600 defaultSettings
+    if port == 0
+        then do
+            (boundPort, socket) <- openFreePort
+            logServerStartup serverOpts boundPort password
+            runSettingsSocket settings socket finalApp
+        else do
+            logServerStartup serverOpts port password
+            runSettings (setPort port settings) finalApp
 
 {- | Run config load-only mode (load all databases from config and exit)
 Useful for cache generation, validation, and benchmarking

--- a/pyvolca/CHANGELOG.md
+++ b/pyvolca/CHANGELOG.md
@@ -18,6 +18,14 @@ git cliff --unreleased --tag pyvolca-v0.X.Y   # render as a released section
 
 Then paste the rendered block at the top of this file and tighten wording.
 
+## [Unreleased]
+
+### Added
+
+- `Server(port="auto")` now uses the engine's atomic OS-assigned port mode and
+  reads the bound port from `VOLCA_PORT=N`; managed servers no longer need to
+  select a port with a reserve-then-release race.
+
 ## [0.8.0] - 2026-07-14
 
 ### Added

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -27,7 +27,7 @@ pyvolca speaks one revision of the engine's JSON wire format; the engine adverti
 
 _Generated from `volca._compat` — run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.8.0** speaks wire format **2** and requires a VoLCA engine **≥ v0.9.1**.
+This build of **pyvolca 0.8.1.dev0** speaks wire format **2** and requires a VoLCA engine **≥ v0.9.1**.
 
 <!-- END: compatibility -->
 
@@ -934,7 +934,7 @@ Usage::
         client = Client(base_url=srv.base_url, db="agribalyse-3.2", password=srv.password)
         activities = client.search_activities(name="at plant")
 
-**Constructor**: `Server(config: str = 'volca.toml', port: int = 0, binary: str = 'volca')`
+**Constructor**: `Server(config: str = 'volca.toml', port: Union[int, Literal['auto']] = 0, binary: str = 'volca')`
 
 #### Properties
 

--- a/pyvolca/pyproject.toml
+++ b/pyvolca/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvolca"
-version = "0.8.0"
+version = "0.8.1.dev0"
 description = "Python client for VoLCA — Life Cycle Assessment engine"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/pyvolca/src/volca/server.py
+++ b/pyvolca/src/volca/server.py
@@ -1,10 +1,13 @@
 """Server lifecycle management for VoLCA."""
 
 import os
+import queue
 import shutil
 import subprocess
+import threading
 import time
 from pathlib import Path
+from typing import Literal
 
 import requests
 
@@ -26,14 +29,16 @@ class Server:
             activities = client.search_activities(name="at plant")
     """
 
-    def __init__(self, config: str = "volca.toml", port: int = 0, binary: str = "volca"):
+    def __init__(self, config: str = "volca.toml", port: int | Literal["auto"] = 0, binary: str = "volca"):
         """Configure (but don't start) a managed VoLCA server.
 
         Args:
             config: Path to the engine TOML. Read for ``server.port`` and
                 ``server.password``. Missing file is tolerated — defaults
                 are used.
-            port: Override the port. ``0`` means "read from config (or 8080)".
+            port: Override the configured port. ``"auto"`` asks the engine to
+                bind an OS-assigned free port atomically. ``0`` reads the
+                config (or uses 8080), preserving the original API.
             binary: Name or path of the volca binary. Looked up on PATH if
                 not absolute.
         """
@@ -44,7 +49,7 @@ class Server:
         # Read port and password from config
         cfg = self._read_config()
         server_cfg = cfg.get("server", {})
-        self.port = port or server_cfg.get("port", 8080)
+        self.port = 0 if port == "auto" else port or server_cfg.get("port", 8080)
         self.password = server_cfg.get("password", "")
 
     @property
@@ -137,6 +142,39 @@ class Server:
 
         _compat.check(Client(self.base_url, password=self.password).get_version())
 
+    def _await_bound_port(self, wait_timeout: int) -> None:
+        """Read the engine's machine-readable port after it has bound port 0."""
+        process = self._process
+        if process is None or process.stdout is None:
+            raise RuntimeError("dynamic-port server has no stdout pipe")
+
+        lines: queue.Queue[str | None] = queue.Queue()
+
+        def read_stdout() -> None:
+            assert process.stdout is not None
+            for line in process.stdout:
+                lines.put(line)
+            lines.put(None)
+
+        threading.Thread(target=read_stdout, daemon=True).start()
+        deadline = time.monotonic() + wait_timeout
+        while (remaining := deadline - time.monotonic()) > 0:
+            if process.poll() is not None:
+                raise RuntimeError("VoLCA exited before reporting its bound port")
+            try:
+                line = lines.get(timeout=min(0.1, remaining))
+            except queue.Empty:
+                continue
+            if line is None:
+                raise RuntimeError("VoLCA closed stdout before reporting its bound port")
+            if line.startswith("VOLCA_PORT="):
+                port = int(line.removeprefix("VOLCA_PORT=").strip())
+                if not 1 <= port <= 65535:
+                    raise RuntimeError(f"VoLCA reported an invalid port: {port}")
+                self.port = port
+                return
+        raise TimeoutError(f"Server did not report its bound port within {wait_timeout}s")
+
     def start(self, idle_timeout: int = 300, wait_timeout: int = 120) -> None:
         """Spawn the engine process if it is not already serving, and wait until ready.
 
@@ -148,7 +186,8 @@ class Server:
 
         No-op if a healthy server is already reachable on ``base_url``.
         """
-        if self.is_alive():
+        dynamic_port = self.port == 0
+        if not dynamic_port and self.is_alive():
             # A server is already up — we didn't spawn it, so verify the wire
             # but leave it running on a mismatch; it isn't ours to stop.
             self._check_wire()
@@ -162,12 +201,22 @@ class Server:
             "--port", str(self.port),
             "--idle-timeout", str(idle_timeout),
         ]
+        if dynamic_port:
+            cmd.append("--desktop")
         self._process = subprocess.Popen(
             cmd,
-            stdout=subprocess.DEVNULL,
+            stdout=subprocess.PIPE if dynamic_port else subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             env=self._subprocess_env(),
+            text=dynamic_port,
         )
+
+        if dynamic_port:
+            try:
+                self._await_bound_port(wait_timeout)
+            except Exception:
+                self.stop()
+                raise
 
         # Poll until server is ready
         deadline = time.monotonic() + wait_timeout

--- a/pyvolca/tests/test_server.py
+++ b/pyvolca/tests/test_server.py
@@ -8,6 +8,7 @@ name (the common case: running a script from a source checkout that has a
 
 from __future__ import annotations
 
+import io
 from pathlib import Path
 from unittest import mock
 
@@ -57,3 +58,56 @@ def test_find_binary_raises_when_nothing_found(tmp_path: Path, monkeypatch):
         srv = Server(config="absent.toml", binary="volca")
         with pytest.raises(FileNotFoundError):
             srv._find_binary()
+
+
+def test_auto_port_preserves_explicit_zero_compatibility(tmp_path: Path):
+    config = tmp_path / "volca.toml"
+    config.write_text("[server]\nport = 8123\n")
+
+    assert Server(config=str(config)).port == 8123
+    assert Server(config=str(config), port=0).port == 8123
+    assert Server(config=str(config), port="auto").port == 0
+
+
+def test_await_bound_port_accepts_engine_announcement():
+    process = mock.Mock()
+    process.stdout = io.StringIO("VOLCA_PORT=43123\n")
+    process.poll.return_value = None
+    srv = Server(config="absent.toml", port="auto")
+    srv._process = process
+
+    srv._await_bound_port(wait_timeout=1)
+
+    assert srv.port == 43123
+
+
+@pytest.mark.parametrize("line", ["VOLCA_PORT=0\n", "VOLCA_PORT=70000\n"])
+def test_await_bound_port_rejects_invalid_port(line: str):
+    process = mock.Mock()
+    process.stdout = io.StringIO(line)
+    process.poll.return_value = None
+    srv = Server(config="absent.toml", port="auto")
+    srv._process = process
+
+    with pytest.raises(RuntimeError, match="invalid port"):
+        srv._await_bound_port(wait_timeout=1)
+
+
+def test_start_dynamic_port_uses_desktop_announcement(monkeypatch):
+    process = mock.Mock()
+    process.stdout = io.StringIO("VOLCA_PORT=43123\n")
+    process.poll.return_value = None
+    srv = Server(config="absent.toml", port="auto")
+    monkeypatch.setattr(srv, "_find_binary", lambda: "/tmp/volca")
+    monkeypatch.setattr(srv, "is_alive", lambda: True)
+    check_wire = mock.Mock()
+    monkeypatch.setattr(srv, "_check_wire", check_wire)
+
+    with mock.patch("volca.server.subprocess.Popen", return_value=process) as popen:
+        srv.start(wait_timeout=1)
+
+    command = popen.call_args.args[0]
+    assert command[-1] == "--desktop"
+    assert command[command.index("--port") + 1] == "0"
+    assert srv.port == 43123
+    check_wire.assert_called_once_with()

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -198,7 +198,7 @@ serverParser = Server <$> serverOptionsParser
 
 serverOptionsParser :: Parser ServerOptions
 serverOptionsParser = do
-    serverPort <- optIntOpt "port" (Just 'p') "PORT" "Server port (overrides [server].port from config; default: 8080)"
+    serverPort <- optIntOpt "port" (Just 'p') "PORT" "Server port (0=OS-assigned; overrides [server].port; default: 8080)"
     serverLoadDbs <-
         optional $
             option dbListReader (long "load" <> metavar "DB1,DB2,..." <> help "Comma-separated list of databases to load at startup (overrides config load=true)")


### PR DESCRIPTION
## Summary
- let VoLCA reserve an OS-assigned loopback port with Warp's `openFreePort`
- announce the actual port only after the listening socket is bound
- add `Server(port="auto")` to pyvolca while preserving existing `port=0` semantics
- cover dynamic-port parsing, invalid announcements, command construction, and compatibility

## Why
The canonical converter previously probed and released a free port before starting VoLCA. Another local process could claim that port and impersonate the engine. This change removes the TOCTOU at its source.

## Verification
- pyvolca: 231 passed, 7 skipped
- pyright: 0 errors, 0 warnings
- Warp `openFreePort` / `runSettingsSocket` integration type-checked locally
- full native build is delegated to CI because this checkout has GHC 9.6.7 while the repository requires GHC 9.12.4