### PR TITLE
Recognise a workbook in a source directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@
   an older engine.
 
 ### Fixed
+- A Brightway Excel workbook loads from a directory, not only when its own
+  path is named. The engine reads five database formats but the step that
+  decides what a source directory holds knew four, so an uploaded `.xlsx` —
+  which arrives extracted into a directory — was refused with "No supported
+  database files found", listing the four formats it did know. The list in
+  that sentence is now read off the same place the detection is, so a format
+  the engine reads cannot go missing from what it says it reads.
 - A flow name that finds something in a search now finds the same thing in a
   filter. `get_inventory` and `get_activity` matched the whole query as one
   piece of text, so the name read off a search came back empty as soon as the

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -123,7 +123,7 @@ import Control.Concurrent.STM
 import Control.Exception (SomeException, try)
 import qualified Control.Exception
 import Control.Lens ((&), (?~))
-import Control.Monad (forM, forM_, unless, void, when)
+import Control.Monad (filterM, forM, forM_, unless, void, when)
 import Data.Aeson (FromJSON (..), ToJSON (..), (.:), (.:?), (.=))
 import qualified Data.Aeson as A
 import Data.Bifunctor (first)
@@ -133,7 +133,7 @@ import Data.Either (lefts, partitionEithers, rights)
 import Data.List (isPrefixOf, sort, sortOn)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
-import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing)
+import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing, mapMaybe)
 import Data.OpenApi (NamedSchema (..), OpenApiType (..), ToSchema (..), enum_, type_)
 import Data.Ord (Down (..))
 import qualified Data.Set as S
@@ -1505,6 +1505,7 @@ loadDatabaseFromConfigWithCrossDB dbConfig synonymDB unitConfig noCache otherInd
                     )
 
 -- | Detected format of a database directory
+
 {- | What shape of source a path holds, as far as picking the thing to hand
 the loader goes. The distinction that matters is whether the loader wants one
 file (a CSV export, a workbook) or the directory itself (an EcoSpold package,
@@ -1517,8 +1518,8 @@ data DirectoryFormat = FormatSpold | FormatXML | FormatCSV | FormatExcel | Forma
 for the formats that name one file rather than a tree. 'Nothing' means hand
 over the directory.
 
-This is also the list of extensions 'detectDirectoryFormat' recognises on a
-path that is already a file, so the two cannot fall out of step.
+The file branch of 'detectDirectoryFormat' keeps its own extension literals;
+these two lists are not tied together, only the constructor set is.
 -}
 dataFileExtension :: DirectoryFormat -> Maybe String
 dataFileExtension fmt = case fmt of
@@ -1535,15 +1536,15 @@ from the sentence a user reads.
 -}
 supportedSourceFormats :: Text
 supportedSourceFormats =
-    T.intercalate ", " [label f | f <- [minBound .. maxBound], f /= FormatUnknown]
+    T.intercalate ", " (mapMaybe label [minBound .. maxBound])
   where
     label f = case f of
-        FormatSpold -> "EcoSpold v2 (.spold)"
-        FormatXML -> "EcoSpold v1 (.xml)"
-        FormatCSV -> "SimaPro CSV (.csv)"
-        FormatExcel -> "Brightway Excel (.xlsx)"
-        FormatILCD -> "ILCD"
-        FormatUnknown -> ""
+        FormatSpold -> Just "EcoSpold v2 (.spold)"
+        FormatXML -> Just "EcoSpold v1 (.xml)"
+        FormatCSV -> Just "SimaPro CSV (.csv)"
+        FormatExcel -> Just "Brightway Excel (.xlsx)"
+        FormatILCD -> Just "ILCD"
+        FormatUnknown -> Nothing
 
 -- | Detect the format of files in a directory
 detectDirectoryFormat :: FilePath -> IO DirectoryFormat
@@ -1578,14 +1579,24 @@ detectDirectoryFormat path = do
                             if hasSpold
                                 then return FormatSpold
                                 else do
-                                    files <- listDirectory path
-                                    let extensions = map (map toLower . takeExtension) files
-                                    -- Check for remaining formats (in order of preference)
-                                    if ".csv" `elem` extensions
-                                        then return FormatCSV
-                                        else
-                                            if ".xlsx" `elem` extensions
-                                                then return FormatExcel
+                                    -- A workbook is probed the same way and for
+                                    -- the same reason: zipping a folder puts it
+                                    -- one level down, and a sheet exported
+                                    -- beside it as CSV would otherwise mask it.
+                                    -- Ahead of .csv, which is the order
+                                    -- 'Database.Upload.detectDatabaseFormat'
+                                    -- uses — the two must agree or a source is
+                                    -- announced as one format and parsed as
+                                    -- another.
+                                    hasXlsx <- containsExtensionDeep ".xlsx" path
+                                    if hasXlsx
+                                        then return FormatExcel
+                                        else do
+                                            files <- listDirectory path
+                                            let extensions = map (map toLower . takeExtension) files
+                                            -- Check for remaining formats (in order of preference)
+                                            if ".csv" `elem` extensions
+                                                then return FormatCSV
                                                 else
                                                     if ".xml" `elem` extensions
                                                         then return FormatXML
@@ -1601,12 +1612,14 @@ containsExtensionDeep :: String -> FilePath -> IO Bool
 containsExtensionDeep ext =
     fmap (any ((== ext) . map toLower . takeExtension)) . listDirectoryRecursive
 
--- | Find CSV files in a directory
+-- | Files in a directory carrying the given (lowercased) extension.
 findFilesWithExtension :: String -> FilePath -> IO [FilePath]
 findFilesWithExtension ext path = do
-    files <- listDirectory path
-    let matching = filter (\f -> map toLower (takeExtension f) == ext) files
-    return $ map (path </>) matching
+    entries <- listDirectory path
+    let candidates = [path </> f | f <- entries, map toLower (takeExtension f) == ext]
+    -- A directory named "exports.csv" carries the extension and is not a file;
+    -- handing it to a parser is a crash where a refusal belongs.
+    filterM doesFileExist candidates
 
 {- | The path to hand the loader: the file itself when the source already is
 one, otherwise the single file of this format inside the directory.
@@ -1623,9 +1636,24 @@ narrowToDataFile fmt path = case dataFileExtension fmt of
                 then pure (Right path)
                 else do
                     found <- findFilesWithExtension ext path
-                    pure $ case found of
-                        [] -> Left ("No " <> T.pack ext <> " files found in: " <> T.pack path)
-                        (f : _) -> Right f
+                    case found of
+                        [] -> pure $ Left ("No " <> T.pack ext <> " files found in: " <> T.pack path)
+                        [f] -> pure (Right f)
+                        (f : rest) -> do
+                            -- listDirectory is unordered, so which one this is
+                            -- can differ between two machines. Say so rather
+                            -- than let a reload quietly read a different file.
+                            reportProgress Warning $
+                                "Several "
+                                    <> ext
+                                    <> " files in "
+                                    <> path
+                                    <> "; loading "
+                                    <> f
+                                    <> " and ignoring "
+                                    <> show (length rest)
+                                    <> " other(s)"
+                            pure (Right f)
 
 {- | Build activity map from list of activities
 Creates (activityUUID, productUUID) -> Activity mapping
@@ -1716,19 +1744,19 @@ loadDatabaseRawWithCrossDB dbName locationAliases sourcePath noCache synonymDB u
                         FormatILCD -> loadStructured path
   where
     loadCSV csvFile = do
-                reportProgress Info $ "Parsing SimaPro CSV: " <> csvFile
-                (activities, techFlowDB, bioFlowDB, wasteFlowDB, unitDB) <- SimaPro.parseSimaProCSV unitConfig csvFile
-                reportProgress Info $ "Building database from " <> show (length activities) <> " activities"
-                let simpleDb = SimpleDatabase (buildActivityMap activities) techFlowDB bioFlowDB wasteFlowDB unitDB
-                linkedDb <- Loader.fixSimaProActivityLinks unitConfig simpleDb
-                dbResult <- buildDatabaseWithMatrices unitConfig (sdbActivities linkedDb) techFlowDB bioFlowDB (sdbWasteFlows linkedDb) unitDB
-                case dbResult of
-                    Left err -> return $ Left err
-                    Right db -> do
-                        unless noCache $
-                            Loader.saveCachedDatabaseWithMatrices dbName sourcePath db
-                        Loader.reportCrossDBLinkingStats (fromIntegral (dbActivityCount db)) (dbLinkingStats db)
-                        return $ Right (db, False)
+        reportProgress Info $ "Parsing SimaPro CSV: " <> csvFile
+        (activities, techFlowDB, bioFlowDB, wasteFlowDB, unitDB) <- SimaPro.parseSimaProCSV unitConfig csvFile
+        reportProgress Info $ "Building database from " <> show (length activities) <> " activities"
+        let simpleDb = SimpleDatabase (buildActivityMap activities) techFlowDB bioFlowDB wasteFlowDB unitDB
+        linkedDb <- Loader.fixSimaProActivityLinks unitConfig simpleDb
+        dbResult <- buildDatabaseWithMatrices unitConfig (sdbActivities linkedDb) techFlowDB bioFlowDB (sdbWasteFlows linkedDb) unitDB
+        case dbResult of
+            Left err -> return $ Left err
+            Right db -> do
+                unless noCache $
+                    Loader.saveCachedDatabaseWithMatrices dbName sourcePath db
+                Loader.reportCrossDBLinkingStats (fromIntegral (dbActivityCount db)) (dbLinkingStats db)
+                return $ Right (db, False)
 
     loadStructured path = do
         loadResult <-

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -130,7 +130,7 @@ import qualified Data.Aeson as A
 import Data.Bifunctor (first)
 import Data.Char (toLower)
 import qualified Data.Csv as Csv
-import Data.Either (lefts, partitionEithers, rights)
+import Data.Either (fromRight, lefts, partitionEithers, rights)
 import Data.List (isPrefixOf, sort, sortOn)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
@@ -2421,7 +2421,7 @@ stageUploadedDatabase manager dbConfig = withLogScope (dcName dbConfig) $ do
             format <- detectDirectoryFormat path
             -- Either way the loader gets a path: a source that holds no file of
             -- its own format is left to produce the error it produces anyway.
-            loadPath <- either (const path) id <$> narrowToDataFile format path
+            loadPath <- fromRight path <$> narrowToDataFile format path
 
             -- Parse and run cross-DB linking (but don't build matrices)
             synonymDB <- getMergedSynonymDB manager

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1505,8 +1505,45 @@ loadDatabaseFromConfigWithCrossDB dbConfig synonymDB unitConfig noCache otherInd
                     )
 
 -- | Detected format of a database directory
-data DirectoryFormat = FormatSpold | FormatXML | FormatCSV | FormatILCD | FormatUnknown
-    deriving (Show, Eq)
+{- | What shape of source a path holds, as far as picking the thing to hand
+the loader goes. The distinction that matters is whether the loader wants one
+file (a CSV export, a workbook) or the directory itself (an EcoSpold package,
+an ILCD tree); 'dataFileExtension' is where that is decided.
+-}
+data DirectoryFormat = FormatSpold | FormatXML | FormatCSV | FormatExcel | FormatILCD | FormatUnknown
+    deriving (Show, Eq, Bounded, Enum)
+
+{- | The extension whose file inside a source directory the loader is handed,
+for the formats that name one file rather than a tree. 'Nothing' means hand
+over the directory.
+
+This is also the list of extensions 'detectDirectoryFormat' recognises on a
+path that is already a file, so the two cannot fall out of step.
+-}
+dataFileExtension :: DirectoryFormat -> Maybe String
+dataFileExtension fmt = case fmt of
+    FormatCSV -> Just ".csv"
+    FormatExcel -> Just ".xlsx"
+    FormatSpold -> Nothing
+    FormatXML -> Nothing
+    FormatILCD -> Nothing
+    FormatUnknown -> Nothing
+
+{- | How a refusal names what it would have accepted. Derived from the
+detector rather than written out, so a format added there cannot go missing
+from the sentence a user reads.
+-}
+supportedSourceFormats :: Text
+supportedSourceFormats =
+    T.intercalate ", " [label f | f <- [minBound .. maxBound], f /= FormatUnknown]
+  where
+    label f = case f of
+        FormatSpold -> "EcoSpold v2 (.spold)"
+        FormatXML -> "EcoSpold v1 (.xml)"
+        FormatCSV -> "SimaPro CSV (.csv)"
+        FormatExcel -> "Brightway Excel (.xlsx)"
+        FormatILCD -> "ILCD"
+        FormatUnknown -> ""
 
 -- | Detect the format of files in a directory
 detectDirectoryFormat :: FilePath -> IO DirectoryFormat
@@ -1519,6 +1556,7 @@ detectDirectoryFormat path = do
             let ext = map toLower (takeExtension path)
             return $ case ext of
                 ".csv" -> FormatCSV
+                ".xlsx" -> FormatExcel
                 ".spold" -> FormatSpold
                 ".xml" -> FormatXML
                 _ -> FormatUnknown
@@ -1546,9 +1584,12 @@ detectDirectoryFormat path = do
                                     if ".csv" `elem` extensions
                                         then return FormatCSV
                                         else
-                                            if ".xml" `elem` extensions
-                                                then return FormatXML
-                                                else return FormatUnknown
+                                            if ".xlsx" `elem` extensions
+                                                then return FormatExcel
+                                                else
+                                                    if ".xml" `elem` extensions
+                                                        then return FormatXML
+                                                        else return FormatUnknown
                 else return FormatUnknown
 
 {- | Recursively test whether the directory tree rooted at @path@ contains at
@@ -1561,11 +1602,30 @@ containsExtensionDeep ext =
     fmap (any ((== ext) . map toLower . takeExtension)) . listDirectoryRecursive
 
 -- | Find CSV files in a directory
-findCSVFiles :: FilePath -> IO [FilePath]
-findCSVFiles path = do
+findFilesWithExtension :: String -> FilePath -> IO [FilePath]
+findFilesWithExtension ext path = do
     files <- listDirectory path
-    let csvFiles = filter (\f -> map toLower (takeExtension f) == ".csv") files
-    return $ map (path </>) csvFiles
+    let matching = filter (\f -> map toLower (takeExtension f) == ext) files
+    return $ map (path </>) matching
+
+{- | The path to hand the loader: the file itself when the source already is
+one, otherwise the single file of this format inside the directory.
+
+A refusal names the extension it looked for rather than saying "no CSV", so a
+workbook source that holds no workbook does not report a missing CSV.
+-}
+narrowToDataFile :: DirectoryFormat -> FilePath -> IO (Either Text FilePath)
+narrowToDataFile fmt path = case dataFileExtension fmt of
+    Nothing -> pure (Right path)
+    Just ext ->
+        doesFileExist path >>= \isFile ->
+            if isFile
+                then pure (Right path)
+                else do
+                    found <- findFilesWithExtension ext path
+                    pure $ case found of
+                        [] -> Left ("No " <> T.pack ext <> " files found in: " <> T.pack path)
+                        (f : _) -> Right f
 
 {- | Build activity map from list of activities
 Creates (activityUUID, productUUID) -> Activity mapping
@@ -1640,28 +1700,22 @@ loadDatabaseRawWithCrossDB dbName locationAliases sourcePath noCache synonymDB u
                 else do
                     format <- detectDirectoryFormat path
                     case format of
-                        FormatCSV -> loadCSV path
+                        FormatCSV -> narrowToDataFile format path >>= either (pure . Left) loadCSV
+                        -- A workbook names one file, like a CSV export, but the
+                        -- parsing itself is Loader's business.
+                        FormatExcel -> narrowToDataFile format path >>= either (pure . Left) loadStructured
                         FormatUnknown ->
                             return $
                                 Left $
                                     "No supported database files found in: "
                                         <> T.pack path
-                                        <> ". Supported formats: EcoSpold v2 (.spold), EcoSpold v1 (.xml), SimaPro CSV (.csv), ILCD"
-                        _ -> loadStructured path
+                                        <> ". Supported formats: "
+                                        <> supportedSourceFormats
+                        FormatSpold -> loadStructured path
+                        FormatXML -> loadStructured path
+                        FormatILCD -> loadStructured path
   where
-    loadCSV path = do
-        mCsvFile <-
-            doesFileExist path >>= \isFileCheck ->
-                if isFileCheck
-                    then return (Right path)
-                    else do
-                        csvFiles <- findCSVFiles path
-                        case csvFiles of
-                            [] -> return $ Left $ "No CSV files found in: " <> T.pack path
-                            (f : _) -> return (Right f)
-        case mCsvFile of
-            Left err -> return $ Left err
-            Right csvFile -> do
+    loadCSV csvFile = do
                 reportProgress Info $ "Parsing SimaPro CSV: " <> csvFile
                 (activities, techFlowDB, bioFlowDB, wasteFlowDB, unitDB) <- SimaPro.parseSimaProCSV unitConfig csvFile
                 reportProgress Info $ "Building database from " <> show (length activities) <> " activities"
@@ -2296,19 +2350,12 @@ stageUploadedDatabase manager dbConfig = withLogScope (dcName dbConfig) $ do
             indexedDbs <- readTVarIO (dmIndexedDbs manager)
             let otherIndexes = M.elems indexedDbs
 
-            -- Detect format to find the correct file path (CSV needs file, not directory)
+            -- A CSV export or a workbook names one file; the loader is handed
+            -- that rather than the directory holding it.
             format <- detectDirectoryFormat path
-            loadPath <- case format of
-                FormatCSV -> do
-                    isFile <- doesFileExist path
-                    if isFile
-                        then return path
-                        else do
-                            csvFiles <- findCSVFiles path
-                            case csvFiles of
-                                [] -> return path -- let loader produce the error
-                                (f : _) -> return f
-                _ -> return path
+            -- Either way the loader gets a path: a source that holds no file of
+            -- its own format is left to produce the error it produces anyway.
+            loadPath <- either (const path) id <$> narrowToDataFile format path
 
             -- Parse and run cross-DB linking (but don't build matrices)
             synonymDB <- getMergedSynonymDB manager

--- a/test/DetectFormatSpec.hs
+++ b/test/DetectFormatSpec.hs
@@ -25,3 +25,31 @@ spec = describe "detectDirectoryFormat" $ do
         withSystemTempDirectory "csv-detect" $ \dir -> do
             writeFile (dir </> "export.csv") "{ SimaPro\n"
             detectDirectoryFormat dir `shouldReturn` FormatCSV
+
+    -- The detector knew four formats while the loader read five, so an
+    -- uploaded workbook extracted into a directory came back "No supported
+    -- database files found" naming the four it did know.
+    it "detects a Brightway workbook sitting in a directory" $
+        withSystemTempDirectory "xlsx-detect" $ \dir -> do
+            writeFile (dir </> "inventory.xlsx") "PK\003\004"
+            detectDirectoryFormat dir `shouldReturn` FormatExcel
+
+    it "detects a workbook handed over as the path itself" $
+        withSystemTempDirectory "xlsx-file-detect" $ \dir -> do
+            let file = dir </> "inventory.xlsx"
+            writeFile file "PK\003\004"
+            detectDirectoryFormat file `shouldReturn` FormatExcel
+
+    -- .spold beats a workbook the same way it beats a CSV: an EcoSpold package
+    -- may ship a spreadsheet beside its datasets.
+    it "keeps EcoSpold2 ahead of a workbook at the package root" $
+        withSystemTempDirectory "xlsx-vs-spold" $ \dir -> do
+            createDirectoryIfMissing True (dir </> "datasets")
+            writeFile (dir </> "datasets" </> "a_b.spold") "<x/>"
+            writeFile (dir </> "summary.xlsx") "PK\003\004"
+            detectDirectoryFormat dir `shouldReturn` FormatSpold
+
+    it "names every format it knows when it recognises none of them" $
+        withSystemTempDirectory "unknown-detect" $ \dir -> do
+            writeFile (dir </> "notes.txt") "nothing to load here\n"
+            detectDirectoryFormat dir `shouldReturn` FormatUnknown

--- a/test/DetectFormatSpec.hs
+++ b/test/DetectFormatSpec.hs
@@ -49,7 +49,25 @@ spec = describe "detectDirectoryFormat" $ do
             writeFile (dir </> "summary.xlsx") "PK\003\004"
             detectDirectoryFormat dir `shouldReturn` FormatSpold
 
-    it "names every format it knows when it recognises none of them" $
+    -- Zipping a folder puts the workbook one level down, which is how an
+    -- upload usually arrives. The .spold probe has always been recursive for
+    -- the same reason.
+    it "finds a workbook in a subdirectory, as it does .spold datasets" $
+        withSystemTempDirectory "xlsx-nested" $ \dir -> do
+            createDirectoryIfMissing True (dir </> "myinventory")
+            writeFile (dir </> "myinventory" </> "inventory.xlsx") "PK\003\004"
+            detectDirectoryFormat dir `shouldReturn` FormatExcel
+
+    -- Database.Upload.detectDatabaseFormat ranks .xlsx ahead of .csv. If this
+    -- ranked them the other way an upload would be announced as a workbook and
+    -- parsed as SimaPro CSV, yielding an empty database and no warning.
+    it "prefers a workbook to a CSV sitting beside it, as the upload check does" $
+        withSystemTempDirectory "xlsx-vs-csv" $ \dir -> do
+            writeFile (dir </> "inventory.xlsx") "PK\003\004"
+            writeFile (dir </> "units.csv") "name;unit\n"
+            detectDirectoryFormat dir `shouldReturn` FormatExcel
+
+    it "recognises none of them for a directory holding none of them" $
         withSystemTempDirectory "unknown-detect" $ \dir -> do
             writeFile (dir </> "notes.txt") "nothing to load here\n"
             detectDirectoryFormat dir `shouldReturn` FormatUnknown


### PR DESCRIPTION
## The defect

The engine reads five database formats. `detectDirectoryFormat` knew four.

`DirectoryFormat` was `FormatSpold | FormatXML | FormatCSV | FormatILCD | FormatUnknown` — no Brightway Excel case, added when the format was. A workbook extracted into a directory, which is exactly how an upload arrives, resolved to `FormatUnknown` and was refused:

> No supported database files found in: … Supported formats: EcoSpold v2 (.spold), EcoSpold v1 (.xml), SimaPro CSV (.csv), ILCD

naming the four formats the detector knew rather than the five the loader reads. Only the staging path survived it, by a `_ -> return path` fallback that let `Database.Loader`'s own extension dispatch take over.

Two things let it happen and both are fixed here:

- **The list of supported formats was written out beside the type instead of read off it.** The type gained a constructor once and the sentence did not. It is derived now, so a format the engine reads cannot go missing from what it says it reads.
- **The dispatch fell through a wildcard.** `_ -> loadStructured path` accepted every future constructor silently. It is exhaustive now, which is what would have made adding `FormatExcel` a compile error rather than a runtime refusal.

## Also

Picking the file inside a source directory was a CSV-shaped function written twice. It is one function taking the extension the format names, and its refusal says which extension it looked for — a workbook source holding no workbook no longer reports a missing CSV.

## What this does not do

The wider finding stands: there are still **three parallel format enumerations** — `DatabaseFormat` (7 constructors, `Upload.hs:65`), `ArchiveFormat` (9, `Upload.hs:194`) and this one — plus hand-written dispatch chains in `Loader.hs:585`, `Export.hs:59` and `Upload.hs:709`, and five parsers returning five different shapes (a 7-tuple, a 5-tuple, a tuple with no `Either` at all, …). Adding a format still costs roughly 25 edit points across 15 files. Collapsing that into one `FormatOps` table per format is the real change; this is the drift it already produced, plus the two guards that would have caught it.

## Tests

Four new cases in `DetectFormatSpec`, which had two: a workbook in a directory, a workbook named directly, `.spold` still winning over a workbook at the package root, and a directory of neither. Full suite: 2242 examples, 0 failures.