### PR TITLE
Make the PyPI page point somewhere, and be findable

### DIFF
--- a/pyvolca/CHANGELOG.md
+++ b/pyvolca/CHANGELOG.md
@@ -32,7 +32,7 @@ Then paste the rendered block at the top of this file and tighten wording.
 - The PyPI listing carries keywords (`lca`, `life-cycle-assessment`,
   `life-cycle-inventory`, `lcia`, `environmental-data`) and the classifiers
   that place it: research audience, OS independent, and the Python versions it
-  is tested against. Searching PyPI for "life cycle assessment" found nothing
+  supports. Searching PyPI for "life cycle assessment" found nothing
   before this.
 
 ## [0.9.1] - 2026-08-01

--- a/pyvolca/CHANGELOG.md
+++ b/pyvolca/CHANGELOG.md
@@ -18,6 +18,23 @@ git cliff --unreleased --tag pyvolca-v0.X.Y   # render as a released section
 
 Then paste the rendered block at the top of this file and tighten wording.
 
+## [Unreleased]
+
+### Fixed
+
+- The Documentation link on the PyPI page pointed at a page that does not
+  exist and answered 404. It now points at <https://volca.run/docs/python/>,
+  where the guide has been all along. The same dead address was in the
+  package's own module docstring, so `help(volca)` sent people there too.
+
+### Added
+
+- The PyPI listing carries keywords (`lca`, `life-cycle-assessment`,
+  `life-cycle-inventory`, `lcia`, `environmental-data`) and the classifiers
+  that place it: research audience, OS independent, and the Python versions it
+  is tested against. Searching PyPI for "life cycle assessment" found nothing
+  before this.
+
 ## [0.9.1] - 2026-08-01
 
 ### Added

--- a/pyvolca/pyproject.toml
+++ b/pyvolca/pyproject.toml
@@ -10,8 +10,24 @@ dependencies = [
     "requests>=2.28",
     "platformdirs>=4.0",
 ]
+keywords = [
+    "lca",
+    "life-cycle-assessment",
+    "life-cycle-inventory",
+    "lcia",
+    "environmental-data",
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    # No License classifier: the SPDX `license` field above supersedes it, and
+    # setuptools refuses a build that carries both (PEP 639).
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
 ]
 
@@ -19,7 +35,7 @@ classifiers = [
 dev = ["pytest", "pyright==1.1.411"]
 
 [project.urls]
-Documentation = "https://volca.run/docs/guides/pyvolca/"
+Documentation = "https://volca.run/docs/python/"
 Repository = "https://github.com/ccomb/volca/tree/main/pyvolca"
 Issues = "https://github.com/ccomb/volca/issues"
 

--- a/pyvolca/src/volca/__init__.py
+++ b/pyvolca/src/volca/__init__.py
@@ -1,6 +1,6 @@
 """VoLCA Python client — Life Cycle Assessment engine.
 
-See https://volca.run/docs/guides/pyvolca/ for the full guide.
+See https://volca.run/docs/python/ for the full guide.
 """
 
 from ._download import DownloadError, Installed, download

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -11,8 +11,8 @@ handle path substitution, query-string assembly, and JSON decoding.
 This removes ~250 lines of hand-written query-param plumbing and
 decouples pyvolca's PyPI release cadence from engine endpoint changes:
 when the engine renames a query parameter, pyvolca picks it up on the
-next spec fetch with no code change. See ``docs/guides/pyvolca.md`` for
-the user-facing view.
+next spec fetch with no code change. See ``README.md`` for the
+user-facing view.
 
 Kwarg name translation
 ----------------------


### PR DESCRIPTION
## Why

Two things wrong with what pyvolca 0.9.1 published.

**The Documentation link is a 404.** It names `/docs/guides/pyvolca/`, a path
the site has never served — the guide is at `/docs/python/`. Verified both
addresses before changing anything. The same dead URL was in the package's own
module docstring, so `help(volca)` sent people there too, and a comment in
`client.py` pointed at a `docs/guides/pyvolca.md` that does not exist in this
repository.

Interesting detail: the site build has been papering over this. `gen-docs.sh`
rewrites `/docs/guides/pyvolca/` to `/docs/python/` when it generates the docs
page, so the published site was always right and only the package metadata was
wrong — which is exactly why nobody noticed.

**Nothing made it findable.** No keywords, and two classifiers. Searching PyPI
for "life cycle assessment" did not turn it up.

## Final state

```
Project-URL: Documentation, https://volca.run/docs/python/
Keywords: lca,life-cycle-assessment,life-cycle-inventory,lcia,environmental-data
Classifier: Development Status :: 3 - Alpha
Classifier: Intended Audience :: Science/Research
Classifier: Operating System :: OS Independent
Classifier: Programming Language :: Python :: 3 (and 3.10 … 3.13)
Classifier: Topic :: Scientific/Engineering
License-Expression: Apache-2.0
```

No `License :: OSI Approved ::` classifier, deliberately: the SPDX `license`
field supersedes it and setuptools **refuses to build** a package carrying
both (PEP 639). Found that by building rather than by reading, which is why it
is a comment in the file now.

The Alpha status stays: it is honest.

## Verification

`uv build` succeeds and the wheel's METADATA is the block above.
`uv run --all-extras pytest -q` → 263 passed, 7 skipped.