### PR TITLE
Refuse an amount cell that is more than a number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@
   delete response now says so with two new fields, `transient` and `warnings`.
 
 ### Fixed
+- A SimaPro amount cell the engine cannot read is now zero and warned about,
+  instead of the number the cell happens to begin with. The reader used to stop
+  at the first character that is not part of a number and keep what it had, so
+  `1,5 kg` became 1.5 and `124902,34825322*1/Qp` — an expression whose parameter
+  went missing — became a hundred and twenty-five thousand. An amount that is
+  wrong by orders of magnitude and looks ordinary is the hardest kind to find;
+  the import now names the cell it could not read and the value it used.
 - A SimaPro amount written as a sum is now added up. An exporter may state a
   quantity in place, `0,45+0,247+,067`, and drop the integer part of a term.
   The reader wanted a digit before every decimal point, so one such term made

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -423,7 +423,7 @@ is not part of one used to turn @0,45+0,247+,067@ into 0.45 — a number of the
 right order of magnitude, wrong by a third, indistinguishable from a real one
 downstream. An amount cell that is not a literal is an expression, and
 'resolveAmount' evaluates it; one that is neither is surfaced by
-'unreadableAmounts' rather than approximated here.
+'fallbackAmounts' rather than approximated here.
 -}
 parseAmount :: Char -> BS.ByteString -> Double
 parseAmount decimalSep bs

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -415,19 +415,24 @@ decodeBS :: BS.ByteString -> Text
 decodeBS = TE.decodeUtf8With TEE.lenientDecode
 {-# INLINE decodeBS #-}
 
--- | Parse amount with configurable decimal separator (ByteString)
+{- | Read a plain decimal cell, with the file's decimal separator. 0 when the
+cell holds anything else.
+
+The whole cell has to be the number. Reading it up to the first character that
+is not part of one used to turn @0,45+0,247+,067@ into 0.45 — a number of the
+right order of magnitude, wrong by a third, indistinguishable from a real one
+downstream. An amount cell that is not a literal is an expression, and
+'resolveAmount' evaluates it; one that is neither is surfaced by
+'unreadableAmounts' rather than approximated here.
+-}
 parseAmount :: Char -> BS.ByteString -> Double
 parseAmount decimalSep bs
     | BS.null bs = 0.0
-    | otherwise =
-        let normalized =
-                if decimalSep == ','
-                    then BS8.map (\c -> if c == ',' then '.' else c) bs
-                    else bs
-         in case reads (BS8.unpack normalized) of
-                [(val, "")] -> val
-                [(val, _)] -> val -- Allow trailing characters
-                _ -> 0.0
+    | otherwise = fromMaybe 0.0 (readAmount (decodeBS normalized))
+  where
+    normalized
+        | decimalSep == ',' = BS8.map (\c -> if c == ',' then '.' else c) bs
+        | otherwise = bs
 
 -- | Split a CSV line by delimiter, respecting RFC 4180 quoted fields.
 splitCSV :: Char -> BS.ByteString -> [BS.ByteString]

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -715,19 +715,16 @@ spec = do
     -- neither a number nor an evaluable expression; 'fallbackAmounts' is the
     -- pure list of those replacements, reported as warnings on import.
     describe "fallbackAmounts" $ do
-        let mixRow raw =
-                TechExchangeRow
-                    { terName = "Mix input"
-                    , terUnit = "kg"
-                    , terAmount = 0.45
-                    , terAmountRaw = raw
-                    , terUncertainty = ""
-                    , terComment = ""
-                    }
+        -- The row goes through the real row parser rather than a literal
+        -- record, so the value reported here is the one an import would use
+        -- and cannot drift from it.
+        let mixRow raw = case parseTechRow defaultConfig ("Mix input;kg;" <> raw <> ";Undefined;;;;;;") of
+                Just r -> r
+                Nothing -> error ("mixRow: unparseable row for " <> show raw)
             block raw = emptyProcessBlock{pbName = "Fungicide mix", pbMaterials = [mixRow raw]}
         it "lists an amount it cannot resolve, with the value used instead" $
             fallbackAmounts mempty (block "0.45+bogus")
-                `shouldBe` [("Fungicide mix", "0.45+bogus", 0.45)]
+                `shouldBe` [("Fungicide mix", "0.45+bogus", 0.0)]
         it "stays silent for numbers, expressions, and resolvable parameters" $ do
             fallbackAmounts mempty (block "0.45") `shouldBe` []
             fallbackAmounts mempty (block "0.45+0.247+.067") `shouldBe` []
@@ -799,6 +796,21 @@ spec = do
 
         it "returns 0.0 for non-numeric" $
             parseAmount '.' "abc" `shouldBe` 0.0
+
+        it "parses scientific notation" $ do
+            parseAmount '.' "1e-5" `shouldBe` 1e-5
+            parseAmount ',' "2,5E3" `shouldBe` 2500.0
+
+        -- The whole cell has to be the number. Reading it up to the first
+        -- character that is not part of one turned "0,45+0,247+,067" into
+        -- 0.45 — right order of magnitude, a third short, and nothing
+        -- downstream could tell it from a real amount. An expression is
+        -- 'resolveAmount''s business, and a cell that is neither is reported.
+        it "refuses a cell that is more than a number" $ do
+            parseAmount ',' "0,45+0,247+,067" `shouldBe` 0.0
+            parseAmount '.' "1.5*Qp" `shouldBe` 0.0
+            parseAmount ',' "1,5 kg" `shouldBe` 0.0
+            parseAmount '.' "12 (estimated)" `shouldBe` 0.0
 
     describe "parseProductRow" $ do
         it "parses 7-field product row" $


### PR DESCRIPTION
The SimaPro amount reader stopped at the first character that could not be part
of a number and kept what it had:

| cell | read as | is |
|---|---|---|
| `1,5 kg` | 1.5 | not a number |
| `124902,34825322*1/Qp` | 124902.35 | an expression, ~0.006 once `Qp` resolves |
| `0,45+0,247+,067` | 0.45 | 0.764 |

The last one is fixed at the source now that the evaluator reads every term.
The first two are the reader itself: it manufactures a plausible quantity out of
a cell it did not understand. A number wrong by five orders of magnitude that
still looks like a number is the hardest kind to find, because nothing
downstream can tell it from a real one.

## What changed

The whole cell has to be the number, read by `readAmount` — the reader the
importers already share. A cell that is an expression is unaffected: it is
evaluated where it is used. A cell that is neither now yields 0, and
`fallbackAmounts` already reports it by name on import, so the honest zero is
announced rather than swapped for a fragment of the text.

## Checked

The new assertions fail on the parent commit and pass here. The `fallbackAmounts`
fixture now builds its row through the real row parser instead of a hand-written
record, so the value it reports is the one an import would actually use.

`./build.sh --test --werror`: 2043 examples, 0 failures.

Agribalyse 3.2 holds 5 502 amount cells that begin with a digit and continue
into an expression; every one of them resolves through its parameters, so this
changes none of them. No characterization factor in EF 3.1 (adapted 1.03) is
affected either — all 288 018 of its factor cells are plain numbers.