### PR TITLE
Name the subject in the missing-metadata details

### DIFF
--- a/src/Database/Quality.hs
+++ b/src/Database/Quality.hs
@@ -271,9 +271,9 @@ qualityReport dbName db =
     -- unknown unit, which change how the entry links and converts.
     metadataOffenders =
         concat
-            [ [offender InfoSev act Nothing "no description" | all (T.null . T.strip) (activityDescription act)]
-                <> [offender InfoSev act Nothing "no classification" | M.null (activityClassification act)]
-                <> [offender WarningSev act Nothing "no location" | T.null (T.strip (activityLocation act))]
+            [ [offender InfoSev act Nothing "the dataset carries no description" | all (T.null . T.strip) (activityDescription act)]
+                <> [offender InfoSev act Nothing "the dataset carries no classification" | M.null (activityClassification act)]
+                <> [offender WarningSev act Nothing "the dataset carries no location" | T.null (T.strip (activityLocation act))]
                 <> [ offender WarningSev act Nothing $
                         T.pack (show unknownUnits) <> " exchange(s) whose unit is absent from the unit registry"
                    | let unknownUnits = length [() | ex <- exchanges act, M.notMember (exchangeUnitId ex) (sdbUnits db)]

--- a/test/QualityReportSpec.hs
+++ b/test/QualityReportSpec.hs
@@ -259,20 +259,20 @@ spec = do
     describe "missing metadata check" $ do
         it "flags an empty description as info" $ do
             let check = qrMissingMetadata (reportOf (mkActivity "bread" [reference breadFlow]){activityDescription = []})
-            details check `shouldBe` ["no description"]
+            details check `shouldBe` ["the dataset carries no description"]
             severities check `shouldBe` [InfoSev]
 
         it "flags a description of blank paragraphs" $
             details (qrMissingMetadata (reportOf (mkActivity "bread" [reference breadFlow]){activityDescription = ["", "   "]}))
-                `shouldBe` ["no description"]
+                `shouldBe` ["the dataset carries no description"]
 
         it "flags a missing classification as info" $
             details (qrMissingMetadata (reportOf (mkActivity "bread" [reference breadFlow]){activityClassification = M.empty}))
-                `shouldBe` ["no classification"]
+                `shouldBe` ["the dataset carries no classification"]
 
         it "flags a missing location as warning" $ do
             let check = qrMissingMetadata (reportOf (mkActivity "bread" [reference breadFlow]){activityLocation = ""})
-            details check `shouldBe` ["no location"]
+            details check `shouldBe` ["the dataset carries no location"]
             severities check `shouldBe` [WarningSev]
 
         it "flags exchanges whose unit is absent from the registry, with a count" $ do


### PR DESCRIPTION
In the quality report, the missing-metadata details read `no description`, `no classification`, `no location`. Displayed under a **Detail** column, `no description` was read by a user as "no description of the finding" — as if the report had nothing to say — rather than "this dataset has no description".

Each detail now names its subject: `the dataset carries no description` (and likewise for classification and location). The unit detail already named its subject and is unchanged. Free-text detail field, so no wire-schema change.