### PR TITLE
Tell same-named flows apart in a flow search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,13 @@
   delete response says so with two fields, `transient` and `warnings`.
 
 ### Fixed
+- A flow search now tells same-named flows apart. Agribalyse 3.2 carries seven
+  `Deltamethrin` flows that differ only by compartment; a search returned seven
+  rows with the same name, medium and unit, in an order that interleaved them.
+  Each result now carries its sub-compartment in a `compartment` field, next to
+  `category`, which has always held the medium alone, and every sort order
+  continues through the remaining displayed columns, so flows that look alike
+  arrive adjacent and ordered instead of scattered.
 - An uploaded database whose `meta.toml` recorded a path containing a backslash
   or a quote came back with that character doubled. The file escapes them as
   its format requires and nothing undid it on the way back, which on Windows

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -1655,9 +1655,11 @@ One rung of the factor-matching cascade, and what it made of the flow.
 
 A technosphere product or biosphere flow as returned by /flows.
 
-Mirrors the server's :code:`FlowSearchResult`. ``synonyms`` maps
-language code → list of synonym strings (empty when the database
-carries no synonym index).
+Mirrors the server's :code:`FlowSearchResult`. ``category`` is the
+medium alone ("soil"); ``compartment`` is the sub-compartment
+("agricultural"), which is often all that tells two same-named flows
+apart. ``synonyms`` maps language code → list of synonym strings
+(empty when the database carries no synonym index).
 
 | Field | Type | Default |
 |-------|------|---------|
@@ -1665,6 +1667,7 @@ carries no synonym index).
 | `name` | `str` | — |
 | `category` | `str` | — |
 | `unit_name` | `str` | — |
+| `compartment` | `str \| None` | None |
 | `synonyms` | `dict[str, list[str]]` | dict() |
 
 ### `FlowContribution`

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -555,15 +555,18 @@ class Activity(FromJson):
 class Flow(FromJson):
     """A technosphere product or biosphere flow as returned by /flows.
 
-    Mirrors the server's :code:`FlowSearchResult`. ``synonyms`` maps
-    language code → list of synonym strings (empty when the database
-    carries no synonym index).
+    Mirrors the server's :code:`FlowSearchResult`. ``category`` is the
+    medium alone ("soil"); ``compartment`` is the sub-compartment
+    ("agricultural"), which is often all that tells two same-named flows
+    apart. ``synonyms`` maps language code → list of synonym strings
+    (empty when the database carries no synonym index).
     """
 
     id: str
     name: str
     category: str
     unit_name: str
+    compartment: str | None = None
     synonyms: dict[str, list[str]] = field(default_factory=dict)
 
 

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -23,7 +23,7 @@ import Data.Aeson
 import Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as BSL
 import Data.Foldable (asum)
-import Data.List (intercalate, sortBy, sortOn)
+import Data.List (intercalate, sortOn)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe)
@@ -2267,18 +2267,13 @@ The 'ffQuery' is always present (callers short-circuit on the no-query
 case); language filtering is not yet implemented.
 -}
 searchFlowsInternal :: Database -> Service.FlowFilter -> AppM (SearchResults FlowSearchResult)
-searchFlowsInternal db Service.FlowFilter{Service.ffQuery = query, Service.ffLimit = limitParam, Service.ffOffset = offsetParam, Service.ffSort = sortParam, Service.ffOrder = orderParam} = do
+searchFlowsInternal db ff@Service.FlowFilter{Service.ffQuery = query, Service.ffLimit = limitParam, Service.ffOffset = offsetParam} =
     -- Language filtering not yet implemented, search all synonyms
-    let flows = findFlowsBySynonym db query
-        unitOf = flowKindUnitName (dbUnits db)
-        allResults = [FlowSearchResult (flowKindId flow) (flowKindName flow) (flowKindCategory flow) (unitOf flow) (M.map S.toList (flowKindSynonyms flow)) | flow <- flows]
-        isDesc = orderParam == Just "desc"
-        fsCmp = case sortParam of
-            Just "category" -> \a b -> compare (fsrCategory a) (fsrCategory b)
-            Just "unit" -> \a b -> compare (fsrUnitName a) (fsrUnitName b)
-            _ -> \a b -> compare (fsrName a) (fsrName b)
-        sorted = sortBy (if isDesc then flip fsCmp else fsCmp) allResults
-    liftIO $ paginateResults sorted limitParam offsetParam
+    liftIO $
+        paginateResults
+            (Service.flowSearchResults (dbUnits db) ff (findFlowsBySynonym db query))
+            limitParam
+            offsetParam
 
 -- | Proxy for the API
 lcaAPI :: Proxy LCAAPI

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -226,7 +226,8 @@ data ConsumersResponse = ConsumersResponse
 data FlowSearchResult = FlowSearchResult
     { fsrId :: UUID
     , fsrName :: Text
-    , fsrCategory :: Text
+    , fsrCategory :: Text -- Medium only (e.g. "soil"), never the sub-compartment
+    , fsrCompartment :: Maybe Text -- Sub-compartment (e.g. "agricultural")
     , fsrUnitName :: Text
     , fsrSynonyms :: M.Map Text [Text] -- Synonyms by language (converted from Set to List for JSON)
     }
@@ -479,7 +480,7 @@ data FlowContributionEntry = FlowContributionEntry
     , fcoContribution :: Double -- Contribution in impact unit
     , fcoSharePct :: Double -- Percentage of total score (0-100)
     , fcoFlowId :: Text -- Flow UUID for disambiguation
-    , fcoCategory :: Text -- e.g. "air/urban air"
+    , fcoCategory :: Text -- Medium only (e.g. "air")
     , fcoCompartment :: Maybe Text -- Sub-compartment (e.g. "urban air")
     , fcoCfValue :: Double -- Raw characterization factor value
     , fcoMatchKind :: Maybe Text -- How the factor was found ("exact_name", "cas_number", …); absent for a flow the method's tables never walked

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -778,35 +778,56 @@ getActivityFlowSummaries db activity = map mkSummary (exchanges activity)
         | exchangeIsInput ex = InputFlow
         | otherwise = OutputFlow
 
+{- | Project matched flows into API results, in the order the filter asks for.
+
+Sorting on the requested column alone leaves flows that share that column in
+whatever order the database yields them (their UUID). Seven @Deltamethrin@
+flows then arrive interleaved and, since a row shows its medium but not its
+sub-compartment, read as duplicates. Every sort key therefore continues with
+the remaining displayed fields, so equal-looking rows end up adjacent and
+ordered.
+
+Shared by the REST and MCP/CLI search paths, which differ only in how they
+paginate.
+-}
+flowSearchResults :: UnitDB -> FlowFilter -> [FlowKind] -> [FlowSearchResult]
+flowSearchResults units FlowFilter{ffSort = sortParam, ffOrder = orderParam} =
+    L.sortBy (direction (\a b -> compare (sortKey a) (sortKey b))) . map toResult
+  where
+    direction = if orderParam == Just "desc" then flip else id
+    -- Parsers turn an absent sub-compartment into 'Nothing', never @""@, so
+    -- the empty string sorts where 'Nothing' would: ahead of every named one.
+    sub = fromMaybe "" . fsrCompartment
+    sortKey r = case sortParam of
+        Just "category" -> (fsrCategory r, sub r, fsrName r, fsrUnitName r)
+        Just "unit" -> (fsrUnitName r, fsrName r, fsrCategory r, sub r)
+        _ -> (fsrName r, fsrCategory r, sub r, fsrUnitName r)
+    -- Three-arm projections from Types are total over FlowKind.
+    toResult flow =
+        FlowSearchResult
+            { fsrId = flowKindId flow
+            , fsrName = flowKindName flow
+            , fsrCategory = flowKindCategory flow
+            , fsrCompartment = flowKindCompartmentSub flow
+            , fsrUnitName = flowKindUnitName units flow
+            , fsrSynonyms = M.map S.toList (flowKindSynonyms flow)
+            }
+
 {- | Search flows (returns same format as API). The query is required by the
 type; callers with no query return 'emptyFlowSearchResults' directly.
 -}
 searchFlows :: Database -> FlowFilter -> IO (Either ServiceError Value)
-searchFlows db FlowFilter{ffQuery = query, ffLimit = limitParam, ffOffset = offsetParam, ffSort = sortParam, ffOrder = orderParam} = do
+searchFlows db ff@FlowFilter{ffQuery = query, ffLimit = limitParam, ffOffset = offsetParam} = do
     startTime <- getCurrentTime
     let limit = maybe 50 (min 1000) limitParam
         offset = maybe 0 (max 0) offsetParam
-        rawResults = findFlowsBySynonym db query
-        isDesc = orderParam == Just "desc"
-        -- Three-arm projections from API.Types are total over FlowKind.
-        unitOf = flowKindUnitName (dbUnits db)
-        flowCmp = case sortParam of
-            Just "category" -> \a b -> compare (flowKindCategory a) (flowKindCategory b)
-            Just "unit" -> \a b -> compare (unitOf a) (unitOf b)
-            _ -> \a b -> compare (flowKindName a) (flowKindName b)
-        allResults = L.sortBy (if isDesc then flip flowCmp else flowCmp) rawResults
+        allResults = flowSearchResults (dbUnits db) ff (findFlowsBySynonym db query)
         total = length allResults
-        dropped = drop offset allResults
-        taken = take (limit + 1) dropped
+        taken = take (limit + 1) (drop offset allResults)
         hasMore = length taken > limit
-        pagedResults = take limit taken
-        flowResults =
-            map
-                (\flow -> FlowSearchResult (flowKindId flow) (flowKindName flow) (flowKindCategory flow) (unitOf flow) (M.map S.toList (flowKindSynonyms flow)))
-                pagedResults
     endTime <- getCurrentTime
     let searchTimeMs = realToFrac (diffUTCTime endTime startTime) * 1000 :: Double
-    return $ Right $ toJSON $ SearchResults flowResults total offset limit hasMore searchTimeMs
+    return $ Right $ toJSON $ SearchResults (take limit taken) total offset limit hasMore searchTimeMs
 
 {- | Retrieve activities by BM25 score. Returns pairs already ordered by score
 descending; only documents with score > 0 are included.

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -607,6 +607,16 @@ flowKindCategory (TechKind _) = ""
 flowKindCategory (BioKind f) = bfCompartmentName f
 flowKindCategory (WasteKind _) = ""
 
+{- | Sub-compartment projection, the companion of 'flowKindCategory'. Two
+biosphere flows of the same name and medium are told apart by this alone
+(e.g. @soil / agricultural@ vs @soil / forestry@), so a flat list view that
+drops it shows what look like duplicate rows.
+-}
+flowKindCompartmentSub :: FlowKind -> Maybe Text
+flowKindCompartmentSub (TechKind _) = Nothing
+flowKindCompartmentSub (BioKind f) = bfCompartmentSub f
+flowKindCompartmentSub (WasteKind _) = Nothing
+
 -- | Unit-id accessor — for unit-name lookup against the 'UnitDB'.
 flowKindUnitId :: FlowKind -> UUID
 flowKindUnitId (TechKind f) = tfUnitId f

--- a/test/FlowSearchSpec.hs
+++ b/test/FlowSearchSpec.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Flow search results must tell homonyms apart.
+
+Agribalyse 3.2 carries seven @Deltamethrin@ flows differing only by
+compartment. A result that drops the sub-compartment, or an order that
+interleaves the media, shows them as duplicate rows.
+-}
+module FlowSearchSpec (spec) where
+
+import API.Types (FlowSearchResult (..))
+import qualified Data.Map as M
+import Data.Text (Text)
+import qualified Data.UUID as UUID
+import Service (FlowFilter (..), flowSearchResults)
+import Test.Hspec
+import Types (BiosphereFlow (..), Compartment (..), FlowKind (..), UUID)
+
+spec :: Spec
+spec = describe "Service.flowSearchResults" $ do
+    it "carries the sub-compartment that tells two same-medium flows apart" $
+        map (\r -> (fsrCategory r, fsrCompartment r)) (search sortByName deltamethrins)
+            `shouldContain` [("soil", Just "agricultural"), ("soil", Just "forestry")]
+
+    it "groups homonyms by compartment instead of leaving them in database order" $
+        -- Sorting on the name alone is stable, so seven identical names would
+        -- keep the input (UUID) order: soil, water, air, soil, soil, water, air.
+        map compartmentOf (search sortByName deltamethrins)
+            `shouldBe` [ ("air", Just "low. pop.")
+                       , ("air", Just "low. pop., long-term")
+                       , ("soil", Nothing)
+                       , ("soil", Just "agricultural")
+                       , ("soil", Just "forestry")
+                       , ("water", Just "groundwater")
+                       , ("water", Just "river")
+                       ]
+
+    it "reverses the whole order on desc, not just the requested column" $
+        map compartmentOf (search sortByName{ffOrder = Just "desc"} deltamethrins)
+            `shouldBe` reverse (map compartmentOf (search sortByName deltamethrins))
+
+    it "orders by medium then sub-compartment when sorting on the category" $
+        map compartmentOf (search sortByName{ffSort = Just "category"} deltamethrins)
+            `shouldBe` map compartmentOf (search sortByName deltamethrins)
+
+compartmentOf :: FlowSearchResult -> (Text, Maybe Text)
+compartmentOf r = (fsrCategory r, fsrCompartment r)
+
+-- | No unit database: every flow reports the same unit, so unit never breaks a tie.
+search :: FlowFilter -> [FlowKind] -> [FlowSearchResult]
+search = flowSearchResults M.empty
+
+sortByName :: FlowFilter
+sortByName =
+    FlowFilter
+        { ffQuery = "Deltamethrin"
+        , ffLang = Nothing
+        , ffLimit = Nothing
+        , ffOffset = Nothing
+        , ffSort = Nothing
+        , ffOrder = Nothing
+        }
+
+{- | The seven Agribalyse 3.2 flows, in the UUID order the database yields
+them — deliberately not the order they should come out in.
+-}
+deltamethrins :: [FlowKind]
+deltamethrins =
+    [ bioFlow 1 "soil" Nothing
+    , bioFlow 2 "water" (Just "groundwater")
+    , bioFlow 3 "air" (Just "low. pop.")
+    , bioFlow 4 "soil" (Just "agricultural")
+    , bioFlow 5 "soil" (Just "forestry")
+    , bioFlow 6 "water" (Just "river")
+    , bioFlow 7 "air" (Just "low. pop., long-term")
+    ]
+
+bioFlow :: Int -> Text -> Maybe Text -> FlowKind
+bioFlow n medium sub =
+    BioKind
+        BiosphereFlow
+            { bfId = mkUUID n
+            , bfName = "Deltamethrin"
+            , bfUnitId = mkUUID 0
+            , bfSynonyms = M.empty
+            , bfCAS = Just "52918-63-5"
+            , bfSubstanceId = Nothing
+            , bfCompartment = Just (Compartment medium sub)
+            }
+
+mkUUID :: Int -> UUID
+mkUUID n = UUID.fromWords64 (fromIntegral n) 0

--- a/volca.cabal
+++ b/volca.cabal
@@ -298,6 +298,7 @@ test-suite lca-tests
                      , StructuredFiltersSpec
                      , BM25Spec
                      , FuzzySpec
+                     , FlowSearchSpec
                      , NestedSubstitutionSpec
                      , SubstitutionSpec
                      , SensitivitySpec


### PR DESCRIPTION
Agribalyse 3.2 carries seven `Deltamethrin` flows that differ only by their compartment: three in soil (none, agricultural, forestry), two in water (river, groundwater), two in air (low pop., low pop. long-term). A search for them came back as seven rows showing the same name, the same medium and the same unit, in no discernible order. They looked like duplicates.

Two things caused that. A search result carried the medium but never the sub-compartment, although the domain has always kept both and `GET /db/{db}/flow/{id}` returns them. And each sort key compared the requested column alone, so flows sharing that column kept the order the database yields them in, which is their UUID: soil, water, air, soil, soil, water, air.

A result now carries the sub-compartment under `compartment`, the field name the six other surfaces that expose one already use, next to `category` for the medium alone. Every sort key continues with the remaining displayed fields, so rows that look alike end up adjacent and ordered.

The REST and the MCP/CLI paths each built and sorted these results themselves, in two copies that would have needed the same correction twice. They now share one pure function and differ only in how they paginate, which is also what lets the new spec run on a handful of flows rather than a whole database.

Checked against a live engine with Agribalyse 3.2 loaded: the seven flows come back grouped by compartment on both paths, `order=desc` reverses the whole order, pagination is unchanged, and the seven usage counts still sum to 2402.