### PR TITLE
Add a dataset-soundness report endpoint and MCP tool

### DIFF
--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -18,6 +18,8 @@ module API.DatabaseHandlers (
     relinkDatabaseHandler,
     gapReportHandler,
     gapReportToAPI,
+    qualityReportHandler,
+    qualityReportToAPI,
     copyDatabaseHandler,
     deleteDatabaseHandler,
     deleteActivitiesHandler,
@@ -91,6 +93,9 @@ import API.Types (
     GapEntryAPI (..),
     GapReportAPI (..),
     LoadDatabaseResponse (..),
+    QualityCheckAPI (..),
+    QualityOffenderAPI (..),
+    QualityReportAPI (..),
     RefDataListResponse (..),
     RefDataStatusAPI (..),
     RelinkRequest (..),
@@ -128,6 +133,7 @@ import Database.Manager (
     addMethodCollection,
     addUnitDefs,
     databaseGapReport,
+    databaseQualityReport,
     finalizeDatabase,
     getDatabase,
     getDatabaseSetupInfo,
@@ -154,6 +160,7 @@ import Database.Manager (
     unloadFlowSynonyms,
     unloadUnitDefs,
  )
+import qualified Database.Quality as Quality
 import Database.RelinkMapping (buildAliasMap, parseAliasCSV, rejectEmpty)
 import Database.Upload (
     DatabaseFormat (..),
@@ -287,6 +294,51 @@ gapReportToAPI mLimit r =
         Loader.GapBlocked blocker -> blockerReasonDetail blocker
         Loader.GapDanglingIdentity -> ("dangling_source_identity", Nothing)
         Loader.GapWasteInput -> ("unlinked_waste_input", Nothing)
+
+{- | Dataset-soundness report for a loaded or staged database: the structural
+defects a score can't reveal. The methodological counterpart of the
+supplier-gap report — that one says what a database is missing, this one says
+what is malformed in it.
+-}
+qualityReportHandler :: Text -> Maybe Int -> AppM QualityReportAPI
+qualityReportHandler dbName mLimit = do
+    dbManager <- asks aeDbManager
+    res <- liftIO $ databaseQualityReport dbManager dbName
+    case res of
+        Left err -> throwError err404{errBody = BSL.fromStrict $ T.encodeUtf8 err}
+        Right report -> return (qualityReportToAPI mLimit report)
+
+{- | Project the domain quality report onto its wire shape, keeping at most
+@limit@ findings per check (they are sorted worst-first, so a cap keeps the
+worst ones). Each check's @offenderCount@ always covers its full list, so a
+truncated list stays countable — never a silent cap.
+-}
+qualityReportToAPI :: Maybe Int -> Quality.QualityReport -> QualityReportAPI
+qualityReportToAPI mLimit r =
+    QualityReportAPI
+        { qraDbName = Quality.qrDbName r
+        , qraProcessCount = Quality.qrProcessCount r
+        , qraReferenceProduct = checkToAPI (Quality.qrReferenceProduct r)
+        , qraAllocationSums = checkToAPI (Quality.qrAllocationSums r)
+        , qraDuplicateActivities = checkToAPI (Quality.qrDuplicateActivities r)
+        , qraSuspiciousAmounts = checkToAPI (Quality.qrSuspiciousAmounts r)
+        , qraMissingMetadata = checkToAPI (Quality.qrMissingMetadata r)
+        }
+  where
+    checkToAPI c =
+        QualityCheckAPI
+            { qcaApplicable = Quality.qcApplicable c
+            , qcaOffenderCount = length (Quality.qcOffenders c)
+            , qcaOffenders = map offenderToAPI (maybe id take mLimit (Quality.qcOffenders c))
+            }
+    offenderToAPI o =
+        QualityOffenderAPI
+            { qoaSeverity = Quality.qoSeverity o
+            , qoaActivityName = Quality.qoActivityName o
+            , qoaLocation = Quality.qoLocation o
+            , qoaProductName = Quality.qoProductName o
+            , qoaDetail = Quality.qoDetail o
+            }
 
 {- | Copy a loaded database under a new name. The copy is an independent
 in-memory database registered under @newName@; the source is untouched.

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -35,7 +35,7 @@ import Database.Manager (DatabaseManager (..), LoadedDatabase (..), getDatabase)
 import qualified Database.Manager as DM
 
 import qualified API.BatchImpacts as BI
-import API.DatabaseHandlers (gapReportToAPI)
+import API.DatabaseHandlers (gapReportToAPI, qualityReportToAPI)
 import API.MCP.Columnar (resolveSingleScoringSet, toColumnarBatch)
 import API.MCP.Enrich (addWebUrlMaybe, attachMarketHintByName, encodeSegment, filterScoringSets, scoreActivityWebUrl, slimLCIAPanel, webUrlField)
 import API.Types (ActivityForAPI (..), ActivityInfo (..), ClassificationSystem (..), ExchangeWithUnit (..), InventoryExport (..), InventoryFlowDetail (..), Perturbation (..), Substitution (..), SubstitutionRequest (..))
@@ -362,6 +362,7 @@ callTool dbManager presets mBaseUrl rid name args = case name of
     "score_activities" -> callScoreActivities dbManager mBaseUrl rid args
     "list_scoring_sets" -> callListScoringSets dbManager rid args
     "get_gap_report" -> callGetGapReport dbManager rid args
+    "get_quality_report" -> callGetQualityReport dbManager rid args
     _ -> return $ toolError rid ("Unknown tool: " <> name)
 
 -- Helper: extract database, then run action
@@ -1313,6 +1314,16 @@ callGetGapReport dbManager rid args = runTool rid $ do
     dbName <- except (requireText "database" args)
     report <- ExceptT (DM.databaseGapReport dbManager dbName)
     return $ toolSuccessJson rid (toJSON (gapReportToAPI (intArg "limit" args) report))
+
+{- | Dataset-soundness report: what is malformed in the database itself. Same
+wire shape as the REST endpoint ('qualityReportToAPI'), so both surfaces stay
+in lock-step.
+-}
+callGetQualityReport :: DatabaseManager -> Value -> KeyMap Value -> IO Value
+callGetQualityReport dbManager rid args = runTool rid $ do
+    dbName <- except (requireText "database" args)
+    report <- ExceptT (DM.databaseQualityReport dbManager dbName)
+    return $ toolSuccessJson rid (toJSON (qualityReportToAPI (intArg "limit" args) report))
 
 callGetFlowMapping :: DatabaseManager -> Value -> KeyMap Value -> IO Value
 callGetFlowMapping dbManager rid args = runTool rid $ do

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -466,7 +466,8 @@ description r = case r of
         \who build or repair one: the structural defects a score cannot \
         \reveal. Five checks, computed on staged and loaded databases alike: \
         \entries without exactly one reference exchange, coproduct allocation \
-        \percentages that don't sum to 100%, entries duplicated outright \
+        \percentages that don't sum to 100% (or blocks where only some \
+        \coproducts carry one), entries duplicated outright \
         \(same name, location and reference product), non-finite amounts or a \
         \zero reference amount, and missing metadata (description, \
         \classification, location, units absent from the registry). Each \

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -72,6 +72,7 @@ data Resource
     | ScoreActivities
     | ListScoringSets
     | GetGapReport
+    | GetQualityReport
     deriving (Eq, Ord, Show, Bounded, Enum)
 
 -- | Whether a parameter must be supplied by the caller.
@@ -154,6 +155,7 @@ apiPath r = case r of
     ScoreActivities -> Just (POST, ["db", "{dbName}", "impacts", "{collection}"])
     ListScoringSets -> Nothing -- MCP-only: scoring sets are configuration metadata, no REST equivalent yet
     GetGapReport -> Just (GET, ["db", "{dbName}", "gap-report"])
+    GetQualityReport -> Just (GET, ["db", "{dbName}", "quality-report"])
 
 {- | The full OpenAPI path template for a resource, e.g.
 @"/api/v1/db/{dbName}/activity/{processId}/impacts/{collection}/{methodId}"@.
@@ -197,6 +199,7 @@ mcpName r = case r of
     ScoreActivities -> "score_activities"
     ListScoringSets -> "list_scoring_sets"
     GetGapReport -> "get_gap_report"
+    GetQualityReport -> "get_quality_report"
 
 -- ---------------------------------------------------------------------------
 -- Projection: CLI subcommand names (kebab-case)
@@ -236,6 +239,7 @@ cliName r = case r of
     ScoreActivities -> "score-activities"
     ListScoringSets -> "scoring-sets"
     GetGapReport -> "gap-report"
+    GetQualityReport -> "quality-report"
 
 -- ---------------------------------------------------------------------------
 -- Projection: human-readable description (shared across surfaces)
@@ -457,6 +461,19 @@ description r = case r of
         \and the top consuming processes. Answers 'what is missing to switch \
         \or complete this database's background dependency?' — typically read \
         \right after a relink."
+    GetQualityReport ->
+        "LCA / ACV — dataset-soundness report of a database, for the people \
+        \who build or repair one: the structural defects a score cannot \
+        \reveal. Five checks, computed on staged and loaded databases alike: \
+        \entries without exactly one reference exchange, coproduct allocation \
+        \percentages that don't sum to 100%, entries duplicated outright \
+        \(same name, location and reference product), non-finite amounts or a \
+        \zero reference amount, and missing metadata (description, \
+        \classification, location, units absent from the registry). Each \
+        \finding carries a severity (danger, warning, info), the activity it \
+        \was found on, and a readable detail. Answers 'is this dataset well \
+        \formed?' — the complement of the supplier-gap report, which answers \
+        \'what is this database missing?'"
 
 -- ---------------------------------------------------------------------------
 -- Projection: parameter schema
@@ -765,4 +782,8 @@ params r = case r of
     GetGapReport ->
         [ pDatabase
         , pLimit "Max gap entries to return, biggest first (default: all). The header counts always cover the full report, so a truncated list stays countable."
+        ]
+    GetQualityReport ->
+        [ pDatabase
+        , pLimit "Max findings to return per check, worst first (default: all). Each check's offenderCount always covers its full list, so a truncated list stays countable."
         ]

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -10,7 +10,7 @@ module API.Routes where
 import API.DatabaseHandlers (simpleAction)
 import qualified API.DatabaseHandlers as DBHandlers
 import qualified API.OpenApi
-import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExportRequest (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GapReportAPI (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadChunk (..), UploadResponse (..), apiFlowOfKind)
+import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExportRequest (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GapReportAPI (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), QualityReportAPI (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadChunk (..), UploadResponse (..), apiFlowOfKind)
 import App.Env (AppEnv (..), AppM, runApp)
 import qualified Config
 import Control.Concurrent.Async (mapConcurrently)
@@ -125,6 +125,8 @@ type LCAAPI =
                 :<|> "db" :> Capture "dbName" Text :> "relink" :> ReqBody '[JSON] RelinkRequest :> Post '[JSON] RelinkResponse
                 -- Supplier-gap report: what is still unsupplied after linking (read-only relink companion)
                 :<|> "db" :> Capture "dbName" Text :> "gap-report" :> QueryParam "limit" Int :> Get '[JSON] GapReportAPI
+                -- Dataset-soundness report: what is malformed in the database itself
+                :<|> "db" :> Capture "dbName" Text :> "quality-report" :> QueryParam "limit" Int :> Get '[JSON] QualityReportAPI
                 :<|> "db" :> Capture "dbName" Text :> "copy" :> Capture "newName" Text :> Post '[JSON] ActivateResponse
                 :<|> "db" :> Capture "dbName" Text :> Delete '[JSON] ActivateResponse
                 -- Delete the whole filtered set of activities (selection in JSON body)
@@ -2015,6 +2017,7 @@ lcaServer env = hoistServer lcaAPI (runApp env) handlers
             :<|> DBHandlers.unloadDatabaseHandler
             :<|> DBHandlers.relinkDatabaseHandler
             :<|> DBHandlers.gapReportHandler
+            :<|> DBHandlers.qualityReportHandler
             :<|> DBHandlers.copyDatabaseHandler
             :<|> DBHandlers.deleteDatabaseHandler
             :<|> DBHandlers.deleteActivitiesHandler

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -25,7 +25,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import GHC.Generics
 import Servant.API.ContentTypes (MimeRender (..), MimeUnrender (..), OctetStream)
-import Types (BiosphereFlow (..), Compartment, Exchange, FlowKind (..), NativeActivityType (..), Pedigree, TechnosphereFlow (..), UUID, Unit, WasteFlow (..))
+import Types (BiosphereFlow (..), Compartment, Exchange, FlowKind (..), NativeActivityType (..), Pedigree, Severity, TechnosphereFlow (..), UUID, Unit, WasteFlow (..))
 
 {- | Tagged wire representation of either side of the flow split.
 
@@ -790,6 +790,47 @@ data GapReportAPI = GapReportAPI
     }
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped GapReportAPI)
+
+-- | One dataset-soundness finding: where it was found, and what is wrong.
+data QualityOffenderAPI = QualityOffenderAPI
+    { qoaSeverity :: Severity
+    , qoaActivityName :: Text
+    , qoaLocation :: Text
+    , qoaProductName :: Maybe Text
+    , qoaDetail :: Text
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped QualityOffenderAPI)
+
+{- | One check of the quality report. @offenderCount@ always covers the whole
+finding list, so a list capped by @limit@ stays countable — never a silent cap.
+@applicable@ is 'False' when the database carries nothing the check could judge,
+which is not the same as passing it.
+-}
+data QualityCheckAPI = QualityCheckAPI
+    { qcaApplicable :: Bool
+    , qcaOffenderCount :: Int
+    , qcaOffenders :: [QualityOffenderAPI]
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped QualityCheckAPI)
+
+{- | Dataset-soundness report of a database: the structural defects a score
+can't reveal, one named field per check. The methodological counterpart of
+'GapReportAPI', which reports what a database is missing rather than what is
+malformed in it.
+-}
+data QualityReportAPI = QualityReportAPI
+    { qraDbName :: Text
+    , qraProcessCount :: Int
+    , qraReferenceProduct :: QualityCheckAPI
+    , qraAllocationSums :: QualityCheckAPI
+    , qraDuplicateActivities :: QualityCheckAPI
+    , qraSuspiciousAmounts :: QualityCheckAPI
+    , qraMissingMetadata :: QualityCheckAPI
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped QualityReportAPI)
 
 -- | Result of auto-loading a single dependency
 data DepLoadResult

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -88,6 +88,7 @@ module Database.Manager (
     getDatabaseSetupInfo,
     buildLoadedSetupInfo,
     databaseGapReport,
+    databaseQualityReport,
     addDependencyToStaged,
     removeDependencyFromStaged,
     setDataPath,
@@ -145,6 +146,7 @@ import qualified Data.ByteString.Lazy as BL
 import Data.Time (diffUTCTime, getCurrentTime)
 import Database (buildDatabaseWithMatrices)
 import qualified Database.Loader as Loader
+import qualified Database.Quality as Quality
 import EcoSpold.Parser2 (normalizeCAS)
 import Matrix (clearCachedSolver)
 import Method.ChemSynonyms (ChemSynonyms, emptyChemSynonyms, loadChemSynonyms)
@@ -2297,6 +2299,19 @@ databaseGapReport manager dbName = do
         (Just loaded, _) -> Right (Loader.gapReportForLoaded dbName (ldDatabase loaded))
         (Nothing, Just staged) ->
             Right (Loader.gapReportForStaged dbName (sdSimpleDB staged) (sdLinkingStats staged))
+        (Nothing, Nothing) -> Left ("Database not loaded: " <> dbName)
+
+{- | Dataset-soundness report for a loaded or staged database — the structural
+defects a score can't reveal. Both phases reduce to the same pure scan, so a
+maker gets the same answer before and after building the matrices.
+-}
+databaseQualityReport :: DatabaseManager -> Text -> IO (Either Text Quality.QualityReport)
+databaseQualityReport manager dbName = do
+    loadedDbs <- readTVarIO (dmLoadedDbs manager)
+    stagedDbs <- readTVarIO (dmStagedDbs manager)
+    pure $ case (M.lookup dbName loadedDbs, M.lookup dbName stagedDbs) of
+        (Just loaded, _) -> Right (Quality.qualityReport dbName (toSimpleDatabase (ldDatabase loaded)))
+        (Nothing, Just staged) -> Right (Quality.qualityReport dbName (sdSimpleDB staged))
         (Nothing, Nothing) -> Left ("Database not loaded: " <> dbName)
 
 data StageAction = AlreadyDone | NeedToStage

--- a/src/Database/Quality.hs
+++ b/src/Database/Quality.hs
@@ -1,0 +1,228 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Dataset-soundness checks, for the people who build or repair databases.
+
+A score tells you whether a database computes; it says nothing about whether
+the dataset is well formed. These checks look for the structural defects a
+score can't reveal: processes without exactly one reference exchange,
+coproduct allocation that doesn't sum to 100%, entries duplicated outright,
+amounts that aren't finite, and missing metadata.
+
+Every check is a pure scan over a 'SimpleDatabase', so the report is
+identical on a staged database (parsed, matrices not built) and on a loaded
+one — a maker can read it before committing to a build.
+-}
+module Database.Quality (
+    QualityOffender (..),
+    QualityCheck (..),
+    QualityReport (..),
+    qualityReport,
+    qualityChecks,
+    allocationTolerance,
+) where
+
+import Control.Applicative ((<|>))
+import Data.List (sortOn)
+import qualified Data.Map.Strict as M
+import Data.Maybe (fromMaybe, isJust)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.UUID as UUID
+
+import Types (
+    Activity (..),
+    BiosphereFlow (..),
+    Severity (..),
+    SimpleDatabase (..),
+    TechnosphereFlow (..),
+    WasteFlow (..),
+    activityGroupKey,
+    exchangeAmount,
+    exchangeFlowId,
+    exchangeIsReference,
+    exchangeUnitId,
+ )
+
+-- | One finding: the activity it was found on, and what is wrong with it.
+data QualityOffender = QualityOffender
+    { qoSeverity :: !Severity
+    , qoActivityName :: !Text
+    , qoLocation :: !Text
+    , qoProductName :: !(Maybe Text)
+    -- ^ Reference product, when the check knows which one it means
+    , qoDetail :: !Text
+    -- ^ Human-readable specifics, e.g. @"3 reference exchanges instead of exactly one"@
+    }
+    deriving (Show, Eq)
+
+{- | The outcome of one check. Offenders are sorted worst-first and complete —
+capping for display happens at the wire boundary, not here.
+-}
+data QualityCheck = QualityCheck
+    { qcApplicable :: !Bool
+    {- ^ 'False' when the database carries nothing this check could judge, which
+    is not the same as passing. See the allocation check in 'qualityReport'.
+    -}
+    , qcOffenders :: ![QualityOffender]
+    }
+    deriving (Show, Eq)
+
+{- | Soundness report of a database: one named field per check. Named fields
+rather than a list keyed by codes — the field name /is/ the check's identity,
+so neither this module nor its consumers can misspell one.
+-}
+data QualityReport = QualityReport
+    { qrDbName :: !Text
+    , qrProcessCount :: !Int
+    -- ^ Entries scanned: one per (activity, product) pair
+    , qrReferenceProduct :: !QualityCheck
+    , qrAllocationSums :: !QualityCheck
+    , qrDuplicateActivities :: !QualityCheck
+    , qrSuspiciousAmounts :: !QualityCheck
+    , qrMissingMetadata :: !QualityCheck
+    }
+    deriving (Show, Eq)
+
+{- | Every check of a report, in report order. For consumers that treat the
+checks uniformly (counting findings, rendering a list) without losing the
+per-field identity above.
+-}
+qualityChecks :: QualityReport -> [QualityCheck]
+qualityChecks r =
+    [ qrReferenceProduct r
+    , qrAllocationSums r
+    , qrDuplicateActivities r
+    , qrSuspiciousAmounts r
+    , qrMissingMetadata r
+    ]
+
+{- | Allowed drift when summing coproduct allocation percentages. Sources round
+their percentages (33.3 + 33.3 + 33.4), so an exact comparison would flag
+correct data; half a point is far below what a dropped or mistyped coproduct
+costs.
+-}
+allocationTolerance :: Double
+allocationTolerance = 0.5
+
+-- | Run every check over a database.
+qualityReport :: Text -> SimpleDatabase -> QualityReport
+qualityReport dbName db =
+    QualityReport
+        { qrDbName = dbName
+        , qrProcessCount = M.size (sdbActivities db)
+        , qrReferenceProduct = QualityCheck True (worstFirst referenceOffenders)
+        , qrAllocationSums = QualityCheck allocationApplicable (worstFirst allocationOffenders)
+        , qrDuplicateActivities = QualityCheck True (worstFirst duplicateOffenders)
+        , qrSuspiciousAmounts = QualityCheck True (worstFirst amountOffenders)
+        , qrMissingMetadata = QualityCheck True (worstFirst metadataOffenders)
+        }
+  where
+    acts = M.elems (sdbActivities db)
+    worstFirst = sortOn (\o -> (qoSeverity o, qoActivityName o))
+    offender sev act = QualityOffender sev (activityName act) (activityLocation act)
+
+    -- Names of the flow an exchange points at, whichever registry holds it.
+    -- An unresolved id degrades to its UUID rather than to a blank: a finding
+    -- naming nothing would be unactionable.
+    techOrWasteFlowName fid =
+        (tfName <$> M.lookup fid (sdbTechFlows db))
+            <|> (wfName <$> M.lookup fid (sdbWasteFlows db))
+    anyFlowName fid =
+        fromMaybe (UUID.toText fid) $
+            techOrWasteFlowName fid
+                <|> (bfName <$> M.lookup fid (sdbBioFlows db))
+
+    -- Exactly one reference exchange defines the process: none leaves nothing
+    -- to normalize against, several make the entry ambiguous. 'exchangeIsReference'
+    -- counts a treatment activity's reference /input/ too, so waste treatment
+    -- passes on its own terms.
+    referenceOffenders =
+        [ offender DangerSev act Nothing $
+            T.pack (show n) <> " reference exchanges instead of exactly one"
+        | act <- acts
+        , let n = length (filter exchangeIsReference (exchanges act))
+        , n /= 1
+        ]
+
+    -- The coproducts of one source block share an 'activityGroupKey'. A block
+    -- whose source format has no identifier falls back to grouping by activity
+    -- UUID alone: two SimaPro blocks whose names collide after the format's
+    -- 80-character truncation would then merge, and their percentages sum to
+    -- ~200%. That is the same over-grouping 'Database.MatrixBuild' accepts.
+    allocationApplicable = any (isJust . activityAllocationPercent) acts
+    allocationGroups =
+        M.fromListWith
+            (<>)
+            [ (activityGroupKey actUUID act, [act])
+            | ((actUUID, _productUUID), act) <- M.toList (sdbActivities db)
+            ]
+    allocationOffenders =
+        [ offender DangerSev representative Nothing $
+            "allocation sums to "
+                <> T.pack (show total)
+                <> "% across "
+                <> T.pack (show (length group'))
+                <> " coproduct(s)"
+        | group'@(representative : _) <- M.elems allocationGroups
+        , -- Judge a group only when every member carries a percentage: a mix of
+        -- allocated and unallocated entries is not a sum.
+        Just percents <- [traverse activityAllocationPercent group']
+        , let total = sum percents
+        , -- NaN needs its own test: any comparison against it is False, so the
+        -- tolerance check alone would let it through.
+        isNaN total || isInfinite total || abs (total - 100) > allocationTolerance
+        ]
+
+    -- Same name, same place, same product, twice: one of them is stale. Entries
+    -- without exactly one reference are skipped — check 1 already reports them,
+    -- and grouping them by a missing product would invent duplicates.
+    referenceProductName act = case filter exchangeIsReference (exchanges act) of
+        [ex] -> Just (fromMaybe (UUID.toText (exchangeFlowId ex)) (techOrWasteFlowName (exchangeFlowId ex)))
+        _ -> Nothing
+    duplicateGroups =
+        M.fromListWith
+            (+)
+            [ ((activityName act, activityLocation act, productName), 1 :: Int)
+            | act <- acts
+            , Just productName <- [referenceProductName act]
+            ]
+    duplicateOffenders =
+        [ QualityOffender WarningSev name location (Just productName) $
+            T.pack (show n) <> " identical entries (same name, location and reference product)"
+        | ((name, location, productName), n) <- M.toList duplicateGroups
+        , n > 1
+        ]
+
+    -- A non-finite amount poisons every downstream sum; a zero reference amount
+    -- is what normalization divides by. Zero on an ordinary input is legal and
+    -- says the activity simply doesn't consume it.
+    amountOffenders =
+        [ offender DangerSev act Nothing detail
+        | act <- acts
+        , ex <- exchanges act
+        , let amount = exchangeAmount ex
+        , let flowName = anyFlowName (exchangeFlowId ex)
+        , Just detail <-
+            [ if isNaN amount || isInfinite amount
+                then Just ("exchange \"" <> flowName <> "\" has a non-finite amount")
+                else
+                    if exchangeIsReference ex && amount == 0
+                        then Just ("reference exchange \"" <> flowName <> "\" has amount 0, which normalization would divide by")
+                        else Nothing
+            ]
+        ]
+
+    -- Incomplete rather than wrong, hence Info — except a missing location or an
+    -- unknown unit, which change how the entry links and converts.
+    metadataOffenders =
+        concat
+            [ [offender InfoSev act Nothing "no description" | all (T.null . T.strip) (activityDescription act)]
+                <> [offender InfoSev act Nothing "no classification" | M.null (activityClassification act)]
+                <> [offender WarningSev act Nothing "no location" | T.null (T.strip (activityLocation act))]
+                <> [ offender WarningSev act Nothing $
+                        T.pack (show unknownUnits) <> " exchange(s) whose unit is absent from the unit registry"
+                   | let unknownUnits = length [() | ex <- exchanges act, M.notMember (exchangeUnitId ex) (sdbUnits db)]
+                   , unknownUnits > 0
+                   ]
+            | act <- acts
+            ]

--- a/src/Database/Quality.hs
+++ b/src/Database/Quality.hs
@@ -28,6 +28,7 @@ import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
+import Numeric (showFFloat)
 
 import Types (
     Activity (..),
@@ -104,6 +105,13 @@ costs.
 allocationTolerance :: Double
 allocationTolerance = 0.5
 
+{- | Two-decimal rendering for detail texts. The judgement uses the exact
+double; only the message is rounded, so a drifting sum reads as @69.90@ rather
+than as floating-point dust like @69.89999999999999@.
+-}
+formatPercent :: Double -> Text
+formatPercent x = T.pack (showFFloat (Just 2) x "")
+
 -- | Run every check over a database.
 qualityReport :: Text -> SimpleDatabase -> QualityReport
 qualityReport dbName db =
@@ -179,7 +187,7 @@ qualityReport dbName db =
             | isNaN total || isInfinite total || abs (total - 100) > allocationTolerance ->
                 [ offender DangerSev representative Nothing $
                     "allocation sums to "
-                        <> T.pack (show total)
+                        <> formatPercent total
                         <> "% across "
                         <> T.pack (show (length group'))
                         <> " coproduct(s)"

--- a/src/Database/Quality.hs
+++ b/src/Database/Quality.hs
@@ -24,7 +24,7 @@ module Database.Quality (
 import Control.Applicative ((<|>))
 import Data.List (sortOn)
 import qualified Data.Map.Strict as M
-import Data.Maybe (fromMaybe, isJust)
+import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
@@ -156,22 +156,39 @@ qualityReport dbName db =
             [ (activityGroupKey actUUID act, [act])
             | ((actUUID, _productUUID), act) <- M.toList (sdbActivities db)
             ]
-    allocationOffenders =
-        [ offender DangerSev representative Nothing $
-            "allocation sums to "
-                <> T.pack (show total)
-                <> "% across "
-                <> T.pack (show (length group'))
-                <> " coproduct(s)"
-        | group'@(representative : _) <- M.elems allocationGroups
-        , -- Judge a group only when every member carries a percentage: a mix of
-        -- allocated and unallocated entries is not a sum.
-        Just percents <- [traverse activityAllocationPercent group']
-        , let total = sum percents
-        , -- NaN needs its own test: any comparison against it is False, so the
-        -- tolerance check alone would let it through.
-        isNaN total || isInfinite total || abs (total - 100) > allocationTolerance
-        ]
+    allocationOffenders = concatMap allocationGroupOffenders (M.elems allocationGroups)
+
+    -- A block whose every coproduct carries a percentage is judged on its sum.
+    -- A block where only some do is its own defect — the sum means nothing
+    -- until the missing percentages are restored, so reporting it as a bad sum
+    -- would misdiagnose. A block where none do is simply unallocated: nothing
+    -- to judge.
+    allocationGroupOffenders group' = case group' of
+        [] -> []
+        representative : _
+            | null carried -> []
+            | missing > 0 ->
+                [ offender WarningSev representative Nothing $
+                    T.pack (show missing)
+                        <> " of "
+                        <> T.pack (show (length group'))
+                        <> " coproduct(s) carry no allocation percentage"
+                ]
+            -- NaN needs its own test: any comparison against it is False, so
+            -- the tolerance check alone would let it through.
+            | isNaN total || isInfinite total || abs (total - 100) > allocationTolerance ->
+                [ offender DangerSev representative Nothing $
+                    "allocation sums to "
+                        <> T.pack (show total)
+                        <> "% across "
+                        <> T.pack (show (length group'))
+                        <> " coproduct(s)"
+                ]
+            | otherwise -> []
+      where
+        carried = mapMaybe activityAllocationPercent group'
+        missing = length group' - length carried
+        total = sum carried
 
     -- Same name, same place, same product, twice: one of them is stale. Entries
     -- without exactly one reference are skipped — check 1 already reports them,

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1211,6 +1211,58 @@ instance ToSchema LocationKind where
                            | c <- ["exact", "parent", "global", "unrelated"]
                            ]
 
+{- | How serious a dataset-soundness finding is. Declaration order is the
+severity order, so 'Ord' sorts the worst findings first.
+
+The constructors carry a @Sev@ suffix for the same reason 'LocationKind' has
+@Loc@: this module is re-exported wholesale, and bare @Warning@ / @Info@ would
+collide with 'Progress.ProgressLevel' wherever both are imported.
+-}
+data Severity
+    = -- | Breaks scoring or a faithful round-trip
+      DangerSev
+    | -- | Suspicious: legal data, but likely a mistake
+      WarningSev
+    | -- | Incomplete rather than wrong
+      InfoSev
+    deriving (Show, Eq, Ord, Generic, NFData)
+
+{- | Stable lowercase wire code for a 'Severity'. Single source of truth shared
+by the JSON encoder and the schema, so consumers never see raw Haskell
+constructor names like @"DangerSev"@.
+-}
+severityCode :: Severity -> Text
+severityCode DangerSev = "danger"
+severityCode WarningSev = "warning"
+severityCode InfoSev = "info"
+
+instance ToJSON Severity where
+    toJSON = toJSON . severityCode
+
+instance FromJSON Severity where
+    parseJSON v = do
+        s <- parseJSON v
+        case (s :: Text) of
+            "danger" -> pure DangerSev
+            "warning" -> pure WarningSev
+            "info" -> pure InfoSev
+            other -> fail $ "Invalid Severity: " <> T.unpack other
+
+{- | OpenAPI schema for 'Severity' as a string-enum matching the wire codes
+produced by 'severityCode', for the same reason as 'LocationKind': the generic
+schema would expose the Haskell constructor names.
+-}
+instance ToSchema Severity where
+    declareNamedSchema _ =
+        pure $
+            NamedSchema (Just "Severity") $
+                mempty
+                    & type_ ?~ OpenApiString
+                    & enum_
+                        ?~ [ toJSON (c :: Text)
+                           | c <- ["danger", "warning", "info"]
+                           ]
+
 -- | A product whose supplier was found at a wider geography than requested.
 data LocationFallback = LocationFallback
     { lfProduct :: !Text

--- a/test/MCPDispatchSpec.hs
+++ b/test/MCPDispatchSpec.hs
@@ -88,3 +88,16 @@ spec = describe "MCP database load/unload tools" $ do
             resp <- call "get_gap_report"
             isError resp `shouldBe` True
             resultText resp `shouldSatisfy` maybe False ("Database not loaded:" `T.isInfixOf`)
+
+    describe "quality-report tool" $ do
+        it "is advertised with a required 'database' parameter" $
+            fmap requiredOf (toolByName "get_quality_report") `shouldBe` Just ["database"]
+
+        it "is routed by callTool (no 'Unknown tool' gap)" $ do
+            resp <- call "get_quality_report"
+            resultText resp `shouldSatisfy` maybe False (not . T.isPrefixOf "Unknown tool:")
+
+        it "surfaces the engine error for an unknown database" $ do
+            resp <- call "get_quality_report"
+            isError resp `shouldBe` True
+            resultText resp `shouldSatisfy` maybe False ("Database not loaded:" `T.isInfixOf`)

--- a/test/QualityReportSpec.hs
+++ b/test/QualityReportSpec.hs
@@ -187,8 +187,17 @@ spec = do
             let db = dbOf [((actA, prodA), allocated "truncated name" (Just 100) (Just "b1")), ((actB, prodB), allocated "truncated name" (Just 100) (Just "b2"))]
             qcOffenders (qrAllocationSums (qualityReport "testdb" db)) `shouldBe` []
 
-        it "does not judge a group where only some entries carry a percentage" $ do
+        it "flags a block where only some coproducts carry a percentage, without judging its sum" $ do
+            -- The 60% alone is neither a good sum nor a bad one — the missing
+            -- percentage is the defect, so it gets its own warning instead of
+            -- a misdiagnosed danger.
             let db = dbOf [((actA, prodA), allocated "block" (Just 60) (Just "b1")), ((actA, prodB), allocated "block" Nothing (Just "b1"))]
+                check = qrAllocationSums (qualityReport "testdb" db)
+            details check `shouldBe` ["1 of 2 coproduct(s) carry no allocation percentage"]
+            severities check `shouldBe` [WarningSev]
+
+        it "leaves a block with no percentages at all alone" $ do
+            let db = dbOf [((actA, prodA), allocated "block" Nothing (Just "b1")), ((actA, prodB), allocated "block" Nothing (Just "b1"))]
             qcOffenders (qrAllocationSums (qualityReport "testdb" db)) `shouldBe` []
 
         it "reports not-applicable on a database without allocation data" $ do

--- a/test/QualityReportSpec.hs
+++ b/test/QualityReportSpec.hs
@@ -1,0 +1,299 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Dataset-soundness report tests.
+
+Each check gets a database built to trip exactly it, plus the negative controls
+that keep it from crying wolf: a treatment activity whose reference is an input,
+allocation that rounds (33.3 × 3), an ordinary input at zero, coproduct blocks
+that share a name but not an identifier.
+-}
+module QualityReportSpec (spec) where
+
+import Data.Aeson (decode, encode)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
+import Test.Hspec
+
+import API.DatabaseHandlers (qualityReportToAPI)
+import API.Types (QualityCheckAPI (..), QualityOffenderAPI (..), QualityReportAPI (..))
+import Database.Quality (
+    QualityCheck (..),
+    QualityOffender (..),
+    QualityReport (..),
+    qualityReport,
+ )
+import Types (
+    Activity (..),
+    Exchange (..),
+    NativeProcessId (..),
+    Severity (..),
+    SimpleDatabase (..),
+    TechRole (..),
+    TechnosphereFlow (..),
+    Unit (..),
+    WasteFlow (..),
+ )
+
+-- ---------------------------------------------------------------------------
+-- UUID helpers: readable fixed identifiers.
+-- ---------------------------------------------------------------------------
+
+u :: String -> UUID
+u suffix = read ("00000000-0000-0000-0000-0000000000" <> suffix)
+
+kgUnit, unknownUnit, breadFlow, flourFlow, wasteFlow :: UUID
+kgUnit = u "01"
+unknownUnit = u "02"
+breadFlow = u "03"
+flourFlow = u "04"
+wasteFlow = u "05"
+
+actA, actB, prodA, prodB :: UUID
+actA = u "0a"
+actB = u "0b"
+prodA = u "1a"
+prodB = u "1b"
+
+-- ---------------------------------------------------------------------------
+-- Fixture building blocks
+-- ---------------------------------------------------------------------------
+
+mkActivity :: Text -> [Exchange] -> Activity
+mkActivity name exs =
+    Activity
+        { activityName = name
+        , activityDescription = ["A described activity"]
+        , activitySynonyms = M.empty
+        , activityClassification = M.singleton "ISIC" "1071"
+        , activityLocation = "FR"
+        , activityUnit = "kg"
+        , exchanges = exs
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
+        , activityNativeId = Nothing
+        }
+
+techExchange :: UUID -> Double -> TechRole -> Exchange
+techExchange fid amount role =
+    TechnosphereExchange
+        { techFlowId = fid
+        , techAmount = amount
+        , techUnitId = kgUnit
+        , techRole = role
+        , techActivityLinkId = UUID.nil
+        , techProcessLinkId = Nothing
+        , techLocation = "FR"
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+reference :: UUID -> Exchange
+reference fid = techExchange fid 1.0 ReferenceProduct
+
+input :: UUID -> Double -> Exchange
+input fid amount = techExchange fid amount Input
+
+-- | A treatment activity is defined by the waste it consumes, not by an output.
+referenceInput :: UUID -> Exchange
+referenceInput fid = techExchange fid 1.0 ReferenceInput
+
+{- | Database from activities keyed by (activity, product), with the standard
+flow and unit registries every fixture shares.
+-}
+dbOf :: [((UUID, UUID), Activity)] -> SimpleDatabase
+dbOf acts =
+    SimpleDatabase
+        { sdbActivities = M.fromList acts
+        , sdbTechFlows =
+            M.fromList
+                [ (breadFlow, TechnosphereFlow breadFlow "bread" kgUnit M.empty Nothing Nothing)
+                , (flourFlow, TechnosphereFlow flourFlow "flour" kgUnit M.empty Nothing Nothing)
+                ]
+        , sdbBioFlows = M.empty
+        , sdbWasteFlows = M.fromList [(wasteFlow, WasteFlow wasteFlow "municipal waste" kgUnit M.empty Nothing Nothing)]
+        , sdbUnits = M.singleton kgUnit (Unit kgUnit "kg" "kg" "")
+        }
+
+-- | The report of a one-activity database, for the many single-defect cases.
+reportOf :: Activity -> QualityReport
+reportOf act = qualityReport "testdb" (dbOf [((actA, prodA), act)])
+
+details :: QualityCheck -> [Text]
+details = map qoDetail . qcOffenders
+
+severities :: QualityCheck -> [Severity]
+severities = map qoSeverity . qcOffenders
+
+-- | An activity carrying an allocation percentage and a source block identity.
+allocated :: Text -> Maybe Double -> Maybe Text -> Activity
+allocated name percent nativeId =
+    (mkActivity name [reference breadFlow])
+        { activityAllocationPercent = percent
+        , activityNativeId = NativeProcessId <$> nativeId
+        }
+
+spec :: Spec
+spec = do
+    describe "reference product check" $ do
+        it "flags an activity with no reference exchange" $ do
+            let check = qrReferenceProduct (reportOf (mkActivity "no reference" [input flourFlow 1.0]))
+            details check `shouldBe` ["0 reference exchanges instead of exactly one"]
+            severities check `shouldBe` [DangerSev]
+
+        it "flags an activity with two reference exchanges" $ do
+            let check = qrReferenceProduct (reportOf (mkActivity "two references" [reference breadFlow, reference flourFlow]))
+            details check `shouldBe` ["2 reference exchanges instead of exactly one"]
+
+        it "passes an activity with exactly one reference exchange" $
+            qcOffenders (qrReferenceProduct (reportOf (mkActivity "bread" [reference breadFlow, input flourFlow 1.0])))
+                `shouldBe` []
+
+        it "passes a treatment activity defined by its reference input" $
+            qcOffenders (qrReferenceProduct (reportOf (mkActivity "waste treatment" [referenceInput wasteFlow])))
+                `shouldBe` []
+
+    describe "allocation sums check" $ do
+        it "passes coproducts of one block summing to 100%" $ do
+            let db = dbOf [((actA, prodA), allocated "block" (Just 60) (Just "b1")), ((actA, prodB), allocated "block" (Just 40) (Just "b1"))]
+            qcOffenders (qrAllocationSums (qualityReport "testdb" db)) `shouldBe` []
+
+        it "flags coproducts summing to 90%, naming the sum" $ do
+            let db = dbOf [((actA, prodA), allocated "block" (Just 60) (Just "b1")), ((actA, prodB), allocated "block" (Just 30) (Just "b1"))]
+                check = qrAllocationSums (qualityReport "testdb" db)
+            details check `shouldBe` ["allocation sums to 90.0% across 2 coproduct(s)"]
+            severities check `shouldBe` [DangerSev]
+
+        it "tolerates source rounding (33.3 + 33.3 + 33.4)" $ do
+            let db =
+                    dbOf
+                        [ ((actA, prodA), allocated "block" (Just 33.3) (Just "b1"))
+                        , ((actA, prodB), allocated "block" (Just 33.3) (Just "b1"))
+                        , ((actA, u "1c"), allocated "block" (Just 33.4) (Just "b1"))
+                        ]
+            qcOffenders (qrAllocationSums (qualityReport "testdb" db)) `shouldBe` []
+
+        it "flags a NaN percentage, which every comparison would otherwise pass" $ do
+            let db = dbOf [((actA, prodA), allocated "block" (Just (0 / 0)) (Just "b1"))]
+            length (qcOffenders (qrAllocationSums (qualityReport "testdb" db))) `shouldBe` 1
+
+        it "keeps same-named blocks with distinct identifiers apart" $ do
+            -- Both blocks are internally complete at 100%. Merging them by name
+            -- would sum to 200% and invent two findings.
+            let db = dbOf [((actA, prodA), allocated "truncated name" (Just 100) (Just "b1")), ((actB, prodB), allocated "truncated name" (Just 100) (Just "b2"))]
+            qcOffenders (qrAllocationSums (qualityReport "testdb" db)) `shouldBe` []
+
+        it "does not judge a group where only some entries carry a percentage" $ do
+            let db = dbOf [((actA, prodA), allocated "block" (Just 60) (Just "b1")), ((actA, prodB), allocated "block" Nothing (Just "b1"))]
+            qcOffenders (qrAllocationSums (qualityReport "testdb" db)) `shouldBe` []
+
+        it "reports not-applicable on a database without allocation data" $ do
+            let check = qrAllocationSums (reportOf (mkActivity "bread" [reference breadFlow]))
+            qcApplicable check `shouldBe` False
+            qcOffenders check `shouldBe` []
+
+        it "reports applicable as soon as one entry carries a percentage" $
+            qcApplicable (qrAllocationSums (reportOf (allocated "block" (Just 100) (Just "b1")))) `shouldBe` True
+
+    describe "duplicate activities check" $ do
+        it "flags the same name, location and reference product under distinct keys" $ do
+            let db = dbOf [((actA, prodA), mkActivity "bread" [reference breadFlow]), ((actB, prodB), mkActivity "bread" [reference breadFlow])]
+                check = qrDuplicateActivities (qualityReport "testdb" db)
+            details check `shouldBe` ["2 identical entries (same name, location and reference product)"]
+            map qoProductName (qcOffenders check) `shouldBe` [Just "bread"]
+            severities check `shouldBe` [WarningSev]
+
+        it "passes the same name with a different reference product" $ do
+            let db = dbOf [((actA, prodA), mkActivity "bakery" [reference breadFlow]), ((actB, prodB), mkActivity "bakery" [reference flourFlow])]
+            qcOffenders (qrDuplicateActivities (qualityReport "testdb" db)) `shouldBe` []
+
+        it "skips entries whose reference is broken, leaving them to the reference check" $ do
+            let db = dbOf [((actA, prodA), mkActivity "bread" []), ((actB, prodB), mkActivity "bread" [])]
+            qcOffenders (qrDuplicateActivities (qualityReport "testdb" db)) `shouldBe` []
+
+    describe "suspicious amounts check" $ do
+        it "flags a non-finite amount" $ do
+            let check = qrSuspiciousAmounts (reportOf (mkActivity "bread" [reference breadFlow, input flourFlow (0 / 0)]))
+            details check `shouldBe` ["exchange \"flour\" has a non-finite amount"]
+            severities check `shouldBe` [DangerSev]
+
+        it "flags an infinite amount" $
+            length (qcOffenders (qrSuspiciousAmounts (reportOf (mkActivity "bread" [reference breadFlow, input flourFlow (1 / 0)]))))
+                `shouldBe` 1
+
+        it "flags a zero reference amount, which normalization divides by" $ do
+            let check = qrSuspiciousAmounts (reportOf (mkActivity "bread" [techExchange breadFlow 0 ReferenceProduct]))
+            details check `shouldBe` ["reference exchange \"bread\" has amount 0, which normalization would divide by"]
+
+        it "passes an ordinary input at zero" $
+            qcOffenders (qrSuspiciousAmounts (reportOf (mkActivity "bread" [reference breadFlow, input flourFlow 0])))
+                `shouldBe` []
+
+    describe "missing metadata check" $ do
+        it "flags an empty description as info" $ do
+            let check = qrMissingMetadata (reportOf (mkActivity "bread" [reference breadFlow]){activityDescription = []})
+            details check `shouldBe` ["no description"]
+            severities check `shouldBe` [InfoSev]
+
+        it "flags a description of blank paragraphs" $
+            details (qrMissingMetadata (reportOf (mkActivity "bread" [reference breadFlow]){activityDescription = ["", "   "]}))
+                `shouldBe` ["no description"]
+
+        it "flags a missing classification as info" $
+            details (qrMissingMetadata (reportOf (mkActivity "bread" [reference breadFlow]){activityClassification = M.empty}))
+                `shouldBe` ["no classification"]
+
+        it "flags a missing location as warning" $ do
+            let check = qrMissingMetadata (reportOf (mkActivity "bread" [reference breadFlow]){activityLocation = ""})
+            details check `shouldBe` ["no location"]
+            severities check `shouldBe` [WarningSev]
+
+        it "flags exchanges whose unit is absent from the registry, with a count" $ do
+            let act = mkActivity "bread" [reference breadFlow, (input flourFlow 1.0){techUnitId = unknownUnit}]
+                check = qrMissingMetadata (reportOf act)
+            details check `shouldBe` ["1 exchange(s) whose unit is absent from the unit registry"]
+            severities check `shouldBe` [WarningSev]
+
+        it "passes a fully documented activity" $
+            qcOffenders (qrMissingMetadata (reportOf (mkActivity "bread" [reference breadFlow]))) `shouldBe` []
+
+    describe "report header" $
+        it "counts one process per (activity, product) entry" $ do
+            let db = dbOf [((actA, prodA), mkActivity "bread" [reference breadFlow]), ((actB, prodB), mkActivity "cake" [reference flourFlow])]
+            qrProcessCount (qualityReport "testdb" db) `shouldBe` 2
+
+    describe "wire projection" $ do
+        it "caps the offender list but keeps the full count" $ do
+            let act = (mkActivity "bread" [reference breadFlow]){activityDescription = [], activityClassification = M.empty}
+                check = qraMissingMetadata (qualityReportToAPI (Just 1) (reportOf act))
+            qcaOffenderCount check `shouldBe` 2
+            length (qcaOffenders check) `shouldBe` 1
+
+        it "returns every offender when no limit is given" $ do
+            let act = (mkActivity "bread" [reference breadFlow]){activityDescription = [], activityClassification = M.empty}
+            length (qcaOffenders (qraMissingMetadata (qualityReportToAPI Nothing (reportOf act)))) `shouldBe` 2
+
+        it "orders findings worst-first, so a cap keeps the worst" $ do
+            -- Missing location (warning) must outrank missing description (info).
+            let act = (mkActivity "bread" [reference breadFlow]){activityDescription = [], activityLocation = ""}
+            map qoaSeverity (qcaOffenders (qraMissingMetadata (qualityReportToAPI Nothing (reportOf act))))
+                `shouldBe` [WarningSev, InfoSev]
+
+        it "carries applicable through to the wire" $
+            qcaApplicable (qraAllocationSums (qualityReportToAPI Nothing (reportOf (mkActivity "bread" [reference breadFlow]))))
+                `shouldBe` False
+
+    describe "severity wire codes" $ do
+        it "round-trips every severity through JSON" $
+            map (decode . encode) [DangerSev, WarningSev, InfoSev]
+                `shouldBe` [Just DangerSev, Just WarningSev, Just InfoSev]
+
+        it "encodes as stable lowercase codes, not constructor names" $
+            encode [DangerSev, WarningSev, InfoSev] `shouldBe` "[\"danger\",\"warning\",\"info\"]"
+
+        it "rejects an unknown code rather than defaulting" $
+            (decode "\"bogus\"" :: Maybe Severity) `shouldBe` Nothing

--- a/test/QualityReportSpec.hs
+++ b/test/QualityReportSpec.hs
@@ -165,8 +165,20 @@ spec = do
         it "flags coproducts summing to 90%, naming the sum" $ do
             let db = dbOf [((actA, prodA), allocated "block" (Just 60) (Just "b1")), ((actA, prodB), allocated "block" (Just 30) (Just "b1"))]
                 check = qrAllocationSums (qualityReport "testdb" db)
-            details check `shouldBe` ["allocation sums to 90.0% across 2 coproduct(s)"]
+            details check `shouldBe` ["allocation sums to 90.00% across 2 coproduct(s)"]
             severities check `shouldBe` [DangerSev]
+
+        it "rounds the reported sum to two decimals, free of floating-point dust" $ do
+            -- 33.3 + 33.3 + 3.3 is 69.89999999999999 as a double; the message
+            -- must not say so, and the judgement still flags it.
+            let db =
+                    dbOf
+                        [ ((actA, prodA), allocated "block" (Just 33.3) (Just "b1"))
+                        , ((actA, prodB), allocated "block" (Just 33.3) (Just "b1"))
+                        , ((actA, u "1c"), allocated "block" (Just 3.3) (Just "b1"))
+                        ]
+            details (qrAllocationSums (qualityReport "testdb" db))
+                `shouldBe` ["allocation sums to 69.90% across 3 coproduct(s)"]
 
         it "tolerates source rounding (33.3 + 33.3 + 33.4)" $ do
             let db =

--- a/test/RoutesSpec.hs
+++ b/test/RoutesSpec.hs
@@ -270,6 +270,11 @@ routeSpecs = do
             resp <- doGet b "/api/v1/db/no-such-db/gap-report"
             statusCode (responseStatus resp) `shouldBe` 404
 
+        it "GET /api/v1/db/no-such-db/quality-report returns 404" $ \b -> do
+            -- Same contract as the gap report: loaded or staged, or nothing.
+            resp <- doGet b "/api/v1/db/no-such-db/quality-report"
+            statusCode (responseStatus resp) `shouldBe` 404
+
     describe "method-not-allowed" $ do
         it "GET /api/v1/db/X returns 405 (only DELETE is defined on /db/{name})" $ \b -> do
             -- Documents the current API surface: /db/{name} accepts DELETE,

--- a/volca.cabal
+++ b/volca.cabal
@@ -48,6 +48,7 @@ library
                      , Database.CrossLinking
                      , Database.RelinkMapping
                      , Database.MatrixBuild
+                     , Database.Quality
                      , Database.Upload
                      , Database.UploadedDatabase
                      , SubstanceRegistry
@@ -285,6 +286,7 @@ test-suite lca-tests
                      , SensitivitySpec
                      , CrossDBSubstitutionSpec
                      , GapReportSpec
+                     , QualityReportSpec
                      , GlobalSubstitutionSpec
                      , DatabaseStatusSpec
                      , DependencyChoiceSpec


### PR DESCRIPTION
## Why

The engine can already tell you what a database is *missing* (the supplier-gap report). It can't tell you what is *malformed* in it. Those are different questions, and the second one is what a database maker asks before trusting a file: is this dataset well formed?

A score doesn't answer it. A database with two reference products on one entry, or coproducts allocated to 90%, still computes — it just computes something wrong, silently.

## What

`GET /db/{db}/quality-report?limit=` and the `get_quality_report` MCP tool, returning five structural checks:

| Check | Severity | What it catches |
|---|---|---|
| Reference product | danger | Entries without exactly one reference exchange |
| Allocation sums | danger / warning | Coproducts of one block not summing to 100% (±0.5 for source rounding); a block where only some coproducts carry a percentage is a warning of its own |
| Duplicate activities | warning | Same name, location and reference product, twice |
| Suspicious amounts | danger | Non-finite amounts; a zero reference amount |
| Missing metadata | info / warning | No description, no classification, no location, units absent from the registry |

Each finding carries its severity, the activity it was found on, and a readable detail. `limit` caps the findings listed per check; `offenderCount` always covers the full list, so a truncated list stays countable.

## Notes for the reviewer

- **Staged and loaded alike.** The whole report is a pure `SimpleDatabase -> QualityReport` scan needing no matrices, so `Database.Manager` dispatches both phases to one function. These defects are worth seeing *before* committing to a build.
- **Allocation grouping.** Groups by `activityGroupKey` (activity UUID + native block id), the same key `Database.MatrixBuild` already uses. Grouping by name would be wrong: source names are truncated to 80 characters and reused across unrelated blocks, so unrelated coproducts would sum to ~200%. A source format without a block identifier keeps the pre-existing UUID-only fallback — that ceiling is noted in a comment rather than papered over.
- **`applicable` is not `passed`.** A database with no allocation data reports `applicable: false`. Returning "0 findings" would claim a check ran that had nothing to judge.
- **`Severity` constructors are suffixed** (`DangerSev`…) for the reason `LocationKind` uses `ExactLoc`…: `Types` is re-exported wholesale and bare `Warning`/`Info` collide with `ProgressLevel`.

## Verification

33 new spec cases (each check plus its negative controls: a treatment activity defined by its reference input, 33.3×3 rounding, an ordinary input at zero, same-named blocks with distinct identifiers). Full suite green at 1659 examples; hlint and fourmolu clean.

Exercised end-to-end against a running engine: the report answers on a **staged, never-finalized** database (`isLoaded: false` → HTTP 200), `limit=1` caps the list while `offenderCount` stays at 3, an unknown database 404s with the engine's message, and the MCP tool returns the same wire shape. On a real SimaPro database the allocation check correctly reports `applicable: true` (against `false` on EcoSpold, which carries no allocation), and the metadata check surfaced genuine findings — activities whose location lives in the name rather than the location field.
