### PR TITLE
Release pyvolca 0.8.2

### DIFF
--- a/pyvolca/CHANGELOG.md
+++ b/pyvolca/CHANGELOG.md
@@ -18,7 +18,7 @@ git cliff --unreleased --tag pyvolca-v0.X.Y   # render as a released section
 
 Then paste the rendered block at the top of this file and tighten wording.
 
-## [Unreleased]
+## [0.8.2] - 2026-07-15
 
 ### Added
 
@@ -52,6 +52,19 @@ Then paste the rendered block at the top of this file and tighten wording.
   empty list instead of disappearing — and replaces the two patterns
   scripts kept hand-rolling: downloading the whole database to build a
   name→process_id dict, and per-name thread pools.
+- `search_activities`, `search_flows`, `get_supply_chain`, and
+  `get_consumers` take optional `sort=` / `order=` keyword arguments,
+  forwarding to the engine's ordering support. Left unset, nothing changes.
+- `MethodFactor` gains `compartment`, `location`, and `unit` — the axes
+  that distinguish factors sharing one `flow_name` (the same substance
+  emitted to air vs. water, or one regionalized factor per location).
+  `None` when the source method has no such axis, or the engine predates
+  these fields.
+- `aggregate` gains a `consumption` scope (`AggregateScope.CONSUMPTION`)
+  with `filter_consumer` / `filter_consumer_not`: total upstream demand
+  for a flow (electricity, heat, grass…) without the double counting that
+  summing cumulative production gives when a flow crosses several
+  transformation steps.
 
 ### Changed
 

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -28,7 +28,7 @@ pyvolca speaks a range of revisions of the engine's JSON wire format; the engine
 
 _Generated from `volca._compat` — run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.8.1** speaks wire formats **2 to 3** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error.
+This build of **pyvolca 0.8.2** speaks wire formats **2 to 3** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error.
 
 <!-- END: compatibility -->
 

--- a/pyvolca/pyproject.toml
+++ b/pyvolca/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvolca"
-version = "0.8.1"
+version = "0.8.2"
 description = "Python client for VoLCA — Life Cycle Assessment engine"
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## What

Dates the changelog, bumps the version. Covers two gaps found while consolidating: `MethodFactor` gained `compartment`/`location`/`unit` (#216) and `aggregate` gained the `consumption` scope (#224) — both touched the pyvolca client without a changelog entry.

## Verification

Full suite (259 passed, 7 skipped — live-engine tests), pyright clean, README API reference regenerated and drift-checked.

## After merge

Tag `pyvolca-v0.8.2` on the squashed commit — PyPI trusted publishing fires on that tag.