### PR TITLE
Ship a "Plain indicators" method with wildcard substance patterns

### DIFF
--- a/data/methods/plain-indicators.csv
+++ b/data/methods/plain-indicators.csv
@@ -1,0 +1,25 @@
+# methodology: Plain indicators
+# Raw physical quantities counted through the supply chain: every factor is
+# 1.0, so a category's score is the summed inventory quantity itself.
+# Open families (occupation, water, energy, waste heat) are wildcard rows —
+# a trailing * matches every flow with that name prefix in the stated
+# compartment, so the database's own flow list defines the coverage and a new
+# flow is counted without touching this file. Single substances are ordinary
+# rows; the flow registry bridges their spelling variants across databases
+# (e.g. "Methane, biogenic" / "Methane, non-fossil").
+;;;;Land occupied;Water used;Fossil CO2;Methane;Primary energy;Waste heat;Cadmium
+;;;;Land occupied;Water used;Fossil CO2;Methane;Primary energy;Waste heat;Cadmium
+;;;;m2a;m3;kg;kg;MJ;MJ;kg
+substance;compartment;cas;unit;;;;;;;
+Occupation*;resource;;;1.0;;;;;;
+Water*;resource;;;;1.0;;;;;
+Carbon dioxide, fossil;air;;;;;1.0;;;;
+Methane;air;;;;;;1.0;;;
+Methane, fossil;air;;;;;;1.0;;;
+Methane, biogenic;air;;;;;;1.0;;;
+Methane, from soil or biomass stock;air;;;;;;1.0;;;
+Energy, *;resource;;;;;;;1.0;;
+Heat, waste*;;;;;;;;;1.0;
+Cadmium (II);air;;;;;;;;;1.0
+Cadmium (II);water;;;;;;;;;1.0
+Cadmium (II);soil;;;;;;;;;1.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -239,6 +239,12 @@ active = true
 name = "Default units"
 path = "data/units.csv"
 active = true
+
+[[methods]]
+name = "plain-indicators"
+path = "data/methods/plain-indicators.csv"
+active = true
+description = "Raw physical quantities counted through the supply chain (CF=1.0)"
 EOF
 
 COPY docker/rts-flags.sh /app/rts-flags.sh

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -282,7 +282,8 @@ isPatternCF = T.isSuffixOf "*" . mcfFlowName
 
 {- | Materialize one pattern CF against the database's biosphere: one concrete
 CF per flow satisfying every predicate the row carries (name prefix, CAS,
-compartment medium). Each concrete CF takes the flow's own identity (UUID,
+compartment medium and — when the row states one — subcompartment). Each
+concrete CF takes the flow's own identity (UUID,
 name, CAS, compartment) — so every table built from the mapping lands exactly
 where the inventory flow will look — and keeps the pattern row's value and
 unit. A database introducing a new flow under the pattern is thus counted on
@@ -311,8 +312,13 @@ expandPatternCF flows cf
     casFits f = maybe True (\cas -> bfCAS f == Just cas) wantCAS
     compFits f = case mcfCompartment cf of
         Nothing -> True
-        Just (Compartment med _ _) ->
-            maybe False (mediumEq med . VT.compartmentName) (bfCompartment f)
+        Just (Compartment med sub _) ->
+            maybe False (\c -> mediumEq med (VT.compartmentName c) && subFits sub c) (bfCompartment f)
+    -- An empty sub means the row constrains only the medium; a stated sub
+    -- must match the flow's, or the row would silently widen to the whole
+    -- medium. Qualifiers are ignored here as 'buildMethodTables' ignores them.
+    subFits sub c =
+        T.null sub || T.toCaseFold sub == maybe "" T.toCaseFold (VT.compartmentSub c)
     mediumEq a b = normalizeMedium (T.toCaseFold a) == normalizeMedium (T.toCaseFold b)
     materialize f =
         cf

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -17,6 +17,8 @@ module Method.Mapping (
     mapMethodFlows,
     mapMethodToFlows,
     resolveCF,
+    isPatternCF,
+    expandPatternCF,
     buildMapContext,
 
     -- * LCIA scoring
@@ -93,7 +95,7 @@ import Control.Exception (evaluate)
 import Control.Monad.ST (runST)
 import Data.Aeson (ToJSON)
 import Data.Either (lefts, rights)
-import Data.List (find, nub, sortOn)
+import Data.List (find, nub, partition, sortOn)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
@@ -111,9 +113,11 @@ import Data.Word (Word8)
 import GHC.Generics (Generic)
 
 import qualified Data.Set as Set
+import EcoSpold.Parser2 (normalizeCAS)
 import Matrix (Inventory, Vector, chunksOf)
 import Method.ChemSynonyms (ChemSynonyms, expandedTokens)
 import Method.Types
+import Progress (ProgressLevel (..), reportProgress)
 import qualified SubstanceRegistry as SR
 import SynonymDB
 import Types (Activity (..), BioFlowDB, BiosphereFlow (..), Database (..), ProcessId, SparseTriple (..), Unit (..), UnitDB)
@@ -226,7 +230,7 @@ mapMethodFlows ::
     IO [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]
 mapMethodFlows ctx0 method = do
     caps <- getNumCapabilities
-    let cfs = methodFactors method
+    let (patternCFs, cfs) = partition isPatternCF (methodFactors method)
         n = length cfs
         -- Precompute the synonym-group → flows memo for the groups this method's
         -- CFs reference (each group expanded once), then resolve every CF against
@@ -234,11 +238,18 @@ mapMethodFlows ctx0 method = do
         -- large closure class — once per CF whose name lands in it.
         ctx = ctx0{mcSynGroupFlows = buildSynGroupFlows ctx0 cfs}
         resolve cf = (cf,) <$> evaluate (resolveCF ctx cf)
-    if caps <= 1 || n < parCfThreshold
-        then mapM resolve cfs
-        else concat <$> mapConcurrently (mapM resolve) (chunksOf (max 1 ((n + caps - 1) `div` caps)) cfs)
+    concrete <-
+        if caps <= 1 || n < parCfThreshold
+            then mapM resolve cfs
+            else concat <$> mapConcurrently (mapM resolve) (chunksOf (max 1 ((n + caps - 1) `div` caps)) cfs)
+    expanded <- fmap concat . mapM materialize $ patternCFs
+    pure (concrete ++ expanded)
   where
     parCfThreshold = 1000
+    materialize cf = do
+        let (rows, warnings) = expandPatternCF (mcBioFlowsByUUID ctx0) cf
+        mapM_ (reportProgress Warning . T.unpack) warnings
+        pure rows
 
 {- | Resolve one method CF to a database biosphere flow. The built-in matchers
 are tried in cascade order — UUID → name → synonym → CAS — and the first whose
@@ -257,6 +268,61 @@ resolveCF ctx cf =
 -- | Convenience wrapper: map method CFs using the built-in cascade + DB.
 mapMethodToFlows :: Database -> Method -> IO [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]
 mapMethodToFlows db = mapMethodFlows (buildMapContext db)
+
+{- | A CF whose substance is a wildcard pattern rather than a literal flow
+name. A trailing @*@ makes the text before it a case-insensitive prefix
+(@"Occupation, *"@ covers every occupation flow); a bare @"*"@ matches any
+name, leaving the row's CAS and compartment cells as the whole predicate.
+Pattern CFs never enter the matcher cascade — 'expandPatternCF' materializes
+them against the database — so a method can declare an open family of flows
+as one rule instead of a per-database list that silently goes stale.
+-}
+isPatternCF :: MethodCF -> Bool
+isPatternCF = T.isSuffixOf "*" . mcfFlowName
+
+{- | Materialize one pattern CF against the database's biosphere: one concrete
+CF per flow satisfying every predicate the row carries (name prefix, CAS,
+compartment medium). Each concrete CF takes the flow's own identity (UUID,
+name, CAS, compartment) — so every table built from the mapping lands exactly
+where the inventory flow will look — and keeps the pattern row's value and
+unit. A database introducing a new flow under the pattern is thus counted on
+its next mapping without touching the method file.
+
+Failure is loud, not silent: a pattern matching no flow comes back as an
+unmatched row plus a warning (coverage then shows the gap instead of the
+category quietly counting zero), and a bare @"*"@ constrained by nothing is
+refused the same way — matching the entire biosphere is never intended.
+-}
+expandPatternCF ::
+    BioFlowDB ->
+    MethodCF ->
+    ([(MethodCF, Maybe (BiosphereFlow, MatchStrategy))], [Text])
+expandPatternCF flows cf
+    | not constrained = refuse "has no name prefix, CAS or compartment; refusing to match every flow"
+    | null matches = refuse "matches no flow in this database"
+    | otherwise = ([(materialize f, Just (f, ByName)) | f <- matches], [])
+  where
+    refuse why = ([(cf, Nothing)], ["[METHOD] wildcard CF '" <> mcfFlowName cf <> "' " <> why])
+    prefix = T.toCaseFold (T.dropEnd 1 (mcfFlowName cf))
+    wantCAS = normalizeCAS <$> mcfCAS cf
+    constrained = not (T.null prefix) || isJust wantCAS || isJust (mcfCompartment cf)
+    matches = filter fits (M.elems flows)
+    fits f = prefix `T.isPrefixOf` T.toCaseFold (bfName f) && casFits f && compFits f
+    casFits f = maybe True (\cas -> bfCAS f == Just cas) wantCAS
+    compFits f = case mcfCompartment cf of
+        Nothing -> True
+        Just (Compartment med _ _) ->
+            maybe False (mediumEq med . VT.compartmentName) (bfCompartment f)
+    mediumEq a b = normalizeMedium (T.toCaseFold a) == normalizeMedium (T.toCaseFold b)
+    materialize f =
+        cf
+            { mcfFlowRef = bfId f
+            , mcfFlowName = bfName f
+            , mcfCAS = bfCAS f
+            , mcfCompartment = fromFlowCompartment <$> bfCompartment f
+            }
+    fromFlowCompartment c =
+        Compartment (VT.compartmentName c) (fromMaybe "" (VT.compartmentSub c)) ""
 
 -- | Convert strategy text back to MatchStrategy
 strategyFromText :: Text -> MatchStrategy

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -248,7 +248,8 @@ mapMethodFlows ctx0 method = do
     parCfThreshold = 1000
     materialize cf = do
         let (rows, warnings) = expandPatternCF (mcBioFlowsByUUID ctx0) cf
-        mapM_ (reportProgress Warning . T.unpack) warnings
+            prefix = "[LCIA " <> methodName method <> "] "
+        mapM_ (reportProgress Warning . T.unpack . (prefix <>)) warnings
         pure rows
 
 {- | Resolve one method CF to a database biosphere flow. The built-in matchers
@@ -303,7 +304,7 @@ expandPatternCF flows cf
     | null matches = refuse "matches no flow in this database"
     | otherwise = ([(materialize f, Just (f, ByName)) | f <- matches], [])
   where
-    refuse why = ([(cf, Nothing)], ["[METHOD] wildcard CF '" <> mcfFlowName cf <> "' " <> why])
+    refuse why = ([(cf, Nothing)], ["wildcard CF '" <> mcfFlowName cf <> "' " <> why])
     prefix = T.toCaseFold (T.dropEnd 1 (mcfFlowName cf))
     wantCAS = normalizeCAS <$> mcfCAS cf
     constrained = not (T.null prefix) || isJust wantCAS || isJust (mcfCompartment cf)

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -2,6 +2,7 @@
 
 module MappingSpec (spec) where
 
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
@@ -12,6 +13,7 @@ import Test.Hspec
 
 import Method.ChemSynonyms (emptyChemSynonyms, parseChemSynonymsCSV)
 import Method.Mapping
+import Method.ParserCSV (parseMethodCSVBytes)
 import Method.Types (Compartment (..), FlowDirection (..), Method (..), MethodCF (..), buildCompartmentMapFromCSV)
 import SynonymDB (BridgeDirection (..), SynEdge (..), buildFromEdges, buildFromPairs, emptySynonymDB, normalizeName)
 import Types (BiosphereFlow (..), Unit (..))
@@ -918,6 +920,19 @@ spec = do
             mappings <- mapMethodFlows ctx method
             map (fmap (bfId . fst) . snd) mappings
                 `shouldMatchList` map (Just . bfId) [waterRiver, occAnnual, occOrchard]
+
+    -- Lint of the shipped method file, like RegistryLintSpec for data/flows.csv:
+    -- a header typo or a misplaced comment would otherwise ship silently.
+    describe "shipped plain-indicators method (data/methods/plain-indicators.csv)" $ do
+        parsed <- runIO (parseMethodCSVBytes <$> BS.readFile "data/methods/plain-indicators.csv")
+
+        it "parses into its seven categories" $
+            fmap (map methodName) parsed
+                `shouldBe` Right ["Land occupied", "Water used", "Fossil CO2", "Methane", "Primary energy", "Waste heat", "Cadmium"]
+
+        it "carries its wildcard rows as patterns" $
+            [mcfFlowName cf | Right ms <- [parsed], m <- ms, cf <- methodFactors m, isPatternCF cf]
+                `shouldBe` ["Occupation*", "Water*", "Energy, *", "Heat, waste*"]
 
 tShow :: (Show a) => a -> Text
 tShow = T.pack . show

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -6,14 +6,14 @@ import qualified Data.ByteString.Lazy as BL
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.UUID (UUID, nil)
+import Data.UUID (UUID, fromWords, nil)
 import Data.UUID.V4 (nextRandom)
 import Test.Hspec
 
 import Method.ChemSynonyms (emptyChemSynonyms, parseChemSynonymsCSV)
 import Method.Mapping
 import Method.Types (Compartment (..), FlowDirection (..), Method (..), MethodCF (..), buildCompartmentMapFromCSV)
-import SynonymDB (BridgeDirection (..), SynEdge (..), buildFromEdges, buildFromPairs, emptySynonymDB)
+import SynonymDB (BridgeDirection (..), SynEdge (..), buildFromEdges, buildFromPairs, emptySynonymDB, normalizeName)
 import Types (BiosphereFlow (..), Unit (..))
 import qualified Types as VT
 import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig)
@@ -838,5 +838,85 @@ spec = do
             cfFamily "unknown" `shouldBe` OtherCFFamily
             cfFamily "" `shouldBe` OtherCFFamily
 
+    describe "wildcard (pattern) CFs" $ do
+        let flowDB = M.fromList [(bfId f, f) | f <- allFlows]
+            allFlows =
+                [ occAnnual
+                , occOrchard
+                , transformation
+                , waterRiver
+                , methaneAir
+                , methaneWater
+                ]
+            occAnnual = mkFlow (u 1) "Occupation, annual crop" "resource" Nothing
+            occOrchard = mkFlow (u 2) "Occupation, permanent crop, fruit" "resource" Nothing
+            transformation = mkFlow (u 3) "Transformation, to annual crop" "resource" Nothing
+            waterRiver = mkFlow (u 4) "Water, river" "resource" Nothing
+            methaneAir = (mkFlow (u 5) "Methane, fossil" "air" Nothing){bfCAS = Just "74-82-8"}
+            methaneWater = (mkFlow (u 6) "Methane, fossil" "water" Nothing){bfCAS = Just "74-82-8"}
+            u = uuidFromInt
+            -- Compare by UUID: BiosphereFlow has no Eq/Show instance.
+            expandedIds = map (fmap (bfId . fst) . snd) . fst
+
+        it "detects a trailing-star name as a pattern, a literal name as not" $ do
+            isPatternCF (mkCF "Occupation*" Nothing 1.0) `shouldBe` True
+            isPatternCF (mkCF "*" Nothing 1.0) `shouldBe` True
+            isPatternCF (mkCF "Occupation, annual crop" Nothing 1.0) `shouldBe` False
+
+        it "expands a prefix pattern to every flow of the compartment, none else" $ do
+            let cf = mkCFComp "Occupation*" "natural resource" "" 1.0
+            expandedIds (expandPatternCF flowDB cf)
+                `shouldMatchList` map (Just . bfId) [occAnnual, occOrchard]
+
+        it "materializes each match with the flow's own identity, keeping value and unit" $ do
+            let cf = (mkCFComp "Occupation*" "natural resource" "" 1.0){mcfUnit = "m2a"}
+                (rows, warnings) = expandPatternCF flowDB cf
+            warnings `shouldBe` []
+            [(mcfFlowRef m, mcfFlowName m, mcfValue m, mcfUnit m) | (m, _) <- rows]
+                `shouldMatchList` [(bfId f, bfName f, 1.0, "m2a") | f <- [occAnnual, occOrchard]]
+
+        it "a bare * with a CAS expands by CAS, filtered by the row's compartment" $ do
+            let cf = (mkCFComp "*" "air" "" 1.0){mcfCAS = Just "74-82-8"}
+            expandedIds (expandPatternCF flowDB cf) `shouldBe` [Just (bfId methaneAir)]
+
+        it "a pattern matching no flow surfaces one unmatched row and a warning" $ do
+            let cf = mkCFComp "Uranium*" "natural resource" "" 1.0
+                (rows, warnings) = expandPatternCF flowDB cf
+            map (fmap (bfId . fst) . snd) rows `shouldBe` [Nothing]
+            length warnings `shouldBe` 1
+
+        it "a bare * constrained by nothing is refused, not matched to everything" $ do
+            let cf = mkCF "*" Nothing 1.0
+                (rows, warnings) = expandPatternCF flowDB cf
+            map (fmap (bfId . fst) . snd) rows `shouldBe` [Nothing]
+            length warnings `shouldBe` 1
+
+        it "mapMethodFlows resolves literal rows via the cascade and expands patterns" $ do
+            let method =
+                    Method
+                        { methodId = nil
+                        , methodName = "Land occupied"
+                        , methodDescription = Nothing
+                        , methodUnit = "m2a"
+                        , methodCategory = "Land occupied"
+                        , methodMethodology = Nothing
+                        , methodFactors =
+                            [ mkCFComp "Water, river" "natural resource" "" 1.0
+                            , mkCFComp "Occupation*" "natural resource" "" 1.0
+                            ]
+                        }
+                ctx = MapContext flowDB (byName allFlows) M.empty emptySynonymDB M.empty M.empty
+            mappings <- mapMethodFlows ctx method
+            map (fmap (bfId . fst) . snd) mappings
+                `shouldMatchList` map (Just . bfId) [waterRiver, occAnnual, occOrchard]
+
 tShow :: (Show a) => a -> Text
 tShow = T.pack . show
+
+-- | Deterministic UUID for wildcard-CF fixtures.
+uuidFromInt :: Int -> UUID
+uuidFromInt n = fromWords (fromIntegral n) 0 0 0
+
+-- | Name index the cascade reads, keyed like the loader keys it.
+byName :: [BiosphereFlow] -> M.Map Text [BiosphereFlow]
+byName fs = M.fromListWith (++) [(normalizeName (bfName f), [f]) | f <- fs]

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -845,6 +845,7 @@ spec = do
                 , occOrchard
                 , transformation
                 , waterRiver
+                , waterWell
                 , methaneAir
                 , methaneWater
                 ]
@@ -852,6 +853,7 @@ spec = do
             occOrchard = mkFlow (u 2) "Occupation, permanent crop, fruit" "resource" Nothing
             transformation = mkFlow (u 3) "Transformation, to annual crop" "resource" Nothing
             waterRiver = mkFlow (u 4) "Water, river" "resource" Nothing
+            waterWell = mkFlow (u 7) "Water, well" "resource" (Just "in ground")
             methaneAir = (mkFlow (u 5) "Methane, fossil" "air" Nothing){bfCAS = Just "74-82-8"}
             methaneWater = (mkFlow (u 6) "Methane, fossil" "water" Nothing){bfCAS = Just "74-82-8"}
             u = uuidFromInt
@@ -874,6 +876,13 @@ spec = do
             warnings `shouldBe` []
             [(mcfFlowRef m, mcfFlowName m, mcfValue m, mcfUnit m) | (m, _) <- rows]
                 `shouldMatchList` [(bfId f, bfName f, 1.0, "m2a") | f <- [occAnnual, occOrchard]]
+
+        it "honors the sub-compartment a pattern row states, widens without one" $ do
+            let inGround = mkCFComp "Water*" "natural resource" "in ground" 1.0
+                anySub = mkCFComp "Water*" "natural resource" "" 1.0
+            expandedIds (expandPatternCF flowDB inGround) `shouldBe` [Just (bfId waterWell)]
+            expandedIds (expandPatternCF flowDB anySub)
+                `shouldMatchList` map (Just . bfId) [waterRiver, waterWell]
 
         it "a bare * with a CAS expands by CAS, filtered by the row's compartment" $ do
             let cf = (mkCFComp "*" "air" "" 1.0){mcfCAS = Just "74-82-8"}

--- a/volca.toml
+++ b/volca.toml
@@ -54,7 +54,8 @@ host = "127.0.0.1"             # Bind address ("0.0.0.0" for all interfaces)
 
 # ── Methods ──────────────────────────────────────────────────────────
 #
-# LCIA characterization methods (ILCD format, .zip of XML files).
+# LCIA characterization methods. Accepted: an ILCD directory or .zip of XML
+# files, a SimaPro or columnar method .csv, or an openLCA ImpactCategory .json.
 #
 # Fields:
 #   name          (required) Method collection name
@@ -62,11 +63,22 @@ host = "127.0.0.1"             # Bind address ("0.0.0.0" for all interfaces)
 #   active        = true     Enable this method
 #   description              Short description
 #
-# Example:
+# Example (bring your own):
 #
 # [[methods]]
 # name = "EF-3.1"
 # path = "DBs/EF-v3.1.zip"
+
+# "Plain indicators" — a small, license-clean method that counts raw physical
+# quantities through the supply chain (land occupied, water used, fossil CO2,
+# methane, primary energy, waste heat, cadmium), each an LCIA category whose
+# factors are all 1.0. Rule-derived, not copied from any licensed workbook, so it
+# ships with the engine and ports to any loaded database through the flow registry.
+[[methods]]
+name = "plain-indicators"
+path = "data/methods/plain-indicators.csv"
+active = true
+description = "Raw physical quantities counted through the supply chain (CF=1.0)"
 
 # ── Reference data (shipped with VoLCA) ──────────────────────────────
 


### PR DESCRIPTION
A small, license-clean LCIA method that counts raw physical quantities through a supply chain — land occupied, water used, fossil CO2, methane, primary energy, waste heat, cadmium — each a category whose factors are all 1.0, so its score is the summed inventory quantity. It ships with the engine and ports to any loaded database through the flow registry.

To keep the method from silently going stale, this adds a small capability to the columnar method loader: a substance cell ending in `*` is a **wildcard pattern**, not a literal flow name. `Occupation*` in the resource compartment characterizes every occupation flow a database carries; a bare `*` with a CAS characterizes every flow of that substance. The method file then declares the open families (occupation, water, energy, waste heat) as one rule each — the database's own flow list defines the coverage, and a newly added or renamed flow is counted without editing the file. Single substances stay explicit rows the registry bridges across databases.

Failure stays loud, never silent: a pattern that matches nothing comes back unmatched with a warning, and a `*` constrained by neither prefix, CAS nor compartment is refused rather than characterizing the whole biosphere.

Validated against Agribalyse 3.2: the wildcard rows reproduce the previously hand-materialized selection exactly for land, fossil CO2, methane, primary energy, waste heat and cadmium, and recover seven water-resource flows a fixed list had omitted — with nothing dropped.