### PR TITLE
Invalidate matrix caches predating the SimaPro CAS backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@
   database. The CAS now comes from the file's own substance registry — the
   trailing blocks that list every substance with its CAS — filling about 89%
   of biosphere flows on a real export, so methods can match these flows by
-  CAS instead of relying on name and synonym matching alone.
+  CAS instead of relying on name and synonym matching alone. A database
+  cached before this change rebuilds its cache once on the next load, so
+  already-imported databases pick the CAS up too instead of serving the
+  old CAS-less flows forever.
 - openLCA JSON-LD method files now load with the right factor directions,
   compartments, and reference unit — including files openLCA itself
   exported. Such files carry no per-factor direction, so every factor used

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -206,6 +206,11 @@ History of manual bumps:
 - 10: Activity record gained activityFormulaCheck (mathematicalRelation
      consistency outcome, surfaced by the database quality report). Old
      caches miss the field and would fail mid-decode.
+- 11: SimaPro flow CAS now backfilled from the export's own substance
+     registry at parse time — a value change with no type change, so the
+     fingerprint alone would accept old caches. Caches built before the
+     backfill keep every SimaPro biosphere flow CAS-less, and the method
+     CAS bridge silently never fires on them.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.
@@ -213,7 +218,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeRep (Proxy :: Proxy Database))
-     in hi `xor` lo `xor` 10
+     in hi `xor` lo `xor` 11
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.


### PR DESCRIPTION
The substance-registry CAS backfill (#254) fills each flow's CAS at parse time with no type change, so the cache schema fingerprint still accepts caches built before it: a warm store keeps serving CAS-less SimaPro flows, and the method CAS bridge silently never fires there — the backfill looks like a no-op on any database that was already imported.

Salt bumps 5 and 6 exist for exactly this situation (a parser starts filling a field with no type change), so this bumps the manual salt 10 → 11: such caches rebuild once on the next load and pick the CAS up. The CHANGELOG entry for the backfill now mentions the one-time rebuild.