### PR TITLE
Emit web_url deep links behind a reverse proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+- Assistant answers now carry their `web_url` deep links when the engine runs
+  behind a reverse proxy that serves the web interface upstream. The proxy
+  declares itself with the standard `X-Forwarded-Prefix` header; the links then
+  carry that prefix and the forwarded protocol. Before, an engine running
+  without a bundled frontend emitted no links at all, even when a proxy in
+  front of it served those very pages.
+
 ## [0.9.5] - 2026-08-04
 
 ### Added

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -16,7 +16,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import Data.IORef
 import qualified Data.Map as M
-import Data.Maybe (fromMaybe, isNothing, mapMaybe)
+import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
@@ -135,14 +135,19 @@ Two ways a frontend can exist: bundled with this process, answering on the
 request's own host; or upstream, behind a reverse proxy that says so by
 setting @X-Forwarded-Prefix@ - the prefix it serves this engine under, which
 then belongs in every link, along with the forwarded protocol.
+
+The header's presence is the declaration, not its value: a proxy serving the
+routes at the root says @X-Forwarded-Prefix: /@. Trailing slashes are dropped
+because every link path starts with its own.
 -}
 webUrlBase :: Bool -> RequestHeaders -> Maybe Text
 webUrlBase hasFrontend hdrs
-    | hasFrontend || prefix /= "" = Just (proto <> "://" <> host <> prefix)
+    | hasFrontend || isJust mPrefix = Just (proto <> "://" <> host <> prefix)
     | otherwise = Nothing
   where
     header n = maybe "" TE.decodeUtf8Lenient (lookup n hdrs)
-    prefix = header "X-Forwarded-Prefix"
+    mPrefix = TE.decodeUtf8Lenient <$> lookup "X-Forwarded-Prefix" hdrs
+    prefix = maybe "" (T.dropWhileEnd (== '/')) mPrefix
     proto = case header "X-Forwarded-Proto" of
         "" -> "http"
         p -> p

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -5,7 +5,7 @@ Implements Streamable HTTP transport (MCP spec 2025-03-26).
 POST /mcp handles initialize, tools/list, tools/call (JSON or SSE response).
 GET  /mcp opens an SSE stream for server-initiated messages (stateless: closes immediately).
 -}
-module API.MCP (mcpApp, mcpCountsAsActivity, toolDefinitions, callTool, selectMethod, handleInitialize, RpcRequest (..)) where
+module API.MCP (mcpApp, mcpCountsAsActivity, toolDefinitions, callTool, selectMethod, handleInitialize, webUrlBase, RpcRequest (..)) where
 
 import Control.Concurrent.STM (readTVarIO)
 import Data.Aeson
@@ -49,7 +49,7 @@ import qualified Method.Explain as Explain
 import Method.Mapping (LCIAOutcome (..), MappingStats (..), SimilarCF (..), SimilarReason (..), UncharacterizedFlow (..), applyLongTermMode, computeLCIAScoreAuto, computeLCIAScoreFromTables, computeMappingStats, defaultUncharacterizedOpts, inventoryContributions, longTermModeFromExclude)
 import qualified Method.Mapping as Mapping
 import Method.Types (FlowDirection (..), Method (..), MethodCF (..), MethodCollection (..), ScoringSet (..))
-import Network.HTTP.Types.Header (hAccept, hHost)
+import Network.HTTP.Types.Header (RequestHeaders, hAccept, hHost)
 import Numeric (showFFloat)
 import Progress (ProgressLevel (Warning), reportProgress)
 import qualified Service
@@ -128,6 +128,28 @@ not anyone is working. Only @tools\/call@ is someone asking a question.
 mcpCountsAsActivity :: Text -> Bool
 mcpCountsAsActivity = (== "tools/call")
 
+{- | The absolute base for @web_url@ deep links, or 'Nothing' when no
+frontend serves those routes and the links would point at a 404.
+
+Two ways a frontend can exist: bundled with this process, answering on the
+request's own host; or upstream, behind a reverse proxy that says so by
+setting @X-Forwarded-Prefix@ - the prefix it serves this engine under, which
+then belongs in every link, along with the forwarded protocol.
+-}
+webUrlBase :: Bool -> RequestHeaders -> Maybe Text
+webUrlBase hasFrontend hdrs
+    | hasFrontend || prefix /= "" = Just (proto <> "://" <> host <> prefix)
+    | otherwise = Nothing
+  where
+    header n = maybe "" TE.decodeUtf8Lenient (lookup n hdrs)
+    prefix = header "X-Forwarded-Prefix"
+    proto = case header "X-Forwarded-Proto" of
+        "" -> "http"
+        p -> p
+    host = case header hHost of
+        "" -> "localhost"
+        h -> h
+
 {- | Build the @\/mcp@ endpoint.
 
 @markActivity@ is called for every request that 'mcpCountsAsActivity' accepts.
@@ -143,13 +165,7 @@ mcpApp dbManager presets hasFrontend mHosting mName markActivity = do
     return $ \req respond -> do
         let method = requestMethod req
             hdrs = requestHeaders req
-            hostHeader = fromMaybe "localhost" $ lookup hHost hdrs
-            -- Only emit 'web_url' when the SPA is bundled to serve those
-            -- routes; otherwise the link would point at a 404.
-            mBaseUrl =
-                if hasFrontend
-                    then Just ("http://" <> TE.decodeUtf8 hostHeader)
-                    else Nothing
+            mBaseUrl = webUrlBase hasFrontend hdrs
             acceptHdr = fromMaybe "" $ lookup hAccept hdrs
             wantsSse = "text/event-stream" `BS.isInfixOf` acceptHdr
         st <- readIORef stateRef

--- a/test/MCPDispatchSpec.hs
+++ b/test/MCPDispatchSpec.hs
@@ -20,7 +20,7 @@ import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
 import Test.Hspec
 
-import API.MCP (RpcRequest (..), callTool, handleInitialize, mcpCountsAsActivity, toolDefinitions)
+import API.MCP (RpcRequest (..), callTool, handleInitialize, mcpCountsAsActivity, toolDefinitions, webUrlBase)
 import Config (ClassificationEntry (..), ClassificationPreset (..), DatabaseConfig (..), ReadOnly (..), ServerName (..), defaultConfig)
 import Database.Manager (addDatabase, initDatabaseManager, loadDatabase)
 import Types (GeographyPolicy (..))
@@ -282,6 +282,24 @@ spec = describe "MCP database load/unload tools" $ do
 
         it "refuses an unknown method" $
             mcpCountsAsActivity "no/such/method" `shouldBe` False
+
+    -- web_url deep links must point where a frontend actually answers: on
+    -- this host when one is bundled, behind the reverse proxy's declared
+    -- prefix when one serves the routes upstream, nowhere otherwise.
+    describe "webUrlBase" $ do
+        it "stays silent with no frontend and no proxy" $
+            webUrlBase False [("Host", "box:8080")] `shouldBe` Nothing
+
+        it "answers on the request's own host when a frontend is bundled" $
+            webUrlBase True [("Host", "box:8080")] `shouldBe` Just "http://box:8080"
+
+        it "reads X-Forwarded-Prefix as proof of an upstream frontend" $
+            webUrlBase False [("Host", "example.org"), ("X-Forwarded-Prefix", "/@ada/lab"), ("X-Forwarded-Proto", "https")]
+                `shouldBe` Just "https://example.org/@ada/lab"
+
+        it "carries the prefix even when a frontend is also bundled" $
+            webUrlBase True [("Host", "example.org"), ("X-Forwarded-Prefix", "/@ada/lab")]
+                `shouldBe` Just "http://example.org/@ada/lab"
 
     -- A client may hold several VoLCA servers at once, one per instance. The
     -- name is the only thing that tells them apart, and it has to reach the

--- a/test/MCPDispatchSpec.hs
+++ b/test/MCPDispatchSpec.hs
@@ -301,6 +301,18 @@ spec = describe "MCP database load/unload tools" $ do
             webUrlBase True [("Host", "example.org"), ("X-Forwarded-Prefix", "/@ada/lab")]
                 `shouldBe` Just "http://example.org/@ada/lab"
 
+        it "reads a root prefix as an upstream frontend with no prefix to carry" $
+            webUrlBase False [("Host", "example.org"), ("X-Forwarded-Prefix", "/"), ("X-Forwarded-Proto", "https")]
+                `shouldBe` Just "https://example.org"
+
+        it "drops a trailing slash so link paths supply their own" $
+            webUrlBase False [("Host", "example.org"), ("X-Forwarded-Prefix", "/@ada/lab/")]
+                `shouldBe` Just "http://example.org/@ada/lab"
+
+        it "honours the forwarded protocol for a bundled frontend too" $
+            webUrlBase True [("Host", "example.org"), ("X-Forwarded-Proto", "https")]
+                `shouldBe` Just "https://example.org"
+
     -- A client may hold several VoLCA servers at once, one per instance. The
     -- name is the only thing that tells them apart, and it has to reach the
     -- assistant, not just the client's server list.


### PR DESCRIPTION
The base for `web_url` deep links only existed when a frontend was bundled with the engine process, so an engine proxied behind a frontend served upstream emitted no links at all. And the links a bundled frontend produced always said `http://`, whatever the visitor actually used.

The engine now reads the standard `X-Forwarded-Prefix` header as the reverse proxy's declaration that it serves the web routes upstream, under that prefix: the links then carry the prefix, and `X-Forwarded-Proto` fixes the scheme. Nothing changes for a bundled frontend without a proxy, and an engine with neither still emits no links.

The base construction moves into `webUrlBase`, pure and covered by four specs.