### PR TITLE
Release 0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-## [Unreleased]
+## [0.9.3] - 2026-07-15
+
+### Changed
+- The wire-format revision advertised on `/api/v1/version` is now `3`. Nothing
+  breaks: every wire change in this release is additive, and existing clients
+  keep working (pyvolca 0.8.x prints at most an upgrade hint). The revision
+  exists so a client can tell whether the engine understands the new delete
+  `ids` selection — an older engine would silently ignore the unknown key and
+  treat the request as an empty filter, i.e. "everything", which is exactly
+  the kind of guess a destructive operation must never make.
 
 ### Fixed
 - `exact=true` on the activity search now applies to the `product=` filter

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1135,10 +1135,14 @@ getOpenApiSpec = return $ toJSON volcaOpenApi
 
 {- | Wire-format revision advertised on /api/v1/version. BUMP this whenever a
 breaking change to the JSON wire shape lands (field rename/removal, type
-narrowing, newly-required field). Clients compare it to decide compatibility.
+narrowing, newly-required field) — or when an additive capability is unsafe
+to probe blindly, so clients need a discriminator (revision 3: the delete
+@ids@ selection, which an older engine would ignore and fall back to the
+whole filtered set). Clients compare it to decide compatibility and to gate
+such capabilities.
 -}
 currentWireVersion :: Int
-currentWireVersion = 2
+currentWireVersion = 3
 
 getVersion :: AppM Value
 getVersion =

--- a/volca.cabal
+++ b/volca.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                volca
-version:             0.9.3-dev
+version:             0.9.3
 build-type:          Simple
 
 license:             Apache-2.0


### PR DESCRIPTION
Cut the 0.9.3 release: date the changelog section, drop the `-dev` suffix, and advertise wire revision 3.

Since 0.9.2 the engine gained the delete-by-ids selection, a server that starts without `--config`, and two honesty fixes: the supply-chain and consumers `name=` filter actually filters, and a scoring integrity error answers 500 instead of a silent 0.

The wire bump carries no break — every change is additive and existing clients keep working (pyvolca 0.8.x prints at most an upgrade hint). It exists as a capability discriminator: a client about to send the delete `ids` selection must be able to tell it from an older engine, which would ignore the unknown key and treat the request as an empty filter ("everything") — a guess a destructive operation must never make. pyvolca's `REQUIRED_WIRE` deliberately stays 2 so the current client keeps accepting 0.9.1/0.9.2 engines; only the future `ids=` parameter will demand revision 3.

Final state after this merges: main carries the released `0.9.3` version and a dated changelog, ready to tag.