### PR TITLE
Read a biosphere flow named in words as the one already declared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,19 @@
   instead of "This instance is read-only", naming who to talk to about it.
 
 ### Changed
+- A biosphere exchange that names its flow in words now reaches the flow the
+  database already declares under that name and compartment, instead of always
+  creating one. Writing an emission the way an inventory shows it, `Nitrogen,
+  total` in water, used to mint a second flow of that name; no characterization
+  method knows that new flow, so the emission scored as zero beside the curated
+  one it was meant to be. Only a flow identifier reached the curated flow, and
+  nothing in a written inventory shows identifiers. A name nothing answers to
+  still brings a flow into the database, with the warning it always carried,
+  and a name two flows answer to is refused with both identifiers so the
+  exchange can name the one it means. Two flows of one name recorded in
+  different units, an energy carrier in kg and in MJ, are told apart by the
+  unit the exchange states. The refusal for a name written into the identifier
+  field now says where identifiers come from and how a name is written instead.
 - The shipped `volca.toml` names the settings it never mentioned: `[hosting]`
   and its nine limits, `chem-synonyms`, `substance-edges`, `[server] name`,
   and the three method fields that carry a single score (`scoring`, `patches`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,15 @@
   different units, an energy carrier in kg and in MJ, are told apart by the
   unit the exchange states. The refusal for a name written into the identifier
   field now says where identifiers come from and how a name is written instead.
+  A biosphere line reads back with its flow's identifier as well, so a line
+  whose words cannot address one flow can still be restated from what the read
+  hands back.
+  This changes what a database written before now means. Its journal records
+  what the author wrote, not what it resolved to, so a line that minted a twin
+  of a curated flow last month now reaches the curated flow on the next load,
+  and the database's scores move accordingly. A line naming several flows in a
+  unit none of them uses, which used to mint a twin in silence, now refuses,
+  and refuses the load with it.
 - The shipped `volca.toml` names the settings it never mentioned: `[hosting]`
   and its nine limits, `chem-synonyms`, `substance-edges`, `[server] name`,
   and the three method fields that carry a single score (`scoring`, `patches`,

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -1419,11 +1419,11 @@ inspect, not a failure.
 One resource taken from the environment, or one emission released into it.
 
 Name the flow one way or the other, never both: ``flow`` is the identifier
-of a flow the database already has, which :meth:`Client.search_flows`
-returns, while ``name`` with ``compartment`` and ``unit`` names one in
-words. Use the two constructors rather than the fields, :meth:`existing`
-and :meth:`named`, which is why passing both or neither raises here
-instead of at the server.
+of a flow the database already has, which :meth:`Client.search_flows` and
+:attr:`BiosphereExchange.flow_id` both return, while ``name`` with
+``compartment`` and ``unit`` names one in words. Use the two constructors
+rather than the fields, :meth:`existing` and :meth:`named`, which is why
+passing both or neither raises here instead of at the server.
 
 A biosphere amount is never converted, so an exchange states its amount in
 the flow's own unit.
@@ -1443,6 +1443,11 @@ the flow's own unit.
 
 An exchange with the environment (resource extraction or emission).
 
+``flow_id`` is what a line writes back when its words cannot address the
+flow on their own: a name several flows answer to, or one whose source
+recorded no compartment. Everything else restates as
+:meth:`BioExchange.named` takes it.
+
 | Field | Type | Default |
 |-------|------|---------|
 | `flow_name` | `str` | _required_ |
@@ -1450,6 +1455,7 @@ An exchange with the environment (resource extraction or emission).
 | `amount` | `float` | _required_ |
 | `unit` | `str` | _required_ |
 | `direction` | `BioDirection` | _required_ |
+| `flow_id` | `str` | _required_ |
 | `comment` | `str \| None` | None |
 | `is_biosphere` | `bool` | True |
 | `is_waste` | `bool` | False |

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -1418,14 +1418,15 @@ inspect, not a failure.
 
 One resource taken from the environment, or one emission released into it.
 
-Name the flow one way or the other, never both: ``flow`` addresses one the
-database already has, and ``name`` + ``compartment`` introduce a new one.
-Use the two constructors rather than the fields,
-:meth:`existing` and :meth:`introducing`, which is why passing both or
-neither raises here instead of at the server.
+Name the flow one way or the other, never both: ``flow`` is the identifier
+of a flow the database already has, which :meth:`Client.search_flows`
+returns, while ``name`` with ``compartment`` and ``unit`` names one in
+words. Use the two constructors rather than the fields, :meth:`existing`
+and :meth:`named`, which is why passing both or neither raises here
+instead of at the server.
 
-A biosphere amount is never converted, so an exchange on an existing flow
-must be stated in that flow's own unit.
+A biosphere amount is never converted, so an exchange states its amount in
+the flow's own unit.
 
 | Field | Type | Default |
 |-------|------|---------|

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -908,13 +908,20 @@ def _direction_is_input(direction: BioDirection) -> bool:
 
 @dataclass
 class BiosphereExchange:
-    """An exchange with the environment (resource extraction or emission)."""
+    """An exchange with the environment (resource extraction or emission).
+
+    ``flow_id`` is what a line writes back when its words cannot address the
+    flow on their own: a name several flows answer to, or one whose source
+    recorded no compartment. Everything else restates as
+    :meth:`BioExchange.named` takes it.
+    """
 
     flow_name: str
     compartment: Compartment | None
     amount: float
     unit: str
     direction: BioDirection  # "Resource" = extraction, "Emission" = release
+    flow_id: str
     comment: str | None = None
 
     is_biosphere: bool = True  # discriminator for callers using duck typing
@@ -947,6 +954,7 @@ class BiosphereExchange:
             amount=inner["amount"],
             unit=ewu["unitName"],
             direction=BioDirection(inner["direction"]),
+            flow_id=inner["flowId"],
             comment=_exchange_comment(ewu, inner),
         )
 
@@ -1059,6 +1067,7 @@ def parse_exchange_detail(ed: dict) -> Exchange:
             amount=inner["amount"],
             unit=unit,
             direction=BioDirection(inner["direction"]),
+            flow_id=inner["flowId"],
             comment=comment,
         )
     if tag == "WasteExchange":
@@ -1930,11 +1939,11 @@ class BioExchange:
     """One resource taken from the environment, or one emission released into it.
 
     Name the flow one way or the other, never both: ``flow`` is the identifier
-    of a flow the database already has, which :meth:`Client.search_flows`
-    returns, while ``name`` with ``compartment`` and ``unit`` names one in
-    words. Use the two constructors rather than the fields, :meth:`existing`
-    and :meth:`named`, which is why passing both or neither raises here
-    instead of at the server.
+    of a flow the database already has, which :meth:`Client.search_flows` and
+    :attr:`BiosphereExchange.flow_id` both return, while ``name`` with
+    ``compartment`` and ``unit`` names one in words. Use the two constructors
+    rather than the fields, :meth:`existing` and :meth:`named`, which is why
+    passing both or neither raises here instead of at the server.
 
     A biosphere amount is never converted, so an exchange states its amount in
     the flow's own unit.
@@ -2005,12 +2014,17 @@ class BioExchange:
 
         That is the flow the database already declares under them when it has
         one, which is what keeps an exchange written from an inventory pointing
-        at the curated flow rather than at a twin of it. A name nothing answers
-        to brings a flow into the database, and since no characterization
-        factor matches a brand-new flow by identity, the engine returns a
-        warning alongside the write rather than refusing it. A name two flows
-        answer to is refused, with both identifiers, so the exchange can name
-        the one it means.
+        at the curated flow rather than at a twin of it. ``sub_compartment`` is
+        part of the address, not a decoration: a flow recorded in
+        ``water/river`` is reached with ``sub_compartment="river"`` and not by
+        ``water`` alone.
+
+        A name nothing answers to brings a flow into the database, and since no
+        characterization factor matches a brand-new flow by identity, the
+        engine returns a warning alongside the write rather than refusing it.
+        A name several flows answer to in the unit stated is refused, listing
+        their identifiers, so the exchange can name the one it means; two flows
+        of one name in two units are told apart by the unit itself.
         """
         return cls(
             direction=BioDirection(direction),

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -1929,14 +1929,15 @@ class TechInput:
 class BioExchange:
     """One resource taken from the environment, or one emission released into it.
 
-    Name the flow one way or the other, never both: ``flow`` addresses one the
-    database already has, and ``name`` + ``compartment`` introduce a new one.
-    Use the two constructors rather than the fields,
-    :meth:`existing` and :meth:`introducing`, which is why passing both or
-    neither raises here instead of at the server.
+    Name the flow one way or the other, never both: ``flow`` is the identifier
+    of a flow the database already has, which :meth:`Client.search_flows`
+    returns, while ``name`` with ``compartment`` and ``unit`` names one in
+    words. Use the two constructors rather than the fields, :meth:`existing`
+    and :meth:`named`, which is why passing both or neither raises here
+    instead of at the server.
 
-    A biosphere amount is never converted, so an exchange on an existing flow
-    must be stated in that flow's own unit.
+    A biosphere amount is never converted, so an exchange states its amount in
+    the flow's own unit.
     """
 
     direction: BioDirection
@@ -1951,8 +1952,9 @@ class BioExchange:
     def __post_init__(self) -> None:
         if (self.flow is None) == (self.name is None):
             raise ValueError(
-                "a biosphere exchange names either an existing flow (flow=...) "
-                "or a new one (name=..., compartment=...), not both and not neither"
+                "a biosphere exchange names its flow by identifier (flow=...) "
+                "or in words (name=..., compartment=..., unit=...), "
+                "not both and not neither"
             )
         if self.name is not None and self.compartment is None:
             raise ValueError(
@@ -1962,7 +1964,7 @@ class BioExchange:
         if self.name is not None and self.unit is None:
             raise ValueError(
                 f"biosphere flow {self.name!r} needs a unit "
-                "(it is half of a new flow's identity, so it cannot be defaulted)"
+                "(it is half of the flow's identity, so it cannot be defaulted)"
             )
 
     @classmethod
@@ -1975,7 +1977,10 @@ class BioExchange:
         unit: str | None = None,
         comment: str | None = None,
     ) -> "BioExchange":
-        """An exchange on a flow the database already declares, by its identifier."""
+        """An exchange on a flow the database already declares, by its identifier.
+
+        :meth:`Client.search_flows` is where identifiers come from.
+        """
         return cls(
             direction=BioDirection(direction),
             amount=amount,
@@ -1985,7 +1990,7 @@ class BioExchange:
         )
 
     @classmethod
-    def introducing(
+    def named(
         cls,
         name: str,
         compartment: str,
@@ -1996,10 +2001,16 @@ class BioExchange:
         sub_compartment: str | None = None,
         comment: str | None = None,
     ) -> "BioExchange":
-        """An exchange on a flow this activity brings into the database.
+        """An exchange on the flow this name, compartment and unit address.
 
-        No characterization factor matches a brand-new flow by identity, so the
-        engine returns a warning alongside the write rather than refusing it.
+        That is the flow the database already declares under them when it has
+        one, which is what keeps an exchange written from an inventory pointing
+        at the curated flow rather than at a twin of it. A name nothing answers
+        to brings a flow into the database, and since no characterization
+        factor matches a brand-new flow by identity, the engine returns a
+        warning alongside the write rather than refusing it. A name two flows
+        answer to is refused, with both identifiers, so the exchange can name
+        the one it means.
         """
         return cls(
             direction=BioDirection(direction),

--- a/pyvolca/tests/conftest.py
+++ b/pyvolca/tests/conftest.py
@@ -302,6 +302,7 @@ def readme_namespace() -> dict[str, Any]:
                 amount=0.41,
                 unit="kg",
                 direction=BioDirection.EMISSION,
+                flow_id="349b29d1-3e58-4c66-98b9-9d1a1b1f1234",
             ),
         ],
     )

--- a/pyvolca/tests/test_db_write.py
+++ b/pyvolca/tests/test_db_write.py
@@ -387,7 +387,7 @@ class TestCreateActivities:
         _ok(session, {"written": ["a_b"], "transient": False, "warnings": ["new flow"]})
         activity = _cheese(
             biosphere=[
-                BioExchange.introducing("Nitrous oxide", "air", "Emission", 0.5, "kg"),
+                BioExchange.named("Nitrous oxide", "air", "Emission", 0.5, "kg"),
                 BioExchange.existing("11111111-2222-3333-4444-555555555555", "Emission", 1.2),
             ]
         )
@@ -458,7 +458,7 @@ class TestAuthoringInputTypes:
     def test_direction_is_read_the_way_the_engine_reads_it(self):
         # The engine lowercases the wire value before matching, so the
         # client accepts any casing but always sends the canonical one.
-        exchange = BioExchange.introducing("Nitrous oxide", "air", "emission", 0.5, "kg")
+        exchange = BioExchange.named("Nitrous oxide", "air", "emission", 0.5, "kg")
         assert exchange.direction is BioDirection.EMISSION
         assert exchange.to_wire()["direction"] == "Emission"
 

--- a/pyvolca/tests/test_exchange_comment.py
+++ b/pyvolca/tests/test_exchange_comment.py
@@ -28,6 +28,7 @@ def _inner(tag: str) -> dict:
         base["role"] = "Input"
     elif tag == "BiosphereExchange":
         base["direction"] = "Resource"
+        base["flowId"] = "11111111-2222-3333-4444-555555555555"
     elif tag == "WasteExchange":
         base["isInput"] = False
     return base

--- a/pyvolca/tests/test_waste_exchange.py
+++ b/pyvolca/tests/test_waste_exchange.py
@@ -102,7 +102,7 @@ class TestParseExchangeWaste:
             "targetActivityName": None, "targetLocation": None, "targetProcessId": None,
         })
         bio = parse_exchange({
-            "exchange": {"tag": "BiosphereExchange", "amount": 1.0, "direction": "Emission"},
+            "exchange": {"tag": "BiosphereExchange", "amount": 1.0, "direction": "Emission", "flowId": "11111111-2222-3333-4444-555555555555"},
             "flowName": "CO2", "unitName": "kg",
             "compartment": {"name": "air", "sub": None},
         })
@@ -118,7 +118,7 @@ class TestParseExchangeWaste:
             "targetActivityName": None, "targetLocation": None, "targetProcessId": None,
         })
         bio = parse_exchange({
-            "exchange": {"tag": "BiosphereExchange", "amount": 1.0, "direction": "Emission"},
+            "exchange": {"tag": "BiosphereExchange", "amount": 1.0, "direction": "Emission", "flowId": "11111111-2222-3333-4444-555555555555"},
             "flowName": "CO2", "unitName": "kg",
             "compartment": {"name": "air", "sub": None},
         })
@@ -170,7 +170,7 @@ class TestParseExchangeDetailWaste:
 
     def test_waste_flow_envelope_rejected_on_biosphere_tag(self):
         bad = {
-            "exchange": {"tag": "BiosphereExchange", "amount": 1.0, "direction": "Emission"},
+            "exchange": {"tag": "BiosphereExchange", "amount": 1.0, "direction": "Emission", "flowId": "11111111-2222-3333-4444-555555555555"},
             "exchangeUnitName": "kg",
             "flow": {"kind": "waste", "flow": {"name": "CO2"}},
         }

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -427,10 +427,10 @@ paramsToSchema ps =
                     [ "direction" .= stringField "resource (taken from the environment) | emission (released into it)"
                     , "amount" .= numberField "Amount exchanged, in the flow's own unit"
                     , "flow" .= stringField "Id of a flow the database already has (from get_activity or search_flows)"
-                    , "name" .= stringField "Name of a flow to introduce instead, with compartment and unit"
+                    , "name" .= stringField "Name of the flow instead, with its compartment and unit: the flow the database declares under them, or a new one when nothing does"
                     , "compartment" .= stringField "air | water | soil | natural resource"
-                    , "subCompartment" .= stringField "Sub-compartment of an introduced flow, e.g. \"low population density\""
-                    , "unit" .= stringField "Unit. Part of an introduced flow's identity, so it cannot be omitted there."
+                    , "subCompartment" .= stringField "Sub-compartment, e.g. \"low population density\". Part of what tells two flows of one name apart."
+                    , "unit" .= stringField "Unit. Part of a named flow's identity, so it cannot be omitted there."
                     , "comment" .= stringField "Free-text note on this line"
                     ]
             , "required" .= (["direction", "amount"] :: [Text])

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -942,6 +942,6 @@ params r = case r of
         , Param "remove" "array" Optional "Lines to drop. Each is {kind, provider|flow}: kind \"input\" or \"waste\" with the provider's process_id, or kind \"biosphere\" with the flow id."
         , Param "set_amounts" "array" Optional "Lines to restate. Each is {select: {kind, provider|flow}, amount}."
         , Param "add_inputs" "array" Optional "Technosphere inputs to add. Each is {provider, amount} plus optional unit and comment. The flow follows from the provider."
-        , Param "add_biosphere" "array" Optional "Biosphere lines to add. Each is {direction, amount} plus either flow (an existing flow id) or name + compartment + unit to introduce a new one."
+        , Param "add_biosphere" "array" Optional "Biosphere lines to add. Each is {direction, amount} plus either flow (an existing flow id) or name + compartment + unit, which reach the flow the database declares under them and introduce one only when nothing does."
         , Param "add_waste_outputs" "array" Optional "Waste outputs to add. Each is {provider, amount} plus optional unit and comment, where the provider is the treatment process."
         ]

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -1945,18 +1945,20 @@ winner.
 -}
 bioFlowRef :: BioExchangeAPI -> Either Text FlowRef
 bioFlowRef be = case (beFlow be, beName be) of
-    (Just _, Just _) -> Left "a biosphere exchange names either an existing flow or a new one, not both"
-    (Nothing, Nothing) -> Left "a biosphere exchange needs either a flow identifier or a name and compartment"
+    (Just _, Just _) -> Left "a biosphere exchange names its flow by identifier or in words, not both"
+    (Nothing, Nothing) -> Left "a biosphere exchange needs either a flow identifier or a name, a compartment and a unit"
     (Just flowId, Nothing) ->
-        maybe (Left (notAnIdentifier flowId)) (Right . ExistingFlow) (UUID.fromText flowId)
+        maybe (Left (notAnIdentifier flowId)) (Right . FlowById) (UUID.fromText flowId)
     (Nothing, Just name) -> case (beCompartment be, beUnit be) of
         (Nothing, _) -> Left ("biosphere flow \"" <> name <> "\" needs a compartment (air, water, soil, natural resource)")
-        -- The unit is half of a named flow's identity (see
-        -- 'Database.Author.authoredBioFlowUUID'), so it cannot be defaulted.
+        -- The unit is half of what makes a flow named in words that flow, both
+        -- when the words reach one the database declares and when they mint a
+        -- new one (see 'Database.Author.authoredBioFlowUUID'), so it cannot be
+        -- defaulted.
         (_, Nothing) -> Left ("biosphere flow \"" <> name <> "\" needs a unit")
         (Just medium, Just unit) ->
             Right $
-                NewBioFlow
+                FlowByName
                     name
                     Compartment{compartmentName = medium, compartmentSub = beSubCompartment be}
                     unit

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -1082,10 +1082,12 @@ data TechInputAPI = TechInputAPI
 {- | One biosphere exchange: a resource taken from the environment or an
 emission released into it.
 
-Either @beFlow@ names a flow already in the vocabulary by its identifier, or
-@beName@ + @beCompartment@ introduce one. Giving both is refused rather than
-guessed at. A biosphere amount is never converted, so an exchange on an
-existing flow must be stated in that flow's own unit.
+Either @beFlow@ names a flow by its identifier, or @beName@ with
+@beCompartment@ and @beUnit@ names one in words, which reaches the flow the
+vocabulary already declares under them and introduces one only when nothing
+answers to them. Giving both is refused rather than guessed at. A biosphere
+amount is never converted, so an exchange states its amount in the flow's own
+unit.
 -}
 data BioExchangeAPI = BioExchangeAPI
     { beFlow :: Maybe Text
@@ -1937,16 +1939,16 @@ toSelector es = case (T.toLower (T.strip (esKind es)), esProvider es, esFlow es)
         | otherwise ->
             Left ["unknown selector kind: " <> kind <> " (expected input|waste|biosphere)"]
 
-{- | A biosphere line names an existing flow by identifier, or introduces one
-by name and compartment. Both at once is ambiguous and neither says nothing,
-so both are refused instead of picking a winner.
+{- | A biosphere line names a flow by identifier, or in words. Both at once is
+ambiguous and neither says nothing, so both are refused instead of picking a
+winner.
 -}
 bioFlowRef :: BioExchangeAPI -> Either Text FlowRef
 bioFlowRef be = case (beFlow be, beName be) of
     (Just _, Just _) -> Left "a biosphere exchange names either an existing flow or a new one, not both"
     (Nothing, Nothing) -> Left "a biosphere exchange needs either a flow identifier or a name and compartment"
     (Just flowId, Nothing) ->
-        maybe (Left ("not a flow identifier: " <> flowId)) (Right . ExistingFlow) (UUID.fromText flowId)
+        maybe (Left (notAnIdentifier flowId)) (Right . ExistingFlow) (UUID.fromText flowId)
     (Nothing, Just name) -> case (beCompartment be, beUnit be) of
         (Nothing, _) -> Left ("biosphere flow \"" <> name <> "\" needs a compartment (air, water, soil, natural resource)")
         -- The unit is half of a named flow's identity (see
@@ -1958,6 +1960,15 @@ bioFlowRef be = case (beFlow be, beName be) of
                     name
                     Compartment{compartmentName = medium, compartmentSub = beSubCompartment be}
                     unit
+
+{- | A name written into the identifier field is the common mistake, so the
+refusal says where identifiers come from and how a name is written instead.
+-}
+notAnIdentifier :: Text -> Text
+notAnIdentifier flowId =
+    "not a flow identifier: "
+        <> flowId
+        <> " (an identifier is the UUID a flow search returns; a flow written in words is stated as its name, compartment and unit instead)"
 
 bioDirection :: Text -> Either Text BioDirection
 bioDirection raw = case T.toLower (T.strip raw) of

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -67,6 +67,7 @@ module Database.Author (
 
 import qualified Data.ByteString as BS
 import Data.Either (partitionEithers)
+import Data.List (nub)
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
 import Data.Text (Text)
@@ -156,9 +157,9 @@ technosphere flow authoring can create is the authored activity's own product,
 and that one is minted from the activity itself, never stated as an input.
 -}
 data FlowRef
-    = ExistingFlow UUID
+    = FlowById UUID
     | -- | name, compartment, unit: an existing flow when one carries them, a new one otherwise
-      NewBioFlow Text Compartment Text
+      FlowByName Text Compartment Text
     deriving (Eq, Show)
 
 {- | One line of an authored activity's inventory.
@@ -352,8 +353,8 @@ describeExchange :: AuthoredExchange -> Text
 describeExchange ex = case ex of
     AuthoredTechInput{atiProvider = provider} -> "input from \"" <> provider <> "\""
     AuthoredWasteOutput{awProvider = provider} -> "waste output to \"" <> provider <> "\""
-    AuthoredBio{abFlow = ExistingFlow flowId} -> "biosphere flow " <> UUID.toText flowId
-    AuthoredBio{abFlow = NewBioFlow name _ _} -> "biosphere flow \"" <> name <> "\""
+    AuthoredBio{abFlow = FlowById flowId} -> "biosphere flow " <> UUID.toText flowId
+    AuthoredBio{abFlow = FlowByName name _ _} -> "biosphere flow \"" <> name <> "\""
 
 {- | An amount that can carry information: finite, and not zero. A zero
 exchange is not a measurement of nothing, it is a line that should not have
@@ -721,7 +722,7 @@ resolveBio ctx flowRef direction amount mUnit comment
     | not (isUsableAmount amount) =
         Left ["the amount is " <> T.pack (show amount) <> "; it must be a finite non-zero number"]
     | otherwise = case flowRef of
-        ExistingFlow flowId -> case findBioFlow ctx flowId of
+        FlowById flowId -> case findBioFlow ctx flowId of
             Nothing ->
                 Left
                     [ "no biosphere flow "
@@ -733,12 +734,13 @@ resolveBio ctx flowRef direction amount mUnit comment
                  in case mUnit of
                         Just stated | normalizeUnit stated /= normalizeUnit flowUnit -> Left [mismatch stated flowUnit]
                         _ -> emitKnown flowId flow flowUnit local
-        NewBioFlow name comp unit -> case findBioFlowsByName ctx name comp of
+        FlowByName name comp unit -> case findBioFlowsByName ctx name comp of
             [] -> introduce name comp unit
             [found] -> attach unit found
             several -> case filter (statedIn unit) several of
                 [found] -> attach unit found
-                _ -> Left [severalNamed comp several]
+                [] -> Left [unitAmong unit several]
+                ties -> Left [severalNamed comp ties]
   where
     -- A name the database already carries addresses that flow, rather than
     -- minting a second one under it: an introduced flow matches no
@@ -766,6 +768,15 @@ resolveBio ctx flowRef direction amount mUnit comment
                         <> name
                         <> "\" is new to this database; no characterization factor matches it by identity yet"
                     ]
+    -- Several flows carry the name and none is recorded in the unit stated.
+    -- That is a unit to restate, not a choice to make: calling it ambiguous
+    -- would send the author to identifiers that refuse for the same reason.
+    unitAmong stated cands =
+        "the flows carrying this name are recorded in "
+            <> T.intercalate " and " (map quoted (nub (map unitOfCandidate cands)))
+            <> " but the exchange states \""
+            <> stated
+            <> "\"; biosphere amounts are not converted, so restate it in one of them"
     -- The refusal carries the identifiers, because an author who reaches it
     -- has to name one of them and has no other place to read them from.
     severalNamed comp several =
@@ -776,6 +787,8 @@ resolveBio ctx flowRef direction amount mUnit comment
             <> "; name the one this exchange means by its identifier"
     describeFlow (flow, ownerUnits, _) =
         UUID.toText (bfId flow) <> " (" <> unitNameOf ownerUnits (bfUnitId flow) <> ")"
+    unitOfCandidate (flow, ownerUnits, _) = unitNameOf ownerUnits (bfUnitId flow)
+    quoted u = "\"" <> u <> "\""
     -- A flow found in a dependency is copied into the edited database with
     -- its unit remapped: characterization resolves flows through the edited
     -- database's own vocabulary ('dbBioFlows'), so an exchange must never

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -142,8 +142,12 @@ authoredBioFlowUUID name comp unit =
 -- What an author writes
 -- ---------------------------------------------------------------------------
 
-{- | The flow a biosphere exchange names: one already in the vocabulary, or one
-the author is introducing.
+{- | The flow a biosphere exchange names: by identifier, or in words.
+
+Words reach the flow the database already declares under that name and
+compartment, and introduce one only when nothing answers to them. An author
+reading an inventory writes the names it shows, so the alternative would have
+them mint a twin of a curated flow, uncharacterized and scoring as zero.
 
 There is deliberately no technosphere counterpart. A technosphere input always
 names a *supplier* — a product that something in scope produces — so the flow
@@ -153,7 +157,7 @@ and that one is minted from the activity itself, never stated as an input.
 -}
 data FlowRef
     = ExistingFlow UUID
-    | -- | name, compartment, unit
+    | -- | name, compartment, unit: an existing flow when one carries them, a new one otherwise
       NewBioFlow Text Compartment Text
     deriving (Eq, Show)
 
@@ -727,24 +731,51 @@ resolveBio ctx flowRef direction amount mUnit comment
             Just (flow, ownerUnits, local) ->
                 let flowUnit = unitNameOf ownerUnits (bfUnitId flow)
                  in case mUnit of
-                        Just stated | normalizeUnit stated /= normalizeUnit flowUnit -> Left [mismatch flow stated flowUnit]
+                        Just stated | normalizeUnit stated /= normalizeUnit flowUnit -> Left [mismatch stated flowUnit]
                         _ -> emitKnown flowId flow flowUnit local
-        NewBioFlow name comp unit -> case lookupUnit ctx unit of
-            Nothing -> Left ["unknown unit \"" <> unit <> "\" for flow \"" <> name <> "\""]
-            Just (unitRef, unitLabel) ->
-                let flowId = authoredBioFlowUUID name comp unitLabel
-                 in case findBioFlow ctx flowId of
-                        Just (flow, ownerUnits, local) -> emitKnown flowId flow (unitNameOf ownerUnits (bfUnitId flow)) local
-                        Nothing ->
-                            emit
-                                flowId
-                                unitRef
-                                (Just (newBioFlow flowId name comp unitRef))
-                                [ "biosphere flow \""
-                                    <> name
-                                    <> "\" is new to this database; no characterization factor matches it by identity yet"
-                                ]
+        NewBioFlow name comp unit -> case findBioFlowsByName ctx name comp of
+            [] -> introduce name comp unit
+            [found] -> attach unit found
+            several -> case filter (statedIn unit) several of
+                [found] -> attach unit found
+                _ -> Left [severalNamed comp several]
   where
+    -- A name the database already carries addresses that flow, rather than
+    -- minting a second one under it: an introduced flow matches no
+    -- characterization factor by identity, so the twin of a curated flow
+    -- would score as zero next to the original.
+    attach stated (flow, ownerUnits, local) =
+        let flowUnit = unitNameOf ownerUnits (bfUnitId flow)
+         in if normalizeUnit stated /= normalizeUnit flowUnit
+                then Left [mismatch stated flowUnit]
+                else emitKnown (bfId flow) flow flowUnit local
+    -- One name and compartment in two units (an energy carrier recorded in
+    -- kg and in MJ) is told apart by the unit the exchange states, which the
+    -- author has already written. Nothing else is guessed at.
+    statedIn stated (flow, ownerUnits, _) =
+        normalizeUnit stated == normalizeUnit (unitNameOf ownerUnits (bfUnitId flow))
+    introduce name comp unit = case lookupUnit ctx unit of
+        Nothing -> Left ["unknown unit \"" <> unit <> "\" for flow \"" <> name <> "\""]
+        Just (unitRef, unitLabel) ->
+            let flowId = authoredBioFlowUUID name comp unitLabel
+             in emit
+                    flowId
+                    unitRef
+                    (Just (newBioFlow flowId name comp unitRef))
+                    [ "biosphere flow \""
+                        <> name
+                        <> "\" is new to this database; no characterization factor matches it by identity yet"
+                    ]
+    -- The refusal carries the identifiers, because an author who reaches it
+    -- has to name one of them and has no other place to read them from.
+    severalNamed comp several =
+        "more than one flow carries this name in "
+            <> renderCompartment comp
+            <> ": "
+            <> T.intercalate ", " (map describeFlow several)
+            <> "; name the one this exchange means by its identifier"
+    describeFlow (flow, ownerUnits, _) =
+        UUID.toText (bfId flow) <> " (" <> unitNameOf ownerUnits (bfUnitId flow) <> ")"
     -- A flow found in a dependency is copied into the edited database with
     -- its unit remapped: characterization resolves flows through the edited
     -- database's own vocabulary ('dbBioFlows'), so an exchange must never
@@ -779,10 +810,8 @@ resolveBio ctx flowRef direction amount mUnit comment
     -- The biosphere matrix carries amounts through unconverted, so a unit the
     -- flow does not use would land as a wrong number rather than as a
     -- conversion. Refuse and name both units.
-    mismatch flow stated flowUnit =
-        "biosphere flow \""
-            <> bfName flow
-            <> "\" is recorded in \""
+    mismatch stated flowUnit =
+        "the flow is recorded in \""
             <> flowUnit
             <> "\" but the exchange states \""
             <> stated
@@ -856,6 +885,46 @@ refUnitOf :: Database -> Activity -> (Exchange -> Bool) -> Text
 refUnitOf db act keep = case filter keep (exchanges act) of
     (ex : _) -> getUnitNameForExchange (dbUnits db) ex
     [] -> ""
+
+{- | Every biosphere flow the edited database or a dependency declares under
+this name and compartment, with what 'findBioFlow' returns beside each.
+
+Matched on the flow's own name, case and spacing aside, and never on a
+synonym: an author writing a name in words means the flow that name belongs
+to, while a synonym match would attach the exchange to a flow they never
+wrote. A blank compartment matches nothing, as does a flow whose source
+recorded no compartment, since neither says where the exchange happens.
+
+Read from 'dbBioFlows' rather than from the name index a loaded database
+carries, because that index is a runtime attachment a rebuild drops: replaying
+a journal against a database that has lost it would resolve a name differently
+than the write that recorded it did.
+-}
+findBioFlowsByName :: AuthorContext -> Text -> Compartment -> [(BiosphereFlow, UnitDB, Bool)]
+findBioFlowsByName ctx name comp = case matchesIn True (acDb ctx) of
+    [] -> concatMap (matchesIn False) (acDeps ctx)
+    found -> found
+  where
+    wantedName = foldName name
+    wantedCompartment = compartmentKey comp
+    matchesIn local db =
+        [ (flow, dbUnits db, local)
+        | not (T.null (fst wantedCompartment))
+        , flow <- M.elems (dbBioFlows db)
+        , foldName (bfName flow) == wantedName
+        , Just flowComp <- [bfCompartment flow]
+        , compartmentKey flowComp == wantedCompartment
+        ]
+
+-- | Names, compartments and sub-compartments compare as written, case and spacing aside.
+foldName :: Text -> Text
+foldName = T.toLower . T.unwords . T.words
+
+compartmentKey :: Compartment -> (Text, Text)
+compartmentKey comp = (foldName (compartmentName comp), foldName (fromMaybe "" (compartmentSub comp)))
+
+renderCompartment :: Compartment -> Text
+renderCompartment comp = compartmentName comp <> maybe "" ("/" <>) (compartmentSub comp)
 
 {- | Find a biosphere flow, with the unit table that can name its unit and
 whether it lives in the edited database itself.

--- a/src/Database/Journal.hs
+++ b/src/Database/Journal.hs
@@ -632,15 +632,17 @@ parseExchange = withObject "exchange" $ \o ->
                 <*> o .:? "comment"
         other -> fail ("unknown exchange kind: " <> T.unpack other)
 
-{- | A biosphere line names a flow the vocabulary already has, or introduces
-one. The unit of an introduced flow is part of its identity, which is why it
-lives inside the flow rather than beside it: the amount's own unit is a
-separate field, and the two are not required to be the same thing.
+{- | A biosphere line names its flow by identifier, or in words. Words are
+recorded as written rather than as resolved, so a replay reads them the way
+'Database.Author.resolveBio' does: the flow the database declares under them,
+or a new one when nothing answers. The unit is part of what the words address,
+which is why it lives inside the flow rather than beside it: the amount's own
+unit is a separate field, and the two are not required to be the same thing.
 -}
 flowJSON :: FlowRef -> Value
 flowJSON = \case
-    ExistingFlow flowId -> object ["id" .= UUID.toText flowId]
-    NewBioFlow name compartment unit ->
+    FlowById flowId -> object ["id" .= UUID.toText flowId]
+    FlowByName name compartment unit ->
         object $
             ["name" .= name, "compartment" .= compartmentName compartment, "unit" .= unit]
                 <> maybe [] (\sub -> ["sub_compartment" .= sub]) (compartmentSub compartment)
@@ -651,19 +653,19 @@ parseFlow = withObject "biosphere flow" $ \o -> do
     mName <- o .:? "name"
     case (mIdentifier, mName) of
         (Just identifier, Nothing) ->
-            maybe (fail ("not a flow identifier: " <> T.unpack identifier)) (pure . ExistingFlow) $
+            maybe (fail ("not a flow identifier: " <> T.unpack identifier)) (pure . FlowById) $
                 UUID.fromText identifier
         (Nothing, Just name) -> do
             compartment <- o .: "compartment"
             sub <- o .:? "sub_compartment"
             unit <- o .: "unit"
             pure $
-                NewBioFlow
+                FlowByName
                     name
                     Compartment{compartmentName = compartment, compartmentSub = sub}
                     unit
         (Just _, Just _) ->
-            fail "a biosphere flow names either an existing flow or a new one, not both"
+            fail "a biosphere flow is named by identifier or in words, not both"
         (Nothing, Nothing) ->
             fail "a biosphere flow needs either an identifier or a name, compartment and unit"
 

--- a/test/AuthorSpec.hs
+++ b/test/AuthorSpec.hs
@@ -222,6 +222,39 @@ spec = do
                 r <- resolveOrFail fixtureDb baseActivity{aaExchanges = [bioOf (ExistingFlow co2Id) 1 Nothing]}
                 map bfName (riNewBioFlows r) `shouldBe` []
 
+            it "reads a flow named in words as the one the database already declares" $ do
+                -- The name an inventory shows is what an author writes back;
+                -- minting a twin of a curated flow would carry no
+                -- characterization factor and score as zero beside it.
+                r <- resolveOrFail fixtureDb baseActivity{aaExchanges = [bioOf (NewBioFlow "carbon dioxide" air "kg") 2 Nothing]}
+                map bfName (riNewBioFlows r) `shouldBe` []
+                bioFlowIds r `shouldBe` [co2Id]
+
+            it "keeps a name in another compartment apart" $ do
+                let urban = Compartment{compartmentName = "air", compartmentSub = Just "urban air"}
+                r <- resolveOrFail fixtureDb baseActivity{aaExchanges = [bioOf (NewBioFlow "Carbon dioxide" urban "kg") 2 Nothing]}
+                map bfName (riNewBioFlows r) `shouldBe` ["Carbon dioxide"]
+                bioFlowIds r `shouldSatisfy` (/= [co2Id])
+
+            it "refuses a named flow restated in another unit" $
+                failsWith
+                    "biosphere amounts are not converted"
+                    (baseActivity{aaExchanges = [bioOf (NewBioFlow "Carbon dioxide" air "m") 1 Nothing]})
+
+            it "tells two flows of one name apart by the unit the exchange states" $ do
+                -- An energy carrier recorded in kg and in MJ is the real case:
+                -- the author has already written which one they mean.
+                r <- resolveOrFail (withTwinFlow fixtureDb) baseActivity{aaExchanges = [bioOf (NewBioFlow "Carbon dioxide" air "kg") 2 Nothing]}
+                bioFlowIds r `shouldBe` [co2Id]
+
+            it "refuses a name two flows answer to, naming both identifiers" $
+                -- The refusal is where the author reads the identifier they
+                -- then have to write, so it carries them.
+                refusalOf
+                    (withTwinFlow fixtureDb)
+                    (UUID.toText twinFlowId)
+                    (baseActivity{aaExchanges = [bioOf (NewBioFlow "Carbon dioxide" air "item") 1 Nothing]})
+
         describe "insertActivities" $ do
             it "adds the activity, its product flow and its new biosphere flow together" $ do
                 let authored =
@@ -457,6 +490,18 @@ wasteOut provider amount unit =
 
 treatPid :: Text
 treatPid = UUID.toText treatActId <> "_" <> UUID.toText usedOilId
+
+-- | The biosphere flows one resolved activity points at, in exchange order.
+bioFlowIds :: ResolvedInsert -> [UUID]
+bioFlowIds r = [flowId | BiosphereExchange{bioFlowId = flowId} <- exchanges (riActivity r)]
+
+-- | The same database with a second "Carbon dioxide" in air, recorded in another unit.
+withTwinFlow :: Database -> Database
+withTwinFlow db =
+    db{dbBioFlows = M.insert twinFlowId co2Flow{bfId = twinFlowId, bfUnitId = metreUnitId} (dbBioFlows db)}
+
+twinFlowId :: UUID
+twinFlowId = mkUUID 6
 
 bioOf :: FlowRef -> Double -> Maybe Text -> AuthoredExchange
 bioOf flow amount unit =

--- a/test/AuthorSpec.hs
+++ b/test/AuthorSpec.hs
@@ -106,14 +106,14 @@ spec = do
             it "refuses a biosphere flow identifier nothing declares" $
                 failsWith
                     "no biosphere flow"
-                    (baseActivity{aaExchanges = [bioOf (ExistingFlow (mkUUID 999)) 1 Nothing]})
+                    (baseActivity{aaExchanges = [bioOf (FlowById (mkUUID 999)) 1 Nothing]})
 
             it "refuses a biosphere amount restated in another unit" $
                 -- The biosphere matrix carries amounts through unconverted, so a
                 -- unit the flow does not use would land as a wrong number.
                 failsWith
                     "biosphere amounts are not converted"
-                    (baseActivity{aaExchanges = [bioOf (ExistingFlow co2Id) 1 (Just "m")]})
+                    (baseActivity{aaExchanges = [bioOf (FlowById co2Id) 1 (Just "m")]})
 
             it "reports a bad product unit and a bad exchange together" $
                 case validateAuthored (contextOf fixtureDb) [baseActivity{aaProductUnit = "furlong", aaExchanges = [techInput "nope" 1 Nothing]}] of
@@ -127,7 +127,7 @@ spec = do
                 let bad =
                         baseActivity
                             { aaName = "two-problems"
-                            , aaExchanges = [techInput "nope" 1 Nothing, bioOf (ExistingFlow (mkUUID 998)) 1 Nothing]
+                            , aaExchanges = [techInput "nope" 1 Nothing, bioOf (FlowById (mkUUID 998)) 1 Nothing]
                             }
                 case validateAuthored (contextOf fixtureDb) [bad, baseActivity{aaProductUnit = "furlong"}] of
                     Right _ -> expectationFailure "expected the batch to be refused"
@@ -194,7 +194,7 @@ spec = do
                     Right (rs, _) -> expectationFailure ("expected one insert, got " <> show (length rs))
 
             it "warns about a biosphere flow new to the database without refusing it" $ do
-                let authored = baseActivity{aaExchanges = [bioOf (NewBioFlow "Nitrous oxide" air "kg") 0.5 Nothing]}
+                let authored = baseActivity{aaExchanges = [bioOf (FlowByName "Nitrous oxide" air "kg") 0.5 Nothing]}
                 case validateAuthored (contextOf fixtureDb) [authored] of
                     Left errs -> expectationFailure ("expected acceptance, got " <> show errs)
                     Right ([r], warnings) -> do
@@ -209,7 +209,7 @@ spec = do
                 bare <- buildBareFixture
                 dep <- buildFixture
                 let ctx = AuthorContext{acDb = bare, acDeps = [dep], acUnitConfig = defaultUnitConfig}
-                case validateAuthored ctx [baseActivity{aaExchanges = [bioOf (ExistingFlow co2Id) 1 Nothing]}] of
+                case validateAuthored ctx [baseActivity{aaExchanges = [bioOf (FlowById co2Id) 1 Nothing]}] of
                     Left errs -> expectationFailure ("expected acceptance, got " <> show errs)
                     Right ([r], _) -> do
                         map bfName (riNewBioFlows r) `shouldBe` ["Carbon dioxide"]
@@ -219,41 +219,47 @@ spec = do
             it "reuses a biosphere flow the database already declares" $ do
                 -- Same three coordinates the flow was minted on: re-declaring it is
                 -- not a second flow.
-                r <- resolveOrFail fixtureDb baseActivity{aaExchanges = [bioOf (ExistingFlow co2Id) 1 Nothing]}
+                r <- resolveOrFail fixtureDb baseActivity{aaExchanges = [bioOf (FlowById co2Id) 1 Nothing]}
                 map bfName (riNewBioFlows r) `shouldBe` []
 
             it "reads a flow named in words as the one the database already declares" $ do
                 -- The name an inventory shows is what an author writes back;
                 -- minting a twin of a curated flow would carry no
                 -- characterization factor and score as zero beside it.
-                r <- resolveOrFail fixtureDb baseActivity{aaExchanges = [bioOf (NewBioFlow "carbon dioxide" air "kg") 2 Nothing]}
+                r <- resolveOrFail fixtureDb baseActivity{aaExchanges = [bioOf (FlowByName "carbon dioxide" air "kg") 2 Nothing]}
                 map bfName (riNewBioFlows r) `shouldBe` []
                 bioFlowIds r `shouldBe` [co2Id]
 
             it "keeps a name in another compartment apart" $ do
                 let urban = Compartment{compartmentName = "air", compartmentSub = Just "urban air"}
-                r <- resolveOrFail fixtureDb baseActivity{aaExchanges = [bioOf (NewBioFlow "Carbon dioxide" urban "kg") 2 Nothing]}
+                r <- resolveOrFail fixtureDb baseActivity{aaExchanges = [bioOf (FlowByName "Carbon dioxide" urban "kg") 2 Nothing]}
                 map bfName (riNewBioFlows r) `shouldBe` ["Carbon dioxide"]
                 bioFlowIds r `shouldSatisfy` (/= [co2Id])
 
             it "refuses a named flow restated in another unit" $
                 failsWith
                     "biosphere amounts are not converted"
-                    (baseActivity{aaExchanges = [bioOf (NewBioFlow "Carbon dioxide" air "m") 1 Nothing]})
+                    (baseActivity{aaExchanges = [bioOf (FlowByName "Carbon dioxide" air "m") 1 Nothing]})
 
             it "tells two flows of one name apart by the unit the exchange states" $ do
                 -- An energy carrier recorded in kg and in MJ is the real case:
                 -- the author has already written which one they mean.
-                r <- resolveOrFail (withTwinFlow fixtureDb) baseActivity{aaExchanges = [bioOf (NewBioFlow "Carbon dioxide" air "kg") 2 Nothing]}
+                r <- resolveOrFail (withTwinFlow fixtureDb) baseActivity{aaExchanges = [bioOf (FlowByName "Carbon dioxide" air "kg") 2 Nothing]}
                 bioFlowIds r `shouldBe` [co2Id]
 
-            it "refuses a name two flows answer to, naming both identifiers" $
+            it "refuses a name two flows answer to in the unit stated, naming their identifiers" $
                 -- The refusal is where the author reads the identifier they
                 -- then have to write, so it carries them.
                 refusalOf
+                    (withSameUnitFlow fixtureDb)
+                    (UUID.toText sameUnitFlowId)
+                    (baseActivity{aaExchanges = [bioOf (FlowByName "Carbon dioxide" air "kg") 1 Nothing]})
+
+            it "names the units on offer when the stated one is none of them" $
+                refusalOf
                     (withTwinFlow fixtureDb)
-                    (UUID.toText twinFlowId)
-                    (baseActivity{aaExchanges = [bioOf (NewBioFlow "Carbon dioxide" air "item") 1 Nothing]})
+                    "restate it in one of them"
+                    (baseActivity{aaExchanges = [bioOf (FlowByName "Carbon dioxide" air "item") 1 Nothing]})
 
         describe "insertActivities" $ do
             it "adds the activity, its product flow and its new biosphere flow together" $ do
@@ -261,7 +267,7 @@ spec = do
                         baseActivity
                             { aaExchanges =
                                 [ techInput supplierPid 2 Nothing
-                                , bioOf (NewBioFlow "Nitrous oxide" air "kg") 0.5 Nothing
+                                , bioOf (FlowByName "Nitrous oxide" air "kg") 0.5 Nothing
                                 ]
                             }
                 r <- resolveOrFail fixtureDb authored
@@ -397,7 +403,7 @@ spec = do
                     `shouldBe` [(3, Just "milk in", Just milkPedigree)]
 
             it "adds a line the way authoring resolves one" $ do
-                edited <- editOrFail [AddExchange (bioOf (NewBioFlow "Nitrous oxide" air "kg") 0.5 Nothing)]
+                edited <- editOrFail [AddExchange (bioOf (FlowByName "Nitrous oxide" air "kg") 0.5 Nothing)]
                 eaMatched edited `shouldBe` [1]
                 map bfName (eaNewBioFlows edited) `shouldBe` ["Nitrous oxide"]
                 eaWarnings edited `shouldSatisfy` any (isInfixOf "no characterization factor matches it")
@@ -500,8 +506,16 @@ withTwinFlow :: Database -> Database
 withTwinFlow db =
     db{dbBioFlows = M.insert twinFlowId co2Flow{bfId = twinFlowId, bfUnitId = metreUnitId} (dbBioFlows db)}
 
-twinFlowId :: UUID
+{- | The same database with a second "Carbon dioxide" in air in the very same
+unit - two rows a file left behind, which no stated unit can tell apart.
+-}
+withSameUnitFlow :: Database -> Database
+withSameUnitFlow db =
+    db{dbBioFlows = M.insert sameUnitFlowId co2Flow{bfId = sameUnitFlowId} (dbBioFlows db)}
+
+twinFlowId, sameUnitFlowId :: UUID
 twinFlowId = mkUUID 6
+sameUnitFlowId = mkUUID 7
 
 bioOf :: FlowRef -> Double -> Maybe Text -> AuthoredExchange
 bioOf flow amount unit =

--- a/test/JournalSpec.hs
+++ b/test/JournalSpec.hs
@@ -256,7 +256,7 @@ cheese =
                 , atiComment = Just "milk in"
                 }
             , AuthoredBio
-                { abFlow = ExistingFlow co2Id
+                { abFlow = FlowById co2Id
                 , abDirection = Emission
                 , abAmount = 0.5
                 , abUnit = Nothing
@@ -264,7 +264,7 @@ cheese =
                 }
             , AuthoredBio
                 { abFlow =
-                    NewBioFlow
+                    FlowByName
                         "Methane"
                         Compartment{compartmentName = "air", compartmentSub = Just "low population density"}
                         "kg"
@@ -281,7 +281,7 @@ methane :: AuthoredExchange
 methane =
     AuthoredBio
         { abFlow =
-            NewBioFlow
+            FlowByName
                 "Methane"
                 Compartment{compartmentName = "air", compartmentSub = Just "low population density"}
                 "kg"


### PR DESCRIPTION
## Why

Someone writing an inventory by hand hits this: they add an activity, then add
an emission the way the inventory shows it, `Nitrogen, total` in water. Today
that mints a second flow of that name. No characterization method knows the new
flow, so the emission scores as zero next to the curated flow it was meant to
be, and all the author sees is a warning that reads as routine. Reaching the
curated flow meant sending its identifier, and nothing a written inventory
shows carries identifiers, so the honest answer to "where do I find them" was
"search the flows first".

## What changes

A biosphere line that names its flow in words now addresses the flow the
database, or one of its dependencies, already declares under that name and
compartment. A name nothing answers to still brings a flow into the database,
with the warning it always carried.

Two flows can share a name and compartment and differ in unit, an energy
carrier recorded in kg and in MJ. The unit the exchange already states tells
them apart. Anything still ambiguous is refused, and the refusal lists the
candidates with their identifiers, which is where the author reads the one they
then have to write. Nothing else is guessed at: synonyms are not matched, and a
name written into the identifier field is refused with a line that says where
identifiers come from.

Candidates are read from the flow table itself rather than from the name index
a loaded database carries. That index is a runtime attachment a rebuild drops,
and a journal replayed without it would resolve a name differently than the
write that recorded it did.

In pyvolca, `BioExchange.introducing` is now `BioExchange.named`, since it no
longer only introduces.

## Checks

`cabal test` is green (2305 examples). Beyond the unit tests, an EcoSpold 2
dataset was loaded into a scratch engine and an activity written against it by
name: the exchange lands on the dataset's own flow identifier, with no warning,
and still does after a restart.
