### PR TITLE
Report exchange amounts too small to have been measured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
   cover. Each affected method now says at load time how many flows are
   affected and names samples — for its global factors and its regionalized
   ones alike — so a silent undercount of this kind can no longer hide.
+- The database quality report now flags exchange amounts too small to have
+  been measured. Below 1e-27 — whatever the unit — a value is smaller than
+  anything an instrument can produce (a hydrogen atom weighs 1.7e-27 kg), so
+  it is a residue of computation wearing the costume of data. An ordinary
+  exchange this small is a warning; a reference exchange this small is a
+  danger, because normalization divides every other amount in the process
+  by it.
 
 ### Changed
 - An EcoSpold 1 dataset published as `process_<uuid>.xml` (or `<uuid>.xml`)

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -350,6 +350,7 @@ qualityReportToAPI mLimit r =
         , qraOxygenDemandOrder = checkToAPI mLimit (Quality.qrOxygenDemandOrder r)
         , qraInvalidCas = checkToAPI mLimit (Quality.qrInvalidCas r)
         , qraAllocationOutOfRange = checkToAPI mLimit (Quality.qrAllocationOutOfRange r)
+        , qraUnmeasurableAmounts = checkToAPI mLimit (Quality.qrUnmeasurableAmounts r)
         }
 
 {- | Same projection for the computed report — one wire cap, one offender

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -855,6 +855,7 @@ data QualityReportAPI = QualityReportAPI
     , qraOxygenDemandOrder :: QualityCheckAPI
     , qraInvalidCas :: QualityCheckAPI
     , qraAllocationOutOfRange :: QualityCheckAPI
+    , qraUnmeasurableAmounts :: QualityCheckAPI
     }
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped QualityReportAPI)

--- a/src/Database/Quality.hs
+++ b/src/Database/Quality.hs
@@ -13,8 +13,8 @@ their database otherwise carries, reference products nothing in the
 database consumes, land transformation whose "to" and "from" areas
 don't balance within an activity, oxygen-demand or organic-carbon
 measures reported in a physically impossible order, CAS numbers
-whose check digit doesn't confirm them, and allocation percentages
-outside the 0-100% range.
+whose check digit doesn't confirm them, allocation percentages
+outside the 0-100% range, and amounts too small to have been measured.
 
 Every check is a pure scan over a 'SimpleDatabase', so the report is
 identical on a staged database (parsed, matrices not built) and on a loaded
@@ -110,6 +110,7 @@ data QualityReport = QualityReport
     , qrOxygenDemandOrder :: !QualityCheck
     , qrInvalidCas :: !QualityCheck
     , qrAllocationOutOfRange :: !QualityCheck
+    , qrUnmeasurableAmounts :: !QualityCheck
     }
     deriving (Show, Eq)
 
@@ -132,6 +133,7 @@ qualityChecks r =
     , qrOxygenDemandOrder r
     , qrInvalidCas r
     , qrAllocationOutOfRange r
+    , qrUnmeasurableAmounts r
     ]
 
 {- | Allowed drift when summing coproduct allocation percentages. Sources round
@@ -199,6 +201,19 @@ far below what a dropped or mistyped flow costs.
 physicalBalanceTolerance :: Double
 physicalBalanceTolerance = 0.01
 
+{- | Magnitude below which an exchange amount cannot be a measurement.
+
+A hydrogen atom weighs 1.7e-27 kg, so a mass under 1e-27 is less than one atom;
+the same figure in joules sits eight orders below a single visible photon, and a
+count of items is quantised at one. Whatever the unit, nothing is measured this
+small — an amount under the floor is a residue of computation (an underflow, a
+conversion through a zero, an allocation of nothing) wearing the costume of
+data. Set far below the smallest real trace amounts in any inventory, so the
+check accuses only what no instrument could have produced.
+-}
+measurableMagnitudeFloor :: Double
+measurableMagnitudeFloor = 1e-27
+
 -- | Run every check over a database.
 qualityReport :: Text -> SimpleDatabase -> QualityReport
 qualityReport dbName db =
@@ -218,6 +233,7 @@ qualityReport dbName db =
         , qrOxygenDemandOrder = QualityCheck oxygenApplicable (worstFirst oxygenOffenders)
         , qrInvalidCas = QualityCheck casApplicable (worstFirst casOffenders)
         , qrAllocationOutOfRange = QualityCheck allocationApplicable (worstFirst allocationRangeOffenders)
+        , qrUnmeasurableAmounts = QualityCheck True (worstFirst unmeasurableOffenders)
         }
   where
     entries = M.toList (sdbActivities db)
@@ -347,6 +363,27 @@ qualityReport dbName db =
                         then Just ("reference exchange \"" <> flowName <> "\" has amount 0, which normalization would divide by")
                         else Nothing
             ]
+        ]
+
+    -- Amounts too small to have been measured (see 'measurableMagnitudeFloor').
+    -- Not a rounding complaint: at this magnitude the value is a computational
+    -- residue that reads as data, and it survives every copy of the dataset
+    -- until someone looks. Warning rather than danger — it distorts nothing in
+    -- a score, it just isn't true.
+    unmeasurableOffenders =
+        [ offender WarningSev key act Nothing $
+            "exchange \""
+                <> anyFlowName (exchangeFlowId ex)
+                <> "\" carries "
+                <> formatAmount amount
+                <> " "
+                <> unitLabel (exchangeUnitId ex)
+                <> ", smaller than anything a measurement can yield"
+        | (key, act) <- entries
+        , ex <- exchanges act
+        , let amount = abs (exchangeAmount ex)
+        , amount > 0
+        , amount < measurableMagnitudeFloor
         ]
 
     -- The parse-time mathematicalRelation check (EcoSpold2): formulas that

--- a/src/Database/Quality.hs
+++ b/src/Database/Quality.hs
@@ -368,22 +368,31 @@ qualityReport dbName db =
     -- Amounts too small to have been measured (see 'measurableMagnitudeFloor').
     -- Not a rounding complaint: at this magnitude the value is a computational
     -- residue that reads as data, and it survives every copy of the dataset
-    -- until someone looks. Warning rather than danger — it distorts nothing in
-    -- a score, it just isn't true.
+    -- until someone looks. An ordinary exchange this small distorts nothing in
+    -- a score — it just isn't true — hence Warning. A reference exchange is
+    -- what normalization divides by: dividing by ~1e-37 scales every other
+    -- amount in the process by its reciprocal (a negative one flips their
+    -- signs too), the near-zero cousin of the zero-reference case above,
+    -- hence Danger.
     unmeasurableOffenders =
-        [ offender WarningSev key act Nothing $
-            "exchange \""
+        [ offender sev key act Nothing $
+            role
+                <> " \""
                 <> anyFlowName (exchangeFlowId ex)
                 <> "\" carries "
-                <> formatAmount amount
+                <> formatAmount (exchangeAmount ex)
                 <> " "
                 <> unitLabel (exchangeUnitId ex)
                 <> ", smaller than anything a measurement can yield"
+                <> consequence
         | (key, act) <- entries
         , ex <- exchanges act
         , let amount = abs (exchangeAmount ex)
         , amount > 0
         , amount < measurableMagnitudeFloor
+        , let (sev, role, consequence)
+                | exchangeIsReference ex = (DangerSev, "reference exchange", ", and normalization divides by it")
+                | otherwise = (WarningSev, "exchange", "")
         ]
 
     -- The parse-time mathematicalRelation check (EcoSpold2): formulas that

--- a/test/QualityReportSpec.hs
+++ b/test/QualityReportSpec.hs
@@ -572,6 +572,21 @@ spec = do
         it "is not applicable to a database without allocation data" $
             qcApplicable (qrAllocationOutOfRange (reportOf (mkActivity "bread" [reference breadFlow]))) `shouldBe` False
 
+    describe "unmeasurable amount check" $ do
+        it "flags an amount smaller than a single atom" $ do
+            let check = qrUnmeasurableAmounts (reportOf (mkActivity "bread" [reference breadFlow, input flourFlow 4.11e-37]))
+            details check `shouldBe` ["exchange \"flour\" carries 4.110e-37 kg, smaller than anything a measurement can yield"]
+            severities check `shouldBe` [WarningSev]
+
+        it "flags a negative amount of the same magnitude" $
+            length (qcOffenders (qrUnmeasurableAmounts (reportOf (mkActivity "bread" [reference breadFlow, input flourFlow (-4.11e-37)])))) `shouldBe` 1
+
+        it "passes a small but measurable trace amount" $
+            qcOffenders (qrUnmeasurableAmounts (reportOf (mkActivity "bread" [reference breadFlow, input flourFlow 1e-15]))) `shouldBe` []
+
+        it "passes an amount of exactly zero, which says the input is absent" $
+            qcOffenders (qrUnmeasurableAmounts (reportOf (mkActivity "bread" [reference breadFlow, input flourFlow 0]))) `shouldBe` []
+
     describe "report header" $
         it "counts one process per (activity, product) entry" $ do
             let db = dbOf [((actA, prodA), mkActivity "bread" [reference breadFlow]), ((actB, prodB), mkActivity "cake" [reference flourFlow])]

--- a/test/QualityReportSpec.hs
+++ b/test/QualityReportSpec.hs
@@ -581,8 +581,20 @@ spec = do
         it "flags a negative amount of the same magnitude" $
             length (qcOffenders (qrUnmeasurableAmounts (reportOf (mkActivity "bread" [reference breadFlow, input flourFlow (-4.11e-37)])))) `shouldBe` 1
 
+        it "flags an unmeasurable reference amount as danger, since normalization divides by it" $ do
+            let check = qrUnmeasurableAmounts (reportOf (mkActivity "bread" [techExchange breadFlow 4.11e-37 ReferenceProduct]))
+            details check `shouldBe` ["reference exchange \"bread\" carries 4.110e-37 kg, smaller than anything a measurement can yield, and normalization divides by it"]
+            severities check `shouldBe` [DangerSev]
+
+        it "flags a negative unmeasurable reference amount as danger too" $
+            severities (qrUnmeasurableAmounts (reportOf (mkActivity "bread" [techExchange breadFlow (-4.11e-37) ReferenceProduct])))
+                `shouldBe` [DangerSev]
+
         it "passes a small but measurable trace amount" $
             qcOffenders (qrUnmeasurableAmounts (reportOf (mkActivity "bread" [reference breadFlow, input flourFlow 1e-15]))) `shouldBe` []
+
+        it "passes an amount at exactly the floor" $
+            qcOffenders (qrUnmeasurableAmounts (reportOf (mkActivity "bread" [reference breadFlow, input flourFlow 1e-27]))) `shouldBe` []
 
         it "passes an amount of exactly zero, which says the input is absent" $
             qcOffenders (qrUnmeasurableAmounts (reportOf (mkActivity "bread" [reference breadFlow, input flourFlow 0]))) `shouldBe` []


### PR DESCRIPTION
## Why

Databases carry exchange amounts like `4e-37 kg`. Nothing is measured at that
magnitude: a hydrogen atom weighs `1.7e-27 kg`, the same figure in joules sits
eight orders of magnitude below a single visible photon, and a count of items is
quantised at one.

A value like that is a residue of computation — an underflow, a conversion
through a zero, an allocation of nothing — that reads as data. It survives every
copy of the dataset until somebody looks, and none of the existing checks look:
`suspiciousAmounts` catches non-finite values and a zero reference amount, not a
number that is merely impossible.

## What it does

A fourteenth structural check, `unmeasurableAmounts`. The floor is `1e-27`
whatever the unit, far below the smallest real trace amount an inventory carries,
so the check accuses only what no instrument could have produced. Zero passes: it
says the input is absent, which is a statement, not a residue.

Warning for an ordinary exchange — such an amount distorts no score, it simply
isn't true. Danger for a reference exchange: normalization divides every other
amount in the process by it, so a reference of ~1e-37 scales the whole process
by its reciprocal (and a negative one flips every sign).

## Verified on real data

Two published national releases: six findings each, from arsine at `7e-28 kg`
through a dioxin at `6e-32 kg` to titanium dioxide at `7e-34 kg`. Low and
discriminating, no flood.
