### PR TITLE
Expose sort and order in the pyvolca search and traversal methods

### DIFF
--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -504,7 +504,7 @@ Returns a :class:`CharacterizationResult` carrying ``matches`` (total
 rows the filter selected) and ``shown`` (rows actually returned under
 ``limit``). Check ``result.has_more`` to detect truncation.
 
-##### `Client.get_consumers(process_id: str, *, name: str | None = None, location: str | None = None, product: str | None = None, preset: str | None = None, classification_filters: list[ClassificationFilter] | None = None, page: int | None = None, page_size: int | None = None, limit: int | None = None, offset: int | None = None, max_depth: int | None = None, include_edges: bool = False) -> ConsumersResponse`
+##### `Client.get_consumers(process_id: str, *, name: str | None = None, location: str | None = None, product: str | None = None, preset: str | None = None, classification_filters: list[ClassificationFilter] | None = None, page: int | None = None, page_size: int | None = None, limit: int | None = None, offset: int | None = None, max_depth: int | None = None, sort: str | None = None, order: str | None = None, include_edges: bool = False) -> ConsumersResponse`
 
 Find all activities that transitively consume this supplier.
 
@@ -513,6 +513,9 @@ Args:
     classification_filters: ClassificationFilter entries restricting
         the results. Multiple filters are AND-combined by the server.
         Mode is :class:`MatchMode.EXACT` or :class:`MatchMode.CONTAINS`.
+    sort: Sort key — ``"name"``, ``"location"``, ``"product"``,
+        ``"amount"``, or ``"unit"``. Default orders by depth.
+    order: ``"desc"`` to reverse; ascending otherwise.
     include_edges: When True, the response carries every technosphere
         edge whose endpoints are both reachable from the supplier.
         Callers can walk these to reconstruct supplier→consumer paths
@@ -647,7 +650,7 @@ Return the engine's runtime statistics (memory use, loaded sizes).
 
 Keys are already snake_case on the wire, so this returns the raw dict.
 
-##### `Client.get_supply_chain(process_id: str, *, name: str | None = None, location: str | None = None, limit: int | None = None, min_quantity: float | None = None, max_depth: int | None = None, preset: str | None = None, classification_filters: list[ClassificationFilter] | None = None, substitutions: list[SubstitutionLike] | None = None, include_edges: bool | None = None) -> SupplyChain`
+##### `Client.get_supply_chain(process_id: str, *, name: str | None = None, location: str | None = None, limit: int | None = None, min_quantity: float | None = None, max_depth: int | None = None, preset: str | None = None, classification_filters: list[ClassificationFilter] | None = None, sort: str | None = None, order: str | None = None, substitutions: list[SubstitutionLike] | None = None, include_edges: bool | None = None) -> SupplyChain`
 
 Get the flat supply chain of an activity.
 
@@ -661,6 +664,10 @@ Args:
     classification_filters: Restrict entries to those matching any
         of the given ClassificationFilter triples. Multiple filters
         are AND-combined by the server.
+    sort: Sort key — ``"name"``, ``"location"``, ``"unit"``,
+        ``"depth"``, ``"consumers"``, or ``"amount"``. Default
+        orders by descending absolute quantity.
+    order: ``"desc"`` to reverse; ascending otherwise.
     substitutions: When provided, the call is upgraded to POST and
         the scaling vector is recomputed with the substituted
         suppliers. Accepts :class:`Substitution` (preferred) or the
@@ -790,7 +797,7 @@ them, a partial result is not an error. ``top_flows`` caps the top
 contributors per category; ``exclude_long_term`` drops long-term
 emissions from the totals.
 
-##### `Client.search_activities(name: str | None = None, *, geo: str | None = None, product: str | None = None, preset: str | None = None, classification: str | None = None, classification_value: str | None = None, classification_match: MatchModeLike | None = None, page: int | None = None, page_size: int | None = None, limit: int | None = None, offset: int | None = None, exact: bool = False) -> SearchResults[Activity]`
+##### `Client.search_activities(name: str | None = None, *, geo: str | None = None, product: str | None = None, preset: str | None = None, classification: str | None = None, classification_value: str | None = None, classification_match: MatchModeLike | None = None, page: int | None = None, page_size: int | None = None, limit: int | None = None, offset: int | None = None, sort: str | None = None, order: str | None = None, exact: bool = False) -> SearchResults[Activity]`
 
 Search activities in the current database.
 
@@ -819,12 +826,15 @@ Args:
         Alone (no ``page``) means "page 1 with this size".
     limit: Wire-level cap on returned items. Prefer ``page_size``.
     offset: Wire-level starting index. Prefer ``page`` + ``page_size``.
+    sort: Sort key — ``"name"`` or ``"location"``. When set, results
+        are ordered lexicographically instead of by relevance.
+    order: ``"desc"`` to reverse; ascending otherwise.
     exact: When True, ``name`` and ``product`` are matched exactly.
 
 Returns:
     :class:`SearchResults[Activity]` — iterable across all pages.
 
-##### `Client.search_flows(query: str | None = None, *, page: int | None = None, page_size: int | None = None, limit: int | None = None, offset: int | None = None) -> SearchResults[Flow]`
+##### `Client.search_flows(query: str | None = None, *, page: int | None = None, page_size: int | None = None, limit: int | None = None, offset: int | None = None, sort: str | None = None, order: str | None = None) -> SearchResults[Flow]`
 
 Search flows (technosphere products and biosphere flows) in the current database.
 
@@ -837,6 +847,8 @@ Args:
     page / page_size: Web-style pagination; convert to wire-level
         ``offset`` / ``limit``.
     limit / offset: Wire-level escape hatch.
+    sort: Sort key — ``"name"`` (default), ``"category"``, or ``"unit"``.
+    order: ``"desc"`` to reverse; ascending otherwise.
 
 ##### `Client.set_data_path(path: str, db_name: str | None = None) -> dict`
 

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -1013,6 +1013,8 @@ class Client:
         page_size: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
+        sort: str | None = None,
+        order: str | None = None,
         exact: bool = False,
     ) -> SearchResults[Activity]:
         """Search activities in the current database.
@@ -1042,6 +1044,9 @@ class Client:
                 Alone (no ``page``) means "page 1 with this size".
             limit: Wire-level cap on returned items. Prefer ``page_size``.
             offset: Wire-level starting index. Prefer ``page`` + ``page_size``.
+            sort: Sort key — ``"name"`` or ``"location"``. When set, results
+                are ordered lexicographically instead of by relevance.
+            order: ``"desc"`` to reverse; ascending otherwise.
             exact: When True, ``name`` and ``product`` are matched exactly.
 
         Returns:
@@ -1060,6 +1065,8 @@ class Client:
                 if classification_match is not None
                 else None
             ),
+            sort=sort,
+            order=order,
             exact=exact,
         )
 
@@ -1077,6 +1084,8 @@ class Client:
         page_size: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
+        sort: str | None = None,
+        order: str | None = None,
     ) -> SearchResults[Flow]:
         """Search flows (technosphere products and biosphere flows) in the current database.
 
@@ -1089,11 +1098,15 @@ class Client:
             page / page_size: Web-style pagination; convert to wire-level
                 ``offset`` / ``limit``.
             limit / offset: Wire-level escape hatch.
+            sort: Sort key — ``"name"`` (default), ``"category"``, or ``"unit"``.
+            order: ``"desc"`` to reverse; ascending otherwise.
         """
         wire_limit, wire_offset = _resolve_page_args(page, page_size, limit, offset)
 
         def fetch(o: int, l: int | None) -> dict:
-            return self._call("search_flows", q=query, limit=l, offset=o)
+            return self._call(
+                "search_flows", q=query, sort=sort, order=order, limit=l, offset=o
+            )
 
         raw = fetch(wire_offset, wire_limit)
         return SearchResults.from_raw(raw, parse=Flow.from_json, fetch=fetch)
@@ -1153,6 +1166,8 @@ class Client:
         max_depth: int | None = None,
         preset: str | None = None,
         classification_filters: list[ClassificationFilter] | None = None,
+        sort: str | None = None,
+        order: str | None = None,
         substitutions: list[SubstitutionLike] | None = None,
         include_edges: bool | None = None,
     ) -> SupplyChain:
@@ -1168,6 +1183,10 @@ class Client:
             classification_filters: Restrict entries to those matching any
                 of the given ClassificationFilter triples. Multiple filters
                 are AND-combined by the server.
+            sort: Sort key — ``"name"``, ``"location"``, ``"unit"``,
+                ``"depth"``, ``"consumers"``, or ``"amount"``. Default
+                orders by descending absolute quantity.
+            order: ``"desc"`` to reverse; ascending otherwise.
             substitutions: When provided, the call is upgraded to POST and
                 the scaling vector is recomputed with the substituted
                 suppliers. Accepts :class:`Substitution` (preferred) or the
@@ -1189,6 +1208,8 @@ class Client:
             classification=classifications or None,
             classification_value=classification_values or None,
             classification_mode=classification_modes or None,
+            sort=sort,
+            order=order,
             include_edges=include_edges,
             substitutions=substitutions,
         )
@@ -1273,6 +1294,8 @@ class Client:
         limit: int | None = None,
         offset: int | None = None,
         max_depth: int | None = None,
+        sort: str | None = None,
+        order: str | None = None,
         include_edges: bool = False,
     ) -> ConsumersResponse:
         """Find all activities that transitively consume this supplier.
@@ -1282,6 +1305,9 @@ class Client:
             classification_filters: ClassificationFilter entries restricting
                 the results. Multiple filters are AND-combined by the server.
                 Mode is :class:`MatchMode.EXACT` or :class:`MatchMode.CONTAINS`.
+            sort: Sort key — ``"name"``, ``"location"``, ``"product"``,
+                ``"amount"``, or ``"unit"``. Default orders by depth.
+            order: ``"desc"`` to reverse; ascending otherwise.
             include_edges: When True, the response carries every technosphere
                 edge whose endpoints are both reachable from the supplier.
                 Callers can walk these to reconstruct supplier→consumer paths
@@ -1306,6 +1332,8 @@ class Client:
             classification_value=classification_values or None,
             classification_mode=classification_modes or None,
             max_depth=max_depth,
+            sort=sort,
+            order=order,
             include_edges=include_edges,
         )
 

--- a/pyvolca/tests/conftest.py
+++ b/pyvolca/tests/conftest.py
@@ -60,6 +60,8 @@ def fixture_spec() -> dict[str, Any]:
                         {"name": "classification-mode", "in": "query", "required": False, "schema": {"type": "string"}},
                         {"name": "limit", "in": "query", "required": False, "schema": {"type": "integer"}},
                         {"name": "offset", "in": "query", "required": False, "schema": {"type": "integer"}},
+                        {"name": "sort", "in": "query", "required": False, "schema": {"type": "string"}},
+                        {"name": "order", "in": "query", "required": False, "schema": {"type": "string"}},
                     ],
                 },
             },

--- a/pyvolca/tests/test_dispatch.py
+++ b/pyvolca/tests/test_dispatch.py
@@ -168,6 +168,24 @@ class TestDispatcher:
         with pytest.raises(ValueError):
             client.search_activities(classification="Category", classification_value="Food", classification_match="exct")
 
+    def test_search_activities_forwards_sort_order(self, mocked_client, make_response, empty_envelope):
+        """sort= and order= must reach the wire as query params (same path as get_consumers etc.)."""
+        client, session = mocked_client
+        session.get.return_value = make_response(empty_envelope())
+        client.search_activities(name="wheat", sort="location", order="desc")
+        params = dict(session.get.call_args[1]["params"])
+        assert params["sort"] == "location"
+        assert params["order"] == "desc"
+
+    def test_search_activities_omits_sort_order_by_default(self, mocked_client, make_response, empty_envelope):
+        """Unset sort/order must not appear in the query string (server defaults apply)."""
+        client, session = mocked_client
+        session.get.return_value = make_response(empty_envelope())
+        client.search_activities(name="wheat")
+        params = dict(session.get.call_args[1]["params"])
+        assert "sort" not in params
+        assert "order" not in params
+
     def test_search_activities_page_kwargs_compute_offset(self, mocked_client, make_response, empty_envelope):
         """page=3 + page_size=20 must translate to offset=40, limit=20."""
         client, session = mocked_client


### PR DESCRIPTION
The engine accepts `sort` and `order` query parameters on four endpoints — the activities search, the flows search, the supply chain, and the consumers listing — but none of the corresponding pyvolca methods forwarded them, so Python callers had no way to ask the server to order results.

`search_activities`, `search_flows`, `get_supply_chain`, and `get_consumers` now take optional keyword-only `sort=` and `order=` arguments. They flow through the dispatcher exactly like the existing pagination parameters: left unset, nothing is added to the query string and the server defaults apply. Each docstring lists the sort keys its endpoint supports, taken from the engine's comparators.

Two dispatch tests cover the shared path: one asserts `sort`/`order` reach the wire, the other asserts they stay out of the query string when unset. The README API reference was regenerated with `scripts/gen_api_md.py --write`. Full pyvolca suite: 232 passed, 7 skipped (live-engine tests, as usual without a built binary).