### PR TITLE
Honor exact= in the product filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 ### Fixed
+- `exact=true` on the activity search now applies to the `product=` filter
+  too: it becomes a case-insensitive equality check on the reference product
+  name, as it already was for names and geographies. Previously the flag was
+  silently ignored for products, so an exact search could return near-miss
+  substring matches.
 - The `name=` filter on the supply-chain and consumers endpoints (REST and
   MCP) now filters. A name matching nothing previously disabled the filter
   and returned every entry — with a matching `filteredActivities` count — so

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -232,7 +232,7 @@ applyStructuredFilters ::
     Maybe Text ->
     -- | classification filters
     [(Text, Text, Bool)] ->
-    -- | exactMatch (affects geo equality)
+    -- | exactMatch (geo and product filters become case-insensitive equality)
     Bool ->
     [(ProcessId, Activity)] ->
     [(ProcessId, Activity)]
@@ -265,6 +265,9 @@ applyStructuredFilters db geoParam productParam classFilters exactMatch candidat
         productFiltered = case productParam of
             Nothing -> geoFiltered
             Just prod
+                | exactMatch ->
+                    let prodFold = T.toCaseFold prod
+                     in [(pid, a) | (pid, a) <- geoFiltered, any ((== prodFold) . T.toCaseFold) (getProductNames a)]
                 | M.null pidx ->
                     [(pid, a) | (pid, a) <- geoFiltered, allWordsMatch prod getProductNames a]
                 | otherwise ->

--- a/test/StructuredFiltersSpec.hs
+++ b/test/StructuredFiltersSpec.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | The structured (geo, product, classification) filters applied on top of
+name candidates. Pins the exact-match contract: @exact=true@ turns the
+product filter into case-insensitive equality, matching what it already
+meant for names and geographies.
+-}
+module StructuredFiltersSpec (spec) where
+
+import Database (findActivitiesByFields)
+import Test.Hspec
+import TestHelpers (loadSampleDatabase)
+import Types
+
+spec :: Spec
+spec = describe "exact product filter" $ do
+    it "matches the full product name only" $ do
+        db <- loadSampleDatabase "SAMPLE.min"
+        let hits = findActivitiesByFields db Nothing Nothing (Just "product C") [] True
+        map (activityName . snd) hits `shouldBe` ["production of product C"]
+
+    it "is case-insensitive" $ do
+        db <- loadSampleDatabase "SAMPLE.min"
+        let hits = findActivitiesByFields db Nothing Nothing (Just "PRODUCT c") [] True
+        map (activityName . snd) hits `shouldBe` ["production of product C"]
+
+    it "rejects a partial product name" $ do
+        db <- loadSampleDatabase "SAMPLE.min"
+        let hits = findActivitiesByFields db Nothing Nothing (Just "product") [] True
+        map (activityName . snd) hits `shouldBe` []
+
+    it "combines with an exact name filter" $ do
+        db <- loadSampleDatabase "SAMPLE.min"
+        let hits = findActivitiesByFields db (Just "production of product C") Nothing (Just "product C") [] True
+        map (activityName . snd) hits `shouldBe` ["production of product C"]

--- a/volca.cabal
+++ b/volca.cabal
@@ -277,6 +277,7 @@ test-suite lca-tests
                      , MCPEnrichSpec
                      , MCPColumnarSpec
                      , NormalizeSpec
+                     , StructuredFiltersSpec
                      , BM25Spec
                      , FuzzySpec
                      , NestedSubstitutionSpec


### PR DESCRIPTION
## Why

`GET /db/{db}/activities?product=X&exact=true` ignored `exact` for the product filter: it always word-infix matched, so an exact search could return near-miss substring matches — and pathologically, a short query word matching inside longer product names returned almost everything. The flag already meant case-insensitive equality for names and geographies; products were the odd one out.

## What

When `exact=true`, the product filter is now a case-insensitive equality check (`toCaseFold`) against the activity's reference product names — the same rule names and geographies already follow. Substring mode (`exact` absent or false) is unchanged.

## Verification

New `StructuredFiltersSpec` pins the contract: full-name match only, case-insensitive, partial name rejected, combined name+product exact filter. Full test suite green.