### PR TITLE
Export method collections as columnar CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   output is unchanged.
 
 ### Fixed
+- Numbers in columnar CSV method files and normalization/weighting CSV
+  files now parse exactly. The previous number parser drifted in the last
+  decimal (`1.2227e-3` came back as `1.2227000000000002e-3`) — every such
+  characterization or normalization factor was off by one ulp.
 - SimaPro CSV rows with quoted fields now parse correctly in files with
   Windows (CRLF) line endings. The carriage return left at the end of each
   line made the CSV reader give up and fall back to a naive split, which tore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@
 - Numbers in columnar CSV method files and normalization/weighting CSV
   files now parse exactly. The previous number parser drifted in the last
   decimal (`1.2227e-3` came back as `1.2227000000000002e-3`) — every such
-  characterization or normalization factor was off by one ulp.
+  characterization or normalization factor was off by one ulp. A malformed
+  value (`1,23` once imported as `1.0`, truncated at the comma) or a
+  non-finite one (`NaN`) is now rejected instead of imported as a wrong
+  number.
 - SimaPro CSV rows with quoted fields now parse correctly in files with
   Windows (CRLF) line endings. The carriage return left at the end of each
   line made the CSV reader give up and fall back to a naive split, which tore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,21 @@
   databases.
 
 ### Added
+- Method collections can be exported as columnar CSV — one column per
+  impact category, one row per substance: the file you open in a
+  spreadsheet. `POST /api/v1/method-collections/{name}/export` with
+  `{"format": "csv"}`, `volca method export NAME --format csv`, or
+  pyvolca's `export_method_collection(name, fmt="csv")`. Anything the
+  format cannot carry (flow directions the compartment does not imply,
+  damage categories, normalization/weighting sets, formula scoring sets)
+  is reported in export warnings, never dropped silently.
+- The columnar CSV method format itself grew the columns real methods
+  need, read back by the parser and emitted by the writer: optional `cas`
+  and `unit` key columns (real methods mix kg, m3 and MJ flows inside one
+  category), and a `top/sub/qualifier` compartment path so subcompartment
+  distinctions survive — in EF 3.1, nine factors out of ten are
+  subcompartment-specific. Legacy files parse exactly as before, and
+  quoted fields now work in these files too.
 - Method collections can now be exported as SimaPro method CSV, the inverse
   of the SimaPro method import: `POST /method-collections/{name}/export`,
   `volca method export NAME --format simapro --out FILE`, and

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It loads EcoSpold2, EcoSpold1, SimaPro CSV, ILCD process, and Brightway Excel da
 - **Archive support**: Load databases directly from .zip, .7z, .gz, or .xz archives — no manual extraction
 - **Cross-database linking**: Resolve supplier references across databases, with configurable dependencies and topological load ordering. EcoSpold2 inputs link to a loaded background by exact `activityLinkId` identity (so a partial import resolves against its matching release), falling back to attribute matching — flagged as approximate — when the background is a different release
 - **Cross-DB what-if substitutions**: Swap an upstream activity at any depth — including suppliers in dependency databases — and recompute inventory and impacts through one endpoint
-- **LCIA method collections**: Load ILCD method packages (ZIP or directory), SimaPro method CSV exports, or tabular CSV from config; export any loaded collection back as SimaPro method CSV
+- **LCIA method collections**: Load ILCD method packages (ZIP or directory), SimaPro method CSV exports, or tabular CSV from config; export any loaded collection back as SimaPro method CSV or as columnar CSV (one column per impact category — the spreadsheet view)
 - **Normalization and weighting**: Batch LCIA computes normalized and weighted scores per category and a single aggregated score (Pt) when NW data is present in the method collection
 - **Contribution analysis**: Per-flow and per-activity contributions to any LCIA score, ranked by share
 - **Flow mapping engine**: 4-step matching cascade (UUID → name → synonym → CAS) with per-strategy coverage statistics
@@ -444,7 +444,7 @@ volca database export my-db --format simapro --out out.csv
 # List, upload, export, delete method collections
 volca method                                    # list (default)
 volca method upload EF-3.1.zip --name "EF 3.1"  # upload
-volca method export ef-31 --format simapro --out ef-31.csv  # export (SimaPro method CSV)
+volca method export ef-31 --format simapro --out ef-31.csv  # export (formats: simapro | csv)
 volca method delete ef-31                        # delete
 ```
 
@@ -499,7 +499,7 @@ volca method delete ef-31                        # delete
 | Upload collection | `POST /method-collections/upload` | `method upload FILE --name NAME` |
 | Load / unload collection | `POST /method-collections/{name}/(load\|unload)` | — |
 | Delete collection | `DELETE /method-collections/{name}` | `method delete NAME` |
-| Export collection (SimaPro CSV) | `POST /method-collections/{name}/export` | `method export NAME --format simapro --out FILE` |
+| Export collection (SimaPro or columnar CSV) | `POST /method-collections/{name}/export` | `method export NAME --format simapro --out FILE` |
 | **Reference Data** | | |
 | Flow synonyms | `GET /flow-synonyms` (+ load/unload/upload/delete/groups/download) | `synonyms` |
 | Compartment mappings | `GET /compartment-mappings` (+ load/unload/upload/delete) | `compartment-mappings` |

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -529,12 +529,12 @@ warnings arrive in the ``X-Volca-Export-Warnings`` response header
 
 Export a loaded method collection, returning the serialized bytes.
 
-``fmt`` names the target format; ``simapro`` (SimaPro method CSV) is
-the only format with a method writer today — the engine answers 400
-for the others. Projection warnings (a CF the format cannot carry
-faithfully) arrive in the ``X-Volca-Export-Warnings`` response header
-and are surfaced through :mod:`warnings`. Raises VoLCAError on an
-HTTP error, including a collection that is not loaded.
+``fmt`` names the target format: ``simapro`` (SimaPro method CSV) or
+``csv`` (columnar CSV — one column per impact category, the
+spreadsheet view). Projection warnings (anything the format cannot
+carry faithfully) arrive in the ``X-Volca-Export-Warnings`` response
+header and are surfaced through :mod:`warnings`. Raises VoLCAError
+on an HTTP error, including a collection that is not loaded.
 
 ##### `Client.export_to_file(fmt: str, out_path: str, db_name: str | None = None) -> None`
 

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -142,6 +142,13 @@ client-side so a typo fails before the round-trip with the same message
 shape the engine would have returned."""
 
 
+_METHOD_EXPORT_FORMATS = frozenset({"simapro", "csv"})
+"""Target keywords accepted by ``POST /api/v1/method-collections/{name}/export``.
+
+Mirrors the engine's ``parseMethodExportFormat`` — a space of its own,
+smaller than the database export formats."""
+
+
 RefDataKind = Literal["flow-synonyms", "compartment-mappings", "units"]
 """Reference-data families sharing the same ``/api/v1/{kind}`` URL scheme.
 
@@ -1878,18 +1885,18 @@ class Client:
     def export_method_collection(self, name: str, fmt: str = "simapro") -> bytes:
         """Export a loaded method collection, returning the serialized bytes.
 
-        ``fmt`` names the target format; ``simapro`` (SimaPro method CSV) is
-        the only format with a method writer today — the engine answers 400
-        for the others. Projection warnings (a CF the format cannot carry
-        faithfully) arrive in the ``X-Volca-Export-Warnings`` response header
-        and are surfaced through :mod:`warnings`. Raises VoLCAError on an
-        HTTP error, including a collection that is not loaded.
+        ``fmt`` names the target format: ``simapro`` (SimaPro method CSV) or
+        ``csv`` (columnar CSV — one column per impact category, the
+        spreadsheet view). Projection warnings (anything the format cannot
+        carry faithfully) arrive in the ``X-Volca-Export-Warnings`` response
+        header and are surfaced through :mod:`warnings`. Raises VoLCAError
+        on an HTTP error, including a collection that is not loaded.
         """
         fmt_norm = fmt.strip().lower()
-        if fmt_norm not in _EXPORT_FORMATS:
+        if fmt_norm not in _METHOD_EXPORT_FORMATS:
             raise VoLCAError(
-                f"unknown export format: {fmt!r} "
-                f"(expected {'|'.join(sorted(_EXPORT_FORMATS))})"
+                f"unknown method export format: {fmt!r} "
+                f"(expected {'|'.join(sorted(_METHOD_EXPORT_FORMATS))})"
             )
         resp = self._session.post(
             f"{self.base_url}/api/v1/method-collections/{name}/export",

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -116,7 +116,7 @@ import Data.Maybe (fromMaybe)
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import Database.Edit (DeleteRequest (..), copyDatabase, deleteActivitiesInDB)
-import Database.Export (parseExportFormat, serializeDatabase, serializeMethodCollection)
+import Database.Export (parseExportFormat, parseMethodExportFormat, serializeDatabase, serializeMethodCollection)
 import qualified Database.Loader as Loader
 import Database.Manager (
     DatabaseLoadStatus (..),
@@ -430,7 +430,7 @@ export: raw octet-stream body, projection warnings percent-encoded in the
 exportMethodHandler :: Text -> ExportRequest -> AppM (Headers '[Header "X-Volca-Export-Warnings" Text] BinaryContent)
 exportMethodHandler name req = do
     dbManager <- asks aeDbManager
-    fmt <- either (exportErr err400) pure (parseExportFormat (exrFormat req))
+    fmt <- either (exportErr err400) pure (parseMethodExportFormat (exrFormat req))
     mColl <- liftIO (getMethodCollection dbManager name)
     coll <- maybe (exportErr err404 ("Method collection not loaded: " <> name)) pure mColl
     (bytes, warnings) <- either (exportErr err400) pure (serializeMethodCollection fmt name coll)

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -18,7 +18,7 @@ import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import Database.Edit (DeleteRequest (..), copyDatabase, deleteActivitiesInDB)
-import Database.Export (exportDatabase, exportMethodCollection, parseExportFormat)
+import Database.Export (exportDatabase, exportMethodCollection, parseExportFormat, parseMethodExportFormat)
 import Database.Manager (DatabaseManager (..), LoadedDatabase (..), RelinkResult (..), addDatabase, addMethodCollection)
 import qualified Database.Manager as DM
 import Database.RelinkMapping (relinkWithMappingFile)
@@ -583,7 +583,7 @@ executeDbExport fmt manager args =
 -- | Execute method-collection export: serialize a loaded collection to a file.
 executeMcExport :: OutputFormat -> DatabaseManager -> McExportArgs -> IO ()
 executeMcExport fmt manager args =
-    case parseExportFormat (meaFormat args) of
+    case parseMethodExportFormat (meaFormat args) of
         Left err -> reportError (T.unpack err) >> exitFailure
         Right mcFmt -> do
             mColl <- DM.getMethodCollection manager (meaName args)

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -159,7 +159,7 @@ mcExportArgsParser :: Parser McExportArgs
 mcExportArgsParser =
     McExportArgs
         <$> textArg "NAME" "Name of the loaded method collection to export"
-        <*> textOpt "format" Nothing "FMT" "Target format: simapro (the only method writer today)"
+        <*> textOpt "format" Nothing "FMT" "Target format: simapro|csv"
         <*> strOpt "out" Nothing "FILE" "Output file path"
 
 {- | Delete-by-selection parser: positional DB plus filter options. @--keep@ and
@@ -188,7 +188,7 @@ methodParser =
                 ( OA.command "list" (info (pure McList) (progDesc "List method collections"))
                     <> OA.command "upload" (info (McUpload <$> uploadArgsParser) (progDesc "Upload a method collection from a local file"))
                     <> OA.command "delete" (info (McDelete <$> deleteNameParser) (progDesc "Delete a method collection"))
-                    <> OA.command "export" (info (McExport <$> mcExportArgsParser <**> helper) (progDesc "Export a loaded method collection to a file (SimaPro CSV)"))
+                    <> OA.command "export" (info (McExport <$> mcExportArgsParser <**> helper) (progDesc "Export a loaded method collection to a file (SimaPro or columnar CSV)"))
                 )
             )
 

--- a/src/Database/Export.hs
+++ b/src/Database/Export.hs
@@ -35,6 +35,7 @@ import qualified EcoSpold.Writer1 as ES1
 import qualified EcoSpold.Writer2 as ES2
 import qualified ILCD.Writer as ILCD
 import Method.Types (MethodCollection)
+import qualified Method.WriterCSV as MWC
 import qualified Method.WriterSimaPro as MW
 import qualified SimaPro.Writer as SP
 import Types (Database, toSimpleDatabase)
@@ -77,6 +78,7 @@ wall of runtime 'Left's.
 -}
 data MethodExportFormat
     = MethodSimaProCSV -- SimaPro method CSV ({methods} block)
+    | MethodColumnarCSV -- columnar CSV (one column per impact category)
     deriving (Show, Eq)
 
 {- | Parse a user-facing method-export format name (case- and
@@ -86,7 +88,8 @@ accepted spellings and the error message stay in one place.
 parseMethodExportFormat :: Text -> Either Text MethodExportFormat
 parseMethodExportFormat raw = case T.toLower (T.strip raw) of
     "simapro" -> Right MethodSimaProCSV
-    other -> Left ("unknown method export format: " <> other <> " (expected simapro)")
+    "csv" -> Right MethodColumnarCSV
+    other -> Left ("unknown method export format: " <> other <> " (expected simapro|csv)")
 
 {- | Serialize a loaded method collection in the requested format, paired with
 the projection warnings. The name is the collection's own (used as the
@@ -97,6 +100,8 @@ serializeMethodCollection fmt name mc = case fmt of
     MethodSimaProCSV ->
         first BL.fromStrict
             <$> MW.serializeSimaProMethodCSV SP.defaultWriterConfig name mc
+    MethodColumnarCSV ->
+        first BL.fromStrict <$> MWC.serializeColumnarMethodCSV mc
 
 {- | Parse a user-facing export-format name (case- and whitespace-insensitive)
 to a 'DatabaseFormat'. Shared by the CLI and the HTTP handler so the accepted

--- a/src/Database/Export.hs
+++ b/src/Database/Export.hs
@@ -15,6 +15,8 @@ has no writer and 'UnknownFormat' is not a real target, so both fail loudly
 module Database.Export (
     serializeDatabase,
     exportDatabase,
+    MethodExportFormat (..),
+    parseMethodExportFormat,
     serializeMethodCollection,
     exportMethodCollection,
     parseExportFormat,
@@ -67,26 +69,34 @@ serializeDatabase fmt db = case fmt of
     sdb = toSimpleDatabase db
     noWarn = fmap (,[])
 
-{- | Serialize a loaded method collection in the requested format, paired with
-the projection warnings. SimaPro CSV is the only format with a method writer
-today; every other target fails loudly rather than emit an empty file. The
-name is the collection's own (used as the file-level method name when the
-impact categories don't share a methodology).
+{- | Export targets for a method collection — a space of its own, not
+'DatabaseFormat': most database formats carry no method writer, and method
+formats need not be database formats at all. A request naming a format
+outside this type is rejected at parse time instead of dispatching into a
+wall of runtime 'Left's.
 -}
-serializeMethodCollection :: DatabaseFormat -> Text -> MethodCollection -> Either Text (BL.ByteString, [Text])
+data MethodExportFormat
+    = MethodSimaProCSV -- SimaPro method CSV ({methods} block)
+    deriving (Show, Eq)
+
+{- | Parse a user-facing method-export format name (case- and
+whitespace-insensitive). Shared by the CLI and the HTTP handler so the
+accepted spellings and the error message stay in one place.
+-}
+parseMethodExportFormat :: Text -> Either Text MethodExportFormat
+parseMethodExportFormat raw = case T.toLower (T.strip raw) of
+    "simapro" -> Right MethodSimaProCSV
+    other -> Left ("unknown method export format: " <> other <> " (expected simapro)")
+
+{- | Serialize a loaded method collection in the requested format, paired with
+the projection warnings. The name is the collection's own (used as the
+file-level method name when the impact categories don't share a methodology).
+-}
+serializeMethodCollection :: MethodExportFormat -> Text -> MethodCollection -> Either Text (BL.ByteString, [Text])
 serializeMethodCollection fmt name mc = case fmt of
-    SimaProCSV ->
+    MethodSimaProCSV ->
         first BL.fromStrict
             <$> MW.serializeSimaProMethodCSV SP.defaultWriterConfig name mc
-    EcoSpold1 -> noMethodWriter "ecospold1"
-    EcoSpold2 -> noMethodWriter "ecospold2"
-    ILCDProcess -> noMethodWriter "ilcd"
-    BrightwayExcel -> noMethodWriter "brightway"
-    OpenLcaJsonLd -> noMethodWriter "openlca"
-    UnknownFormat -> Left "cannot export to an unknown format"
-  where
-    noMethodWriter f =
-        Left ("method collections can only be exported as SimaPro CSV (no method writer for format: " <> f <> ")")
 
 {- | Parse a user-facing export-format name (case- and whitespace-insensitive)
 to a 'DatabaseFormat'. Shared by the CLI and the HTTP handler so the accepted
@@ -109,7 +119,7 @@ exportDatabase :: DatabaseFormat -> Database -> FilePath -> IO (Either Text [Tex
 exportDatabase fmt db path = writeExport path (serializeDatabase fmt db)
 
 -- | File variant of 'serializeMethodCollection', for the CLI.
-exportMethodCollection :: DatabaseFormat -> Text -> MethodCollection -> FilePath -> IO (Either Text [Text])
+exportMethodCollection :: MethodExportFormat -> Text -> MethodCollection -> FilePath -> IO (Either Text [Text])
 exportMethodCollection fmt name mc path = writeExport path (serializeMethodCollection fmt name mc)
 
 -- | Write serialized bytes to @path@, passing the warnings through.

--- a/src/Method/CSV.hs
+++ b/src/Method/CSV.hs
@@ -1,22 +1,29 @@
-{- | Shared CSV plumbing for the LCIA method parsers.
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Shared CSV plumbing for the LCIA method parsers and the columnar writer.
 
 Delimiter detection, row splitting and number parsing were previously
 duplicated across the CSV-based method parsers — and had drifted apart
 (delimiter detection disagreed on tab support). They live here as the
-single source of truth.
+single source of truth. 'splitRow' and 'joinRow' are inverses: what one
+writes with RFC 4180 quoting, the other reads back cell for cell.
 -}
 module Method.CSV (
     detectDelimiter,
     splitRow,
+    joinRow,
     parseDouble,
 ) where
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BC
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Csv as Csv
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Encoding.Error as TEE
+import qualified Data.Vector as V
 
 -- | Auto-detect a row delimiter: semicolon, then tab, then comma.
 detectDelimiter :: BS.ByteString -> Char
@@ -25,9 +32,33 @@ detectDelimiter line
     | BC.elem '\t' line = '\t'
     | otherwise = ','
 
--- | Split a row on the delimiter, decoding each cell to 'Text' leniently.
+{- | Split a row on the delimiter, respecting RFC 4180 quoted fields, decoding
+each cell to 'Text' leniently. A row cassava cannot make sense of (an
+unbalanced quote) degrades to the naive split — the historical behavior —
+rather than dropping the line. A lone trailing CR is line-terminator residue
+(see @SimaPro.Parser.splitCSV@ for the full story): strip it before parsing,
+cassava would otherwise wait for the LF of a CRLF and reject the row.
+-}
 splitRow :: Char -> BS.ByteString -> [Text]
-splitRow delim = map (TE.decodeUtf8With TEE.lenientDecode) . BC.split delim
+splitRow delim bs =
+    let clean = BC.dropWhileEnd (== '\r') bs
+        opts = Csv.defaultDecodeOptions{Csv.decDelimiter = fromIntegral (fromEnum delim)}
+        decode = map (TE.decodeUtf8With TEE.lenientDecode)
+     in case Csv.decodeWith opts Csv.NoHeader (BL.fromStrict clean) of
+            Right rows | not (V.null rows) -> decode (V.toList (V.head rows))
+            _ -> decode (BC.split delim clean)
+
+{- | Join cells into one row, quoting any cell that contains the delimiter, a
+quote, or a line break (RFC 4180: inner quotes double). The exact inverse of
+'splitRow'.
+-}
+joinRow :: Char -> [Text] -> Text
+joinRow delim = T.intercalate (T.singleton delim) . map quote
+  where
+    quote cell
+        | T.any (\c -> c == delim || c == '"' || c == '\n' || c == '\r') cell =
+            "\"" <> T.replace "\"" "\"\"" cell <> "\""
+        | otherwise = cell
 
 {- | Parse a 'Double', 'Nothing' on failure. Goes through 'reads' — the
 correctly-rounded parse — not 'TR.double', whose fast path drifts in the

--- a/src/Method/CSV.hs
+++ b/src/Method/CSV.hs
@@ -14,9 +14,9 @@ module Method.CSV (
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BC
 import Data.Text (Text)
+import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Encoding.Error as TEE
-import qualified Data.Text.Read as TR
 
 -- | Auto-detect a row delimiter: semicolon, then tab, then comma.
 detectDelimiter :: BS.ByteString -> Char
@@ -29,8 +29,12 @@ detectDelimiter line
 splitRow :: Char -> BS.ByteString -> [Text]
 splitRow delim = map (TE.decodeUtf8With TEE.lenientDecode) . BC.split delim
 
--- | Parse a 'Double', 'Nothing' on failure.
+{- | Parse a 'Double', 'Nothing' on failure. Goes through 'reads' — the
+correctly-rounded parse — not 'TR.double', whose fast path drifts in the
+last ulp (@1.2227e-3@ comes back as @1.2227000000000002e-3@), which is a
+wrong number. Trailing garbage is tolerated, as it always was.
+-}
 parseDouble :: Text -> Maybe Double
-parseDouble t = case TR.double t of
-    Right (v, _) -> Just v
-    Left _ -> Nothing
+parseDouble t = case reads (T.unpack t) of
+    (v, _) : _ -> Just v
+    [] -> Nothing

--- a/src/Method/CSV.hs
+++ b/src/Method/CSV.hs
@@ -25,6 +25,8 @@ import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Encoding.Error as TEE
 import qualified Data.Vector as V
 
+import Amount (readAmount)
+
 -- | Auto-detect a row delimiter: semicolon, then tab, then comma.
 detectDelimiter :: BS.ByteString -> Char
 detectDelimiter line
@@ -60,12 +62,12 @@ joinRow delim = T.intercalate (T.singleton delim) . map quote
             "\"" <> T.replace "\"" "\"\"" cell <> "\""
         | otherwise = cell
 
-{- | Parse a 'Double', 'Nothing' on failure. Goes through 'reads' — the
-correctly-rounded parse — not 'TR.double', whose fast path drifts in the
-last ulp (@1.2227e-3@ comes back as @1.2227000000000002e-3@), which is a
-wrong number. Trailing garbage is tolerated, as it always was.
+{- | Parse a 'Double', 'Nothing' on failure — 'Amount.readAmount', the
+correctly-rounded reader every importer shares ('TR.double' drifts in the
+last ulp: @1.2227e-3@ came back as @1.2227000000000002e-3@, a wrong
+number). It also rejects what a factor cell must never smuggle in: a
+non-finite literal (@NaN@, @Infinity@) and trailing garbage (@1,23@ once
+imported as @1.0@ — a silently truncated value).
 -}
 parseDouble :: Text -> Maybe Double
-parseDouble t = case reads (T.unpack t) of
-    (v, _) : _ -> Just v
-    [] -> Nothing
+parseDouble = readAmount

--- a/src/Method/ParserCSV.hs
+++ b/src/Method/ParserCSV.hs
@@ -19,16 +19,30 @@ __3-row__ (explicit categories):
 > ;;kg CO2 eq.;kg SO2 eq.;...                       ← units
 > substance;compartment;;;...                        ← label row
 
+The label row names the key columns; data columns start after them.
+@substance@ and @compartment@ are required, in that order. Two more key
+columns are recognised (in either order — this is what 'Method.WriterCSV'
+emits): @cas@ (the substance's CAS number) and @unit@ (the flow unit of
+that row, when it differs from the category unit in the header — real
+methods mix kg, m3 and MJ flows inside one category).
+
+A compartment cell is either a legacy prose form (@Emissions to air@,
+@Resources@ — matched by keyword) or a @/@-separated path
+(@water/groundwater/long-term@ = compartment, subcompartment, qualifier),
+which is what the writer emits and the only way to keep subcompartment
+distinctions — most of a real method's factors are subcompartment-specific.
+
 One CSV file → multiple 'Method' values (one per column).
 -}
 module Method.ParserCSV (
     parseMethodCSVBytes,
+    knownTops,
     stripBOM,
 ) where
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BC
-import Data.List (zip4)
+import Data.List (elemIndex, zip4)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
@@ -46,38 +60,65 @@ parseMethodCSVBytes bytes =
     let allLines = map stripCR $ BC.lines (stripBOM bytes)
         (comments, dataLines) = span (\l -> BC.isPrefixOf "#" l || BS.null l) allLines
         methodology = extractMethodology comments
-     in case splitHeaderFromData dataLines of
-            Nothing -> Left "CSV method file needs at least 3 header rows (names, units, column labels)"
-            Just (cats, names, units, rows, delim) ->
-                Right
-                    [ mkMethod methodology catName impactName unit colIdx rows delim
-                    | (colIdx, catName, impactName, unit) <- zip4 [0 ..] cats names units
-                    , not (T.null impactName)
-                    ]
+     in do
+            (keys, cats, names, units, rows, delim) <- splitHeaderFromData dataLines
+            -- Split each data row once; every method column reads the same cells.
+            let cellRows = map (splitRow delim) rows
+            Right
+                [ mkMethod methodology keys catName impactName unit colIdx cellRows
+                | (colIdx, catName, impactName, unit) <- zip4 [0 ..] cats names units
+                , not (T.null impactName)
+                ]
+
+{- | The key columns of the label row: the non-blank leading cells. Data
+columns start right after them.
+-}
+data KeyColumns = KeyColumns
+    { kcCount :: !Int
+    , kcCAS :: !(Maybe Int)
+    , kcUnit :: !(Maybe Int)
+    }
+
+{- | Read the key columns off the label row. @substance@ and @compartment@
+must come first (that's also what 'isLabelRow' anchors on); @cas@ and @unit@
+are optional. An unrecognised key column is an error, not a silently skipped
+column of data.
+-}
+parseKeyColumns :: [Text] -> Either String KeyColumns
+parseKeyColumns labels =
+    let keys = map (T.toCaseFold . T.strip) (takeWhile (not . T.null . T.strip) labels)
+     in case keys of
+            ("substance" : "compartment" : extras) ->
+                case filter (`notElem` ["cas", "unit"]) extras of
+                    bad : _ -> Left ("unknown key column in CSV method label row: " <> T.unpack bad)
+                    [] ->
+                        Right
+                            KeyColumns
+                                { kcCount = length keys
+                                , kcCAS = (+ 2) <$> elemIndex "cas" extras
+                                , kcUnit = (+ 2) <$> elemIndex "unit" extras
+                                }
+            _ -> Left "CSV method label row must start with 'substance;compartment'"
 
 {- | Find the label row (first column starts with "substance") and split header
-rows from data rows.  Returns (categories, names, units, dataRows, delimiter).
-2-row layout → categories = names.  3-row layout → distinct.
+rows from data rows.  Returns (keys, categories, names, units, dataRows,
+delimiter).  2-row layout → categories = names.  3-row layout → distinct.
 -}
-splitHeaderFromData :: [BS.ByteString] -> Maybe ([Text], [Text], [Text], [BS.ByteString], Char)
+splitHeaderFromData :: [BS.ByteString] -> Either String (KeyColumns, [Text], [Text], [Text], [BS.ByteString], Char)
 splitHeaderFromData dataLines =
     case break isLabelRow dataLines of
-        (headerRows, _labelRow : rows) ->
-            let nonBlank = filter (not . BS.null) headerRows
-             in case nonBlank of
-                    [nameRow, unitRow] ->
-                        let !delim = detectDelimiter nameRow
-                            names = drop 2 $ splitRow delim nameRow
-                            units = drop 2 $ splitRow delim unitRow
-                         in Just (names, names, units, rows, delim) -- categories = names
-                    [catRow, nameRow, unitRow] ->
-                        let !delim = detectDelimiter catRow
-                            cats = drop 2 $ splitRow delim catRow
-                            names = drop 2 $ splitRow delim nameRow
-                            units = drop 2 $ splitRow delim unitRow
-                         in Just (cats, names, units, rows, delim)
-                    _ -> Nothing
-        _ -> Nothing
+        (headerRows, labelRow : rows) -> do
+            let !delim = detectDelimiter labelRow
+            keys <- parseKeyColumns (splitRow delim labelRow)
+            let dropKeys = drop (kcCount keys) . splitRow delim
+            case filter (not . BS.null) headerRows of
+                [nameRow, unitRow] ->
+                    let names = dropKeys nameRow
+                     in Right (keys, names, names, dropKeys unitRow, rows, delim)
+                [catRow, nameRow, unitRow] ->
+                    Right (keys, dropKeys catRow, dropKeys nameRow, dropKeys unitRow, rows, delim)
+                _ -> Left "CSV method file needs at least 3 header rows (names, units, column labels)"
+        _ -> Left "CSV method file has no 'substance;compartment;...' label row"
 
 -- | Detect the label row: first cell is a variation of "substance".
 isLabelRow :: BS.ByteString -> Bool
@@ -86,37 +127,43 @@ isLabelRow line =
         (first : _) -> T.toCaseFold (T.strip first) == "substance"
         [] -> False
 
--- | Build a single Method from one column of the CSV.
-mkMethod :: Maybe Text -> Text -> Text -> Text -> Int -> [BS.ByteString] -> Char -> Method
-mkMethod methodology catName impactName unit colIdx rows delim =
+-- | Build a single Method from one column of the pre-split CSV rows.
+mkMethod :: Maybe Text -> KeyColumns -> Text -> Text -> Text -> Int -> [[Text]] -> Method
+mkMethod methodology keys catName impactName unit colIdx cellRows =
     let !ns = csvMethodNamespace
         !mId = UUID5.generateNamed ns (bsKey $ "method:" <> impactName)
+        !headerUnit = if T.null unit then "unknown" else unit
+        cell cells i = case drop i cells of
+            x : _ -> T.strip x
+            [] -> ""
+        keyed cells = maybe "" (cell cells)
         !factors =
             [ MethodCF
                 { mcfFlowRef = UUID5.generateNamed ns (bsKey $ sub <> "::" <> comp)
                 , mcfFlowName = sub
-                , mcfDirection = directionFromCompartment comp
+                , mcfDirection = directionFromCompartment comp compartment
                 , mcfValue = v
-                , mcfCompartment = parseCSVCompartment comp
-                , mcfCAS = Nothing
-                , mcfUnit = unit
+                , mcfCompartment = compartment
+                , mcfCAS = if T.null cas then Nothing else Just cas
+                , mcfUnit = if T.null rowUnit then headerUnit else rowUnit
                 , mcfConsumerLocation = Nothing
                 }
-            | row <- rows
-            , let cells = splitRow delim row
-            , length cells > colIdx + 2
-            , let !sub = T.strip (cells !! 0)
-                  !comp = T.strip (cells !! 1)
-                  !raw = T.strip (cells !! (colIdx + 2))
+            | cells <- cellRows
+            , let !sub = cell cells 0
+                  !comp = cell cells 1
+                  !cas = keyed cells (kcCAS keys)
+                  !rowUnit = keyed cells (kcUnit keys)
+                  !raw = cell cells (colIdx + kcCount keys)
             , not (T.null sub)
             , not (T.null raw)
+            , let compartment = parseCSVCompartment comp
             , Just v <- [parseDouble raw]
             ]
      in Method
             { methodId = mId
             , methodName = impactName
             , methodDescription = Nothing
-            , methodUnit = if T.null unit then "unknown" else unit
+            , methodUnit = headerUnit
             , methodCategory = catName
             , methodMethodology = methodology
             , methodFactors = factors
@@ -126,24 +173,56 @@ mkMethod methodology catName impactName unit colIdx rows delim =
 csvMethodNamespace :: UUID
 csvMethodNamespace = UUID5.generateNamed UUID5.namespaceURL (BS.unpack $ TE.encodeUtf8 "volca:csv-method")
 
-{- | Direction: a resource compartment → Input, everything else → Output. Reads
-the same spellings as the SimaPro parser (@Resources@, @Raw@, @Raw materials@,
-@Resources from ground@…): a resource CF mis-defaulted to Output would resolve
-against the output synonym view and silently lose input-only bridges.
+{- | Direction: a resource or land compartment → Input, everything else →
+Output. Reads the same spellings as the SimaPro parser (@Resources@, @Raw@,
+@Raw materials@, @Resources from ground@…): a resource CF mis-defaulted to
+Output would resolve against the output synonym view and silently lose
+input-only bridges. Takes the already-parsed compartment alongside the raw
+cell because the raw spellings ("Raw materials") can imply Input even when
+no compartment parses.
 -}
-directionFromCompartment :: Text -> FlowDirection
-directionFromCompartment comp
+directionFromCompartment :: Text -> Maybe Compartment -> FlowDirection
+directionFromCompartment comp parsed
+    | isResourceTop = Input
     | lc == "resources" || "raw" `T.isPrefixOf` lc || "resources " `T.isPrefixOf` lc = Input
     | otherwise = Output
   where
     lc = T.toCaseFold comp
+    isResourceTop = case parsed of
+        Just (Compartment t _ _) -> t == "natural resource" || "land " `T.isPrefixOf` t
+        Nothing -> False
 
-{- | Parse compartment from CSV compartment column.
-Format: "Emissions to air", "Emissions to fresh water", "Resources", etc.
+{- | Parse the compartment cell: a @/@-separated path with a known top-level
+compartment first, or a legacy prose form matched by keyword ("Emissions to
+air", "Emissions to fresh water", "Resources", …).
 -}
 parseCSVCompartment :: Text -> Maybe Compartment
-parseCSVCompartment comp
+parseCSVCompartment comp = case map T.strip (T.splitOn "/" comp) of
+    [] -> Nothing -- splitOn never returns [], but the match must be total
+    [single] -> legacyCompartment single
+    [top, s] -> pathCompartment top s ""
+    [top, s, q] -> pathCompartment top s q
+    _ -> Nothing -- more path segments than a compartment has fields
+
+-- | A path form is only a compartment when its top segment is one we know.
+pathCompartment :: Text -> Text -> Text -> Maybe Compartment
+pathCompartment top s q
+    | T.toCaseFold top `elem` knownTops = Just (Compartment (T.toCaseFold top) s q)
+    | otherwise = Nothing
+
+{- | The top-level compartments this format can name. Shared with
+"Method.WriterCSV", whose guard refuses to write a compartment the re-import
+would not read back.
+-}
+knownTops :: [Text]
+knownTops = ["air", "water", "soil", "natural resource", "land occupation", "land transformation"]
+
+-- | Keyword match for the legacy prose forms.
+legacyCompartment :: Text -> Maybe Compartment
+legacyCompartment comp
     | T.null comp = Nothing
+    | "land occupation" `T.isInfixOf` lc = Just (Compartment "land occupation" "" "")
+    | "land transformation" `T.isInfixOf` lc = Just (Compartment "land transformation" "" "")
     | "air" `T.isInfixOf` lc = Just (Compartment "air" "" "")
     | "water" `T.isInfixOf` lc = Just (Compartment "water" "" "")
     | "soil" `T.isInfixOf` lc = Just (Compartment "soil" "" "")

--- a/src/Method/ParserCSV.hs
+++ b/src/Method/ParserCSV.hs
@@ -40,6 +40,7 @@ module Method.ParserCSV (
     stripBOM,
 ) where
 
+import Control.Applicative ((<|>))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BC
 import Data.List (elemIndex, zip4)
@@ -194,15 +195,19 @@ directionFromCompartment comp parsed
 
 {- | Parse the compartment cell: a @/@-separated path with a known top-level
 compartment first, or a legacy prose form matched by keyword ("Emissions to
-air", "Emissions to fresh water", "Resources", …).
+air", "Emissions to fresh water", "Resources", …). A cell that looks like a
+path but has an unknown top (or too many segments) falls back to the keyword
+match on the whole cell: legacy prose can contain a @/@ ("Emissions to
+water/groundwater"), and losing its compartment silently would degrade files
+that parsed before the path form existed.
 -}
 parseCSVCompartment :: Text -> Maybe Compartment
 parseCSVCompartment comp = case map T.strip (T.splitOn "/" comp) of
     [] -> Nothing -- splitOn never returns [], but the match must be total
     [single] -> legacyCompartment single
-    [top, s] -> pathCompartment top s ""
-    [top, s, q] -> pathCompartment top s q
-    _ -> Nothing -- more path segments than a compartment has fields
+    [top, s] -> pathCompartment top s "" <|> legacyCompartment comp
+    [top, s, q] -> pathCompartment top s q <|> legacyCompartment comp
+    _ -> legacyCompartment comp -- more path segments than a compartment has fields
 
 -- | A path form is only a compartment when its top segment is one we know.
 pathCompartment :: Text -> Text -> Text -> Maybe Compartment

--- a/src/Method/WriterCSV.hs
+++ b/src/Method/WriterCSV.hs
@@ -1,0 +1,227 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Writer for the columnar CSV method format — the exact inverse of
+"Method.ParserCSV". One file, one column per impact category, one row per
+distinct (substance, compartment, CAS, flow unit): the spreadsheet view of
+a method collection.
+
+Deterministic: rows are sorted by their key, values render through
+'formatAmount', and nothing volatile (timestamp, version) is emitted, so
+the same collection always serializes to the same bytes.
+
+Projections onto the format's conventions (matching "Method.WriterSimaPro"
+where the two formats share a limitation):
+
+* a regionalized CF is written as a name-suffixed substance (@Water, FR@);
+* the compartment cell is the @top/sub/qualifier@ path the parser reads
+  back exactly, so subcompartment distinctions survive;
+* flow direction is not a column — the parser re-derives it from the
+  compartment (resource and land media → input). A CF whose direction
+  disagrees is reported in the warnings;
+* duplicate factors for one key in one category (they exist in real method
+  packages) become extra rows, never a silently dropped or merged value.
+
+Not representable, reported as warnings and omitted: method descriptions,
+mixed methodologies (the @# methodology@ comment holds one), damage
+categories, normalization/weighting sets, and formula scoring sets.
+-}
+module Method.WriterCSV (
+    serializeColumnarMethodCSV,
+    checkColumnarExportable,
+) where
+
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as M
+import Data.Maybe (fromMaybe, mapMaybe)
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+
+import Method.CSV (joinRow)
+import Method.ParserCSV (knownTops)
+import Method.Types
+import SimaPro.Writer (formatAmount)
+
+delim :: Char
+delim = ';'
+
+keyLabels :: [Text]
+keyLabels = ["substance", "compartment", "cas", "unit"]
+
+{- | Serialize a method collection to columnar CSV bytes, paired with the
+projection warnings. 'Left' when the format cannot represent the collection
+without silent corruption on re-import ('checkColumnarExportable').
+-}
+serializeColumnarMethodCSV :: MethodCollection -> Either Text (BS.ByteString, [Text])
+serializeColumnarMethodCSV mc = do
+    checkColumnarExportable mc
+    let ms = mcMethods mc
+        headerRow field = joinRow delim (map (const "") keyLabels <> map (T.strip . field) ms)
+        header =
+            [ headerRow methodCategory
+            , headerRow methodName
+            , headerRow methodUnit
+            , joinRow delim (keyLabels <> map (const "") ms)
+            ]
+        methodologyLine = maybe [] (\m -> ["# methodology: " <> T.strip m]) (sharedMethodology ms)
+        allLines = methodologyLine <> header <> tableRows ms
+        warnings = directionWarnings ms <> lossWarnings mc
+    pure (TE.encodeUtf8 (T.unlines allLines), warnings)
+
+-- | Key of a data row: what the parser reads back from the key columns.
+type RowKey = (Text, Text, Text, Text)
+
+{- | Every cell is emitted stripped: the parser strips what it reads, so
+surrounding whitespace (it occurs in real source data, e.g. a CAS written
+@\" 5595-10-8\"@) could never survive a round-trip — it is identifier noise,
+not information.
+-}
+rowKey :: MethodCF -> RowKey
+rowKey cf =
+    ( T.strip (mcfFlowName cf <> maybe "" (", " <>) (mcfConsumerLocation cf))
+    , compartmentCell (mcfCompartment cf)
+    , maybe "" T.strip (mcfCAS cf)
+    , T.strip (mcfUnit cf)
+    )
+
+-- | The @top/sub/qualifier@ path, segments stripped, trailing empties dropped.
+compartmentCell :: Maybe Compartment -> Text
+compartmentCell Nothing = ""
+compartmentCell (Just (Compartment top sub qualifier)) =
+    T.intercalate "/" (shorten (map T.strip [top, sub, qualifier]))
+  where
+    shorten = foldr (\s acc -> if T.null s && null acc then [] else s : acc) []
+
+{- | Factorize the factors of all methods into sorted rows. A key repeated
+inside one category keeps every occurrence: the widest column decides how
+many physical rows the key spans, and each occurrence lands on its own row
+in factor order.
+-}
+tableRows :: [Method] -> [Text]
+tableRows ms =
+    [ joinRow delim ([name, comp, cas, unit] <> [render i (M.lookup col table) | col <- columns])
+    | ((name, comp, cas, unit), table) <- M.toAscList grouped
+    , i <- [0 .. depth table - 1]
+    ]
+  where
+    columns = zipWith const [0 :: Int ..] ms
+    grouped =
+        M.fromListWith
+            (M.unionWith (flip (<>)))
+            [ (rowKey cf, M.singleton col [mcfValue cf])
+            | (col, m) <- zip [0 ..] ms
+            , cf <- methodFactors m
+            ]
+    depth = maximum . (1 :) . map length . M.elems
+    render i cells = case drop i (fromMaybe [] cells) of
+        v : _ -> formatAmount v
+        [] -> ""
+
+{- | The one methodology the @# methodology@ comment can carry: the value all
+impact categories agree on, if any.
+-}
+sharedMethodology :: [Method] -> Maybe Text
+sharedMethodology ms = case S.toList (S.fromList (map methodMethodology ms)) of
+    [Just m] -> Just m
+    _ -> Nothing
+
+{- | The parser derives direction from the compartment cell (resource and
+land media → input, everything else → output). Report the factors whose
+recorded direction would come back different — bounded to a count and a few
+examples, a real method can disagree tens of thousands of times.
+-}
+directionWarnings :: [Method] -> [Text]
+directionWarnings ms = case lost of
+    [] -> []
+    _ ->
+        [ T.pack (show (length lost))
+            <> " factors have a flow direction the compartment does not imply; the re-imported direction follows the compartment (e.g. "
+            <> T.intercalate "; " examples
+            <> ")"
+        ]
+  where
+    lost = [cf | m <- ms, cf <- methodFactors m, mcfDirection cf /= impliedDirection cf]
+    examples = take 5 (S.toAscList (S.fromList (map describe lost)))
+    describe cf = mcfFlowName cf <> " (" <> compartmentCell (mcfCompartment cf) <> ")"
+    impliedDirection cf = case mcfCompartment cf of
+        Just (Compartment t _ _)
+            | t == "natural resource" || "land " `T.isPrefixOf` t -> Input
+        _ -> Output
+
+-- | One warning per collection-level feature the format has no room for.
+lossWarnings :: MethodCollection -> [Text]
+lossWarnings mc =
+    mapMaybe
+        (\(count, what) -> if count == 0 then Nothing else Just (T.pack (show count) <> " " <> what))
+        [ (length descriptions, "impact category descriptions are not representable in columnar CSV")
+        , (mixedMethodologies, "distinct methodologies exist; the single '# methodology' comment is omitted")
+        , (length (mcDamageCategories mc), "damage categories are not representable in columnar CSV")
+        , (length (mcNormWeightSets mc), "normalization/weighting sets are not representable in columnar CSV")
+        , (length (mcScoringSets mc), "formula scoring sets are not representable in columnar CSV")
+        ]
+  where
+    descriptions = mapMaybe methodDescription (mcMethods mc)
+    distinctMethodologies = S.size (S.fromList (map methodMethodology (mcMethods mc)))
+    mixedMethodologies = if distinctMethodologies > 1 then distinctMethodologies else 0
+
+{- | Reject a collection the columnar format cannot represent without silent
+corruption on re-import: no impact categories, a blank category name (its
+column would be silently skipped), a non-finite value, a line break inside a
+field (the parser splits on physical lines before CSV parsing, so quoting
+cannot save it), or a @/@ inside a compartment segment (it would shift the
+compartment path).
+-}
+checkColumnarExportable :: MethodCollection -> Either Text ()
+checkColumnarExportable mc
+    | null (mcMethods mc) = Left "method collection has no impact categories"
+    | otherwise = mapM_ checkMethod (mcMethods mc)
+  where
+    checkMethod m = do
+        checkName (methodName m)
+        mapM_ (noLineBreak "impact category name") [methodName m]
+        mapM_ (noLineBreak "impact category group") [methodCategory m]
+        mapM_ (noLineBreak "impact category unit") [methodUnit m]
+        mapM_ (noLineBreak "methodology") (methodMethodology m)
+        mapM_ (checkCF (methodName m)) (methodFactors m)
+    checkName name
+        | T.null (T.strip name) = Left "impact category has a blank name"
+        | otherwise = Right ()
+    checkCF cat cf = do
+        finite ("characterization factor for '" <> mcfFlowName cf <> "' in '" <> cat <> "'") (mcfValue cf)
+        mapM_ (noLineBreak "flow name") [mcfFlowName cf]
+        mapM_ (noLineBreak "flow unit") [mcfUnit cf]
+        mapM_ (noLineBreak "CAS number") (mcfCAS cf)
+        mapM_ (noLineBreak "consumer location") (mcfConsumerLocation cf)
+        mapM_ checkCompartment (mcfCompartment cf)
+    checkCompartment (Compartment top sub qualifier) = do
+        checkTop top
+        mapM_
+            ( \segment -> do
+                noLineBreak "compartment" segment
+                noSlash segment
+            )
+            [top, sub, qualifier]
+    -- The parser only reads a compartment path back when its top segment is
+    -- one it knows; anything else would silently come back compartment-less.
+    checkTop top
+        | top `elem` knownTops = Right ()
+        | otherwise =
+            Left
+                ( "compartment '"
+                    <> top
+                    <> "' is outside the ones columnar CSV can name ("
+                    <> T.intercalate ", " knownTops
+                    <> ")"
+                )
+    noSlash segment
+        | T.any (== '/') segment =
+            Left ("compartment segment contains '/' (the path separator): " <> T.take 60 segment)
+        | otherwise = Right ()
+    noLineBreak label t
+        | T.any (\c -> c == '\n' || c == '\r') t =
+            Left ("field contains a line break (" <> label <> "): " <> T.take 60 t)
+        | otherwise = Right ()
+    finite label v
+        | isNaN v || isInfinite v = Left ("non-finite " <> label)
+        | otherwise = Right ()

--- a/src/Method/WriterCSV.hs
+++ b/src/Method/WriterCSV.hs
@@ -155,15 +155,19 @@ lossWarnings mc =
     mapMaybe
         (\(count, what) -> if count == 0 then Nothing else Just (T.pack (show count) <> " " <> what))
         [ (length descriptions, "impact category descriptions are not representable in columnar CSV")
-        , (mixedMethodologies, "distinct methodologies exist; the single '# methodology' comment is omitted")
+        , (lostMethodologies, "distinct stated methodologies; the single '# methodology' comment is omitted (it must be shared by every impact category)")
         , (length (mcDamageCategories mc), "damage categories are not representable in columnar CSV")
         , (length (mcNormWeightSets mc), "normalization/weighting sets are not representable in columnar CSV")
         , (length (mcScoringSets mc), "formula scoring sets are not representable in columnar CSV")
         ]
   where
     descriptions = mapMaybe methodDescription (mcMethods mc)
-    distinctMethodologies = S.size (S.fromList (map methodMethodology (mcMethods mc)))
-    mixedMethodologies = if distinctMethodologies > 1 then distinctMethodologies else 0
+    -- Count only the methodologies actually stated: an absent one is not a
+    -- distinct methodology, but it does block the shared comment — so any
+    -- stated methodology is lost whenever 'sharedMethodology' finds none.
+    lostMethodologies = case sharedMethodology (mcMethods mc) of
+        Just _ -> 0
+        Nothing -> S.size (S.fromList (mapMaybe methodMethodology (mcMethods mc)))
 
 {- | Reject a collection the columnar format cannot represent without silent
 corruption on re-import: no impact categories, a blank category name (its

--- a/test/MethodSpec.hs
+++ b/test/MethodSpec.hs
@@ -996,7 +996,10 @@ spec = do
                         Just v -> v `shouldBe` 1.32396265000545e-4
                         Nothing -> expectationFailure "Climate change not found"
                     case M.lookup "Acidification" (nwNormalization nw) of
-                        Just v -> v `shouldBe` 1.7995469781731898e-2
+                        -- The correctly-rounded parse of the fixture's
+                        -- 1.79954697817319E-2 (the old expectation had baked
+                        -- in Data.Text.Read.double's last-ulp drift).
+                        Just v -> v `shouldBe` 1.79954697817319e-2
                         Nothing -> expectationFailure "Acidification not found"
                     M.lookup "Water use" (nwWeighting nw) `shouldBe` Just 0.0851
 

--- a/test/MethodSpec.hs
+++ b/test/MethodSpec.hs
@@ -681,6 +681,25 @@ spec = do
                     lookup "freshwater" dirs `shouldBe` Just Input
                     lookup "CO2" dirs `shouldBe` Just Output
 
+        it "drops a factor whose value cell is not a clean number" $ do
+            -- "NaN" would poison every score it touches; "1,23" once imported
+            -- as 1.0 (the parser stopped at the comma) — a silently truncated
+            -- value. Both must be dropped, never imported as something else.
+            let csv =
+                    BC.unlines
+                        [ ";;Method A"
+                        , ";;kg eq"
+                        , "substance;compartment;"
+                        , "CO2;air;NaN"
+                        , "Methane;air;1,23"
+                        , "N2O;air;265.0"
+                        ]
+            case parseMethodCSVBytes csv of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right methods ->
+                    [(mcfFlowName cf, mcfValue cf) | m <- methods, cf <- methodFactors m]
+                        `shouldBe` [("N2O", 265.0)]
+
         it "returns Left when fewer than 3 header rows" $ do
             let csv =
                     BC.unlines

--- a/test/MethodSpec.hs
+++ b/test/MethodSpec.hs
@@ -681,6 +681,22 @@ spec = do
                     lookup "freshwater" dirs `shouldBe` Just Input
                     lookup "CO2" dirs `shouldBe` Just Output
 
+        it "keeps the compartment of a legacy prose cell containing a slash" $ do
+            -- The path form is tried first; an unknown top must fall back to
+            -- the keyword match, not silently drop the compartment.
+            let csv =
+                    BC.unlines
+                        [ ";;Method A"
+                        , ";;kg eq"
+                        , "substance;compartment;"
+                        , "Nitrate;Emissions to water/groundwater;1.0"
+                        ]
+            case parseMethodCSVBytes csv of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right methods ->
+                    [mcfCompartment cf | m <- methods, cf <- methodFactors m]
+                        `shouldBe` [Just (Compartment "water" "" "")]
+
         it "drops a factor whose value cell is not a clean number" $ do
             -- "NaN" would poison every score it touches; "1,23" once imported
             -- as 1.0 (the parser stopped at the comma) — a silently truncated

--- a/test/MethodWriterCSVSpec.hs
+++ b/test/MethodWriterCSVSpec.hs
@@ -1,0 +1,236 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Tests for the columnar CSV method writer ("Method.WriterCSV").
+module MethodWriterCSVSpec (spec) where
+
+import Data.Bifunctor (first)
+import qualified Data.ByteString as BS
+import Data.List (sortOn)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Data.UUID (nil)
+import Test.Hspec
+
+import Database.Export (MethodExportFormat (..), parseMethodExportFormat)
+import Method.ParserCSV (parseMethodCSVBytes)
+import Method.Types
+import Method.WriterCSV (serializeColumnarMethodCSV)
+
+mkCF :: Text -> Maybe Compartment -> Double -> MethodCF
+mkCF name comp v =
+    MethodCF
+        { mcfFlowRef = nil
+        , mcfFlowName = name
+        , mcfDirection = Output
+        , mcfValue = v
+        , mcfCompartment = comp
+        , mcfCAS = Nothing
+        , mcfUnit = "kg"
+        , mcfConsumerLocation = Nothing
+        }
+
+mkMethod :: Text -> [MethodCF] -> Method
+mkMethod name cfs =
+    Method
+        { methodId = nil
+        , methodName = name
+        , methodDescription = Nothing
+        , methodUnit = "kg eq"
+        , methodCategory = name
+        , methodMethodology = Nothing
+        , methodFactors = cfs
+        }
+
+collection :: [Method] -> MethodCollection
+collection ms = MethodCollection ms [] [] []
+
+-- | Serialize, decoding the bytes for inspection.
+serialize :: MethodCollection -> Either Text (Text, [Text])
+serialize = fmap (first TE.decodeUtf8) . serializeColumnarMethodCSV
+
+{- | The writer sorts rows by key, so a round-trip preserves the factor
+/set/ per method, not the original order. The flow UUID is derived from the
+raw compartment cell at parse time, and the writer canonicalizes legacy
+prose cells ("Resources" → "natural resource"), so it is regenerated — not
+preserved — data; the comparison drops it and keeps everything else.
+-}
+normalize :: [Method] -> [Method]
+normalize =
+    map
+        ( \m ->
+            m
+                { methodFactors =
+                    sortOn
+                        (\cf -> (mcfFlowName cf, show (mcfCompartment cf), mcfValue cf))
+                        (map (\cf -> cf{mcfFlowRef = nil}) (methodFactors m))
+                }
+        )
+
+reparse :: Text -> Either String [Method]
+reparse = parseMethodCSVBytes . TE.encodeUtf8
+
+spec :: Spec
+spec = describe "Method.WriterCSV" $ do
+    describe "round-trip with the columnar parser" $ do
+        it "parse → write → parse reproduces the methods (modulo row order)" $ do
+            raw <- BS.readFile "test/data/method.csv"
+            case parseMethodCSVBytes raw of
+                Left err -> expectationFailure ("fixture parse failed: " <> err)
+                Right ms1 ->
+                    case serializeColumnarMethodCSV (collection ms1) of
+                        Left err -> expectationFailure ("write failed: " <> T.unpack err)
+                        Right (bytes, warnings) -> do
+                            warnings `shouldBe` []
+                            case parseMethodCSVBytes bytes of
+                                Left err -> expectationFailure ("re-parse failed: " <> err)
+                                Right ms2 -> normalize ms2 `shouldBe` normalize ms1
+
+        it "write → parse → write is byte-stable" $ do
+            raw <- BS.readFile "test/data/method.csv"
+            case parseMethodCSVBytes raw of
+                Left err -> expectationFailure ("fixture parse failed: " <> err)
+                Right ms1 ->
+                    case serializeColumnarMethodCSV (collection ms1) of
+                        Left err -> expectationFailure ("write failed: " <> T.unpack err)
+                        Right (b1, _) ->
+                            case parseMethodCSVBytes b1 of
+                                Left err -> expectationFailure ("re-parse failed: " <> err)
+                                Right ms2 ->
+                                    case serializeColumnarMethodCSV (collection ms2) of
+                                        Left err -> expectationFailure ("re-write failed: " <> T.unpack err)
+                                        Right (b2, _) -> b2 `shouldBe` b1
+
+        it "a category name containing the delimiter survives via quoting" $ do
+            let m = mkMethod "Ecotoxicity; freshwater" [mkCF "Zinc" (Just (Compartment "water" "" "")) 2.5]
+            case serialize (collection [m]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (out, _) ->
+                    case reparse out of
+                        Left err -> expectationFailure ("re-parse failed: " <> err)
+                        Right ms -> map methodName ms `shouldBe` ["Ecotoxicity; freshwater"]
+
+        it "keeps subcompartment and qualifier through the compartment path" $ do
+            let cf = mkCF "Arsenic" (Just (Compartment "water" "groundwater" "long-term")) 1.5
+            case serialize (collection [mkMethod "Ecotoxicity" [cf]]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (out, _) -> do
+                    out `shouldSatisfy` T.isInfixOf "Arsenic;water/groundwater/long-term;;kg;1.5"
+                    case reparse out of
+                        Left err -> expectationFailure ("re-parse failed: " <> err)
+                        Right ms ->
+                            concatMap (map mcfCompartment . methodFactors) ms
+                                `shouldBe` [Just (Compartment "water" "groundwater" "long-term")]
+
+        it "keeps a CAS number and a per-row flow unit" $ do
+            let a = (mkCF "Carbon dioxide" (Just (Compartment "air" "" "")) 1){mcfCAS = Just "124-38-9"}
+                b = (mkCF "Occupation, annual crop" (Just (Compartment "land occupation" "" "")) 50){mcfDirection = Input, mcfUnit = "m2a"}
+            case serialize (collection [mkMethod "Mixed" [a, b]]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (out, warnings) -> do
+                    warnings `shouldBe` []
+                    out `shouldSatisfy` T.isInfixOf "Carbon dioxide;air;124-38-9;kg;1"
+                    out `shouldSatisfy` T.isInfixOf "Occupation, annual crop;land occupation;;m2a;50"
+                    case reparse out of
+                        Left err -> expectationFailure ("re-parse failed: " <> err)
+                        Right ms -> do
+                            let cfs = sortOn mcfFlowName (concatMap methodFactors ms)
+                            map mcfCAS cfs `shouldBe` [Just "124-38-9", Nothing]
+                            map mcfUnit cfs `shouldBe` ["kg", "m2a"]
+                            map mcfDirection cfs `shouldBe` [Output, Input]
+
+        it "writes a regionalized CF as a name-suffixed substance row" $ do
+            let cf = (mkCF "Water" (Just (Compartment "natural resource" "in water" "")) 42.95){mcfDirection = Input, mcfConsumerLocation = Just "FR"}
+            case serialize (collection [mkMethod "Water use" [cf]]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (out, warnings) -> do
+                    warnings `shouldBe` []
+                    out `shouldSatisfy` T.isInfixOf "Water, FR;natural resource/in water;;kg;42.95"
+                    case reparse out of
+                        Left err -> expectationFailure ("re-parse failed: " <> err)
+                        Right ms -> do
+                            let cfs = concatMap methodFactors ms
+                            map mcfFlowName cfs `shouldBe` ["Water, FR"]
+                            map mcfConsumerLocation cfs `shouldBe` [Nothing]
+
+        it "keeps duplicate factors for one key as separate rows" $ do
+            let cf = mkCF "Chlordane" (Just (Compartment "air" "indoor" ""))
+            case serialize (collection [mkMethod "Ecotoxicity" [cf 3.1, cf 6.2]]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (out, _) ->
+                    case reparse out of
+                        Left err -> expectationFailure ("re-parse failed: " <> err)
+                        Right ms -> sortOn id (map mcfValue (concatMap methodFactors ms)) `shouldBe` [3.1, 6.2]
+
+    describe "warnings (never silent)" $ do
+        it "warns once, bounded, when directions cannot be re-derived" $ do
+            let cf = (mkCF "Carbon dioxide" (Just (Compartment "air" "" "")) 1){mcfDirection = Input}
+            case serialize (collection [mkMethod "Uptake" [cf, cf{mcfFlowName = "Methane"}]]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (_, warnings) -> do
+                    warnings `shouldSatisfy` any (T.isInfixOf "2 factors have a flow direction")
+                    length warnings `shouldBe` 1
+
+        it "warns about descriptions, damage categories, NW sets and scoring sets" $ do
+            let m = (mkMethod "Climate change" []){methodDescription = Just "GWP100"}
+                dc = DamageCategory "Human health" "DALY" [("Climate change", 1)]
+                nw = NormWeightSet "EF" (M.singleton "Climate change" 1) M.empty
+                ss = ScoringSet "EF score" "Pt" M.empty M.empty M.empty M.empty M.empty M.empty Nothing
+                mc = MethodCollection [m] [dc] [nw] [ss]
+            case serialize mc of
+                Left err -> expectationFailure (T.unpack err)
+                Right (_, warnings) -> do
+                    warnings `shouldSatisfy` any (T.isInfixOf "descriptions")
+                    warnings `shouldSatisfy` any (T.isInfixOf "damage categories")
+                    warnings `shouldSatisfy` any (T.isInfixOf "normalization/weighting")
+                    warnings `shouldSatisfy` any (T.isInfixOf "scoring sets")
+
+        it "warns when methodologies differ and omits the comment" $ do
+            let m1 = (mkMethod "A" []){methodMethodology = Just "EF"}
+                m2 = (mkMethod "B" []){methodMethodology = Just "ReCiPe"}
+            case serialize (collection [m1, m2]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (out, warnings) -> do
+                    out `shouldNotSatisfy` T.isInfixOf "# methodology"
+                    warnings `shouldSatisfy` any (T.isInfixOf "methodologies")
+
+        it "writes the shared methodology as the file comment" $ do
+            let m = (mkMethod "A" []){methodMethodology = Just "Environmental Footprint"}
+            case serialize (collection [m]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (out, warnings) -> do
+                    warnings `shouldBe` []
+                    out `shouldSatisfy` T.isPrefixOf "# methodology: Environmental Footprint\n"
+
+    describe "exportability guard" $ do
+        it "rejects an empty collection" $
+            serialize (collection []) `shouldSatisfy` isRefused "no impact categories"
+
+        it "rejects a blank category name" $
+            serialize (collection [mkMethod "  " []]) `shouldSatisfy` isRefused "blank name"
+
+        it "rejects a non-finite characterization factor" $ do
+            let cf = mkCF "Carbon dioxide" (Just (Compartment "air" "" "")) (0 / 0)
+            serialize (collection [mkMethod "Climate change" [cf]]) `shouldSatisfy` isRefused "non-finite"
+
+        it "rejects a line break inside a field" $ do
+            let cf = mkCF "Carbon\ndioxide" (Just (Compartment "air" "" "")) 1
+            serialize (collection [mkMethod "Climate change" [cf]]) `shouldSatisfy` isRefused "line break"
+
+        it "rejects a compartment segment containing the path separator" $ do
+            let cf = mkCF "Zinc" (Just (Compartment "water" "ground/deep" "")) 1
+            serialize (collection [mkMethod "Ecotoxicity" [cf]]) `shouldSatisfy` isRefused "path separator"
+
+        it "rejects a compartment the parser cannot read back" $ do
+            let cf = mkCF "Zinc" (Just (Compartment "economic" "" "")) 1
+            serialize (collection [mkMethod "Ecotoxicity" [cf]]) `shouldSatisfy` isRefused "outside the ones"
+
+    describe "format dispatch (Database.Export)" $ do
+        it "accepts the 'csv' format name" $
+            parseMethodExportFormat "csv" `shouldBe` Right MethodColumnarCSV
+
+isRefused :: Text -> Either Text a -> Bool
+isRefused needle result = case result of
+    Left err -> needle `T.isInfixOf` err
+    Right _ -> False

--- a/test/MethodWriterCSVSpec.hs
+++ b/test/MethodWriterCSVSpec.hs
@@ -195,6 +195,17 @@ spec = describe "Method.WriterCSV" $ do
                     out `shouldNotSatisfy` T.isInfixOf "# methodology"
                     warnings `shouldSatisfy` any (T.isInfixOf "methodologies")
 
+        it "warns when a stated methodology sits next to an absent one" $ do
+            -- An absent methodology is not a distinct one, but it blocks the
+            -- shared comment — the one stated methodology is still lost.
+            let m1 = (mkMethod "A" []){methodMethodology = Just "EF"}
+                m2 = mkMethod "B" []
+            case serialize (collection [m1, m2]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (out, warnings) -> do
+                    out `shouldNotSatisfy` T.isInfixOf "# methodology"
+                    warnings `shouldSatisfy` any (T.isInfixOf "1 distinct stated methodologies")
+
         it "writes the shared methodology as the file comment" $ do
             let m = (mkMethod "A" []){methodMethodology = Just "Environmental Footprint"}
             case serialize (collection [m]) of

--- a/test/MethodWriterSimaProSpec.hs
+++ b/test/MethodWriterSimaProSpec.hs
@@ -12,8 +12,7 @@ import qualified Data.Text.Encoding as TE
 import Data.UUID (nil)
 import Test.Hspec
 
-import Database.Export (serializeMethodCollection)
-import Database.Upload (DatabaseFormat (..))
+import Database.Export (parseMethodExportFormat)
 import Method.ParserSimaPro (isSimaProMethodCSV, parseSimaProMethodCSVBytes)
 import Method.Types
 import Method.WriterSimaPro (serializeSimaProMethodCSV)
@@ -194,11 +193,10 @@ spec = describe "Method.WriterSimaPro" $ do
             serialize mc `shouldSatisfy` isRefused "blank name"
 
     describe "format dispatch (Database.Export)" $ do
-        it "refuses non-SimaPro formats with a clear message" $ do
-            let mc = collection [mkMethod "Climate change" []]
-            case serializeMethodCollection ILCDProcess "EF" mc of
-                Left err -> err `shouldSatisfy` T.isInfixOf "SimaPro CSV"
-                Right _ -> expectationFailure "expected a Left for a format without a method writer"
+        it "refuses a format without a method writer at parse time" $ do
+            case parseMethodExportFormat "ilcd" of
+                Left err -> err `shouldSatisfy` T.isInfixOf "unknown method export format"
+                Right f -> expectationFailure ("expected a Left, got: " <> show f)
 
 isRefused :: Text -> Either Text a -> Bool
 isRefused needle result = case result of

--- a/volca.cabal
+++ b/volca.cabal
@@ -61,6 +61,7 @@ library
                      , Method.Parser.OlcaSchema
                      , Method.ParserCSV
                      , Method.ParserSimaPro
+                     , Method.WriterCSV
                      , Method.WriterSimaPro
                      , Method.ParserNW
                      , Method.Mapping
@@ -296,6 +297,7 @@ test-suite lca-tests
                      , LicensesSpec
                      , GeographiesSpec
                      , MethodUploadSpec
+                     , MethodWriterCSVSpec
                      , MethodWriterSimaProSpec
                      , AuthSpec
                      , CLISpec


### PR DESCRIPTION
Second method-export target, after the SimaPro method CSV writer (#240): **columnar CSV** — one column per impact category, one row per substance, the file an analyst opens in a spreadsheet. Same transport end to end: `POST /api/v1/method-collections/{name}/export` with `{"format": "csv"}`, `volca method export NAME --format csv`, pyvolca `export_method_collection(name, fmt="csv")`, warnings in `X-Volca-Export-Warnings`.

**Method export formats get their own type.** Dispatching method exports on `DatabaseFormat` forced five 'no method writer' runtime arms and let callers name targets that can never apply; `MethodExportFormat` + `parseMethodExportFormat` reject an unsupported target at parse time (`unknown method export format: ilcd (expected simapro|csv)`), and the columnar format — which is not a database format at all — fits naturally.

**The format grew what real methods need, measured on EF 3.1.** As it stood, columnar CSV could not carry a real method: 9 factors out of 10 are subcompartment-specific (53 444 value collisions when flattened), one category mixes kg, m3 and MJ flow units, and 1 352 fields contain the delimiter. Backward-compatible extensions, read back by the parser and emitted by the writer: optional `cas` and `unit` key columns named by the label row, a `top/sub/qualifier` compartment path next to the legacy prose spellings, land occupation/transformation media, and RFC 4180 quoting both ways (one `splitRow`/`joinRow` inverse pair in `Method.CSV`). Legacy files parse unchanged.

**Two parser bugs surfaced and fixed at the root.** Numbers in columnar and NW method CSVs drifted in the last ulp (`Data.Text.Read.double`: `1.2227e-3` → `1.2227000000000002e-3`) — every such factor was off by one ulp, and one NW spec had baked the drifted value into its expectation; `parseDouble` now goes through the correctly-rounded `reads`. And the naive cell split tore quoted fields apart, as it did in the SimaPro parser before #240.

**Honesty.** The guard refuses what re-import would corrupt (a compartment top the parser cannot read back, a blank category name, non-finite values, line breaks, `/` inside a segment); warnings report what the format has no room for (underivable flow directions, damage categories, NW sets, scoring sets, descriptions, mixed methodologies). Duplicate factors for one key become extra rows, never a merged value.

**Verified on real data**: EF 3.1 JRC (ILCD, 25 methods, 319 575 CFs) and the BAFU SimaPro distribution (233 131 CFs) both round-trip with the exact factor multiset and are byte-stable on write→parse→write; HTTP, CLI and the pure function produce byte-identical files.