### PR TITLE
Give a process reference a type instead of a spelling convention

### DIFF
--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -231,10 +231,12 @@ import Types (
     BiosphereFlow (..),
     Database (..),
     GeographyPolicy (..),
+    ProcessRef (..),
     bfCompartmentName,
     bfCompartmentSub,
     blockerReasonDetail,
     getUnitNameForBioFlow,
+    processRefText,
     unresolvedCount,
  )
 
@@ -357,7 +359,7 @@ gapReportToAPI mLimit r =
                 }
     consumerToAPI c =
         GapConsumerAPI
-            { gcaProcessId = UUID.toText (Loader.gcActUUID c) <> "_" <> UUID.toText (Loader.gcProdUUID c)
+            { gcaProcessId = processRefText (ProcessRef (Loader.gcActUUID c) (Loader.gcProdUUID c))
             , gcaActivityName = Loader.gcActivityName c
             , gcaProductName = Loader.gcProductName c
             , gcaLocation = Loader.gcLocation c

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -57,7 +57,7 @@ import qualified Service
 import qualified Service.Aggregate as Agg
 import SharedSolver (SharedSolver, computeInventoryMatrixWithDepsCached, crossDBProcessContributions)
 import qualified SharedSolver
-import Types (Activity (..), BiosphereFlow (..), Database (..), FlowKind (BioKind), Indexes (..), ProcessId, UUID, UnitDB, activityLocation, activityName, bfCompartmentName, bfCompartmentSub, exchangeIsInput, getUnitNameForBioFlow, lookupExchangeFlow, processIdToText, unresolvedCount)
+import Types (Activity (..), BiosphereFlow (..), Database (..), FlowKind (BioKind), Indexes (..), ProcessId, UUID, UnitDB, activityLocation, activityName, bfCompartmentName, bfCompartmentSub, exchangeIsInput, getUnitNameForBioFlow, lookupExchangeFlow, processIdToText, qualifyRef, unresolvedCount)
 import UnitConversion (defaultUnitConfig)
 
 -- ---------------------------------------------------------------------------
@@ -1745,7 +1745,7 @@ mkMcpCrossDBEntry dbManager rootDbName mBaseUrl colName methodIdText unitDB scor
                     txt =
                         if depDbName == rootDbName
                             then processIdToText d pid
-                            else depDbName <> "::" <> processIdToText d pid
+                            else qualifyRef depDbName (processIdToText d pid)
                     -- Reference products are technosphere; pull the supplier's tech flow map.
                     (pn, _, _) = maybe ("", 0, "") (Service.getReferenceProductInfo (dbTechFlows d) unitDB) mAct
                  in (maybe "" activityName mAct, maybe "" activityLocation mAct, pn, txt)

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -343,7 +343,7 @@ mkCrossDBContrib dbManager rootDbName _flowDB unitDB score ((depDbName, pid), c)
                 pidText =
                     if depDbName == rootDbName
                         then processIdToText d pid
-                        else depDbName <> "::" <> processIdToText d pid
+                        else qualifyRef depDbName (processIdToText d pid)
                 -- Reference products are technosphere; pull from the dep DB's tech flows.
                 (prodName, _, _) = maybe ("", 0, "") (Service.getReferenceProductInfo (dbTechFlows d) unitDB) mAct
              in ActivityContribution

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1003,7 +1003,7 @@ computedQualityReportH dbName mCollection mLimit = do
     let simple = toSimpleDatabase db
         entriesByPid =
             M.fromList
-                [ (UUID.toText a <> "_" <> UUID.toText p, act)
+                [ (processRefText (ProcessRef a p), act)
                 | ((a, p), act) <- M.toList (sdbActivities simple)
                 ]
         refProductName act = case filter exchangeIsReference (exchanges act) of
@@ -1425,10 +1425,7 @@ getActivityTree dbName processId = do
     maxTreeDepth <- asks aeMaxTreeDepth
     (db, _) <- requireDatabaseByName dbName
     withValidatedActivity db processId $ \_activity -> do
-        let activityUuidText = case T.splitOn "_" processId of
-                (uuid : _) -> uuid
-                [] -> processId
-        case UUID.fromText activityUuidText of
+        case refActivityUUID processId of
             Nothing -> throwError err400{errBody = "Invalid activity UUID format"}
             Just activityUuid -> do
                 unitCfg <- liftIO $ getMergedUnitConfig dbManager

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -84,6 +84,7 @@ import Types (
     Database (..),
     Exchange (..),
     ProcessId,
+    ProcessRef (..),
     TechRole (..),
     TechnosphereFlow (..),
     UUID,
@@ -94,7 +95,7 @@ import Types (
     exchangeIsReference,
     findProcessIdByActivityUUID,
     getUnitNameForExchange,
-    parseUUIDPair,
+    parseProcessRef,
  )
 import UnitConversion (UnitConfig, convertUnit, normalizeUnit)
 
@@ -561,8 +562,8 @@ import — is still addressable.
 data ProviderKey = ProviderPair UUID UUID | ProviderActivity UUID
 
 parseProvider :: Text -> Maybe ProviderKey
-parseProvider provider = case parseUUIDPair provider of
-    Just (activityId, productId) -> Just (ProviderPair activityId productId)
+parseProvider provider = case parseProcessRef provider of
+    Just ref -> Just (ProviderPair (prActivity ref) (prProduct ref))
     Nothing -> ProviderActivity <$> UUID.fromText provider
 
 matchesProvider :: ProviderKey -> UUID -> UUID -> Bool
@@ -846,8 +847,8 @@ does: the canonical @activityUUID_productUUID@ pair, or a bare activity UUID
 when that activity has a single product.
 -}
 resolveProcess :: Database -> Text -> Maybe ProcessId
-resolveProcess db queryText = case parseUUIDPair queryText of
-    Just (a, p) -> M.lookup (a, p) (dbProcessIdLookup db)
+resolveProcess db queryText = case parseProcessRef queryText of
+    Just ref -> M.lookup (prActivity ref, prProduct ref) (dbProcessIdLookup db)
     Nothing -> UUID.fromText queryText >>= findProcessIdByActivityUUID db
 
 refUnitOf :: Database -> Activity -> (Exchange -> Bool) -> Text

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -603,11 +603,11 @@ resolveOne ctx ex = case ex of
     AuthoredTechInput provider amount mUnit comment ->
         resolveLinked ctx provider amount mUnit $ \sup unitRef ->
             TechnosphereExchange
-                { techFlowId = snd (supKey sup)
+                { techFlowId = prProduct (supKey sup)
                 , techAmount = amount
                 , techUnitId = unitRef
                 , techRole = Input
-                , techActivityLinkId = fst (supKey sup)
+                , techActivityLinkId = prActivity (supKey sup)
                 , techProcessLinkId = Nothing
                 , techLocation = ""
                 , techComment = comment
@@ -616,11 +616,11 @@ resolveOne ctx ex = case ex of
     AuthoredWasteOutput provider amount mUnit comment ->
         resolveLinked ctx provider amount mUnit $ \sup unitRef ->
             WasteExchange
-                { waFlowId = snd (supKey sup)
+                { waFlowId = prProduct (supKey sup)
                 , waAmount = amount
                 , waUnitId = unitRef
                 , waIsInput = False
-                , waActivityLinkId = fst (supKey sup)
+                , waActivityLinkId = prActivity (supKey sup)
                 , waProcessLinkId = Nothing
                 , waLocation = ""
                 , waComment = comment
@@ -812,7 +812,7 @@ an embedded one would silently point at whichever row inherits the number.
 in a dependency resolves the same way through cross-database relinking.
 -}
 data Supplier = Supplier
-    { supKey :: (UUID, UUID)
+    { supKey :: ProcessRef
     , supProducedUnit :: Text
     {- ^ unit of the produced reference output, @""@ for a treatment process
     that has only a reference input. Mirrors
@@ -837,7 +837,7 @@ resolveSupplier ctx provider =
         act <- dbActivities db V.!? fromIntegral pid
         pure
             Supplier
-                { supKey = key
+                { supKey = uncurry ProcessRef key
                 , supProducedUnit = refUnitOf db act (\e -> exchangeIsReference e && not (exchangeIsInput e))
                 , supAnyRefUnit = refUnitOf db act exchangeIsReference
                 }

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -105,7 +105,8 @@ import Types (
     findProcessIdByActivityUUID,
     getActivity,
     initializeRuntimeFields,
-    parseUUIDPair,
+    parseProcessRef,
+    processRefText,
  )
 
 {- | Copy a loaded database into the runtime registry under the slugified
@@ -455,8 +456,8 @@ here too. A target that resolves to nothing is kept as sent: the presence
 check owns that refusal.
 -}
 canonicalTarget :: Database -> Text -> Text
-canonicalTarget db target = case parseUUIDPair target of
-    Just pair -> renderKey pair
+canonicalTarget db target = case parseProcessRef target of
+    Just ref -> processRefText ref
     Nothing -> fromMaybe target $ do
         actUUID <- UUID.fromText target
         pid <- findProcessIdByActivityUUID db actUUID

--- a/src/Database/Quality.hs
+++ b/src/Database/Quality.hs
@@ -48,6 +48,7 @@ import Types (
     Exchange (..),
     FormulaCheck (..),
     LocationSource (..),
+    ProcessRef (..),
     Severity (..),
     SimpleDatabase (..),
     TechRole (..),
@@ -60,6 +61,7 @@ import Types (
     exchangeIsReference,
     exchangePedigree,
     exchangeUnitId,
+    processRefText,
  )
 
 -- | One finding: the activity it was found on, and what is wrong with it.
@@ -243,7 +245,7 @@ qualityReport dbName db =
   where
     entries = M.toList (sdbActivities db)
     acts = map snd entries
-    pidText (actUUID, prodUUID) = UUID.toText actUUID <> "_" <> UUID.toText prodUUID
+    pidText = processRefText . uncurry ProcessRef
     worstFirst = sortOn (\o -> (qoSeverity o, qoActivityName o))
     offender sev key act = QualityOffender sev (pidText key) (activityName act) (activityLocation act)
 

--- a/src/Database/Rebuild.hs
+++ b/src/Database/Rebuild.hs
@@ -59,11 +59,13 @@ import Types (
     Database (..),
     Exchange (..),
     ProcessId,
+    ProcessRef (..),
     TechnosphereFlow (..),
     UUID,
     findProcessId,
     findProcessIdByActivityUUID,
-    parseUUIDPair,
+    parseProcessRef,
+    processRefText,
  )
 import UnitConversion (UnitConfig, defaultUnitConfig)
 
@@ -281,7 +283,7 @@ checkKeys intent existing keys = case intent of
 
 -- | @activityUUID_productUUID@, the identity a process is addressed by.
 renderKey :: (UUID, UUID) -> Text
-renderKey (actUUID, prodUUID) = UUID.toText actUUID <> "_" <> UUID.toText prodUUID
+renderKey = processRefText . uncurry ProcessRef
 
 {- | The identity a 'ProcessId' currently stands for. Out of range is a caller
 error and says so, rather than resolving to whichever row is at that index
@@ -302,6 +304,6 @@ silently dropped.
 -}
 resolveProcess :: Database -> Text -> Either Text ProcessId
 resolveProcess db queryText =
-    maybe (Left ("Unknown process id: " <> queryText)) Right $ case parseUUIDPair queryText of
-        Just (a, p) -> findProcessId db a p
+    maybe (Left ("Unknown process id: " <> queryText)) Right $ case parseProcessRef queryText of
+        Just ref -> findProcessId db (prActivity ref) (prProduct ref)
         Nothing -> UUID.fromText queryText >>= findProcessIdByActivityUUID db

--- a/src/EcoSpold/Writer2.hs
+++ b/src/EcoSpold/Writer2.hs
@@ -215,7 +215,7 @@ checkEcoSpold2Exportable db =
 -- | Canonical filename for an activity: @{actUUID}_{prodUUID}.spold@.
 activityFileName :: UUID.UUID -> UUID.UUID -> FilePath
 activityFileName actUUID prodUUID =
-    T.unpack (UUID.toText actUUID <> "_" <> UUID.toText prodUUID <> ".spold")
+    T.unpack (processRefText (ProcessRef actUUID prodUUID) <> ".spold")
 
 {- | Resolver for the registry-held data the parser writes onto exchanges.
 Passed in so 'renderActivity' stays a pure function of its inputs.

--- a/src/ILCD/Writer.hs
+++ b/src/ILCD/Writer.hs
@@ -130,7 +130,7 @@ ilcdProcessUUID :: S.Set UUID -> (UUID, UUID) -> UUID
 ilcdProcessUUID sharedActUUIDs (actUUID, prodUUID)
     | actUUID `S.member` sharedActUUIDs =
         UUID5.generateNamed ilcdExportNamespace $
-            BS.unpack (TE.encodeUtf8 ("process:" <> uuidText actUUID <> "_" <> uuidText prodUUID))
+            BS.unpack (TE.encodeUtf8 ("process:" <> processRefText (ProcessRef actUUID prodUUID)))
     | otherwise = actUUID
 
 {- | One warning per activity whose products 'ilcdProcessUUID' spreads over

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -161,7 +161,7 @@ resolveActivityAndProcessId db queryText =
     -- A syntactically valid identifier that does not resolve is not-found, not
     -- a format error. Only genuinely malformed input is 'InvalidProcessId'.
     findPid
-        | Just (a, p) <- parseUUIDPair queryText = maybe (Left notFound) Right (findProcessId db a p)
+        | Just ref <- parseProcessRef queryText = maybe (Left notFound) Right (findProcessId db (prActivity ref) (prProduct ref))
         -- Bare activity UUID fallback (EcoInvent compatibility).
         | Just uuid <- UUID.fromText queryText = maybe (Left notFound) Right (findProcessIdByActivityUUID db uuid)
         | otherwise =
@@ -373,7 +373,7 @@ getTreeNodeId db (TreeLoop uuid _ _) =
     -- Use ProcessId format for consistency, maintain UUID_UUID format even in fallback
     case findProcessIdByActivityUUID db uuid of
         Just processId -> processIdToText db processId
-        Nothing -> UUID.toText uuid <> "_" <> UUID.toText uuid -- Fallback maintains ProcessId format
+        Nothing -> processRefText (ProcessRef uuid uuid) -- Fallback maintains ProcessId format
 getTreeNodeId db (TreeNode activity _) =
     case findProcessIdForActivity db activity of
         Just processId -> processIdToText db processId
@@ -579,11 +579,7 @@ convertToTreeExport db _rootProcessId maxDepth tree =
 getActivityTree :: Database -> Text -> Int -> Maybe Text -> Either ServiceError Value
 getActivityTree db queryText maxDepth nameFilter = do
     (_processId, _activity) <- resolveActivityAndProcessId db queryText
-    -- Get the activity UUID from the processIdText (which is activityUUID_productUUID)
-    let activityUuidText = case T.splitOn "_" queryText of
-            (uuid : _) -> uuid
-            [] -> queryText -- Fallback
-    case UUID.fromText activityUuidText of
+    case refActivityUUID queryText of
         Just activityUuid ->
             let loopAwareTree = buildLoopAwareTree defaultUnitConfig db activityUuid maxDepth
                 treeExport = convertToTreeExport db queryText maxDepth loopAwareTree
@@ -591,7 +587,7 @@ getActivityTree db queryText maxDepth nameFilter = do
                     Nothing -> treeExport
                     Just pat -> filterTreeExport pat treeExport
              in Right $ toJSON filtered
-        Nothing -> Left $ InvalidUUID $ "Invalid activity UUID: " <> activityUuidText
+        Nothing -> Left $ InvalidUUID $ "Invalid activity UUID: " <> queryText
 
 {- | Post-filter a TreeExport by name: keep matching nodes plus all their ancestors up to root.
 Uses the enParentId chain already stored in each ExportNode — no extra graph traversal.
@@ -669,7 +665,7 @@ mkGraphEdgeFromTriple db activities units flows nodeIdMap (SparseTriple row col 
         tgt <- M.lookup targetPid nodeIdMap
         let matchingExchange = do
                 srcAct <- activities V.!? fromIntegral row
-                (targetUUID, _) <- processIdToUUIDs db targetPid
+                targetUUID <- prActivity <$> processIdToRef db targetPid
                 L.find (isInputLinkTo targetUUID) (exchanges srcAct)
             flowInfo = matchingExchange >>= \ex -> M.lookup (exchangeFlowId ex) flows
             uName = maybe "<unresolved unit>" (getUnitNameForTechFlow units) flowInfo
@@ -960,9 +956,9 @@ matrix path). Empty when the activity has no entry in the process-id table.
 -}
 crossDBResolvedFlowIds :: Database -> Activity -> S.Set UUID
 crossDBResolvedFlowIds db activity =
-    case findProcessIdForActivity db activity >>= processIdToUUIDs db of
+    case prActivity <$> (findProcessIdForActivity db activity >>= processIdToRef db) of
         Nothing -> S.empty
-        Just (actUUID, _) ->
+        Just actUUID ->
             S.fromList
                 [ cdlConsumerFlowId link
                 | link <- dbCrossDBLinks db
@@ -1048,8 +1044,8 @@ Note: This function requires the ProcessId to get the activity UUID
 -}
 convertActivityForAPI :: UnitConfig -> Database -> ProcessId -> Activity -> ActivityForAPI
 convertActivityForAPI unitCfg db processId activity =
-    let allProducts = case processIdToUUIDs db processId of
-            Just (activityUUID, _) -> getAllProductsForActivity db (activityGroupKey activityUUID activity)
+    let allProducts = case processIdToRef db processId of
+            Just ref -> getAllProductsForActivity db (activityGroupKey (prActivity ref) activity)
             Nothing -> []
         (refProdName, refProdAmount, refProdUnit) = getReferenceProductInfo (dbTechFlows db) (dbUnits db) activity
         linkMap = buildCrossDBLinkMap db processId
@@ -1152,8 +1148,8 @@ UUIDs are unique across flow kinds, so a tech and a waste link on the same
 activity cannot collide here.
 -}
 buildCrossDBLinkMap :: Database -> ProcessId -> M.Map UUID CrossDBLink
-buildCrossDBLinkMap db pid = case processIdToUUIDs db pid of
-    Just (actUUID, _) ->
+buildCrossDBLinkMap db pid = case prActivity <$> processIdToRef db pid of
+    Just actUUID ->
         M.fromList
             [ (cdlConsumerFlowId link, link)
             | link <- dbCrossDBLinks db
@@ -2842,11 +2838,8 @@ exportMatrixDebugData database processIdText opts = do
     case resolveActivityAndProcessId database processIdText of
         Left err -> return $ Left err
         Right (_processId, targetActivity) -> do
-            let activityUuidText = case T.splitOn "_" processIdText of
-                    (uuid : _) -> uuid
-                    [] -> processIdText
-            case UUID.fromText activityUuidText of
-                Nothing -> return $ Left $ InvalidUUID $ "Invalid activity UUID: " <> activityUuidText
+            case refActivityUUID processIdText of
+                Nothing -> return $ Left $ InvalidUUID $ "Invalid activity UUID: " <> processIdText
                 Just activityUuid -> do
                     matrixData <- MatrixExport.extractMatrixDebugInfo database activityUuid (debugFlowFilter opts)
                     let inventoryList = MatrixExport.mdInventoryVector matrixData

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -1084,12 +1084,7 @@ crossDBLinkToTarget link =
     TargetRef
         (cdlFlowName link)
         (cdlLocation link)
-        ( cdlSourceDatabase link
-            <> "::"
-            <> UUID.toText (cdlSupplierActUUID link)
-            <> "_"
-            <> UUID.toText (cdlSupplierProdUUID link)
-        )
+        (supplierRefText link)
 
 -- | EcoSpold path: resolve a target by activity UUID.
 resolveByActivityUUID :: Database -> UUID -> Maybe TargetRef
@@ -1302,12 +1297,7 @@ exchange-details endpoint.
 crossDBLinkToSummary :: CrossDBLink -> ActivitySummary
 crossDBLinkToSummary link =
     ActivitySummary
-        { prsProcessId =
-            cdlSourceDatabase link
-                <> "::"
-                <> UUID.toText (cdlSupplierActUUID link)
-                <> "_"
-                <> UUID.toText (cdlSupplierProdUUID link)
+        { prsProcessId = supplierRefText link
         , prsActivityName = cdlFlowName link
         , prsLocation = cdlLocation link
         , prsProductName = cdlFlowName link
@@ -1597,7 +1587,7 @@ collectSupplyChainEntries db dbName mRootPid supplyVec scf includeEdges qualifyP
              in nameOk && locOk && productOk && classOk && depthOk
 
         qualify pid
-            | qualifyPids = dbName <> "::" <> processIdToText db pid
+            | qualifyPids = qualifyRef dbName (processIdToText db pid)
             | otherwise = processIdToText db pid
 
         mkEntry (pid, scalingFactor) =

--- a/src/Service/Aggregate.hs
+++ b/src/Service/Aggregate.hs
@@ -73,6 +73,8 @@ import Types (
     exchangeIsInput,
     exchangeIsReference,
     processIdToText,
+    qualifyRef,
+    supplierRefText,
  )
 import UnitConversion (UnitConfig)
 
@@ -350,7 +352,7 @@ rowsFromConsumption rootRefAmount ((rootDbName, rootDb, rootScaling) :| deps) =
                 pidText = processIdToText db' (fromIntegral supplierIdx)
              in AggRow
                     { rowName = fromMaybe (activityName supplier) (getReferenceProductName (dbTechFlows db') supplier)
-                    , rowFlowId = if qualifyPids then dbN <> "::" <> pidText else pidText
+                    , rowFlowId = if qualifyPids then qualifyRef dbN pidText else pidText
                     , rowUnit = activityUnit supplier
                     , rowQuantity = v * sj * mult
                     , rowIsInput = Nothing
@@ -376,12 +378,7 @@ rowsFromConsumption rootRefAmount ((rootDbName, rootDb, rootScaling) :| deps) =
                     Just
                         AggRow
                             { rowName = cdlFlowName link
-                            , rowFlowId =
-                                cdlSourceDatabase link
-                                    <> "::"
-                                    <> UUID.toText (cdlSupplierActUUID link)
-                                    <> "_"
-                                    <> UUID.toText (cdlSupplierProdUUID link)
+                            , rowFlowId = supplierRefText link
                             , rowUnit = cdlExchangeUnit link
                             , rowQuantity = cdlCoefficient link * sj / activityNormalizationFactor db' consumerPid * mult
                             , rowIsInput = Nothing

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -59,6 +59,21 @@ Based on EcoSpold filename pattern {activity_uuid}_{product_uuid}.spold
 -}
 type ProcessId = Int32
 
+{- | The (activity, product) pair a process is. 'ProcessId' is the matrix row
+index for that pair inside one database; a 'ProcessRef' is the pair itself,
+which is what travels — over the wire, in a @.spold@ file name, in an ILCD
+process identifier.
+
+Named fields rather than a bare @(UUID, UUID)@ because the two halves are
+indistinguishable to the compiler, and a swapped pair produces a reference
+that is well-formed and wrong.
+-}
+data ProcessRef = ProcessRef
+    { prActivity :: !UUID
+    , prProduct :: !UUID
+    }
+    deriving (Eq, Ord, Show)
+
 {- | Biosphere compartment — the natural medium a biosphere flow exchanges
 with. Present only on `BiosphereFlow`; technosphere flows have no
 compartment (their taxonomy, when meaningful, lives on the producing
@@ -995,32 +1010,51 @@ searchProductsByLocation :: Database -> Text -> [ProcessId]
 searchProductsByLocation db loc =
     M.findWithDefault [] loc (piByLocation $ dbProductIndex db)
 
--- | Convert ProcessId to UUID pair
-processIdToUUIDs :: Database -> ProcessId -> Maybe (UUID, UUID)
-processIdToUUIDs db pid
+-- | The pair a 'ProcessId' indexes, if the index is in range.
+processIdToRef :: Database -> ProcessId -> Maybe ProcessRef
+processIdToRef db pid
     | pid >= 0 && fromIntegral pid < V.length (dbProcessIdTable db) =
-        Just $ dbProcessIdTable db V.! fromIntegral pid
+        Just $ uncurry ProcessRef $ dbProcessIdTable db V.! fromIntegral pid
     | otherwise = Nothing
 
--- | Convert ProcessId to Text representation for display (activityUUID_productUUID)
+{- | The one spelling of a process reference: @activityUUID_productUUID@.
+Everything that writes a reference — the wire, a @.spold@ file name, an ILCD
+process identifier — goes through here, so there is one place the separator
+is decided.
+-}
+processRefText :: ProcessRef -> Text
+processRefText r = UUID.toText (prActivity r) <> refSeparator <> UUID.toText (prProduct r)
+
+-- | The separator between the two halves. Inverse of 'parseProcessRef'.
+refSeparator :: Text
+refSeparator = "_"
+
+-- | Text form of the process a 'ProcessId' indexes, for display.
 processIdToText :: Database -> ProcessId -> Text
 processIdToText db pid =
-    case processIdToUUIDs db pid of
-        Just (actUUID, prodUUID) -> UUID.toText actUUID <> "_" <> UUID.toText prodUUID
-        Nothing -> "invalid-process-id-" <> T.pack (show pid)
+    maybe ("invalid-process-id-" <> T.pack (show pid)) processRefText (processIdToRef db pid)
 
-{- | Pure syntactic parse of a ProcessId reference (activityUUID_productUUID).
-Returns the UUID pair when the text has the expected shape, regardless of
-whether that pair exists in any database. 'Nothing' is a genuine format
-error — callers treat a well-formed-but-absent pair as not-found, not malformed.
+{- | Pure syntactic parse of a process reference. Returns the pair when the
+text has the expected shape, regardless of whether it exists in any database.
+'Nothing' is a genuine format error — callers treat a well-formed-but-absent
+reference as not-found, not malformed.
 -}
-parseUUIDPair :: Text -> Maybe (UUID, UUID)
-parseUUIDPair t = case T.splitOn "_" t of
+parseProcessRef :: Text -> Maybe ProcessRef
+parseProcessRef t = case T.splitOn refSeparator t of
     [actText, prodText]
         | not (T.null actText)
         , not (T.null prodText) ->
-            (,) <$> UUID.fromText actText <*> UUID.fromText prodText
+            ProcessRef <$> UUID.fromText actText <*> UUID.fromText prodText
     _ -> Nothing
+
+{- | The activity a reference names. Accepts a bare activity UUID as well as
+the full @activityUUID_productUUID@ form, because callers that only need the
+activity half are given both by the surfaces above them.
+-}
+refActivityUUID :: Text -> Maybe UUID
+refActivityUUID t = case parseProcessRef t of
+    Just r -> Just (prActivity r)
+    Nothing -> UUID.fromText t
 
 -- | Add SynonymDB to a Database (used after loading from cache)
 addSynonymDBToDatabase :: Database -> SynonymDB -> Database

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1029,6 +1029,24 @@ processRefText r = UUID.toText (prActivity r) <> refSeparator <> UUID.toText (pr
 refSeparator :: Text
 refSeparator = "_"
 
+{- | A process reference qualified by the database that holds it,
+@db::activityUUID_productUUID@ — how a cross-database supplier is named on the
+wire, and what a substitution endpoint accepts back. Its reader is
+@API.Types.parseSubRef@.
+-}
+qualifyRef :: Text -> Text -> Text
+qualifyRef dbName ref = dbName <> "::" <> ref
+
+{- | How a cross-database supplier is named on the wire: the reference to the
+supplying process, qualified by the database that holds it. One renderer, so
+the several payloads carrying a link's identity cannot spell it three ways.
+-}
+supplierRefText :: CrossDBLink -> Text
+supplierRefText link =
+    qualifyRef
+        (cdlSourceDatabase link)
+        (processRefText (ProcessRef (cdlSupplierActUUID link) (cdlSupplierProdUUID link)))
+
 -- | Text form of the process a 'ProcessId' indexes, for display.
 processIdToText :: Database -> ProcessId -> Text
 processIdToText db pid =


### PR DESCRIPTION
## Why

A process — one `(activity, product)` pair — is addressed as `activityUUID_productUUID`. That was a convention rather than a type, and it had drifted into three shapes:

- **Seven places built the text by hand** with `<> "_" <>`: `API/DatabaseHandlers.hs:360`, `Database/Quality.hs:246`, `Database/Rebuild.hs:284`, `API/Routes.hs:1006`, `Service.hs:376`, `EcoSpold/Writer2.hs:218`, `ILCD/Writer.hs:133`. The canonical renderer (`processIdToText`) needs a `Database` to resolve the index, so a caller holding the pair already had nowhere to go.
- **Three places re-implemented "take the activity half"** — `Service.hs:583`, `Service.hs:2845`, `API/Routes.hs:1428` — each with the same nine-line `T.splitOn "_"` block, an unreachable `[]` branch, and a redundant fallback.
- **The pair travelled as a bare `(UUID, UUID)`**, whose halves the compiler cannot tell apart. That is the hazard `RootDb`/`ThisDb` exist to prevent; the docstring at `API/Types.hs:1478` records the bug that followed when two database names were the same bare `Text`. The same lesson had not reached the identifier every search, get and score call carries.

## What changed

`ProcessRef` names the pair with named fields. `processRefText` is the one writer and `parseProcessRef` the one reader, so the separator is decided in one place. `refActivityUUID` replaces the three copies of the head-segment idiom, accepting a bare activity UUID as those did.

`processIdToUUIDs` and `parseUUIDPair` are gone. They returned the tuple this type replaces, and keeping two spellings of one value is what let the seven hand-written renderings drift.

## Deliberately left alone

`Database/Loader.hs:933` and `EcoSpold/Parser2.hs:65` keep their own filename splitting. They accept halves that are not UUIDs — `Loader` mints a deterministic UUID from arbitrary text, which is how test fixtures with names like `productX-uuid` load at all — so `parseProcessRef` would reject input they currently accept. Tightening that is a separate decision about what a `.spold` filename may contain.

The wire type stays `Text` at the API surface. Threading `ProcessRef` through `Service`'s signatures is a much larger change and would make this one unreviewable; this PR gives the value a type and one place to render and read it.

## Tests

No new spec: this is a refactor with no behaviour change, and the existing suite covers all seven rendering sites and all three readers through the endpoints that use them. Full suite: 2242 examples, 0 failures — the same count as `main`.