### PR TITLE
Add Client.ensure_database, the idempotent upload lifecycle

### DIFF
--- a/pyvolca/CHANGELOG.md
+++ b/pyvolca/CHANGELOG.md
@@ -36,6 +36,16 @@ Then paste the rendered block at the top of this file and tighten wording.
 - `Server.start()` fails fast with the exit code when the spawned engine dies
   before serving, instead of hanging until the readiness timeout — in both
   fixed-port and `port="auto"` modes.
+- `Client.ensure_database(source, name=…)` — the one-call, idempotent form of
+  the upload lifecycle. It matches by display name (default: the file's
+  stem), uploads only when absent, finalizes the staged copy, loads if
+  unloaded, and returns the slug. Run it at the top of a script and it
+  converges on the same loaded database every time instead of re-uploading;
+  the list → match → upload → finalize → load state machine that every
+  script hand-rolled is now one line. A copy that is not ready to finalize
+  raises with the concrete blocker (missing suppliers, no activities
+  parsed) — including an upload left staged by an earlier failed run, which
+  goes through the same readiness gate instead of being loaded half-linked.
 
 ### Changed
 

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -493,6 +493,21 @@ Download a flow-synonyms set as its raw CSV bytes.
 
 Raises VoLCAError on an HTTP error (e.g. the set does not exist).
 
+##### `Client.ensure_database(source: str | Path | bytes, name: str | None = None) -> str`
+
+Idempotently make the archive at ``source`` a loaded database.
+
+The one-call form of the upload lifecycle: match by display name
+(default: the file's stem), upload only when absent, finalize the
+staged copy, load if unloaded. Returns the slug every later call
+targets — run it at the top of a script and it converges on the same
+loaded database every time instead of re-uploading.
+
+A staged archive that is not ready to finalize (unresolved
+dependencies) raises VoLCAError naming what is missing — wire the
+dependencies with :meth:`add_dependency` and :meth:`finalize_database`
+yourself in that case.
+
 ##### `Client.export_database(fmt: str, db_name: str | None = None) -> bytes`
 
 Export a loaded database, returning the serialized bytes.

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -501,12 +501,15 @@ The one-call form of the upload lifecycle: match by display name
 (default: the file's stem), upload only when absent, finalize the
 staged copy, load if unloaded. Returns the slug every later call
 targets — run it at the top of a script and it converges on the same
-loaded database every time instead of re-uploading.
+loaded database every time instead of re-uploading. A match that is
+already loaded — even partially linked — is left untouched.
 
-A staged archive that is not ready to finalize (unresolved
-dependencies) raises VoLCAError naming what is missing — wire the
-dependencies with :meth:`add_dependency` and :meth:`finalize_database`
-yourself in that case.
+A staged copy that is not ready to finalize raises VoLCAError naming
+the blocker (missing suppliers, no activities parsed) — fix it with
+:meth:`add_dependency` or :meth:`set_data_path`, then
+:meth:`finalize_database`. The gate also holds on re-runs: an upload
+left staged by an earlier failed run goes through the same readiness
+check instead of being loaded half-linked.
 
 ##### `Client.export_database(fmt: str, db_name: str | None = None) -> bytes`
 

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -62,6 +62,7 @@ from .types import (
     ContributingActivities,
     ContributingFlows,
     DatabaseInfo,
+    DatabaseStatus,
     Exchange,
     Flow,
     FlowDetail,
@@ -985,6 +986,43 @@ class Client:
         return self._upload(
             "/api/v1/db/upload", source, name, description, "upload_database"
         )
+
+    def ensure_database(self, source: str | Path | bytes, name: str | None = None) -> str:
+        """Idempotently make the archive at ``source`` a loaded database.
+
+        The one-call form of the upload lifecycle: match by display name
+        (default: the file's stem), upload only when absent, finalize the
+        staged copy, load if unloaded. Returns the slug every later call
+        targets — run it at the top of a script and it converges on the same
+        loaded database every time instead of re-uploading.
+
+        A staged archive that is not ready to finalize (unresolved
+        dependencies) raises VoLCAError naming what is missing — wire the
+        dependencies with :meth:`add_dependency` and :meth:`finalize_database`
+        yourself in that case.
+        """
+        if name is None:
+            if isinstance(source, bytes):
+                raise VoLCAError(
+                    "ensure_database: name= is required when source is bytes"
+                )
+            name = Path(source).stem
+        for db in self.list_databases():
+            if name in (db.display_name, db.name):
+                if db.status == DatabaseStatus.UNLOADED:
+                    self.load_database(db.name)
+                return db.name
+        slug = self.upload_database(source, name=name)["slug"]
+        setup = self.get_setup(slug)
+        if not setup.get("isReady", False):
+            missing = setup.get("missingSuppliers") or setup.get("unresolvedLinks") or []
+            raise VoLCAError(
+                f"ensure_database: uploaded {name!r} (slug {slug!r}) is not "
+                f"ready to finalize — unresolved dependencies: {missing!r}. "
+                "Wire them with add_dependency, then finalize_database."
+            )
+        self.finalize_database(slug)
+        return slug
 
     def get_setup(self, db_name: str | None = None) -> dict:
         """Setup status of a staged or loaded database (``DatabaseSetupInfo``).

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -994,12 +994,15 @@ class Client:
         (default: the file's stem), upload only when absent, finalize the
         staged copy, load if unloaded. Returns the slug every later call
         targets — run it at the top of a script and it converges on the same
-        loaded database every time instead of re-uploading.
+        loaded database every time instead of re-uploading. A match that is
+        already loaded — even partially linked — is left untouched.
 
-        A staged archive that is not ready to finalize (unresolved
-        dependencies) raises VoLCAError naming what is missing — wire the
-        dependencies with :meth:`add_dependency` and :meth:`finalize_database`
-        yourself in that case.
+        A staged copy that is not ready to finalize raises VoLCAError naming
+        the blocker (missing suppliers, no activities parsed) — fix it with
+        :meth:`add_dependency` or :meth:`set_data_path`, then
+        :meth:`finalize_database`. The gate also holds on re-runs: an upload
+        left staged by an earlier failed run goes through the same readiness
+        check instead of being loaded half-linked.
         """
         if name is None:
             if isinstance(source, bytes):
@@ -1010,19 +1013,48 @@ class Client:
         for db in self.list_databases():
             if name in (db.display_name, db.name):
                 if db.status == DatabaseStatus.UNLOADED:
-                    self.load_database(db.name)
+                    if db.is_uploaded:
+                        self._finalize_when_ready(db.name, name)
+                    else:
+                        self.load_database(db.name)
                 return db.name
         slug = self.upload_database(source, name=name)["slug"]
-        setup = self.get_setup(slug)
-        if not setup.get("isReady", False):
-            missing = setup.get("missingSuppliers") or setup.get("unresolvedLinks") or []
-            raise VoLCAError(
-                f"ensure_database: uploaded {name!r} (slug {slug!r}) is not "
-                f"ready to finalize — unresolved dependencies: {missing!r}. "
-                "Wire them with add_dependency, then finalize_database."
-            )
-        self.finalize_database(slug)
+        self._finalize_when_ready(slug, name)
         return slug
+
+    def _finalize_when_ready(self, slug: str, name: str) -> None:
+        """Readiness gate of :meth:`ensure_database`: finalize or refuse.
+
+        Finalizing builds the matrices and loads the database, so a staged
+        copy that ``get_setup`` reports not ready raises with the concrete
+        blocker instead — a half-linked database silently undercounts and
+        the consumer can't tell.
+        """
+        setup = self.get_setup(slug)
+        if setup.get("isReady", False):
+            self.finalize_database(slug)
+            return
+        missing = setup.get("missingSuppliers") or []
+        if missing:
+            blocker = (
+                f"missing suppliers {missing!r} — wire them with "
+                "add_dependency, then finalize_database"
+            )
+        elif not setup.get("activityCount"):
+            blocker = (
+                "no activities parsed — pick the data file with "
+                "set_data_path (see availablePaths in get_setup), "
+                "then finalize_database"
+            )
+        else:
+            blocker = (
+                f"{setup.get('unresolvedLinks')} unresolved links — "
+                "inspect get_setup"
+            )
+        raise VoLCAError(
+            f"ensure_database: {name!r} (slug {slug!r}) is not ready to "
+            f"finalize — {blocker}."
+        )
 
     def get_setup(self, db_name: str | None = None) -> dict:
         """Setup status of a staged or loaded database (``DatabaseSetupInfo``).

--- a/pyvolca/tests/test_ensure_database.py
+++ b/pyvolca/tests/test_ensure_database.py
@@ -1,0 +1,88 @@
+"""Offline orchestration tests for Client.ensure_database.
+
+The wire shape of each primitive (list/upload/setup/finalize/load) is covered
+by its own tests; these pin the idempotent orchestration: what gets called,
+in which mode, and what never gets called.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from volca.client import Client, VoLCAError
+from volca.types import DatabaseInfo, DatabaseStatus
+
+
+def _info(slug: str, display: str, status: DatabaseStatus) -> DatabaseInfo:
+    return DatabaseInfo(
+        name=slug, display_name=display, status=status, path=f"/data/{slug}"
+    )
+
+
+@pytest.fixture()
+def client() -> Client:
+    c = Client(base_url="http://test.local")
+    # Orchestration only: every primitive is replaced by a mock.
+    c.list_databases = mock.Mock(return_value=[])  # type: ignore[method-assign]
+    c.upload_database = mock.Mock(return_value={"slug": "fresh-1-0"})  # type: ignore[method-assign]
+    c.get_setup = mock.Mock(return_value={"isReady": True})  # type: ignore[method-assign]
+    c.finalize_database = mock.Mock(return_value={"success": True})  # type: ignore[method-assign]
+    c.load_database = mock.Mock(return_value={"success": True})  # type: ignore[method-assign]
+    return c
+
+
+def test_absent_database_is_uploaded_finalized(client: Client, tmp_path):
+    archive = tmp_path / "fresh-1.0.xlsx"
+    archive.write_bytes(b"x")
+    slug = client.ensure_database(str(archive))
+    assert slug == "fresh-1-0"
+    client.upload_database.assert_called_once_with(str(archive), name="fresh-1.0")
+    client.finalize_database.assert_called_once_with("fresh-1-0")
+    client.load_database.assert_not_called()
+
+
+def test_loaded_database_is_left_alone(client: Client):
+    client.list_databases.return_value = [
+        _info("fresh-1-0", "fresh-1.0", DatabaseStatus.LOADED)
+    ]
+    slug = client.ensure_database("ignored/fresh-1.0.xlsx")
+    assert slug == "fresh-1-0"
+    client.upload_database.assert_not_called()
+    client.finalize_database.assert_not_called()
+    client.load_database.assert_not_called()
+
+
+def test_unloaded_database_is_loaded_not_reuploaded(client: Client):
+    client.list_databases.return_value = [
+        _info("fresh-1-0", "fresh-1.0", DatabaseStatus.UNLOADED)
+    ]
+    slug = client.ensure_database("ignored/fresh-1.0.xlsx")
+    assert slug == "fresh-1-0"
+    client.upload_database.assert_not_called()
+    client.load_database.assert_called_once_with("fresh-1-0")
+
+
+def test_match_by_slug_works_too(client: Client):
+    client.list_databases.return_value = [
+        _info("fresh-1-0", "Fresh database", DatabaseStatus.LOADED)
+    ]
+    assert client.ensure_database(b"raw", name="fresh-1-0") == "fresh-1-0"
+    client.upload_database.assert_not_called()
+
+
+def test_unready_upload_fails_before_finalize(client: Client):
+    client.get_setup.return_value = {
+        "isReady": False,
+        "missingSuppliers": ["ecoinvent-3.11"],
+    }
+    with pytest.raises(VoLCAError, match="ecoinvent-3.11"):
+        client.ensure_database("ignored/fresh-1.0.xlsx")
+    client.finalize_database.assert_not_called()
+
+
+def test_bytes_source_requires_a_name(client: Client):
+    with pytest.raises(VoLCAError, match="name= is required"):
+        client.ensure_database(b"raw bytes")
+    client.upload_database.assert_not_called()

--- a/pyvolca/tests/test_ensure_database.py
+++ b/pyvolca/tests/test_ensure_database.py
@@ -15,9 +15,15 @@ from volca.client import Client, VoLCAError
 from volca.types import DatabaseInfo, DatabaseStatus
 
 
-def _info(slug: str, display: str, status: DatabaseStatus) -> DatabaseInfo:
+def _info(
+    slug: str, display: str, status: DatabaseStatus, uploaded: bool = False
+) -> DatabaseInfo:
     return DatabaseInfo(
-        name=slug, display_name=display, status=status, path=f"/data/{slug}"
+        name=slug,
+        display_name=display,
+        status=status,
+        path=f"/data/{slug}",
+        is_uploaded=uploaded,
     )
 
 
@@ -78,6 +84,45 @@ def test_unready_upload_fails_before_finalize(client: Client):
         "missingSuppliers": ["ecoinvent-3.11"],
     }
     with pytest.raises(VoLCAError, match="ecoinvent-3.11"):
+        client.ensure_database("ignored/fresh-1.0.xlsx")
+    client.finalize_database.assert_not_called()
+
+
+def test_staged_leftover_goes_through_readiness_gate(client: Client):
+    """An upload left staged by an earlier failed run must not be blind-loaded.
+
+    Uploads register in the engine's database list immediately, before
+    finalize — so the name match finds them as unloaded. Loading one with
+    unresolved suppliers would silently produce a half-linked database.
+    """
+    client.list_databases.return_value = [
+        _info("fresh-1-0", "fresh-1.0", DatabaseStatus.UNLOADED, uploaded=True)
+    ]
+    client.get_setup.return_value = {
+        "isReady": False,
+        "missingSuppliers": ["ecoinvent-3.11"],
+    }
+    with pytest.raises(VoLCAError, match="ecoinvent-3.11"):
+        client.ensure_database("ignored/fresh-1.0.xlsx")
+    client.load_database.assert_not_called()
+    client.upload_database.assert_not_called()
+    client.finalize_database.assert_not_called()
+
+
+def test_staged_leftover_ready_is_finalized_not_loaded(client: Client):
+    client.list_databases.return_value = [
+        _info("fresh-1-0", "fresh-1.0", DatabaseStatus.UNLOADED, uploaded=True)
+    ]
+    slug = client.ensure_database("ignored/fresh-1.0.xlsx")
+    assert slug == "fresh-1-0"
+    client.upload_database.assert_not_called()
+    client.load_database.assert_not_called()
+    client.finalize_database.assert_called_once_with("fresh-1-0")
+
+
+def test_no_activities_names_the_data_path_remedy(client: Client):
+    client.get_setup.return_value = {"isReady": False, "activityCount": 0}
+    with pytest.raises(VoLCAError, match="set_data_path"):
         client.ensure_database("ignored/fresh-1.0.xlsx")
     client.finalize_database.assert_not_called()
 


### PR DESCRIPTION
Every script that feeds the engine its own data hand-rolls the same state machine: list databases, match by display name, upload when absent, finalize the staged copy, load when unloaded. Three copies of it exist in the wild (two in ecobalyse-method-tooling, one in the canonical converter's ancestry) and each re-uploads or half-configures in some corner case.

`ensure_database(source, name=…)` is that state machine as one call, returning the slug it converged on. A staged archive that is not ready to finalize (unresolved dependencies) raises with the missing names instead of finalizing a broken database.

Verified end-to-end against a locally built v0.9.3: first call uploads, finalizes and loads an EcoSpold 2 fixture (status `loaded`, activities queryable); the second call returns the same slug without re-uploading. 236 tests green (6 new orchestration specs).