### PR TITLE
Make an edit outlive the process it was made in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,26 @@
   at once, one per set of loaded databases, can now tell which one answered
   instead of guessing from the data.
 
+### Changed
+- Deleting activities from a database you uploaded or copied now survives a
+  restart. The engine rewrites the database's own source files before it
+  answers, so unloading and reloading returns what was written; previously the
+  sources and the matrix cache kept the pre-edit set and a restart quietly
+  brought every removed activity back. Only a database stored as EcoSpold 2 can
+  be written back, because its file names carry each process identity through a
+  reload; other formats refuse the edit and name the way out (export to
+  EcoSpold 2, upload that). A copy gets files of its own on the first save
+  instead of writing into the database it was copied from. A configured
+  database the engine only reads is still edited in memory alone, and the
+  delete response now says so with two new fields, `transient` and `warnings`.
+
 ### Fixed
 - The MCP handshake announced version `0.6.0` whatever the build was; it now
   reports the running version.
+- The dependency chosen for an uploaded database is now written into its
+  `meta.toml`. It used to live only in memory and in the binary matrix cache,
+  so a restart between choosing the dependency and finalizing the database lost
+  it silently, and the database came back linked to nothing.
 
 ## [0.9.4] - 2026-08-01
 

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -132,7 +132,7 @@ import qualified Data.Aeson.KeyMap as KM
 import Data.Maybe (fromMaybe)
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
-import Database.Edit (DeleteRequest (..), copyDatabase, deleteActivitiesInDB)
+import Database.Edit (DeleteOutcome (..), DeleteRequest (..), copyDatabase, deleteActivitiesInDB)
 import Database.Export (parseExportFormat, parseMethodExportFormat, serializeDatabase, serializeMethodCollection)
 import qualified Database.Loader as Loader
 import Database.Manager (
@@ -516,12 +516,14 @@ deleteActivitiesHandler dbName req = do
         -- dependents). Surface it as 4xx so a raw HTTP client can't read the
         -- 200 envelope as success.
         Left err -> throwError err400{errBody = BSL.fromStrict $ T.encodeUtf8 err}
-        Right deleted ->
+        Right outcome ->
             return $
                 DeleteSelectionResponse
                     True
-                    ("Deleted " <> T.pack (show deleted) <> " activities from " <> dbName)
-                    deleted
+                    ("Deleted " <> T.pack (show (doRemoved outcome)) <> " activities from " <> dbName)
+                    (doRemoved outcome)
+                    (not (doPersisted outcome))
+                    (doWarnings outcome)
 
 {- | Export a loaded database as a raw octet-stream body — the same shape the
 upload endpoint reads, and the only response cheap enough for a multi-hundred-MB
@@ -807,6 +809,7 @@ uploadDatabaseHandler mName mDesc src = do
                             , UploadedDB.umDescription = mDescription
                             , UploadedDB.umFormat = urFormat uploadResult -- Types are now unified
                             , UploadedDB.umDataPath = makeRelative uploadDir (urPath uploadResult)
+                            , UploadedDB.umDepends = []
                             }
                 liftIO $ UploadedDB.writeUploadMeta uploadDir meta
 
@@ -1003,6 +1006,7 @@ uploadMethodHandler mName mDesc src =
                             , UploadedDB.umDescription = mDescription
                             , UploadedDB.umFormat = methodFormat
                             , UploadedDB.umDataPath = makeRelative uploadDir methodDir
+                            , UploadedDB.umDepends = []
                             }
                 liftIO $ UploadedDB.writeUploadMeta uploadDir meta
 

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -978,6 +978,13 @@ data DeleteSelectionResponse = DeleteSelectionResponse
     { dsrSuccess :: Bool
     , dsrMessage :: Text
     , dsrDeleted :: Int
+    , dsrTransient :: Bool
+    {- ^ True when the deletion lives in memory only, because the database is
+    one the engine reads from configuration rather than owns. Reloading it
+    brings the removed activities back, and a caller has to be able to say
+    so rather than let the user assume the change stuck.
+    -}
+    , dsrWarnings :: [Text]
     }
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped DeleteSelectionResponse)

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -17,7 +17,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
-import Database.Edit (DeleteRequest (..), copyDatabase, deleteActivitiesInDB)
+import Database.Edit (DeleteOutcome (..), DeleteRequest (..), copyDatabase, deleteActivitiesInDB)
 import Database.Export (exportDatabase, exportMethodCollection, parseExportFormat, parseMethodExportFormat)
 import Database.Manager (DatabaseManager (..), LoadedDatabase (..), RelinkResult (..), addDatabase, addMethodCollection)
 import qualified Database.Manager as DM
@@ -348,6 +348,7 @@ executeDbUpload fmt manager args = do
                         , UploadedDB.umDescription = uaDescription args
                         , UploadedDB.umFormat = urFormat uploadResult
                         , UploadedDB.umDataPath = makeRelative uploadDir (urPath uploadResult)
+                        , UploadedDB.umDepends = []
                         }
             UploadedDB.writeUploadMeta uploadDir meta
 
@@ -414,6 +415,7 @@ executeMcUpload fmt manager args = do
                         , UploadedDB.umDescription = uaDescription args
                         , UploadedDB.umFormat = urFormat uploadResult
                         , UploadedDB.umDataPath = makeRelative uploadDir (urPath uploadResult)
+                        , UploadedDB.umDepends = []
                         }
             UploadedDB.writeUploadMeta uploadDir meta
 
@@ -483,9 +485,16 @@ executeDbDeleteActivities fmt manager args = do
         Left err -> do
             reportError $ "Delete failed: " ++ T.unpack err
             exitFailure
-        Right deleted -> do
-            reportProgress Info $ "Deleted " ++ show deleted ++ " activities from " ++ T.unpack (ddaDb args)
-            outputResult fmt $ object ["database" .= ddaDb args, "deleted" .= deleted]
+        Right outcome -> do
+            reportProgress Info $ "Deleted " ++ show (doRemoved outcome) ++ " activities from " ++ T.unpack (ddaDb args)
+            mapM_ (reportProgress Warning . T.unpack) (doWarnings outcome)
+            outputResult fmt $
+                object
+                    [ "database" .= ddaDb args
+                    , "deleted" .= doRemoved outcome
+                    , "transient" .= not (doPersisted outcome)
+                    , "warnings" .= doWarnings outcome
+                    ]
 
 {- | Execute database load: bring a configured database (and its declared
 dependencies) into memory. Any failed dependency is surfaced in the output.

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -40,22 +40,34 @@ module Database.Edit (
     resolveDeleteSelection,
     DeleteSelection (..),
     DeleteRequest (..),
+    DeleteOutcome (..),
     deleteActivitiesInDB,
     insertActivities,
     replaceActivities,
+    MutationOutcome (..),
+    mutateUploadedDatabase,
 ) where
 
 import Control.Concurrent.STM (atomically, modifyTVar', readTVar, readTVarIO)
-import Control.Exception (finally)
+import Control.Exception (SomeException, finally, try)
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.IntSet as IS
+import Data.List (isPrefixOf)
 import qualified Data.Map.Strict as M
-import Data.Maybe (isJust)
+import Data.Maybe (fromMaybe, isJust)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
+import System.Directory (
+    createDirectoryIfMissing,
+    doesDirectoryExist,
+    removePathForcibly,
+    renameDirectory,
+ )
+import System.FilePath (makeRelative, takeDirectory, (</>))
 
 import Config (DatabaseConfig (..))
 import Database (
@@ -66,6 +78,8 @@ import Database (
  )
 import Database.Author (ResolvedInsert (..))
 import Database.CrossLinking (buildIndexedDatabaseFromDB)
+import Database.Export (serializeDatabaseFiles)
+import qualified Database.Loader as Loader
 import Database.Manager (
     DatabaseManager (..),
     LoadedDatabase (..),
@@ -73,6 +87,7 @@ import Database.Manager (
     getDatabase,
     getMergedSynonymDB,
     getMergedUnitConfig,
+    relinkDatabase,
  )
 import Database.MatrixBuild (
     InterningTables (..),
@@ -82,7 +97,8 @@ import Database.MatrixBuild (
     buildTechTriples,
     collectBioFlowOrder,
  )
-import Database.Upload (slugify)
+import Database.Upload (DatabaseFormat (..), slugify)
+import qualified Database.UploadedDatabase as UploadedDB
 import Matrix (clearCachedSolver)
 import qualified Search.BM25 as BM25
 import Service (bm25Retrieve)
@@ -407,6 +423,250 @@ checkKeys intent existing keys = case intent of
     renderKey (a, p) = UUID.toText a <> "_" <> UUID.toText p
 
 -- ---------------------------------------------------------------------------
+-- Persisting an edit
+-- ---------------------------------------------------------------------------
+
+{- | What a mutation did.
+
+'moPersisted' is the honest half: an edit to a configured (TOML) database
+lives in memory only and is gone at the next unload, and the caller has to be
+able to say so rather than let the user assume otherwise.
+-}
+data MutationOutcome = MutationOutcome
+    { moDatabase :: Database
+    , moPersisted :: Bool
+    , moWarnings :: [Text]
+    }
+
+{- | Apply a pure edit to a loaded database, then commit it to memory and — for
+a database that owns its files — to disk.
+
+The sequence is prepare-then-commit, because everything that can fail must
+fail before anything is visible:
+
+  1. refuse while another loaded database depends on this one (a rebuild
+     renumbers processes, and the dependent's cross-database links would
+     resolve to the wrong rows or silently drop at solve time);
+  2. run the pure edit;
+  3. serialize the result and write it into a staging directory beside the
+     live one — nothing observable yet;
+  4. build the runtime indexes and a fresh solver for the edited value;
+  5. commit: swing the staging directory into place and swap the registry;
+  6. relink across dependencies and save the matrix cache, so an unload and
+     reload gives back what was just written rather than the pre-edit sources.
+
+Steps 1-4 leave both memory and disk untouched on failure. Step 5 is two
+renames rather than one atomic operation; a crash between them leaves the
+previous sources beside the new ones under a @.old@ suffix rather than
+losing them.
+-}
+mutateUploadedDatabase ::
+    DatabaseManager ->
+    Text ->
+    (Database -> Either Text Database) ->
+    IO (Either Text MutationOutcome)
+mutateUploadedDatabase manager dbName edit =
+    getDatabase manager dbName >>= \case
+        Nothing -> pure $ Left $ "Database not loaded: " <> dbName
+        Just loaded -> do
+            loadedDbs <- readTVarIO (dmLoadedDbs manager)
+            case guardDependents dbName loadedDbs *> edit (ldDatabase loaded) of
+                Left err -> pure (Left err)
+                Right edited -> do
+                    prepared <- prepareSources dbName (ldConfig loaded) edited
+                    case prepared of
+                        Left err -> pure (Left err)
+                        Right (staging, warnings) ->
+                            Right <$> commitMutation manager dbName loaded edited staging warnings
+
+{- | Refuse an edit while another loaded database depends on this one. Shared
+with the delete path, which has the same reason: rebuilding renumbers every
+process, and a dependent's cross-database links would then resolve elsewhere
+or drop silently at solve time.
+-}
+guardDependents :: Text -> M.Map Text LoadedDatabase -> Either Text ()
+guardDependents dbName loadedDbs = case dependents of
+    [] -> Right ()
+    names ->
+        Left $
+            "Cannot edit "
+                <> dbName
+                <> ": still required by "
+                <> T.intercalate ", " names
+                <> ". Unload dependents first."
+  where
+    dependents =
+        [ name
+        | (name, ld) <- M.toList loadedDbs
+        , name /= dbName
+        , dbName `elem` dbDependsOn (ldDatabase ld)
+        ]
+
+{- | Sources written and waiting to be swung into place, or 'Nothing' when the
+database has no files of its own to write.
+-}
+data StagedSources = StagedSources
+    { ssDataDir :: FilePath
+    -- ^ where the live sources are, or will be
+    , ssStaging :: FilePath
+    -- ^ the fully-written replacement, still invisible
+    , ssHome :: Maybe (FilePath, DatabaseFormat)
+    {- ^ set when this write gives the database a home it did not have; the
+    upload root whose @meta.toml@ has to be written on commit
+    -}
+    }
+
+{- | Serialize the edited database and stage it beside its live sources.
+
+Three cases, in the order they are decided:
+
+  * a configured (TOML) database writes nothing — it is a background database
+    the engine reads and never owns, so its edits stay in memory;
+  * a database with its own upload directory is rewritten in its own format,
+    and refused when that format cannot record process identity
+    ('Database.Export.serializeDatabaseFiles' says which and why);
+  * a copy has no files at all — 'copyDatabase' shares the source's value
+    without duplicating its directory — so the first write gives it one. It
+    gets EcoSpold 2, the format that survives the round trip. The source's
+    own files are never touched: writing through the shared path would edit a
+    database nobody asked to edit.
+-}
+prepareSources ::
+    Text ->
+    DatabaseConfig ->
+    Database ->
+    IO (Either Text (Maybe StagedSources, [Text]))
+prepareSources dbName config edited
+    | not (dcIsUploaded config) = pure (Right (Nothing, []))
+    | otherwise = do
+        uploadsDir <- UploadedDB.getDatabaseUploadsDir
+        let home = uploadsDir </> T.unpack dbName
+            ownsItsFiles = home `isPrefixOf` dcPath config
+            dataDir = if ownsItsFiles then dcPath config else home </> "data"
+            format = if ownsItsFiles then fromMaybe UnknownFormat (dcFormat config) else EcoSpold2
+        case serializeDatabaseFiles format edited of
+            Left err -> pure (Left err)
+            Right (entries, warnings) -> do
+                written <- writeStaging (dataDir <> ".new") entries
+                pure $ case written of
+                    Left err -> Left err
+                    Right staging ->
+                        Right
+                            ( Just
+                                StagedSources
+                                    { ssDataDir = dataDir
+                                    , ssStaging = staging
+                                    , ssHome = if ownsItsFiles then Nothing else Just (home, format)
+                                    }
+                            , warnings
+                            )
+
+{- | Write every entry into a fresh staging directory, replacing any leftover
+from an interrupted write. Returns the directory on success; on failure the
+partial directory is removed, so a retry never inherits half of a previous
+attempt.
+-}
+writeStaging :: FilePath -> [(FilePath, BL.ByteString)] -> IO (Either Text FilePath)
+writeStaging staging entries = do
+    attempt <- try $ do
+        removePathForcibly staging
+        createDirectoryIfMissing True staging
+        mapM_ writeEntry entries
+    case attempt of
+        Right () -> pure (Right staging)
+        Left err -> do
+            removePathForcibly staging
+            pure $ Left $ "could not write the database sources: " <> T.pack (show (err :: SomeException))
+  where
+    writeEntry (relPath, bytes) = do
+        let full = staging </> relPath
+        createDirectoryIfMissing True (takeDirectory full)
+        BL.writeFile full bytes
+
+{- | Swing the staged sources into place, keeping the previous ones until the
+new ones are live.
+-}
+commitSources :: StagedSources -> IO ()
+commitSources staged = do
+    let live = ssDataDir staged
+        previous = live <> ".old"
+    hadSources <- doesDirectoryExist live
+    removePathForcibly previous
+    if hadSources
+        then renameDirectory live previous
+        else createDirectoryIfMissing True (takeDirectory live)
+    renameDirectory (ssStaging staged) live
+    removePathForcibly previous
+
+{- | Install the edited database: commit its sources, swap it into the
+registry behind a fresh solver, then relink and re-cache so a reload returns
+what was written.
+-}
+commitMutation ::
+    DatabaseManager ->
+    Text ->
+    LoadedDatabase ->
+    Database ->
+    Maybe StagedSources ->
+    [Text] ->
+    IO MutationOutcome
+commitMutation manager dbName loaded edited staged warnings = do
+    synonymDB <- getMergedSynonymDB manager
+    let withRuntime = BM25.addBM25Index (initializeRuntimeFields edited synonymDB)
+        techTriplesInt =
+            [ (fromIntegral i, fromIntegral j, v)
+            | SparseTriple i j v <- U.toList (dbTechnosphereTriples withRuntime)
+            ]
+    -- The solver cached under this name has the pre-edit dimensions; drain and
+    -- destroy it before installing the rebuilt one, as the delete path does.
+    clearCachedSolver dbName
+    solver <- createSharedSolver dbName techTriplesInt (fromIntegral (dbActivityCount withRuntime))
+    mapM_ commitSources staged
+    config <- maybe (pure (ldConfig loaded)) (recordHome manager dbName (ldConfig loaded) edited) staged
+    let loaded' = loaded{ldDatabase = withRuntime, ldSharedSolver = solver, ldConfig = config}
+        indexedDb = buildIndexedDatabaseFromDB dbName synonymDB withRuntime
+    atomically $ do
+        modifyTVar' (dmLoadedDbs manager) (M.insert dbName loaded')
+        modifyTVar' (dmIndexedDbs manager) (M.insert dbName indexedDb)
+    clearMethodMappingCacheForDb manager dbName
+    relinkWarnings <- case staged of
+        Nothing -> pure []
+        Just source -> do
+            -- Rebuilding cleared the cross-database links; rebuild them against
+            -- the current dependency set before the cache records the result.
+            relinked <- relinkDatabase manager dbName
+            saved <- getDatabase manager dbName
+            mapM_ (Loader.saveCachedDatabaseWithMatrices dbName (ssDataDir source) . ldDatabase) saved
+            pure (either (\err -> ["the edit is saved, but relinking failed: " <> err]) (const []) relinked)
+    pure
+        MutationOutcome
+            { moDatabase = withRuntime
+            , moPersisted = isJust staged
+            , moWarnings = warnings <> relinkWarnings
+            }
+
+{- | Give a database that had no files of its own a @meta.toml@ describing the
+home it just acquired, and point its config at the new sources.
+-}
+recordHome :: DatabaseManager -> Text -> DatabaseConfig -> Database -> StagedSources -> IO DatabaseConfig
+recordHome manager dbName config edited staged = case ssHome staged of
+    Nothing -> pure config
+    Just (home, format) -> do
+        UploadedDB.writeUploadMeta
+            home
+            UploadedDB.UploadMeta
+                { UploadedDB.umVersion = 1
+                , UploadedDB.umDisplayName = dcDisplayName config
+                , UploadedDB.umDescription = dcDescription config
+                , UploadedDB.umFormat = format
+                , UploadedDB.umDataPath = makeRelative home (ssDataDir staged)
+                , UploadedDB.umDepends = dbDependsOn edited
+                }
+        let config' = config{dcPath = ssDataDir staged, dcFormat = Just format}
+        atomically $ modifyTVar' (dmAvailableDbs manager) (M.insert dbName config')
+        pure config'
+
+-- ---------------------------------------------------------------------------
 -- Selection resolver
 -- ---------------------------------------------------------------------------
 
@@ -506,47 +766,40 @@ data DeleteRequest = DeleteRequest
     , drIds :: Maybe [Text]
     }
 
+{- | What a delete-by-selection request did: how many activities went, and
+whether the database it edited keeps the change past an unload.
+-}
+data DeleteOutcome = DeleteOutcome
+    { doRemoved :: Int
+    , doPersisted :: Bool
+    , doWarnings :: [Text]
+    }
+
 {- | Delete a selection from a loaded database, in place under the same name.
 
 Resolves the selection ('drIds' verbatim, else the filter's full matching
 set), resolves the explicit keep/extra process-id strings, applies the
-adjustments, deletes + rebuilds with the manager's merged unit config,
-re-attaches runtime indexes with the merged synonym DB, swaps a fresh solver
-in, and updates the loaded / indexed registry maps. Returns the number of
-activities removed. Fails (Left) when the database is not loaded, an
-ids/keep/extra id is unknown, 'drIds' is combined with filter fields, or the
-rebuild reports an inconsistency.
+adjustments, then hands the deletion to 'mutateUploadedDatabase', which
+rebuilds, rewrites the sources of a database that owns them, and swaps the
+result in. Fails (Left) when the database is not loaded, an ids/keep/extra id
+is unknown, 'drIds' is combined with filter fields, the format cannot record
+what the edit produced, or the rebuild reports an inconsistency.
+
+A deletion from a database with its own files now outlives the process: the
+old behaviour left the sources and the matrix cache holding the pre-delete
+set, so a restart quietly resurrected every removed activity. A configured
+(TOML) database still edits in memory only, and 'doPersisted' says so.
 -}
 deleteActivitiesInDB ::
     DatabaseManager ->
     Text -> -- database name
     DeleteRequest ->
-    IO (Either Text Int)
+    IO (Either Text DeleteOutcome)
 deleteActivitiesInDB manager dbName DeleteRequest{drName = nameP, drLocation = geoP, drProduct = prodP, drClassifications = classFilters, drExactName = exactMatch, drKeep = keep, drExtra = extra, drIds = mIds} =
     getDatabase manager dbName >>= \case
         Nothing -> pure $ Left $ "Database not loaded: " <> dbName
         Just loaded -> do
-            -- Deleting activities renumbers/removes them, which would leave any loaded
-            -- database that depends on this one holding cross-DB links that no longer
-            -- resolve — and those silently drop at solve time, undercounting the
-            -- dependent. Refuse while dependents are loaded (mirrors 'unloadDatabase').
-            loadedDbs <- readTVarIO (dmLoadedDbs manager)
             let db = ldDatabase loaded
-                dependents =
-                    [ name
-                    | (name, ld) <- M.toList loadedDbs
-                    , name /= dbName
-                    , dbName `elem` dbDependsOn (ldDatabase ld)
-                    ]
-                guardDeps
-                    | null dependents = Right ()
-                    | otherwise =
-                        Left $
-                            "Cannot delete from "
-                                <> dbName
-                                <> ": still required by "
-                                <> T.intercalate ", " dependents
-                                <> ". Unload dependents first."
                 -- The two selection modes are exclusive: ids name the set
                 -- verbatim, filters compute it. A request carrying both is
                 -- ambiguous, so it is refused rather than guessed at — exact
@@ -558,44 +811,17 @@ deleteActivitiesInDB manager dbName DeleteRequest{drName = nameP, drLocation = g
                         | hasFilter -> Left "ids cannot be combined with name/location/product/classification/exact filters"
                         | otherwise -> traverse (resolvePid db) ids
                     Nothing -> Right (filteredProcessIds db nameP geoP prodP classFilters exactMatch)
-            case guardDeps *> ((,,) <$> traverse (resolvePid db) keep <*> traverse (resolvePid db) extra <*> selectionE) of
+            case (,,) <$> traverse (resolvePid db) keep <*> traverse (resolvePid db) extra <*> selectionE of
                 Left err -> pure $ Left err
                 Right (keepPids, extraPids, filtered) -> do
                     let toDelete =
                             resolveDeleteSelection
                                 DeleteSelection{dsFiltered = filtered, dsKeep = keepPids, dsExtra = extraPids}
                     unitConfig <- getMergedUnitConfig manager
-                    case deleteActivitiesWith unitConfig toDelete db of
-                        Left err -> pure $ Left err
-                        Right rebuilt -> do
-                            synonymDB <- getMergedSynonymDB manager
-                            let withRuntime = BM25.addBM25Index (initializeRuntimeFields rebuilt synonymDB)
-                                techTriplesInt =
-                                    [ (fromIntegral i, fromIntegral j, v)
-                                    | SparseTriple i j v <- U.toList (dbTechnosphereTriples withRuntime)
-                                    ]
-                            -- The MUMPS solver cached under this name is now stale (old
-                            -- dimensions/factorization); drain + destroy it as unload/remove do,
-                            -- before installing the rebuilt one — otherwise the first post-delete
-                            -- solve overwrites the map entry and leaks a worker thread + native
-                            -- instance.
-                            clearCachedSolver dbName
-                            solver <-
-                                createSharedSolver
-                                    dbName
-                                    techTriplesInt
-                                    (fromIntegral (dbActivityCount withRuntime))
-                            let loaded' = loaded{ldDatabase = withRuntime, ldSharedSolver = solver}
-                                indexedDb = buildIndexedDatabaseFromDB dbName synonymDB withRuntime
-                            atomically $ do
-                                modifyTVar' (dmLoadedDbs manager) (M.insert dbName loaded')
-                                modifyTVar' (dmIndexedDbs manager) (M.insert dbName indexedDb)
-                            clearMethodMappingCacheForDb manager dbName
-                            -- Edits are transient by design. The on-disk matrix cache
-                            -- and the source still hold the pre-delete set, so an
-                            -- unload/reload deliberately restores the original
-                            -- database; persisting an edited database is a separate,
-                            -- explicit step (exporting it to a new file). We therefore
-                            -- leave the cache in place rather than forcing the next
-                            -- load to rebuild from source.
-                            pure $ Right (length toDelete)
+                    outcome <- mutateUploadedDatabase manager dbName (deleteActivitiesWith unitConfig toDelete)
+                    pure $ flip fmap outcome $ \done ->
+                        DeleteOutcome
+                            { doRemoved = length toDelete
+                            , doPersisted = moPersisted done
+                            , doWarnings = moWarnings done
+                            }

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -67,7 +67,7 @@ import System.Directory (
     removePathForcibly,
     renameDirectory,
  )
-import System.FilePath (makeRelative, takeDirectory, (</>))
+import System.FilePath (makeRelative, splitDirectories, takeDirectory, (</>))
 
 import Config (DatabaseConfig (..))
 import Database (
@@ -433,8 +433,7 @@ lives in memory only and is gone at the next unload, and the caller has to be
 able to say so rather than let the user assume otherwise.
 -}
 data MutationOutcome = MutationOutcome
-    { moDatabase :: Database
-    , moPersisted :: Bool
+    { moPersisted :: Bool
     , moWarnings :: [Text]
     }
 
@@ -465,7 +464,30 @@ mutateUploadedDatabase ::
     Text ->
     (Database -> Either Text Database) ->
     IO (Either Text MutationOutcome)
-mutateUploadedDatabase manager dbName edit =
+mutateUploadedDatabase manager dbName edit = do
+    -- Two concurrent edits of the same database would share one staging
+    -- directory and interleave the renames over the live sources. Reserve the
+    -- name (the same reservation copy and setup staging use) and refuse the
+    -- second edit rather than queue it: edits are interactive and rare.
+    reserved <- atomically $ do
+        staging <- readTVar (dmStagingDbs manager)
+        if S.member dbName staging
+            then pure False
+            else True <$ modifyTVar' (dmStagingDbs manager) (S.insert dbName)
+    if not reserved
+        then pure $ Left $ "An edit of " <> dbName <> " is already in progress. Retry when it finishes."
+        else
+            finally
+                (mutateReserved manager dbName edit)
+                (atomically $ modifyTVar' (dmStagingDbs manager) (S.delete dbName))
+
+-- | The mutation proper. The caller holds the 'dmStagingDbs' reservation.
+mutateReserved ::
+    DatabaseManager ->
+    Text ->
+    (Database -> Either Text Database) ->
+    IO (Either Text MutationOutcome)
+mutateReserved manager dbName edit =
     getDatabase manager dbName >>= \case
         Nothing -> pure $ Left $ "Database not loaded: " <> dbName
         Just loaded -> do
@@ -541,7 +563,10 @@ prepareSources dbName config edited
     | otherwise = do
         uploadsDir <- UploadedDB.getDatabaseUploadsDir
         let home = uploadsDir </> T.unpack dbName
-            ownsItsFiles = home `isPrefixOf` dcPath config
+            -- Judged on path components, not on text: a textual prefix would
+            -- make a database named "agri" the owner of "agribalyse"'s files,
+            -- and its first save would rewrite them.
+            ownsItsFiles = splitDirectories home `isPrefixOf` splitDirectories (dcPath config)
             dataDir = if ownsItsFiles then dcPath config else home </> "data"
             format = if ownsItsFiles then fromMaybe UnknownFormat (dcFormat config) else EcoSpold2
         case serializeDatabaseFiles format edited of
@@ -630,7 +655,17 @@ commitMutation manager dbName loaded edited staged warnings = do
         modifyTVar' (dmIndexedDbs manager) (M.insert dbName indexedDb)
     clearMethodMappingCacheForDb manager dbName
     relinkWarnings <- case staged of
-        Nothing -> pure []
+        -- The transient path must not relink: 'relinkDatabase' saves the
+        -- matrix cache when links change, which would half-persist an edit
+        -- the caller is being told is memory-only. Say what that costs.
+        Nothing ->
+            pure
+                [ "the edit cleared the links to "
+                    <> T.intercalate ", " (dbDependsOn edited)
+                    <> "; they return at the next load, and cross-database totals undercount until then"
+                | not (null (dbDependsOn edited))
+                , null (dbCrossDBLinks edited)
+                ]
         Just source -> do
             -- Rebuilding cleared the cross-database links; rebuild them against
             -- the current dependency set before the cache records the result.
@@ -640,8 +675,7 @@ commitMutation manager dbName loaded edited staged warnings = do
             pure (either (\err -> ["the edit is saved, but relinking failed: " <> err]) (const []) relinked)
     pure
         MutationOutcome
-            { moDatabase = withRuntime
-            , moPersisted = isJust staged
+            { moPersisted = isJust staged
             , moWarnings = warnings <> relinkWarnings
             }
 

--- a/src/Database/Export.hs
+++ b/src/Database/Export.hs
@@ -14,6 +14,7 @@ has no writer and 'UnknownFormat' is not a real target, so both fail loudly
 -}
 module Database.Export (
     serializeDatabase,
+    serializeDatabaseFiles,
     exportDatabase,
     MethodExportFormat (..),
     parseMethodExportFormat,
@@ -72,6 +73,42 @@ serializeDatabase fmt db = case fmt of
   where
     sdb = toSimpleDatabase db
     noWarn = fmap (,[])
+
+{- | The @(relative path, bytes)@ a database becomes as a directory tree,
+rather than the single stream 'serializeDatabase' hands to a download.
+
+This is the shape persistence needs: rewriting an upload's own source files in
+place, so that unloading and reloading the database gives back what was
+written. That demands more of a format than exporting does — it must record
+process identity, not re-derive it.
+
+'EcoSpold2' does: each dataset is a file named @{activityUUID}_{productUUID}.spold@
+and the parser reads the pair straight off the name, so every process id
+survives the round trip. The other writers re-mint identity from names and
+locations on read, which is stable for rows that came from a file but moves
+the identity of rows an author just created — silently, and only after a
+restart. They are refused here rather than allowed to lose that quietly;
+'serializeDatabase' still exports to all of them, because an export is a copy
+that leaves the original in place.
+-}
+serializeDatabaseFiles :: DatabaseFormat -> Database -> Either Text ([(FilePath, BL.ByteString)], [Text])
+serializeDatabaseFiles fmt db = case fmt of
+    EcoSpold2 -> (\entries -> (map (fmap encodeLazy) entries, [])) <$> ES2.writeEcoSpold2 ES2.noVolatileMeta sdb
+    SimaProCSV -> remints "SimaPro CSV"
+    EcoSpold1 -> remints "EcoSpold 1"
+    ILCDProcess -> remints "ILCD"
+    BrightwayExcel -> remints "Brightway Excel"
+    OpenLcaJsonLd -> Left "openLCA JSON-LD export is not supported"
+    UnknownFormat -> Left "cannot write to an unknown format"
+  where
+    sdb = toSimpleDatabase db
+    encodeLazy = BL.fromStrict . TE.encodeUtf8
+    remints name =
+        Left $
+            name
+                <> " does not record process identifiers, so saving would give the edited\
+                   \ activities different identities the next time the database is read.\
+                   \ Export this database to EcoSpold 2 and upload that to make edits durable."
 
 {- | Export targets for a method collection — a space of its own, not
 'DatabaseFormat': most database formats carry no method writer, and method

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1240,13 +1240,40 @@ uploadMetaToConfig slug dirPath meta =
         , dcDescription = UploadedDB.umDescription meta
         , dcLoad = False -- Never auto-load uploads
         , dcDefault = False
-        , dcDepends = []
+        , dcDepends = UploadedDB.umDepends meta
         , dcLocationAliases = M.empty
         , dcFormat = Just (UploadedDB.umFormat meta)
         , dcIsUploaded = True -- Discovered from uploads/ directory
         , dcDeletable = True
         , dcGeographyPolicy = GeoGlobal -- Uploads can't yet express policy; default to permissive
         }
+
+{- | Record an uploaded database's dependency pin where a restart can find it.
+
+The pin otherwise lives in the staging registry and inside the binary matrix
+cache, so a restart between choosing a dependency and finalizing the database
+used to lose it without saying so — the database came back linked to nothing.
+Writes 'UploadedDB.umDepends' and keeps the in-memory config in step.
+
+A configured (TOML) database has no meta.toml to write and owns its
+dependencies in the config file, so it is left alone.
+-}
+persistUploadDepends :: DatabaseManager -> Text -> [Text] -> IO ()
+persistUploadDepends manager dbName deps = do
+    availableDbs <- readTVarIO (dmAvailableDbs manager)
+    case M.lookup dbName availableDbs of
+        Nothing -> pure ()
+        Just dbConfig
+            | not (dcIsUploaded dbConfig) -> pure ()
+            | otherwise -> do
+                uploadsDir <- UploadedDB.getDatabaseUploadsDir
+                let uploadRoot = uploadsDir </> T.unpack dbName
+                mMeta <- UploadedDB.readUploadMeta uploadRoot
+                case mMeta of
+                    Nothing -> pure ()
+                    Just meta -> UploadedDB.writeUploadMeta uploadRoot meta{UploadedDB.umDepends = deps}
+                atomically $
+                    modifyTVar' (dmAvailableDbs manager) (M.insert dbName dbConfig{dcDepends = deps})
 
 {- | Discover uploaded methods from uploads/methods/ directory
 Reads meta.toml from each subdirectory and converts to MethodConfig
@@ -2826,6 +2853,7 @@ addDependencyToStaged manager dbName depName = do
 
                 -- Save updated staged database
                 atomically $ modifyTVar' (dmStagedDbs manager) (M.insert dbName updatedStaged)
+                persistUploadDepends manager dbName newDeps
 
                 -- Return updated setup info
                 first setupErrorMessage <$> getDatabaseSetupInfo manager dbName
@@ -2864,6 +2892,7 @@ removeDependencyFromStaged manager dbName depName = do
                         }
 
             atomically $ modifyTVar' (dmStagedDbs manager) (M.insert dbName updatedStaged)
+            persistUploadDepends manager dbName newDeps
             first setupErrorMessage <$> getDatabaseSetupInfo manager dbName
 
 -- | Finalize a staged database (build matrices and make it ready for queries)
@@ -2954,6 +2983,9 @@ finalizeDatabase manager dbName = withLogScope dbName $ do
                                 modifyTVar' (dmLoadedDbs manager) (M.insert dbName loaded)
                                 modifyTVar' (dmIndexedDbs manager) (M.insert dbName indexedDb)
                             clearMethodMappingCacheForDb manager dbName
+                            -- Finalizing is the moment the dependency pin becomes
+                            -- the database's own; record it where a restart reads.
+                            persistUploadDepends manager dbName (sdSelectedDeps staged)
 
                             -- Self-relink first against the current
                             -- dep set: a cached or staged build can

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1270,10 +1270,18 @@ persistUploadDepends manager dbName deps = do
                 let uploadRoot = uploadsDir </> T.unpack dbName
                 mMeta <- UploadedDB.readUploadMeta uploadRoot
                 case mMeta of
-                    Nothing -> pure ()
+                    Nothing ->
+                        -- Losing the pin silently is the very bug this exists
+                        -- to fix, so a missing meta.toml at least says so.
+                        reportProgress Warning $
+                            "No meta.toml under "
+                                <> uploadRoot
+                                <> "; the dependency pin of "
+                                <> T.unpack dbName
+                                <> " lives in memory only and is lost at restart"
                     Just meta -> UploadedDB.writeUploadMeta uploadRoot meta{UploadedDB.umDepends = deps}
                 atomically $
-                    modifyTVar' (dmAvailableDbs manager) (M.insert dbName dbConfig{dcDepends = deps})
+                    modifyTVar' (dmAvailableDbs manager) (M.adjust (\c -> c{dcDepends = deps}) dbName)
 
 {- | Discover uploaded methods from uploads/methods/ directory
 Reads meta.toml from each subdirectory and converts to MethodConfig

--- a/src/Database/UploadedDatabase.hs
+++ b/src/Database/UploadedDatabase.hs
@@ -48,6 +48,13 @@ data UploadMeta = UploadMeta
     , umDescription :: !(Maybe Text) -- Optional description
     , umFormat :: !DatabaseFormat -- Detected database format
     , umDataPath :: !FilePath -- Relative path to data within upload dir
+    , umDepends :: ![Text]
+    {- ^ Names of the databases this one draws suppliers from. The only durable
+    record of the pin: it otherwise lives in the staging registry and inside
+    the binary matrix cache, so a restart between staging and finalizing used
+    to lose it silently. A file written before this field existed reads back
+    with no dependencies, which is what it meant.
+    -}
     }
     deriving (Show, Eq, Generic)
 
@@ -138,7 +145,21 @@ parseMetaToml content = do
             , umDescription = description
             , umFormat = format
             , umDataPath = dataPath
+            , umDepends = maybe [] parseStringList (getValue "depends")
             }
+
+{- | Read a TOML inline array of strings, @["a", "b"]@. Entries that are not
+quoted strings are skipped rather than failing the whole file: the key is
+additive metadata, and a malformed dependency list must not make an otherwise
+good database undiscoverable.
+-}
+parseStringList :: Text -> [Text]
+parseStringList raw =
+    [ T.dropAround (== '"') item
+    | item <- map T.strip (T.splitOn "," (T.dropAround (`elem` ("[]" :: String)) (T.strip raw)))
+    , not (T.null item)
+    , T.isPrefixOf "\"" item
+    ]
 
 {- | Parse a format string to a DatabaseFormat.
 Inverse of 'formatMetaToml''s writer below — every slug it can write is read back
@@ -164,6 +185,7 @@ formatMetaToml UploadMeta{..} =
             ++ maybe [] (\d -> ["description = " <> quote d]) umDescription
             ++ [ "format = " <> quote (formatToText umFormat)
                , "dataPath = " <> quote (T.pack umDataPath)
+               , "depends = [" <> T.intercalate ", " (map quote umDepends) <> "]"
                ]
   where
     quote t = "\"" <> escapeToml t <> "\""

--- a/src/Database/UploadedDatabase.hs
+++ b/src/Database/UploadedDatabase.hs
@@ -151,7 +151,9 @@ parseMetaToml content = do
 {- | Read a TOML inline array of strings, @["a", "b"]@. Entries that are not
 quoted strings are skipped rather than failing the whole file: the key is
 additive metadata, and a malformed dependency list must not make an otherwise
-good database undiscoverable.
+good database undiscoverable. The writer's escapes (@\"@, @\\@) are not
+decoded, which is fine for database names: they are slugs and cannot contain
+either character.
 -}
 parseStringList :: Text -> [Text]
 parseStringList raw =

--- a/test/DeleteSelectionSpec.hs
+++ b/test/DeleteSelectionSpec.hs
@@ -34,6 +34,7 @@ import Config (DatabaseConfig (..), defaultConfig)
 import Data.Aeson (eitherDecode, encode)
 import Database (buildDatabaseWithMatrices)
 import Database.Edit (
+    DeleteOutcome (..),
     DeleteRequest (..),
     DeleteSelection (..),
     deleteActivities,
@@ -211,7 +212,7 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
             case r of
                 Left err -> expectationFailure ("deleteActivitiesInDB failed: " <> show err)
                 Right deleted -> do
-                    deleted `shouldBe` 1 -- two matched, one kept
+                    doRemoved deleted `shouldBe` 1 -- two matched, one kept
                     loaded <- readTVarIO (dmLoadedDbs manager)
                     let db' = ldDatabase (loaded M.! "edit-me")
                     dbActivityCount db' `shouldBe` 2
@@ -235,7 +236,7 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
         it "fails when the database is not loaded" $ do
             manager <- initDatabaseManager defaultConfig True Nothing
             r <- deleteActivitiesInDB manager "ghost" emptyDelete
-            r `shouldBe` Left "Database not loaded: ghost"
+            fmap doRemoved r `shouldBe` Left "Database not loaded: ghost"
 
         it "refuses to delete while a loaded database depends on it" $ do
             -- Deleting from "base" would renumber/remove activities that the loaded
@@ -265,7 +266,7 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
             case r of
                 Left err -> expectationFailure ("deleteActivitiesInDB failed: " <> show err)
                 Right deleted -> do
-                    deleted `shouldBe` 1
+                    doRemoved deleted `shouldBe` 1
                     loaded <- readTVarIO (dmLoadedDbs manager)
                     let db' = ldDatabase (loaded M.! "by-ids")
                     dbActivityCount db' `shouldBe` 2
@@ -320,7 +321,7 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
             case r of
                 Left err -> expectationFailure ("deleteActivitiesInDB failed: " <> show err)
                 Right deleted -> do
-                    deleted `shouldBe` 2 -- foodB and energy; foodA kept
+                    doRemoved deleted `shouldBe` 2 -- foodB and energy; foodA kept
                     loaded <- readTVarIO (dmLoadedDbs manager)
                     let db' = ldDatabase (loaded M.! "by-ids-5")
                     map activityName (V.toList (dbActivities db')) `shouldBe` ["food-A"]
@@ -335,7 +336,7 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
             r <- deleteActivitiesInDB manager "by-ids-6" emptyDelete{drIds = Just [], drExtra = [foodA]}
             case r of
                 Left err -> expectationFailure ("deleteActivitiesInDB failed: " <> show err)
-                Right deleted -> deleted `shouldBe` 1
+                Right deleted -> doRemoved deleted `shouldBe` 1
 
     describe "DeleteSelectionRequest wire compatibility" $ do
         it "decodes a request without the ids key (old clients)" $ do
@@ -402,7 +403,7 @@ mkConfig name =
         , dcDepends = []
         , dcLocationAliases = M.empty
         , dcFormat = Nothing
-        , dcIsUploaded = True
+        , dcIsUploaded = False
         , dcDeletable = True
         , dcGeographyPolicy = GeoGlobal
         }

--- a/test/PersistenceSpec.hs
+++ b/test/PersistenceSpec.hs
@@ -23,6 +23,7 @@ import Control.Concurrent.STM (atomically, modifyTVar')
 import Control.Exception (bracket_)
 import Data.List (sort)
 import qualified Data.Map.Strict as M
+import qualified Data.Set as Set
 import Data.Text (Text, isInfixOf)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
@@ -47,6 +48,8 @@ import Database.Manager (
     DatabaseManager (..),
     LoadedDatabase (..),
     initDatabaseManager,
+    loadDatabase,
+    unloadDatabase,
  )
 import Database.Upload (DatabaseFormat (..))
 import Database.UploadedDatabase (UploadMeta (..), readUploadMeta)
@@ -148,6 +151,55 @@ spec = describe "persisting an edit" $ do
                         listDirectory (home </> "data") >>= (`shouldSatisfy` ((== 1) . length))
                         doesFileExist (elsewhere </> "untouched.txt") `shouldReturn` True
                         listDirectory elsewhere `shouldReturn` ["untouched.txt"]
+
+        it "does not take a sibling's files for its own when its name is a prefix of theirs" $
+            -- Ownership is judged on path components: a database named "agri"
+            -- pointing at "agribalyse"'s data directory (a copy keeps its
+            -- source's path) must be given a home of its own, not rewrite the
+            -- sibling whose name it happens to prefix.
+            withDataDir $ \dataRoot -> do
+                manager <- initDatabaseManager defaultConfig True Nothing
+                db <- buildTwoActivityFixture
+                let siblingDir = dataRoot </> "uploads" </> "databases" </> "agribalyse" </> "data"
+                createDirectoryIfMissing True siblingDir
+                writeFile (siblingDir </> "untouched.spold") "the sibling's dataset"
+                install manager "agri" db (uploadedConfig "agri" siblingDir)
+                r <- mutateUploadedDatabase manager "agri" (dropSecond db)
+                case r of
+                    Left err -> expectationFailure ("mutateUploadedDatabase: " <> show err)
+                    Right outcome -> do
+                        moPersisted outcome `shouldBe` True
+                        listDirectory siblingDir `shouldReturn` ["untouched.spold"]
+                        meta <- readUploadMeta (dataRoot </> "uploads" </> "databases" </> "agri")
+                        fmap umDataPath meta `shouldBe` Just "data"
+
+        it "reloads to what was written, not to the pre-edit sources" $
+            -- The point of the whole path: unloading and loading again returns
+            -- the edited database, where it used to resurrect the original.
+            withDataDir $ \dataRoot -> do
+                manager <- initDatabaseManager defaultConfig True Nothing
+                db <- buildTwoActivityFixture
+                let dataDir = dataRoot </> "uploads" </> "databases" </> "reload-me" </> "data"
+                createDirectoryIfMissing True dataDir
+                install manager "reload-me" db (uploadedConfig "reload-me" dataDir)
+                r <- mutateUploadedDatabase manager "reload-me" (dropSecond db)
+                either (expectationFailure . ("mutateUploadedDatabase: " <>) . show) (const (pure ())) r
+                unloadDatabase manager "reload-me" `shouldReturn` Right ()
+                reloaded <- loadDatabase manager "reload-me"
+                case reloaded of
+                    Left err -> expectationFailure ("loadDatabase: " <> show err)
+                    Right (loaded, _) -> dbActivityCount (ldDatabase loaded) `shouldBe` 1
+
+        it "refuses a second edit while one is in progress" $
+            withDataDir $ \_ -> do
+                manager <- initDatabaseManager defaultConfig True Nothing
+                db <- buildTwoActivityFixture
+                install manager "busy" db (configuredConfig "busy")
+                atomically $ modifyTVar' (dmStagingDbs manager) (Set.insert "busy")
+                r <- mutateUploadedDatabase manager "busy" (dropSecond db)
+                case r of
+                    Left err -> err `shouldSatisfy` isInfixOf "already in progress"
+                    Right _ -> expectationFailure "expected the second edit to be refused"
 
         it "says an edit is not saved when the database is one the engine only reads" $
             withDataDir $ \dataRoot -> do

--- a/test/PersistenceSpec.hs
+++ b/test/PersistenceSpec.hs
@@ -1,0 +1,380 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{- | Tests for making an edit outlive the process
+('Database.Edit.mutateUploadedDatabase' and
+'Database.Export.serializeDatabaseFiles').
+
+Editing used to be transient by design: the sources and the matrix cache still
+held the pre-edit database, so an unload and reload deliberately undid the
+change. That is defensible for a database the engine reads from configuration
+and does not own, and wrong for one it does — a restart quietly resurrected
+every activity a user had removed.
+
+What follows pins the three decisions that make persistence honest: which
+formats may be written back (only those that record process identity), that a
+database with no files of its own is given a home rather than writing through
+to the database it was copied from, and that an edit which is not saved says
+so instead of looking like one that was.
+-}
+module PersistenceSpec (spec) where
+
+import Control.Concurrent.STM (atomically, modifyTVar')
+import Control.Exception (bracket_)
+import Data.List (sort)
+import qualified Data.Map.Strict as M
+import Data.Text (Text, isInfixOf)
+import qualified Data.Text as T
+import qualified Data.UUID as UUID
+import qualified Data.Vector.Unboxed as U
+import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist, listDirectory)
+import System.Environment (setEnv, unsetEnv)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+
+import Config (DatabaseConfig (..), defaultConfig)
+import Database (buildDatabaseWithMatrices)
+import Database.Edit (
+    DeleteRequest (..),
+    MutationOutcome (..),
+    deleteActivitiesInDB,
+    deleteActivitiesWith,
+    mutateUploadedDatabase,
+ )
+import Database.Export (serializeDatabaseFiles)
+import Database.Manager (
+    DatabaseManager (..),
+    LoadedDatabase (..),
+    initDatabaseManager,
+ )
+import Database.Upload (DatabaseFormat (..))
+import Database.UploadedDatabase (UploadMeta (..), readUploadMeta)
+import SharedSolver (SharedSolver, createSharedSolver)
+import Types (
+    Activity (..),
+    BioDirection (..),
+    BiosphereFlow (..),
+    Compartment (..),
+    Database (..),
+    Exchange (..),
+    GeographyPolicy (..),
+    LocationSource (..),
+    SparseTriple (..),
+    TechRole (..),
+    TechnosphereFlow (..),
+    UUID,
+    Unit (..),
+    findProcessId,
+ )
+import UnitConversion (defaultUnitConfig)
+
+spec :: Spec
+spec = describe "persisting an edit" $ do
+    describe "serializeDatabaseFiles" $ do
+        it "writes one EcoSpold 2 dataset per process, named by its identity" $ do
+            db <- buildFixture
+            case serializeDatabaseFiles EcoSpold2 db of
+                Left err -> expectationFailure ("expected EcoSpold 2 to be writable: " <> show err)
+                Right (entries, warnings) -> do
+                    warnings `shouldBe` []
+                    -- The name is the identity: the parser reads the pair back
+                    -- off it, which is the whole reason this format may be
+                    -- written in place.
+                    sort (map fst entries)
+                        `shouldBe` [T.unpack (UUID.toText supplierActId <> "_" <> UUID.toText supplierProdId) <> ".spold"]
+
+        it "refuses every format that would re-mint identity on read" $
+            -- Exporting to these stays available; writing a database back over
+            -- its own sources does not, because the rows that survive would
+            -- come back under different process ids after a restart, and every
+            -- reference anyone kept to them would point elsewhere.
+            mapM_
+                refusesIdentity
+                [(SimaProCSV, "SimaPro CSV"), (EcoSpold1, "EcoSpold 1"), (ILCDProcess, "ILCD"), (BrightwayExcel, "Brightway Excel")]
+
+        it "refuses the formats that have no writer at all" $ do
+            db <- buildFixture
+            fmap fst (serializeDatabaseFiles OpenLcaJsonLd db)
+                `shouldSatisfy` failsWith "not supported"
+            fmap fst (serializeDatabaseFiles UnknownFormat db)
+                `shouldSatisfy` failsWith "unknown format"
+
+    describe "mutateUploadedDatabase" $ do
+        it "rewrites the sources of a database that owns them" $
+            withDataDir $ \dataRoot -> do
+                manager <- initDatabaseManager defaultConfig True Nothing
+                db <- buildTwoActivityFixture
+                let dataDir = dataRoot </> "uploads" </> "databases" </> "own-files" </> "data"
+                createDirectoryIfMissing True dataDir
+                install manager "own-files" db (uploadedConfig "own-files" dataDir)
+                r <- mutateUploadedDatabase manager "own-files" (dropSecond db)
+                case r of
+                    Left err -> expectationFailure ("mutateUploadedDatabase: " <> show err)
+                    Right outcome -> do
+                        moPersisted outcome `shouldBe` True
+                        -- One process left, in a file named after its own
+                        -- identity: the deletion reached the sources, not only
+                        -- the copy of the database held in memory.
+                        listDirectory dataDir
+                            `shouldReturn` [T.unpack (keyText (supplierActId, supplierProdId)) <> ".spold"]
+                        -- Nothing of the staging or the previous generation is left behind.
+                        doesDirectoryExist (dataDir <> ".new") `shouldReturn` False
+                        doesDirectoryExist (dataDir <> ".old") `shouldReturn` False
+
+        it "gives a database with no files of its own a home instead of writing through" $
+            -- A copy shares the source's value without duplicating its
+            -- directory; writing through the shared path would edit a database
+            -- nobody asked to edit.
+            withDataDir $ \dataRoot -> do
+                manager <- initDatabaseManager defaultConfig True Nothing
+                db <- buildTwoActivityFixture
+                let elsewhere = dataRoot </> "somebody-elses" </> "data"
+                createDirectoryIfMissing True elsewhere
+                writeFile (elsewhere </> "untouched.txt") "the source of the copy"
+                install manager "the-copy" db{dbDependsOn = ["background"]} (uploadedConfig "the-copy" elsewhere)
+                r <- mutateUploadedDatabase manager "the-copy" (dropSecond db)
+                case r of
+                    Left err -> expectationFailure ("mutateUploadedDatabase: " <> show err)
+                    Right outcome -> do
+                        moPersisted outcome `shouldBe` True
+                        let home = dataRoot </> "uploads" </> "databases" </> "the-copy"
+                        meta <- readUploadMeta home
+                        fmap umFormat meta `shouldBe` Just EcoSpold2
+                        fmap umDataPath meta `shouldBe` Just "data"
+                        -- The dependency pin is written down, not left to the
+                        -- binary cache that a restart may not read.
+                        fmap umDepends meta `shouldBe` Just ["background"]
+                        listDirectory (home </> "data") >>= (`shouldSatisfy` ((== 1) . length))
+                        doesFileExist (elsewhere </> "untouched.txt") `shouldReturn` True
+                        listDirectory elsewhere `shouldReturn` ["untouched.txt"]
+
+        it "says an edit is not saved when the database is one the engine only reads" $
+            withDataDir $ \dataRoot -> do
+                manager <- initDatabaseManager defaultConfig True Nothing
+                db <- buildTwoActivityFixture
+                install manager "configured" db (configuredConfig "configured")
+                r <- mutateUploadedDatabase manager "configured" (dropSecond db)
+                case r of
+                    Left err -> expectationFailure ("mutateUploadedDatabase: " <> show err)
+                    Right outcome -> do
+                        moPersisted outcome `shouldBe` False
+                        -- No home was made for it: a configured database owns its
+                        -- files through the config file, and the engine writes none.
+                        listDirectory (dataRoot </> "uploads" </> "databases") `shouldReturn` []
+
+        it "refuses while another loaded database depends on this one" $
+            withDataDir $ \_ -> do
+                manager <- initDatabaseManager defaultConfig True Nothing
+                db <- buildTwoActivityFixture
+                install manager "background" db (configuredConfig "background")
+                install manager "foreground" db{dbDependsOn = ["background"]} (configuredConfig "foreground")
+                r <- mutateUploadedDatabase manager "background" (dropSecond db)
+                case r of
+                    Left err -> err `shouldSatisfy` isInfixOf "still required by"
+                    Right _ -> expectationFailure "expected the edit to be refused while a dependent is loaded"
+
+    describe "deleteActivitiesInDB" $
+        it "refuses to write a deletion back in a format that cannot record identity" $
+            withDataDir $ \dataRoot -> do
+                manager <- initDatabaseManager defaultConfig True Nothing
+                db <- buildTwoActivityFixture
+                let dataDir = dataRoot </> "uploads" </> "databases" </> "simapro-db" </> "data"
+                createDirectoryIfMissing True dataDir
+                install manager "simapro-db" db (uploadedConfig "simapro-db" dataDir){dcFormat = Just SimaProCSV}
+                r <- deleteActivitiesInDB manager "simapro-db" (deleteIds [keyText (supplierActId, supplierProdId)])
+                case r of
+                    Left err -> err `shouldSatisfy` isInfixOf "does not record process identifiers"
+                    Right _ -> expectationFailure "expected the deletion to be refused rather than silently unsaved"
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+
+failsWith :: Text -> Either Text a -> Bool
+failsWith needle = either (isInfixOf needle) (const False)
+
+refusesIdentity :: (DatabaseFormat, Text) -> Expectation
+refusesIdentity (fmt, label) = do
+    db <- buildFixture
+    case serializeDatabaseFiles fmt db of
+        Right _ -> expectationFailure (T.unpack label <> " should be refused for writing in place")
+        Left err -> do
+            err `shouldSatisfy` isInfixOf label
+            err `shouldSatisfy` isInfixOf "does not record process identifiers"
+
+{- | Point the engine's data directory at a scratch tree for the duration of
+one example, so nothing is written next to the sources.
+-}
+withDataDir :: (FilePath -> IO ()) -> IO ()
+withDataDir act =
+    withSystemTempDirectory "volca-persist" $ \dir ->
+        bracket_ (setEnv "VOLCA_DATA_DIR" dir) (unsetEnv "VOLCA_DATA_DIR") (act dir)
+
+keyText :: (UUID, UUID) -> Text
+keyText (a, p) = UUID.toText a <> "_" <> UUID.toText p
+
+{- | Remove the second activity of the two-activity fixture: any edit will do
+here, and a deletion is the one every database supports, so these examples pin
+the mutation path itself rather than what happened to be edited.
+-}
+dropSecond :: Database -> Database -> Either Text Database
+dropSecond fixture db = case findProcessId fixture otherActId supplierProdId of
+    Nothing -> Left "fixture: the activity to delete is not in it"
+    Just pid -> deleteActivitiesWith defaultUnitConfig [pid] db
+
+deleteIds :: [Text] -> DeleteRequest
+deleteIds ids =
+    DeleteRequest
+        { drName = Nothing
+        , drLocation = Nothing
+        , drProduct = Nothing
+        , drClassifications = []
+        , drExactName = False
+        , drKeep = []
+        , drExtra = []
+        , drIds = Just ids
+        }
+
+install :: DatabaseManager -> Text -> Database -> DatabaseConfig -> IO ()
+install manager name db config = do
+    solver <- mkSolver name db
+    let loaded = LoadedDatabase{ldDatabase = db, ldSharedSolver = solver, ldConfig = config}
+    atomically $ do
+        modifyTVar' (dmLoadedDbs manager) (M.insert name loaded)
+        modifyTVar' (dmAvailableDbs manager) (M.insert name config)
+
+mkSolver :: Text -> Database -> IO SharedSolver
+mkSolver name db =
+    let triples = [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList (dbTechnosphereTriples db)]
+     in createSharedSolver name triples (fromIntegral (dbActivityCount db))
+
+baseConfig :: Text -> DatabaseConfig
+baseConfig name =
+    DatabaseConfig
+        { dcName = name
+        , dcDisplayName = name
+        , dcPath = ""
+        , dcDescription = Nothing
+        , dcLoad = True
+        , dcDefault = False
+        , dcDepends = []
+        , dcLocationAliases = M.empty
+        , dcFormat = Just EcoSpold2
+        , dcIsUploaded = False
+        , dcDeletable = True
+        , dcGeographyPolicy = GeoGlobal
+        }
+
+uploadedConfig :: Text -> FilePath -> DatabaseConfig
+uploadedConfig name dataDir = (baseConfig name){dcPath = dataDir, dcIsUploaded = True}
+
+configuredConfig :: Text -> DatabaseConfig
+configuredConfig = baseConfig
+
+-- ---------------------------------------------------------------------------
+-- Fixture
+-- ---------------------------------------------------------------------------
+
+buildFixture :: IO Database
+buildFixture = buildFrom (M.singleton (supplierActId, supplierProdId) (milkActivity "milk production"))
+
+buildTwoActivityFixture :: IO Database
+buildTwoActivityFixture =
+    buildFrom $
+        M.fromList
+            [ ((supplierActId, supplierProdId), milkActivity "milk production")
+            , ((otherActId, supplierProdId), milkActivity "milk production, organic")
+            ]
+
+buildFrom :: M.Map (UUID, UUID) Activity -> IO Database
+buildFrom activities = do
+    r <-
+        buildDatabaseWithMatrices
+            defaultUnitConfig
+            activities
+            (M.singleton supplierProdId milkFlow)
+            (M.singleton co2Id co2Flow)
+            M.empty
+            unitTable
+    either (fail . show) pure r
+
+mkUUID :: Int -> UUID
+mkUUID n = UUID.fromWords64 (fromIntegral n) 0
+
+supplierActId, otherActId, supplierProdId, co2Id, kgUnitId :: UUID
+supplierActId = mkUUID 1
+otherActId = mkUUID 4
+supplierProdId = mkUUID 2
+co2Id = mkUUID 3
+kgUnitId = mkUUID 10
+
+unitTable :: M.Map UUID Unit
+unitTable = M.singleton kgUnitId Unit{unitId = kgUnitId, unitName = "kg", unitSymbol = "kg", unitComment = ""}
+
+milkFlow :: TechnosphereFlow
+milkFlow =
+    TechnosphereFlow
+        { tfId = supplierProdId
+        , tfName = "milk"
+        , tfUnitId = kgUnitId
+        , tfSynonyms = M.empty
+        , tfCAS = Nothing
+        , tfSubstanceId = Nothing
+        }
+
+air :: Compartment
+air = Compartment{compartmentName = "air", compartmentSub = Nothing}
+
+co2Flow :: BiosphereFlow
+co2Flow =
+    BiosphereFlow
+        { bfId = co2Id
+        , bfName = "Carbon dioxide"
+        , bfUnitId = kgUnitId
+        , bfSynonyms = M.empty
+        , bfCAS = Just "124-38-9"
+        , bfSubstanceId = Nothing
+        , bfCompartment = Just air
+        }
+
+milkActivity :: Text -> Activity
+milkActivity name =
+    Activity
+        { activityName = name
+        , activityDescription = []
+        , activitySynonyms = M.empty
+        , activityClassification = M.empty
+        , activityLocation = "FR"
+        , activityLocationSource = LocationDeclared
+        , activityUnit = "kg"
+        , exchanges =
+            [ TechnosphereExchange
+                { techFlowId = supplierProdId
+                , techAmount = 1.0
+                , techUnitId = kgUnitId
+                , techRole = ReferenceProduct
+                , techActivityLinkId = supplierActId
+                , techProcessLinkId = Nothing
+                , techLocation = ""
+                , techComment = Nothing
+                , techPedigree = Nothing
+                }
+            , BiosphereExchange
+                { bioFlowId = co2Id
+                , bioAmount = 1.2
+                , bioUnitId = kgUnitId
+                , bioDirection = Emission
+                , bioLocation = ""
+                , bioComment = Nothing
+                , bioPedigree = Nothing
+                }
+            ]
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
+        , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
+        }

--- a/test/UploadedDatabaseSpec.hs
+++ b/test/UploadedDatabaseSpec.hs
@@ -17,6 +17,7 @@ baseMeta =
         , umDescription = Nothing
         , umFormat = EcoSpold2
         , umDataPath = "data"
+        , umDepends = []
         }
 
 spec :: Spec
@@ -90,6 +91,7 @@ spec = do
                         , umDescription = Nothing
                         , umFormat = EcoSpold2
                         , umDataPath = "data"
+                        , umDepends = []
                         }
 
         it "parses meta with description" $ do
@@ -125,6 +127,17 @@ spec = do
         it "round-trips a path with spaces" $ do
             let meta = baseMeta{umDataPath = "my data/sub dir"}
             fmap umDataPath (parseMetaToml (formatMetaToml meta)) `shouldBe` Just "my data/sub dir"
+
+        it "round-trips the dependency pin" $ do
+            -- The only durable record of which databases this one draws
+            -- suppliers from; it otherwise lived in the staging registry and
+            -- the binary cache, so a restart lost it without saying so.
+            let meta = baseMeta{umDepends = ["agribalyse", "ecoinvent"]}
+            fmap umDepends (parseMetaToml (formatMetaToml meta)) `shouldBe` Just ["agribalyse", "ecoinvent"]
+
+        it "reads a file written before the dependency pin existed as pinning nothing" $ do
+            let toml = "version = 1\ndisplayName = \"DB\"\nformat = \"ecospold2\"\ndataPath = \"data\"\n"
+            fmap umDepends (parseMetaToml toml) `shouldBe` Just []
 
     -- -----------------------------------------------------------------------
     -- readUploadMeta / writeUploadMeta (IO roundtrip)

--- a/volca.cabal
+++ b/volca.cabal
@@ -321,6 +321,7 @@ test-suite lca-tests
                      , AggregateSpec
                      , CopySpec
                      , AuthorSpec
+                     , PersistenceSpec
                      , DeleteSelectionSpec
                      , ExportSpec
                      , ExportHandlerSpec


### PR DESCRIPTION
## Why

Editing was transient by design: after a delete, the sources and the matrix
cache still held the pre-edit database, so unloading and reloading undid the
change. That is right for a database the engine reads from its configuration
and does not own. It is wrong for one it does — a restart quietly resurrected
every activity a user had removed, and nothing said so.

## What changes

Every mutation of a database the engine owns now goes through one
prepare-then-commit path. Everything that can fail runs before anything is
visible: the dependent guard, the pure edit, serializing the result, and
writing it into a staging directory beside the live one. Only then are the
sources swung into place and the registry swapped, followed by a relink and a
cache save so a reload returns what was written. A failure anywhere before the
swap leaves memory and disk exactly as they were.

The two renames are not jointly atomic: a crash between them leaves the
previous sources under `.old`, which is recoverable by hand and was worth
preferring to a copy of the whole database.

## Only EcoSpold 2 is written back

Its files are named `activityUUID_productUUID.spold` and its parser reads the
pair straight off the name, so every process id survives a save and a reload.
The other writers re-derive identity from names on read: stable for rows that
came from a file, but the rows that survive a deletion would come back under
different ids, and every reference anyone kept to them would point elsewhere —
silently, and only after a restart. Writing those formats back is refused with
a message naming the conversion.

Exporting is untouched: an export is a copy that leaves the original in place,
and every writer still accepts every database.

## A copy gets a home

Copying shares the source's value without duplicating its directory, so a copy
has no files of its own and its recorded path still points at the source's.
Writing through that path would edit a database nobody asked to edit. The first
save gives the copy a directory of its own instead, and the source is never
touched.

## Two smaller things

`meta.toml` gains the dependency pin. It previously lived only in the staging
registry and inside the binary cache, so a restart between choosing a
dependency and finalizing lost it and the database came back linked to nothing.
A `meta.toml` written before this reads back with no dependencies, as it did.

The delete response gains `transient` and `warnings`: "deleted 12 activities"
from a database that will forget them is not a true sentence without them.
