### PR TITLE
Refuse duplicate classification preset and method collection names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@
   apart on re-import.
 
 ### Changed
+- Startup now refuses a configuration in which two classification presets or
+  two method collections share a name, the same way it already refused two
+  databases sharing one. Both are looked up by name, so the duplicate would
+  have silently shadowed one of its bearers; the error names the offenders
+  instead.
 - Every download now includes `THIRD-PARTY-LICENSES.md`, naming the numerical
   libraries built into the program and their terms. The Windows zip also
   carries the full licence texts of the runtime libraries beside it.

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -28,6 +28,7 @@ module Config (
     loadConfig,
     loadConfigFile,
     loadConfigOrDefault,
+    validateConfig,
 
     -- * VOLCA_DATA_DIR resolution
     redirectIntoDataDir,
@@ -589,6 +590,18 @@ validateConfig cfg = do
     unless (null duplicates) $
         Left $
             "Duplicate database names: " <> T.intercalate ", " duplicates
+
+    -- A duplicate name would silently shadow one of its bearers everywhere the
+    -- name is the key (preset expansion, method lookup), so refuse it up front.
+    let presetDupes = findDuplicates (map cpName (cfgClassificationPresets cfg))
+    unless (null presetDupes) $
+        Left $
+            "Duplicate classification preset names: " <> T.intercalate ", " presetDupes
+
+    let methodDupes = findDuplicates (map mcName (cfgMethods cfg))
+    unless (null methodDupes) $
+        Left $
+            "Duplicate method collection names: " <> T.intercalate ", " methodDupes
 
     -- Check that at most one database is marked as default
     let defaultDbs = filter dcDefault (cfgDatabases cfg)

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -20,7 +20,9 @@ import Config (
     loadConfigOrDefault,
     redirectIntoDataDir,
     resolveConfigPaths,
+    validateConfig,
  )
+import Data.Either (isRight)
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -85,6 +87,45 @@ spec = do
             case decodeHosting "read_only = true\n" of
                 Right hc -> hcReadOnlyMessage hc `shouldBe` ""
                 Left e -> expectationFailure (show e)
+
+    describe "validateConfig" $ do
+        let preset name =
+                ClassificationPreset
+                    { cpName = name
+                    , cpLabel = name
+                    , cpDescription = Nothing
+                    , cpFilters = []
+                    }
+            decodeMethod t = TOML.decode t :: Either TOML.TOMLError MethodConfig
+
+        -- Presets and methods are looked up by name, so a duplicate would
+        -- silently shadow one of its bearers; startup refuses it instead.
+        it "refuses two classification presets sharing a name" $
+            case validateConfig defaultConfig{cfgClassificationPresets = [preset "raw", preset "raw"]} of
+                Right _ -> expectationFailure "expected a refusal"
+                Left err -> do
+                    err `shouldSatisfy` T.isInfixOf "Duplicate classification preset"
+                    err `shouldSatisfy` T.isInfixOf "raw"
+
+        it "refuses two method collections sharing a name" $
+            case decodeMethod "name = \"EF\"\npath = \"x.zip\"\n" of
+                Left e -> expectationFailure (show e)
+                Right mc -> case validateConfig defaultConfig{cfgMethods = [mc, mc]} of
+                    Right _ -> expectationFailure "expected a refusal"
+                    Left err -> do
+                        err `shouldSatisfy` T.isInfixOf "Duplicate method collection"
+                        err `shouldSatisfy` T.isInfixOf "EF"
+
+        it "accepts distinct names" $
+            case decodeMethod "name = \"EF\"\npath = \"x.zip\"\n" of
+                Left e -> expectationFailure (show e)
+                Right mc ->
+                    validateConfig
+                        defaultConfig
+                            { cfgClassificationPresets = [preset "raw", preset "transformed"]
+                            , cfgMethods = [mc]
+                            }
+                        `shouldSatisfy` isRight
 
     describe "MethodConfig global-methods" $ do
         let decodeMethod t = TOML.decode t :: Either TOML.TOMLError MethodConfig


### PR DESCRIPTION
Both presets and method collections are looked up by name. A configuration carrying the same name twice silently shadowed one of its bearers: preset expansion took the first match and the second never answered, and the presets listing showed the name twice.

Startup now refuses such a configuration outright, the same way it already refused two databases sharing a name. The error names the offending names, so the fix is a rename in the configuration file.

Covered by three new cases in ConfigSpec; CHANGELOG entry included.