### PR TITLE
Tag log lines with the database they belong to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@
 ## [0.9.3] - 2026-07-15
 
 ### Changed
+- Log lines now say which database they belong to. When several databases
+  load at once their lines used to interleave in one anonymous stream, so a
+  page following one load would show another's progress. Each line of
+  `GET /api/v1/logs` and of the `/api/v1/logs/stream` SSE feed is now a
+  `{db, text}` object — `db` names the database whose operation emitted the
+  line, or is null for lines that belong to no particular one. The terminal
+  output is unchanged.
 - The wire-format revision advertised on `/api/v1/version` is now `3`. Nothing
   breaks: every wire change in this release is additive, and existing clients
   keep working (pyvolca 0.8.x prints at most an upgrade hint). The revision

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Changed
+- Log lines now say which database they belong to. When several databases
+  load at once their lines used to interleave in one anonymous stream, so a
+  page following one load would show another's progress. Each line of
+  `GET /api/v1/logs` and of the `/api/v1/logs/stream` SSE feed is now a
+  `{db, text}` object — `db` names the database whose operation emitted the
+  line, or is null for lines that belong to no particular one. The terminal
+  output is unchanged.
+
 ### Fixed
 - The free-text comment on a SimaPro Products row (Agribalyse uses it for
   modelling notes such as edible fraction and raw-to-cooked ratios) now
@@ -34,13 +43,6 @@
 ## [0.9.3] - 2026-07-15
 
 ### Changed
-- Log lines now say which database they belong to. When several databases
-  load at once their lines used to interleave in one anonymous stream, so a
-  page following one load would show another's progress. Each line of
-  `GET /api/v1/logs` and of the `/api/v1/logs/stream` SSE feed is now a
-  `{db, text}` object — `db` names the database whose operation emitted the
-  line, or is null for lines that belong to no particular one. The terminal
-  output is unchanged.
 - The wire-format revision advertised on `/api/v1/version` is now `3`. Nothing
   breaks: every wire change in this release is additive, and existing clients
   keep working (pyvolca 0.8.x prints at most an upgrade hint). The revision

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -43,6 +43,7 @@ import API.Routes (lcaAPI, lcaServer, volcaOpenApi)
 import App.Env (AppEnv (..))
 import Data.Aeson (encode)
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Char8 as C8
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import Data.String (fromString)
@@ -412,7 +413,11 @@ handleLogStream req respond = do
             let loop !cursor = do
                     (!nextIdx, newLines) <- waitForNewLines cursor
                     forM_ newLines $ \line ->
-                        write (fromString $ "id:" ++ show nextIdx ++ "\ndata:" ++ line ++ "\n\n")
+                        write
+                            ( fromString ("id:" ++ show nextIdx ++ "\ndata:")
+                                <> Builder.lazyByteString (encode line)
+                                <> fromString "\n\n"
+                            )
                     flush
                     loop nextIdx
             loop since

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -746,7 +746,8 @@ loadEcoSpoldDirectory locationAliases dir = do
 
         -- Process all workers in parallel
         startTime <- getCurrentTime
-        results <- mapConcurrently (processWorker startTime isEcoSpold1) (zip [1 ..] workers)
+        scoped <- inheritLogScope
+        results <- mapConcurrently (scoped . processWorker startTime isEcoSpold1) (zip [1 ..] workers)
 
         -- Check for errors from any worker
         let errors = lefts results

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -184,7 +184,7 @@ import Method.Types (
     compartmentMapSize,
     energyDensityMapSize,
  )
-import Progress (ProgressLevel (..), reportError, reportProgress, reportProgressWithTiming)
+import Progress (ProgressLevel (..), reportError, reportProgress, reportProgressWithTiming, withLogScope)
 import qualified Search.BM25 as BM25
 import SharedSolver (SharedSolver, createSharedSolver)
 import qualified SharedSolver
@@ -753,7 +753,7 @@ so serial warming is both lower-peak-memory and faster wall-clock here. A
 failure is logged, not fatal — the on-demand path rebuilds and surfaces it.
 -}
 warmMethodTables :: DatabaseManager -> Text -> Database -> IO ()
-warmMethodTables manager dbName db = void $ forkIO $ do
+warmMethodTables manager dbName db = void $ forkIO $ withLogScope dbName $ do
     collections <- readTVarIO (dmLoadedMethods manager)
     let methods = [(collName, m) | (collName, mc) <- M.toList collections, m <- mcMethods mc]
     t0 <- getCurrentTime
@@ -1091,7 +1091,7 @@ loadOneDatabase ::
     DatabaseManager ->
     DatabaseConfig ->
     IO ()
-loadOneDatabase synonymDB unitConfig noCache otherIndexes loadedDbsVar indexedDbsVar manager dbConfig = do
+loadOneDatabase synonymDB unitConfig noCache otherIndexes loadedDbsVar indexedDbsVar manager dbConfig = withLogScope (dcName dbConfig) $ do
     dbStart <- getCurrentTime
     reportProgress Info $ "[STARTING] Loading database: " <> T.unpack (dcDisplayName dbConfig)
     result <- loadDatabaseFromConfigWithCrossDB dbConfig synonymDB unitConfig noCache otherIndexes (M.map snd (dmGeographies manager))
@@ -1763,7 +1763,7 @@ relinkDatabaseWithMapping ::
     -- | consumer-flow → designated-supplier aliases
     CrossLinking.AliasMap ->
     IO (Either Text RelinkResult)
-relinkDatabaseWithMapping manager dbName depDb aliases = do
+relinkDatabaseWithMapping manager dbName depDb aliases = withLogScope dbName $ do
     loadedDbs <- readTVarIO (dmLoadedDbs manager)
     case M.lookup dbName loadedDbs of
         Nothing -> relinkStaged manager dbName (Just depDb) aliases
@@ -1798,7 +1798,7 @@ page before a database is finalized. @maybeDepDb@ pins a chosen dependency (a
 mapping relink); @aliases@ feeds the supplier-alias map.
 -}
 relinkStaged :: DatabaseManager -> Text -> Maybe Text -> CrossLinking.AliasMap -> IO (Either Text RelinkResult)
-relinkStaged manager dbName maybeDepDb aliases = do
+relinkStaged manager dbName maybeDepDb aliases = withLogScope dbName $ do
     stagedDbs <- readTVarIO (dmStagedDbs manager)
     case M.lookup dbName stagedDbs of
         Nothing -> return $ Left $ "Database not loaded: " <> dbName
@@ -1864,7 +1864,7 @@ relinkDatabaseWith ::
     CrossLinking.AliasMap ->
     Maybe [Text] ->
     IO (Either Text RelinkResult)
-relinkDatabaseWith manager dbName aliases persistedDeps = do
+relinkDatabaseWith manager dbName aliases persistedDeps = withLogScope dbName $ do
     loadedDbs <- readTVarIO (dmLoadedDbs manager)
     case M.lookup dbName loadedDbs of
         Nothing -> relinkStaged manager dbName Nothing aliases
@@ -2014,7 +2014,7 @@ Pre-loads declared dependencies (from TOML config) so cross-DB linking works,
 then loads the target database.
 -}
 loadDatabase :: DatabaseManager -> Text -> IO (Either Text (LoadedDatabase, [DepLoadResult]))
-loadDatabase manager dbName = fmap flattenLoad (try go)
+loadDatabase manager dbName = fmap flattenLoad (try (withLogScope dbName go))
   where
     -- A fresh load parses/reads from disk and can throw. Fold any exception
     -- into the Left this function already returns, so every surface (REST,
@@ -2044,7 +2044,7 @@ When a valid cache exists, reconstructs staged state from the cached Database
 without re-parsing, turning a ~90s operation into ~7s.
 -}
 stageUploadedDatabase :: DatabaseManager -> DatabaseConfig -> IO (Either Text ())
-stageUploadedDatabase manager dbConfig = do
+stageUploadedDatabase manager dbConfig = withLogScope (dcName dbConfig) $ do
     let dbName = dcName dbConfig
     reportProgress Info $ "[STARTING] Staging: " <> T.unpack (dcDisplayName dbConfig)
 
@@ -2174,7 +2174,7 @@ Refuses to unload if any currently-loaded database declares this one as a
 dependency — unloading would leave the dependent's cross-DB links dangling.
 -}
 unloadDatabase :: DatabaseManager -> Text -> IO (Either Text ())
-unloadDatabase manager dbName = do
+unloadDatabase manager dbName = withLogScope dbName $ do
     loadedDbs <- readTVarIO (dmLoadedDbs manager)
 
     case M.lookup dbName loadedDbs of
@@ -2787,7 +2787,7 @@ removeDependencyFromStaged manager dbName depName = do
 
 -- | Finalize a staged database (build matrices and make it ready for queries)
 finalizeDatabase :: DatabaseManager -> Text -> IO (Either Text LoadedDatabase)
-finalizeDatabase manager dbName = do
+finalizeDatabase manager dbName = withLogScope dbName $ do
     stagedDbs <- readTVarIO (dmStagedDbs manager)
 
     case M.lookup dbName stagedDbs of

--- a/src/Progress.hs
+++ b/src/Progress.hs
@@ -38,16 +38,25 @@ module Progress (
     getLogLines,
     waitForNewLines,
 
+    -- * Log scoping
+    withLogScope,
+    inheritLogScope,
+
     -- * Types
     ProgressLevel (..),
+    LogLine (..),
 ) where
 
+import Control.Concurrent (ThreadId, myThreadId)
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Concurrent.STM (TVar, atomically, modifyTVar', newTVarIO, readTVar, readTVarIO, retry)
-import Control.Exception (SomeException, catch, try)
+import Control.Exception (SomeException, bracket_, catch, try)
 import Control.Monad (when)
+import Data.Aeson (ToJSON (toJSON), object, (.=))
+import qualified Data.Map.Strict as M
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
+import Data.Text (Text)
 import Data.Time (diffUTCTime, getCurrentTime)
 import GHC.Stats (RTSStats (..), getRTSStats)
 import System.Directory (doesFileExist, getFileSize)
@@ -71,9 +80,25 @@ data ProgressLevel
       Error
     deriving (Eq, Show)
 
+{- | One buffered log line, tagged with the database whose operation emitted it
+when that operation declared one via 'withLogScope'. The tag is what lets a
+consumer showing one database's progress drop the lines of a concurrent load
+of another.
+-}
+data LogLine = LogLine
+    { llScope :: !(Maybe Text)
+    -- ^ Database name the emitting operation was scoped to, if any
+    , llText :: !String
+    -- ^ Formatted line, exactly as written to stderr
+    }
+    deriving (Eq, Show)
+
+instance ToJSON LogLine where
+    toJSON l = object ["db" .= llScope l, "text" .= llText l]
+
 -- | In-memory log buffer state
 data LogBuffer = LogBuffer
-    { lbLines :: !(Seq String)
+    { lbLines :: !(Seq LogLine)
     -- ^ Buffered log lines
     , lbOffset :: !Int
     -- ^ Absolute index of first line in buffer
@@ -100,8 +125,42 @@ logBufferRef =
                 , lbMaxSize = 1000
                 }
 
+{- | Per-thread log scopes. 'reportProgress' reads the calling thread's entry
+to tag the line; threads outside any 'withLogScope' stay untagged.
+-}
+{-# NOINLINE logScopesRef #-}
+logScopesRef :: TVar (M.Map ThreadId Text)
+logScopesRef = unsafePerformIO $ newTVarIO M.empty
+
+{- | Tag every log line the current thread emits during the action with the
+given scope (a database name). The outermost scope wins: a dependency loaded
+inside another database's load keeps reporting under the database the caller
+named, because that is the load being watched.
+-}
+withLogScope :: Text -> IO a -> IO a
+withLogScope scope action = do
+    tid <- myThreadId
+    existing <- M.lookup tid <$> readTVarIO logScopesRef
+    case existing of
+        Just _ -> action
+        Nothing ->
+            bracket_
+                (atomically $ modifyTVar' logScopesRef (M.insert tid scope))
+                (atomically $ modifyTVar' logScopesRef (M.delete tid))
+                action
+
+{- | Capture the calling thread's log scope as a wrapper for worker actions.
+Scopes are per-thread, so a forked worker starts unscoped — wrapping its action
+with what this returns keeps its lines attributed to the same database.
+-}
+inheritLogScope :: IO (IO a -> IO a)
+inheritLogScope = do
+    tid <- myThreadId
+    scope <- M.lookup tid <$> readTVarIO logScopesRef
+    pure (maybe id withLogScope scope)
+
 -- | Append a line to the global log buffer
-appendLogLine :: String -> IO ()
+appendLogLine :: LogLine -> IO ()
 appendLogLine line = atomically $ modifyTVar' logBufferRef $ \buf ->
     let newLines = lbLines buf Seq.|> line
         len = Seq.length newLines
@@ -118,7 +177,7 @@ appendLogLine line = atomically $ modifyTVar' logBufferRef $ \buf ->
 {- | Get log lines since a given absolute index.
 Returns (nextIndex, newLines).
 -}
-getLogLines :: Int -> IO (Int, [String])
+getLogLines :: Int -> IO (Int, [LogLine])
 getLogLines since = do
     buf <- readTVarIO logBufferRef
     let nextIndex = lbOffset buf + Seq.length (lbLines buf)
@@ -128,7 +187,7 @@ getLogLines since = do
 {- | Block until new lines appear after the given index.
 Returns (nextIndex, newLines). Uses STM retry for efficient blocking.
 -}
-waitForNewLines :: Int -> IO (Int, [String])
+waitForNewLines :: Int -> IO (Int, [LogLine])
 waitForNewLines since = atomically $ do
     buf <- readTVar logBufferRef
     let nextIndex = lbOffset buf + Seq.length (lbLines buf)
@@ -149,8 +208,10 @@ reportProgress level message = do
             Solver -> "[SOLVER] "
             Error -> "[ERROR] "
         formatted = prefix ++ message
-    -- Append to in-memory buffer
-    appendLogLine formatted
+    -- Append to in-memory buffer, tagged with the thread's scope
+    tid <- myThreadId
+    scope <- M.lookup tid <$> readTVarIO logScopesRef
+    appendLogLine (LogLine scope formatted)
     -- Serialize all output to prevent thread-unsafe stderr corruption
     -- Catch encoding errors (safety net for Windows code page issues)
     withMVar progressOutputMutex $ \_ ->

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -11,7 +11,7 @@ import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
 import EcoSpold.Parser2 (streamParseActivityAndFlowsFromFile)
-import Progress (getLogLines)
+import Progress (LogLine (llText), getLogLines)
 import Types
 
 {- | The bundled fixture has a `<comment xml:lang="en">...</comment>` on each
@@ -231,9 +231,10 @@ spec = describe "per-exchange comments" $ do
             (since, _) <- getLogLines 0
             withFormulaFixture $ \_ -> pure ()
             (_, newLines) <- getLogLines since
-            any ("Ignoring <parameter> \"ghost\"" `isInfixOf`) newLines
+            let newTexts = map llText newLines
+            any ("Ignoring <parameter> \"ghost\"" `isInfixOf`) newTexts
                 `shouldBe` True
-            any ("mathematicalRelation" `isInfixOf`) newLines
+            any ("mathematicalRelation" `isInfixOf`) newTexts
                 `shouldBe` False
 
 {- | Synthetic ecospold2 dataset parameterised on the activityType code and

--- a/test/ProgressSpec.hs
+++ b/test/ProgressSpec.hs
@@ -2,16 +2,21 @@
 
 module ProgressSpec (spec) where
 
+import Control.Concurrent.Async (async, wait)
+import Data.List (isInfixOf)
 import Progress (
+    LogLine (..),
     ProgressLevel (..),
     formatBytes,
     formatDuration,
     getLogLines,
+    inheritLogScope,
     reportCacheOperation,
     reportError,
     reportMatrixOperation,
     reportProgress,
     reportSolverOperation,
+    withLogScope,
  )
 import Test.Hspec
 
@@ -100,14 +105,70 @@ spec = do
             (_, newLines) <- getLogLines before
             concatLines newLines `shouldSatisfy` ("[SOLVER]" `isInfixOf`)
 
-concatLines :: [String] -> String
-concatLines = unlines
+    describe "log scoping" $ do
+        it "tags lines emitted inside withLogScope with the database name" $ do
+            let marker = "progress-spec-scoped"
+            found <- emitAndCollect (withLogScope "db-a" (reportProgress Info marker)) marker
+            map llScope found `shouldBe` [Just "db-a"]
 
-isInfixOf :: String -> String -> Bool
-isInfixOf needle haystack = any (needle `isPrefixOf'`) (tails' haystack)
-  where
-    isPrefixOf' [] _ = True
-    isPrefixOf' _ [] = False
-    isPrefixOf' (x : xs) (y : ys) = x == y && isPrefixOf' xs ys
-    tails' [] = [[]]
-    tails' s@(_ : rest) = s : tails' rest
+        it "leaves lines emitted outside any scope untagged" $ do
+            let marker = "progress-spec-unscoped"
+            found <- emitAndCollect (reportProgress Info marker) marker
+            map llScope found `shouldBe` [Nothing]
+
+        it "keeps the outermost scope when scopes nest" $ do
+            let marker = "progress-spec-nested"
+            found <-
+                emitAndCollect
+                    (withLogScope "outer" (withLogScope "inner" (reportProgress Info marker)))
+                    marker
+            map llScope found `shouldBe` [Just "outer"]
+
+        it "restores the unscoped state after the action" $ do
+            let marker = "progress-spec-after"
+            found <-
+                emitAndCollect
+                    ( do
+                        withLogScope "db-a" (pure ())
+                        reportProgress Info marker
+                    )
+                    marker
+            map llScope found `shouldBe` [Nothing]
+
+        it "propagates the scope to a worker thread through inheritLogScope" $ do
+            let marker = "progress-spec-worker"
+            found <-
+                emitAndCollect
+                    ( withLogScope "db-a" $ do
+                        scoped <- inheritLogScope
+                        worker <- async (scoped (reportProgress Info marker))
+                        wait worker
+                    )
+                    marker
+            map llScope found `shouldBe` [Just "db-a"]
+
+        it "leaves a worker thread unscoped without inheritLogScope" $ do
+            let marker = "progress-spec-worker-bare"
+            found <-
+                emitAndCollect
+                    ( withLogScope "db-a" $ do
+                        worker <- async (reportProgress Info marker)
+                        wait worker
+                    )
+                    marker
+            map llScope found `shouldBe` [Nothing]
+
+concatLines :: [LogLine] -> String
+concatLines = unlines . map llText
+
+{- | Emit a marker line, then return the buffered lines carrying it. The log
+buffer is one process-global stream shared with every other spec in this
+suite, so each test reads from the cursor captured before emitting and
+filters on a marker unique to itself.
+-}
+emitAndCollect :: IO () -> String -> IO [LogLine]
+emitAndCollect emit marker = do
+    (cursor, _) <- getLogLines maxBound
+    emit
+    (_, logLines) <- getLogLines cursor
+    pure (filter ((marker `isInfixOf`) . llText) logLines)


### PR DESCRIPTION
## Why

Load two databases at the same time and the live log stream mixes their lines: a page following one load shows the other's progress, up to a wrong "Finalized: <other-db>" while its own database is still parsing. The stream had no notion of which database a line belonged to.

## What

Every buffered log line now names the database whose operation emitted it:

- `withLogScope` tags all lines a thread emits during an operation (load, finalize, relink, stage, unload, background method-table warm-up). The outermost scope wins, so a dependency loaded inside another database's load reports under the load being watched.
- The parser's parallel worker fan-out inherits the caller's scope through `inheritLogScope`.
- `GET /api/v1/logs` and the `/api/v1/logs/stream` SSE feed serve each line as a `{db, text}` object, with `db` null for lines that belong to no particular database. The terminal output is unchanged.

A consumer can now follow one database's progress and drop the concurrent noise; the global view still sees everything.