### PR TITLE
Let a method except flows from its own wildcard rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@
   prefix with a real factory yard. Writing the family out as a list instead
   would be the stale, per-database list that patterns exist to avoid. An
   exception that matches nothing is announced at load time, like a pattern that
-  matches nothing.
+  matches nothing. Exporting such a method to SimaPro, openLCA or ILCD leaves
+  the exception rows out — those formats have no way to say "except this", and a
+  row written as a flow would characterize exactly what it removes; VoLCA's own
+  CSV keeps them and reads them back.
 - The quality report now says when a geography was never declared. Nearly every
   process of some SimaPro databases leaves the `Geography` field at
   `Unspecified` — 97% of Agribalyse 3.2 — and the only geography left is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## [Unreleased]
 
 ### Added
+- A method can now write an exception to one of its own wildcard rules: a
+  substance starting with `!` takes its flows back out of the patterns declared
+  for the same impact category. Some open families hold members that do not
+  belong to the quantity the category counts, and no set of prefixes separates
+  them — `Occupation, industrial area, benthos` is the sea floor and shares its
+  prefix with a real factory yard. Writing the family out as a list instead
+  would be the stale, per-database list that patterns exist to avoid. An
+  exception that matches nothing is announced at load time, like a pattern that
+  matches nothing.
 - The quality report now says when a geography was never declared. Nearly every
   process of some SimaPro databases leaves the `Geography` field at
   `Unspecified` — 97% of Agribalyse 3.2 — and the only geography left is the
@@ -53,6 +62,17 @@
   output is unchanged.
 
 ### Fixed
+- "Land occupied", in the shipped Plain indicators method, no longer counts the
+  sea. Its rule takes every `Occupation, …` flow, and that family holds the open
+  ocean and the sea floor alongside fields and roads. Anything fed from the sea
+  was reported as standing on it: one aggregated fish-meal process declares 679
+  m²·year of `Occupation, sea and ocean`, and a farmed trout came out at 388
+  m²·year of land — it now reads 0.87. A land crop is barely touched, since all
+  it loses is the water a cargo ship crossed on its behalf: across Agribalyse's
+  455 farm-gate products the median change is −0.004%, an apricot orchard goes
+  from 6.96202 to 6.96198, and nothing anywhere rises. Sea, seabed and benthic
+  occupation are now excepted; inland water bodies stay counted, a reservoir
+  being a real surface somebody flooded.
 - A region-tagged flow now gets the density that goes with the factor it
   borrows. When a method has no line for `Water, SERC`, VoLCA lends it the line
   written for `Water` — but that line can be denominated per kilogram while the

--- a/data/methods/plain-indicators.csv
+++ b/data/methods/plain-indicators.csv
@@ -7,11 +7,21 @@
 # flow is counted without touching this file. Single substances are ordinary
 # rows; the flow registry bridges their spelling variants across databases
 # (e.g. "Methane, biogenic" / "Methane, non-fossil").
+# A substance starting with ! is an exception carved out of the patterns of the
+# same category: "Land occupied" counts fields, roads and roofs, but an
+# occupation family also holds the sea floor, which is neither land nor
+# anybody's ground. The value cell only says which category the exception
+# applies to. Inland water bodies stay counted: a reservoir is a real surface
+# somebody flooded.
 ;;;;Land occupied;Water used;Fossil CO2;Methane;Primary energy;Waste heat;Cadmium
 ;;;;Land occupied;Water used;Fossil CO2;Methane;Primary energy;Waste heat;Cadmium
 ;;;;m2a;m3;kg;kg;MJ;MJ;kg
 substance;compartment;cas;unit;;;;;;;
 Occupation*;resource;;;1.0;;;;;;
+!Occupation, sea*;resource;;;1.0;;;;;;
+!Occupation, seabed*;resource;;;1.0;;;;;;
+!Occupation, dump site, benthos;resource;;;1.0;;;;;;
+!Occupation, industrial area, benthos;resource;;;1.0;;;;;;
 Water*;resource;;;;1.0;;;;;
 Carbon dioxide, fossil;air;;;;;1.0;;;;
 Methane;air;;;;;;1.0;;;

--- a/src/Database/Export.hs
+++ b/src/Database/Export.hs
@@ -34,7 +34,8 @@ import Database.Upload (DatabaseFormat (..))
 import qualified EcoSpold.Writer1 as ES1
 import qualified EcoSpold.Writer2 as ES2
 import qualified ILCD.Writer as ILCD
-import Method.Types (MethodCollection)
+import Method.Mapping (isExclusionCF)
+import Method.Types (Method (..), MethodCollection (..))
 import qualified Method.WriterCSV as MWC
 import qualified Method.WriterILCD as MWI
 import qualified Method.WriterOlcaSchema as MWO
@@ -105,13 +106,24 @@ serializeMethodCollection :: MethodExportFormat -> Text -> MethodCollection -> E
 serializeMethodCollection fmt name mc = case fmt of
     MethodSimaProCSV ->
         first BL.fromStrict
-            <$> MW.serializeSimaProMethodCSV SP.defaultWriterConfig name mc
+            <$> MW.serializeSimaProMethodCSV SP.defaultWriterConfig name (withoutExclusions mc)
     MethodColumnarCSV ->
         first BL.fromStrict <$> MWC.serializeColumnarMethodCSV mc
     MethodOpenLcaJsonLd ->
-        first zipFiles <$> MWO.serializeOlcaMethodEntries mc
+        first zipFiles <$> MWO.serializeOlcaMethodEntries (withoutExclusions mc)
     MethodIlcdXml ->
-        first zipFiles <$> MWI.serializeIlcdMethodEntries mc
+        first zipFiles <$> MWI.serializeIlcdMethodEntries (withoutExclusions mc)
+
+{- | Drop the exclusion rows before writing a format that has no notion of one.
+A @"!Occupation, sea*"@ row would otherwise land as a flow characterized at the
+number its value cell only ever used to name a category — the export would
+characterize exactly what the exception takes out. The columnar CSV is VoLCA's
+own method format and reads the marker back, so it keeps them and round-trips.
+-}
+withoutExclusions :: MethodCollection -> MethodCollection
+withoutExclusions mc = mc{mcMethods = map dropExclusionRows (mcMethods mc)}
+  where
+    dropExclusionRows m = m{methodFactors = filter (not . isExclusionCF) (methodFactors m)}
 
 {- | Parse a user-facing export-format name (case- and whitespace-insensitive)
 to a 'DatabaseFormat'. Shared by the CLI and the HTTP handler so the accepted

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -170,10 +170,12 @@ import Method.Mapping (
     buildMethodTables,
     characterizedFlowIds,
     directionExcludedCFs,
+    dropExcludedMappings,
     expandProxyEdges,
     expandSynonymMappings,
     fillBroadcastVector,
     fillRegionalActivityWeights,
+    isExclusionCF,
     mapMethodToFlows,
     mtRegionalActivityWeights,
     mtRegionalizedCF,
@@ -613,6 +615,10 @@ than the raw cascade, or they under-report what the score tables contain.
 Uses the database's frozen-at-load-time synonym DB, which holds the curated
 registry plus any source the user had explicitly activated at load time
 (auto-extracted candidates are persisted but never loaded by the engine).
+
+The method's exclusions are re-applied last: the expansions travel by flow
+name and would otherwise hand an excepted flow the factor of a sibling it
+shares a synonym group with (see 'dropExcludedMappings').
 -}
 effectiveMethodMappings :: DatabaseManager -> Text -> Text -> Database -> Method -> IO [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]
 effectiveMethodMappings manager dbName collection db method = do
@@ -620,9 +626,10 @@ effectiveMethodMappings manager dbName collection db method = do
     let synDB = fromMaybe emptySynonymDB (dbSynonymDB db)
         proxyTargets = ProxyTargets (dbFlowsByName db) (dbFlowsByCAS db) (dbBioFlows db)
     pure $
-        expandProxyEdges proxyTargets (dmSubstanceEdges manager) $
-            projectRegionalResourceFlows synDB (dbBioFlows db) $
-                expandSynonymMappings synDB (dbFlowsByName db) mappings
+        dropExcludedMappings (filter isExclusionCF (methodFactors method)) $
+            expandProxyEdges proxyTargets (dmSubstanceEdges manager) $
+                projectRegionalResourceFlows synDB (dbBioFlows db) $
+                    expandSynonymMappings synDB (dbFlowsByName db) mappings
 
 -- | Cached prepared CF tables: built once per (db, method), reused across inventories.
 mapMethodToTablesCached :: DatabaseManager -> Text -> Text -> Database -> Method -> IO MethodTables

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -18,7 +18,9 @@ module Method.Mapping (
     mapMethodToFlows,
     resolveCF,
     isPatternCF,
+    isExclusionCF,
     expandPatternCF,
+    exclusionWarning,
     buildMapContext,
 
     -- * LCIA scoring
@@ -100,7 +102,7 @@ import Data.List (find, nub, partition, sortOn)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
-import Data.Maybe (fromMaybe, isJust, isNothing)
+import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe)
 import Data.Ord (Down (..))
 import Data.STRef (modifySTRef', newSTRef, readSTRef)
 import qualified Data.Set as S
@@ -231,7 +233,8 @@ mapMethodFlows ::
     IO [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]
 mapMethodFlows ctx0 method = do
     caps <- getNumCapabilities
-    let (patternCFs, cfs) = partition isPatternCF (methodFactors method)
+    let (exclusionCFs, plainCFs) = partition isExclusionCF (methodFactors method)
+        (patternCFs, cfs) = partition isPatternCF plainCFs
         n = length cfs
         -- Precompute the synonym-group → flows memo for the groups this method's
         -- CFs reference (each group expanded once), then resolve every CF against
@@ -243,14 +246,15 @@ mapMethodFlows ctx0 method = do
         if caps <= 1 || n < parCfThreshold
             then mapM resolve cfs
             else concat <$> mapConcurrently (mapM resolve) (chunksOf (max 1 ((n + caps - 1) `div` caps)) cfs)
-    expanded <- fmap concat . mapM materialize $ patternCFs
+    mapM_ (warn . pure) (mapMaybe (exclusionWarning (mcBioFlowsByUUID ctx0)) exclusionCFs)
+    expanded <- fmap concat . mapM (materialize exclusionCFs) $ patternCFs
     pure (concrete ++ expanded)
   where
     parCfThreshold = 1000
-    materialize cf = do
-        let (rows, warnings) = expandPatternCF (mcBioFlowsByUUID ctx0) cf
-            prefix = "[LCIA " <> methodName method <> "] "
-        mapM_ (reportProgress Warning . T.unpack . (prefix <>)) warnings
+    warn = mapM_ (reportProgress Warning . T.unpack . (("[LCIA " <> methodName method <> "] ") <>))
+    materialize exclusions cf = do
+        let (rows, warnings) = expandPatternCF (mcBioFlowsByUUID ctx0) exclusions cf
+        warn warnings
         pure rows
 
 {- | Resolve one method CF to a database biosphere flow. The built-in matchers
@@ -280,39 +284,45 @@ them against the database — so a method can declare an open family of flows
 as one rule instead of a per-database list that silently goes stale.
 -}
 isPatternCF :: MethodCF -> Bool
-isPatternCF = T.isSuffixOf "*" . mcfFlowName
+isPatternCF cf = not (isExclusionCF cf) && T.isSuffixOf "*" (mcfFlowName cf)
 
-{- | Materialize one pattern CF against the database's biosphere: one concrete
-CF per flow satisfying every predicate the row carries (name prefix, CAS,
-compartment medium and — when the row states one — subcompartment). Each
-concrete CF takes the flow's own identity (UUID,
-name, CAS, compartment) — so every table built from the mapping lands exactly
-where the inventory flow will look — and keeps the pattern row's value and
-unit. A database introducing a new flow under the pattern is thus counted on
-its next mapping without touching the method file.
+{- | A row whose substance starts with @!@: an exception carved out of the
+patterns declared for the same impact category. Some open families have members
+that do not belong to the quantity the category counts — an occupation family
+holds the sea floor as well as the fields — and no set of prefixes can separate
+them, because @"Occupation, industrial area, benthos"@ shares its prefix with
+real industrial land.
 
-Failure is loud, not silent: a pattern matching no flow comes back as an
-unmatched row plus a warning (coverage then shows the gap instead of the
-category quietly counting zero), and a bare @"*"@ constrained by nothing is
-refused the same way — matching the entire biosphere is never intended.
+The substance after the @!@ reads exactly like a pattern's: a case-insensitive
+name prefix, with the trailing @*@ optional since a full flow name is already
+the prefix of nothing else. The value cell says which categories the exception
+applies to; its magnitude is never used.
+
+Exceptions narrow patterns only. A literal row is a deliberate statement about
+one flow, so excluding it would be the method contradicting itself rather than
+qualifying an open family.
 -}
-expandPatternCF ::
-    BioFlowDB ->
-    MethodCF ->
-    ([(MethodCF, Maybe (BiosphereFlow, MatchStrategy))], [Text])
-expandPatternCF flows cf
-    | not constrained = refuse "has no name prefix, CAS or compartment; refusing to match every flow"
-    | null matches = refuse "matches no flow in this database"
-    | otherwise = ([(materialize f, Just (f, ByName)) | f <- matches], [])
+isExclusionCF :: MethodCF -> Bool
+isExclusionCF = T.isPrefixOf "!" . mcfFlowName
+
+{- | The case-insensitive name prefix a pattern or exclusion row selects on:
+the substance cell without its @!@ marker and without its trailing @*@.
+-}
+patternPrefix :: MethodCF -> Text
+patternPrefix = T.toCaseFold . dropStar . T.dropWhile (== '!') . mcfFlowName
   where
-    refuse why = ([(cf, Nothing)], ["wildcard CF '" <> mcfFlowName cf <> "' " <> why])
-    prefix = T.toCaseFold (T.dropEnd 1 (mcfFlowName cf))
-    wantCAS = normalizeCAS <$> mcfCAS cf
-    constrained = not (T.null prefix) || isJust wantCAS || isJust (mcfCompartment cf)
-    matches = filter fits (M.elems flows)
-    fits f = prefix `T.isPrefixOf` T.toCaseFold (bfName f) && casFits f && compFits f
-    casFits f = maybe True (\cas -> bfCAS f == Just cas) wantCAS
-    compFits f = case mcfCompartment cf of
+    dropStar t = fromMaybe t (T.stripSuffix "*" t)
+
+{- | Does a pattern-shaped row select that flow? Every predicate the row
+carries must hold: name prefix, CAS, compartment medium and — when the row
+states one — subcompartment. Shared by 'expandPatternCF' and by the exclusions
+that narrow it, so a family and its exceptions are read by one rule.
+-}
+selectsFlow :: MethodCF -> BiosphereFlow -> Bool
+selectsFlow cf f = patternPrefix cf `T.isPrefixOf` T.toCaseFold (bfName f) && casFits && compFits
+  where
+    casFits = maybe True ((\cas -> bfCAS f == Just cas) . normalizeCAS) (mcfCAS cf)
+    compFits = case mcfCompartment cf of
         Nothing -> True
         Just (Compartment med sub _) ->
             maybe False (\c -> mediumEq med (VT.compartmentName c) && subFits sub c) (bfCompartment f)
@@ -322,6 +332,45 @@ expandPatternCF flows cf
     subFits sub c =
         T.null sub || T.toCaseFold sub == maybe "" T.toCaseFold (VT.compartmentSub c)
     mediumEq a b = normalizeMedium (T.toCaseFold a) == normalizeMedium (T.toCaseFold b)
+
+{- | Is the row constrained by anything at all? A selector with no name prefix,
+no CAS and no compartment would match the entire biosphere, which is never what
+a method means.
+-}
+isConstrainedCF :: MethodCF -> Bool
+isConstrainedCF cf =
+    not (T.null (patternPrefix cf)) || isJust (mcfCAS cf) || isJust (mcfCompartment cf)
+
+{- | Materialize one pattern CF against the database's biosphere: one concrete
+CF per flow the row selects and no exclusion of the same category takes back.
+Each concrete CF takes the flow's own identity (UUID, name, CAS, compartment) —
+so every table built from the mapping lands exactly where the inventory flow
+will look — and keeps the pattern row's value and unit. A database introducing
+a new flow under the pattern is thus counted on its next mapping without
+touching the method file.
+
+Failure is loud, not silent: a pattern matching no flow comes back as an
+unmatched row plus a warning (coverage then shows the gap instead of the
+category quietly counting zero), and a bare @"*"@ constrained by nothing is
+refused the same way — matching the entire biosphere is never intended. A
+pattern whose every match is excluded is refused on the same grounds: a family
+that survives as nothing is a method file that has stopped saying anything.
+-}
+expandPatternCF ::
+    BioFlowDB ->
+    -- | exclusions declared for this category, see 'isExclusionCF'
+    [MethodCF] ->
+    MethodCF ->
+    ([(MethodCF, Maybe (BiosphereFlow, MatchStrategy))], [Text])
+expandPatternCF flows exclusions cf
+    | not (isConstrainedCF cf) = refuse "has no name prefix, CAS or compartment; refusing to match every flow"
+    | null selected = refuse "matches no flow in this database"
+    | null matches = refuse "matches only flows its exclusions take back"
+    | otherwise = ([(materialize f, Just (f, ByName)) | f <- matches], [])
+  where
+    refuse why = ([(cf, Nothing)], ["wildcard CF '" <> mcfFlowName cf <> "' " <> why])
+    selected = filter (selectsFlow cf) (M.elems flows)
+    matches = filter (\f -> not (any (`selectsFlow` f) exclusions)) selected
     materialize f =
         cf
             { mcfFlowRef = bfId f
@@ -331,6 +380,18 @@ expandPatternCF flows cf
             }
     fromFlowCompartment c =
         Compartment (VT.compartmentName c) (fromMaybe "" (VT.compartmentSub c)) ""
+
+{- | Why an exclusion row could not do its job, if it could not. An exclusion
+that takes nothing back is almost always a misspelling, and left unsaid it
+reads exactly like a category that never needed the exception.
+-}
+exclusionWarning :: BioFlowDB -> MethodCF -> Maybe Text
+exclusionWarning flows cf
+    | not (isConstrainedCF cf) = Just (why "has no name prefix, CAS or compartment; refusing to exclude every flow")
+    | not (any (selectsFlow cf) (M.elems flows)) = Just (why "matches no flow in this database")
+    | otherwise = Nothing
+  where
+    why reason = "exclusion CF '" <> mcfFlowName cf <> "' " <> reason
 
 -- | Convert strategy text back to MatchStrategy
 strategyFromText :: Text -> MatchStrategy

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -20,6 +20,7 @@ module Method.Mapping (
     isPatternCF,
     isExclusionCF,
     expandPatternCF,
+    dropExcludedMappings,
     exclusionWarning,
     buildMapContext,
 
@@ -309,8 +310,9 @@ isExclusionCF = T.isPrefixOf "!" . mcfFlowName
 the substance cell without its @!@ marker and without its trailing @*@.
 -}
 patternPrefix :: MethodCF -> Text
-patternPrefix = T.toCaseFold . dropStar . T.dropWhile (== '!') . mcfFlowName
+patternPrefix = T.toCaseFold . dropStar . dropBang . mcfFlowName
   where
+    dropBang t = fromMaybe t (T.stripPrefix "!" t)
     dropStar t = fromMaybe t (T.stripSuffix "*" t)
 
 {- | Does a pattern-shaped row select that flow? Every predicate the row
@@ -319,10 +321,15 @@ states one — subcompartment. Shared by 'expandPatternCF' and by the exclusions
 that narrow it, so a family and its exceptions are read by one rule.
 -}
 selectsFlow :: MethodCF -> BiosphereFlow -> Bool
-selectsFlow cf f = patternPrefix cf `T.isPrefixOf` T.toCaseFold (bfName f) && casFits && compFits
+-- Written as a lambda over the flow so the row's own share of the work — case
+-- folding its prefix, normalizing its CAS — is done once per row rather than
+-- once per (row, flow) pair: this runs over the whole biosphere.
+selectsFlow cf = \f -> prefix `T.isPrefixOf` T.toCaseFold (bfName f) && casFits f && compFits f
   where
-    casFits = maybe True ((\cas -> bfCAS f == Just cas) . normalizeCAS) (mcfCAS cf)
-    compFits = case mcfCompartment cf of
+    prefix = patternPrefix cf
+    wantCAS = normalizeCAS <$> mcfCAS cf
+    casFits f = maybe True (\cas -> bfCAS f == Just cas) wantCAS
+    compFits f = case mcfCompartment cf of
         Nothing -> True
         Just (Compartment med sub _) ->
             maybe False (\c -> mediumEq med (VT.compartmentName c) && subFits sub c) (bfCompartment f)
@@ -332,6 +339,14 @@ selectsFlow cf f = patternPrefix cf `T.isPrefixOf` T.toCaseFold (bfName f) && ca
     subFits sub c =
         T.null sub || T.toCaseFold sub == maybe "" T.toCaseFold (VT.compartmentSub c)
     mediumEq a b = normalizeMedium (T.toCaseFold a) == normalizeMedium (T.toCaseFold b)
+
+{- | Is that flow taken back by any of these exclusion rows? The predicates are
+built once for the row set, then run over as many flows as the caller has.
+-}
+excludedBy :: [MethodCF] -> BiosphereFlow -> Bool
+excludedBy exclusions = \f -> any ($ f) predicates
+  where
+    predicates = map selectsFlow exclusions
 
 {- | Is the row constrained by anything at all? A selector with no name prefix,
 no CAS and no compartment would match the entire biosphere, which is never what
@@ -370,7 +385,7 @@ expandPatternCF flows exclusions cf
   where
     refuse why = ([(cf, Nothing)], ["wildcard CF '" <> mcfFlowName cf <> "' " <> why])
     selected = filter (selectsFlow cf) (M.elems flows)
-    matches = filter (\f -> not (any (`selectsFlow` f) exclusions)) selected
+    matches = filter (not . excludedBy exclusions) selected
     materialize f =
         cf
             { mcfFlowRef = bfId f
@@ -380,6 +395,31 @@ expandPatternCF flows exclusions cf
             }
     fromFlowCompartment c =
         Compartment (VT.compartmentName c) (fromMaybe "" (VT.compartmentSub c)) ""
+
+{- | Take the exclusions' flows back out of a finished mapping list.
+
+'expandPatternCF' already leaves them out when it materializes a family, but
+the mappings scoring reads are that output re-expanded — synonym fan-out,
+regional projection, proxy edges — and those expansions travel by flow name,
+knowing nothing of the method's exceptions. The curated flow registry bridges
+@"Occupation, industrial area"@ and @"Occupation, industrial area, benthos"@
+through the label they share, so a surviving sibling would hand the excluded
+sea floor its own factor back. Applied after the expansions, this holds the
+exception wherever the flow re-enters.
+-}
+dropExcludedMappings ::
+    -- | exclusions declared for this category, see 'isExclusionCF'
+    [MethodCF] ->
+    [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] ->
+    [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]
+dropExcludedMappings [] = id
+dropExcludedMappings exclusions = filter kept
+  where
+    excluded = excludedBy exclusions
+    -- An unmatched row carries no flow to judge, and dropping it would hide the
+    -- gap the coverage report exists to show.
+    kept (_, Just (f, _)) = not (excluded f)
+    kept (_, Nothing) = True
 
 {- | Why an exclusion row could not do its job, if it could not. An exclusion
 that takes nothing back is almost always a misspelling, and left unsaid it

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -12,14 +12,17 @@ module ExportSpec (spec) where
 import Control.Monad (forM_)
 import qualified Data.ByteString.Lazy as BL
 import Data.Either (isLeft)
+import Data.List (isInfixOf)
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
 import qualified Data.UUID as UUID
 import Test.Hspec
 
 import qualified Database as DB
-import Database.Export (serializeDatabase)
+import Database.Export (MethodExportFormat (..), serializeDatabase, serializeMethodCollection)
 import Database.Upload (DatabaseFormat (..))
+import qualified Method.Types as MT
 import Types
 import UnitConversion (defaultUnitConfig)
 
@@ -36,6 +39,40 @@ spec = describe "Database.Export dispatcher" $ do
         db <- buildFixture (Compartment "air" (Just "unspecified"))
         serializeDatabase OpenLcaJsonLd db `shouldSatisfy` isLeft
         serializeDatabase UnknownFormat db `shouldSatisfy` isLeft
+
+    it "writes an exclusion row only to the format that reads the marker back" $ do
+        -- VoLCA's own columnar CSV parses "!…" as an exception and must keep it,
+        -- or a round-trip loses it and the category counts what it excepted.
+        -- SimaPro has no such notion: the row would land as a characterized flow
+        -- named "!Occupation, sea*" — the sea counted at 1, the exception inverted.
+        let mc = MT.MethodCollection [landOccupied] [] [] []
+            landOccupied =
+                MT.Method
+                    { MT.methodId = UUID.nil
+                    , MT.methodName = "Land occupied"
+                    , MT.methodDescription = Nothing
+                    , MT.methodUnit = "m2a"
+                    , MT.methodCategory = "Land occupied"
+                    , MT.methodMethodology = Nothing
+                    , MT.methodFactors = [mkFactor "Occupation, annual crop", mkFactor "!Occupation, sea*"]
+                    }
+            mkFactor name =
+                MT.MethodCF
+                    { MT.mcfFlowRef = UUID.nil
+                    , MT.mcfFlowName = name
+                    , MT.mcfDirection = MT.Input
+                    , MT.mcfValue = 1.0
+                    , MT.mcfCompartment = Just (MT.Compartment "natural resource" "" "")
+                    , MT.mcfCAS = Nothing
+                    , MT.mcfUnit = "m2a"
+                    , MT.mcfConsumerLocation = Nothing
+                    }
+            written fmt = case serializeMethodCollection fmt "plain-indicators" mc of
+                Left err -> T.unpack err
+                Right (bytes, _warnings) -> T.unpack (TE.decodeUtf8 (BL.toStrict bytes))
+        written MethodColumnarCSV `shouldSatisfy` isInfixOf "!Occupation, sea*"
+        written MethodSimaProCSV `shouldSatisfy` (not . isInfixOf "!Occupation")
+        written MethodSimaProCSV `shouldSatisfy` isInfixOf "Occupation, annual crop"
 
     it "propagates a writer's export-guard failure" $ do
         -- A "raw" emission compartment has no faithful SimaPro section, so the

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -11,6 +11,7 @@ import Data.UUID (UUID, fromWords, nil)
 import Data.UUID.V4 (nextRandom)
 import Test.Hspec
 
+import Data.Maybe (isJust)
 import Method.ChemSynonyms (emptyChemSynonyms, parseChemSynonymsCSV)
 import Method.Mapping
 import Method.ParserCSV (parseMethodCSVBytes)
@@ -924,14 +925,24 @@ spec = do
                 , waterWell
                 , methaneAir
                 , methaneWater
+                , occSea
+                , occIndustrial
+                , occBenthos
                 ]
             occAnnual = mkFlow (u 1) "Occupation, annual crop" "resource" Nothing
             occOrchard = mkFlow (u 2) "Occupation, permanent crop, fruit" "resource" Nothing
+            -- The sea floor and a factory yard sit in one occupation family, and
+            -- the drowned one shares its prefix with the dry one: the case
+            -- exclusions exist for, since no set of prefixes separates them.
+            occSea = mkFlow (u 8) "Occupation, sea and ocean" "resource" Nothing
+            occIndustrial = mkFlow (u 9) "Occupation, industrial area" "resource" Nothing
+            occBenthos = mkFlow (u 10) "Occupation, industrial area, benthos" "resource" Nothing
             transformation = mkFlow (u 3) "Transformation, to annual crop" "resource" Nothing
             waterRiver = mkFlow (u 4) "Water, river" "resource" Nothing
             waterWell = mkFlow (u 7) "Water, well" "resource" (Just "in ground")
             methaneAir = (mkFlow (u 5) "Methane, fossil" "air" Nothing){bfCAS = Just "74-82-8"}
             methaneWater = (mkFlow (u 6) "Methane, fossil" "water" Nothing){bfCAS = Just "74-82-8"}
+            occupationFlows = [occAnnual, occOrchard, occSea, occIndustrial, occBenthos]
             u = uuidFromInt
             -- Compare by UUID: BiosphereFlow has no Eq/Show instance.
             expandedIds = map (fmap (bfId . fst) . snd) . fst
@@ -943,38 +954,99 @@ spec = do
 
         it "expands a prefix pattern to every flow of the compartment, none else" $ do
             let cf = mkCFComp "Occupation*" "natural resource" "" 1.0
-            expandedIds (expandPatternCF flowDB cf)
-                `shouldMatchList` map (Just . bfId) [occAnnual, occOrchard]
+            expandedIds (expandPatternCF flowDB [] cf)
+                `shouldMatchList` map (Just . bfId) occupationFlows
 
         it "materializes each match with the flow's own identity, keeping value and unit" $ do
             let cf = (mkCFComp "Occupation*" "natural resource" "" 1.0){mcfUnit = "m2a"}
-                (rows, warnings) = expandPatternCF flowDB cf
+                (rows, warnings) = expandPatternCF flowDB [] cf
             warnings `shouldBe` []
             [(mcfFlowRef m, mcfFlowName m, mcfValue m, mcfUnit m) | (m, _) <- rows]
-                `shouldMatchList` [(bfId f, bfName f, 1.0, "m2a") | f <- [occAnnual, occOrchard]]
+                `shouldMatchList` [(bfId f, bfName f, 1.0, "m2a") | f <- occupationFlows]
 
         it "honors the sub-compartment a pattern row states, widens without one" $ do
             let inGround = mkCFComp "Water*" "natural resource" "in ground" 1.0
                 anySub = mkCFComp "Water*" "natural resource" "" 1.0
-            expandedIds (expandPatternCF flowDB inGround) `shouldBe` [Just (bfId waterWell)]
-            expandedIds (expandPatternCF flowDB anySub)
+            expandedIds (expandPatternCF flowDB [] inGround) `shouldBe` [Just (bfId waterWell)]
+            expandedIds (expandPatternCF flowDB [] anySub)
                 `shouldMatchList` map (Just . bfId) [waterRiver, waterWell]
 
         it "a bare * with a CAS expands by CAS, filtered by the row's compartment" $ do
             let cf = (mkCFComp "*" "air" "" 1.0){mcfCAS = Just "74-82-8"}
-            expandedIds (expandPatternCF flowDB cf) `shouldBe` [Just (bfId methaneAir)]
+            expandedIds (expandPatternCF flowDB [] cf) `shouldBe` [Just (bfId methaneAir)]
 
         it "a pattern matching no flow surfaces one unmatched row and a warning" $ do
             let cf = mkCFComp "Uranium*" "natural resource" "" 1.0
-                (rows, warnings) = expandPatternCF flowDB cf
+                (rows, warnings) = expandPatternCF flowDB [] cf
             map (fmap (bfId . fst) . snd) rows `shouldBe` [Nothing]
             length warnings `shouldBe` 1
 
         it "a bare * constrained by nothing is refused, not matched to everything" $ do
             let cf = mkCF "*" Nothing 1.0
-                (rows, warnings) = expandPatternCF flowDB cf
+                (rows, warnings) = expandPatternCF flowDB [] cf
             map (fmap (bfId . fst) . snd) rows `shouldBe` [Nothing]
             length warnings `shouldBe` 1
+
+        it "reads a leading ! as an exclusion, not as a pattern" $ do
+            isExclusionCF (mkCF "!Occupation, sea*" Nothing 1.0) `shouldBe` True
+            isExclusionCF (mkCF "Occupation*" Nothing 1.0) `shouldBe` False
+            -- An exclusion ends in a star too; whichever test runs first must
+            -- not claim it, or the row would be expanded instead of subtracted.
+            isPatternCF (mkCF "!Occupation, sea*" Nothing 1.0) `shouldBe` False
+
+        it "an exclusion takes its flows back out of the family the pattern opened" $ do
+            let cf = mkCFComp "Occupation*" "natural resource" "" 1.0
+                sea = mkCFComp "!Occupation, sea*" "natural resource" "" 1.0
+            expandedIds (expandPatternCF flowDB [sea] cf)
+                `shouldMatchList` map (Just . bfId) [occAnnual, occOrchard, occIndustrial, occBenthos]
+
+        it "an exclusion needs no trailing star: a whole flow name is a prefix of nothing else" $ do
+            let cf = mkCFComp "Occupation*" "natural resource" "" 1.0
+                benthos = mkCFComp "!Occupation, industrial area, benthos" "natural resource" "" 1.0
+            -- The dry industrial area survives, though it shares the prefix up
+            -- to the comma: the exclusion is read in full, not truncated.
+            expandedIds (expandPatternCF flowDB [benthos] cf)
+                `shouldMatchList` map (Just . bfId) [occAnnual, occOrchard, occSea, occIndustrial]
+
+        it "an exclusion matching no flow is announced, never silently ignored" $ do
+            let typo = mkCFComp "!Occupation, seaa*" "natural resource" "" 1.0
+            exclusionWarning flowDB typo `shouldSatisfy` isJust
+
+        it "an exclusion constrained by nothing is refused, like a bare pattern" $
+            exclusionWarning flowDB (mkCF "!" Nothing 1.0) `shouldSatisfy` isJust
+
+        it "an exclusion that does its job says nothing" $ do
+            let sea = mkCFComp "!Occupation, sea*" "natural resource" "" 1.0
+            exclusionWarning flowDB sea `shouldBe` Nothing
+
+        it "a pattern whose every match is excluded is refused, not silently empty" $ do
+            let cf = mkCFComp "Transformation*" "natural resource" "" 1.0
+                all' = mkCFComp "!Transformation*" "natural resource" "" 1.0
+                (rows, warnings) = expandPatternCF flowDB [all'] cf
+            map (fmap (bfId . fst) . snd) rows `shouldBe` [Nothing]
+            length warnings `shouldBe` 1
+
+        it "mapMethodFlows subtracts the category's exclusions from its patterns" $ do
+            let method =
+                    Method
+                        { methodId = nil
+                        , methodName = "Land occupied"
+                        , methodDescription = Nothing
+                        , methodUnit = "m2a"
+                        , methodCategory = "Land occupied"
+                        , methodMethodology = Nothing
+                        , methodFactors =
+                            [ mkCFComp "Occupation*" "natural resource" "" 1.0
+                            , mkCFComp "!Occupation, sea*" "natural resource" "" 1.0
+                            , mkCFComp "!Occupation, industrial area, benthos" "natural resource" "" 1.0
+                            ]
+                        }
+                ctx = MapContext flowDB (byName allFlows) M.empty emptySynonymDB M.empty M.empty
+            mappings <- mapMethodFlows ctx method
+            -- The exclusion rows themselves never become factors: a method that
+            -- kept them would characterize the very flows it just disowned.
+            map (fmap (bfId . fst) . snd) mappings
+                `shouldMatchList` map (Just . bfId) [occAnnual, occOrchard, occIndustrial]
 
         it "mapMethodFlows resolves literal rows via the cascade and expands patterns" $ do
             let method =
@@ -993,7 +1065,7 @@ spec = do
                 ctx = MapContext flowDB (byName allFlows) M.empty emptySynonymDB M.empty M.empty
             mappings <- mapMethodFlows ctx method
             map (fmap (bfId . fst) . snd) mappings
-                `shouldMatchList` map (Just . bfId) [waterRiver, occAnnual, occOrchard]
+                `shouldMatchList` map (Just . bfId) (waterRiver : occupationFlows)
 
     -- Lint of the shipped method file, like RegistryLintSpec for data/flows.csv:
     -- a header typo or a misplaced comment would otherwise ship silently.
@@ -1007,6 +1079,19 @@ spec = do
         it "carries its wildcard rows as patterns" $
             [mcfFlowName cf | Right ms <- [parsed], m <- ms, cf <- methodFactors m, isPatternCF cf]
                 `shouldBe` ["Occupation*", "Water*", "Energy, *", "Heat, waste*"]
+
+        it "carries its marine exceptions as exclusions of Land occupied" $
+            [ (methodName m, mcfFlowName cf)
+            | Right ms <- [parsed]
+            , m <- ms
+            , cf <- methodFactors m
+            , isExclusionCF cf
+            ]
+                `shouldBe` [ ("Land occupied", "!Occupation, sea*")
+                           , ("Land occupied", "!Occupation, seabed*")
+                           , ("Land occupied", "!Occupation, dump site, benthos")
+                           , ("Land occupied", "!Occupation, industrial area, benthos")
+                           ]
 
 tShow :: (Show a) => a -> Text
 tShow = T.pack . show

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -1048,6 +1048,38 @@ spec = do
             map (fmap (bfId . fst) . snd) mappings
                 `shouldMatchList` map (Just . bfId) [occAnnual, occOrchard, occIndustrial]
 
+        it "an exclusion still holds when the synonym fan-out re-reaches its flow" $ do
+            let method =
+                    Method
+                        { methodId = nil
+                        , methodName = "Land occupied"
+                        , methodDescription = Nothing
+                        , methodUnit = "m2a"
+                        , methodCategory = "Land occupied"
+                        , methodMethodology = Nothing
+                        , methodFactors =
+                            [ mkCFComp "Occupation*" "natural resource" "" 1.0
+                            , mkCFComp "!Occupation, industrial area, benthos" "natural resource" "" 1.0
+                            ]
+                        }
+                ctx = MapContext flowDB (byName allFlows) M.empty emptySynonymDB M.empty M.empty
+                -- The curated registry bridges the dry industrial area and its
+                -- drowned namesake through the label they share, as data/flows.csv
+                -- does; the fan-out then travels by name, knowing no exceptions.
+                synDB =
+                    buildFromPairs
+                        [ ("Occupation, industrial area", "industrial area")
+                        , ("Occupation, industrial area, benthos", "industrial area")
+                        ]
+            mappings <- mapMethodFlows ctx method
+            let expanded = expandSynonymMappings synDB (byName allFlows) mappings
+                ids = map (fmap (bfId . fst) . snd)
+            -- The bridge really does hand the excluded flow back — without this
+            -- the test below would pass on an expansion that never reached it.
+            ids expanded `shouldSatisfy` elem (Just (bfId occBenthos))
+            ids (dropExcludedMappings (filter isExclusionCF (methodFactors method)) expanded)
+                `shouldSatisfy` notElem (Just (bfId occBenthos))
+
         it "mapMethodFlows resolves literal rows via the cascade and expands patterns" $ do
             let method =
                     Method


### PR DESCRIPTION
## Problem

The shipped **Plain indicators** method computes "Land occupied" from one
wildcard rule, `Occupation*`. That family is not all land: Agribalyse names
the open ocean `Occupation, sea and ocean`, the sea floor `Occupation,
seabed, …`, and the drowned parts of two other families `…, benthos`.

One aggregated fish-meal process declares **679 m²·year of ocean**, so
anything fed from the sea was reported as standing on it. A farmed trout came
out at **388 m²·year of land**. It is 0.87.

No set of prefixes separates the two. `Occupation, industrial area, benthos`
is the sea floor and shares its prefix with a real factory yard. Writing the
family out as an explicit list instead would reintroduce exactly the stale,
per-database list that wildcard rows were added to remove.

## What this does

A substance cell starting with `!` is an **exception**: it takes its flows back
out of the patterns declared for the same impact category. The text after the
`!` reads like a pattern's — a case-insensitive name prefix, trailing `*`
optional, since a full flow name is already the prefix of nothing else. The
value cell only says which categories the exception applies to.

Exceptions narrow patterns only. A literal row is a deliberate statement about
one flow, so excluding it would be the method contradicting itself rather than
qualifying an open family.

`selectsFlow` is now shared by patterns and exceptions, so a family and its
exceptions are read by one rule rather than two that can drift.

The exception is subtracted twice: once when a family is materialized, and once
where the mappings scoring reads are finished. The steps in between — synonym
fan-out, regional projection, proxy edges — travel by flow name and know nothing
of a method's exceptions, and the curated registry bridges `Occupation,
industrial area` and `Occupation, industrial area, benthos` through the label
they share, so a surviving sibling would hand the sea floor its factor back.

Exporting such a method to SimaPro, openLCA or ILCD leaves the exception rows
out: those formats have no way to say "except this", and a row written as a flow
would characterize exactly what it removes. VoLCA's own columnar CSV reads the
marker back and keeps them, so it still round-trips.

Failure stays loud, as it already was for patterns: an exception matching no
flow is announced at load time, an exception constrained by nothing is refused,
and a pattern left with no match by its own exceptions is refused rather than
quietly counting zero.

"Land occupied" then excepts sea, seabed and benthic occupation. Inland water
bodies stay counted — a reservoir is a real surface somebody flooded.

## Measured

Agribalyse 3.2, all 455 farm-gate products, against the same method before the
change:

| | |
|---|---|
| products that rise | **0** |
| median change | −0.004 % |
| change by more than half | 14, every one sea-fed |

A land crop barely moves, because all it loses is the water a cargo ship
crossed carrying an imported input — an apricot orchard goes from 6.96202 to
6.96198 m²·year. The sea-fed ones collapse:

| product | before | after |
|---|---|---|
| Sea bass or sea bream, in cage, at farm gate | 1632.95 | 1.29 |
| Small trout, at farm gate {FR} | 471.74 | 0.88 |
| Farmed salmon, head on, gutted {NO} | 416.03 | 2.65 |
| Large trout, at farm gate {FR} | 387.91 | 0.87 |
| Fish meal with waste water treatment, Peru | 678.68 | 0.011 |

## How to test

`cabal test --test-options='--match "/wildcard (pattern) CFs/"'` — 17 examples,
including a pattern whose neighbours share a prefix with its exception, an
exception written without a trailing star, an exception a synonym bridge hands
back, and the three refusal paths. The shipped-method lint asserts the four
marine exceptions parse as exclusions of "Land occupied", and the export
dispatcher spec asserts which formats carry an exception row.

Full suite: 1947 examples, 0 failures.
