### PR TITLE
Say seconds, not minutes, in the idle-timeout field comment

### DIFF
--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -155,7 +155,7 @@ data ServerOptions = ServerOptions
     , serverLoadDbs :: Maybe [Text] -- Databases to load at startup (--load db1,db2)
     , serverDesktopMode :: Bool -- Desktop mode (--desktop): print port and minimize logging
     , serverStaticDir :: Maybe FilePath -- Static directory (--static-dir): override default web/dist
-    , serverIdleTimeout :: Int -- Idle timeout in minutes (--idle-timeout, 0=disabled). Server exits after being idle.
+    , serverIdleTimeout :: Int -- Idle timeout in seconds (--idle-timeout, 0=disabled). Server exits after being idle.
     , serverTreeDepth :: Int -- Default max depth for /tree endpoint (--tree-depth, default 2)
     }
     deriving (Eq, Show, Generic)


### PR DESCRIPTION
The option parser (metavar SECONDS) and the watchdog both treat the value as seconds; the field comment said minutes, and that wrong word had already leaked into a documentation example. One word changes, nothing else.