### PR TITLE
Count coverage the way scoring counts it, and add a collection-level figure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@
   (DEL, `\x7f`) between the lines; the parser now decodes it as a line break
   on every exchange comment, and the SimaPro writer encodes line breaks back
   the same way on export.
+- The per-method `uniqueDbFlowsMatched` figure on the mapping-status endpoint
+  now counts every database flow the method actually characterizes — probed
+  with the same lookup scoring uses — instead of only the flows a factor
+  resolved to directly. The old count missed every flow reached through a
+  fallback (a factor covering a substance across many compartments counted as
+  one flow), under-reporting a method's real reach several-fold on typical
+  databases.
+
+### Added
+- A collection-coverage endpoint:
+  `GET /db/{db}/method-collection/{collection}/coverage` reports how many of
+  a database's emission and resource flows at least one method of a
+  collection characterizes, as a distinct count. No sum over the per-method
+  figures can recover it, because a collection's methods overlap on the same
+  flows. Exposed in pyvolca as `Client.get_collection_coverage`.
 
 ## [0.9.3] - 2026-07-15
 

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -553,6 +553,16 @@ Returns a :class:`CharacterizationResult` carrying ``matches`` (total
 rows the filter selected) and ``shown`` (rows actually returned under
 ``limit``). Check ``result.has_more`` to detect truncation.
 
+##### `Client.get_collection_coverage(collection: str, db_name: str | None = None) -> CollectionCoverage`
+
+How much of a database a whole method collection characterizes.
+
+Counts the distinct emission and resource flows at least one of the
+collection's methods resolves a factor for, with the same lookup
+scoring uses. Distinct across methods — their factors overlap, so the
+per-method figures from :meth:`get_mapping_status` do not add up to
+this number.
+
 ##### `Client.get_consumers(process_id: str, *, name: str | None = None, location: str | None = None, product: str | None = None, preset: str | None = None, classification_filters: list[ClassificationFilter] | None = None, page: int | None = None, page_size: int | None = None, limit: int | None = None, offset: int | None = None, max_depth: int | None = None, sort: str | None = None, order: str | None = None, include_edges: bool = False) -> ConsumersResponse`
 
 Find all activities that transitively consume this supplier.

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -58,6 +58,7 @@ from .types import (
     CharacterizationResult,
     ClassificationFilter,
     ClassificationSystem,
+    CollectionCoverage,
     ConsumerResult,
     ConsumersResponse,
     ContributingActivities,
@@ -2004,6 +2005,26 @@ class Client:
             self._json(
                 self._session.get(
                     f"{self.base_url}/api/v1/db/{target}/method/{method_id}/mapping"
+                )
+            )
+        )
+
+    def get_collection_coverage(
+        self, collection: str, db_name: str | None = None
+    ) -> CollectionCoverage:
+        """How much of a database a whole method collection characterizes.
+
+        Counts the distinct emission and resource flows at least one of the
+        collection's methods resolves a factor for, with the same lookup
+        scoring uses. Distinct across methods — their factors overlap, so the
+        per-method figures from :meth:`get_mapping_status` do not add up to
+        this number.
+        """
+        target = self._db(db_name)
+        return CollectionCoverage.from_json(
+            self._json(
+                self._session.get(
+                    f"{self.base_url}/api/v1/db/{target}/method-collection/{urllib.parse.quote(collection, safe='')}/coverage"
                 )
             )
         )

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -1747,3 +1747,20 @@ class MappingStatus:
             unique_db_flows_matched=d["uniqueDbFlowsMatched"],
             unmapped_flows=[UnmappedFlow.from_json(u) for u in d["unmappedFlows"]],
         )
+
+
+@dataclass
+class CollectionCoverage(FromJson):
+    """How much of one database a whole method collection characterizes.
+
+    Returned by :meth:`Client.get_collection_coverage`.
+    ``characterized_flows`` counts distinct emission and resource flows that
+    at least one of the collection's methods resolves a factor for, with the
+    same lookup scoring uses — a figure no sum over the per-method
+    :class:`MappingStatus` values can recover, since the methods overlap.
+    """
+
+    collection: str
+    db_name: str
+    total_flows: int
+    characterized_flows: int

--- a/pyvolca/tests/test_detail_lookups.py
+++ b/pyvolca/tests/test_detail_lookups.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from volca.types import FlowDetail, MappingStatus, MethodDetail, MethodFactor
+from volca.types import CollectionCoverage, FlowDetail, MappingStatus, MethodDetail, MethodFactor
 
 
 def _resp(session_attr, json_body: dict) -> None:
@@ -77,6 +77,24 @@ class TestMappingStatus:
         assert out.db_biosphere_count == 300
         assert out.unique_db_flows_matched == 75
         assert out.unmapped_flows[0].flow_name == "Unobtanium"
+
+
+class TestCollectionCoverage:
+    def test_collection_name_is_url_encoded(self, mocked_client):
+        client, session = mocked_client
+        _resp(session.get, {
+            "collection": "EF 3.1",
+            "dbName": "testdb",
+            "totalFlows": 300,
+            "characterizedFlows": 210,
+        })
+        out = client.get_collection_coverage("EF 3.1")
+        assert session.get.call_args[0][0] == (
+            "http://test.local/api/v1/db/testdb/method-collection/EF%203.1/coverage"
+        )
+        assert isinstance(out, CollectionCoverage)
+        assert out.characterized_flows == 210
+        assert out.total_flows == 300
 
 
 class TestStats:

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -10,7 +10,7 @@ module API.Routes where
 import API.DatabaseHandlers (simpleAction)
 import qualified API.DatabaseHandlers as DBHandlers
 import qualified API.OpenApi
-import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExportRequest (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GapReportAPI (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), QualityReportAPI (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadChunk (..), UploadResponse (..), apiFlowOfKind)
+import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), CollectionCoverage (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExportRequest (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GapReportAPI (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), QualityReportAPI (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadChunk (..), UploadResponse (..), apiFlowOfKind)
 import App.Env (AppEnv (..), AppM, runApp)
 import qualified Config
 import Control.Concurrent.Async (mapConcurrently)
@@ -43,7 +43,7 @@ import qualified Expr
 import GHC.Generics
 import qualified GHC.Stats
 import Matrix (Inventory, Vector)
-import Method.Mapping (LCIAOutcome (..), LongTermMode (..), MappingStats (..), MatchStrategy (..), MethodTables (..), applyLongTermMode, computeLCIAScoreFromTables, computeLCIAScoreSetFromTables, computeMappingStats, inventoryContributions, longTermModeFromExclude, lookupCFForFlow, strategyPriority, sumRegionalizedLCIAScoreCrossDB)
+import Method.Mapping (LCIAOutcome (..), LongTermMode (..), MappingStats (..), MatchStrategy (..), MethodTables (..), applyLongTermMode, characterizedFlowIds, computeLCIAScoreFromTables, computeLCIAScoreSetFromTables, computeMappingStats, inventoryContributions, longTermModeFromExclude, lookupCFForFlow, strategyPriority, sumRegionalizedLCIAScoreCrossDB)
 import qualified Method.Mapping
 import Method.Types (DamageCategory (..), Method (..), MethodCF (..), MethodCollection (..), NormWeightSet (..), ScoringEvaluation (..), ScoringSet (..), computeFormulaScores)
 import qualified Method.Types as MT
@@ -111,6 +111,7 @@ type LCAAPI =
                 :<|> "method" :> Capture "methodId" Text :> "factors" :> Get '[JSON] [MethodFactorAPI]
                 :<|> "db" :> Capture "dbName" Text :> "method" :> Capture "methodId" Text :> "mapping" :> Get '[JSON] MappingStatus
                 :<|> "db" :> Capture "dbName" Text :> "method" :> Capture "methodId" Text :> "flow-mapping" :> Get '[JSON] FlowCFMapping
+                :<|> "db" :> Capture "dbName" Text :> "method-collection" :> Capture "collection" Text :> "coverage" :> Get '[JSON] CollectionCoverage
                 :<|> "db" :> Capture "dbName" Text :> "method" :> Capture "methodId" Text :> "characterization" :> QueryParam "flow" Text :> QueryParam "limit" Int :> Get '[JSON] CharacterizationResult
                 :<|> "db" :> Capture "dbName" Text :> "flows" :> QueryParam "q" Text :> QueryParam "lang" Text :> QueryParam "limit" Int :> QueryParam "offset" Int :> QueryParam "sort" Text :> QueryParam "order" Text :> Get '[JSON] (SearchResults FlowSearchResult)
                 :<|> "db" :> Capture "dbName" Text :> "activities" :> QueryParam "name" Text :> QueryParam "geo" Text :> QueryParam "product" Text :> QueryParam "exact" Bool :> QueryParam "preset" Text :> QueryParams "classification" Text :> QueryParams "classification-value" Text :> QueryParams "classification-mode" Text :> QueryParam "limit" Int :> QueryParam "offset" Int :> QueryParam "sort" Text :> QueryParam "order" Text :> Get '[JSON] (SearchResults ActivitySummary)
@@ -1786,6 +1787,7 @@ getMethodMapping dbName methodIdText = do
     (db, _) <- requireDatabaseByName dbName
     (collectionName, method) <- loadMethodByUUID methodIdText
     mappings <- liftIO $ DM.mapMethodToFlowsCached dbManager dbName collectionName db method
+    tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName collectionName db method
     let stats = computeMappingStats mappings
         totalFactors = length mappings
         coverage =
@@ -1804,7 +1806,11 @@ getMethodMapping dbName methodIdText = do
                     }
                 | (cf, Nothing) <- mappings
                 ]
-        uniqueDbFlows = S.size $ S.fromList [bfId f | (_, Just (f, _)) <- mappings]
+        -- Counted from the read-side tables, not the build-side mappings: a
+        -- factor resolves to at most one flow there, so counting resolved
+        -- flows would miss every flow reached through a fallback and report a
+        -- fraction of the method's real reach.
+        uniqueDbFlows = S.size (characterizedFlowIds tables (dbBioFlows db))
     return
         MappingStatus
             { mstMethodId = methodId method
@@ -1846,6 +1852,25 @@ getFlowCFMapping dbName methodIdText = do
             , fcmTotalFlows = fromIntegral (dbBiosphereCount db)
             , fcmMatchedFlows = matchedCount
             , fcmFlows = entries
+            }
+
+{- | Coverage of one database by a whole method collection, as distinct flows.
+Distinct across methods, because they overlap — every climate-change variant
+characterizes the same gases — so this number cannot be recovered from the
+per-method mapping statuses.
+-}
+getCollectionCoverage :: Text -> Text -> AppM CollectionCoverage
+getCollectionCoverage dbName collectionName = do
+    dbManager <- asks aeDbManager
+    (db, _) <- requireDatabaseByName dbName
+    (methods, _, _, _) <- loadCollection collectionName
+    tablesList <- liftIO $ mapM (DM.mapMethodToTablesCached dbManager dbName collectionName db) methods
+    return
+        CollectionCoverage
+            { ccvCollection = collectionName
+            , ccvDbName = dbName
+            , ccvTotalFlows = fromIntegral (dbBiosphereCount db)
+            , ccvCharacterizedFlows = S.size (S.unions (map (`characterizedFlowIds` dbBioFlows db) tablesList))
             }
 
 getCharacterization :: Text -> Text -> Maybe Text -> Maybe Int -> AppM CharacterizationResult
@@ -2007,6 +2032,7 @@ lcaServer env = hoistServer lcaAPI (runApp env) handlers
             :<|> getMethodFactors
             :<|> getMethodMapping
             :<|> getFlowCFMapping
+            :<|> getCollectionCoverage
             :<|> getCharacterization
             :<|> searchFlows
             :<|> searchActivitiesWithCount

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -617,7 +617,7 @@ data MappingStatus = MappingStatus
     , mstUnmapped :: Int -- Not matched
     , mstCoverage :: Double -- Percentage of mapped flows (0-100)
     , mstDbBiosphereCount :: Int -- Total biosphere flows in the DB
-    , mstUniqueDbFlowsMatched :: Int -- Unique DB flows hit by this method's CFs
+    , mstUniqueDbFlowsMatched :: Int -- Distinct DB flows the method characterizes, counted with the same lookup scoring uses (fallbacks included)
     , mstUnmappedFlows :: [UnmappedFlowAPI] -- Details of unmapped flows
     }
     deriving (Generic)
@@ -654,6 +654,24 @@ data FlowCFEntry = FlowCFEntry
     }
     deriving (Generic)
     deriving (ToJSON, ToSchema) via (Stripped FlowCFEntry)
+
+{- | How much of one database a whole method collection characterizes: the
+distinct emission and resource flows that at least one of its methods
+resolves a factor for, probed with the same lookup scoring uses.
+
+Distinct is the point. A collection's methods overlap heavily — every
+climate-change variant characterizes the same gases — so summing per-method
+figures counts a flow once per method that reaches it, and no sum of the
+per-method mapping statuses can recover this number.
+-}
+data CollectionCoverage = CollectionCoverage
+    { ccvCollection :: Text
+    , ccvDbName :: Text
+    , ccvTotalFlows :: Int -- Emission and resource flows the database carries
+    , ccvCharacterizedFlows :: Int -- Distinct flows at least one method characterizes
+    }
+    deriving (Generic)
+    deriving (ToJSON, ToSchema) via (Stripped CollectionCoverage)
 
 -- | Characterization result: matched CFs for a method in a database
 data CharacterizationResult = CharacterizationResult

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -51,6 +51,7 @@ module Method.Mapping (
     inventoryContributions,
     processContributionsFromTables,
     lookupCFForFlow,
+    characterizedFlowIds,
     convertForCharacterization,
     expandSynonymMappings,
     directionExcludedCFs,
@@ -2364,6 +2365,25 @@ characterizes. Cold path; the singleton allocation is irrelevant here.
 lookupCFForFlow :: MethodTables -> UUID -> Maybe BiosphereFlow -> Maybe (Double, Text)
 lookupCFForFlow tables fid mFlow =
     lookupCascadeCF tables (maybe M.empty (M.singleton fid) mFlow) fid
+
+{- | The database flows a method's tables characterize, each probed with
+'lookupCFForFlow' — the read-side lookup scoring uses — so a flow reached
+through a name-level, subcompartment or CAS-bridge fallback counts as covered.
+
+This is the honest way to count a method's reach into a database. The
+build-side mappings undercount it: there each factor resolves to at most one
+flow, so a factor that covers a substance across many compartments or
+locations surfaces as a single flow. And because the answer is a set, a whole
+collection's reach is the union of its methods' sets — summing per-method
+counts would count a flow once per method that characterizes it.
+-}
+characterizedFlowIds :: MethodTables -> BioFlowDB -> S.Set UUID
+characterizedFlowIds tables bioFlows =
+    S.fromList
+        [ fid
+        | (fid, flow) <- M.toList bioFlows
+        , isJust (lookupCFForFlow tables fid (Just flow))
+        ]
 
 {- | Find the top-N method CFs that most resemble a database flow.
 

--- a/test/CharacterizedFlowsSpec.hs
+++ b/test/CharacterizedFlowsSpec.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Counting a method's reach into a database honestly: 'characterizedFlowIds'
+probes every database flow with the same lookup scoring uses, so a flow
+covered through a fallback counts — where the build-side mappings, which
+resolve each factor to at most one flow, would miss it.
+-}
+module CharacterizedFlowsSpec (spec) where
+
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import Data.Text (Text)
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
+import Test.Hspec
+
+import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, characterizedFlowIds)
+import Method.Types (CFFamily (..), Compartment (..), FlowDirection (..), MethodCF (..))
+import Types (BioFlowDB, BiosphereFlow (..))
+import qualified Types as VT
+
+mkUUID :: Integer -> UUID
+mkUUID n = UUID.fromWords64 (fromIntegral n) 0
+
+-- An emission CF with an unspecified subcompartment: the kind that lands in
+-- the medium-level fallback table and covers every subcompartment of "air".
+airCF :: Text -> Double -> MethodCF
+airCF name val =
+    MethodCF
+        { mcfFlowRef = mkUUID 100
+        , mcfFlowName = name
+        , mcfDirection = Output
+        , mcfValue = val
+        , mcfCompartment = Just (Compartment "air" "" "")
+        , mcfCAS = Nothing
+        , mcfUnit = "kg"
+        , mcfConsumerLocation = Nothing
+        }
+
+mkFlow :: Integer -> Text -> Maybe Text -> BiosphereFlow
+mkFlow i name sub =
+    BiosphereFlow
+        { bfId = mkUUID i
+        , bfName = name
+        , bfUnitId = mkUUID 0
+        , bfSynonyms = M.empty
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfCompartment = Just (VT.Compartment "air" sub)
+        }
+
+-- The database side: ammonia in two subcompartments, methane in one.
+ammoniaUrban, ammoniaRural, methane :: BiosphereFlow
+ammoniaUrban = mkFlow 1 "Ammonia" (Just "urban air")
+ammoniaRural = mkFlow 2 "Ammonia" (Just "rural")
+methane = mkFlow 3 "Methane" Nothing
+
+bioFlows :: BioFlowDB
+bioFlows = M.fromList [(bfId f, f) | f <- [ammoniaUrban, ammoniaRural, methane]]
+
+-- One ammonia factor, resolved at build time to the urban flow ONLY — the
+-- build side pairs each factor with at most one flow.
+ammoniaTables :: MethodTables
+ammoniaTables =
+    buildMethodTables OtherCFFamily M.empty M.empty [(airCF "Ammonia" 2.7, Just (ammoniaUrban, ByName))]
+
+methaneTables :: MethodTables
+methaneTables =
+    buildMethodTables OtherCFFamily M.empty M.empty [(airCF "Methane" 28.0, Just (methane, ByName))]
+
+spec :: Spec
+spec = describe "characterizedFlowIds" $ do
+    it "counts every flow the read-side lookup covers, not just the one the factor resolved to" $
+        characterizedFlowIds ammoniaTables bioFlows
+            `shouldBe` S.fromList [bfId ammoniaUrban, bfId ammoniaRural]
+
+    it "leaves a flow no factor reaches out of the set" $
+        S.member (bfId methane) (characterizedFlowIds ammoniaTables bioFlows)
+            `shouldBe` False
+
+    it "lets a collection's reach be the union of its methods' sets" $
+        S.size
+            ( S.unions
+                (map (`characterizedFlowIds` bioFlows) [ammoniaTables, methaneTables])
+            )
+            `shouldBe` 3

--- a/volca.cabal
+++ b/volca.cabal
@@ -226,6 +226,7 @@ test-suite lca-tests
                      , CASBackfillSpec
                      , RegionFallbackSpec
                      , EnergyResourceFillSpec
+                     , CharacterizedFlowsSpec
                      , SubBlindCFSpec
                      , ServerSpec
                      , ILCDParserSpec


### PR DESCRIPTION
## Why

The mapping-status endpoint's `uniqueDbFlowsMatched` counted the flows a method characterizes from the build-side mappings, where each factor resolves to at most one flow. A factor covering a substance across many compartments surfaced as one flow, and flows reached through name-level, subcompartment or CAS-bridge fallbacks were missed entirely. Measured on an EcoSpold database under an ILCD EF collection, the aggregate figure was wrong by roughly a factor of five — pessimistic — so a consumer reading it as coverage would conclude the method barely touches the database when scoring in fact characterizes about 70% of its flows.

There was also no honest way to state a whole collection's coverage: summing the per-method figures counts a flow once per method that reaches it, and a collection's methods overlap heavily (every climate-change variant characterizes the same gases).

## Final state

- `uniqueDbFlowsMatched` is now counted by probing every database flow with `lookupCFForFlow` — the same read-side lookup scoring uses — via a new `Method.Mapping.characterizedFlowIds` returning the set of covered flows.
- `GET /db/{db}/method-collection/{collection}/coverage` reports the distinct count for a whole collection, as the union of its methods' sets. Exposed in pyvolca as `Client.get_collection_coverage`.

## Checking it

- New spec (`CharacterizedFlowsSpec`) pins the decisive case: a factor resolved to one subcompartment also covers the sibling subcompartment through the fallback, and the collection union deduplicates across methods.
- Verified live against a 27 811-flow EcoSpold database under a 25-method EF 3.1 collection: the endpoint's distinct count matches an independent client-side union over the per-method `flow-mapping` responses exactly (19 517), and the per-method figure for a toxicity category went from 67 to 2 990 — the number the flow-mapping endpoint already reported.
- Full test suite, hlint and fourmolu green; pyvolca tests green, README regenerated.