### PR TITLE
Add Client.resolve_activities, concurrent batch name resolution

### DIFF
--- a/pyvolca/CHANGELOG.md
+++ b/pyvolca/CHANGELOG.md
@@ -46,6 +46,12 @@ Then paste the rendered block at the top of this file and tighten wording.
   raises with the concrete blocker (missing suppliers, no activities
   parsed) — including an upload left staged by an earlier failed run, which
   goes through the same readiness gate instead of being loaded half-linked.
+- `Client.resolve_activities(names)` resolves a batch of activity (or
+  product) names to their matching activities with concurrent searches.
+  The returned mapping is total — a name that doesn't resolve maps to an
+  empty list instead of disappearing — and replaces the two patterns
+  scripts kept hand-rolling: downloading the whole database to build a
+  name→process_id dict, and per-name thread pools.
 
 ### Changed
 

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -838,6 +838,37 @@ Remove ``dep_name`` from the target database's dependencies.
 
 Returns the updated ``DatabaseSetupInfo`` dict.
 
+##### `Client.resolve_activities(names: Iterable[str], *, by: Literal['name', 'product'] = 'name', geo: str | None = None, exact: bool = True, limit: int = 5, workers: int = 8) -> dict[str, list[Activity]]`
+
+Resolve a batch of names to their matching activities, concurrently.
+
+One :meth:`search_activities` call per unique name, fanned out over
+``workers`` threads on the client's HTTP session. This replaces the
+two patterns scripts keep hand-rolling: downloading the whole
+database to build a name→process_id dict, and per-name thread pools.
+
+The result maps every input name to its matches — the mapping is
+total, so misses are visible, never silently dropped:
+
+* ``[]`` — no match; the name does not resolve.
+* one :class:`Activity` — unambiguous; ``matches[0].process_id``.
+* several — ambiguous (same name across geographies or products);
+  disambiguate with ``geo=`` or inspect the candidates.
+
+With ``exact=False`` matches are relevance-ranked (best first), so
+``matches[0]`` is the engine's best fuzzy guess.
+
+Args:
+    names: Names to resolve. Duplicates are searched once.
+    by: Match against activity ``"name"`` or reference ``"product"``.
+    geo: Restrict every search to one geography code.
+    exact: Exact (default) or substring/ranked matching.
+    limit: Maximum candidates returned per name.
+    workers: Concurrent searches.
+
+Returns:
+    ``{name: matches}`` for every input name, in input order.
+
 ##### `Client.score_activities(process_ids: list[str], *, collection: str = 'methods', top_flows: int | None = None, exclude_long_term: bool | None = None) -> BatchScores`
 
 Score many processes in one call (every category of a collection each).

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -41,9 +41,10 @@ from __future__ import annotations
 
 import urllib.parse
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from pathlib import Path
-from typing import Any, Literal, get_args
+from typing import Any, Iterable, Literal, get_args
 
 import requests
 
@@ -1191,6 +1192,68 @@ class Client:
 
         raw = fetch(wire_offset, wire_limit)
         return SearchResults.from_raw(raw, parse=Activity.from_json, fetch=fetch)
+
+    def resolve_activities(
+        self,
+        names: Iterable[str],
+        *,
+        by: Literal["name", "product"] = "name",
+        geo: str | None = None,
+        exact: bool = True,
+        limit: int = 5,
+        workers: int = 8,
+    ) -> dict[str, list[Activity]]:
+        """Resolve a batch of names to their matching activities, concurrently.
+
+        One :meth:`search_activities` call per unique name, fanned out over
+        ``workers`` threads on the client's HTTP session. This replaces the
+        two patterns scripts keep hand-rolling: downloading the whole
+        database to build a name→process_id dict, and per-name thread pools.
+
+        The result maps every input name to its matches — the mapping is
+        total, so misses are visible, never silently dropped:
+
+        * ``[]`` — no match; the name does not resolve.
+        * one :class:`Activity` — unambiguous; ``matches[0].process_id``.
+        * several — ambiguous (same name across geographies or products);
+          disambiguate with ``geo=`` or inspect the candidates.
+
+        With ``exact=False`` matches are relevance-ranked (best first), so
+        ``matches[0]`` is the engine's best fuzzy guess.
+
+        Args:
+            names: Names to resolve. Duplicates are searched once.
+            by: Match against activity ``"name"`` or reference ``"product"``.
+            geo: Restrict every search to one geography code.
+            exact: Exact (default) or substring/ranked matching.
+            limit: Maximum candidates returned per name.
+            workers: Concurrent searches.
+
+        Returns:
+            ``{name: matches}`` for every input name, in input order.
+        """
+        if by not in ("name", "product"):
+            raise VoLCAError(f"by= must be 'name' or 'product', got {by!r}")
+        unique = list(dict.fromkeys(names))
+        if not unique:
+            return {}
+
+        def search(n: str) -> list[Activity]:
+            kwargs: dict[str, Any] = {by: n}
+            matches = self.search_activities(
+                **kwargs, geo=geo, exact=exact, limit=limit
+            ).results
+            if exact:
+                # Engines released before the product filter honored exact=
+                # return substring matches; re-check equality (same casefold
+                # rule as the engine) so a near-miss never resolves silently.
+                want = n.casefold()
+                field = "activity_name" if by == "name" else "product_name"
+                matches = [a for a in matches if getattr(a, field).casefold() == want]
+            return matches
+
+        with ThreadPoolExecutor(max_workers=min(workers, len(unique))) as pool:
+            return dict(zip(unique, pool.map(search, unique)))
 
     def search_flows(
         self,

--- a/pyvolca/tests/test_resolve_activities.py
+++ b/pyvolca/tests/test_resolve_activities.py
@@ -1,0 +1,93 @@
+"""Offline orchestration tests for Client.resolve_activities.
+
+search_activities carries its own wire tests; these pin the batch
+orchestration: total mapping, dedup, argument passthrough, the client-side
+exactness guard, and fail-loud on errors.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from volca.client import Client, VoLCAError
+
+
+def _act(name: str, product: str = "p") -> SimpleNamespace:
+    return SimpleNamespace(activity_name=name, product_name=product)
+
+
+@pytest.fixture()
+def client() -> Client:
+    c = Client(base_url="http://test.local")
+    c.search_activities = mock.Mock(return_value=mock.Mock(results=[]))  # type: ignore[method-assign]
+    return c
+
+
+def test_mapping_is_total_and_ordered(client: Client):
+    wheat = _act("Wheat")
+    client.search_activities.side_effect = lambda **kw: mock.Mock(
+        results=[wheat] if kw.get("name") == "Wheat" else []
+    )
+    out = client.resolve_activities(["Rye", "Wheat"])
+    assert list(out) == ["Rye", "Wheat"]
+    assert out == {"Rye": [], "Wheat": [wheat]}
+
+
+def test_arguments_reach_search(client: Client):
+    client.resolve_activities(["Wheat"], geo="FR", exact=False, limit=3)
+    client.search_activities.assert_called_once_with(
+        name="Wheat", geo="FR", exact=False, limit=3
+    )
+
+
+def test_by_product_searches_product(client: Client):
+    client.resolve_activities(["Wheat flour"], by="product")
+    client.search_activities.assert_called_once_with(
+        product="Wheat flour", geo=None, exact=True, limit=5
+    )
+
+
+def test_exact_drops_near_misses_from_lax_engines(client: Client):
+    """An engine that ignores exact= returns substring matches; the client
+    re-checks equality (casefold) so only the true match survives."""
+    client.search_activities.return_value = mock.Mock(
+        results=[
+            _act("m", product="Product A"),
+            _act("m", product="produCt c"),
+            _act("m", product="product C, organic"),
+        ]
+    )
+    out = client.resolve_activities(["Product C"], by="product")
+    assert [a.product_name for a in out["Product C"]] == ["produCt c"]
+
+
+def test_fuzzy_keeps_engine_ranking(client: Client):
+    ranked = [_act("Wheat flour"), _act("Wheat, grain")]
+    client.search_activities.return_value = mock.Mock(results=ranked)
+    assert client.resolve_activities(["wheat"], exact=False) == {"wheat": ranked}
+
+
+def test_duplicates_searched_once(client: Client):
+    out = client.resolve_activities(["Wheat", "Wheat", "Rye"])
+    assert client.search_activities.call_count == 2
+    assert list(out) == ["Wheat", "Rye"]
+
+
+def test_invalid_by_is_refused(client: Client):
+    with pytest.raises(VoLCAError, match="'name' or 'product'"):
+        client.resolve_activities(["Wheat"], by="location")  # type: ignore[arg-type]
+    client.search_activities.assert_not_called()
+
+
+def test_empty_input_makes_no_calls(client: Client):
+    assert client.resolve_activities([]) == {}
+    client.search_activities.assert_not_called()
+
+
+def test_search_error_propagates(client: Client):
+    client.search_activities.side_effect = VoLCAError("boom", status_code=500)
+    with pytest.raises(VoLCAError, match="boom"):
+        client.resolve_activities(["Wheat", "Rye"])


### PR DESCRIPTION
## Why

Scripts that need process ids for a list of names keep reinventing the same two workarounds: downloading the entire database (`limit=200000`) to build a name→process_id dict, or hand-rolled thread pools issuing one `search_activities` per name.

## What

`Client.resolve_activities(names, *, by="name"|"product", geo=, exact=True, limit=5, workers=8)` resolves a batch of names concurrently and returns `{name: [matches]}`:

- The mapping is **total**: a name that doesn't resolve maps to `[]` instead of disappearing — misses stay visible.
- One match = unambiguous; several = ambiguous (same name across geographies), disambiguate with `geo=` or inspect the candidates.
- `exact=False` returns relevance-ranked candidates, best first.
- Duplicated input names are searched once; errors propagate instead of degrading to empty results.

With `exact=True` the client re-checks equality on the returned matches (same casefold rule as the engine): engines whose product filter ignores `exact=` return substring matches, and a near-miss must never resolve silently. A separate engine PR fixes that filter at the source.

## Verification

- 10 offline orchestration tests (mapping totality, dedup, argument passthrough, exactness guard, fail-loud).
- End-to-end against a local engine build: exact hit, miss, fuzzy ranking, `by="product"`, and a deduplicated batch.
- README API reference regenerated (drift test green).