### PR TITLE
Simplify the dynamic-port announcement follow-up to #204

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## [Unreleased]
 
 ### Added
-- `server --port 0 --desktop` now asks the OS to bind an available port and
-  prints the actual `VOLCA_PORT=N` only after the listening socket is reserved.
-  Launchers can therefore avoid reserve-then-release port races.
+- `server --port 0 --desktop` now asks the OS to bind an available loopback
+  port and prints the actual `VOLCA_PORT=N` only after the listening socket is
+  reserved. Launchers can therefore avoid reserve-then-release port races.
+  With port 0 the server is only reachable from the local machine.
 
 ## [0.9.1] - 2026-07-11
 

--- a/pyvolca/src/volca/server.py
+++ b/pyvolca/src/volca/server.py
@@ -1,7 +1,6 @@
 """Server lifecycle management for VoLCA."""
 
 import os
-import queue
 import shutil
 import subprocess
 import threading
@@ -148,32 +147,29 @@ class Server:
         if process is None or process.stdout is None:
             raise RuntimeError("dynamic-port server has no stdout pipe")
 
-        lines: queue.Queue[str | None] = queue.Queue()
+        announced: list[str] = []
 
         def read_stdout() -> None:
             assert process.stdout is not None
             for line in process.stdout:
-                lines.put(line)
-            lines.put(None)
+                if line.startswith("VOLCA_PORT="):
+                    announced.append(line.removeprefix("VOLCA_PORT=").strip())
+                    return
 
-        threading.Thread(target=read_stdout, daemon=True).start()
-        deadline = time.monotonic() + wait_timeout
-        while (remaining := deadline - time.monotonic()) > 0:
-            if process.poll() is not None:
-                raise RuntimeError("VoLCA exited before reporting its bound port")
-            try:
-                line = lines.get(timeout=min(0.1, remaining))
-            except queue.Empty:
-                continue
-            if line is None:
-                raise RuntimeError("VoLCA closed stdout before reporting its bound port")
-            if line.startswith("VOLCA_PORT="):
-                port = int(line.removeprefix("VOLCA_PORT=").strip())
-                if not 1 <= port <= 65535:
-                    raise RuntimeError(f"VoLCA reported an invalid port: {port}")
-                self.port = port
-                return
-        raise TimeoutError(f"Server did not report its bound port within {wait_timeout}s")
+        # The engine's death closes stdout, which ends the thread; the join
+        # carries the timeout. No need to watch the process separately.
+        reader = threading.Thread(target=read_stdout, daemon=True)
+        reader.start()
+        reader.join(wait_timeout)
+        if reader.is_alive():
+            raise TimeoutError(f"Server did not report its bound port within {wait_timeout}s")
+        if not announced:
+            raise RuntimeError("VoLCA exited before reporting its bound port")
+        raw = announced[0]
+        port = int(raw) if raw.isdigit() else 0
+        if not 1 <= port <= 65535:
+            raise RuntimeError(f"VoLCA reported an invalid port: {raw}")
+        self.port = port
 
     def start(self, idle_timeout: int = 300, wait_timeout: int = 120) -> None:
         """Spawn the engine process if it is not already serving, and wait until ready.
@@ -208,7 +204,7 @@ class Server:
             stdout=subprocess.PIPE if dynamic_port else subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             env=self._subprocess_env(),
-            text=dynamic_port,
+            text=True,
         )
 
         if dynamic_port:

--- a/pyvolca/src/volca/server.py
+++ b/pyvolca/src/volca/server.py
@@ -166,7 +166,7 @@ class Server:
         if not announced:
             raise RuntimeError("VoLCA exited before reporting its bound port")
         raw = announced[0]
-        port = int(raw) if raw.isdigit() else 0
+        port = int(raw) if raw.isdecimal() else 0
         if not 1 <= port <= 65535:
             raise RuntimeError(f"VoLCA reported an invalid port: {raw}")
         self.port = port

--- a/pyvolca/tests/test_server.py
+++ b/pyvolca/tests/test_server.py
@@ -80,7 +80,9 @@ def test_await_bound_port_accepts_engine_announcement():
     assert srv.port == 43123
 
 
-@pytest.mark.parametrize("line", ["VOLCA_PORT=0\n", "VOLCA_PORT=70000\n", "VOLCA_PORT=garbage\n"])
+@pytest.mark.parametrize(
+    "line", ["VOLCA_PORT=0\n", "VOLCA_PORT=70000\n", "VOLCA_PORT=garbage\n", "VOLCA_PORT=²\n"]
+)
 def test_await_bound_port_rejects_invalid_port(line: str):
     process = mock.Mock()
     process.stdout = io.StringIO(line)

--- a/pyvolca/tests/test_server.py
+++ b/pyvolca/tests/test_server.py
@@ -72,7 +72,6 @@ def test_auto_port_preserves_explicit_zero_compatibility(tmp_path: Path):
 def test_await_bound_port_accepts_engine_announcement():
     process = mock.Mock()
     process.stdout = io.StringIO("VOLCA_PORT=43123\n")
-    process.poll.return_value = None
     srv = Server(config="absent.toml", port="auto")
     srv._process = process
 
@@ -81,11 +80,10 @@ def test_await_bound_port_accepts_engine_announcement():
     assert srv.port == 43123
 
 
-@pytest.mark.parametrize("line", ["VOLCA_PORT=0\n", "VOLCA_PORT=70000\n"])
+@pytest.mark.parametrize("line", ["VOLCA_PORT=0\n", "VOLCA_PORT=70000\n", "VOLCA_PORT=garbage\n"])
 def test_await_bound_port_rejects_invalid_port(line: str):
     process = mock.Mock()
     process.stdout = io.StringIO(line)
-    process.poll.return_value = None
     srv = Server(config="absent.toml", port="auto")
     srv._process = process
 
@@ -93,10 +91,19 @@ def test_await_bound_port_rejects_invalid_port(line: str):
         srv._await_bound_port(wait_timeout=1)
 
 
+def test_await_bound_port_reports_early_exit():
+    process = mock.Mock()
+    process.stdout = io.StringIO("some unrelated log line\n")
+    srv = Server(config="absent.toml", port="auto")
+    srv._process = process
+
+    with pytest.raises(RuntimeError, match="exited before reporting"):
+        srv._await_bound_port(wait_timeout=1)
+
+
 def test_start_dynamic_port_uses_desktop_announcement(monkeypatch):
     process = mock.Mock()
     process.stdout = io.StringIO("VOLCA_PORT=43123\n")
-    process.poll.return_value = None
     srv = Server(config="absent.toml", port="auto")
     monkeypatch.setattr(srv, "_find_binary", lambda: "/tmp/volca")
     monkeypatch.setattr(srv, "is_alive", lambda: True)
@@ -107,7 +114,7 @@ def test_start_dynamic_port_uses_desktop_announcement(monkeypatch):
         srv.start(wait_timeout=1)
 
     command = popen.call_args.args[0]
-    assert command[-1] == "--desktop"
+    assert "--desktop" in command
     assert command[command.index("--port") + 1] == "0"
     assert srv.port == 43123
     check_wire.assert_called_once_with()

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -198,7 +198,7 @@ serverParser = Server <$> serverOptionsParser
 
 serverOptionsParser :: Parser ServerOptions
 serverOptionsParser = do
-    serverPort <- optIntOpt "port" (Just 'p') "PORT" "Server port (0=OS-assigned; overrides [server].port; default: 8080)"
+    serverPort <- optIntOpt "port" (Just 'p') "PORT" "Server port (0=OS-assigned, binds loopback only; overrides [server].port; default: 8080)"
     serverLoadDbs <-
         optional $
             option dbListReader (long "load" <> metavar "DB1,DB2,..." <> help "Comma-separated list of databases to load at startup (overrides config load=true)")


### PR DESCRIPTION
## Summary
Follow-up to the post-merge review of #204.

- `_await_bound_port` now lets the reader thread do the parsing and relies on `thread.join(timeout)`: the engine's death closes stdout and ends the thread, so the queue, the manual deadline loop and the `process.poll()` check were three error paths for the same condition. Same guarantees, a third less code.
- A non-numeric `VOLCA_PORT=` value now raises the same clear `RuntimeError` as an out-of-range one, instead of leaking a bare `ValueError`. Covered by a new test parameter.
- The `--port` help text and the changelog now say that port 0 binds the loopback interface only — Warp's `openFreePort` binds 127.0.0.1, unlike the fixed-port path which listens on all interfaces. Without this note the narrower bind is a silent behavior difference.

## Verification
- pyvolca: 233 passed, 7 skipped
- pyright on `server.py`: 0 errors, 0 warnings