### PR TITLE
Name the documentation host that actually answers

### DIFF
--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -2,7 +2,7 @@
 
 Python client for [VoLCA](https://github.com/ccomb/volca), the Life Cycle Assessment engine over Agribalyse and ecoinvent.
 
-> **Full guide and tutorials**: <https://volca.run/docs/python/>  
+> **Full guide and tutorials**: <https://www.volca.run/docs/python/>  
 > **Issues / source**: <https://github.com/ccomb/volca>  
 > **Changelog**: <https://github.com/ccomb/volca/blob/main/pyvolca/CHANGELOG.md>
 
@@ -2573,7 +2573,7 @@ Type alias: `Literal['flow-synonyms', 'compartment-mappings', 'units']`.
 
 ## See also
 
-- Full guide and tutorials: <https://volca.run/docs/python/>
+- Full guide and tutorials: <https://www.volca.run/docs/python/>
 - VoLCA engine: <https://github.com/ccomb/volca>
 - Runnable examples: <https://www.volca.run/examples/>
 

--- a/pyvolca/pyproject.toml
+++ b/pyvolca/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 dev = ["pytest", "pyright==1.1.411"]
 
 [project.urls]
-Documentation = "https://volca.run/docs/python/"
+Documentation = "https://www.volca.run/docs/python/"
 Changelog = "https://github.com/ccomb/volca/blob/main/pyvolca/CHANGELOG.md"
 Repository = "https://github.com/ccomb/volca/tree/main/pyvolca"
 Issues = "https://github.com/ccomb/volca/issues"

--- a/pyvolca/src/volca/__init__.py
+++ b/pyvolca/src/volca/__init__.py
@@ -1,6 +1,6 @@
 """VoLCA Python client for the Life Cycle Assessment engine.
 
-See https://volca.run/docs/python/ for the full guide.
+See https://www.volca.run/docs/python/ for the full guide.
 """
 
 from ._download import DownloadError, Installed, download

--- a/src/API/Licenses.hs
+++ b/src/API/Licenses.hs
@@ -43,7 +43,7 @@ licensesValue =
                 , "version" .= Version.version
                 , "license" .= ("Apache-2.0" :: Text)
                 , "copyright" .= ("Copyright (c) 2024-present Christophe Combelles and contributors" :: Text)
-                , "homepage" .= ("https://volca.run/" :: Text)
+                , "homepage" .= ("https://www.volca.run/" :: Text)
                 ]
         , "components" .= componentList
         , "haskell_dependencies_url" .= ("https://github.com/ccomb/volca/blob/main/THIRD_PARTY_LICENSES.md" :: Text)


### PR DESCRIPTION
The documentation site is served on `www.volca.run`; the bare `volca.run` answers with a permanent redirect and nothing else. Four places in this repository still named the redirect rather than the page: the `volca` package docstring, the `Documentation` link in `pyproject.toml` (which PyPI shows on the project page), the README header, and the `homepage` field of the `/licenses` response.

Following a redirect costs a reader nothing, but a package index and an API response are better off naming the address that answers.

Two occurrences are deliberately left alone: the changelog entry quotes the URL as it was written at the time, and `MCPEnrichSpec` uses `https://volca.run` as an arbitrary base URL for percent-encoding assertions, where the host is irrelevant.
