### PR TITLE
Move the mathematicalRelation check from the load log to the quality report

### DIFF
--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -327,6 +327,7 @@ qualityReportToAPI mLimit r =
         , qraDuplicateActivities = checkToAPI (Quality.qrDuplicateActivities r)
         , qraSuspiciousAmounts = checkToAPI (Quality.qrSuspiciousAmounts r)
         , qraMissingMetadata = checkToAPI (Quality.qrMissingMetadata r)
+        , qraFormulaConsistency = checkToAPI (Quality.qrFormulaConsistency r)
         }
   where
     checkToAPI c =

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -464,13 +464,15 @@ description r = case r of
     GetQualityReport ->
         "LCA / ACV — dataset-soundness report of a database, for the people \
         \who build or repair one: the structural defects a score cannot \
-        \reveal. Five checks, computed on staged and loaded databases alike: \
+        \reveal. Six checks, computed on staged and loaded databases alike: \
         \entries without exactly one reference exchange, coproduct allocation \
         \percentages that don't sum to 100% (or blocks where only some \
         \coproducts carry one), entries duplicated outright \
         \(same name, location and reference product), non-finite amounts or a \
-        \zero reference amount, and missing metadata (description, \
-        \classification, location, units absent from the registry). Each \
+        \zero reference amount, missing metadata (description, \
+        \classification, location, units absent from the registry), and \
+        \stored amounts that disagree with the formulas documenting them \
+        \(mathematicalRelation, checked at parse time). Each \
         \finding carries a severity (danger, warning, info), the activity it \
         \was found on, and a readable detail. Answers 'is this dataset well \
         \formed?' — the complement of the supplier-gap report, which answers \

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -846,6 +846,7 @@ data QualityReportAPI = QualityReportAPI
     , qraDuplicateActivities :: QualityCheckAPI
     , qraSuspiciousAmounts :: QualityCheckAPI
     , qraMissingMetadata :: QualityCheckAPI
+    , qraFormulaConsistency :: QualityCheckAPI
     }
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped QualityReportAPI)

--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -336,6 +336,7 @@ rawToActivity cfg ra =
             , activityAllocationFormula = Nothing
             , activityNativeType = Nothing
             , activityNativeId = Nothing
+            , activityFormulaCheck = Nothing
             }
 
 {- | Build the reference-product (or coproduct) exchange from a @production@ row,

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -202,6 +202,9 @@ History of manual bumps:
      changes the Store layout of the linking stats embedded in the cache; a
      downgrade reading a newer cache would fail mid-decode, so both directions
      rebuild once instead.
+- 10: Activity record gained activityFormulaCheck (mathematicalRelation
+     consistency outcome, surfaced by the database quality report). Old
+     caches miss the field and would fail mid-decode.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.
@@ -209,7 +212,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeRep (Proxy :: Proxy Database))
-     in hi `xor` lo `xor` 9
+     in hi `xor` lo `xor` 10
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.

--- a/src/Database/Quality.hs
+++ b/src/Database/Quality.hs
@@ -259,7 +259,7 @@ qualityReport dbName db =
     formulaDetail fc =
         T.pack (show (fcDivergent fc))
             <> " of "
-            <> T.pack (show (fcChecked fc))
+            <> T.pack (show (fcEvaluated fc))
             <> " evaluable formula(s) disagree with the stored amount"
             <> maybe "" (\e -> " (e.g. " <> e <> ")") (fcExample fc)
             <> ( if fcUnevaluable fc > 0

--- a/src/Database/Quality.hs
+++ b/src/Database/Quality.hs
@@ -6,7 +6,8 @@ A score tells you whether a database computes; it says nothing about whether
 the dataset is well formed. These checks look for the structural defects a
 score can't reveal: processes without exactly one reference exchange,
 coproduct allocation that doesn't sum to 100%, entries duplicated outright,
-amounts that aren't finite, and missing metadata.
+amounts that aren't finite, missing metadata, and stored amounts that
+disagree with the formulas documenting them.
 
 Every check is a pure scan over a 'SimpleDatabase', so the report is
 identical on a staged database (parsed, matrices not built) and on a loaded
@@ -33,6 +34,7 @@ import Numeric (showFFloat)
 import Types (
     Activity (..),
     BiosphereFlow (..),
+    FormulaCheck (..),
     Severity (..),
     SimpleDatabase (..),
     TechnosphereFlow (..),
@@ -81,6 +83,7 @@ data QualityReport = QualityReport
     , qrDuplicateActivities :: !QualityCheck
     , qrSuspiciousAmounts :: !QualityCheck
     , qrMissingMetadata :: !QualityCheck
+    , qrFormulaConsistency :: !QualityCheck
     }
     deriving (Show, Eq)
 
@@ -95,6 +98,7 @@ qualityChecks r =
     , qrDuplicateActivities r
     , qrSuspiciousAmounts r
     , qrMissingMetadata r
+    , qrFormulaConsistency r
     ]
 
 {- | Allowed drift when summing coproduct allocation percentages. Sources round
@@ -123,6 +127,7 @@ qualityReport dbName db =
         , qrDuplicateActivities = QualityCheck True (worstFirst duplicateOffenders)
         , qrSuspiciousAmounts = QualityCheck True (worstFirst amountOffenders)
         , qrMissingMetadata = QualityCheck True (worstFirst metadataOffenders)
+        , qrFormulaConsistency = QualityCheck formulaApplicable (worstFirst formulaOffenders)
         }
   where
     acts = M.elems (sdbActivities db)
@@ -236,6 +241,31 @@ qualityReport dbName db =
                         else Nothing
             ]
         ]
+
+    -- The parse-time mathematicalRelation check (EcoSpold2): formulas that
+    -- re-evaluate away from the amount they document. Expected in system-model
+    -- exports — allocation rescales amounts without updating the copied
+    -- formulas — hence Info: the stored amounts stay authoritative, this only
+    -- tells a maker where their own formulas and amounts drifted apart.
+    -- Datasets whose formulas merely could not be evaluated are not findings;
+    -- 'False' applicability means no dataset carried a formula at all.
+    formulaApplicable = any (isJust . activityFormulaCheck) acts
+    formulaOffenders =
+        [ offender InfoSev act Nothing (formulaDetail fc)
+        | act <- acts
+        , Just fc <- [activityFormulaCheck act]
+        , fcDivergent fc > 0
+        ]
+    formulaDetail fc =
+        T.pack (show (fcDivergent fc))
+            <> " of "
+            <> T.pack (show (fcChecked fc))
+            <> " evaluable formula(s) disagree with the stored amount"
+            <> maybe "" (\e -> " (e.g. " <> e <> ")") (fcExample fc)
+            <> ( if fcUnevaluable fc > 0
+                    then "; " <> T.pack (show (fcUnevaluable fc)) <> " more could not be evaluated"
+                    else ""
+               )
 
     -- Incomplete rather than wrong, hence Info — except a missing location or an
     -- unknown unit, which change how the entry links and converts.

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -460,7 +460,7 @@ buildResult st =
                 filter
                     (not . T.null . snd)
                     [("Category", psActivityCategory st), ("SubCategory", psActivitySubCategory st)]
-        activity = Activity name description M.empty classifications location refUnit (reverse $ psExchanges st) M.empty M.empty Nothing Nothing Nothing Nothing
+        activity = Activity name description M.empty classifications location refUnit (reverse $ psExchanges st) M.empty M.empty Nothing Nothing Nothing Nothing Nothing
         pack act =
             ( act
             , reverse (psTechFlows st)

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -418,7 +418,7 @@ checkFormulas params pairs = case checked of
     _ ->
         Just
             FormulaCheck
-                { fcChecked = length evaluated
+                { fcEvaluated = length evaluated
                 , fcDivergent = length divergent
                 , fcUnevaluable = length [() | (_, _, Left _) <- checked]
                 , fcExample = listToMaybe (map example divergent)

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -9,7 +9,7 @@ import Amount (readAmount)
 import Data.Bifunctor (first)
 import qualified Data.ByteString as BS
 import qualified Data.Map as M
-import Data.Maybe (catMaybes, fromMaybe)
+import Data.Maybe (catMaybes, fromMaybe, listToMaybe)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -407,49 +407,43 @@ The stored amount always stays authoritative. EcoSpold2 sources carry
 pre-evaluated amounts, and this evaluator only supports a subset of the
 formula language (no @UnitConversion@, no cross-dataset @Ref@) with
 SimaPro-flavoured semantics, so its result serves as a consistency check, not
-a replacement. A formula that evaluates to a different value is reported as a
-divergence; the formulas that cannot be evaluated at all are summarized in a
-single warning per dataset — real EcoSpold2 databases use unsupported
-functions heavily, and one line per exchange would flood the load log.
+a replacement. Divergences are expected in real EcoSpold2 databases
+(system-model exports rescale amounts without updating the copied formulas),
+so nothing is logged: the outcome is recorded on the activity for the
+database quality report.
 -}
-validateFormulas :: M.Map Text Double -> [(Exchange, ExchangeFormula)] -> [String]
-validateFormulas params pairs = divergences ++ unevaluableSummary
+checkFormulas :: M.Map Text Double -> [(Exchange, ExchangeFormula)] -> Maybe FormulaCheck
+checkFormulas params pairs = case checked of
+    [] -> Nothing
+    _ ->
+        Just
+            FormulaCheck
+                { fcChecked = length evaluated
+                , fcDivergent = length divergent
+                , fcUnevaluable = length [() | (_, _, Left _) <- checked]
+                , fcExample = listToMaybe (map example divergent)
+                }
   where
     -- Left-biased union: a <parameter> wins over an exchange variable of the same name.
     env = M.union params (M.fromList [(v, exchangeAmount ex) | (ex, ef) <- pairs, Just v <- [efVariableName ef]])
     checked = [(ex, rel, Expr.evaluate env (Expr.normalizeExpr '.' rel)) | (ex, ef) <- pairs, Just rel <- [efMathRel ef]]
-    divergences =
-        [ "[WARNING] mathematicalRelation \""
-            ++ T.unpack rel
-            ++ "\" for exchange flow "
-            ++ UUID.toString (exchangeFlowId ex)
-            ++ " evaluates to "
-            ++ show v
-            ++ " but the dataset stores amount "
-            ++ show (exchangeAmount ex)
-            ++ " - keeping the stored amount"
-        | (ex, rel, Right v) <- checked
-        , not (nearlyEqual v (exchangeAmount ex))
-        ]
-    unevaluableSummary = case [(ex, rel) | (ex, rel, Left _) <- checked] of
-        [] -> []
-        unevaluable@((ex, rel) : _) ->
-            [ "[WARNING] "
-                ++ show (length unevaluable)
-                ++ " mathematicalRelation formula(s) could not be evaluated (e.g. \""
-                ++ T.unpack rel
-                ++ "\" on exchange flow "
-                ++ UUID.toString (exchangeFlowId ex)
-                ++ ") - keeping the stored amounts"
-            ]
+    evaluated = [(ex, rel, v) | (ex, rel, Right v) <- checked]
+    divergent = [(ex, rel, v) | (ex, rel, v) <- evaluated, not (nearlyEqual v (exchangeAmount ex))]
+    example (ex, rel, v) =
+        "\""
+            <> rel
+            <> "\" evaluates to "
+            <> T.pack (show v)
+            <> " but the dataset stores "
+            <> T.pack (show (exchangeAmount ex))
     nearlyEqual a b = abs (a - b) <= 1e-9 * max 1 (max (abs a) (abs b))
 
 -- | Xeno SAX parser implementation
 parseWithXeno :: BS.ByteString -> ProcessId -> Either String ((Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]), [String])
 parseWithXeno xmlContent processId = do
     finalState <- first show (X.fold openTag attribute endOpen text closeTag cdata initialParseState xmlContent)
-    (result, formulaWarns) <- buildResult finalState processId
-    pure (result, reverse (psWarnings finalState) ++ formulaWarns)
+    result <- buildResult finalState processId
+    pure (result, reverse (psWarnings finalState))
   where
     -- Open tag handler - update path and context
     openTag state tagName =
@@ -778,7 +772,7 @@ parseWithXeno xmlContent processId = do
     cdata = text
 
     -- Build final result from parse state
-    buildResult :: ParseState -> ProcessId -> Either String ((Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]), [String])
+    buildResult :: ParseState -> ProcessId -> Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit])
     buildResult st _pid =
         let name = fromMaybe "Unknown Activity" (psActivityName st)
             location = fromMaybe "GLO" (psLocation st)
@@ -786,14 +780,14 @@ parseWithXeno xmlContent processId = do
             refUnit = fromMaybe "UNKNOWN_UNIT" (psRefUnit st)
             nativeType = ecoSpoldNativeType (psActivityType st) (psSpecialActivityType st)
             pairs = reverse (psExchanges st)
-            formulaWarns = validateFormulas (psParams st) pairs
+            formulaCheck = checkFormulas (psParams st) pairs
             -- Apply cutoff strategy to exchanges
-            activity = Activity name description M.empty (psClassifications st) location refUnit (map fst pairs) (psParams st) (psParamExprs st) Nothing Nothing nativeType Nothing
+            activity = Activity name description M.empty (psClassifications st) location refUnit (map fst pairs) (psParams st) (psParamExprs st) Nothing Nothing nativeType Nothing formulaCheck
             techs = reverse (psTechFlows st)
             bios = reverse (psBioFlows st)
             wastes = reverse (psWasteFlows st)
             units = reverse (psUnits st)
-         in (,formulaWarns) . (,techs,bios,wastes,units) <$> applyCutoffStrategy activity
+         in (,techs,bios,wastes,units) <$> applyCutoffStrategy activity
 
 -- | Parse EcoSpold file using Xeno SAX parser
 streamParseActivityAndFlowsFromFile :: FilePath -> IO (Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]))

--- a/src/ILCD/Parser.hs
+++ b/src/ILCD/Parser.hs
@@ -571,6 +571,7 @@ buildActivity flowInfoMap techFlowDB bioFlowDB wasteFlowDB unitDB p =
                 then Nothing
                 else Just (ILCDProcessType{iptLabel = iprProcessType p})
         , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
         }
   where
     -- Look up the reference exchange's flow unit. Reference exchange is typically

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -928,6 +928,7 @@ processBlockToActivity unitCfg GlobalParams{..} ProcessBlock{..} =
                     , activityAllocationFormula = allocFormula
                     , activityNativeType = nativeType
                     , activityNativeId = nativeId
+                    , activityFormulaCheck = Nothing
                     }
             allUnits =
                 map

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -466,6 +466,23 @@ of a database.
 newtype NativeProcessId = NativeProcessId Text
     deriving (Show, Eq, Ord, Generic, NFData, Store)
 
+{- | Per-dataset outcome of the mathematicalRelation consistency check,
+computed at parse time (exchange formulas are discarded after parsing).
+The stored amounts always stay authoritative; this only records how well the
+dataset's formulas agree with them, for the database quality report.
+-}
+data FormulaCheck = FormulaCheck
+    { fcChecked :: !Int
+    -- ^ Formulas successfully evaluated
+    , fcDivergent :: !Int
+    -- ^ Evaluated to a value different from the stored amount (beyond float tolerance)
+    , fcUnevaluable :: !Int
+    -- ^ Not evaluable (unsupported functions, external references)
+    , fcExample :: !(Maybe Text)
+    -- ^ One divergent example, pre-rendered for display
+    }
+    deriving (Generic, NFData, Store)
+
 {- | Base LCA activity
 Note: ProcessId is the index in dbActivities vector, UUIDs stored in dbProcessIdTable
 -}
@@ -483,6 +500,7 @@ data Activity = Activity
     , activityAllocationFormula :: !(Maybe Text) -- Raw SimaPro allocation formula (e.g. "Qp*DMp/(Qp*DMp+Qw*DMw)*100"); Nothing if purely numeric
     , activityNativeType :: !(Maybe NativeActivityType) -- Source-format-native activity type (ecospold @activityType, SimaPro Type, ILCD processType); Nothing when source format lacks the field
     , activityNativeId :: !(Maybe NativeProcessId) -- Source dataset block this activity was read from; groups the coproducts of one block. Nothing when the source format lacks the field
+    , activityFormulaCheck :: !(Maybe FormulaCheck) -- Outcome of the mathematicalRelation consistency check; Nothing when the dataset has no formulas or the format has none
     }
     deriving (Generic, NFData, Store)
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -472,7 +472,7 @@ The stored amounts always stay authoritative; this only records how well the
 dataset's formulas agree with them, for the database quality report.
 -}
 data FormulaCheck = FormulaCheck
-    { fcChecked :: !Int
+    { fcEvaluated :: !Int
     -- ^ Formulas successfully evaluated
     , fcDivergent :: !Int
     -- ^ Evaluated to a value different from the stored amount (beyond float tolerance)

--- a/test/BM25Spec.hs
+++ b/test/BM25Spec.hs
@@ -37,6 +37,7 @@ mkActivity name loc xs =
         , activityAllocationFormula = Nothing
         , activityNativeType = Nothing
         , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
         }
 
 mkRefOutput :: UUID -> Exchange

--- a/test/BrightwayExcelWriterSpec.hs
+++ b/test/BrightwayExcelWriterSpec.hs
@@ -269,6 +269,7 @@ elec =
         , activityAllocationFormula = Nothing
         , activityNativeType = Nothing
         , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
         }
 
 prodExch :: Exchange

--- a/test/CopySpec.hs
+++ b/test/CopySpec.hs
@@ -282,6 +282,7 @@ supplierDB offset products =
                         , activityAllocationFormula = Nothing
                         , activityNativeType = Nothing
                         , activityNativeId = Nothing
+                        , activityFormulaCheck = Nothing
                         }
                in (((actUUID, prodUUID), act), (flowUUID, flow))
             | (i, name) <- zip [0 ..] products

--- a/test/CrossDBActivityLinkSpec.hs
+++ b/test/CrossDBActivityLinkSpec.hs
@@ -77,6 +77,7 @@ mkActivity name loc exs =
         , activityAllocationFormula = Nothing
         , activityNativeType = Nothing
         , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
         }
 
 refEx :: UUID.UUID -> Exchange

--- a/test/CrossDBRegionalLCIAFixture.hs
+++ b/test/CrossDBRegionalLCIAFixture.hs
@@ -111,6 +111,7 @@ mkActivity _ loc =
         , activityAllocationFormula = Nothing
         , activityNativeType = Nothing
         , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
         }
 
 emptyIndexes :: Indexes

--- a/test/CrossLinkingSpec.hs
+++ b/test/CrossLinkingSpec.hs
@@ -452,6 +452,7 @@ mkActivityAt loc =
         , activityAllocationFormula = Nothing
         , activityNativeType = Nothing
         , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
         }
 
 mkRefExchangeAt :: Text -> Exchange

--- a/test/DeleteSelectionSpec.hs
+++ b/test/DeleteSelectionSpec.hs
@@ -509,6 +509,7 @@ mkActivity name loc classif exs =
         , activityAllocationFormula = Nothing
         , activityNativeType = Nothing
         , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
         }
 
 units :: M.Map UUID Unit

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -33,6 +33,7 @@ emptyActivity =
         , activityAllocationFormula = Nothing
         , activityNativeType = Nothing
         , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
         }
 
 -- | A production output exchange (isInput=False, isReference=False by default)

--- a/test/EcoSpold1WriterSpec.hs
+++ b/test/EcoSpold1WriterSpec.hs
@@ -138,7 +138,7 @@ soloDb name prodU extra techs bios wastes =
         }
   where
     ref = TechnosphereExchange prodU 1.0 kgUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing
-    act = Activity name [] M.empty M.empty "GLO" "kg" (ref : extra) M.empty M.empty Nothing Nothing Nothing Nothing
+    act = Activity name [] M.empty M.empty "GLO" "kg" (ref : extra) M.empty M.empty Nothing Nothing Nothing Nothing Nothing
 
 -- | Empty database: no activities, no flows.
 emptyDb :: SimpleDatabase
@@ -166,7 +166,7 @@ linkedDb link =
   where
     supU = supplierLink
     conU = read "33333333-0000-4000-8000-000000000001"
-    mkAct nm prodU exs = Activity nm [] M.empty M.empty "GLO" "kg" (refOf prodU : exs) M.empty M.empty Nothing Nothing Nothing Nothing
+    mkAct nm prodU exs = Activity nm [] M.empty M.empty "GLO" "kg" (refOf prodU : exs) M.empty M.empty Nothing Nothing Nothing Nothing Nothing
     refOf prodU = TechnosphereExchange prodU 1.0 kgUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing
     supplier = mkAct "aaa supplier" supU []
     -- The consumer's input consumes the supplier's product and links to it.
@@ -559,6 +559,7 @@ spec = do
                         [ref]
                         M.empty
                         M.empty
+                        Nothing
                         Nothing
                         Nothing
                         Nothing

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -189,14 +189,15 @@ spec = describe "per-exchange comments" $ do
     -- mathematicalRelation formulas: <parameter> variables plus exchange
     -- variableNames form a dataset-local environment; an exchange's
     -- mathematicalRelation is checked against it as a consistency control.
-    -- The stored amount always stays authoritative — a divergence or an
-    -- unresolvable formula warns, never changes a number, never crashes.
+    -- The stored amount always stays authoritative — the check's outcome is
+    -- recorded on the activity for the quality report, never logged, never
+    -- changes a number, never crashes.
     -- -----------------------------------------------------------------------
     describe "mathematicalRelation formulas" $ do
         it "keeps the stored amount when the formula evaluates to a different value" $
             withFormulaFixture $ \(act, _, _, _, _) ->
                 -- fuel_input(2.0) * 2 + production(1.0) = 5.0 diverges from the
-                -- stored 4.0; the stored amount wins (the divergence warning is
+                -- stored 4.0; the stored amount wins (the recorded divergence is
                 -- asserted below, proving the nested <property>'s own
                 -- mathematicalRelation "9999" did not leak into the evaluation).
                 [exchangeAmount e | e@TechnosphereExchange{techRole = Input} <- exchanges act]
@@ -216,16 +217,24 @@ spec = describe "per-exchange comments" $ do
             withFormulaFixture $ \(act, _, _, _, _) ->
                 M.member "ghost" (activityParams act) `shouldBe` False
 
-        it "warns on divergence, on unresolvable formulas (aggregated), and on a dropped parameter" $ do
+        it "records the check outcome on the activity, with the divergent example" $
+            withFormulaFixture $ \(act, _, _, _, _) ->
+                case activityFormulaCheck act of
+                    Nothing -> expectationFailure "expected a FormulaCheck on the activity"
+                    Just fc -> do
+                        fcChecked fc `shouldBe` 1
+                        fcDivergent fc `shouldBe` 1
+                        fcUnevaluable fc `shouldBe` 1
+                        fcExample fc `shouldBe` Just "\"fuel_input * 2 + production\" evaluates to 5.0 but the dataset stores 4.0"
+
+        it "logs the dropped parameter but nothing about the formulas" $ do
             (since, _) <- getLogLines 0
             withFormulaFixture $ \_ -> pure ()
             (_, newLines) <- getLogLines since
-            any ("evaluates to 5.0 but the dataset stores amount 4.0 - keeping the stored amount" `isInfixOf`) newLines
-                `shouldBe` True
-            any ("1 mathematicalRelation formula(s) could not be evaluated (e.g. \"missing_var * 2\"" `isInfixOf`) newLines
-                `shouldBe` True
             any ("Ignoring <parameter> \"ghost\"" `isInfixOf`) newLines
                 `shouldBe` True
+            any ("mathematicalRelation" `isInfixOf`) newLines
+                `shouldBe` False
 
 {- | Synthetic ecospold2 dataset parameterised on the activityType code and
 optional specialActivityType code. One reference output, no other exchanges.

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -222,7 +222,7 @@ spec = describe "per-exchange comments" $ do
                 case activityFormulaCheck act of
                     Nothing -> expectationFailure "expected a FormulaCheck on the activity"
                     Just fc -> do
-                        fcChecked fc `shouldBe` 1
+                        fcEvaluated fc `shouldBe` 1
                         fcDivergent fc `shouldBe` 1
                         fcUnevaluable fc `shouldBe` 1
                         fcExample fc `shouldBe` Just "\"fuel_input * 2 + production\" evaluates to 5.0 but the dataset stores 4.0"

--- a/test/EcoSpold2WriterSpec.hs
+++ b/test/EcoSpold2WriterSpec.hs
@@ -120,6 +120,7 @@ fixtureSimple =
             Nothing
             (Just (EcoSpoldActivityType 1 "Ordinary transforming activity" Nothing Nothing))
             Nothing
+            Nothing
     activityB =
         Activity
             "production of B"
@@ -136,6 +137,7 @@ fixtureSimple =
             Nothing
             Nothing
             (Just (EcoSpoldActivityType 2 "Market activity" (Just 1) (Just "Hard link")))
+            Nothing
             Nothing
 
 -- | The fixture as a 'SimpleDatabase' (matches the previous IO-shaped helper).
@@ -175,6 +177,7 @@ fixtureDupBio =
             Nothing
             (Just (EcoSpoldActivityType 1 "Ordinary transforming activity" Nothing Nothing))
             Nothing
+            Nothing
 
 {- | A single-activity database wrapping one adversarial exchange. The
 exchange is the only difference between the rejection fixtures, so the export
@@ -206,6 +209,7 @@ fixtureWithExchange ex =
             Nothing
             Nothing
             (Just (EcoSpoldActivityType 1 "Ordinary transforming activity" Nothing Nothing))
+            Nothing
             Nothing
 
 {- | A single-activity database whose biosphere flow carries synonyms, so the
@@ -239,6 +243,7 @@ fixtureWithBioSynonyms =
             ]
             M.empty
             M.empty
+            Nothing
             Nothing
             Nothing
             Nothing
@@ -289,6 +294,7 @@ fixtureWasteCoproduct =
             Nothing
             Nothing
             (Just (EcoSpoldActivityType 1 "Ordinary transforming activity" Nothing Nothing))
+            Nothing
             Nothing
 
 -- | Build a full 'Database' (with matrices) from a 'SimpleDatabase'.

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -81,3 +81,4 @@ buildFixture comp = do
             Nothing
             Nothing
             Nothing
+            Nothing

--- a/test/FuzzySpec.hs
+++ b/test/FuzzySpec.hs
@@ -28,6 +28,7 @@ mkActivity name xs =
         , activityAllocationFormula = Nothing
         , activityNativeType = Nothing
         , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
         }
 
 -- Index-builder helper: create a BM25 index over a list of activity names.

--- a/test/GapReportSpec.hs
+++ b/test/GapReportSpec.hs
@@ -92,6 +92,7 @@ mkActivity name exs =
         , activityAllocationFormula = Nothing
         , activityNativeType = Nothing
         , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
         }
 
 mkTechFlow :: UUID -> Text -> TechnosphereFlow

--- a/test/ILCDParserSpec.hs
+++ b/test/ILCDParserSpec.hs
@@ -52,6 +52,7 @@ activityWithRefExchange fid =
         , activityAllocationFormula = Nothing
         , activityNativeType = Nothing
         , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
         }
 
 -- An activity with a single unresolved input exchange for the given flow UUID
@@ -83,6 +84,7 @@ activityWithInputExchange fid =
         , activityParamExprs = M.empty
         , activityNativeType = Nothing
         , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
         }
 
 spec :: Spec

--- a/test/ILCDWriterSpec.hs
+++ b/test/ILCDWriterSpec.hs
@@ -532,6 +532,7 @@ multiOutputDb =
             Nothing
             Nothing
             Nothing
+            Nothing
 
 -- ---------------------------------------------------------------------------
 -- Feature fixtures (single-output, exercising the recent ILCD writer fixes)
@@ -602,6 +603,7 @@ oneActivityDb bios exs =
             , activityAllocationFormula = Nothing
             , activityNativeType = Nothing
             , activityNativeId = Nothing
+            , activityFormulaCheck = Nothing
             }
 
 refProductEx :: Exchange

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -53,6 +53,7 @@ minimalActivity name loc exs =
         , activityAllocationFormula = Nothing
         , activityNativeType = Nothing
         , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
         }
 
 refExchange :: UUID.UUID -> Exchange

--- a/test/MatrixConstructionSpec.hs
+++ b/test/MatrixConstructionSpec.hs
@@ -171,6 +171,7 @@ spec = do
                         , activityAllocationFormula = Nothing
                         , activityNativeType = Nothing
                         , activityNativeId = Nothing
+                        , activityFormulaCheck = Nothing
                         }
                 activityMap = M.singleton (actUUID, prodUUID) activity
                 techFlowDB = M.singleton prodUUID (TechnosphereFlow prodUUID "energy product" jUnitId M.empty Nothing Nothing)
@@ -243,6 +244,7 @@ spec = do
                         , activityAllocationFormula = Nothing
                         , activityNativeType = Nothing
                         , activityNativeId = Nothing
+                        , activityFormulaCheck = Nothing
                         }
                 activityMap = M.singleton (actUUID, prodUUID) activity
                 techFlowDB = M.singleton prodUUID (TechnosphereFlow prodUUID "energy product" jUnitId M.empty Nothing Nothing)
@@ -310,6 +312,7 @@ spec = do
                         , activityAllocationFormula = Nothing
                         , activityNativeType = Nothing
                         , activityNativeId = Nothing
+                        , activityFormulaCheck = Nothing
                         }
                 pRef =
                     TechnosphereExchange
@@ -350,6 +353,7 @@ spec = do
                         , activityAllocationFormula = Nothing
                         , activityNativeType = Nothing
                         , activityNativeId = Nothing
+                        , activityFormulaCheck = Nothing
                         }
                 activityMap = M.fromList [((tA, wW), treatment), ((pA, yY), producer)]
                 techFlowDB =

--- a/test/MinimalCoverIntegrationSpec.hs
+++ b/test/MinimalCoverIntegrationSpec.hs
@@ -147,6 +147,7 @@ supplierDB offset =
                 , activityAllocationFormula = Nothing
                 , activityNativeType = Nothing
                 , activityNativeId = Nothing
+                , activityFormulaCheck = Nothing
                 }
      in SimpleDatabase
             { sdbActivities = M.singleton (actUUID, prodUUID) act
@@ -224,6 +225,7 @@ consumerDB offset n =
                         , activityAllocationFormula = Nothing
                         , activityNativeType = Nothing
                         , activityNativeId = Nothing
+                        , activityFormulaCheck = Nothing
                         }
              in ((actUUID, prodUUID), act)
         activities = M.fromList [mkConsumer i | i <- [1 .. n]]

--- a/test/QualityReportSpec.hs
+++ b/test/QualityReportSpec.hs
@@ -286,14 +286,14 @@ spec = do
 
     describe "formula consistency check" $ do
         it "flags an activity whose formulas diverge, with counts and the example" $ do
-            let fc = FormulaCheck{fcChecked = 30, fcDivergent = 12, fcUnevaluable = 3, fcExample = Just "\"a*2\" evaluates to 5.0 but the dataset stores 4.0"}
+            let fc = FormulaCheck{fcEvaluated = 30, fcDivergent = 12, fcUnevaluable = 3, fcExample = Just "\"a*2\" evaluates to 5.0 but the dataset stores 4.0"}
                 check = qrFormulaConsistency (reportOf ((mkActivity "bread" [reference breadFlow]){activityFormulaCheck = Just fc}))
             details check
                 `shouldBe` ["12 of 30 evaluable formula(s) disagree with the stored amount (e.g. \"a*2\" evaluates to 5.0 but the dataset stores 4.0); 3 more could not be evaluated"]
             severities check `shouldBe` [InfoSev]
 
         it "passes an activity whose formulas only failed to evaluate" $ do
-            let fc = FormulaCheck{fcChecked = 0, fcDivergent = 0, fcUnevaluable = 7, fcExample = Nothing}
+            let fc = FormulaCheck{fcEvaluated = 0, fcDivergent = 0, fcUnevaluable = 7, fcExample = Nothing}
                 check = qrFormulaConsistency (reportOf ((mkActivity "bread" [reference breadFlow]){activityFormulaCheck = Just fc}))
             qcOffenders check `shouldBe` []
             qcApplicable check `shouldBe` True

--- a/test/QualityReportSpec.hs
+++ b/test/QualityReportSpec.hs
@@ -27,6 +27,7 @@ import Database.Quality (
 import Types (
     Activity (..),
     Exchange (..),
+    FormulaCheck (..),
     NativeProcessId (..),
     Severity (..),
     SimpleDatabase (..),
@@ -76,6 +77,7 @@ mkActivity name exs =
         , activityAllocationFormula = Nothing
         , activityNativeType = Nothing
         , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
         }
 
 techExchange :: UUID -> Double -> TechRole -> Exchange
@@ -281,6 +283,24 @@ spec = do
 
         it "passes a fully documented activity" $
             qcOffenders (qrMissingMetadata (reportOf (mkActivity "bread" [reference breadFlow]))) `shouldBe` []
+
+    describe "formula consistency check" $ do
+        it "flags an activity whose formulas diverge, with counts and the example" $ do
+            let fc = FormulaCheck{fcChecked = 30, fcDivergent = 12, fcUnevaluable = 3, fcExample = Just "\"a*2\" evaluates to 5.0 but the dataset stores 4.0"}
+                check = qrFormulaConsistency (reportOf ((mkActivity "bread" [reference breadFlow]){activityFormulaCheck = Just fc}))
+            details check
+                `shouldBe` ["12 of 30 evaluable formula(s) disagree with the stored amount (e.g. \"a*2\" evaluates to 5.0 but the dataset stores 4.0); 3 more could not be evaluated"]
+            severities check `shouldBe` [InfoSev]
+
+        it "passes an activity whose formulas only failed to evaluate" $ do
+            let fc = FormulaCheck{fcChecked = 0, fcDivergent = 0, fcUnevaluable = 7, fcExample = Nothing}
+                check = qrFormulaConsistency (reportOf ((mkActivity "bread" [reference breadFlow]){activityFormulaCheck = Just fc}))
+            qcOffenders check `shouldBe` []
+            qcApplicable check `shouldBe` True
+
+        it "is not applicable to a database without any formula" $
+            qcApplicable (qrFormulaConsistency (reportOf (mkActivity "bread" [reference breadFlow])))
+                `shouldBe` False
 
     describe "report header" $
         it "counts one process per (activity, product) entry" $ do

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -92,6 +92,7 @@ mkActivity loc =
         , activityAllocationFormula = Nothing
         , activityNativeType = Nothing
         , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
         }
 
 -- Triples: (bioRow=0, col=i, value=v) for each activity.

--- a/test/RelinkMappingSpec.hs
+++ b/test/RelinkMappingSpec.hs
@@ -90,6 +90,7 @@ targetDB =
                 , activityAllocationFormula = Nothing
                 , activityNativeType = Nothing
                 , activityNativeId = Nothing
+                , activityFormulaCheck = Nothing
                 }
         flow =
             TechnosphereFlow

--- a/test/SetupInfoSpec.hs
+++ b/test/SetupInfoSpec.hs
@@ -66,6 +66,7 @@ minimalActivity name exs =
         , activityAllocationFormula = Nothing
         , activityNativeType = Nothing
         , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
         }
 
 refExchange :: UUID.UUID -> Exchange

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -602,6 +602,7 @@ emissionDb comp =
             Nothing
             Nothing
             Nothing
+            Nothing
 
 -- ---------------------------------------------------------------------------
 -- Allocation round-trip fixture
@@ -648,6 +649,7 @@ allocationDb =
             Nothing
             Nothing
             Nothing
+            Nothing
 
 {- | A 0%-allocated activity: its shared material input is stored at 0 (the parser
 scaled every shared amount by allocFraction = 0 on import). A correct writer emits
@@ -686,6 +688,7 @@ zeroAllocationDb =
             M.empty
             M.empty
             (Just 0)
+            Nothing
             Nothing
             Nothing
             Nothing
@@ -733,6 +736,7 @@ commentDb ped cmt =
             Nothing
             Nothing
             Nothing
+            Nothing
 
 {- | One activity with the given name and a single reference product. Exercises
 the metadata-key collision guard: a name equal to a SimaPro key is rejected.
@@ -762,6 +766,7 @@ namedDb name =
             [TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing]
             M.empty
             M.empty
+            Nothing
             Nothing
             Nothing
             Nothing
@@ -819,4 +824,4 @@ guardDb alloc ntype exs =
         }
   where
     act =
-        Activity "guard maker" [] M.empty M.empty "GLO" "kg" exs M.empty M.empty alloc Nothing ntype Nothing
+        Activity "guard maker" [] M.empty M.empty "GLO" "kg" exs M.empty M.empty alloc Nothing ntype Nothing Nothing

--- a/test/StrictPinSpec.hs
+++ b/test/StrictPinSpec.hs
@@ -252,6 +252,7 @@ supplierDB offset products =
                         , activityAllocationFormula = Nothing
                         , activityNativeType = Nothing
                         , activityNativeId = Nothing
+                        , activityFormulaCheck = Nothing
                         }
                in (((actUUID, prodUUID), act), (flowUUID, flow))
             | (i, name) <- zip [0 ..] products
@@ -313,6 +314,7 @@ consumerDB offset products =
                         , activityAllocationFormula = Nothing
                         , activityNativeType = Nothing
                         , activityNativeId = Nothing
+                        , activityFormulaCheck = Nothing
                         }
                in (((actUUID, prodUUID), act), [(inFlowUUID, inFlow), (outFlowUUID, outFlow)])
             | (i, name) <- zip [0 ..] products

--- a/test/WasteTreatmentSignSpec.hs
+++ b/test/WasteTreatmentSignSpec.hs
@@ -68,6 +68,7 @@ emptyActivity =
         , activityAllocationFormula = Nothing
         , activityNativeType = Nothing
         , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
         }
 
 techEx :: UUID -> Double -> TechRole -> UUID -> Exchange


### PR DESCRIPTION
Loading an EcoSpold2 database printed one warning per exchange whose `mathematicalRelation` re-evaluates away from the stored amount — thousands of lines on a real database. These divergences are expected by construction: system-model exports rescale amounts (allocation, waste-flow signs, unit normalization) without updating the formulas copied from the unallocated parent dataset, and the evaluator only covers a subset of the formula language. Nobody can act on such a warning while a database loads.

The load log now says nothing about formulas. The parse-time check instead records its outcome on each activity (evaluated, divergent and unevaluable counts, plus one divergent example), and the database quality report gains a sixth check that reads it: one info-severity finding per dataset whose formulas disagree with its stored amounts. Datasets whose formulas merely could not be evaluated are not findings, and a database without any formula marks the check not applicable. The stored amounts stay authoritative throughout.

The `Activity` record gained a field, so the cache schema salt is bumped and old caches rebuild once.