### PR TITLE
Write multi-line descriptions the way SimaPro writes them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Fixed
+- A database read from a SimaPro export can be written back out as one. Long
+  descriptions run to several paragraphs, and the export held them on a single
+  line with SimaPro's own in-cell line break. Reading one turned that break
+  back into a real newline, and the writer then refused the whole database
+  because of it, so no such database could be exported at all. Descriptions are
+  now written the way SimaPro writes them, and the paragraph breaks survive the
+  round trip instead of being flattened to spaces. A line break in a name or a
+  geography is still refused: there it means nothing and would tear the row
+  apart on re-import.
+
 ### Changed
 - Assistant answers now carry their `web_url` deep links when the engine runs
   behind a reverse proxy that serves the web interface upstream. The proxy

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -56,7 +56,10 @@ databases imported from /other/ formats are dropped — always score-preserving
     emissions are unaffected;
   * multi-paragraph descriptions are joined into the single physical @Comment@
     line with @\\x7f@ separators, so the re-parse reads one description entry
-    holding the paragraph breaks rather than the original list.
+    holding the paragraph breaks rather than the original list. A description
+    that already /contains/ a literal @\\x7f@ re-parses with that character read
+    as a line break, since the format reserves it for exactly that; no SimaPro
+    parse can produce one, so this only reaches a cross-format import.
 
 Anything the format /cannot/ represent without silently corrupting the data on
 re-import (non-finite amounts, a zero allocation, a missing unit, newlines in an

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -54,13 +54,15 @@ databases imported from /other/ formats are dropped — always score-preserving
     generated UUID), so it is the one lossy case that can affect characterisation
     for a cross-format export; air/water/soil media and all SimaPro-origin
     emissions are unaffected;
-  * multi-paragraph descriptions are joined into the single-line @Comment@ field.
+  * multi-paragraph descriptions are joined into the single physical @Comment@
+    line with @\\x7f@ separators, so the re-parse reads one description entry
+    holding the paragraph breaks rather than the original list.
 
 Anything the format /cannot/ represent without silently corrupting the data on
-re-import (non-finite amounts, a zero allocation, a missing unit, newlines in a
-field, a pedigree-shaped comment, a metadata-key collision, an activity without
-exactly one reference product) is rejected outright by 'checkSimaProExportable'
-rather than written lossily.
+re-import (non-finite amounts, a zero allocation, a missing unit, newlines in an
+identity field, a pedigree-shaped comment, a metadata-key collision, an activity
+without exactly one reference product) is rejected outright by
+'checkSimaProExportable' rather than written lossily.
 -}
 module SimaPro.Writer (
     WriterConfig (..),
@@ -128,13 +130,16 @@ Amounts must also be finite: a NaN or ±Infinity has no parseable literal, so
 inventory. Report it here instead. This is the export-boundary check;
 'serializeSimaProCSV' itself stays pure and total.
 
-Names and metadata values must also be free of newline characters.
-'escapeField' RFC-4180-quotes them, but the parser splits the file on physical
-lines ('BS8.lines') /before/ CSV parsing, so an embedded @\\n@ or @\\r@ tears
-the row apart and corrupts or drops it. Reject such fields rather than emit a
-row the parser cannot read back. Exchange comments are the exception:
-'renderComment' encodes their line breaks as @\\x7f@, SimaPro's in-cell
-newline, so they round-trip instead of being rejected.
+Identity fields must also be free of newline characters. 'escapeField'
+RFC-4180-quotes them, but the parser splits the file on physical lines
+('BS8.lines') /before/ CSV parsing, so an embedded @\\n@ or @\\r@ tears the row
+apart and corrupts or drops it. Reject such fields rather than emit a row the
+parser cannot read back. Free text is the exception, and never reaches this
+guard: 'encodeNewlines' turns its line breaks into @\\x7f@, SimaPro's in-cell
+newline, before they are written, so descriptions and exchange comments
+round-trip instead of being rejected. That distinction is the whole rule: a line
+break carries meaning in prose and none in a name, and a @\\x7f@ in a name would
+poison the matching a re-import does on it.
 
 Two more round-trip hazards are specific to SimaPro's textual layout, and bite
 only for databases imported from other formats (a SimaPro parse can't produce
@@ -308,10 +313,10 @@ checkSimaProExportable db =
     -- Every text field that lands in the output verbatim: the bare metadata
     -- value lines (so a newline in any of them — the Type label included — is
     -- caught), the "Category" product-column value, and all flow names.
-    -- Exchange comments are exempt: 'renderComment' encodes their newlines as
-    -- \x7f, SimaPro's in-cell line break. The line-based parser splits on
-    -- physical newlines /before/ CSV parsing, so even a quoted newline tears
-    -- a row apart; reject upstream.
+    -- Free text never offends: 'activityMetaLines' and 'renderComment' both
+    -- run 'encodeNewlines' over it first, so what this sees is already
+    -- \x7f-encoded. The line-based parser splits on physical newlines /before/
+    -- CSV parsing, so even a quoted newline tears a row apart; reject upstream.
     activityTexts act =
         map snd (activityMetaLines act)
             ++ M.elems (activityClassification act)
@@ -449,12 +454,12 @@ values are dropped on emission by 'serializeActivity'’s @meta@, but kept here 
 the guards still inspect exactly what /would/ be written.
 
 The "Category" classification value is intentionally absent: it rides the
-@Products@ row's category column, not a bare metadata line. Multi-paragraph
-descriptions are flattened to one space-joined "Comment" line; the re-parse
-reads them back as a single description entry, losing the paragraph boundaries —
-an accepted limitation of SimaPro's single-line "Comment" field. A missing
-native type yields an empty "Type" value, so @meta@ omits the line and a
-re-parse yields 'Nothing' again rather than drifting to "Unit process".
+@Products@ row's category column, not a bare metadata line. The description is
+joined and 'encodeNewlines'-encoded, so paragraph breaks survive as @\\x7f@ on
+the one physical "Comment" line the format allows; the re-parse decodes them
+back into a single description entry carrying the breaks. A missing native type
+yields an empty "Type" value, so @meta@ omits the line and a re-parse yields
+'Nothing' again rather than drifting to "Unit process".
 -}
 activityMetaLines :: Activity -> [(Text, Text)]
 activityMetaLines Activity{..} =
@@ -462,18 +467,29 @@ activityMetaLines Activity{..} =
     , ("Process name", activityName)
     , ("Type", typeLabelOf activityNativeType)
     , ("Geography", activityLocation)
-    , ("Comment", T.intercalate " " activityDescription)
+    , ("Comment", encodeNewlines (T.intercalate "\n" activityDescription))
     ]
 
+{- | Encode line breaks as @\\x7f@ (DEL), SimaPro's in-cell newline, after
+normalising CRLF and lone CR to LF. This is how the format itself carries
+multi-line free text: the row stays one physical line, and the parser decodes
+@\\x7f@ back to a newline ('SimaPro.Parser.nonEmptyText'), so the text
+round-trips instead of tearing the row apart.
+
+Every free-text field the writer emits goes through this. Identity fields
+(names, geography, type, classification) do not: a line break there is rejected
+by 'checkSimaProExportable' rather than encoded, because it carries no meaning
+worth keeping and a @\\x7f@ would poison the name a re-import matches on.
+-}
+encodeNewlines :: Text -> Text
+encodeNewlines = T.replace "\n" "\x7f" . T.replace "\r" "\n" . T.replace "\r\n" "\n"
+
 {- | Render the comment column, re-attaching a pedigree prefix when present.
-Line breaks are encoded as @\\x7f@ (DEL), SimaPro's in-cell newline — the
-line-based format cannot hold a literal newline (see 'checkSimaProExportable'),
-and the parser decodes @\\x7f@ back, so multi-line comments round-trip.
+Line breaks are 'encodeNewlines'-encoded, so multi-line comments round-trip.
 -}
 renderComment :: Maybe Pedigree -> Maybe Text -> Text
 renderComment ped cmt =
     let pedTxt = maybe "" renderPedigree ped
-        encodeNewlines = T.replace "\n" "\x7f" . T.replace "\r" "\n" . T.replace "\r\n" "\n"
         cmtTxt = encodeNewlines (fromMaybe "" cmt)
      in case (pedTxt, cmtTxt) of
             ("", c) -> c

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -76,6 +76,11 @@ fixtureCSV =
         , "Geography"
         , "FR"
         , ""
+        , "Comment"
+        , -- Multi-line free text the way SimaPro writes it: one physical line,
+          -- \x7f standing in for the newline.
+          "Churned in a batch churn.\x7f\&Milk comes from the same farm."
+        , ""
         , "Products"
         , "Butter;kg;1;100;not defined;material;(2,1,1,1,1),churned on site\x7f\&from pasture milk"
         , ""
@@ -404,6 +409,11 @@ spec = describe "SimaPro.Writer round-trip" $ do
         -- writer's \n → \x7f re-encoding as well.
         map exchangeComment origExchanges `shouldSatisfy` elem (Just "churned on site\nfrom pasture milk")
         map exchangePedigree origExchanges `shouldSatisfy` elem (Just (Pedigree 2 1 1 1 1))
+        -- Same again for the activity description, the other multi-line free
+        -- text field. It reaches the writer holding a \n, and only survives
+        -- because the Comment metadata line is \x7f-encoded on the way out.
+        map activityDescription (activitiesOf original)
+            `shouldSatisfy` elem ["Churned in a batch churn.\nMilk comes from the same farm."]
 
     it "(c) score-equivalence: same inventory for a sample activity within tolerance" $ do
         original <- parseBytes fixtureCSV
@@ -519,6 +529,17 @@ spec = describe "SimaPro.Writer round-trip" $ do
             -- (it is derived from the same 'activityMetaLines' as the emitter).
             checkSimaProExportable (guardDb Nothing (Just (SimaProProcessType "Unit\nprocess")) [refProd])
                 `shouldSatisfy` isLeft
+
+        it "accepts a multi-paragraph description and encodes it as \\x7f" $ do
+            -- Free text is not an identity field: a line break there carries
+            -- meaning, and SimaPro's own convention holds it on one physical
+            -- line as \x7f. Refusing it would make every database that came
+            -- from a SimaPro export inexportable, since the parser decodes
+            -- \x7f to \n on the way in.
+            let db = describedDb ["First paragraph.\nStill the first.", "Second paragraph."]
+            checkSimaProExportable db `shouldBe` Right ()
+            out <- serBytes db
+            out `shouldSatisfy` BS.isInfixOf "First paragraph.\x7fStill the first.\x7fSecond paragraph."
 
         it "rejects an activity with no reference product" $
             -- An empty Products section makes the parser discard the whole block.
@@ -830,3 +851,9 @@ guardDb alloc ntype exs =
   where
     act =
         Activity "guard maker" [] M.empty M.empty "GLO" LocationDeclared "kg" exs M.empty M.empty alloc Nothing ntype Nothing Nothing
+
+-- | The baseline guard fixture, carrying the given description paragraphs.
+describedDb :: [Text] -> SimpleDatabase
+describedDb paragraphs =
+    let db = guardDb Nothing Nothing [refProd]
+     in db{sdbActivities = M.map (\a -> a{activityDescription = paragraphs}) (sdbActivities db)}


### PR DESCRIPTION
## Why

No database that came from a SimaPro export could be exported back to SimaPro.

The export guard refused any field containing a newline, reasoning that the parser splits the file on physical lines before it does any CSV parsing, so an embedded break would tear the row apart. That is right for a name. It was wrong for free text, and the newline it refused was one the engine had produced itself: SimaPro keeps a multi-line comment on a single physical line, using `\x7f` where the break goes, and the parser decodes that to a real newline on the way in. The writer then rejected the whole database because of it.

Agribalyse 4.0 carries 21 559 such comments. So did every other SimaPro-origin database.

## What changed

Descriptions are encoded back to `\x7f` on the way out, which the writer already did for exchange comments. `encodeNewlines` moves up to the top level and both callers share it.

The guard itself is untouched and still refuses a newline in an identity field, where a break carries no meaning and a `\x7f` would poison the name a re-import matches on. Free text simply no longer reaches it.

A side effect worth naming: paragraph breaks now survive. They were being flattened to spaces, and the haddock called that an accepted limitation. It was only acceptable while nothing could be exported at all.

## Verification

The unit fixture gained a `Comment` block holding a `\x7f`, so the three existing round-trip properties (idempotence, semantic equality, score equivalence) now cover this path, plus a guard spec pinning that a multi-paragraph description is accepted and written encoded. Full suite: 2140 examples, 0 failures.

End to end on the real Agribalyse 4.0 (661 MB, 22 822 processes):

- before, `POST /db/{db}/export` answered 400
- now it writes 634 MB
- re-loading that output yields the same 22 822 processes under the same names
- 401 sampled descriptions come back identical, 274 of them carrying a newline

## Out of scope

Two parser defects surfaced while measuring this and belong in their own issues: records whose cells use bare LF as the in-cell break are split by the line scan, and a quoted `Comment` value keeps its literal quotes in the description.