### PR TITLE
Release 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.9.2] - 2026-07-14
 
 ### Added
 - `server --port 0 --desktop` now asks the OS to bind an available loopback

--- a/volca.cabal
+++ b/volca.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                volca
-version:             0.9.2-dev
+version:             0.9.2
 build-type:          Simple
 
 license:             Apache-2.0


### PR DESCRIPTION
Cut the 0.9.2 release: date the changelog section and drop the `-dev` suffix from the cabal version.

Since 0.9.1 the engine gained one user-visible change: `server --port 0 --desktop` now reserves an OS-assigned loopback port atomically and announces `VOLCA_PORT=N` only after the listening socket is bound, so launchers no longer race a reserve-then-release port probe. The wire revision is unchanged (still 2).

Final state after this merges: main carries the released `0.9.2` version and a dated changelog, ready to tag.