### PR TITLE
Let the regionalized table rank its colliding factors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@
   delete response now says so with two new fields, `transient` and `warnings`.
 
 ### Fixed
+- A regionalized factor now comes from the method's most specific line, not from
+  whichever line the file happened to list last. When a method writes both a
+  medium-level factor and one naming the flow's own subcompartment, and both
+  carry a location, the two used to collide and the later row won: reordering
+  the same file changed the score. The line that names the subcompartment wins,
+  and between two of the same kind the larger factor does, as everywhere else.
 - An emission to the sea is now characterized by an impact category that writes
   no sea-water factor of its own. A method file spells out a subcompartment only
   when its factor differs from the medium-level ("unspecified") one, so a

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -1136,6 +1136,15 @@ heuristic/expanded): when two CFs collide on one flow or table key, the lower
 rank — the more discriminating match — wins. Exported so diagnostics dedup
 with the same preference the score tables use.
 -}
+
+{- | How a CF's own subcompartment met the flow's: by naming it, or by naming
+none at all and standing as the method's medium-level default. Only
+'mtRegionalizedCF' needs to tell the two apart, because it is the one table
+where both compete for a single key.
+-}
+data SubMatch = ExactSub | MediumLevelSub
+    deriving (Eq, Show)
+
 strategyPriority :: MatchStrategy -> Int
 strategyPriority ByUUID = 0
 strategyPriority ByName = 1
@@ -1339,12 +1348,14 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             -- ByName/synonym fan-out and clobbers the correct (unspecified)
             -- fallback CF. CFs with no specific subcomp ('isUnspecifiedSub')
             -- are wildcards and match any flow subcomp.
-            M.fromList
-                [ ((bfId flow, Location loc), cfOf cf)
-                | (cf, Just (flow, _)) <- mappings
-                , cfSubcompMatchesFlow cf flow
-                , Just loc <- [mcfConsumerLocation cf]
-                ]
+            M.map snd $
+                M.fromListWith
+                    preferRegional
+                    [ ((bfId flow, Location loc), (m, cfOf cf))
+                    | (cf, Just (flow, _)) <- mappings
+                    , Just m <- [cfSubcompMatchesFlow cf flow]
+                    , Just loc <- [mcfConsumerLocation cf]
+                    ]
         , mtCFFamily = methodFamily
         , mtSeaWaterCFs = seaWaterCFs
         , mtCompartmentMap = cmap
@@ -1444,7 +1455,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
     -- 'compartmentSub' field, fall back to the tail of "<medium>/<sub>"
     -- parsed from the compartment name.
     cfSubcompMatchesFlow cf flow = case mcfCompartment cf of
-        Nothing -> True
+        Nothing -> Just MediumLevelSub
         Just comp ->
             let Compartment _ cfSubRaw _ = normalizeCompartment cmap comp
                 !cfSubN = T.toLower (T.strip cfSubRaw)
@@ -1464,9 +1475,28 @@ buildMethodTables methodFamily cmap energyDensities mappings =
                 -- non-regional path — both tiers: a foreign medium (sea/ocean)
                 -- never borrows a freshwater CF, and long-term groundwater
                 -- borrows no surface USEtox CF. An explicit same-sub CF still
-                -- matches.
-                (isUnspecifiedSub cfSubN && wildcardReachesSub methodFamily seaWaterCFs (Subcompartment flowSubN))
-                    || cfSubN == flowSubN
+                -- matches, and says so, because the two are ranked against each
+                -- other when both land on one (flow, location).
+                subMatch cfSubN flowSubN
+
+    subMatch cfSubN flowSubN
+        | cfSubN == flowSubN = Just ExactSub
+        | isUnspecifiedSub cfSubN
+        , wildcardReachesSub methodFamily seaWaterCFs (Subcompartment flowSubN) =
+            Just MediumLevelSub
+        | otherwise = Nothing
+
+    -- Rank two CFs competing for one (flow, location) key. 'mtRegionalizedCF' is
+    -- the only table where an exact-subcompartment CF and a medium-level one
+    -- compete at all: 'mtExactCF' and 'mtFallbackCF' are kept apart by
+    -- construction and the read cascade orders them. Here both land on the same
+    -- key, so without a rank the winner is whichever row the method file listed
+    -- last. The method's more specific line wins; between two of the same kind,
+    -- the larger factor, as everywhere else in this module.
+    preferRegional a@(mA, CF va _) b@(mB, CF vb _)
+        | mA /= mB = if mA == ExactSub then a else b
+        | abs va >= abs vb = a
+        | otherwise = b
 
     -- Rank colliding CFs for one name key: better match strategy first, then a
     -- CF whose own (raw) flow name equals the matched DB flow's name — when

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -1131,12 +1131,6 @@ expandProxyEdges targets edges mappings =
     flowsMatching (SR.ByCAS (SR.CASNumber c)) = M.findWithDefault [] c (ptByCAS targets)
     flowsMatching (SR.ByUUID (SR.FlowUUID u)) = maybe [] pure (M.lookup u (ptByUUID targets))
 
-{- | Cascade-order rank of a match strategy (UUID → name → synonym → CAS →
-heuristic/expanded): when two CFs collide on one flow or table key, the lower
-rank — the more discriminating match — wins. Exported so diagnostics dedup
-with the same preference the score tables use.
--}
-
 {- | How a CF's own subcompartment met the flow's: by naming it, or by naming
 none at all and standing as the method's medium-level default. Only
 'mtRegionalizedCF' needs to tell the two apart, because it is the one table
@@ -1145,6 +1139,11 @@ where both compete for a single key.
 data SubMatch = ExactSub | MediumLevelSub
     deriving (Eq, Show)
 
+{- | Cascade-order rank of a match strategy (UUID → name → synonym → CAS →
+heuristic/expanded): when two CFs collide on one flow or table key, the lower
+rank — the more discriminating match — wins. Exported so diagnostics dedup
+with the same preference the score tables use.
+-}
 strategyPriority :: MatchStrategy -> Int
 strategyPriority ByUUID = 0
 strategyPriority ByName = 1

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -452,13 +452,37 @@ spec = do
             M.lookup (fid, Location "DE") (mtRegionalizedCF tUnspec) `shouldBe` Just (CF 7.0 (CFUnit "kg"))
             M.lookup (fid, Location "DE") (mtRegionalizedCF tUnspecBare) `shouldBe` Just (CF 9.0 (CFUnit "kg"))
 
+        it "prefers the CF that names the flow's subcompartment, whatever the row order" $ do
+            -- Both a medium-level CF and an exact-subcompartment one apply to a
+            -- river flow, and both land on the same (flow, location) key. The
+            -- method's more specific line is the answer; before this was ranked,
+            -- the winner was whichever row the file happened to list last.
+            let fid = mkUuid 134
+                uidKg = mkUuid 200
+                flowRiver =
+                    (mkFlow fid "water" uidKg)
+                        { bfCompartment = Just (VT.Compartment "water" (Just "river"))
+                        }
+                cfAt sub value =
+                    (mkCF fid value)
+                        { mcfFlowName = "water"
+                        , mcfCompartment = Just (Compartment "water" sub "")
+                        , mcfConsumerLocation = Just "DE"
+                        }
+                tablesFrom rows =
+                    mtRegionalizedCF (buildMethodTables OtherCFFamily M.empty M.empty rows)
+                medium = (cfAt "(unspecified)" 7.0, Just (flowRiver, ByName))
+                exact = (cfAt "river" 3.0, Just (flowRiver, ByName))
+            M.lookup (fid, Location "DE") (tablesFrom [medium, exact])
+                `shouldBe` Just (CF 3.0 (CFUnit "kg"))
+            M.lookup (fid, Location "DE") (tablesFrom [exact, medium])
+                `shouldBe` Just (CF 3.0 (CFUnit "kg"))
+
         it "does not let a wildcard CF reach a sea/ocean flow (foreign medium)" $ do
             -- A freshwater CF must not characterize a sea-water release via the
             -- regionalized wildcard. The method says so itself: EF writes a
             -- sea-water factor of its own, and that line — not the freshwater
-            -- one — is what a release to the sea gets. Ranking colliding CFs
-            -- keeps the larger value, so without the gate the 7.0 would beat
-            -- the method's own sea line.
+            -- one — is what a release to the sea gets.
             let fid = mkUuid 130
                 uidKg = mkUuid 200
                 flowOcean =


### PR DESCRIPTION
`mtRegionalizedCF` was built with a bare `M.fromList`. When a method writes both
a medium-level factor and one naming the flow's own subcompartment, and both
carry a consumer location, the two land on the same `(flow, location)` key and
the later row wins. Reordering the same method file changes the score.

```haskell
M.fromList
    [ ((bfId flow, Location loc), cfOf cf)
    | (cf, Just (flow, _)) <- mappings
    , cfSubcompMatchesFlow cf flow          -- lets both kinds through
    , Just loc <- [mcfConsumerLocation cf]
    ]
```

The sibling tables never had this problem, which is why it went unnoticed:
`mtExactCF` keeps only CFs with a subcompartment, `mtFallbackCF` only those
without, and `lookupCascadeCF` reads the first before the second. Specificity
wins there by construction. This table holds both kinds at once, so the rank has
to be stated.

## What changed

`cfSubcompMatchesFlow` returned `Bool`; it now returns which kind of match it
found, and `Nothing` when the CF does not apply at all. The table merges with
that in hand: the line that names the subcompartment wins, and between two of
the same kind the larger factor does, as everywhere else in the module.

Nothing about the gates themselves moved. A medium-level CF still reaches only
the subcompartments `wildcardReachesSub` allows, so the sea and long-term
groundwater rules are untouched.

## Checked

The new test builds the same two factors in both orders and expects the same
answer. It fails on `main` (7.0, the medium-level factor, instead of 3.0) and
passes here.

`cabal test`: 2051 examples, 0 failures.

## Scope

Only methods that write located factors are affected, and only where they write
both kinds of line for one flow. A method whose subcompartment lines carry no
location, or that writes only one kind, produces the same table as before.
