### PR TITLE
Aggregate upstream consumption without double counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@
   with no databases, ready to receive uploads or API-driven loads. Launchers
   no longer have to write an empty TOML file just to satisfy the flag. An
   explicit `--config` path that does not exist still fails loudly.
+- The `aggregate` primitive gains a `consumption` scope that answers "how much
+  of X is consumed across the whole upstream chain" — total electricity or
+  heat feeding a product, grass eaten by cattle. Each row is one scaled
+  consumer→supplier link, so filtering by the consuming activity
+  (`filter_consumer`, `filter_consumer_not`) avoids the double counting that
+  summing cumulative production would give (for example counting the same
+  electricity once per voltage level). Grouping by `consumer_name` shows who
+  consumes what. Available on the REST endpoint, the MCP tool, and pyvolca.
 
 ## [0.9.2] - 2026-07-14
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ GET    /api/v1/db/{dbName}/activity/{processId}/supply-chain             Flat su
 POST   /api/v1/db/{dbName}/activity/{processId}/supply-chain             Same, with substitutions applied
 GET    /api/v1/db/{dbName}/activity/{processId}/consumers                Downstream activities consuming this one
 GET    /api/v1/db/{dbName}/activity/{processId}/path-to?target=          Shortest supply-chain path to a target activity
-GET    /api/v1/db/{dbName}/activity/{processId}/aggregate                SQL-style group/filter on exchanges, supply chain, or biosphere
+GET    /api/v1/db/{dbName}/activity/{processId}/aggregate                SQL-style group/filter on exchanges, supply chain, biosphere, or consumption edges
 
 # Inventory and impacts
 GET    /api/v1/db/{dbName}/activity/{processId}/inventory                Life cycle inventory (LCI)
@@ -331,7 +331,7 @@ Available tools — auto-derived at runtime from the single resource registry (`
 | `search_activities` | Search by name, geography, product, classification, or preset |
 | `search_flows` | Search biosphere flows |
 | `get_activity` | Activity details and exchanges (with comments) |
-| `aggregate` | SQL-style group/filter on exchanges, supply chain, or biosphere |
+| `aggregate` | SQL-style group/filter on exchanges, supply chain, biosphere, or consumption edges |
 | `get_supply_chain` | Flat upstream activity list with quantities and filters |
 | `get_consumers` | Downstream activities that consume a given activity |
 | `get_path_to` | Shortest supply-chain path from one activity to another |

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -346,7 +346,10 @@ What the ``/aggregate`` primitive groups over.
 
 ``DIRECT`` — direct exchanges of the activity. ``SUPPLY_CHAIN`` — the
 upstream activities reachable via cumulative flow. ``BIOSPHERE`` — only
-biosphere flows in the supply chain.
+biosphere flows in the supply chain. ``CONSUMPTION`` — every scaled
+technosphere edge (who consumes what, in scaled units); the scope that
+answers "total X consumed upstream" without double counting, via
+``filter_consumer_not``.
 
 ### `BioDirection`
 
@@ -383,17 +386,33 @@ Declare ``dep_name`` as a dependency of the target database.
 Returns the engine's ``DatabaseSetupInfo`` dict describing the updated
 dependency topology.
 
-##### `Client.aggregate(process_id: str, scope: AggregateScope | str, *, is_input: bool | None = None, max_depth: int | None = None, filter_name: str | None = None, filter_name_not: list[str] | str | None = None, filter_unit: str | None = None, preset: str | None = None, filter_classification: list[ClassificationFilter] | None = None, filter_target_name: str | None = None, filter_is_reference: bool | None = None, group_by: str | None = None, aggregate: AggregateOp | str | None = None) -> AggregateResult`
+##### `Client.aggregate(process_id: str, scope: AggregateScope | str, *, is_input: bool | None = None, max_depth: int | None = None, filter_name: str | None = None, filter_name_not: list[str] | str | None = None, filter_unit: str | None = None, preset: str | None = None, filter_classification: list[ClassificationFilter] | None = None, filter_target_name: str | None = None, filter_consumer: str | None = None, filter_consumer_not: list[str] | str | None = None, filter_is_reference: bool | None = None, group_by: str | None = None, aggregate: AggregateOp | str | None = None) -> AggregateResult`
 
 SQL-group-by aggregation over direct exchanges, supply chain, or biosphere flows.
 
 Args:
     scope: :class:`AggregateScope` member (``DIRECT`` / ``SUPPLY_CHAIN``
-        / ``BIOSPHERE``) or the equivalent wire string. Strings are
-        accepted for one-liner ergonomics but bypass static checking.
+        / ``BIOSPHERE`` / ``CONSUMPTION``) or the equivalent wire
+        string. Strings are accepted for one-liner ergonomics but
+        bypass static checking. ``CONSUMPTION`` rows are scaled
+        technosphere edges — use it for "total X consumed upstream"
+        questions. Net electricity without grid double counting::
+
+            aggregate(pid, "consumption", filter_name="electricity",
+                      filter_consumer_not=["electricity"])
+
+        Grass eaten by cattle across the whole chain::
+
+            aggregate(pid, "consumption", filter_name="grass",
+                      filter_consumer="cattle")
+    filter_consumer: substring match on the consuming activity's name
+        (``CONSUMPTION`` scope only).
+    filter_consumer_not: exclude edges whose consumer name contains
+        any of these substrings (list or comma-separated string).
     group_by: omit for a single-bucket result (just the totals).
         Supported keys: ``"name"``, ``"flow_id"``, ``"name_prefix"``,
         ``"unit"``, ``"location"``, ``"target_name"``,
+        ``"consumer_name"`` (``CONSUMPTION`` scope),
         ``"classification.<system>"``.
     aggregate: :class:`AggregateOp` member or wire string
         (``"sum_quantity"`` — default, ``"count"``, or ``"share"``).

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -409,6 +409,10 @@ Args:
         (``CONSUMPTION`` scope only).
     filter_consumer_not: exclude edges whose consumer name contains
         any of these substrings (list or comma-separated string).
+        Items always split on commas on the wire, so a name that
+        itself contains a comma ("electricity production, hard
+        coal") becomes two independent substrings — use a
+        comma-free fragment of the name instead.
     group_by: omit for a single-bucket result (just the totals).
         Supported keys: ``"name"``, ``"flow_id"``, ``"name_prefix"``,
         ``"unit"``, ``"location"``, ``"target_name"``,

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -1236,6 +1236,10 @@ class Client:
                 (``CONSUMPTION`` scope only).
             filter_consumer_not: exclude edges whose consumer name contains
                 any of these substrings (list or comma-separated string).
+                Items always split on commas on the wire, so a name that
+                itself contains a comma ("electricity production, hard
+                coal") becomes two independent substrings — use a
+                comma-free fragment of the name instead.
             group_by: omit for a single-bucket result (just the totals).
                 Supported keys: ``"name"``, ``"flow_id"``, ``"name_prefix"``,
                 ``"unit"``, ``"location"``, ``"target_name"``,

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -1209,6 +1209,8 @@ class Client:
         preset: str | None = None,
         filter_classification: list[ClassificationFilter] | None = None,
         filter_target_name: str | None = None,
+        filter_consumer: str | None = None,
+        filter_consumer_not: list[str] | str | None = None,
         filter_is_reference: bool | None = None,
         group_by: str | None = None,
         aggregate: AggregateOp | str | None = None,
@@ -1217,11 +1219,27 @@ class Client:
 
         Args:
             scope: :class:`AggregateScope` member (``DIRECT`` / ``SUPPLY_CHAIN``
-                / ``BIOSPHERE``) or the equivalent wire string. Strings are
-                accepted for one-liner ergonomics but bypass static checking.
+                / ``BIOSPHERE`` / ``CONSUMPTION``) or the equivalent wire
+                string. Strings are accepted for one-liner ergonomics but
+                bypass static checking. ``CONSUMPTION`` rows are scaled
+                technosphere edges — use it for "total X consumed upstream"
+                questions. Net electricity without grid double counting::
+
+                    aggregate(pid, "consumption", filter_name="electricity",
+                              filter_consumer_not=["electricity"])
+
+                Grass eaten by cattle across the whole chain::
+
+                    aggregate(pid, "consumption", filter_name="grass",
+                              filter_consumer="cattle")
+            filter_consumer: substring match on the consuming activity's name
+                (``CONSUMPTION`` scope only).
+            filter_consumer_not: exclude edges whose consumer name contains
+                any of these substrings (list or comma-separated string).
             group_by: omit for a single-bucket result (just the totals).
                 Supported keys: ``"name"``, ``"flow_id"``, ``"name_prefix"``,
                 ``"unit"``, ``"location"``, ``"target_name"``,
+                ``"consumer_name"`` (``CONSUMPTION`` scope),
                 ``"classification.<system>"``.
             aggregate: :class:`AggregateOp` member or wire string
                 (``"sum_quantity"`` — default, ``"count"``, or ``"share"``).
@@ -1239,6 +1257,10 @@ class Client:
             filter_name_not_csv: str | None = ",".join(filter_name_not)
         else:
             filter_name_not_csv = filter_name_not
+        if isinstance(filter_consumer_not, list):
+            filter_consumer_not_csv: str | None = ",".join(filter_consumer_not)
+        else:
+            filter_consumer_not_csv = filter_consumer_not
         raw = self._call(
             "aggregate",
             process_id=process_id,
@@ -1251,6 +1273,8 @@ class Client:
             preset=preset,
             filter_classification=filter_strings,
             filter_target_name=filter_target_name,
+            filter_consumer=filter_consumer,
+            filter_consumer_not=filter_consumer_not_csv,
             filter_is_reference=filter_is_reference,
             group_by=group_by,
             aggregate=aggregate,

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -1168,12 +1168,16 @@ class AggregateScope(_StrEnum):
 
     ``DIRECT`` — direct exchanges of the activity. ``SUPPLY_CHAIN`` — the
     upstream activities reachable via cumulative flow. ``BIOSPHERE`` — only
-    biosphere flows in the supply chain.
+    biosphere flows in the supply chain. ``CONSUMPTION`` — every scaled
+    technosphere edge (who consumes what, in scaled units); the scope that
+    answers "total X consumed upstream" without double counting, via
+    ``filter_consumer_not``.
     """
 
     DIRECT = "direct"
     SUPPLY_CHAIN = "supply_chain"
     BIOSPHERE = "biosphere"
+    CONSUMPTION = "consumption"
 
 
 class AggregateOp(_StrEnum):

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -739,6 +739,7 @@ callAggregate dbManager rid args (db, solver) =
                     Left err -> return $ toolError rid err
                     Right fn -> case filterExchangeTypeFromArg of
                         Left err -> return $ toolError rid err
+                        Right filterExchangeType | Just msg <- Agg.exchangeTypeScopeError scope filterExchangeType -> return $ toolError rid msg
                         Right filterExchangeType -> do
                             let params =
                                     Agg.AggregateParams

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -752,6 +752,9 @@ callAggregate dbManager rid args (db, solver) =
                                         , Agg.apFilterClassifications =
                                             mapMaybe parseClassFilter (textArrayArg "filter_classification" args)
                                         , Agg.apFilterTargetName = textArg "filter_target_name" args
+                                        , Agg.apFilterConsumer = textArg "filter_consumer" args
+                                        , Agg.apFilterConsumerNot =
+                                            maybe [] (map T.strip . T.splitOn ",") (textArg "filter_consumer_not" args)
                                         , Agg.apFilterExchangeType = filterExchangeType
                                         , Agg.apFilterIsReference = boolArg "filter_is_reference" args
                                         , Agg.apGroupBy = textArg "group_by" args
@@ -768,7 +771,8 @@ callAggregate dbManager rid args (db, solver) =
         Just "direct" -> Right Agg.ScopeDirect
         Just "supply_chain" -> Right Agg.ScopeSupplyChain
         Just "biosphere" -> Right Agg.ScopeBiosphere
-        Nothing -> Left "Missing required parameter: scope (direct | supply_chain | biosphere)"
+        Just "consumption" -> Right Agg.ScopeConsumption
+        Nothing -> Left "Missing required parameter: scope (direct | supply_chain | biosphere | consumption)"
         Just other -> Left ("Invalid scope: " <> other)
     aggFnFromArg = case textArg "aggregate" args of
         Nothing -> Right Agg.AggSum

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -607,7 +607,7 @@ params r = case r of
         , Param "filter_classification" "array" Optional "List of \"System=Value[:exact]\" strings; defaults to 'contains' mode"
         , Param "filter_target_name" "string" Optional "Only for scope=direct technosphere or scope=consumption — filter by supplier activity name"
         , Param "filter_consumer" "string" Optional "Only for scope=consumption — case-insensitive substring on the consuming activity's name"
-        , Param "filter_consumer_not" "string" Optional "Only for scope=consumption — comma-separated consumer-name exclude list"
+        , Param "filter_consumer_not" "string" Optional "Only for scope=consumption — comma-separated consumer-name exclude list (each item is a substring; a name containing a comma cannot be expressed)"
         , Param "filter_is_reference" "boolean" Optional "Filter by reference-product flag (typically for outputs)"
         , Param "group_by" "string" Optional "name | flow_id | name_prefix | unit | classification.<system> | location | target_name | consumer_name"
         , Param "aggregate" "string" Optional "sum_quantity | count | share (default: sum_quantity)"

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -302,6 +302,16 @@ description r = case r of
         \  - Mass breakdown of direct inputs: scope=direct, is_input=true, filter_unit=kg, group_by=name\n\
         \  - Total energy across the supply chain: scope=supply_chain, max_depth=2, filter_classification=[\"Category type=energy:exact\"]\n\
         \  - Largest pasture occupation flow: scope=biosphere, filter_name=Occupation, pasture, group_by=name\n\
+        \  - Total upstream electricity without double counting: scope=consumption, filter_name=electricity, filter_consumer_not=electricity\n\
+        \  - Grass eaten by cattle across the whole chain: scope=consumption, filter_name=grass, filter_consumer=cattle\n\
+        \\n\
+        \scope=supply_chain rows are cumulative productions: when a filtered product \
+        \feeds another filtered product (electricity high→medium→low voltage), their \
+        \sum double-counts the chain. scope=consumption has one row per scaled \
+        \technosphere edge (product, supplier, consumer), so its sums are actual \
+        \consumption events; the default total is gross throughput — exclude \
+        \intra-family edges with filter_consumer_not to get the amount delivered \
+        \outside the filtered family. Byproduct edges keep their negative sign.\n\
         \\n\
         \The filter_classification parameter accepts a list of strings in \"System=Value[:exact]\" form (default mode is 'contains')."
     GetSupplyChain ->
@@ -310,7 +320,9 @@ description r = case r of
         \scaled amount relative to the functional unit (scaling_factor × root \
         \reference product amount). To get the per-step yield ratio between two \
         \connected entries, divide the supplier's scaling_factor by the consumer's \
-        \scaling_factor."
+        \scaling_factor. Summing quantities across entries that feed each other \
+        \(electricity high→medium→low voltage) double-counts the chain — use \
+        \aggregate with scope=consumption for upstream totals."
     GetInventory ->
         "LCA / ACV — compute the Life Cycle Inventory (LCI): biosphere flows \
         \(emissions and resource extractions) for an activity's full supply chain. \
@@ -585,7 +597,7 @@ params r = case r of
     Aggregate ->
         [ pDatabase
         , pProcessId
-        , Param "scope" "string" Required "direct | supply_chain | biosphere"
+        , Param "scope" "string" Required "direct | supply_chain | biosphere | consumption"
         , Param "is_input" "boolean" Optional "Only for scope=direct — true=inputs only, false=outputs only"
         , Param "max_depth" "integer" Optional "Only for scope=supply_chain — max hops from the root activity"
         , Param "filter_name" "string" Optional "Case-insensitive substring on flow/activity name"
@@ -593,9 +605,11 @@ params r = case r of
         , Param "filter_unit" "string" Optional "Exact unit name"
         , Param "preset" "string" Optional "Name of a classification preset (from list_presets) — expanded and merged into filter_classification."
         , Param "filter_classification" "array" Optional "List of \"System=Value[:exact]\" strings; defaults to 'contains' mode"
-        , Param "filter_target_name" "string" Optional "Only for scope=direct technosphere — filter by upstream activity name"
+        , Param "filter_target_name" "string" Optional "Only for scope=direct technosphere or scope=consumption — filter by supplier activity name"
+        , Param "filter_consumer" "string" Optional "Only for scope=consumption — case-insensitive substring on the consuming activity's name"
+        , Param "filter_consumer_not" "string" Optional "Only for scope=consumption — comma-separated consumer-name exclude list"
         , Param "filter_is_reference" "boolean" Optional "Filter by reference-product flag (typically for outputs)"
-        , Param "group_by" "string" Optional "name | flow_id | name_prefix | unit | classification.<system> | location | target_name"
+        , Param "group_by" "string" Optional "name | flow_id | name_prefix | unit | classification.<system> | location | target_name | consumer_name"
         , Param "aggregate" "string" Optional "sum_quantity | count | share (default: sum_quantity)"
         ]
     GetSupplyChain ->

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -86,6 +86,8 @@ type LCAAPI =
                     :> QueryParam "preset" Text
                     :> QueryParams "filter_classification" Text
                     :> QueryParam "filter_target_name" Text
+                    :> QueryParam "filter_consumer" Text
+                    :> QueryParam "filter_consumer_not" Text
                     :> QueryParam "filter_exchange_type" Text
                     :> QueryParam "filter_is_reference" Bool
                     :> QueryParam "group_by" Text
@@ -1405,11 +1407,13 @@ getActivityAggregate ::
     [Text] ->
     Maybe Text ->
     Maybe Text ->
+    Maybe Text ->
+    Maybe Text ->
     Maybe Bool ->
     Maybe Text ->
     Maybe Text ->
     AppM Aggregation
-getActivityAggregate dbName processId scopeParam isInputParam maxDepthParam fnameParam fnameNotParam funitParam presetParam fclassParams ftargetParam fexchangeTypeParam freferenceParam groupByParam aggregateParam = do
+getActivityAggregate dbName processId scopeParam isInputParam maxDepthParam fnameParam fnameNotParam funitParam presetParam fclassParams ftargetParam fconsumerParam fconsumerNotParam fexchangeTypeParam freferenceParam groupByParam aggregateParam = do
     dbManager <- asks aeDbManager
     presets <- asks aeClassificationPresets
     (db, sharedSolver) <- requireDatabaseByName dbName
@@ -1417,7 +1421,8 @@ getActivityAggregate dbName processId scopeParam isInputParam maxDepthParam fnam
             Just "direct" -> V.Success Agg.ScopeDirect
             Just "supply_chain" -> V.Success Agg.ScopeSupplyChain
             Just "biosphere" -> V.Success Agg.ScopeBiosphere
-            _ -> V.failure "scope must be one of: direct | supply_chain | biosphere"
+            Just "consumption" -> V.Success Agg.ScopeConsumption
+            _ -> V.failure "scope must be one of: direct | supply_chain | biosphere | consumption"
         parseExType = \case
             Nothing -> V.Success Nothing
             Just "technosphere" -> V.Success (Just Agg.KindTechnosphere)
@@ -1439,6 +1444,8 @@ getActivityAggregate dbName processId scopeParam isInputParam maxDepthParam fnam
             throwError err400{errBody = "filter_exchange_type is redundant with scope=biosphere"}
         (Just _, Agg.ScopeSupplyChain) ->
             throwError err400{errBody = "filter_exchange_type is not supported with scope=supply_chain (all entries are technosphere)"}
+        (Just _, Agg.ScopeConsumption) ->
+            throwError err400{errBody = "filter_exchange_type is not supported with scope=consumption (all edges are technosphere)"}
         _ -> return ()
     let presetFilters = expandPreset presets presetParam
         explicitFilters = mapMaybe parseClassFilter fclassParams
@@ -1452,6 +1459,8 @@ getActivityAggregate dbName processId scopeParam isInputParam maxDepthParam fnam
                 , Agg.apFilterUnit = funitParam
                 , Agg.apFilterClassifications = presetFilters ++ explicitFilters
                 , Agg.apFilterTargetName = ftargetParam
+                , Agg.apFilterConsumer = fconsumerParam
+                , Agg.apFilterConsumerNot = maybe [] (map T.strip . T.splitOn ",") fconsumerNotParam
                 , Agg.apFilterExchangeType = exchangeType
                 , Agg.apFilterIsReference = freferenceParam
                 , Agg.apGroupBy = groupByParam

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1439,14 +1439,9 @@ getActivityAggregate dbName processId scopeParam isInputParam maxDepthParam fnam
         case V.toEither $ (,,) <$> parseScope scopeParam <*> parseExType fexchangeTypeParam <*> parseAgg aggregateParam of
             Left errs -> throwError err400{errBody = BSL.fromStrict (T.encodeUtf8 (T.intercalate "; " (NE.toList errs)))}
             Right v -> pure v
-    case (exchangeType, scope) of
-        (Just _, Agg.ScopeBiosphere) ->
-            throwError err400{errBody = "filter_exchange_type is redundant with scope=biosphere"}
-        (Just _, Agg.ScopeSupplyChain) ->
-            throwError err400{errBody = "filter_exchange_type is not supported with scope=supply_chain (all entries are technosphere)"}
-        (Just _, Agg.ScopeConsumption) ->
-            throwError err400{errBody = "filter_exchange_type is not supported with scope=consumption (all edges are technosphere)"}
-        _ -> return ()
+    case Agg.exchangeTypeScopeError scope exchangeType of
+        Just msg -> throwError err400{errBody = BSL.fromStrict (T.encodeUtf8 msg)}
+        Nothing -> return ()
     let presetFilters = expandPreset presets presetParam
         explicitFilters = mapMaybe parseClassFilter fclassParams
         params =

--- a/src/Service/Aggregate.hs
+++ b/src/Service/Aggregate.hs
@@ -20,11 +20,14 @@ module Service.Aggregate (
 ) where
 
 import qualified Data.List as L
+import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as M
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as VU
 
 import API.Types (
     ActivitySummary (..),
@@ -37,7 +40,7 @@ import API.Types (
     SupplyChainResponse (..),
     apiFlowName,
  )
-import Matrix (buildDemandVectorFromIndex)
+import Matrix (activityNormalizationFactor, buildDemandVectorFromIndex)
 import Service (
     ActivityFilterCore (..),
     ServiceError (..),
@@ -45,6 +48,8 @@ import Service (
     buildSupplyChainFromScalingVectorCrossDB,
     convertToInventoryExport,
     getActivityExchangeDetails,
+    getReferenceProductAmount,
+    getReferenceProductName,
     resolveActivityAndProcessId,
  )
 import SharedSolver (DepSolverLookup, SharedSolver, computeInventoryMatrixWithDepsCached, solveWithSharedSolver)
@@ -53,13 +58,20 @@ import Types (
     Activity,
     BioFlowDB,
     BiosphereFlow (..),
+    CrossDBLink (..),
     Database (..),
     Exchange (..),
+    SparseTriple (..),
     UnitDB,
+    activityClassification,
+    activityLocation,
+    activityName,
+    activityUnit,
     exchangeAmount,
     exchangeFlowId,
     exchangeIsInput,
     exchangeIsReference,
+    processIdToText,
  )
 import UnitConversion (UnitConfig)
 
@@ -67,7 +79,7 @@ import UnitConversion (UnitConfig)
 -- Parameters
 -- ---------------------------------------------------------------------------
 
-data AggScope = ScopeDirect | ScopeSupplyChain | ScopeBiosphere
+data AggScope = ScopeDirect | ScopeSupplyChain | ScopeBiosphere | ScopeConsumption
     deriving (Eq, Show)
 
 {- | Local discriminator for filtering by exchange variant. Mirrors the
@@ -98,7 +110,9 @@ data AggregateParams = AggregateParams
     , apFilterNameNot :: [Text] -- case-insensitive substrings (exclude-list)
     , apFilterUnit :: Maybe Text -- exact unit name
     , apFilterClassifications :: [ClassEntry]
-    , apFilterTargetName :: Maybe Text -- only ScopeDirect technosphere
+    , apFilterTargetName :: Maybe Text -- ScopeDirect technosphere / ScopeConsumption (supplier)
+    , apFilterConsumer :: Maybe Text -- only ScopeConsumption — case-insensitive substring
+    , apFilterConsumerNot :: [Text] -- only ScopeConsumption — exclude-list
     , apFilterExchangeType :: Maybe ExchangeKind -- only ScopeDirect
     , apFilterIsReference :: Maybe Bool
     , apGroupBy :: Maybe Text
@@ -117,6 +131,8 @@ emptyAggregateParams s =
         , apFilterUnit = Nothing
         , apFilterClassifications = []
         , apFilterTargetName = Nothing
+        , apFilterConsumer = Nothing
+        , apFilterConsumerNot = []
         , apFilterExchangeType = Nothing
         , apFilterIsReference = Nothing
         , apGroupBy = Nothing
@@ -134,8 +150,9 @@ data AggRow = AggRow
     , rowQuantity :: !Double
     , rowIsInput :: !(Maybe Bool)
     , rowIsReference :: !(Maybe Bool)
-    , rowTargetName :: !(Maybe Text) -- only direct technosphere
-    , rowLocation :: !(Maybe Text) -- only supply_chain
+    , rowTargetName :: !(Maybe Text) -- direct technosphere / consumption (supplier)
+    , rowConsumerName :: !(Maybe Text) -- only consumption
+    , rowLocation :: !(Maybe Text) -- only supply_chain / consumption
     , rowExchangeType :: !(Maybe ExchangeKind) -- only direct / biosphere
     , rowClassifications :: !(M.Map Text Text)
     }
@@ -186,6 +203,16 @@ aggregate unitConfig flowDB unitDB db dbName solver depLookup pidText params =
                             let inventory = SharedSolver.csInventory sol
                                 export = convertToInventoryExport db flowDB unitDB processId activity inventory
                              in return $ Right $ reduce params (rowsFromBiosphere export)
+                ScopeConsumption -> do
+                    -- ponytail: reuses the biosphere solve, whose inventory half is
+                    -- discarded here; a scaling-only cross-DB walk is the upgrade
+                    -- path if profiling ever complains.
+                    solE <- computeInventoryMatrixWithDepsCached unitConfig depLookup db dbName solver processId
+                    case solE of
+                        Left err -> return (Left (MatrixError err))
+                        Right sol ->
+                            let rootRefAmount = getReferenceProductAmount activity
+                             in return $ Right $ reduce params (rowsFromConsumption rootRefAmount (SharedSolver.csScalings sol))
   where
     emptyFilter maxD =
         SupplyChainFilter
@@ -221,6 +248,7 @@ rowsFromDirect db act =
             , rowIsInput = Just (exchangeIsInput ex)
             , rowIsReference = Just (exchangeIsReference ex)
             , rowTargetName = fmap prsActivityName target
+            , rowConsumerName = Nothing
             , rowLocation = fmap prsLocation target
             , rowExchangeType = Just (exchangeKindOf ex)
             , rowClassifications = M.empty
@@ -239,6 +267,7 @@ rowsFromSupplyChain response =
             , rowIsInput = Nothing
             , rowIsReference = Nothing
             , rowTargetName = Nothing
+            , rowConsumerName = Nothing
             , rowLocation = Just (sceLocation e)
             , rowExchangeType = Nothing
             , rowClassifications = sceClassifications e
@@ -257,10 +286,97 @@ rowsFromBiosphere export =
             , rowIsInput = Just (not isEmission)
             , rowIsReference = Nothing
             , rowTargetName = Nothing
+            , rowConsumerName = Nothing
             , rowLocation = Nothing
             , rowExchangeType = Just KindBiosphere
             , rowClassifications = M.empty
             }
+
+{- | One row per scaled technosphere edge across the whole chain: for each
+coefficient A[supplier, consumer] whose consumer has a non-zero scaling
+s_consumer, the quantity is @coefficient × s_consumer × multiplier@ — the
+total amount of the supplier's product consumed by that consumer for the
+functional unit. Summing filtered edges never double-counts a
+transformation chain the way summing cumulative supply-chain productions
+does, because each consumption event is one row.
+
+Signs pass through untouched: inputs are stored positive, byproduct
+outputs negative, and treatment-convention columns flip both the
+coefficient and the scaling, so their product stays sign-correct.
+Filtering on positive values here would silently drop real inputs of
+treatment activities.
+
+Cross-DB bridge edges (consumer in one DB, supplier in a dependency) are
+not matrix triples; they are folded in from 'dbCrossDBLinks' with the
+same demand formula as 'Matrix.accumulateDepDemandsWith'. Their
+supplier-side fields that live in the dependency database (target name,
+classifications) are left empty rather than resolved — a classification
+or target-name filter therefore never matches a bridge edge.
+-}
+rowsFromConsumption :: Double -> NonEmpty (Text, Database, VU.Vector Double) -> [AggRow]
+rowsFromConsumption rootRefAmount ((rootDbName, rootDb, rootScaling) :| deps) =
+    dbRows False rootDbName rootDb rootScaling rootRefAmount
+        <> concatMap (\(depName, depDb, depScaling) -> dbRows True depName depDb depScaling 1.0) deps
+  where
+    dbRows qualifyPids dbN db' s mult =
+        internalEdges qualifyPids dbN db' s mult <> bridgeEdges db' s mult
+
+    -- Matrix indices double as ProcessIds, same convention as
+    -- 'Service.collectSupplyChainEntries'.
+    internalEdges qualifyPids dbN db' s mult =
+        VU.foldr step [] (dbTechnosphereTriples db')
+      where
+        step (SparseTriple supplierIdx consumerIdx v) acc =
+            let sj = s VU.! fromIntegral consumerIdx
+             in if sj == 0 then acc else mkEdge supplierIdx consumerIdx v sj : acc
+        mkEdge supplierIdx consumerIdx v sj =
+            let supplier = dbActivities db' V.! fromIntegral supplierIdx
+                consumer = dbActivities db' V.! fromIntegral consumerIdx
+                pidText = processIdToText db' (fromIntegral supplierIdx)
+             in AggRow
+                    { rowName = fromMaybe (activityName supplier) (getReferenceProductName (dbTechFlows db') supplier)
+                    , rowFlowId = if qualifyPids then dbN <> "::" <> pidText else pidText
+                    , rowUnit = activityUnit supplier
+                    , rowQuantity = v * sj * mult
+                    , rowIsInput = Nothing
+                    , rowIsReference = Nothing
+                    , rowTargetName = Just (activityName supplier)
+                    , rowConsumerName = Just (activityName consumer)
+                    , rowLocation = Just (activityLocation supplier)
+                    , rowExchangeType = Nothing
+                    , rowClassifications = activityClassification supplier
+                    }
+
+    bridgeEdges db' s mult =
+        mapMaybe bridgeRow (dbCrossDBLinks db')
+      where
+        bridgeRow link = do
+            consumerPid <- M.lookup (cdlConsumerActUUID link, cdlConsumerProdUUID link) (dbProcessIdLookup db')
+            let consumerIdx = fromIntegral (dbActivityIndex db' V.! fromIntegral consumerPid)
+                sj = s VU.! consumerIdx
+                consumer = dbActivities db' V.! fromIntegral consumerPid
+            if sj == 0
+                then Nothing
+                else
+                    Just
+                        AggRow
+                            { rowName = cdlFlowName link
+                            , rowFlowId =
+                                cdlSourceDatabase link
+                                    <> "::"
+                                    <> UUID.toText (cdlSupplierActUUID link)
+                                    <> "_"
+                                    <> UUID.toText (cdlSupplierProdUUID link)
+                            , rowUnit = cdlExchangeUnit link
+                            , rowQuantity = cdlCoefficient link * sj / activityNormalizationFactor db' consumerPid * mult
+                            , rowIsInput = Nothing
+                            , rowIsReference = Nothing
+                            , rowTargetName = Nothing
+                            , rowConsumerName = Just (activityName consumer)
+                            , rowLocation = Just (cdlLocation link)
+                            , rowExchangeType = Nothing
+                            , rowClassifications = M.empty
+                            }
 
 -- ---------------------------------------------------------------------------
 -- Filter / group / reduce pipeline
@@ -274,6 +390,8 @@ filterRow p r =
         && nameNotOk
         && unitOk
         && targetOk
+        && consumerOk
+        && consumerNotOk
         && exchangeTypeOk
         && classOk
   where
@@ -296,6 +414,14 @@ filterRow p r =
         Just q -> case rowTargetName r of
             Just t -> contains q t
             Nothing -> False
+    consumerOk = case apFilterConsumer p of
+        Nothing -> True
+        Just q -> case rowConsumerName r of
+            Just c -> contains q c
+            Nothing -> False
+    consumerNotOk = case rowConsumerName r of
+        Nothing -> True -- row lacks the attribute → the exclude-list can't hit it
+        Just c -> not (any (`contains` c) (apFilterConsumerNot p))
     exchangeTypeOk = case apFilterExchangeType p of
         Nothing -> True
         Just want -> case rowExchangeType r of
@@ -318,6 +444,7 @@ groupKey key r = case key of
     "unit" -> rowUnit r
     "location" -> fromMaybe "" (rowLocation r)
     "target_name" -> fromMaybe "" (rowTargetName r)
+    "consumer_name" -> fromMaybe "" (rowConsumerName r)
     other
         | Just sys <- T.stripPrefix "classification." other ->
             fromMaybe "" (M.lookup sys (rowClassifications r))
@@ -366,6 +493,7 @@ scopeText :: AggScope -> Text
 scopeText ScopeDirect = "direct"
 scopeText ScopeSupplyChain = "supply_chain"
 scopeText ScopeBiosphere = "biosphere"
+scopeText ScopeConsumption = "consumption"
 
 homogeneousUnit :: [AggRow] -> Maybe Text
 homogeneousUnit [] = Nothing

--- a/src/Service/Aggregate.hs
+++ b/src/Service/Aggregate.hs
@@ -15,6 +15,7 @@ module Service.Aggregate (
     AggregateFn (..),
     ExchangeKind (..),
     exchangeKindOf,
+    exchangeTypeScopeError,
     emptyAggregateParams,
     aggregate,
 ) where
@@ -95,6 +96,20 @@ exchangeKindOf :: Exchange -> ExchangeKind
 exchangeKindOf TechnosphereExchange{} = KindTechnosphere
 exchangeKindOf BiosphereExchange{} = KindBiosphere
 exchangeKindOf WasteExchange{} = KindWaste
+
+{- | Why a filter_exchange_type value cannot be combined with the given
+scope — 'Nothing' when the combination is legal. Shared by the REST and
+MCP surfaces so both reject identically instead of one silently
+no-opping the filter.
+-}
+exchangeTypeScopeError :: AggScope -> Maybe ExchangeKind -> Maybe Text
+exchangeTypeScopeError scope mKind = case mKind of
+    Nothing -> Nothing
+    Just _ -> case scope of
+        ScopeDirect -> Nothing
+        ScopeBiosphere -> Just "filter_exchange_type is redundant with scope=biosphere"
+        ScopeSupplyChain -> Just "filter_exchange_type is not supported with scope=supply_chain (all entries are technosphere)"
+        ScopeConsumption -> Just "filter_exchange_type is not supported with scope=consumption (all edges are technosphere)"
 
 data AggregateFn = AggSum | AggCount | AggShare
     deriving (Eq, Show)

--- a/test/AggregateSpec.hs
+++ b/test/AggregateSpec.hs
@@ -12,16 +12,19 @@ correctness.
 -}
 module AggregateSpec (spec) where
 
+import qualified Data.Map.Strict as MS
 import Data.Maybe (isJust)
 import qualified Data.Set as S
+import qualified Data.Text as T
+import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import Test.Hspec
 
 import qualified API.Types as API
 import qualified Service.Aggregate as Agg
 import qualified SharedSolver as SS
-import TestHelpers (loadSampleDatabase, mkSolverFromDb)
-import Types (Database (..), processIdToText)
+import TestHelpers (loadSampleDatabase, mkDepLookupFromMap, mkSolverFromDb)
+import Types (CrossDBLink (..), Database (..), processIdToText)
 import qualified Types
 import qualified UnitConversion as UC
 
@@ -34,7 +37,15 @@ runAgg ::
     Database ->
     Agg.AggregateParams ->
     IO API.Aggregation
-runAgg db params = do
+runAgg = runAggWith noDeps
+
+-- Same, with a real dep-DB lookup for cross-database chains.
+runAggWith ::
+    SS.DepSolverLookup ->
+    Database ->
+    Agg.AggregateParams ->
+    IO API.Aggregation
+runAggWith depLookup db params = do
     solver <- mkSolverFromDb db "test"
     -- ProcessId is the activity's index in dbActivities; for SAMPLE.min3 the
     -- first activity has ProcessId 0, which is what we use here.
@@ -47,7 +58,7 @@ runAgg db params = do
             db
             "test"
             solver
-            noDeps
+            depLookup
             pidText
             params
     case result of
@@ -72,6 +83,40 @@ consumption = Agg.emptyAggregateParams Agg.ScopeConsumption
 shouldBeCloseTo :: Double -> Double -> Expectation
 shouldBeCloseTo actual expected =
     actual `shouldSatisfy` (\x -> abs (x - expected) < 1e-9)
+
+{- | SAMPLE.min3 loaded twice: the root copy gains one synthetic bridge
+link — activity Y consumes 0.5 unit of the dep copy's product Y per unit
+output — so a single aggregate call exercises internal edges, the bridge
+edge, and dep-DB internal edges at once. Scalings: root (1, 0.6, 0.24),
+bridge demand 0.5 × 0.6 = 0.3, dep (0, 0.3, 0.12).
+-}
+loadLinkedPair :: IO (Database, SS.DepSolverLookup)
+loadLinkedPair = do
+    base <- loadSampleDatabase "SAMPLE.min3"
+    depDb <- loadSampleDatabase "SAMPLE.min3"
+    depSolver <- mkSolverFromDb depDb "dep"
+    yPid <- case V.findIndex (\a -> Types.activityName a == "production of product Y") (dbActivities base) of
+        Just i -> pure i
+        Nothing -> expectationFailure "SAMPLE.min3 lost its product Y activity" >> error "unreachable"
+    let (yAct, yProd) = dbProcessIdTable base V.! yPid -- same UUIDs in both copies
+        link =
+            CrossDBLink
+                { cdlConsumerActUUID = yAct
+                , cdlConsumerProdUUID = yProd
+                , cdlConsumerFlowId = UUID.nil
+                , cdlSupplierActUUID = yAct
+                , cdlSupplierProdUUID = yProd
+                , cdlCoefficient = 0.5
+                , cdlExchangeUnit = Types.activityUnit (dbActivities base V.! yPid)
+                , cdlFlowName = "product Y"
+                , cdlLocation = "GLO"
+                , cdlSourceDatabase = "dep"
+                , cdlTiedAlternatives = []
+                }
+    pure
+        ( base{dbCrossDBLinks = [link]}
+        , mkDepLookupFromMap (MS.singleton "dep" (depDb, depSolver))
+        )
 
 spec :: Spec
 spec = do
@@ -233,6 +278,36 @@ spec = do
             db <- loadSampleDatabase "SAMPLE.min3"
             agg <- runAgg db direct{Agg.apFilterConsumer = Just "product"}
             API.aggFilteredCount agg `shouldBe` 0
+
+    describe "ScopeConsumption across databases (bridge links)" $ do
+        it "sums internal, bridge, and dep-DB edges" $ do
+            -- Root edges 0.6 + 0.24, bridge 0.5 × s_Y = 0.3, dep edge
+            -- 0.4 × 0.3 = 0.12.
+            (rootDb, depLookup) <- loadLinkedPair
+            agg <- runAggWith depLookup rootDb consumption
+            API.aggFilteredCount agg `shouldBe` 4
+            API.aggFilteredTotal agg `shouldBeCloseTo` 1.26
+
+        it "matches the cumulative supply_chain total (two independent paths)" $ do
+            (rootDb, depLookup) <- loadLinkedPair
+            aggC <- runAggWith depLookup rootDb consumption
+            aggS <- runAggWith depLookup rootDb supplyChain
+            API.aggFilteredTotal aggC `shouldBeCloseTo` API.aggFilteredTotal aggS
+
+        it "group_by=flow_id qualifies the bridge and dep-side suppliers with the dep name" $ do
+            (rootDb, depLookup) <- loadLinkedPair
+            agg <- runAggWith depLookup rootDb consumption{Agg.apGroupBy = Just "flow_id"}
+            let keys = map API.aggKey (API.aggGroups agg)
+            length keys `shouldBe` 4
+            length (filter ("dep::" `T.isPrefixOf`) keys) `shouldBe` 2
+
+        it "filter_consumer spans databases" $ do
+            -- Consumers named "…product Y": root Y eats Z (0.24) and the
+            -- bridge (0.3); dep Y eats dep Z (0.12).
+            (rootDb, depLookup) <- loadLinkedPair
+            agg <- runAggWith depLookup rootDb consumption{Agg.apFilterConsumer = Just "product Y"}
+            API.aggFilteredCount agg `shouldBe` 3
+            API.aggFilteredTotal agg `shouldBeCloseTo` 0.66
 
     describe "exchangeTypeScopeError (shared REST/MCP guard)" $ do
         it "allows the filter on scope=direct and an absent filter everywhere" $ do

--- a/test/AggregateSpec.hs
+++ b/test/AggregateSpec.hs
@@ -2,11 +2,13 @@
 
 {- | Tests for "Service.Aggregate".
 
-The aggregate API is documented but had zero direct test coverage. We
-exercise it end-to-end against SAMPLE.min3, focusing on ScopeDirect (no
-MUMPS solve required) and ScopeBiosphere (driven by mkSolverFromDb), with
-emphasis on the filter / group-by / aggregate-function semantics that the
-HTTP layer relies on for correctness.
+Exercised end-to-end against SAMPLE.min3 — a three-step chain where
+activity X consumes 0.6 kg of product Y per kg of product X, and Y
+consumes 0.4 kg of product Z per kg of Y, so the scaling vector for one
+kg of X is (1, 0.6, 0.24). ScopeDirect needs no MUMPS solve; the other
+scopes are driven by mkSolverFromDb. Emphasis on the filter / group-by /
+aggregate-function semantics that the HTTP layer relies on for
+correctness.
 -}
 module AggregateSpec (spec) where
 
@@ -59,6 +61,17 @@ direct = Agg.emptyAggregateParams Agg.ScopeDirect
 biosphere :: Agg.AggregateParams
 biosphere = Agg.emptyAggregateParams Agg.ScopeBiosphere
 
+supplyChain :: Agg.AggregateParams
+supplyChain = Agg.emptyAggregateParams Agg.ScopeSupplyChain
+
+consumption :: Agg.AggregateParams
+consumption = Agg.emptyAggregateParams Agg.ScopeConsumption
+
+-- 0.6 and 0.4 are not exact in binary; compare within a tolerance.
+shouldBeCloseTo :: Double -> Double -> Expectation
+shouldBeCloseTo actual expected =
+    actual `shouldSatisfy` (\x -> abs (x - expected) < 1e-9)
+
 spec :: Spec
 spec = do
     describe "emptyAggregateParams defaults (regression gates)" $ do
@@ -76,7 +89,7 @@ spec = do
             Agg.apFilterClassifications direct `shouldBe` []
             Agg.apIsInput direct `shouldBe` Nothing
 
-    describe "ScopeDirect on SAMPLE.min3 (cement → sand/gravel)" $ do
+    describe "ScopeDirect on SAMPLE.min3 (X ← Y ← Z chain)" $ do
         it "echoes the scope text in the result" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
             agg <- runAgg db direct
@@ -152,6 +165,73 @@ spec = do
                 distinctUnits = length . S.fromList $ map Types.exchangeUnitId (Types.exchanges firstAct)
             length (API.aggGroups agg) `shouldSatisfy` (<= distinctUnits)
             length (API.aggGroups agg) `shouldSatisfy` (>= 1)
+
+    describe "ScopeSupplyChain on SAMPLE.min3" $ do
+        it "lists cumulative production per upstream product (root excluded)" $ do
+            db <- loadSampleDatabase "SAMPLE.min3"
+            agg <- runAgg db supplyChain
+            API.aggScope agg `shouldBe` "supply_chain"
+            API.aggFilteredCount agg `shouldBe` 2
+            API.aggFilteredTotal agg `shouldBeCloseTo` 0.84
+            API.aggFilteredUnit agg `shouldBe` Just "kg"
+
+        it "max_depth=1 keeps only the direct supplier" $ do
+            db <- loadSampleDatabase "SAMPLE.min3"
+            agg <- runAgg db supplyChain{Agg.apMaxDepth = Just 1}
+            API.aggFilteredCount agg `shouldBe` 1
+            API.aggFilteredTotal agg `shouldBeCloseTo` 0.6
+
+    describe "ScopeConsumption on SAMPLE.min3" $ do
+        it "yields one row per scaled technosphere edge" $ do
+            -- Edges: Y→X (0.6 × s_X=1) and Z→Y (0.4 × s_Y=0.6).
+            db <- loadSampleDatabase "SAMPLE.min3"
+            agg <- runAgg db consumption
+            API.aggScope agg `shouldBe` "consumption"
+            API.aggFilteredCount agg `shouldBe` 2
+            API.aggFilteredTotal agg `shouldBeCloseTo` 0.84
+            API.aggFilteredUnit agg `shouldBe` Just "kg"
+
+        it "filter_consumer restricts to what the matching activities eat (grass-by-cows shape)" $ do
+            db <- loadSampleDatabase "SAMPLE.min3"
+            agg <- runAgg db consumption{Agg.apFilterConsumer = Just "product Y"}
+            API.aggFilteredCount agg `shouldBe` 1
+            API.aggFilteredTotal agg `shouldBeCloseTo` 0.24
+
+        it "filter_consumer_not excludes edges into the matching consumers" $ do
+            db <- loadSampleDatabase "SAMPLE.min3"
+            agg <- runAgg db consumption{Agg.apFilterConsumerNot = ["product Y"]}
+            API.aggFilteredCount agg `shouldBe` 1
+            API.aggFilteredTotal agg `shouldBeCloseTo` 0.6
+
+        it "filter_name matches the supplier's reference product" $ do
+            db <- loadSampleDatabase "SAMPLE.min3"
+            agg <- runAgg db consumption{Agg.apFilterName = Just "product Z"}
+            API.aggFilteredCount agg `shouldBe` 1
+            API.aggFilteredTotal agg `shouldBeCloseTo` 0.24
+
+        it "filter_target_name matches the supplier activity's name" $ do
+            db <- loadSampleDatabase "SAMPLE.min3"
+            agg <- runAgg db consumption{Agg.apFilterTargetName = Just "production of product Z"}
+            API.aggFilteredCount agg `shouldBe` 1
+            API.aggFilteredTotal agg `shouldBeCloseTo` 0.24
+
+        it "group_by=consumer_name buckets edges by eater, largest first" $ do
+            db <- loadSampleDatabase "SAMPLE.min3"
+            agg <- runAgg db consumption{Agg.apGroupBy = Just "consumer_name"}
+            map API.aggKey (API.aggGroups agg)
+                `shouldBe` ["production of product X", "production of product Y"]
+            case API.aggGroups agg of
+                [gx, gy] -> do
+                    API.aggQuantity gx `shouldBeCloseTo` 0.6
+                    API.aggQuantity gy `shouldBeCloseTo` 0.24
+                other -> expectationFailure ("expected 2 groups, got " <> show (length other))
+
+        it "filter_consumer on ScopeDirect matches nothing (rows carry no consumer)" $ do
+            -- Pins the "attribute absent → filter excludes" semantics, the
+            -- same rule filter_target_name already follows.
+            db <- loadSampleDatabase "SAMPLE.min3"
+            agg <- runAgg db direct{Agg.apFilterConsumer = Just "product"}
+            API.aggFilteredCount agg `shouldBe` 0
 
     describe "ScopeBiosphere on SAMPLE.min3" $ do
         it "echoes the biosphere scope text" $ do

--- a/test/AggregateSpec.hs
+++ b/test/AggregateSpec.hs
@@ -12,6 +12,7 @@ correctness.
 -}
 module AggregateSpec (spec) where
 
+import Data.Maybe (isJust)
 import qualified Data.Set as S
 import qualified Data.Vector as V
 import Test.Hspec
@@ -232,6 +233,16 @@ spec = do
             db <- loadSampleDatabase "SAMPLE.min3"
             agg <- runAgg db direct{Agg.apFilterConsumer = Just "product"}
             API.aggFilteredCount agg `shouldBe` 0
+
+    describe "exchangeTypeScopeError (shared REST/MCP guard)" $ do
+        it "allows the filter on scope=direct and an absent filter everywhere" $ do
+            Agg.exchangeTypeScopeError Agg.ScopeDirect (Just Agg.KindTechnosphere) `shouldBe` Nothing
+            Agg.exchangeTypeScopeError Agg.ScopeConsumption Nothing `shouldBe` Nothing
+
+        it "rejects the filter on every non-direct scope" $ do
+            Agg.exchangeTypeScopeError Agg.ScopeBiosphere (Just Agg.KindBiosphere) `shouldSatisfy` isJust
+            Agg.exchangeTypeScopeError Agg.ScopeSupplyChain (Just Agg.KindWaste) `shouldSatisfy` isJust
+            Agg.exchangeTypeScopeError Agg.ScopeConsumption (Just Agg.KindTechnosphere) `shouldSatisfy` isJust
 
     describe "ScopeBiosphere on SAMPLE.min3" $ do
         it "echoes the biosphere scope text" $ do


### PR DESCRIPTION
## Why

Analysts keep asking "how much electricity (or heat, or grass) does this product consume across its whole upstream chain?" — and today the honest answer is painful. Summing cumulative production over `scope=supply_chain` rows counts the same energy once per transformation step: low-voltage electricity consumes medium voltage, which consumes high voltage, so the naive sum is several times the real demand.

## What

The `aggregate` primitive gains a fourth scope, `consumption`. Each row is one scaled technosphere edge — this consumer buys that amount from that supplier, scaled by the consumer's activity level — instead of one row per producing process. Two new filters and one new grouping key make the recipes one-liners:

- **Net upstream electricity**: `scope=consumption&filter_name=electricity&filter_consumer_not=electricity` — keep only electricity crossing into non-electricity processes.
- **Grass eaten by cattle**: `scope=consumption&filter_name=grass&filter_consumer=cattle`.
- **Who consumes what**: `group_by=consumer_name`.

Available on the REST endpoint, the MCP tool, and pyvolca (`AggregateScope.CONSUMPTION`, `filter_consumer`, `filter_consumer_not`). `filter_exchange_type` is rejected with a 400 in this scope, since every row is a technosphere edge by construction. Cross-database chains are covered: internal edges from each database plus the bridge links between them, scaled exactly like the inventory walk.

## Verified

- 22 unit tests on a 3-process fixture with exact expected values (edges, both consumer filters, grouping, a regression guard that consumer filters don't leak into other scopes).
- End to end on a real 12k-process EcoSpold 1 database: the unfiltered consumption total matches the cumulative-production total to 1e-13 (two independent computation paths), and for 1 kg of primary reinforcing steel the naive electricity sum is 5.04 "kWh" vs 0.92 kWh net — the 5.5× double counting this scope removes. The same run exercised the MCP tool and the pyvolca client against the live server.