### PR TITLE
Keep both changelog entries instead of conflicting on them

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,11 @@
 # Enforce LF line endings for all text files
 * text=auto eol=lf
 
+# Two branches each adding an entry under the same heading is not a
+# disagreement, it is two entries. Keep both sides instead of raising a
+# conflict every time a branch catches up with main.
+CHANGELOG.md merge=union
+
 # Windows-specific files can use CRLF
 *.bat text eol=crlf
 *.nsh text eol=crlf


### PR DESCRIPTION
Every branch that catches up with main hits the same conflict in `CHANGELOG.md`: two entries added under the same heading. That is not two branches disagreeing about one line, it is two lines that both belong, and resolving it by hand is pure ceremony.

`CHANGELOG.md merge=union` tells git's built-in union driver to keep both sides. It applies to a local merge, rebase or cherry-pick, which is where these conflicts happen.

The trade: a branch editing an entry another branch also edited now gets both versions one under the other, with no conflict raised. That reads oddly rather than dangerously, and the release preparation re-reads the Unreleased section anyway. If it ever stops being enough, the structural answer is one file per change under a `changelog.d/` directory, assembled at release time.