### PR TITLE
Reserve a database name one way instead of three

### DIFF
--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -46,7 +46,7 @@ module Database.Edit (
 ) where
 
 import Control.Concurrent.STM (atomically, modifyTVar', readTVar, readTVarIO)
-import Control.Exception (SomeException, finally, try)
+import Control.Exception (SomeException, try)
 import Control.Monad (when)
 import qualified Data.IntSet as IS
 import qualified Data.Map.Strict as M
@@ -90,6 +90,7 @@ import Database.Manager (
     getMergedSynonymDB,
     getMergedUnitConfig,
     relinkDatabase,
+    withReservedName,
  )
 import Database.Rebuild (processKey, renderKey, resolveProcess)
 import Database.Upload (DatabaseFormat (..), slugify)
@@ -134,20 +135,18 @@ copyDatabase manager srcName newName = do
         else
             getDatabase manager srcName >>= \case
                 Nothing -> pure $ Left $ "Database not loaded: " <> srcName
-                Just src -> do
-                    reserved <- atomically $ do
-                        loadedDbs <- readTVar (dmLoadedDbs manager)
-                        availableDbs <- readTVar (dmAvailableDbs manager)
-                        stagingDbs <- readTVar (dmStagingDbs manager)
-                        if M.member slug loadedDbs || M.member slug availableDbs || S.member slug stagingDbs
-                            then pure (Left ("Database already exists: " <> slug))
-                            else Right () <$ modifyTVar' (dmStagingDbs manager) (S.insert slug)
-                    case reserved of
-                        Left err -> pure (Left err)
-                        Right () ->
-                            finally
-                                (registerCopy manager slug src)
-                                (atomically $ modifyTVar' (dmStagingDbs manager) (S.delete slug))
+                Just src ->
+                    withReservedName manager slug (nameIsFree slug) $ \() ->
+                        registerCopy manager slug src
+  where
+    nameIsFree slug = do
+        loadedDbs <- readTVar (dmLoadedDbs manager)
+        availableDbs <- readTVar (dmAvailableDbs manager)
+        stagingDbs <- readTVar (dmStagingDbs manager)
+        pure $
+            if M.member slug loadedDbs || M.member slug availableDbs || S.member slug stagingDbs
+                then Left ("Database already exists: " <> slug)
+                else Right ()
 
 {- | Build the copy's solver/index and insert it under @slug@. Caller holds the
 'dmStagingDbs' reservation for @slug@.
@@ -534,17 +533,15 @@ mutateUploadedDatabase manager dbName op = do
     -- the other started from, and both would land in the journal. Reserve the
     -- name (the same reservation copy and staging use) and refuse the second
     -- rather than queue it: edits are interactive and rare.
-    reserved <- atomically $ do
+    withReservedName manager dbName notAlreadyRunning $ \() ->
+        mutateReserved manager dbName op
+  where
+    notAlreadyRunning = do
         staging <- readTVar (dmStagingDbs manager)
-        if S.member dbName staging
-            then pure False
-            else True <$ modifyTVar' (dmStagingDbs manager) (S.insert dbName)
-    if not reserved
-        then pure $ Left $ "An edit of " <> dbName <> " is already in progress. Retry when it finishes."
-        else
-            finally
-                (mutateReserved manager dbName op)
-                (atomically $ modifyTVar' (dmStagingDbs manager) (S.delete dbName))
+        pure $
+            if S.member dbName staging
+                then Left ("An edit of " <> dbName <> " is already in progress. Retry when it finishes.")
+                else Right ()
 
 -- | The mutation proper. The caller holds the 'dmStagingDbs' reservation.
 mutateReserved :: DatabaseManager -> Text -> JournalOp -> IO (Either Text MutationOutcome)

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -31,6 +31,7 @@ module Database.Manager (
 
     -- * Initialization
     initDatabaseManager,
+    withReservedName,
 
     -- * Operations
     getDatabase,
@@ -882,6 +883,44 @@ mapMethodToIndexCached manager dbName collection method = do
             let !idx = buildMethodIndex method
             atomically $ modifyTVar' (dmMethodIndexCache manager) (M.insert key idx)
             pure idx
+
+{- | Hold a database name against concurrent work for the duration of an
+action, and release it whether the action returns or throws.
+
+@decide@ runs in the same transaction as the claim, so a caller refuses for
+its own reasons — a name already taken, an edit already running — with no
+window between finding the name free and taking it. That window is the whole
+reason this is one function: two copies of it, written apart, are two chances
+to widen it.
+
+The reservation lives in 'dmStagingDbs' whatever the slow work is. Staging,
+copying and editing all rewrite the same database under the same name, so
+they contend with each other and not only with their own kind.
+
+'getDatabaseSetupInfo' does not come through here on purpose: it waits for
+whoever holds the name (STM @retry@) instead of refusing, and it has a third
+answer — already staged, nothing to reserve — that this shape has no room for.
+-}
+withReservedName ::
+    DatabaseManager ->
+    Text ->
+    -- | Refuse with the caller's own error, or carry a value into the action
+    STM (Either e a) ->
+    (a -> IO (Either e b)) ->
+    IO (Either e b)
+withReservedName manager dbName decide act = do
+    claimed <- atomically $ do
+        decided <- decide
+        case decided of
+            Left err -> pure (Left err)
+            Right carried ->
+                Right carried <$ modifyTVar' (dmStagingDbs manager) (S.insert dbName)
+    case claimed of
+        Left err -> pure (Left err)
+        Right carried ->
+            Control.Exception.finally
+                (act carried)
+                (atomically $ modifyTVar' (dmStagingDbs manager) (S.delete dbName))
 
 {- | Clear all cached flow mappings (call when databases, methods, or synonyms change).
 Also drops the merged flow/unit snapshots — both caches depend on the loaded-DB set.


### PR DESCRIPTION
## Why

Staging, copying and editing all rewrite the same database under the same name, so they contend with each other — and each held the name its own way:

| | refuses when | on contention |
|---|---|---|
| `Manager.getDatabaseSetupInfo:2607` | not found / not uploaded | **waits** (STM `retry`) |
| `Edit.copyDatabase:138` | name loaded, configured, or in flight | refuses |
| `Edit.mutateUploadedDatabase:537` | an edit already running | refuses |

Three hand-written decide-then-claim-then-release sequences around one `TVar`. They agreed by luck rather than by construction, and the window they exist to close — between finding a name free and taking it — stays closed only while every copy is written carefully.

## What changed

`Manager.withReservedName` is the one bracket. The caller's own refusal runs inside the same transaction as the claim, so the check and the claim cannot come apart, and the release happens whether the slow work returns or throws:

```haskell
withReservedName manager slug (nameIsFree slug) $ \() ->
    registerCopy manager slug src
```

Both `Edit` sites come through it. Behaviour is unchanged — same refusals, same messages.

## Deliberately not converted

`getDatabaseSetupInfo` keeps its own transaction, and its docstring now says why: it *waits* for whoever holds the name instead of refusing, and it has a third answer — already staged, nothing to reserve — that this shape has no room for. One caller that fits differently is not a third copy; forcing it through would mean an argument that exists only for it.

## What this does not do

`DatabaseManager` still exports all 22 of its `TVar`s (`DatabaseManager (..)`), so the registry is still writable from outside: `dmLoadedDbs` alone is written from nine sites across two modules, and nine test modules install fixtures with `modifyTVar'` because no function offers to. Closing that is the larger half of the same subject and wants its own change — it touches every direct reader.

## Tests

Behaviour-preserving; the suite is unchanged at 2242 examples, 0 failures.

Worth saying plainly: the concurrency this guards is not tested here either, before or after. `test/PersistenceSpec.hs:181` fakes the refusal by inserting into `dmStagingDbs` by hand rather than racing two edits — which is only possible *because* the field is exported, and is the sort of test that keeps passing when the reservation stops working.