### PR TITLE
Listen on the address the configuration names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@
   instead of "This instance is read-only", naming who to talk to about it.
 
 ### Fixed
+- The server now listens on the address `[server] host` names. That setting
+  had never reached the socket: whatever it said, the server answered on every
+  IPv4 interface, so a configuration written to keep an engine on its own
+  machine did not, and the password is off by default. The documented default,
+  `127.0.0.1`, is now real, so a server that used to be reachable from the
+  network stops being reachable unless its configuration says so - set
+  `host = "0.0.0.0"` to keep answering the network over IPv4, or `"*"` to
+  answer it over IPv4 and IPv6. The startup banner names the address it bound,
+  so the case `--port 0` cannot honour (it takes a free port on loopback) is
+  visible rather than silent.
 - The Docker image's default configuration now loads everything it ships.
   `geographies` was declared below `[server]`, where it parsed as
   `server.geographies` and was silently dropped, so a standalone container

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,6 @@
   instead of "This instance is read-only", naming who to talk to about it.
 
 ### Fixed
-- The server now listens on the address `[server] host` names. That setting
-  had never reached the socket: whatever it said, the server answered on every
-  IPv4 interface, so a configuration written to keep an engine on its own
-  machine did not, and the password is off by default. The documented default,
-  `127.0.0.1`, is now real, so a server that used to be reachable from the
-  network stops being reachable unless its configuration says so - set
-  `host = "0.0.0.0"` to keep answering the network over IPv4, or `"*"` to
-  answer it over IPv4 and IPv6. The startup banner names the address it bound,
-  so the case `--port 0` cannot honour (it takes a free port on loopback) is
-  visible rather than silent.
 - The Docker image's default configuration now loads everything it ships.
   `geographies` was declared below `[server]`, where it parsed as
   `server.geographies` and was silently dropped, so a standalone container
@@ -55,6 +45,17 @@
   apart on re-import.
 
 ### Changed
+- **The server now listens on the address `[server] host` names, and stops
+  answering the network unless it is told to.** That setting had never reached
+  the socket: whatever it said, the server accepted on every IPv4 interface, so
+  a configuration written to keep an engine on its own machine did not, while
+  the password is off by default. The documented default, `127.0.0.1`, is now
+  real. A deployment that relied on the old reach without asking for it has to
+  ask: `host = "0.0.0.0"` answers the network over IPv4, `"::"` over IPv6. The
+  startup banner names the address it bound, so the one case that cannot be
+  honoured - `--port 0` takes a free port on loopback - is visible rather than
+  silent. The command line reaches such a server at this machine rather than at
+  the wildcard, which is not an address anything can connect to.
 - The location hierarchy the regionalized scoring path uses is built once at
   startup instead of being rebuilt from the geography table on every call.
   It was two full passes over that table for each scoring request, and each

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ A TOML config file enables multi-database setups, method collections, and refere
 
 [server]
 port = 8080
-host = "127.0.0.1"
+host = "127.0.0.1"             # interface to listen on; "0.0.0.0" answers the
+                               # network over IPv4, "::" over IPv6
 password = "mysecret"          # optional — omit to disable auth
 name = "lab-archive"           # optional — how this server introduces itself over MCP
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -28,7 +28,7 @@ import CLI.Command (executeCommand)
 import CLI.Parser (cliParserInfo)
 import CLI.Repl (runRepl)
 import CLI.Types
-import Config (ClassificationPreset, Config (..), DatabaseConfig (..), HostingConfig (..), ReadOnly (..), ServerConfig (..), ServerName, hostingReadOnly, loadConfigOrDefault, readOnlyRefusalFor)
+import Config (ClassificationPreset, Config (..), DatabaseConfig (..), HostPreference, HostingConfig (..), Listen (..), ReadOnly (..), ServerConfig (..), ServerName, freePortHost, hostingReadOnly, listenOn, loadConfigOrDefault, readOnlyRefusalFor, renderHost)
 import Control.Concurrent.STM (readTVarIO)
 import Database.Manager (DatabaseManager (..), initDatabaseManager)
 import Network.HTTP.Client (Manager, defaultManagerSettings, managerResponseTimeout, newManager, responseTimeoutNone)
@@ -52,7 +52,7 @@ import Network.HTTP.Types (status200, status403)
 import Network.HTTP.Types.Header (hCacheControl, hContentType, hPragma)
 import Network.Wai (Application, Middleware, Request (..), Response, ResponseReceived, mapResponseHeaders, pathInfo, rawPathInfo, rawQueryString, requestHeaders, requestMethod, responseLBS, responseStream)
 import Network.Wai.Application.Static (StaticSettings, defaultWebAppSettings, ssIndices, staticApp)
-import Network.Wai.Handler.Warp (defaultSettings, openFreePort, runSettings, runSettingsSocket, setPort, setTimeout)
+import Network.Wai.Handler.Warp (defaultSettings, openFreePort, runSettings, runSettingsSocket, setHost, setPort, setTimeout)
 import Network.Wai.Middleware.RequestSizeLimit (defaultRequestSizeLimitSettings, requestSizeLimitMiddleware, setMaxLengthForRequest)
 import Servant (serve)
 import WaiAppStatic.Types (MaxAge (..), ssMaxAge, unsafeToPiece)
@@ -187,15 +187,18 @@ resolvePassword globalOpts serverCfg = case CLI.Types.serverPassword globalOpts 
         Nothing -> lookupEnv "VOLCA_PASSWORD"
 
 {- | In desktop mode, print a machine-readable port line for the launcher
-to capture and stay quiet. Otherwise emit the human-facing startup banner.
+to capture and stay quiet. Otherwise emit the human-facing startup banner,
+naming the interface as well as the port: a configuration asking for one the
+server cannot bind - @0.0.0.0@ under @--port 0@ - shows up here rather than
+being discovered from a connection that never arrives.
 -}
-logServerStartup :: ServerOptions -> Int -> Maybe String -> IO ()
-logServerStartup serverOpts port password
+logServerStartup :: ServerOptions -> HostPreference -> Int -> Maybe String -> IO ()
+logServerStartup serverOpts host port password
     | serverDesktopMode serverOpts = do
         putStrLn ("VOLCA_PORT=" ++ show port)
         hFlush stdout
     | otherwise = do
-        reportProgress Info ("Starting API server on port " ++ show port)
+        reportProgress Info ("Starting API server on " ++ renderHost host ++ " port " ++ show port)
         reportProgress Info ("Tree depth: " ++ show (serverTreeDepth serverOpts))
         reportProgress Info $ case password of
             Just _ -> "Authentication: ENABLED"
@@ -248,8 +251,7 @@ runServerWithConfig cliConfig serverOpts mCfgFile = do
     reportProgress Info "Initializing database manager..."
     dbManager <- initDatabaseManager config (noCache (globalOptions cliConfig))
     logLoadedDatabases dbManager
-    let port = fromMaybe (scPort (cfgServer config)) (serverPort serverOpts)
-        staticDir = fromMaybe "web/dist" (serverStaticDir serverOpts)
+    let staticDir = fromMaybe "web/dist" (serverStaticDir serverOpts)
     password <- resolvePassword (globalOptions cliConfig) (cfgServer config)
     (lastRequestRef, idleActiveRef) <- setupIdleTimeout serverOpts
     baseApp <-
@@ -267,14 +269,14 @@ runServerWithConfig cliConfig serverOpts mCfgFile = do
             uploadSizeLimitMiddleware (cfgHosting config) $
                 wrapWithMiddleware password (cfgHosting config) lastRequestRef idleActiveRef baseApp
         settings = setTimeout 600 defaultSettings
-    if port == 0
-        then do
+    case listenOn (serverPort serverOpts) (cfgServer config) of
+        ListenOnFreeLoopbackPort -> do
             (boundPort, socket) <- openFreePort
-            logServerStartup serverOpts boundPort password
+            logServerStartup serverOpts freePortHost boundPort password
             runSettingsSocket settings socket finalApp
-        else do
-            logServerStartup serverOpts port password
-            runSettings (setPort port settings) finalApp
+        ListenOn host port -> do
+            logServerStartup serverOpts host port password
+            runSettings (setHost host (setPort port settings)) finalApp
 
 {- | Run config load-only mode (load all databases from config and exit)
 Useful for cache generation, validation, and benchmarking

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,6 +10,7 @@ import Data.IORef
 import Data.List (intercalate)
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
+import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
 import Foreign.C.Types (CInt (..))
@@ -28,7 +29,7 @@ import CLI.Command (executeCommand)
 import CLI.Parser (cliParserInfo)
 import CLI.Repl (runRepl)
 import CLI.Types
-import Config (ClassificationPreset, Config (..), DatabaseConfig (..), HostPreference, HostingConfig (..), Listen (..), ReadOnly (..), ServerConfig (..), ServerName, freePortHost, hostingReadOnly, listenOn, loadConfigOrDefault, readOnlyRefusalFor, renderHost)
+import Config (ClassificationPreset, Config (..), DatabaseConfig (..), HostingConfig (..), Listen (..), ReadOnly (..), ServerConfig (..), ServerName, clientHost, freePortHost, hostingReadOnly, listenOn, loadConfigOrDefault, readOnlyRefusalFor)
 import Control.Concurrent.STM (readTVarIO)
 import Database.Manager (DatabaseManager (..), initDatabaseManager)
 import Network.HTTP.Client (Manager, defaultManagerSettings, managerResponseTimeout, newManager, responseTimeoutNone)
@@ -192,18 +193,18 @@ naming the interface as well as the port: a configuration asking for one the
 server cannot bind - @0.0.0.0@ under @--port 0@ - shows up here rather than
 being discovered from a connection that never arrives.
 -}
-logServerStartup :: ServerOptions -> HostPreference -> Int -> Maybe String -> IO ()
+logServerStartup :: ServerOptions -> Text -> Int -> Maybe String -> IO ()
 logServerStartup serverOpts host port password
     | serverDesktopMode serverOpts = do
         putStrLn ("VOLCA_PORT=" ++ show port)
         hFlush stdout
     | otherwise = do
-        reportProgress Info ("Starting API server on " ++ renderHost host ++ " port " ++ show port)
+        reportProgress Info ("Starting API server on " ++ T.unpack host ++ " port " ++ show port)
         reportProgress Info ("Tree depth: " ++ show (serverTreeDepth serverOpts))
         reportProgress Info $ case password of
             Just _ -> "Authentication: ENABLED"
             Nothing -> "Authentication: DISABLED (use --password or VOLCA_PASSWORD to enable)"
-        reportProgress Info ("Web interface available at: http://localhost:" ++ show port ++ "/")
+        reportProgress Info ("Web interface available at: http://" ++ T.unpack (clientHost host) ++ ":" ++ show port ++ "/")
 
 {- | Allocate the idle-tracking refs and fork the watchdog when
 @--idle-timeout@ is positive. The refs are returned for both the
@@ -276,7 +277,7 @@ runServerWithConfig cliConfig serverOpts mCfgFile = do
             runSettingsSocket settings socket finalApp
         ListenOn host port -> do
             logServerStartup serverOpts host port password
-            runSettings (setHost host (setPort port settings)) finalApp
+            runSettings (setHost (fromString (T.unpack host)) (setPort port settings)) finalApp
 
 {- | Run config load-only mode (load all databases from config and exit)
 Useful for cache generation, validation, and benchmarking

--- a/src/CLI/Client.hs
+++ b/src/CLI/Client.hs
@@ -13,7 +13,7 @@ module CLI.Client (
 ) where
 
 import CLI.Types
-import Config (Config (..), ServerConfig (..))
+import Config (Config (..), ServerConfig (..), clientHost)
 import Control.Exception (IOException, try)
 import Data.Aeson (FromJSON, Value (..), decode, eitherDecode, encode, object, (.:), (.=))
 import Data.Aeson.Encode.Pretty (encodePretty)
@@ -70,7 +70,10 @@ resolveRemoteConfig globalOpts mbConfig = do
             case envUrl of
                 Just u -> return u
                 Nothing -> case cfgServer <$> mbConfig of
-                    Just sc -> return $ "http://" ++ T.unpack (scHost sc) ++ ":" ++ show (scPort sc)
+                    -- clientHost, not scHost: that setting names the
+                    -- interfaces to accept on, and "every interface" is not
+                    -- somewhere a client can connect to.
+                    Just sc -> return $ "http://" ++ T.unpack (clientHost (scHost sc)) ++ ":" ++ show (scPort sc)
                     Nothing -> do
                         reportError "No server URL: use --config, --url, or VOLCA_URL"
                         exitFailure

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -30,6 +31,13 @@ module Config (
     loadConfigOrDefault,
     validateConfig,
 
+    -- * Listening address
+    Listen (..),
+    HostPreference,
+    listenOn,
+    freePortHost,
+    renderHost,
+
     -- * VOLCA_DATA_DIR resolution
     redirectIntoDataDir,
     applyDataDir,
@@ -50,6 +58,8 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, isNothing)
 import qualified Data.Set as S
+import Data.Streaming.Network.Internal (HostPreference (..))
+import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Database.Upload (DatabaseFormat (..))
@@ -316,6 +326,44 @@ defaultServerConfig =
         , scPassword = Nothing
         , scName = Nothing
         }
+
+{- | The address the server listens on.
+
+@--port 0@ asks the operating system for a free port. The only way to learn
+which one it picked is to bind the socket first, and that path binds loopback,
+so a configured host cannot be honoured there. Naming the case keeps it from
+reading as an oversight where the server starts.
+-}
+data Listen
+    = ListenOn HostPreference Int
+    | ListenOnFreeLoopbackPort
+    deriving (Show, Eq)
+
+{- | Resolve where to listen: @--port@ overrides @[server] port@, and
+@[server] host@ decides the interface. Its default keeps a server reachable
+from the machine it runs on and from nowhere else, which is what a password
+left unset assumes.
+-}
+listenOn :: Maybe Int -> ServerConfig -> Listen
+listenOn mPort sc = case fromMaybe (scPort sc) mPort of
+    0 -> ListenOnFreeLoopbackPort
+    port -> ListenOn (fromString (T.unpack (scHost sc))) port
+
+{- | What 'ListenOnFreeLoopbackPort' ends up bound to, so the address the
+server announces is the one it is actually reachable at.
+-}
+freePortHost :: HostPreference
+freePortHost = Host "127.0.0.1"
+
+-- | An address written the way it is written in the configuration file.
+renderHost :: HostPreference -> String
+renderHost = \case
+    Host h -> h
+    HostAny -> "*"
+    HostIPv4 -> "*4"
+    HostIPv4Only -> "!4"
+    HostIPv6 -> "*6"
+    HostIPv6Only -> "!6"
 
 -- | Default config (empty databases)
 defaultConfig :: Config

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -33,10 +32,9 @@ module Config (
 
     -- * Listening address
     Listen (..),
-    HostPreference,
     listenOn,
     freePortHost,
-    renderHost,
+    clientHost,
 
     -- * VOLCA_DATA_DIR resolution
     redirectIntoDataDir,
@@ -58,8 +56,6 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, isNothing)
 import qualified Data.Set as S
-import Data.Streaming.Network.Internal (HostPreference (..))
-import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Database.Upload (DatabaseFormat (..))
@@ -335,7 +331,7 @@ so a configured host cannot be honoured there. Naming the case keeps it from
 reading as an oversight where the server starts.
 -}
 data Listen
-    = ListenOn HostPreference Int
+    = ListenOn Text Int
     | ListenOnFreeLoopbackPort
     deriving (Show, Eq)
 
@@ -347,23 +343,26 @@ left unset assumes.
 listenOn :: Maybe Int -> ServerConfig -> Listen
 listenOn mPort sc = case fromMaybe (scPort sc) mPort of
     0 -> ListenOnFreeLoopbackPort
-    port -> ListenOn (fromString (T.unpack (scHost sc))) port
+    port -> ListenOn (scHost sc) port
 
 {- | What 'ListenOnFreeLoopbackPort' ends up bound to, so the address the
 server announces is the one it is actually reachable at.
 -}
-freePortHost :: HostPreference
-freePortHost = Host "127.0.0.1"
+freePortHost :: Text
+freePortHost = "127.0.0.1"
 
--- | An address written the way it is written in the configuration file.
-renderHost :: HostPreference -> String
-renderHost = \case
-    Host h -> h
-    HostAny -> "*"
-    HostIPv4 -> "*4"
-    HostIPv4Only -> "!4"
-    HostIPv6 -> "*6"
-    HostIPv6Only -> "!6"
+{- | The host a client dials to reach a server told to listen on this one.
+
+A listening address names interfaces to accept on; it is not a destination.
+@0.0.0.0@ and warp\'s wildcards mean "every interface", which nothing can
+connect to - on Windows @http:\/\/0.0.0.0@ fails outright, and @*@ is not
+even a valid URL host. A server accepting on all of them accepts on this
+machine too, so that is where a client on this machine goes.
+-}
+clientHost :: Text -> Text
+clientHost host
+    | host `elem` ["0.0.0.0", "::", "*", "*4", "!4", "*6", "!6"] = "localhost"
+    | otherwise = host
 
 -- | Default config (empty databases)
 defaultConfig :: Config

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -17,18 +17,17 @@ import Config (
     ScoringSetConfig (..),
     ServerConfig (..),
     applyDataDir,
+    clientHost,
     defaultConfig,
     expandClassificationPreset,
     listenOn,
     loadConfigOrDefault,
     redirectIntoDataDir,
-    renderHost,
     resolveConfigPaths,
     validateConfig,
  )
 import Data.Either (isRight)
 import qualified Data.Map.Strict as M
-import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text as T
 import System.FilePath (normalise)
@@ -59,25 +58,35 @@ spec :: Spec
 spec = do
     describe "listenOn" $ do
         it "listens on the interface the configuration names" $
-            listenOn Nothing (serverOn "0.0.0.0") `shouldBe` ListenOn (fromString "0.0.0.0") 8080
+            listenOn Nothing (serverOn "0.0.0.0") `shouldBe` ListenOn "0.0.0.0" 8080
 
-        -- The default is what a password left unset assumes: reachable from
-        -- this machine and from nowhere else.
+        -- Read through the real decoder rather than a hand-built record: what
+        -- has to hold is the decoder's own fallback, since it is what a file
+        -- with no host at all gets, and what a password left unset assumes.
         it "keeps a configuration that names no host on loopback" $
-            listenOn Nothing (serverOn "127.0.0.1") `shouldBe` ListenOn (fromString "127.0.0.1") 8080
+            case TOML.decode "port = 8080\n" :: Either TOML.TOMLError ServerConfig of
+                Left err -> expectationFailure (show err)
+                Right sc -> listenOn Nothing sc `shouldBe` ListenOn "127.0.0.1" 8080
 
         it "lets --port override the configured port without moving the interface" $
-            listenOn (Just 9000) (serverOn "0.0.0.0") `shouldBe` ListenOn (fromString "0.0.0.0") 9000
+            listenOn (Just 9000) (serverOn "0.0.0.0") `shouldBe` ListenOn "0.0.0.0" 9000
 
         -- --port 0 goes through the free-port path, which binds loopback and
         -- takes no host, so the configured one cannot be honoured there.
         it "asks for a free loopback port whatever host the configuration names" $
             listenOn (Just 0) (serverOn "0.0.0.0") `shouldBe` ListenOnFreeLoopbackPort
 
-    describe "renderHost" $
-        it "writes an address back the way a configuration file writes it" $ do
-            let written = ["127.0.0.1", "0.0.0.0", "example.internal", "*", "*4", "!4", "*6", "!6"]
-            map (renderHost . fromString) written `shouldBe` written
+    describe "clientHost" $ do
+        -- A listening address names interfaces to accept on. Handing one to a
+        -- client as a destination gives http://0.0.0.0:8080, which fails
+        -- outright on Windows, or http://*:8080, which is not a URL at all.
+        it "sends a client to this machine when the server accepts on every interface" $
+            map clientHost ["0.0.0.0", "::", "*", "*4", "!4", "*6", "!6"]
+                `shouldBe` replicate 7 "localhost"
+
+        it "leaves an address that names one interface alone" $
+            map clientHost ["127.0.0.1", "::1", "192.168.1.10", "engine.internal"]
+                `shouldBe` ["127.0.0.1", "::1", "192.168.1.10", "engine.internal"]
 
     describe "expandClassificationPreset" $ do
         let raw =

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -9,26 +9,40 @@ import Config (
     Config (..),
     DatabaseConfig (..),
     HostingConfig (..),
+    Listen (..),
     MethodConfig (..),
     MethodPatch (..),
     MethodPatchMatch (..),
     RefDataConfig (..),
     ScoringSetConfig (..),
+    ServerConfig (..),
     applyDataDir,
     defaultConfig,
     expandClassificationPreset,
+    listenOn,
     loadConfigOrDefault,
     redirectIntoDataDir,
+    renderHost,
     resolveConfigPaths,
     validateConfig,
  )
 import Data.Either (isRight)
 import qualified Data.Map.Strict as M
+import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text as T
 import System.FilePath (normalise)
 import qualified TOML
 import Test.Hspec
+
+serverOn :: Text -> ServerConfig
+serverOn host =
+    ServerConfig
+        { scPort = 8080
+        , scHost = host
+        , scPassword = Nothing
+        , scName = Nothing
+        }
 
 mkRef :: FilePath -> RefDataConfig
 mkRef p =
@@ -43,6 +57,28 @@ mkRef p =
 
 spec :: Spec
 spec = do
+    describe "listenOn" $ do
+        it "listens on the interface the configuration names" $
+            listenOn Nothing (serverOn "0.0.0.0") `shouldBe` ListenOn (fromString "0.0.0.0") 8080
+
+        -- The default is what a password left unset assumes: reachable from
+        -- this machine and from nowhere else.
+        it "keeps a configuration that names no host on loopback" $
+            listenOn Nothing (serverOn "127.0.0.1") `shouldBe` ListenOn (fromString "127.0.0.1") 8080
+
+        it "lets --port override the configured port without moving the interface" $
+            listenOn (Just 9000) (serverOn "0.0.0.0") `shouldBe` ListenOn (fromString "0.0.0.0") 9000
+
+        -- --port 0 goes through the free-port path, which binds loopback and
+        -- takes no host, so the configured one cannot be honoured there.
+        it "asks for a free loopback port whatever host the configuration names" $
+            listenOn (Just 0) (serverOn "0.0.0.0") `shouldBe` ListenOnFreeLoopbackPort
+
+    describe "renderHost" $
+        it "writes an address back the way a configuration file writes it" $ do
+            let written = ["127.0.0.1", "0.0.0.0", "example.internal", "*", "*4", "!4", "*6", "!6"]
+            map (renderHost . fromString) written `shouldBe` written
+
     describe "expandClassificationPreset" $ do
         let raw =
                 ClassificationPreset

--- a/volca.toml
+++ b/volca.toml
@@ -19,7 +19,8 @@ geographies = "data/geographies.csv"
 port = 8080                     # HTTP port
 # The interface to listen on. The default answers this machine and nothing
 # else, which is what leaving the password unset assumes. Use "0.0.0.0" to
-# answer the network over IPv4, "*" to answer it over IPv4 and IPv6.
+# answer the network over IPv4, "::" over IPv6, or name one interface's own
+# address to answer on that one alone.
 host = "127.0.0.1"
 # password = "changeme"        # Optional HTTP Basic Auth password
 

--- a/volca.toml
+++ b/volca.toml
@@ -17,7 +17,10 @@ geographies = "data/geographies.csv"
 
 [server]
 port = 8080                     # HTTP port
-host = "127.0.0.1"             # Bind address ("0.0.0.0" for all interfaces)
+# The interface to listen on. The default answers this machine and nothing
+# else, which is what leaving the password unset assumes. Use "0.0.0.0" to
+# answer the network over IPv4, "*" to answer it over IPv4 and IPv6.
+host = "127.0.0.1"
 # password = "changeme"        # Optional HTTP Basic Auth password
 
 # ── Databases ────────────────────────────────────────────────────────


### PR DESCRIPTION
`[server] host` was decoded, defaulted to `127.0.0.1`, and documented in the shipped `volca.toml` as the bind address. It never reached the socket. The only reader was the CLI client, building its base URL; the server started on warp's own default, which is every IPv4 interface. Since the password is off unless one is set, anyone who wrote `host = "127.0.0.1"` to keep an engine on its own machine was in fact serving it to the network, and had a config file telling them otherwise.

**This closes a server that was open.** A deployment that relied on the old reach without asking for it needs `host = "0.0.0.0"` in its configuration now (or `"*"` for IPv4 and IPv6). The image's own `/app/volca.toml` already says `0.0.0.0`, so a plain `docker run` is unaffected.

Where it listens is a value rather than an `if` at the call site, because `--port 0` cannot honour a host: it asks the operating system for a free port, and the only way to learn which one it picked is to let warp bind it, which it does on loopback. Naming that case keeps it from reading as an oversight. The startup banner now prints the address it bound, so a setting that could not be honoured shows up there instead of being discovered from a connection that never arrives.

Tests cover the decision itself: the interface the file names reaches the bind, `--port` moves the port without moving the interface, and `--port 0` goes to loopback whatever the file says.