### PR TITLE
One flow per substance in an EcoSpold 1 database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@
   of its reference product, so anything holding one has to look it up again.
   And the cache of every database, whatever its format, is rebuilt from its
   source once, because one version number covers them all.
+- An input of an EcoSpold 1 dataset is now resolved to its supplier through the
+  dataset number the export itself points at. That number was read off the last
+  numbered element in the dataset's metadata, which is the person who wrote it,
+  not off the dataset, so the lookup found nothing and every input was matched
+  on name and geography instead. A 12 000 dataset export offered 67 suppliers
+  to that lookup where it should have offered 11 947. Inputs still all resolve,
+  and a few now resolve to the dataset the export names rather than to another
+  one carrying the same name.
 - The macOS download for Apple Silicon now runs on a Mac that has no developer
   tools. It was built against the build machine's Homebrew copies of OpenBLAS
   and the Fortran runtime and looked for them at the same paths on yours, so it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,28 @@
   of its reference product, so anything holding one has to look it up again.
   And the cache of every database, whatever its format, is rebuilt from its
   source once, because one version number covers them all.
+- A substance an EcoSpold 1 export records in two units stays two flows. One
+  export writes waste heat in MJ in some datasets and in kWh in others, and
+  natural gas in m3 and Nm3, 193 flows in all; an inventory row is summed
+  without conversion, so merging those would have added MJ to kWh and reported
+  the total under one of the two units.
+- A cache the engine can no longer read is left on disk instead of deleted.
+  A cache written by an older version reads the same way a corrupted one does,
+  and both were deleted before rebuilding from source. A host that ships only
+  the cache, with no source archive beside it, lost the database outright and
+  failed to start from then on.
+- A CAS number an EcoSpold 1 export declares in one dataset and omits in
+  another is kept. It decides whether a flow can be matched to a
+  characterization factor by CAS when its name does not match, and which of the
+  two datasets was read first was an accident of file distribution.
+- One malformed number in an EcoSpold 1 export no longer stops the whole load.
+  A dataset or an exchange numbered with something that is not a number ended
+  the read there; it is now treated as carrying no number, which the parser
+  already handles.
+- An EcoSpold 1 export the engine writes reads back the way it was written.
+  Exchanges were numbered by their position in their dataset, and a number is
+  what names a flow, so re-importing split one substance into one flow per
+  position and merged two products that differed only by geography.
 - An input of an EcoSpold 1 dataset is now resolved to its supplier through the
   dataset number the export itself points at. That number was read off the last
   numbered element in the dataset's metadata, which is the person who wrote it,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@
   started with no method at all. One caveat for named volumes created by an
   older image: Docker never repopulates a non-empty volume, so copy
   `energy_density.csv` into it or recreate it.
+- A database read from an EcoSpold 1 export now has one flow per substance.
+  Each flow used to carry the dataset it happened to be read from, so the same
+  substance became a separate flow in every dataset that mentions it: searching
+  a 12 000 dataset export for `Water, fossil` returned eight identical lines,
+  and one inventory of that export listed `Lead` 150 times. It held 27 935
+  biosphere flows for 2 515 real substances. Totals stayed right, but nothing
+  that groups by flow was readable. Two things follow on upgrade. The process
+  id of an EcoSpold 1 activity changes, because its second half is the identity
+  of its reference product, so anything holding one has to look it up again.
+  And the cache of every database, whatever its format, is rebuilt from its
+  source once, because one version number covers them all.
 - The macOS download for Apple Silicon now runs on a Mac that has no developer
   tools. It was built against the build machine's Homebrew copies of OpenBLAS
   and the Fortran runtime and looked for them at the same paths on yours, so it

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -148,7 +148,7 @@ import Method.Types (Location)
 import Progress
 import qualified SimaPro.Parser as SimaPro
 import SynonymDB (SynonymDB)
-import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist, getFileSize, listDirectory, removeFile)
+import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist, getFileSize, listDirectory)
 import System.FilePath (takeBaseName, takeDirectory, takeExtension, (</>))
 import Text.Printf (printf)
 import Types
@@ -1051,13 +1051,15 @@ loadCachedDatabaseWithMatrices dbName dataDir = do
             return Nothing
         else do
             -- Delegate to the shared reader; a Nothing here means the cache
-            -- is corrupted/incompatible and should be rebuilt from source.
+            -- is corrupted or was written by another schema, and the database
+            -- is rebuilt from source. The file is left alone: a rebuild
+            -- overwrites it anyway, and a host that ships only the cache (see
+            -- 'Manager.loadDatabaseRawWithCrossDB') has no source to rebuild
+            -- from, so deleting it there destroyed the only copy of the data.
             result <- loadCompressedCacheFile zstdFile
             case result of
                 Just _ -> return result
                 Nothing -> do
-                    reportCacheOperation $ "Deleting corrupted cache file: " ++ zstdFile
-                    removeFile zstdFile
                     reportCacheOperation "Will rebuild database from source files"
                     return Nothing
 

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -219,6 +219,10 @@ History of manual bumps:
 - 13: Activity record gained activityLocationSource (declared, read off the
      dataset name, or neither). Old caches miss the field; the Store layout
      is positional, so decoding them would misread every field after it.
+- 14: EcoSpold1 flow UUID no longer carries the dataset a flow was read from,
+     so one substance is one flow across the export. Old caches hold one flow
+     per (dataset, substance) pair — a value change with no type change, which
+     the fingerprint alone would accept.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.
@@ -226,7 +230,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeRep (Proxy :: Proxy Database))
-     in hi `xor` lo `xor` 13
+     in hi `xor` lo `xor` 14
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -86,6 +86,7 @@ module Database.Loader (
 
 import qualified BrightwayExcel.Parser as BrightwayExcel
 import qualified Codec.Compression.Zstd as Zstd
+import Control.Applicative ((<|>))
 import Control.Concurrent.Async
 import Control.DeepSeq (force)
 import Control.Exception (SomeException, catch, evaluate)
@@ -97,6 +98,12 @@ import Data.Either (lefts, partitionEithers, rights)
 import Data.List (sort, sortBy, sortOn)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
+
+-- The flow tables are merged through the strict API: one substance now appears
+-- in many datasets, so every merge that used to be a no-op (keys were unique
+-- per dataset) is real, and the lazy API would stack one unforced merge per
+-- occurrence, holding every superseded record until something forced the chain.
+import qualified Data.Map.Strict as MS
 import Data.Maybe (fromMaybe, isJust, isNothing)
 import Data.Ord (Down (..))
 import Data.Proxy (Proxy (..))
@@ -151,16 +158,32 @@ import qualified UnitConversion as UC
 cacheMagic :: BS.ByteString
 cacheMagic = "VOLCACHE"
 
-{- | Merge two technosphere flows with the same UUID, combining their synonyms.
+{- | Merge two technosphere flows with the same UUID, combining their synonyms
+and keeping whichever of the two declares a CAS number.
 When multiple .spold files reference the same flow each may carry different
 synonyms; M.fromListWith mergeTechFlows ensures no synonym is lost.
+
+The CAS is kept the same way because a file that declares it and a file that
+omits it describe the same substance, and which one lands first is an accident
+of how the loader distributed the files over its workers. Of the export
+measured here, 430 flows are declared with a CAS in some datasets and without
+in others; losing it there would silently disable the CAS rung of the
+characterization cascade for the whole database.
 -}
 mergeTechFlows :: TechnosphereFlow -> TechnosphereFlow -> TechnosphereFlow
-mergeTechFlows a b = a{tfSynonyms = M.unionWith S.union (tfSynonyms a) (tfSynonyms b)}
+mergeTechFlows a b =
+    a
+        { tfSynonyms = M.unionWith S.union (tfSynonyms a) (tfSynonyms b)
+        , tfCAS = tfCAS a <|> tfCAS b
+        }
 
 -- | Biosphere counterpart of 'mergeTechFlows'.
 mergeBioFlows :: BiosphereFlow -> BiosphereFlow -> BiosphereFlow
-mergeBioFlows a b = a{bfSynonyms = M.unionWith S.union (bfSynonyms a) (bfSynonyms b)}
+mergeBioFlows a b =
+    a
+        { bfSynonyms = M.unionWith S.union (bfSynonyms a) (bfSynonyms b)
+        , bfCAS = bfCAS a <|> bfCAS b
+        }
 
 -- | 9-element unzip helper (Data.List ships 7-tuple as max).
 unzip9 :: [(a, b, c, d, e, f, g, h, i)] -> ([a], [b], [c], [d], [e], [f], [g], [h], [i])
@@ -789,8 +812,8 @@ loadEcoSpoldDirectory locationAliases dir = do
                 let successResults = rights results
                 let (procMaps, techFlowMaps, bioFlowMaps, wasteFlowMaps, unitMaps, rawFlowCounts, rawUnitCounts, dsIndexes, supplierLinksLists) = unzip9 successResults
                 let !finalProcMap = M.unions procMaps
-                let !finalTechFlowMap = M.unionsWith mergeTechFlows techFlowMaps
-                let !finalBioFlowMap = M.unionsWith mergeBioFlows bioFlowMaps
+                let !finalTechFlowMap = MS.unionsWith mergeTechFlows techFlowMaps
+                let !finalBioFlowMap = MS.unionsWith mergeBioFlows bioFlowMaps
                 let !finalWasteFlowMap = M.unions wasteFlowMaps
                 let !finalUnitMap = M.unions unitMaps
                 let !finalDsIndex = M.unions dsIndexes
@@ -868,8 +891,8 @@ loadEcoSpoldDirectory locationAliases dir = do
             (firstErr : _) -> return $ Left firstErr
             [] -> do
                 let !procMap = M.fromList (rights procEntries)
-                let !techFlowMap = M.fromListWith mergeTechFlows [(tfId f, f) | f <- allTechs]
-                let !bioFlowMap = M.fromListWith mergeBioFlows [(bfId f, f) | f <- allBios]
+                let !techFlowMap = MS.fromListWith mergeTechFlows [(tfId f, f) | f <- allTechs]
+                let !bioFlowMap = MS.fromListWith mergeBioFlows [(bfId f, f) | f <- allBios]
                 let !wasteFlowMap = M.fromList [(wfId f, f) | f <- allWastes]
                 let !unitMap = M.fromList [(unitId u, u) | u <- allUnits]
                 let !dsIndex =
@@ -933,8 +956,8 @@ loadSingleEcoSpold1File locationAliases filepath = do
             _ -> Nothing
         expanded = map (buildProcEntryFromResult fileUUID) results
         !procMap = M.fromList expanded
-        !techFlowMap = M.fromListWith mergeTechFlows [(tfId f, f) | (_, techs, _, _, _, _, _) <- results, f <- techs]
-        !bioFlowMap = M.fromListWith mergeBioFlows [(bfId f, f) | (_, _, bios, _, _, _, _) <- results, f <- bios]
+        !techFlowMap = MS.fromListWith mergeTechFlows [(tfId f, f) | (_, techs, _, _, _, _, _) <- results, f <- techs]
+        !bioFlowMap = MS.fromListWith mergeBioFlows [(bfId f, f) | (_, _, bios, _, _, _, _) <- results, f <- bios]
         !wasteFlowMap = M.fromList [(wfId f, f) | (_, _, _, wastes, _, _, _) <- results, f <- wastes]
         !unitMap = M.fromList [(unitId u, u) | (_, _, _, _, units, _, _) <- results, u <- units]
         !dsIndex =

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -30,7 +30,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V5 as UUID5
-import EcoSpold.Common (bsToDouble, bsToInt, bsToText, isElement, nonEmptyText)
+import EcoSpold.Common (bsToDouble, bsToIntMaybe, bsToText, isElement, nonEmptyText)
 import EcoSpold.Cutoff (applyCutoffStrategy)
 import Progress (ProgressLevel (..), reportProgress)
 import Types
@@ -222,11 +222,16 @@ onAttribute state name value = case psContext state of
     -- the head of the path. Accepting it anywhere under <dataset> let the
     -- metadata's own numbered elements (<source>, <person>) overwrite it, so
     -- what was recorded was really the last data generator's id.
+    --
+    -- A number that will not parse leaves the dataset with none, which drops
+    -- it out of the supplier index the same way a dataset carrying no number
+    -- does. 'bsToInt' would call @error@ from inside the pure fold instead,
+    -- killing the whole load over one malformed attribute.
     datasetNumberAttr
         | isElement name "number"
         , currentElement : _ <- psPath state
         , isElement currentElement "dataset" =
-            state{psDatasetNumber = bsToInt value}
+            state{psDatasetNumber = fromMaybe 0 (bsToIntMaybe value)}
         | otherwise = state
 
 -- | Apply a single referenceFunction attribute to the parse state.
@@ -244,7 +249,10 @@ setRefFunctionAttr name value st
 -- | Apply a single exchange attribute to the in-progress exchange.
 setExchangeAttr :: BS.ByteString -> BS.ByteString -> ExchangeData -> ExchangeData
 setExchangeAttr name value e
-    | isElement name "number" = e{exNumber = bsToInt value}
+    -- An unparseable number leaves the exchange at 0, which merges it with the
+    -- other unnumbered exchanges of the same name and compartment rather than
+    -- killing the load; 'bsToInt' would call @error@ from inside the fold.
+    | isElement name "number" = e{exNumber = fromMaybe 0 (bsToIntMaybe value)}
     | isElement name "name" = e{exName = bsToText value}
     | isElement name "category" = e{exCategory = bsToText value}
     | isElement name "subCategory" = e{exSubCategory = bsToText value}

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -210,9 +210,14 @@ onAttribute state name value = case psContext state of
     InOutputGroup _ -> datasetNumberAttr
     Other -> datasetNumberAttr
   where
-    -- The dataset's numeric id lives on the top-level <dataset> element.
+    -- The dataset's numeric id lives on the <dataset> element itself, which is
+    -- the head of the path. Accepting it anywhere under <dataset> let the
+    -- metadata's own numbered elements (<source>, <person>) overwrite it, so
+    -- what was recorded was really the last data generator's id.
     datasetNumberAttr
-        | isElement name "number" && any (isElement "dataset") (psPath state) =
+        | isElement name "number"
+        , currentElement : _ <- psPath state
+        , isElement currentElement "dataset" =
             state{psDatasetNumber = bsToInt value}
         | otherwise = state
 

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -42,21 +42,28 @@ Using UUID v5 (SHA1-based) with a custom namespace
 ecospold1Namespace :: UUID
 ecospold1Namespace = UUID5.generateNamed UUID5.namespaceURL (BS.unpack $ TE.encodeUtf8 "ecospold1.ecoinvent.org")
 
-{- | Generate deterministic UUID from the exchange number and the full
-compartment (category + subCategory).
+{- | Generate deterministic UUID from the exchange number, the full compartment
+(category + subCategory) and the unit.
 
 The exchange number is already the identity EcoSpold1 gives a flow across the
 whole export: an elementary flow carries its substance number (@Water, fossil@
 is 62793 in every dataset that draws it), and a technosphere input carries the
 number of the dataset producing it, the same number that dataset stamps on its
-own reference product. So the four fields below name one flow, once, for the
-whole database.
+own reference product (true of all 11947 datasets of the export measured here).
+So the fields below name one flow, once, for the whole database.
+
+The unit is in the key because a matrix row is summed without conversion. Real
+exports record one substance in two units: the measured one writes @Heat,
+waste@ in MJ in some datasets and in kWh in others, and @Natural gas, at
+production@ in m3 and Nm3, 193 such flows in all. Merging those onto one row
+would add MJ to kWh and report the total under whichever unit won the merge.
+The SimaPro parser keys on the unit for the same reason.
 
 The dataset a flow was *read from* is deliberately not part of the key. Keying
-on it splintered every shared substance into one flow per dataset — the ecoinvent
-EcoSpold1 export of a Swiss database carried 27935 biosphere flows for 2515
-substances, and a single inventory listed @Carbon dioxide, fossil@ four times
-because its supply chain crossed four datasets.
+on it splintered every shared substance into one flow per dataset: the export
+measured here carried 27935 biosphere flows for 2515 substances, and a single
+inventory of it listed @Lead@ 150 times, once per dataset its supply chain
+crossed that emits lead.
 
 The subCategory is part of the key because it is part of a flow's identity: an
 emission of one substance to two subcompartments (e.g. a leachate to both
@@ -68,8 +75,8 @@ silently scoring gated groundwater/ocean mass at a surface-freshwater CF (or the
 reverse). Keying on the full compartment keeps each subcompartment a separate row
 scored at its own CF.
 -}
-generateFlowUUID :: Int -> Text -> Text -> Text -> UUID
-generateFlowUUID exchangeNumber flowName category subCategory =
+generateFlowUUID :: Int -> Text -> Text -> Text -> Text -> UUID
+generateFlowUUID exchangeNumber flowName category subCategory unitName =
     let key =
             T.intercalate
                 ":"
@@ -77,6 +84,7 @@ generateFlowUUID exchangeNumber flowName category subCategory =
                 , flowName
                 , category
                 , subCategory
+                , unitName
                 ]
      in UUID5.generateNamed ecospold1Namespace (BS.unpack $ TE.encodeUtf8 key)
 
@@ -386,7 +394,7 @@ buildExchange activityLoc edata
     | isBiosphere = (bioEx, ParsedBio bioFlow, unit)
     | otherwise = (techEx, ParsedTech techFlow, unit)
   where
-    flowId = generateFlowUUID (exNumber edata) (exName edata) (exCategory edata) (exSubCategory edata)
+    flowId = generateFlowUUID (exNumber edata) (exName edata) (exCategory edata) (exSubCategory edata) (exUnit edata)
     unitId = generateUnitUUID (exUnit edata)
     unit = Unit unitId (exUnit edata) (exUnit edata) ""
 

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -42,8 +42,21 @@ Using UUID v5 (SHA1-based) with a custom namespace
 ecospold1Namespace :: UUID
 ecospold1Namespace = UUID5.generateNamed UUID5.namespaceURL (BS.unpack $ TE.encodeUtf8 "ecospold1.ecoinvent.org")
 
-{- | Generate deterministic UUID from dataset number, exchange number, and the
-full compartment (category + subCategory).
+{- | Generate deterministic UUID from the exchange number and the full
+compartment (category + subCategory).
+
+The exchange number is already the identity EcoSpold1 gives a flow across the
+whole export: an elementary flow carries its substance number (@Water, fossil@
+is 62793 in every dataset that draws it), and a technosphere input carries the
+number of the dataset producing it, the same number that dataset stamps on its
+own reference product. So the four fields below name one flow, once, for the
+whole database.
+
+The dataset a flow was *read from* is deliberately not part of the key. Keying
+on it splintered every shared substance into one flow per dataset — the ecoinvent
+EcoSpold1 export of a Swiss database carried 27935 biosphere flows for 2515
+substances, and a single inventory listed @Carbon dioxide, fossil@ four times
+because its supply chain crossed four datasets.
 
 The subCategory is part of the key because it is part of a flow's identity: an
 emission of one substance to two subcompartments (e.g. a leachate to both
@@ -55,13 +68,12 @@ silently scoring gated groundwater/ocean mass at a surface-freshwater CF (or the
 reverse). Keying on the full compartment keeps each subcompartment a separate row
 scored at its own CF.
 -}
-generateFlowUUID :: Int -> Int -> Text -> Text -> Text -> UUID
-generateFlowUUID datasetNumber exchangeNumber flowName category subCategory =
+generateFlowUUID :: Int -> Text -> Text -> Text -> UUID
+generateFlowUUID exchangeNumber flowName category subCategory =
     let key =
             T.intercalate
                 ":"
-                [ T.pack (show datasetNumber)
-                , T.pack (show exchangeNumber)
+                [ T.pack (show exchangeNumber)
                 , flowName
                 , category
                 , subCategory
@@ -298,7 +310,7 @@ record the supplier link for technosphere inputs.
 closeExchange :: ParseState -> ParseState
 closeExchange state = case psContext state of
     InExchange edata ->
-        let (exchange, parsedFlow, unit) = buildExchange (psDatasetNumber state) (psLocation state) edata
+        let (exchange, parsedFlow, unit) = buildExchange (psLocation state) edata
             !supplierLinks = case exchange of
                 TechnosphereExchange{techRole = Input}
                     | exNumber edata /= 0 ->
@@ -363,13 +375,13 @@ EcoSpold1 groups:
   Input:  1-3 = technosphere, 4 = resource (biosphere)
   Output: 0 = reference product, 1-3 = byproduct/co-product, 4 = emission (biosphere)
 -}
-buildExchange :: Int -> Maybe Text -> ExchangeData -> (Exchange, ParsedFlow, Unit)
-buildExchange datasetNum activityLoc edata
+buildExchange :: Maybe Text -> ExchangeData -> (Exchange, ParsedFlow, Unit)
+buildExchange activityLoc edata
     | isWasteFlow = (wasteEx, ParsedWaste wasteFlow, unit)
     | isBiosphere = (bioEx, ParsedBio bioFlow, unit)
     | otherwise = (techEx, ParsedTech techFlow, unit)
   where
-    flowId = generateFlowUUID datasetNum (exNumber edata) (exName edata) (exCategory edata) (exSubCategory edata)
+    flowId = generateFlowUUID (exNumber edata) (exName edata) (exCategory edata) (exSubCategory edata)
     unitId = generateUnitUUID (exUnit edata)
     unit = Unit unitId (exUnit edata) (exUnit edata) ""
 

--- a/src/EcoSpold/Writer1.hs
+++ b/src/EcoSpold/Writer1.hs
@@ -9,16 +9,19 @@ __canonical and deterministic__:
   * activities are emitted in a stable order (sorted by @(activityName,
     location)@), each in its own @\<dataset\>@ inside one @\<ecoSpold\>@;
   * dataset numbers are assigned sequentially (1-based) in that order, and
-    exchange numbers likewise (see below). Because the parser derives flow
-    UUIDs from @datasetNumber@, exchange number, name and category, these
-    reassigned numbers make the writer's output __self-stable for every
-    exchange except a linked technosphere input__: reference products,
-    co-products, biosphere and waste exchanges, and /unlinked/ inputs all
-    reproduce the same flow UUIDs on a write→parse→write cycle. This is
-    fixed-point stability of the writer's own canonical form, __not__
-    reproduction of the UUIDs of an arbitrary parsed source file — that source
-    carried its own dataset/exchange numbering, which the writer does not
-    preserve;
+    exchange numbers follow the convention EcoSpold1 exports use, which the
+    parser reads as a flow's identity: a number names a flow for the whole
+    export, not a position in one dataset. A reference product carries its own
+    dataset's number, a linked technosphere input carries its supplier's, and
+    every other exchange carries a number assigned once per distinct flow.
+    That makes the writer's output __self-stable for every exchange except a
+    linked technosphere input__: reference products, co-products, biosphere and
+    waste exchanges, and /unlinked/ inputs all reproduce the same flow UUIDs on
+    a write→parse→write cycle, and one substance stays one flow across the
+    re-imported export. This is fixed-point stability of the writer's own
+    canonical form, __not__ reproduction of the UUIDs of an arbitrary parsed
+    source file — that source carried its own numbering, which the writer does
+    not preserve;
   * a /linked/ technosphere input is the one exception. Its @number@ attribute
     carries the /supplier's/ dataset number (so the loader can re-link it by
     'techActivityLinkId'); but 'SimpleDatabase' has no field for that link, so a
@@ -27,7 +30,7 @@ __canonical and deterministic__:
     loader re-resolving the link (by supplier name/location) rather than on a
     direct 'SimpleDatabase' round-trip. The semantic round-trip — flow name,
     amount, role, unit — is preserved either way;
-  * exchange numbers are sequential (1-based) in exchange order;
+  * exchange numbers come from the flow, not from the position in the dataset;
   * attributes appear in a fixed order, classification maps are sorted by
     key, numbers use a fixed textual form, and there is no insignificant
     whitespace beyond a single newline between top-level lines;
@@ -77,6 +80,7 @@ import Data.Either (lefts)
 import Data.List (sortOn)
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe)
+import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
@@ -157,7 +161,7 @@ writeActivities opts techs bios wastes units activities =
             ++ concat (zipWith (datasetLines opts res) [1 ..] (map snd ordered))
             ++ ["</ecoSpold>"]
   where
-    res = Resolvers techs bios wastes units (supplierNumberIndex ordered)
+    res = Resolvers techs bios wastes units (supplierNumberIndex ordered) (flowNumberIndex ordered)
     -- Stable, content-derived order so dataset numbers (and thus flow UUIDs)
     -- are reproducible regardless of the source Map's ordering.
     ordered = orderedActivities activities
@@ -186,6 +190,30 @@ source format minted the UUID in.
 supplierNumberIndex :: [(UUID, Activity)] -> M.Map UUID Int
 supplierNumberIndex ordered =
     M.fromList [(actU, n) | (n, (actU, _)) <- zip [1 ..] ordered]
+
+{- | Map each flow that is not a reference product to the number the export
+gives it, once, across every dataset that carries it.
+
+EcoSpold1 numbers a flow for the whole export, not for the dataset it appears
+in, and the parser reads that number as part of the flow's identity. Numbering
+by position instead would re-import one substance as one flow per position it
+happens to occupy, which is exactly the splintering the parser stopped doing.
+
+Numbers start above the dataset numbers, which occupy @1 .. length ordered@ and
+are what a reference product and a linked input carry.
+-}
+flowNumberIndex :: [(UUID, Activity)] -> M.Map UUID Int
+flowNumberIndex ordered =
+    M.fromList (zip flows [length ordered + 1 ..])
+  where
+    flows =
+        S.toAscList $
+            S.fromList
+                [ exchangeFlowId ex
+                | (_, act) <- ordered
+                , ex <- exchanges act
+                , not (exchangeIsReference ex)
+                ]
 
 {- | Guard an EcoSpold1 export against data the writer cannot faithfully
 re-encode. Each check reports its first offender and fails loudly rather than
@@ -365,6 +393,7 @@ data Resolvers = Resolvers
     , rWaste :: !WasteFlowDB
     , rUnits :: !UnitDB
     , rSupplierNumbers :: !(M.Map UUID Int)
+    , rFlowNumbers :: !(M.Map UUID Int)
     }
 
 -- ----------------------------------------------------------------------------
@@ -383,7 +412,7 @@ datasetLines opts res num act =
     , indent 2 <> "</metaInformation>"
     , indent 2 <> "<flowData>"
     ]
-        ++ concat (zipWith (exchangeLines res) [1 ..] (exchanges act))
+        ++ concatMap (exchangeLines res num) (exchanges act)
         ++ [ indent 2 <> "</flowData>"
            , indent 1 <> "</dataset>"
            ]
@@ -430,39 +459,49 @@ to classify the exchange, so it is derived from the exchange variant +
 role/direction, never guessed.
 -}
 exchangeLines :: Resolvers -> Int -> Exchange -> [Text]
-exchangeLines res num ex =
-    [ indent 3 <> "<exchange" <> exchangeAttrs res num ex <> ">"
+exchangeLines res datasetNum ex =
+    [ indent 3 <> "<exchange" <> exchangeAttrs res datasetNum ex <> ">"
     , indent 4 <> groupElement ex
     , indent 3 <> "</exchange>"
     ]
 
-{- | The @number@ attribute to emit for an exchange. For a technosphere input
-that the loader resolved to a supplier, this is the supplier's assigned dataset
-number ('EcoSpold.Parser1.closeExchange' reads it back as the supplier link),
-not the positional exchange index. Every other exchange (reference products,
-co-products, biosphere, waste, and unlinked inputs) keeps the positional index,
-which seeds its flow UUID on re-parse. 'checkEcoSpold1Exportable' guarantees any
-resolved link is present in the index before export, so the @positional@
-fallback is unreachable for a linked input on the wired-up path.
+{- | The @number@ attribute to emit for an exchange, following the convention
+the parser reads: a number names a flow across the whole export.
+
+A reference product carries its own dataset's number, which is what every
+EcoSpold1 export observed here does and what lets a consumer name its supplier.
+A technosphere input the loader resolved carries its supplier's dataset number
+('EcoSpold.Parser1.closeExchange' reads it back as the supplier link), so the
+two agree on one number for one product. Everything else — co-products,
+biosphere, waste, and unlinked inputs — carries the number its flow was given
+once for the whole export ('flowNumberIndex').
+
+'checkEcoSpold1Exportable' guarantees any resolved link is present in the
+supplier index before export, so that fallback is unreachable on the wired-up
+path; the flow index covers every non-reference exchange by construction.
 -}
 exchangeNumber :: Resolvers -> Int -> Exchange -> Int
-exchangeNumber res positional ex = case ex of
-    TechnosphereExchange{techRole = Input, techActivityLinkId = link}
-        | link /= UUID.nil ->
-            M.findWithDefault positional link (rSupplierNumbers res)
-    TechnosphereExchange{} -> positional
-    BiosphereExchange{} -> positional
-    WasteExchange{} -> positional
+exchangeNumber res datasetNum ex
+    | exchangeIsReference ex = datasetNum
+    | otherwise = case ex of
+        TechnosphereExchange{techRole = Input, techActivityLinkId = link}
+            | link /= UUID.nil ->
+                M.findWithDefault flowNum link (rSupplierNumbers res)
+        TechnosphereExchange{} -> flowNum
+        BiosphereExchange{} -> flowNum
+        WasteExchange{} -> flowNum
+  where
+    flowNum = M.findWithDefault datasetNum (exchangeFlowId ex) (rFlowNumbers res)
 
 {- | Common exchange attributes in fixed order: number, name, category,
 subCategory, location, unit, meanValue, then optional CAS / generalComment.
-Name and category are the inputs the parser hashes into the flow UUID, so
-they must be reproduced verbatim for a stable round-trip.
+Number, name, category, subCategory and unit are the inputs the parser hashes
+into the flow UUID, so they must be reproduced verbatim for a stable round-trip.
 -}
 exchangeAttrs :: Resolvers -> Int -> Exchange -> Text
-exchangeAttrs res num ex =
+exchangeAttrs res datasetNum ex =
     " number="
-        <> attr (T.pack (show (exchangeNumber res num ex)))
+        <> attr (T.pack (show (exchangeNumber res datasetNum ex)))
         <> " name="
         <> attr name
         <> optAttr "category" category

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -115,6 +115,46 @@ minimalXml =
         , "</ecoSpold>"
         ]
 
+{- | The same two elementary flows as 'minimalXml', in another dataset written
+by another author. The @<person number>@ sits where EcoSpold1 metadata really
+carries one: under @<dataset>@, after the dataset's own number.
+-}
+otherAuthorXml :: BC.ByteString
+otherAuthorXml =
+    BC.unlines
+        [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold01\">"
+        , "  <dataset number=\"43\">"
+        , "    <metaInformation>"
+        , "      <processInformation>"
+        , "        <referenceFunction name=\"heat production\" category=\"Energy\""
+        , "                           subCategory=\"Heat\" unit=\"MJ\"/>"
+        , "        <geography location=\"FR\" />"
+        , "      </processInformation>"
+        , "      <administrativeInformation>"
+        , "        <dataGeneratorAndPublication person=\"777\" />"
+        , "        <person number=\"777\" name=\"Doe\" />"
+        , "      </administrativeInformation>"
+        , "    </metaInformation>"
+        , "    <flowData>"
+        , "      <exchange number=\"5\" name=\"heat, district network\" category=\"Energy\""
+        , "                subCategory=\"Heat\" unit=\"MJ\" meanValue=\"1.0\">"
+        , "        <outputGroup>0</outputGroup>"
+        , "      </exchange>"
+        , "      <exchange number=\"2\" name=\"Carbon dioxide, fossil\" category=\"air\""
+        , "                subCategory=\"low population density\" unit=\"kg\" meanValue=\"0.08\""
+        , "                CASNumber=\"124-38-9\">"
+        , "        <outputGroup>4</outputGroup>"
+        , "      </exchange>"
+        , "      <exchange number=\"3\" name=\"natural gas\" category=\"resource\""
+        , "                subCategory=\"in ground\" unit=\"MJ\" meanValue=\"14.0\">"
+        , "        <inputGroup>4</inputGroup>"
+        , "      </exchange>"
+        , "    </flowData>"
+        , "  </dataset>"
+        , "</ecoSpold>"
+        ]
+
 {- | Fixture exercising per-exchange `generalComment` attribute.
 Exchange #1 (reference) carries a comment, #2 has none. The
 referenceFunction also carries an activity-level generalComment to
@@ -224,24 +264,27 @@ spec :: Spec
 spec = do
     describe "generateFlowUUID" $ do
         it "produces a stable UUID for known inputs" $
-            generateFlowUUID 42 1 "CO2" "air" ""
-                `shouldBe` read "64b107af-792c-5a2a-874f-2a3323510af7"
-
-        it "differs when dataset number changes" $
-            generateFlowUUID 1 1 "CO2" "air" ""
-                `shouldNotBe` generateFlowUUID 2 1 "CO2" "air" ""
+            generateFlowUUID 1 "CO2" "air" ""
+                `shouldBe` read "7906e0fa-adbb-55e4-a9f2-dbdb43f90121"
 
         it "differs when exchange number changes" $
-            generateFlowUUID 1 1 "CO2" "air" ""
-                `shouldNotBe` generateFlowUUID 1 2 "CO2" "air" ""
+            generateFlowUUID 1 "CO2" "air" ""
+                `shouldNotBe` generateFlowUUID 2 "CO2" "air" ""
 
         it "differs when flow name changes" $
-            generateFlowUUID 1 1 "CO2" "air" ""
-                `shouldNotBe` generateFlowUUID 1 1 "methane" "air" ""
+            generateFlowUUID 1 "CO2" "air" ""
+                `shouldNotBe` generateFlowUUID 1 "methane" "air" ""
 
         it "differs when subcategory changes (river vs groundwater must not collapse)" $
-            generateFlowUUID 1 1 "Hydrogen sulfide" "water" "river"
-                `shouldNotBe` generateFlowUUID 1 1 "Hydrogen sulfide" "water" "groundwater, long-term"
+            generateFlowUUID 1 "Hydrogen sulfide" "water" "river"
+                `shouldNotBe` generateFlowUUID 1 "Hydrogen sulfide" "water" "groundwater, long-term"
+
+    describe "flow identity across datasets" $ do
+        it "gives one substance one flow id in every dataset that draws it" $
+            case (parseWithXeno minimalXml, parseWithXeno otherAuthorXml) of
+                (Right (_, _, bios1, _, _, _, _), Right (_, _, bios2, _, _, _, _)) ->
+                    map bfId bios1 `shouldBe` map bfId bios2
+                _ -> expectationFailure "both fixtures should parse"
 
     describe "generateUnitUUID" $ do
         it "produces a stable UUID for known inputs" $

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -264,20 +264,24 @@ spec :: Spec
 spec = do
     describe "generateFlowUUID" $ do
         it "produces a stable UUID for known inputs" $
-            generateFlowUUID 1 "CO2" "air" ""
-                `shouldBe` read "7906e0fa-adbb-55e4-a9f2-dbdb43f90121"
+            generateFlowUUID 1 "CO2" "air" "" "kg"
+                `shouldBe` read "10615fc0-b605-52fc-86d4-273d5523c752"
 
         it "differs when exchange number changes" $
-            generateFlowUUID 1 "CO2" "air" ""
-                `shouldNotBe` generateFlowUUID 2 "CO2" "air" ""
+            generateFlowUUID 1 "CO2" "air" "" "kg"
+                `shouldNotBe` generateFlowUUID 2 "CO2" "air" "" "kg"
 
         it "differs when flow name changes" $
-            generateFlowUUID 1 "CO2" "air" ""
-                `shouldNotBe` generateFlowUUID 1 "methane" "air" ""
+            generateFlowUUID 1 "CO2" "air" "" "kg"
+                `shouldNotBe` generateFlowUUID 1 "methane" "air" "" "kg"
 
         it "differs when subcategory changes (river vs groundwater must not collapse)" $
-            generateFlowUUID 1 "Hydrogen sulfide" "water" "river"
-                `shouldNotBe` generateFlowUUID 1 "Hydrogen sulfide" "water" "groundwater, long-term"
+            generateFlowUUID 1 "Hydrogen sulfide" "water" "river" "kg"
+                `shouldNotBe` generateFlowUUID 1 "Hydrogen sulfide" "water" "groundwater, long-term" "kg"
+
+        it "differs when the unit changes (MJ must not be summed into kWh)" $
+            generateFlowUUID 1 "Heat, waste" "air" "unspecified" "MJ"
+                `shouldNotBe` generateFlowUUID 1 "Heat, waste" "air" "unspecified" "kWh"
 
     describe "flow identity across datasets" $ do
         it "gives one substance one flow id in every dataset that draws it" $
@@ -290,6 +294,7 @@ spec = do
             case parseWithXeno otherAuthorXml of
                 Right (_, _, _, _, _, dsNum, _) -> dsNum `shouldBe` 43
                 Left err -> expectationFailure err
+
 
     describe "generateUnitUUID" $ do
         it "produces a stable UUID for known inputs" $

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -286,6 +286,11 @@ spec = do
                     map bfId bios1 `shouldBe` map bfId bios2
                 _ -> expectationFailure "both fixtures should parse"
 
+        it "reads the dataset number off <dataset>, not off a numbered <person>" $
+            case parseWithXeno otherAuthorXml of
+                Right (_, _, _, _, _, dsNum, _) -> dsNum `shouldBe` 43
+                Left err -> expectationFailure err
+
     describe "generateUnitUUID" $ do
         it "produces a stable UUID for known inputs" $
             generateUnitUUID "kg" `shouldBe` read "d74bc05e-6502-555a-a40c-e6e7580dbf93"

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -117,7 +117,9 @@ minimalXml =
 
 {- | The same two elementary flows as 'minimalXml', in another dataset written
 by another author. The @<person number>@ sits where EcoSpold1 metadata really
-carries one: under @<dataset>@, after the dataset's own number.
+carries one: under @<dataset>@, after the dataset's own number. The reference
+product repeats the dataset's number, which is what every export observed does
+and what lets a consumer name this dataset as its supplier.
 -}
 otherAuthorXml :: BC.ByteString
 otherAuthorXml =
@@ -137,7 +139,7 @@ otherAuthorXml =
         , "      </administrativeInformation>"
         , "    </metaInformation>"
         , "    <flowData>"
-        , "      <exchange number=\"5\" name=\"heat, district network\" category=\"Energy\""
+        , "      <exchange number=\"43\" name=\"heat, district network\" category=\"Energy\""
         , "                subCategory=\"Heat\" unit=\"MJ\" meanValue=\"1.0\">"
         , "        <outputGroup>0</outputGroup>"
         , "      </exchange>"
@@ -200,6 +202,9 @@ multiDatasetXml =
         , "        <referenceFunction name=\"process A\" unit=\"kg\"/>"
         , "        <geography location=\"CH\" />"
         , "      </processInformation>"
+        , "      <administrativeInformation>"
+        , "        <person number=\"777\" name=\"Doe\" />"
+        , "      </administrativeInformation>"
         , "    </metaInformation>"
         , "    <flowData>"
         , "      <exchange number=\"1\" name=\"product A\" category=\"goods\" unit=\"kg\" meanValue=\"1.0\">"
@@ -288,13 +293,18 @@ spec = do
             case (parseWithXeno minimalXml, parseWithXeno otherAuthorXml) of
                 (Right (_, _, bios1, _, _, _, _), Right (_, _, bios2, _, _, _, _)) ->
                     map bfId bios1 `shouldBe` map bfId bios2
-                _ -> expectationFailure "both fixtures should parse"
+                (Left err, _) -> expectationFailure ("minimalXml: " <> err)
+                (_, Left err) -> expectationFailure ("otherAuthorXml: " <> err)
 
         it "reads the dataset number off <dataset>, not off a numbered <person>" $
             case parseWithXeno otherAuthorXml of
                 Right (_, _, _, _, _, dsNum, _) -> dsNum `shouldBe` 43
                 Left err -> expectationFailure err
 
+        it "reads every dataset's own number when a numbered person precedes them" $
+            case parseAllWithXeno multiDatasetXml of
+                Right results -> map (fmap (\(_, _, _, _, _, n, _) -> n)) results `shouldBe` [Right 1, Right 2]
+                Left err -> expectationFailure err
 
     describe "generateUnitUUID" $ do
         it "produces a stable UUID for known inputs" $

--- a/test/EcoSpold1WriterSpec.hs
+++ b/test/EcoSpold1WriterSpec.hs
@@ -73,6 +73,73 @@ minimalXml =
         , "</ecoSpold>"
         ]
 
+{- | Three datasets that pin what a number means across an export.
+
+One substance (@Carbon dioxide, fossil@, number 100) is emitted by all three,
+at the second position in two of them and at the first in the third. Two
+products carry the same name, category and unit and differ only by geography,
+each numbered after its own dataset.
+
+Numbering exchanges by their position instead would re-import this as two
+carbon dioxide flows (positions 1 and 2) and fuse the two electricity products
+into one (both at position 1).
+-}
+sharedFlowXml :: BC.ByteString
+sharedFlowXml =
+    BC.unlines
+        [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold01\">"
+        , "  <dataset number=\"1\">"
+        , "    <metaInformation>"
+        , "      <processInformation>"
+        , "        <referenceFunction name=\"electricity, low voltage\" category=\"Energy\" unit=\"kWh\"/>"
+        , "        <geography location=\"CH\" />"
+        , "      </processInformation>"
+        , "    </metaInformation>"
+        , "    <flowData>"
+        , "      <exchange number=\"1\" name=\"electricity, low voltage\" category=\"Energy\" unit=\"kWh\" meanValue=\"1.0\">"
+        , "        <outputGroup>0</outputGroup>"
+        , "      </exchange>"
+        , "      <exchange number=\"100\" name=\"Carbon dioxide, fossil\" category=\"air\" unit=\"kg\" meanValue=\"0.05\">"
+        , "        <outputGroup>4</outputGroup>"
+        , "      </exchange>"
+        , "    </flowData>"
+        , "  </dataset>"
+        , "  <dataset number=\"2\">"
+        , "    <metaInformation>"
+        , "      <processInformation>"
+        , "        <referenceFunction name=\"electricity, low voltage\" category=\"Energy\" unit=\"kWh\"/>"
+        , "        <geography location=\"DE\" />"
+        , "      </processInformation>"
+        , "    </metaInformation>"
+        , "    <flowData>"
+        , "      <exchange number=\"2\" name=\"electricity, low voltage\" category=\"Energy\" unit=\"kWh\" meanValue=\"1.0\">"
+        , "        <outputGroup>0</outputGroup>"
+        , "      </exchange>"
+        , "      <exchange number=\"100\" name=\"Carbon dioxide, fossil\" category=\"air\" unit=\"kg\" meanValue=\"0.42\">"
+        , "        <outputGroup>4</outputGroup>"
+        , "      </exchange>"
+        , "    </flowData>"
+        , "  </dataset>"
+        , "  <dataset number=\"3\">"
+        , "    <metaInformation>"
+        , "      <processInformation>"
+        , "        <referenceFunction name=\"heat, district network\" category=\"Energy\" unit=\"MJ\"/>"
+        , "        <geography location=\"CH\" />"
+        , "      </processInformation>"
+        , "    </metaInformation>"
+        , "    <flowData>"
+        , "      <exchange number=\"100\" name=\"Carbon dioxide, fossil\" category=\"air\" unit=\"kg\" meanValue=\"0.07\">"
+        , "        <outputGroup>4</outputGroup>"
+        , "      </exchange>"
+        , "      <exchange number=\"3\" name=\"heat, district network\" category=\"Energy\" unit=\"MJ\" meanValue=\"1.0\">"
+        , "        <outputGroup>0</outputGroup>"
+        , "      </exchange>"
+        , "    </flowData>"
+        , "  </dataset>"
+        , "</ecoSpold>"
+        ]
+
 {- | Parsed fixture as a 'SimpleDatabase'. Fails the spec loudly if the
 fixture can't be parsed (it is a known-good EcoSpold1 document).
 -}
@@ -442,6 +509,16 @@ spec = do
             -- the only check that exercises a linked input end to end.
             (dbViews <$> roundTrip (linkedDb supplierLink))
                 `shouldBe` Right (dbViews (linkedDb supplierLink))
+
+    describe "flow tables across a multi-dataset round-trip" $ do
+        it "keeps one substance one flow and two same-named products apart" $
+            case parseAllWithXeno sharedFlowXml >>= sequence of
+                Left err -> expectationFailure ("fixture parse failed: " ++ err)
+                Right datasets -> do
+                    let sdb = assembleSimpleDb datasets
+                        sizes db = (M.size (sdbBioFlows db), M.size (sdbTechFlows db))
+                    sizes sdb `shouldBe` (1, 3)
+                    (sizes <$> roundTrip sdb) `shouldBe` Right (1, 3)
 
     describe "empty database" $ do
         it "writes a well-formed, dataset-free document the parser accepts" $ do


### PR DESCRIPTION
## Why

Opening BAFU 2026v1 and searching the flows for `Water, fossil` returns eight
rows that look identical: same name, same compartment, same subcompartment,
same unit. They really are eight different flows, with eight different UUIDs.

The flow UUID of an EcoSpold 1 database was built from the dataset the flow was
read from, plus the exchange number, name, category and subcategory. So the
same substance became a separate flow in every dataset that mentions it, and
`Water, fossil` appears in 138 of that export's datasets.

Eight rather than 138 because of a second defect underneath. The dataset number
was supposed to come from the `number` attribute of `<dataset>`, but the guard
only asked whether `dataset` was somewhere up the path, which is true of every
element in the file. The metadata's own numbered elements overwrite it, and the
last one before `<flowData>` is a `<person>`. What the parser recorded was the
identifier of the person who wrote the dataset. The export has 11 947 datasets
and 67 such people, and 8 of them touched a dataset drawing fossil water.

## What changes

The flow UUID no longer carries the dataset a flow was read from. It does not
need to: the exchange number already is that identity across the whole export.
An elementary flow carries its substance number (`Water, fossil` is 62793 in
every dataset), and a technosphere input carries the number of the dataset
producing it, the same number that dataset stamps on its own reference product.
So an input's flow id now equals its supplier's reference product id, which it
never did before.

The dataset number is also read off `<dataset>` again. It keys tier 1 of the
supplier lookup, the tier that resolves an input through the number the export
itself points at, so that lookup was being offered 67 suppliers instead of
11 947 and answered nothing.

The cache signature is bumped to 14. Both changes move values without moving
types, and the type fingerprint alone would accept a cache built before them.

## Measured on that export

Loaded twice with `--no-cache`, once per binary:

| | before | after |
|---|---|---|
| biosphere flows | 27 935 | 2 515 |
| technosphere flows | 20 347 | 11 947 |
| suppliers offered to the dataset-number lookup | 67 | 11 947 |
| rows for `Water, fossil` in flow search | 8 | 1 |
| rows in one inventory | 10 675 | 2 145 |
| rows named `Lead` in that inventory | 150 | 15 |
| rows named `Carbon dioxide, fossil` in it | 70 | 4 |

The 15 remaining `Lead` rows and 4 remaining `Carbon dioxide, fossil` rows are
subcompartments, which are part of a flow's identity on purpose and stay
separate.

Inputs resolved 100% before and after. The totals move in the sixth digit
(that inventory's fossil CO2 goes from 2.15703919 to 2.15703447 kg) because a
few inputs now resolve to the dataset the export names rather than to another
one carrying the same name.

## Note for callers

A `process_id` of an EcoSpold 1 database contains the reference product's flow
UUID, so those ids change. Anything holding one has to look it up again.
