### PR TITLE
Refuse the CAS bridge where the method's own values disagree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,10 @@
   database. The CAS now comes from the file's own substance registry — the
   trailing blocks that list every substance with its CAS — filling about 89%
   of biosphere flows on a real export, so methods can match these flows by
-  CAS instead of relying on name and synonym matching alone.
+  CAS instead of relying on name and synonym matching alone. A database
+  cached before this change rebuilds its cache once on the next load, so
+  already-imported databases pick the CAS up too instead of serving the
+  old CAS-less flows forever.
 - openLCA JSON-LD method files now load with the right factor directions,
   compartments, and reference unit — including files openLCA itself
   exported. Such files carry no per-factor direction, so every factor used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,12 @@
   to one arbitrary line (the world-average factor) made water scores explode
   on databases whose flows carry CAS numbers. Such a CAS class is now left to
   name matching alone; a CAS that identifies a single factor value still
-  bridges. Region-located factor lines and subcompartment variants keep
-  working as before — their variance is dispatched by location or arbitrated
-  to the medium-level default, not guessed.
+  bridges. The refusal covers the per-location CAS bridge too, so an excluded
+  flow cannot pick up a regional factor instead, and a flow that names its
+  own region keeps that region's value rather than the consuming activity's.
+  Region-located factor lines and subcompartment variants keep working as
+  before — their variance is dispatched by location or arbitrated to the
+  medium-level default, not guessed.
 - Flows from a SimaPro CSV database now carry their CAS numbers. The parser
   used to leave every flow's CAS empty, so a characterization factor that
   could only reach its flow by CAS never matched on a SimaPro-sourced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@
   output is unchanged.
 
 ### Fixed
+- The CAS bridge no longer guesses when one CAS number covers factor lines
+  with different values. Water is the canonical case: every water flow shares
+  one CAS, but a water-use method values each region differently and
+  deliberately leaves rain, ocean and turbined water out — bridging them all
+  to one arbitrary line (the world-average factor) made water scores explode
+  on databases whose flows carry CAS numbers. Such a CAS class is now left to
+  name matching alone; a CAS that identifies a single factor value still
+  bridges. Region-located factor lines and subcompartment variants keep
+  working as before — their variance is dispatched by location or arbitrated
+  to the medium-level default, not guessed.
 - Flows from a SimaPro CSV database now carry their CAS numbers. The parser
   used to leave every flow's CAS empty, so a characterization factor that
   could only reach its flow by CAS never matched on a SimaPro-sourced

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -206,6 +206,11 @@ History of manual bumps:
 - 10: Activity record gained activityFormulaCheck (mathematicalRelation
      consistency outcome, surfaced by the database quality report). Old
      caches miss the field and would fail mid-decode.
+- 11: SimaPro flow CAS now backfilled from the export's own substance
+     registry at parse time — a value change with no type change, so the
+     fingerprint alone would accept old caches. Caches built before the
+     backfill keep every SimaPro biosphere flow CAS-less, and the method
+     CAS bridge silently never fires on them.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.
@@ -213,7 +218,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeRep (Proxy :: Proxy Database))
-     in hi `xor` lo `xor` 10
+     in hi `xor` lo `xor` 11
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -1168,7 +1168,15 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             -- location: when several subcompartment CFs collide on one
             -- (CAS, medium, location) the medium-level default wins over a
             -- niche subcompartment, rather than the largest magnitude.
-            M.map (M.map snd) $
+            --
+            -- And the same 'casDiscriminated' veto: this table feeds the
+            -- name-blind CAS fallback of the regionalized read path
+            -- ('fillRegionalActivityWeights'), so serving a discriminated
+            -- class here would hand an excluded flow (turbine water) the
+            -- consuming activity's regional factor — and would regionalize
+            -- a name-suffixed flow ("Water, lake, CH") by the consuming
+            -- activity's location instead of the flow's own projected value.
+            (`M.withoutKeys` casDiscriminated) . M.map (M.map snd) $
                 M.fromListWith
                     (M.unionWith preferUnspecifiedCas)
                     [ ((SR.CASNumber cas, Medium normMed), M.singleton (Location loc) (casSubRank normSub, cfOf cf))
@@ -1221,7 +1229,14 @@ buildMethodTables methodFamily cmap energyDensities mappings =
     -- Two deliberate non-voters: consumer-located rows, whose variance the
     -- regional tables dispatch by the flow's own location, and rows at
     -- \*different* subcompartments, whose variance 'preferUnspecifiedCas'
-    -- already arbitrates to the medium-level default. Values compare without
+    -- already arbitrates to the medium-level default. The rule behind both:
+    -- a value votes exactly when the method can serve it with no location
+    -- attached. So located rows abstain only as such — against a database
+    -- that writes its regions into flow names,
+    -- 'projectRegionalResourceFlows' has already materialized them into
+    -- region-less copies upstream, and those copies do vote: no location
+    -- can dispatch the variance on that pairing, so both CAS bridges must
+    -- refuse instead. Values compare without
     -- their unit: the read path unit-converts the bridged CF anyway, and
     -- pattern-expanded rows carry each flow's own unit, which is flow
     -- diversity, not authored discrimination.

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -1140,7 +1140,17 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             -- factor — rather than the largest. The largest is often a niche
             -- subcompartment (indoor air can be ~100x the outdoor value) that
             -- would over-characterize every same-CAS flow the bridge reaches.
-            M.map snd $
+            --
+            -- And no bridge at all for a CAS class the method discriminates
+            -- within ('casDiscriminated'): when rows at one (CAS, medium,
+            -- subcompartment) carry different factor values — water is the
+            -- canonical case, one CAS across regional name variants and
+            -- deliberate exclusions like rain, ocean and turbined water — no
+            -- single value is "the" factor for that CAS, and a name-blind
+            -- bridge would stamp an arbitrary one (AWARE's region-less 42.95)
+            -- onto exactly the flows the method chose to distinguish or leave
+            -- out. Same never-guess rule as 'agreedValue'.
+            (`M.withoutKeys` casDiscriminated) . M.map snd $
                 M.fromListWith
                     preferUnspecifiedCas
                     [ ((SR.CASNumber cas, Medium normMed), (casSubRank normSub, cfOf cf))
@@ -1200,6 +1210,40 @@ buildMethodTables methodFamily cmap energyDensities mappings =
     agreedValue vus = case nub vus of
         [vu] -> Just vu
         _ -> Nothing
+
+    -- (CAS, medium) keys the CAS bridge must not serve: two rows agreeing on
+    -- (CAS, medium, subcompartment) but not on the factor value prove the
+    -- method distinguishes flows by something the name-blind bridge cannot
+    -- see — a name-suffixed region ("Water, lake, CH" against the region-less
+    -- "Water" default) or a plain name distinction (fossil against non-fossil
+    -- methane). Every such row votes whatever it resolved to: an unmatched
+    -- "Water, lake, AT" row still proves the method regionalizes water.
+    -- Two deliberate non-voters: consumer-located rows, whose variance the
+    -- regional tables dispatch by the flow's own location, and rows at
+    -- \*different* subcompartments, whose variance 'preferUnspecifiedCas'
+    -- already arbitrates to the medium-level default. Values compare without
+    -- their unit: the read path unit-converts the bridged CF anyway, and
+    -- pattern-expanded rows carry each flow's own unit, which is flow
+    -- diversity, not authored discrimination.
+    casDiscriminated =
+        S.fromList
+            [ (casKey, med)
+            | ((casKey, med, _), vals) <- M.toList casValuesBySub
+            , S.size vals > 1
+            ]
+    casValuesBySub =
+        M.fromListWith
+            S.union
+            [ ((SR.CASNumber cas, Medium normMed, Subcompartment subClass), S.singleton (mcfValue cf))
+            | (cf, _) <- mappings
+            , Just cas <- [mcfCAS cf]
+            , not (T.null cas)
+            , Nothing <- [mcfConsumerLocation cf]
+            , Just comp <- [mcfCompartment cf]
+            , let Compartment normMedRaw normSub _ = normalizeCompartment cmap comp
+            , let normMed = normalizeMedium (T.toLower normMedRaw)
+            , let subClass = if isUnspecifiedSub normSub then "" else normSub
+            ]
 
     -- For the CAS bridge: rank the unspecified / empty subcompartment ahead of
     -- any specific one, so 'preferUnspecifiedCas' keeps the medium-level

--- a/test/CASBridgeAmbiguitySpec.hs
+++ b/test/CASBridgeAmbiguitySpec.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | The CAS bridge ('mtCasCF') characterizes a flow the cascade could not
+match by name through a factor line sharing its CAS number. That is only
+sound when the CAS identifies one factor: a method whose lines carry
+different values at one (CAS, medium, subcompartment) — water is the
+canonical case, one CAS across regional name variants and deliberate
+exclusions like rain or turbined water — distinguishes flows by something
+the name-blind bridge cannot see, so the bridge must refuse rather than
+stamp an arbitrary value onto exactly the flows the method separated.
+This pins the refusal and its two deliberate non-voters: consumer-located
+rows (dispatched by the regional tables) and rows at different
+subcompartments (arbitrated to the medium-level default).
+-}
+module CASBridgeAmbiguitySpec (spec) where
+
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
+import Test.Hspec
+
+import Method.Mapping (MatchStrategy (..), buildMethodTables, cfValue, lookupCFForFlow)
+import Method.Types (CFFamily (..), Compartment (..), FlowDirection (..), MethodCF (..))
+import Types (BiosphereFlow (..))
+import qualified Types as VT
+
+mkUUID :: Integer -> UUID
+mkUUID n = UUID.fromWords64 (fromIntegral n) 0
+
+mkCF :: Integer -> Text -> Text -> Maybe Text -> Double -> MethodCF
+mkCF i name sub cas val =
+    MethodCF
+        { mcfFlowRef = mkUUID i
+        , mcfFlowName = name
+        , mcfDirection = Input
+        , mcfValue = val
+        , mcfCompartment = Just (Compartment "resource" sub "")
+        , mcfCAS = cas
+        , mcfUnit = "m3"
+        , mcfConsumerLocation = Nothing
+        }
+
+mkFlow :: Integer -> Text -> Maybe Text -> BiosphereFlow
+mkFlow i name cas =
+    BiosphereFlow
+        { bfId = mkUUID i
+        , bfName = name
+        , bfUnitId = mkUUID 0
+        , bfSynonyms = M.empty
+        , bfCAS = cas
+        , bfSubstanceId = Nothing
+        , bfCompartment = Just (VT.Compartment "resource" Nothing)
+        }
+
+water :: Maybe Text
+water = Just "7732-18-5"
+
+score :: [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> BiosphereFlow -> Maybe Double
+score mappings flow =
+    fmap cfValue (lookupCFForFlow (buildMethodTables OtherCFFamily M.empty M.empty mappings) (bfId flow) (Just flow))
+
+spec :: Spec
+spec = describe "CAS bridge ambiguity guard" $ do
+    it "refuses to bridge a CAS whose same-subcompartment lines disagree (regionalized water)" $ do
+        -- The region-less default matched its flow by name; the CH variant has
+        -- no same-named flow and landed on a water flow through its CAS —
+        -- which is what arms the bridge. Their values differ at the same
+        -- (CAS, medium, sub), so no single value stands for the CAS.
+        let mappings =
+                [ (mkCF 1 "Water" "" water 42.955, Just (mkFlow 1 "Water" water, ByName))
+                , (mkCF 2 "Water, lake, CH" "" water 1.44, Just (mkFlow 1 "Water" water, ByCAS))
+                ]
+        -- Turbined water: same CAS, no CF of its own — deliberately excluded
+        -- by the method, and it must stay that way.
+        score mappings (mkFlow 99 "Water, turbine use" water) `shouldBe` Nothing
+
+    it "still bridges a CAS with one factor line" $ do
+        let mappings =
+                [(mkCF 1 "Chlorpyrifos" "" (Just "2921-88-2") 5.0, Just (mkFlow 1 "Chlorpyriphos-ethyl" (Just "2921-88-2"), ByCAS))]
+        score mappings (mkFlow 99 "Chlorpyriphos" (Just "2921-88-2")) `shouldBe` Just 5.0
+
+    it "ignores consumer-located rows: their variance is dispatched by location, not guessed" $ do
+        -- JRC-style regionalization: the per-country values live on located
+        -- rows; the region-less default remains the legitimate answer for a
+        -- flow with no location.
+        let located = (mkCF 2 "Water" "" water 1.44){mcfConsumerLocation = Just "CH"}
+            mappings =
+                [ (mkCF 1 "Water" "" water 42.955, Just (mkFlow 1 "Water" water, ByCAS))
+                , (located, Just (mkFlow 1 "Water" water, ByCAS))
+                ]
+        score mappings (mkFlow 99 "Water, unspecified natural origin" water) `shouldBe` Just 42.955
+
+    it "ignores variance across different subcompartments: the medium-level default still bridges" $ do
+        -- Sub-specific siblings (an indoor factor ~100x the outdoor one) are
+        -- already arbitrated to the unspecified default; that arbitration is
+        -- not ambiguity.
+        let mappings =
+                [ (mkCF 1 "Particulates" "" (Just "0000-00-0") 1.0, Just (mkFlow 1 "Particulates, alias" (Just "0000-00-0"), ByCAS))
+                , (mkCF 2 "Particulates" "indoor" (Just "0000-00-0") 100.0, Just (mkFlow 2 "Particulates, indoor" (Just "0000-00-0"), ByName))
+                ]
+        score mappings (mkFlow 99 "Dust" (Just "0000-00-0")) `shouldBe` Just 1.0

--- a/test/CASBridgeAmbiguitySpec.hs
+++ b/test/CASBridgeAmbiguitySpec.hs
@@ -8,9 +8,12 @@ canonical case, one CAS across regional name variants and deliberate
 exclusions like rain or turbined water — distinguishes flows by something
 the name-blind bridge cannot see, so the bridge must refuse rather than
 stamp an arbitrary value onto exactly the flows the method separated.
-This pins the refusal and its two deliberate non-voters: consumer-located
+This pins the refusal and its two deliberate non-voters — consumer-located
 rows (dispatched by the regional tables) and rows at different
-subcompartments (arbitrated to the medium-level default).
+subcompartments (arbitrated to the medium-level default) — and the pairing
+where located rows do end up voting: against a name-suffixed database the
+regional projection materializes them into region-less copies, and both
+CAS bridges must refuse.
 -}
 module CASBridgeAmbiguitySpec (spec) where
 
@@ -20,8 +23,10 @@ import Data.UUID (UUID)
 import qualified Data.UUID as UUID
 import Test.Hspec
 
-import Method.Mapping (MatchStrategy (..), buildMethodTables, cfValue, lookupCFForFlow)
-import Method.Types (CFFamily (..), Compartment (..), FlowDirection (..), MethodCF (..))
+import Method.Mapping (MatchStrategy (..), buildMethodTables, cfValue, lookupCFForFlow, mtCasCF, mtRegionalCasCF, projectRegionalResourceFlows)
+import Method.Types (CFFamily (..), Compartment (..), FlowDirection (..), Medium (..), MethodCF (..))
+import SubstanceRegistry (CASNumber (..))
+import SynonymDB (emptySynonymDB)
 import Types (BiosphereFlow (..))
 import qualified Types as VT
 
@@ -75,6 +80,15 @@ spec = describe "CAS bridge ambiguity guard" $ do
         -- by the method, and it must stay that way.
         score mappings (mkFlow 99 "Water, turbine use" water) `shouldBe` Nothing
 
+    it "an unmatched row votes: it proves the discrimination without resolving to a flow" $ do
+        -- "Water, lake, AT" matches nothing in this database, but its value
+        -- still shows the method regionalizes water — the bridge must refuse.
+        let mappings =
+                [ (mkCF 1 "Water" "" water 42.955, Just (mkFlow 1 "Water" water, ByCAS))
+                , (mkCF 2 "Water, lake, AT" "" water 1.89, Nothing)
+                ]
+        score mappings (mkFlow 99 "Water, turbine use" water) `shouldBe` Nothing
+
     it "still bridges a CAS with one factor line" $ do
         let mappings =
                 [(mkCF 1 "Chlorpyrifos" "" (Just "2921-88-2") 5.0, Just (mkFlow 1 "Chlorpyriphos-ethyl" (Just "2921-88-2"), ByCAS))]
@@ -100,3 +114,35 @@ spec = describe "CAS bridge ambiguity guard" $ do
                 , (mkCF 2 "Particulates" "indoor" (Just "0000-00-0") 100.0, Just (mkFlow 2 "Particulates, indoor" (Just "0000-00-0"), ByName))
                 ]
         score mappings (mkFlow 99 "Dust" (Just "0000-00-0")) `shouldBe` Just 1.0
+
+    describe "a located method against a name-suffixed database" $ do
+        -- JRC-style rows (per-country values, consumer-located) meeting
+        -- SimaPro-style flows (region in the name): location cannot dispatch
+        -- anything there, so 'projectRegionalResourceFlows' materializes the
+        -- located rows into region-less copies — and those copies vote.
+        -- Without their votes the lone region-less row would be unanimous,
+        -- and turbine water would take the world-average factor on exactly
+        -- the pairing the veto exists for.
+        let plainFlow = mkFlow 10 "Water" water
+            chFlow = mkFlow 11 "Water, lake, CH" water
+            inFlow = mkFlow 12 "Water, lake, IN" water
+            bioFlows = M.fromList [(bfId f, f) | f <- [plainFlow, chFlow, inFlow]]
+            mappings =
+                [ (mkCF 1 "Water" "" water 42.955, Just (plainFlow, ByCAS))
+                , ((mkCF 2 "Water, lake" "" water 1.44){mcfConsumerLocation = Just "CH"}, Just (chFlow, ByCAS))
+                , ((mkCF 3 "Water, lake" "" water 100.0){mcfConsumerLocation = Just "IN"}, Just (inFlow, ByCAS))
+                ]
+            tables =
+                buildMethodTables OtherCFFamily M.empty M.empty $
+                    projectRegionalResourceFlows emptySynonymDB bioFlows mappings
+
+        it "the projected copies veto both CAS bridges" $ do
+            M.lookup (CASNumber "7732-18-5", Medium "resource") (mtCasCF tables) `shouldBe` Nothing
+            M.lookup (CASNumber "7732-18-5", Medium "resource") (mtRegionalCasCF tables) `shouldBe` Nothing
+
+        it "a deliberately excluded flow stays uncharacterized" $ do
+            let turbine = mkFlow 99 "Water, turbine use" water
+            fmap cfValue (lookupCFForFlow tables (bfId turbine) (Just turbine)) `shouldBe` Nothing
+
+        it "a suffixed flow keeps its own region's projected value" $
+            fmap cfValue (lookupCFForFlow tables (bfId chFlow) (Just chFlow)) `shouldBe` Just 1.44

--- a/test/SharedCASCoverageSpec.hs
+++ b/test/SharedCASCoverageSpec.hs
@@ -474,15 +474,16 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
             M.lookup (bfId river) (mtUuidCF tables) `shouldBe` Just (CF 5 (CFUnit "m3"))
             M.lookup (bfId river, Location "IN") (mtRegionalizedCF tables) `shouldBe` Just (CF 100 (CFUnit "m3"))
 
-        it "keeps name-regionalized SimaPro rows out of mtCasCF (parser path)" $ do
+        it "vetoes the CAS bridge when name-regionalized rows disagree with the default (parser path)" $ do
             -- End-to-end through the real parser: 'parseCFRow' leaves
             -- 'mcfConsumerLocation' Nothing for SimaPro CFs (the region lives
-            -- in the flow name), so the consumer-location gate cannot exclude
-            -- them from the CAS bridge. Against an inventory that shares the
-            -- CAS but none of the suffixed names ('mcBioFlowsByName' is
-            -- empty), every row falls back to ByCAS — and without the
-            -- name-suffix filter the magnitude tie-break would broadcast the
-            -- arid ±100 rows instead of the region-less default.
+            -- in the flow name), so location cannot dispatch the variance —
+            -- the CH and IN rows disagree with the region-less default at one
+            -- (CAS, medium, sub). No single value stands for the CAS then:
+            -- broadcasting the region-less default used to stamp the
+            -- world-average deprivation factor onto exactly the flows the
+            -- method regionalizes or deliberately excludes (rain, ocean,
+            -- turbined water), so the bridge refuses on both sides.
             let csv =
                     BC.pack $
                         unlines
@@ -507,14 +508,10 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
                 Right coll -> do
                     mappings <- concat <$> mapM (mapMethodFlows mapCtx) (mcMethods coll)
                     let tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
-                    -- Only the region-less rows may broadcast through the
-                    -- name-blind bridge, on both the withdrawal and release
-                    -- sides (the negative release default keeps AWARE's
-                    -- netting on the CAS-fallback path).
                     M.lookup (CASNumber waterCAS, Medium "resource") (mtCasCF tables)
-                        `shouldBe` Just (CF 42.95 (CFUnit "m3"))
+                        `shouldBe` Nothing
                     M.lookup (CASNumber waterCAS, Medium "water") (mtCasCF tables)
-                        `shouldBe` Just (CF (-42.95) (CFUnit "m3"))
+                        `shouldBe` Nothing
 
     describe "unspecified subcompartment is the medium-level fallback" $ do
         it "an uncovered subcompartment falls back to the unspecified CF" $ do

--- a/volca.cabal
+++ b/volca.cabal
@@ -231,6 +231,7 @@ test-suite lca-tests
                      , UnitConversionSpec
                      , ProxyEdgeSpec
                      , CASBackfillSpec
+                     , CASBridgeAmbiguitySpec
                      , RegionFallbackSpec
                      , EnergyResourceFillSpec
                      , CharacterizedFlowsSpec


### PR DESCRIPTION
The substance-registry CAS backfill (#254) armed the CAS bridge on SimaPro-sourced databases — and measuring a real database showed water use exploding by four orders of magnitude on irrigated products. Every water flow shares one CAS number, so the name-blind bridge stamped the world-average deprivation factor (42.95) onto regional name variants and onto flows a water-use method deliberately excludes: rain, ocean and turbined water gained factors, and five regional flows had their fallback value overridden a thousandfold.

The bridge now refuses any (CAS, medium) key where rows at one subcompartment disagree on the factor value — no single value stands for such a CAS, so guessing is worse than leaving the flow to name matching and the coverage report. Two kinds of variance deliberately do not vote: consumer-located rows (their variance is dispatched by the flow's own location through the regional tables, so ILCD-style regionalized water keeps working) and rows at different subcompartments (still arbitrated to the medium-level default, so the indoor/outdoor case keeps working). Located rows abstain only as such: against a database that writes its regions into flow names, the regional projection has already materialized them into region-less copies, and those copies do vote — no location can dispatch the variance on that pairing, so the bridge refuses there too. The same veto applies to the per-location CAS bridge, which the regionalized scoring path consults by bare CAS: without it, an excluded flow would pick up the consuming activity's regional factor, and a name-suffixed flow would be regionalized by the activity's location instead of its own. A CAS that identifies a single factor value still bridges, which is the point of the backfill.

Verified three ways: the new CASBridgeAmbiguitySpec pins the veto, its two non-voters, the located-method × name-suffixed-database pairing (both bridges refuse, turbine water stays excluded, a suffixed flow keeps its own region's value) and that an unmatched row votes; the SharedCASCoverage parser-path expectation — which asserted the failure mode — now pins the veto end to end; and a full 252-product scoring run over a freshly parsed SimaPro database with CAS present reproduces the pre-backfill scores exactly (water flow mapping byte-identical, 757 = 757 characterized flows).

Revalidated empirically on real databases, against both neighbours: the merged tip (backfill, no veto) and the commit before the backfill — the state every published score was validated in. On Agribalyse 3.2 the veto restores that earlier state exactly where it should: water use is bit-identical to pre-backfill on four products under both EF 3.1 distributions, and the water flow mapping matches flow for flow (1028 and 904 characterized, same counts as before the backfill), while the backfill's legitimate CAS bridges survive untouched in the other categories. Measured against the tip, the inflated water scores fall back by five- to tenfold and a product whose water use had gone negative returns positive; the five regional flows whose factor the bridge had overridden thousandfold recover their own value. The veto's whole footprint on that database is the water class plus one xylene class. On native ecoinvent 3.11 cut-off × EF 3.1 it is a measured no-op: the only mapping change is “Water, salt, ocean” losing the world-average factor the bridge had handed it — a factor AWARE deliberately withholds from salt water — and that factor was reaching no score, since all 244 activities emitting that flow score identically across the 25 categories, as does a 300-activity random panel. The salt bump was exercised live too: the engine detects the schema mismatch, discards the stale cache and rebuilds it.

The second commit is the cache salt bump from #255 (10 → 11), riding here so the one-time cache rebuild that surfaces the backfilled CAS ships together with the guard that makes it safe. Closes #255.


