### PR TITLE
Answer --help on every subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
   instead of "This instance is read-only", naming who to talk to about it.
 
 ### Fixed
+- `--help` now works on every subcommand. Seven of them answered
+  ``Invalid option `--help'`` and exited with an error instead of describing
+  themselves: `database list`, `database upload`, `database delete`,
+  `method list`, `method upload`, `method delete` and `flow activities`. The
+  usage text was printed, but to the error stream and behind a failure, so
+  anything reading the help of `volca database upload` got nothing at all.
 - The Docker image's default configuration now loads everything it ships.
   `geographies` was declared below `[server]`, where it parsed as
   `server.geographies` and was silently dropped, so a standalone container

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,17 @@
   instead of "This instance is read-only", naming who to talk to about it.
 
 ### Fixed
-- `--help` now works on every subcommand. Seven of them answered
-  ``Invalid option `--help'`` and exited with an error instead of describing
-  themselves: `database list`, `database upload`, `database delete`,
-  `method list`, `method upload`, `method delete` and `flow activities`. The
-  usage text was printed, but to the error stream and behind a failure, so
-  anything reading the help of `volca database upload` got nothing at all.
+- `--help` now describes every subcommand, including inside the REPL. Nine
+  answered something else. `database upload`, `database delete`,
+  `method upload` and `method delete` printed ``Invalid option `--help'`` and
+  exited with an error, putting their usage on the error stream where anything
+  capturing it got nothing: that is why four of the command pages on the
+  website have been empty. `database list`, `method list` and
+  `flow ... activities` quietly answered with their parent command's help page
+  instead of their own. `dump-openapi` and `dump-mcp-tools` answered with the
+  top-level one. In the REPL, every `--help` read as an unknown command,
+  because a parser answers the flag by failing with the help text and the REPL
+  kept only successes.
 - The Docker image's default configuration now loads everything it ships.
   `geographies` was declared below `[server]`, where it parsed as
   `server.geographies` and was silently dropped, so a standalone container

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -48,6 +48,17 @@ textArg m h = T.pack <$> argument str (metavar m <> help h)
 strArg :: String -> String -> Parser String
 strArg m h = argument str (metavar m <> help h)
 
+{- | A subcommand that answers @--help@.
+
+'OA.command' alone does not: a parser built without 'helper' does not know
+the flag, so it rejects it and prints its usage to the error stream behind a
+failing exit, where anything capturing a command's help sees nothing at all.
+Declaring every subcommand through here is what keeps that from being one
+more thing to remember.
+-}
+cmd :: String -> Parser a -> String -> Mod CommandFields a
+cmd name parser desc = OA.command name (info (parser <**> helper) (progDesc desc))
+
 {- | Main CLI parser combining global options and optional command
 If no command is given, just load database and exit (useful for cache generation)
 -}
@@ -82,28 +93,28 @@ outputFormatReader = eitherReader $ \s ->
 commandParser :: Parser Command
 commandParser =
     subparser
-        ( OA.command "server" (info (serverParser <**> helper) (progDesc "Start API server"))
-            <> OA.command "activity" (info (activityParser <**> helper) (progDesc "Get basic activity information"))
-            <> OA.command "inventory" (info (inventoryParser <**> helper) (progDesc "Get life cycle inventory for activity"))
-            <> OA.command "flow" (info (flowParser <**> helper) (progDesc "Query flow information"))
-            <> OA.command "activities" (info (searchActivitiesParser <**> helper) (progDesc "Search activities"))
-            <> OA.command "flows" (info (searchFlowsParser <**> helper) (progDesc "Search flows"))
-            <> OA.command "impacts" (info (impactsParser <**> helper) (progDesc "Compute impact assessment (LCIA) scores with a characterization method"))
-            <> OA.command "debug-matrices" (info (debugMatricesParser <**> helper) (progDesc "Export targeted matrix slices for debugging"))
-            <> OA.command "export-matrices" (info (exportMatricesParser <**> helper) (progDesc "Export matrices in universal format (Ecoinvent-compatible)"))
-            <> OA.command "database" (info (databaseParser <**> helper) (progDesc "Manage databases (list, upload, delete)"))
-            <> OA.command "method" (info (methodParser <**> helper) (progDesc "Manage method collections"))
-            <> OA.command "methods" (info (pure Methods <**> helper) (progDesc "List loaded methods (flattened)"))
-            <> OA.command "synonyms" (info (pure Synonyms <**> helper) (progDesc "List synonym sources"))
-            <> OA.command "compartment-mappings" (info (pure CompartmentMappings <**> helper) (progDesc "List compartment mappings"))
-            <> OA.command "units" (info (pure Units <**> helper) (progDesc "List unit definitions"))
-            <> OA.command "flow-mapping" (info (flowMappingParser <**> helper) (progDesc "Analyze flow mapping coverage between a method and database"))
-            <> OA.command "stop" (info (pure Stop <**> helper) (progDesc "Stop running server (uses --config or --url to find it)"))
-            <> OA.command "repl" (info (pure Repl <**> helper) (progDesc "Interactive REPL over HTTP (connects to running server)"))
+        ( cmd "server" serverParser "Start API server"
+            <> cmd "activity" activityParser "Get basic activity information"
+            <> cmd "inventory" inventoryParser "Get life cycle inventory for activity"
+            <> cmd "flow" flowParser "Query flow information"
+            <> cmd "activities" searchActivitiesParser "Search activities"
+            <> cmd "flows" searchFlowsParser "Search flows"
+            <> cmd "impacts" impactsParser "Compute impact assessment (LCIA) scores with a characterization method"
+            <> cmd "debug-matrices" debugMatricesParser "Export targeted matrix slices for debugging"
+            <> cmd "export-matrices" exportMatricesParser "Export matrices in universal format (Ecoinvent-compatible)"
+            <> cmd "database" databaseParser "Manage databases (list, upload, delete)"
+            <> cmd "method" methodParser "Manage method collections"
+            <> cmd "methods" (pure Methods) "List loaded methods (flattened)"
+            <> cmd "synonyms" (pure Synonyms) "List synonym sources"
+            <> cmd "compartment-mappings" (pure CompartmentMappings) "List compartment mappings"
+            <> cmd "units" (pure Units) "List unit definitions"
+            <> cmd "flow-mapping" flowMappingParser "Analyze flow mapping coverage between a method and database"
+            <> cmd "stop" (pure Stop) "Stop running server (uses --config or --url to find it)"
+            <> cmd "repl" (pure Repl) "Interactive REPL over HTTP (connects to running server)"
         )
         <|> subparser
-            ( OA.command "dump-openapi" (info (pure DumpOpenApi) (progDesc "Dump OpenAPI spec as JSON to stdout"))
-                <> OA.command "dump-mcp-tools" (info (pure DumpMcpTools) (progDesc "Dump MCP tool definitions as JSON to stdout"))
+            ( cmd "dump-openapi" (pure DumpOpenApi) "Dump OpenAPI spec as JSON to stdout"
+                <> cmd "dump-mcp-tools" (pure DumpMcpTools) "Dump MCP tool definitions as JSON to stdout"
                 <> internal
             )
 
@@ -113,18 +124,18 @@ databaseParser =
     Database . fromMaybe DbList
         <$> optional
             ( subparser
-                ( OA.command "list" (info (pure DbList <**> helper) (progDesc "List databases"))
-                    <> OA.command "load" (info (DbLoad <$> textArg "DB" "Name of the configured database to load" <**> helper) (progDesc "Load a configured database into memory"))
-                    <> OA.command "unload" (info (DbUnload <$> textArg "DB" "Name of the loaded database to unload" <**> helper) (progDesc "Unload a database from memory"))
-                    <> OA.command "upload" (info (DbUpload <$> uploadArgsParser <**> helper) (progDesc "Upload a database from a local file"))
-                    <> OA.command "delete" (info (DbDelete <$> deleteNameParser <**> helper) (progDesc "Delete a database"))
-                    <> OA.command "delete-activities" (info (DbDeleteActivities <$> deleteActivitiesArgsParser <**> helper) (progDesc "Delete the whole filtered set of activities from a loaded database"))
-                    <> OA.command "copy" (info (copyArgsParser <**> helper) (progDesc "Copy a loaded database under a new name"))
-                    <> OA.command "relink" (info (DbRelinkMapping <$> relinkArgsParser <**> helper) (progDesc "Relink a database to a dependency using a supplier alias CSV (source/target names, optional locations)"))
-                    <> OA.command "export" (info (DbExport <$> exportArgsParser <**> helper) (progDesc "Export a loaded database to a file"))
-                    <> OA.command "create-activities" (info (DbCreateActivities <$> writeArgsParser <**> helper) (progDesc "Write new activities into a database from a JSON file"))
-                    <> OA.command "replace-activity" (info (DbReplaceActivity <$> replaceArgsParser <**> helper) (progDesc "Rewrite one activity of a database from a JSON file"))
-                    <> OA.command "edit-exchanges" (info (DbEditExchanges <$> editArgsParser <**> helper) (progDesc "Change one activity's inventory from a JSON file, keeping the rest of the activity"))
+                ( cmd "list" (pure DbList) "List databases"
+                    <> cmd "load" (DbLoad <$> textArg "DB" "Name of the configured database to load") "Load a configured database into memory"
+                    <> cmd "unload" (DbUnload <$> textArg "DB" "Name of the loaded database to unload") "Unload a database from memory"
+                    <> cmd "upload" (DbUpload <$> uploadArgsParser) "Upload a database from a local file"
+                    <> cmd "delete" (DbDelete <$> deleteNameParser) "Delete a database"
+                    <> cmd "delete-activities" (DbDeleteActivities <$> deleteActivitiesArgsParser) "Delete the whole filtered set of activities from a loaded database"
+                    <> cmd "copy" copyArgsParser "Copy a loaded database under a new name"
+                    <> cmd "relink" (DbRelinkMapping <$> relinkArgsParser) "Relink a database to a dependency using a supplier alias CSV (source/target names, optional locations)"
+                    <> cmd "export" (DbExport <$> exportArgsParser) "Export a loaded database to a file"
+                    <> cmd "create-activities" (DbCreateActivities <$> writeArgsParser) "Write new activities into a database from a JSON file"
+                    <> cmd "replace-activity" (DbReplaceActivity <$> replaceArgsParser) "Rewrite one activity of a database from a JSON file"
+                    <> cmd "edit-exchanges" (DbEditExchanges <$> editArgsParser) "Change one activity's inventory from a JSON file, keeping the rest of the activity"
                 )
             )
 
@@ -219,10 +230,10 @@ methodParser =
     Method . fromMaybe McList
         <$> optional
             ( subparser
-                ( OA.command "list" (info (pure McList <**> helper) (progDesc "List method collections"))
-                    <> OA.command "upload" (info (McUpload <$> uploadArgsParser <**> helper) (progDesc "Upload a method collection from a local file"))
-                    <> OA.command "delete" (info (McDelete <$> deleteNameParser <**> helper) (progDesc "Delete a method collection"))
-                    <> OA.command "export" (info (McExport <$> mcExportArgsParser <**> helper) (progDesc "Export a loaded method collection to a file (SimaPro CSV, columnar CSV, openLCA JSON-LD, or ILCD method package)"))
+                ( cmd "list" (pure McList) "List method collections"
+                    <> cmd "upload" (McUpload <$> uploadArgsParser) "Upload a method collection from a local file"
+                    <> cmd "delete" (McDelete <$> deleteNameParser) "Delete a method collection"
+                    <> cmd "export" (McExport <$> mcExportArgsParser) "Export a loaded method collection to a file (SimaPro CSV, columnar CSV, openLCA JSON-LD, or ILCD method package)"
                 )
             )
 
@@ -281,7 +292,7 @@ flowParser = do
 flowSubCommandParser :: Parser FlowSubCommand
 flowSubCommandParser =
     subparser
-        (OA.command "activities" (info (pure FlowActivities <**> helper) (progDesc "List activities using this flow")))
+        (cmd "activities" (pure FlowActivities) "List activities using this flow")
 
 -- | Search activities parser (now top-level)
 searchActivitiesParser :: Parser Command

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -113,11 +113,11 @@ databaseParser =
     Database . fromMaybe DbList
         <$> optional
             ( subparser
-                ( OA.command "list" (info (pure DbList) (progDesc "List databases"))
+                ( OA.command "list" (info (pure DbList <**> helper) (progDesc "List databases"))
                     <> OA.command "load" (info (DbLoad <$> textArg "DB" "Name of the configured database to load" <**> helper) (progDesc "Load a configured database into memory"))
                     <> OA.command "unload" (info (DbUnload <$> textArg "DB" "Name of the loaded database to unload" <**> helper) (progDesc "Unload a database from memory"))
-                    <> OA.command "upload" (info (DbUpload <$> uploadArgsParser) (progDesc "Upload a database from a local file"))
-                    <> OA.command "delete" (info (DbDelete <$> deleteNameParser) (progDesc "Delete a database"))
+                    <> OA.command "upload" (info (DbUpload <$> uploadArgsParser <**> helper) (progDesc "Upload a database from a local file"))
+                    <> OA.command "delete" (info (DbDelete <$> deleteNameParser <**> helper) (progDesc "Delete a database"))
                     <> OA.command "delete-activities" (info (DbDeleteActivities <$> deleteActivitiesArgsParser <**> helper) (progDesc "Delete the whole filtered set of activities from a loaded database"))
                     <> OA.command "copy" (info (copyArgsParser <**> helper) (progDesc "Copy a loaded database under a new name"))
                     <> OA.command "relink" (info (DbRelinkMapping <$> relinkArgsParser <**> helper) (progDesc "Relink a database to a dependency using a supplier alias CSV (source/target names, optional locations)"))
@@ -219,9 +219,9 @@ methodParser =
     Method . fromMaybe McList
         <$> optional
             ( subparser
-                ( OA.command "list" (info (pure McList) (progDesc "List method collections"))
-                    <> OA.command "upload" (info (McUpload <$> uploadArgsParser) (progDesc "Upload a method collection from a local file"))
-                    <> OA.command "delete" (info (McDelete <$> deleteNameParser) (progDesc "Delete a method collection"))
+                ( OA.command "list" (info (pure McList <**> helper) (progDesc "List method collections"))
+                    <> OA.command "upload" (info (McUpload <$> uploadArgsParser <**> helper) (progDesc "Upload a method collection from a local file"))
+                    <> OA.command "delete" (info (McDelete <$> deleteNameParser <**> helper) (progDesc "Delete a method collection"))
                     <> OA.command "export" (info (McExport <$> mcExportArgsParser <**> helper) (progDesc "Export a loaded method collection to a file (SimaPro CSV, columnar CSV, openLCA JSON-LD, or ILCD method package)"))
                 )
             )
@@ -281,7 +281,7 @@ flowParser = do
 flowSubCommandParser :: Parser FlowSubCommand
 flowSubCommandParser =
     subparser
-        (OA.command "activities" (info (pure FlowActivities) (progDesc "List activities using this flow")))
+        (OA.command "activities" (info (pure FlowActivities <**> helper) (progDesc "List activities using this flow")))
 
 -- | Search activities parser (now top-level)
 searchActivitiesParser :: Parser Command

--- a/src/CLI/Repl.hs
+++ b/src/CLI/Repl.hs
@@ -20,6 +20,7 @@ import qualified Options.Applicative as OA
 import System.Console.Haskeline
 import System.Directory (getTemporaryDirectory)
 import System.Environment (getExecutablePath)
+import System.Exit (ExitCode (..))
 import System.FilePath ((</>))
 import System.IO (IOMode (..), hFlush, openFile, stdout)
 import System.Process (CreateProcess (..), ProcessHandle, StdStream (..), createProcess, proc)
@@ -112,14 +113,19 @@ runRepl mgr rc globalOpts cfgFile = do
     dispatch stateRef tokens = liftIO $ do
         st <- readIORef stateRef
         let opts = globalOpts{dbName = rsDb st, format = rsFormat st}
-        case parseCommand tokens of
-            Just cmd -> executeRemoteCommand mgr rc opts cmd
-            Nothing -> putStrLn "Unknown command. Type :help for usage."
+        case OA.execParserPure OA.defaultPrefs (OA.info (commandParser OA.<**> OA.helper) mempty) tokens of
+            OA.Success cmd -> executeRemoteCommand mgr rc opts cmd
+            OA.CompletionInvoked _ -> putStrLn unknownCommand
+            -- A parser answers --help by failing with the help text and an
+            -- exit code of zero. Reading only the success case, as
+            -- getParseResult does, made every --help here read as a command
+            -- nobody knows - in the one place a user types it by reflex.
+            OA.Failure failure -> case OA.renderFailure failure "volca" of
+                (helpText, ExitSuccess) -> putStrLn helpText
+                (_, ExitFailure _) -> putStrLn unknownCommand
         return True
 
-    parseCommand tokens =
-        OA.getParseResult $
-            OA.execParserPure OA.defaultPrefs (OA.info (commandParser OA.<**> OA.helper) mempty) tokens
+    unknownCommand = "Unknown command. Type :help for usage."
 
     cleanupServer _stateRef = pure ()
 

--- a/src/Tools/SynonymsCompiler.hs
+++ b/src/Tools/SynonymsCompiler.hs
@@ -74,8 +74,8 @@ outputOpts =
 optParser :: Parser Options
 optParser =
     subparser
-        ( command "json" (info jsonParser (progDesc "Compile from JSON (legacy mode)"))
-            <> command "sources" (info sourcesParser (progDesc "Build from ILCD flows + pair CSVs"))
+        ( command "json" (info (jsonParser <**> helper) (progDesc "Compile from JSON (legacy mode)"))
+            <> command "sources" (info (sourcesParser <**> helper) (progDesc "Build from ILCD flows + pair CSVs"))
         )
         <|> jsonParser -- default to JSON mode for backward compatibility
 

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -8,6 +8,7 @@ import Options.Applicative (
     execParserPure,
     renderFailure,
  )
+import System.Exit (ExitCode (..))
 import Test.Hspec
 
 import CLI.Parser (cliParserInfo)
@@ -31,6 +32,59 @@ parseCmd argv = case runParse argv of
 
 spec :: Spec
 spec = do
+    describe "--help on every subcommand" $ do
+        -- A parser built without `helper` does not know --help, so it rejects
+        -- it: usage on the error stream, non-zero exit, nothing for whoever
+        -- was capturing the help. That is invisible from the terminal, where
+        -- the usage still appears, which is how four documentation files came
+        -- to be committed empty. So it is asked of every subcommand here.
+        let answersHelp argv = case execParserPure defaultPrefs cliParserInfo (argv <> ["--help"]) of
+                Failure f -> snd (renderFailure f "volca") == ExitSuccess
+                Success _ -> False
+                CompletionInvoked _ -> False
+            subcommands =
+                [ ["server"]
+                , ["activity", "x"]
+                , ["inventory", "x"]
+                , ["flow", "x"]
+                , ["flow", "x", "activities"]
+                , ["activities"]
+                , ["flows"]
+                , ["impacts", "x"]
+                , ["debug-matrices"]
+                , ["export-matrices"]
+                , ["database"]
+                , ["database", "list"]
+                , ["database", "load", "x"]
+                , ["database", "unload", "x"]
+                , ["database", "upload", "f"]
+                , ["database", "delete", "x"]
+                , ["database", "delete-activities"]
+                , ["database", "copy", "x"]
+                , ["database", "relink", "x"]
+                , ["database", "export", "x"]
+                , ["database", "create-activities", "x"]
+                , ["database", "replace-activity", "x"]
+                , ["database", "edit-exchanges", "x"]
+                , ["method"]
+                , ["method", "list"]
+                , ["method", "upload", "f"]
+                , ["method", "delete", "x"]
+                , ["method", "export", "x"]
+                , ["methods"]
+                , ["synonyms"]
+                , ["compartment-mappings"]
+                , ["units"]
+                , ["flow-mapping"]
+                , ["stop"]
+                , ["repl"]
+                , ["dump-openapi"]
+                , ["dump-mcp-tools"]
+                ]
+        mapM_
+            (\argv -> it (unwords argv <> " --help describes itself") $ answersHelp argv `shouldBe` True)
+            subcommands
+
     describe "CLI.Types.parseOutputFormat" $ do
         let cases =
                 [ ("json", Just JSON)


### PR DESCRIPTION
`volca database upload --help` answered ``Invalid option `--help'`` and exited 1. So did `database list`, `database delete`, `method list`, `method upload`, `method delete` and `flow activities`: seven parsers built without `helper`, so `--help` was not an option they knew.

The usage text did come out, but on the error stream and behind a failing exit, which makes it invisible to anything capturing a command's help rather than reading a terminal. The documentation generator that dumps this help into the site has been writing four empty files for exactly that reason, and the site renders them as empty code blocks.

Verified on all seven: each now prints its usage and exits 0.

The companion change on the deployment side regenerates the committed help artifacts once this is in; it needs a binary built from this commit, so it follows rather than accompanies.