### PR TITLE
Add a supplier-gap report endpoint and MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@
   demand it, the distinct consumers, the total demanded amount, and the top
   consuming processes. It is the natural read right after a relink: it answers
   "what is missing to switch this database's background dependency?" without
-  rebuilding the list by hand from the linking statistics.
+  rebuilding the list by hand from the linking statistics. An optional `limit`
+  keeps only the biggest gaps; the header counts always cover the full report.
 - Delete-activities accepts an `ids` list to delete exactly the named
   processes, on the API (`"ids": [...]`) and the CLI (repeatable `--id`).
   Previously the only selection mode was a filter, so deleting a known list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@
   carries per-entry errors.
 
 ### Added
+- A supplier-gap report: `GET /db/{db}/gap-report` and the `get_gap_report`
+  MCP tool list everything a database still demands but nothing supplies,
+  after internal resolution and cross-database linking. Each missing product
+  (name, location, unit) carries the blocking reason, how many consumer edges
+  demand it, the distinct consumers, the total demanded amount, and the top
+  consuming processes. It is the natural read right after a relink: it answers
+  "what is missing to switch this database's background dependency?" without
+  rebuilding the list by hand from the linking statistics.
 - Delete-activities accepts an `ids` list to delete exactly the named
   processes, on the API (`"ids": [...]`) and the CLI (repeatable `--id`).
   Previously the only selection mode was a filter, so deleting a known list

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ POST   /api/v1/db/upload                                                 Upload 
 POST   /api/v1/db/{dbName}/load                                          Load a configured database
 POST   /api/v1/db/{dbName}/unload                                        Unload (keep config, free memory)
 POST   /api/v1/db/{dbName}/relink                                        Re-resolve cross-DB links (optional JSON body: depDb + mappingCsv for an alias relink)
+GET    /api/v1/db/{dbName}/gap-report                                    Supplier-gap report (what is still unsupplied after linking)
 POST   /api/v1/db/{dbName}/finalize                                      Finalize cross-DB linking
 DELETE /api/v1/db/{dbName}                                               Delete a database
 GET    /api/v1/db/{dbName}/setup                                         Setup info (path, dependencies)

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -235,17 +235,21 @@ relinkDatabaseHandler dbName req = do
 unsupplied after internal resolution and cross-DB linking. The natural
 follow-up read after a relink — POST relink, then GET gap-report.
 -}
-gapReportHandler :: Text -> AppM GapReportAPI
-gapReportHandler dbName = do
+gapReportHandler :: Text -> Maybe Int -> AppM GapReportAPI
+gapReportHandler dbName mLimit = do
     dbManager <- asks aeDbManager
     res <- liftIO $ databaseGapReport dbManager dbName
     case res of
         Left err -> throwError err404{errBody = BSL.fromStrict $ T.encodeUtf8 err}
-        Right report -> return (gapReportToAPI report)
+        Right report -> return (gapReportToAPI mLimit report)
 
--- | Project the domain gap report onto its wire shape.
-gapReportToAPI :: Loader.GapReport -> GapReportAPI
-gapReportToAPI r =
+{- | Project the domain gap report onto its wire shape, keeping at most
+@limit@ gap entries (they are ranked by demanding edges, so a cap keeps the
+biggest gaps). The header counts always cover the full report, so a truncated
+list stays countable — never a silent cap.
+-}
+gapReportToAPI :: Maybe Int -> Loader.GapReport -> GapReportAPI
+gapReportToAPI mLimit r =
     GapReportAPI
         { graDbName = Loader.grDbName r
         , graTotalInputs = Loader.grTotalInputs r
@@ -254,7 +258,7 @@ gapReportToAPI r =
         , graUnresolvedEdges = Loader.grUnresolvedEdges r
         , graUnresolvedProducts = Loader.grUnresolvedProducts r
         , graCompleteness = Loader.grCompleteness r
-        , graGaps = map entryToAPI (Loader.grGaps r)
+        , graGaps = map entryToAPI (maybe id take mLimit (Loader.grGaps r))
         }
   where
     entryToAPI e =

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -16,6 +16,8 @@ module API.DatabaseHandlers (
     loadDatabaseHandler,
     unloadDatabaseHandler,
     relinkDatabaseHandler,
+    gapReportHandler,
+    gapReportToAPI,
     copyDatabaseHandler,
     deleteDatabaseHandler,
     deleteActivitiesHandler,
@@ -85,6 +87,9 @@ import API.Types (
     DeleteSelectionRequest (..),
     DeleteSelectionResponse (..),
     ExportRequest (..),
+    GapConsumerAPI (..),
+    GapEntryAPI (..),
+    GapReportAPI (..),
     LoadDatabaseResponse (..),
     RefDataListResponse (..),
     RefDataStatusAPI (..),
@@ -102,9 +107,11 @@ import Data.Aeson (Value, toJSON)
 import qualified Data.Aeson as A
 import qualified Data.Aeson.KeyMap as KM
 import Data.Maybe (fromMaybe)
+import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import Database.Edit (DeleteRequest (..), copyDatabase, deleteActivitiesInDB)
 import Database.Export (parseExportFormat, serializeDatabase)
+import qualified Database.Loader as Loader
 import Database.Manager (
     DatabaseLoadStatus (..),
     DatabaseManager (..),
@@ -120,6 +127,7 @@ import Database.Manager (
     addFlowSynonyms,
     addMethodCollection,
     addUnitDefs,
+    databaseGapReport,
     finalizeDatabase,
     getDatabase,
     getDatabaseSetupInfo,
@@ -155,7 +163,7 @@ import Database.Upload (
     handleUpload,
  )
 import qualified Database.UploadedDatabase as UploadedDB
-import Types (Database (..), GeographyPolicy (..), unresolvedCount)
+import Types (Database (..), GeographyPolicy (..), blockerReasonDetail, unresolvedCount)
 
 -- | List all databases
 getDatabases :: AppM DatabaseListResponse
@@ -222,6 +230,58 @@ relinkDatabaseHandler dbName req = do
                         , rrCrossDBLinks = rresCrossDBLinks r
                         , rrDependsOn = rresDepsLoaded r
                         }
+
+{- | Supplier-gap report for a loaded or staged database: everything still
+unsupplied after internal resolution and cross-DB linking. The natural
+follow-up read after a relink — POST relink, then GET gap-report.
+-}
+gapReportHandler :: Text -> AppM GapReportAPI
+gapReportHandler dbName = do
+    dbManager <- asks aeDbManager
+    res <- liftIO $ databaseGapReport dbManager dbName
+    case res of
+        Left err -> throwError err404{errBody = BSL.fromStrict $ T.encodeUtf8 err}
+        Right report -> return (gapReportToAPI report)
+
+-- | Project the domain gap report onto its wire shape.
+gapReportToAPI :: Loader.GapReport -> GapReportAPI
+gapReportToAPI r =
+    GapReportAPI
+        { graDbName = Loader.grDbName r
+        , graTotalInputs = Loader.grTotalInputs r
+        , graInternalLinks = Loader.grInternalLinks r
+        , graCrossDBLinks = Loader.grCrossDBLinks r
+        , graUnresolvedEdges = Loader.grUnresolvedEdges r
+        , graUnresolvedProducts = Loader.grUnresolvedProducts r
+        , graCompleteness = Loader.grCompleteness r
+        , graGaps = map entryToAPI (Loader.grGaps r)
+        }
+  where
+    entryToAPI e =
+        let (reason, detail) = gapReasonDetail (Loader.geReason e)
+         in GapEntryAPI
+                { gaeName = Loader.geFlowName e
+                , gaeLocation = Loader.geLocation e
+                , gaeUnit = Loader.geUnit e
+                , gaeReason = reason
+                , gaeDetail = detail
+                , gaeEdges = Loader.geEdges e
+                , gaeConsumers = Loader.geConsumers e
+                , gaeDemandSum = Loader.geDemandSum e
+                , gaeTopConsumers = map consumerToAPI (Loader.geTopConsumers e)
+                }
+    consumerToAPI c =
+        GapConsumerAPI
+            { gcaProcessId = UUID.toText (Loader.gcActUUID c) <> "_" <> UUID.toText (Loader.gcProdUUID c)
+            , gcaActivityName = Loader.gcActivityName c
+            , gcaProductName = Loader.gcProductName c
+            , gcaLocation = Loader.gcLocation c
+            , gcaEdges = Loader.gcEdges c
+            }
+    gapReasonDetail gr = case gr of
+        Loader.GapBlocked blocker -> blockerReasonDetail blocker
+        Loader.GapDanglingIdentity -> ("dangling_source_identity", Nothing)
+        Loader.GapWasteInput -> ("unlinked_waste_input", Nothing)
 
 {- | Copy a loaded database under a new name. The copy is an independent
 in-memory database registered under @newName@; the source is untouched.

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -35,6 +35,7 @@ import Database.Manager (DatabaseManager (..), LoadedDatabase (..), getDatabase)
 import qualified Database.Manager as DM
 
 import qualified API.BatchImpacts as BI
+import API.DatabaseHandlers (gapReportToAPI)
 import API.MCP.Columnar (resolveSingleScoringSet, toColumnarBatch)
 import API.MCP.Enrich (addWebUrlMaybe, attachMarketHintByName, encodeSegment, filterScoringSets, scoreActivityWebUrl, slimLCIAPanel, webUrlField)
 import API.Types (ActivityForAPI (..), ActivityInfo (..), ClassificationSystem (..), ExchangeWithUnit (..), InventoryExport (..), InventoryFlowDetail (..), Perturbation (..), Substitution (..), SubstitutionRequest (..))
@@ -360,6 +361,7 @@ callTool dbManager presets mBaseUrl rid name args = case name of
     "score_activity" -> callScoreActivity dbManager mBaseUrl rid args
     "score_activities" -> callScoreActivities dbManager mBaseUrl rid args
     "list_scoring_sets" -> callListScoringSets dbManager rid args
+    "get_gap_report" -> callGetGapReport dbManager rid args
     _ -> return $ toolError rid ("Unknown tool: " <> name)
 
 -- Helper: extract database, then run action
@@ -1296,6 +1298,16 @@ callListMethods dbManager rid = do
                 )
                 loadedMethods
     return $ toolSuccessJson rid $ object ["methods" .= summaries]
+
+{- | Supplier-gap report: what is still unsupplied after cross-DB linking.
+Same wire shape as the REST endpoint ('gapReportToAPI'), so both surfaces
+stay in lock-step.
+-}
+callGetGapReport :: DatabaseManager -> Value -> KeyMap Value -> IO Value
+callGetGapReport dbManager rid args = runTool rid $ do
+    dbName <- except (requireText "database" args)
+    report <- ExceptT (DM.databaseGapReport dbManager dbName)
+    return $ toolSuccessJson rid (toJSON (gapReportToAPI report))
 
 callGetFlowMapping :: DatabaseManager -> Value -> KeyMap Value -> IO Value
 callGetFlowMapping dbManager rid args = runTool rid $ do

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -1307,7 +1307,7 @@ callGetGapReport :: DatabaseManager -> Value -> KeyMap Value -> IO Value
 callGetGapReport dbManager rid args = runTool rid $ do
     dbName <- except (requireText "database" args)
     report <- ExceptT (DM.databaseGapReport dbManager dbName)
-    return $ toolSuccessJson rid (toJSON (gapReportToAPI report))
+    return $ toolSuccessJson rid (toJSON (gapReportToAPI (intArg "limit" args) report))
 
 callGetFlowMapping :: DatabaseManager -> Value -> KeyMap Value -> IO Value
 callGetFlowMapping dbManager rid args = runTool rid $ do

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -750,4 +750,5 @@ params r = case r of
         ]
     GetGapReport ->
         [ pDatabase
+        , pLimit "Max gap entries to return, biggest first (default: all). The header counts always cover the full report, so a truncated list stays countable."
         ]

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -71,6 +71,7 @@ data Resource
     | ScoreActivity
     | ScoreActivities
     | ListScoringSets
+    | GetGapReport
     deriving (Eq, Ord, Show, Bounded, Enum)
 
 -- | Whether a parameter must be supplied by the caller.
@@ -152,6 +153,7 @@ apiPath r = case r of
     ScoreActivity -> Just (GET, ["db", "{dbName}", "activity", "{processId}", "impacts", "{collection}"])
     ScoreActivities -> Just (POST, ["db", "{dbName}", "impacts", "{collection}"])
     ListScoringSets -> Nothing -- MCP-only: scoring sets are configuration metadata, no REST equivalent yet
+    GetGapReport -> Just (GET, ["db", "{dbName}", "gap-report"])
 
 {- | The full OpenAPI path template for a resource, e.g.
 @"/api/v1/db/{dbName}/activity/{processId}/impacts/{collection}/{methodId}"@.
@@ -194,6 +196,7 @@ mcpName r = case r of
     ScoreActivity -> "score_activity"
     ScoreActivities -> "score_activities"
     ListScoringSets -> "list_scoring_sets"
+    GetGapReport -> "get_gap_report"
 
 -- ---------------------------------------------------------------------------
 -- Projection: CLI subcommand names (kebab-case)
@@ -232,6 +235,7 @@ cliName r = case r of
     ScoreActivity -> "score-activity"
     ScoreActivities -> "score-activities"
     ListScoringSets -> "scoring-sets"
+    GetGapReport -> "gap-report"
 
 -- ---------------------------------------------------------------------------
 -- Projection: human-readable description (shared across surfaces)
@@ -432,6 +436,15 @@ description r = case r of
         \factors, and the score \
         \formulas. Use the returned set names as keys when interpreting \
         \score_activity / score_activities responses."
+    GetGapReport ->
+        "LCA / ACV — supplier-gap report of a database: every input demand \
+        \still unsupplied after internal resolution and cross-database \
+        \linking, aggregated per (product, location, unit) and ranked by \
+        \demanding edges. Each gap carries the blocking reason, the number of \
+        \consumer edges and distinct consumers, the total demanded amount, \
+        \and the top consuming processes. Answers 'what is missing to switch \
+        \or complete this database's background dependency?' — typically read \
+        \right after a relink."
 
 -- ---------------------------------------------------------------------------
 -- Projection: parameter schema
@@ -734,4 +747,7 @@ params r = case r of
         ]
     ListScoringSets ->
         [ Param "collection" "string" Optional "Method collection name. If omitted, returns scoring sets across all loaded collections, grouped by collection."
+        ]
+    GetGapReport ->
+        [ pDatabase
         ]

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -122,7 +122,7 @@ type LCAAPI =
                 -- Relink: empty {} body = plain relink; {depDb,mappingCsv} = mapping relink
                 :<|> "db" :> Capture "dbName" Text :> "relink" :> ReqBody '[JSON] RelinkRequest :> Post '[JSON] RelinkResponse
                 -- Supplier-gap report: what is still unsupplied after linking (read-only relink companion)
-                :<|> "db" :> Capture "dbName" Text :> "gap-report" :> Get '[JSON] GapReportAPI
+                :<|> "db" :> Capture "dbName" Text :> "gap-report" :> QueryParam "limit" Int :> Get '[JSON] GapReportAPI
                 :<|> "db" :> Capture "dbName" Text :> "copy" :> Capture "newName" Text :> Post '[JSON] ActivateResponse
                 :<|> "db" :> Capture "dbName" Text :> Delete '[JSON] ActivateResponse
                 -- Delete the whole filtered set of activities (selection in JSON body)

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -10,7 +10,7 @@ module API.Routes where
 import API.DatabaseHandlers (simpleAction)
 import qualified API.DatabaseHandlers as DBHandlers
 import qualified API.OpenApi
-import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExportRequest (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadChunk (..), UploadResponse (..), apiFlowOfKind)
+import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExportRequest (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GapReportAPI (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadChunk (..), UploadResponse (..), apiFlowOfKind)
 import App.Env (AppEnv (..), AppM, runApp)
 import qualified Config
 import Control.Concurrent.Async (mapConcurrently)
@@ -121,6 +121,8 @@ type LCAAPI =
                 :<|> "db" :> Capture "dbName" Text :> "unload" :> Post '[JSON] ActivateResponse
                 -- Relink: empty {} body = plain relink; {depDb,mappingCsv} = mapping relink
                 :<|> "db" :> Capture "dbName" Text :> "relink" :> ReqBody '[JSON] RelinkRequest :> Post '[JSON] RelinkResponse
+                -- Supplier-gap report: what is still unsupplied after linking (read-only relink companion)
+                :<|> "db" :> Capture "dbName" Text :> "gap-report" :> Get '[JSON] GapReportAPI
                 :<|> "db" :> Capture "dbName" Text :> "copy" :> Capture "newName" Text :> Post '[JSON] ActivateResponse
                 :<|> "db" :> Capture "dbName" Text :> Delete '[JSON] ActivateResponse
                 -- Delete the whole filtered set of activities (selection in JSON body)
@@ -1994,6 +1996,7 @@ lcaServer env = hoistServer lcaAPI (runApp env) handlers
             :<|> DBHandlers.loadDatabaseHandler
             :<|> DBHandlers.unloadDatabaseHandler
             :<|> DBHandlers.relinkDatabaseHandler
+            :<|> DBHandlers.gapReportHandler
             :<|> DBHandlers.copyDatabaseHandler
             :<|> DBHandlers.deleteDatabaseHandler
             :<|> DBHandlers.deleteActivitiesHandler

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -735,6 +735,54 @@ data RelinkRequest = RelinkRequest
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped RelinkRequest)
 
+-- | One consuming process of a supplier-gap entry.
+data GapConsumerAPI = GapConsumerAPI
+    { gcaProcessId :: Text
+    , gcaActivityName :: Text
+    , gcaProductName :: Text
+    , gcaLocation :: Text
+    , gcaEdges :: Int
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped GapConsumerAPI)
+
+{- | One supplier gap, aggregated per (product name, location, unit) so
+@demandSum@ never mixes units. @reason@ carries the stable blocker code
+('Types.blockerReasonDetail'), plus @dangling_source_identity@ for inputs whose
+named source activity no dependency ships, and @unlinked_waste_input@ for
+treatment-side waste inputs with no internal producer.
+-}
+data GapEntryAPI = GapEntryAPI
+    { gaeName :: Text
+    , gaeLocation :: Text
+    , gaeUnit :: Text
+    , gaeReason :: Text
+    , gaeDetail :: Maybe Text
+    , gaeEdges :: Int
+    , gaeConsumers :: Int
+    , gaeDemandSum :: Double
+    , gaeTopConsumers :: [GapConsumerAPI]
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped GapEntryAPI)
+
+{- | Supplier-gap report of a database: everything still unsupplied after
+internal resolution and cross-DB linking, aggregated and ranked by demanding
+edges — the work list for switching or completing a background dependency.
+-}
+data GapReportAPI = GapReportAPI
+    { graDbName :: Text
+    , graTotalInputs :: Int
+    , graInternalLinks :: Int
+    , graCrossDBLinks :: Int
+    , graUnresolvedEdges :: Int
+    , graUnresolvedProducts :: Int
+    , graCompleteness :: Double
+    , graGaps :: [GapEntryAPI]
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped GapReportAPI)
+
 -- | Result of auto-loading a single dependency
 data DepLoadResult
     = DepLoaded {dlrName :: Text}

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -56,6 +56,15 @@ module Database.Loader (
     collectDanglingProductNames,
     collectStagedDanglingProductNames,
 
+    -- * Supplier-gap report
+    GapReason (..),
+    GapEdge (..),
+    GapConsumer (..),
+    GapEntry (..),
+    GapReport (..),
+    gapReportForLoaded,
+    gapReportForStaged,
+
     -- * Internal Linking
     fixSimaProActivityLinks,
 
@@ -109,6 +118,7 @@ import Database.CrossLinking (
     SupplierEntry (..),
     WasteTreatmentMatch (..),
     defaultLinkingThreshold,
+    extractBracketedLocation,
     extractProductPrefixes,
     findSupplierAcrossDatabases,
     findSupplierByActivityProduct,
@@ -1469,6 +1479,233 @@ collectStagedDanglingProductNames db links =
         , Just _ <- [exchangeActivityLinkId ex]
         , Just flow <- [M.lookup (exchangeFlowId ex) (sdbTechFlows db)]
         ]
+
+-- ---------------------------------------------------------------------------
+-- Supplier-gap report
+-- ---------------------------------------------------------------------------
+
+{- | Why one supplier demand is left unsupplied after internal resolution and
+cross-DB linking.
+-}
+data GapReason
+    = -- | Nil-link input the attribute matcher could not place, with its blocker.
+      GapBlocked !LinkBlocker
+    | {- | Non-nil source identity no dependency ships, and no attribute match
+      rescued it — a partial import referencing activities it doesn't carry.
+      -}
+      GapDanglingIdentity
+    | {- | Waste input (treatment side): never a cross-DB demand, so an
+      internally unlinked one is a genuine gap.
+      -}
+      GapWasteInput
+    deriving (Show, Eq)
+
+-- | One consumer edge left unsupplied — the unit of the supplier-gap report.
+data GapEdge = GapEdge
+    { gapFlowName :: !T.Text
+    , gapLocation :: !T.Text
+    -- ^ Effective requested location ("" when the demand names none)
+    , gapUnit :: !T.Text
+    , gapAmount :: !Double
+    , gapConsumerAct :: !UUID.UUID
+    , gapConsumerProd :: !UUID.UUID
+    , gapReason :: !GapReason
+    }
+    deriving (Show, Eq)
+
+-- | One consuming process of a gap entry, with how many of its edges hit it.
+data GapConsumer = GapConsumer
+    { gcActUUID :: !UUID.UUID
+    , gcProdUUID :: !UUID.UUID
+    , gcActivityName :: !T.Text
+    , gcProductName :: !T.Text
+    , gcLocation :: !T.Text
+    , gcEdges :: !Int
+    }
+    deriving (Show, Eq)
+
+{- | Aggregate over one (flow name, location, unit) key of the gap report.
+Unit is part of the key so 'geDemandSum' never mixes units.
+-}
+data GapEntry = GapEntry
+    { geFlowName :: !T.Text
+    , geLocation :: !T.Text
+    , geUnit :: !T.Text
+    , geReason :: !GapReason
+    , geEdges :: !Int
+    , geConsumers :: !Int
+    , geDemandSum :: !Double
+    , geTopConsumers :: ![GapConsumer]
+    }
+    deriving (Show, Eq)
+
+-- | Supplier-gap report: header arithmetic plus the aggregated gap entries.
+data GapReport = GapReport
+    { grDbName :: !T.Text
+    , grTotalInputs :: !Int
+    , grInternalLinks :: !Int
+    , grCrossDBLinks :: !Int
+    , grUnresolvedEdges :: !Int
+    , grUnresolvedProducts :: !Int
+    , grCompleteness :: !Double
+    , grGaps :: ![GapEntry]
+    }
+    deriving (Show, Eq)
+
+{- | Shared gap-edge scan: every supplier demand with no internal producer,
+minus per-triple cross-DB coverage. The per-triple accounting mirrors
+'tallyDangling' (count-based: a partially covered triple drops its covered
+occurrences in scan order), so edge counts stay consistent with the dangling
+scans.
+-}
+gapEdgesWith ::
+    (Exchange -> Bool) ->
+    SimpleDatabase ->
+    [CrossDBLink] ->
+    CrossDBLinkingStats ->
+    [GapEdge]
+gapEdgesWith hasProducer db links stats =
+    concatMap surplus (M.toList byTriple)
+  where
+    covered = crossDBCoveredCounts links
+    surplus (triple, es) = drop (M.findWithDefault 0 triple covered) es
+    byTriple =
+        M.fromListWith
+            (flip (<>))
+            [ ((actUUID, prodUUID, exchangeFlowId ex), [edge])
+            | ((actUUID, prodUUID), act) <- M.toList (sdbActivities db)
+            , ex <- exchanges act
+            , isSupplierDemand ex
+            , not (hasProducer ex)
+            , Just edge <- [mkGapEdge db stats actUUID prodUUID ex]
+            ]
+
+{- | Describe one unsupplied demand. Biosphere exchanges are never demands
+('isSupplierDemand'), hence 'Nothing'. A missing flow entry doesn't hide the
+edge: the flow UUID stands in for the name so the report stays countable.
+-}
+mkGapEdge ::
+    SimpleDatabase ->
+    CrossDBLinkingStats ->
+    UUID.UUID ->
+    UUID.UUID ->
+    Exchange ->
+    Maybe GapEdge
+mkGapEdge db stats actUUID prodUUID ex = case ex of
+    TechnosphereExchange{} ->
+        let name = flowNameOr tfName (sdbTechFlows db)
+            reason = case exchangeActivityLinkId ex of
+                Nothing -> GapBlocked (maybe NoNameMatch snd (M.lookup name (cdlUnresolvedProducts stats)))
+                Just _ -> GapDanglingIdentity
+         in Just (edge name reason)
+    WasteExchange{} -> Just (edge (flowNameOr wfName (sdbWasteFlows db)) GapWasteInput)
+    BiosphereExchange{} -> Nothing
+  where
+    flowNameOr nameOf flows =
+        maybe (UUID.toText (exchangeFlowId ex)) nameOf (M.lookup (exchangeFlowId ex) flows)
+    edge name reason =
+        GapEdge
+            { gapFlowName = name
+            , gapLocation =
+                let loc = exchangeLocation ex
+                 in if T.null loc then extractBracketedLocation name else loc
+            , gapUnit = getUnitNameForExchange (sdbUnits db) ex
+            , gapAmount = exchangeAmount ex
+            , gapConsumerAct = actUUID
+            , gapConsumerProd = prodUUID
+            , gapReason = reason
+            }
+
+-- | Consumers shown per gap entry — the tail is countable via 'geConsumers'.
+topConsumerCap :: Int
+topConsumerCap = 20
+
+{- | Group gap edges by (flow name, location, unit), sorted by edge count
+descending. Within a group the reason with the richest diagnostic wins
+('GapBlocked' over 'GapDanglingIdentity' over 'GapWasteInput'). Consumer
+processes are named from the database, most-demanding first.
+-}
+gapEntries :: SimpleDatabase -> [GapEdge] -> [GapEntry]
+gapEntries db edges =
+    sortOn (Down . geEdges) (map entry (M.toList byKey))
+  where
+    byKey =
+        M.fromListWith
+            (flip (<>))
+            [((gapFlowName e, gapLocation e, gapUnit e), [e]) | e <- edges]
+    reasonRank r = case r of
+        GapBlocked _ -> 0 :: Int
+        GapDanglingIdentity -> 1
+        GapWasteInput -> 2
+    strongerReason a b = if reasonRank a <= reasonRank b then a else b
+    entry ((name, loc, unit), es) =
+        let consumers =
+                M.fromListWith (+) [((gapConsumerAct e, gapConsumerProd e), 1 :: Int) | e <- es]
+         in GapEntry
+                { geFlowName = name
+                , geLocation = loc
+                , geUnit = unit
+                , geReason = foldr (strongerReason . gapReason) GapWasteInput es
+                , geEdges = length es
+                , geConsumers = M.size consumers
+                , geDemandSum = sum (map gapAmount es)
+                , geTopConsumers =
+                    [ consumerOf a p n
+                    | ((a, p), n) <- take topConsumerCap (sortOn (Down . snd) (M.toList consumers))
+                    ]
+                }
+    consumerOf a p n =
+        GapConsumer
+            { gcActUUID = a
+            , gcProdUUID = p
+            , gcActivityName = maybe (UUID.toText a) activityName (M.lookup (a, p) (sdbActivities db))
+            , gcProductName = maybe (UUID.toText p) tfName (M.lookup p (sdbTechFlows db))
+            , gcLocation = maybe "" activityLocation (M.lookup (a, p) (sdbActivities db))
+            , gcEdges = n
+            }
+
+{- | Assemble the report. Header counts reuse the setup-page predicates
+('countTotalTechInputs' / 'countUnlinkedExchanges'); 'grUnresolvedEdges' is the
+edge-accurate count (per-triple coverage), so it can sit below the setup page's
+coarse @unlinked - crossDBLinks@ difference when waste-output links exist.
+-}
+buildGapReport :: T.Text -> SimpleDatabase -> Int -> [GapEdge] -> GapReport
+buildGapReport dbName db nLinks edges =
+    let total = countTotalTechInputs db
+        unlinked = countUnlinkedExchanges db
+        entries = gapEntries db edges
+     in GapReport
+            { grDbName = dbName
+            , grTotalInputs = total
+            , grInternalLinks = max 0 (total - unlinked)
+            , grCrossDBLinks = nLinks
+            , grUnresolvedEdges = length edges
+            , grUnresolvedProducts = length entries
+            , grCompleteness =
+                if total > 0
+                    then 100 * fromIntegral (total - length edges) / fromIntegral total
+                    else 100
+            , grGaps = entries
+            }
+
+-- | Supplier-gap report of a loaded database ('findProducer' honours process links).
+gapReportForLoaded :: T.Text -> Database -> GapReport
+gapReportForLoaded dbName db =
+    let sdb = toSimpleDatabase db
+        edges =
+            gapEdgesWith
+                (isJust . findProducer (dbProcessIdLookup db))
+                sdb
+                (dbCrossDBLinks db)
+                (dbLinkingStats db)
+     in buildGapReport dbName sdb (length (dbCrossDBLinks db)) edges
+
+{- | Staged-path counterpart of 'gapReportForLoaded', against the staged
+database's just-computed links and stats.
+-}
+gapReportForStaged :: T.Text -> SimpleDatabase -> CrossDBLinkingStats -> GapReport
+gapReportForStaged dbName sdb stats =
+    buildGapReport dbName sdb (crossDBLinksCount stats) (gapEdgesWith (hasInternalProducer sdb) sdb (cdlLinks stats) stats)
 
 {- | Per-run linking environment: the cross-DB context, the consumer database's
 own activity-key set (for the internal-resolution gate), and its flow tables.

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -1583,6 +1583,10 @@ gapEdgesWith hasProducer db links stats =
 {- | Describe one unsupplied demand. Biosphere exchanges are never demands
 ('isSupplierDemand'), hence 'Nothing'. A missing flow entry doesn't hide the
 edge: the flow UUID stands in for the name so the report stays countable.
+
+'cdlUnresolvedProducts' records one blocker per flow /name/, while the report
+keys entries by (name, location, unit) — two same-named entries at different
+locations therefore share that blocker even when the underlying causes differ.
 -}
 mkGapEdge ::
     SimpleDatabase ->

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -87,6 +87,7 @@ module Database.Manager (
     getStagedDatabase,
     getDatabaseSetupInfo,
     buildLoadedSetupInfo,
+    databaseGapReport,
     addDependencyToStaged,
     removeDependencyFromStaged,
     setDataPath,
@@ -205,6 +206,7 @@ import Types (
     UnitDB,
     bfCompartmentName,
     bfCompartmentSub,
+    blockerReasonDetail,
     computeMinimalSelectedDeps,
     crossDBBySource,
     crossDBRedundantSources,
@@ -215,7 +217,6 @@ import Types (
     exchangeFlowId,
     exchangeIsReference,
     initializeRuntimeFields,
-    locationKindCode,
     toSimpleDatabase,
     unresolvedCount,
  )
@@ -2283,6 +2284,20 @@ getStagedDatabase manager dbName = do
     stagedDbs <- readTVarIO (dmStagedDbs manager)
     return $ M.lookup dbName stagedDbs
 
+{- | Supplier-gap report for a loaded or staged database — what is still
+missing to fully supply its demands from the pinned dependencies, aggregated
+per (product, location, unit) with the consumers that demand it.
+-}
+databaseGapReport :: DatabaseManager -> Text -> IO (Either Text Loader.GapReport)
+databaseGapReport manager dbName = do
+    loadedDbs <- readTVarIO (dmLoadedDbs manager)
+    stagedDbs <- readTVarIO (dmStagedDbs manager)
+    pure $ case (M.lookup dbName loadedDbs, M.lookup dbName stagedDbs) of
+        (Just loaded, _) -> Right (Loader.gapReportForLoaded dbName (ldDatabase loaded))
+        (Nothing, Just staged) ->
+            Right (Loader.gapReportForStaged dbName (sdSimpleDB staged) (sdLinkingStats staged))
+        (Nothing, Nothing) -> Left ("Database not loaded: " <> dbName)
+
 data StageAction = AlreadyDone | NeedToStage
 
 {- | Get setup info for a database (for the setup page)
@@ -2393,12 +2408,7 @@ buildStagedSetupInfo staged configs indexedDbs =
         -- Convert missing products to MissingSupplier with reason/detail
         missingSuppliers = take 10 $ map blockerToMissingSupplier (sdMissingProducts staged)
         blockerToMissingSupplier (name, cnt, blocker) =
-            let (reason, detail) = case blocker of
-                    NoNameMatch -> ("no_name_match", Nothing)
-                    UnitIncompatible q s -> ("unit_incompatible", Just (q <> " vs " <> s))
-                    LocationUnavailable loc -> ("location_unavailable", Just loc)
-                    LocationRejectedByPolicy req act kind ->
-                        ("location_rejected", Just (req <> " ↛ " <> act <> " (" <> locationKindCode kind <> ")"))
+            let (reason, detail) = blockerReasonDetail blocker
              in MissingSupplier name cnt Nothing reason detail
         -- Combined dependencies list (selected + redundant + available, alpha sorted)
         dependencies =
@@ -2458,12 +2468,7 @@ buildLoadedSetupInfo config db configs indexedDbs =
                 then 100.0 * fromIntegral resolved / fromIntegral totalInputs
                 else 100.0
         blockerToMissingSupplier (name, (cnt, blocker)) =
-            let (reason, detail) = case blocker of
-                    NoNameMatch -> ("no_name_match", Nothing)
-                    UnitIncompatible q s -> ("unit_incompatible", Just (q <> " vs " <> s))
-                    LocationUnavailable loc -> ("location_unavailable", Just loc)
-                    LocationRejectedByPolicy req act kind ->
-                        ("location_rejected", Just (req <> " ↛ " <> act <> " (" <> locationKindCode kind <> ")"))
+            let (reason, detail) = blockerReasonDetail blocker
              in MissingSupplier name cnt Nothing reason detail
         statsSuppliers = map blockerToMissingSupplier (M.toList (cdlUnresolvedProducts stats))
         danglingSuppliers =

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1165,6 +1165,19 @@ never drift apart.
 instance ToJSON LocationKind where
     toJSON = toJSON . locationKindCode
 
+{- | Stable wire (reason code, optional detail) of a 'LinkBlocker' — single
+source of truth shared by the setup page's missing-supplier list and the
+supplier-gap report, so the two surfaces can never name the same blocker
+differently.
+-}
+blockerReasonDetail :: LinkBlocker -> (Text, Maybe Text)
+blockerReasonDetail blocker = case blocker of
+    NoNameMatch -> ("no_name_match", Nothing)
+    UnitIncompatible q s -> ("unit_incompatible", Just (q <> " vs " <> s))
+    LocationUnavailable loc -> ("location_unavailable", Just loc)
+    LocationRejectedByPolicy req act kind ->
+        ("location_rejected", Just (req <> " ↛ " <> act <> " (" <> locationKindCode kind <> ")"))
+
 instance FromJSON LocationKind where
     parseJSON v = do
         s <- parseJSON v

--- a/test/GapReportSpec.hs
+++ b/test/GapReportSpec.hs
@@ -1,0 +1,285 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Supplier-gap report tests.
+
+A consumer database demands four products: one satisfied internally, one
+supplied by a cross-DB background, and three genuine gaps of different kinds —
+a nil-link product the matcher can't place ('GapBlocked'), a non-nil source
+identity no dependency ships ('GapDanglingIdentity'), and an unlinked waste
+input ('GapWasteInput'). The report must count edges exactly, aggregate per
+(name, location, unit), rank by demanding edges, and name the top consumers.
+-}
+module GapReportSpec (spec) where
+
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
+import Test.Hspec
+
+import Database.CrossLinking (
+    IndexedDatabase,
+    buildIndexedDatabase,
+ )
+import Database.Loader (
+    CrossDBLinkingStats (..),
+    GapConsumer (..),
+    GapEntry (..),
+    GapReason (..),
+    GapReport (..),
+    gapReportForStaged,
+    relinkSimpleDatabase,
+ )
+import SynonymDB (emptySynonymDB)
+import Types (
+    Activity (..),
+    Exchange (..),
+    GeographyPolicy (..),
+    LinkBlocker (..),
+    SimpleDatabase (..),
+    TechRole (..),
+    TechnosphereFlow (..),
+    Unit (..),
+    WasteFlow (..),
+ )
+import UnitConversion (defaultUnitConfig)
+
+-- ---------------------------------------------------------------------------
+-- UUID helpers: readable fixed identifiers.
+-- ---------------------------------------------------------------------------
+
+u :: String -> UUID
+u suffix = read ("00000000-0000-0000-0000-0000000000" <> suffix)
+
+kgUnit, breadFlow, cakeFlow, flourFlow, waterFlow, sugarFlow, wasteFlow :: UUID
+kgUnit = u "01"
+breadFlow = u "02"
+cakeFlow = u "03"
+flourFlow = u "04"
+waterFlow = u "05"
+sugarFlow = u "06"
+wasteFlow = u "07"
+
+actBread, actCake, actSupplier, ghostAct :: UUID
+actBread = u "0a"
+actCake = u "0b"
+actSupplier = u "0c"
+ghostAct = u "0d" -- named by a dangling activityLinkId, shipped by nobody
+
+-- ---------------------------------------------------------------------------
+-- Fixture building blocks
+-- ---------------------------------------------------------------------------
+
+mkActivity :: Text -> [Exchange] -> Activity
+mkActivity name exs =
+    Activity
+        { activityName = name
+        , activityDescription = []
+        , activitySynonyms = M.empty
+        , activityClassification = M.empty
+        , activityLocation = "FR"
+        , activityUnit = "kg"
+        , exchanges = exs
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
+        , activityNativeId = Nothing
+        }
+
+mkTechFlow :: UUID -> Text -> TechnosphereFlow
+mkTechFlow fid name =
+    TechnosphereFlow
+        { tfId = fid
+        , tfName = name
+        , tfUnitId = kgUnit
+        , tfSynonyms = M.empty
+        , tfCAS = Nothing
+        , tfSubstanceId = Nothing
+        }
+
+reference :: UUID -> Exchange
+reference fid = (techInput fid 1.0){techRole = ReferenceProduct}
+
+techInput :: UUID -> Double -> Exchange
+techInput fid amount =
+    TechnosphereExchange
+        { techFlowId = fid
+        , techAmount = amount
+        , techUnitId = kgUnit
+        , techRole = Input
+        , techActivityLinkId = UUID.nil
+        , techProcessLinkId = Nothing
+        , techLocation = "FR"
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+wasteInput :: UUID -> Double -> Exchange
+wasteInput fid amount =
+    WasteExchange
+        { waFlowId = fid
+        , waAmount = amount
+        , waUnitId = kgUnit
+        , waIsInput = True
+        , waActivityLinkId = UUID.nil
+        , waProcessLinkId = Nothing
+        , waLocation = ""
+        , waComment = Nothing
+        , waPedigree = Nothing
+        }
+
+units :: M.Map UUID Unit
+units = M.singleton kgUnit (Unit kgUnit "kg" "kg" "")
+
+{- | Consumer database. Demands (7 supplier demands in total):
+
+* bread activity: flour ×2 (1.0 + 2.0), water ×1 (3.0),
+  sugar ×1 (0.5, non-nil link to 'ghostAct'), waste input ×1 (0.25)
+* cake activity: flour ×1 (4.0), bread ×1 (1.0, resolved internally)
+-}
+consumerDB :: SimpleDatabase
+consumerDB =
+    SimpleDatabase
+        { sdbActivities =
+            M.fromList
+                [ ((actBread, breadFlow), mkActivity "bread baking" breadExchanges)
+                , ((actCake, cakeFlow), mkActivity "cake baking" cakeExchanges)
+                ]
+        , sdbTechFlows =
+            M.fromList
+                [ (breadFlow, mkTechFlow breadFlow "bread")
+                , (cakeFlow, mkTechFlow cakeFlow "cake")
+                , (flourFlow, mkTechFlow flourFlow "flour")
+                , (waterFlow, mkTechFlow waterFlow "water")
+                , (sugarFlow, mkTechFlow sugarFlow "sugar")
+                ]
+        , sdbBioFlows = M.empty
+        , sdbWasteFlows =
+            M.singleton wasteFlow (WasteFlow wasteFlow "plastic waste" kgUnit M.empty Nothing Nothing)
+        , sdbUnits = units
+        }
+  where
+    breadExchanges =
+        [ reference breadFlow
+        , techInput flourFlow 1.0
+        , techInput flourFlow 2.0
+        , techInput waterFlow 3.0
+        , (techInput sugarFlow 0.5){techActivityLinkId = ghostAct}
+        , wasteInput wasteFlow 0.25
+        ]
+    cakeExchanges =
+        [ reference cakeFlow
+        , techInput flourFlow 4.0
+        , (techInput breadFlow 1.0){techActivityLinkId = actBread}
+        ]
+
+-- | Background dependency: supplies "water" @ FR in kg, nothing else.
+supplierIndexed :: IndexedDatabase
+supplierIndexed = buildIndexedDatabase "background" emptySynonymDB supplierDB
+
+supplierDB :: SimpleDatabase
+supplierDB =
+    SimpleDatabase
+        { sdbActivities = M.singleton (actSupplier, waterFlow) (mkActivity "water supply" [reference waterFlow])
+        , sdbTechFlows = M.singleton waterFlow (mkTechFlow waterFlow "water")
+        , sdbBioFlows = M.empty
+        , sdbWasteFlows = M.empty
+        , sdbUnits = units
+        }
+
+stats :: CrossDBLinkingStats
+stats =
+    relinkSimpleDatabase [supplierIndexed] emptySynonymDB defaultUnitConfig M.empty GeoGlobal Nothing consumerDB
+
+report :: GapReport
+report = gapReportForStaged "consumer" consumerDB stats
+
+entryFor :: Text -> Maybe GapEntry
+entryFor name = case filter ((== name) . geFlowName) (grGaps report) of
+    [e] -> Just e
+    _ -> Nothing
+
+-- ---------------------------------------------------------------------------
+
+spec :: Spec
+spec = do
+    describe "gap report header" $ do
+        it "counts every supplier demand in the denominator" $
+            grTotalInputs report `shouldBe` 7
+
+        it "credits the internally resolved input" $
+            grInternalLinks report `shouldBe` 1
+
+        it "credits the cross-DB water link" $
+            grCrossDBLinks report `shouldBe` 1
+
+        it "counts exactly the unsupplied edges" $
+            grUnresolvedEdges report `shouldBe` 5
+
+        it "counts distinct (name, location, unit) gap products" $
+            grUnresolvedProducts report `shouldBe` 3
+
+        it "keeps completeness consistent with the edge count" $
+            grCompleteness report `shouldBe` (100 * 2 / 7)
+
+        it "keeps the header edge count equal to the entry sum" $
+            sum (map geEdges (grGaps report)) `shouldBe` grUnresolvedEdges report
+
+    describe "gap entries" $ do
+        it "ranks the most-demanded product first" $
+            map geFlowName (take 1 (grGaps report)) `shouldBe` ["flour"]
+
+        it "aggregates flour across both consumers with its blocker" $
+            case entryFor "flour" of
+                Nothing -> expectationFailure "expected exactly one flour entry"
+                Just e -> do
+                    geEdges e `shouldBe` 3
+                    geConsumers e `shouldBe` 2
+                    geDemandSum e `shouldBe` 7.0
+                    geLocation e `shouldBe` "FR"
+                    geUnit e `shouldBe` "kg"
+                    geReason e `shouldBe` GapBlocked NoNameMatch
+
+        it "names the top consumers most-demanding first" $
+            case entryFor "flour" of
+                Nothing -> expectationFailure "expected exactly one flour entry"
+                Just e -> do
+                    map gcActivityName (geTopConsumers e) `shouldBe` ["bread baking", "cake baking"]
+                    map gcEdges (geTopConsumers e) `shouldBe` [2, 1]
+                    map gcProductName (geTopConsumers e) `shouldBe` ["bread", "cake"]
+
+        it "reports a dangling source identity as its own reason" $
+            fmap geReason (entryFor "sugar") `shouldBe` Just GapDanglingIdentity
+
+        it "reports an unlinked waste input as its own reason" $
+            fmap geReason (entryFor "plastic waste") `shouldBe` Just GapWasteInput
+
+        it "does not list the supplied or internal products" $ do
+            entryFor "water" `shouldBe` Nothing
+            entryFor "bread" `shouldBe` Nothing
+
+    describe "partial coverage" $ do
+        it "reports only the surplus edges of a partially covered demand" $ do
+            -- Two identical water demands, but only one of the two links kept:
+            -- the report must show exactly the uncovered occurrence (the
+            -- 'tallyDangling' count-based accounting), not zero and not both.
+            let twoWaterDB =
+                    consumerDB
+                        { sdbActivities =
+                            M.singleton
+                                (actBread, breadFlow)
+                                (mkActivity "washing" [reference breadFlow, techInput waterFlow 1.0, techInput waterFlow 2.0])
+                        }
+                twoWaterStats =
+                    relinkSimpleDatabase [supplierIndexed] emptySynonymDB defaultUnitConfig M.empty GeoGlobal Nothing twoWaterDB
+                onlyWater r = filter ((== "water") . geFlowName) (grGaps r)
+            -- sanity: both demands link, so the full stats leave no water gap
+            length (cdlLinks twoWaterStats) `shouldBe` 2
+            onlyWater (gapReportForStaged "consumer" twoWaterDB twoWaterStats) `shouldBe` []
+            -- with one of the two links dropped, exactly one edge resurfaces
+            let partialStats = twoWaterStats{cdlLinks = take 1 (cdlLinks twoWaterStats)}
+            case onlyWater (gapReportForStaged "consumer" twoWaterDB partialStats) of
+                [e] -> geEdges e `shouldBe` 1
+                other -> expectationFailure ("expected one water entry, got: " <> show other)

--- a/test/GapReportSpec.hs
+++ b/test/GapReportSpec.hs
@@ -17,6 +17,8 @@ import Data.UUID (UUID)
 import qualified Data.UUID as UUID
 import Test.Hspec
 
+import API.DatabaseHandlers (gapReportToAPI)
+import API.Types (GapEntryAPI (..), GapReportAPI (..))
 import Database.CrossLinking (
     IndexedDatabase,
     buildIndexedDatabase,
@@ -259,6 +261,16 @@ spec = do
         it "does not list the supplied or internal products" $ do
             entryFor "water" `shouldBe` Nothing
             entryFor "bread" `shouldBe` Nothing
+
+    describe "wire projection limit" $ do
+        it "keeps only the biggest gaps but the full header counts" $ do
+            let api = gapReportToAPI (Just 1) report
+            map gaeName (graGaps api) `shouldBe` ["flour"]
+            graUnresolvedProducts api `shouldBe` 3
+            graUnresolvedEdges api `shouldBe` 5
+
+        it "returns everything without a limit" $
+            length (graGaps (gapReportToAPI Nothing report)) `shouldBe` 3
 
     describe "partial coverage" $ do
         it "reports only the surplus edges of a partially covered demand" $ do

--- a/test/MCPDispatchSpec.hs
+++ b/test/MCPDispatchSpec.hs
@@ -75,3 +75,16 @@ spec = describe "MCP database load/unload tools" $ do
         resp <- call "unload_database"
         isError resp `shouldBe` True
         resultText resp `shouldSatisfy` maybe False ("Database not loaded:" `T.isInfixOf`)
+
+    describe "gap-report tool" $ do
+        it "is advertised with a required 'database' parameter" $
+            fmap requiredOf (toolByName "get_gap_report") `shouldBe` Just ["database"]
+
+        it "is routed by callTool (no 'Unknown tool' gap)" $ do
+            resp <- call "get_gap_report"
+            resultText resp `shouldSatisfy` maybe False (not . T.isPrefixOf "Unknown tool:")
+
+        it "surfaces the engine error for an unknown database" $ do
+            resp <- call "get_gap_report"
+            isError resp `shouldBe` True
+            resultText resp `shouldSatisfy` maybe False ("Database not loaded:" `T.isInfixOf`)

--- a/test/RoutesSpec.hs
+++ b/test/RoutesSpec.hs
@@ -265,6 +265,11 @@ routeSpecs = do
             resp <- doGet b "/api/v1/db/no-such-db/activity/whatever"
             statusCode (responseStatus resp) `shouldBe` 404
 
+        it "GET /api/v1/db/no-such-db/gap-report returns 404" $ \b -> do
+            -- The gap report answers only for a loaded or staged database.
+            resp <- doGet b "/api/v1/db/no-such-db/gap-report"
+            statusCode (responseStatus resp) `shouldBe` 404
+
     describe "method-not-allowed" $ do
         it "GET /api/v1/db/X returns 405 (only DELETE is defined on /db/{name})" $ \b -> do
             -- Documents the current API surface: /db/{name} accepts DELETE,

--- a/volca.cabal
+++ b/volca.cabal
@@ -283,6 +283,7 @@ test-suite lca-tests
                      , SubstitutionSpec
                      , SensitivitySpec
                      , CrossDBSubstitutionSpec
+                     , GapReportSpec
                      , GlobalSubstitutionSpec
                      , DatabaseStatusSpec
                      , DependencyChoiceSpec


### PR DESCRIPTION
## Why

Replacing or completing a background dependency starts with one question: **what does this database still demand that nothing supplies?** The engine already computes every element of the answer during cross-database linking, but it only exposed coarse counts and a 10-item teaser on the setup page — the full list had to be rebuilt client-side by scanning every exchange.

## What

`GET /db/{db}/gap-report` — and `get_gap_report` on MCP, OpenAPI and the Python client via the resource registry — returns the whole ledger, for loaded and staged databases:

- one entry per missing (product, location, unit), ranked by demanding edges;
- each entry carries the blocking reason (`no_name_match`, `unit_incompatible`, `location_unavailable`, `location_rejected`, `dangling_source_identity`, `unlinked_waste_input`), the number of demanding edges, distinct consumers, the total demanded amount, and the top consuming processes;
- a header with the same completeness arithmetic as the setup page.

The per-edge scan generalizes the dangling-name tally and reuses its per-triple coverage accounting, so the counts stay consistent with the existing surfaces. Blocker wire codes are factored into `Types.blockerReasonDetail`, shared by the setup page and the report so the two can never drift apart.