### PR TITLE
Say which keys of the configuration nothing reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@
   The default sentence now opens with "This engine is configured read-only"
   instead of "This instance is read-only", naming who to talk to about it.
 
+### Changed
+- Startup now says which keys of the configuration file nothing reads. A
+  configuration is a list of things the engine looks for, so anything it does
+  not look for was dropped without a word, however it got that way: written
+  under the wrong section header (`geographies` below `[server]` becomes
+  `server.geographies`), spelled with the wrong separator, or named the way an
+  older release named it. Each unread key gets a line naming its path, and
+  `[[databases]] active` is named as having become `load`, which is why a
+  configuration written before that rename started up loading nothing at all.
+  A warning rather than a refusal: a key from a later release should not stop
+  an older engine.
+
 ### Fixed
 - `--help` now describes every subcommand, including inside the REPL. Nine
   answered something else. `database upload`, `database delete`,

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -36,6 +37,11 @@ module Config (
     freePortHost,
     clientHost,
 
+    -- * Keys nothing reads
+    KeySpec (..),
+    configKeys,
+    unknownKeys,
+
     -- * VOLCA_DATA_DIR resolution
     redirectIntoDataDir,
     applyDataDir,
@@ -58,12 +64,14 @@ import Data.Maybe (fromMaybe, isNothing)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.IO as TIO
 import Database.Upload (DatabaseFormat (..))
 import GHC.Generics (Generic)
+import Progress (ProgressLevel (..), reportProgress)
 import System.Directory (doesFileExist)
 import System.Environment (lookupEnv)
 import System.FilePath (isAbsolute, normalise, takeDirectory, takeFileName, (</>))
-import TOML (DecodeTOML (..), Decoder, decodeFile, getArrayOf, getField, getFieldOpt, getFieldOptWith, getFieldWith)
+import TOML (DecodeTOML (..), Decoder, TOMLError, Table, Value (..), decode, getArrayOf, getField, getFieldOpt, getFieldOptWith, getFieldWith)
 import Types (GeographyPolicy (..))
 
 -- | A single classification filter entry (system + value)
@@ -533,10 +541,133 @@ loadConfigFile path = do
     if not exists
         then pure $ Left $ "Config file not found: " <> T.pack path
         else do
-            result <- decodeFile path
-            case result of
-                Right cfg -> pure $ Right cfg
+            text <- TIO.readFile path
+            case decode text of
                 Left err -> pure $ Left $ "TOML parse error: " <> T.pack (show err)
+                Right cfg -> do
+                    mapM_ (reportProgress Warning . T.unpack) (unreadKeyWarnings path text)
+                    pure $ Right cfg
+
+{- | One line per key of the file no decoder reads.
+
+A warning, not a refusal: a key from a later release should not stop an older
+engine. But saying nothing is worse than either, because the ways a key goes
+unread are all invisible - written under the wrong section header, spelled
+with the wrong separator, or named the way an older release named it.
+-}
+unreadKeyWarnings :: FilePath -> Text -> [Text]
+unreadKeyWarnings path text = map complain (either (const []) (unknownKeys configKeys) parsed)
+  where
+    parsed = decode text :: Either TOMLError Table
+    complain key = T.pack path <> ": nothing reads " <> key <> maybe "" hint (lookup key renamedKeys)
+    hint replacement = " (renamed to " <> replacement <> ")"
+
+{- | Keys an earlier release read, and what replaced them, so a configuration
+written against one says why it stopped working rather than only that a key is
+unread. Keyed by the path 'unknownKeys' reports, with any array index dropped.
+-}
+renamedKeys :: [(Text, Text)]
+renamedKeys = [("databases[].active", "load")]
+
+{- | What one part of the configuration accepts: keys read for their value,
+and the parts nested under it.
+-}
+data KeySpec
+    = Accepts [Text] [(Text, KeySpec)]
+    | {- | The caller names the keys, so none of them can be unknown: a scoring
+      set's variables, a database's location aliases.
+      -}
+      AcceptsAnything
+    deriving (Show, Eq)
+
+{- | Every key the decoders in this module read, in the shape a file has them.
+
+Kept beside the decoders because it is only worth having while it matches
+them: a decoder gaining a field and this not is a key reported unread that is
+read perfectly well.
+-}
+configKeys :: KeySpec
+configKeys =
+    Accepts
+        ["geographies", "chem-synonyms", "substance-edges"]
+        [ ("server", Accepts ["port", "host", "password", "name"] [])
+        , ("hosting", Accepts hostingKeys [])
+        ,
+            ( "databases"
+            , Accepts
+                ["name", "displayName", "path", "description", "load", "default", "depends", "deletable", "geography_policy"]
+                [("locationAliases", AcceptsAnything)]
+            )
+        ,
+            ( "methods"
+            , Accepts
+                ["name", "path", "active", "description", "global-methods"]
+                [("scoring", scoringSet), ("patches", patch)]
+            )
+        , ("flow-synonyms", refData)
+        , ("compartment-mappings", refData)
+        , ("units", refData)
+        , ("energy-densities", refData)
+        ,
+            ( "classification-presets"
+            , Accepts ["name", "label", "description"] [("filters", Accepts ["system", "value", "mode"] [])]
+            )
+        ]
+  where
+    hostingKeys =
+        [ "max_uploads"
+        , "max_upload_mb"
+        , "max_loaded_uploads"
+        , "api_access"
+        , "read_only"
+        , "read_only_message"
+        , "upgrade_upload"
+        , "upgrade_api"
+        , "upgrade_vm_size"
+        ]
+    refData = Accepts ["path", "name", "active", "description"] []
+    scoringSet =
+        Accepts
+            ["name", "unit", "displayMultiplier"]
+            [(k, AcceptsAnything) | k <- ["variables", "computed", "labels", "normalization", "weighting", "scores"]]
+    patch =
+        Accepts
+            ["description", "scale", "set-value"]
+            [("match", Accepts ["category", "flow-name", "flow-name-prefix", "cas", "subcompartment-contains"] [])]
+
+{- | The dotted path of every key of a parsed document that the given shape
+does not name, an array written @name[]@ because the complaint is about the
+key rather than about one of its occurrences. Sorted and without repeats, so
+a file listing twenty databases with the same stale key says it once.
+-}
+unknownKeys :: KeySpec -> Table -> [Text]
+unknownKeys spec = S.toAscList . S.fromList . walk [] spec
+  where
+    walk _ AcceptsAnything _ = []
+    walk here (Accepts keys sections) table = concatMap (judge here keys sections) (M.toList table)
+
+    judge here keys sections (key, value) = case lookup key sections of
+        Just nested -> let (segment, tables) = sectionUnder key value in concatMap (walk (here <> [segment]) nested) tables
+        Nothing
+            | key `elem` keys -> []
+            | otherwise -> [T.intercalate "." (here <> [key])]
+
+    -- How a section is written in a path, and the tables it holds. A section
+    -- is a table or an array of tables wherever a decoder reads one, and a
+    -- value of any other shape has already failed to decode, so there is
+    -- nothing under it left to judge.
+    sectionUnder :: Text -> Value -> (Text, [Table])
+    sectionUnder key = \case
+        Table t -> (key, [t])
+        Array vs -> (key <> "[]", concatMap (snd . sectionUnder key) vs)
+        String{} -> (key, [])
+        Integer{} -> (key, [])
+        Float{} -> (key, [])
+        Boolean{} -> (key, [])
+        OffsetDateTime{} -> (key, [])
+        LocalDateTime{} -> (key, [])
+        LocalDate{} -> (key, [])
+        LocalTime{} -> (key, [])
 
 {- | Load configuration, with validation. Honours VOLCA_DATA_DIR: when set,
 any reference-data path beginning with "data/" (e.g. "data/flows.csv")

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -40,6 +40,8 @@ module Config (
     -- * Keys nothing reads
     KeySpec (..),
     configKeys,
+    keyPaths,
+    documentKeyPaths,
     unknownKeys,
 
     -- * VOLCA_DATA_DIR resolution
@@ -71,7 +73,7 @@ import Progress (ProgressLevel (..), reportProgress)
 import System.Directory (doesFileExist)
 import System.Environment (lookupEnv)
 import System.FilePath (isAbsolute, normalise, takeDirectory, takeFileName, (</>))
-import TOML (DecodeTOML (..), Decoder, TOMLError, Table, Value (..), decode, getArrayOf, getField, getFieldOpt, getFieldOptWith, getFieldWith)
+import TOML (DecodeTOML (..), Decoder, TOMLError, Table, Value (..), decode, decodeFile, getArrayOf, getField, getFieldOpt, getFieldOptWith, getFieldWith)
 import Types (GeographyPolicy (..))
 
 -- | A single classification filter entry (system + value)
@@ -541,12 +543,20 @@ loadConfigFile path = do
     if not exists
         then pure $ Left $ "Config file not found: " <> T.pack path
         else do
+            -- The keys first, and from the text rather than from the decoded
+            -- configuration: a document that parses can say which of its keys
+            -- nothing reads whether or not it then decodes, and an operator
+            -- fixing one mistake per restart pays minutes a time on a machine
+            -- that is already running.
             text <- TIO.readFile path
-            case decode text of
-                Left err -> pure $ Left $ "TOML parse error: " <> T.pack (show err)
-                Right cfg -> do
-                    mapM_ (reportProgress Warning . T.unpack) (unreadKeyWarnings path text)
-                    pure $ Right cfg
+            mapM_ (reportProgress Warning . T.unpack) (unreadKeyWarnings path text)
+            -- decodeFile rather than the text just read: it hands the parser
+            -- the file name, so a syntax error says which file, which matters
+            -- most where the engine reads a document assembled from two.
+            result <- decodeFile path
+            pure $ case result of
+                Right cfg -> Right cfg
+                Left err -> Left $ "TOML parse error: " <> T.pack (show err)
 
 {- | One line per key of the file no decoder reads.
 
@@ -554,6 +564,9 @@ A warning, not a refusal: a key from a later release should not stop an older
 engine. But saying nothing is worse than either, because the ways a key goes
 unread are all invisible - written under the wrong section header, spelled
 with the wrong separator, or named the way an older release named it.
+
+Nothing to say about a document that does not parse: the decode that follows
+reports that, and better.
 -}
 unreadKeyWarnings :: FilePath -> Text -> [Text]
 unreadKeyWarnings path text = map complain (either (const []) (unknownKeys configKeys) parsed)
@@ -569,11 +582,15 @@ unread. Keyed by the path 'unknownKeys' reports, with any array index dropped.
 renamedKeys :: [(Text, Text)]
 renamedKeys = [("databases[].active", "load")]
 
-{- | What one part of the configuration accepts: keys read for their value,
-and the parts nested under it.
+{- | What one part of the configuration accepts: the keys read there, each
+with what is accepted under it. A key read for its value alone accepts an
+empty map.
+
+One map rather than a list of keys beside a list of sections, so a key cannot
+be declared as both and then be silently resolved one way.
 -}
 data KeySpec
-    = Accepts [Text] [(Text, KeySpec)]
+    = Accepts (Map Text KeySpec)
     | {- | The caller names the keys, so none of them can be unknown: a scoring
       set's variables, a database's location aliases.
       -}
@@ -588,21 +605,23 @@ read perfectly well.
 -}
 configKeys :: KeySpec
 configKeys =
-    Accepts
-        ["geographies", "chem-synonyms", "substance-edges"]
-        [ ("server", Accepts ["port", "host", "password", "name"] [])
-        , ("hosting", Accepts hostingKeys [])
+    keys
+        [ ("geographies", value)
+        , ("chem-synonyms", value)
+        , ("substance-edges", value)
+        , ("server", keys (map plain ["port", "host", "password", "name"]))
+        , ("hosting", keys (map plain hostingKeys))
         ,
             ( "databases"
-            , Accepts
-                ["name", "displayName", "path", "description", "load", "default", "depends", "deletable", "geography_policy"]
-                [("locationAliases", AcceptsAnything)]
+            , keys $
+                map plain ["name", "displayName", "path", "description", "load", "default", "depends", "deletable", "geography_policy"]
+                    <> [("locationAliases", AcceptsAnything)]
             )
         ,
             ( "methods"
-            , Accepts
-                ["name", "path", "active", "description", "global-methods"]
-                [("scoring", scoringSet), ("patches", patch)]
+            , keys $
+                map plain ["name", "path", "active", "description", "global-methods"]
+                    <> [("scoring", scoringSet), ("patches", patch)]
             )
         , ("flow-synonyms", refData)
         , ("compartment-mappings", refData)
@@ -610,10 +629,15 @@ configKeys =
         , ("energy-densities", refData)
         ,
             ( "classification-presets"
-            , Accepts ["name", "label", "description"] [("filters", Accepts ["system", "value", "mode"] [])]
+            , keys $
+                map plain ["name", "label", "description"]
+                    <> [("filters", keys (map plain ["system", "value", "mode"]))]
             )
         ]
   where
+    keys = Accepts . M.fromList
+    value = Accepts M.empty
+    plain k = (k, value)
     hostingKeys =
         [ "max_uploads"
         , "max_upload_mb"
@@ -625,15 +649,25 @@ configKeys =
         , "upgrade_api"
         , "upgrade_vm_size"
         ]
-    refData = Accepts ["path", "name", "active", "description"] []
+    refData = keys (map plain ["path", "name", "active", "description"])
     scoringSet =
-        Accepts
-            ["name", "unit", "displayMultiplier"]
-            [(k, AcceptsAnything) | k <- ["variables", "computed", "labels", "normalization", "weighting", "scores"]]
+        keys $
+            map plain ["name", "unit", "displayMultiplier"]
+                <> [(k, AcceptsAnything) | k <- ["variables", "computed", "labels", "normalization", "weighting", "scores"]]
     patch =
-        Accepts
-            ["description", "scale", "set-value"]
-            [("match", Accepts ["category", "flow-name", "flow-name-prefix", "cas", "subcompartment-contains"] [])]
+        keys $
+            map plain ["description", "scale", "set-value"]
+                <> [("match", keys (map plain ["category", "flow-name", "flow-name-prefix", "cas", "subcompartment-contains"]))]
+
+{- | Every key a shape names, as the dotted paths 'unknownKeys' reports: what
+a document has to spell out to exercise the whole of it.
+-}
+keyPaths :: KeySpec -> [Text]
+keyPaths = go []
+  where
+    go _ AcceptsAnything = []
+    go here (Accepts known) =
+        concat [T.intercalate "." (reverse (k : here)) : go (k : here) nested | (k, nested) <- M.toList known]
 
 {- | The dotted path of every key of a parsed document that the given shape
 does not name, an array written @name[]@ because the complaint is about the
@@ -644,30 +678,40 @@ unknownKeys :: KeySpec -> Table -> [Text]
 unknownKeys spec = S.toAscList . S.fromList . walk [] spec
   where
     walk _ AcceptsAnything _ = []
-    walk here (Accepts keys sections) table = concatMap (judge here keys sections) (M.toList table)
+    walk here (Accepts known) table = concatMap (judge here known) (M.toList table)
 
-    judge here keys sections (key, value) = case lookup key sections of
-        Just nested -> let (segment, tables) = sectionUnder key value in concatMap (walk (here <> [segment]) nested) tables
-        Nothing
-            | key `elem` keys -> []
-            | otherwise -> [T.intercalate "." (here <> [key])]
+    judge here known (key, val) = case M.lookup key known of
+        Nothing -> [T.intercalate "." (here <> [key])]
+        Just nested -> let (segment, tables) = sectionUnder key val in concatMap (walk (here <> [segment]) nested) tables
 
-    -- How a section is written in a path, and the tables it holds. A section
-    -- is a table or an array of tables wherever a decoder reads one, and a
-    -- value of any other shape has already failed to decode, so there is
-    -- nothing under it left to judge.
-    sectionUnder :: Text -> Value -> (Text, [Table])
-    sectionUnder key = \case
-        Table t -> (key, [t])
-        Array vs -> (key <> "[]", concatMap (snd . sectionUnder key) vs)
-        String{} -> (key, [])
-        Integer{} -> (key, [])
-        Float{} -> (key, [])
-        Boolean{} -> (key, [])
-        OffsetDateTime{} -> (key, [])
-        LocalDateTime{} -> (key, [])
-        LocalDate{} -> (key, [])
-        LocalTime{} -> (key, [])
+{- | The dotted path of every key a parsed document names, written the way
+'unknownKeys' and 'keyPaths' write them. What a document actually exercises,
+against what a shape allows.
+-}
+documentKeyPaths :: Table -> [Text]
+documentKeyPaths = S.toAscList . S.fromList . walk []
+  where
+    walk here table = concatMap (describe here) (M.toList table)
+    describe here (key, val) =
+        let (segment, tables) = sectionUnder key val
+         in T.intercalate "." (here <> [segment]) : concatMap (walk (here <> [segment])) tables
+
+{- | How a section is written in a path, and the tables it holds. A section is
+a table or an array of tables wherever a decoder reads one; a value of any
+other shape holds nothing to walk into.
+-}
+sectionUnder :: Text -> Value -> (Text, [Table])
+sectionUnder key = \case
+    Table t -> (key, [t])
+    Array vs -> (key <> "[]", concatMap (snd . sectionUnder key) vs)
+    String{} -> (key, [])
+    Integer{} -> (key, [])
+    Float{} -> (key, [])
+    Boolean{} -> (key, [])
+    OffsetDateTime{} -> (key, [])
+    LocalDateTime{} -> (key, [])
+    LocalDate{} -> (key, [])
+    LocalTime{} -> (key, [])
 
 {- | Load configuration, with validation. Honours VOLCA_DATA_DIR: when set,
 any reference-data path beginning with "data/" (e.g. "data/flows.csv")

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -18,18 +18,21 @@ import Config (
     ServerConfig (..),
     applyDataDir,
     clientHost,
+    configKeys,
     defaultConfig,
     expandClassificationPreset,
     listenOn,
     loadConfigOrDefault,
     redirectIntoDataDir,
     resolveConfigPaths,
+    unknownKeys,
     validateConfig,
  )
 import Data.Either (isRight)
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.IO as TIO
 import System.FilePath (normalise)
 import qualified TOML
 import Test.Hspec
@@ -87,6 +90,48 @@ spec = do
         it "leaves an address that names one interface alone" $
             map clientHost ["127.0.0.1", "::1", "192.168.1.10", "engine.internal"]
                 `shouldBe` ["127.0.0.1", "::1", "192.168.1.10", "engine.internal"]
+
+    describe "unknownKeys" $ do
+        let unread t = case TOML.decode t :: Either TOML.TOMLError TOML.Table of
+                Left err -> ["did not parse: " <> T.pack (show err)]
+                Right doc -> unknownKeys configKeys doc
+
+        -- The one that matters: a key wrongly reported unread is a warning on
+        -- a file that is perfectly good, which teaches the reader to ignore
+        -- warnings.
+        it "reads every key of the configuration this repository ships" $ do
+            shipped <- TIO.readFile "volca.toml"
+            unread shipped `shouldBe` []
+
+        -- How geographies went missing from the Docker image's own config: a
+        -- top-level key written below a header belongs to that header.
+        it "names a top-level key written under a section" $
+            unread "[server]\nport = 8080\ngeographies = \"data/geographies.csv\"\n"
+                `shouldBe` ["server.geographies"]
+
+        it "names a key an array of tables does not carry" $
+            unread "[[databases]]\nname = \"a\"\npath = \"a.zip\"\nactive = true\n"
+                `shouldBe` ["databases[].active"]
+
+        it "says once what twenty entries get wrong" $
+            unread "[[databases]]\nname=\"a\"\npath=\"a\"\nactive=true\n[[databases]]\nname=\"b\"\npath=\"b\"\nactive=true\n"
+                `shouldBe` ["databases[].active"]
+
+        -- Scoring variables, computed formulas and location aliases are named
+        -- by whoever writes the file, so no name there can be unknown.
+        it "leaves the keys the file's author invents alone" $
+            unread
+                "[[methods]]\nname=\"EF\"\npath=\"x.zip\"\n\
+                \[[methods.scoring]]\nname=\"ECS\"\n\
+                \[methods.scoring.variables]\ncch = \"Climate change\"\n\
+                \[methods.scoring.weighting]\ncch = 0.21\n"
+                `shouldBe` []
+
+        it "reaches a section nested two deep" $
+            unread
+                "[[methods]]\nname=\"EF\"\npath=\"x.zip\"\n\
+                \[[methods.patches]]\nscale = 0.6\nmatch = { flow-name = \"Uranium\", flavour = \"x\" }\n"
+                `shouldBe` ["methods[].patches[].match.flavour"]
 
     describe "expandClassificationPreset" $ do
         let raw =

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -20,7 +20,9 @@ import Config (
     clientHost,
     configKeys,
     defaultConfig,
+    documentKeyPaths,
     expandClassificationPreset,
+    keyPaths,
     listenOn,
     loadConfigOrDefault,
     redirectIntoDataDir,
@@ -98,10 +100,29 @@ spec = do
 
         -- The one that matters: a key wrongly reported unread is a warning on
         -- a file that is perfectly good, which teaches the reader to ignore
-        -- warnings.
+        -- warnings. The shipped configuration exercises about a quarter of the
+        -- schema, so the fixture below names the rest.
         it "reads every key of the configuration this repository ships" $ do
             shipped <- TIO.readFile "volca.toml"
             unread shipped `shouldBe` []
+
+        it "reads every key a document can name" $ do
+            everyKey <- TIO.readFile "test/data/every-config-key.toml"
+            unread everyKey `shouldBe` []
+
+        -- The other direction, so the fixture cannot quietly stop covering
+        -- what it claims to: whatever the schema names, the fixture spells
+        -- out. Without this, a key dropped from configKeys would go on being
+        -- reported unread on every valid file and no test would notice.
+        it "leaves no key of the schema unexercised" $ do
+            everyKey <- TIO.readFile "test/data/every-config-key.toml"
+            case TOML.decode everyKey :: Either TOML.TOMLError TOML.Table of
+                Left err -> expectationFailure (show err)
+                Right doc ->
+                    -- Compared without the [] an array carries in a path: the
+                    -- schema names keys, not how many of each a file holds.
+                    let named = map (T.replace "[]" "") (documentKeyPaths doc)
+                     in filter (`notElem` named) (keyPaths configKeys) `shouldBe` []
 
         -- How geographies went missing from the Docker image's own config: a
         -- top-level key written below a header belongs to that header.

--- a/test/data/every-config-key.toml
+++ b/test/data/every-config-key.toml
@@ -1,0 +1,110 @@
+# Names every key the decoders read, so the unknown-key check is exercised
+# over the whole schema rather than over the quarter of it the shipped
+# volca.toml happens to use. Nothing loads this file; it is read as text.
+#
+# Keeping it complete is what the ConfigSpec assertion is for: it compares
+# what this names against what `configKeys` names, in both directions.
+
+geographies = "data/geographies.csv"
+chem-synonyms = "data/chem_synonyms.csv"
+substance-edges = "data/substance_edges.csv"
+
+[server]
+port = 8080
+host = "127.0.0.1"
+password = "secret"
+name = "every-key"
+
+[hosting]
+max_uploads = 2
+max_upload_mb = 100
+max_loaded_uploads = 1
+api_access = true
+read_only = false
+read_only_message = "Ask the operator."
+upgrade_upload = "upload"
+upgrade_api = "api"
+upgrade_vm_size = "size"
+
+[[databases]]
+name = "db"
+displayName = "Db"
+path = "db.zip"
+description = "a database"
+load = true
+default = true
+depends = ["other"]
+deletable = false
+geography_policy = "parent"
+
+[databases.locationAliases]
+"FR " = "FR"
+
+[[methods]]
+name = "EF"
+path = "ef.zip"
+active = true
+description = "a method collection"
+global-methods = ["Land use"]
+
+[[methods.scoring]]
+name = "ECS"
+unit = "Pts"
+displayMultiplier = 1e6
+
+[methods.scoring.variables]
+cch = "Climate change"
+
+[methods.scoring.computed]
+tot = "2 * cch"
+
+[methods.scoring.labels]
+tot = "Total"
+
+[methods.scoring.normalization]
+cch = 7553.08
+
+[methods.scoring.weighting]
+cch = 0.2106
+
+[methods.scoring.scores]
+total = "cch"
+
+[[methods.patches]]
+description = "a patch"
+match = { category = "Resource use, fossils", flow-name = "Uranium", flow-name-prefix = "Ura", cas = "7440-61-1", subcompartment-contains = "long-term" }
+scale = 0.6
+
+[[methods.patches]]
+match = { flow-name = "Other" }
+set-value = 0.0
+
+[[flow-synonyms]]
+name = "Default flow synonyms"
+path = "data/flows.csv"
+active = true
+description = "synonyms"
+
+[[compartment-mappings]]
+name = "Default compartment mapping"
+path = "data/compartments.csv"
+active = true
+description = "compartments"
+
+[[units]]
+name = "Default units"
+path = "data/units.csv"
+active = true
+description = "units"
+
+[[energy-densities]]
+name = "Default energy densities"
+path = "data/energy_density.csv"
+active = true
+description = "densities"
+
+[[classification-presets]]
+name = "raw"
+label = "Raw"
+description = "a preset"
+filters = [{ system = "Category", value = "Agricultural", mode = "contains" }]


### PR DESCRIPTION
A decoder asks for the keys it knows and never looks at what is left, so a key that misses its mark is dropped without a word. Every way of missing looks identical from outside the program:

- a top-level key written below a section header belongs to that section. `geographies` under `[server]` becomes `server.geographies`, which is how the published Docker image ran without a geography hierarchy while shipping the CSV.
- a separator spelled the other way is a different key.
- a key an older release read under another name is simply gone. A configuration written before `[[databases]] active` became `load` starts up loading nothing at all, and says nothing about why.

Each one produces an engine running without the thing its file asked for, and no way to tell from the outside.

So the document is parsed a second time as a plain table and compared against a list of what the decoders read. Unread keys get one line each, naming the path, and `active` names the key that replaced it. A warning rather than a refusal: a key from a later release should not stop an older engine, and the point is to be told rather than to be stopped.

The list is only worth having while it matches the decoders, so it sits beside them and a test reads the configuration this repository ships and expects silence. Checked against three real configurations that are not in the test suite either, all silent; and a file with both classic mistakes reports both:

```
[WARN] bad.toml: nothing reads databases[].active (renamed to load)
[WARN] bad.toml: nothing reads server.geographies
```

Sections whose keys the file's author invents (scoring variables, computed formulas, normalization and weighting tables, location aliases) are marked as such, so nothing under them is ever reported.