### PR TITLE
Hold insert-ordered-containers below 0.3 in the image too

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -126,8 +126,13 @@ COPY mumps-hs/ /build/mumps-hs/
 COPY gen-cabal-config.sh /build/volca/
 
 # Set up cabal.project with mumps-hs as local package, LINK_MODE=musl.
+# This project is written here rather than copied, so it inherits nothing
+# from the repository's own cabal.project: the hold on
+# insert-ordered-containers has to be repeated, and allow-newer above
+# would let the breaking version in otherwise.
 RUN echo "packages: ./volca ./mumps-hs" > /build/cabal.project \
     && echo "allow-newer: true" >> /build/cabal.project \
+    && echo "constraints: insert-ordered-containers < 0.3" >> /build/cabal.project \
     && MUMPS_LIB_DIR="/build/mumps/lib" \
     MUMPS_INCLUDE_DIR="/build/mumps/include" \
     OPENBLAS_LIB_DIR="/build/openblas/lib" \


### PR DESCRIPTION
The image build writes its own `cabal.project` at `docker/Dockerfile:129`
rather than copying the repository's, so the hold added when
insert-ordered-containers released 0.3 never reached it, and the
`allow-newer: true` on the line above let the breaking version in.
Building the engine from its own sources stopped at `API.Types`:

```
Couldn't match type: Data.HashMap.Strict.InsOrd.Compat.InsOrdHashMap
                       Text (Referenced Data.OpenApi.Internal.Schema)
                with: InsOrdHashMap.InsOrdHashMap k5 (...)
```

the same mismatch the repository-level constraint was added for, between
the plain `InsOrdHashMap` the schema code builds `properties` with and the
compat newtype openapi3 3.2.5 wraps it in from that version on.

## What was and was not affected

The published image never hit this. `volca-image.yml` downloads the
released binary, checks it against `SHA256SUMS`, and passes it as a build
context that shadows the `haskell-builder` stage, so BuildKit resolves
`COPY --from=haskell-builder` against that directory and never builds the
stage. What was broken is the path that actually compiles: building the
image from source, and the image step of the deployment repository's
release gate.

The comment above the line now says why the constraint is repeated rather
than shared, so the next person does not delete it as a duplicate.

Verified by building the `haskell-builder` stage through to a statically
linked binary, which is what the stage's own check requires.