### PR TITLE
Fail loud on scoring integrity errors instead of scoring 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- A scoring integrity error (a regionalized score whose tables are internally
+  inconsistent — mismatched lengths, absent weights) now fails the request
+  with a 500 instead of silently scoring the category 0. A consumer could not
+  tell that 0 from a real score. Coverage gaps are unaffected: an unmapped
+  flow still contributes nothing and is reported as before. In sensitivity
+  responses the error lands on the affected perturbation entry, which already
+  carries per-entry errors.
+
 ## [0.9.2] - 2026-07-14
 
 ### Added

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -586,6 +586,27 @@ batchedScoresFor dbManager _dbName collection _db sol methods = do
                 hier
                 perDb
 
+{- | Resolve a method's precomputed batched score. A 'Left' here is a scoring
+integrity error (mismatched table lengths, absent weights — never a mere
+coverage gap, see 'computeRegionalizedLCIAScore'): it must reach the caller
+as an error, never collapse to a 0 the consumer cannot tell from a real
+score. A method missing from the map is the same kind of error — the map is
+built from the very method list being scored.
+-}
+resolveBatchedScore :: Method -> M.Map UUID (Either Text Double) -> Either Text Double
+resolveBatchedScore method scoreMap =
+    case M.lookup (methodId method) scoreMap of
+        Nothing -> Left ("[LCIA " <> methodName method <> "] missing from the batched score set")
+        Just (Left err) -> Left ("[LCIA " <> methodName method <> "] " <> err)
+        Just (Right s) -> Right s
+
+{- | Surface a scoring integrity error as a 500: the collection's tables are
+inconsistent and the score is not computable — a silent 0 would be worse
+than the failure.
+-}
+scoringError :: Text -> AppM a
+scoringError err = throwError err500{errBody = BSL.fromStrict (T.encodeUtf8 err)}
+
 {- | Pre-warm per-(db, method) cached tables so subsequent 'batchedScoresFor'
 and 'inventoryContributions' calls hit a warm cache.
 -}
@@ -610,7 +631,7 @@ computeCategoryResult ::
     Int ->
     Maybe (Either Text Double) ->
     Method ->
-    IO LCIAResult
+    IO (Either Text LCIAResult)
 computeCategoryResult dbManager dbName collection db sol activity topFlows precomputedScore method = do
     unitCfg <- getMergedUnitConfig dbManager
     (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
@@ -618,66 +639,66 @@ computeCategoryResult dbManager dbName collection db sol activity topFlows preco
     tables <- DM.mapMethodToTablesCached dbManager dbName collection db method
     let inventory = SharedSolver.csInventory sol
     let stats = computeMappingStats mappings
-    score <- case precomputedScore of
-        Just (Right s) -> evaluate s
-        Just (Left err) -> do
-            reportProgress Warning $
-                "[LCIA " <> T.unpack (methodName method) <> "] " <> T.unpack err
-            evaluate (0 :: Double)
+    -- A Left is a scoring integrity error (see 'resolveBatchedScore') — it
+    -- propagates instead of collapsing to a 0 the consumer can't tell from a
+    -- real score.
+    scoreE <- case precomputedScore of
+        Just e -> traverse evaluate e
         Nothing ->
             if M.null (mtRegionalizedCF tables)
-                then evaluate $ loScore (computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables)
+                then Right <$> evaluate (loScore (computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables))
                 else do
                     hier <- DM.getLocationHierarchy dbManager
                     perDb <-
                         forM (NE.toList (SharedSolver.csScalings sol)) $ \(n, d, sv) -> do
                             tbls <- DM.mapMethodToTablesCached dbManager n collection d method
                             pure (d, sv, tbls)
-                    case sumRegionalizedLCIAScoreCrossDB unitCfg mUnits mFlows hier perDb of
-                        Right s -> evaluate s
-                        Left err -> do
-                            reportProgress Warning $
-                                "[LCIA " <> T.unpack (methodName method) <> "] " <> T.unpack err
-                            evaluate (0 :: Double)
-    let (prodName, prodAmount, prodUnit) = Service.getReferenceProductInfo (dbTechFlows db) mUnits activity
-        functionalUnit = T.pack (showFFloat (Just 2) prodAmount "") <> " " <> prodUnit <> " of " <> prodName
-        (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
-        contribs = sortOn (\(_, _, c) -> negate (abs c)) rawContribs
-        topContribs = take topFlows contribs
-        topContributors =
-            [ FlowContributionEntry
-                { fcoFlowName = bfName f
-                , fcoContribution = c
-                , fcoSharePct = if score /= 0 then c / score * 100 else 0
-                , fcoFlowId = UUID.toText (bfId f)
-                , fcoCategory = bfCompartmentName f
-                , fcoCompartment = bfCompartmentSub f
-                , fcoCfValue = cfVal
-                }
-            | (f, cfVal, c) <- topContribs
-            ]
-    unless (null unknownUuids) $
-        reportProgress Warning $
-            "[LCIA "
-                <> T.unpack (methodName method)
-                <> "] "
-                <> show (length unknownUuids)
-                <> " inventory flow UUID(s) absent from merged FlowDB — characterization incomplete. Samples: "
-                <> show (take 3 unknownUuids)
-    pure
-        LCIAResult
-            { lrMethodId = methodId method
-            , lrMethodName = methodName method
-            , lrCategory = methodCategory method
-            , lrDamageCategory = methodCategory method
-            , lrScore = score
-            , lrUnit = methodUnit method
-            , lrNormalizedScore = Nothing
-            , lrWeightedScore = Nothing
-            , lrMappedFlows = msTotal stats - msUnmatched stats
-            , lrFunctionalUnit = functionalUnit
-            , lrTopContributors = topContributors
-            }
+                    traverse evaluate (sumRegionalizedLCIAScoreCrossDB unitCfg mUnits mFlows hier perDb)
+    case scoreE of
+        Left err -> pure (Left ("[LCIA " <> methodName method <> "] " <> err))
+        Right score -> buildResult unitCfg mFlows mUnits inventory tables stats score
+  where
+    buildResult unitCfg mFlows mUnits inventory tables stats score = do
+        let (prodName, prodAmount, prodUnit) = Service.getReferenceProductInfo (dbTechFlows db) mUnits activity
+            functionalUnit = T.pack (showFFloat (Just 2) prodAmount "") <> " " <> prodUnit <> " of " <> prodName
+            (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
+            contribs = sortOn (\(_, _, c) -> negate (abs c)) rawContribs
+            topContribs = take topFlows contribs
+            topContributors =
+                [ FlowContributionEntry
+                    { fcoFlowName = bfName f
+                    , fcoContribution = c
+                    , fcoSharePct = if score /= 0 then c / score * 100 else 0
+                    , fcoFlowId = UUID.toText (bfId f)
+                    , fcoCategory = bfCompartmentName f
+                    , fcoCompartment = bfCompartmentSub f
+                    , fcoCfValue = cfVal
+                    }
+                | (f, cfVal, c) <- topContribs
+                ]
+        unless (null unknownUuids) $
+            reportProgress Warning $
+                "[LCIA "
+                    <> T.unpack (methodName method)
+                    <> "] "
+                    <> show (length unknownUuids)
+                    <> " inventory flow UUID(s) absent from merged FlowDB — characterization incomplete. Samples: "
+                    <> show (take 3 unknownUuids)
+        pure $
+            Right
+                LCIAResult
+                    { lrMethodId = methodId method
+                    , lrMethodName = methodName method
+                    , lrCategory = methodCategory method
+                    , lrDamageCategory = methodCategory method
+                    , lrScore = score
+                    , lrUnit = methodUnit method
+                    , lrNormalizedScore = Nothing
+                    , lrWeightedScore = Nothing
+                    , lrMappedFlows = msTotal stats - msUnmatched stats
+                    , lrFunctionalUnit = functionalUnit
+                    , lrTopContributors = topContributors
+                    }
 
 {- | Batch fast path: scores via 'batchedScoresFor', then build LCIAResult
 records straight from the precomputed contexts. Skips the per-pid
@@ -696,7 +717,7 @@ buildLCIABatchResultCached ::
     SharedSolver.CrossDBSolution ->
     [MethodCtx] ->
     Int ->
-    IO LCIABatchResult
+    IO (Either Text LCIABatchResult)
 buildLCIABatchResultCached dbManager dbName collectionName db actPid activity collection sol ctxs topFlows = do
     let damageCats = mcDamageCategories collection
         nwSets = mcNormWeightSets collection
@@ -733,18 +754,10 @@ buildLCIABatchResultCached dbManager dbName collectionName db actPid activity co
         functionalUnit = T.pack (showFFloat (Just 2) prodAmount "") <> " " <> prodUnit <> " of " <> prodName
         mkResultIO ctx = do
             let method = mctxMethod ctx
-            score <- case M.lookup (methodId method) scoreMap of
-                Just (Right s) -> pure s
-                Just (Left err) -> do
-                    reportProgress Warning $
-                        "[LCIA "
-                            <> T.unpack (methodName method)
-                            <> "] pid="
-                            <> show actPid
-                            <> ": "
-                            <> T.unpack err
-                    pure 0
-                Nothing -> pure 0
+            case resolveBatchedScore method scoreMap of
+                Left err -> pure (Left (err <> " (pid=" <> T.pack (show actPid) <> ")"))
+                Right score -> Right <$> mkResultForScore ctx method score
+        mkResultForScore ctx method score = do
             topContributors <- case mUnitCfg of
                 Nothing -> pure []
                 Just unitCfg -> do
@@ -780,11 +793,14 @@ buildLCIABatchResultCached dbManager dbName collectionName db actPid activity co
                         , lrFunctionalUnit = functionalUnit
                         , lrTopContributors = topContributors
                         }
-    results <- traverse mkResultIO ctxs
-    let rawScoreMap = rawScoreMapByName results
-    (scoringResults, scoringIndicators) <-
-        computeAllScoringSets (mcScoringSets collection) rawScoreMap
-    pure (mkLCIABatchResult results mNW nwSets scoringResults (mcScoringSets collection) scoringIndicators (Service.buildCutoffWaste db activity))
+    resultsE <- sequence <$> traverse mkResultIO ctxs
+    case resultsE of
+        Left err -> pure (Left err)
+        Right results -> do
+            let rawScoreMap = rawScoreMapByName results
+            (scoringResults, scoringIndicators) <-
+                computeAllScoringSets (mcScoringSets collection) rawScoreMap
+            pure (Right (mkLCIABatchResult results mNW nwSets scoringResults (mcScoringSets collection) scoringIndicators (Service.buildCutoffWaste db activity)))
 
 {- | Top-level LCIA batch entry point — AppM-returning. Used by the Servant
 routes (via thin where-aliases) and by API.BatchImpacts.
@@ -824,11 +840,12 @@ activityLCIABatchH dbName processIdText collectionName mSub ltMode = do
                 reportProgress Info $
                     "  Inventory UUIDs: " <> intercalate ", " (map UUID.toString $ M.keys inventory)
     scoreMap <- liftIO $ batchedScoresFor dbManager dbName collectionName db sol methods
-    rawResults <-
+    rawResultsE <-
         liftIO $
             mapConcurrently
-                (\m -> computeCategoryResult dbManager dbName collectionName db sol activity 5 (M.lookup (methodId m) scoreMap) m)
+                (\m -> computeCategoryResult dbManager dbName collectionName db sol activity 5 (Just (resolveBatchedScore m scoreMap)) m)
                 methods
+    rawResults <- either scoringError pure (sequence rawResultsE)
     let results = map (enrichWithNW dcLookup mNW) rawResults
         rawScoreMap = rawScoreMapByName rawResults
     (scoringResults, scoringIndicators) <- liftIO $ computeAllScoringSets scoringSets rawScoreMap
@@ -883,14 +900,19 @@ batchImpactsH dbName collectionName topFlowsParam ltMode req = do
     ctxs <- liftIO $ mapConcurrently (prepMethodCtx dbManager dbName collectionName db) (mcMethods collection)
     let topFlows = max 0 (fromMaybe 0 topFlowsParam)
     let mkEntry ((pidText, pidNum, activity), sol) = do
-            impacts <- buildLCIABatchResultCached dbManager dbName collectionName db pidNum activity collection sol ctxs topFlows
-            pure
-                BatchImpactsEntry
-                    { bieProcessId = pidText
-                    , bieActivityName = activityName activity
-                    , bieImpacts = impacts
-                    }
-    entries <- liftIO $ mapM mkEntry (zip valid sols)
+            impactsE <- buildLCIABatchResultCached dbManager dbName collectionName db pidNum activity collection sol ctxs topFlows
+            pure $
+                fmap
+                    ( \impacts ->
+                        BatchImpactsEntry
+                            { bieProcessId = pidText
+                            , bieActivityName = activityName activity
+                            , bieImpacts = impacts
+                            }
+                    )
+                    impactsE
+    entriesE <- liftIO $ mapM mkEntry (zip valid sols)
+    entries <- either scoringError pure (sequence entriesE)
     t2 <- liftIO getCurrentTime
     liftIO $
         reportProgress Info $
@@ -1444,7 +1466,8 @@ activityLCIACore dbName processIdText collectionName methodIdText topFlowsParam 
     method <- loadMethodInCollection collectionName methodIdText
     (processId, activity) <- resolveOrThrow db processIdText
     sol <- crossDBSolutionFor dbName db sharedSolver processId mSub
-    result <- liftIO $ computeCategoryResult dbManager dbName collectionName db sol activity (fromMaybe 5 topFlowsParam) Nothing method
+    resultE <- liftIO $ computeCategoryResult dbManager dbName collectionName db sol activity (fromMaybe 5 topFlowsParam) Nothing method
+    result <- either scoringError pure resultE
     when (isNothing mSub) $ liftIO $ logLCIAResult result method
     pure result
 
@@ -1491,17 +1514,20 @@ postActivitySensitivity dbName processIdText collectionName methodIdText senReq 
                 case eSol of
                     Left err -> pure (PerturbedEntry p (Left err))
                     Right sol -> do
-                        lcia <- computeCategoryResult dbManager dbName collectionName db sol activity 5 Nothing method
-                        pure (PerturbedEntry p (Right (lcia, lrScore lcia - lrScore baselineLcia)))
+                        eLcia <- computeCategoryResult dbManager dbName collectionName db sol activity 5 Nothing method
+                        pure $ case eLcia of
+                            Left err -> PerturbedEntry p (Left err)
+                            Right lcia -> PerturbedEntry p (Right (lcia, lrScore lcia - lrScore baselineLcia))
     eBaselineSol <- liftIO $ scaleToSolution baselineX
     baselineSol <-
         either
             (\err -> throwError err422{errBody = BSL.fromStrict $ T.encodeUtf8 err})
             pure
             eBaselineSol
-    baselineLcia <-
+    eBaselineLcia <-
         liftIO $
             computeCategoryResult dbManager dbName collectionName db baselineSol activity 5 Nothing method
+    baselineLcia <- either scoringError pure eBaselineLcia
     perturbed <-
         liftIO $
             mapConcurrently (buildEntry baselineLcia) perResults

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -20,6 +20,7 @@ import Control.Monad (forM, forM_, unless, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (asks)
 import Data.Aeson
+import Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as BSL
 import Data.Foldable (asum)
 import Data.List (find, intercalate, sortBy, sortOn)
@@ -641,21 +642,23 @@ computeCategoryResult dbManager dbName collection db sol activity topFlows preco
     let stats = computeMappingStats mappings
     -- A Left is a scoring integrity error (see 'resolveBatchedScore') — it
     -- propagates instead of collapsing to a 0 the consumer can't tell from a
-    -- real score.
+    -- real score. A precomputed Left arrives already labeled by
+    -- 'resolveBatchedScore'; only the locally computed one is labeled here.
     scoreE <- case precomputedScore of
         Just e -> traverse evaluate e
         Nothing ->
-            if M.null (mtRegionalizedCF tables)
-                then Right <$> evaluate (loScore (computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables))
-                else do
-                    hier <- DM.getLocationHierarchy dbManager
-                    perDb <-
-                        forM (NE.toList (SharedSolver.csScalings sol)) $ \(n, d, sv) -> do
-                            tbls <- DM.mapMethodToTablesCached dbManager n collection d method
-                            pure (d, sv, tbls)
-                    traverse evaluate (sumRegionalizedLCIAScoreCrossDB unitCfg mUnits mFlows hier perDb)
+            fmap (first (("[LCIA " <> methodName method <> "] ") <>)) $
+                if M.null (mtRegionalizedCF tables)
+                    then Right <$> evaluate (loScore (computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables))
+                    else do
+                        hier <- DM.getLocationHierarchy dbManager
+                        perDb <-
+                            forM (NE.toList (SharedSolver.csScalings sol)) $ \(n, d, sv) -> do
+                                tbls <- DM.mapMethodToTablesCached dbManager n collection d method
+                                pure (d, sv, tbls)
+                        traverse evaluate (sumRegionalizedLCIAScoreCrossDB unitCfg mUnits mFlows hier perDb)
     case scoreE of
-        Left err -> pure (Left ("[LCIA " <> methodName method <> "] " <> err))
+        Left err -> pure (Left err)
         Right score -> buildResult unitCfg mFlows mUnits inventory tables stats score
   where
     buildResult unitCfg mFlows mUnits inventory tables stats score = do
@@ -912,6 +915,9 @@ batchImpactsH dbName collectionName topFlowsParam ltMode req = do
                     )
                     impactsE
     entriesE <- liftIO $ mapM mkEntry (zip valid sols)
+    -- All-or-nothing on purpose: an integrity error is a property of the
+    -- (db, method) tables, not of one activity, so every entry would fail
+    -- identically. Unresolvable pids stay per-entry (birNotFound/birInvalid).
     entries <- either scoringError pure (sequence entriesE)
     t2 <- liftIO getCurrentTime
     liftIO $

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -1625,15 +1625,12 @@ coverage DB just contributes its partial score to the sum. The build-time
 WARN + 'rawMissingPairs' per @(db, method)@ is the single source of truth
 for what's missing — score time stays quiet.
 
-Per-DB 'Left' is tolerated for genuine integrity errors (scaling/weights
-length mismatch, weights absent on a regionalized method): that DB drops
-to a 0 contribution and the function keeps summing the rest, preserving
-the partial answer over the other DBs.
-
-Returns 'Left' only when 'every' triple's score is 'Left' — i.e. every
-participating DB hit an integrity error and there is no salvageable
-contribution. The concatenated error messages are surfaced so the caller
-can act on them.
+A per-DB 'Left' is a genuine integrity error (scaling/weights length
+mismatch, weights absent on a regionalized method — never a coverage gap)
+and fails the whole sum: dropping that DB to a 0 contribution would return
+a silently undercounted total the consumer cannot tell from a real score.
+The concatenated per-DB error messages are surfaced so the caller can act
+on them.
 -}
 sumRegionalizedLCIAScoreCrossDB ::
     UnitConfig ->
@@ -1647,11 +1644,9 @@ sumRegionalizedLCIAScoreCrossDB ::
     Either Text Double
 sumRegionalizedLCIAScoreCrossDB unitCfg unitDB flowDB hier triples =
     let results = [computeRegionalizedLCIAScore unitCfg unitDB flowDB db sv hier t | (db, sv, t) <- triples]
-        oks = rights results
-        errs = lefts results
-     in case (oks, errs) of
-            ([], es) | not (null es) -> Left (T.intercalate "; " es)
-            _ -> Right (sum oks)
+     in case lefts results of
+            [] -> Right (sum (rights results))
+            es -> Left (T.intercalate "; " es)
 
 {- | Cascade CF lookup: UUID → exact (name, medium, subcomp) → fallback (name, medium).
 The same logic is baked into 'mtBroadcast' once unit conversion is available;

--- a/test/CrossDBRegionalLCIASpec.hs
+++ b/test/CrossDBRegionalLCIASpec.hs
@@ -125,15 +125,54 @@ spec = describe "cross-DB regional LCIA" $ do
                     perDb
                     `shouldBe` Right 5.0
 
-    it "NEW path: tainted dep-DB drops to 0 contribution; root contribution survives" $ do
+    it "NEW path: a dep-DB integrity error fails the whole sum, never undercounts" $ do
+        -- Same solve as the 5.0 case, but the dep DB's tables carry a
+        -- genuine integrity error (regional CFs present, precomputed
+        -- weights absent — the stale-cache shape). Summing the healthy
+        -- root alone would silently return 0 instead of 5; the sum must
+        -- refuse instead.
+        rootSolver <- mkSolverFromDb rootDb "root"
+        depSolver <- mkSolverFromDb depDb "dep"
+        let depLookup name =
+                pure $
+                    if name == "dep" then Just (depDb, depSolver) else Nothing
+        eRes <-
+            SS.computeInventoryMatrixWithDepsCached
+                kgUnitConfig
+                depLookup
+                rootDb
+                "root"
+                rootSolver
+                0
+        case eRes of
+            Left err -> expectationFailure ("solve failed: " <> show err)
+            Right sol -> do
+                let perDb =
+                        [ (db, s, tablesFor n)
+                        | (n, db, s) <- NE.toList (SS.csScalings sol)
+                        ]
+                    tablesFor n = case n of
+                        "root" -> rootTables
+                        "dep" -> depTables{mtRegionalActivityWeights = Nothing}
+                        other -> error ("unexpected dbName in csScalings: " <> show other)
+                case sumRegionalizedLCIAScoreCrossDB
+                    kgUnitConfig
+                    (dbUnits depDb)
+                    (dbBioFlows depDb)
+                    M.empty
+                    perDb of
+                    Left _ -> pure ()
+                    Right s -> expectationFailure ("expected the integrity error to propagate, got Right " <> show s)
+
+    it "NEW path: tainted dep-DB column contributes 0; root contribution survives" $ do
         -- Same DBs, but the method only has CF[F, FR]. The dep DB's DE
         -- activity is regionalized in the method (F appears in regional
         -- CFs) but no CF resolves at DE / parents / broadcast — that's a
-        -- tainted column, and it carries scaling 1. Per-DB scoring Lefts
-        -- on dep. The cross-DB sum tolerates it: drops the dep DB to a 0
-        -- contribution and keeps the root DB's Right. The build-time WARN
-        -- already names the gap (per-(flow, location) pair); score-time
-        -- loudness would regress users who used to see partial scores.
+        -- tainted column, and it carries scaling 1. The precomputed
+        -- weights leave it at 0 (a coverage gap, not an integrity error),
+        -- so the dep DB scores Right 0 and the cross-DB sum stays Right.
+        -- The build-time WARN already names the gap per (flow, location)
+        -- pair.
         let strictMappings = regionalMappings [("FR", 1)]
             depTablesStrict = buildTables depDb strictMappings
             rootTablesStrict = buildTables rootDb strictMappings
@@ -162,8 +201,8 @@ spec = describe "cross-DB regional LCIA" $ do
                         "dep" -> depTablesStrict
                         other -> error ("unexpected dbName in csScalings: " <> show other)
                 -- Root has no biosphere triples → contributes Right 0.
-                -- Dep biosphere triple at DE has no CF → Left (tainted).
-                -- Tolerant sum: Right 0 (root) + 0 dropped (dep) = Right 0.
+                -- Dep's DE column is tainted → weight 0 → contributes Right 0.
+                -- Sum: Right 0.
                 sumRegionalizedLCIAScoreCrossDB
                     kgUnitConfig
                     (dbUnits depDb)

--- a/test/ScoringKeySpec.hs
+++ b/test/ScoringKeySpec.hs
@@ -4,11 +4,13 @@ module ScoringKeySpec (spec) where
 
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
+import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import Test.Hspec
 
-import API.Routes (rawScoreMapByName)
+import API.Routes (rawScoreMapByName, resolveBatchedScore)
 import API.Types (LCIAResult (..))
+import Method.Types (Method (..))
 
 -- | Minimal LCIAResult for keying tests (only name/category/score matter here).
 mkR :: Text -> Text -> Double -> LCIAResult
@@ -27,28 +29,57 @@ mkR name category score =
         , lrTopContributors = []
         }
 
-spec :: Spec
-spec = describe "rawScoreMapByName" $ do
-    it "keys by method name, retaining methods that share a coarse category" $ do
-        -- Mirrors JRC ILCD EF 3.1: fossils and minerals both sit under the
-        -- "Abiotic resource depletion" damage category. Keying by category
-        -- would drop one; keying by name keeps both so single-score variables
-        -- (mapped to method names) resolve.
-        let results =
-                [ mkR "Climate change" "Climate change" 10
-                , mkR "Resource use, fossils" "Abiotic resource depletion" 5
-                , mkR "Resource use, minerals and metals" "Abiotic resource depletion" 3
-                ]
-            m = rawScoreMapByName results
-        M.lookup "Resource use, fossils" m `shouldBe` Just 5
-        M.lookup "Resource use, minerals and metals" m `shouldBe` Just 3
-        M.lookup "Climate change" m `shouldBe` Just 10
-        M.size m `shouldBe` 3
+-- | Minimal Method for score-resolution tests.
+mkMethod :: Text -> Method
+mkMethod name =
+    Method
+        { methodId = UUID.nil
+        , methodName = name
+        , methodDescription = Nothing
+        , methodUnit = "kg CO2 eq"
+        , methodCategory = name
+        , methodMethodology = Nothing
+        , methodFactors = []
+        }
 
-    it "is identical to category-keying when name == category (SimaPro case)" $ do
-        let results =
-                [ mkR "Acidification" "Acidification" 2
-                , mkR "Water use" "Water use" 7
-                ]
-        rawScoreMapByName results
-            `shouldBe` M.fromList [("Acidification", 2), ("Water use", 7)]
+spec :: Spec
+spec = do
+    describe "resolveBatchedScore" $ do
+        let method = mkMethod "Climate change"
+        it "passes a computed score through" $
+            resolveBatchedScore method (M.singleton UUID.nil (Right 42))
+                `shouldBe` Right 42
+
+        it "propagates a scoring integrity error instead of collapsing it to 0" $
+            resolveBatchedScore method (M.singleton UUID.nil (Left "weights absent"))
+                `shouldBe` Left "[LCIA Climate change] weights absent"
+
+        it "treats a method missing from the batched set as an error, not a 0" $
+            case resolveBatchedScore method M.empty of
+                Left err -> err `shouldSatisfy` T.isInfixOf "missing"
+                Right s -> expectationFailure ("expected Left, got Right " <> show s)
+
+    describe "rawScoreMapByName" $ do
+        it "keys by method name, retaining methods that share a coarse category" $ do
+            -- Mirrors JRC ILCD EF 3.1: fossils and minerals both sit under the
+            -- "Abiotic resource depletion" damage category. Keying by category
+            -- would drop one; keying by name keeps both so single-score variables
+            -- (mapped to method names) resolve.
+            let results =
+                    [ mkR "Climate change" "Climate change" 10
+                    , mkR "Resource use, fossils" "Abiotic resource depletion" 5
+                    , mkR "Resource use, minerals and metals" "Abiotic resource depletion" 3
+                    ]
+                m = rawScoreMapByName results
+            M.lookup "Resource use, fossils" m `shouldBe` Just 5
+            M.lookup "Resource use, minerals and metals" m `shouldBe` Just 3
+            M.lookup "Climate change" m `shouldBe` Just 10
+            M.size m `shouldBe` 3
+
+        it "is identical to category-keying when name == category (SimaPro case)" $ do
+            let results =
+                    [ mkR "Acidification" "Acidification" 2
+                    , mkR "Water use" "Water use" 7
+                    ]
+            rawScoreMapByName results
+                `shouldBe` M.fromList [("Acidification", 2), ("Water use", 7)]


### PR DESCRIPTION
`computeRegionalizedLCIAScore` reserves its `Left` for genuine integrity errors — mismatched table lengths, absent weights — never for coverage gaps. Yet every consumer collapsed that `Left` to a score of **0** with only a server-side log line, so the API answered a plausible number the consumer could not tell from a real score: a silent undercount, the exact failure mode the engineering rules forbid.

The `Either` now travels to the handlers. Single-method, batch and multi-activity scoring answer **500** with the error text; sensitivity keeps partial results by putting the error on the affected perturbation entry, which already carries per-entry errors on the wire. The shared resolution lives in `resolveBatchedScore` (spec-covered), which also turns "method missing from the batched score set" — impossible by construction, silently 0 before — into an error.

Coverage gaps are unaffected: an unmapped flow still contributes nothing and is reported through the existing warning and mapping-stats channels.