### PR TITLE
Delete the wire table that no code kept honest

### DIFF
--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -18,13 +18,6 @@ Requires Python ≥ 3.10 and a running VoLCA engine. Use `Server` (below) to run
 
 pyvolca speaks a range of revisions of the engine's JSON wire format; the engine advertises its revision as `wireVersion` on `/api/v1/version`. pyvolca checks it the first time it talks to the engine: too old fails with a clear error, newer than this client knows warns, and a capability that needs a newer wire than the engine speaks refuses to run instead of letting the engine misread the request. pyvolca and engine version numbers move independently: `wireVersion` carries compatibility, not the version numbers.
 
-| pyvolca | wire | compatible engine |
-|---------|------|-------------------|
-| `0.5.x` | (pre-`wireVersion`) | `v0.5.0` … `v0.7.x` |
-| `0.6.0` … `0.7.1` | `1` | `v0.8.0` … `v0.9.0` |
-| `0.7.2` … `0.8.1` | `2` | `≥ v0.9.1` |
-| `> 0.8.1` | `2` … `4` | `≥ v0.9.1` (delete by ids: `≥ v0.9.3`; quality reports: `≥ v0.9.4`) |
-
 <!-- BEGIN: compatibility -->
 
 _Generated from `volca._compat`: run `python scripts/gen_api_md.py` to regenerate._


### PR DESCRIPTION
The README's Compatibility section stated the same fact twice: a hand-written table, then the block generated from `volca._compat`.

The two disagreed. The table said this pyvolca speaks wires `2 … 4` and stopped naming versions at 0.8.1; `KNOWN_WIRE` is 8, and the generated block six lines below already said "wire formats 2 to 8". A reader who gated on the table would conclude that `edit_exchanges`, which needs wire 7, was unavailable.

Re-syncing the numbers would just restart the same drift: nothing tested that table. The generated block is guarded by `test_compat_doc_drift`, and the per-capability engine minimums ("Needs an engine >= v0.9.5") already live in each method's docstring, which is where a reader meets the capability.

`pytest`: 292 passed, 7 skipped. `gen_api_md.py --check`: clean.