### PR TITLE
Read a waste output's link as the activity that treats it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,9 +180,13 @@
   but the activity view read that link on the input side only, so a waste output
   answered with no target whatever it was linked to. Anything reading a waste
   output with no target as a final waste flow, which is what a waste nothing
-  treats is, then described every linked one as final. Databases written by hand
-  are where this shows, since authoring always records the treatment a waste
-  output goes to.
+  treats is, then described every linked one as final. The treatment is read off
+  the pair the matrix routes the waste on, activity and flow together, so the
+  row named is the one the score charged and never another product of the same
+  treatment. Databases written by hand are where this shows most, since
+  authoring always records the treatment a waste output goes to; an imported
+  file that states a link on a waste output is read the same way, which the
+  EcoSpold 2 reader carries through as written.
 - A Brightway Excel workbook loads from a directory, not only when its own
   path is named. The engine reads five database formats but the step that
   decides what a source directory holds knew four, so an uploaded `.xlsx` —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,14 @@
   an older engine.
 
 ### Fixed
+- A waste output now names the activity that treats it. An exchange records the
+  link to its treatment exactly as an input records the link to its supplier,
+  but the activity view read that link on the input side only, so a waste output
+  answered with no target whatever it was linked to. Anything reading a waste
+  output with no target as a final waste flow, which is what a waste nothing
+  treats is, then described every linked one as final. Databases written by hand
+  are where this shows, since authoring always records the treatment a waste
+  output goes to.
 - A Brightway Excel workbook loads from a directory, not only when its own
   path is named. The engine reads five database formats but the step that
   decides what a source directory holds knew four, so an uploaded `.xlsx` —

--- a/pyvolca/tests/test_waste_exchange.py
+++ b/pyvolca/tests/test_waste_exchange.py
@@ -9,8 +9,9 @@ for SimaPro "Final waste flows".
 This module covers the wire shape for both envelopes:
 
 * ``ExchangeWithUnit``: inner ``{tag: "WasteExchange", isInput, ...}`` plus
-  target fields at the envelope level when the cross-DB linker resolved the
-  waste output to a treatment activity.
+  target fields at the envelope level whenever a treatment was resolved,
+  either through the waste output's own link (a bare same-database process
+  id) or through the cross-DB linker (a ``db::pid`` one).
 * ``ExchangeDetail``: same inner shape, but the flow is carried as a
   ``{kind: "waste", flow: <wasteFlow>}`` tagged sum.
 """

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -1519,9 +1519,9 @@ data ExchangeWithUnit = ExchangeWithUnit
     , ewuUnitName :: Text -- Unit name for the exchange
     , ewuFlowName :: Text -- Name of the flow being exchanged
     , ewuCompartment :: Maybe Compartment -- Biosphere compartment, Nothing for technosphere
-    , ewuTargetActivityName :: Maybe Text -- For technosphere: name of target activity
-    , ewuTargetLocation :: Maybe Text -- For technosphere: location of target activity
-    , ewuTargetProcessId :: Maybe Text -- For technosphere: ProcessId for navigation (activityUUID_productUUID)
+    , ewuTargetActivityName :: Maybe Text -- Supplier, or the treatment a waste goes to; Nothing on a biosphere line
+    , ewuTargetLocation :: Maybe Text -- Location of that activity
+    , ewuTargetProcessId :: Maybe Text -- ProcessId for navigation (activityUUID_productUUID)
     , ewuExComment :: Maybe Text -- Free-text per-exchange comment (mirrors exchangeComment)
     , ewuPedigree :: Maybe Pedigree -- LCA data-quality scores when available (mirrors exchangePedigree)
     }

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -1130,9 +1130,13 @@ resolveTarget cfg db links = \case
     WasteExchange{waIsInput = True, waActivityLinkId = lid}
         | lid /= UUID.nil -> resolveByActivityUUID db lid
         | otherwise -> Nothing
+    -- An output's link names the activity that treats the waste, exactly as an
+    -- input's names the one that supplies it. Reading it as no target at all
+    -- makes a linked waste output indistinguishable from a final waste flow,
+    -- which is what a consumer reports when nothing treats a waste.
     WasteExchange{waIsInput = False, waActivityLinkId = lid, waFlowId = fid}
-        | lid == UUID.nil -> resolveByCrossDBLink links fid
-        | otherwise -> Nothing
+        | lid /= UUID.nil -> resolveByActivityUUID db lid
+        | otherwise -> resolveByCrossDBLink links fid
 
 {- | Flow name + (biosphere-only) compartment. Each variant has exactly one
 flow side by construction, so no Maybe-merge is needed downstream.

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -30,6 +30,7 @@ import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import Database (applyStructuredFilters, findActivitiesByFields, findFlowsBySynonym, flowNameRelevance)
+import Database.MatrixBuild (findProducer)
 import Matrix (DepDemands, Inventory, accumulateDepDemandsWith, activityNormalizationFactor, applyBiosphereMatrix, buildDemandVectorFromIndex, computeInventoryMatrix, depDemandsToVector, perturbA, perturbABatch, perturbGlobal, toList)
 import qualified Matrix.Export as MatrixExport
 import qualified Progress
@@ -1110,10 +1111,23 @@ resolveByProductFlow cfg db fId = do
 resolveByCrossDBLink :: M.Map UUID CrossDBLink -> UUID -> Maybe TargetRef
 resolveByCrossDBLink links fId = crossDBLinkToTarget <$> M.lookup fId links
 
+{- | The producer the matrix routes this exchange through: 'findProducer' is the
+same function the triples are built with, so a target named here is the row the
+score charged. The activity UUID alone would answer with an arbitrary product of
+a multi-product activity, and would name a treatment for a pair the matrix never
+routed.
+-}
+resolveByRoutedProducer :: Database -> Exchange -> Maybe TargetRef
+resolveByRoutedProducer db ex = do
+    pid <- findProducer (dbProcessIdLookup db) ex
+    act <- getActivity db pid
+    pure (activityToTarget db pid act)
+
 {- | Resolve the target activity (if any) for one exchange. Technosphere broken
 links (linkId set but unresolvable) do NOT fall through to the product-flow
 path — that matches the original behaviour. Use '<|>' to chain fallbacks only
-where the original code did.
+where the original code did. A waste output is the one arm resolved the way the
+matrix routes it; the others answer from the activity UUID alone.
 -}
 resolveTarget ::
     UnitConfig ->
@@ -1134,8 +1148,8 @@ resolveTarget cfg db links = \case
     -- input's names the one that supplies it. Reading it as no target at all
     -- makes a linked waste output indistinguishable from a final waste flow,
     -- which is what a consumer reports when nothing treats a waste.
-    WasteExchange{waIsInput = False, waActivityLinkId = lid, waFlowId = fid}
-        | lid /= UUID.nil -> resolveByActivityUUID db lid
+    ex@WasteExchange{waIsInput = False, waActivityLinkId = lid, waFlowId = fid}
+        | lid /= UUID.nil -> resolveByRoutedProducer db ex
         | otherwise -> resolveByCrossDBLink links fid
 
 {- | Flow name + (biosphere-only) compartment. Each variant has exactly one

--- a/test/AuthorSpec.hs
+++ b/test/AuthorSpec.hs
@@ -15,6 +15,7 @@ module AuthorSpec (spec) where
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.Text (Text, isInfixOf)
+import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU
@@ -52,6 +53,7 @@ import Types (
     TechnosphereFlow (..),
     UUID,
     Unit (..),
+    WasteFlow (..),
     exchangeAmount,
     findProcessId,
     getActivity,
@@ -288,20 +290,23 @@ spec = do
                 -- like. An authored one always has a treatment, so reading its
                 -- link as no target would report every one of them as final.
                 r <- resolveOrFail fixtureDb baseActivity{aaExchanges = [wasteOut treatPid 0.5 Nothing]}
-                case insertActivities defaultUnitConfig [r] fixtureDb of
-                    Left err -> expectationFailure ("insertActivities: " <> show err)
-                    Right db' ->
-                        case (uncurry (findProcessId db') (riKey r), findProcessId db' treatActId usedOilId) of
-                            (Just pid, Just treatmentPid) ->
-                                case getActivity db' pid of
-                                    Nothing -> expectationFailure "the inserted activity is not in the database"
-                                    Just act ->
-                                        case [ewu | ewu <- pfaExchanges (convertActivityForAPI defaultUnitConfig db' pid act), WasteExchange{waIsInput = False} <- [ewuExchange ewu]] of
-                                            [ewu] -> do
-                                                ewuTargetProcessId ewu `shouldBe` Just (processIdToText db' treatmentPid)
-                                                ewuTargetActivityName ewu `shouldBe` Just "waste oil incineration"
-                                            other -> expectationFailure ("expected one waste output, got " <> show (length other))
-                            _ -> expectationFailure "the authored activity or its treatment has no process id"
+                case insertedWasteOutput fixtureDb r of
+                    Left err -> expectationFailure (T.unpack err)
+                    Right (ewu, treatment) -> do
+                        ewuFlowName ewu `shouldBe` "used oil"
+                        ewuTargetProcessId ewu `shouldBe` Just treatment
+                        ewuTargetActivityName ewu `shouldBe` Just "waste oil incineration"
+
+            it "names the treatment's own row, not another product of the same activity" $ do
+                -- The matrix routes the waste on the pair (activity, flow); an
+                -- activity that answers to two process ids would otherwise be
+                -- reported at whichever product the UUID index happens to hold,
+                -- naming a row the score never charged.
+                db <- buildTwoProductTreatment
+                r <- resolveOrFail db baseActivity{aaExchanges = [wasteOut treatPid 0.5 Nothing]}
+                case insertedWasteOutput db r of
+                    Left err -> expectationFailure (T.unpack err)
+                    Right (ewu, treatment) -> ewuTargetProcessId ewu `shouldBe` Just treatment
 
             it "refuses a key the database already holds" $ do
                 r <- resolveOrFail fixtureDb baseActivity
@@ -521,6 +526,22 @@ wasteOut provider amount unit =
 treatPid :: Text
 treatPid = UUID.toText treatActId <> "_" <> UUID.toText usedOilId
 
+{- | Insert one resolved activity and read back its single waste-output line as
+the activity view describes it, next to the process id its treatment sits at.
+-}
+insertedWasteOutput :: Database -> ResolvedInsert -> Either Text (ExchangeWithUnit, Text)
+insertedWasteOutput db r = do
+    db' <- insertActivities defaultUnitConfig [r] db
+    pid <- note "the authored activity has no process id" (uncurry (findProcessId db') (riKey r))
+    act <- note "the inserted activity is not in the database" (getActivity db' pid)
+    treatment <- note "the treatment has no process id" (findProcessId db' treatActId usedOilId)
+    case [ewu | ewu <- pfaExchanges (convertActivityForAPI defaultUnitConfig db' pid act), WasteExchange{waIsInput = False} <- [ewuExchange ewu]] of
+        [ewu] -> Right (ewu, processIdToText db' treatment)
+        other -> Left ("expected one waste output, got " <> T.pack (show (length other)))
+  where
+    note :: Text -> Maybe a -> Either Text a
+    note msg = maybe (Left msg) Right
+
 -- | The biosphere flows one resolved activity points at, in exchange order.
 bioFlowIds :: ResolvedInsert -> [UUID]
 bioFlowIds r = [flowId | BiosphereExchange{bioFlowId = flowId} <- exchanges (riActivity r)]
@@ -723,7 +744,33 @@ buildFixtureAt actId prodId = do
                 ]
             )
             (M.singleton co2Id co2Flow)
-            M.empty
+            (M.singleton usedOilId usedOilWasteFlow)
+            unitTable
+    either (fail . show) pure r
+
+{- | The same fixture with a second product on the treatment, so its activity
+UUID answers to two process ids. Which of them a waste output resolves to is
+then a real question, and only the pair the matrix routes on answers it.
+-}
+buildTwoProductTreatment :: IO Database
+buildTwoProductTreatment = do
+    r <-
+        buildDatabaseWithMatrices
+            defaultUnitConfig
+            ( M.fromList
+                [ ((supplierActId, supplierProdId), supplierActivityAt supplierActId supplierProdId)
+                , ((treatActId, usedOilId), treatmentWithHeat)
+                , ((treatActId, heatId), treatmentWithHeat)
+                ]
+            )
+            ( M.fromList
+                [ (supplierProdId, milkFlowAt supplierProdId)
+                , (usedOilId, usedOilFlow)
+                , (heatId, heatFlow)
+                ]
+            )
+            (M.singleton co2Id co2Flow)
+            (M.singleton usedOilId usedOilWasteFlow)
             unitTable
     either (fail . show) pure r
 
@@ -747,12 +794,13 @@ buildBareFixture = do
 mkUUID :: Int -> UUID
 mkUUID n = UUID.fromWords64 (fromIntegral n) 0
 
-supplierActId, supplierProdId, co2Id, treatActId, usedOilId, highActId, highProdId, kgUnitId, itemUnitId, metreUnitId :: UUID
+supplierActId, supplierProdId, co2Id, treatActId, usedOilId, heatId, highActId, highProdId, kgUnitId, itemUnitId, metreUnitId :: UUID
 supplierActId = mkUUID 1
 supplierProdId = mkUUID 2
 co2Id = mkUUID 3
 treatActId = mkUUID 4
 usedOilId = mkUUID 5
+heatId = mkUUID 30
 highActId = UUID.fromWords64 maxBound 1
 highProdId = UUID.fromWords64 maxBound 2
 kgUnitId = mkUUID 10
@@ -793,6 +841,33 @@ co2Flow =
         , bfCompartment = Just air
         }
 
+{- | The same waste declared on the waste axis. A treatment's reference stays a
+technosphere product while the lines that send waste to it sit on the waste
+axis, so an import declares the flow in both tables.
+-}
+usedOilWasteFlow :: WasteFlow
+usedOilWasteFlow =
+    WasteFlow
+        { wfId = usedOilId
+        , wfName = "used oil"
+        , wfUnitId = kgUnitId
+        , wfSynonyms = M.empty
+        , wfCAS = Nothing
+        , wfSubstanceId = Nothing
+        }
+
+-- | The heat a treatment recovers, its second product.
+heatFlow :: TechnosphereFlow
+heatFlow =
+    TechnosphereFlow
+        { tfId = heatId
+        , tfName = "heat, recovered"
+        , tfUnitId = kgUnitId
+        , tfSynonyms = M.empty
+        , tfCAS = Nothing
+        , tfSubstanceId = Nothing
+        }
+
 usedOilFlow :: TechnosphereFlow
 usedOilFlow =
     TechnosphereFlow
@@ -802,6 +877,28 @@ usedOilFlow =
         , tfSynonyms = M.empty
         , tfCAS = Nothing
         , tfSubstanceId = Nothing
+        }
+
+{- | The same treatment, recovering heat as a second product. Its activity UUID
+then answers to two process ids, only one of which treats the waste.
+-}
+treatmentWithHeat :: Activity
+treatmentWithHeat =
+    treatmentActivity
+        { exchanges =
+            exchanges treatmentActivity
+                ++ [ TechnosphereExchange
+                        { techFlowId = heatId
+                        , techAmount = 3.0
+                        , techUnitId = kgUnitId
+                        , techRole = Coproduct
+                        , techActivityLinkId = UUID.nil
+                        , techProcessLinkId = Nothing
+                        , techLocation = ""
+                        , techComment = Nothing
+                        , techPedigree = Nothing
+                        }
+                   ]
         }
 
 {- | A treatment process: its only reference is an input, so it has no

--- a/test/AuthorSpec.hs
+++ b/test/AuthorSpec.hs
@@ -20,6 +20,7 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU
 import Test.Hspec
 
+import API.Types (ActivityForAPI (..), ExchangeWithUnit (..))
 import Database (buildDatabaseWithMatrices)
 import Database.Author (
     AuthorContext (..),
@@ -36,6 +37,7 @@ import Database.Author (
     validateAuthored,
  )
 import Database.Rebuild (deleteActivities, insertActivities, replaceActivities)
+import Service (convertActivityForAPI)
 import Types (
     Activity (..),
     BioDirection (..),
@@ -52,7 +54,9 @@ import Types (
     Unit (..),
     exchangeAmount,
     findProcessId,
+    getActivity,
     isTechnosphereExchange,
+    processIdToText,
  )
 import UnitConversion (defaultUnitConfig)
 
@@ -278,6 +282,26 @@ spec = do
                         M.member (snd (riKey r)) (dbTechFlows db') `shouldBe` True
                         map bfName (M.elems (dbBioFlows db')) `shouldSatisfy` elem "Nitrous oxide"
                         uncurry (findProcessId db') (riKey r) `shouldSatisfy` (/= Nothing)
+
+            it "names the treatment a waste output was linked to" $ do
+                -- A waste output with no target is what a final waste flow looks
+                -- like. An authored one always has a treatment, so reading its
+                -- link as no target would report every one of them as final.
+                r <- resolveOrFail fixtureDb baseActivity{aaExchanges = [wasteOut treatPid 0.5 Nothing]}
+                case insertActivities defaultUnitConfig [r] fixtureDb of
+                    Left err -> expectationFailure ("insertActivities: " <> show err)
+                    Right db' ->
+                        case (uncurry (findProcessId db') (riKey r), findProcessId db' treatActId usedOilId) of
+                            (Just pid, Just treatmentPid) ->
+                                case getActivity db' pid of
+                                    Nothing -> expectationFailure "the inserted activity is not in the database"
+                                    Just act ->
+                                        case [ewu | ewu <- pfaExchanges (convertActivityForAPI defaultUnitConfig db' pid act), WasteExchange{waIsInput = False} <- [ewuExchange ewu]] of
+                                            [ewu] -> do
+                                                ewuTargetProcessId ewu `shouldBe` Just (processIdToText db' treatmentPid)
+                                                ewuTargetActivityName ewu `shouldBe` Just "waste oil incineration"
+                                            other -> expectationFailure ("expected one waste output, got " <> show (length other))
+                            _ -> expectationFailure "the authored activity or its treatment has no process id"
 
             it "refuses a key the database already holds" $ do
                 r <- resolveOrFail fixtureDb baseActivity


### PR DESCRIPTION
A waste output carries the link to the activity that treats it, exactly as an input carries the link to its supplier. The activity view read that link on the input side only: a waste output answered with no target at all, whatever it was linked to.

That makes a linked waste output indistinguishable from a final waste flow, which is what a waste nothing treats is. A reader that tells the two apart by the target, and there is one, described every linked waste output as final.

The treatment is resolved through `findProducer`, the same function the technosphere triples are built with: it matches on the pair (activity, flow), so the row named is the row the score charged. Resolving from the activity UUID alone would name an arbitrary product of a multi-product treatment (the heat it recovers rather than the waste it treats), and would name a treatment for a pair the matrix never routed, which is a target shown next to a score of nothing.

Where it shows: databases written by hand, since authoring always records the treatment a waste output goes to. An imported file that states a link on a waste output is read the same way; the EcoSpold 2 reader copies `activityLinkId` through on both sides, so a file that carries one on an output is affected too.

Two specs, both red on the code before the change: one on the link being read at all (`expected: Just "...", but got: Nothing`), one on a treatment with two products (`...0005...` expected, `...001e...` given).
