### PR TITLE
Let the idle countdown follow real work, not chatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@
   by it.
 
 ### Changed
+- A server started with `--idle-timeout` now follows real work, not traffic.
+  A connected MCP assistant polls its server all day (`ping`, `tools/list`),
+  and those calls used to hold the server open with nobody behind them; now
+  only an actual tool call counts. A matrix solve also counts as use in its
+  own right, so an analysis that outlasts the request that asked for it no
+  longer has the server exit underneath it.
 - An EcoSpold 1 dataset published as `process_<uuid>.xml` (or `<uuid>.xml`)
   now keeps that identifier as its activity UUID instead of getting one
   minted from its name and location. Two releases of such a database can be

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -47,6 +47,7 @@ import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Char8 as C8
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import Data.String (fromString)
+import qualified Matrix
 import Network.HTTP.Types (status200, status403)
 import Network.HTTP.Types.Header (hCacheControl, hContentType, hPragma)
 import Network.Wai (Application, Middleware, Request (..), Response, ResponseReceived, mapResponseHeaders, pathInfo, rawPathInfo, rawQueryString, requestHeaders, requestMethod, responseLBS, responseStream)
@@ -260,6 +261,7 @@ runServerWithConfig cliConfig serverOpts mCfgFile = do
             password
             (cfgHosting config)
             (cfgClassificationPresets config)
+            (getCurrentTime >>= writeIORef lastRequestRef)
     let finalApp =
             uploadSizeLimitMiddleware (cfgHosting config) $
                 wrapWithMiddleware password (hostingReadOnly (cfgHosting config)) lastRequestRef idleActiveRef baseApp
@@ -375,15 +377,15 @@ logRequest req = do
     hFlush stdout
 
 -- | Create a Wai application with DatabaseManager.
-createServerApp :: DatabaseManager -> Int -> FilePath -> Bool -> Maybe String -> Maybe HostingConfig -> [ClassificationPreset] -> IO Application
-createServerApp dbManager maxTreeDepth staticDir desktopMode password hostingConfig filterPresets = do
+createServerApp :: DatabaseManager -> Int -> FilePath -> Bool -> Maybe String -> Maybe HostingConfig -> [ClassificationPreset] -> IO () -> IO Application
+createServerApp dbManager maxTreeDepth staticDir desktopMode password hostingConfig filterPresets markActivity = do
     -- The MCP @web_url@ deep links point at Elm SPA routes served from
     -- 'staticDir'. When the SPA is not bundled (backend-only image), those
     -- URLs would 404, so we omit 'web_url' from MCP responses entirely.
     hasFrontend <- doesFileExist (staticDir </> "index.html")
     unless (desktopMode || hasFrontend) $
         reportProgress Info "Frontend not bundled — MCP responses will omit 'web_url'"
-    mcp <- mcpApp dbManager filterPresets hasFrontend hostingConfig
+    mcp <- mcpApp dbManager filterPresets hasFrontend hostingConfig markActivity
     let env =
             AppEnv
                 { aeDbManager = dbManager
@@ -433,10 +435,16 @@ validateCLIConfig (CLIConfig globalOpts _) =
                 die "--jsonpath can only be used with --format csv"
         _ -> pure ()
 
--- | WAI middleware that updates last-request timestamp on every request
+{- | WAI middleware that updates the last-request timestamp on every request.
+
+@\/mcp@ is exempt: a connected assistant polls it on its own initiative, so
+counting those requests would keep an idle server alive with nobody at the
+other end. That endpoint marks activity itself, for the calls that are someone
+asking a question ('API.MCP.mcpCountsAsActivity').
+-}
 idleTrackingMiddleware :: IORef UTCTime -> Application -> Application
 idleTrackingMiddleware ref app req respond = do
-    getCurrentTime >>= writeIORef ref
+    unless (rawPathInfo req == "/mcp") (getCurrentTime >>= writeIORef ref)
     app req respond
 
 {- | Middleware that handles POST /api/v1/idle-timeout/{seconds} and POST /api/v1/shutdown
@@ -483,17 +491,27 @@ shutdownEndpoint readOnly lastRequestRef idleActiveRef app req respond =
                 [(hContentType, "application/json")]
                 (encode (object ["error" .= readOnlyRefusal]))
 
--- | Background thread that exits the server after idle timeout (in seconds)
+{- | Background thread that exits the server after the idle timeout (seconds).
+
+Two things count as being in use, because one alone would be wrong. An HTTP
+request proves someone is there — reading a process sheet resolves no matrix,
+and that reader must not lose the server under them. A matrix solve proves
+expensive work is under way, which may well outlast the request that asked for
+it. So the deadline moves on either, and the solve count is read first: a solve
+that lands in the last seconds has to be seen before the deadline is judged.
+-}
 idleWatchdog :: IORef UTCTime -> IORef Bool -> Int -> IO ()
-idleWatchdog ref activeRef timeoutSecs = go
+idleWatchdog ref activeRef timeoutSecs = go =<< Matrix.readSolveCounter
   where
     checkInterval = min (timeoutSecs * 1000000) (5 * 1000000) -- check every 5s or timeout, whichever is shorter
-    go = do
+    go lastSeen = do
         threadDelay checkInterval
         active <- readIORef activeRef
         if not active
             then pure ()
             else do
+                solves <- Matrix.readSolveCounter
+                when (solves /= lastSeen) (getCurrentTime >>= writeIORef ref)
                 now <- getCurrentTime
                 lastReq <- readIORef ref
                 let idleSeconds = realToFrac (diffUTCTime now lastReq) :: Double
@@ -501,4 +519,4 @@ idleWatchdog ref activeRef timeoutSecs = go
                     then do
                         reportProgress Info $ "Idle for " ++ show timeoutSecs ++ "s, shutting down."
                         hardExit
-                    else go
+                    else go solves

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -1076,8 +1076,9 @@ Health check — GET /api/v1/db, return True if 200.
 Spawn the engine process if it is not already serving, and wait until ready.
 
 Args:
-    idle_timeout: Seconds without an HTTP request before the engine
-        shuts itself down. Default 5 min.
+    idle_timeout: Seconds without use before the engine shuts itself
+        down. Default 5 min. An API request or a matrix solve counts
+        as use; an MCP client merely staying connected does not.
     wait_timeout: How long to poll for the server to become healthy
         before raising :class:`TimeoutError`.
 

--- a/pyvolca/src/volca/server.py
+++ b/pyvolca/src/volca/server.py
@@ -204,8 +204,9 @@ class Server:
         """Spawn the engine process if it is not already serving, and wait until ready.
 
         Args:
-            idle_timeout: Seconds without an HTTP request before the engine
-                shuts itself down. Default 5 min.
+            idle_timeout: Seconds without use before the engine shuts itself
+                down. Default 5 min. An API request or a matrix solve counts
+                as use; an MCP client merely staying connected does not.
             wait_timeout: How long to poll for the server to become healthy
                 before raising :class:`TimeoutError`.
 

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -5,7 +5,7 @@ Implements Streamable HTTP transport (MCP spec 2025-03-26).
 POST /mcp handles initialize, tools/list, tools/call (JSON or SSE response).
 GET  /mcp opens an SSE stream for server-initiated messages (stateless: closes immediately).
 -}
-module API.MCP (mcpApp, toolDefinitions, callTool, selectMethod) where
+module API.MCP (mcpApp, mcpCountsAsActivity, toolDefinitions, callTool, selectMethod) where
 
 import Control.Concurrent.STM (readTVarIO)
 import Data.Aeson
@@ -39,7 +39,7 @@ import API.DatabaseHandlers (coverageReportToAPI, gapReportToAPI, loadQuotaRefus
 import API.MCP.Columnar (resolveSingleScoringSet, toColumnarBatch)
 import API.MCP.Enrich (addWebUrlMaybe, attachMarketHintByName, encodeSegment, filterScoringSets, scoreActivityWebUrl, slimLCIAPanel, webUrlField)
 import API.Types (ActivityForAPI (..), ActivityInfo (..), ClassificationSystem (..), ExchangeWithUnit (..), InventoryExport (..), InventoryFlowDetail (..), Perturbation (..), Substitution (..), SubstitutionRequest (..))
-import Control.Monad (unless)
+import Control.Monad (unless, when)
 import qualified Data.List as L
 import Matrix (applyBiosphereMatrix)
 import Method.Mapping (LCIAOutcome (..), MappingStats (..), SimilarCF (..), SimilarReason (..), UncharacterizedFlow (..), applyLongTermMode, computeLCIAScoreAuto, computeLCIAScoreFromTables, computeMappingStats, defaultUncharacterizedOpts, inventoryContributions, longTermModeFromExclude)
@@ -116,8 +116,23 @@ newtype McpState = McpState
     { mcpSessionId :: Text
     }
 
-mcpApp :: DatabaseManager -> [ClassificationPreset] -> Bool -> Maybe HostingConfig -> IO Application
-mcpApp dbManager presets hasFrontend mHosting = do
+{- | Which MCP calls mean a human is there. @initialize@, @tools\/list@, @ping@
+and the notifications announce or maintain a client without asking anything of
+the engine: a connected assistant emits them on its own, all day, whether or
+not anyone is working. Only @tools\/call@ is someone asking a question.
+-}
+mcpCountsAsActivity :: Text -> Bool
+mcpCountsAsActivity = (== "tools/call")
+
+{- | Build the @\/mcp@ endpoint.
+
+@markActivity@ is called for every request that 'mcpCountsAsActivity' accepts.
+A server that shuts itself down when idle uses it to tell a working client from
+a merely connected one; a server with no such policy passes an action that does
+nothing.
+-}
+mcpApp :: DatabaseManager -> [ClassificationPreset] -> Bool -> Maybe HostingConfig -> IO () -> IO Application
+mcpApp dbManager presets hasFrontend mHosting markActivity = do
     (a, b) <- (,) <$> (randomIO :: IO Int) <*> (randomIO :: IO Int)
     let sessionId = T.pack $ show (abs a) ++ "-" ++ show (abs b)
     stateRef <- newIORef McpState{mcpSessionId = sessionId}
@@ -153,6 +168,7 @@ mcpApp dbManager presets hasFrontend mHosting = do
                     Left err ->
                         respond $ jsonResponse (mcpSessionId st) $ rpcError Null (-32700) (T.pack $ "Parse error: " ++ err)
                     Right rpcReq -> do
+                        when (mcpCountsAsActivity (rpcMethod rpcReq)) markActivity
                         resp <- handleRpc dbManager presets mHosting mBaseUrl st rpcReq
                         case resp of
                             Nothing ->

--- a/src/Matrix.hs
+++ b/src/Matrix.hs
@@ -187,6 +187,9 @@ readSolveCounter = readIORef solveCounter
 {- | Bracket a solve. The count moves when the work starts and again when it
 ends, so a solve begun moments before an idle deadline is not cut off in
 flight, and a long chain of solves keeps the deadline moving throughout.
+The count is silent between the two moves, so a single solve that alone
+outlasts the whole timeout is still cut off mid-flight — a ceiling that
+stands far above real work, since solves take seconds and timeouts minutes.
 -}
 countingSolve :: IO a -> IO a
 countingSolve act = bumpSolveCounter *> act <* bumpSolveCounter

--- a/src/Matrix.hs
+++ b/src/Matrix.hs
@@ -60,6 +60,7 @@ module Matrix (
     computeInventoryMatrixBatch,
     clearCachedSolver,
     chunksOf,
+    readSolveCounter,
 ) where
 
 import Control.Concurrent (forkIO)
@@ -80,6 +81,7 @@ import Control.Concurrent.STM (
  )
 import Control.Exception (SomeException, catch, evaluate, throwIO, toException, try)
 import Control.Monad (forM_, unless, void, when)
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
 import Data.Int (Int32)
 import qualified Data.Map as M
 import Data.Maybe (catMaybes)
@@ -161,6 +163,33 @@ solves across DBs while leaving the per-DB coalescing workers intact.
 {-# NOINLINE mumpsSolveMutex #-}
 mumpsSolveMutex :: MVar ()
 mumpsSolveMutex = unsafePerformIO $ newMVar ()
+
+{- | Count of matrix solves performed since the process started.
+
+A solve is the expensive thing this server does, and the only work that can
+outlast a request: an analysis started just before an idle deadline must not
+have the process exit under it. Callers therefore only ever ask whether the
+number moved between two moments, never what it means, so the double count on
+a fallback path (a batch solve that degrades to per-demand solves) is harmless.
+-}
+{-# NOINLINE solveCounter #-}
+solveCounter :: IORef Int
+solveCounter = unsafePerformIO $ newIORef 0
+
+-- | Record that one matrix solve happened.
+bumpSolveCounter :: IO ()
+bumpSolveCounter = atomicModifyIORef' solveCounter (\n -> (n + 1, ()))
+
+-- | Read the running solve count. Meaningful only compared against itself.
+readSolveCounter :: IO Int
+readSolveCounter = readIORef solveCounter
+
+{- | Bracket a solve. The count moves when the work starts and again when it
+ends, so a solve begun moments before an idle deadline is not cut off in
+flight, and a long chain of solves keeps the deadline moving throughout.
+-}
+countingSolve :: IO a -> IO a
+countingSolve act = bumpSolveCounter *> act <* bumpSolveCounter
 
 -- ---------------------------------------------------------------------------
 -- Coalescing solver: per-database worker that batches concurrent requests
@@ -337,7 +366,7 @@ The solver is looked up by database ID from the per-database cache, enabling
 instant switching between databases without re-factorization.
 -}
 solveSparseLinearSystemWithFactorization :: MatrixFactorization -> Vector -> IO Vector
-solveSparseLinearSystemWithFactorization factorization demandVec = do
+solveSparseLinearSystemWithFactorization factorization demandVec = countingSolve $ do
     let dbId = mfDatabaseId factorization
     cachedSolvers <- readMVar cachedSolver
     case M.lookup dbId cachedSolvers of
@@ -388,7 +417,7 @@ if the cached solver is absent or the multi-solve raises an exception.
 -}
 solveSparseLinearSystemWithFactorizationMulti :: MatrixFactorization -> [Vector] -> IO [Vector]
 solveSparseLinearSystemWithFactorizationMulti _ [] = pure []
-solveSparseLinearSystemWithFactorizationMulti factorization demandVecs = do
+solveSparseLinearSystemWithFactorizationMulti factorization demandVecs = countingSolve $ do
     let dbId = mfDatabaseId factorization
         k = length demandVecs
     cachedSolvers <- readMVar cachedSolver
@@ -461,7 +490,7 @@ Performance: ~3s for 14,457 activities with 116K technosphere entries
 
 -- | Uses global mutex: MUMPS_SEQ create/factorize/destroy have global Fortran state.
 solveSparseLinearSystemMUMPS :: [(Int, Int, Double)] -> Int -> Vector -> IO Vector
-solveSparseLinearSystemMUMPS techTriples n demandVec = withMVar mumpsFactorizationMutex $ \_ -> do
+solveSparseLinearSystemMUMPS techTriples n demandVec = countingSolve $ withMVar mumpsFactorizationMutex $ \_ -> do
     let identityTriples = [(i, i, 1.0) | i <- [0 .. n - 1]]
         systemTechTriples = [(i, j, -value) | (i, j, value) <- techTriples]
         allTriples = aggregateMatrixEntries (identityTriples ++ systemTechTriples)

--- a/test/CoalescingSolverSpec.hs
+++ b/test/CoalescingSolverSpec.hs
@@ -19,6 +19,7 @@ import Matrix (
     buildDemandVectorFromIndex,
     clearCachedSolver,
     fromList,
+    readSolveCounter,
     solveSparseLinearSystem,
     solveSparseLinearSystemWithFactorization,
     solveSparseLinearSystemWithFactorizationMulti,
@@ -83,6 +84,23 @@ spec = do
                     (solveSparseLinearSystemWithFactorizationMulti fact multiBatch)
             actualSingles `shouldSatisfy` allCloseTo expectedSingles
             actualMulti `shouldSatisfy` allCloseTo expectedMulti
+
+    -- A server that shuts itself down when idle watches this number to know
+    -- that work is under way. If a solve path stopped moving it, an analysis
+    -- longer than the timeout would be killed halfway through.
+    describe "solve counter" $ do
+        it "moves on the cached path, the batch path and the fresh path" $ do
+            (_solver, fact, db) <- min3CachedSolver
+            let demand = buildDemandVectorFromIndex (dbActivityIndex db) 0
+            before <- readSolveCounter
+            _ <- solveSparseLinearSystemWithFactorization fact demand
+            afterSingle <- readSolveCounter
+            _ <- solveSparseLinearSystemWithFactorizationMulti fact [demand, demand]
+            afterMulti <- readSolveCounter
+            _ <- oracleSolve db demand
+            afterFresh <- readSolveCounter
+            [afterSingle > before, afterMulti > afterSingle, afterFresh > afterMulti]
+                `shouldBe` [True, True, True]
 
     describe "clean shutdown" $ do
         it "clearCachedSolver lets the next request fall back without deadlock" $ do

--- a/test/MCPDispatchSpec.hs
+++ b/test/MCPDispatchSpec.hs
@@ -15,7 +15,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Test.Hspec
 
-import API.MCP (callTool, toolDefinitions)
+import API.MCP (callTool, mcpCountsAsActivity, toolDefinitions)
 import Config (ReadOnly (..), defaultConfig)
 import Database.Manager (initDatabaseManager)
 
@@ -114,3 +114,18 @@ spec = describe "MCP database load/unload tools" $ do
             resp <- call "get_characterization_coverage"
             isError resp `shouldBe` True
             resultText resp `shouldSatisfy` maybe False ("Database not loaded:" `T.isInfixOf`)
+
+    -- A server that shuts itself down when idle asks this question of every
+    -- MCP request. Answering "yes" too often keeps an unused server alive for
+    -- as long as an assistant stays connected, which is a bill with nobody
+    -- behind it; answering "no" too often kills a server mid-conversation.
+    describe "mcpCountsAsActivity" $ do
+        it "accepts a tool call" $
+            mcpCountsAsActivity "tools/call" `shouldBe` True
+
+        it "refuses the calls a client makes on its own" $
+            map mcpCountsAsActivity ["initialize", "notifications/initialized", "tools/list", "ping"]
+                `shouldBe` [False, False, False, False]
+
+        it "refuses an unknown method" $
+            mcpCountsAsActivity "no/such/method" `shouldBe` False


### PR DESCRIPTION
A server started with `--idle-timeout` reads one signal today: the timestamp
that every HTTP request stamps before routing. A connected MCP client refreshes
that timestamp on its own initiative — `initialize`, `tools/list` and `ping`
arrive all day whether or not anyone is working — so such a server never reaches
its deadline as long as an assistant stays connected.

Two signals now count, because either alone is wrong:

- an HTTP request still proves someone is there. Searching, opening a process
  sheet and reading its exchanges resolve no matrix, and that reader must not
  lose the server under them;
- a matrix solve proves expensive work is under way, which can outlast the
  request that asked for it.

`/mcp` is exempt from the first signal and marks activity itself, only for
`tools/call` — the one method that is someone asking a question. The classifier
is a pure function next to the dispatch case that already enumerates the five
methods, tested on all of them.

The solve counter is a bare `Int` bracketed around the three entry points that
reach MUMPS. Callers can only ask whether it moved, never what it means, so the
double count when a batch solve degrades to per-demand solves costs nothing, and
the solver stays ignorant of what a timeout is. The watchdog reads it before
judging the deadline, so a solve landing in the last seconds is seen in time.

Verified live against a built binary, `--idle-timeout 20` polled every 5s for
35s: a client sending `ping` or `tools/list` lets it exit on schedule; one
sending `tools/call`, and one sending a plain REST request, keep it alive.