### PR TITLE
Backfill SimaPro flow CAS from the file's own substance registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@
   output is unchanged.
 
 ### Fixed
+- Flows from a SimaPro CSV database now carry their CAS numbers. The parser
+  used to leave every flow's CAS empty, so a characterization factor that
+  could only reach its flow by CAS never matched on a SimaPro-sourced
+  database. The CAS now comes from the file's own substance registry — the
+  trailing blocks that list every substance with its CAS — filling about 89%
+  of biosphere flows on a real export, so methods can match these flows by
+  CAS instead of relying on name and synonym matching alone.
 - openLCA JSON-LD method files now load with the right factor directions,
   compartments, and reference unit — including files openLCA itself
   exported. Such files carry no per-factor direction, so every factor used

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -36,7 +36,7 @@ import Amount (readAmount)
 import Control.Concurrent.Async (mapConcurrently)
 import Control.DeepSeq (NFData, force)
 import Control.Exception (evaluate)
-import Control.Monad (mfilter)
+import Control.Monad (forM_, mfilter)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as BL
@@ -59,7 +59,7 @@ import qualified Expr
 import GHC.Conc (getNumCapabilities)
 import GHC.Generics (Generic)
 import Progress (ProgressLevel (..), reportProgress)
-import SubstanceRegistry (CASNumber (..), NormName (..))
+import SubstanceRegistry (CASNumber (..), NormName (..), casBindings)
 import SynonymDB (normalizeName)
 import Text.Printf (printf)
 import Types
@@ -353,6 +353,10 @@ for both a process section and a trailing substance-registry block. Inside a
 process) @Emissions to soil@ — and the registry-only @Raw materials@ /
 @Airborne emissions@ / @Waterborne emissions@ — introduce the substance
 registry, a @name;unit;cas;comment@ list of every substance with its CAS.
+The trailer's @Final waste flows@ block collides too but is deliberately left
+to its process-section reading: its substances are waste flows, not biosphere
+flows, so it has no CAS to contribute (and its productless block is discarded
+as before).
 -}
 classifyHeader :: Bool -> BS.ByteString -> Maybe SectionType
 classifyHeader inProcess line
@@ -1365,8 +1369,28 @@ parseWorkerLines cfg ls =
                     , gpProjInput = paProjInputParams finalAcc
                     , gpProjCalc = paProjCalcParams finalAcc
                     }
-            , wrSubstanceCAS = paSubstanceCAS finalAcc
+            , -- Restore file order (rows accumulate reversed): downstream the
+              -- first binding of a name wins, and "first" must mean the file's.
+              wrSubstanceCAS = reverse (paSubstanceCAS finalAcc)
             }
+
+{- | Fill empty biosphere-flow CAS from the @(name, CAS)@ pairs a SimaPro
+export lists in its trailing substance registry. Holes only — reuses
+'fillBioFlowCAS', so a CAS the flow already carries is never overwritten. Name
+and CAS are canonicalized the same way the runtime registry bridge is
+('normalizeName' / 'normalizeCAS'), so a filled CAS keys the same as one the
+method side resolved. A registry binding one name to two different CAS follows
+the runtime registry's rule — the first wins — and the conflicts come back for
+the caller to report. A no-op when the file had no registry.
+-}
+fillCASFromRegistry :: [(Text, Text)] -> BioFlowDB -> (BioFlowDB, [(NormName, (CASNumber, CASNumber))])
+fillCASFromRegistry substanceCAS db = (fillBioFlowCAS bindings db, conflicts)
+  where
+    (bindings, conflicts) =
+        casBindings
+            [ (NormName (normalizeName nm), CASNumber (normalizeCAS cas))
+            | (nm, cas) <- substanceCAS
+            ]
 
 -- ============================================================================
 -- Main Entry Point
@@ -1379,25 +1403,6 @@ Reference-product amounts are normalized to the canonical base unit of their
 dimension (e.g. 1 t → 1000 kg) during parsing, so downstream matrix
 construction yields per-base-unit columns.
 -}
-
-{- | Fill empty biosphere-flow CAS from the @(name, CAS)@ pairs a SimaPro
-export lists in its trailing substance registry. Holes only — reuses
-'fillBioFlowCAS', so a CAS the flow already carries is never overwritten. Name
-and CAS are canonicalized the same way the runtime registry bridge is
-('normalizeName' / 'normalizeCAS'), so a filled CAS keys the same as one the
-method side resolved. A no-op when the file had no registry.
--}
-fillCASFromRegistry :: [(Text, Text)] -> BioFlowDB -> BioFlowDB
-fillCASFromRegistry substanceCAS
-    | M.null bindings = id
-    | otherwise = fillBioFlowCAS bindings
-  where
-    bindings =
-        M.fromList
-            [ (NormName (normalizeName nm), CASNumber (normalizeCAS cas))
-            | (nm, cas) <- substanceCAS
-            ]
-
 parseSimaProCSV :: UnitConversion.UnitConfig -> FilePath -> IO ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB)
 parseSimaProCSV unitCfg path = do
     reportProgress Info $ "Loading SimaPro CSV file: " ++ path
@@ -1438,9 +1443,17 @@ parseSimaProCSV unitCfg path = do
         -- Fill empty flow CAS from the file's own substance registry (the
         -- trailing name;unit;cas blocks) so the native CAS bridge fires on a
         -- SimaPro export, which otherwise carries no per-flow CAS at all.
-        bioFlowDB = fillCASFromRegistry substanceCAS (M.fromList [(bfId f, f) | f <- allBioFlows])
+        (bioFlowDB, casConflicts) = fillCASFromRegistry substanceCAS (M.fromList [(bfId f, f) | f <- allBioFlows])
         wasteFlowDB = M.fromList [(wfId f, f) | f <- allWasteFlows]
         unitDB = M.fromList [(unitId u, u) | u <- allUnits]
+
+    forM_ casConflicts $ \(NormName n, (CASNumber kept, CASNumber ignored)) ->
+        reportProgress Warning $
+            printf
+                "substance registry binds '%s' to two CAS (%s kept, %s ignored)"
+                (T.unpack n)
+                (T.unpack kept)
+                (T.unpack ignored)
 
     -- Force evaluation before returning
     let !numActivities = length activities

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -54,10 +54,13 @@ import Data.Time (diffUTCTime, getCurrentTime)
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V5 as UUID5
 import qualified Data.Vector as V
+import EcoSpold.Parser2 (normalizeCAS)
 import qualified Expr
 import GHC.Conc (getNumCapabilities)
 import GHC.Generics (Generic)
 import Progress (ProgressLevel (..), reportProgress)
+import SubstanceRegistry (CASNumber (..), NormName (..))
+import SynonymDB (normalizeName)
 import Text.Printf (printf)
 import Types
 import qualified UnitConversion
@@ -219,6 +222,7 @@ data SectionType
     | SecDbCalcParams
     | SecProjInputParams
     | SecProjCalcParams
+    | SecSubstanceRegistry -- trailing name;unit;cas;comment substance list
     | SecNone
     deriving (Show, Eq)
 
@@ -234,6 +238,7 @@ data ParseState
 data ParseAcc = ParseAcc
     { paConfig :: !SimaProConfig
     , paState :: !ParseState
+    , paInProcess :: !Bool -- inside a Process…End pair (vs the file trailer)
     , paCurrentBlock :: !ProcessBlock
     , paBlocks :: ![ProcessBlock]
     , paLineNum :: !Int
@@ -241,6 +246,7 @@ data ParseAcc = ParseAcc
     , paDbCalcParams :: ![(Text, Text)]
     , paProjInputParams :: ![(Text, Text)]
     , paProjCalcParams :: ![(Text, Text)]
+    , paSubstanceCAS :: ![(Text, Text)] -- (name, CAS) from the trailer registry
     }
 
 -- ============================================================================
@@ -273,6 +279,7 @@ instance Monoid GlobalParams where
 data WorkerResult = WorkerResult
     { wrBlocks :: ![ProcessBlock]
     , wrParams :: !GlobalParams
+    , wrSubstanceCAS :: ![(Text, Text)]
     }
     deriving (Show, Eq, Generic)
 
@@ -339,6 +346,21 @@ detectSection line = case BS8.strip line of
     "Social issues" -> Just SecNone
     "Economic issues" -> Just SecNone
     _ -> Nothing
+
+{- | Classify a section header, resolving the two names a SimaPro file reuses
+for both a process section and a trailing substance-registry block. Inside a
+@Process@…@End@ pair the process meaning wins; in the file trailer (no open
+process) @Emissions to soil@ — and the registry-only @Raw materials@ /
+@Airborne emissions@ / @Waterborne emissions@ — introduce the substance
+registry, a @name;unit;cas;comment@ list of every substance with its CAS.
+-}
+classifyHeader :: Bool -> BS.ByteString -> Maybe SectionType
+classifyHeader inProcess line
+    | not inProcess, BS8.strip line `elem` registryHeaders = Just SecSubstanceRegistry
+    | otherwise = detectSection line
+  where
+    registryHeaders =
+        ["Raw materials", "Airborne emissions", "Waterborne emissions", "Emissions to soil"]
 
 -- | Known metadata keys in process block (ByteString)
 isMetadataKey :: BS.ByteString -> Bool
@@ -554,6 +576,21 @@ parseBioRow cfg line =
                         }
             _ -> Nothing
 
+{- | Parse one row of a trailing substance-registry block
+(@name;unit;cas;comment@), returning the @(name, CAS)@ pair when the CAS column
+is populated. The registry lists every elementary substance the file uses with
+its CAS; waste rows and a few substances leave the CAS column blank and are
+skipped (a name→CAS binding needs a CAS).
+-}
+parseSubstanceRow :: SimaProConfig -> BS.ByteString -> Maybe (Text, Text)
+parseSubstanceRow cfg line =
+    case splitCSV (spDelimiter cfg) line of
+        (name : _unit : cas : _) ->
+            let n = decodeBS (BS8.strip name)
+                c = decodeBS (BS8.strip cas)
+             in if T.null n || T.null c then Nothing else Just (n, c)
+        _ -> Nothing
+
 -- ============================================================================
 -- State Machine Processing (ByteString based)
 -- ============================================================================
@@ -574,6 +611,7 @@ processLine acc@ParseAcc{..} line
     | BS8.strip line == "Process" =
         acc
             { paState = BetweenBlocks
+            , paInProcess = True
             , paCurrentBlock = emptyProcessBlock
             }
     -- End of block
@@ -583,11 +621,12 @@ processLine acc@ParseAcc{..} line
             isValid = not (null (pbProducts block))
          in acc
                 { paState = BetweenBlocks
+                , paInProcess = False
                 , paBlocks = if isValid then block : paBlocks else paBlocks
                 , paCurrentBlock = emptyProcessBlock
                 }
-    -- Section detection
-    | Just sec <- detectSection line =
+    -- Section detection (trailer registry blocks resolve against paInProcess)
+    | Just sec <- classifyHeader paInProcess line =
         acc{paState = InSection sec}
     -- In a section, parse row (route db/project params to ParseAcc, process params to block)
     | InSection sec <- paState
@@ -604,6 +643,9 @@ processLine acc@ParseAcc{..} line
                 Nothing -> acc
             SecProjCalcParams -> case parseParamRow paConfig line of
                 Just p -> acc{paProjCalcParams = p : paProjCalcParams}
+                Nothing -> acc
+            SecSubstanceRegistry -> case parseSubstanceRow paConfig line of
+                Just nc -> acc{paSubstanceCAS = nc : paSubstanceCAS}
                 Nothing -> acc
             _ -> acc{paCurrentBlock = addRowToBlock paConfig sec line paCurrentBlock}
     -- Metadata key-value pairs
@@ -1303,6 +1345,7 @@ parseWorkerLines cfg ls =
             ParseAcc
                 { paConfig = cfg
                 , paState = BetweenBlocks
+                , paInProcess = False
                 , paCurrentBlock = emptyProcessBlock
                 , paBlocks = []
                 , paLineNum = 0
@@ -1310,6 +1353,7 @@ parseWorkerLines cfg ls =
                 , paDbCalcParams = []
                 , paProjInputParams = []
                 , paProjCalcParams = []
+                , paSubstanceCAS = []
                 }
         finalAcc = foldl' processLine initAcc ls
      in WorkerResult
@@ -1321,6 +1365,7 @@ parseWorkerLines cfg ls =
                     , gpProjInput = paProjInputParams finalAcc
                     , gpProjCalc = paProjCalcParams finalAcc
                     }
+            , wrSubstanceCAS = paSubstanceCAS finalAcc
             }
 
 -- ============================================================================
@@ -1334,6 +1379,25 @@ Reference-product amounts are normalized to the canonical base unit of their
 dimension (e.g. 1 t → 1000 kg) during parsing, so downstream matrix
 construction yields per-base-unit columns.
 -}
+
+{- | Fill empty biosphere-flow CAS from the @(name, CAS)@ pairs a SimaPro
+export lists in its trailing substance registry. Holes only — reuses
+'fillBioFlowCAS', so a CAS the flow already carries is never overwritten. Name
+and CAS are canonicalized the same way the runtime registry bridge is
+('normalizeName' / 'normalizeCAS'), so a filled CAS keys the same as one the
+method side resolved. A no-op when the file had no registry.
+-}
+fillCASFromRegistry :: [(Text, Text)] -> BioFlowDB -> BioFlowDB
+fillCASFromRegistry substanceCAS
+    | M.null bindings = id
+    | otherwise = fillBioFlowCAS bindings
+  where
+    bindings =
+        M.fromList
+            [ (NormName (normalizeName nm), CASNumber (normalizeCAS cas))
+            | (nm, cas) <- substanceCAS
+            ]
+
 parseSimaProCSV :: UnitConversion.UnitConfig -> FilePath -> IO ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB)
 parseSimaProCSV unitCfg path = do
     reportProgress Info $ "Loading SimaPro CSV file: " ++ path
@@ -1357,6 +1421,7 @@ parseSimaProCSV unitCfg path = do
     results <- mapConcurrently (evaluate . force . parseWorkerLines cfg) workerChunks
     let allBlocks = concatMap wrBlocks results
         globalParams = foldMap wrParams results
+        substanceCAS = concatMap wrSubstanceCAS results
 
     -- Convert all blocks to activities (one activity per product) - PARALLEL
     converted <- concat <$> mapConcurrently (evaluate . force . processBlockToActivity unitCfg globalParams) allBlocks
@@ -1370,7 +1435,10 @@ parseSimaProCSV unitCfg path = do
     -- by construction (tech flows hash with empty compartment, bio flows hash
     -- with their compartment, waste flows hash with "waste" compartment).
     let techFlowDB = M.fromList [(tfId f, f) | f <- allTechFlows]
-        bioFlowDB = M.fromList [(bfId f, f) | f <- allBioFlows]
+        -- Fill empty flow CAS from the file's own substance registry (the
+        -- trailing name;unit;cas blocks) so the native CAS bridge fires on a
+        -- SimaPro export, which otherwise carries no per-flow CAS at all.
+        bioFlowDB = fillCASFromRegistry substanceCAS (M.fromList [(bfId f, f) | f <- allBioFlows])
         wasteFlowDB = M.fromList [(wfId f, f) | f <- allWasteFlows]
         unitDB = M.fromList [(unitId u, u) | u <- allUnits]
 
@@ -1378,6 +1446,7 @@ parseSimaProCSV unitCfg path = do
     let !numActivities = length activities
     let !numTechFlows = M.size techFlowDB
     let !numBioFlows = M.size bioFlowDB
+    let !numBioFlowsCAS = length [() | f <- M.elems bioFlowDB, maybe False (not . T.null) (bfCAS f)]
     let !numWasteFlows = M.size wasteFlowDB
     let !numUnits = M.size unitDB
 
@@ -1386,7 +1455,7 @@ parseSimaProCSV unitCfg path = do
     reportProgress Info $ printf "SimaPro parsing completed in %.2fs:" duration
     reportProgress Info $ printf "  Activities: %d processes" numActivities
     reportProgress Info $ printf "  Technosphere flows: %d unique" numTechFlows
-    reportProgress Info $ printf "  Biosphere flows: %d unique" numBioFlows
+    reportProgress Info $ printf "  Biosphere flows: %d unique (%d carry a CAS)" numBioFlows numBioFlowsCAS
     reportProgress Info $ printf "  Waste flows: %d unique" numWasteFlows
     reportProgress Info $ printf "  Units: %d unique" numUnits
 

--- a/src/SubstanceRegistry.hs
+++ b/src/SubstanceRegistry.hs
@@ -33,6 +33,7 @@ module SubstanceRegistry (
     classesFromEdges,
 
     -- * CAS enrichment
+    casBindings,
     casBindingsFromEdges,
 
     -- * On-disk format
@@ -192,7 +193,7 @@ second component rather than silently resolved (the first wins, but the caller
 is told).
 -}
 casBindingsFromEdges :: [SubstanceEdge] -> (Map NormName CASNumber, [(NormName, (CASNumber, CASNumber))])
-casBindingsFromEdges edges = foldl' (flip insert) (M.empty, []) pairs
+casBindingsFromEdges edges = casBindings pairs
   where
     pairs =
         [ nc
@@ -203,6 +204,15 @@ casBindingsFromEdges edges = foldl' (flip insert) (M.empty, []) pairs
     nameCasPair (ByName _ n) (ByCAS c) = [(n, c)]
     nameCasPair (ByCAS c) (ByName _ n) = [(n, c)]
     nameCasPair _ _ = []
+
+{- | Fold name→CAS pairs into bindings under the registry's conflict rule: the
+first binding of a name wins, and a later pair binding the same name to a
+/different/ CAS comes back as a conflict for the caller to report — never
+resolved silently.
+-}
+casBindings :: [(NormName, CASNumber)] -> (Map NormName CASNumber, [(NormName, (CASNumber, CASNumber))])
+casBindings = foldl' (flip insert) (M.empty, [])
+  where
     insert (n, c) (m, conflicts) =
         case M.lookup n m of
             Nothing -> (M.insert n c m, conflicts)

--- a/test/SimaProRegistryCASSpec.hs
+++ b/test/SimaProRegistryCASSpec.hs
@@ -26,6 +26,8 @@ giving three of them a CAS. Methane and fossil CO2 are listed under the
 registry-only @Airborne emissions@ header; Cadmium under @Emissions to soil@,
 which also names an in-process section — the trailer copy must win there.
 Dinitrogen monoxide is emitted but absent from the registry (negative case).
+A later @Waterborne emissions@ block re-binds Methane to a different CAS —
+the first binding must win (the file-order rule the fill promises).
 -}
 registryCSV :: BS.ByteString
 registryCSV =
@@ -77,6 +79,11 @@ registryCSV =
         , "Cadmium;kg;007440-43-9;Formula: Cd"
         , ""
         , "End"
+        , ""
+        , "Waterborne emissions"
+        , "Methane;kg;000056-23-5;conflicting duplicate binding"
+        , ""
+        , "End"
         ]
 
 parseRegistryCSV :: IO BioFlowDB
@@ -107,3 +114,9 @@ spec = describe "SimaPro trailing substance registry backfills flow CAS" $ do
     it "leaves a flow the registry does not list without a CAS" $ do
         db <- parseRegistryCSV
         casOf "Dinitrogen monoxide" db `shouldBe` Nothing
+
+    it "keeps the first CAS when the registry binds a name twice" $ do
+        db <- parseRegistryCSV
+        -- The later Waterborne block re-binds Methane to 56-23-5; the
+        -- Airborne binding came first in the file and must survive.
+        casOf "Methane" db `shouldBe` Just "74-82-8"

--- a/test/SimaProRegistryCASSpec.hs
+++ b/test/SimaProRegistryCASSpec.hs
@@ -1,0 +1,109 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | The trailing substance registry a SimaPro export carries (its
+@Raw materials@ / @Airborne emissions@ / … blocks, each row
+@name;unit;cas;comment@) backfills the per-flow CAS the inventory rows omit, so
+the engine's native CAS bridge fires on a SimaPro database. This pins that the
+registry is parsed, merged across the parallel workers, and filled — and that a
+trailer @Emissions to soil@ block is read as the registry, not mistaken for the
+in-process emission section of the same name.
+-}
+module SimaProRegistryCASSpec (spec) where
+
+import qualified Data.ByteString as BS
+import Data.List (find)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import SimaPro.Parser (parseSimaProCSV)
+import System.IO (hClose)
+import System.IO.Temp (withSystemTempFile)
+import Test.Hspec
+import Types (BioFlowDB, BiosphereFlow (..))
+import UnitConversion (defaultUnitConfig)
+
+{- | One process emitting four substances, then a trailer substance registry
+giving three of them a CAS. Methane and fossil CO2 are listed under the
+registry-only @Airborne emissions@ header; Cadmium under @Emissions to soil@,
+which also names an in-process section — the trailer copy must win there.
+Dinitrogen monoxide is emitted but absent from the registry (negative case).
+-}
+registryCSV :: BS.ByteString
+registryCSV =
+    BS.intercalate
+        "\r\n"
+        [ "{SimaPro 9.6.0.1}"
+        , "{CSV separator: semicolon}"
+        , "{Decimal separator: .}"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , "Test process"
+        , ""
+        , "Type"
+        , "Unit process"
+        , ""
+        , "Geography"
+        , "GLO"
+        , ""
+        , "Products"
+        , "Widget;kg;1.0;100;not defined;material;"
+        , ""
+        , "Emissions to air"
+        , "Methane;;kg;2.0;;;;;"
+        , "Carbon dioxide, fossil;;kg;3.0;;;;;"
+        , "Dinitrogen monoxide;;kg;0.5;;;;;"
+        , ""
+        , "Emissions to soil"
+        , "Cadmium;agricultural;kg;4.0;;;;;"
+        , ""
+        , "End"
+        , ""
+        , "Quantities"
+        , "Mass;Yes"
+        , ""
+        , "End"
+        , ""
+        , "Airborne emissions"
+        , "Methane;kg;000074-82-8;Formula: CH4"
+        , "Carbon dioxide, fossil;kg;000124-38-9;Formula: CO2"
+        , ""
+        , "End"
+        , ""
+        , "Emissions to soil"
+        , "Cadmium;kg;007440-43-9;Formula: Cd"
+        , ""
+        , "End"
+        ]
+
+parseRegistryCSV :: IO BioFlowDB
+parseRegistryCSV = withSystemTempFile "registry-cas-test.csv" $ \path handle -> do
+    BS.hPut handle registryCSV
+    hClose handle
+    (_, _, bioFlowDB, _, _) <- parseSimaProCSV defaultUnitConfig path
+    pure bioFlowDB
+
+casOf :: Text -> BioFlowDB -> Maybe Text
+casOf name db = find ((== name) . bfName) (M.elems db) >>= bfCAS
+
+spec :: Spec
+spec = describe "SimaPro trailing substance registry backfills flow CAS" $ do
+    it "fills an air emission's CAS from the Airborne emissions registry" $ do
+        db <- parseRegistryCSV
+        -- 000074-82-8 → normalized (leading zeros stripped from the first group)
+        casOf "Methane" db `shouldBe` Just "74-82-8"
+
+    it "fills fossil CO2's CAS (a name the method cannot resolve by origin)" $ do
+        db <- parseRegistryCSV
+        casOf "Carbon dioxide, fossil" db `shouldBe` Just "124-38-9"
+
+    it "reads a trailer 'Emissions to soil' block as the registry, not the process section" $ do
+        db <- parseRegistryCSV
+        casOf "Cadmium" db `shouldBe` Just "7440-43-9"
+
+    it "leaves a flow the registry does not list without a CAS" $ do
+        db <- parseRegistryCSV
+        casOf "Dinitrogen monoxide" db `shouldBe` Nothing

--- a/volca.cabal
+++ b/volca.cabal
@@ -225,6 +225,7 @@ test-suite lca-tests
                      , MethodSpec
                      , MethodPatchSpec
                      , SimaProParserSpec
+                     , SimaProRegistryCASSpec
                      , BrightwayExcelSpec
                      , BrightwayExcelWriterSpec
                      , UnitConversionSpec


### PR DESCRIPTION
## Why

The CF matching cascade ends in a CAS fallback (UUID → name → synonym → CAS), but the SimaPro parser set every biosphere flow's CAS to nothing. So on any SimaPro-sourced database that last rung was structurally dead: a flow the method could only reach by CAS stayed uncharacterized, and a CAS-keyed audit or probe came back empty.

## What

A SimaPro export ends with a substance registry — `Raw materials`, `Airborne emissions`, `Waterborne emissions`, `Emissions to soil` blocks whose rows are `name;unit;cas;comment` and list every elementary substance with its CAS. The parser now reads those blocks and fills each flow's empty CAS from them, reusing the existing hole-only fill (a CAS the flow already carries is authoritative and kept). The file's own registry takes precedence; the runtime name→CAS registry still fills whatever the file leaves blank.

On a real SimaPro export this lifts CAS coverage from zero to about 89% of biosphere flows (5423 of 6109), which brings the native CAS bridge to life on databases that previously relied on name and synonym matching alone.

## Final state

- New behaviour lives entirely in `SimaPro.Parser`; the fill is the same tested function the loader already used for the runtime registry.
- The registry blocks are `End`-terminated like processes, so they scatter across the parallel workers; each worker gathers its `(name, CAS)` rows and they merge into one fill pass, in file order.
- `Emissions to soil` also names an in-process section — an in-process latch resolves the trailing copy to the registry, not the process section. The trailer's `Final waste flows` block collides too but is deliberately not read: its substances are waste flows, so it has no CAS a biosphere flow could use.
- A registry that binds one name to two different CAS follows the runtime registry's rule — the first binding in file order wins and the conflict is logged as a warning, never resolved silently.
- Covered by a new end-to-end spec parsing a small export (the header-collision case, a conflicting duplicate binding, and a negative control). No regressions across the parser, coverage, mapping and CAS suites.
