### PR TITLE
Expose compartment, location and unit on method factors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   with no databases, ready to receive uploads or API-driven loads. Launchers
   no longer have to write an empty TOML file just to satisfy the flag. An
   explicit `--config` path that does not exist still fails loudly.
+- Each factor listed by `GET /method/{id}/factors` now carries its
+  compartment, location, and unit. A method routinely holds several factors
+  for one substance name — emitted to air vs. water, or one per region — and
+  without these fields such rows looked like duplicates.
 
 ## [0.9.2] - 2026-07-14
 

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -1636,7 +1636,11 @@ and ``description`` are free-text metadata the source may or may not carry.
 One characterization factor of a method (:meth:`Client.get_method_factors`).
 
 ``direction`` is the flow direction the factor applies to; ``value`` is the
-factor in the method's unit per the flow's unit.
+factor in the method's unit per the flow's unit. A method routinely holds
+several factors sharing one ``flow_name`` — the same substance emitted to
+air vs. water, or one regionalized factor per ``location`` — so
+``compartment``, ``location`` and ``unit`` are what tell them apart.
+Engines older than wire additions may omit them (``None``).
 
 | Field | Type | Default |
 |-------|------|---------|
@@ -1644,6 +1648,9 @@ factor in the method's unit per the flow's unit.
 | `flow_name` | `str` | — |
 | `direction` | `str` | — |
 | `value` | `float` | — |
+| `unit` | `str \| None` | None |
+| `compartment` | `str \| None` | None |
+| `location` | `str \| None` | None |
 
 ### `PathResult`
 

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -1640,7 +1640,8 @@ factor in the method's unit per the flow's unit. A method routinely holds
 several factors sharing one ``flow_name`` — the same substance emitted to
 air vs. water, or one regionalized factor per ``location`` — so
 ``compartment``, ``location`` and ``unit`` are what tell them apart.
-Engines older than wire additions may omit them (``None``).
+Each is ``None`` when the source method does not carry that axis, or
+when the engine predates these fields.
 
 | Field | Type | Default |
 |-------|------|---------|

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -1674,13 +1674,20 @@ class MethodFactor(FromJson):
     """One characterization factor of a method (:meth:`Client.get_method_factors`).
 
     ``direction`` is the flow direction the factor applies to; ``value`` is the
-    factor in the method's unit per the flow's unit.
+    factor in the method's unit per the flow's unit. A method routinely holds
+    several factors sharing one ``flow_name`` — the same substance emitted to
+    air vs. water, or one regionalized factor per ``location`` — so
+    ``compartment``, ``location`` and ``unit`` are what tell them apart.
+    Engines older than wire additions may omit them (``None``).
     """
 
     flow_ref: str
     flow_name: str
     direction: str
     value: float
+    unit: "str | None" = None
+    compartment: "str | None" = None
+    location: "str | None" = None
 
 
 @dataclass

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -1678,7 +1678,8 @@ class MethodFactor(FromJson):
     several factors sharing one ``flow_name`` — the same substance emitted to
     air vs. water, or one regionalized factor per ``location`` — so
     ``compartment``, ``location`` and ``unit`` are what tell them apart.
-    Engines older than wire additions may omit them (``None``).
+    Each is ``None`` when the source method does not carry that axis, or
+    when the engine predates these fields.
     """
 
     flow_ref: str

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -16,7 +16,7 @@ import qualified Config
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Concurrent.STM (readTVarIO)
 import Control.Exception (evaluate)
-import Control.Monad (forM, forM_, unless, when)
+import Control.Monad (forM, forM_, mfilter, unless, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (asks)
 import Data.Aeson
@@ -1030,7 +1030,7 @@ cfToAPI cf =
             MT.Input -> "Input"
             MT.Output -> "Output"
         , mfaValue = mcfValue cf
-        , mfaUnit = mcfUnit cf
+        , mfaUnit = mfilter (not . T.null) (Just (mcfUnit cf))
         , mfaCompartment = compartmentPath <$> mcfCompartment cf
         , mfaLocation = mcfConsumerLocation cf
         }

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1030,7 +1030,17 @@ cfToAPI cf =
             MT.Input -> "Input"
             MT.Output -> "Output"
         , mfaValue = mcfValue cf
+        , mfaUnit = mcfUnit cf
+        , mfaCompartment = compartmentPath <$> mcfCompartment cf
+        , mfaLocation = mcfConsumerLocation cf
         }
+
+{- | Render a compartment triple as one display path, keeping every non-empty
+axis: @"air/urban air"@, @"water/unspecified/long-term"@.
+-}
+compartmentPath :: MT.Compartment -> Text
+compartmentPath (MT.Compartment medium sub qualifier) =
+    T.intercalate "/" (filter (not . T.null) [medium, sub, qualifier])
 
 -- ---------------------------------------------------------------------------
 -- AppM helpers

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -448,12 +448,20 @@ data MethodDetail = MethodDetail
     deriving (Generic)
     deriving (ToJSON, ToSchema) via (Stripped MethodDetail)
 
--- | Characterization factor for API response
+{- | Characterization factor for API response. A method routinely carries
+several CFs sharing one flow name — same substance emitted to air vs. water,
+or one regionalized CF per location — so the distinguishing axes
+(compartment, location, unit) travel with each row instead of leaving
+consumers with apparent duplicates.
+-}
 data MethodFactorAPI = MethodFactorAPI
     { mfaFlowRef :: UUID -- ILCD flow UUID
     , mfaFlowName :: Text -- Flow name
     , mfaDirection :: Text -- "Input" or "Output"
     , mfaValue :: Double -- CF value
+    , mfaUnit :: Text -- CF reference unit (e.g. "kg", "kBq")
+    , mfaCompartment :: Maybe Text -- e.g. "air/urban air", "water/unspecified/long-term"
+    , mfaLocation :: Maybe Text -- Consumer location for regionalized CFs
     }
     deriving (Generic)
     deriving (ToJSON, ToSchema) via (Stripped MethodFactorAPI)

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -459,7 +459,7 @@ data MethodFactorAPI = MethodFactorAPI
     , mfaFlowName :: Text -- Flow name
     , mfaDirection :: Text -- "Input" or "Output"
     , mfaValue :: Double -- CF value
-    , mfaUnit :: Text -- CF reference unit (e.g. "kg", "kBq")
+    , mfaUnit :: Maybe Text -- CF reference unit (e.g. "kg", "kBq"); Nothing when the source method states none
     , mfaCompartment :: Maybe Text -- e.g. "air/urban air", "water/unspecified/long-term"
     , mfaLocation :: Maybe Text -- Consumer location for regionalized CFs
     }

--- a/src/Method/ParserSimaPro.hs
+++ b/src/Method/ParserSimaPro.hs
@@ -395,7 +395,12 @@ mkCompartment comp sub =
         subcomp =
             let s = decodeBS (BS8.strip sub)
              in if s == "(unspecified)" then "" else s
-     in Just (Compartment medium subcomp "")
+     in -- An empty compartment column must yield no compartment at all: a
+        -- 'Compartment "" sub ""' would wrongly constrain flow matching and
+        -- leak an empty path onto the API.
+        if T.null medium
+            then Nothing
+            else Just (Compartment medium subcomp "")
 
 normalizeCAS :: Text -> Maybe Text
 normalizeCAS cas

--- a/test/MethodSpec.hs
+++ b/test/MethodSpec.hs
@@ -819,7 +819,11 @@ spec = do
             mfaCompartment toWaterLongTerm `shouldBe` Just "water/unspecified/long-term"
             mfaCompartment inFrance `shouldBe` Nothing
             mfaLocation inFrance `shouldBe` Just "FR"
-            mfaUnit toAir `shouldBe` "kg"
+            mfaUnit toAir `shouldBe` Just "kg"
+
+        it "emits no unit rather than an empty one when the source method states none" $ do
+            let unitless = MethodCF (UUID.fromWords 1 2 3 4) "Ammonia" Output 1.0 Nothing Nothing "" Nothing
+            mfaUnit (cfToAPI unitless) `shouldBe` Nothing
 
     describe "SimaPro Method CSV Parser" $ do
         it "detects SimaPro method CSV format" $ do
@@ -870,6 +874,18 @@ spec = do
                     mcfValue co2 `shouldBe` 1.0
                     mcfDirection co2 `shouldBe` Output
                     mcfCAS co2 `shouldBe` Just "124-38-9"
+
+        it "drops the compartment when the compartment column is empty" $ do
+            let csv =
+                    "{SimaPro 10.2.0.0}\r\n{methods}\r\n{CSV separator: Semicolon}\r\n{Decimal separator: .}\r\n\r\n\
+                    \Method\r\n\r\nName\r\nTest\r\n\r\n\
+                    \Impact category\r\nClimate change;kg CO2 eq\r\n\r\n\
+                    \Substances\r\n;;Mystery substance;;1;kg\r\n\r\nEnd\r\n"
+            case parseSimaProMethodCSVBytes csv of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right coll -> do
+                    let cfs = methodFactors (head (mcMethods coll))
+                    map mcfCompartment cfs `shouldBe` [Nothing]
 
         it "parses Methane CF = 29.8" $ do
             csv <- BS.readFile "test/data/simapro_method.csv"

--- a/test/MethodSpec.hs
+++ b/test/MethodSpec.hs
@@ -10,6 +10,8 @@ import qualified Data.Text.Encoding as TE
 import qualified Data.UUID as UUID
 import Test.Hspec
 
+import API.Routes (cfToAPI)
+import API.Types (MethodFactorAPI (..))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString.Lazy as BL
@@ -805,6 +807,19 @@ spec = do
             it "returns 0 for empty mappings" $ do
                 let inventory = M.fromList [(UUID.fromWords 1 2 3 4, 100.0)]
                 loScore (computeLCIAScore defaultUnitConfig M.empty M.empty inventory []) `shouldBe` 0.0
+
+    describe "cfToAPI" $ do
+        it "keeps the axes that distinguish same-name factors: compartment, location, unit" $ do
+            let uuid = UUID.fromWords 1 2 3 4
+                cf comp = MethodCF uuid "Ammonia" Output 1.0 comp Nothing "kg"
+                toAir = cfToAPI (cf (Just (Compartment "air" "urban air" "")) Nothing)
+                toWaterLongTerm = cfToAPI (cf (Just (Compartment "water" "unspecified" "long-term")) Nothing)
+                inFrance = cfToAPI (cf Nothing (Just "FR"))
+            mfaCompartment toAir `shouldBe` Just "air/urban air"
+            mfaCompartment toWaterLongTerm `shouldBe` Just "water/unspecified/long-term"
+            mfaCompartment inFrance `shouldBe` Nothing
+            mfaLocation inFrance `shouldBe` Just "FR"
+            mfaUnit toAir `shouldBe` "kg"
 
     describe "SimaPro Method CSV Parser" $ do
         it "detects SimaPro method CSV format" $ do


### PR DESCRIPTION
## Why

`GET /method/{id}/factors` returned only the flow name, direction and CF value. A characterization method routinely holds several factors for one substance name — the same substance emitted to air vs. water vs. soil, a long-term variant, or one regionalized factor per location — so consumers listing a method's factors saw rows that looked like exact duplicates, with no field to tell them apart.

## Final state

Each factor now carries the axes that distinguish it:

- `compartment` — the compartment path with every non-empty axis kept (`"air/urban air"`, `"water/unspecified/long-term"`), `null` when the source method has none;
- `location` — the consumer location for regionalized factors, `null` for universal ones;
- `unit` — the CF reference unit (`"kg"`, `"kBq"`, `"m3"`).

On the test method fixture, the three `Carbon dioxide, fossil` factors that previously rendered as duplicates now read `air`, `air/indoor` and `soil`.

The change is additive (no wire-version bump). The bundled Python client's `MethodFactor` model gains the same three optional fields and tolerates older engines that omit them; its generated API reference is regenerated.