### PR TITLE
Type locations in the regionalized CF tables as Location

### DIFF
--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -88,6 +88,7 @@ import qualified Data.Text as T
 import Data.UUID (UUID)
 
 import qualified Data.Vector as V
+import Method.Types (Location (..))
 import SynonymDB (SynonymDB, lookupSynonymGroup, normalizeName)
 import Types (
     Activity (..),
@@ -164,7 +165,7 @@ data LinkingContext = LinkingContext
     name+location scoring; geographic acceptability is enforced separately
     by 'lcGeographyPolicy' via 'acceptableLocation'.
     -}
-    , lcLocationHierarchy :: !(M.Map Text [Text])
+    , lcLocationHierarchy :: !(M.Map Location [Location])
     -- ^ Location hierarchy (code → parent codes)
     , lcGeographyPolicy :: !GeographyPolicy
     -- ^ How aggressively to widen geography when no exact match is found
@@ -776,7 +777,7 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
 
     classifyEntry :: Text -> (Text, SupplierEntry) -> Maybe ((Text, SupplierEntry), LocationKind)
     classifyEntry queryLoc entry@(_, SupplierEntry{seLocation}) =
-        case acceptableLocation lcGeographyPolicy lcLocationHierarchy queryLoc seLocation of
+        case acceptableLocation lcGeographyPolicy lcLocationHierarchy (Location queryLoc) (Location seLocation) of
             Just kind -> Just (entry, kind)
             Nothing -> Nothing
 
@@ -790,7 +791,7 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
                 mapMaybe
                     ( \(_, SupplierEntry{seLocation}) ->
                         (seLocation,)
-                            <$> acceptableLocation GeoGlobal lcLocationHierarchy queryLoc seLocation
+                            <$> acceptableLocation GeoGlobal lcLocationHierarchy (Location queryLoc) (Location seLocation)
                     )
                     candidates
             kindOrder ExactLoc = 4 :: Int
@@ -803,7 +804,7 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
 
     scoreEntry :: Text -> (Text, SupplierEntry) -> CrossDBCandidate
     scoreEntry queryLoc (dbName, SupplierEntry{..}) =
-        let locScore = matchLocation lcLocationHierarchy queryLoc seLocation
+        let locScore = matchLocation lcLocationHierarchy (Location queryLoc) (Location seLocation)
             nameScore = 50
             !totalScore = nameScore + locScore
          in CrossDBCandidate
@@ -872,11 +873,11 @@ Returns:
   10 = Global fallback (GLO or RoW)
    5 = Different but not blocking
 -}
-matchLocation :: M.Map Text [Text] -> Text -> Text -> Int
+matchLocation :: M.Map Location [Location] -> Location -> Location -> Int
 matchLocation hier queryLoc candidateLoc
     | queryLoc == candidateLoc = 30 -- Exact
     | isSubregionOf hier queryLoc candidateLoc = 20 -- Widening (FR→GLO, FR→RER)
-    | candidateLoc `elem` ["GLO", "RoW", "Unspecified"] = 10 -- Global fallback
+    | candidateLoc `elem` placelessLocations = 10 -- Global fallback
     | isSubregionOf hier candidateLoc queryLoc = 0 -- Narrowing (GLO→FR) — blocked
     | otherwise = 5 -- Unrelated
 
@@ -889,10 +890,10 @@ the requested location's parent chain (every country has GLO/RoW listed in
 'locationHierarchy'), because semantically a global fallback is a stronger
 caveat than an honest geographic widening.
 -}
-describeLocation :: M.Map Text [Text] -> Text -> Text -> LocationKind
+describeLocation :: M.Map Location [Location] -> Location -> Location -> LocationKind
 describeLocation hier queryLoc candidateLoc
     | queryLoc == candidateLoc = ExactLoc
-    | candidateLoc `elem` ["GLO", "RoW", "Unspecified"] = GlobalLoc
+    | candidateLoc `elem` placelessLocations = GlobalLoc
     | isSubregionOf hier queryLoc candidateLoc = ParentLoc
     | otherwise = UnrelatedLoc
 
@@ -903,11 +904,11 @@ rejected: it would invent precision the source dataset does not have.
 -}
 acceptableLocation ::
     GeographyPolicy ->
-    M.Map Text [Text] ->
+    M.Map Location [Location] ->
     -- | requested location
-    Text ->
+    Location ->
     -- | candidate location
-    Text ->
+    Location ->
     Maybe LocationKind
 acceptableLocation policy hier queryLoc candidateLoc
     | isNarrowing = Nothing
@@ -924,21 +925,31 @@ acceptableLocation policy hier queryLoc candidateLoc
     -- placeless code (GLO/RoW/Unspecified) — those are wider, not narrower
     isNarrowing =
         queryLoc /= candidateLoc
-            && candidateLoc `notElem` ["GLO", "RoW", "Unspecified"]
+            && candidateLoc `notElem` placelessLocations
             && isSubregionOf hier candidateLoc queryLoc
 
 -- | Check if one location is a subregion of another
-isSubregionOf :: M.Map Text [Text] -> Text -> Text -> Bool
+isSubregionOf :: M.Map Location [Location] -> Location -> Location -> Bool
 isSubregionOf hier child parent =
     case M.lookup child hier of
         Just parents -> parent `elem` parents
         Nothing -> False
 
+{- | Placeless codes: wider than any region — a valid global fallback,
+never a narrowing target.
+-}
+placelessLocations :: [Location]
+placelessLocations = map Location ["GLO", "RoW", "Unspecified"]
+
 {- | Location hierarchy for common LCA regions
 Maps a location code to its parent regions
 -}
-locationHierarchy :: M.Map Text [Text]
-locationHierarchy =
+locationHierarchy :: M.Map Location [Location]
+locationHierarchy = M.mapKeysMonotonic Location (M.map (map Location) rawLocationHierarchy)
+
+-- | The hierarchy table, kept as literal 'Text' for readability.
+rawLocationHierarchy :: M.Map Text [Text]
+rawLocationHierarchy =
     M.fromList
         [ -- European countries → regional/continental groupings
           ("FR", ["Europe without Switzerland", "Europe without Austria", "Europe", "EU", "RER", "ENTSO-E", "GLO", "RoW"])

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -136,6 +136,7 @@ import EcoSpold.Parser2 (streamParseActivityAndFlowsFromFile)
 import GHC.Conc (getNumCapabilities)
 import GHC.Fingerprint (Fingerprint (..))
 import qualified ILCD.Parser as ILCD
+import Method.Types (Location)
 import Progress
 import qualified SimaPro.Parser as SimaPro
 import SynonymDB (SynonymDB)
@@ -1176,7 +1177,7 @@ loadDatabaseWithCrossDBLinking ::
     -- | Unit configuration for compatibility checking
     UC.UnitConfig ->
     -- | Location hierarchy (empty = use built-in)
-    M.Map T.Text [T.Text] ->
+    M.Map Location [Location] ->
     -- | Geography policy for this database
     GeographyPolicy ->
     -- | Path to load from
@@ -1245,7 +1246,7 @@ fixActivityLinksWithCrossDB ::
     -- | Unit configuration
     UC.UnitConfig ->
     -- | Location hierarchy (code → parent codes)
-    M.Map T.Text [T.Text] ->
+    M.Map Location [Location] ->
     -- | Geography policy for this database
     GeographyPolicy ->
     -- | Database to fix
@@ -1355,7 +1356,7 @@ relinkSimpleDatabase ::
     [IndexedDatabase] ->
     SynonymDB ->
     UC.UnitConfig ->
-    M.Map T.Text [T.Text] ->
+    M.Map Location [Location] ->
     GeographyPolicy ->
     AliasMap ->
     SimpleDatabase ->

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -174,6 +174,7 @@ import Method.Mapping (
 import Method.Types (
     CompartmentMap,
     EnergyDensityMap,
+    Location (..),
     Method (..),
     MethodCF (..),
     MethodCollection (..),
@@ -630,7 +631,7 @@ mapMethodToTablesCachedWithHier ::
     Text ->
     Text ->
     Database ->
-    M.Map Text [Text] ->
+    M.Map Location [Location] ->
     Method ->
     IO MethodTables
 mapMethodToTablesCachedWithHier manager dbName collection db hier method = do
@@ -654,7 +655,7 @@ coverage gaps are surfaced once here, at build time, rather than per-pid on the
 scoring path. Caching and single-flighting are the caller's responsibility.
 -}
 buildMethodTablesFor ::
-    DatabaseManager -> Text -> Text -> Database -> M.Map Text [Text] -> Method -> IO MethodTables
+    DatabaseManager -> Text -> Text -> Database -> M.Map Location [Location] -> Method -> IO MethodTables
 buildMethodTablesFor manager dbName collection db hier method = do
     expanded <- effectiveMethodMappings manager dbName collection db method
     -- A CF matchable through the union synonym tables but not through its own
@@ -706,7 +707,7 @@ buildMethodTablesFor manager dbName collection db hier method = do
                         <> " regionalized (flow, location) pair(s) without CF coverage "
                         <> "(after walking parent regions and universal broadcast). "
                         <> "Samples: "
-                        <> show (take 3 [(show fid, T.unpack loc) | (fid, loc) <- rawMissingPairs raw'])
+                        <> show (take 3 [(show fid, T.unpack loc) | (fid, Location loc) <- rawMissingPairs raw'])
     pure tables
 
 {- | Run @build@ at most once per @key@ across concurrent callers. The first
@@ -3241,8 +3242,8 @@ but if data drift produces them, surface via log rather than hide.
 'data/geographies.csv' (or the hardcoded fallback). Reused across the LCIA
 regionalized scoring path (see 'Method.Mapping.computeRegionalizedLCIAScore').
 -}
-getLocationHierarchy :: DatabaseManager -> IO (M.Map Text [Text])
-getLocationHierarchy manager = pure (M.map snd (dmGeographies manager))
+getLocationHierarchy :: DatabaseManager -> IO (M.Map Location [Location])
+getLocationHierarchy manager = pure (M.map (map Location . snd) (M.mapKeysMonotonic Location (dmGeographies manager)))
 
 {- | Merged biosphere flow metadata + units across all loaded DBs. Technosphere
 flows are not merged here because characterization (the only consumer of

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -799,7 +799,7 @@ mapMethodSetToTablesCached manager dbName collection db methods = do
         Just mst -> pure mst
         Nothing -> do
             -- Fetch the location hierarchy once for the whole fan-out so the
-            -- concurrent workers don't each rebuild 'M.map snd dmGeographies'
+            -- concurrent workers don't each rebuild the typed hierarchy
             -- under 'getLocationHierarchy'.
             hier <- getLocationHierarchy manager
             -- mapConcurrently here parallelizes the per-method 'MethodTables'
@@ -1095,7 +1095,7 @@ loadOneDatabase ::
 loadOneDatabase synonymDB unitConfig noCache otherIndexes loadedDbsVar indexedDbsVar manager dbConfig = do
     dbStart <- getCurrentTime
     reportProgress Info $ "[STARTING] Loading database: " <> T.unpack (dcDisplayName dbConfig)
-    result <- loadDatabaseFromConfigWithCrossDB dbConfig synonymDB unitConfig noCache otherIndexes (M.map snd (dmGeographies manager))
+    result <- loadDatabaseFromConfigWithCrossDB dbConfig synonymDB unitConfig noCache otherIndexes (locationHierarchyOf manager)
     case result of
         Right (loaded0, _fromCache) -> do
             -- Backfill empty bfCAS from the registry's name↔CAS edges before
@@ -1381,7 +1381,7 @@ loadDatabaseFromConfigWithCrossDB ::
     UnitConversion.UnitConfig ->
     Bool -> -- noCache
     [IndexedDatabase] -> -- Pre-built indexes from other databases for cross-DB linking
-    M.Map T.Text [T.Text] -> -- Location hierarchy (empty = use built-in)
+    M.Map Location [Location] -> -- Location hierarchy (empty = use built-in)
     IO (Either Text (LoadedDatabase, Bool))
 loadDatabaseFromConfigWithCrossDB dbConfig synonymDB unitConfig noCache otherIndexes locationHier = do
     let sourcePath = dcPath dbConfig
@@ -1512,7 +1512,7 @@ loadDatabaseRawWithCrossDB ::
     -- | Pre-built indexes from other databases
     [IndexedDatabase] ->
     -- | Location hierarchy (empty = use built-in)
-    M.Map T.Text [T.Text] ->
+    M.Map Location [Location] ->
     -- | Geography policy for this database
     GeographyPolicy ->
     {- | (Database, fromCache): True iff the result came from the matrix cache
@@ -1666,7 +1666,7 @@ loadDatabaseSingleFromConfig manager dbName = do
                                 unitConfig
                                 (dmNoCache manager)
                                 otherIndexes
-                                (M.map snd (dmGeographies manager))
+                                (locationHierarchyOf manager)
                     case eitherResult of
                         Left (ex :: SomeException) -> return $ Left $ "Exception loading database: " <> T.pack (show ex)
                         Right (Left err) -> return $ Left err
@@ -1822,7 +1822,7 @@ relinkStaged manager dbName maybeDepDb aliases = do
                                 selectedIndexes
                                 synonymDB
                                 unitConfig
-                                (M.map snd (dmGeographies manager))
+                                (locationHierarchyOf manager)
                                 (dcGeographyPolicy (sdConfig staged))
                                 aliases
                                 (sdSimpleDB staged)
@@ -1896,7 +1896,7 @@ relinkDatabaseWith manager dbName aliases persistedDeps = do
                         , lcSynonymDB = synonymDB
                         , lcUnitConfig = unitConfig
                         , lcThreshold = defaultLinkingThreshold
-                        , lcLocationHierarchy = M.map snd (dmGeographies manager)
+                        , lcLocationHierarchy = locationHierarchyOf manager
                         , lcGeographyPolicy = dcGeographyPolicy (ldConfig loaded)
                         , lcSupplierAliases = aliases
                         }
@@ -2118,7 +2118,7 @@ stageUploadedDatabase manager dbConfig = do
                     otherIndexes
                     synonymDB
                     unitConfig
-                    (M.map snd (dmGeographies manager))
+                    (locationHierarchyOf manager)
                     (dcGeographyPolicy dbConfig)
                     loadPath
 
@@ -2149,7 +2149,7 @@ stageUploadedDatabase manager dbConfig = do
                                         restrictedIndexes
                                         synonymDB
                                         unitConfig
-                                        (M.map snd (dmGeographies manager))
+                                        (locationHierarchyOf manager)
                                         (dcGeographyPolicy dbConfig)
                                         simpleDb
                                 return (stats', simpleDb')
@@ -2731,7 +2731,7 @@ addDependencyToStaged manager dbName depName = do
                         selectedIndexes
                         synonymDB
                         unitConfig
-                        (M.map snd (dmGeographies manager))
+                        (locationHierarchyOf manager)
                         (dcGeographyPolicy (sdConfig staged))
                         (sdSimpleDB staged)
 
@@ -2770,7 +2770,7 @@ removeDependencyFromStaged manager dbName depName = do
                     remainingIndexes
                     synonymDB
                     unitConfig
-                    (M.map snd (dmGeographies manager))
+                    (locationHierarchyOf manager)
                     (dcGeographyPolicy (sdConfig staged))
                     (sdSimpleDB staged)
 
@@ -3243,7 +3243,11 @@ but if data drift produces them, surface via log rather than hide.
 regionalized scoring path (see 'Method.Mapping.computeRegionalizedLCIAScore').
 -}
 getLocationHierarchy :: DatabaseManager -> IO (M.Map Location [Location])
-getLocationHierarchy manager = pure (M.map (map Location . snd) (M.mapKeysMonotonic Location (dmGeographies manager)))
+getLocationHierarchy = pure . locationHierarchyOf
+
+-- | Pure form of 'getLocationHierarchy', shared by the loading paths.
+locationHierarchyOf :: DatabaseManager -> M.Map Location [Location]
+locationHierarchyOf manager = M.map (map Location . snd) (M.mapKeysMonotonic Location (dmGeographies manager))
 
 {- | Merged biosphere flow metadata + units across all loaded DBs. Technosphere
 flows are not merged here because characterization (the only consumer of

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -465,13 +465,13 @@ data MethodTables = MethodTables
     (minerals are reachable only through this bridge). Empty for methods whose
     CFs carry no CAS.
     -}
-    , mtRegionalCasCF :: !(M.Map (SR.CASNumber, Medium) (M.Map Text CF))
+    , mtRegionalCasCF :: !(M.Map (SR.CASNumber, Medium) (M.Map Location CF))
     {- ^ (CAS, normalized medium) → (location → CF), from regionalized
     CFs. The regionalized analogue of 'mtCasCF': lets the regionalized build
     characterize every same-CAS flow per location, not just the one a CF
     resolved to. Empty for methods with no regionalized CAS-bearing CFs.
     -}
-    , mtRegionalizedCF :: !(M.Map (UUID, Text) CF)
+    , mtRegionalizedCF :: !(M.Map (UUID, Location) CF)
     {- ^ Regionalized cells of the C matrix: (DB flow UUID, consumer location) → CF.
     Empty for non-regionalized methods. When non-empty, callers should dispatch
     to the regionalized scoring path (see 'Matrix.computeRegionalizedLCIAScore').
@@ -538,7 +538,7 @@ caller can emit one warning per gap rather than per pid × per method.
 data RegionalActivityWeights = RegionalActivityWeights
     { rawWeights :: !(U.Vector Double)
     , rawTainted :: !(U.Vector Word8)
-    , rawMissingPairs :: ![(UUID, Text)]
+    , rawMissingPairs :: ![(UUID, Location)]
     }
 
 {- | Inverted indices over a 'Method' for the post-scoring suggester.
@@ -1108,7 +1108,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             M.map (M.map snd) $
                 M.fromListWith
                     (M.unionWith preferUnspecifiedCas)
-                    [ ((SR.CASNumber cas, Medium normMed), M.singleton loc (casSubRank normSub, cfOf cf))
+                    [ ((SR.CASNumber cas, Medium normMed), M.singleton (Location loc) (casSubRank normSub, cfOf cf))
                     | (cf, Just (_, ByCAS)) <- mappings
                     , Just cas <- [mcfCAS cf]
                     , not (T.null cas)
@@ -1126,7 +1126,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             -- fallback CF. CFs with no specific subcomp ('isUnspecifiedSub')
             -- are wildcards and match any flow subcomp.
             M.fromList
-                [ ((bfId flow, loc), cfOf cf)
+                [ ((bfId flow, Location loc), cfOf cf)
                 | (cf, Just (flow, _)) <- mappings
                 , cfSubcompMatchesFlow cf flow
                 , Just loc <- [mcfConsumerLocation cf]
@@ -1311,7 +1311,7 @@ fillRegionalActivityWeights ::
     UnitDB ->
     BioFlowDB ->
     Database ->
-    M.Map Text [Text] ->
+    M.Map Location [Location] ->
     MethodTables ->
     MethodTables
 fillRegionalActivityWeights unitCfg unitDB flowDB db hier tables
@@ -1334,9 +1334,9 @@ fillRegionalActivityWeights unitCfg unitDB flowDB db hier tables
     -- @(UUID, Text)@-keyed map. Subsumes the old
     -- @regionalizedFlows :: Set UUID@ check — @Just _@ here is the
     -- "this flow is regionalized" signal needed at the taint branch.
-    regionalByRow :: V.Vector (Maybe (M.Map Text CF))
+    regionalByRow :: V.Vector (Maybe (M.Map Location CF))
     regionalByRow =
-        let perFlow :: M.Map UUID (M.Map Text CF)
+        let perFlow :: M.Map UUID (M.Map Location CF)
             perFlow =
                 M.fromListWith
                     M.union
@@ -1356,10 +1356,10 @@ fillRegionalActivityWeights unitCfg unitDB flowDB db hier tables
 
     -- ProcessId → matrix column index → activity's reference location.
     -- Built once (O(nActivities)) and indexed by column inside the hot loop.
-    colLoc :: V.Vector Text
+    colLoc :: V.Vector Location
     colLoc =
-        V.replicate nCols T.empty
-            V.// [ (fromIntegral (actIdx V.! pid), activityLocation (activities V.! pid))
+        V.replicate nCols (Location T.empty)
+            V.// [ (fromIntegral (actIdx V.! pid), Location (activityLocation (activities V.! pid)))
                  | pid <- [0 .. V.length actIdx - 1]
                  , let !col = fromIntegral (actIdx V.! pid) :: Int
                  , col >= 0
@@ -1389,7 +1389,7 @@ fillRegionalActivityWeights unitCfg unitDB flowDB db hier tables
     precomputed = runST $ do
         ws <- MU.replicate nCols (0 :: Double)
         ts <- MU.replicate nCols (0 :: Word8)
-        missRef <- newSTRef (Set.empty :: Set.Set (UUID, Text))
+        missRef <- newSTRef (Set.empty :: Set.Set (UUID, Location))
         U.forM_ bioTriples $ \(SparseTriple flowRow colIdx bioVal) -> do
             let !col = fromIntegral colIdx :: Int
                 !row = fromIntegral flowRow :: Int
@@ -1532,7 +1532,7 @@ computeLCIAScoreAuto ::
     -- | Pre-computed inventory @g = B · s@ (only used in the classic path)
     Inventory ->
     -- | Location hierarchy: child → ordered list of parents
-    M.Map Text [Text] ->
+    M.Map Location [Location] ->
     MethodTables ->
     Either Text Double
 computeLCIAScoreAuto unitCfg unitDB flowDB db scalingVec inventory hier tables
@@ -1570,7 +1570,7 @@ computeRegionalizedLCIAScore ::
     -- | Scaling vector @s@ from 'Matrix.computeScalingVector'
     Vector ->
     -- | Location hierarchy: child → ordered list of parents
-    M.Map Text [Text] ->
+    M.Map Location [Location] ->
     MethodTables ->
     Either Text Double
 computeRegionalizedLCIAScore _unitConfig _unitDB _flowDB _db scalingVec _hier tables =
@@ -1658,7 +1658,7 @@ sumRegionalizedLCIAScoreCrossDB ::
     UnitConfig ->
     UnitDB ->
     BioFlowDB ->
-    M.Map Text [Text] ->
+    M.Map Location [Location] ->
     {- | Per-DB triples: one per database participating in the cross-DB solve
     (root + dep DBs in the same order returned by 'SharedSolver.csScalings').
     -}
@@ -2264,7 +2264,7 @@ computeLCIAScoreSetFromTables ::
     UnitDB ->
     BioFlowDB ->
     Inventory ->
-    M.Map Text [Text] ->
+    M.Map Location [Location] ->
     {- | Non-empty per-DB triples: 'NE.head' is root, tail is each participating
     dep DB. Building order matches 'SharedSolver.csScalings'.
     -}
@@ -2292,7 +2292,7 @@ scoreRegionalCrossDB ::
     UnitConfig ->
     UnitDB ->
     BioFlowDB ->
-    M.Map Text [Text] ->
+    M.Map Location [Location] ->
     V.Vector MethodSetEntry ->
     NonEmpty (Database, Vector, MethodSetTables) ->
     [(UUID, Either Text Double)]

--- a/src/Method/Types.hs
+++ b/src/Method/Types.hs
@@ -14,6 +14,7 @@ module Method.Types (
     MethodCF (..),
     FlowDirection (..),
     Compartment (..),
+    Location (..),
     Medium (..),
     Subcompartment (..),
     CFFamily (..),
@@ -98,6 +99,13 @@ newtype Medium = Medium Text
 normalized name; a newtype so it can't be swapped with a medium in a key tuple.
 -}
 newtype Subcompartment = Subcompartment Text
+    deriving (Eq, Ord, Show)
+
+{- | A location / geography code (@"FR"@, @"CN-SC"@, @"RER"@, @"GLO"@) as used
+by regionalized CFs and the location hierarchy. A newtype so a location can't
+be swapped with any other Text axis in a regionalized lookup key.
+-}
+newtype Location = Location Text
     deriving (Eq, Ord, Show)
 
 {- | A characterization factor from a method file

--- a/test/CrossLinkingSpec.hs
+++ b/test/CrossLinkingSpec.hs
@@ -10,6 +10,7 @@ import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import Database.CrossLinking
 import Database.Loader (loadDatabase)
+import Method.Types (Location (..))
 import SynonymDB (buildFromPairs, emptySynonymDB)
 import Test.Hspec
 import Types
@@ -141,41 +142,41 @@ spec = do
     -- -----------------------------------------------------------------------
     describe "isSubregionOf" $ do
         it "FR is a subregion of RER" $
-            isSubregionOf locationHierarchy "FR" "RER" `shouldBe` True
+            isSubregionOf locationHierarchy (Location "FR") (Location "RER") `shouldBe` True
 
         it "FR is a subregion of GLO" $
-            isSubregionOf locationHierarchy "FR" "GLO" `shouldBe` True
+            isSubregionOf locationHierarchy (Location "FR") (Location "GLO") `shouldBe` True
 
         it "GLO is not a subregion of FR" $
-            isSubregionOf locationHierarchy "GLO" "FR" `shouldBe` False
+            isSubregionOf locationHierarchy (Location "GLO") (Location "FR") `shouldBe` False
 
         it "unknown location has no parents" $
-            isSubregionOf locationHierarchy "XX" "GLO" `shouldBe` False
+            isSubregionOf locationHierarchy (Location "XX") (Location "GLO") `shouldBe` False
 
     -- -----------------------------------------------------------------------
     -- matchLocation
     -- -----------------------------------------------------------------------
     describe "matchLocation" $ do
         it "exact match scores 30" $
-            matchLocation locationHierarchy "FR" "FR" `shouldBe` 30
+            matchLocation locationHierarchy (Location "FR") (Location "FR") `shouldBe` 30
 
         it "FR consumer, RER supplier scores 20 (widening)" $
-            matchLocation locationHierarchy "FR" "RER" `shouldBe` 20
+            matchLocation locationHierarchy (Location "FR") (Location "RER") `shouldBe` 20
 
         it "FR consumer, GLO supplier scores 20 (widening via subregion)" $
-            matchLocation locationHierarchy "FR" "GLO" `shouldBe` 20
+            matchLocation locationHierarchy (Location "FR") (Location "GLO") `shouldBe` 20
 
         it "unknown location, GLO supplier scores 10 (global fallback)" $
-            matchLocation locationHierarchy "XX" "GLO" `shouldBe` 10
+            matchLocation locationHierarchy (Location "XX") (Location "GLO") `shouldBe` 10
 
         it "unknown location, RoW supplier scores 10 (global fallback)" $
-            matchLocation locationHierarchy "XX" "RoW" `shouldBe` 10
+            matchLocation locationHierarchy (Location "XX") (Location "RoW") `shouldBe` 10
 
         it "narrowing (GLO consumer, FR supplier) scores 0" $
-            matchLocation locationHierarchy "GLO" "FR" `shouldBe` 0
+            matchLocation locationHierarchy (Location "GLO") (Location "FR") `shouldBe` 0
 
         it "unrelated locations score 5" $
-            matchLocation locationHierarchy "FR" "CN" `shouldBe` 5
+            matchLocation locationHierarchy (Location "FR") (Location "CN") `shouldBe` 5
 
     -- -----------------------------------------------------------------------
     -- matchProductName
@@ -212,32 +213,32 @@ spec = do
     -- -----------------------------------------------------------------------
     describe "isSubregionOf (additional)" $ do
         it "US is a subregion of North America" $
-            isSubregionOf locationHierarchy "US" "North America" `shouldBe` True
+            isSubregionOf locationHierarchy (Location "US") (Location "North America") `shouldBe` True
 
         it "CA is a subregion of NAFTA" $
-            isSubregionOf locationHierarchy "CA" "NAFTA" `shouldBe` True
+            isSubregionOf locationHierarchy (Location "CA") (Location "NAFTA") `shouldBe` True
 
         it "JP is a subregion of Asia" $
-            isSubregionOf locationHierarchy "JP" "Asia" `shouldBe` True
+            isSubregionOf locationHierarchy (Location "JP") (Location "Asia") `shouldBe` True
 
         it "BR is a subregion of Latin America" $
-            isSubregionOf locationHierarchy "BR" "Latin America" `shouldBe` True
+            isSubregionOf locationHierarchy (Location "BR") (Location "Latin America") `shouldBe` True
 
         it "AU is a subregion of GLO" $
-            isSubregionOf locationHierarchy "AU" "GLO" `shouldBe` True
+            isSubregionOf locationHierarchy (Location "AU") (Location "GLO") `shouldBe` True
 
     -- -----------------------------------------------------------------------
     -- matchLocation — additional scoring cases
     -- -----------------------------------------------------------------------
     describe "matchLocation (additional)" $ do
         it "US consumer, NAFTA supplier scores 20 (widening)" $
-            matchLocation locationHierarchy "US" "NAFTA" `shouldBe` 20
+            matchLocation locationHierarchy (Location "US") (Location "NAFTA") `shouldBe` 20
 
         it "GLO consumer, GLO supplier scores 30 (exact)" $
-            matchLocation locationHierarchy "GLO" "GLO" `shouldBe` 30
+            matchLocation locationHierarchy (Location "GLO") (Location "GLO") `shouldBe` 30
 
         it "RoW consumer, RoW supplier scores 30 (exact)" $
-            matchLocation locationHierarchy "RoW" "RoW" `shouldBe` 30
+            matchLocation locationHierarchy (Location "RoW") (Location "RoW") `shouldBe` 30
 
     -- -----------------------------------------------------------------------
     -- findSupplierInIndexedDBs — integration using SAMPLE.min3
@@ -353,9 +354,9 @@ spec = do
                 , ("BR→GLO is global", "BR", "GLO", Nothing, Nothing, Just GlobalLoc)
                 ]
         forM_ cases $ \(label, req, cand, expExact, expParent, expGlobal) -> do
-            it (label ++ " — exact") $ acceptableLocation GeoExact hier req cand `shouldBe` expExact
-            it (label ++ " — parent") $ acceptableLocation GeoParent hier req cand `shouldBe` expParent
-            it (label ++ " — global") $ acceptableLocation GeoGlobal hier req cand `shouldBe` expGlobal
+            it (label ++ " — exact") $ acceptableLocation GeoExact hier (Location req) (Location cand) `shouldBe` expExact
+            it (label ++ " — parent") $ acceptableLocation GeoParent hier (Location req) (Location cand) `shouldBe` expParent
+            it (label ++ " — global") $ acceptableLocation GeoGlobal hier (Location req) (Location cand) `shouldBe` expGlobal
 
     -- -----------------------------------------------------------------------
     -- findSupplierInIndexedDBs — geography_policy enforcement

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -22,7 +22,7 @@ import Test.Hspec
 
 import Matrix (Inventory)
 import Method.Mapping
-import Method.Types (Compartment (..), Method (..), MethodCF (..))
+import Method.Types (Compartment (..), Location (..), Method (..), MethodCF (..))
 import qualified Method.Types as MT
 import Types (BiosphereFlow (..), Database, Unit (..))
 import qualified Types as VT
@@ -111,7 +111,7 @@ spec = do
                 cf = mkCF fid 1.0
                 tables0 =
                     (buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (mkFlow fid "co2" uidKg, ByUUID))])
-                        { mtRegionalizedCF = M.singleton (fid, "FR") (CF 2.0 (CFUnit "kg"))
+                        { mtRegionalizedCF = M.singleton (fid, Location "FR") (CF 2.0 (CFUnit "kg"))
                         }
                 m1 = mkMethod 1 "m1" [cf]
                 fdb = M.singleton fid (mkFlow fid "co2" uidKg)
@@ -317,7 +317,7 @@ spec = do
                 tRegio =
                     fill
                         ( (buildMethodTables OtherCFFamily M.empty M.empty [(cf2a, Just (flow1, ByUUID))])
-                            { mtRegionalizedCF = M.singleton (fid1, "FR") (CF 7.0 (CFUnit "kg"))
+                            { mtRegionalizedCF = M.singleton (fid1, Location "FR") (CF 7.0 (CFUnit "kg"))
                             }
                         )
                 tNonRegio2 =
@@ -409,11 +409,11 @@ spec = do
                 regio = mtRegionalizedCF tables
             -- Pre-fix: this was (0.0, "kg") — clobbered by cfOcean. The
             -- filter drops (cfOcean, flowUns) so the wildcard cfUns survives.
-            M.lookup (fidUns, "FR") regio `shouldBe` Just (CF 3.0 (CFUnit "kg"))
+            M.lookup (fidUns, Location "FR") regio `shouldBe` Just (CF 3.0 (CFUnit "kg"))
             -- The ocean flow legitimately receives the ocean CF (and the
             -- wildcard cfUns also matches, but cfOcean writes last so its
             -- explicit zero stays — that's the intended modeller behaviour).
-            M.lookup (fidOcean, "FR") regio `shouldBe` Just (CF 0.0 (CFUnit "kg"))
+            M.lookup (fidOcean, Location "FR") regio `shouldBe` Just (CF 0.0 (CFUnit "kg"))
 
         it "treats CFs with empty / (unspecified) subcomp as wildcards" $ do
             let fid = mkUuid 110
@@ -448,9 +448,9 @@ spec = do
                 tUnspec = buildMethodTables OtherCFFamily M.empty M.empty [(cfUnspecified, Just (flowRiver, ByName))]
                 tUnspecBare = buildMethodTables OtherCFFamily M.empty M.empty [(cfUnspecBare, Just (flowRiver, ByName))]
             -- All three wildcard forms apply to a specific-subcomp flow.
-            M.lookup (fid, "DE") (mtRegionalizedCF tEmpty) `shouldBe` Just (CF 2.0 (CFUnit "kg"))
-            M.lookup (fid, "DE") (mtRegionalizedCF tUnspec) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
-            M.lookup (fid, "DE") (mtRegionalizedCF tUnspecBare) `shouldBe` Just (CF 9.0 (CFUnit "kg"))
+            M.lookup (fid, Location "DE") (mtRegionalizedCF tEmpty) `shouldBe` Just (CF 2.0 (CFUnit "kg"))
+            M.lookup (fid, Location "DE") (mtRegionalizedCF tUnspec) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
+            M.lookup (fid, Location "DE") (mtRegionalizedCF tUnspecBare) `shouldBe` Just (CF 9.0 (CFUnit "kg"))
 
         it "does not let a wildcard CF reach a sea/ocean flow (foreign medium)" $ do
             -- A freshwater CF must not characterize a sea-water release via the
@@ -469,7 +469,7 @@ spec = do
                         , mcfConsumerLocation = Just "DE"
                         }
                 tables = buildMethodTables OtherCFFamily M.empty M.empty [(cfUnspecified, Just (flowOcean, ByName))]
-            M.lookup (fid, "DE") (mtRegionalizedCF tables) `shouldBe` Nothing
+            M.lookup (fid, Location "DE") (mtRegionalizedCF tables) `shouldBe` Nothing
 
         it "does not let a wildcard CF reach a long-term groundwater flow for a USEtox method" $ do
             -- The USEtox gate is scoped to LONG-TERM groundwater: EF methods
@@ -493,10 +493,10 @@ spec = do
                         , mcfConsumerLocation = Just "DE"
                         }
                 tablesFor fam sub = buildMethodTables fam M.empty M.empty [(cfUnspecified, Just (flowSub sub, ByName))]
-            M.lookup (fid, "DE") (mtRegionalizedCF (tablesFor USEtoxFamily "groundwater, long-term")) `shouldBe` Nothing
-            M.lookup (fid, "DE") (mtRegionalizedCF (tablesFor USEtoxFamily "groundwater")) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
-            M.lookup (fid, "DE") (mtRegionalizedCF (tablesFor OtherCFFamily "groundwater, long-term")) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
-            M.lookup (fid, "DE") (mtRegionalizedCF (tablesFor OtherCFFamily "groundwater")) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
+            M.lookup (fid, Location "DE") (mtRegionalizedCF (tablesFor USEtoxFamily "groundwater, long-term")) `shouldBe` Nothing
+            M.lookup (fid, Location "DE") (mtRegionalizedCF (tablesFor USEtoxFamily "groundwater")) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
+            M.lookup (fid, Location "DE") (mtRegionalizedCF (tablesFor OtherCFFamily "groundwater, long-term")) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
+            M.lookup (fid, Location "DE") (mtRegionalizedCF (tablesFor OtherCFFamily "groundwater")) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
 
         it "keeps CF when mcfCompartment is Nothing (no subcomp info)" $ do
             let fid = mkUuid 120
@@ -512,4 +512,4 @@ spec = do
                         , mcfConsumerLocation = Just "IT"
                         }
                 tables = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flowAny, ByName))]
-            M.lookup (fid, "IT") (mtRegionalizedCF tables) `shouldBe` Just (CF 4.0 (CFUnit "kg"))
+            M.lookup (fid, Location "IT") (mtRegionalizedCF tables) `shouldBe` Just (CF 4.0 (CFUnit "kg"))

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -21,6 +21,7 @@ import Test.Hspec
 import Method.Mapping
 import Method.Types (
     FlowDirection (..),
+    Location (..),
     MethodCF (..),
  )
 import Types (
@@ -157,7 +158,7 @@ regionalMappings = map (\(loc, v) -> (cf loc v, Just (testFlow, ByName)))
 
 buildTables ::
     Database ->
-    M.Map Text [Text] ->
+    M.Map Location [Location] ->
     [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] ->
     MethodTables
 buildTables db hier mappings =
@@ -179,7 +180,7 @@ buildTables db hier mappings =
 -- For each biosphere triple, look up the regional CF (with parent fallback)
 -- and accumulate per-column weight. No reliance on the cascade or mtBroadcast,
 -- so a bug in either won't mask a bug in fillRegionalActivityWeights.
-oracleWeights :: Database -> M.Map Text [Text] -> MethodTables -> U.Vector Double
+oracleWeights :: Database -> M.Map Location [Location] -> MethodTables -> U.Vector Double
 oracleWeights db hier tables = U.generate (fromIntegral (dbActivityCount db)) wForCol
   where
     regional = mtRegionalizedCF tables
@@ -188,7 +189,7 @@ oracleWeights db hier tables = U.generate (fromIntegral (dbActivityCount db)) wF
     bioFlows = dbBiosphereOrder db
     colToLoc =
         M.fromList
-            [ (fromIntegral (actIdx V.! pid), activityLocation (activities V.! pid))
+            [ (fromIntegral (actIdx V.! pid), Location (activityLocation (activities V.! pid)))
             | pid <- [0 .. V.length actIdx - 1]
             ]
     wForCol col =
@@ -197,7 +198,7 @@ oracleWeights db hier tables = U.generate (fromIntegral (dbActivityCount db)) wF
             | SparseTriple flowRow colIdx bioVal <- U.toList (dbBiosphereTriples db)
             , fromIntegral colIdx == col
             , let flow = bioFlows V.! fromIntegral flowRow
-            , let loc = M.findWithDefault "" col colToLoc
+            , let loc = M.findWithDefault (Location "") col colToLoc
             ]
     cfFor flow loc =
         case M.lookup (flow, loc) regional of
@@ -230,7 +231,7 @@ spec = do
             -- A1@FR, A2@DE; DE has parent EU; CFs: FR=2, EU=7. Activity DE
             -- finds CF via parent walk.
             let db = mkDB [("FR", 10), ("DE", 20)]
-                hier = M.fromList [("DE", ["EU"])]
+                hier = M.fromList [(Location "DE", [Location "EU"])]
                 mappings = regionalMappings [("FR", 2), ("EU", 7)]
                 tables = buildTables db hier mappings
                 Just raw = mtRegionalActivityWeights tables

--- a/test/SharedCASCoverageSpec.hs
+++ b/test/SharedCASCoverageSpec.hs
@@ -35,7 +35,7 @@ import Test.Hspec
 
 import Method.Mapping
 import Method.ParserSimaPro (parseSimaProMethodCSVBytes)
-import Method.Types (Compartment (..), FlowDirection (..), Medium (..), Method (..), MethodCF (..), MethodCollection (..))
+import Method.Types (Compartment (..), FlowDirection (..), Location (..), Medium (..), Method (..), MethodCF (..), MethodCollection (..))
 import SubstanceRegistry (CASNumber (..))
 import SynonymDB (buildFromPairs, emptySynonymDB, normalizeName)
 import Types (BiosphereFlow (..))
@@ -463,7 +463,7 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
             mappings <- mapMethodFlows mapCtx regionalCasMethod
             let tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
             M.lookup (CASNumber waterCAS, Medium "resource") (mtRegionalCasCF tables)
-                `shouldBe` Just (M.fromList [("FR", CF 9 (CFUnit "m3"))])
+                `shouldBe` Just (M.fromList [(Location "FR", CF 9 (CFUnit "m3"))])
             M.member (CASNumber waterCAS, Medium "resource") (mtCasCF tables) `shouldBe` False
 
         it "keeps regionalized UUID-matched rows out of mtUuidCF" $ do
@@ -472,7 +472,7 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
             -- The global row stands; the location row lives in the regional
             -- table instead of clobbering the flow's universal value.
             M.lookup (bfId river) (mtUuidCF tables) `shouldBe` Just (CF 5 (CFUnit "m3"))
-            M.lookup (bfId river, "IN") (mtRegionalizedCF tables) `shouldBe` Just (CF 100 (CFUnit "m3"))
+            M.lookup (bfId river, Location "IN") (mtRegionalizedCF tables) `shouldBe` Just (CF 100 (CFUnit "m3"))
 
         it "keeps name-regionalized SimaPro rows out of mtCasCF (parser path)" $ do
             -- End-to-end through the real parser: 'parseCFRow' leaves
@@ -554,4 +554,4 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
             mappings <- mapMethodFlows acrCtx acrRegionalMethod
             let tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
             M.lookup (CASNumber acrCAS, Medium "air") (mtRegionalCasCF tables)
-                `shouldBe` Just (M.fromList [("FR", CF 1 (CFUnit "kg"))])
+                `shouldBe` Just (M.fromList [(Location "FR", CF 1 (CFUnit "kg"))])


### PR DESCRIPTION
## Why

Stacked on #235. After the CF value slice, locations were the last bare-`Text` axis in the regionalized lookup layer: the `(UUID, Text)` key of `mtRegionalizedCF`, the inner map of `mtRegionalCasCF`, `rawMissingPairs`, the per-column location vector, and the location hierarchy threaded through every regionalized scoring signature as `M.Map Text [Text]`. Nothing prevented a location from being swapped with a name, medium or unit in a key.

## Final state

- `newtype Location = Location Text` in `Method.Types`, next to `Medium` / `Subcompartment`.
- All regionalized table keys, the missing-pair diagnostics, and the hierarchy (`M.Map Location [Location]`) are typed.
- `getLocationHierarchy` is the single choke point producing the hierarchy, so the wrap happens once there; parser-side fields (`mcfConsumerLocation`, `activityLocation`) stay `Text` and are wrapped where they enter the tables — parsers untouched.

Pure retype, no behaviour change: 1679 tests green, hlint clean.