### PR TITLE
Warn when a matched factor cannot be converted into its flow's unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+- A warning now reports factor lines that match a flow but cannot be
+  converted into its unit — a per-kilogram factor against a flow measured in
+  cubic metres, for instance. Refusing such a factor is correct (the
+  dimensions do not agree), but the refusal used to be invisible: the flow
+  simply scored zero, indistinguishable from a flow the method does not
+  cover. Each affected method now says at load time how many factors it
+  refused and names samples, so a silent undercount of this kind can no
+  longer hide.
+
 ### Changed
 - The engine now advertises wire revision 4 on `/api/v1/version`. The three
   quality-report routes added since 0.9.3 arrived without a revision bump, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@
   cubic metres, for instance. Refusing such a factor is correct (the
   dimensions do not agree), but the refusal used to be invisible: the flow
   simply scored zero, indistinguishable from a flow the method does not
-  cover. Each affected method now says at load time how many factors it
-  refused and names samples, so a silent undercount of this kind can no
-  longer hide.
+  cover. Each affected method now says at load time how many flows are
+  affected and names samples — for its global factors and its regionalized
+  ones alike — so a silent undercount of this kind can no longer hide.
 
 ### Changed
 - The engine now advertises wire revision 4 on `/api/v1/version`. The three

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -176,7 +176,7 @@ import Method.Mapping (
     mtRegionalActivityWeights,
     mtRegionalizedCF,
     projectRegionalResourceFlows,
-    zeroedBroadcastCFs,
+    zeroedMatchedCFs,
  )
 import Method.Types (
     CompartmentMap,
@@ -715,21 +715,22 @@ buildMethodTablesFor manager dbName collection db hier method = do
                         <> "(after walking parent regions and universal broadcast). "
                         <> "Samples: "
                         <> show (take 3 [(show fid, T.unpack loc) | (fid, Location loc) <- rawMissingPairs raw'])
-    -- A CF that matched but cannot be unit-converted scores an (intentional)
-    -- 0 — refusing wrong-dimension data is right, hiding the refusal is not:
-    -- unreported, it reads exactly like an uncharacterized flow and the method
-    -- silently undercounts. One deduplicated WARN per (db, method), same
-    -- channel as the regionalized coverage gaps above.
-    let zeroed = zeroedBroadcastCFs mFlows withBroadcast
-        flowUnitOf f = maybe "" (T.unpack . unitName) (M.lookup (bfUnitId f) mUnits)
+    -- A CF that matched (broadcast or regionalized) but cannot be
+    -- unit-converted scores an (intentional) 0 — refusing wrong-dimension data
+    -- is right, hiding the refusal is not: unreported, it reads exactly like an
+    -- uncharacterized flow and the method silently undercounts. One
+    -- deduplicated WARN per (db, method), same channel as the regionalized
+    -- coverage gaps above.
+    let zeroed = zeroedMatchedCFs unitConfig mUnits mFlows withBroadcast
+        flowUnitOf f = maybe "<unknown unit>" (T.unpack . unitName) (M.lookup (bfUnitId f) mUnits)
     unless (null zeroed) $
         reportProgress Warning $
             "[LCIA "
                 <> T.unpack (methodName method)
                 <> "] "
                 <> show (length zeroed)
-                <> " matched CF(s) cannot be unit-converted from their flow's unit "
-                <> "(dimensional mismatch); their contributions score 0. Samples: "
+                <> " flow(s) matched a CF that cannot be converted from the flow's unit "
+                <> "(no unit-conversion path); their contributions score 0. Samples: "
                 <> show (take 3 [(T.unpack (bfName f), flowUnitOf f, T.unpack u) | (f, CF _ (CFUnit u)) <- zeroed])
     pure tables
 

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -155,6 +155,8 @@ import Matrix (clearCachedSolver)
 import Method.ChemSynonyms (ChemSynonyms, emptyChemSynonyms, loadChemSynonyms)
 import qualified Method.Coverage as Coverage
 import Method.Mapping (
+    CF (..),
+    CFUnit (..),
     MatchStrategy,
     MethodIndex,
     MethodSetTables,
@@ -174,6 +176,7 @@ import Method.Mapping (
     mtRegionalActivityWeights,
     mtRegionalizedCF,
     projectRegionalResourceFlows,
+    zeroedBroadcastCFs,
  )
 import Method.Types (
     CompartmentMap,
@@ -712,6 +715,22 @@ buildMethodTablesFor manager dbName collection db hier method = do
                         <> "(after walking parent regions and universal broadcast). "
                         <> "Samples: "
                         <> show (take 3 [(show fid, T.unpack loc) | (fid, Location loc) <- rawMissingPairs raw'])
+    -- A CF that matched but cannot be unit-converted scores an (intentional)
+    -- 0 — refusing wrong-dimension data is right, hiding the refusal is not:
+    -- unreported, it reads exactly like an uncharacterized flow and the method
+    -- silently undercounts. One deduplicated WARN per (db, method), same
+    -- channel as the regionalized coverage gaps above.
+    let zeroed = zeroedBroadcastCFs mFlows withBroadcast
+        flowUnitOf f = maybe "" (T.unpack . unitName) (M.lookup (bfUnitId f) mUnits)
+    unless (null zeroed) $
+        reportProgress Warning $
+            "[LCIA "
+                <> T.unpack (methodName method)
+                <> "] "
+                <> show (length zeroed)
+                <> " matched CF(s) cannot be unit-converted from their flow's unit "
+                <> "(dimensional mismatch); their contributions score 0. Samples: "
+                <> show (take 3 [(T.unpack (bfName f), flowUnitOf f, T.unpack u) | (f, CF _ (CFUnit u)) <- zeroed])
     pure tables
 
 {- | Run @build@ at most once per @key@ across concurrent callers. The first

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -37,7 +37,7 @@ module Method.Mapping (
     buildMethodTables,
     buildMethodIndex,
     fillBroadcastVector,
-    zeroedBroadcastCFs,
+    zeroedMatchedCFs,
     fillRegionalActivityWeights,
     RegionalActivityWeights (..),
     computeLCIAScore,
@@ -1422,26 +1422,47 @@ fillBroadcastVector unitConfig unitDB flowDB tables =
         Nothing -> Nothing
         Just cf -> Just (convertAndMultiply unitConfig unitDB (mtEnergyDensities tables) (Just flow) cf 1.0)
 
-{- | Broadcast entries whose matched CF is nonzero yet whose effective factor
-collapsed to @0@: the flow-to-CF unit conversion was refused (dimensional
+{- | Matched CFs whose effective factor collapses to @0@ although the factor
+itself is nonzero: the flow-to-CF unit conversion was refused (dimensional
 mismatch, missing canonical base, or a failed energy bridge — the @0@ arms of
 'convertForCharacterization' and 'energyAwareConversion'). The refusal itself
 is right — wrong-dimension data must not score — but left unreported it is
 indistinguishable from an uncharacterized flow, and the method silently
 undercounts. Callers surface these once per (db, method) at build time.
 
-Re-runs the cascade only for the zero-valued entries, so scanning is free
-unless something is actually wrong.
+Covers both read paths: the broadcast vector (re-running the cascade only for
+its zero-valued entries, so a healthy method pays nothing) and the
+regionalized CF table (one representative CF per flow — whether a conversion
+is refused depends on the units, not on the per-location value). The
+name-blind regional CAS bridge is not scanned: it has no fixed flow to
+convert against until scoring. One entry per flow.
 -}
-zeroedBroadcastCFs :: BioFlowDB -> MethodTables -> [(BiosphereFlow, CF)]
-zeroedBroadcastCFs flowDB tables =
-    [ (flow, cf)
-    | (fid, eff) <- M.toList (mtBroadcast tables)
-    , eff == 0
-    , Just flow <- [M.lookup fid flowDB]
-    , Just cf <- [lookupCascadeCF tables flowDB fid]
-    , cfValue cf /= 0
-    ]
+zeroedMatchedCFs :: UnitConfig -> UnitDB -> BioFlowDB -> MethodTables -> [(BiosphereFlow, CF)]
+zeroedMatchedCFs unitConfig unitDB flowDB tables =
+    M.elems (M.union broadcastZeroed regionalZeroed)
+  where
+    broadcastZeroed =
+        M.fromList
+            [ (fid, (flow, cf))
+            | (fid, eff) <- M.toList (mtBroadcast tables)
+            , eff == 0
+            , Just flow <- [M.lookup fid flowDB]
+            , Just cf <- [lookupCascadeCF tables flowDB fid]
+            , cfValue cf /= 0
+            ]
+    regionalZeroed =
+        M.fromList
+            [ (fid, (flow, cf))
+            | (fid, cf) <- M.toList regionalRep
+            , Just flow <- [M.lookup fid flowDB]
+            , convertAndMultiply unitConfig unitDB (mtEnergyDensities tables) (Just flow) cf 1.0 == 0
+            ]
+    regionalRep =
+        M.fromList
+            [ (fid, cf)
+            | ((fid, _), cf) <- M.toList (mtRegionalizedCF tables)
+            , cfValue cf /= 0
+            ]
 
 {- | Precompute per-activity-column contributions for a regionalized method.
 

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -37,6 +37,7 @@ module Method.Mapping (
     buildMethodTables,
     buildMethodIndex,
     fillBroadcastVector,
+    zeroedBroadcastCFs,
     fillRegionalActivityWeights,
     RegionalActivityWeights (..),
     computeLCIAScore,
@@ -1420,6 +1421,27 @@ fillBroadcastVector unitConfig unitDB flowDB tables =
     buildEntry fid flow = case lookupCascadeCF tables flowDB fid of
         Nothing -> Nothing
         Just cf -> Just (convertAndMultiply unitConfig unitDB (mtEnergyDensities tables) (Just flow) cf 1.0)
+
+{- | Broadcast entries whose matched CF is nonzero yet whose effective factor
+collapsed to @0@: the flow-to-CF unit conversion was refused (dimensional
+mismatch, missing canonical base, or a failed energy bridge — the @0@ arms of
+'convertForCharacterization' and 'energyAwareConversion'). The refusal itself
+is right — wrong-dimension data must not score — but left unreported it is
+indistinguishable from an uncharacterized flow, and the method silently
+undercounts. Callers surface these once per (db, method) at build time.
+
+Re-runs the cascade only for the zero-valued entries, so scanning is free
+unless something is actually wrong.
+-}
+zeroedBroadcastCFs :: BioFlowDB -> MethodTables -> [(BiosphereFlow, CF)]
+zeroedBroadcastCFs flowDB tables =
+    [ (flow, cf)
+    | (fid, eff) <- M.toList (mtBroadcast tables)
+    , eff == 0
+    , Just flow <- [M.lookup fid flowDB]
+    , Just cf <- [lookupCascadeCF tables flowDB fid]
+    , cfValue cf /= 0
+    ]
 
 {- | Precompute per-activity-column contributions for a regionalized method.
 

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -14,7 +14,7 @@ import Test.Hspec
 import Method.ChemSynonyms (emptyChemSynonyms, parseChemSynonymsCSV)
 import Method.Mapping
 import Method.ParserCSV (parseMethodCSVBytes)
-import Method.Types (Compartment (..), FlowDirection (..), Method (..), MethodCF (..), buildCompartmentMapFromCSV)
+import Method.Types (Compartment (..), EnergyDensity (..), FlowDirection (..), Method (..), MethodCF (..), buildCompartmentMapFromCSV)
 import SynonymDB (BridgeDirection (..), SynEdge (..), buildFromEdges, buildFromPairs, emptySynonymDB, normalizeName)
 import Types (BiosphereFlow (..), Unit (..))
 import qualified Types as VT
@@ -688,7 +688,7 @@ spec = do
             -- The fallback path must NOT crash on the unknown UUID.
             fast `shouldBe` (3.0 :: Double)
 
-    describe "zeroedBroadcastCFs (matched CF the flow's unit cannot reach)" $ do
+    describe "zeroedMatchedCFs (matched CF the flow's unit cannot reach)" $ do
         -- kg is a mass and m3 a volume: no conversion path between them, so a
         -- kg-denominated CF matched by an m3 flow is refused and scores 0 —
         -- exactly the silent undercount this scan exists to surface.
@@ -699,10 +699,11 @@ spec = do
                         M.fromList
                             [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
                             , ("m3", UnitDef [0, 1, 0, 0, 0, 0, 0, 0] 1.0)
+                            , ("mj", UnitDef [0, 0, 1, 0, 0, 0, 0, 0] 1.0)
                             ]
-                    , ucOriginalKeys = M.fromList [("kg", "kg"), ("m3", "m3")]
+                    , ucOriginalKeys = M.fromList [("kg", "kg"), ("m3", "m3"), ("mj", "MJ")]
                     }
-            fillFor unitName' cf = do
+            fillWith densities unitName' cf = do
                 fid <- nextRandom
                 uid <- nextRandom
                 let flow = (mkFlow fid "gas" "air" Nothing){bfUnitId = uid}
@@ -710,22 +711,41 @@ spec = do
                     unitDB = M.singleton uid ((unitNamed unitName'){unitId = uid})
                     filled =
                         fillBroadcastVector cfg unitDB flowDB $
-                            buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flow, ByUUID))]
-                pure (fid, flowDB, filled)
+                            buildMethodTables OtherCFFamily M.empty densities [(cf, Just (flow, ByUUID))]
+                pure (fid, map (bfId . fst) (zeroedMatchedCFs cfg unitDB flowDB filled))
+            fillFor = fillWith M.empty
 
         it "flags a kg-denominated CF matched by an m3 flow" $ do
-            (fid, flowDB, filled) <- fillFor "m3" (mkCF "gas" Nothing 43.1)
-            map (bfId . fst) (zeroedBroadcastCFs flowDB filled) `shouldBe` [fid]
+            (fid, zeroed) <- fillFor "m3" (mkCF "gas" Nothing 43.1)
+            zeroed `shouldBe` [fid]
 
         it "stays quiet when the conversion exists" $ do
-            (_, flowDB, filled) <- fillFor "kg" (mkCF "gas" Nothing 43.1)
-            map (bfId . fst) (zeroedBroadcastCFs flowDB filled) `shouldBe` []
+            (_, zeroed) <- fillFor "kg" (mkCF "gas" Nothing 43.1)
+            zeroed `shouldBe` []
 
         it "stays quiet for a CF the method genuinely declares as 0" $ do
             -- Same dimensional mismatch, but the factor itself is 0: the zero
             -- contribution is the method's own value, not a refusal.
-            (_, flowDB, filled) <- fillFor "m3" (mkCF "gas" Nothing 0.0)
-            map (bfId . fst) (zeroedBroadcastCFs flowDB filled) `shouldBe` []
+            (_, zeroed) <- fillFor "m3" (mkCF "gas" Nothing 0.0)
+            zeroed `shouldBe` []
+
+        it "flags a refused CF that is only regionalized (no broadcast entry)" $ do
+            -- A located CF never reaches the broadcast tables, so a
+            -- broadcast-only scan would stay silent about its refusal.
+            (fid, zeroed) <-
+                fillFor "m3" ((mkCF "gas" Nothing 43.1){mcfConsumerLocation = Just "FR"})
+            zeroed `shouldBe` [fid]
+
+        it "flags a failed energy-density bridge" $ do
+            -- CF per MJ, density native to kg, flow in m3: the bridge fires
+            -- (MJ matches the density unit) but m3 cannot reach kg, so the
+            -- conversion is refused.
+            (fid, zeroed) <-
+                fillWith
+                    (M.singleton "gas" (EnergyDensity 43.1 "MJ" "kg"))
+                    "m3"
+                    ((mkCF "gas" Nothing 50.0){mcfUnit = "MJ"})
+            zeroed `shouldBe` [fid]
 
     describe "findSimilarCFs (post-scoring suggester)" $ do
         let mkMethod cfs =

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -688,6 +688,45 @@ spec = do
             -- The fallback path must NOT crash on the unknown UUID.
             fast `shouldBe` (3.0 :: Double)
 
+    describe "zeroedBroadcastCFs (matched CF the flow's unit cannot reach)" $ do
+        -- kg is a mass and m3 a volume: no conversion path between them, so a
+        -- kg-denominated CF matched by an m3 flow is refused and scores 0 —
+        -- exactly the silent undercount this scan exists to surface.
+        let cfg =
+                UnitConfig
+                    { ucDimensionOrder = []
+                    , ucUnits =
+                        M.fromList
+                            [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
+                            , ("m3", UnitDef [0, 1, 0, 0, 0, 0, 0, 0] 1.0)
+                            ]
+                    , ucOriginalKeys = M.fromList [("kg", "kg"), ("m3", "m3")]
+                    }
+            fillFor unitName' cf = do
+                fid <- nextRandom
+                uid <- nextRandom
+                let flow = (mkFlow fid "gas" "air" Nothing){bfUnitId = uid}
+                    flowDB = M.singleton fid flow
+                    unitDB = M.singleton uid ((unitNamed unitName'){unitId = uid})
+                    filled =
+                        fillBroadcastVector cfg unitDB flowDB $
+                            buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flow, ByUUID))]
+                pure (fid, flowDB, filled)
+
+        it "flags a kg-denominated CF matched by an m3 flow" $ do
+            (fid, flowDB, filled) <- fillFor "m3" (mkCF "gas" Nothing 43.1)
+            map (bfId . fst) (zeroedBroadcastCFs flowDB filled) `shouldBe` [fid]
+
+        it "stays quiet when the conversion exists" $ do
+            (_, flowDB, filled) <- fillFor "kg" (mkCF "gas" Nothing 43.1)
+            map (bfId . fst) (zeroedBroadcastCFs flowDB filled) `shouldBe` []
+
+        it "stays quiet for a CF the method genuinely declares as 0" $ do
+            -- Same dimensional mismatch, but the factor itself is 0: the zero
+            -- contribution is the method's own value, not a refusal.
+            (_, flowDB, filled) <- fillFor "m3" (mkCF "gas" Nothing 0.0)
+            map (bfId . fst) (zeroedBroadcastCFs flowDB filled) `shouldBe` []
+
     describe "findSimilarCFs (post-scoring suggester)" $ do
         let mkMethod cfs =
                 Method


### PR DESCRIPTION
Refusing to score wrong-dimension data is correct, but the refusal was invisible: a factor line that matched a flow yet could not be converted into the flow's unit contributed an effective 0, indistinguishable from a flow the method simply does not cover. That silence is how the per-unit SimaPro homonyms (#257) undercounted natural gas by a factor of four before an external comparison exposed it.

Each method now scans its broadcast vector once at build time: an entry whose matched factor is nonzero but whose effective (unit-converted) factor collapsed to 0 can only be a refused conversion — a dimensional mismatch, a missing canonical base, or a failed energy-density bridge. The method reports how many factors it refused and samples of (flow name, flow unit, factor unit), through the same warning channel as the regionalized coverage gaps.

The scan re-runs the CF cascade only for the zero-valued entries, so it costs nothing on a healthy method. Scores are unchanged — a refused factor still scores 0; it just can no longer do so silently. Any future name-collapse bug of the #257 kind now announces itself at load time instead of hiding in the totals.