### PR TITLE
Read every term of a summed SimaPro amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@
   delete response now says so with two new fields, `transient` and `warnings`.
 
 ### Fixed
+- A SimaPro amount written as a sum is now added up. An exporter may state a
+  quantity in place, `0,45+0,247+,067`, and drop the integer part of a term.
+  The reader wanted a digit before every decimal point, so one such term made
+  the whole expression unreadable and the amount silently became the number it
+  began with: 0.45 where the file says 0.764. In Agribalyse 3.2 this fell on
+  the pesticide emission mixes — the shares of a mix stopped adding up to the
+  kilogram they divide, and the freshwater ecotoxicity of the cereal crops
+  built on them came out about 10% low.
 - The MCP handshake announced version `0.6.0` whatever the build was; it now
   reports the running version.
 - The dependency chosen for an uploaded database is now written into its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@
   began with: 0.45 where the file says 0.764. In Agribalyse 3.2 this fell on
   the pesticide emission mixes — the shares of a mix stopped adding up to the
   kilogram they divide, and the freshwater ecotoxicity of the cereal crops
-  built on them came out about 10% low.
+  built on them came out about 10% low. And when an amount really cannot be
+  read, the import now says so: a warning names the process, the text it could
+  not read, and the value used in its place.
 - The MCP handshake announced version `0.6.0` whatever the build was; it now
   reports the running version.
 - The dependency chosen for an uploaded database is now written into its

--- a/src/Expr.hs
+++ b/src/Expr.hs
@@ -106,8 +106,8 @@ round exactly as the same literal does on its own.
 -}
 pNumber :: Parser Double
 pNumber = lexeme $ do
-    token <- pNumberToken
-    maybe (fail ("not a number: " <> T.unpack token)) pure (readAmount token)
+    literal <- pNumberToken
+    maybe (fail ("not a number: " <> T.unpack literal)) pure (readAmount literal)
 
 {- | Digits with an optional point and an optional exponent. The sign belongs to
 'pUnary', so it is not part of the token.

--- a/src/Expr.hs
+++ b/src/Expr.hs
@@ -10,7 +10,9 @@ module Expr (
     collectIdentifiers,
 ) where
 
-import Control.Monad (void)
+import Amount (readAmount)
+import Control.Monad (void, when)
+import Data.Char (isDigit)
 import Data.Either (isRight)
 import qualified Data.Map.Strict as M
 import Data.Maybe (catMaybes)
@@ -91,8 +93,40 @@ pPrimary env =
         , pVariable env
         ]
 
+{- | A numeric literal, tokenized here and read by 'readAmount'.
+
+The integer part is optional. SimaPro exports drop it: Agribalyse writes the
+cereal fungicide mix as @0,45+0,247+,067@, whose last term normalizes to
+@.067@. Megaparsec's 'L.float' requires a digit before the point, so one such
+term used to fail the /whole/ expression, and the caller then fell back to
+reading the leading number — 0.45 where the file says 0.764.
+
+Handing the token to 'readAmount' also makes a literal inside an expression
+round exactly as the same literal does on its own.
+-}
 pNumber :: Parser Double
-pNumber = lexeme $ try L.float <|> (fromIntegral <$> (L.decimal :: Parser Integer))
+pNumber = lexeme $ do
+    token <- pNumberToken
+    maybe (fail ("not a number: " <> T.unpack token)) pure (readAmount token)
+
+{- | Digits with an optional point and an optional exponent. The sign belongs to
+'pUnary', so it is not part of the token.
+-}
+pNumberToken :: Parser Text
+pNumberToken = try $ do
+    whole <- takeWhileP (Just "digit") isDigit
+    fractional <- option "" (T.cons <$> char '.' <*> takeWhileP (Just "digit") isDigit)
+    -- Digits somewhere: a lone "." is not a number, and neither is the empty
+    -- string, which would otherwise match every identifier and every operator.
+    when (T.null whole && T.length fractional < 2) (fail "expected a number")
+    exponent' <- option "" (try pExponent)
+    pure (whole <> fractional <> exponent')
+  where
+    pExponent = do
+        marker <- oneOf ("eE" :: String)
+        sign <- option "" (T.singleton <$> oneOf ("+-" :: String))
+        digits <- takeWhile1P (Just "digit") isDigit
+        pure (T.cons marker (sign <> digits))
 
 -- | Look up a variable in the pre-lowercased env. Case-insensitive by construction.
 pVariable :: M.Map Text Double -> Parser Double

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -13,6 +13,9 @@ module SimaPro.Parser (
     ProductRow (..),
     TechExchangeRow (..),
     BioExchangeRow (..),
+    GlobalParams (..),
+    emptyProcessBlock,
+    fallbackAmounts,
     generateActivityUUID,
     generateFlowUUID,
     generateUnitUUID,
@@ -36,6 +39,7 @@ module SimaPro.Parser (
 ) where
 
 import Amount (readAmount)
+import Control.Applicative ((<|>))
 import Control.Concurrent.Async (mapConcurrently)
 import Control.DeepSeq (NFData, force)
 import Control.Exception (evaluate)
@@ -876,11 +880,37 @@ extractLocation name =
 resolveAmount :: M.Map Text Double -> Text -> Double -> Double
 resolveAmount env raw fallback
     | T.null raw = fallback
-    | otherwise = case readAmount raw of
-        Just v -> v
-        Nothing -> case Expr.evaluate env raw of
-            Right v -> v
-            Left _ -> fallback
+    | otherwise = fromMaybe fallback (resolveExpr env raw)
+
+-- | A number, or an expression over the parameter environment. Nothing: neither.
+resolveExpr :: M.Map Text Double -> Text -> Maybe Double
+resolveExpr env raw = readAmount raw <|> either (const Nothing) Just (Expr.evaluate env raw)
+
+{- | Every raw amount in a block that 'resolveAmount' will replace with its
+lenient fallback: not a number, and not an expression the block's parameter
+environment can evaluate. Reported as warnings at the IO edge, like the CAS
+conflicts, so the conversion itself stays pure and a wrong amount never
+passes without a word.
+-}
+fallbackAmounts :: GlobalParams -> ProcessBlock -> [(Text, Text, Double)]
+fallbackAmounts gp pb@ProcessBlock{..} =
+    [ (blockName, raw, fallback)
+    | (raw, fallback) <- rawAmounts
+    , not (T.null raw)
+    , isNothing (resolveExpr env raw)
+    ]
+  where
+    -- Forced only when a raw fails 'readAmount', so a block of plain numbers
+    -- never builds its environment a second time.
+    env = fst (blockParamEnv gp pb)
+    blockName = case nonEmptyText (T.strip pbName) of
+        Just n -> n
+        Nothing -> maybe "unnamed process" prName (listToMaybe pbProducts)
+    rawAmounts =
+        concatMap (\p -> [(prAmountRaw p, prAmount p), (prAllocRaw p, prAllocation p)]) pbProducts
+            ++ map (\p -> (prAmountRaw p, prAmount p)) pbAvoidedProducts
+            ++ map (\r -> (terAmountRaw r, terAmount r)) (pbMaterials ++ pbElectricity ++ pbWasteToTreatment)
+            ++ map (\r -> (berAmountRaw r, berAmount r)) (pbResources ++ pbEmissionsAir ++ pbEmissionsWater ++ pbEmissionsSoil ++ pbFinalWaste)
 
 {- | Build the resolved parameter environment and the raw-expression map from
 ordered parameter groups. Input groups are resolved with a single pass each;
@@ -900,6 +930,13 @@ buildParamEnv inputGroups calcGroups =
         let acc' = foldl' evalParam acc params
          in if M.size acc' == M.size acc then acc' else evalToFixpoint acc' params
 
+-- | The parameter environment a block's amounts are evaluated in.
+blockParamEnv :: GlobalParams -> ProcessBlock -> (M.Map Text Double, M.Map Text Text)
+blockParamEnv GlobalParams{..} ProcessBlock{..} =
+    buildParamEnv
+        (reverse <$> [gpDbInput, gpProjInput, pbInputParams])
+        (reverse <$> [gpDbCalc, gpProjCalc, pbCalcParams])
+
 {- | Convert ProcessBlock to list of Activities (one per product)
 This matches EcoSpold behavior where multi-product processes create multiple activities
 Global params (db + project level) are passed in and combined with process-level params.
@@ -909,7 +946,7 @@ processBlockToActivity ::
     GlobalParams ->
     ProcessBlock ->
     [(Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit])]
-processBlockToActivity unitCfg GlobalParams{..} ProcessBlock{..} =
+processBlockToActivity unitCfg gp pb@ProcessBlock{..} =
     map makeActivity productsInFileOrder
   where
     -- pbProducts is accumulated by prepending; restore file order so the
@@ -925,10 +962,7 @@ processBlockToActivity unitCfg GlobalParams{..} ProcessBlock{..} =
         [] -> ""
     referenceReading = extractLocation referenceName
     fallbackName = maybe referenceName locatedName referenceReading
-    (env, exprMap) =
-        buildParamEnv
-            (reverse <$> [gpDbInput, gpProjInput, pbInputParams])
-            (reverse <$> [gpDbCalc, gpProjCalc, pbCalcParams])
+    (env, exprMap) = blockParamEnv gp pb
 
     processReading = extractLocation pbName
 
@@ -1495,6 +1529,17 @@ parseSimaProCSV unitCfg path = do
 
     -- Convert all blocks to activities (one activity per product) - PARALLEL
     converted <- concat <$> mapConcurrently (evaluate . force . processBlockToActivity unitCfg globalParams) allBlocks
+
+    -- Surface every amount the conversion replaced with its lenient fallback:
+    -- a number that silently shrinks is worse than a warned one.
+    fallbacks <- concat <$> mapConcurrently (evaluate . force . fallbackAmounts globalParams) allBlocks
+    forM_ fallbacks $ \(name, raw, fallback) ->
+        reportProgress Warning $
+            printf
+                "amount '%s' in '%s' is neither a number nor a resolvable expression; using %g"
+                (T.unpack raw)
+                (T.unpack name)
+                fallback
     let activities = map (\(a, _, _, _, _) -> a) converted
         allTechFlows = concatMap (\(_, tf, _, _, _) -> tf) converted
         allBioFlows = concatMap (\(_, _, bf, _, _) -> bf) converted

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -14,10 +14,13 @@ import SimaPro.Parser (
     BioExchangeRow (..),
     Located (..),
     NameReading (..),
+    ProcessBlock (..),
     ProductRow (..),
     TechExchangeRow (..),
     defaultConfig,
+    emptyProcessBlock,
     extractLocation,
+    fallbackAmounts,
     generateActivityUUID,
     generateFlowUUID,
     generateUnitUUID,
@@ -707,6 +710,28 @@ spec = do
             length bioExchanges `shouldBe` 1
             -- CO2 = 0.5 * allocButter/100 ≈ 0.5 * 0.25285 ≈ 0.1264
             bioAmount (head bioExchanges) `shouldSatisfy` (\x -> abs (x - 0.1264) < 0.01)
+
+    -- The conversion falls back to a lenient numeric parse when an amount is
+    -- neither a number nor an evaluable expression; 'fallbackAmounts' is the
+    -- pure list of those replacements, reported as warnings on import.
+    describe "fallbackAmounts" $ do
+        let mixRow raw =
+                TechExchangeRow
+                    { terName = "Mix input"
+                    , terUnit = "kg"
+                    , terAmount = 0.45
+                    , terAmountRaw = raw
+                    , terUncertainty = ""
+                    , terComment = ""
+                    }
+            block raw = emptyProcessBlock{pbName = "Fungicide mix", pbMaterials = [mixRow raw]}
+        it "lists an amount it cannot resolve, with the value used instead" $
+            fallbackAmounts mempty (block "0.45+bogus")
+                `shouldBe` [("Fungicide mix", "0.45+bogus", 0.45)]
+        it "stays silent for numbers, expressions, and resolvable parameters" $ do
+            fallbackAmounts mempty (block "0.45") `shouldBe` []
+            fallbackAmounts mempty (block "0.45+0.247+.067") `shouldBe` []
+            fallbackAmounts mempty ((block "dose*2"){pbInputParams = [("dose", "0.5")]}) `shouldBe` []
 
     describe "SimaPro amounts summed in place" $ do
         it "sums every term of the expression, integer part or not" $ do

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -395,6 +395,49 @@ parseYieldChainCSV = withSystemTempFile "yield-test.csv" $ \path handle -> do
     hClose handle
     parseSimaProCSV defaultUnitConfig path
 
+{- | The shape Agribalyse writes a pesticide emission mix in: the amount is
+summed in place, and one term drops its integer part (@,067@).
+
+The three shares are a partition of one kilogram, so a truncated first term
+does not merely shrink one row — it makes the block stop summing to its own
+reference, which is what the assertions below check.
+-}
+summedAmountTestCSV :: BS.ByteString
+summedAmountTestCSV =
+    BS.intercalate
+        "\r\n"
+        [ "{SimaPro 9.6.0.1}"
+        , "{CSV separator: semicolon}"
+        , "{Decimal separator: ,}"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , "Fungicide emission mix"
+        , ""
+        , "Type"
+        , "Unit process"
+        , ""
+        , "Products"
+        , "Fungicide emissions {GLO} U;kg;1;100;not defined;material;"
+        , ""
+        , "Materials/fuels"
+        , "Cyclic N-compound emission {GLO} U;kg;0,45+0,247+,067;Undefined;;;;;;"
+        , "Sulfur emission {GLO} U;kg;0,161;Undefined;;;;;;"
+        , "Benzimidazole-compound emission {GLO} U;kg;0,075;Undefined;;;;;;"
+        , ""
+        , "End"
+        ]
+
+parseSummedAmountCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)
+parseSummedAmountCSV = withSystemTempFile "summed-amount-test.csv" $ \path handle -> do
+    BS.hPut handle summedAmountTestCSV
+    hClose handle
+    parseSimaProCSV defaultUnitConfig path
+
 -- Helper: get all tech input amounts
 techInputAmounts :: Activity -> [Double]
 techInputAmounts act =
@@ -468,6 +511,29 @@ spec = do
 
         it "rejects unknown variables" $ do
             evaluate M.empty "xyz" `shouldSatisfy` isLeft
+
+        -- Regression: SimaPro exports drop the integer part of a decimal, and
+        -- Agribalyse sums a pesticide mix in place — "0,45+0,247+,067". The
+        -- last term made the whole expression unparseable, and the amount
+        -- silently became its leading number: 0.45 where the file says 0.764.
+        it "evaluates decimals written without their integer part" $ do
+            evaluate M.empty ".067" `shouldBe` Right 0.067
+            evaluate M.empty "0.45+0.247+.067" `shouldBe` Right (0.45 + 0.247 + 0.067)
+            evaluate M.empty ".5*2" `shouldBe` Right 1.0
+            evaluate M.empty "-.5" `shouldBe` Right (-0.5)
+            evaluate M.empty "(.25+.75)*4" `shouldBe` Right 4.0
+            evaluate M.empty ".5e1" `shouldBe` Right 5.0
+
+        it "still rejects a point that is not part of a number" $ do
+            evaluate M.empty "." `shouldSatisfy` isLeft
+            evaluate M.empty "1+." `shouldSatisfy` isLeft
+            evaluate M.empty ".+1" `shouldSatisfy` isLeft
+
+        it "reads a literal in an expression exactly as it reads it alone" $ do
+            -- Not 'read'/'L.float' rounding: both paths go through readAmount,
+            -- so a literal keeps its value when an operator is put next to it.
+            evaluate M.empty "0.0000010897906999999999"
+                `shouldBe` evaluate M.empty "0.0000010897906999999999*1"
 
         -- Regression: Agribalyse Emmental defines the dry-matter param as "Dmper"
         -- but references "DMper" in the allocation formula. SimaPro treats parameter
@@ -641,6 +707,18 @@ spec = do
             length bioExchanges `shouldBe` 1
             -- CO2 = 0.5 * allocButter/100 ≈ 0.5 * 0.25285 ≈ 0.1264
             bioAmount (head bioExchanges) `shouldSatisfy` (\x -> abs (x - 0.1264) < 0.01)
+
+    describe "SimaPro amounts summed in place" $ do
+        it "sums every term of the expression, integer part or not" $ do
+            (activities, _, _, _, _) <- parseSummedAmountCSV
+            let mix = head activities
+            techInputAmounts mix `shouldMatchList` [0.45 + 0.247 + 0.067, 0.161, 0.075]
+
+        it "keeps the mix a partition of its own reference product" $ do
+            (activities, _, _, _, _) <- parseSummedAmountCSV
+            let mix = head activities
+            refProductAmount mix `shouldBe` Just 1.0
+            sum (techInputAmounts mix) `shouldSatisfy` (\x -> abs (x - 1.0) < 1e-9)
 
     describe "SimaPro database-level parameters" $ do
         it "resolves database input params in exchange amounts" $ do


### PR DESCRIPTION
A SimaPro export can state an amount as an expression rather than a number, and
it can write a decimal without its integer part. Agribalyse 3.2 does both at
once on the pesticide emission mixes:

    Emission from fungicides, unspecified, family Cyclic N-compound;kg;0,45+0,247+,067

That is 0.764 kg. The expression evaluator's number parser required a digit
before every decimal point, so the last term failed to parse and took the whole
expression down with it. The amount then fell back to the leading literal, and
the exchange carried **0.45**.

Nothing said so. The mix stopped being a partition of the kilogram it divides —
0.45 + 0.161 + 0.075 = 0.686 — and every cereal built on it lost about a tenth
of its freshwater ecotoxicity. That shortfall is indistinguishable from a
missing characterization factor, which is what makes it worth a regression test
rather than a one-line patch.

## What changed

The numeric token now allows the integer part to be absent, and is read by
`readAmount` — the correctly-rounded reader the importers already share — so a
literal inside an expression keeps the value it has on its own.

Nothing else in the grammar moves: sums, products, parentheses, exponents and
variables behave as before, and a lone `.` is still not a number.

## Checked

Cutting the real block out of the Agribalyse 3.2 export and loading it: the
Cyclic N-compound share reads 0.764 and the three inputs sum to exactly the
1 kg the block produces. The new tests fail on the parent commit and pass here;
the full suite is green (2026 examples, 0 failures).