### PR TITLE
Open 0.9.4 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.9.3] - 2026-07-15
 
 ### Changed

--- a/volca.cabal
+++ b/volca.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                volca
-version:             0.9.3
+version:             0.9.4-dev
 build-type:          Simple
 
 license:             Apache-2.0


### PR DESCRIPTION
v0.9.3 is tagged and released — back to a `-dev` version and a fresh `[Unreleased]` changelog section.