### PR TITLE
Stop dropping the depth the supply chain already carries

### DIFF
--- a/pyvolca/CHANGELOG.md
+++ b/pyvolca/CHANGELOG.md
@@ -18,6 +18,37 @@ git cliff --unreleased --tag pyvolca-v0.X.Y   # render as a released section
 
 Then paste the rendered block at the top of this file and tighten wording.
 
+## [0.9.0] - 2026-07-31
+
+### Changed — breaking
+
+- `SupplyChainEntry` gains three **required** fields the engine has emitted
+  since v0.6.0 and pyvolca silently dropped at decoding: `depth` (BFS
+  shortest-path distance from the queried root, 0 = the root itself),
+  `upstream_count` (direct consumers of the entry inside the chain), and
+  `database_name` (which loaded database the entry lives in). Every engine
+  this client accepts (wire revision >= 2, i.e. >= v0.9.1) emits them, so
+  they are required without defaults — the type guarantees what the wire
+  guarantees, like `ConsumerResult.depth` already did. **Breaking only for
+  code that constructs `SupplyChainEntry` by hand** (mocks, fixtures): add
+  the three fields. Code that reads decoded entries just gains data — a
+  filtered `get_supply_chain` response is no longer flat, `depth` finally
+  tells a packaging system from the stage that consumes it without a
+  hand-rolled traversal.
+
+### Added
+
+- `export_method_collection(name, fmt=…)` exports a loaded method
+  collection as SimaPro method CSV (`simapro`), columnar CSV (`csv`),
+  openLCA JSON-LD (`openlca`), or an ILCD LCIA-method package (`ilcd`),
+  returning the serialized bytes.
+- `get_collection_coverage` reports how much of a database a whole method
+  collection characterizes (typed `CollectionCoverage`), counting coverage
+  the way scoring counts it.
+- The client now understands wire revision 4 (engines >= v0.9.4, which
+  advertise the quality-report routes); nothing changes against older
+  engines.
+
 ## [0.8.2] - 2026-07-15
 
 ### Added

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -28,7 +28,7 @@ pyvolca speaks a range of revisions of the engine's JSON wire format; the engine
 
 _Generated from `volca._compat` — run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.8.2** speaks wire formats **2 to 4** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error.
+This build of **pyvolca 0.9.0** speaks wire formats **2 to 4** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error.
 
 <!-- END: compatibility -->
 
@@ -2011,15 +2011,22 @@ activity to produce ``quantity`` — i.e. ``quantity = ref_output * scaling_fact
 ``classifications`` mirrors the producing activity's classifications
 (ISIC, CPC, Category, …) so callers can filter by taxonomy without a
 second :meth:`Client.get_activity` round trip.
+``depth`` is the BFS shortest-path distance from the queried root
+(0 = the root itself), ``upstream_count`` the number of direct
+consumers of this activity inside the chain, and ``database_name``
+the database the entry lives in (they differ across linked databases).
 
 | Field | Type | Default |
 |-------|------|---------|
 | `process_id` | `str` | — |
+| `database_name` | `str` | — |
 | `activity_name` | `str` | — |
 | `location` | `str` | — |
 | `quantity` | `float` | — |
 | `unit` | `str` | — |
 | `scaling_factor` | `float` | — |
+| `depth` | `int` | — |
+| `upstream_count` | `int` | — |
 | `classifications` | `dict[str, str]` | dict() |
 
 ### `TechnosphereExchange`

--- a/pyvolca/pyproject.toml
+++ b/pyvolca/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvolca"
-version = "0.8.2"
+version = "0.9.0"
 description = "Python client for VoLCA — Life Cycle Assessment engine"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -590,14 +590,21 @@ class SupplyChainEntry(FromJson):
     ``classifications`` mirrors the producing activity's classifications
     (ISIC, CPC, Category, …) so callers can filter by taxonomy without a
     second :meth:`Client.get_activity` round trip.
+    ``depth`` is the BFS shortest-path distance from the queried root
+    (0 = the root itself), ``upstream_count`` the number of direct
+    consumers of this activity inside the chain, and ``database_name``
+    the database the entry lives in (they differ across linked databases).
     """
 
     process_id: str
+    database_name: str
     activity_name: str
     location: str
     quantity: float
     unit: str
     scaling_factor: float
+    depth: int  # hops from the queried root (0 = root), BFS shortest path
+    upstream_count: int
     classifications: dict[str, str] = field(default_factory=dict)
 
 

--- a/pyvolca/tests/conftest.py
+++ b/pyvolca/tests/conftest.py
@@ -312,11 +312,14 @@ def readme_namespace() -> dict[str, Any]:
         entries=[
             SupplyChainEntry(
                 process_id="cccc3333-aaaa-bbbb-cccc-111122223333_aaaa4444-eeee-ffff-aaaa-444455556666",
+                database_name="agribalyse-3-2",
                 activity_name="Soft wheat grain, at farm",
                 location="FR",
                 quantity=1.31,
                 unit="kg",
                 scaling_factor=1.31,
+                depth=1,
+                upstream_count=1,
             ),
         ],
     )

--- a/pyvolca/tests/test_typed_returns.py
+++ b/pyvolca/tests/test_typed_returns.py
@@ -56,8 +56,9 @@ class TestSupplyChainHasMore:
 
     def _entry(self, name: str) -> SupplyChainEntry:
         return SupplyChainEntry(
-            process_id=f"{name}_pid", activity_name=name, location="FR",
-            quantity=1.0, unit="kg", scaling_factor=1.0,
+            process_id=f"{name}_pid", database_name="db", activity_name=name,
+            location="FR", quantity=1.0, unit="kg", scaling_factor=1.0,
+            depth=1, upstream_count=1,
         )
 
     def test_has_more_false_when_entries_match_filtered(self):
@@ -73,6 +74,46 @@ class TestSupplyChainHasMore:
             entries=[self._entry("a"), self._entry("b")],  # only 2 of 50
         )
         assert sc.has_more is True
+
+
+class TestSupplyChainEntryDecoding:
+    """Decode a wire-shaped entry: the engine has emitted ``depth``,
+    ``databaseName`` and ``upstreamCount`` since v0.6.0, and 0.8.2 silently
+    dropped them — these tests pin that they now survive ``from_json``."""
+
+    WIRE_ENTRY = {
+        "processId": "act_prod",
+        "databaseName": "agribalyse-3-2",
+        "activityName": "market for electricity, low voltage FR",
+        "location": "FR",
+        "quantity": 6.59e8,
+        "unit": "j",
+        "scalingFactor": 138549.0,
+        "depth": 1,
+        "upstreamCount": 2,
+        "classifications": {"Category": "Energy"},
+    }
+
+    def test_wire_entry_keeps_depth_database_and_upstream_count(self):
+        e = SupplyChainEntry.from_json(self.WIRE_ENTRY)
+        assert e.process_id == "act_prod"
+        assert e.database_name == "agribalyse-3-2"
+        assert e.depth == 1
+        assert e.upstream_count == 2
+        assert e.classifications["Category"] == "Energy"
+
+    def test_supply_chain_response_decodes_its_entries(self):
+        sc = SupplyChain.from_json({
+            "root": {
+                "processId": "root", "activityName": "Aioli", "location": "FR",
+                "productName": "aioli", "productAmount": 1.0, "productUnit": "kg",
+            },
+            "totalActivities": 1,
+            "filteredActivities": 1,
+            "supplyChain": [self.WIRE_ENTRY],
+        })
+        assert sc.entries[0].depth == 1
+        assert sc.entries[0].database_name == "agribalyse-3-2"
 
 
 class TestCharacterizationHasMore:

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -1027,7 +1027,7 @@ data SupplyChainEntry = SupplyChainEntry
     , sceScalingFactor :: Double -- raw value from scaling vector
     , sceClassifications :: M.Map Text Text -- Classifications (ISIC, CPC, Category, etc.)
     , sceDepth :: Int -- shortest path distance from root (BFS)
-    , sceUpstreamCount :: Int -- number of unique upstream activities reachable from this one
+    , sceUpstreamCount :: Int -- number of direct consumers of this entry inside the chain
     }
     deriving (Generic)
     deriving (ToJSON, ToSchema) via (Stripped SupplyChainEntry)


### PR DESCRIPTION
The engine has emitted `depth`, `databaseName` and `upstreamCount` on every supply-chain entry since v0.6.0, but pyvolca's `FromJson` mixin silently discarded them. `SupplyChainEntry` now declares the three fields.

They are **required, without defaults**: every engine this client accepts (wire revision 2, so v0.9.1 and later) emits them, and the type should guarantee what the wire guarantees — exactly as `ConsumerResult.depth` already does. No wire revision bump, no `_require_wire` gate.

With `depth`, a filtered `get_supply_chain` response stops being flat: a caller can tell a packaging system (deeper) from the packaging stage that consumes it (shallower) in one call, instead of re-walking the chain activity by activity. That is what the Agribalyse recipe extraction in ecobalyse-method-tooling needs to shed its hand-rolled lifecycle traversal.

Breaking for code that builds `SupplyChainEntry` by hand (our own fixtures needed the three fields), hence **0.9.0** per the changelog's semver note. The release section also covers the pyvolca-visible work merged since 0.8.2: the four method-collection export formats, `get_collection_coverage`, and the wire-4 awareness.

- `pyright` 1.1.411: clean; `pytest`: 266 passed, 5 skipped
- `scripts/gen_api_md.py --write` run (api-reference block regenerated)
- `scripts/release_precheck.py`: READY for `pyvolca-v0.9.0`