### PR TITLE
Type the CF value as CF/CFUnit and locations as Location

### DIFF
--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -43,7 +43,7 @@ import qualified Expr
 import GHC.Generics
 import qualified GHC.Stats
 import Matrix (Inventory, Vector)
-import Method.Mapping (LCIAOutcome (..), LongTermMode (..), MappingStats (..), MatchStrategy (..), MethodTables (..), applyLongTermMode, characterizedFlowIds, computeLCIAScoreFromTables, computeLCIAScoreSetFromTables, computeMappingStats, inventoryContributions, longTermModeFromExclude, lookupCFForFlow, strategyPriority, sumRegionalizedLCIAScoreCrossDB)
+import Method.Mapping (CF (..), LCIAOutcome (..), LongTermMode (..), MappingStats (..), MatchStrategy (..), MethodTables (..), applyLongTermMode, characterizedFlowIds, computeLCIAScoreFromTables, computeLCIAScoreSetFromTables, computeMappingStats, inventoryContributions, longTermModeFromExclude, lookupCFForFlow, strategyPriority, sumRegionalizedLCIAScoreCrossDB)
 import qualified Method.Mapping
 import Method.Types (DamageCategory (..), Method (..), MethodCF (..), MethodCollection (..), NormWeightSet (..), ScoringEvaluation (..), ScoringSet (..), computeFormulaScores)
 import qualified Method.Types as MT
@@ -1037,7 +1037,7 @@ buildFlowEntry db tables reverseIndex uuid =
               -- single build-side CF resolved to it) still reports as covered —
               -- exactly what scoring sees. mMatch only annotates how a direct
               -- match resolved; it is absent for fallback-covered flows.
-              fceCfValue = fmap fst (mFlow >>= lookupCFForFlow tables uuid . Just)
+              fceCfValue = fmap cfValue (mFlow >>= lookupCFForFlow tables uuid . Just)
             , fceCfFlowName = fmap (mcfFlowName . fst) mMatch
             , fceMatchStrategy = fmap (strategyToText . snd) mMatch
             }

--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -88,6 +88,7 @@ import qualified Data.Text as T
 import Data.UUID (UUID)
 
 import qualified Data.Vector as V
+import Method.Types (Location (..))
 import SynonymDB (SynonymDB, lookupSynonymGroup, normalizeName)
 import Types (
     Activity (..),
@@ -164,7 +165,7 @@ data LinkingContext = LinkingContext
     name+location scoring; geographic acceptability is enforced separately
     by 'lcGeographyPolicy' via 'acceptableLocation'.
     -}
-    , lcLocationHierarchy :: !(M.Map Text [Text])
+    , lcLocationHierarchy :: !(M.Map Location [Location])
     -- ^ Location hierarchy (code → parent codes)
     , lcGeographyPolicy :: !GeographyPolicy
     -- ^ How aggressively to widen geography when no exact match is found
@@ -776,7 +777,7 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
 
     classifyEntry :: Text -> (Text, SupplierEntry) -> Maybe ((Text, SupplierEntry), LocationKind)
     classifyEntry queryLoc entry@(_, SupplierEntry{seLocation}) =
-        case acceptableLocation lcGeographyPolicy lcLocationHierarchy queryLoc seLocation of
+        case acceptableLocation lcGeographyPolicy lcLocationHierarchy (Location queryLoc) (Location seLocation) of
             Just kind -> Just (entry, kind)
             Nothing -> Nothing
 
@@ -790,7 +791,7 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
                 mapMaybe
                     ( \(_, SupplierEntry{seLocation}) ->
                         (seLocation,)
-                            <$> acceptableLocation GeoGlobal lcLocationHierarchy queryLoc seLocation
+                            <$> acceptableLocation GeoGlobal lcLocationHierarchy (Location queryLoc) (Location seLocation)
                     )
                     candidates
             kindOrder ExactLoc = 4 :: Int
@@ -803,7 +804,7 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
 
     scoreEntry :: Text -> (Text, SupplierEntry) -> CrossDBCandidate
     scoreEntry queryLoc (dbName, SupplierEntry{..}) =
-        let locScore = matchLocation lcLocationHierarchy queryLoc seLocation
+        let locScore = matchLocation lcLocationHierarchy (Location queryLoc) (Location seLocation)
             nameScore = 50
             !totalScore = nameScore + locScore
          in CrossDBCandidate
@@ -872,11 +873,11 @@ Returns:
   10 = Global fallback (GLO or RoW)
    5 = Different but not blocking
 -}
-matchLocation :: M.Map Text [Text] -> Text -> Text -> Int
+matchLocation :: M.Map Location [Location] -> Location -> Location -> Int
 matchLocation hier queryLoc candidateLoc
     | queryLoc == candidateLoc = 30 -- Exact
     | isSubregionOf hier queryLoc candidateLoc = 20 -- Widening (FR→GLO, FR→RER)
-    | candidateLoc `elem` ["GLO", "RoW", "Unspecified"] = 10 -- Global fallback
+    | candidateLoc `elem` placelessLocations = 10 -- Global fallback
     | isSubregionOf hier candidateLoc queryLoc = 0 -- Narrowing (GLO→FR) — blocked
     | otherwise = 5 -- Unrelated
 
@@ -889,10 +890,10 @@ the requested location's parent chain (every country has GLO/RoW listed in
 'locationHierarchy'), because semantically a global fallback is a stronger
 caveat than an honest geographic widening.
 -}
-describeLocation :: M.Map Text [Text] -> Text -> Text -> LocationKind
+describeLocation :: M.Map Location [Location] -> Location -> Location -> LocationKind
 describeLocation hier queryLoc candidateLoc
     | queryLoc == candidateLoc = ExactLoc
-    | candidateLoc `elem` ["GLO", "RoW", "Unspecified"] = GlobalLoc
+    | candidateLoc `elem` placelessLocations = GlobalLoc
     | isSubregionOf hier queryLoc candidateLoc = ParentLoc
     | otherwise = UnrelatedLoc
 
@@ -903,11 +904,11 @@ rejected: it would invent precision the source dataset does not have.
 -}
 acceptableLocation ::
     GeographyPolicy ->
-    M.Map Text [Text] ->
+    M.Map Location [Location] ->
     -- | requested location
-    Text ->
+    Location ->
     -- | candidate location
-    Text ->
+    Location ->
     Maybe LocationKind
 acceptableLocation policy hier queryLoc candidateLoc
     | isNarrowing = Nothing
@@ -924,21 +925,31 @@ acceptableLocation policy hier queryLoc candidateLoc
     -- placeless code (GLO/RoW/Unspecified) — those are wider, not narrower
     isNarrowing =
         queryLoc /= candidateLoc
-            && candidateLoc `notElem` ["GLO", "RoW", "Unspecified"]
+            && candidateLoc `notElem` placelessLocations
             && isSubregionOf hier candidateLoc queryLoc
 
 -- | Check if one location is a subregion of another
-isSubregionOf :: M.Map Text [Text] -> Text -> Text -> Bool
+isSubregionOf :: M.Map Location [Location] -> Location -> Location -> Bool
 isSubregionOf hier child parent =
     case M.lookup child hier of
         Just parents -> parent `elem` parents
         Nothing -> False
 
+{- | Placeless codes: wider than any region — a valid global fallback,
+never a narrowing target.
+-}
+placelessLocations :: [Location]
+placelessLocations = map Location ["GLO", "RoW", "Unspecified"]
+
 {- | Location hierarchy for common LCA regions
 Maps a location code to its parent regions
 -}
-locationHierarchy :: M.Map Text [Text]
-locationHierarchy =
+locationHierarchy :: M.Map Location [Location]
+locationHierarchy = M.mapKeysMonotonic Location (M.map (map Location) rawLocationHierarchy)
+
+-- | The hierarchy table, kept as literal 'Text' for readability.
+rawLocationHierarchy :: M.Map Text [Text]
+rawLocationHierarchy =
     M.fromList
         [ -- European countries → regional/continental groupings
           ("FR", ["Europe without Switzerland", "Europe without Austria", "Europe", "EU", "RER", "ENTSO-E", "GLO", "RoW"])

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -136,6 +136,7 @@ import EcoSpold.Parser2 (streamParseActivityAndFlowsFromFile)
 import GHC.Conc (getNumCapabilities)
 import GHC.Fingerprint (Fingerprint (..))
 import qualified ILCD.Parser as ILCD
+import Method.Types (Location)
 import Progress
 import qualified SimaPro.Parser as SimaPro
 import SynonymDB (SynonymDB)
@@ -1176,7 +1177,7 @@ loadDatabaseWithCrossDBLinking ::
     -- | Unit configuration for compatibility checking
     UC.UnitConfig ->
     -- | Location hierarchy (empty = use built-in)
-    M.Map T.Text [T.Text] ->
+    M.Map Location [Location] ->
     -- | Geography policy for this database
     GeographyPolicy ->
     -- | Path to load from
@@ -1245,7 +1246,7 @@ fixActivityLinksWithCrossDB ::
     -- | Unit configuration
     UC.UnitConfig ->
     -- | Location hierarchy (code → parent codes)
-    M.Map T.Text [T.Text] ->
+    M.Map Location [Location] ->
     -- | Geography policy for this database
     GeographyPolicy ->
     -- | Database to fix
@@ -1355,7 +1356,7 @@ relinkSimpleDatabase ::
     [IndexedDatabase] ->
     SynonymDB ->
     UC.UnitConfig ->
-    M.Map T.Text [T.Text] ->
+    M.Map Location [Location] ->
     GeographyPolicy ->
     AliasMap ->
     SimpleDatabase ->

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -174,6 +174,7 @@ import Method.Mapping (
 import Method.Types (
     CompartmentMap,
     EnergyDensityMap,
+    Location (..),
     Method (..),
     MethodCF (..),
     MethodCollection (..),
@@ -630,7 +631,7 @@ mapMethodToTablesCachedWithHier ::
     Text ->
     Text ->
     Database ->
-    M.Map Text [Text] ->
+    M.Map Location [Location] ->
     Method ->
     IO MethodTables
 mapMethodToTablesCachedWithHier manager dbName collection db hier method = do
@@ -654,7 +655,7 @@ coverage gaps are surfaced once here, at build time, rather than per-pid on the
 scoring path. Caching and single-flighting are the caller's responsibility.
 -}
 buildMethodTablesFor ::
-    DatabaseManager -> Text -> Text -> Database -> M.Map Text [Text] -> Method -> IO MethodTables
+    DatabaseManager -> Text -> Text -> Database -> M.Map Location [Location] -> Method -> IO MethodTables
 buildMethodTablesFor manager dbName collection db hier method = do
     expanded <- effectiveMethodMappings manager dbName collection db method
     -- A CF matchable through the union synonym tables but not through its own
@@ -706,7 +707,7 @@ buildMethodTablesFor manager dbName collection db hier method = do
                         <> " regionalized (flow, location) pair(s) without CF coverage "
                         <> "(after walking parent regions and universal broadcast). "
                         <> "Samples: "
-                        <> show (take 3 [(show fid, T.unpack loc) | (fid, loc) <- rawMissingPairs raw'])
+                        <> show (take 3 [(show fid, T.unpack loc) | (fid, Location loc) <- rawMissingPairs raw'])
     pure tables
 
 {- | Run @build@ at most once per @key@ across concurrent callers. The first
@@ -3241,8 +3242,8 @@ but if data drift produces them, surface via log rather than hide.
 'data/geographies.csv' (or the hardcoded fallback). Reused across the LCIA
 regionalized scoring path (see 'Method.Mapping.computeRegionalizedLCIAScore').
 -}
-getLocationHierarchy :: DatabaseManager -> IO (M.Map Text [Text])
-getLocationHierarchy manager = pure (M.map snd (dmGeographies manager))
+getLocationHierarchy :: DatabaseManager -> IO (M.Map Location [Location])
+getLocationHierarchy manager = pure (M.map (map Location . snd) (M.mapKeysMonotonic Location (dmGeographies manager)))
 
 {- | Merged biosphere flow metadata + units across all loaded DBs. Technosphere
 flows are not merged here because characterization (the only consumer of

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -799,7 +799,7 @@ mapMethodSetToTablesCached manager dbName collection db methods = do
         Just mst -> pure mst
         Nothing -> do
             -- Fetch the location hierarchy once for the whole fan-out so the
-            -- concurrent workers don't each rebuild 'M.map snd dmGeographies'
+            -- concurrent workers don't each rebuild the typed hierarchy
             -- under 'getLocationHierarchy'.
             hier <- getLocationHierarchy manager
             -- mapConcurrently here parallelizes the per-method 'MethodTables'
@@ -1095,7 +1095,7 @@ loadOneDatabase ::
 loadOneDatabase synonymDB unitConfig noCache otherIndexes loadedDbsVar indexedDbsVar manager dbConfig = do
     dbStart <- getCurrentTime
     reportProgress Info $ "[STARTING] Loading database: " <> T.unpack (dcDisplayName dbConfig)
-    result <- loadDatabaseFromConfigWithCrossDB dbConfig synonymDB unitConfig noCache otherIndexes (M.map snd (dmGeographies manager))
+    result <- loadDatabaseFromConfigWithCrossDB dbConfig synonymDB unitConfig noCache otherIndexes (locationHierarchyOf manager)
     case result of
         Right (loaded0, _fromCache) -> do
             -- Backfill empty bfCAS from the registry's name↔CAS edges before
@@ -1381,7 +1381,7 @@ loadDatabaseFromConfigWithCrossDB ::
     UnitConversion.UnitConfig ->
     Bool -> -- noCache
     [IndexedDatabase] -> -- Pre-built indexes from other databases for cross-DB linking
-    M.Map T.Text [T.Text] -> -- Location hierarchy (empty = use built-in)
+    M.Map Location [Location] -> -- Location hierarchy (empty = use built-in)
     IO (Either Text (LoadedDatabase, Bool))
 loadDatabaseFromConfigWithCrossDB dbConfig synonymDB unitConfig noCache otherIndexes locationHier = do
     let sourcePath = dcPath dbConfig
@@ -1512,7 +1512,7 @@ loadDatabaseRawWithCrossDB ::
     -- | Pre-built indexes from other databases
     [IndexedDatabase] ->
     -- | Location hierarchy (empty = use built-in)
-    M.Map T.Text [T.Text] ->
+    M.Map Location [Location] ->
     -- | Geography policy for this database
     GeographyPolicy ->
     {- | (Database, fromCache): True iff the result came from the matrix cache
@@ -1666,7 +1666,7 @@ loadDatabaseSingleFromConfig manager dbName = do
                                 unitConfig
                                 (dmNoCache manager)
                                 otherIndexes
-                                (M.map snd (dmGeographies manager))
+                                (locationHierarchyOf manager)
                     case eitherResult of
                         Left (ex :: SomeException) -> return $ Left $ "Exception loading database: " <> T.pack (show ex)
                         Right (Left err) -> return $ Left err
@@ -1822,7 +1822,7 @@ relinkStaged manager dbName maybeDepDb aliases = do
                                 selectedIndexes
                                 synonymDB
                                 unitConfig
-                                (M.map snd (dmGeographies manager))
+                                (locationHierarchyOf manager)
                                 (dcGeographyPolicy (sdConfig staged))
                                 aliases
                                 (sdSimpleDB staged)
@@ -1896,7 +1896,7 @@ relinkDatabaseWith manager dbName aliases persistedDeps = do
                         , lcSynonymDB = synonymDB
                         , lcUnitConfig = unitConfig
                         , lcThreshold = defaultLinkingThreshold
-                        , lcLocationHierarchy = M.map snd (dmGeographies manager)
+                        , lcLocationHierarchy = locationHierarchyOf manager
                         , lcGeographyPolicy = dcGeographyPolicy (ldConfig loaded)
                         , lcSupplierAliases = aliases
                         }
@@ -2118,7 +2118,7 @@ stageUploadedDatabase manager dbConfig = do
                     otherIndexes
                     synonymDB
                     unitConfig
-                    (M.map snd (dmGeographies manager))
+                    (locationHierarchyOf manager)
                     (dcGeographyPolicy dbConfig)
                     loadPath
 
@@ -2149,7 +2149,7 @@ stageUploadedDatabase manager dbConfig = do
                                         restrictedIndexes
                                         synonymDB
                                         unitConfig
-                                        (M.map snd (dmGeographies manager))
+                                        (locationHierarchyOf manager)
                                         (dcGeographyPolicy dbConfig)
                                         simpleDb
                                 return (stats', simpleDb')
@@ -2731,7 +2731,7 @@ addDependencyToStaged manager dbName depName = do
                         selectedIndexes
                         synonymDB
                         unitConfig
-                        (M.map snd (dmGeographies manager))
+                        (locationHierarchyOf manager)
                         (dcGeographyPolicy (sdConfig staged))
                         (sdSimpleDB staged)
 
@@ -2770,7 +2770,7 @@ removeDependencyFromStaged manager dbName depName = do
                     remainingIndexes
                     synonymDB
                     unitConfig
-                    (M.map snd (dmGeographies manager))
+                    (locationHierarchyOf manager)
                     (dcGeographyPolicy (sdConfig staged))
                     (sdSimpleDB staged)
 
@@ -3243,7 +3243,11 @@ but if data drift produces them, surface via log rather than hide.
 regionalized scoring path (see 'Method.Mapping.computeRegionalizedLCIAScore').
 -}
 getLocationHierarchy :: DatabaseManager -> IO (M.Map Location [Location])
-getLocationHierarchy manager = pure (M.map (map Location . snd) (M.mapKeysMonotonic Location (dmGeographies manager)))
+getLocationHierarchy = pure . locationHierarchyOf
+
+-- | Pure form of 'getLocationHierarchy', shared by the loading paths.
+locationHierarchyOf :: DatabaseManager -> M.Map Location [Location]
+locationHierarchyOf manager = M.map (map Location . snd) (M.mapKeysMonotonic Location (dmGeographies manager))
 
 {- | Merged biosphere flow metadata + units across all loaded DBs. Technosphere
 flows are not merged here because characterization (the only consumer of

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -20,6 +20,8 @@ module Method.Mapping (
     buildMapContext,
 
     -- * LCIA scoring
+    CF (..),
+    CFUnit (..),
     CFFamily (..),
     cfFamily,
     MethodTables (..),
@@ -406,35 +408,52 @@ computeMappingStats = foldMap (tally . fmap snd . snd)
     -- to keep the match exhaustive. Counts as unmatched if ever introduced.
     tally (Just NoMatch) = one{msUnmatched = 1}
 
+{- | The unit a CF value is denominated in ('mcfUnit' as parsed — a flow
+reference unit like @"kg"@, or an impact-result expression like @"kg CO2 eq"@).
+A distinct type from the flow's own unit so the two sides of a
+flow-unit → CF-unit conversion can't be silently swapped.
+-}
+newtype CFUnit = CFUnit Text
+    deriving (Eq, Ord, Show)
+
+{- | A characterization factor as stored in the lookup tables: the value and
+the unit it is denominated in, kept together so they can't drift apart.
+-}
+data CF = CF
+    { cfValue :: !Double
+    , cfUnit :: !CFUnit
+    }
+    deriving (Eq, Show)
+
 {- | Precomputed CF lookup tables for one (database, method) pair.
 Building these from raw mappings is O(n log n) over thousands of CFs, so they
 should be computed once per method and reused across inventories.
 -}
 data MethodTables = MethodTables
-    { mtUuidCF :: !(M.Map UUID (Double, Text))
-    -- ^ UUID-matched CFs: exact flow id → (CF value, CF unit)
-    , mtExactCF :: !(M.Map (SR.NormName, Medium, Subcompartment) (Double, Text))
-    -- ^ (normalized name, medium, subcompartment) → (CF, unit)
-    , mtFallbackCF :: !(M.Map (SR.NormName, Medium) (Double, Text))
-    -- ^ (normalized name, medium) → (CF, unit) for entries with unspecified subcompartment
-    , mtLongTermFallbackCF :: !(M.Map (SR.NormName, Medium) (Double, Text))
-    {- ^ (normalized name, medium) → (CF, unit) for entries with the long-term
+    { mtUuidCF :: !(M.Map UUID CF)
+    -- ^ UUID-matched CFs: exact flow id → CF
+    , mtExactCF :: !(M.Map (SR.NormName, Medium, Subcompartment) CF)
+    -- ^ (normalized name, medium, subcompartment) → CF
+    , mtFallbackCF :: !(M.Map (SR.NormName, Medium) CF)
+    -- ^ (normalized name, medium) → CF for entries with unspecified subcompartment
+    , mtLongTermFallbackCF :: !(M.Map (SR.NormName, Medium) CF)
+    {- ^ (normalized name, medium) → CF for entries with the long-term
     UNSPECIFIED subcompartment ("unspecified (long-term)"). A long-term flow at an
     uncovered specific subcompartment ("groundwater, long-term") inherits this —
     the method's long-term default, often a deliberate zero — instead of the
     immediate-emission 'mtFallbackCF', so JRC scores delayed emissions with the
     method's own long-term factor rather than the immediate one.
     -}
-    , mtSubBlindCF :: !(M.Map (SR.NormName, Medium) (Double, Text))
-    {- ^ (normalized name, medium) → (CF, unit), but only where the substance's
+    , mtSubBlindCF :: !(M.Map (SR.NormName, Medium) CF)
+    {- ^ (normalized name, medium) → CF, but only where the substance's
     factor is the SAME across every subcompartment — i.e. the subcompartment
     genuinely doesn't change it (mineral/metal extraction: "Cadmium, in ground"
     == any sub). Lets a flow whose sub matches no exact CF and has no
     unspecified fallback still resolve, without guessing for a substance whose
     factor DOES vary by sub (water by source), which is omitted as ambiguous.
     -}
-    , mtCasCF :: !(M.Map (SR.CASNumber, Medium) (Double, Text))
-    {- ^ (CAS, normalized medium) → (CF, unit), from non-regionalized CFs.
+    , mtCasCF :: !(M.Map (SR.CASNumber, Medium) CF)
+    {- ^ (CAS, normalized medium) → CF, from non-regionalized CFs.
     Read-path fallback after UUID and name. Without it, a CF resolves to a
     single database flow at build time, so when many flows share one CAS in a
     compartment (e.g. every water flow shares 7732-18-5) only that one flow is
@@ -446,14 +465,14 @@ data MethodTables = MethodTables
     (minerals are reachable only through this bridge). Empty for methods whose
     CFs carry no CAS.
     -}
-    , mtRegionalCasCF :: !(M.Map (SR.CASNumber, Medium) (M.Map Text (Double, Text)))
-    {- ^ (CAS, normalized medium) → (location → (CF, unit)), from regionalized
+    , mtRegionalCasCF :: !(M.Map (SR.CASNumber, Medium) (M.Map Text CF))
+    {- ^ (CAS, normalized medium) → (location → CF), from regionalized
     CFs. The regionalized analogue of 'mtCasCF': lets the regionalized build
     characterize every same-CAS flow per location, not just the one a CF
     resolved to. Empty for methods with no regionalized CAS-bearing CFs.
     -}
-    , mtRegionalizedCF :: !(M.Map (UUID, Text) (Double, Text))
-    {- ^ Regionalized cells of the C matrix: (DB flow UUID, consumer location) → (CF, unit).
+    , mtRegionalizedCF :: !(M.Map (UUID, Text) CF)
+    {- ^ Regionalized cells of the C matrix: (DB flow UUID, consumer location) → CF.
     Empty for non-regionalized methods. When non-empty, callers should dispatch
     to the regionalized scoring path (see 'Matrix.computeRegionalizedLCIAScore').
     -}
@@ -962,7 +981,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             -- keeps the last row). Regionalized UUID-matched rows reach
             -- 'mtRegionalizedCF' keyed by flow UUID + location.
             M.fromList
-                [ (bfId flow, (mcfValue cf, mcfUnit cf))
+                [ (bfId flow, cfOf cf)
                 | (cf, Just (flow, ByUUID)) <- mappings
                 , Nothing <- [mcfConsumerLocation cf]
                 ]
@@ -976,7 +995,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             stripStrategy $
                 M.fromListWith
                     preferBetter
-                    [ ((SR.NormName (nameKey cf mflow), Medium normMed, Subcompartment normSub), (mcfValue cf, mcfUnit cf, matchStrategy mflow, rawNameMatches cf mflow))
+                    [ ((SR.NormName (nameKey cf mflow), Medium normMed, Subcompartment normSub), (cfOf cf, matchStrategy mflow, rawNameMatches cf mflow))
                     | (cf, mflow) <- mappings
                     , Nothing <- [mcfConsumerLocation cf]
                     , Just comp <- [mcfCompartment cf]
@@ -999,7 +1018,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             stripStrategy $
                 M.fromListWith
                     preferBetter
-                    [ ((SR.NormName (nameKey cf mflow), Medium normMed), (mcfValue cf, mcfUnit cf, matchStrategy mflow, rawNameMatches cf mflow))
+                    [ ((SR.NormName (nameKey cf mflow), Medium normMed), (cfOf cf, matchStrategy mflow, rawNameMatches cf mflow))
                     | (cf, mflow) <- mappings
                     , Nothing <- [mcfConsumerLocation cf]
                     , Just comp <- [mcfCompartment cf]
@@ -1017,7 +1036,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             stripStrategy $
                 M.fromListWith
                     preferBetter
-                    [ ((SR.NormName (nameKey cf mflow), Medium normMed), (mcfValue cf, mcfUnit cf, matchStrategy mflow, rawNameMatches cf mflow))
+                    [ ((SR.NormName (nameKey cf mflow), Medium normMed), (cfOf cf, matchStrategy mflow, rawNameMatches cf mflow))
                     | (cf, mflow) <- mappings
                     , Nothing <- [mcfConsumerLocation cf]
                     , Just comp <- [mcfCompartment cf]
@@ -1033,7 +1052,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             M.mapMaybe agreedValue $
                 M.fromListWith
                     (++)
-                    [ ((SR.NormName (nameKey cf mflow), Medium normMed), [(mcfValue cf, mcfUnit cf)])
+                    [ ((SR.NormName (nameKey cf mflow), Medium normMed), [cfOf cf])
                     | (cf, mflow) <- mappings
                     , Nothing <- [mcfConsumerLocation cf]
                     , Just comp <- [mcfCompartment cf]
@@ -1071,7 +1090,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             M.map snd $
                 M.fromListWith
                     preferUnspecifiedCas
-                    [ ((SR.CASNumber cas, Medium normMed), (casSubRank normSub, (mcfValue cf, mcfUnit cf)))
+                    [ ((SR.CASNumber cas, Medium normMed), (casSubRank normSub, cfOf cf))
                     | (cf, Just (_, ByCAS)) <- mappings
                     , Just cas <- [mcfCAS cf]
                     , not (T.null cas)
@@ -1089,7 +1108,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             M.map (M.map snd) $
                 M.fromListWith
                     (M.unionWith preferUnspecifiedCas)
-                    [ ((SR.CASNumber cas, Medium normMed), M.singleton loc (casSubRank normSub, (mcfValue cf, mcfUnit cf)))
+                    [ ((SR.CASNumber cas, Medium normMed), M.singleton loc (casSubRank normSub, cfOf cf))
                     | (cf, Just (_, ByCAS)) <- mappings
                     , Just cas <- [mcfCAS cf]
                     , not (T.null cas)
@@ -1107,7 +1126,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             -- fallback CF. CFs with no specific subcomp ('isUnspecifiedSub')
             -- are wildcards and match any flow subcomp.
             M.fromList
-                [ ((bfId flow, loc), (mcfValue cf, mcfUnit cf))
+                [ ((bfId flow, loc), cfOf cf)
                 | (cf, Just (flow, _)) <- mappings
                 , cfSubcompMatchesFlow cf flow
                 , Just loc <- [mcfConsumerLocation cf]
@@ -1119,7 +1138,9 @@ buildMethodTables methodFamily cmap energyDensities mappings =
         , mtRegionalActivityWeights = Nothing -- fill via 'fillRegionalActivityWeights' for regional fast path
         }
   where
-    stripStrategy = M.map (\(v, u, _, _) -> (v, u))
+    cfOf cf = CF (mcfValue cf) (CFUnit (mcfUnit cf))
+
+    stripStrategy = M.map (\(c, _, _) -> c)
 
     -- All subcompartments of a (name, medium) agree on the CF ⇒ the sub is
     -- irrelevant; return that common value. Disagreement ⇒ Nothing (ambiguous).
@@ -1136,7 +1157,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
     casSubRank s
         | isUnspecifiedSub s = 0 :: Int
         | otherwise = 1
-    preferUnspecifiedCas a@(ra, (va, _)) b@(rb, (vb, _))
+    preferUnspecifiedCas a@(ra, CF va _) b@(rb, CF vb _)
         | ra /= rb = if ra < rb then a else b
         | abs va >= abs vb = a
         | otherwise = b
@@ -1185,7 +1206,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
     -- verbatim carries the unit the flow is actually declared in; the other
     -- variant is dimensionally incompatible and would silently convert to 0.
     -- Only then the historical higher-value tie-break.
-    preferBetter a@(v1, _, s1, r1) b@(v2, _, s2, r2)
+    preferBetter a@(CF v1 _, s1, r1) b@(CF v2 _, s2, r2)
         | strategyPriority s1 < strategyPriority s2 = a
         | strategyPriority s1 > strategyPriority s2 = b
         | r1 /= r2 = if r1 then a else b
@@ -1228,11 +1249,11 @@ expects, for characterization.
     amount.
   * The flow unit itself is unknown → @qty@ unchanged (no base to normalize to).
 -}
-convertForCharacterization :: UnitConfig -> Text -> Text -> Double -> Double
-convertForCharacterization cfg flowUnit cfUnit qty
-    | flowUnit == cfUnit || T.null cfUnit || T.null flowUnit = qty
+convertForCharacterization :: UnitConfig -> Text -> CFUnit -> Double -> Double
+convertForCharacterization cfg flowUnit (CFUnit cfu) qty
+    | flowUnit == cfu || T.null cfu || T.null flowUnit = qty
     | not (isKnownUnit cfg flowUnit) = qty
-    | isKnownUnit cfg cfUnit = fromMaybe 0 (convertUnit cfg flowUnit cfUnit qty)
+    | isKnownUnit cfg cfu = fromMaybe 0 (convertUnit cfg flowUnit cfu qty)
     | otherwise = maybe 0 snd (normalizeToCanonical cfg flowUnit qty)
 
 {- | Pre-compute the broadcast CF Map: each flow UUID covered by the method maps
@@ -1313,9 +1334,9 @@ fillRegionalActivityWeights unitCfg unitDB flowDB db hier tables
     -- @(UUID, Text)@-keyed map. Subsumes the old
     -- @regionalizedFlows :: Set UUID@ check — @Just _@ here is the
     -- "this flow is regionalized" signal needed at the taint branch.
-    regionalByRow :: V.Vector (Maybe (M.Map Text (Double, Text)))
+    regionalByRow :: V.Vector (Maybe (M.Map Text CF))
     regionalByRow =
-        let perFlow :: M.Map UUID (M.Map Text (Double, Text))
+        let perFlow :: M.Map UUID (M.Map Text CF)
             perFlow =
                 M.fromListWith
                     M.union
@@ -1661,7 +1682,7 @@ converges on the same canonical form — a compartments.csv rule like
 against ILCD-style bare media without requiring an explicit (medium, sub)
 pair for every combination.
 -}
-lookupCascadeCF :: MethodTables -> BioFlowDB -> UUID -> Maybe (Double, Text)
+lookupCascadeCF :: MethodTables -> BioFlowDB -> UUID -> Maybe CF
 lookupCascadeCF tables flowDB fid =
     M.lookup fid (mtUuidCF tables)
         <|> (M.lookup fid flowDB >>= byNameOrCas)
@@ -1926,8 +1947,8 @@ silently using the raw value.
 Every other case (matching dimensions, no density, or an energy flow) defers
 to 'convertForCharacterization', so flows without a density are unchanged.
 -}
-energyAwareConversion :: UnitConfig -> Text -> Text -> Maybe EnergyDensity -> Double -> Double
-energyAwareConversion cfg flowUnit cfUnit mDensity qty =
+energyAwareConversion :: UnitConfig -> Text -> CFUnit -> Maybe EnergyDensity -> Double -> Double
+energyAwareConversion cfg flowUnit cfu@(CFUnit rawCfUnit) mDensity qty =
     case mDensity of
         -- The bridge fires when the CF is denominated in the density's target
         -- unit (MJ for a calorific value, m³ for a mass density) and the flow is
@@ -1937,13 +1958,13 @@ energyAwareConversion cfg flowUnit cfUnit mDensity qty =
         -- CF (kg → m³ via density), which are the two cases where a per-physical-
         -- quantity CF meets a mass inventory flow.
         Just (EnergyDensity ev densityUnit nativeUnit)
-            | unitsCompatible cfg cfUnit densityUnit
-            , not (unitsCompatible cfg cfUnit flowUnit) ->
+            | unitsCompatible cfg rawCfUnit densityUnit
+            , not (unitsCompatible cfg rawCfUnit flowUnit) ->
                 fromMaybe 0 $ do
                     qtyNative <- toNativeQty flowUnit nativeUnit
-                    factor <- convertUnit cfg densityUnit cfUnit ev
+                    factor <- convertUnit cfg densityUnit rawCfUnit ev
                     pure (qtyNative * factor)
-        _ -> convertForCharacterization cfg flowUnit cfUnit qty
+        _ -> convertForCharacterization cfg flowUnit cfu qty
   where
     -- Bring the inventory quantity into the unit the density is denominated
     -- against: identical units need no table entry, otherwise a same-dimension
@@ -1970,11 +1991,10 @@ convertAndMultiply ::
     the identity factor (no flow record means no flow unit known).
     -}
     Maybe BiosphereFlow ->
-    -- | (CF value, CF unit)
-    (Double, Text) ->
+    CF ->
     Double ->
     Double
-convertAndMultiply unitConfig unitDB energyDensities mflow (cfVal, cfUnit) qty =
+convertAndMultiply unitConfig unitDB energyDensities mflow (CF cfVal cfu) qty =
     let flowUnit = maybe "" unitName (mflow >>= \f -> M.lookup (bfUnitId f) unitDB)
         -- Density from the curated CSV first; else parse it from the flow name
         -- ("Coal, 18 MJ per kg" → 18 MJ), so energy-resource variants the CSV
@@ -1983,7 +2003,7 @@ convertAndMultiply unitConfig unitDB energyDensities mflow (cfVal, cfUnit) qty =
             mflow >>= \f ->
                 M.lookup (normalizeName (bfName f)) energyDensities
                     <|> fmap snd (parseEnergyDensitySuffix (bfName f))
-        converted = energyAwareConversion unitConfig flowUnit cfUnit mDensity qty
+        converted = energyAwareConversion unitConfig flowUnit cfu mDensity qty
      in converted * cfVal
 
 {- | Per-flow contributions over an 'Inventory', keyed by flow UUID (possibly
@@ -2026,8 +2046,8 @@ inventoryContributions unitConfig unitDB flowDB inventory tables =
             Nothing -> (contribs, fid : unknowns) -- metadata missing — surface it
             Just flow -> case lookupCascadeCF tables flowDB fid of
                 Nothing -> (contribs, unknowns) -- no CF match — legitimately uncharacterized
-                Just cfTuple@(cfVal, _) ->
-                    let !contribution = convertAndMultiply unitConfig unitDB (mtEnergyDensities tables) (Just flow) cfTuple qty
+                Just found@(CF cfVal _) ->
+                    let !contribution = convertAndMultiply unitConfig unitDB (mtEnergyDensities tables) (Just flow) found qty
                      in ((flow, cfVal, contribution) : contribs, unknowns)
 
 {- | Per-process LCIA contributions for one DB + one method, driven by
@@ -2362,7 +2382,7 @@ DB) so the suggester sees exactly what scoring sees — including the CAS
 bridge — and 'findUncharacterized' never flags a flow the score path
 characterizes. Cold path; the singleton allocation is irrelevant here.
 -}
-lookupCFForFlow :: MethodTables -> UUID -> Maybe BiosphereFlow -> Maybe (Double, Text)
+lookupCFForFlow :: MethodTables -> UUID -> Maybe BiosphereFlow -> Maybe CF
 lookupCFForFlow tables fid mFlow =
     lookupCascadeCF tables (maybe M.empty (M.singleton fid) mFlow) fid
 

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -414,7 +414,7 @@ A distinct type from the flow's own unit so the two sides of a
 flow-unit → CF-unit conversion can't be silently swapped.
 -}
 newtype CFUnit = CFUnit Text
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Show)
 
 {- | A characterization factor as stored in the lookup tables: the value and
 the unit it is denominated in, kept together so they can't drift apart.
@@ -1273,7 +1273,7 @@ fillBroadcastVector unitConfig unitDB flowDB tables =
   where
     buildEntry fid flow = case lookupCascadeCF tables flowDB fid of
         Nothing -> Nothing
-        Just cfTuple -> Just (convertAndMultiply unitConfig unitDB (mtEnergyDensities tables) (Just flow) cfTuple 1.0)
+        Just cf -> Just (convertAndMultiply unitConfig unitDB (mtEnergyDensities tables) (Just flow) cf 1.0)
 
 {- | Precompute per-activity-column contributions for a regionalized method.
 
@@ -1394,14 +1394,14 @@ fillRegionalActivityWeights unitCfg unitDB flowDB db hier tables
             let !col = fromIntegral colIdx :: Int
                 !row = fromIntegral flowRow :: Int
                 !flowUUID = bioFlows V.! row
-                applyRaw cfTuple =
+                applyRaw cf =
                     let !contribution =
                             convertAndMultiply
                                 unitCfg
                                 unitDB
                                 (mtEnergyDensities tables)
                                 (M.lookup flowUUID flowDB)
-                                cfTuple
+                                cf
                                 bioVal
                      in MU.unsafeModify ws (+ contribution) col
                 -- 'mtBroadcast' is the unit-converted CF per unit of flow, so
@@ -1425,9 +1425,9 @@ fillRegionalActivityWeights unitCfg unitDB flowDB db hier tables
                             Just cf -> Just cf
                             Nothing -> lookupParents ps
                      in case M.lookup loc locMap of
-                            Just cfTuple -> applyRaw cfTuple
+                            Just cf -> applyRaw cf
                             Nothing -> case lookupParents (M.findWithDefault [] loc hier) of
-                                Just cfTuple -> applyRaw cfTuple
+                                Just cf -> applyRaw cf
                                 Nothing -> case M.lookup flowUUID broadcast of
                                     Just preMultipliedCF ->
                                         MU.unsafeModify ws (+ bioVal * preMultipliedCF) col
@@ -1494,7 +1494,7 @@ computeLCIAScoreFromTables unitConfig unitDB flowDB inventory tables =
 
     legacyScoreFlow fid qty = case lookupCascadeCF tables flowDB fid of
         Nothing -> Nothing
-        Just cfTuple -> Just (convertAndMultiply unitConfig unitDB (mtEnergyDensities tables) (M.lookup fid flowDB) cfTuple qty)
+        Just cf -> Just (convertAndMultiply unitConfig unitDB (mtEnergyDensities tables) (M.lookup fid flowDB) cf qty)
 
 {- | Back-compat wrapper: build tables on the fly, with no compartment map,
 energy densities, or CF-family gating ('OtherCFFamily'). Prefer the cached path
@@ -2100,7 +2100,7 @@ processContributionsFromTables unitConfig unitDB flowDB ltMode db scalingVec tab
                     Nothing -> 0
                     Just _ -> case lookupCascadeCF tables flowDB flowUUID of
                         Nothing -> 0
-                        Just cfTuple -> convertAndMultiply unitConfig unitDB (mtEnergyDensities tables) mflow cfTuple 1.0
+                        Just cf -> convertAndMultiply unitConfig unitDB (mtEnergyDensities tables) mflow cf 1.0
 
     -- Invert dbActivityIndex (pid -> col) into (col -> pid) as an unboxed
     -- vector for O(1) per-triple lookup. Assumes matrix cols are dense in
@@ -2340,8 +2340,8 @@ scoreBatched unitCfg unitDB flowDB bt inventory
             cascadeContrib !tables !uuid !qty =
                 case lookupCascadeCF tables flowDB uuid of
                     Nothing -> 0
-                    Just cfTuple ->
-                        convertAndMultiply unitCfg unitDB (mtEnergyDensities tables) (M.lookup uuid flowDB) cfTuple qty
+                    Just cf ->
+                        convertAndMultiply unitCfg unitDB (mtEnergyDensities tables) (M.lookup uuid flowDB) cf qty
             scores = U.create $ do
                 mv <- MU.replicate nMethods (0.0 :: Double)
                 mapM_

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -465,13 +465,13 @@ data MethodTables = MethodTables
     (minerals are reachable only through this bridge). Empty for methods whose
     CFs carry no CAS.
     -}
-    , mtRegionalCasCF :: !(M.Map (SR.CASNumber, Medium) (M.Map Text CF))
+    , mtRegionalCasCF :: !(M.Map (SR.CASNumber, Medium) (M.Map Location CF))
     {- ^ (CAS, normalized medium) → (location → CF), from regionalized
     CFs. The regionalized analogue of 'mtCasCF': lets the regionalized build
     characterize every same-CAS flow per location, not just the one a CF
     resolved to. Empty for methods with no regionalized CAS-bearing CFs.
     -}
-    , mtRegionalizedCF :: !(M.Map (UUID, Text) CF)
+    , mtRegionalizedCF :: !(M.Map (UUID, Location) CF)
     {- ^ Regionalized cells of the C matrix: (DB flow UUID, consumer location) → CF.
     Empty for non-regionalized methods. When non-empty, callers should dispatch
     to the regionalized scoring path (see 'Matrix.computeRegionalizedLCIAScore').
@@ -538,7 +538,7 @@ caller can emit one warning per gap rather than per pid × per method.
 data RegionalActivityWeights = RegionalActivityWeights
     { rawWeights :: !(U.Vector Double)
     , rawTainted :: !(U.Vector Word8)
-    , rawMissingPairs :: ![(UUID, Text)]
+    , rawMissingPairs :: ![(UUID, Location)]
     }
 
 {- | Inverted indices over a 'Method' for the post-scoring suggester.
@@ -1108,7 +1108,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             M.map (M.map snd) $
                 M.fromListWith
                     (M.unionWith preferUnspecifiedCas)
-                    [ ((SR.CASNumber cas, Medium normMed), M.singleton loc (casSubRank normSub, cfOf cf))
+                    [ ((SR.CASNumber cas, Medium normMed), M.singleton (Location loc) (casSubRank normSub, cfOf cf))
                     | (cf, Just (_, ByCAS)) <- mappings
                     , Just cas <- [mcfCAS cf]
                     , not (T.null cas)
@@ -1126,7 +1126,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             -- fallback CF. CFs with no specific subcomp ('isUnspecifiedSub')
             -- are wildcards and match any flow subcomp.
             M.fromList
-                [ ((bfId flow, loc), cfOf cf)
+                [ ((bfId flow, Location loc), cfOf cf)
                 | (cf, Just (flow, _)) <- mappings
                 , cfSubcompMatchesFlow cf flow
                 , Just loc <- [mcfConsumerLocation cf]
@@ -1311,7 +1311,7 @@ fillRegionalActivityWeights ::
     UnitDB ->
     BioFlowDB ->
     Database ->
-    M.Map Text [Text] ->
+    M.Map Location [Location] ->
     MethodTables ->
     MethodTables
 fillRegionalActivityWeights unitCfg unitDB flowDB db hier tables
@@ -1334,9 +1334,9 @@ fillRegionalActivityWeights unitCfg unitDB flowDB db hier tables
     -- @(UUID, Text)@-keyed map. Subsumes the old
     -- @regionalizedFlows :: Set UUID@ check — @Just _@ here is the
     -- "this flow is regionalized" signal needed at the taint branch.
-    regionalByRow :: V.Vector (Maybe (M.Map Text CF))
+    regionalByRow :: V.Vector (Maybe (M.Map Location CF))
     regionalByRow =
-        let perFlow :: M.Map UUID (M.Map Text CF)
+        let perFlow :: M.Map UUID (M.Map Location CF)
             perFlow =
                 M.fromListWith
                     M.union
@@ -1356,10 +1356,10 @@ fillRegionalActivityWeights unitCfg unitDB flowDB db hier tables
 
     -- ProcessId → matrix column index → activity's reference location.
     -- Built once (O(nActivities)) and indexed by column inside the hot loop.
-    colLoc :: V.Vector Text
+    colLoc :: V.Vector Location
     colLoc =
-        V.replicate nCols T.empty
-            V.// [ (fromIntegral (actIdx V.! pid), activityLocation (activities V.! pid))
+        V.replicate nCols (Location T.empty)
+            V.// [ (fromIntegral (actIdx V.! pid), Location (activityLocation (activities V.! pid)))
                  | pid <- [0 .. V.length actIdx - 1]
                  , let !col = fromIntegral (actIdx V.! pid) :: Int
                  , col >= 0
@@ -1389,7 +1389,7 @@ fillRegionalActivityWeights unitCfg unitDB flowDB db hier tables
     precomputed = runST $ do
         ws <- MU.replicate nCols (0 :: Double)
         ts <- MU.replicate nCols (0 :: Word8)
-        missRef <- newSTRef (Set.empty :: Set.Set (UUID, Text))
+        missRef <- newSTRef (Set.empty :: Set.Set (UUID, Location))
         U.forM_ bioTriples $ \(SparseTriple flowRow colIdx bioVal) -> do
             let !col = fromIntegral colIdx :: Int
                 !row = fromIntegral flowRow :: Int
@@ -1532,7 +1532,7 @@ computeLCIAScoreAuto ::
     -- | Pre-computed inventory @g = B · s@ (only used in the classic path)
     Inventory ->
     -- | Location hierarchy: child → ordered list of parents
-    M.Map Text [Text] ->
+    M.Map Location [Location] ->
     MethodTables ->
     Either Text Double
 computeLCIAScoreAuto unitCfg unitDB flowDB db scalingVec inventory hier tables
@@ -1570,7 +1570,7 @@ computeRegionalizedLCIAScore ::
     -- | Scaling vector @s@ from 'Matrix.computeScalingVector'
     Vector ->
     -- | Location hierarchy: child → ordered list of parents
-    M.Map Text [Text] ->
+    M.Map Location [Location] ->
     MethodTables ->
     Either Text Double
 computeRegionalizedLCIAScore _unitConfig _unitDB _flowDB _db scalingVec _hier tables =
@@ -1658,7 +1658,7 @@ sumRegionalizedLCIAScoreCrossDB ::
     UnitConfig ->
     UnitDB ->
     BioFlowDB ->
-    M.Map Text [Text] ->
+    M.Map Location [Location] ->
     {- | Per-DB triples: one per database participating in the cross-DB solve
     (root + dep DBs in the same order returned by 'SharedSolver.csScalings').
     -}
@@ -2264,7 +2264,7 @@ computeLCIAScoreSetFromTables ::
     UnitDB ->
     BioFlowDB ->
     Inventory ->
-    M.Map Text [Text] ->
+    M.Map Location [Location] ->
     {- | Non-empty per-DB triples: 'NE.head' is root, tail is each participating
     dep DB. Building order matches 'SharedSolver.csScalings'.
     -}
@@ -2292,7 +2292,7 @@ scoreRegionalCrossDB ::
     UnitConfig ->
     UnitDB ->
     BioFlowDB ->
-    M.Map Text [Text] ->
+    M.Map Location [Location] ->
     V.Vector MethodSetEntry ->
     NonEmpty (Database, Vector, MethodSetTables) ->
     [(UUID, Either Text Double)]

--- a/src/Method/Types.hs
+++ b/src/Method/Types.hs
@@ -14,6 +14,7 @@ module Method.Types (
     MethodCF (..),
     FlowDirection (..),
     Compartment (..),
+    Location (..),
     Medium (..),
     Subcompartment (..),
     CFFamily (..),
@@ -98,6 +99,13 @@ newtype Medium = Medium Text
 normalized name; a newtype so it can't be swapped with a medium in a key tuple.
 -}
 newtype Subcompartment = Subcompartment Text
+    deriving (Eq, Ord, Show)
+
+{- | A location / geography code (@"FR"@, @"CN-SC"@, @"RER"@, @"GLO"@) as used
+by regionalized CFs and the location hierarchy. A newtype so a location can't
+be swapped with any other Text axis in a regionalized lookup key.
+-}
+newtype Location = Location Text
     deriving (Eq, Ord, Show)
 
 {- | A characterization factor from a method file

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1114,13 +1114,6 @@ toSimpleDatabase db =
         , sdbUnits = dbUnits db
         }
 
--- | Impact category (e.g. Climate change)
-data ImpactCategory = ImpactCategory
-    { categoryId :: !Text
-    , categoryName :: !Text
-    }
-    deriving (Eq, Ord, Show)
-
 -- | Blocking reason for cross-database linking failure
 data LinkBlocker
     = -- | Product not found at all
@@ -1505,13 +1498,6 @@ data CrossDBLink = CrossDBLink
     -}
     }
     deriving (Generic, NFData, Store, Show, Eq, Ord)
-
--- | Characterization factor (associated with an LCIA method)
-data CF = CF
-    { cfFlowId :: !UUID -- Biosphere flow being characterized
-    , cfCategory :: !ImpactCategory -- Impact category
-    , cfFactor :: !Double -- Characterization factor
-    }
 
 -- ToJSON/FromJSON for the records above are produced via `deriving via (Stripped X)`
 -- attached to each `data` declaration. The two enums TechRole and BioDirection use

--- a/test/CrossDBInventorySpec.hs
+++ b/test/CrossDBInventorySpec.hs
@@ -23,7 +23,7 @@ import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import Matrix (accumulateDepDemands, depDemandsToVector)
-import Method.Mapping (MethodTables (..), inventoryContributions)
+import Method.Mapping (CF (..), CFUnit (..), MethodTables (..), inventoryContributions)
 import qualified Method.Mapping as Mapping
 import Method.Types (CFFamily (..))
 import SharedSolver (
@@ -170,8 +170,8 @@ spec = do
                 MethodTables
                     { mtUuidCF =
                         M.fromList
-                            [ (uuidRoot, (27.0, "kg CO2 eq"))
-                            , (uuidDep, (1.0, "kg CO2 eq"))
+                            [ (uuidRoot, CF 27.0 (CFUnit "kg CO2 eq"))
+                            , (uuidDep, CF 1.0 (CFUnit "kg CO2 eq"))
                             ]
                     , mtExactCF = M.empty
                     , mtFallbackCF = M.empty

--- a/test/CrossLinkingSpec.hs
+++ b/test/CrossLinkingSpec.hs
@@ -10,6 +10,7 @@ import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import Database.CrossLinking
 import Database.Loader (loadDatabase)
+import Method.Types (Location (..))
 import SynonymDB (buildFromPairs, emptySynonymDB)
 import Test.Hspec
 import Types
@@ -141,41 +142,41 @@ spec = do
     -- -----------------------------------------------------------------------
     describe "isSubregionOf" $ do
         it "FR is a subregion of RER" $
-            isSubregionOf locationHierarchy "FR" "RER" `shouldBe` True
+            isSubregionOf locationHierarchy (Location "FR") (Location "RER") `shouldBe` True
 
         it "FR is a subregion of GLO" $
-            isSubregionOf locationHierarchy "FR" "GLO" `shouldBe` True
+            isSubregionOf locationHierarchy (Location "FR") (Location "GLO") `shouldBe` True
 
         it "GLO is not a subregion of FR" $
-            isSubregionOf locationHierarchy "GLO" "FR" `shouldBe` False
+            isSubregionOf locationHierarchy (Location "GLO") (Location "FR") `shouldBe` False
 
         it "unknown location has no parents" $
-            isSubregionOf locationHierarchy "XX" "GLO" `shouldBe` False
+            isSubregionOf locationHierarchy (Location "XX") (Location "GLO") `shouldBe` False
 
     -- -----------------------------------------------------------------------
     -- matchLocation
     -- -----------------------------------------------------------------------
     describe "matchLocation" $ do
         it "exact match scores 30" $
-            matchLocation locationHierarchy "FR" "FR" `shouldBe` 30
+            matchLocation locationHierarchy (Location "FR") (Location "FR") `shouldBe` 30
 
         it "FR consumer, RER supplier scores 20 (widening)" $
-            matchLocation locationHierarchy "FR" "RER" `shouldBe` 20
+            matchLocation locationHierarchy (Location "FR") (Location "RER") `shouldBe` 20
 
         it "FR consumer, GLO supplier scores 20 (widening via subregion)" $
-            matchLocation locationHierarchy "FR" "GLO" `shouldBe` 20
+            matchLocation locationHierarchy (Location "FR") (Location "GLO") `shouldBe` 20
 
         it "unknown location, GLO supplier scores 10 (global fallback)" $
-            matchLocation locationHierarchy "XX" "GLO" `shouldBe` 10
+            matchLocation locationHierarchy (Location "XX") (Location "GLO") `shouldBe` 10
 
         it "unknown location, RoW supplier scores 10 (global fallback)" $
-            matchLocation locationHierarchy "XX" "RoW" `shouldBe` 10
+            matchLocation locationHierarchy (Location "XX") (Location "RoW") `shouldBe` 10
 
         it "narrowing (GLO consumer, FR supplier) scores 0" $
-            matchLocation locationHierarchy "GLO" "FR" `shouldBe` 0
+            matchLocation locationHierarchy (Location "GLO") (Location "FR") `shouldBe` 0
 
         it "unrelated locations score 5" $
-            matchLocation locationHierarchy "FR" "CN" `shouldBe` 5
+            matchLocation locationHierarchy (Location "FR") (Location "CN") `shouldBe` 5
 
     -- -----------------------------------------------------------------------
     -- matchProductName
@@ -212,32 +213,32 @@ spec = do
     -- -----------------------------------------------------------------------
     describe "isSubregionOf (additional)" $ do
         it "US is a subregion of North America" $
-            isSubregionOf locationHierarchy "US" "North America" `shouldBe` True
+            isSubregionOf locationHierarchy (Location "US") (Location "North America") `shouldBe` True
 
         it "CA is a subregion of NAFTA" $
-            isSubregionOf locationHierarchy "CA" "NAFTA" `shouldBe` True
+            isSubregionOf locationHierarchy (Location "CA") (Location "NAFTA") `shouldBe` True
 
         it "JP is a subregion of Asia" $
-            isSubregionOf locationHierarchy "JP" "Asia" `shouldBe` True
+            isSubregionOf locationHierarchy (Location "JP") (Location "Asia") `shouldBe` True
 
         it "BR is a subregion of Latin America" $
-            isSubregionOf locationHierarchy "BR" "Latin America" `shouldBe` True
+            isSubregionOf locationHierarchy (Location "BR") (Location "Latin America") `shouldBe` True
 
         it "AU is a subregion of GLO" $
-            isSubregionOf locationHierarchy "AU" "GLO" `shouldBe` True
+            isSubregionOf locationHierarchy (Location "AU") (Location "GLO") `shouldBe` True
 
     -- -----------------------------------------------------------------------
     -- matchLocation — additional scoring cases
     -- -----------------------------------------------------------------------
     describe "matchLocation (additional)" $ do
         it "US consumer, NAFTA supplier scores 20 (widening)" $
-            matchLocation locationHierarchy "US" "NAFTA" `shouldBe` 20
+            matchLocation locationHierarchy (Location "US") (Location "NAFTA") `shouldBe` 20
 
         it "GLO consumer, GLO supplier scores 30 (exact)" $
-            matchLocation locationHierarchy "GLO" "GLO" `shouldBe` 30
+            matchLocation locationHierarchy (Location "GLO") (Location "GLO") `shouldBe` 30
 
         it "RoW consumer, RoW supplier scores 30 (exact)" $
-            matchLocation locationHierarchy "RoW" "RoW" `shouldBe` 30
+            matchLocation locationHierarchy (Location "RoW") (Location "RoW") `shouldBe` 30
 
     -- -----------------------------------------------------------------------
     -- findSupplierInIndexedDBs — integration using SAMPLE.min3
@@ -353,9 +354,9 @@ spec = do
                 , ("BR→GLO is global", "BR", "GLO", Nothing, Nothing, Just GlobalLoc)
                 ]
         forM_ cases $ \(label, req, cand, expExact, expParent, expGlobal) -> do
-            it (label ++ " — exact") $ acceptableLocation GeoExact hier req cand `shouldBe` expExact
-            it (label ++ " — parent") $ acceptableLocation GeoParent hier req cand `shouldBe` expParent
-            it (label ++ " — global") $ acceptableLocation GeoGlobal hier req cand `shouldBe` expGlobal
+            it (label ++ " — exact") $ acceptableLocation GeoExact hier (Location req) (Location cand) `shouldBe` expExact
+            it (label ++ " — parent") $ acceptableLocation GeoParent hier (Location req) (Location cand) `shouldBe` expParent
+            it (label ++ " — global") $ acceptableLocation GeoGlobal hier (Location req) (Location cand) `shouldBe` expGlobal
 
     -- -----------------------------------------------------------------------
     -- findSupplierInIndexedDBs — geography_policy enforcement

--- a/test/EnergyResourceFillSpec.hs
+++ b/test/EnergyResourceFillSpec.hs
@@ -8,7 +8,7 @@ import Data.UUID (UUID)
 import qualified Data.UUID as UUID
 import Test.Hspec
 
-import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, lookupCFForFlow)
+import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, cfValue, lookupCFForFlow)
 import Method.Types (CFFamily (..), Compartment (..), EnergyDensity (..), EnergyDensityMap, FlowDirection (..), MethodCF (..), parseEnergyDensitySuffix)
 import SynonymDB (normalizeName)
 import Types (BiosphereFlow (..))
@@ -74,7 +74,7 @@ disagreeingCoalTables =
 -- Borrowed raw CF (the density is applied later by convertAndMultiply).
 borrowFor :: EnergyDensityMap -> Text -> Maybe Double
 borrowFor eds flowName =
-    fmap fst (lookupCFForFlow (coalTables eds) (mkUUID 99) (Just (mkFlow 99 flowName)))
+    fmap cfValue (lookupCFForFlow (coalTables eds) (mkUUID 99) (Just (mkFlow 99 flowName)))
 
 spec :: Spec
 spec = do
@@ -98,7 +98,7 @@ spec = do
         it "does NOT borrow when the resource family is unknown to the engine" $
             borrowFor M.empty "Coal, 18 MJ per kg" `shouldBe` Nothing
         it "does NOT borrow when same-family CFs disagree (ambiguous, never guesses)" $
-            fmap fst (lookupCFForFlow disagreeingCoalTables (mkUUID 99) (Just (mkFlow 99 "Coal, 18 MJ per kg")))
+            fmap cfValue (lookupCFForFlow disagreeingCoalTables (mkUUID 99) (Just (mkFlow 99 "Coal, 18 MJ per kg")))
                 `shouldBe` Nothing
         it "does NOT fill a non-energy name" $
             borrowFor coalDensity "Water, per capita" `shouldBe` Nothing

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -520,7 +520,7 @@ spec = do
         mapM_
             ( \(label, cfg, flowU, cfU, qty, expected) ->
                 it label $
-                    convertForCharacterization cfg flowU cfU qty `shouldBe` expected
+                    convertForCharacterization cfg flowU (CFUnit cfU) qty `shouldBe` expected
             )
             cases
 

--- a/test/MethodCollectionCacheSpec.hs
+++ b/test/MethodCollectionCacheSpec.hs
@@ -25,7 +25,7 @@ import Test.Hspec
 
 import Config (defaultConfig)
 import qualified Database.Manager as DM
-import Method.Mapping (mtUuidCF)
+import Method.Mapping (CF (..), CFUnit (..), mtUuidCF)
 import Method.Types (FlowDirection (..), Method (..), MethodCF (..))
 import Types (UUID)
 
@@ -87,13 +87,13 @@ spec = do
             let db = mkDB 0 ["FR"] []
             tablesA <- DM.mapMethodToTablesCached mgr "db" collectionA db (mkFossilsMethod cfA)
             tablesB <- DM.mapMethodToTablesCached mgr "db" collectionB db (mkFossilsMethod cfB)
-            M.lookup flowUUID (mtUuidCF tablesA) `shouldBe` Just (cfA, "MJ")
-            M.lookup flowUUID (mtUuidCF tablesB) `shouldBe` Just (cfB, "MJ")
+            M.lookup flowUUID (mtUuidCF tablesA) `shouldBe` Just (CF cfA (CFUnit "MJ"))
+            M.lookup flowUUID (mtUuidCF tablesB) `shouldBe` Just (CF cfB (CFUnit "MJ"))
 
         it "returns per-collection CF tables for same-UUID methods (B then A)" $ do
             mgr <- DM.initDatabaseManager defaultConfig False Nothing
             let db = mkDB 0 ["FR"] []
             tablesB <- DM.mapMethodToTablesCached mgr "db" collectionB db (mkFossilsMethod cfB)
             tablesA <- DM.mapMethodToTablesCached mgr "db" collectionA db (mkFossilsMethod cfA)
-            M.lookup flowUUID (mtUuidCF tablesB) `shouldBe` Just (cfB, "MJ")
-            M.lookup flowUUID (mtUuidCF tablesA) `shouldBe` Just (cfA, "MJ")
+            M.lookup flowUUID (mtUuidCF tablesB) `shouldBe` Just (CF cfB (CFUnit "MJ"))
+            M.lookup flowUUID (mtUuidCF tablesA) `shouldBe` Just (CF cfA (CFUnit "MJ"))

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -111,7 +111,7 @@ spec = do
                 cf = mkCF fid 1.0
                 tables0 =
                     (buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))])
-                        { mtRegionalizedCF = M.singleton (fid, "FR") (2.0, "kg")
+                        { mtRegionalizedCF = M.singleton (fid, "FR") (CF 2.0 (CFUnit "kg"))
                         }
                 m1 = mkMethod 1 "m1" [cf]
                 fdb = M.singleton fid (mkFlow fid "co2" uidKg)
@@ -317,7 +317,7 @@ spec = do
                 tRegio =
                     fill
                         ( (buildMethodTables OtherCFFamily M.empty M.empty [(cf2a, Just (flow1, ByUUID))])
-                            { mtRegionalizedCF = M.singleton (fid1, "FR") (7.0, "kg")
+                            { mtRegionalizedCF = M.singleton (fid1, "FR") (CF 7.0 (CFUnit "kg"))
                             }
                         )
                 tNonRegio2 =
@@ -409,11 +409,11 @@ spec = do
                 regio = mtRegionalizedCF tables
             -- Pre-fix: this was (0.0, "kg") — clobbered by cfOcean. The
             -- filter drops (cfOcean, flowUns) so the wildcard cfUns survives.
-            M.lookup (fidUns, "FR") regio `shouldBe` Just (3.0, "kg")
+            M.lookup (fidUns, "FR") regio `shouldBe` Just (CF 3.0 (CFUnit "kg"))
             -- The ocean flow legitimately receives the ocean CF (and the
             -- wildcard cfUns also matches, but cfOcean writes last so its
             -- explicit zero stays — that's the intended modeller behaviour).
-            M.lookup (fidOcean, "FR") regio `shouldBe` Just (0.0, "kg")
+            M.lookup (fidOcean, "FR") regio `shouldBe` Just (CF 0.0 (CFUnit "kg"))
 
         it "treats CFs with empty / (unspecified) subcomp as wildcards" $ do
             let fid = mkUuid 110
@@ -448,9 +448,9 @@ spec = do
                 tUnspec = buildMethodTables OtherCFFamily M.empty M.empty [(cfUnspecified, Just (flowRiver, ByName))]
                 tUnspecBare = buildMethodTables OtherCFFamily M.empty M.empty [(cfUnspecBare, Just (flowRiver, ByName))]
             -- All three wildcard forms apply to a specific-subcomp flow.
-            M.lookup (fid, "DE") (mtRegionalizedCF tEmpty) `shouldBe` Just (2.0, "kg")
-            M.lookup (fid, "DE") (mtRegionalizedCF tUnspec) `shouldBe` Just (7.0, "kg")
-            M.lookup (fid, "DE") (mtRegionalizedCF tUnspecBare) `shouldBe` Just (9.0, "kg")
+            M.lookup (fid, "DE") (mtRegionalizedCF tEmpty) `shouldBe` Just (CF 2.0 (CFUnit "kg"))
+            M.lookup (fid, "DE") (mtRegionalizedCF tUnspec) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
+            M.lookup (fid, "DE") (mtRegionalizedCF tUnspecBare) `shouldBe` Just (CF 9.0 (CFUnit "kg"))
 
         it "does not let a wildcard CF reach a sea/ocean flow (foreign medium)" $ do
             -- A freshwater CF must not characterize a sea-water release via the
@@ -494,9 +494,9 @@ spec = do
                         }
                 tablesFor fam sub = buildMethodTables fam M.empty M.empty [(cfUnspecified, Just (flowSub sub, ByName))]
             M.lookup (fid, "DE") (mtRegionalizedCF (tablesFor USEtoxFamily "groundwater, long-term")) `shouldBe` Nothing
-            M.lookup (fid, "DE") (mtRegionalizedCF (tablesFor USEtoxFamily "groundwater")) `shouldBe` Just (7.0, "kg")
-            M.lookup (fid, "DE") (mtRegionalizedCF (tablesFor OtherCFFamily "groundwater, long-term")) `shouldBe` Just (7.0, "kg")
-            M.lookup (fid, "DE") (mtRegionalizedCF (tablesFor OtherCFFamily "groundwater")) `shouldBe` Just (7.0, "kg")
+            M.lookup (fid, "DE") (mtRegionalizedCF (tablesFor USEtoxFamily "groundwater")) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
+            M.lookup (fid, "DE") (mtRegionalizedCF (tablesFor OtherCFFamily "groundwater, long-term")) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
+            M.lookup (fid, "DE") (mtRegionalizedCF (tablesFor OtherCFFamily "groundwater")) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
 
         it "keeps CF when mcfCompartment is Nothing (no subcomp info)" $ do
             let fid = mkUuid 120
@@ -512,4 +512,4 @@ spec = do
                         , mcfConsumerLocation = Just "IT"
                         }
                 tables = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flowAny, ByName))]
-            M.lookup (fid, "IT") (mtRegionalizedCF tables) `shouldBe` Just (4.0, "kg")
+            M.lookup (fid, "IT") (mtRegionalizedCF tables) `shouldBe` Just (CF 4.0 (CFUnit "kg"))

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -22,7 +22,7 @@ import Test.Hspec
 
 import Matrix (Inventory)
 import Method.Mapping
-import Method.Types (Compartment (..), Method (..), MethodCF (..))
+import Method.Types (Compartment (..), Location (..), Method (..), MethodCF (..))
 import qualified Method.Types as MT
 import Types (BiosphereFlow (..), Database, Unit (..))
 import qualified Types as VT
@@ -111,7 +111,7 @@ spec = do
                 cf = mkCF fid 1.0
                 tables0 =
                     (buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))])
-                        { mtRegionalizedCF = M.singleton (fid, "FR") (CF 2.0 (CFUnit "kg"))
+                        { mtRegionalizedCF = M.singleton (fid, Location "FR") (CF 2.0 (CFUnit "kg"))
                         }
                 m1 = mkMethod 1 "m1" [cf]
                 fdb = M.singleton fid (mkFlow fid "co2" uidKg)
@@ -317,7 +317,7 @@ spec = do
                 tRegio =
                     fill
                         ( (buildMethodTables OtherCFFamily M.empty M.empty [(cf2a, Just (flow1, ByUUID))])
-                            { mtRegionalizedCF = M.singleton (fid1, "FR") (CF 7.0 (CFUnit "kg"))
+                            { mtRegionalizedCF = M.singleton (fid1, Location "FR") (CF 7.0 (CFUnit "kg"))
                             }
                         )
                 tNonRegio2 =
@@ -409,11 +409,11 @@ spec = do
                 regio = mtRegionalizedCF tables
             -- Pre-fix: this was (0.0, "kg") — clobbered by cfOcean. The
             -- filter drops (cfOcean, flowUns) so the wildcard cfUns survives.
-            M.lookup (fidUns, "FR") regio `shouldBe` Just (CF 3.0 (CFUnit "kg"))
+            M.lookup (fidUns, Location "FR") regio `shouldBe` Just (CF 3.0 (CFUnit "kg"))
             -- The ocean flow legitimately receives the ocean CF (and the
             -- wildcard cfUns also matches, but cfOcean writes last so its
             -- explicit zero stays — that's the intended modeller behaviour).
-            M.lookup (fidOcean, "FR") regio `shouldBe` Just (CF 0.0 (CFUnit "kg"))
+            M.lookup (fidOcean, Location "FR") regio `shouldBe` Just (CF 0.0 (CFUnit "kg"))
 
         it "treats CFs with empty / (unspecified) subcomp as wildcards" $ do
             let fid = mkUuid 110
@@ -448,9 +448,9 @@ spec = do
                 tUnspec = buildMethodTables OtherCFFamily M.empty M.empty [(cfUnspecified, Just (flowRiver, ByName))]
                 tUnspecBare = buildMethodTables OtherCFFamily M.empty M.empty [(cfUnspecBare, Just (flowRiver, ByName))]
             -- All three wildcard forms apply to a specific-subcomp flow.
-            M.lookup (fid, "DE") (mtRegionalizedCF tEmpty) `shouldBe` Just (CF 2.0 (CFUnit "kg"))
-            M.lookup (fid, "DE") (mtRegionalizedCF tUnspec) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
-            M.lookup (fid, "DE") (mtRegionalizedCF tUnspecBare) `shouldBe` Just (CF 9.0 (CFUnit "kg"))
+            M.lookup (fid, Location "DE") (mtRegionalizedCF tEmpty) `shouldBe` Just (CF 2.0 (CFUnit "kg"))
+            M.lookup (fid, Location "DE") (mtRegionalizedCF tUnspec) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
+            M.lookup (fid, Location "DE") (mtRegionalizedCF tUnspecBare) `shouldBe` Just (CF 9.0 (CFUnit "kg"))
 
         it "does not let a wildcard CF reach a sea/ocean flow (foreign medium)" $ do
             -- A freshwater CF must not characterize a sea-water release via the
@@ -469,7 +469,7 @@ spec = do
                         , mcfConsumerLocation = Just "DE"
                         }
                 tables = buildMethodTables OtherCFFamily M.empty M.empty [(cfUnspecified, Just (flowOcean, ByName))]
-            M.lookup (fid, "DE") (mtRegionalizedCF tables) `shouldBe` Nothing
+            M.lookup (fid, Location "DE") (mtRegionalizedCF tables) `shouldBe` Nothing
 
         it "does not let a wildcard CF reach a long-term groundwater flow for a USEtox method" $ do
             -- The USEtox gate is scoped to LONG-TERM groundwater: EF methods
@@ -493,10 +493,10 @@ spec = do
                         , mcfConsumerLocation = Just "DE"
                         }
                 tablesFor fam sub = buildMethodTables fam M.empty M.empty [(cfUnspecified, Just (flowSub sub, ByName))]
-            M.lookup (fid, "DE") (mtRegionalizedCF (tablesFor USEtoxFamily "groundwater, long-term")) `shouldBe` Nothing
-            M.lookup (fid, "DE") (mtRegionalizedCF (tablesFor USEtoxFamily "groundwater")) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
-            M.lookup (fid, "DE") (mtRegionalizedCF (tablesFor OtherCFFamily "groundwater, long-term")) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
-            M.lookup (fid, "DE") (mtRegionalizedCF (tablesFor OtherCFFamily "groundwater")) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
+            M.lookup (fid, Location "DE") (mtRegionalizedCF (tablesFor USEtoxFamily "groundwater, long-term")) `shouldBe` Nothing
+            M.lookup (fid, Location "DE") (mtRegionalizedCF (tablesFor USEtoxFamily "groundwater")) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
+            M.lookup (fid, Location "DE") (mtRegionalizedCF (tablesFor OtherCFFamily "groundwater, long-term")) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
+            M.lookup (fid, Location "DE") (mtRegionalizedCF (tablesFor OtherCFFamily "groundwater")) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
 
         it "keeps CF when mcfCompartment is Nothing (no subcomp info)" $ do
             let fid = mkUuid 120
@@ -512,4 +512,4 @@ spec = do
                         , mcfConsumerLocation = Just "IT"
                         }
                 tables = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flowAny, ByName))]
-            M.lookup (fid, "IT") (mtRegionalizedCF tables) `shouldBe` Just (CF 4.0 (CFUnit "kg"))
+            M.lookup (fid, Location "IT") (mtRegionalizedCF tables) `shouldBe` Just (CF 4.0 (CFUnit "kg"))

--- a/test/ProxyEdgeSpec.hs
+++ b/test/ProxyEdgeSpec.hs
@@ -13,6 +13,7 @@ import Method.Mapping (
     MatchStrategy (..),
     ProxyTargets (..),
     buildMethodTables,
+    cfValue,
     computeMappingStats,
     expandProxyEdges,
     lookupCFForFlow,
@@ -123,4 +124,4 @@ spec = describe "expandProxyEdges" $ do
             tablesProxy = buildMethodTables OtherCFFamily M.empty M.empty (expandProxyEdges byNameTargets edges baseMappings)
             lookup' ts = lookupCFForFlow ts (bfId phosphateFlow) (Just phosphateFlow)
         lookup' tablesNoProxy `shouldBe` Nothing
-        fmap fst (lookup' tablesProxy) `shouldBe` Just 1.0 -- 2.0 * 0.5
+        fmap cfValue (lookup' tablesProxy) `shouldBe` Just 1.0 -- 2.0 * 0.5

--- a/test/RegionFallbackSpec.hs
+++ b/test/RegionFallbackSpec.hs
@@ -8,7 +8,7 @@ import Data.UUID (UUID)
 import qualified Data.UUID as UUID
 import Test.Hspec
 
-import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, lookupCFForFlow)
+import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, cfValue, lookupCFForFlow)
 import Method.Types (CFFamily (..), Compartment (..), FlowDirection (..), MethodCF (..), extractLocationSuffix)
 import Types (BiosphereFlow (..))
 import qualified Types as VT
@@ -52,7 +52,7 @@ tablesFor base val =
 -- | Score a flow of the given name against those tables.
 scoreOf :: Text -> Double -> Text -> Maybe Double
 scoreOf base val flowName =
-    fmap fst (lookupCFForFlow (tablesFor base val) (mkUUID 99) (Just (mkFlow 99 flowName)))
+    fmap cfValue (lookupCFForFlow (tablesFor base val) (mkUUID 99) (Just (mkFlow 99 flowName)))
 
 spec :: Spec
 spec = do

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -201,10 +201,10 @@ oracleWeights db hier tables = U.generate (fromIntegral (dbActivityCount db)) wF
             ]
     cfFor flow loc =
         case M.lookup (flow, loc) regional of
-            Just (v, _) -> v
+            Just (CF v _) -> v
             Nothing ->
                 let parents = M.findWithDefault [] loc hier
-                 in case [v | p <- parents, Just (v, _) <- [M.lookup (flow, p) regional]] of
+                 in case [v | p <- parents, Just (CF v _) <- [M.lookup (flow, p) regional]] of
                         (v : _) -> v
                         [] -> 0 -- no fallback used in these fixtures
 

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -21,6 +21,7 @@ import Test.Hspec
 import Method.Mapping
 import Method.Types (
     FlowDirection (..),
+    Location (..),
     MethodCF (..),
  )
 import Types (
@@ -157,7 +158,7 @@ regionalMappings = map (\(loc, v) -> (cf loc v, Just (testFlow, ByName)))
 
 buildTables ::
     Database ->
-    M.Map Text [Text] ->
+    M.Map Location [Location] ->
     [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] ->
     MethodTables
 buildTables db hier mappings =
@@ -179,7 +180,7 @@ buildTables db hier mappings =
 -- For each biosphere triple, look up the regional CF (with parent fallback)
 -- and accumulate per-column weight. No reliance on the cascade or mtBroadcast,
 -- so a bug in either won't mask a bug in fillRegionalActivityWeights.
-oracleWeights :: Database -> M.Map Text [Text] -> MethodTables -> U.Vector Double
+oracleWeights :: Database -> M.Map Location [Location] -> MethodTables -> U.Vector Double
 oracleWeights db hier tables = U.generate (fromIntegral (dbActivityCount db)) wForCol
   where
     regional = mtRegionalizedCF tables
@@ -188,7 +189,7 @@ oracleWeights db hier tables = U.generate (fromIntegral (dbActivityCount db)) wF
     bioFlows = dbBiosphereOrder db
     colToLoc =
         M.fromList
-            [ (fromIntegral (actIdx V.! pid), activityLocation (activities V.! pid))
+            [ (fromIntegral (actIdx V.! pid), Location (activityLocation (activities V.! pid)))
             | pid <- [0 .. V.length actIdx - 1]
             ]
     wForCol col =
@@ -197,7 +198,7 @@ oracleWeights db hier tables = U.generate (fromIntegral (dbActivityCount db)) wF
             | SparseTriple flowRow colIdx bioVal <- U.toList (dbBiosphereTriples db)
             , fromIntegral colIdx == col
             , let flow = bioFlows V.! fromIntegral flowRow
-            , let loc = M.findWithDefault "" col colToLoc
+            , let loc = M.findWithDefault (Location "") col colToLoc
             ]
     cfFor flow loc =
         case M.lookup (flow, loc) regional of
@@ -230,7 +231,7 @@ spec = do
             -- A1@FR, A2@DE; DE has parent EU; CFs: FR=2, EU=7. Activity DE
             -- finds CF via parent walk.
             let db = mkDB [("FR", 10), ("DE", 20)]
-                hier = M.fromList [("DE", ["EU"])]
+                hier = M.fromList [(Location "DE", [Location "EU"])]
                 mappings = regionalMappings [("FR", 2), ("EU", 7)]
                 tables = buildTables db hier mappings
                 Just raw = mtRegionalActivityWeights tables

--- a/test/SharedCASCoverageSpec.hs
+++ b/test/SharedCASCoverageSpec.hs
@@ -463,7 +463,7 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
             mappings <- mapMethodFlows mapCtx regionalCasMethod
             let tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
             M.lookup (CASNumber waterCAS, Medium "resource") (mtRegionalCasCF tables)
-                `shouldBe` Just (M.fromList [("FR", (9, "m3"))])
+                `shouldBe` Just (M.fromList [("FR", CF 9 (CFUnit "m3"))])
             M.member (CASNumber waterCAS, Medium "resource") (mtCasCF tables) `shouldBe` False
 
         it "keeps regionalized UUID-matched rows out of mtUuidCF" $ do
@@ -471,8 +471,8 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
             let tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
             -- The global row stands; the location row lives in the regional
             -- table instead of clobbering the flow's universal value.
-            M.lookup (bfId river) (mtUuidCF tables) `shouldBe` Just (5, "m3")
-            M.lookup (bfId river, "IN") (mtRegionalizedCF tables) `shouldBe` Just (100, "m3")
+            M.lookup (bfId river) (mtUuidCF tables) `shouldBe` Just (CF 5 (CFUnit "m3"))
+            M.lookup (bfId river, "IN") (mtRegionalizedCF tables) `shouldBe` Just (CF 100 (CFUnit "m3"))
 
         it "keeps name-regionalized SimaPro rows out of mtCasCF (parser path)" $ do
             -- End-to-end through the real parser: 'parseCFRow' leaves
@@ -512,9 +512,9 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
                     -- sides (the negative release default keeps AWARE's
                     -- netting on the CAS-fallback path).
                     M.lookup (CASNumber waterCAS, Medium "resource") (mtCasCF tables)
-                        `shouldBe` Just (42.95, "m3")
+                        `shouldBe` Just (CF 42.95 (CFUnit "m3"))
                     M.lookup (CASNumber waterCAS, Medium "water") (mtCasCF tables)
-                        `shouldBe` Just (-42.95, "m3")
+                        `shouldBe` Just (CF (-42.95) (CFUnit "m3"))
 
     describe "unspecified subcompartment is the medium-level fallback" $ do
         it "an uncovered subcompartment falls back to the unspecified CF" $ do
@@ -539,7 +539,7 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
             mappings <- mapMethodFlows acrCtx acrMethod
             let tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
             -- indoor air is 100x; the bridge must not broadcast it.
-            M.lookup (CASNumber acrCAS, Medium "air") (mtCasCF tables) `shouldBe` Just (1, "kg")
+            M.lookup (CASNumber acrCAS, Medium "air") (mtCasCF tables) `shouldBe` Just (CF 1 (CFUnit "kg"))
 
         it "reaches the flow with the unspecified factor, not the indoor max" $ do
             mappings <- mapMethodFlows acrCtx acrMethod
@@ -554,4 +554,4 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
             mappings <- mapMethodFlows acrCtx acrRegionalMethod
             let tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
             M.lookup (CASNumber acrCAS, Medium "air") (mtRegionalCasCF tables)
-                `shouldBe` Just (M.fromList [("FR", (1, "kg"))])
+                `shouldBe` Just (M.fromList [("FR", CF 1 (CFUnit "kg"))])

--- a/test/SharedCASCoverageSpec.hs
+++ b/test/SharedCASCoverageSpec.hs
@@ -35,7 +35,7 @@ import Test.Hspec
 
 import Method.Mapping
 import Method.ParserSimaPro (parseSimaProMethodCSVBytes)
-import Method.Types (Compartment (..), FlowDirection (..), Medium (..), Method (..), MethodCF (..), MethodCollection (..))
+import Method.Types (Compartment (..), FlowDirection (..), Location (..), Medium (..), Method (..), MethodCF (..), MethodCollection (..))
 import SubstanceRegistry (CASNumber (..))
 import SynonymDB (buildFromPairs, emptySynonymDB, normalizeName)
 import Types (BiosphereFlow (..))
@@ -463,7 +463,7 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
             mappings <- mapMethodFlows mapCtx regionalCasMethod
             let tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
             M.lookup (CASNumber waterCAS, Medium "resource") (mtRegionalCasCF tables)
-                `shouldBe` Just (M.fromList [("FR", CF 9 (CFUnit "m3"))])
+                `shouldBe` Just (M.fromList [(Location "FR", CF 9 (CFUnit "m3"))])
             M.member (CASNumber waterCAS, Medium "resource") (mtCasCF tables) `shouldBe` False
 
         it "keeps regionalized UUID-matched rows out of mtUuidCF" $ do
@@ -472,7 +472,7 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
             -- The global row stands; the location row lives in the regional
             -- table instead of clobbering the flow's universal value.
             M.lookup (bfId river) (mtUuidCF tables) `shouldBe` Just (CF 5 (CFUnit "m3"))
-            M.lookup (bfId river, "IN") (mtRegionalizedCF tables) `shouldBe` Just (CF 100 (CFUnit "m3"))
+            M.lookup (bfId river, Location "IN") (mtRegionalizedCF tables) `shouldBe` Just (CF 100 (CFUnit "m3"))
 
         it "keeps name-regionalized SimaPro rows out of mtCasCF (parser path)" $ do
             -- End-to-end through the real parser: 'parseCFRow' leaves
@@ -554,4 +554,4 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
             mappings <- mapMethodFlows acrCtx acrRegionalMethod
             let tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
             M.lookup (CASNumber acrCAS, Medium "air") (mtRegionalCasCF tables)
-                `shouldBe` Just (M.fromList [("FR", CF 1 (CFUnit "kg"))])
+                `shouldBe` Just (M.fromList [(Location "FR", CF 1 (CFUnit "kg"))])

--- a/test/SubBlindCFSpec.hs
+++ b/test/SubBlindCFSpec.hs
@@ -8,7 +8,7 @@ import Data.UUID (UUID)
 import qualified Data.UUID as UUID
 import Test.Hspec
 
-import Method.Mapping (MatchStrategy (..), buildMethodTables, lookupCFForFlow)
+import Method.Mapping (MatchStrategy (..), buildMethodTables, cfValue, lookupCFForFlow)
 import Method.Types (CFFamily (..), Compartment (..), FlowDirection (..), MethodCF (..))
 import Types (BiosphereFlow (..))
 import qualified Types as VT
@@ -44,7 +44,7 @@ mkFlow i name sub =
 
 score :: [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> BiosphereFlow -> Maybe Double
 score mappings flow =
-    fmap fst (lookupCFForFlow (buildMethodTables OtherCFFamily M.empty M.empty mappings) (bfId flow) (Just flow))
+    fmap cfValue (lookupCFForFlow (buildMethodTables OtherCFFamily M.empty M.empty mappings) (bfId flow) (Just flow))
 
 spec :: Spec
 spec = describe "sub-blind CF fallback" $ do


### PR DESCRIPTION
## Why

After the lookup-key slice (#141), the remaining bare primitives in the characterization layer were the CF value itself — a `(Double, Text)` tuple whose halves can drift apart — and every location axis: the regionalized table keys, the location hierarchy, and the cross-DB linking match functions, all over bare `Text`. Nothing prevented a location from being swapped with a name, medium, or unit in a key or a call.

## Final state

- `data CF = CF { cfValue :: !Double, cfUnit :: !CFUnit }` with `newtype CFUnit` in `Method.Mapping`; the dead `Types.CF` / `Types.ImpactCategory` are removed. `convertForCharacterization` / `energyAwareConversion` take the CF side as `CFUnit`, so the two unit arguments can no longer be swapped silently.
- `newtype Location = Location Text` in `Method.Types`, next to `Medium` / `Subcompartment`. All regionalized table keys (`mtRegionalizedCF`, `mtRegionalCasCF`), the missing-pair diagnostics, and the hierarchy (`M.Map Location [Location]`) are typed.
- The cross-DB linking layer is typed too: `lcLocationHierarchy`, `matchLocation` / `describeLocation` / `acceptableLocation` / `isSubregionOf`, with the three placeless codes (GLO, RoW, Unspecified) in one shared `placelessLocations` list. `Manager.locationHierarchyOf` is the single choke point producing the typed hierarchy, replacing eight inline rebuilds.
- Parser-side fields (`mcfConsumerLocation`, `activityLocation`) stay `Text` and are wrapped where they enter the tables — parsers untouched.

Pure retype, no behaviour change: 1679 tests green, hlint clean.