### PR TITLE
Open 0.9.5 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.9.4] - 2026-08-01
 
 ### Added

--- a/volca.cabal
+++ b/volca.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                volca
-version:             0.9.4
+version:             0.9.5-dev
 build-type:          Simple
 
 license:             Apache-2.0


### PR DESCRIPTION
v0.9.4 is tagged and released, so main goes back to a `-dev` version and gains a fresh `[Unreleased]` changelog section.

Mechanical, no behaviour change.