### PR TITLE
Ask for a method by name, not by collection plus UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@
   `VOLCA_PASSWORD` is read only when neither `--password` nor the file sets
   one, so it cannot rotate a password written there, and `api_access` is
   reported for whatever fronts the server rather than enforced by it.
+- Asking for a method collection that is not loaded now tells you which ones
+  are. The refusal used to read "Collection not loaded: methods" and nothing
+  more, which looks like a broken engine when it is really the wrong name: a
+  collection is named in the configuration file (`[[methods]] name`), and the
+  caller had no way to learn those names from the refusal itself. They now
+  follow on a second line, as the assistant tools already said them.
 - Startup now says which keys of the configuration file nothing reads. A
   configuration is a list of things the engine looks for, so anything it does
   not look for was dropped without a word, however it got that way: written

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,16 @@
   `VOLCA_PASSWORD` is read only when neither `--password` nor the file sets
   one, so it cannot rotate a password written there, and `api_access` is
   reported for whatever fronts the server rather than enforced by it.
+- In pyvolca, a method is asked for by name as readily as by UUID, and the
+  collection carrying it no longer has to be named: `get_impacts(pid, "Water
+  use")` now scores. `collection` lost its old default of `"methods"`, a name
+  nothing ever loads, which is why that call used to fail whatever you passed;
+  a whole-collection call (`get_impacts_batch`, `score_activities`) runs
+  against the only loaded collection. Nothing is guessed: an unknown method, a
+  name two collections carry, or several collections loaded with none named
+  raises before the request leaves, naming the candidates. Such a refusal
+  carries no HTTP status, so read the exception itself rather than
+  `status_code`.
 - Asking for a method collection that is not loaded now tells you which ones
   are. The refusal used to read "Collection not loaded: methods" and nothing
   more, which looks like a broken engine when it is really the wrong name: a

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -869,8 +869,9 @@ Each entry carries ``name``, ``displayName``, ``status``,
 List every LCIA method available in the engine.
 
 Each :class:`Method` carries ``id``, ``name``, ``category``, ``unit``,
-``factor_count``, and the parent ``collection``. Pass ``m.id`` to
-:meth:`get_impacts` as ``method_id``.
+``factor_count``, and the parent ``collection``. Every ``method_id``
+argument takes either, so this list is for browsing, not for looking
+up an id before a call.
 
 ##### `Client.list_presets()`
 
@@ -1944,10 +1945,11 @@ survive the generic camelCase→snake_case conversion.
 
 One LCIA method, returned by :meth:`Client.list_methods`.
 
-Pass ``id`` to :meth:`Client.get_impacts` as ``method_id``. ``collection``
-is the parent method collection (e.g. ``"ef-31"``), forwarded to
-:meth:`Client.get_impacts` / :meth:`Client.get_impacts_batch` as their
-``collection`` argument.
+Pass ``id`` — or ``name``, which the client resolves against the loaded
+methods — wherever a ``method_id`` is asked for. ``collection`` is the
+parent method collection (e.g. ``"ef-31"``); the client reads it off the
+resolved method, so it is worth passing to :meth:`Client.get_impacts` /
+:meth:`Client.get_impacts_batch` only to pin one of several loaded.
 
 | Field | Type | Default |
 |-------|------|---------|

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -186,11 +186,13 @@ print(f"  {inv.statistics.emission_quantity:.4g} emissions / "
 > *What's the carbon footprint of this product? Which emissions dominate the score?*
 
 ```python
-score = c.get_impacts(plants[0].process_id, method_id="EF3.1-climate-change", top_flows=5)
+score = c.get_impacts(plants[0].process_id, method_id="Climate change", top_flows=5)
 print(f"{score.score:.4g} {score.unit}")
 for c_flow in score.top_contributors:
     print(f"  {c_flow.share_pct:.1f}%  {c_flow.flow_name}")
 ```
+
+`method_id` takes a method UUID or its name: a name is resolved against the loaded methods, which also settles which collection carries it. Pass `collection=` only to pin one when several are loaded.
 
 `LCIAResult` carries the score, unit, optional `normalized_score` / `weighted_score` (in Pt), and the top contributing biosphere flows with their `share_pct`.
 
@@ -215,7 +217,7 @@ if batch.single_score is not None:
 ```python
 flows = c.get_contributing_flows(
     plants[0].process_id,
-    method_id="EF3.1-climate-change",
+    method_id="Climate change",
     limit=10,
 )
 for f in flows.top_flows:
@@ -223,7 +225,7 @@ for f in flows.top_flows:
 
 acts = c.get_contributing_activities(
     plants[0].process_id,
-    method_id="EF3.1-climate-change",
+    method_id="Climate change",
     limit=10,
 )
 for a in acts.activities:
@@ -235,7 +237,7 @@ for a in acts.activities:
 > *Which characterization factors does a method apply, and to which database flows?*
 
 ```python
-char = c.get_characterization(method_id="EF3.1-climate-change", limit=20)
+char = c.get_characterization(method_id="Climate change", limit=20)
 ```
 
 Useful for sanity-checking method coverage or building custom indicators on top of the engine's mapping.
@@ -284,7 +286,7 @@ subs = [{
     "to":   "new-supplier-pid",      # the replacement
     "consumer": "consumer-pid",      # the activity that directly uses the old supplier
 }]
-score = c.get_impacts(plants[0].process_id, method_id="EF3.1-climate-change", substitutions=subs)
+score = c.get_impacts(plants[0].process_id, method_id="Climate change", substitutions=subs)
 ```
 
 Multiple substitutions chain in one call — the `consumer` field disambiguates *where* in the chain each swap applies.
@@ -297,7 +299,7 @@ Multiple substitutions chain in one call — the `consumer` field disambiguates 
 from volca import VoLCAError
 
 try:
-    score = c.get_impacts("nonexistent-pid", method_id="EF3.1-climate-change")
+    score = c.get_impacts("nonexistent-pid", method_id="Climate change")
 except VoLCAError as e:
     print(f"  failed: {e.status_code} — {e.body[:80]}")
 ```
@@ -434,7 +436,7 @@ Returns the raw JSON (no dataclass wrapping). Use this for
 operations that don't have an ergonomic wrapper yet, or for new
 endpoints added after the installed pyvolca was released.
 
-##### `Client.compute_sensitivity(process_id: str, method_id: str, perturbations: list[dict], *, collection: str = 'methods') -> SensitivityResult`
+##### `Client.compute_sensitivity(process_id: str, method_id: str, perturbations: list[dict], *, collection: str | None = None) -> SensitivityResult`
 
 How much one impact score moves when technosphere links are perturbed.
 
@@ -665,7 +667,7 @@ a :class:`SearchResults[ConsumerResult]` (iterate it to walk every
 consumer across all pages) and whose ``edges`` attribute carries
 the traversal subgraph (empty by default).
 
-##### `Client.get_contributing_activities(process_id: str, method_id: str, *, collection: str = 'methods', limit: int | None = None) -> ContributingActivities`
+##### `Client.get_contributing_activities(process_id: str, method_id: str, *, collection: str | None = None, limit: int | None = None) -> ContributingActivities`
 
 Which upstream activities drive a given impact category.
 
@@ -673,7 +675,7 @@ Same engine-side limitation as :meth:`get_contributing_flows`: no
 total exposed, so ``has_more`` cannot be derived. Inspect
 ``share_pct`` totals to gauge coverage.
 
-##### `Client.get_contributing_flows(process_id: str, method_id: str, *, collection: str = 'methods', limit: int | None = None) -> ContributingFlows`
+##### `Client.get_contributing_flows(process_id: str, method_id: str, *, collection: str | None = None, limit: int | None = None) -> ContributingFlows`
 
 Which elementary flows drive a given impact category.
 
@@ -698,7 +700,7 @@ Get the characterization-factor-to-database-flow mapping coverage.
 biosphere flows the method has a CF for; ``flows`` is the per-flow
 breakdown including unmatched rows (``cf_value=None``).
 
-##### `Client.get_impacts(process_id: str, method_id: str, *, collection: str = 'methods', top_flows: int | None = None, substitutions: list[SubstitutionLike] | None = None) -> LCIAResult`
+##### `Client.get_impacts(process_id: str, method_id: str, *, collection: str | None = None, top_flows: int | None = None, substitutions: list[SubstitutionLike] | None = None) -> LCIAResult`
 
 Compute the LCIA score for a single impact category on an activity.
 
@@ -706,12 +708,13 @@ Use :meth:`get_impacts_batch` to retrieve every category in a method
 collection at once (and any configured scoring sets).
 
 Args:
-    collection: Method collection name. Defaults to ``"methods"`` for
-        single-method calls; most engines expose methods under a
-        single collection.
+    method_id: A method UUID, or the method's name ("Water use") —
+        a name is resolved against the engine's loaded methods.
+    collection: Method collection name. Left out, it is read off the
+        resolved method, so the caller needs to know only the method.
     top_flows: Max top contributing flows to return (default 5).
 
-##### `Client.get_impacts_batch(process_id: str, *, collection: str = 'methods', substitutions: list[SubstitutionLike] | None = None, exclude_long_term: bool | None = None) -> LCIABatchResult`
+##### `Client.get_impacts_batch(process_id: str, *, collection: str | None = None, substitutions: list[SubstitutionLike] | None = None, exclude_long_term: bool | None = None) -> LCIABatchResult`
 
 Compute LCIA for every impact category in a collection, in one call.
 
@@ -721,6 +724,9 @@ formula-based scoring sets declared in the engine config (PEF, ECS…).
 scoring set, pre-multiplied by the set's ``displayMultiplier``.
 ``exclude_long_term`` drops long-term emissions before scoring, the
 same switch :meth:`score_activities` carries.
+
+Left without a ``collection``, the call runs against the only loaded
+one, and refuses when several are loaded rather than picking one.
 
 Uses a direct HTTP call: the batch endpoint has no operationId in the
 OpenAPI spec (the dispatcher primary is the single-method variant), so
@@ -973,7 +979,7 @@ Args:
 Returns:
     ``{name: matches}`` for every input name, in input order.
 
-##### `Client.score_activities(process_ids: list[str], *, collection: str = 'methods', top_flows: int | None = None, exclude_long_term: bool | None = None) -> BatchScores`
+##### `Client.score_activities(process_ids: list[str], *, collection: str | None = None, top_flows: int | None = None, exclude_long_term: bool | None = None) -> BatchScores`
 
 Score many processes in one call (every category of a collection each).
 
@@ -982,7 +988,8 @@ Returns a :class:`BatchScores`: ``results`` holds one
 ``not_found`` / ``invalid`` list the ids it could not resolve — inspect
 them, a partial result is not an error. ``top_flows`` caps the top
 contributors per category; ``exclude_long_term`` drops long-term
-emissions from the totals.
+emissions from the totals. ``collection`` defaults to the only loaded
+one.
 
 ##### `Client.search_activities(name: str | None = None, *, geo: str | None = None, product: str | None = None, preset: str | None = None, classification: str | None = None, classification_value: str | None = None, classification_match: MatchModeLike | None = None, page: int | None = None, page_size: int | None = None, limit: int | None = None, offset: int | None = None, sort: str | None = None, order: str | None = None, exact: bool = False) -> SearchResults[Activity]`
 

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -206,6 +206,8 @@ if batch.single_score is not None:
     print(f"PEF single score: {batch.single_score:.4g} {batch.single_score_unit}")
 ```
 
+There is no method to name here, so the collection has to come from somewhere: with one loaded it is that one, and with several the call refuses and names them, rather than scoring against a collection you did not pick. Pass `collection=` to say which.
+
 `LCIABatchResult` also surfaces formula-based scoring sets (PEF, ECS…) via `scoring_results` and `scoring_indicators`, so you can render a per-indicator chart alongside the aggregate single score.
 
 ## Drill into what drives a single impact
@@ -301,10 +303,10 @@ from volca import VoLCAError
 try:
     score = c.get_impacts("nonexistent-pid", method_id="Climate change")
 except VoLCAError as e:
-    print(f"  failed: {e.status_code} — {e.body[:80]}")
+    print(f"  failed: {e}")
 ```
 
-`VoLCAError.status_code` is the HTTP status when the engine returned one; `body` is the raw response body.
+`VoLCAError.status_code` is the HTTP status when the engine returned one, and `body` the raw response body. Both are empty when the client refuses on its own, which is what happens to a method name nothing carries or a collection you had to choose: print the exception itself and you get either explanation.
 
 ## Switch databases
 
@@ -446,7 +448,9 @@ Each perturbation is a dict
 so ``-1.0`` removes the link). Returns the ``baseline`` :class:`LCIAResult`
 plus one :class:`PerturbedResult` per perturbation — each carrying
 either the perturbed impact and its delta, or an ``error`` string when
-that perturbation could not be resolved.
+that perturbation could not be resolved. ``method_id`` takes a method
+name as well as a UUID, and ``collection`` is read off the resolved
+method unless you pin it.
 
 ##### `Client.copy_database(new_name: str, db_name: str | None = None) -> dict`
 
@@ -673,7 +677,9 @@ Which upstream activities drive a given impact category.
 
 Same engine-side limitation as :meth:`get_contributing_flows`: no
 total exposed, so ``has_more`` cannot be derived. Inspect
-``share_pct`` totals to gauge coverage.
+``share_pct`` totals to gauge coverage. ``method_id`` takes a method
+name as well as a UUID, and ``collection`` is read off the resolved
+method unless you pin it.
 
 ##### `Client.get_contributing_flows(process_id: str, method_id: str, *, collection: str | None = None, limit: int | None = None) -> ContributingFlows`
 
@@ -682,7 +688,9 @@ Which elementary flows drive a given impact category.
 Returns a :class:`ContributingFlows`. Caveat: the engine does not
 report the total flow count, so pyvolca cannot derive ``has_more``
 from the response. Pass a generous ``limit`` if you need exhaustive
-coverage and inspect ``share_pct`` totals.
+coverage and inspect ``share_pct`` totals. ``method_id`` takes a method
+name as well as a UUID, and ``collection`` is read off the resolved
+method unless you pin it.
 
 ##### `Client.get_flow(flow_id: str, db_name: str | None = None) -> FlowDetail`
 
@@ -989,8 +997,9 @@ Returns a :class:`BatchScores`: ``results`` holds one
 ``not_found`` / ``invalid`` list the ids it could not resolve — inspect
 them, a partial result is not an error. ``top_flows`` caps the top
 contributors per category; ``exclude_long_term`` drops long-term
-emissions from the totals. ``collection`` defaults to the only loaded
-one.
+emissions from the totals. Left without a ``collection``, the call runs
+against the only loaded one, and refuses when several are loaded rather
+than picking one.
 
 ##### `Client.search_activities(name: str | None = None, *, geo: str | None = None, product: str | None = None, preset: str | None = None, classification: str | None = None, classification_value: str | None = None, classification_match: MatchModeLike | None = None, page: int | None = None, page_size: int | None = None, limit: int | None = None, offset: int | None = None, sort: str | None = None, order: str | None = None, exact: bool = False) -> SearchResults[Activity]`
 

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -562,6 +562,10 @@ class Client:
             )
         return hits[0].collection, hits[0].id
 
+    def _method_uuid(self, method_id: str) -> str:
+        """The UUID of a method given by UUID or name, for URLs with no collection."""
+        return self._resolve_method(method_id, None)[1]
+
     def _resolve_collection(self, collection: str | None) -> str:
         """The collection a whole-collection call runs against.
 
@@ -1979,8 +1983,9 @@ class Client:
         """List every LCIA method available in the engine.
 
         Each :class:`Method` carries ``id``, ``name``, ``category``, ``unit``,
-        ``factor_count``, and the parent ``collection``. Pass ``m.id`` to
-        :meth:`get_impacts` as ``method_id``.
+        ``factor_count``, and the parent ``collection``. Every ``method_id``
+        argument takes either, so this list is for browsing, not for looking
+        up an id before a call.
         """
         return [Method.from_json(m) for m in self._call("list_methods")]
 
@@ -1991,7 +1996,9 @@ class Client:
         biosphere flows the method has a CF for; ``flows`` is the per-flow
         breakdown including unmatched rows (``cf_value=None``).
         """
-        return FlowMapping.from_json(self._call("get_flow_mapping", method_id=method_id))
+        return FlowMapping.from_json(
+            self._call("get_flow_mapping", method_id=self._method_uuid(method_id))
+        )
 
     def get_characterization(
         self,
@@ -2007,7 +2014,12 @@ class Client:
         ``limit``). Check ``result.has_more`` to detect truncation.
         """
         return CharacterizationResult.from_json(
-            self._call("get_characterization", method_id=method_id, flow=flow, limit=limit)
+            self._call(
+                "get_characterization",
+                method_id=self._method_uuid(method_id),
+                flow=flow,
+                limit=limit,
+            )
         )
 
     def explain_cf(self, method_id: str, flow_id: str) -> ExplainCFResult:
@@ -2019,7 +2031,9 @@ class Client:
         rungs the cascade walked before the one that answered.
         """
         return ExplainCFResult.from_json(
-            self._call("explain_cf", method_id=method_id, flow_id=flow_id)
+            self._call(
+                "explain_cf", method_id=self._method_uuid(method_id), flow_id=flow_id
+            )
         )
 
     def get_contributing_flows(
@@ -2277,13 +2291,19 @@ class Client:
     def get_method(self, method_id: str) -> MethodDetail:
         """Detail of one LCIA method: unit, category, methodology, factor count."""
         return MethodDetail.from_json(
-            self._json(self._session.get(f"{self.base_url}/api/v1/method/{method_id}"))
+            self._json(
+                self._session.get(
+                    f"{self.base_url}/api/v1/method/{self._method_uuid(method_id)}"
+                )
+            )
         )
 
     def get_method_factors(self, method_id: str) -> list[MethodFactor]:
         """The characterization factors of a method (flow, direction, value)."""
         raw = self._json(
-            self._session.get(f"{self.base_url}/api/v1/method/{method_id}/factors")
+            self._session.get(
+                f"{self.base_url}/api/v1/method/{self._method_uuid(method_id)}/factors"
+            )
         )
         return [MethodFactor.from_json(f) for f in raw]
 
@@ -2299,7 +2319,8 @@ class Client:
         return MappingStatus.from_json(
             self._json(
                 self._session.get(
-                    f"{self.base_url}/api/v1/db/{target}/method/{method_id}/mapping"
+                    f"{self.base_url}/api/v1/db/{target}"
+                    f"/method/{self._method_uuid(method_id)}/mapping"
                 )
             )
         )

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -40,6 +40,7 @@ variants in the Servant API.
 from __future__ import annotations
 
 import urllib.parse
+import uuid
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
@@ -120,6 +121,15 @@ def _snake_to_camel(s: str) -> str:
 def _snake_to_kebab(s: str) -> str:
     """``min_quantity`` → ``min-quantity``."""
     return s.replace("_", "-")
+
+
+def _is_uuid(s: str) -> bool:
+    """Whether ``s`` is a UUID, the only method id the engine's URLs accept."""
+    try:
+        uuid.UUID(s)
+    except ValueError:
+        return False
+    return True
 
 
 def _candidate_wire_names(py_name: str) -> list[str]:
@@ -427,6 +437,10 @@ class Client:
         # gates (_require_wire) don't refetch it.
         self._checked = False
         self._server_wire: int | None = None
+        # Loaded methods, fetched on the first call that has to resolve a
+        # method or a collection (see _resolve_method). Dropped whenever this
+        # client loads or unloads a collection.
+        self._methods_cache: list[Method] | None = None
 
     # -- Spec / dispatch plumbing --
 
@@ -494,6 +508,81 @@ class Client:
         self._operations = _parse_spec(spec)
         from . import _stub_gen
         _stub_gen.write_stubs_for_spec(spec)
+
+    # -- Method resolution --
+    #
+    # Every LCIA URL carries a collection *and* a method: the engine keys its
+    # CF caches by collection, since one UUID can live in several. Callers
+    # rarely know or care which collection carries "Water use", so these two
+    # helpers answer it from the engine instead of making the caller guess.
+
+    def _loaded_methods(self, refresh: bool = False) -> list[Method]:
+        """Every method the engine has loaded, cached on the client."""
+        if refresh or self._methods_cache is None:
+            self._methods_cache = self.list_methods()
+        return self._methods_cache
+
+    def _resolve_method(
+        self, method_id: str, collection: str | None
+    ) -> tuple[str, str]:
+        """Map a method UUID *or name* to the ``(collection, uuid)`` a URL needs.
+
+        A UUID with an explicit collection is passed straight through — no
+        lookup, no round-trip. Anything else is matched against the engine's
+        loaded methods, which is what lets ``get_impacts(pid, "Water use")``
+        work without the caller knowing the collection. An unknown or
+        ambiguous name is an error naming the candidates, never a guess.
+        """
+        if collection is not None and _is_uuid(method_id):
+            return collection, method_id
+
+        def match(methods: list[Method]) -> list[Method]:
+            return [
+                m
+                for m in methods
+                if (m.id == method_id or m.name.casefold() == method_id.casefold())
+                and (collection is None or m.collection == collection)
+            ]
+
+        hits = match(self._loaded_methods())
+        if not hits:
+            # A collection may have been loaded since we last looked.
+            hits = match(self._loaded_methods(refresh=True))
+        if not hits:
+            where = "" if collection is None else f" in collection {collection!r}"
+            raise VoLCAError(
+                f"No loaded method named or identified by {method_id!r}{where}. "
+                "See list_methods()."
+            )
+        if len({(m.collection, m.id) for m in hits}) > 1:
+            candidates = ", ".join(sorted(f"{m.collection}/{m.id}" for m in hits))
+            raise VoLCAError(
+                f"{method_id!r} matches several loaded methods ({candidates}). "
+                "Pass collection= or the method id."
+            )
+        return hits[0].collection, hits[0].id
+
+    def _resolve_collection(self, collection: str | None) -> str:
+        """The collection a whole-collection call runs against.
+
+        With a single collection loaded there is nothing to choose; with
+        several, the choice is the caller's, and refusing names them rather
+        than picking one.
+        """
+        if collection is not None:
+            return collection
+        names = sorted({m.collection for m in self._loaded_methods()})
+        if len(names) == 1:
+            return names[0]
+        if not names:
+            raise VoLCAError(
+                "No method collection loaded. See list_method_collections() "
+                "and load_method_collection()."
+            )
+        raise VoLCAError(
+            f"Several method collections are loaded ({', '.join(names)}); "
+            "pass collection= to choose one."
+        )
 
     def _call(
         self,
@@ -1752,7 +1841,7 @@ class Client:
         process_id: str,
         method_id: str,
         *,
-        collection: str = "methods",
+        collection: str | None = None,
         top_flows: int | None = None,
         substitutions: list[SubstitutionLike] | None = None,
     ) -> LCIAResult:
@@ -1762,11 +1851,13 @@ class Client:
         collection at once (and any configured scoring sets).
 
         Args:
-            collection: Method collection name. Defaults to ``"methods"`` for
-                single-method calls; most engines expose methods under a
-                single collection.
+            method_id: A method UUID, or the method's name ("Water use") —
+                a name is resolved against the engine's loaded methods.
+            collection: Method collection name. Left out, it is read off the
+                resolved method, so the caller needs to know only the method.
             top_flows: Max top contributing flows to return (default 5).
         """
+        collection, method_id = self._resolve_method(method_id, collection)
         return LCIAResult.from_json(
             self._call(
                 "get_impacts",
@@ -1782,7 +1873,7 @@ class Client:
         self,
         process_id: str,
         *,
-        collection: str = "methods",
+        collection: str | None = None,
         substitutions: list[SubstitutionLike] | None = None,
         exclude_long_term: bool | None = None,
     ) -> LCIABatchResult:
@@ -1795,6 +1886,9 @@ class Client:
         ``exclude_long_term`` drops long-term emissions before scoring, the
         same switch :meth:`score_activities` carries.
 
+        Left without a ``collection``, the call runs against the only loaded
+        one, and refuses when several are loaded rather than picking one.
+
         Uses a direct HTTP call: the batch endpoint has no operationId in the
         OpenAPI spec (the dispatcher primary is the single-method variant), so
         this wrapper bypasses ``_call`` and builds the URL itself.
@@ -1803,6 +1897,7 @@ class Client:
             raise VoLCAError(
                 "get_impacts_batch requires a database; construct Client(db=...)."
             )
+        collection = self._resolve_collection(collection)
         url = (
             f"{self.base_url}/api/v1/db/{self.db}/activity/{process_id}"
             f"/impacts/{collection}"
@@ -1826,7 +1921,7 @@ class Client:
         method_id: str,
         perturbations: list[dict],
         *,
-        collection: str = "methods",
+        collection: str | None = None,
     ) -> SensitivityResult:
         """How much one impact score moves when technosphere links are perturbed.
 
@@ -1838,6 +1933,7 @@ class Client:
         either the perturbed impact and its delta, or an ``error`` string when
         that perturbation could not be resolved.
         """
+        collection, method_id = self._resolve_method(method_id, collection)
         return SensitivityResult.from_json(
             self._call(
                 "compute_sensitivity",
@@ -1852,7 +1948,7 @@ class Client:
         self,
         process_ids: list[str],
         *,
-        collection: str = "methods",
+        collection: str | None = None,
         top_flows: int | None = None,
         exclude_long_term: bool | None = None,
     ) -> BatchScores:
@@ -1863,8 +1959,10 @@ class Client:
         ``not_found`` / ``invalid`` list the ids it could not resolve — inspect
         them, a partial result is not an error. ``top_flows`` caps the top
         contributors per category; ``exclude_long_term`` drops long-term
-        emissions from the totals.
+        emissions from the totals. ``collection`` defaults to the only loaded
+        one.
         """
+        collection = self._resolve_collection(collection)
         return BatchScores.from_json(
             self._call(
                 "score_activities",
@@ -1929,7 +2027,7 @@ class Client:
         process_id: str,
         method_id: str,
         *,
-        collection: str = "methods",
+        collection: str | None = None,
         limit: int | None = None,
     ) -> ContributingFlows:
         """Which elementary flows drive a given impact category.
@@ -1939,6 +2037,7 @@ class Client:
         from the response. Pass a generous ``limit`` if you need exhaustive
         coverage and inspect ``share_pct`` totals.
         """
+        collection, method_id = self._resolve_method(method_id, collection)
         return ContributingFlows.from_json(
             self._call(
                 "get_contributing_flows",
@@ -1954,7 +2053,7 @@ class Client:
         process_id: str,
         method_id: str,
         *,
-        collection: str = "methods",
+        collection: str | None = None,
         limit: int | None = None,
     ) -> ContributingActivities:
         """Which upstream activities drive a given impact category.
@@ -1963,6 +2062,7 @@ class Client:
         total exposed, so ``has_more`` cannot be derived. Inspect
         ``share_pct`` totals to gauge coverage.
         """
+        collection, method_id = self._resolve_method(method_id, collection)
         return ContributingActivities.from_json(self._call(
             "get_contributing_activities",
             process_id=process_id,
@@ -1993,6 +2093,7 @@ class Client:
         payload = self._json(
             self._session.post(f"{self.base_url}/api/v1/method-collections/{name}/load")
         )
+        self._methods_cache = None
         return self._require_success(payload, "load_method_collection")
 
     def unload_method_collection(self, name: str) -> dict:
@@ -2002,6 +2103,7 @@ class Client:
                 f"{self.base_url}/api/v1/method-collections/{name}/unload"
             )
         )
+        self._methods_cache = None
         return self._require_success(payload, "unload_method_collection")
 
     def delete_method_collection(self, name: str) -> dict:
@@ -2009,6 +2111,7 @@ class Client:
         payload = self._json(
             self._session.delete(f"{self.base_url}/api/v1/method-collections/{name}")
         )
+        self._methods_cache = None
         return self._require_success(payload, "delete_method_collection")
 
     def upload_method_collection(

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -124,12 +124,17 @@ def _snake_to_kebab(s: str) -> str:
 
 
 def _is_uuid(s: str) -> bool:
-    """Whether ``s`` is a UUID, the only method id the engine's URLs accept."""
+    """Whether ``s`` is a UUID written the way the engine's URLs accept it.
+
+    Canonical dashed form only: Python also reads ``{...}``, ``urn:uuid:...``
+    and the undashed 32 characters, which the engine's parser refuses, and
+    letting those through would send the caller a 400 from the far end
+    instead of a message naming what is wrong.
+    """
     try:
-        uuid.UUID(s)
-    except ValueError:
+        return str(uuid.UUID(s)) == s.casefold()
+    except (ValueError, AttributeError, TypeError):
         return False
-    return True
 
 
 def _candidate_wire_names(py_name: str) -> list[str]:
@@ -438,9 +443,11 @@ class Client:
         self._checked = False
         self._server_wire: int | None = None
         # Loaded methods, fetched on the first call that has to resolve a
-        # method or a collection (see _resolve_method). Dropped whenever this
-        # client loads or unloads a collection.
-        self._methods_cache: list[Method] | None = None
+        # method or a collection (see _resolve_method), emptied whenever a
+        # collection is loaded or unloaded. Emptied and refilled in place,
+        # never rebound: methods belong to the engine, not to a database, so
+        # the clones use() hands out share this one list and one invalidation.
+        self._methods_cache: list[Method] = []
 
     # -- Spec / dispatch plumbing --
 
@@ -517,9 +524,16 @@ class Client:
     # helpers answer it from the engine instead of making the caller guess.
 
     def _loaded_methods(self, refresh: bool = False) -> list[Method]:
-        """Every method the engine has loaded, cached on the client."""
-        if refresh or self._methods_cache is None:
-            self._methods_cache = self.list_methods()
+        """Every method the engine has loaded, cached on the client.
+
+        Empty means "not looked yet", so an engine that answered nothing once
+        is asked again rather than refusing every later call for the life of
+        the client.
+        """
+        # ponytail: no lock, so a thread fan-out warming a cold cache repeats
+        # the request rather than waiting; add one if the extra GETs ever show.
+        if refresh or not self._methods_cache:
+            self._methods_cache[:] = self.list_methods()
         return self._methods_cache
 
     def _resolve_method(
@@ -533,19 +547,29 @@ class Client:
         work without the caller knowing the collection. An unknown or
         ambiguous name is an error naming the candidates, never a guess.
         """
+        if not isinstance(method_id, str):
+            raise VoLCAError(
+                "method_id must be a method UUID or a method name, got "
+                f"{type(method_id).__name__}."
+            )
         if collection is not None and _is_uuid(method_id):
             return collection, method_id
+
+        needle = method_id.strip().casefold()
 
         def match(methods: list[Method]) -> list[Method]:
             return [
                 m
                 for m in methods
-                if (m.id == method_id or m.name.casefold() == method_id.casefold())
+                # The engine writes UUIDs in lower case and reads them in
+                # either, so an id is compared the way a name is.
+                if (m.id.casefold() == needle or m.name.casefold() == needle)
                 and (collection is None or m.collection == collection)
             ]
 
+        warm = bool(self._methods_cache)
         hits = match(self._loaded_methods())
-        if not hits:
+        if not hits and warm:
             # A collection may have been loaded since we last looked.
             hits = match(self._loaded_methods(refresh=True))
         if not hits:
@@ -558,12 +582,19 @@ class Client:
             candidates = ", ".join(sorted(f"{m.collection}/{m.id}" for m in hits))
             raise VoLCAError(
                 f"{method_id!r} matches several loaded methods ({candidates}). "
-                "Pass collection= or the method id."
+                "Pass collection= to choose one."
             )
         return hits[0].collection, hits[0].id
 
     def _method_uuid(self, method_id: str) -> str:
-        """The UUID of a method given by UUID or name, for URLs with no collection."""
+        """The UUID of a method given by UUID or name, for URLs with no collection.
+
+        A UUID goes straight to the URL: these routes look a method up across
+        every loaded collection themselves, so resolving here would only add a
+        round-trip and turn the engine's own answer into a client-side refusal.
+        """
+        if _is_uuid(method_id):
+            return method_id
         return self._resolve_method(method_id, None)[1]
 
     def _resolve_collection(self, collection: str | None) -> str:
@@ -580,8 +611,8 @@ class Client:
             return names[0]
         if not names:
             raise VoLCAError(
-                "No method collection loaded. See list_method_collections() "
-                "and load_method_collection()."
+                "No loaded collection carries a method. See "
+                "list_method_collections() and load_method_collection()."
             )
         raise VoLCAError(
             f"Several method collections are loaded ({', '.join(names)}); "
@@ -1935,7 +1966,9 @@ class Client:
         so ``-1.0`` removes the link). Returns the ``baseline`` :class:`LCIAResult`
         plus one :class:`PerturbedResult` per perturbation — each carrying
         either the perturbed impact and its delta, or an ``error`` string when
-        that perturbation could not be resolved.
+        that perturbation could not be resolved. ``method_id`` takes a method
+        name as well as a UUID, and ``collection`` is read off the resolved
+        method unless you pin it.
         """
         collection, method_id = self._resolve_method(method_id, collection)
         return SensitivityResult.from_json(
@@ -1963,8 +1996,9 @@ class Client:
         ``not_found`` / ``invalid`` list the ids it could not resolve — inspect
         them, a partial result is not an error. ``top_flows`` caps the top
         contributors per category; ``exclude_long_term`` drops long-term
-        emissions from the totals. ``collection`` defaults to the only loaded
-        one.
+        emissions from the totals. Left without a ``collection``, the call runs
+        against the only loaded one, and refuses when several are loaded rather
+        than picking one.
         """
         collection = self._resolve_collection(collection)
         return BatchScores.from_json(
@@ -2049,7 +2083,9 @@ class Client:
         Returns a :class:`ContributingFlows`. Caveat: the engine does not
         report the total flow count, so pyvolca cannot derive ``has_more``
         from the response. Pass a generous ``limit`` if you need exhaustive
-        coverage and inspect ``share_pct`` totals.
+        coverage and inspect ``share_pct`` totals. ``method_id`` takes a method
+        name as well as a UUID, and ``collection`` is read off the resolved
+        method unless you pin it.
         """
         collection, method_id = self._resolve_method(method_id, collection)
         return ContributingFlows.from_json(
@@ -2074,7 +2110,9 @@ class Client:
 
         Same engine-side limitation as :meth:`get_contributing_flows`: no
         total exposed, so ``has_more`` cannot be derived. Inspect
-        ``share_pct`` totals to gauge coverage.
+        ``share_pct`` totals to gauge coverage. ``method_id`` takes a method
+        name as well as a UUID, and ``collection`` is read off the resolved
+        method unless you pin it.
         """
         collection, method_id = self._resolve_method(method_id, collection)
         return ContributingActivities.from_json(self._call(
@@ -2107,7 +2145,7 @@ class Client:
         payload = self._json(
             self._session.post(f"{self.base_url}/api/v1/method-collections/{name}/load")
         )
-        self._methods_cache = None
+        self._methods_cache.clear()
         return self._require_success(payload, "load_method_collection")
 
     def unload_method_collection(self, name: str) -> dict:
@@ -2117,7 +2155,7 @@ class Client:
                 f"{self.base_url}/api/v1/method-collections/{name}/unload"
             )
         )
-        self._methods_cache = None
+        self._methods_cache.clear()
         return self._require_success(payload, "unload_method_collection")
 
     def delete_method_collection(self, name: str) -> dict:
@@ -2125,7 +2163,7 @@ class Client:
         payload = self._json(
             self._session.delete(f"{self.base_url}/api/v1/method-collections/{name}")
         )
-        self._methods_cache = None
+        self._methods_cache.clear()
         return self._require_success(payload, "delete_method_collection")
 
     def upload_method_collection(

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -1289,10 +1289,11 @@ class Substitution:
 class Method(FromJson):
     """One LCIA method, returned by :meth:`Client.list_methods`.
 
-    Pass ``id`` to :meth:`Client.get_impacts` as ``method_id``. ``collection``
-    is the parent method collection (e.g. ``"ef-31"``), forwarded to
-    :meth:`Client.get_impacts` / :meth:`Client.get_impacts_batch` as their
-    ``collection`` argument.
+    Pass ``id`` — or ``name``, which the client resolves against the loaded
+    methods — wherever a ``method_id`` is asked for. ``collection`` is the
+    parent method collection (e.g. ``"ef-31"``); the client reads it off the
+    resolved method, so it is worth passing to :meth:`Client.get_impacts` /
+    :meth:`Client.get_impacts_batch` only to pin one of several loaded.
     """
 
     id: str

--- a/pyvolca/tests/test_detail_lookups.py
+++ b/pyvolca/tests/test_detail_lookups.py
@@ -4,21 +4,17 @@ from __future__ import annotations
 
 import pytest
 
-from volca.types import CollectionCoverage, FlowDetail, MappingStatus, Method, MethodDetail, MethodFactor
+from volca.types import CollectionCoverage, FlowDetail, MappingStatus, MethodDetail, MethodFactor
+
+# A method id travels the URL as a UUID; the client resolves anything else
+# against the engine's loaded methods first.
+_M1 = "00000000-0000-0000-0000-000000000001"
 
 
 def _resp(session_attr, json_body: dict) -> None:
     from tests.conftest import _make_response
 
     session_attr.return_value = _make_response(json_body)
-
-
-def _knows_m1(client) -> None:
-    """Seed the loaded methods so a method_id needs no lookup round-trip."""
-    client._methods_cache = [
-        Method(id="m1", name="Climate change", category="Climate", unit="kg CO2 eq",
-               factor_count=200, collection="EF3.1")
-    ]
 
 
 class TestFlowDetail:
@@ -45,9 +41,8 @@ class TestMethodDetail:
     def test_method_detail_optional_fields(self, mocked_client):
         client, session = mocked_client
         _resp(session.get, {"id": "m1", "name": "Climate change", "unit": "kg CO2 eq", "category": "Climate", "factorCount": 200})
-        _knows_m1(client)
-        out = client.get_method("m1")
-        assert session.get.call_args[0][0] == "http://test.local/api/v1/method/m1"
+        out = client.get_method(_M1)
+        assert session.get.call_args[0][0] == f"http://test.local/api/v1/method/{_M1}"
         assert isinstance(out, MethodDetail)
         assert out.factor_count == 200
         assert out.description is None and out.methodology is None
@@ -55,9 +50,8 @@ class TestMethodDetail:
     def test_method_factors_parsed(self, mocked_client):
         client, session = mocked_client
         _resp(session.get, [{"flowRef": "f1", "flowName": "CO2", "direction": "Output", "value": 1.0}])
-        _knows_m1(client)
-        out = client.get_method_factors("m1")
-        assert session.get.call_args[0][0] == "http://test.local/api/v1/method/m1/factors"
+        out = client.get_method_factors(_M1)
+        assert session.get.call_args[0][0] == f"http://test.local/api/v1/method/{_M1}/factors"
         assert isinstance(out[0], MethodFactor)
         assert out[0].flow_ref == "f1" and out[0].value == 1.0
 
@@ -79,9 +73,8 @@ class TestMappingStatus:
             "uniqueDbFlowsMatched": 75,
             "unmappedFlows": [{"flowRef": "f9", "flowName": "Unobtanium", "direction": "Input"}],
         })
-        _knows_m1(client)
-        out = client.get_mapping_status("m1")
-        assert session.get.call_args[0][0] == "http://test.local/api/v1/db/testdb/method/m1/mapping"
+        out = client.get_mapping_status(_M1)
+        assert session.get.call_args[0][0] == f"http://test.local/api/v1/db/testdb/method/{_M1}/mapping"
         assert isinstance(out, MappingStatus)
         assert out.mapped_by_uuid == 40
         assert out.mapped_by_cas == 20

--- a/pyvolca/tests/test_detail_lookups.py
+++ b/pyvolca/tests/test_detail_lookups.py
@@ -4,13 +4,21 @@ from __future__ import annotations
 
 import pytest
 
-from volca.types import CollectionCoverage, FlowDetail, MappingStatus, MethodDetail, MethodFactor
+from volca.types import CollectionCoverage, FlowDetail, MappingStatus, Method, MethodDetail, MethodFactor
 
 
 def _resp(session_attr, json_body: dict) -> None:
     from tests.conftest import _make_response
 
     session_attr.return_value = _make_response(json_body)
+
+
+def _knows_m1(client) -> None:
+    """Seed the loaded methods so a method_id needs no lookup round-trip."""
+    client._methods_cache = [
+        Method(id="m1", name="Climate change", category="Climate", unit="kg CO2 eq",
+               factor_count=200, collection="EF3.1")
+    ]
 
 
 class TestFlowDetail:
@@ -37,6 +45,7 @@ class TestMethodDetail:
     def test_method_detail_optional_fields(self, mocked_client):
         client, session = mocked_client
         _resp(session.get, {"id": "m1", "name": "Climate change", "unit": "kg CO2 eq", "category": "Climate", "factorCount": 200})
+        _knows_m1(client)
         out = client.get_method("m1")
         assert session.get.call_args[0][0] == "http://test.local/api/v1/method/m1"
         assert isinstance(out, MethodDetail)
@@ -46,6 +55,7 @@ class TestMethodDetail:
     def test_method_factors_parsed(self, mocked_client):
         client, session = mocked_client
         _resp(session.get, [{"flowRef": "f1", "flowName": "CO2", "direction": "Output", "value": 1.0}])
+        _knows_m1(client)
         out = client.get_method_factors("m1")
         assert session.get.call_args[0][0] == "http://test.local/api/v1/method/m1/factors"
         assert isinstance(out[0], MethodFactor)
@@ -69,6 +79,7 @@ class TestMappingStatus:
             "uniqueDbFlowsMatched": 75,
             "unmappedFlows": [{"flowRef": "f9", "flowName": "Unobtanium", "direction": "Input"}],
         })
+        _knows_m1(client)
         out = client.get_mapping_status("m1")
         assert session.get.call_args[0][0] == "http://test.local/api/v1/db/testdb/method/m1/mapping"
         assert isinstance(out, MappingStatus)

--- a/pyvolca/tests/test_dispatch.py
+++ b/pyvolca/tests/test_dispatch.py
@@ -468,44 +468,103 @@ class TestMethodResolution:
 
     def test_name_resolves_to_its_collection_and_id(self, mocked_client, make_response):
         client, session = mocked_client
-        client._methods_cache = [_method("Water use", "EF3.1")]
+        client._methods_cache[:] = [_method("Water use", "EF3.1")]
         session.get.return_value = make_response(_minimal_lcia_result())
         client.get_impacts("abc_def", method_id="water USE")
         assert session.get.call_args[0][0].endswith(f"/impacts/EF3.1/{_WATER_USE_ID}")
 
     def test_unknown_method_never_reaches_the_engine(self, mocked_client, make_response):
         client, session = mocked_client
-        client._methods_cache = [_method("Water use", "EF3.1")]
+        client._methods_cache[:] = [_method("Water use", "EF3.1")]
         session.get.return_value = make_response([])
         with pytest.raises(VoLCAError, match="No loaded method"):
             client.get_impacts("abc_def", method_id="EF3.1-water-use")
 
     def test_same_name_in_two_collections_refuses_to_guess(self, mocked_client):
         client, _ = mocked_client
-        client._methods_cache = [
+        client._methods_cache[:] = [
             _method("Water use", "EF3.1"),
             _method("Water use", "EF3.0", id="00000000-0000-0000-0000-000000000003"),
         ]
         with pytest.raises(VoLCAError, match="matches several loaded methods"):
             client.get_impacts("abc_def", method_id="Water use")
 
+    def test_a_uuid_reaches_a_collection_less_url_without_a_lookup(self, mocked_client, make_response):
+        """These routes search every collection themselves; asking first would
+        only add a round-trip and turn their answer into a client refusal."""
+        client, session = mocked_client
+        session.get.return_value = make_response({"id": _WATER_USE_ID, "name": "Water use", "unit": "m3", "category": "Water use", "factorCount": 1})
+        client.get_method(_WATER_USE_ID)
+        assert session.get.call_count == 1
+        assert session.get.call_args[0][0].endswith(f"/api/v1/method/{_WATER_USE_ID}")
+
+    def test_an_upper_case_uuid_resolves_like_the_engine_reads_it(self, mocked_client, make_response):
+        client, session = mocked_client
+        client._methods_cache[:] = [_method("Water use", "EF3.1")]
+        session.get.return_value = make_response(_minimal_lcia_result())
+        client.get_impacts("abc_def", method_id=_WATER_USE_ID.upper())
+        assert session.get.call_args[0][0].endswith(f"/impacts/EF3.1/{_WATER_USE_ID}")
+
+    def test_a_uuid_the_engine_cannot_read_is_not_forwarded(self, mocked_client, make_response):
+        """Python reads urn: and brace forms the engine's parser refuses."""
+        client, session = mocked_client
+        client._methods_cache[:] = [_method("Water use", "EF3.1")]
+        session.get.return_value = make_response([])
+        with pytest.raises(VoLCAError, match="No loaded method"):
+            client.get_impacts("abc_def", method_id=f"urn:uuid:{_WATER_USE_ID}", collection="EF3.1")
+        assert not [c for c in session.get.call_args_list if "/impacts/" in c[0][0]]
+
+    def test_a_method_id_that_is_not_text_says_so(self, mocked_client):
+        client, _ = mocked_client
+        with pytest.raises(VoLCAError, match="must be a method UUID or a method name"):
+            client.get_impacts("abc_def", method_id=None)
+
+    def test_a_cold_cache_is_read_once_before_refusing(self, mocked_client, make_response):
+        client, session = mocked_client
+        session.get.return_value = make_response([])
+        with pytest.raises(VoLCAError, match="No loaded method"):
+            client.get_impacts("abc_def", method_id="Water use")
+        assert session.get.call_count == 1
+
+    def test_an_empty_answer_is_not_kept(self, mocked_client, make_response):
+        """An engine still loading must not silence the client for good."""
+        client, session = mocked_client
+        session.get.side_effect = [
+            make_response([]),
+            make_response([{"id": _WATER_USE_ID, "name": "Water use", "category": "Water use", "unit": "m3", "factorCount": 1, "collection": "EF3.1"}]),
+            make_response({"results": []}),
+        ]
+        with pytest.raises(VoLCAError, match="No loaded collection carries a method"):
+            client.get_impacts_batch("abc_def")
+        client.get_impacts_batch("abc_def")
+        assert session.get.call_args[0][0].endswith("/impacts/EF3.1")
+
+    def test_a_clone_shares_the_lookup_and_its_invalidation(self, mocked_client, make_response):
+        client, session = mocked_client
+        client._methods_cache[:] = [_method("Water use", "EF3.1")]
+        other = client.use("otherdb")
+        _resp = make_response({"success": True, "message": "loaded"})
+        session.post.return_value = _resp
+        other.load_method_collection("EF3.0")
+        assert client._methods_cache == []
+
     def test_a_url_without_a_collection_still_takes_a_name(self, mocked_client, make_response):
         client, session = mocked_client
-        client._methods_cache = [_method("Water use", "EF3.1")]
+        client._methods_cache[:] = [_method("Water use", "EF3.1")]
         session.get.return_value = make_response({"id": _WATER_USE_ID, "name": "Water use", "unit": "m3", "category": "Water use", "factorCount": 1})
         client.get_method("Water use")
         assert session.get.call_args[0][0].endswith(f"/api/v1/method/{_WATER_USE_ID}")
 
     def test_batch_uses_the_only_loaded_collection(self, mocked_client, make_response):
         client, session = mocked_client
-        client._methods_cache = [_method("Water use", "EF3.1")]
+        client._methods_cache[:] = [_method("Water use", "EF3.1")]
         session.get.return_value = make_response({"results": [_minimal_lcia_result()]})
         client.get_impacts_batch("abc_def")
         assert session.get.call_args[0][0].endswith("/impacts/EF3.1")
 
     def test_batch_refuses_to_choose_between_collections(self, mocked_client):
         client, _ = mocked_client
-        client._methods_cache = [
+        client._methods_cache[:] = [
             _method("Water use", "EF3.1"),
             _method("Land use", "plain-indicators", id="00000000-0000-0000-0000-000000000004"),
         ]
@@ -515,7 +574,7 @@ class TestMethodResolution:
     def test_a_miss_refetches_before_giving_up(self, mocked_client, make_response):
         """A collection loaded since the client last looked must still be seen."""
         client, session = mocked_client
-        client._methods_cache = []
+        client._methods_cache.clear()
         session.get.side_effect = [
             make_response([
                 {

--- a/pyvolca/tests/test_dispatch.py
+++ b/pyvolca/tests/test_dispatch.py
@@ -10,6 +10,16 @@ from __future__ import annotations
 import pytest
 
 from volca.client import Client, VoLCAError, _candidate_wire_names, _Operation, _parse_spec, _resolve_wire_name
+from volca.types import Method
+
+_WATER_USE_ID = "00000000-0000-0000-0000-000000000002"
+
+
+def _method(name: str, collection: str, id: str = _WATER_USE_ID) -> Method:
+    """One loaded method, as :meth:`Client.list_methods` would return it."""
+    return Method(
+        id=id, name=name, category=name, unit="m3", factor_count=1, collection=collection
+    )
 
 
 def _minimal_lcia_result() -> dict:
@@ -295,9 +305,9 @@ class TestDispatcher:
     def test_get_impacts_uses_all_four_path_captures(self, mocked_client, make_response):
         client, session = mocked_client
         session.get.return_value = make_response(_minimal_lcia_result())
-        result = client.get_impacts("abc_def", method_id="method-uuid", collection="EF3.1")
+        result = client.get_impacts("abc_def", method_id=_WATER_USE_ID, collection="EF3.1")
         called_url = session.get.call_args[0][0]
-        assert called_url == "http://test.local/api/v1/db/testdb/activity/abc_def/impacts/EF3.1/method-uuid"
+        assert called_url == f"http://test.local/api/v1/db/testdb/activity/abc_def/impacts/EF3.1/{_WATER_USE_ID}"
         assert result.score == 1.23
 
     def test_substitutions_upgrade_to_post(self, mocked_client, make_response):
@@ -305,7 +315,8 @@ class TestDispatcher:
         session.post.return_value = make_response(_minimal_lcia_result())
         client.get_impacts(
             "abc_def",
-            method_id="method-uuid",
+            method_id=_WATER_USE_ID,
+            collection="EF3.1",
             substitutions=[{"from": "a", "to": "b", "consumer": "c"}],
         )
         session.post.assert_called_once()
@@ -351,6 +362,7 @@ class TestDispatcher:
         })
         client.get_impacts_batch(
             "abc_def",
+            collection="EF3.1",
             substitutions=[{"from": "a", "to": "b", "consumer": "c"}],
         )
         session.post.assert_called_once()
@@ -374,17 +386,18 @@ class TestDispatcher:
             "scoringIndicators": {},
         }
         session.get.return_value = make_response(empty)
-        client.get_impacts_batch("abc_def", exclude_long_term=True)
+        client.get_impacts_batch("abc_def", collection="EF3.1", exclude_long_term=True)
         assert session.get.call_args[1]["params"] == {"exclude-long-term": "true"}
 
         # Left unsaid, the engine keeps its own default: no query parameter at all.
         session.get.return_value = make_response(empty)
-        client.get_impacts_batch("abc_def")
+        client.get_impacts_batch("abc_def", collection="EF3.1")
         assert session.get.call_args[1]["params"] == {}
 
         session.post.return_value = make_response(empty)
         client.get_impacts_batch(
             "abc_def",
+            collection="EF3.1",
             substitutions=[{"from": "a", "to": "b", "consumer": "c"}],
             exclude_long_term=True,
         )
@@ -448,3 +461,66 @@ class TestDispatcher:
         params = dict(session.get.call_args[1]["params"])
         assert params.get("is_input") == "true"
         assert params.get("max_depth") == "2"
+
+
+class TestMethodResolution:
+    """A caller knows the method; which collection carries it is the engine's business."""
+
+    def test_name_resolves_to_its_collection_and_id(self, mocked_client, make_response):
+        client, session = mocked_client
+        client._methods_cache = [_method("Water use", "EF3.1")]
+        session.get.return_value = make_response(_minimal_lcia_result())
+        client.get_impacts("abc_def", method_id="water USE")
+        assert session.get.call_args[0][0].endswith(f"/impacts/EF3.1/{_WATER_USE_ID}")
+
+    def test_unknown_method_never_reaches_the_engine(self, mocked_client, make_response):
+        client, session = mocked_client
+        client._methods_cache = [_method("Water use", "EF3.1")]
+        session.get.return_value = make_response([])
+        with pytest.raises(VoLCAError, match="No loaded method"):
+            client.get_impacts("abc_def", method_id="EF3.1-water-use")
+
+    def test_same_name_in_two_collections_refuses_to_guess(self, mocked_client):
+        client, _ = mocked_client
+        client._methods_cache = [
+            _method("Water use", "EF3.1"),
+            _method("Water use", "EF3.0", id="00000000-0000-0000-0000-000000000003"),
+        ]
+        with pytest.raises(VoLCAError, match="matches several loaded methods"):
+            client.get_impacts("abc_def", method_id="Water use")
+
+    def test_batch_uses_the_only_loaded_collection(self, mocked_client, make_response):
+        client, session = mocked_client
+        client._methods_cache = [_method("Water use", "EF3.1")]
+        session.get.return_value = make_response({"results": [_minimal_lcia_result()]})
+        client.get_impacts_batch("abc_def")
+        assert session.get.call_args[0][0].endswith("/impacts/EF3.1")
+
+    def test_batch_refuses_to_choose_between_collections(self, mocked_client):
+        client, _ = mocked_client
+        client._methods_cache = [
+            _method("Water use", "EF3.1"),
+            _method("Land use", "plain-indicators", id="00000000-0000-0000-0000-000000000004"),
+        ]
+        with pytest.raises(VoLCAError, match="Several method collections"):
+            client.get_impacts_batch("abc_def")
+
+    def test_a_miss_refetches_before_giving_up(self, mocked_client, make_response):
+        """A collection loaded since the client last looked must still be seen."""
+        client, session = mocked_client
+        client._methods_cache = []
+        session.get.side_effect = [
+            make_response([
+                {
+                    "id": _WATER_USE_ID,
+                    "name": "Water use",
+                    "category": "Water use",
+                    "unit": "m3",
+                    "factorCount": 1,
+                    "collection": "EF3.1",
+                }
+            ]),
+            make_response(_minimal_lcia_result()),
+        ]
+        client.get_impacts("abc_def", method_id="Water use")
+        assert session.get.call_args[0][0].endswith(f"/impacts/EF3.1/{_WATER_USE_ID}")

--- a/pyvolca/tests/test_dispatch.py
+++ b/pyvolca/tests/test_dispatch.py
@@ -489,6 +489,13 @@ class TestMethodResolution:
         with pytest.raises(VoLCAError, match="matches several loaded methods"):
             client.get_impacts("abc_def", method_id="Water use")
 
+    def test_a_url_without_a_collection_still_takes_a_name(self, mocked_client, make_response):
+        client, session = mocked_client
+        client._methods_cache = [_method("Water use", "EF3.1")]
+        session.get.return_value = make_response({"id": _WATER_USE_ID, "name": "Water use", "unit": "m3", "category": "Water use", "factorCount": 1})
+        client.get_method("Water use")
+        assert session.get.call_args[0][0].endswith(f"/api/v1/method/{_WATER_USE_ID}")
+
     def test_batch_uses_the_only_loaded_collection(self, mocked_client, make_response):
         client, session = mocked_client
         client._methods_cache = [_method("Water use", "EF3.1")]

--- a/pyvolca/tests/test_sensitivity_scoring.py
+++ b/pyvolca/tests/test_sensitivity_scoring.py
@@ -12,6 +12,10 @@ import pytest
 
 from volca.types import BatchScores, SensitivityResult
 
+# A method id travels the URL as a UUID; anything else is a name the client
+# resolves against the engine first (see TestMethodResolution).
+_METHOD_ID = "00000000-0000-0000-0000-000000000001"
+
 
 def _lcia(score: float) -> dict:
     return {
@@ -45,13 +49,14 @@ class TestComputeSensitivity:
         )
         result = client.compute_sensitivity(
             "proc_a",
-            "method-uuid",
+            _METHOD_ID,
             [{"consumer": "c", "supplier": "s", "delta": -0.05, "label": "cut"}],
+            collection="methods",
         )
         session.post.assert_called_once()
         session.get.assert_not_called()
         url = session.post.call_args[0][0]
-        assert url == "http://test.local/api/v1/db/testdb/activity/proc_a/sensitivity/methods/method-uuid"
+        assert url == f"http://test.local/api/v1/db/testdb/activity/proc_a/sensitivity/methods/{_METHOD_ID}"
         assert session.post.call_args[1]["json"] == {
             "perturbations": [{"consumer": "c", "supplier": "s", "delta": -0.05, "label": "cut"}]
         }
@@ -75,7 +80,9 @@ class TestScoreActivities:
                 "invalid": ["bogus"],
             }
         )
-        result = client.score_activities(["p1", "p2", "p3"], top_flows=5, exclude_long_term=True)
+        result = client.score_activities(
+            ["p1", "p2", "p3"], collection="methods", top_flows=5, exclude_long_term=True
+        )
         session.post.assert_called_once()
         session.get.assert_not_called()
         assert session.post.call_args[0][0] == "http://test.local/api/v1/db/testdb/impacts/methods"
@@ -92,7 +99,7 @@ class TestScoreActivities:
     def test_optional_query_params_omitted_by_default(self, mocked_client, make_response):
         client, session = mocked_client
         session.post.return_value = make_response({"results": [], "notFound": [], "invalid": []})
-        client.score_activities(["p1"])
+        client.score_activities(["p1"], collection="methods")
         params = dict(session.post.call_args[1]["params"])
         assert "top-flows" not in params
         assert "exclude-long-term" not in params

--- a/src/API/BatchImpacts.hs
+++ b/src/API/BatchImpacts.hs
@@ -159,13 +159,16 @@ loadedCollectionNames dbm = M.keys <$> readTVarIO (dmLoadedMethods dbm)
 
 The match is by HTTP status + body prefix. The prefix constants are
 imported from "API.Routes" so the throw site and the translator move
-together; changing one without the other breaks compilation here.
+together; changing one without the other breaks compilation here. The
+collection body names the loaded collections on a second line
+('API.Routes.collectionNotLoadedBody'), so only its first line is the
+requested name.
 -}
 translateError :: [Text] -> ServerError -> BatchError
 translateError availableCollections se
     | code == 404
     , Just rest <- T.stripPrefix collectionNotLoadedPrefix body =
-        CollectionNotLoaded rest availableCollections
+        CollectionNotLoaded (T.takeWhile (/= '\n') rest) availableCollections
     | code == 404
     , Just rest <- T.stripPrefix databaseNotLoadedPrefix body =
         DatabaseNotLoaded rest

--- a/src/API/BatchImpacts.hs
+++ b/src/API/BatchImpacts.hs
@@ -158,11 +158,12 @@ loadedCollectionNames dbm = M.keys <$> readTVarIO (dmLoadedMethods dbm)
 {- | Translate a Servant 'ServerError' back to the typed 'BatchError' sum.
 
 The match is by HTTP status + body prefix. The prefix constants are
-imported from "API.Routes" so the throw site and the translator move
-together; changing one without the other breaks compilation here. The
-collection body names the loaded collections on a second line
-('API.Routes.collectionNotLoadedBody'), so only its first line is the
-requested name.
+imported from "API.Routes", so a renamed prefix breaks compilation here
+rather than drifting. The rest of the shape is a convention the compiler
+cannot hold: the collection body names the loaded collections on a
+second line ('API.Routes.collectionNotLoadedMessage'), so only its first
+line is the requested name. What actually guards that is 'BatchImpactsSpec',
+which writes a message with that function and parses it with this one.
 -}
 translateError :: [Text] -> ServerError -> BatchError
 translateError availableCollections se

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -42,6 +42,7 @@ import qualified API.BatchImpacts as BI
 import API.DatabaseHandlers (coverageReportToAPI, editReportToAPI, explainCFToAPI, gapReportToAPI, loadQuotaRefusal, qualityReportToAPI)
 import API.MCP.Columnar (resolveSingleScoringSet, toColumnarBatch)
 import API.MCP.Enrich (addWebUrlMaybe, attachMarketHintByName, encodeSegment, filterScoringSets, scoreActivityWebUrl, slimLCIAPanel, webUrlField)
+import API.Routes (collectionNotLoadedMessage)
 import API.Types (ActivityForAPI (..), ActivityInfo (..), ClassificationSystem (..), ExchangeEditRequest (..), ExchangeWithUnit (..), InventoryExport (..), InventoryFlowDetail (..), Perturbation (..), Substitution (..), SubstitutionRequest (..), toExchangeEdits)
 import Control.Monad (unless, when)
 import qualified Data.List as L
@@ -2057,11 +2058,7 @@ callListGeographies dbManager rid args = runTool rid $ do
 -- | Translate a 'BI.BatchError' into the MCP 'toolError' payload.
 batchErrorMsg :: BI.BatchError -> Text
 batchErrorMsg err = case err of
-    BI.CollectionNotLoaded name available ->
-        "Collection not loaded: "
-            <> name
-            <> ". Available collections: "
-            <> T.intercalate ", " available
+    BI.CollectionNotLoaded name available -> collectionNotLoadedMessage name available
     BI.DatabaseNotLoaded name -> "Database not loaded: " <> name
     BI.ActivityResolutionFailed msg -> msg
     BI.LinkingIncomplete msg -> msg
@@ -2187,14 +2184,7 @@ callListScoringSets dbManager rid args = do
         Right Nothing -> return $ toolSuccessJson rid (encodeAll loaded)
         Right (Just collName) -> case M.lookup collName loaded of
             Nothing ->
-                return $
-                    toolError
-                        rid
-                        ( "Collection not loaded: "
-                            <> collName
-                            <> ". Available collections: "
-                            <> T.intercalate ", " (M.keys loaded)
-                        )
+                return $ toolError rid (collectionNotLoadedMessage collName (M.keys loaded))
             Just mc -> return $ toolSuccessJson rid (encodeAll (M.singleton collName mc))
   where
     encodeAll :: M.Map Text MethodCollection -> Value

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -223,6 +223,21 @@ collectionNotLoadedPrefix = "Collection not loaded: "
 notLoadedBody :: Text -> Text -> BSL.ByteString
 notLoadedBody prefix name = BSL.fromStrict (T.encodeUtf8 (prefix <> name))
 
+{- | 404 body for a collection that is not loaded, naming the ones that are on
+a second line. A caller on plain HTTP has no other way to learn what to ask
+for, and the MCP path already says it ('API.MCP.batchErrorMsg'). The first
+line ends at the requested name, which is what 'API.BatchImpacts.translateError'
+reads back.
+-}
+collectionNotLoadedBody :: Text -> [Text] -> BSL.ByteString
+collectionNotLoadedBody name loaded =
+    BSL.fromStrict . T.encodeUtf8 $
+        collectionNotLoadedPrefix <> name <> "\nAvailable collections: " <> available
+  where
+    available
+        | null loaded = "none loaded"
+        | otherwise = T.intercalate ", " loaded
+
 -- | Get database by name, throw 404 if not loaded
 requireDatabaseByName :: Text -> AppM (Database, SharedSolver)
 requireDatabaseByName dbName = do
@@ -531,7 +546,7 @@ loadCollection collectionName = do
     loadedCollections <- liftIO $ readTVarIO (dmLoadedMethods dbManager)
     case M.lookup collectionName loadedCollections of
         Just mc -> return (mcMethods mc, mcDamageCategories mc, mcNormWeightSets mc, mcScoringSets mc)
-        Nothing -> throwError err404{errBody = notLoadedBody collectionNotLoadedPrefix collectionName}
+        Nothing -> throwError err404{errBody = collectionNotLoadedBody collectionName (M.keys loadedCollections)}
 
 {- | Cross-DB inventory solution for an activity. 'Nothing' takes the cached
 no-substitution path ('requireFullyLinked' runs inside 'solutionWithDeps');
@@ -902,7 +917,7 @@ batchImpactsH dbName collectionName topFlowsParam ltMode req = do
     loadedCollections <- liftIO $ readTVarIO (dmLoadedMethods dbManager)
     collection <- case M.lookup collectionName loadedCollections of
         Just mc -> pure mc
-        Nothing -> throwError err404{errBody = notLoadedBody collectionNotLoadedPrefix collectionName}
+        Nothing -> throwError err404{errBody = collectionNotLoadedBody collectionName (M.keys loadedCollections)}
     let resolved =
             [ (pidText, Service.resolveActivityAndProcessId db pidText)
             | pidText <- birProcessIds req

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -215,28 +215,35 @@ from the wire body without the two ends silently drifting apart.
 databaseNotLoadedPrefix :: Text
 databaseNotLoadedPrefix = "Database not loaded: "
 
--- | Same idea for "collection not loaded" 404 bodies.
+-- | Same idea for "collection not loaded" bodies and messages.
 collectionNotLoadedPrefix :: Text
 collectionNotLoadedPrefix = "Collection not loaded: "
 
--- | Build the 404 body for a not-loaded database / collection by name.
-notLoadedBody :: Text -> Text -> BSL.ByteString
-notLoadedBody prefix name = BSL.fromStrict (T.encodeUtf8 (prefix <> name))
+-- | Build the 404 body for a database that is not loaded.
+databaseNotLoadedBody :: Text -> BSL.ByteString
+databaseNotLoadedBody name = BSL.fromStrict (T.encodeUtf8 (databaseNotLoadedPrefix <> name))
 
-{- | 404 body for a collection that is not loaded, naming the ones that are on
-a second line. A caller on plain HTTP has no other way to learn what to ask
-for, and the MCP path already says it ('API.MCP.batchErrorMsg'). The first
-line ends at the requested name, which is what 'API.BatchImpacts.translateError'
-reads back.
+{- | What every surface says when a collection is not loaded: the name asked
+for, then the ones that are, since a caller cannot guess names that come from
+the operator's configuration file. The one wording, used by the HTTP body
+below and by the MCP messages ('API.MCP.batchErrorMsg',
+'API.MCP.callListScoringSets'), so a single refusal does not read three ways.
+
+The names go on a second line because 'API.BatchImpacts.translateError' reads
+the first one back as the requested name; 'BatchImpactsSpec' builds a message
+here and parses it there, which is what keeps the two halves honest.
 -}
-collectionNotLoadedBody :: Text -> [Text] -> BSL.ByteString
-collectionNotLoadedBody name loaded =
-    BSL.fromStrict . T.encodeUtf8 $
-        collectionNotLoadedPrefix <> name <> "\nAvailable collections: " <> available
+collectionNotLoadedMessage :: Text -> [Text] -> Text
+collectionNotLoadedMessage name loaded =
+    collectionNotLoadedPrefix <> name <> "\nAvailable collections: " <> available
   where
     available
         | null loaded = "none loaded"
         | otherwise = T.intercalate ", " loaded
+
+-- | The same message as a 404 body.
+collectionNotLoadedBody :: Text -> [Text] -> BSL.ByteString
+collectionNotLoadedBody name = BSL.fromStrict . T.encodeUtf8 . collectionNotLoadedMessage name
 
 -- | Get database by name, throw 404 if not loaded
 requireDatabaseByName :: Text -> AppM (Database, SharedSolver)
@@ -245,7 +252,7 @@ requireDatabaseByName dbName = do
     maybeLoaded <- liftIO $ getDatabase dbManager dbName
     case maybeLoaded of
         Just loaded -> return (ldDatabase loaded, ldSharedSolver loaded)
-        Nothing -> throwError err404{errBody = notLoadedBody databaseNotLoadedPrefix dbName}
+        Nothing -> throwError err404{errBody = databaseNotLoadedBody dbName}
 
 {- | Refuse LCIA when the DB still has unresolved cross-DB products. Forces
 the user to load the missing dep DBs (or POST {} to /relink) rather than

--- a/test/BatchImpactsSpec.hs
+++ b/test/BatchImpactsSpec.hs
@@ -19,7 +19,7 @@ Two layers :
 module BatchImpactsSpec (spec) where
 
 import API.BatchImpacts (BatchError (..), runActivityLCIABatch, runBatchImpacts)
-import API.Routes (collectionNotLoadedBody)
+import API.Routes (collectionNotLoadedMessage)
 import Config (defaultConfig)
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Text.Encoding as TE
@@ -52,10 +52,13 @@ spec = do
             translateError' ["a", "b"] 404 "Collection not loaded: EF-3.1"
                 `shouldBe` CollectionNotLoaded "EF-3.1" ["a", "b"]
 
-        it "reads the name off the real body, which also names the loaded collections" $
-            let body = TE.decodeUtf8 (BSL.toStrict (collectionNotLoadedBody "methods" ["EF-3.1", "plain-indicators"]))
-             in translateError' ["EF-3.1", "plain-indicators"] 404 body
-                    `shouldBe` CollectionNotLoaded "methods" ["EF-3.1", "plain-indicators"]
+        it "reads the name off the real message, which also names the loaded collections" $
+            translateError' ["EF-3.1", "plain-indicators"] 404 (collectionNotLoadedMessage "methods" ["EF-3.1", "plain-indicators"])
+                `shouldBe` CollectionNotLoaded "methods" ["EF-3.1", "plain-indicators"]
+
+        it "reads it back the same way when nothing is loaded" $
+            translateError' [] 404 (collectionNotLoadedMessage "methods" [])
+                `shouldBe` CollectionNotLoaded "methods" []
 
         it "maps 404 + 'Database not loaded: X' to DatabaseNotLoaded" $
             translateError' [] 404 "Database not loaded: agribalyse"

--- a/test/BatchImpactsSpec.hs
+++ b/test/BatchImpactsSpec.hs
@@ -19,6 +19,7 @@ Two layers :
 module BatchImpactsSpec (spec) where
 
 import API.BatchImpacts (BatchError (..), runActivityLCIABatch, runBatchImpacts)
+import API.Routes (collectionNotLoadedBody)
 import Config (defaultConfig)
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Text.Encoding as TE
@@ -50,6 +51,11 @@ spec = do
         it "maps 404 + 'Collection not loaded: X' to CollectionNotLoaded" $
             translateError' ["a", "b"] 404 "Collection not loaded: EF-3.1"
                 `shouldBe` CollectionNotLoaded "EF-3.1" ["a", "b"]
+
+        it "reads the name off the real body, which also names the loaded collections" $
+            let body = TE.decodeUtf8 (BSL.toStrict (collectionNotLoadedBody "methods" ["EF-3.1", "plain-indicators"]))
+             in translateError' ["EF-3.1", "plain-indicators"] 404 body
+                    `shouldBe` CollectionNotLoaded "methods" ["EF-3.1", "plain-indicators"]
 
         it "maps 404 + 'Database not loaded: X' to DatabaseNotLoaded" $
             translateError' [] 404 "Database not loaded: agribalyse"


### PR DESCRIPTION
Scoring one activity meant knowing two things before the first call: the UUID of the method, and the name of the collection carrying it. pyvolca defaulted that second argument to `methods`, a name nothing ever loads, so the plain call

    c.get_impacts(pid, method_id=...)

always came back `404 Collection not loaded: methods`, and the refusal did not say which collections were loaded. A caller with the right method and no idea of the collection had nowhere to go.

Two changes, one on each side.

**The engine names the collections it has.** The 404 body now carries them on a second line, as the assistant tools already did from the same state. The first line still ends at the requested name, which is what `translateError` reads back into `CollectionNotLoaded`; a test builds the body with the real function so the two ends cannot drift.

**pyvolca reads the collection off the method.** `collection` defaults to nothing, and `method_id` takes a method name as well as a UUID: the name is matched against the engine's loaded methods, and the collection comes with the match. So this works, whatever collection carries it:

    c.get_impacts(pid, method_id="Water use", substitutions=subs)

Whole-collection calls (batch, scoring) run against the only loaded collection. Nothing is guessed: an unknown method, a name carried by two collections, or several collections loaded with none named all raise and name the candidates. The lookup is cached per client, refetched once on a miss so a collection loaded elsewhere since is still found, and dropped when the client itself loads or unloads one.

The same resolution covers the method URLs that carry no collection (method detail, factors, mapping status, characterization, explain_cf), so a name works everywhere a method id is asked for rather than on half the calls.

Checked against a running engine: a name with no collection scores, a substitution scores, a wrong collection answers `Collection not loaded: methods / Available collections: plain-indicators`, and an invented method is refused client-side before any request.