### PR TITLE
Export method collections as SimaPro CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,19 @@
   databases.
 
 ### Added
+- Method collections can now be exported as SimaPro method CSV, the inverse
+  of the SimaPro method import: `POST /method-collections/{name}/export`,
+  `volca method export NAME --format simapro --out FILE`, and
+  `export_method_collection` in the Python client. The file carries the
+  collection's impact categories, damage categories and
+  normalization/weighting sets, so a method imported in one format (for
+  example an ILCD Environmental Footprint package) can be handed to a
+  SimaPro user. Regionalized factors are written as name-suffixed substances
+  (`Water, FR`) and land occupation/transformation factors under the `Raw`
+  compartment — the conventions SimaPro method files use themselves; whatever
+  the format cannot carry — a factor without a compartment, a factor whose
+  direction the compartment column cannot express, formula scoring sets — is
+  listed in the export warnings instead of being dropped silently.
 - A collection-coverage endpoint:
   `GET /db/{db}/method-collection/{collection}/coverage` reports how many of
   a database's emission and resource flows at least one method of a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   output is unchanged.
 
 ### Fixed
+- SimaPro CSV rows with quoted fields now parse correctly in files with
+  Windows (CRLF) line endings. The carriage return left at the end of each
+  line made the CSV reader give up and fall back to a naive split, which tore
+  a quoted field apart at the separator it contains — a substance or category
+  name like `"Ecotoxicity; freshwater"` landed in the wrong columns.
 - The free-text comment on a SimaPro Products row (Agribalyse uses it for
   modelling notes such as edible fraction and raw-to-cooked ratios) now
   reaches the reference product and coproduct exchanges, so it shows up in

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It loads EcoSpold2, EcoSpold1, SimaPro CSV, ILCD process, and Brightway Excel da
 - **Archive support**: Load databases directly from .zip, .7z, .gz, or .xz archives — no manual extraction
 - **Cross-database linking**: Resolve supplier references across databases, with configurable dependencies and topological load ordering. EcoSpold2 inputs link to a loaded background by exact `activityLinkId` identity (so a partial import resolves against its matching release), falling back to attribute matching — flagged as approximate — when the background is a different release
 - **Cross-DB what-if substitutions**: Swap an upstream activity at any depth — including suppliers in dependency databases — and recompute inventory and impacts through one endpoint
-- **LCIA method collections**: Load ILCD method packages (ZIP or directory), SimaPro method CSV exports, or tabular CSV from config
+- **LCIA method collections**: Load ILCD method packages (ZIP or directory), SimaPro method CSV exports, or tabular CSV from config; export any loaded collection back as SimaPro method CSV
 - **Normalization and weighting**: Batch LCIA computes normalized and weighted scores per category and a single aggregated score (Pt) when NW data is present in the method collection
 - **Contribution analysis**: Per-flow and per-activity contributions to any LCIA score, ranked by share
 - **Flow mapping engine**: 4-step matching cascade (UUID → name → synonym → CAS) with per-strategy coverage statistics
@@ -441,9 +441,10 @@ volca database delete-activities my-db --id UUID_UUID --id UUID_UUID  # delete e
 volca database export my-db --format simapro --out out.csv
 #   formats: simapro | ecospold1 | ecospold2 | ilcd | brightway
 
-# List, upload, delete method collections
+# List, upload, export, delete method collections
 volca method                                    # list (default)
 volca method upload EF-3.1.zip --name "EF 3.1"  # upload
+volca method export ef-31 --format simapro --out ef-31.csv  # export (SimaPro method CSV)
 volca method delete ef-31                        # delete
 ```
 
@@ -498,6 +499,7 @@ volca method delete ef-31                        # delete
 | Upload collection | `POST /method-collections/upload` | `method upload FILE --name NAME` |
 | Load / unload collection | `POST /method-collections/{name}/(load\|unload)` | — |
 | Delete collection | `DELETE /method-collections/{name}` | `method delete NAME` |
+| Export collection (SimaPro CSV) | `POST /method-collections/{name}/export` | `method export NAME --format simapro --out FILE` |
 | **Reference Data** | | |
 | Flow synonyms | `GET /flow-synonyms` (+ load/unload/upload/delete/groups/download) | `synonyms` |
 | Compartment mappings | `GET /compartment-mappings` (+ load/unload/upload/delete) | `compartment-mappings` |

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -525,6 +525,17 @@ warnings arrive in the ``X-Volca-Export-Warnings`` response header
 (percent-encoded, newline-joined) and are surfaced through
 :mod:`warnings`. Raises VoLCAError on an HTTP error.
 
+##### `Client.export_method_collection(name: str, fmt: str = 'simapro') -> bytes`
+
+Export a loaded method collection, returning the serialized bytes.
+
+``fmt`` names the target format; ``simapro`` (SimaPro method CSV) is
+the only format with a method writer today — the engine answers 400
+for the others. Projection warnings (a CF the format cannot carry
+faithfully) arrive in the ``X-Volca-Export-Warnings`` response header
+and are surfaced through :mod:`warnings`. Raises VoLCAError on an
+HTTP error, including a collection that is not loaded.
+
 ##### `Client.export_to_file(fmt: str, out_path: str, db_name: str | None = None) -> None`
 
 Export a database (see :meth:`export_database`) and write it to a file.

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -1875,6 +1875,38 @@ class Client:
             "upload_method_collection",
         )
 
+    def export_method_collection(self, name: str, fmt: str = "simapro") -> bytes:
+        """Export a loaded method collection, returning the serialized bytes.
+
+        ``fmt`` names the target format; ``simapro`` (SimaPro method CSV) is
+        the only format with a method writer today — the engine answers 400
+        for the others. Projection warnings (a CF the format cannot carry
+        faithfully) arrive in the ``X-Volca-Export-Warnings`` response header
+        and are surfaced through :mod:`warnings`. Raises VoLCAError on an
+        HTTP error, including a collection that is not loaded.
+        """
+        fmt_norm = fmt.strip().lower()
+        if fmt_norm not in _EXPORT_FORMATS:
+            raise VoLCAError(
+                f"unknown export format: {fmt!r} "
+                f"(expected {'|'.join(sorted(_EXPORT_FORMATS))})"
+            )
+        resp = self._session.post(
+            f"{self.base_url}/api/v1/method-collections/{name}/export",
+            json={"format": fmt_norm},
+            headers={"Accept": "application/octet-stream"},
+        )
+        if resp.status_code >= 400:
+            raise VoLCAError(
+                f"export_method_collection failed (HTTP {resp.status_code}): "
+                f"{resp.text[:500]}"
+            )
+        header = resp.headers.get("X-Volca-Export-Warnings", "")
+        for line in urllib.parse.unquote(header).split("\n"):
+            if line:
+                warnings.warn(line, stacklevel=2)
+        return resp.content
+
     # -- Reference data (flow synonyms, compartment mappings, units) --
     #
     # Three families, one URL scheme (/api/v1/{kind}/...), so these methods

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -24,6 +24,7 @@ module API.DatabaseHandlers (
     deleteDatabaseHandler,
     deleteActivitiesHandler,
     exportDatabaseHandler,
+    exportMethodHandler,
     uploadDatabaseHandler,
     uploadMethodHandler,
     deleteMethodHandler,
@@ -115,7 +116,7 @@ import Data.Maybe (fromMaybe)
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import Database.Edit (DeleteRequest (..), copyDatabase, deleteActivitiesInDB)
-import Database.Export (parseExportFormat, serializeDatabase)
+import Database.Export (parseExportFormat, serializeDatabase, serializeMethodCollection)
 import qualified Database.Loader as Loader
 import Database.Manager (
     DatabaseLoadStatus (..),
@@ -138,6 +139,7 @@ import Database.Manager (
     getDatabase,
     getDatabaseSetupInfo,
     getFlowSynonymGroups,
+    getMethodCollection,
     listCompartmentMappings,
     listDatabases,
     listFlowSynonyms,
@@ -414,15 +416,34 @@ database that is not loaded — never a 200 with a failure flag.
 exportDatabaseHandler :: Text -> ExportRequest -> AppM (Headers '[Header "X-Volca-Export-Warnings" Text] BinaryContent)
 exportDatabaseHandler dbName req = do
     dbManager <- asks aeDbManager
-    fmt <- either (httpErr err400) pure (parseExportFormat (exrFormat req))
+    fmt <- either (exportErr err400) pure (parseExportFormat (exrFormat req))
     mLoaded <- liftIO (getDatabase dbManager dbName)
-    ld <- maybe (httpErr err404 ("Database not loaded: " <> dbName)) pure mLoaded
-    (bytes, warnings) <- either (httpErr err400) pure (serializeDatabase fmt (ldDatabase ld))
-    pure (addHeader (encodeWarnings warnings) (BinaryContent bytes))
-  where
-    encodeWarnings = T.decodeUtf8 . urlEncode False . T.encodeUtf8 . T.intercalate "\n"
-    httpErr :: ServerError -> Text -> AppM a
-    httpErr status msg = throwError status{errBody = BSL.fromStrict (T.encodeUtf8 msg)}
+    ld <- maybe (exportErr err404 ("Database not loaded: " <> dbName)) pure mLoaded
+    (bytes, warnings) <- either (exportErr err400) pure (serializeDatabase fmt (ldDatabase ld))
+    pure (addHeader (encodeExportWarnings warnings) (BinaryContent bytes))
+
+{- | Export a loaded method collection over the same transport as the database
+export: raw octet-stream body, projection warnings percent-encoded in the
+@X-Volca-Export-Warnings@ header, 400 for a format without a method writer,
+404 for a collection that is not loaded.
+-}
+exportMethodHandler :: Text -> ExportRequest -> AppM (Headers '[Header "X-Volca-Export-Warnings" Text] BinaryContent)
+exportMethodHandler name req = do
+    dbManager <- asks aeDbManager
+    fmt <- either (exportErr err400) pure (parseExportFormat (exrFormat req))
+    mColl <- liftIO (getMethodCollection dbManager name)
+    coll <- maybe (exportErr err404 ("Method collection not loaded: " <> name)) pure mColl
+    (bytes, warnings) <- either (exportErr err400) pure (serializeMethodCollection fmt name coll)
+    pure (addHeader (encodeExportWarnings warnings) (BinaryContent bytes))
+
+{- | Join export warnings for the response header, percent-encoded because
+flow and activity names are arbitrary Unicode.
+-}
+encodeExportWarnings :: [Text] -> Text
+encodeExportWarnings = T.decodeUtf8 . urlEncode False . T.encodeUtf8 . T.intercalate "\n"
+
+exportErr :: ServerError -> Text -> AppM a
+exportErr status msg = throwError status{errBody = BSL.fromStrict (T.encodeUtf8 msg)}
 
 {- | Resolve the hosting upload-size policy into a streaming byte cap.
 Local/CLI mode (no hosting config) is unlimited. A configured limit of 0

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -149,6 +149,9 @@ type LCAAPI =
                 :<|> "method-collections" :> Capture "name" Text :> "unload" :> Post '[JSON] ActivateResponse
                 :<|> "method-collections" :> Capture "name" Text :> Delete '[JSON] ActivateResponse
                 :<|> "method-collections" :> "upload" :> QueryParam "name" Text :> QueryParam "description" Text :> StreamBody NoFraming OctetStream (SourceIO UploadChunk) :> Post '[JSON] UploadResponse
+                -- Export a loaded method collection as raw bytes (SimaPro CSV);
+                -- projection warnings travel percent-encoded in a response header
+                :<|> "method-collections" :> Capture "name" Text :> "export" :> ReqBody '[JSON] ExportRequest :> Post '[OctetStream] (Headers '[Header "X-Volca-Export-Warnings" Text] BinaryContent)
                 -- Reference data endpoints (flow synonyms, compartment mappings, units)
                 :<|> "flow-synonyms" :> Get '[JSON] RefDataListResponse
                 :<|> "flow-synonyms" :> Capture "name" Text :> "load" :> Post '[JSON] ActivateResponse
@@ -2059,6 +2062,7 @@ lcaServer env = hoistServer lcaAPI (runApp env) handlers
             :<|> unloadMethodCollectionHandler
             :<|> DBHandlers.deleteMethodHandler
             :<|> DBHandlers.uploadMethodHandler
+            :<|> DBHandlers.exportMethodHandler
             :<|> DBHandlers.listRefData DBHandlers.FlowSynonyms
             :<|> DBHandlers.loadRefData DBHandlers.FlowSynonyms
             :<|> DBHandlers.unloadRefData DBHandlers.FlowSynonyms

--- a/src/CLI/Client.hs
+++ b/src/CLI/Client.hs
@@ -130,6 +130,8 @@ executeRemoteCommand mgr rc globalOpts cmd = do
             executeUpload mgr rc fmt jp "/api/v1/method-collections/upload" args
         Method (McDelete name) ->
             apiDelete mgr rc ("/api/v1/method-collections/" ++ T.unpack name) >>= output fmt jp
+        Method (McExport args) ->
+            executeRemoteMethodExport mgr rc fmt jp args
         Methods ->
             apiGet mgr rc "/api/v1/methods" >>= output fmt jp
         Synonyms ->
@@ -307,6 +309,19 @@ executeRemoteExport mgr rc fmt jp args = do
             mapM_ (reportProgress Warning . T.unpack) (exportWarnings r)
             BL.writeFile (deaOut args) (responseBody r)
             output fmt jp (Right (object ["database" .= deaDb args, "format" .= deaFormat args, "out" .= deaOut args]))
+
+{- | Remote counterpart of @method export@: same transport as the database
+export, against the method-collections endpoint.
+-}
+executeRemoteMethodExport :: Manager -> RemoteConfig -> OutputFormat -> Maybe Text -> McExportArgs -> IO ()
+executeRemoteMethodExport mgr rc fmt jp args = do
+    resp <- apiPostRaw mgr rc ("/api/v1/method-collections/" ++ T.unpack (meaName args) ++ "/export") (object ["format" .= meaFormat args])
+    case resp of
+        Left err -> reportError err >> exitFailure
+        Right r -> do
+            mapM_ (reportProgress Warning . T.unpack) (exportWarnings r)
+            BL.writeFile (meaOut args) (responseBody r)
+            output fmt jp (Right (object ["collection" .= meaName args, "format" .= meaFormat args, "out" .= meaOut args]))
 
 {- | Decode the @X-Volca-Export-Warnings@ response header: percent-decode, then
 split on the newlines the server joined with. Absent or empty header = no

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -3,7 +3,7 @@
 
 module CLI.Command where
 
-import CLI.Types (CLIConfig (..), Command (..), DatabaseAction (..), DbDeleteArgs (..), DbExportArgs (..), DbRelinkArgs (..), DebugMatricesOptions (..), FlowSubCommand (..), GlobalOptions (..), LCIAOptions (..), MappingOptions (..), MethodAction (..), OutputFormat (..), SearchActivitiesOptions (..), SearchFlowsOptions (..), UploadArgs (..))
+import CLI.Types (CLIConfig (..), Command (..), DatabaseAction (..), DbDeleteArgs (..), DbExportArgs (..), DbRelinkArgs (..), DebugMatricesOptions (..), FlowSubCommand (..), GlobalOptions (..), LCIAOptions (..), MappingOptions (..), McExportArgs (..), MethodAction (..), OutputFormat (..), SearchActivitiesOptions (..), SearchFlowsOptions (..), UploadArgs (..))
 import Config (DatabaseConfig (..), MethodConfig (..))
 import Control.Concurrent.STM (readTVarIO)
 import Data.Aeson (Value, encode, object, toJSON, (.=))
@@ -18,7 +18,7 @@ import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import Database.Edit (DeleteRequest (..), copyDatabase, deleteActivitiesInDB)
-import Database.Export (exportDatabase, parseExportFormat)
+import Database.Export (exportDatabase, exportMethodCollection, parseExportFormat)
 import Database.Manager (DatabaseManager (..), LoadedDatabase (..), RelinkResult (..), addDatabase, addMethodCollection)
 import qualified Database.Manager as DM
 import Database.RelinkMapping (relinkWithMappingFile)
@@ -116,6 +116,8 @@ executeCommand (CLIConfig globalOpts _) cmd manager = do
             executeMcUpload outputFormat manager args
         Method (McDelete name) ->
             executeMcDelete outputFormat manager name
+        Method (McExport args) ->
+            executeMcExport outputFormat manager args
         Methods -> do
             pairs <- DM.getLoadedMethods manager
             let val = toJSON [object ["collection" .= col, "method" .= m] | (col, m) <- pairs]
@@ -576,6 +578,31 @@ executeDbExport fmt manager args =
                                     [ "database" .= deaDb args
                                     , "format" .= deaFormat args
                                     , "out" .= deaOut args
+                                    ]
+
+-- | Execute method-collection export: serialize a loaded collection to a file.
+executeMcExport :: OutputFormat -> DatabaseManager -> McExportArgs -> IO ()
+executeMcExport fmt manager args =
+    case parseExportFormat (meaFormat args) of
+        Left err -> reportError (T.unpack err) >> exitFailure
+        Right mcFmt -> do
+            mColl <- DM.getMethodCollection manager (meaName args)
+            case mColl of
+                Nothing -> do
+                    reportError $ "Method collection '" ++ T.unpack (meaName args) ++ "' not loaded"
+                    exitFailure
+                Just coll -> do
+                    result <- exportMethodCollection mcFmt (meaName args) coll (meaOut args)
+                    case result of
+                        Left err -> reportError (T.unpack err) >> exitFailure
+                        Right warnings -> do
+                            mapM_ (reportProgress Warning . T.unpack) warnings
+                            reportProgress Info $ "Exported " ++ T.unpack (meaName args) ++ " -> " ++ meaOut args
+                            outputResult fmt $
+                                object
+                                    [ "collection" .= meaName args
+                                    , "format" .= meaFormat args
+                                    , "out" .= meaOut args
                                     ]
 
 -- | Execute method delete command

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -92,7 +92,7 @@ commandParser =
             <> OA.command "debug-matrices" (info (debugMatricesParser <**> helper) (progDesc "Export targeted matrix slices for debugging"))
             <> OA.command "export-matrices" (info (exportMatricesParser <**> helper) (progDesc "Export matrices in universal format (Ecoinvent-compatible)"))
             <> OA.command "database" (info (databaseParser <**> helper) (progDesc "Manage databases (list, upload, delete)"))
-            <> OA.command "method" (info (methodParser <**> helper) (progDesc "Manage method collections (list, upload, delete)"))
+            <> OA.command "method" (info (methodParser <**> helper) (progDesc "Manage method collections"))
             <> OA.command "methods" (info (pure Methods <**> helper) (progDesc "List loaded methods (flattened)"))
             <> OA.command "synonyms" (info (pure Synonyms <**> helper) (progDesc "List synonym sources"))
             <> OA.command "compartment-mappings" (info (pure CompartmentMappings <**> helper) (progDesc "List compartment mappings"))

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -152,6 +152,16 @@ exportArgsParser =
         <*> textOpt "format" Nothing "FMT" "Target format: simapro|ecospold1|ecospold2|ilcd|brightway"
         <*> strOpt "out" Nothing "FILE" "Output file path"
 
+{- | Method-export parser: positional collection name, @--format@ keyword,
+@--out@ file path. Mirrors @method export <name> --format <fmt> --out <file>@.
+-}
+mcExportArgsParser :: Parser McExportArgs
+mcExportArgsParser =
+    McExportArgs
+        <$> textArg "NAME" "Name of the loaded method collection to export"
+        <*> textOpt "format" Nothing "FMT" "Target format: simapro (the only method writer today)"
+        <*> strOpt "out" Nothing "FILE" "Output file path"
+
 {- | Delete-by-selection parser: positional DB plus filter options. @--keep@ and
 @--add@ may be repeated; they spare or add individual ProcessIds.
 -}
@@ -178,6 +188,7 @@ methodParser =
                 ( OA.command "list" (info (pure McList) (progDesc "List method collections"))
                     <> OA.command "upload" (info (McUpload <$> uploadArgsParser) (progDesc "Upload a method collection from a local file"))
                     <> OA.command "delete" (info (McDelete <$> deleteNameParser) (progDesc "Delete a method collection"))
+                    <> OA.command "export" (info (McExport <$> mcExportArgsParser <**> helper) (progDesc "Export a loaded method collection to a file (SimaPro CSV)"))
                 )
             )
 

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -126,6 +126,19 @@ data MethodAction
     = McList
     | McUpload UploadArgs
     | McDelete Text
+    | -- | Export a loaded collection to a file: @NAME@, @--format fmt@, @--out file@.
+      McExport McExportArgs
+    deriving (Eq, Show, Generic)
+
+-- | Arguments for @method export@.
+data McExportArgs = McExportArgs
+    { meaName :: Text
+    -- ^ Method collection to export
+    , meaFormat :: Text
+    -- ^ Target format keyword (@--format@): simapro is the only method writer today
+    , meaOut :: FilePath
+    -- ^ Output file path (@--out@)
+    }
     deriving (Eq, Show, Generic)
 
 -- | Shared upload arguments for database and method uploads

--- a/src/Database/Export.hs
+++ b/src/Database/Export.hs
@@ -15,10 +15,13 @@ has no writer and 'UnknownFormat' is not a real target, so both fail loudly
 module Database.Export (
     serializeDatabase,
     exportDatabase,
+    serializeMethodCollection,
+    exportMethodCollection,
     parseExportFormat,
 ) where
 
 import Control.Exception (SomeException, try)
+import Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as BL
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -29,6 +32,8 @@ import Database.Upload (DatabaseFormat (..))
 import qualified EcoSpold.Writer1 as ES1
 import qualified EcoSpold.Writer2 as ES2
 import qualified ILCD.Writer as ILCD
+import Method.Types (MethodCollection)
+import qualified Method.WriterSimaPro as MW
 import qualified SimaPro.Writer as SP
 import Types (Database, toSimpleDatabase)
 import Zip (zipFiles)
@@ -62,6 +67,27 @@ serializeDatabase fmt db = case fmt of
     sdb = toSimpleDatabase db
     noWarn = fmap (,[])
 
+{- | Serialize a loaded method collection in the requested format, paired with
+the projection warnings. SimaPro CSV is the only format with a method writer
+today; every other target fails loudly rather than emit an empty file. The
+name is the collection's own (used as the file-level method name when the
+impact categories don't share a methodology).
+-}
+serializeMethodCollection :: DatabaseFormat -> Text -> MethodCollection -> Either Text (BL.ByteString, [Text])
+serializeMethodCollection fmt name mc = case fmt of
+    SimaProCSV ->
+        first BL.fromStrict
+            <$> MW.serializeSimaProMethodCSV SP.defaultWriterConfig name mc
+    EcoSpold1 -> noMethodWriter "ecospold1"
+    EcoSpold2 -> noMethodWriter "ecospold2"
+    ILCDProcess -> noMethodWriter "ilcd"
+    BrightwayExcel -> noMethodWriter "brightway"
+    OpenLcaJsonLd -> noMethodWriter "openlca"
+    UnknownFormat -> Left "cannot export to an unknown format"
+  where
+    noMethodWriter f =
+        Left ("method collections can only be exported as SimaPro CSV (no method writer for format: " <> f <> ")")
+
 {- | Parse a user-facing export-format name (case- and whitespace-insensitive)
 to a 'DatabaseFormat'. Shared by the CLI and the HTTP handler so the accepted
 spellings and the error message stay in one place.
@@ -80,7 +106,15 @@ warnings so the caller can report them — a local export approximates exactly a
 much as a remote one.
 -}
 exportDatabase :: DatabaseFormat -> Database -> FilePath -> IO (Either Text [Text])
-exportDatabase fmt db path = case serializeDatabase fmt db of
+exportDatabase fmt db path = writeExport path (serializeDatabase fmt db)
+
+-- | File variant of 'serializeMethodCollection', for the CLI.
+exportMethodCollection :: DatabaseFormat -> Text -> MethodCollection -> FilePath -> IO (Either Text [Text])
+exportMethodCollection fmt name mc path = writeExport path (serializeMethodCollection fmt name mc)
+
+-- | Write serialized bytes to @path@, passing the warnings through.
+writeExport :: FilePath -> Either Text (BL.ByteString, [Text]) -> IO (Either Text [Text])
+writeExport path serialized = case serialized of
     Left err -> pure (Left err)
     Right (bytes, warnings) -> either (Left . renderErr) (const (Right warnings)) <$> try (BL.writeFile path bytes)
   where

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -53,6 +53,7 @@ module Database.Manager (
     loadMethodCollectionFromConfig,
     unloadMethodCollection,
     getLoadedMethods,
+    getMethodCollection,
     addMethodCollection,
     removeMethodCollection,
 
@@ -3114,6 +3115,10 @@ getLoadedMethods :: DatabaseManager -> IO [(Text, Method)]
 getLoadedMethods manager = do
     loaded <- readTVarIO (dmLoadedMethods manager)
     return [(collName, m) | (collName, coll) <- M.toList loaded, m <- mcMethods coll]
+
+-- | Look up one loaded method collection by name.
+getMethodCollection :: DatabaseManager -> Text -> IO (Maybe MethodCollection)
+getMethodCollection manager name = M.lookup name <$> readTVarIO (dmLoadedMethods manager)
 
 -- | Add a new method collection to the available list
 addMethodCollection :: DatabaseManager -> MethodConfig -> IO ()

--- a/src/Method/WriterSimaPro.hs
+++ b/src/Method/WriterSimaPro.hs
@@ -119,10 +119,20 @@ checkMethodExportable mc
             )
             (dcImpacts dc)
     checkNW nw = do
-        noLineBreak "normalization-weighting set name" (nwName nw)
+        checkNWName (nwName nw)
         mapM_ (checkNamed ("normalization factor (" <> nwName nw <> ")")) (M.toAscList (nwNormalization nw))
         mapM_ (checkNamed ("weighting factor (" <> nwName nw <> ")")) (M.toAscList (nwWeighting nw))
     checkNamed label (n, v) = noLineBreak "impact category name" n *> finite (label <> " for '" <> n <> "'") v
+
+{- | The NW-set name is written verbatim on its own line, and the parser takes
+the first non-blank line after the marker as the name — a blank name would
+promote the following section keyword (@Normalization@) to the set's name and
+silently drop that section's factors on re-import.
+-}
+checkNWName :: Text -> Either Text ()
+checkNWName name
+    | T.null (T.strip name) = Left "normalization-weighting set has a blank name"
+    | otherwise = noLineBreak "normalization-weighting set name" name
 
 noLineBreak :: Text -> Text -> Either Text ()
 noLineBreak label t

--- a/src/Method/WriterSimaPro.hs
+++ b/src/Method/WriterSimaPro.hs
@@ -1,0 +1,339 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | SimaPro method CSV writer — the inverse of "Method.ParserSimaPro".
+
+Serializes an in-memory 'MethodCollection' to a SimaPro @{methods}@ CSV
+export: one file-level method whose impact categories, damage categories and
+normalization-weighting sets are the collection's. The output is deterministic
+(no timestamp, 'M.toAscList' for the NW maps, CRLF, the same pinned header as
+"SimaPro.Writer") so a write→parse→write cycle is stable, and a
+@parse → write → parse@ round-trip of a SimaPro-origin collection reproduces
+the collection exactly (flow and method UUIDs are name-derived on both sides).
+
+Collections imported from other formats (ILCD, openLCA, tabular CSV) are
+projected onto SimaPro's conventions rather than dropped:
+
+  * a regionalized CF (@'mcfConsumerLocation' = Just loc@) becomes a
+    name-suffixed substance row (@\"Water, FR\"@) — the representation the
+    SimaPro-adapted method distributions themselves use;
+  * a compartment qualifier folds into the subcompartment column
+    (@\"groundwater, long-term\"@), SimaPro's own encoding of long-term;
+  * the land media (@land occupation@, @land transformation@) file under
+    SimaPro's @Raw@ compartment, where every SimaPro method distribution
+    keeps its occupation and transformation flows — the from/to semantics
+    (and hence the flow's direction) live in the flow name there, so these
+    rows are exempt from the direction check below;
+  * the CAS number is zero-padded back to SimaPro's 6-digit first segment.
+
+What the format cannot carry travels as an explicit warning, never silently:
+a CF with no compartment (emitted with empty compartment columns), a CF whose
+direction contradicts its compartment (SimaPro derives direction from the
+compartment column alone), an NW set with no factors, and formula scoring
+sets (config-side, not part of the format). Anything that would corrupt the
+file structure or re-import wrongly (a non-finite value, a line break inside
+a field, a file-level name that collides with a section marker) is rejected
+outright by 'checkMethodExportable'.
+-}
+module Method.WriterSimaPro (
+    serializeSimaProMethodCSV,
+    checkMethodExportable,
+) where
+
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+
+import Method.Types (
+    Compartment (..),
+    DamageCategory (..),
+    FlowDirection (..),
+    Method (..),
+    MethodCF (..),
+    MethodCollection (..),
+    NormWeightSet (..),
+ )
+import SimaPro.Writer (WriterConfig, escapeField, formatAmount, headerLines)
+
+{- | Serialize a 'MethodCollection' to SimaPro method CSV bytes (UTF-8, CRLF),
+paired with the projection warnings. The file-level method name is the
+methodology shared by every impact category when there is one, otherwise the
+supplied collection name. Fails on a collection the format cannot represent
+without corruption ('checkMethodExportable').
+-}
+serializeSimaProMethodCSV :: WriterConfig -> Text -> MethodCollection -> Either Text (BS.ByteString, [Text])
+serializeSimaProMethodCSV cfg collectionName mc = do
+    checkMethodExportable mc
+    let fileName = fileLevelName collectionName mc
+    checkFileLevelName fileName
+    let (catBlocks, issues) = unzip (map categoryBlock (mcMethods mc))
+        (nwBlocks, nwWarnings) = unzip (map nwBlock (mcNormWeightSets mc))
+        allLines =
+            header cfg
+                ++ metaBlock fileName mc
+                ++ concat catBlocks
+                ++ concatMap damageBlock (mcDamageCategories mc)
+                ++ concat nwBlocks
+                ++ ["End"]
+        warnings = issueWarnings (concat issues) ++ concat nwWarnings ++ scoringSetWarning mc
+    pure (TE.encodeUtf8 (T.intercalate crlf allLines <> crlf), warnings)
+
+-- ============================================================================
+-- Exportability guard
+-- ============================================================================
+
+{- | Reject a collection the SimaPro method format cannot represent without
+silent corruption on re-import: no impact categories at all, a non-finite
+value (its literal would re-import as a parse failure or a wrong number), or
+a line break inside a field (the parser splits on physical lines before CSV
+parsing, so quoting cannot save it — same rule as the process writer).
+-}
+checkMethodExportable :: MethodCollection -> Either Text ()
+checkMethodExportable mc
+    | null (mcMethods mc) = Left "method collection has no impact categories"
+    | otherwise = do
+        mapM_ checkMethod (mcMethods mc)
+        mapM_ checkDamage (mcDamageCategories mc)
+        mapM_ checkNW (mcNormWeightSets mc)
+  where
+    checkMethod m = do
+        mapM_ (noLineBreak "impact category name") [methodName m]
+        mapM_ (noLineBreak "impact category unit") [methodUnit m]
+        mapM_ (checkCF (methodName m)) (methodFactors m)
+    checkCF cat cf = do
+        finite ("characterization factor for '" <> mcfFlowName cf <> "' in '" <> cat <> "'") (mcfValue cf)
+        mapM_ (noLineBreak "flow name") [mcfFlowName cf]
+        mapM_ (noLineBreak "flow unit") [mcfUnit cf]
+        mapM_ (noLineBreak "CAS number") (mcfCAS cf)
+        mapM_ (noLineBreak "consumer location") (mcfConsumerLocation cf)
+        mapM_ (\(Compartment a b c) -> mapM_ (noLineBreak "compartment") [a, b, c]) (mcfCompartment cf)
+    checkDamage dc = do
+        mapM_ (noLineBreak "damage category name") [dcName dc]
+        mapM_ (noLineBreak "damage category unit") [dcUnit dc]
+        mapM_
+            ( \(n, v) -> do
+                noLineBreak "damage impact name" n
+                finite ("damage factor for '" <> n <> "' in '" <> dcName dc <> "'") v
+            )
+            (dcImpacts dc)
+    checkNW nw = do
+        noLineBreak "normalization-weighting set name" (nwName nw)
+        mapM_ (checkNamed ("normalization factor (" <> nwName nw <> ")")) (M.toAscList (nwNormalization nw))
+        mapM_ (checkNamed ("weighting factor (" <> nwName nw <> ")")) (M.toAscList (nwWeighting nw))
+    checkNamed label (n, v) = noLineBreak "impact category name" n *> finite (label <> " for '" <> n <> "'") v
+
+noLineBreak :: Text -> Text -> Either Text ()
+noLineBreak label t
+    | T.any (\c -> c == '\n' || c == '\r') t =
+        Left ("field contains a line break (" <> label <> "): " <> T.take 60 t)
+    | otherwise = Right ()
+
+finite :: Text -> Double -> Either Text ()
+finite label v
+    | isNaN v || isInfinite v = Left ("non-finite " <> label)
+    | otherwise = Right ()
+
+{- | The file-level @Name@ line is read back verbatim as one physical line, and
+the parser scans method-level metadata for section markers — a name that /is/
+a marker would derail the state machine, so it is rejected rather than
+written.
+-}
+checkFileLevelName :: Text -> Either Text ()
+checkFileLevelName name = do
+    noLineBreak "method name" name
+    if name `elem` ["Impact category", "Damage category"]
+        || "Normalization-Weighting set" `T.isPrefixOf` name
+        || "Normalisation-Weighting set" `T.isPrefixOf` name
+        then Left ("method name collides with a SimaPro section marker: " <> name)
+        else Right ()
+
+-- ============================================================================
+-- Blocks
+-- ============================================================================
+
+crlf :: Text
+crlf = "\r\n"
+
+-- | Join fields with the semicolon delimiter (each escaped).
+spRow :: [Text] -> Text
+spRow = T.intercalate ";" . map escapeField
+
+-- | The pinned header block with the @{methods}@ file-type line.
+header :: WriterConfig -> [Text]
+header cfg = case headerLines cfg of
+    (banner : rest) -> banner : "{methods}" : rest
+    [] -> ["{methods}"]
+
+{- | File-level name: the methodology every impact category agrees on when
+there is exactly one, otherwise the collection's own name. Preserves the
+original SimaPro @Name@ across an upload→export cycle without inventing one
+for mixed or ILCD-origin collections.
+-}
+fileLevelName :: Text -> MethodCollection -> Text
+fileLevelName fallback mc =
+    case S.toList (S.fromList (map methodMethodology (mcMethods mc))) of
+        [Just m] -> m
+        _ -> fallback
+
+{- | Method-level metadata: the @Name@ the parser reads back as the
+methodology, plus the Use-flags SimaPro expects, reflecting what the
+collection actually carries. Key and value each sit on their own line.
+-}
+metaBlock :: Text -> MethodCollection -> [Text]
+metaBlock fileName mc =
+    ["Method", "", "Name", fileName, ""]
+        ++ ["Use Damage Assessment", yesNo (not (null (mcDamageCategories mc))), ""]
+        ++ ["Use Normalization", yesNo hasNorm, ""]
+        ++ ["Use Weighting", yesNo hasWeight, ""]
+        ++ (if hasWeight then ["Weighting unit", "Pt", ""] else [])
+  where
+    yesNo b = if b then "Yes" else "No"
+    hasNorm = not (all (M.null . nwNormalization) (mcNormWeightSets mc))
+    hasWeight = not (all (M.null . nwWeighting) (mcNormWeightSets mc))
+
+-- | One @Impact category@ block, plus the per-CF representation issues.
+categoryBlock :: Method -> ([Text], [CFIssue])
+categoryBlock m =
+    ( ["Impact category", spRow [methodName m, methodUnit m], "", "Substances"]
+        ++ cfLines
+        ++ [""]
+    , concat issues
+    )
+  where
+    (cfLines, issues) = unzip (map cfRow (methodFactors m))
+
+{- | What a substance row cannot carry faithfully. Collected per CF, then
+summarized into a bounded number of warnings ('issueWarnings').
+-}
+data CFIssue
+    = -- | No compartment: emitted with empty compartment columns.
+      NoCompartment !Text
+    | {- | Direction contradicts the compartment column, which is what SimaPro
+      derives direction from — a re-import flips it.
+      -}
+      DirectionLost !Text
+
+{- | One substance row:
+@compartment;subcompartment;name;cas;value;unit@. A regionalized CF gets the
+SimaPro name suffix; the CAS is padded back to SimaPro's 6-digit first
+segment.
+-}
+cfRow :: MethodCF -> (Text, [CFIssue])
+cfRow cf = (line, noComp ++ dirLost)
+  where
+    (compCol, subCol) = compartmentColumns (mcfCompartment cf)
+    name = mcfFlowName cf <> maybe "" (", " <>) (mcfConsumerLocation cf)
+    line =
+        spRow
+            [ compCol
+            , subCol
+            , name
+            , maybe "" padCAS (mcfCAS cf)
+            , formatAmount (mcfValue cf)
+            , mcfUnit cf
+            ]
+    noComp = case mcfCompartment cf of
+        Nothing -> [NoCompartment name]
+        Just _ -> []
+    impliedDirection =
+        let lc = T.toLower compCol
+         in if lc == "resources" || "raw" `T.isPrefixOf` lc then Input else Output
+    -- Land rows are exempt: filing them under Raw is the format's own
+    -- convention (see the module header), not a representation loss.
+    landProjected = case mcfCompartment cf of
+        Just (Compartment medium _ _) -> isLandMedium medium
+        Nothing -> False
+    dirLost = [DirectionLost name | not landProjected, impliedDirection /= mcfDirection cf]
+
+{- | Project a compartment onto SimaPro's two columns: the known media get
+their SimaPro spelling, an unknown medium passes through verbatim, a
+qualifier folds into the subcompartment (SimaPro's own long-term encoding),
+and an empty subcompartment becomes @(unspecified)@.
+-}
+compartmentColumns :: Maybe Compartment -> (Text, Text)
+compartmentColumns Nothing = ("", "")
+compartmentColumns (Just (Compartment medium sub qualifier)) = (compCol, subCol)
+  where
+    compCol = case T.toLower medium of
+        "air" -> "Air"
+        "water" -> "Water"
+        "soil" -> "Soil"
+        "natural resource" -> "Raw"
+        _ | isLandMedium medium -> "Raw"
+        _ -> medium
+    subWithQualifier
+        | T.null qualifier = sub
+        | T.null sub = qualifier
+        | otherwise = sub <> ", " <> qualifier
+    subCol = if T.null subWithQualifier then "(unspecified)" else subWithQualifier
+
+-- | The ILCD land media, which SimaPro files under its @Raw@ compartment.
+isLandMedium :: Text -> Bool
+isLandMedium medium = T.toLower medium `elem` ["land occupation", "land transformation"]
+
+{- | Pad a normalized CAS ("124-38-9") back to SimaPro's 6-digit first segment
+("000124-38-9"). A value without dashes is not CAS-shaped and passes through.
+-}
+padCAS :: Text -> Text
+padCAS cas = case T.splitOn "-" cas of
+    (first : rest@(_ : _)) -> T.intercalate "-" (T.justifyRight 6 '0' first : rest)
+    _ -> cas
+
+-- | One @Damage category@ block.
+damageBlock :: DamageCategory -> [Text]
+damageBlock dc =
+    ["Damage category", spRow [dcName dc, dcUnit dc], "", "Impact categories"]
+        ++ [spRow [n, formatAmount v] | (n, v) <- dcImpacts dc]
+        ++ [""]
+
+{- | One @Normalization-Weighting set@ block. A set with no factors at all is
+skipped with a warning: the parser drops such a set on re-import, so writing
+it would only fake fidelity.
+-}
+nwBlock :: NormWeightSet -> ([Text], [Text])
+nwBlock nw
+    | M.null (nwNormalization nw) && M.null (nwWeighting nw) =
+        ([], ["normalization-weighting set '" <> nwName nw <> "' has no factors; skipped"])
+    | otherwise =
+        ( ["Normalization-Weighting set", nwName nw, ""]
+            ++ section "Normalization" (nwNormalization nw)
+            ++ section "Weighting" (nwWeighting nw)
+        , []
+        )
+  where
+    section title m
+        | M.null m = []
+        | otherwise = title : [spRow [n, formatAmount v] | (n, v) <- M.toAscList m] ++ [""]
+
+-- ============================================================================
+-- Warnings
+-- ============================================================================
+
+-- | Summarize the per-CF issues into one bounded warning per kind.
+issueWarnings :: [CFIssue] -> [Text]
+issueWarnings issues =
+    summarize
+        "CF(s) without compartment, emitted with empty compartment columns"
+        [n | NoCompartment n <- issues]
+        ++ summarize
+            "CF(s) whose direction the compartment column cannot express; a re-import derives the opposite direction"
+            [n | DirectionLost n <- issues]
+  where
+    summarize label names =
+        let distinct = S.toAscList (S.fromList names)
+         in [ label
+                <> ": "
+                <> T.pack (show (length distinct))
+                <> " — e.g. "
+                <> T.intercalate ", " (take 5 distinct)
+            | not (null distinct)
+            ]
+
+-- | Formula scoring sets are configuration, not part of the SimaPro format.
+scoringSetWarning :: MethodCollection -> [Text]
+scoringSetWarning mc =
+    [ "formula scoring sets are not part of the SimaPro method CSV format; not exported"
+    | not (null (mcScoringSets mc))
+    ]

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -399,13 +399,21 @@ parseAmount decimalSep bs
 -- | Split a CSV line by delimiter, respecting RFC 4180 quoted fields.
 splitCSV :: Char -> BS.ByteString -> [BS.ByteString]
 splitCSV delim bs =
-    let opts =
+    -- 'BS8.lines' leaves the CR of a CRLF terminator on the line. A lone
+    -- trailing CR makes cassava's incremental parser wait for the LF of a
+    -- CRLF and fail with "not enough input" at end of line (observably, its
+    -- success even varies with the optimization level), silently degrading
+    -- every CRLF row to the naive split below — which tears quoted fields
+    -- apart. Strip it before parsing: it is line-terminator residue, never
+    -- field data.
+    let clean = BS8.dropWhileEnd (== '\r') bs
+        opts =
             Csv.defaultDecodeOptions
                 { Csv.decDelimiter = fromIntegral (fromEnum delim)
                 }
-     in case Csv.decodeWith opts Csv.NoHeader (BL.fromStrict bs) of
+     in case Csv.decodeWith opts Csv.NoHeader (BL.fromStrict clean) of
             Right rows | not (V.null rows) -> V.toList (V.head rows)
-            _ -> BS8.split delim bs -- fallback to naive on parse error
+            _ -> BS8.split delim clean -- fallback to naive on parse error
 
 -- | Parse a parameter row: name;value_or_expression;...
 parseParamRow :: SimaProConfig -> BS.ByteString -> Maybe (Text, Text)

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -69,9 +69,10 @@ module SimaPro.Writer (
     serializeSimaProCSV,
     checkSimaProExportable,
 
-    -- * Pure helpers (exposed for testing)
+    -- * Pure helpers (exposed for testing and for "Method.WriterSimaPro")
     escapeField,
     formatAmount,
+    headerLines,
 ) where
 
 import qualified Data.ByteString as BS

--- a/test/MethodWriterSimaProSpec.hs
+++ b/test/MethodWriterSimaProSpec.hs
@@ -186,6 +186,13 @@ spec = describe "Method.WriterSimaPro" $ do
             let m = (mkMethod "Climate change" []){methodMethodology = Just "Impact category"}
             serialize (collection [m]) `shouldSatisfy` isRefused "marker"
 
+        it "rejects a blank normalization-weighting set name" $ do
+            -- A blank name line would make the re-import take the next section
+            -- keyword as the name and drop that section's factors.
+            let nw = NormWeightSet "  " (M.singleton "Climate change" 1.0) M.empty
+                mc = MethodCollection [mkMethod "Climate change" []] [] [nw] []
+            serialize mc `shouldSatisfy` isRefused "blank name"
+
     describe "format dispatch (Database.Export)" $ do
         it "refuses non-SimaPro formats with a clear message" $ do
             let mc = collection [mkMethod "Climate change" []]

--- a/test/MethodWriterSimaProSpec.hs
+++ b/test/MethodWriterSimaProSpec.hs
@@ -1,0 +1,199 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Tests for the SimaPro method CSV writer ("Method.WriterSimaPro").
+module MethodWriterSimaProSpec (spec) where
+
+import Data.Bifunctor (first)
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Data.UUID (nil)
+import Test.Hspec
+
+import Database.Export (serializeMethodCollection)
+import Database.Upload (DatabaseFormat (..))
+import Method.ParserSimaPro (isSimaProMethodCSV, parseSimaProMethodCSVBytes)
+import Method.Types
+import Method.WriterSimaPro (serializeSimaProMethodCSV)
+import SimaPro.Writer (defaultWriterConfig)
+
+mkCF :: Text -> Maybe Compartment -> Double -> MethodCF
+mkCF name comp v =
+    MethodCF
+        { mcfFlowRef = nil
+        , mcfFlowName = name
+        , mcfDirection = Output
+        , mcfValue = v
+        , mcfCompartment = comp
+        , mcfCAS = Nothing
+        , mcfUnit = "kg"
+        , mcfConsumerLocation = Nothing
+        }
+
+mkMethod :: Text -> [MethodCF] -> Method
+mkMethod name cfs =
+    Method
+        { methodId = nil
+        , methodName = name
+        , methodDescription = Nothing
+        , methodUnit = "kg eq"
+        , methodCategory = name
+        , methodMethodology = Nothing
+        , methodFactors = cfs
+        }
+
+collection :: [Method] -> MethodCollection
+collection ms = MethodCollection ms [] [] []
+
+-- | Serialize with a fixed collection name, decoding the bytes for inspection.
+serialize :: MethodCollection -> Either Text (Text, [Text])
+serialize mc =
+    first TE.decodeUtf8
+        <$> serializeSimaProMethodCSV defaultWriterConfig "Test collection" mc
+
+spec :: Spec
+spec = describe "Method.WriterSimaPro" $ do
+    describe "round-trip with the SimaPro method parser" $ do
+        it "parse → write → parse reproduces the collection exactly" $ do
+            raw <- BS.readFile "test/data/simapro_method.csv"
+            case parseSimaProMethodCSVBytes raw of
+                Left err -> expectationFailure ("fixture parse failed: " <> err)
+                Right c1 ->
+                    case serializeSimaProMethodCSV defaultWriterConfig "fallback" c1 of
+                        Left err -> expectationFailure ("write failed: " <> T.unpack err)
+                        Right (bytes, warnings) -> do
+                            warnings `shouldBe` []
+                            case parseSimaProMethodCSVBytes bytes of
+                                Left err -> expectationFailure ("re-parse failed: " <> err)
+                                Right c2 -> c2 `shouldBe` c1
+
+        it "write → parse → write is byte-stable and self-detecting" $ do
+            raw <- BS.readFile "test/data/simapro_method.csv"
+            case parseSimaProMethodCSVBytes raw of
+                Left err -> expectationFailure ("fixture parse failed: " <> err)
+                Right c1 ->
+                    case serializeSimaProMethodCSV defaultWriterConfig "fallback" c1 of
+                        Left err -> expectationFailure ("write failed: " <> T.unpack err)
+                        Right (b1, _) -> do
+                            isSimaProMethodCSV b1 `shouldBe` True
+                            case parseSimaProMethodCSVBytes b1 of
+                                Left err -> expectationFailure ("re-parse failed: " <> err)
+                                Right c2 ->
+                                    case serializeSimaProMethodCSV defaultWriterConfig "fallback" c2 of
+                                        Left err -> expectationFailure ("re-write failed: " <> T.unpack err)
+                                        Right (b2, _) -> b2 `shouldBe` b1
+
+        it "keeps the original file-level Name via the shared methodology" $ do
+            raw <- BS.readFile "test/data/simapro_method.csv"
+            case parseSimaProMethodCSVBytes raw of
+                Left err -> expectationFailure ("fixture parse failed: " <> err)
+                Right c1 ->
+                    case serialize c1 of
+                        Left err -> expectationFailure (T.unpack err)
+                        Right (out, _) -> out `shouldSatisfy` T.isInfixOf "\r\nTest EF Method\r\n"
+
+        it "a method name containing the delimiter survives the round-trip" $ do
+            let m = mkMethod "Ecotoxicity; freshwater" [mkCF "Zinc" (Just (Compartment "water" "" "")) 2.5]
+            case serialize (collection [m]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (out, _) ->
+                    case parseSimaProMethodCSVBytes (TE.encodeUtf8 out) of
+                        Left err -> expectationFailure ("re-parse failed: " <> err)
+                        Right c2 -> map methodName (mcMethods c2) `shouldBe` ["Ecotoxicity; freshwater"]
+
+    describe "projections onto SimaPro conventions" $ do
+        it "writes a regionalized CF as a name-suffixed substance row" $ do
+            let cf = (mkCF "Water" (Just (Compartment "natural resource" "in water" "")) 42.95){mcfDirection = Input, mcfConsumerLocation = Just "FR"}
+            case serialize (collection [mkMethod "Water use" [cf]]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (out, warnings) -> do
+                    warnings `shouldBe` []
+                    out `shouldSatisfy` T.isInfixOf "Raw;in water;Water, FR;;42.95;kg"
+                    case parseSimaProMethodCSVBytes (TE.encodeUtf8 out) of
+                        Left err -> expectationFailure ("re-parse failed: " <> err)
+                        Right c2 -> do
+                            let cfs = concatMap methodFactors (mcMethods c2)
+                            map mcfFlowName cfs `shouldBe` ["Water, FR"]
+                            map mcfConsumerLocation cfs `shouldBe` [Nothing]
+
+        it "folds a compartment qualifier into the subcompartment column" $ do
+            let cf = mkCF "Arsenic" (Just (Compartment "water" "groundwater" "long-term")) 1.5
+            case serialize (collection [mkMethod "Ecotoxicity" [cf]]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (out, _) -> out `shouldSatisfy` T.isInfixOf "Water;groundwater, long-term;Arsenic"
+
+        it "files land flows under Raw without a direction warning" $ do
+            let occ = (mkCF "Occupation, annual crop" (Just (Compartment "land occupation" "" "")) 50.2){mcfDirection = Input}
+                to = mkCF "Transformation, to annual crop" (Just (Compartment "land transformation" "" "")) 1.1
+            case serialize (collection [mkMethod "Land use" [occ, to]]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (out, warnings) -> do
+                    warnings `shouldBe` []
+                    out `shouldSatisfy` T.isInfixOf "Raw;(unspecified);Occupation, annual crop"
+                    out `shouldSatisfy` T.isInfixOf "Raw;(unspecified);Transformation, to annual crop"
+
+        it "pads a normalized CAS back to SimaPro's 6-digit first segment" $ do
+            let cf = (mkCF "Carbon dioxide" (Just (Compartment "air" "" "")) 1){mcfCAS = Just "124-38-9"}
+            case serialize (collection [mkMethod "Climate change" [cf]]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (out, _) -> out `shouldSatisfy` T.isInfixOf "Air;(unspecified);Carbon dioxide;000124-38-9;1;kg"
+
+    describe "warnings (never silent)" $ do
+        it "warns when a CF has no compartment and still emits the row" $ do
+            let cf = mkCF "Mystery flow" Nothing 3
+            case serialize (collection [mkMethod "Climate change" [cf]]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (out, warnings) -> do
+                    out `shouldSatisfy` T.isInfixOf ";;Mystery flow;;3;kg"
+                    warnings `shouldSatisfy` any (T.isInfixOf "without compartment")
+
+        it "warns when the compartment implies the opposite direction" $ do
+            let cf = (mkCF "Occupation, arable" (Just (Compartment "air" "" "")) 1){mcfDirection = Input}
+            case serialize (collection [mkMethod "Land use" [cf]]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (_, warnings) -> warnings `shouldSatisfy` any (T.isInfixOf "direction")
+
+        it "skips a normalization-weighting set with no factors, with a warning" $ do
+            let mc = MethodCollection [mkMethod "Climate change" []] [] [NormWeightSet "Empty set" M.empty M.empty] []
+            case serialize mc of
+                Left err -> expectationFailure (T.unpack err)
+                Right (out, warnings) -> do
+                    out `shouldNotSatisfy` T.isInfixOf "Empty set"
+                    warnings `shouldSatisfy` any (T.isInfixOf "no factors")
+
+        it "warns that formula scoring sets are not exported" $ do
+            let ss = ScoringSet "EF score" "Pt" M.empty M.empty M.empty M.empty M.empty M.empty Nothing
+                mc = MethodCollection [mkMethod "Climate change" []] [] [] [ss]
+            case serialize mc of
+                Left err -> expectationFailure (T.unpack err)
+                Right (_, warnings) -> warnings `shouldSatisfy` any (T.isInfixOf "scoring sets")
+
+    describe "exportability guard" $ do
+        it "rejects an empty collection" $
+            serialize (collection []) `shouldSatisfy` isRefused "no impact categories"
+
+        it "rejects a non-finite characterization factor" $ do
+            let cf = mkCF "Carbon dioxide" (Just (Compartment "air" "" "")) (0 / 0)
+            serialize (collection [mkMethod "Climate change" [cf]]) `shouldSatisfy` isRefused "non-finite"
+
+        it "rejects a line break inside a field" $ do
+            let cf = mkCF "Carbon\ndioxide" (Just (Compartment "air" "" "")) 1
+            serialize (collection [mkMethod "Climate change" [cf]]) `shouldSatisfy` isRefused "line break"
+
+        it "rejects a file-level name that collides with a section marker" $ do
+            let m = (mkMethod "Climate change" []){methodMethodology = Just "Impact category"}
+            serialize (collection [m]) `shouldSatisfy` isRefused "marker"
+
+    describe "format dispatch (Database.Export)" $ do
+        it "refuses non-SimaPro formats with a clear message" $ do
+            let mc = collection [mkMethod "Climate change" []]
+            case serializeMethodCollection ILCDProcess "EF" mc of
+                Left err -> err `shouldSatisfy` T.isInfixOf "SimaPro CSV"
+                Right _ -> expectationFailure "expected a Left for a format without a method writer"
+
+isRefused :: Text -> Either Text a -> Bool
+isRefused needle result = case result of
+    Left err -> needle `T.isInfixOf` err
+    Right _ -> False

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -665,6 +665,12 @@ spec = do
         it "strips quotes and embeds delimiter in field" $
             splitCSV ';' "\"a;b\";c" `shouldBe` ["a;b", "c"]
 
+        -- Lines split out of a CRLF file keep their trailing CR; it must not
+        -- degrade quoted-field parsing to the naive split (which tears the
+        -- quoted field apart).
+        it "still strips quotes when the line ends with the CR of a CRLF file" $
+            splitCSV ';' "\"a;b\";c\r" `shouldBe` ["a;b", "c"]
+
         it "splits comma-delimited row" $
             splitCSV ',' "x,y,z" `shouldBe` ["x", "y", "z"]
 

--- a/volca.cabal
+++ b/volca.cabal
@@ -61,6 +61,7 @@ library
                      , Method.Parser.OlcaSchema
                      , Method.ParserCSV
                      , Method.ParserSimaPro
+                     , Method.WriterSimaPro
                      , Method.ParserNW
                      , Method.Mapping
                      , Method.Patch
@@ -295,6 +296,7 @@ test-suite lca-tests
                      , LicensesSpec
                      , GeographiesSpec
                      , MethodUploadSpec
+                     , MethodWriterSimaProSpec
                      , AuthSpec
                      , CLISpec
                      , RoutesSpec


### PR DESCRIPTION
A loaded LCIA method collection can now be exported as a SimaPro method CSV — the exact inverse of the existing SimaPro method import. A method imported in one format, for example the ILCD Environmental Footprint 3.1 package, can be handed to a SimaPro user.

**What it does.** `Method.WriterSimaPro` serializes a collection's impact categories, damage categories and normalization/weighting sets to a `{methods}` CSV, deterministically (pinned header, no timestamp), and is wired through `Database.Export` so future method writers slot in beside the database ones. Surfaces: `POST /api/v1/method-collections/{name}/export` (same transport as the database export, warnings in `X-Volca-Export-Warnings`), `volca method export NAME --format simapro --out FILE` in local and remote mode, and `export_method_collection` in the Python client.

**Faithfulness.** Collections imported from other formats are projected onto SimaPro's own conventions: regionalized factors become name-suffixed substances (`water, FR`), compartment qualifiers fold into the subcompartment, land occupation/transformation flows file under `Raw`. What the format cannot carry is reported in the export warnings, never dropped silently; what would corrupt a re-import (non-finite values, line breaks, a name colliding with a section marker) is rejected.

**Validation.** Parse → write → parse of a real 25-method, 233k-factor SimaPro method file reproduces the collection exactly and is byte-stable; the ILCD EF 3.1 package (25 methods, 319 575 factors) exports and re-parses with every factor preserved and zero warnings.

**Drive-by fix.** The shared SimaPro row splitter silently degraded to a naive split on every line of a CRLF file (a lone trailing CR makes cassava demand more input), tearing quoted fields apart. The CR is stripped before parsing; regression test added.