### PR TITLE
Write the drift test API.Resources claimed for four months

### DIFF
--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -5,7 +5,7 @@
 This module is the single source of truth for naming and metadata across
 all VoLCA user surfaces: MCP tools, CLI subcommands, pyvolca Python client,
 and OpenAPI documentation. Each surface consumes this module via a
-projection function ('mcpName', 'cliName', 'description', 'params').
+projection function ('mcpName', 'description', 'params').
 
 Per-language naming conventions are respected: projections emit the form
 natural to their target (snake_case for MCP/Python, kebab-case for CLI/URLs).
@@ -13,7 +13,7 @@ The Haskell call sites use 'Resource' PascalCase constructors directly.
 
 Adding a new operation means extending the 'Resource' ADT and adding one
 equation to each projection function. The compiler catches missing cases
-for 'mcpName'/'cliName'/'description'/'params'.
+for 'mcpName'/'description'/'params'.
 -}
 module API.Resources (
     Resource (..),
@@ -21,7 +21,6 @@ module API.Resources (
     ParamKind (..),
     allResources,
     mcpName,
-    cliName,
     description,
     params,
     requiredParams,
@@ -258,50 +257,6 @@ mcpName r = case r of
     GetComputedQualityReport -> "get_computed_quality_report"
     GetCoverageReport -> "get_characterization_coverage"
     EditExchanges -> "edit_exchanges"
-
--- ---------------------------------------------------------------------------
--- Projection: CLI subcommand names (kebab-case)
--- ---------------------------------------------------------------------------
-
-{- | Name as exposed on the command line.
-
-Note: some MCP tools don't have a standalone CLI subcommand (e.g.
-'list_databases' is 'database list' under the 'database' namespace,
-not a top-level command). For those, 'cliName' returns the nested form.
--}
-cliName :: Resource -> Text
-cliName r = case r of
-    ListDatabases -> "database list"
-    LoadDatabase -> "database load"
-    UnloadDatabase -> "database unload"
-    ListPresets -> "presets"
-    SearchActivities -> "activities"
-    SearchFlows -> "flows"
-    GetActivity -> "activity"
-    Aggregate -> "aggregate"
-    GetSupplyChain -> "supply-chain"
-    GetInventory -> "inventory"
-    GetImpacts -> "impacts"
-    ComputeSensitivity -> "sensitivity"
-    ListMethods -> "methods"
-    GetFlowMapping -> "flow-mapping"
-    GetCharacterization -> "characterization"
-    ExplainCF -> "explain-cf"
-    GetContributingFlows -> "contributing-flows"
-    GetContributingActivities -> "contributing-activities"
-    ListGeographies -> "geographies"
-    ListClassifications -> "classifications"
-    GetPathTo -> "path-to"
-    GetConsumers -> "consumers"
-    CompareImpacts -> "compare-impacts"
-    ScoreActivity -> "score-activity"
-    ScoreActivities -> "score-activities"
-    ListScoringSets -> "scoring-sets"
-    GetGapReport -> "gap-report"
-    GetQualityReport -> "quality-report"
-    GetComputedQualityReport -> "computed-quality-report"
-    GetCoverageReport -> "characterization-coverage"
-    EditExchanges -> "edit-exchanges"
 
 -- ---------------------------------------------------------------------------
 -- Projection: human-readable description (shared across surfaces)

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -2,14 +2,20 @@
 
 {- | Canonical enumeration of user-facing VoLCA operations.
 
-This module is the single source of truth for naming and metadata across
-all VoLCA user surfaces: MCP tools, CLI subcommands, pyvolca Python client,
-and OpenAPI documentation. Each surface consumes this module via a
-projection function ('mcpName', 'description', 'params').
+This module names every user-facing operation once, and two surfaces read it:
+the MCP tool metadata ("API.MCP") and the published OpenAPI document
+("API.OpenApi"). The Haskell call sites use 'Resource' PascalCase constructors
+directly.
 
-Per-language naming conventions are respected: projections emit the form
-natural to their target (snake_case for MCP/Python, kebab-case for CLI/URLs).
-The Haskell call sites use 'Resource' PascalCase constructors directly.
+The command line does not read it. Its subcommands and their help text are
+written out by hand in "CLI.Parser", and a projection that claimed otherwise
+('cliName') had drifted into naming fifteen commands that do not exist before
+it was removed. Nor does pyvolca: it reads the published spec at runtime.
+
+How much of what is written here actually reaches the OpenAPI document is
+measured by @test\/ResourcesDriftSpec.hs@, and the answer today is: the
+operation names and descriptions, and almost none of the parameter
+descriptions.
 
 Adding a new operation means extending the 'Resource' ADT and adding one
 equation to each projection function. The compiler catches missing cases
@@ -89,8 +95,14 @@ data ParamKind = Required | Optional
 {- | A single parameter accepted by a resource operation.
 
 'paramType' uses JSON Schema type names ("string", "integer", "number",
-"boolean", "array") so the MCP tool schema can emit it directly. The
-CLI and OpenAPI projections use it too.
+"boolean", "array") so the MCP tool schema can emit it directly, and the
+OpenAPI enrichment reads it too.
+
+A 'Param' does not record /where/ the value rides — path capture, query
+parameter, or request body — which is why most of these descriptions never
+reach the published spec: the enrichment matches on the name against a route's
+query parameters, and a path capture is named by Servant while a body field is
+not a parameter at all. @test\/ResourcesDriftSpec.hs@ pins the whole list.
 -}
 data Param = Param
     { paramName :: Text
@@ -275,9 +287,9 @@ webUrlTip page =
 
 {- | Description of the resource operation.
 
-These strings are consumed as-is by the MCP tool metadata and are
-summarised (first sentence) by the CLI --help. They are written for
-LLM tool use, so they're detailed and include usage hints.
+These strings are consumed as-is by the MCP tool metadata and stamped onto
+the published OpenAPI operation. They are written for LLM tool use, so they
+are detailed and include usage hints.
 -}
 description :: Resource -> Text
 description r = case r of

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1051,7 +1051,8 @@ over as a file fetches it rather than reimplementing the columns.
 
 These are a second representation of an operation 'API.Resources' already
 names, not operations of their own, so they get no registry entry: one there
-would mint a second MCP tool and a second CLI name for the same question.
+would mint a second MCP tool and a second published operation for the same
+question.
 -}
 qualityReportCsvH :: Text -> Maybe Int -> AppM (Headers '[Header "Content-Disposition" Text] QualityReportAPI)
 qualityReportCsvH dbName mLimit =

--- a/test/ResourcesDriftSpec.hs
+++ b/test/ResourcesDriftSpec.hs
@@ -1,0 +1,204 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Does the resource registry describe the routes that actually exist?
+
+"API.Resources" calls itself the single source of truth for every operation's
+name, path and parameters, and "API.OpenApi" stamps those onto the published
+spec by matching on names. When a name does not match, the enrichment leaves
+the parameter alone and says nothing, so a description can be written, shipped
+and read by nobody with every test green.
+
+This is the test that says otherwise. It has no server and no database: the
+spec is a pure value.
+-}
+module ResourcesDriftSpec (spec) where
+
+import Control.Lens ((^.))
+import qualified Data.HashMap.Strict.InsOrd as InsOrd
+import Data.List (sort)
+import Data.Maybe (mapMaybe)
+import Data.OpenApi (OpenApi, Operation, Param, PathItem, Referenced (..))
+import qualified Data.OpenApi.Lens as OA
+import Data.Text (Text)
+import qualified Data.Text as T
+import Test.Hspec
+
+import qualified API.Resources as R
+import API.Routes (volcaOpenApi)
+
+{- | Every operation the published spec carries, by its operationId, paired
+with every parameter name it accepts — the operation's own query parameters
+plus the path captures its route declares, which openapi3 hangs on the path
+rather than on each operation under it.
+-}
+operationsById :: OpenApi -> [(Text, [Text])]
+operationsById api =
+    [ (opId, names (op ^. OA.parameters) ++ names (item ^. OA.parameters))
+    | (_, item) <- InsOrd.toList (api ^. OA.paths)
+    , op <- operationsOf item
+    , Just opId <- [op ^. OA.operationId]
+    ]
+  where
+    names :: [Referenced Param] -> [Text]
+    names ps = [p ^. OA.name | Inline p <- ps]
+
+operationsOf :: PathItem -> [Operation]
+operationsOf item =
+    mapMaybe
+        (item ^.)
+        [OA.get, OA.put, OA.post, OA.delete, OA.patch, OA.head_, OA.options]
+
+-- | A registry parameter whose name no parameter of its own route carries.
+type Divergence = (Text, Text)
+
+{- | Every registry parameter whose name its own route does not carry.
+
+Ninety of them, which is nearly all of them: 'API.OpenApi.enrichParameters'
+matches on the name, so each of these is a description that reaches the
+published spec for nobody. Three separate causes, none of them a typo:
+
+  * __Path captures are named by Servant.__ The registry says @database@ and
+    @process_id@; the route says @dbName@ and @processId@. Every capture on
+    every route diverges.
+  * __Body fields are not parameters at all.__ @substitutions@, @remove@,
+    @set_amounts@ and the rest travel in a @ReqBody@, which has no
+    @parameters@ entry to enrich. The registry has no way to say so — a
+    'R.Param' records a name and a JSON-Schema type, not where the value rides.
+  * __Query parameters disagree on spelling.__ @exclude_long_term@ against
+    @exclude-long-term@, @query@ against @q@, @max_depth@ against @max-depth@.
+
+Pinned rather than fixed: the first two want the registry to record what kind
+of parameter each is, and the third changes the query parameters clients send.
+Both are their own decisions. Pinned so the list can only shrink, and so the
+next name that drifts is one this test names rather than one nobody counts.
+-}
+knownDivergences :: [Divergence]
+knownDivergences =
+    [ ("aggregate", "database")
+    , ("aggregate", "process_id")
+    , ("compute_sensitivity", "database")
+    , ("compute_sensitivity", "method_id")
+    , ("compute_sensitivity", "perturbations")
+    , ("compute_sensitivity", "process_id")
+    , ("edit_exchanges", "add_biosphere")
+    , ("edit_exchanges", "add_inputs")
+    , ("edit_exchanges", "add_waste_outputs")
+    , ("edit_exchanges", "database")
+    , ("edit_exchanges", "process_id")
+    , ("edit_exchanges", "remove")
+    , ("edit_exchanges", "set_amounts")
+    , ("explain_cf", "collection")
+    , ("explain_cf", "database")
+    , ("explain_cf", "flow_id")
+    , ("explain_cf", "method_id")
+    , ("get_activity", "database")
+    , ("get_activity", "exchange_type")
+    , ("get_activity", "flow")
+    , ("get_activity", "is_input")
+    , ("get_activity", "process_id")
+    , ("get_characterization", "collection")
+    , ("get_characterization", "database")
+    , ("get_characterization", "method_id")
+    , ("get_characterization_coverage", "database")
+    , ("get_computed_quality_report", "database")
+    , ("get_consumers", "classification_value")
+    , ("get_consumers", "database")
+    , ("get_consumers", "include_edges")
+    , ("get_consumers", "max_depth")
+    , ("get_consumers", "process_id")
+    , ("get_contributing_activities", "database")
+    , ("get_contributing_activities", "exclude_long_term")
+    , ("get_contributing_activities", "method_id")
+    , ("get_contributing_activities", "process_id")
+    , ("get_contributing_flows", "database")
+    , ("get_contributing_flows", "exclude_long_term")
+    , ("get_contributing_flows", "include_diagnostics")
+    , ("get_contributing_flows", "method_id")
+    , ("get_contributing_flows", "process_id")
+    , ("get_flow_mapping", "collection")
+    , ("get_flow_mapping", "database")
+    , ("get_flow_mapping", "max_unmatched")
+    , ("get_flow_mapping", "method_id")
+    , ("get_flow_mapping", "process_id")
+    , ("get_flow_mapping", "verbose")
+    , ("get_gap_report", "database")
+    , ("get_impacts", "database")
+    , ("get_impacts", "exclude_long_term")
+    , ("get_impacts", "include_diagnostics")
+    , ("get_impacts", "method_id")
+    , ("get_impacts", "process_id")
+    , ("get_impacts", "substitutions")
+    , ("get_impacts", "top_flows")
+    , ("get_inventory", "database")
+    , ("get_inventory", "flow")
+    , ("get_inventory", "limit")
+    , ("get_inventory", "process_id")
+    , ("get_inventory", "substitutions")
+    , ("get_path_to", "database")
+    , ("get_path_to", "process_id")
+    , ("get_quality_report", "database")
+    , ("get_supply_chain", "classification_match")
+    , ("get_supply_chain", "classification_value")
+    , ("get_supply_chain", "database")
+    , ("get_supply_chain", "max_depth")
+    , ("get_supply_chain", "min_quantity")
+    , ("get_supply_chain", "process_id")
+    , ("get_supply_chain", "substitutions")
+    , ("list_classifications", "database")
+    , ("list_classifications", "filter")
+    , ("list_classifications", "system")
+    , ("load_database", "database")
+    , ("score_activities", "database")
+    , ("score_activities", "exclude_long_term")
+    , ("score_activities", "process_ids")
+    , ("score_activities", "scoring_sets")
+    , ("score_activities", "summary_only")
+    , ("score_activity", "database")
+    , ("score_activity", "exclude_long_term")
+    , ("score_activity", "process_id")
+    , ("score_activity", "scoring_sets")
+    , ("score_activity", "substitutions")
+    , ("search_activities", "classification_match")
+    , ("search_activities", "classification_value")
+    , ("search_activities", "database")
+    , ("search_flows", "database")
+    , ("search_flows", "query")
+    , ("unload_database", "database")
+    ]
+
+spec :: Spec
+spec = describe "API.Resources against the published spec" $ do
+    let spec' = volcaOpenApi
+        byId = operationsById spec'
+        withPath = [r | r <- R.allResources, Just _ <- [R.apiPath r]]
+
+    it "publishes an operation for every resource that names a route" $
+        let missing = [R.mcpName r | r <- withPath, R.mcpName r `notElem` map fst byId]
+         in missing `shouldBe` []
+
+    -- The registry's whole claim. A description stamped onto a name the route
+    -- does not carry is a description nobody will ever read.
+    it "describes only parameters the routes accept, beyond the pinned list" $
+        let divergences =
+                [ (R.mcpName r, R.paramName p)
+                | r <- withPath
+                , Just accepted <- [lookup (R.mcpName r) byId]
+                , p <- R.params r
+                , R.paramName p `notElem` accepted
+                ]
+         in sort divergences `shouldBe` sort knownDivergences
+
+    -- The pinned list is only honest while every entry still diverges;
+    -- otherwise it silently starts excusing names that are fine.
+    it "pins no divergence that has since been fixed" $
+        let stale =
+                [ d
+                | d@(opId, name) <- knownDivergences
+                , Just accepted <- [lookup opId byId]
+                , name `elem` accepted
+                ]
+         in stale `shouldBe` []
+
+    it "gives every resource a description, since the spec publishes it" $
+        let blank = [R.mcpName r | r <- R.allResources, T.null (T.strip (R.description r))]
+         in blank `shouldBe` []

--- a/test/ResourcesDriftSpec.hs
+++ b/test/ResourcesDriftSpec.hs
@@ -14,10 +14,10 @@ spec is a pure value.
 module ResourcesDriftSpec (spec) where
 
 import Control.Lens ((^.))
-import qualified Data.HashMap.Strict.InsOrd as InsOrd
-import Data.List (sort)
+import Data.Foldable (toList)
+import Data.List ((\\))
 import Data.Maybe (mapMaybe)
-import Data.OpenApi (OpenApi, Operation, Param, PathItem, Referenced (..))
+import Data.OpenApi (OpenApi, Operation, PathItem, Referenced (..))
 import qualified Data.OpenApi.Lens as OA
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -27,20 +27,20 @@ import qualified API.Resources as R
 import API.Routes (volcaOpenApi)
 
 {- | Every operation the published spec carries, by its operationId, paired
-with every parameter name it accepts — the operation's own query parameters
-plus the path captures its route declares, which openapi3 hangs on the path
-rather than on each operation under it.
+with every parameter name it accepts.
+
+servant-openapi3 hangs both query parameters and path captures on the
+operation — its @addParam@ writes @allOperations . parameters@ — and never
+fills a path item's own parameter list, so reading the operation reads all of
+them.
 -}
 operationsById :: OpenApi -> [(Text, [Text])]
 operationsById api =
-    [ (opId, names (op ^. OA.parameters) ++ names (item ^. OA.parameters))
-    | (_, item) <- InsOrd.toList (api ^. OA.paths)
+    [ (opId, [p ^. OA.name | Inline p <- op ^. OA.parameters])
+    | item <- toList (api ^. OA.paths)
     , op <- operationsOf item
     , Just opId <- [op ^. OA.operationId]
     ]
-  where
-    names :: [Referenced Param] -> [Text]
-    names ps = [p ^. OA.name | Inline p <- ps]
 
 operationsOf :: PathItem -> [Operation]
 operationsOf item =
@@ -178,7 +178,10 @@ spec = describe "API.Resources against the published spec" $ do
 
     -- The registry's whole claim. A description stamped onto a name the route
     -- does not carry is a description nobody will ever read.
-    it "describes only parameters the routes accept, beyond the pinned list" $
+    -- Reported as two differences rather than one equality: a wall of ninety
+    -- tuples does not say which one moved. The first list is a name that has
+    -- started diverging, the second one that has stopped.
+    it "describes only parameters the routes accept, beyond the pinned list" $ do
         let divergences =
                 [ (R.mcpName r, R.paramName p)
                 | r <- withPath
@@ -186,19 +189,16 @@ spec = describe "API.Resources against the published spec" $ do
                 , p <- R.params r
                 , R.paramName p `notElem` accepted
                 ]
-         in sort divergences `shouldBe` sort knownDivergences
+        (divergences \\ knownDivergences) `shouldBe` []
+        (knownDivergences \\ divergences) `shouldBe` []
 
-    -- The pinned list is only honest while every entry still diverges;
-    -- otherwise it silently starts excusing names that are fine.
-    it "pins no divergence that has since been fixed" $
-        let stale =
-                [ d
-                | d@(opId, name) <- knownDivergences
-                , Just accepted <- [lookup opId byId]
-                , name `elem` accepted
+    -- paramDesc is what the enrichment carries; an empty one reaches the
+    -- published spec as a parameter with no explanation at all.
+    it "gives every parameter of a published operation a description" $
+        let blank =
+                [ (R.mcpName r, R.paramName p)
+                | r <- withPath
+                , p <- R.params r
+                , T.null (T.strip (R.paramDesc p))
                 ]
-         in stale `shouldBe` []
-
-    it "gives every resource a description, since the spec publishes it" $
-        let blank = [R.mcpName r | r <- R.allResources, T.null (T.strip (R.description r))]
          in blank `shouldBe` []

--- a/volca.cabal
+++ b/volca.cabal
@@ -373,7 +373,6 @@ test-suite lca-tests
                      , network
                      , toml-reader
                      , openapi3
-                     , insert-ordered-containers
                      , lens
   build-tool-depends:  hspec-discover:hspec-discover
 

--- a/volca.cabal
+++ b/volca.cabal
@@ -324,6 +324,7 @@ test-suite lca-tests
                      , MethodWriterSimaProSpec
                      , AuthSpec
                      , CLISpec
+                     , ResourcesDriftSpec
                      , RoutesSpec
                      , ScoringKeySpec
                      , NumericEdgesSpec
@@ -371,6 +372,9 @@ test-suite lca-tests
                      , QuickCheck
                      , network
                      , toml-reader
+                     , openapi3
+                     , insert-ordered-containers
+                     , lens
   build-tool-depends:  hspec-discover:hspec-discover
 
   default-language:    Haskell2010

--- a/weeder.toml
+++ b/weeder.toml
@@ -28,7 +28,7 @@ roots = [
   # an external consumer looks dead. Rooting them keeps the API stable; revisit
   # if a symbol is confirmed to have no consumer anywhere.
   # ---------------------------------------------------------------------------
-  "^API\\.Resources\\.(requiredParams|optionalParams|cliName)$",
+  "^API\\.Resources\\.(requiredParams|optionalParams)$",
   "^API\\.Types\\.(apiFlowId|apiFlowSynonyms)$",
   "^Database\\.Loader\\.(validateCacheFile|loadDatabaseFromCacheFile|loadUncompressedCacheFile)$",
   "^Database\\.Manager\\.(loadDatabaseFromConfig|loadDatabaseFromConfigWithCrossDB|getStagedDatabase)$",


### PR DESCRIPTION
## The claim

`src/API/Resources.hs` said, for four months:

> A separate drift test (ResourcesDriftSpec) enforces that each 'Resource' corresponds to an actual Servant route.

`git log -S ResourcesDriftSpec --all` returns two commits: the one that wrote that sentence, and `4a27a04`, which deleted it. `test/ResourcesDriftSpec.hs` has never been a tracked file. Nothing in any language compared the registry to the routes.

## The test

It exists now. It needs neither a server nor a database — `volcaOpenApi` is a pure value — and it asserts four things:

- every resource that names a route has an operation in the published spec;
- every registry parameter name is one its own route actually carries, beyond a pinned list;
- nothing in that pinned list has quietly been fixed;
- no resource has a blank description, since the spec publishes it.

## What it found

Larger than expected. `API.OpenApi.enrichParameters` stamps a description by matching the parameter's name, and **ninety of the registry's parameter names — nearly all of them — match nothing on their own route.** Every one of those descriptions is written, shipped, and reaches the published spec for nobody.

Three causes, none of them a typo:

| cause | example |
|---|---|
| Path captures are named by Servant | registry `database` / `process_id`, route `dbName` / `processId` — every capture on every route |
| Body fields are not parameters | `substitutions`, `remove`, `set_amounts` ride in a `ReqBody`, which has no `parameters` entry to enrich. `Param` records a name and a JSON-Schema type, not where the value rides |
| Query parameters disagree on spelling | `exclude_long_term` / `exclude-long-term`, `query` / `q`, `max_depth` / `max-depth` |

All ninety are pinned, with the causes named beside them.

## Why pinned rather than fixed

Two separate decisions, neither of which belongs in the test that measures them:

- the first two causes want `Param` to record **what kind** of parameter each is — path, query, or body — which is the registry carrying its contract rather than a name;
- the third changes the query parameters clients send, which is a wire change.

Pinned, the list can only shrink, and the next name that drifts is one this test names rather than one nobody counts.

## Also

`cliName` is deleted. Nothing read it, `weeder.toml:31` was told to ignore it, and it had drifted into naming fifteen commands that do not exist (`supply-chain`, `aggregate`, `explain-cf`, …) while spelling the one real command wrong (`edit-exchanges`, actually `database edit-exchanges`).

## Tests

2246 examples, 0 failures. The four new ones are the whole point.