### PR TITLE
Spell a CAS number the same way whichever parser read it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,20 @@
   an older engine.
 
 ### Fixed
+- A substance is now recognised by its CAS number however the source spelled
+  it. A CAS reads `registry-group-check`, and only the registry number is ever
+  zero-padded: the group is two digits and the check digit one. One of the two
+  readers stripped zeros from every segment, turning formaldehyde's `50-00-0`
+  into `50-0-0`, so which spelling a value carried depended on which parser had
+  read it — and the two never met. Every substance whose group segment begins
+  with a zero was affected. Both sides of the bridge now canonicalize, so a
+  padded and an unpadded spelling of one substance meet whichever parser
+  produced them. **Scores change** where a factor was previously missed: an
+  impact that silently counted nothing for such a substance now counts it. A
+  `cas` selector in a method patch written as `50-0-0` no longer matches
+  anything and should be rewritten as `50-00-0`. A CAS made only of zeros and
+  dashes is read as "no CAS stated" rather than as a substance every CAS-less
+  flow shares.
 - A flow name that finds something in a search now finds the same thing in a
   filter. `get_inventory` and `get_activity` matched the whole query as one
   piece of text, so the name read off a search came back empty as soon as the

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -275,9 +275,11 @@ data MethodPatchMatch = MethodPatchMatch
     , mpmFlowNamePrefix :: !(Maybe Text)
     -- ^ Flow name prefix (TOML: @flow-name-prefix@), matched with 'Data.Text.isPrefixOf'.
     , mpmCAS :: !(Maybe Text)
-    {- ^ CAS registry number (TOML: @cas@), matched against 'Method.mcfCAS' after
-    normalizing both sides the same way (leading zeros in each dash-separated
-    segment are insignificant), so either the raw or the normalized form works.
+    {- ^ CAS registry number (TOML: @cas@), matched against 'Method.mcfCAS' with
+    both sides canonicalized, so a selector matches whichever way the method's
+    source spelled the padding. Only the registry number (the first segment) is
+    ever zero-padded, so @0000050-00-0@ and @50-00-0@ are the same substance
+    while @50-0-0@ is not one at all.
     -}
     , mpmSubcompartmentContains :: !(Maybe Text)
     {- ^ Case-insensitive substring of the subcompartment (TOML:

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -154,7 +154,6 @@ import Data.Time (diffUTCTime, getCurrentTime)
 import Database (buildDatabaseWithMatrices)
 import qualified Database.Loader as Loader
 import qualified Database.Quality as Quality
-import EcoSpold.Parser2 (normalizeCAS)
 import Matrix (clearCachedSolver)
 import Method.ChemSynonyms (ChemSynonyms, emptyChemSynonyms, loadChemSynonyms)
 import qualified Method.Coverage as Coverage
@@ -208,7 +207,7 @@ import Progress (ProgressLevel (..), reportError, reportProgress, reportProgress
 import qualified Search.BM25 as BM25
 import SharedSolver (SharedSolver, createSharedSolver)
 import qualified SharedSolver
-import SubstanceRegistry (CASNumber (..), KeyNormalizers (..), NormName (..), SubstanceEdge, casBindingsFromEdges, parseSubstanceEdges)
+import SubstanceRegistry (CASNumber (..), KeyNormalizers (..), NormName (..), SubstanceEdge, casBindingsFromEdges, normalizeCAS, parseSubstanceEdges)
 import SynonymDB (BridgeDirection (..), SynEdge (..), SynonymDB (..), buildFromCSV, emptySynonymDB, excludeJunkSynonyms, excludeOverFrequentSynonyms, loadFromCSVFileWithCache, mergeSynonymDBs, normalizeName, oversizedClasses, reopenedBridges, synonymCount, uncoveredUnitSuffixes)
 import Types (
     Activity (..),

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -20,7 +20,7 @@ import EcoSpold.Common (bsToDouble, bsToInt, bsToIntMaybe, bsToText, isElement, 
 import EcoSpold.Cutoff (applyCutoffStrategy)
 import qualified Expr
 import Progress (ProgressLevel (..), reportProgress)
-import SubstanceRegistry (normalizeCAS)
+import SubstanceRegistry (nonEmptyCAS)
 import System.FilePath (takeBaseName)
 import Types
 import qualified Xeno.SAX as X
@@ -490,7 +490,7 @@ parseWithXeno xmlContent processId = do
                             | isElement name "unitId" && not isInsideProperty = edata{edUnitId = bsToText value}
                             | isElement name "inputGroup" = edata{edInputGroup = bsToText value}
                             | isElement name "outputGroup" = edata{edOutputGroup = bsToText value}
-                            | isElement name "casNumber" = edata{edCAS = Just (normalizeCAS (bsToText value))}
+                            | isElement name "casNumber" = edata{edCAS = nonEmptyCAS (bsToText value)}
                             | isElement name "variableName" && not isInsideProperty = edata{edVariableName = bsToText value}
                             | isElement name "mathematicalRelation" && not isInsideProperty = edata{edMathRel = bsToText value}
                             | otherwise = edata

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections #-}
 
-module EcoSpold.Parser2 (streamParseActivityAndFlowsFromFile, normalizeCAS) where
+module EcoSpold.Parser2 (streamParseActivityAndFlowsFromFile) where
 
 import Amount (readAmount)
 import Data.Bifunctor (first)
@@ -20,19 +20,10 @@ import EcoSpold.Common (bsToDouble, bsToInt, bsToIntMaybe, bsToText, isElement, 
 import EcoSpold.Cutoff (applyCutoffStrategy)
 import qualified Expr
 import Progress (ProgressLevel (..), reportProgress)
+import SubstanceRegistry (normalizeCAS)
 import System.FilePath (takeBaseName)
 import Types
 import qualified Xeno.SAX as X
-
-{- | Normalize CAS number by stripping leading zeros from first segment.
-Ecoinvent zero-pads: "001309-36-0" → "1309-36-0". ILCD uses canonical form.
--}
-normalizeCAS :: Text -> Text
-normalizeCAS cas = case T.splitOn "-" cas of
-    [a, b, c] ->
-        let a' = T.dropWhile (== '0') a
-         in (if T.null a' then "0" else a') <> "-" <> b <> "-" <> c
-    _ -> T.strip cas
 
 {- | Namespace UUID for generating deterministic UUIDs from invalid text
 Using UUID v5 (SHA1-based) with a custom namespace for test data compatibility

--- a/src/Method/FlowResolver.hs
+++ b/src/Method/FlowResolver.hs
@@ -45,9 +45,13 @@ import System.FilePath (takeDirectory, takeExtension, (</>))
 import qualified Xeno.SAX as X
 
 import EcoSpold.Common (bsToText, decodeXmlEntitiesFull, distributeFiles, isElement)
-import EcoSpold.Parser2 (normalizeCAS)
 import Method.Types (Compartment (..))
 import Progress (ProgressLevel (..), reportProgress)
+import SubstanceRegistry (normalizeCAS)
+
+-- The on-disk flow cache below serializes a 'UUID', whose 'Store' instance is
+-- an orphan living in "Types". Imported for the instance alone.
+import Types ()
 
 -- | Enrichment data extracted from an ILCD flow XML
 data ILCDFlowInfo = ILCDFlowInfo

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -136,11 +136,11 @@ import Data.Word (Word8)
 import GHC.Generics (Generic)
 
 import qualified Data.Set as Set
-import EcoSpold.Parser2 (normalizeCAS)
 import Matrix (Inventory, Vector, chunksOf)
 import Method.ChemSynonyms (ChemSynonyms, expandedTokens)
 import Method.Types
 import Progress (ProgressLevel (..), reportProgress)
+import SubstanceRegistry (normalizeCAS)
 import qualified SubstanceRegistry as SR
 import SynonymDB
 import Types (Activity (..), BioFlowDB, BiosphereFlow (..), Database (..), ProcessId, SparseTriple (..), Unit (..), UnitDB)

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -140,7 +140,7 @@ import Matrix (Inventory, Vector, chunksOf)
 import Method.ChemSynonyms (ChemSynonyms, expandedTokens)
 import Method.Types
 import Progress (ProgressLevel (..), reportProgress)
-import SubstanceRegistry (normalizeCAS)
+import SubstanceRegistry (nonEmptyCAS, normalizeCAS)
 import qualified SubstanceRegistry as SR
 import SynonymDB
 import Types (Activity (..), BioFlowDB, BiosphereFlow (..), Database (..), ProcessId, SparseTriple (..), Unit (..), UnitDB)
@@ -481,10 +481,14 @@ strategyFromText t = case T.toLower t of
 findFlowByUUID :: M.Map UUID BiosphereFlow -> UUID -> Maybe BiosphereFlow
 findFlowByUUID flowsByUUID uuid = M.lookup uuid flowsByUUID
 
--- | Find flow by CAS number with compartment preference
+{- | Find flow by CAS number with compartment preference. Canonicalizes on the
+way in, as 'findFlowByNameComp' does for names: the index is keyed canonically,
+and a method that states a padded CAS must still meet the flow that states it
+unpadded.
+-}
 findFlowByCAS :: M.Map Text [BiosphereFlow] -> Text -> Maybe Compartment -> Maybe BiosphereFlow
 findFlowByCAS flowsByCAS cas mComp =
-    M.lookup cas flowsByCAS >>= \flows -> pickByCompartment flows mComp
+    nonEmptyCAS cas >>= (`M.lookup` flowsByCAS) >>= \flows -> pickByCompartment flows mComp
 
 -- | Find flow by normalized name match (compartment-aware)
 findFlowByName :: M.Map Text [BiosphereFlow] -> Text -> Maybe BiosphereFlow
@@ -1367,10 +1371,10 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             (`M.withoutKeys` casDiscriminated) . M.map snd $
                 M.fromListWith
                     (preferUnspecifiedBy teCF)
-                    [ ((SR.CASNumber cas, Medium normMed), (casSubRank normSub, entryOf cf mflow))
+                    [ ((casNo, Medium normMed), (casSubRank normSub, entryOf cf mflow))
                     | (cf, mflow@(Just (_, ByCAS))) <- mappings
                     , Just cas <- [mcfCAS cf]
-                    , not (T.null cas)
+                    , Just casNo <- [SR.casKey cas]
                     , Nothing <- [mcfConsumerLocation cf]
                     , (_, Nothing) <- [extractLocationSuffix (mcfFlowName cf)]
                     , Just comp <- [mcfCompartment cf]
@@ -1393,10 +1397,10 @@ buildMethodTables methodFamily cmap energyDensities mappings =
             (`M.withoutKeys` casDiscriminated) . M.map (M.map snd) $
                 M.fromListWith
                     (M.unionWith (preferUnspecifiedBy id))
-                    [ ((SR.CASNumber cas, Medium normMed), M.singleton (Location loc) (casSubRank normSub, cfOf cf))
+                    [ ((casNo, Medium normMed), M.singleton (Location loc) (casSubRank normSub, cfOf cf))
                     | (cf, Just (_, ByCAS)) <- mappings
                     , Just cas <- [mcfCAS cf]
-                    , not (T.null cas)
+                    , Just casNo <- [SR.casKey cas]
                     , Just loc <- [mcfConsumerLocation cf]
                     , Just comp <- [mcfCompartment cf]
                     , let Compartment normMedRaw normSub _ = normalizeCompartment cmap comp
@@ -1861,7 +1865,8 @@ fillRegionalActivityWeights unitCfg unitDB flowDB db hier tables
                 M.lookup fid perFlow
                     <|> ( M.lookup fid flowDB >>= \flow ->
                             bfCAS flow
-                                >>= \cas -> M.lookup (SR.CASNumber cas, fst (flowMediumSub cmap flow)) regionalCas
+                                >>= SR.casKey
+                                >>= \casNo -> M.lookup (casNo, fst (flowMediumSub cmap flow)) regionalCas
                         )
          in V.map lookupRow bioFlows
 
@@ -2311,7 +2316,9 @@ cascadeTrail tables flowDB fid =
 
         casOutcome = case bfCAS flow of
             Nothing -> RungNotApplicable
-            Just cas -> gated (M.lookup (SR.CASNumber cas, baseMed) (mtCasCF tables))
+            Just cas -> case SR.casKey cas of
+                Nothing -> RungNotApplicable
+                Just casNo -> gated (M.lookup (casNo, baseMed) (mtCasCF tables))
 
         -- A SimaPro region-suffixed flow ("Ammonia, FR") whose region the method
         -- doesn't tag falls back to the base substance's CF: an unregionalized CF

--- a/src/Method/ParserSimaPro.hs
+++ b/src/Method/ParserSimaPro.hs
@@ -12,7 +12,6 @@ module Method.ParserSimaPro (
     parseSimaProMethodCSV,
     parseSimaProMethodCSVBytes,
     isSimaProMethodCSV,
-    normalizeCAS,
 ) where
 
 import qualified Data.ByteString as BS
@@ -25,6 +24,8 @@ import qualified Data.Text.Encoding as TE
 import qualified Data.UUID.V5 as UUID5
 
 import Method.Types
+import SubstanceRegistry (nonEmptyCAS)
+
 import SimaPro.Parser (
     SimaProConfig (..),
     decodeBS,
@@ -319,7 +320,7 @@ parseCFRow cfg line =
                         , mcfDirection = direction comp
                         , mcfValue = parseAmount (spDecimal cfg) (BS8.strip cfVal)
                         , mcfCompartment = mkCompartment comp sub
-                        , mcfCAS = normalizeCAS (decodeBS (BS8.strip cas))
+                        , mcfCAS = nonEmptyCAS (decodeBS (BS8.strip cas))
                         , mcfUnit = cfUnitT
                         , mcfConsumerLocation = Nothing
                         }
@@ -401,15 +402,3 @@ mkCompartment comp sub =
         if T.null medium
             then Nothing
             else Just (Compartment medium subcomp "")
-
-normalizeCAS :: Text -> Maybe Text
-normalizeCAS cas
-    | T.null cas = Nothing
-    | otherwise =
-        let segments = T.splitOn "-" cas
-            stripped = map (T.dropWhile (== '0')) segments
-            fixed = map (\s -> if T.null s then "0" else s) stripped
-            result = T.intercalate "-" fixed
-         in if T.all (\c -> c == '-' || c == '0') cas
-                then Nothing
-                else Just result

--- a/src/Method/Patch.hs
+++ b/src/Method/Patch.hs
@@ -70,15 +70,15 @@ cfMatches sel category cf =
         && maybe True (casMatches (mcfCAS cf)) (mpmCAS sel)
         && maybe True (subcompartmentMatches (mcfCompartment cf)) (mpmSubcompartmentContains sel)
 
-{- | Compare CAS numbers after normalizing both sides the same way (dropping
-insignificant leading zeros), so either the raw or normalized form matches.
-An unnormalizable selector (e.g. all zeros/dashes) matches nothing rather
-than mis-matching every CAS-less CF.
+{- | Compare CAS numbers with both sides canonicalized, so a selector matches
+whichever way the method's parser spelled the padding. A selector that states
+no CAS (empty, or all zeros and dashes) matches nothing rather than matching
+every CAS-less CF.
 -}
 casMatches :: Maybe T.Text -> T.Text -> Bool
 casMatches mcfCas want = case nonEmptyCAS want of
     Nothing -> False
-    Just normalized -> mcfCas == Just normalized
+    Just wanted -> (nonEmptyCAS =<< mcfCas) == Just wanted
 
 subcompartmentMatches :: Maybe Compartment -> T.Text -> Bool
 subcompartmentMatches Nothing _ = False

--- a/src/Method/Patch.hs
+++ b/src/Method/Patch.hs
@@ -22,8 +22,8 @@ import Config (CFPatchOp (..), MethodPatch (..), MethodPatchMatch (..))
 import Data.List (mapAccumL)
 import Data.Maybe (maybeToList)
 import qualified Data.Text as T
-import Method.ParserSimaPro (normalizeCAS)
 import Method.Types (Compartment (..), Method (..), MethodCF (..), MethodCollection (..))
+import SubstanceRegistry (nonEmptyCAS)
 
 {- | Apply every patch, in order, to a method collection. Each patch scans
 every CF of every method whose category matches (via 'cfMatches') and
@@ -76,7 +76,7 @@ An unnormalizable selector (e.g. all zeros/dashes) matches nothing rather
 than mis-matching every CAS-less CF.
 -}
 casMatches :: Maybe T.Text -> T.Text -> Bool
-casMatches mcfCas want = case normalizeCAS want of
+casMatches mcfCas want = case nonEmptyCAS want of
     Nothing -> False
     Just normalized -> mcfCas == Just normalized
 

--- a/src/Method/WriterILCD.hs
+++ b/src/Method/WriterILCD.hs
@@ -62,10 +62,10 @@ import qualified Data.Text.Encoding as TE
 import Data.UUID (UUID)
 import qualified Data.UUID as UUID
 
-import EcoSpold.Parser2 (normalizeCAS)
 import ILCD.Writer (escapeXml, formatDouble)
 import Method.FlowResolver (parseCompartment)
 import Method.Types
+import SubstanceRegistry (normalizeCAS)
 
 --------------------------------------------------------------------------------
 -- Entry points

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -61,12 +61,11 @@ import Data.Time (diffUTCTime, getCurrentTime)
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V5 as UUID5
 import qualified Data.Vector as V
-import EcoSpold.Parser2 (normalizeCAS)
 import qualified Expr
 import GHC.Conc (getNumCapabilities)
 import GHC.Generics (Generic)
 import Progress (ProgressLevel (..), reportProgress)
-import SubstanceRegistry (CASNumber (..), NormName (..), casBindings)
+import SubstanceRegistry (CASNumber (..), NormName (..), casBindings, normalizeCAS)
 import SynonymDB (normalizeName)
 import Text.Printf (printf)
 import Types

--- a/src/SubstanceRegistry.hs
+++ b/src/SubstanceRegistry.hs
@@ -33,6 +33,8 @@ module SubstanceRegistry (
     classesFromEdges,
 
     -- * CAS enrichment
+    normalizeCAS,
+    nonEmptyCAS,
     casBindings,
     casBindingsFromEdges,
 
@@ -205,6 +207,37 @@ casBindingsFromEdges edges = casBindings pairs
     nameCasPair (ByCAS c) (ByName _ n) = [(n, c)]
     nameCasPair _ _ = []
 
+{- | Canonical spelling of a CAS registry number, so the same substance keys
+identically whichever source stated it.
+
+A CAS number is @registry-group-check@: a registry number of two to seven
+digits, a two-digit group, and a single check digit. Only the registry number
+is ever zero-padded — ecoinvent writes @001309-36-0@ where the canonical form
+is @1309-36-0@ — so only its leading zeros come off. The other two segments are
+fixed-width and keep theirs: formaldehyde is @50-00-0@, never @50-0-0@.
+
+Anything that is not three dash-separated segments is passed through stripped;
+this is a canonicalizer, not a validator.
+-}
+normalizeCAS :: Text -> Text
+normalizeCAS cas = case T.splitOn "-" (T.strip cas) of
+    [registry, group, check] ->
+        let registry' = T.dropWhile (== '0') registry
+         in (if T.null registry' then "0" else registry') <> "-" <> group <> "-" <> check
+    _ -> T.strip cas
+
+{- | 'normalizeCAS' for a field that may carry no CAS at all: 'Nothing' for an
+empty string and for a placeholder made only of zeros and dashes, which several
+sources write where they mean "unknown".
+-}
+nonEmptyCAS :: Text -> Maybe Text
+nonEmptyCAS cas
+    | T.null stripped = Nothing
+    | T.all (\c -> c == '-' || c == '0') stripped = Nothing
+    | otherwise = Just (normalizeCAS stripped)
+  where
+    stripped = T.strip cas
+
 {- | Fold name→CAS pairs into bindings under the registry's conflict rule: the
 first binding of a name wins, and a later pair binding the same name to a
 /different/ CAS comes back as a conflict for the caller to report — never
@@ -221,11 +254,10 @@ casBindings = foldl' (flip insert) (M.empty, [])
                 | otherwise -> (m, (n, (c', c)) : conflicts)
 
 {- | The normalizers a CSV row's keys pass through, injected to keep this
-module free of the parser/synonym layers it would otherwise have to import.
+module free of the synonym layer it would otherwise have to import.
 'knName' canonicalizes a flow name (typically @SynonymDB.normalizeName@);
-'knCAS' canonicalizes a CAS string (typically @EcoSpold.Parser2.normalizeCAS@)
-so an edge's CAS lands in the same form as a method's, and the two actually
-meet on the bridge.
+'knCAS' canonicalizes a CAS string (typically 'normalizeCAS') so an edge's CAS
+lands in the same form as a method's, and the two actually meet on the bridge.
 -}
 data KeyNormalizers = KeyNormalizers
     { knName :: Text -> NormName

--- a/src/SubstanceRegistry.hs
+++ b/src/SubstanceRegistry.hs
@@ -35,6 +35,7 @@ module SubstanceRegistry (
     -- * CAS enrichment
     normalizeCAS,
     nonEmptyCAS,
+    casKey,
     casBindings,
     casBindingsFromEdges,
 
@@ -238,6 +239,17 @@ nonEmptyCAS cas
   where
     stripped = T.strip cas
 
+{- | The key a CAS anchors on, or 'Nothing' when the text states no CAS.
+
+Both sides of the CAS bridge build their key through here, so a flow and a
+method factor meet whichever source spelled the padding — which is the whole
+point of canonicalizing, and does not happen if either side keys on the raw
+string. A placeholder never becomes a key at all, so unrelated substances
+cannot collide on one.
+-}
+casKey :: Text -> Maybe CASNumber
+casKey = fmap CASNumber . nonEmptyCAS
+
 {- | Fold name→CAS pairs into bindings under the registry's conflict rule: the
 first binding of a name wins, and a later pair binding the same name to a
 /different/ CAS comes back as a conflict for the caller to report — never
@@ -254,10 +266,10 @@ casBindings = foldl' (flip insert) (M.empty, [])
                 | otherwise -> (m, (n, (c', c)) : conflicts)
 
 {- | The normalizers a CSV row's keys pass through, injected to keep this
-module free of the synonym layer it would otherwise have to import.
-'knName' canonicalizes a flow name (typically @SynonymDB.normalizeName@);
-'knCAS' canonicalizes a CAS string (typically 'normalizeCAS') so an edge's CAS
-lands in the same form as a method's, and the two actually meet on the bridge.
+module free of the synonym layer it would otherwise have to import. Only
+'knName' still needs injecting for that reason; 'knCAS' is 'normalizeCAS',
+which lives here, and is a parameter so a test can key edges by a stub without
+building the real name normalizer.
 -}
 data KeyNormalizers = KeyNormalizers
     { knName :: Text -> NormName

--- a/src/Tools/SynonymsCompiler.hs
+++ b/src/Tools/SynonymsCompiler.hs
@@ -41,7 +41,7 @@ import System.FilePath (takeExtension, (</>))
 import System.IO (hPutStrLn, stderr)
 import Text.Printf (printf)
 
-import EcoSpold.Parser2 (normalizeCAS)
+import SubstanceRegistry (normalizeCAS)
 import SynonymDB (fromClassMaps, normalizeName)
 import SynonymDB.Types (SynonymDB (..))
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -37,7 +37,7 @@ import Control.Lens ((&), (?~))
 import Data.List (nub)
 import Data.OpenApi (NamedSchema (..), OpenApiType (..), ToSchema (..), enum_, type_)
 import Search.BM25.Types (BM25Index)
-import SubstanceRegistry (CASNumber (..), NormName (..))
+import SubstanceRegistry (CASNumber (..), NormName (..), nonEmptyCAS)
 import SynonymDB (normalizeName)
 import SynonymDB.Types (SynonymDB)
 
@@ -1042,15 +1042,22 @@ buildFlowNameIndex bioDB =
                 ]
          in [(k, [f]) | k <- nub (primary : synKeys)]
 
--- | Build CAS index from biosphere flows
+{- | Build CAS index from biosphere flows.
+
+Keyed by the canonical spelling, because a flow and the method factor that
+characterizes it are read by different parsers and only one of them
+canonicalizes on the way in. A flow stating no CAS — empty, or a placeholder
+made of zeros and dashes — is left out rather than indexed under a key
+unrelated substances would share.
+-}
 buildFlowCASIndex :: BioFlowDB -> M.Map Text [BiosphereFlow]
 buildFlowCASIndex bioDB =
     M.fromListWith
         (++)
         [ (cas, [f])
         | f <- M.elems bioDB
-        , Just cas <- [bfCAS f]
-        , not (T.null cas)
+        , Just stated <- [bfCAS f]
+        , Just cas <- [nonEmptyCAS stated]
         ]
 
 -- | Add biosphere flow indexes (name + CAS) and search index to a Database

--- a/test/CASBridgeAmbiguitySpec.hs
+++ b/test/CASBridgeAmbiguitySpec.hs
@@ -110,10 +110,10 @@ spec = describe "CAS bridge ambiguity guard" $ do
         -- already arbitrated to the unspecified default; that arbitration is
         -- not ambiguity.
         let mappings =
-                [ (mkCF 1 "Particulates" "" (Just "0000-00-0") 1.0, Just (mkFlow 1 "Particulates, alias" (Just "0000-00-0"), ByCAS))
-                , (mkCF 2 "Particulates" "indoor" (Just "0000-00-0") 100.0, Just (mkFlow 2 "Particulates, indoor" (Just "0000-00-0"), ByName))
+                [ (mkCF 1 "Particulates" "" (Just "1234-56-7") 1.0, Just (mkFlow 1 "Particulates, alias" (Just "1234-56-7"), ByCAS))
+                , (mkCF 2 "Particulates" "indoor" (Just "1234-56-7") 100.0, Just (mkFlow 2 "Particulates, indoor" (Just "1234-56-7"), ByName))
                 ]
-        score mappings (mkFlow 99 "Dust" (Just "0000-00-0")) `shouldBe` Just 1.0
+        score mappings (mkFlow 99 "Dust" (Just "1234-56-7")) `shouldBe` Just 1.0
 
     describe "a located method against a name-suffixed database" $ do
         -- JRC-style rows (per-country values, consumer-located) meeting

--- a/test/FlowResolverSpec.hs
+++ b/test/FlowResolverSpec.hs
@@ -5,7 +5,6 @@ module FlowResolverSpec (spec) where
 import Data.ByteString (ByteString)
 import qualified Data.UUID as UUID
 import EcoSpold.Common (decodeXmlEntities, decodeXmlEntitiesFull)
-import EcoSpold.Parser2 (normalizeCAS)
 import Method.FlowResolver (ILCDFlowInfo (..), parseFlowXML, splitIlcdSynonyms)
 import Method.Types (Compartment (..))
 import Test.Hspec
@@ -50,25 +49,6 @@ spec = do
 
         it "splits on the 'othernames' pseudo-delimiter the source glues names with" $
             splitIlcdSynonyms "a;b othernames c" `shouldBe` ["a", "b", "c"]
-
-    -- -----------------------------------------------------------------------
-    -- normalizeCAS (pure, from EcoSpold.Parser2)
-    -- -----------------------------------------------------------------------
-    describe "normalizeCAS" $ do
-        it "strips leading zeros from first segment" $
-            normalizeCAS "001309-36-0" `shouldBe` "1309-36-0"
-
-        it "preserves canonical CAS (no leading zeros)" $
-            normalizeCAS "7732-18-5" `shouldBe` "7732-18-5"
-
-        it "handles single zero in first segment" $
-            normalizeCAS "0074-98-6" `shouldBe` "74-98-6"
-
-        it "preserves the zero when segment is all zeros" $
-            normalizeCAS "000-00-0" `shouldBe` "0-00-0"
-
-        it "passes through non-3-segment format stripped" $
-            normalizeCAS "  not-valid  " `shouldBe` "not-valid"
 
     -- -----------------------------------------------------------------------
     -- parseFlowXML — well-formed elementary flow

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -156,6 +156,23 @@ spec = do
         it "returns Nothing for unknown CAS" $
             fmap bfId (findFlowByCAS M.empty "000-00-0" Nothing) `shouldBe` Nothing
 
+        -- The index is keyed canonically; a method whose parser kept the
+        -- source's zero-padding still has to reach the same flow, or its
+        -- factor goes silently missing.
+        it "meets a canonically indexed flow from a zero-padded query" $ do
+            fid <- nextRandom
+            let flow = mkFlow fid "Carbon dioxide" "air" Nothing
+                byCAS = M.singleton "124-38-9" [flow]
+            fmap bfId (findFlowByCAS byCAS "000124-38-9" Nothing) `shouldBe` Just fid
+
+        -- An all-zeros placeholder is not a substance anchor: indexing it
+        -- would collide every CAS-less flow onto one key.
+        it "refuses an all-zeros placeholder rather than treating it as a CAS" $ do
+            fid <- nextRandom
+            let flow = mkFlow fid "Unknown" "air" Nothing
+                byCAS = M.singleton "0-00-0" [flow]
+            fmap bfId (findFlowByCAS byCAS "000-00-0" Nothing) `shouldBe` Nothing
+
     describe "findFlowByName" $ do
         it "finds a flow by name (case-insensitive via normalization)" $ do
             fid <- nextRandom

--- a/test/MethodPatchSpec.hs
+++ b/test/MethodPatchSpec.hs
@@ -90,6 +90,18 @@ spec = do
                 sel = emptyMatch{mpmCAS = Just "007440-61-1"}
             cfMatches sel "any" cfWithCas `shouldBe` True
 
+        -- The other direction: a parser that stores the source spelling as it
+        -- came still has to meet a selector written canonically.
+        it "matches a padded CF CAS against a canonical selector" $ do
+            let cfWithCas = cf{mcfCAS = Just "007440-61-1"}
+                sel = emptyMatch{mpmCAS = Just "7440-61-1"}
+            cfMatches sel "any" cfWithCas `shouldBe` True
+
+        it "never matches an all-zeros placeholder selector" $ do
+            let cfWithCas = cf{mcfCAS = Just "7440-61-1"}
+                sel = emptyMatch{mpmCAS = Just "000-00-0"}
+            cfMatches sel "any" cfWithCas `shouldBe` False
+
     describe "applyMethodPatches" $ do
         let uranium = mkCF "Uranium" 560000
             uraniumOre = mkCF "Uranium ore, 1.11 GJ per kg" 1110

--- a/test/MethodSpec.hs
+++ b/test/MethodSpec.hs
@@ -1018,8 +1018,14 @@ spec = do
             case parseSimaProMethodCSVBytes csv of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
                 Right coll -> do
-                    let nh3 = head (methodFactors (mcMethods coll !! 1))
-                    mcfCAS nh3 `shouldBe` Just "7664-41-7"
+                    let factors = methodFactors (mcMethods coll !! 1)
+                    mcfCAS (head factors) `shouldBe` Just "7664-41-7"
+                    -- Only the registry number is zero-padded. Stripping the
+                    -- fixed-width group segment too would key this substance as
+                    -- "7446-9-5", which no flow carries, and the CAS rung would
+                    -- never bridge it.
+                    [mcfCAS cf | cf <- factors, mcfFlowName cf == "Sulfur dioxide"]
+                        `shouldBe` [Just "7446-09-5"]
 
         it "produces deterministic UUIDs" $ do
             csv <- BS.readFile "test/data/simapro_method.csv"

--- a/test/RegistryLintSpec.hs
+++ b/test/RegistryLintSpec.hs
@@ -24,7 +24,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Test.Hspec
 
-import EcoSpold.Parser2 (normalizeCAS)
+import SubstanceRegistry (normalizeCAS)
 import SynonymDB (
     BridgeDirection (..),
     RegistryRow (..),

--- a/test/SubstanceRegistrySpec.hs
+++ b/test/SubstanceRegistrySpec.hs
@@ -94,7 +94,7 @@ spec = do
             normCas "  not-valid  " `shouldBe` "not-valid"
 
         it "agrees on a CAS however it was padded, so the bridge meets" $
-            normCas "0000050-00-0" `shouldBe` normCas "50-00-0"
+            normCas "0000050-00-0" `shouldBe` "50-00-0"
 
     describe "nonEmptyCAS" $ do
         it "canonicalizes a stated CAS" $
@@ -113,7 +113,7 @@ spec = do
         -- every flow carried "50-00-0", so the CAS rung compared two spellings
         -- of the same substance and never bridged.
         it "keeps the group segment padded, so a method CAS meets a flow CAS" $
-            nonEmptyCas "50-00-0" `shouldBe` Just (normCas "50-00-0")
+            nonEmptyCas "50-00-0" `shouldBe` Just "50-00-0"
 
     describe "equivalenceClasses" $ do
         it "takes the transitive closure of chained pairs (A=B, B=C ⟹ {A,B,C})" $

--- a/test/SubstanceRegistrySpec.hs
+++ b/test/SubstanceRegistrySpec.hs
@@ -23,6 +23,8 @@ import SubstanceRegistry (
     casBindingsFromEdges,
     classesFromEdges,
     equivalenceClasses,
+    nonEmptyCAS,
+    normalizeCAS,
     parseSubstanceEdges,
  )
 
@@ -49,15 +51,8 @@ byName1 n c = M.singleton (NormName (T.pack n)) (CASNumber (T.pack c))
 testNorm :: T.Text -> NormName
 testNorm = NormName . T.toLower . T.strip
 
--- Mirrors EcoSpold.Parser2.normalizeCAS: strip leading zeros from the first
--- segment only. Injected so the parser tests exercise CAS canonicalization
--- without pulling in the parser module.
 testCas :: T.Text -> CASNumber
-testCas c = CASNumber $ case T.splitOn dash (T.strip c) of
-    [a, b, d] -> let a' = T.dropWhile (== '0') a in (if T.null a' then T.pack "0" else a') <> dash <> b <> dash <> d
-    _ -> T.strip c
-  where
-    dash = T.pack "-"
+testCas = CASNumber . normalizeCAS
 
 testNorms :: KeyNormalizers
 testNorms = KeyNormalizers testNorm testCas
@@ -67,8 +62,59 @@ edgesCsv :: String -> BLC.ByteString
 edgesCsv body =
     BLC.pack ("from_keytype,from_source,from_key,to_keytype,to_source,to_key,relation,scale\n" <> body)
 
+-- CAS canonicalization asserted on String, so these read without OverloadedStrings.
+normCas :: String -> String
+normCas = T.unpack . normalizeCAS . T.pack
+
+nonEmptyCas :: String -> Maybe String
+nonEmptyCas = fmap T.unpack . nonEmptyCAS . T.pack
+
 spec :: Spec
 spec = do
+    describe "normalizeCAS" $ do
+        it "strips the zero-padding ecoinvent writes on the registry number" $
+            normCas "001309-36-0" `shouldBe` "1309-36-0"
+
+        it "leaves a canonical CAS alone" $
+            normCas "7732-18-5" `shouldBe` "7732-18-5"
+
+        it "strips a single leading zero from the registry number" $
+            normCas "0074-98-6" `shouldBe` "74-98-6"
+
+        it "keeps the fixed-width group segment padded (formaldehyde is 50-00-0)" $
+            normCas "50-00-0" `shouldBe` "50-00-0"
+
+        it "keeps a zero check digit" $
+            normCas "1309-36-0" `shouldBe` "1309-36-0"
+
+        it "keeps one zero when the registry number is all zeros" $
+            normCas "000-00-0" `shouldBe` "0-00-0"
+
+        it "passes a non-CAS string through stripped rather than mangling it" $
+            normCas "  not-valid  " `shouldBe` "not-valid"
+
+        it "agrees on a CAS however it was padded, so the bridge meets" $
+            normCas "0000050-00-0" `shouldBe` normCas "50-00-0"
+
+    describe "nonEmptyCAS" $ do
+        it "canonicalizes a stated CAS" $
+            nonEmptyCas "001309-36-0" `shouldBe` Just "1309-36-0"
+
+        it "reads an empty field as no CAS" $
+            nonEmptyCas "" `shouldBe` Nothing
+
+        it "reads an all-zeros placeholder as no CAS" $
+            nonEmptyCas "000-00-0" `shouldBe` Nothing
+
+        it "reads a bare dash placeholder as no CAS" $
+            nonEmptyCas "-" `shouldBe` Nothing
+
+        -- A SimaPro-format method used to key formaldehyde as "50-0-0" while
+        -- every flow carried "50-00-0", so the CAS rung compared two spellings
+        -- of the same substance and never bridged.
+        it "keeps the group segment padded, so a method CAS meets a flow CAS" $
+            nonEmptyCas "50-00-0" `shouldBe` Just (normCas "50-00-0")
+
     describe "equivalenceClasses" $ do
         it "takes the transitive closure of chained pairs (A=B, B=C ⟹ {A,B,C})" $
             classesOf [("a", "b"), ("b", "c")]


### PR DESCRIPTION
## Why

`normalizeCAS` existed twice, with different answers for the same input.

A CAS registry number is `registry-group-check`: a registry number of two to seven digits, a fixed two-digit group, and a single check digit. Only the registry number is ever zero-padded — ecoinvent writes `001309-36-0` where the canonical form is `1309-36-0`.

- `EcoSpold/Parser2.hs:30` stripped leading zeros from the first segment only. Correct.
- `Method/ParserSimaPro.hs:405` stripped them from *every* segment. `50-00-0` (formaldehyde) became `50-0-0`.

Which spelling a value carried depended purely on which parser had read it. Flows loaded from EcoSpold carried `50-00-0`; characterization factors parsed from a SimaPro-format method carried `50-0-0`. The CAS rung of the read cascade compares the stored strings, so the two never met: the factor was silently absent rather than reported missing.

Every CAS whose group segment begins with a zero was affected — that is every substance in groups `00`–`09`.

## What changed

The canonicalizer moved to `SubstanceRegistry`, beside `CASNumber`. That module's `KeyNormalizers` documentation already named it as the function that makes an edge's CAS and a method's meet, while pointing at a format parser to supply it.

Callers previously imported `EcoSpold.Parser2` to reach a domain function; the registry's own tests carried a fourth hand-written copy specifically to avoid that import. Both are gone.

`nonEmptyCAS` serves the two call sites that need "this field states no CAS" (empty string, or an all-zeros placeholder) told apart from a real value — `Method.ParserSimaPro` when reading the CAS column, and `Method.Patch` when matching a selector.

`Method.FlowResolver` gains an explicit `import Types ()`. It was reaching the orphan `Store UUID` instance transitively through `EcoSpold.Parser2`, and that import is gone.

## Tests

The canonicalization tests moved from `FlowResolverSpec` to `SubstanceRegistrySpec`, where the function now lives, and gained the cases that name the defect:

- `normalizeCAS "50-00-0"` is `"50-00-0"` — the group segment keeps its padding
- `nonEmptyCAS "50-00-0"` agrees with `normalizeCAS "50-00-0"` — the method side and the flow side spell it identically

Full suite: 2250 examples, 0 failures.