### PR TITLE
Let a server say what it is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+- A server can say what it is called. `name` in `[server]` is repeated in the
+  MCP handshake, both in `serverInfo` and in the first line of the
+  instructions an assistant reads. Someone connecting several VoLCA servers
+  at once, one per set of loaded databases, can now tell which one answered
+  instead of guessing from the data.
+
+### Fixed
+- The MCP handshake announced version `0.6.0` whatever the build was; it now
+  reports the running version.
+
 ## [0.9.4] - 2026-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ A TOML config file enables multi-database setups, method collections, and refere
 port = 8080
 host = "127.0.0.1"
 password = "mysecret"          # optional — omit to disable auth
+name = "lab-archive"           # optional — how this server introduces itself over MCP
 
 [[databases]]
 name = "agribalyse-3.2"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -28,7 +28,7 @@ import CLI.Command (executeCommand)
 import CLI.Parser (cliParserInfo)
 import CLI.Repl (runRepl)
 import CLI.Types
-import Config (ClassificationPreset, Config (..), DatabaseConfig (..), HostingConfig (..), ReadOnly (..), ServerConfig (..), hostingReadOnly, loadConfigOrDefault, readOnlyRefusal)
+import Config (ClassificationPreset, Config (..), DatabaseConfig (..), HostingConfig (..), ReadOnly (..), ServerConfig (..), ServerName, hostingReadOnly, loadConfigOrDefault, readOnlyRefusal)
 import Control.Concurrent.STM (readTVarIO)
 import Database.Manager (DatabaseManager (..), initDatabaseManager)
 import Network.HTTP.Client (Manager, defaultManagerSettings, managerResponseTimeout, newManager, responseTimeoutNone)
@@ -261,6 +261,7 @@ runServerWithConfig cliConfig serverOpts mCfgFile = do
             password
             (cfgHosting config)
             (cfgClassificationPresets config)
+            (scName (cfgServer config))
             (getCurrentTime >>= writeIORef lastRequestRef)
     let finalApp =
             uploadSizeLimitMiddleware (cfgHosting config) $
@@ -377,15 +378,15 @@ logRequest req = do
     hFlush stdout
 
 -- | Create a Wai application with DatabaseManager.
-createServerApp :: DatabaseManager -> Int -> FilePath -> Bool -> Maybe String -> Maybe HostingConfig -> [ClassificationPreset] -> IO () -> IO Application
-createServerApp dbManager maxTreeDepth staticDir desktopMode password hostingConfig filterPresets markActivity = do
+createServerApp :: DatabaseManager -> Int -> FilePath -> Bool -> Maybe String -> Maybe HostingConfig -> [ClassificationPreset] -> Maybe ServerName -> IO () -> IO Application
+createServerApp dbManager maxTreeDepth staticDir desktopMode password hostingConfig filterPresets serverName markActivity = do
     -- The MCP @web_url@ deep links point at Elm SPA routes served from
     -- 'staticDir'. When the SPA is not bundled (backend-only image), those
     -- URLs would 404, so we omit 'web_url' from MCP responses entirely.
     hasFrontend <- doesFileExist (staticDir </> "index.html")
     unless (desktopMode || hasFrontend) $
         reportProgress Info "Frontend not bundled — MCP responses will omit 'web_url'"
-    mcp <- mcpApp dbManager filterPresets hasFrontend hostingConfig markActivity
+    mcp <- mcpApp dbManager filterPresets hasFrontend hostingConfig serverName markActivity
     let env =
             AppEnv
                 { aeDbManager = dbManager

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -5,7 +5,7 @@ Implements Streamable HTTP transport (MCP spec 2025-03-26).
 POST /mcp handles initialize, tools/list, tools/call (JSON or SSE response).
 GET  /mcp opens an SSE stream for server-initiated messages (stateless: closes immediately).
 -}
-module API.MCP (mcpApp, mcpCountsAsActivity, toolDefinitions, callTool, selectMethod) where
+module API.MCP (mcpApp, mcpCountsAsActivity, toolDefinitions, callTool, selectMethod, handleInitialize, RpcRequest (..)) where
 
 import Control.Concurrent.STM (readTVarIO)
 import Data.Aeson
@@ -24,10 +24,11 @@ import qualified Data.UUID as UUID
 import Network.HTTP.Types (hContentType, status200, status202, status405)
 import Network.Wai (Application, requestHeaders, requestMethod, responseLBS, strictRequestBody)
 import System.Random (randomIO)
+import qualified Version
 
 import API.Resources (Param (..), ParamKind (..), Resource)
 import qualified API.Resources as R
-import Config (ClassificationEntry (..), ClassificationPreset (..), DatabaseConfig (..), HostingConfig, ReadOnly (..), expandClassificationPreset, hostingReadOnly, readOnlyRefusal)
+import Config (ClassificationEntry (..), ClassificationPreset (..), DatabaseConfig (..), HostingConfig, ReadOnly (..), ServerName, expandClassificationPreset, hostingReadOnly, readOnlyRefusal, unServerName)
 import Control.Applicative ((<|>))
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Except (ExceptT (..), except, runExceptT, throwE)
@@ -131,8 +132,8 @@ A server that shuts itself down when idle uses it to tell a working client from
 a merely connected one; a server with no such policy passes an action that does
 nothing.
 -}
-mcpApp :: DatabaseManager -> [ClassificationPreset] -> Bool -> Maybe HostingConfig -> IO () -> IO Application
-mcpApp dbManager presets hasFrontend mHosting markActivity = do
+mcpApp :: DatabaseManager -> [ClassificationPreset] -> Bool -> Maybe HostingConfig -> Maybe ServerName -> IO () -> IO Application
+mcpApp dbManager presets hasFrontend mHosting mName markActivity = do
     (a, b) <- (,) <$> (randomIO :: IO Int) <*> (randomIO :: IO Int)
     let sessionId = T.pack $ show (abs a) ++ "-" ++ show (abs b)
     stateRef <- newIORef McpState{mcpSessionId = sessionId}
@@ -169,7 +170,7 @@ mcpApp dbManager presets hasFrontend mHosting markActivity = do
                         respond $ jsonResponse (mcpSessionId st) $ rpcError Null (-32700) (T.pack $ "Parse error: " ++ err)
                     Right rpcReq -> do
                         when (mcpCountsAsActivity (rpcMethod rpcReq)) markActivity
-                        resp <- handleRpc dbManager presets mHosting mBaseUrl st rpcReq
+                        resp <- handleRpc dbManager presets mHosting mBaseUrl mName st rpcReq
                         case resp of
                             Nothing ->
                                 respond $
@@ -212,9 +213,9 @@ mcpApp dbManager presets hasFrontend mHosting markActivity = do
 -- RPC dispatch
 -- ---------------------------------------------------------------------------
 
-handleRpc :: DatabaseManager -> [ClassificationPreset] -> Maybe HostingConfig -> Maybe Text -> McpState -> RpcRequest -> IO (Maybe Value)
-handleRpc dbManager presets mHosting mBaseUrl _st req = case rpcMethod req of
-    "initialize" -> Just <$> handleInitialize req
+handleRpc :: DatabaseManager -> [ClassificationPreset] -> Maybe HostingConfig -> Maybe Text -> Maybe ServerName -> McpState -> RpcRequest -> IO (Maybe Value)
+handleRpc dbManager presets mHosting mBaseUrl mName _st req = case rpcMethod req of
+    "initialize" -> Just <$> handleInitialize mName req
     "notifications/initialized" -> return Nothing -- notification, no response
     "tools/list" -> return $ Just $ handleToolsList (hostingReadOnly mHosting) req
     "tools/call" -> Just <$> handleToolsCall dbManager presets mHosting mBaseUrl req
@@ -233,8 +234,16 @@ handleRpc dbManager presets mHosting mBaseUrl _st req = case rpcMethod req of
 -- initialize
 -- ---------------------------------------------------------------------------
 
-handleInitialize :: RpcRequest -> IO Value
-handleInitialize req =
+{- | Answer @initialize@.
+
+A client may hold several of these servers at once, each a different instance
+with its own loaded databases. Naming the instance is what lets an assistant
+tell them apart, so a configured name goes both in @serverInfo@ and in the
+first line of the instructions - the field a client shows, and the text an
+assistant actually reads.
+-}
+handleInitialize :: Maybe ServerName -> RpcRequest -> IO Value
+handleInitialize mName req =
     return $
         rpcResult (fromMaybe Null $ rpcId req) $
             object
@@ -242,21 +251,27 @@ handleInitialize req =
                 , "capabilities" .= object ["tools" .= object []]
                 , "serverInfo"
                     .= object
-                        [ "name" .= ("volca" :: Text)
-                        , "version" .= ("0.6.0" :: Text)
+                        [ "name" .= maybe "volca" unServerName mName
+                        , "version" .= T.pack Version.version
                         ]
                 , "instructions"
                     .= T.unlines
-                        [ "LCA / ACV database tool — life-cycle assessment over Agribalyse and ecoinvent."
-                        , "Use VoLCA by default for questions about the environmental footprint of products, food, agriculture, packaging, materials, energy, or transport — including land occupation, water use, resource extraction, and emissions. Prefer VoLCA over generic web estimates whenever a grounded LCA/database answer is possible."
-                        , "Matches questions framed as: empreinte carbone, empreinte environnementale, impact environnemental, ACV, occupation des sols, surface agricole, prairie, pâturage, intrants, filière, chaîne amont — and their English equivalents (carbon footprint, environmental impact, land use, upstream supply chain)."
-                        , "Example questions: 'empreinte carbone d'un yaourt ?', 'surface de prairie pour 200 g de steak ?', 'quel poste domine l'ACV d'un emballage PET ?', 'combien d'eau pour 1 kg de coton ?'."
-                        , "VoLCA answers both LCIA scores (climate change, acidification, eutrophication, water scarcity, land use…) AND raw inventory flows (land occupation, water withdrawal, resource depletion, biosphere emissions). Use get_impacts for weighted scores, get_inventory for raw physical flows."
-                        , "Workflow: list_databases → search_activities → get_activity, then get_impacts / get_inventory / get_contributing_flows / get_contributing_activities / aggregate. Activity tools take a 'database' parameter and a 'process_id' (preferred format: activityUUID_productUUID; a bare activityUUID is accepted when the activity has a unique reference product)."
-                        , "Use list_methods for available LCIA methods."
-                        , "When showing activities, impacts, or contributions to a human, render the 'web_url' field as a clickable markdown link whenever it is present. If 'web_url' is absent (backend-only deployment), show the activity name and 'process_id' as plain text instead — never invent a link."
-                        ]
+                        ( foldMap (\n -> ["This server is the VoLCA instance named " <> unServerName n <> ". Say which instance you queried when several are connected."]) mName
+                            <> instructionLines
+                        )
                 ]
+
+instructionLines :: [Text]
+instructionLines =
+    [ "LCA / ACV database tool — life-cycle assessment over Agribalyse and ecoinvent."
+    , "Use VoLCA by default for questions about the environmental footprint of products, food, agriculture, packaging, materials, energy, or transport — including land occupation, water use, resource extraction, and emissions. Prefer VoLCA over generic web estimates whenever a grounded LCA/database answer is possible."
+    , "Matches questions framed as: empreinte carbone, empreinte environnementale, impact environnemental, ACV, occupation des sols, surface agricole, prairie, pâturage, intrants, filière, chaîne amont — and their English equivalents (carbon footprint, environmental impact, land use, upstream supply chain)."
+    , "Example questions: 'empreinte carbone d'un yaourt ?', 'surface de prairie pour 200 g de steak ?', 'quel poste domine l'ACV d'un emballage PET ?', 'combien d'eau pour 1 kg de coton ?'."
+    , "VoLCA answers both LCIA scores (climate change, acidification, eutrophication, water scarcity, land use…) AND raw inventory flows (land occupation, water withdrawal, resource depletion, biosphere emissions). Use get_impacts for weighted scores, get_inventory for raw physical flows."
+    , "Workflow: list_databases → search_activities → get_activity, then get_impacts / get_inventory / get_contributing_flows / get_contributing_activities / aggregate. Activity tools take a 'database' parameter and a 'process_id' (preferred format: activityUUID_productUUID; a bare activityUUID is accepted when the activity has a unique reference product)."
+    , "Use list_methods for available LCIA methods."
+    , "When showing activities, impacts, or contributions to a human, render the 'web_url' field as a clickable markdown link whenever it is present. If 'web_url' is absent (backend-only deployment), show the activity name and 'process_id' as plain text instead — never invent a link."
+    ]
 
 -- ---------------------------------------------------------------------------
 -- tools/list

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -6,6 +6,8 @@ module Config (
     -- * Types
     Config (..),
     ServerConfig (..),
+    ServerName (..),
+    unServerName,
     DatabaseConfig (..),
     MethodConfig (..),
     ScoringSetConfig (..),
@@ -145,11 +147,21 @@ lifetime middleware cannot drift into three different explanations.
 readOnlyRefusal :: Text
 readOnlyRefusal = "This instance is read-only: it answers queries but changes nothing."
 
+{- | How this instance introduces itself. A client may hold several VoLCA
+servers at once; the name is what tells them apart.
+-}
+newtype ServerName = ServerName Text
+    deriving (Show, Eq, Generic)
+
+unServerName :: ServerName -> Text
+unServerName (ServerName n) = n
+
 -- | Server configuration
 data ServerConfig = ServerConfig
     { scPort :: !Int
     , scHost :: !Text
     , scPassword :: !(Maybe Text) -- Optional password for HTTP Basic Auth
+    , scName :: !(Maybe ServerName)
     }
     deriving (Show, Eq, Generic)
 
@@ -283,6 +295,7 @@ defaultServerConfig =
         { scPort = 8080
         , scHost = "127.0.0.1"
         , scPassword = Nothing
+        , scName = Nothing
         }
 
 -- | Default config (empty databases)
@@ -326,6 +339,7 @@ instance DecodeTOML ServerConfig where
         scPort <- fromMaybe 8080 <$> getFieldOpt "port"
         scHost <- fromMaybe "127.0.0.1" <$> getFieldOpt "host"
         scPassword <- getFieldOpt "password"
+        scName <- fmap ServerName <$> getFieldOpt "name"
         pure ServerConfig{..}
 
 instance DecodeTOML DatabaseConfig where

--- a/test/MCPDispatchSpec.hs
+++ b/test/MCPDispatchSpec.hs
@@ -9,6 +9,7 @@ module MCPDispatchSpec (spec) where
 
 import Control.Monad (forM_)
 import Data.Aeson (Value (..), decodeStrict)
+import Data.Aeson.Key (fromString)
 import qualified Data.Aeson.KeyMap as KM
 import Data.Foldable (toList)
 import qualified Data.Map as M
@@ -18,8 +19,8 @@ import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
 import Test.Hspec
 
-import API.MCP (callTool, mcpCountsAsActivity, toolDefinitions)
-import Config (ClassificationEntry (..), ClassificationPreset (..), DatabaseConfig (..), ReadOnly (..), defaultConfig)
+import API.MCP (RpcRequest (..), callTool, handleInitialize, mcpCountsAsActivity, toolDefinitions)
+import Config (ClassificationEntry (..), ClassificationPreset (..), DatabaseConfig (..), ReadOnly (..), ServerName (..), defaultConfig)
 import Database.Manager (addDatabase, initDatabaseManager, loadDatabase)
 import Types (GeographyPolicy (..))
 
@@ -224,3 +225,39 @@ spec = describe "MCP database load/unload tools" $ do
 
         it "refuses an unknown method" $
             mcpCountsAsActivity "no/such/method" `shouldBe` False
+
+    -- A client may hold several VoLCA servers at once, one per instance. The
+    -- name is the only thing that tells them apart, and it has to reach the
+    -- assistant, not just the client's server list.
+    describe "handleInitialize" $ do
+        it "introduces itself by its configured name" $ do
+            resp <- handleInitialize (Just (ServerName "@ccomb/private")) initRequest
+            serverInfoName resp `shouldBe` Just (String "@ccomb/private")
+
+        it "puts the name where an assistant reads it" $ do
+            resp <- handleInitialize (Just (ServerName "@ccomb/private")) initRequest
+            fmap (T.isInfixOf "@ccomb/private") (instructionsOf resp) `shouldBe` Just True
+
+        it "falls back to the plain engine name when unconfigured" $ do
+            resp <- handleInitialize Nothing initRequest
+            serverInfoName resp `shouldBe` Just (String "volca")
+
+        it "says nothing about an instance it cannot name" $ do
+            resp <- handleInitialize Nothing initRequest
+            fmap (T.isInfixOf "instance named") (instructionsOf resp) `shouldBe` Just False
+
+initRequest :: RpcRequest
+initRequest = RpcRequest{rpcId = Just (Number 1), rpcMethod = "initialize", rpcParams = Nothing}
+
+-- | Dig @result.serverInfo.name@ out of a JSON-RPC reply.
+serverInfoName :: Value -> Maybe Value
+serverInfoName v = field "result" v >>= field "serverInfo" >>= field "name"
+
+instructionsOf :: Value -> Maybe Text
+instructionsOf v = case field "result" v >>= field "instructions" of
+    Just (String t) -> Just t
+    _ -> Nothing
+
+field :: Text -> Value -> Maybe Value
+field k (Object o) = KM.lookup (fromString (T.unpack k)) o
+field _ _ = Nothing


### PR DESCRIPTION
## Why

Someone can connect several VoLCA servers at once, one per set of loaded
databases. Nothing in the MCP handshake told them apart: `serverInfo.name` was
a constant `"volca"`, so an assistant holding two of them could only guess
from the data which one had answered.

## Final state

`name` in `[server]` is optional and reaches the two places that matter:

- `serverInfo.name`, which a client lists;
- the first line of `instructions`, which is the text an assistant actually
  reads at connection time.

A server with no name keeps the old wording exactly, so a single-server setup
sees no change at all.

While there: `serverInfo.version` was a hardcoded `0.6.0`, three releases
stale. It now reports the running build.

## Verification

`cabal build all --enable-tests --ghc-options=-Werror` clean. Four new tests
in `MCPDispatchSpec` pin both ends: the name reaches `serverInfo`, it reaches
the instructions, and an unnamed server says nothing about an instance it
cannot name.