### PR TITLE
Fold the accessor into the ServerName newtype

### DIFF
--- a/src/Config.hs
+++ b/src/Config.hs
@@ -7,7 +7,6 @@ module Config (
     Config (..),
     ServerConfig (..),
     ServerName (..),
-    unServerName,
     DatabaseConfig (..),
     MethodConfig (..),
     ScoringSetConfig (..),
@@ -150,11 +149,8 @@ readOnlyRefusal = "This instance is read-only: it answers queries but changes no
 {- | How this instance introduces itself. A client may hold several VoLCA
 servers at once; the name is what tells them apart.
 -}
-newtype ServerName = ServerName Text
+newtype ServerName = ServerName {unServerName :: Text}
     deriving (Show, Eq, Generic)
-
-unServerName :: ServerName -> Text
-unServerName (ServerName n) = n
 
 -- | Server configuration
 data ServerConfig = ServerConfig

--- a/test/MCPDispatchSpec.hs
+++ b/test/MCPDispatchSpec.hs
@@ -9,7 +9,7 @@ module MCPDispatchSpec (spec) where
 
 import Control.Monad (forM_)
 import Data.Aeson (Value (..), decodeStrict)
-import Data.Aeson.Key (fromString)
+import Data.Aeson.Key (fromText)
 import qualified Data.Aeson.KeyMap as KM
 import Data.Foldable (toList)
 import qualified Data.Map as M
@@ -259,5 +259,5 @@ instructionsOf v = case field "result" v >>= field "instructions" of
     _ -> Nothing
 
 field :: Text -> Value -> Maybe Value
-field k (Object o) = KM.lookup (fromString (T.unpack k)) o
+field k (Object o) = KM.lookup (fromText k) o
 field _ _ = Nothing


### PR DESCRIPTION
Review follow-up to #276, whose automerge fired before these two small fixes reached the branch.

The sibling ReadOnly newtype in the same module already uses a record accessor, so ServerName now does the same instead of carrying a separate unpacking function. The test helper builds its JSON key with fromText rather than a pack/unpack round trip.

No behaviour change; the four handleInitialize tests still pass.