### PR TITLE
Surface the provenance a dataset states about itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 ## [Unreleased]
 
 ### Added
+- An activity now carries the provenance its dataset states about itself, and
+  `GET /api/v1/activity/{id}` reports it as `documentation`: the source it was
+  published in, the technology and period it describes, how it was sampled, and
+  the reviews it passed. EcoSpold files carry a whole dossier next to the
+  general comment - an EcoSpold 1 dataset names its bibliography and the report
+  it came from ("ecoinvent report No. 1"), an EcoSpold 2 dataset names its
+  author, year and reviewers - and none of it was read, so an analyst asking
+  where a number comes from had to open the source file. Each section keeps the
+  name its format gives it, and a section the dataset left blank is not
+  reported.
+  Two things it does not do. The full title of an ecoinvent report lives in
+  `MasterData/Sources.xml`, which is not read, so an EcoSpold 2 dataset reports
+  its author, year and pages rather than the report's title. And the machine
+  validation log some ecoinvent reviews carry (mass-balance warnings, property
+  deviations) is left out: it is kilobytes per dataset addressed to the
+  database's own build process. Exporting a database does not write these
+  sections back, the same way it has never written anything the general comment
+  does not hold.
 - The two quality reports of a database can now be taken as a CSV file, from
   the command line or from a plain web address. Load a database with one
   command and take its report with the next:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,20 @@
   where a number comes from had to open the source file. Each section keeps the
   name its format gives it, and a section the dataset left blank is not
   reported.
-  Two things it does not do. The full title of an ecoinvent report lives in
+  Three things it does not do. The full title of an ecoinvent report lives in
   `MasterData/Sources.xml`, which is not read, so an EcoSpold 2 dataset reports
-  its author, year and pages rather than the report's title. And the machine
-  validation log some ecoinvent reviews carry (mass-balance warnings, property
-  deviations) is left out: it is kilobytes per dataset addressed to the
-  database's own build process. Exporting a database does not write these
-  sections back, the same way it has never written anything the general comment
-  does not hold.
+  its author, year and pages rather than the report's title. The report the
+  ecoinvent build process files as a review under the name `[System]` is left
+  out, because it is kilobytes of mass-balance warnings per dataset written for
+  that process rather than for a reader; a review signed by a person is kept
+  whether or not they wrote anything beyond their name and the date. And a
+  field an exporter filled with its own placeholder for absence counts as
+  blank: openLCA writes the literal `<null>`, and reporting that as what a
+  dataset says about its geography would be worse than saying nothing. Only the
+  placeholder alone is read that way, since "none" and "not known" are
+  statements a person wrote.
+  Exporting a database does not write these sections back, the same way it has
+  never written anything the general comment does not hold.
 - The two quality reports of a database can now be taken as a CSV file, from
   the command line or from a plain web address. Load a database with one
   command and take its report with the next:

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -34,7 +34,7 @@ import Database.Author (
  )
 import GHC.Generics
 import Servant.API.ContentTypes (MimeRender (..), MimeUnrender (..), OctetStream)
-import Types (BioDirection (..), BiosphereFlow (..), Compartment (..), Exchange, FlowKind (..), NativeActivityType (..), Pedigree, Severity, TechnosphereFlow (..), UUID, Unit, WasteFlow (..))
+import Types (BioDirection (..), BiosphereFlow (..), Compartment (..), DocSection (..), Exchange, FlowKind (..), NativeActivityType (..), Pedigree, Severity, TechnosphereFlow (..), UUID, Unit, WasteFlow (..))
 
 {- | Tagged wire representation of either side of the flow split.
 
@@ -1526,6 +1526,7 @@ data ActivityForAPI = ActivityForAPI
     { pfaProcessId :: Text -- ProcessId format: "activityUUID_productUUID"
     , pfaActivityName :: Text
     , pfaDescription :: [Text] -- Description par paragraphes
+    , pfaDocumentation :: [DocSection] -- Provenance the dataset states about itself (source, technology, review); empty when the format records none
     , pfaSynonyms :: M.Map Text (S.Set Text) -- Synonymes par langue
     , pfaClassifications :: M.Map Text Text -- Classifications (ISIC, CPC, etc.)
     , pfaLocation :: Text

--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -326,6 +326,7 @@ rawToActivity cfg ra =
         Activity
             { activityName = raName ra
             , activityDescription = maybeToList (metaText meta "comment")
+            , activityDocumentation = [] -- A workbook records no source dossier
             , activitySynonyms = M.empty
             , activityClassification = M.empty
             , activityLocation = location

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -324,6 +324,7 @@ buildActivity a unitLabel exchangeList =
     Activity
         { activityName = aaName a
         , activityDescription = aaDescription a
+        , activityDocumentation = [] -- An authored activity states no source of its own
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = aaLocation a

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -246,6 +246,10 @@ History of manual bumps:
      so one substance is one flow across the export. Old caches hold one flow
      per (dataset, substance) pair — a value change with no type change, which
      the fingerprint alone would accept.
+- 15: Activity record gained activityDocumentation (the provenance a dataset
+     states about itself: published source, technology, review). Old caches
+     miss the field; the Store layout is positional, so decoding them would
+     misread every field after it.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.
@@ -253,7 +257,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeRep (Proxy :: Proxy Database))
-     in hi `xor` lo `xor` 14
+     in hi `xor` lo `xor` 15
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.

--- a/src/EcoSpold/Common.hs
+++ b/src/EcoSpold/Common.hs
@@ -144,9 +144,18 @@ nonEmptyText t =
 {- | One documentation section, or none at all when the dataset left the field
 blank. Both EcoSpold parsers assemble their sections through this, so "a rubric
 the source did not fill is not a rubric" is decided once.
+
+A field an exporter filled with its own placeholder for absence counts as
+blank: openLCA writes the literal @\<null\>@ where it has nothing, 3794 of the
+11947 datasets of the BAFU export among them, and reporting that to a reader as
+what the dataset says about its geography would be worse than saying nothing.
+Only the placeholder alone is read that way - "none" and "not known" are
+statements a person wrote, and they are reported as written.
 -}
 docSection :: Text -> Text -> [DocSection]
-docSection label = maybe [] (pure . DocSection label) . nonEmptyText
+docSection label = maybe [] (pure . DocSection label) . nonEmptyText . dropNullMarker
+  where
+    dropNullMarker t = if T.strip t == "<null>" then "" else t
 
 {- | Join the pieces a format spreads one section over, dropping the blanks:
 a publisher with no place of publication reads as the publisher alone, not as

--- a/src/EcoSpold/Common.hs
+++ b/src/EcoSpold/Common.hs
@@ -12,18 +12,21 @@ module EcoSpold.Common (
     isElement,
     distributeFiles,
     nonEmptyText,
+    docSection,
+    joinParts,
     showFFloatTrim,
 ) where
 
 import Amount (readAmount)
 import qualified Data.ByteString as BS
 import Data.Char (chr)
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Read as TR
 import Numeric (showFFloat)
+import Types (DocSection (..))
 
 -- | ByteString to Text conversion with UTF-8 decoding and XML entity decoding
 bsToText :: BS.ByteString -> Text
@@ -137,6 +140,20 @@ nonEmptyText :: Text -> Maybe Text
 nonEmptyText t =
     let s = T.strip t
      in if T.null s then Nothing else Just s
+
+{- | One documentation section, or none at all when the dataset left the field
+blank. Both EcoSpold parsers assemble their sections through this, so "a rubric
+the source did not fill is not a rubric" is decided once.
+-}
+docSection :: Text -> Text -> [DocSection]
+docSection label = maybe [] (pure . DocSection label) . nonEmptyText
+
+{- | Join the pieces a format spreads one section over, dropping the blanks:
+a publisher with no place of publication reads as the publisher alone, not as
+a dangling separator.
+-}
+joinParts :: Text -> [Text] -> Text
+joinParts sep = T.intercalate sep . mapMaybe nonEmptyText
 
 -- | Distribute a list evenly across N buckets (for parallel workers)
 distributeFiles :: Int -> [a] -> [[a]]

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -161,8 +161,8 @@ data DatasetDocs = DatasetDocs
     , ddGeography :: !Text
     , ddTechnology :: !Text
     , ddTimePeriod :: !Text
-    , ddStartYear :: !Text
-    , ddEndYear :: !Text
+    , ddPeriodStart :: !Text -- <startYear> or the more precise <startDate>
+    , ddPeriodEnd :: !Text
     , ddSampling :: !Text
     , ddExtrapolations :: !Text
     , ddProductionVolume :: !Text
@@ -379,8 +379,10 @@ onCloseTag state tagName
     | isElement tagName "geography" = (popElement state){psContext = Other}
     | isElement tagName "source" = closeSource state
     | isElement tagName "person" = closePerson state
-    | isElement tagName "startYear" = closeDocText (\d t -> d{ddStartYear = t}) state
-    | isElement tagName "endYear" = closeDocText (\d t -> d{ddEndYear = t}) state
+    | isElement tagName "startYear" = closeDocText (\d t -> d{ddPeriodStart = statedAsYear (ddPeriodStart d) t}) state
+    | isElement tagName "endYear" = closeDocText (\d t -> d{ddPeriodEnd = statedAsYear (ddPeriodEnd d) t}) state
+    | isElement tagName "startDate" = closeDocText (\d t -> d{ddPeriodStart = statedAsDate (ddPeriodStart d) t}) state
+    | isElement tagName "endDate" = closeDocText (\d t -> d{ddPeriodEnd = statedAsDate (ddPeriodEnd d) t}) state
     | isElement tagName "dataset" = closeDataset state
     | otherwise = popPath state
 
@@ -406,6 +408,23 @@ closePerson state =
             | ddPendingPersonNumber docs == 0 = ddPersons docs
             | otherwise = IM.insert (ddPendingPersonNumber docs) (ddPendingPersonName docs) (ddPersons docs)
      in (popElement state){psDocs = docs{ddPersons = filed, ddPendingPersonNumber = 0, ddPendingPersonName = ""}}
+
+{- | A period bound the dataset states as a year. EcoSpold1 has both a
+@\<startYear\>@ / @\<endYear\>@ pair and a @\<startDate\>@ / @\<endDate\>@ one
+(the ESU/BAFU export writes dates on 338 of its 400 datasets, years on the
+rest), so a dataset writing both states the same period twice and the year does
+not overwrite a date already read.
+-}
+statedAsYear :: Text -> Text -> Text
+statedAsYear existing t
+    | T.null (T.strip existing) = T.strip t
+    | otherwise = existing
+
+-- | The same bound stated as a full date: the precise form, so it wins.
+statedAsDate :: Text -> Text -> Text
+statedAsDate existing t
+    | T.null (T.strip t) = existing
+    | otherwise = T.strip t
 
 -- | Close an element whose documentation value is its text rather than an attribute.
 closeDocText :: (DatasetDocs -> Text -> DatasetDocs) -> ParseState -> ParseState
@@ -629,7 +648,7 @@ documentationSections d =
         [ docSection "Included processes" (ddIncludedProcesses d)
         , docSection "Geography" (ddGeography d)
         , docSection "Technology" (ddTechnology d)
-        , docSection "Time period" (joinParts " " [years, ddTimePeriod d])
+        , docSection "Time period" (joinParts " " [period, ddTimePeriod d])
         , docSection "Sampling procedure" (ddSampling d)
         , docSection "Extrapolations" (ddExtrapolations d)
         , docSection "Production volume" (ddProductionVolume d)
@@ -638,7 +657,7 @@ documentationSections d =
         , docSection "Review" (joinParts " " [ddProofReading d, reviewer])
         ]
   where
-    years = joinParts "-" [ddStartYear d, ddEndYear d]
+    period = joinParts " - " [ddPeriodStart d, ddPeriodEnd d]
     publishedIn = IM.lookup (ddPublishedSource d) (ddSources d)
     otherSources = IM.elems (IM.delete (ddPublishedSource d) (ddSources d))
     reviewer = maybe "" (\p -> "(" <> p <> ")") (IM.lookup (ddValidator d) (ddPersons d) >>= nonEmptyText)

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -23,6 +23,7 @@ import Control.Monad (forM_)
 import Data.Bifunctor (first)
 import qualified Data.ByteString as BS
 import Data.Either (lefts, rights)
+import qualified Data.IntMap.Strict as IM
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe, isNothing)
 import Data.Text (Text)
@@ -30,7 +31,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V5 as UUID5
-import EcoSpold.Common (bsToDouble, bsToIntMaybe, bsToText, isElement, nonEmptyText)
+import EcoSpold.Common (bsToDouble, bsToIntMaybe, bsToText, docSection, isElement, joinParts, nonEmptyText)
 import EcoSpold.Cutoff (applyCutoffStrategy)
 import Progress (ProgressLevel (..), reportProgress)
 import Types
@@ -131,6 +132,53 @@ data ExchangeData = ExchangeData
 emptyExchangeData :: ExchangeData
 emptyExchangeData = ExchangeData 0 "" "" "" "" "" 0.0 "" "" "" "" False ""
 
+{- | One @\<source\>@ of the dataset's own bibliography. EcoSpold1 numbers them
+within the dataset, and @dataGeneratorAndPublication\@referenceToPublishedSource@
+names the one the dataset was published in - the methodological report.
+-}
+data Source1 = Source1
+    { s1Number :: !Int
+    , s1FirstAuthor :: !Text
+    , s1AdditionalAuthors :: !Text
+    , s1Year :: !Text
+    , s1Title :: !Text
+    , s1TitleOfAnthology :: !Text -- Where ecoinvent puts "ecoinvent report No. 1"
+    , s1Publisher :: !Text
+    , s1Place :: !Text
+    }
+    deriving (Eq)
+
+emptySource1 :: Source1
+emptySource1 = Source1 0 "" "" "" "" "" "" ""
+
+{- | The provenance a dataset states about itself, accumulated as the metadata
+elements go by. Sources and persons are keyed by the number the dataset gives
+them, because the elements referring to them (the published source, the
+validator) may be read before or after the thing they name.
+-}
+data DatasetDocs = DatasetDocs
+    { ddIncludedProcesses :: !Text
+    , ddGeography :: !Text
+    , ddTechnology :: !Text
+    , ddTimePeriod :: !Text
+    , ddStartYear :: !Text
+    , ddEndYear :: !Text
+    , ddSampling :: !Text
+    , ddExtrapolations :: !Text
+    , ddProductionVolume :: !Text
+    , ddProofReading :: !Text
+    , ddValidator :: !Int -- <person> number of the proof reader
+    , ddPublishedSource :: !Int -- <source> number the dataset was published in
+    , ddSources :: !(IM.IntMap Source1)
+    , ddPersons :: !(IM.IntMap Text)
+    , ddPendingSource :: !Source1 -- attributes of the open <source>
+    , ddPendingPersonNumber :: !Int -- attributes of the open <person>
+    , ddPendingPersonName :: !Text
+    }
+
+emptyDatasetDocs :: DatasetDocs
+emptyDatasetDocs = DatasetDocs "" "" "" "" "" "" "" "" "" "" 0 0 IM.empty IM.empty emptySource1 0 ""
+
 -- | Parsing state accumulator
 data ParseState = ParseState
     { psDatasetNumber :: !Int
@@ -149,6 +197,7 @@ data ParseState = ParseState
     , psContext :: !ElementContext
     , psTextAccum :: ![BS.ByteString]
     , psSupplierLinks :: !(M.Map UUID Int) -- flowId → supplier dataset number (technosphere inputs)
+    , psDocs :: !DatasetDocs -- Provenance the dataset states about itself
     , psCompletedActivities :: ![Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit], Int, M.Map UUID Int)]
     }
 
@@ -172,6 +221,7 @@ initialParseState =
         , psContext = Other
         , psTextAccum = []
         , psSupplierLinks = M.empty
+        , psDocs = emptyDatasetDocs
         , psCompletedActivities = []
         }
 
@@ -212,12 +262,14 @@ onAttribute state name value = case psContext state of
     InReferenceFunction -> setRefFunctionAttr name value state
     InGeography
         | isElement name "location" -> state{psLocation = Just (bsToText value)}
+        | isElement name "text" -> setDocs (\d -> d{ddGeography = bsToText value})
         | otherwise -> state
     InExchange edata -> state{psContext = InExchange (setExchangeAttr name value edata)}
     InInputGroup _ -> datasetNumberAttr
     InOutputGroup _ -> datasetNumberAttr
-    Other -> datasetNumberAttr
+    Other -> docAttr name value datasetNumberAttr
   where
+    setDocs f = state{psDocs = f (psDocs state)}
     -- The dataset's numeric id lives on the <dataset> element itself, which is
     -- the head of the path. Accepting it anywhere under <dataset> let the
     -- metadata's own numbered elements (<source>, <person>) overwrite it, so
@@ -234,6 +286,44 @@ onAttribute state name value = case psContext state of
             state{psDatasetNumber = fromMaybe 0 (bsToIntMaybe value)}
         | otherwise = state
 
+{- | Attributes of the metadata elements a dataset states its provenance on.
+EcoSpold1 writes each of them as one self-closing element carrying everything
+in attributes, so the element currently open is what tells them apart - the
+attribute names alone collide (@text@ is on both @\<geography\>@ and
+@\<technology\>@, @number@ is on @\<dataset\>@, @\<source\>@ and @\<person\>@).
+-}
+docAttr :: BS.ByteString -> BS.ByteString -> ParseState -> ParseState
+docAttr name value state
+    | on "technology" "text" = setDocs (\d -> d{ddTechnology = txt})
+    | on "timePeriod" "text" = setDocs (\d -> d{ddTimePeriod = txt})
+    | on "representativeness" "samplingProcedure" = setDocs (\d -> d{ddSampling = txt})
+    | on "representativeness" "extrapolations" = setDocs (\d -> d{ddExtrapolations = txt})
+    | on "representativeness" "productionVolume" = setDocs (\d -> d{ddProductionVolume = txt})
+    | on "validation" "proofReadingDetails" = setDocs (\d -> d{ddProofReading = txt})
+    | on "validation" "proofReadingValidator" = setDocs (\d -> d{ddValidator = num})
+    | on "dataGeneratorAndPublication" "referenceToPublishedSource" = setDocs (\d -> d{ddPublishedSource = num})
+    | on "source" "number" = setSource (\s -> s{s1Number = num})
+    | on "source" "firstAuthor" = setSource (\s -> s{s1FirstAuthor = txt})
+    | on "source" "additionalAuthors" = setSource (\s -> s{s1AdditionalAuthors = txt})
+    | on "source" "year" = setSource (\s -> s{s1Year = txt})
+    | on "source" "title" = setSource (\s -> s{s1Title = txt})
+    | on "source" "titleOfAnthology" = setSource (\s -> s{s1TitleOfAnthology = txt})
+    | on "source" "publisher" = setSource (\s -> s{s1Publisher = txt})
+    | on "source" "placeOfPublications" = setSource (\s -> s{s1Place = txt})
+    | on "person" "number" = setDocs (\d -> d{ddPendingPersonNumber = num})
+    | on "person" "name" = setDocs (\d -> d{ddPendingPersonName = txt})
+    | otherwise = state
+  where
+    txt = bsToText value
+    -- A number that will not parse leaves the reference at 0, which resolves to
+    -- no source and no person rather than killing the load.
+    num = fromMaybe 0 (bsToIntMaybe value)
+    on element attr = case psPath state of
+        current : _ -> isElement current element && isElement name attr
+        [] -> False
+    setDocs f = state{psDocs = f (psDocs state)}
+    setSource f = setDocs (\d -> d{ddPendingSource = f (ddPendingSource d)})
+
 -- | Apply a single referenceFunction attribute to the parse state.
 setRefFunctionAttr :: BS.ByteString -> BS.ByteString -> ParseState -> ParseState
 setRefFunctionAttr name value st
@@ -244,6 +334,8 @@ setRefFunctionAttr name value st
     | isElement name "generalComment"
     , not (BS.null value) =
         st{psDescription = bsToText value : psDescription st}
+    | isElement name "includedProcesses" =
+        st{psDocs = (psDocs st){ddIncludedProcesses = bsToText value}}
     | otherwise = st
 
 -- | Apply a single exchange attribute to the in-progress exchange.
@@ -285,8 +377,40 @@ onCloseTag state tagName
     | isElement tagName "exchange" = closeExchange state
     | isElement tagName "referenceFunction" = (popElement state){psContext = Other}
     | isElement tagName "geography" = (popElement state){psContext = Other}
+    | isElement tagName "source" = closeSource state
+    | isElement tagName "person" = closePerson state
+    | isElement tagName "startYear" = closeDocText (\d t -> d{ddStartYear = t}) state
+    | isElement tagName "endYear" = closeDocText (\d t -> d{ddEndYear = t}) state
     | isElement tagName "dataset" = closeDataset state
     | otherwise = popPath state
+
+{- | Close a @\<source\>@: file it under the number the dataset gave it, so
+@referenceToPublishedSource@ can name it whichever order the two were read in.
+An unnumbered source is dropped - nothing can refer to it, and it would
+overwrite the previous one at key 0.
+-}
+closeSource :: ParseState -> ParseState
+closeSource state =
+    let docs = psDocs state
+        pending = ddPendingSource docs
+        filed
+            | s1Number pending == 0 = ddSources docs
+            | otherwise = IM.insert (s1Number pending) pending (ddSources docs)
+     in (popElement state){psDocs = docs{ddSources = filed, ddPendingSource = emptySource1}}
+
+-- | Close a @\<person\>@: file their name under their number, same as a source.
+closePerson :: ParseState -> ParseState
+closePerson state =
+    let docs = psDocs state
+        filed
+            | ddPendingPersonNumber docs == 0 = ddPersons docs
+            | otherwise = IM.insert (ddPendingPersonNumber docs) (ddPendingPersonName docs) (ddPersons docs)
+     in (popElement state){psDocs = docs{ddPersons = filed, ddPendingPersonNumber = 0, ddPendingPersonName = ""}}
+
+-- | Close an element whose documentation value is its text rather than an attribute.
+closeDocText :: (DatasetDocs -> Text -> DatasetDocs) -> ParseState -> ParseState
+closeDocText setField state =
+    (popElement state){psDocs = setField (psDocs state) (T.strip $ T.concat $ reverse $ map bsToText (psTextAccum state))}
 
 {- | Close an input/output group: fold its accumulated text into the parent
 exchange's matching group field and return to the exchange context.
@@ -387,6 +511,7 @@ resetDataset state =
         , psContext = Other
         , psTextAccum = []
         , psSupplierLinks = M.empty
+        , psDocs = emptyDatasetDocs
         }
 
 {- | Build exchange, flow, and unit from exchange data.
@@ -481,6 +606,43 @@ buildExchange activityLoc edata
             , techPedigree = Nothing
             }
 
+{- | One bibliographic line for a @\<source\>@. ecoinvent files put the
+methodological report in @titleOfAnthology@ ("ecoinvent report No. 1"), which is
+usually the piece a reader is after, so it follows the title directly.
+-}
+renderSource :: Source1 -> Text
+renderSource s = case joinParts ". " [authors, s1Title s, s1TitleOfAnthology s, publisher] of
+    "" -> ""
+    line -> line <> "."
+  where
+    authors = joinParts " " [joinParts ", " [s1FirstAuthor s, s1AdditionalAuthors s], year]
+    year = maybe "" (\y -> "(" <> y <> ")") (nonEmptyText (s1Year s))
+    publisher = joinParts ", " [s1Publisher s, s1Place s]
+
+{- | The provenance sections of one dataset, in the order a reader wants them:
+what the dataset covers, then how it was built, then where it was published and
+who vouched for it.
+-}
+documentationSections :: DatasetDocs -> [DocSection]
+documentationSections d =
+    concat
+        [ docSection "Included processes" (ddIncludedProcesses d)
+        , docSection "Geography" (ddGeography d)
+        , docSection "Technology" (ddTechnology d)
+        , docSection "Time period" (joinParts " " [years, ddTimePeriod d])
+        , docSection "Sampling procedure" (ddSampling d)
+        , docSection "Extrapolations" (ddExtrapolations d)
+        , docSection "Production volume" (ddProductionVolume d)
+        , docSection "Published in" (maybe "" renderSource publishedIn)
+        , docSection "Sources" (joinParts "\n" (map renderSource otherSources))
+        , docSection "Review" (joinParts " " [ddProofReading d, reviewer])
+        ]
+  where
+    years = joinParts "-" [ddStartYear d, ddEndYear d]
+    publishedIn = IM.lookup (ddPublishedSource d) (ddSources d)
+    otherSources = IM.elems (IM.delete (ddPublishedSource d) (ddSources d))
+    reviewer = maybe "" (\p -> "(" <> p <> ")") (IM.lookup (ddValidator d) (ddPersons d) >>= nonEmptyText)
+
 -- | Build the final per-dataset result, applying the cut-off strategy.
 buildResult :: ParseState -> Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit], Int, M.Map UUID Int)
 buildResult st =
@@ -496,7 +658,25 @@ buildResult st =
                 filter
                     (not . T.null . snd)
                     [("Category", psActivityCategory st), ("SubCategory", psActivitySubCategory st)]
-        activity = Activity name description M.empty classifications location locationSource refUnit (reverse $ psExchanges st) M.empty M.empty Nothing Nothing Nothing Nothing Nothing
+        activity =
+            Activity
+                { activityName = name
+                , activityDescription = description
+                , activityDocumentation = documentationSections (psDocs st)
+                , activitySynonyms = M.empty
+                , activityClassification = classifications
+                , activityLocation = location
+                , activityLocationSource = locationSource
+                , activityUnit = refUnit
+                , exchanges = reverse (psExchanges st)
+                , activityParams = M.empty
+                , activityParamExprs = M.empty
+                , activityAllocationPercent = Nothing
+                , activityAllocationFormula = Nothing
+                , activityNativeType = Nothing
+                , activityNativeId = Nothing
+                , activityFormulaCheck = Nothing
+                }
         pack act =
             ( act
             , reverse (psTechFlows st)

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -16,7 +16,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V5 as UUID5
-import EcoSpold.Common (bsToDouble, bsToInt, bsToIntMaybe, bsToText, isElement, nonEmptyText)
+import EcoSpold.Common (bsToDouble, bsToInt, bsToIntMaybe, bsToText, docSection, isElement, joinParts, nonEmptyText)
 import EcoSpold.Cutoff (applyCutoffStrategy)
 import qualified Expr
 import Progress (ProgressLevel (..), reportProgress)
@@ -133,6 +133,42 @@ data PendingParam = PendingParam
 emptyPendingParam :: PendingParam
 emptyPendingParam = PendingParam "" Nothing ""
 
+-- | One @\<review\>@ of the dataset: who read it, when, and what they said.
+data Review = Review
+    { rvReviewer :: !Text
+    , rvDate :: !Text
+    , rvText :: !Text
+    }
+
+emptyReview :: Review
+emptyReview = Review "" "" ""
+
+{- | The provenance a dataset states about itself, accumulated as the metadata
+elements go by. Reviews are held in reverse arrival order and flipped back at
+the end, the same way exchanges are.
+-}
+data DatasetDocs = DatasetDocs
+    { ddIncludedStart :: !Text
+    , ddIncludedEnd :: !Text
+    , ddGeography :: !Text
+    , ddTechnology :: !Text
+    , ddTimePeriod :: !Text
+    , ddStartDate :: !Text
+    , ddEndDate :: !Text
+    , ddSystemModel :: !Text
+    , ddSampling :: !Text
+    , ddExtrapolations :: !Text
+    , ddPublishedAuthor :: !Text
+    , ddPublishedYear :: !Text
+    , ddPublishedPages :: !Text
+    , ddReviews :: ![Review]
+    , ddPendingReview :: !Review -- the open <review>, filed when it closes
+    , ddTextLang :: !Text -- xml:lang of the open <text>, which is where ecospold2 puts it
+    }
+
+emptyDatasetDocs :: DatasetDocs
+emptyDatasetDocs = DatasetDocs "" "" "" "" "" "" "" "" "" "" "" "" "" [] emptyReview ""
+
 {- | Update a comment slot with a newly seen `<comment xml:lang="…">` text.
 Prefer English; otherwise keep the first non-empty entry. Empty / blank
 incoming text never overwrites an existing slot.
@@ -173,6 +209,7 @@ data ParseState = ParseState
     , psParams :: !(M.Map Text Double) -- <parameter> variableName → amount (amounts are pre-evaluated in the source)
     , psParamExprs :: !(M.Map Text Text) -- <parameter> variableName → mathematicalRelation (raw formula, for inspection)
     , psPendingParam :: !PendingParam -- attribute accumulator for the open <parameter>
+    , psDocs :: !DatasetDocs -- Provenance the dataset states about itself
     }
 
 -- | Initial parsing state
@@ -202,6 +239,7 @@ initialParseState =
         , psParams = M.empty
         , psParamExprs = M.empty
         , psPendingParam = emptyPendingParam
+        , psDocs = emptyDatasetDocs
         }
 
 {- | Build the source-native activity-type record from the ecospold2
@@ -329,6 +367,102 @@ inGeneralComment st = case psContext st of
     InGeographyShortname -> False
     Other -> False
 
+{- | Attributes of the metadata elements that carry the dataset's provenance:
+the period it covers, where it was published, who reviewed it. Routed by the
+element currently open, since the same attribute names appear in several blocks.
+-}
+docAttr :: BS.ByteString -> BS.ByteString -> ParseState -> ParseState
+docAttr name value state
+    | on "timePeriod" "startDate" = setDocs (\d -> d{ddStartDate = txt})
+    | on "timePeriod" "endDate" = setDocs (\d -> d{ddEndDate = txt})
+    | on "dataGeneratorAndPublication" "publishedSourceFirstAuthor" = setDocs (\d -> d{ddPublishedAuthor = txt})
+    | on "dataGeneratorAndPublication" "publishedSourceYear" = setDocs (\d -> d{ddPublishedYear = txt})
+    | on "dataGeneratorAndPublication" "pageNumbers" = setDocs (\d -> d{ddPublishedPages = txt})
+    | on "review" "reviewerName" = setReview (\r -> r{rvReviewer = txt})
+    | on "review" "reviewDate" = setReview (\r -> r{rvDate = txt})
+    -- ecospold2 states the language on the <text> itself, not on the <comment>
+    -- around it, which is why 'psPendingCommentLang' does not see it.
+    | on "text" "xml:lang" = setDocs (\d -> d{ddTextLang = txt})
+    | otherwise = state
+  where
+    txt = bsToText value
+    on element attr = pathAt 0 element state && isElement name attr
+    setDocs f = state{psDocs = f (psDocs state)}
+    setReview f = setDocs (\d -> d{ddPendingReview = f (ddPendingReview d)})
+
+{- | Which documentation field the element now closing belongs to, if any,
+given how far up the path the element it documents sits. ecospold2 wraps a free
+text in @\<comment\>\<text\>@ and a review's words in @\<details\>\<text\>@, so
+closing a @\<text\>@ looks two levels up; files that write the text straight
+into the @\<comment\>@ (the shape the exchange comments already accept) look
+one level up.
+-}
+docTextTarget :: Int -> ParseState -> Maybe (DatasetDocs -> Text -> DatasetDocs)
+docTextTarget depth state
+    | documents "geography" = Just (\d t -> d{ddGeography = paragraph (ddGeography d) t})
+    | documents "technology" = Just (\d t -> d{ddTechnology = paragraph (ddTechnology d) t})
+    | documents "timePeriod" = Just (\d t -> d{ddTimePeriod = paragraph (ddTimePeriod d) t})
+    | documents "review" = Just (\d t -> d{ddPendingReview = appendReview (ddPendingReview d) t})
+    | otherwise = Nothing
+  where
+    documents element = pathAt depth element state
+    appendReview r t = r{rvText = paragraph (rvText r) t}
+
+-- | Successive @\<text index="…"\>@ elements are the paragraphs of one field.
+paragraph :: Text -> Text -> Text
+paragraph existing t = joinParts "\n" [existing, t]
+
+{- | Capture a metadata text into the field it documents. A text stating a
+language other than English is skipped, the same preference 'pickComment'
+applies to exchange comments; ecospold2 states it on the @\<text\>@ when there
+is one and on the @\<comment\>@ otherwise, so the caller passes whichever it
+read.
+-}
+captureDocText :: Int -> Text -> ParseState -> ParseState
+captureDocText depth lang state = case docTextTarget depth state of
+    Just setField | lang `elem` ["", "en"] -> state{psDocs = setField (psDocs state) (accumText state)}
+    _ -> state
+
+-- | Close an element whose whole text content is one documentation field.
+closeDocText :: (DatasetDocs -> Text -> DatasetDocs) -> ParseState -> ParseState
+closeDocText setField state = popText state{psDocs = setField (psDocs state) (accumText state)}
+
+{- | Close a @\<review\>@, keeping it only when the reviewer wrote something.
+ecoinvent files also carry @[System]@ reviews whose only content is the machine
+validation log (@\<otherDetails\>@) - kilobytes of mass-balance warnings per
+dataset that no reader wants. Not reading that element is what leaves those
+reviews empty, and empty is what drops them here.
+-}
+closeReview :: ParseState -> ParseState
+closeReview state =
+    let docs = psDocs state
+        pending = ddPendingReview docs
+        kept = maybe (ddReviews docs) (const (pending : ddReviews docs)) (nonEmptyText (rvText pending))
+     in popText state{psDocs = docs{ddReviews = kept, ddPendingReview = emptyReview}}
+
+{- | The provenance sections of one dataset, in the order a reader wants them:
+what the dataset covers, then how it was built, then where it was published and
+who vouched for it.
+-}
+documentationSections :: DatasetDocs -> [DocSection]
+documentationSections d =
+    concat
+        [ docSection "Included activities" (joinParts " " [ddIncludedStart d, ddIncludedEnd d])
+        , docSection "Geography" (ddGeography d)
+        , docSection "Technology" (ddTechnology d)
+        , docSection "Time period" (joinParts " " [period, ddTimePeriod d])
+        , docSection "System model" (ddSystemModel d)
+        , docSection "Sampling procedure" (ddSampling d)
+        , docSection "Extrapolations" (ddExtrapolations d)
+        , docSection "Published in" (joinParts ", " [publishedBy, ddPublishedPages d])
+        , docSection "Review" (joinParts "\n" (map renderReview (reverse (ddReviews d))))
+        ]
+  where
+    period = joinParts " - " [ddStartDate d, ddEndDate d]
+    publishedBy = joinParts " " [ddPublishedAuthor d, parenthesised (ddPublishedYear d)]
+    renderReview r = joinParts ": " [joinParts " " [rvReviewer r, parenthesised (rvDate r)], rvText r]
+    parenthesised = maybe "" (\t -> "(" <> t <> ")") . nonEmptyText
+
 -- | Build a 'Unit', substituting placeholders for a missing unit name.
 mkUnit :: UUID -> Text -> Unit
 mkUnit uuid name
@@ -444,6 +578,10 @@ parseWithXeno xmlContent processId = do
                     state{psPendingInputGroup = "", psPendingOutputGroup = ""}
                 | isElement tagName "comment" =
                     state{psPendingCommentLang = ""}
+                | isElement tagName "text" =
+                    -- Forget the previous <text>'s language, so a text stating
+                    -- none is read as unstated rather than as its neighbour's.
+                    state{psDocs = (psDocs state){ddTextLang = ""}}
                 | isElement tagName "parameter" =
                     state{psPendingParam = emptyPendingParam}
                 | otherwise = state
@@ -517,7 +655,7 @@ parseWithXeno xmlContent processId = do
                                 state{psPendingParam = pending{ppAmount = readAmount (bsToText value)}}
                             | onParameter && isElement name "mathematicalRelation" =
                                 state{psPendingParam = pending{ppMathRel = bsToText value}}
-                            | otherwise = state
+                            | otherwise = docAttr name value state
                      in withLang captured
 
     -- End of opening tag - no action needed for SAX
@@ -544,7 +682,9 @@ parseWithXeno xmlContent processId = do
                     onExchange
                         (\d -> if pathAt 1 "intermediateExchange" state then d{idComment = pickComment (idComment d) lang txt} else d)
                         (\d -> if pathAt 1 "elementaryExchange" state then d{edComment = pickComment (edComment d) lang txt} else d)
-                        state
+                        -- A metadata comment written without a <text> child is
+                        -- captured here, before onExchange pops the path.
+                        (captureDocText 1 lang state)
              in st'{psPendingCommentLang = ""}
         | isElement tagName "shortname" && psContext state == InGeographyShortname =
             (popText state){psLocation = Just (accumText state), psContext = Other}
@@ -694,7 +834,13 @@ parseWithXeno xmlContent processId = do
                     let txt = accumText state
                         withDesc = if T.null txt then state else state{psDescription = txt : psDescription state}
                      in withDesc{psContext = Other, psTextAccum = []}
-                else popText state
+                else popText (captureDocText 2 (ddTextLang (psDocs state)) state)
+        | isElement tagName "includedActivitiesStart" = closeDocText (\d t -> d{ddIncludedStart = t}) state
+        | isElement tagName "includedActivitiesEnd" = closeDocText (\d t -> d{ddIncludedEnd = t}) state
+        | isElement tagName "systemModelName" = closeDocText (\d t -> d{ddSystemModel = t}) state
+        | isElement tagName "samplingProcedure" = closeDocText (\d t -> d{ddSampling = t}) state
+        | isElement tagName "extrapolations" = closeDocText (\d t -> d{ddExtrapolations = t}) state
+        | isElement tagName "review" = closeReview state
         | isElement tagName "name" =
             let txt = accumText state
              in if pathAt 1 "property" state
@@ -776,7 +922,25 @@ parseWithXeno xmlContent processId = do
             pairs = reverse (psExchanges st)
             formulaCheck = checkFormulas (psParams st) pairs
             -- Apply cutoff strategy to exchanges
-            activity = Activity name description M.empty (psClassifications st) location locationSource refUnit (map fst pairs) (psParams st) (psParamExprs st) Nothing Nothing nativeType Nothing formulaCheck
+            activity =
+                Activity
+                    { activityName = name
+                    , activityDescription = description
+                    , activityDocumentation = documentationSections (psDocs st)
+                    , activitySynonyms = M.empty
+                    , activityClassification = psClassifications st
+                    , activityLocation = location
+                    , activityLocationSource = locationSource
+                    , activityUnit = refUnit
+                    , exchanges = map fst pairs
+                    , activityParams = psParams st
+                    , activityParamExprs = psParamExprs st
+                    , activityAllocationPercent = Nothing
+                    , activityAllocationFormula = Nothing
+                    , activityNativeType = nativeType
+                    , activityNativeId = Nothing
+                    , activityFormulaCheck = formulaCheck
+                    }
             techs = reverse (psTechFlows st)
             bios = reverse (psBioFlows st)
             wastes = reverse (psWasteFlows st)

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -163,7 +163,7 @@ data DatasetDocs = DatasetDocs
     , ddPublishedPages :: !Text
     , ddReviews :: ![Review]
     , ddPendingReview :: !Review -- the open <review>, filed when it closes
-    , ddTextLang :: !Text -- xml:lang of the open <text>, which is where ecospold2 puts it
+    , ddElementLang :: !Text -- xml:lang of the element currently open, whichever it is
     }
 
 emptyDatasetDocs :: DatasetDocs
@@ -380,9 +380,11 @@ docAttr name value state
     | on "dataGeneratorAndPublication" "pageNumbers" = setDocs (\d -> d{ddPublishedPages = txt})
     | on "review" "reviewerName" = setReview (\r -> r{rvReviewer = txt})
     | on "review" "reviewDate" = setReview (\r -> r{rvDate = txt})
-    -- ecospold2 states the language on the <text> itself, not on the <comment>
-    -- around it, which is why 'psPendingCommentLang' does not see it.
-    | on "text" "xml:lang" = setDocs (\d -> d{ddTextLang = txt})
+    -- ecospold2 states the language on the element carrying the text, not on
+    -- the <comment> around it, which is why 'psPendingCommentLang' does not
+    -- see it. Kept for whichever element is open, since the multilingual ones
+    -- are not only the <text> children.
+    | isElement name "xml:lang" = setDocs (\d -> d{ddElementLang = txt})
     | otherwise = state
   where
     txt = bsToText value
@@ -420,12 +422,28 @@ read.
 -}
 captureDocText :: Int -> Text -> ParseState -> ParseState
 captureDocText depth lang state = case docTextTarget depth state of
-    Just setField | lang `elem` ["", "en"] -> state{psDocs = setField (psDocs state) (accumText state)}
+    Just setField | readableAsEnglish lang -> state{psDocs = setField (psDocs state) (accumText state)}
     _ -> state
 
--- | Close an element whose whole text content is one documentation field.
+{- | Is a stated language one this reader keeps? An element stating none is
+taken at its word; ecospold2 repeats a translated element once per language,
+and keeping them all would leave whichever came last.
+-}
+readableAsEnglish :: Text -> Bool
+readableAsEnglish lang = lang `elem` ["", "en"]
+
+{- | Close an element whose whole text content is one documentation field.
+
+@samplingProcedure@, @extrapolations@ and the rest state their language on
+themselves rather than on a @\<text\>@ child, and a dataset that says the same
+thing twice writes the element twice. Skipping the other languages is what
+stops the German version from replacing the English one; refusing a blank is
+what stops an empty repeat from erasing the section.
+-}
 closeDocText :: (DatasetDocs -> Text -> DatasetDocs) -> ParseState -> ParseState
-closeDocText setField state = popText state{psDocs = setField (psDocs state) (accumText state)}
+closeDocText setField state = case nonEmptyText (accumText state) of
+    Just txt | readableAsEnglish (ddElementLang (psDocs state)) -> popText state{psDocs = setField (psDocs state) txt}
+    _ -> popText state
 
 {- | Close a @\<review\>@, keeping it only when the reviewer wrote something.
 ecoinvent files also carry @[System]@ reviews whose only content is the machine
@@ -578,10 +596,6 @@ parseWithXeno xmlContent processId = do
                     state{psPendingInputGroup = "", psPendingOutputGroup = ""}
                 | isElement tagName "comment" =
                     state{psPendingCommentLang = ""}
-                | isElement tagName "text" =
-                    -- Forget the previous <text>'s language, so a text stating
-                    -- none is read as unstated rather than as its neighbour's.
-                    state{psDocs = (psDocs state){ddTextLang = ""}}
                 | isElement tagName "parameter" =
                     state{psPendingParam = emptyPendingParam}
                 | otherwise = state
@@ -597,7 +611,15 @@ parseWithXeno xmlContent processId = do
                 -- Switching context here would destroy InIntermediateExchange when classifications appear inside exchanges.
                 -- DON'T switch context for child elements (synonym, compartment, etc) - keep parent exchange context
                 | otherwise = psContext cleanState
-         in cleanState{psPath = newPath, psContext = newContext, psTextAccum = []}
+         in -- The language is forgotten at every open tag, so an element
+            -- stating none is read as unstated rather than as its
+            -- predecessor's.
+            cleanState
+                { psPath = newPath
+                , psContext = newContext
+                , psTextAccum = []
+                , psDocs = (psDocs cleanState){ddElementLang = ""}
+                }
 
     -- Attribute handler - extract attributes
     attribute state name value =
@@ -834,7 +856,7 @@ parseWithXeno xmlContent processId = do
                     let txt = accumText state
                         withDesc = if T.null txt then state else state{psDescription = txt : psDescription state}
                      in withDesc{psContext = Other, psTextAccum = []}
-                else popText (captureDocText 2 (ddTextLang (psDocs state)) state)
+                else popText (captureDocText 2 (ddElementLang (psDocs state)) state)
         | isElement tagName "includedActivitiesStart" = closeDocText (\d t -> d{ddIncludedStart = t}) state
         | isElement tagName "includedActivitiesEnd" = closeDocText (\d t -> d{ddIncludedEnd = t}) state
         | isElement tagName "systemModelName" = closeDocText (\d t -> d{ddSystemModel = t}) state

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -445,17 +445,28 @@ closeDocText setField state = case nonEmptyText (accumText state) of
     Just txt | readableAsEnglish (ddElementLang (psDocs state)) -> popText state{psDocs = setField (psDocs state) txt}
     _ -> popText state
 
-{- | Close a @\<review\>@, keeping it only when the reviewer wrote something.
-ecoinvent files also carry @[System]@ reviews whose only content is the machine
-validation log (@\<otherDetails\>@) - kilobytes of mass-balance warnings per
-dataset that no reader wants. Not reading that element is what leaves those
-reviews empty, and empty is what drops them here.
+{- | Close a @\<review\>@, keeping what a person signed and dropping what the
+database's own checker filed.
+
+ecoinvent runs an automated check and files its report as a review under the
+reviewer name @[System]@: mass-balance warnings and property deviations,
+kilobytes per dataset addressed to the build process rather than to a reader.
+Which of the two a review is cannot be read off its content - measured over
+1500 ecoinvent datasets, 488 of those machine reports are written in
+@\<details\>@ exactly like a person's, and 578 reviews signed by a named person
+carry no text at all, only who passed the dataset and when. So the reviewer's
+name is what decides, and the only other review dropped is one that says
+nothing whatsoever.
 -}
 closeReview :: ParseState -> ParseState
 closeReview state =
     let docs = psDocs state
         pending = ddPendingReview docs
-        kept = maybe (ddReviews docs) (const (pending : ddReviews docs)) (nonEmptyText (rvText pending))
+        automated = T.strip (rvReviewer pending) == "[System]"
+        saysNothing = T.null (joinParts " " [rvReviewer pending, rvDate pending, rvText pending])
+        kept
+            | automated || saysNothing = ddReviews docs
+            | otherwise = pending : ddReviews docs
      in popText state{psDocs = docs{ddReviews = kept, ddPendingReview = emptyReview}}
 
 {- | The provenance sections of one dataset, in the order a reader wants them:
@@ -850,12 +861,11 @@ parseWithXeno xmlContent processId = do
                             then addExchange wasteExchange formula (addWasteFlow wasteFlow base)
                             else addExchange bioExchange formula (addBioFlow bioFlow base)
         | isElement tagName "text" =
-            -- The generalComment <text> branch deliberately does NOT pop the path.
             if inGeneralComment state
                 then
                     let txt = accumText state
                         withDesc = if T.null txt then state else state{psDescription = txt : psDescription state}
-                     in withDesc{psContext = Other, psTextAccum = []}
+                     in (popText withDesc){psContext = Other}
                 else popText (captureDocText 2 (ddElementLang (psDocs state)) state)
         | isElement tagName "includedActivitiesStart" = closeDocText (\d t -> d{ddIncludedStart = t}) state
         | isElement tagName "includedActivitiesEnd" = closeDocText (\d t -> d{ddIncludedEnd = t}) state

--- a/src/ILCD/Parser.hs
+++ b/src/ILCD/Parser.hs
@@ -557,6 +557,7 @@ buildActivity flowInfoMap techFlowDB bioFlowDB wasteFlowDB unitDB p =
     Activity
         { activityName = iprName p
         , activityDescription = []
+        , activityDocumentation = [] -- ILCD states its provenance too; not read yet
         , activitySynonyms = M.empty
         , activityClassification = iprClassifications p
         , activityLocation = iprLocation p

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -1053,6 +1053,7 @@ convertActivityForAPI unitCfg db processId activity =
             { pfaProcessId = processIdToText db processId
             , pfaActivityName = activityName activity
             , pfaDescription = activityDescription activity
+            , pfaDocumentation = activityDocumentation activity
             , pfaSynonyms = activitySynonyms activity
             , pfaClassifications = activityClassification activity
             , pfaLocation = activityLocation activity

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -1063,6 +1063,7 @@ processBlockToActivity unitCfg gp pb@ProcessBlock{..} =
                 Activity
                     { activityName = effectiveActivityName
                     , activityDescription = descriptionLines
+                    , activityDocumentation = [] -- SimaPro states its provenance too; not read yet
                     , activitySynonyms = M.empty
                     , activityClassification =
                         M.fromList $

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -523,12 +523,30 @@ declaredLocationSource loc
     | T.null (T.strip loc) = LocationUnspecified
     | otherwise = LocationDeclared
 
+{- | One labelled section of the documentation a dataset carries about itself:
+where it was published, the technology it describes, how it was sampled, who
+reviewed it. The label is what the source format calls the section, so the
+consumer renders whatever the database happened to record rather than a fixed
+list this type would have to keep in step with five formats.
+
+Kept as an ordered list rather than a map because the order is the source's
+own reading order (what the dataset covers, then how, then who vouched for
+it), which a map would sort away.
+-}
+data DocSection = DocSection
+    { docLabel :: !Text -- What the source format calls this section ("Technology", "Published in")
+    , docText :: !Text -- Its text, already assembled from whatever fields the format spreads it over
+    }
+    deriving (Show, Eq, Generic, NFData, Store)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped DocSection)
+
 {- | Base LCA activity
 Note: ProcessId is the index in dbActivities vector, UUIDs stored in dbProcessIdTable
 -}
 data Activity = Activity
     { activityName :: !Text -- Name
     , activityDescription :: ![Text] -- General description (generalComment) by paragraphs
+    , activityDocumentation :: ![DocSection] -- Provenance the dataset states about itself, in the source's own order; empty when the format records none
     , activitySynonyms :: !(M.Map Text (S.Set Text)) -- Synonyms by language, same structure as flows
     , activityClassification :: !(M.Map Text Text) -- Classifications (ISIC, CPC, etc.)
     , activityLocation :: !Text -- Location code (e.g. FR, RER)

--- a/test/ActivityWriteHandlerSpec.hs
+++ b/test/ActivityWriteHandlerSpec.hs
@@ -499,6 +499,7 @@ milkActivity =
     Activity
         { activityName = "milk production"
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = "FR"

--- a/test/AuthorSpec.hs
+++ b/test/AuthorSpec.hs
@@ -524,6 +524,7 @@ importedActivity =
     Activity
         { activityName = "cheese production"
         , activityDescription = ["Imported from a database file, never authored."]
+        , activityDocumentation = []
         , activitySynonyms = M.singleton "en" (S.fromList ["cheese making"])
         , activityClassification = M.singleton "ISIC rev.4" "1050:Manufacture of dairy products"
         , activityLocation = "FR"
@@ -728,6 +729,7 @@ treatmentActivity =
     Activity
         { activityName = "waste oil incineration"
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = "FR"
@@ -760,6 +762,7 @@ supplierActivityAt actId prodId =
     Activity
         { activityName = "milk production"
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = "FR"

--- a/test/BM25Spec.hs
+++ b/test/BM25Spec.hs
@@ -26,6 +26,7 @@ mkActivity name loc xs =
     Activity
         { activityName = name
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = loc

--- a/test/BrightwayExcelWriterSpec.hs
+++ b/test/BrightwayExcelWriterSpec.hs
@@ -258,6 +258,7 @@ elec =
     Activity
         { activityName = "Electricity production, natural gas"
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = "GLO"

--- a/test/CopySpec.hs
+++ b/test/CopySpec.hs
@@ -275,6 +275,7 @@ supplierDB offset products =
                     Activity
                         { activityName = "supplier-of-" <> name
                         , activityDescription = []
+                        , activityDocumentation = []
                         , activitySynonyms = M.empty
                         , activityClassification = M.empty
                         , activityLocation = "GLO"

--- a/test/CrossDBActivityLinkSpec.hs
+++ b/test/CrossDBActivityLinkSpec.hs
@@ -66,6 +66,7 @@ mkActivity name loc exs =
     Activity
         { activityName = name
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = loc

--- a/test/CrossDBRegionalLCIAFixture.hs
+++ b/test/CrossDBRegionalLCIAFixture.hs
@@ -100,6 +100,7 @@ mkActivity _ loc =
     Activity
         { activityName = "act-" <> loc
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = loc

--- a/test/CrossLinkingSpec.hs
+++ b/test/CrossLinkingSpec.hs
@@ -442,6 +442,7 @@ mkActivityAt loc =
     Activity
         { activityName = "test product"
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = loc

--- a/test/DeleteSelectionSpec.hs
+++ b/test/DeleteSelectionSpec.hs
@@ -500,6 +500,7 @@ mkActivity name loc classif exs =
     Activity
         { activityName = name
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = classif
         , activityLocation = loc

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -338,6 +338,32 @@ datedPeriodXml bounds =
         , "</ecoSpold>"
         ]
 
+{- | A dataset written by an exporter that fills what it has nothing for with
+the literal @\<null\>@, as openLCA does across a third of the BAFU export.
+-}
+nullMarkerXml :: BC.ByteString
+nullMarkerXml =
+    BC.unlines
+        [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold01\">"
+        , "  <dataset number=\"11\">"
+        , "    <metaInformation>"
+        , "      <processInformation>"
+        , "        <referenceFunction name=\"null process\" category=\"c\" subCategory=\"s\" unit=\"kg\"/>"
+        , "        <geography location=\"CH\" text=\"&lt;null&gt;\"/>"
+        , "        <technology text=\"Port distances.\"/>"
+        , "      </processInformation>"
+        , "    </metaInformation>"
+        , "    <flowData>"
+        , "      <exchange number=\"11\" name=\"null product\" category=\"c\" subCategory=\"s\""
+        , "                unit=\"kg\" meanValue=\"1.0\">"
+        , "        <outputGroup>0</outputGroup>"
+        , "      </exchange>"
+        , "    </flowData>"
+        , "  </dataset>"
+        , "</ecoSpold>"
+        ]
+
 -- | The documentation section under that label, if the parser recorded one.
 sectionNamed :: Text -> Activity -> Maybe Text
 sectionNamed label act = lookup label [(docLabel s, docText s) | s <- activityDocumentation act]
@@ -391,6 +417,13 @@ spec = do
         it "names the proof reader by the person number the validation points at" $
             withDocumented $ \act ->
                 sectionNamed "Review" act `shouldBe` Just "Passed. (Niels Jungbluth)"
+
+        it "reads an exporter's null placeholder as an unfilled rubric" $
+            case parseWithXeno nullMarkerXml of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right (act, _, _, _, _, _, _) -> do
+                    sectionNamed "Geography" act `shouldBe` Nothing
+                    sectionNamed "Technology" act `shouldBe` Just "Port distances."
 
         it "records no section for a dataset that states none" $
             case parseWithXeno minimalXml of

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -313,6 +313,31 @@ documentedXml =
         , "</ecoSpold>"
         ]
 
+{- | A dataset whose only documentation is the period, stated with the bounds
+given. EcoSpold1 has two ways to write them and a real export uses both.
+-}
+datedPeriodXml :: BC.ByteString -> BC.ByteString
+datedPeriodXml bounds =
+    BC.unlines
+        [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold01\">"
+        , "  <dataset number=\"10\">"
+        , "    <metaInformation>"
+        , "      <processInformation>"
+        , "        <referenceFunction name=\"dated process\" category=\"c\" subCategory=\"s\" unit=\"kg\"/>"
+        , "        <timePeriod>" <> bounds <> "</timePeriod>"
+        , "      </processInformation>"
+        , "    </metaInformation>"
+        , "    <flowData>"
+        , "      <exchange number=\"10\" name=\"dated product\" category=\"c\" subCategory=\"s\""
+        , "                unit=\"kg\" meanValue=\"1.0\">"
+        , "        <outputGroup>0</outputGroup>"
+        , "      </exchange>"
+        , "    </flowData>"
+        , "  </dataset>"
+        , "</ecoSpold>"
+        ]
+
 -- | The documentation section under that label, if the parser recorded one.
 sectionNamed :: Text -> Activity -> Maybe Text
 sectionNamed label act = lookup label [(docLabel s, docText s) | s <- activityDocumentation act]
@@ -351,7 +376,17 @@ spec = do
 
         it "reads the period as its years followed by what the dataset says about them" $
             withDocumented $ \act ->
-                sectionNamed "Time period" act `shouldBe` Just "2023-2024 Transport modes investigated for 2023."
+                sectionNamed "Time period" act `shouldBe` Just "2023 - 2024 Transport modes investigated for 2023."
+
+        it "prefers the dates over the years when a dataset states both" $
+            case parseWithXeno (datedPeriodXml "<startYear>2000</startYear><endYear>2020</endYear><startDate>2000-01</startDate><endDate>2020-01</endDate>") of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right (act, _, _, _, _, _, _) -> sectionNamed "Time period" act `shouldBe` Just "2000-01 - 2020-01"
+
+        it "reads a period stated only as dates, the form most of a real export uses" $
+            case parseWithXeno (datedPeriodXml "<startDate>2000-01</startDate><endDate>2020-01</endDate>") of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right (act, _, _, _, _, _, _) -> sectionNamed "Time period" act `shouldBe` Just "2000-01 - 2020-01"
 
         it "names the proof reader by the person number the validation points at" $
             withDocumented $ \act ->

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -5,6 +5,7 @@ module EcoSpold1Spec (spec) where
 
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.Map.Strict as M
+import Data.Text (Text)
 import Data.UUID (nil)
 import Test.Hspec
 
@@ -22,6 +23,7 @@ emptyActivity =
     Activity
         { activityName = "Test Activity"
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = "GLO"
@@ -261,12 +263,105 @@ wasteFlowXml =
         , "</ecoSpold>"
         ]
 
+{- | Fixture carrying the provenance blocks a real export writes: two numbered
+sources of which only the second is the one the dataset was published in, a
+numbered person who proof-read it, and the free texts of the process
+information. Shaped after the ESU/BAFU and ecoinvent 2.x exports.
+-}
+documentedXml :: BC.ByteString
+documentedXml =
+    BC.unlines
+        [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold01\">"
+        , "  <dataset number=\"9\">"
+        , "    <metaInformation>"
+        , "      <processInformation>"
+        , "        <referenceFunction name=\"natural gas, liquefied\" category=\"natural gas\""
+        , "                           subCategory=\"production\" unit=\"Nm3\""
+        , "                           includedProcesses=\"Transport on a freight ship.\"/>"
+        , "        <geography location=\"KW\" text=\"not known\"/>"
+        , "        <technology text=\"Distances based on port distances.\"/>"
+        , "        <timePeriod text=\"Transport modes investigated for 2023.\">"
+        , "          <startYear>2023</startYear>"
+        , "          <endYear>2024</endYear>"
+        , "        </timePeriod>"
+        , "      </processInformation>"
+        , "      <modellingAndValidation>"
+        , "        <representativeness samplingProcedure=\"Literature.\" extrapolations=\"none\""
+        , "                            productionVolume=\"not known\"/>"
+        , "        <source number=\"1\" firstAuthor=\"Frischknecht R.\" year=\"2007\""
+        , "                title=\"Overview and Methodology\""
+        , "                titleOfAnthology=\"ecoinvent report No. 1\""
+        , "                publisher=\"Swiss Centre for LCI\" placeOfPublications=\"Duebendorf, CH\"/>"
+        , "        <source number=\"2\" firstAuthor=\"Bussa M.\" additionalAuthors=\"Jungbluth N.\""
+        , "                year=\"2025\" title=\"LCI long-distance transport of natural gas\""
+        , "                publisher=\"ESU-services Ltd.\" placeOfPublications=\"Schaffhausen, CH\"/>"
+        , "        <validation proofReadingDetails=\"Passed.\" proofReadingValidator=\"41\"/>"
+        , "      </modellingAndValidation>"
+        , "      <administrativeInformation>"
+        , "        <dataGeneratorAndPublication person=\"41\" referenceToPublishedSource=\"2\"/>"
+        , "        <person number=\"41\" name=\"Niels Jungbluth\" companyCode=\"ESU\"/>"
+        , "      </administrativeInformation>"
+        , "    </metaInformation>"
+        , "    <flowData>"
+        , "      <exchange number=\"9\" name=\"natural gas, liquefied\" category=\"natural gas\""
+        , "                subCategory=\"production\" unit=\"Nm3\" meanValue=\"1.0\">"
+        , "        <outputGroup>0</outputGroup>"
+        , "      </exchange>"
+        , "    </flowData>"
+        , "  </dataset>"
+        , "</ecoSpold>"
+        ]
+
+-- | The documentation section under that label, if the parser recorded one.
+sectionNamed :: Text -> Activity -> Maybe Text
+sectionNamed label act = lookup label [(docLabel s, docText s) | s <- activityDocumentation act]
+
+{- | Parse 'documentedXml' and hand the activity to an expectation, failing the
+example rather than the whole run when the fixture stops parsing.
+-}
+withDocumented :: (Activity -> Expectation) -> Expectation
+withDocumented k = case parseWithXeno documentedXml of
+    Left err -> expectationFailure $ "Parse failed: " ++ err
+    Right (act, _, _, _, _, _, _) -> k act
+
 -- ---------------------------------------------------------------------------
 -- Spec
 -- ---------------------------------------------------------------------------
 
 spec :: Spec
 spec = do
+    describe "dataset documentation" $ do
+        it "names the source the dataset was published in, not the first one read" $
+            withDocumented $ \act ->
+                sectionNamed "Published in" act
+                    `shouldBe` Just "Bussa M., Jungbluth N. (2025). LCI long-distance transport of natural gas. ESU-services Ltd., Schaffhausen, CH."
+
+        it "keeps the methodological report the other source names" $
+            withDocumented $ \act ->
+                sectionNamed "Sources" act
+                    `shouldBe` Just "Frischknecht R. (2007). Overview and Methodology. ecoinvent report No. 1. Swiss Centre for LCI, Duebendorf, CH."
+
+        it "reads the free texts of the process information" $
+            withDocumented $ \act -> do
+                sectionNamed "Included processes" act `shouldBe` Just "Transport on a freight ship."
+                sectionNamed "Technology" act `shouldBe` Just "Distances based on port distances."
+                sectionNamed "Geography" act `shouldBe` Just "not known"
+                sectionNamed "Sampling procedure" act `shouldBe` Just "Literature."
+
+        it "reads the period as its years followed by what the dataset says about them" $
+            withDocumented $ \act ->
+                sectionNamed "Time period" act `shouldBe` Just "2023-2024 Transport modes investigated for 2023."
+
+        it "names the proof reader by the person number the validation points at" $
+            withDocumented $ \act ->
+                sectionNamed "Review" act `shouldBe` Just "Passed. (Niels Jungbluth)"
+
+        it "records no section for a dataset that states none" $
+            case parseWithXeno minimalXml of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right (act, _, _, _, _, _, _) -> activityDocumentation act `shouldBe` []
+
     describe "generateFlowUUID" $ do
         it "produces a stable UUID for known inputs" $
             generateFlowUUID 1 "CO2" "air" "" "kg"

--- a/test/EcoSpold1WriterSpec.hs
+++ b/test/EcoSpold1WriterSpec.hs
@@ -205,7 +205,7 @@ soloDb name prodU extra techs bios wastes =
         }
   where
     ref = TechnosphereExchange prodU 1.0 kgUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing
-    act = Activity name [] M.empty M.empty "GLO" LocationDeclared "kg" (ref : extra) M.empty M.empty Nothing Nothing Nothing Nothing Nothing
+    act = Activity name [] [] M.empty M.empty "GLO" LocationDeclared "kg" (ref : extra) M.empty M.empty Nothing Nothing Nothing Nothing Nothing
 
 -- | Empty database: no activities, no flows.
 emptyDb :: SimpleDatabase
@@ -233,7 +233,7 @@ linkedDb link =
   where
     supU = supplierLink
     conU = read "33333333-0000-4000-8000-000000000001"
-    mkAct nm prodU exs = Activity nm [] M.empty M.empty "GLO" LocationDeclared "kg" (refOf prodU : exs) M.empty M.empty Nothing Nothing Nothing Nothing Nothing
+    mkAct nm prodU exs = Activity nm [] [] M.empty M.empty "GLO" LocationDeclared "kg" (refOf prodU : exs) M.empty M.empty Nothing Nothing Nothing Nothing Nothing
     refOf prodU = TechnosphereExchange prodU 1.0 kgUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing
     supplier = mkAct "aaa supplier" supU []
     -- The consumer's input consumes the supplier's product and links to it.
@@ -629,6 +629,7 @@ spec = do
                     Activity
                         "documented process"
                         ["first paragraph", "second paragraph"]
+                        []
                         M.empty
                         M.empty
                         "GLO"

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -272,6 +272,18 @@ spec = describe "per-exchange comments" $ do
                     Left err -> expectationFailure $ "Parse failed: " ++ err
                     Right (act, _, _, _, _) -> k act
 
+        it "reads the sections of a dataset whose general comment runs to several paragraphs" $
+            -- The shape four ecoinvent datasets in five have. Each paragraph of
+            -- a general comment used to leave its <text> on the element path,
+            -- so every later <text> in the file read as more general comment.
+            onDocumented $ \act -> do
+                activityDescription act
+                    `shouldBe` [ "The dataset represents the construction of one port."
+                               , "Its life time is assumed to be 100 years."
+                               ]
+                sectionNamed "Technology" act
+                    `shouldBe` Just "Conditions at the Port of Rotterdam.\nMaterial composition from Maibach et al."
+
         it "assembles the published source from the three attributes it is spread over" $
             onDocumented $ \act ->
                 sectionNamed "Published in" act `shouldBe` Just "Spielmann M. (2007), Water Transport"
@@ -289,10 +301,14 @@ spec = describe "per-exchange comments" $ do
                 sectionNamed "Sampling procedure" act `shouldBe` Just "Literature studies."
                 sectionNamed "Extrapolations" act `shouldBe` Just "none"
 
-        it "keeps a review the reviewer wrote, and drops the machine validation log" $
+        it "keeps what a person signed, whether or not they wrote anything, and drops the checker's report" $
+            -- The [System] review writes its log in <details> like a person's,
+            -- and the second person signed without writing: neither the shape
+            -- nor the presence of a text tells the two apart, only the name.
             onDocumented $ \act ->
                 sectionNamed "Review" act
-                    `shouldBe` Just "Carl Vadenbo (2012-06-29): The amounts of the exchanges were reviewed."
+                    `shouldBe` Just
+                        "Carl Vadenbo (2012-06-29): The amounts of the exchanges were reviewed.\nGregor Wernet (2014-06-03)"
 
         it "reads a comment written straight into the element, with no <text> child" $
             withFixture $ \(act, _, _, _, _) -> do
@@ -323,6 +339,10 @@ documentedXml =
     \    <activityDescription>\n\
     \      <activity id=\"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\" activityNameId=\"doc-test\" activityType=\"1\">\n\
     \        <activityName xml:lang=\"en\">port facilities construction</activityName>\n\
+    \        <generalComment>\n\
+    \          <text xml:lang=\"en\" index=\"0\">The dataset represents the construction of one port.</text>\n\
+    \          <text xml:lang=\"en\" index=\"1\">Its life time is assumed to be 100 years.</text>\n\
+    \        </generalComment>\n\
     \      </activity>\n\
     \      <geography geographyId=\"RER\"><shortname xml:lang=\"en\">RER</shortname></geography>\n\
     \      <technology technologyLevel=\"3\">\n\
@@ -354,8 +374,11 @@ documentedXml =
     \        </details>\n\
     \      </review>\n\
     \      <review reviewerName=\"[System]\" reviewDate=\"2012-06-29\">\n\
-    \        <otherDetails xml:lang=\"en\">Validation warnings: mass deficit of 22% in activity dataset.</otherDetails>\n\
+    \        <details>\n\
+    \          <text xml:lang=\"en\" index=\"0\">Validation warnings: mass deficit of 22% in activity dataset.</text>\n\
+    \        </details>\n\
     \      </review>\n\
+    \      <review reviewerName=\"Gregor Wernet\" reviewDate=\"2014-06-03\" reviewedMajorRelease=\"3\"/>\n\
     \    </modellingAndValidation>\n\
     \    <administrativeInformation>\n\
     \      <dataGeneratorAndPublication personId=\"p\" publishedSourceFirstAuthor=\"Spielmann M.\"\n\

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -262,6 +262,94 @@ spec = describe "per-exchange comments" $ do
                     activityLocation act `shouldBe` "GLO"
                     activityLocationSource act `shouldBe` LocationUnspecified
 
+    describe "dataset documentation" $ do
+        let sectionNamed label act = lookup label [(docLabel s, docText s) | s <- activityDocumentation act]
+            onDocumented k = withSystemTempDirectory "es2-docs" $ \dir -> do
+                let path = dir </> "12345678-1234-5678-9abc-123456789001_12345678-1234-5678-9abc-123456789002.spold"
+                BS.writeFile path documentedXml
+                result <- streamParseActivityAndFlowsFromFile path
+                case result of
+                    Left err -> expectationFailure $ "Parse failed: " ++ err
+                    Right (act, _, _, _, _) -> k act
+
+        it "assembles the published source from the three attributes it is spread over" $
+            onDocumented $ \act ->
+                sectionNamed "Published in" act `shouldBe` Just "Spielmann M. (2007), Water Transport"
+
+        it "reads a comment through its <text> children, in English and in order" $
+            onDocumented $ \act ->
+                sectionNamed "Technology" act
+                    `shouldBe` Just "Conditions at the Port of Rotterdam.\nMaterial composition from Maibach et al."
+
+        it "keeps a review the reviewer wrote, and drops the machine validation log" $
+            onDocumented $ \act ->
+                sectionNamed "Review" act
+                    `shouldBe` Just "Carl Vadenbo (2012-06-29): The amounts of the exchanges were reviewed."
+
+        it "reads a comment written straight into the element, with no <text> child" $
+            withFixture $ \(act, _, _, _, _) -> do
+                sectionNamed "Technology" act `shouldBe` Just "Coal-fired power plant"
+                sectionNamed "Geography" act `shouldBe` Just "Test geography"
+
+        it "reads the period as its dates followed by what the dataset says about them" $
+            withFixture $ \(act, _, _, _, _) ->
+                sectionNamed "Time period" act `shouldBe` Just "2020-01-01 - 2020-12-31 Test time period"
+
+        it "reads what the dataset includes, and how it was sampled" $
+            withFixture $ \(act, _, _, _, _) -> do
+                sectionNamed "Included activities" act `shouldBe` Just "Coal combustion Electricity generation"
+                sectionNamed "System model" act `shouldBe` Just "Test system model"
+                sectionNamed "Sampling procedure" act `shouldBe` Just "Test sampling"
+                sectionNamed "Extrapolations" act `shouldBe` Just "Test extrapolation"
+
+{- | Synthetic dataset in the shape a real ecoinvent file uses: every free text
+wrapped in @\<comment\>\<text\>@, a published source spread over three
+attributes, one review with details, and one @[System]@ review whose only
+content is the machine validation log.
+-}
+documentedXml :: BS.ByteString
+documentedXml =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+    \<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold02\">\n\
+    \  <activityDataset>\n\
+    \    <activityDescription>\n\
+    \      <activity id=\"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\" activityNameId=\"doc-test\" activityType=\"1\">\n\
+    \        <activityName xml:lang=\"en\">port facilities construction</activityName>\n\
+    \      </activity>\n\
+    \      <geography geographyId=\"RER\"><shortname xml:lang=\"en\">RER</shortname></geography>\n\
+    \      <technology technologyLevel=\"3\">\n\
+    \        <comment>\n\
+    \          <text xml:lang=\"en\" index=\"0\">Conditions at the Port of Rotterdam.</text>\n\
+    \          <text xml:lang=\"de\" index=\"1\">Bedingungen im Hafen von Rotterdam.</text>\n\
+    \          <text xml:lang=\"en\" index=\"2\">Material composition from Maibach et al.</text>\n\
+    \        </comment>\n\
+    \      </technology>\n\
+    \    </activityDescription>\n\
+    \    <flowData>\n\
+    \      <intermediateExchange id=\"ref\" unitId=\"unit-kg\" amount=\"1.0\"\n\
+    \                           intermediateExchangeId=\"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb\">\n\
+    \        <name xml:lang=\"en\">port facilities</name>\n\
+    \        <unitName xml:lang=\"en\">unit</unitName>\n\
+    \        <outputGroup>0</outputGroup>\n\
+    \      </intermediateExchange>\n\
+    \    </flowData>\n\
+    \    <modellingAndValidation>\n\
+    \      <review reviewerName=\"Carl Vadenbo\" reviewDate=\"2012-06-29\">\n\
+    \        <details>\n\
+    \          <text xml:lang=\"en\" index=\"0\">The amounts of the exchanges were reviewed.</text>\n\
+    \        </details>\n\
+    \      </review>\n\
+    \      <review reviewerName=\"[System]\" reviewDate=\"2012-06-29\">\n\
+    \        <otherDetails xml:lang=\"en\">Validation warnings: mass deficit of 22% in activity dataset.</otherDetails>\n\
+    \      </review>\n\
+    \    </modellingAndValidation>\n\
+    \    <administrativeInformation>\n\
+    \      <dataGeneratorAndPublication personId=\"p\" publishedSourceFirstAuthor=\"Spielmann M.\"\n\
+    \                                  publishedSourceYear=\"2007\" pageNumbers=\"Water Transport\"/>\n\
+    \    </administrativeInformation>\n\
+    \  </activityDataset>\n\
+    \</ecoSpold>\n"
+
 {- | Synthetic ecospold2 dataset parameterised on the activityType code and
 optional specialActivityType code. One reference output, no other exchanges.
 -}

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -281,6 +281,14 @@ spec = describe "per-exchange comments" $ do
                 sectionNamed "Technology" act
                     `shouldBe` Just "Conditions at the Port of Rotterdam.\nMaterial composition from Maibach et al."
 
+        it "keeps the English of a field the dataset repeats per language" $
+            onDocumented $ \act -> do
+                -- The German repeat comes second: taking the last one read
+                -- would answer "Literaturstudien.", and an empty repeat would
+                -- erase the rubric altogether.
+                sectionNamed "Sampling procedure" act `shouldBe` Just "Literature studies."
+                sectionNamed "Extrapolations" act `shouldBe` Just "none"
+
         it "keeps a review the reviewer wrote, and drops the machine validation log" $
             onDocumented $ \act ->
                 sectionNamed "Review" act
@@ -334,6 +342,12 @@ documentedXml =
     \      </intermediateExchange>\n\
     \    </flowData>\n\
     \    <modellingAndValidation>\n\
+    \      <representativeness systemModelId=\"m\">\n\
+    \        <samplingProcedure xml:lang=\"en\">Literature studies.</samplingProcedure>\n\
+    \        <samplingProcedure xml:lang=\"de\">Literaturstudien.</samplingProcedure>\n\
+    \        <extrapolations xml:lang=\"en\">none</extrapolations>\n\
+    \        <extrapolations xml:lang=\"de\"></extrapolations>\n\
+    \      </representativeness>\n\
     \      <review reviewerName=\"Carl Vadenbo\" reviewDate=\"2012-06-29\">\n\
     \        <details>\n\
     \          <text xml:lang=\"en\" index=\"0\">The amounts of the exchanges were reviewed.</text>\n\

--- a/test/EcoSpold2WriterSpec.hs
+++ b/test/EcoSpold2WriterSpec.hs
@@ -106,6 +106,7 @@ fixtureSimple =
         Activity
             "production of A & B <café> ☕"
             ["First fixture activity: a & b <c> — ünïcödé"]
+            []
             M.empty
             (M.fromList [("ISIC rev.4 ecoinvent", "2011:Manufacture of food products"), ("CPC", "2399: Other food products n.e.c.")])
             "GLO"
@@ -125,6 +126,7 @@ fixtureSimple =
     activityB =
         Activity
             "production of B"
+            []
             []
             M.empty
             M.empty
@@ -165,6 +167,7 @@ fixtureDupBio =
         Activity
             "production of A"
             []
+            []
             M.empty
             M.empty
             "GLO"
@@ -199,6 +202,7 @@ fixtureWithExchange ex =
     activity =
         Activity
             "adversarial activity"
+            []
             []
             M.empty
             M.empty
@@ -237,6 +241,7 @@ fixtureWithBioSynonyms =
     activity =
         Activity
             "synonym activity"
+            []
             []
             M.empty
             M.empty
@@ -284,6 +289,7 @@ fixtureWasteCoproduct =
     activity =
         Activity
             "waste and coproduct activity"
+            []
             []
             M.empty
             M.empty

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -105,6 +105,7 @@ buildFixture comp = do
         Activity
             "maker"
             []
+            []
             M.empty
             M.empty
             "GLO"

--- a/test/FuzzySpec.hs
+++ b/test/FuzzySpec.hs
@@ -17,6 +17,7 @@ mkActivity name xs =
     Activity
         { activityName = name
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = "FR"

--- a/test/GapReportSpec.hs
+++ b/test/GapReportSpec.hs
@@ -82,6 +82,7 @@ mkActivity name exs =
     Activity
         { activityName = name
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = "FR"

--- a/test/ILCDParserSpec.hs
+++ b/test/ILCDParserSpec.hs
@@ -29,6 +29,7 @@ activityWithRefExchange fid =
     Activity
         { activityName = "test"
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = "GLO"
@@ -62,6 +63,7 @@ activityWithInputExchange fid =
     Activity
         { activityName = "consumer"
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = "GLO"

--- a/test/ILCDWriterSpec.hs
+++ b/test/ILCDWriterSpec.hs
@@ -521,6 +521,7 @@ multiOutputDb =
         Activity
             nm
             []
+            []
             M.empty
             M.empty
             "GLO"
@@ -593,6 +594,7 @@ oneActivityDb bios exs =
         Activity
             { activityName = specialText
             , activityDescription = []
+            , activityDocumentation = []
             , activitySynonyms = M.empty
             , activityClassification = M.empty
             , activityLocation = "GLO"

--- a/test/JournalSpec.hs
+++ b/test/JournalSpec.hs
@@ -421,6 +421,7 @@ supplierActivity =
     Activity
         { activityName = "milk production"
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = "FR"

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -42,6 +42,7 @@ minimalActivity name loc exs =
     Activity
         { activityName = name
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = loc

--- a/test/MatrixConstructionSpec.hs
+++ b/test/MatrixConstructionSpec.hs
@@ -160,6 +160,7 @@ spec = do
                     Activity
                         { activityName = "high-canonical-unit power process"
                         , activityDescription = []
+                        , activityDocumentation = []
                         , activitySynonyms = M.empty
                         , activityClassification = M.empty
                         , activityLocation = "GLO"
@@ -234,6 +235,7 @@ spec = do
                     Activity
                         { activityName = "process with empty biosphere row"
                         , activityDescription = []
+                        , activityDocumentation = []
                         , activitySynonyms = M.empty
                         , activityClassification = M.empty
                         , activityLocation = "GLO"
@@ -303,6 +305,7 @@ spec = do
                     Activity
                         { activityName = "treatment of waste W"
                         , activityDescription = []
+                        , activityDocumentation = []
                         , activitySynonyms = M.empty
                         , activityClassification = M.empty
                         , activityLocation = "GLO"
@@ -345,6 +348,7 @@ spec = do
                     Activity
                         { activityName = "producer of Y"
                         , activityDescription = []
+                        , activityDocumentation = []
                         , activitySynonyms = M.empty
                         , activityClassification = M.empty
                         , activityLocation = "GLO"

--- a/test/MinimalCoverIntegrationSpec.hs
+++ b/test/MinimalCoverIntegrationSpec.hs
@@ -137,6 +137,7 @@ supplierDB offset =
             Activity
                 { activityName = "supplier-of-shared-product"
                 , activityDescription = []
+                , activityDocumentation = []
                 , activitySynonyms = M.empty
                 , activityClassification = M.empty
                 , activityLocation = "GLO"
@@ -216,6 +217,7 @@ consumerDB offset n =
                     Activity
                         { activityName = "consumer"
                         , activityDescription = []
+                        , activityDocumentation = []
                         , activitySynonyms = M.empty
                         , activityClassification = M.empty
                         , activityLocation = "GLO"

--- a/test/PersistenceSpec.hs
+++ b/test/PersistenceSpec.hs
@@ -406,6 +406,7 @@ milkActivity name =
     Activity
         { activityName = name
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = "FR"

--- a/test/QualityReportSpec.hs
+++ b/test/QualityReportSpec.hs
@@ -83,6 +83,7 @@ mkActivity name exs =
     Activity
         { activityName = name
         , activityDescription = ["A described activity"]
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.singleton "ISIC" "1071"
         , activityLocation = "FR"

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -83,6 +83,7 @@ mkActivity loc =
     Activity
         { activityName = "act-" <> loc
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = loc

--- a/test/RelinkMappingSpec.hs
+++ b/test/RelinkMappingSpec.hs
@@ -68,6 +68,7 @@ targetDB =
             Activity
                 { activityName = "wheat production"
                 , activityDescription = []
+                , activityDocumentation = []
                 , activitySynonyms = M.empty
                 , activityClassification = M.empty
                 , activityLocation = loc

--- a/test/SetupInfoSpec.hs
+++ b/test/SetupInfoSpec.hs
@@ -55,6 +55,7 @@ minimalActivity name exs =
     Activity
         { activityName = name
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = "GLO"

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -610,6 +610,7 @@ emissionDb comp =
         Activity
             "thing maker"
             []
+            []
             M.empty
             M.empty
             "GLO"
@@ -658,6 +659,7 @@ allocationDb =
         Activity
             "alloc maker"
             []
+            []
             M.empty
             M.empty
             "GLO"
@@ -700,6 +702,7 @@ zeroAllocationDb =
     act =
         Activity
             "zero alloc maker"
+            []
             []
             M.empty
             M.empty
@@ -747,6 +750,7 @@ commentDb ped cmt =
         Activity
             "comment maker"
             []
+            []
             M.empty
             M.empty
             "GLO"
@@ -783,6 +787,7 @@ namedDb name =
     act =
         Activity
             name
+            []
             []
             M.empty
             M.empty
@@ -850,7 +855,7 @@ guardDb alloc ntype exs =
         }
   where
     act =
-        Activity "guard maker" [] M.empty M.empty "GLO" LocationDeclared "kg" exs M.empty M.empty alloc Nothing ntype Nothing Nothing
+        Activity "guard maker" [] [] M.empty M.empty "GLO" LocationDeclared "kg" exs M.empty M.empty alloc Nothing ntype Nothing Nothing
 
 -- | The baseline guard fixture, carrying the given description paragraphs.
 describedDb :: [Text] -> SimpleDatabase

--- a/test/StrictPinSpec.hs
+++ b/test/StrictPinSpec.hs
@@ -242,6 +242,7 @@ supplierDB offset products =
                     Activity
                         { activityName = "supplier-of-" <> name
                         , activityDescription = []
+                        , activityDocumentation = []
                         , activitySynonyms = M.empty
                         , activityClassification = M.empty
                         , activityLocation = "GLO"
@@ -305,6 +306,7 @@ consumerDB offset products =
                     Activity
                         { activityName = "consumer-" <> name
                         , activityDescription = []
+                        , activityDocumentation = []
                         , activitySynonyms = M.empty
                         , activityClassification = M.empty
                         , activityLocation = "GLO"

--- a/test/WasteTreatmentSignSpec.hs
+++ b/test/WasteTreatmentSignSpec.hs
@@ -57,6 +57,7 @@ emptyActivity =
     Activity
         { activityName = ""
         , activityDescription = []
+        , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.empty
         , activityLocation = "GLO"


### PR DESCRIPTION
An EcoSpold file carries a whole dossier beside its general comment: the report it was published in, the technology and period it describes, how it was sampled, who reviewed it. The engine read none of it, so an analyst asking where a number comes from had to open the source file.

An activity now carries that dossier, and `GET /api/v1/activity/{id}` reports it as `documentation`: an ordered list of labelled sections. The label is what the source format calls the section, so a database is described in its own words rather than through a fixed list five formats would have to fit; a section a dataset left blank is not reported.

Read on a real ESU/BAFU EcoSpold 1 dataset:

```
## Published in
Bussa M., Jungbluth N., Meili C. (2021). 2021 - LCI long-dist. transp. and distrib. natural gas - Bussa. Project report. ESU-services Ltd., Schaffhausen, CH.
## Time period
2000-01 - 2020-01 Transport modes investigated for 2019.
## Review
Passed. https://esuservices-my.sharepoint.com/... (Axel Liebich, Daniel Muenter)
```

and on ecoinvent 3.9.1 `port facilities construction`:

```
## Published in
Spielmann M. (2007), Water Transport
## Review
Niels Jungbluth (2003-08-20): passed.
Roland Hischier (2011-09-23): Transfer of Documentation done.
Carl Vadenbo (2012-06-29): In preparation for the release of ecoinvent v3.0, the datasets ...
```

An EcoSpold 1 dataset numbers its sources and points at the one it was published in, which is what makes "ecoinvent report No. 1" reachable rather than merely present. EcoSpold 2 spreads the same fact over three attributes of `dataGeneratorAndPublication`.

Four things it deliberately does not do:

- The full title of an ecoinvent report lives in `MasterData/Sources.xml`, which the loader does not read, so an EcoSpold 2 dataset reports author, year and pages rather than the report's title.
- The report the ecoinvent build process files as a review under the name `[System]` is dropped: kilobytes of mass-balance warnings and property deviations per dataset, written for that process rather than for a reader. The name is what decides, because the shape does not: over 1500 datasets, 488 of those machine reports are written in `<details>` exactly like a person's, and 578 reviews signed by a named person carry no text at all. A review a person signed is kept whether or not they wrote anything beyond their name and the date.
- A field an exporter filled with its own placeholder for absence counts as blank. openLCA writes the literal `<null>`, which reaches a documentation field 6436 times in the BAFU export, 2071 of them the geography. Only the placeholder alone is read that way: "none" and "not known" are sentences a person wrote and are reported as written.
- Exporting a database does not write these sections back, the same way it has never written anything the general comment does not hold.

Review of this branch found one defect worth naming here: each paragraph of a general comment left its `<text>` on the element path, so from the second paragraph on every later `<text>` in the file read as more general comment. Four ecoinvent datasets in five are written that way, and on those the technology, the geography and the reviews arrived empty. Fixed, with the case pinned; on a 60-dataset slice of a real ecoinvent 3.9.1 export, all 38 datasets carrying a technology comment now report one.

ILCD, SimaPro and Brightway report an empty list for now. The field is format-agnostic; they fill in when their turn comes.

Measured on the ESU/BAFU export (11747 datasets, same flags, no cache): parsing 955 ms to 1.02 s, resident memory 1080 MB to 1150 MB.

The cache salt moves to 15: the `Store` layout is positional, so a cache written before this field would be misread from that field on.
