### PR TITLE
Record edits in a journal instead of rewriting the database's sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,17 +40,21 @@
   instead of guessing from the data.
 
 ### Changed
-- Deleting activities from a database you uploaded or copied now survives a
-  restart. The engine rewrites the database's own source files before it
-  answers, so unloading and reloading returns what was written; previously the
-  sources and the matrix cache kept the pre-edit set and a restart quietly
-  brought every removed activity back. Only a database stored as EcoSpold 2 can
-  be written back, because its file names carry each process identity through a
-  reload; other formats refuse the edit and name the way out (export to
-  EcoSpold 2, upload that). A copy gets files of its own on the first save
-  instead of writing into the database it was copied from. A configured
+- Editing a database you uploaded or copied now survives a restart, whatever
+  format it is stored in. Previously the sources and the matrix cache kept the
+  pre-edit set, so a restart quietly brought every removed activity back. The
+  edits are now recorded in a journal beside the database's own files and
+  replayed when it is loaded again; the files themselves are never rewritten.
+  That is what lets an EcoSpold 1, SimaPro CSV, ILCD or Brightway Excel
+  database be edited at all: rewriting them would have worked only for
+  EcoSpold 2, because the others derive each process identity from names,
+  categories and the position of a dataset in its file, so saving would have
+  given every activity a new identity at the next read. A copy now gets a
+  directory of its own the moment it is made, holding its identity and its
+  edits but no data - it reads the files of the database it was copied from,
+  which can no longer be deleted while a copy still needs them. A configured
   database the engine only reads is still edited in memory alone, and the
-  delete response now says so with two new fields, `transient` and `warnings`.
+  delete response says so with two fields, `transient` and `warnings`.
 
 ### Fixed
 - A regionalized factor now comes from the method's most specific line, not from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@
   delete response says so with two fields, `transient` and `warnings`.
 
 ### Fixed
+- An uploaded database whose `meta.toml` recorded a path containing a backslash
+  or a quote came back with that character doubled. The file escapes them as
+  its format requires and nothing undid it on the way back, which on Windows
+  meant a nested data path that resolved to nothing.
 - A regionalized factor now comes from the method's most specific line, not from
   whichever line the file happened to list last. When a method writes both a
   medium-level factor and one naming the flow's own subcompartment, and both

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -884,7 +884,7 @@ uploadDatabaseHandler mName mDesc src = do
                 -- Create meta.toml for self-describing upload
                 let meta =
                         UploadedDB.UploadMeta
-                            { UploadedDB.umVersion = 1
+                            { UploadedDB.umVersion = UploadedDB.metaVersion
                             , UploadedDB.umDisplayName = name
                             , UploadedDB.umDescription = mDescription
                             , UploadedDB.umFormat = urFormat uploadResult -- Types are now unified
@@ -1082,7 +1082,7 @@ uploadMethodHandler mName mDesc src =
                 -- Create meta.toml (store path relative to upload dir)
                 let meta =
                         UploadedDB.UploadMeta
-                            { UploadedDB.umVersion = 1
+                            { UploadedDB.umVersion = UploadedDB.metaVersion
                             , UploadedDB.umDisplayName = name
                             , UploadedDB.umDescription = mDescription
                             , UploadedDB.umFormat = methodFormat

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -890,6 +890,7 @@ uploadDatabaseHandler mName mDesc src = do
                             , UploadedDB.umFormat = urFormat uploadResult -- Types are now unified
                             , UploadedDB.umDataPath = makeRelative uploadDir (urPath uploadResult)
                             , UploadedDB.umDepends = []
+                            , UploadedDB.umSource = Nothing
                             }
                 liftIO $ UploadedDB.writeUploadMeta uploadDir meta
 
@@ -1087,6 +1088,7 @@ uploadMethodHandler mName mDesc src =
                             , UploadedDB.umFormat = methodFormat
                             , UploadedDB.umDataPath = makeRelative uploadDir methodDir
                             , UploadedDB.umDepends = []
+                            , UploadedDB.umSource = Nothing
                             }
                 liftIO $ UploadedDB.writeUploadMeta uploadDir meta
 

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -364,6 +364,7 @@ executeDbUpload fmt manager args = do
                         , UploadedDB.umFormat = urFormat uploadResult
                         , UploadedDB.umDataPath = makeRelative uploadDir (urPath uploadResult)
                         , UploadedDB.umDepends = []
+                        , UploadedDB.umSource = Nothing
                         }
             UploadedDB.writeUploadMeta uploadDir meta
 
@@ -431,6 +432,7 @@ executeMcUpload fmt manager args = do
                         , UploadedDB.umFormat = urFormat uploadResult
                         , UploadedDB.umDataPath = makeRelative uploadDir (urPath uploadResult)
                         , UploadedDB.umDepends = []
+                        , UploadedDB.umSource = Nothing
                         }
             UploadedDB.writeUploadMeta uploadDir meta
 

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -358,7 +358,7 @@ executeDbUpload fmt manager args = do
 
             let meta =
                     UploadedDB.UploadMeta
-                        { UploadedDB.umVersion = 1
+                        { UploadedDB.umVersion = UploadedDB.metaVersion
                         , UploadedDB.umDisplayName = uaName args
                         , UploadedDB.umDescription = uaDescription args
                         , UploadedDB.umFormat = urFormat uploadResult
@@ -426,7 +426,7 @@ executeMcUpload fmt manager args = do
 
             let meta =
                     UploadedDB.UploadMeta
-                        { UploadedDB.umVersion = 1
+                        { UploadedDB.umVersion = UploadedDB.metaVersion
                         , UploadedDB.umDisplayName = uaName args
                         , UploadedDB.umDescription = uaDescription args
                         , UploadedDB.umFormat = urFormat uploadResult

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -138,6 +138,7 @@ data FlowRef
     = ExistingFlow UUID
     | -- | name, compartment, unit
       NewBioFlow Text Compartment Text
+    deriving (Eq, Show)
 
 {- | One line of an authored activity's inventory.
 
@@ -170,6 +171,7 @@ data AuthoredExchange
         , awUnit :: Maybe Text
         , awComment :: Maybe Text
         }
+    deriving (Eq, Show)
 
 -- | A complete activity as an author states it: what it is, and what it exchanges.
 data AuthoredActivity = AuthoredActivity
@@ -181,6 +183,7 @@ data AuthoredActivity = AuthoredActivity
     , aaProductUnit :: Text
     , aaExchanges :: [AuthoredExchange]
     }
+    deriving (Eq, Show)
 
 {- | Everything resolution needs to read: the database being edited, the
 databases it may draw suppliers from, and the unit table conversions are

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -44,7 +44,7 @@ module Database.Edit (
 ) where
 
 import Control.Concurrent.STM (atomically, modifyTVar', readTVar, readTVarIO)
-import Control.Exception (finally)
+import Control.Exception (SomeException, finally, try)
 import qualified Data.IntSet as IS
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, isJust)
@@ -143,35 +143,43 @@ copyDatabase manager srcName newName = do
 
 {- | Build the copy's solver/index and insert it under @slug@. Caller holds the
 'dmStagingDbs' reservation for @slug@.
+
+The home is written before anything is registered: a copy that cannot be
+recorded on disk would work until the restart and then be gone, which is the
+kind of quiet loss this ordering exists to refuse. Nothing after the write can
+fail into an inconsistent state — the registry swap is a pure STM commit.
 -}
 registerCopy :: DatabaseManager -> Text -> LoadedDatabase -> IO (Either Text ())
-registerCopy manager slug src = do
-    let copiedDb = ldDatabase src
-        newConfig = renameConfig slug (ldConfig src)
-        -- Fresh solver: a distinct name keys a distinct factorization cache.
-        techTriplesInt =
-            [ (fromIntegral i, fromIntegral j, v)
-            | SparseTriple i j v <- U.toList (dbTechnosphereTriples copiedDb)
-            ]
-    solver <-
-        createSharedSolver
-            slug
-            techTriplesInt
-            (fromIntegral (dbActivityCount copiedDb))
-    synonymDB <- getMergedSynonymDB manager
-    let copied =
-            LoadedDatabase
-                { ldDatabase = copiedDb
-                , ldSharedSolver = solver
-                , ldConfig = newConfig
-                }
-        indexedDb = buildIndexedDatabaseFromDB slug synonymDB copiedDb
-    atomically $ do
-        modifyTVar' (dmLoadedDbs manager) (M.insert slug copied)
-        modifyTVar' (dmAvailableDbs manager) (M.insert slug newConfig)
-        modifyTVar' (dmIndexedDbs manager) (M.insert slug indexedDb)
-    clearMethodMappingCacheForDb manager slug
-    Right <$> recordCopy slug src
+registerCopy manager slug src =
+    recordCopy slug src >>= \case
+        Left err -> pure (Left err)
+        Right () -> do
+            let copiedDb = ldDatabase src
+                newConfig = renameConfig slug (ldConfig src)
+                -- Fresh solver: a distinct name keys a distinct factorization cache.
+                techTriplesInt =
+                    [ (fromIntegral i, fromIntegral j, v)
+                    | SparseTriple i j v <- U.toList (dbTechnosphereTriples copiedDb)
+                    ]
+            solver <-
+                createSharedSolver
+                    slug
+                    techTriplesInt
+                    (fromIntegral (dbActivityCount copiedDb))
+            synonymDB <- getMergedSynonymDB manager
+            let copied =
+                    LoadedDatabase
+                        { ldDatabase = copiedDb
+                        , ldSharedSolver = solver
+                        , ldConfig = newConfig
+                        }
+                indexedDb = buildIndexedDatabaseFromDB slug synonymDB copiedDb
+            atomically $ do
+                modifyTVar' (dmLoadedDbs manager) (M.insert slug copied)
+                modifyTVar' (dmAvailableDbs manager) (M.insert slug newConfig)
+                modifyTVar' (dmIndexedDbs manager) (M.insert slug indexedDb)
+            clearMethodMappingCacheForDb manager slug
+            pure (Right ())
 
 {- | Give the copy a home: a directory of its own holding the @meta.toml@ that
 describes it and, once it is edited, its journal.
@@ -182,32 +190,32 @@ source's own files, which the copy reads and never writes, and @source@ names
 whose they are so a delete can refuse to take files a copy still needs. That
 is what makes a copy cost a directory rather than a second database.
 -}
-recordCopy :: Text -> LoadedDatabase -> IO ()
+recordCopy :: Text -> LoadedDatabase -> IO (Either Text ())
 recordCopy slug src = do
-    uploadsDir <- UploadedDB.getDatabaseUploadsDir
-    let home = uploadsDir </> T.unpack slug
-        config = ldConfig src
-    createDirectoryIfMissing True home
-    -- The source's path may be relative to the working directory, while the
-    -- copy's is read back relative to its own home.
-    sourcePath <- makeAbsolute (dcPath config)
-    UploadedDB.writeUploadMeta
-        home
-        UploadedDB.UploadMeta
-            { UploadedDB.umVersion = metaVersion
-            , UploadedDB.umDisplayName = slug
-            , UploadedDB.umDescription = dcDescription config
-            , UploadedDB.umFormat = fromMaybe UnknownFormat (dcFormat config)
-            , UploadedDB.umDataPath = sourcePath
-            , UploadedDB.umDepends = dbDependsOn (ldDatabase src)
-            , UploadedDB.umSource = Just (dcName config)
-            }
-
-{- | The @meta.toml@ shape this engine writes. Version 3 added @source@, which
-is what tells a copy from an upload.
--}
-metaVersion :: Int
-metaVersion = 3
+    written <- try $ do
+        uploadsDir <- UploadedDB.getDatabaseUploadsDir
+        let home = uploadsDir </> T.unpack slug
+            config = ldConfig src
+        createDirectoryIfMissing True home
+        -- The source's path may be relative to the working directory, while
+        -- the copy's is read back from its own home; 'uploadMetaToConfig'
+        -- keeps an absolute path as it is.
+        sourcePath <- makeAbsolute (dcPath config)
+        UploadedDB.writeUploadMeta
+            home
+            UploadedDB.UploadMeta
+                { UploadedDB.umVersion = UploadedDB.metaVersion
+                , UploadedDB.umDisplayName = slug
+                , UploadedDB.umDescription = dcDescription config
+                , UploadedDB.umFormat = fromMaybe UnknownFormat (dcFormat config)
+                , UploadedDB.umDataPath = sourcePath
+                , UploadedDB.umDepends = dbDependsOn (ldDatabase src)
+                , UploadedDB.umSource = Just (dcName config)
+                }
+    pure $ case written of
+        Right () -> Right ()
+        Left (err :: SomeException) ->
+            Left $ "could not record the copy " <> slug <> ": " <> T.pack (show err)
 
 {- | Rename a config for the copy: new internal name, derived display name, and
 forced deletable/uploaded so the copy can be removed again via the normal

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -78,6 +78,7 @@ import Database.Manager (
     DatabaseManager (..),
     LoadedDatabase (..),
     clearMethodMappingCacheForDb,
+    editHome,
     getDatabase,
     getMergedSynonymDB,
     getMergedUnitConfig,
@@ -462,7 +463,7 @@ mutateReserved manager dbName op =
             case guardDependents dbName loadedDbs *> applyOp ctx op of
                 Left err -> pure (Left err)
                 Right edited -> do
-                    home <- editHome (ldConfig loaded) dbName
+                    home <- editHome (ldConfig loaded)
                     recorded <- traverse (`appendEvent` op) home
                     case sequence recorded of
                         Left err -> pure (Left err)
@@ -478,18 +479,6 @@ authorContext manager db = do
     deps <- loadedDependencies manager db
     unitConfig <- getMergedUnitConfig manager
     pure AuthorContext{acDb = db, acDeps = deps, acUnitConfig = unitConfig}
-
-{- | Where a database's journal lives, or 'Nothing' for one the engine only
-reads. Both an upload and a copy keep theirs in the upload directory named
-after them, beside the @meta.toml@ that describes them - for a copy, that
-directory is the only thing it owns.
--}
-editHome :: DatabaseConfig -> Text -> IO (Maybe FilePath)
-editHome config dbName
-    | not (dcIsUploaded config) = pure Nothing
-    | otherwise = do
-        uploadsDir <- UploadedDB.getDatabaseUploadsDir
-        pure (Just (uploadsDir </> T.unpack dbName))
 
 {- | Refuse an edit while another loaded database depends on this one. Shared
 with the delete path, which has the same reason: rebuilding renumbers every

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -44,11 +44,8 @@ module Database.Edit (
 ) where
 
 import Control.Concurrent.STM (atomically, modifyTVar', readTVar, readTVarIO)
-import Control.Exception (SomeException, finally, try)
-import Data.Bifunctor (first)
-import qualified Data.ByteString.Lazy as BL
+import Control.Exception (finally)
 import qualified Data.IntSet as IS
-import Data.List (isPrefixOf)
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, isJust)
 import qualified Data.Set as S
@@ -57,13 +54,8 @@ import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
-import System.Directory (
-    createDirectoryIfMissing,
-    doesDirectoryExist,
-    removePathForcibly,
-    renameDirectory,
- )
-import System.FilePath (makeRelative, splitDirectories, takeDirectory, (</>))
+import System.Directory (createDirectoryIfMissing, makeAbsolute)
+import System.FilePath ((</>))
 
 import Config (DatabaseConfig (..))
 import Database (applyStructuredFilters, findActivitiesByFields)
@@ -74,7 +66,13 @@ import Database.Author (
     validateAuthored,
  )
 import Database.CrossLinking (buildIndexedDatabaseFromDB)
-import Database.Export (serializeDatabaseFiles)
+import Database.Journal (
+    JournalOp (..),
+    appendEvent,
+    applyOp,
+    journalStamp,
+    writeAppliedStamp,
+ )
 import qualified Database.Loader as Loader
 import Database.Manager (
     DatabaseManager (..),
@@ -85,13 +83,7 @@ import Database.Manager (
     getMergedUnitConfig,
     relinkDatabase,
  )
-import Database.Rebuild (
-    deleteActivitiesWith,
-    insertActivities,
-    renderKey,
-    replaceActivities,
-    resolveProcess,
- )
+import Database.Rebuild (processKey, renderKey, resolveProcess)
 import Database.Upload (DatabaseFormat (..), slugify)
 import qualified Database.UploadedDatabase as UploadedDB
 import Matrix (clearCachedSolver)
@@ -178,7 +170,43 @@ registerCopy manager slug src = do
         modifyTVar' (dmAvailableDbs manager) (M.insert slug newConfig)
         modifyTVar' (dmIndexedDbs manager) (M.insert slug indexedDb)
     clearMethodMappingCacheForDb manager slug
-    pure $ Right ()
+    Right <$> recordCopy slug src
+
+{- | Give the copy a home: a directory of its own holding the @meta.toml@ that
+describes it and, once it is edited, its journal.
+
+It is written now rather than at the first edit, so a copy survives a restart
+from the moment it exists. The home holds no data: @dataPath@ points at the
+source's own files, which the copy reads and never writes, and @source@ names
+whose they are so a delete can refuse to take files a copy still needs. That
+is what makes a copy cost a directory rather than a second database.
+-}
+recordCopy :: Text -> LoadedDatabase -> IO ()
+recordCopy slug src = do
+    uploadsDir <- UploadedDB.getDatabaseUploadsDir
+    let home = uploadsDir </> T.unpack slug
+        config = ldConfig src
+    createDirectoryIfMissing True home
+    -- The source's path may be relative to the working directory, while the
+    -- copy's is read back relative to its own home.
+    sourcePath <- makeAbsolute (dcPath config)
+    UploadedDB.writeUploadMeta
+        home
+        UploadedDB.UploadMeta
+            { UploadedDB.umVersion = metaVersion
+            , UploadedDB.umDisplayName = slug
+            , UploadedDB.umDescription = dcDescription config
+            , UploadedDB.umFormat = fromMaybe UnknownFormat (dcFormat config)
+            , UploadedDB.umDataPath = sourcePath
+            , UploadedDB.umDepends = dbDependsOn (ldDatabase src)
+            , UploadedDB.umSource = Just (dcName config)
+            }
+
+{- | The @meta.toml@ shape this engine writes. Version 3 added @source@, which
+is what tells a copy from an upload.
+-}
+metaVersion :: Int
+metaVersion = 3
 
 {- | Rename a config for the copy: new internal name, derived display name, and
 forced deletable/uploaded so the copy can be removed again via the normal
@@ -253,23 +281,33 @@ writeActivities manager dbName verb authored =
         Just loaded
             | not (dcIsUploaded (ldConfig loaded)) -> pure (Left (NotWritable dbName))
             | otherwise -> do
-                deps <- loadedDependencies manager (ldDatabase loaded)
-                unitConfig <- getMergedUnitConfig manager
-                let ctx =
-                        AuthorContext
-                            { acDb = ldDatabase loaded
-                            , acDeps = deps
-                            , acUnitConfig = unitConfig
-                            }
+                ctx <- authorContext manager (ldDatabase loaded)
                 case validateAuthored ctx authored of
                     Left errs -> pure (Left (Malformed errs))
                     Right (resolved, warnings) ->
                         case presenceRefusal (ldDatabase loaded) verb resolved of
                             Just refusal -> pure (Left refusal)
-                            Nothing -> commit deps unitConfig resolved warnings
+                            Nothing -> either (pure . Left) (commit resolved warnings) (operation resolved)
   where
-    commit deps unitConfig resolved warnings = do
-        outcome <- mutateUploadedDatabase manager dbName (edit deps unitConfig)
+    {- The operation is what gets journalled and what gets applied - one
+    description, so the record and the result cannot disagree. Its identities
+    are the canonical ones minted here, which is also what a replay compares
+    against. -}
+    operation resolved = case (verb, zip authored (map (renderKey . riKey) resolved)) of
+        (CreateActivities, written) -> Right (Created authored (map snd written))
+        (ReplaceActivity _, [(activity, key)]) -> Right (Replaced key activity)
+        (ReplaceActivity target, _) ->
+            Left (Malformed ["a replace writes exactly one activity over " <> target])
+    -- Everything above judged a snapshot taken before the reservation;
+    -- 'mutateReserved' re-reads the database under it and validates the
+    -- operation again against what is actually there, so a batch overtaken by
+    -- a concurrent edit is refused rather than written with a supplier link
+    -- that no longer resolves. In that rare interleaving the refusal degrades
+    -- from a classified status to a 'WriteFailed' message, never to a dangling
+    -- link. Identity minting is pure, so the keys cannot differ between the
+    -- two runs.
+    commit resolved warnings op = do
+        outcome <- mutateUploadedDatabase manager dbName op
         pure $ case outcome of
             Left err -> Left (WriteFailed err)
             Right done ->
@@ -279,20 +317,6 @@ writeActivities manager dbName verb authored =
                         , wrPersisted = moPersisted done
                         , wrWarnings = warnings <> moWarnings done
                         }
-    -- Everything above judged a snapshot taken before the staging
-    -- reservation; 'mutateReserved' re-reads the database under it. The edit
-    -- therefore validates again against what is actually there, so a batch
-    -- overtaken by a concurrent edit is refused rather than written with a
-    -- supplier link that no longer resolves. In that rare interleaving the
-    -- refusal degrades from a classified status to a 'WriteFailed' message —
-    -- never to a dangling link. Identity minting is pure, so the keys cannot
-    -- differ between the two runs.
-    edit deps unitConfig db = do
-        let ctx = AuthorContext{acDb = db, acDeps = deps, acUnitConfig = unitConfig}
-        (resolved, _) <- first (T.intercalate "\n") (validateAuthored ctx authored)
-        case verb of
-            CreateActivities -> insertActivities unitConfig resolved db
-            ReplaceActivity _ -> replaceActivities unitConfig resolved db
 
 {- | The two refusals only a verb can name: creating over a process that is
 already there, and rewriting one that is not. Checked before the mutation so
@@ -380,38 +404,41 @@ data MutationOutcome = MutationOutcome
     , moWarnings :: [Text]
     }
 
-{- | Apply a pure edit to a loaded database, then commit it to memory and — for
-a database that owns its files — to disk.
+{- | Apply an edit to a loaded database and record it where a later load will
+find it again.
 
-The sequence is prepare-then-commit, because everything that can fail must
-fail before anything is visible:
+The order is what makes an acknowledged edit durable:
 
   1. refuse while another loaded database depends on this one (a rebuild
      renumbers processes, and the dependent's cross-database links would
      resolve to the wrong rows or silently drop at solve time);
-  2. run the pure edit;
-  3. serialize the result and write it into a staging directory beside the
-     live one — nothing observable yet;
-  4. build the runtime indexes and a fresh solver for the edited value;
-  5. commit: swing the staging directory into place and swap the registry;
-  6. relink across dependencies and save the matrix cache, so an unload and
-     reload gives back what was just written rather than the pre-edit sources.
+  2. apply the operation to the loaded value, which is where every refusal
+     the author can act on comes from;
+  3. append it to the database's journal, the commit point: it is the last
+     step that can fail while nothing has been claimed yet;
+  4. install the result - fresh solver, registry swap, relink;
+  5. save the matrix cache, then stamp it with the journal it now holds.
 
-Steps 1-4 leave both memory and disk untouched on failure. Step 5 is two
-renames rather than one atomic operation; a crash between them leaves the
-previous sources beside the new ones under a @.old@ suffix rather than
-losing them.
+A crash before step 3 leaves nothing behind. A crash after it leaves an edit
+in the journal, which the next load replays: the same answer the caller was
+given. A crash between 4 and 5 leaves a cache that predates the journal, and
+the missing stamp is what makes the next load read the sources again rather
+than trust it.
+
+The database's own files are never rewritten. They are what their author
+uploaded, and only some formats could be written back without moving every
+process identity in them ("Database.Journal" says why).
 -}
 mutateUploadedDatabase ::
     DatabaseManager ->
     Text ->
-    (Database -> Either Text Database) ->
+    JournalOp ->
     IO (Either Text MutationOutcome)
-mutateUploadedDatabase manager dbName edit = do
-    -- Two concurrent edits of the same database would share one staging
-    -- directory and interleave the renames over the live sources. Reserve the
-    -- name (the same reservation copy and setup staging use) and refuse the
-    -- second edit rather than queue it: edits are interactive and rare.
+mutateUploadedDatabase manager dbName op = do
+    -- Two concurrent edits of the same database would each apply to the value
+    -- the other started from, and both would land in the journal. Reserve the
+    -- name (the same reservation copy and staging use) and refuse the second
+    -- rather than queue it: edits are interactive and rare.
     reserved <- atomically $ do
         staging <- readTVar (dmStagingDbs manager)
         if S.member dbName staging
@@ -421,28 +448,48 @@ mutateUploadedDatabase manager dbName edit = do
         then pure $ Left $ "An edit of " <> dbName <> " is already in progress. Retry when it finishes."
         else
             finally
-                (mutateReserved manager dbName edit)
+                (mutateReserved manager dbName op)
                 (atomically $ modifyTVar' (dmStagingDbs manager) (S.delete dbName))
 
 -- | The mutation proper. The caller holds the 'dmStagingDbs' reservation.
-mutateReserved ::
-    DatabaseManager ->
-    Text ->
-    (Database -> Either Text Database) ->
-    IO (Either Text MutationOutcome)
-mutateReserved manager dbName edit =
+mutateReserved :: DatabaseManager -> Text -> JournalOp -> IO (Either Text MutationOutcome)
+mutateReserved manager dbName op =
     getDatabase manager dbName >>= \case
         Nothing -> pure $ Left $ "Database not loaded: " <> dbName
         Just loaded -> do
             loadedDbs <- readTVarIO (dmLoadedDbs manager)
-            case guardDependents dbName loadedDbs *> edit (ldDatabase loaded) of
+            ctx <- authorContext manager (ldDatabase loaded)
+            case guardDependents dbName loadedDbs *> applyOp ctx op of
                 Left err -> pure (Left err)
                 Right edited -> do
-                    prepared <- prepareSources dbName (ldConfig loaded) edited
-                    case prepared of
+                    home <- editHome (ldConfig loaded) dbName
+                    recorded <- traverse (`appendEvent` op) home
+                    case sequence recorded of
                         Left err -> pure (Left err)
-                        Right (staging, warnings) ->
-                            Right <$> commitMutation manager dbName loaded edited staging warnings
+                        Right _ -> Right <$> commitMutation manager dbName loaded edited home
+
+{- | Everything an edit is judged against: the database it applies to, the
+dependencies its suppliers may live in, and the units its amounts are stated
+in. The same context serves a live edit and a replay, which is what keeps the
+two from disagreeing about what is valid.
+-}
+authorContext :: DatabaseManager -> Database -> IO AuthorContext
+authorContext manager db = do
+    deps <- loadedDependencies manager db
+    unitConfig <- getMergedUnitConfig manager
+    pure AuthorContext{acDb = db, acDeps = deps, acUnitConfig = unitConfig}
+
+{- | Where a database's journal lives, or 'Nothing' for one the engine only
+reads. Both an upload and a copy keep theirs in the upload directory named
+after them, beside the @meta.toml@ that describes them - for a copy, that
+directory is the only thing it owns.
+-}
+editHome :: DatabaseConfig -> Text -> IO (Maybe FilePath)
+editHome config dbName
+    | not (dcIsUploaded config) = pure Nothing
+    | otherwise = do
+        uploadsDir <- UploadedDB.getDatabaseUploadsDir
+        pure (Just (uploadsDir </> T.unpack dbName))
 
 {- | Refuse an edit while another loaded database depends on this one. Shared
 with the delete path, which has the same reason: rebuilding renumbers every
@@ -467,118 +514,18 @@ guardDependents dbName loadedDbs = case dependents of
         , dbName `elem` dbDependsOn (ldDatabase ld)
         ]
 
-{- | Sources written and waiting to be swung into place, or 'Nothing' when the
-database has no files of its own to write.
--}
-data StagedSources = StagedSources
-    { ssDataDir :: FilePath
-    -- ^ where the live sources are, or will be
-    , ssStaging :: FilePath
-    -- ^ the fully-written replacement, still invisible
-    , ssHome :: Maybe (FilePath, DatabaseFormat)
-    {- ^ set when this write gives the database a home it did not have; the
-    upload root whose @meta.toml@ has to be written on commit
-    -}
-    }
-
-{- | Serialize the edited database and stage it beside its live sources.
-
-Three cases, in the order they are decided:
-
-  * a configured (TOML) database writes nothing — it is a background database
-    the engine reads and never owns, so its edits stay in memory;
-  * a database with its own upload directory is rewritten in its own format,
-    and refused when that format cannot record process identity
-    ('Database.Export.serializeDatabaseFiles' says which and why);
-  * a copy has no files at all — 'copyDatabase' shares the source's value
-    without duplicating its directory — so the first write gives it one. It
-    gets EcoSpold 2, the format that survives the round trip. The source's
-    own files are never touched: writing through the shared path would edit a
-    database nobody asked to edit.
--}
-prepareSources ::
-    Text ->
-    DatabaseConfig ->
-    Database ->
-    IO (Either Text (Maybe StagedSources, [Text]))
-prepareSources dbName config edited
-    | not (dcIsUploaded config) = pure (Right (Nothing, []))
-    | otherwise = do
-        uploadsDir <- UploadedDB.getDatabaseUploadsDir
-        let home = uploadsDir </> T.unpack dbName
-            -- Judged on path components, not on text: a textual prefix would
-            -- make a database named "agri" the owner of "agribalyse"'s files,
-            -- and its first save would rewrite them.
-            ownsItsFiles = splitDirectories home `isPrefixOf` splitDirectories (dcPath config)
-            dataDir = if ownsItsFiles then dcPath config else home </> "data"
-            format = if ownsItsFiles then fromMaybe UnknownFormat (dcFormat config) else EcoSpold2
-        case serializeDatabaseFiles format edited of
-            Left err -> pure (Left err)
-            Right (entries, warnings) -> do
-                written <- writeStaging (dataDir <> ".new") entries
-                pure $ case written of
-                    Left err -> Left err
-                    Right staging ->
-                        Right
-                            ( Just
-                                StagedSources
-                                    { ssDataDir = dataDir
-                                    , ssStaging = staging
-                                    , ssHome = if ownsItsFiles then Nothing else Just (home, format)
-                                    }
-                            , warnings
-                            )
-
-{- | Write every entry into a fresh staging directory, replacing any leftover
-from an interrupted write. Returns the directory on success; on failure the
-partial directory is removed, so a retry never inherits half of a previous
-attempt.
--}
-writeStaging :: FilePath -> [(FilePath, BL.ByteString)] -> IO (Either Text FilePath)
-writeStaging staging entries = do
-    attempt <- try $ do
-        removePathForcibly staging
-        createDirectoryIfMissing True staging
-        mapM_ writeEntry entries
-    case attempt of
-        Right () -> pure (Right staging)
-        Left err -> do
-            removePathForcibly staging
-            pure $ Left $ "could not write the database sources: " <> T.pack (show (err :: SomeException))
-  where
-    writeEntry (relPath, bytes) = do
-        let full = staging </> relPath
-        createDirectoryIfMissing True (takeDirectory full)
-        BL.writeFile full bytes
-
-{- | Swing the staged sources into place, keeping the previous ones until the
-new ones are live.
--}
-commitSources :: StagedSources -> IO ()
-commitSources staged = do
-    let live = ssDataDir staged
-        previous = live <> ".old"
-    hadSources <- doesDirectoryExist live
-    removePathForcibly previous
-    if hadSources
-        then renameDirectory live previous
-        else createDirectoryIfMissing True (takeDirectory live)
-    renameDirectory (ssStaging staged) live
-    removePathForcibly previous
-
-{- | Install the edited database: commit its sources, swap it into the
-registry behind a fresh solver, then relink and re-cache so a reload returns
-what was written.
+{- | Install the edited database: rebuilt runtime indexes, a fresh solver, the
+registry swap, and - for a database that has a journal - a matrix cache the
+next load can trust.
 -}
 commitMutation ::
     DatabaseManager ->
     Text ->
     LoadedDatabase ->
     Database ->
-    Maybe StagedSources ->
-    [Text] ->
+    Maybe FilePath ->
     IO MutationOutcome
-commitMutation manager dbName loaded edited staged warnings = do
+commitMutation manager dbName loaded edited home = do
     synonymDB <- getMergedSynonymDB manager
     let withRuntime = BM25.addBM25Index (initializeRuntimeFields edited synonymDB)
         techTriplesInt =
@@ -589,15 +536,13 @@ commitMutation manager dbName loaded edited staged warnings = do
     -- destroy it before installing the rebuilt one, as the delete path does.
     clearCachedSolver dbName
     solver <- createSharedSolver dbName techTriplesInt (fromIntegral (dbActivityCount withRuntime))
-    mapM_ commitSources staged
-    config <- maybe (pure (ldConfig loaded)) (recordHome manager dbName (ldConfig loaded) edited) staged
-    let loaded' = loaded{ldDatabase = withRuntime, ldSharedSolver = solver, ldConfig = config}
+    let loaded' = loaded{ldDatabase = withRuntime, ldSharedSolver = solver}
         indexedDb = buildIndexedDatabaseFromDB dbName synonymDB withRuntime
     atomically $ do
         modifyTVar' (dmLoadedDbs manager) (M.insert dbName loaded')
         modifyTVar' (dmIndexedDbs manager) (M.insert dbName indexedDb)
     clearMethodMappingCacheForDb manager dbName
-    relinkWarnings <- case staged of
+    warnings <- case home of
         -- The transient path must not relink: 'relinkDatabase' saves the
         -- matrix cache when links change, which would half-persist an edit
         -- the caller is being told is memory-only. Say what that costs.
@@ -609,39 +554,19 @@ commitMutation manager dbName loaded edited staged warnings = do
                 | not (null (dbDependsOn edited))
                 , null (dbCrossDBLinks edited)
                 ]
-        Just source -> do
+        Just dir -> do
             -- Rebuilding cleared the cross-database links; rebuild them against
             -- the current dependency set before the cache records the result.
             relinked <- relinkDatabase manager dbName
             saved <- getDatabase manager dbName
-            mapM_ (Loader.saveCachedDatabaseWithMatrices dbName (ssDataDir source) . ldDatabase) saved
+            mapM_ (Loader.saveCachedDatabaseWithMatrices dbName (dcPath (ldConfig loaded)) . ldDatabase) saved
+            journalStamp dir >>= writeAppliedStamp dir
             pure (either (\err -> ["the edit is saved, but relinking failed: " <> err]) (const []) relinked)
     pure
         MutationOutcome
-            { moPersisted = isJust staged
-            , moWarnings = warnings <> relinkWarnings
+            { moPersisted = isJust home
+            , moWarnings = warnings
             }
-
-{- | Give a database that had no files of its own a @meta.toml@ describing the
-home it just acquired, and point its config at the new sources.
--}
-recordHome :: DatabaseManager -> Text -> DatabaseConfig -> Database -> StagedSources -> IO DatabaseConfig
-recordHome manager dbName config edited staged = case ssHome staged of
-    Nothing -> pure config
-    Just (home, format) -> do
-        UploadedDB.writeUploadMeta
-            home
-            UploadedDB.UploadMeta
-                { UploadedDB.umVersion = 1
-                , UploadedDB.umDisplayName = dcDisplayName config
-                , UploadedDB.umDescription = dcDescription config
-                , UploadedDB.umFormat = format
-                , UploadedDB.umDataPath = makeRelative home (ssDataDir staged)
-                , UploadedDB.umDepends = dbDependsOn edited
-                }
-        let config' = config{dcPath = ssDataDir staged, dcFormat = Just format}
-        atomically $ modifyTVar' (dmAvailableDbs manager) (M.insert dbName config')
-        pure config'
 
 -- ---------------------------------------------------------------------------
 -- Selection resolver
@@ -780,11 +705,16 @@ deleteActivitiesInDB manager dbName DeleteRequest{drName = nameP, drLocation = g
                     let toDelete =
                             resolveDeleteSelection
                                 DeleteSelection{dsFiltered = filtered, dsKeep = keepPids, dsExtra = extraPids}
-                    unitConfig <- getMergedUnitConfig manager
-                    outcome <- mutateUploadedDatabase manager dbName (deleteActivitiesWith unitConfig toDelete)
-                    pure $ flip fmap outcome $ \done ->
-                        DeleteOutcome
-                            { doRemoved = length toDelete
-                            , doPersisted = moPersisted done
-                            , doWarnings = moWarnings done
-                            }
+                    case traverse (fmap renderKey . processKey db) toDelete of
+                        Left err -> pure (Left err)
+                        -- A filter that matched nothing changes nothing: no
+                        -- rebuild, and no line in the journal saying an empty
+                        -- deletion happened.
+                        Right [] -> pure (Right (removed 0 (dcIsUploaded (ldConfig loaded)) []))
+                        Right targets -> do
+                            outcome <- mutateUploadedDatabase manager dbName (Deleted targets)
+                            pure $ flip fmap outcome $ \done ->
+                                removed (length targets) (moPersisted done) (moWarnings done)
+  where
+    removed count persisted warnings =
+        DeleteOutcome{doRemoved = count, doPersisted = persisted, doWarnings = warnings}

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -90,6 +90,7 @@ import Database.Rebuild (
     insertActivities,
     renderKey,
     replaceActivities,
+    resolveProcess,
  )
 import Database.Upload (DatabaseFormat (..), slugify)
 import qualified Database.UploadedDatabase as UploadedDB
@@ -101,7 +102,6 @@ import Types (
     Database (..),
     ProcessId,
     SparseTriple (..),
-    findProcessId,
     findProcessIdByActivityUUID,
     initializeRuntimeFields,
     parseUUIDPair,
@@ -712,20 +712,6 @@ filteredProcessIds db nameP geoP prodP classFilters exactMatch =
 -- Effectful entry point (registry swap)
 -- ---------------------------------------------------------------------------
 
-{- | Resolve a process-id string to its 'ProcessId'. Accepts the canonical
-@activityUUID_productUUID@ form and the bare-activity-UUID fallback (when the
-activity has a unique reference product), mirroring
-'Service.resolveActivityAndProcessId'. The UI and CLI carry these textual ids,
-so keep/extra adjustments are expressed in the same currency as the rows the
-user sees — not the volatile integer matrix index. Unresolvable ids fail loudly
-rather than being silently dropped.
--}
-resolvePid :: Database -> Text -> Either Text ProcessId
-resolvePid db queryText =
-    maybe (Left ("Unknown process id: " <> queryText)) Right $ case parseUUIDPair queryText of
-        Just (a, p) -> findProcessId db a p
-        Nothing -> UUID.fromText queryText >>= findProcessIdByActivityUUID db
-
 {- | One delete-by-selection request against a loaded database. Two exclusive
 selection modes: the filter fields select the whole matching set (@drIds =
 Nothing@), or @drIds@ names the set exactly — every filter field must then be
@@ -786,9 +772,9 @@ deleteActivitiesInDB manager dbName DeleteRequest{drName = nameP, drLocation = g
                 selectionE = case mIds of
                     Just ids
                         | hasFilter -> Left "ids cannot be combined with name/location/product/classification/exact filters"
-                        | otherwise -> traverse (resolvePid db) ids
+                        | otherwise -> traverse (resolveProcess db) ids
                     Nothing -> Right (filteredProcessIds db nameP geoP prodP classFilters exactMatch)
-            case (,,) <$> traverse (resolvePid db) keep <*> traverse (resolvePid db) extra <*> selectionE of
+            case (,,) <$> traverse (resolveProcess db) keep <*> traverse (resolveProcess db) extra <*> selectionE of
                 Left err -> pure $ Left err
                 Right (keepPids, extraPids, filtered) -> do
                     let toDelete =

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -303,6 +303,9 @@ writeActivities manager dbName verb authored =
     are the canonical ones minted here, which is also what a replay compares
     against. -}
     operation resolved = case (verb, zip authored (map (renderKey . riKey) resolved)) of
+        -- Refused rather than journalled: a line recording that nothing
+        -- happened would be replayed forever for nothing.
+        (CreateActivities, []) -> Left (Malformed ["a create writes at least one activity"])
         (CreateActivities, written) -> Right (Created authored (map snd written))
         (ReplaceActivity _, [(activity, key)]) -> Right (Replaced key activity)
         (ReplaceActivity target, _) ->

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -17,16 +17,10 @@ nothing is mutable. The only fresh allocation is the solver (it holds an
 let the two registry entries share a factorization cache, so the copy gets
 its own.
 
-DELETE is reconstruction, not mutation either. 'deleteActivities' drops a set
-of activities and rebuilds every dependent structure (interning tables,
-indexes, sparse matrices, product index) from the surviving activities. The
-rebuild reuses the exact pure builders that back a freshly-loaded database
-('buildInterningTables' / 'buildTechTriples' / 'buildBioTriples' /
-'buildProductIndex' / 'buildIndexesWithProcessIds'), so a deleted-from
-database is byte-for-byte indistinguishable from one that never carried the
-removed rows. Exchanges in surviving activities that referenced a deleted
-activity are UNLINKED (their activity link reset to nil), leaving the value
-ready for relinking — never silently dropped.
+What an edit does to the activity set itself is pure and lives in
+"Database.Rebuild"; this module is the effectful half around it — which
+database, under what reservation, written where, swapped into the registry
+how.
 
 Memory cost (copy): the copy keeps the source 'Database' alive for as long as
 it is loaded. Structural sharing means we don't re-allocate the activity/flow
@@ -35,15 +29,11 @@ while any copy of it is loaded.
 -}
 module Database.Edit (
     copyDatabase,
-    deleteActivities,
-    deleteActivitiesWith,
     resolveDeleteSelection,
     DeleteSelection (..),
     DeleteRequest (..),
     DeleteOutcome (..),
     deleteActivitiesInDB,
-    insertActivities,
-    replaceActivities,
     MutationOutcome (..),
     mutateUploadedDatabase,
     WriteVerb (..),
@@ -76,12 +66,7 @@ import System.Directory (
 import System.FilePath (makeRelative, splitDirectories, takeDirectory, (</>))
 
 import Config (DatabaseConfig (..))
-import Database (
-    applyStructuredFilters,
-    buildIndexesWithProcessIds,
-    buildProductIndex,
-    findActivitiesByFields,
- )
+import Database (applyStructuredFilters, findActivitiesByFields)
 import Database.Author (
     AuthorContext (..),
     AuthoredActivity,
@@ -100,13 +85,11 @@ import Database.Manager (
     getMergedUnitConfig,
     relinkDatabase,
  )
-import Database.MatrixBuild (
-    InterningTables (..),
-    buildBioTriples,
-    buildInterningTables,
-    buildSupplierRefUnits,
-    buildTechTriples,
-    collectBioFlowOrder,
+import Database.Rebuild (
+    deleteActivitiesWith,
+    insertActivities,
+    renderKey,
+    replaceActivities,
  )
 import Database.Upload (DatabaseFormat (..), slugify)
 import qualified Database.UploadedDatabase as UploadedDB
@@ -115,20 +98,14 @@ import qualified Search.BM25 as BM25
 import Service (bm25Retrieve)
 import SharedSolver (createSharedSolver)
 import Types (
-    Activity (..),
-    BiosphereFlow (..),
     Database (..),
-    Exchange (..),
     ProcessId,
     SparseTriple (..),
-    TechnosphereFlow (..),
-    UUID,
     findProcessId,
     findProcessIdByActivityUUID,
     initializeRuntimeFields,
     parseUUIDPair,
  )
-import UnitConversion (UnitConfig, defaultUnitConfig)
 
 {- | Copy a loaded database into the runtime registry under the slugified
 @newName@.
@@ -215,222 +192,6 @@ renameConfig newName cfg =
         , dcIsUploaded = True
         , dcDeletable = True
         }
-
--- ---------------------------------------------------------------------------
--- Delete by selection
--- ---------------------------------------------------------------------------
-
-{- | Remove a set of activities (by 'ProcessId') and rebuild every dependent
-structure. Uses 'defaultUnitConfig'; effectful call sites that carry a merged
-unit config (the only place where non-SI conversions matter) should call
-'deleteActivitiesWith' instead so a coefficient is never silently dropped on
-an unknown-unit conversion.
--}
-deleteActivities :: [ProcessId] -> Database -> Either Text Database
-deleteActivities = deleteActivitiesWith defaultUnitConfig
-
-{- | 'deleteActivities' with an explicit 'UnitConfig'.
-
-Steps, all pure:
-
-  1. Resolve the delete set to the @(activityUUID, productUUID)@ keys it
-     occupies in 'dbProcessIdTable', validating that every requested
-     'ProcessId' exists (no silent skip).
-  2. Drop those keys; for every surviving activity, UNLINK any technosphere /
-     waste exchange whose @(activityLink, flow)@ pointed at a deleted key —
-     reset its activity link to 'UUID.nil' and clear the stale process link.
-  3. Rebuild interning tables, indexes, matrices and the product index from
-     the surviving activity map via the shared loader builders.
-
-Fails (Left) when an out-of-range 'ProcessId' is requested, when the result
-would be empty, or when matrix construction reports an inconsistency (e.g. an
-unknown unit conversion under the given config).
--}
-deleteActivitiesWith :: UnitConfig -> [ProcessId] -> Database -> Either Text Database
-deleteActivitiesWith unitConfig pids db = do
-    deletedKeys <- resolveDeleteKeys db pids
-    let survivors = surviving db deletedKeys
-        survivingKeys = M.keysSet survivors
-        unlinkedMap = M.map (unlinkActivity survivingKeys) survivors
-    if M.null unlinkedMap
-        then Left "Refusing to delete: the result would have no activities"
-        else rebuildFromActivities unitConfig db unlinkedMap
-
-{- | Resolve each requested 'ProcessId' to its @(activityUUID, productUUID)@ key.
-Every id must be in range — an out-of-range id is a caller error, surfaced as
-'Left' rather than silently ignored. The result is a 'Set' so membership tests
-during unlinking are @O(log n)@.
--}
-resolveDeleteKeys :: Database -> [ProcessId] -> Either Text (S.Set (UUID, UUID))
-resolveDeleteKeys db = fmap S.fromList . traverse keyOf
-  where
-    table = dbProcessIdTable db
-    n = V.length table
-    keyOf pid
-        | i >= 0 && i < n = Right (table V.! i)
-        | otherwise = Left ("Delete: ProcessId out of range: " <> T.pack (show pid))
-      where
-        i = fromIntegral pid
-
--- | The activity map keyed by @(activityUUID, productUUID)@, minus the deleted keys.
-surviving :: Database -> S.Set (UUID, UUID) -> M.Map (UUID, UUID) Activity
-surviving db deletedKeys =
-    M.fromList
-        [ (key, dbActivities db V.! i)
-        | i <- [0 .. V.length (dbActivities db) - 1]
-        , let key = dbProcessIdTable db V.! i
-        , not (S.member key deletedKeys)
-        ]
-
-{- | Reset technosphere / waste exchanges on a surviving activity whose producer
-link no longer resolves to a surviving @(activityUUID, productUUID)@ key.
-
-The link target is exactly that pair: 'findProducer' resolves
-@(activityLink, flowId)@ against the interning table, so a multi-product
-activity that keeps at least one product stays a valid target for exchanges
-pointing at a *surviving* product, while exchanges pointing at a deleted
-product are unlinked. A biosphere exchange has no producer link and is
-returned unchanged. The stale 'ProcessId' link is always cleared because
-deletion renumbers every 'ProcessId'. An already-orphan link
-(@activityLink == nil@) stays orphan.
--}
-unlinkActivity :: S.Set (UUID, UUID) -> Activity -> Activity
-unlinkActivity survivingKeys act =
-    act{exchanges = map unlinkExchange (exchanges act)}
-  where
-    dangling link flow = link /= UUID.nil && not (S.member (link, flow) survivingKeys)
-    unlinkExchange ex = case ex of
-        BiosphereExchange{} -> ex
-        TechnosphereExchange{techActivityLinkId = link, techFlowId = flow}
-            | dangling link flow ->
-                ex{techActivityLinkId = UUID.nil, techProcessLinkId = Nothing}
-            | otherwise -> ex{techProcessLinkId = Nothing}
-        WasteExchange{waActivityLinkId = link, waFlowId = flow}
-            | dangling link flow ->
-                ex{waActivityLinkId = UUID.nil, waProcessLinkId = Nothing}
-            | otherwise -> ex{waProcessLinkId = Nothing}
-
-{- | Rebuild a 'Database' from a surviving activity map, reusing the exact pure
-builders that back a freshly-loaded database. Flow / unit tables are carried
-over unchanged: deletion removes activities, never the flow or unit
-vocabulary, so a relink can still resolve the surviving links. Runtime fields
-(synonym, flow-name, BM25 indexes) are reset to their unloaded state; the
-effectful caller re-attaches them with the merged synonym DB.
--}
-rebuildFromActivities :: UnitConfig -> Database -> M.Map (UUID, UUID) Activity -> Either Text Database
-rebuildFromActivities unitConfig db activityMap =
-    let tables = buildInterningTables activityMap
-        supplierRefUnits = buildSupplierRefUnits (dbUnits db) (itActivities tables)
-        indexes = buildIndexesWithProcessIds (itActivities tables) (itProcessIdTable tables)
-        bioFlowUUIDs = collectBioFlowOrder (itActivities tables)
-        bioTriples = buildBioTriples bioFlowUUIDs tables
-        productIndex = buildProductIndex (itActivities tables) (itProcessIdTable tables) (dbTechFlows db)
-     in case buildTechTriples unitConfig (dbUnits db) tables supplierRefUnits of
-            Left err -> Left err
-            Right (techTriples, _warnings) ->
-                Right
-                    db
-                        { dbProcessIdTable = itProcessIdTable tables
-                        , dbProcessIdLookup = itProcessIdLookup tables
-                        , dbActivityUUIDIndex = itActivityUUIDIndex tables
-                        , dbActivityProductsIndex = itActivityProductsIndex tables
-                        , dbProductIndex = productIndex
-                        , dbActivities = itActivities tables
-                        , dbIndexes = indexes
-                        , dbTechnosphereTriples = techTriples
-                        , dbBiosphereTriples = bioTriples
-                        , dbActivityIndex = V.generate (fromIntegral (itActivityCount tables)) fromIntegral
-                        , dbBiosphereOrder = bioFlowUUIDs
-                        , dbActivityCount = itActivityCount tables
-                        , dbBiosphereCount = fromIntegral (V.length bioFlowUUIDs)
-                        , -- Cross-DB links may now reference deleted activities; clear so a
-                          -- subsequent relink rebuilds them against the surviving set.
-                          dbCrossDBLinks = []
-                        , -- Linking stats describe the pre-delete set (input count, completeness,
-                          -- missing suppliers); reset to the fresh-load default so the setup/status
-                          -- endpoint never reports stale numbers until the next relink.
-                          dbLinkingStats = mempty
-                        , -- Runtime-only indexes are reset; re-attached by the effectful caller.
-                          dbSynonymDB = Nothing
-                        , dbFlowsByName = M.empty
-                        , dbFlowsByCAS = M.empty
-                        , dbProductSearchIndex = M.empty
-                        , dbBM25Index = Nothing
-                        }
-
--- ---------------------------------------------------------------------------
--- Insert / replace
--- ---------------------------------------------------------------------------
-
-{- | Whether a batch means to add rows the database does not have, or to
-rewrite rows it does. There is deliberately no upsert: a mistyped identity
-must fail, not quietly become a second copy of an activity the author thought
-they were correcting.
--}
-data WriteIntent = Insert | Replace
-
-{- | Add authored activities to a database and rebuild everything that depends
-on them.
-
-Every key must be absent — 'Database.Author' mints identity from the activity's
-own name, location, product and unit, so a key that already exists means the
-author is re-describing something the database already holds and wants
-'replaceActivities' instead.
--}
-insertActivities :: UnitConfig -> [ResolvedInsert] -> Database -> Either Text Database
-insertActivities = applyResolved Insert
-
-{- | Rewrite activities the database already holds, keeping their identity.
-
-Every key must be present. Replacing keeps the old version's flows in the
-vocabulary, exactly as deletion does: a flow no activity uses any more is
-inert, and dropping it would break a relink that still resolves through it.
--}
-replaceActivities :: UnitConfig -> [ResolvedInsert] -> Database -> Either Text Database
-replaceActivities = applyResolved Replace
-
-{- | Shared write path. The vocabulary the batch brings (its product flows and
-any new biosphere flows) lands in the same step as the activities that
-reference it, so no intermediate value exists in which an exchange points at a
-flow the database cannot name.
-
-An empty batch returns the database untouched rather than rebuilding: a
-rebuild resets cross-database links ('rebuildFromActivities'), so treating "no
-activities to write" as a no-op is what keeps a caller's empty request from
-silently unlinking the database.
--}
-applyResolved :: WriteIntent -> UnitConfig -> [ResolvedInsert] -> Database -> Either Text Database
-applyResolved intent unitConfig inserts db
-    | null inserts = Right db
-    | otherwise = do
-        let existing = surviving db S.empty
-        checkKeys intent existing (map riKey inserts)
-        rebuildFromActivities
-            unitConfig
-            db
-                { dbTechFlows = M.union (indexBy tfId (concatMap riNewTechFlows inserts)) (dbTechFlows db)
-                , dbBioFlows = M.union (indexBy bfId (concatMap riNewBioFlows inserts)) (dbBioFlows db)
-                }
-            (M.union (M.fromList [(riKey i, riActivity i) | i <- inserts]) existing)
-  where
-    indexBy key xs = M.fromList [(key x, x) | x <- xs]
-
-{- | Refuse a batch whose keys contradict the intent, naming every offending
-identity at once so a long batch is not fixed one round-trip at a time.
--}
-checkKeys :: WriteIntent -> M.Map (UUID, UUID) Activity -> [(UUID, UUID)] -> Either Text ()
-checkKeys intent existing keys = case intent of
-    Insert -> refuse "already exists" (filter (`M.member` existing) keys)
-    Replace -> refuse "does not exist" (filter (not . (`M.member` existing)) keys)
-  where
-    refuse _ [] = Right ()
-    refuse what offenders =
-        Left $
-            "Refusing to write: "
-                <> T.intercalate ", " (map renderKey offenders)
-                <> " "
-                <> what
-                <> " in this database"
 
 -- ---------------------------------------------------------------------------
 -- Writing authored activities
@@ -587,10 +348,6 @@ loadedDependencies :: DatabaseManager -> Database -> IO [Database]
 loadedDependencies manager db = do
     loadedDbs <- readTVarIO (dmLoadedDbs manager)
     pure [ldDatabase ld | name <- dbDependsOn db, Just ld <- [M.lookup name loadedDbs]]
-
--- | @activityUUID_productUUID@, the identity a process is addressed by.
-renderKey :: (UUID, UUID) -> Text
-renderKey (actUUID, prodUUID) = UUID.toText actUUID <> "_" <> UUID.toText prodUUID
 
 {- | Plain-language rendering, for callers with nowhere to put a status code.
 An HTTP caller maps the constructors to codes instead.

--- a/src/Database/Export.hs
+++ b/src/Database/Export.hs
@@ -14,7 +14,6 @@ has no writer and 'UnknownFormat' is not a real target, so both fail loudly
 -}
 module Database.Export (
     serializeDatabase,
-    serializeDatabaseFiles,
     exportDatabase,
     MethodExportFormat (..),
     parseMethodExportFormat,
@@ -73,42 +72,6 @@ serializeDatabase fmt db = case fmt of
   where
     sdb = toSimpleDatabase db
     noWarn = fmap (,[])
-
-{- | The @(relative path, bytes)@ a database becomes as a directory tree,
-rather than the single stream 'serializeDatabase' hands to a download.
-
-This is the shape persistence needs: rewriting an upload's own source files in
-place, so that unloading and reloading the database gives back what was
-written. That demands more of a format than exporting does — it must record
-process identity, not re-derive it.
-
-'EcoSpold2' does: each dataset is a file named @{activityUUID}_{productUUID}.spold@
-and the parser reads the pair straight off the name, so every process id
-survives the round trip. The other writers re-mint identity from names and
-locations on read, which is stable for rows that came from a file but moves
-the identity of rows an author just created — silently, and only after a
-restart. They are refused here rather than allowed to lose that quietly;
-'serializeDatabase' still exports to all of them, because an export is a copy
-that leaves the original in place.
--}
-serializeDatabaseFiles :: DatabaseFormat -> Database -> Either Text ([(FilePath, BL.ByteString)], [Text])
-serializeDatabaseFiles fmt db = case fmt of
-    EcoSpold2 -> (\entries -> (map (fmap encodeLazy) entries, [])) <$> ES2.writeEcoSpold2 ES2.noVolatileMeta sdb
-    SimaProCSV -> remints "SimaPro CSV"
-    EcoSpold1 -> remints "EcoSpold 1"
-    ILCDProcess -> remints "ILCD"
-    BrightwayExcel -> remints "Brightway Excel"
-    OpenLcaJsonLd -> Left "openLCA JSON-LD export is not supported"
-    UnknownFormat -> Left "cannot write to an unknown format"
-  where
-    sdb = toSimpleDatabase db
-    encodeLazy = BL.fromStrict . TE.encodeUtf8
-    remints name =
-        Left $
-            name
-                <> " does not record process identifiers, so saving would give the edited\
-                   \ activities different identities the next time the database is read.\
-                   \ Export this database to EcoSpold 2 and upload that to make edits durable."
 
 {- | Export targets for a method collection — a space of its own, not
 'DatabaseFormat': most database formats carry no method writer, and method

--- a/src/Database/Journal.hs
+++ b/src/Database/Journal.hs
@@ -1,0 +1,474 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{- |
+Module      : Database.Journal
+Description : The record of what was edited, and how to apply it again
+
+An uploaded database is what its author uploaded. Editing it never rewrites
+those files: the edits are appended to a journal beside them, and loading the
+database means reading the sources (or the matrix cache) and then replaying
+that journal over them.
+
+The alternative — rewriting the sources in their own format after every edit —
+only works for a format that records process identity in the files themselves.
+EcoSpold 1 does not: its flow identifiers are derived from the position of a
+dataset in the file, and any writer that renumbers them moves every identity
+the next time the file is read. Leaving the sources alone sidesteps the whole
+question, because a file that is never rewritten parses to the same
+identifiers forever.
+
+What a line records is a verb, not a result: the activities as their author
+described them, or the process ids removed. Replaying them re-derives
+everything else, so the journal stays small and readable, and the difference
+between a published database and the one in use is exactly its journal.
+
+The file is @journal.jsonl@ in the database's upload directory, one JSON
+object per line:
+
+> {"v":1,"at":"2026-08-03T09:12:41Z","op":"create","activities":[…],"written":["8f3c…_a1b2…"]}
+> {"v":1,"at":"2026-08-03T09:14:02Z","op":"replace","target":"8f3c…_a1b2…","activity":{…}}
+> {"v":1,"at":"2026-08-03T09:15:30Z","op":"delete","targets":["3e7a…_c4d5…"]}
+
+Two things guard the replay.
+
+The first is @written@ (and @target@, which serves the same purpose for a
+replace): the process ids the edit produced when it was made. Identity is
+minted from what the author wrote, so replaying re-mints it; if the two ever
+disagree, the engine's minting has changed under a journal written by an older
+one, and the replay stops there instead of silently landing the activity under
+a different identity.
+
+The second is the version on every line. A line this engine cannot read is
+refused, never skipped.
+
+The last line is the exception, and only when it is the last: a line is
+written and flushed before its edit is acknowledged, so a torn final line
+belongs to an edit no caller was ever told had happened. It is dropped with a
+warning. A line that fails to parse anywhere else refuses the whole journal.
+-}
+module Database.Journal (
+    -- * What a journal records
+    JournalEvent (..),
+    JournalOp (..),
+
+    -- * The file
+    journalPath,
+    appendEvent,
+    readJournal,
+
+    -- * Applying it
+    replayJournal,
+) where
+
+import Control.Exception (SomeException, try)
+import Control.Monad (foldM)
+import Data.Aeson (
+    FromJSON (..),
+    Object,
+    ToJSON (..),
+    Value,
+    eitherDecodeStrict,
+    encode,
+    object,
+    withObject,
+    (.:),
+    (.:?),
+    (.=),
+ )
+import Data.Aeson.Types (Pair, Parser, parseEither)
+import Data.Bifunctor (bimap, first)
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy as BL
+import Data.Char (isSpace)
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.Time.Clock (getCurrentTime)
+import Data.Time.Format.ISO8601 (iso8601Show)
+import qualified Data.UUID as UUID
+import System.Directory (createDirectoryIfMissing, doesFileExist)
+import System.FilePath ((</>))
+import System.IO (IOMode (AppendMode), withFile)
+
+import Database.Author (
+    AuthorContext (..),
+    AuthoredActivity (..),
+    AuthoredExchange (..),
+    FlowRef (..),
+    ResolvedInsert (..),
+    validateAuthored,
+ )
+import Database.Rebuild (
+    deleteActivitiesWith,
+    insertActivities,
+    renderKey,
+    replaceActivities,
+    resolveProcess,
+ )
+import Progress (ProgressLevel (..), reportProgress)
+import Types (BioDirection (..), Compartment (..), Database)
+
+-- ---------------------------------------------------------------------------
+-- What a journal records
+-- ---------------------------------------------------------------------------
+
+{- | One line of the journal: what was done, and when. The timestamp is
+provenance for whoever reads the file; the replay never looks at it.
+-}
+data JournalEvent = JournalEvent
+    { jeAt :: Text
+    , jeOp :: JournalOp
+    }
+    deriving (Eq, Show)
+
+{- | The three ways a database changes. Each carries the identity the edit
+produced, so a replay can check that it still produces it.
+-}
+data JournalOp
+    = -- | Activities added, and the process ids they minted.
+      Created [AuthoredActivity] [Text]
+    | {- | The process rewritten, and the description written over it. The
+      target is the identity the new description has to keep.
+      -}
+      Replaced Text AuthoredActivity
+    | -- | The process ids removed.
+      Deleted [Text]
+    deriving (Eq, Show)
+
+-- | The version this engine writes, and the only one it reads.
+journalVersion :: Int
+journalVersion = 1
+
+-- | A database's journal, given the upload directory that database lives in.
+journalPath :: FilePath -> FilePath
+journalPath home = home </> "journal.jsonl"
+
+-- ---------------------------------------------------------------------------
+-- The file
+-- ---------------------------------------------------------------------------
+
+{- | Record an edit. Appends one line and closes the file before returning, so
+an edit is on disk by the time its caller answers.
+
+Stamps the line with the current time, which is why this takes the operation
+rather than a whole event: when it happened is the journal's business, not its
+caller's.
+-}
+appendEvent :: FilePath -> JournalOp -> IO (Either Text ())
+appendEvent home op = do
+    now <- getCurrentTime
+    let event = JournalEvent{jeAt = T.pack (iso8601Show now), jeOp = op}
+    written <- try $ do
+        createDirectoryIfMissing True home
+        withFile (journalPath home) AppendMode $ \handle ->
+            BL.hPut handle (encode event <> "\n")
+    pure $ case written of
+        Right () -> Right ()
+        Left (err :: SomeException) ->
+            Left $
+                "could not record the edit in "
+                    <> T.pack (journalPath home)
+                    <> ": "
+                    <> T.pack (show err)
+
+{- | Read a database's journal. A database with no journal has made no edits,
+which is not an error.
+
+A torn last line is dropped with a warning (see the module header); anything
+else unreadable refuses the whole file, naming the line.
+-}
+readJournal :: FilePath -> IO (Either Text [JournalEvent])
+readJournal home = do
+    let path = journalPath home
+    exists <- doesFileExist path
+    if not exists
+        then pure (Right [])
+        else
+            try (BS.readFile path) >>= \case
+                Left (err :: SomeException) ->
+                    pure $ Left $ "could not read " <> T.pack path <> ": " <> T.pack (show err)
+                Right bytes -> decodeLines path bytes
+
+{- | What a line turned out to be.
+
+The distinction is what keeps the last-line exception honest. A line that is
+not JSON at all is a write that was cut short. A line that is complete JSON
+says something definite, and if this engine cannot read what it says — a
+version it does not know, an operation it has no verb for — that is a refusal
+wherever the line sits, including at the end. Otherwise a newer engine's
+entries, which are exactly the ones at the end of the file, would be dropped
+as debris.
+-}
+data LineProblem
+    = Torn String
+    | Unreadable String
+
+decodeLines :: FilePath -> BS.ByteString -> IO (Either Text [JournalEvent])
+decodeLines path bytes =
+    case problems of
+        [] -> pure (Right events)
+        [(i, Torn err)] | i == lastLine -> do
+            reportProgress Warning $
+                "The last line of "
+                    <> path
+                    <> " is incomplete and was dropped ("
+                    <> err
+                    <> "). A line is written before its edit is acknowledged, so no\
+                       \ edit anyone was told about is lost."
+            pure (Right events)
+        ((i, problem) : _) -> pure (Left (situate i problem))
+  where
+    numbered =
+        [ (i, line)
+        | (i, line) <- zip [1 :: Int ..] (BS.lines bytes)
+        , not (BS.all isSpace line)
+        ]
+    results = [(i, readLine line) | (i, line) <- numbered]
+    events = [event | (_, Right event) <- results]
+    problems = [(i, problem) | (i, Left problem) <- results]
+    lastLine = length numbered
+    situate i problem =
+        T.pack path <> " line " <> T.pack (show i) <> " " <> case problem of
+            Torn err -> "is not complete JSON: " <> T.pack err
+            Unreadable err -> "is not an entry this engine reads: " <> T.pack err
+
+readLine :: BS.ByteString -> Either LineProblem JournalEvent
+readLine line = case eitherDecodeStrict line of
+    Left err -> Left (Torn err)
+    Right value -> first Unreadable (parseEither parseJSON value)
+
+-- ---------------------------------------------------------------------------
+-- Applying it
+-- ---------------------------------------------------------------------------
+
+{- | Replay a journal over the database it belongs to, one line at a time, each
+line seeing the result of the ones before it.
+
+The context carries the database to start from ('acDb'), the dependencies
+suppliers are resolved against, and the units amounts are judged in — the same
+context authoring uses, because a replay validates exactly what authoring
+validated. That is deliberate: a supplier that has since vanished from a
+dependency fails here rather than landing as a dangling link.
+
+Any failure refuses the whole database, naming the line and the reason. A
+half-applied journal would be a database that silently disagrees with its own
+record.
+
+Warnings raised during validation are dropped: they were reported to the
+author when the edit was made, and repeating them at every load says nothing
+new.
+-}
+replayJournal :: AuthorContext -> [JournalEvent] -> Either Text Database
+replayJournal ctx = foldM step (acDb ctx) . zip [1 :: Int ..]
+  where
+    step db (i, event) =
+        first (situate i (jeOp event)) (applyOp ctx{acDb = db} (jeOp event))
+    situate i op msg =
+        "journal event " <> T.pack (show i) <> " (" <> opName op <> "): " <> msg
+
+applyOp :: AuthorContext -> JournalOp -> Either Text Database
+applyOp ctx = \case
+    Created activities written -> do
+        resolved <- resolve activities
+        let minted = map (renderKey . riKey) resolved
+        if minted == written
+            then insertActivities (acUnitConfig ctx) resolved (acDb ctx)
+            else Left (drift written minted)
+    Replaced target activity -> do
+        resolved <- resolve [activity]
+        case map (renderKey . riKey) resolved of
+            [minted]
+                | minted == target -> replaceActivities (acUnitConfig ctx) resolved (acDb ctx)
+            others -> Left (drift [target] others)
+    Deleted targets -> do
+        pids <- traverse (resolveProcess (acDb ctx)) targets
+        deleteActivitiesWith (acUnitConfig ctx) pids (acDb ctx)
+  where
+    resolve = bimap (T.intercalate "; ") fst . validateAuthored ctx
+
+{- | The one failure a journal exists to make impossible to miss: the same
+description no longer minting the identity it was recorded under. Everything
+that points at a process id — a script, a saved score, another database's
+links — would follow the old one.
+-}
+drift :: [Text] -> [Text] -> Text
+drift recorded minted =
+    "recorded as "
+        <> render recorded
+        <> " but the same description now mints "
+        <> render minted
+        <> ". Identity comes from the name, location, product and unit, so this\
+           \ journal cannot be replayed by an engine that mints differently."
+  where
+    render [] = "nothing"
+    render keys = T.intercalate ", " keys
+
+opName :: JournalOp -> Text
+opName = \case
+    Created _ _ -> "create"
+    Replaced _ _ -> "replace"
+    Deleted _ -> "delete"
+
+-- ---------------------------------------------------------------------------
+-- Codec
+--
+-- Hand-written, and the journal's own: the wire types describing the same
+-- edits ("API.Types") are free to change shape with the API, while what is
+-- already on disk has to keep reading. The version on each line is what makes
+-- that separation enforceable.
+-- ---------------------------------------------------------------------------
+
+instance ToJSON JournalEvent where
+    toJSON event = object $ ["v" .= journalVersion, "at" .= jeAt event] <> opFields (jeOp event)
+
+instance FromJSON JournalEvent where
+    parseJSON = withObject "journal entry" $ \o -> do
+        version <- o .: "v"
+        if version /= journalVersion
+            then
+                fail $
+                    "journal format version "
+                        <> show (version :: Int)
+                        <> ", but this engine reads version "
+                        <> show journalVersion
+            else JournalEvent <$> o .: "at" <*> parseOp o
+
+opFields :: JournalOp -> [Pair]
+opFields = \case
+    Created activities written ->
+        [ "op" .= ("create" :: Text)
+        , "activities" .= map activityJSON activities
+        , "written" .= written
+        ]
+    Replaced target activity ->
+        ["op" .= ("replace" :: Text), "target" .= target, "activity" .= activityJSON activity]
+    Deleted targets ->
+        ["op" .= ("delete" :: Text), "targets" .= targets]
+
+parseOp :: Object -> Parser JournalOp
+parseOp o =
+    o .: "op" >>= \case
+        ("create" :: Text) ->
+            Created <$> (o .: "activities" >>= traverse parseActivity) <*> o .: "written"
+        "replace" ->
+            Replaced <$> o .: "target" <*> (o .: "activity" >>= parseActivity)
+        "delete" ->
+            Deleted <$> o .: "targets"
+        other -> fail ("unknown journal operation: " <> T.unpack other)
+
+activityJSON :: AuthoredActivity -> Value
+activityJSON a =
+    object
+        [ "name" .= aaName a
+        , "location" .= aaLocation a
+        , "description" .= aaDescription a
+        , "product"
+            .= object
+                [ "name" .= aaProductName a
+                , "amount" .= aaProductAmount a
+                , "unit" .= aaProductUnit a
+                ]
+        , "exchanges" .= map exchangeJSON (aaExchanges a)
+        ]
+
+parseActivity :: Value -> Parser AuthoredActivity
+parseActivity = withObject "authored activity" $ \o -> do
+    prod <- o .: "product"
+    name <- o .: "name"
+    location <- o .: "location"
+    description <- o .: "description"
+    productName <- prod .: "name"
+    productAmount <- prod .: "amount"
+    productUnit <- prod .: "unit"
+    exchanges <- o .: "exchanges" >>= traverse parseExchange
+    pure
+        AuthoredActivity
+            { aaName = name
+            , aaLocation = location
+            , aaDescription = description
+            , aaProductName = productName
+            , aaProductAmount = productAmount
+            , aaProductUnit = productUnit
+            , aaExchanges = exchanges
+            }
+
+exchangeJSON :: AuthoredExchange -> Value
+exchangeJSON = \case
+    AuthoredTechInput provider amount unit comment ->
+        object $ ["kind" .= ("input" :: Text), "provider" .= provider, "amount" .= amount] <> stated unit comment
+    AuthoredWasteOutput provider amount unit comment ->
+        object $ ["kind" .= ("waste" :: Text), "provider" .= provider, "amount" .= amount] <> stated unit comment
+    AuthoredBio flow direction amount unit comment ->
+        object $
+            [ "kind" .= ("biosphere" :: Text)
+            , "flow" .= flowJSON flow
+            , "direction" .= directionText direction
+            , "amount" .= amount
+            ]
+                <> stated unit comment
+  where
+    stated unit comment = optional "unit" unit <> optional "comment" comment
+    optional key = maybe [] (\value -> [key .= (value :: Text)])
+
+parseExchange :: Value -> Parser AuthoredExchange
+parseExchange = withObject "exchange" $ \o ->
+    o .: "kind" >>= \case
+        ("input" :: Text) ->
+            AuthoredTechInput <$> o .: "provider" <*> o .: "amount" <*> o .:? "unit" <*> o .:? "comment"
+        "waste" ->
+            AuthoredWasteOutput <$> o .: "provider" <*> o .: "amount" <*> o .:? "unit" <*> o .:? "comment"
+        "biosphere" ->
+            AuthoredBio
+                <$> (o .: "flow" >>= parseFlow)
+                <*> (o .: "direction" >>= parseDirection)
+                <*> o .: "amount"
+                <*> o .:? "unit"
+                <*> o .:? "comment"
+        other -> fail ("unknown exchange kind: " <> T.unpack other)
+
+{- | A biosphere line names a flow the vocabulary already has, or introduces
+one. The unit of an introduced flow is part of its identity, which is why it
+lives inside the flow rather than beside it: the amount's own unit is a
+separate field, and the two are not required to be the same thing.
+-}
+flowJSON :: FlowRef -> Value
+flowJSON = \case
+    ExistingFlow flowId -> object ["id" .= UUID.toText flowId]
+    NewBioFlow name compartment unit ->
+        object $
+            ["name" .= name, "compartment" .= compartmentName compartment, "unit" .= unit]
+                <> maybe [] (\sub -> ["sub_compartment" .= sub]) (compartmentSub compartment)
+
+parseFlow :: Value -> Parser FlowRef
+parseFlow = withObject "biosphere flow" $ \o -> do
+    mIdentifier <- o .:? "id"
+    mName <- o .:? "name"
+    case (mIdentifier, mName) of
+        (Just identifier, Nothing) ->
+            maybe (fail ("not a flow identifier: " <> T.unpack identifier)) (pure . ExistingFlow) $
+                UUID.fromText identifier
+        (Nothing, Just name) -> do
+            compartment <- o .: "compartment"
+            sub <- o .:? "sub_compartment"
+            unit <- o .: "unit"
+            pure $
+                NewBioFlow
+                    name
+                    Compartment{compartmentName = compartment, compartmentSub = sub}
+                    unit
+        (Just _, Just _) ->
+            fail "a biosphere flow names either an existing flow or a new one, not both"
+        (Nothing, Nothing) ->
+            fail "a biosphere flow needs either an identifier or a name, compartment and unit"
+
+directionText :: BioDirection -> Text
+directionText = \case
+    Resource -> "resource"
+    Emission -> "emission"
+
+parseDirection :: Text -> Parser BioDirection
+parseDirection raw = case T.toLower (T.strip raw) of
+    "resource" -> pure Resource
+    "emission" -> pure Emission
+    other -> fail ("unknown biosphere direction: " <> T.unpack other <> " (expected resource|emission)")

--- a/src/Database/Journal.hs
+++ b/src/Database/Journal.hs
@@ -58,7 +58,13 @@ module Database.Journal (
     appendEvent,
     readJournal,
 
+    -- * Keeping a cache honest about it
+    journalStamp,
+    readAppliedStamp,
+    writeAppliedStamp,
+
     -- * Applying it
+    applyOp,
     replayJournal,
 ) where
 
@@ -79,14 +85,17 @@ import Data.Aeson (
  )
 import Data.Aeson.Types (Pair, Parser, parseEither)
 import Data.Bifunctor (bimap, first)
+import Data.Bits (xor)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy as BL
 import Data.Char (isSpace)
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.IO as TIO
 import Data.Time.Clock (getCurrentTime)
 import Data.Time.Format.ISO8601 (iso8601Show)
 import qualified Data.UUID as UUID
+import Data.Word (Word64)
 import System.Directory (createDirectoryIfMissing, doesFileExist)
 import System.FilePath ((</>))
 import System.IO (IOMode (AppendMode), withFile)
@@ -237,6 +246,69 @@ readLine :: BS.ByteString -> Either LineProblem JournalEvent
 readLine line = case eitherDecodeStrict line of
     Left err -> Left (Torn err)
     Right value -> first Unreadable (parseEither parseJSON value)
+
+-- ---------------------------------------------------------------------------
+-- Keeping a cache honest about the journal
+-- ---------------------------------------------------------------------------
+
+{- | What the journal currently says, in one line: its length and a hash of
+its bytes. Empty when there is no journal.
+
+The matrix cache holds the database /after/ its edits, which is what keeps a
+load from replaying them every time. That is only safe if the cache can say
+which journal it was built from: a crash between appending a line and saving
+the cache would otherwise leave a cache that silently predates an edit its
+author was told had happened. The stamp is written last, so a cache without a
+matching one is treated as stale and the sources are read again.
+-}
+journalStamp :: FilePath -> IO Text
+journalStamp home = do
+    let path = journalPath home
+    exists <- doesFileExist path
+    if not exists
+        then pure ""
+        else do
+            bytes <- BS.readFile path
+            pure $ T.pack (show (BS.length bytes)) <> ":" <> T.pack (show (fnv1a bytes))
+
+-- | The stamp the cache was last saved with, empty when there is none.
+readAppliedStamp :: FilePath -> IO Text
+readAppliedStamp home = do
+    let path = appliedPath home
+    exists <- doesFileExist path
+    if not exists
+        then pure ""
+        else either (const "") T.strip <$> readStamp path
+  where
+    readStamp path = try (TIO.readFile path) :: IO (Either SomeException Text)
+
+-- | Record that the cache now holds everything this journal describes.
+writeAppliedStamp :: FilePath -> Text -> IO ()
+writeAppliedStamp home stamp = do
+    written <- try (TIO.writeFile (appliedPath home) stamp)
+    case written of
+        Right () -> pure ()
+        Left (err :: SomeException) ->
+            -- Losing the stamp costs a re-read of the sources at the next
+            -- load, never an edit, so it is a warning and not a failure.
+            reportProgress Warning $
+                "Could not record which edits the cache of "
+                    <> home
+                    <> " holds ("
+                    <> show err
+                    <> "); the next load will read the sources again."
+
+appliedPath :: FilePath -> FilePath
+appliedPath home = home </> "journal.applied"
+
+{- | FNV-1a, for telling one journal from another. Not a security property:
+what it has to catch is a file that grew, shrank or was edited by hand since
+the cache was written.
+-}
+fnv1a :: BS.ByteString -> Word64
+fnv1a = BS.foldl' step 14695981039346656037
+  where
+    step hash byte = (hash `xor` fromIntegral (fromEnum byte)) * 1099511628211
 
 -- ---------------------------------------------------------------------------
 -- Applying it

--- a/src/Database/Journal.hs
+++ b/src/Database/Journal.hs
@@ -69,7 +69,7 @@ module Database.Journal (
 ) where
 
 import Control.Exception (SomeException, try)
-import Control.Monad (foldM)
+import Control.Monad (foldM, when)
 import Data.Aeson (
     FromJSON (..),
     Object,
@@ -98,7 +98,15 @@ import qualified Data.UUID as UUID
 import Data.Word (Word64)
 import System.Directory (createDirectoryIfMissing, doesFileExist)
 import System.FilePath ((</>))
-import System.IO (IOMode (AppendMode), withFile)
+import System.IO (
+    Handle,
+    IOMode (ReadWriteMode),
+    SeekMode (AbsoluteSeek, SeekFromEnd),
+    hFileSize,
+    hSeek,
+    hSetFileSize,
+    withFile,
+ )
 
 import Database.Author (
     AuthorContext (..),
@@ -170,7 +178,9 @@ appendEvent home op = do
     let event = JournalEvent{jeAt = T.pack (iso8601Show now), jeOp = op}
     written <- try $ do
         createDirectoryIfMissing True home
-        withFile (journalPath home) AppendMode $ \handle ->
+        withFile (journalPath home) ReadWriteMode $ \handle -> do
+            dropTornTail handle
+            hSeek handle SeekFromEnd 0
             BL.hPut handle (encode event <> "\n")
     pure $ case written of
         Right () -> Right ()
@@ -180,6 +190,26 @@ appendEvent home op = do
                     <> T.pack (journalPath home)
                     <> ": "
                     <> T.pack (show err)
+
+{- | Remove a torn tail before appending, so the new line starts a line.
+
+A file that does not end in a newline carries the tail of an append that was
+cut short, which belongs to an edit that was never acknowledged (the line is
+on disk before the caller is answered). Appending straight after it would fuse
+the new line with the debris, turning an edit that /was/ acknowledged into a
+line no replay can read. Truncating to the last newline drops exactly what the
+replay's torn-last-line rule would have dropped, one write earlier.
+-}
+dropTornTail :: Handle -> IO ()
+dropTornTail handle = do
+    size <- hFileSize handle
+    when (size > 0) $ do
+        hSeek handle AbsoluteSeek (size - 1)
+        lastByte <- BS.hGet handle 1
+        when (lastByte /= "\n") $ do
+            hSeek handle AbsoluteSeek 0
+            bytes <- BS.hGet handle (fromIntegral size)
+            hSetFileSize handle (fromIntegral (BS.length (BS.dropWhileEnd (/= '\n') bytes)))
 
 {- | Read a database's journal. A database with no journal has made no edits,
 which is not an error.

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -46,6 +46,7 @@ module Database.Manager (
     RelinkResult (..),
     addDatabase,
     removeDatabase,
+    editHome,
 
     -- * Method Operations
     listMethodCollections,
@@ -1832,6 +1833,10 @@ loadDatabaseSingleFromConfig manager dbName = do
 
 {- | Where a database keeps its edits, or 'Nothing' for one the engine only
 reads from its configuration and never writes.
+
+An upload and a copy both keep theirs in the upload directory named after
+them, beside the @meta.toml@ that describes them. For a copy that directory is
+the only thing it owns, since its data is the source's.
 -}
 editHome :: DatabaseConfig -> IO (Maybe FilePath)
 editHome dbConfig

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -247,8 +247,10 @@ import qualified UnitConversion
 -- CrossDBLinkingStats is now in Types, re-exported from Database.Loader
 
 import API.Types (DepLoadResult (..))
+import Database.Author (AuthorContext (..))
 import Database.CrossLinking (IndexedDatabase (..), LinkingContext (..), buildIndexedDatabaseFromDB, defaultLinkingThreshold)
 import qualified Database.CrossLinking as CrossLinking
+import qualified Database.Journal as Journal
 import Database.Upload (detectMethodFormat, detectedFormatLabel, findMethodDirectory, listDirectoryRecursive)
 import qualified Database.Upload as Upload
 import qualified Database.UploadedDatabase as UploadedDB
@@ -1763,19 +1765,31 @@ loadDatabaseSingleFromConfig manager dbName = do
                     synonymDB <- getMergedSynonymDB manager
                     warnReopenedBridges synonymDB
                     unitConfig <- getMergedUnitConfig manager
+                    -- A cache saved before the last edit was journalled would
+                    -- come back without it. Read the sources again in that
+                    -- case, so the journal below is replayed over them.
+                    journalAhead <- journalAheadOfCache dbConfig
                     eitherResult <-
                         try $
                             loadDatabaseFromConfigWithCrossDB
                                 dbConfig
                                 synonymDB
                                 unitConfig
-                                (dmNoCache manager)
+                                (dmNoCache manager || journalAhead)
                                 otherIndexes
                                 (locationHierarchyOf manager)
-                    case eitherResult of
-                        Left (ex :: SomeException) -> return $ Left $ "Exception loading database: " <> T.pack (show ex)
-                        Right (Left err) -> return $ Left err
-                        Right (Right (loaded, fromCache)) -> do
+                    replayResult <- case eitherResult of
+                        Left (ex :: SomeException) -> pure $ Left $ "Exception loading database: " <> T.pack (show ex)
+                        Right (Left err) -> pure (Left err)
+                        -- A cache hit already holds the edits (its stamp says
+                        -- so); a fresh parse holds only what the author
+                        -- uploaded, and the journal is the rest.
+                        Right (Right (loaded, fromCache))
+                            | fromCache -> pure (Right (loaded, fromCache, False))
+                            | otherwise -> fmap (\(l, replayed) -> (l, fromCache, replayed)) <$> replayEdits manager dbConfig loaded
+                    case replayResult of
+                        Left err -> return (Left err)
+                        Right (loaded, fromCache, replayed) -> do
                             let indexedDb = buildIndexedDatabaseFromDB dbName synonymDB (ldDatabase loaded)
                             atomically $ do
                                 modifyTVar' (dmLoadedDbs manager) (M.insert dbName loaded)
@@ -1799,7 +1813,9 @@ loadDatabaseSingleFromConfig manager dbName = do
                             -- against a previous dep set — possibly stale
                             -- versions of the same dep names — so a relink
                             -- is required to converge.
-                            when fromCache $ do
+                            -- A replay clears the cross-database links, exactly
+                            -- as an edit does, so it needs the same relink.
+                            when (fromCache || replayed) $ do
                                 result <- relinkDatabase manager dbName
                                 case result of
                                     Right _ -> return ()
@@ -1807,7 +1823,98 @@ loadDatabaseSingleFromConfig manager dbName = do
                                         reportProgress Warning $
                                             "Self-relink of " <> T.unpack dbName <> " failed: " <> T.unpack err
                             relinkDependents manager dbName
+                            -- Cache what the journal produced, so the next load
+                            -- does not replay it, and stamp the cache with the
+                            -- journal it holds. The stamp goes last: a cache
+                            -- that is not stamped is read again from source.
+                            when replayed $ recordReplayedCache manager dbConfig
                             return $ Right loaded
+
+{- | Where a database keeps its edits, or 'Nothing' for one the engine only
+reads from its configuration and never writes.
+-}
+editHome :: DatabaseConfig -> IO (Maybe FilePath)
+editHome dbConfig
+    | not (dcIsUploaded dbConfig) = pure Nothing
+    | otherwise = do
+        uploadsDir <- UploadedDB.getDatabaseUploadsDir
+        pure (Just (uploadsDir </> T.unpack (dcName dbConfig)))
+
+{- | Whether the journal has moved since the matrix cache was saved from it.
+
+The cache holds the database after its edits, which is what keeps every load
+from replaying them. It is only trustworthy while it can say which journal it
+was built from, so a cache whose stamp does not match the journal is not used
+at all: the sources are read again and the journal replayed over them.
+-}
+journalAheadOfCache :: DatabaseConfig -> IO Bool
+journalAheadOfCache dbConfig =
+    editHome dbConfig >>= \case
+        Nothing -> pure False
+        Just home -> do
+            current <- Journal.journalStamp home
+            applied <- Journal.readAppliedStamp home
+            pure (current /= applied)
+
+{- | Replay a database's edits over the sources just parsed, returning whether
+there were any.
+
+Everything the author was told had happened lives in the journal, so a failure
+here refuses the load rather than handing back a database that quietly
+disagrees with its own record. The dependencies are the ones the config pins,
+already loaded by 'loadDatabase', because a supplier an edit points at may
+live in one of them.
+-}
+replayEdits :: DatabaseManager -> DatabaseConfig -> LoadedDatabase -> IO (Either Text (LoadedDatabase, Bool))
+replayEdits manager dbConfig loaded =
+    editHome dbConfig >>= \case
+        Nothing -> pure (Right (loaded, False))
+        Just home ->
+            Journal.readJournal home >>= \case
+                Left err -> pure (Left (dcName dbConfig <> ": " <> err))
+                Right [] -> pure (Right (loaded, False))
+                Right events -> do
+                    loadedDbs <- readTVarIO (dmLoadedDbs manager)
+                    unitConfig <- getMergedUnitConfig manager
+                    synonymDB <- getMergedSynonymDB manager
+                    let deps = [ldDatabase ld | name <- dcDepends dbConfig, Just ld <- [M.lookup name loadedDbs]]
+                        ctx =
+                            AuthorContext
+                                { acDb = ldDatabase loaded
+                                , acDeps = deps
+                                , acUnitConfig = unitConfig
+                                }
+                    reportProgress Info $
+                        "Replaying " <> show (length events) <> " recorded edit(s) of " <> T.unpack (dcName dbConfig)
+                    case Journal.replayJournal ctx events of
+                        Left err -> pure (Left (dcName dbConfig <> ": " <> err))
+                        Right edited -> do
+                            -- The rebuild resets the runtime indexes and moves
+                            -- every matrix row, so both are made again here.
+                            let withRuntime = BM25.addBM25Index (initializeRuntimeFields edited synonymDB)
+                                techTriplesInt =
+                                    [ (fromIntegral i, fromIntegral j, v)
+                                    | SparseTriple i j v <- U.toList (dbTechnosphereTriples withRuntime)
+                                    ]
+                            clearCachedSolver (dcName dbConfig)
+                            solver <-
+                                createSharedSolver
+                                    (dcName dbConfig)
+                                    techTriplesInt
+                                    (fromIntegral (dbActivityCount withRuntime))
+                            pure (Right (loaded{ldDatabase = withRuntime, ldSharedSolver = solver}, True))
+
+{- | Save the replayed database to its matrix cache and stamp the cache with
+the journal it now holds, so the next load reads it instead of replaying.
+-}
+recordReplayedCache :: DatabaseManager -> DatabaseConfig -> IO ()
+recordReplayedCache manager dbConfig =
+    editHome dbConfig >>= \case
+        Nothing -> pure ()
+        Just home -> do
+            saved <- getDatabase manager (dcName dbConfig)
+            mapM_ (Loader.saveCachedDatabaseWithMatrices (dcName dbConfig) (dcPath dbConfig) . ldDatabase) saved
+            Journal.journalStamp home >>= Journal.writeAppliedStamp home
 
 -- | Result of a relink operation (unresolved counts before/after).
 data RelinkResult = RelinkResult
@@ -2330,39 +2437,52 @@ removeDatabase :: DatabaseManager -> Text -> IO (Either Text ())
 removeDatabase manager dbName = do
     loadedDbs <- readTVarIO (dmLoadedDbs manager)
     availableDbs <- readTVarIO (dmAvailableDbs manager)
-
     case M.lookup dbName availableDbs of
         Nothing -> return $ Left $ "Database not found: " <> dbName
-        Just dbConfig -> do
+        Just dbConfig
             -- Honor the per-config deletable policy (defaults to dcIsUploaded).
-            if not (dcDeletable dbConfig)
-                then return $ Left "Cannot delete configured database. Edit volca.toml to remove it."
-                else
-                    if M.member dbName loadedDbs
-                        then return $ Left "Cannot delete loaded database. Close it first."
-                        else do
-                            -- Get the upload directory (uploads/<slug>/)
-                            uploadsDir <- UploadedDB.getDatabaseUploadsDir
-                            let uploadDir = uploadsDir </> T.unpack dbName
-                            pathExists <- doesDirectoryExist uploadDir
-                            if pathExists
-                                then do
-                                    -- Delete the database directory immediately
-                                    result <- tryIO $ removeDirectoryRecursive uploadDir
-                                    case result of
-                                        Left (e :: SomeException) ->
-                                            return $ Left $ "Failed to delete: " <> T.pack (show e)
-                                        Right () -> do
-                                            reportProgress Info $ "Deleted: " <> uploadDir
-                                            deleteCacheFile dbName (dcPath dbConfig)
-                                            removeFromMemory manager dbName
-                                else do
-                                    -- Directory already missing, just remove from memory
-                                    reportProgress Info $ "Directory already missing: " <> uploadDir
-                                    removeFromMemory manager dbName
+            | not (dcDeletable dbConfig) ->
+                return $ Left "Cannot delete configured database. Edit volca.toml to remove it."
+            | M.member dbName loadedDbs ->
+                return $ Left "Cannot delete loaded database. Close it first."
+            | otherwise -> do
+                -- A copy owns no data: it reads this database's files and keeps
+                -- only its own edits, so taking the files would leave it unable
+                -- to load at all.
+                copies <- copiesOf dbName
+                case copies of
+                    [] -> deleteUpload dbConfig
+                    names ->
+                        return $
+                            Left $
+                                "Cannot delete "
+                                    <> dbName
+                                    <> ": "
+                                    <> T.intercalate ", " names
+                                    <> " were copied from it and read its files. Delete them first."
   where
     tryIO :: IO a -> IO (Either SomeException a)
     tryIO = Control.Exception.try
+    -- The databases copied from this one, which still read its files.
+    copiesOf name = do
+        uploads <- UploadedDB.discoverUploadedDatabases
+        pure [slug | (slug, _, meta) <- uploads, UploadedDB.umSource meta == Just name]
+    deleteUpload dbConfig = do
+        uploadsDir <- UploadedDB.getDatabaseUploadsDir
+        let uploadDir = uploadsDir </> T.unpack dbName
+        pathExists <- doesDirectoryExist uploadDir
+        if pathExists
+            then
+                tryIO (removeDirectoryRecursive uploadDir) >>= \case
+                    Left (e :: SomeException) -> return $ Left $ "Failed to delete: " <> T.pack (show e)
+                    Right () -> do
+                        reportProgress Info $ "Deleted: " <> uploadDir
+                        deleteCacheFile dbName (dcPath dbConfig)
+                        removeFromMemory manager dbName
+            else do
+                -- Directory already missing, just remove from memory
+                reportProgress Info $ "Directory already missing: " <> uploadDir
+                removeFromMemory manager dbName
     deleteCacheFile name sourcePath = do
         cacheFile <- Loader.generateMatrixCacheFilename name sourcePath
         let zstdFile = cacheFile ++ ".zst"

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1269,7 +1269,10 @@ uploadMetaToConfig slug dirPath meta =
     DatabaseConfig
         { dcName = slug
         , dcDisplayName = UploadedDB.umDisplayName meta
-        , dcPath = dirPath </> UploadedDB.umDataPath meta -- Full path to data
+        , -- Full path to data. An upload's path is relative to its home; a
+          -- copy's is absolute (it names the source's files), and '</>'
+          -- returns an absolute right operand as it is.
+          dcPath = dirPath </> UploadedDB.umDataPath meta
         , dcDescription = UploadedDB.umDescription meta
         , dcLoad = False -- Never auto-load uploads
         , dcDefault = False

--- a/src/Database/Rebuild.hs
+++ b/src/Database/Rebuild.hs
@@ -33,6 +33,7 @@ module Database.Rebuild (
 
     -- * Identity
     renderKey,
+    resolveProcess,
 ) where
 
 import qualified Data.Map.Strict as M
@@ -60,6 +61,9 @@ import Types (
     ProcessId,
     TechnosphereFlow (..),
     UUID,
+    findProcessId,
+    findProcessIdByActivityUUID,
+    parseUUIDPair,
  )
 import UnitConversion (UnitConfig, defaultUnitConfig)
 
@@ -286,3 +290,17 @@ checkKeys intent existing keys = case intent of
 -- | @activityUUID_productUUID@, the identity a process is addressed by.
 renderKey :: (UUID, UUID) -> Text
 renderKey (actUUID, prodUUID) = UUID.toText actUUID <> "_" <> UUID.toText prodUUID
+
+{- | Resolve a process-id string to its 'ProcessId'. Accepts the canonical
+@activityUUID_productUUID@ form and the bare-activity-UUID fallback (when the
+activity has a unique reference product), mirroring
+'Service.resolveActivityAndProcessId'. The UI, the CLI and the journal all
+carry these textual ids, because a 'ProcessId' is a matrix index that
+renumbers on every edit. Unresolvable ids fail loudly rather than being
+silently dropped.
+-}
+resolveProcess :: Database -> Text -> Either Text ProcessId
+resolveProcess db queryText =
+    maybe (Left ("Unknown process id: " <> queryText)) Right $ case parseUUIDPair queryText of
+        Just (a, p) -> findProcessId db a p
+        Nothing -> UUID.fromText queryText >>= findProcessIdByActivityUUID db

--- a/src/Database/Rebuild.hs
+++ b/src/Database/Rebuild.hs
@@ -1,0 +1,288 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Database.Rebuild
+Description : How a changed activity set becomes a database again (pure)
+
+Editing a database is two things: deciding what changes, which is effectful
+(the registry, the files, the solver — "Database.Edit"), and turning the
+changed activity set back into a 'Database', which is not. This module is the
+second half, and nothing here touches the manager or the disk.
+
+The split is what lets anything below the effectful editor apply an edit.
+Every function is @Database -> Either Text Database@ or smaller, so the same
+primitives serve a live mutation and a replay of edits recorded earlier.
+
+The rebuild reuses the exact pure builders that back a freshly-loaded database
+('buildInterningTables' / 'buildTechTriples' / 'buildBioTriples' /
+'buildProductIndex' / 'buildIndexesWithProcessIds'), so an edited database is
+indistinguishable from one that was loaded that way to begin with.
+-}
+module Database.Rebuild (
+    -- * Delete
+    deleteActivities,
+    deleteActivitiesWith,
+
+    -- * Insert and replace
+    insertActivities,
+    replaceActivities,
+
+    -- * The rebuild itself
+    rebuildFromActivities,
+    activityMap,
+
+    -- * Identity
+    renderKey,
+) where
+
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+
+import Database (buildIndexesWithProcessIds, buildProductIndex)
+import Database.Author (ResolvedInsert (..))
+import Database.MatrixBuild (
+    InterningTables (..),
+    buildBioTriples,
+    buildInterningTables,
+    buildSupplierRefUnits,
+    buildTechTriples,
+    collectBioFlowOrder,
+ )
+import Types (
+    Activity (..),
+    BiosphereFlow (..),
+    Database (..),
+    Exchange (..),
+    ProcessId,
+    TechnosphereFlow (..),
+    UUID,
+ )
+import UnitConversion (UnitConfig, defaultUnitConfig)
+
+-- ---------------------------------------------------------------------------
+-- Delete
+-- ---------------------------------------------------------------------------
+
+{- | Remove a set of activities (by 'ProcessId') and rebuild every dependent
+structure. Uses 'defaultUnitConfig'; effectful call sites that carry a merged
+unit config (the only place where non-SI conversions matter) should call
+'deleteActivitiesWith' instead so a coefficient is never silently dropped on
+an unknown-unit conversion.
+-}
+deleteActivities :: [ProcessId] -> Database -> Either Text Database
+deleteActivities = deleteActivitiesWith defaultUnitConfig
+
+{- | 'deleteActivities' with an explicit 'UnitConfig'.
+
+Steps, all pure:
+
+  1. Resolve the delete set to the @(activityUUID, productUUID)@ keys it
+     occupies in 'dbProcessIdTable', validating that every requested
+     'ProcessId' exists (no silent skip).
+  2. Drop those keys; for every surviving activity, UNLINK any technosphere /
+     waste exchange whose @(activityLink, flow)@ pointed at a deleted key —
+     reset its activity link to 'UUID.nil' and clear the stale process link.
+  3. Rebuild interning tables, indexes, matrices and the product index from
+     the surviving activity map via the shared loader builders.
+
+Fails (Left) when an out-of-range 'ProcessId' is requested, when the result
+would be empty, or when matrix construction reports an inconsistency (e.g. an
+unknown unit conversion under the given config).
+-}
+deleteActivitiesWith :: UnitConfig -> [ProcessId] -> Database -> Either Text Database
+deleteActivitiesWith unitConfig pids db = do
+    deletedKeys <- resolveDeleteKeys db pids
+    let survivors = surviving db deletedKeys
+        survivingKeys = M.keysSet survivors
+        unlinkedMap = M.map (unlinkActivity survivingKeys) survivors
+    if M.null unlinkedMap
+        then Left "Refusing to delete: the result would have no activities"
+        else rebuildFromActivities unitConfig db unlinkedMap
+
+{- | Resolve each requested 'ProcessId' to its @(activityUUID, productUUID)@ key.
+Every id must be in range — an out-of-range id is a caller error, surfaced as
+'Left' rather than silently ignored. The result is a 'Set' so membership tests
+during unlinking are @O(log n)@.
+-}
+resolveDeleteKeys :: Database -> [ProcessId] -> Either Text (S.Set (UUID, UUID))
+resolveDeleteKeys db = fmap S.fromList . traverse keyOf
+  where
+    table = dbProcessIdTable db
+    n = V.length table
+    keyOf pid
+        | i >= 0 && i < n = Right (table V.! i)
+        | otherwise = Left ("Delete: ProcessId out of range: " <> T.pack (show pid))
+      where
+        i = fromIntegral pid
+
+-- | The activity map keyed by @(activityUUID, productUUID)@, minus the deleted keys.
+surviving :: Database -> S.Set (UUID, UUID) -> M.Map (UUID, UUID) Activity
+surviving db deletedKeys =
+    M.fromList
+        [ (key, dbActivities db V.! i)
+        | i <- [0 .. V.length (dbActivities db) - 1]
+        , let key = dbProcessIdTable db V.! i
+        , not (S.member key deletedKeys)
+        ]
+
+-- | The database's activities, keyed the way a rebuild takes them.
+activityMap :: Database -> M.Map (UUID, UUID) Activity
+activityMap db = surviving db S.empty
+
+{- | Reset technosphere / waste exchanges on a surviving activity whose producer
+link no longer resolves to a surviving @(activityUUID, productUUID)@ key.
+
+The link target is exactly that pair: 'findProducer' resolves
+@(activityLink, flowId)@ against the interning table, so a multi-product
+activity that keeps at least one product stays a valid target for exchanges
+pointing at a *surviving* product, while exchanges pointing at a deleted
+product are unlinked. A biosphere exchange has no producer link and is
+returned unchanged. The stale 'ProcessId' link is always cleared because
+deletion renumbers every 'ProcessId'. An already-orphan link
+(@activityLink == nil@) stays orphan.
+-}
+unlinkActivity :: S.Set (UUID, UUID) -> Activity -> Activity
+unlinkActivity survivingKeys act =
+    act{exchanges = map unlinkExchange (exchanges act)}
+  where
+    dangling link flow = link /= UUID.nil && not (S.member (link, flow) survivingKeys)
+    unlinkExchange ex = case ex of
+        BiosphereExchange{} -> ex
+        TechnosphereExchange{techActivityLinkId = link, techFlowId = flow}
+            | dangling link flow ->
+                ex{techActivityLinkId = UUID.nil, techProcessLinkId = Nothing}
+            | otherwise -> ex{techProcessLinkId = Nothing}
+        WasteExchange{waActivityLinkId = link, waFlowId = flow}
+            | dangling link flow ->
+                ex{waActivityLinkId = UUID.nil, waProcessLinkId = Nothing}
+            | otherwise -> ex{waProcessLinkId = Nothing}
+
+{- | Rebuild a 'Database' from a surviving activity map, reusing the exact pure
+builders that back a freshly-loaded database. Flow / unit tables are carried
+over unchanged: deletion removes activities, never the flow or unit
+vocabulary, so a relink can still resolve the surviving links. Runtime fields
+(synonym, flow-name, BM25 indexes) are reset to their unloaded state; the
+effectful caller re-attaches them with the merged synonym DB.
+-}
+rebuildFromActivities :: UnitConfig -> Database -> M.Map (UUID, UUID) Activity -> Either Text Database
+rebuildFromActivities unitConfig db activities =
+    let tables = buildInterningTables activities
+        supplierRefUnits = buildSupplierRefUnits (dbUnits db) (itActivities tables)
+        indexes = buildIndexesWithProcessIds (itActivities tables) (itProcessIdTable tables)
+        bioFlowUUIDs = collectBioFlowOrder (itActivities tables)
+        bioTriples = buildBioTriples bioFlowUUIDs tables
+        productIndex = buildProductIndex (itActivities tables) (itProcessIdTable tables) (dbTechFlows db)
+     in case buildTechTriples unitConfig (dbUnits db) tables supplierRefUnits of
+            Left err -> Left err
+            Right (techTriples, _warnings) ->
+                Right
+                    db
+                        { dbProcessIdTable = itProcessIdTable tables
+                        , dbProcessIdLookup = itProcessIdLookup tables
+                        , dbActivityUUIDIndex = itActivityUUIDIndex tables
+                        , dbActivityProductsIndex = itActivityProductsIndex tables
+                        , dbProductIndex = productIndex
+                        , dbActivities = itActivities tables
+                        , dbIndexes = indexes
+                        , dbTechnosphereTriples = techTriples
+                        , dbBiosphereTriples = bioTriples
+                        , dbActivityIndex = V.generate (fromIntegral (itActivityCount tables)) fromIntegral
+                        , dbBiosphereOrder = bioFlowUUIDs
+                        , dbActivityCount = itActivityCount tables
+                        , dbBiosphereCount = fromIntegral (V.length bioFlowUUIDs)
+                        , -- Cross-DB links may now reference deleted activities; clear so a
+                          -- subsequent relink rebuilds them against the surviving set.
+                          dbCrossDBLinks = []
+                        , -- Linking stats describe the pre-delete set (input count, completeness,
+                          -- missing suppliers); reset to the fresh-load default so the setup/status
+                          -- endpoint never reports stale numbers until the next relink.
+                          dbLinkingStats = mempty
+                        , -- Runtime-only indexes are reset; re-attached by the effectful caller.
+                          dbSynonymDB = Nothing
+                        , dbFlowsByName = M.empty
+                        , dbFlowsByCAS = M.empty
+                        , dbProductSearchIndex = M.empty
+                        , dbBM25Index = Nothing
+                        }
+
+-- ---------------------------------------------------------------------------
+-- Insert / replace
+-- ---------------------------------------------------------------------------
+
+{- | Whether a batch means to add rows the database does not have, or to
+rewrite rows it does. There is deliberately no upsert: a mistyped identity
+must fail, not quietly become a second copy of an activity the author thought
+they were correcting.
+-}
+data WriteIntent = Insert | Replace
+
+{- | Add authored activities to a database and rebuild everything that depends
+on them.
+
+Every key must be absent — 'Database.Author' mints identity from the activity's
+own name, location, product and unit, so a key that already exists means the
+author is re-describing something the database already holds and wants
+'replaceActivities' instead.
+-}
+insertActivities :: UnitConfig -> [ResolvedInsert] -> Database -> Either Text Database
+insertActivities = applyResolved Insert
+
+{- | Rewrite activities the database already holds, keeping their identity.
+
+Every key must be present. Replacing keeps the old version's flows in the
+vocabulary, exactly as deletion does: a flow no activity uses any more is
+inert, and dropping it would break a relink that still resolves through it.
+-}
+replaceActivities :: UnitConfig -> [ResolvedInsert] -> Database -> Either Text Database
+replaceActivities = applyResolved Replace
+
+{- | Shared write path. The vocabulary the batch brings (its product flows and
+any new biosphere flows) lands in the same step as the activities that
+reference it, so no intermediate value exists in which an exchange points at a
+flow the database cannot name.
+
+An empty batch returns the database untouched rather than rebuilding: a
+rebuild resets cross-database links ('rebuildFromActivities'), so treating "no
+activities to write" as a no-op is what keeps a caller's empty request from
+silently unlinking the database.
+-}
+applyResolved :: WriteIntent -> UnitConfig -> [ResolvedInsert] -> Database -> Either Text Database
+applyResolved intent unitConfig inserts db
+    | null inserts = Right db
+    | otherwise = do
+        let existing = activityMap db
+        checkKeys intent existing (map riKey inserts)
+        rebuildFromActivities
+            unitConfig
+            db
+                { dbTechFlows = M.union (indexBy tfId (concatMap riNewTechFlows inserts)) (dbTechFlows db)
+                , dbBioFlows = M.union (indexBy bfId (concatMap riNewBioFlows inserts)) (dbBioFlows db)
+                }
+            (M.union (M.fromList [(riKey i, riActivity i) | i <- inserts]) existing)
+  where
+    indexBy key xs = M.fromList [(key x, x) | x <- xs]
+
+{- | Refuse a batch whose keys contradict the intent, naming every offending
+identity at once so a long batch is not fixed one round-trip at a time.
+-}
+checkKeys :: WriteIntent -> M.Map (UUID, UUID) Activity -> [(UUID, UUID)] -> Either Text ()
+checkKeys intent existing keys = case intent of
+    Insert -> refuse "already exists" (filter (`M.member` existing) keys)
+    Replace -> refuse "does not exist" (filter (not . (`M.member` existing)) keys)
+  where
+    refuse _ [] = Right ()
+    refuse what offenders =
+        Left $
+            "Refusing to write: "
+                <> T.intercalate ", " (map renderKey offenders)
+                <> " "
+                <> what
+                <> " in this database"
+
+-- | @activityUUID_productUUID@, the identity a process is addressed by.
+renderKey :: (UUID, UUID) -> Text
+renderKey (actUUID, prodUUID) = UUID.toText actUUID <> "_" <> UUID.toText prodUUID

--- a/src/Database/Rebuild.hs
+++ b/src/Database/Rebuild.hs
@@ -29,7 +29,6 @@ module Database.Rebuild (
 
     -- * The rebuild itself
     rebuildFromActivities,
-    activityMap,
 
     -- * Identity
     renderKey,

--- a/src/Database/Rebuild.hs
+++ b/src/Database/Rebuild.hs
@@ -33,6 +33,7 @@ module Database.Rebuild (
 
     -- * Identity
     renderKey,
+    processKey,
     resolveProcess,
 ) where
 
@@ -113,15 +114,7 @@ Every id must be in range — an out-of-range id is a caller error, surfaced as
 during unlinking are @O(log n)@.
 -}
 resolveDeleteKeys :: Database -> [ProcessId] -> Either Text (S.Set (UUID, UUID))
-resolveDeleteKeys db = fmap S.fromList . traverse keyOf
-  where
-    table = dbProcessIdTable db
-    n = V.length table
-    keyOf pid
-        | i >= 0 && i < n = Right (table V.! i)
-        | otherwise = Left ("Delete: ProcessId out of range: " <> T.pack (show pid))
-      where
-        i = fromIntegral pid
+resolveDeleteKeys db = fmap S.fromList . traverse (processKey db)
 
 -- | The activity map keyed by @(activityUUID, productUUID)@, minus the deleted keys.
 surviving :: Database -> S.Set (UUID, UUID) -> M.Map (UUID, UUID) Activity
@@ -290,6 +283,15 @@ checkKeys intent existing keys = case intent of
 -- | @activityUUID_productUUID@, the identity a process is addressed by.
 renderKey :: (UUID, UUID) -> Text
 renderKey (actUUID, prodUUID) = UUID.toText actUUID <> "_" <> UUID.toText prodUUID
+
+{- | The identity a 'ProcessId' currently stands for. Out of range is a caller
+error and says so, rather than resolving to whichever row is at that index
+after the next rebuild.
+-}
+processKey :: Database -> ProcessId -> Either Text (UUID, UUID)
+processKey db pid =
+    maybe (Left ("ProcessId out of range: " <> T.pack (show pid))) Right $
+        dbProcessIdTable db V.!? fromIntegral pid
 
 {- | Resolve a process-id string to its 'ProcessId'. Accepts the canonical
 @activityUUID_productUUID@ form and the bare-activity-UUID fallback (when the

--- a/src/Database/UploadedDatabase.hs
+++ b/src/Database/UploadedDatabase.hs
@@ -7,6 +7,7 @@ module Database.UploadedDatabase (
     -- * Types
     UploadMeta (..),
     DatabaseFormat (..),
+    metaVersion,
 
     -- * Meta file operations
     readUploadMeta,
@@ -64,6 +65,14 @@ data UploadMeta = UploadMeta
     -}
     }
     deriving (Show, Eq, Generic)
+
+{- | The @meta.toml@ shape this engine writes, stamped by every writer.
+Version 3 added @source@, which is what tells a copy from an upload. The
+parser reads every version, taking absent fields to mean what their absence
+meant when they did not exist.
+-}
+metaVersion :: Int
+metaVersion = 3
 
 -- | Name of the metadata file in each upload directory
 metaFileName :: FilePath

--- a/src/Database/UploadedDatabase.hs
+++ b/src/Database/UploadedDatabase.hs
@@ -55,6 +55,13 @@ data UploadMeta = UploadMeta
     to lose it silently. A file written before this field existed reads back
     with no dependencies, which is what it meant.
     -}
+    , umSource :: !(Maybe Text)
+    {- ^ The database this one is a copy of, when it is one. A copy has no
+    files: 'umDataPath' points at the source's, and this says whose they are,
+    which is what lets a delete refuse to take the files a copy still reads.
+    A file written before this field existed is not a copy, which is what it
+    meant.
+    -}
     }
     deriving (Show, Eq, Generic)
 
@@ -146,6 +153,7 @@ parseMetaToml content = do
             , umFormat = format
             , umDataPath = dataPath
             , umDepends = maybe [] parseStringList (getValue "depends")
+            , umSource = unquote <$> getValue "source"
             }
 
 {- | Read a TOML inline array of strings, @["a", "b"]@. Entries that are not
@@ -189,6 +197,7 @@ formatMetaToml UploadMeta{..} =
                , "dataPath = " <> quote (T.pack umDataPath)
                , "depends = [" <> T.intercalate ", " (map quote umDepends) <> "]"
                ]
+            ++ maybe [] (\s -> ["source = " <> quote s]) umSource
   where
     quote t = "\"" <> escapeToml t <> "\""
 

--- a/src/Database/UploadedDatabase.hs
+++ b/src/Database/UploadedDatabase.hs
@@ -137,7 +137,7 @@ parseMetaToml content = do
             , let v = T.strip $ T.drop 1 rest
             ]
         getValue key = lookup key kvPairs
-        unquote = T.dropAround (== '"')
+        unquote = unescapeToml . T.dropAround (== '"')
 
     version <- getValue "version" >>= readMaybe . T.unpack
     displayName <- unquote <$> getValue "displayName"
@@ -155,6 +155,22 @@ parseMetaToml content = do
             , umDepends = maybe [] parseStringList (getValue "depends")
             , umSource = unquote <$> getValue "source"
             }
+
+{- | Undo the escaping 'formatMetaToml' writes, so a value survives the round
+trip it is written for.
+
+A Windows path is why this is not academic: its separators are backslashes,
+which the writer doubles as TOML requires, and a reader that took the value
+verbatim handed back a path with every separator twice over.
+-}
+unescapeToml :: Text -> Text
+unescapeToml = T.pack . unescape . T.unpack
+  where
+    unescape ('\\' : '"' : rest) = '"' : unescape rest
+    unescape ('\\' : '\\' : rest) = '\\' : unescape rest
+    unescape ('\\' : 'n' : rest) = '\n' : unescape rest
+    unescape (c : rest) = c : unescape rest
+    unescape [] = []
 
 {- | Read a TOML inline array of strings, @["a", "b"]@. Entries that are not
 quoted strings are skipped rather than failing the whole file: the key is

--- a/test/AuthorSpec.hs
+++ b/test/AuthorSpec.hs
@@ -31,7 +31,7 @@ import Database.Author (
     authoredProductUUID,
     validateAuthored,
  )
-import Database.Edit (deleteActivities, insertActivities, replaceActivities)
+import Database.Rebuild (deleteActivities, insertActivities, replaceActivities)
 import Types (
     Activity (..),
     BioDirection (..),

--- a/test/CopySpec.hs
+++ b/test/CopySpec.hs
@@ -39,6 +39,7 @@ import SharedSolver (
     getFactorization,
     solveWithSharedSolver,
  )
+import TestHelpers (withScratchDataDir)
 import Types (
     Activity (..),
     Database (..),
@@ -54,7 +55,9 @@ import Types (
 import UnitConversion (defaultUnitConfig)
 
 spec :: Spec
-spec = describe "Database.Edit copy primitive" $ do
+-- A copy now leaves a directory of its own behind, so each example gets a data
+-- directory of its own rather than writing into the tree it was run from.
+spec = around_ withScratchDataDir $ describe "Database.Edit copy primitive" $ do
     it "registers an independent copy under the new name" $ do
         manager <- initDatabaseManager defaultConfig True Nothing
         srcDb <- buildOrFail (supplierDB 100 ["p1", "p2"])

--- a/test/DeleteSelectionSpec.hs
+++ b/test/DeleteSelectionSpec.hs
@@ -37,7 +37,6 @@ import Database.Edit (
     DeleteOutcome (..),
     DeleteRequest (..),
     DeleteSelection (..),
-    deleteActivities,
     deleteActivitiesInDB,
     resolveDeleteSelection,
  )
@@ -46,6 +45,7 @@ import Database.Manager (
     LoadedDatabase (..),
     initDatabaseManager,
  )
+import Database.Rebuild (deleteActivities)
 import SharedSolver (SharedSolver, createSharedSolver)
 import Types (
     Activity (..),

--- a/test/JournalSpec.hs
+++ b/test/JournalSpec.hs
@@ -10,6 +10,7 @@ rather than quietly losing an edit.
 -}
 module JournalSpec (spec) where
 
+import Control.Monad (void)
 import Data.Aeson (Value, decodeStrict, encode, toJSON)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy as BL
@@ -146,7 +147,7 @@ event = JournalEvent "2026-08-03T09:12:41Z"
 
 -- | Replay, keeping only what a failed assertion can print.
 replayOutcome :: AuthorContext -> [JournalEvent] -> Either Text ()
-replayOutcome ctx = fmap (const ()) . replayJournal ctx
+replayOutcome ctx = void . replayJournal ctx
 
 failsWith :: Text -> Either Text a -> Bool
 failsWith needle = either (isInfixOf needle) (const False)

--- a/test/JournalSpec.hs
+++ b/test/JournalSpec.hs
@@ -104,6 +104,18 @@ spec = do
                 [deleteLine, deleteLine, "{\"v\":1,\"at\":\"now\",\"op\":\"del"]
                 (\result -> fmap length result `shouldBe` Right 2)
 
+        it "never fuses an edit onto the torn tail a crash left behind" $
+            -- A torn tail has no newline, so a blind append would glue the
+            -- next line onto it, and that line's edit IS acknowledged. The
+            -- append truncates the tail first: what is dropped is exactly the
+            -- unacknowledged debris, never the edit being recorded.
+            withSystemTempDirectory "journal" $ \home -> do
+                appendOrFail home (Deleted ["a_b"])
+                appendFile (journalPath home) "{\"v\":1,\"at\":\"now\",\"op\":\"del"
+                appendOrFail home (Deleted ["c_d"])
+                read' <- readJournal home
+                fmap (map jeOp) read' `shouldBe` Right [Deleted ["a_b"], Deleted ["c_d"]]
+
     describe "Database.Journal (replay)" $ do
         it "applies a create" $
             case replayJournal ctx [event (Created [cheese] [cheeseKey])] of

--- a/test/JournalSpec.hs
+++ b/test/JournalSpec.hs
@@ -1,0 +1,354 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Tests for the edit journal ("Database.Journal").
+
+The journal is what makes an edit outlive the process without rewriting the
+database's own files, so two properties carry the whole design: what it writes
+it can read back, and replaying it produces the database the edit produced.
+The rest is about the ways a file can be wrong, and each of them says so
+rather than quietly losing an edit.
+-}
+module JournalSpec (spec) where
+
+import Data.Aeson (Value, decodeStrict, encode, toJSON)
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import Data.Text (Text, isInfixOf)
+import qualified Data.Text as T
+import qualified Data.UUID as UUID
+import qualified Data.Vector as V
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+
+import Database (buildDatabaseWithMatrices)
+import Database.Author (
+    AuthorContext (..),
+    AuthoredActivity (..),
+    AuthoredExchange (..),
+    FlowRef (..),
+    ResolvedInsert (..),
+    validateAuthored,
+ )
+import Database.Journal (
+    JournalEvent (..),
+    JournalOp (..),
+    appendEvent,
+    journalPath,
+    readJournal,
+    replayJournal,
+ )
+import Database.Rebuild (renderKey)
+import Types (
+    Activity (..),
+    BioDirection (..),
+    BiosphereFlow (..),
+    Compartment (..),
+    Database (..),
+    Exchange (..),
+    LocationSource (..),
+    TechRole (..),
+    TechnosphereFlow (..),
+    UUID,
+    Unit (..),
+ )
+import UnitConversion (defaultUnitConfig)
+
+spec :: Spec
+spec = do
+    fixture <- runIO buildFixture
+    let ctx = AuthorContext{acDb = fixture, acDeps = [], acUnitConfig = defaultUnitConfig}
+        cheeseKey = mintedKey fixture cheese
+
+    describe "Database.Journal (codec)" $ do
+        it "writes the shape it documents" $
+            -- A golden on names and nesting rather than on bytes: what has to
+            -- stay stable is the vocabulary on disk, not the order aeson
+            -- happens to serialize an object in.
+            Just (toJSON (event (Created [cheese] ["a_b"])))
+                `shouldBe` (decodeStrict expectedCreateJSON :: Maybe Value)
+
+        it "reads back every event it writes" $
+            -- One event per operation, and one exchange per kind, so a field
+            -- lost in the codec cannot hide behind the others.
+            mapM_ (\written -> decodeStrict (BL.toStrict (encode written)) `shouldBe` Just written) richEvents
+
+    describe "Database.Journal (file)" $ do
+        it "reads a database that has never been edited as an empty journal" $
+            withSystemTempDirectory "journal" $ \home ->
+                readJournal home `shouldReturn` Right []
+
+        it "appends and reads back in order" $
+            withSystemTempDirectory "journal" $ \home -> do
+                mapM_ (appendOrFail home . jeOp) richEvents
+                read' <- readJournal home
+                fmap (map jeOp) read' `shouldBe` Right (map jeOp richEvents)
+
+        it "refuses a version it does not read" $
+            withJournalFile
+                ["{\"v\":2,\"at\":\"now\",\"op\":\"delete\",\"targets\":[]}"]
+                (`shouldSatisfy` failsWith "version 2")
+
+        it "refuses a line it cannot parse, naming it" $
+            withJournalFile
+                [deleteLine, "{ this is not json", deleteLine]
+                (`shouldSatisfy` failsWith "line 2")
+
+        it "drops a torn last line, because its edit was never acknowledged" $
+            -- The line is written and flushed before the caller is told the
+            -- edit happened, so a half-written final line belongs to an edit
+            -- nobody knows about.
+            withJournalFile
+                [deleteLine, deleteLine, "{\"v\":1,\"at\":\"now\",\"op\":\"del"]
+                (\result -> fmap length result `shouldBe` Right 2)
+
+    describe "Database.Journal (replay)" $ do
+        it "applies a create" $
+            case replayJournal ctx [event (Created [cheese] [cheeseKey])] of
+                Left err -> expectationFailure ("replay: " <> show err)
+                Right db -> processKeys db `shouldBe` S.insert cheeseKey (processKeys fixture)
+
+        it "gives the same database every time it is replayed" $
+            let journal = [event (Created [cheese] [cheeseKey]), event (Replaced cheeseKey cheese{aaProductAmount = 2})]
+             in fmap processKeys (replayJournal ctx journal)
+                    `shouldBe` fmap processKeys (replayJournal ctx journal)
+
+        it "applies a delete, leaving the database it started from" $
+            case replayJournal ctx [event (Created [cheese] [cheeseKey]), event (Deleted [cheeseKey])] of
+                Left err -> expectationFailure ("replay: " <> show err)
+                Right db -> processKeys db `shouldBe` processKeys fixture
+
+        it "refuses an identity that no longer mints the same way" $
+            -- The guard the whole file exists for: if minting ever moves, a
+            -- replay must stop rather than land the activity somewhere else.
+            replayOutcome ctx [event (Created [cheese] ["8f3c-not-what-this-mints"])]
+                `shouldSatisfy` failsWith "now mints"
+
+        it "names the event that failed" $
+            replayOutcome ctx [event (Deleted [cheeseKey]), event (Created [cheese] [cheeseKey])]
+                `shouldSatisfy` failsWith "journal event 1 (delete)"
+
+        it "refuses a delete of something the database does not have" $
+            replayOutcome ctx [event (Deleted [cheeseKey])]
+                `shouldSatisfy` failsWith "Unknown process id"
+
+        it "refuses a replace whose description no longer addresses its target" $
+            replayOutcome ctx [event (Replaced supplierPid cheese)]
+                `shouldSatisfy` failsWith "now mints"
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+
+event :: JournalOp -> JournalEvent
+event = JournalEvent "2026-08-03T09:12:41Z"
+
+-- | Replay, keeping only what a failed assertion can print.
+replayOutcome :: AuthorContext -> [JournalEvent] -> Either Text ()
+replayOutcome ctx = fmap (const ()) . replayJournal ctx
+
+failsWith :: Text -> Either Text a -> Bool
+failsWith needle = either (isInfixOf needle) (const False)
+
+appendOrFail :: FilePath -> JournalOp -> IO ()
+appendOrFail home op = appendEvent home op >>= either (fail . show) pure
+
+{- | Run a check against a journal file written verbatim, so a line this
+engine would never write can still be read.
+-}
+withJournalFile :: [BS.ByteString] -> (Either Text [JournalEvent] -> Expectation) -> Expectation
+withJournalFile lines' check =
+    withSystemTempDirectory "journal" $ \home -> do
+        BS.writeFile (journalPath home) (BS.intercalate "\n" lines')
+        readJournal home >>= check
+
+deleteLine :: BS.ByteString
+deleteLine = "{\"v\":1,\"at\":\"now\",\"op\":\"delete\",\"targets\":[\"" <> ascii supplierPid <> "\"]}"
+
+-- | A 'Text' that is known to be ASCII, spliced into a JSON literal.
+ascii :: Text -> BS.ByteString
+ascii = BS.pack . T.unpack
+
+{- | The identity an authored activity mints against a given database. A
+fixture that does not resolve yields a key nothing matches, so the test that
+depends on it fails on the assertion rather than here.
+-}
+mintedKey :: Database -> AuthoredActivity -> Text
+mintedKey db activity = case validateAuthored ctx [activity] of
+    Right ([resolved], _) -> renderKey (riKey resolved)
+    Right _ -> "the fixture activity resolved to something other than one process"
+    Left errs -> "the fixture activity does not resolve: " <> T.intercalate "; " errs
+  where
+    ctx = AuthorContext{acDb = db, acDeps = [], acUnitConfig = defaultUnitConfig}
+
+processKeys :: Database -> S.Set Text
+processKeys = S.fromList . map renderKey . V.toList . dbProcessIdTable
+
+-- ---------------------------------------------------------------------------
+-- What the journal carries
+-- ---------------------------------------------------------------------------
+
+-- | An activity using every exchange kind the journal has to record.
+cheese :: AuthoredActivity
+cheese =
+    AuthoredActivity
+        { aaName = "cheese, at dairy"
+        , aaLocation = "FR"
+        , aaDescription = ["An authored activity."]
+        , aaProductName = "cheese"
+        , aaProductAmount = 1.0
+        , aaProductUnit = "kg"
+        , aaExchanges =
+            [ AuthoredTechInput
+                { atiProvider = supplierPid
+                , atiAmount = 8.0
+                , atiUnit = Just "kg"
+                , atiComment = Just "milk in"
+                }
+            , AuthoredBio
+                { abFlow = ExistingFlow co2Id
+                , abDirection = Emission
+                , abAmount = 0.5
+                , abUnit = Nothing
+                , abComment = Nothing
+                }
+            , AuthoredBio
+                { abFlow =
+                    NewBioFlow
+                        "Methane"
+                        Compartment{compartmentName = "air", compartmentSub = Just "low population density"}
+                        "kg"
+                , abDirection = Emission
+                , abAmount = 0.01
+                , abUnit = Just "kg"
+                , abComment = Nothing
+                }
+            ]
+        }
+
+richEvents :: [JournalEvent]
+richEvents =
+    [ event (Created [cheese] ["a_b"])
+    , event (Replaced "a_b" cheese)
+    , event (Deleted ["a_b", "c_d"])
+    , event
+        ( Created
+            [cheese{aaExchanges = [AuthoredWasteOutput{awProvider = supplierPid, awAmount = 0.2, awUnit = Nothing, awComment = Nothing}]}]
+            ["a_b"]
+        )
+    ]
+
+expectedCreateJSON :: BS.ByteString
+expectedCreateJSON =
+    "{\"v\":1,\"at\":\"2026-08-03T09:12:41Z\",\"op\":\"create\",\"written\":[\"a_b\"],\
+    \\"activities\":[{\
+    \\"name\":\"cheese, at dairy\",\"location\":\"FR\",\
+    \\"description\":[\"An authored activity.\"],\
+    \\"product\":{\"name\":\"cheese\",\"amount\":1,\"unit\":\"kg\"},\
+    \\"exchanges\":[\
+    \{\"kind\":\"input\",\"provider\":\""
+        <> ascii supplierPid
+        <> "\",\"amount\":8,\"unit\":\"kg\",\"comment\":\"milk in\"},\
+           \{\"kind\":\"biosphere\",\"flow\":{\"id\":\""
+        <> ascii (UUID.toText co2Id)
+        <> "\"},\"direction\":\"emission\",\"amount\":0.5},\
+           \{\"kind\":\"biosphere\",\"flow\":{\"name\":\"Methane\",\"compartment\":\"air\",\
+           \\"sub_compartment\":\"low population density\",\"unit\":\"kg\"},\
+           \\"direction\":\"emission\",\"amount\":0.01,\"unit\":\"kg\"}]}]}"
+
+-- ---------------------------------------------------------------------------
+-- Fixture: one supplier producing milk in kg, emitting CO2
+-- ---------------------------------------------------------------------------
+
+buildFixture :: IO Database
+buildFixture = do
+    built <-
+        buildDatabaseWithMatrices
+            defaultUnitConfig
+            (M.singleton (supplierActId, supplierProdId) supplierActivity)
+            (M.singleton supplierProdId milkFlow)
+            (M.singleton co2Id co2Flow)
+            M.empty
+            unitTable
+    either (fail . show) pure built
+
+mkUUID :: Int -> UUID
+mkUUID n = UUID.fromWords64 (fromIntegral n) 0
+
+supplierActId, supplierProdId, co2Id, kgUnitId :: UUID
+supplierActId = mkUUID 1
+supplierProdId = mkUUID 2
+co2Id = mkUUID 3
+kgUnitId = mkUUID 10
+
+supplierPid :: Text
+supplierPid = renderKey (supplierActId, supplierProdId)
+
+unitTable :: M.Map UUID Unit
+unitTable =
+    M.singleton kgUnitId Unit{unitId = kgUnitId, unitName = "kg", unitSymbol = "kg", unitComment = ""}
+
+milkFlow :: TechnosphereFlow
+milkFlow =
+    TechnosphereFlow
+        { tfId = supplierProdId
+        , tfName = "milk"
+        , tfUnitId = kgUnitId
+        , tfSynonyms = M.empty
+        , tfCAS = Nothing
+        , tfSubstanceId = Nothing
+        }
+
+co2Flow :: BiosphereFlow
+co2Flow =
+    BiosphereFlow
+        { bfId = co2Id
+        , bfName = "Carbon dioxide"
+        , bfUnitId = kgUnitId
+        , bfSynonyms = M.empty
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfCompartment = Just Compartment{compartmentName = "air", compartmentSub = Nothing}
+        }
+
+supplierActivity :: Activity
+supplierActivity =
+    Activity
+        { activityName = "milk production"
+        , activityDescription = []
+        , activitySynonyms = M.empty
+        , activityClassification = M.empty
+        , activityLocation = "FR"
+        , activityLocationSource = LocationDeclared
+        , activityUnit = "kg"
+        , exchanges =
+            [ TechnosphereExchange
+                { techFlowId = supplierProdId
+                , techAmount = 1.0
+                , techUnitId = kgUnitId
+                , techRole = ReferenceProduct
+                , techActivityLinkId = supplierActId
+                , techProcessLinkId = Nothing
+                , techLocation = ""
+                , techComment = Nothing
+                , techPedigree = Nothing
+                }
+            , BiosphereExchange
+                { bioFlowId = co2Id
+                , bioAmount = 1.2
+                , bioUnitId = kgUnitId
+                , bioDirection = Emission
+                , bioLocation = ""
+                , bioComment = Nothing
+                , bioPedigree = Nothing
+                }
+            ]
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
+        , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
+        }

--- a/test/PersistenceSpec.hs
+++ b/test/PersistenceSpec.hs
@@ -40,7 +40,6 @@ import Database.Edit (
     DeleteRequest (..),
     MutationOutcome (..),
     deleteActivitiesInDB,
-    deleteActivitiesWith,
     mutateUploadedDatabase,
  )
 import Database.Export (serializeDatabaseFiles)
@@ -51,6 +50,7 @@ import Database.Manager (
     loadDatabase,
     unloadDatabase,
  )
+import Database.Rebuild (deleteActivitiesWith)
 import Database.Upload (DatabaseFormat (..))
 import Database.UploadedDatabase (UploadMeta (..), readUploadMeta)
 import SharedSolver (SharedSolver, createSharedSolver)

--- a/test/PersistenceSpec.hs
+++ b/test/PersistenceSpec.hs
@@ -2,55 +2,60 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 {- | Tests for making an edit outlive the process
-('Database.Edit.mutateUploadedDatabase' and
-'Database.Export.serializeDatabaseFiles').
+('Database.Edit.mutateUploadedDatabase' and "Database.Journal").
 
 Editing used to be transient by design: the sources and the matrix cache still
 held the pre-edit database, so an unload and reload deliberately undid the
 change. That is defensible for a database the engine reads from configuration
-and does not own, and wrong for one it does — a restart quietly resurrected
-every activity a user had removed.
+and does not own, and wrong for one it does.
 
-What follows pins the three decisions that make persistence honest: which
-formats may be written back (only those that record process identity), that a
-database with no files of its own is given a home rather than writing through
-to the database it was copied from, and that an edit which is not saved says
-so instead of looking like one that was.
+What replaced it is not a rewrite of the sources, which only a format that
+records process identity could survive. The sources are left exactly as their
+author uploaded them and the edits are recorded beside them, so what follows
+uses an EcoSpold 1 database on purpose: it is the format whose identities are
+derived from the position of a dataset in its file, and the one a rewrite
+would move.
 -}
 module PersistenceSpec (spec) where
 
-import Control.Concurrent.STM (atomically, modifyTVar')
+import Control.Concurrent.STM (atomically, modifyTVar', readTVarIO)
 import Control.Exception (bracket_)
-import Data.List (sort)
+import Control.Monad (void)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as Set
 import Data.Text (Text, isInfixOf)
 import qualified Data.Text as T
+import qualified Data.Text.IO as TIO
 import qualified Data.UUID as UUID
+import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
-import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist, listDirectory)
+import System.Directory (createDirectoryIfMissing, listDirectory, removeFile)
 import System.Environment (setEnv, unsetEnv)
-import System.FilePath ((</>))
+import System.FilePath (takeDirectory, (</>))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
 import Config (DatabaseConfig (..), defaultConfig)
 import Database (buildDatabaseWithMatrices)
 import Database.Edit (
+    DeleteOutcome (..),
     DeleteRequest (..),
     MutationOutcome (..),
+    copyDatabase,
     deleteActivitiesInDB,
     mutateUploadedDatabase,
  )
-import Database.Export (serializeDatabaseFiles)
+import Database.Journal (JournalOp (..), journalPath, readJournal)
 import Database.Manager (
     DatabaseManager (..),
     LoadedDatabase (..),
+    addDatabase,
     initDatabaseManager,
     loadDatabase,
+    removeDatabase,
     unloadDatabase,
  )
-import Database.Rebuild (deleteActivitiesWith)
+import Database.Rebuild (renderKey)
 import Database.Upload (DatabaseFormat (..))
 import Database.UploadedDatabase (UploadMeta (..), readUploadMeta)
 import SharedSolver (SharedSolver, createSharedSolver)
@@ -68,152 +73,103 @@ import Types (
     TechnosphereFlow (..),
     UUID,
     Unit (..),
-    findProcessId,
  )
 import UnitConversion (defaultUnitConfig)
 
 spec :: Spec
 spec = describe "persisting an edit" $ do
-    describe "serializeDatabaseFiles" $ do
-        it "writes one EcoSpold 2 dataset per process, named by its identity" $ do
-            db <- buildFixture
-            case serializeDatabaseFiles EcoSpold2 db of
-                Left err -> expectationFailure ("expected EcoSpold 2 to be writable: " <> show err)
-                Right (entries, warnings) -> do
-                    warnings `shouldBe` []
-                    -- The name is the identity: the parser reads the pair back
-                    -- off it, which is the whole reason this format may be
-                    -- written in place.
-                    sort (map fst entries)
-                        `shouldBe` [T.unpack (UUID.toText supplierActId <> "_" <> UUID.toText supplierProdId) <> ".spold"]
+    describe "an uploaded database" $ do
+        it "records the edit beside its sources, and leaves the sources alone" $
+            withEcoSpold1Database $ \manager home -> do
+                keys <- processKeysOf manager "bafu-like"
+                outcome <- deleteFirst manager "bafu-like" keys
+                doPersisted outcome `shouldBe` True
+                -- What the author uploaded is what is still there: the edit is
+                -- a line beside the files, not a rewrite of them.
+                listDirectory (home </> "data") >>= (`shouldSatisfy` ((== 2) . length))
+                journal <- readJournal home
+                fmap length journal `shouldBe` Right 1
 
-        it "refuses every format that would re-mint identity on read" $
-            -- Exporting to these stays available; writing a database back over
-            -- its own sources does not, because the rows that survive would
-            -- come back under different process ids after a restart, and every
-            -- reference anyone kept to them would point elsewhere.
-            mapM_
-                refusesIdentity
-                [(SimaProCSV, "SimaPro CSV"), (EcoSpold1, "EcoSpold 1"), (ILCDProcess, "ILCD"), (BrightwayExcel, "Brightway Excel")]
+        it "reloads to what was written, under the identities it was written with" $
+            -- The point of the whole path. EcoSpold 1 derives its identities
+            -- from dataset and exchange numbers, so a writer that renumbered
+            -- them would give the surviving activity a different process id
+            -- and every reference anyone kept would point elsewhere.
+            withEcoSpold1Database $ \manager _ -> do
+                keys <- processKeysOf manager "bafu-like"
+                length keys `shouldBe` 2
+                _ <- deleteFirst manager "bafu-like" keys
+                reloadOf manager "bafu-like" `shouldReturn` drop 1 keys
 
-        it "refuses the formats that have no writer at all" $ do
-            db <- buildFixture
-            fmap fst (serializeDatabaseFiles OpenLcaJsonLd db)
-                `shouldSatisfy` failsWith "not supported"
-            fmap fst (serializeDatabaseFiles UnknownFormat db)
-                `shouldSatisfy` failsWith "unknown format"
+        it "replays the journal when the cache cannot say that it holds it" $
+            -- A crash between recording an edit and saving the cache leaves a
+            -- cache that predates the journal. Only the stamp says otherwise,
+            -- so without it the sources are read again and the journal
+            -- replayed over them.
+            withEcoSpold1Database $ \manager home -> do
+                keys <- processKeysOf manager "bafu-like"
+                _ <- deleteFirst manager "bafu-like" keys
+                removeFile (home </> "journal.applied")
+                reloadOf manager "bafu-like" `shouldReturn` drop 1 keys
 
-    describe "mutateUploadedDatabase" $ do
-        it "rewrites the sources of a database that owns them" $
+        it "refuses to load at all when the journal names something it cannot apply" $
+            -- Half-applying it would hand back a database that silently
+            -- disagrees with its own record of what was done to it.
+            withEcoSpold1Database $ \manager home -> do
+                keys <- processKeysOf manager "bafu-like"
+                _ <- deleteFirst manager "bafu-like" keys
+                TIO.appendFile (journalPath home) (deleteLineFor (head' keys) <> "\n")
+                removeFile (home </> "journal.applied")
+                unloadDatabase manager "bafu-like" `shouldReturn` Right ()
+                reloaded <- loadDatabase manager "bafu-like"
+                void reloaded `shouldSatisfy` failsWith "Unknown process id"
+
+    describe "a copy" $ do
+        it "gets a home of its own at once, holding no data" $
+            -- A copy shares the source's value and reads the source's files;
+            -- what it owns is a directory with its own identity and, once it
+            -- is edited, its own journal.
+            withEcoSpold1Database $ \manager home -> do
+                copyDatabase manager "bafu-like" "bafu-mine" `shouldReturn` Right ()
+                let uploads = uploadsDirOf home
+                meta <- readUploadMeta (uploads </> "bafu-mine")
+                fmap umSource meta `shouldBe` Just (Just "bafu-like")
+                fmap umDataPath meta `shouldBe` Just (home </> "data")
+                listDirectory (uploads </> "bafu-mine") `shouldReturn` ["meta.toml"]
+
+        it "keeps the database it was copied from from being deleted" $
+            withEcoSpold1Database $ \manager home -> do
+                copyDatabase manager "bafu-like" "bafu-mine" `shouldReturn` Right ()
+                unloadDatabase manager "bafu-like" `shouldReturn` Right ()
+                let uploads = uploadsDirOf home
+                removed <- removeDatabase manager "bafu-like"
+                removed `shouldSatisfy` failsWith "copied from it"
+                listDirectory (uploads </> "bafu-like") >>= (`shouldSatisfy` elem "data")
+
+    describe "a database the engine only reads" $ do
+        it "says the edit is not saved, and is given no home" $
             withDataDir $ \dataRoot -> do
                 manager <- initDatabaseManager defaultConfig True Nothing
                 db <- buildTwoActivityFixture
-                let dataDir = dataRoot </> "uploads" </> "databases" </> "own-files" </> "data"
-                createDirectoryIfMissing True dataDir
-                install manager "own-files" db (uploadedConfig "own-files" dataDir)
-                r <- mutateUploadedDatabase manager "own-files" (dropSecond db)
+                install manager "configured" db (configuredConfig "configured")
+                r <- mutateUploadedDatabase manager "configured" dropSecond
                 case r of
                     Left err -> expectationFailure ("mutateUploadedDatabase: " <> show err)
                     Right outcome -> do
-                        moPersisted outcome `shouldBe` True
-                        -- One process left, in a file named after its own
-                        -- identity: the deletion reached the sources, not only
-                        -- the copy of the database held in memory.
-                        listDirectory dataDir
-                            `shouldReturn` [T.unpack (keyText (supplierActId, supplierProdId)) <> ".spold"]
-                        -- Nothing of the staging or the previous generation is left behind.
-                        doesDirectoryExist (dataDir <> ".new") `shouldReturn` False
-                        doesDirectoryExist (dataDir <> ".old") `shouldReturn` False
+                        moPersisted outcome `shouldBe` False
+                        -- A configured database owns its files through the
+                        -- config file, and the engine writes none of its own.
+                        listDirectory (dataRoot </> "uploads" </> "databases") `shouldReturn` []
 
-        it "gives a database with no files of its own a home instead of writing through" $
-            -- A copy shares the source's value without duplicating its
-            -- directory; writing through the shared path would edit a database
-            -- nobody asked to edit.
-            withDataDir $ \dataRoot -> do
-                manager <- initDatabaseManager defaultConfig True Nothing
-                db <- buildTwoActivityFixture
-                let elsewhere = dataRoot </> "somebody-elses" </> "data"
-                createDirectoryIfMissing True elsewhere
-                writeFile (elsewhere </> "untouched.txt") "the source of the copy"
-                install manager "the-copy" db{dbDependsOn = ["background"]} (uploadedConfig "the-copy" elsewhere)
-                r <- mutateUploadedDatabase manager "the-copy" (dropSecond db)
-                case r of
-                    Left err -> expectationFailure ("mutateUploadedDatabase: " <> show err)
-                    Right outcome -> do
-                        moPersisted outcome `shouldBe` True
-                        let home = dataRoot </> "uploads" </> "databases" </> "the-copy"
-                        meta <- readUploadMeta home
-                        fmap umFormat meta `shouldBe` Just EcoSpold2
-                        fmap umDataPath meta `shouldBe` Just "data"
-                        -- The dependency pin is written down, not left to the
-                        -- binary cache that a restart may not read.
-                        fmap umDepends meta `shouldBe` Just ["background"]
-                        listDirectory (home </> "data") >>= (`shouldSatisfy` ((== 1) . length))
-                        doesFileExist (elsewhere </> "untouched.txt") `shouldReturn` True
-                        listDirectory elsewhere `shouldReturn` ["untouched.txt"]
-
-        it "does not take a sibling's files for its own when its name is a prefix of theirs" $
-            -- Ownership is judged on path components: a database named "agri"
-            -- pointing at "agribalyse"'s data directory (a copy keeps its
-            -- source's path) must be given a home of its own, not rewrite the
-            -- sibling whose name it happens to prefix.
-            withDataDir $ \dataRoot -> do
-                manager <- initDatabaseManager defaultConfig True Nothing
-                db <- buildTwoActivityFixture
-                let siblingDir = dataRoot </> "uploads" </> "databases" </> "agribalyse" </> "data"
-                createDirectoryIfMissing True siblingDir
-                writeFile (siblingDir </> "untouched.spold") "the sibling's dataset"
-                install manager "agri" db (uploadedConfig "agri" siblingDir)
-                r <- mutateUploadedDatabase manager "agri" (dropSecond db)
-                case r of
-                    Left err -> expectationFailure ("mutateUploadedDatabase: " <> show err)
-                    Right outcome -> do
-                        moPersisted outcome `shouldBe` True
-                        listDirectory siblingDir `shouldReturn` ["untouched.spold"]
-                        meta <- readUploadMeta (dataRoot </> "uploads" </> "databases" </> "agri")
-                        fmap umDataPath meta `shouldBe` Just "data"
-
-        it "reloads to what was written, not to the pre-edit sources" $
-            -- The point of the whole path: unloading and loading again returns
-            -- the edited database, where it used to resurrect the original.
-            withDataDir $ \dataRoot -> do
-                manager <- initDatabaseManager defaultConfig True Nothing
-                db <- buildTwoActivityFixture
-                let dataDir = dataRoot </> "uploads" </> "databases" </> "reload-me" </> "data"
-                createDirectoryIfMissing True dataDir
-                install manager "reload-me" db (uploadedConfig "reload-me" dataDir)
-                r <- mutateUploadedDatabase manager "reload-me" (dropSecond db)
-                either (expectationFailure . ("mutateUploadedDatabase: " <>) . show) (const (pure ())) r
-                unloadDatabase manager "reload-me" `shouldReturn` Right ()
-                reloaded <- loadDatabase manager "reload-me"
-                case reloaded of
-                    Left err -> expectationFailure ("loadDatabase: " <> show err)
-                    Right (loaded, _) -> dbActivityCount (ldDatabase loaded) `shouldBe` 1
-
+    describe "refusals that protect the value" $ do
         it "refuses a second edit while one is in progress" $
             withDataDir $ \_ -> do
                 manager <- initDatabaseManager defaultConfig True Nothing
                 db <- buildTwoActivityFixture
                 install manager "busy" db (configuredConfig "busy")
                 atomically $ modifyTVar' (dmStagingDbs manager) (Set.insert "busy")
-                r <- mutateUploadedDatabase manager "busy" (dropSecond db)
-                case r of
-                    Left err -> err `shouldSatisfy` isInfixOf "already in progress"
-                    Right _ -> expectationFailure "expected the second edit to be refused"
-
-        it "says an edit is not saved when the database is one the engine only reads" $
-            withDataDir $ \dataRoot -> do
-                manager <- initDatabaseManager defaultConfig True Nothing
-                db <- buildTwoActivityFixture
-                install manager "configured" db (configuredConfig "configured")
-                r <- mutateUploadedDatabase manager "configured" (dropSecond db)
-                case r of
-                    Left err -> expectationFailure ("mutateUploadedDatabase: " <> show err)
-                    Right outcome -> do
-                        moPersisted outcome `shouldBe` False
-                        -- No home was made for it: a configured database owns its
-                        -- files through the config file, and the engine writes none.
-                        listDirectory (dataRoot </> "uploads" </> "databases") `shouldReturn` []
+                r <- mutateUploadedDatabase manager "busy" dropSecond
+                void r `shouldSatisfy` failsWith "already in progress"
 
         it "refuses while another loaded database depends on this one" $
             withDataDir $ \_ -> do
@@ -221,23 +177,8 @@ spec = describe "persisting an edit" $ do
                 db <- buildTwoActivityFixture
                 install manager "background" db (configuredConfig "background")
                 install manager "foreground" db{dbDependsOn = ["background"]} (configuredConfig "foreground")
-                r <- mutateUploadedDatabase manager "background" (dropSecond db)
-                case r of
-                    Left err -> err `shouldSatisfy` isInfixOf "still required by"
-                    Right _ -> expectationFailure "expected the edit to be refused while a dependent is loaded"
-
-    describe "deleteActivitiesInDB" $
-        it "refuses to write a deletion back in a format that cannot record identity" $
-            withDataDir $ \dataRoot -> do
-                manager <- initDatabaseManager defaultConfig True Nothing
-                db <- buildTwoActivityFixture
-                let dataDir = dataRoot </> "uploads" </> "databases" </> "simapro-db" </> "data"
-                createDirectoryIfMissing True dataDir
-                install manager "simapro-db" db (uploadedConfig "simapro-db" dataDir){dcFormat = Just SimaProCSV}
-                r <- deleteActivitiesInDB manager "simapro-db" (deleteIds [keyText (supplierActId, supplierProdId)])
-                case r of
-                    Left err -> err `shouldSatisfy` isInfixOf "does not record process identifiers"
-                    Right _ -> expectationFailure "expected the deletion to be refused rather than silently unsaved"
+                r <- mutateUploadedDatabase manager "background" dropSecond
+                void r `shouldSatisfy` failsWith "still required by"
 
 -- ---------------------------------------------------------------------------
 -- Helpers
@@ -245,15 +186,6 @@ spec = describe "persisting an edit" $ do
 
 failsWith :: Text -> Either Text a -> Bool
 failsWith needle = either (isInfixOf needle) (const False)
-
-refusesIdentity :: (DatabaseFormat, Text) -> Expectation
-refusesIdentity (fmt, label) = do
-    db <- buildFixture
-    case serializeDatabaseFiles fmt db of
-        Right _ -> expectationFailure (T.unpack label <> " should be refused for writing in place")
-        Left err -> do
-            err `shouldSatisfy` isInfixOf label
-            err `shouldSatisfy` isInfixOf "does not record process identifiers"
 
 {- | Point the engine's data directory at a scratch tree for the duration of
 one example, so nothing is written next to the sources.
@@ -263,17 +195,87 @@ withDataDir act =
     withSystemTempDirectory "volca-persist" $ \dir ->
         bracket_ (setEnv "VOLCA_DATA_DIR" dir) (unsetEnv "VOLCA_DATA_DIR") (act dir)
 
-keyText :: (UUID, UUID) -> Text
-keyText (a, p) = UUID.toText a <> "_" <> UUID.toText p
+-- | The uploads directory a database's home sits in.
+uploadsDirOf :: FilePath -> FilePath
+uploadsDirOf = takeDirectory
+
+{- | An uploaded EcoSpold 1 database of two datasets, loaded and ready to
+edit. Each dataset is a file named after the identifier it carries, the layout
+a published EcoSpold 1 collection uses.
+-}
+withEcoSpold1Database :: (DatabaseManager -> FilePath -> IO ()) -> IO ()
+withEcoSpold1Database act =
+    withDataDir $ \dataRoot -> do
+        let home = dataRoot </> "uploads" </> "databases" </> "bafu-like"
+            dataDir = home </> "data"
+        createDirectoryIfMissing True dataDir
+        TIO.writeFile (dataDir </> "process_" <> T.unpack (UUID.toText (mkUUID 101)) <> ".xml") (dataset 1 "electricity production, wind")
+        TIO.writeFile (dataDir </> "process_" <> T.unpack (UUID.toText (mkUUID 102)) <> ".xml") (dataset 2 "electricity production, solar")
+        manager <- initDatabaseManager defaultConfig False Nothing
+        addDatabase manager (uploadedConfig "bafu-like" dataDir)
+        loaded <- loadDatabase manager "bafu-like"
+        case loaded of
+            Left err -> expectationFailure ("loading the fixture: " <> show err)
+            Right _ -> act manager home
+
+-- | One EcoSpold 1 dataset: a reference product and one emission.
+dataset :: Int -> Text -> Text
+dataset number name =
+    T.unlines
+        [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold01\">"
+        , "  <dataset number=\"" <> T.pack (show number) <> "\" generator=\"Test\" timestamp=\"2026-01-01T00:00:00\">"
+        , "    <metaInformation><processInformation>"
+        , "      <referenceFunction name=\"" <> name <> "\" category=\"Energy\" subCategory=\"Electricity\" unit=\"kWh\" />"
+        , "      <geography location=\"DE\" />"
+        , "    </processInformation></metaInformation>"
+        , "    <flowData>"
+        , "      <exchange number=\"1\" name=\"" <> name <> ", output\" category=\"Energy\" subCategory=\"Electricity\" unit=\"kWh\" meanValue=\"1.0\">"
+        , "        <outputGroup>0</outputGroup>"
+        , "      </exchange>"
+        , "      <exchange number=\"2\" name=\"Carbon dioxide, fossil\" category=\"air\" subCategory=\"low population density\" unit=\"kg\" meanValue=\"0.01\">"
+        , "        <outputGroup>4</outputGroup>"
+        , "      </exchange>"
+        , "    </flowData>"
+        , "  </dataset>"
+        , "</ecoSpold>"
+        ]
+
+-- | The process ids a loaded database currently holds, in table order.
+processKeysOf :: DatabaseManager -> Text -> IO [Text]
+processKeysOf manager dbName = do
+    loadedDbs <- readTVarIO (dmLoadedDbs manager)
+    pure $ case M.lookup dbName loadedDbs of
+        Nothing -> []
+        Just loaded -> map renderKey (V.toList (dbProcessIdTable (ldDatabase loaded)))
+
+-- | Delete the first process, through the request path a client uses.
+deleteFirst :: DatabaseManager -> Text -> [Text] -> IO DeleteOutcome
+deleteFirst manager dbName keys = do
+    r <- deleteActivitiesInDB manager dbName (deleteIds [head' keys])
+    either (fail . T.unpack) pure r
+
+-- | Unload, load again, and say which processes came back.
+reloadOf :: DatabaseManager -> Text -> IO [Text]
+reloadOf manager dbName = do
+    unloadDatabase manager dbName >>= either (fail . T.unpack) pure
+    loadDatabase manager dbName >>= either (fail . T.unpack) (const (pure ()))
+    processKeysOf manager dbName
+
+deleteLineFor :: Text -> Text
+deleteLineFor target =
+    "{\"v\":1,\"at\":\"2026-08-03T00:00:00Z\",\"op\":\"delete\",\"targets\":[\"" <> target <> "\"]}"
+
+head' :: [Text] -> Text
+head' (x : _) = x
+head' [] = "the fixture has no processes"
 
 {- | Remove the second activity of the two-activity fixture: any edit will do
 here, and a deletion is the one every database supports, so these examples pin
 the mutation path itself rather than what happened to be edited.
 -}
-dropSecond :: Database -> Database -> Either Text Database
-dropSecond fixture db = case findProcessId fixture otherActId supplierProdId of
-    Nothing -> Left "fixture: the activity to delete is not in it"
-    Just pid -> deleteActivitiesWith defaultUnitConfig [pid] db
+dropSecond :: JournalOp
+dropSecond = Deleted [renderKey (otherActId, supplierProdId)]
 
 deleteIds :: [Text] -> DeleteRequest
 deleteIds ids =
@@ -319,17 +321,15 @@ baseConfig name =
         }
 
 uploadedConfig :: Text -> FilePath -> DatabaseConfig
-uploadedConfig name dataDir = (baseConfig name){dcPath = dataDir, dcIsUploaded = True}
+uploadedConfig name dataDir =
+    (baseConfig name){dcPath = dataDir, dcIsUploaded = True, dcFormat = Just EcoSpold1}
 
 configuredConfig :: Text -> DatabaseConfig
 configuredConfig = baseConfig
 
 -- ---------------------------------------------------------------------------
--- Fixture
+-- In-memory fixture, for the refusals that never reach a file
 -- ---------------------------------------------------------------------------
-
-buildFixture :: IO Database
-buildFixture = buildFrom (M.singleton (supplierActId, supplierProdId) (milkActivity "milk production"))
 
 buildTwoActivityFixture :: IO Database
 buildTwoActivityFixture =

--- a/test/TestHelpers.hs
+++ b/test/TestHelpers.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module TestHelpers (
+    withScratchDataDir,
     loadSampleDatabase,
     loadSampleDatabaseWithPath,
     withinTolerance,
@@ -11,6 +12,7 @@ module TestHelpers (
     mkSolverFromDb,
 ) where
 
+import Control.Exception (bracket_)
 import Control.Monad (zipWithM_)
 import qualified Data.Map as M
 import qualified Data.Map.Strict as MS
@@ -22,9 +24,20 @@ import qualified Data.Vector.Unboxed as U
 import Database (buildDatabaseWithMatrices)
 import Database.Loader (loadDatabase)
 import qualified SharedSolver as SS
+import System.Environment (setEnv, unsetEnv)
+import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 import Types
 import UnitConversion (defaultUnitConfig)
+
+{- | Run an example with the engine's data directory pointed at a scratch
+tree. Anything that writes there - an upload, a copy, an edit journal - then
+belongs to the example rather than to the working tree it was run from.
+-}
+withScratchDataDir :: IO () -> IO ()
+withScratchDataDir act =
+    withSystemTempDirectory "volca-scratch" $ \dir ->
+        bracket_ (setEnv "VOLCA_DATA_DIR" dir) (unsetEnv "VOLCA_DATA_DIR") act
 
 -- | Load a SAMPLE database for testing
 loadSampleDatabase :: String -> IO Database

--- a/test/UploadedDatabaseSpec.hs
+++ b/test/UploadedDatabaseSpec.hs
@@ -18,6 +18,7 @@ baseMeta =
         , umFormat = EcoSpold2
         , umDataPath = "data"
         , umDepends = []
+        , umSource = Nothing
         }
 
 spec :: Spec
@@ -92,6 +93,7 @@ spec = do
                         , umFormat = EcoSpold2
                         , umDataPath = "data"
                         , umDepends = []
+                        , umSource = Nothing
                         }
 
         it "parses meta with description" $ do

--- a/test/UploadedDatabaseSpec.hs
+++ b/test/UploadedDatabaseSpec.hs
@@ -118,6 +118,18 @@ spec = do
             let meta = baseMeta{umDescription = Just "A nice database"}
             parseMetaToml (formatMetaToml meta) `shouldBe` Just meta
 
+        it "round-trips a path whose separators are backslashes" $ do
+            -- A copy records the absolute path of the files it reads, and on
+            -- Windows every separator in it is a backslash. The writer doubles
+            -- them as TOML requires, so a reader that took the value verbatim
+            -- handed back a path that resolves to nothing.
+            let meta = baseMeta{umDataPath = "C:\\volca\\uploads\\bafu\\data", umSource = Just "bafu"}
+            parseMetaToml (formatMetaToml meta) `shouldBe` Just meta
+
+        it "round-trips a description holding a quote" $ do
+            let meta = baseMeta{umDescription = Just "the \"good\" one"}
+            parseMetaToml (formatMetaToml meta) `shouldBe` Just meta
+
         it "round-trips all database formats" $
             mapM_
                 ( \fmt -> do

--- a/volca.cabal
+++ b/volca.cabal
@@ -45,6 +45,7 @@ library
                      , Database.Manager
                      , Database.Author
                      , Database.Rebuild
+                     , Database.Journal
                      , Database.Edit
                      , Database.Loader
                      , Database.CrossLinking
@@ -324,6 +325,7 @@ test-suite lca-tests
                      , AggregateSpec
                      , CopySpec
                      , AuthorSpec
+                     , JournalSpec
                      , ActivityWriteHandlerSpec
                      , PersistenceSpec
                      , DeleteSelectionSpec

--- a/volca.cabal
+++ b/volca.cabal
@@ -44,6 +44,7 @@ library
                      , Database
                      , Database.Manager
                      , Database.Author
+                     , Database.Rebuild
                      , Database.Edit
                      , Database.Loader
                      , Database.CrossLinking


### PR DESCRIPTION
An edit to an uploaded database used to be saved by rewriting that database's
own source files. That only ever worked for EcoSpold 2, whose file names carry
the `activityUUID_productUUID` a reload reads back. Every other format derives
identity from names, categories and the position of a dataset in its file, so
writing one back would have handed every activity a new identity at the next
read, silently and only after a restart. They were refused, which left the
formats people actually upload uneditable.

The sources are now left exactly as their author uploaded them, and the edit
is appended to a journal beside them: `journal.jsonl` in the database's upload
directory, one line per create, replace or delete. Loading reads the sources
and replays the journal over them. A file that is never rewritten parses to
the same identifiers forever, so EcoSpold 1, SimaPro CSV, ILCD and Brightway
Excel are now editable on the same terms as EcoSpold 2, without converting
anything.

Two things guard the replay. Each line carries the process ids the edit
produced; a replay re-mints them and stops if the two disagree, so a change in
how identity is minted can never quietly land an activity somewhere else. And
each line carries a format version, refused rather than skipped when unknown.
The exception is a torn last line, dropped with a warning: a line is written
before its edit is acknowledged, so an incomplete final line belongs to an edit
nobody was told about. A line that is complete JSON but unreadable is refused
wherever it sits, including at the end, which is where a newer engine's entries
would be.

Replaying on every load would be slow, so the matrix cache still holds the
database after its edits. It is stamped with the journal it was built from, and
a cache whose stamp does not match is not used at all. That is exactly what a
crash between recording an edit and saving the cache leaves behind, and reading
the sources again is the honest answer to it. A journal that cannot be applied
refuses the load rather than returning a database that disagrees with its own
record.

A copy changes shape too. It gets its directory when it is made rather than at
its first save, so it survives a restart from the moment it exists, and that
directory holds its identity and its edits but no data: it reads the files of
the database it was copied from. Deleting that database is now refused while a
copy still needs it.

The API is unchanged. `transient` still means what it meant, and now says
`false` for every uploaded database whatever its format.

Structurally, the pure half of editing moved out of `Database.Edit` into
`Database.Rebuild`, so the load path can apply a recorded edit without
importing the effectful editor. `Database.Journal` owns the event type, its
codec and the replay; the codec is its own rather than the wire's, because what
is on disk has to keep reading while the API stays free to change shape.

Verified end to end on an EcoSpold 1 database in the layout a published
collection uses (one dataset per file, named after its identifier): edit,
restart, same process ids, and the same result again with the cache stamp
removed so the journal is replayed.

One fix rides along, because this change is what exposed it: `meta.toml`
escapes a backslash and a quote as its format requires, and nothing undid that
on the way back. Nothing noticed while every path written there was a relative
`data`; a copy records the absolute path of the files it reads, and on Windows
every separator in it came back twice over. The build matrix caught it.
