### PR TITLE
Make a non-matching name filter return an empty result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- The `name=` filter on the supply-chain and consumers endpoints (REST and
+  MCP) now filters. A name matching nothing previously disabled the filter
+  and returned every entry — with a matching `filteredActivities` count — so
+  a caller could not tell "no match" from "no filter". It now returns an
+  empty result.
+
 ## [0.9.2] - 2026-07-14
 
 ### Added

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -832,9 +832,11 @@ bm25Retrieve db queryText = do
              in Just [(pid, a) | (pid, _, a) <- sorted]
 
 {- | Set of ProcessIds whose name fuzzy-matches the query, using the same
-semantics as @/activities@ BM25 search. @Nothing@ signals \"no filter\":
-either the query tokenizes to nothing or the database has no BM25 index
-(only happens in bare test fixtures; production DBs always carry one).
+semantics as @/activities@ BM25 search. @Nothing@ means the retrieval could
+not run — no BM25 index (only bare test fixtures; production DBs always
+carry one) or a query whose fuzzy expansion is empty. What that means is
+the caller's call: 'nameFilterSet' treats a present-but-unmatchable query
+as \"reject every pid\", never as \"no filter\".
 -}
 bm25MatchingPids :: Database -> Text -> Maybe IS.IntSet
 bm25MatchingPids db =

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -842,13 +842,17 @@ bm25MatchingPids db =
 
 {- | BM25/fuzzy membership set for the optional @name@ filter carried on any
 activity-oriented filter. Blank/absent queries and DBs without a BM25 index
-both collapse to @Nothing@ (⇒ predicate accepts every pid), so call sites
-stay a one-liner.
+both collapse to @Nothing@ (⇒ predicate accepts every pid). A present query
+whose fuzzy expansion matches nothing yields @Just IS.empty@ (⇒ reject every
+pid): a non-matching name must return an empty result, never silently
+disable the filter.
 -}
 nameFilterSet :: Database -> Maybe Text -> Maybe IS.IntSet
 nameFilterSet db mq = do
     q <- mq
-    if T.null (T.strip q) then Nothing else bm25MatchingPids db q
+    guard (not (T.null (T.strip q)))
+    _ <- dbBM25Index db
+    pure (fromMaybe IS.empty (bm25MatchingPids db q))
 
 {- | BM25 retrieval applies only when the user provided a non-empty name
 query, didn't request exact matching, and didn't pick an explicit sort

--- a/test/SupplyChainSpec.hs
+++ b/test/SupplyChainSpec.hs
@@ -178,6 +178,16 @@ spec = do
             scrFilteredActivities (buildWithName db rootPid supplyVec (Just "zzznomatch"))
                 `shouldBe` 0
 
+        it "punctuation-only name query returns zero entries" $ do
+            -- "???" survives the blank check but tokenizes to nothing, so
+            -- its expansion is empty: a query that matches nothing, not an
+            -- absent filter.
+            db <- loadWithIndex
+            let rootPid = 0 :: ProcessId
+            supplyVec <- computeScalingVector db rootPid
+            scrFilteredActivities (buildWithName db rootPid supplyVec (Just "???"))
+                `shouldBe` 0
+
         it "preserves depth sort order across filtered entries" $ do
             db <- loadWithIndex
             let rootPid = 0 :: ProcessId

--- a/test/SupplyChainSpec.hs
+++ b/test/SupplyChainSpec.hs
@@ -171,6 +171,13 @@ spec = do
                 nBlank = scrFilteredActivities (buildWithName db rootPid supplyVec (Just "   "))
             nBlank `shouldBe` nNone
 
+        it "non-matching name query returns zero entries" $ do
+            db <- loadWithIndex
+            let rootPid = 0 :: ProcessId
+            supplyVec <- computeScalingVector db rootPid
+            scrFilteredActivities (buildWithName db rootPid supplyVec (Just "zzznomatch"))
+                `shouldBe` 0
+
         it "preserves depth sort order across filtered entries" $ do
             db <- loadWithIndex
             let rootPid = 0 :: ProcessId
@@ -211,6 +218,13 @@ spec = do
             case getConsumers db "test-db" pidZ emptyConsumer of
                 Left err -> expectationFailure $ "getConsumers failed: " ++ show err
                 Right cr -> length (srResults (crrResults cr)) `shouldBe` 2
+
+        it "non-matching name query returns zero consumers" $ do
+            db <- loadWithIndex
+            let pidZ = processIdToText db 2
+            case getConsumers db "test-db" pidZ (mapConsumerCore (\c -> c{afcName = Just "zzznomatch"}) emptyConsumer) of
+                Left err -> expectationFailure $ "getConsumers failed: " ++ show err
+                Right cr -> length (srResults (crrResults cr)) `shouldBe` 0
 
     describe "Classifications on consumers" $ do
         let loadWithIndex = fmap BM25.addBM25Index (loadSampleDatabase "SAMPLE.min3")


### PR DESCRIPTION
`nameFilterSet` collapsed three different cases into `Nothing`: no query, no BM25 index, and a query whose fuzzy expansion matches nothing. The downstream predicate treats `Nothing` as accept-every-pid, so a name that matched nothing silently disabled the filter — supply-chain and consumers returned every entry, with a `filteredActivities` count to match, and the caller could not tell "no match" from "no filter" (`?name=zzznomatch` returned 790 entries on Agribalyse).

A present, non-blank query on an indexed database now yields the real match set, empty included. Absent or blank queries and index-less databases keep the accept-all behavior. One shared helper, so the fix covers supply-chain and consumers on both the REST and MCP surfaces. Covered by two new specs (supply-chain and consumers) next to the existing fuzzy-filter tests.