### PR TITLE
Resolve every configured path against the configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,16 @@
   delete response says so with two fields, `transient` and `warnings`.
 
 ### Fixed
+- Every path in a configuration file now means the same thing. A relative
+  `path` under `[[databases]]`, `[[flow-synonyms]]`, `[[compartment-mappings]]`,
+  `[[units]]`, `[[energy-densities]]` or `geographies` was read next to the
+  configuration file, while the same key under `[[methods]]`, `chem_synonyms`
+  or `substance_edges` was read next to wherever the engine happened to be
+  started from. Two neighbouring lines of one file therefore pointed at two
+  different places, and the usual way out was to write absolute paths, which
+  makes the file describe one machine. All of them now follow the file, so a
+  configuration and the data beside it can be moved or shared as one directory.
+  Absolute paths are untouched.
 - A flow search now tells same-named flows apart. Agribalyse 3.2 carries seven
   `Deltamethrin` flows that differ only by compartment; a search returned seven
   rows with the same name, medium and unit, in an order that interleaved them.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -114,7 +114,7 @@ isLocalCommand _ = False
 runCLIWithConfig :: CLIConfig -> Command -> FilePath -> IO ()
 runCLIWithConfig cliConfig cmd cfgFile = do
     config <- loadConfigOrDie (Just cfgFile)
-    dbManager <- initDatabaseManager config (noCache (globalOptions cliConfig)) (Just cfgFile)
+    dbManager <- initDatabaseManager config (noCache (globalOptions cliConfig))
     executeCommand cliConfig cmd dbManager
 
 {- | HTTP manager for client-mode commands, with the 30 s default response
@@ -246,7 +246,7 @@ runServerWithConfig cliConfig serverOpts mCfgFile = do
     config <- applyLoadOverride serverOpts <$> loadConfigOrDie mCfgFile
     warnUnknownLoadNames serverOpts config
     reportProgress Info "Initializing database manager..."
-    dbManager <- initDatabaseManager config (noCache (globalOptions cliConfig)) mCfgFile
+    dbManager <- initDatabaseManager config (noCache (globalOptions cliConfig))
     logLoadedDatabases dbManager
     let port = fromMaybe (scPort (cfgServer config)) (serverPort serverOpts)
         staticDir = fromMaybe "web/dist" (serverStaticDir serverOpts)
@@ -285,7 +285,7 @@ runConfigLoadOnly cliConfig cfgFile = do
 
     -- Initialize DatabaseManager (pre-loads databases with load=true)
     reportProgress Info "Loading all databases from config..."
-    _dbManager <- initDatabaseManager config (noCache (globalOptions cliConfig)) (Just cfgFile)
+    _dbManager <- initDatabaseManager config (noCache (globalOptions cliConfig))
 
     -- Report success
     let loadCount = length $ filter dcLoad (cfgDatabases config)

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -480,15 +480,16 @@ loadConfig :: FilePath -> IO (Either Text Config)
 loadConfig = loadConfigOrDefault . Just
 
 {- | Resolve the effective configuration: parse the file when a path is given,
-otherwise fall back to 'defaultConfig'. Both paths honour VOLCA_DATA_DIR and
-run 'validateConfig' by construction — an explicit path that does not exist
+otherwise fall back to 'defaultConfig'. Both paths honour VOLCA_DATA_DIR,
+resolve relative paths against the file ('resolveConfigPaths') and run
+'validateConfig' by construction — an explicit path that does not exist
 still fails loudly, while no path at all means "all defaults, no databases".
 -}
 loadConfigOrDefault :: Maybe FilePath -> IO (Either Text Config)
 loadConfigOrDefault mPath = do
     raw <- maybe (pure (Right defaultConfig)) loadConfigFile mPath
     mDataDir <- lookupEnv "VOLCA_DATA_DIR"
-    pure $ raw >>= validateConfig . applyDataDir mDataDir
+    pure $ raw >>= validateConfig . resolveConfigPaths mPath . applyDataDir mDataDir
 
 {- | Redirect a "data/<rest>" path to "$VOLCA_DATA_DIR/<rest>".
 Returns the input unchanged when the env var is unset, or when the path
@@ -537,8 +538,9 @@ Every path-bearing field is listed here, and nothing resolves paths anywhere
 else: a config whose @[[databases]]@ path followed the file while its
 @[[methods]]@ path followed the process was the bug this replaces.
 
-Runs after 'applyDataDir', which is what recognises a leading @data/@ as the
-shipped bundle - prefixing it with a directory first would hide it.
+'loadConfigOrDefault' composes this after 'applyDataDir', which is what
+recognises a leading @data/@ as the shipped bundle - prefixing it with a
+directory first would hide it.
 -}
 resolveConfigPaths :: Maybe FilePath -> Config -> Config
 resolveConfigPaths mConfigPath cfg =

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -31,6 +31,9 @@ module Config (
     redirectIntoDataDir,
     applyDataDir,
 
+    -- * Config-relative path resolution
+    resolveConfigPaths,
+
     -- * Default values
     defaultConfig,
 
@@ -50,7 +53,7 @@ import Database.Upload (DatabaseFormat (..))
 import GHC.Generics (Generic)
 import System.Directory (doesFileExist)
 import System.Environment (lookupEnv)
-import System.FilePath (takeFileName)
+import System.FilePath (isAbsolute, normalise, takeDirectory, takeFileName, (</>))
 import TOML (DecodeTOML (..), Decoder, decodeFile, getArrayOf, getField, getFieldOpt, getFieldOptWith, getFieldWith)
 import Types (GeographyPolicy (..))
 
@@ -524,6 +527,36 @@ applyDataDir mDataDir cfg =
   where
     resolve = redirectIntoDataDir mDataDir
     mapPath f r = r{rdPath = f (rdPath r)}
+
+{- | Resolve every relative path a config carries against the directory the
+config file sits in, so one file describes the same setup from any working
+directory. An absolute path is already unambiguous and is left alone; 'Nothing'
+(no config file) means the process directory, which is all there is to go on.
+
+Every path-bearing field is listed here, and nothing resolves paths anywhere
+else: a config whose @[[databases]]@ path followed the file while its
+@[[methods]]@ path followed the process was the bug this replaces.
+
+Runs after 'applyDataDir', which is what recognises a leading @data/@ as the
+shipped bundle - prefixing it with a directory first would hide it.
+-}
+resolveConfigPaths :: Maybe FilePath -> Config -> Config
+resolveConfigPaths mConfigPath cfg =
+    cfg
+        { cfgDatabases = map (\d -> d{dcPath = resolve (dcPath d)}) (cfgDatabases cfg)
+        , cfgMethods = map (\m -> m{mcPath = resolve (mcPath m)}) (cfgMethods cfg)
+        , cfgFlowSynonyms = map refData (cfgFlowSynonyms cfg)
+        , cfgCompartmentMappings = map refData (cfgCompartmentMappings cfg)
+        , cfgUnits = map refData (cfgUnits cfg)
+        , cfgEnergyDensities = map refData (cfgEnergyDensities cfg)
+        , cfgGeographies = fmap resolve (cfgGeographies cfg)
+        , cfgChemSynonyms = fmap resolve (cfgChemSynonyms cfg)
+        , cfgSubstanceEdges = fmap resolve (cfgSubstanceEdges cfg)
+        }
+  where
+    configDir = maybe "." takeDirectory mConfigPath
+    resolve p = normalise $ if isAbsolute p then p else configDir </> p
+    refData r = r{rdPath = resolve (rdPath r)}
 
 -- | Validate configuration
 validateConfig :: Config -> Either Text Config

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -144,7 +144,7 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import GHC.Generics (Generic)
 import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist, listDirectory, removeDirectoryRecursive, removeFile)
-import System.FilePath (isAbsolute, normalise, takeDirectory, takeExtension, takeFileName, (</>))
+import System.FilePath (takeDirectory, takeExtension, takeFileName, (</>))
 import System.Mem (performGC)
 
 import Config
@@ -929,14 +929,14 @@ Pre-loads databases with load=true at startup
 Also discovers uploaded databases from uploads/ directory
 -}
 initDatabaseManager :: Config -> Bool -> Maybe FilePath -> IO DatabaseManager
-initDatabaseManager config noCache configPath = do
-    -- Resolve relative paths against the config file's directory
-    let configDir = maybe "." takeDirectory configPath
-        resolveRelative p = normalise $ if isAbsolute p then p else configDir </> p
+initDatabaseManager rawConfig noCache configPath = do
+    -- Every path the config carries is made config-relative in one place, so
+    -- the rest of this function only ever sees paths it can open.
+    let config = resolveConfigPaths configPath rawConfig
 
     -- Get configured databases and detect their format
     configuredDbs <- forM (cfgDatabases config) $ \dbConfig -> do
-        resolvedPath <- resolveDataPath (resolveRelative (dcPath dbConfig))
+        resolvedPath <- resolveDataPath (dcPath dbConfig)
         format <- Upload.detectDatabaseFormat resolvedPath
         return dbConfig{dcPath = resolvedPath, dcFormat = Just format}
 
@@ -965,12 +965,10 @@ initDatabaseManager config noCache configPath = do
     uploadedCompMaps <- discoverUploadedRefData "uploads/compartment-mappings"
     uploadedUnitDefs <- discoverUploadedRefData "uploads/units"
     uploadedEnergyDensities <- discoverUploadedRefData "uploads/energy-densities"
-    -- Resolve reference data paths relative to config directory
-    let resolveRdPath rd = rd{rdPath = resolveRelative (rdPath rd)}
-    let allFlowSyns = map resolveRdPath (cfgFlowSynonyms config) ++ uploadedFlowSyns
-        allCompMaps = map resolveRdPath (cfgCompartmentMappings config) ++ uploadedCompMaps
-        allUnitDefs = map resolveRdPath (cfgUnits config) ++ uploadedUnitDefs
-        allEnergyDensities = map resolveRdPath (cfgEnergyDensities config) ++ uploadedEnergyDensities
+    let allFlowSyns = cfgFlowSynonyms config ++ uploadedFlowSyns
+        allCompMaps = cfgCompartmentMappings config ++ uploadedCompMaps
+        allUnitDefs = cfgUnits config ++ uploadedUnitDefs
+        allEnergyDensities = cfgEnergyDensities config ++ uploadedEnergyDensities
     availableFlowSynsVar <- newTVarIO $ M.fromList [(rdName rd, rd) | rd <- allFlowSyns]
     loadedFlowSynsVar <- newTVarIO M.empty
     availableCompMapsVar <- newTVarIO $ M.fromList [(rdName rd, rd) | rd <- allCompMaps]
@@ -983,7 +981,7 @@ initDatabaseManager config noCache configPath = do
     geographies <- case cfgGeographies config of
         Nothing -> return M.empty
         Just path -> do
-            result <- parseGeographiesCSV (resolveRelative path)
+            result <- parseGeographiesCSV path
             case result of
                 Right geos -> pure geos
                 -- Falling back to the built-in hierarchy silently would change

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -928,12 +928,8 @@ clearMethodMappingCacheForDb manager dbName = atomically $ do
 Pre-loads databases with load=true at startup
 Also discovers uploaded databases from uploads/ directory
 -}
-initDatabaseManager :: Config -> Bool -> Maybe FilePath -> IO DatabaseManager
-initDatabaseManager rawConfig noCache configPath = do
-    -- Every path the config carries is made config-relative in one place, so
-    -- the rest of this function only ever sees paths it can open.
-    let config = resolveConfigPaths configPath rawConfig
-
+initDatabaseManager :: Config -> Bool -> IO DatabaseManager
+initDatabaseManager config noCache = do
     -- Get configured databases and detect their format
     configuredDbs <- forM (cfgDatabases config) $ \dbConfig -> do
         resolvedPath <- resolveDataPath (dcPath dbConfig)

--- a/test/ActivityWriteHandlerSpec.hs
+++ b/test/ActivityWriteHandlerSpec.hs
@@ -363,7 +363,7 @@ withDb mkConfig act =
         bracket_ (setEnv "VOLCA_DATA_DIR" root) (unsetEnv "VOLCA_DATA_DIR") $ do
             let dataDir = root </> "uploads" </> "databases" </> "authored" </> "data"
             createDirectoryIfMissing True dataDir
-            dbm <- initDatabaseManager defaultConfig True Nothing
+            dbm <- initDatabaseManager defaultConfig True
             db <- buildFixture
             solver <- createSharedSolver "authored" (triplesOf db) (fromIntegral (dbActivityCount db))
             let config = mkConfig "authored" dataDir

--- a/test/AutoSynonymsSpec.hs
+++ b/test/AutoSynonymsSpec.hs
@@ -33,7 +33,7 @@ withTempManager action =
     withSystemTempDirectory "volca-auto-syns" $ \tmp -> do
         oldCwd <- getCurrentDirectory
         setCurrentDirectory tmp
-        (initDatabaseManager defaultConfig True Nothing >>= action)
+        (initDatabaseManager defaultConfig True >>= action)
             `finally` setCurrentDirectory oldCwd
 
 spec :: Spec

--- a/test/BatchImpactsSpec.hs
+++ b/test/BatchImpactsSpec.hs
@@ -73,7 +73,7 @@ spec = do
 
     describe "runActivityLCIABatch (empty DatabaseManager)" $ do
         it "returns DatabaseNotLoaded when the requested DB is not loaded" $ do
-            dbm <- initDatabaseManager defaultConfig True Nothing
+            dbm <- initDatabaseManager defaultConfig True
             res <- runActivityLCIABatch dbm "no-such-db" "no-pid" "no-coll" Nothing IncludeLongTerm
             -- LCIABatchResult has no Show instance, so we pattern-match
             -- rather than rely on 'shouldBe' over the whole Either.
@@ -83,7 +83,7 @@ spec = do
 
     describe "runBatchImpacts (empty DatabaseManager)" $ do
         it "returns DatabaseNotLoaded when the requested DB is not loaded" $ do
-            dbm <- initDatabaseManager defaultConfig True Nothing
+            dbm <- initDatabaseManager defaultConfig True
             res <- runBatchImpacts dbm "no-such-db" "no-coll" Nothing IncludeLongTerm ["pidA", "pidB"]
             case res of
                 Left e -> e `shouldBe` DatabaseNotLoaded "no-such-db"

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -23,6 +23,7 @@ import Config (
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
+import System.FilePath (normalise)
 import qualified TOML
 import Test.Hspec
 
@@ -211,21 +212,23 @@ spec = do
                     resolved = resolveConfigPaths (Just "/etc/volca/volca.toml") cfg
                 -- A method path used to follow the process while the database
                 -- path beside it followed the file. They move together now.
-                map dcPath (cfgDatabases resolved) `shouldBe` ["/etc/volca/agb.CSV"]
-                map mcPath (cfgMethods resolved) `shouldBe` ["/etc/volca/ef.zip"]
-                map rdPath (cfgFlowSynonyms resolved) `shouldBe` ["/etc/volca/flows.csv"]
-                map rdPath (cfgCompartmentMappings resolved) `shouldBe` ["/etc/volca/compartments.csv"]
-                map rdPath (cfgUnits resolved) `shouldBe` ["/etc/volca/units.csv"]
-                map rdPath (cfgEnergyDensities resolved) `shouldBe` ["/etc/volca/energy.csv"]
-                cfgGeographies resolved `shouldBe` Just "/etc/volca/geographies.csv"
-                cfgChemSynonyms resolved `shouldBe` Just "/etc/volca/chem.csv"
-                cfgSubstanceEdges resolved `shouldBe` Just "/etc/volca/edges.csv"
+                -- Expected values go through 'normalise' too: on Windows the
+                -- resolver emits backslashes.
+                map dcPath (cfgDatabases resolved) `shouldBe` [normalise "/etc/volca/agb.CSV"]
+                map mcPath (cfgMethods resolved) `shouldBe` [normalise "/etc/volca/ef.zip"]
+                map rdPath (cfgFlowSynonyms resolved) `shouldBe` [normalise "/etc/volca/flows.csv"]
+                map rdPath (cfgCompartmentMappings resolved) `shouldBe` [normalise "/etc/volca/compartments.csv"]
+                map rdPath (cfgUnits resolved) `shouldBe` [normalise "/etc/volca/units.csv"]
+                map rdPath (cfgEnergyDensities resolved) `shouldBe` [normalise "/etc/volca/energy.csv"]
+                cfgGeographies resolved `shouldBe` Just (normalise "/etc/volca/geographies.csv")
+                cfgChemSynonyms resolved `shouldBe` Just (normalise "/etc/volca/chem.csv")
+                cfgSubstanceEdges resolved `shouldBe` Just (normalise "/etc/volca/edges.csv")
 
         it "leaves an absolute path alone" $
             withParsed $ \_ method -> do
                 let cfg = defaultConfig{cfgMethods = [method{mcPath = "/srv/methods/ef.zip"}]}
                 map mcPath (cfgMethods (resolveConfigPaths (Just "/etc/volca/volca.toml") cfg))
-                    `shouldBe` ["/srv/methods/ef.zip"]
+                    `shouldBe` [normalise "/srv/methods/ef.zip"]
 
         it "falls back to the process directory when there is no config file" $
             withParsed $ \_ method -> do
@@ -238,7 +241,7 @@ spec = do
             let cfg = defaultConfig{cfgFlowSynonyms = [mkRef "data/flows.csv"]}
                 bundled = applyDataDir (Just "/opt/volca/data") cfg
             map rdPath (cfgFlowSynonyms (resolveConfigPaths (Just "/etc/volca/volca.toml") bundled))
-                `shouldBe` ["/opt/volca/data/flows.csv"]
+                `shouldBe` [normalise "/opt/volca/data/flows.csv"]
 
     describe "loadConfigOrDefault" $ do
         it "yields the validated defaults when no path is given" $ do

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -7,6 +7,7 @@ import Config (
     ClassificationEntry (..),
     ClassificationPreset (..),
     Config (..),
+    DatabaseConfig (..),
     MethodConfig (..),
     MethodPatch (..),
     MethodPatchMatch (..),
@@ -17,6 +18,7 @@ import Config (
     expandClassificationPreset,
     loadConfigOrDefault,
     redirectIntoDataDir,
+    resolveConfigPaths,
  )
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
@@ -182,6 +184,61 @@ spec = do
 
         it "is a no-op when the env var is unset" $
             applyDataDir Nothing cfg `shouldBe` cfg
+
+    describe "resolveConfigPaths" $ do
+        let decodeDb t = TOML.decode t :: Either TOML.TOMLError DatabaseConfig
+            decodeMethod t = TOML.decode t :: Either TOML.TOMLError MethodConfig
+            withParsed body =
+                case (decodeDb "name = \"agb\"\npath = \"agb.CSV\"\n", decodeMethod "name = \"EF\"\npath = \"ef.zip\"\n") of
+                    (Right db, Right method) -> body db method
+                    (Left e, _) -> expectationFailure (show e)
+                    (_, Left e) -> expectationFailure (show e)
+
+        it "prefixes every relative path with the config file's directory" $
+            withParsed $ \db method -> do
+                let cfg =
+                        defaultConfig
+                            { cfgDatabases = [db]
+                            , cfgMethods = [method]
+                            , cfgFlowSynonyms = [mkRef "flows.csv"]
+                            , cfgCompartmentMappings = [mkRef "compartments.csv"]
+                            , cfgUnits = [mkRef "units.csv"]
+                            , cfgEnergyDensities = [mkRef "energy.csv"]
+                            , cfgGeographies = Just "geographies.csv"
+                            , cfgChemSynonyms = Just "chem.csv"
+                            , cfgSubstanceEdges = Just "edges.csv"
+                            }
+                    resolved = resolveConfigPaths (Just "/etc/volca/volca.toml") cfg
+                -- A method path used to follow the process while the database
+                -- path beside it followed the file. They move together now.
+                map dcPath (cfgDatabases resolved) `shouldBe` ["/etc/volca/agb.CSV"]
+                map mcPath (cfgMethods resolved) `shouldBe` ["/etc/volca/ef.zip"]
+                map rdPath (cfgFlowSynonyms resolved) `shouldBe` ["/etc/volca/flows.csv"]
+                map rdPath (cfgCompartmentMappings resolved) `shouldBe` ["/etc/volca/compartments.csv"]
+                map rdPath (cfgUnits resolved) `shouldBe` ["/etc/volca/units.csv"]
+                map rdPath (cfgEnergyDensities resolved) `shouldBe` ["/etc/volca/energy.csv"]
+                cfgGeographies resolved `shouldBe` Just "/etc/volca/geographies.csv"
+                cfgChemSynonyms resolved `shouldBe` Just "/etc/volca/chem.csv"
+                cfgSubstanceEdges resolved `shouldBe` Just "/etc/volca/edges.csv"
+
+        it "leaves an absolute path alone" $
+            withParsed $ \_ method -> do
+                let cfg = defaultConfig{cfgMethods = [method{mcPath = "/srv/methods/ef.zip"}]}
+                map mcPath (cfgMethods (resolveConfigPaths (Just "/etc/volca/volca.toml") cfg))
+                    `shouldBe` ["/srv/methods/ef.zip"]
+
+        it "falls back to the process directory when there is no config file" $
+            withParsed $ \_ method -> do
+                let cfg = defaultConfig{cfgMethods = [method]}
+                map mcPath (cfgMethods (resolveConfigPaths Nothing cfg)) `shouldBe` ["ef.zip"]
+
+        it "keeps the shipped data bundle applyDataDir already pointed at" $ do
+            -- applyDataDir runs first and turns "data/x" into an absolute path;
+            -- resolving after it must not prefix that a second time.
+            let cfg = defaultConfig{cfgFlowSynonyms = [mkRef "data/flows.csv"]}
+                bundled = applyDataDir (Just "/opt/volca/data") cfg
+            map rdPath (cfgFlowSynonyms (resolveConfigPaths (Just "/etc/volca/volca.toml") bundled))
+                `shouldBe` ["/opt/volca/data/flows.csv"]
 
     describe "loadConfigOrDefault" $ do
         it "yields the validated defaults when no path is given" $ do

--- a/test/CopySpec.hs
+++ b/test/CopySpec.hs
@@ -59,7 +59,7 @@ spec :: Spec
 -- directory of its own rather than writing into the tree it was run from.
 spec = around_ withScratchDataDir $ describe "Database.Edit copy primitive" $ do
     it "registers an independent copy under the new name" $ do
-        manager <- initDatabaseManager defaultConfig True Nothing
+        manager <- initDatabaseManager defaultConfig True
         srcDb <- buildOrFail (supplierDB 100 ["p1", "p2"])
         installLoaded manager "source" srcDb
 
@@ -80,7 +80,7 @@ spec = around_ withScratchDataDir $ describe "Database.Edit copy primitive" $ do
             `shouldBe` V.length (dbActivities srcDb)
 
     it "is a deep, independent value — dropping the copy does not touch the source" $ do
-        manager <- initDatabaseManager defaultConfig True Nothing
+        manager <- initDatabaseManager defaultConfig True
         srcDb <- buildOrFail (supplierDB 200 ["p1", "p2", "p3"])
         installLoaded manager "source" srcDb
         _ <- copyDatabase manager "source" "mycopy"
@@ -100,7 +100,7 @@ spec = around_ withScratchDataDir $ describe "Database.Edit copy primitive" $ do
         V.length (dbActivities (ldDatabase (after M.! "source"))) `shouldBe` srcCount
 
     it "is a deep, independent value — dropping the source leaves the copy intact" $ do
-        manager <- initDatabaseManager defaultConfig True Nothing
+        manager <- initDatabaseManager defaultConfig True
         srcDb <- buildOrFail (supplierDB 300 ["p1", "p2"])
         installLoaded manager "source" srcDb
         _ <- copyDatabase manager "source" "mycopy"
@@ -116,7 +116,7 @@ spec = around_ withScratchDataDir $ describe "Database.Edit copy primitive" $ do
         V.length (dbActivities (ldDatabase (after M.! "mycopy"))) `shouldBe` srcCount
 
     it "gives the copy its own solver — factorizing the source does not warm the copy's cache" $ do
-        manager <- initDatabaseManager defaultConfig True Nothing
+        manager <- initDatabaseManager defaultConfig True
         srcDb <- buildOrFail (supplierDB 700 ["p1", "p2"])
         installLoaded manager "source" srcDb
         _ <- copyDatabase manager "source" "mycopy"
@@ -134,7 +134,7 @@ spec = around_ withScratchDataDir $ describe "Database.Edit copy primitive" $ do
         getFactorization copySolver >>= (`shouldBe` True) . isNothing
 
     it "refuses to overwrite an existing database name" $ do
-        manager <- initDatabaseManager defaultConfig True Nothing
+        manager <- initDatabaseManager defaultConfig True
         srcDb <- buildOrFail (supplierDB 400 ["p1"])
         otherDb <- buildOrFail (supplierDB 500 ["q1"])
         installLoaded manager "source" srcDb
@@ -144,7 +144,7 @@ spec = around_ withScratchDataDir $ describe "Database.Edit copy primitive" $ do
         result `shouldBe` Left "Database already exists: taken"
 
     it "fails when the source is not loaded" $ do
-        manager <- initDatabaseManager defaultConfig True Nothing
+        manager <- initDatabaseManager defaultConfig True
         result <- copyDatabase manager "ghost" "mycopy"
         result `shouldBe` Left "Database not loaded: ghost"
 
@@ -152,7 +152,7 @@ spec = around_ withScratchDataDir $ describe "Database.Edit copy primitive" $ do
         -- The copy is registered as an uploaded database and later deleted by
         -- name via removeDirectoryRecursive, so the name must never carry a
         -- path separator or parent ref that could escape the uploads directory.
-        manager <- initDatabaseManager defaultConfig True Nothing
+        manager <- initDatabaseManager defaultConfig True
         srcDb <- buildOrFail (supplierDB 800 ["p1", "p2"])
         installLoaded manager "source" srcDb
         result <- copyDatabase manager "source" "../../etc/passwd"
@@ -163,7 +163,7 @@ spec = around_ withScratchDataDir $ describe "Database.Edit copy primitive" $ do
         copyNames `shouldSatisfy` all (\n -> not ("/" `isInfixOf` n) && not (".." `isInfixOf` n))
 
     it "rejects a copy name with no usable characters" $ do
-        manager <- initDatabaseManager defaultConfig True Nothing
+        manager <- initDatabaseManager defaultConfig True
         srcDb <- buildOrFail (supplierDB 900 ["p1", "p2"])
         installLoaded manager "source" srcDb
         result <- copyDatabase manager "source" "///"

--- a/test/DeleteSelectionSpec.hs
+++ b/test/DeleteSelectionSpec.hs
@@ -198,7 +198,7 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
 
     describe "deleteActivitiesInDB (filter-driven, in-place)" $ do
         it "deletes the whole filtered set and respects keep" $ do
-            manager <- initDatabaseManager defaultConfig True Nothing
+            manager <- initDatabaseManager defaultConfig True
             db <- buildOrFail (classifiedDB 600)
             installLoaded manager "edit-me" db
             -- Filter matches the two "food" activities; keep one by its
@@ -221,7 +221,7 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
                         `shouldSatisfy` elem "food-A"
 
         it "fails loudly on an unknown keep process id" $ do
-            manager <- initDatabaseManager defaultConfig True Nothing
+            manager <- initDatabaseManager defaultConfig True
             db <- buildOrFail (classifiedDB 700)
             installLoaded manager "edit-me-2" db
             r <-
@@ -234,7 +234,7 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
                 Right _ -> expectationFailure "expected unknown keep id to fail"
 
         it "fails when the database is not loaded" $ do
-            manager <- initDatabaseManager defaultConfig True Nothing
+            manager <- initDatabaseManager defaultConfig True
             r <- deleteActivitiesInDB manager "ghost" emptyDelete
             fmap doRemoved r `shouldBe` Left "Database not loaded: ghost"
 
@@ -242,7 +242,7 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
             -- Deleting from "base" would renumber/remove activities that the loaded
             -- "dependent" links to across databases; those links would then silently
             -- drop at solve time. The delete must be refused, mirroring unloadDatabase.
-            manager <- initDatabaseManager defaultConfig True Nothing
+            manager <- initDatabaseManager defaultConfig True
             base <- buildOrFail (classifiedDB 800)
             installLoaded manager "base" base
             dep <- buildOrFail (classifiedDB 900)
@@ -258,7 +258,7 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
 
     describe "deleteActivitiesInDB (delete exactly these ids)" $ do
         it "deletes exactly the listed process ids, no base filter" $ do
-            manager <- initDatabaseManager defaultConfig True Nothing
+            manager <- initDatabaseManager defaultConfig True
             db <- buildOrFail (classifiedDB 1000)
             installLoaded manager "by-ids" db
             let foodA = processIdToText db (pidFor2 db (mkUUID 1001) (mkUUID 1001))
@@ -274,7 +274,7 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
                         `shouldNotSatisfy` elem "food-A"
 
         it "refuses ids combined with a filter field" $ do
-            manager <- initDatabaseManager defaultConfig True Nothing
+            manager <- initDatabaseManager defaultConfig True
             db <- buildOrFail (classifiedDB 1100)
             installLoaded manager "by-ids-2" db
             let foodA = processIdToText db (pidFor2 db (mkUUID 1101) (mkUUID 1101))
@@ -288,7 +288,7 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
                 Right _ -> expectationFailure "expected ids+filter to be refused"
 
         it "fails loudly on an unknown id" $ do
-            manager <- initDatabaseManager defaultConfig True Nothing
+            manager <- initDatabaseManager defaultConfig True
             db <- buildOrFail (classifiedDB 1200)
             installLoaded manager "by-ids-3" db
             r <- deleteActivitiesInDB manager "by-ids-3" emptyDelete{drIds = Just ["not-a-real-process-id"]}
@@ -297,7 +297,7 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
                 Right _ -> expectationFailure "expected unknown id to fail"
 
         it "refuses ids combined with exact (it would silently do nothing)" $ do
-            manager <- initDatabaseManager defaultConfig True Nothing
+            manager <- initDatabaseManager defaultConfig True
             db <- buildOrFail (classifiedDB 1300)
             installLoaded manager "by-ids-4" db
             let foodA = processIdToText db (pidFor2 db (mkUUID 1301) (mkUUID 1301))
@@ -307,7 +307,7 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
                 Right _ -> expectationFailure "expected ids+exact to be refused"
 
         it "composes ids with keep and extra: (ids ∪ extra) \\ keep" $ do
-            manager <- initDatabaseManager defaultConfig True Nothing
+            manager <- initDatabaseManager defaultConfig True
             db <- buildOrFail (classifiedDB 1400)
             installLoaded manager "by-ids-5" db
             let foodA = processIdToText db (pidFor2 db (mkUUID 1401) (mkUUID 1401))
@@ -329,7 +329,7 @@ spec = describe "Database.Edit delete-by-selection primitive" $ do
         it "deletes only the extras when ids is the empty selection" $ do
             -- The official replacement for the old "unsatisfiable filter +
             -- extra" hack: an empty ids selection plus explicit extras.
-            manager <- initDatabaseManager defaultConfig True Nothing
+            manager <- initDatabaseManager defaultConfig True
             db <- buildOrFail (classifiedDB 1500)
             installLoaded manager "by-ids-6" db
             let foodA = processIdToText db (pidFor2 db (mkUUID 1501) (mkUUID 1501))

--- a/test/ExportHandlerSpec.hs
+++ b/test/ExportHandlerSpec.hs
@@ -27,7 +27,7 @@ pattern never forces it.
 -}
 runExport :: Text -> Text -> IO (Either ServerError (Headers '[Header "X-Volca-Export-Warnings" Text] BinaryContent))
 runExport dbName fmt = do
-    dbm <- initDatabaseManager defaultConfig True Nothing
+    dbm <- initDatabaseManager defaultConfig True
     let env =
             AppEnv
                 { aeDbManager = dbm

--- a/test/MCPDispatchSpec.hs
+++ b/test/MCPDispatchSpec.hs
@@ -80,7 +80,7 @@ isError _ = False
 
 call :: Text -> IO Value
 call name = do
-    manager <- initDatabaseManager defaultConfig True Nothing
+    manager <- initDatabaseManager defaultConfig True
     callTool manager [] Nothing Nothing Null name (KM.singleton "database" (String "no-such-db"))
 
 {- | Call the edit tool with one line named. An edit that names nothing is
@@ -89,7 +89,7 @@ test is actually about.
 -}
 callEdit :: IO Value
 callEdit = do
-    manager <- initDatabaseManager defaultConfig True Nothing
+    manager <- initDatabaseManager defaultConfig True
     callTool manager [] Nothing Nothing Null "edit_exchanges" $
         KM.fromList
             [ ("database", String "no-such-db")
@@ -207,7 +207,7 @@ spec = describe "MCP database load/unload tools" $ do
                     , cpFilters = [ClassificationEntry{ceSystem = "AGB", ceValue = "Agriculture", ceMode = "exact"}]
                     }
             callWithPreset name = do
-                manager <- initDatabaseManager defaultConfig True Nothing
+                manager <- initDatabaseManager defaultConfig True
                 callTool manager [configured] Nothing Nothing Null name $
                     KM.fromList
                         [ ("database", String "no-such-db")
@@ -247,7 +247,7 @@ spec = describe "MCP database load/unload tools" $ do
                         , dcGeographyPolicy = GeoGlobal
                         }
                 callOnSample name presetArgs = do
-                    manager <- initDatabaseManager defaultConfig True Nothing
+                    manager <- initDatabaseManager defaultConfig True
                     addDatabase manager sampleConfig
                     loadDatabase manager "sample" >>= either (expectationFailure . T.unpack) (const (pure ()))
                     callTool manager [configured] Nothing Nothing Null name $

--- a/test/MethodCollectionCacheSpec.hs
+++ b/test/MethodCollectionCacheSpec.hs
@@ -83,7 +83,7 @@ spec :: Spec
 spec = do
     describe "mapMethodToTablesCached (collection-scoped cache)" $ do
         it "returns per-collection CF tables for same-UUID methods (A then B)" $ do
-            mgr <- DM.initDatabaseManager defaultConfig False Nothing
+            mgr <- DM.initDatabaseManager defaultConfig False
             let db = mkDB 0 ["FR"] []
             tablesA <- DM.mapMethodToTablesCached mgr "db" collectionA db (mkFossilsMethod cfA)
             tablesB <- DM.mapMethodToTablesCached mgr "db" collectionB db (mkFossilsMethod cfB)
@@ -91,7 +91,7 @@ spec = do
             fmap teCF (M.lookup flowUUID (mtUuidCF tablesB)) `shouldBe` Just (CF cfB (CFUnit "MJ"))
 
         it "returns per-collection CF tables for same-UUID methods (B then A)" $ do
-            mgr <- DM.initDatabaseManager defaultConfig False Nothing
+            mgr <- DM.initDatabaseManager defaultConfig False
             let db = mkDB 0 ["FR"] []
             tablesB <- DM.mapMethodToTablesCached mgr "db" collectionB db (mkFossilsMethod cfB)
             tablesA <- DM.mapMethodToTablesCached mgr "db" collectionA db (mkFossilsMethod cfA)

--- a/test/PersistenceSpec.hs
+++ b/test/PersistenceSpec.hs
@@ -160,7 +160,7 @@ spec = describe "persisting an edit" $ do
     describe "a database the engine only reads" $ do
         it "says the edit is not saved, and is given no home" $
             withDataDir $ \dataRoot -> do
-                manager <- initDatabaseManager defaultConfig True Nothing
+                manager <- initDatabaseManager defaultConfig True
                 db <- buildTwoActivityFixture
                 install manager "configured" db (configuredConfig "configured")
                 r <- mutateUploadedDatabase manager "configured" dropSecond
@@ -175,7 +175,7 @@ spec = describe "persisting an edit" $ do
     describe "refusals that protect the value" $ do
         it "refuses a second edit while one is in progress" $
             withDataDir $ \_ -> do
-                manager <- initDatabaseManager defaultConfig True Nothing
+                manager <- initDatabaseManager defaultConfig True
                 db <- buildTwoActivityFixture
                 install manager "busy" db (configuredConfig "busy")
                 atomically $ modifyTVar' (dmStagingDbs manager) (Set.insert "busy")
@@ -184,7 +184,7 @@ spec = describe "persisting an edit" $ do
 
         it "refuses while another loaded database depends on this one" $
             withDataDir $ \_ -> do
-                manager <- initDatabaseManager defaultConfig True Nothing
+                manager <- initDatabaseManager defaultConfig True
                 db <- buildTwoActivityFixture
                 install manager "background" db (configuredConfig "background")
                 install manager "foreground" db{dbDependsOn = ["background"]} (configuredConfig "foreground")
@@ -222,7 +222,7 @@ withEcoSpold1Database act =
         createDirectoryIfMissing True dataDir
         TIO.writeFile (dataDir </> "process_" <> T.unpack (UUID.toText (mkUUID 101)) <> ".xml") (dataset 1 "electricity production, wind")
         TIO.writeFile (dataDir </> "process_" <> T.unpack (UUID.toText (mkUUID 102)) <> ".xml") (dataset 2 "electricity production, solar")
-        manager <- initDatabaseManager defaultConfig False Nothing
+        manager <- initDatabaseManager defaultConfig False
         addDatabase manager (uploadedConfig "bafu-like" dataDir)
         loaded <- loadDatabase manager "bafu-like"
         case loaded of

--- a/test/ReadOnlySpec.hs
+++ b/test/ReadOnlySpec.hs
@@ -64,7 +64,7 @@ hosting ro =
 -- | Build an environment whose only interesting knob is the hosting stance.
 envWith :: Maybe HostingConfig -> IO AppEnv
 envWith hc = do
-    manager <- initDatabaseManager defaultConfig True Nothing
+    manager <- initDatabaseManager defaultConfig True
     pure
         AppEnv
             { aeDbManager = manager
@@ -169,7 +169,7 @@ spec = do
 
     describe "MCP tools under read_only" $ do
         it "refuse the state-changing tools" $ do
-            manager <- initDatabaseManager defaultConfig True Nothing
+            manager <- initDatabaseManager defaultConfig True
             let call name =
                     callTool manager [] (Just (hosting True)) Nothing Null name $
                         KM.singleton "database" (String "nope")
@@ -179,7 +179,7 @@ spec = do
             isToolError unloadResp `shouldBe` True
 
         it "still answer a read-only tool" $ do
-            manager <- initDatabaseManager defaultConfig True Nothing
+            manager <- initDatabaseManager defaultConfig True
             listed <- callTool manager [] (Just (hosting True)) Nothing Null "list_databases" KM.empty
             isToolError listed `shouldBe` False
 

--- a/test/SetupInfoSpec.hs
+++ b/test/SetupInfoSpec.hs
@@ -154,7 +154,7 @@ installLoaded manager name db = do
 -- | A fresh manager with @db@ installed as a loaded database named "test".
 managerWithLoaded :: Database -> IO DatabaseManager
 managerWithLoaded db = do
-    manager <- initDatabaseManager defaultConfig True Nothing
+    manager <- initDatabaseManager defaultConfig True
     installLoaded manager "test" db
     pure manager
 
@@ -291,7 +291,7 @@ spec = do
                 Right loaded -> dcName (ldConfig loaded) `shouldBe` "test"
 
         it "answers not-loaded for a configured database that was never loaded" $ do
-            manager <- initDatabaseManager defaultConfig True Nothing
+            manager <- initDatabaseManager defaultConfig True
             let config = stubConfig{dcName = "cfg", dcDisplayName = "cfg"}
             atomically $ modifyTVar' (dmAvailableDbs manager) (M.insert "cfg" config)
             result <- getDatabaseSetupInfo manager "cfg"

--- a/test/StrictPinSpec.hs
+++ b/test/StrictPinSpec.hs
@@ -68,7 +68,7 @@ spec = describe "relinkDatabase strict dependency pin" $ do
             -- Pin the consumer to alpha only, with no links yet — relink populates them.
             let consumerDb = consumerDb0{dbDependsOn = ["alpha"], dbCrossDBLinks = []}
 
-            manager <- initDatabaseManager defaultConfig True Nothing
+            manager <- initDatabaseManager defaultConfig True
             solver <- mkSolver "consumer" consumerDb
             let consumerLoaded =
                     LoadedDatabase
@@ -105,7 +105,7 @@ spec = describe "relinkDatabase strict dependency pin" $ do
             consumerDb0 <- buildOrFail (consumerDB 300 ["p1", "p2"])
             let consumerDb = consumerDb0{dbDependsOn = ["alpha", "beta"], dbCrossDBLinks = []}
 
-            manager <- initDatabaseManager defaultConfig True Nothing
+            manager <- initDatabaseManager defaultConfig True
             consumerSolver <- mkSolver "consumer" consumerDb
             alphaSolver <- mkSolver "alpha" alphaDb
             betaSolver <- mkSolver "beta" betaDb

--- a/test/UploadQuotaSpec.hs
+++ b/test/UploadQuotaSpec.hs
@@ -114,7 +114,7 @@ spec = describe "hosting database quotas" $ do
 
     describe "the MCP door" $
         it "refuses load_database by the same budget as REST" $ do
-            manager <- initDatabaseManager defaultConfig True Nothing
+            manager <- initDatabaseManager defaultConfig True
             atomically $ modifyTVar' (dmAvailableDbs manager) (M.insert "mine" (uploadedEntry "mine"))
             resp <-
                 callTool manager [] (Just (plan 1 0)) Nothing Null "load_database" $


### PR DESCRIPTION
A configuration file could not be moved. Half of its paths were read next to
the file, half next to wherever the engine was started from, so the only way to
make one work reliably was to write it absolute, and an absolute path describes
one machine.

Which key did which:

| follows the file | follows the process |
|---|---|
| `[[databases]]`, `[[flow-synonyms]]`, `[[compartment-mappings]]`, `[[units]]`, `[[energy-densities]]`, `geographies` | `[[methods]]`, `chem_synonyms`, `substance_edges` |

Nothing justified the split. It came from resolution being written at each use
site in `initDatabaseManager`, six of them, and three fields never got one.

Now there is one pure `resolveConfigPaths` on `Config`, applied once, and the
six sites are gone. Every path-bearing field is named in that function and
nowhere else, so the next field added is hard to forget. Absolute paths are
left alone.

## The ordering that had to be pinned

`applyDataDir` is what recognises a leading `data/` as the data bundle shipped
with the engine. Resolving paths before it would prefix that `data/` with a
directory and hide it, silently sending the engine to look for its own
reference data somewhere it has never been. `applyDataDir` runs when the file
is parsed and this runs at initialisation, so the order is right, but nothing
said so. A test now does.

## Effect on an existing configuration

Pre-1.0, and the change is in the direction of the documented behaviour rather
than away from it. A configuration whose method path was relative and which
only worked when launched from one directory will now resolve that path next to
the file, like its database paths always did. Absolute paths, which is what
most files ended up using precisely because of this bug, are unaffected.

Full suite: 2132 examples, 0 failures.