### PR TITLE
Make a classification preset always narrow, or say why it cannot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,14 @@
   output is unchanged.
 
 ### Fixed
+- A classification preset that does not resolve is now refused instead of
+  quietly filtering nothing. Asking a server for its raw agricultural products
+  by a preset name it does not carry — a typo, or a config that never declared
+  it — used to answer with every activity in the database, which reads like a
+  result. The refusal names the presets the instance does carry. The MCP
+  `aggregate` and `get_supply_chain` tools had a second form of the same
+  problem: both advertise a `preset` parameter and neither ever read it, so
+  even a valid preset was dropped there.
 - "Land occupied", in the shipped Plain indicators method, no longer counts the
   sea. Its rule takes every `Occupation, …` flow, and that family holds the open
   ocean and the sea floor alongside fields and roads. Anything fed from the sea

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -365,6 +365,10 @@ callTool :: DatabaseManager -> [ClassificationPreset] -> Maybe HostingConfig -> 
 callTool _ _ mHosting _ rid name _
     | isReadOnly (hostingReadOnly mHosting) && mutatingTool name =
         return $ toolError rid readOnlyRefusal
+-- A preset the instance does not carry is refused here rather than in each
+-- handler, so no tool can answer as if the caller had asked for no filter.
+callTool _ presets _ _ rid _ args
+    | Left err <- presetFilters presets args = return $ toolError rid err
 callTool dbManager presets mHosting mBaseUrl rid name args = case name of
     "list_databases" -> callListDatabases dbManager rid
     "load_database" -> callLoadDatabase dbManager mHosting rid args
@@ -373,8 +377,8 @@ callTool dbManager presets mHosting mBaseUrl rid name args = case name of
     "search_activities" -> withDb dbManager rid args $ callSearchActivities presets rid args
     "search_flows" -> withDb dbManager rid args $ callSearchFlows rid args
     "get_activity" -> withDb dbManager rid args $ callGetActivity rid args
-    "get_supply_chain" -> callGetSupplyChain dbManager rid args
-    "aggregate" -> withDb dbManager rid args $ callAggregate dbManager rid args
+    "get_supply_chain" -> callGetSupplyChain dbManager presets rid args
+    "aggregate" -> withDb dbManager rid args $ callAggregate dbManager presets rid args
     "get_inventory" -> callGetInventory dbManager rid args
     "get_impacts" -> callGetImpacts dbManager mBaseUrl rid args
     "compute_sensitivity" -> callComputeSensitivity dbManager mBaseUrl rid args
@@ -724,10 +728,11 @@ callGetActivity rid args (db, _) = runTool rid $ do
         Nothing -> True
         Just want -> exchangeIsInput (ewuExchange ewu) == want
 
-callGetSupplyChain :: DatabaseManager -> Value -> KeyMap Value -> IO Value
-callGetSupplyChain dbManager rid args = runTool rid $ do
+callGetSupplyChain :: DatabaseManager -> [ClassificationPreset] -> Value -> KeyMap Value -> IO Value
+callGetSupplyChain dbManager presets rid args = runTool rid $ do
     (dbName, pid) <- except $ (,) <$> requireText "database" args <*> requireText "process_id" args
     ld <- requireDatabase dbManager dbName
+    classifications <- except (classificationFilters presets args)
     let db = ldDatabase ld
         solver = ldSharedSolver ld
         depLookup = DM.mkDepSolverLookup dbManager
@@ -738,7 +743,7 @@ callGetSupplyChain dbManager rid args = runTool rid $ do
                         { Service.afcName = textArg "name" args
                         , Service.afcLocation = textArg "location" args
                         , Service.afcProduct = Nothing
-                        , Service.afcClassifications = explicitClassFilter args
+                        , Service.afcClassifications = classifications
                         , Service.afcLimit = intArg "limit" args
                         , Service.afcOffset = Nothing
                         , Service.afcSort = Nothing
@@ -766,8 +771,8 @@ callGetSupplyChain dbManager rid args = runTool rid $ do
 {- | Generic SQL-group-by aggregation. One small primitive for "how much X is
 in Y" questions — replaces ad-hoc decomposition tools.
 -}
-callAggregate :: DatabaseManager -> Value -> KeyMap Value -> (Database, SharedSolver) -> IO Value
-callAggregate dbManager rid args (db, solver) =
+callAggregate :: DatabaseManager -> [ClassificationPreset] -> Value -> KeyMap Value -> (Database, SharedSolver) -> IO Value
+callAggregate dbManager presets rid args (db, solver) =
     let dbName = fromMaybe "" (textArg "database" args) -- already validated by withDb
      in case textArg "process_id" args of
             Nothing -> return $ toolError rid "Missing required parameter: process_id"
@@ -778,33 +783,35 @@ callAggregate dbManager rid args (db, solver) =
                     Right fn -> case filterExchangeTypeFromArg of
                         Left err -> return $ toolError rid err
                         Right filterExchangeType | Just msg <- Agg.exchangeTypeScopeError scope filterExchangeType -> return $ toolError rid msg
-                        Right filterExchangeType -> do
-                            let params =
-                                    Agg.AggregateParams
-                                        { Agg.apScope = scope
-                                        , Agg.apIsInput = boolArg "is_input" args
-                                        , Agg.apMaxDepth = intArg "max_depth" args
-                                        , Agg.apFilterName = textArg "filter_name" args
-                                        , Agg.apFilterNameNot =
-                                            maybe [] (map T.strip . T.splitOn ",") (textArg "filter_name_not" args)
-                                        , Agg.apFilterUnit = textArg "filter_unit" args
-                                        , Agg.apFilterClassifications =
-                                            mapMaybe parseClassFilter (textArrayArg "filter_classification" args)
-                                        , Agg.apFilterTargetName = textArg "filter_target_name" args
-                                        , Agg.apFilterConsumer = textArg "filter_consumer" args
-                                        , Agg.apFilterConsumerNot =
-                                            maybe [] (map T.strip . T.splitOn ",") (textArg "filter_consumer_not" args)
-                                        , Agg.apFilterExchangeType = filterExchangeType
-                                        , Agg.apFilterIsReference = boolArg "filter_is_reference" args
-                                        , Agg.apGroupBy = textArg "group_by" args
-                                        , Agg.apAggregate = fn
-                                        }
-                            unitCfg <- DM.getMergedUnitConfig dbManager
-                            (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
-                            result <- Agg.aggregate unitCfg mFlows mUnits db dbName solver (DM.mkDepSolverLookup dbManager) pid params
-                            case result of
-                                Left err -> return $ toolError rid (T.pack $ show err)
-                                Right agg -> return $ toolSuccessJson rid (toJSON agg)
+                        Right filterExchangeType -> case presetFilters presets args of
+                            Left err -> return $ toolError rid err
+                            Right fromPreset -> do
+                                let params =
+                                        Agg.AggregateParams
+                                            { Agg.apScope = scope
+                                            , Agg.apIsInput = boolArg "is_input" args
+                                            , Agg.apMaxDepth = intArg "max_depth" args
+                                            , Agg.apFilterName = textArg "filter_name" args
+                                            , Agg.apFilterNameNot =
+                                                maybe [] (map T.strip . T.splitOn ",") (textArg "filter_name_not" args)
+                                            , Agg.apFilterUnit = textArg "filter_unit" args
+                                            , Agg.apFilterClassifications =
+                                                fromPreset ++ mapMaybe parseClassFilter (textArrayArg "filter_classification" args)
+                                            , Agg.apFilterTargetName = textArg "filter_target_name" args
+                                            , Agg.apFilterConsumer = textArg "filter_consumer" args
+                                            , Agg.apFilterConsumerNot =
+                                                maybe [] (map T.strip . T.splitOn ",") (textArg "filter_consumer_not" args)
+                                            , Agg.apFilterExchangeType = filterExchangeType
+                                            , Agg.apFilterIsReference = boolArg "filter_is_reference" args
+                                            , Agg.apGroupBy = textArg "group_by" args
+                                            , Agg.apAggregate = fn
+                                            }
+                                unitCfg <- DM.getMergedUnitConfig dbManager
+                                (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
+                                result <- Agg.aggregate unitCfg mFlows mUnits db dbName solver (DM.mkDepSolverLookup dbManager) pid params
+                                case result of
+                                    Left err -> return $ toolError rid (T.pack $ show err)
+                                    Right agg -> return $ toolSuccessJson rid (toJSON agg)
   where
     scopeFromArg = case textArg "scope" args of
         Just "direct" -> Right Agg.ScopeDirect

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -27,7 +27,7 @@ import System.Random (randomIO)
 
 import API.Resources (Param (..), ParamKind (..), Resource)
 import qualified API.Resources as R
-import Config (ClassificationEntry (..), ClassificationPreset (..), DatabaseConfig (..), HostingConfig, ReadOnly (..), hostingReadOnly, readOnlyRefusal)
+import Config (ClassificationEntry (..), ClassificationPreset (..), DatabaseConfig (..), HostingConfig, ReadOnly (..), expandClassificationPreset, hostingReadOnly, readOnlyRefusal)
 import Control.Applicative ((<|>))
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Except (ExceptT (..), except, runExceptT, throwE)
@@ -597,44 +597,36 @@ explicitClassFilter args = case (textArg "classification" args, textArg "classif
   where
     isExact = textArg "classification_match" args `elem` [Just "equals", Just "exact"]
 
+-- | The @preset@ argument expanded, as every tool advertising that parameter must.
+presetFilters :: [ClassificationPreset] -> KeyMap Value -> Either Text [(Text, Text, Bool)]
+presetFilters presets args = expandClassificationPreset presets (textArg "preset" args)
+
 {- | Preset filters (looked up by @preset@ name) followed by the explicit
 filter. Shared by the search and consumers handlers.
 -}
-classificationFilters :: [ClassificationPreset] -> KeyMap Value -> [(Text, Text, Bool)]
-classificationFilters presets args = presetFilters ++ explicitClassFilter args
-  where
-    presetFilters = case textArg "preset" args of
-        Just pn -> case L.find (\p -> cpName p == pn) presets of
-            Just p -> [(ceSystem e, ceValue e, ceMode e == "exact") | e <- cpFilters p]
-            Nothing -> []
-        Nothing -> []
+classificationFilters :: [ClassificationPreset] -> KeyMap Value -> Either Text [(Text, Text, Bool)]
+classificationFilters presets args = (++ explicitClassFilter args) <$> presetFilters presets args
 
 callSearchActivities :: [ClassificationPreset] -> Value -> KeyMap Value -> (Database, SharedSolver) -> IO Value
-callSearchActivities presets rid args (db, _) = do
-    let name = textArg "name" args
-        geo = textArg "geo" args
-        product' = textArg "product" args
-        limit = intArg "limit" args
-        exact = fromMaybe False (boolArg "exact" args)
-        sf =
+callSearchActivities presets rid args (db, _) = runTool rid $ do
+    classifications <- except (classificationFilters presets args)
+    let sf =
             Service.SearchFilter
                 { Service.sfCore =
                     Service.ActivityFilterCore
-                        { Service.afcName = name
-                        , Service.afcLocation = geo
-                        , Service.afcProduct = product'
-                        , Service.afcClassifications = classificationFilters presets args
-                        , Service.afcLimit = limit <|> Just 20
+                        { Service.afcName = textArg "name" args
+                        , Service.afcLocation = textArg "geo" args
+                        , Service.afcProduct = textArg "product" args
+                        , Service.afcClassifications = classifications
+                        , Service.afcLimit = intArg "limit" args <|> Just 20
                         , Service.afcOffset = Nothing
                         , Service.afcSort = Nothing
                         , Service.afcOrder = Nothing
                         }
-                , Service.sfExactMatch = exact
+                , Service.sfExactMatch = fromMaybe False (boolArg "exact" args)
                 }
-    result <- Service.searchActivities db sf
-    case result of
-        Left err -> return $ toolError rid (T.pack $ show err)
-        Right val -> return $ toolSuccessJson rid val
+    val <- liftIO (Service.searchActivities db sf) >>= liftShow
+    pure (toolSuccessJson rid val)
 
 callListClassifications :: Value -> KeyMap Value -> (Database, SharedSolver) -> IO Value
 callListClassifications rid args (db, _) =
@@ -856,6 +848,7 @@ callGetPathTo rid args (db, solver) = runTool rid $ do
 callGetConsumers :: [ClassificationPreset] -> Value -> KeyMap Value -> (Database, SharedSolver) -> IO Value
 callGetConsumers presets rid args (db, _) = runTool rid $ do
     pid <- except (requireText "process_id" args)
+    classifications <- except (classificationFilters presets args)
     let dbName = fromMaybe "" (textArg "database" args) -- validated by withDb
         cnf =
             Service.ConsumerFilter
@@ -864,7 +857,7 @@ callGetConsumers presets rid args (db, _) = runTool rid $ do
                         { Service.afcName = textArg "name" args
                         , Service.afcLocation = textArg "location" args
                         , Service.afcProduct = textArg "product" args
-                        , Service.afcClassifications = classificationFilters presets args
+                        , Service.afcClassifications = classifications
                         , Service.afcLimit = intArg "limit" args
                         , Service.afcOffset = Nothing
                         , Service.afcSort = Nothing

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -394,18 +394,6 @@ Built in two steps:
 volcaOpenApi :: OpenApi
 volcaOpenApi = API.OpenApi.stampInfo (API.OpenApi.enrichWithResources (toOpenApi (Proxy :: Proxy LCAAPI)))
 
-{- | Expand a named classification preset from config into the
-(system, value, exact) triples used by the Service/Aggregate layers.
-An unknown preset name yields the empty list (same behavior as the
-previous inline implementations in searchActivitiesWithCount and
-getActivityConsumers).
--}
-expandPreset :: [Config.ClassificationPreset] -> Maybe Text -> [(Text, Text, Bool)]
-expandPreset _ Nothing = []
-expandPreset presets (Just pn) = case find (\p -> Config.cpName p == pn) presets of
-    Just p -> [(Config.ceSystem e, Config.ceValue e, Config.ceMode e == "exact") | e <- Config.cpFilters p]
-    Nothing -> []
-
 -- ============================================================================
 -- Hoisted helpers — previously in lcaServer's `where`. Lifted to top level so
 -- non-Servant callers (notably src/API/BatchImpacts.hs and any client of the
@@ -515,6 +503,10 @@ serviceErrorToServerError = \case
 
 throwServiceError :: Service.ServiceError -> AppM a
 throwServiceError = throwError . serviceErrorToServerError
+
+-- | Answer 400 with a message the caller can act on, rather than a body-less status.
+badRequest :: Text -> AppM a
+badRequest msg = throwError err400{errBody = BSL.fromStrict (T.encodeUtf8 msg)}
 
 -- | Load a method collection by name from the live DatabaseManager state.
 loadCollection :: Text -> AppM ([Method], [DamageCategory], [NormWeightSet], [ScoringSet])
@@ -1064,10 +1056,12 @@ mergeClassFilters ::
     [Text] ->
     [Text] ->
     [Text] ->
-    [(Text, Text, Bool)]
+    Either Text [(Text, Text, Bool)]
 mergeClassFilters presets presetParam systems values modes =
-    expandPreset presets presetParam
-        ++ zipWith3
+    (++ explicit) <$> Config.expandClassificationPreset presets presetParam
+  where
+    explicit =
+        zipWith3
             (\s v m -> (s, v, m == "exact"))
             systems
             values
@@ -1089,23 +1083,25 @@ buildSupplyChainFilter ::
     [Text] ->
     Maybe Text ->
     Maybe Text ->
-    Service.SupplyChainFilter
-buildSupplyChainFilter presets nameFilter limitParam minQuantity offsetParam maxDepthParam locationFilter productFilter presetParam classSystems classValues classModes sortParam orderParam =
-    Service.SupplyChainFilter
-        { Service.scfCore =
-            Service.ActivityFilterCore
-                { Service.afcName = nameFilter
-                , Service.afcLocation = locationFilter
-                , Service.afcProduct = productFilter
-                , Service.afcClassifications = mergeClassFilters presets presetParam classSystems classValues classModes
-                , Service.afcLimit = limitParam
-                , Service.afcOffset = offsetParam
-                , Service.afcSort = sortParam
-                , Service.afcOrder = orderParam
-                }
-        , Service.scfMaxDepth = maxDepthParam
-        , Service.scfMinQuantity = minQuantity
-        }
+    Either Text Service.SupplyChainFilter
+buildSupplyChainFilter presets nameFilter limitParam minQuantity offsetParam maxDepthParam locationFilter productFilter presetParam classSystems classValues classModes sortParam orderParam = do
+    classifications <- mergeClassFilters presets presetParam classSystems classValues classModes
+    pure
+        Service.SupplyChainFilter
+            { Service.scfCore =
+                Service.ActivityFilterCore
+                    { Service.afcName = nameFilter
+                    , Service.afcLocation = locationFilter
+                    , Service.afcProduct = productFilter
+                    , Service.afcClassifications = classifications
+                    , Service.afcLimit = limitParam
+                    , Service.afcOffset = offsetParam
+                    , Service.afcSort = sortParam
+                    , Service.afcOrder = orderParam
+                    }
+            , Service.scfMaxDepth = maxDepthParam
+            , Service.scfMinQuantity = minQuantity
+            }
 
 buildFlowEntry :: Database -> MethodTables -> M.Map UUID (MethodCF, MatchStrategy) -> UUID -> FlowCFEntry
 buildFlowEntry db tables reverseIndex uuid =
@@ -1429,7 +1425,8 @@ activitySupplyChainCore dbName processIdText nameFilter limitParam minQuantity o
     presets <- asks aeClassificationPresets
     (db, sharedSolver) <- requireDatabaseByName dbName
     let includeEdges = fromMaybe False includeEdgesParam
-        scf =
+    scf <-
+        either badRequest pure $
             buildSupplyChainFilter
                 presets
                 nameFilter
@@ -1552,8 +1549,8 @@ getActivityAggregate dbName processId scopeParam isInputParam maxDepthParam fnam
     case Agg.exchangeTypeScopeError scope exchangeType of
         Just msg -> throwError err400{errBody = BSL.fromStrict (T.encodeUtf8 msg)}
         Nothing -> return ()
-    let presetFilters = expandPreset presets presetParam
-        explicitFilters = mapMaybe parseClassFilter fclassParams
+    presetFilters <- either badRequest pure (Config.expandClassificationPreset presets presetParam)
+    let explicitFilters = mapMaybe parseClassFilter fclassParams
         params =
             Agg.AggregateParams
                 { Agg.apScope = scope
@@ -1706,6 +1703,7 @@ getActivityConsumers ::
 getActivityConsumers dbName processIdText nameFilter locationFilter productFilter presetParam classSystems classValues classModes limitParam offsetParam maxDepthParam sortParam orderParam includeEdgesParam = do
     presets <- asks aeClassificationPresets
     (db, _) <- requireDatabaseByName dbName
+    classifications <- either badRequest pure (mergeClassFilters presets presetParam classSystems classValues classModes)
     let cnf =
             Service.ConsumerFilter
                 { Service.cnfCore =
@@ -1713,7 +1711,7 @@ getActivityConsumers dbName processIdText nameFilter locationFilter productFilte
                         { Service.afcName = nameFilter
                         , Service.afcLocation = locationFilter
                         , Service.afcProduct = productFilter
-                        , Service.afcClassifications = mergeClassFilters presets presetParam classSystems classValues classModes
+                        , Service.afcClassifications = classifications
                         , Service.afcLimit = limitParam
                         , Service.afcOffset = offsetParam
                         , Service.afcSort = sortParam
@@ -2055,6 +2053,7 @@ searchActivitiesWithCount :: Text -> Maybe Text -> Maybe Text -> Maybe Text -> M
 searchActivitiesWithCount dbName nameParam geoParam productParam exactParam presetParam classSystems classValues classModes limitParam offsetParam sortParam orderParam = do
     presets <- asks aeClassificationPresets
     (db, _) <- requireDatabaseByName dbName
+    classifications <- either badRequest pure (mergeClassFilters presets presetParam classSystems classValues classModes)
     let exactMatch = fromMaybe False exactParam
         sf =
             Service.SearchFilter
@@ -2063,7 +2062,7 @@ searchActivitiesWithCount dbName nameParam geoParam productParam exactParam pres
                         { Service.afcName = nameParam
                         , Service.afcLocation = geoParam
                         , Service.afcProduct = productParam
-                        , Service.afcClassifications = mergeClassFilters presets presetParam classSystems classValues classModes
+                        , Service.afcClassifications = classifications
                         , Service.afcLimit = limitParam
                         , Service.afcOffset = offsetParam
                         , Service.afcSort = sortParam

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -23,7 +23,7 @@ import Data.Aeson
 import Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as BSL
 import Data.Foldable (asum)
-import Data.List (find, intercalate, sortBy, sortOn)
+import Data.List (intercalate, sortBy, sortOn)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe)

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -19,6 +19,7 @@ module Config (
     readOnlyRefusal,
     ClassificationPreset (..),
     ClassificationEntry (..),
+    expandClassificationPreset,
 
     -- * Loading
     loadConfig,
@@ -68,6 +69,27 @@ data ClassificationPreset = ClassificationPreset
     , cpFilters :: ![ClassificationEntry]
     }
     deriving (Show, Eq, Generic)
+
+{- | Expand a preset name into the (system, value, exact) triples every query
+surface filters with.
+
+A name no configured preset carries is an error, never an empty filter list: a
+preset narrows a query, so dropping it silently answers with the whole database
+where the caller asked for a slice of it.
+-}
+expandClassificationPreset :: [ClassificationPreset] -> Maybe Text -> Either Text [(Text, Text, Bool)]
+expandClassificationPreset _ Nothing = Right []
+expandClassificationPreset presets (Just name) =
+    case filter ((== name) . cpName) presets of
+        p : _ -> Right [(ceSystem e, ceValue e, ceMode e == "exact") | e <- cpFilters p]
+        [] -> Left (unknownPresetMessage presets name)
+
+-- | Why a preset name did not resolve, naming what this instance does carry.
+unknownPresetMessage :: [ClassificationPreset] -> Text -> Text
+unknownPresetMessage presets name =
+    "Unknown classification preset '" <> name <> "'. " <> case map cpName presets of
+        [] -> "This instance has no classification presets configured."
+        configured -> "Configured presets: " <> T.intercalate ", " configured
 
 -- | Main configuration type
 data Config = Config

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -4,6 +4,8 @@ module ConfigSpec (spec) where
 
 import Config (
     CFPatchOp (..),
+    ClassificationEntry (..),
+    ClassificationPreset (..),
     Config (..),
     MethodConfig (..),
     MethodPatch (..),
@@ -12,6 +14,7 @@ import Config (
     ScoringSetConfig (..),
     applyDataDir,
     defaultConfig,
+    expandClassificationPreset,
     loadConfigOrDefault,
     redirectIntoDataDir,
  )
@@ -34,6 +37,38 @@ mkRef p =
 
 spec :: Spec
 spec = do
+    describe "expandClassificationPreset" $ do
+        let raw =
+                ClassificationPreset
+                    { cpName = "raw"
+                    , cpLabel = "Raw"
+                    , cpDescription = Nothing
+                    , cpFilters =
+                        [ ClassificationEntry{ceSystem = "AGB", ceValue = "Agriculture", ceMode = "exact"}
+                        , ClassificationEntry{ceSystem = "AGB", ceValue = "Food", ceMode = "contains"}
+                        ]
+                    }
+        it "expands a configured preset into its filters" $
+            expandClassificationPreset [raw] (Just "raw")
+                `shouldBe` Right [("AGB", "Agriculture", True), ("AGB", "Food", False)]
+
+        it "filters nothing when no preset was asked for" $
+            expandClassificationPreset [raw] Nothing `shouldBe` Right []
+
+        -- An unknown name used to expand to no filters at all, which turned a
+        -- request for one slice of the database into a request for all of it.
+        it "refuses an unknown name instead of widening the query" $
+            case expandClassificationPreset [raw] (Just "transformed") of
+                Right filters -> expectationFailure ("expected a refusal, got " <> show filters)
+                Left err -> do
+                    err `shouldSatisfy` T.isInfixOf "transformed"
+                    err `shouldSatisfy` T.isInfixOf "raw"
+
+        it "says so when the instance carries no preset at all" $
+            case expandClassificationPreset [] (Just "raw") of
+                Right filters -> expectationFailure ("expected a refusal, got " <> show filters)
+                Left err -> err `shouldSatisfy` T.isInfixOf "no classification presets"
+
     describe "MethodConfig global-methods" $ do
         let decodeMethod t = TOML.decode t :: Either TOML.TOMLError MethodConfig
         it "parses the global-methods list" $

--- a/test/MCPDispatchSpec.hs
+++ b/test/MCPDispatchSpec.hs
@@ -8,17 +8,20 @@ tool at runtime with an "Unknown tool" reply. These tests pin both ends.
 module MCPDispatchSpec (spec) where
 
 import Control.Monad (forM_)
-import Data.Aeson (Value (..))
+import Data.Aeson (Value (..), decodeStrict)
 import qualified Data.Aeson.KeyMap as KM
 import Data.Foldable (toList)
+import qualified Data.Map as M
 import Data.Maybe (listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
+import Data.Text.Encoding (encodeUtf8)
 import Test.Hspec
 
 import API.MCP (callTool, mcpCountsAsActivity, toolDefinitions)
-import Config (ClassificationEntry (..), ClassificationPreset (..), ReadOnly (..), defaultConfig)
-import Database.Manager (initDatabaseManager)
+import Config (ClassificationEntry (..), ClassificationPreset (..), DatabaseConfig (..), ReadOnly (..), defaultConfig)
+import Database.Manager (addDatabase, initDatabaseManager, loadDatabase)
+import Types (GeographyPolicy (..))
 
 -- | The tool definition advertised under a given MCP name.
 toolByName :: Text -> Maybe Value
@@ -58,6 +61,13 @@ resultText v = do
     Object c <- listToMaybe (toList arr)
     String t <- KM.lookup "text" c
     pure t
+
+-- | A top-level field of a tool reply's JSON payload.
+jsonField :: KM.Key -> Value -> Maybe Value
+jsonField key resp = do
+    t <- resultText resp
+    Object o <- decodeStrict (encodeUtf8 t)
+    KM.lookup key o
 
 -- | Whether a tool reply is flagged as an error.
 isError :: Value -> Bool
@@ -156,6 +166,49 @@ spec = describe "MCP database load/unload tools" $ do
                 resp <- callWithPreset name
                 isError resp `shouldBe` True
                 resultText resp `shouldSatisfy` maybe False ("transformed" `T.isInfixOf`)
+
+        -- The refusal above is enforced in dispatch, so it cannot tell a
+        -- handler that reads the preset from one that drops it. These pin the
+        -- application: the fixture carries no classification at all, so a
+        -- preset that resolves must narrow the answer to nothing — a handler
+        -- ignoring it answers with the unfiltered set instead.
+        describe "a preset that resolves is applied" $ do
+            let sampleConfig =
+                    DatabaseConfig
+                        { dcName = "sample"
+                        , dcDisplayName = "sample"
+                        , dcPath = "test-data/SAMPLE.min"
+                        , dcDescription = Nothing
+                        , dcLoad = False
+                        , dcDefault = False
+                        , dcDepends = []
+                        , dcLocationAliases = M.empty
+                        , dcFormat = Nothing
+                        , dcIsUploaded = False
+                        , dcDeletable = False
+                        , dcGeographyPolicy = GeoGlobal
+                        }
+                callOnSample name presetArgs = do
+                    manager <- initDatabaseManager defaultConfig True Nothing
+                    addDatabase manager sampleConfig
+                    loadDatabase manager "sample" >>= either (expectationFailure . T.unpack) (const (pure ()))
+                    callTool manager [configured] Nothing Nothing Null name $
+                        KM.fromList $
+                            [ ("database", String "sample")
+                            , ("process_id", String "aa000001-0000-0000-0000-000000000000")
+                            , ("scope", String "direct")
+                            ]
+                                ++ presetArgs
+                positiveNumber v = case v of
+                    Just (Number n) -> n > 0
+                    _ -> False
+
+            forM_ [("aggregate", "filteredCount"), ("get_supply_chain", "filteredActivities")] $
+                \(tool, field) -> it (T.unpack tool <> " narrows to nothing under the preset") $ do
+                    full <- callOnSample tool []
+                    jsonField field full `shouldSatisfy` positiveNumber
+                    narrowed <- callOnSample tool [("preset", String "raw")]
+                    jsonField field narrowed `shouldBe` Just (Number 0)
 
     -- A server that shuts itself down when idle asks this question of every
     -- MCP request. Answering "yes" too often keeps an unused server alive for

--- a/test/MCPDispatchSpec.hs
+++ b/test/MCPDispatchSpec.hs
@@ -7,6 +7,7 @@ tool at runtime with an "Unknown tool" reply. These tests pin both ends.
 -}
 module MCPDispatchSpec (spec) where
 
+import Control.Monad (forM_)
 import Data.Aeson (Value (..))
 import qualified Data.Aeson.KeyMap as KM
 import Data.Foldable (toList)
@@ -16,7 +17,7 @@ import qualified Data.Text as T
 import Test.Hspec
 
 import API.MCP (callTool, mcpCountsAsActivity, toolDefinitions)
-import Config (ReadOnly (..), defaultConfig)
+import Config (ClassificationEntry (..), ClassificationPreset (..), ReadOnly (..), defaultConfig)
 import Database.Manager (initDatabaseManager)
 
 -- | The tool definition advertised under a given MCP name.
@@ -24,6 +25,17 @@ toolByName :: Text -> Maybe Value
 toolByName name =
     listToMaybe
         [t | t@(Object o) <- toolDefinitions (ReadOnly False), KM.lookup "name" o == Just (String name)]
+
+-- | Every advertised tool whose input schema declares a @preset@ parameter.
+takesPreset :: [Text]
+takesPreset =
+    [ name
+    | Object o <- toolDefinitions (ReadOnly False)
+    , Just (String name) <- [KM.lookup "name" o]
+    , Just (Object schema) <- [KM.lookup "inputSchema" o]
+    , Just (Object props) <- [KM.lookup "properties" schema]
+    , KM.member "preset" props
+    ]
 
 -- | The 'required' parameter names declared in a tool's input schema.
 requiredOf :: Value -> [Text]
@@ -114,6 +126,36 @@ spec = describe "MCP database load/unload tools" $ do
             resp <- call "get_characterization_coverage"
             isError resp `shouldBe` True
             resultText resp `shouldSatisfy` maybe False ("Database not loaded:" `T.isInfixOf`)
+
+    -- A preset narrows a search. A tool that advertises the parameter and then
+    -- ignores an unresolvable one answers with the whole database, which reads
+    -- like a result rather than like the mistake it is.
+    describe "tools taking a classification preset" $ do
+        let configured =
+                ClassificationPreset
+                    { cpName = "raw"
+                    , cpLabel = "Raw"
+                    , cpDescription = Nothing
+                    , cpFilters = [ClassificationEntry{ceSystem = "AGB", ceValue = "Agriculture", ceMode = "exact"}]
+                    }
+            callWithPreset name = do
+                manager <- initDatabaseManager defaultConfig True Nothing
+                callTool manager [configured] Nothing Nothing Null name $
+                    KM.fromList
+                        [ ("database", String "no-such-db")
+                        , ("process_id", String "no-such-pid")
+                        , ("scope", String "direct")
+                        , ("preset", String "transformed")
+                        ]
+
+        it "is a non-empty list, or this test proves nothing" $
+            takesPreset `shouldSatisfy` not . null
+
+        forM_ takesPreset $ \name ->
+            it (T.unpack name <> " refuses a preset the instance does not carry") $ do
+                resp <- callWithPreset name
+                isError resp `shouldBe` True
+                resultText resp `shouldSatisfy` maybe False ("transformed" `T.isInfixOf`)
 
     -- A server that shuts itself down when idle asks this question of every
     -- MCP request. Answering "yes" too often keeps an unused server alive for


### PR DESCRIPTION
A `preset` names a bundle of classification filters an instance declares in its
config. It exists to narrow a query. Two ways of asking for one did the
opposite.

**A name that resolves to nothing.** An unknown preset expanded to an empty
filter list, so a search for a slice of a database answered with all of it — no
error, no warning, just a much longer list than the caller asked for. A caller
reading the result has no way to tell the filter was dropped. It is now refused,
and the refusal names the presets the instance does carry, so a typo is one
message away from the right name and a server that never declared the preset
says so.

**A parameter nobody read.** The MCP `aggregate` and `get_supply_chain` tools
both advertise `preset` in their schema and neither ever looked at it. A valid
preset was dropped there too.

Both query surfaces kept their own copy of the preset lookup; they now share one
expander that lives next to the type it reads. The MCP refusal sits in tool
dispatch rather than in each handler, so a tool cannot advertise the parameter
and quietly ignore it, and the test walks the advertised schemas — a tool added
later is covered without touching it.