### PR TITLE
Propagate SimaPro Products-row comments to product exchanges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Fixed
+- The free-text comment on a SimaPro Products row (Agribalyse uses it for
+  modelling notes such as edible fraction and raw-to-cooked ratios) now
+  reaches the reference product and coproduct exchanges, so it shows up in
+  activity details and exports like input and emission comments already did.
+  Its data-quality pedigree prefix is decoded the same way too, and the
+  SimaPro writer emits both back on the Products row instead of leaving the
+  comment column empty.
+
 ## [0.9.3] - 2026-07-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
   Its data-quality pedigree prefix is decoded the same way too, and the
   SimaPro writer emits both back on the Products row instead of leaving the
   comment column empty.
+- Multi-line SimaPro comments now display as real lines. SimaPro exports a
+  multi-line comment on one physical line with an invisible control character
+  (DEL, `\x7f`) between the lines; the parser now decodes it as a line break
+  on every exchange comment, and the SimaPro writer encodes line breaks back
+  the same way on export.
 
 ## [0.9.3] - 2026-07-15
 

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -998,12 +998,13 @@ productToExchange unitCfg env isRef ProductRow{..} =
         unit = Unit{unitId = unitUUID, unitName = effUnitName, unitSymbol = effUnitName, unitComment = ""}
      in (exchange, flow, unit)
 
-{- | Drop empty / whitespace-only text. Single normalisation point so future
-cleanup (e.g. stripping control bytes from SimaPro exports) lives here.
+{- | Drop empty / whitespace-only text, decoding SimaPro's in-cell line
+breaks: a multi-line comment is exported on one physical line with @\\x7f@
+(DEL) separating the lines. Single normalisation point for comment cleanup.
 -}
 nonEmptyText :: Text -> Maybe Text
 nonEmptyText t =
-    let s = T.strip t
+    let s = T.strip (T.replace "\x7f" "\n" t)
      in if T.null s then Nothing else Just s
 
 {- | Split SimaPro's trailing comment column into the pedigree matrix (when

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -452,7 +452,7 @@ parseProductRow cfg line =
                             , prAllocRaw = norm alloc
                             , prWasteType = decodeBS (BS8.strip waste)
                             , prCategory = decodeBS (BS8.strip cat)
-                            , prComment = decodeBS (BS8.intercalate ";" rest)
+                            , prComment = joinComment rest
                             }
             -- 6+ fields without allocation: name;unit;amount;waste;cat;comment
             (name : unit : amount : waste : cat : rest) ->
@@ -466,7 +466,7 @@ parseProductRow cfg line =
                         , prAllocRaw = "100"
                         , prWasteType = decodeBS (BS8.strip waste)
                         , prCategory = decodeBS (BS8.strip cat)
-                        , prComment = decodeBS (BS8.intercalate ";" rest)
+                        , prComment = joinComment rest
                         }
             _ -> Nothing
 
@@ -967,6 +967,7 @@ productToExchange unitCfg env isRef ProductRow{..} =
                 else (prUnit, rawAmount)
         flowUUID = generateFlowUUID cleanName "" effUnitName
         unitUUID = generateUnitUUID effUnitName
+        (pedigree, cleanedComment) = parsePedigreePrefix prComment
         exchange =
             TechnosphereExchange
                 { techFlowId = flowUUID
@@ -982,8 +983,8 @@ productToExchange unitCfg env isRef ProductRow{..} =
                   -- field lets the cross-DB supplier index expose the
                   -- product under its declared geographic scope as well.
                   techLocation = prodRowLoc
-                , techComment = Nothing
-                , techPedigree = Nothing
+                , techComment = cleanedComment
+                , techPedigree = pedigree
                 }
         flow =
             TechnosphereFlow

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -576,12 +576,16 @@ productLines keep cats allocPct category exchs =
         -- known to be a TechnosphereExchange — so mkRow is total (no unreachable
         -- blank-row arm). Sort by (name, unit, amount) for determinism.
         entries =
-            [ (tfName flow, unitNameOf (catUnits cats) (exchangeUnitId ex), exchangeAmount ex)
+            [ ( tfName flow
+              , unitNameOf (catUnits cats) (exchangeUnitId ex)
+              , exchangeAmount ex
+              , renderComment (exchangePedigree ex) (exchangeComment ex)
+              )
             | ex@TechnosphereExchange{} <- exchs
             , keep ex
             , Just flow <- [M.lookup (exchangeFlowId ex) (catTech cats)]
             ]
-        mkRow (nm, unit, amt) = row [nm, unit, formatAmount amt, alloc, "not defined", category, ""]
+        mkRow (nm, unit, amt, comment) = row [nm, unit, formatAmount amt, alloc, "not defined", category, comment]
      in map mkRow (sortOn id entries)
 
 {- | A coproduct technosphere output (SimaPro @Avoided products@ section, which

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -127,11 +127,13 @@ Amounts must also be finite: a NaN or ±Infinity has no parseable literal, so
 inventory. Report it here instead. This is the export-boundary check;
 'serializeSimaProCSV' itself stays pure and total.
 
-Names and comments must also be free of newline characters. 'escapeField'
-RFC-4180-quotes them, but the parser splits the file on physical lines
-('BS8.lines') /before/ CSV parsing, so an embedded @\\n@ or @\\r@ tears the row
-apart and corrupts or drops it. Reject such fields rather than emit a row the
-parser cannot read back.
+Names and metadata values must also be free of newline characters.
+'escapeField' RFC-4180-quotes them, but the parser splits the file on physical
+lines ('BS8.lines') /before/ CSV parsing, so an embedded @\\n@ or @\\r@ tears
+the row apart and corrupts or drops it. Reject such fields rather than emit a
+row the parser cannot read back. Exchange comments are the exception:
+'renderComment' encodes their line breaks as @\\x7f@, SimaPro's in-cell
+newline, so they round-trip instead of being rejected.
 
 Two more round-trip hazards are specific to SimaPro's textual layout, and bite
 only for databases imported from other formats (a SimaPro parse can't produce
@@ -304,13 +306,14 @@ checkSimaProExportable db =
     hasNewline = T.any (\c -> c == '\n' || c == '\r')
     -- Every text field that lands in the output verbatim: the bare metadata
     -- value lines (so a newline in any of them — the Type label included — is
-    -- caught), the "Category" product-column value, exchange comments, and all
-    -- flow names. The line-based parser splits on physical newlines /before/
-    -- CSV parsing, so even a quoted newline tears a row apart; reject upstream.
+    -- caught), the "Category" product-column value, and all flow names.
+    -- Exchange comments are exempt: 'renderComment' encodes their newlines as
+    -- \x7f, SimaPro's in-cell line break. The line-based parser splits on
+    -- physical newlines /before/ CSV parsing, so even a quoted newline tears
+    -- a row apart; reject upstream.
     activityTexts act =
         map snd (activityMetaLines act)
             ++ M.elems (activityClassification act)
-            ++ [cmt | ex <- exchanges act, Just cmt <- [exchangeComment ex]]
     newlineOffenders =
         filter hasNewline $
             concatMap activityTexts (M.elems (sdbActivities db))
@@ -461,11 +464,16 @@ activityMetaLines Activity{..} =
     , ("Comment", T.intercalate " " activityDescription)
     ]
 
--- | Render the comment column, re-attaching a pedigree prefix when present.
+{- | Render the comment column, re-attaching a pedigree prefix when present.
+Line breaks are encoded as @\\x7f@ (DEL), SimaPro's in-cell newline — the
+line-based format cannot hold a literal newline (see 'checkSimaProExportable'),
+and the parser decodes @\\x7f@ back, so multi-line comments round-trip.
+-}
 renderComment :: Maybe Pedigree -> Maybe Text -> Text
 renderComment ped cmt =
     let pedTxt = maybe "" renderPedigree ped
-        cmtTxt = fromMaybe "" cmt
+        encodeNewlines = T.replace "\n" "\x7f" . T.replace "\r" "\n" . T.replace "\r\n" "\n"
+        cmtTxt = encodeNewlines (fromMaybe "" cmt)
      in case (pedTxt, cmtTxt) of
             ("", c) -> c
             (p, "") -> p <> ","

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -823,6 +823,14 @@ spec = do
             map exchangeComment refs `shouldBe` [Just "Modelled parameters: Edible fraction = 0.5"]
             map exchangePedigree refs `shouldBe` [Just (Pedigree 3 3 2 1 2)]
 
+        it "decodes \\x7f (SimaPro's in-cell line break) as a newline in comments" $ do
+            (activities, _, _, _, _) <-
+                parseProductsCSV
+                    "Walnut process"
+                    ["Walnut at consumer;kg;1.0;100;not defined;material;Edible fraction = 0.5\x7f\&Raw to cooked ratio = 1"]
+            let comments = [exchangeComment ex | act <- activities, ex <- exchanges act]
+            comments `shouldBe` [Just "Edible fraction = 0.5\nRaw to cooked ratio = 1"]
+
     -- -----------------------------------------------------------------------
     -- Pedigree matrix
     -- -----------------------------------------------------------------------

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -807,6 +807,22 @@ spec = do
                     ]
             map exchangeComment bios `shouldBe` [Just "tail-pipe combustion"]
 
+        it "surfaces the Products-row comment and pedigree on the reference product" $ do
+            (activities, _, _, _, _) <-
+                parseProductsCSV
+                    "Walnut process"
+                    ["Walnut at consumer;kg;1.0;100;not defined;material;(3,3,2,1,2),Modelled parameters: Edible fraction = 0.5"]
+            let refs =
+                    [ ex
+                    | act <- activities
+                    , ex <- exchanges act
+                    , case ex of
+                        TechnosphereExchange{techRole = ReferenceProduct} -> True
+                        _ -> False
+                    ]
+            map exchangeComment refs `shouldBe` [Just "Modelled parameters: Edible fraction = 0.5"]
+            map exchangePedigree refs `shouldBe` [Just (Pedigree 3 3 2 1 2)]
+
     -- -----------------------------------------------------------------------
     -- Pedigree matrix
     -- -----------------------------------------------------------------------

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -77,7 +77,7 @@ fixtureCSV =
         , "FR"
         , ""
         , "Products"
-        , "Butter;kg;1;100;not defined;material;"
+        , "Butter;kg;1;100;not defined;material;(2,1,1,1,1),churned on site"
         , ""
         , "Materials/fuels"
         , -- name;unit;amount;Undefined;0;0;0;<pedigree>,<comment>
@@ -398,6 +398,10 @@ spec = describe "SimaPro.Writer round-trip" $ do
         let origExchanges = concatMap exchanges (activitiesOf original)
         map exchangeComment origExchanges `shouldSatisfy` elem (Just "farm milk")
         map exchangePedigree origExchanges `shouldSatisfy` elem (Just (Pedigree 3 3 2 1 2))
+        -- Same guard for the Products row: the reference product's comment and
+        -- pedigree must survive the round-trip, not just the input rows'.
+        map exchangeComment origExchanges `shouldSatisfy` elem (Just "churned on site")
+        map exchangePedigree origExchanges `shouldSatisfy` elem (Just (Pedigree 2 1 1 1 1))
 
     it "(c) score-equivalence: same inventory for a sample activity within tolerance" $ do
         original <- parseBytes fixtureCSV

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -77,7 +77,7 @@ fixtureCSV =
         , "FR"
         , ""
         , "Products"
-        , "Butter;kg;1;100;not defined;material;(2,1,1,1,1),churned on site"
+        , "Butter;kg;1;100;not defined;material;(2,1,1,1,1),churned on site\x7f\&from pasture milk"
         , ""
         , "Materials/fuels"
         , -- name;unit;amount;Undefined;0;0;0;<pedigree>,<comment>
@@ -399,8 +399,10 @@ spec = describe "SimaPro.Writer round-trip" $ do
         map exchangeComment origExchanges `shouldSatisfy` elem (Just "farm milk")
         map exchangePedigree origExchanges `shouldSatisfy` elem (Just (Pedigree 3 3 2 1 2))
         -- Same guard for the Products row: the reference product's comment and
-        -- pedigree must survive the round-trip, not just the input rows'.
-        map exchangeComment origExchanges `shouldSatisfy` elem (Just "churned on site")
+        -- pedigree must survive the round-trip, not just the input rows'. The
+        -- comment is multi-line (\x7f in the file, \n in memory), pinning the
+        -- writer's \n → \x7f re-encoding as well.
+        map exchangeComment origExchanges `shouldSatisfy` elem (Just "churned on site\nfrom pasture milk")
         map exchangePedigree origExchanges `shouldSatisfy` elem (Just (Pedigree 2 1 1 1 1))
 
     it "(c) score-equivalence: same inventory for a sample activity within tolerance" $ do


### PR DESCRIPTION
SimaPro CSV Products rows carry a trailing free-text comment (Agribalyse uses it for modelling notes such as edible fraction and raw-to-cooked ratios on some datasets). The parser captured it into `prComment` but dropped it when building the reference product or coproduct exchange, so product-level comments never reached `get_activity`, the MCP tools, or the format writers — while input and emission row comments already did.

Products rows now go through the same pedigree-prefix split as the other exchange rows, so the comment and its data-quality pedigree land on the product exchange like everywhere else. The comment column is also joined with the shared `joinComment` helper, so a blank column yields no comment instead of leftover semicolon padding.