### PR TITLE
Let an exponent carry a sign

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -14,8 +14,10 @@
 - ignore: {name: "Use head", within: Method.ParserCSV}
 
 # fourmolu's `single-constraint-parens: always` writes `(HasCallStack) =>`, which hlint
-# reads as a redundant bracket. The formatter wins, so silence the lint on this helper.
-- ignore: {name: "Redundant bracket", within: SimaProParserSpec.findByName}
+# reads as a redundant bracket. The formatter wins, so silence the lint on these
+# helpers — both carry the constraint so a failed assertion points at its call site
+# rather than at the helper.
+- ignore: {name: "Redundant bracket", within: [SimaProParserSpec.findByName, SimaProParserSpec.shouldEvalTo]}
 
 # This test's whole point is the right-identity law `s <> mempty`; hlint would simplify
 # it to `s` and delete exactly what's under test. Keep the law spelled out.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,14 @@
   or a quote came back with that character doubled. The file escapes them as
   its format requires and nothing undid it on the way back, which on Windows
   meant a nested data path that resolved to nothing.
+- An amount written as a signed power of ten is read instead of refused.
+  SimaPro writes a scale factor that way — `1*10^-3*50` — and the engine
+  understood `10^3` but not `10^-6`: the exponent was read by the
+  exponentiation rule itself, which knows numbers but not signs, so the minus
+  failed the whole expression and the amount fell back to whatever the cell
+  began with. The exponent now goes through the same rule as any other signed
+  operand. Exponentiation stays right-associative and still binds tighter than
+  multiplication, so `2^3^2` is 512 and `-2^2` is −4.
 - A regionalized factor now comes from the method's most specific line, not from
   whichever line the file happened to list last. When a method writes both a
   medium-level factor and one naming the flow's own subcompartment, and both

--- a/src/Expr.hs
+++ b/src/Expr.hs
@@ -79,10 +79,17 @@ pUnary env =
         <|> (symbol "+" *> pUnary env)
         <|> pPower env
 
+{- | Exponentiation, right-associative and binding tighter than @*@ and @/@.
+
+The exponent goes through 'pUnary' rather than straight back to 'pPower', so it
+may carry a sign. SimaPro writes scale factors that way — @1*10^-3*50@ — and
+without it the @-@ met 'pPrimary', which knows numbers but not signs, and the
+whole expression failed.
+-}
 pPower :: M.Map Text Double -> Parser Double
 pPower env = do
     base <- pPrimary env
-    (symbol "^" *> ((base **) <$> pPower env)) <|> pure base
+    (symbol "^" *> ((base **) <$> pUnary env)) <|> pure base
 
 pPrimary :: M.Map Text Double -> Parser Double
 pPrimary env =
@@ -211,7 +218,7 @@ pSynUnary :: Parser ()
 pSynUnary = (symbol "-" *> pSynUnary) <|> (symbol "+" *> pSynUnary) <|> pSynPower
 
 pSynPower :: Parser ()
-pSynPower = pSynPrimary >> ((symbol "^" *> pSynPower) <|> pure ())
+pSynPower = pSynPrimary >> ((symbol "^" *> pSynUnary) <|> pure ())
 
 pSynPrimary :: Parser ()
 pSynPrimary =

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -9,7 +9,7 @@ import qualified Data.Set as S
 import Data.Text (Text)
 import Database.Loader (getReferenceProductUUID)
 import Database.MatrixBuild (InterningTables (..), buildInterningTables)
-import Expr (evaluate, normalizeExpr)
+import Expr (evaluate, isExpression, normalizeExpr)
 import SimaPro.Parser (
     BioExchangeRow (..),
     Located (..),
@@ -507,6 +507,29 @@ spec = do
         it "evaluates power operator" $ do
             evaluate M.empty "2^3" `shouldBe` Right 8.0
             evaluate M.empty "3^2" `shouldBe` Right 9.0
+
+        -- Regression: SimaPro writes a scale factor as a signed power of ten.
+        -- The exponent used to be parsed by the power rule itself, which knows
+        -- numbers but not signs, so the '-' failed the whole expression and the
+        -- amount fell back to something else entirely.
+        it "evaluates a signed exponent" $ do
+            evaluate M.empty "10^-6" `shouldBe` Right 1.0e-6
+            evaluate M.empty "10^+3" `shouldBe` Right 1000.0
+            evaluate M.empty "1*10^-3*50" `shouldBe` Right 0.05
+            evaluate M.empty "2^-2" `shouldBe` Right 0.25
+
+        it "keeps exponentiation right-associative and below unary minus" $ do
+            -- Reading the exponent through the unary rule must not flatten the
+            -- tower nor take the sign away from the operand in front of it.
+            evaluate M.empty "2^3^2" `shouldBe` Right 512.0
+            evaluate M.empty "-2^2" `shouldBe` Right (-4.0)
+            evaluate M.empty "2^-3^2" `shouldBe` Right (2 ** (-9))
+
+        it "accepts a signed exponent as syntax, not only as a value" $ do
+            -- `isExpression` runs a parallel parser that takes no environment,
+            -- so it has to learn the same shape or the cell reads as prose.
+            isExpression ',' "10^-6" `shouldBe` True
+            isExpression ',' "(38-15)*4185*30/0,9*10^-6" `shouldBe` True
 
         it "evaluates unary minus" $ do
             evaluate M.empty "-5" `shouldBe` Right (-5.0)

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -467,6 +467,19 @@ findByName name acts = case [a | a <- acts, activityName a == name] of
     [] -> error $ "findByName: no activity named " <> show name
     _ -> error $ "findByName: more than one activity named " <> show name
 
+{- | An evaluation that reached a value, to within a relative ulp or so.
+
+For everything but exponentiation the evaluator is exact and 'shouldBe' says
+so. @**@ is not: it goes through the platform's @pow@, and Windows answers
+@1.0000000000000006e-6@ where Linux answers @1.0e-6@ for the same @10^-6@. The
+property under test is that the expression parses and reaches the right number,
+not that two libm implementations agree on its last bit.
+-}
+shouldEvalTo :: (HasCallStack) => Either String Double -> Double -> Expectation
+shouldEvalTo (Left err) _ = expectationFailure ("evaluation failed: " <> err)
+shouldEvalTo (Right got) want =
+    got `shouldSatisfy` \v -> abs (v - want) <= 1e-12 * abs want
+
 spec :: Spec
 spec = do
     describe "SimaPro expression evaluator" $ do
@@ -513,17 +526,19 @@ spec = do
         -- numbers but not signs, so the '-' failed the whole expression and the
         -- amount fell back to something else entirely.
         it "evaluates a signed exponent" $ do
-            evaluate M.empty "10^-6" `shouldBe` Right 1.0e-6
-            evaluate M.empty "10^+3" `shouldBe` Right 1000.0
-            evaluate M.empty "1*10^-3*50" `shouldBe` Right 0.05
-            evaluate M.empty "2^-2" `shouldBe` Right 0.25
+            evaluate M.empty "10^-6" `shouldEvalTo` 1.0e-6
+            evaluate M.empty "10^+3" `shouldEvalTo` 1000.0
+            evaluate M.empty "1*10^-3*50" `shouldEvalTo` 0.05
+            evaluate M.empty "2^-2" `shouldEvalTo` 0.25
 
         it "keeps exponentiation right-associative and below unary minus" $ do
             -- Reading the exponent through the unary rule must not flatten the
             -- tower nor take the sign away from the operand in front of it.
-            evaluate M.empty "2^3^2" `shouldBe` Right 512.0
-            evaluate M.empty "-2^2" `shouldBe` Right (-4.0)
-            evaluate M.empty "2^-3^2" `shouldBe` Right (2 ** (-9))
+            -- 512 rather than 64 is the whole point: a flattened tower would be
+            -- (2^3)^2, and no rounding tolerance can hide that difference.
+            evaluate M.empty "2^3^2" `shouldEvalTo` 512.0
+            evaluate M.empty "-2^2" `shouldEvalTo` (-4.0)
+            evaluate M.empty "2^-3^2" `shouldEvalTo` (2 ** (-9))
 
         it "accepts a signed exponent as syntax, not only as a value" $ do
             -- `isExpression` runs a parallel parser that takes no environment,

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -477,8 +477,9 @@ not that two libm implementations agree on its last bit.
 -}
 shouldEvalTo :: (HasCallStack) => Either String Double -> Double -> Expectation
 shouldEvalTo (Left err) _ = expectationFailure ("evaluation failed: " <> err)
-shouldEvalTo (Right got) want =
-    got `shouldSatisfy` \v -> abs (v - want) <= 1e-12 * abs want
+shouldEvalTo (Right got) want
+    | abs (got - want) <= 1e-12 * abs want = pure ()
+    | otherwise = expectationFailure (show got <> " is not within a relative 1e-12 of " <> show want)
 
 spec :: Spec
 spec = do


### PR DESCRIPTION
## Why

The evaluator understood `10^3` and refused `10^-6`.

Exponentiation parsed its exponent with the exponentiation rule itself, which
descends straight to a primary — parentheses, a function call, a literal, a
variable. A primary has never included a sign; the unary rule sits one level
above it. So the minus met a parser that had no arm for it, the whole
expression failed to parse, and the amount fell back to whatever the cell
began with.

Three amount cells in a public agricultural database need it. Two lose a heat
input entirely; one reads `1*10^-3*50` as 1 instead of 0.05, which is twenty
times the freight it declares. All three were found by the load-time warning
for unresolvable amounts rather than by anyone noticing a wrong number, which
is the point of that warning.

## Final state

The exponent goes through the unary rule, one line in the evaluator and one in
the syntax-only parser that `isExpression` runs.

That keeps both properties the old shape had, and the tests pin them:

- **right-associative**, because the unary rule returns to exponentiation —
  `2^3^2` is 512, not 64
- **binds tighter than `*` and `/`**, because neither rule reaches back up —
  `-2^2` is −4, and the sign in front of an operand is still not eaten by the
  exponent that follows it

```
10^-6        1e-6
10^+3        1000
1*10^-3*50   0.05
2^-3^2       2 ** (-9)
```

2077 examples, 0 failures.