### PR TITLE
Give every location the databases use a place in the geography hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,10 @@
   geographies file was split on commas without regard for quoting, so
   `Europe, Western` — the location of 863 Agribalyse activities — parsed as a
   code called `Europe` followed by a stray field, and matched nothing. The file
-  now goes through a real CSV reader, and a file it cannot read is reported
-  instead of being quietly replaced by the built-in fallback table.
+  now goes through a real CSV reader and is decoded as UTF-8 whatever the
+  system locale; a file it cannot read — bad quoting, bad encoding, duplicated
+  codes — is reported instead of being quietly replaced by the built-in
+  fallback table.
 
 - A method's own per-unit factor lines no longer cancel each other. SimaPro
   names can bake the unit into the flow name — "Gas, natural/m3" and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,24 @@
   output is unchanged.
 
 ### Fixed
+- Locations the databases actually use now have a place in the geography
+  hierarchy. `data/geographies.csv` listed 91 codes; the databases use several
+  hundred, so a Kenyan, Ukrainian or Brazilian-state activity had no wider
+  location at all and its characterisation factors fell straight through to the
+  global average with nothing said. The table now covers ecoinvent's whole
+  vocabulary — every country in its UN subregion and continent, every province
+  and grid inside the country it belongs to, and the regional aggregates the
+  databases name. Containment comes from Natural Earth's public-domain country
+  polygons rather than from hand-written guesses; codes whose membership is a
+  judgement call, such as the aluminium industry's IAI areas, carry their
+  region and nothing finer.
+- A location whose name contains a comma is no longer cut in half. The
+  geographies file was split on commas without regard for quoting, so
+  `Europe, Western` — the location of 863 Agribalyse activities — parsed as a
+  code called `Europe` followed by a stray field, and matched nothing. The file
+  now goes through a real CSV reader, and a file it cannot read is reported
+  instead of being quietly replaced by the built-in fallback table.
+
 - A method's own per-unit factor lines no longer cancel each other. SimaPro
   names can bake the unit into the flow name — "Gas, natural/m3" and
   "Gas, natural/kg" are the same substance declared in two units, with two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@
   databases name. Containment comes from Natural Earth's public-domain country
   polygons rather than from hand-written guesses; codes whose membership is a
   judgement call, such as the aluminium industry's IAI areas, carry their
-  region and nothing finer.
+  region and nothing finer. The global codes close every fallback list, so a
+  nearer regional factor always wins over the global average.
 - A location whose name contains a comma is no longer cut in half. The
   geographies file was split on commas without regard for quoting, so
   `Europe, Western` — the location of 863 Agribalyse activities — parsed as a

--- a/data/geographies.csv
+++ b/data/geographies.csv
@@ -1,5 +1,7 @@
 # Location hierarchy: a code, its display name, and every wider
-# location its data may fall back to, nearest first.
+# location its data may fall back to, nearest first. Order matters:
+# the characterization cascade walks the parents in order and stops
+# at the first factor it finds, so GLO and RoW close every list.
 #
 # Vocabulary and names come from ecoinvent 3.11's own
 # MasterData/Geographies.xml. Containment -- which country sits in
@@ -9,37 +11,37 @@
 # region and nothing finer: a wrong parent silently lends one
 # region's characterisation factors to another.
 code,display_name,parents
-FR,France,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|WEU|Europe, Western"
-DE,Germany,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|WEU|Europe, Western"
-IT,Italy,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-SEUROPE
-ES,Spain,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-SEUROPE
-GB,United Kingdom,Europe without Switzerland|Europe without Austria|Europe|RER|ENTSO-E|GLO|RoW|UN-NEUROPE
-UK,United Kingdom,Europe without Switzerland|Europe without Austria|Europe|RER|ENTSO-E|GLO|RoW
-PL,Poland,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-EEUROPE|Europe, Eastern"
-NL,Netherlands,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|WEU|Europe, Western"
-BE,Belgium,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|WEU|Europe, Western"
-AT,Austria,"Europe without Switzerland|Europe|EU|RER|ENTSO-E|GLO|RoW|WEU|Europe, Western"
-CH,Switzerland,"Europe without Austria|Europe|RER|ENTSO-E|GLO|RoW|WEU|Europe, Western"
-SE,Sweden,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|NORDEL|GLO|RoW|UN-NEUROPE
-NO,Norway,Europe without Switzerland|Europe without Austria|Europe|RER|ENTSO-E|NORDEL|GLO|RoW|UN-NEUROPE
-DK,Denmark,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|NORDEL|GLO|RoW|UN-NEUROPE
-FI,Finland,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|NORDEL|GLO|RoW|UN-NEUROPE
-PT,Portugal,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-SEUROPE
-GR,Greece,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-SEUROPE
-IE,Ireland,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-NEUROPE
-CZ,Czech Republic,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-EEUROPE|Europe, Eastern"
-RO,Romania,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-EEUROPE|Europe, Eastern"
-HU,Hungary,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-EEUROPE|Europe, Eastern"
-SK,Slovakia,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-EEUROPE|Europe, Eastern"
-BG,Bulgaria,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-EEUROPE|Europe, Eastern"
-HR,Croatia,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-SEUROPE
-SI,Slovenia,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-SEUROPE
-LT,Lithuania,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-NEUROPE
-LV,Latvia,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-NEUROPE
-EE,Estonia,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-NEUROPE
-LU,Luxembourg,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|WEU|Europe, Western"
-MT,Malta,Europe without Switzerland|Europe without Austria|Europe|EU|RER|GLO|RoW|UN-SEUROPE
-CY,Cyprus,Europe without Switzerland|Europe without Austria|Europe|EU|RER|GLO|RoW|UN-WASIA|Asia
+FR,France,"France, including overseas territories|Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|WEU|Europe, Western|GLO|RoW"
+DE,Germany,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|WEU|Europe, Western|GLO|RoW"
+IT,Italy,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|UN-SEUROPE|GLO|RoW
+ES,Spain,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|UN-SEUROPE|GLO|RoW
+GB,United Kingdom,Europe without Switzerland|Europe without Austria|Europe|RER|ENTSO-E|UN-NEUROPE|GLO|RoW
+UK,United Kingdom,Europe without Switzerland|Europe without Austria|Europe|RER|ENTSO-E|UN-NEUROPE|GLO|RoW
+PL,Poland,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|UN-EEUROPE|Europe, Eastern|GLO|RoW"
+NL,Netherlands,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|WEU|Europe, Western|GLO|RoW"
+BE,Belgium,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|WEU|Europe, Western|GLO|RoW"
+AT,Austria,"Europe without Switzerland|Europe|EU|RER|ENTSO-E|WEU|Europe, Western|GLO|RoW"
+CH,Switzerland,"Europe without Austria|Europe|RER|ENTSO-E|WEU|Europe, Western|GLO|RoW"
+SE,Sweden,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|NORDEL|UN-NEUROPE|GLO|RoW
+NO,Norway,Europe without Switzerland|Europe without Austria|Europe|RER|ENTSO-E|NORDEL|UN-NEUROPE|GLO|RoW
+DK,Denmark,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|NORDEL|UN-NEUROPE|GLO|RoW
+FI,Finland,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|NORDEL|UN-NEUROPE|GLO|RoW
+PT,Portugal,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|UN-SEUROPE|GLO|RoW
+GR,Greece,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|UN-SEUROPE|GLO|RoW
+IE,Ireland,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|UN-NEUROPE|GLO|RoW
+CZ,Czech Republic,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|UN-EEUROPE|Europe, Eastern|GLO|RoW"
+RO,Romania,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|UN-EEUROPE|Europe, Eastern|GLO|RoW"
+HU,Hungary,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|UN-EEUROPE|Europe, Eastern|GLO|RoW"
+SK,Slovakia,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|UN-EEUROPE|Europe, Eastern|GLO|RoW"
+BG,Bulgaria,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|UN-EEUROPE|Europe, Eastern|GLO|RoW"
+HR,Croatia,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|UN-SEUROPE|GLO|RoW
+SI,Slovenia,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|UN-SEUROPE|GLO|RoW
+LT,Lithuania,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|UN-NEUROPE|GLO|RoW
+LV,Latvia,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|UN-NEUROPE|GLO|RoW
+EE,Estonia,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|UN-NEUROPE|GLO|RoW
+LU,Luxembourg,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|WEU|Europe, Western|GLO|RoW"
+MT,Malta,Europe without Switzerland|Europe without Austria|Europe|EU|RER|UN-SEUROPE|GLO|RoW
+CY,Cyprus,Europe without Switzerland|Europe without Austria|Europe|EU|RER|UN-WASIA|Asia|GLO|RoW
 EU,European Union,Europe without Switzerland|Europe without Austria|Europe|RER|GLO|RoW
 EU-27,European Union (27),Europe without Switzerland|Europe without Austria|Europe|EU|RER|GLO|RoW
 EU-28,European Union (28),Europe without Switzerland|Europe without Austria|Europe|EU|RER|GLO|RoW
@@ -52,58 +54,58 @@ Europe without Austria,Europe without Austria,Europe|RER|GLO|RoW
 Europe,Europe,GLO|RoW
 US,United States,North America|NAFTA|GLO|RoW
 CA,Canada,North America|NAFTA|GLO|RoW
-MX,Mexico,North America|Latin America|NAFTA|GLO|RoW|UN-CAMERICA
+MX,Mexico,North America|Latin America|NAFTA|UN-CAMERICA|GLO|RoW
 NAFTA,NAFTA,North America|GLO|RoW
 Canada without Quebec,Canada without Quebec,North America|CA|NAFTA|GLO|RoW
 North America,North America,GLO|RoW
 RNA,Rest of North America,North America|GLO|RoW
-CN,China,Asia|GLO|RoW|UN-EASIA
-JP,Japan,Asia|GLO|RoW|UN-EASIA
-KR,South Korea,Asia|GLO|RoW|UN-EASIA
-IN,India,Asia|GLO|RoW|SAS
-IN-Southern grid,India (Southern grid),IN|Asia|GLO|RoW|SAS
-IN-North-eastern grid,India (North-eastern grid),IN|Asia|GLO|RoW|SAS
-IN-Eastern grid,India (Eastern grid),IN|Asia|GLO|RoW|SAS
-IN-Northern grid,India (Northern grid),IN|Asia|GLO|RoW|SAS
-IN-Western grid,India (Western grid),IN|Asia|GLO|RoW|SAS
-TW,Taiwan,Asia|GLO|RoW|UN-EASIA
-ID,Indonesia,"Asia|GLO|RoW|UN-SEASIA|Asia, South East"
-TH,Thailand,"Asia|GLO|RoW|UN-SEASIA|Asia, South East"
-MY,Malaysia,"Asia|GLO|RoW|UN-SEASIA|Asia, South East"
-VN,Vietnam,"Asia|GLO|RoW|UN-SEASIA|Asia, South East"
-PH,Philippines,"Asia|GLO|RoW|UN-SEASIA|Asia, South East"
-SG,Singapore,"Asia|GLO|RoW|UN-SEASIA|Asia, South East"
+CN,China,Asia|UN-EASIA|GLO|RoW
+JP,Japan,Asia|UN-EASIA|GLO|RoW
+KR,South Korea,Asia|UN-EASIA|GLO|RoW
+IN,India,Asia|SAS|GLO|RoW
+IN-Southern grid,India (Southern grid),IN|Asia|SAS|GLO|RoW
+IN-North-eastern grid,India (North-eastern grid),IN|Asia|SAS|GLO|RoW
+IN-Eastern grid,India (Eastern grid),IN|Asia|SAS|GLO|RoW
+IN-Northern grid,India (Northern grid),IN|Asia|SAS|GLO|RoW
+IN-Western grid,India (Western grid),IN|Asia|SAS|GLO|RoW
+TW,Taiwan,Asia|UN-EASIA|GLO|RoW
+ID,Indonesia,"Asia|UN-SEASIA|Asia, South East|GLO|RoW"
+TH,Thailand,"Asia|UN-SEASIA|Asia, South East|GLO|RoW"
+MY,Malaysia,"Asia|UN-SEASIA|Asia, South East|GLO|RoW"
+VN,Vietnam,"Asia|UN-SEASIA|Asia, South East|GLO|RoW"
+PH,Philippines,"Asia|UN-SEASIA|Asia, South East|GLO|RoW"
+SG,Singapore,"Asia|UN-SEASIA|Asia, South East|GLO|RoW"
 Asia,Asia,GLO|RoW
 RAS,Rest of Asia,Asia|GLO|RoW
-BR,Brazil,Latin America|South America|GLO|RoW|UN-SAMERICA
-AR,Argentina,Latin America|South America|GLO|RoW|UN-SAMERICA
-CL,Chile,Latin America|South America|GLO|RoW|UN-SAMERICA
-CO,Colombia,Latin America|South America|GLO|RoW|UN-SAMERICA
-PE,Peru,Latin America|South America|GLO|RoW|UN-SAMERICA
+BR,Brazil,Latin America|South America|UN-SAMERICA|GLO|RoW
+AR,Argentina,Latin America|South America|UN-SAMERICA|GLO|RoW
+CL,Chile,Latin America|South America|UN-SAMERICA|GLO|RoW
+CO,Colombia,Latin America|South America|UN-SAMERICA|GLO|RoW
+PE,Peru,Latin America|South America|UN-SAMERICA|GLO|RoW
 Latin America,Latin America,GLO|RoW
 South America,South America,Latin America|GLO|RoW
 RLA,Rest of Latin America,Latin America|GLO|RoW
 ZA,South Africa,Africa|GLO|RoW
-EG,Egypt,Africa|Middle East|GLO|RoW|UN-NAFRICA
-NG,Nigeria,Africa|GLO|RoW|UN-WAFRICA
-MA,Morocco,Africa|GLO|RoW|UN-NAFRICA
+EG,Egypt,Africa|Middle East|UN-NAFRICA|GLO|RoW
+NG,Nigeria,Africa|UN-WAFRICA|GLO|RoW
+MA,Morocco,Africa|UN-NAFRICA|GLO|RoW
 Africa,Africa,GLO|RoW
 RAF,Rest of Africa,Africa|GLO|RoW
-AU,Australia,Oceania|GLO|RoW|UN-AUSTRALIANZ
-NZ,New Zealand,Oceania|GLO|RoW|UN-AUSTRALIANZ
+AU,Australia,"Australia, including overseas territorie|Oceania|UN-AUSTRALIANZ|GLO|RoW"
+NZ,New Zealand,Oceania|UN-AUSTRALIANZ|GLO|RoW
 Oceania,Oceania,GLO|RoW
-SA,Saudi Arabia,Middle East|Asia|GLO|RoW|UN-WASIA
-AE,United Arab Emirates,Middle East|Asia|GLO|RoW|UN-WASIA
-IL,Israel,Middle East|GLO|RoW|UN-WASIA|Asia
-TR,Turkey,Middle East|Europe|GLO|RoW|UN-WASIA|Asia
+SA,Saudi Arabia,Middle East|Asia|UN-WASIA|GLO|RoW
+AE,United Arab Emirates,Middle East|Asia|UN-WASIA|GLO|RoW
+IL,Israel,Middle East|UN-WASIA|Asia|GLO|RoW
+TR,Turkey,Middle East|Europe|UN-WASIA|Asia|GLO|RoW
 Middle East,Middle East,GLO|RoW
 RME,Rest of Middle East,Middle East|GLO|RoW
 GLO,Global,RoW
 RoW,Rest of World,GLO
 AD,Andorra,UN-SEUROPE|Europe|GLO|RoW
 AF,Afghanistan,SAS|Asia|GLO|RoW
-AG,Antigua and Barbuda,UN-CARIBBEAN|North America|GLO|RoW
-AI,Anguilla,UN-CARIBBEAN|North America|GLO|RoW
+AG,Antigua and Barbuda,UN-CARIBBEAN|North America|Latin America|GLO|RoW
+AI,Anguilla,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 AL,Albania,UN-SEUROPE|Europe|GLO|RoW
 AM,Armenia,UN-WASIA|Asia|GLO|RoW
 AO,Angola,UN-MAFRICA|Africa|GLO|RoW
@@ -111,74 +113,74 @@ AQ,Antarctica,GLO|RoW
 AS,American Samoa,UN-POLYNESIA|Oceania|GLO|RoW
 ASCC,Alaska Systems Coordinating Council,US|North America|NAFTA|GLO|RoW
 "ASCC, US only",Alaska Systems Coordinating Council,US|North America|NAFTA|GLO|RoW
-AU-AC,"Australia, Ashmore and Cartier Islands",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
-AU-ACT,"Australia, Australian Capital Territory",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
-AU-IOT,"Australia, Indian Ocean Territories",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
-AU-JBT,"Australia, Jervis Bay Territory",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
-AU-NSW,"Australia, New South Wales",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
-AU-NT,"Australia, Northern Territory",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
-AU-QLD,"Australia, Queensland",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
-AU-SA,"Australia, South Australia",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
-AU-TAS,"Australia, Tasmania",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
-AU-VIC,"Australia, Victoria",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
-AU-WA,"Australia, Western Australia",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
-AW,Aruba,UN-CARIBBEAN|North America|GLO|RoW
+AU-AC,"Australia, Ashmore and Cartier Islands",AU|Oceania|UN-AUSTRALIANZ|GLO|RoW
+AU-ACT,"Australia, Australian Capital Territory",AU|Oceania|UN-AUSTRALIANZ|GLO|RoW
+AU-IOT,"Australia, Indian Ocean Territories",AU|Oceania|UN-AUSTRALIANZ|GLO|RoW
+AU-JBT,"Australia, Jervis Bay Territory",AU|Oceania|UN-AUSTRALIANZ|GLO|RoW
+AU-NSW,"Australia, New South Wales",AU|Oceania|UN-AUSTRALIANZ|GLO|RoW
+AU-NT,"Australia, Northern Territory",AU|Oceania|UN-AUSTRALIANZ|GLO|RoW
+AU-QLD,"Australia, Queensland",AU|Oceania|UN-AUSTRALIANZ|GLO|RoW
+AU-SA,"Australia, South Australia",AU|Oceania|UN-AUSTRALIANZ|GLO|RoW
+AU-TAS,"Australia, Tasmania",AU|Oceania|UN-AUSTRALIANZ|GLO|RoW
+AU-VIC,"Australia, Victoria",AU|Oceania|UN-AUSTRALIANZ|GLO|RoW
+AU-WA,"Australia, Western Australia",AU|Oceania|UN-AUSTRALIANZ|GLO|RoW
+AW,Aruba,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 AX,Aland,UN-NEUROPE|Europe|GLO|RoW
 AZ,Azerbaijan,UN-WASIA|Asia|GLO|RoW
 Akrotiri,Akrotiri Sovereign Base Area,Asia|GLO|RoW
 Asia without China,Asia without China,Asia|GLO|RoW
 "Asia, South East",South-Eastern Asia,Asia|GLO|RoW
-"Australia, including overseas territorie","Australia, including overseas territories",AU|Oceania|GLO|RoW
+"Australia, including overseas territorie","Australia, including overseas territories",Oceania|GLO|RoW
 BA,Bosnia and Herzegovina,UN-SEUROPE|Europe|GLO|RoW
 BALTSO,Baltic System Operator,Europe|RER|ENTSO-E|GLO|RoW
-BB,Barbados,UN-CARIBBEAN|North America|GLO|RoW
+BB,Barbados,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 BD,Bangladesh,SAS|Asia|GLO|RoW
 BF,Burkina Faso,UN-WAFRICA|Africa|GLO|RoW
 BH,Bahrain,UN-WASIA|Asia|GLO|RoW
 BI,Burundi,UN-EAFRICA|Africa|GLO|RoW
 BJ,Benin,UN-WAFRICA|Africa|GLO|RoW
-BL,Saint Barthelemy,UN-CARIBBEAN|North America|GLO|RoW
+BL,Saint Barthelemy,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 BM,Bermuda,North America|GLO|RoW
 BN,Brunei,"UN-SEASIA|Asia, South East|Asia|GLO|RoW"
 BO,Bolivia,UN-SAMERICA|South America|Latin America|GLO|RoW
-BR-AC,"Brazil, Acre",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-AL,"Brazil, Alagoas",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-AM,"Brazil, Amazonas",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-AP,"Brazil, Amapá",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-BA,"Brazil, Bahia",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-CE,"Brazil, Ceará",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-DF,"Brazil, Distrito Federal",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-ES,"Brazil, Espírito Santo",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-GO,"Brazil, Goiás",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-MA,"Brazil, Maranhão",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-MG,"Brazil, Minas Gerais",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-MS,"Brazil, Mato Grosso do Sul",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-MT,"Brazil, Mato Grosso",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-Mid-western grid,"Brazil, Mid-western grid",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-North-eastern grid,"Brazil, North-eastern grid",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-Northern grid,"Brazil, Northern grid",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-PA,"Brazil, Pará",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-PB,"Brazil, Paraíba",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-PE,"Brazil, Pernambuco",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-PI,"Brazil, Piauí",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-PR,"Brazil, Paraná",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-RJ,"Brazil, Rio de Janeiro",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-RN,"Brazil, Rio Grande do Norte",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-RO,"Brazil, Rondônia",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-RR,"Brazil, Roraima",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-RS,"Brazil, Rio Grande do Sul",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-SC,"Brazil, Santa Catarina",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-SE,"Brazil, Sergipe",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-SP,"Brazil, São Paulo",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-South-eastern grid,"Brazil, South-eastern grid",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-South-eastern/Mid-western grid,"Brazil, South-eastern and Mid-western grid",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-Southern grid,"Brazil, Southern grid",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BR-TO,"Brazil, Tocantins",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
-BS,The Bahamas,UN-CARIBBEAN|North America|GLO|RoW
+BR-AC,"Brazil, Acre",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-AL,"Brazil, Alagoas",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-AM,"Brazil, Amazonas",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-AP,"Brazil, Amapá",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-BA,"Brazil, Bahia",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-CE,"Brazil, Ceará",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-DF,"Brazil, Distrito Federal",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-ES,"Brazil, Espírito Santo",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-GO,"Brazil, Goiás",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-MA,"Brazil, Maranhão",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-MG,"Brazil, Minas Gerais",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-MS,"Brazil, Mato Grosso do Sul",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-MT,"Brazil, Mato Grosso",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-Mid-western grid,"Brazil, Mid-western grid",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-North-eastern grid,"Brazil, North-eastern grid",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-Northern grid,"Brazil, Northern grid",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-PA,"Brazil, Pará",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-PB,"Brazil, Paraíba",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-PE,"Brazil, Pernambuco",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-PI,"Brazil, Piauí",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-PR,"Brazil, Paraná",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-RJ,"Brazil, Rio de Janeiro",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-RN,"Brazil, Rio Grande do Norte",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-RO,"Brazil, Rondônia",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-RR,"Brazil, Roraima",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-RS,"Brazil, Rio Grande do Sul",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-SC,"Brazil, Santa Catarina",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-SE,"Brazil, Sergipe",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-SP,"Brazil, São Paulo",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-South-eastern grid,"Brazil, South-eastern grid",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-South-eastern/Mid-western grid,"Brazil, South-eastern and Mid-western grid",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-Southern grid,"Brazil, Southern grid",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BR-TO,"Brazil, Tocantins",BR|Latin America|South America|UN-SAMERICA|GLO|RoW
+BS,The Bahamas,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 BT,Bhutan,SAS|Asia|GLO|RoW
 BW,Botswana,Africa|GLO|RoW
 BY,Belarus,"UN-EEUROPE|Europe, Eastern|Europe|GLO|RoW"
-BZ,Belize,UN-CAMERICA|North America|GLO|RoW
+BZ,Belize,UN-CAMERICA|North America|Latin America|GLO|RoW
 Bajo Nuevo,Bajo Nuevo Bank (Petrel Is.),Latin America|GLO|RoW
 CA-AB,"Canada, Alberta",CA|North America|NAFTA|GLO|RoW
 CA-BC,"Canada, British Columbia",CA|North America|NAFTA|GLO|RoW
@@ -200,60 +202,60 @@ CG,Congo,UN-MAFRICA|Africa|GLO|RoW
 CI,Ivory Coast,UN-WAFRICA|Africa|GLO|RoW
 CK,Cook Islands,UN-POLYNESIA|Oceania|GLO|RoW
 CM,Cameroon,UN-MAFRICA|Africa|GLO|RoW
-CN-AH,"China, Anhui (安徽)",CN|Asia|GLO|RoW|UN-EASIA
-CN-BJ,"China, Beijing (北京)",CN|Asia|GLO|RoW|UN-EASIA
-CN-CCG,"China, Central Grid",CN|Asia|GLO|RoW|UN-EASIA
-CN-CQ,"China, Chongqing (重庆)",CN|Asia|GLO|RoW|UN-EASIA
-CN-CSG,"China, China Southern Power Grid",CN|Asia|GLO|RoW|UN-EASIA
-CN-ECGC,"China, East Grid",CN|Asia|GLO|RoW|UN-EASIA
-CN-FJ,"China, Fujian (福建)",CN|Asia|GLO|RoW|UN-EASIA
-CN-GD,"China, Guangdong (广东)",CN|Asia|GLO|RoW|UN-EASIA
-CN-GS,"China, Gansu (甘肃)",CN|Asia|GLO|RoW|UN-EASIA
-CN-GX,"China, Guangxi (广西壮族自治区)",CN|Asia|GLO|RoW|UN-EASIA
-CN-GZ,"China, Guizhou (贵州)",CN|Asia|GLO|RoW|UN-EASIA
-CN-HA,"China, Hainan (海南)",CN|Asia|GLO|RoW|UN-EASIA
-CN-HB,"China, Hebei (河北)",CN|Asia|GLO|RoW|UN-EASIA
-CN-HE,"China, Henan (河南)",CN|Asia|GLO|RoW|UN-EASIA
-CN-HL,"China, Heilongjiang (黑龙江省)",CN|Asia|GLO|RoW|UN-EASIA
-CN-HN,"China, Hunan (湖南)",CN|Asia|GLO|RoW|UN-EASIA
-CN-HU,"China, Hubei (湖北)",CN|Asia|GLO|RoW|UN-EASIA
-CN-JL,"China, Jilin (吉林)",CN|Asia|GLO|RoW|UN-EASIA
-CN-JS,"China, Jiangsu (江苏)",CN|Asia|GLO|RoW|UN-EASIA
-CN-JX,"China, Jiangxi (江西)",CN|Asia|GLO|RoW|UN-EASIA
-CN-LN,"China, Liaoning (辽宁)",CN|Asia|GLO|RoW|UN-EASIA
-CN-NCGC,"China, North Grid",CN|Asia|GLO|RoW|UN-EASIA
-CN-NECG,"China, Northeast Grid",CN|Asia|GLO|RoW|UN-EASIA
-CN-NM,"China, Inner Mongol (内蒙古自治区)",CN|Asia|GLO|RoW|UN-EASIA
-CN-NWG,"China, Northwest Grid",CN|Asia|GLO|RoW|UN-EASIA
-CN-NX,"China, Ningxia (宁夏回族自治区)",CN|Asia|GLO|RoW|UN-EASIA
-CN-QH,"China, Qinghai (青海)",CN|Asia|GLO|RoW|UN-EASIA
-CN-SA,"China, Shaanxi (陕西)",CN|Asia|GLO|RoW|UN-EASIA
-CN-SC,"China, Sichuan (四川)",CN|Asia|GLO|RoW|UN-EASIA
-CN-SD,"China, Shandong (山东)",CN|Asia|GLO|RoW|UN-EASIA
-CN-SGCC,"China, State Grid Corporation of China",CN|Asia|GLO|RoW|UN-EASIA
-CN-SH,"China, Shanghai (上海)",CN|Asia|GLO|RoW|UN-EASIA
-CN-SWG,"China, Southwest Grid",CN|Asia|GLO|RoW|UN-EASIA
-CN-SX,"China, Shanxi (山西)",CN|Asia|GLO|RoW|UN-EASIA
-CN-TJ,"China, Tianjin (天津)",CN|Asia|GLO|RoW|UN-EASIA
-CN-XJ,"China, Xinjiang (新疆维吾尔自治区)",CN|Asia|GLO|RoW|UN-EASIA
-CN-XZ,"China, Xizang (西藏自治区)",CN|Asia|GLO|RoW|UN-EASIA
-CN-YN,"China, Yunnan (云南)",CN|Asia|GLO|RoW|UN-EASIA
-CN-ZJ,"China, Zhejiang (浙江)",CN|Asia|GLO|RoW|UN-EASIA
-CR,Costa Rica,UN-CAMERICA|North America|GLO|RoW
-CU,Cuba,UN-CARIBBEAN|North America|GLO|RoW
+CN-AH,"China, Anhui (安徽)",CN|Asia|UN-EASIA|GLO|RoW
+CN-BJ,"China, Beijing (北京)",CN|Asia|UN-EASIA|GLO|RoW
+CN-CCG,"China, Central Grid",CN|Asia|UN-EASIA|GLO|RoW
+CN-CQ,"China, Chongqing (重庆)",CN|Asia|UN-EASIA|GLO|RoW
+CN-CSG,"China, China Southern Power Grid",CN|Asia|UN-EASIA|GLO|RoW
+CN-ECGC,"China, East Grid",CN|Asia|UN-EASIA|GLO|RoW
+CN-FJ,"China, Fujian (福建)",CN|Asia|UN-EASIA|GLO|RoW
+CN-GD,"China, Guangdong (广东)",CN|Asia|UN-EASIA|GLO|RoW
+CN-GS,"China, Gansu (甘肃)",CN|Asia|UN-EASIA|GLO|RoW
+CN-GX,"China, Guangxi (广西壮族自治区)",CN|Asia|UN-EASIA|GLO|RoW
+CN-GZ,"China, Guizhou (贵州)",CN|Asia|UN-EASIA|GLO|RoW
+CN-HA,"China, Hainan (海南)",CN|Asia|UN-EASIA|GLO|RoW
+CN-HB,"China, Hebei (河北)",CN|Asia|UN-EASIA|GLO|RoW
+CN-HE,"China, Henan (河南)",CN|Asia|UN-EASIA|GLO|RoW
+CN-HL,"China, Heilongjiang (黑龙江省)",CN|Asia|UN-EASIA|GLO|RoW
+CN-HN,"China, Hunan (湖南)",CN|Asia|UN-EASIA|GLO|RoW
+CN-HU,"China, Hubei (湖北)",CN|Asia|UN-EASIA|GLO|RoW
+CN-JL,"China, Jilin (吉林)",CN|Asia|UN-EASIA|GLO|RoW
+CN-JS,"China, Jiangsu (江苏)",CN|Asia|UN-EASIA|GLO|RoW
+CN-JX,"China, Jiangxi (江西)",CN|Asia|UN-EASIA|GLO|RoW
+CN-LN,"China, Liaoning (辽宁)",CN|Asia|UN-EASIA|GLO|RoW
+CN-NCGC,"China, North Grid",CN|Asia|UN-EASIA|GLO|RoW
+CN-NECG,"China, Northeast Grid",CN|Asia|UN-EASIA|GLO|RoW
+CN-NM,"China, Inner Mongol (内蒙古自治区)",CN|Asia|UN-EASIA|GLO|RoW
+CN-NWG,"China, Northwest Grid",CN|Asia|UN-EASIA|GLO|RoW
+CN-NX,"China, Ningxia (宁夏回族自治区)",CN|Asia|UN-EASIA|GLO|RoW
+CN-QH,"China, Qinghai (青海)",CN|Asia|UN-EASIA|GLO|RoW
+CN-SA,"China, Shaanxi (陕西)",CN|Asia|UN-EASIA|GLO|RoW
+CN-SC,"China, Sichuan (四川)",CN|Asia|UN-EASIA|GLO|RoW
+CN-SD,"China, Shandong (山东)",CN|Asia|UN-EASIA|GLO|RoW
+CN-SGCC,"China, State Grid Corporation of China",CN|Asia|UN-EASIA|GLO|RoW
+CN-SH,"China, Shanghai (上海)",CN|Asia|UN-EASIA|GLO|RoW
+CN-SWG,"China, Southwest Grid",CN|Asia|UN-EASIA|GLO|RoW
+CN-SX,"China, Shanxi (山西)",CN|Asia|UN-EASIA|GLO|RoW
+CN-TJ,"China, Tianjin (天津)",CN|Asia|UN-EASIA|GLO|RoW
+CN-XJ,"China, Xinjiang (新疆维吾尔自治区)",CN|Asia|UN-EASIA|GLO|RoW
+CN-XZ,"China, Xizang (西藏自治区)",CN|Asia|UN-EASIA|GLO|RoW
+CN-YN,"China, Yunnan (云南)",CN|Asia|UN-EASIA|GLO|RoW
+CN-ZJ,"China, Zhejiang (浙江)",CN|Asia|UN-EASIA|GLO|RoW
+CR,Costa Rica,UN-CAMERICA|North America|Latin America|GLO|RoW
+CU,Cuba,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 CV,Cape Verde,UN-WAFRICA|Africa|GLO|RoW
-CW,Curaçao,UN-CARIBBEAN|North America|GLO|RoW
+CW,Curaçao,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 Canada without Alberta,Canada without Alberta,CA|North America|NAFTA|GLO|RoW
 Canada without Alberta and Quebec,Canada without Alberta and Quebec,CA|North America|NAFTA|GLO|RoW
 Canary Islands,Canary Islands,ES|Europe|GLO|RoW
 Central Asia,Central Asia,Asia|GLO|RoW
-China w/o Inner Mongol,China without Inner Mongol,CN|Asia|GLO|RoW
+China w/o Inner Mongol,China without Inner Mongol,CN|Asia|UN-EASIA|GLO|RoW
 Clipperton Island,Clipperton Island,Oceania|GLO|RoW
 Coral Sea Islands,Coral Sea Islands,Oceania|GLO|RoW
 Cyprus No Mans Area,Cyprus No Mans Area,Asia|GLO|RoW
 DJ,Djibouti,UN-EAFRICA|Africa|GLO|RoW
-DM,Dominica,UN-CARIBBEAN|North America|GLO|RoW
-DO,Dominican Republic,UN-CARIBBEAN|North America|GLO|RoW
+DM,Dominica,UN-CARIBBEAN|North America|Latin America|GLO|RoW
+DO,Dominican Republic,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 DZ,Algeria,UN-NAFRICA|Africa|GLO|RoW
 Dhekelia Base,Dhekelia Sovereign Base Area,Asia|GLO|RoW
 EC,Ecuador,UN-SAMERICA|South America|Latin America|GLO|RoW
@@ -263,17 +265,17 @@ ET,Ethiopia,UN-EAFRICA|Africa|GLO|RoW
 Europe without NORDEL (NCPA),Europe without NORDEL (NCPA),Europe|RER|GLO|RoW
 Europe without Switzerland and Austria,Europe without Switzerland and Austria,Europe|RER|GLO|RoW
 Europe without Switzerland and France,Europe without Switzerland and France,Europe|RER|GLO|RoW
-"Europe, Eastern",Eastern Europe,Europe|GLO|RoW
-"Europe, Western",Western Europe,Europe|GLO|RoW
+"Europe, Eastern",Eastern Europe,Europe|RER|GLO|RoW
+"Europe, Western",Western Europe,Europe|RER|GLO|RoW
 "Europe, without Russia and Türkiye","Europe, without Russia and Türkiye",Europe|RER|GLO|RoW
 FJ,Fiji,UN-MELANESIA|Oceania|GLO|RoW
 FK,Falkland Islands,UN-SAMERICA|South America|Latin America|GLO|RoW
 FM,"Micronesia, Federated States of",UN-MICRONESIA|Oceania|GLO|RoW
 FO,Faroe Islands,UN-NEUROPE|Europe|GLO|RoW
 FSU,Commonwealth of Independent States,Europe|Asia|GLO|RoW
-"France, including overseas territories","France, including overseas territories",FR|Europe|GLO|RoW
+"France, including overseas territories","France, including overseas territories",Europe|GLO|RoW
 GA,Gabon,UN-MAFRICA|Africa|GLO|RoW
-GD,Grenada,UN-CARIBBEAN|North America|GLO|RoW
+GD,Grenada,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 GE,Georgia,UN-WASIA|Asia|GLO|RoW
 GG,Guernsey,UN-NEUROPE|Europe|GLO|RoW
 GH,Ghana,UN-WAFRICA|Africa|GLO|RoW
@@ -283,7 +285,7 @@ GN,Guinea,UN-WAFRICA|Africa|GLO|RoW
 GP,Guadeloupe,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 GQ,Equatorial Guinea,UN-MAFRICA|Africa|GLO|RoW
 GS,South Georgia and South Sandwich Islands,GLO|RoW
-GT,Guatemala,UN-CAMERICA|North America|GLO|RoW
+GT,Guatemala,UN-CAMERICA|North America|Latin America|GLO|RoW
 GU,Guam,UN-MICRONESIA|Oceania|GLO|RoW
 GW,Guinea Bissau,UN-WAFRICA|Africa|GLO|RoW
 GY,Guyana,UN-SAMERICA|South America|Latin America|GLO|RoW
@@ -292,8 +294,8 @@ HICC,Hawaiian Islands Coordinating Council,US|North America|NAFTA|GLO|RoW
 "HICC, US only",Hawaiian Islands Coordinating Council,US|North America|NAFTA|GLO|RoW
 HK,Hong Kong S.A.R.,UN-EASIA|Asia|GLO|RoW
 HM,Heard Island and McDonald Islands,GLO|RoW
-HN,Honduras,UN-CAMERICA|North America|GLO|RoW
-HT,Haiti,UN-CARIBBEAN|North America|GLO|RoW
+HN,Honduras,UN-CAMERICA|North America|Latin America|GLO|RoW
+HT,Haiti,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 "IAI Area, Africa","IAI Area, Africa",Africa|GLO|RoW
 "IAI Area, Asia, without China and GCC","IAI Area, Asia, without China and GCC",Asia|GLO|RoW
 "IAI Area, EU27 & EFTA","IAI Area, EU27 & EFTA",Europe|RER|GLO|RoW
@@ -303,62 +305,62 @@ HT,Haiti,UN-CARIBBEAN|North America|GLO|RoW
 "IAI Area, Russia & RER w/o EU27 & EFTA","IAI Area, Russia & Europe outside EU27 & EFTA",Europe|GLO|RoW
 "IAI Area, South America","IAI Area, South America",South America|Latin America|GLO|RoW
 IM,Isle of Man,UN-NEUROPE|Europe|GLO|RoW
-IN-AN,"India, Andaman and Nicobar",IN|Asia|GLO|RoW|SAS
-IN-AP,"India, Andhra Pradesh",IN|Asia|GLO|RoW|SAS
-IN-AR,"India, Arunachal Pradesh",IN|Asia|GLO|RoW|SAS
-IN-AS,"India, Assam",IN|Asia|GLO|RoW|SAS
-IN-BR,"India, Bihar",IN|Asia|GLO|RoW|SAS
-IN-CH,"India, Chandigarh",IN|Asia|GLO|RoW|SAS
-IN-CT,"India, Chhattisgarh",IN|Asia|GLO|RoW|SAS
-IN-DD,"India, Daman and Diu",IN|Asia|GLO|RoW|SAS
-IN-DL,"India, Delhi",IN|Asia|GLO|RoW|SAS
-IN-DN,"India, Dadra and Nagar Haveli",IN|Asia|GLO|RoW|SAS
-IN-GA,"India, Goa",IN|Asia|GLO|RoW|SAS
-IN-GJ,"India, Gujarat",IN|Asia|GLO|RoW|SAS
-IN-HP,"India, Himachal Pradesh",IN|Asia|GLO|RoW|SAS
-IN-HR,"India, Haryana",IN|Asia|GLO|RoW|SAS
-IN-Islands,"India, Islands",IN|Asia|GLO|RoW|SAS
-IN-JH,"India, Jharkhand",IN|Asia|GLO|RoW|SAS
-IN-JK,"India, Jammu and Kashmir",IN|Asia|GLO|RoW|SAS
-IN-KA,"India, Karnataka",IN|Asia|GLO|RoW|SAS
-IN-KL,"India, Kerala",IN|Asia|GLO|RoW|SAS
-IN-LD,"India, Lakshadweep",IN|Asia|GLO|RoW|SAS
-IN-MH,"India, Maharashtra",IN|Asia|GLO|RoW|SAS
-IN-ML,"India, Meghalaya",IN|Asia|GLO|RoW|SAS
-IN-MN,"India, Manipur",IN|Asia|GLO|RoW|SAS
-IN-MP,"India, Madhya Pradesh",IN|Asia|GLO|RoW|SAS
-IN-MZ,"India, Mizoram",IN|Asia|GLO|RoW|SAS
-IN-NL,"India, Nagaland",IN|Asia|GLO|RoW|SAS
-IN-OR,"India, Odisha",IN|Asia|GLO|RoW|SAS
-IN-PB,"India, Punjab",IN|Asia|GLO|RoW|SAS
-IN-PY,"India, Puducherry",IN|Asia|GLO|RoW|SAS
-IN-RJ,"India, Rajasthan",IN|Asia|GLO|RoW|SAS
-IN-SK,"India, Sikkim",IN|Asia|GLO|RoW|SAS
-IN-TN,"India, Tamil Nadu",IN|Asia|GLO|RoW|SAS
-IN-TR,"India, Tripura",IN|Asia|GLO|RoW|SAS
-IN-UP,"India, Uttar Pradesh",IN|Asia|GLO|RoW|SAS
-IN-UT,"India, Uttarakhand",IN|Asia|GLO|RoW|SAS
-IN-WB,"India, West Bengal",IN|Asia|GLO|RoW|SAS
+IN-AN,"India, Andaman and Nicobar",IN|Asia|SAS|GLO|RoW
+IN-AP,"India, Andhra Pradesh",IN|Asia|SAS|GLO|RoW
+IN-AR,"India, Arunachal Pradesh",IN|Asia|SAS|GLO|RoW
+IN-AS,"India, Assam",IN|Asia|SAS|GLO|RoW
+IN-BR,"India, Bihar",IN|Asia|SAS|GLO|RoW
+IN-CH,"India, Chandigarh",IN|Asia|SAS|GLO|RoW
+IN-CT,"India, Chhattisgarh",IN|Asia|SAS|GLO|RoW
+IN-DD,"India, Daman and Diu",IN|Asia|SAS|GLO|RoW
+IN-DL,"India, Delhi",IN|Asia|SAS|GLO|RoW
+IN-DN,"India, Dadra and Nagar Haveli",IN|Asia|SAS|GLO|RoW
+IN-GA,"India, Goa",IN|Asia|SAS|GLO|RoW
+IN-GJ,"India, Gujarat",IN|Asia|SAS|GLO|RoW
+IN-HP,"India, Himachal Pradesh",IN|Asia|SAS|GLO|RoW
+IN-HR,"India, Haryana",IN|Asia|SAS|GLO|RoW
+IN-Islands,"India, Islands",IN|Asia|SAS|GLO|RoW
+IN-JH,"India, Jharkhand",IN|Asia|SAS|GLO|RoW
+IN-JK,"India, Jammu and Kashmir",IN|Asia|SAS|GLO|RoW
+IN-KA,"India, Karnataka",IN|Asia|SAS|GLO|RoW
+IN-KL,"India, Kerala",IN|Asia|SAS|GLO|RoW
+IN-LD,"India, Lakshadweep",IN|Asia|SAS|GLO|RoW
+IN-MH,"India, Maharashtra",IN|Asia|SAS|GLO|RoW
+IN-ML,"India, Meghalaya",IN|Asia|SAS|GLO|RoW
+IN-MN,"India, Manipur",IN|Asia|SAS|GLO|RoW
+IN-MP,"India, Madhya Pradesh",IN|Asia|SAS|GLO|RoW
+IN-MZ,"India, Mizoram",IN|Asia|SAS|GLO|RoW
+IN-NL,"India, Nagaland",IN|Asia|SAS|GLO|RoW
+IN-OR,"India, Odisha",IN|Asia|SAS|GLO|RoW
+IN-PB,"India, Punjab",IN|Asia|SAS|GLO|RoW
+IN-PY,"India, Puducherry",IN|Asia|SAS|GLO|RoW
+IN-RJ,"India, Rajasthan",IN|Asia|SAS|GLO|RoW
+IN-SK,"India, Sikkim",IN|Asia|SAS|GLO|RoW
+IN-TN,"India, Tamil Nadu",IN|Asia|SAS|GLO|RoW
+IN-TR,"India, Tripura",IN|Asia|SAS|GLO|RoW
+IN-UP,"India, Uttar Pradesh",IN|Asia|SAS|GLO|RoW
+IN-UT,"India, Uttarakhand",IN|Asia|SAS|GLO|RoW
+IN-WB,"India, West Bengal",IN|Asia|SAS|GLO|RoW
 IO,British Indian Ocean Territory,GLO|RoW
 IQ,Iraq,UN-WASIA|Asia|GLO|RoW
 IR,Iran,SAS|Asia|GLO|RoW
 IS,Iceland,UN-NEUROPE|Europe|GLO|RoW
 JE,Jersey,UN-NEUROPE|Europe|GLO|RoW
-JM,Jamaica,UN-CARIBBEAN|North America|GLO|RoW
+JM,Jamaica,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 JO,Jordan,UN-WASIA|Asia|GLO|RoW
 KE,Kenya,UN-EAFRICA|Africa|GLO|RoW
 KG,Kyrgyzstan,Central Asia|Asia|GLO|RoW
 KH,Cambodia,"UN-SEASIA|Asia, South East|Asia|GLO|RoW"
 KI,Kiribati,UN-MICRONESIA|Oceania|GLO|RoW
 KM,Comoros,UN-EAFRICA|Africa|GLO|RoW
-KN,Saint Kitts and Nevis,UN-CARIBBEAN|North America|GLO|RoW
+KN,Saint Kitts and Nevis,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 KP,North Korea,UN-EASIA|Asia|GLO|RoW
 KW,Kuwait,UN-WASIA|Asia|GLO|RoW
-KY,Cayman Islands,UN-CARIBBEAN|North America|GLO|RoW
+KY,Cayman Islands,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 KZ,Kazakhstan,Central Asia|Asia|GLO|RoW
 LA,Laos,"UN-SEASIA|Asia, South East|Asia|GLO|RoW"
 LB,Lebanon,UN-WASIA|Asia|GLO|RoW
-LC,Saint Lucia,UN-CARIBBEAN|North America|GLO|RoW
+LC,Saint Lucia,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 LI,Liechtenstein,"WEU|Europe, Western|Europe|GLO|RoW"
 LK,Sri Lanka,SAS|Asia|GLO|RoW
 LR,Liberia,UN-WAFRICA|Africa|GLO|RoW
@@ -367,7 +369,7 @@ LY,Libya,UN-NAFRICA|Africa|GLO|RoW
 MC,Monaco,"WEU|Europe, Western|Europe|GLO|RoW"
 MD,Moldova,"UN-EEUROPE|Europe, Eastern|Europe|GLO|RoW"
 ME,Montenegro,UN-SEUROPE|Europe|GLO|RoW
-MF,Saint Martin,UN-CARIBBEAN|North America|GLO|RoW
+MF,Saint Martin,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 MG,Madagascar,UN-EAFRICA|Africa|GLO|RoW
 MH,Marshall Islands,UN-MICRONESIA|Oceania|GLO|RoW
 MK,North Macedonia,UN-SEUROPE|Europe|GLO|RoW
@@ -380,16 +382,16 @@ MQ,Martinique,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 MR,Mauritania,UN-WAFRICA|Africa|GLO|RoW
 MRO,Midwest Reliability Organization,US|North America|NAFTA|GLO|RoW
 "MRO, US only",Midwest Reliability Organization,US|North America|NAFTA|GLO|RoW
-MS,Montserrat,UN-CARIBBEAN|North America|GLO|RoW
-MU,Mauritius,UN-EAFRICA|GLO|RoW
-MV,Maldives,SAS|GLO|RoW
+MS,Montserrat,UN-CARIBBEAN|North America|Latin America|GLO|RoW
+MU,Mauritius,UN-EAFRICA|Africa|GLO|RoW
+MV,Maldives,SAS|Asia|GLO|RoW
 MW,Malawi,UN-EAFRICA|Africa|GLO|RoW
 MZ,Mozambique,UN-EAFRICA|Africa|GLO|RoW
 NA,Namibia,Africa|GLO|RoW
 NC,New Caledonia,UN-MELANESIA|Oceania|GLO|RoW
 NE,Niger,UN-WAFRICA|Africa|GLO|RoW
 NF,Norfolk Island,UN-AUSTRALIANZ|Oceania|GLO|RoW
-NI,Nicaragua,UN-CAMERICA|North America|GLO|RoW
+NI,Nicaragua,UN-CAMERICA|North America|Latin America|GLO|RoW
 NP,Nepal,SAS|Asia|GLO|RoW
 NPCC,Northeast Power Coordinating Council,US|North America|NAFTA|GLO|RoW
 "NPCC, US only",Northeast Power Coordinating Council,US|North America|NAFTA|GLO|RoW
@@ -398,13 +400,13 @@ NU,Niue,UN-POLYNESIA|Oceania|GLO|RoW
 North America without Quebec,North America without Quebec,North America|GLO|RoW
 Northern Cyprus,Northern Cyprus,Asia|GLO|RoW
 OM,Oman,UN-WASIA|Asia|GLO|RoW
-PA,Panama,UN-CAMERICA|North America|GLO|RoW
+PA,Panama,UN-CAMERICA|North America|Latin America|GLO|RoW
 PF,French Polynesia,UN-POLYNESIA|Oceania|GLO|RoW
 PG,Papua New Guinea,UN-MELANESIA|Oceania|GLO|RoW
 PK,Pakistan,SAS|Asia|GLO|RoW
 PM,Saint Pierre and Miquelon,North America|GLO|RoW
 PN,Pitcairn Islands,UN-POLYNESIA|Oceania|GLO|RoW
-PR,PR,UN-CARIBBEAN|North America|GLO|RoW
+PR,Puerto Rico,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 PS,Palestine,UN-WASIA|Asia|GLO|RoW
 PW,Palau,UN-MICRONESIA|Oceania|GLO|RoW
 PY,Paraguay,UN-SAMERICA|South America|Latin America|GLO|RoW
@@ -426,11 +428,11 @@ Russia (Asia),Russia (Asia),RU|Asia|GLO|RoW
 Russia (Europe),Russia (Europe),RU|Europe|GLO|RoW
 SAS,Southern Asia,Asia|GLO|RoW
 SB,Solomon Islands,UN-MELANESIA|Oceania|GLO|RoW
-SC,Seychelles,UN-EAFRICA|GLO|RoW
+SC,Seychelles,UN-EAFRICA|Africa|GLO|RoW
 SD,Sudan,UN-NAFRICA|Africa|GLO|RoW
 SERC,SERC Reliability Corporation,US|North America|NAFTA|GLO|RoW
 "SERC, US only",SERC Reliability Corporation,US|North America|NAFTA|GLO|RoW
-SH,Saint Helena,UN-WAFRICA|GLO|RoW
+SH,Saint Helena,UN-WAFRICA|Africa|GLO|RoW
 SL,Sierra Leone,UN-WAFRICA|Africa|GLO|RoW
 SM,San Marino,UN-SEUROPE|Europe|GLO|RoW
 SN,Senegal,UN-WAFRICA|Africa|GLO|RoW
@@ -438,8 +440,8 @@ SO,Somalia,UN-EAFRICA|Africa|GLO|RoW
 SR,Suriname,UN-SAMERICA|South America|Latin America|GLO|RoW
 SS,South Sudan,UN-EAFRICA|Africa|GLO|RoW
 ST,Sao Tome and Principe,UN-MAFRICA|Africa|GLO|RoW
-SV,El Salvador,UN-CAMERICA|North America|GLO|RoW
-SX,Sint Maarten,UN-CARIBBEAN|North America|GLO|RoW
+SV,El Salvador,UN-CAMERICA|North America|Latin America|GLO|RoW
+SX,Sint Maarten,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 SY,Syria,UN-WASIA|Asia|GLO|RoW
 SZ,Eswatini,Africa|GLO|RoW
 Scarborough Reef,Scarborough Reef,Asia|GLO|RoW
@@ -448,7 +450,7 @@ Siachen Glacier,Siachen Glacier,Asia|GLO|RoW
 Somaliland,Somaliland,Africa|GLO|RoW
 South and Central America,South and Central America,Latin America|GLO|RoW
 Spratly Islands,Spratly Islands,Asia|GLO|RoW
-TC,Turks and Caicos Islands,UN-CARIBBEAN|North America|GLO|RoW
+TC,Turks and Caicos Islands,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 TD,Chad,UN-MAFRICA|Africa|GLO|RoW
 TF,French Southern and Antarctic Lands,GLO|RoW
 TG,Togo,UN-WAFRICA|Africa|GLO|RoW
@@ -459,7 +461,7 @@ TN,Tunisia,UN-NAFRICA|Africa|GLO|RoW
 TO,Tonga,UN-POLYNESIA|Oceania|GLO|RoW
 TRE,Texas Reliability Entity,US|North America|NAFTA|GLO|RoW
 "TRE, US only",Texas Reliability Entity,US|North America|NAFTA|GLO|RoW
-TT,Trinidad and Tobago,UN-CARIBBEAN|North America|GLO|RoW
+TT,Trinidad and Tobago,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 TV,Tuvalu,UN-POLYNESIA|Oceania|GLO|RoW
 TZ,Tanzania,UN-EAFRICA|Africa|GLO|RoW
 UA,Ukraine,"UN-EEUROPE|Europe, Eastern|Europe|GLO|RoW"
@@ -474,19 +476,19 @@ UN-CAMERICA,Central America,North America|Latin America|GLO|RoW
 UN-CARIBBEAN,Caribbean,North America|Latin America|GLO|RoW
 UN-EAFRICA,Eastern Africa,Africa|GLO|RoW
 UN-EASIA,Eastern Asia,Asia|GLO|RoW
-UN-EEUROPE,Eastern Europe,Europe|GLO|RoW
-UN-EUROPE,"Europe, UN Region",Europe|GLO|RoW
+UN-EEUROPE,Eastern Europe,Europe|RER|GLO|RoW
+UN-EUROPE,"Europe, UN Region",Europe|RER|GLO|RoW
 UN-MAFRICA,Middle Africa,Africa|GLO|RoW
 UN-MELANESIA,Melanesia,Oceania|GLO|RoW
 UN-MICRONESIA,Micronesia,Oceania|GLO|RoW
 UN-NAFRICA,Northern Africa,Africa|GLO|RoW
-UN-NEUROPE,Northern Europe,Europe|GLO|RoW
+UN-NEUROPE,Northern Europe,Europe|RER|GLO|RoW
 UN-OCEANIA,Oceania,Oceania|GLO|RoW
 UN-POLYNESIA,Polynesia,Oceania|GLO|RoW
 UN-SAMERICA,South America (UN region),South America|Latin America|GLO|RoW
 UN-SEASIA,South-Eastern Asia,Asia|GLO|RoW
-UN-SEUROPE,Southern Europe,Europe|GLO|RoW
-UN-WAFRICA,Western Africa,GLO|RoW
+UN-SEUROPE,Southern Europe,Europe|RER|GLO|RoW
+UN-WAFRICA,Western Africa,Africa|GLO|RoW
 UN-WASIA,Western Asia,Asia|GLO|RoW
 US-AK,"United States of America, Alaska",US|North America|NAFTA|GLO|RoW
 US-AL,"United States of America, Alabama",US|North America|NAFTA|GLO|RoW
@@ -502,7 +504,7 @@ US-FL,"United States of America, Florida",US|North America|NAFTA|GLO|RoW
 US-FRCC,Florida Reliability Coordinating Council,US|North America|NAFTA|GLO|RoW
 US-GA,"United States of America, Georgia",US|North America|NAFTA|GLO|RoW
 US-HI,"United States of America, Hawaii",US|North America|NAFTA|GLO|RoW
-US-HICC,HICC,US|North America|NAFTA|GLO|RoW
+US-HICC,Hawaiian Islands Coordinating Council,US|North America|NAFTA|GLO|RoW
 US-IA,"United States of America, Iowa",US|North America|NAFTA|GLO|RoW
 US-ID,"United States of America, Idaho",US|North America|NAFTA|GLO|RoW
 US-IL,"United States of America, Illinois",US|North America|NAFTA|GLO|RoW
@@ -553,14 +555,14 @@ US-WY,"United States of America, Wyoming",US|North America|NAFTA|GLO|RoW
 UY,Uruguay,UN-SAMERICA|South America|Latin America|GLO|RoW
 UZ,Uzbekistan,Central Asia|Asia|GLO|RoW
 VA,Vatican,UN-SEUROPE|Europe|GLO|RoW
-VC,Saint Vincent and the Grenadines,UN-CARIBBEAN|North America|GLO|RoW
+VC,Saint Vincent and the Grenadines,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 VE,Venezuela,UN-SAMERICA|South America|Latin America|GLO|RoW
-VG,British Virgin Islands,UN-CARIBBEAN|North America|GLO|RoW
-VI,United States Virgin Islands,UN-CARIBBEAN|North America|GLO|RoW
+VG,British Virgin Islands,UN-CARIBBEAN|North America|Latin America|GLO|RoW
+VI,United States Virgin Islands,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 VU,Vanuatu,UN-MELANESIA|Oceania|GLO|RoW
 WECC,Western Electricity Coordinating Council,US|North America|NAFTA|GLO|RoW
 "WECC, US only",Western Electricity Coordinating Council,US|North America|NAFTA|GLO|RoW
-WEU,Western Europe,Europe|GLO|RoW|RER
+WEU,Western Europe,Europe|RER|GLO|RoW
 WF,Wallis and Futuna,UN-POLYNESIA|Oceania|GLO|RoW
 WS,Samoa,UN-POLYNESIA|Oceania|GLO|RoW
 World,World,GLO|RoW

--- a/data/geographies.csv
+++ b/data/geographies.csv
@@ -1,35 +1,45 @@
+# Location hierarchy: a code, its display name, and every wider
+# location its data may fall back to, nearest first.
+#
+# Vocabulary and names come from ecoinvent 3.11's own
+# MasterData/Geographies.xml. Containment -- which country sits in
+# which UN M49 subregion and continent -- comes from Natural Earth
+# 1:50m admin-0 (public domain). Codes whose membership is a
+# judgement call, such as the IAI industry areas, carry their
+# region and nothing finer: a wrong parent silently lends one
+# region's characterisation factors to another.
 code,display_name,parents
-FR,France,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-DE,Germany,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-IT,Italy,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-ES,Spain,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-GB,United Kingdom,Europe without Switzerland|Europe without Austria|Europe|RER|ENTSO-E|GLO|RoW
+FR,France,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|WEU|Europe, Western"
+DE,Germany,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|WEU|Europe, Western"
+IT,Italy,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-SEUROPE
+ES,Spain,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-SEUROPE
+GB,United Kingdom,Europe without Switzerland|Europe without Austria|Europe|RER|ENTSO-E|GLO|RoW|UN-NEUROPE
 UK,United Kingdom,Europe without Switzerland|Europe without Austria|Europe|RER|ENTSO-E|GLO|RoW
-PL,Poland,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-NL,Netherlands,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-BE,Belgium,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-AT,Austria,Europe without Switzerland|Europe|EU|RER|ENTSO-E|GLO|RoW
-CH,Switzerland,Europe without Austria|Europe|RER|ENTSO-E|GLO|RoW
-SE,Sweden,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|NORDEL|GLO|RoW
-NO,Norway,Europe without Switzerland|Europe without Austria|Europe|RER|ENTSO-E|NORDEL|GLO|RoW
-DK,Denmark,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|NORDEL|GLO|RoW
-FI,Finland,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|NORDEL|GLO|RoW
-PT,Portugal,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-GR,Greece,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-IE,Ireland,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-CZ,Czech Republic,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-RO,Romania,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-HU,Hungary,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-SK,Slovakia,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-BG,Bulgaria,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-HR,Croatia,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-SI,Slovenia,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-LT,Lithuania,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-LV,Latvia,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-EE,Estonia,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-LU,Luxembourg,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW
-MT,Malta,Europe without Switzerland|Europe without Austria|Europe|EU|RER|GLO|RoW
-CY,Cyprus,Europe without Switzerland|Europe without Austria|Europe|EU|RER|GLO|RoW
+PL,Poland,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-EEUROPE|Europe, Eastern"
+NL,Netherlands,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|WEU|Europe, Western"
+BE,Belgium,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|WEU|Europe, Western"
+AT,Austria,"Europe without Switzerland|Europe|EU|RER|ENTSO-E|GLO|RoW|WEU|Europe, Western"
+CH,Switzerland,"Europe without Austria|Europe|RER|ENTSO-E|GLO|RoW|WEU|Europe, Western"
+SE,Sweden,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|NORDEL|GLO|RoW|UN-NEUROPE
+NO,Norway,Europe without Switzerland|Europe without Austria|Europe|RER|ENTSO-E|NORDEL|GLO|RoW|UN-NEUROPE
+DK,Denmark,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|NORDEL|GLO|RoW|UN-NEUROPE
+FI,Finland,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|NORDEL|GLO|RoW|UN-NEUROPE
+PT,Portugal,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-SEUROPE
+GR,Greece,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-SEUROPE
+IE,Ireland,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-NEUROPE
+CZ,Czech Republic,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-EEUROPE|Europe, Eastern"
+RO,Romania,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-EEUROPE|Europe, Eastern"
+HU,Hungary,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-EEUROPE|Europe, Eastern"
+SK,Slovakia,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-EEUROPE|Europe, Eastern"
+BG,Bulgaria,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-EEUROPE|Europe, Eastern"
+HR,Croatia,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-SEUROPE
+SI,Slovenia,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-SEUROPE
+LT,Lithuania,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-NEUROPE
+LV,Latvia,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-NEUROPE
+EE,Estonia,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|UN-NEUROPE
+LU,Luxembourg,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|GLO|RoW|WEU|Europe, Western"
+MT,Malta,Europe without Switzerland|Europe without Austria|Europe|EU|RER|GLO|RoW|UN-SEUROPE
+CY,Cyprus,Europe without Switzerland|Europe without Austria|Europe|EU|RER|GLO|RoW|UN-WASIA|Asia
 EU,European Union,Europe without Switzerland|Europe without Austria|Europe|RER|GLO|RoW
 EU-27,European Union (27),Europe without Switzerland|Europe without Austria|Europe|EU|RER|GLO|RoW
 EU-28,European Union (28),Europe without Switzerland|Europe without Austria|Europe|EU|RER|GLO|RoW
@@ -41,52 +51,520 @@ Europe without Switzerland,Europe without Switzerland,Europe|RER|GLO|RoW
 Europe without Austria,Europe without Austria,Europe|RER|GLO|RoW
 Europe,Europe,GLO|RoW
 US,United States,North America|NAFTA|GLO|RoW
-CA,Canada,Canada without Quebec|North America|NAFTA|GLO|RoW
-MX,Mexico,North America|Latin America|NAFTA|GLO|RoW
+CA,Canada,North America|NAFTA|GLO|RoW
+MX,Mexico,North America|Latin America|NAFTA|GLO|RoW|UN-CAMERICA
 NAFTA,NAFTA,North America|GLO|RoW
 Canada without Quebec,Canada without Quebec,North America|CA|NAFTA|GLO|RoW
 North America,North America,GLO|RoW
 RNA,Rest of North America,North America|GLO|RoW
-CN,China,Asia|GLO|RoW
-JP,Japan,Asia|GLO|RoW
-KR,South Korea,Asia|GLO|RoW
-IN,India,Asia|GLO|RoW
-IN-Southern grid,India (Southern grid),IN|Asia|GLO|RoW
-IN-North-eastern grid,India (North-eastern grid),IN|Asia|GLO|RoW
-IN-Eastern grid,India (Eastern grid),IN|Asia|GLO|RoW
-IN-Northern grid,India (Northern grid),IN|Asia|GLO|RoW
-IN-Western grid,India (Western grid),IN|Asia|GLO|RoW
-TW,Taiwan,Asia|GLO|RoW
-ID,Indonesia,Asia|GLO|RoW
-TH,Thailand,Asia|GLO|RoW
-MY,Malaysia,Asia|GLO|RoW
-VN,Vietnam,Asia|GLO|RoW
-PH,Philippines,Asia|GLO|RoW
-SG,Singapore,Asia|GLO|RoW
+CN,China,Asia|GLO|RoW|UN-EASIA
+JP,Japan,Asia|GLO|RoW|UN-EASIA
+KR,South Korea,Asia|GLO|RoW|UN-EASIA
+IN,India,Asia|GLO|RoW|SAS
+IN-Southern grid,India (Southern grid),IN|Asia|GLO|RoW|SAS
+IN-North-eastern grid,India (North-eastern grid),IN|Asia|GLO|RoW|SAS
+IN-Eastern grid,India (Eastern grid),IN|Asia|GLO|RoW|SAS
+IN-Northern grid,India (Northern grid),IN|Asia|GLO|RoW|SAS
+IN-Western grid,India (Western grid),IN|Asia|GLO|RoW|SAS
+TW,Taiwan,Asia|GLO|RoW|UN-EASIA
+ID,Indonesia,"Asia|GLO|RoW|UN-SEASIA|Asia, South East"
+TH,Thailand,"Asia|GLO|RoW|UN-SEASIA|Asia, South East"
+MY,Malaysia,"Asia|GLO|RoW|UN-SEASIA|Asia, South East"
+VN,Vietnam,"Asia|GLO|RoW|UN-SEASIA|Asia, South East"
+PH,Philippines,"Asia|GLO|RoW|UN-SEASIA|Asia, South East"
+SG,Singapore,"Asia|GLO|RoW|UN-SEASIA|Asia, South East"
 Asia,Asia,GLO|RoW
 RAS,Rest of Asia,Asia|GLO|RoW
-BR,Brazil,Latin America|South America|GLO|RoW
-AR,Argentina,Latin America|South America|GLO|RoW
-CL,Chile,Latin America|South America|GLO|RoW
-CO,Colombia,Latin America|South America|GLO|RoW
-PE,Peru,Latin America|South America|GLO|RoW
+BR,Brazil,Latin America|South America|GLO|RoW|UN-SAMERICA
+AR,Argentina,Latin America|South America|GLO|RoW|UN-SAMERICA
+CL,Chile,Latin America|South America|GLO|RoW|UN-SAMERICA
+CO,Colombia,Latin America|South America|GLO|RoW|UN-SAMERICA
+PE,Peru,Latin America|South America|GLO|RoW|UN-SAMERICA
 Latin America,Latin America,GLO|RoW
 South America,South America,Latin America|GLO|RoW
 RLA,Rest of Latin America,Latin America|GLO|RoW
 ZA,South Africa,Africa|GLO|RoW
-EG,Egypt,Africa|Middle East|GLO|RoW
-NG,Nigeria,Africa|GLO|RoW
-MA,Morocco,Africa|GLO|RoW
+EG,Egypt,Africa|Middle East|GLO|RoW|UN-NAFRICA
+NG,Nigeria,Africa|GLO|RoW|UN-WAFRICA
+MA,Morocco,Africa|GLO|RoW|UN-NAFRICA
 Africa,Africa,GLO|RoW
 RAF,Rest of Africa,Africa|GLO|RoW
-AU,Australia,Oceania|GLO|RoW
-NZ,New Zealand,Oceania|GLO|RoW
+AU,Australia,Oceania|GLO|RoW|UN-AUSTRALIANZ
+NZ,New Zealand,Oceania|GLO|RoW|UN-AUSTRALIANZ
 Oceania,Oceania,GLO|RoW
-SA,Saudi Arabia,Middle East|Asia|GLO|RoW
-AE,United Arab Emirates,Middle East|Asia|GLO|RoW
-IL,Israel,Middle East|GLO|RoW
-TR,Turkey,Middle East|Europe|GLO|RoW
+SA,Saudi Arabia,Middle East|Asia|GLO|RoW|UN-WASIA
+AE,United Arab Emirates,Middle East|Asia|GLO|RoW|UN-WASIA
+IL,Israel,Middle East|GLO|RoW|UN-WASIA|Asia
+TR,Turkey,Middle East|Europe|GLO|RoW|UN-WASIA|Asia
 Middle East,Middle East,GLO|RoW
 RME,Rest of Middle East,Middle East|GLO|RoW
 GLO,Global,RoW
 RoW,Rest of World,GLO
+AD,Andorra,UN-SEUROPE|Europe|GLO|RoW
+AF,Afghanistan,SAS|Asia|GLO|RoW
+AG,Antigua and Barbuda,UN-CARIBBEAN|North America|GLO|RoW
+AI,Anguilla,UN-CARIBBEAN|North America|GLO|RoW
+AL,Albania,UN-SEUROPE|Europe|GLO|RoW
+AM,Armenia,UN-WASIA|Asia|GLO|RoW
+AO,Angola,UN-MAFRICA|Africa|GLO|RoW
+AQ,Antarctica,GLO|RoW
+AS,American Samoa,UN-POLYNESIA|Oceania|GLO|RoW
+ASCC,Alaska Systems Coordinating Council,US|North America|NAFTA|GLO|RoW
+"ASCC, US only",Alaska Systems Coordinating Council,US|North America|NAFTA|GLO|RoW
+AU-AC,"Australia, Ashmore and Cartier Islands",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
+AU-ACT,"Australia, Australian Capital Territory",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
+AU-IOT,"Australia, Indian Ocean Territories",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
+AU-JBT,"Australia, Jervis Bay Territory",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
+AU-NSW,"Australia, New South Wales",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
+AU-NT,"Australia, Northern Territory",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
+AU-QLD,"Australia, Queensland",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
+AU-SA,"Australia, South Australia",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
+AU-TAS,"Australia, Tasmania",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
+AU-VIC,"Australia, Victoria",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
+AU-WA,"Australia, Western Australia",AU|Oceania|GLO|RoW|UN-AUSTRALIANZ
+AW,Aruba,UN-CARIBBEAN|North America|GLO|RoW
+AX,Aland,UN-NEUROPE|Europe|GLO|RoW
+AZ,Azerbaijan,UN-WASIA|Asia|GLO|RoW
+Akrotiri,Akrotiri Sovereign Base Area,Asia|GLO|RoW
+Asia without China,Asia without China,Asia|GLO|RoW
+"Asia, South East",South-Eastern Asia,Asia|GLO|RoW
+"Australia, including overseas territorie","Australia, including overseas territories",AU|Oceania|GLO|RoW
+BA,Bosnia and Herzegovina,UN-SEUROPE|Europe|GLO|RoW
+BALTSO,Baltic System Operator,Europe|RER|ENTSO-E|GLO|RoW
+BB,Barbados,UN-CARIBBEAN|North America|GLO|RoW
+BD,Bangladesh,SAS|Asia|GLO|RoW
+BF,Burkina Faso,UN-WAFRICA|Africa|GLO|RoW
+BH,Bahrain,UN-WASIA|Asia|GLO|RoW
+BI,Burundi,UN-EAFRICA|Africa|GLO|RoW
+BJ,Benin,UN-WAFRICA|Africa|GLO|RoW
+BL,Saint Barthelemy,UN-CARIBBEAN|North America|GLO|RoW
+BM,Bermuda,North America|GLO|RoW
+BN,Brunei,"UN-SEASIA|Asia, South East|Asia|GLO|RoW"
+BO,Bolivia,UN-SAMERICA|South America|Latin America|GLO|RoW
+BR-AC,"Brazil, Acre",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-AL,"Brazil, Alagoas",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-AM,"Brazil, Amazonas",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-AP,"Brazil, Amapá",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-BA,"Brazil, Bahia",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-CE,"Brazil, Ceará",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-DF,"Brazil, Distrito Federal",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-ES,"Brazil, Espírito Santo",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-GO,"Brazil, Goiás",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-MA,"Brazil, Maranhão",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-MG,"Brazil, Minas Gerais",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-MS,"Brazil, Mato Grosso do Sul",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-MT,"Brazil, Mato Grosso",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-Mid-western grid,"Brazil, Mid-western grid",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-North-eastern grid,"Brazil, North-eastern grid",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-Northern grid,"Brazil, Northern grid",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-PA,"Brazil, Pará",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-PB,"Brazil, Paraíba",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-PE,"Brazil, Pernambuco",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-PI,"Brazil, Piauí",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-PR,"Brazil, Paraná",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-RJ,"Brazil, Rio de Janeiro",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-RN,"Brazil, Rio Grande do Norte",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-RO,"Brazil, Rondônia",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-RR,"Brazil, Roraima",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-RS,"Brazil, Rio Grande do Sul",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-SC,"Brazil, Santa Catarina",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-SE,"Brazil, Sergipe",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-SP,"Brazil, São Paulo",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-South-eastern grid,"Brazil, South-eastern grid",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-South-eastern/Mid-western grid,"Brazil, South-eastern and Mid-western grid",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-Southern grid,"Brazil, Southern grid",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BR-TO,"Brazil, Tocantins",BR|Latin America|South America|GLO|RoW|UN-SAMERICA
+BS,The Bahamas,UN-CARIBBEAN|North America|GLO|RoW
+BT,Bhutan,SAS|Asia|GLO|RoW
+BW,Botswana,Africa|GLO|RoW
+BY,Belarus,"UN-EEUROPE|Europe, Eastern|Europe|GLO|RoW"
+BZ,Belize,UN-CAMERICA|North America|GLO|RoW
+Bajo Nuevo,Bajo Nuevo Bank (Petrel Is.),Latin America|GLO|RoW
+CA-AB,"Canada, Alberta",CA|North America|NAFTA|GLO|RoW
+CA-BC,"Canada, British Columbia",CA|North America|NAFTA|GLO|RoW
+CA-MB,"Canada, Manitoba",CA|North America|NAFTA|GLO|RoW
+CA-NB,"Canada, New Brunswick",CA|North America|NAFTA|GLO|RoW
+CA-NF,"Canada, Newfoundland and Labrador",CA|North America|NAFTA|GLO|RoW
+CA-NS,"Canada, Nova Scotia",CA|North America|NAFTA|GLO|RoW
+CA-NT,"Canada, Northwest Territories",CA|North America|NAFTA|GLO|RoW
+CA-NU,"Canada, Nunavut",CA|North America|NAFTA|GLO|RoW
+CA-ON,"Canada, Ontario",CA|North America|NAFTA|GLO|RoW
+CA-PE,"Canada, Prince Edward Island",CA|North America|NAFTA|GLO|RoW
+CA-QC,"Canada, Québec",CA|North America|NAFTA|GLO|RoW
+CA-SK,"Canada, Saskatchewan",CA|North America|NAFTA|GLO|RoW
+CA-YK,"Canada, Yukon",CA|North America|NAFTA|GLO|RoW
+CD,"Congo, Democratic Republic of the",UN-MAFRICA|Africa|GLO|RoW
+CENTREL,Central European Power Association,Europe|RER|ENTSO-E|GLO|RoW
+CF,Central African Republic,UN-MAFRICA|Africa|GLO|RoW
+CG,Congo,UN-MAFRICA|Africa|GLO|RoW
+CI,Ivory Coast,UN-WAFRICA|Africa|GLO|RoW
+CK,Cook Islands,UN-POLYNESIA|Oceania|GLO|RoW
+CM,Cameroon,UN-MAFRICA|Africa|GLO|RoW
+CN-AH,"China, Anhui (安徽)",CN|Asia|GLO|RoW|UN-EASIA
+CN-BJ,"China, Beijing (北京)",CN|Asia|GLO|RoW|UN-EASIA
+CN-CCG,"China, Central Grid",CN|Asia|GLO|RoW|UN-EASIA
+CN-CQ,"China, Chongqing (重庆)",CN|Asia|GLO|RoW|UN-EASIA
+CN-CSG,"China, China Southern Power Grid",CN|Asia|GLO|RoW|UN-EASIA
+CN-ECGC,"China, East Grid",CN|Asia|GLO|RoW|UN-EASIA
+CN-FJ,"China, Fujian (福建)",CN|Asia|GLO|RoW|UN-EASIA
+CN-GD,"China, Guangdong (广东)",CN|Asia|GLO|RoW|UN-EASIA
+CN-GS,"China, Gansu (甘肃)",CN|Asia|GLO|RoW|UN-EASIA
+CN-GX,"China, Guangxi (广西壮族自治区)",CN|Asia|GLO|RoW|UN-EASIA
+CN-GZ,"China, Guizhou (贵州)",CN|Asia|GLO|RoW|UN-EASIA
+CN-HA,"China, Hainan (海南)",CN|Asia|GLO|RoW|UN-EASIA
+CN-HB,"China, Hebei (河北)",CN|Asia|GLO|RoW|UN-EASIA
+CN-HE,"China, Henan (河南)",CN|Asia|GLO|RoW|UN-EASIA
+CN-HL,"China, Heilongjiang (黑龙江省)",CN|Asia|GLO|RoW|UN-EASIA
+CN-HN,"China, Hunan (湖南)",CN|Asia|GLO|RoW|UN-EASIA
+CN-HU,"China, Hubei (湖北)",CN|Asia|GLO|RoW|UN-EASIA
+CN-JL,"China, Jilin (吉林)",CN|Asia|GLO|RoW|UN-EASIA
+CN-JS,"China, Jiangsu (江苏)",CN|Asia|GLO|RoW|UN-EASIA
+CN-JX,"China, Jiangxi (江西)",CN|Asia|GLO|RoW|UN-EASIA
+CN-LN,"China, Liaoning (辽宁)",CN|Asia|GLO|RoW|UN-EASIA
+CN-NCGC,"China, North Grid",CN|Asia|GLO|RoW|UN-EASIA
+CN-NECG,"China, Northeast Grid",CN|Asia|GLO|RoW|UN-EASIA
+CN-NM,"China, Inner Mongol (内蒙古自治区)",CN|Asia|GLO|RoW|UN-EASIA
+CN-NWG,"China, Northwest Grid",CN|Asia|GLO|RoW|UN-EASIA
+CN-NX,"China, Ningxia (宁夏回族自治区)",CN|Asia|GLO|RoW|UN-EASIA
+CN-QH,"China, Qinghai (青海)",CN|Asia|GLO|RoW|UN-EASIA
+CN-SA,"China, Shaanxi (陕西)",CN|Asia|GLO|RoW|UN-EASIA
+CN-SC,"China, Sichuan (四川)",CN|Asia|GLO|RoW|UN-EASIA
+CN-SD,"China, Shandong (山东)",CN|Asia|GLO|RoW|UN-EASIA
+CN-SGCC,"China, State Grid Corporation of China",CN|Asia|GLO|RoW|UN-EASIA
+CN-SH,"China, Shanghai (上海)",CN|Asia|GLO|RoW|UN-EASIA
+CN-SWG,"China, Southwest Grid",CN|Asia|GLO|RoW|UN-EASIA
+CN-SX,"China, Shanxi (山西)",CN|Asia|GLO|RoW|UN-EASIA
+CN-TJ,"China, Tianjin (天津)",CN|Asia|GLO|RoW|UN-EASIA
+CN-XJ,"China, Xinjiang (新疆维吾尔自治区)",CN|Asia|GLO|RoW|UN-EASIA
+CN-XZ,"China, Xizang (西藏自治区)",CN|Asia|GLO|RoW|UN-EASIA
+CN-YN,"China, Yunnan (云南)",CN|Asia|GLO|RoW|UN-EASIA
+CN-ZJ,"China, Zhejiang (浙江)",CN|Asia|GLO|RoW|UN-EASIA
+CR,Costa Rica,UN-CAMERICA|North America|GLO|RoW
+CU,Cuba,UN-CARIBBEAN|North America|GLO|RoW
+CV,Cape Verde,UN-WAFRICA|Africa|GLO|RoW
+CW,Curaçao,UN-CARIBBEAN|North America|GLO|RoW
+Canada without Alberta,Canada without Alberta,CA|North America|NAFTA|GLO|RoW
+Canada without Alberta and Quebec,Canada without Alberta and Quebec,CA|North America|NAFTA|GLO|RoW
+Canary Islands,Canary Islands,ES|Europe|GLO|RoW
+Central Asia,Central Asia,Asia|GLO|RoW
+China w/o Inner Mongol,China without Inner Mongol,CN|Asia|GLO|RoW
+Clipperton Island,Clipperton Island,Oceania|GLO|RoW
+Coral Sea Islands,Coral Sea Islands,Oceania|GLO|RoW
+Cyprus No Mans Area,Cyprus No Mans Area,Asia|GLO|RoW
+DJ,Djibouti,UN-EAFRICA|Africa|GLO|RoW
+DM,Dominica,UN-CARIBBEAN|North America|GLO|RoW
+DO,Dominican Republic,UN-CARIBBEAN|North America|GLO|RoW
+DZ,Algeria,UN-NAFRICA|Africa|GLO|RoW
+Dhekelia Base,Dhekelia Sovereign Base Area,Asia|GLO|RoW
+EC,Ecuador,UN-SAMERICA|South America|Latin America|GLO|RoW
+EH,Western Sahara,UN-NAFRICA|Africa|GLO|RoW
+ER,Eritrea,UN-EAFRICA|Africa|GLO|RoW
+ET,Ethiopia,UN-EAFRICA|Africa|GLO|RoW
+Europe without NORDEL (NCPA),Europe without NORDEL (NCPA),Europe|RER|GLO|RoW
+Europe without Switzerland and Austria,Europe without Switzerland and Austria,Europe|RER|GLO|RoW
+Europe without Switzerland and France,Europe without Switzerland and France,Europe|RER|GLO|RoW
+"Europe, Eastern",Eastern Europe,Europe|GLO|RoW
+"Europe, Western",Western Europe,Europe|GLO|RoW
+"Europe, without Russia and Türkiye","Europe, without Russia and Türkiye",Europe|RER|GLO|RoW
+FJ,Fiji,UN-MELANESIA|Oceania|GLO|RoW
+FK,Falkland Islands,UN-SAMERICA|South America|Latin America|GLO|RoW
+FM,"Micronesia, Federated States of",UN-MICRONESIA|Oceania|GLO|RoW
+FO,Faroe Islands,UN-NEUROPE|Europe|GLO|RoW
+FSU,Commonwealth of Independent States,Europe|Asia|GLO|RoW
+"France, including overseas territories","France, including overseas territories",FR|Europe|GLO|RoW
+GA,Gabon,UN-MAFRICA|Africa|GLO|RoW
+GD,Grenada,UN-CARIBBEAN|North America|GLO|RoW
+GE,Georgia,UN-WASIA|Asia|GLO|RoW
+GG,Guernsey,UN-NEUROPE|Europe|GLO|RoW
+GH,Ghana,UN-WAFRICA|Africa|GLO|RoW
+GL,Greenland,North America|GLO|RoW
+GM,Gambia,UN-WAFRICA|Africa|GLO|RoW
+GN,Guinea,UN-WAFRICA|Africa|GLO|RoW
+GP,Guadeloupe,UN-CARIBBEAN|North America|Latin America|GLO|RoW
+GQ,Equatorial Guinea,UN-MAFRICA|Africa|GLO|RoW
+GS,South Georgia and South Sandwich Islands,GLO|RoW
+GT,Guatemala,UN-CAMERICA|North America|GLO|RoW
+GU,Guam,UN-MICRONESIA|Oceania|GLO|RoW
+GW,Guinea Bissau,UN-WAFRICA|Africa|GLO|RoW
+GY,Guyana,UN-SAMERICA|South America|Latin America|GLO|RoW
+Guantanamo Bay,US Naval Base Guantanamo Bay,CU|Latin America|GLO|RoW
+HICC,Hawaiian Islands Coordinating Council,US|North America|NAFTA|GLO|RoW
+"HICC, US only",Hawaiian Islands Coordinating Council,US|North America|NAFTA|GLO|RoW
+HK,Hong Kong S.A.R.,UN-EASIA|Asia|GLO|RoW
+HM,Heard Island and McDonald Islands,GLO|RoW
+HN,Honduras,UN-CAMERICA|North America|GLO|RoW
+HT,Haiti,UN-CARIBBEAN|North America|GLO|RoW
+"IAI Area, Africa","IAI Area, Africa",Africa|GLO|RoW
+"IAI Area, Asia, without China and GCC","IAI Area, Asia, without China and GCC",Asia|GLO|RoW
+"IAI Area, EU27 & EFTA","IAI Area, EU27 & EFTA",Europe|RER|GLO|RoW
+"IAI Area, Gulf Cooperation Council","IAI Area, Gulf Cooperation Council",Asia|GLO|RoW
+"IAI Area, North America","IAI Area, North America",North America|GLO|RoW
+"IAI Area, North America, without Quebec","IAI Area, North America, without Quebec",North America|GLO|RoW
+"IAI Area, Russia & RER w/o EU27 & EFTA","IAI Area, Russia & Europe outside EU27 & EFTA",Europe|GLO|RoW
+"IAI Area, South America","IAI Area, South America",South America|Latin America|GLO|RoW
+IM,Isle of Man,UN-NEUROPE|Europe|GLO|RoW
+IN-AN,"India, Andaman and Nicobar",IN|Asia|GLO|RoW|SAS
+IN-AP,"India, Andhra Pradesh",IN|Asia|GLO|RoW|SAS
+IN-AR,"India, Arunachal Pradesh",IN|Asia|GLO|RoW|SAS
+IN-AS,"India, Assam",IN|Asia|GLO|RoW|SAS
+IN-BR,"India, Bihar",IN|Asia|GLO|RoW|SAS
+IN-CH,"India, Chandigarh",IN|Asia|GLO|RoW|SAS
+IN-CT,"India, Chhattisgarh",IN|Asia|GLO|RoW|SAS
+IN-DD,"India, Daman and Diu",IN|Asia|GLO|RoW|SAS
+IN-DL,"India, Delhi",IN|Asia|GLO|RoW|SAS
+IN-DN,"India, Dadra and Nagar Haveli",IN|Asia|GLO|RoW|SAS
+IN-GA,"India, Goa",IN|Asia|GLO|RoW|SAS
+IN-GJ,"India, Gujarat",IN|Asia|GLO|RoW|SAS
+IN-HP,"India, Himachal Pradesh",IN|Asia|GLO|RoW|SAS
+IN-HR,"India, Haryana",IN|Asia|GLO|RoW|SAS
+IN-Islands,"India, Islands",IN|Asia|GLO|RoW|SAS
+IN-JH,"India, Jharkhand",IN|Asia|GLO|RoW|SAS
+IN-JK,"India, Jammu and Kashmir",IN|Asia|GLO|RoW|SAS
+IN-KA,"India, Karnataka",IN|Asia|GLO|RoW|SAS
+IN-KL,"India, Kerala",IN|Asia|GLO|RoW|SAS
+IN-LD,"India, Lakshadweep",IN|Asia|GLO|RoW|SAS
+IN-MH,"India, Maharashtra",IN|Asia|GLO|RoW|SAS
+IN-ML,"India, Meghalaya",IN|Asia|GLO|RoW|SAS
+IN-MN,"India, Manipur",IN|Asia|GLO|RoW|SAS
+IN-MP,"India, Madhya Pradesh",IN|Asia|GLO|RoW|SAS
+IN-MZ,"India, Mizoram",IN|Asia|GLO|RoW|SAS
+IN-NL,"India, Nagaland",IN|Asia|GLO|RoW|SAS
+IN-OR,"India, Odisha",IN|Asia|GLO|RoW|SAS
+IN-PB,"India, Punjab",IN|Asia|GLO|RoW|SAS
+IN-PY,"India, Puducherry",IN|Asia|GLO|RoW|SAS
+IN-RJ,"India, Rajasthan",IN|Asia|GLO|RoW|SAS
+IN-SK,"India, Sikkim",IN|Asia|GLO|RoW|SAS
+IN-TN,"India, Tamil Nadu",IN|Asia|GLO|RoW|SAS
+IN-TR,"India, Tripura",IN|Asia|GLO|RoW|SAS
+IN-UP,"India, Uttar Pradesh",IN|Asia|GLO|RoW|SAS
+IN-UT,"India, Uttarakhand",IN|Asia|GLO|RoW|SAS
+IN-WB,"India, West Bengal",IN|Asia|GLO|RoW|SAS
+IO,British Indian Ocean Territory,GLO|RoW
+IQ,Iraq,UN-WASIA|Asia|GLO|RoW
+IR,Iran,SAS|Asia|GLO|RoW
+IS,Iceland,UN-NEUROPE|Europe|GLO|RoW
+JE,Jersey,UN-NEUROPE|Europe|GLO|RoW
+JM,Jamaica,UN-CARIBBEAN|North America|GLO|RoW
+JO,Jordan,UN-WASIA|Asia|GLO|RoW
+KE,Kenya,UN-EAFRICA|Africa|GLO|RoW
+KG,Kyrgyzstan,Central Asia|Asia|GLO|RoW
+KH,Cambodia,"UN-SEASIA|Asia, South East|Asia|GLO|RoW"
+KI,Kiribati,UN-MICRONESIA|Oceania|GLO|RoW
+KM,Comoros,UN-EAFRICA|Africa|GLO|RoW
+KN,Saint Kitts and Nevis,UN-CARIBBEAN|North America|GLO|RoW
+KP,North Korea,UN-EASIA|Asia|GLO|RoW
+KW,Kuwait,UN-WASIA|Asia|GLO|RoW
+KY,Cayman Islands,UN-CARIBBEAN|North America|GLO|RoW
+KZ,Kazakhstan,Central Asia|Asia|GLO|RoW
+LA,Laos,"UN-SEASIA|Asia, South East|Asia|GLO|RoW"
+LB,Lebanon,UN-WASIA|Asia|GLO|RoW
+LC,Saint Lucia,UN-CARIBBEAN|North America|GLO|RoW
+LI,Liechtenstein,"WEU|Europe, Western|Europe|GLO|RoW"
+LK,Sri Lanka,SAS|Asia|GLO|RoW
+LR,Liberia,UN-WAFRICA|Africa|GLO|RoW
+LS,Lesotho,Africa|GLO|RoW
+LY,Libya,UN-NAFRICA|Africa|GLO|RoW
+MC,Monaco,"WEU|Europe, Western|Europe|GLO|RoW"
+MD,Moldova,"UN-EEUROPE|Europe, Eastern|Europe|GLO|RoW"
+ME,Montenegro,UN-SEUROPE|Europe|GLO|RoW
+MF,Saint Martin,UN-CARIBBEAN|North America|GLO|RoW
+MG,Madagascar,UN-EAFRICA|Africa|GLO|RoW
+MH,Marshall Islands,UN-MICRONESIA|Oceania|GLO|RoW
+MK,North Macedonia,UN-SEUROPE|Europe|GLO|RoW
+ML,Mali,UN-WAFRICA|Africa|GLO|RoW
+MM,Myanmar,"UN-SEASIA|Asia, South East|Asia|GLO|RoW"
+MN,Mongolia,UN-EASIA|Asia|GLO|RoW
+MO,Macao S.A.R,UN-EASIA|Asia|GLO|RoW
+MP,Northern Mariana Islands,UN-MICRONESIA|Oceania|GLO|RoW
+MQ,Martinique,UN-CARIBBEAN|North America|Latin America|GLO|RoW
+MR,Mauritania,UN-WAFRICA|Africa|GLO|RoW
+MRO,Midwest Reliability Organization,US|North America|NAFTA|GLO|RoW
+"MRO, US only",Midwest Reliability Organization,US|North America|NAFTA|GLO|RoW
+MS,Montserrat,UN-CARIBBEAN|North America|GLO|RoW
+MU,Mauritius,UN-EAFRICA|GLO|RoW
+MV,Maldives,SAS|GLO|RoW
+MW,Malawi,UN-EAFRICA|Africa|GLO|RoW
+MZ,Mozambique,UN-EAFRICA|Africa|GLO|RoW
+NA,Namibia,Africa|GLO|RoW
+NC,New Caledonia,UN-MELANESIA|Oceania|GLO|RoW
+NE,Niger,UN-WAFRICA|Africa|GLO|RoW
+NF,Norfolk Island,UN-AUSTRALIANZ|Oceania|GLO|RoW
+NI,Nicaragua,UN-CAMERICA|North America|GLO|RoW
+NP,Nepal,SAS|Asia|GLO|RoW
+NPCC,Northeast Power Coordinating Council,US|North America|NAFTA|GLO|RoW
+"NPCC, US only",Northeast Power Coordinating Council,US|North America|NAFTA|GLO|RoW
+NR,Nauru,UN-MICRONESIA|Oceania|GLO|RoW
+NU,Niue,UN-POLYNESIA|Oceania|GLO|RoW
+North America without Quebec,North America without Quebec,North America|GLO|RoW
+Northern Cyprus,Northern Cyprus,Asia|GLO|RoW
+OM,Oman,UN-WASIA|Asia|GLO|RoW
+PA,Panama,UN-CAMERICA|North America|GLO|RoW
+PF,French Polynesia,UN-POLYNESIA|Oceania|GLO|RoW
+PG,Papua New Guinea,UN-MELANESIA|Oceania|GLO|RoW
+PK,Pakistan,SAS|Asia|GLO|RoW
+PM,Saint Pierre and Miquelon,North America|GLO|RoW
+PN,Pitcairn Islands,UN-POLYNESIA|Oceania|GLO|RoW
+PR,PR,UN-CARIBBEAN|North America|GLO|RoW
+PS,Palestine,UN-WASIA|Asia|GLO|RoW
+PW,Palau,UN-MICRONESIA|Oceania|GLO|RoW
+PY,Paraguay,UN-SAMERICA|South America|Latin America|GLO|RoW
+QA,Qatar,UN-WASIA|Asia|GLO|RoW
+RE,Réunion,UN-EAFRICA|Africa|GLO|RoW
+RER w/o AT+BE+CH+DE+FR+IT,"Europe without Austria, Belgium, France, Germany, Italy, Liechtenstein, Monaco, San Marino, Switzerland, and the Vatican",Europe|RER|GLO|RoW
+RER w/o CH+DE,Europe without Germany and Switzerland,Europe|RER|GLO|RoW
+RER w/o DE+NL+NO,"Europe without Germany, the Netherlands, and Norway",Europe|RER|GLO|RoW
+RER w/o DE+NL+NO+RU,"Europe without Germany, the Netherlands, Norway, and Russia",Europe|RER|GLO|RoW
+RER w/o DE+NL+RU,"Europe without Germany, the Netherlands, and Russia",Europe|RER|GLO|RoW
+RER w/o RU,Europe without Russia,Europe|RER|GLO|RoW
+RFC,ReliabilityFirst Corporation,US|North America|NAFTA|GLO|RoW
+"RFC, US only",ReliabilityFirst Corporation,US|North America|NAFTA|GLO|RoW
+RS,Serbia,UN-SEUROPE|Europe|GLO|RoW
+RU,Russia,"UN-EEUROPE|Europe, Eastern|Europe|GLO|RoW"
+RW,Rwanda,UN-EAFRICA|Africa|GLO|RoW
+RoE,Rest of Europe,Europe|GLO|RoW
+Russia (Asia),Russia (Asia),RU|Asia|GLO|RoW
+Russia (Europe),Russia (Europe),RU|Europe|GLO|RoW
+SAS,Southern Asia,Asia|GLO|RoW
+SB,Solomon Islands,UN-MELANESIA|Oceania|GLO|RoW
+SC,Seychelles,UN-EAFRICA|GLO|RoW
+SD,Sudan,UN-NAFRICA|Africa|GLO|RoW
+SERC,SERC Reliability Corporation,US|North America|NAFTA|GLO|RoW
+"SERC, US only",SERC Reliability Corporation,US|North America|NAFTA|GLO|RoW
+SH,Saint Helena,UN-WAFRICA|GLO|RoW
+SL,Sierra Leone,UN-WAFRICA|Africa|GLO|RoW
+SM,San Marino,UN-SEUROPE|Europe|GLO|RoW
+SN,Senegal,UN-WAFRICA|Africa|GLO|RoW
+SO,Somalia,UN-EAFRICA|Africa|GLO|RoW
+SR,Suriname,UN-SAMERICA|South America|Latin America|GLO|RoW
+SS,South Sudan,UN-EAFRICA|Africa|GLO|RoW
+ST,Sao Tome and Principe,UN-MAFRICA|Africa|GLO|RoW
+SV,El Salvador,UN-CAMERICA|North America|GLO|RoW
+SX,Sint Maarten,UN-CARIBBEAN|North America|GLO|RoW
+SY,Syria,UN-WASIA|Asia|GLO|RoW
+SZ,Eswatini,Africa|GLO|RoW
+Scarborough Reef,Scarborough Reef,Asia|GLO|RoW
+Serranilla Bank,Serranilla Bank,Latin America|GLO|RoW
+Siachen Glacier,Siachen Glacier,Asia|GLO|RoW
+Somaliland,Somaliland,Africa|GLO|RoW
+South and Central America,South and Central America,Latin America|GLO|RoW
+Spratly Islands,Spratly Islands,Asia|GLO|RoW
+TC,Turks and Caicos Islands,UN-CARIBBEAN|North America|GLO|RoW
+TD,Chad,UN-MAFRICA|Africa|GLO|RoW
+TF,French Southern and Antarctic Lands,GLO|RoW
+TG,Togo,UN-WAFRICA|Africa|GLO|RoW
+TJ,Tajikistan,Central Asia|Asia|GLO|RoW
+TL,East Timor,"UN-SEASIA|Asia, South East|Asia|GLO|RoW"
+TM,Turkmenistan,Central Asia|Asia|GLO|RoW
+TN,Tunisia,UN-NAFRICA|Africa|GLO|RoW
+TO,Tonga,UN-POLYNESIA|Oceania|GLO|RoW
+TRE,Texas Reliability Entity,US|North America|NAFTA|GLO|RoW
+"TRE, US only",Texas Reliability Entity,US|North America|NAFTA|GLO|RoW
+TT,Trinidad and Tobago,UN-CARIBBEAN|North America|GLO|RoW
+TV,Tuvalu,UN-POLYNESIA|Oceania|GLO|RoW
+TZ,Tanzania,UN-EAFRICA|Africa|GLO|RoW
+UA,Ukraine,"UN-EEUROPE|Europe, Eastern|Europe|GLO|RoW"
+UCTE without France,UCTE without France,Europe|RER|UCTE|GLO|RoW
+UCTE without Germany,UCTE without Germany,Europe|RER|UCTE|GLO|RoW
+UCTE without Germany and France,UCTE without Germany and France,Europe|RER|UCTE|GLO|RoW
+UG,Uganda,UN-EAFRICA|Africa|GLO|RoW
+UN-AMERICAS,Americas,North America|Latin America|GLO|RoW
+UN-ASIA,"Asia, UN Region",Asia|GLO|RoW
+UN-AUSTRALIANZ,Australia and New Zealand,Oceania|GLO|RoW
+UN-CAMERICA,Central America,North America|Latin America|GLO|RoW
+UN-CARIBBEAN,Caribbean,North America|Latin America|GLO|RoW
+UN-EAFRICA,Eastern Africa,Africa|GLO|RoW
+UN-EASIA,Eastern Asia,Asia|GLO|RoW
+UN-EEUROPE,Eastern Europe,Europe|GLO|RoW
+UN-EUROPE,"Europe, UN Region",Europe|GLO|RoW
+UN-MAFRICA,Middle Africa,Africa|GLO|RoW
+UN-MELANESIA,Melanesia,Oceania|GLO|RoW
+UN-MICRONESIA,Micronesia,Oceania|GLO|RoW
+UN-NAFRICA,Northern Africa,Africa|GLO|RoW
+UN-NEUROPE,Northern Europe,Europe|GLO|RoW
+UN-OCEANIA,Oceania,Oceania|GLO|RoW
+UN-POLYNESIA,Polynesia,Oceania|GLO|RoW
+UN-SAMERICA,South America (UN region),South America|Latin America|GLO|RoW
+UN-SEASIA,South-Eastern Asia,Asia|GLO|RoW
+UN-SEUROPE,Southern Europe,Europe|GLO|RoW
+UN-WAFRICA,Western Africa,GLO|RoW
+UN-WASIA,Western Asia,Asia|GLO|RoW
+US-AK,"United States of America, Alaska",US|North America|NAFTA|GLO|RoW
+US-AL,"United States of America, Alabama",US|North America|NAFTA|GLO|RoW
+US-AR,"United States of America, Arkansas",US|North America|NAFTA|GLO|RoW
+US-ASCC,Alaska Systems Coordinating Council,US|North America|NAFTA|GLO|RoW
+US-AZ,"United States of America, Arizona",US|North America|NAFTA|GLO|RoW
+US-CA,"United States of America, California",US|North America|NAFTA|GLO|RoW
+US-CO,"United States of America, Colorado",US|North America|NAFTA|GLO|RoW
+US-CT,"United States of America, Connecticut",US|North America|NAFTA|GLO|RoW
+US-DC,"United States of America, District of Columbia",US|North America|NAFTA|GLO|RoW
+US-DE,"United States of America, Delaware",US|North America|NAFTA|GLO|RoW
+US-FL,"United States of America, Florida",US|North America|NAFTA|GLO|RoW
+US-FRCC,Florida Reliability Coordinating Council,US|North America|NAFTA|GLO|RoW
+US-GA,"United States of America, Georgia",US|North America|NAFTA|GLO|RoW
+US-HI,"United States of America, Hawaii",US|North America|NAFTA|GLO|RoW
+US-HICC,HICC,US|North America|NAFTA|GLO|RoW
+US-IA,"United States of America, Iowa",US|North America|NAFTA|GLO|RoW
+US-ID,"United States of America, Idaho",US|North America|NAFTA|GLO|RoW
+US-IL,"United States of America, Illinois",US|North America|NAFTA|GLO|RoW
+US-IN,"United States of America, Indiana",US|North America|NAFTA|GLO|RoW
+US-KS,"United States of America, Kansas",US|North America|NAFTA|GLO|RoW
+US-KY,"United States of America, Kentucky",US|North America|NAFTA|GLO|RoW
+US-LA,"United States of America, Louisiana",US|North America|NAFTA|GLO|RoW
+US-MA,"United States of America, Massachusetts",US|North America|NAFTA|GLO|RoW
+US-MD,"United States of America, Maryland",US|North America|NAFTA|GLO|RoW
+US-ME,"United States of America, Maine",US|North America|NAFTA|GLO|RoW
+US-MI,"United States of America, Michigan",US|North America|NAFTA|GLO|RoW
+US-MN,"United States of America, Minnesota",US|North America|NAFTA|GLO|RoW
+US-MO,"United States of America, Missouri",US|North America|NAFTA|GLO|RoW
+US-MRO,"Midwest Reliability Organization, US part only",US|North America|NAFTA|GLO|RoW
+US-MS,"United States of America, Mississippi",US|North America|NAFTA|GLO|RoW
+US-MT,"United States of America, Montana",US|North America|NAFTA|GLO|RoW
+US-NC,"United States of America, North Carolina",US|North America|NAFTA|GLO|RoW
+US-ND,"United States of America, North Dakota",US|North America|NAFTA|GLO|RoW
+US-NE,"United States of America, Nebraska",US|North America|NAFTA|GLO|RoW
+US-NH,"United States of America, New Hampshire",US|North America|NAFTA|GLO|RoW
+US-NJ,"United States of America, New Jersey",US|North America|NAFTA|GLO|RoW
+US-NM,"United States of America, New Mexico",US|North America|NAFTA|GLO|RoW
+US-NPCC,"Northeast Power Coordinating Council, US part only",US|North America|NAFTA|GLO|RoW
+US-NV,"United States of America, Nevada",US|North America|NAFTA|GLO|RoW
+US-NY,"United States of America, New York",US|North America|NAFTA|GLO|RoW
+US-OH,"United States of America, Ohio",US|North America|NAFTA|GLO|RoW
+US-OK,"United States of America, Oklahoma",US|North America|NAFTA|GLO|RoW
+US-OR,"United States of America, Oregon",US|North America|NAFTA|GLO|RoW
+US-PA,"United States of America, Pennsylvania",US|North America|NAFTA|GLO|RoW
+US-PR,Puerto Rico,US|North America|NAFTA|GLO|RoW
+US-RFC,ReliabilityFirst Corporation,US|North America|NAFTA|GLO|RoW
+US-RI,"United States of America, Rhode Island",US|North America|NAFTA|GLO|RoW
+US-SC,"United States of America, South Carolina",US|North America|NAFTA|GLO|RoW
+US-SD,"United States of America, South Dakota",US|North America|NAFTA|GLO|RoW
+US-SERC,SERC Reliability Corporation,US|North America|NAFTA|GLO|RoW
+US-SPP,Southwest Power Pool,US|North America|NAFTA|GLO|RoW
+US-TN,"United States of America, Tennessee",US|North America|NAFTA|GLO|RoW
+US-TRE,Texas Regional Entity,US|North America|NAFTA|GLO|RoW
+US-TX,"United States of America, Texas",US|North America|NAFTA|GLO|RoW
+US-UT,"United States of America, Utah",US|North America|NAFTA|GLO|RoW
+US-VA,"United States of America, Virginia",US|North America|NAFTA|GLO|RoW
+US-VT,"United States of America, Vermont",US|North America|NAFTA|GLO|RoW
+US-WA,"United States of America, Washington",US|North America|NAFTA|GLO|RoW
+US-WECC,"Western Electricity Coordinating Council, US part only",US|North America|NAFTA|GLO|RoW
+US-WI,"United States of America, Wisconsin",US|North America|NAFTA|GLO|RoW
+US-WV,"United States of America, West Virginia",US|North America|NAFTA|GLO|RoW
+US-WY,"United States of America, Wyoming",US|North America|NAFTA|GLO|RoW
+UY,Uruguay,UN-SAMERICA|South America|Latin America|GLO|RoW
+UZ,Uzbekistan,Central Asia|Asia|GLO|RoW
+VA,Vatican,UN-SEUROPE|Europe|GLO|RoW
+VC,Saint Vincent and the Grenadines,UN-CARIBBEAN|North America|GLO|RoW
+VE,Venezuela,UN-SAMERICA|South America|Latin America|GLO|RoW
+VG,British Virgin Islands,UN-CARIBBEAN|North America|GLO|RoW
+VI,United States Virgin Islands,UN-CARIBBEAN|North America|GLO|RoW
+VU,Vanuatu,UN-MELANESIA|Oceania|GLO|RoW
+WECC,Western Electricity Coordinating Council,US|North America|NAFTA|GLO|RoW
+"WECC, US only",Western Electricity Coordinating Council,US|North America|NAFTA|GLO|RoW
+WEU,Western Europe,Europe|GLO|RoW|RER
+WF,Wallis and Futuna,UN-POLYNESIA|Oceania|GLO|RoW
+WS,Samoa,UN-POLYNESIA|Oceania|GLO|RoW
+World,World,GLO|RoW
+XK,Kosovo,UN-SEUROPE|Europe|GLO|RoW
+YE,Yemen,UN-WASIA|Asia|GLO|RoW
+ZM,Zambia,UN-EAFRICA|Africa|GLO|RoW
+ZW,Zimbabwe,UN-EAFRICA|Africa|GLO|RoW

--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -943,6 +943,11 @@ placelessLocations = map Location ["GLO", "RoW", "Unspecified"]
 
 {- | Location hierarchy for common LCA regions
 Maps a location code to its parent regions
+
+The floor, not the table: a configuration that names no geographies file gets
+this. Every shipped configuration points at @data/geographies.csv@, which is
+where a location belongs — it covers the whole ecoinvent vocabulary, this
+covers the handful of regions needed to start up without it.
 -}
 locationHierarchy :: M.Map Location [Location]
 locationHierarchy = M.mapKeysMonotonic Location (M.map (map Location) rawLocationHierarchy)

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -126,8 +126,9 @@ import Data.Aeson (FromJSON (..), ToJSON (..), (.:), (.:?), (.=))
 import qualified Data.Aeson as A
 import Data.Bifunctor (first)
 import Data.Char (toLower)
+import qualified Data.Csv as Csv
 import Data.Either (lefts, partitionEithers, rights)
-import Data.List (isPrefixOf, sort, sortOn, unsnoc)
+import Data.List (isPrefixOf, sort, sortOn)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing)
@@ -136,6 +137,7 @@ import Data.Ord (Down (..))
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import GHC.Generics (Generic)
@@ -941,7 +943,15 @@ initDatabaseManager config noCache configPath = do
 
     geographies <- case cfgGeographies config of
         Nothing -> return M.empty
-        Just path -> parseGeographiesCSV (resolveRelative path)
+        Just path -> do
+            result <- parseGeographiesCSV (resolveRelative path)
+            case result of
+                Right geos -> pure geos
+                -- Falling back to the built-in hierarchy silently would change
+                -- every regionalized score without anyone asking for it.
+                Left err -> do
+                    putStrLn $ "warning: could not load geographies from " <> T.unpack err
+                    pure M.empty
 
     methodMappingCacheVar <- newTVarIO M.empty
     methodTablesCacheVar <- newTVarIO M.empty
@@ -3637,38 +3647,45 @@ removeUnitDefs = removeRefDataG unitDefOps
 
 {- | Parse a geographies CSV file (code,display_name,parents) into a lookup map.
 Parents field uses '|' as separator. display_name is optional (falls back to code).
-Lines starting with "code" are treated as headers and skipped.
+Comment lines start with '#', and the header row starts with "code".
+
+Quoting is the reason this goes through a real CSV reader rather than splitting
+on commas: several location codes carry one -- @Europe, Western@,
+@IAI Area, EU27 & EFTA@ -- and a hand-split would cut them in half, turning a
+region into two codes that match nothing.
 -}
-parseGeographiesCSV :: FilePath -> IO (Map Text (Text, [Text]))
+parseGeographiesCSV :: FilePath -> IO (Either Text (Map Text (Text, [Text])))
 parseGeographiesCSV path = do
     exists <- doesFileExist path
     if not exists
         then do
             reportProgress Info $ "Geographies file not found: " <> path <> " (using built-in hierarchy)"
-            return M.empty
+            return (Right M.empty)
         else do
             content <- TIO.readFile path
-            let ls = T.lines content
-                parsed = concatMap parseLine ls
-            reportProgress Info $ "Loaded " <> show (length parsed) <> " geographies from " <> path
-            return $ M.fromList parsed
+            let body = T.unlines (filter meaningful (T.lines content))
+            case Csv.decode Csv.NoHeader (BL.fromStrict (TE.encodeUtf8 body)) of
+                Left err -> return $ Left $ T.pack path <> ": " <> T.pack err
+                Right rows -> do
+                    let parsed = map entry (V.toList rows)
+                    reportProgress Info $ "Loaded " <> show (length parsed) <> " geographies from " <> path
+                    return $ Right $ M.fromList parsed
   where
-    parseLine line
-        | T.null (T.strip line) = []
-        | "code" `T.isPrefixOf` line = [] -- header row
-        | "#" `T.isPrefixOf` T.strip line = [] -- comment
-        | otherwise = case T.splitOn "," line of
-            [] -> []
-            [_] -> []
-            parts@(codeRaw : _) -> case unsnoc parts of
-                Nothing -> [] -- unreachable: parts is non-empty by pattern
-                Just (initPart, parentsRaw) ->
-                    let code = T.strip codeRaw
-                        parentsStr = T.strip parentsRaw
-                        displayRaw = T.intercalate "," (drop 1 initPart)
-                        displayName = let d = T.strip displayRaw in if T.null d then code else d
-                        parents = if T.null parentsStr then [] else T.splitOn "|" parentsStr
-                     in [(code, (displayName, parents))]
+    meaningful line =
+        let stripped = T.strip line
+         in not (T.null stripped)
+                && not ("#" `T.isPrefixOf` stripped)
+                && not ("code," `T.isPrefixOf` stripped)
+    entry (codeRaw, displayRaw, parentsRaw) =
+        let code = T.strip codeRaw
+            display = T.strip displayRaw
+            parents = T.strip parentsRaw
+         in ( code
+            ,
+                ( if T.null display then code else display
+                , if T.null parents then [] else T.splitOn "|" parents
+                )
+            )
 
 -- | Load CSV file content from path.
 loadRefDataCSV :: FilePath -> IO (Either Text BL.ByteString)

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -238,7 +238,6 @@ import qualified UnitConversion
 -- CrossDBLinkingStats is now in Types, re-exported from Database.Loader
 
 import API.Types (DepLoadResult (..))
-import qualified Data.Text.IO as TIO
 import Database.CrossLinking (IndexedDatabase (..), LinkingContext (..), buildIndexedDatabaseFromDB, defaultLinkingThreshold)
 import qualified Database.CrossLinking as CrossLinking
 import Database.Upload (detectMethodFormat, detectedFormatLabel, findMethodDirectory, listDirectoryRecursive)
@@ -950,7 +949,7 @@ initDatabaseManager config noCache configPath = do
                 -- Falling back to the built-in hierarchy silently would change
                 -- every regionalized score without anyone asking for it.
                 Left err -> do
-                    putStrLn $ "warning: could not load geographies from " <> T.unpack err
+                    reportProgress Warning $ "Could not load geographies from " <> T.unpack err <> " — using built-in hierarchy"
                     pure M.empty
 
     methodMappingCacheVar <- newTVarIO M.empty
@@ -3662,14 +3661,26 @@ parseGeographiesCSV path = do
             reportProgress Info $ "Geographies file not found: " <> path <> " (using built-in hierarchy)"
             return (Right M.empty)
         else do
-            content <- TIO.readFile path
-            let body = T.unlines (filter meaningful (T.lines content))
-            case Csv.decode Csv.NoHeader (BL.fromStrict (TE.encodeUtf8 body)) of
-                Left err -> return $ Left $ T.pack path <> ": " <> T.pack err
-                Right rows -> do
-                    let parsed = map entry (V.toList rows)
-                    reportProgress Info $ "Loaded " <> show (length parsed) <> " geographies from " <> path
-                    return $ Right $ M.fromList parsed
+            -- Decode the bytes as UTF-8 ourselves: the file carries non-ASCII
+            -- display names, and a locale-driven read would give mojibake or
+            -- a crash on a non-UTF-8 system.
+            bytes <- BS.readFile path
+            case TE.decodeUtf8' bytes of
+                Left decodeErr -> return $ Left $ T.pack path <> ": not valid UTF-8 (" <> T.pack (show decodeErr) <> ")"
+                Right content -> do
+                    let body = T.unlines (filter meaningful (T.lines content))
+                    case Csv.decode Csv.NoHeader (BL.fromStrict (TE.encodeUtf8 body)) of
+                        Left err -> return $ Left $ T.pack path <> ": " <> T.pack err
+                        Right rows -> do
+                            let parsed = map entry (V.toList rows)
+                                dups = M.keys (M.filter (> (1 :: Int)) (M.fromListWith (+) [(fst p, 1) | p <- parsed]))
+                            if null dups
+                                then do
+                                    reportProgress Info $ "Loaded " <> show (length parsed) <> " geographies from " <> path
+                                    return $ Right $ M.fromList parsed
+                                else -- A duplicated code would silently shadow the earlier
+                                -- row in the map; refuse the file instead.
+                                    return $ Left $ T.pack path <> ": duplicate codes: " <> T.intercalate ", " dups
   where
     meaningful line =
         let stripped = T.strip line

--- a/test/GeographiesSpec.hs
+++ b/test/GeographiesSpec.hs
@@ -75,20 +75,40 @@ spec = do
             dangling `shouldBe` []
 
         it "no location is its own ancestor" $ do
-            -- Two locations that each list the other as a parent make
-            -- "wider than" meaningless: the matcher would accept either as a
-            -- fallback for the other, in both directions. GLO and RoW are the
+            -- A cycle through the parent lists makes "wider than"
+            -- meaningless: two locations on it would each be accepted as a
+            -- fallback for the other, in both directions. Checked
+            -- transitively, not just for mutual pairs. GLO and RoW are the
             -- deliberate exception — they are the same breadth.
             geos <- table
-            let mutual =
-                    [ (code, parent)
-                    | (code, (_, parents)) <- M.toList geos
-                    , parent <- parents
-                    , code `elem` maybe [] snd (M.lookup parent geos)
-                    , [code, parent] /= ["GLO", "RoW"]
-                    , [code, parent] /= ["RoW", "GLO"]
+            let parentsOf c = maybe [] snd (M.lookup c geos)
+                ancestors c = go [] (parentsOf c)
+                  where
+                    go seen [] = seen
+                    go seen (p : ps)
+                        | p `elem` seen = go seen ps
+                        | otherwise = go (p : seen) (parentsOf p ++ ps)
+                cyclic =
+                    [ code
+                    | code <- M.keys geos
+                    , code `notElem` ["GLO", "RoW"]
+                    , code `elem` ancestors code
                     ]
-            mutual `shouldBe` []
+            cyclic `shouldBe` []
+
+        it "GLO and RoW close every parents list" $ do
+            -- The regionalized CF cascade walks the parents in order and
+            -- stops at the first factor it finds, so a parent listed after
+            -- the global codes could never beat the global average — exactly
+            -- the fallback the nearer parents exist to improve on.
+            geos <- table
+            let placeless = ["GLO", "RoW"] :: [Text]
+                misordered =
+                    [ code
+                    | (code, (_, parents)) <- M.toList geos
+                    , any (`notElem` placeless) (dropWhile (`notElem` placeless) parents)
+                    ]
+            misordered `shouldBe` []
 
         it "keeps a code that contains a comma in one piece" $ do
             -- "Europe, Western" is one location, not a code called "Europe"
@@ -136,4 +156,17 @@ spec = do
         it "does not offer one Brazilian state to another" $ do
             hier <- hierarchy
             acceptableLocation GeoParent hier (Location "BR-MG") (Location "BR-SP")
+                `shouldBe` Nothing
+
+        it "offers the country-plus-territories aggregate to the bare country" $ do
+            -- Same shape as the Canada / "Canada without Quebec" correction:
+            -- "France, including overseas territories" is wider than FR, so
+            -- the aggregate is a fallback for France — never the reverse.
+            hier <- hierarchy
+            acceptableLocation GeoParent hier (Location "FR") (Location "France, including overseas territories")
+                `shouldBe` Just ParentLoc
+
+        it "refuses bare-country data for the country-plus-territories aggregate" $ do
+            hier <- hierarchy
+            acceptableLocation GeoParent hier (Location "France, including overseas territories") (Location "FR")
                 `shouldBe` Nothing

--- a/test/GeographiesSpec.hs
+++ b/test/GeographiesSpec.hs
@@ -9,8 +9,24 @@ global behavior.
 module GeographiesSpec (spec) where
 
 import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import Database.CrossLinking (acceptableLocation)
 import Database.Manager (parseGeographiesCSV)
+import Method.Types (Location (..))
 import Test.Hspec
+import Types (GeographyPolicy (..), LocationKind (..))
+
+table :: IO (M.Map Text (Text, [Text]))
+table = do
+    parsed <- parseGeographiesCSV "data/geographies.csv"
+    case parsed of
+        Right geos -> pure geos
+        Left err -> fail (T.unpack err)
+
+-- | The table in the shape the matcher reads it: codes wrapped, parents wrapped.
+hierarchy :: IO (M.Map Location [Location])
+hierarchy = M.map (map Location . snd) . M.mapKeysMonotonic Location <$> table
 
 spec :: Spec
 spec = do
@@ -20,7 +36,7 @@ spec = do
             -- "Rest of World" CF lookup failed instead of falling back to
             -- the global value — silently underestimating impact for every
             -- ecoinvent activity whose location is RoW.
-            geos <- parseGeographiesCSV "data/geographies.csv"
+            geos <- table
             case M.lookup "RoW" geos of
                 Just (display, parents) -> do
                     display `shouldBe` "Rest of World"
@@ -28,7 +44,7 @@ spec = do
                 Nothing -> expectationFailure "RoW missing from geographies.csv"
 
         it "GLO cascades to RoW (existing fallback, regression gate)" $ do
-            geos <- parseGeographiesCSV "data/geographies.csv"
+            geos <- table
             case M.lookup "GLO" geos of
                 Just (_, parents) -> parents `shouldBe` ["RoW"]
                 Nothing -> expectationFailure "GLO missing from geographies.csv"
@@ -37,10 +53,87 @@ spec = do
             -- Sanity check that no other row regresses to the empty-parents
             -- state RoW used to have. The only leaves are GLO and RoW
             -- themselves (mutual fallback between the two).
-            geos <- parseGeographiesCSV "data/geographies.csv"
+            geos <- table
             let orphaned =
                     [ code
                     | (code, (_, parents)) <- M.toList geos
                     , null parents
                     ]
             orphaned `shouldBe` []
+
+        it "every parent is itself a row" $ do
+            -- A parent nobody defines ends the cascade one step early and
+            -- without saying so: the lookup for that step finds nothing and
+            -- the walk stops, short of GLO.
+            geos <- table
+            let dangling =
+                    [ (code, parent)
+                    | (code, (_, parents)) <- M.toList geos
+                    , parent <- parents
+                    , not (M.member parent geos)
+                    ]
+            dangling `shouldBe` []
+
+        it "no location is its own ancestor" $ do
+            -- Two locations that each list the other as a parent make
+            -- "wider than" meaningless: the matcher would accept either as a
+            -- fallback for the other, in both directions. GLO and RoW are the
+            -- deliberate exception — they are the same breadth.
+            geos <- table
+            let mutual =
+                    [ (code, parent)
+                    | (code, (_, parents)) <- M.toList geos
+                    , parent <- parents
+                    , code `elem` maybe [] snd (M.lookup parent geos)
+                    , [code, parent] /= ["GLO", "RoW"]
+                    , [code, parent] /= ["RoW", "GLO"]
+                    ]
+            mutual `shouldBe` []
+
+        it "keeps a code that contains a comma in one piece" $ do
+            -- "Europe, Western" is one location, not a code called "Europe"
+            -- with a stray field after it. Splitting the line on commas used
+            -- to cut it in half, which is why the file goes through a real
+            -- CSV reader.
+            geos <- table
+            case M.lookup "Europe, Western" geos of
+                Just (display, parents) -> do
+                    display `shouldBe` "Western Europe"
+                    parents `shouldContain` ["Europe"]
+                Nothing -> expectationFailure "\"Europe, Western\" missing from geographies.csv"
+
+        it "puts a country in its UN subregion, not just its continent" $ do
+            -- The subregion memberships are what make a regional dataset
+            -- usable for a country: without them a French activity can only
+            -- fall back to Europe, and from there straight to the global
+            -- average.
+            geos <- table
+            case M.lookup "FR" geos of
+                Just (_, parents) -> parents `shouldContain` ["Europe, Western"]
+                Nothing -> expectationFailure "FR missing from geographies.csv"
+
+    describe "what the cascade lets the matcher accept" $ do
+        it "offers a Western European dataset to a French activity" $ do
+            -- The point of the table, stated as behaviour rather than as
+            -- rows: a location the file does not know is Unrelated, which
+            -- only the loosest policy accepts and only as a global caveat.
+            hier <- hierarchy
+            acceptableLocation GeoParent hier (Location "FR") (Location "Europe, Western")
+                `shouldBe` Just ParentLoc
+
+        it "refuses to pass a French dataset off as Western European" $ do
+            -- The other direction is narrowing: France is one member of the
+            -- region, so its data must not stand in for the whole of it.
+            hier <- hierarchy
+            acceptableLocation GeoParent hier (Location "Europe, Western") (Location "FR")
+                `shouldBe` Nothing
+
+        it "offers Brazil to one of its states" $ do
+            hier <- hierarchy
+            acceptableLocation GeoParent hier (Location "BR-MG") (Location "BR")
+                `shouldBe` Just ParentLoc
+
+        it "does not offer one Brazilian state to another" $ do
+            hier <- hierarchy
+            acceptableLocation GeoParent hier (Location "BR-MG") (Location "BR-SP")
+                `shouldBe` Nothing


### PR DESCRIPTION
The geography table decides what a characterisation factor may fall back to when none exists for the exact location asked for. It listed 91 codes. The databases use several hundred.

In Agribalyse 3.2 alone, 138 of the 215 distinct locations were absent, covering 1558 of its 21510 activities — Kenya, Ukraine, most of Brazil's states, every North American grid, and `Europe, Western`, which 863 activities use. An absent code has no wider location at all, so `isSubregionOf` answers no in every direction and the lookup falls straight through to the global average. Nothing says so.

Two things were wrong, so this is two commits.

**The reader.** The file was split on commas without regard for quoting. A location whose own name contains one — `Europe, Western`, `IAI Area, EU27 & EFTA`, `WECC, US only` — parsed as a code called `Europe` followed by a stray field. Those regions could not be written down at all, whatever the table said. It now goes through the CSV reader the rest of the engine already uses, and a file it cannot parse is reported rather than quietly replaced by the built-in fallback table — that substitution would change every regionalized score without anyone asking for it.

**The table.** It now covers ecoinvent's whole vocabulary, taken from that database's own `MasterData/Geographies.xml` so the codes and names are its, not mine. Containment is derived, not guessed: Natural Earth's public-domain country polygons carry each country's UN M49 subregion and continent, a province or grid sits inside the country its code names, and a code whose membership is a judgement call — the aluminium industry's IAI areas, the "Europe without X" variants — carries its region and nothing finer. A wrong parent lends one region's factors to another, which is worse than no fallback at all. Every existing row keeps every parent it had; the table only grows.

One correction on the way through: Canada listed "Canada without Quebec" among its parents while that row listed Canada among its own, so each was the other's fallback in both directions. A country is not inside itself minus a province.

## Checked

The suite is green, 1879 examples. `GeographiesSpec` gains six tests: every parent is itself a row, no location is its own ancestor, a comma survives parsing, a country lands in its UN subregion — and four that state the point as behaviour rather than as rows, that a Western European dataset is now offered to a French activity, that a French one is still refused for the region, and the same pair for a Brazilian state.