### PR TITLE
Let get_impacts_batch drop long-term emissions too

### DIFF
--- a/pyvolca/CHANGELOG.md
+++ b/pyvolca/CHANGELOG.md
@@ -45,6 +45,11 @@ Then paste the rendered block at the top of this file and tighten wording.
 - `get_collection_coverage` reports how much of a database a whole method
   collection characterizes (typed `CollectionCoverage`), counting coverage
   the way scoring counts it.
+- `get_impacts_batch(..., exclude_long_term=True)` drops long-term emissions
+  before scoring — the switch `score_activities` already carried. The engine
+  route has always accepted it and only this wrapper had no way to say so, so
+  scoring a whole list and scoring one process could not be asked the same
+  question.
 - The client now understands wire revision 4 (engines >= v0.9.4, which
   advertise the quality-report routes); nothing changes against older
   engines.

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -645,7 +645,7 @@ Args:
         single collection.
     top_flows: Max top contributing flows to return (default 5).
 
-##### `Client.get_impacts_batch(process_id: str, *, collection: str = 'methods', substitutions: list[SubstitutionLike] | None = None) -> LCIABatchResult`
+##### `Client.get_impacts_batch(process_id: str, *, collection: str = 'methods', substitutions: list[SubstitutionLike] | None = None, exclude_long_term: bool | None = None) -> LCIABatchResult`
 
 Compute LCIA for every impact category in a collection, in one call.
 
@@ -653,6 +653,8 @@ The response carries the per-method :class:`LCIAResult` list plus any
 formula-based scoring sets declared in the engine config (PEF, ECS…).
 ``scoring_indicators`` gives the per-variable breakdown of each
 scoring set, pre-multiplied by the set's ``displayMultiplier``.
+``exclude_long_term`` drops long-term emissions before scoring, the
+same switch :meth:`score_activities` carries.
 
 Uses a direct HTTP call: the batch endpoint has no operationId in the
 OpenAPI spec (the dispatcher primary is the single-method variant), so

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -1680,7 +1680,9 @@ class Client:
             f"/impacts/{collection}"
         )
         params = (
-            {} if exclude_long_term is None else {"exclude-long-term": exclude_long_term}
+            {}
+            if exclude_long_term is None
+            else {"exclude-long-term": _format_query_value(exclude_long_term)}
         )
         if substitutions:
             r = self._session.post(

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -1656,6 +1656,7 @@ class Client:
         *,
         collection: str = "methods",
         substitutions: list[SubstitutionLike] | None = None,
+        exclude_long_term: bool | None = None,
     ) -> LCIABatchResult:
         """Compute LCIA for every impact category in a collection, in one call.
 
@@ -1663,6 +1664,8 @@ class Client:
         formula-based scoring sets declared in the engine config (PEF, ECS…).
         ``scoring_indicators`` gives the per-variable breakdown of each
         scoring set, pre-multiplied by the set's ``displayMultiplier``.
+        ``exclude_long_term`` drops long-term emissions before scoring, the
+        same switch :meth:`score_activities` carries.
 
         Uses a direct HTTP call: the batch endpoint has no operationId in the
         OpenAPI spec (the dispatcher primary is the single-method variant), so
@@ -1676,10 +1679,15 @@ class Client:
             f"{self.base_url}/api/v1/db/{self.db}/activity/{process_id}"
             f"/impacts/{collection}"
         )
+        params = (
+            {} if exclude_long_term is None else {"exclude-long-term": exclude_long_term}
+        )
         if substitutions:
-            r = self._session.post(url, json=_substitution_body(substitutions))
+            r = self._session.post(
+                url, json=_substitution_body(substitutions), params=params
+            )
         else:
-            r = self._session.get(url)
+            r = self._session.get(url, params=params)
         return LCIABatchResult.from_json(self._json(r))
 
     def compute_sensitivity(

--- a/pyvolca/tests/test_dispatch.py
+++ b/pyvolca/tests/test_dispatch.py
@@ -375,7 +375,7 @@ class TestDispatcher:
         }
         session.get.return_value = make_response(empty)
         client.get_impacts_batch("abc_def", exclude_long_term=True)
-        assert session.get.call_args[1]["params"] == {"exclude-long-term": True}
+        assert session.get.call_args[1]["params"] == {"exclude-long-term": "true"}
 
         # Left unsaid, the engine keeps its own default: no query parameter at all.
         session.get.return_value = make_response(empty)
@@ -388,7 +388,7 @@ class TestDispatcher:
             substitutions=[{"from": "a", "to": "b", "consumer": "c"}],
             exclude_long_term=True,
         )
-        assert session.post.call_args[1]["params"] == {"exclude-long-term": True}
+        assert session.post.call_args[1]["params"] == {"exclude-long-term": "true"}
 
     def test_get_impacts_batch_requires_db(self, fixture_spec, make_response):
         client = Client(base_url="http://test.local", db="")

--- a/pyvolca/tests/test_dispatch.py
+++ b/pyvolca/tests/test_dispatch.py
@@ -360,6 +360,36 @@ class TestDispatcher:
             "substitutions": [{"from": "a", "to": "b", "consumer": "c"}]
         }
 
+    def test_get_impacts_batch_passes_exclude_long_term(self, mocked_client, make_response):
+        """The engine route takes exclude-long-term; a caller comparing against a
+        source that zeroes long-term factors needs to be able to say so here too,
+        not only through score_activities.
+        """
+        client, session = mocked_client
+        empty = {
+            "results": [],
+            "availableNWsets": [],
+            "scoringResults": {},
+            "scoringUnits": {},
+            "scoringIndicators": {},
+        }
+        session.get.return_value = make_response(empty)
+        client.get_impacts_batch("abc_def", exclude_long_term=True)
+        assert session.get.call_args[1]["params"] == {"exclude-long-term": True}
+
+        # Left unsaid, the engine keeps its own default: no query parameter at all.
+        session.get.return_value = make_response(empty)
+        client.get_impacts_batch("abc_def")
+        assert session.get.call_args[1]["params"] == {}
+
+        session.post.return_value = make_response(empty)
+        client.get_impacts_batch(
+            "abc_def",
+            substitutions=[{"from": "a", "to": "b", "consumer": "c"}],
+            exclude_long_term=True,
+        )
+        assert session.post.call_args[1]["params"] == {"exclude-long-term": True}
+
     def test_get_impacts_batch_requires_db(self, fixture_spec, make_response):
         client = Client(base_url="http://test.local", db="")
         client._operations = _parse_spec(fixture_spec)


### PR DESCRIPTION
## Problem

The engine route `GET /db/{db}/activity/{pid}/impacts/{collection}` has always
accepted `exclude-long-term`, and `score_activities` has always passed it. The
batch wrapper had no parameter for it, so scoring a list of processes and
scoring a single one could not be asked the same question.

That matters when comparing VoLCA against a source that zeroes long-term
characterization factors on import — the comparison has to be like for like on
both call shapes, and today one of them cannot be told.

## Solution

One keyword argument, forwarded as the query parameter the route already reads.
Left unsaid, it is absent from the query string entirely, so the engine keeps
its own default rather than being told a false `no`.

## How to test

`pytest tests/test_dispatch.py` — the new example checks all three paths: the
GET with the flag, the GET without it (no parameter at all), and the POST that
carries substitutions. 263 passed, 7 skipped over the whole suite; the README
api-reference block is regenerated.