### PR TITLE
Serve each unit-suffixed flow the factor line written in its own unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@
   output is unchanged.
 
 ### Fixed
+- A method's own per-unit factor lines no longer cancel each other. SimaPro
+  names can bake the unit into the flow name — "Gas, natural/m3" and
+  "Gas, natural/kg" are the same substance declared in two units, with two
+  densities — and name normalization collapses both onto one key, where a
+  single winner was crowned. The flow declared in the losing unit then read a
+  dimensionally incompatible factor whose unit conversion silently zeroed its
+  score: on a real SimaPro database, natural gas contributed nothing to
+  fossil resource use, undercounting every gas-heated product by a factor of
+  four. Unit-suffixed flows now match the factor line written for their exact
+  name first, so each variant scores in its own unit; a lone variant still
+  borrows its base resource's factor as before.
 - The CAS bridge no longer guesses when one CAS number covers factor lines
   with different values. Water is the canonical case: every water flow shares
   one CAS, but a water-use method values each region differently and

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -1835,8 +1835,18 @@ lookupCascadeCF tables flowDB fid =
   where
     byNameOrCas flow =
         let name = SR.NormName (normalizeName (bfName flow))
-            variantName = SR.NormName (normalizeNameKeepUnit (bfName flow))
             (baseMed, normSub) = flowMediumSub (mtCompartmentMap tables) flow
+            -- 'mtUnitVariantCF' is empty for every method whose factor lines
+            -- carry no unit suffix — the common case — and 'M.lookup' is strict
+            -- in its key, so an unguarded lookup would make every flow pay a
+            -- second full name normalization on the warmup-hot path for a table
+            -- that cannot answer.
+            unitVariantCF
+                | M.null (mtUnitVariantCF tables) = Nothing
+                | otherwise =
+                    M.lookup
+                        (SR.NormName (normalizeNameKeepUnit (bfName flow)), baseMed)
+                        (mtUnitVariantCF tables)
             -- The medium-level / CAS / sub-blind fallbacks all stand for a
             -- surface, immediate emission, so gate a resolved one by the flow's
             -- subcompartment: a foreign medium (sea/ocean) gets no freshwater CF
@@ -1862,8 +1872,12 @@ lookupCascadeCF tables flowDB fid =
             -- own unit ('mtUnitVariantCF') — the collapsed-name tables below
             -- crown one winner per base name, which for a sibling unit variant
             -- is dimensionally wrong and zeroes on conversion. Gated like the
-            -- other sub-blind rungs.
-            gate (M.lookup (variantName, baseMed) (mtUnitVariantCF tables))
+            -- other sub-blind rungs, but ranked ahead of the sub-exact table on
+            -- purpose: that table is keyed by the collapsed name, so it is
+            -- exactly where the wrong-unit winner sits. A right-unit,
+            -- sub-blind factor beats a right-sub, wrong-unit one — the latter
+            -- scores 0, the former scores.
+            gate unitVariantCF
                 <|> M.lookup (name, baseMed, normSub) (mtExactCF tables)
                 <|> (if isLongTermSub normSub then M.lookup (name, baseMed) (mtLongTermFallbackCF tables) else Nothing)
                 <|> gate (M.lookup (name, baseMed) (mtFallbackCF tables))

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -505,6 +505,18 @@ should be computed once per method and reused across inventories.
 data MethodTables = MethodTables
     { mtUuidCF :: !(M.Map UUID CF)
     -- ^ UUID-matched CFs: exact flow id → CF
+    , mtUnitVariantCF :: !(M.Map (SR.NormName, Medium) CF)
+    {- ^ (unit-suffix-preserving normalized name, medium) → CF, holding only
+    rows whose name carries a SimaPro unit suffix (@"Gas, natural\/m3"@).
+    'normalizeName' strips that suffix, so a method's own per-unit rows
+    (@\/kg@ 43.1 vs @\/m3@ 34.5 — same substance, different densities)
+    collapse onto one name key where a single winner is crowned; the losing
+    variant's flow then reads a dimensionally incompatible CF and its unit
+    conversion silently zeroes the score. This table keys each variant by its
+    full name ('normalizeNameKeepUnit') so a suffixed flow finds the row
+    declared in its own unit. Consulted before the collapsed-name tables;
+    same-key rows that disagree are dropped ('agreedValue' — never guess).
+    -}
     , mtExactCF :: !(M.Map (SR.NormName, Medium, Subcompartment) CF)
     -- ^ (normalized name, medium, subcompartment) → CF
     , mtFallbackCF :: !(M.Map (SR.NormName, Medium) CF)
@@ -1038,6 +1050,28 @@ buildMethodTables methodFamily cmap energyDensities mappings =
                 | (cf, Just (flow, ByUUID)) <- mappings
                 , Nothing <- [mcfConsumerLocation cf]
                 ]
+        , mtUnitVariantCF =
+            -- Keyed by the CF's OWN name with the unit suffix kept, so each
+            -- per-unit row serves the flow declared in its unit — including a
+            -- row whose build-time resolution went to a sibling variant (the
+            -- collapsed-name pick is exactly what this table corrects). Only
+            -- names that actually carry a suffix enter ('normalizeNameKeepUnit'
+            -- differs from 'normalizeName'), keeping the table tiny.
+            -- Subcompartment-blind like 'mtSubBlindCF', with the same
+            -- 'agreedValue' veto: a variant name whose rows disagree (across
+            -- subs or true duplicates) resolves nothing rather than guessing.
+            M.mapMaybe agreedValue $
+                M.fromListWith
+                    (++)
+                    [ ((SR.NormName rawName, Medium normMed), [cfOf cf])
+                    | (cf, _) <- mappings
+                    , let rawName = normalizeNameKeepUnit (mcfFlowName cf)
+                    , rawName /= normalizeName (mcfFlowName cf)
+                    , Nothing <- [mcfConsumerLocation cf]
+                    , Just comp <- [mcfCompartment cf]
+                    , let Compartment normMedRaw _ _ = normalizeCompartment cmap comp
+                    , let normMed = normalizeMedium (T.toLower normMedRaw)
+                    ]
         , -- The broadcast name tables (exact + fallback) hold only
           -- non-regionalized CFs. Location-specific rows belong to
           -- 'mtRegionalizedCF' / 'mtRegionalCasCF'; letting them in here makes
@@ -1801,6 +1835,7 @@ lookupCascadeCF tables flowDB fid =
   where
     byNameOrCas flow =
         let name = SR.NormName (normalizeName (bfName flow))
+            variantName = SR.NormName (normalizeNameKeepUnit (bfName flow))
             (baseMed, normSub) = flowMediumSub (mtCompartmentMap tables) flow
             -- The medium-level / CAS / sub-blind fallbacks all stand for a
             -- surface, immediate emission, so gate a resolved one by the flow's
@@ -1823,7 +1858,13 @@ lookupCascadeCF tables flowDB fid =
             -- emission first tries the method's long-term default
             -- ('mtLongTermFallbackCF') so it inherits the long-term factor, not
             -- the immediate-emission one; if the method has none it falls through.
-            M.lookup (name, baseMed, normSub) (mtExactCF tables)
+            -- A unit-suffixed flow first tries the method row declared in its
+            -- own unit ('mtUnitVariantCF') — the collapsed-name tables below
+            -- crown one winner per base name, which for a sibling unit variant
+            -- is dimensionally wrong and zeroes on conversion. Gated like the
+            -- other sub-blind rungs.
+            gate (M.lookup (variantName, baseMed) (mtUnitVariantCF tables))
+                <|> M.lookup (name, baseMed, normSub) (mtExactCF tables)
                 <|> (if isLongTermSub normSub then M.lookup (name, baseMed) (mtLongTermFallbackCF tables) else Nothing)
                 <|> gate (M.lookup (name, baseMed) (mtFallbackCF tables))
                 <|> gate (bfCAS flow >>= \cas -> M.lookup (SR.CASNumber cas, baseMed) (mtCasCF tables))

--- a/src/SynonymDB.hs
+++ b/src/SynonymDB.hs
@@ -27,6 +27,7 @@ module SynonymDB (
     lookupSynonymGroup,
     getSynonyms,
     normalizeName,
+    normalizeNameKeepUnit,
     mergeSynonymDBs,
     synonymCount,
     oversizedClasses,
@@ -478,7 +479,19 @@ Normalization rules:
 - Remove punctuation: commas, parentheses, quotes
 -}
 normalizeName :: Text -> Text
-normalizeName name =
+normalizeName = normalizeNameWith True
+
+{- | 'normalizeName' minus the unit-suffix strip: @"Gas, natural\/m3"@ keeps its
+@\/m3@. The strip lets a unit variant borrow its base resource's CF, but it also
+collapses a method's own per-unit rows (@\/kg@ vs @\/m3@ — same substance,
+different densities) onto one key — this variant is the lookup key when those
+rows must stay apart.
+-}
+normalizeNameKeepUnit :: Text -> Text
+normalizeNameKeepUnit = normalizeNameWith False
+
+normalizeNameWith :: Bool -> Text -> Text
+normalizeNameWith stripUnits name =
     let
         -- Lowercase and strip
         t1 = T.strip $ T.toLower name
@@ -487,7 +500,7 @@ normalizeName name =
         -- Strip ", in ground" suffix
         t3 = stripSuffix ", in ground" $ stripSuffix " in ground" t2
         -- Strip a trailing SimaPro unit suffix; see 'unitSuffixes'.
-        t4 = foldr stripSuffix t3 unitSuffixes
+        t4 = if stripUnits then foldr stripSuffix t3 unitSuffixes else t3
         -- Remove punctuation. Inlined char predicate: the old version used
         -- @T.filter (`notElem` (",()'\"" :: String))@ which forces 'T.filter'
         -- to traverse a 5-cons-cell @[Char]@ list per input character. With

--- a/test/CrossDBInventorySpec.hs
+++ b/test/CrossDBInventorySpec.hs
@@ -173,6 +173,7 @@ spec = do
                             [ (uuidRoot, CF 27.0 (CFUnit "kg CO2 eq"))
                             , (uuidDep, CF 1.0 (CFUnit "kg CO2 eq"))
                             ]
+                    , mtUnitVariantCF = M.empty
                     , mtExactCF = M.empty
                     , mtFallbackCF = M.empty
                     , mtLongTermFallbackCF = M.empty

--- a/test/UnitVariantCFSpec.hs
+++ b/test/UnitVariantCFSpec.hs
@@ -39,8 +39,16 @@ mkCF ref name unit val =
         , mcfConsumerLocation = Nothing
         }
 
+-- | Move a row to a named subcompartment ('mkCF' writes the unspecified one).
+inSub :: Text -> MethodCF -> MethodCF
+inSub sub cf = cf{mcfCompartment = Just (Compartment "resource" sub "")}
+
 mkFlow :: Integer -> Text -> BiosphereFlow
-mkFlow i name =
+mkFlow i name = mkFlowAt i name Nothing
+
+-- | 'mkFlow' emitted at a named subcompartment.
+mkFlowAt :: Integer -> Text -> Maybe Text -> BiosphereFlow
+mkFlowAt i name sub =
     BiosphereFlow
         { bfId = mkUUID i
         , bfName = name
@@ -48,7 +56,7 @@ mkFlow i name =
         , bfSynonyms = M.empty
         , bfCAS = Nothing
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (VT.Compartment "resource" Nothing)
+        , bfCompartment = Just (VT.Compartment "resource" sub)
         }
 
 lookupFor :: MethodTables -> BiosphereFlow -> Maybe Double
@@ -108,3 +116,33 @@ spec = describe "per-unit method rows (unit-suffixed homonyms)" $ do
         -- matches no row, so the answer comes from the name cascade, not
         -- 'mtUuidCF'.
         lookupFor dup (mkFlow 99 "Gas, natural/kg") `shouldBe` Just 10.0
+
+    it "outranks a sub-exact row keyed by the collapsed name" $ do
+        -- The precedence this rung buys, and its price. The method writes the
+        -- /m3 factor at no particular subcompartment and a DIFFERENT factor for
+        -- the bare name at "in water"; the flow is /m3 emitted in water, so the
+        -- two rows key apart and 'agreedValue' never sees the disagreement.
+        -- Before this table the sub-exact row answered — right subcompartment,
+        -- wrong unit, hence 0 after conversion. The unit-matched row wins now:
+        -- a factor that scores beats one that cannot.
+        let subExact =
+                buildMethodTables
+                    OtherCFFamily
+                    M.empty
+                    M.empty
+                    [ (mkCF 1 "Gas, natural/m3" "m3" 34.5, Nothing)
+                    , (inSub "in water" (mkCF 2 "Gas, natural" "kg" 43.1), Nothing)
+                    ]
+        lookupFor subExact (mkFlowAt 5 "Gas, natural/m3" (Just "in water")) `shouldBe` Just 34.5
+
+    it "stays silent for a subcompartment no medium-level row may reach" $ do
+        -- Sub-blind like its siblings, so it takes the same gate: an ocean
+        -- emission is a foreign medium and must not borrow the freshwater
+        -- factor, unit-matched or not.
+        let oceanic =
+                buildMethodTables
+                    OtherCFFamily
+                    M.empty
+                    M.empty
+                    [(mkCF 1 "Water/m3" "m3" 42.95, Nothing)]
+        lookupFor oceanic (mkFlowAt 6 "Water/m3" (Just "ocean")) `shouldBe` Nothing

--- a/test/UnitVariantCFSpec.hs
+++ b/test/UnitVariantCFSpec.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | A SimaPro name can bake the flow's unit into the name ("Gas, natural\/m3").
+'normalizeName' strips that suffix so a lone variant can borrow its base
+resource's CF — but when the method itself ships one row PER unit variant
+(\/kg 43.1 vs \/m3 34.5: same substance, different densities), the collapsed
+name key crowns a single winner and the losing variant's flow reads a
+dimensionally incompatible CF, whose unit conversion silently zeroes the score.
+
+'mtUnitVariantCF' keys those rows by their full (suffix-preserving) name so
+each suffixed flow finds the row declared in its own unit.
+-}
+module UnitVariantCFSpec (spec) where
+
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
+import Test.Hspec
+
+import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, cfValue, lookupCFForFlow)
+import Method.Types (CFFamily (..), Compartment (..), FlowDirection (..), MethodCF (..))
+import Types (BiosphereFlow (..))
+import qualified Types as VT
+
+mkUUID :: Integer -> UUID
+mkUUID n = UUID.fromWords64 (fromIntegral n) 0
+
+mkCF :: Integer -> Text -> Text -> Double -> MethodCF
+mkCF ref name unit val =
+    MethodCF
+        { mcfFlowRef = mkUUID ref
+        , mcfFlowName = name
+        , mcfDirection = Input
+        , mcfValue = val
+        , mcfCompartment = Just (Compartment "resource" "" "")
+        , mcfCAS = Nothing
+        , mcfUnit = unit
+        , mcfConsumerLocation = Nothing
+        }
+
+mkFlow :: Integer -> Text -> BiosphereFlow
+mkFlow i name =
+    BiosphereFlow
+        { bfId = mkUUID i
+        , bfName = name
+        , bfUnitId = mkUUID 0
+        , bfSynonyms = M.empty
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfCompartment = Just (VT.Compartment "resource" Nothing)
+        }
+
+lookupFor :: MethodTables -> BiosphereFlow -> Maybe Double
+lookupFor tables flow = cfValue <$> lookupCFForFlow tables (bfId flow) (Just flow)
+
+kgFlow, m3Flow :: BiosphereFlow
+kgFlow = mkFlow 1 "Gas, natural/kg"
+m3Flow = mkFlow 2 "Gas, natural/m3"
+
+-- The method ships one row per unit variant. The /kg row UUID-matched its flow;
+-- the /m3 row name-matched — after suffix collapse both compete for the one
+-- "gas natural" name key, which is exactly the failure this spec pins.
+perUnitTables :: MethodTables
+perUnitTables =
+    buildMethodTables
+        OtherCFFamily
+        M.empty
+        M.empty
+        [ (mkCF 1 "Gas, natural/kg" "kg" 43.1, Just (kgFlow, ByUUID))
+        , (mkCF 20 "Gas, natural/m3" "m3" 34.5, Just (m3Flow, ByName))
+        ]
+
+spec :: Spec
+spec = describe "per-unit method rows (unit-suffixed homonyms)" $ do
+    it "serves each unit variant the row declared in its own unit" $ do
+        lookupFor perUnitTables m3Flow `shouldBe` Just 34.5
+        lookupFor perUnitTables kgFlow `shouldBe` Just 43.1
+
+    it "still resolves a bare (unsuffixed) flow through the collapsed name key" $
+        -- No behavior change outside the suffixed variants: the bare name never
+        -- keys into 'mtUnitVariantCF' and keeps today's collapsed-key winner.
+        lookupFor perUnitTables (mkFlow 3 "Gas, natural") `shouldBe` Just 43.1
+
+    it "keeps the base-row ride for a variant the method has no row for" $ do
+        -- Method knows only the base substance: a suffixed flow still borrows
+        -- its CF through the suffix-stripping collapse (the reason the strip
+        -- exists) — the variant table must not get in the way.
+        let baseOnly =
+                buildMethodTables
+                    OtherCFFamily
+                    M.empty
+                    M.empty
+                    [(mkCF 1 "Gas, natural" "m3" 40.0, Just (mkFlow 1 "Gas, natural", ByUUID))]
+        lookupFor baseOnly (mkFlow 4 "Gas, natural/Sm3") `shouldBe` Just 40.0
+
+    it "refuses a variant name whose own rows disagree (true duplicate, never guesses)" $ do
+        let dup =
+                buildMethodTables
+                    OtherCFFamily
+                    M.empty
+                    M.empty
+                    [ (mkCF 1 "Gas, natural/kg" "kg" 10.0, Just (kgFlow, ByUUID))
+                    , (mkCF 2 "Gas, natural/kg" "kg" 20.0, Nothing)
+                    ]
+        -- The variant rung refuses; the collapsed key still answers with its
+        -- winner, exactly as before this table existed. The probe flow's UUID
+        -- matches no row, so the answer comes from the name cascade, not
+        -- 'mtUuidCF'.
+        lookupFor dup (mkFlow 99 "Gas, natural/kg") `shouldBe` Just 10.0

--- a/volca.cabal
+++ b/volca.cabal
@@ -234,6 +234,7 @@ test-suite lca-tests
                      , CASBridgeAmbiguitySpec
                      , RegionFallbackSpec
                      , EnergyResourceFillSpec
+                     , UnitVariantCFSpec
                      , CharacterizedFlowsSpec
                      , SubBlindCFSpec
                      , ServerSpec


### PR DESCRIPTION
SimaPro bakes a flow's unit into its name: "Gas, natural/m3" and "Gas, natural/kg" are the same substance declared in two units, with two densities (34.5 vs 43.1 MJ). Name normalization deliberately strips those suffixes so a lone unit variant can borrow its base resource's factor — but when the method itself ships one factor line per unit, both lines collapse onto one name key, a single winner is crowned, and the flow declared in the losing unit reads a dimensionally incompatible factor whose unit conversion silently zeroes its score.

On a real SimaPro database this made natural gas contribute nothing to fossil resource use: a gas-heated product's inventory carried 0.58 m³ of "Gas, natural/m3" with a matching 34.5 MJ/m³ line in the method, and scored 0 for it — the category undercounted by a factor of four, invisibly, on every gas-consuming product.

The fix is a small table (`mtUnitVariantCF`) keying the factor lines whose name carries a unit suffix by their full, suffix-preserving name (`normalizeNameKeepUnit` — the same normalization pipeline minus the suffix strip). The read cascade consults it before the collapsed-name tables, gated like the other sub-blind rungs; same-name lines that disagree are dropped (`agreedValue`) rather than guessed. Flows with no suffixed line keep the borrow-the-base behavior the strip exists for, and bare names keep their collapsed-key winner.

Verified red-green (the spec's first case reproduces the wrong-winner pick on the unfixed build), full suite 1864 examples 0 failures, and on a real database the change is surgical: only fossil resource use moves, every other category is bit-identical.