### PR TITLE
Place a SimaPro activity by a stated location, not a guessed one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,20 @@
   output is unchanged.
 
 ### Fixed
+- A SimaPro activity is now placed by the location its producer wrote down,
+  rather than by one guessed from a name. SimaPro cuts its "Process name"
+  field at 80 characters, which on a long name takes the `{FR}` tag off the
+  end and leaves only a slash the name has for its own reasons — so
+  "Bresaola … Already packed - PP/PE | No preparation" was filed under Peru,
+  PE being the plastic. Reading a slash off the end of a name is how the
+  WFLDB convention states a location and still works, but it is a reading of
+  the name and now loses to a tag, wherever the tag sits. On Agribalyse 3.2
+  this moves 73 activities, mostly to France, and retires the four
+  "locations" that named no place: `PE` where it meant polyethylene,
+  `F-Organic`, `F-Org(Farrrowin` and `Mid-western`. Names stop being cut
+  short too, which separates 39 pairs of activities that until now shared one
+  identity. Databases whose names really do end in a location — WFLDB, which
+  relies on it 1876 times — are unaffected.
 - Locations the databases actually use now have a place in the geography
   hierarchy. `data/geographies.csv` listed 91 codes; the databases use several
   hundred, so a Kenyan, Ukrainian or Brazilian-state activity had no wider

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -997,9 +997,12 @@ processBlockToActivity unitCfg GlobalParams{..} ProcessBlock{..} =
             -- A blank reference name (malformed row) must not blank the whole
             -- block: degrade per-product, as before the shared fallback.
             -- The readings that may name the place are the ones behind the name
-            -- we settled on.
+            -- we settled on. The reference product's reading comes last: a
+            -- coproduct whose own name states nothing inherits the reference's
+            -- location rather than a guess read off the process name, keeping
+            -- every coproduct of the block on one location.
             (effectiveActivityName, readings)
-                | not (T.null processNameTrimmed) = (processNameTrimmed, [processReading, productReading])
+                | not (T.null processNameTrimmed) = (processNameTrimmed, [processReading, productReading, referenceReading])
                 | not (T.null fallbackName) = (fallbackName, [referenceReading])
                 | otherwise = (cleanProductName, [productReading])
             -- Best-founded reading wins; sortOn is stable, so a tie goes to the

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -17,6 +17,9 @@ module SimaPro.Parser (
     generateFlowUUID,
     generateUnitUUID,
     normalizeSimaProCompartment,
+    extractLocation,
+    Located (..),
+    LocationSource (..),
 
     -- * Shared utilities (used by Method.ParserSimaPro)
     defaultConfig,
@@ -42,9 +45,9 @@ import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as BL
 import Data.Char (isUpper, toLower)
 import qualified Data.Csv as Csv
-import Data.List (dropWhileEnd)
+import Data.List (dropWhileEnd, sortOn)
 import qualified Data.Map.Strict as M
-import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing, maybeToList)
+import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing, listToMaybe, maybeToList)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -788,6 +791,29 @@ generateUnitUUID unitName =
 -- Conversion to volca Types
 -- ============================================================================
 
+{- | How a location was read out of a SimaPro name.
+
+A tag is a location the producer wrote down. A slash suffix is a guess made by
+cutting the name, and names end in a slash for reasons that have nothing to do
+with geography — in "Already packed - PP/PE", PE is a plastic, not Peru. So the
+ordering here says a tag beats a suffix, wherever each of the two sits.
+-}
+data LocationSource
+    = Tagged
+    | SlashSuffix
+    deriving (Eq, Ord, Show)
+
+-- | A location read out of a name, with the name the reading leaves behind.
+data Located = Located
+    { locatedName :: Text
+    {- ^ The name without the location: unchanged for a tag, which is only
+    informational, shortened for a suffix, which is part of the name.
+    -}
+    , locatedLocation :: Text
+    , locatedSource :: LocationSource
+    }
+    deriving (Eq, Show)
+
 {- | Extract location from SimaPro-style names
 Handles three forms:
   * Curly-brace tag (ecoinvent 3.10+): "Name {FR}| market for ..."
@@ -795,8 +821,11 @@ Handles three forms:
   * WFLDB-style "/XX" suffix: "Ammonium nitrate .../CN".
 The first two preserve the full name (the tag is informational); the WFLDB
 form strips at the slash because the geo code is a true suffix.
+
+Nothing when the name states no location — callers keep the name they passed in
+rather than a shortened one.
 -}
-extractLocation :: Text -> (Text, Text)
+extractLocation :: Text -> Maybe Located
 extractLocation name =
     case T.breakOn "{" name of
         (_, rest) | not (T.null rest) ->
@@ -805,14 +834,14 @@ extractLocation name =
                     | not (T.null afterBrace) ->
                         let cleanLoc = T.strip loc
                          in if T.length cleanLoc >= 2
-                                then (T.strip name, cleanLoc)
-                                else (name, "")
-                _ -> (name, "")
+                                then Just (Located (T.strip name) cleanLoc Tagged)
+                                else Nothing
+                _ -> Nothing
         _ -> case extractBracketLocation name of
-            Just loc -> (T.strip name, loc)
+            Just loc -> Just (Located (T.strip name) loc Tagged)
             Nothing -> case extractSlashLocation name of
-                Just (cleanName, loc) -> (cleanName, loc)
-                Nothing -> (name, "")
+                Just (cleanName, loc) -> Just (Located cleanName loc SlashSuffix)
+                Nothing -> Nothing
   where
     -- Match "//[XX]" anywhere in the string (older SimaPro exports of
     -- ecoinvent embed the geo code mid-name, so we keep the full name).
@@ -889,24 +918,35 @@ processBlockToActivity unitCfg GlobalParams{..} ProcessBlock{..} =
     -- coproduct inherits the reference product's name and location, so a
     -- multi-product block still collapses onto one activityUUID (which is
     -- derived from name + location) instead of splitting into N activities.
-    (fallbackName, fallbackLoc) = case productsInFileOrder of
-        (p : _) -> extractLocation (prName p)
-        [] -> ("", "")
+    referenceName = case productsInFileOrder of
+        (p : _) -> prName p
+        [] -> ""
+    referenceReading = extractLocation referenceName
+    fallbackName = maybe referenceName locatedName referenceReading
     (env, exprMap) =
         buildParamEnv
             (reverse <$> [gpDbInput, gpProjInput, pbInputParams])
             (reverse <$> [gpDbCalc, gpProjCalc, pbCalcParams])
 
-    -- Extract location from process name if not specified.
-    (cleanProcessNameRaw, locFromName) = extractLocation pbName
-    location =
-        if T.null pbLocation || T.toLower pbLocation == "unspecified"
-            then locFromName
-            else pbLocation
-    -- Trimmed Process name (without curly-brace location tag). Empty when the
-    -- SimaPro "Process name" field is empty (typical for mono-product blocks
-    -- where only the Product line carries the human-readable name).
-    processNameTrimmed = T.strip cleanProcessNameRaw
+    processReading = extractLocation pbName
+
+    -- The Geography field, when the producer filled it in. It outranks anything
+    -- read out of a name, being the one place meant to hold a location.
+    statedLocation = mfilter ((/= "unspecified") . T.toLower) (nonEmptyText pbLocation)
+
+    {- Trimmed Process name (without curly-brace location tag). Empty when the
+    SimaPro "Process name" field is empty (typical for mono-product blocks
+    where only the Product line carries the human-readable name).
+
+    A name only loses its tail when that tail is what named the place. When the
+    reference product states a tag, the tail was never a location and the whole
+    name stays: "… - PP/PE | No preparation" keeps its packaging and its
+    preparation step instead of ending at the PP. -}
+    processNameTrimmed
+        | (locatedSource <$> processReading) == Just SlashSuffix
+        , (locatedSource <$> referenceReading) == Just Tagged =
+            T.strip pbName
+        | otherwise = T.strip (maybe pbName locatedName processReading)
 
     -- Convert each section's rows to (exchange, flow, unit) triples in one pass.
     -- 'Final waste flows' route to WasteExchange so the cross-DB linker doesn't
@@ -949,17 +989,27 @@ processBlockToActivity unitCfg GlobalParams{..} ProcessBlock{..} =
             effUnitName = unitName productUnit
             allocPercent = resolveAmount env (prAllocRaw prod) (prAllocation prod)
             allocFraction = allocPercent / 100.0
-            (cleanProductName, locFromProduct) = extractLocation (prName prod)
+            productReading = extractLocation (prName prod)
+            cleanProductName = maybe (prName prod) locatedName productReading
             -- Activity name = Process name when present, otherwise the reference
             -- product's name (with its location) — never the coproduct's own,
             -- so all coproducts of a name-less block share one activityUUID.
             -- A blank reference name (malformed row) must not blank the whole
             -- block: degrade per-product, as before the shared fallback.
-            (effectiveActivityName, locFallback)
-                | not (T.null processNameTrimmed) = (processNameTrimmed, locFromProduct)
-                | not (T.null fallbackName) = (fallbackName, fallbackLoc)
-                | otherwise = (cleanProductName, locFromProduct)
-            effectiveLoc = if T.null location then locFallback else location
+            -- The readings that may name the place are the ones behind the name
+            -- we settled on.
+            (effectiveActivityName, readings)
+                | not (T.null processNameTrimmed) = (processNameTrimmed, [processReading, productReading])
+                | not (T.null fallbackName) = (fallbackName, [referenceReading])
+                | otherwise = (cleanProductName, [productReading])
+            -- Best-founded reading wins; sortOn is stable, so a tie goes to the
+            -- Process name, which is what named the block.
+            readLocation =
+                foldMap locatedLocation
+                    . listToMaybe
+                    . sortOn locatedSource
+                    $ catMaybes readings
+            effectiveLoc = fromMaybe readLocation statedLocation
             allocFormula = mfilter (not . isNumericFormula) (nonEmptyText (prAllocRaw prod))
             activity =
                 Activity
@@ -1014,7 +1064,9 @@ unknown-unit errors with a clear message).
 -}
 productToExchange :: UnitConversion.UnitConfig -> M.Map Text Double -> Bool -> ProductRow -> (Exchange, TechnosphereFlow, Unit)
 productToExchange unitCfg env isRef ProductRow{..} =
-    let (cleanName, prodRowLoc) = extractLocation prName
+    let reading = extractLocation prName
+        cleanName = maybe prName locatedName reading
+        prodRowLoc = foldMap locatedLocation reading
         rawAmount = resolveAmount env prAmountRaw prAmount
         (effUnitName, amount) =
             if isRef
@@ -1104,7 +1156,9 @@ Always returns the flow/unit; exchange is Nothing for zero-amount rows.
 -}
 techRowToExchange :: M.Map Text Double -> TechExchangeRow -> (Maybe Exchange, TechnosphereFlow, Unit)
 techRowToExchange env TechExchangeRow{..} =
-    let (cleanName, location) = extractLocation terName
+    let reading = extractLocation terName
+        cleanName = maybe terName locatedName reading
+        location = foldMap locatedLocation reading
         flowUUID = generateFlowUUID cleanName "" terUnit
         unitUUID = generateUnitUUID terUnit
         resolvedAmount = resolveAmount env terAmountRaw terAmount

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -1059,6 +1059,21 @@ spec = do
             activityName act
                 `shouldBe` "Bresaola, processed in FR | Chilled | Already packed - PP/PE | No preparation |"
 
+        -- A coproduct whose own name states no location inherits the reference
+        -- product's tag rather than the slash guess, so the whole block stays
+        -- on one location — and therefore on one activityUUID.
+        it "keeps every coproduct of a block on the reference product's tag" $ do
+            (activities, _, _, _, _) <-
+                parseProductsCSV
+                    "Bresaola, processed in FR | Chilled | Already packed - PP/PE | No preparation |"
+                    [ "Bresaola, processed in FR | Chilled | Already packed - PP/PE | at consumer {FR} U;kg;1;60;not defined;material;"
+                    , "Beef trimmings, at plant;kg;1;40;not defined;material;"
+                    ]
+            map activityLocation activities `shouldBe` ["FR", "FR"]
+            case map generateActivityUUID activities of
+                [refUUID, coproductUUID] -> coproductUUID `shouldBe` refUUID
+                other -> length other `shouldBe` 2
+
         it "keeps a region whose own name contains a slash" $ do
             (activities, _, _, _, _) <-
                 parseProductsCSV

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -12,9 +12,12 @@ import Database.MatrixBuild (InterningTables (..), buildInterningTables)
 import Expr (evaluate, normalizeExpr)
 import SimaPro.Parser (
     BioExchangeRow (..),
+    Located (..),
+    LocationSource (..),
     ProductRow (..),
     TechExchangeRow (..),
     defaultConfig,
+    extractLocation,
     generateActivityUUID,
     generateFlowUUID,
     generateUnitUUID,
@@ -1039,6 +1042,62 @@ spec = do
             (activities, _, _, _, _) <- parseTestCSV
             let a = head activities
             activityLocation a `shouldBe` "GLO"
+
+        -- SimaPro cuts the "Process name" field at 80 characters, which takes
+        -- the "{FR}" tag off the end of a long name and leaves only a slash the
+        -- name has for its own reasons. The product name is not cut and still
+        -- states the tag, so the tag is what the activity is placed by.
+        it "believes a tag on the product over a slash in the process name" $ do
+            (activities, _, _, _, _) <-
+                parseProductsCSV
+                    "Bresaola, processed in FR | Chilled | Already packed - PP/PE | No preparation |"
+                    ["Bresaola, processed in FR | Chilled | Already packed - PP/PE | at consumer {FR} U;kg;1;100;not defined;material;"]
+            let act = head activities
+            -- PE is the plastic, not Peru.
+            activityLocation act `shouldBe` "FR"
+            -- And the name keeps the tail the slash reading would have cut off.
+            activityName act
+                `shouldBe` "Bresaola, processed in FR | Chilled | Already packed - PP/PE | No preparation |"
+
+        it "keeps a region whose own name contains a slash" $ do
+            (activities, _, _, _, _) <-
+                parseProductsCSV
+                    "Electricity, low voltage BR-South-eastern/Mid-western grid| market for electr"
+                    ["Electricity, low voltage {BR-South-eastern/Mid-western grid}| market for U;MJ;1;100;not defined;material;"]
+            let act = head activities
+            activityLocation act `shouldBe` "BR-South-eastern/Mid-western grid"
+            activityName act
+                `shouldBe` "Electricity, low voltage BR-South-eastern/Mid-western grid| market for electr"
+
+        -- The reading the slash form exists for, with nothing better on offer.
+        it "still reads a WFLDB slash suffix, and still drops it from the name" $ do
+            (activities, _, _, _, _) <-
+                parseProductsCSV
+                    "Maize grain, non-irrigated, at farm (WFLDB)/US U"
+                    ["Maize grain, non-irrigated, at farm (WFLDB)/US U;kg;1;100;not defined;material;"]
+            let act = head activities
+            activityLocation act `shouldBe` "US"
+            activityName act `shouldBe` "Maize grain, non-irrigated, at farm (WFLDB)"
+
+    describe "extractLocation" $ do
+        it "reads a curly-brace tag, leaving the name whole" $
+            extractLocation "Wheat grain {FR}| production | Cut-off, U"
+                `shouldBe` Just (Located "Wheat grain {FR}| production | Cut-off, U" "FR" Tagged)
+
+        it "reads an embedded bracket tag, leaving the name whole" $
+            extractLocation "mango//[BR] mango production"
+                `shouldBe` Just (Located "mango//[BR] mango production" "BR" Tagged)
+
+        it "reads a slash suffix, which is part of the name and goes with it" $
+            extractLocation "Maize grain, at farm (WFLDB)/US U"
+                `shouldBe` Just (Located "Maize grain, at farm (WFLDB)" "US" SlashSuffix)
+
+        it "scans past a slash segment that names no place" $
+            extractLocation "Product/ha/GLO/I U"
+                `shouldBe` Just (Located "Product/ha" "GLO" SlashSuffix)
+
+        it "says nothing when the name states nothing, rather than a blank" $
+            extractLocation "Diesel, burned in machinery" `shouldBe` Nothing
 
         -- WFLDB convention: the Process name carries the data-collection
         -- country (/CH) while the Products row carries the geographic scope


### PR DESCRIPTION
## Why

A handful of Agribalyse activities were filed under "locations" that name no place: `F-Organic`, `F-Org(Farrrowin`, `Mid-western`. Following it back, the cause is not a bad list of geographies but a reading that outranks a fact.

SimaPro caps its `Process name` field at 80 characters — 8096 Agribalyse names sit exactly at the limit. On a long name that cut takes the trailing `{FR}` tag away and leaves only a slash the name has for its own reasons. The parser then read the tail after the last slash as a geography code:

```
Bresaola, processed in FR | Chilled | Already packed - PP/PE | No preparation |
                                                        ^^ read as Peru
```

PE is polyethylene. Two arithmetic twins make the truncation plain — a stray dot in the source shifts the cut by one character and the "location" shortens by one character with it:

| process name (80 chars) | location it produced |
|---|---|
| `…mulched floor for PW/F-Org(Farrrowin` | `F-Org(Farrrowin` |
| `…mulched floor for PW/F-Org(Far-mate` (with `Build.ing`) | `F-Org(Far-mate` |

In every one of these cases the **product** name is not truncated and still states `{FR}`. The parser consulted it only when the process name yielded nothing, so a guess beat a statement.

## What changed

`extractLocation` now says *how* it found a location — a tag (`{FR}`, `//[FR]`) or a slash suffix — and returns `Maybe` instead of a name paired with a blank. The Geography field still outranks both; between the two names, a tag wins wherever it sits and a slash suffix only wins when no tag is on offer.

The name follows that same decision: it loses its tail only when the tail is what named the place. That is what stops names being cut short, which matters beyond the label — a shortened name merges activities, since the activity UUID is a hash of name and location.

No shape heuristic was added, deliberately: `F-Organic` and the real WFLDB code `UN-SEASIA` have the same shape, so no test on the string can separate them. Provenance can.

## Measured

Reproduced over every SimaPro export at hand, before and after:

| export | activities placed by the slash reading | changed by this PR |
|---|---|---|
| Agribalyse 3.2 | 81 | **73**, all to a tag the product already stated |
| WFLDB | 1876 | **0** — 80 distinct locations, identical |
| ginko 2025.2 | 0 | 0 |
| pastoeco | 1 | 0 |

On Agribalyse the four junk locations are retired, the 68 bogus `PE` become `FR` (39 genuine `{PE}` activities in Peru stay), and distinct `(name, location)` pairs go from 15163 to 15202 — 39 pairs of activities that shared one identity are now told apart.

WFLDB was re-parsed with the patched engine and produces the same 80 locations as before, which is the point: the slash reading is the WFLDB convention and had to keep working.

Engine suite: 1904 examples, 0 failures.