### PR TITLE
Add a computed-quality report: score outliers, zero scores, negative categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,16 @@
   databases.
 
 ### Added
+- A computed-checks report joins the structural quality report:
+  `GET /db/{db}/computed-quality-report` and the `get_computed_quality_report`
+  MCP tool score every entry of a loaded database against a method collection
+  and report per-category score outliers (median/MAD on a log scale within
+  (category, reference-unit) groups — a mg-read-as-kg slip lands three orders
+  of magnitude out), entries whose every score is zero, and negative category
+  scores (info: avoided-production credits and waste treatment produce them
+  legitimately). Separate from the structural report on purpose — that one
+  stays identical on staged and loaded databases; this one needs the matrices
+  and a loaded method collection.
 - The quality report flags distinct activity names that merge under
   SimaPro's 80-character name truncation — each colliding name gets its own
   finding, so an export bound for SimaPro can be repaired before the names

--- a/src/API/BatchImpacts.hs
+++ b/src/API/BatchImpacts.hs
@@ -16,11 +16,12 @@ module API.BatchImpacts (
     BatchError (..),
     runActivityLCIABatch,
     runBatchImpacts,
+    runComputedQuality,
     translateError,
 ) where
 
-import API.Routes (activityLCIABatchH, batchImpactsH, collectionNotLoadedPrefix, databaseNotLoadedPrefix)
-import API.Types (BatchImpactsRequest (..), BatchImpactsResponse, LCIABatchResult, SubstitutionRequest)
+import API.Routes (activityLCIABatchH, batchImpactsH, collectionNotLoadedPrefix, computedQualityReportH, databaseNotLoadedPrefix)
+import API.Types (BatchImpactsRequest (..), BatchImpactsResponse, ComputedQualityReportAPI, LCIABatchResult, SubstitutionRequest)
 import App.Env (AppEnv (..), runApp)
 import Control.Concurrent.STM (readTVarIO)
 import qualified Data.ByteString.Lazy as BSL
@@ -130,6 +131,33 @@ runBatchImpacts dbm dbName coll topFlows ltMode pids = do
                     topFlows
                     ltMode
                     (BatchImpactsRequest{birProcessIds = pids})
+    case res of
+        Right r -> pure (Right r)
+        Left se -> Left <$> translateErrorIO dbm se
+
+{- | Computed-checks report over the whole catalogue of a loaded database.
+Same wire shape as the REST endpoint ('computedQualityReportH'), so both
+surfaces stay in lock-step.
+-}
+runComputedQuality ::
+    DatabaseManager ->
+    -- | database name
+    Text ->
+    -- | method collection; 'Nothing' picks the single loaded one
+    Maybe Text ->
+    -- | max findings per check, worst first
+    Maybe Int ->
+    IO (Either BatchError ComputedQualityReportAPI)
+runComputedQuality dbm dbName mColl mLimit = do
+    let env =
+            AppEnv
+                { aeDbManager = dbm
+                , aeMaxTreeDepth = 0
+                , aePassword = Nothing
+                , aeHostingConfig = Nothing
+                , aeClassificationPresets = []
+                }
+    res <- Servant.runHandler (runApp env (computedQualityReportH dbName mColl mLimit))
     case res of
         Right r -> pure (Right r)
         Left se -> Left <$> translateErrorIO dbm se

--- a/src/API/BatchImpacts.hs
+++ b/src/API/BatchImpacts.hs
@@ -22,7 +22,7 @@ module API.BatchImpacts (
 
 import API.Routes (activityLCIABatchH, batchImpactsH, collectionNotLoadedPrefix, computedQualityReportH, databaseNotLoadedPrefix)
 import API.Types (BatchImpactsRequest (..), BatchImpactsResponse, ComputedQualityReportAPI, LCIABatchResult, SubstitutionRequest)
-import App.Env (AppEnv (..), runApp)
+import App.Env (AppEnv (..), AppM, runApp)
 import Control.Concurrent.STM (readTVarIO)
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Map as M
@@ -81,19 +81,8 @@ runActivityLCIABatch ::
     -- | whether to keep or drop delayed long-term emissions
     LongTermMode ->
     IO (Either BatchError LCIABatchResult)
-runActivityLCIABatch dbm dbName pid coll mSub ltMode = do
-    let env =
-            AppEnv
-                { aeDbManager = dbm
-                , aeMaxTreeDepth = 0
-                , aePassword = Nothing
-                , aeHostingConfig = Nothing
-                , aeClassificationPresets = []
-                }
-    res <- Servant.runHandler (runApp env (activityLCIABatchH dbName pid coll mSub ltMode))
-    case res of
-        Right lbr -> pure (Right lbr)
-        Left se -> Left <$> translateErrorIO dbm se
+runActivityLCIABatch dbm dbName pid coll mSub ltMode =
+    runBare dbm (activityLCIABatchH dbName pid coll mSub ltMode)
 
 {- | Score N activities against every method in a collection in one
 multi-RHS MUMPS solve plus parallel characterization. Unresolved process
@@ -113,27 +102,8 @@ runBatchImpacts ::
     -- | process_ids to score
     [Text] ->
     IO (Either BatchError BatchImpactsResponse)
-runBatchImpacts dbm dbName coll topFlows ltMode pids = do
-    let env =
-            AppEnv
-                { aeDbManager = dbm
-                , aeMaxTreeDepth = 0
-                , aePassword = Nothing
-                , aeHostingConfig = Nothing
-                , aeClassificationPresets = []
-                }
-    res <-
-        Servant.runHandler $
-            runApp env $
-                batchImpactsH
-                    dbName
-                    coll
-                    topFlows
-                    ltMode
-                    (BatchImpactsRequest{birProcessIds = pids})
-    case res of
-        Right r -> pure (Right r)
-        Left se -> Left <$> translateErrorIO dbm se
+runBatchImpacts dbm dbName coll topFlows ltMode pids =
+    runBare dbm (batchImpactsH dbName coll topFlows ltMode BatchImpactsRequest{birProcessIds = pids})
 
 {- | Computed-checks report over the whole catalogue of a loaded database.
 Same wire shape as the REST endpoint ('computedQualityReportH'), so both
@@ -148,7 +118,14 @@ runComputedQuality ::
     -- | max findings per check, worst first
     Maybe Int ->
     IO (Either BatchError ComputedQualityReportAPI)
-runComputedQuality dbm dbName mColl mLimit = do
+runComputedQuality dbm dbName mColl mLimit =
+    runBare dbm (computedQualityReportH dbName mColl mLimit)
+
+{- | Run one handler outside the Servant stack: the bare environment every
+wrapper shares, then 'ServerError' translated back to a 'BatchError'.
+-}
+runBare :: DatabaseManager -> AppM a -> IO (Either BatchError a)
+runBare dbm action = do
     let env =
             AppEnv
                 { aeDbManager = dbm
@@ -157,7 +134,7 @@ runComputedQuality dbm dbName mColl mLimit = do
                 , aeHostingConfig = Nothing
                 , aeClassificationPresets = []
                 }
-    res <- Servant.runHandler (runApp env (computedQualityReportH dbName mColl mLimit))
+    res <- Servant.runHandler (runApp env action)
     case res of
         Right r -> pure (Right r)
         Left se -> Left <$> translateErrorIO dbm se

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -20,6 +20,7 @@ module API.DatabaseHandlers (
     gapReportToAPI,
     qualityReportHandler,
     qualityReportToAPI,
+    computedQualityReportToAPI,
     copyDatabaseHandler,
     deleteDatabaseHandler,
     deleteActivitiesHandler,
@@ -81,9 +82,12 @@ import System.IO (hClose, openBinaryTempFile)
 
 -- Unit definitions
 
+import qualified Database.ComputedQuality as CQ
+
 import API.Types (
     ActivateResponse (..),
     BinaryContent (..),
+    ComputedQualityReportAPI (..),
     DatabaseListResponse (..),
     DatabaseStatusAPI (..),
     DeleteClassFilter (..),
@@ -324,23 +328,40 @@ qualityReportToAPI mLimit r =
     QualityReportAPI
         { qraDbName = Quality.qrDbName r
         , qraProcessCount = Quality.qrProcessCount r
-        , qraReferenceProduct = checkToAPI (Quality.qrReferenceProduct r)
-        , qraAllocationSums = checkToAPI (Quality.qrAllocationSums r)
-        , qraDuplicateActivities = checkToAPI (Quality.qrDuplicateActivities r)
-        , qraSuspiciousAmounts = checkToAPI (Quality.qrSuspiciousAmounts r)
-        , qraMissingMetadata = checkToAPI (Quality.qrMissingMetadata r)
-        , qraFormulaConsistency = checkToAPI (Quality.qrFormulaConsistency r)
-        , qraTruncatedNameCollisions = checkToAPI (Quality.qrTruncatedNameCollisions r)
-        , qraMissingPedigree = checkToAPI (Quality.qrMissingPedigree r)
-        , qraUnconsumedProducts = checkToAPI (Quality.qrUnconsumedProducts r)
+        , qraReferenceProduct = checkToAPI mLimit (Quality.qrReferenceProduct r)
+        , qraAllocationSums = checkToAPI mLimit (Quality.qrAllocationSums r)
+        , qraDuplicateActivities = checkToAPI mLimit (Quality.qrDuplicateActivities r)
+        , qraSuspiciousAmounts = checkToAPI mLimit (Quality.qrSuspiciousAmounts r)
+        , qraMissingMetadata = checkToAPI mLimit (Quality.qrMissingMetadata r)
+        , qraFormulaConsistency = checkToAPI mLimit (Quality.qrFormulaConsistency r)
+        , qraTruncatedNameCollisions = checkToAPI mLimit (Quality.qrTruncatedNameCollisions r)
+        , qraMissingPedigree = checkToAPI mLimit (Quality.qrMissingPedigree r)
+        , qraUnconsumedProducts = checkToAPI mLimit (Quality.qrUnconsumedProducts r)
+        }
+
+{- | Same projection for the computed report — one wire cap, one offender
+shape, shared with the structural report via 'checkToAPI'.
+-}
+computedQualityReportToAPI :: Maybe Int -> CQ.ComputedQualityReport -> ComputedQualityReportAPI
+computedQualityReportToAPI mLimit r =
+    ComputedQualityReportAPI
+        { cqaDbName = CQ.cqDbName r
+        , cqaCollection = CQ.cqCollection r
+        , cqaProcessCount = CQ.cqProcessCount r
+        , cqaScoreOutliers = checkToAPI mLimit (CQ.cqScoreOutliers r)
+        , cqaZeroScores = checkToAPI mLimit (CQ.cqZeroScores r)
+        , cqaNegativeScores = checkToAPI mLimit (CQ.cqNegativeScores r)
+        }
+
+-- | Project one domain check onto the wire, capping its list at @limit@.
+checkToAPI :: Maybe Int -> Quality.QualityCheck -> QualityCheckAPI
+checkToAPI mLimit c =
+    QualityCheckAPI
+        { qcaApplicable = Quality.qcApplicable c
+        , qcaOffenderCount = length (Quality.qcOffenders c)
+        , qcaOffenders = map offenderToAPI (maybe id take mLimit (Quality.qcOffenders c))
         }
   where
-    checkToAPI c =
-        QualityCheckAPI
-            { qcaApplicable = Quality.qcApplicable c
-            , qcaOffenderCount = length (Quality.qcOffenders c)
-            , qcaOffenders = map offenderToAPI (maybe id take mLimit (Quality.qcOffenders c))
-            }
     offenderToAPI o =
         QualityOffenderAPI
             { qoaSeverity = Quality.qoSeverity o

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -363,6 +363,7 @@ callTool dbManager presets mBaseUrl rid name args = case name of
     "list_scoring_sets" -> callListScoringSets dbManager rid args
     "get_gap_report" -> callGetGapReport dbManager rid args
     "get_quality_report" -> callGetQualityReport dbManager rid args
+    "get_computed_quality_report" -> callGetComputedQualityReport dbManager rid args
     _ -> return $ toolError rid ("Unknown tool: " <> name)
 
 -- Helper: extract database, then run action
@@ -1324,6 +1325,18 @@ callGetQualityReport dbManager rid args = runTool rid $ do
     dbName <- except (requireText "database" args)
     report <- ExceptT (DM.databaseQualityReport dbManager dbName)
     return $ toolSuccessJson rid (toJSON (qualityReportToAPI (intArg "limit" args) report))
+
+{- | Computed-checks report: what a loaded database computes, judged against
+the catalogue's own norms. Same wire shape as the REST endpoint, so both
+surfaces stay in lock-step.
+-}
+callGetComputedQualityReport :: DatabaseManager -> Value -> KeyMap Value -> IO Value
+callGetComputedQualityReport dbManager rid args = runTool rid $ do
+    dbName <- except (requireText "database" args)
+    res <- liftIO $ BI.runComputedQuality dbManager dbName (textArg "collection" args) (intArg "limit" args)
+    case res of
+        Left e -> throwE (batchErrorMsg e)
+        Right r -> pure (toolSuccessJson rid (toJSON r))
 
 callGetFlowMapping :: DatabaseManager -> Value -> KeyMap Value -> IO Value
 callGetFlowMapping dbManager rid args = runTool rid $ do

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -73,6 +73,7 @@ data Resource
     | ListScoringSets
     | GetGapReport
     | GetQualityReport
+    | GetComputedQualityReport
     deriving (Eq, Ord, Show, Bounded, Enum)
 
 -- | Whether a parameter must be supplied by the caller.
@@ -156,6 +157,7 @@ apiPath r = case r of
     ListScoringSets -> Nothing -- MCP-only: scoring sets are configuration metadata, no REST equivalent yet
     GetGapReport -> Just (GET, ["db", "{dbName}", "gap-report"])
     GetQualityReport -> Just (GET, ["db", "{dbName}", "quality-report"])
+    GetComputedQualityReport -> Just (GET, ["db", "{dbName}", "computed-quality-report"])
 
 {- | The full OpenAPI path template for a resource, e.g.
 @"/api/v1/db/{dbName}/activity/{processId}/impacts/{collection}/{methodId}"@.
@@ -200,6 +202,7 @@ mcpName r = case r of
     ListScoringSets -> "list_scoring_sets"
     GetGapReport -> "get_gap_report"
     GetQualityReport -> "get_quality_report"
+    GetComputedQualityReport -> "get_computed_quality_report"
 
 -- ---------------------------------------------------------------------------
 -- Projection: CLI subcommand names (kebab-case)
@@ -240,6 +243,7 @@ cliName r = case r of
     ListScoringSets -> "scoring-sets"
     GetGapReport -> "gap-report"
     GetQualityReport -> "quality-report"
+    GetComputedQualityReport -> "computed-quality-report"
 
 -- ---------------------------------------------------------------------------
 -- Projection: human-readable description (shared across surfaces)
@@ -481,6 +485,20 @@ description r = case r of
         \was found on, and a readable detail. Answers 'is this dataset well \
         \formed?' — the complement of the supplier-gap report, which answers \
         \'what is this database missing?'"
+    GetComputedQualityReport ->
+        "LCA / ACV — computed-checks report of a LOADED database: what the \
+        \data computes, judged against the catalogue's own norms. Scores \
+        \every (activity, product) entry against one method collection (the \
+        \single loaded one, or the 'collection' parameter) and reports: \
+        \per-category score outliers, judged on a log scale within \
+        \(category, reference-unit) groups by median/MAD — a mg-read-as-kg \
+        \unit slip lands three orders of magnitude out; entries whose every \
+        \category score is zero (empty or uncharacterized inventory); and \
+        \negative category scores (info — legitimate where avoided-production \
+        \credits or waste treatment dominate). Complements get_quality_report, \
+        \which checks what the database STORES and runs on staged databases \
+        \too; this one needs the matrices and a loaded method collection. \
+        \Same finding shape: severity, the entry, a readable detail."
 
 -- ---------------------------------------------------------------------------
 -- Projection: parameter schema
@@ -792,5 +810,10 @@ params r = case r of
         ]
     GetQualityReport ->
         [ pDatabase
+        , pLimit "Max findings to return per check, worst first (default: all). Each check's offenderCount always covers its full list, so a truncated list stays countable."
+        ]
+    GetComputedQualityReport ->
+        [ pDatabase
+        , Param "collection" "string" Optional "Method collection to score the catalogue against. Defaults to the single loaded collection; required when several are loaded."
         , pLimit "Max findings to return per check, worst first (default: all). Each check's offenderCount always covers its full list, so a truncated list stays countable."
         ]

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -10,7 +10,7 @@ module API.Routes where
 import API.DatabaseHandlers (simpleAction)
 import qualified API.DatabaseHandlers as DBHandlers
 import qualified API.OpenApi
-import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), CollectionCoverage (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExportRequest (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GapReportAPI (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), QualityReportAPI (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadChunk (..), UploadResponse (..), apiFlowOfKind)
+import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), CollectionCoverage (..), ComputedQualityReportAPI (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExportRequest (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GapReportAPI (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), QualityReportAPI (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadChunk (..), UploadResponse (..), apiFlowOfKind)
 import App.Env (AppEnv (..), AppM, runApp)
 import qualified Config
 import Control.Concurrent.Async (mapConcurrently)
@@ -37,6 +37,7 @@ import qualified Data.UUID as UUID
 import qualified Data.Validation as V
 import qualified Data.Vector as V
 import Database
+import qualified Database.ComputedQuality as CQ
 import Database.Manager (DatabaseManager (..), DatabaseSetupInfo (..), LoadedDatabase (..), MethodCollectionStatus (..), getDatabase, getMergedUnitConfig)
 import qualified Database.Manager as DM
 import qualified Expr
@@ -128,6 +129,8 @@ type LCAAPI =
                 :<|> "db" :> Capture "dbName" Text :> "gap-report" :> QueryParam "limit" Int :> Get '[JSON] GapReportAPI
                 -- Dataset-soundness report: what is malformed in the database itself
                 :<|> "db" :> Capture "dbName" Text :> "quality-report" :> QueryParam "limit" Int :> Get '[JSON] QualityReportAPI
+                -- Computed checks: what a loaded database computes, judged against its own norms
+                :<|> "db" :> Capture "dbName" Text :> "computed-quality-report" :> QueryParam "collection" Text :> QueryParam "limit" Int :> Get '[JSON] ComputedQualityReportAPI
                 :<|> "db" :> Capture "dbName" Text :> "copy" :> Capture "newName" Text :> Post '[JSON] ActivateResponse
                 :<|> "db" :> Capture "dbName" Text :> Delete '[JSON] ActivateResponse
                 -- Delete the whole filtered set of activities (selection in JSON body)
@@ -960,6 +963,74 @@ batchImpactsH dbName collectionName topFlowsParam ltMode req = do
             , birNotFound = notFound
             , birInvalid = invalid
             }
+
+{- | Computed quality checks over the whole catalogue: score every entry of a
+loaded database against one method collection — chunked multi-RHS solves on
+the cached factorization, warm method tables — then judge the numbers with
+the pure 'Database.ComputedQuality' checks. The structural quality report
+runs on staged data too; this one needs matrices and methods, so it is a
+separate report with the same finding shape.
+-}
+computedQualityReportH :: Text -> Maybe Text -> Maybe Int -> AppM ComputedQualityReportAPI
+computedQualityReportH dbName mCollection mLimit = do
+    dbManager <- asks aeDbManager
+    (db, _solver) <- requireDatabaseByName dbName
+    loadedCollections <- liftIO $ readTVarIO (dmLoadedMethods dbManager)
+    collection <- case (mCollection, M.keys loadedCollections) of
+        (Just c, _) -> pure c -- an unknown name answers 404 in batchImpactsH below
+        (Nothing, [only]) -> pure only
+        (Nothing, []) ->
+            throwError err400{errBody = "No method collection loaded - the computed checks judge scores, so they need one"}
+        (Nothing, several) ->
+            throwError
+                err400
+                    { errBody =
+                        BSL.fromStrict . T.encodeUtf8 $
+                            "Several method collections loaded (" <> T.intercalate ", " several <> ") - pass ?collection= to pick one"
+                    }
+    let simple = toSimpleDatabase db
+        entriesByPid =
+            M.fromList
+                [ (UUID.toText a <> "_" <> UUID.toText p, act)
+                | ((a, p), act) <- M.toList (sdbActivities simple)
+                ]
+        refProductName act = case filter exchangeIsReference (exchanges act) of
+            [ex] ->
+                asum
+                    [ tfName <$> M.lookup (exchangeFlowId ex) (sdbTechFlows simple)
+                    , wfName <$> M.lookup (exchangeFlowId ex) (sdbWasteFlows simple)
+                    ]
+            _ -> Nothing
+        chunks xs = case splitAt scoringChunk xs of
+            (h, []) -> [h | not (null h)]
+            (h, t) -> h : chunks t
+    responses <-
+        mapM
+            (\pids -> batchImpactsH dbName collection Nothing IncludeLongTerm BatchImpactsRequest{birProcessIds = pids})
+            (chunks (M.keys entriesByPid))
+    let scored =
+            [ CQ.ScoredEntry
+                { CQ.seProcessId = bieProcessId e
+                , CQ.seActivityName = bieActivityName e
+                , CQ.seLocation = activityLocation act
+                , CQ.seProductName = refProductName act
+                , CQ.seRefUnit = activityUnit act
+                , CQ.seScores =
+                    [ CQ.CategoryScore (lrMethodName r) (lrUnit r) (lrScore r)
+                    | r <- lbrResults (bieImpacts e)
+                    ]
+                }
+            | e <- concatMap birResults responses
+            , Just act <- [M.lookup (bieProcessId e) entriesByPid]
+            ]
+    pure (DBHandlers.computedQualityReportToAPI mLimit (CQ.computedQualityReport dbName collection scored))
+
+{- | Batch size of the catalogue-wide solve: bounds the dense right-hand-side
+block of one multi-RHS solve while every chunk still reuses the one cached
+factorization.
+-}
+scoringChunk :: Int
+scoringChunk = 512
 
 -- ---------------------------------------------------------------------------
 -- Pure helpers shared by handlers
@@ -2047,6 +2118,7 @@ lcaServer env = hoistServer lcaAPI (runApp env) handlers
             :<|> DBHandlers.relinkDatabaseHandler
             :<|> DBHandlers.gapReportHandler
             :<|> DBHandlers.qualityReportHandler
+            :<|> computedQualityReportH
             :<|> DBHandlers.copyDatabaseHandler
             :<|> DBHandlers.deleteDatabaseHandler
             :<|> DBHandlers.deleteActivitiesHandler

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1008,6 +1008,13 @@ computedQualityReportH dbName mCollection mLimit = do
         mapM
             (\pids -> batchImpactsH dbName collection Nothing IncludeLongTerm BatchImpactsRequest{birProcessIds = pids})
             (chunks (M.keys entriesByPid))
+    -- The ids come from the catalogue itself, so nothing should be
+    -- unresolvable — but a dropped entry would silently shrink the report,
+    -- so any is worth a warning in the log.
+    let unresolved = concatMap (\r -> birNotFound r <> birInvalid r) responses
+    unless (null unresolved) $
+        liftIO . reportProgress Warning $
+            "Computed quality report on " <> T.unpack dbName <> ": " <> show (length unresolved) <> " catalogue entries could not be scored and are missing from the report"
     let scored =
             [ CQ.ScoredEntry
                 { CQ.seProcessId = bieProcessId e

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -855,6 +855,23 @@ data QualityReportAPI = QualityReportAPI
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped QualityReportAPI)
 
+{- | Computed-checks report of a loaded database: what the data computes,
+judged against the catalogue's own norms. Same check and offender shape as
+'QualityReportAPI', so consumers render both reports alike; a separate
+report because these checks need matrices and a method collection, which
+the structural report deliberately does not.
+-}
+data ComputedQualityReportAPI = ComputedQualityReportAPI
+    { cqaDbName :: Text
+    , cqaCollection :: Text
+    , cqaProcessCount :: Int
+    , cqaScoreOutliers :: QualityCheckAPI
+    , cqaZeroScores :: QualityCheckAPI
+    , cqaNegativeScores :: QualityCheckAPI
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped ComputedQualityReportAPI)
+
 -- | Result of auto-loading a single dependency
 data DepLoadResult
     = DepLoaded {dlrName :: Text}

--- a/src/Database/ComputedQuality.hs
+++ b/src/Database/ComputedQuality.hs
@@ -1,0 +1,190 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Computed dataset checks, for the people who build or repair databases.
+
+Where 'Database.Quality' scans what a database stores, these checks judge
+what it computes: category scores far off the database norm (a mg-read-as-kg
+slip surfaces as a ×1000 outlier), entries whose every score is zero, and
+negative category scores. They need a loaded database and a method
+collection, so they live in their own report rather than compromising the
+structural report's staged/loaded identity.
+
+The scoring itself happens at the effectful edge; this module only judges
+the numbers it is handed.
+-}
+module Database.ComputedQuality (
+    CategoryScore (..),
+    ScoredEntry (..),
+    ComputedQualityReport (..),
+    computedQualityReport,
+    outlierSigma,
+    minGroupSize,
+) where
+
+import Data.List (sort, sortOn)
+import qualified Data.Map.Strict as M
+import Data.Maybe (mapMaybe)
+import Data.Ord (Down (..))
+import Data.Text (Text)
+import qualified Data.Text as T
+import Numeric (showFFloat, showGFloat)
+
+import Database.Quality (QualityCheck (..), QualityOffender (..))
+import Types (Severity (..))
+
+-- | One impact-category score of one entry, with the unit it is expressed in.
+data CategoryScore = CategoryScore
+    { csCategory :: !Text
+    , csUnit :: !Text
+    , csScore :: !Double
+    }
+    deriving (Show, Eq)
+
+-- | One scored (activity, product) entry, as the effectful edge hands it over.
+data ScoredEntry = ScoredEntry
+    { seProcessId :: !Text
+    , seActivityName :: !Text
+    , seLocation :: !Text
+    , seProductName :: !(Maybe Text)
+    , seRefUnit :: !Text
+    {- ^ Unit of the reference product. Scores are per reference unit, so only
+    entries sharing it are comparable — a kg of wheat and a kWh of power
+    legitimately live orders of magnitude apart.
+    -}
+    , seScores :: ![CategoryScore]
+    }
+    deriving (Show, Eq)
+
+{- | Computed counterpart of 'Database.Quality.QualityReport': one named field
+per check, same offender shape, so consumers treat both reports alike.
+-}
+data ComputedQualityReport = ComputedQualityReport
+    { cqDbName :: !Text
+    , cqCollection :: !Text
+    -- ^ The method collection the scores were computed against
+    , cqProcessCount :: !Int
+    , cqScoreOutliers :: !QualityCheck
+    , cqZeroScores :: !QualityCheck
+    , cqNegativeScores :: !QualityCheck
+    }
+    deriving (Show, Eq)
+
+{- | How far (in robust sigmas) a log-score may sit from its group's median
+before it is flagged. 3.5 is the classic conservative cut; a mg-as-kg slip
+lands three orders of magnitude out and clears it by a wide margin.
+-}
+outlierSigma :: Double
+outlierSigma = 3.5
+
+{- | Groups smaller than this carry too little evidence for a robust norm, so
+they produce no outlier findings at all.
+-}
+minGroupSize :: Int
+minGroupSize = 20
+
+-- | Run every computed check over the scored catalogue.
+computedQualityReport :: Text -> Text -> [ScoredEntry] -> ComputedQualityReport
+computedQualityReport dbName collection entries =
+    ComputedQualityReport
+        { cqDbName = dbName
+        , cqCollection = collection
+        , cqProcessCount = length entries
+        , cqScoreOutliers = QualityCheck True (worstFirst outlierOffenders)
+        , cqZeroScores = QualityCheck True (worstFirst zeroOffenders)
+        , cqNegativeScores = QualityCheck True (worstFirst negativeOffenders)
+        }
+  where
+    worstFirst = sortOn (\o -> (qoSeverity o, qoActivityName o))
+    offender sev e = QualityOffender sev (seProcessId e) (seActivityName e) (seLocation e) (seProductName e)
+
+    -- Scores are compared on a log scale within one (category, reference
+    -- unit) group: multiplicative unit slips are exactly what we hunt, and
+    -- honest scores span orders of magnitude anyway. Zero and negative
+    -- scores have no logarithm and their own checks below.
+    groups =
+        M.fromListWith
+            (<>)
+            [ ((csCategory s, seRefUnit e), [logBase 10 (csScore s)])
+            | e <- entries
+            , s <- seScores e
+            , csScore s > 0
+            ]
+    norms = M.mapMaybe groupNorm groups
+    groupNorm ls
+        | length ls < minGroupSize = Nothing
+        | otherwise = do
+            m <- median ls
+            mad <- median (map (abs . subtract m) ls)
+            -- A zero MAD means half the group is identical — a degenerate
+            -- norm that would flag any honest variation, so judge nothing.
+            if mad > 0 then Just (m, 1.4826 * mad) else Nothing
+
+    outlierOffenders = mapMaybe entryOutlier entries
+    entryOutlier e = case sortOn (Down . abs . snd) (mapMaybe deviation (seScores e)) of
+        [] -> Nothing
+        (s, d) : rest ->
+            Just . offender WarningSev e $
+                T.pack (show (1 + length rest))
+                    <> " category score(s) far off the database norm for "
+                    <> seRefUnit e
+                    <> "-referenced entries (worst: "
+                    <> csCategory s
+                    <> " at "
+                    <> fmtScore (csScore s)
+                    <> " "
+                    <> csUnit s
+                    <> ", "
+                    <> fmtSigma (abs d)
+                    <> " robust sigmas "
+                    <> (if d > 0 then "above" else "below")
+                    <> " the median)"
+      where
+        deviation s = do
+            (m, sigma) <- M.lookup (csCategory s, seRefUnit e) norms
+            if csScore s > 0
+                then
+                    let d = (logBase 10 (csScore s) - m) / sigma
+                     in if abs d > outlierSigma then Just (s, d) else Nothing
+                else Nothing
+
+    -- Every category at exactly zero: the inventory solved to nothing, or
+    -- nothing in it is characterized. Either way the entry contributes
+    -- nothing to any assessment, which its maker should know.
+    zeroOffenders =
+        [ offender WarningSev e "every category score is zero — the inventory is empty or nothing in it is characterized"
+        | e <- entries
+        , not (null (seScores e))
+        , all ((== 0) . csScore) (seScores e)
+        ]
+
+    -- Negative scores are legitimate where avoided-production credits or
+    -- waste treatment dominate — hence Info, a place to look, not a verdict.
+    negativeOffenders =
+        [ offender InfoSev e $
+            T.pack (show (length negs))
+                <> " category score(s) below zero (worst: "
+                <> csCategory s
+                <> " at "
+                <> fmtScore (csScore s)
+                <> " "
+                <> csUnit s
+                <> ") — expected for avoided-production credits and waste treatment"
+        | e <- entries
+        , let negs = filter ((< 0) . csScore) (seScores e)
+        , s : _ <- [sortOn csScore negs]
+        ]
+
+-- | Total median: 'Nothing' on an empty list rather than a crash.
+median :: [Double] -> Maybe Double
+median xs = case (drop ((n - 1) `div` 2) sorted, drop (n `div` 2) sorted) of
+    (lo : _, hi : _) -> Just ((lo + hi) / 2)
+    (_, _) -> Nothing
+  where
+    sorted = sort xs
+    n = length xs
+
+fmtScore :: Double -> Text
+fmtScore x = T.pack (showGFloat (Just 3) x "")
+
+fmtSigma :: Double -> Text
+fmtSigma x = T.pack (showFFloat (Just 1) x "")

--- a/src/Database/ComputedQuality.hs
+++ b/src/Database/ComputedQuality.hs
@@ -89,7 +89,10 @@ computedQualityReport dbName collection entries =
         { cqDbName = dbName
         , cqCollection = collection
         , cqProcessCount = length entries
-        , cqScoreOutliers = QualityCheck True (worstFirst outlierOffenders)
+        , -- Every outlier shares one severity, so the generic worst-first order
+          -- would fall back to names; the maintainer wants the wildest
+          -- deviation on top — that is where the unit slip sits.
+          cqScoreOutliers = QualityCheck True (map fst (sortOn (Down . snd) outlierOffenders))
         , cqZeroScores = QualityCheck True (worstFirst zeroOffenders)
         , cqNegativeScores = QualityCheck True (worstFirst negativeOffenders)
         }
@@ -119,25 +122,28 @@ computedQualityReport dbName collection entries =
             -- norm that would flag any honest variation, so judge nothing.
             if mad > 0 then Just (m, 1.4826 * mad) else Nothing
 
+    -- Each element carries the entry's worst absolute deviation, the sort key
+    -- above.
     outlierOffenders = mapMaybe entryOutlier entries
     entryOutlier e = case sortOn (Down . abs . snd) (mapMaybe deviation (seScores e)) of
         [] -> Nothing
         (s, d) : rest ->
-            Just . offender WarningSev e $
-                T.pack (show (1 + length rest))
-                    <> " category score(s) far off the database norm for "
-                    <> seRefUnit e
-                    <> "-referenced entries (worst: "
-                    <> csCategory s
-                    <> " at "
-                    <> fmtScore (csScore s)
-                    <> " "
-                    <> csUnit s
-                    <> ", "
-                    <> fmtSigma (abs d)
-                    <> " robust sigmas "
-                    <> (if d > 0 then "above" else "below")
-                    <> " the median)"
+            let detail =
+                    T.pack (show (1 + length rest))
+                        <> " category score(s) far off the database norm for "
+                        <> seRefUnit e
+                        <> "-referenced entries (worst: "
+                        <> csCategory s
+                        <> " at "
+                        <> fmtScore (csScore s)
+                        <> " "
+                        <> csUnit s
+                        <> ", "
+                        <> fmtSigma (abs d)
+                        <> " robust sigmas "
+                        <> (if d > 0 then "above" else "below")
+                        <> " the median)"
+             in Just (offender WarningSev e detail, abs d)
       where
         deviation s = do
             (m, sigma) <- M.lookup (csCategory s, seRefUnit e) norms

--- a/test/ComputedQualitySpec.hs
+++ b/test/ComputedQualitySpec.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Computed-checks report tests: the log-scale outlier norm and its guard
+rails (group size, degenerate MAD, per-unit grouping), plus the zero and
+negative checks — all on hand-made scored entries.
+-}
+module ComputedQualitySpec (spec) where
+
+import Data.Text (Text)
+import qualified Data.Text as T
+import Test.Hspec
+
+import Database.ComputedQuality (
+    CategoryScore (..),
+    ComputedQualityReport (..),
+    ScoredEntry (..),
+    computedQualityReport,
+ )
+import Database.Quality (QualityCheck (..), QualityOffender (..))
+import Types (Severity (..))
+
+entry :: Text -> [CategoryScore] -> ScoredEntry
+entry name scores =
+    ScoredEntry
+        { seProcessId = name <> "_pid"
+        , seActivityName = name
+        , seLocation = "FR"
+        , seProductName = Just (name <> " product")
+        , seRefUnit = "kg"
+        , seScores = scores
+        }
+
+cch :: Double -> CategoryScore
+cch = CategoryScore "Climate change" "kg CO2 eq"
+
+reportOf :: [ScoredEntry] -> ComputedQualityReport
+reportOf = computedQualityReport "testdb" "EF-3.1"
+
+{- | Honest scores spread over 10..34 — wide enough for a non-degenerate MAD,
+tight enough on the log scale that none of the crowd flags itself.
+-}
+crowd :: [ScoredEntry]
+crowd = [entry ("crowd " <> T.pack (show i)) [cch (fromIntegral i)] | i <- [10 .. 34 :: Int]]
+
+names :: QualityCheck -> [Text]
+names = map qoActivityName . qcOffenders
+
+details :: QualityCheck -> [Text]
+details = map qoDetail . qcOffenders
+
+spec :: Spec
+spec = do
+    describe "score outliers check" $ do
+        it "flags the entry a million times above the norm, and only it" $ do
+            let check = cqScoreOutliers (reportOf (crowd <> [entry "monster" [cch 1e6]]))
+            names check `shouldBe` ["monster"]
+            map qoSeverity (qcOffenders check) `shouldBe` [WarningSev]
+            case details check of
+                [d] -> do
+                    d `shouldSatisfy` T.isInfixOf "above the median"
+                    d `shouldSatisfy` T.isInfixOf "Climate change"
+                    d `shouldSatisfy` T.isInfixOf "kg-referenced"
+                other -> expectationFailure ("expected one detail, got " <> show other)
+
+        it "flags the entry a million times below the norm as below" $ do
+            let check = cqScoreOutliers (reportOf (crowd <> [entry "dust" [cch 1e-6]]))
+            names check `shouldBe` ["dust"]
+            case details check of
+                [d] -> d `shouldSatisfy` T.isInfixOf "below the median"
+                other -> expectationFailure ("expected one detail, got " <> show other)
+
+        it "judges nothing in a group smaller than the minimum" $ do
+            let check = cqScoreOutliers (reportOf (take 10 crowd <> [entry "monster" [cch 1e6]]))
+            qcOffenders check `shouldBe` []
+
+        it "compares entries only within their reference unit" $ do
+            -- The kWh entry is huge next to the kg crowd, but it has no kg
+            -- peers to be compared with — one entry is not a norm.
+            let power = (entry "power plant" [cch 1e6]){seRefUnit = "kWh"}
+                check = cqScoreOutliers (reportOf (crowd <> [power]))
+            qcOffenders check `shouldBe` []
+
+        it "judges nothing against a degenerate norm where half the group is identical" $ do
+            let same = [entry ("same " <> T.pack (show i)) [cch 1.0] | i <- [1 .. 25 :: Int]]
+                check = cqScoreOutliers (reportOf (same <> [entry "monster" [cch 1e6]]))
+            qcOffenders check `shouldBe` []
+
+    describe "zero scores check" $ do
+        it "flags an entry whose every category score is zero" $ do
+            let zeroed = entry "placeholder" [cch 0, CategoryScore "Land use" "Pt" 0]
+                check = cqZeroScores (reportOf (crowd <> [zeroed]))
+            names check `shouldBe` ["placeholder"]
+            map qoSeverity (qcOffenders check) `shouldBe` [WarningSev]
+
+        it "passes an entry with any non-zero score, and an entry with no scores at all" $ do
+            let mixed = entry "mixed" [cch 0, CategoryScore "Land use" "Pt" 1]
+                bare = entry "bare" []
+            qcOffenders (cqZeroScores (reportOf (crowd <> [mixed, bare]))) `shouldBe` []
+
+    describe "negative scores check" $ do
+        it "flags negative categories as info, naming the worst" $ do
+            let credit = entry "avoided burden" [cch (-5), CategoryScore "Land use" "Pt" (-9)]
+                check = cqNegativeScores (reportOf (crowd <> [credit]))
+            names check `shouldBe` ["avoided burden"]
+            map qoSeverity (qcOffenders check) `shouldBe` [InfoSev]
+            case details check of
+                [d] -> do
+                    d `shouldSatisfy` T.isInfixOf "2 category score(s) below zero"
+                    d `shouldSatisfy` T.isInfixOf "Land use"
+                other -> expectationFailure ("expected one detail, got " <> show other)
+
+        it "keeps negative scores out of the outlier norm" $ do
+            qcOffenders (cqScoreOutliers (reportOf (crowd <> [entry "credit" [cch (-1e6)]])))
+                `shouldBe` []
+
+    describe "report header" $
+        it "carries the collection and counts every entry handed over" $ do
+            let r = reportOf crowd
+            cqCollection r `shouldBe` "EF-3.1"
+            cqProcessCount r `shouldBe` 25

--- a/test/ComputedQualitySpec.hs
+++ b/test/ComputedQualitySpec.hs
@@ -69,6 +69,12 @@ spec = do
                 [d] -> d `shouldSatisfy` T.isInfixOf "below the median"
                 other -> expectationFailure ("expected one detail, got " <> show other)
 
+        it "ranks outliers by deviation, wildest first, not by name" $ do
+            let check =
+                    cqScoreOutliers
+                        (reportOf (crowd <> [entry "a mild outlier" [cch 1e4], entry "z wild outlier" [cch 1e8]]))
+            names check `shouldBe` ["z wild outlier", "a mild outlier"]
+
         it "judges nothing in a group smaller than the minimum" $ do
             let check = cqScoreOutliers (reportOf (take 10 crowd <> [entry "monster" [cch 1e6]]))
             qcOffenders check `shouldBe` []

--- a/volca.cabal
+++ b/volca.cabal
@@ -49,6 +49,7 @@ library
                      , Database.RelinkMapping
                      , Database.MatrixBuild
                      , Database.Quality
+                     , Database.ComputedQuality
                      , Database.Upload
                      , Database.UploadedDatabase
                      , SubstanceRegistry
@@ -291,6 +292,7 @@ test-suite lca-tests
                      , CrossDBSubstitutionSpec
                      , GapReportSpec
                      , QualityReportSpec
+                     , ComputedQualitySpec
                      , GlobalSubstitutionSpec
                      , DatabaseStatusSpec
                      , DependencyChoiceSpec


### PR DESCRIPTION
The structural quality report judges what a database stores. This adds its computed counterpart, for database maintainers hunting the mistakes only the numbers reveal: a mg-read-as-kg slip that survives every structural check but lands three orders of magnitude off the database norm.

`GET /api/v1/db/{dbName}/computed-quality-report` (and the matching MCP tool `get_computed_quality_report`) scores the whole catalogue against a method collection and runs three checks over the results:

- **Score outliers** (warning): per (impact category, reference unit) group, scores are compared on a log scale against the group's median with a MAD-based robust sigma; entries beyond 3.5 robust sigmas are flagged, wildest deviation first. Groups smaller than 20 entries, or with a degenerate (zero) MAD, judge nothing rather than flag noise.
- **Zero scores** (warning): entries whose every category score is exactly zero — an empty inventory, or one nothing characterizes.
- **Negative scores** (info): entries with categories below zero. Legitimate where avoided-production credits or waste treatment dominate, so the wording says so — a place to look, not a verdict.

The report reuses the structural report's offender shape (severity, process id, name, location, detail, `limit` cap with exact `offenderCount`), so consumers treat both alike. It lives in its own endpoint rather than the structural report because it needs a loaded database and a method collection: the structural report keeps its staged/loaded identity. With several collections loaded, `?collection=` picks one; the error names the candidates.

Scoring runs in chunks of 512 through the batch solver (one factorization per chunk). On a large database the full catalogue takes minutes; the tool description says so.

Verified live on a 21510-entry database: 1599 outliers (the top ones are genuine unit-scale anomalies), 453 all-zero entries, 835 negative-score entries correctly described as expected credits.