### PR TITLE
Let Server start the engine without a config file

### DIFF
--- a/pyvolca/CHANGELOG.md
+++ b/pyvolca/CHANGELOG.md
@@ -28,6 +28,13 @@ Then paste the rendered block at the top of this file and tighten wording.
   key and read the request as an empty filter ("everything"), so pyvolca
   refuses to send it there instead of letting the engine guess. `keep` and
   `extra` compose with `ids`; the filter arguments do not.
+- `Server(config=None)` starts the engine without any config file — built-in
+  defaults, no databases (needs an engine >= v0.9.3). Scripts that only
+  upload or convert no longer have to write an empty TOML. A config *path*
+  that does not exist now fails loudly at `start()` instead of the engine
+  dying behind the scenes — a typo must never silently become "all defaults".
+- `Server.start()` fails fast with the exit code when the spawned engine dies
+  before serving, instead of hanging until the readiness timeout.
 
 ### Changed
 

--- a/pyvolca/CHANGELOG.md
+++ b/pyvolca/CHANGELOG.md
@@ -34,7 +34,8 @@ Then paste the rendered block at the top of this file and tighten wording.
   that does not exist now fails loudly at `start()` instead of the engine
   dying behind the scenes — a typo must never silently become "all defaults".
 - `Server.start()` fails fast with the exit code when the spawned engine dies
-  before serving, instead of hanging until the readiness timeout.
+  before serving, instead of hanging until the readiness timeout — in both
+  fixed-port and `port="auto"` modes.
 
 ### Changed
 

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -980,7 +980,7 @@ Usage::
         client = Client(base_url=srv.base_url, db="agribalyse-3.2", password=srv.password)
         activities = client.search_activities(name="at plant")
 
-**Constructor**: `Server(config: str = 'volca.toml', port: Union[int, Literal['auto']] = 0, binary: str = 'volca')`
+**Constructor**: `Server(config: str | None = 'volca.toml', port: Union[int, Literal['auto']] = 0, binary: str = 'volca')`
 
 #### Properties
 

--- a/pyvolca/src/volca/server.py
+++ b/pyvolca/src/volca/server.py
@@ -28,13 +28,21 @@ class Server:
             activities = client.search_activities(name="at plant")
     """
 
-    def __init__(self, config: str = "volca.toml", port: int | Literal["auto"] = 0, binary: str = "volca"):
+    def __init__(
+        self,
+        config: str | None = "volca.toml",
+        port: int | Literal["auto"] = 0,
+        binary: str = "volca",
+    ):
         """Configure (but don't start) a managed VoLCA server.
 
         Args:
-            config: Path to the engine TOML. Read for ``server.port`` and
-                ``server.password``. Missing file is tolerated — defaults
-                are used.
+            config: Path to the engine TOML, read for ``server.port`` and
+                ``server.password``. ``None`` starts the engine without any
+                config file — built-in defaults, no databases (needs an
+                engine >= v0.9.3). A path that does not exist makes
+                :meth:`start` fail loudly: a typo must never silently become
+                "all defaults".
             port: Override the configured port. ``"auto"`` asks the engine to
                 bind an OS-assigned free port atomically. ``0`` reads the
                 config (or uses 8080), preserving the original API.
@@ -60,7 +68,14 @@ class Server:
         return f"http://localhost:{self.port}"
 
     def _read_config(self) -> dict:
-        """Read the TOML config file."""
+        """Read the TOML config file; ``{}`` when running config-less.
+
+        A missing file also reads as ``{}`` here — port and password get
+        their defaults — but :meth:`start` still refuses to spawn against a
+        path that does not exist.
+        """
+        if self.config is None:
+            return {}
         try:
             with open(self.config, "rb") as f:
                 return tomllib.load(f)
@@ -190,9 +205,15 @@ class Server:
             return
 
         binary = self._find_binary()
-        cmd = [
-            binary,
-            "--config", self.config,
+        if self.config is not None and not Path(self.config).is_file():
+            raise FileNotFoundError(
+                f"Config file not found: {self.config!r}. Pass config=None to "
+                "run on the engine's built-in defaults (engine >= v0.9.3)."
+            )
+        cmd = [binary]
+        if self.config is not None:
+            cmd += ["--config", self.config]
+        cmd += [
             "server",
             "--port", str(self.port),
             "--idle-timeout", str(idle_timeout),
@@ -226,6 +247,20 @@ class Server:
                     self.stop()
                     raise
                 return
+            code = self._process.poll()
+            if code is not None:
+                # The engine died before serving — fail now, not at the
+                # timeout. The likeliest config-less cause is an engine too
+                # old to run without --config.
+                self._process = None
+                hint = (
+                    " Running without a config file needs an engine >= v0.9.3."
+                    if self.config is None
+                    else ""
+                )
+                raise RuntimeError(
+                    f"Engine exited with code {code} before becoming ready.{hint}"
+                )
             time.sleep(0.5)
 
         raise TimeoutError(

--- a/pyvolca/src/volca/server.py
+++ b/pyvolca/src/volca/server.py
@@ -156,6 +156,19 @@ class Server:
 
         _compat.check(Client(self.base_url, password=self.password).get_version())
 
+    def _early_exit(self, code: int, doing: str) -> RuntimeError:
+        """Fail-fast error for an engine that died before ``doing``.
+
+        The likeliest config-less cause is an engine too old to run without
+        ``--config``, hence the version hint.
+        """
+        hint = (
+            " Running without a config file needs an engine >= v0.9.3."
+            if self.config is None
+            else ""
+        )
+        return RuntimeError(f"Engine exited with code {code} before {doing}.{hint}")
+
     def _await_bound_port(self, wait_timeout: int) -> None:
         """Read the engine's machine-readable port after it has bound port 0."""
         process = self._process
@@ -179,7 +192,8 @@ class Server:
         if reader.is_alive():
             raise TimeoutError(f"Server did not report its bound port within {wait_timeout}s")
         if not announced:
-            raise RuntimeError("VoLCA exited before reporting its bound port")
+            # EOF on stdout without an announcement means the engine died.
+            raise self._early_exit(process.wait(timeout=5), "reporting its bound port")
         raw = announced[0]
         port = int(raw) if raw.isdecimal() else 0
         if not 1 <= port <= 65535:
@@ -249,18 +263,9 @@ class Server:
                 return
             code = self._process.poll()
             if code is not None:
-                # The engine died before serving — fail now, not at the
-                # timeout. The likeliest config-less cause is an engine too
-                # old to run without --config.
+                # Fail now, not at the readiness timeout.
                 self._process = None
-                hint = (
-                    " Running without a config file needs an engine >= v0.9.3."
-                    if self.config is None
-                    else ""
-                )
-                raise RuntimeError(
-                    f"Engine exited with code {code} before becoming ready.{hint}"
-                )
+                raise self._early_exit(code, "becoming ready")
             time.sleep(0.5)
 
         raise TimeoutError(

--- a/pyvolca/tests/test_server.py
+++ b/pyvolca/tests/test_server.py
@@ -103,10 +103,12 @@ def test_await_bound_port_reports_early_exit():
         srv._await_bound_port(wait_timeout=1)
 
 
-def test_start_dynamic_port_uses_desktop_announcement(monkeypatch):
+def test_start_dynamic_port_uses_desktop_announcement(monkeypatch, tmp_path: Path):
+    config = tmp_path / "volca.toml"
+    config.write_text("")
     process = mock.Mock()
     process.stdout = io.StringIO("VOLCA_PORT=43123\n")
-    srv = Server(config="absent.toml", port="auto")
+    srv = Server(config=str(config), port="auto")
     monkeypatch.setattr(srv, "_find_binary", lambda: "/tmp/volca")
     monkeypatch.setattr(srv, "is_alive", lambda: True)
     check_wire = mock.Mock()
@@ -120,3 +122,45 @@ def test_start_dynamic_port_uses_desktop_announcement(monkeypatch):
     assert command[command.index("--port") + 1] == "0"
     assert srv.port == 43123
     check_wire.assert_called_once_with()
+
+
+def test_start_config_none_omits_the_flag(monkeypatch):
+    process = mock.Mock()
+    process.stdout = io.StringIO("VOLCA_PORT=43123\n")
+    srv = Server(config=None, port="auto")
+    monkeypatch.setattr(srv, "_find_binary", lambda: "/tmp/volca")
+    monkeypatch.setattr(srv, "is_alive", lambda: True)
+    monkeypatch.setattr(srv, "_check_wire", mock.Mock())
+
+    with mock.patch("volca.server.subprocess.Popen", return_value=process) as popen:
+        srv.start(wait_timeout=1)
+
+    command = popen.call_args.args[0]
+    assert "--config" not in command
+
+
+def test_start_refuses_a_missing_config_path(monkeypatch):
+    # A typo'd path must fail loudly, never silently become "all defaults".
+    srv = Server(config="absent.toml")
+    monkeypatch.setattr(srv, "_find_binary", lambda: "/tmp/volca")
+    monkeypatch.setattr(srv, "is_alive", lambda: False)
+
+    with mock.patch("volca.server.subprocess.Popen") as popen:
+        with pytest.raises(FileNotFoundError, match="config=None"):
+            srv.start(wait_timeout=1)
+    popen.assert_not_called()
+
+
+def test_start_reports_early_engine_exit_with_config_hint(monkeypatch):
+    # Fixed-port path: the engine dies at once (e.g. an engine too old for
+    # config-less startup) — start() must fail now with the hint, not hang
+    # until the readiness timeout.
+    process = mock.Mock()
+    process.poll.return_value = 1
+    srv = Server(config=None, port=8199)
+    monkeypatch.setattr(srv, "_find_binary", lambda: "/tmp/volca")
+    monkeypatch.setattr(srv, "is_alive", lambda: False)
+
+    with mock.patch("volca.server.subprocess.Popen", return_value=process):
+        with pytest.raises(RuntimeError, match="engine >= v0.9.3"):
+            srv.start(wait_timeout=5)

--- a/pyvolca/tests/test_server.py
+++ b/pyvolca/tests/test_server.py
@@ -96,10 +96,24 @@ def test_await_bound_port_rejects_invalid_port(line: str):
 def test_await_bound_port_reports_early_exit():
     process = mock.Mock()
     process.stdout = io.StringIO("some unrelated log line\n")
+    process.wait.return_value = 1
     srv = Server(config="absent.toml", port="auto")
     srv._process = process
 
-    with pytest.raises(RuntimeError, match="exited before reporting"):
+    with pytest.raises(RuntimeError, match="code 1 before reporting"):
+        srv._await_bound_port(wait_timeout=1)
+
+
+def test_await_bound_port_early_exit_hints_config_less():
+    # port="auto" is the canonical config-less invocation — an engine too old
+    # to run without --config must get the version hint on this path too.
+    process = mock.Mock()
+    process.stdout = io.StringIO("")
+    process.wait.return_value = 1
+    srv = Server(config=None, port="auto")
+    srv._process = process
+
+    with pytest.raises(RuntimeError, match="engine >= v0.9.3"):
         srv._await_bound_port(wait_timeout=1)
 
 


### PR DESCRIPTION
`Server(config=None)` spawns the engine with no `--config` at all: built-in defaults, no databases — what a converter or upload-driven script wants. Needs an engine >= v0.9.3, which learned to run config-less (#211).

Two silent failure modes die with it. A config *path* that does not exist now fails loudly at `start()` instead of the engine dying behind the scenes — the docstring used to claim "missing file is tolerated" while the spawned engine refused it. And an engine that exits before serving (the likeliest config-less cause: an engine too old) fails immediately with its exit code and a version hint, instead of hanging until the readiness timeout.

Verified end-to-end against a locally built v0.9.3: `Server(config=None, port="auto")` boots, answers `/version` with wire 3, and lists the uploads it rediscovers from the shared data dir. 233 tests green (4 new).