### PR TITLE
Hold insert-ordered-containers below 0.3

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -17,3 +17,9 @@ program-options
 -- prebuilt-store hash includes this file).
 package *
   split-sections: True
+
+-- insert-ordered-containers 0.3 changed its JSON instances, and openapi3 3.2.5
+-- answers by wrapping InsOrdHashMap in a compat newtype from that version on.
+-- Our schema code builds `properties` with the plain type, so the two no longer
+-- meet. Hold the old library until that code moves to openapi3's compat module.
+constraints: insert-ordered-containers < 0.3


### PR DESCRIPTION
Every CI run has been red since Hackage published insert-ordered-containers 0.3 alongside openapi3 3.2.5: the new library changed its JSON instances, openapi3 wraps `InsOrdHashMap` in a compat newtype from that version on, and our schema code still builds `properties` with the plain type. `src/API/Types.hs:134` is the first of seven sites that no longer typecheck.

This pins `insert-ordered-containers < 0.3` in `cabal.project`, which makes the solver pick 0.2.7 again. A full `cabal build all` passes locally with the pin. The lasting fix is to move the schema code to openapi3's `Data.HashMap.Strict.InsOrd.Compat` module, at which point the constraint goes away.