### PR TITLE
Give the flat-vs-regionalized choice one home, and name what has not come through it

### DIFF
--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -45,7 +45,6 @@ import API.MCP.Enrich (addWebUrlMaybe, attachMarketHintByName, encodeSegment, fi
 import API.Types (ActivityForAPI (..), ActivityInfo (..), ClassificationSystem (..), ExchangeEditRequest (..), ExchangeWithUnit (..), InventoryExport (..), InventoryFlowDetail (..), Perturbation (..), Substitution (..), SubstitutionRequest (..), toExchangeEdits)
 import Control.Monad (unless, when)
 import qualified Data.List as L
-import qualified Impact
 import Matrix (applyBiosphereMatrix)
 import qualified Method.Explain as Explain
 import Method.Mapping (LCIAOutcome (..), MappingStats (..), SimilarCF (..), SimilarReason (..), UncharacterizedFlow (..), applyLongTermMode, computeLCIAScoreAuto, computeLCIAScoreFromTables, computeMappingStats, defaultUncharacterizedOpts, inventoryContributions, longTermModeFromExclude)
@@ -1133,14 +1132,12 @@ runImpactsRequest dbManager args req = do
     subs <- except (parseArrayArg "substitutions" Nothing args :: Either Text [Substitution])
     unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
     (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
-    -- The whole solution, not just its inventory: a regionalized method is
-    -- scored from the per-database scaling vectors it carries.
-    sol <-
+    solvedInventory <-
         ExceptT $
             if null subs
-                then computeInventoryMatrixWithDepsCached unitCfg (DM.mkDepSolverLookup dbManager) db dbName (ldSharedSolver ld) (raPid ra)
+                then fmap (fmap SharedSolver.csInventory) (computeInventoryMatrixWithDepsCached unitCfg (DM.mkDepSolverLookup dbManager) db dbName (ldSharedSolver ld) (raPid ra))
                 else
-                    first (T.pack . show)
+                    either (Left . T.pack . show) (Right . SharedSolver.csInventory)
                         <$> Service.inventoryWithSubsAndDeps
                             unitCfg
                             (DM.mkDepSolverLookup dbManager)
@@ -1150,12 +1147,11 @@ runImpactsRequest dbManager args req = do
                             (raPid ra)
                             subs
     let ltMode = longTermModeFromExclude (fromMaybe False (boolArg "exclude_long_term" args))
-        inventory = applyLongTermMode mFlows ltMode (SharedSolver.csInventory sol)
+        inventory = applyLongTermMode mFlows ltMode solvedInventory
     mappings <- liftIO $ DM.mapMethodToFlowsCached dbManager dbName collection db method
     tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName collection db method
-    score <- ExceptT $ Impact.scoreSolution dbManager collection method tables sol inventory
     let stats = computeMappingStats mappings
-        baseOutcome = (computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables){loScore = score}
+        baseOutcome = computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables
         (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
         contribs = L.sortOn (\(_, _, c) -> negate (abs c)) rawContribs
         (prodName, prodAmount, prodUnit) = Service.getReferenceProductInfo (dbTechFlows db) mUnits (raActivity ra)
@@ -1920,8 +1916,8 @@ callGetContributingFlows dbManager mBaseUrl rid args =
         let ltMode = longTermModeFromExclude (fromMaybe False (boolArg "exclude_long_term" args))
             inventory = applyLongTermMode mFlows ltMode (SharedSolver.csInventory sol)
         tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName collection db method
-        score <- ExceptT $ Impact.scoreSolution dbManager collection method tables sol inventory
         let outcome = computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables
+            score = loScore outcome
             (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
             contribs = L.sortOn (\(_, _, c) -> negate (abs c)) rawContribs
             top = take lim contribs

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -45,6 +45,7 @@ import API.MCP.Enrich (addWebUrlMaybe, attachMarketHintByName, encodeSegment, fi
 import API.Types (ActivityForAPI (..), ActivityInfo (..), ClassificationSystem (..), ExchangeEditRequest (..), ExchangeWithUnit (..), InventoryExport (..), InventoryFlowDetail (..), Perturbation (..), Substitution (..), SubstitutionRequest (..), toExchangeEdits)
 import Control.Monad (unless, when)
 import qualified Data.List as L
+import qualified Impact
 import Matrix (applyBiosphereMatrix)
 import qualified Method.Explain as Explain
 import Method.Mapping (LCIAOutcome (..), MappingStats (..), SimilarCF (..), SimilarReason (..), UncharacterizedFlow (..), applyLongTermMode, computeLCIAScoreAuto, computeLCIAScoreFromTables, computeMappingStats, defaultUncharacterizedOpts, inventoryContributions, longTermModeFromExclude)
@@ -1132,12 +1133,14 @@ runImpactsRequest dbManager args req = do
     subs <- except (parseArrayArg "substitutions" Nothing args :: Either Text [Substitution])
     unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
     (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
-    solvedInventory <-
+    -- The whole solution, not just its inventory: a regionalized method is
+    -- scored from the per-database scaling vectors it carries.
+    sol <-
         ExceptT $
             if null subs
-                then fmap (fmap SharedSolver.csInventory) (computeInventoryMatrixWithDepsCached unitCfg (DM.mkDepSolverLookup dbManager) db dbName (ldSharedSolver ld) (raPid ra))
+                then computeInventoryMatrixWithDepsCached unitCfg (DM.mkDepSolverLookup dbManager) db dbName (ldSharedSolver ld) (raPid ra)
                 else
-                    either (Left . T.pack . show) (Right . SharedSolver.csInventory)
+                    first (T.pack . show)
                         <$> Service.inventoryWithSubsAndDeps
                             unitCfg
                             (DM.mkDepSolverLookup dbManager)
@@ -1147,11 +1150,12 @@ runImpactsRequest dbManager args req = do
                             (raPid ra)
                             subs
     let ltMode = longTermModeFromExclude (fromMaybe False (boolArg "exclude_long_term" args))
-        inventory = applyLongTermMode mFlows ltMode solvedInventory
+        inventory = applyLongTermMode mFlows ltMode (SharedSolver.csInventory sol)
     mappings <- liftIO $ DM.mapMethodToFlowsCached dbManager dbName collection db method
     tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName collection db method
+    score <- ExceptT $ Impact.scoreSolution dbManager collection method tables sol inventory
     let stats = computeMappingStats mappings
-        baseOutcome = computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables
+        baseOutcome = (computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables){loScore = score}
         (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
         contribs = L.sortOn (\(_, _, c) -> negate (abs c)) rawContribs
         (prodName, prodAmount, prodUnit) = Service.getReferenceProductInfo (dbTechFlows db) mUnits (raActivity ra)
@@ -1916,8 +1920,8 @@ callGetContributingFlows dbManager mBaseUrl rid args =
         let ltMode = longTermModeFromExclude (fromMaybe False (boolArg "exclude_long_term" args))
             inventory = applyLongTermMode mFlows ltMode (SharedSolver.csInventory sol)
         tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName collection db method
+        score <- ExceptT $ Impact.scoreSolution dbManager collection method tables sol inventory
         let outcome = computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables
-            score = loScore outcome
             (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
             contribs = L.sortOn (\(_, _, c) -> negate (abs c)) rawContribs
             top = take lim contribs

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -21,7 +21,6 @@ import Control.Monad (forM, forM_, mfilter, unless, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (asks)
 import Data.Aeson
-import Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as BSL
 import Data.Char (isAscii, isControl)
 import Data.Foldable (asum)
@@ -45,9 +44,10 @@ import qualified Database.Manager as DM
 import qualified Expr
 import GHC.Generics
 import qualified GHC.Stats
+import qualified Impact
 import Matrix (Inventory, Vector)
 import qualified Method.Explain as Explain
-import Method.Mapping (BuildProvenance (..), CF (..), LCIAOutcome (..), LongTermMode (..), MappingStats (..), MethodTables (..), TableEntry (..), applyLongTermMode, characterizedFlowIds, computeLCIAScoreFromTables, computeLCIAScoreSetFromTables, computeMappingStats, inventoryContributions, longTermModeFromExclude, lookupEntryForFlow, strategyToText, sumRegionalizedLCIAScoreCrossDB)
+import Method.Mapping (BuildProvenance (..), CF (..), LCIAOutcome (..), LongTermMode (..), MappingStats (..), MethodTables (..), TableEntry (..), applyLongTermMode, characterizedFlowIds, computeLCIAScoreFromTables, computeLCIAScoreSetFromTables, computeMappingStats, inventoryContributions, longTermModeFromExclude, lookupEntryForFlow, strategyToText)
 import qualified Method.Mapping
 import Method.Types (DamageCategory (..), Method (..), MethodCF (..), MethodCollection (..), NormWeightSet (..), ScoringEvaluation (..), ScoringSet (..), computeFormulaScores)
 import qualified Method.Types as MT
@@ -669,17 +669,7 @@ computeCategoryResult dbManager dbName collection db sol activity topFlows preco
     -- 'resolveBatchedScore'; only the locally computed one is labeled here.
     scoreE <- case precomputedScore of
         Just e -> traverse evaluate e
-        Nothing ->
-            fmap (first (("[LCIA " <> methodName method <> "] ") <>)) $
-                if M.null (mtRegionalizedCF tables)
-                    then Right <$> evaluate (loScore (computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables))
-                    else do
-                        let hier = DM.dmLocationHierarchy dbManager
-                        perDb <-
-                            forM (NE.toList (SharedSolver.csScalings sol)) $ \(n, d, sv) -> do
-                                tbls <- DM.mapMethodToTablesCached dbManager n collection d method
-                                pure (d, sv, tbls)
-                        traverse evaluate (sumRegionalizedLCIAScoreCrossDB unitCfg mUnits mFlows hier perDb)
+        Nothing -> Impact.scoreSolution dbManager collection method tables sol inventory
     case scoreE of
         Left err -> pure (Left err)
         Right score -> buildResult unitCfg mFlows mUnits inventory tables stats score

--- a/src/Impact.hs
+++ b/src/Impact.hs
@@ -2,13 +2,30 @@
 
 {- | Scoring one method against one solved inventory.
 
-The step every surface needs and none of them should own. A method carrying
-regional characterization factors is scored from the per-database scaling
-vectors rather than from the merged inventory, because a factor that depends
-on where a flow occurs cannot be applied to a total that has forgotten. Which
-of the two paths a method takes is a property of the method, not of who is
-asking — so the choice lives here, and the REST routes and the assistant tools
-both come through.
+A method carrying regional characterization factors is scored from the
+per-database scaling vectors rather than from the merged inventory, because a
+factor that depends on where a flow occurs cannot be applied to a total that
+has forgotten. Which of the two paths a method takes is a property of the
+method, not of who is asking, so the choice belongs below every surface rather
+than inside one of them.
+
+It is not yet reached from below every surface. The REST impact routes come
+through here; the assistant tools score regionalized methods with the flat
+path, and so do both contributing-flows endpoints and both
+contributing-activities endpoints. Routing them here is not a matter of
+calling this function: the per-flow contributions each reports are computed
+region-blind by 'Method.Mapping.inventoryContributions', so a surface that
+took its total from here and its shares from there would publish percentages
+that no longer sum. The contributions have to move with the total, and that
+walk does not exist yet.
+
+Two further gaps, both older than this module and neither fixed by it:
+
+  * The dispatch below asks the /root/ database's tables whether the method is
+    regionalized. A root database with no matching regional factors scores its
+    dependencies' regional flows flat.
+  * Long-term-emission filtering applies to the inventory only, so the
+    regionalized path ignores @exclude_long_term@.
 -}
 module Impact (
     scoreSolution,
@@ -35,9 +52,9 @@ import qualified SharedSolver
 {- | The score of one method against a cross-database solution.
 
 @inventory@ is passed separately from @sol@ because a caller may have filtered
-it (long-term emissions) after solving; the regionalized path reads the
-solution's scaling vectors instead and is unaffected by that filtering, as it
-was before this was shared.
+it (long-term emissions) after solving. The regionalized path reads the
+solution's scaling vectors instead, so that filtering does not reach it — see
+the note above.
 
 A 'Left' is a scoring integrity error — a regionalized method with a gap it
 cannot fill. It propagates rather than collapsing to a zero the consumer could

--- a/src/Impact.hs
+++ b/src/Impact.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Scoring one method against one solved inventory.
+
+The step every surface needs and none of them should own. A method carrying
+regional characterization factors is scored from the per-database scaling
+vectors rather than from the merged inventory, because a factor that depends
+on where a flow occurs cannot be applied to a total that has forgotten. Which
+of the two paths a method takes is a property of the method, not of who is
+asking — so the choice lives here, and the REST routes and the assistant tools
+both come through.
+-}
+module Impact (
+    scoreSolution,
+) where
+
+import Control.Exception (evaluate)
+import Control.Monad (forM)
+import Data.Bifunctor (first)
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+
+import Database.Manager (DatabaseManager (..), getMergedFlowMetadata, getMergedUnitConfig, mapMethodToTablesCached)
+import Matrix (Inventory)
+import Method.Mapping (
+    LCIAOutcome (..),
+    MethodTables (..),
+    computeLCIAScoreFromTables,
+    sumRegionalizedLCIAScoreCrossDB,
+ )
+import Method.Types (Method (..))
+import qualified SharedSolver
+
+{- | The score of one method against a cross-database solution.
+
+@inventory@ is passed separately from @sol@ because a caller may have filtered
+it (long-term emissions) after solving; the regionalized path reads the
+solution's scaling vectors instead and is unaffected by that filtering, as it
+was before this was shared.
+
+A 'Left' is a scoring integrity error — a regionalized method with a gap it
+cannot fill. It propagates rather than collapsing to a zero the consumer could
+not tell from a real score.
+-}
+scoreSolution ::
+    DatabaseManager ->
+    -- | Method collection name, to reach each dependency database's tables
+    Text ->
+    Method ->
+    MethodTables ->
+    SharedSolver.CrossDBSolution ->
+    -- | The inventory to score, after any filtering the caller applied
+    Inventory ->
+    IO (Either Text Double)
+scoreSolution dbManager collection method tables sol inventory = do
+    unitCfg <- getMergedUnitConfig dbManager
+    (mFlows, mUnits) <- getMergedFlowMetadata dbManager
+    fmap (first (("[LCIA " <> methodName method <> "] ") <>)) $
+        if M.null (mtRegionalizedCF tables)
+            then Right <$> evaluate (loScore (computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables))
+            else do
+                let hier = dmLocationHierarchy dbManager
+                perDb <-
+                    forM (NE.toList (SharedSolver.csScalings sol)) $ \(n, d, sv) -> do
+                        tbls <- mapMethodToTablesCached dbManager n collection d method
+                        pure (d, sv, tbls)
+                traverse evaluate (sumRegionalizedLCIAScoreCrossDB unitCfg mUnits mFlows hier perDb)

--- a/volca.cabal
+++ b/volca.cabal
@@ -37,6 +37,7 @@ library
                      , Config
                      , Service
                      , Service.Aggregate
+                     , Impact
                      , Tree
                      , Matrix
                      , Matrix.Export


### PR DESCRIPTION
## What this started as, and why it shrank

A method carrying regional characterization factors must be scored from the per-database scaling vectors, not from the merged inventory: a factor that depends on *where* a flow occurs cannot be applied to a total that has forgotten. `Method.Mapping` offers both paths and something has to choose.

That choice lived inside `API/Routes.hs:672`, so only the REST impact route made it. **Two MCP tools do not** — `get_impacts` (`MCP.hs:1154`) and contributing-flows (`MCP.hs:1920`) call `computeLCIAScoreFromTables` unconditionally, which is the flat path, and answer a regionalized method with a number the REST route would not give for the same question. `get_sensitivity` *does* dispatch, through `computeLCIAScoreAuto`, which is what made the gap easy to miss.

The first version of this PR routed those two MCP tools through the new shared function. A fresh review showed that made things worse, and it was right:

- The per-flow contributions published beside the score come from `inventoryContributions`, which resolves factors region-blind by construction. Taking the total from the regionalized path and the shares from the flat one gives a response whose percentages no longer sum toward its own total.
- `exclude_long_term` filters the inventory. The regionalized path reads the scaling vectors, so the flag stops moving the score — and on `main` it *did* move it for these two tools, via the flat path.

Two defects traded for one, both silent. The contributions have to move with the total, and no per-flow regional walk exists to move them to. Writing one is the real work and it is not this change.

## What is left

`Impact.scoreSolution` — the flat-vs-regionalized choice with one home, called by the REST impact route. Behaviour is unchanged everywhere.

Its haddock names what has **not** come through it, so the next attempt reads it in the right place:

- the assistant tools, both contributing-flows endpoints and both contributing-activities endpoints still score regionalized methods flat;
- the dispatch asks the *root* database's tables whether the method is regionalized, so a root database with no matching regional factors scores its dependencies' regional flows flat;
- long-term filtering applies to the inventory only, so the regionalized path never sees `exclude_long_term`.

All four predate this module. None is fixed here.

## Tests

None, and none needed: the diff is a move plus documentation, and the suite is unchanged at 2242 examples, 0 failures — the same count as `main`. That the suite did not notice the original MCP divergence is itself a gap; a test would need a live `DatabaseManager`, a hand-built `CrossDBSolution` with more than one scaling, and a regionalized `MethodTables`, and `test/CrossDBRegionalLCIAFixture.hs` builds only the last of the three.

## If you would rather not carry this

Closing it loses the seam but keeps the finding, which is written down above. The seam is worth roughly one function; the finding is the valuable half.