### PR TITLE
Let delete-activities target an exact list of process ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- Delete-activities accepts an `ids` list to delete exactly the named
+  processes, on the API (`"ids": [...]`) and the CLI (repeatable `--id`).
+  Previously the only selection mode was a filter, so deleting a known list
+  of processes required a deliberately unsatisfiable filter plus the `extra`
+  list. `ids` cannot be combined with filter fields — an ambiguous request
+  is refused, not guessed at.
+
 ## [0.9.2] - 2026-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ volca database delete my-db                     # delete
 volca database copy my-db my-db-v2              # copy under a new name
 volca database relink my-db --to bg-db --mapping aliases.csv
 volca database delete-activities my-db --name "electricity"  # delete filtered set
+volca database delete-activities my-db --id UUID_UUID --id UUID_UUID  # delete exactly these
 volca database export my-db --format simapro --out out.csv
 #   formats: simapro | ecospold1 | ecospold2 | ilcd | brightway
 
@@ -485,7 +486,7 @@ volca method delete ef-31                        # delete
 | Relink / finalize | `POST /db/{name}/(relink\|finalize)` | `database relink DB --to DEP --mapping CSV` |
 | Setup / dependencies | `GET /db/{name}/setup`, `POST .../{add,remove}-dependency/{dep}`, `POST .../set-data-path` | — |
 | Copy database | `POST /db/{name}/copy/{newName}` | `database copy SRC NEW_NAME` |
-| Delete activities (filtered set) | `POST /db/{name}/delete` | `database delete-activities DB [filters]` |
+| Delete activities (by filter or ids) | `POST /db/{name}/delete` | `database delete-activities DB [filters\|--id …]` |
 | Export database | `POST /db/{name}/export` | `database export DB --format FMT --out FILE` |
 | Delete database | `DELETE /db/{name}` | `database delete NAME` |
 | **Method Management** | | |

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -103,7 +103,7 @@ import qualified Data.Aeson as A
 import qualified Data.Aeson.KeyMap as KM
 import Data.Maybe (fromMaybe)
 import qualified Data.Vector as V
-import Database.Edit (copyDatabase, deleteActivitiesInDB)
+import Database.Edit (DeleteRequest (..), copyDatabase, deleteActivitiesInDB)
 import Database.Export (parseExportFormat, serializeDatabase)
 import Database.Manager (
     DatabaseLoadStatus (..),
@@ -256,13 +256,16 @@ deleteActivitiesHandler dbName req = do
             deleteActivitiesInDB
                 dbManager
                 dbName
-                (nonBlank (dsqName req))
-                (nonBlank (dsqLocation req))
-                (nonBlank (dsqProduct req))
-                classFilters
-                (fromMaybe False (dsqExact req))
-                (dsqKeep req)
-                (dsqExtra req)
+                DeleteRequest
+                    { drName = nonBlank (dsqName req)
+                    , drLocation = nonBlank (dsqLocation req)
+                    , drProduct = nonBlank (dsqProduct req)
+                    , drClassifications = classFilters
+                    , drExactName = fromMaybe False (dsqExact req)
+                    , drKeep = dsqKeep req
+                    , drExtra = dsqExtra req
+                    , drIds = dsqIds req
+                    }
     case result of
         -- A failed delete is a client error (bad filter, unknown DB, loaded
         -- dependents). Surface it as 4xx so a raw HTTP client can't read the

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -762,10 +762,12 @@ data DeleteClassFilter = DeleteClassFilter
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped DeleteClassFilter)
 
-{- | Request for delete-by-selection. The filter fields select the whole
-matching set (pagination ignored); @dsqKeep@ spares matched process ids and
-@dsqExtra@ adds ones the filter missed. Process ids are the canonical
-@activityUUID_productUUID@ strings the UI/CLI carry, not matrix indices.
+{- | Request for delete-by-selection. Two exclusive selection modes: the
+filter fields select the whole matching set (pagination ignored), or @dsqIds@
+names the set exactly — the filter fields must then be absent. @dsqKeep@
+spares selected process ids and @dsqExtra@ adds ones the selection missed.
+Process ids are the canonical @activityUUID_productUUID@ strings the UI/CLI
+carry, not matrix indices.
 -}
 data DeleteSelectionRequest = DeleteSelectionRequest
     { dsqName :: Maybe Text -- Filter by activity name
@@ -775,6 +777,7 @@ data DeleteSelectionRequest = DeleteSelectionRequest
     , dsqExact :: Maybe Bool -- Exact name match (default False)
     , dsqKeep :: [Text] -- Process-id strings to spare from deletion
     , dsqExtra :: [Text] -- Process-id strings to add to deletion
+    , dsqIds :: Maybe [Text] -- Delete exactly these process ids (no filter fields allowed)
     }
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped DeleteSelectionRequest)

--- a/src/CLI/Client.hs
+++ b/src/CLI/Client.hs
@@ -6,6 +6,7 @@ module CLI.Client (
     executeRemoteCommand,
     apiGet,
     apiPost,
+    deleteSelectionBody,
 ) where
 
 import CLI.Types
@@ -269,6 +270,7 @@ deleteSelectionBody args =
         , "exact" .= ddaExact args
         , "keep" .= ddaKeep args
         , "extra" .= ddaExtra args
+        , "ids" .= (if null (ddaIds args) then Nothing else Just (ddaIds args))
         ]
   where
     classifications = case (ddaClassSystem args, ddaClassValue args) of

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -17,7 +17,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
-import Database.Edit (copyDatabase, deleteActivitiesInDB)
+import Database.Edit (DeleteRequest (..), copyDatabase, deleteActivitiesInDB)
 import Database.Export (exportDatabase, parseExportFormat)
 import Database.Manager (DatabaseManager (..), LoadedDatabase (..), RelinkResult (..), addDatabase, addMethodCollection)
 import qualified Database.Manager as DM
@@ -467,13 +467,16 @@ executeDbDeleteActivities fmt manager args = do
         deleteActivitiesInDB
             manager
             (ddaDb args)
-            (ddaName args)
-            (ddaLocation args)
-            (ddaProduct args)
-            classFilters
-            (ddaExact args)
-            (ddaKeep args)
-            (ddaExtra args)
+            DeleteRequest
+                { drName = ddaName args
+                , drLocation = ddaLocation args
+                , drProduct = ddaProduct args
+                , drClassifications = classFilters
+                , drExactName = ddaExact args
+                , drKeep = ddaKeep args
+                , drExtra = ddaExtra args
+                , drIds = if null (ddaIds args) then Nothing else Just (ddaIds args)
+                }
     case result of
         Left err -> do
             reportError $ "Delete failed: " ++ T.unpack err

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -167,6 +167,7 @@ deleteActivitiesArgsParser =
         <*> switch (long "exact" <> help "Exact (case-insensitive) name match instead of token-contains")
         <*> many (textOpt "keep" Nothing "PID" "Process id (activityUUID_productUUID) to spare from deletion (repeatable)")
         <*> many (textOpt "add" Nothing "PID" "Process id to add to deletion (repeatable)")
+        <*> many (textOpt "id" Nothing "PID" "Delete exactly this process id (repeatable, excludes the filter options)")
 
 -- | Method command parser with optional subcommand (defaults to list)
 methodParser :: Parser Command

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -117,6 +117,7 @@ data DbDeleteArgs = DbDeleteArgs
     , ddaExact :: Bool
     , ddaKeep :: [Text]
     , ddaExtra :: [Text]
+    , ddaIds :: [Text] -- Delete exactly these process ids (@--id@, excludes filters)
     }
     deriving (Eq, Show, Generic)
 

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -47,6 +47,7 @@ import Control.Concurrent.STM (atomically, modifyTVar', readTVar, readTVarIO)
 import Control.Exception (finally)
 import qualified Data.IntSet as IS
 import qualified Data.Map.Strict as M
+import Data.Maybe (isJust)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -468,12 +469,13 @@ deleteActivitiesInDB manager dbName DeleteRequest{drName = nameP, drLocation = g
                                 <> ". Unload dependents first."
                 -- The two selection modes are exclusive: ids name the set
                 -- verbatim, filters compute it. A request carrying both is
-                -- ambiguous, so it is refused rather than guessed at.
+                -- ambiguous, so it is refused rather than guessed at — exact
+                -- included, since it only modifies name/classification matching.
                 hasFilter =
-                    any (/= Nothing) [nameP, geoP, prodP] || not (null classFilters)
+                    any isJust [nameP, geoP, prodP] || not (null classFilters) || exactMatch
                 selectionE = case mIds of
                     Just ids
-                        | hasFilter -> Left "ids cannot be combined with name/location/product/classification filters"
+                        | hasFilter -> Left "ids cannot be combined with name/location/product/classification/exact filters"
                         | otherwise -> traverse (resolvePid db) ids
                     Nothing -> Right (filteredProcessIds db nameP geoP prodP classFilters exactMatch)
             case guardDeps *> ((,,) <$> traverse (resolvePid db) keep <*> traverse (resolvePid db) extra <*> selectionE) of

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -39,6 +39,7 @@ module Database.Edit (
     deleteActivitiesWith,
     resolveDeleteSelection,
     DeleteSelection (..),
+    DeleteRequest (..),
     deleteActivitiesInDB,
 ) where
 
@@ -407,28 +408,40 @@ resolvePid db queryText =
         Just (a, p) -> findProcessId db a p
         Nothing -> UUID.fromText queryText >>= findProcessIdByActivityUUID db
 
+{- | One delete-by-selection request against a loaded database. Two exclusive
+selection modes: the filter fields select the whole matching set (@drIds =
+Nothing@), or @drIds@ names the set exactly — every filter field must then be
+absent, so a request can never silently mean two things. @drKeep@ spares and
+@drExtra@ adds explicit process ids in both modes.
+-}
+data DeleteRequest = DeleteRequest
+    { drName :: Maybe Text
+    , drLocation :: Maybe Text
+    , drProduct :: Maybe Text
+    , drClassifications :: [(Text, Text, Bool)]
+    , drExactName :: Bool
+    , drKeep :: [Text]
+    , drExtra :: [Text]
+    , drIds :: Maybe [Text]
+    }
+
 {- | Delete a selection from a loaded database, in place under the same name.
 
-Resolves the filter to its full matching set, resolves the explicit
-keep/extra process-id strings, applies the adjustments, deletes + rebuilds
-with the manager's merged unit config, re-attaches runtime indexes with the
-merged synonym DB, swaps a fresh solver in, and updates the loaded / indexed
-registry maps. Returns the number of activities removed. Fails (Left) when the
-database is not loaded, a keep/extra id is unknown, or the rebuild reports an
-inconsistency.
+Resolves the selection ('drIds' verbatim, else the filter's full matching
+set), resolves the explicit keep/extra process-id strings, applies the
+adjustments, deletes + rebuilds with the manager's merged unit config,
+re-attaches runtime indexes with the merged synonym DB, swaps a fresh solver
+in, and updates the loaded / indexed registry maps. Returns the number of
+activities removed. Fails (Left) when the database is not loaded, an
+ids/keep/extra id is unknown, 'drIds' is combined with filter fields, or the
+rebuild reports an inconsistency.
 -}
 deleteActivitiesInDB ::
     DatabaseManager ->
     Text -> -- database name
-    Maybe Text -> -- filter: name
-    Maybe Text -> -- filter: location
-    Maybe Text -> -- filter: product
-    [(Text, Text, Bool)] -> -- filter: classification
-    Bool -> -- exact name match
-    [Text] -> -- explicit keep (process-id strings)
-    [Text] -> -- explicit extra (process-id strings)
+    DeleteRequest ->
     IO (Either Text Int)
-deleteActivitiesInDB manager dbName nameP geoP prodP classFilters exactMatch keep extra =
+deleteActivitiesInDB manager dbName DeleteRequest{drName = nameP, drLocation = geoP, drProduct = prodP, drClassifications = classFilters, drExactName = exactMatch, drKeep = keep, drExtra = extra, drIds = mIds} =
     getDatabase manager dbName >>= \case
         Nothing -> pure $ Left $ "Database not loaded: " <> dbName
         Just loaded -> do
@@ -453,11 +466,20 @@ deleteActivitiesInDB manager dbName nameP geoP prodP classFilters exactMatch kee
                                 <> ": still required by "
                                 <> T.intercalate ", " dependents
                                 <> ". Unload dependents first."
-            case guardDeps *> ((,) <$> traverse (resolvePid db) keep <*> traverse (resolvePid db) extra) of
+                -- The two selection modes are exclusive: ids name the set
+                -- verbatim, filters compute it. A request carrying both is
+                -- ambiguous, so it is refused rather than guessed at.
+                hasFilter =
+                    any (/= Nothing) [nameP, geoP, prodP] || not (null classFilters)
+                selectionE = case mIds of
+                    Just ids
+                        | hasFilter -> Left "ids cannot be combined with name/location/product/classification filters"
+                        | otherwise -> traverse (resolvePid db) ids
+                    Nothing -> Right (filteredProcessIds db nameP geoP prodP classFilters exactMatch)
+            case guardDeps *> ((,,) <$> traverse (resolvePid db) keep <*> traverse (resolvePid db) extra <*> selectionE) of
                 Left err -> pure $ Left err
-                Right (keepPids, extraPids) -> do
-                    let filtered = filteredProcessIds db nameP geoP prodP classFilters exactMatch
-                        toDelete =
+                Right (keepPids, extraPids, filtered) -> do
+                    let toDelete =
                             resolveDeleteSelection
                                 DeleteSelection{dsFiltered = filtered, dsKeep = keepPids, dsExtra = extraPids}
                     unitConfig <- getMergedUnitConfig manager

--- a/test/DeleteSelectionSpec.hs
+++ b/test/DeleteSelectionSpec.hs
@@ -27,9 +27,12 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import Test.Hspec
 
+import API.Types (DeleteSelectionRequest (..))
 import Config (DatabaseConfig (..), defaultConfig)
+import Data.Aeson (eitherDecode)
 import Database (buildDatabaseWithMatrices)
 import Database.Edit (
+    DeleteRequest (..),
     DeleteSelection (..),
     deleteActivities,
     deleteActivitiesInDB,
@@ -56,6 +59,20 @@ import Types (
     processIdToText,
  )
 import UnitConversion (defaultUnitConfig)
+
+-- | Empty 'DeleteRequest'; tests tweak only the fields they need.
+emptyDelete :: DeleteRequest
+emptyDelete =
+    DeleteRequest
+        { drName = Nothing
+        , drLocation = Nothing
+        , drProduct = Nothing
+        , drClassifications = []
+        , drExactName = False
+        , drKeep = []
+        , drExtra = []
+        , drIds = Nothing
+        }
 
 spec :: Spec
 spec = describe "Database.Edit delete-by-selection primitive" $ do
@@ -171,13 +188,7 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
                 deleteActivitiesInDB
                     manager
                     "edit-me"
-                    Nothing
-                    Nothing
-                    Nothing
-                    [("category", "food", False)]
-                    False
-                    [foodA] -- keep
-                    [] -- extra
+                    emptyDelete{drClassifications = [("category", "food", False)], drKeep = [foodA]}
             case r of
                 Left err -> expectationFailure ("deleteActivitiesInDB failed: " <> show err)
                 Right deleted -> do
@@ -197,20 +208,14 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
                 deleteActivitiesInDB
                     manager
                     "edit-me-2"
-                    Nothing
-                    Nothing
-                    Nothing
-                    [("category", "food", False)]
-                    False
-                    ["not-a-real-process-id"]
-                    []
+                    emptyDelete{drClassifications = [("category", "food", False)], drKeep = ["not-a-real-process-id"]}
             case r of
                 Left _ -> pure ()
                 Right _ -> expectationFailure "expected unknown keep id to fail"
 
         it "fails when the database is not loaded" $ do
             manager <- initDatabaseManager defaultConfig True Nothing
-            r <- deleteActivitiesInDB manager "ghost" Nothing Nothing Nothing [] False [] []
+            r <- deleteActivitiesInDB manager "ghost" emptyDelete
             r `shouldBe` Left "Database not loaded: ghost"
 
         it "refuses to delete while a loaded database depends on it" $ do
@@ -226,16 +231,57 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
                 deleteActivitiesInDB
                     manager
                     "base"
-                    Nothing
-                    Nothing
-                    Nothing
-                    [("category", "food", False)]
-                    False
-                    []
-                    []
+                    emptyDelete{drClassifications = [("category", "food", False)]}
             case r of
                 Left err -> err `shouldSatisfy` isInfixOf "still required by"
                 Right _ -> expectationFailure "expected delete to be refused while a dependent is loaded"
+
+    describe "deleteActivitiesInDB (delete exactly these ids)" $ do
+        it "deletes exactly the listed process ids, no base filter" $ do
+            manager <- initDatabaseManager defaultConfig True Nothing
+            db <- buildOrFail (classifiedDB 1000)
+            installLoaded manager "by-ids" db
+            let foodA = processIdToText db (pidFor2 db (mkUUID 1001) (mkUUID 1001))
+            r <- deleteActivitiesInDB manager "by-ids" emptyDelete{drIds = Just [foodA]}
+            case r of
+                Left err -> expectationFailure ("deleteActivitiesInDB failed: " <> show err)
+                Right deleted -> do
+                    deleted `shouldBe` 1
+                    loaded <- readTVarIO (dmLoadedDbs manager)
+                    let db' = ldDatabase (loaded M.! "by-ids")
+                    dbActivityCount db' `shouldBe` 2
+                    map activityName (V.toList (dbActivities db'))
+                        `shouldNotSatisfy` elem "food-A"
+
+        it "refuses ids combined with a filter field" $ do
+            manager <- initDatabaseManager defaultConfig True Nothing
+            db <- buildOrFail (classifiedDB 1100)
+            installLoaded manager "by-ids-2" db
+            let foodA = processIdToText db (pidFor2 db (mkUUID 1101) (mkUUID 1101))
+            r <-
+                deleteActivitiesInDB
+                    manager
+                    "by-ids-2"
+                    emptyDelete{drIds = Just [foodA], drClassifications = [("category", "food", False)]}
+            case r of
+                Left err -> err `shouldSatisfy` isInfixOf "cannot be combined"
+                Right _ -> expectationFailure "expected ids+filter to be refused"
+
+        it "fails loudly on an unknown id" $ do
+            manager <- initDatabaseManager defaultConfig True Nothing
+            db <- buildOrFail (classifiedDB 1200)
+            installLoaded manager "by-ids-3" db
+            r <- deleteActivitiesInDB manager "by-ids-3" emptyDelete{drIds = Just ["not-a-real-process-id"]}
+            case r of
+                Left err -> err `shouldSatisfy` isInfixOf "Unknown process id"
+                Right _ -> expectationFailure "expected unknown id to fail"
+
+    describe "DeleteSelectionRequest wire compatibility" $ do
+        it "decodes a request without the ids key (old clients)" $ do
+            let json = "{\"classifications\":[],\"exact\":false,\"keep\":[],\"extra\":[]}"
+            case eitherDecode json :: Either String DeleteSelectionRequest of
+                Left err -> expectationFailure ("decode failed: " <> err)
+                Right req -> dsqIds req `shouldBe` Nothing
 
 -- ---------------------------------------------------------------------------
 -- Helpers

--- a/test/DeleteSelectionSpec.hs
+++ b/test/DeleteSelectionSpec.hs
@@ -28,8 +28,10 @@ import qualified Data.Vector.Unboxed as U
 import Test.Hspec
 
 import API.Types (DeleteSelectionRequest (..))
+import CLI.Client (deleteSelectionBody)
+import CLI.Types (DbDeleteArgs (..))
 import Config (DatabaseConfig (..), defaultConfig)
-import Data.Aeson (eitherDecode)
+import Data.Aeson (eitherDecode, encode)
 import Database (buildDatabaseWithMatrices)
 import Database.Edit (
     DeleteRequest (..),
@@ -59,6 +61,22 @@ import Types (
     processIdToText,
  )
 import UnitConversion (defaultUnitConfig)
+
+-- | Empty CLI delete args; tests tweak only the fields they need.
+emptyDeleteArgs :: DbDeleteArgs
+emptyDeleteArgs =
+    DbDeleteArgs
+        { ddaDb = "db"
+        , ddaName = Nothing
+        , ddaLocation = Nothing
+        , ddaProduct = Nothing
+        , ddaClassSystem = Nothing
+        , ddaClassValue = Nothing
+        , ddaExact = False
+        , ddaKeep = []
+        , ddaExtra = []
+        , ddaIds = []
+        }
 
 -- | Empty 'DeleteRequest'; tests tweak only the fields they need.
 emptyDelete :: DeleteRequest
@@ -276,12 +294,61 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
                 Left err -> err `shouldSatisfy` isInfixOf "Unknown process id"
                 Right _ -> expectationFailure "expected unknown id to fail"
 
+        it "composes ids with keep and extra: (ids ∪ extra) \\ keep" $ do
+            manager <- initDatabaseManager defaultConfig True Nothing
+            db <- buildOrFail (classifiedDB 1400)
+            installLoaded manager "by-ids-5" db
+            let foodA = processIdToText db (pidFor2 db (mkUUID 1401) (mkUUID 1401))
+                foodB = processIdToText db (pidFor2 db (mkUUID 1411) (mkUUID 1411))
+                energ = processIdToText db (pidFor2 db (mkUUID 1421) (mkUUID 1421))
+            r <-
+                deleteActivitiesInDB
+                    manager
+                    "by-ids-5"
+                    emptyDelete{drIds = Just [foodA, foodB], drKeep = [foodA], drExtra = [energ]}
+            case r of
+                Left err -> expectationFailure ("deleteActivitiesInDB failed: " <> show err)
+                Right deleted -> do
+                    deleted `shouldBe` 2 -- foodB and energy; foodA kept
+                    loaded <- readTVarIO (dmLoadedDbs manager)
+                    let db' = ldDatabase (loaded M.! "by-ids-5")
+                    map activityName (V.toList (dbActivities db')) `shouldBe` ["food-A"]
+
+        it "deletes only the extras when ids is the empty selection" $ do
+            -- The official replacement for the old "unsatisfiable filter +
+            -- extra" hack: an empty ids selection plus explicit extras.
+            manager <- initDatabaseManager defaultConfig True Nothing
+            db <- buildOrFail (classifiedDB 1500)
+            installLoaded manager "by-ids-6" db
+            let foodA = processIdToText db (pidFor2 db (mkUUID 1501) (mkUUID 1501))
+            r <- deleteActivitiesInDB manager "by-ids-6" emptyDelete{drIds = Just [], drExtra = [foodA]}
+            case r of
+                Left err -> expectationFailure ("deleteActivitiesInDB failed: " <> show err)
+                Right deleted -> deleted `shouldBe` 1
+
     describe "DeleteSelectionRequest wire compatibility" $ do
         it "decodes a request without the ids key (old clients)" $ do
             let json = "{\"classifications\":[],\"exact\":false,\"keep\":[],\"extra\":[]}"
             case eitherDecode json :: Either String DeleteSelectionRequest of
                 Left err -> expectationFailure ("decode failed: " <> err)
                 Right req -> dsqIds req `shouldBe` Nothing
+
+        it "CLI --id values reach the server as the ids selection" $ do
+            -- The CLI builds this body by hand (CLI.Client.deleteSelectionBody);
+            -- a dropped field here silently falls back to filter mode, whose
+            -- empty filter selects the WHOLE database. Pin the contract.
+            let args = emptyDeleteArgs{ddaIds = ["pid-a", "pid-b"]}
+            case eitherDecode (encode (deleteSelectionBody args)) :: Either String DeleteSelectionRequest of
+                Left err -> expectationFailure ("decode failed: " <> err)
+                Right req -> dsqIds req `shouldBe` Just ["pid-a", "pid-b"]
+
+        it "CLI filter mode still sends no ids (old servers keep working)" $ do
+            let args = emptyDeleteArgs{ddaName = Just "electricity"}
+            case eitherDecode (encode (deleteSelectionBody args)) :: Either String DeleteSelectionRequest of
+                Left err -> expectationFailure ("decode failed: " <> err)
+                Right req -> do
+                    dsqIds req `shouldBe` Nothing
+                    dsqName req `shouldBe` Just "electricity"
 
 -- ---------------------------------------------------------------------------
 -- Helpers

--- a/test/DeleteSelectionSpec.hs
+++ b/test/DeleteSelectionSpec.hs
@@ -294,6 +294,16 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
                 Left err -> err `shouldSatisfy` isInfixOf "Unknown process id"
                 Right _ -> expectationFailure "expected unknown id to fail"
 
+        it "refuses ids combined with exact (it would silently do nothing)" $ do
+            manager <- initDatabaseManager defaultConfig True Nothing
+            db <- buildOrFail (classifiedDB 1300)
+            installLoaded manager "by-ids-4" db
+            let foodA = processIdToText db (pidFor2 db (mkUUID 1301) (mkUUID 1301))
+            r <- deleteActivitiesInDB manager "by-ids-4" emptyDelete{drIds = Just [foodA], drExactName = True}
+            case r of
+                Left err -> err `shouldSatisfy` isInfixOf "cannot be combined"
+                Right _ -> expectationFailure "expected ids+exact to be refused"
+
         it "composes ids with keep and extra: (ids ∪ extra) \\ keep" $ do
             manager <- initDatabaseManager defaultConfig True Nothing
             db <- buildOrFail (classifiedDB 1400)


### PR DESCRIPTION
The only selection mode was a filter that resolves to its whole matching set — an empty filter matches everything. Deleting a known list of processes therefore required a deliberately unsatisfiable filter (e.g. `product="ZZZ_no_match_ZZZ"`) plus the `extra` list, a hack even pyvolca's client documents.

The request now carries an optional `ids` list naming the selection verbatim; `keep` and `extra` compose with it unchanged. `ids` combined with filter fields is refused — an ambiguous request must never be guessed at. The field is additive on the wire (a spec pins that a request without the key still decodes), and reaches the CLI as a repeatable `--id`.

Delete's arguments moved into a `DeleteRequest` record on the way: the nine-positional-argument signature was already a smell, and a tenth would have made every call site unreadable.