### PR TITLE
Release pyvolca 0.8.1

### DIFF
--- a/pyvolca/CHANGELOG.md
+++ b/pyvolca/CHANGELOG.md
@@ -18,13 +18,26 @@ git cliff --unreleased --tag pyvolca-v0.X.Y   # render as a released section
 
 Then paste the rendered block at the top of this file and tighten wording.
 
-## [Unreleased]
+## [0.8.1] - 2026-07-14
 
 ### Added
 
-- `Server(port="auto")` now uses the engine's atomic OS-assigned port mode and
-  reads the bound port from `VOLCA_PORT=N`; managed servers no longer need to
-  select a port with a reserve-then-release race.
+- `Server(port="auto")` asks the engine (v0.9.2 or newer) to bind an
+  OS-assigned loopback port atomically and reads the bound port from
+  `VOLCA_PORT=N`; managed servers no longer need to select a port with a
+  reserve-then-release race.
+
+### Fixed
+
+- Binary database exports work again: 0.8.0 forgot to send the
+  `Accept: application/octet-stream` header the engine's raw-bytes export
+  requires, so every `export_database` call failed with HTTP 406. The client
+  now sends it.
+
+### Changed
+
+- The runnable examples left this repository — they now live at
+  <https://www.volca.run/examples/>.
 
 ## [0.8.0] - 2026-07-14
 

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -27,7 +27,7 @@ pyvolca speaks one revision of the engine's JSON wire format; the engine adverti
 
 _Generated from `volca._compat` — run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.8.1.dev0** speaks wire format **2** and requires a VoLCA engine **≥ v0.9.1**.
+This build of **pyvolca 0.8.1** speaks wire format **2** and requires a VoLCA engine **≥ v0.9.1**.
 
 <!-- END: compatibility -->
 

--- a/pyvolca/pyproject.toml
+++ b/pyvolca/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvolca"
-version = "0.8.1.dev0"
+version = "0.8.1"
 description = "Python client for VoLCA — Life Cycle Assessment engine"
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
Cut the pyvolca release for the two client changes merged since 0.8.0: the missing `Accept` header that broke every binary database export with HTTP 406, and `Server(port="auto")` which delegates port allocation to the engine's atomic OS-assigned mode (engine v0.9.2 or newer).

The wire revision is unchanged (2), so `MIN_ENGINE_HINT` stays 0.9.1; `port="auto"` is the only feature needing v0.9.2 and its changelog entry says so.

Final state after this merges: `pyvolca/pyproject.toml` carries `0.8.1` and the changelog has a dated 0.8.1 section, ready to tag `pyvolca-v0.8.1`.