### PR TITLE
Open 0.10.1 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.10.0] - 2026-08-22
 
 ### Added

--- a/volca.cabal
+++ b/volca.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                volca
-version:             0.10.0
+version:             0.10.1-dev
 build-type:          Simple
 
 license:             Apache-2.0


### PR DESCRIPTION
v0.10.0 is tagged and released, so main goes back to a -dev version and gains a fresh `[Unreleased]` changelog section.

A patch and not a minor: the numbering rule says not knowing yet counts as nothing removed, so this picks the patch. If a removal or a redefinition lands during the cycle, the release PR raises the number when it drops the suffix, the way v0.10.0 was raised from 0.9.6-dev.

Mechanical, no behaviour change.