### PR TITLE
Print the keys a configuration file may carry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ A Python client lives in `pyvolca/` (own `pyproject.toml`); the MUMPS binding in
 
 ### Documentation
 - **Re-read this file + README before each PR.** Update them when: (a) you hit a statement contradicting the code, (b) a new convention appears, (c) a command or a config key changes. NON-trigger: adding a module, tool, or endpoint that follows the stated conventions — the rules cover it, no list to grow.
-- Never write hand-maintained counts, versions, or enumerations the code already knows — state the naming rule and point at the source of truth (`versions.env`, `API.Resources`, `volca dump-mcp-tools`).
+- Never write hand-maintained counts, versions, or enumerations the code already knows — state the naming rule and point at the source of truth (`versions.env`, `API.Resources`, `volca dump-mcp-tools`, `volca dump-config-schema`).
 
 ### Commits & PRs
 - NEVER use `git add -A` — always add specific files explicitly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 ### Added
+- `volca dump-config-schema` prints every key the configuration file may carry,
+  as JSON, the way `dump-mcp-tools` prints the assistant tools. It is what the
+  documentation is checked against, so a key the engine reads and nobody
+  documents is a build failure rather than something a reader finds out by
+  its absence.
 - A hosted server can refuse changes in its operator's own words:
   `read_only_message` under `[hosting]` replaces the default read-only
   sentence on every surface (the REST API, the MCP tools, and the shutdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,10 @@
 ## [Unreleased]
 
 ### Added
-- `volca dump-config-schema` prints every key the configuration file may carry,
-  as JSON, the way `dump-mcp-tools` prints the assistant tools. It is what the
-  documentation is checked against, so a key the engine reads and nobody
-  documents is a build failure rather than something a reader finds out by
-  its absence.
+- `volca dump-config-schema` prints the keys a configuration file may carry, by
+  name, as JSON, the way `dump-mcp-tools` prints the assistant tools. Writing
+  about this file has meant reading the decoders, so anything written about it
+  drifts quietly; now there is a list to check a text against.
 - A hosted server can refuse changes in its operator's own words:
   `read_only_message` under `[hosting]` replaces the default read-only
   sentence on every surface (the REST API, the MCP tools, and the shutdown

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -29,7 +29,7 @@ import CLI.Command (executeCommand)
 import CLI.Parser (cliParserInfo)
 import CLI.Repl (runRepl)
 import CLI.Types
-import Config (ClassificationPreset, Config (..), DatabaseConfig (..), HostingConfig (..), Listen (..), ReadOnly (..), ServerConfig (..), ServerName, clientHost, freePortHost, hostingReadOnly, listenOn, loadConfigOrDefault, readOnlyRefusalFor)
+import Config (ClassificationPreset, Config (..), DatabaseConfig (..), HostingConfig (..), Listen (..), ReadOnly (..), ServerConfig (..), ServerName, clientHost, configKeys, freePortHost, hostingReadOnly, keyPaths, listenOn, loadConfigOrDefault, readOnlyRefusalFor)
 import Control.Concurrent.STM (readTVarIO)
 import Database.Manager (DatabaseManager (..), initDatabaseManager)
 import Network.HTTP.Client (Manager, defaultManagerSettings, managerResponseTimeout, newManager, responseTimeoutNone)
@@ -81,6 +81,7 @@ main = do
     case (CLI.Types.command cliConfig, configFile (globalOptions cliConfig)) of
         (Just DumpOpenApi, _) -> BSL.putStrLn (encode volcaOpenApi)
         (Just DumpMcpTools, _) -> BSL.putStrLn (encode (toolDefinitions (ReadOnly False)))
+        (Just DumpConfigSchema, _) -> BSL.putStrLn (encode (keyPaths configKeys))
         (Just (Server serverOpts), mCfgFile) -> runServerWithConfig cliConfig serverOpts mCfgFile
         (Just Repl, Just cfgFile) -> runReplMode cliConfig cfgFile
         (Just cmd, Just cfgFile) | isLocalCommand cmd -> runCLIWithConfig cliConfig cmd cfgFile

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -79,9 +80,7 @@ main = do
     validateCLIConfig cliConfig
 
     case (CLI.Types.command cliConfig, configFile (globalOptions cliConfig)) of
-        (Just DumpOpenApi, _) -> BSL.putStrLn (encode volcaOpenApi)
-        (Just DumpMcpTools, _) -> BSL.putStrLn (encode (toolDefinitions (ReadOnly False)))
-        (Just DumpConfigSchema, _) -> BSL.putStrLn (encode (keyPaths configKeys))
+        (Just (Dump target), _) -> BSL.putStrLn (dumpDocument target)
         (Just (Server serverOpts), mCfgFile) -> runServerWithConfig cliConfig serverOpts mCfgFile
         (Just Repl, Just cfgFile) -> runReplMode cliConfig cfgFile
         (Just cmd, Just cfgFile) | isLocalCommand cmd -> runCLIWithConfig cliConfig cmd cfgFile
@@ -187,6 +186,16 @@ resolvePassword globalOpts serverCfg = case CLI.Types.serverPassword globalOpts 
     Nothing -> case scPassword serverCfg of
         Just pwd -> pure (Just (T.unpack pwd))
         Nothing -> lookupEnv "VOLCA_PASSWORD"
+
+{- | What a hidden @dump-*@ command writes to stdout. Pure, and answered
+before any configuration is read, so these documents describe the engine
+itself rather than one installation of it.
+-}
+dumpDocument :: DumpTarget -> BSL.ByteString
+dumpDocument = \case
+    DumpOpenApi -> encode volcaOpenApi
+    DumpMcpTools -> encode (toolDefinitions (ReadOnly False))
+    DumpConfigSchema -> encode (keyPaths configKeys)
 
 {- | In desktop mode, print a machine-readable port line for the launcher
 to capture and stay quiet. Otherwise emit the human-facing startup banner,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,7 +73,7 @@ of the system; the CLI and REPL are just thin HTTP clients.
 | `volca <command>`         | Thin CLI client: queries the server over HTTP (~0.2 s/command)    |
 | `volca dump-openapi`      | Emits the OpenAPI specification on stdout                         |
 | `volca dump-mcp-tools`    | Emits the MCP tool definitions on stdout                         |
-| `volca dump-config-schema`| Emits every key the configuration file may carry, on stdout       |
+| `volca dump-config-schema` | Emits the names of the keys a configuration file may carry       |
 | `volca stop`              | Stops the running server                                         |
 
 ## Two key flows

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,6 +73,7 @@ of the system; the CLI and REPL are just thin HTTP clients.
 | `volca <command>`         | Thin CLI client: queries the server over HTTP (~0.2 s/command)    |
 | `volca dump-openapi`      | Emits the OpenAPI specification on stdout                         |
 | `volca dump-mcp-tools`    | Emits the MCP tool definitions on stdout                         |
+| `volca dump-config-schema`| Emits every key the configuration file may carry, on stdout       |
 | `volca stop`              | Stops the running server                                         |
 
 ## Two key flows

--- a/src/CLI/Client.hs
+++ b/src/CLI/Client.hs
@@ -235,6 +235,7 @@ executeRemoteCommand mgr rc globalOpts cmd = do
         Repl -> reportError "repl should be handled in Main" >> exitFailure
         DumpOpenApi -> reportError "dump-openapi should be handled in Main" >> exitFailure
         DumpMcpTools -> reportError "dump-mcp-tools should be handled in Main" >> exitFailure
+        DumpConfigSchema -> reportError "dump-config-schema should be handled in Main" >> exitFailure
 
 -- | Look up the collection name for a given method UUID via /api/v1/methods
 lookupMethodCollection :: Manager -> RemoteConfig -> Text -> IO (Maybe Text)

--- a/src/CLI/Client.hs
+++ b/src/CLI/Client.hs
@@ -233,9 +233,10 @@ executeRemoteCommand mgr rc globalOpts cmd = do
         DebugMatrices{} -> reportError "debug-matrices is local-only" >> exitFailure
         ExportMatrices{} -> reportError "export-matrices is local-only" >> exitFailure
         Repl -> reportError "repl should be handled in Main" >> exitFailure
-        DumpOpenApi -> reportError "dump-openapi should be handled in Main" >> exitFailure
-        DumpMcpTools -> reportError "dump-mcp-tools should be handled in Main" >> exitFailure
-        DumpConfigSchema -> reportError "dump-config-schema should be handled in Main" >> exitFailure
+        -- Answered before a server is contacted, so reaching here means the
+        -- REPL, where the line is simply not one of its commands. Saying so
+        -- and carrying on, rather than ending the session over it.
+        Dump _ -> reportError "A dump command writes to stdout; run it outside the REPL."
 
 -- | Look up the collection name for a given method UUID via /api/v1/methods
 lookupMethodCollection :: Manager -> RemoteConfig -> Text -> IO (Maybe Text)

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -182,15 +182,7 @@ executeCommand (CLIConfig globalOpts _) cmd manager = do
         Repl -> do
             reportError "Repl command should be handled in Main.hs"
             exitFailure
-        DumpOpenApi -> do
-            reportError "DumpOpenApi should be handled in Main.hs"
-            exitFailure
-        DumpMcpTools -> do
-            reportError "DumpMcpTools should be handled in Main.hs"
-            exitFailure
-        DumpConfigSchema -> do
-            reportError "DumpConfigSchema should be handled in Main.hs"
-            exitFailure
+        Dump _ -> reportError "A dump command is answered before a database is loaded."
 
 -- | Execute commands that require a loaded database
 executeDbCommand :: OutputFormat -> GlobalOptions -> Database -> Command -> IO ()
@@ -224,9 +216,7 @@ executeDbCommand fmt _globalOpts database = \case
     FlowMapping _ -> pure ()
     Stop -> pure ()
     Repl -> pure ()
-    DumpOpenApi -> pure ()
-    DumpMcpTools -> pure ()
-    DumpConfigSchema -> pure ()
+    Dump _ -> pure ()
 
 -- | Execute activity info command
 executeActivityCommand :: OutputFormat -> Database -> T.Text -> IO ()

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -188,6 +188,9 @@ executeCommand (CLIConfig globalOpts _) cmd manager = do
         DumpMcpTools -> do
             reportError "DumpMcpTools should be handled in Main.hs"
             exitFailure
+        DumpConfigSchema -> do
+            reportError "DumpConfigSchema should be handled in Main.hs"
+            exitFailure
 
 -- | Execute commands that require a loaded database
 executeDbCommand :: OutputFormat -> GlobalOptions -> Database -> Command -> IO ()
@@ -223,6 +226,7 @@ executeDbCommand fmt _globalOpts database = \case
     Repl -> pure ()
     DumpOpenApi -> pure ()
     DumpMcpTools -> pure ()
+    DumpConfigSchema -> pure ()
 
 -- | Execute activity info command
 executeActivityCommand :: OutputFormat -> Database -> T.Text -> IO ()

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -115,6 +115,7 @@ commandParser =
         <|> subparser
             ( cmd "dump-openapi" (pure DumpOpenApi) "Dump OpenAPI spec as JSON to stdout"
                 <> cmd "dump-mcp-tools" (pure DumpMcpTools) "Dump MCP tool definitions as JSON to stdout"
+                <> cmd "dump-config-schema" (pure DumpConfigSchema) "Dump the configuration file's key names as JSON to stdout"
                 <> internal
             )
 

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -113,9 +113,9 @@ commandParser =
             <> cmd "repl" (pure Repl) "Interactive REPL over HTTP (connects to running server)"
         )
         <|> subparser
-            ( cmd "dump-openapi" (pure DumpOpenApi) "Dump OpenAPI spec as JSON to stdout"
-                <> cmd "dump-mcp-tools" (pure DumpMcpTools) "Dump MCP tool definitions as JSON to stdout"
-                <> cmd "dump-config-schema" (pure DumpConfigSchema) "Dump the configuration file's key names as JSON to stdout"
+            ( cmd "dump-openapi" (pure (Dump DumpOpenApi)) "Dump OpenAPI spec as JSON to stdout"
+                <> cmd "dump-mcp-tools" (pure (Dump DumpMcpTools)) "Dump MCP tool definitions as JSON to stdout"
+                <> cmd "dump-config-schema" (pure (Dump DumpConfigSchema)) "Dump the configuration file's key names as JSON to stdout"
                 <> internal
             )
 

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -53,10 +53,18 @@ data Command
     | FlowMapping MappingOptions -- Flow mapping coverage analysis
     | Stop -- Stop running server
     | Repl -- Interactive REPL over HTTP
-    -- Hidden tooling commands (not shown in --help)
-    | DumpOpenApi -- Dump OpenAPI spec as JSON to stdout
-    | DumpMcpTools -- Dump MCP tool definitions as JSON to stdout
-    | DumpConfigSchema -- Dump the configuration file's key names as JSON to stdout
+    | Dump DumpTarget -- Hidden tooling: write a machine-readable document to stdout
+    deriving (Eq, Show, Generic)
+
+{- | What a hidden @dump-*@ command writes out. One constructor for all of
+them, because each is answered in exactly one place, before any configuration
+is read, and every other dispatch only has to know that it is not its
+business.
+-}
+data DumpTarget
+    = DumpOpenApi -- OpenAPI specification
+    | DumpMcpTools -- MCP tool definitions
+    | DumpConfigSchema -- Names of the keys a configuration file may carry
     deriving (Eq, Show, Generic)
 
 -- | Database management actions

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -56,6 +56,7 @@ data Command
     -- Hidden tooling commands (not shown in --help)
     | DumpOpenApi -- Dump OpenAPI spec as JSON to stdout
     | DumpMcpTools -- Dump MCP tool definitions as JSON to stdout
+    | DumpConfigSchema -- Dump the configuration file's key names as JSON to stdout
     deriving (Eq, Show, Generic)
 
 -- | Database management actions

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -659,11 +659,18 @@ configKeys =
             map plain ["description", "scale", "set-value"]
                 <> [("match", keys (map plain ["category", "flow-name", "flow-name-prefix", "cas", "subcompartment-contains"]))]
 
-{- | Every key a shape names, as the dotted paths 'unknownKeys' reports: what
-a document has to spell out to exercise the whole of it.
+{- | Every key a shape names by name, dotted: what a document has to spell out
+to exercise the whole of it.
+
+Not quite what 'unknownKeys' reports, which marks an array of tables @name[]@
+because it is describing one document; a shape has no arity to mark. And not
+every key a document may carry: an 'AcceptsAnything' section is named, but the
+keys under it are the file author\'s and cannot be enumerated.
+
+Sorted, so a consumer can diff two of these.
 -}
 keyPaths :: KeySpec -> [Text]
-keyPaths = go []
+keyPaths = S.toAscList . S.fromList . go []
   where
     go _ AcceptsAnything = []
     go here (Accepts known) =

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -80,6 +80,7 @@ spec = do
                 , ["repl"]
                 , ["dump-openapi"]
                 , ["dump-mcp-tools"]
+                , ["dump-config-schema"]
                 ]
         mapM_
             (\argv -> it (unwords argv <> " --help describes itself") $ answersHelp argv `shouldBe` True)

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -31,6 +31,7 @@ import Config (
     validateConfig,
  )
 import Data.Either (isRight)
+import Data.List (sort)
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -153,6 +154,21 @@ spec = do
                 "[[methods]]\nname=\"EF\"\npath=\"x.zip\"\n\
                 \[[methods.patches]]\nscale = 0.6\nmatch = { flow-name = \"Uranium\", flavour = \"x\" }\n"
                 `shouldBe` ["methods[].patches[].match.flavour"]
+
+    describe "keyPaths" $ do
+        -- What `volca dump-config-schema` prints, which another build reads.
+        it "names a key of every section, sorted" $ do
+            let paths = keyPaths configKeys
+            paths `shouldSatisfy` elem "hosting.read_only"
+            paths `shouldSatisfy` elem "methods.scoring.weighting"
+            paths `shouldSatisfy` elem "geographies"
+            paths `shouldBe` sort paths
+
+        -- A section whose keys the file's author invents is named, but its
+        -- contents cannot be enumerated, so the list stops there.
+        it "stops at a section the file's author fills" $
+            filter (T.isPrefixOf "methods.scoring.variables") (keyPaths configKeys)
+                `shouldBe` ["methods.scoring.variables"]
 
     describe "expandClassificationPreset" $ do
         let raw =


### PR DESCRIPTION
The documentation of `volca.toml` is written by hand against decoders nobody ever diffs it against, so it drifts and nothing says so. As it stands, roughly two thirds of the keys the engine reads are documented nowhere, and several of the sentences that do exist describe behaviour the code stopped having.

The list the unknown-key check already compares a document against is the same list a reader needs, so the engine prints it:

```
$ volca dump-config-schema
["chem-synonyms","classification-presets","classification-presets.description", ... ,"units.path"]
```

Eighty-three dotted paths, sorted. A hidden command, like `dump-openapi` and `dump-mcp-tools`, because the audience is a documentation build rather than an operator, and answered before any configuration is read so it needs no `--config`.

**Names only.** Types and defaults stay prose, written where they can be explained; what a machine can usefully decide is whether a key the engine reads is mentioned anywhere at all. The keys under a section whose contents the file's author names - scoring variables, location aliases - are named as sections and not enumerated, because they cannot be.

**The three dump commands now share one constructor.** Adding a third meant a third unreachable arm in each of two executors and a third in the HTTP client, where it was not unreachable: typing `dump-config-schema` at the REPL prompt ended the session. `Dump DumpTarget` gives each dispatch one arm for all three, and the client's now says what to do rather than calling `exitFailure`.

The companion change on the deployment side commits this output beside the CLI help and the OpenAPI spec, and fails the site build when a key appears in it and in no page.