### PR TITLE
Read EcoSpold 2 mathematicalRelation formulas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## [Unreleased]
 
 ### Added
+- EcoSpold 2 `mathematicalRelation` formulas are now read. Dataset
+  `<parameter>` variables are kept on the activity (value and raw formula),
+  and an exchange whose amount is defined by a formula over the dataset's
+  parameters and exchange variables gets the freshly evaluated result. A
+  formula that cannot be evaluated — an unknown variable, an unsupported
+  function — keeps the amount stored in the file and is reported as a
+  warning at load time instead of being silently ignored.
 - `volca server` starts without `--config`: it runs on the built-in defaults
   with no databases, ready to receive uploads or API-driven loads. Launchers
   no longer have to write an empty TOML file just to satisfy the flag. An

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@
 ### Added
 - EcoSpold 2 `mathematicalRelation` formulas are now read. Dataset
   `<parameter>` variables are kept on the activity (value and raw formula),
-  and an exchange whose amount is defined by a formula over the dataset's
-  parameters and exchange variables gets the freshly evaluated result. A
-  formula that cannot be evaluated — an unknown variable, an unsupported
-  function — keeps the amount stored in the file and is reported as a
-  warning at load time instead of being silently ignored.
+  and each exchange formula is checked against the dataset's parameters and
+  exchange variables as a consistency control. The amount stored in the file
+  always stays authoritative: a formula that evaluates to a different value
+  is reported as a divergence warning at load time, and the formulas that
+  cannot be evaluated (unsupported functions, cross-dataset references) are
+  summarized in one warning per dataset instead of being silently ignored.
 - `volca server` starts without `--config`: it runs on the built-in defaults
   with no databases, ready to receive uploads or API-driven loads. Launchers
   no longer have to write an empty TOML file just to satisfy the flag. An

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -9,7 +9,7 @@ import Amount (readAmount)
 import Data.Bifunctor (first)
 import qualified Data.ByteString as BS
 import qualified Data.Map as M
-import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
+import Data.Maybe (catMaybes, fromMaybe)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -123,8 +123,9 @@ data ElementaryData = ElementaryData
 
 {- | Dataset-local formula metadata carried by an exchange: its own
 @variableName@ (referencable from other formulas in the same dataset) and its
-@mathematicalRelation@ (re-evaluated once the whole dataset is parsed, since
-the variables it references may be declared after it in the file).
+@mathematicalRelation@ (checked against the stored amount once the whole
+dataset is parsed, since the variables it references may be declared after it
+in the file).
 -}
 data ExchangeFormula = ExchangeFormula
     { efVariableName :: !(Maybe Text)
@@ -398,58 +399,49 @@ finishExchange unit warns st =
         , psWarnings = warns ++ psWarnings st
         }
 
--- | Replace an exchange's amount, whatever its variant.
-setAmount :: Double -> Exchange -> Exchange
-setAmount v ex = case ex of
-    TechnosphereExchange{} -> ex{techAmount = v}
-    BiosphereExchange{} -> ex{bioAmount = v}
-    WasteExchange{} -> ex{waAmount = v}
+{- | Check exchange @mathematicalRelation@ formulas against the dataset-local
+environment: the dataset's @\<parameter\>@ variables plus every exchange's own
+@variableName@ bound to its stored amount.
 
-{- | Re-evaluate exchange @mathematicalRelation@ formulas against the
-dataset-local environment: the dataset's @\<parameter\>@ variables plus every
-exchange's own @variableName@ bound to its stored amount. Stored amounts are
-already evaluated in EcoSpold2 sources, so binding them directly needs no
-fixpoint iteration.
-
-A formula that evaluates replaces the stored amount (normally to the same
-value — a divergence means the stored amount was stale and is reported). One
-that doesn't evaluate — unknown variable, unsupported function, cross-dataset
-reference — keeps the stored amount and yields a warning: never zero, never a
-crash.
+The stored amount always stays authoritative. EcoSpold2 sources carry
+pre-evaluated amounts, and this evaluator only supports a subset of the
+formula language (no @UnitConversion@, no cross-dataset @Ref@) with
+SimaPro-flavoured semantics, so its result serves as a consistency check, not
+a replacement. A formula that evaluates to a different value is reported as a
+divergence; the formulas that cannot be evaluated at all are summarized in a
+single warning per dataset — real EcoSpold2 databases use unsupported
+functions heavily, and one line per exchange would flood the load log.
 -}
-evaluateFormulas :: M.Map Text Double -> [(Exchange, ExchangeFormula)] -> ([Exchange], [String])
-evaluateFormulas params pairs = (map fst resolved, mapMaybe snd resolved)
+validateFormulas :: M.Map Text Double -> [(Exchange, ExchangeFormula)] -> [String]
+validateFormulas params pairs = divergences ++ unevaluableSummary
   where
     -- Left-biased union: a <parameter> wins over an exchange variable of the same name.
     env = M.union params (M.fromList [(v, exchangeAmount ex) | (ex, ef) <- pairs, Just v <- [efVariableName ef]])
-    resolved = map apply pairs
-    apply (ex, ef) = case efMathRel ef of
-        Nothing -> (ex, Nothing)
-        Just rel -> case Expr.evaluate env (Expr.normalizeExpr '.' rel) of
-            Right v -> (setAmount v ex, mismatchWarning rel v ex)
-            Left _ ->
-                ( ex
-                , Just $
-                    "[WARNING] Cannot evaluate mathematicalRelation \""
-                        ++ T.unpack rel
-                        ++ "\" for exchange flow "
-                        ++ UUID.toString (exchangeFlowId ex)
-                        ++ " - keeping stored amount "
-                        ++ show (exchangeAmount ex)
-                )
-    mismatchWarning rel v ex
-        | nearlyEqual v (exchangeAmount ex) = Nothing
-        | otherwise =
-            Just $
-                "[WARNING] mathematicalRelation \""
-                    ++ T.unpack rel
-                    ++ "\" for exchange flow "
-                    ++ UUID.toString (exchangeFlowId ex)
-                    ++ " evaluates to "
-                    ++ show v
-                    ++ " but the dataset stores amount "
-                    ++ show (exchangeAmount ex)
-                    ++ " - using the formula result"
+    checked = [(ex, rel, Expr.evaluate env (Expr.normalizeExpr '.' rel)) | (ex, ef) <- pairs, Just rel <- [efMathRel ef]]
+    divergences =
+        [ "[WARNING] mathematicalRelation \""
+            ++ T.unpack rel
+            ++ "\" for exchange flow "
+            ++ UUID.toString (exchangeFlowId ex)
+            ++ " evaluates to "
+            ++ show v
+            ++ " but the dataset stores amount "
+            ++ show (exchangeAmount ex)
+            ++ " - keeping the stored amount"
+        | (ex, rel, Right v) <- checked
+        , not (nearlyEqual v (exchangeAmount ex))
+        ]
+    unevaluableSummary = case [(ex, rel) | (ex, rel, Left _) <- checked] of
+        [] -> []
+        unevaluable@((ex, rel) : _) ->
+            [ "[WARNING] "
+                ++ show (length unevaluable)
+                ++ " mathematicalRelation formula(s) could not be evaluated (e.g. \""
+                ++ T.unpack rel
+                ++ "\" on exchange flow "
+                ++ UUID.toString (exchangeFlowId ex)
+                ++ ") - keeping the stored amounts"
+            ]
     nearlyEqual a b = abs (a - b) <= 1e-9 * max 1 (max (abs a) (abs b))
 
 -- | Xeno SAX parser implementation
@@ -746,8 +738,10 @@ parseWithXeno xmlContent processId = do
                 add d = if T.null txt then d else d{edSubcompartments = txt : edSubcompartments d}
              in onExchange id add state
         -- A <parameter> is referencable from formulas only through its
-        -- variableName; its amount is pre-evaluated in the source, so an
-        -- entry without either has nothing to contribute and is skipped.
+        -- variableName; its amount is pre-evaluated in the source. An entry
+        -- with no variableName has nothing to contribute and is skipped; one
+        -- with a variableName but no usable amount is dropped with a warning,
+        -- since formulas referencing it will fail to evaluate downstream.
         | isElement tagName "parameter" =
             let PendingParam var amt rel = psPendingParam state
                 committed = case (nonEmptyText var, amt) of
@@ -756,7 +750,13 @@ parseWithXeno xmlContent processId = do
                             { psParams = M.insert v a (psParams state)
                             , psParamExprs = maybe (psParamExprs state) (\r -> M.insert v r (psParamExprs state)) (nonEmptyText rel)
                             }
-                    (_, _) -> state
+                    (Just v, Nothing) ->
+                        state
+                            { psWarnings =
+                                ("[WARNING] Ignoring <parameter> \"" ++ T.unpack v ++ "\" - missing or unparseable amount")
+                                    : psWarnings state
+                            }
+                    (Nothing, _) -> state
              in popText committed{psPendingParam = emptyPendingParam}
         | isElement tagName "classificationSystem" =
             (popText state){psPendingClassSystem = T.strip (accumText state)}
@@ -785,9 +785,10 @@ parseWithXeno xmlContent processId = do
             description = reverse (psDescription st) -- Reverse to get correct order
             refUnit = fromMaybe "UNKNOWN_UNIT" (psRefUnit st)
             nativeType = ecoSpoldNativeType (psActivityType st) (psSpecialActivityType st)
-            (resolvedExchanges, formulaWarns) = evaluateFormulas (psParams st) (reverse (psExchanges st))
+            pairs = reverse (psExchanges st)
+            formulaWarns = validateFormulas (psParams st) pairs
             -- Apply cutoff strategy to exchanges
-            activity = Activity name description M.empty (psClassifications st) location refUnit resolvedExchanges (psParams st) (psParamExprs st) Nothing Nothing nativeType Nothing
+            activity = Activity name description M.empty (psClassifications st) location refUnit (map fst pairs) (psParams st) (psParamExprs st) Nothing Nothing nativeType Nothing
             techs = reverse (psTechFlows st)
             bios = reverse (psBioFlows st)
             wastes = reverse (psWasteFlows st)

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -5,18 +5,20 @@
 
 module EcoSpold.Parser2 (streamParseActivityAndFlowsFromFile, normalizeCAS) where
 
+import Amount (readAmount)
 import Data.Bifunctor (first)
 import qualified Data.ByteString as BS
 import qualified Data.Map as M
-import Data.Maybe (catMaybes, fromMaybe)
+import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V5 as UUID5
-import EcoSpold.Common (bsToDouble, bsToInt, bsToIntMaybe, bsToText, isElement)
+import EcoSpold.Common (bsToDouble, bsToInt, bsToIntMaybe, bsToText, isElement, nonEmptyText)
 import EcoSpold.Cutoff (applyCutoffStrategy)
+import qualified Expr
 import Progress (ProgressLevel (..), reportProgress)
 import System.FilePath (takeBaseName)
 import Types
@@ -95,6 +97,8 @@ data IntermediateData = IntermediateData
     , idSynonyms :: !(M.Map Text (S.Set Text))
     , idComment :: !(Maybe (Text, Text)) -- (xml:lang, comment text) — English wins
     , idClassifications :: !(M.Map Text Text) -- per-exchange classifications (e.g. By-product classification → Waste)
+    , idVariableName :: !Text -- variableName attribute (referencable from other formulas in the dataset)
+    , idMathRel :: !Text -- mathematicalRelation attribute (formula defining the amount)
     }
     deriving (Eq)
 
@@ -112,8 +116,30 @@ data ElementaryData = ElementaryData
     , edSynonyms :: !(M.Map Text (S.Set Text))
     , edCAS :: !(Maybe Text)
     , edComment :: !(Maybe (Text, Text))
+    , edVariableName :: !Text -- variableName attribute (referencable from other formulas in the dataset)
+    , edMathRel :: !Text -- mathematicalRelation attribute (formula defining the amount)
     }
     deriving (Eq)
+
+{- | Dataset-local formula metadata carried by an exchange: its own
+@variableName@ (referencable from other formulas in the same dataset) and its
+@mathematicalRelation@ (re-evaluated once the whole dataset is parsed, since
+the variables it references may be declared after it in the file).
+-}
+data ExchangeFormula = ExchangeFormula
+    { efVariableName :: !(Maybe Text)
+    , efMathRel :: !(Maybe Text)
+    }
+
+-- | Attribute accumulator for the currently-open @\<parameter\>@ element.
+data PendingParam = PendingParam
+    { ppVariableName :: !Text
+    , ppAmount :: !(Maybe Double)
+    , ppMathRel :: !Text
+    }
+
+emptyPendingParam :: PendingParam
+emptyPendingParam = PendingParam "" Nothing ""
 
 {- | Update a comment slot with a newly seen `<comment xml:lang="…">` text.
 Prefer English; otherwise keep the first non-empty entry. Empty / blank
@@ -136,7 +162,7 @@ data ParseState = ParseState
     , psLocation :: !(Maybe Text)
     , psRefUnit :: !(Maybe Text)
     , psDescription :: ![Text]
-    , psExchanges :: ![Exchange]
+    , psExchanges :: ![(Exchange, ExchangeFormula)]
     , psTechFlows :: ![TechnosphereFlow]
     , psBioFlows :: ![BiosphereFlow]
     , psWasteFlows :: ![WasteFlow]
@@ -152,6 +178,9 @@ data ParseState = ParseState
     , psPendingCommentLang :: !Text -- xml:lang on the currently-open <comment>
     , psActivityType :: !(Maybe Int) -- ecospold2 <activity activityType="1..8"> attribute
     , psSpecialActivityType :: !(Maybe Int) -- ecospold2 <activity specialActivityType="…"> attribute
+    , psParams :: !(M.Map Text Double) -- <parameter> variableName → amount (amounts are pre-evaluated in the source)
+    , psParamExprs :: !(M.Map Text Text) -- <parameter> variableName → mathematicalRelation (raw formula, for inspection)
+    , psPendingParam :: !PendingParam -- attribute accumulator for the open <parameter>
     }
 
 -- | Initial parsing state
@@ -178,6 +207,9 @@ initialParseState =
         , psPendingCommentLang = ""
         , psActivityType = Nothing
         , psSpecialActivityType = Nothing
+        , psParams = M.empty
+        , psParamExprs = M.empty
+        , psPendingParam = emptyPendingParam
         }
 
 {- | Build the source-native activity-type record from the ecospold2
@@ -341,8 +373,8 @@ parseUUIDOrNil t
 nonBlankOr :: Text -> Text -> Text
 nonBlankOr fallback t = if T.null t then fallback else t
 
-addExchange :: Exchange -> ParseState -> ParseState
-addExchange ex st = st{psExchanges = ex : psExchanges st}
+addExchange :: Exchange -> ExchangeFormula -> ParseState -> ParseState
+addExchange ex ef st = st{psExchanges = (ex, ef) : psExchanges st}
 
 addTechFlow :: TechnosphereFlow -> ParseState -> ParseState
 addTechFlow f st = st{psTechFlows = f : psTechFlows st}
@@ -366,12 +398,66 @@ finishExchange unit warns st =
         , psWarnings = warns ++ psWarnings st
         }
 
+-- | Replace an exchange's amount, whatever its variant.
+setAmount :: Double -> Exchange -> Exchange
+setAmount v ex = case ex of
+    TechnosphereExchange{} -> ex{techAmount = v}
+    BiosphereExchange{} -> ex{bioAmount = v}
+    WasteExchange{} -> ex{waAmount = v}
+
+{- | Re-evaluate exchange @mathematicalRelation@ formulas against the
+dataset-local environment: the dataset's @\<parameter\>@ variables plus every
+exchange's own @variableName@ bound to its stored amount. Stored amounts are
+already evaluated in EcoSpold2 sources, so binding them directly needs no
+fixpoint iteration.
+
+A formula that evaluates replaces the stored amount (normally to the same
+value — a divergence means the stored amount was stale and is reported). One
+that doesn't evaluate — unknown variable, unsupported function, cross-dataset
+reference — keeps the stored amount and yields a warning: never zero, never a
+crash.
+-}
+evaluateFormulas :: M.Map Text Double -> [(Exchange, ExchangeFormula)] -> ([Exchange], [String])
+evaluateFormulas params pairs = (map fst resolved, mapMaybe snd resolved)
+  where
+    -- Left-biased union: a <parameter> wins over an exchange variable of the same name.
+    env = M.union params (M.fromList [(v, exchangeAmount ex) | (ex, ef) <- pairs, Just v <- [efVariableName ef]])
+    resolved = map apply pairs
+    apply (ex, ef) = case efMathRel ef of
+        Nothing -> (ex, Nothing)
+        Just rel -> case Expr.evaluate env (Expr.normalizeExpr '.' rel) of
+            Right v -> (setAmount v ex, mismatchWarning rel v ex)
+            Left _ ->
+                ( ex
+                , Just $
+                    "[WARNING] Cannot evaluate mathematicalRelation \""
+                        ++ T.unpack rel
+                        ++ "\" for exchange flow "
+                        ++ UUID.toString (exchangeFlowId ex)
+                        ++ " - keeping stored amount "
+                        ++ show (exchangeAmount ex)
+                )
+    mismatchWarning rel v ex
+        | nearlyEqual v (exchangeAmount ex) = Nothing
+        | otherwise =
+            Just $
+                "[WARNING] mathematicalRelation \""
+                    ++ T.unpack rel
+                    ++ "\" for exchange flow "
+                    ++ UUID.toString (exchangeFlowId ex)
+                    ++ " evaluates to "
+                    ++ show v
+                    ++ " but the dataset stores amount "
+                    ++ show (exchangeAmount ex)
+                    ++ " - using the formula result"
+    nearlyEqual a b = abs (a - b) <= 1e-9 * max 1 (max (abs a) (abs b))
+
 -- | Xeno SAX parser implementation
 parseWithXeno :: BS.ByteString -> ProcessId -> Either String ((Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]), [String])
 parseWithXeno xmlContent processId = do
     finalState <- first show (X.fold openTag attribute endOpen text closeTag cdata initialParseState xmlContent)
-    result <- buildResult finalState processId
-    pure (result, reverse (psWarnings finalState))
+    (result, formulaWarns) <- buildResult finalState processId
+    pure (result, reverse (psWarnings finalState) ++ formulaWarns)
   where
     -- Open tag handler - update path and context
     openTag state tagName =
@@ -381,14 +467,16 @@ parseWithXeno xmlContent processId = do
                     state{psPendingInputGroup = "", psPendingOutputGroup = ""}
                 | isElement tagName "comment" =
                     state{psPendingCommentLang = ""}
+                | isElement tagName "parameter" =
+                    state{psPendingParam = emptyPendingParam}
                 | otherwise = state
             newContext
                 | isElement tagName "activityName" = InActivityName
                 | isElement tagName "shortname" && any (isElement "geography") (psPath cleanState) = InGeographyShortname
                 | isElement tagName "intermediateExchange" =
-                    InIntermediateExchange (IntermediateData "" 0.0 "" "" "" "" "" "" M.empty Nothing M.empty)
+                    InIntermediateExchange (IntermediateData "" 0.0 "" "" "" "" "" "" M.empty Nothing M.empty "" "")
                 | isElement tagName "elementaryExchange" =
-                    InElementaryExchange (ElementaryData "" 0.0 "" "" "" "" "" [] [] M.empty Nothing Nothing)
+                    InElementaryExchange (ElementaryData "" 0.0 "" "" "" "" "" [] [] M.empty Nothing Nothing "" "")
                 | isElement tagName "text" && any (isElement "generalComment") (psPath cleanState) = InGeneralCommentText 0
                 -- Classification elements: don't switch context. Handled via psTextAccum + psPendingClassSystem.
                 -- Switching context here would destroy InIntermediateExchange when classifications appear inside exchanges.
@@ -414,6 +502,8 @@ parseWithXeno xmlContent processId = do
                             | isElement name "inputGroup" = idata{idInputGroup = bsToText value}
                             | isElement name "outputGroup" = idata{idOutputGroup = bsToText value}
                             | isElement name "activityLinkId" = idata{idActivityLinkId = bsToText value}
+                            | isElement name "variableName" && not isInsideProperty = idata{idVariableName = bsToText value}
+                            | isElement name "mathematicalRelation" && not isInsideProperty = idata{idMathRel = bsToText value}
                             | otherwise = idata
                      in withLang state{psContext = InIntermediateExchange updated}
                 InElementaryExchange edata ->
@@ -424,6 +514,8 @@ parseWithXeno xmlContent processId = do
                             | isElement name "inputGroup" = edata{edInputGroup = bsToText value}
                             | isElement name "outputGroup" = edata{edOutputGroup = bsToText value}
                             | isElement name "casNumber" = edata{edCAS = Just (normalizeCAS (bsToText value))}
+                            | isElement name "variableName" && not isInsideProperty = edata{edVariableName = bsToText value}
+                            | isElement name "mathematicalRelation" && not isInsideProperty = edata{edMathRel = bsToText value}
                             | otherwise = edata
                      in withLang state{psContext = InElementaryExchange updated}
                 InGeneralCommentText _ ->
@@ -431,13 +523,23 @@ parseWithXeno xmlContent processId = do
                      in withLang state{psContext = InGeneralCommentText idx}
                 _ ->
                     -- Attributes on the <activity> opening tag carry the
-                    -- ecospold2 activityType and specialActivityType enums.
+                    -- ecospold2 activityType and specialActivityType enums;
+                    -- attributes on a <parameter> carry its variableName,
+                    -- pre-evaluated amount and mathematicalRelation formula.
                     let onActivity = pathAt 0 "activity" state
+                        onParameter = pathAt 0 "parameter" state
+                        pending = psPendingParam state
                         captured
                             | onActivity && isElement name "activityType" =
                                 state{psActivityType = bsToIntMaybe value}
                             | onActivity && isElement name "specialActivityType" =
                                 state{psSpecialActivityType = bsToIntMaybe value}
+                            | onParameter && isElement name "variableName" =
+                                state{psPendingParam = pending{ppVariableName = bsToText value}}
+                            | onParameter && isElement name "amount" =
+                                state{psPendingParam = pending{ppAmount = readAmount (bsToText value)}}
+                            | onParameter && isElement name "mathematicalRelation" =
+                                state{psPendingParam = pending{ppMathRel = bsToText value}}
                             | otherwise = state
                      in withLang captured
 
@@ -534,10 +636,11 @@ parseWithXeno xmlContent processId = do
                             if isReferenceProduct && not (T.null (idUnitName idata))
                                 then Just (idUnitName idata)
                                 else psRefUnit state
+                        formula = ExchangeFormula (nonEmptyText (idVariableName idata)) (nonEmptyText (idMathRel idata))
                         base = (finishExchange unit warns state){psRefUnit = newRefUnit}
                      in if refOnWasteAxis
-                            then addExchange wasteExchange (addWasteFlow wasteFlow base)
-                            else addExchange techExchange (addTechFlow techFlow base)
+                            then addExchange wasteExchange formula (addWasteFlow wasteFlow base)
+                            else addExchange techExchange formula (addTechFlow techFlow base)
         | isElement tagName "elementaryExchange" =
             case currentElementary state of
                 Nothing -> popPath state
@@ -602,10 +705,11 @@ parseWithXeno xmlContent processId = do
                                 , waPedigree = Nothing
                                 }
                         wasteFlow = WasteFlow flowUUID resolvedFlowName unitUUID (edSynonyms edata) (edCAS edata) Nothing
+                        formula = ExchangeFormula (nonEmptyText (edVariableName edata)) (nonEmptyText (edMathRel edata))
                         base = finishExchange unit warns state
                      in if isInventoryIndicatorWaste
-                            then addExchange wasteExchange (addWasteFlow wasteFlow base)
-                            else addExchange bioExchange (addBioFlow bioFlow base)
+                            then addExchange wasteExchange formula (addWasteFlow wasteFlow base)
+                            else addExchange bioExchange formula (addBioFlow bioFlow base)
         | isElement tagName "text" =
             -- The generalComment <text> branch deliberately does NOT pop the path.
             if inGeneralComment state
@@ -641,6 +745,19 @@ parseWithXeno xmlContent processId = do
             let txt = T.strip (accumText state)
                 add d = if T.null txt then d else d{edSubcompartments = txt : edSubcompartments d}
              in onExchange id add state
+        -- A <parameter> is referencable from formulas only through its
+        -- variableName; its amount is pre-evaluated in the source, so an
+        -- entry without either has nothing to contribute and is skipped.
+        | isElement tagName "parameter" =
+            let PendingParam var amt rel = psPendingParam state
+                committed = case (nonEmptyText var, amt) of
+                    (Just v, Just a) ->
+                        state
+                            { psParams = M.insert v a (psParams state)
+                            , psParamExprs = maybe (psParamExprs state) (\r -> M.insert v r (psParamExprs state)) (nonEmptyText rel)
+                            }
+                    (_, _) -> state
+             in popText committed{psPendingParam = emptyPendingParam}
         | isElement tagName "classificationSystem" =
             (popText state){psPendingClassSystem = T.strip (accumText state)}
         | isElement tagName "classificationValue" =
@@ -661,20 +778,21 @@ parseWithXeno xmlContent processId = do
     cdata = text
 
     -- Build final result from parse state
-    buildResult :: ParseState -> ProcessId -> Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit])
+    buildResult :: ParseState -> ProcessId -> Either String ((Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]), [String])
     buildResult st _pid =
         let name = fromMaybe "Unknown Activity" (psActivityName st)
             location = fromMaybe "GLO" (psLocation st)
             description = reverse (psDescription st) -- Reverse to get correct order
             refUnit = fromMaybe "UNKNOWN_UNIT" (psRefUnit st)
             nativeType = ecoSpoldNativeType (psActivityType st) (psSpecialActivityType st)
+            (resolvedExchanges, formulaWarns) = evaluateFormulas (psParams st) (reverse (psExchanges st))
             -- Apply cutoff strategy to exchanges
-            activity = Activity name description M.empty (psClassifications st) location refUnit (reverse $ psExchanges st) M.empty M.empty Nothing Nothing nativeType Nothing
+            activity = Activity name description M.empty (psClassifications st) location refUnit resolvedExchanges (psParams st) (psParamExprs st) Nothing Nothing nativeType Nothing
             techs = reverse (psTechFlows st)
             bios = reverse (psBioFlows st)
             wastes = reverse (psWasteFlows st)
             units = reverse (psUnits st)
-         in (,techs,bios,wastes,units) <$> applyCutoffStrategy activity
+         in (,formulaWarns) . (,techs,bios,wastes,units) <$> applyCutoffStrategy activity
 
 -- | Parse EcoSpold file using Xeno SAX parser
 streamParseActivityAndFlowsFromFile :: FilePath -> IO (Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]))

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -477,8 +477,8 @@ data Activity = Activity
     , activityLocation :: !Text -- Location code (e.g. FR, RER)
     , activityUnit :: !Text -- Reference unit
     , exchanges :: ![Exchange] -- List of exchanges
-    , activityParams :: !(M.Map Text Double) -- Resolved SimaPro parameter values
-    , activityParamExprs :: !(M.Map Text Text) -- Raw SimaPro parameter expressions (for re-evaluation)
+    , activityParams :: !(M.Map Text Double) -- Resolved dataset parameter values (SimaPro parameters, EcoSpold2 <parameter> variables)
+    , activityParamExprs :: !(M.Map Text Text) -- Raw parameter expressions/formulas keyed like activityParams (for inspection and re-evaluation)
     , activityAllocationPercent :: !(Maybe Double) -- SimaPro multi-product allocation fraction (%, 0..100); Nothing for non-allocated bases
     , activityAllocationFormula :: !(Maybe Text) -- Raw SimaPro allocation formula (e.g. "Qp*DMp/(Qp*DMp+Qw*DMw)*100"); Nothing if purely numeric
     , activityNativeType :: !(Maybe NativeActivityType) -- Source-format-native activity type (ecospold @activityType, SimaPro Type, ILCD processType); Nothing when source format lacks the field

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -3,12 +3,15 @@
 module EcoSpold2Spec (spec) where
 
 import qualified Data.ByteString as BS
+import Data.List (isInfixOf)
+import qualified Data.Map as M
 import qualified Data.Text as T
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
 import EcoSpold.Parser2 (streamParseActivityAndFlowsFromFile)
+import Progress (getLogLines)
 import Types
 
 {- | The bundled fixture has a `<comment xml:lang="en">...</comment>` on each
@@ -182,6 +185,39 @@ spec = describe "per-exchange comments" $ do
                 Right (act, _, _, _, _) ->
                     activityNativeType act `shouldBe` Nothing
 
+    -- -----------------------------------------------------------------------
+    -- mathematicalRelation formulas: <parameter> variables plus exchange
+    -- variableNames form a dataset-local environment; an exchange's
+    -- mathematicalRelation is re-evaluated against it. An unresolvable
+    -- formula keeps the stored amount and warns — never zero, never a crash.
+    -- -----------------------------------------------------------------------
+    describe "mathematicalRelation formulas" $ do
+        it "evaluates an exchange formula from parameters and exchange variables" $
+            withFormulaFixture $ \(act, _, _, _, _) ->
+                -- fuel_input(2.0) * 2 + production(1.0) = 5.0, overriding the stale stored 4.0.
+                -- The nested <property>'s own mathematicalRelation ("9999") must not leak in.
+                [exchangeAmount e | e@TechnosphereExchange{techRole = Input} <- exchanges act]
+                    `shouldBe` [5.0]
+
+        it "stores <parameter> values and raw formulas on the activity" $
+            withFormulaFixture $ \(act, _, _, _, _) -> do
+                activityParams act `shouldBe` M.fromList [("fuel_input", 2.0)]
+                activityParamExprs act `shouldBe` M.fromList [("fuel_input", "4.0 / 2")]
+
+        it "keeps the stored amount when a formula references an unknown variable" $
+            withFormulaFixture $ \(act, _, _, _, _) ->
+                [exchangeAmount e | e@BiosphereExchange{} <- exchanges act]
+                    `shouldBe` [3.0]
+
+        it "warns on an unresolvable formula and on a stored/evaluated mismatch" $ do
+            (since, _) <- getLogLines 0
+            withFormulaFixture $ \_ -> pure ()
+            (_, newLines) <- getLogLines since
+            any ("Cannot evaluate mathematicalRelation \"missing_var * 2\"" `isInfixOf`) newLines
+                `shouldBe` True
+            any ("evaluates to 5.0 but the dataset stores amount 4.0" `isInfixOf`) newLines
+                `shouldBe` True
+
 {- | Synthetic ecospold2 dataset parameterised on the activityType code and
 optional specialActivityType code. One reference output, no other exchanges.
 -}
@@ -329,3 +365,69 @@ parseWasteReference = withSystemTempDirectory "es2-waste-ref" $ \dir -> do
 withWasteReferenceFixture :: ((Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]) -> IO ()) -> IO ()
 withWasteReferenceFixture k =
     parseWasteReference >>= either (expectationFailure . ("Parse failed: " ++)) k
+
+{- | Synthetic dataset exercising mathematicalRelation evaluation:
+  - a reference output carrying variableName="production" (amount 1.0)
+  - a fuel input whose stored amount (4.0) is stale next to its formula
+    "fuel_input * 2 + production" (= 5.0); its nested <property> carries its
+    own variableName/mathematicalRelation which must NOT leak onto the exchange
+  - an emission whose formula references an unknown variable (kept at 3.0)
+  - a <parameter> (fuel_input = 2.0, formula "4.0 / 2") placed AFTER the
+    exchanges, as the EcoSpold2 schema orders flowData
+-}
+formulaXml :: BS.ByteString
+formulaXml =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+    \<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold02\">\n\
+    \  <activityDataset>\n\
+    \    <activityDescription>\n\
+    \      <activity id=\"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\" activityNameId=\"formula-test\">\n\
+    \        <activityName xml:lang=\"en\">Formula test activity</activityName>\n\
+    \      </activity>\n\
+    \      <geography geographyId=\"TEST\"><shortname xml:lang=\"en\">TEST</shortname></geography>\n\
+    \    </activityDescription>\n\
+    \    <flowData>\n\
+    \      <intermediateExchange id=\"ref\" unitId=\"unit-kwh\" amount=\"1.0\" variableName=\"production\"\n\
+    \                           intermediateExchangeId=\"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb\">\n\
+    \        <name xml:lang=\"en\">Formula test product</name>\n\
+    \        <unitName xml:lang=\"en\">kWh</unitName>\n\
+    \        <outputGroup>0</outputGroup>\n\
+    \      </intermediateExchange>\n\
+    \      <intermediateExchange id=\"fuel\" unitId=\"unit-kg\" amount=\"4.0\"\n\
+    \                           mathematicalRelation=\"fuel_input * 2 + production\"\n\
+    \                           intermediateExchangeId=\"cccccccc-cccc-cccc-cccc-cccccccccccc\">\n\
+    \        <name xml:lang=\"en\">Fuel</name>\n\
+    \        <unitName xml:lang=\"en\">kg</unitName>\n\
+    \        <property propertyId=\"prop-1\" amount=\"7.0\" variableName=\"prop_var\" mathematicalRelation=\"9999\">\n\
+    \          <name xml:lang=\"en\">dry mass</name>\n\
+    \          <unitName xml:lang=\"en\">kg</unitName>\n\
+    \        </property>\n\
+    \        <inputGroup>5</inputGroup>\n\
+    \      </intermediateExchange>\n\
+    \      <elementaryExchange id=\"em\" unitId=\"unit-kg\" amount=\"3.0\"\n\
+    \                         mathematicalRelation=\"missing_var * 2\"\n\
+    \                         elementaryExchangeId=\"dddddddd-dddd-dddd-dddd-dddddddddddd\">\n\
+    \        <name xml:lang=\"en\">Carbon dioxide</name>\n\
+    \        <unitName xml:lang=\"en\">kg</unitName>\n\
+    \        <compartment>\n\
+    \          <compartment xml:lang=\"en\">air</compartment>\n\
+    \          <subcompartment xml:lang=\"en\">unspecified</subcompartment>\n\
+    \        </compartment>\n\
+    \        <outputGroup>4</outputGroup>\n\
+    \      </elementaryExchange>\n\
+    \      <parameter parameterId=\"par-1\" variableName=\"fuel_input\" amount=\"2.0\" mathematicalRelation=\"4.0 / 2\">\n\
+    \        <name xml:lang=\"en\">fuel input</name>\n\
+    \        <unitName xml:lang=\"en\">kg</unitName>\n\
+    \      </parameter>\n\
+    \    </flowData>\n\
+    \  </activityDataset>\n\
+    \</ecoSpold>\n"
+
+withFormulaFixture :: ((Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]) -> IO ()) -> IO ()
+withFormulaFixture k = withSystemTempDirectory "es2-formula" $ \dir -> do
+    let path = dir </> "12345678-1234-5678-9abc-123456789001_12345678-1234-5678-9abc-123456789002.spold"
+    BS.writeFile path formulaXml
+    result <- streamParseActivityAndFlowsFromFile path
+    case result of
+        Left err -> expectationFailure $ "Parse failed: " ++ err
+        Right res -> k res

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -188,16 +188,19 @@ spec = describe "per-exchange comments" $ do
     -- -----------------------------------------------------------------------
     -- mathematicalRelation formulas: <parameter> variables plus exchange
     -- variableNames form a dataset-local environment; an exchange's
-    -- mathematicalRelation is re-evaluated against it. An unresolvable
-    -- formula keeps the stored amount and warns — never zero, never a crash.
+    -- mathematicalRelation is checked against it as a consistency control.
+    -- The stored amount always stays authoritative — a divergence or an
+    -- unresolvable formula warns, never changes a number, never crashes.
     -- -----------------------------------------------------------------------
     describe "mathematicalRelation formulas" $ do
-        it "evaluates an exchange formula from parameters and exchange variables" $
+        it "keeps the stored amount when the formula evaluates to a different value" $
             withFormulaFixture $ \(act, _, _, _, _) ->
-                -- fuel_input(2.0) * 2 + production(1.0) = 5.0, overriding the stale stored 4.0.
-                -- The nested <property>'s own mathematicalRelation ("9999") must not leak in.
+                -- fuel_input(2.0) * 2 + production(1.0) = 5.0 diverges from the
+                -- stored 4.0; the stored amount wins (the divergence warning is
+                -- asserted below, proving the nested <property>'s own
+                -- mathematicalRelation "9999" did not leak into the evaluation).
                 [exchangeAmount e | e@TechnosphereExchange{techRole = Input} <- exchanges act]
-                    `shouldBe` [5.0]
+                    `shouldBe` [4.0]
 
         it "stores <parameter> values and raw formulas on the activity" $
             withFormulaFixture $ \(act, _, _, _, _) -> do
@@ -209,13 +212,19 @@ spec = describe "per-exchange comments" $ do
                 [exchangeAmount e | e@BiosphereExchange{} <- exchanges act]
                     `shouldBe` [3.0]
 
-        it "warns on an unresolvable formula and on a stored/evaluated mismatch" $ do
+        it "does not keep a <parameter> without a usable amount" $
+            withFormulaFixture $ \(act, _, _, _, _) ->
+                M.member "ghost" (activityParams act) `shouldBe` False
+
+        it "warns on divergence, on unresolvable formulas (aggregated), and on a dropped parameter" $ do
             (since, _) <- getLogLines 0
             withFormulaFixture $ \_ -> pure ()
             (_, newLines) <- getLogLines since
-            any ("Cannot evaluate mathematicalRelation \"missing_var * 2\"" `isInfixOf`) newLines
+            any ("evaluates to 5.0 but the dataset stores amount 4.0 - keeping the stored amount" `isInfixOf`) newLines
                 `shouldBe` True
-            any ("evaluates to 5.0 but the dataset stores amount 4.0" `isInfixOf`) newLines
+            any ("1 mathematicalRelation formula(s) could not be evaluated (e.g. \"missing_var * 2\"" `isInfixOf`) newLines
+                `shouldBe` True
+            any ("Ignoring <parameter> \"ghost\"" `isInfixOf`) newLines
                 `shouldBe` True
 
 {- | Synthetic ecospold2 dataset parameterised on the activityType code and
@@ -366,14 +375,15 @@ withWasteReferenceFixture :: ((Activity, [TechnosphereFlow], [BiosphereFlow], [W
 withWasteReferenceFixture k =
     parseWasteReference >>= either (expectationFailure . ("Parse failed: " ++)) k
 
-{- | Synthetic dataset exercising mathematicalRelation evaluation:
+{- | Synthetic dataset exercising mathematicalRelation checking:
   - a reference output carrying variableName="production" (amount 1.0)
-  - a fuel input whose stored amount (4.0) is stale next to its formula
+  - a fuel input whose stored amount (4.0) diverges from its formula
     "fuel_input * 2 + production" (= 5.0); its nested <property> carries its
     own variableName/mathematicalRelation which must NOT leak onto the exchange
   - an emission whose formula references an unknown variable (kept at 3.0)
   - a <parameter> (fuel_input = 2.0, formula "4.0 / 2") placed AFTER the
     exchanges, as the EcoSpold2 schema orders flowData
+  - a <parameter> with a variableName but no amount, dropped with a warning
 -}
 formulaXml :: BS.ByteString
 formulaXml =
@@ -418,6 +428,9 @@ formulaXml =
     \      <parameter parameterId=\"par-1\" variableName=\"fuel_input\" amount=\"2.0\" mathematicalRelation=\"4.0 / 2\">\n\
     \        <name xml:lang=\"en\">fuel input</name>\n\
     \        <unitName xml:lang=\"en\">kg</unitName>\n\
+    \      </parameter>\n\
+    \      <parameter parameterId=\"par-2\" variableName=\"ghost\">\n\
+    \        <name xml:lang=\"en\">ghost parameter</name>\n\
     \      </parameter>\n\
     \    </flowData>\n\
     \  </activityDataset>\n\


### PR DESCRIPTION
## Why

EcoSpold 2 datasets carry their calculation logic in `mathematicalRelation` attributes: `<parameter>` elements declare variables, and an exchange's amount can be defined as a formula over them. The parser ignored all of it — parameters were dropped on the floor and formulas were invisible, so a consumer could never inspect how an amount was derived, and a stored amount inconsistent with its formula went unnoticed. The SimaPro path already evaluates formulas through `Expr`; this brings EcoSpold 2 formula reading onto the same machinery.

## What it does now

- `<parameter>` variables land on the activity: the resolved value in `activityParams` and the raw formula in `activityParamExprs` — the same fields the SimaPro parser fills. A parameter with a `variableName` but no usable amount is dropped with a warning.
- An exchange's `mathematicalRelation` is checked after the whole dataset is read (its variables may be declared later in the file), against a dataset-local environment: the dataset's parameters plus every exchange's own `variableName` bound to its stored amount.
- The stored amount always stays authoritative. The evaluator supports only a subset of the formula language (no `UnitConversion`, no cross-dataset `Ref`) with SimaPro-flavoured semantics, so its result serves as a consistency check: a formula that evaluates to a different value is reported as a divergence warning, never applied.
- Formulas that cannot be evaluated are summarized in a single warning per dataset — real databases use unsupported functions heavily, and one line per exchange would flood the load log.
- Attributes on a nested `<property>` are excluded from exchange capture, the same way property amounts already were.

Cross-dataset variable resolution is out of scope: everything is resolved within one dataset.

## Tests

New `mathematicalRelation formulas` group in `EcoSpold2Spec`: divergence keeps the stored amount and warns, parameter storage on the activity, the unresolvable-variable fallback, the dropped-parameter warning, and the property-attribute no-leak case. Full suite: 1555 examples, 0 failures.
