### PR TITLE
Report which flow names a method scores only through a bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,17 @@
   databases.
 
 ### Added
+- A characterization-coverage report tells database maintainers which flow
+  names a method scores only through a name bridge. When a database names a
+  substance differently from the method that characterizes it — `Bromomethane`
+  versus `Methane, bromo-, Halon 1001`, say — VoLCA still scores the flow by
+  matching on a synonym or CAS number. A tool that matches factors by their
+  exact name, as many downstream consumers do, has no such bridge and scores
+  that flow as zero without warning. The report lists each bridged flow grouped
+  under the name the method itself uses, so the fix is a rename. It is available
+  as the `get_characterization_coverage` MCP tool and at
+  `GET /api/v1/db/{db}/characterization-coverage`, with one entry per loaded
+  method collection so two method versions can be compared side by side.
 - Method collections can be exported as an ILCD LCIA-method package (`ilcd`):
   a zip of one method dataset per impact category plus the flow datasets they
   reference (`lciamethods/` + `flows/`), which loads straight back. It carries

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -21,6 +21,8 @@ module API.DatabaseHandlers (
     qualityReportHandler,
     qualityReportToAPI,
     computedQualityReportToAPI,
+    coverageReportHandler,
+    coverageReportToAPI,
     copyDatabaseHandler,
     deleteDatabaseHandler,
     deleteActivitiesHandler,
@@ -87,7 +89,11 @@ import qualified Database.ComputedQuality as CQ
 import API.Types (
     ActivateResponse (..),
     BinaryContent (..),
+    BridgeGroupAPI (..),
+    BridgedFlowAPI (..),
+    CollectionBridgesAPI (..),
     ComputedQualityReportAPI (..),
+    CoverageReportAPI (..),
     DatabaseListResponse (..),
     DatabaseStatusAPI (..),
     DeleteClassFilter (..),
@@ -137,6 +143,7 @@ import Database.Manager (
     addFlowSynonyms,
     addMethodCollection,
     addUnitDefs,
+    databaseCoverageReport,
     databaseGapReport,
     databaseQualityReport,
     finalizeDatabase,
@@ -180,6 +187,8 @@ import Database.Upload (
     handleUpload,
  )
 import qualified Database.UploadedDatabase as UploadedDB
+import qualified Method.Coverage as Coverage
+import Method.Mapping (MatchStrategy (..))
 import Types (Database (..), GeographyPolicy (..), blockerReasonDetail, unresolvedCount)
 
 -- | List all databases
@@ -375,6 +384,61 @@ checkToAPI mLimit c =
             , qoaProductName = Quality.qoProductName o
             , qoaDetail = Quality.qoDetail o
             }
+
+{- | Characterization-coverage report for a loaded database: the flows each
+loaded method collection scores only through a name bridge. Loaded-only (the
+coverage probe reads the built method tables), so a missing database or an
+unloaded named collection is a 404.
+-}
+coverageReportHandler :: Text -> Maybe Text -> Maybe Int -> AppM CoverageReportAPI
+coverageReportHandler dbName mCollection mLimit = do
+    dbManager <- asks aeDbManager
+    res <- liftIO $ databaseCoverageReport dbManager dbName mCollection
+    case res of
+        Left err -> throwError err404{errBody = BSL.fromStrict $ T.encodeUtf8 err}
+        Right report -> return (coverageReportToAPI mLimit report)
+
+{- | Project the domain coverage report onto its wire shape, keeping at most
+@limit@ bridge groups per collection (sorted by rename target, so a cap is
+stable). Each collection's @bridgeGroupCount@ always covers the full list, so a
+truncated list stays countable — never a silent cap.
+-}
+coverageReportToAPI :: Maybe Int -> Coverage.CoverageReport -> CoverageReportAPI
+coverageReportToAPI mLimit r =
+    CoverageReportAPI
+        { cvrDbName = Coverage.crDbName r
+        , cvrCollections = map collectionToAPI (Coverage.crCollections r)
+        }
+  where
+    collectionToAPI c =
+        CollectionBridgesAPI
+            { cvcCollection = Coverage.cbCollection c
+            , cvcTotalFlows = Coverage.cbTotalFlows c
+            , cvcCharacterizedFlows = Coverage.cbCharacterizedFlows c
+            , cvcBridgeGroupCount = length (Coverage.cbGroups c)
+            , cvcBridgeGroups = map groupToAPI (maybe id take mLimit (Coverage.cbGroups c))
+            }
+    groupToAPI g =
+        BridgeGroupAPI
+            { cvgCas = Coverage.bgCas g
+            , cvgMethodName = Coverage.bgMethodName g
+            , cvgBridgedFlows = map flowToAPI (Coverage.bgBridged g)
+            }
+    flowToAPI f =
+        BridgedFlowAPI
+            { cvfFlowName = Coverage.brfFlowName f
+            , cvfStrategy = strategyLabel (Coverage.brfStrategy f)
+            }
+
+-- | Wire label for the bridge that reached a flow (only bridge strategies occur).
+strategyLabel :: MatchStrategy -> Text
+strategyLabel ByCAS = "cas"
+strategyLabel BySynonym = "synonym"
+strategyLabel ByFuzzy = "fuzzy"
+strategyLabel ByProxy = "proxy"
+strategyLabel ByName = "name"
+strategyLabel ByUUID = "uuid"
+strategyLabel NoMatch = "none"
 
 {- | Copy a loaded database under a new name. The copy is an independent
 in-memory database registered under @newName@; the source is untouched.

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -35,7 +35,7 @@ import Database.Manager (DatabaseManager (..), LoadedDatabase (..), getDatabase)
 import qualified Database.Manager as DM
 
 import qualified API.BatchImpacts as BI
-import API.DatabaseHandlers (gapReportToAPI, qualityReportToAPI)
+import API.DatabaseHandlers (coverageReportToAPI, gapReportToAPI, qualityReportToAPI)
 import API.MCP.Columnar (resolveSingleScoringSet, toColumnarBatch)
 import API.MCP.Enrich (addWebUrlMaybe, attachMarketHintByName, encodeSegment, filterScoringSets, scoreActivityWebUrl, slimLCIAPanel, webUrlField)
 import API.Types (ActivityForAPI (..), ActivityInfo (..), ClassificationSystem (..), ExchangeWithUnit (..), InventoryExport (..), InventoryFlowDetail (..), Perturbation (..), Substitution (..), SubstitutionRequest (..))
@@ -364,6 +364,7 @@ callTool dbManager presets mBaseUrl rid name args = case name of
     "get_gap_report" -> callGetGapReport dbManager rid args
     "get_quality_report" -> callGetQualityReport dbManager rid args
     "get_computed_quality_report" -> callGetComputedQualityReport dbManager rid args
+    "get_characterization_coverage" -> callGetCoverageReport dbManager rid args
     _ -> return $ toolError rid ("Unknown tool: " <> name)
 
 -- Helper: extract database, then run action
@@ -1337,6 +1338,17 @@ callGetComputedQualityReport dbManager rid args = runTool rid $ do
     case res of
         Left e -> throwE (batchErrorMsg e)
         Right r -> pure (toolSuccessJson rid (toJSON r))
+
+{- | Characterization-coverage report: the flows each loaded method collection
+scores only through a name bridge. Same wire shape as the REST endpoint
+('coverageReportToAPI'), so both surfaces stay in lock-step.
+-}
+callGetCoverageReport :: DatabaseManager -> Value -> KeyMap Value -> IO Value
+callGetCoverageReport dbManager rid args = runTool rid $ do
+    dbName <- except (requireText "database" args)
+    mCollection <- except (optionalText "collection" args)
+    report <- ExceptT (DM.databaseCoverageReport dbManager dbName mCollection)
+    return $ toolSuccessJson rid (toJSON (coverageReportToAPI (intArg "limit" args) report))
 
 callGetFlowMapping :: DatabaseManager -> Value -> KeyMap Value -> IO Value
 callGetFlowMapping dbManager rid args = runTool rid $ do

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -74,6 +74,7 @@ data Resource
     | GetGapReport
     | GetQualityReport
     | GetComputedQualityReport
+    | GetCoverageReport
     deriving (Eq, Ord, Show, Bounded, Enum)
 
 -- | Whether a parameter must be supplied by the caller.
@@ -158,6 +159,7 @@ apiPath r = case r of
     GetGapReport -> Just (GET, ["db", "{dbName}", "gap-report"])
     GetQualityReport -> Just (GET, ["db", "{dbName}", "quality-report"])
     GetComputedQualityReport -> Just (GET, ["db", "{dbName}", "computed-quality-report"])
+    GetCoverageReport -> Just (GET, ["db", "{dbName}", "characterization-coverage"])
 
 {- | The full OpenAPI path template for a resource, e.g.
 @"/api/v1/db/{dbName}/activity/{processId}/impacts/{collection}/{methodId}"@.
@@ -203,6 +205,7 @@ mcpName r = case r of
     GetGapReport -> "get_gap_report"
     GetQualityReport -> "get_quality_report"
     GetComputedQualityReport -> "get_computed_quality_report"
+    GetCoverageReport -> "get_characterization_coverage"
 
 -- ---------------------------------------------------------------------------
 -- Projection: CLI subcommand names (kebab-case)
@@ -244,6 +247,7 @@ cliName r = case r of
     GetGapReport -> "gap-report"
     GetQualityReport -> "quality-report"
     GetComputedQualityReport -> "computed-quality-report"
+    GetCoverageReport -> "characterization-coverage"
 
 -- ---------------------------------------------------------------------------
 -- Projection: human-readable description (shared across surfaces)
@@ -504,6 +508,19 @@ description r = case r of
         \which checks what the database STORES and runs on staged databases \
         \too; this one needs the matrices and a loaded method collection. \
         \Same finding shape: severity, the entry, a readable detail."
+    GetCoverageReport ->
+        "LCA / ACV — characterization-coverage report of a database against the \
+        \loaded LCIA method collections, for the people who maintain databases. \
+        \Surfaces the flows a method scores ONLY through a name bridge: VoLCA \
+        \matches a factor to a flow that carries a different name for the same \
+        \substance (via synonym or CAS number), so the flow is characterized \
+        \here — but a tool that matches factors by their exact name has no such \
+        \bridge and scores it as zero, silently. Each \
+        \bridged flow is grouped under the name the method itself uses (its \
+        \rename target). One entry per loaded collection, so two method versions \
+        \can be compared side by side. Optionally filtered to a single \
+        \collection. Answers 'which of this database's flow names would an \
+        \exact-name tool fail to characterize?'"
 
 -- ---------------------------------------------------------------------------
 -- Projection: parameter schema
@@ -821,4 +838,9 @@ params r = case r of
         [ pDatabase
         , Param "collection" "string" Optional "Method collection to score the catalogue against. Defaults to the single loaded collection; required when several are loaded."
         , pLimit "Max findings to return per check, worst first (default: all). Each check's offenderCount always covers its full list, so a truncated list stays countable."
+        ]
+    GetCoverageReport ->
+        [ pDatabase
+        , Param "collection" "string" Optional "Restrict the report to one loaded method collection (from list_methods). If omitted, every loaded collection is reported, so two method versions can be compared side by side."
+        , pLimit "Max bridge groups to return per collection (default: all). Each collection's bridgeGroupCount always covers its full list, so a truncated list stays countable."
         ]

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -10,7 +10,7 @@ module API.Routes where
 import API.DatabaseHandlers (simpleAction)
 import qualified API.DatabaseHandlers as DBHandlers
 import qualified API.OpenApi
-import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), CollectionCoverage (..), ComputedQualityReportAPI (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExportRequest (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GapReportAPI (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), QualityReportAPI (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadChunk (..), UploadResponse (..), apiFlowOfKind)
+import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), CollectionCoverage (..), ComputedQualityReportAPI (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CoverageReportAPI (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExportRequest (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GapReportAPI (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), QualityReportAPI (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadChunk (..), UploadResponse (..), apiFlowOfKind)
 import App.Env (AppEnv (..), AppM, runApp)
 import qualified Config
 import Control.Concurrent.Async (mapConcurrently)
@@ -131,6 +131,8 @@ type LCAAPI =
                 :<|> "db" :> Capture "dbName" Text :> "quality-report" :> QueryParam "limit" Int :> Get '[JSON] QualityReportAPI
                 -- Computed checks: what a loaded database computes, judged against its own norms
                 :<|> "db" :> Capture "dbName" Text :> "computed-quality-report" :> QueryParam "collection" Text :> QueryParam "limit" Int :> Get '[JSON] ComputedQualityReportAPI
+                -- Characterization-coverage report: flows a method collection scores only through a name bridge
+                :<|> "db" :> Capture "dbName" Text :> "characterization-coverage" :> QueryParam "collection" Text :> QueryParam "limit" Int :> Get '[JSON] CoverageReportAPI
                 :<|> "db" :> Capture "dbName" Text :> "copy" :> Capture "newName" Text :> Post '[JSON] ActivateResponse
                 :<|> "db" :> Capture "dbName" Text :> Delete '[JSON] ActivateResponse
                 -- Delete the whole filtered set of activities (selection in JSON body)
@@ -2126,6 +2128,7 @@ lcaServer env = hoistServer lcaAPI (runApp env) handlers
             :<|> DBHandlers.gapReportHandler
             :<|> DBHandlers.qualityReportHandler
             :<|> computedQualityReportH
+            :<|> DBHandlers.coverageReportHandler
             :<|> DBHandlers.copyDatabaseHandler
             :<|> DBHandlers.deleteDatabaseHandler
             :<|> DBHandlers.deleteActivitiesHandler

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -876,6 +876,54 @@ data ComputedQualityReportAPI = ComputedQualityReportAPI
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped ComputedQualityReportAPI)
 
+-- | One database flow a method scores only through a name bridge.
+data BridgedFlowAPI = BridgedFlowAPI
+    { cvfFlowName :: Text
+    , cvfStrategy :: Text -- how the match was reached: "synonym" | "cas" | "fuzzy" | "proxy"
+    }
+    deriving (Eq, Show, Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped BridgedFlowAPI)
+
+{- | The database flows that bridge to one factor. @methodName@ is the name the
+method carries for the substance — the name each bridged flow should be renamed
+to for the database to score in an exact-name tool.
+-}
+data BridgeGroupAPI = BridgeGroupAPI
+    { cvgCas :: Maybe Text
+    , cvgMethodName :: Text
+    , cvgBridgedFlows :: [BridgedFlowAPI]
+    }
+    deriving (Eq, Show, Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped BridgeGroupAPI)
+
+{- | One collection's coverage of the database. @characterizedFlows@ of
+@totalFlows@ is the honest reach; @bridgeGroups@ is the subset reached only
+through a bridge (empty means every scored flow matches by its exact name).
+@bridgeGroupCount@ always covers the whole list, so a list capped by @limit@
+stays countable — never a silent cap.
+-}
+data CollectionBridgesAPI = CollectionBridgesAPI
+    { cvcCollection :: Text
+    , cvcTotalFlows :: Int
+    , cvcCharacterizedFlows :: Int
+    , cvcBridgeGroupCount :: Int
+    , cvcBridgeGroups :: [BridgeGroupAPI]
+    }
+    deriving (Eq, Show, Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped CollectionBridgesAPI)
+
+{- | Characterization-coverage report of a database against the loaded method
+collections: the flows each collection scores only through a synonym/CAS bridge,
+which an exact-name consumer would score as zero. One entry
+per loaded collection, so two method versions can be compared side by side.
+-}
+data CoverageReportAPI = CoverageReportAPI
+    { cvrDbName :: Text
+    , cvrCollections :: [CollectionBridgesAPI]
+    }
+    deriving (Eq, Show, Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped CoverageReportAPI)
+
 -- | Result of auto-loading a single dependency
 data DepLoadResult
     = DepLoaded {dlrName :: Text}

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -91,6 +91,7 @@ module Database.Manager (
     buildLoadedSetupInfo,
     databaseGapReport,
     databaseQualityReport,
+    databaseCoverageReport,
     addDependencyToStaged,
     removeDependencyFromStaged,
     setDataPath,
@@ -152,6 +153,7 @@ import qualified Database.Quality as Quality
 import EcoSpold.Parser2 (normalizeCAS)
 import Matrix (clearCachedSolver)
 import Method.ChemSynonyms (ChemSynonyms, emptyChemSynonyms, loadChemSynonyms)
+import qualified Method.Coverage as Coverage
 import Method.Mapping (
     MatchStrategy,
     MethodIndex,
@@ -162,6 +164,7 @@ import Method.Mapping (
     buildMethodIndex,
     buildMethodSetTables,
     buildMethodTables,
+    characterizedFlowIds,
     directionExcludedCFs,
     expandProxyEdges,
     expandSynonymMappings,
@@ -2313,6 +2316,46 @@ databaseQualityReport manager dbName = do
         (Just loaded, _) -> Right (Quality.qualityReport dbName (toSimpleDatabase (ldDatabase loaded)))
         (Nothing, Just staged) -> Right (Quality.qualityReport dbName (sdSimpleDB staged))
         (Nothing, Nothing) -> Left ("Database not loaded: " <> dbName)
+
+{- | Characterization-coverage report: the database flows a method collection
+scores only through a name bridge (synonym/CAS), which an exact-name consumer
+would score as zero. One entry per loaded collection when @mCollection@ is
+'Nothing'; a single named collection otherwise (an error if it isn't loaded).
+
+Needs a built database (the coverage probe reads the method tables), so unlike
+the quality report it is loaded-only — no staged answer. Computed per request
+on top of the per-method table and mapping caches; if it proves slow at
+ecoinvent scale, the upgrade path is a @(db, collection)@-keyed cache beside
+'mapMethodToTablesCached'.
+-}
+databaseCoverageReport :: DatabaseManager -> Text -> Maybe Text -> IO (Either Text Coverage.CoverageReport)
+databaseCoverageReport manager dbName mCollection = do
+    mLoaded <- getDatabase manager dbName
+    loadedMethods <- readTVarIO (dmLoadedMethods manager)
+    case mLoaded of
+        Nothing -> pure (Left ("Database not loaded: " <> dbName))
+        Just loaded -> do
+            let db = ldDatabase loaded
+            case collectionsToReport mCollection loadedMethods of
+                Left err -> pure (Left err)
+                Right cols -> do
+                    hier <- getLocationHierarchy manager
+                    bridges <- mapM (collectionBridgesFor db hier) cols
+                    pure (Right (Coverage.CoverageReport dbName bridges))
+  where
+    -- The named collection (must be loaded) or every loaded one, by name.
+    collectionsToReport sel loaded = case sel of
+        Just name -> case M.lookup name loaded of
+            Just mc -> Right [(name, mc)]
+            Nothing -> Left ("Method collection not loaded: " <> name)
+        Nothing -> Right (M.toList loaded)
+    collectionBridgesFor db hier (collName, mc) = do
+        let methods = mcMethods mc
+        tables <- mapM (mapMethodToTablesCachedWithHier manager dbName collName db hier) methods
+        mappings <- mapM (effectiveMethodMappings manager dbName collName db) methods
+        let characterized = S.size (S.unions (map (`characterizedFlowIds` dbBioFlows db) tables))
+            total = fromIntegral (dbBiosphereCount db)
+        pure (Coverage.collectionBridges collName total characterized mappings)
 
 {- | Outcome of the atomic staging decision; 'NeedToStage' carries the config
 read inside the same transaction, so no later (racy) re-lookup is needed.

--- a/src/Method/Coverage.hs
+++ b/src/Method/Coverage.hs
@@ -1,0 +1,158 @@
+{- | Characterization-coverage report, for the people who maintain a database
+against a given LCIA method collection.
+
+A score tells you a flow is characterized; it does not tell you /how/ it was
+reached. VoLCA's matcher bridges a name difference — it will score a flow named
+@"Methane, bromo-, Halon 1001"@ off a factor the method lists under
+@"Bromomethane"@, because a synonym or CAS number links the two. A tool that
+matches factors by their exact name has no such bridge: it scores that flow as
+zero, silently.
+
+This report surfaces exactly those flows: the ones a method scores /only/
+through a name bridge, grouped by the factor they bridge to (the name the
+method itself uses, i.e. the rename target). It is the coverage a raw score
+hides, seen from the side of an exact-name consumer.
+
+The heavy lifting — cascading a factor to a flow and recording which strategy
+won — already happens in 'Method.Mapping'. This module is a pure fold over that
+result: partition the reached flows into exact-name and bridge-only, keep the
+bridge-only ones, group them.
+-}
+module Method.Coverage (
+    CoverageReport (..),
+    CollectionBridges (..),
+    BridgeGroup (..),
+    BridgedFlow (..),
+    collectionBridges,
+) where
+
+import Data.List (sortOn)
+import qualified Data.Map.Strict as M
+import Data.Maybe (catMaybes, listToMaybe)
+import qualified Data.Set as Set
+import Data.Text (Text)
+
+import Method.Mapping (MatchStrategy (..))
+import Method.Types (MethodCF (..))
+import Types (BiosphereFlow (..))
+
+{- | The whole report for one database: one entry per loaded method collection,
+so a maintainer comparing two method versions sees both asymmetries side by
+side.
+-}
+data CoverageReport = CoverageReport
+    { crDbName :: !Text
+    , crCollections :: ![CollectionBridges]
+    }
+    deriving (Show, Eq)
+
+{- | One collection's coverage of the database. 'cbCharacterizedFlows' of
+'cbTotalFlows' is the honest reach (name matches /and/ bridges); 'cbGroups' is
+the subset reached only through a bridge — empty means every scored flow
+matches by its exact name.
+-}
+data CollectionBridges = CollectionBridges
+    { cbCollection :: !Text
+    , cbTotalFlows :: !Int
+    , cbCharacterizedFlows :: !Int
+    , cbGroups :: ![BridgeGroup]
+    }
+    deriving (Show, Eq)
+
+{- | The database flows that bridge to one factor. 'bgMethodName' is the name
+the method carries for the substance — the name each bridged flow should be
+renamed to for the database to score in an exact-name tool.
+-}
+data BridgeGroup = BridgeGroup
+    { bgCas :: !(Maybe Text)
+    , bgMethodName :: !Text
+    , bgBridged :: ![BridgedFlow]
+    }
+    deriving (Show, Eq)
+
+-- | One database flow scored only through a bridge, and which bridge won.
+data BridgedFlow = BridgedFlow
+    { brfFlowName :: !Text
+    , brfStrategy :: !MatchStrategy
+    }
+    deriving (Show, Eq)
+
+-- | Whether a strategy reached a flow by its own name, or bridged to it.
+data Reach = Exact | Bridged
+
+{- | An exact-name match is what an exact-string consumer also sees; every other
+strategy is a bridge it would miss. Total on 'MatchStrategy' so a new variant
+forces a decision here. ('NoMatch' cannot occur on a resolved tuple, but the
+match must stay exhaustive.)
+-}
+strategyReach :: MatchStrategy -> Reach
+strategyReach ByName = Exact
+strategyReach ByUUID = Exact
+strategyReach ByCAS = Bridged
+strategyReach BySynonym = Bridged
+strategyReach ByFuzzy = Bridged
+strategyReach ByProxy = Bridged
+strategyReach NoMatch = Bridged
+
+{- | Fold a collection's effective per-method mappings into its bridge groups.
+'total' and 'characterized' are the caller's honest counts (from
+'Method.Mapping.characterizedFlowIds'); the groups are derived here.
+-}
+collectionBridges ::
+    -- | collection name
+    Text ->
+    -- | total biosphere flows in the database
+    Int ->
+    -- | flows the collection characterizes (distinct, bridges included)
+    Int ->
+    -- | per-method effective mappings (factor, matched flow + winning strategy)
+    [[(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]] ->
+    CollectionBridges
+collectionBridges name total characterized perMethod =
+    CollectionBridges name total characterized groups
+  where
+    tuples =
+        [ (cf, flow, strat)
+        | mappings <- perMethod
+        , (cf, Just (flow, strat)) <- mappings
+        ]
+    reachOf (_, _, strat) = strategyReach strat
+    exactNameIds =
+        Set.fromList [bfId flow | t@(_, flow, _) <- tuples, isExact (reachOf t)]
+    bridged =
+        [ (cf, flow, strat)
+        | t@(cf, flow, strat) <- tuples
+        , isBridged (reachOf t)
+        , bfId flow `Set.notMember` exactNameIds
+        ]
+    -- Group by the factor's own name: the flows that all bridge to it are the
+    -- same substance as the method names it, so that name is their rename target.
+    byMethodName =
+        M.fromListWith
+            (<>)
+            [(mcfFlowName cf, [(cf, flow, strat)]) | (cf, flow, strat) <- bridged]
+    groups = sortOn bgMethodName (map toGroup (M.toList byMethodName))
+    toGroup (methodName, items) =
+        BridgeGroup
+            { bgCas = firstJust ([mcfCAS cf | (cf, _, _) <- items] ++ [bfCAS f | (_, f, _) <- items])
+            , bgMethodName = methodName
+            , bgBridged = flowsOf items
+            }
+    -- One row per distinct database name; a flow bridged by several factors
+    -- keeps its first-seen strategy.
+    flowsOf items =
+        sortOn brfFlowName $
+            [ BridgedFlow fname strat
+            | (fname, strat) <- M.toList (M.fromListWith (\_ old -> old) [(bfName f, s) | (_, f, s) <- items])
+            ]
+
+isExact :: Reach -> Bool
+isExact Exact = True
+isExact Bridged = False
+
+isBridged :: Reach -> Bool
+isBridged Bridged = True
+isBridged Exact = False
+
+firstJust :: [Maybe a] -> Maybe a
+firstJust = listToMaybe . catMaybes

--- a/test/CoverageSpec.hs
+++ b/test/CoverageSpec.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Pure tests for 'Method.Coverage': from a collection's per-method effective
+mappings, does it surface exactly the flows scored only through a name bridge,
+grouped under the name the method itself uses?
+
+The fixtures build the mapping tuples directly — @collectionBridges@ is a pure
+fold over them, so no database or method tables are needed.
+-}
+module CoverageSpec (spec) where
+
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import Data.UUID (UUID, fromWords, nil)
+import Data.Word (Word32)
+import Test.Hspec
+
+import Data.Aeson (decode, encode)
+
+import API.DatabaseHandlers (coverageReportToAPI)
+import API.Types (CollectionBridgesAPI (..), CoverageReportAPI (..))
+import Method.Coverage
+import Method.Mapping (MatchStrategy (..))
+import Method.Types (FlowDirection (..), MethodCF (..))
+import Types (BiosphereFlow (..))
+
+uuid :: Word32 -> UUID
+uuid = fromWords 0 0 0
+
+flowNamed :: Word32 -> Text -> Maybe Text -> BiosphereFlow
+flowNamed n name mCas =
+    BiosphereFlow
+        { bfId = uuid n
+        , bfName = name
+        , bfUnitId = nil
+        , bfSynonyms = M.empty
+        , bfCAS = mCas
+        , bfSubstanceId = Nothing
+        , bfCompartment = Nothing
+        }
+
+cfNamed :: Text -> Maybe Text -> MethodCF
+cfNamed name mCas =
+    MethodCF
+        { mcfFlowRef = nil
+        , mcfFlowName = name
+        , mcfDirection = Output
+        , mcfValue = 1.0
+        , mcfCompartment = Nothing
+        , mcfCAS = mCas
+        , mcfUnit = "kg"
+        , mcfConsumerLocation = Nothing
+        }
+
+spec :: Spec
+spec = describe "Method.Coverage.collectionBridges" $ do
+    it "flags a flow scored only through a synonym bridge, naming its rename target" $ do
+        -- The method lists a factor under "Bromomethane"; the database emits the
+        -- same substance under two names. The exact-name one is fine; the other
+        -- is scored only because a synonym links it to the factor.
+        let cf = cfNamed "Bromomethane" (Just "74-83-9")
+            fExact = flowNamed 1 "Bromomethane" (Just "74-83-9")
+            fBridge = flowNamed 2 "Methane, bromo-, Halon 1001" (Just "74-83-9")
+            cb = collectionBridges "EF3.1" 2 2 [[(cf, Just (fExact, ByName)), (cf, Just (fBridge, BySynonym))]]
+        cbGroups cb
+            `shouldBe` [ BridgeGroup
+                            (Just "74-83-9")
+                            "Bromomethane"
+                            [BridgedFlow "Methane, bromo-, Halon 1001" BySynonym]
+                       ]
+
+    it "does not flag a flow the method reaches by its own exact name" $ do
+        let cf = cfNamed "Bromomethane" Nothing
+            f = flowNamed 1 "Bromomethane" Nothing
+        cbGroups (collectionBridges "m" 1 1 [[(cf, Just (f, ByName))]]) `shouldBe` []
+
+    it "excludes a flow bridged by one factor but exact-named by another" $ do
+        -- The same flow name matches factor B by name, so an exact-name tool
+        -- would score it too — not a silent zero. Must not be reported.
+        let cfA = cfNamed "Bromomethane" Nothing
+            cfB = cfNamed "Methane, bromo-, Halon 1001" Nothing
+            f = flowNamed 1 "Methane, bromo-, Halon 1001" Nothing
+        cbGroups (collectionBridges "m" 1 1 [[(cfA, Just (f, BySynonym)), (cfB, Just (f, ByName))]])
+            `shouldBe` []
+
+    it "groups bridged names under their shared rename target, sorted and deduped across methods" $ do
+        let cf = cfNamed "Bromomethane" (Just "74-83-9")
+            f1 = flowNamed 1 "Methane, bromo-, Halon 1001" (Just "74-83-9")
+            f2 = flowNamed 2 "Bromomethane, halon" Nothing
+            m1 = [(cf, Just (f1, BySynonym))]
+            m2 = [(cf, Just (f1, BySynonym)), (cf, Just (f2, ByCAS))]
+        cbGroups (collectionBridges "m" 5 2 [m1, m2])
+            `shouldBe` [ BridgeGroup
+                            (Just "74-83-9")
+                            "Bromomethane"
+                            [ BridgedFlow "Bromomethane, halon" ByCAS
+                            , BridgedFlow "Methane, bromo-, Halon 1001" BySynonym
+                            ]
+                       ]
+
+    it "reports no groups when nothing bridges" $
+        cbGroups (collectionBridges "m" 0 0 []) `shouldBe` []
+
+    it "carries the caller's collection name and coverage counts through" $ do
+        let cb = collectionBridges "EF3.1 (adapted) v1.03" 1300 1240 []
+        cbCollection cb `shouldBe` "EF3.1 (adapted) v1.03"
+        cbTotalFlows cb `shouldBe` 1300
+        cbCharacterizedFlows cb `shouldBe` 1240
+
+    describe "wire projection" $ do
+        -- Two substances, each with one bridged name → two groups.
+        let twoGroups =
+                collectionBridges
+                    "EF3.1"
+                    2
+                    2
+                    [
+                        [ (cfNamed "Bromomethane" Nothing, Just (flowNamed 1 "Methane, bromo-, Halon 1001" Nothing, BySynonym))
+                        , (cfNamed "Bromotrifluoromethane" Nothing, Just (flowNamed 2 "Methane, bromotrifluoro-, Halon 1301" Nothing, BySynonym))
+                        ]
+                    ]
+            report = CoverageReport "agb" [twoGroups]
+
+        it "caps bridge groups per collection but keeps the full count" $
+            case cvrCollections (coverageReportToAPI (Just 1) report) of
+                [coll] -> do
+                    cvcBridgeGroupCount coll `shouldBe` 2
+                    length (cvcBridgeGroups coll) `shouldBe` 1
+                _ -> expectationFailure "expected exactly one collection"
+
+        it "returns every bridge group when no limit is given" $
+            case cvrCollections (coverageReportToAPI Nothing report) of
+                [coll] -> length (cvcBridgeGroups coll) `shouldBe` 2
+                _ -> expectationFailure "expected exactly one collection"
+
+        it "round-trips the wire report through JSON" $ do
+            let api = coverageReportToAPI Nothing report
+            decode (encode api) `shouldBe` Just api

--- a/test/MCPDispatchSpec.hs
+++ b/test/MCPDispatchSpec.hs
@@ -101,3 +101,16 @@ spec = describe "MCP database load/unload tools" $ do
             resp <- call "get_quality_report"
             isError resp `shouldBe` True
             resultText resp `shouldSatisfy` maybe False ("Database not loaded:" `T.isInfixOf`)
+
+    describe "characterization-coverage tool" $ do
+        it "is advertised with a required 'database' parameter (collection is optional)" $
+            fmap requiredOf (toolByName "get_characterization_coverage") `shouldBe` Just ["database"]
+
+        it "is routed by callTool (no 'Unknown tool' gap)" $ do
+            resp <- call "get_characterization_coverage"
+            resultText resp `shouldSatisfy` maybe False (not . T.isPrefixOf "Unknown tool:")
+
+        it "surfaces the engine error for an unknown database" $ do
+            resp <- call "get_characterization_coverage"
+            isError resp `shouldBe` True
+            resultText resp `shouldSatisfy` maybe False ("Database not loaded:" `T.isInfixOf`)

--- a/test/RoutesSpec.hs
+++ b/test/RoutesSpec.hs
@@ -275,6 +275,12 @@ routeSpecs = do
             resp <- doGet b "/api/v1/db/no-such-db/quality-report"
             statusCode (responseStatus resp) `shouldBe` 404
 
+        it "GET /api/v1/db/no-such-db/characterization-coverage returns 404" $ \b -> do
+            -- Loaded-only: it reads the built method tables, so an absent
+            -- database is a 404.
+            resp <- doGet b "/api/v1/db/no-such-db/characterization-coverage"
+            statusCode (responseStatus resp) `shouldBe` 404
+
     describe "method-not-allowed" $ do
         it "GET /api/v1/db/X returns 405 (only DELETE is defined on /db/{name})" $ \b -> do
             -- Documents the current API surface: /db/{name} accepts DELETE,

--- a/volca.cabal
+++ b/volca.cabal
@@ -68,6 +68,7 @@ library
                      , Method.WriterSimaPro
                      , Method.ParserNW
                      , Method.Mapping
+                     , Method.Coverage
                      , Method.Patch
                      , Method.ChemSynonyms
                      , Method.FlowResolver
@@ -294,6 +295,7 @@ test-suite lca-tests
                      , GapReportSpec
                      , QualityReportSpec
                      , ComputedQualitySpec
+                     , CoverageSpec
                      , GlobalSubstitutionSpec
                      , DatabaseStatusSpec
                      , DependencyChoiceSpec


### PR DESCRIPTION
## Why

When a database names a substance differently from the method that characterizes it — `Bromomethane` versus `Methane, bromo-, Halon 1001`, same CAS number — the matching cascade still resolves a factor through the synonym or CAS bridge, so the flow is scored here. A consumer that matches factors by their exact name has no such bridge and scores that flow as zero, without warning. A database maintainer has no way to see those flows today: the score looks complete.

## What

A characterization-coverage report lists exactly the flows a method scores only through a bridge, grouped under the name the method itself uses — so the fix is to rename the database's flow to that name. One entry per loaded method collection, so two versions of a method can be compared side by side.

It is a dedicated resource, deliberately **not** a seventh quality check: the coverage depends on which methods are loaded, whereas the structural quality report is a method-free scan (identical staged or loaded) whose shape a release gate keys on. Folding this in would have made that gate start blocking on a method-dependent signal.

The computation reuses the existing mapping cascade rather than adding matching logic: a flow is bridge-only when it is in the collection's honest reach (`characterizedFlowIds`) but not reached by an exact-name strategy (`ByName`/`ByUUID`) in `effectiveMethodMappings`. Grouped by the factor it bridges to, whose name is the rename target.

## Surface

- MCP tool `get_characterization_coverage`
- `GET /api/v1/db/{db}/characterization-coverage` (optional `collection`, `limit`)

Registered as one `Resource` (`API.Resources`), so REST, MCP and OpenAPI derive from a single entry.

## Tests

`test/CoverageSpec.hs` covers the pure fold (the Bromomethane case, exact-name exclusion, grouping/dedup, the wire cap and JSON round-trip); `MCPDispatchSpec` pins the tool advertised and routed; `RoutesSpec` pins the 404 on an absent database.