### PR TITLE
Release pyvolca 0.9.1

### DIFF
--- a/pyvolca/CHANGELOG.md
+++ b/pyvolca/CHANGELOG.md
@@ -18,6 +18,23 @@ git cliff --unreleased --tag pyvolca-v0.X.Y   # render as a released section
 
 Then paste the rendered block at the top of this file and tighten wording.
 
+## [0.9.1] - 2026-08-01
+
+### Added
+
+- `get_impacts_batch(..., exclude_long_term=True)` drops long-term emissions
+  before scoring — the switch `score_activities` already carried. The engine
+  route has always accepted it and only this wrapper had no way to say so, so
+  scoring a whole list and scoring one process could not be asked the same
+  question.
+
+### Changed
+
+- `Server.start(idle_timeout=…)` counts real use rather than traffic. Against
+  an engine >= v0.9.4, an API request or a matrix solve holds the server open,
+  while an MCP client that merely stays connected does not — an assistant left
+  running overnight no longer keeps the process alive on its own.
+
 ## [0.9.0] - 2026-07-31
 
 ### Changed — breaking
@@ -45,11 +62,6 @@ Then paste the rendered block at the top of this file and tighten wording.
 - `get_collection_coverage` reports how much of a database a whole method
   collection characterizes (typed `CollectionCoverage`), counting coverage
   the way scoring counts it.
-- `get_impacts_batch(..., exclude_long_term=True)` drops long-term emissions
-  before scoring — the switch `score_activities` already carried. The engine
-  route has always accepted it and only this wrapper had no way to say so, so
-  scoring a whole list and scoring one process could not be asked the same
-  question.
 - The client now understands wire revision 4 (engines >= v0.9.4, which
   advertise the quality-report routes); nothing changes against older
   engines.

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -28,7 +28,7 @@ pyvolca speaks a range of revisions of the engine's JSON wire format; the engine
 
 _Generated from `volca._compat` — run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.9.0** speaks wire formats **2 to 4** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error.
+This build of **pyvolca 0.9.1** speaks wire formats **2 to 4** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error.
 
 <!-- END: compatibility -->
 

--- a/pyvolca/pyproject.toml
+++ b/pyvolca/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvolca"
-version = "0.9.0"
+version = "0.9.1"
 description = "Python client for VoLCA — Life Cycle Assessment engine"
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Why

Two changes have shipped since the `pyvolca-v0.9.0` tag and neither has a
release: `get_impacts_batch(..., exclude_long_term=True)`, and the idle
countdown that changes what `Server.start(idle_timeout=…)` actually promises.

The first was written into the `[0.9.0]` section of the changelog *after* that
tag was already posted, so the published 0.9.0 announces a parameter it does
not contain. Anyone reading the changelog to decide whether to upgrade would
have been told the feature was already theirs.

## Final state

`pyvolca 0.9.1`, with both changes under their own dated section. The README
sentinel regenerates from the version, which is the third file in the diff.

Nothing about wire compatibility moves: `REQUIRED_WIRE` stays 2 and
`MIN_ENGINE_HINT` stays v0.9.1. The `exclude_long_term` parameter reaches a
route that has always accepted it, so the client keeps working against every
engine it worked against before.

The `Server.start` entry is a *Changed* rather than an *Added* because the
behaviour it describes lives in the engine (>= v0.9.4): an API request or a
matrix solve holds the server open, an MCP client that merely stays connected
no longer does. A user who left an assistant connected overnight to keep the
process alive needs to know that stopped working.

## Verification

`pytest`: 263 passed, 7 skipped. The generated API reference is in sync.

This lands before the `v0.9.4` tag is cut, so the engine tag's tree carries
pyvolca 0.9.1 and the published docs page, PyPI and the tag all state the same
version.
