### PR TITLE
Let an energy density travel the synonym table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@
   instead of "This instance is read-only", naming who to talk to about it.
 
 ### Fixed
+- An energy density now reaches a flow under every name the curated synonym
+  table gives that substance, so the fossil-resource categories stop reporting
+  zero for a database that spells its resources out. The densities ship under
+  short names ("Coal, hard"), while ecoinvent 3.8 and the exports made from it
+  call the same resource "Coal, hard, unspecified, in ground". The
+  characterization factor already travelled the synonym table to reach that
+  flow and arrived counted per MJ; the density did not, so there was nothing to
+  carry the flow's kilograms onto the factor and the category scored zero
+  without saying why. A flow that states its own calorific value in its name
+  ("Coal, brown, 10 MJ per kg") keeps that value rather than the group's, and a
+  name two curated densities reach with different values is left without one
+  and reported, instead of being handed whichever came last.
 - The Docker image's default configuration now loads everything it ships.
   `geographies` was declared below `[server]`, where it parsed as
   `server.geographies` and was silently dropped, so a standalone container

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -203,6 +203,7 @@ import Method.Types (
     cfFamily,
     compartmentMapSize,
     energyDensityMapSize,
+    expandEnergyDensitiesBySynonym,
  )
 import Progress (ProgressLevel (..), reportError, reportProgress, reportProgressWithTiming, withLogScope)
 import qualified Search.BM25 as BM25
@@ -700,7 +701,21 @@ buildMethodTablesFor manager dbName collection db hier method = do
                 <> "(direction metadata may be missing from the method). Samples: "
                 <> show (take 3 (map mcfFlowName dirExcluded))
     cmap <- getMergedCompartmentMap manager
-    energyDensities <- getMergedEnergyDensities manager
+    curatedDensities <- getMergedEnergyDensities manager
+    -- The densities travel the same synonym groups the CFs travelled to reach
+    -- these flows, using the same frozen table, or a flow lent a per-MJ factor
+    -- under a name it does not carry itself would have nothing to bridge its
+    -- mass onto.
+    let (energyDensities, ambiguousDensities) =
+            expandEnergyDensitiesBySynonym (fromMaybe emptySynonymDB (dbSynonymDB db)) curatedDensities
+    unless (null ambiguousDensities) $
+        reportProgress Warning $
+            "[LCIA "
+                <> T.unpack (methodName method)
+                <> "] "
+                <> show (length ambiguousDensities)
+                <> " flow name(s) reached by two curated densities of different value, left without one: "
+                <> show (take 3 ambiguousDensities)
     unitConfig <- getMergedUnitConfig manager
     (mFlows, mUnits) <- getMergedFlowMetadata manager
     -- A method listed in its collection's 'global-methods' is scored without

--- a/src/Method/Types.hs
+++ b/src/Method/Types.hs
@@ -42,6 +42,7 @@ module Method.Types (
     EnergyDensityMap,
     buildEnergyDensityMapFromCSV,
     energyDensityMapSize,
+    expandEnergyDensitiesBySynonym,
     parseEnergyDensitySuffix,
     lookupEnergyDensity,
 
@@ -55,7 +56,7 @@ import Data.Aeson (FromJSON, ToJSON)
 import qualified Data.ByteString.Lazy as BL
 import Data.Char (isAsciiLower, isAsciiUpper)
 import Data.Csv (HasHeader (..), decode)
-import Data.List (sortOn)
+import Data.List (nub, sortOn)
 import qualified Data.Map.Strict as M
 import qualified Data.Maybe
 import Data.Store (Store)
@@ -65,7 +66,7 @@ import Data.UUID (UUID)
 import qualified Data.Vector as V
 import qualified Expr
 import GHC.Generics (Generic)
-import SynonymDB (normalizeName)
+import SynonymDB (SynonymDB, getSynonyms, lookupSynonymGroup, normalizeName)
 import Text.Read (readMaybe)
 
 -- | Direction of a biosphere flow (input from or output to environment)
@@ -449,6 +450,43 @@ buildEnergyDensityMapFromCSV csvData =
 -- | Number of entries in the energy-density map.
 energyDensityMapSize :: EnergyDensityMap -> Int
 energyDensityMapSize = M.size
+
+{- | Widen a density map along the same synonym groups the CF matching travels.
+
+The curated rows carry short substance names (@"Coal, hard"@), while a
+database spells the same substance out (@"Coal, hard, unspecified, in
+ground"@). The factor for that flow arrives through the synonym fan-out (see
+'Method.Mapping.expandSynonymMappings'), so it is written per MJ; without the
+same fan-out here there is nothing to carry the flow's kilograms onto it, and
+the category scores zero without saying so.
+
+A name that already has a density of its own keeps it, and so does a name that
+states one: the curated table holds @"Coal, hard"@ in the same group as
+@"Coal, 26.4 MJ per kg"@ and @"Coal, 29.3 MJ per kg"@, and those two say what
+they are worth more precisely than the group does.
+
+A name that two curated densities reach through their groups, with different
+values, is left without one and returned instead: choosing between them
+silently would hand brown coal the calorific value of hard coal.
+-}
+expandEnergyDensitiesBySynonym :: SynonymDB -> EnergyDensityMap -> (EnergyDensityMap, [Text])
+expandEnergyDensitiesBySynonym synDB densities =
+    (M.union densities (M.mapMaybe single reached), M.keys (M.filter ambiguous fresh))
+  where
+    reached =
+        M.fromListWith
+            (<>)
+            [ (normalizeName sibling, [density])
+            | (name, density) <- M.toList densities
+            , Just group <- [lookupSynonymGroup synDB name]
+            , sibling <- Data.Maybe.fromMaybe [] (getSynonyms synDB group)
+            , Data.Maybe.isNothing (parseEnergyDensitySuffix sibling)
+            ]
+    fresh = M.difference reached densities
+    single ds = case nub ds of
+        [d] -> Just d
+        _ -> Nothing
+    ambiguous ds = length (nub ds) > 1
 
 {- | Parse a flow name that encodes an energy density as a suffix —
 @"Coal, 18 MJ per kg"@, @"Gas, natural, 35 MJ per m3"@, @"Uranium, 2291 GJ per

--- a/test/EnergyDensityCFSpec.hs
+++ b/test/EnergyDensityCFSpec.hs
@@ -34,8 +34,9 @@ import qualified Data.UUID as UUID
 import Test.Hspec
 
 import Method.Mapping
-import Method.Types (Compartment (..), EnergyDensity (..), EnergyDensityMap, FlowDirection (..), MethodCF (..), buildEnergyDensityMapFromCSV)
+import Method.Types (Compartment (..), EnergyDensity (..), EnergyDensityMap, FlowDirection (..), MethodCF (..), buildEnergyDensityMapFromCSV, expandEnergyDensitiesBySynonym, lookupEnergyDensity)
 import SynonymDB (normalizeName)
+import qualified SynonymDB
 import Types (BiosphereFlow (..), Unit (..), UnitDB)
 import qualified Types as VT
 import UnitConversion (UnitConfig, buildFromCSV, defaultUnitConfig)
@@ -301,3 +302,50 @@ spec = do
         it "rejects a missing native unit" $
             buildEnergyDensityMapFromCSV (BLC.pack "flow_name,value,target_unit,native_unit\nPeat,9.76,MJ,\n")
                 `shouldSatisfy` isLeft
+
+    -- The curated rows are short substance names; a database spells the same
+    -- substance out. The CF reaches the long name through the synonym fan-out,
+    -- so the density has to travel the same way or the flow holds a per-MJ
+    -- factor with nothing to carry its kilograms onto.
+    describe "expandEnergyDensitiesBySynonym" $ do
+        let synonyms = SynonymDB.buildFromPairs
+            curated rows = M.fromList [(normalizeName n, EnergyDensity v "MJ" "kg") | (n, v) <- rows]
+            expanded pairs rows = expandEnergyDensitiesBySynonym (synonyms pairs) (curated rows)
+
+        -- The name is ecoinvent 3.8's, and the curated table really does hold
+        -- it in the same group as the short name the density row carries.
+        -- Stripping ", in ground" leaves "coal hard unspecified", which is not
+        -- the density's key, so nothing else in the cascade reaches it.
+        it "lends a density to the spelled-out name of the same substance" $ do
+            let curatedOnly = curated [("Coal, hard", 18.01)]
+                (m, _) = expanded [("Coal, hard", "Coal, hard, unspecified, in ground")] [("Coal, hard", 18.01)]
+            lookupEnergyDensity curatedOnly "Coal, hard, unspecified, in ground" `shouldBe` Nothing
+            lookupEnergyDensity m "Coal, hard, unspecified, in ground"
+                `shouldBe` Just (EnergyDensity 18.01 "MJ" "kg")
+
+        it "leaves a name that states its own calorific value alone" $ do
+            -- The shipped table really does hold these three in one group, and
+            -- 26.4 MJ/kg is not 18.01.
+            let (m, _) =
+                    expanded
+                        [ ("Coal, hard", "Coal, 26.4 MJ per kg")
+                        , ("Coal, hard", "Coal, 29.3 MJ per kg")
+                        ]
+                        [("Coal, hard", 18.01)]
+            M.lookup (normalizeName "Coal, 26.4 MJ per kg") m `shouldBe` Nothing
+            fmap edValue (lookupEnergyDensity m "Coal, 26.4 MJ per kg") `shouldBe` Just 26.4
+
+        it "refuses to choose when two curated densities reach one name" $ do
+            let (m, ambiguous) =
+                    expanded
+                        [("Coal, hard", "coal in ground"), ("Coal, brown", "coal in ground")]
+                        [("Coal, hard", 18.01), ("Coal, brown", 9.41)]
+            M.lookup (normalizeName "coal in ground") m `shouldBe` Nothing
+            ambiguous `shouldBe` [normalizeName "coal in ground"]
+
+        it "never displaces a density written under the name itself" $ do
+            let (m, _) =
+                    expanded
+                        [("Coal, hard", "Coal, brown")]
+                        [("Coal, hard", 18.01), ("Coal, brown", 9.41)]
+            fmap edValue (lookupEnergyDensity m "Coal, brown") `shouldBe` Just 9.41


### PR DESCRIPTION
The curated energy densities are written under short substance names, `Coal, hard`. ecoinvent 3.8, and the exports made from it, call the same resource `Coal, hard, unspecified, in ground`. None of the three rungs of `lookupEnergyDensity` gets from one to the other: normalizing strips `, in ground` and leaves `coal hard unspecified`, which is not the density's key; the name carries no region suffix; and it states no calorific value of its own.

The characterization factor **does** reach that flow, through the synonym fan-out, and a JRC fossil-resource factor is counted per MJ. So the flow ended up holding a factor of a dimension its kilograms could not be converted to, and the fossil-resource categories scored zero without saying why. This is the same bridge the density mechanism exists for, missing one rung.

The density map is now widened along the same synonym groups, using the same frozen table the factors travelled, before the method tables are built.

Two guards, both taken from what the shipped table actually contains rather than imagined:

- A name that states its own calorific value keeps it. `Coal, hard` sits in a group with `Coal, 26.4 MJ per kg` and `Coal, 29.3 MJ per kg`, and 18.01 is not what those say they are worth. Agribalyse carries `Coal, brown, 10 MJ per kg` and `Coal, brown, 8 MJ per kg` in the same shape.
- A name that two curated densities reach with different values is left without one and reported in a warning, rather than taking whichever came last. That is how brown coal would have been handed the calorific value of hard coal.

**What it does not change, measured.** BAFU 2026 v1 scored with EF 3.1 (JRC), 200 processes across 25 categories, engine run before and after: no score moves. That database writes `Coal, hard` exactly as the density row does, and so does ecoinvent 3.11. The long spelling belongs to 3.8, which is where this bites.

The four unit tests pin both halves: the long name has no density before the widening and the right one after, the self-describing name keeps its own value, the ambiguous name is refused and reported, and a name with its own curated row is never displaced.