### PR TITLE
Take the EcoSpold 1 activity identifier from the dataset file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## [Unreleased]
 
 ### Changed
+- An EcoSpold 1 dataset published as `process_<uuid>.xml` (or `<uuid>.xml`)
+  now keeps that identifier as its activity UUID instead of getting one
+  minted from its name and location. Two releases of such a database can be
+  compared dataset by dataset: a renamed dataset no longer reads as one
+  deletion plus one creation. The process ids of these databases change once
+  when the new engine first loads them, and their caches rebuild
+  automatically. Files named any other way, and files holding several
+  datasets, keep the minted UUID.
 - The engine now advertises wire revision 4 on `/api/v1/version`. The three
   quality-report routes added since 0.9.3 arrived without a revision bump, so
   a client had no way to know whether an engine offered them: an engine too

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -908,7 +908,11 @@ loadEcoSpoldDirectory locationAliases dir = do
                 _ -> Left $ T.pack $ "Invalid filename format (expected activityUUID_productUUID.spold): " ++ filepath
 
 {- | Load a single EcoSpold1 file containing multiple datasets
-This handles files where <ecoSpold> contains multiple <dataset> elements
+This handles files where <ecoSpold> contains multiple <dataset> elements.
+
+A file holding exactly one dataset is keyed like the per-file directory
+path: the identifier its file name carries wins over the minted UUID.
+Several datasets share one file name, so none of them can claim it.
 -}
 loadSingleEcoSpold1File :: M.Map T.Text T.Text -> FilePath -> IO (Either T.Text SimpleDatabase)
 loadSingleEcoSpold1File locationAliases filepath = do
@@ -917,7 +921,10 @@ loadSingleEcoSpold1File locationAliases filepath = do
     reportProgress Info $ "Parsed " ++ show (length results) ++ " datasets from file"
 
     -- Build activity map from all parsed activities
-    let expanded = map buildProcEntryFromResult results
+    let fileUUID = case results of
+            [_] -> datasetUUIDFromPath filepath
+            _ -> Nothing
+        expanded = map (buildProcEntryFromResult fileUUID) results
         !procMap = M.fromList expanded
         !techFlowMap = M.fromListWith mergeTechFlows [(tfId f, f) | (_, techs, _, _, _, _, _) <- results, f <- techs]
         !bioFlowMap = M.fromListWith mergeBioFlows [(bfId f, f) | (_, _, bios, _, _, _, _) <- results, f <- bios]
@@ -939,9 +946,9 @@ loadSingleEcoSpold1File locationAliases filepath = do
 
     Right <$> fixEcoSpold1ActivityLinks locationAliases dsIndex supplierLinks simpleDb
   where
-    buildProcEntryFromResult :: (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit], Int, M.Map UUID.UUID Int) -> ((UUID.UUID, UUID.UUID), Activity)
-    buildProcEntryFromResult (activity, _, _, _, _, _, _) =
-        let actUUID = generateActivityUUIDFromActivity activity
+    buildProcEntryFromResult :: Maybe UUID.UUID -> (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit], Int, M.Map UUID.UUID Int) -> ((UUID.UUID, UUID.UUID), Activity)
+    buildProcEntryFromResult fileUUID (activity, _, _, _, _, _, _) =
+        let actUUID = fromMaybe (generateActivityUUIDFromActivity activity) fileUUID
             prodUUID = getReferenceProductUUID activity
          in ((actUUID, prodUUID), activity)
 

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -76,6 +76,7 @@ module Database.Loader (
     mergeTechFlows,
     mergeBioFlows,
     generateActivityUUIDFromActivity,
+    datasetUUIDFromPath,
     getReferenceProductUUID,
     UnlinkedSummary (..),
     buildSupplierIndex,
@@ -211,6 +212,10 @@ History of manual bumps:
      fingerprint alone would accept old caches. Caches built before the
      backfill keep every SimaPro biosphere flow CAS-less, and the method
      CAS bridge silently never fires on them.
+- 12: EcoSpold1 activity UUID now taken from the dataset file's own name
+     when that name carries one, instead of always being minted from
+     name and location. Old caches key the same dataset under the minted
+     UUID, so a mixed pair would compare as two disjoint databases.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.
@@ -218,7 +223,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeRep (Proxy :: Proxy Database))
-     in hi `xor` lo `xor` 11
+     in hi `xor` lo `xor` 12
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.
@@ -239,6 +244,20 @@ generateActivityUUIDFromActivity :: Activity -> UUID.UUID
 generateActivityUUIDFromActivity act =
     let key = activityName act <> ":" <> activityLocation act
      in UUID5.generateNamed ecospold1Namespace (BS.unpack $ T.encodeUtf8 key)
+
+{- | The identifier an EcoSpold1 dataset publishes in its own file name,
+@process_<uuid>.xml@ or plain @<uuid>.xml@.
+
+Publishers that keep this identifier stable across releases (it survives a
+rename, which a name-derived UUID does not) let two versions of a database be
+compared dataset by dataset. Files named any other way — ecoinvent's EcoSpold1
+exports are numbered, not identified — yield 'Nothing' and keep the minted
+UUID.
+-}
+datasetUUIDFromPath :: FilePath -> Maybe UUID.UUID
+datasetUUIDFromPath path =
+    let base = T.pack (takeBaseName path)
+     in UUID.fromText (fromMaybe base (T.stripPrefix "process_" base))
 
 -- | Get reference product UUID from activity exchanges
 getReferenceProductUUID :: Activity -> UUID.UUID
@@ -871,9 +890,11 @@ loadEcoSpoldDirectory locationAliases dir = do
 
     -- Build a single process entry, returning Either for error handling
     buildProcEntry :: Bool -> FilePath -> Activity -> Either T.Text ((UUID, UUID), Activity)
-    buildProcEntry True _filepath activity =
-        -- EcoSpold1: Generate activity UUID from name and location
-        let actUUID = generateActivityUUIDFromActivity activity
+    buildProcEntry True filepath activity =
+        -- EcoSpold1: prefer the identifier the file itself carries, so a
+        -- dataset keeps its identity across releases; mint from name and
+        -- location only when the file name carries none.
+        let actUUID = fromMaybe (generateActivityUUIDFromActivity activity) (datasetUUIDFromPath filepath)
             prodUUID = getReferenceProductUUID activity
          in Right ((actUUID, prodUUID), activity)
     buildProcEntry False filepath activity =

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -176,6 +176,24 @@ spec = do
                 `shouldNotBe` generateActivityUUIDFromActivity b
 
     -- -----------------------------------------------------------------------
+    -- datasetUUIDFromPath
+    -- -----------------------------------------------------------------------
+    describe "datasetUUIDFromPath" $ do
+        it "reads the identifier out of a process_<uuid>.xml file name" $
+            datasetUUIDFromPath "/db/process_0004e814-c18d-42e2-a3f7-ce1fa51a3c2c.xml"
+                `shouldBe` UUID.fromText "0004e814-c18d-42e2-a3f7-ce1fa51a3c2c"
+
+        it "reads a bare <uuid>.xml file name too" $
+            datasetUUIDFromPath "0004e814-c18d-42e2-a3f7-ce1fa51a3c2c.xml"
+                `shouldBe` UUID.fromText "0004e814-c18d-42e2-a3f7-ce1fa51a3c2c"
+
+        it "declines a numbered file name, so the minted UUID stands" $
+            datasetUUIDFromPath "/db/1234.xml" `shouldBe` Nothing
+
+        it "declines a name that only looks like an identifier" $
+            datasetUUIDFromPath "process_not-a-uuid.xml" `shouldBe` Nothing
+
+    -- -----------------------------------------------------------------------
     -- getReferenceProductUUID
     -- -----------------------------------------------------------------------
     describe "getReferenceProductUUID" $ do

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -88,6 +88,31 @@ actUUID2, missingActUUID :: UUID.UUID
 actUUID2 = read "cccccccc-0000-0000-0000-000000000002"
 missingActUUID = read "dddddddd-0000-0000-0000-000000000099"
 
+{- | A minimal EcoSpold1 document, one @<dataset>@ per (name, location) pair.
+Each dataset declares "<name> production" as its activity and @name@ as its
+reference product, mirroring @test-data/SAMPLE.ecospold1@.
+-}
+es1Xml :: [(String, String)] -> String
+es1Xml datasets =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        <> "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold01\">\n"
+        <> concat (zipWith dataset [1 :: Int ..] datasets)
+        <> "</ecoSpold>\n"
+  where
+    dataset n (name, loc) =
+        "  <dataset number=\""
+            <> show n
+            <> "\" generator=\"Test\" timestamp=\"2025-01-01T00:00:00\">\n"
+            <> "    <metaInformation><processInformation>\n"
+            <> ("      <referenceFunction name=\"" <> name <> " production\" category=\"Energy\" subCategory=\"Electricity\" unit=\"kWh\" />\n")
+            <> ("      <geography location=\"" <> loc <> "\" />\n")
+            <> "      <timePeriod startYear=\"2020\" endYear=\"2024\" />\n"
+            <> "    </processInformation></metaInformation>\n"
+            <> "    <flowData>\n"
+            <> ("      <exchange number=\"1\" name=\"" <> name <> "\" category=\"Energy\" subCategory=\"Electricity\" unit=\"kWh\" meanValue=\"1.0\"><outputGroup>0</outputGroup></exchange>\n")
+            <> "    </flowData>\n"
+            <> "  </dataset>\n"
+
 -- | An input linked (non-nil) to producer activity @actId@ producing @prodId@.
 linkedInput :: UUID.UUID -> UUID.UUID -> Exchange
 linkedInput actId prodId = (inputExchange prodId "GLO"){techActivityLinkId = actId}
@@ -192,6 +217,35 @@ spec = do
 
         it "declines a name that only looks like an identifier" $
             datasetUUIDFromPath "process_not-a-uuid.xml" `shouldBe` Nothing
+
+    -- -----------------------------------------------------------------------
+    -- EcoSpold1 file-name identity, end to end through loadDatabase
+    -- -----------------------------------------------------------------------
+    describe "EcoSpold1 file-name identity" $ do
+        let fileUUID = read "0004e814-c18d-42e2-a3f7-ce1fa51a3c2c" :: UUID.UUID
+            loadedActUUIDs dir = do
+                result <- loadDatabase defaultUnitConfig dir
+                either (fail . show) (return . map fst . M.keys . sdbActivities) result
+
+        it "keys each per-dataset file on its own identifier, minting only where the name carries none" $
+            withSystemTempDirectory "es1-ident" $ \dir -> do
+                writeFile (dir </> "process_0004e814-c18d-42e2-a3f7-ce1fa51a3c2c.xml") (es1Xml [("wind", "DE")])
+                writeFile (dir </> "dataset2.xml") (es1Xml [("solar", "FR")])
+                actUUIDs <- loadedActUUIDs dir
+                actUUIDs `shouldMatchList` [fileUUID, generateActivityUUIDFromActivity (minimalActivity "solar production" "FR" [])]
+
+        it "keys a lone single-dataset file on its identifier too" $
+            withSystemTempDirectory "es1-ident" $ \dir -> do
+                writeFile (dir </> "process_0004e814-c18d-42e2-a3f7-ce1fa51a3c2c.xml") (es1Xml [("wind", "DE")])
+                actUUIDs <- loadedActUUIDs dir
+                actUUIDs `shouldBe` [fileUUID]
+
+        it "never hands one file's identifier to several datasets inside it" $
+            withSystemTempDirectory "es1-ident" $ \dir -> do
+                writeFile (dir </> "process_0004e814-c18d-42e2-a3f7-ce1fa51a3c2c.xml") (es1Xml [("wind", "DE"), ("solar", "FR")])
+                actUUIDs <- loadedActUUIDs dir
+                length actUUIDs `shouldBe` 2
+                actUUIDs `shouldSatisfy` notElem fileUUID
 
     -- -----------------------------------------------------------------------
     -- getReferenceProductUUID


### PR DESCRIPTION
## Why

An EcoSpold 1 dataset published as `process_<uuid>.xml` carries an identifier its
publisher controls and keeps stable from one release to the next. The loader
threw it away and minted the activity UUID from name and location instead.

The cost is that two releases of the same database compare as two disjoint sets:
rename a dataset and it reads as one deletion plus one creation. Measured on a
real pair of published national releases, **0 of 11747 activities matched by
identifier before this change, 11747 of 11747 after**.

## What it does

`datasetUUIDFromPath` reads the identifier out of `process_<uuid>.xml` or a bare
`<uuid>.xml`, and returns `Nothing` for anything else. The per-file EcoSpold 1
branch prefers it and falls back to the mint — exports that number their files
rather than identify them carry no identifier to read, and a multi-dataset single
file has no per-dataset name at all. The format has no structured field for it
either: where the identifier appears inside the XML at all, it is buried in free
text, so the file name is the only place worth looking.

## Two consequences worth naming

Datasets sharing a name and location used to collapse onto one key and silently
overwrite each other in the process table. They no longer can.

The product half of the process id still derives from the reference exchange, so
a publisher who renames a reference product still moves the pair. The activity
half is what now holds — which is the half that identifies the dataset.

The cache signature is bumped: existing caches key the same dataset under the
minted UUID.