### PR TITLE
Refuse GET /mcp instead of answering with a closed stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Fixed
+- A `GET /mcp` is now refused with 405 instead of answered with an empty
+  stream. That stream is how a server speaks to a client unprompted; VoLCA
+  never speaks first, so it was returned already closed, which a client reads
+  as a dropped connection and reconnects at once. Server and client then loop
+  for as long as both are up: one such pair sent 71 644 requests in 21 hours,
+  and on an engine holding several gigabytes of loaded data each wake cost a
+  full garbage collection, so the engine burned two and a half cores doing
+  nothing. A 405 says there is no stream to open, and the client stops asking.
+
 ## [0.10.0] - 2026-08-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
   for as long as both are up: one such pair sent 71 644 requests in 21 hours,
   and on an engine holding several gigabytes of loaded data each wake cost a
   full garbage collection, so the engine burned two and a half cores doing
-  nothing. A 405 says there is no stream to open, and the client stops asking.
+  nothing. A 405 says there is no stream to open, and the client stops
+  asking, and it is what the protocol asks of a server that offers no such
+  stream. This reads as a fix and not a removal: no working client relied
+  on the old answer, the one observed behaviour was the loop.
 
 ## [0.10.0] - 2026-08-22
 

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -51,7 +51,7 @@ import qualified Method.Explain as Explain
 import Method.Mapping (LCIAOutcome (..), MappingStats (..), SimilarCF (..), SimilarReason (..), UncharacterizedFlow (..), applyLongTermMode, computeLCIAScoreAuto, computeLCIAScoreFromTables, computeMappingStats, defaultUncharacterizedOpts, inventoryContributions, longTermModeFromExclude)
 import qualified Method.Mapping as Mapping
 import Method.Types (FlowDirection (..), Method (..), MethodCF (..), MethodCollection (..), ScoringSet (..))
-import Network.HTTP.Types.Header (RequestHeaders, hAccept, hHost)
+import Network.HTTP.Types.Header (RequestHeaders, hAccept, hAllow, hHost)
 import Numeric (showFFloat)
 import Progress (ProgressLevel (Warning), reportProgress)
 import qualified Service
@@ -204,10 +204,12 @@ mcpApp dbManager presets hasFrontend mHosting mName markActivity = do
             -- connection, which it reconnects, forever. 405 says there is no
             -- stream to open, and the client stops asking.
             _ ->
-                respond $
-                    responseLBS status405 [(hContentType, "application/json")] $
-                        encode $
-                            rpcError Null (-32700) "Method not allowed"
+                respond
+                    $ responseLBS
+                        status405
+                        [(hContentType, "application/json"), (hAllow, "POST")]
+                    $ encode
+                    $ rpcError Null (-32700) "Method not allowed"
   where
     jsonResponse sid v =
         responseLBS

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -177,18 +177,6 @@ mcpApp dbManager presets hasFrontend mHosting mName markActivity = do
             wantsSse = "text/event-stream" `BS.isInfixOf` acceptHdr
         st <- readIORef stateRef
         case method of
-            -- GET: open SSE stream for server-initiated messages.
-            -- VoLCA is stateless so we return an empty stream immediately.
-            "GET" ->
-                respond $
-                    responseLBS
-                        status200
-                        [ (hContentType, "text/event-stream; charset=utf-8")
-                        , ("Cache-Control", "no-cache")
-                        , ("Connection", "keep-alive")
-                        , ("Mcp-Session-Id", TE.encodeUtf8 (mcpSessionId st))
-                        ]
-                        ""
             "POST" -> do
                 body <- strictRequestBody req
                 case eitherDecode body of
@@ -210,6 +198,11 @@ mcpApp dbManager presets hasFrontend mHosting mName markActivity = do
                                 if wantsSse
                                     then respond $ sseResponse (mcpSessionId st) val
                                     else respond $ jsonResponse (mcpSessionId st) val
+            -- Everything else, GET included. A GET opens the stream a server
+            -- uses to speak first; VoLCA never does, and answering it with a
+            -- stream that closes at once reads to a client as a dropped
+            -- connection, which it reconnects, forever. 405 says there is no
+            -- stream to open, and the client stops asking.
             _ ->
                 respond $
                     responseLBS status405 [(hContentType, "application/json")] $

--- a/test/MCPStreamSpec.hs
+++ b/test/MCPStreamSpec.hs
@@ -10,10 +10,12 @@ and the client stops asking.
 -}
 module MCPStreamSpec (spec) where
 
+import Data.ByteString (ByteString)
 import Data.IORef
 import Network.HTTP.Types (Method)
+import Network.HTTP.Types.Header (hAllow)
 import Network.HTTP.Types.Status (statusCode)
-import Network.Wai (defaultRequest, requestMethod, responseStatus)
+import Network.Wai (defaultRequest, requestMethod, responseHeaders, responseStatus)
 import Network.Wai.Internal (ResponseReceived (..))
 import Test.Hspec
 
@@ -21,21 +23,24 @@ import API.MCP (mcpApp)
 import Config (defaultConfig)
 import Database.Manager (initDatabaseManager)
 
--- | Drive one request of the given method through the endpoint, report its status.
-status :: Method -> IO Int
-status m = do
+{- | Drive one request of the given method through the endpoint,
+report its status and the methods it says are allowed.
+-}
+answer :: Method -> IO (Int, Maybe ByteString)
+answer m = do
     manager <- initDatabaseManager defaultConfig True
     app <- mcpApp manager [] False Nothing Nothing (pure ())
     ref <- newIORef Nothing
     _ <- app defaultRequest{requestMethod = m} $ \resp -> do
         writeIORef ref (Just resp)
         pure ResponseReceived
-    maybe (fail "no response") (pure . statusCode . responseStatus) =<< readIORef ref
+    let read' resp = (statusCode (responseStatus resp), lookup hAllow (responseHeaders resp))
+    maybe (fail "no response") (pure . read') =<< readIORef ref
 
 spec :: Spec
 spec = describe "the /mcp endpoint" $ do
     it "refuses a GET rather than hand back a stream that closes at once" $
-        status "GET" `shouldReturn` 405
+        answer "GET" `shouldReturn` (405, Just "POST")
 
     it "refuses a DELETE the same way" $
-        status "DELETE" `shouldReturn` 405
+        answer "DELETE" `shouldReturn` (405, Just "POST")

--- a/test/MCPStreamSpec.hs
+++ b/test/MCPStreamSpec.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | The @\/mcp@ endpoint answers POST and refuses everything else.
+
+A GET opens the stream a server uses to speak to a client unprompted. VoLCA
+never speaks first, and an empty stream closed at once reads to a client as a
+dropped connection: it reconnects, and the pair loops for as long as both are
+up. One such pair sent 71 644 GETs in 21 hours. 405 says there is no stream,
+and the client stops asking.
+-}
+module MCPStreamSpec (spec) where
+
+import Data.IORef
+import Network.HTTP.Types (Method)
+import Network.HTTP.Types.Status (statusCode)
+import Network.Wai (defaultRequest, requestMethod, responseStatus)
+import Network.Wai.Internal (ResponseReceived (..))
+import Test.Hspec
+
+import API.MCP (mcpApp)
+import Config (defaultConfig)
+import Database.Manager (initDatabaseManager)
+
+-- | Drive one request of the given method through the endpoint, report its status.
+status :: Method -> IO Int
+status m = do
+    manager <- initDatabaseManager defaultConfig True
+    app <- mcpApp manager [] False Nothing Nothing (pure ())
+    ref <- newIORef Nothing
+    _ <- app defaultRequest{requestMethod = m} $ \resp -> do
+        writeIORef ref (Just resp)
+        pure ResponseReceived
+    maybe (fail "no response") (pure . statusCode . responseStatus) =<< readIORef ref
+
+spec :: Spec
+spec = describe "the /mcp endpoint" $ do
+    it "refuses a GET rather than hand back a stream that closes at once" $
+        status "GET" `shouldReturn` 405
+
+    it "refuses a DELETE the same way" $
+        status "DELETE" `shouldReturn` 405

--- a/volca.cabal
+++ b/volca.cabal
@@ -296,6 +296,7 @@ test-suite lca-tests
                      , ILCDWriterSpec
                      , MCPSchemaSpec
                      , MCPDispatchSpec
+                     , MCPStreamSpec
                      , BatchImpactsSpec
                      , MCPEnrichSpec
                      , MCPColumnarSpec


### PR DESCRIPTION
## What happens today

`GET /mcp` is the stream a server uses to speak to a client unprompted. VoLCA never speaks first, so the endpoint answered with an SSE response whose body was empty and already closed.

A client reads a closed stream as a dropped connection and reconnects. The server closes again. The two loop for as long as both are up.

Measured on a live instance holding Agribalyse 3.2, BAFU 2026 v1 and two EF 3.1 method sets, with an MCP client attached: **71 644 GETs in 21 hours**, one about every second. The requests themselves are trivial, but each one wakes a process whose live heap is around 6 GB, and the idle collector then runs a full collection. The engine sat at 250 % CPU on a four-core machine, permanently, having done no work at all.

## The change

Drop the `GET` arm. Every other method already fell through to a 405, which is what the protocol asks of a server that offers no server-initiated stream, and a conformant client stops asking after it.

`DELETE` was already answered that way and stays so.

## Why not keep the stream open instead

Holding it open with a periodic keep-alive would also stop the loop, but it means maintaining a stream that never carries anything. 405 states the same fact and costs nothing.

## One thing to settle before merge

The GET arm arrived in `e087b55`, a commit that added five things at once for compatibility with the OpenAI Responses API: the protocol version, the session header, SSE on POST, the 405 for other methods, and this stream. Which of the five that client actually needed was never recorded, and I have not tested against it.

The spec obliges a client to accept a 405 at this endpoint, and a stream returned already closed cannot have carried anything, so the likely answer is that the connector needed the version and the session header. But it is a guess. If someone can point an OpenAI MCP connector at an engine built from this branch, that closes the question.

The same question decides the next release number: `docs/release.md` reads a removal a working client relies on as minor. The CHANGELOG entry states the judgment that no working client relied on the old answer, since the one behaviour ever observed was the reconnect loop. If the OpenAI check contradicts that, the entry and the number both need revisiting.
