### PR TITLE
Advertise wire revision 4 for the quality-report routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 
 ### Changed
+- The engine now advertises wire revision 4 on `/api/v1/version`. The three
+  quality-report routes added since 0.9.3 arrived without a revision bump, so
+  a client had no way to know whether an engine offered them: an engine too
+  old to have the route answers 404, and so does an engine asked about a
+  database it has not loaded. Clients gate on revision 4 and can tell the two
+  apart. `pyvolca` understands the new revision.
 - Log lines now say which database they belong to. When several databases
   load at once their lines used to interleave in one anonymous stream, so a
   page following one load would show another's progress. Each line of

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -28,7 +28,7 @@ pyvolca speaks a range of revisions of the engine's JSON wire format; the engine
 
 _Generated from `volca._compat` — run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.8.2** speaks wire formats **2 to 3** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error.
+This build of **pyvolca 0.8.2** speaks wire formats **2 to 4** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error.
 
 <!-- END: compatibility -->
 

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -22,7 +22,7 @@ pyvolca speaks a range of revisions of the engine's JSON wire format; the engine
 | `0.5.x` | (pre-`wireVersion`) | `v0.5.0` … `v0.7.x` |
 | `0.6.0` … `0.7.1` | `1` | `v0.8.0` … `v0.9.0` |
 | `0.7.2` … `0.8.1` | `2` | `≥ v0.9.1` |
-| `> 0.8.1` | `2` … `3` | `≥ v0.9.1` (delete by ids: `≥ v0.9.3`) |
+| `> 0.8.1` | `2` … `4` | `≥ v0.9.1` (delete by ids: `≥ v0.9.3`; quality reports: `≥ v0.9.4`) |
 
 <!-- BEGIN: compatibility -->
 

--- a/pyvolca/src/volca/_compat.py
+++ b/pyvolca/src/volca/_compat.py
@@ -25,10 +25,10 @@ the client works against it except the revision-gated capabilities (see
 ``Client._require_wire``), which check the engine's advertised revision
 before sending anything."""
 
-KNOWN_WIRE = 3
-"""The newest wire revision this pyvolca understands (revision 3 adds the
-delete ``ids`` selection). An engine advertising more is newer than this
-client and may answer shapes it cannot decode."""
+KNOWN_WIRE = 4
+"""The newest wire revision this pyvolca understands (revision 4 adds the
+quality-report routes). An engine advertising more is newer than this client
+and may answer shapes it cannot decode."""
 
 MIN_ENGINE_HINT = "0.9.1"
 """First engine release that advertises :data:`REQUIRED_WIRE`. Used only for the

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1221,14 +1221,18 @@ getOpenApiSpec = return $ toJSON volcaOpenApi
 
 {- | Wire-format revision advertised on /api/v1/version. BUMP this whenever a
 breaking change to the JSON wire shape lands (field rename/removal, type
-narrowing, newly-required field) — or when an additive capability is unsafe
-to probe blindly, so clients need a discriminator (revision 3: the delete
-@ids@ selection, which an older engine would ignore and fall back to the
-whole filtered set). Clients compare it to decide compatibility and to gate
-such capabilities.
+narrowing, newly-required field), or whenever a new route or capability
+appears that a client must know about /before/ calling it. Adding a route
+does not exempt a change from the bump: an absent route answers 404, and so
+does a request naming a database the engine has not loaded, so a client
+cannot tell "this engine is too old" from "you asked for the wrong thing"
+(revision 4: the quality-report, computed-quality-report and
+characterization-coverage routes; revision 3: the delete @ids@ selection,
+which an older engine would ignore and fall back to the whole filtered set).
+Clients compare it to decide compatibility and to gate such capabilities.
 -}
 currentWireVersion :: Int
-currentWireVersion = 3
+currentWireVersion = 4
 
 getVersion :: AppM Value
 getVersion =


### PR DESCRIPTION
The three quality-report routes added since 0.9.3 arrived without a wire-revision bump, on the reading that a new route needs none — a client can just call it and see.

It cannot. An engine too old to have the route answers 404, and so does an engine asked about a database it has not loaded. From the answer alone a client cannot tell "this engine is too old" from "you asked for the wrong thing", so it shows the bare status and the reader is left guessing. The revision is the only thing that separates the two cases.

The engine now advertises revision 4, the rule above the constant says that a new route counts, and pyvolca's `KNOWN_WIRE` follows so it stops warning about an engine of its own generation.