### PR TITLE
Load the reference data the Docker image ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
   instead of "This instance is read-only", naming who to talk to about it.
 
 ### Fixed
+- The Docker image's default configuration now loads the geography hierarchy
+  and the energy densities it ships. `geographies` was declared below
+  `[server]`, where it parsed as `server.geographies` and was silently
+  dropped, so a standalone container ran on the built-in hierarchy while its
+  own CSV sat unused; energy densities were not declared at all, and without
+  the density bridge the fossil and water-use categories meet mass flows
+  cross-dimensionally and silently score zero or a thousand times off.
 - The macOS download for Apple Silicon now runs on a Mac that has no developer
   tools. It was built against the build machine's Homebrew copies of OpenBLAS
   and the Fortran runtime and looked for them at the same paths on yours, so it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,17 @@
   instead of "This instance is read-only", naming who to talk to about it.
 
 ### Fixed
-- The Docker image's default configuration now loads the geography hierarchy
-  and the energy densities it ships. `geographies` was declared below
-  `[server]`, where it parsed as `server.geographies` and was silently
-  dropped, so a standalone container ran on the built-in hierarchy while its
-  own CSV sat unused; energy densities were not declared at all, and without
-  the density bridge the fossil and water-use categories meet mass flows
-  cross-dimensionally and silently score zero or a thousand times off.
+- The Docker image's default configuration now loads everything it ships.
+  `geographies` was declared below `[server]`, where it parsed as
+  `server.geographies` and was silently dropped, so a standalone container
+  scored regionalized characterization factors with no geography hierarchy at
+  all while its own CSV sat unused. Energy densities were not declared, so
+  factors counted per MJ or per m3 could never meet a flow measured by mass
+  or volume and their categories silently scored zero. And the built-in
+  method's path resolved under `/app` instead of `/data`, so the image
+  started with no method at all. One caveat for named volumes created by an
+  older image: Docker never repopulates a non-empty volume, so copy
+  `energy_density.csv` into it or recreate it.
 - The macOS download for Apple Silicon now runs on a Mac that has no developer
   tools. It was built against the build machine's Homebrew copies of OpenBLAS
   and the Fortran runtime and looked for them at the same paths on yours, so it

--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ volca --config volca.toml repl
 A TOML config file enables multi-database setups, method collections, and reference data:
 
 ```toml
+# Single-path reference data (all optional). Top-level keys stay above the
+# first [section] header: below one they parse as members of that section
+# and are silently dropped.
+# geographies = "data/geographies.csv"         # code,display_name,parents
+# chem-synonyms = "data/chem_synonyms.csv"     # PubChem snapshot for the suggester
+# substance-edges = "data/substance_edges.csv" # typed flow-correspondence edges
+
 [server]
 port = 8080
 host = "127.0.0.1"
@@ -182,18 +189,13 @@ active = true
 
 [[energy-densities]]
 name = "Default energy densities"
-path = "data/energy_densities.csv"
+path = "data/energy_density.csv"
 active = true
 
 [[classification-presets]]     # named filter bundles for classifications
 name = "agriculture"
 label = "Agriculture"
 filters = [{ system = "ISIC", value = "01", mode = "contains" }]  # mode: exact | contains
-
-# Single-path reference data (all optional):
-# geographies = "data/geographies.csv"        # code,display_name,parents
-# chem-synonyms = "data/chem_synonyms.csv"    # PubChem snapshot for the suggester
-# substance-edges = "data/substance_edges.csv" # typed flow-correspondence edges
 
 # [hosting] tunes upload/API limits when the engine runs behind a manager:
 # max_uploads, max_upload_mb, max_loaded_uploads, api_access,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -219,11 +219,13 @@ ENV VOLCA_DATA_DIR=/data
 VOLUME /data
 
 RUN cat > /app/volca.toml <<'EOF'
+# Top-level keys must stay above the first [section] header: below one they
+# parse as members of that section and are silently dropped.
+geographies = "data/geographies.csv"
+
 [server]
 port = 8080
 host = "0.0.0.0"
-
-geographies = "data/geographies.csv"
 
 [[flow-synonyms]]
 name = "Default flow synonyms"
@@ -238,6 +240,14 @@ active = true
 [[units]]
 name = "Default units"
 path = "data/units.csv"
+active = true
+
+# Activates the density bridge (kg -> MJ for fossil CFs, kg -> m3 for water
+# CFs). Without it, per-MJ and per-m3 CFs meet mass flows cross-dimensionally
+# and the fossils / water-use categories silently score zero or x1000.
+[[energy-densities]]
+name = "Default energy densities"
+path = "data/energy_density.csv"
 active = true
 
 [[methods]]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -210,6 +210,8 @@ WORKDIR /app
 # auto-populates empty named volumes with whatever the image holds at the
 # volume path). Standalone `docker run volca` reads these directly; bind
 # mounts hide them and the caller is expected to provide their own data.
+# The default config below names each of these files, so a bind mount that
+# lacks one logs a load failure at startup; the server keeps running.
 #
 # Config paths like `path = "data/flows.csv"` resolve to /data/flows.csv via
 # Config.redirectIntoDataDir (strip leading `data/`, prepend VOLCA_DATA_DIR).
@@ -242,17 +244,21 @@ name = "Default units"
 path = "data/units.csv"
 active = true
 
-# Activates the density bridge (kg -> MJ for fossil CFs, kg -> m3 for water
-# CFs). Without it, per-MJ and per-m3 CFs meet mass flows cross-dimensionally
-# and the fossils / water-use categories silently score zero or x1000.
+# Activates the density bridge, so characterization factors counted per MJ
+# or per m3 can meet flows measured by mass or volume. Without it the match
+# is cross-dimensional and the energy and water categories silently report
+# zero contributions.
 [[energy-densities]]
 name = "Default energy densities"
 path = "data/energy_density.csv"
 active = true
 
+# Method paths are user content that VOLCA_DATA_DIR does not rewrite, so the
+# shipped method needs the absolute path; a relative one would resolve under
+# /app and the image would start with no method at all.
 [[methods]]
 name = "plain-indicators"
-path = "data/methods/plain-indicators.csv"
+path = "/data/methods/plain-indicators.csv"
 active = true
 description = "Raw physical quantities counted through the supply chain (CF=1.0)"
 EOF


### PR DESCRIPTION
The image's default configuration did not load what the image ships.

- `geographies` was declared below `[server]`. A top-level key placed after a section header parses as a member of that section, and unknown members are silently dropped, so a standalone container scored regionalized factors with no geography hierarchy at all while the CSV baked into `/data` sat unused. The key now sits above the first header, with a comment stating the rule.
- No energy densities were declared, although `/data` ships them. Without the density bridge, factors counted per MJ or per m3 can never meet a flow measured by mass or volume, and the energy and water categories silently score zero. The default configuration now declares them.
- The shipped method never loaded: `VOLCA_DATA_DIR` rewrites reference-data paths but not method paths, so its relative path resolved under `/app` and the image started with no method at all. The path is now absolute.

The README's configuration example taught the same trap, with the single-path keys commented below the last array of tables where uncommenting them in place silently drops them. They moved above `[server]`, and the energy-densities example now names the file that actually ships.

CHANGELOG entry included, with a caveat for named volumes created by an older image: Docker never repopulates a non-empty volume, so `energy_density.csv` must be copied in or the volume recreated.