### PR TITLE
Let a client write activities, over HTTP and from the command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 ## [Unreleased]
 
 ### Added
+- Activities can be written into a database you uploaded or copied, instead of
+  only deleted from it. `POST /api/v1/db/{db}/activities` adds them,
+  `PUT /api/v1/db/{db}/activity/{process-id}` rewrites one, and
+  `volca database create-activities` / `replace-activity` do the same from the
+  command line reading the same JSON document. You never supply a process id:
+  it is derived from the activity name, location, product name and product
+  unit, so writing the same description twice corrects one activity rather than
+  making two. Writing is strict where importing is tolerant - a supplier that
+  does not resolve, an amount that is not a finite number, a unit that cannot
+  reach the supplier's are all refused, and a batch comes back with every
+  complaint at once rather than one per round trip. A database the engine reads
+  from its configuration is refused outright: it is background data the whole
+  installation shares. This is wire revision 5.
 - A server can say what it is called. `name` in `[server]` is repeated in the
   MCP handshake, both in `serverInfo` and in the first line of the
   instructions an assistant reads. Someone connecting several VoLCA servers

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -127,7 +127,7 @@ import API.Types (
     SynonymGroupsResponse (..),
     UploadChunk (..),
     UploadResponse (..),
-    toAuthoredActivity,
+    toAuthoredActivities,
  )
 import App.Env (AppEnv (..), AppM)
 import Config (DatabaseConfig (..), HostingConfig (..), MethodConfig (..), ReadOnly (..), RefDataConfig (..), hostingReadOnly, readOnlyRefusal)
@@ -569,7 +569,7 @@ runWrite :: Text -> WriteVerb -> [ActivityInput] -> AppM ActivityWriteResponse
 runWrite dbName verb inputs = do
     guardMutation
     dbManager <- asks aeDbManager
-    authored <- either (writeErr err400) pure (traverse toAuthoredActivity inputs)
+    authored <- either (writeErr err400 . T.intercalate "\n") pure (toAuthoredActivities inputs)
     outcome <- liftIO (writeActivities dbManager dbName verb authored)
     case outcome of
         Left refusal -> writeErr (statusFor refusal) (refusalMessage refusal)

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -26,6 +27,8 @@ module API.DatabaseHandlers (
     copyDatabaseHandler,
     deleteDatabaseHandler,
     deleteActivitiesHandler,
+    createActivitiesHandler,
+    replaceActivityHandler,
     exportDatabaseHandler,
     exportMethodHandler,
     uploadDatabaseHandler,
@@ -79,7 +82,7 @@ import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as T
 import Data.Word (Word64)
 import Network.HTTP.Types.URI (urlEncode)
-import Servant (Header, Headers, ServerError, SourceIO, addHeader, err400, err403, err404, err500, errBody, throwError)
+import Servant (Header, Headers, ServerError, SourceIO, addHeader, err400, err403, err404, err409, err500, errBody, throwError)
 import qualified Servant.Types.SourceT as S
 import qualified System.Directory
 import System.FilePath ((</>))
@@ -95,6 +98,9 @@ import qualified Database.ComputedQuality as CQ
 
 import API.Types (
     ActivateResponse (..),
+    ActivityInput (..),
+    ActivityWriteRequest (..),
+    ActivityWriteResponse (..),
     BinaryContent (..),
     BridgeGroupAPI (..),
     BridgedFlowAPI (..),
@@ -121,6 +127,7 @@ import API.Types (
     SynonymGroupsResponse (..),
     UploadChunk (..),
     UploadResponse (..),
+    toAuthoredActivity,
  )
 import App.Env (AppEnv (..), AppM)
 import Config (DatabaseConfig (..), HostingConfig (..), MethodConfig (..), ReadOnly (..), RefDataConfig (..), hostingReadOnly, readOnlyRefusal)
@@ -132,7 +139,17 @@ import qualified Data.Aeson.KeyMap as KM
 import Data.Maybe (fromMaybe)
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
-import Database.Edit (DeleteOutcome (..), DeleteRequest (..), copyDatabase, deleteActivitiesInDB)
+import Database.Edit (
+    DeleteOutcome (..),
+    DeleteRequest (..),
+    WriteRefusal (..),
+    WriteReport (..),
+    WriteVerb (..),
+    copyDatabase,
+    deleteActivitiesInDB,
+    refusalMessage,
+    writeActivities,
+ )
 import Database.Export (parseExportFormat, parseMethodExportFormat, serializeDatabase, serializeMethodCollection)
 import qualified Database.Loader as Loader
 import Database.Manager (
@@ -196,7 +213,12 @@ import Database.Upload (
 import qualified Database.UploadedDatabase as UploadedDB
 import qualified Method.Coverage as Coverage
 import Method.Mapping (MatchStrategy (..))
-import Types (Database (..), GeographyPolicy (..), blockerReasonDetail, unresolvedCount)
+import Types (
+    Database (..),
+    GeographyPolicy (..),
+    blockerReasonDetail,
+    unresolvedCount,
+ )
 
 -- | List all databases
 getDatabases :: AppM DatabaseListResponse
@@ -524,6 +546,53 @@ deleteActivitiesHandler dbName req = do
                     (doRemoved outcome)
                     (not (doPersisted outcome))
                     (doWarnings outcome)
+
+{- | Write new activities into a loaded database.
+
+The domain decides what is allowed ('Database.Edit.writeActivities'); this
+turns each refusal into the status a client can act on. A key that already
+exists is a 409 — the author is re-describing a row the database holds and
+wants the PUT — and a batch a caller can fix is a 400 carrying every complaint
+at once, so a ten-line inventory is fixed in one round trip.
+-}
+createActivitiesHandler :: Text -> ActivityWriteRequest -> AppM ActivityWriteResponse
+createActivitiesHandler dbName req = runWrite dbName CreateActivities (awrActivities req)
+
+{- | Rewrite one activity the database already holds, keeping its identity. A
+@process_id@ the database does not hold is a 404.
+-}
+replaceActivityHandler :: Text -> Text -> ActivityInput -> AppM ActivityWriteResponse
+replaceActivityHandler dbName processId body =
+    runWrite dbName (ReplaceActivity processId) [body]
+
+runWrite :: Text -> WriteVerb -> [ActivityInput] -> AppM ActivityWriteResponse
+runWrite dbName verb inputs = do
+    guardMutation
+    dbManager <- asks aeDbManager
+    authored <- either (writeErr err400) pure (traverse toAuthoredActivity inputs)
+    outcome <- liftIO (writeActivities dbManager dbName verb authored)
+    case outcome of
+        Left refusal -> writeErr (statusFor refusal) (refusalMessage refusal)
+        Right report ->
+            pure
+                ActivityWriteResponse
+                    { awpWritten = wrWritten report
+                    , awpTransient = not (wrPersisted report)
+                    , awpWarnings = wrWarnings report
+                    }
+
+-- | One status per refusal, so a client never has to read the message to branch.
+statusFor :: WriteRefusal -> ServerError
+statusFor = \case
+    NotLoaded _ -> err404
+    NotWritable _ -> err400
+    Malformed _ -> err400
+    AlreadyPresent _ -> err409
+    NotPresent _ -> err404
+    WriteFailed _ -> err400
+
+writeErr :: ServerError -> Text -> AppM a
+writeErr status message = throwError status{errBody = BSL.fromStrict (T.encodeUtf8 message)}
 
 {- | Export a loaded database as a raw octet-stream body — the same shape the
 upload endpoint reads, and the only response cheap enough for a multi-hundred-MB

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -10,7 +10,7 @@ module API.Routes where
 import API.DatabaseHandlers (simpleAction)
 import qualified API.DatabaseHandlers as DBHandlers
 import qualified API.OpenApi
-import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivitySummary (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), CollectionCoverage (..), ComputedQualityReportAPI (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CoverageReportAPI (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExportRequest (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GapReportAPI (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), QualityReportAPI (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadChunk (..), UploadResponse (..), apiFlowOfKind)
+import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivityInput (..), ActivitySummary (..), ActivityWriteRequest (..), ActivityWriteResponse (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), CollectionCoverage (..), ComputedQualityReportAPI (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CoverageReportAPI (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExportRequest (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GapReportAPI (..), GraphExport (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), QualityReportAPI (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadChunk (..), UploadResponse (..), apiFlowOfKind)
 import App.Env (AppEnv (..), AppM, runApp)
 import qualified Config
 import Control.Concurrent.Async (mapConcurrently)
@@ -137,6 +137,11 @@ type LCAAPI =
                 :<|> "db" :> Capture "dbName" Text :> Delete '[JSON] ActivateResponse
                 -- Delete the whole filtered set of activities (selection in JSON body)
                 :<|> "db" :> Capture "dbName" Text :> "delete" :> ReqBody '[JSON] DeleteSelectionRequest :> Post '[JSON] DeleteSelectionResponse
+                -- Write activities. POST adds to the collection, PUT rewrites the one
+                -- addressed — never both, so a mistyped identity fails instead of
+                -- quietly becoming a duplicate of the row it meant to correct.
+                :<|> "db" :> Capture "dbName" Text :> "activities" :> ReqBody '[JSON] ActivityWriteRequest :> Post '[JSON] ActivityWriteResponse
+                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> ReqBody '[JSON] ActivityInput :> Put '[JSON] ActivityWriteResponse
                 -- Export a loaded database as raw bytes in the requested format;
                 -- approximation warnings travel percent-encoded in a response header
                 :<|> "db" :> Capture "dbName" Text :> "export" :> ReqBody '[JSON] ExportRequest :> Post '[OctetStream] (Headers '[Header "X-Volca-Export-Warnings" Text] BinaryContent)
@@ -1222,13 +1227,15 @@ appears that a client must know about /before/ calling it. Adding a route
 does not exempt a change from the bump: an absent route answers 404, and so
 does a request naming a database the engine has not loaded, so a client
 cannot tell "this engine is too old" from "you asked for the wrong thing"
-(revision 4: the quality-report, computed-quality-report and
-characterization-coverage routes; revision 3: the delete @ids@ selection,
-which an older engine would ignore and fall back to the whole filtered set).
+(revision 5: writing activities, and the @transient@ / @warnings@ fields the
+delete response gained alongside it; revision 4: the quality-report,
+computed-quality-report and characterization-coverage routes; revision 3: the
+delete @ids@ selection, which an older engine would ignore and fall back to
+the whole filtered set).
 Clients compare it to decide compatibility and to gate such capabilities.
 -}
 currentWireVersion :: Int
-currentWireVersion = 4
+currentWireVersion = 5
 
 getVersion :: AppM Value
 getVersion =
@@ -2139,6 +2146,8 @@ lcaServer env = hoistServer lcaAPI (runApp env) handlers
             :<|> DBHandlers.copyDatabaseHandler
             :<|> DBHandlers.deleteDatabaseHandler
             :<|> DBHandlers.deleteActivitiesHandler
+            :<|> DBHandlers.createActivitiesHandler
+            :<|> DBHandlers.replaceActivityHandler
             :<|> DBHandlers.exportDatabaseHandler
             :<|> DBHandlers.uploadDatabaseHandler
             :<|> DBHandlers.getDatabaseSetupHandler

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -17,15 +17,22 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.HashMap.Strict.InsOrd as InsOrdHashMap
 import qualified Data.Map as M
+import Data.Maybe (fromMaybe)
 import Data.OpenApi (NamedSchema (..), OpenApiType (..), Referenced (..), ToSchema (..), binarySchema, declareSchemaRef, enum_, format, nullable, properties, required, type_)
 import qualified Data.OpenApi.Lens as OA
 import Data.Proxy (Proxy (..))
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.UUID as UUID
+import Database.Author (
+    AuthoredActivity (..),
+    AuthoredExchange (..),
+    FlowRef (..),
+ )
 import GHC.Generics
 import Servant.API.ContentTypes (MimeRender (..), MimeUnrender (..), OctetStream)
-import Types (BiosphereFlow (..), Compartment, Exchange, FlowKind (..), NativeActivityType (..), Pedigree, Severity, TechnosphereFlow (..), UUID, Unit, WasteFlow (..))
+import Types (BioDirection (..), BiosphereFlow (..), Compartment (..), Exchange, FlowKind (..), NativeActivityType (..), Pedigree, Severity, TechnosphereFlow (..), UUID, Unit, WasteFlow (..))
 
 {- | Tagged wire representation of either side of the flow split.
 
@@ -960,6 +967,107 @@ spares selected process ids and @dsqExtra@ adds ones the selection missed.
 Process ids are the canonical @activityUUID_productUUID@ strings the UI/CLI
 carry, not matrix indices.
 -}
+
+{- | One technosphere input: a product this activity consumes, named by the
+process that supplies it.
+
+@tiProvider@ is a @process_id@ (@activityUUID_productUUID@, or a bare activity
+UUID when that activity has a single product) — the same currency the read
+endpoints hand out. The flow follows from the supplier, so it is never stated
+separately. @tiUnit@ defaults to the supplier's own reference unit; stating
+another one is allowed as long as it converts.
+-}
+data TechInputAPI = TechInputAPI
+    { tiProvider :: Text
+    , tiAmount :: Double
+    , tiUnit :: Maybe Text
+    , tiComment :: Maybe Text
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped TechInputAPI)
+
+{- | One biosphere exchange: a resource taken from the environment or an
+emission released into it.
+
+Either @beFlow@ names a flow already in the vocabulary by its identifier, or
+@beName@ + @beCompartment@ introduce one. Giving both is refused rather than
+guessed at. A biosphere amount is never converted, so an exchange on an
+existing flow must be stated in that flow's own unit.
+-}
+data BioExchangeAPI = BioExchangeAPI
+    { beFlow :: Maybe Text
+    , beName :: Maybe Text
+    , beCompartment :: Maybe Text
+    , beSubCompartment :: Maybe Text
+    , beDirection :: Text
+    -- ^ @resource@ (taken from the environment) or @emission@ (released into it)
+    , beAmount :: Double
+    , beUnit :: Maybe Text
+    , beComment :: Maybe Text
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped BioExchangeAPI)
+
+{- | One waste output: a residue this activity hands to a treatment process.
+@woProvider@ names that treatment process, exactly as a technosphere input
+names its producer.
+-}
+data WasteOutputAPI = WasteOutputAPI
+    { woProvider :: Text
+    , woAmount :: Double
+    , woUnit :: Maybe Text
+    , woComment :: Maybe Text
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped WasteOutputAPI)
+
+{- | An activity as a client writes it.
+
+The inventory arrives as three lists rather than one tagged list, so a field
+that makes sense for a supplier link cannot be sent on an emission and back
+again. One reference product per activity: coproducts and allocation are a
+later phase, and this shape does not pretend to accept them.
+
+Identity is not sent. It is minted from the name, location, product and unit
+below, so writing the same activity twice addresses the same row instead of
+creating a second one.
+-}
+data ActivityInput = ActivityInput
+    { aiName :: Text
+    , aiLocation :: Text
+    , aiDescription :: [Text]
+    , aiProductName :: Text
+    , aiProductAmount :: Double
+    , aiProductUnit :: Text
+    , aiInputs :: [TechInputAPI]
+    , aiBiosphere :: [BioExchangeAPI]
+    , aiWasteOutputs :: [WasteOutputAPI]
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped ActivityInput)
+
+-- | A batch of activities to write.
+newtype ActivityWriteRequest = ActivityWriteRequest
+    { awrActivities :: [ActivityInput]
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped ActivityWriteRequest)
+
+{- | What a write produced: the process ids now addressable, whether they
+survive an unload, and everything the engine wants the author to know but did
+not refuse over.
+-}
+data ActivityWriteResponse = ActivityWriteResponse
+    { awpWritten :: [Text]
+    , awpTransient :: Bool
+    {- ^ True when the write lives in memory only, because the database is one
+    the engine reads from configuration rather than owns.
+    -}
+    , awpWarnings :: [Text]
+    }
+    deriving (Generic)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped ActivityWriteResponse)
+
 data DeleteSelectionRequest = DeleteSelectionRequest
     { dsqName :: Maybe Text -- Filter by activity name
     , dsqLocation :: Maybe Text -- Filter by location
@@ -1545,3 +1653,78 @@ instance MimeUnrender OctetStream UploadChunk where
 
 instance ToSchema UploadChunk where
     declareNamedSchema _ = pure $ NamedSchema (Just "UploadChunk") binarySchema
+
+-- ---------------------------------------------------------------------------
+-- Wire → authoring input
+-- ---------------------------------------------------------------------------
+
+{- | Translate one request activity into the authoring input. Shared by the
+HTTP endpoints and the command line, which read the same JSON document.
+
+The only thing that can fail here is a biosphere line that names its flow in
+two ways at once or in none: everything else is a value the validator judges.
+-}
+toAuthoredActivity :: ActivityInput -> Either Text AuthoredActivity
+toAuthoredActivity ai = do
+    bio <- traverse toBio (aiBiosphere ai)
+    pure
+        AuthoredActivity
+            { aaName = aiName ai
+            , aaLocation = aiLocation ai
+            , aaDescription = aiDescription ai
+            , aaProductName = aiProductName ai
+            , aaProductAmount = aiProductAmount ai
+            , aaProductUnit = aiProductUnit ai
+            , aaExchanges = map toTechInput (aiInputs ai) <> bio <> map toWasteOutput (aiWasteOutputs ai)
+            }
+  where
+    toTechInput ti =
+        AuthoredTechInput
+            { atiProvider = tiProvider ti
+            , atiAmount = tiAmount ti
+            , atiUnit = tiUnit ti
+            , atiComment = tiComment ti
+            }
+    toWasteOutput wo =
+        AuthoredWasteOutput
+            { awProvider = woProvider wo
+            , awAmount = woAmount wo
+            , awUnit = woUnit wo
+            , awComment = woComment wo
+            }
+    toBio be = do
+        flow <- bioFlowRef be
+        direction <- bioDirection (beDirection be)
+        pure
+            AuthoredBio
+                { abFlow = flow
+                , abDirection = direction
+                , abAmount = beAmount be
+                , abUnit = beUnit be
+                , abComment = beComment be
+                }
+
+{- | A biosphere line names an existing flow by identifier, or introduces one
+by name and compartment. Both at once is ambiguous and neither says nothing,
+so both are refused instead of picking a winner.
+-}
+bioFlowRef :: BioExchangeAPI -> Either Text FlowRef
+bioFlowRef be = case (beFlow be, beName be) of
+    (Just _, Just _) -> Left "a biosphere exchange names either an existing flow or a new one, not both"
+    (Nothing, Nothing) -> Left "a biosphere exchange needs either a flow identifier or a name and compartment"
+    (Just flowId, Nothing) ->
+        maybe (Left ("not a flow identifier: " <> flowId)) (Right . ExistingFlow) (UUID.fromText flowId)
+    (Nothing, Just name) -> case beCompartment be of
+        Nothing -> Left ("biosphere flow \"" <> name <> "\" needs a compartment (air, water, soil, natural resource)")
+        Just medium ->
+            Right $
+                NewBioFlow
+                    name
+                    Compartment{compartmentName = medium, compartmentSub = beSubCompartment be}
+                    (fromMaybe "" (beUnit be))
+
+bioDirection :: Text -> Either Text BioDirection
+bioDirection raw = case T.toLower (T.strip raw) of
+    "resource" -> Right Resource
+    "emission" -> Right Emission
+    other -> Left ("unknown biosphere direction: " <> other <> " (expected resource|emission)")

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -15,9 +15,9 @@ import Data.Aeson
 import Data.Aeson.Types (Parser)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
+import Data.Either (partitionEithers)
 import qualified Data.HashMap.Strict.InsOrd as InsOrdHashMap
 import qualified Data.Map as M
-import Data.Maybe (fromMaybe)
 import Data.OpenApi (NamedSchema (..), OpenApiType (..), Referenced (..), ToSchema (..), binarySchema, declareSchemaRef, enum_, format, nullable, properties, required, type_)
 import qualified Data.OpenApi.Lens as OA
 import Data.Proxy (Proxy (..))
@@ -1658,26 +1658,37 @@ instance ToSchema UploadChunk where
 -- Wire → authoring input
 -- ---------------------------------------------------------------------------
 
-{- | Translate one request activity into the authoring input. Shared by the
+{- | Translate the request activities into authoring inputs. Shared by the
 HTTP endpoints and the command line, which read the same JSON document.
 
-The only thing that can fail here is a biosphere line that names its flow in
-two ways at once or in none: everything else is a value the validator judges.
+What can fail here is only shape — a biosphere line that names its flow in
+two ways at once or in none, a direction that is neither of the two, a flow
+introduced without the unit that is part of its identity; every value is the
+validator's to judge. Complaints accumulate across the whole batch and name
+the activity they belong to, exactly as the validator's do, so a batch is
+fixed in one round trip whichever layer refused it.
 -}
-toAuthoredActivity :: ActivityInput -> Either Text AuthoredActivity
-toAuthoredActivity ai = do
-    bio <- traverse toBio (aiBiosphere ai)
-    pure
-        AuthoredActivity
-            { aaName = aiName ai
-            , aaLocation = aiLocation ai
-            , aaDescription = aiDescription ai
-            , aaProductName = aiProductName ai
-            , aaProductAmount = aiProductAmount ai
-            , aaProductUnit = aiProductUnit ai
-            , aaExchanges = map toTechInput (aiInputs ai) <> bio <> map toWasteOutput (aiWasteOutputs ai)
-            }
+toAuthoredActivities :: [ActivityInput] -> Either [Text] [AuthoredActivity]
+toAuthoredActivities inputs = case partitionEithers (map toAuthoredActivity inputs) of
+    ([], authored) -> Right authored
+    (errs, _) -> Left (concat errs)
+
+toAuthoredActivity :: ActivityInput -> Either [Text] AuthoredActivity
+toAuthoredActivity ai = case partitionEithers (map toBio (aiBiosphere ai)) of
+    (errs@(_ : _), _) -> Left (map here (concat errs))
+    ([], bio) ->
+        Right
+            AuthoredActivity
+                { aaName = aiName ai
+                , aaLocation = aiLocation ai
+                , aaDescription = aiDescription ai
+                , aaProductName = aiProductName ai
+                , aaProductAmount = aiProductAmount ai
+                , aaProductUnit = aiProductUnit ai
+                , aaExchanges = map toTechInput (aiInputs ai) <> bio <> map toWasteOutput (aiWasteOutputs ai)
+                }
   where
+    here msg = aiName ai <> " {" <> aiLocation ai <> "}: " <> msg
     toTechInput ti =
         AuthoredTechInput
             { atiProvider = tiProvider ti
@@ -1692,17 +1703,19 @@ toAuthoredActivity ai = do
             , awUnit = woUnit wo
             , awComment = woComment wo
             }
-    toBio be = do
-        flow <- bioFlowRef be
-        direction <- bioDirection (beDirection be)
-        pure
-            AuthoredBio
-                { abFlow = flow
-                , abDirection = direction
-                , abAmount = beAmount be
-                , abUnit = beUnit be
-                , abComment = beComment be
-                }
+    -- One bad line can be bad both ways at once; both complaints travel.
+    toBio be = case (bioFlowRef be, bioDirection (beDirection be)) of
+        (Right flow, Right direction) ->
+            Right
+                AuthoredBio
+                    { abFlow = flow
+                    , abDirection = direction
+                    , abAmount = beAmount be
+                    , abUnit = beUnit be
+                    , abComment = beComment be
+                    }
+        (flow, direction) -> Left (leftList flow <> leftList direction)
+    leftList = either pure (const [])
 
 {- | A biosphere line names an existing flow by identifier, or introduces one
 by name and compartment. Both at once is ambiguous and neither says nothing,
@@ -1714,14 +1727,17 @@ bioFlowRef be = case (beFlow be, beName be) of
     (Nothing, Nothing) -> Left "a biosphere exchange needs either a flow identifier or a name and compartment"
     (Just flowId, Nothing) ->
         maybe (Left ("not a flow identifier: " <> flowId)) (Right . ExistingFlow) (UUID.fromText flowId)
-    (Nothing, Just name) -> case beCompartment be of
-        Nothing -> Left ("biosphere flow \"" <> name <> "\" needs a compartment (air, water, soil, natural resource)")
-        Just medium ->
+    (Nothing, Just name) -> case (beCompartment be, beUnit be) of
+        (Nothing, _) -> Left ("biosphere flow \"" <> name <> "\" needs a compartment (air, water, soil, natural resource)")
+        -- The unit is half of a named flow's identity (see
+        -- 'Database.Author.authoredBioFlowUUID'), so it cannot be defaulted.
+        (_, Nothing) -> Left ("biosphere flow \"" <> name <> "\" needs a unit")
+        (Just medium, Just unit) ->
             Right $
                 NewBioFlow
                     name
                     Compartment{compartmentName = medium, compartmentSub = beSubCompartment be}
-                    (fromMaybe "" (beUnit be))
+                    unit
 
 bioDirection :: Text -> Either Text BioDirection
 bioDirection raw = case T.toLower (T.strip raw) of

--- a/src/CLI/Client.hs
+++ b/src/CLI/Client.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -8,12 +9,13 @@ module CLI.Client (
     apiGet,
     apiPost,
     deleteSelectionBody,
+    readJsonFile,
 ) where
 
 import CLI.Types
 import Config (Config (..), ServerConfig (..))
-import Control.Exception (IOException, SomeException, try)
-import Data.Aeson (Value (..), decode, eitherDecode, encode, object, (.:), (.=))
+import Control.Exception (IOException, try)
+import Data.Aeson (FromJSON, Value (..), decode, eitherDecode, encode, object, (.:), (.=))
 import Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KM
@@ -548,13 +550,20 @@ putJsonFile :: Manager -> RemoteConfig -> OutputFormat -> Maybe Text -> String -
 putJsonFile mgr rc fmt jp path = sendJsonFile (apiPut mgr rc path) fmt jp
 
 sendJsonFile :: (Value -> IO (Either String Value)) -> OutputFormat -> Maybe Text -> FilePath -> IO ()
-sendJsonFile send fmt jp file = do
-    raw <- try (BL.readFile file)
-    case raw of
-        Left (e :: SomeException) -> output fmt jp (Left (file ++ ": " ++ show e))
-        Right bytes -> case eitherDecode bytes of
-            Left err -> output fmt jp (Left (file ++ ": " ++ err))
-            Right body -> send body >>= output fmt jp
+sendJsonFile send fmt jp file =
+    readJsonFile file >>= \case
+        Left err -> output fmt jp (Left err)
+        Right body -> send body >>= output fmt jp
+
+{- | Read and decode a JSON file, naming the file in any complaint about it.
+Shared by the remote and local write commands, which read the same document.
+-}
+readJsonFile :: (FromJSON a) => FilePath -> IO (Either String a)
+readJsonFile path = do
+    bytes <- try (BL.readFile path)
+    pure $ case bytes of
+        Left (e :: IOException) -> Left (path <> ": " <> show e)
+        Right raw -> either (\err -> Left (path <> ": " <> err)) Right (eitherDecode raw)
 
 {- | POST a JSON body and return the raw response (bytes + headers), for
 octet-stream endpoints like database export. Shares the error formatting of

--- a/src/CLI/Client.hs
+++ b/src/CLI/Client.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module CLI.Client (
     RemoteConfig (..),
@@ -11,8 +12,8 @@ module CLI.Client (
 
 import CLI.Types
 import Config (Config (..), ServerConfig (..))
-import Control.Exception (IOException, try)
-import Data.Aeson (Value (..), decode, encode, object, (.:), (.=))
+import Control.Exception (IOException, SomeException, try)
+import Data.Aeson (Value (..), decode, eitherDecode, encode, object, (.:), (.=))
 import Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KM
@@ -124,6 +125,18 @@ executeRemoteCommand mgr rc globalOpts cmd = do
                         >>= output fmt jp
         Database (DbExport args) ->
             executeRemoteExport mgr rc fmt jp args
+        Database (DbCreateActivities args) ->
+            -- The file is the request body; the server owns validation, so the
+            -- client forwards it rather than judging it twice.
+            postJsonFile mgr rc fmt jp ("/api/v1/db/" ++ T.unpack (dwaDb args) ++ "/activities") (dwaFile args)
+        Database (DbReplaceActivity args) ->
+            putJsonFile
+                mgr
+                rc
+                fmt
+                jp
+                ("/api/v1/db/" ++ T.unpack (drpDb args) ++ "/activity/" ++ T.unpack (drpProcessId args))
+                (drpFile args)
         Method McList ->
             apiGet mgr rc "/api/v1/method-collections" >>= output fmt jp
         Method (McUpload args) ->
@@ -519,6 +532,29 @@ apiPost mgr rc path body = apiRequest mgr rc "POST" path (Just body)
 
 apiDelete :: Manager -> RemoteConfig -> String -> IO (Either String Value)
 apiDelete mgr rc path = apiRequest mgr rc "DELETE" path Nothing
+
+apiPut :: Manager -> RemoteConfig -> String -> Value -> IO (Either String Value)
+apiPut mgr rc path body = apiRequest mgr rc "PUT" path (Just body)
+
+{- | Send a JSON file as the request body. The activities a user writes live in
+a file, not on the command line, and the server owns what is valid — so the
+client forwards the document rather than judging it twice. A file that is not
+JSON at all is caught here, where the path can be named.
+-}
+postJsonFile :: Manager -> RemoteConfig -> OutputFormat -> Maybe Text -> String -> FilePath -> IO ()
+postJsonFile mgr rc fmt jp path = sendJsonFile (apiPost mgr rc path) fmt jp
+
+putJsonFile :: Manager -> RemoteConfig -> OutputFormat -> Maybe Text -> String -> FilePath -> IO ()
+putJsonFile mgr rc fmt jp path = sendJsonFile (apiPut mgr rc path) fmt jp
+
+sendJsonFile :: (Value -> IO (Either String Value)) -> OutputFormat -> Maybe Text -> FilePath -> IO ()
+sendJsonFile send fmt jp file = do
+    raw <- try (BL.readFile file)
+    case raw of
+        Left (e :: SomeException) -> output fmt jp (Left (file ++ ": " ++ show e))
+        Right bytes -> case eitherDecode bytes of
+            Left err -> output fmt jp (Left (file ++ ": " ++ err))
+            Right body -> send body >>= output fmt jp
 
 {- | POST a JSON body and return the raw response (bytes + headers), for
 octet-stream endpoints like database export. Shares the error formatting of

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -1,12 +1,16 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module CLI.Command where
 
-import CLI.Types (CLIConfig (..), Command (..), DatabaseAction (..), DbDeleteArgs (..), DbExportArgs (..), DbRelinkArgs (..), DebugMatricesOptions (..), FlowSubCommand (..), GlobalOptions (..), LCIAOptions (..), MappingOptions (..), McExportArgs (..), MethodAction (..), OutputFormat (..), SearchActivitiesOptions (..), SearchFlowsOptions (..), UploadArgs (..))
+import API.Types (ActivityInput, ActivityWriteRequest (..), toAuthoredActivity)
+import CLI.Types (CLIConfig (..), Command (..), DatabaseAction (..), DbDeleteArgs (..), DbExportArgs (..), DbRelinkArgs (..), DbReplaceArgs (..), DbWriteArgs (..), DebugMatricesOptions (..), FlowSubCommand (..), GlobalOptions (..), LCIAOptions (..), MappingOptions (..), McExportArgs (..), MethodAction (..), OutputFormat (..), SearchActivitiesOptions (..), SearchFlowsOptions (..), UploadArgs (..))
 import Config (DatabaseConfig (..), MethodConfig (..))
 import Control.Concurrent.STM (readTVarIO)
+import Control.Exception (SomeException, try)
 import Data.Aeson (Value, encode, object, toJSON, (.=))
+import qualified Data.Aeson as A
 import Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as BSL
@@ -17,7 +21,16 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
-import Database.Edit (DeleteOutcome (..), DeleteRequest (..), copyDatabase, deleteActivitiesInDB)
+import Database.Edit (
+    DeleteOutcome (..),
+    DeleteRequest (..),
+    WriteReport (..),
+    WriteVerb (..),
+    copyDatabase,
+    deleteActivitiesInDB,
+    refusalMessage,
+    writeActivities,
+ )
 import Database.Export (exportDatabase, exportMethodCollection, parseExportFormat, parseMethodExportFormat)
 import Database.Manager (DatabaseManager (..), LoadedDatabase (..), RelinkResult (..), addDatabase, addMethodCollection)
 import qualified Database.Manager as DM
@@ -110,6 +123,10 @@ executeCommand (CLIConfig globalOpts _) cmd manager = do
             executeDbRelinkMapping outputFormat manager args
         Database (DbExport args) ->
             executeDbExport outputFormat manager args
+        Database (DbCreateActivities args) ->
+            executeDbCreateActivities outputFormat manager args
+        Database (DbReplaceActivity args) ->
+            executeDbReplaceActivity outputFormat manager args
         Method McList ->
             DM.listMethodCollections manager >>= out . toJSON
         Method (McUpload args) ->
@@ -495,6 +512,60 @@ executeDbDeleteActivities fmt manager args = do
                     , "transient" .= not (doPersisted outcome)
                     , "warnings" .= doWarnings outcome
                     ]
+
+{- | Write new activities into a database, read from a JSON file.
+
+The file is the same document the HTTP endpoint accepts
+(@{"activities": [...]}@), and the refusals are the same ones — the command
+line and the server share the whole of authoring above the primitives, so
+neither can allow what the other forbids.
+-}
+executeDbCreateActivities :: OutputFormat -> DatabaseManager -> DbWriteArgs -> IO ()
+executeDbCreateActivities fmt manager args = do
+    request <- readJsonFile (dwaFile args)
+    case request of
+        Left err -> reportError err >> exitFailure
+        Right req -> runWrite fmt manager (dwaDb args) CreateActivities (awrActivities req)
+
+-- | Rewrite one activity, addressed by the process id it already has.
+executeDbReplaceActivity :: OutputFormat -> DatabaseManager -> DbReplaceArgs -> IO ()
+executeDbReplaceActivity fmt manager args = do
+    activity <- readJsonFile (drpFile args)
+    case activity of
+        Left err -> reportError err >> exitFailure
+        Right body -> runWrite fmt manager (drpDb args) (ReplaceActivity (drpProcessId args)) [body]
+
+{- | Shared tail of both write commands: translate, write, and report. A
+refusal is printed and exits non-zero, so a script can tell a rejected batch
+from a written one without parsing the output.
+-}
+runWrite :: OutputFormat -> DatabaseManager -> Text -> WriteVerb -> [ActivityInput] -> IO ()
+runWrite fmt manager target verb inputs =
+    case traverse toAuthoredActivity inputs of
+        Left err -> reportError (T.unpack err) >> exitFailure
+        Right authored -> do
+            outcome <- writeActivities manager target verb authored
+            case outcome of
+                Left refusal -> do
+                    reportError (T.unpack (refusalMessage refusal))
+                    exitFailure
+                Right report -> do
+                    mapM_ (reportProgress Warning . T.unpack) (wrWarnings report)
+                    outputResult fmt $
+                        object
+                            [ "database" .= target
+                            , "written" .= wrWritten report
+                            , "transient" .= not (wrPersisted report)
+                            , "warnings" .= wrWarnings report
+                            ]
+
+-- | Read and decode a JSON file, naming the file in any complaint about it.
+readJsonFile :: (A.FromJSON a) => FilePath -> IO (Either String a)
+readJsonFile path = do
+    bytes <- try (BL.readFile path)
+    pure $ case bytes of
+        Left (e :: SomeException) -> Left (path <> ": " <> show e)
+        Right raw -> either (\err -> Left (path <> ": " <> err)) Right (A.eitherDecode raw)
 
 {- | Execute database load: bring a configured database (and its declared
 dependencies) into memory. Any failed dependency is surfaced in the output.

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -4,7 +4,7 @@
 
 module CLI.Command where
 
-import API.Types (ActivityInput, ActivityWriteRequest (..), toAuthoredActivity)
+import API.Types (ActivityInput, ActivityWriteRequest (..), toAuthoredActivities)
 import CLI.Types (CLIConfig (..), Command (..), DatabaseAction (..), DbDeleteArgs (..), DbExportArgs (..), DbRelinkArgs (..), DbReplaceArgs (..), DbWriteArgs (..), DebugMatricesOptions (..), FlowSubCommand (..), GlobalOptions (..), LCIAOptions (..), MappingOptions (..), McExportArgs (..), MethodAction (..), OutputFormat (..), SearchActivitiesOptions (..), SearchFlowsOptions (..), UploadArgs (..))
 import Config (DatabaseConfig (..), MethodConfig (..))
 import Control.Concurrent.STM (readTVarIO)
@@ -541,8 +541,8 @@ from a written one without parsing the output.
 -}
 runWrite :: OutputFormat -> DatabaseManager -> Text -> WriteVerb -> [ActivityInput] -> IO ()
 runWrite fmt manager target verb inputs =
-    case traverse toAuthoredActivity inputs of
-        Left err -> reportError (T.unpack err) >> exitFailure
+    case toAuthoredActivities inputs of
+        Left errs -> reportError (T.unpack (T.intercalate "\n" errs)) >> exitFailure
         Right authored -> do
             outcome <- writeActivities manager target verb authored
             case outcome of

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -1,16 +1,14 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 module CLI.Command where
 
 import API.Types (ActivityInput, ActivityWriteRequest (..), toAuthoredActivities)
+import CLI.Client (readJsonFile)
 import CLI.Types (CLIConfig (..), Command (..), DatabaseAction (..), DbDeleteArgs (..), DbExportArgs (..), DbRelinkArgs (..), DbReplaceArgs (..), DbWriteArgs (..), DebugMatricesOptions (..), FlowSubCommand (..), GlobalOptions (..), LCIAOptions (..), MappingOptions (..), McExportArgs (..), MethodAction (..), OutputFormat (..), SearchActivitiesOptions (..), SearchFlowsOptions (..), UploadArgs (..))
 import Config (DatabaseConfig (..), MethodConfig (..))
 import Control.Concurrent.STM (readTVarIO)
-import Control.Exception (SomeException, try)
 import Data.Aeson (Value, encode, object, toJSON, (.=))
-import qualified Data.Aeson as A
 import Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as BSL
@@ -558,14 +556,6 @@ runWrite fmt manager target verb inputs =
                             , "transient" .= not (wrPersisted report)
                             , "warnings" .= wrWarnings report
                             ]
-
--- | Read and decode a JSON file, naming the file in any complaint about it.
-readJsonFile :: (A.FromJSON a) => FilePath -> IO (Either String a)
-readJsonFile path = do
-    bytes <- try (BL.readFile path)
-    pure $ case bytes of
-        Left (e :: SomeException) -> Left (path <> ": " <> show e)
-        Right raw -> either (\err -> Left (path <> ": " <> err)) Right (A.eitherDecode raw)
 
 {- | Execute database load: bring a configured database (and its declared
 dependencies) into memory. Any failed dependency is surfaced in the output.

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -122,6 +122,8 @@ databaseParser =
                     <> OA.command "copy" (info (copyArgsParser <**> helper) (progDesc "Copy a loaded database under a new name"))
                     <> OA.command "relink" (info (DbRelinkMapping <$> relinkArgsParser <**> helper) (progDesc "Relink a database to a dependency using a supplier alias CSV (source/target names, optional locations)"))
                     <> OA.command "export" (info (DbExport <$> exportArgsParser <**> helper) (progDesc "Export a loaded database to a file"))
+                    <> OA.command "create-activities" (info (DbCreateActivities <$> writeArgsParser <**> helper) (progDesc "Write new activities into a database from a JSON file"))
+                    <> OA.command "replace-activity" (info (DbReplaceActivity <$> replaceArgsParser <**> helper) (progDesc "Rewrite one activity of a database from a JSON file"))
                 )
             )
 
@@ -151,6 +153,26 @@ exportArgsParser =
         <$> textArg "DB" "Name of the loaded database to export"
         <*> textOpt "format" Nothing "FMT" "Target format: simapro|ecospold1|ecospold2|ilcd|brightway"
         <*> strOpt "out" Nothing "FILE" "Output file path"
+
+{- | Authoring parser: positional DB plus @--from@, the JSON file holding the
+activities. The file is the same document the HTTP endpoint accepts
+(@{"activities": [...]}@), so one description works over either transport.
+-}
+writeArgsParser :: Parser DbWriteArgs
+writeArgsParser =
+    DbWriteArgs
+        <$> textArg "DB" "Name of the loaded database to write to"
+        <*> strOpt "from" Nothing "FILE" "JSON file holding the activities to write"
+
+{- | Replace parser: as 'writeArgsParser', plus the identity being rewritten.
+The file holds one activity rather than a batch.
+-}
+replaceArgsParser :: Parser DbReplaceArgs
+replaceArgsParser =
+    DbReplaceArgs
+        <$> textArg "DB" "Name of the loaded database holding the activity"
+        <*> textOpt "process-id" Nothing "PID" "Identity of the activity to rewrite (activityUUID_productUUID)"
+        <*> strOpt "from" Nothing "FILE" "JSON file holding the activity"
 
 {- | Method-export parser: positional collection name, @--format@ keyword,
 @--out@ file path. Mirrors @method export <name> --format <fmt> --out <file>@.

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -79,6 +79,10 @@ data DatabaseAction
       DbRelinkMapping DbRelinkArgs
     | -- | Export a loaded database to a file: @db@, @--format fmt@, @--out file@.
       DbExport DbExportArgs
+    | -- | Write new activities read from a JSON file: @db@, @--from file@.
+      DbCreateActivities DbWriteArgs
+    | -- | Rewrite one activity: @db@, @--process-id pid@, @--from file@.
+      DbReplaceActivity DbReplaceArgs
     deriving (Eq, Show, Generic)
 
 -- | Arguments for @database export@.
@@ -89,6 +93,32 @@ data DbExportArgs = DbExportArgs
     -- ^ Target format keyword (@--format@): simapro|ecospold1|ecospold2|ilcd|brightway
     , deaOut :: FilePath
     -- ^ Output file path (@--out@)
+    }
+    deriving (Eq, Show, Generic)
+
+{- | Arguments for @database create-activities@: the database to write to and
+a JSON file shaped like the HTTP request body (@{"activities": [...]}@), so
+the same document works over either transport.
+-}
+data DbWriteArgs = DbWriteArgs
+    { dwaDb :: Text
+    -- ^ Database to write to (@--db@)
+    , dwaFile :: FilePath
+    -- ^ JSON file holding the activities (@--from@)
+    }
+    deriving (Eq, Show, Generic)
+
+{- | Arguments for @database replace-activity@: as 'DbWriteArgs', plus the
+process id being rewritten. The file holds one activity object rather than a
+batch.
+-}
+data DbReplaceArgs = DbReplaceArgs
+    { drpDb :: Text
+    -- ^ Database holding the activity (@--db@)
+    , drpProcessId :: Text
+    -- ^ Identity of the activity to rewrite (@--process-id@)
+    , drpFile :: FilePath
+    -- ^ JSON file holding the activity (@--from@)
     }
     deriving (Eq, Show, Generic)
 

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -247,7 +247,7 @@ duplicateKeys keys = M.keys (M.filter (> (1 :: Int)) (M.fromListWith (+) [(k, 1)
 
 validateOne :: AuthorContext -> AuthoredActivity -> Either [Text] (ResolvedInsert, [Text])
 validateOne ctx a =
-    case (productChecks, partitionEithers (zipWith resolveExchange [1 :: Int ..] (aaExchanges a)), mProductUnit) of
+    case (productChecks, partitionEithers (map resolveExchange (aaExchanges a)), mProductUnit) of
         ([], ([], resolved), Just (unitRef, unitLabel)) ->
             let key = (authoredActivityUUID (aaName a) (aaLocation a), authoredProductUUID (aaProductName a) unitLabel)
                 productExchange =
@@ -285,8 +285,7 @@ validateOne ctx a =
         (perActivityErrs, (exchangeErrs, _), _) -> Left (map here (perActivityErrs <> concat exchangeErrs))
   where
     here msg = aaName a <> " {" <> aaLocation a <> "}: " <> msg
-    resolveExchange i ex = mapLeft (map (numbered i)) (resolveOne ctx ex)
-    numbered i msg = "exchange " <> T.pack (show i) <> ": " <> msg
+    resolveExchange ex = mapLeft (map ((describeExchange ex <> ": ") <>)) (resolveOne ctx ex)
     mProductUnit = lookupUnit ctx (aaProductUnit a)
     productChecks =
         concat
@@ -319,6 +318,17 @@ buildActivity a unitLabel exchangeList =
         , activityNativeId = Nothing
         , activityFormulaCheck = Nothing
         }
+
+{- | How a complaint names the line it is about. What an author can act on is
+which supplier or which flow, not a position in a list — an API caller may not
+even have sent the exchanges as one list.
+-}
+describeExchange :: AuthoredExchange -> Text
+describeExchange ex = case ex of
+    AuthoredTechInput{atiProvider = provider} -> "input from \"" <> provider <> "\""
+    AuthoredWasteOutput{awProvider = provider} -> "waste output to \"" <> provider <> "\""
+    AuthoredBio{abFlow = ExistingFlow flowId} -> "biosphere flow " <> UUID.toText flowId
+    AuthoredBio{abFlow = NewBioFlow name _ _} -> "biosphere flow \"" <> name <> "\""
 
 {- | An amount that can carry information: finite, and not zero. A zero
 exchange is not a measurement of nothing, it is a line that should not have

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -550,7 +550,7 @@ presenceRefusal db verb resolved = case verb of
     -- elsewhere describes a process the database may well not have, and
     -- answering "no such activity" would send the author looking for the wrong
     -- mistake.
-    ReplaceActivity target -> case filter ((/= target) . renderKey) keys of
+    ReplaceActivity target -> case filter ((/= canonicalTarget db target) . renderKey) keys of
         elsewhere@(_ : _) ->
             Just . Malformed $
                 [ "This activity's identity is "
@@ -567,6 +567,20 @@ presenceRefusal db verb resolved = case verb of
   where
     keys = map riKey resolved
     present key = M.member key (dbProcessIdLookup db)
+
+{- | The PUT target in the currency 'renderKey' speaks. A process is addressed
+by the canonical @activityUUID_productUUID@ pair, or by the bare activity UUID
+the read endpoints also accept, so the handle a caller got from a read works
+here too. A target that resolves to nothing is kept as sent: the presence
+check owns that refusal.
+-}
+canonicalTarget :: Database -> Text -> Text
+canonicalTarget db target = case parseUUIDPair target of
+    Just pair -> renderKey pair
+    Nothing -> fromMaybe target $ do
+        actUUID <- UUID.fromText target
+        pid <- findProcessIdByActivityUUID db actUUID
+        renderKey <$> dbProcessIdTable db V.!? fromIntegral pid
 
 -- | The loaded databases a database draws suppliers from.
 loadedDependencies :: DatabaseManager -> Database -> IO [Database]

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -481,6 +481,10 @@ writeActivities ::
     WriteVerb ->
     [AuthoredActivity] ->
     IO (Either WriteRefusal WriteReport)
+writeActivities _ _ _ [] =
+    -- Committing re-serializes the whole database and rebuilds its solver;
+    -- an empty batch would pay all of that to write nothing.
+    pure (Left (Malformed ["The batch is empty: there is nothing to write."]))
 writeActivities manager dbName verb authored =
     getDatabase manager dbName >>= \case
         Nothing -> pure (Left (NotLoaded dbName))

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -46,6 +46,11 @@ module Database.Edit (
     replaceActivities,
     MutationOutcome (..),
     mutateUploadedDatabase,
+    WriteVerb (..),
+    WriteRefusal (..),
+    WriteReport (..),
+    writeActivities,
+    refusalMessage,
 ) where
 
 import Control.Concurrent.STM (atomically, modifyTVar', readTVar, readTVarIO)
@@ -76,7 +81,12 @@ import Database (
     buildProductIndex,
     findActivitiesByFields,
  )
-import Database.Author (ResolvedInsert (..))
+import Database.Author (
+    AuthorContext (..),
+    AuthoredActivity,
+    ResolvedInsert (..),
+    validateAuthored,
+ )
 import Database.CrossLinking (buildIndexedDatabaseFromDB)
 import Database.Export (serializeDatabaseFiles)
 import qualified Database.Loader as Loader
@@ -367,7 +377,7 @@ author is re-describing something the database already holds and wants
 'replaceActivities' instead.
 -}
 insertActivities :: UnitConfig -> [ResolvedInsert] -> Database -> Either Text Database
-insertActivities = writeActivities Insert
+insertActivities = applyResolved Insert
 
 {- | Rewrite activities the database already holds, keeping their identity.
 
@@ -376,7 +386,7 @@ vocabulary, exactly as deletion does: a flow no activity uses any more is
 inert, and dropping it would break a relink that still resolves through it.
 -}
 replaceActivities :: UnitConfig -> [ResolvedInsert] -> Database -> Either Text Database
-replaceActivities = writeActivities Replace
+replaceActivities = applyResolved Replace
 
 {- | Shared write path. The vocabulary the batch brings (its product flows and
 any new biosphere flows) lands in the same step as the activities that
@@ -388,8 +398,8 @@ rebuild resets cross-database links ('rebuildFromActivities'), so treating "no
 activities to write" as a no-op is what keeps a caller's empty request from
 silently unlinking the database.
 -}
-writeActivities :: WriteIntent -> UnitConfig -> [ResolvedInsert] -> Database -> Either Text Database
-writeActivities intent unitConfig inserts db
+applyResolved :: WriteIntent -> UnitConfig -> [ResolvedInsert] -> Database -> Either Text Database
+applyResolved intent unitConfig inserts db
     | null inserts = Right db
     | otherwise = do
         let existing = surviving db S.empty
@@ -420,7 +430,153 @@ checkKeys intent existing keys = case intent of
                 <> " "
                 <> what
                 <> " in this database"
-    renderKey (a, p) = UUID.toText a <> "_" <> UUID.toText p
+
+-- ---------------------------------------------------------------------------
+-- Writing authored activities
+-- ---------------------------------------------------------------------------
+
+{- | Which way a batch is meant to land: added to the collection, or written
+over the one process the caller names.
+-}
+data WriteVerb = CreateActivities | ReplaceActivity Text
+
+{- | Why a write did not happen, in the terms its caller has to answer in.
+
+Each constructor exists because a different response is owed: an HTTP client
+needs 404 apart from 409 apart from 400, and someone at a terminal needs to be
+told which of "there is no such database", "that one is not yours to write"
+and "your file has four problems" happened. A single error string would force
+both to guess by reading it.
+-}
+data WriteRefusal
+    = NotLoaded Text
+    | NotWritable Text
+    | Malformed [Text]
+    | AlreadyPresent [Text]
+    | NotPresent [Text]
+    | WriteFailed Text
+
+-- | What a write produced.
+data WriteReport = WriteReport
+    { wrWritten :: [Text]
+    , wrPersisted :: Bool
+    , wrWarnings :: [Text]
+    }
+
+{- | Validate a batch of authored activities against a loaded database and, if
+nothing is wrong with it, write it.
+
+This is the whole of authoring above the primitives, shared by the HTTP
+endpoints and the command line so the two cannot drift on what is allowed.
+Refusals are classified rather than stringly-typed, because the two callers
+owe their users different answers to the same refusal.
+
+A database the engine reads from its configuration is refused: that is
+background data the whole installation shares, and a copy or an upload is
+where authoring belongs.
+-}
+writeActivities ::
+    DatabaseManager ->
+    Text ->
+    WriteVerb ->
+    [AuthoredActivity] ->
+    IO (Either WriteRefusal WriteReport)
+writeActivities manager dbName verb authored =
+    getDatabase manager dbName >>= \case
+        Nothing -> pure (Left (NotLoaded dbName))
+        Just loaded
+            | not (dcIsUploaded (ldConfig loaded)) -> pure (Left (NotWritable dbName))
+            | otherwise -> do
+                deps <- loadedDependencies manager (ldDatabase loaded)
+                unitConfig <- getMergedUnitConfig manager
+                let ctx =
+                        AuthorContext
+                            { acDb = ldDatabase loaded
+                            , acDeps = deps
+                            , acUnitConfig = unitConfig
+                            }
+                case validateAuthored ctx authored of
+                    Left errs -> pure (Left (Malformed errs))
+                    Right (resolved, warnings) ->
+                        case presenceRefusal (ldDatabase loaded) verb resolved of
+                            Just refusal -> pure (Left refusal)
+                            Nothing -> commit unitConfig resolved warnings
+  where
+    commit unitConfig resolved warnings = do
+        outcome <- mutateUploadedDatabase manager dbName (edit unitConfig resolved)
+        pure $ case outcome of
+            Left err -> Left (WriteFailed err)
+            Right done ->
+                Right
+                    WriteReport
+                        { wrWritten = map (renderKey . riKey) resolved
+                        , wrPersisted = moPersisted done
+                        , wrWarnings = warnings <> moWarnings done
+                        }
+    edit unitConfig resolved = case verb of
+        CreateActivities -> insertActivities unitConfig resolved
+        ReplaceActivity _ -> replaceActivities unitConfig resolved
+
+{- | The two refusals only a verb can name: creating over a process that is
+already there, and rewriting one that is not. Checked before the mutation so
+the caller learns which happened rather than reading it out of a message.
+
+'ReplaceActivity' also checks that the body describes the process the caller
+addressed. Identity is minted from the name, location, product and unit, so a
+body that mints elsewhere would silently become a second row.
+-}
+presenceRefusal :: Database -> WriteVerb -> [ResolvedInsert] -> Maybe WriteRefusal
+presenceRefusal db verb resolved = case verb of
+    CreateActivities -> case filter present keys of
+        [] -> Nothing
+        clashes -> Just (AlreadyPresent (map renderKey clashes))
+    -- The mismatch is checked before presence on purpose: a body that mints
+    -- elsewhere describes a process the database may well not have, and
+    -- answering "no such activity" would send the author looking for the wrong
+    -- mistake.
+    ReplaceActivity target -> case filter ((/= target) . renderKey) keys of
+        elsewhere@(_ : _) ->
+            Just . Malformed $
+                [ "This activity's identity is "
+                    <> renderKey wrong
+                    <> ", not "
+                    <> target
+                    <> ". Identity comes from the name, location, product and unit, so\
+                       \ writing this body here would address a different activity."
+                | wrong <- elsewhere
+                ]
+        [] -> case filter (not . present) keys of
+            [] -> Nothing
+            absent -> Just (NotPresent (map renderKey absent))
+  where
+    keys = map riKey resolved
+    present key = M.member key (dbProcessIdLookup db)
+
+-- | The loaded databases a database draws suppliers from.
+loadedDependencies :: DatabaseManager -> Database -> IO [Database]
+loadedDependencies manager db = do
+    loadedDbs <- readTVarIO (dmLoadedDbs manager)
+    pure [ldDatabase ld | name <- dbDependsOn db, Just ld <- [M.lookup name loadedDbs]]
+
+-- | @activityUUID_productUUID@, the identity a process is addressed by.
+renderKey :: (UUID, UUID) -> Text
+renderKey (actUUID, prodUUID) = UUID.toText actUUID <> "_" <> UUID.toText prodUUID
+
+{- | Plain-language rendering, for callers with nowhere to put a status code.
+An HTTP caller maps the constructors to codes instead.
+-}
+refusalMessage :: WriteRefusal -> Text
+refusalMessage = \case
+    NotLoaded name -> "Database not loaded: " <> name
+    NotWritable name ->
+        name
+            <> " is a database this engine reads from its configuration, so it is shared\
+               \ background data rather than yours to write. Copy it, or upload a database\
+               \ of your own, and author there."
+    Malformed errs -> T.intercalate "\n" errs
+    AlreadyPresent keys -> "Already in this database: " <> T.intercalate ", " keys
+    NotPresent keys -> "Not in this database: " <> T.intercalate ", " keys
+    WriteFailed err -> err
 
 -- ---------------------------------------------------------------------------
 -- Persisting an edit

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -55,6 +55,7 @@ module Database.Edit (
 
 import Control.Concurrent.STM (atomically, modifyTVar', readTVar, readTVarIO)
 import Control.Exception (SomeException, finally, try)
+import Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.IntSet as IS
 import Data.List (isPrefixOf)
@@ -504,10 +505,10 @@ writeActivities manager dbName verb authored =
                     Right (resolved, warnings) ->
                         case presenceRefusal (ldDatabase loaded) verb resolved of
                             Just refusal -> pure (Left refusal)
-                            Nothing -> commit unitConfig resolved warnings
+                            Nothing -> commit deps unitConfig resolved warnings
   where
-    commit unitConfig resolved warnings = do
-        outcome <- mutateUploadedDatabase manager dbName (edit unitConfig resolved)
+    commit deps unitConfig resolved warnings = do
+        outcome <- mutateUploadedDatabase manager dbName (edit deps unitConfig)
         pure $ case outcome of
             Left err -> Left (WriteFailed err)
             Right done ->
@@ -517,9 +518,20 @@ writeActivities manager dbName verb authored =
                         , wrPersisted = moPersisted done
                         , wrWarnings = warnings <> moWarnings done
                         }
-    edit unitConfig resolved = case verb of
-        CreateActivities -> insertActivities unitConfig resolved
-        ReplaceActivity _ -> replaceActivities unitConfig resolved
+    -- Everything above judged a snapshot taken before the staging
+    -- reservation; 'mutateReserved' re-reads the database under it. The edit
+    -- therefore validates again against what is actually there, so a batch
+    -- overtaken by a concurrent edit is refused rather than written with a
+    -- supplier link that no longer resolves. In that rare interleaving the
+    -- refusal degrades from a classified status to a 'WriteFailed' message —
+    -- never to a dangling link. Identity minting is pure, so the keys cannot
+    -- differ between the two runs.
+    edit deps unitConfig db = do
+        let ctx = AuthorContext{acDb = db, acDeps = deps, acUnitConfig = unitConfig}
+        (resolved, _) <- first (T.intercalate "\n") (validateAuthored ctx authored)
+        case verb of
+            CreateActivities -> insertActivities unitConfig resolved db
+            ReplaceActivity _ -> replaceActivities unitConfig resolved db
 
 {- | The two refusals only a verb can name: creating over a process that is
 already there, and rewriting one that is not. Checked before the mutation so

--- a/test/ActivityWriteHandlerSpec.hs
+++ b/test/ActivityWriteHandlerSpec.hs
@@ -111,6 +111,18 @@ spec = describe "writing activities over HTTP" $ do
                 Left err -> expectationFailure ("expected the rewrite to land: " <> showErr err)
                 Right written -> awpWritten written `shouldBe` [keyOf cheese]
 
+    it "accepts the bare activity UUID as the PUT address, like every read does" $
+        -- A process is addressed by the canonical pair or by the bare
+        -- activity UUID when it is unambiguous; the handle a caller got from
+        -- a read must work on the rewrite too.
+        withWritableDb $ \env -> do
+            _ <- create env "authored" [cheese]
+            let bare = UUID.toText (authoredActivityUUID (aiName cheese) (aiLocation cheese))
+            res <- replace env "authored" bare cheese{aiProductAmount = 2}
+            case res of
+                Left err -> expectationFailure ("expected the rewrite to land: " <> showErr err)
+                Right written -> awpWritten written `shouldBe` [keyOf cheese]
+
     it "refuses a body whose identity is not the one the path addresses" $
         -- Identity comes from the name, location, product and unit, so a body
         -- that would land elsewhere must not be written to a second row.

--- a/test/ActivityWriteHandlerSpec.hs
+++ b/test/ActivityWriteHandlerSpec.hs
@@ -149,6 +149,36 @@ spec = describe "writing activities over HTTP" $ do
             neither <- create env "authored" [bio Nothing Nothing]
             void neither `shouldSatisfy` refusedWith "needs either a flow identifier"
 
+    it "reports every shape defect of a batch at once, each naming its activity" $
+        -- Shape complaints accumulate like the validator's do: a batch with a
+        -- bad direction in one activity and a doubly-named flow in another is
+        -- fixed in one round trip, and each line says where to look.
+        withWritableDb $ \env -> do
+            let badDirection =
+                    cheese
+                        { aiName = "yogurt, at dairy"
+                        , aiBiosphere = [emission{beName = Just "Carbon dioxide", beDirection = "released"}]
+                        }
+                doublyNamed =
+                    cheese
+                        { aiName = "butter, at dairy"
+                        , aiBiosphere = [emission{beFlow = Just (UUID.toText co2Id), beName = Just "Carbon dioxide"}]
+                        }
+            res <- create env "authored" [badDirection, doublyNamed]
+            case res of
+                Right _ -> expectationFailure "expected the batch to be refused"
+                Left err -> do
+                    errHTTPCode err `shouldBe` 400
+                    bodyOf err `shouldSatisfy` isInfixOf "yogurt, at dairy {FR}: unknown biosphere direction"
+                    bodyOf err `shouldSatisfy` isInfixOf "butter, at dairy {FR}: "
+
+    it "refuses a named biosphere flow that comes without its unit" $
+        -- The unit is half of a named flow's identity, so it cannot be
+        -- defaulted; the complaint says so instead of "unknown unit \"\"".
+        withWritableDb $ \env -> do
+            res <- create env "authored" [cheese{aiBiosphere = [emission{beName = Just "Dust", beUnit = Nothing}]}]
+            void res `shouldSatisfy` refusedWith "\"Dust\" needs a unit"
+
 -- ---------------------------------------------------------------------------
 -- Driving the handlers
 -- ---------------------------------------------------------------------------

--- a/test/ActivityWriteHandlerSpec.hs
+++ b/test/ActivityWriteHandlerSpec.hs
@@ -1,0 +1,353 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Tests for the activity-write endpoints
+('API.DatabaseHandlers.createActivitiesHandler' and
+'API.DatabaseHandlers.replaceActivityHandler').
+
+What the HTTP layer owns, and what these pin, is the mapping from a refusal to
+a status a client can act on: a batch a caller can fix is a 400 carrying every
+complaint at once, writing over a row that exists is a 409, rewriting one that
+does not is a 404, and a database the engine only reads is refused outright.
+The validation itself is "AuthorSpec"'s subject, not this file's.
+-}
+module ActivityWriteHandlerSpec (spec) where
+
+import Control.Concurrent.STM (atomically, modifyTVar')
+import Control.Monad (void)
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (isInfixOf)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.UUID as UUID
+import qualified Data.Vector.Unboxed as U
+import Servant (ServerError, errBody, errHTTPCode, runHandler)
+import System.Directory (createDirectoryIfMissing)
+import System.Environment (setEnv, unsetEnv)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+
+import API.DatabaseHandlers (createActivitiesHandler, replaceActivityHandler)
+import Database.Author (authoredActivityUUID, authoredProductUUID)
+
+import API.Types (ActivityInput (..), ActivityWriteRequest (..), ActivityWriteResponse (..), BioExchangeAPI (..), TechInputAPI (..))
+import App.Env (AppEnv (..), runApp)
+import Config (DatabaseConfig (..), defaultConfig)
+import Control.Exception (bracket_)
+import Database (buildDatabaseWithMatrices)
+import Database.Manager (DatabaseManager (..), LoadedDatabase (..), initDatabaseManager)
+import Database.Upload (DatabaseFormat (..))
+import SharedSolver (createSharedSolver)
+import Types (
+    Activity (..),
+    BioDirection (..),
+    BiosphereFlow (..),
+    Compartment (..),
+    Database (..),
+    Exchange (..),
+    GeographyPolicy (..),
+    LocationSource (..),
+    SparseTriple (..),
+    TechRole (..),
+    TechnosphereFlow (..),
+    UUID,
+    Unit (..),
+ )
+import UnitConversion (defaultUnitConfig)
+
+spec :: Spec
+spec = describe "writing activities over HTTP" $ do
+    it "writes a batch and answers with the process ids it can now be asked for" $
+        withWritableDb $ \env -> do
+            res <- create env "authored" [cheese]
+            case res of
+                Left err -> expectationFailure ("expected a successful write: " <> showErr err)
+                Right written -> do
+                    awpTransient written `shouldBe` False
+                    -- The identity is the pair, and it is the caller's handle
+                    -- on the row from here on.
+                    awpWritten written `shouldBe` [keyOf cheese]
+
+    it "reports every defect of a batch at once, as a 400" $
+        withWritableDb $ \env -> do
+            let broken =
+                    cheese
+                        { aiProductUnit = "furlong"
+                        , aiInputs = [TechInputAPI{tiProvider = "nope", tiAmount = 1, tiUnit = Nothing, tiComment = Nothing}]
+                        }
+            res <- create env "authored" [broken]
+            case res of
+                Right _ -> expectationFailure "expected the batch to be refused"
+                Left err -> do
+                    errHTTPCode err `shouldBe` 400
+                    -- Both complaints travel together: fixing a ten-line
+                    -- inventory should take one round trip, not ten.
+                    bodyOf err `shouldSatisfy` isInfixOf "unknown provider"
+                    bodyOf err `shouldSatisfy` isInfixOf "unknown unit \"furlong\""
+
+    it "answers 409 when the batch would write over a row that already exists" $
+        withWritableDb $ \env -> do
+            _ <- create env "authored" [cheese]
+            res <- create env "authored" [cheese]
+            case res of
+                Right _ -> expectationFailure "expected the second write to conflict"
+                Left err -> do
+                    errHTTPCode err `shouldBe` 409
+                    bodyOf err `shouldSatisfy` isInfixOf "Already in this database"
+
+    it "answers 404 when rewriting an activity the database does not hold" $
+        withWritableDb $ \env -> do
+            res <- replace env "authored" (keyOf cheese) cheese
+            case res of
+                Right _ -> expectationFailure "expected the rewrite to find nothing"
+                Left err -> errHTTPCode err `shouldBe` 404
+
+    it "rewrites in place once the activity is there" $
+        withWritableDb $ \env -> do
+            _ <- create env "authored" [cheese]
+            res <- replace env "authored" (keyOf cheese) cheese{aiProductAmount = 2}
+            case res of
+                Left err -> expectationFailure ("expected the rewrite to land: " <> showErr err)
+                Right written -> awpWritten written `shouldBe` [keyOf cheese]
+
+    it "refuses a body whose identity is not the one the path addresses" $
+        -- Identity comes from the name, location, product and unit, so a body
+        -- that would land elsewhere must not be written to a second row.
+        withWritableDb $ \env -> do
+            _ <- create env "authored" [cheese]
+            res <- replace env "authored" (keyOf cheese) cheese{aiName = "butter, at dairy"}
+            case res of
+                Right _ -> expectationFailure "expected the mismatch to be refused"
+                Left err -> do
+                    errHTTPCode err `shouldBe` 400
+                    bodyOf err `shouldSatisfy` isInfixOf "Identity comes from the name"
+
+    it "refuses to author into a database the engine only reads" $
+        -- Configured databases are background data the whole installation
+        -- shares; authoring belongs in a database of one's own.
+        withDb (\name dataDir -> (uploadedConfig name dataDir){dcIsUploaded = False}) $ \env -> do
+            res <- create env "authored" [cheese]
+            case res of
+                Right _ -> expectationFailure "expected authoring into a configured database to be refused"
+                Left err -> do
+                    errHTTPCode err `shouldBe` 400
+                    bodyOf err `shouldSatisfy` isInfixOf "reads from its configuration"
+
+    it "answers 404 for a database that is not loaded" $
+        withWritableDb $ \env -> do
+            res <- create env "no-such-db" [cheese]
+            case res of
+                Right _ -> expectationFailure "expected a 404"
+                Left err -> errHTTPCode err `shouldBe` 404
+
+    it "refuses a biosphere line that names its flow twice, or not at all" $
+        withWritableDb $ \env -> do
+            let bio flow name = cheese{aiBiosphere = [emission{beFlow = flow, beName = name}]}
+            both <- create env "authored" [bio (Just (UUID.toText co2Id)) (Just "Carbon dioxide")]
+            void both `shouldSatisfy` refusedWith "not both"
+            neither <- create env "authored" [bio Nothing Nothing]
+            void neither `shouldSatisfy` refusedWith "needs either a flow identifier"
+
+-- ---------------------------------------------------------------------------
+-- Driving the handlers
+-- ---------------------------------------------------------------------------
+
+create :: AppEnv -> Text -> [ActivityInput] -> IO (Either ServerError ActivityWriteResponse)
+create env dbName activities =
+    runHandler (runApp env (createActivitiesHandler dbName (ActivityWriteRequest activities)))
+
+replace :: AppEnv -> Text -> Text -> ActivityInput -> IO (Either ServerError ActivityWriteResponse)
+replace env dbName processId body =
+    runHandler (runApp env (replaceActivityHandler dbName processId body))
+
+refusedWith :: String -> Either ServerError () -> Bool
+refusedWith needle = either ((needle `isInfixOf`) . bodyOf) (const False)
+
+bodyOf :: ServerError -> String
+bodyOf = BSL.unpack . errBody
+
+showErr :: ServerError -> String
+showErr err = show (errHTTPCode err) <> " " <> bodyOf err
+
+-- | An environment holding one writable EcoSpold 2 database called @authored@.
+withWritableDb :: (AppEnv -> IO ()) -> IO ()
+withWritableDb = withDb uploadedConfig
+
+withDb :: (Text -> FilePath -> DatabaseConfig) -> (AppEnv -> IO ()) -> IO ()
+withDb mkConfig act =
+    withSystemTempDirectory "volca-write" $ \root ->
+        bracket_ (setEnv "VOLCA_DATA_DIR" root) (unsetEnv "VOLCA_DATA_DIR") $ do
+            let dataDir = root </> "uploads" </> "databases" </> "authored" </> "data"
+            createDirectoryIfMissing True dataDir
+            dbm <- initDatabaseManager defaultConfig True Nothing
+            db <- buildFixture
+            solver <- createSharedSolver "authored" (triplesOf db) (fromIntegral (dbActivityCount db))
+            let config = mkConfig "authored" dataDir
+                loaded = LoadedDatabase{ldDatabase = db, ldSharedSolver = solver, ldConfig = config}
+            atomically $ do
+                modifyTVar' (dmLoadedDbs dbm) (M.insert "authored" loaded)
+                modifyTVar' (dmAvailableDbs dbm) (M.insert "authored" config)
+            act
+                AppEnv
+                    { aeDbManager = dbm
+                    , aeMaxTreeDepth = 10
+                    , aePassword = Nothing
+                    , aeHostingConfig = Nothing
+                    , aeClassificationPresets = []
+                    }
+  where
+    triplesOf db = [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList (dbTechnosphereTriples db)]
+
+uploadedConfig :: Text -> FilePath -> DatabaseConfig
+uploadedConfig name dataDir =
+    DatabaseConfig
+        { dcName = name
+        , dcDisplayName = name
+        , dcPath = dataDir
+        , dcDescription = Nothing
+        , dcLoad = True
+        , dcDefault = False
+        , dcDepends = []
+        , dcLocationAliases = M.empty
+        , dcFormat = Just EcoSpold2
+        , dcIsUploaded = True
+        , dcDeletable = True
+        , dcGeographyPolicy = GeoGlobal
+        }
+
+-- ---------------------------------------------------------------------------
+-- Request fixtures
+-- ---------------------------------------------------------------------------
+
+cheese :: ActivityInput
+cheese =
+    ActivityInput
+        { aiName = "cheese, at dairy"
+        , aiLocation = "FR"
+        , aiDescription = []
+        , aiProductName = "cheese"
+        , aiProductAmount = 1
+        , aiProductUnit = "kg"
+        , aiInputs = [TechInputAPI{tiProvider = supplierPid, tiAmount = 8, tiUnit = Nothing, tiComment = Nothing}]
+        , aiBiosphere = []
+        , aiWasteOutputs = []
+        }
+
+emission :: BioExchangeAPI
+emission =
+    BioExchangeAPI
+        { beFlow = Nothing
+        , beName = Nothing
+        , beCompartment = Just "air"
+        , beSubCompartment = Nothing
+        , beDirection = "emission"
+        , beAmount = 0.5
+        , beUnit = Just "kg"
+        , beComment = Nothing
+        }
+
+{- | The identity the engine will mint for an activity input — the same
+function 'Database.Author' uses, restated here as the caller's expectation
+rather than borrowed, so a change to the minting rule fails this test loudly.
+-}
+keyOf :: ActivityInput -> Text
+keyOf ai =
+    UUID.toText (authoredActivityUUID (aiName ai) (aiLocation ai))
+        <> "_"
+        <> UUID.toText (authoredProductUUID (aiProductName ai) (aiProductUnit ai))
+
+-- ---------------------------------------------------------------------------
+-- Database fixture
+-- ---------------------------------------------------------------------------
+
+buildFixture :: IO Database
+buildFixture = do
+    r <-
+        buildDatabaseWithMatrices
+            defaultUnitConfig
+            (M.singleton (supplierActId, supplierProdId) milkActivity)
+            (M.singleton supplierProdId milkFlow)
+            (M.singleton co2Id co2Flow)
+            M.empty
+            unitTable
+    either (fail . show) pure r
+
+mkUUID :: Int -> UUID
+mkUUID n = UUID.fromWords64 (fromIntegral n) 0
+
+supplierActId, supplierProdId, co2Id, kgUnitId :: UUID
+supplierActId = mkUUID 1
+supplierProdId = mkUUID 2
+co2Id = mkUUID 3
+kgUnitId = mkUUID 10
+
+supplierPid :: Text
+supplierPid = UUID.toText supplierActId <> "_" <> UUID.toText supplierProdId
+
+unitTable :: M.Map UUID Unit
+unitTable = M.singleton kgUnitId Unit{unitId = kgUnitId, unitName = "kg", unitSymbol = "kg", unitComment = ""}
+
+milkFlow :: TechnosphereFlow
+milkFlow =
+    TechnosphereFlow
+        { tfId = supplierProdId
+        , tfName = "milk"
+        , tfUnitId = kgUnitId
+        , tfSynonyms = M.empty
+        , tfCAS = Nothing
+        , tfSubstanceId = Nothing
+        }
+
+co2Flow :: BiosphereFlow
+co2Flow =
+    BiosphereFlow
+        { bfId = co2Id
+        , bfName = "Carbon dioxide"
+        , bfUnitId = kgUnitId
+        , bfSynonyms = M.empty
+        , bfCAS = Just "124-38-9"
+        , bfSubstanceId = Nothing
+        , bfCompartment = Just Compartment{compartmentName = "air", compartmentSub = Nothing}
+        }
+
+milkActivity :: Activity
+milkActivity =
+    Activity
+        { activityName = "milk production"
+        , activityDescription = []
+        , activitySynonyms = M.empty
+        , activityClassification = M.empty
+        , activityLocation = "FR"
+        , activityLocationSource = LocationDeclared
+        , activityUnit = "kg"
+        , exchanges =
+            [ TechnosphereExchange
+                { techFlowId = supplierProdId
+                , techAmount = 1.0
+                , techUnitId = kgUnitId
+                , techRole = ReferenceProduct
+                , techActivityLinkId = supplierActId
+                , techProcessLinkId = Nothing
+                , techLocation = ""
+                , techComment = Nothing
+                , techPedigree = Nothing
+                }
+            , BiosphereExchange
+                { bioFlowId = co2Id
+                , bioAmount = 1.2
+                , bioUnitId = kgUnitId
+                , bioDirection = Emission
+                , bioLocation = ""
+                , bioComment = Nothing
+                , bioPedigree = Nothing
+                }
+            ]
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
+        , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
+        }

--- a/test/ActivityWriteHandlerSpec.hs
+++ b/test/ActivityWriteHandlerSpec.hs
@@ -134,6 +134,17 @@ spec = describe "writing activities over HTTP" $ do
                     errHTTPCode err `shouldBe` 400
                     bodyOf err `shouldSatisfy` isInfixOf "reads from its configuration"
 
+    it "refuses an empty batch instead of rewriting the database for nothing" $
+        -- Committing re-serializes the whole database and rebuilds its
+        -- solver; an empty batch would pay all of that to write nothing.
+        withWritableDb $ \env -> do
+            res <- create env "authored" []
+            case res of
+                Right _ -> expectationFailure "expected the empty batch to be refused"
+                Left err -> do
+                    errHTTPCode err `shouldBe` 400
+                    bodyOf err `shouldSatisfy` isInfixOf "nothing to write"
+
     it "answers 404 for a database that is not loaded" $
         withWritableDb $ \env -> do
             res <- create env "no-such-db" [cheese]

--- a/test/AuthorSpec.hs
+++ b/test/AuthorSpec.hs
@@ -128,8 +128,8 @@ spec = do
                     Right _ -> expectationFailure "expected the batch to be refused"
                     Left errs -> do
                         length errs `shouldBe` 3
-                        errs `shouldSatisfy` any (isInfixOf "two-problems {FR}: exchange 1: unknown provider")
-                        errs `shouldSatisfy` any (isInfixOf "exchange 2: no biosphere flow")
+                        errs `shouldSatisfy` any (isInfixOf "two-problems {FR}: input from \"nope\": unknown provider")
+                        errs `shouldSatisfy` any (isInfixOf ": no biosphere flow")
                         errs `shouldSatisfy` any (isInfixOf "unknown unit \"furlong\"")
 
             it "refuses a batch that mints one identity twice" $

--- a/test/ReadOnlySpec.hs
+++ b/test/ReadOnlySpec.hs
@@ -19,6 +19,7 @@ import Test.Hspec
 
 import API.DatabaseHandlers (
     addDependencyHandler,
+    createActivitiesHandler,
     deleteActivitiesHandler,
     deleteDatabaseHandler,
     finalizeDatabaseHandler,
@@ -26,12 +27,13 @@ import API.DatabaseHandlers (
     loadDatabaseHandler,
     relinkDatabaseHandler,
     removeDependencyHandler,
+    replaceActivityHandler,
     unloadDatabaseHandler,
     uploadDatabaseHandler,
  )
 import API.MCP (callTool, toolDefinitions)
 import API.Resources (Resource (..), allResources, resourceMutates)
-import API.Types (DeleteSelectionRequest (..), RelinkRequest (..))
+import API.Types (ActivityInput (..), ActivityWriteRequest (..), DeleteSelectionRequest (..), RelinkRequest (..))
 import App.Env (AppEnv (..), runApp)
 import Config (HostingConfig (..), ReadOnly (..), defaultConfig, hostingReadOnly)
 import Database.Manager (initDatabaseManager)
@@ -85,9 +87,23 @@ mutatingHandlers =
     , ("remove-dependency", run (removeDependencyHandler "nope" "dep"))
     , ("finalize", run (finalizeDatabaseHandler "nope"))
     , ("upload", run (uploadDatabaseHandler (Just "nope") Nothing (source [])))
+    , ("create-activities", run (createActivitiesHandler "nope" (ActivityWriteRequest [])))
+    , ("replace-activity", run (replaceActivityHandler "nope" "id" nothingInParticular))
     ]
   where
     run h env = statusOf <$> runHandler (runApp env h)
+    nothingInParticular =
+        ActivityInput
+            { aiName = ""
+            , aiLocation = ""
+            , aiDescription = []
+            , aiProductName = ""
+            , aiProductAmount = 0
+            , aiProductUnit = ""
+            , aiInputs = []
+            , aiBiosphere = []
+            , aiWasteOutputs = []
+            }
     everything =
         DeleteSelectionRequest
             { dsqName = Nothing

--- a/volca.cabal
+++ b/volca.cabal
@@ -321,6 +321,7 @@ test-suite lca-tests
                      , AggregateSpec
                      , CopySpec
                      , AuthorSpec
+                     , ActivityWriteHandlerSpec
                      , PersistenceSpec
                      , DeleteSelectionSpec
                      , ExportSpec


### PR DESCRIPTION
## Why

The engine could verify an inventory and persist an edit, but nothing could
send it one. Authoring stopped at the library boundary.

## What it does

`POST /api/v1/db/{db}/activities` adds to the collection,
`PUT /api/v1/db/{db}/activity/{process-id}` rewrites the one addressed, and
`volca database create-activities` / `replace-activity` do the same from the
command line, reading the JSON document the endpoints accept. One description
of an activity works over either transport and against a local or a remote
engine.

Two verbs, no upsert between them: a mistyped identity must fail rather than
quietly become a duplicate of the row it meant to correct, so the two refusals
a client acts on stay distinguishable - 409 for writing over a row that exists,
404 for rewriting one that does not.

## One write core, two surfaces

Rather than let the CLI reimplement the endpoint, the whole of authoring above
the primitives lives in `Database.Edit.writeActivities`, which both callers
share: neither can allow what the other forbids. It returns a typed
`WriteRefusal`, and each caller maps the constructors to what it owes its user
— statuses for one, a message and a non-zero exit for the other. Nothing sniffs
a message prefix to pick a status.

## The shape of a request

The inventory arrives as three lists (inputs, biosphere, waste outputs) rather
than one tagged list, so a field that means something on a supplier link cannot
be sent on an emission.

Identity is not sent at all — it is minted from the name, location, product and
unit — which is why the `PUT` refuses a body that would land somewhere other
than the path it was sent to. That mismatch is checked before presence: a body
that mints elsewhere describes a process the database may well not have, and
answering "no such activity" sent the author looking for the wrong mistake.

Complaints name an exchange by its supplier or its flow rather than by
position, since a caller who sent three lists has no single index to count.

## What is refused

A database the engine reads from its configuration: it is background data the
whole installation shares, and a copy or an upload is the place to write. And a
read-only instance (#265), which is shared by callers who did not ask for the
write — the two new endpoints join the others behind `guardMutation`, and
`ReadOnlySpec` lists them, which also pins that a writable instance never
answers 403.

## Wire revision 5

An absent route answers 404, and so does a request naming a database that is
not loaded. Without the revision a client cannot tell "this engine is too old"
from "you asked for the wrong thing". The pyvolca client that gates on it is a
separate pull request, to be merged after this one.
