### PR TITLE
Export method collections as openLCA JSON-LD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,16 @@
   databases.
 
 ### Added
+- Method collections can be exported as openLCA JSON-LD (`openlca`): a zip
+  of one `ImpactCategory` document per impact category, in the olca-schema
+  archive layout, that loads straight back. Flow UUIDs, per-factor
+  directions (`INPUT`/`OUTPUT`) and location codes are native to this
+  format, so regionalized collections round-trip without the name-suffix
+  projection the CSV formats use. What it cannot carry (methodology
+  labels, damage categories, normalization/weighting and scoring sets) is
+  reported in export warnings. The openLCA reader now also picks up the
+  document-level `category` field as the impact category's group label,
+  and method files load in a deterministic order on every machine.
 - Method collections can be exported as columnar CSV — one column per
   impact category, one row per substance: the file you open in a
   spreadsheet. `POST /api/v1/method-collections/{name}/export` with

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It loads EcoSpold2, EcoSpold1, SimaPro CSV, ILCD process, and Brightway Excel da
 - **Archive support**: Load databases directly from .zip, .7z, .gz, or .xz archives — no manual extraction
 - **Cross-database linking**: Resolve supplier references across databases, with configurable dependencies and topological load ordering. EcoSpold2 inputs link to a loaded background by exact `activityLinkId` identity (so a partial import resolves against its matching release), falling back to attribute matching — flagged as approximate — when the background is a different release
 - **Cross-DB what-if substitutions**: Swap an upstream activity at any depth — including suppliers in dependency databases — and recompute inventory and impacts through one endpoint
-- **LCIA method collections**: Load ILCD method packages (ZIP or directory), SimaPro method CSV exports, or tabular CSV from config; export any loaded collection back as SimaPro method CSV or as columnar CSV (one column per impact category — the spreadsheet view)
+- **LCIA method collections**: Load ILCD method packages (ZIP or directory), SimaPro method CSV exports, openLCA JSON-LD impact categories, or tabular CSV from config; export any loaded collection back as SimaPro method CSV, columnar CSV (one column per impact category — the spreadsheet view), or an openLCA JSON-LD zip
 - **Normalization and weighting**: Batch LCIA computes normalized and weighted scores per category and a single aggregated score (Pt) when NW data is present in the method collection
 - **Contribution analysis**: Per-flow and per-activity contributions to any LCIA score, ranked by share
 - **Flow mapping engine**: 4-step matching cascade (UUID → name → synonym → CAS) with per-strategy coverage statistics
@@ -444,7 +444,7 @@ volca database export my-db --format simapro --out out.csv
 # List, upload, export, delete method collections
 volca method                                    # list (default)
 volca method upload EF-3.1.zip --name "EF 3.1"  # upload
-volca method export ef-31 --format simapro --out ef-31.csv  # export (formats: simapro | csv)
+volca method export ef-31 --format simapro --out ef-31.csv  # export (formats: simapro | csv | openlca)
 volca method delete ef-31                        # delete
 ```
 
@@ -499,7 +499,7 @@ volca method delete ef-31                        # delete
 | Upload collection | `POST /method-collections/upload` | `method upload FILE --name NAME` |
 | Load / unload collection | `POST /method-collections/{name}/(load\|unload)` | — |
 | Delete collection | `DELETE /method-collections/{name}` | `method delete NAME` |
-| Export collection (SimaPro or columnar CSV) | `POST /method-collections/{name}/export` | `method export NAME --format simapro --out FILE` |
+| Export collection (SimaPro CSV, columnar CSV, or openLCA JSON-LD) | `POST /method-collections/{name}/export` | `method export NAME --format simapro --out FILE` |
 | **Reference Data** | | |
 | Flow synonyms | `GET /flow-synonyms` (+ load/unload/upload/delete/groups/download) | `synonyms` |
 | Compartment mappings | `GET /compartment-mappings` (+ load/unload/upload/delete) | `compartment-mappings` |

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -529,9 +529,10 @@ warnings arrive in the ``X-Volca-Export-Warnings`` response header
 
 Export a loaded method collection, returning the serialized bytes.
 
-``fmt`` names the target format: ``simapro`` (SimaPro method CSV) or
+``fmt`` names the target format: ``simapro`` (SimaPro method CSV),
 ``csv`` (columnar CSV — one column per impact category, the
-spreadsheet view). Projection warnings (anything the format cannot
+spreadsheet view), or ``openlca`` (a zip of openLCA JSON-LD impact
+categories). Projection warnings (anything the format cannot
 carry faithfully) arrive in the ``X-Volca-Export-Warnings`` response
 header and are surfaced through :mod:`warnings`. Raises VoLCAError
 on an HTTP error, including a collection that is not loaded.

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -142,7 +142,7 @@ client-side so a typo fails before the round-trip with the same message
 shape the engine would have returned."""
 
 
-_METHOD_EXPORT_FORMATS = frozenset({"simapro", "csv"})
+_METHOD_EXPORT_FORMATS = frozenset({"simapro", "csv", "openlca"})
 """Target keywords accepted by ``POST /api/v1/method-collections/{name}/export``.
 
 Mirrors the engine's ``parseMethodExportFormat`` — a space of its own,
@@ -1885,9 +1885,10 @@ class Client:
     def export_method_collection(self, name: str, fmt: str = "simapro") -> bytes:
         """Export a loaded method collection, returning the serialized bytes.
 
-        ``fmt`` names the target format: ``simapro`` (SimaPro method CSV) or
+        ``fmt`` names the target format: ``simapro`` (SimaPro method CSV),
         ``csv`` (columnar CSV — one column per impact category, the
-        spreadsheet view). Projection warnings (anything the format cannot
+        spreadsheet view), or ``openlca`` (a zip of openLCA JSON-LD impact
+        categories). Projection warnings (anything the format cannot
         carry faithfully) arrive in the ``X-Volca-Export-Warnings`` response
         header and are surfaced through :mod:`warnings`. Raises VoLCAError
         on an HTTP error, including a collection that is not loaded.

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -159,7 +159,7 @@ mcExportArgsParser :: Parser McExportArgs
 mcExportArgsParser =
     McExportArgs
         <$> textArg "NAME" "Name of the loaded method collection to export"
-        <*> textOpt "format" Nothing "FMT" "Target format: simapro|csv"
+        <*> textOpt "format" Nothing "FMT" "Target format: simapro|csv|openlca"
         <*> strOpt "out" Nothing "FILE" "Output file path"
 
 {- | Delete-by-selection parser: positional DB plus filter options. @--keep@ and
@@ -188,7 +188,7 @@ methodParser =
                 ( OA.command "list" (info (pure McList) (progDesc "List method collections"))
                     <> OA.command "upload" (info (McUpload <$> uploadArgsParser) (progDesc "Upload a method collection from a local file"))
                     <> OA.command "delete" (info (McDelete <$> deleteNameParser) (progDesc "Delete a method collection"))
-                    <> OA.command "export" (info (McExport <$> mcExportArgsParser <**> helper) (progDesc "Export a loaded method collection to a file (SimaPro or columnar CSV)"))
+                    <> OA.command "export" (info (McExport <$> mcExportArgsParser <**> helper) (progDesc "Export a loaded method collection to a file (SimaPro CSV, columnar CSV, or openLCA JSON-LD)"))
                 )
             )
 

--- a/src/Database/Export.hs
+++ b/src/Database/Export.hs
@@ -36,6 +36,7 @@ import qualified EcoSpold.Writer2 as ES2
 import qualified ILCD.Writer as ILCD
 import Method.Types (MethodCollection)
 import qualified Method.WriterCSV as MWC
+import qualified Method.WriterOlcaSchema as MWO
 import qualified Method.WriterSimaPro as MW
 import qualified SimaPro.Writer as SP
 import Types (Database, toSimpleDatabase)
@@ -79,6 +80,7 @@ wall of runtime 'Left's.
 data MethodExportFormat
     = MethodSimaProCSV -- SimaPro method CSV ({methods} block)
     | MethodColumnarCSV -- columnar CSV (one column per impact category)
+    | MethodOpenLcaJsonLd -- openLCA JSON-LD zip (one ImpactCategory per method)
     deriving (Show, Eq)
 
 {- | Parse a user-facing method-export format name (case- and
@@ -89,7 +91,8 @@ parseMethodExportFormat :: Text -> Either Text MethodExportFormat
 parseMethodExportFormat raw = case T.toLower (T.strip raw) of
     "simapro" -> Right MethodSimaProCSV
     "csv" -> Right MethodColumnarCSV
-    other -> Left ("unknown method export format: " <> other <> " (expected simapro|csv)")
+    "openlca" -> Right MethodOpenLcaJsonLd
+    other -> Left ("unknown method export format: " <> other <> " (expected simapro|csv|openlca)")
 
 {- | Serialize a loaded method collection in the requested format, paired with
 the projection warnings. The name is the collection's own (used as the
@@ -102,6 +105,8 @@ serializeMethodCollection fmt name mc = case fmt of
             <$> MW.serializeSimaProMethodCSV SP.defaultWriterConfig name mc
     MethodColumnarCSV ->
         first BL.fromStrict <$> MWC.serializeColumnarMethodCSV mc
+    MethodOpenLcaJsonLd ->
+        first zipFiles <$> MWO.serializeOlcaMethodEntries mc
 
 {- | Parse a user-facing export-format name (case- and whitespace-insensitive)
 to a 'DatabaseFormat'. Shared by the CLI and the HTTP handler so the accepted

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -126,7 +126,7 @@ import qualified Data.Aeson as A
 import Data.Bifunctor (first)
 import Data.Char (toLower)
 import Data.Either (lefts, partitionEithers, rights)
-import Data.List (isPrefixOf, sortOn, unsnoc)
+import Data.List (isPrefixOf, sort, sortOn, unsnoc)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing)
@@ -2952,7 +2952,10 @@ loadMethodCollectionFromConfig mc = do
                     else do
                         -- Find method directory (handles nested ILCD structures)
                         d <- findMethodDirectory resolvedPath
-                        fs <- listDirectory d
+                        -- listDirectory order is filesystem-dependent; sort so a
+                        -- collection loads its methods in the same order on every
+                        -- machine (and a re-export of it is byte-stable).
+                        fs <- sort <$> listDirectory d
                         let xs = filter (\f -> map toLower (takeExtension f) == ".xml") fs
                             cs = filter (\f -> map toLower (takeExtension f) == ".csv") fs
                             js = filter (\f -> map toLower (takeExtension f) == ".json") fs

--- a/src/Method/Parser/OlcaSchema.hs
+++ b/src/Method/Parser/OlcaSchema.hs
@@ -24,6 +24,10 @@ Top-level shape:
 >   ]
 > }
 
+The document-level @category@ (the impact category's group label, a plain
+string in the olca schema) becomes 'methodCategory', falling back to the
+name when absent.
+
 Each 'ImpactFactor' becomes a single 'MethodCF':
 
 * @flow.\@id@ → 'mcfFlowRef' (UUID — deterministic match against DB flow UUIDs)
@@ -97,7 +101,7 @@ parseOlcaImpactCategoryBytes bytes = do
                     , methodName = name
                     , methodDescription = description
                     , methodUnit = unit
-                    , methodCategory = name
+                    , methodCategory = fromMaybe name (lookupText o "category")
                     , methodMethodology = Just "openLCA JSON-LD"
                     , methodFactors = factors
                     }

--- a/src/Method/WriterOlcaSchema.hs
+++ b/src/Method/WriterOlcaSchema.hs
@@ -1,0 +1,195 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Writer for LCIA methods as openLCA JSON-LD — the exact inverse of
+'Method.Parser.OlcaSchema'. Each method becomes one @ImpactCategory@
+document, named @lcia_categories/\<method-uuid\>.json@ (the olca-schema
+archive layout, which the loader's directory scan finds again on
+re-import). The caller packs the entries into a zip.
+
+What round-trips exactly: the method UUID, name, category label,
+description, reference unit, and per-factor flow UUID/name/CAS, value,
+unit, direction (@INPUT@/@OUTPUT@ is native here — no compartment
+heuristic), and location code. Entries are sorted by file name so a
+loaded-then-re-exported archive is byte-identical.
+
+Projection (documented, no warning): a compartment qualifier folds into
+the subcompartment — the category path @medium/sub/qualifier@ reads back
+as @(medium, \"sub\/qualifier\")@, the same fold the SimaPro writer applies
+to long-term.
+
+Not representable (reported as warnings): methodology labels (re-import
+stamps \"openLCA JSON-LD\"), blank category labels (they read back as the
+name), damage categories, normalization\/weighting sets, and scoring sets.
+-}
+module Method.WriterOlcaSchema (
+    serializeOlcaMethodEntries,
+    checkOlcaExportable,
+) where
+
+import Data.Aeson (KeyValue ((.=)))
+import Data.Aeson.Encoding (Encoding, Series, encodingToLazyByteString, list, pair, pairs)
+import qualified Data.Aeson.Key as K
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BL
+import Data.List (sortOn)
+import qualified Data.Map.Strict as M
+import Data.Maybe (mapMaybe)
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.UUID as UUID
+
+import Method.Types
+
+{- | Serialize a method collection to openLCA JSON-LD zip entries, paired
+with the projection warnings. 'Left' when the format cannot represent the
+collection without silent corruption on re-import ('checkOlcaExportable').
+-}
+serializeOlcaMethodEntries :: MethodCollection -> Either Text ([(FilePath, BS.ByteString)], [Text])
+serializeOlcaMethodEntries mc = do
+    checkOlcaExportable mc
+    let entries =
+            [ (entryPath m, BL.toStrict (encodingToLazyByteString (methodDoc m)))
+            | m <- mcMethods mc
+            ]
+    pure (sortOn fst entries, lossWarnings mc)
+
+-- | Archive entry for one method, keyed by its UUID (unique by the guard).
+entryPath :: Method -> FilePath
+entryPath m = "lcia_categories/" <> UUID.toString (methodId m) <> ".json"
+
+{- | One @ImpactCategory@ document. Keys the parser reads nothing from when
+empty (description, unit, CAS, …) are omitted rather than emitted blank —
+the parser treats an empty string as absent, so both spellings read back
+the same and only one of them is canonical.
+-}
+methodDoc :: Method -> Encoding
+methodDoc m =
+    pairs $
+        "@context" .= ("http://greendelta.github.io/olca-schema/context.jsonld" :: Text)
+            <> "@type" .= ("ImpactCategory" :: Text)
+            <> "@id" .= UUID.toText (methodId m)
+            <> "name" .= methodName m
+            <> categorySeries
+            <> maybe mempty (optKey "description") (methodDescription m)
+            <> optKey "referenceUnitName" (methodUnit m)
+            <> pair "impactFactors" (list factorDoc (methodFactors m))
+  where
+    -- The parser falls back to the name when category is absent, so a label
+    -- equal to the name needs no field of its own.
+    categorySeries
+        | methodCategory m == methodName m = mempty
+        | otherwise = optKey "category" (methodCategory m)
+
+factorDoc :: MethodCF -> Encoding
+factorDoc cf =
+    pairs $
+        "@type" .= ("ImpactFactor" :: Text)
+            <> "value" .= mcfValue cf
+            <> pair "flow" (flowDoc cf)
+            <> "direction" .= directionText (mcfDirection cf)
+            <> optRef "unit" "Unit" "name" (mcfUnit cf)
+            <> maybe mempty (optRef "location" "Location" "code") (mcfConsumerLocation cf)
+
+flowDoc :: MethodCF -> Encoding
+flowDoc cf =
+    pairs $
+        "@type" .= ("Flow" :: Text)
+            <> "@id" .= UUID.toText (mcfFlowRef cf)
+            <> "name" .= mcfFlowName cf
+            <> "flowType" .= ("ELEMENTARY_FLOW" :: Text)
+            <> maybe mempty (optKey "cas") (mcfCAS cf)
+            <> maybe mempty categoryRef (mcfCompartment cf)
+
+-- | The compartment as a @Category@ Ref whose name is the slash path.
+categoryRef :: Compartment -> Series
+categoryRef comp =
+    pair "category" (pairs ("@type" .= ("Category" :: Text) <> "name" .= compartmentPath comp))
+
+{- | The @medium/sub/qualifier@ path, segments stripped (the parser strips
+what it reads back), empty segments dropped.
+-}
+compartmentPath :: Compartment -> Text
+compartmentPath (Compartment medium sub qualifier) =
+    T.intercalate "/" (filter (not . T.null) (map T.strip [medium, sub, qualifier]))
+
+directionText :: FlowDirection -> Text
+directionText Input = "INPUT"
+directionText Output = "OUTPUT"
+
+-- | Emit @key@ only when the value is non-empty.
+optKey :: Text -> Text -> Series
+optKey key value
+    | T.null value = mempty
+    | otherwise = K.fromText key .= value
+
+-- | A one-field Ref object (@unit@, @location@), omitted when the value is empty.
+optRef :: Text -> Text -> Text -> Text -> Series
+optRef key refType field value
+    | T.null value = mempty
+    | otherwise = pair (K.fromText key) (pairs ("@type" .= refType <> K.fromText field .= value))
+
+{- | Representation losses the format cannot carry; counted, never dropped
+silently. Blank category labels are a loss (not a guard) because the
+collection still re-imports correctly except for that one label.
+-}
+lossWarnings :: MethodCollection -> [Text]
+lossWarnings mc =
+    mapMaybe
+        (\(count, what) -> if count == 0 then Nothing else Just (T.pack (show count) <> " " <> what))
+        [ (S.size lostMethodologies, "methodology labels are not representable in openLCA JSON-LD (re-import reads \"openLCA JSON-LD\")")
+        , (length blankCategories, "blank impact category group labels read back as the category name")
+        , (length (mcDamageCategories mc), "damage categories are not representable in openLCA JSON-LD")
+        , (length (mcNormWeightSets mc), "normalization/weighting sets are not representable in openLCA JSON-LD")
+        , (length (mcScoringSets mc), "formula scoring sets are not representable in openLCA JSON-LD")
+        ]
+  where
+    -- "openLCA JSON-LD" is what re-import stamps, so that label survives.
+    lostMethodologies =
+        S.fromList [x | Just x <- map methodMethodology (mcMethods mc), x /= "openLCA JSON-LD"]
+    blankCategories =
+        [() | m <- mcMethods mc, T.null (methodCategory m), not (T.null (methodName m))]
+
+{- | Reject a collection the format cannot represent without silent
+corruption on re-import: no impact categories, two methods sharing a UUID
+(their archive entries would overwrite each other), a factor with no flow
+name (the parser silently drops it), a non-finite value (JSON encodes it
+as @null@ and the parser silently drops the factor), or a compartment
+whose medium is empty or contains @/@ (the path would read back shifted
+or compartment-less).
+-}
+checkOlcaExportable :: MethodCollection -> Either Text ()
+checkOlcaExportable mc
+    | null (mcMethods mc) = Left "method collection has no impact categories"
+    | otherwise = do
+        checkUniqueIds (mcMethods mc)
+        mapM_ checkMethod (mcMethods mc)
+  where
+    checkUniqueIds ms =
+        case M.toList (M.filter ((> 1) . length) (M.fromListWith (<>) [(methodId m, [methodName m]) | m <- ms])) of
+            [] -> Right ()
+            (mid, names) : _ ->
+                Left
+                    ( "impact categories share the id "
+                        <> UUID.toText mid
+                        <> " ("
+                        <> T.intercalate ", " names
+                        <> "); their archive entries would overwrite each other"
+                    )
+    checkMethod m = mapM_ (checkCF (methodName m)) (methodFactors m)
+    checkCF cat cf = do
+        finite ("characterization factor for '" <> mcfFlowName cf <> "' in '" <> cat <> "'") (mcfValue cf)
+        checkFlowName cat cf
+        mapM_ checkCompartment (mcfCompartment cf)
+    checkFlowName cat cf
+        | T.null (mcfFlowName cf) =
+            Left ("a characterization factor in '" <> cat <> "' has no flow name; re-import would silently drop it")
+        | otherwise = Right ()
+    checkCompartment (Compartment medium _ _)
+        | T.null (T.strip medium) = Left "compartment has an empty medium"
+        | T.any (== '/') medium =
+            Left ("compartment medium contains '/' (the path separator): " <> T.take 60 medium)
+        | otherwise = Right ()
+    finite label v
+        | isNaN v || isInfinite v = Left ("non-finite " <> label)
+        | otherwise = Right ()

--- a/test/MethodWriterOlcaSchemaSpec.hs
+++ b/test/MethodWriterOlcaSchemaSpec.hs
@@ -1,0 +1,252 @@
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Tests for the openLCA JSON-LD method writer ("Method.WriterOlcaSchema").
+module MethodWriterOlcaSchemaSpec (spec) where
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BL
+import Data.List (sortOn)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Data.UUID (UUID, fromWords)
+import qualified Data.UUID as UUID
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+
+import Config (MethodConfig (..))
+import Database.Export (MethodExportFormat (..), parseMethodExportFormat, serializeMethodCollection)
+import Database.Manager (loadMethodCollectionFromConfig)
+import Method.Parser.OlcaSchema (parseOlcaImpactCategoryBytes)
+import Method.Types
+import Method.WriterOlcaSchema (serializeOlcaMethodEntries)
+
+mkCF :: Text -> Maybe Compartment -> Double -> MethodCF
+mkCF name comp v =
+    MethodCF
+        { mcfFlowRef = fromWords 0 0 0 9
+        , mcfFlowName = name
+        , mcfDirection = Output
+        , mcfValue = v
+        , mcfCompartment = comp
+        , mcfCAS = Nothing
+        , mcfUnit = "kg"
+        , mcfConsumerLocation = Nothing
+        }
+
+mkId :: Word -> UUID
+mkId n = fromWords (fromIntegral n) 0 0 0
+
+mkMethod :: Word -> Text -> [MethodCF] -> Method
+mkMethod n name cfs =
+    Method
+        { methodId = mkId n
+        , methodName = name
+        , methodDescription = Nothing
+        , methodUnit = "kg eq"
+        , methodCategory = name
+        , methodMethodology = Nothing
+        , methodFactors = cfs
+        }
+
+collection :: [Method] -> MethodCollection
+collection ms = MethodCollection ms [] [] []
+
+{- | What a method reads back as: the methodology is the only field the
+format cannot carry, so re-import stamps its own.
+-}
+reimported :: Method -> Method
+reimported m = m{methodMethodology = Just "openLCA JSON-LD"}
+
+-- | Re-parse every archive entry, failing the test on a parse error.
+reparseEntries :: [(FilePath, BS.ByteString)] -> Either String [Method]
+reparseEntries = traverse (parseOlcaImpactCategoryBytes . snd)
+
+spec :: Spec
+spec = describe "Method.WriterOlcaSchema" $ do
+    describe "round-trip with the openLCA parser" $ do
+        it "write → parse reproduces each method exactly (UUIDs, order, factors)" $ do
+            let cfA = (mkCF "Carbon dioxide" (Just (Compartment "air" "" "")) 1.0){mcfCAS = Just "124-38-9"}
+                cfB =
+                    (mkCF "Water" (Just (Compartment "natural resource" "in water" "")) 42.95)
+                        { mcfDirection = Input
+                        , mcfConsumerLocation = Just "FR"
+                        , mcfUnit = "m3"
+                        }
+                m =
+                    (mkMethod 1 "Water use" [cfA, cfB])
+                        { methodDescription = Just "deprivation-weighted"
+                        , methodUnit = "m3 world eq"
+                        , methodCategory = "EF 3.1"
+                        }
+            case serializeOlcaMethodEntries (collection [m]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (entries, warnings) -> do
+                    warnings `shouldBe` []
+                    map fst entries `shouldBe` ["lcia_categories/" <> UUID.toString (mkId 1) <> ".json"]
+                    reparseEntries entries `shouldBe` Right [reimported m]
+
+        it "write → parse → write is byte-stable" $ do
+            let m =
+                    (mkMethod 3 "Acidification" [mkCF "Ammonia" (Just (Compartment "air" "" "")) 3.02])
+                        { methodCategory = "EF 3.1"
+                        , methodMethodology = Just "openLCA JSON-LD"
+                        }
+            case serializeOlcaMethodEntries (collection [m]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (entries, _) -> case reparseEntries entries of
+                    Left err -> expectationFailure ("re-parse failed: " <> err)
+                    Right ms ->
+                        serializeOlcaMethodEntries (collection ms)
+                            `shouldBe` Right (entries, [])
+
+        it "round-trips the mini fixture identically" $ do
+            raw <- BS.readFile "test-data/olca-schema-mini/impact-category-mini.json"
+            case parseOlcaImpactCategoryBytes raw of
+                Left err -> expectationFailure ("fixture parse failed: " <> err)
+                Right m ->
+                    case serializeOlcaMethodEntries (collection [m]) of
+                        Left err -> expectationFailure (T.unpack err)
+                        Right (entries, warnings) -> do
+                            warnings `shouldBe` []
+                            reparseEntries entries `shouldBe` Right [m]
+
+        it "folds the compartment qualifier into the subcompartment" $ do
+            let cf = mkCF "Arsenic" (Just (Compartment "water" "groundwater" "long-term")) 1.5
+            case serializeOlcaMethodEntries (collection [mkMethod 4 "Ecotoxicity" [cf]]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (entries, _) -> case reparseEntries entries of
+                    Right [m] ->
+                        map mcfCompartment (methodFactors m)
+                            `shouldBe` [Just (Compartment "water" "groundwater/long-term" "")]
+                    other -> expectationFailure ("unexpected re-parse: " <> show other)
+
+        it "sorts archive entries by method UUID" $ do
+            let ms = [mkMethod 2 "B" [], mkMethod 1 "A" []]
+            case serializeOlcaMethodEntries (collection ms) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (entries, _) ->
+                    map fst entries
+                        `shouldBe` [ "lcia_categories/" <> UUID.toString (mkId 1) <> ".json"
+                                   , "lcia_categories/" <> UUID.toString (mkId 2) <> ".json"
+                                   ]
+
+    describe "document shape" $ do
+        it "omits empty optional fields instead of writing them blank" $ do
+            let cf = (mkCF "Ammonia" Nothing 2.0){mcfUnit = ""}
+                m = (mkMethod 5 "Acidification" [cf]){methodUnit = ""}
+            case serializeOlcaMethodEntries (collection [m]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (entries, _) -> case entries of
+                    [(_, bytes)] -> do
+                        let doc = TE.decodeUtf8 bytes
+                        doc `shouldNotSatisfy` T.isInfixOf "referenceUnitName"
+                        doc `shouldNotSatisfy` T.isInfixOf "description"
+                        doc `shouldNotSatisfy` T.isInfixOf "\"unit\""
+                        doc `shouldNotSatisfy` T.isInfixOf "location"
+                        doc `shouldNotSatisfy` T.isInfixOf "cas"
+                        doc `shouldNotSatisfy` T.isInfixOf "category"
+                    other -> expectationFailure ("expected one entry, got " <> show (length other))
+
+        it "writes the category label only when it differs from the name" $ do
+            let m = (mkMethod 6 "Climate change" []){methodCategory = "EF 3.1"}
+            case serializeOlcaMethodEntries (collection [m]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (entries, _) -> case entries of
+                    [(_, bytes)] -> do
+                        TE.decodeUtf8 bytes `shouldSatisfy` T.isInfixOf "\"category\":\"EF 3.1\""
+                        reparseEntries entries `shouldBe` Right [reimported m]
+                    other -> expectationFailure ("expected one entry, got " <> show (length other))
+
+    describe "representation-loss warnings" $ do
+        it "counts methodology labels, blank group labels, damage, NW and scoring sets" $ do
+            let m1 = (mkMethod 7 "Climate change" []){methodMethodology = Just "Environmental Footprint"}
+                m2 = (mkMethod 8 "Acidification" []){methodCategory = ""}
+                dc = DamageCategory "Human health" "DALY" [("Climate change", 1)]
+                nw = NormWeightSet "EF" (M.singleton "Climate change" 1) M.empty
+                ss = ScoringSet "EF score" "Pt" M.empty M.empty M.empty M.empty M.empty M.empty Nothing
+            case serializeOlcaMethodEntries (MethodCollection [m1, m2] [dc] [nw] [ss]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (_, warnings) -> do
+                    warnings `shouldSatisfy` any (T.isInfixOf "1 methodology labels")
+                    warnings `shouldSatisfy` any (T.isInfixOf "1 blank impact category group labels")
+                    warnings `shouldSatisfy` any (T.isInfixOf "1 damage categories")
+                    warnings `shouldSatisfy` any (T.isInfixOf "1 normalization/weighting sets")
+                    warnings `shouldSatisfy` any (T.isInfixOf "1 formula scoring sets")
+
+        it "does not warn about the methodology re-import itself stamps" $ do
+            let m = (mkMethod 9 "A" []){methodMethodology = Just "openLCA JSON-LD"}
+            case serializeOlcaMethodEntries (collection [m]) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (_, warnings) -> warnings `shouldBe` []
+
+    describe "exportability guard" $ do
+        it "rejects an empty collection" $
+            serializeOlcaMethodEntries (collection []) `shouldSatisfy` isRefused "no impact categories"
+
+        it "rejects two methods sharing a UUID" $ do
+            let ms = [mkMethod 1 "A" [], mkMethod 1 "B" []]
+            serializeOlcaMethodEntries (collection ms) `shouldSatisfy` isRefused "share the id"
+
+        it "rejects a factor with no flow name" $ do
+            let cf = mkCF "" (Just (Compartment "air" "" "")) 1
+            serializeOlcaMethodEntries (collection [mkMethod 1 "A" [cf]])
+                `shouldSatisfy` isRefused "no flow name"
+
+        it "rejects a non-finite characterization factor" $ do
+            let cf = mkCF "Carbon dioxide" (Just (Compartment "air" "" "")) (0 / 0)
+            serializeOlcaMethodEntries (collection [mkMethod 1 "A" [cf]])
+                `shouldSatisfy` isRefused "non-finite"
+
+        it "rejects a compartment with an empty medium" $ do
+            let cf = mkCF "Zinc" (Just (Compartment " " "ground" "")) 1
+            serializeOlcaMethodEntries (collection [mkMethod 1 "A" [cf]])
+                `shouldSatisfy` isRefused "empty medium"
+
+        it "rejects a medium containing the path separator" $ do
+            let cf = mkCF "Zinc" (Just (Compartment "wa/ter" "" "")) 1
+            serializeOlcaMethodEntries (collection [mkMethod 1 "A" [cf]])
+                `shouldSatisfy` isRefused "path separator"
+
+    describe "zip archive end to end" $ do
+        it "the exported zip loads back through the method-collection loader" $ do
+            let cfA = (mkCF "Carbon dioxide" (Just (Compartment "air" "" "")) 1.0){mcfCAS = Just "124-38-9"}
+                cfB = (mkCF "Occupation, arable" (Just (Compartment "resource" "land" "")) 50){mcfDirection = Input, mcfUnit = "m2a"}
+                ms = [mkMethod 2 "Climate change" [cfA], mkMethod 1 "Land use" [cfB]]
+            case serializeMethodCollection MethodOpenLcaJsonLd "x" (collection ms) of
+                Left err -> expectationFailure (T.unpack err)
+                Right (zipBytes, _) -> withSystemTempDirectory "olca-export" $ \dir -> do
+                    let path = dir </> "methods.zip"
+                    BL.writeFile path zipBytes
+                    loaded <- loadMethodCollectionFromConfig (methodConfig path)
+                    case loaded of
+                        Left err -> expectationFailure ("reload failed: " <> T.unpack err)
+                        Right (coll, _) ->
+                            sortOn methodId (mcMethods coll)
+                                `shouldBe` sortOn methodId (map reimported ms)
+
+    describe "format dispatch (Database.Export)" $ do
+        it "accepts the 'openlca' format name" $
+            parseMethodExportFormat "openlca" `shouldBe` Right MethodOpenLcaJsonLd
+
+methodConfig :: FilePath -> MethodConfig
+methodConfig path =
+    MethodConfig
+        { mcName = "reload"
+        , mcPath = path
+        , mcActive = True
+        , mcIsUploaded = False
+        , mcDescription = Nothing
+        , mcFormat = Nothing
+        , mcScoringSets = []
+        , mcGlobalMethods = []
+        , mcPatches = []
+        }
+
+isRefused :: Text -> Either Text a -> Bool
+isRefused needle result = case result of
+    Left err -> needle `T.isInfixOf` err
+    Right _ -> False

--- a/test/OlcaSchemaSpec.hs
+++ b/test/OlcaSchemaSpec.hs
@@ -65,6 +65,21 @@ spec = do
                     UUID.toText (mcfFlowRef landFR)
                         `shouldBe` "0305b169-255d-4041-8f5d-6e095bcb6358"
 
+        it "reads the document-level category as the group label" $ do
+            let bytes =
+                    "{\"@type\":\"ImpactCategory\",\"name\":\"Acidification\",\
+                    \\"category\":\"EF 3.1\",\"referenceUnitName\":\"mol H+ eq\",\
+                    \\"impactFactors\":[]}"
+            case parseOlcaImpactCategoryBytes bytes of
+                Left err -> expectationFailure ("parse failed: " ++ err)
+                Right method -> methodCategory method `shouldBe` "EF 3.1"
+
+        it "falls back to the name when category is absent" $ do
+            bytes <- BS.readFile "test-data/olca-schema-mini/impact-category-mini.json"
+            case parseOlcaImpactCategoryBytes bytes of
+                Left err -> expectationFailure ("parse failed: " ++ err)
+                Right method -> methodCategory method `shouldBe` methodName method
+
         it "rejects a non-object top level" $
             case parseOlcaImpactCategoryBytes "[1,2,3]" of
                 Left _ -> pure ()

--- a/volca.cabal
+++ b/volca.cabal
@@ -62,6 +62,7 @@ library
                      , Method.ParserCSV
                      , Method.ParserSimaPro
                      , Method.WriterCSV
+                     , Method.WriterOlcaSchema
                      , Method.WriterSimaPro
                      , Method.ParserNW
                      , Method.Mapping
@@ -298,6 +299,7 @@ test-suite lca-tests
                      , GeographiesSpec
                      , MethodUploadSpec
                      , MethodWriterCSVSpec
+                     , MethodWriterOlcaSchemaSpec
                      , MethodWriterSimaProSpec
                      , AuthSpec
                      , CLISpec


### PR DESCRIPTION
Method collections can now be exported as `openlca`: a zip of one `ImpactCategory` JSON-LD document per impact category, in the olca-schema archive layout (`lcia_categories/<uuid>.json`), that the method-collection loader reads straight back. This is the third method-export format, after SimaPro CSV and columnar CSV.

openLCA JSON-LD is the roomiest of the three: flow UUIDs, per-factor directions (`INPUT`/`OUTPUT`) and location codes are native fields, so regionalized collections round-trip exactly, without the name-suffix projection the CSV writers use. The writer refuses anything a re-import would silently corrupt (a factor with no flow name, a non-finite value, duplicate method UUIDs, a compartment medium containing the path separator) and reports what the format cannot carry — methodology labels, damage categories, normalization/weighting and scoring sets — as export warnings.

Two small reader fixes back the round-trip:

- the openLCA parser now picks up the document-level `category` field as the impact category's group label (on EF 3.1, 21 of 25 categories have a label that differs from their name — it used to be dropped);
- method files load in a deterministic (sorted) order, so a collection loads the same on every machine and a loaded-then-re-exported archive is byte-identical.

Verified on real data: EF 3.1 JRC (25 methods, 319,575 CFs) and a SimaPro-exported EF collection (233,131 CFs) reload with the exact factor multiset and re-export byte-identically; HTTP, remote CLI and the pure function produce identical bytes.

Stacked on #242 (columnar CSV export).