### PR TITLE
Fan the synonym expansion out through the registry's own closure

### DIFF
--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -698,17 +698,28 @@ Pass 'M.empty' for the compartment map when no normalization is desired
 
 {- | Fan out one-to-many synonym matches: for each CF, look up the
 synonym group of the CF name and emit one extra @(cf, Just (peerFlow,
-BySynonym))@ row per BAFU flow whose name is in the group and whose
-compartment medium matches the CF's compartment. The original mapping
-list is preserved.
+BySynonym))@ row per flow whose name is in the group, resolved in the
+CF's direction view. The original mapping list is preserved.
 
 This is the missing piece when a method-side CF (e.g. ILCD's bare
-@copper@) covers many inventory-side variants (BAFU's @Copper, 2.19% in
+@copper@) covers many inventory-side variants (@Copper, 2.19% in
 sulfide, …@, @Copper, 1.18% in sulfide, …@, etc.). Without expansion,
 @buildMethodTables@ would key the CF under a single matched-flow name
 and the other variants would silently look up as @Nothing@. With
 expansion, the CF is keyed under every group member, so every inventory
 variant of the same substance finds the same CF.
+
+The fan-out follows the registry's own closure classes, exactly as
+'lookupSynonymGroup' reports them. A curated chain routinely pivots
+through an alias that names no loaded flow (@Energy, from coal@ =
+@hard coal@ = @Coal, hard@ — only the endpoints are flows), so the walk
+must not require every intermediate to be a flow or CF name: an earlier
+version re-closed the relation on that induced subgraph and silently
+cut every such bridge. Keeping junk hubs out of the closure is the
+ingestion layer's job — matching trusts only the curated registry plus
+sources the user explicitly activates, and candidates pass
+'excludeJunkSynonyms' / 'excludeOverFrequentSynonyms' with an
+'oversizedClasses' audit before they can be activated.
 
 Duplicates are harmless — 'buildMethodTables' uses @fromListWith
 preferBetter@.
@@ -721,39 +732,8 @@ expandSynonymMappings ::
 expandSynonymMappings synDB flowsByName mappings =
     mappings ++ concatMap expand mappings
   where
-    -- De-fan-out (M): restrict the synonym relation to USED flow names — the
-    -- DB's own flow-name index ∪ this method's CF names — then re-close on that
-    -- induced subgraph. Generic source-synonym tokens that are not flow names
-    -- (e.g. @organic@, listed on tens of thousands of ILCD flows) drop out, so
-    -- they stop fusing unrelated substances into one giant junk-hub class. The
-    -- global closure has already merged such a hub and cannot be re-split, so we
-    -- re-close from 'synEdges' (the original pairs) against the used set here.
-    --
-    -- Trade-off: a synonym whose name is neither a flow nor a CF is dropped, so a
-    -- substance bridged ONLY through such an intermediate would be lost. Measured
-    -- on JRC EF-3.1 × BAFU (all 25 categories), the dropped matches are junk-hub
-    -- fan-out (e.g. @arsenic → {butanol, acetone, aluminium, …}@) plus correct
-    -- CO₂/CH₄/land-use subtype discrimination (a @…, land use change@ CF must not
-    -- reach the generic @carbon dioxide@ flow); no genuine same-substance match
-    -- was lost. The restriction is sound in practice.
-    used :: S.Set Text
-    used =
-        foldr
-            (S.insert . normalizeName . mcfFlowName . fst)
-            (S.fromList (M.keys flowsByName))
-            mappings
-
-    -- Re-close so the direction tags survive: the induced DB is rebuilt from
-    -- 'SynEdge's, so it carries the same directional views as the source. A CF
-    -- then fans out only through bridges valid for its direction. The stored
-    -- edges are already normalized — re-closing must NOT re-normalize them
-    -- ('normalizeName' is not idempotent), hence 'buildFromNormalizedEdges'.
-    inducedDB :: SynonymDB
-    inducedDB =
-        buildFromNormalizedEdges [e | e <- synEdges synDB, S.member (seA e) used, S.member (seB e) used]
-
     expand (cf, _) =
-        let dirDB = viewFor (mcfDirection cf) inducedDB
+        let dirDB = viewFor (mcfDirection cf) synDB
             peers = fromMaybe [] (getSynonyms dirDB =<< lookupSynonymGroup dirDB (mcfFlowName cf))
          in [ (cf, Just (flow, BySynonym))
             | syn <- peers

--- a/src/SynonymDB.hs
+++ b/src/SynonymDB.hs
@@ -159,8 +159,8 @@ buildFromEdges :: [SynEdge] -> SynonymDB
 buildFromEdges = buildFromNormalizedEdges . normalizeEdges
 
 {- | Build from edges whose endpoints already carry 'normalizeName''s output —
-the invariant every built DB's 'synEdges' satisfies. Merging and the
-induced-subgraph restriction re-close through HERE, not 'buildFromEdges':
+the invariant every built DB's 'synEdges' satisfies. 'mergeSynonymDBs'
+re-closes through HERE, not 'buildFromEdges':
 'normalizeName' is not idempotent (a suffix exposed by punctuation removal —
 @"Zinc in ground,"@ → @"zinc in ground"@ → @"zinc"@ — strips only on a second
 pass), so re-normalizing stored edges would key the rebuilt tables away from
@@ -179,10 +179,9 @@ buildFromNormalizedEdges es =
      in base{synViews = views}
   where
     edgesFor dir = filter (\e -> seDir e == BridgeBoth || seDir e == dir)
-    -- Views are terminal: nothing re-closes them (merge and the induced
-    -- restriction read the TOP-level 'synEdges'), so a view's own edge list is
-    -- dead weight in memory and in the serialized cache — store the lookup
-    -- tables only.
+    -- Views are terminal: nothing re-closes them (merging reads the TOP-level
+    -- 'synEdges'), so a view's own edge list is dead weight in memory and in
+    -- the serialized cache — store the lookup tables only.
     viewTables = clearEdges . buildTables
     clearEdges t = t{synEdges = []}
 

--- a/src/SynonymDB/Types.hs
+++ b/src/SynonymDB/Types.hs
@@ -28,8 +28,8 @@ data BridgeDirection = BridgeBoth | BridgeInput | BridgeOutput
     deriving (Eq, Ord, Show, Generic, NFData, Store)
 
 {- | A normalized @SameAs@ edge carrying the direction it is valid for. Kept in
-'synEdges' so the relation can be re-closed (merge, induced-subgraph restriction)
-without losing the direction constraint.
+'synEdges' so the relation can be re-closed (merging) without losing the
+direction constraint.
 -}
 data SynEdge = SynEdge
     { seA :: !Text

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -216,6 +216,29 @@ spec = do
             fid <- nextRandom
             fannedIds outputCF fid `shouldBe` []
 
+    describe "expandSynonymMappings transitivity" $ do
+        -- A curated chain routinely pivots through an alias that names no loaded
+        -- flow: "Energy, from coal" = "hard coal" = "Coal, hard", where only the
+        -- endpoints are flow or CF names. The fan-out must follow the closure
+        -- through that pivot — requiring every intermediate to be a flow or CF
+        -- name silently cut the whole coal family out of energy accounting.
+        let synDB =
+                buildFromEdges
+                    [ SynEdge "Energy, from coal" "hard coal" BridgeBoth
+                    , SynEdge "hard coal" "Coal, hard" BridgeBoth
+                    ]
+            energyCF = (mkCF "Energy, from coal" Nothing 1.0){mcfDirection = Input}
+
+        it "fans out through a pivot alias that is neither a flow nor a CF name" $ do
+            fid <- nextRandom
+            let coalFlow = mkFlow fid "Coal, hard" "resource" Nothing
+                flowsByName = M.singleton "coal hard" [coalFlow]
+            [ bfId flow
+              | (_, Just (flow, BySynonym)) <-
+                    drop 1 (expandSynonymMappings synDB flowsByName [(energyCF, Nothing)])
+              ]
+                `shouldBe` [fid]
+
     describe "directionExcludedCFs" $ do
         -- An unmapped CF whose name matches through the UNION synonym tables but
         -- not through its own direction's view was excluded by the direction


### PR DESCRIPTION
## Why

A characterization factor fans out to every flow in its synonym group, but the expansion restricted the synonym relation to edges whose **both** endpoints name a loaded flow or a method CF, re-closing on that induced subgraph. Curated chains in `data/flows.csv` routinely pivot through an alias that names no flow:

```
Energy, from coal  =  hard coal  =  Coal, hard        ← "hard coal" is neither a flow nor a CF
```

Both edges around such a pivot died, cutting the chain — silently. On a SimaPro-named food database, a primary-energy category lost the entire coal and natural-gas families (~7% of a cereal chain's energy). Oil escaped by accident: an identically-named *water emission* ("Crude oil") kept its pivot in the used set. Peat and uranium escaped because their pivot happens to be the flow name itself.

The restriction existed to stop junk hubs (auto-extracted tokens like "organic") from fusing unrelated substances. That defense has since moved to ingestion: matching trusts only the curated registry plus sources the user explicitly activates, and candidates pass `excludeJunkSynonyms` / `excludeOverFrequentSynonyms` with an `oversizedClasses` audit before they can be activated.

## Final state

The fan-out follows the registry's closure classes exactly as `lookupSynonymGroup` reports them; directional (input/output) views still apply. A regression test reproduces the non-flow-pivot topology.

Verified: full suite green; binary-to-binary diff on the same process shows five of six counting categories bit-identical, and the sixth gains exactly the natural-gas + hard-coal + brown-coal inventory converted at the configured energy densities — nothing else moves.