### PR TITLE
Gate delete_activities(ids=) behind wire revision 3

### DIFF
--- a/pyvolca/CHANGELOG.md
+++ b/pyvolca/CHANGELOG.md
@@ -18,6 +18,24 @@ git cliff --unreleased --tag pyvolca-v0.X.Y   # render as a released section
 
 Then paste the rendered block at the top of this file and tighten wording.
 
+## [Unreleased]
+
+### Added
+
+- `delete_activities(ids=[...])` deletes exactly the named processes — no more
+  deliberately unsatisfiable filter plus `extra`. Needs an engine speaking
+  wire revision 3 (>= v0.9.3): an older one would silently drop the unknown
+  key and read the request as an empty filter ("everything"), so pyvolca
+  refuses to send it there instead of letting the engine guess. `keep` and
+  `extra` compose with `ids`; the filter arguments do not.
+
+### Changed
+
+- pyvolca now understands wire revision 3 while still accepting wire-2
+  engines (v0.9.1 / v0.9.2): everything works against them except the
+  revision-gated `ids` selection, which fails with a clear message. An
+  engine newer than wire 3 still triggers the upgrade warning.
+
 ## [0.8.1] - 2026-07-14
 
 ### Added

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -15,19 +15,20 @@ Requires Python ≥ 3.10 and a running VoLCA engine. Use `Server` (below) to run
 
 ## Compatibility
 
-pyvolca speaks one revision of the engine's JSON wire format; the engine advertises its revision as `wireVersion` on `/api/v1/version`. pyvolca checks it the first time it talks to the engine — too old fails with a clear error, newer than this client knows warns. pyvolca and engine version numbers move independently: `wireVersion` carries compatibility, not the version numbers.
+pyvolca speaks a range of revisions of the engine's JSON wire format; the engine advertises its revision as `wireVersion` on `/api/v1/version`. pyvolca checks it the first time it talks to the engine — too old fails with a clear error, newer than this client knows warns, and a capability that needs a newer wire than the engine speaks refuses to run instead of letting the engine misread the request. pyvolca and engine version numbers move independently: `wireVersion` carries compatibility, not the version numbers.
 
 | pyvolca | wire | compatible engine |
 |---------|------|-------------------|
 | `0.5.x` | (pre-`wireVersion`) | `v0.5.0` … `v0.7.x` |
 | `0.6.0` … `0.7.1` | `1` | `v0.8.0` … `v0.9.0` |
-| `≥ 0.7.2` | `2` | `≥ v0.9.1` |
+| `0.7.2` … `0.8.1` | `2` | `≥ v0.9.1` |
+| `> 0.8.1` | `2` … `3` | `≥ v0.9.1` (delete by ids: `≥ v0.9.3`) |
 
 <!-- BEGIN: compatibility -->
 
 _Generated from `volca._compat` — run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.8.1** speaks wire format **3** and requires a VoLCA engine **≥ v0.9.1**.
+This build of **pyvolca 0.8.1** speaks wire formats **2 to 3** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error.
 
 <!-- END: compatibility -->
 
@@ -764,8 +765,11 @@ package directory so IDE autocomplete reflects the current engine.
 Useful when the engine is upgraded without reinstalling pyvolca.
 
 This is the explicit "the engine was upgraded" path — the likeliest
-place to meet a wire mismatch — so it runs the same one-shot gate as
-:meth:`_load_operations`, refusing a spec pyvolca can't decode.
+place to meet a wire *change* — so it forgets the cached wire and
+re-runs the gate against the live engine before fetching a spec
+pyvolca can't decode. Without the reset, a client that first met an
+older engine would keep refusing wire-gated capabilities after an
+in-place upgrade.
 
 ##### `Client.relink(dep_db: str, mapping_csv: str, db_name: str | None = None) -> dict`
 

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -27,7 +27,7 @@ pyvolca speaks one revision of the engine's JSON wire format; the engine adverti
 
 _Generated from `volca._compat` — run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.8.1** speaks wire format **2** and requires a VoLCA engine **≥ v0.9.1**.
+This build of **pyvolca 0.8.1** speaks wire format **3** and requires a VoLCA engine **≥ v0.9.1**.
 
 <!-- END: compatibility -->
 
@@ -427,15 +427,22 @@ Returns the engine's ``ActivateResponse`` dict
 (``{"success", "message", "database"?}``). Raises VoLCAError if the
 engine reports ``success=false``.
 
-##### `Client.delete_activities(*, name: str = '', location: str = '', product: str = '', classifications: list[dict | tuple] | None = None, exact: bool = False, keep: list[str] | None = None, extra: list[str] | None = None, db_name: str | None = None) -> dict`
+##### `Client.delete_activities(*, name: str = '', location: str = '', product: str = '', classifications: list[dict | tuple] | None = None, exact: bool = False, keep: list[str] | None = None, extra: list[str] | None = None, ids: list[str] | None = None, db_name: str | None = None) -> dict`
 
-Delete activities selected by filter, sparing/adding explicit ids.
+Delete activities selected by filter — or exactly the ``ids`` list.
 
 Builds a ``DeleteSelectionRequest``: the filter fields select the whole
 matching set, ``keep`` spares matched process ids, and ``extra`` adds
 ones the filter missed. ``classifications`` is a list of
 ``{"system", "value", "exact"}`` dicts or ``(system, value, exact)``
 tuples.
+
+``ids`` names the selection verbatim instead of filtering; the filter
+arguments (and ``exact``) must then stay unset — the two modes are
+exclusive, mirroring the engine. Needs an engine speaking wire
+revision 3 (>= v0.9.3): an older one would silently drop the unknown
+``ids`` key and read the request as an empty filter — "everything" —
+so pyvolca refuses to send it rather than let the engine guess.
 
 Returns the ``DeleteSelectionResponse`` dict
 (``{"success", "message", "deleted"}``); raises VoLCAError on

--- a/pyvolca/scripts/gen_api_md.py
+++ b/pyvolca/scripts/gen_api_md.py
@@ -331,12 +331,18 @@ def render_compatibility() -> str:
 
     from volca import _compat
 
+    wires = (
+        f"format **{_compat.REQUIRED_WIRE}**"
+        if _compat.REQUIRED_WIRE == _compat.KNOWN_WIRE
+        else f"formats **{_compat.REQUIRED_WIRE} to {_compat.KNOWN_WIRE}**"
+    )
     return (
         "_Generated from `volca._compat` — run "
         "`python scripts/gen_api_md.py` to regenerate._\n\n"
-        f"This build of **pyvolca {version('pyvolca')}** speaks wire format "
-        f"**{_compat.KNOWN_WIRE}** and requires a VoLCA engine "
-        f"**≥ v{_compat.MIN_ENGINE_HINT}**."
+        f"This build of **pyvolca {version('pyvolca')}** speaks wire "
+        f"{wires} and requires a VoLCA engine "
+        f"**≥ v{_compat.MIN_ENGINE_HINT}**; a capability gated on a newer "
+        "wire than the engine speaks refuses to run with a clear error."
     )
 
 

--- a/pyvolca/scripts/gen_api_md.py
+++ b/pyvolca/scripts/gen_api_md.py
@@ -335,7 +335,7 @@ def render_compatibility() -> str:
         "_Generated from `volca._compat` — run "
         "`python scripts/gen_api_md.py` to regenerate._\n\n"
         f"This build of **pyvolca {version('pyvolca')}** speaks wire format "
-        f"**{_compat.REQUIRED_WIRE}** and requires a VoLCA engine "
+        f"**{_compat.KNOWN_WIRE}** and requires a VoLCA engine "
         f"**≥ v{_compat.MIN_ENGINE_HINT}**."
     )
 

--- a/pyvolca/src/volca/_compat.py
+++ b/pyvolca/src/volca/_compat.py
@@ -1,9 +1,9 @@
 """Engine wire-compatibility policy — the single source of truth.
 
-pyvolca speaks one revision of the JSON wire format; the engine advertises its
-own revision as ``wireVersion`` on ``/api/v1/version``. This module owns the
-comparison: the wire this client requires, the engine hint shown when the check
-fails, and the check itself.
+pyvolca speaks a range of revisions of the JSON wire format; the engine
+advertises its own revision as ``wireVersion`` on ``/api/v1/version``. This
+module owns the comparison: the oldest wire this client accepts, the newest it
+understands, the engine hint shown when the check fails, and the check itself.
 
 It is deliberately import-cheap — only the stdlib at runtime — so the release
 preflight can read :data:`MIN_ENGINE_HINT` without pulling in ``requests`` or
@@ -20,7 +20,15 @@ if TYPE_CHECKING:
     from .types import ServerVersion
 
 REQUIRED_WIRE = 2
-"""The JSON wire-format revision this pyvolca speaks."""
+"""The oldest JSON wire-format revision this pyvolca accepts. Everything in
+the client works against it except the revision-gated capabilities (see
+``Client._require_wire``), which check the engine's advertised revision
+before sending anything."""
+
+KNOWN_WIRE = 3
+"""The newest wire revision this pyvolca understands (revision 3 adds the
+delete ``ids`` selection). An engine advertising more is newer than this
+client and may answer shapes it cannot decode."""
 
 MIN_ENGINE_HINT = "0.9.1"
 """First engine release that advertises :data:`REQUIRED_WIRE`. Used only for the
@@ -52,9 +60,9 @@ def check(sv: ServerVersion) -> None:
             f"needs (wire {spoken} < {REQUIRED_WIRE}). Upgrade the engine to "
             f">= v{MIN_ENGINE_HINT}, or `pip install 'pyvolca<0.7.2'`."
         )
-    if w > REQUIRED_WIRE:
+    if w > KNOWN_WIRE:
         warnings.warn(
             f"Engine v{sv.version} speaks wire {w}; this pyvolca knows up to "
-            f"wire {REQUIRED_WIRE}. Some responses may not decode — upgrade "
+            f"wire {KNOWN_WIRE}. Some responses may not decode — upgrade "
             "pyvolca."
         )

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -425,8 +425,10 @@ class Client:
         """One-shot wire-compatibility gate, run before the first real call.
 
         Placed inside the spec-fetch branch so it fires once per client, right
-        before we first depend on the engine's wire — and never for a client
-        that was handed a preloaded operation table (the offline fixtures).
+        before we first depend on the engine's wire. A client handed a
+        preloaded operation table (the offline fixtures) never reaches it
+        through dispatch — only a wire-gated capability (:meth:`_require_wire`)
+        forces the check, since it must ask the live engine.
         ``get_version`` is a direct GET, so this does not recurse.
         """
         if self._checked:
@@ -436,12 +438,13 @@ class Client:
         self._server_wire = sv.wire_version
         self._checked = True
 
-    def _require_wire(self, minimum: int, feature: str) -> None:
+    def _require_wire(self, minimum: int, feature: str, engine_hint: str) -> None:
         """Refuse ``feature`` unless the engine's wire revision is >= ``minimum``.
 
         For capabilities where an older engine would not merely lack the
         feature but silently misread the request (it drops the unknown wire
-        key), the request must never be sent at all.
+        key), the request must never be sent at all. ``engine_hint`` is the
+        first engine release advertising ``minimum``, shown in the error.
         """
         self._ensure_compatible()
         wire = self._server_wire
@@ -449,7 +452,8 @@ class Client:
             spoken = "pre-1" if wire is None else str(wire)
             raise VoLCAError(
                 f"{feature} needs engine wire revision >= {minimum}; this "
-                f"engine speaks wire {spoken}. Upgrade the engine."
+                f"engine speaks wire {spoken}. Upgrade the engine to "
+                f">= v{engine_hint}."
             )
 
     def refresh_stubs(self) -> None:
@@ -844,7 +848,7 @@ class Client:
             if value:
                 body[key] = value
         if ids is not None:
-            self._require_wire(3, "delete_activities(ids=...)")
+            self._require_wire(3, "delete_activities(ids=...)", engine_hint="0.9.3")
             body["ids"] = list(ids)
         target = self._db(db_name)
         payload = self._json(

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -460,9 +460,14 @@ class Client:
         Useful when the engine is upgraded without reinstalling pyvolca.
 
         This is the explicit "the engine was upgraded" path — the likeliest
-        place to meet a wire mismatch — so it runs the same one-shot gate as
-        :meth:`_load_operations`, refusing a spec pyvolca can't decode.
+        place to meet a wire *change* — so it forgets the cached wire and
+        re-runs the gate against the live engine before fetching a spec
+        pyvolca can't decode. Without the reset, a client that first met an
+        older engine would keep refusing wire-gated capabilities after an
+        in-place upgrade.
         """
+        self._checked = False
+        self._server_wire = None
         self._ensure_compatible()
         spec = self._json(self._session.get(f"{self.base_url}/api/v1/openapi.json"))
         self._operations = _parse_spec(spec)

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -405,8 +405,11 @@ class Client:
             self._session.headers["Authorization"] = f"Bearer {password}"
         # Lazily fetched on first _call() invocation.
         self._operations: dict[str, _Operation] | None = None
-        # One-shot wire-compatibility gate (see _ensure_compatible).
+        # One-shot wire-compatibility gate (see _ensure_compatible). The
+        # engine's advertised wire revision is cached alongside so per-feature
+        # gates (_require_wire) don't refetch it.
         self._checked = False
+        self._server_wire: int | None = None
 
     # -- Spec / dispatch plumbing --
 
@@ -428,8 +431,26 @@ class Client:
         """
         if self._checked:
             return
-        _compat.check(self.get_version())
+        sv = self.get_version()
+        _compat.check(sv)
+        self._server_wire = sv.wire_version
         self._checked = True
+
+    def _require_wire(self, minimum: int, feature: str) -> None:
+        """Refuse ``feature`` unless the engine's wire revision is >= ``minimum``.
+
+        For capabilities where an older engine would not merely lack the
+        feature but silently misread the request (it drops the unknown wire
+        key), the request must never be sent at all.
+        """
+        self._ensure_compatible()
+        wire = self._server_wire
+        if wire is None or wire < minimum:
+            spoken = "pre-1" if wire is None else str(wire)
+            raise VoLCAError(
+                f"{feature} needs engine wire revision >= {minimum}; this "
+                f"engine speaks wire {spoken}. Upgrade the engine."
+            )
 
     def refresh_stubs(self) -> None:
         """Fetch the OpenAPI spec from the server and refresh the dispatch table.
@@ -776,9 +797,10 @@ class Client:
         exact: bool = False,
         keep: list[str] | None = None,
         extra: list[str] | None = None,
+        ids: list[str] | None = None,
         db_name: str | None = None,
     ) -> dict:
-        """Delete activities selected by filter, sparing/adding explicit ids.
+        """Delete activities selected by filter — or exactly the ``ids`` list.
 
         Builds a ``DeleteSelectionRequest``: the filter fields select the whole
         matching set, ``keep`` spares matched process ids, and ``extra`` adds
@@ -786,10 +808,22 @@ class Client:
         ``{"system", "value", "exact"}`` dicts or ``(system, value, exact)``
         tuples.
 
+        ``ids`` names the selection verbatim instead of filtering; the filter
+        arguments (and ``exact``) must then stay unset — the two modes are
+        exclusive, mirroring the engine. Needs an engine speaking wire
+        revision 3 (>= v0.9.3): an older one would silently drop the unknown
+        ``ids`` key and read the request as an empty filter — "everything" —
+        so pyvolca refuses to send it rather than let the engine guess.
+
         Returns the ``DeleteSelectionResponse`` dict
         (``{"success", "message", "deleted"}``); raises VoLCAError on
         ``success=false``.
         """
+        if ids is not None and (name or location or product or classifications or exact):
+            raise VoLCAError(
+                "delete_activities: ids cannot be combined with the filter "
+                "arguments (name/location/product/classifications/exact)"
+            )
         # Omit blank filters entirely: sending "name":"" makes the engine treat
         # an empty string as a real (unsatisfiable) name filter, so a
         # product-only delete would match nothing and still report success.
@@ -804,6 +838,9 @@ class Client:
         for key, value in (("name", name), ("location", location), ("product", product)):
             if value:
                 body[key] = value
+        if ids is not None:
+            self._require_wire(3, "delete_activities(ids=...)")
+            body["ids"] = list(ids)
         target = self._db(db_name)
         payload = self._json(
             self._session.post(

--- a/pyvolca/tests/test_compat.py
+++ b/pyvolca/tests/test_compat.py
@@ -58,15 +58,16 @@ def test_check_message_distinguishes_absent_from_zero() -> None:
     assert "wire 0" in str(zero_exc.value)
 
 
-def test_check_is_silent_on_exact_wire() -> None:
+@pytest.mark.parametrize("wire", [_compat.REQUIRED_WIRE, _compat.KNOWN_WIRE])
+def test_check_is_silent_on_known_wires(wire: int) -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error")  # any warning would fail the test
-        _compat.check(_sv(_compat.REQUIRED_WIRE))  # neither raises nor warns
+        _compat.check(_sv(wire))  # neither raises nor warns
 
 
 def test_check_warns_on_newer_wire() -> None:
     with pytest.warns(UserWarning, match="upgrade pyvolca"):
-        _compat.check(_sv(_compat.REQUIRED_WIRE + 1))
+        _compat.check(_sv(_compat.KNOWN_WIRE + 1))
 
 
 @pytest.mark.parametrize("wire", [None, 0])

--- a/pyvolca/tests/test_compat.py
+++ b/pyvolca/tests/test_compat.py
@@ -112,6 +112,19 @@ def test_refresh_stubs_is_gated(make_response) -> None:
     assert session.get.call_count == 1  # version checked; openapi.json never fetched
 
 
+def test_refresh_stubs_rechecks_the_wire(make_response, monkeypatch) -> None:
+    """The documented "engine was upgraded" path must re-read the live wire:
+    a client that first met an older engine would otherwise keep refusing
+    wire-gated capabilities from a stale cache after an in-place upgrade."""
+    monkeypatch.setattr("volca._stub_gen.write_stubs_for_spec", lambda spec: None)
+    c, session = _client_with_version(make_response, wire=_compat.REQUIRED_WIRE)
+    c._ensure_compatible()
+    assert c._server_wire == _compat.REQUIRED_WIRE
+    session.get.return_value = make_response(_version_body(_compat.KNOWN_WIRE))
+    c.refresh_stubs()
+    assert c._server_wire == _compat.KNOWN_WIRE
+
+
 def test_ensure_compatible_is_one_shot(make_response) -> None:
     c, session = _client_with_version(make_response, wire=_compat.REQUIRED_WIRE)
     c._ensure_compatible()

--- a/pyvolca/tests/test_db_write.py
+++ b/pyvolca/tests/test_db_write.py
@@ -101,6 +101,52 @@ class TestDelete:
             client.delete_activities(name="x")
 
 
+def _version_ok(session, wire: int) -> None:
+    """Wire the mocked session's GET (used by get_version) to a wire response."""
+    from tests.conftest import _make_response
+
+    session.get.return_value = _make_response(
+        {
+            "version": "0.9.3",
+            "gitHash": "abc1234",
+            "gitTag": "v0.9.3",
+            "buildTarget": "x86_64-linux",
+            "wireVersion": wire,
+        }
+    )
+
+
+class TestDeleteByIds:
+    def test_ids_body_shape_behind_the_wire_gate(self, mocked_client):
+        client, session = mocked_client
+        _version_ok(session, wire=3)
+        _ok(session, {"success": True, "message": "ok", "deleted": 2})
+        result = client.delete_activities(ids=["a_b", "c_d"], keep=["a_b"])
+        assert result["deleted"] == 2
+        body = session.post.call_args[1]["json"]
+        assert body["ids"] == ["a_b", "c_d"]
+        assert body["keep"] == ["a_b"]
+        # ids names the selection verbatim: no filter keys ride along.
+        assert "name" not in body and "product" not in body
+
+    def test_ids_refused_with_filter_arguments(self, mocked_client):
+        client, session = mocked_client
+        with pytest.raises(VoLCAError, match="cannot be combined"):
+            client.delete_activities(ids=["a_b"], name="wheat")
+        with pytest.raises(VoLCAError, match="cannot be combined"):
+            client.delete_activities(ids=["a_b"], exact=True)
+        session.post.assert_not_called()
+
+    def test_ids_never_sent_to_a_wire2_engine(self, mocked_client):
+        # A wire-2 engine would drop the unknown "ids" key and read the request
+        # as an empty filter ("everything") — the client must refuse to send it.
+        client, session = mocked_client
+        _version_ok(session, wire=2)
+        with pytest.raises(VoLCAError, match="wire revision >= 3"):
+            client.delete_activities(ids=["a_b"])
+        session.post.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # copy
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The engine's delete-by-ids selection shipped in v0.9.3 (#218) with a wire bump serving as its capability marker: an older engine drops the unknown `ids` key and reads the request as an empty filter — "everything" — which a destructive operation must never let happen. The client therefore checks the engine's advertised `wireVersion` and refuses to send `ids` to anything below 3, with a clear upgrade message; nothing is sent at all in that case (spec-pinned).

The compat policy grows a second constant for this: `REQUIRED_WIRE` stays the floor (2 — wire-2 engines v0.9.1/v0.9.2 keep working for everything else), and `KNOWN_WIRE` (3) is the newest revision this client understands, so the "upgrade pyvolca" warning now fires only above what the client knows instead of on every connection to a 0.9.3 engine.

`keep` and `extra` compose with `ids`; the filter arguments (and `exact`) are refused client-side, mirroring the engine. README compatibility line regenerated. 241 tests green.