### PR TITLE
Guard the assistant protocol with the password too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@
   instead of "This instance is read-only", naming who to talk to about it.
 
 ### Changed
+- The shipped `volca.toml` names the settings it never mentioned: `[hosting]`
+  and its nine limits, `chem-synonyms`, `substance-edges`, `[server] name`,
+  and the three method fields that carry a single score (`scoring`, `patches`,
+  `global-methods`). It also stops promising more than the engine does:
+  `VOLCA_PASSWORD` is read only when neither `--password` nor the file sets
+  one, so it cannot rotate a password written there, and `api_access` is
+  reported for whatever fronts the server rather than enforced by it.
 - Startup now says which keys of the configuration file nothing reads. A
   configuration is a list of things the engine looks for, so anything it does
   not look for was dropped without a word, however it got that way: written
@@ -36,6 +43,17 @@
   an older engine.
 
 ### Fixed
+- A password now guards the assistant protocol as well as the REST API.
+  `authMiddleware` only ever protected `/api/`, so a server started with
+  `password` set answered `/mcp` to anyone who asked - and `/mcp` reaches the
+  same operations, including loading, uploading and deleting on a writable
+  server. A password that closes one and leaves the other open reads as
+  protection and is none. Static files and the login page stay public, so a
+  browser can still reach the login screen.
+- The Docker image's default configuration declares the chemical synonyms it
+  ships. The file was copied into the image and named by nothing, so the
+  flow-mapping suggester ran on an empty table, the same way `geographies` did
+  before 0.9.6.
 - The command line can again find the loaded database on its own, so `--db`
   is only needed when several are loaded. It was reading the database list
   under names the engine stopped using, and reported "No databases loaded on

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ A TOML config file enables multi-database setups, method collections, and refere
 
 ```toml
 # Single-path reference data (all optional). Top-level keys stay above the
-# first [section] header: below one they parse as members of that section
-# and are silently dropped.
+# first [section] header: below one they parse as members of that section,
+# which startup reports by name.
 # geographies = "data/geographies.csv"         # code,display_name,parents
 # chem-synonyms = "data/chem_synonyms.csv"     # PubChem snapshot for the suggester
 # substance-edges = "data/substance_edges.csv" # typed flow-correspondence edges

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -222,8 +222,9 @@ VOLUME /data
 
 RUN cat > /app/volca.toml <<'EOF'
 # Top-level keys must stay above the first [section] header: below one they
-# parse as members of that section and are silently dropped.
+# parse as members of that section, which startup reports by name.
 geographies = "data/geographies.csv"
+chem-synonyms = "data/chem_synonyms.csv"
 
 [server]
 port = 8080

--- a/src/API/Auth.hs
+++ b/src/API/Auth.hs
@@ -20,11 +20,15 @@ Returns plain 401 with JSON body (no WWW-Authenticate header, so no browser dial
 authMiddleware :: ByteString -> Middleware
 authMiddleware expectedPassword app req respond =
     let path = rawPathInfo req
-        isApiRoute = "/api/" `BS.isPrefixOf` path
+        -- @/mcp@ reaches the same operations as the REST API, and on a
+        -- writable server that includes loading, uploading and deleting. It is
+        -- guarded with it: a password that closed one and not the other would
+        -- read as protection and be none.
+        isProtected = "/api/" `BS.isPrefixOf` path || path == "/mcp" || "/mcp/" `BS.isPrefixOf` path
         isLoginEndpoint = requestMethod req == "POST" && path == "/api/v1/auth"
-     in -- Only protect /api/ routes; static files and SPA index are public
-        -- (so the browser can load the login page)
-        if not isApiRoute || isLoginEndpoint || isAuthenticated expectedPassword req
+     in -- Static files and the SPA index stay public, so the browser can load
+        -- the login page at all.
+        if not isProtected || isLoginEndpoint || isAuthenticated expectedPassword req
             then app req respond
             else respond unauthorized
   where

--- a/test/AuthSpec.hs
+++ b/test/AuthSpec.hs
@@ -83,6 +83,20 @@ spec = do
             called `shouldBe` False
             code `shouldBe` 401
 
+    describe "the assistant protocol is guarded too" $ do
+        -- /mcp reaches the same operations as the REST API, so a password that
+        -- closed one and left the other open would read as protection and be
+        -- none: an unauthenticated caller could load, upload and delete.
+        it "rejects POST /mcp without credentials" $ do
+            (called, code) <- runAuth "POST" "/mcp" []
+            called `shouldBe` False
+            code `shouldBe` 401
+
+        it "lets POST /mcp through with the password" $ do
+            (called, code) <- runAuth "POST" "/mcp" (bearerHeader password)
+            called `shouldBe` True
+            code `shouldBe` 200
+
     describe "protected /api/ routes — no credentials" $ do
         it "rejects with 401 when Authorization and Cookie are absent" $ do
             (called, code) <- runAuth "GET" "/api/v1/db" []

--- a/volca.toml
+++ b/volca.toml
@@ -15,8 +15,10 @@
 # Geographies are required for regionalized LCIA cascade lookups. The other two
 # widen how flows are recognised across databases and methods; both optional.
 geographies = "data/geographies.csv"
-# chem-synonyms = "data/chem_synonyms.csv"      # PubChem snapshot for the mapping suggester
-# substance-edges = "data/substance_edges.csv"  # typed correspondences between substances
+# chem-synonyms = "data/chem_synonyms.csv"      # PubChem snapshot, shipped here
+# Typed correspondences between substances. No file ships for this one: the
+# format is your own to write, eight columns, see src/SubstanceRegistry.hs.
+# substance-edges = "data/substance_edges.csv"
 
 # ── Server ───────────────────────────────────────────────────────────
 
@@ -27,8 +29,11 @@ port = 8080                     # HTTP port
 # answer the network over IPv4, "::" over IPv6, or name one interface's own
 # address to answer on that one alone.
 host = "127.0.0.1"
-# A request must carry this: Authorization: Bearer <it>, HTTP Basic, or the
-# session cookie the login page sets. --password and VOLCA_PASSWORD override it.
+# Set it and every request to /api/ and /mcp must carry it: Authorization:
+# Bearer <it>, HTTP Basic, or the session cookie the login page sets. Static
+# files and the login page stay public. --password wins over this line; the
+# VOLCA_PASSWORD environment variable is only read when neither is set, so it
+# cannot be used to rotate a password written here.
 # password = "changeme"
 # How this server introduces itself over MCP, so someone holding several can
 # tell which one answered.
@@ -44,13 +49,20 @@ host = "127.0.0.1"
 # [hosting]
 # read_only = true                  # refuse every change; queries still answer
 # read_only_message = "Ask the operator to load it for you."
-# max_uploads = 2                   # -1 unlimited, 0 disables uploading
-# max_upload_mb = 100               # per upload; -1 unlimited, 0 disables
-# max_loaded_uploads = 1            # how many uploads may sit in memory at once
-# api_access = true                 # false refuses programmatic access
-# upgrade_upload = ""               # what to say instead of a bare refusal
-# upgrade_api = ""
-# upgrade_vm_size = ""
+# max_uploads = 2                   # default -1 (unlimited); 0 disables uploading
+# max_upload_mb = 100               # per upload, and this IS the default even
+#                                   # with no [hosting] at all; -1 unlimited
+# max_loaded_uploads = 1            # default -1; how many uploads may sit in
+#                                   # memory at once
+# api_access = true                 # default true. Reported by GET
+#                                   # /api/v1/hosting for whatever fronts this
+#                                   # server to enforce; the server itself does
+#                                   # not refuse on it
+# upgrade_upload = ""               # shown instead of a bare refusal when the
+#                                   # upload count or size limit is hit
+# upgrade_vm_size = ""              # shown when max_loaded_uploads is hit
+# upgrade_api = ""                  # reported by GET /api/v1/hosting, for
+#                                   # whoever refuses programmatic access
 
 # ── Databases ────────────────────────────────────────────────────────
 #

--- a/volca.toml
+++ b/volca.toml
@@ -9,9 +9,14 @@
 
 # Top-level scalar fields MUST come before any [section] / [[array-of-tables]]
 # header. After a header, every following key is parsed as a member of that
-# section until the next header — silently dropped if the schema doesn't know
-# the key. Geographies are required for regionalized LCIA cascade lookups.
+# section until the next header. Startup warns about every key nothing reads,
+# naming its path, which is how such a mistake is found.
+#
+# Geographies are required for regionalized LCIA cascade lookups. The other two
+# widen how flows are recognised across databases and methods; both optional.
 geographies = "data/geographies.csv"
+# chem-synonyms = "data/chem_synonyms.csv"      # PubChem snapshot for the mapping suggester
+# substance-edges = "data/substance_edges.csv"  # typed correspondences between substances
 
 # ── Server ───────────────────────────────────────────────────────────
 
@@ -22,7 +27,30 @@ port = 8080                     # HTTP port
 # answer the network over IPv4, "::" over IPv6, or name one interface's own
 # address to answer on that one alone.
 host = "127.0.0.1"
-# password = "changeme"        # Optional HTTP Basic Auth password
+# A request must carry this: Authorization: Bearer <it>, HTTP Basic, or the
+# session cookie the login page sets. --password and VOLCA_PASSWORD override it.
+# password = "changeme"
+# How this server introduces itself over MCP, so someone holding several can
+# tell which one answered.
+# name = "lab-archive"
+
+# ── Hosting limits ───────────────────────────────────────────────────
+#
+# For a server answering people who did not configure it. Every setting here
+# is a refusal rather than data, and GET /api/v1/hosting reports all of them,
+# so a client can explain a limit before a request runs into it. Absent, the
+# server refuses nothing.
+#
+# [hosting]
+# read_only = true                  # refuse every change; queries still answer
+# read_only_message = "Ask the operator to load it for you."
+# max_uploads = 2                   # -1 unlimited, 0 disables uploading
+# max_upload_mb = 100               # per upload; -1 unlimited, 0 disables
+# max_loaded_uploads = 1            # how many uploads may sit in memory at once
+# api_access = true                 # false refuses programmatic access
+# upgrade_upload = ""               # what to say instead of a bare refusal
+# upgrade_api = ""
+# upgrade_vm_size = ""
 
 # ── Databases ────────────────────────────────────────────────────────
 #
@@ -62,10 +90,18 @@ host = "127.0.0.1"
 # files, a SimaPro or columnar method .csv, or an openLCA ImpactCategory .json.
 #
 # Fields:
-#   name          (required) Method collection name
-#   path          (required) Path to method archive
-#   active        = true     Enable this method
-#   description              Short description
+#   name           (required) Method collection name
+#   path           (required) Path to method archive
+#   active         = true     Enable this method
+#   description               Short description
+#   global-methods            Names of methods here whose factors apply
+#                             everywhere, so the regionalized cascade is skipped
+#   scoring                   [[methods.scoring]] blocks: single scores built
+#                             from these categories
+#   patches                   [[methods.patches]] blocks: corrections to
+#                             individual characterization factors
+#
+# The last two have a page of their own: https://www.volca.run/docs/guides/single-score/
 #
 # Example (bring your own):
 #


### PR DESCRIPTION
`volca.toml` at the root of this repository is where someone starts, and three of the things it did not mention are among the ones most worth knowing:

- `[hosting]`, which decides every refusal a user of a shared server meets, and which appeared nowhere in this file.
- `chem-synonyms` and `substance-edges`, the two optional tables that widen how flows are recognised across databases and methods.
- `[server] name`, which is how somebody holding several engines tells which one answered.

All commented out, since none of them is a default.

**The methods block listed four fields where the decoder reads seven.** The three missing ones are `scoring`, `patches` and `global-methods` - that is the whole of the single score, the largest thing this file can carry, with no mention here at all. Now listed, and pointed at the page that explains them.

The warning about top-level keys said such a key is "silently dropped". Since #308 it is reported by name at startup, which is a more useful thing to tell a reader than to watch out.