### PR TITLE
Say what a waste output does, and find the treatment it names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 ## [Unreleased]
 
 ### Added
+- Every waste line of an activity now says what it does, as `wasteRole`. A
+  consumer had to work it out from the target being absent, and that reading
+  runs two opposite statements together: a waste nothing treats, which is a
+  complete description of an end-of-life flow, and a waste whose named
+  treatment is in no loaded database, which is a gap in what was loaded. Both
+  arrive with no target, and calling the second one final says the burden is
+  accounted for when it is missing. The four values are `TreatsWaste` for a
+  line the activity treats, `SentToTreatment` for one whose treatment was
+  found, `FinalWasteFlow` for an output naming no treatment, and
+  `TreatmentNotLoaded` for one naming a treatment that is nowhere to be found.
+  Only the engine holds both facts, so the engine now states the role instead
+  of leaving it to be guessed. This is wire revision 10.
 - A flow search now says what kind of flow each result is, and can be asked for
   one kind alone. Three different things answer to a name: a technosphere flow,
   meaning a product one activity makes and another consumes; a biosphere flow,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,19 @@
   an older engine.
 
 ### Fixed
+- A waste output that names its treatment now reaches that treatment when it
+  lives in another loaded database. The step that links a database to the ones
+  it depends on looked at waste outputs naming no treatment at all, and skipped
+  every output that named one, on the assumption that a named treatment is
+  always in the same file. That holds for an imported file and not for a
+  database written by hand, where naming the treatment is exactly how a waste
+  output is written: the waste was silently cut off and its burden counted as
+  zero. The link now decides which match applies, not whether the search
+  happens: an output naming a treatment is matched on that activity's identity,
+  one naming none on the waste flow itself, and neither falls back on the other,
+  since substituting a treatment found by name for the one the author named
+  would charge an activity nobody asked for. An output the database resolves in
+  place is still left to the matrix, so nothing is charged twice.
 - A waste output now names the activity that treats it. An exchange records the
   link to its treatment exactly as an input records the link to its supplier,
   but the activity view read that link on the input side only, so a waste output

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -24,7 +24,7 @@ The other direction is a promise about pyvolca's own names. A name this client p
 
 _Generated from `volca._compat`: run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.9.2** speaks wire formats **2 to 9** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error. A name this build has retired keeps working until pyvolca **1.0**.
+This build of **pyvolca 0.9.2** speaks wire formats **2 to 10** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error. A name this build has retired keeps working until pyvolca **1.0**.
 
 <!-- END: compatibility -->
 
@@ -1206,6 +1206,19 @@ Role a technosphere exchange plays within its host activity.
 ``COPRODUCT``: a secondary output (in allocated activities).
 ``REFERENCE_INPUT``: the reference input (in waste-treatment activities).
 ``INPUT``: any other technosphere input.
+
+### `WasteRole`
+
+What a waste line does within its activity.
+
+``TREATS_WASTE``: an input, so this activity is the one treating it.
+``SENT_TO_TREATMENT``: an output whose treatment was found.
+``FINAL_WASTE_FLOW``: an output naming no treatment, so nothing treats it.
+``TREATMENT_NOT_LOADED``: an output naming a treatment no loaded database
+ships, so its burden is missing rather than accounted for.
+
+The last two both arrive with no target, which is why the role is stated
+rather than worked out from the target fields.
 
 ## Exceptions
 
@@ -2470,8 +2483,10 @@ An exchange of a waste flow with a treatment activity.
 
 Shares the technosphere matrix with product flows but tracked as its own
 kind so callers can tell a "waste sent to landfill" output apart from a
-product input. Orphan waste (no linked treatment) contributes zero impact,
-the same cut-off semantics as an orphan technosphere input.
+product input. A waste output no treatment is found for contributes zero
+impact, the same cut-off semantics as an orphan technosphere input;
+``role`` says whether that is because nothing treats it or because the
+treatment it names was not loaded.
 
 | Field | Type | Default |
 |-------|------|---------|
@@ -2483,6 +2498,7 @@ the same cut-off semantics as an orphan technosphere input.
 | `target_location` | `str \| None` | _required_ |
 | `target_process_id` | `str \| None` | _required_ |
 | `comment` | `str \| None` | None |
+| `role` | `WasteRole \| None` | None |
 | `is_biosphere` | `bool` | False |
 | `is_waste` | `bool` | True |
 

--- a/pyvolca/src/volca/__init__.py
+++ b/pyvolca/src/volca/__init__.py
@@ -73,6 +73,7 @@ from .types import (
     UnmappedFlow,
     WasteExchange,
     WasteOutput,
+    WasteRole,
 )
 
 __all__ = [
@@ -149,6 +150,7 @@ __all__ = [
     "VoLCAError",
     "WasteExchange",
     "WasteOutput",
+    "WasteRole",
     "compare_activities",
     "download",
 ]

--- a/pyvolca/src/volca/_compat.py
+++ b/pyvolca/src/volca/_compat.py
@@ -33,7 +33,8 @@ the client works against it except the revision-gated capabilities (see
 before sending anything."""
 
 KNOWN_WIRE = 10
-"""The newest wire revision this pyvolca understands (revision 9 adds the kind
+"""The newest wire revision this pyvolca understands (revision 10 adds the role
+a waste line reports; revision 9 added the kind
 a flow search reports and filters on; revision 8 added the two
 quality reports as downloadable CSV; revision 7 added editing an activity's
 exchanges; revision 6 added explain_cf and the match_kind field on flow

--- a/pyvolca/src/volca/_compat.py
+++ b/pyvolca/src/volca/_compat.py
@@ -32,7 +32,7 @@ the client works against it except the revision-gated capabilities (see
 ``Client._require_wire``), which check the engine's advertised revision
 before sending anything."""
 
-KNOWN_WIRE = 9
+KNOWN_WIRE = 10
 """The newest wire revision this pyvolca understands (revision 9 adds the kind
 a flow search reports and filters on; revision 8 added the two
 quality reports as downloadable CSV; revision 7 added editing an activity's

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -977,14 +977,35 @@ class BiosphereExchange:
         )
 
 
+class WasteRole(_StrEnum):
+    """What a waste line does within its activity.
+
+    ``TREATS_WASTE``: an input, so this activity is the one treating it.
+    ``SENT_TO_TREATMENT``: an output whose treatment was found.
+    ``FINAL_WASTE_FLOW``: an output naming no treatment, so nothing treats it.
+    ``TREATMENT_NOT_LOADED``: an output naming a treatment no loaded database
+    ships, so its burden is missing rather than accounted for.
+
+    The last two both arrive with no target, which is why the role is stated
+    rather than worked out from the target fields.
+    """
+
+    TREATS_WASTE = "TreatsWaste"
+    SENT_TO_TREATMENT = "SentToTreatment"
+    FINAL_WASTE_FLOW = "FinalWasteFlow"
+    TREATMENT_NOT_LOADED = "TreatmentNotLoaded"
+
+
 @dataclass
 class WasteExchange:
     """An exchange of a waste flow with a treatment activity.
 
     Shares the technosphere matrix with product flows but tracked as its own
     kind so callers can tell a "waste sent to landfill" output apart from a
-    product input. Orphan waste (no linked treatment) contributes zero impact,
-    the same cut-off semantics as an orphan technosphere input.
+    product input. A waste output no treatment is found for contributes zero
+    impact, the same cut-off semantics as an orphan technosphere input;
+    ``role`` says whether that is because nothing treats it or because the
+    treatment it names was not loaded.
     """
 
     flow_name: str
@@ -995,6 +1016,7 @@ class WasteExchange:
     target_location: str | None
     target_process_id: str | None
     comment: str | None = None
+    role: WasteRole | None = None  # None from an engine older than wire 10
 
     is_biosphere: bool = False
     is_waste: bool = True
@@ -1011,6 +1033,7 @@ class WasteExchange:
     @classmethod
     def from_json(cls, ewu: dict) -> "WasteExchange":
         inner = ewu["exchange"]
+        raw_role = ewu.get("wasteRole")
         return cls(
             flow_name=ewu["flowName"],
             amount=inner["amount"],
@@ -1020,6 +1043,7 @@ class WasteExchange:
             target_location=ewu.get("targetLocation"),
             target_process_id=ewu.get("targetProcessId"),
             comment=_exchange_comment(ewu, inner),
+            role=WasteRole(raw_role) if raw_role else None,
         )
 
 

--- a/pyvolca/tests/test_waste_exchange.py
+++ b/pyvolca/tests/test_waste_exchange.py
@@ -11,7 +11,8 @@ This module covers the wire shape for both envelopes:
 * ``ExchangeWithUnit``: inner ``{tag: "WasteExchange", isInput, ...}`` plus
   target fields at the envelope level whenever a treatment was resolved,
   either through the waste output's own link (a bare same-database process
-  id) or through the cross-DB linker (a ``db::pid`` one).
+  id) or through the cross-DB linker (a ``db::pid`` one), plus a
+  ``wasteRole`` saying what the line does (wire 10 and above).
 * ``ExchangeDetail``: same inner shape, but the flow is carried as a
   ``{kind: "waste", flow: <wasteFlow>}`` tagged sum.
 """
@@ -24,12 +25,13 @@ from volca.types import (
     BiosphereExchange,
     TechnosphereExchange,
     WasteExchange,
+    WasteRole,
     parse_exchange,
     parse_exchange_detail,
 )
 
 
-def _waste_ewu(*, is_input: bool, target: dict | None = None) -> dict:
+def _waste_ewu(*, is_input: bool, target: dict | None = None, role: str | None = None) -> dict:
     out: dict = {
         "exchange": {
             "tag": "WasteExchange",
@@ -42,6 +44,8 @@ def _waste_ewu(*, is_input: bool, target: dict | None = None) -> dict:
         "targetLocation": (target or {}).get("location"),
         "targetProcessId": (target or {}).get("processId"),
     }
+    if role is not None:
+        out["wasteRole"] = role
     return out
 
 
@@ -87,6 +91,19 @@ class TestParseExchangeWaste:
         assert ex.target_activity_name == "Landfill of organic waste, FR"
         assert ex.target_location == "FR"
         assert ex.target_process_id == target["processId"]
+
+    def test_role_tells_a_final_waste_from_a_treatment_that_is_missing(self):
+        # Both lines have no target, and they say opposite things: one is a
+        # complete end-of-life flow, the other a gap in what was loaded.
+        final = parse_exchange(_waste_ewu(is_input=False, role="FinalWasteFlow"))
+        missing = parse_exchange(_waste_ewu(is_input=False, role="TreatmentNotLoaded"))
+        assert final.target_process_id is None
+        assert missing.target_process_id is None
+        assert final.role is WasteRole.FINAL_WASTE_FLOW
+        assert missing.role is WasteRole.TREATMENT_NOT_LOADED
+
+    def test_role_is_none_from_an_engine_that_does_not_send_one(self):
+        assert parse_exchange(_waste_ewu(is_input=False)).role is None
 
     def test_discriminator_flags_set_correctly(self):
         """Duck-typing flags must place waste alongside neither tech nor bio."""

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1279,7 +1279,8 @@ appears that a client must know about /before/ calling it. Adding a route
 does not exempt a change from the bump: an absent route answers 404, and so
 does a request naming a database the engine has not loaded, so a client
 cannot tell "this engine is too old" from "you asked for the wrong thing"
-(revision 9: the @kind@ a flow search reports and filters on;
+(revision 10: the @wasteRole@ an activity's waste lines report;
+revision 9: the @kind@ a flow search reports and filters on;
 revision 8: the two quality reports as downloadable CSV;
 revision 7: editing the exchanges of an activity the database already holds;
 revision 6: the explain-cf route, and the @match_kind@ field flow
@@ -1292,7 +1293,7 @@ the whole filtered set).
 Clients compare it to decide compatibility and to gate such capabilities.
 -}
 currentWireVersion :: Int
-currentWireVersion = 9
+currentWireVersion = 10
 
 getVersion :: AppM Value
 getVersion =

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -34,7 +34,7 @@ import Database.Author (
  )
 import GHC.Generics
 import Servant.API.ContentTypes (MimeRender (..), MimeUnrender (..), OctetStream)
-import Types (BioDirection (..), BiosphereFlow (..), Compartment (..), DocSection (..), Exchange, ExchangeKind (..), FlowKind (..), NativeActivityType (..), Pedigree, Severity, TechnosphereFlow (..), UUID, Unit, WasteFlow (..), exchangeKindName)
+import Types (BioDirection (..), BiosphereFlow (..), Compartment (..), DocSection (..), Exchange, ExchangeKind (..), FlowKind (..), NativeActivityType (..), Pedigree, Severity, TechnosphereFlow (..), UUID, Unit, WasteFlow (..), WasteRole (..), exchangeKindName)
 
 {- | Tagged wire representation of either side of the flow split.
 
@@ -1522,6 +1522,7 @@ data ExchangeWithUnit = ExchangeWithUnit
     , ewuTargetActivityName :: Maybe Text -- Supplier, or the treatment a waste goes to; Nothing on a biosphere line
     , ewuTargetLocation :: Maybe Text -- Location of that activity
     , ewuTargetProcessId :: Maybe Text -- ProcessId for navigation (activityUUID_productUUID)
+    , ewuWasteRole :: Maybe WasteRole -- What a waste line does; Nothing on every other kind
     , ewuExComment :: Maybe Text -- Free-text per-exchange comment (mirrors exchangeComment)
     , ewuPedigree :: Maybe Pedigree -- LCA data-quality scores when available (mirrors exchangePedigree)
     }

--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -53,6 +53,7 @@ module Database.CrossLinking (
     findSupplierInIndexedDBs,
     findSupplierByActivityProduct,
     findWasteTreatmentAcrossDatabases,
+    findWasteTreatmentByActivity,
     WasteTreatmentMatch (..),
 
     -- * Scoring Functions
@@ -79,7 +80,7 @@ import Control.Applicative ((<|>))
 import Data.Bifunctor (first)
 import Data.Char (isAlpha, isUpper)
 import Data.Foldable (find)
-import Data.List (maximumBy)
+import Data.List (maximumBy, nub)
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Ord (comparing)
@@ -610,6 +611,34 @@ findWasteTreatmentAcrossDatabases LinkingContext{lcIndexedDatabases} flowUUID fl
                 [_] -> WasteNoMatch -- single DB with multiple candidates: stay orphan
                 [] -> WasteNoMatch
                 manyDbs -> WasteAmbiguous (map fst manyDbs)
+
+{- | The treatment a waste output's own link names, looked up in the loaded
+databases. The link is the dataset author's own disambiguation, so the match is
+strict on identity: same waste flow, same activity UUID, no name match, no
+location widening. Two databases shipping that identity resolve to
+'WasteAmbiguous' rather than a first-wins pick, as everywhere else here.
+
+Waste treatments live in 'idbWasteTreatmentByFlowUUID' and nowhere else:
+'idbByActivityProduct' is built from activities whose reference is a
+technosphere product, which a treatment's never is.
+-}
+findWasteTreatmentByActivity ::
+    LinkingContext ->
+    -- | Activity the waste output links to
+    UUID ->
+    -- | Waste flow UUID
+    UUID ->
+    WasteTreatmentMatch
+findWasteTreatmentByActivity LinkingContext{lcIndexedDatabases} actUUID flowUUID =
+    case [ (idbName idb, entry)
+         | idb <- lcIndexedDatabases
+         , Just entries <- [M.lookup flowUUID (idbWasteTreatmentByFlowUUID idb)]
+         , entry <- entries
+         , seActivityUUID entry == actUUID
+         ] of
+        [(dbN, entry)] -> WasteMatched entry dbN
+        [] -> WasteNoMatch
+        matches -> WasteAmbiguous (nub (map fst matches))
 
 {- | Find a supplier across all loaded databases (using pre-built indexes)
 This is the fast O(1) lookup version

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -133,6 +133,7 @@ import Database.CrossLinking (
     findSupplierAcrossDatabases,
     findSupplierByActivityProduct,
     findWasteTreatmentAcrossDatabases,
+    findWasteTreatmentByActivity,
     locationHierarchy,
     normalizeUnicode,
  )
@@ -1862,8 +1863,10 @@ A link whose target resolves in the internal matrix would be double-counted by
 a cross-DB link too, so 'resolvesInternally' gates it out — mirroring
 'Database.MatrixBuild.findProducer': a populated process link, or a non-nil
 @activityLinkId@ whose @(linkId, flowId)@ key is one of this database's own
-('lsOwnKeys'). Orphan waste outputs (waIsInput=False, linkId=nil) use the strict
-'findWasteTreatmentAcrossDatabases' — no synonym, no widening.
+('lsOwnKeys'). Waste outputs take the same gate, then a strict matcher chosen by
+their link — 'findWasteTreatmentByActivity' when they name a treatment,
+'findWasteTreatmentAcrossDatabases' when they name none — with no synonym and
+no widening in either.
 -}
 findExchangeCrossDBLink ::
     LinkScan ->
@@ -1962,44 +1965,57 @@ findExchangeCrossDBLink LinkScan{lsCtx = ctx, lsOwnKeys = ownKeys, lsTechFlows =
                 , cdlLocationUnresolved = unresolved
                 }
 findExchangeCrossDBLink _ _ _ BiosphereExchange{} = mempty
--- Cross-DB linking for orphan waste OUTPUTS: strict match only — see
--- 'findWasteTreatmentAcrossDatabases'. No synonym, no fuzzy name match, no
--- location widening. Multi-DB matches stay orphan as 'cdlWasteAmbiguous'.
+-- Cross-DB linking for waste OUTPUTS the internal matrix does not route:
+-- strict match only. No synonym, no fuzzy name match, no location widening.
+-- Multi-DB matches stay orphan as 'cdlWasteAmbiguous'. Which matcher applies
+-- follows the link: an output that names its treatment is matched on that
+-- identity, one that names none on the flow itself. Neither falls back on the
+-- other — substituting a treatment found by name for the one the author named
+-- would link the waste to an activity nobody asked for.
 -- Waste inputs (treatment side) are left alone: they have no clean LCA
 -- semantic as a cross-DB demand.
-findExchangeCrossDBLink LinkScan{lsCtx = ctx, lsWasteFlows = wasteFlowDb} consumerActUUID consumerProdUUID WasteExchange{waFlowId = fid, waAmount = amt, waActivityLinkId = lid, waIsInput = isInp}
-    | not isInp && lid == UUID.nil =
-        let flowName = maybe "" wfName (M.lookup fid wasteFlowDb)
-         in case findWasteTreatmentAcrossDatabases ctx fid flowName of
-                WasteMatched entry dbN ->
-                    let
-                        -- The dep-demand solve drives the matched treatment in
-                        -- its OWN reference convention: an EcoSpold2 treatment
-                        -- has a negative-output reference ('seRefSign' = -1),
-                        -- an ILCD one a positive 'ReferenceInput' (+1). The
-                        -- consumer's waste-output amount is positive, so we
-                        -- carry the treatment's sign into the coefficient —
-                        -- without it a negative-reference background treatment
-                        -- scores the treated waste's burden with a flipped sign.
-                        !crossLink =
-                            CrossDBLink
-                                { cdlConsumerActUUID = consumerActUUID
-                                , cdlConsumerProdUUID = consumerProdUUID
-                                , cdlConsumerFlowId = fid
-                                , cdlSupplierActUUID = seActivityUUID entry
-                                , cdlSupplierProdUUID = seProductUUID entry
-                                , cdlCoefficient = amt * seRefSign entry
-                                , cdlExchangeUnit = seUnit entry
-                                , cdlFlowName = seProductName entry
-                                , cdlLocation = seLocation entry
-                                , cdlSourceDatabase = dbN
-                                , cdlTiedAlternatives = []
-                                }
-                     in
-                        mempty{cdlLinks = [crossLink], cdlWasteExactLinks = 1}
-                WasteAmbiguous _ -> mempty{cdlWasteAmbiguous = 1}
-                WasteNoMatch -> mempty{cdlCutoffWasteCount = 1}
+findExchangeCrossDBLink LinkScan{lsCtx = ctx, lsOwnKeys = ownKeys, lsWasteFlows = wasteFlowDb} consumerActUUID consumerProdUUID ex@WasteExchange{waFlowId = fid, waAmount = amt, waActivityLinkId = lid, waIsInput = isInp}
+    | not isInp && not resolvesInternally =
+        case treatmentMatch of
+            WasteMatched entry dbN ->
+                let
+                    -- The dep-demand solve drives the matched treatment in
+                    -- its OWN reference convention: an EcoSpold2 treatment
+                    -- has a negative-output reference ('seRefSign' = -1),
+                    -- an ILCD one a positive 'ReferenceInput' (+1). The
+                    -- consumer's waste-output amount is positive, so we
+                    -- carry the treatment's sign into the coefficient —
+                    -- without it a negative-reference background treatment
+                    -- scores the treated waste's burden with a flipped sign.
+                    !crossLink =
+                        CrossDBLink
+                            { cdlConsumerActUUID = consumerActUUID
+                            , cdlConsumerProdUUID = consumerProdUUID
+                            , cdlConsumerFlowId = fid
+                            , cdlSupplierActUUID = seActivityUUID entry
+                            , cdlSupplierProdUUID = seProductUUID entry
+                            , cdlCoefficient = amt * seRefSign entry
+                            , cdlExchangeUnit = seUnit entry
+                            , cdlFlowName = seProductName entry
+                            , cdlLocation = seLocation entry
+                            , cdlSourceDatabase = dbN
+                            , cdlTiedAlternatives = []
+                            }
+                 in
+                    mempty{cdlLinks = [crossLink], cdlWasteExactLinks = 1}
+            WasteAmbiguous _ -> mempty{cdlWasteAmbiguous = 1}
+            WasteNoMatch -> mempty{cdlCutoffWasteCount = 1}
     | otherwise = mempty
+  where
+    -- Same gate as the technosphere arm: a link the matrix already routes in
+    -- place would be counted twice if a cross-DB link were emitted for it too.
+    resolvesInternally =
+        isJust (exchangeProcessLinkId ex)
+            || (lid /= UUID.nil && S.member (lid, fid) ownKeys)
+    treatmentMatch
+        | lid /= UUID.nil = findWasteTreatmentByActivity ctx lid fid
+        | otherwise = findWasteTreatmentAcrossDatabases ctx fid flowName
+    flowName = maybe "" wfName (M.lookup fid wasteFlowDb)
 
 -- | Report cross-database linking statistics
 reportCrossDBLinkingStats :: Int -> CrossDBLinkingStats -> IO ()

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -1152,6 +1152,25 @@ resolveTarget cfg db links = \case
         | lid /= UUID.nil -> resolveByRoutedProducer db ex
         | otherwise -> resolveByCrossDBLink links fid
 
+{- | What a waste line does, given the target 'resolveTarget' found for it.
+'Nothing' on every other kind, which is what makes the field a statement about
+waste rather than a target-shaped restatement of the three fields next to it.
+
+The distinction the caller cannot make for itself is the last two: an output
+naming no treatment describes an end-of-life flow completely, while an output
+whose named treatment resolved to nothing is a gap in what was loaded. Both
+arrive with no target.
+-}
+wasteRoleOf :: Maybe TargetRef -> Exchange -> Maybe WasteRole
+wasteRoleOf target = \case
+    TechnosphereExchange{} -> Nothing
+    BiosphereExchange{} -> Nothing
+    WasteExchange{waIsInput = True} -> Just TreatsWaste
+    WasteExchange{waActivityLinkId = lid}
+        | isJust target -> Just SentToTreatment
+        | lid /= UUID.nil -> Just TreatmentNotLoaded
+        | otherwise -> Just FinalWasteFlow
+
 {- | Flow name + (biosphere-only) compartment. Each variant has exactly one
 flow side by construction, so no Maybe-merge is needed downstream.
 -}
@@ -1195,6 +1214,7 @@ toExchangeWithUnit cfg db links exchange =
             , ewuTargetActivityName = trName <$> target
             , ewuTargetLocation = trLocation <$> target
             , ewuTargetProcessId = trProcessId <$> target
+            , ewuWasteRole = wasteRoleOf target exchange
             , ewuExComment = exchangeComment exchange
             , ewuPedigree = exchangePedigree exchange
             }

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -1147,9 +1147,12 @@ resolveTarget cfg db links = \case
     -- An output's link names the activity that treats the waste, exactly as an
     -- input's names the one that supplies it. Reading it as no target at all
     -- makes a linked waste output indistinguishable from a final waste flow,
-    -- which is what a consumer reports when nothing treats a waste.
+    -- which is what a consumer reports when nothing treats a waste. A named
+    -- treatment this database does not hold falls through to the cross-DB link
+    -- the loader built for it, for the same reason as everywhere here: the row
+    -- named must be the row the score charged, and that link is charged.
     ex@WasteExchange{waIsInput = False, waActivityLinkId = lid, waFlowId = fid}
-        | lid /= UUID.nil -> resolveByRoutedProducer db ex
+        | lid /= UUID.nil -> resolveByRoutedProducer db ex <|> resolveByCrossDBLink links fid
         | otherwise -> resolveByCrossDBLink links fid
 
 {- | What a waste line does, given the target 'resolveTarget' found for it.

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -702,6 +702,27 @@ exchangeKindName KindTechnosphere = "technosphere"
 exchangeKindName KindBiosphere = "biosphere"
 exchangeKindName KindWaste = "waste"
 
+{- | What a waste line does within its activity.
+
+A consumer used to read this off the target being absent, which conflates two
+opposite statements: a waste nothing treats, and a waste whose named treatment
+is in no loaded database. The first is a complete description of an end-of-life
+flow, the second is a gap in what was loaded, and calling the second final says
+the burden is accounted for when it is missing. Only the engine holds both
+facts, so the engine states the role instead of leaving it to be inferred.
+-}
+data WasteRole
+    = -- | An input: this activity is the one treating the waste.
+      TreatsWaste
+    | -- | An output whose treatment resolved.
+      SentToTreatment
+    | -- | An output naming no treatment: nothing treats this waste.
+      FinalWasteFlow
+    | -- | An output naming a treatment no loaded database ships.
+      TreatmentNotLoaded
+    deriving (Eq, Show, Generic, NFData, Enum, Bounded)
+    deriving anyclass (ToSchema)
+
 {- | Read a kind a request asked for. 'Nothing' for anything else, so the
 caller refuses with its own message rather than filtering on a guess.
 -}
@@ -1661,6 +1682,9 @@ data CrossDBLink = CrossDBLink
 -- the default Generic encoding (constructor name as JSON string).
 instance ToJSON TechRole
 instance FromJSON TechRole
+
+instance ToJSON WasteRole
+instance FromJSON WasteRole
 
 instance ToJSON BioDirection
 instance FromJSON BioDirection

--- a/test/AuthorSpec.hs
+++ b/test/AuthorSpec.hs
@@ -54,6 +54,7 @@ import Types (
     UUID,
     Unit (..),
     WasteFlow (..),
+    WasteRole (..),
     exchangeAmount,
     findProcessId,
     getActivity,
@@ -296,6 +297,7 @@ spec = do
                         ewuFlowName ewu `shouldBe` "used oil"
                         ewuTargetProcessId ewu `shouldBe` Just treatment
                         ewuTargetActivityName ewu `shouldBe` Just "waste oil incineration"
+                        ewuWasteRole ewu `shouldBe` Just SentToTreatment
 
             it "names the treatment's own row, not another product of the same activity" $ do
                 -- The matrix routes the waste on the pair (activity, flow); an

--- a/test/ServiceSpec.hs
+++ b/test/ServiceSpec.hs
@@ -14,9 +14,10 @@ import API.Types (
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.Text (Text)
-import Data.UUID (nil, toText)
+import Data.UUID (fromWords, nil, toText)
 import Service (
     ServiceError (..),
+    TargetRef (..),
     buildUnitGroups,
     extractCompartment,
     filterTreeExport,
@@ -24,6 +25,7 @@ import Service (
     resolveActivityAndProcessId,
     validateProcessIdInMatrixIndex,
     validateUUID,
+    wasteRoleOf,
  )
 import Test.Hspec
 import TestHelpers (loadSampleDatabase)
@@ -185,6 +187,46 @@ spec = do
     -- -----------------------------------------------------------------------
     -- filterTreeExport
     -- -----------------------------------------------------------------------
+    -- -----------------------------------------------------------------------
+    -- wasteRoleOf
+    -- -----------------------------------------------------------------------
+    describe "wasteRoleOf" $ do
+        let treatment = TargetRef "waste oil incineration" "GLO" "aaa_bbb"
+            wasteLine isInput link =
+                WasteExchange
+                    { waFlowId = nil
+                    , waAmount = 1.0
+                    , waUnitId = nil
+                    , waIsInput = isInput
+                    , waActivityLinkId = link
+                    , waProcessLinkId = Nothing
+                    , waLocation = ""
+                    , waComment = Nothing
+                    , waPedigree = Nothing
+                    }
+            linked = fromWords 1 2 3 4
+
+        it "calls an input a treatment of the waste" $
+            wasteRoleOf (Just treatment) (wasteLine True linked) `shouldBe` Just TreatsWaste
+
+        it "calls a resolved output a waste sent to treatment" $
+            wasteRoleOf (Just treatment) (wasteLine False linked) `shouldBe` Just SentToTreatment
+
+        it "calls an output naming no treatment a final waste flow" $
+            wasteRoleOf Nothing (wasteLine False nil) `shouldBe` Just FinalWasteFlow
+
+        -- The distinction the whole field exists for: this output states that
+        -- something treats the waste, so calling it final would report a
+        -- missing database as an accounted-for end of life.
+        it "does not call an output whose named treatment is missing final" $
+            wasteRoleOf Nothing (wasteLine False linked) `shouldBe` Just TreatmentNotLoaded
+
+        it "leaves every other kind of line without a role" $ do
+            let bio = BiosphereExchange nil 1.0 nil Emission "" Nothing Nothing
+                tech = TechnosphereExchange nil 1.0 nil Input nil Nothing "" Nothing Nothing
+            wasteRoleOf Nothing bio `shouldBe` Nothing
+            wasteRoleOf (Just treatment) tech `shouldBe` Nothing
+
     describe "filterTreeExport" $ do
         it "keeps matching node and its ancestor" $
             let export =

--- a/test/WasteCrossDBSpec.hs
+++ b/test/WasteCrossDBSpec.hs
@@ -11,16 +11,18 @@ import SynonymDB (emptySynonymDB)
 import Test.Hspec
 import qualified UnitConversion as UC
 
-{- | Unit tests for the exact-match cross-DB waste-treatment linker.
+{- | Unit tests for the exact-match cross-DB waste-treatment linkers.
 
-The linker honors only author-provided alignment: same flow UUID or
-byte-exact normalized name on the supplier's reference product. There is
-no synonym graph, no compound-name extraction, no widening, no scoring.
-Multiple databases offering a candidate resolves to 'WasteAmbiguous',
-never to a first-wins auto-pick.
+Both honor only author-provided alignment, and differ in what the waste
+output states: 'findWasteTreatmentAcrossDatabases' matches an output naming
+no treatment, on flow UUID or byte-exact normalized name;
+'findWasteTreatmentByActivity' matches one naming its treatment, on that
+activity's identity. There is no synonym graph, no compound-name extraction,
+no widening, no scoring. Multiple databases offering a candidate resolves to
+'WasteAmbiguous', never to a first-wins auto-pick.
 -}
 spec :: Spec
-spec = describe "findWasteTreatmentAcrossDatabases" $ do
+spec = describe "Cross-DB waste-treatment matching" $ do
     let supplierFor :: Text -> SupplierEntry
         supplierFor nm =
             SupplierEntry
@@ -126,3 +128,29 @@ spec = describe "findWasteTreatmentAcrossDatabases" $ do
                     , idbWith "wfldb" [] [("organic carbon, placed in landfill", entry)]
                     ]
         expectMatched "ecoinvent" (findWasteTreatmentAcrossDatabases ctx wasteUUID "Organic carbon, placed in landfill")
+
+    let treatActUUID = seActivityUUID entry
+        otherActUUID = UUID.fromWords 8 8 8 8
+
+    it "matches the treatment a waste output's link names" $ do
+        let ctx = ctxWith [idbWith "ecoinvent" [(wasteUUID, entry)] []]
+        expectMatched "ecoinvent" (findWasteTreatmentByActivity ctx treatActUUID wasteUUID)
+
+    it "stays orphan when the named activity treats the flow in no loaded DB" $ do
+        let ctx = ctxWith [idbWith "ecoinvent" [(wasteUUID, entry)] []]
+        expectNoMatch (findWasteTreatmentByActivity ctx otherActUUID wasteUUID)
+
+    it "ignores the name index: a named link is matched on identity alone" $ do
+        let ctx = ctxWith [idbWith "ecoinvent" [] [("organic carbon, placed in landfill", entry)]]
+        expectNoMatch (findWasteTreatmentByActivity ctx treatActUUID wasteUUID)
+
+    it "reports WasteAmbiguous when two databases ship that same treatment" $ do
+        let ctx =
+                ctxWith
+                    [ idbWith "ecoinvent-3.9" [(wasteUUID, entry)] []
+                    , idbWith "ecoinvent-3.10" [(wasteUUID, entry)] []
+                    ]
+        case findWasteTreatmentByActivity ctx treatActUUID wasteUUID of
+            WasteAmbiguous dbs -> dbs `shouldMatchList` ["ecoinvent-3.9", "ecoinvent-3.10"]
+            WasteMatched _ dbN -> expectationFailure $ "expected ambiguous, got match in " <> show dbN
+            WasteNoMatch -> expectationFailure "expected ambiguous, got no match"

--- a/test/WasteTreatmentSignSpec.hs
+++ b/test/WasteTreatmentSignSpec.hs
@@ -171,28 +171,39 @@ scoreIntra name acts = do
         Nothing -> fail "producer not interned"
         Just pid -> co2Of <$> computeInventoryMatrix db (fromIntegral pid)
 
-{- | Cross-DB scoring: a root DB whose orphan waste OUTPUT is resolved — by the
-real linker ('findAllCrossDBLinks' → 'findWasteTreatmentAcrossDatabases') — to a
-treatment in a separate dependency DB, then scored through the dep-demand solve.
-Going through the linker (rather than a hand-built 'CrossDBLink') is the point:
-that is where the treatment's reference-sign correction is applied.
+-- | A linking context holding one dependency database.
+ctxWithDep :: T.Text -> Database -> LinkingContext
+ctxWithDep depName depDB =
+    LinkingContext
+        { lcIndexedDatabases = [buildIndexedDatabaseFromDB depName emptySynonymDB depDB]
+        , lcSynonymDB = emptySynonymDB
+        , lcUnitConfig = defaultUnitConfig
+        , lcThreshold = defaultLinkingThreshold
+        , lcLocationHierarchy = M.empty
+        , lcGeographyPolicy = GeoExact
+        , lcSupplierAliases = emptyAliasMap
+        }
+
+-- | The cross-DB links the real linker finds for one root activity map.
+linksFor :: LinkingContext -> M.Map (UUID, UUID) Activity -> [CrossDBLink]
+linksFor ctx = cdlLinks . findAllCrossDBLinks ctx techFlowDB wasteFlowDB (M.singleton kgU (Unit kgU "kg" "kg" ""))
+
+{- | Cross-DB scoring: a root DB whose waste OUTPUT is resolved by the real
+linker ('findAllCrossDBLinks') to a treatment in a separate dependency DB, then
+scored through the dep-demand solve. Going through the linker (rather than a
+hand-built 'CrossDBLink') is the point: that is where the treatment's
+reference-sign correction is applied.
+
+@rootLink@ is what the waste output states about its treatment: 'UUID.nil' for
+an output naming none, @tA@ for one naming the dependency's treatment. Both
+must reach the same treatment and the same score.
 -}
-scoreCross :: T.Text -> TechRole -> Double -> IO Double
-scoreCross depName depRole depRefAmount = do
-    let rootActs = M.singleton (pA, yY) (producer (wasteEx False UUID.nil 3.0))
+scoreCross :: UUID -> T.Text -> TechRole -> Double -> IO Double
+scoreCross rootLink depName depRole depRefAmount = do
+    let rootActs = M.singleton (pA, yY) (producer (wasteEx False rootLink 3.0))
     rootBase <- buildDB "root" rootActs
     depDB <- buildDB depName (M.singleton (tA, wW) (treatment depRole depRefAmount))
-    let ctx =
-            LinkingContext
-                { lcIndexedDatabases = [buildIndexedDatabaseFromDB depName emptySynonymDB depDB]
-                , lcSynonymDB = emptySynonymDB
-                , lcUnitConfig = defaultUnitConfig
-                , lcThreshold = defaultLinkingThreshold
-                , lcLocationHierarchy = M.empty
-                , lcGeographyPolicy = GeoExact
-                , lcSupplierAliases = emptyAliasMap
-                }
-        links = cdlLinks (findAllCrossDBLinks ctx techFlowDB wasteFlowDB (M.singleton kgU (Unit kgU "kg" "kg" "")) rootActs)
+    let links = linksFor (ctxWithDep depName depDB) rootActs
         rootDB = rootBase{dbCrossDBLinks = links}
     if null links
         then fail "linker created no cross-DB waste link (matcher did not fire)"
@@ -233,9 +244,29 @@ spec = describe "Waste-treatment scoring sign across reference conventions" $ do
         withinTolerance 1.0e-9 6.0 score `shouldBe` True
 
     it "cross-DB to an ILCD (positive ReferenceInput) treatment scores +6" $ do
-        score <- scoreCross "ilcd-dep" ReferenceInput 1.0
+        score <- scoreCross UUID.nil "ilcd-dep" ReferenceInput 1.0
         withinTolerance 1.0e-9 6.0 score `shouldBe` True
 
     it "cross-DB to an ecoinvent (negative ReferenceProduct) treatment scores +6" $ do
-        score <- scoreCross "eco-dep" ReferenceProduct (-1.0)
+        score <- scoreCross UUID.nil "eco-dep" ReferenceProduct (-1.0)
         withinTolerance 1.0e-9 6.0 score `shouldBe` True
+
+    -- An authored waste output states the treatment it goes to. When that
+    -- treatment lives in a dependency, naming it must reach the dependency
+    -- just as naming nothing does; reading the link as "resolved elsewhere"
+    -- cut the waste off with no burden at all.
+    it "cross-DB from a waste output that names the dependency's treatment scores +6" $ do
+        score <- scoreCross tA "eco-dep" ReferenceProduct (-1.0)
+        withinTolerance 1.0e-9 6.0 score `shouldBe` True
+
+    -- The other half of the same gate: a link the root database resolves in
+    -- place is the matrix's business, and a cross-DB link on top would charge
+    -- the treatment twice.
+    it "a waste output linked inside its own database gets no cross-DB link" $ do
+        let rootActs =
+                M.fromList
+                    [ ((pA, yY), producer (wasteEx False tA 3.0))
+                    , ((tA, wW), treatment ReferenceProduct (-1.0))
+                    ]
+        depDB <- buildDB "eco-dep" (M.singleton (tA, wW) (treatment ReferenceProduct (-1.0)))
+        linksFor (ctxWithDep "eco-dep" depDB) rootActs `shouldBe` []

--- a/test/WasteTreatmentSignSpec.hs
+++ b/test/WasteTreatmentSignSpec.hs
@@ -21,6 +21,7 @@ every case — treating waste adds burden, it never subtracts it.
 -}
 module WasteTreatmentSignSpec (spec) where
 
+import API.Types (ExchangeWithUnit (..))
 import Data.List (elemIndex)
 import qualified Data.Map as M
 import qualified Data.Map.Strict as MS
@@ -32,6 +33,7 @@ import Database (buildDatabaseWithMatrices)
 import Database.CrossLinking (LinkingContext (..), buildIndexedDatabaseFromDB, defaultLinkingThreshold, emptyAliasMap)
 import Database.Loader (findAllCrossDBLinks)
 import Matrix (computeInventoryMatrix)
+import Service (buildCrossDBLinkMap, toExchangeWithUnit)
 import SharedSolver (CrossDBSolution (..), computeInventoryMatrixWithDepsCached)
 import SynonymDB (emptySynonymDB)
 import Test.Hspec
@@ -197,8 +199,12 @@ reference-sign correction is applied.
 @rootLink@ is what the waste output states about its treatment: 'UUID.nil' for
 an output naming none, @tA@ for one naming the dependency's treatment. Both
 must reach the same treatment and the same score.
+
+Returns the score and the waste line as the API reports it, so a test can hold
+the two against each other: a charged line that reports no treatment is the
+same bug read from the other end.
 -}
-scoreCross :: UUID -> T.Text -> TechRole -> Double -> IO Double
+scoreCross :: UUID -> T.Text -> TechRole -> Double -> IO (Double, ExchangeWithUnit)
 scoreCross rootLink depName depRole depRefAmount = do
     let rootActs = M.singleton (pA, yY) (producer (wasteEx False rootLink 3.0))
     rootBase <- buildDB "root" rootActs
@@ -215,9 +221,15 @@ scoreCross rootLink depName depRole depRefAmount = do
                 Nothing -> fail "producer not interned"
                 Just pid -> do
                     res <- computeInventoryMatrixWithDepsCached defaultUnitConfig depLookup rootDB "root" rootSolver pid
+                    let reported =
+                            toExchangeWithUnit
+                                defaultUnitConfig
+                                rootDB
+                                (buildCrossDBLinkMap rootDB pid)
+                                (wasteEx False rootLink 3.0)
                     case res of
                         Left err -> fail (T.unpack err)
-                        Right sol -> pure (co2Of (csInventory sol))
+                        Right sol -> pure (co2Of (csInventory sol), reported)
 
 spec :: Spec
 spec = describe "Waste-treatment scoring sign across reference conventions" $ do
@@ -244,11 +256,11 @@ spec = describe "Waste-treatment scoring sign across reference conventions" $ do
         withinTolerance 1.0e-9 6.0 score `shouldBe` True
 
     it "cross-DB to an ILCD (positive ReferenceInput) treatment scores +6" $ do
-        score <- scoreCross UUID.nil "ilcd-dep" ReferenceInput 1.0
+        (score, _) <- scoreCross UUID.nil "ilcd-dep" ReferenceInput 1.0
         withinTolerance 1.0e-9 6.0 score `shouldBe` True
 
     it "cross-DB to an ecoinvent (negative ReferenceProduct) treatment scores +6" $ do
-        score <- scoreCross UUID.nil "eco-dep" ReferenceProduct (-1.0)
+        (score, _) <- scoreCross UUID.nil "eco-dep" ReferenceProduct (-1.0)
         withinTolerance 1.0e-9 6.0 score `shouldBe` True
 
     -- An authored waste output states the treatment it goes to. When that
@@ -256,8 +268,22 @@ spec = describe "Waste-treatment scoring sign across reference conventions" $ do
     -- just as naming nothing does; reading the link as "resolved elsewhere"
     -- cut the waste off with no burden at all.
     it "cross-DB from a waste output that names the dependency's treatment scores +6" $ do
-        score <- scoreCross tA "eco-dep" ReferenceProduct (-1.0)
+        (score, _) <- scoreCross tA "eco-dep" ReferenceProduct (-1.0)
         withinTolerance 1.0e-9 6.0 score `shouldBe` True
+
+    -- Both halves of the same statement: the treatment charged is the one
+    -- reported. Reporting no treatment for a line the score charged says the
+    -- burden is missing when it was counted, which is the reading the role
+    -- exists to make impossible.
+    it "reports the dependency's treatment for the waste output it charged" $ do
+        (_, reported) <- scoreCross tA "eco-dep" ReferenceProduct (-1.0)
+        ewuWasteRole reported `shouldBe` Just SentToTreatment
+        (T.isPrefixOf "eco-dep::" <$> ewuTargetProcessId reported) `shouldBe` Just True
+
+    it "reports the dependency's treatment for an output naming none" $ do
+        (_, reported) <- scoreCross UUID.nil "eco-dep" ReferenceProduct (-1.0)
+        ewuWasteRole reported `shouldBe` Just SentToTreatment
+        (T.isPrefixOf "eco-dep::" <$> ewuTargetProcessId reported) `shouldBe` Just True
 
     -- The other half of the same gate: a link the root database resolves in
     -- place is the matrix's business, and a cross-DB link on top would charge


### PR DESCRIPTION
A waste output says two things a consumer could not tell apart, and one of them was never even looked for. This closes both.

## A named treatment in another database was skipped

The cross-database linker only considered waste outputs whose link was nil, on the assumption that a named treatment always sits in the same file. That holds for an imported file. It does not hold for a database written by hand, where naming the treatment is exactly how a waste output is written: such an output was cut off in silence and its burden counted as zero.

The waste arm now takes the same gate the technosphere arm has had all along, then picks its matcher from the link. An output naming a treatment is matched on that activity's identity, an output naming none on the waste flow itself, and neither falls back on the other: substituting a treatment found by name for the one the author named would charge an activity nobody asked for. An output the database resolves in place is still left to the matrix, so nothing is charged twice.

## "Nothing treats this waste" and "the treatment is missing" now say so

Both arrive with no target, and reading the role off that absence calls the second one a final waste flow, which says the burden is accounted for when it is missing. Only the engine holds both facts, so `ExchangeWithUnit` now carries `wasteRole`: `TreatsWaste`, `SentToTreatment`, `FinalWasteFlow`, `TreatmentNotLoaded`. `null` on every other kind of line.

This is wire revision 10. pyvolca reads the role as `WasteExchange.role`, `None` from an older engine.

## What this does not do

Two databases shipping the same treatment make the linker emit nothing on purpose (`cdlWasteAmbiguous`), and the role then reads the absent target as `FinalWasteFlow` or `TreatmentNotLoaded` depending on the link, neither of which says "several loaded databases treat this". Telling that case apart means recording ambiguity per exchange rather than as a count, which is its own change.

The role is on `ExchangeWithUnit` alone. `ExchangeDetail` resolves its target through `resolveTargetSummary`, which already diverges from `resolveTarget` on technosphere lines; carrying the role there means settling that divergence first, which is its own subject.

## Verification

Full suite green (2330 examples), `fourmolu --mode check` clean, `hlint` reports no hints, pyvolca 299 passed / 7 skipped. The cross-database test is red without the linker change: it fails with "linker created no cross-DB waste link (matcher did not fire)".
