### PR TITLE
Read a method collection's format from its method directory

### DIFF
--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -108,7 +108,7 @@ import App.Env (AppEnv (..), AppM)
 import Config (DatabaseConfig (..), HostingConfig (..), MethodConfig (..), RefDataConfig (..))
 import Control.Concurrent.STM (readTVarIO)
 import Control.Monad.Reader (asks)
-import Data.Aeson (Value, toJSON)
+import Data.Aeson (Value)
 import qualified Data.Aeson as A
 import qualified Data.Aeson.KeyMap as KM
 import Data.Maybe (fromMaybe)
@@ -166,7 +166,9 @@ import Database.Upload (
     DatabaseFormat (..),
     UploadData (..),
     UploadResult (..),
+    detectMethodFormat,
     findMethodDirectory,
+    formatDisplayText,
     handleUpload,
  )
 import qualified Database.UploadedDatabase as UploadedDB
@@ -640,12 +642,6 @@ makeRelative base path
     | base `isPrefixOf` path = drop (length base + 1) path -- +1 for separator
     | otherwise = path
 
--- | Convert DatabaseFormat to display text (uses ToJSON instance: "EcoSpold 2", etc.)
-formatDisplayText :: DatabaseFormat -> Text
-formatDisplayText fmt = case toJSON fmt of
-    A.String t -> t
-    _ -> ""
-
 -- | Convert DatabaseFormat to API slug text
 formatToText :: DatabaseFormat -> Text
 formatToText SimaProCSV = "simapro-csv"
@@ -742,6 +738,10 @@ uploadMethodHandler mName mDesc src =
 
                 -- Find the actual method XML directory (e.g. ILCD/lciamethods/)
                 methodDir <- liftIO $ findMethodDirectory uploadDir
+                -- Format comes from the method directory, not from the database
+                -- detector: companion spreadsheets shipped alongside a method
+                -- package would otherwise read as a Brightway Excel inventory.
+                methodFormat <- liftIO $ detectMethodFormat methodDir
 
                 -- Create meta.toml (store path relative to upload dir)
                 let meta =
@@ -749,7 +749,7 @@ uploadMethodHandler mName mDesc src =
                             { UploadedDB.umVersion = 1
                             , UploadedDB.umDisplayName = name
                             , UploadedDB.umDescription = mDescription
-                            , UploadedDB.umFormat = urFormat uploadResult
+                            , UploadedDB.umFormat = methodFormat
                             , UploadedDB.umDataPath = makeRelative uploadDir methodDir
                             }
                 liftIO $ UploadedDB.writeUploadMeta uploadDir meta
@@ -762,7 +762,7 @@ uploadMethodHandler mName mDesc src =
                             , mcActive = False
                             , mcIsUploaded = True
                             , mcDescription = mDescription
-                            , mcFormat = Just $ formatToText $ urFormat uploadResult
+                            , mcFormat = Just $ formatDisplayText methodFormat
                             , mcScoringSets = []
                             , mcGlobalMethods = []
                             , mcPatches = []

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -167,6 +167,7 @@ import Database.Upload (
     UploadData (..),
     UploadResult (..),
     detectMethodFormat,
+    detectedFormatLabel,
     findMethodDirectory,
     formatDisplayText,
     handleUpload,
@@ -762,7 +763,7 @@ uploadMethodHandler mName mDesc src =
                             , mcActive = False
                             , mcIsUploaded = True
                             , mcDescription = mDescription
-                            , mcFormat = Just $ formatDisplayText methodFormat
+                            , mcFormat = detectedFormatLabel methodFormat
                             , mcScoringSets = []
                             , mcGlobalMethods = []
                             , mcPatches = []

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -230,7 +230,7 @@ import API.Types (DepLoadResult (..))
 import qualified Data.Text.IO as TIO
 import Database.CrossLinking (IndexedDatabase (..), LinkingContext (..), buildIndexedDatabaseFromDB, defaultLinkingThreshold)
 import qualified Database.CrossLinking as CrossLinking
-import Database.Upload (DatabaseFormat (..), findMethodDirectory, listDirectoryRecursive)
+import Database.Upload (detectMethodFormat, findMethodDirectory, formatDisplayText, listDirectoryRecursive)
 import qualified Database.Upload as Upload
 import qualified Database.UploadedDatabase as UploadedDB
 import Method.FlowResolver (ILCDFlowInfo)
@@ -1246,12 +1246,6 @@ warnZeroTouchPatches collName stats =
                 <> T.unpack (Method.Patch.describePatch patch)
                 <> "\" touched 0 characterization factors — check the selector."
 
--- | Convert a DatabaseFormat to display text for methods
-methodFormatText :: DatabaseFormat -> Text
-methodFormatText SimaProCSV = "SimaPro CSV"
-methodFormatText ILCDProcess = "ILCD"
-methodFormatText f = T.pack (show f)
-
 discoverUploadedMethodConfigs :: IO [MethodConfig]
 discoverUploadedMethodConfigs = do
     uploads <- UploadedDB.discoverUploadedMethods
@@ -1259,6 +1253,9 @@ discoverUploadedMethodConfigs = do
         reportProgress Info $ "Discovered uploaded method: " <> T.unpack slug
         -- Find the actual method XML directory (e.g., ILCD/lciamethods/)
         methodDir <- findMethodDirectory dirPath
+        -- Read the format off the directory rather than meta.toml: the file on
+        -- disk may predate method-aware detection, and can't drift this way.
+        methodFormat <- detectMethodFormat methodDir
         return
             MethodConfig
                 { mcName = UploadedDB.umDisplayName meta
@@ -1266,7 +1263,7 @@ discoverUploadedMethodConfigs = do
                 , mcActive = False -- Never auto-load uploaded methods
                 , mcIsUploaded = True
                 , mcDescription = UploadedDB.umDescription meta
-                , mcFormat = Just $ methodFormatText (UploadedDB.umFormat meta)
+                , mcFormat = Just $ formatDisplayText methodFormat
                 , mcScoringSets = []
                 , mcGlobalMethods = []
                 , mcPatches = []

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -230,7 +230,7 @@ import API.Types (DepLoadResult (..))
 import qualified Data.Text.IO as TIO
 import Database.CrossLinking (IndexedDatabase (..), LinkingContext (..), buildIndexedDatabaseFromDB, defaultLinkingThreshold)
 import qualified Database.CrossLinking as CrossLinking
-import Database.Upload (detectMethodFormat, findMethodDirectory, formatDisplayText, listDirectoryRecursive)
+import Database.Upload (detectMethodFormat, detectedFormatLabel, findMethodDirectory, listDirectoryRecursive)
 import qualified Database.Upload as Upload
 import qualified Database.UploadedDatabase as UploadedDB
 import Method.FlowResolver (ILCDFlowInfo)
@@ -1263,7 +1263,7 @@ discoverUploadedMethodConfigs = do
                 , mcActive = False -- Never auto-load uploaded methods
                 , mcIsUploaded = True
                 , mcDescription = UploadedDB.umDescription meta
-                , mcFormat = Just $ formatDisplayText methodFormat
+                , mcFormat = detectedFormatLabel methodFormat
                 , mcScoringSets = []
                 , mcGlobalMethods = []
                 , mcPatches = []

--- a/src/Database/Upload.hs
+++ b/src/Database/Upload.hs
@@ -32,6 +32,7 @@ module Database.Upload (
     countMethodFilesIn,
     anyMethodFilesIn,
     detectMethodFormat,
+    detectedFormatLabel,
     formatDisplayText,
     slugify,
 ) where
@@ -85,6 +86,14 @@ formatDisplayText :: DatabaseFormat -> Text
 formatDisplayText fmt = case toJSON fmt of
     A.String t -> t
     _ -> ""
+
+{- | Label for a format that was detected rather than declared.
+'Nothing' when detection failed, so a caller can say so — or fall back to its own
+guess — instead of advertising an empty format.
+-}
+detectedFormatLabel :: DatabaseFormat -> Maybe Text
+detectedFormatLabel UnknownFormat = Nothing
+detectedFormatLabel fmt = Just (formatDisplayText fmt)
 
 instance FromJSON DatabaseFormat where
     parseJSON = withText "DatabaseFormat" $ \case
@@ -584,13 +593,20 @@ otherwise be mistaken for a Brightway Excel inventory.
 -}
 detectMethodFormat :: FilePath -> IO DatabaseFormat
 detectMethodFormat dir = do
-    fs <- listDirectory dir
-    let withExt e = [dir </> f | f <- fs, map toLower (takeExtension f) == e]
-    firstMatch
-        [ (SimaProCSV, return $ not $ null $ withExt ".csv")
-        , (ILCDProcess, anyM isMethodXml (withExt ".xml"))
-        , (OpenLcaJsonLd, anyM isOlcaJsonFile (withExt ".json"))
-        ]
+    listed <- try @SomeException (listDirectory dir)
+    case listed of
+        -- An unreadable directory is not a format guess, and must not abort the
+        -- caller: discovery walks every uploaded collection in one pass.
+        Left _ -> return UnknownFormat
+        Right fs -> do
+            let withExt e = [dir </> f | f <- fs, map toLower (takeExtension f) == e]
+            firstMatch
+                [ (ILCDProcess, anyM isMethodXml (withExt ".xml"))
+                , (OpenLcaJsonLd, anyM isOlcaJsonFile (withExt ".json"))
+                , -- Content-checked, like the two above: a stray spreadsheet
+                  -- export next to the method files is not a SimaPro method.
+                  (SimaProCSV, checkForSimaProCSV (withExt ".csv"))
+                ]
   where
     -- No fallback guess: an unrecognized directory stays UnknownFormat.
     firstMatch [] = return UnknownFormat

--- a/src/Database/Upload.hs
+++ b/src/Database/Upload.hs
@@ -31,6 +31,8 @@ module Database.Upload (
     findAllMethodDirectories,
     countMethodFilesIn,
     anyMethodFilesIn,
+    detectMethodFormat,
+    formatDisplayText,
     slugify,
 ) where
 
@@ -77,6 +79,12 @@ instance ToJSON DatabaseFormat where
     toJSON OpenLcaJsonLd = A.String "openLCA JSON-LD"
     toJSON BrightwayExcel = A.String "Brightway Excel"
     toJSON UnknownFormat = A.String ""
+
+-- | Human-readable label for a format, straight from the 'ToJSON' instance above.
+formatDisplayText :: DatabaseFormat -> Text
+formatDisplayText fmt = case toJSON fmt of
+    A.String t -> t
+    _ -> ""
 
 instance FromJSON DatabaseFormat where
     parseJSON = withText "DatabaseFormat" $ \case
@@ -569,6 +577,25 @@ findMethodDirectory dir = do
                 (best : _) -> return (fst best)
                 [] -> return dir
 
+{- | Detect the format of a method collection from its method directory.
+Looks at that one directory only (like 'anyMethodFilesIn'), never at the whole
+extraction tree: a method package often ships companion spreadsheets that would
+otherwise be mistaken for a Brightway Excel inventory.
+-}
+detectMethodFormat :: FilePath -> IO DatabaseFormat
+detectMethodFormat dir = do
+    fs <- listDirectory dir
+    let withExt e = [dir </> f | f <- fs, map toLower (takeExtension f) == e]
+    firstMatch
+        [ (SimaProCSV, return $ not $ null $ withExt ".csv")
+        , (ILCDProcess, anyM isMethodXml (withExt ".xml"))
+        , (OpenLcaJsonLd, anyM isOlcaJsonFile (withExt ".json"))
+        ]
+  where
+    -- No fallback guess: an unrecognized directory stays UnknownFormat.
+    firstMatch [] = return UnknownFormat
+    firstMatch ((fmt, check) : rest) = check >>= \b -> if b then return fmt else firstMatch rest
+
 -- | Find all directories containing ILCD method XML files under a root.
 findAllMethodDirectories :: FilePath -> IO [FilePath]
 findAllMethodDirectories = go
@@ -610,11 +637,11 @@ anyMethodFilesIn d = do
             if hasMethodXml
                 then return True
                 else anyM isOlcaJsonFile jsonFiles
-  where
-    anyM _ [] = return False
-    anyM p (x : xs) = do
-        b <- p x
-        if b then return True else anyM p xs
+
+-- | Short-circuiting monadic 'any'.
+anyM :: (a -> IO Bool) -> [a] -> IO Bool
+anyM _ [] = return False
+anyM p (x : xs) = p x >>= \b -> if b then return True else anyM p xs
 
 -- | Check if an XML file is an ILCD LCIA method dataset
 isMethodXml :: FilePath -> IO Bool

--- a/src/Database/UploadedDatabase.hs
+++ b/src/Database/UploadedDatabase.hs
@@ -140,13 +140,18 @@ parseMetaToml content = do
             , umDataPath = dataPath
             }
 
--- | Parse format string to DatabaseFormat
+{- | Parse a format string to a DatabaseFormat.
+Inverse of 'formatMetaToml''s writer below — every slug it can write is read back
+here. An unrecognized slug reads as 'UnknownFormat' rather than dropping the whole
+collection, since the format is re-detected from the files anyway.
+-}
 parseFormat :: Text -> Maybe DatabaseFormat
 parseFormat "ecospold2" = Just EcoSpold2
 parseFormat "ecospold1" = Just EcoSpold1
 parseFormat "simapro" = Just SimaProCSV
 parseFormat "ilcd" = Just ILCDProcess
 parseFormat "openlca-jsonld" = Just OpenLcaJsonLd
+parseFormat "brightway-excel" = Just BrightwayExcel
 parseFormat _ = Just UnknownFormat
 
 -- | Format meta.toml content

--- a/test/MethodUploadSpec.hs
+++ b/test/MethodUploadSpec.hs
@@ -127,6 +127,23 @@ spec = do
                 detectMethodFormat found `shouldReturn` ILCDProcess
                 formatDisplayText ILCDProcess `shouldBe` "ILCD"
 
+    describe "detectMethodFormat when nothing matches" $ do
+        it "does not read a non-SimaPro CSV sitting next to the method files as SimaPro" $
+            withSystemTempDirectory "volca-method-format-csv" $ \tmp -> do
+                BL.writeFile (tmp </> "climate.xml") miniLciaMethodXml
+                BL.writeFile (tmp </> "factors.csv") (BLC.pack "flow,cf\nCO2,1.0\n")
+                detectMethodFormat tmp `shouldReturn` ILCDProcess
+
+        it "stays UnknownFormat, with no label to advertise, on an unrecognized directory" $
+            withSystemTempDirectory "volca-method-format-empty" $ \tmp -> do
+                BL.writeFile (tmp </> "readme.txt") (BLC.pack "nothing to see")
+                detectMethodFormat tmp `shouldReturn` UnknownFormat
+                detectedFormatLabel UnknownFormat `shouldBe` Nothing
+
+        it "reports UnknownFormat instead of throwing on a missing directory" $
+            withSystemTempDirectory "volca-method-format-gone" $ \tmp ->
+                detectMethodFormat (tmp </> "does-not-exist") `shouldReturn` UnknownFormat
+
     describe "loadMethodCollectionFromConfig on the uploaded JSON" $
         it "produces one Method with one CF carrying the fixture's value" $
             withSystemTempDirectory "volca-method-load" $ \tmp -> do

--- a/test/MethodUploadSpec.hs
+++ b/test/MethodUploadSpec.hs
@@ -51,6 +51,16 @@ miniImpactCategoryJson =
             , "}"
             ]
 
+-- | A minimal ILCD LCIA method dataset — only the root element matters here.
+miniLciaMethodXml :: BL.ByteString
+miniLciaMethodXml =
+    BLC.pack $
+        unlines
+            [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            , "<LCIAMethodDataSet xmlns=\"http://lca.jrc.it/ILCD/LCIAMethod\">"
+            , "</LCIAMethodDataSet>"
+            ]
+
 -- | An openLCA Process document — must NOT be picked up as a method.
 miniProcessJson :: BL.ByteString
 miniProcessJson =
@@ -96,6 +106,26 @@ spec = do
                 createDirectoryIfMissing True dir
                 BL.writeFile (dir </> "impact-category.json") miniImpactCategoryJson
                 detectDatabaseFormat dir `shouldReturn` OpenLcaJsonLd
+
+    describe "detectMethodFormat on an ILCD method package" $
+        -- Regression: an EF 3.1 ILCD package ships companion spreadsheets
+        -- (normalisation factors, UUID mappings) outside the method directory.
+        -- The database detector saw those and called the whole thing Brightway
+        -- Excel, so the Methods page advertised the wrong format.
+        it "reads ILCD off the method directory, ignoring companion spreadsheets" $
+            withSystemTempDirectory "volca-method-format" $ \tmp -> do
+                let methodDir = tmp </> "ILCD" </> "lciamethods"
+                    otherDir = tmp </> "other"
+                createDirectoryIfMissing True methodDir
+                createDirectoryIfMissing True otherDir
+                BL.writeFile (methodDir </> "climate.xml") miniLciaMethodXml
+                BL.writeFile (otherDir </> "Normalisation_Weighting_Factors.xlsx") (BLC.pack "PK stub")
+                -- The database detector is the one that gets it wrong:
+                detectDatabaseFormat tmp `shouldReturn` BrightwayExcel
+                found <- findMethodDirectory tmp
+                found `shouldBe` methodDir
+                detectMethodFormat found `shouldReturn` ILCDProcess
+                formatDisplayText ILCDProcess `shouldBe` "ILCD"
 
     describe "loadMethodCollectionFromConfig on the uploaded JSON" $
         it "produces one Method with one CF carrying the fixture's value" $


### PR DESCRIPTION
## Why

An uploaded ILCD method package (EF 3.1) was listed with the format `brightway-excel`. Parsing and loading were fine — only the advertised format was wrong.

Method upload asked the **database** format detector, which scans the whole extraction tree. An EF 3.1 package ships companion spreadsheets outside the method files (`other/Normalisation_Weighting_Factors_EF_3.1.xlsx`, `other/converter/Mapping_UUID.xlsx`), so the `.xlsx` branch won.

The method-aware detection already existed, and the very same upload already used it — but only to locate the directory, never to name the format.

## Final state

Format comes from the method directory, via a new `detectMethodFormat` that reuses the existing content-aware `isMethodXml` / `isOlcaJsonFile` checks. A directory matching nothing stays `UnknownFormat` rather than guessing.

Discovery reads the format off the disk instead of trusting `meta.toml`. Collections uploaded before this fix therefore correct themselves on restart, with no migration and no re-upload, and the metadata file can no longer drift from the directory it describes.

The three format-to-text variants — API slug after upload, constructor name after discovery, label for preinstalled entries — collapse onto a single `formatDisplayText` backed by the existing `ToJSON` instance, so the listing reads the same before and after a restart.

Verified against the real artifact, not only in tests: pointed at an existing collection whose `meta.toml` still says `format = "brightway-excel"`, `/api/v1/method-collections` now answers `"format": "ILCD"`.

The regression test rebuilds the trap (an ILCD method directory plus a decoy spreadsheet) and also asserts that the database detector still gets it wrong on that layout — a guard worth keeping the day someone considers merging the two detectors.