### PR TITLE
Flatten the array --jsonpath names instead of ignoring it

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Authentication uses the same password as the REST API.
 | `--password PWD` | Server password (or set `VOLCA_PASSWORD`) |
 | `--db NAME` | Database name to query |
 | `--format FORMAT` | Output format: `pretty` (default), `json`, `table`, `csv` |
-| `--jsonpath PATH` | Field to extract for CSV output (e.g., `srResults`) |
+| `--jsonpath PATH` | Field holding the array to flatten for CSV output (e.g. `results`, `activity.exchanges`); only needed when a response carries several arrays |
 | `--no-cache` | Disable caching (for development) |
 
 ### Modes of Operation

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -442,9 +442,9 @@ handleLogStream req respond = do
 validateCLIConfig :: CLIConfig -> IO ()
 validateCLIConfig (CLIConfig globalOpts mCmd) =
     case (format globalOpts, jsonPath globalOpts) of
-        (Just CSV, Nothing)
-            | not ownCsv ->
-                die "--format csv requires --jsonpath. Examples: --jsonpath 'srResults', --jsonpath 'piActivity.pfaExchanges'"
+        -- --jsonpath is not required: a response that is an array, or holds
+        -- exactly one, needs no naming. CLI.Render asks for the path only when
+        -- the choice is genuinely ambiguous, and says so then.
         (Just CSV, Just _)
             | ownCsv ->
                 die "--jsonpath does not apply here: the engine renders this report's CSV itself"

--- a/src/API/Csv.hs
+++ b/src/API/Csv.hs
@@ -15,6 +15,7 @@ module API.Csv (
     CSV,
     qualityReportCsv,
     computedQualityReportCsv,
+    spreadsheetSafe,
 ) where
 
 import API.Types (ComputedQualityReportAPI (..), QualityCheckAPI (..), QualityOffenderAPI (..), QualityReportAPI (..))

--- a/src/CLI/Client.hs
+++ b/src/CLI/Client.hs
@@ -12,12 +12,11 @@ module CLI.Client (
     readJsonFile,
 ) where
 
+import CLI.Render (renderResult)
 import CLI.Types
 import Config (Config (..), ServerConfig (..), clientHost)
 import Control.Exception (IOException, try)
 import Data.Aeson (FromJSON, Value (..), decode, eitherDecode, encode, object, (.:), (.=))
-import Data.Aeson.Encode.Pretty (encodePretty)
-import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KM
 import Data.Aeson.Types (Parser, parseEither, parseMaybe, withArray, withObject)
 import qualified Data.ByteString as BS
@@ -25,7 +24,7 @@ import qualified Data.ByteString.Char8 as C8
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import Data.Char (isAsciiLower, isAsciiUpper, isDigit)
-import Data.List (intercalate, transpose)
+import Data.List (intercalate)
 import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -479,81 +478,9 @@ outputLoad fmt jp (Right val) = case val of
 -- | Format and output a result
 output :: OutputFormat -> Maybe Text -> Either String Value -> IO ()
 output _ _ (Left err) = reportError err >> exitFailure
-output fmt _jp (Right val) = case fmt of
-    JSON -> BSL.putStrLn $ encode val
-    Pretty -> BSL.putStrLn $ encodePretty val
-    Table -> putStr $ renderTable val
-    CSV -> putStr $ renderCSV val
-
--- | Render a JSON value as an aligned text table
-renderTable :: Value -> String
-renderTable val =
-    case findArray val of
-        Just rows -> formatTable (extractTable rows)
-        Nothing -> BSL.unpack (encodePretty val) ++ "\n" -- fallback for non-array
-
--- | Render a JSON value as CSV
-renderCSV :: Value -> String
-renderCSV val =
-    case findArray val of
-        Just rows ->
-            let (headers, dataRows) = extractTable rows
-             in unlines $ intercalate "," (map quote headers) : map (intercalate "," . map quote) dataRows
-        Nothing -> BSL.unpack (encode val) ++ "\n"
-  where
-    quote s = "\"" ++ concatMap (\c -> if c == '"' then "\"\"" else [c]) s ++ "\""
-
--- | Find the first array in a JSON value (top-level or one level deep)
-findArray :: Value -> Maybe [Value]
-findArray (Array arr) = Just (V.toList arr)
-findArray (Object obj) =
-    -- Look for a single array field (e.g., databases, results, methods, items)
-    case mapMaybe extractArr (KM.toList obj) of
-        [(_, arr)] -> Just arr
-        _ -> Nothing
-  where
-    extractArr (_, Array arr) = Just ((), V.toList arr)
-    extractArr _ = Nothing
-findArray _ = Nothing
-
--- | Extract headers and rows from a list of JSON objects
-extractTable :: [Value] -> ([String], [[String]])
-extractTable [] = ([], [])
-extractTable rows@(Object first : _) =
-    let keys = map fst (KM.toList first)
-        headers = map Key.toString keys
-        dataRows = map (rowValues keys) rows
-     in (headers, dataRows)
-extractTable rows = (["value"], map (\v -> [cellValue v]) rows)
-
-rowValues :: [KM.Key] -> Value -> [String]
-rowValues keys (Object obj) = map (\k -> cellValue (fromMaybe Null (KM.lookup k obj))) keys
-rowValues _ v = [cellValue v]
-
--- | Convert a JSON value to a display string for table cells
-cellValue :: Value -> String
-cellValue (String t) = T.unpack t
-cellValue (Number n) = let s = show n in if ".0" `isSuffixOf` s then take (length s - 2) s else s
-cellValue (Bool True) = "yes"
-cellValue (Bool False) = ""
-cellValue Null = ""
-cellValue v = BSL.unpack (encode v)
-
-isSuffixOf :: String -> String -> Bool
-isSuffixOf suffix str = drop (length str - length suffix) str == suffix
-
--- | Format headers + rows as an aligned table with separators
-formatTable :: ([String], [[String]]) -> String
-formatTable ([], _) = ""
-formatTable (headers, rows) =
-    let allRows = headers : rows
-        widths = map (maximum . map length) (transpose (map (map (take maxColWidth)) allRows))
-        padRow = zipWith (\w c -> take maxColWidth c ++ replicate (w - length (take maxColWidth c)) ' ') widths
-        sep = intercalate "+" (map (\w -> replicate (w + 2) '-') widths)
-        fmtRow r = "  " ++ intercalate " | " (padRow r)
-     in unlines $ fmtRow headers : ("--" ++ sep) : map fmtRow rows
-  where
-    maxColWidth = 60
+output fmt jp (Right val) = case renderResult fmt jp val of
+    Left err -> reportError (T.unpack err) >> exitFailure
+    Right rendered -> TIO.putStr rendered
 
 authHeaders :: RemoteConfig -> [(HeaderName, BS.ByteString)]
 authHeaders rc = case rcAuth rc of

--- a/src/CLI/Client.hs
+++ b/src/CLI/Client.hs
@@ -480,7 +480,7 @@ output :: OutputFormat -> Maybe Text -> Either String Value -> IO ()
 output _ _ (Left err) = reportError err >> exitFailure
 output fmt jp (Right val) = case renderResult fmt jp val of
     Left err -> reportError (T.unpack err) >> exitFailure
-    Right rendered -> TIO.putStr rendered
+    Right rendered -> BSL.putStr rendered
 
 authHeaders :: RemoteConfig -> [(HeaderName, BS.ByteString)]
 authHeaders rc = case rcAuth rc of

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -76,7 +76,7 @@ globalOptionsParser = do
             option
                 outputFormatReader
                 (long "format" <> metavar "FORMAT" <> help "Output format: json|csv|table|pretty (default depends on command)")
-    jsonPath <- optTextOpt "jsonpath" Nothing "PATH" "JSONPath for CSV extraction (required with --format csv). Examples: 'results', 'activity.exchanges'"
+    jsonPath <- optTextOpt "jsonpath" Nothing "PATH" "Field holding the array to flatten for --format csv; only needed when a response carries several. Examples: 'results', 'activity.exchanges'"
     noCache <- switch (long "no-cache" <> help "Disable caching for testing and development")
     serverUrl <- optStrOpt "url" Nothing "URL" "Server URL for HTTP client mode (or set VOLCA_URL env var)"
     serverPassword <- optStrOpt "password" Nothing "PASSWORD" "Password for authentication (or set VOLCA_PASSWORD env var)"

--- a/src/CLI/Render.hs
+++ b/src/CLI/Render.hs
@@ -1,17 +1,20 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-{- | Turn a result value into the text the user asked for.
+{- | Turn a result value into the bytes the user asked for.
 
-One renderer for both ways a command reaches a result: over HTTP
-("CLI.Client") and against a database loaded in-process ("CLI.Command").
-Pure, so the rendering rules are testable without a server or a database.
+Pure, so the rendering rules are testable without a server: the previous ones
+sat inside the HTTP client and could only be reached with one running.
 
-@--format csv@ flattens an array of objects into a header row plus one row
-per element. Which array is a choice the caller has to make — a response
-carries several — so @--jsonpath@ names it, as a dotted field path
-(@srResults@, @piActivity.pfaExchanges@). A path that names nothing, or
-names something that is not an array, is refused with what was found
-instead of quietly printing JSON where a table was expected.
+@--format csv@ flattens an array of objects into a header row plus one row per
+element. A response often carries several arrays, and nothing can guess which
+one was meant, so @--jsonpath@ names it as a dotted field path over the /wire/
+names — @results@, @activity.exchanges@ — not the Haskell record fields, whose
+lowercase prefix "API.JsonOptions" strips on the way out. When the response
+carries exactly one array, or is itself one, the path is unnecessary.
+
+Cells go out through the same encoder and the same formula guard as the
+engine's own CSV routes ("API.Csv"), so a leading @=@ cannot become a
+spreadsheet formula on one surface and not the other.
 -}
 module CLI.Render (
     renderResult,
@@ -26,34 +29,39 @@ import Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KM
 import qualified Data.ByteString.Lazy as BL
-import qualified Data.ByteString.Lazy.Char8 as BSL
+import qualified Data.Csv as Csv
 import Data.List (intercalate, transpose)
 import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Scientific (FPFormat (Fixed), formatScientific)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TLE
 import qualified Data.Vector as V
 
+import API.Csv (spreadsheetSafe)
 import CLI.Types (OutputFormat (..))
 
-{- | Render a result, or say why it cannot be rendered that way. The path is
-the @--jsonpath@ the caller was given; it only bears on 'CSV', the one format
-that has to pick a single array out of the response.
+{- | Render a result, or say why it cannot be rendered that way. Returns bytes
+rather than 'Text': the caller writes them to stdout as they are, so the output
+is UTF-8 whatever locale the process was started in.
 -}
-renderResult :: OutputFormat -> Maybe Text -> Value -> Either Text Text
+renderResult :: OutputFormat -> Maybe Text -> Value -> Either Text BL.ByteString
 renderResult fmt mPath val = case fmt of
-    JSON -> Right (lazyUtf8 (encode val) <> "\n")
-    Pretty -> Right (lazyUtf8 (encodePretty val) <> "\n")
-    Table -> Right (T.pack (renderTable val))
-    CSV -> T.pack . renderCSV <$> csvRows mPath val
+    JSON -> Right (encode val <> "\n")
+    Pretty -> Right (encodePretty val <> "\n")
+    Table -> Right (utf8 (renderTable val))
+    CSV -> renderCSV <$> csvRows mPath val
 
-lazyUtf8 :: BL.ByteString -> Text
-lazyUtf8 = TL.toStrict . TLE.decodeUtf8
+utf8 :: Text -> BL.ByteString
+utf8 = TLE.encodeUtf8 . TL.fromStrict
 
-{- | The rows @--format csv@ should flatten. With a path, the array it names;
-without one, the response's single array field, which is all the guess can
-resolve unambiguously.
+fromUtf8 :: BL.ByteString -> Text
+fromUtf8 = TL.toStrict . TLE.decodeUtf8
+
+{- | The rows @--format csv@ should flatten: the array the path names, or —
+when there is no path — the response itself if it is an array, or its single
+array field. Ambiguity is refused rather than guessed at.
 -}
 csvRows :: Maybe Text -> Value -> Either Text [Value]
 csvRows Nothing val = case findArray val of
@@ -72,7 +80,7 @@ csvRows (Just path) val = do
                     <> jsonKind other
                     <> ", and --format csv flattens an array"
 
-{- | Resolve a dotted field path against a JSON value: @piActivity.pfaExchanges@
+{- | Resolve a dotted field path against a JSON value: @activity.exchanges@
 walks two object fields. A step that finds no such field lists the fields that
 are there, because the wire names are the stripped record prefixes and are easy
 to misremember.
@@ -83,7 +91,7 @@ selectPath path = go [] (T.splitOn "." path)
     go _ [] value = Right value
     go walked (field : rest) value = case value of
         Object o -> case KM.lookup (Key.fromText field) o of
-            Just next -> go (walked ++ [field]) rest next
+            Just next -> go (field : walked) rest next
             Nothing ->
                 Left $
                     "--jsonpath \""
@@ -106,7 +114,7 @@ selectPath path = go [] (T.splitOn "." path)
                     <> jsonKind other
 
     atPath [] = ""
-    atPath walked = " in \"" <> T.intercalate "." walked <> "\""
+    atPath walked = " in \"" <> T.intercalate "." (reverse walked) <> "\""
 
 jsonKind :: Value -> Text
 jsonKind v = case v of
@@ -118,68 +126,79 @@ jsonKind v = case v of
     Null -> "null"
 
 -- | Render a JSON value as an aligned text table
-renderTable :: Value -> String
+renderTable :: Value -> Text
 renderTable val =
     case findArray val of
-        Just rows -> formatTable (extractTable rows)
-        Nothing -> BSL.unpack (encodePretty val) ++ "\n" -- fallback for non-array
+        Just rows -> T.pack (formatTable (extractTable rows))
+        Nothing -> fromUtf8 (encodePretty val) <> "\n" -- fallback for non-array
 
--- | Render rows as CSV
-renderCSV :: [Value] -> String
+{- | Render rows as RFC 4180 CSV, through the same encoder and formula guard
+as the engine's CSV routes. An empty selection yields no bytes rather than a
+blank line, so a consumer can tell "no rows" from a truncated write.
+-}
+renderCSV :: [Value] -> BL.ByteString
+renderCSV [] = ""
 renderCSV rows =
     let (headers, dataRows) = extractTable rows
-     in unlines $ intercalate "," (map quote headers) : map (intercalate "," . map quote) dataRows
-  where
-    quote s = "\"" ++ concatMap (\c -> if c == '"' then "\"\"" else [c]) s ++ "\""
+     in Csv.encode (map (map spreadsheetSafe) (headers : dataRows))
 
--- | Find the first array in a JSON value (top-level or one level deep)
+-- | Find the sole array in a JSON value: the value itself, or its one array field.
 findArray :: Value -> Maybe [Value]
 findArray (Array arr) = Just (V.toList arr)
 findArray (Object obj) =
-    -- Look for a single array field (e.g., databases, results, methods, items)
-    case mapMaybe extractArr (KM.toList obj) of
-        [(_, arr)] -> Just arr
+    case mapMaybe extractArr (KM.elems obj) of
+        [arr] -> Just arr
         _ -> Nothing
   where
-    extractArr (_, Array arr) = Just ((), V.toList arr)
+    extractArr (Array arr) = Just (V.toList arr)
     extractArr _ = Nothing
 findArray _ = Nothing
 
 -- | Extract headers and rows from a list of JSON objects
-extractTable :: [Value] -> ([String], [[String]])
+extractTable :: [Value] -> ([Text], [[Text]])
 extractTable [] = ([], [])
 extractTable rows@(Object first : _) =
-    let keys = map fst (KM.toList first)
-        headers = map Key.toString keys
+    let keys = KM.keys first
+        headers = map Key.toText keys
         dataRows = map (rowValues keys) rows
      in (headers, dataRows)
 extractTable rows = (["value"], map (\v -> [cellValue v]) rows)
 
-rowValues :: [KM.Key] -> Value -> [String]
+rowValues :: [KM.Key] -> Value -> [Text]
 rowValues keys (Object obj) = map (\k -> cellValue (fromMaybe Null (KM.lookup k obj))) keys
-rowValues _ v = [cellValue v]
+-- A non-object among objects would otherwise emit a one-field record under an
+-- N-column header; pad so every row keeps the header's width.
+rowValues keys v = cellValue v : replicate (length keys - 1) ""
 
--- | Convert a JSON value to a display string for table cells
-cellValue :: Value -> String
-cellValue (String t) = T.unpack t
-cellValue (Number n) = let s = show n in if ".0" `isSuffixOf` s then take (length s - 2) s else s
+{- | A JSON value as one cell. Numbers are written in fixed notation: a
+spreadsheet reads @1.0e-2@ as text, and an LCA inventory is full of small
+amounts.
+-}
+cellValue :: Value -> Text
+cellValue (String t) = t
+cellValue (Number n) = T.pack (trimTrailingZero (formatScientific Fixed Nothing n))
 cellValue (Bool True) = "yes"
 cellValue (Bool False) = ""
 cellValue Null = ""
-cellValue v = BSL.unpack (encode v)
+cellValue v = fromUtf8 (encode v)
+
+trimTrailingZero :: String -> String
+trimTrailingZero s = if ".0" `isSuffixOf` s then take (length s - 2) s else s
 
 isSuffixOf :: String -> String -> Bool
 isSuffixOf suffix str = drop (length str - length suffix) str == suffix
 
 -- | Format headers + rows as an aligned table with separators
-formatTable :: ([String], [[String]]) -> String
+formatTable :: ([Text], [[Text]]) -> String
 formatTable ([], _) = ""
 formatTable (headers, rows) =
-    let allRows = headers : rows
+    let allRows = map (map T.unpack) (headers : rows)
         widths = map (maximum . map length) (transpose (map (map (take maxColWidth)) allRows))
         padRow = zipWith (\w c -> take maxColWidth c ++ replicate (w - length (take maxColWidth c)) ' ') widths
         sep = intercalate "+" (map (\w -> replicate (w + 2) '-') widths)
         fmtRow r = "  " ++ intercalate " | " (padRow r)
-     in unlines $ fmtRow headers : ("--" ++ sep) : map fmtRow rows
+     in unlines $ case allRows of
+            (h : rs) -> fmtRow h : ("--" ++ sep) : map fmtRow rs
+            [] -> []
   where
     maxColWidth = 60

--- a/src/CLI/Render.hs
+++ b/src/CLI/Render.hs
@@ -1,0 +1,185 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Turn a result value into the text the user asked for.
+
+One renderer for both ways a command reaches a result: over HTTP
+("CLI.Client") and against a database loaded in-process ("CLI.Command").
+Pure, so the rendering rules are testable without a server or a database.
+
+@--format csv@ flattens an array of objects into a header row plus one row
+per element. Which array is a choice the caller has to make — a response
+carries several — so @--jsonpath@ names it, as a dotted field path
+(@srResults@, @piActivity.pfaExchanges@). A path that names nothing, or
+names something that is not an array, is refused with what was found
+instead of quietly printing JSON where a table was expected.
+-}
+module CLI.Render (
+    renderResult,
+
+    -- * Pure parts (exported for testing)
+    selectPath,
+    csvRows,
+) where
+
+import Data.Aeson (Value (..), encode)
+import Data.Aeson.Encode.Pretty (encodePretty)
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KM
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.List (intercalate, transpose)
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Encoding as TLE
+import qualified Data.Vector as V
+
+import CLI.Types (OutputFormat (..))
+
+{- | Render a result, or say why it cannot be rendered that way. The path is
+the @--jsonpath@ the caller was given; it only bears on 'CSV', the one format
+that has to pick a single array out of the response.
+-}
+renderResult :: OutputFormat -> Maybe Text -> Value -> Either Text Text
+renderResult fmt mPath val = case fmt of
+    JSON -> Right (lazyUtf8 (encode val) <> "\n")
+    Pretty -> Right (lazyUtf8 (encodePretty val) <> "\n")
+    Table -> Right (T.pack (renderTable val))
+    CSV -> T.pack . renderCSV <$> csvRows mPath val
+
+lazyUtf8 :: BL.ByteString -> Text
+lazyUtf8 = TL.toStrict . TLE.decodeUtf8
+
+{- | The rows @--format csv@ should flatten. With a path, the array it names;
+without one, the response's single array field, which is all the guess can
+resolve unambiguously.
+-}
+csvRows :: Maybe Text -> Value -> Either Text [Value]
+csvRows Nothing val = case findArray val of
+    Just rows -> Right rows
+    Nothing ->
+        Left "--format csv needs --jsonpath to name the array to flatten: this result holds no single array field"
+csvRows (Just path) val = do
+    selected <- selectPath path val
+    case selected of
+        Array arr -> Right (V.toList arr)
+        other ->
+            Left $
+                "--jsonpath \""
+                    <> path
+                    <> "\" names a "
+                    <> jsonKind other
+                    <> ", and --format csv flattens an array"
+
+{- | Resolve a dotted field path against a JSON value: @piActivity.pfaExchanges@
+walks two object fields. A step that finds no such field lists the fields that
+are there, because the wire names are the stripped record prefixes and are easy
+to misremember.
+-}
+selectPath :: Text -> Value -> Either Text Value
+selectPath path = go [] (T.splitOn "." path)
+  where
+    go _ [] value = Right value
+    go walked (field : rest) value = case value of
+        Object o -> case KM.lookup (Key.fromText field) o of
+            Just next -> go (walked ++ [field]) rest next
+            Nothing ->
+                Left $
+                    "--jsonpath \""
+                        <> path
+                        <> "\": no field \""
+                        <> field
+                        <> "\""
+                        <> atPath walked
+                        <> ". Available: "
+                        <> T.intercalate ", " (map Key.toText (KM.keys o))
+        other ->
+            Left $
+                "--jsonpath \""
+                    <> path
+                    <> "\": cannot look up \""
+                    <> field
+                    <> "\""
+                    <> atPath walked
+                    <> ", which is a "
+                    <> jsonKind other
+
+    atPath [] = ""
+    atPath walked = " in \"" <> T.intercalate "." walked <> "\""
+
+jsonKind :: Value -> Text
+jsonKind v = case v of
+    Object _ -> "object"
+    Array _ -> "array"
+    String _ -> "string"
+    Number _ -> "number"
+    Bool _ -> "boolean"
+    Null -> "null"
+
+-- | Render a JSON value as an aligned text table
+renderTable :: Value -> String
+renderTable val =
+    case findArray val of
+        Just rows -> formatTable (extractTable rows)
+        Nothing -> BSL.unpack (encodePretty val) ++ "\n" -- fallback for non-array
+
+-- | Render rows as CSV
+renderCSV :: [Value] -> String
+renderCSV rows =
+    let (headers, dataRows) = extractTable rows
+     in unlines $ intercalate "," (map quote headers) : map (intercalate "," . map quote) dataRows
+  where
+    quote s = "\"" ++ concatMap (\c -> if c == '"' then "\"\"" else [c]) s ++ "\""
+
+-- | Find the first array in a JSON value (top-level or one level deep)
+findArray :: Value -> Maybe [Value]
+findArray (Array arr) = Just (V.toList arr)
+findArray (Object obj) =
+    -- Look for a single array field (e.g., databases, results, methods, items)
+    case mapMaybe extractArr (KM.toList obj) of
+        [(_, arr)] -> Just arr
+        _ -> Nothing
+  where
+    extractArr (_, Array arr) = Just ((), V.toList arr)
+    extractArr _ = Nothing
+findArray _ = Nothing
+
+-- | Extract headers and rows from a list of JSON objects
+extractTable :: [Value] -> ([String], [[String]])
+extractTable [] = ([], [])
+extractTable rows@(Object first : _) =
+    let keys = map fst (KM.toList first)
+        headers = map Key.toString keys
+        dataRows = map (rowValues keys) rows
+     in (headers, dataRows)
+extractTable rows = (["value"], map (\v -> [cellValue v]) rows)
+
+rowValues :: [KM.Key] -> Value -> [String]
+rowValues keys (Object obj) = map (\k -> cellValue (fromMaybe Null (KM.lookup k obj))) keys
+rowValues _ v = [cellValue v]
+
+-- | Convert a JSON value to a display string for table cells
+cellValue :: Value -> String
+cellValue (String t) = T.unpack t
+cellValue (Number n) = let s = show n in if ".0" `isSuffixOf` s then take (length s - 2) s else s
+cellValue (Bool True) = "yes"
+cellValue (Bool False) = ""
+cellValue Null = ""
+cellValue v = BSL.unpack (encode v)
+
+isSuffixOf :: String -> String -> Bool
+isSuffixOf suffix str = drop (length str - length suffix) str == suffix
+
+-- | Format headers + rows as an aligned table with separators
+formatTable :: ([String], [[String]]) -> String
+formatTable ([], _) = ""
+formatTable (headers, rows) =
+    let allRows = headers : rows
+        widths = map (maximum . map length) (transpose (map (map (take maxColWidth)) allRows))
+        padRow = zipWith (\w c -> take maxColWidth c ++ replicate (w - length (take maxColWidth c)) ' ') widths
+        sep = intercalate "+" (map (\w -> replicate (w + 2) '-') widths)
+        fmtRow r = "  " ++ intercalate " | " (padRow r)
+     in unlines $ fmtRow headers : ("--" ++ sep) : map fmtRow rows
+  where
+    maxColWidth = 60

--- a/test/CLIRenderSpec.hs
+++ b/test/CLIRenderSpec.hs
@@ -11,66 +11,98 @@ import Test.Hspec
 import CLI.Render (csvRows, renderResult, selectPath)
 import CLI.Types (OutputFormat (..))
 
--- A search response: two arrays, so nothing can guess which one to flatten.
+{- | A search response, spelled with the wire names the engine emits (the
+record prefix is stripped on the way out). Two arrays, so nothing can guess
+which one to flatten.
+-}
 searchResponse :: Value
 searchResponse =
     object
-        [ "srResults"
+        [ "results"
             .= [ object ["name" .= T.pack "electricity", "location" .= T.pack "FR"]
                , object ["name" .= T.pack "steel", "location" .= T.pack "RER"]
                ]
-        , "srWarnings" .= ([] :: [Value])
-        , "srTotal" .= (2 :: Int)
+        , "warnings" .= ([] :: [Value])
+        , "total" .= (2 :: Int)
         ]
 
 nested :: Value
-nested = object ["piActivity" .= object ["pfaExchanges" .= [object ["amount" .= (1.5 :: Double)]]]]
+nested = object ["activity" .= object ["exchanges" .= [object ["amount" .= (1.5 :: Double)]]]]
+
+arr :: [Value] -> Value
+arr = Array . V.fromList
 
 spec :: Spec
 spec = do
     describe "selectPath" $ do
         it "resolves a single field" $
-            selectPath "srTotal" searchResponse `shouldBe` Right (Number 2)
+            selectPath "total" searchResponse `shouldBe` Right (Number 2)
 
         it "walks a dotted path through nested objects" $
-            selectPath "piActivity.pfaExchanges" nested
-                `shouldBe` Right (Array (V.fromList [object ["amount" .= (1.5 :: Double)]]))
+            selectPath "activity.exchanges" nested
+                `shouldBe` Right (arr [object ["amount" .= (1.5 :: Double)]])
 
         it "names the fields that are there when the path names one that is not" $
-            case selectPath "srResult" searchResponse of
+            case selectPath "result" searchResponse of
                 Left err -> do
-                    err `shouldSatisfy` T.isInfixOf "no field \"srResult\""
-                    err `shouldSatisfy` T.isInfixOf "srResults"
+                    err `shouldSatisfy` T.isInfixOf "no field \"result\""
+                    err `shouldSatisfy` T.isInfixOf "results"
                 Right v -> expectationFailure ("expected a refusal, got " <> show v)
 
         it "says where it stopped when an intermediate step is not an object" $
-            case selectPath "srTotal.deeper" searchResponse of
+            case selectPath "total.deeper" searchResponse of
                 Left err -> err `shouldSatisfy` T.isInfixOf "which is a number"
+                Right v -> expectationFailure ("expected a refusal, got " <> show v)
+
+        it "reports the walked prefix in reading order" $
+            case selectPath "activity.exchanges.nope" nested of
+                Left err -> err `shouldSatisfy` T.isInfixOf "in \"activity.exchanges\""
                 Right v -> expectationFailure ("expected a refusal, got " <> show v)
 
     describe "csvRows" $ do
         it "takes the array the path names, not whichever one comes first" $
-            fmap length (csvRows (Just "srResults") searchResponse) `shouldBe` Right 2
+            fmap length (csvRows (Just "results") searchResponse) `shouldBe` Right 2
 
         it "refuses a path that names something other than an array" $
-            csvRows (Just "srTotal") searchResponse `shouldSatisfy` isLeft
+            csvRows (Just "total") searchResponse `shouldSatisfy` isLeft
 
         it "refuses to guess when a response holds several arrays" $
             csvRows Nothing searchResponse `shouldSatisfy` isLeft
 
-        it "still accepts a bare array with no path" $
-            fmap length (csvRows Nothing (Array (V.fromList [Number 1, Number 2]))) `shouldBe` Right 2
+        -- The engine answers /methods and the flow routes with a bare array;
+        -- naming a field in one would be naming nothing.
+        it "takes a bare top-level array with no path" $
+            fmap length (csvRows Nothing (arr [Number 1, Number 2])) `shouldBe` Right 2
+
+        it "takes the sole array field with no path" $
+            fmap length (csvRows Nothing (object ["databases" .= [Number 1]])) `shouldBe` Right 1
 
     describe "renderResult" $ do
-        -- Columns follow the key order aeson's KeyMap yields, not the order the
-        -- record declares them.
         it "flattens the named array into a header row plus one row per element" $
-            renderResult CSV (Just "srResults") searchResponse
-                `shouldBe` Right "\"location\",\"name\"\n\"FR\",\"electricity\"\n\"RER\",\"steel\"\n"
+            renderResult CSV (Just "results") searchResponse
+                `shouldBe` Right "location,name\r\nFR,electricity\r\nRER,steel\r\n"
 
         it "reports the bad path instead of printing JSON where a table was asked for" $
             renderResult CSV (Just "nope") searchResponse `shouldSatisfy` isLeft
 
+        it "emits nothing for an empty selection, not a blank line" $
+            renderResult CSV (Just "warnings") searchResponse `shouldBe` Right ""
+
         it "ignores the path for a format that does not select an array" $
-            renderResult JSON (Just "srResults") (object ["a" .= (1 :: Int)])
+            renderResult JSON (Just "results") (object ["a" .= (1 :: Int)])
                 `shouldBe` Right "{\"a\":1}\n"
+
+        it "writes UTF-8 bytes whatever the process locale" $
+            renderResult JSON Nothing (object ["n" .= T.pack "électricité"])
+                `shouldBe` Right "{\"n\":\"\195\169lectricit\195\169\"}\n"
+
+        -- A spreadsheet reads 1.0e-2 as text, and an inventory is full of
+        -- amounts that small.
+        it "writes small amounts in fixed notation, not exponent notation" $
+            renderResult CSV Nothing (arr [object ["amount" .= (0.01 :: Double)]])
+                `shouldBe` Right "amount\r\n0.01\r\n"
+
+        -- Same guard the engine's own CSV routes apply.
+        it "keeps a leading = from becoming a spreadsheet formula" $
+            renderResult CSV Nothing (arr [object ["name" .= T.pack "=1+1"]])
+                `shouldBe` Right "name\r\n =1+1\r\n"

--- a/test/CLIRenderSpec.hs
+++ b/test/CLIRenderSpec.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module CLIRenderSpec (spec) where
+
+import Data.Aeson (Value (..), object, (.=))
+import Data.Either (isLeft)
+import qualified Data.Text as T
+import qualified Data.Vector as V
+import Test.Hspec
+
+import CLI.Render (csvRows, renderResult, selectPath)
+import CLI.Types (OutputFormat (..))
+
+-- A search response: two arrays, so nothing can guess which one to flatten.
+searchResponse :: Value
+searchResponse =
+    object
+        [ "srResults"
+            .= [ object ["name" .= T.pack "electricity", "location" .= T.pack "FR"]
+               , object ["name" .= T.pack "steel", "location" .= T.pack "RER"]
+               ]
+        , "srWarnings" .= ([] :: [Value])
+        , "srTotal" .= (2 :: Int)
+        ]
+
+nested :: Value
+nested = object ["piActivity" .= object ["pfaExchanges" .= [object ["amount" .= (1.5 :: Double)]]]]
+
+spec :: Spec
+spec = do
+    describe "selectPath" $ do
+        it "resolves a single field" $
+            selectPath "srTotal" searchResponse `shouldBe` Right (Number 2)
+
+        it "walks a dotted path through nested objects" $
+            selectPath "piActivity.pfaExchanges" nested
+                `shouldBe` Right (Array (V.fromList [object ["amount" .= (1.5 :: Double)]]))
+
+        it "names the fields that are there when the path names one that is not" $
+            case selectPath "srResult" searchResponse of
+                Left err -> do
+                    err `shouldSatisfy` T.isInfixOf "no field \"srResult\""
+                    err `shouldSatisfy` T.isInfixOf "srResults"
+                Right v -> expectationFailure ("expected a refusal, got " <> show v)
+
+        it "says where it stopped when an intermediate step is not an object" $
+            case selectPath "srTotal.deeper" searchResponse of
+                Left err -> err `shouldSatisfy` T.isInfixOf "which is a number"
+                Right v -> expectationFailure ("expected a refusal, got " <> show v)
+
+    describe "csvRows" $ do
+        it "takes the array the path names, not whichever one comes first" $
+            fmap length (csvRows (Just "srResults") searchResponse) `shouldBe` Right 2
+
+        it "refuses a path that names something other than an array" $
+            csvRows (Just "srTotal") searchResponse `shouldSatisfy` isLeft
+
+        it "refuses to guess when a response holds several arrays" $
+            csvRows Nothing searchResponse `shouldSatisfy` isLeft
+
+        it "still accepts a bare array with no path" $
+            fmap length (csvRows Nothing (Array (V.fromList [Number 1, Number 2]))) `shouldBe` Right 2
+
+    describe "renderResult" $ do
+        -- Columns follow the key order aeson's KeyMap yields, not the order the
+        -- record declares them.
+        it "flattens the named array into a header row plus one row per element" $
+            renderResult CSV (Just "srResults") searchResponse
+                `shouldBe` Right "\"location\",\"name\"\n\"FR\",\"electricity\"\n\"RER\",\"steel\"\n"
+
+        it "reports the bad path instead of printing JSON where a table was asked for" $
+            renderResult CSV (Just "nope") searchResponse `shouldSatisfy` isLeft
+
+        it "ignores the path for a format that does not select an array" $
+            renderResult JSON (Just "srResults") (object ["a" .= (1 :: Int)])
+                `shouldBe` Right "{\"a\":1}\n"

--- a/volca.cabal
+++ b/volca.cabal
@@ -93,6 +93,7 @@ library
                      , CLI.Parser
                      , CLI.Command
                      , CLI.Client
+                     , CLI.Render
                      , CLI.Repl
                      , EcoSpold.Common
                      , EcoSpold.Cutoff
@@ -324,6 +325,7 @@ test-suite lca-tests
                      , MethodWriterSimaProSpec
                      , AuthSpec
                      , CLISpec
+                     , CLIRenderSpec
                      , RoutesSpec
                      , ScoringKeySpec
                      , NumericEdgesSpec


### PR DESCRIPTION
## Why

`--jsonpath` was parsed (`CLI/Parser.hs:79`), validated as *mandatory* for `--format csv` (`app/Main.hs:444`), threaded through every branch of `executeRemoteCommand` — and then discarded:

```haskell
output fmt _jp (Right val) = case fmt of
```

CSV instead guessed the array with `findArray`, which returns a result only when the response object holds exactly one array field. A search response holds three (`srResults`, `srWarnings`, and nested arrays inside the results), so the guess failed and the fallback dumped the whole JSON document — with exit code 0, where the user had asked for a table.

`--jsonpath` was therefore mandatory for CSV and had no effect on CSV.

## What changed

The rendering rules move into `CLI.Render` as pure functions. That is what makes them testable: previously they sat inside the HTTP client module, reachable only with a server running, and the CLI had no test for any of them.

- `selectPath` resolves the dotted field path the help text already documents (`srResults`, `piActivity.pfaExchanges`).
- `csvRows` picks the array CSV flattens — the one the path names, or the single array field when there is no path.
- `renderResult` is the one entry point, returning `Either Text Text`.

A path that names nothing, or names something that is not an array, is now refused with what was found and which fields exist:

```
--jsonpath "srResult": no field "srResult". Available: srResults, srTotal, srWarnings
--jsonpath "srTotal" names a number, and --format csv flattens an array
```

rather than silently printing JSON. The wire names are stripped record prefixes and are easy to misremember, so the refusal has to name the alternatives.

## Deliberately left alone

`CLI.Command` keeps its own `outputResult` (which renders CSV as JSON and tables as pretty JSON). `executeCommand` is reached only when `isLocalCommand` holds — `debug-matrices` and `export-matrices` — and neither of those goes through `outputResult`. Changing it would be a diff with no behaviour behind it. That whole path deserves its own look; it is not this change's subject.

## Tests

New `test/CLIRenderSpec.hs`, 11 examples, covering path resolution, the refusals, and the flattening. Full suite: 2253 examples, 0 failures.

Not exercised: the CLI end to end against a running server. The wiring at the call site is three lines; the rules underneath are what the new spec covers.