### PR TITLE
Start the server without --config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- `volca server` starts without `--config`: it runs on the built-in defaults
+  with no databases, ready to receive uploads or API-driven loads. Launchers
+  no longer have to write an empty TOML file just to satisfy the flag. An
+  explicit `--config` path that does not exist still fails loudly.
+
 ## [0.9.2] - 2026-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Authentication uses the same password as the REST API.
 
 | Option | Description |
 |--------|-------------|
-| `--config FILE` | TOML config file for multi-database setup |
+| `--config FILE` | TOML config file for multi-database setup (optional for `server` and `stop`, which run on built-in defaults without it) |
 | `--url URL` | Server URL (default: from config; or set `VOLCA_URL`) |
 | `--password PWD` | Server password (or set `VOLCA_PASSWORD`) |
 | `--db NAME` | Database name to query |

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -92,7 +92,9 @@ still validates it and honours VOLCA_DATA_DIR.
 -}
 loadConfigOrDie :: Maybe FilePath -> IO Config
 loadConfigOrDie mCfgFile = do
-    mapM_ (\cfgFile -> reportProgress Info $ "Loading configuration from: " ++ cfgFile) mCfgFile
+    reportProgress Info $ case mCfgFile of
+        Just cfgFile -> "Loading configuration from: " ++ cfgFile
+        Nothing -> "No --config given, running on built-in defaults (no databases)"
     configResult <- loadConfigOrDefault mCfgFile
     case configResult of
         Left err -> do
@@ -148,6 +150,20 @@ applyLoadOverride :: ServerOptions -> Config -> Config
 applyLoadOverride serverOpts config = case serverLoadDbs serverOpts of
     Nothing -> config
     Just dbNames -> config{cfgDatabases = map (overrideLoad dbNames) (cfgDatabases config)}
+
+{- | Warn for each --load name that matches no configured database: the
+override silently loads nothing for it — guaranteed when running on the
+built-in defaults, which configure no databases at all.
+-}
+warnUnknownLoadNames :: ServerOptions -> Config -> IO ()
+warnUnknownLoadNames serverOpts config =
+    mapM_ warn unknown
+  where
+    known = map dcName (cfgDatabases config)
+    unknown = concatMap (filter (`notElem` known)) (serverLoadDbs serverOpts)
+    warn name =
+        reportProgress Warning $
+            "--load " ++ T.unpack name ++ " matches no configured database; nothing will be loaded for it"
 
 -- | Log loaded databases (allows starting with none for BYOL mode).
 logLoadedDatabases :: DatabaseManager -> IO ()
@@ -222,10 +238,11 @@ uploadSizeLimitMiddleware hostingConfig =
             (pure . uploadBodyCeiling hostingConfig . pathInfo)
             defaultRequestSizeLimitSettings
 
--- | Run server with multi-database configuration file
+-- | Run the server: on a configuration file when given, else on built-in defaults.
 runServerWithConfig :: CLIConfig -> ServerOptions -> Maybe FilePath -> IO ()
 runServerWithConfig cliConfig serverOpts mCfgFile = do
     config <- applyLoadOverride serverOpts <$> loadConfigOrDie mCfgFile
+    warnUnknownLoadNames serverOpts config
     reportProgress Info "Initializing database manager..."
     dbManager <- initDatabaseManager config (noCache (globalOptions cliConfig)) mCfgFile
     logLoadedDatabases dbManager

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -28,7 +28,7 @@ import CLI.Command (executeCommand)
 import CLI.Parser (cliParserInfo)
 import CLI.Repl (runRepl)
 import CLI.Types
-import Config (ClassificationPreset, Config (..), DatabaseConfig (..), HostingConfig (..), ServerConfig (..), loadConfig)
+import Config (ClassificationPreset, Config (..), DatabaseConfig (..), HostingConfig (..), ServerConfig (..), loadConfigOrDefault)
 import Control.Concurrent.STM (readTVarIO)
 import Database.Manager (DatabaseManager (..), initDatabaseManager)
 import Network.HTTP.Client (Manager, defaultManagerSettings, managerResponseTimeout, newManager, responseTimeoutNone)
@@ -78,7 +78,7 @@ main = do
     case (CLI.Types.command cliConfig, configFile (globalOptions cliConfig)) of
         (Just DumpOpenApi, _) -> BSL.putStrLn (encode volcaOpenApi)
         (Just DumpMcpTools, _) -> BSL.putStrLn (encode toolDefinitions)
-        (Just (Server serverOpts), Just cfgFile) -> runServerWithConfig cliConfig serverOpts cfgFile
+        (Just (Server serverOpts), mCfgFile) -> runServerWithConfig cliConfig serverOpts mCfgFile
         (Just Repl, Just cfgFile) -> runReplMode cliConfig cfgFile
         (Just cmd, Just cfgFile) | isLocalCommand cmd -> runCLIWithConfig cliConfig cmd cfgFile
         (Just cmd, Just cfgFile) -> runCLIViaAPI cliConfig cmd cfgFile
@@ -86,11 +86,14 @@ main = do
         (Just Stop, Nothing) -> runStopWithoutConfig cliConfig
         _ -> die "--config is required"
 
--- | Load config or die with error message
-loadConfigOrDie :: FilePath -> IO Config
-loadConfigOrDie cfgFile = do
-    reportProgress Info $ "Loading configuration from: " ++ cfgFile
-    configResult <- loadConfig cfgFile
+{- | Load config or die with error message. Without a path the effective
+config is the built-in defaults (no databases) — 'loadConfigOrDefault'
+still validates it and honours VOLCA_DATA_DIR.
+-}
+loadConfigOrDie :: Maybe FilePath -> IO Config
+loadConfigOrDie mCfgFile = do
+    mapM_ (\cfgFile -> reportProgress Info $ "Loading configuration from: " ++ cfgFile) mCfgFile
+    configResult <- loadConfigOrDefault mCfgFile
     case configResult of
         Left err -> do
             reportError $ "Failed to load config: " ++ T.unpack err
@@ -106,7 +109,7 @@ isLocalCommand _ = False
 -- | Run local-only CLI commands through DatabaseManager (loads DBs, matrix solver)
 runCLIWithConfig :: CLIConfig -> Command -> FilePath -> IO ()
 runCLIWithConfig cliConfig cmd cfgFile = do
-    config <- loadConfigOrDie cfgFile
+    config <- loadConfigOrDie (Just cfgFile)
     dbManager <- initDatabaseManager config (noCache (globalOptions cliConfig)) (Just cfgFile)
     executeCommand cliConfig cmd dbManager
 
@@ -120,7 +123,7 @@ newClientManager = newManager defaultManagerSettings{managerResponseTimeout = re
 -- | Run CLI commands via HTTP against a running server (lightweight, no DB loading)
 runCLIViaAPI :: CLIConfig -> Command -> FilePath -> IO ()
 runCLIViaAPI cliConfig cmd cfgFile = do
-    config <- loadConfigOrDie cfgFile
+    config <- loadConfigOrDie (Just cfgFile)
     mgr <- newClientManager
     rc <- resolveRemoteConfig (globalOptions cliConfig) (Just config)
     executeRemoteCommand mgr rc (globalOptions cliConfig) cmd
@@ -128,7 +131,7 @@ runCLIViaAPI cliConfig cmd cfgFile = do
 -- | Run interactive REPL over HTTP (auto-starts server if needed)
 runReplMode :: CLIConfig -> FilePath -> IO ()
 runReplMode cliConfig cfgFile = do
-    config <- loadConfigOrDie cfgFile
+    config <- loadConfigOrDie (Just cfgFile)
     mgr <- newClientManager
     rc <- resolveRemoteConfig (globalOptions cliConfig) (Just config)
     runRepl mgr rc (globalOptions cliConfig) cfgFile
@@ -220,11 +223,11 @@ uploadSizeLimitMiddleware hostingConfig =
             defaultRequestSizeLimitSettings
 
 -- | Run server with multi-database configuration file
-runServerWithConfig :: CLIConfig -> ServerOptions -> FilePath -> IO ()
-runServerWithConfig cliConfig serverOpts cfgFile = do
-    config <- applyLoadOverride serverOpts <$> loadConfigOrDie cfgFile
+runServerWithConfig :: CLIConfig -> ServerOptions -> Maybe FilePath -> IO ()
+runServerWithConfig cliConfig serverOpts mCfgFile = do
+    config <- applyLoadOverride serverOpts <$> loadConfigOrDie mCfgFile
     reportProgress Info "Initializing database manager..."
-    dbManager <- initDatabaseManager config (noCache (globalOptions cliConfig)) (Just cfgFile)
+    dbManager <- initDatabaseManager config (noCache (globalOptions cliConfig)) mCfgFile
     logLoadedDatabases dbManager
     let port = fromMaybe (scPort (cfgServer config)) (serverPort serverOpts)
         staticDir = fromMaybe "web/dist" (serverStaticDir serverOpts)
@@ -257,7 +260,7 @@ Useful for cache generation, validation, and benchmarking
 -}
 runConfigLoadOnly :: CLIConfig -> FilePath -> IO ()
 runConfigLoadOnly cliConfig cfgFile = do
-    config <- loadConfigOrDie cfgFile
+    config <- loadConfigOrDie (Just cfgFile)
 
     -- Initialize DatabaseManager (pre-loads databases with load=true)
     reportProgress Info "Loading all databases from config..."

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -57,7 +57,7 @@ cliParser = CLIConfig <$> globalOptionsParser <*> optional commandParser
 -- | Global options parser (applied before commands)
 globalOptionsParser :: Parser GlobalOptions
 globalOptionsParser = do
-    configFile <- optStrOpt "config" (Just 'c') "FILE" "TOML config file (required)"
+    configFile <- optStrOpt "config" (Just 'c') "FILE" "TOML config file (server and stop run on built-in defaults without it; other commands require it)"
     dbName <- optTextOpt "db" Nothing "NAME" "Database name to query (from config file)"
     methodsDir <- optStrOpt "methods" Nothing "PATH" "Directory containing ILCD method XML files for LCIA"
     format <-

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -20,6 +20,7 @@ module Config (
     -- * Loading
     loadConfig,
     loadConfigFile,
+    loadConfigOrDefault,
 
     -- * VOLCA_DATA_DIR resolution
     redirectIntoDataDir,
@@ -416,6 +417,17 @@ loadConfig path = do
     case result of
         Left err -> pure $ Left err
         Right cfg -> pure $ validateConfig (applyDataDir mDataDir cfg)
+
+{- | Resolve the effective configuration: parse the file when a path is given,
+otherwise fall back to 'defaultConfig'. Both paths honour VOLCA_DATA_DIR and
+run 'validateConfig' — an explicit path that does not exist still fails
+loudly, while no path at all means "all defaults, no databases".
+-}
+loadConfigOrDefault :: Maybe FilePath -> IO (Either Text Config)
+loadConfigOrDefault (Just path) = loadConfig path
+loadConfigOrDefault Nothing = do
+    mDataDir <- lookupEnv "VOLCA_DATA_DIR"
+    pure $ validateConfig (applyDataDir mDataDir defaultConfig)
 
 {- | Redirect a "data/<rest>" path to "$VOLCA_DATA_DIR/<rest>".
 Returns the input unchanged when the env var is unset, or when the path

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -411,23 +411,18 @@ data bundle from the binary so they can be versioned independently.
 Database and method paths (user content) are unaffected.
 -}
 loadConfig :: FilePath -> IO (Either Text Config)
-loadConfig path = do
-    result <- loadConfigFile path
-    mDataDir <- lookupEnv "VOLCA_DATA_DIR"
-    case result of
-        Left err -> pure $ Left err
-        Right cfg -> pure $ validateConfig (applyDataDir mDataDir cfg)
+loadConfig = loadConfigOrDefault . Just
 
 {- | Resolve the effective configuration: parse the file when a path is given,
 otherwise fall back to 'defaultConfig'. Both paths honour VOLCA_DATA_DIR and
-run 'validateConfig' — an explicit path that does not exist still fails
-loudly, while no path at all means "all defaults, no databases".
+run 'validateConfig' by construction — an explicit path that does not exist
+still fails loudly, while no path at all means "all defaults, no databases".
 -}
 loadConfigOrDefault :: Maybe FilePath -> IO (Either Text Config)
-loadConfigOrDefault (Just path) = loadConfig path
-loadConfigOrDefault Nothing = do
+loadConfigOrDefault mPath = do
+    raw <- maybe (pure (Right defaultConfig)) loadConfigFile mPath
     mDataDir <- lookupEnv "VOLCA_DATA_DIR"
-    pure $ validateConfig (applyDataDir mDataDir defaultConfig)
+    pure $ raw >>= validateConfig . applyDataDir mDataDir
 
 {- | Redirect a "data/<rest>" path to "$VOLCA_DATA_DIR/<rest>".
 Returns the input unchanged when the env var is unset, or when the path

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -12,10 +12,12 @@ import Config (
     ScoringSetConfig (..),
     applyDataDir,
     defaultConfig,
+    loadConfigOrDefault,
     redirectIntoDataDir,
  )
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
+import qualified Data.Text as T
 import qualified TOML
 import Test.Hspec
 
@@ -145,6 +147,19 @@ spec = do
 
         it "is a no-op when the env var is unset" $
             applyDataDir Nothing cfg `shouldBe` cfg
+
+    describe "loadConfigOrDefault" $ do
+        it "yields the validated defaults when no path is given" $ do
+            result <- loadConfigOrDefault Nothing
+            case result of
+                Right cfg -> cfgDatabases cfg `shouldBe` []
+                Left err -> expectationFailure (show err)
+
+        it "still fails loudly on an explicit path that does not exist" $ do
+            result <- loadConfigOrDefault (Just "/nonexistent/volca.toml")
+            case result of
+                Left err -> err `shouldSatisfy` ("Config file not found" `T.isPrefixOf`)
+                Right _ -> expectationFailure "expected a missing explicit config to fail"
 
     describe "ScoringSetConfig labels" $ do
         let decodeSet :: Text -> Either TOML.TOMLError ScoringSetConfig


### PR DESCRIPTION
A throwaway or upload-driven server previously required a config file on disk even when everything about it was default — launchers wrote an empty TOML file just to satisfy the flag. `volca server` (and the existing `stop`) now run on the built-in defaults when `--config` is absent: no databases, everything loadable over the API.

Both paths funnel through the new `Config.loadConfigOrDefault`, so the defaults are validated and honour `VOLCA_DATA_DIR` exactly like a parsed file, and an explicit `--config` path that does not exist still fails loudly — a typo must never silently become "all defaults". Other commands keep requiring the flag: without a config they have neither databases nor a server address to act on.