### PR TITLE
Make the relink mapping geography-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,24 @@
   summing cumulative production would give (for example counting the same
   electricity once per voltage level). Grouping by `consumer_name` shows who
   consumes what. Available on the REST endpoint, the MCP tool, and pyvolca.
+- The relink mapping CSV's `source_location` and `target_location` columns
+  now steer the linking instead of being informational. A row with a source
+  location applies only to demands at that exact location (an exact row wins
+  over a name-only row for the same name). A row with a target location
+  designates the supplier literally: the link goes to that name at that
+  location, bypassing the geography policy — so "a French process consuming
+  Swiss cement: replace it with the French cement?" is answered row by row in
+  the mapping. When nothing supplies the designated target, the relink
+  reports a new `alias_target_missing` blocker (visible in the linking stats
+  and the gap report) rather than silently falling back.
+
+### Changed
+- A mapping row now preempts the direct name cascade instead of being a
+  last-resort retry. A curated row is a stronger statement of intent than a
+  coincidental direct name match; names the mapping does not mention resolve
+  exactly as before.
+- The matrix-cache format changed with the new blocker (manual schema bump
+  8 → 9): the first start after upgrading rebuilds each database cache once.
 
 ## [0.9.2] - 2026-07-14
 

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -193,12 +193,13 @@ unloadDatabaseHandler dbName = do
 re-resolves links within the existing dependency pin (plain relink) — letting
 the user recover from loads that happened in a suboptimal order without
 reloading. A body carrying both @depDb@ and @mappingCsv@ switches to mapping
-mode: relink against that one dependency using an inline name→name
-supplier-alias CSV, so an Ecoinvent-named background (e.g. Agribalyse) resolves
-against a differently-named dependency (e.g. BAFU). A loaded-but-undeclared
-dependency is auto-pinned in-memory rather than rejected. Supplying exactly one
-of the two is a client error. Parse/validation failures surface as 4xx rather
-than a silent no-op; the only 404 from this path is an unloaded database or
+mode: relink against that one dependency using an inline supplier-alias CSV
+(source/target names with optional locations — see "Database.RelinkMapping"),
+so inputs named after one background database resolve against a
+differently-named dependency. A loaded-but-undeclared dependency is
+auto-pinned in-memory rather than rejected. Supplying exactly one of the two
+is a client error. Parse/validation failures surface as 4xx rather than a
+silent no-op; the only 404 from this path is an unloaded database or
 dependency.
 -}
 relinkDatabaseHandler :: Text -> RelinkRequest -> AppM RelinkResponse

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -120,7 +120,7 @@ databaseParser =
                     <> OA.command "delete" (info (DbDelete <$> deleteNameParser) (progDesc "Delete a database"))
                     <> OA.command "delete-activities" (info (DbDeleteActivities <$> deleteActivitiesArgsParser <**> helper) (progDesc "Delete the whole filtered set of activities from a loaded database"))
                     <> OA.command "copy" (info (copyArgsParser <**> helper) (progDesc "Copy a loaded database under a new name"))
-                    <> OA.command "relink" (info (DbRelinkMapping <$> relinkArgsParser <**> helper) (progDesc "Relink a database to a dependency using a name->name supplier alias CSV"))
+                    <> OA.command "relink" (info (DbRelinkMapping <$> relinkArgsParser <**> helper) (progDesc "Relink a database to a dependency using a supplier alias CSV (source/target names, optional locations)"))
                     <> OA.command "export" (info (DbExport <$> exportArgsParser <**> helper) (progDesc "Export a loaded database to a file"))
                 )
             )
@@ -140,7 +140,7 @@ relinkArgsParser =
     DbRelinkArgs
         <$> textArg "DB" "Name of the loaded database to relink"
         <*> textOpt "to" Nothing "DEP_DB" "Dependency database to link against"
-        <*> strOpt "mapping" Nothing "CSV" "Path to the name->name supplier alias CSV"
+        <*> strOpt "mapping" Nothing "CSV" "Path to the supplier alias CSV (source/target names, optional source/target locations)"
 
 {- | Export parser: positional DB, @--format@ keyword, @--out@ file path.
 Mirrors @db export <db> --format <fmt> --out <file>@.

--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -668,6 +668,9 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
     -- do not (and no 'UpperLocationUsed' warning — the widening is
     -- deliberate). A designated location nothing supplies is a loud
     -- curated-mapping error, never a silent fallback to the generic cascade.
+    -- The stored score still rates the supplier against the consumer's own
+    -- location, so a pinned cross-location link can carry a score below the
+    -- threshold — expected, since the designation overrode the ranking.
     designatedAt targetName targetLoc candidates =
         case filter ((== targetLoc) . seLocation . snd) candidates of
             [] -> CrossDBNotLinked (AliasTargetMissing targetName (Just targetLoc))

--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -32,6 +32,13 @@ module Database.CrossLinking (
     IndexedDatabase (..),
     SupplierEntry (..),
 
+    -- * Supplier aliases (relink mapping)
+    AliasKey (..),
+    AliasTarget (..),
+    AliasMap (..),
+    emptyAliasMap,
+    lookupAlias,
+
     -- * Configuration
     defaultLinkingThreshold,
 
@@ -68,6 +75,7 @@ module Database.CrossLinking (
     normalizeUnicode,
 ) where
 
+import Control.Applicative ((<|>))
 import Data.Bifunctor (first)
 import Data.Char (isAlpha, isUpper)
 import Data.Foldable (find)
@@ -160,16 +168,64 @@ data LinkingContext = LinkingContext
     -- ^ Location hierarchy (code → parent codes)
     , lcGeographyPolicy :: !GeographyPolicy
     -- ^ How aggressively to widen geography when no exact match is found
-    , lcSupplierAliases :: !(Maybe (M.Map Text Text))
-    {- ^ Optional consumer-flow-name → supplier-name aliases. When a
-    consumer's input flow name does not match any supplier directly, the
-    matcher retries with its alias from this map (e.g. an Ecoinvent-named
-    input rewritten to the BAFU activity name). 'Nothing' disables the
-    feature entirely (the common case for ordinary loads); 'Just' an empty
-    map is equivalent. Keys are matched on the raw (un-normalized) flow
-    name, falling back to 'normalizeText'.
+    , lcSupplierAliases :: !AliasMap
+    {- ^ Consumer-flow → designated-supplier aliases from a relink mapping
+    (an input named after one background database, rewritten to another
+    database's activity name). A matching row preempts the direct cascade:
+    the curated designation is a stronger statement of intent than a
+    generic name match, otherwise a row could be silently overridden by a
+    coincidental direct hit. Keys match the raw (un-normalized) flow name
+    plus the demand's effective location — see 'lookupAlias'.
+    'emptyAliasMap' disables the feature (the common case).
     -}
     }
+
+{- | Alias source key: consumer flow name plus optional consumer location.
+A row with a location applies only to demands at that exact location code
+(no hierarchy — the curator writes the code as it appears in the data); a
+row without one applies at any location.
+-}
+data AliasKey = AliasKey
+    { akName :: !Text
+    , akLocation :: !(Maybe Text)
+    }
+    deriving (Show, Eq, Ord)
+
+{- | Designated supplier of an alias row: product/activity name, optionally
+pinned to an exact location code. A pinned location is honoured literally —
+the matcher links there bypassing the geography policy and score threshold,
+and reports 'AliasTargetMissing' when nothing supplies that name there.
+Without a pinned location the geography policy chooses among the name's
+candidates, as for any other demand.
+-}
+data AliasTarget = AliasTarget
+    { atName :: !Text
+    , atLocation :: !(Maybe Text)
+    }
+    deriving (Show, Eq)
+
+{- | Consumer-flow → designated-supplier mapping. The empty map means no
+mapping is in force, so a bare newtype keeps "no aliases" and "no matching
+row" from needing two representations.
+-}
+newtype AliasMap = AliasMap (M.Map AliasKey AliasTarget)
+    deriving (Show, Eq)
+
+emptyAliasMap :: AliasMap
+emptyAliasMap = AliasMap M.empty
+
+{- | The alias row in force for a demand: an exact (name, location) row wins
+over a name-only row; a demand without a location can only match name-only
+rows.
+-}
+lookupAlias :: AliasMap -> Text -> Text -> Maybe AliasTarget
+lookupAlias (AliasMap m) name loc =
+    located <|> M.lookup (AliasKey name Nothing) m
+  where
+    located =
+        if T.null loc
+            then Nothing
+            else M.lookup (AliasKey name (Just loc)) m
 
 -- | A candidate supplier from another database
 data CrossDBCandidate = CrossDBCandidate
@@ -567,38 +623,66 @@ findSupplierInIndexedDBs ::
     Text ->
     CrossDBLinkResult
 findSupplierInIndexedDBs LinkingContext{..} productName location unit =
-    let normalizedName = normalizeText productName
-        -- Three priority-ordered match strategies; we take the first non-empty
-        -- result via 'firstNonEmpty' (the "First" monoid restricted to lists).
-        --   1. Exact product-name match across all indexed DBs.
-        --   2. Synonym-group match if exact yielded nothing.
-        --   3. Prefix-splitting fallback for compound names (e.g. SimaPro).
-        -- Alias retry: when the consumer's flow name only matches the target
-        -- supplier under an explicit name→name mapping (e.g. Ecoinvent name →
-        -- BAFU activity name), look the alias up and run the same
-        -- exact/synonym sub-cascade on it. Tried last, so direct matches always
-        -- win over the mapping.
-        aliasOf nm = case lcSupplierAliases of
-            Nothing -> Nothing
-            Just aliases -> M.lookup nm aliases
-        aliasCandidates = case aliasOf productName of
-            Nothing -> []
-            Just aliasName -> firstNonEmpty [tryName aliasName, tryPrefixes (extractProductPrefixes aliasName)]
-        allCandidates =
-            firstNonEmpty
-                [ concatMap (lookupExact normalizedName) lcIndexedDatabases
-                , case lookupSynonymGroup lcSynonymDB (normalizeName productName) of
-                    Just groupId -> concatMap (lookupBySynonym groupId) lcIndexedDatabases
-                    Nothing -> []
-                , tryPrefixes (extractProductPrefixes productName)
-                , aliasCandidates
-                ]
-        -- Effective location: if raw location is empty, try extracting from compound name
-        effectiveLocation =
-            if T.null location
-                then extractBracketedLocation productName
-                else location
-     in case allCandidates of
+    -- An alias row preempts the direct cascade: the curator's designation is
+    -- a stronger statement of intent than a generic name match — otherwise a
+    -- row answering "which supplier replaces this input?" could be silently
+    -- overridden by a coincidental direct hit. A name with no row resolves
+    -- exactly as it would without any mapping.
+    case lookupAlias lcSupplierAliases productName effectiveLocation of
+        Just target -> resolveDesignated target
+        Nothing ->
+            -- Three priority-ordered match strategies; take the first
+            -- non-empty result via 'firstNonEmpty':
+            --   1. Exact product-name match across all indexed DBs.
+            --   2. Synonym-group match if exact yielded nothing.
+            --   3. Prefix-splitting fallback for compound names (e.g. SimaPro).
+            resolveCandidates $
+                firstNonEmpty
+                    [ concatMap (lookupExact (normalizeText productName)) lcIndexedDatabases
+                    , case lookupSynonymGroup lcSynonymDB (normalizeName productName) of
+                        Just groupId -> concatMap (lookupBySynonym groupId) lcIndexedDatabases
+                        Nothing -> []
+                    , tryPrefixes (extractProductPrefixes productName)
+                    ]
+  where
+    -- Effective location: if raw location is empty, try extracting from compound name
+    effectiveLocation =
+        if T.null location
+            then extractBracketedLocation productName
+            else location
+
+    -- Resolve an alias row's designated target: the exact/synonym/prefix
+    -- sub-cascade on the target name, then either the normal geography-policy
+    -- pipeline (no pinned location) or the literal designated link. A target
+    -- name that matches nowhere is a loud curated-mapping error
+    -- ('AliasTargetMissing'), never a silent 'NoNameMatch'.
+    resolveDesignated (AliasTarget targetName mTargetLoc) =
+        case firstNonEmpty [tryName targetName, tryPrefixes (extractProductPrefixes targetName)] of
+            [] -> CrossDBNotLinked (AliasTargetMissing targetName Nothing)
+            candidates -> case mTargetLoc of
+                Nothing -> resolveCandidates candidates
+                Just targetLoc -> designatedAt targetName targetLoc candidates
+
+    -- The curator designated (name, location): link there directly. Unit
+    -- compatibility still applies; the geography policy and score threshold
+    -- do not (and no 'UpperLocationUsed' warning — the widening is
+    -- deliberate). A designated location nothing supplies is a loud
+    -- curated-mapping error, never a silent fallback to the generic cascade.
+    designatedAt targetName targetLoc candidates =
+        case filter ((== targetLoc) . seLocation . snd) candidates of
+            [] -> CrossDBNotLinked (AliasTargetMissing targetName (Just targetLoc))
+            atLoc@((_, firstSe) : _) ->
+                case filter (\(_, se) -> unitsAreCompatible lcUnitConfig unit (seUnit se)) atLoc of
+                    [] -> CrossDBNotLinked (UnitIncompatible unit (seUnit firstSe))
+                    compatible@(_ : _) ->
+                        let scored = map (scoreEntry effectiveLocation) compatible
+                            !best = maximumBy (comparing cdbScore) scored
+                         in mkLinked best [] (tiedDatabases best scored)
+
+    -- Pipeline once the candidate set is fixed: unit filter, geography
+    -- policy, then rank the survivors against the score threshold.
+    resolveCandidates allCandidates =
+        case allCandidates of
             [] -> CrossDBNotLinked NoNameMatch
             ((_, firstSe) : _) ->
                 -- Check unit compatibility first
@@ -623,36 +707,38 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
                                     _ ->
                                         let scored = map (first (scoreEntry effectiveLocation)) accepted
                                             !(bestCand, bestKind) = maximumBy (comparing (cdbScore . fst)) scored
-                                            -- Other databases whose surviving best candidate ties the
-                                            -- winner's score. Dedup by DB name to ignore intra-DB ties.
-                                            tied =
-                                                let winnerDB = cdbDatabaseName bestCand
-                                                    winnerScore = cdbScore bestCand
-                                                    sameScoreDBs =
-                                                        [ cdbDatabaseName c
-                                                        | (c, _) <- scored
-                                                        , cdbScore c == winnerScore
-                                                        , cdbDatabaseName c /= winnerDB
-                                                        ]
-                                                 in M.keys (M.fromList [(d, ()) | d <- sameScoreDBs])
                                          in if cdbScore bestCand >= lcThreshold
                                                 then
-                                                    let warnings =
-                                                            [ UpperLocationUsed effectiveLocation (cdbLocation bestCand) bestKind
-                                                            | not (T.null location || bestKind == ExactLoc)
-                                                            ]
-                                                     in CrossDBLinked
-                                                            { cdlrActivityUUID = cdbActivityUUID bestCand
-                                                            , cdlrProductUUID = cdbProductUUID bestCand
-                                                            , cdlrDatabaseName = cdbDatabaseName bestCand
-                                                            , cdlrScore = cdbScore bestCand
-                                                            , cdlrProductName = cdbProductName bestCand
-                                                            , cdlrLocation = cdbLocation bestCand
-                                                            , cdlrWarnings = warnings
-                                                            , cdlrTiedDatabases = tied
-                                                            }
+                                                    mkLinked
+                                                        bestCand
+                                                        [ UpperLocationUsed effectiveLocation (cdbLocation bestCand) bestKind
+                                                        | not (T.null location || bestKind == ExactLoc)
+                                                        ]
+                                                        (tiedDatabases bestCand (map fst scored))
                                                 else CrossDBNotLinked (LocationUnavailable effectiveLocation)
-  where
+
+    -- Other databases whose surviving best candidate ties the winner's
+    -- score. Dedup by DB name to ignore intra-DB ties.
+    tiedDatabases winner scored =
+        M.keys $
+            M.fromList
+                [ (cdbDatabaseName c, ())
+                | c <- scored
+                , cdbScore c == cdbScore winner
+                , cdbDatabaseName c /= cdbDatabaseName winner
+                ]
+
+    mkLinked best warnings tied =
+        CrossDBLinked
+            { cdlrActivityUUID = cdbActivityUUID best
+            , cdlrProductUUID = cdbProductUUID best
+            , cdlrDatabaseName = cdbDatabaseName best
+            , cdlrScore = cdbScore best
+            , cdlrProductName = cdbProductName best
+            , cdlrLocation = cdbLocation best
+            , cdlrWarnings = warnings
+            , cdlrTiedDatabases = tied
+            }
     lookupExact :: Text -> IndexedDatabase -> [(Text, SupplierEntry)]
     lookupExact name idb =
         [(idbName idb, entry) | entry <- fromMaybe [] (M.lookup name (idbByProductName idb))]

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -111,6 +111,7 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU
 import Data.Word (Word64)
 import Database.CrossLinking (
+    AliasMap,
     CrossDBLinkResult (..),
     IndexedDatabase (..),
     LinkWarning (..),
@@ -118,6 +119,7 @@ import Database.CrossLinking (
     SupplierEntry (..),
     WasteTreatmentMatch (..),
     defaultLinkingThreshold,
+    emptyAliasMap,
     extractBracketedLocation,
     extractProductPrefixes,
     findSupplierAcrossDatabases,
@@ -196,6 +198,10 @@ History of manual bumps:
      emission to two subcompartments (e.g. river + groundwater, long-term)
      no longer collapses to one row scored at a single arbitrary
      subcompartment's CF. Old caches merged those amounts under one flow.
+- 9: LinkBlocker gained AliasTargetMissing (geo-aware relink mapping), which
+     changes the Store layout of the linking stats embedded in the cache; a
+     downgrade reading a newer cache would fail mid-decode, so both directions
+     rebuild once instead.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.
@@ -203,7 +209,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeRep (Proxy :: Proxy Database))
-     in hi `xor` lo `xor` 8
+     in hi `xor` lo `xor` 9
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.
@@ -1276,7 +1282,7 @@ fixActivityLinksWithCrossDB indexedDbs synonymDB unitConfig locationHier policy 
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = if M.null locationHier then locationHierarchy else locationHier
                         , lcGeographyPolicy = policy
-                        , lcSupplierAliases = Nothing
+                        , lcSupplierAliases = emptyAliasMap
                         }
 
             -- Process all activities to find cross-DB links
@@ -1348,7 +1354,7 @@ relinkSimpleDatabase ::
     UC.UnitConfig ->
     M.Map T.Text [T.Text] ->
     GeographyPolicy ->
-    Maybe (M.Map T.Text T.Text) ->
+    AliasMap ->
     SimpleDatabase ->
     CrossDBLinkingStats
 relinkSimpleDatabase indexedDbs synonymDB unitConfig locationHier policy aliases db =
@@ -1867,6 +1873,7 @@ findExchangeCrossDBLink LinkScan{lsCtx = ctx, lsOwnKeys = ownKeys, lsTechFlows =
                     [LocationUnresolved (tfName flow) req "no candidate above link threshold"]
                 NoNameMatch -> []
                 UnitIncompatible _ _ -> []
+                AliasTargetMissing _ _ -> []
          in mempty
                 { cdlUnresolvedProducts = M.singleton (tfName flow) (1, blocker)
                 , cdlLocationUnresolved = unresolved
@@ -2025,3 +2032,5 @@ showBlocker (UnitIncompatible q s) = printf "Unit: %s vs %s" (T.unpack q) (T.unp
 showBlocker (LocationUnavailable loc) = printf "Location: %s" (T.unpack loc)
 showBlocker (LocationRejectedByPolicy req act kind) =
     printf "Rejected by policy: %s → %s (%s)" (T.unpack req) (T.unpack act) (T.unpack (locationKindCode kind))
+showBlocker (AliasTargetMissing name mLoc) =
+    printf "Mapping target not found: %s%s" (T.unpack name) (maybe "" ((" @ " <>) . T.unpack) mLoc)

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -227,6 +227,7 @@ import qualified UnitConversion
 import API.Types (DepLoadResult (..))
 import qualified Data.Text.IO as TIO
 import Database.CrossLinking (IndexedDatabase (..), LinkingContext (..), buildIndexedDatabaseFromDB, defaultLinkingThreshold)
+import qualified Database.CrossLinking as CrossLinking
 import Database.Upload (DatabaseFormat (..), findMethodDirectory, listDirectoryRecursive)
 import qualified Database.Upload as Upload
 import qualified Database.UploadedDatabase as UploadedDB
@@ -1738,10 +1739,10 @@ even though we already know the answer. The save is skipped when the
 relink is a no-op (no change vs. the in-memory state).
 -}
 relinkDatabase :: DatabaseManager -> Text -> IO (Either Text RelinkResult)
-relinkDatabase manager dbName = relinkDatabaseWith manager dbName Nothing Nothing
+relinkDatabase manager dbName = relinkDatabaseWith manager dbName CrossLinking.emptyAliasMap Nothing
 
 {- | Re-link a loaded DB across its full pinned dependency set, applying a
-name→name supplier-alias map. The aliases let a consumer's input flow name that
+curated supplier-alias map. The aliases let a consumer's input flow name that
 only matches a target supplier (typically in @depDb@) under the mapping still
 link; links to the other pinned dependencies are re-resolved unchanged rather
 than dropped. If @depDb@ is loaded but not yet in the database's declared
@@ -1756,13 +1757,13 @@ relinkDatabaseWithMapping ::
     Text ->
     -- | dependency database to link against
     Text ->
-    -- | consumer-flow-name → supplier-name aliases
-    M.Map Text Text ->
+    -- | consumer-flow → designated-supplier aliases
+    CrossLinking.AliasMap ->
     IO (Either Text RelinkResult)
 relinkDatabaseWithMapping manager dbName depDb aliases = do
     loadedDbs <- readTVarIO (dmLoadedDbs manager)
     case M.lookup dbName loadedDbs of
-        Nothing -> relinkStaged manager dbName (Just depDb) (Just aliases)
+        Nothing -> relinkStaged manager dbName (Just depDb) aliases
         Just loaded
             | not (M.member depDb loadedDbs) ->
                 return $ Left $ "Dependency database not loaded: " <> depDb <> " (load it first)"
@@ -1777,7 +1778,7 @@ relinkDatabaseWithMapping manager dbName depDb aliases = do
                 unless (depDb `elem` persistedDeps) $
                     atomically $
                         modifyTVar' (dmLoadedDbs manager) (M.adjust (addPinnedDep depDb) dbName)
-                relinkDatabaseWith manager dbName (Just aliases) (Just persistedDeps)
+                relinkDatabaseWith manager dbName aliases (Just persistedDeps)
   where
     -- Idempotent: a concurrent relink may have pinned the dep between the
     -- snapshot above and this transaction, so never prepend a duplicate.
@@ -1793,7 +1794,7 @@ relinkDatabaseWithMapping manager dbName depDb aliases = do
 page before a database is finalized. @maybeDepDb@ pins a chosen dependency (a
 mapping relink); @aliases@ feeds the supplier-alias map.
 -}
-relinkStaged :: DatabaseManager -> Text -> Maybe Text -> Maybe (M.Map Text Text) -> IO (Either Text RelinkResult)
+relinkStaged :: DatabaseManager -> Text -> Maybe Text -> CrossLinking.AliasMap -> IO (Either Text RelinkResult)
 relinkStaged manager dbName maybeDepDb aliases = do
     stagedDbs <- readTVarIO (dmStagedDbs manager)
     case M.lookup dbName stagedDbs of
@@ -1847,9 +1848,9 @@ relinkStaged manager dbName maybeDepDb aliases = do
 {- | Shared relink core. Candidates are the database's full declared pin
 ('dbDependsOn'); relink recomputes the links within it but never grows or
 shrinks the set. @aliases@ feeds 'lcSupplierAliases' — a mapping relink passes
-the user's name→name map (which retargets a chosen dependency without dropping
-links to the others), a plain relink passes 'Nothing'. The dependency set
-stored on the database is never mutated here.
+the user's curated map (which retargets a chosen dependency without dropping
+links to the others), a plain relink passes 'emptyAliasMap'. The dependency
+set stored on the database is never mutated here.
 
 @persistedDeps@ is the dependency set as it stands in the matrix cache on disk
 ('Just' when the caller pinned a new dep in-memory before calling). The cache
@@ -1860,7 +1861,7 @@ that divergence. 'Nothing' means the pin is unchanged from disk.
 relinkDatabaseWith ::
     DatabaseManager ->
     Text ->
-    Maybe (M.Map Text Text) ->
+    CrossLinking.AliasMap ->
     Maybe [Text] ->
     IO (Either Text RelinkResult)
 relinkDatabaseWith manager dbName aliases persistedDeps = do

--- a/src/Database/RelinkMapping.hs
+++ b/src/Database/RelinkMapping.hs
@@ -1,24 +1,30 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 {- | Relink-with-mapping: re-link an (unlinked) database to a chosen background
-dependency using a name→name alias mapping loaded from a CSV.
+dependency using a curated alias mapping loaded from a CSV.
 
-Agribalyse carries Ecoinvent-named background inputs; the BAFU database names
-the same activities differently. A curated CSV maps the source (consumer)
-input-flow name to the target (BAFU) activity name, so the existing cross-DB
-matcher resolves the link even though the raw names differ.
+A consumer database often carries background inputs named after one database
+while the replacement dependency names the same activities differently. A
+curated CSV maps the source (consumer) input-flow name to the target supplier
+activity name, so the cross-DB matcher resolves the link even though the raw
+names differ. A row preempts the direct name cascade — the curator's
+designation always wins over a coincidental direct match.
 
 The CSV is header-based (cassava 'decodeByName'). Recognized columns:
 
   * @source@ (or @source_name@ / @from@) — required: the consumer's input flow name
   * @target@ (or @target_name@ / @to@)  — required: the supplier activity name
-  * @source_location@ / @target_location@ — optional, currently informational
+  * @source_location@ (or @source_geo@) — optional: restrict the row to demands
+    at this exact location code; a row without one applies at any location, and
+    an exact (name, location) row wins over the name-only row for the same name
+  * @target_location@ (or @target_geo@) — optional: pin the supplier to this
+    exact location code, bypassing the geography policy; when nothing supplies
+    the target name there, the relink reports 'Types.AliasTargetMissing' rather
+    than silently falling back
 
-Only the (source → target) name pair drives linking; location is matched by
-the existing geography policy, not by this map. Unit-incompatible or
-consumed-nowhere outcomes are not silently dropped — they surface through the
-relink's 'CrossDBLinkingStats' (unresolved products carry a 'LinkBlocker') and
-through the returned 'RelinkResult'.
+Unit-incompatible or consumed-nowhere outcomes are not silently dropped — they
+surface through the relink's 'CrossDBLinkingStats' (unresolved products carry
+a 'LinkBlocker') and through the returned 'RelinkResult'.
 -}
 module Database.RelinkMapping (
     -- * CSV mapping
@@ -37,18 +43,18 @@ import Control.Monad (mfilter)
 import qualified Data.ByteString.Lazy as BL
 import Data.Csv (FromNamedRecord (..), (.:))
 import qualified Data.Csv as Csv
-import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Vector as V
 
 import Control.Exception (SomeException, try)
+import Database.CrossLinking (AliasKey (..), AliasMap (..), AliasTarget (..))
 import Database.Manager (DatabaseManager, RelinkResult, relinkDatabaseWithMapping)
 
-{- | One row of the alias mapping. Locations are parsed when present but are
-not (yet) used to disambiguate the link — the cross-DB matcher applies the
-database's geography policy independently.
+{- | One row of the alias mapping. The source location scopes the row to
+demands at that exact code; the target location pins the designated supplier
+— see the module header for the full semantics.
 -}
 data AliasRow = AliasRow
     { arSource :: !Text
@@ -124,35 +130,38 @@ parseAliasCSV bytes =
                 (False, True) -> halfBlank "target"
                 (False, False) -> Right [row{arSource = src, arTarget = tgt}]
 
-{- | Build the source-name → target-name alias map. On a duplicate source name
-with conflicting targets, fail rather than silently pick one. Identical
-duplicates collapse harmlessly.
+{- | Build the alias map keyed by (source name, optional source location). The
+same name with and without a location is two distinct rows (the located one
+wins at lookup). On a duplicate key with conflicting targets, fail rather than
+silently pick one. Identical duplicates collapse harmlessly.
 -}
-buildAliasMap :: [AliasRow] -> Either Text (Map Text Text)
+buildAliasMap :: [AliasRow] -> Either Text AliasMap
 buildAliasMap =
-    foldr step (Right M.empty)
+    fmap AliasMap . foldr step (Right M.empty)
   where
     step row acc = do
         m <- acc
-        let src = arSource row
-            tgt = arTarget row
-        case M.lookup src m of
+        let key = AliasKey (arSource row) (arSourceLocation row)
+            tgt = AliasTarget (arTarget row) (arTargetLocation row)
+        case M.lookup key m of
             Just existing
                 | existing /= tgt ->
                     Left $
                         "conflicting alias for "
-                            <> src
+                            <> describeKey key
                             <> ": "
-                            <> existing
+                            <> describeTarget existing
                             <> " vs "
-                            <> tgt
-            _ -> Right (M.insert src tgt m)
+                            <> describeTarget tgt
+            _ -> Right (M.insert key tgt m)
+    describeKey (AliasKey name mLoc) = name <> maybe "" (" @ " <>) mLoc
+    describeTarget (AliasTarget name mLoc) = name <> maybe "" (" @ " <>) mLoc
 
 {- | Load and validate an alias map from a CSV file path. An alias map with no
 usable rows (header-only / all-blank) would relink as a silent no-op, so it is
 rejected loudly.
 -}
-loadAliasMap :: FilePath -> IO (Either Text (Map Text Text))
+loadAliasMap :: FilePath -> IO (Either Text AliasMap)
 loadAliasMap path = do
     result <- try (BL.readFile path) :: IO (Either SomeException BL.ByteString)
     case result of
@@ -163,10 +172,10 @@ loadAliasMap path = do
 map would relink as a silent no-op, so both the CLI ('loadAliasMap') and the
 HTTP relink handler reject it loudly rather than return 200 with no effect.
 -}
-rejectEmpty :: Map Text Text -> Either Text (Map Text Text)
-rejectEmpty m
+rejectEmpty :: AliasMap -> Either Text AliasMap
+rejectEmpty am@(AliasMap m)
     | M.null m = Left "mapping file contains no usable source→target rows"
-    | otherwise = Right m
+    | otherwise = Right am
 
 {- | Relink @dbName@ against @depDb@ using the alias mapping in @csvPath@.
 Loads + validates the CSV, then delegates to 'relinkDatabaseWithMapping'.

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1115,6 +1115,12 @@ data LinkBlocker
       geography_policy rejected it
       -}
       LocationRejectedByPolicy !Text !Text !LocationKind
+    | {- | targetName, targetLocation — a relink-mapping row designated a supplier
+      that no pinned dependency ships ('Nothing' when the name matches nowhere,
+      'Just' the pinned location when the name exists but not there). A curated
+      designation must fail loudly, never fall back to the generic cascade.
+      -}
+      AliasTargetMissing !Text !(Maybe Text)
     deriving (Show, Eq, Generic, NFData, Store)
 
 {- | Per-database knob controlling how aggressively geography may be widened when
@@ -1177,6 +1183,8 @@ blockerReasonDetail blocker = case blocker of
     LocationUnavailable loc -> ("location_unavailable", Just loc)
     LocationRejectedByPolicy req act kind ->
         ("location_rejected", Just (req <> " ↛ " <> act <> " (" <> locationKindCode kind <> ")"))
+    AliasTargetMissing name mLoc ->
+        ("alias_target_missing", Just (name <> maybe "" (" @ " <>) mLoc))
 
 instance FromJSON LocationKind where
     parseJSON v = do

--- a/test/CrossDBActivityLinkSpec.hs
+++ b/test/CrossDBActivityLinkSpec.hs
@@ -22,6 +22,7 @@ import Database.CrossLinking (
     LinkingContext (..),
     buildIndexedDatabase,
     defaultLinkingThreshold,
+    emptyAliasMap,
     findSupplierByActivityProduct,
     locationHierarchy,
  )
@@ -126,7 +127,7 @@ ctxFor idbs =
         , lcThreshold = defaultLinkingThreshold
         , lcLocationHierarchy = locationHierarchy
         , lcGeographyPolicy = GeoGlobal
-        , lcSupplierAliases = Nothing
+        , lcSupplierAliases = emptyAliasMap
         }
 
 runLinks :: SimpleDatabase -> [IndexedDatabase] -> CrossDBLinkingStats

--- a/test/CrossLinkingSpec.hs
+++ b/test/CrossLinkingSpec.hs
@@ -253,7 +253,7 @@ spec = do
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
                         , lcGeographyPolicy = GeoGlobal
-                        , lcSupplierAliases = Nothing
+                        , lcSupplierAliases = emptyAliasMap
                         }
             case findSupplierInIndexedDBs ctx "product Y" "GLO" "kg" of
                 CrossDBLinked{cdlrScore = score} -> score `shouldSatisfy` (>= defaultLinkingThreshold)
@@ -269,7 +269,7 @@ spec = do
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
                         , lcGeographyPolicy = GeoGlobal
-                        , lcSupplierAliases = Nothing
+                        , lcSupplierAliases = emptyAliasMap
                         }
             case findSupplierInIndexedDBs ctx "no such product" "GLO" "kg" of
                 CrossDBNotLinked _ -> return ()
@@ -285,7 +285,7 @@ spec = do
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
                         , lcGeographyPolicy = GeoGlobal
-                        , lcSupplierAliases = Nothing
+                        , lcSupplierAliases = emptyAliasMap
                         }
             -- "product Y" exists in kg; asking for m3 should fail unit check
             case findSupplierInIndexedDBs ctx "product Y" "GLO" "m3" of
@@ -305,7 +305,7 @@ spec = do
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
                         , lcGeographyPolicy = GeoGlobal
-                        , lcSupplierAliases = Nothing
+                        , lcSupplierAliases = emptyAliasMap
                         }
             -- Synonym lookup: "producto y" → group containing "product y" → supplier
             case findSupplierInIndexedDBs ctx "producto y" "GLO" "kg" of
@@ -322,7 +322,7 @@ spec = do
                         , lcThreshold = defaultLinkingThreshold
                         , lcLocationHierarchy = locationHierarchy
                         , lcGeographyPolicy = GeoGlobal
-                        , lcSupplierAliases = Nothing
+                        , lcSupplierAliases = emptyAliasMap
                         }
             -- "product Y {GLO}" compound name with empty location arg
             -- extractBracketedLocation will find "GLO"
@@ -373,7 +373,7 @@ spec = do
                     , lcThreshold = defaultLinkingThreshold
                     , lcLocationHierarchy = locationHierarchy
                     , lcGeographyPolicy = policy
-                    , lcSupplierAliases = Nothing
+                    , lcSupplierAliases = emptyAliasMap
                     }
 
         it "GeoGlobal accepts FR query against a GLO candidate" $ do

--- a/test/GapReportSpec.hs
+++ b/test/GapReportSpec.hs
@@ -20,8 +20,12 @@ import Test.Hspec
 import API.DatabaseHandlers (gapReportToAPI)
 import API.Types (GapEntryAPI (..), GapReportAPI (..))
 import Database.CrossLinking (
+    AliasKey (..),
+    AliasMap (..),
+    AliasTarget (..),
     IndexedDatabase,
     buildIndexedDatabase,
+    emptyAliasMap,
  )
 import Database.Loader (
     CrossDBLinkingStats (..),
@@ -193,7 +197,7 @@ supplierDB =
 
 stats :: CrossDBLinkingStats
 stats =
-    relinkSimpleDatabase [supplierIndexed] emptySynonymDB defaultUnitConfig M.empty GeoGlobal Nothing consumerDB
+    relinkSimpleDatabase [supplierIndexed] emptySynonymDB defaultUnitConfig M.empty GeoGlobal emptyAliasMap consumerDB
 
 report :: GapReport
 report = gapReportForStaged "consumer" consumerDB stats
@@ -272,6 +276,19 @@ spec = do
         it "returns everything without a limit" $
             length (graGaps (gapReportToAPI Nothing report)) `shouldBe` 3
 
+    describe "alias integration" $ do
+        it "surfaces a missing designated target as its blocker in the report" $ do
+            -- A relink mapping redirects flour to a supplier nobody ships:
+            -- the gap report must carry the curated-mapping error, not a
+            -- generic no_name_match.
+            let aliases = AliasMap (M.singleton (AliasKey "flour" Nothing) (AliasTarget "no such product" (Just "CH")))
+                aliasStats =
+                    relinkSimpleDatabase [supplierIndexed] emptySynonymDB defaultUnitConfig M.empty GeoGlobal aliases consumerDB
+                r = gapReportForStaged "consumer" consumerDB aliasStats
+            case filter ((== "flour") . geFlowName) (grGaps r) of
+                [e] -> geReason e `shouldBe` GapBlocked (AliasTargetMissing "no such product" Nothing)
+                other -> expectationFailure ("expected one flour entry, got: " <> show other)
+
     describe "partial coverage" $ do
         it "reports only the surplus edges of a partially covered demand" $ do
             -- Two identical water demands, but only one of the two links kept:
@@ -285,7 +302,7 @@ spec = do
                                 (mkActivity "washing" [reference breadFlow, techInput waterFlow 1.0, techInput waterFlow 2.0])
                         }
                 twoWaterStats =
-                    relinkSimpleDatabase [supplierIndexed] emptySynonymDB defaultUnitConfig M.empty GeoGlobal Nothing twoWaterDB
+                    relinkSimpleDatabase [supplierIndexed] emptySynonymDB defaultUnitConfig M.empty GeoGlobal emptyAliasMap twoWaterDB
                 onlyWater r = filter ((== "water") . geFlowName) (grGaps r)
             -- sanity: both demands link, so the full stats leave no water gap
             length (cdlLinks twoWaterStats) `shouldBe` 2

--- a/test/RelinkMappingSpec.hs
+++ b/test/RelinkMappingSpec.hs
@@ -2,12 +2,13 @@
 
 {- | Relink-with-mapping tests.
 
-A small target ("BAFU") database is indexed as a cross-DB supplier. A consumer
-input flow whose name only matches the target *via* an alias from the mapping
-CSV must link once the alias map is threaded into the 'LinkingContext'; without
-it the same lookup yields 'NoNameMatch'. Unit incompatibility surfaces as an
-error rather than being silently dropped, and the post-link score matches the
-expected name+location total.
+A small target database supplies "wheat production" at FR and at CH; a
+consumer input flow whose name only matches the target *via* an alias row must
+link once the alias map is threaded into the 'LinkingContext'. The geo-aware
+semantics are pinned here: an exact (name, location) row wins over the
+name-only row, a pinned target location bypasses the geography policy, a
+missing designated target surfaces as 'AliasTargetMissing' (never a silent
+fallback), and a matching row preempts the direct name cascade.
 -}
 module RelinkMappingSpec (spec) where
 
@@ -20,13 +21,18 @@ import System.IO.Temp (withSystemTempFile)
 import Test.Hspec
 
 import Database.CrossLinking (
+    AliasKey (..),
+    AliasMap (..),
+    AliasTarget (..),
     CrossDBLinkResult (..),
     IndexedDatabase,
     LinkingContext (..),
     buildIndexedDatabase,
     defaultLinkingThreshold,
+    emptyAliasMap,
     findSupplierInIndexedDBs,
     locationHierarchy,
+    lookupAlias,
  )
 import Database.RelinkMapping (
     AliasRow (..),
@@ -48,37 +54,36 @@ import Types (
 import UnitConversion (defaultUnitConfig)
 
 -- ---------------------------------------------------------------------------
--- Target ("BAFU") fixture: one activity, "wheat production" @ FR, in kg.
+-- Target fixture: "wheat production" supplied at FR and at CH, in kg.
 -- ---------------------------------------------------------------------------
 
 targetIndexed :: IndexedDatabase
-targetIndexed = buildIndexedDatabase "BAFU" emptySynonymDB targetDB
+targetIndexed = buildIndexedDatabase "background" emptySynonymDB targetDB
 
 targetDB :: SimpleDatabase
 targetDB =
     let flowUUID = read "aaaaaaaa-0000-0000-0000-000000000001"
-        actUUID = read "cccccccc-0000-0000-0000-000000000001"
-        ex =
-            TechnosphereExchange
-                { techFlowId = flowUUID
-                , techAmount = 1.0
-                , techUnitId = UUID.nil
-                , techRole = ReferenceProduct
-                , techActivityLinkId = UUID.nil
-                , techProcessLinkId = Nothing
-                , techLocation = ""
-                , techComment = Nothing
-                , techPedigree = Nothing
-                }
-        act =
+        mkAct loc =
             Activity
                 { activityName = "wheat production"
                 , activityDescription = []
                 , activitySynonyms = M.empty
                 , activityClassification = M.empty
-                , activityLocation = "FR"
+                , activityLocation = loc
                 , activityUnit = "kg"
-                , exchanges = [ex]
+                , exchanges =
+                    [ TechnosphereExchange
+                        { techFlowId = flowUUID
+                        , techAmount = 1.0
+                        , techUnitId = UUID.nil
+                        , techRole = ReferenceProduct
+                        , techActivityLinkId = UUID.nil
+                        , techProcessLinkId = Nothing
+                        , techLocation = ""
+                        , techComment = Nothing
+                        , techPedigree = Nothing
+                        }
+                    ]
                 , activityParams = M.empty
                 , activityParamExprs = M.empty
                 , activityAllocationPercent = Nothing
@@ -95,33 +100,45 @@ targetDB =
                 , tfCAS = Nothing
                 , tfSubstanceId = Nothing
                 }
+        actFR = read "cccccccc-0000-0000-0000-000000000001"
+        actCH = read "cccccccc-0000-0000-0000-000000000002"
      in SimpleDatabase
-            { sdbActivities = M.singleton (actUUID, flowUUID) act
+            { sdbActivities =
+                M.fromList
+                    [ ((actFR, flowUUID), mkAct "FR")
+                    , ((actCH, flowUUID), mkAct "CH")
+                    ]
             , sdbTechFlows = M.singleton flowUUID flow
             , sdbBioFlows = M.empty
             , sdbWasteFlows = M.empty
             , sdbUnits = M.empty
             }
 
--- | Linking context against the target, with an optional alias map.
-mkCtx :: Maybe (M.Map Text Text) -> LinkingContext
-mkCtx aliases =
+-- | Linking context against the target, with a geography policy and aliases.
+mkCtxPolicy :: GeographyPolicy -> AliasMap -> LinkingContext
+mkCtxPolicy policy aliases =
     LinkingContext
         { lcIndexedDatabases = [targetIndexed]
         , lcSynonymDB = emptySynonymDB
         , lcUnitConfig = defaultUnitConfig
         , lcThreshold = defaultLinkingThreshold
         , lcLocationHierarchy = locationHierarchy
-        , lcGeographyPolicy = GeoGlobal
+        , lcGeographyPolicy = policy
         , lcSupplierAliases = aliases
         }
 
--- | The consumer's Ecoinvent-style name that only resolves via the alias.
-consumerName :: Text
-consumerName = "wheat, ecoinvent name"
+mkCtx :: AliasMap -> LinkingContext
+mkCtx = mkCtxPolicy GeoGlobal
 
-aliasMap :: M.Map Text Text
-aliasMap = M.singleton consumerName "wheat production"
+-- | The consumer's differently-named input that only resolves via the alias.
+consumerName :: Text
+consumerName = "wheat, background name"
+
+singletonAlias :: AliasKey -> AliasTarget -> AliasMap
+singletonAlias key target = AliasMap (M.singleton key target)
+
+aliasMap :: AliasMap
+aliasMap = singletonAlias (AliasKey consumerName Nothing) (AliasTarget "wheat production" Nothing)
 
 -- ---------------------------------------------------------------------------
 
@@ -130,19 +147,33 @@ spec = do
     describe "alias CSV loading" $ do
         it "parses source/target columns and builds the map" $ do
             -- The source name contains a comma, so it must be CSV-quoted.
-            let csv = BLC.pack "source,target\n\"wheat, ecoinvent name\",wheat production\n"
+            let csv = BLC.pack "source,target\n\"wheat, background name\",wheat production\n"
             rows <- either (fail . show) pure (parseAliasCSV csv)
             map arSource rows `shouldBe` [consumerName]
             map arTarget rows `shouldBe` ["wheat production"]
             buildAliasMap rows `shouldBe` Right aliasMap
 
-        it "accepts the from/to column synonyms and optional locations" $ do
-            let csv = BLC.pack "from,to,source_location\na,b,FR\n"
+        it "keys the row by source location and pins the target location" $ do
+            let csv = BLC.pack "from,to,source_location,target_location\na,b,FR,CH\n"
             rows <- either (fail . show) pure (parseAliasCSV csv)
-            map arSourceLocation rows `shouldBe` [Just "FR"]
-            buildAliasMap rows `shouldBe` Right (M.singleton "a" "b")
+            buildAliasMap rows
+                `shouldBe` Right (singletonAlias (AliasKey "a" (Just "FR")) (AliasTarget "b" (Just "CH")))
 
-        it "rejects a conflicting alias for the same source" $ do
+        it "accepts the same source name with and without a location as two rows" $ do
+            let rows =
+                    [ AliasRow "x" "y" Nothing Nothing
+                    , AliasRow "x" "z" (Just "FR") Nothing
+                    ]
+            buildAliasMap rows
+                `shouldBe` Right
+                    ( AliasMap $
+                        M.fromList
+                            [ (AliasKey "x" Nothing, AliasTarget "y" Nothing)
+                            , (AliasKey "x" (Just "FR"), AliasTarget "z" Nothing)
+                            ]
+                    )
+
+        it "rejects a conflicting alias for the same (source, location) key" $ do
             let rows =
                     [ AliasRow "x" "y" Nothing Nothing
                     , AliasRow "x" "z" Nothing Nothing
@@ -169,52 +200,119 @@ spec = do
         it "rejectEmpty rejects an empty map and passes a non-empty one" $ do
             -- The HTTP relink handler relies on this so a header-only CSV is a 4xx,
             -- not a silent 200 no-op (matching the CLI's loadAliasMap).
-            rejectEmpty M.empty `shouldSatisfy` either (const True) (const False)
-            rejectEmpty (M.singleton "a" "b") `shouldBe` Right (M.singleton "a" "b")
+            rejectEmpty emptyAliasMap `shouldSatisfy` either (const True) (const False)
+            rejectEmpty aliasMap `shouldBe` Right aliasMap
 
         it "collapses two identical duplicate rows harmlessly" $ do
             let rows =
                     [ AliasRow "x" "y" Nothing Nothing
                     , AliasRow "x" "y" Nothing Nothing
                     ]
-            buildAliasMap rows `shouldBe` Right (M.singleton "x" "y")
+            buildAliasMap rows `shouldBe` Right (singletonAlias (AliasKey "x" Nothing) (AliasTarget "y" Nothing))
 
         it "round-trips a quoted target that contains a comma" $ do
             -- The target name contains a comma, so it must be CSV-quoted.
             let csv = BLC.pack "source,target\nwheat,\"production, FR\"\n"
             rows <- either (fail . show) pure (parseAliasCSV csv)
-            buildAliasMap rows `shouldBe` Right (M.singleton "wheat" "production, FR")
+            buildAliasMap rows
+                `shouldBe` Right (singletonAlias (AliasKey "wheat" Nothing) (AliasTarget "production, FR" Nothing))
+
+    describe "lookupAlias" $ do
+        it "prefers the exact (name, location) row over the name-only row" $ do
+            let m =
+                    AliasMap $
+                        M.fromList
+                            [ (AliasKey "x" Nothing, AliasTarget "anywhere" Nothing)
+                            , (AliasKey "x" (Just "FR"), AliasTarget "france" Nothing)
+                            ]
+            lookupAlias m "x" "FR" `shouldBe` Just (AliasTarget "france" Nothing)
+            lookupAlias m "x" "DE" `shouldBe` Just (AliasTarget "anywhere" Nothing)
+
+        it "matches only name-only rows for a demand without a location" $ do
+            let m = singletonAlias (AliasKey "x" (Just "FR")) (AliasTarget "france" Nothing)
+            lookupAlias m "x" "" `shouldBe` Nothing
 
     describe "findSupplierInIndexedDBs with supplier aliases" $ do
         it "does NOT link the aliased consumer name without the alias map" $
-            case findSupplierInIndexedDBs (mkCtx Nothing) consumerName "FR" "kg" of
+            case findSupplierInIndexedDBs (mkCtx emptyAliasMap) consumerName "FR" "kg" of
                 CrossDBNotLinked NoNameMatch -> pure ()
                 CrossDBNotLinked other -> expectationFailure $ "Expected NoNameMatch, got: " ++ show other
                 CrossDBLinked{} -> expectationFailure "Expected no link without alias map"
 
         it "links the aliased consumer name to the target via the alias map" $
-            case findSupplierInIndexedDBs (mkCtx (Just aliasMap)) consumerName "FR" "kg" of
+            case findSupplierInIndexedDBs (mkCtx aliasMap) consumerName "FR" "kg" of
                 CrossDBLinked{cdlrProductName = name, cdlrDatabaseName = db} -> do
                     name `shouldBe` "wheat production"
-                    db `shouldBe` "BAFU"
+                    db `shouldBe` "background"
                 CrossDBNotLinked reason -> expectationFailure $ "Expected link, got: " ++ show reason
 
         it "scores name(50) + exact-location(30) = 80 for an FR→FR alias link" $
-            case findSupplierInIndexedDBs (mkCtx (Just aliasMap)) consumerName "FR" "kg" of
-                CrossDBLinked{cdlrScore = score} -> score `shouldBe` 80
+            case findSupplierInIndexedDBs (mkCtx aliasMap) consumerName "FR" "kg" of
+                CrossDBLinked{cdlrScore = score, cdlrLocation = loc} -> do
+                    score `shouldBe` 80
+                    loc `shouldBe` "FR"
                 CrossDBNotLinked reason -> expectationFailure $ "Expected link, got: " ++ show reason
 
         it "surfaces a unit mismatch as UnitIncompatible, never a silent drop" $
-            case findSupplierInIndexedDBs (mkCtx (Just aliasMap)) consumerName "FR" "m3" of
+            case findSupplierInIndexedDBs (mkCtx aliasMap) consumerName "FR" "m3" of
                 CrossDBNotLinked (UnitIncompatible req got) -> do
                     req `shouldBe` "m3"
                     got `shouldBe` "kg"
                 CrossDBNotLinked other -> expectationFailure $ "Expected UnitIncompatible, got: " ++ show other
                 CrossDBLinked{} -> expectationFailure "Expected unit mismatch to block the link"
 
-        it "still prefers a direct name match over the alias map" $
-            -- The target's own canonical name resolves directly; the alias is
-            -- only a last-resort retry, so a direct lookup must not depend on it.
-            case findSupplierInIndexedDBs (mkCtx (Just aliasMap)) "wheat production" "FR" "kg" of
+        it "resolves a name without an alias row independently of the mapping" $
+            -- The target's own canonical name resolves directly; a mapping
+            -- must never change the behaviour of names it doesn't mention.
+            case findSupplierInIndexedDBs (mkCtx aliasMap) "wheat production" "FR" "kg" of
                 CrossDBLinked{cdlrScore = score} -> score `shouldBe` 80
                 CrossDBNotLinked reason -> expectationFailure $ "Expected direct link, got: " ++ show reason
+
+        it "lets a matching row preempt a direct name match" $ do
+            -- "wheat production" matches the target directly at FR, but the
+            -- curator redirected it to CH: the row must win, otherwise a
+            -- curated answer could be silently overridden.
+            let redirect = singletonAlias (AliasKey "wheat production" Nothing) (AliasTarget "wheat production" (Just "CH"))
+            case findSupplierInIndexedDBs (mkCtx redirect) "wheat production" "FR" "kg" of
+                CrossDBLinked{cdlrLocation = loc} -> loc `shouldBe` "CH"
+                CrossDBNotLinked reason -> expectationFailure $ "Expected CH link, got: " ++ show reason
+
+        it "links to a pinned target location even when the geography policy forbids it" $ do
+            -- GeoExact would reject CH for an FR demand; the curator's pinned
+            -- location is a deliberate designation, so it bypasses the policy.
+            let pinned = singletonAlias (AliasKey consumerName Nothing) (AliasTarget "wheat production" (Just "CH"))
+            case findSupplierInIndexedDBs (mkCtxPolicy GeoExact pinned) consumerName "FR" "kg" of
+                CrossDBLinked{cdlrLocation = loc} -> loc `shouldBe` "CH"
+                CrossDBNotLinked reason -> expectationFailure $ "Expected CH link, got: " ++ show reason
+
+        it "reports a designated target name that matches nowhere" $ do
+            let missing = singletonAlias (AliasKey consumerName Nothing) (AliasTarget "no such product" (Just "CH"))
+            case findSupplierInIndexedDBs (mkCtx missing) consumerName "FR" "kg" of
+                CrossDBNotLinked (AliasTargetMissing name loc) -> do
+                    name `shouldBe` "no such product"
+                    loc `shouldBe` Nothing
+                other -> expectationFailure $ "Expected AliasTargetMissing, got a different result: " ++ describe' other
+
+        it "reports a designated target that exists but not at the pinned location" $ do
+            let wrongLoc = singletonAlias (AliasKey consumerName Nothing) (AliasTarget "wheat production" (Just "DE"))
+            case findSupplierInIndexedDBs (mkCtx wrongLoc) consumerName "FR" "kg" of
+                CrossDBNotLinked (AliasTargetMissing name loc) -> do
+                    name `shouldBe` "wheat production"
+                    loc `shouldBe` Just "DE"
+                other -> expectationFailure $ "Expected AliasTargetMissing, got a different result: " ++ describe' other
+
+        it "applies the located row only at its location" $ do
+            -- The FR row designates a target nobody ships, so an FR demand
+            -- fails loudly through the row — while a CH demand has no row in
+            -- force and links normally through the cascade.
+            let m = singletonAlias (AliasKey "wheat production" (Just "FR")) (AliasTarget "no such product" Nothing)
+            case findSupplierInIndexedDBs (mkCtx m) "wheat production" "FR" "kg" of
+                CrossDBNotLinked (AliasTargetMissing name _) -> name `shouldBe` "no such product"
+                other -> expectationFailure $ "Expected AliasTargetMissing, got a different result: " ++ describe' other
+            case findSupplierInIndexedDBs (mkCtx m) "wheat production" "CH" "kg" of
+                CrossDBLinked{cdlrLocation = loc} -> loc `shouldBe` "CH"
+                CrossDBNotLinked reason -> expectationFailure $ "Expected CH link, got: " ++ show reason
+  where
+    describe' result = case result of
+        CrossDBLinked{cdlrLocation = loc} -> "linked @ " ++ show loc
+        CrossDBNotLinked reason -> show reason

--- a/test/StrictPinSpec.hs
+++ b/test/StrictPinSpec.hs
@@ -29,7 +29,7 @@ import Test.Hspec
 import Config (DatabaseConfig (..), defaultConfig)
 import qualified Data.Vector.Unboxed as U
 import Database (buildDatabaseWithMatrices)
-import Database.CrossLinking (buildIndexedDatabaseFromDB)
+import Database.CrossLinking (AliasKey (..), AliasMap (..), AliasTarget (..), buildIndexedDatabaseFromDB)
 import Database.Manager (
     DatabaseManager (..),
     LoadedDatabase (..),
@@ -124,7 +124,12 @@ spec = describe "relinkDatabase strict dependency pin" $ do
             -- A mapping relink scoped to beta must re-resolve the whole pin, not
             -- drop the alpha link. (The alias is inert here; it only exercises the
             -- mapping path.)
-            result <- relinkDatabaseWithMapping manager "consumer" "beta" (M.singleton "no-such-input" "no-such-supplier")
+            result <-
+                relinkDatabaseWithMapping
+                    manager
+                    "consumer"
+                    "beta"
+                    (AliasMap (M.singleton (AliasKey "no-such-input" Nothing) (AliasTarget "no-such-supplier" Nothing)))
             result `shouldSatisfy` isRight
 
             loaded <- readTVarIO (dmLoadedDbs manager)

--- a/test/WasteCrossDBSpec.hs
+++ b/test/WasteCrossDBSpec.hs
@@ -52,7 +52,7 @@ spec = describe "findWasteTreatmentAcrossDatabases" $ do
                 , lcThreshold = defaultLinkingThreshold
                 , lcLocationHierarchy = M.empty
                 , lcGeographyPolicy = GeoExact
-                , lcSupplierAliases = Nothing
+                , lcSupplierAliases = emptyAliasMap
                 }
 
         wasteUUID = UUID.fromWords 0xa 0xb 0xc 0xd

--- a/test/WasteTreatmentSignSpec.hs
+++ b/test/WasteTreatmentSignSpec.hs
@@ -29,7 +29,7 @@ import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import Database (buildDatabaseWithMatrices)
-import Database.CrossLinking (LinkingContext (..), buildIndexedDatabaseFromDB, defaultLinkingThreshold)
+import Database.CrossLinking (LinkingContext (..), buildIndexedDatabaseFromDB, defaultLinkingThreshold, emptyAliasMap)
 import Database.Loader (findAllCrossDBLinks)
 import Matrix (computeInventoryMatrix)
 import SharedSolver (CrossDBSolution (..), computeInventoryMatrixWithDepsCached)
@@ -187,7 +187,7 @@ scoreCross depName depRole depRefAmount = do
                 , lcThreshold = defaultLinkingThreshold
                 , lcLocationHierarchy = M.empty
                 , lcGeographyPolicy = GeoExact
-                , lcSupplierAliases = Nothing
+                , lcSupplierAliases = emptyAliasMap
                 }
         links = cdlLinks (findAllCrossDBLinks ctx techFlowDB wasteFlowDB (M.singleton kgU (Unit kgU "kg" "kg" "")) rootActs)
         rootDB = rootBase{dbCrossDBLinks = links}


### PR DESCRIPTION
## Why

The relink mapping CSV always had `source_location` and `target_location` columns, but they were parsed and ignored: rows keyed on name alone and the geography policy chose the supplier's location. That left the curator unable to answer the real question a background switch raises — *a French process consumes Swiss cement in the old background: is the replacement the Swiss cement or the French one?* The answer differs per row, so the row must carry it.

## What

- An alias row now keys on **(source name, optional source location)** — the located row wins over the name-only row for the same name; a demand without a location only matches name-only rows.
- A row's target can pin an **exact supplier location**: the link goes there literally, bypassing the geography policy and score threshold — the designation is deliberate, so no `UpperLocationUsed` warning either.
- When nothing supplies the designated target (name matches nowhere, or not at the pinned location), the relink reports a new **`alias_target_missing`** blocker — visible in the linking stats, the setup page and the gap report — instead of silently falling back to the generic cascade.
- `lcSupplierAliases` loses its `Maybe`: an `AliasMap` is its own empty, so "no aliases" stops having two representations. The stale docstring (it promised a `normalizeText` fallback the code never had) is rewritten.

Two deliberate semantic changes, pre-1.0 (both in the CHANGELOG):

1. **A matching row preempts the direct name cascade** (it used to be a last-resort retry). A curated answer must not be silently overridden by a coincidental direct match; names the mapping does not mention resolve exactly as before.
2. **Matrix-cache schema bump 8 → 9** — the new blocker changes the Store layout of the linking stats embedded in the cache, so the first start after upgrading rebuilds each database cache once.

The wire format does not change: the CSV travels inline in the existing relink body, and the new columns were already accepted.

Stacked on #217 (the gap report), which supplies the shared `blockerReasonDetail` and the report the new blocker surfaces in.