### PR TITLE
Enumerate a configuration's paths once, not once per rewrite

### DIFF
--- a/src/Config.hs
+++ b/src/Config.hs
@@ -44,6 +44,10 @@ module Config (
     documentKeyPaths,
     unknownKeys,
 
+    -- * The paths a configuration carries
+    PathKind (..),
+    overPaths,
+
     -- * VOLCA_DATA_DIR resolution
     redirectIntoDataDir,
     applyDataDir,
@@ -760,55 +764,73 @@ redirectIntoDataDir (Just dataDir) p
         | last d == '/' || last d == '\\' = d ++ r
         | otherwise = d ++ "/" ++ r
 
+{- | What a path in a configuration file points at. The two rewrites below
+treat them differently, which is the only reason the distinction exists:
+reference data is shipped alongside the engine, user content is not.
+-}
+data PathKind
+    = {- | Flow synonyms, compartment mappings, units, energy densities,
+      geographies, chemical synonyms, substance edges — the data bundle.
+      -}
+      ReferenceDataPath
+    | -- | Databases and method collections, which the operator supplies.
+      UserContentPath
+    deriving (Show, Eq)
+
+{- | Rewrite every path a configuration carries.
+
+The one place that enumerates the path-bearing fields. Both rewrites below run
+through here, so a new path-bearing setting is added to this list rather than
+to each of them — a config whose @[[databases]]@ path followed the file while
+its @[[methods]]@ path followed the process was the bug that taught this.
+-}
+overPaths :: (PathKind -> FilePath -> FilePath) -> Config -> Config
+overPaths f cfg =
+    cfg
+        { cfgDatabases = map (\d -> d{dcPath = content (dcPath d)}) (cfgDatabases cfg)
+        , cfgMethods = map (\m -> m{mcPath = content (mcPath m)}) (cfgMethods cfg)
+        , cfgFlowSynonyms = map refData (cfgFlowSynonyms cfg)
+        , cfgCompartmentMappings = map refData (cfgCompartmentMappings cfg)
+        , cfgUnits = map refData (cfgUnits cfg)
+        , cfgEnergyDensities = map refData (cfgEnergyDensities cfg)
+        , cfgGeographies = fmap reference (cfgGeographies cfg)
+        , cfgChemSynonyms = fmap reference (cfgChemSynonyms cfg)
+        , cfgSubstanceEdges = fmap reference (cfgSubstanceEdges cfg)
+        }
+  where
+    reference = f ReferenceDataPath
+    content = f UserContentPath
+    refData r = r{rdPath = reference (rdPath r)}
+
 {- | Apply redirectIntoDataDir to every reference-data path on the Config.
 Other fields (databases, methods, plugins) are user content that lives
 outside the shipped data bundle and is left untouched.
 -}
 applyDataDir :: Maybe FilePath -> Config -> Config
-applyDataDir mDataDir cfg =
-    cfg
-        { cfgGeographies = fmap resolve (cfgGeographies cfg)
-        , cfgChemSynonyms = fmap resolve (cfgChemSynonyms cfg)
-        , cfgSubstanceEdges = fmap resolve (cfgSubstanceEdges cfg)
-        , cfgFlowSynonyms = map (mapPath resolve) (cfgFlowSynonyms cfg)
-        , cfgCompartmentMappings = map (mapPath resolve) (cfgCompartmentMappings cfg)
-        , cfgUnits = map (mapPath resolve) (cfgUnits cfg)
-        , cfgEnergyDensities = map (mapPath resolve) (cfgEnergyDensities cfg)
-        }
-  where
-    resolve = redirectIntoDataDir mDataDir
-    mapPath f r = r{rdPath = f (rdPath r)}
+applyDataDir mDataDir = overPaths $ \kind path -> case kind of
+    ReferenceDataPath -> redirectIntoDataDir mDataDir path
+    UserContentPath -> path
 
 {- | Resolve every relative path a config carries against the directory the
 config file sits in, so one file describes the same setup from any working
 directory. An absolute path is already unambiguous and is left alone; 'Nothing'
 (no config file) means the process directory, which is all there is to go on.
 
-Every path-bearing field is listed here, and nothing resolves paths anywhere
-else: a config whose @[[databases]]@ path followed the file while its
-@[[methods]]@ path followed the process was the bug this replaces.
+Every path-bearing field is listed in 'overPaths', and nothing resolves paths
+anywhere else: a config whose @[[databases]]@ path followed the file while its
+@[[methods]]@ path followed the process was the bug this replaces. Every kind
+is resolved, reference data included — this runs after 'applyDataDir', so a
+bundle path is already absolute by the time it arrives.
 
 'loadConfigOrDefault' composes this after 'applyDataDir', which is what
 recognises a leading @data/@ as the shipped bundle - prefixing it with a
 directory first would hide it.
 -}
 resolveConfigPaths :: Maybe FilePath -> Config -> Config
-resolveConfigPaths mConfigPath cfg =
-    cfg
-        { cfgDatabases = map (\d -> d{dcPath = resolve (dcPath d)}) (cfgDatabases cfg)
-        , cfgMethods = map (\m -> m{mcPath = resolve (mcPath m)}) (cfgMethods cfg)
-        , cfgFlowSynonyms = map refData (cfgFlowSynonyms cfg)
-        , cfgCompartmentMappings = map refData (cfgCompartmentMappings cfg)
-        , cfgUnits = map refData (cfgUnits cfg)
-        , cfgEnergyDensities = map refData (cfgEnergyDensities cfg)
-        , cfgGeographies = fmap resolve (cfgGeographies cfg)
-        , cfgChemSynonyms = fmap resolve (cfgChemSynonyms cfg)
-        , cfgSubstanceEdges = fmap resolve (cfgSubstanceEdges cfg)
-        }
+resolveConfigPaths mConfigPath = overPaths (const resolve)
   where
     configDir = maybe "." takeDirectory mConfigPath
     resolve p = normalise $ if isAbsolute p then p else configDir </> p
-    refData r = r{rdPath = resolve (rdPath r)}
 
 -- | Validate configuration
 validateConfig :: Config -> Either Text Config

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -44,10 +44,6 @@ module Config (
     documentKeyPaths,
     unknownKeys,
 
-    -- * The paths a configuration carries
-    PathKind (..),
-    overPaths,
-
     -- * VOLCA_DATA_DIR resolution
     redirectIntoDataDir,
     applyDataDir,
@@ -764,17 +760,17 @@ redirectIntoDataDir (Just dataDir) p
         | last d == '/' || last d == '\\' = d ++ r
         | otherwise = d ++ "/" ++ r
 
-{- | What a path in a configuration file points at. The two rewrites below
-treat them differently, which is the only reason the distinction exists:
-reference data is shipped alongside the engine, user content is not.
+{- | What a path in a configuration file points at.
+
+'applyDataDir' is the one rewrite that treats them differently:
+@VOLCA_DATA_DIR@ names where the shipped data bundle was installed, so it
+redirects reference data and leaves the operator's own files where they are.
+'resolveConfigPaths' resolves every kind alike. Which field is which is
+recorded in 'overPaths' and nowhere else.
 -}
 data PathKind
-    = {- | Flow synonyms, compartment mappings, units, energy densities,
-      geographies, chemical synonyms, substance edges — the data bundle.
-      -}
-      ReferenceDataPath
-    | -- | Databases and method collections, which the operator supplies.
-      UserContentPath
+    = ReferenceDataPath
+    | UserContentPath
     deriving (Show, Eq)
 
 {- | Rewrite every path a configuration carries.
@@ -803,8 +799,9 @@ overPaths f cfg =
     refData r = r{rdPath = reference (rdPath r)}
 
 {- | Apply redirectIntoDataDir to every reference-data path on the Config.
-Other fields (databases, methods, plugins) are user content that lives
-outside the shipped data bundle and is left untouched.
+Database and method paths are the operator's own and are left untouched,
+which is what keeps a database kept at @data\/agb.7z@ from being redirected
+into the shipped bundle.
 -}
 applyDataDir :: Maybe FilePath -> Config -> Config
 applyDataDir mDataDir = overPaths $ \kind path -> case kind of
@@ -816,18 +813,21 @@ config file sits in, so one file describes the same setup from any working
 directory. An absolute path is already unambiguous and is left alone; 'Nothing'
 (no config file) means the process directory, which is all there is to go on.
 
-Every path-bearing field is listed in 'overPaths', and nothing resolves paths
-anywhere else: a config whose @[[databases]]@ path followed the file while its
-@[[methods]]@ path followed the process was the bug this replaces. Every kind
-is resolved, reference data included — this runs after 'applyDataDir', so a
-bundle path is already absolute by the time it arrives.
+Every path a config file carries is listed in 'overPaths', and nothing else
+resolves one: a config whose @[[databases]]@ path followed the file while its
+@[[methods]]@ path followed the process was the bug this replaces. Both kinds
+are resolved the same way — a reference path @VOLCA_DATA_DIR@ already made
+absolute is left alone by the @isAbsolute@ test, and one it did not touch
+(the variable unset, or naming a relative directory) still needs anchoring.
 
 'loadConfigOrDefault' composes this after 'applyDataDir', which is what
 recognises a leading @data/@ as the shipped bundle - prefixing it with a
 directory first would hide it.
 -}
 resolveConfigPaths :: Maybe FilePath -> Config -> Config
-resolveConfigPaths mConfigPath = overPaths (const resolve)
+resolveConfigPaths mConfigPath = overPaths $ \kind path -> case kind of
+    ReferenceDataPath -> resolve path
+    UserContentPath -> resolve path
   where
     configDir = maybe "." takeDirectory mConfigPath
     resolve p = normalise $ if isAbsolute p then p else configDir </> p

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -60,6 +60,21 @@ mkRef p =
         , rdDescription = Nothing
         }
 
+{- | A decoded database and method entry carrying the given paths. Read through
+the real decoders so a required key added to either one fails here rather than
+in whichever test happened to hand-build the record.
+-}
+withParsedPaths :: FilePath -> FilePath -> (DatabaseConfig -> MethodConfig -> Expectation) -> Expectation
+withParsedPaths dbPath methodPath body =
+    case ( TOML.decode (entry "agb" dbPath) :: Either TOML.TOMLError DatabaseConfig
+         , TOML.decode (entry "EF" methodPath) :: Either TOML.TOMLError MethodConfig
+         ) of
+        (Right db, Right method) -> body db method
+        (Left e, _) -> expectationFailure (show e)
+        (_, Left e) -> expectationFailure (show e)
+  where
+    entry name path = "name = \"" <> name <> "\"\npath = \"" <> T.pack path <> "\"\n"
+
 spec :: Spec
 spec = do
     describe "listenOn" $ do
@@ -353,24 +368,16 @@ spec = do
         let cfg =
                 defaultConfig
                     { cfgGeographies = Just "data/geographies.csv"
+                    , cfgChemSynonyms = Just "data/chem.csv"
+                    , cfgSubstanceEdges = Just "data/edges.csv"
                     , cfgFlowSynonyms = [mkRef "data/flows.csv"]
                     , cfgCompartmentMappings = [mkRef "data/compartments.csv"]
                     , cfgUnits = [mkRef "data/units.csv"]
+                    , cfgEnergyDensities = [mkRef "data/energy.csv"]
                     }
-            userContent =
-                ( TOML.decode "name = \"agb\"\npath = \"agb.CSV\"\n" :: Either TOML.TOMLError DatabaseConfig
-                , TOML.decode "name = \"EF\"\npath = \"ef.zip\"\n" :: Either TOML.TOMLError MethodConfig
-                )
 
         it "rewrites every reference-data path when the env var is set" $ do
-            let resolved =
-                    applyDataDir
-                        (Just "/d")
-                        cfg
-                            { cfgEnergyDensities = [mkRef "data/energy.csv"]
-                            , cfgChemSynonyms = Just "data/chem.csv"
-                            , cfgSubstanceEdges = Just "data/edges.csv"
-                            }
+            let resolved = applyDataDir (Just "/d") cfg
             cfgGeographies resolved `shouldBe` Just "/d/geographies.csv"
             cfgChemSynonyms resolved `shouldBe` Just "/d/chem.csv"
             cfgSubstanceEdges resolved `shouldBe` Just "/d/edges.csv"
@@ -380,29 +387,21 @@ spec = do
             map rdPath (cfgEnergyDensities resolved) `shouldBe` ["/d/energy.csv"]
 
         -- Both rewrites walk one enumeration of the path-bearing fields, so
-        -- what keeps them apart is the kind each field is tagged with. A
-        -- database path is the operator's, not part of the shipped bundle.
+        -- what keeps them apart is the kind each field is tagged with. The
+        -- fixture paths open with "data/" on purpose: that prefix is the only
+        -- input redirectIntoDataDir acts on, so a database tagged as reference
+        -- data would be visibly redirected here and nowhere else.
         it "leaves user content where the operator put it" $
-            case userContent of
-                (Right db, Right method) -> do
-                    let userCfg = cfg{cfgDatabases = [db], cfgMethods = [method]}
-                        resolved = applyDataDir (Just "/d") userCfg
-                    map dcPath (cfgDatabases resolved) `shouldBe` [dcPath db]
-                    map mcPath (cfgMethods resolved) `shouldBe` [mcPath method]
-                (Left e, _) -> expectationFailure (show e)
-                (_, Left e) -> expectationFailure (show e)
+            withParsedPaths "data/agb.CSV" "data/ef.zip" $ \db method -> do
+                let userCfg = cfg{cfgDatabases = [db], cfgMethods = [method]}
+                applyDataDir (Just "/d") userCfg
+                    `shouldBe` (applyDataDir (Just "/d") cfg){cfgDatabases = [db], cfgMethods = [method]}
 
         it "is a no-op when the env var is unset" $
             applyDataDir Nothing cfg `shouldBe` cfg
 
     describe "resolveConfigPaths" $ do
-        let decodeDb t = TOML.decode t :: Either TOML.TOMLError DatabaseConfig
-            decodeMethod t = TOML.decode t :: Either TOML.TOMLError MethodConfig
-            withParsed body =
-                case (decodeDb "name = \"agb\"\npath = \"agb.CSV\"\n", decodeMethod "name = \"EF\"\npath = \"ef.zip\"\n") of
-                    (Right db, Right method) -> body db method
-                    (Left e, _) -> expectationFailure (show e)
-                    (_, Left e) -> expectationFailure (show e)
+        let withParsed = withParsedPaths "agb.CSV" "ef.zip"
 
         it "prefixes every relative path with the config file's directory" $
             withParsed $ \db method -> do

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -357,13 +357,40 @@ spec = do
                     , cfgCompartmentMappings = [mkRef "data/compartments.csv"]
                     , cfgUnits = [mkRef "data/units.csv"]
                     }
+            userContent =
+                ( TOML.decode "name = \"agb\"\npath = \"agb.CSV\"\n" :: Either TOML.TOMLError DatabaseConfig
+                , TOML.decode "name = \"EF\"\npath = \"ef.zip\"\n" :: Either TOML.TOMLError MethodConfig
+                )
 
         it "rewrites every reference-data path when the env var is set" $ do
-            let resolved = applyDataDir (Just "/d") cfg
+            let resolved =
+                    applyDataDir
+                        (Just "/d")
+                        cfg
+                            { cfgEnergyDensities = [mkRef "data/energy.csv"]
+                            , cfgChemSynonyms = Just "data/chem.csv"
+                            , cfgSubstanceEdges = Just "data/edges.csv"
+                            }
             cfgGeographies resolved `shouldBe` Just "/d/geographies.csv"
+            cfgChemSynonyms resolved `shouldBe` Just "/d/chem.csv"
+            cfgSubstanceEdges resolved `shouldBe` Just "/d/edges.csv"
             map rdPath (cfgFlowSynonyms resolved) `shouldBe` ["/d/flows.csv"]
             map rdPath (cfgCompartmentMappings resolved) `shouldBe` ["/d/compartments.csv"]
             map rdPath (cfgUnits resolved) `shouldBe` ["/d/units.csv"]
+            map rdPath (cfgEnergyDensities resolved) `shouldBe` ["/d/energy.csv"]
+
+        -- Both rewrites walk one enumeration of the path-bearing fields, so
+        -- what keeps them apart is the kind each field is tagged with. A
+        -- database path is the operator's, not part of the shipped bundle.
+        it "leaves user content where the operator put it" $
+            case userContent of
+                (Right db, Right method) -> do
+                    let userCfg = cfg{cfgDatabases = [db], cfgMethods = [method]}
+                        resolved = applyDataDir (Just "/d") userCfg
+                    map dcPath (cfgDatabases resolved) `shouldBe` [dcPath db]
+                    map mcPath (cfgMethods resolved) `shouldBe` [mcPath method]
+                (Left e, _) -> expectationFailure (show e)
+                (_, Left e) -> expectationFailure (show e)
 
         it "is a no-op when the env var is unset" $
             applyDataDir Nothing cfg `shouldBe` cfg


### PR DESCRIPTION
## Why

A configuration file's paths get rewritten twice on the way in: `applyDataDir` redirects reference data into `VOLCA_DATA_DIR`, then `resolveConfigPaths` resolves what is left against the config file's directory. Each function listed the path-bearing fields itself.

The two lists were not identical, and correctly so — `applyDataDir` skips `[[databases]]` and `[[methods]]`, which hold the operator's own content rather than the shipped bundle. But that made the duplication worse rather than better: a new reference-data setting had to be added to both lists, in the right one of two shapes, and nothing said anything if it went into only one.

`resolveConfigPaths`' own docstring already claimed:

> Every path-bearing field is listed here, and nothing resolves paths anywhere else: a config whose `[[databases]]` path followed the file while its `[[methods]]` path followed the process was the bug this replaces.

Half of that was true. Nothing else resolved paths — but the enumeration existed twice.

## What changed

`overPaths` is the single enumeration. Each field is tagged with a `PathKind` saying what its path points at, and the two rewrites differ only in what they do with the tag:

```haskell
applyDataDir mDataDir = overPaths $ \kind path -> case kind of
    ReferenceDataPath -> redirectIntoDataDir mDataDir path
    UserContentPath -> path

resolveConfigPaths mConfigPath = overPaths (const resolve)
```

A new path-bearing setting is now added to one list, and the tag is the only decision left to make about it.

## Examined and left alone

The larger claim behind this — that `configKeys` should be derived from the decoders rather than hand-mirrored beside them — does not survive reading the code. `test/ConfigSpec.hs:105-127` already diffs the key list against an exhaustive TOML fixture in both directions, so a decoder that gains a field without a matching key is caught by the suite. Replacing a working bidirectional test with an applicative key-collecting decoder would be machinery bought with nothing.

The duplicated defaults are two literals (`8080` and `127.0.0.1`, stated in both `defaultServerConfig` and the decoder). Worth fixing, but not the same subject as this, and too thin to carry a change on its own.

## Tests

The `applyDataDir` spec covered four of the seven reference-data fields and never checked that user content is left where the operator put it — which, now that both rewrites share one traversal, is the only thing the tag decides. It covers all seven and both kinds.

Full suite: 2243 examples, 0 failures.