### PR TITLE
Lend a region-tagged flow the density that goes with its factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,21 @@
   output is unchanged.
 
 ### Fixed
+- A region-tagged flow now gets the density that goes with the factor it
+  borrows. When a method has no line for `Water, SERC`, VoLCA lends it the line
+  written for `Water` — but that line can be denominated per kilogram while the
+  flow is measured in cubic metres, and the density that bridges the two was
+  only ever looked up under the flow's full name, region tag included. The tag
+  was stripped to find the factor and not to find the density, so the flow ended
+  up holding a factor of a dimension it could not reach, and scored nothing.
+  Both lookups now strip it the same way.
+- A density is now read in both directions. It relates two dimensions — mass to
+  energy for a calorific value, mass to volume for a density proper — and a flow
+  can meet a factor from either side of it, but only one side was handled: a
+  flow in kilograms against a per-cubic-metre factor converted, while the same
+  substance in cubic metres against a per-kilogram factor scored zero. A
+  non-positive density is now refused outright rather than divided by, and the
+  refusal is reported like any other.
 - A SimaPro activity is now placed by the location its producer wrote down,
   rather than by one guessed from a name. SimaPro cuts its "Process name"
   field at 80 characters, which on a long name takes the `{FR}` tag off the

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -1935,6 +1935,12 @@ lookupCascadeCF tables flowDB fid =
     -- for "Ammonia" applies to the emission wherever it occurs. Only fires
     -- after every direct lookup misses, and only when the suffix is a real
     -- region code (extractLocationSuffix leaves "Methane, fossil" untouched).
+    --
+    -- The borrowed CF keeps the base substance's *unit*, which may differ in
+    -- dimension from the flow's. 'lookupEnergyDensity' therefore strips the
+    -- suffix with this same 'extractLocationSuffix' before looking a density
+    -- up: whatever name lends the factor must also lend the density, or the
+    -- flow holds a factor it cannot be converted to and scores 0.
     regionBaseFallback flow baseMed normSub =
         case extractLocationSuffix (bfName flow) of
             (base, Just _) ->
@@ -2145,43 +2151,61 @@ flowMediumSub cmap flow =
 {- | Flow→CF conversion factor for @qty@ units of flow, applying the
 energy-density bridge when it is needed and available.
 
-The bridge fires only when the CF is energy-denominated, the flow is __not__
-(its unit isn't an energy unit), and the flow carries an 'EnergyDensity'. The
-inventory quantity is first brought into the density's native unit, then turned
-into energy: @qNative × E@, where @E@ is the density value converted from its
-declared energy unit into the CF's unit. Either conversion failing — the flow
-unit can't reach the native unit, or the energy unit can't reach the CF unit —
-yields @0@: we refuse a wrong-basis or wrong-dimension factor rather than
-silently using the raw value.
+A density relates two dimensions — @target@ per @native@, MJ per kg for a
+calorific value, m³ per kg for a mass density — and a flow can meet a CF from
+either side of it, so the bridge reads the ratio both ways:
 
-Every other case (matching dimensions, no density, or an energy flow) defers
-to 'convertForCharacterization', so flows without a density are unchanged.
+  * __forward__, the CF is in the target unit and the flow in the native one
+    (a mass flow against a per-MJ or per-m³ factor): @qNative × E@;
+  * __inverse__, the mirror image, the flow is in the target unit and the CF in
+    the native one (a volume flow against a per-kg factor): @qTarget ÷ E@.
+
+Both require the flow's own unit to be dimensionally unreachable from the CF's
+— a pair the ordinary conversion can already handle is its business, not the
+bridge's — and both require a positive density: a zero would divide, and a
+negative one would silently flip the sign of a score.
+
+Any leg failing to convert yields @0@, and so does a non-positive density: we
+refuse a wrong-basis or wrong-dimension factor rather than silently using the
+raw value, and 'zeroedMatchedCFs' reports the refusal. Every other case
+(matching dimensions, no density) defers to 'convertForCharacterization', so
+flows without a density are unchanged.
 -}
 energyAwareConversion :: UnitConfig -> Text -> CFUnit -> Maybe EnergyDensity -> Double -> Double
 energyAwareConversion cfg flowUnit cfu@(CFUnit rawCfUnit) mDensity qty =
     case mDensity of
-        -- The bridge fires when the CF is denominated in the density's target
-        -- unit (MJ for a calorific value, m³ for a mass density) and the flow is
-        -- a different dimension (mass). Generalizing the guard from "energy" to
-        -- "same dimension as the density unit" lets one mechanism serve both the
-        -- fossil energy CF (kg → MJ via calorific value) and the water-scarcity
-        -- CF (kg → m³ via density), which are the two cases where a per-physical-
-        -- quantity CF meets a mass inventory flow.
-        Just (EnergyDensity ev densityUnit nativeUnit)
-            | unitsCompatible cfg rawCfUnit densityUnit
-            , not (unitsCompatible cfg rawCfUnit flowUnit) ->
+        -- Generalizing the guard from "energy" to "same dimension as one leg of
+        -- the density" lets one mechanism serve the fossil energy CF (kg → MJ
+        -- via calorific value), the water-scarcity CF (kg → m³ via density) and
+        -- their mirrors, which is every case where a per-physical-quantity CF
+        -- meets an inventory flow of another dimension.
+        Just (EnergyDensity ev targetUnit nativeUnit)
+            | crossDimension
+            , ev > 0
+            , unitsCompatible cfg rawCfUnit targetUnit ->
                 fromMaybe 0 $ do
-                    qtyNative <- toNativeQty flowUnit nativeUnit
-                    factor <- convertUnit cfg densityUnit rawCfUnit ev
+                    qtyNative <- toUnit nativeUnit
+                    factor <- convertUnit cfg targetUnit rawCfUnit ev
                     pure (qtyNative * factor)
+            | crossDimension
+            , ev > 0
+            , unitsCompatible cfg rawCfUnit nativeUnit ->
+                fromMaybe 0 $ do
+                    qtyTarget <- toUnit targetUnit
+                    convertUnit cfg nativeUnit rawCfUnit (qtyTarget / ev)
         _ -> convertForCharacterization cfg flowUnit cfu qty
   where
-    -- Bring the inventory quantity into the unit the density is denominated
+    -- Both arms need the flow's unit to be unreachable from the CF's: a
+    -- same-dimension pair belongs to the ordinary conversion, and a CF unit the
+    -- config does not know (a result expression like "kg CO2 eq") is compatible
+    -- with neither leg, so it is never bridged.
+    crossDimension = not (unitsCompatible cfg rawCfUnit flowUnit)
+    -- Bring the inventory quantity into the leg the arm applies the density
     -- against: identical units need no table entry, otherwise a same-dimension
     -- conversion. An incompatible or unknown unit yields 'Nothing' → 0.
-    toNativeQty fu nu
-        | normalizeUnit fu == normalizeUnit nu = Just qty
-        | otherwise = convertUnit cfg fu nu qty
+    toUnit u
+        | normalizeUnit flowUnit == normalizeUnit u = Just qty
+        | otherwise = convertUnit cfg flowUnit u qty
 
 {- | Apply the flow→CF unit conversion factor and multiply by the CF value.
 
@@ -2206,13 +2230,10 @@ convertAndMultiply ::
     Double
 convertAndMultiply unitConfig unitDB energyDensities mflow (CF cfVal cfu) qty =
     let flowUnit = maybe "" unitName (mflow >>= \f -> M.lookup (bfUnitId f) unitDB)
-        -- Density from the curated CSV first; else parse it from the flow name
-        -- ("Coal, 18 MJ per kg" → 18 MJ), so energy-resource variants the CSV
-        -- doesn't enumerate still convert mass/volume → energy.
-        mDensity =
-            mflow >>= \f ->
-                M.lookup (normalizeName (bfName f)) energyDensities
-                    <|> fmap snd (parseEnergyDensitySuffix (bfName f))
+        -- 'lookupEnergyDensity' walks the same names the CF lookup walks —
+        -- including the region-stripped one, so a flow lent the base substance's
+        -- factor is lent its density too.
+        mDensity = mflow >>= \f -> lookupEnergyDensity energyDensities (bfName f)
         converted = energyAwareConversion unitConfig flowUnit cfu mDensity qty
      in converted * cfVal
 

--- a/src/Method/Types.hs
+++ b/src/Method/Types.hs
@@ -42,6 +42,7 @@ module Method.Types (
     buildEnergyDensityMapFromCSV,
     energyDensityMapSize,
     parseEnergyDensitySuffix,
+    lookupEnergyDensity,
 
     -- * Region-suffixed flow names
     extractLocationSuffix,
@@ -51,6 +52,7 @@ module Method.Types (
     MatchType (..),
 ) where
 
+import Control.Applicative ((<|>))
 import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON, ToJSON)
 import qualified Data.ByteString.Lazy as BL
@@ -456,6 +458,32 @@ parseEnergyDensitySuffix name =
   where
     isJouleUnit u = T.toUpper u `elem` map T.pack ["KJ", "MJ", "GJ", "TJ"]
     cleanBase ws = T.dropWhileEnd (\c -> c == ',' || c == ' ') (T.unwords ws)
+
+{- | The density for a flow name, following the same cascade of names the CF
+lookup follows: the curated map under the flow's own name, then under its
+region-stripped base name (@"Water, SERC"@ → @"Water"@), then the density the
+name itself encodes (@"Coal, 18 MJ per kg"@).
+
+The region rung is what keeps the two lookups on the same key. A
+region-suffixed flow is lent the base substance's CF (see
+'extractLocationSuffix'), and that CF carries the base substance's unit — so if
+the density is only ever looked up under the full name, the flow ends up
+holding a factor of a dimension it cannot be converted to and nothing to bridge
+with, and scores 0. Stripping here exactly as the CF lookup strips there is the
+invariant: whatever name lent the factor must also lend the density.
+
+Curated rows outrank the name-encoded density, so a database that spells a
+density into its flow names cannot override a curated correction.
+-}
+lookupEnergyDensity :: EnergyDensityMap -> Text -> Maybe EnergyDensity
+lookupEnergyDensity densities name =
+    M.lookup (normalizeName name) densities
+        <|> regionBase
+        <|> fmap snd (parseEnergyDensitySuffix name)
+  where
+    regionBase = case extractLocationSuffix name of
+        (base, Just _) -> M.lookup (normalizeName base) densities
+        (_, Nothing) -> Nothing
 
 {- | SimaPro encodes regional variants of a flow as a suffix on the flow name:
 @"Nitrogen dioxide, FR"@. Split that suffix off, returning the base name and

--- a/test/EnergyDensityCFSpec.hs
+++ b/test/EnergyDensityCFSpec.hs
@@ -52,10 +52,11 @@ unitConfig =
     fromRight defaultUnitConfig $
         buildFromCSV (BLC.pack "name,dimension,factor\nkg,mass,1.0\ntonne,mass,1000.0\nm3,volume,1.0\nmj,energy,1.0e6\n")
 
-uidKg, uidTonne, uidM3 :: UUID
+uidKg, uidTonne, uidM3, uidMJ :: UUID
 uidKg = UUID.fromWords64 1 0
 uidTonne = UUID.fromWords64 2 0
 uidM3 = UUID.fromWords64 3 0
+uidMJ = UUID.fromWords64 4 0
 
 mkUnit :: UUID -> Text -> Unit
 mkUnit uid name = Unit{unitId = uid, unitName = name, unitSymbol = name, unitComment = ""}
@@ -67,6 +68,7 @@ unitDB =
         [ (uidKg, mkUnit uidKg "kg")
         , (uidTonne, mkUnit uidTonne "tonne")
         , (uidM3, mkUnit uidM3 "m3")
+        , (uidMJ, mkUnit uidMJ "mj")
         ]
 
 -- ---------------------------------------------------------------------------
@@ -127,15 +129,40 @@ waterFlowIn unitId = (coalFlowIn unitId){bfId = waterId, bfName = "Water"}
 volumeCF :: MethodCF
 volumeCF = energyCF{mcfFlowRef = waterId, mcfFlowName = "Water", mcfValue = 42.95, mcfUnit = "m3"}
 
+-- A per-kilogram water CF — the shape a non-regionalized method takes when it
+-- writes water deprivation against a mass basis instead of a volume one.
+waterMassCF :: MethodCF
+waterMassCF = volumeCF{mcfValue = -0.042955, mcfUnit = "kg"}
+
 -- Mass density of water: 0.001 m³ per kg — same shape as a calorific value.
 waterDensities :: EnergyDensityMap
 waterDensities = M.fromList [(normalizeName "Water", EnergyDensity 0.001 "m3" "kg")]
+
+-- The same water, tagged with a US grid region the method does not enumerate.
+-- Its own UUID keeps it out of 'mtUuidCF', so it can only reach a CF through
+-- the region base-name fallback.
+regionWaterId :: UUID
+regionWaterId = UUID.fromWords64 12 0
+
+regionWaterFlowIn :: UUID -> BiosphereFlow
+regionWaterFlowIn unitId = (waterFlowIn unitId){bfId = regionWaterId, bfName = "Water, SERC"}
 
 -- Build tables (with broadcast) for a flow + energy-density set + CF.
 tablesFor :: BiosphereFlow -> EnergyDensityMap -> MethodCF -> MethodTables
 tablesFor flow densities cf =
     let fdb = M.singleton (bfId flow) flow
         raw = buildMethodTables OtherCFFamily M.empty densities [(cf, Just (flow, ByUUID))]
+     in fillBroadcastVector unitConfig unitDB fdb raw
+
+{- | Tables where the CF is name-matched to the __base__ substance while the
+inventory holds a __region-suffixed__ flow — the situation a non-regionalized
+method meets in a regionalized database, and the only one that exercises the
+region rung of both the CF lookup and the density lookup.
+-}
+tablesForRegion :: BiosphereFlow -> BiosphereFlow -> EnergyDensityMap -> MethodCF -> MethodTables
+tablesForRegion baseFlow regionFlow densities cf =
+    let fdb = M.singleton (bfId regionFlow) regionFlow
+        raw = buildMethodTables OtherCFFamily M.empty densities [(cf, Just (baseFlow, ByName))]
      in fillBroadcastVector unitConfig unitDB fdb raw
 
 -- Score a @qty@-unit inventory of @flow@ against the given tables.
@@ -210,6 +237,56 @@ spec = do
             let flow = waterFlowIn uidKg
                 tables = tablesFor flow M.empty volumeCF
             scoreFlow flow 1.0 tables `shouldSatisfy` near 0
+
+    describe "Density bridge, inverse direction: mass CF vs. volume flow" $ do
+        -- The mirror of the arm above. A density relates two dimensions, and a
+        -- flow can meet a CF from either side of it: here the flow is in the
+        -- density's target unit (m³) and the CF in its native one (per kg), so
+        -- the ratio divides instead of multiplying.
+        it "divides a volume flow by the density to reach a per-kg CF" $ do
+            let flow = waterFlowIn uidM3
+                tables = tablesFor flow waterDensities waterMassCF
+            scoreFlow flow 0.283452 tables `shouldSatisfy` near ((0.283452 / 0.001) * (-0.042955))
+
+        it "leaves a flow already in the CF's own unit to the ordinary conversion" $ do
+            let flow = waterFlowIn uidKg
+                tables = tablesFor flow waterDensities waterMassCF
+            scoreFlow flow 1.0 tables `shouldSatisfy` near (-0.042955)
+
+        it "still scores 0 without a density" $ do
+            let flow = waterFlowIn uidM3
+                tables = tablesFor flow M.empty waterMassCF
+            scoreFlow flow 1.0 tables `shouldSatisfy` near 0
+
+        it "refuses a non-positive density rather than dividing by it" $ do
+            let flow = waterFlowIn uidM3
+                zeroDensity = M.fromList [(normalizeName "Water", EnergyDensity 0 "m3" "kg")]
+                score = scoreFlow flow 1.0 (tablesFor flow zeroDensity waterMassCF)
+            score `shouldSatisfy` near 0
+            score `shouldSatisfy` (not . isNaN)
+
+        it "mirrors for fuel too: an MJ flow against a per-kg CF divides by the calorific value" $ do
+            let flow = coalFlowIn uidMJ
+                tables = tablesFor flow coalDensities massCF
+            scoreFlow flow 1.0 tables `shouldSatisfy` near ((1.0 / 26.4) * 3.0)
+
+    describe "Region-suffixed flow, end to end" $ do
+        -- The defect this whole arm exists for. The CF lookup lends "Water,
+        -- SERC" the base "Water" factor, which is written per kilogram; the
+        -- flow is in m³. Scoring it needs the region rung of the CF lookup, the
+        -- region rung of the density lookup, and the inverse bridge — remove
+        -- any one of the three and this returns 0.
+        it "characterizes a region-tagged m3 flow through the base per-kg CF" $ do
+            let base = waterFlowIn uidM3
+                flow = regionWaterFlowIn uidM3
+                tables = tablesForRegion base flow waterDensities waterMassCF
+            scoreFlow flow 0.283452 tables `shouldSatisfy` near ((0.283452 / 0.001) * (-0.042955))
+
+        it "scores 0 without the density, so the bridge is what carries it" $ do
+            let base = waterFlowIn uidM3
+                flow = regionWaterFlowIn uidM3
+                tables = tablesForRegion base flow M.empty waterMassCF
+            scoreFlow flow 0.283452 tables `shouldSatisfy` near 0
 
     describe "buildEnergyDensityMapFromCSV" $ do
         it "parses a valid row, keyed by normalized flow name" $

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -747,6 +747,21 @@ spec = do
                     ((mkCF "gas" Nothing 50.0){mcfUnit = "MJ"})
             zeroed `shouldBe` [fid]
 
+        it "stays quiet when the bridge converts the other way round" $ do
+            -- The mirror: flow in the density's target unit (m3), CF in its
+            -- native one (kg). The inverse arm divides, so nothing is refused
+            -- and the scan must not keep reporting it.
+            (_, zeroed) <-
+                fillWith (M.singleton "gas" (EnergyDensity 0.001 "m3" "kg")) "m3" (mkCF "gas" Nothing 43.1)
+            zeroed `shouldBe` []
+
+        it "still flags a pair neither direction of the bridge can span" $ do
+            -- Density between m3 and kg, but the flow is in MJ: neither leg is
+            -- reachable, so the refusal stands and stays visible.
+            (fid, zeroed) <-
+                fillWith (M.singleton "gas" (EnergyDensity 0.001 "m3" "kg")) "mj" (mkCF "gas" Nothing 43.1)
+            zeroed `shouldBe` [fid]
+
     describe "findSimilarCFs (post-scoring suggester)" $ do
         let mkMethod cfs =
                 Method

--- a/test/RegionFallbackSpec.hs
+++ b/test/RegionFallbackSpec.hs
@@ -9,7 +9,8 @@ import qualified Data.UUID as UUID
 import Test.Hspec
 
 import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, cfValue, lookupCFForFlow)
-import Method.Types (CFFamily (..), Compartment (..), FlowDirection (..), MethodCF (..), extractLocationSuffix)
+import Method.Types (CFFamily (..), Compartment (..), EnergyDensity (..), EnergyDensityMap, FlowDirection (..), MethodCF (..), extractLocationSuffix, lookupEnergyDensity)
+import SynonymDB (normalizeName)
 import Types (BiosphereFlow (..))
 import qualified Types as VT
 
@@ -75,3 +76,26 @@ spec = do
             scoreOf "Methane" 28.0 "Methane, fossil" `shouldBe` Nothing
         it "still characterizes the base flow itself" $
             scoreOf "Ammonia" 11.5 "Ammonia" `shouldBe` Just 11.5
+
+    describe "lookupEnergyDensity strips the same suffix the CF lookup strips" $ do
+        -- A borrowed CF carries the base substance's unit, so the density that
+        -- bridges to it has to be findable under the base substance's name. If
+        -- these two lookups disagree on the key, the flow holds a factor of a
+        -- dimension it cannot reach and scores 0.
+        it "finds the base substance's density for a region-suffixed flow" $
+            lookupEnergyDensity waterRow "Water, SERC" `shouldBe` Just (EnergyDensity 0.001 "m3" "kg")
+        it "prefers a row written for the region-suffixed name itself" $
+            let rows = M.insert (normalizeName "Water, SERC") (EnergyDensity 0.002 "m3" "kg") waterRow
+             in lookupEnergyDensity rows "Water, SERC" `shouldBe` Just (EnergyDensity 0.002 "m3" "kg")
+        it "does not borrow across a chemical qualifier" $
+            lookupEnergyDensity coalRow "Coal, hard" `shouldBe` Nothing
+        it "still reads a density the name itself spells out" $
+            lookupEnergyDensity M.empty "Coal, 18 MJ per kg" `shouldBe` Just (EnergyDensity 18 "MJ" "kg")
+
+waterRow :: EnergyDensityMap
+waterRow = M.singleton (normalizeName "Water") (EnergyDensity 0.001 "m3" "kg")
+
+-- Keyed on the bare family name: ", hard" is a qualifier, not a region, so
+-- 'extractLocationSuffix' leaves it alone and nothing is borrowed.
+coalRow :: EnergyDensityMap
+coalRow = M.singleton (normalizeName "Coal") (EnergyDensity 26.4 "MJ" "kg")


### PR DESCRIPTION
When a method tags no region for `Water, SERC`, VoLCA lends the flow the factor written for `Water`. That factor can be denominated per kilogram while the flow is measured in cubic metres, and the density that bridges the two was only ever looked up under the flow's full name, region tag included — so the tag was stripped to find the factor and not to find the density. The flow ended up holding a factor of a dimension it could not reach, and scored nothing.

Two lookups walking two different keys for the same flow is the defect, so they now walk the same names: `lookupEnergyDensity` tries the flow's own name, then its region-stripped base name, then the density the name itself spells out.

That alone was not enough. A density relates two dimensions — mass to energy for a calorific value, mass to volume for a density proper — and a flow can meet a factor from either side of it, but only one side was handled. A flow in kilograms against a per-cubic-metre factor converted; the same substance in cubic metres against a per-kilogram factor did not. The bridge now reads the ratio both ways. A non-positive density is refused outright rather than divided by, and is reported like any other refusal.

**What it moves.** Measured on Agribalyse 3.2 against an EF 3.1 water-use method: the flows whose factor cannot be converted drop from seven to one, and 396 of 400 sampled products see their water use fall. They fall rather than rise because what was scoring zero is the water *returned* to the environment, which offsets an intake already on the books — a turbine draws water and gives it back, and only the drawing was counted. `Water, SERC` alone was worth −12.18 m³ deprivation on one product whose total was 15.08.

**What it does not move.** 400 activities were scored across all 25 categories before and after: nothing outside water use changes. The bridge cannot fire unless the flow's unit is dimensionally unreachable from the factor's — a pair the ordinary conversion already handles is not its business — and unless the factor's unit is one the unit configuration knows, which excludes every result expression (`kg CO2 eq`). What is left was scoring exactly zero.

The regression anchor is a test that fails if any one of the three pieces is missing: a region-tagged m³ flow, a per-kilogram base factor matched by name, and a density keyed on the base substance.