### PR TITLE
Find a flow whose name the user did not punctuate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,18 @@
   `water fossil` returned nothing at all while `water, fossil` returned eight
   results, because the whole query was looked up as one piece of text and the
   comma is part of the name. Every word of the query is now looked for on its
-  own, in any order, so `fossil water` finds it too. Searching by fragment is
-  unchanged: `chlor` still reaches `Trichloroethane`.
+  own, in any order, so `fossil water` finds it too, and a word is still looked
+  for inside longer words: `chlor` reaches `Trichloroethane`.
+  Two consequences worth knowing. Results are no longer purely alphabetical:
+  with no sort column asked for, the flows whose name carries the query as you
+  typed it come first, then those carrying all its words, then the rest. This
+  is what keeps the exact flow on the first page, since looking for words
+  separately returns a good deal more than before. And a punctuated query is
+  now a set of words rather than one string, so `2,4-D` also returns names
+  holding a 2, a 4 and a d elsewhere. They sort below the flow actually named
+  `2,4-D`.
+  A search with an empty query returns nothing instead of the whole catalogue,
+  which is what asking for no flow in particular already did.
 - `--help` now describes every subcommand, including inside the REPL. Nine
   answered something else. `database upload`, `database delete`,
   `method upload` and `method delete` printed ``Invalid option `--help'`` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
   instead of "This instance is read-only", naming who to talk to about it.
 
 ### Fixed
+- Searching flows now finds a flow whose name you didn't punctuate exactly.
+  `water fossil` returned nothing at all while `water, fossil` returned eight
+  results, because the whole query was looked up as one piece of text and the
+  comma is part of the name. Every word of the query is now looked for on its
+  own, in any order, so `fossil water` finds it too. Searching by fragment is
+  unchanged: `chlor` still reaches `Trichloroethane`.
 - `--help` now describes every subcommand, including inside the REPL. Nine
   answered something else. `database upload`, `database delete`,
   `method upload` and `method delete` printed ``Invalid option `--help'`` and

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -1030,7 +1030,13 @@ every match across all pages, or use ``.page(n)`` for explicit
 access. See :meth:`search_activities` for the pagination contract.
 
 Args:
-    query: Substring matched case-insensitively against flow names.
+    query: Words matched case-insensitively against flow names and
+        synonyms. Every word must appear, in any order, and a word
+        matches inside a longer one (``chlor`` finds
+        ``Trichloroethane``). Punctuation separates words, so
+        ``water fossil`` and ``water, fossil`` search alike. With no
+        ``sort`` asked for, names carrying the query as typed come
+        first. An empty query returns nothing.
     page / page_size: Web-style pagination; convert to wire-level
         ``offset`` / ``limit``.
     limit / offset: Wire-level escape hatch.

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -1403,7 +1403,13 @@ class Client:
         access. See :meth:`search_activities` for the pagination contract.
 
         Args:
-            query: Substring matched case-insensitively against flow names.
+            query: Words matched case-insensitively against flow names and
+                synonyms. Every word must appear, in any order, and a word
+                matches inside a longer one (``chlor`` finds
+                ``Trichloroethane``). Punctuation separates words, so
+                ``water fossil`` and ``water, fossil`` search alike. With no
+                ``sort`` asked for, names carrying the query as typed come
+                first. An empty query returns nothing.
             page / page_size: Web-style pagination; convert to wire-level
                 ``offset`` / ``limit``.
             limit / offset: Wire-level escape hatch.

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -4,7 +4,6 @@
 
 module Database where
 
-import Data.Char (isAlphaNum)
 import qualified Data.IntSet as IS
 import qualified Data.Map as M
 import qualified Data.Set as S
@@ -324,13 +323,19 @@ appropriate shape via the 'flowKind*' projections in "API.Types".
 -}
 findFlowsBySynonym :: Database -> Text -> [FlowKind]
 findFlowsBySynonym db query =
-    filter (flowMatchesQuery query) $
-        map TechKind (M.elems (dbTechFlows db))
-            ++ map BioKind (M.elems (dbBioFlows db))
-            ++ map WasteKind (M.elems (dbWasteFlows db))
+    filter (flowMatchesQuery query) (allFlows (dbTechFlows db) (dbBioFlows db) (dbWasteFlows db))
 
-{- | A flow matches when every word of the query appears in its name or one
-of its synonyms, case-blind and in any order.
+-- | Every flow the three maps hold, each tagged with the kind it came from.
+allFlows :: TechFlowDB -> BioFlowDB -> WasteFlowDB -> [FlowKind]
+allFlows tech bio waste =
+    map TechKind (M.elems tech)
+        ++ map BioKind (M.elems bio)
+        ++ map WasteKind (M.elems waste)
+
+{- | A flow matches when every word of the query appears in its name or in
+one of its synonyms, case-blind and in any order. Different words may land
+in different fields: a chemical is often searched by its trade name and its
+compartment at once.
 
 Matching the query as a single string instead made @water fossil@ miss the
 flow named @Water, fossil@: the comma belongs to the name, so the user had
@@ -338,19 +343,34 @@ to punctuate exactly, and @fossil water@ found nothing either.
 
 Words stay substrings rather than whole tokens, because flows are searched
 by fragment: @chlor@ must keep reaching @Trichloroethane@, which no
-tokenizer would return. A query holding no word at all (pure punctuation)
-matches nothing rather than everything.
+tokenizer would return. That width is paid for by 'flowNameRelevance',
+which puts the flow the user actually typed at the top. A query holding no
+word at all (pure punctuation) matches nothing rather than everything.
 -}
 flowMatchesQuery :: Text -> FlowKind -> Bool
-flowMatchesQuery query = case map T.toCaseFold (queryWords query) of
+flowMatchesQuery query = case map T.toCaseFold (Normalize.queryWords query) of
     [] -> const False
-    ws -> \flow -> all (`T.isInfixOf` T.toCaseFold (searchableText flow)) ws
+    ws -> \flow -> all (\w -> any (T.isInfixOf w) (searchableFields flow)) ws
   where
-    searchableText flow =
-        T.unwords (flowKindName flow : concatMap S.toList (M.elems (flowKindSynonyms flow)))
+    searchableFields flow =
+        map
+            T.toCaseFold
+            (flowKindName flow : concatMap S.toList (M.elems (flowKindSynonyms flow)))
 
-{- | Split a query into the words it searches for. Anything not alphanumeric
-separates, so the punctuation a flow name carries never has to be retyped.
+{- | How closely a flow's name answers the query, smallest first: it carries
+the query as it was typed, or it carries every word, or it does neither and
+was reached some other way (through a synonym, or with the words scattered
+over name and synonyms).
+
+Matching word by word widens what comes back a lot, and the result list is
+otherwise alphabetical, so on a real database @oil, crude@ pushed the flow
+named @Oil, crude@ hundreds of rows down a list an assistant only ever sees
+the first page of. Ranking is what keeps the width from costing the answer.
 -}
-queryWords :: Text -> [Text]
-queryWords = filter (not . T.null) . T.split (not . isAlphaNum)
+flowNameRelevance :: Text -> Text -> Int
+flowNameRelevance query name
+    | T.toCaseFold (T.strip query) `T.isInfixOf` folded = 0
+    | all ((`T.isInfixOf` folded) . T.toCaseFold) (Normalize.queryWords query) = 1
+    | otherwise = 2
+  where
+    folded = T.toCaseFold name

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -4,6 +4,7 @@
 
 module Database where
 
+import Data.Char (isAlphaNum)
 import qualified Data.IntSet as IS
 import qualified Data.Map as M
 import qualified Data.Set as S
@@ -323,13 +324,33 @@ appropriate shape via the 'flowKind*' projections in "API.Types".
 -}
 findFlowsBySynonym :: Database -> Text -> [FlowKind]
 findFlowsBySynonym db query =
-    let queryLower = T.toLower query
-        matches name syns =
-            T.isInfixOf queryLower (T.toLower name)
-                || any (any (T.isInfixOf queryLower . T.toLower) . S.toList) (M.elems syns)
-        matchesTech f = matches (tfName f) (tfSynonyms f)
-        matchesBio f = matches (bfName f) (bfSynonyms f)
-        matchesWaste f = matches (wfName f) (wfSynonyms f)
-     in [TechKind f | f <- M.elems (dbTechFlows db), matchesTech f]
-            ++ [BioKind f | f <- M.elems (dbBioFlows db), matchesBio f]
-            ++ [WasteKind f | f <- M.elems (dbWasteFlows db), matchesWaste f]
+    filter (flowMatchesQuery query) $
+        map TechKind (M.elems (dbTechFlows db))
+            ++ map BioKind (M.elems (dbBioFlows db))
+            ++ map WasteKind (M.elems (dbWasteFlows db))
+
+{- | A flow matches when every word of the query appears in its name or one
+of its synonyms, case-blind and in any order.
+
+Matching the query as a single string instead made @water fossil@ miss the
+flow named @Water, fossil@: the comma belongs to the name, so the user had
+to punctuate exactly, and @fossil water@ found nothing either.
+
+Words stay substrings rather than whole tokens, because flows are searched
+by fragment: @chlor@ must keep reaching @Trichloroethane@, which no
+tokenizer would return. A query holding no word at all (pure punctuation)
+matches nothing rather than everything.
+-}
+flowMatchesQuery :: Text -> FlowKind -> Bool
+flowMatchesQuery query = case map T.toCaseFold (queryWords query) of
+    [] -> const False
+    ws -> \flow -> all (`T.isInfixOf` T.toCaseFold (searchableText flow)) ws
+  where
+    searchableText flow =
+        T.unwords (flowKindName flow : concatMap S.toList (M.elems (flowKindSynonyms flow)))
+
+{- | Split a query into the words it searches for. Anything not alphanumeric
+separates, so the punctuation a flow name carries never has to be retyped.
+-}
+queryWords :: Text -> [Text]
+queryWords = filter (not . T.null) . T.split (not . isAlphaNum)

--- a/src/Search/BM25.hs
+++ b/src/Search/BM25.hs
@@ -1,14 +1,15 @@
 {-# LANGUAGE BangPatterns #-}
 
-{- | Pure BM25 ranker for activity search.
+{- | Pure BM25 ranker.
 
-The index is built once at database load time and queried per-request.
-Documents are identified by ProcessId-equivalent Ints (0..N-1), matching
+The index is built once at database load time and queried per-request. A
+document is an Int (0..N-1): its position in the vector the tokens were
+drawn from, which the caller resolves it back through. The one corpus built
+today is the activities, so those Ints are ProcessId-equivalent, matching
 the activity vector layout the rest of the engine uses.
 -}
 module Search.BM25 (
     BM25Index,
-    buildIndex,
     indexActivities,
     addBM25Index,
     score,
@@ -53,7 +54,9 @@ b = 0.75
 A document is its position in the vector and nothing else, so any corpus
 can be indexed here as long as the caller keeps the vector it drew the
 tokens from: activity documents resolve back through the activity vector,
-and a second corpus would resolve through its own.
+and a second corpus would resolve through its own. Kept module-private
+until such a corpus exists, so nothing can build an index whose documents
+the activity-shaped consumers would misread.
 -}
 buildIndex :: V.Vector [Text] -> BM25Index
 buildIndex tokensByDoc =

--- a/src/Search/BM25.hs
+++ b/src/Search/BM25.hs
@@ -9,6 +9,7 @@ the activity vector layout the rest of the engine uses.
 module Search.BM25 (
     BM25Index,
     buildIndex,
+    indexActivities,
     addBM25Index,
     score,
 ) where
@@ -32,7 +33,13 @@ import Types (Activity, Database (..), TechFlowDB, activityName, exchangeFlowId,
 initializeRuntimeFields during database load. Idempotent.
 -}
 addBM25Index :: Database -> Database
-addBM25Index db = db{dbBM25Index = Just (buildIndex (dbActivities db) (dbTechFlows db))}
+addBM25Index db = db{dbBM25Index = Just (indexActivities (dbActivities db) (dbTechFlows db))}
+
+{- | Index the activity corpus: a document is an activity, and its doc id is
+its position in the activity vector the rest of the engine already uses.
+-}
+indexActivities :: V.Vector Activity -> TechFlowDB -> BM25Index
+indexActivities activities flowDb = buildIndex (V.map (documentTokens flowDb) activities)
 
 -- BM25 hyperparameters. Defaults from the canonical Okapi BM25 paper.
 k1 :: Double
@@ -41,16 +48,16 @@ k1 = 1.2
 b :: Double
 b = 0.75
 
-{- | Build the BM25 index for a vector of activities.
-Document text per activity = activity name + reference product name.
-Location is intentionally excluded: it's a structured filter (geoParam),
-not a ranking signal.
+{- | Build the BM25 index from one token list per document.
+
+A document is its position in the vector and nothing else, so any corpus
+can be indexed here as long as the caller keeps the vector it drew the
+tokens from: activity documents resolve back through the activity vector,
+and a second corpus would resolve through its own.
 -}
-buildIndex :: V.Vector Activity -> TechFlowDB -> BM25Index
-buildIndex activities flowDb =
-    let n = V.length activities
-        tokensByDoc :: V.Vector [Text]
-        tokensByDoc = V.map (documentTokens flowDb) activities
+buildIndex :: V.Vector [Text] -> BM25Index
+buildIndex tokensByDoc =
+    let n = V.length tokensByDoc
 
         docLengths :: VU.Vector Int
         docLengths = VU.generate n (\i -> length (tokensByDoc V.! i))
@@ -112,7 +119,10 @@ tokenTrigrams t
             raw = go t
          in M.keys (M.fromList [(tg, ()) | tg <- raw]) -- dedupe
 
--- | Extract searchable tokens for one activity: name + reference product name(s).
+{- | Extract searchable tokens for one activity: name + reference product
+name(s). Location is deliberately excluded: it's a structured filter
+(geoParam), not a ranking signal.
+-}
 documentTokens :: TechFlowDB -> Activity -> [Text]
 documentTokens flowDb a =
     tokenize (activityName a)

--- a/src/Search/Normalize.hs
+++ b/src/Search/Normalize.hs
@@ -5,10 +5,13 @@ the same transformation applies to both sides.
 module Search.Normalize (
     normalize,
     tokenize,
+    queryWords,
     caseInsensitiveInfixOf,
 ) where
 
 import Data.Char (GeneralCategory (NonSpacingMark), generalCategory, isAlphaNum)
+import Data.List (nub, sortOn)
+import Data.Ord (Down (..))
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Normalize as TN
@@ -25,6 +28,29 @@ normalize =
 
 tokenize :: Text -> [Text]
 tokenize = filter (not . T.null) . T.words . normalize
+
+{- | Split a search query into the words it looks for, when those words are
+matched against text that keeps its accents (unlike 'tokenize', which feeds
+an index built on stripped text).
+
+Anything not alphanumeric separates, so punctuation the searched text
+carries never has to be retyped. Three details earn their line:
+
+  * the query is recomposed (NFC) first, because a decomposed accent is a
+    combining mark, which is not alphanumeric and would otherwise cut a
+    word in two;
+  * repeats are dropped, since a word already looked for tells us nothing
+    the second time, and a caller scanning a corpus per word pays for it;
+  * the longest words come first, so a scan that must satisfy every word
+    fails on the most selective one first.
+-}
+queryWords :: Text -> [Text]
+queryWords =
+    sortOn (Down . T.length)
+        . nub
+        . filter (not . T.null)
+        . T.split (not . isAlphaNum)
+        . TN.normalize TN.NFC
 
 {- | Case-insensitive substring test using Unicode case folding.
 @needle `caseInsensitiveInfixOf` haystack@ mirrors 'T.isInfixOf' semantics.

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -29,7 +29,7 @@ import Data.Time (diffUTCTime, getCurrentTime)
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
-import Database (applyStructuredFilters, findActivitiesByFields, findFlowsBySynonym)
+import Database (applyStructuredFilters, findActivitiesByFields, findFlowsBySynonym, flowNameRelevance)
 import Matrix (DepDemands, Inventory, accumulateDepDemandsWith, activityNormalizationFactor, applyBiosphereMatrix, buildDemandVectorFromIndex, computeInventoryMatrix, depDemandsToVector, perturbA, perturbABatch, perturbGlobal, toList)
 import qualified Matrix.Export as MatrixExport
 import qualified Progress
@@ -787,21 +787,30 @@ sub-compartment, read as duplicates. Every sort key therefore continues with
 the remaining displayed fields, so equal-looking rows end up adjacent and
 ordered.
 
+With no column asked for, the flows whose name answers the query best come
+first ('flowNameRelevance'), because matching word by word returns far more
+than the exact name and a client often reads only the first page. Asking for
+a column is asking for that column alone, so the ranking steps aside: a
+table sorted by name must stay alphabetical.
+
 Shared by the REST and MCP/CLI search paths, which differ only in how they
 paginate.
 -}
 flowSearchResults :: UnitDB -> FlowFilter -> [FlowKind] -> [FlowSearchResult]
-flowSearchResults units FlowFilter{ffSort = sortParam, ffOrder = orderParam} =
+flowSearchResults units FlowFilter{ffQuery = query, ffSort = sortParam, ffOrder = orderParam} =
     L.sortBy (direction (\a b -> compare (sortKey a) (sortKey b))) . map toResult
   where
     direction = if orderParam == Just "desc" then flip else id
     -- Parsers turn an absent sub-compartment into 'Nothing', never @""@, so
     -- the empty string sorts where 'Nothing' would: ahead of every named one.
     sub = fromMaybe "" . fsrCompartment
+    -- A column asked for orders on that column alone, so its key carries a
+    -- constant rank; only the default arm ranks.
     sortKey r = case sortParam of
-        Just "category" -> (fsrCategory r, sub r, fsrName r, fsrUnitName r)
-        Just "unit" -> (fsrUnitName r, fsrName r, fsrCategory r, sub r)
-        _ -> (fsrName r, fsrCategory r, sub r, fsrUnitName r)
+        Just "category" -> (0, fsrCategory r, sub r, fsrName r, fsrUnitName r)
+        Just "unit" -> (0, fsrUnitName r, fsrName r, fsrCategory r, sub r)
+        Just "name" -> (0, fsrName r, fsrCategory r, sub r, fsrUnitName r)
+        _ -> (flowNameRelevance query (fsrName r), fsrName r, fsrCategory r, sub r, fsrUnitName r)
     -- Three-arm projections from Types are total over FlowKind.
     toResult flow =
         FlowSearchResult

--- a/test/BM25Spec.hs
+++ b/test/BM25Spec.hs
@@ -11,7 +11,7 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU
 import Test.Hspec
 
-import Search.BM25 (buildIndex, score)
+import Search.BM25 (indexActivities, score)
 import Search.Normalize (tokenize)
 import Types
 
@@ -86,18 +86,18 @@ spec = describe "Search.BM25" $ do
                     , mkActivity "Viande bovine, steak haché, cru" "FR" []
                     , mkActivity "Lait demi-écrémé" "FR" []
                     ]
-            idx = buildIndex acts M.empty
+            idx = indexActivities acts M.empty
             scores = score idx (weighted "steak hache")
         head (ranking scores) `shouldBe` 1
 
     it "returns empty results for no query terms" $ do
         let acts = V.fromList [mkActivity "foo" "GLO" []]
-            idx = buildIndex acts M.empty
+            idx = indexActivities acts M.empty
         ranking (score idx []) `shouldBe` []
 
     it "returns zero scores when no term matches" $ do
         let acts = V.fromList [mkActivity "Electricity" "FR" []]
-            idx = buildIndex acts M.empty
+            idx = indexActivities acts M.empty
         ranking (score idx (weighted "steak")) `shouldBe` []
 
     it "matches reference product names too" $ do
@@ -107,7 +107,7 @@ spec = describe "Search.BM25" $ do
                     [ mkActivity "Production activity alpha" "FR" [mkRefOutput f1]
                     , mkActivity "Electricity, grid" "FR" []
                     ]
-            idx = buildIndex acts flows
+            idx = indexActivities acts flows
             scores = score idx (weighted "lait")
         head (ranking scores) `shouldBe` 0
 
@@ -117,7 +117,7 @@ spec = describe "Search.BM25" $ do
                     [ mkActivity "Steak haché 15% MG" "FR" []
                     , mkActivity "Electricity" "FR" []
                     ]
-            idx = buildIndex acts M.empty
+            idx = indexActivities acts M.empty
         head (ranking (score idx (weighted "HACHE"))) `shouldBe` 0
         head (ranking (score idx (weighted "Haché"))) `shouldBe` 0
         head (ranking (score idx (weighted "hache"))) `shouldBe` 0
@@ -130,7 +130,7 @@ spec = describe "Search.BM25" $ do
                     [ mkActivity longTxt "FR" []
                     , mkActivity short "FR" []
                     ]
-            idx = buildIndex acts M.empty
+            idx = indexActivities acts M.empty
             scores = score idx (weighted "bovine steak")
         head (ranking scores) `shouldBe` 1
 
@@ -143,7 +143,7 @@ spec = describe "Search.BM25" $ do
                     , mkActivity "Viande de porc" "FR" []
                     , mkActivity "Electricity, grid" "FR" []
                     ]
-            idx = buildIndex acts M.empty
+            idx = indexActivities acts M.empty
             scores = score idx (weighted "steak viande")
             retrieved = ranking scores
         length retrieved `shouldBe` 2
@@ -159,6 +159,6 @@ spec = describe "Search.BM25" $ do
                     [ mkActivity "Lait demi-écrémé" "FR" []
                     , mkActivity "Electricity grid" "FR" []
                     ]
-            idx = buildIndex acts M.empty
+            idx = indexActivities acts M.empty
             scores = score idx (weighted "FR")
         ranking scores `shouldBe` []

--- a/test/FlowSearchSpec.hs
+++ b/test/FlowSearchSpec.hs
@@ -13,10 +13,18 @@ import qualified Data.Map as M
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.UUID as UUID
-import Database (flowMatchesQuery)
+import Database (allFlows, flowMatchesQuery)
 import Service (FlowFilter (..), flowSearchResults)
 import Test.Hspec
-import Types (BiosphereFlow (..), Compartment (..), FlowKind (..), UUID)
+import Types (
+    BiosphereFlow (..),
+    Compartment (..),
+    FlowKind (..),
+    TechnosphereFlow (..),
+    UUID,
+    WasteFlow (..),
+    flowKindName,
+ )
 
 spec :: Spec
 spec = do
@@ -46,6 +54,20 @@ matchSpec = describe "Database.flowMatchesQuery" $ do
     it "matches nothing when the query holds no word at all" $
         flowMatchesQuery ", " waterFossil `shouldBe` False
 
+    it "reads a query whose accents arrived decomposed" $
+        -- Pasting from another application can deliver NFD, where the accent
+        -- is a separate combining mark (here U+0301 after a plain "e").
+        -- Splitting on it would search for "pe" and "trole" instead of the
+        -- word the user typed.
+        flowMatchesQuery "Pe\769trole" (namedFlow "Pétrole brut" []) `shouldBe` True
+
+    it "searches a punctuated name for the pieces the user typed" $
+        flowMatchesQuery "2,4-D" (namedFlow "2,4-D" []) `shouldBe` True
+
+    it "looks in every family of flows, not only the biosphere" $
+        map flowKindName (allFlows techMap bioMap wasteMap)
+            `shouldMatchList` ["tap water", "Water, fossil", "Waste paperboard"]
+
 waterFossil :: FlowKind
 waterFossil = namedFlow "Water, fossil" []
 
@@ -54,6 +76,15 @@ laughingGas = namedFlow "Dinitrogen monoxide" ["laughing gas", "nitrous oxide"]
 
 namedFlow :: Text -> [Text] -> FlowKind
 namedFlow name syns = BioKind (biosphere 0 name syns)
+
+techMap :: M.Map UUID TechnosphereFlow
+techMap = M.singleton (mkUUID 1) (TechnosphereFlow (mkUUID 1) "tap water" (mkUUID 0) M.empty Nothing Nothing)
+
+bioMap :: M.Map UUID BiosphereFlow
+bioMap = M.singleton (mkUUID 2) (biosphere 2 "Water, fossil" [])
+
+wasteMap :: M.Map UUID WasteFlow
+wasteMap = M.singleton (mkUUID 3) (WasteFlow (mkUUID 3) "Waste paperboard" (mkUUID 0) M.empty Nothing Nothing)
 
 orderSpec :: Spec
 orderSpec = describe "Service.flowSearchResults" $ do
@@ -81,6 +112,26 @@ orderSpec = describe "Service.flowSearchResults" $ do
     it "orders by medium then sub-compartment when sorting on the category" $
         map compartmentOf (search sortByName{ffSort = Just "category"} deltamethrins)
             `shouldBe` map compartmentOf (search sortByName deltamethrins)
+
+    it "puts the flow the user typed first, ahead of what the words also reached" $
+        -- "Crude oil, in ground" is alphabetically first and is only reached
+        -- because the query was split into words, so it goes last; the two
+        -- names carrying "oil, crude" as typed come first, in name order.
+        map fsrName (search crudeOil oilFlows)
+            `shouldBe` ["Oil, crude", "Palm oil, crude, at plant", "Crude oil, in ground"]
+
+    it "leaves the order alone when a column was asked for" $
+        map fsrName (search crudeOil{ffSort = Just "name"} oilFlows)
+            `shouldBe` ["Crude oil, in ground", "Oil, crude", "Palm oil, crude, at plant"]
+
+crudeOil :: FlowFilter
+crudeOil = sortByName{ffQuery = "oil, crude"}
+
+oilFlows :: [FlowKind]
+oilFlows =
+    map
+        (`namedFlow` [])
+        ["Crude oil, in ground", "Oil, crude", "Palm oil, crude, at plant"]
 
 compartmentOf :: FlowSearchResult -> (Text, Maybe Text)
 compartmentOf r = (fsrCategory r, fsrCompartment r)

--- a/test/FlowSearchSpec.hs
+++ b/test/FlowSearchSpec.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-{- | Flow search results must tell homonyms apart.
+{- | What a flow search matches, and how it orders what it found.
 
 Agribalyse 3.2 carries seven @Deltamethrin@ flows differing only by
 compartment. A result that drops the sub-compartment, or an order that
@@ -10,14 +10,53 @@ module FlowSearchSpec (spec) where
 
 import API.Types (FlowSearchResult (..))
 import qualified Data.Map as M
+import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.UUID as UUID
+import Database (flowMatchesQuery)
 import Service (FlowFilter (..), flowSearchResults)
 import Test.Hspec
 import Types (BiosphereFlow (..), Compartment (..), FlowKind (..), UUID)
 
 spec :: Spec
-spec = describe "Service.flowSearchResults" $ do
+spec = do
+    matchSpec
+    orderSpec
+
+matchSpec :: Spec
+matchSpec = describe "Database.flowMatchesQuery" $ do
+    it "finds a name whose words the query didn't punctuate" $
+        flowMatchesQuery "water fossil" waterFossil `shouldBe` True
+
+    it "finds it whatever order the words come in" $
+        flowMatchesQuery "fossil water" waterFossil `shouldBe` True
+
+    it "still finds it when the query does punctuate" $
+        flowMatchesQuery "water, fossil" waterFossil `shouldBe` True
+
+    it "requires every word, not just one" $
+        flowMatchesQuery "water fossil" (namedFlow "Water, lake" []) `shouldBe` False
+
+    it "keeps matching inside a word, which is how chemicals are searched" $
+        flowMatchesQuery "chlor" (namedFlow "Trichloroethane" []) `shouldBe` True
+
+    it "reads the name and the synonyms as one text" $
+        flowMatchesQuery "laughing dinitrogen" laughingGas `shouldBe` True
+
+    it "matches nothing when the query holds no word at all" $
+        flowMatchesQuery ", " waterFossil `shouldBe` False
+
+waterFossil :: FlowKind
+waterFossil = namedFlow "Water, fossil" []
+
+laughingGas :: FlowKind
+laughingGas = namedFlow "Dinitrogen monoxide" ["laughing gas", "nitrous oxide"]
+
+namedFlow :: Text -> [Text] -> FlowKind
+namedFlow name syns = BioKind (biosphere 0 name syns)
+
+orderSpec :: Spec
+orderSpec = describe "Service.flowSearchResults" $ do
     it "carries the sub-compartment that tells two same-medium flows apart" $
         map (\r -> (fsrCategory r, fsrCompartment r)) (search sortByName deltamethrins)
             `shouldContain` [("soil", Just "agricultural"), ("soil", Just "forestry")]
@@ -77,16 +116,19 @@ deltamethrins =
 
 bioFlow :: Int -> Text -> Maybe Text -> FlowKind
 bioFlow n medium sub =
-    BioKind
-        BiosphereFlow
-            { bfId = mkUUID n
-            , bfName = "Deltamethrin"
-            , bfUnitId = mkUUID 0
-            , bfSynonyms = M.empty
-            , bfCAS = Just "52918-63-5"
-            , bfSubstanceId = Nothing
-            , bfCompartment = Just (Compartment medium sub)
-            }
+    BioKind (biosphere n "Deltamethrin" []){bfCompartment = Just (Compartment medium sub)}
+
+biosphere :: Int -> Text -> [Text] -> BiosphereFlow
+biosphere n name syns =
+    BiosphereFlow
+        { bfId = mkUUID n
+        , bfName = name
+        , bfUnitId = mkUUID 0
+        , bfSynonyms = M.singleton "en" (S.fromList syns)
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfCompartment = Nothing
+        }
 
 mkUUID :: Int -> UUID
 mkUUID n = UUID.fromWords64 (fromIntegral n) 0

--- a/test/FuzzySpec.hs
+++ b/test/FuzzySpec.hs
@@ -7,7 +7,7 @@ import Data.Text (Text)
 import qualified Data.Vector as V
 import Test.Hspec
 
-import Search.BM25 (buildIndex)
+import Search.BM25 (indexActivities)
 import Search.BM25.Types (BM25Index)
 import Search.Fuzzy (expandTokens)
 import Types
@@ -35,7 +35,7 @@ mkActivity name xs =
 -- Index-builder helper: create a BM25 index over a list of activity names.
 indexOfNames :: [Text] -> BM25Index
 indexOfNames names =
-    buildIndex (V.fromList [mkActivity n [] | n <- names]) M.empty
+    indexActivities (V.fromList [mkActivity n [] | n <- names]) M.empty
 
 spec :: Spec
 spec = describe "Search.Fuzzy" $ do


### PR DESCRIPTION
Searching flows for `water fossil` returned nothing, while `water, fossil` returned eight results. The whole query was looked up as one piece of text, so the comma in the flow name had to be retyped exactly, and `fossil water` found nothing either.

Every word of the query is now looked for on its own, in any order, in the flow name and its synonyms. Searching by fragment is unchanged and still matters more here than anywhere else: `chlor` reaches `Trichloroethane`, which no tokenizer would return, so words stay substrings rather than whole tokens.

That width has a price, and the second commit pays it. Looking for words separately returns far more rows than looking for the whole query, and the list was purely alphabetical, so on a real database `oil, crude` went from 17 results with `Oil, crude` first to 313 with it around rank 276, while the MCP tool asks for 20 rows and cannot page. Results now lead with the names carrying the query as it was typed, then those carrying all its words, then the rest, each group alphabetical as before. Asking for a sort column still means that column alone, so a table sorted by name stays alphabetical. A BM25 index over the flows would rank within those groups too; that needs its cost at load measured first, and is not in this PR.

Two smaller consequences are documented rather than hidden: a punctuated query like `2,4-D` is now three words and also returns names holding a 2, a 4 and a d elsewhere (below the flow actually named that), and an empty query returns nothing rather than the whole catalogue, which is what asking for no flow in particular already did.

The BM25 commits are preparation, not behaviour: the index built its documents from the activity vector itself, so it could only ever rank activities. It now takes one token list per document, which is all it ever used, and stays module-private until a second corpus exists.

Checked against a running engine on the `SAMPLE.units` fixture: `water fresh`, `fresh water` and `water, fresh` all reach `Water, fresh`; `wate` still returns the four flows carrying that fragment; `, ` and an empty query return none.