### PR TITLE
Derive the direction of openLCA factors from their category path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,20 @@
   output is unchanged.
 
 ### Fixed
-- Resource factors in openLCA JSON-LD method files now get the input
-  direction. openLCA files carry no per-factor direction, so every factor
-  used to default to output — a resource factor (water withdrawal, land
+- openLCA JSON-LD method files now load with the right factor directions,
+  compartments, and reference unit — including files openLCA itself
+  exported. Such files carry no per-factor direction, so every factor used
+  to default to output — a resource factor (water withdrawal, land
   occupation) then matched against the wrong synonym view and could
   silently miss its flow. The direction now comes from the flow's category
-  path (`resource/…`, `Raw materials`, `Land use` → input), or from the
-  impact category's own direction when the path says nothing either way. A
-  factor that states its direction explicitly is untouched.
+  path (`resource/…`, `Raw materials`, `Land use` → input; `Emission to …`
+  → output), or from the impact category's own direction when the path
+  says nothing either way; a factor that states its direction explicitly
+  is untouched. The parser also reads the olca-schema spellings a genuine
+  export uses — the category path as a plain string on the flow reference
+  (its `Elementary flows` root is dropped) and `refUnit` — where it
+  previously only understood its own exporter's shape and silently lost
+  the compartment and reference unit.
 - Numbers in columnar CSV method files and normalization/weighting CSV
   files now parse exactly. The previous number parser drifted in the last
   decimal (`1.2227e-3` came back as `1.2227000000000002e-3`) — every such

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@
   output is unchanged.
 
 ### Fixed
+- Resource factors in openLCA JSON-LD method files now get the input
+  direction. openLCA files carry no per-factor direction, so every factor
+  used to default to output — a resource factor (water withdrawal, land
+  occupation) then matched against the wrong synonym view and could
+  silently miss its flow. The direction now comes from the flow's category
+  path (`resource/…`, `Raw materials`, `Land use` → input), or from the
+  impact category's own direction when the path says nothing either way. A
+  factor that states its direction explicitly is untouched.
 - Numbers in columnar CSV method files and normalization/weighting CSV
   files now parse exactly. The previous number parser drifted in the last
   decimal (`1.2227e-3` came back as `1.2227000000000002e-3`) — every such

--- a/src/Method/Parser/OlcaSchema.hs
+++ b/src/Method/Parser/OlcaSchema.hs
@@ -38,6 +38,8 @@ Each 'ImpactFactor' becomes a single 'MethodCF':
   Absent location → 'Nothing' = universal CF (broadcast over all locations).
 * @value@ → 'mcfValue'
 * @unit.name@ → 'mcfUnit'
+* 'mcfDirection' comes from the factor's own @direction@ field when present,
+  else the flow's category path, else the document's — see 'factorDirection'.
 
 Optional fields ignored at this stage but trivial to wire later:
 
@@ -54,6 +56,7 @@ module Method.Parser.OlcaSchema (
     isOlcaImpactCategoryJson,
 ) where
 
+import Control.Applicative ((<|>))
 import Data.Aeson (Value (..), eitherDecodeStrict)
 import qualified Data.Aeson.Key as K
 import qualified Data.Aeson.KeyMap as KM
@@ -92,8 +95,9 @@ parseOlcaImpactCategoryBytes bytes = do
             let mid = parseUuidField o "@id"
                 description = lookupText o "description"
                 unit = fromMaybe "" (lookupText o "referenceUnitName")
+                docDirection = parseDirection =<< lookupText o "direction"
                 factors = case KM.lookup "impactFactors" o of
-                    Just (Array v) -> mapMaybe parseImpactFactor (V.toList v)
+                    Just (Array v) -> mapMaybe (parseImpactFactor docDirection) (V.toList v)
                     _ -> []
             Right
                 Method
@@ -107,8 +111,8 @@ parseOlcaImpactCategoryBytes bytes = do
                     }
         _ -> Left "openLCA ImpactCategory: expected a top-level JSON object"
 
-parseImpactFactor :: Value -> Maybe MethodCF
-parseImpactFactor (Object o) = do
+parseImpactFactor :: Maybe FlowDirection -> Value -> Maybe MethodCF
+parseImpactFactor docDirection (Object o) = do
     value <- numberField o "value"
     flow <- objectField o "flow"
     let flowName = fromMaybe "" (lookupText flow "name")
@@ -122,7 +126,7 @@ parseImpactFactor (Object o) = do
                 Just c -> Just c
                 Nothing -> lookupText l "name"
             Nothing -> Nothing
-        direction = directionFromFlow o
+        direction = factorDirection docDirection o flow
         compartment = parseCompartment flow
     -- A factor without a flow name is unmatchable; drop it. (UUID alone could
     -- in theory match by id, but in practice the name carries the matching
@@ -141,7 +145,7 @@ parseImpactFactor (Object o) = do
                     , mcfUnit = unitName
                     , mcfConsumerLocation = loc
                     }
-parseImpactFactor _ = Nothing
+parseImpactFactor _ _ = Nothing
 
 {- | Read the optional @flow.category@ Ref and turn it into a 'Compartment'.
 The category's @name@ is treated as a slash-separated path: the first
@@ -167,15 +171,45 @@ parseCompartment flow = do
                     then Nothing
                     else Just (Compartment med sub "")
 
-{- | Direction is carried by 'ImpactFactor.direction' (Direction enum) when
-present, otherwise default to 'Output' since the vast majority of
-environmental CFs are emissions.
+{- | Direction of one factor, most specific signal first:
+
+1. the factor's own @direction@ field — not in the olca schema (openLCA
+   ignores it on import) but written by VoLCA's own exporter, so a VoLCA
+   archive round-trips its directions exactly;
+2. the flow's category path — openLCA files carry no per-factor direction
+   at all, but a resource category (@resource/…@, @Elementary
+   flows\/Resource\/…@, @Raw materials@, @Land use@) marks an input the
+   same way the columnar-CSV parser reads it: a resource CF defaulted to
+   Output would resolve against the output synonym view and silently lose
+   input-only bridges;
+3. the document-level @ImpactCategory.direction@ (olca schema v2) — the
+   category's overall orientation, for flows whose category path says
+   nothing either way;
+4. 'Output', since the vast majority of environmental CFs are emissions.
 -}
-directionFromFlow :: KM.KeyMap Value -> FlowDirection
-directionFromFlow o = case lookupText o "direction" of
-    Just "INPUT" -> Input
-    Just "OUTPUT" -> Output
-    _ -> Output
+factorDirection :: Maybe FlowDirection -> KM.KeyMap Value -> KM.KeyMap Value -> FlowDirection
+factorDirection docDirection factor flow =
+    fromMaybe Output (explicit <|> fromCategory <|> docDirection)
+  where
+    explicit = parseDirection =<< lookupText factor "direction"
+    fromCategory = do
+        cat <- objectField flow "category"
+        catName <- lookupText cat "name"
+        if any resourceSegment (T.splitOn "/" catName)
+            then Just Input
+            else Nothing
+    resourceSegment seg =
+        let s = T.toCaseFold (T.strip seg)
+         in s `elem` ["resource", "resources", "natural resource"]
+                || "raw" `T.isPrefixOf` s
+                || "land " `T.isPrefixOf` s
+
+-- | The olca @Direction@ enum, case-insensitively; 'Nothing' on anything else.
+parseDirection :: Text -> Maybe FlowDirection
+parseDirection t = case T.toCaseFold (T.strip t) of
+    "input" -> Just Input
+    "output" -> Just Output
+    _ -> Nothing
 
 -- ---------------------------------------------------------------------------
 -- Aeson helpers

--- a/src/Method/Parser/OlcaSchema.hs
+++ b/src/Method/Parser/OlcaSchema.hs
@@ -94,7 +94,7 @@ parseOlcaImpactCategoryBytes bytes = do
             name <- requireText o "name"
             let mid = parseUuidField o "@id"
                 description = lookupText o "description"
-                unit = fromMaybe "" (lookupText o "referenceUnitName")
+                unit = fromMaybe "" (lookupText o "referenceUnitName" <|> lookupText o "refUnit")
                 docDirection = parseDirection =<< lookupText o "direction"
                 factors = case KM.lookup "impactFactors" o of
                     Just (Array v) -> mapMaybe (parseImpactFactor docDirection) (V.toList v)
@@ -147,8 +147,9 @@ parseImpactFactor docDirection (Object o) = do
                     }
 parseImpactFactor _ _ = Nothing
 
-{- | Read the optional @flow.category@ Ref and turn it into a 'Compartment'.
-The category's @name@ is treated as a slash-separated path: the first
+{- | Turn the flow's category path into a 'Compartment'. The path is
+slash-separated: after dropping the @Elementary flows@ root that openLCA's
+category tree prepends (a tree artifact, not a compartment), the first
 segment is the medium ('resource', 'air', 'water', …) and the rest is the
 subcompartment ('land', 'urban air close to ground', …). Without this,
 VoLCA's matcher cannot disambiguate DB flows that share a name across
@@ -158,11 +159,9 @@ compartments (e.g. Agribalyse has 3 flows literally named
 -}
 parseCompartment :: KM.KeyMap Value -> Maybe Compartment
 parseCompartment flow = do
-    cat <- objectField flow "category"
-    catName <- lookupText cat "name"
-    -- T.splitOn always returns a non-empty list, so the empty case is
-    -- unreachable; pattern-matching avoids the partial 'head'.
-    case T.splitOn "/" catName of
+    catName <- categoryPath flow
+    -- A path that was only the tree root leaves no segments — no compartment.
+    case dropTreeRoot (T.splitOn "/" catName) of
         [] -> Nothing
         (med0 : rest) ->
             let med = T.strip med0
@@ -171,17 +170,33 @@ parseCompartment flow = do
                     then Nothing
                     else Just (Compartment med sub "")
 
+-- | Drop the @Elementary flows@ root of openLCA's category tree.
+dropTreeRoot :: [Text] -> [Text]
+dropTreeRoot (root : rest)
+    | T.toCaseFold (T.strip root) == "elementary flows" = rest
+dropTreeRoot segs = segs
+
+{- | The flow's category path. The olca schema carries it as a plain string
+on the flow Ref (@"Elementary flows/Emission to air/unspecified"@) — the
+form a genuine openLCA export uses — while VoLCA's own exports write a
+Category Ref object whose @name@ holds the same path.
+-}
+categoryPath :: KM.KeyMap Value -> Maybe Text
+categoryPath flow =
+    lookupText flow "category"
+        <|> (objectField flow "category" >>= (`lookupText` "name"))
+
 {- | Direction of one factor, most specific signal first:
 
 1. the factor's own @direction@ field — not in the olca schema (openLCA
    ignores it on import) but written by VoLCA's own exporter, so a VoLCA
    archive round-trips its directions exactly;
 2. the flow's category path — openLCA files carry no per-factor direction
-   at all, but a resource category (@resource/…@, @Elementary
-   flows\/Resource\/…@, @Raw materials@, @Land use@) marks an input the
-   same way the columnar-CSV parser reads it: a resource CF defaulted to
-   Output would resolve against the output synonym view and silently lose
-   input-only bridges;
+   at all, but the path names the boundary side: a resource segment
+   (@resource/…@, @Raw materials@, @Land use@) means Input — the same
+   spellings the columnar-CSV parser reads — and an emission segment
+   (@Emission to air/…@) means Output. A CF resolved against the wrong
+   synonym view silently loses direction-specific bridges;
 3. the document-level @ImpactCategory.direction@ (olca schema v2) — the
    category's overall orientation, for flows whose category path says
    nothing either way;
@@ -192,17 +207,22 @@ factorDirection docDirection factor flow =
     fromMaybe Output (explicit <|> fromCategory <|> docDirection)
   where
     explicit = parseDirection =<< lookupText factor "direction"
-    fromCategory = do
-        cat <- objectField flow "category"
-        catName <- lookupText cat "name"
-        if any resourceSegment (T.splitOn "/" catName)
-            then Just Input
-            else Nothing
-    resourceSegment seg =
-        let s = T.toCaseFold (T.strip seg)
-         in s `elem` ["resource", "resources", "natural resource"]
-                || "raw" `T.isPrefixOf` s
-                || "land " `T.isPrefixOf` s
+    fromCategory = pathDirection =<< categoryPath flow
+
+-- | The direction a category path implies; 'Nothing' when it says nothing.
+pathDirection :: Text -> Maybe FlowDirection
+pathDirection path
+    | any resourceSegment segments = Just Input
+    | any emissionSegment segments = Just Output
+    | otherwise = Nothing
+  where
+    segments = map (T.toCaseFold . T.strip) (T.splitOn "/" path)
+    resourceSegment s =
+        s `elem` ["resource", "resources", "natural resource"]
+            || "raw" `T.isPrefixOf` s
+            || "resources " `T.isPrefixOf` s
+            || "land " `T.isPrefixOf` s
+    emissionSegment s = "emission" `T.isPrefixOf` s
 
 -- | The olca @Direction@ enum, case-insensitively; 'Nothing' on anything else.
 parseDirection :: Text -> Maybe FlowDirection

--- a/test/OlcaSchemaSpec.hs
+++ b/test/OlcaSchemaSpec.hs
@@ -80,6 +80,16 @@ spec = do
                 Left err -> expectationFailure ("parse failed: " ++ err)
                 Right method -> methodCategory method `shouldBe` methodName method
 
+        it "reads the olca-schema refUnit spelling of the reference unit" $ do
+            -- A genuine openLCA export writes `refUnit`; VoLCA's own exports
+            -- write `referenceUnitName`. Both must land in methodUnit.
+            let bytes =
+                    "{\"@type\":\"ImpactCategory\",\"name\":\"M\",\
+                    \\"refUnit\":\"kg CO2 eq\",\"impactFactors\":[]}"
+            case parseOlcaImpactCategoryBytes bytes of
+                Left err -> expectationFailure ("parse failed: " ++ err)
+                Right method -> methodUnit method `shouldBe` "kg CO2 eq"
+
         it "rejects a non-object top level" $
             case parseOlcaImpactCategoryBytes "[1,2,3]" of
                 Left _ -> pure ()
@@ -151,6 +161,20 @@ spec = do
                         _ -> expectationFailure "expected exactly one factor"
                 Left err -> expectationFailure ("parse failed: " ++ err)
 
+        it "reads the olca-schema string form of the category" $
+            -- A genuine openLCA export carries the category as a plain string
+            -- on the flow Ref, not as a Category Ref object.
+            factorCompartments (directionDocStr "" "" "Emission to air/urban")
+                `shouldBe` Right [Just (Compartment "Emission to air" "urban" "")]
+
+        it "drops the Elementary flows category-tree root" $
+            factorCompartments (directionDocStr "" "" "Elementary flows/Resource/in ground")
+                `shouldBe` Right [Just (Compartment "Resource" "in ground" "")]
+
+        it "a path that is only the tree root leaves no compartment" $
+            factorCompartments (directionDocStr "" "" "Elementary flows")
+                `shouldBe` Right [Nothing]
+
     describe "factor direction derivation" $ do
         -- Real openLCA files carry no per-factor direction field; a resource
         -- CF mis-defaulted to Output resolves against the output synonym
@@ -169,6 +193,14 @@ spec = do
             factorDirections (directionDoc "" "" "Elementary flows/Resource/in ground")
                 `shouldBe` Right [Input]
 
+        it "reads the olca-schema string form of the category path" $
+            factorDirections (directionDocStr "" "" "Elementary flows/Resource/in ground")
+                `shouldBe` Right [Input]
+
+        it "reads the prose resource spellings of the columnar parser" $
+            factorDirections (directionDoc "" "" "Resources from ground")
+                `shouldBe` Right [Input]
+
         it "an emission category path stays Output" $
             factorDirections (directionDoc "" "" "Emission to air/urban")
                 `shouldBe` Right [Output]
@@ -180,6 +212,13 @@ spec = do
         it "a resource category path beats the document-level direction" $
             factorDirections (directionDoc "\"direction\":\"OUTPUT\"," "" "resource/land")
                 `shouldBe` Right [Input]
+
+        it "an emission category path beats the document-level direction" $
+            -- A water-use category oriented Input at the document level still
+            -- has release factors filed under Emission to water — they must
+            -- stay Output.
+            factorDirections (directionDoc "\"direction\":\"INPUT\"," "" "Emission to water/unspecified")
+                `shouldBe` Right [Output]
 
         it "defaults to Output with no signal at all" $
             factorDirections (directionDoc "" "" "water")
@@ -201,20 +240,34 @@ spec = do
 
 {- | A one-factor ImpactCategory document: @docFields@ / @factorFields@ are
 raw JSON fragments (trailing comma when non-empty), @categoryPath@ the
-flow's category name.
+flow's category name, carried as a Category Ref object (VoLCA's own
+export shape).
 -}
 directionDoc :: BS.ByteString -> BS.ByteString -> BS.ByteString -> BS.ByteString
 directionDoc docFields factorFields categoryPath =
+    olcaDoc docFields factorFields ("{\"@type\":\"Category\",\"name\":\"" <> categoryPath <> "\"}")
+
+-- | Same document with the category as the olca-schema plain string.
+directionDocStr :: BS.ByteString -> BS.ByteString -> BS.ByteString -> BS.ByteString
+directionDocStr docFields factorFields categoryPath =
+    olcaDoc docFields factorFields ("\"" <> categoryPath <> "\"")
+
+olcaDoc :: BS.ByteString -> BS.ByteString -> BS.ByteString -> BS.ByteString
+olcaDoc docFields factorFields categoryJson =
     "{\"@type\":\"ImpactCategory\",\"name\":\"D\","
         <> docFields
         <> "\"impactFactors\":[{\"@type\":\"ImpactFactor\",\"value\":1.0,"
         <> factorFields
-        <> "\"flow\":{\"@type\":\"Flow\",\"name\":\"f\",\
-           \\"category\":{\"@type\":\"Category\",\"name\":\""
-        <> categoryPath
-        <> "\"}}}]}"
+        <> "\"flow\":{\"@type\":\"Flow\",\"name\":\"f\",\"category\":"
+        <> categoryJson
+        <> "}}]}"
 
 -- | The direction of every parsed factor of the given document.
 factorDirections :: BS.ByteString -> Either String [FlowDirection]
 factorDirections bytes =
     map mcfDirection . methodFactors <$> parseOlcaImpactCategoryBytes bytes
+
+-- | The compartment of every parsed factor of the given document.
+factorCompartments :: BS.ByteString -> Either String [Maybe Compartment]
+factorCompartments bytes =
+    map mcfCompartment . methodFactors <$> parseOlcaImpactCategoryBytes bytes

--- a/test/OlcaSchemaSpec.hs
+++ b/test/OlcaSchemaSpec.hs
@@ -151,6 +151,40 @@ spec = do
                         _ -> expectationFailure "expected exactly one factor"
                 Left err -> expectationFailure ("parse failed: " ++ err)
 
+    describe "factor direction derivation" $ do
+        -- Real openLCA files carry no per-factor direction field; a resource
+        -- CF mis-defaulted to Output resolves against the output synonym
+        -- view and silently loses input-only bridges. The signals below are
+        -- tried most-specific first.
+        it "the factor's own direction field wins over the category path" $
+            factorDirections
+                (directionDoc "" "\"direction\":\"OUTPUT\"," "natural resource/in water")
+                `shouldBe` Right [Output]
+
+        it "a resource category path means Input" $
+            factorDirections (directionDoc "" "" "natural resource/in water")
+                `shouldBe` Right [Input]
+
+        it "recognizes the resource segment behind openLCA's category-tree root" $
+            factorDirections (directionDoc "" "" "Elementary flows/Resource/in ground")
+                `shouldBe` Right [Input]
+
+        it "an emission category path stays Output" $
+            factorDirections (directionDoc "" "" "Emission to air/urban")
+                `shouldBe` Right [Output]
+
+        it "falls back to the document-level direction when the path says nothing" $
+            factorDirections (directionDoc "\"direction\":\"INPUT\"," "" "water")
+                `shouldBe` Right [Input]
+
+        it "a resource category path beats the document-level direction" $
+            factorDirections (directionDoc "\"direction\":\"OUTPUT\"," "" "resource/land")
+                `shouldBe` Right [Input]
+
+        it "defaults to Output with no signal at all" $
+            factorDirections (directionDoc "" "" "water")
+                `shouldBe` Right [Output]
+
     describe "buildMethodTables on parsed openLCA methods" $ do
         it "leaves mtRegionalizedCF empty when no flow matched (Nothing in mappings)" $ do
             -- Without database flows to match against, every CF stays unmapped, so
@@ -164,3 +198,23 @@ spec = do
                     let mappings = [(cf, Nothing) | cf <- methodFactors method]
                         tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
                     M.size (mtRegionalizedCF tables) `shouldBe` 0
+
+{- | A one-factor ImpactCategory document: @docFields@ / @factorFields@ are
+raw JSON fragments (trailing comma when non-empty), @categoryPath@ the
+flow's category name.
+-}
+directionDoc :: BS.ByteString -> BS.ByteString -> BS.ByteString -> BS.ByteString
+directionDoc docFields factorFields categoryPath =
+    "{\"@type\":\"ImpactCategory\",\"name\":\"D\","
+        <> docFields
+        <> "\"impactFactors\":[{\"@type\":\"ImpactFactor\",\"value\":1.0,"
+        <> factorFields
+        <> "\"flow\":{\"@type\":\"Flow\",\"name\":\"f\",\
+           \\"category\":{\"@type\":\"Category\",\"name\":\""
+        <> categoryPath
+        <> "\"}}}]}"
+
+-- | The direction of every parsed factor of the given document.
+factorDirections :: BS.ByteString -> Either String [FlowDirection]
+factorDirections bytes =
+    map mcfDirection . methodFactors <$> parseOlcaImpactCategoryBytes bytes


### PR DESCRIPTION
Real openLCA JSON-LD files carry no per-factor direction — that field is VoLCA's own, written by its exporter so an exported archive round-trips its directions exactly. Every factor in a genuine openLCA file therefore defaulted to output, and a resource factor (water withdrawal, land occupation) resolved against the output synonym view, where it could silently miss the input-only bridge to its flow. The loader's direction-excluded report exists precisely to flag that loss; this removes its main cause for openLCA imports.

When a factor states no direction, the parser now reads the most specific signal available: the flow's category path — a resource segment means input, an emission segment means output, with the same spellings as the columnar-CSV parser — then the document-level `ImpactCategory.direction` of olca schema v2, then output. A factor that does state its direction is untouched, so VoLCA's own exports round-trip exactly as before.

The parser also reads the olca-schema spellings a genuine openLCA export uses, which it previously did not understand at all: the category path carried as a plain string on the flow reference (the `Elementary flows` root of openLCA's category tree is dropped before the compartment split) and the reference unit under `refUnit`. Without this, the direction heuristic never fired on the very files it targets, and their compartments and reference unit were silently lost.