### PR TITLE
Author activities into a database instead of only deleting them

### DIFF
--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -1,0 +1,590 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
+
+{- |
+Module      : Database.Author
+Description : Turning authored activity descriptions into database rows
+
+Importing a database is tolerant: a supplier link that resolves to nothing is
+warned about and dropped ('Database.MatrixBuild.findProducer'), because the
+alternative — refusing a 20 000-dataset file over one bad row — helps nobody.
+Authoring is the opposite situation. The author is present, the batch is small,
+and every defect is fixable on the spot, so this module refuses instead of
+repairing: an unresolvable supplier, an impossible unit conversion, a
+non-finite amount and an empty name are all 'Left'. Nothing is guessed, and
+nothing is silently dropped.
+
+Identity is deterministic. An authored activity is addressed by
+@(activityUUID, productUUID)@ like every other process, and both halves are
+UUID5-minted from what the author wrote (see 'authoredNamespace'), never from
+a counter or a clock. Authoring the same description twice therefore yields
+the same key — which is what makes "write this activity again with one number
+changed" a replace rather than a silent duplicate.
+
+The product UUID keys on name *and* unit. Two activities that both produce
+@milk@ in @kg@ share one product flow, exactly as a database with several
+producers of the same product does; @milk@ in @kg@ and @milk@ in @l@ are two
+flows, because they are. That makes "one flow UUID carrying two different
+units" unrepresentable rather than merely unlikely.
+
+Scope: one reference product per authored activity. Coproducts and allocation
+are a later phase, and the types here do not pretend to support them — an
+'AuthoredActivity' has exactly one product field group, not a list.
+-}
+module Database.Author (
+    -- * What an author writes
+    AuthoredActivity (..),
+    AuthoredExchange (..),
+    FlowRef (..),
+    AuthorContext (..),
+
+    -- * What the database can take
+    ResolvedInsert (..),
+    validateAuthored,
+
+    -- * Deterministic identity
+    authoredNamespace,
+    authoredActivityUUID,
+    authoredProductUUID,
+    authoredBioFlowUUID,
+) where
+
+import qualified Data.ByteString as BS
+import Data.Either (partitionEithers)
+import qualified Data.Map.Strict as M
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified Data.UUID as UUID
+import qualified Data.UUID.V5 as UUID5
+import qualified Data.Vector as V
+
+import Types (
+    Activity (..),
+    BioDirection (..),
+    BiosphereFlow (..),
+    Compartment (..),
+    Database (..),
+    Exchange (..),
+    ProcessId,
+    TechRole (..),
+    TechnosphereFlow (..),
+    UUID,
+    Unit (..),
+    UnitDB,
+    declaredLocationSource,
+    exchangeIsInput,
+    exchangeIsReference,
+    findProcessIdByActivityUUID,
+    getUnitNameForExchange,
+    parseUUIDPair,
+ )
+import UnitConversion (UnitConfig, convertUnit, normalizeUnit)
+
+-- ---------------------------------------------------------------------------
+-- Deterministic identity
+-- ---------------------------------------------------------------------------
+
+{- | UUID5 namespace for everything an author creates, alongside the
+per-format namespaces each parser owns ('SimaPro.Parser.simaproNamespace',
+@ecospold1Namespace@). A separate namespace is what keeps an authored
+@wheat, at farm/FR@ from colliding with an imported one of the same name: the
+two are different datasets and must stay different rows.
+-}
+authoredNamespace :: UUID
+authoredNamespace = UUID5.generateNamed UUID5.namespaceURL (BS.unpack $ TE.encodeUtf8 "volca:authored")
+
+mintAuthored :: Text -> UUID
+mintAuthored = UUID5.generateNamed authoredNamespace . BS.unpack . TE.encodeUtf8
+
+-- | Activity half of the process key: what the activity does, and where.
+authoredActivityUUID :: Text -> Text -> UUID
+authoredActivityUUID name location = mintAuthored ("activity:" <> name <> "@" <> location)
+
+{- | Product half of the process key. Keyed on unit as well as name — see the
+module header on why @milk@ in @kg@ and @milk@ in @l@ are two flows.
+-}
+authoredProductUUID :: Text -> Text -> UUID
+authoredProductUUID productName unit = mintAuthored ("product:" <> productName <> ":" <> unit)
+
+{- | Identity of a biosphere flow an author introduces. Same three coordinates
+the SimaPro parser mints on (name, compartment, unit), so re-declaring the
+same flow in a second activity reuses the first one instead of forking it.
+-}
+authoredBioFlowUUID :: Text -> Compartment -> Text -> UUID
+authoredBioFlowUUID name comp unit =
+    mintAuthored ("flow:" <> name <> ":" <> compartmentKey comp <> ":" <> unit)
+
+compartmentKey :: Compartment -> Text
+compartmentKey comp = compartmentName comp <> "/" <> fromMaybe "" (compartmentSub comp)
+
+-- ---------------------------------------------------------------------------
+-- What an author writes
+-- ---------------------------------------------------------------------------
+
+{- | The flow a biosphere exchange names: one already in the vocabulary, or one
+the author is introducing.
+
+There is deliberately no technosphere counterpart. A technosphere input always
+names a *supplier* — a product that something in scope produces — so the flow
+is whatever that supplier's process key already says it is. The only new
+technosphere flow authoring can create is the authored activity's own product,
+and that one is minted from the activity itself, never stated as an input.
+-}
+data FlowRef
+    = ExistingFlow UUID
+    | -- | name, compartment, unit
+      NewBioFlow Text Compartment Text
+
+{- | One line of an authored activity's inventory.
+
+@ati*@ / @aw*@ carry a @process_id@ in the same currency the API and the UI
+speak (@activityUUID_productUUID@, or a bare activity UUID when the activity
+has a single product), never a matrix index — those renumber on every edit.
+
+'AuthoredWasteOutput' is a waste this activity generates and hands to a
+treatment process: the provider is the treatment activity, exactly as a
+technosphere input's provider is the producer. The two resolve identically;
+only the direction differs.
+-}
+data AuthoredExchange
+    = AuthoredTechInput
+        { atiProvider :: Text
+        , atiAmount :: Double
+        , atiUnit :: Maybe Text
+        , atiComment :: Maybe Text
+        }
+    | AuthoredBio
+        { abFlow :: FlowRef
+        , abDirection :: BioDirection
+        , abAmount :: Double
+        , abUnit :: Maybe Text
+        , abComment :: Maybe Text
+        }
+    | AuthoredWasteOutput
+        { awProvider :: Text
+        , awAmount :: Double
+        , awUnit :: Maybe Text
+        , awComment :: Maybe Text
+        }
+
+-- | A complete activity as an author states it: what it is, and what it exchanges.
+data AuthoredActivity = AuthoredActivity
+    { aaName :: Text
+    , aaLocation :: Text
+    , aaDescription :: [Text]
+    , aaProductName :: Text
+    , aaProductAmount :: Double
+    , aaProductUnit :: Text
+    , aaExchanges :: [AuthoredExchange]
+    }
+
+{- | Everything resolution needs to read: the database being edited, the
+databases it may draw suppliers from, and the unit table conversions are
+judged against.
+-}
+data AuthorContext = AuthorContext
+    { acDb :: Database
+    , acDeps :: [(Text, Database)]
+    , acUnitConfig :: UnitConfig
+    }
+
+{- | An authored activity that the database can accept, with the vocabulary it
+brings along. The caller inserts the flows and the activity together —
+'Database.Edit.insertActivities' does — so the activity never lands referring
+to a flow nothing declares.
+-}
+data ResolvedInsert = ResolvedInsert
+    { riKey :: (UUID, UUID)
+    , riActivity :: Activity
+    , riNewTechFlows :: [TechnosphereFlow]
+    , riNewBioFlows :: [BiosphereFlow]
+    }
+
+-- ---------------------------------------------------------------------------
+-- Validation
+-- ---------------------------------------------------------------------------
+
+{- | Resolve a batch of authored activities, or report everything wrong with it.
+
+Errors accumulate across the whole batch and across every exchange of every
+activity: an author fixing a ten-line inventory sees ten complaints once, not
+one complaint ten times. Each message names the activity it belongs to.
+
+Warnings ('snd' of the success case) never block. Today the only one is a
+biosphere flow new to the database, which by construction no characterization
+factor matches by UUID — it may still be reached by name, so it is a caution
+and not a refusal.
+
+Whether the key may already exist is not decided here: this function does not
+know if the caller means to insert or to replace.
+'Database.Edit.insertActivities' and 'Database.Edit.replaceActivities' own
+that check, each in the direction it means. What *is* checked here is that the
+batch does not mint one key twice, since no intent makes that coherent.
+-}
+validateAuthored :: AuthorContext -> [AuthoredActivity] -> Either [Text] ([ResolvedInsert], [Text])
+validateAuthored ctx activities =
+    case partitionEithers (map (validateOne ctx) activities) of
+        ([], oks) ->
+            let inserts = map fst oks
+             in case duplicateKeys (map riKey inserts) of
+                    [] -> Right (inserts, concatMap snd oks)
+                    dups -> Left (map duplicateMessage dups)
+        (errs, _) -> Left (concat errs)
+  where
+    duplicateMessage (a, p) =
+        "Two activities in this batch mint the same identity ("
+            <> UUID.toText a
+            <> "_"
+            <> UUID.toText p
+            <> "): same name, location, product and unit."
+
+duplicateKeys :: [(UUID, UUID)] -> [(UUID, UUID)]
+duplicateKeys keys = M.keys (M.filter (> (1 :: Int)) (M.fromListWith (+) [(k, 1) | k <- keys]))
+
+validateOne :: AuthorContext -> AuthoredActivity -> Either [Text] (ResolvedInsert, [Text])
+validateOne ctx a =
+    case (productChecks, partitionEithers (zipWith resolveExchange [1 :: Int ..] (aaExchanges a))) of
+        ([], ([], resolved)) ->
+            case lookupUnit ctx (aaProductUnit a) of
+                Nothing -> Left [here ("unknown unit \"" <> aaProductUnit a <> "\" for the product")]
+                Just (unitRef, unitLabel) ->
+                    let key = (authoredActivityUUID (aaName a) (aaLocation a), authoredProductUUID (aaProductName a) unitLabel)
+                        productExchange =
+                            TechnosphereExchange
+                                { techFlowId = snd key
+                                , techAmount = aaProductAmount a
+                                , techUnitId = unitRef
+                                , techRole = ReferenceProduct
+                                , techActivityLinkId = UUID.nil
+                                , techProcessLinkId = Nothing
+                                , techLocation = ""
+                                , techComment = Nothing
+                                , techPedigree = Nothing
+                                }
+                        productFlow =
+                            TechnosphereFlow
+                                { tfId = snd key
+                                , tfName = aaProductName a
+                                , tfUnitId = unitRef
+                                , tfSynonyms = M.empty
+                                , tfCAS = Nothing
+                                , tfSubstanceId = Nothing
+                                }
+                     in Right
+                            ( ResolvedInsert
+                                { riKey = key
+                                , riActivity = buildActivity a unitLabel (productExchange : map reExchange resolved)
+                                , riNewTechFlows = [productFlow | not (M.member (snd key) (dbTechFlows (acDb ctx)))]
+                                , riNewBioFlows = mapMaybe reNewBioFlow resolved
+                                }
+                            , map here (concatMap reWarnings resolved)
+                            )
+        (perActivityErrs, (exchangeErrs, _)) -> Left (map here (perActivityErrs <> concat exchangeErrs))
+  where
+    here msg = aaName a <> " {" <> aaLocation a <> "}: " <> msg
+    resolveExchange i ex = mapLeft (map (numbered i)) (resolveOne ctx ex)
+    numbered i msg = "exchange " <> T.pack (show i) <> ": " <> msg
+    productChecks =
+        concat
+            [ ["the activity name is empty" | T.null (T.strip (aaName a))]
+            , ["the product name is empty" | T.null (T.strip (aaProductName a))]
+            , [ "the product amount is " <> T.pack (show (aaProductAmount a)) <> "; it must be a finite non-zero number"
+              | not (isUsableAmount (aaProductAmount a))
+              ]
+            ]
+
+buildActivity :: AuthoredActivity -> Text -> [Exchange] -> Activity
+buildActivity a unitLabel exchangeList =
+    Activity
+        { activityName = aaName a
+        , activityDescription = aaDescription a
+        , activitySynonyms = M.empty
+        , activityClassification = M.empty
+        , activityLocation = aaLocation a
+        , activityLocationSource = declaredLocationSource (aaLocation a)
+        , activityUnit = unitLabel
+        , exchanges = exchangeList
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
+        , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
+        }
+
+{- | An amount that can carry information: finite, and not zero. A zero
+exchange is not a measurement of nothing, it is a line that should not have
+been written — and it would divide into a zero normalization factor.
+-}
+isUsableAmount :: Double -> Bool
+isUsableAmount x = not (isNaN x) && not (isInfinite x) && x /= 0
+
+-- ---------------------------------------------------------------------------
+-- Exchange resolution
+-- ---------------------------------------------------------------------------
+
+-- | One resolved inventory line, plus whatever it drags into the vocabulary.
+data ResolvedExchange = ResolvedExchange
+    { reExchange :: Exchange
+    , reNewBioFlow :: Maybe BiosphereFlow
+    , reWarnings :: [Text]
+    }
+
+resolveOne :: AuthorContext -> AuthoredExchange -> Either [Text] ResolvedExchange
+resolveOne ctx ex = case ex of
+    AuthoredTechInput provider amount mUnit comment ->
+        resolveLinked ctx provider amount mUnit $ \sup unitRef ->
+            TechnosphereExchange
+                { techFlowId = snd (supKey sup)
+                , techAmount = amount
+                , techUnitId = unitRef
+                , techRole = Input
+                , techActivityLinkId = fst (supKey sup)
+                , techProcessLinkId = supLocalPid sup
+                , techLocation = ""
+                , techComment = comment
+                , techPedigree = Nothing
+                }
+    AuthoredWasteOutput provider amount mUnit comment ->
+        resolveLinked ctx provider amount mUnit $ \sup unitRef ->
+            WasteExchange
+                { waFlowId = snd (supKey sup)
+                , waAmount = amount
+                , waUnitId = unitRef
+                , waIsInput = False
+                , waActivityLinkId = fst (supKey sup)
+                , waProcessLinkId = supLocalPid sup
+                , waLocation = ""
+                , waComment = comment
+                , waPedigree = Nothing
+                }
+    AuthoredBio flowRef direction amount mUnit comment ->
+        resolveBio ctx flowRef direction amount mUnit comment
+
+{- | A technosphere input and a waste output differ only in the constructor
+they build: both name a provider by process id, both take their flow from that
+provider's process key, and both convert into that provider's reference unit.
+-}
+resolveLinked ::
+    AuthorContext ->
+    Text ->
+    Double ->
+    Maybe Text ->
+    (Supplier -> UUID -> Exchange) ->
+    Either [Text] ResolvedExchange
+resolveLinked ctx provider amount mUnit build =
+    case (amountCheck, resolveSupplier ctx provider) of
+        ([], Right sup) ->
+            let stated = fromMaybe (defaultUnit sup) mUnit
+             in case lookupUnit ctx stated of
+                    Nothing -> Left ["unknown unit \"" <> stated <> "\""]
+                    Just (unitRef, unitLabel) ->
+                        case conversionError ctx unitLabel (supProducedUnit sup) of
+                            Just err -> Left [err]
+                            Nothing -> Right (ResolvedExchange (build sup unitRef) Nothing [])
+        (errs, Right _) -> Left errs
+        (errs, Left err) -> Left (errs <> [err])
+  where
+    amountCheck =
+        [ "the amount is " <> T.pack (show amount) <> "; it must be a finite non-zero number"
+        | not (isUsableAmount amount)
+        ]
+    defaultUnit sup =
+        case (supProducedUnit sup, supAnyRefUnit sup) of
+            ("", "") -> ""
+            ("", other) -> other
+            (produced, _) -> produced
+
+{- | The unit a value must be stated in before it can enter the technosphere
+matrix. Mirrors 'Database.MatrixBuild.techTriple' exactly — same emptiness
+guards, same conversion table — so a batch that validates here cannot fail the
+rebuild afterwards for a reason authoring could have named first.
+-}
+conversionError :: AuthorContext -> Text -> Text -> Maybe Text
+conversionError ctx stated supplierUnit
+    | not needsConversion = Nothing
+    | otherwise = case convertUnit (acUnitConfig ctx) stated supplierUnit 1 of
+        Just _ -> Nothing
+        Nothing ->
+            Just $
+                "cannot convert \""
+                    <> stated
+                    <> "\" into the supplier's \""
+                    <> supplierUnit
+                    <> "\""
+  where
+    needsConversion =
+        normalizeUnit stated /= normalizeUnit supplierUnit
+            && not (T.null stated)
+            && not (T.null supplierUnit)
+
+resolveBio ::
+    AuthorContext ->
+    FlowRef ->
+    BioDirection ->
+    Double ->
+    Maybe Text ->
+    Maybe Text ->
+    Either [Text] ResolvedExchange
+resolveBio ctx flowRef direction amount mUnit comment
+    | not (isUsableAmount amount) =
+        Left ["the amount is " <> T.pack (show amount) <> "; it must be a finite non-zero number"]
+    | otherwise = case flowRef of
+        ExistingFlow flowId -> case findBioFlow ctx flowId of
+            Nothing ->
+                Left
+                    [ "no biosphere flow "
+                        <> UUID.toText flowId
+                        <> " in this database or its dependencies"
+                    ]
+            Just (flow, ownerUnits) ->
+                let flowUnit = unitNameOf ownerUnits (bfUnitId flow)
+                 in case mUnit of
+                        Just stated | normalizeUnit stated /= normalizeUnit flowUnit -> Left [mismatch flow stated flowUnit]
+                        _ -> emit flowId (bfUnitId flow) Nothing []
+        NewBioFlow name comp unit -> case lookupUnit ctx unit of
+            Nothing -> Left ["unknown unit \"" <> unit <> "\" for flow \"" <> name <> "\""]
+            Just (unitRef, unitLabel) ->
+                let flowId = authoredBioFlowUUID name comp unitLabel
+                 in case findBioFlow ctx flowId of
+                        Just (flow, _) -> emit flowId (bfUnitId flow) Nothing []
+                        Nothing ->
+                            emit
+                                flowId
+                                unitRef
+                                (Just (newBioFlow flowId name comp unitRef))
+                                [ "biosphere flow \""
+                                    <> name
+                                    <> "\" is new to this database; no characterization factor matches it by identity yet"
+                                ]
+  where
+    emit flowId unitRef mNew warnings =
+        Right
+            ( ResolvedExchange
+                BiosphereExchange
+                    { bioFlowId = flowId
+                    , bioAmount = amount
+                    , bioUnitId = unitRef
+                    , bioDirection = direction
+                    , bioLocation = ""
+                    , bioComment = comment
+                    , bioPedigree = Nothing
+                    }
+                mNew
+                warnings
+            )
+    -- The biosphere matrix carries amounts through unconverted, so a unit the
+    -- flow does not use would land as a wrong number rather than as a
+    -- conversion. Refuse and name both units.
+    mismatch flow stated flowUnit =
+        "biosphere flow \""
+            <> bfName flow
+            <> "\" is recorded in \""
+            <> flowUnit
+            <> "\" but the exchange states \""
+            <> stated
+            <> "\"; biosphere amounts are not converted, so restate it in \""
+            <> flowUnit
+            <> "\""
+
+newBioFlow :: UUID -> Text -> Compartment -> UUID -> BiosphereFlow
+newBioFlow flowId name comp unitRef =
+    BiosphereFlow
+        { bfId = flowId
+        , bfName = name
+        , bfUnitId = unitRef
+        , bfSynonyms = M.empty
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfCompartment = Just comp
+        }
+
+-- ---------------------------------------------------------------------------
+-- Lookups across the edited database and its dependencies
+-- ---------------------------------------------------------------------------
+
+{- | A resolved provider. 'supLocalPid' is 'Just' only when the provider lives
+in the database being edited: a provider in a dependency has no process id
+here, and its link is left for cross-database relinking to resolve.
+-}
+data Supplier = Supplier
+    { supKey :: (UUID, UUID)
+    , supLocalPid :: Maybe ProcessId
+    , supProducedUnit :: Text
+    {- ^ unit of the produced reference output, @""@ for a treatment process
+    that has only a reference input. Mirrors
+    'Database.MatrixBuild.buildSupplierRefUnits', which is what the matrix
+    converts into.
+    -}
+    , supAnyRefUnit :: Text
+    {- ^ unit of the first reference exchange either way, used only to default
+    an omitted unit — a treatment provider has no produced unit to borrow.
+    -}
+    }
+
+resolveSupplier :: AuthorContext -> Text -> Either Text Supplier
+resolveSupplier ctx provider =
+    case mapMaybe inDatabase ((thisDb, acDb ctx) : acDeps ctx) of
+        [] -> Left ("unknown provider \"" <> provider <> "\"")
+        (sup : _) -> Right sup
+  where
+    thisDb = ""
+    inDatabase (name, db) = do
+        pid <- resolveProcess db provider
+        key <- dbProcessIdTable db V.!? fromIntegral pid
+        act <- dbActivities db V.!? fromIntegral pid
+        pure
+            Supplier
+                { supKey = key
+                , supLocalPid = if name == thisDb then Just pid else Nothing
+                , supProducedUnit = refUnitOf db act (\e -> exchangeIsReference e && not (exchangeIsInput e))
+                , supAnyRefUnit = refUnitOf db act exchangeIsReference
+                }
+
+{- | Resolve a process id string the same two ways the rest of the engine
+does: the canonical @activityUUID_productUUID@ pair, or a bare activity UUID
+when that activity has a single product.
+-}
+resolveProcess :: Database -> Text -> Maybe ProcessId
+resolveProcess db queryText = case parseUUIDPair queryText of
+    Just (a, p) -> M.lookup (a, p) (dbProcessIdLookup db)
+    Nothing -> UUID.fromText queryText >>= findProcessIdByActivityUUID db
+
+refUnitOf :: Database -> Activity -> (Exchange -> Bool) -> Text
+refUnitOf db act keep = case filter keep (exchanges act) of
+    (ex : _) -> getUnitNameForExchange (dbUnits db) ex
+    [] -> ""
+
+findBioFlow :: AuthorContext -> UUID -> Maybe (BiosphereFlow, UnitDB)
+findBioFlow ctx flowId =
+    case mapMaybe look (acDb ctx : map snd (acDeps ctx)) of
+        [] -> Nothing
+        (found : _) -> Just found
+  where
+    look db = (,dbUnits db) <$> M.lookup flowId (dbBioFlows db)
+
+{- | Resolve a unit the author names to the identifier an exchange carries,
+plus the canonical name of that unit. Names and symbols both resolve, so
+@kilogram@ and @kg@ reach the same row; a name wins over a symbol when a
+database happens to use one string for both.
+-}
+lookupUnit :: AuthorContext -> Text -> Maybe (UUID, Text)
+lookupUnit ctx stated = M.lookup (normalizeUnit stated) (unitIndex (dbUnits (acDb ctx)))
+
+unitIndex :: UnitDB -> M.Map Text (UUID, Text)
+unitIndex units =
+    M.fromList
+        [ (normalizeUnit key, (unitId u, unitName u))
+        | u <- M.elems units
+        , key <- [unitSymbol u, unitName u]
+        , not (T.null (T.strip key))
+        ]
+
+unitNameOf :: UnitDB -> UUID -> Text
+unitNameOf units uid = maybe "" unitName (M.lookup uid units)
+
+mapLeft :: (a -> b) -> Either a c -> Either b c
+mapLeft f = either (Left . f) Right

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -94,18 +94,23 @@ two are different datasets and must stay different rows.
 authoredNamespace :: UUID
 authoredNamespace = UUID5.generateNamed UUID5.namespaceURL (BS.unpack $ TE.encodeUtf8 "volca:authored")
 
-mintAuthored :: Text -> UUID
-mintAuthored = UUID5.generateNamed authoredNamespace . BS.unpack . TE.encodeUtf8
+{- | Fields are joined with NUL before hashing: an author may write any
+printable character in a name, so a printable separator would let two
+different descriptions mint one key ("wheat @farm" in "FR" versus "wheat"
+in "farm@FR").
+-}
+mintAuthored :: [Text] -> UUID
+mintAuthored = UUID5.generateNamed authoredNamespace . BS.unpack . TE.encodeUtf8 . T.intercalate "\0"
 
 -- | Activity half of the process key: what the activity does, and where.
 authoredActivityUUID :: Text -> Text -> UUID
-authoredActivityUUID name location = mintAuthored ("activity:" <> name <> "@" <> location)
+authoredActivityUUID name location = mintAuthored ["activity", name, location]
 
 {- | Product half of the process key. Keyed on unit as well as name — see the
 module header on why @milk@ in @kg@ and @milk@ in @l@ are two flows.
 -}
 authoredProductUUID :: Text -> Text -> UUID
-authoredProductUUID productName unit = mintAuthored ("product:" <> productName <> ":" <> unit)
+authoredProductUUID productName unit = mintAuthored ["product", productName, unit]
 
 {- | Identity of a biosphere flow an author introduces. Same three coordinates
 the SimaPro parser mints on (name, compartment, unit), so re-declaring the
@@ -113,10 +118,7 @@ same flow in a second activity reuses the first one instead of forking it.
 -}
 authoredBioFlowUUID :: Text -> Compartment -> Text -> UUID
 authoredBioFlowUUID name comp unit =
-    mintAuthored ("flow:" <> name <> ":" <> compartmentKey comp <> ":" <> unit)
-
-compartmentKey :: Compartment -> Text
-compartmentKey comp = compartmentName comp <> "/" <> fromMaybe "" (compartmentSub comp)
+    mintAuthored ["flow", name, compartmentName comp, fromMaybe "" (compartmentSub comp), unit]
 
 -- ---------------------------------------------------------------------------
 -- What an author writes

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -382,7 +382,7 @@ resolveLinked ctx provider amount mUnit build =
              in case lookupUnit ctx stated of
                     Nothing -> Left ["unknown unit \"" <> stated <> "\""]
                     Just (unitRef, unitLabel) ->
-                        case conversionError ctx unitLabel (supProducedUnit sup) of
+                        case unitError ctx sup unitLabel of
                             Just err -> Left [err]
                             Nothing -> Right (ResolvedExchange (build sup unitRef) Nothing [])
         (errs, Right _) -> Left errs
@@ -397,6 +397,28 @@ resolveLinked ctx provider amount mUnit build =
             ("", "") -> ""
             ("", other) -> other
             (produced, _) -> produced
+
+{- | Judge the unit an amount is stated in against what the matrix will do
+with it. A provider with a produced reference output gets the conversion
+check; a provider whose only reference is an input (a treatment process) gets
+an exact-match rule instead, because 'Database.MatrixBuild.techTriple' never
+converts into a reference input — a mismatched unit would land as a wrong raw
+number, not as a conversion.
+-}
+unitError :: AuthorContext -> Supplier -> Text -> Maybe Text
+unitError ctx sup stated
+    | T.null (supProducedUnit sup)
+    , not (T.null (supAnyRefUnit sup))
+    , normalizeUnit stated /= normalizeUnit (supAnyRefUnit sup) =
+        Just $
+            "the provider's reference is stated in \""
+                <> supAnyRefUnit sup
+                <> "\" but the exchange states \""
+                <> stated
+                <> "\"; amounts to a provider with no produced output are not converted, so restate it in \""
+                <> supAnyRefUnit sup
+                <> "\""
+    | otherwise = conversionError ctx stated (supProducedUnit sup)
 
 {- | The unit a value must be stated in before it can enter the technosphere
 matrix. Mirrors 'Database.MatrixBuild.techTriple' exactly — same emptiness

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -246,53 +246,54 @@ duplicateKeys keys = M.keys (M.filter (> (1 :: Int)) (M.fromListWith (+) [(k, 1)
 
 validateOne :: AuthorContext -> AuthoredActivity -> Either [Text] (ResolvedInsert, [Text])
 validateOne ctx a =
-    case (productChecks, partitionEithers (zipWith resolveExchange [1 :: Int ..] (aaExchanges a))) of
-        ([], ([], resolved)) ->
-            case lookupUnit ctx (aaProductUnit a) of
-                Nothing -> Left [here ("unknown unit \"" <> aaProductUnit a <> "\" for the product")]
-                Just (unitRef, unitLabel) ->
-                    let key = (authoredActivityUUID (aaName a) (aaLocation a), authoredProductUUID (aaProductName a) unitLabel)
-                        productExchange =
-                            TechnosphereExchange
-                                { techFlowId = snd key
-                                , techAmount = aaProductAmount a
-                                , techUnitId = unitRef
-                                , techRole = ReferenceProduct
-                                , techActivityLinkId = UUID.nil
-                                , techProcessLinkId = Nothing
-                                , techLocation = ""
-                                , techComment = Nothing
-                                , techPedigree = Nothing
-                                }
-                        productFlow =
-                            TechnosphereFlow
-                                { tfId = snd key
-                                , tfName = aaProductName a
-                                , tfUnitId = unitRef
-                                , tfSynonyms = M.empty
-                                , tfCAS = Nothing
-                                , tfSubstanceId = Nothing
-                                }
-                     in Right
-                            ( ResolvedInsert
-                                { riKey = key
-                                , riActivity = buildActivity a unitLabel (productExchange : map reExchange resolved)
-                                , riNewTechFlows = [productFlow | not (M.member (snd key) (dbTechFlows (acDb ctx)))]
-                                , riNewBioFlows = mapMaybe reNewBioFlow resolved
-                                }
-                            , map here (concatMap reWarnings resolved)
-                            )
-        (perActivityErrs, (exchangeErrs, _)) -> Left (map here (perActivityErrs <> concat exchangeErrs))
+    case (productChecks, partitionEithers (zipWith resolveExchange [1 :: Int ..] (aaExchanges a)), mProductUnit) of
+        ([], ([], resolved), Just (unitRef, unitLabel)) ->
+            let key = (authoredActivityUUID (aaName a) (aaLocation a), authoredProductUUID (aaProductName a) unitLabel)
+                productExchange =
+                    TechnosphereExchange
+                        { techFlowId = snd key
+                        , techAmount = aaProductAmount a
+                        , techUnitId = unitRef
+                        , techRole = ReferenceProduct
+                        , techActivityLinkId = UUID.nil
+                        , techProcessLinkId = Nothing
+                        , techLocation = ""
+                        , techComment = Nothing
+                        , techPedigree = Nothing
+                        }
+                productFlow =
+                    TechnosphereFlow
+                        { tfId = snd key
+                        , tfName = aaProductName a
+                        , tfUnitId = unitRef
+                        , tfSynonyms = M.empty
+                        , tfCAS = Nothing
+                        , tfSubstanceId = Nothing
+                        }
+             in Right
+                    ( ResolvedInsert
+                        { riKey = key
+                        , riActivity = buildActivity a unitLabel (productExchange : map reExchange resolved)
+                        , riNewTechFlows = [productFlow | not (M.member (snd key) (dbTechFlows (acDb ctx)))]
+                        , riNewBioFlows = mapMaybe reNewBioFlow resolved
+                        }
+                    , map here (concatMap reWarnings resolved)
+                    )
+        (perActivityErrs, (exchangeErrs, _), _) -> Left (map here (perActivityErrs <> concat exchangeErrs))
   where
     here msg = aaName a <> " {" <> aaLocation a <> "}: " <> msg
     resolveExchange i ex = mapLeft (map (numbered i)) (resolveOne ctx ex)
     numbered i msg = "exchange " <> T.pack (show i) <> ": " <> msg
+    mProductUnit = lookupUnit ctx (aaProductUnit a)
     productChecks =
         concat
             [ ["the activity name is empty" | T.null (T.strip (aaName a))]
             , ["the product name is empty" | T.null (T.strip (aaProductName a))]
             , [ "the product amount is " <> T.pack (show (aaProductAmount a)) <> "; it must be a finite non-zero number"
               | not (isUsableAmount (aaProductAmount a))
+              ]
+            , [ "unknown unit \"" <> aaProductUnit a <> "\" for the product"
+              | Nothing <- [mProductUnit]
               ]
             ]
 

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -255,7 +255,9 @@ validateOne ctx a =
                         , techAmount = aaProductAmount a
                         , techUnitId = unitRef
                         , techRole = ReferenceProduct
-                        , techActivityLinkId = UUID.nil
+                        , -- Self-link, as every loaded database records its
+                          -- reference products.
+                          techActivityLinkId = fst key
                         , techProcessLinkId = Nothing
                         , techLocation = ""
                         , techComment = Nothing

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
 
 {- |
 Module      : Database.Author
@@ -608,7 +609,7 @@ findBioFlow ctx flowId =
         [] -> Nothing
         (found : _) -> Just found
   where
-    look (local, db) = (\flow -> (flow, dbUnits db, local)) <$> M.lookup flowId (dbBioFlows db)
+    look (local, db) = (,dbUnits db,local) <$> M.lookup flowId (dbBioFlows db)
 
 {- | Resolve a unit the author names to the identifier an exchange carries,
 plus the canonical name of that unit. Names and symbols both resolve, so

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TupleSections #-}
 
 {- |
 Module      : Database.Author
@@ -462,17 +461,17 @@ resolveBio ctx flowRef direction amount mUnit comment
                         <> UUID.toText flowId
                         <> " in this database or its dependencies"
                     ]
-            Just (flow, ownerUnits) ->
+            Just (flow, ownerUnits, local) ->
                 let flowUnit = unitNameOf ownerUnits (bfUnitId flow)
                  in case mUnit of
                         Just stated | normalizeUnit stated /= normalizeUnit flowUnit -> Left [mismatch flow stated flowUnit]
-                        _ -> emit flowId (bfUnitId flow) Nothing []
+                        _ -> emitKnown flowId flow flowUnit local
         NewBioFlow name comp unit -> case lookupUnit ctx unit of
             Nothing -> Left ["unknown unit \"" <> unit <> "\" for flow \"" <> name <> "\""]
             Just (unitRef, unitLabel) ->
                 let flowId = authoredBioFlowUUID name comp unitLabel
                  in case findBioFlow ctx flowId of
-                        Just (flow, _) -> emit flowId (bfUnitId flow) Nothing []
+                        Just (flow, ownerUnits, local) -> emitKnown flowId flow (unitNameOf ownerUnits (bfUnitId flow)) local
                         Nothing ->
                             emit
                                 flowId
@@ -483,6 +482,22 @@ resolveBio ctx flowRef direction amount mUnit comment
                                     <> "\" is new to this database; no characterization factor matches it by identity yet"
                                 ]
   where
+    -- A flow found in a dependency is copied into the edited database with
+    -- its unit remapped: characterization resolves flows through the edited
+    -- database's own vocabulary ('dbBioFlows'), so an exchange must never
+    -- reference a flow only a dependency declares.
+    emitKnown flowId flow flowUnit local
+        | local = emit flowId (bfUnitId flow) Nothing []
+        | otherwise = case lookupUnit ctx flowUnit of
+            Nothing ->
+                Left
+                    [ "biosphere flow \""
+                        <> bfName flow
+                        <> "\" from a dependency is stated in \""
+                        <> flowUnit
+                        <> "\", a unit this database does not have"
+                    ]
+            Just (unitRef, _) -> emit flowId unitRef (Just flow{bfUnitId = unitRef}) []
     emit flowId unitRef mNew warnings =
         Right
             ( ResolvedExchange
@@ -579,13 +594,16 @@ refUnitOf db act keep = case filter keep (exchanges act) of
     (ex : _) -> getUnitNameForExchange (dbUnits db) ex
     [] -> ""
 
-findBioFlow :: AuthorContext -> UUID -> Maybe (BiosphereFlow, UnitDB)
+{- | Find a biosphere flow, with the unit table that can name its unit and
+whether it lives in the edited database itself.
+-}
+findBioFlow :: AuthorContext -> UUID -> Maybe (BiosphereFlow, UnitDB, Bool)
 findBioFlow ctx flowId =
-    case mapMaybe look (acDb ctx : acDeps ctx) of
+    case mapMaybe look (zip (True : repeat False) (acDb ctx : acDeps ctx)) of
         [] -> Nothing
         (found : _) -> Just found
   where
-    look db = (,dbUnits db) <$> M.lookup flowId (dbBioFlows db)
+    look (local, db) = (\flow -> (flow, dbUnits db, local)) <$> M.lookup flowId (dbBioFlows db)
 
 {- | Resolve a unit the author names to the identifier an exchange carries,
 plus the canonical name of that unit. Names and symbols both resolve, so

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -186,7 +186,7 @@ judged against.
 -}
 data AuthorContext = AuthorContext
     { acDb :: Database
-    , acDeps :: [(Text, Database)]
+    , acDeps :: [Database]
     , acUnitConfig :: UnitConfig
     }
 
@@ -343,7 +343,7 @@ resolveOne ctx ex = case ex of
                 , techUnitId = unitRef
                 , techRole = Input
                 , techActivityLinkId = fst (supKey sup)
-                , techProcessLinkId = supLocalPid sup
+                , techProcessLinkId = Nothing
                 , techLocation = ""
                 , techComment = comment
                 , techPedigree = Nothing
@@ -356,7 +356,7 @@ resolveOne ctx ex = case ex of
                 , waUnitId = unitRef
                 , waIsInput = False
                 , waActivityLinkId = fst (supKey sup)
-                , waProcessLinkId = supLocalPid sup
+                , waProcessLinkId = Nothing
                 , waLocation = ""
                 , waComment = comment
                 , waPedigree = Nothing
@@ -506,13 +506,14 @@ newBioFlow flowId name comp unitRef =
 -- Lookups across the edited database and its dependencies
 -- ---------------------------------------------------------------------------
 
-{- | A resolved provider. 'supLocalPid' is 'Just' only when the provider lives
-in the database being edited: a provider in a dependency has no process id
-here, and its link is left for cross-database relinking to resolve.
+{- | A resolved provider. Only its @(activityUUID, productUUID)@ key goes into
+the exchange, never a 'ProcessId': process ids renumber on every rebuild, so
+an embedded one would silently point at whichever row inherits the number.
+'Database.MatrixBuild.findProducer' resolves the pair, and a provider living
+in a dependency resolves the same way through cross-database relinking.
 -}
 data Supplier = Supplier
     { supKey :: (UUID, UUID)
-    , supLocalPid :: Maybe ProcessId
     , supProducedUnit :: Text
     {- ^ unit of the produced reference output, @""@ for a treatment process
     that has only a reference input. Mirrors
@@ -527,19 +528,17 @@ data Supplier = Supplier
 
 resolveSupplier :: AuthorContext -> Text -> Either Text Supplier
 resolveSupplier ctx provider =
-    case mapMaybe inDatabase ((thisDb, acDb ctx) : acDeps ctx) of
+    case mapMaybe inDatabase (acDb ctx : acDeps ctx) of
         [] -> Left ("unknown provider \"" <> provider <> "\"")
         (sup : _) -> Right sup
   where
-    thisDb = ""
-    inDatabase (name, db) = do
+    inDatabase db = do
         pid <- resolveProcess db provider
         key <- dbProcessIdTable db V.!? fromIntegral pid
         act <- dbActivities db V.!? fromIntegral pid
         pure
             Supplier
                 { supKey = key
-                , supLocalPid = if name == thisDb then Just pid else Nothing
                 , supProducedUnit = refUnitOf db act (\e -> exchangeIsReference e && not (exchangeIsInput e))
                 , supAnyRefUnit = refUnitOf db act exchangeIsReference
                 }
@@ -560,7 +559,7 @@ refUnitOf db act keep = case filter keep (exchanges act) of
 
 findBioFlow :: AuthorContext -> UUID -> Maybe (BiosphereFlow, UnitDB)
 findBioFlow ctx flowId =
-    case mapMaybe look (acDb ctx : map snd (acDeps ctx)) of
+    case mapMaybe look (acDb ctx : acDeps ctx) of
         [] -> Nothing
         (found : _) -> Just found
   where

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -41,6 +41,8 @@ module Database.Edit (
     DeleteSelection (..),
     DeleteRequest (..),
     deleteActivitiesInDB,
+    insertActivities,
+    replaceActivities,
 ) where
 
 import Control.Concurrent.STM (atomically, modifyTVar', readTVar, readTVarIO)
@@ -62,6 +64,7 @@ import Database (
     buildProductIndex,
     findActivitiesByFields,
  )
+import Database.Author (ResolvedInsert (..))
 import Database.CrossLinking (buildIndexedDatabaseFromDB)
 import Database.Manager (
     DatabaseManager (..),
@@ -86,10 +89,12 @@ import Service (bm25Retrieve)
 import SharedSolver (createSharedSolver)
 import Types (
     Activity (..),
+    BiosphereFlow (..),
     Database (..),
     Exchange (..),
     ProcessId,
     SparseTriple (..),
+    TechnosphereFlow (..),
     UUID,
     findProcessId,
     findProcessIdByActivityUUID,
@@ -325,6 +330,81 @@ rebuildFromActivities unitConfig db activityMap =
                         , dbProductSearchIndex = M.empty
                         , dbBM25Index = Nothing
                         }
+
+-- ---------------------------------------------------------------------------
+-- Insert / replace
+-- ---------------------------------------------------------------------------
+
+{- | Whether a batch means to add rows the database does not have, or to
+rewrite rows it does. There is deliberately no upsert: a mistyped identity
+must fail, not quietly become a second copy of an activity the author thought
+they were correcting.
+-}
+data WriteIntent = Insert | Replace
+
+{- | Add authored activities to a database and rebuild everything that depends
+on them.
+
+Every key must be absent — 'Database.Author' mints identity from the activity's
+own name, location, product and unit, so a key that already exists means the
+author is re-describing something the database already holds and wants
+'replaceActivities' instead.
+-}
+insertActivities :: UnitConfig -> [ResolvedInsert] -> Database -> Either Text Database
+insertActivities = writeActivities Insert
+
+{- | Rewrite activities the database already holds, keeping their identity.
+
+Every key must be present. Replacing keeps the old version's flows in the
+vocabulary, exactly as deletion does: a flow no activity uses any more is
+inert, and dropping it would break a relink that still resolves through it.
+-}
+replaceActivities :: UnitConfig -> [ResolvedInsert] -> Database -> Either Text Database
+replaceActivities = writeActivities Replace
+
+{- | Shared write path. The vocabulary the batch brings (its product flows and
+any new biosphere flows) lands in the same step as the activities that
+reference it, so no intermediate value exists in which an exchange points at a
+flow the database cannot name.
+
+An empty batch returns the database untouched rather than rebuilding: a
+rebuild resets cross-database links ('rebuildFromActivities'), so treating "no
+activities to write" as a no-op is what keeps a caller's empty request from
+silently unlinking the database.
+-}
+writeActivities :: WriteIntent -> UnitConfig -> [ResolvedInsert] -> Database -> Either Text Database
+writeActivities intent unitConfig inserts db
+    | null inserts = Right db
+    | otherwise = do
+        let existing = surviving db S.empty
+        checkKeys intent existing (map riKey inserts)
+        rebuildFromActivities
+            unitConfig
+            db
+                { dbTechFlows = M.union (indexBy tfId (concatMap riNewTechFlows inserts)) (dbTechFlows db)
+                , dbBioFlows = M.union (indexBy bfId (concatMap riNewBioFlows inserts)) (dbBioFlows db)
+                }
+            (M.union (M.fromList [(riKey i, riActivity i) | i <- inserts]) existing)
+  where
+    indexBy key xs = M.fromList [(key x, x) | x <- xs]
+
+{- | Refuse a batch whose keys contradict the intent, naming every offending
+identity at once so a long batch is not fixed one round-trip at a time.
+-}
+checkKeys :: WriteIntent -> M.Map (UUID, UUID) Activity -> [(UUID, UUID)] -> Either Text ()
+checkKeys intent existing keys = case intent of
+    Insert -> refuse "already exists" (filter (`M.member` existing) keys)
+    Replace -> refuse "does not exist" (filter (not . (`M.member` existing)) keys)
+  where
+    refuse _ [] = Right ()
+    refuse what offenders =
+        Left $
+            "Refusing to write: "
+                <> T.intercalate ", " (map renderKey offenders)
+                <> " "
+                <> what
+                <> " in this database"
+    renderKey (a, p) = UUID.toText a <> "_" <> UUID.toText p
 
 -- ---------------------------------------------------------------------------
 -- Selection resolver

--- a/test/AuthorSpec.hs
+++ b/test/AuthorSpec.hs
@@ -110,6 +110,14 @@ spec = do
                     "biosphere amounts are not converted"
                     (baseActivity{aaExchanges = [bioOf (ExistingFlow co2Id) 1 (Just "m")]})
 
+            it "reports a bad product unit and a bad exchange together" $
+                case validateAuthored (contextOf fixtureDb) [baseActivity{aaProductUnit = "furlong", aaExchanges = [techInput "nope" 1 Nothing]}] of
+                    Right _ -> expectationFailure "expected both defects to be refused"
+                    Left errs -> do
+                        length errs `shouldBe` 2
+                        errs `shouldSatisfy` any (isInfixOf "unknown unit \"furlong\"")
+                        errs `shouldSatisfy` any (isInfixOf "unknown provider")
+
             it "reports every defect of a batch at once, each naming its activity" $ do
                 let bad =
                         baseActivity

--- a/test/AuthorSpec.hs
+++ b/test/AuthorSpec.hs
@@ -1,0 +1,405 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Tests for authoring activities into an editable database
+('Database.Author.validateAuthored', 'Database.Edit.insertActivities' and
+'Database.Edit.replaceActivities').
+
+Authoring is the strict counterpart of importing. Where the loader warns and
+drops a row it cannot resolve, authoring refuses — so most of what follows is
+one red case per refusal, plus the two properties that make repeated authoring
+safe: identity is a function of what was written (author twice, get the same
+key), and writing then deleting leaves the activity set it started from.
+-}
+module AuthorSpec (spec) where
+
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import Data.Text (Text, isInfixOf)
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import Test.Hspec
+
+import Database (buildDatabaseWithMatrices)
+import Database.Author (
+    AuthorContext (..),
+    AuthoredActivity (..),
+    AuthoredExchange (..),
+    FlowRef (..),
+    ResolvedInsert (..),
+    authoredActivityUUID,
+    authoredProductUUID,
+    validateAuthored,
+ )
+import Database.Edit (deleteActivities, insertActivities, replaceActivities)
+import Types (
+    Activity (..),
+    BioDirection (..),
+    BiosphereFlow (..),
+    Compartment (..),
+    Database (..),
+    Exchange (..),
+    LocationSource (..),
+    TechRole (..),
+    TechnosphereFlow (..),
+    UUID,
+    Unit (..),
+    exchangeAmount,
+    findProcessId,
+    isTechnosphereExchange,
+ )
+import UnitConversion (defaultUnitConfig)
+
+spec :: Spec
+spec = do
+    fixtureDb <- runIO buildFixture
+    let failsWith = refusalOf fixtureDb
+    describe "Database.Author" $ do
+        describe "validateAuthored (refusals)" $ do
+            it "refuses an empty activity name" $
+                failsWith "the activity name is empty" (baseActivity{aaName = "  "})
+
+            it "refuses an empty product name" $
+                failsWith "the product name is empty" (baseActivity{aaProductName = ""})
+
+            it "refuses a zero product amount" $
+                -- Zero output would divide the whole column by a zero normalization
+                -- factor; it is a line that should not have been written.
+                failsWith "finite non-zero" (baseActivity{aaProductAmount = 0})
+
+            it "refuses a non-finite product amount" $
+                failsWith "finite non-zero" (baseActivity{aaProductAmount = 0 / 0})
+
+            it "refuses a product unit the database does not know" $
+                failsWith "unknown unit \"furlong\"" (baseActivity{aaProductUnit = "furlong"})
+
+            it "refuses a supplier that resolves to nothing" $
+                -- The loader warns and drops this case; authoring will not, because
+                -- a dropped input silently undercounts the activity's inventory.
+                failsWith
+                    "unknown provider"
+                    (baseActivity{aaExchanges = [techInput "no-such-process" 1 Nothing]})
+
+            it "refuses an input whose unit cannot reach the supplier's" $
+                failsWith
+                    "cannot convert \"m\" into the supplier's \"kg\""
+                    (baseActivity{aaExchanges = [techInput supplierPid 1 (Just "m")]})
+
+            it "refuses a non-finite exchange amount" $
+                failsWith
+                    "finite non-zero"
+                    (baseActivity{aaExchanges = [techInput supplierPid (1 / 0) Nothing]})
+
+            it "refuses a biosphere flow identifier nothing declares" $
+                failsWith
+                    "no biosphere flow"
+                    (baseActivity{aaExchanges = [bioOf (ExistingFlow (mkUUID 999)) 1 Nothing]})
+
+            it "refuses a biosphere amount restated in another unit" $
+                -- The biosphere matrix carries amounts through unconverted, so a
+                -- unit the flow does not use would land as a wrong number.
+                failsWith
+                    "biosphere amounts are not converted"
+                    (baseActivity{aaExchanges = [bioOf (ExistingFlow co2Id) 1 (Just "m")]})
+
+            it "reports every defect of a batch at once, each naming its activity" $ do
+                let bad =
+                        baseActivity
+                            { aaName = "two-problems"
+                            , aaExchanges = [techInput "nope" 1 Nothing, bioOf (ExistingFlow (mkUUID 998)) 1 Nothing]
+                            }
+                case validateAuthored (contextOf fixtureDb) [bad, baseActivity{aaProductUnit = "furlong"}] of
+                    Right _ -> expectationFailure "expected the batch to be refused"
+                    Left errs -> do
+                        length errs `shouldBe` 3
+                        errs `shouldSatisfy` any (isInfixOf "two-problems {FR}: exchange 1: unknown provider")
+                        errs `shouldSatisfy` any (isInfixOf "exchange 2: no biosphere flow")
+                        errs `shouldSatisfy` any (isInfixOf "unknown unit \"furlong\"")
+
+            it "refuses a batch that mints one identity twice" $
+                case validateAuthored (contextOf fixtureDb) [baseActivity, baseActivity] of
+                    Right _ -> expectationFailure "expected the duplicate identity to be refused"
+                    Left errs -> errs `shouldSatisfy` any (isInfixOf "mint the same identity")
+
+        describe "validateAuthored (resolution)" $ do
+            it "mints the same identity for the same description, twice" $ do
+                a <- resolveOrFail fixtureDb baseActivity
+                b <- resolveOrFail fixtureDb baseActivity
+                riKey a `shouldBe` riKey b
+                riKey a
+                    `shouldBe` ( authoredActivityUUID "cheese, at dairy" "FR"
+                               , authoredProductUUID "cheese" "kg"
+                               )
+
+            it "gives the same product two units two identities" $ do
+                a <- resolveOrFail fixtureDb baseActivity
+                b <- resolveOrFail fixtureDb baseActivity{aaProductUnit = "item"}
+                snd (riKey a) `shouldNotBe` snd (riKey b)
+
+            it "resolves a local supplier to a process link" $ do
+                r <- resolveOrFail fixtureDb baseActivity{aaExchanges = [techInput supplierPid 2 Nothing]}
+                case [ex | ex <- exchanges (riActivity r), isTechnosphereExchange ex, exchangeAmount ex == 2] of
+                    [TechnosphereExchange{techActivityLinkId = link, techProcessLinkId = pid}] -> do
+                        link `shouldBe` supplierActId
+                        pid `shouldBe` findProcessId fixtureDb supplierActId supplierProdId
+                    other -> expectationFailure ("expected one resolved input, got " <> show (length other))
+
+            it "leaves a dependency's supplier for cross-database relinking" $ do
+                -- A supplier in another database has no process id here; the link
+                -- carries the activity UUID and waits for the relink.
+                depDb <- buildFixture
+                let ctx = (contextOf fixtureDb){acDeps = [("other", depDb)]}
+                    authored = baseActivity{aaName = "from-dep", aaExchanges = [techInput supplierPid 3 Nothing]}
+                case validateAuthored ctx{acDb = emptyOf fixtureDb} [authored] of
+                    Left errs -> expectationFailure ("expected resolution, got " <> show errs)
+                    Right ([r], _) ->
+                        case [ex | ex <- exchanges (riActivity r), exchangeAmount ex == 3] of
+                            [TechnosphereExchange{techActivityLinkId = link, techProcessLinkId = pid}] -> do
+                                link `shouldBe` supplierActId
+                                pid `shouldBe` Nothing
+                            other -> expectationFailure ("expected one dependency input, got " <> show (length other))
+                    Right (rs, _) -> expectationFailure ("expected one insert, got " <> show (length rs))
+
+            it "warns about a biosphere flow new to the database without refusing it" $ do
+                let authored = baseActivity{aaExchanges = [bioOf (NewBioFlow "Nitrous oxide" air "kg") 0.5 Nothing]}
+                case validateAuthored (contextOf fixtureDb) [authored] of
+                    Left errs -> expectationFailure ("expected acceptance, got " <> show errs)
+                    Right ([r], warnings) -> do
+                        map bfName (riNewBioFlows r) `shouldBe` ["Nitrous oxide"]
+                        warnings `shouldSatisfy` any (isInfixOf "no characterization factor matches it")
+                    Right (rs, _) -> expectationFailure ("expected one insert, got " <> show (length rs))
+
+            it "reuses a biosphere flow the database already declares" $ do
+                -- Same three coordinates the flow was minted on: re-declaring it is
+                -- not a second flow.
+                r <- resolveOrFail fixtureDb baseActivity{aaExchanges = [bioOf (ExistingFlow co2Id) 1 Nothing]}
+                map bfName (riNewBioFlows r) `shouldBe` []
+
+        describe "insertActivities" $ do
+            it "adds the activity, its product flow and its new biosphere flow together" $ do
+                let authored =
+                        baseActivity
+                            { aaExchanges =
+                                [ techInput supplierPid 2 Nothing
+                                , bioOf (NewBioFlow "Nitrous oxide" air "kg") 0.5 Nothing
+                                ]
+                            }
+                r <- resolveOrFail fixtureDb authored
+                case insertActivities defaultUnitConfig [r] fixtureDb of
+                    Left err -> expectationFailure ("insertActivities: " <> show err)
+                    Right db' -> do
+                        dbActivityCount db' `shouldBe` dbActivityCount fixtureDb + 1
+                        M.member (snd (riKey r)) (dbTechFlows db') `shouldBe` True
+                        map bfName (M.elems (dbBioFlows db')) `shouldSatisfy` elem "Nitrous oxide"
+                        uncurry (findProcessId db') (riKey r) `shouldSatisfy` (/= Nothing)
+
+            it "refuses a key the database already holds" $ do
+                r <- resolveOrFail fixtureDb baseActivity
+                case insertActivities defaultUnitConfig [r] fixtureDb >>= insertActivities defaultUnitConfig [r] of
+                    Left err -> err `shouldSatisfy` isInfixOf "already exists"
+                    Right _ -> expectationFailure "expected the second insert to be refused"
+
+            it "leaves the database untouched on an empty batch" $
+                -- A rebuild would clear cross-database links; "nothing to write"
+                -- must not silently unlink the database.
+                case insertActivities defaultUnitConfig [] fixtureDb{dbDependsOn = ["other"]} of
+                    Left err -> expectationFailure ("expected a no-op, got " <> show err)
+                    Right db' -> dbDependsOn db' `shouldBe` ["other"]
+
+            it "restores the original activity set when the insert is deleted again" $ do
+                r <- resolveOrFail fixtureDb baseActivity
+                case insertActivities defaultUnitConfig [r] fixtureDb of
+                    Left err -> expectationFailure ("insertActivities: " <> show err)
+                    Right db' -> case uncurry (findProcessId db') (riKey r) of
+                        Nothing -> expectationFailure "the inserted activity has no process id"
+                        Just pid -> case deleteActivities [pid] db' of
+                            Left err -> expectationFailure ("deleteActivities: " <> show err)
+                            Right db'' -> do
+                                processKeys db'' `shouldBe` processKeys fixtureDb
+                                dbActivityCount db'' `shouldBe` dbActivityCount fixtureDb
+
+        describe "replaceActivities" $ do
+            it "refuses a key the database does not hold" $ do
+                r <- resolveOrFail fixtureDb baseActivity
+                case replaceActivities defaultUnitConfig [r] fixtureDb of
+                    Left err -> err `shouldSatisfy` isInfixOf "does not exist"
+                    Right _ -> expectationFailure "expected the replace to be refused"
+
+            it "rewrites the activity in place, keeping its identity" $ do
+                first <- resolveOrFail fixtureDb baseActivity{aaExchanges = [techInput supplierPid 2 Nothing]}
+                case insertActivities defaultUnitConfig [first] fixtureDb of
+                    Left err -> expectationFailure ("insertActivities: " <> show err)
+                    Right db' -> do
+                        second <- resolveOrFail db' baseActivity{aaExchanges = [techInput supplierPid 7 Nothing]}
+                        riKey second `shouldBe` riKey first
+                        case replaceActivities defaultUnitConfig [second] db' of
+                            Left err -> expectationFailure ("replaceActivities: " <> show err)
+                            Right db'' -> do
+                                dbActivityCount db'' `shouldBe` dbActivityCount db'
+                                inputAmounts db'' (fst (riKey second)) `shouldBe` [7]
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+
+-- | "Authoring this against that database is refused, and says why."
+refusalOf :: Database -> Text -> AuthoredActivity -> Expectation
+refusalOf db needle authored =
+    case validateAuthored (contextOf db) [authored] of
+        Right _ -> expectationFailure ("expected a refusal mentioning " <> show needle)
+        Left errs -> errs `shouldSatisfy` any (isInfixOf needle)
+
+resolveOrFail :: Database -> AuthoredActivity -> IO ResolvedInsert
+resolveOrFail db authored = case validateAuthored (contextOf db) [authored] of
+    Left errs -> fail ("validateAuthored: " <> show errs)
+    Right ([r], _) -> pure r
+    Right (rs, _) -> fail ("expected one insert, got " <> show (length rs))
+
+contextOf :: Database -> AuthorContext
+contextOf db = AuthorContext{acDb = db, acDeps = [], acUnitConfig = defaultUnitConfig}
+
+-- | The same database with no activities — used to prove a dependency link resolves.
+emptyOf :: Database -> Database
+emptyOf db = db{dbActivities = V.empty, dbProcessIdTable = V.empty, dbProcessIdLookup = M.empty}
+
+processKeys :: Database -> S.Set (UUID, UUID)
+processKeys = S.fromList . V.toList . dbProcessIdTable
+
+-- | Amounts of the non-reference technosphere inputs of one activity.
+inputAmounts :: Database -> UUID -> [Double]
+inputAmounts db actUUID =
+    [ exchangeAmount ex
+    | (key, act) <- zip (V.toList (dbProcessIdTable db)) (V.toList (dbActivities db))
+    , fst key == actUUID
+    , ex@TechnosphereExchange{techRole = Input} <- exchanges act
+    ]
+
+baseActivity :: AuthoredActivity
+baseActivity =
+    AuthoredActivity
+        { aaName = "cheese, at dairy"
+        , aaLocation = "FR"
+        , aaDescription = ["An authored activity."]
+        , aaProductName = "cheese"
+        , aaProductAmount = 1.0
+        , aaProductUnit = "kg"
+        , aaExchanges = []
+        }
+
+techInput :: Text -> Double -> Maybe Text -> AuthoredExchange
+techInput provider amount unit =
+    AuthoredTechInput{atiProvider = provider, atiAmount = amount, atiUnit = unit, atiComment = Nothing}
+
+bioOf :: FlowRef -> Double -> Maybe Text -> AuthoredExchange
+bioOf flow amount unit =
+    AuthoredBio
+        { abFlow = flow
+        , abDirection = Emission
+        , abAmount = amount
+        , abUnit = unit
+        , abComment = Nothing
+        }
+
+air :: Compartment
+air = Compartment{compartmentName = "air", compartmentSub = Nothing}
+
+-- ---------------------------------------------------------------------------
+-- Fixture: one supplier producing "milk" in kg, emitting CO2
+-- ---------------------------------------------------------------------------
+
+buildFixture :: IO Database
+buildFixture = do
+    r <-
+        buildDatabaseWithMatrices
+            defaultUnitConfig
+            (M.singleton (supplierActId, supplierProdId) supplierActivity)
+            (M.singleton supplierProdId milkFlow)
+            (M.singleton co2Id co2Flow)
+            M.empty
+            unitTable
+    either (fail . show) pure r
+
+mkUUID :: Int -> UUID
+mkUUID n = UUID.fromWords64 (fromIntegral n) 0
+
+supplierActId, supplierProdId, co2Id, kgUnitId, itemUnitId, metreUnitId :: UUID
+supplierActId = mkUUID 1
+supplierProdId = mkUUID 2
+co2Id = mkUUID 3
+kgUnitId = mkUUID 10
+itemUnitId = mkUUID 11
+metreUnitId = mkUUID 12
+
+supplierPid :: Text
+supplierPid = UUID.toText supplierActId <> "_" <> UUID.toText supplierProdId
+
+unitTable :: M.Map UUID Unit
+unitTable =
+    M.fromList
+        [ (kgUnitId, Unit{unitId = kgUnitId, unitName = "kg", unitSymbol = "kg", unitComment = ""})
+        , (itemUnitId, Unit{unitId = itemUnitId, unitName = "item", unitSymbol = "item", unitComment = ""})
+        , (metreUnitId, Unit{unitId = metreUnitId, unitName = "m", unitSymbol = "m", unitComment = ""})
+        ]
+
+milkFlow :: TechnosphereFlow
+milkFlow =
+    TechnosphereFlow
+        { tfId = supplierProdId
+        , tfName = "milk"
+        , tfUnitId = kgUnitId
+        , tfSynonyms = M.empty
+        , tfCAS = Nothing
+        , tfSubstanceId = Nothing
+        }
+
+co2Flow :: BiosphereFlow
+co2Flow =
+    BiosphereFlow
+        { bfId = co2Id
+        , bfName = "Carbon dioxide"
+        , bfUnitId = kgUnitId
+        , bfSynonyms = M.empty
+        , bfCAS = Just "124-38-9"
+        , bfSubstanceId = Nothing
+        , bfCompartment = Just air
+        }
+
+supplierActivity :: Activity
+supplierActivity =
+    Activity
+        { activityName = "milk production"
+        , activityDescription = []
+        , activitySynonyms = M.empty
+        , activityClassification = M.empty
+        , activityLocation = "FR"
+        , activityLocationSource = LocationDeclared
+        , activityUnit = "kg"
+        , exchanges =
+            [ TechnosphereExchange
+                { techFlowId = supplierProdId
+                , techAmount = 1.0
+                , techUnitId = kgUnitId
+                , techRole = ReferenceProduct
+                , techActivityLinkId = supplierActId
+                , techProcessLinkId = Nothing
+                , techLocation = ""
+                , techComment = Nothing
+                , techPedigree = Nothing
+                }
+            , BiosphereExchange
+                { bioFlowId = co2Id
+                , bioAmount = 1.2
+                , bioUnitId = kgUnitId
+                , bioDirection = Emission
+                , bioLocation = ""
+                , bioComment = Nothing
+                , bioPedigree = Nothing
+                }
+            ]
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
+        , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
+        }

--- a/test/AuthorSpec.hs
+++ b/test/AuthorSpec.hs
@@ -86,6 +86,13 @@ spec = do
                     "cannot convert \"m\" into the supplier's \"kg\""
                     (baseActivity{aaExchanges = [techInput supplierPid 1 (Just "m")]})
 
+            it "refuses a waste output restated in a unit its treatment does not use" $
+                -- The matrix never converts into a reference input, so a
+                -- mismatched unit would land as a wrong raw number.
+                failsWith
+                    "amounts to a provider with no produced output are not converted"
+                    (baseActivity{aaExchanges = [wasteOut treatPid 1 (Just "m")]})
+
             it "refuses a non-finite exchange amount" $
                 failsWith
                     "finite non-zero"
@@ -146,6 +153,16 @@ spec = do
                         link `shouldBe` supplierActId
                         pid `shouldBe` Nothing
                     other -> expectationFailure ("expected one resolved input, got " <> show (length other))
+
+            it "defaults a waste output to the treatment's reference unit" $ do
+                -- A treatment has no produced unit to borrow; the omitted unit
+                -- falls back to its reference input's.
+                r <- resolveOrFail fixtureDb baseActivity{aaExchanges = [wasteOut treatPid 1 Nothing]}
+                case [ex | ex@WasteExchange{} <- exchanges (riActivity r)] of
+                    [WasteExchange{waActivityLinkId = link, waUnitId = unit}] -> do
+                        link `shouldBe` treatActId
+                        unit `shouldBe` kgUnitId
+                    other -> expectationFailure ("expected one waste output, got " <> show (length other))
 
             it "leaves a dependency's supplier for cross-database relinking" $ do
                 -- A supplier in another database has no process id here; the link
@@ -314,6 +331,13 @@ techInput :: Text -> Double -> Maybe Text -> AuthoredExchange
 techInput provider amount unit =
     AuthoredTechInput{atiProvider = provider, atiAmount = amount, atiUnit = unit, atiComment = Nothing}
 
+wasteOut :: Text -> Double -> Maybe Text -> AuthoredExchange
+wasteOut provider amount unit =
+    AuthoredWasteOutput{awProvider = provider, awAmount = amount, awUnit = unit, awComment = Nothing}
+
+treatPid :: Text
+treatPid = UUID.toText treatActId <> "_" <> UUID.toText usedOilId
+
 bioOf :: FlowRef -> Double -> Maybe Text -> AuthoredExchange
 bioOf flow amount unit =
     AuthoredBio
@@ -342,8 +366,16 @@ buildFixtureAt actId prodId = do
     r <-
         buildDatabaseWithMatrices
             defaultUnitConfig
-            (M.singleton (actId, prodId) (supplierActivityAt actId prodId))
-            (M.singleton prodId (milkFlowAt prodId))
+            ( M.fromList
+                [ ((actId, prodId), supplierActivityAt actId prodId)
+                , ((treatActId, usedOilId), treatmentActivity)
+                ]
+            )
+            ( M.fromList
+                [ (prodId, milkFlowAt prodId)
+                , (usedOilId, usedOilFlow)
+                ]
+            )
             (M.singleton co2Id co2Flow)
             M.empty
             unitTable
@@ -352,10 +384,12 @@ buildFixtureAt actId prodId = do
 mkUUID :: Int -> UUID
 mkUUID n = UUID.fromWords64 (fromIntegral n) 0
 
-supplierActId, supplierProdId, co2Id, highActId, highProdId, kgUnitId, itemUnitId, metreUnitId :: UUID
+supplierActId, supplierProdId, co2Id, treatActId, usedOilId, highActId, highProdId, kgUnitId, itemUnitId, metreUnitId :: UUID
 supplierActId = mkUUID 1
 supplierProdId = mkUUID 2
 co2Id = mkUUID 3
+treatActId = mkUUID 4
+usedOilId = mkUUID 5
 highActId = UUID.fromWords64 maxBound 1
 highProdId = UUID.fromWords64 maxBound 2
 kgUnitId = mkUUID 10
@@ -394,6 +428,52 @@ co2Flow =
         , bfCAS = Just "124-38-9"
         , bfSubstanceId = Nothing
         , bfCompartment = Just air
+        }
+
+usedOilFlow :: TechnosphereFlow
+usedOilFlow =
+    TechnosphereFlow
+        { tfId = usedOilId
+        , tfName = "used oil"
+        , tfUnitId = kgUnitId
+        , tfSynonyms = M.empty
+        , tfCAS = Nothing
+        , tfSubstanceId = Nothing
+        }
+
+{- | A treatment process: its only reference is an input, so it has no
+produced unit for the matrix to convert into.
+-}
+treatmentActivity :: Activity
+treatmentActivity =
+    Activity
+        { activityName = "waste oil incineration"
+        , activityDescription = []
+        , activitySynonyms = M.empty
+        , activityClassification = M.empty
+        , activityLocation = "FR"
+        , activityLocationSource = LocationDeclared
+        , activityUnit = "kg"
+        , exchanges =
+            [ TechnosphereExchange
+                { techFlowId = usedOilId
+                , techAmount = 1.0
+                , techUnitId = kgUnitId
+                , techRole = ReferenceInput
+                , techActivityLinkId = treatActId
+                , techProcessLinkId = Nothing
+                , techLocation = ""
+                , techComment = Nothing
+                , techPedigree = Nothing
+                }
+            ]
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
+        , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
         }
 
 supplierActivityAt :: UUID -> UUID -> Activity

--- a/test/AuthorSpec.hs
+++ b/test/AuthorSpec.hs
@@ -17,6 +17,7 @@ import qualified Data.Set as S
 import Data.Text (Text, isInfixOf)
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as VU
 import Test.Hspec
 
 import Database (buildDatabaseWithMatrices)
@@ -39,6 +40,7 @@ import Types (
     Database (..),
     Exchange (..),
     LocationSource (..),
+    SparseTriple (..),
     TechRole (..),
     TechnosphereFlow (..),
     UUID,
@@ -135,19 +137,21 @@ spec = do
                 b <- resolveOrFail fixtureDb baseActivity{aaProductUnit = "item"}
                 snd (riKey a) `shouldNotBe` snd (riKey b)
 
-            it "resolves a local supplier to a process link" $ do
+            it "links a local supplier by UUIDs, never by process id" $ do
+                -- Process ids renumber on every rebuild; an embedded one would
+                -- silently point at whichever row inherits the number.
                 r <- resolveOrFail fixtureDb baseActivity{aaExchanges = [techInput supplierPid 2 Nothing]}
                 case [ex | ex <- exchanges (riActivity r), isTechnosphereExchange ex, exchangeAmount ex == 2] of
                     [TechnosphereExchange{techActivityLinkId = link, techProcessLinkId = pid}] -> do
                         link `shouldBe` supplierActId
-                        pid `shouldBe` findProcessId fixtureDb supplierActId supplierProdId
+                        pid `shouldBe` Nothing
                     other -> expectationFailure ("expected one resolved input, got " <> show (length other))
 
             it "leaves a dependency's supplier for cross-database relinking" $ do
                 -- A supplier in another database has no process id here; the link
                 -- carries the activity UUID and waits for the relink.
                 depDb <- buildFixture
-                let ctx = (contextOf fixtureDb){acDeps = [("other", depDb)]}
+                let ctx = (contextOf fixtureDb){acDeps = [depDb]}
                     authored = baseActivity{aaName = "from-dep", aaExchanges = [techInput supplierPid 3 Nothing]}
                 case validateAuthored ctx{acDb = emptyOf fixtureDb} [authored] of
                     Left errs -> expectationFailure ("expected resolution, got " <> show errs)
@@ -204,6 +208,27 @@ spec = do
                 case insertActivities defaultUnitConfig [] fixtureDb{dbDependsOn = ["other"]} of
                     Left err -> expectationFailure ("expected a no-op, got " <> show err)
                     Right db' -> dbDependsOn db' `shouldBe` ["other"]
+
+            it "keeps the supplier linked when insertion renumbers the rows" $ do
+                -- An authored key sorting before the supplier's shifts every
+                -- process id at rebuild; the input must still reach the
+                -- supplier's row, so links carry UUIDs and never a row number.
+                highDb <- buildFixtureAt highActId highProdId
+                let pidText = UUID.toText highActId <> "_" <> UUID.toText highProdId
+                r <- resolveOrFail highDb baseActivity{aaExchanges = [techInput pidText 2 Nothing]}
+                riKey r < (highActId, highProdId) `shouldBe` True
+                case insertActivities defaultUnitConfig [r] highDb of
+                    Left err -> expectationFailure ("insertActivities: " <> show err)
+                    Right db' ->
+                        case (uncurry (findProcessId db') (riKey r), findProcessId db' highActId highProdId) of
+                            (Just col, Just row) ->
+                                [ v
+                                | SparseTriple i j v <- VU.toList (dbTechnosphereTriples db')
+                                , i == row
+                                , j == col
+                                ]
+                                    `shouldBe` [2]
+                            other -> expectationFailure ("missing process ids after insert: " <> show other)
 
             it "restores the original activity set when the insert is deleted again" $ do
                 r <- resolveOrFail fixtureDb baseActivity
@@ -307,12 +332,18 @@ air = Compartment{compartmentName = "air", compartmentSub = Nothing}
 -- ---------------------------------------------------------------------------
 
 buildFixture :: IO Database
-buildFixture = do
+buildFixture = buildFixtureAt supplierActId supplierProdId
+
+{- | The same fixture with the supplier under chosen UUIDs — high ones sort
+after any authored key, which forces a renumbering on insert.
+-}
+buildFixtureAt :: UUID -> UUID -> IO Database
+buildFixtureAt actId prodId = do
     r <-
         buildDatabaseWithMatrices
             defaultUnitConfig
-            (M.singleton (supplierActId, supplierProdId) supplierActivity)
-            (M.singleton supplierProdId milkFlow)
+            (M.singleton (actId, prodId) (supplierActivityAt actId prodId))
+            (M.singleton prodId (milkFlowAt prodId))
             (M.singleton co2Id co2Flow)
             M.empty
             unitTable
@@ -321,10 +352,12 @@ buildFixture = do
 mkUUID :: Int -> UUID
 mkUUID n = UUID.fromWords64 (fromIntegral n) 0
 
-supplierActId, supplierProdId, co2Id, kgUnitId, itemUnitId, metreUnitId :: UUID
+supplierActId, supplierProdId, co2Id, highActId, highProdId, kgUnitId, itemUnitId, metreUnitId :: UUID
 supplierActId = mkUUID 1
 supplierProdId = mkUUID 2
 co2Id = mkUUID 3
+highActId = UUID.fromWords64 maxBound 1
+highProdId = UUID.fromWords64 maxBound 2
 kgUnitId = mkUUID 10
 itemUnitId = mkUUID 11
 metreUnitId = mkUUID 12
@@ -340,10 +373,10 @@ unitTable =
         , (metreUnitId, Unit{unitId = metreUnitId, unitName = "m", unitSymbol = "m", unitComment = ""})
         ]
 
-milkFlow :: TechnosphereFlow
-milkFlow =
+milkFlowAt :: UUID -> TechnosphereFlow
+milkFlowAt prodId =
     TechnosphereFlow
-        { tfId = supplierProdId
+        { tfId = prodId
         , tfName = "milk"
         , tfUnitId = kgUnitId
         , tfSynonyms = M.empty
@@ -363,8 +396,8 @@ co2Flow =
         , bfCompartment = Just air
         }
 
-supplierActivity :: Activity
-supplierActivity =
+supplierActivityAt :: UUID -> UUID -> Activity
+supplierActivityAt actId prodId =
     Activity
         { activityName = "milk production"
         , activityDescription = []
@@ -375,11 +408,11 @@ supplierActivity =
         , activityUnit = "kg"
         , exchanges =
             [ TechnosphereExchange
-                { techFlowId = supplierProdId
+                { techFlowId = prodId
                 , techAmount = 1.0
                 , techUnitId = kgUnitId
                 , techRole = ReferenceProduct
-                , techActivityLinkId = supplierActId
+                , techActivityLinkId = actId
                 , techProcessLinkId = Nothing
                 , techLocation = ""
                 , techComment = Nothing

--- a/test/AuthorSpec.hs
+++ b/test/AuthorSpec.hs
@@ -189,6 +189,20 @@ spec = do
                         warnings `shouldSatisfy` any (isInfixOf "no characterization factor matches it")
                     Right (rs, _) -> expectationFailure ("expected one insert, got " <> show (length rs))
 
+            it "copies a dependency's biosphere flow into the edited database" $ do
+                -- Characterization resolves flows through the edited database's
+                -- own vocabulary; a flow left only in the dependency would
+                -- score zero in silence.
+                bare <- buildBareFixture
+                dep <- buildFixture
+                let ctx = AuthorContext{acDb = bare, acDeps = [dep], acUnitConfig = defaultUnitConfig}
+                case validateAuthored ctx [baseActivity{aaExchanges = [bioOf (ExistingFlow co2Id) 1 Nothing]}] of
+                    Left errs -> expectationFailure ("expected acceptance, got " <> show errs)
+                    Right ([r], _) -> do
+                        map bfName (riNewBioFlows r) `shouldBe` ["Carbon dioxide"]
+                        map bfUnitId (riNewBioFlows r) `shouldBe` [kgUnitId]
+                    Right (rs, _) -> expectationFailure ("expected one insert, got " <> show (length rs))
+
             it "reuses a biosphere flow the database already declares" $ do
                 -- Same three coordinates the flow was minted on: re-declaring it is
                 -- not a second flow.
@@ -377,6 +391,23 @@ buildFixtureAt actId prodId = do
                 ]
             )
             (M.singleton co2Id co2Flow)
+            M.empty
+            unitTable
+    either (fail . show) pure r
+
+{- | A database that declares no biosphere flow at all — bio vocabulary can
+only come from a dependency.
+-}
+buildBareFixture :: IO Database
+buildBareFixture = do
+    let act = supplierActivityAt supplierActId supplierProdId
+        noBio = act{exchanges = filter isTechnosphereExchange (exchanges act)}
+    r <-
+        buildDatabaseWithMatrices
+            defaultUnitConfig
+            (M.singleton (supplierActId, supplierProdId) noBio)
+            (M.singleton supplierProdId (milkFlowAt supplierProdId))
+            M.empty
             M.empty
             unitTable
     either (fail . show) pure r

--- a/volca.cabal
+++ b/volca.cabal
@@ -43,6 +43,7 @@ library
                      , SharedSolver
                      , Database
                      , Database.Manager
+                     , Database.Author
                      , Database.Edit
                      , Database.Loader
                      , Database.CrossLinking
@@ -319,6 +320,7 @@ test-suite lca-tests
                      , NumericEdgesSpec
                      , AggregateSpec
                      , CopySpec
+                     , AuthorSpec
                      , DeleteSelectionSpec
                      , ExportSpec
                      , ExportHandlerSpec


### PR DESCRIPTION
## Why

A database could be copied, relinked and deleted from, but nothing could be
added to it. The engine could verify an inventory it was given and never one it
helped write, so correcting a background dataset meant editing the source file
by hand and re-importing the whole thing.

## What it does

`Database.Author` turns a described activity into one the database can hold:
it resolves every supplier, converts every amount into the unit its target is
stated in, mints identity, and returns either the resolved rows or every
complaint at once. `Database.Edit` gains `insertActivities` and
`replaceActivities`, symmetric with the existing delete: both rebuild the
matrices, indexes and interning tables from the surviving activity map, so an
authored database is indistinguishable from one that was loaded that way.

There is deliberately no upsert. A mistyped identity must fail rather than
quietly become a second copy of the activity the author thought they were
correcting.

## Identity is minted, not chosen

`process_id` comes from the activity name, location, product name and product
unit, through a UUID5 namespace of its own. Writing the same description twice
addresses the same row — which is what makes a correction a correction. It also
means changing any of those four describes a different activity: renaming one
is writing the new and deleting the old.

## Authoring is strict where importing is tolerant

Importing 20 000 datasets warns and drops a line whose supplier does not
resolve, because refusing a file over one row helps nobody. Authoring is the
opposite situation — the caller is present and the batch is small — so an
unresolved supplier, a non-finite amount, an impossible unit conversion and a
biosphere line stated in the wrong unit are all errors. Everything wrong with a
batch comes back together, each complaint naming its activity and the exchange
it belongs to.

A newly introduced biosphere flow comes back as a warning rather than an error:
no characterization factor matches it by identity, so it scores zero in every
method until one is mapped to it. That is worth saying and not worth refusing.

## Scope

Pure domain only: nothing is written to disk and no route is exposed. Persistence
and the HTTP/CLI surfaces are separate pull requests.
