### PR TITLE
Make the database setup and finalize endpoints agree

### DIFF
--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -155,6 +155,7 @@ import Database.Manager (
     removeMethodCollection,
     removeUnitDefs,
     setDataPath,
+    setupErrorMessage,
     unloadCompartmentMappings,
     unloadDatabase,
     unloadFlowSynonyms,
@@ -668,6 +669,9 @@ getDatabaseSetupHandler dbName = do
         Left (ex :: SomeException) ->
             throwError $ err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ "Setup failed: " <> T.pack (show ex)}
         Right (Left (SetupNotFound msg)) -> throwError $ err404{errBody = BSL.fromStrict $ T.encodeUtf8 msg}
+        -- Same 404 + "Database not loaded: " body as every other not-loaded
+        -- arm, so typed-error recovery on the client keeps working.
+        Right (Left e@(SetupNotLoaded _)) -> throwError $ err404{errBody = BSL.fromStrict $ T.encodeUtf8 (setupErrorMessage e)}
         Right (Left (SetupFailed msg)) -> throwError $ err500{errBody = BSL.fromStrict $ T.encodeUtf8 msg}
         Right (Right setupInfo) -> return setupInfo
 

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -128,7 +128,7 @@ import Data.Either (lefts, partitionEithers, rights)
 import Data.List (isPrefixOf, sortOn, unsnoc)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
-import Data.Maybe (catMaybes, fromMaybe, isJust)
+import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing)
 import Data.OpenApi (NamedSchema (..), OpenApiType (..), ToSchema (..), enum_, type_)
 import Data.Ord (Down (..))
 import qualified Data.Set as S
@@ -1625,18 +1625,16 @@ loadDatabaseSingle manager dbName = do
     -- Check if already staged -> try to finalize, or clear stale staged entry
     stagedDbs <- readTVarIO (dmStagedDbs manager)
     case M.lookup dbName stagedDbs of
-        Just staged -> do
-            -- Check if the staged database can be finalized
-            let unlinked = Loader.countUnlinkedExchanges (sdSimpleDB staged)
-                crossDBLinks' = Loader.crossDBLinksCount (sdLinkingStats staged)
-                unresolvedLinks = max 0 (unlinked - crossDBLinks')
-            if unresolvedLinks == 0
-                then finalizeDatabase manager dbName
-                else do
-                    -- Cannot finalize: clear staged entry, reload from config
-                    -- (loadDatabase pre-loaded deps, so fresh load should resolve links)
-                    atomically $ modifyTVar' (dmStagedDbs manager) (M.delete dbName)
-                    loadDatabaseSingleFromConfig manager dbName
+        Just staged
+            -- Same readiness gate as finalize itself, so the shortcut and the
+            -- gate can't disagree
+            | isNothing (notReadyReason (stagedLinkCounts staged)) ->
+                finalizeDatabase manager dbName
+            | otherwise -> do
+                -- Cannot finalize: clear staged entry, reload from config
+                -- (loadDatabase pre-loaded deps, so fresh load should resolve links)
+                atomically $ modifyTVar' (dmStagedDbs manager) (M.delete dbName)
+                loadDatabaseSingleFromConfig manager dbName
         Nothing -> loadDatabaseSingleFromConfig manager dbName
 
 -- | Load a database from config (not staged)
@@ -2388,130 +2386,168 @@ buildSetupResult manager dbName = do
                 return $ Right $ buildLoadedSetupInfo (ldConfig loaded) (ldDatabase loaded) availableDbs indexedDbs
             Nothing -> return $ Left $ SetupFailed $ "Failed to stage database: " <> dbName
 
-{- | Missing-supplier list for a staged database. Nil-link gaps carry the rich
-blockers the attribute matcher produced ('cdlUnresolvedProducts'); non-nil
-dangling gaps — a partial EcoSpold2 import whose background activities no loaded
-dependency ships, even after UUID + attribute linking — are scanned separately
-and named. The two sets are disjoint (nil vs non-nil), so the concatenation
-never duplicates. Sorted by activity count, descending.
+{- | Link-resolution tally shared by the setup page and the finalize gate.
+Both derive readiness from this one record, so "ready" and "can be finalized"
+can never drift apart.
+-}
+data LinkCounts = LinkCounts
+    { lcActivityCount :: !Int
+    , lcTotalInputs :: !Int
+    , lcInternalLinks :: !Int
+    , lcCrossDBLinks :: !Int
+    , lcUnresolvedLinks :: !Int
+    }
+
+mkLinkCounts :: Int -> Int -> Int -> Int -> LinkCounts
+mkLinkCounts activityCount totalInputs unlinked crossDB =
+    LinkCounts
+        { lcActivityCount = activityCount
+        , lcTotalInputs = totalInputs
+        , lcInternalLinks = max 0 (totalInputs - unlinked)
+        , lcCrossDBLinks = crossDB
+        , lcUnresolvedLinks = max 0 (unlinked - crossDB)
+        }
+
+-- | Tally for a staged database, from its parsed activities and linking stats.
+stagedLinkCounts :: StagedDatabase -> LinkCounts
+stagedLinkCounts staged =
+    mkLinkCounts
+        (M.size (sdbActivities sdb))
+        (Loader.countTotalTechInputs sdb)
+        (Loader.countUnlinkedExchanges sdb)
+        (Loader.crossDBLinksCount (sdLinkingStats staged))
+  where
+    sdb = sdSimpleDB staged
+
+{- | Tally for a loaded database. Counts are recomputed from the activity set
+via the same predicate as the staged path ('Loader.countUnlinkedExchanges'),
+not read from 'dbLinkingStats': the stats only track nil-link / cross-DB
+resolution and are blind to dangling internal links (non-nil 'activityLinkId'
+pointing at an activity the database doesn't ship). A database bulk-loaded
+from config bypasses the finalize gate, so without this it would report a
+partial EcoSpold2 import as 100% ready while the matrix silently drops those
+inputs.
+-}
+loadedLinkCounts :: Database -> LinkCounts
+loadedLinkCounts db =
+    mkLinkCounts
+        (fromIntegral (dbActivityCount db))
+        (Loader.countTotalTechInputs sdb)
+        (Loader.countUnlinkedExchanges sdb)
+        (length (dbCrossDBLinks db))
+  where
+    sdb = toSimpleDatabase db
+
+-- | Percentage of resolved inputs (0-100); an inputless database is complete.
+lcCompleteness :: LinkCounts -> Double
+lcCompleteness lc
+    | lcTotalInputs lc > 0 =
+        100.0 * fromIntegral (lcInternalLinks lc + lcCrossDBLinks lc) / fromIntegral (lcTotalInputs lc)
+    | otherwise = 100.0
+
+{- | Why a database cannot be finalized — 'Nothing' means ready. The setup
+page's 'dsiIsReady' is the 'isNothing' of this, so the ready badge and the
+finalize gate always agree.
+-}
+notReadyReason :: LinkCounts -> Maybe Text
+notReadyReason lc
+    | lcActivityCount lc == 0 =
+        Just "database contains 0 activities. The data file may be corrupted or in an unsupported format."
+    | lcUnresolvedLinks lc > 0 =
+        Just $
+            T.pack (show (lcUnresolvedLinks lc))
+                <> " unresolved inputs. Add dependencies to resolve them first."
+    | otherwise = Nothing
+
+{- | Rank missing products by demanding-input count, descending. Nil-link gaps
+carry the rich blockers the attribute matcher produced; dangling non-nil gaps
+are tagged 'NoNameMatch'. The two sets are disjoint (nil vs non-nil), so the
+concatenation never duplicates.
+-}
+rankMissingProducts :: Map Text (Int, LinkBlocker) -> Map Text Int -> [(Text, Int, LinkBlocker)]
+rankMissingProducts blocked dangling =
+    sortOn
+        (\(_, cnt, _) -> Down cnt)
+        ( [(name, cnt, blocker) | (name, (cnt, blocker)) <- M.toList blocked]
+            <> [(name, cnt, NoNameMatch) | (name, cnt) <- M.toList dangling]
+        )
+
+-- | Project one ranked missing product onto its wire shape.
+blockerToMissingSupplier :: (Text, Int, LinkBlocker) -> MissingSupplier
+blockerToMissingSupplier (name, cnt, blocker) =
+    let (reason, detail) = blockerReasonDetail blocker
+     in MissingSupplier name cnt Nothing reason detail
+
+{- | Missing-supplier list for a staged database: rich blockers from the
+linking stats plus dangling background links a partial import leaves behind
+('Loader.collectStagedDanglingProductNames'), ranked by demand.
 -}
 stagedMissingProducts :: SimpleDatabase -> CrossDBLinkingStats -> [(Text, Int, LinkBlocker)]
 stagedMissingProducts sdb stats =
-    let fromStats = [(name, cnt, blocker) | (name, (cnt, blocker)) <- M.toList (cdlUnresolvedProducts stats)]
-        fromDangling =
-            [ (name, cnt, NoNameMatch)
-            | (name, cnt) <- M.toList (Loader.collectStagedDanglingProductNames sdb (cdlLinks stats))
-            ]
-     in sortOn (\(_, cnt, _) -> Down cnt) (fromStats <> fromDangling)
+    rankMissingProducts
+        (cdlUnresolvedProducts stats)
+        (Loader.collectStagedDanglingProductNames sdb (cdlLinks stats))
 
-{- | Build setup info from a staged database
-dataPath and availablePaths are filled in by buildSetupResult (requires IO)
+{- | Assemble the wire record from the shared tally — the single place the
+completeness, readiness, and linking-stats fields are filled, for both the
+staged and the loaded builder. availablePaths is filled in by
+'buildSetupResult' for uploaded databases (requires IO).
 -}
+setupInfoFrom :: DatabaseConfig -> LinkCounts -> CrossDBLinkingStats -> [(Text, Int, LinkBlocker)] -> [DependencyChoice] -> Bool -> DatabaseSetupInfo
+setupInfoFrom config lc stats missing dependencies isLoaded =
+    DatabaseSetupInfo
+        { dsiName = dcName config
+        , dsiDisplayName = dcDisplayName config
+        , dsiActivityCount = lcActivityCount lc
+        , dsiInputCount = lcTotalInputs lc
+        , dsiCompleteness = lcCompleteness lc
+        , dsiInternalLinks = lcInternalLinks lc
+        , dsiCrossDBLinks = lcCrossDBLinks lc
+        , dsiUnresolvedLinks = lcUnresolvedLinks lc
+        , dsiMissingSuppliers = take 10 (map blockerToMissingSupplier missing)
+        , dsiDependencies = dependencies
+        , dsiIsReady = isNothing (notReadyReason lc)
+        , dsiUnknownUnits = S.toList (cdlUnknownUnits stats)
+        , dsiLocationFallbacks = deduplicateFallbacks (cdlLocationFallbacks stats)
+        , dsiLocationUnresolved = deduplicateUnresolved (cdlLocationUnresolved stats)
+        , dsiAttributeFallbacks = deduplicateAttributeFallbacks (cdlAttributeFallbacks stats)
+        , dsiDataPath = T.pack (dcPath config)
+        , dsiAvailablePaths = []
+        , dsiIsLoaded = isLoaded
+        }
+
+-- | Build setup info from a staged database
 buildStagedSetupInfo :: StagedDatabase -> Map Text DatabaseConfig -> Map Text IndexedDatabase -> DatabaseSetupInfo
 buildStagedSetupInfo staged configs indexedDbs =
     let stats = sdLinkingStats staged
-        -- Count from the actual database, not from cross-DB linking stats
-        totalInputs = Loader.countTotalTechInputs (sdSimpleDB staged)
-        unlinked = Loader.countUnlinkedExchanges (sdSimpleDB staged)
-        crossDBLinks = Loader.crossDBLinksCount stats
-        internalLinks = totalInputs - unlinked
-        unresolvedLinks = max 0 (unlinked - crossDBLinks)
-        resolved = internalLinks + crossDBLinks
-        completeness =
-            if totalInputs > 0
-                then 100.0 * fromIntegral resolved / fromIntegral totalInputs
-                else 100.0
-        -- Convert missing products to MissingSupplier with reason/detail
-        missingSuppliers = take 10 $ map blockerToMissingSupplier (sdMissingProducts staged)
-        blockerToMissingSupplier (name, cnt, blocker) =
-            let (reason, detail) = blockerReasonDetail blocker
-             in MissingSupplier name cnt Nothing reason detail
-        -- Combined dependencies list (selected + redundant + available, alpha sorted)
-        dependencies =
-            buildDependencyChoices
+     in setupInfoFrom
+            (sdConfig staged)
+            (stagedLinkCounts staged)
+            stats
+            (sdMissingProducts staged)
+            ( buildDependencyChoices
                 (dcName (sdConfig staged))
                 (sdSelectedDeps staged)
                 (crossDBRedundantSources (cdlLinks stats) (sdSelectedDeps staged))
                 configs
                 indexedDbs
-        -- Database is ready only when it has activities and all inputs are resolved
-        activityCount = M.size (sdbActivities (sdSimpleDB staged))
-        isReady = activityCount > 0 && unresolvedLinks == 0
-     in DatabaseSetupInfo
-            { dsiName = dcName (sdConfig staged)
-            , dsiDisplayName = dcDisplayName (sdConfig staged)
-            , dsiActivityCount = activityCount
-            , dsiInputCount = totalInputs
-            , dsiCompleteness = completeness
-            , dsiInternalLinks = internalLinks
-            , dsiCrossDBLinks = crossDBLinks
-            , dsiUnresolvedLinks = unresolvedLinks
-            , dsiMissingSuppliers = missingSuppliers
-            , dsiDependencies = dependencies
-            , dsiIsReady = isReady
-            , dsiUnknownUnits = S.toList (cdlUnknownUnits stats)
-            , dsiLocationFallbacks = deduplicateFallbacks (cdlLocationFallbacks stats)
-            , dsiLocationUnresolved = deduplicateUnresolved (cdlLocationUnresolved stats)
-            , dsiAttributeFallbacks = deduplicateAttributeFallbacks (cdlAttributeFallbacks stats)
-            , dsiDataPath = T.pack (dcPath (sdConfig staged))
-            , dsiAvailablePaths = [] -- Filled in by buildSetupResult (requires IO)
-            , dsiIsLoaded = False
-            }
+            )
+            False
 
-{- | Build setup info from a loaded database (already finalized).
-
-Counts are recomputed from the activity set via the same predicate as the
-staged path ('Loader.countUnlinkedExchanges'), not read from 'dbLinkingStats':
-the stats only track nil-link / cross-DB resolution and are blind to dangling
-internal links (non-nil 'activityLinkId' pointing at an activity the database
-doesn't ship). A database bulk-loaded from config bypasses the finalize gate,
-so without this it would report a partial EcoSpold2 import as 100% ready while
-the matrix silently drops those inputs. Rich blocker reasons still come from
-the stats; dangling links are appended.
+{- | Build setup info from a loaded database (already finalized). Counts come
+from 'loadedLinkCounts' (see its note on recomputing rather than trusting
+'dbLinkingStats'); rich blocker reasons still come from the stats, dangling
+links are ranked in with them.
 -}
 buildLoadedSetupInfo :: DatabaseConfig -> Database -> Map Text DatabaseConfig -> Map Text IndexedDatabase -> DatabaseSetupInfo
 buildLoadedSetupInfo config db configs indexedDbs =
-    let sdb = toSimpleDatabase db
-        stats = dbLinkingStats db
-        totalInputs = Loader.countTotalTechInputs sdb
-        unlinked = Loader.countUnlinkedExchanges sdb
-        nCrossDBLinks = length (dbCrossDBLinks db)
-        internalLinks = max 0 (totalInputs - unlinked)
-        unresolvedLinks = max 0 (unlinked - nCrossDBLinks)
-        resolved = internalLinks + nCrossDBLinks
-        completeness =
-            if totalInputs > 0
-                then 100.0 * fromIntegral resolved / fromIntegral totalInputs
-                else 100.0
-        blockerToMissingSupplier (name, (cnt, blocker)) =
-            let (reason, detail) = blockerReasonDetail blocker
-             in MissingSupplier name cnt Nothing reason detail
-        statsSuppliers = map blockerToMissingSupplier (M.toList (cdlUnresolvedProducts stats))
-        danglingSuppliers =
-            [ MissingSupplier name cnt Nothing "no_name_match" Nothing
-            | (name, cnt) <- M.toList (Loader.collectDanglingProductNames db)
-            ]
-        missingSuppliers = take 10 (statsSuppliers ++ danglingSuppliers)
-     in DatabaseSetupInfo
-            { dsiName = dcName config
-            , dsiDisplayName = dcDisplayName config
-            , dsiActivityCount = fromIntegral (dbActivityCount db)
-            , dsiInputCount = totalInputs
-            , dsiCompleteness = completeness
-            , dsiInternalLinks = internalLinks
-            , dsiCrossDBLinks = nCrossDBLinks
-            , dsiUnresolvedLinks = unresolvedLinks
-            , dsiMissingSuppliers = missingSuppliers
-            , dsiDependencies = buildDependencyChoices (dcName config) (dbDependsOn db) [] configs indexedDbs
-            , dsiIsReady = dbActivityCount db > 0 && unresolvedLinks == 0
-            , dsiUnknownUnits = S.toList (cdlUnknownUnits stats)
-            , dsiLocationFallbacks = deduplicateFallbacks (cdlLocationFallbacks stats)
-            , dsiLocationUnresolved = deduplicateUnresolved (cdlLocationUnresolved stats)
-            , dsiAttributeFallbacks = deduplicateAttributeFallbacks (cdlAttributeFallbacks stats)
-            , dsiDataPath = T.pack (dcPath config)
-            , dsiAvailablePaths = [] -- No picker for loaded/configured databases
-            , dsiIsLoaded = True
-            }
+    setupInfoFrom
+        config
+        (loadedLinkCounts db)
+        (dbLinkingStats db)
+        (rankMissingProducts (cdlUnresolvedProducts (dbLinkingStats db)) (Loader.collectDanglingProductNames db))
+        (buildDependencyChoices (dcName config) (dbDependsOn db) [] configs indexedDbs)
+        True
 
 {- | Discover candidate data paths within an uploaded database's root directory.
 Returns one 'PathCandidate' per candidate directory.
@@ -2757,130 +2793,119 @@ finalizeDatabase manager dbName = do
 
     case M.lookup dbName stagedDbs of
         Nothing -> do
-            -- Not staged — check if already loaded (no-op finalize)
+            -- Not staged — an already-loaded database finalizes as a no-op,
+            -- but only through the same readiness gate the setup page reports:
+            -- a partial import bulk-loaded from config must not get a success
+            -- where the setup says not ready.
             loadedDbs <- readTVarIO (dmLoadedDbs manager)
             case M.lookup dbName loadedDbs of
-                Just loaded -> return $ Right loaded
+                Just loaded ->
+                    return $ case notReadyReason (loadedLinkCounts (ldDatabase loaded)) of
+                        Just reason -> Left ("Cannot finalize: " <> reason)
+                        Nothing -> Right loaded
                 Nothing -> return $ Left $ "Staged database not found: " <> dbName
-        Just staged -> do
-            -- Reject finalization if there are unresolved links
-            let unlinked = Loader.countUnlinkedExchanges (sdSimpleDB staged)
-                crossDBLinks = Loader.crossDBLinksCount (sdLinkingStats staged)
-                unresolvedLinks = max 0 (unlinked - crossDBLinks)
-            let activityCount = M.size (sdbActivities (sdSimpleDB staged))
-            if activityCount == 0
-                then
-                    return $
-                        Left $
-                            "Cannot finalize: database contains 0 activities. "
-                                <> "The data file may be corrupted or in an unsupported format."
-                else
-                    if unresolvedLinks > 0
-                        then
-                            return $
-                                Left $
-                                    "Cannot finalize: "
-                                        <> T.pack (show unresolvedLinks)
-                                        <> " unresolved inputs. Add dependencies to resolve them first."
-                        else do
-                            reportProgress Info $ "[STARTING] Finalizing database: " <> T.unpack dbName
+        Just staged ->
+            case notReadyReason (stagedLinkCounts staged) of
+                Just reason -> return $ Left ("Cannot finalize: " <> reason)
+                Nothing -> do
+                    reportProgress Info $ "[STARTING] Finalizing database: " <> T.unpack dbName
 
-                            synonymDB <- getMergedSynonymDB manager
+                    synonymDB <- getMergedSynonymDB manager
 
-                            -- Use pre-built database from cache, or build matrices from scratch
-                            buildResult <- case sdCachedDB staged of
-                                Just cachedDb -> do
-                                    -- The on-disk cache == cachedDb. Carry the
-                                    -- (possibly edited) staged dependency pin and
-                                    -- its recomputed links onto the loaded DB so
-                                    -- the pin is authoritative; flag a re-save
-                                    -- when either diverges from what's on disk.
-                                    let pinned =
-                                            cachedDb
+                    -- Use pre-built database from cache, or build matrices from scratch
+                    buildResult <- case sdCachedDB staged of
+                        Just cachedDb -> do
+                            -- The on-disk cache == cachedDb. Carry the
+                            -- (possibly edited) staged dependency pin and
+                            -- its recomputed links onto the loaded DB so
+                            -- the pin is authoritative; flag a re-save
+                            -- when either diverges from what's on disk.
+                            let pinned =
+                                    cachedDb
+                                        { dbCrossDBLinks = sdCrossDBLinks staged
+                                        , dbDependsOn = sdSelectedDeps staged
+                                        , dbLinkingStats = sdLinkingStats staged
+                                        }
+                                needsSave =
+                                    not (sameSet (dbDependsOn cachedDb) (sdSelectedDeps staged))
+                                        || not (sameSet (dbCrossDBLinks cachedDb) (sdCrossDBLinks staged))
+                            return $ Right (BM25.addBM25Index (initializeRuntimeFields pinned synonymDB), needsSave)
+                        Nothing -> do
+                            unitConfig <- getMergedUnitConfig manager
+                            dbResult <-
+                                buildDatabaseWithMatrices
+                                    unitConfig
+                                    (sdbActivities (sdSimpleDB staged))
+                                    (sdbTechFlows (sdSimpleDB staged))
+                                    (sdbBioFlows (sdSimpleDB staged))
+                                    (sdbWasteFlows (sdSimpleDB staged))
+                                    (sdbUnits (sdSimpleDB staged))
+                            case dbResult of
+                                Left err -> return $ Left err
+                                Right db -> do
+                                    let dbWithLinks =
+                                            db
                                                 { dbCrossDBLinks = sdCrossDBLinks staged
                                                 , dbDependsOn = sdSelectedDeps staged
                                                 , dbLinkingStats = sdLinkingStats staged
                                                 }
-                                        needsSave =
-                                            not (sameSet (dbDependsOn cachedDb) (sdSelectedDeps staged))
-                                                || not (sameSet (dbCrossDBLinks cachedDb) (sdCrossDBLinks staged))
-                                    return $ Right (BM25.addBM25Index (initializeRuntimeFields pinned synonymDB), needsSave)
-                                Nothing -> do
-                                    unitConfig <- getMergedUnitConfig manager
-                                    dbResult <-
-                                        buildDatabaseWithMatrices
-                                            unitConfig
-                                            (sdbActivities (sdSimpleDB staged))
-                                            (sdbTechFlows (sdSimpleDB staged))
-                                            (sdbBioFlows (sdSimpleDB staged))
-                                            (sdbWasteFlows (sdSimpleDB staged))
-                                            (sdbUnits (sdSimpleDB staged))
-                                    case dbResult of
-                                        Left err -> return $ Left err
-                                        Right db -> do
-                                            let dbWithLinks =
-                                                    db
-                                                        { dbCrossDBLinks = sdCrossDBLinks staged
-                                                        , dbDependsOn = sdSelectedDeps staged
-                                                        , dbLinkingStats = sdLinkingStats staged
-                                                        }
-                                            -- Freshly built matrices: always persist.
-                                            return $ Right (BM25.addBM25Index (initializeRuntimeFields dbWithLinks synonymDB), True)
+                                    -- Freshly built matrices: always persist.
+                                    return $ Right (BM25.addBM25Index (initializeRuntimeFields dbWithLinks synonymDB), True)
 
-                            case buildResult of
-                                Left err -> return $ Left err
-                                Right (dbWithRuntime, needsSave) -> do
-                                    -- Create shared solver with lazy factorization (deferred to first query)
-                                    let techTriplesInt = [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList (dbTechnosphereTriples dbWithRuntime)]
-                                        activityCountInt = fromIntegral $ dbActivityCount dbWithRuntime
-                                    sharedSolver <- createSharedSolver dbName techTriplesInt activityCountInt
+                    case buildResult of
+                        Left err -> return $ Left err
+                        Right (dbWithRuntime, needsSave) -> do
+                            -- Create shared solver with lazy factorization (deferred to first query)
+                            let techTriplesInt = [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList (dbTechnosphereTriples dbWithRuntime)]
+                                activityCountInt = fromIntegral $ dbActivityCount dbWithRuntime
+                            sharedSolver <- createSharedSolver dbName techTriplesInt activityCountInt
 
-                                    let loaded =
-                                            LoadedDatabase
-                                                { ldDatabase = dbWithRuntime
-                                                , ldSharedSolver = sharedSolver
-                                                , ldConfig = sdConfig staged
-                                                }
+                            let loaded =
+                                    LoadedDatabase
+                                        { ldDatabase = dbWithRuntime
+                                        , ldSharedSolver = sharedSolver
+                                        , ldConfig = sdConfig staged
+                                        }
 
-                                    -- Move from staged to loaded
-                                    let indexedDb = buildIndexedDatabaseFromDB dbName synonymDB dbWithRuntime
-                                    atomically $ do
-                                        modifyTVar' (dmStagedDbs manager) (M.delete dbName)
-                                        modifyTVar' (dmLoadedDbs manager) (M.insert dbName loaded)
-                                        modifyTVar' (dmIndexedDbs manager) (M.insert dbName indexedDb)
-                                    clearMethodMappingCacheForDb manager dbName
+                            -- Move from staged to loaded
+                            let indexedDb = buildIndexedDatabaseFromDB dbName synonymDB dbWithRuntime
+                            atomically $ do
+                                modifyTVar' (dmStagedDbs manager) (M.delete dbName)
+                                modifyTVar' (dmLoadedDbs manager) (M.insert dbName loaded)
+                                modifyTVar' (dmIndexedDbs manager) (M.insert dbName indexedDb)
+                            clearMethodMappingCacheForDb manager dbName
 
-                                    -- Self-relink first against the current
-                                    -- dep set: a cached or staged build can
-                                    -- carry cross-DB links that don't match
-                                    -- the deps now in 'dmIndexedDbs'.
-                                    -- 'relinkDatabase' rewrites both the
-                                    -- in-memory state and (when 'linksChanged'
-                                    -- is True) the matrix cache.
-                                    relinkOutcome <- relinkDatabase manager dbName
+                            -- Self-relink first against the current
+                            -- dep set: a cached or staged build can
+                            -- carry cross-DB links that don't match
+                            -- the deps now in 'dmIndexedDbs'.
+                            -- 'relinkDatabase' rewrites both the
+                            -- in-memory state and (when 'linksChanged'
+                            -- is True) the matrix cache.
+                            relinkOutcome <- relinkDatabase manager dbName
 
-                                    -- 'needsSave' marks a finalize that changed
-                                    -- something on disk (fresh build, or an
-                                    -- edited dependency pin on a cache hit). The
-                                    -- 'Left' fallback treats a failed relink as
-                                    -- "no relink write happened", so the explicit
-                                    -- save below still fires when needed.
-                                    linksChangedAfter <- case relinkOutcome of
-                                        Right rr -> return (rresLinksChanged rr)
-                                        Left err -> do
-                                            reportProgress Warning $
-                                                "Self-relink of " <> T.unpack dbName <> " failed: " <> T.unpack err
-                                            return False
-                                    -- Persist when this finalize introduced a
-                                    -- change (fresh build, or an edited pin on a
-                                    -- cache hit) that the relink didn't already
-                                    -- write. relink owns the save whenever it
-                                    -- actually changed the in-memory links.
-                                    when (needsSave && not linksChangedAfter) $
-                                        Loader.saveCachedDatabaseWithMatrices dbName (dcPath (sdConfig staged)) dbWithRuntime
+                            -- 'needsSave' marks a finalize that changed
+                            -- something on disk (fresh build, or an
+                            -- edited dependency pin on a cache hit). The
+                            -- 'Left' fallback treats a failed relink as
+                            -- "no relink write happened", so the explicit
+                            -- save below still fires when needed.
+                            linksChangedAfter <- case relinkOutcome of
+                                Right rr -> return (rresLinksChanged rr)
+                                Left err -> do
+                                    reportProgress Warning $
+                                        "Self-relink of " <> T.unpack dbName <> " failed: " <> T.unpack err
+                                    return False
+                            -- Persist when this finalize introduced a
+                            -- change (fresh build, or an edited pin on a
+                            -- cache hit) that the relink didn't already
+                            -- write. relink owns the save whenever it
+                            -- actually changed the in-memory links.
+                            when (needsSave && not linksChangedAfter) $
+                                Loader.saveCachedDatabaseWithMatrices dbName (dcPath (sdConfig staged)) dbWithRuntime
 
-                                    reportProgress Info $ "  [OK] Finalized: " <> T.unpack dbName
-                                    return $ Right loaded
+                            reportProgress Info $ "  [OK] Finalized: " <> T.unpack dbName
+                            return $ Right loaded
 
 --------------------------------------------------------------------------------
 -- Method Collection Management

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -2378,11 +2378,7 @@ buildSetupResult manager dbName = do
                 else return $ Right info
         Nothing -> case M.lookup dbName loadedDbs of
             Just loaded ->
-                -- 'buildLoadedSetupInfo' already derives dsiIsReady honestly
-                -- (it sees dangling internal links); only the loaded flag needs
-                -- flipping here.
-                let info = buildLoadedSetupInfo (ldConfig loaded) (ldDatabase loaded) availableDbs indexedDbs
-                 in return $ Right info{dsiIsLoaded = False}
+                return $ Right $ buildLoadedSetupInfo (ldConfig loaded) (ldDatabase loaded) availableDbs indexedDbs
             Nothing -> return $ Left $ SetupFailed $ "Failed to stage database: " <> dbName
 
 {- | Missing-supplier list for a staged database. Nil-link gaps carry the rich

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -15,6 +15,7 @@ module Database.Manager (
     StagedDatabase (..),
     DatabaseSetupInfo (..),
     SetupError (..),
+    setupErrorMessage,
     MissingSupplier (..),
     DependencyChoice (..),
     DependencyStatus (..),
@@ -385,11 +386,16 @@ data DatabaseSetupInfo = DatabaseSetupInfo
     deriving (ToJSON) via (Stripped DatabaseSetupInfo)
 
 -- | Errors from getDatabaseSetupInfo
-data SetupError = SetupNotFound Text | SetupFailed Text
+data SetupError
+    = SetupNotFound Text
+    | -- | Configured (non-uploaded) database that must be loaded before setup.
+      SetupNotLoaded Text
+    | SetupFailed Text
     deriving (Show, Eq)
 
 setupErrorMessage :: SetupError -> Text
 setupErrorMessage (SetupNotFound msg) = msg
+setupErrorMessage (SetupNotLoaded name) = "Database not loaded: " <> name
 setupErrorMessage (SetupFailed msg) = msg
 
 -- | Load status: derivable from TVar membership + linking stats
@@ -2341,7 +2347,7 @@ getDatabaseSetupInfo manager dbName = do
                                         modifyTVar' (dmStagingDbs manager) (S.insert dbName)
                                         return $ Right NeedToStage
                                     | otherwise ->
-                                        return $ Left $ SetupFailed $ "Database is not loaded. Use the Load button to load it first: " <> dbName
+                                        return $ Left $ SetupNotLoaded dbName
 
     case action of
         Left err -> return $ Left err

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -2434,11 +2434,14 @@ loadedLinkCounts db =
   where
     sdb = toSimpleDatabase db
 
--- | Percentage of resolved inputs (0-100); an inputless database is complete.
+{- | Percentage of resolved inputs (0-100); an inputless database is complete.
+Clamped: stats recording more cross-DB links than unlinked inputs must not
+report above 100%.
+-}
 lcCompleteness :: LinkCounts -> Double
 lcCompleteness lc
     | lcTotalInputs lc > 0 =
-        100.0 * fromIntegral (lcInternalLinks lc + lcCrossDBLinks lc) / fromIntegral (lcTotalInputs lc)
+        min 100.0 $ 100.0 * fromIntegral (lcInternalLinks lc + lcCrossDBLinks lc) / fromIntegral (lcTotalInputs lc)
     | otherwise = 100.0
 
 {- | Why a database cannot be finalized — 'Nothing' means ready. The setup

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1831,10 +1831,7 @@ relinkStaged manager dbName maybeDepDb aliases = do
                                 { sdSelectedDeps = pinnedDeps
                                 , sdCrossDBLinks = newLinks
                                 , sdLinkingStats = newStats
-                                , sdMissingProducts =
-                                    sortOn
-                                        (\(_, cnt, _) -> Down cnt)
-                                        [(name, cnt, blocker) | (name, (cnt, blocker)) <- M.toList (Loader.cdlUnresolvedProducts newStats)]
+                                , sdMissingProducts = stagedMissingProducts (sdSimpleDB staged) newStats
                                 }
                     atomically $ modifyTVar' (dmStagedDbs manager) (M.insert dbName updatedStaged)
                     return $

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -2317,7 +2317,10 @@ databaseQualityReport manager dbName = do
         (Nothing, Just staged) -> Right (Quality.qualityReport dbName (sdSimpleDB staged))
         (Nothing, Nothing) -> Left ("Database not loaded: " <> dbName)
 
-data StageAction = AlreadyDone | NeedToStage
+{- | Outcome of the atomic staging decision; 'NeedToStage' carries the config
+read inside the same transaction, so no later (racy) re-lookup is needed.
+-}
+data StageAction = AlreadyDone | NeedToStage DatabaseConfig
 
 {- | Get setup info for a database (for the setup page)
 Works for both staged and loaded databases
@@ -2345,17 +2348,15 @@ getDatabaseSetupInfo manager dbName = do
                                 Just dbConfig
                                     | dcIsUploaded dbConfig -> do
                                         modifyTVar' (dmStagingDbs manager) (S.insert dbName)
-                                        return $ Right NeedToStage
+                                        return $ Right (NeedToStage dbConfig)
                                     | otherwise ->
                                         return $ Left $ SetupNotLoaded dbName
 
     case action of
         Left err -> return $ Left err
         Right AlreadyDone -> buildSetupResult manager dbName
-        Right NeedToStage -> do
+        Right (NeedToStage dbConfig) -> do
             -- Do the slow work, ensuring we always unmark on exception
-            availableDbs <- readTVarIO (dmAvailableDbs manager)
-            let dbConfig = availableDbs M.! dbName -- safe: checked above
             stageResult <-
                 Control.Exception.finally
                     (stageUploadedDatabase manager dbConfig)

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -2390,29 +2390,27 @@ can never drift apart.
 data LinkCounts = LinkCounts
     { lcActivityCount :: !Int
     , lcTotalInputs :: !Int
-    , lcInternalLinks :: !Int
+    , lcUnlinked :: !Int
     , lcCrossDBLinks :: !Int
-    , lcUnresolvedLinks :: !Int
     }
 
-mkLinkCounts :: Int -> Int -> Int -> Int -> LinkCounts
-mkLinkCounts activityCount totalInputs unlinked crossDB =
-    LinkCounts
-        { lcActivityCount = activityCount
-        , lcTotalInputs = totalInputs
-        , lcInternalLinks = max 0 (totalInputs - unlinked)
-        , lcCrossDBLinks = crossDB
-        , lcUnresolvedLinks = max 0 (unlinked - crossDB)
-        }
+-- | Inputs resolved inside the database itself.
+lcInternalLinks :: LinkCounts -> Int
+lcInternalLinks lc = max 0 (lcTotalInputs lc - lcUnlinked lc)
+
+-- | Inputs no link, internal or cross-DB, resolves.
+lcUnresolvedLinks :: LinkCounts -> Int
+lcUnresolvedLinks lc = max 0 (lcUnlinked lc - lcCrossDBLinks lc)
 
 -- | Tally for a staged database, from its parsed activities and linking stats.
 stagedLinkCounts :: StagedDatabase -> LinkCounts
 stagedLinkCounts staged =
-    mkLinkCounts
-        (M.size (sdbActivities sdb))
-        (Loader.countTotalTechInputs sdb)
-        (Loader.countUnlinkedExchanges sdb)
-        (Loader.crossDBLinksCount (sdLinkingStats staged))
+    LinkCounts
+        { lcActivityCount = M.size (sdbActivities sdb)
+        , lcTotalInputs = Loader.countTotalTechInputs sdb
+        , lcUnlinked = Loader.countUnlinkedExchanges sdb
+        , lcCrossDBLinks = Loader.crossDBLinksCount (sdLinkingStats staged)
+        }
   where
     sdb = sdSimpleDB staged
 
@@ -2427,11 +2425,12 @@ inputs.
 -}
 loadedLinkCounts :: Database -> LinkCounts
 loadedLinkCounts db =
-    mkLinkCounts
-        (fromIntegral (dbActivityCount db))
-        (Loader.countTotalTechInputs sdb)
-        (Loader.countUnlinkedExchanges sdb)
-        (length (dbCrossDBLinks db))
+    LinkCounts
+        { lcActivityCount = fromIntegral (dbActivityCount db)
+        , lcTotalInputs = Loader.countTotalTechInputs sdb
+        , lcUnlinked = Loader.countUnlinkedExchanges sdb
+        , lcCrossDBLinks = length (dbCrossDBLinks db)
+        }
   where
     sdb = toSimpleDatabase db
 

--- a/test/SetupInfoSpec.hs
+++ b/test/SetupInfoSpec.hs
@@ -2,18 +2,27 @@
 
 module SetupInfoSpec (spec) where
 
+import Control.Concurrent.STM (atomically, modifyTVar')
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.UUID as UUID
+import qualified Data.Vector.Unboxed as U
 import Test.Hspec
 
-import Config (DatabaseConfig (..))
+import Config (DatabaseConfig (..), defaultConfig)
 import Database (buildDatabaseWithMatrices)
 import Database.Manager (
+    DatabaseManager (..),
     DatabaseSetupInfo (..),
+    LoadedDatabase (..),
     MissingSupplier (..),
+    SetupError (..),
     buildLoadedSetupInfo,
+    finalizeDatabase,
+    getDatabaseSetupInfo,
+    initDatabaseManager,
  )
+import SharedSolver (createSharedSolver)
 import Types
 import UnitConversion (defaultUnitConfig)
 
@@ -21,12 +30,14 @@ import UnitConversion (defaultUnitConfig)
 -- Minimal fixtures
 -- ---------------------------------------------------------------------------
 
-consumerAct, consumerProd, supplierAct, supplierProd, missingAct :: UUID.UUID
+consumerAct, consumerProd, supplierAct, supplierProd, missingAct, gapProdA, gapProdB :: UUID.UUID
 consumerAct = read "cccccccc-0000-0000-0000-000000000001"
 consumerProd = read "aaaaaaaa-0000-0000-0000-000000000001"
 supplierAct = read "cccccccc-0000-0000-0000-000000000002"
 supplierProd = read "bbbbbbbb-0000-0000-0000-000000000002"
 missingAct = read "dddddddd-0000-0000-0000-000000000099"
+gapProdA = read "bbbbbbbb-0000-0000-0000-000000000003"
+gapProdB = read "bbbbbbbb-0000-0000-0000-000000000004"
 
 minimalFlow :: UUID.UUID -> Text -> TechnosphereFlow
 minimalFlow fid name =
@@ -124,6 +135,54 @@ buildDb acts flows = do
 setupInfoFor :: Database -> DatabaseSetupInfo
 setupInfoFor db = buildLoadedSetupInfo stubConfig db M.empty M.empty
 
+{- | Install a built database as a LoadedDatabase under @name@: solver, config,
+loaded map, and available map. Mirrors what the load path does, without disk
+I/O.
+-}
+installLoaded :: DatabaseManager -> Text -> Database -> IO ()
+installLoaded manager name db = do
+    let triples = [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList (dbTechnosphereTriples db)]
+        config = stubConfig{dcName = name, dcDisplayName = name}
+    solver <- createSharedSolver name triples (fromIntegral (dbActivityCount db))
+    let loaded = LoadedDatabase{ldDatabase = db, ldSharedSolver = solver, ldConfig = config}
+    atomically $ do
+        modifyTVar' (dmLoadedDbs manager) (M.insert name loaded)
+        modifyTVar' (dmAvailableDbs manager) (M.insert name config)
+
+-- | A fresh manager with @db@ installed as a loaded database named "test".
+managerWithLoaded :: Database -> IO DatabaseManager
+managerWithLoaded db = do
+    manager <- initDatabaseManager defaultConfig True Nothing
+    installLoaded manager "test" db
+    pure manager
+
+-- | The partial-import shape: a dangling background link no dependency ships.
+partialDb :: IO Database
+partialDb =
+    buildDb
+        [
+            ( (consumerAct, consumerProd)
+            , minimalActivity
+                "lyocell fibre"
+                [refExchange consumerProd, linkedInput missingAct supplierProd]
+            )
+        ]
+        [(consumerProd, "lyocell fibre"), (supplierProd, "chemical, inorganic")]
+
+-- | The self-contained shape: every input resolves internally.
+readyDb :: IO Database
+readyDb =
+    buildDb
+        [
+            ( (consumerAct, consumerProd)
+            , minimalActivity
+                "lyocell fibre"
+                [refExchange consumerProd, linkedInput supplierAct supplierProd]
+            )
+        , ((supplierAct, supplierProd), minimalActivity "chemical, inorganic" [refExchange supplierProd])
+        ]
+        [(consumerProd, "lyocell fibre"), (supplierProd, "chemical, inorganic")]
+
 -- ---------------------------------------------------------------------------
 
 spec :: Spec
@@ -136,15 +195,7 @@ spec = do
     -- zero score.
     describe "buildLoadedSetupInfo (partial EcoSpold2 import)" $ do
         it "reports a dangling background link as not ready / 0% / named" $ do
-            let consumer =
-                    minimalActivity
-                        "lyocell fibre"
-                        [refExchange consumerProd, linkedInput missingAct supplierProd]
-            db <-
-                buildDb
-                    [((consumerAct, consumerProd), consumer)]
-                    [(consumerProd, "lyocell fibre"), (supplierProd, "chemical, inorganic")]
-            let info = setupInfoFor db
+            info <- setupInfoFor <$> partialDb
             dsiIsReady info `shouldBe` False
             dsiCompleteness info `shouldBe` 0.0
             map msProductName (dsiMissingSuppliers info) `shouldBe` ["chemical, inorganic"]
@@ -153,21 +204,30 @@ spec = do
     -- resolves internally, so the database stays ready at 100% with no gaps.
     describe "buildLoadedSetupInfo (well-formed self-contained database)" $ do
         it "reports a fully resolved database as ready / 100% / no gaps" $ do
-            let consumer =
-                    minimalActivity
-                        "lyocell fibre"
-                        [refExchange consumerProd, linkedInput supplierAct supplierProd]
-                supplier = minimalActivity "chemical, inorganic" [refExchange supplierProd]
-            db <-
-                buildDb
-                    [ ((consumerAct, consumerProd), consumer)
-                    , ((supplierAct, supplierProd), supplier)
-                    ]
-                    [(consumerProd, "lyocell fibre"), (supplierProd, "chemical, inorganic")]
-            let info = setupInfoFor db
+            info <- setupInfoFor <$> readyDb
             dsiIsReady info `shouldBe` True
             dsiCompleteness info `shouldBe` 100.0
             dsiMissingSuppliers info `shouldBe` []
+
+    -- Two gaps with different demand counts, alphabetically ordered against
+    -- the count order: the list must rank by demand, not map order.
+    describe "buildLoadedSetupInfo (missing-supplier ranking)" $ do
+        it "ranks missing suppliers by demanding-input count, descending" $ do
+            let consumer =
+                    minimalActivity
+                        "lyocell fibre"
+                        [ refExchange consumerProd
+                        , linkedInput missingAct gapProdA
+                        , linkedInput missingAct gapProdB
+                        , linkedInput missingAct gapProdB
+                        ]
+            db <-
+                buildDb
+                    [((consumerAct, consumerProd), consumer)]
+                    [(consumerProd, "lyocell fibre"), (gapProdA, "aaa gap"), (gapProdB, "zzz gap")]
+            let info = setupInfoFor db
+            [(msProductName s, msCount s) | s <- dsiMissingSuppliers info]
+                `shouldBe` [("zzz gap", 2), ("aaa gap", 1)]
 
     -- The dangling-import shape, but its matching background is loaded as a
     -- dependency: the input resolves cross-DB by activityLinkId, recorded in
@@ -201,3 +261,38 @@ spec = do
             dsiIsReady info `shouldBe` True
             dsiCompleteness info `shouldBe` 100.0
             dsiMissingSuppliers info `shouldBe` []
+
+    -- The wire-level contract between GET /setup and POST /finalize: the two
+    -- must never disagree about a loaded database.
+    describe "setup / finalize coherence (loaded databases)" $ do
+        it "reports a loaded database as loaded" $ do
+            manager <- managerWithLoaded =<< readyDb
+            result <- getDatabaseSetupInfo manager "test"
+            fmap dsiIsLoaded result `shouldBe` Right True
+
+        it "refuses to finalize a loaded database the setup reports as not ready" $ do
+            manager <- managerWithLoaded =<< partialDb
+            setup <- getDatabaseSetupInfo manager "test"
+            fmap dsiIsReady setup `shouldBe` Right False
+            finalized <- finalizeDatabase manager "test"
+            case finalized of
+                Left msg -> msg `shouldBe` "Cannot finalize: 1 unresolved inputs. Add dependencies to resolve them first."
+                Right _ -> expectationFailure "expected finalize to refuse a not-ready loaded database"
+
+        it "finalizes a ready loaded database as a no-op success" $ do
+            manager <- managerWithLoaded =<< readyDb
+            setup <- getDatabaseSetupInfo manager "test"
+            fmap dsiIsReady setup `shouldBe` Right True
+            finalized <- finalizeDatabase manager "test"
+            case finalized of
+                Left msg -> expectationFailure ("expected no-op finalize to succeed, got: " <> show msg)
+                Right loaded -> dcName (ldConfig loaded) `shouldBe` "test"
+
+        it "answers not-loaded for a configured database that was never loaded" $ do
+            manager <- initDatabaseManager defaultConfig True Nothing
+            let config = stubConfig{dcName = "cfg", dcDisplayName = "cfg"}
+            atomically $ modifyTVar' (dmAvailableDbs manager) (M.insert "cfg" config)
+            result <- getDatabaseSetupInfo manager "cfg"
+            case result of
+                Left (SetupNotLoaded name) -> name `shouldBe` "cfg"
+                other -> expectationFailure ("expected SetupNotLoaded, got: " <> show (fmap dsiName other))


### PR DESCRIPTION
## Why

`GET /db/{db}/setup` and `POST /db/{db}/finalize` each computed their own view of a database's link resolution, and the two had drifted apart. The most visible symptom: the setup response never reported a loaded database as loaded (`isLoaded` was forced to `false` on the wire by a leftover of an earlier design), so any consumer keying behavior on that flag could never see it fire. Around it, three quieter incoherences: finalize answered success for a loaded database the setup page reported as not ready, the loaded path listed its "top missing suppliers" in map order instead of by demand, and a configured-but-unloaded database got a 500 instead of the standard 404 not-loaded answer.

## Final state

Both endpoints now derive from one shared tally (`LinkCounts`):

- **One readiness verdict.** `notReadyReason` is the single formula: the setup page's `isReady` is its `isNothing`, finalize refuses with its message (including the no-op path on an already-loaded database), and the load path's finalize shortcut tests the same predicate. The ready badge and the gate can no longer disagree.
- **`isLoaded` is honest.** A loaded database's setup response carries `isLoaded: true`, matching the field's documentation.
- **Missing suppliers ranked identically** by demanding-input count on both the staged and loaded paths, so the ten shown are the ten biggest gaps.
- **Standard not-loaded answer.** Asking setup about a configured database that isn't loaded returns the same 404 `Database not loaded: <name>` body as every other not-loaded arm, so typed-error recovery on clients applies. (Previously a 500 with UI-specific wording.)
- The staging decision now carries its config out of the deciding STM transaction, removing a racy re-lookup through a partial function.

API consumers that relied on `isLoaded` always being `false`, on the no-op finalize succeeding for a not-ready database, or on the 500 for an unloaded configured database will see the corrected behavior; those consumers are adapted separately.

Tests pin the contract: a loaded database reports as loaded, finalize refuses exactly when setup says not ready and no-ops when ready, missing suppliers come ranked, and the not-loaded case answers as such.