### PR TITLE
Name the coproduct an exchange asks for

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,8 @@ A Python client lives in `pyvolca/` (own `pyproject.toml`); the MUMPS binding in
 - **No wildcard patterns on sum types** — exhaustive matches only. They hide incomplete matches from the compiler.
 - **No runtime crashes**: never use `error`, `throw`, `undefined`, or partial functions (`head`, `fromJust`). Functions that can fail must return `Either Text a` or `Maybe a`, never crash.
 - **No silent errors or silent misbehaviour**: never return zero, empty, or a fallback value when a lookup fails, a unit conversion can't be done, or data is missing. Surface it: `Either Text a` propagated to a 4xx/5xx, a `reportProgress Warning` log line, or a `toolError` in MCP. A score that silently undercounts is worse than a clear failure — the consumer can't tell something is wrong.
+- **An index asserts that its key determines its value.** `fromList` silences duplicate keys, so a key that is only part of a wider identity (an activity UUID taken from the (activity, product) pair, a normalised name taken from a name) quietly keeps one row and drops the rest. Either the key really is the primary key, or the honest type is `Map k (NonEmpty v)` and every reader has to say what it does with several.
+- **A comment that says "arbitrary", "the first match" or "one of them" is describing a bug, not a behaviour.** Put the multiplicity in the type, or open an issue.
 - Builds are `-Wall`-clean — introduce no new warnings (incomplete patterns, unused binds). This is what backs the exhaustive-match rule above.
 
 ### Code style

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@
   now left unresolved when the product alone does not say which activity is
   meant, the same rule the name-and-unit fallback beside it already applied.
   Scores are unaffected: they never read that index.
+- Loading an EcoSpold 1 database no longer attaches an input to a supplier in
+  the wrong country. When an input names its product but no location, the
+  loader looked the product name up in an index that kept one dataset per name.
+  An EcoSpold 1 product name carries no location, so one name covers every
+  geography the product is made in: in a 11 947 dataset database, 787 names
+  cover 4 526 datasets, and the location always tells them apart. The index now
+  keeps all of them and the loader leaves the input unresolved, and says so in
+  the unlinked report, when the name alone does not say which dataset is meant.
 - Exporting an allocated activity to EcoSpold 1 no longer moves the links that
   point at it. Each coproduct is written as its own dataset with its own
   number, and an input naming that supplier now carries the number of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 ## [Unreleased]
 
 ### Fixed
+- An exchange now names the coproduct it actually asks for. A dataset whose
+  production is allocated is written as one activity per coproduct, all
+  sharing one activity identifier, and the engine kept an index from that
+  identifier to a single one of those activities. So an input for a cheese
+  could come back naming the whey permeate produced alongside it, and the
+  same swap reached the tree export, the list of activities that use a flow,
+  and the matrix debug export. Scores were never affected: they are computed
+  from the pair (activity, product), which is the resolution everything now
+  uses. What was affected is everything a client does with the identifier it
+  was given back, starting with asking for that activity, or substituting it.
+  Three visible consequences: an activity written as several coproducts is
+  now several nodes in a tree instead of one, an input whose declared supplier
+  is in no loaded database is a node of its own type (`MissingNode`) rather
+  than a branch that vanished, and a loop node's `loopTarget` is the process
+  identifier the schema always said it was rather than a bare activity
+  identifier. Every database cache is rebuilt on first load.
 - A `GET /mcp` is now refused with 405 instead of answered with an empty
   stream. That stream is how a server speaks to a client unprompted; VoLCA
   never speaks first, so it was returned already closed, which a client reads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
   than a branch that vanished, and a loop node's `loopTarget` is the process
   identifier the schema always said it was rather than a bare activity
   identifier. Every database cache is rebuilt on first load.
+- The wire revision moves to 12. A tree export can now report a node type a
+  client has not seen, for a link naming a row no loaded database holds, so a
+  client has to be able to tell a new engine from an old one before asking.
+  pyvolca knows revision 12 and no longer warns that the engine is newer than
+  it is.
 - Asking for an activity by its identifier alone no longer answers with one of
   its coproducts, and says so rather than reporting the activity as missing. The same index that misdirected exchanges also served the
   bare activity identifier the API, the CLI and the edit journal accept, and it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,15 @@
   identifier the schema always said it was rather than a bare activity
   identifier. Every database cache is rebuilt on first load.
 - Asking for an activity by its identifier alone no longer answers with one of
-  its coproducts. The same index that misdirected exchanges also served the
+  its coproducts, and says so rather than reporting the activity as missing. The same index that misdirected exchanges also served the
   bare activity identifier the API, the CLI and the edit journal accept, and it
   held a single row per activity, so an allocated activity resolved to whichever
   coproduct was recorded last. Such an identifier is now refused rather than
   answered wrongly, which is what the code beside it already claimed to do: it
-  names one row only when the activity was written as one. Every database cache
-  is rebuilt on first load.
+  names one row only when the activity was written as one. The refusal says the
+  activity is there and asks for the product alongside it, with a 400 rather
+  than the 404 that would send the caller looking for data the engine holds.
+  Every database cache is rebuilt on first load.
 - An input that names only the product it consumes no longer gets a supplier
   drawn at random. The same product is often made by several activities, one
   per geography, and the index from a product to its producer kept only one of
@@ -53,10 +55,12 @@
   construction. Two flows in one database can carry the same three, and only
   the last was kept, so its neighbour's contribution vanished from the
   comparison or was reported as present on one side only. Both sides are now
-  read from the same summed totals.
+  read from the same summed totals, and the largest contributions are chosen
+  on those totals too, so a flow split across two lines that together lead the
+  comparison is no longer left out of it.
 - Loading a Brightway workbook now says when a column heading appears twice.
-  Only the rightmost such column was read, and the others were dropped without
-  a word.
+  Only one such column is read on any given row, and the others were dropped
+  without a word.
 - A `GET /mcp` is now refused with 405 instead of answered with an empty
   stream. That stream is how a server speaks to a client unprompted; VoLCA
   never speaks first, so it was returned already closed, which a client reads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@
   number, and an input naming that supplier now carries the number of the
   coproduct it asks for. It carried whichever coproduct was written last, so
   reading the exported file back attached the input to the wrong product.
+- Comparing two impacts adds up the flows it treats as one instead of keeping
+  one of them. The comparison aligns the two databases on a flow's name,
+  medium and subcompartment, because their identifiers are unrelated by
+  construction. Two flows in one database can carry the same three, and only
+  the last was kept, so its neighbour's contribution vanished from the
+  comparison or was reported as present on one side only. Both sides are now
+  read from the same summed totals.
 - A `GET /mcp` is now refused with 405 instead of answered with an empty
   stream. That stream is how a server speaks to a client unprompted; VoLCA
   never speaks first, so it was returned already closed, which a client reads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@
   now left unresolved when the product alone does not say which activity is
   meant, the same rule the name-and-unit fallback beside it already applied.
   Scores are unaffected: they never read that index.
+- Exporting an allocated activity to EcoSpold 1 no longer moves the links that
+  point at it. Each coproduct is written as its own dataset with its own
+  number, and an input naming that supplier now carries the number of the
+  coproduct it asks for. It carried whichever coproduct was written last, so
+  reading the exported file back attached the input to the wrong product.
 - A `GET /mcp` is now refused with 405 instead of answered with an empty
   stream. That stream is how a server speaks to a client unprompted; VoLCA
   never speaks first, so it was returned already closed, which a client reads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@
   than a branch that vanished, and a loop node's `loopTarget` is the process
   identifier the schema always said it was rather than a bare activity
   identifier. Every database cache is rebuilt on first load.
+- An input that names only the product it consumes no longer gets a supplier
+  drawn at random. The same product is often made by several activities, one
+  per geography, and the index from a product to its producer kept only one of
+  them, so such an input was attached to whichever producer came last. It is
+  now left unresolved when the product alone does not say which activity is
+  meant, the same rule the name-and-unit fallback beside it already applied.
+  Scores are unaffected: they never read that index.
 - A `GET /mcp` is now refused with 405 instead of answered with an empty
   stream. That stream is how a server speaks to a client unprompted; VoLCA
   never speaks first, so it was returned already closed, which a client reads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@
   the last was kept, so its neighbour's contribution vanished from the
   comparison or was reported as present on one side only. Both sides are now
   read from the same summed totals.
+- Loading a Brightway workbook now says when a column heading appears twice.
+  Only the rightmost such column was read, and the others were dropped without
+  a word.
 - A `GET /mcp` is now refused with 405 instead of answered with an empty
   stream. That stream is how a server speaks to a client unprompted; VoLCA
   never speaks first, so it was returned already closed, which a client reads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@
   than a branch that vanished, and a loop node's `loopTarget` is the process
   identifier the schema always said it was rather than a bare activity
   identifier. Every database cache is rebuilt on first load.
+- Asking for an activity by its identifier alone no longer answers with one of
+  its coproducts. The same index that misdirected exchanges also served the
+  bare activity identifier the API, the CLI and the edit journal accept, and it
+  held a single row per activity, so an allocated activity resolved to whichever
+  coproduct was recorded last. Such an identifier is now refused rather than
+  answered wrongly, which is what the code beside it already claimed to do: it
+  names one row only when the activity was written as one. Every database cache
+  is rebuilt on first load.
 - An input that names only the product it consumes no longer gets a supplier
   drawn at random. The same product is often made by several activities, one
   per geography, and the index from a product to its producer kept only one of

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -24,7 +24,7 @@ The other direction is a promise about pyvolca's own names. A name this client p
 
 _Generated from `volca._compat`: run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.10.0** speaks wire formats **2 to 11** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error. A name this build has retired keeps working until pyvolca **1.0**.
+This build of **pyvolca 0.10.0** speaks wire formats **2 to 12** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error. A name this build has retired keeps working until pyvolca **1.0**.
 
 <!-- END: compatibility -->
 

--- a/pyvolca/src/volca/_compat.py
+++ b/pyvolca/src/volca/_compat.py
@@ -32,8 +32,10 @@ the client works against it except the revision-gated capabilities (see
 ``Client._require_wire``), which check the engine's advertised revision
 before sending anything."""
 
-KNOWN_WIRE = 11
-"""The newest wire revision this pyvolca understands (revision 11 adds the
+KNOWN_WIRE = 12
+"""The newest wire revision this pyvolca understands (revision 12 adds the
+node type a tree export reports where a link names a row no loaded database
+holds; revision 11 added the
 data bundle's version on the version route; revision 10 added the role
 a waste line reports; revision 9 added the kind
 a flow search reports and filters on; revision 8 added the two

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -14,7 +14,9 @@ import Data.Aeson.KeyMap (KeyMap)
 import qualified Data.Aeson.KeyMap as KM
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
+import Data.Function (on)
 import Data.IORef
+import Data.List (nubBy)
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe)
 import Data.Text (Text)
@@ -1376,10 +1378,14 @@ callCompareImpacts dbManager rid args =
                 if scoreB /= 0
                     then abs delta / abs scoreB * 100
                     else 0
-            aTop = take topN (irContribs irA)
-            bTop = take topN (irContribs irB)
-            aMap = M.fromList [(flowKey f, c) | (f, _, c) <- irContribs irA]
-            bMap = M.fromList [(flowKey f, c) | (f, _, c) <- irContribs irB]
+            -- Summed, not overwritten: 'flowKey' drops the UUID on purpose, so
+            -- two flows that differ only by it are one flow on this axis and both
+            -- contributions belong to its total. Every number below is read back
+            -- from these maps, so the two sides are compared on the same basis.
+            aMap = M.fromListWith (+) [(flowKey f, c) | (f, _, c) <- irContribs irA]
+            bMap = M.fromListWith (+) [(flowKey f, c) | (f, _, c) <- irContribs irB]
+            aTop = topFlows topN (irContribs irA)
+            bTop = topFlows topN (irContribs irB)
             common =
                 [ object
                     [ "flow_name" .= bfName f
@@ -1389,19 +1395,22 @@ callCompareImpacts dbManager rid args =
                     , "b_contrib" .= cB
                     , "delta" .= (cA - cB)
                     ]
-                | (f, _, cA) <- aTop
+                | f <- aTop
                 , let k = flowKey f
+                , Just cA <- [M.lookup k aMap]
                 , Just cB <- [M.lookup k bMap]
                 ]
             aOnly =
                 [ encodeContrib f c
-                | (f, _, c) <- aTop
+                | f <- aTop
                 , M.notMember (flowKey f) bMap
+                , Just c <- [M.lookup (flowKey f) aMap]
                 ]
             bOnly =
                 [ encodeContrib f c
-                | (f, _, c) <- bTop
+                | f <- bTop
                 , M.notMember (flowKey f) aMap
+                , Just c <- [M.lookup (flowKey f) bMap]
                 ]
         pure $
             toolSuccessJson rid $
@@ -1439,6 +1448,12 @@ callCompareImpacts dbManager rid args =
             , "compartment" .= bfCompartmentSub f
             , "contribution" .= c
             ]
+
+    -- The distinct flows behind the n largest contributions, in order. Two rows
+    -- sharing a 'flowKey' are one flow for this comparison, so the first of them
+    -- stands for the group and the aligned maps carry their summed contribution.
+    topFlows :: Int -> [(BiosphereFlow, a, Double)] -> [BiosphereFlow]
+    topFlows n = nubBy ((==) `on` flowKey) . map (\(f, _, _) -> f) . take n
 
     -- Align flows across databases by (normalized name, medium, subcompartment).
     -- UUIDs differ across DBs by construction — see Method/Mapping comments.

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -14,9 +14,7 @@ import Data.Aeson.KeyMap (KeyMap)
 import qualified Data.Aeson.KeyMap as KM
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
-import Data.Function (on)
 import Data.IORef
-import Data.List (nubBy)
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe)
 import Data.Text (Text)
@@ -1378,14 +1376,17 @@ callCompareImpacts dbManager rid args =
                 if scoreB /= 0
                     then abs delta / abs scoreB * 100
                     else 0
-            -- Summed, not overwritten: 'flowKey' drops the UUID on purpose, so
+            -- Gathered, not overwritten: 'flowKey' drops the UUID on purpose, so
             -- two flows that differ only by it are one flow on this axis and both
             -- contributions belong to its total. Every number below is read back
-            -- from these maps, so the two sides are compared on the same basis.
-            aMap = M.fromListWith (+) [(flowKey f, c) | (f, _, c) <- irContribs irA]
-            bMap = M.fromListWith (+) [(flowKey f, c) | (f, _, c) <- irContribs irB]
-            aTop = topFlows topN (irContribs irA)
-            bTop = topFlows topN (irContribs irB)
+            -- from these maps, and so is the ranking, so the two sides are
+            -- compared and ordered on the same basis.
+            alignedA = alignContribs (irContribs irA)
+            alignedB = alignContribs (irContribs irB)
+            aMap = M.map snd alignedA
+            bMap = M.map snd alignedB
+            aTop = topFlows topN alignedA
+            bTop = topFlows topN alignedB
             common =
                 [ object
                     [ "flow_name" .= bfName f
@@ -1449,11 +1450,20 @@ callCompareImpacts dbManager rid args =
             , "contribution" .= c
             ]
 
-    -- The distinct flows behind the n largest contributions, in order. Two rows
-    -- sharing a 'flowKey' are one flow for this comparison, so the first of them
-    -- stands for the group and the aligned maps carry their summed contribution.
-    topFlows :: Int -> [(BiosphereFlow, a, Double)] -> [BiosphereFlow]
-    topFlows n = nubBy ((==) `on` flowKey) . map (\(f, _, _) -> f) . take n
+    -- Contributions gathered on the key the two sides are compared by. The rows
+    -- arrive largest first, so the first of a key keeps its spelling for
+    -- display while the total is what the comparison ranks and reports.
+    alignContribs :: [(BiosphereFlow, Double, Double)] -> M.Map (Text, Text, Text) (BiosphereFlow, Double)
+    alignContribs contribs =
+        M.fromListWith
+            (\(_, cNew) (f, cOld) -> (f, cOld + cNew))
+            [(flowKey f, (f, c)) | (f, _, c) <- contribs]
+
+    -- The n flows contributing most on that key. Ranking single rows instead
+    -- would leave out a flow whose rows each fall outside the window while
+    -- their total leads it.
+    topFlows :: Int -> M.Map (Text, Text, Text) (BiosphereFlow, Double) -> [BiosphereFlow]
+    topFlows n = map fst . take n . L.sortOn (\(_, c) -> negate (abs c)) . M.elems
 
     -- Align flows across databases by (normalized name, medium, subcompartment).
     -- UUIDs differ across DBs by construction — see Method/Mapping comments.

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1442,13 +1442,9 @@ getActivityTree dbName processId = do
     dbManager <- asks aeDbManager
     maxTreeDepth <- asks aeMaxTreeDepth
     (db, _) <- requireDatabaseByName dbName
-    withValidatedActivity db processId $ \_activity -> do
-        case refActivityUUID processId of
-            Nothing -> throwError err400{errBody = "Invalid activity UUID format"}
-            Just activityUuid -> do
-                unitCfg <- liftIO $ getMergedUnitConfig dbManager
-                let loopAwareTree = buildLoopAwareTree unitCfg db activityUuid maxTreeDepth
-                return $ Service.convertToTreeExport db processId maxTreeDepth loopAwareTree
+    root <- either throwServiceError pure (Service.resolveActivityAndProcessId db processId)
+    unitCfg <- liftIO $ getMergedUnitConfig dbManager
+    return $ Service.convertToTreeExport db processId maxTreeDepth (buildLoopAwareTree unitCfg db maxTreeDepth root)
 
 {- | Inventory with optional substitutions; goes through the cross-DB
 back-substitution path so dep-DB inventories merge into the response.

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1295,7 +1295,10 @@ appears that a client must know about /before/ calling it. Adding a route
 does not exempt a change from the bump: an absent route answers 404, and so
 does a request naming a database the engine has not loaded, so a client
 cannot tell "this engine is too old" from "you asked for the wrong thing"
-(revision 11: the @dataVersion@ the version route reports; revision 10: the
+(revision 12: the @MissingNode@ a tree export reports where a link names a
+row no loaded database holds, and the @missing:@ prefixed id such a node and
+its edge carry in place of a process id;
+revision 11: the @dataVersion@ the version route reports; revision 10: the
 @wasteRole@ an activity's waste lines report;
 revision 9: the @kind@ a flow search reports and filters on;
 revision 8: the two quality reports as downloadable CSV;
@@ -1310,7 +1313,7 @@ the whole filtered set).
 Clients compare it to decide compatibility and to gate such capabilities.
 -}
 currentWireVersion :: Int
-currentWireVersion = 11
+currentWireVersion = 12
 
 getVersion :: AppM Value
 getVersion = do

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -530,6 +530,9 @@ serviceErrorToServerError :: Service.ServiceError -> ServerError
 serviceErrorToServerError = \case
     Service.InvalidUUID msg -> err400{errBody = utf8Body msg}
     Service.InvalidProcessId msg -> err400{errBody = utf8Body msg}
+    -- The activity is there; the query does not say which of its products.
+    -- A 404 would send the caller looking for data that is present.
+    Service.AmbiguousActivity msg -> err400{errBody = utf8Body msg}
     Service.ActivityNotFound _ -> err404{errBody = "Activity not found"}
     Service.FlowNotFound _ -> err404{errBody = "Flow not found"}
     -- MatrixError covers singular Sherman-Morrison, missing technosphere links,
@@ -931,7 +934,19 @@ batchImpactsH dbName collectionName topFlowsParam ltMode req = do
             ]
         valid = [(pidText, pidNum, act) | (pidText, Right (pidNum, act)) <- resolved]
         notFound = [pidText | (pidText, Left (Service.ActivityNotFound _)) <- resolved]
-        invalid = [pidText | (pidText, Left (Service.InvalidProcessId _)) <- resolved]
+        -- An under-specified id is unusable as sent, like a malformed one, and
+        -- belongs in a bucket rather than in neither.
+        invalid =
+            [ pidText
+            | (pidText, Left err) <- resolved
+            , case err of
+                Service.InvalidProcessId _ -> True
+                Service.AmbiguousActivity _ -> True
+                Service.InvalidUUID _ -> False
+                Service.ActivityNotFound _ -> False
+                Service.FlowNotFound _ -> False
+                Service.MatrixError _ -> False
+            ]
         validPidNums = [pidNum | (_, pidNum, _) <- valid]
     t0 <- liftIO getCurrentTime
     sols0 <- solutionsWithDeps dbName db sharedSolver validPidNums
@@ -1262,6 +1277,7 @@ withActivityAndMethod dbName collectionName processIdText methodIdText k = do
     case Service.resolveActivityAndProcessId db processIdText of
         Left (Service.ActivityNotFound _) -> throwError err404{errBody = "Activity not found"}
         Left (Service.InvalidProcessId _) -> throwError err400{errBody = "Invalid ProcessId format"}
+        Left (Service.AmbiguousActivity msg) -> throwError err400{errBody = BSL.fromStrict $ T.encodeUtf8 msg}
         Left err -> throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ T.pack $ show err}
         Right (actProcessId, activity) -> k db sharedSolver actProcessId activity method
 
@@ -1804,6 +1820,8 @@ getActivityPathTo dbName processIdText targetParam = do
         Left (Service.ActivityNotFound msg) ->
             throwError err404{errBody = BSL.fromStrict $ T.encodeUtf8 msg}
         Left (Service.InvalidProcessId msg) ->
+            throwError err400{errBody = BSL.fromStrict $ T.encodeUtf8 msg}
+        Left (Service.AmbiguousActivity msg) ->
             throwError err400{errBody = BSL.fromStrict $ T.encodeUtf8 msg}
         Left err ->
             throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ T.pack $ show err}

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -298,16 +298,22 @@ data TreeMetadata = TreeMetadata
     deriving (Generic)
     deriving (ToJSON, ToSchema) via (Stripped TreeMetadata)
 
+{- | One node of a tree export. Every node names the row it sits at, in
+ProcessId format, save a 'MissingNode': it stands for a link no row satisfies,
+so it has none to name and wears "missing:" and the activity identifier
+instead. Anything reading an id as a process id has to allow for that one, here
+and on the two ends of an edge.
+-}
 data ExportNode = ExportNode
-    { enId :: Text -- Changed to Text (ProcessId format)
+    { enId :: Text -- ProcessId format, or "missing:<activityUUID>" on a MissingNode
     , enName :: Text
     , enDescription :: [Text]
     , enLocation :: Text
     , enUnit :: Text
     , enNodeType :: NodeType
     , enDepth :: Int
-    , enLoopTarget :: Maybe Text -- Changed to Text (ProcessId format)
-    , enParentId :: Maybe Text -- Changed to Text (ProcessId format) -- For navigation back up
+    , enLoopTarget :: Maybe Text -- ProcessId format; set on a LoopNode alone
+    , enParentId :: Maybe Text -- Node id of the parent, for navigation back up
     , enChildrenCount :: Int -- Number of potential children for expandability
     , enCompartment :: Maybe Text -- Biosphere compartment (air/water/soil), only for BiosphereNodes
     }
@@ -323,8 +329,8 @@ data EdgeType = TechnosphereEdge | BiosphereEmissionEdge | BiosphereResourceEdge
     deriving anyclass (ToSchema)
 
 data TreeEdge = TreeEdge
-    { teFrom :: Text -- Changed to Text (ProcessId format)
-    , teTo :: Text -- Changed to Text (ProcessId format)
+    { teFrom :: Text -- Node id, as ExportNode carries it
+    , teTo :: Text -- Node id, as ExportNode carries it
     , teFlow :: FlowInfo
     , teQuantity :: Double
     , teUnit :: Text

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -314,7 +314,7 @@ data ExportNode = ExportNode
     deriving (Generic)
     deriving (ToJSON, ToSchema) via (Stripped ExportNode)
 
-data NodeType = ActivityNode | LoopNode | BiosphereEmissionNode | BiosphereResourceNode
+data NodeType = ActivityNode | LoopNode | MissingNode | BiosphereEmissionNode | BiosphereResourceNode
     deriving (Eq, Show, Generic)
     deriving anyclass (ToSchema)
 

--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -256,6 +256,17 @@ rowFields :: [(Int, Text)] -> Row -> M.Map Text CellValue
 rowFields headers row =
     M.fromList [(lbl, v) | (i, lbl) <- headers, Just v <- [M.lookup i row]]
 
+{- | The labels a header row spells more than once. 'rowFields' keys on the
+label, so only the rightmost column of each survives; the reader is told which
+ones rather than losing a column in silence.
+-}
+duplicateLabels :: [(Int, Text)] -> [Text]
+duplicateLabels headers =
+    [ lbl
+    | (lbl, n) <- M.toList (M.fromListWith (+) [(lbl, 1 :: Int) | (_, lbl) <- headers])
+    , n > 1
+    ]
+
 -- ---------------------------------------------------------------------------
 -- Domain construction (pure)
 -- ---------------------------------------------------------------------------
@@ -319,6 +330,9 @@ rawToActivity cfg ra =
                ]
             ++ [ "activity '" <> raName ra <> "': no reference product; activity will not be scoreable"
                | not (any exchangeIsReference exchanges')
+               ]
+            ++ [ "activity '" <> raName ra <> "': column '" <> lbl <> "' appears more than once; only the rightmost is read"
+               | lbl <- duplicateLabels (raHeaders ra)
                ]
 
     location = fromMaybe "" (metaText meta "location")

--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -257,8 +257,9 @@ rowFields headers row =
     M.fromList [(lbl, v) | (i, lbl) <- headers, Just v <- [M.lookup i row]]
 
 {- | The labels a header row spells more than once. 'rowFields' keys on the
-label, so only the rightmost column of each survives; the reader is told which
-ones rather than losing a column in silence.
+label, so one column of each survives per row and which one is whichever
+carries a value; the reader is told which labels rather than losing a column in
+silence.
 -}
 duplicateLabels :: [(Int, Text)] -> [Text]
 duplicateLabels headers =
@@ -331,7 +332,7 @@ rawToActivity cfg ra =
             ++ [ "activity '" <> raName ra <> "': no reference product; activity will not be scoreable"
                | not (any exchangeIsReference exchanges')
                ]
-            ++ [ "activity '" <> raName ra <> "': column '" <> lbl <> "' appears more than once; only the rightmost is read"
+            ++ [ "activity '" <> raName ra <> "': column '" <> lbl <> "' appears more than once; one of them is read per row and the others are dropped"
                | lbl <- duplicateLabels (raHeaders ra)
                ]
 

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -114,6 +114,9 @@ buildIndexesWithProcessIds activityVec processIdTable =
         activityUUIDs = [actUUID | (actUUID, _) <- V.toList processIdTable]
         activities = V.toList activityVec
         activityPairs = zip activityUUIDs activities
+        -- The process id table is in row order, so the row of each activity is
+        -- its position in it.
+        rows = zip [0 ..] activities
 
         nameIdx =
             M.fromListWith
@@ -128,7 +131,7 @@ buildIndexesWithProcessIds activityVec processIdTable =
         flowIdx =
             M.fromListWith
                 (++)
-                [ (exchangeFlowId ex, [uuid]) | (uuid, activity) <- activityPairs, ex <- exchanges activity
+                [ (exchangeFlowId ex, [pid]) | (pid, activity) <- rows, ex <- exchanges activity
                 ]
 
         unitIdx =

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -5,6 +5,7 @@
 module Database where
 
 import qualified Data.IntSet as IS
+import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map as M
 import qualified Data.Set as S
 import Data.Text (Text)
@@ -164,7 +165,10 @@ buildProductIndex activities processIdTable techFlowDb =
             ]
      in
         ProductIndex
-            { piByUUID = M.fromList [(prodUUID, pid) | (pid, prodUUID, _, _) <- entries]
+            { -- One flow, every row producing it: several is the ordinary shape of a
+              -- product made in more than one geography, and 'M.fromList' would
+              -- have kept whichever row came last.
+              piByUUID = M.fromListWith (flip (<>)) [(prodUUID, pid :| []) | (pid, prodUUID, _, _) <- entries]
             , piByName = M.fromListWith (++) [(name, [pid]) | (pid, _, name, _) <- entries]
             , piByLocation = M.fromListWith (++) [(loc, [pid]) | (pid, _, _, loc) <- entries, not (T.null loc)]
             }

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -67,6 +67,7 @@ module Database.Loader (
 
     -- * Internal Linking
     fixSimaProActivityLinks,
+    fixEcoSpold1ActivityLinks,
 
     -- * Reporting
     reportCrossDBLinkingStats,
@@ -327,11 +328,15 @@ could not convert), instead of forming a link that aborts the whole load.
 -}
 type NameOnlyIndex = M.Map T.Text (UUID.UUID, UUID.UUID, T.Text)
 
-{- | Type alias for name-only supplier lookup with location (for EcoSpold1)
-Maps normalizedProductName → (activityUUID, productUUID, location)
-Used when exchange has no location attribute to find the activity's actual location
+{- | Name-only supplier lookup for EcoSpold1, mapping a normalized product name
+to every dataset producing it as @(activityUUID, productUUID, location)@.
+
+Several is the ordinary shape here, not the exception: an EcoSpold1 product name
+carries no location, so one name covers every geography the product is made in.
+That is why the value is a 'NE.NonEmpty' and why both readers refuse a name that
+covers more than one dataset instead of taking whichever it finds.
 -}
-type SupplierByNameWithLocation = M.Map T.Text (UUID.UUID, UUID.UUID, T.Text)
+type SupplierByNameWithLocation = M.Map T.Text (NE.NonEmpty (UUID.UUID, UUID.UUID, T.Text))
 
 -- | Dataset number → (activityUUID, productUUID) for EcoSpold1 Tier 1 linking
 type DatasetNumberIndex = M.Map Int (UUID.UUID, UUID.UUID)
@@ -439,14 +444,14 @@ buildSupplierIndexByName unitDB activities techFlowDb =
                 ]
      in M.union exactIndex prefixIndex
 
-{- | Build name-only supplier index with location for EcoSpold1 linking
-Used when exchange has no location attribute to find the activity's actual location
-Maps normalizedProductName → (activityUUID, productUUID, activityLocation)
+{- | Build the name-only supplier index for EcoSpold1 linking, keeping every
+dataset a name covers rather than the last one seen.
 -}
 buildSupplierIndexByNameWithLocation :: ActivityMap -> TechFlowDB -> SupplierByNameWithLocation
 buildSupplierIndexByNameWithLocation activities techFlowDb =
-    M.fromList
-        [ (normalizeText (tfName flow), (actUUID, prodUUID, activityLocation act))
+    M.fromListWith
+        (flip (<>))
+        [ (normalizeText (tfName flow), (actUUID, prodUUID, activityLocation act) NE.:| [])
         | ((actUUID, prodUUID), act) <- M.toList activities
         , ex <- exchanges act
         , exchangeIsReference ex
@@ -551,18 +556,18 @@ fixExchangeLink ExchangeLinkContext{..} consumerName ex@TechnosphereExchange{tec
                         _ ->
                             -- Tier 2: name + location lookup
                             let normalizedLoc = fromMaybe loc (M.lookup loc elcLocationAliases)
+                                soleSupplier = M.lookup (normalizeText (tfName flow)) elcNameIndex >>= sole
                                 lookupLoc
-                                    | T.null normalizedLoc =
-                                        case M.lookup (normalizeText (tfName flow)) elcNameIndex of
-                                            Just (_, _, actLoc) -> actLoc
-                                            Nothing -> normalizedLoc
+                                    | T.null normalizedLoc = maybe normalizedLoc (\(_, _, actLoc) -> actLoc) soleSupplier
                                     | otherwise = normalizedLoc
                                 key = (normalizeText (tfName flow), lookupLoc)
                              in case M.lookup key elcSupplierIndex of
                                     Just (actUUID, prodUUID) -> linked actUUID prodUUID
                                     Nothing ->
-                                        -- Tier 3: name-only fallback (safe for EcoSpold1 where names include {LOCATION})
-                                        case M.lookup (normalizeText (tfName flow)) elcNameIndex of
+                                        -- Tier 3: the name alone, and only when it
+                                        -- covers a single dataset. A name shared by
+                                        -- several geographies names none of them.
+                                        case soleSupplier of
                                             Just (actUUID, prodUUID, _) -> linked actUUID prodUUID
                                             Nothing -> unlinked flow lookupLoc
                 Nothing ->

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -260,6 +260,10 @@ History of manual bumps:
      dimensionless, which changes the product flow's UUID (it is derived from
      the unit name) and so the activity's process id. Value changes with no
      type change, which the fingerprint alone would accept.
+- 17: the flow index now lists the rows that use a flow, not their activity
+     UUIDs. The fingerprint hashes the identity of Database, never the types
+     inside it, so an old cache would pass the check and be decoded reading
+     16-byte UUIDs as 4-byte row numbers.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.
@@ -267,7 +271,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeRep (Proxy :: Proxy Database))
-     in hi `xor` lo `xor` 16
+     in hi `xor` lo `xor` 17
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -261,7 +261,8 @@ History of manual bumps:
      the unit name) and so the activity's process id. Value changes with no
      type change, which the fingerprint alone would accept.
 - 17: the flow index now lists the rows that use a flow, not their activity
-     UUIDs. The fingerprint hashes the identity of Database, never the types
+     UUIDs, and the product index lists every row producing a flow instead of
+     one. The fingerprint hashes the identity of Database, never the types
      inside it, so an old cache would pass the check and be decoded reading
      16-byte UUIDs as 4-byte row numbers.
 

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -261,10 +261,11 @@ History of manual bumps:
      the unit name) and so the activity's process id. Value changes with no
      type change, which the fingerprint alone would accept.
 - 17: the flow index now lists the rows that use a flow, not their activity
-     UUIDs, and the product index lists every row producing a flow instead of
-     one. The fingerprint hashes the identity of Database, never the types
-     inside it, so an old cache would pass the check and be decoded reading
-     16-byte UUIDs as 4-byte row numbers.
+     UUIDs, and the product and activity indexes list every row a flow or an
+     activity was written as instead of one. The fingerprint hashes the
+     identity of Database, never the types inside it, so an old cache would
+     pass the check and be decoded reading 16-byte UUIDs as 4-byte row
+     numbers, or one row number as a list of them.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.

--- a/src/Database/MatrixBuild.hs
+++ b/src/Database/MatrixBuild.hs
@@ -21,6 +21,7 @@ module Database.MatrixBuild (
 import Control.Applicative ((<|>))
 import Data.Foldable (fold)
 import Data.Int (Int32)
+import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map as M
 import qualified Data.Set as S
 import Data.Text (Text)
@@ -40,7 +41,7 @@ activity of each row is the one its key maps to.
 data InterningTables = InterningTables
     { itProcessIdTable :: !(V.Vector (UUID, UUID))
     , itProcessIdLookup :: !(M.Map (UUID, UUID) ProcessId)
-    , itActivityUUIDIndex :: !(M.Map UUID ProcessId)
+    , itActivityUUIDIndex :: !(M.Map UUID (NonEmpty ProcessId))
     , itActivityProductsIndex :: !(M.Map (UUID, Maybe NativeProcessId) [ProcessId])
     , itActivities :: !(V.Vector Activity)
     , itActivityCount :: !Int32
@@ -51,7 +52,10 @@ buildInterningTables activityMap =
     InterningTables
         { itProcessIdTable = V.fromList [k | (_, k, _) <- indexed]
         , itProcessIdLookup = M.fromList [(k, pid) | (pid, k, _) <- indexed]
-        , itActivityUUIDIndex = M.fromList [(actUUID, pid) | (pid, (actUUID, _), _) <- indexed]
+        , -- One activity, every row it was written as: an allocated activity is
+          -- written once per coproduct, and 'M.fromList' would have kept
+          -- whichever row came last.
+          itActivityUUIDIndex = M.fromListWith (flip (<>)) [(actUUID, pid :| []) | (pid, (actUUID, _), _) <- indexed]
         , itActivityProductsIndex =
             M.fromListWith (++) [(activityGroupKey actUUID act, [pid]) | (pid, (actUUID, _), act) <- indexed]
         , itActivities = V.fromList [act | (_, _, act) <- indexed]
@@ -104,12 +108,12 @@ findProducer lkp ex =
         <|> (exchangeActivityLinkId ex >>= \actUUID -> M.lookup (actUUID, exchangeFlowId ex) lkp)
 
 {- | The row a consumer names as this exchange's target: the row the matrix
-routes it through, else the row its activity link alone names. Keying on the
-activity UUID alone answers with an arbitrary product of a multi-product
-activity, which is what this exists to avoid. The fallback still keeps the
-targets of links whose (activity, flow) pair is no row at all: the matrix drops
-such an exchange, so the row named is one no score charged, but that is a
-lesser evil than dropping targets that answer today.
+routes it through, else the row its activity link alone names. The fallback
+keeps the targets of links whose (activity, flow) pair is no row at all: the
+matrix drops such an exchange, so the row named is one no score charged, but
+that is a lesser evil than dropping targets that answer today. It answers only
+for an activity written as a single row, so an allocated activity reached this
+way is left without a target rather than given the wrong coproduct.
 -}
 linkedProducer :: Database -> Exchange -> Maybe ProcessId
 linkedProducer db ex =

--- a/src/Database/MatrixBuild.hs
+++ b/src/Database/MatrixBuild.hs
@@ -15,6 +15,7 @@ module Database.MatrixBuild (
     buildTechTriples,
     buildBioTriples,
     findProducer,
+    linkedProducer,
 ) where
 
 import Control.Applicative ((<|>))
@@ -101,6 +102,19 @@ findProducer :: M.Map (UUID, UUID) ProcessId -> Exchange -> Maybe ProcessId
 findProducer lkp ex =
     exchangeProcessLinkId ex
         <|> (exchangeActivityLinkId ex >>= \actUUID -> M.lookup (actUUID, exchangeFlowId ex) lkp)
+
+{- | The row a consumer names as this exchange's target: the row the matrix
+routes it through, else the row its activity link alone names. Keying on the
+activity UUID alone answers with an arbitrary product of a multi-product
+activity, which is what this exists to avoid. The fallback still keeps the
+targets of links whose (activity, flow) pair is no row at all: the matrix drops
+such an exchange, so the row named is one no score charged, but that is a
+lesser evil than dropping targets that answer today.
+-}
+linkedProducer :: Database -> Exchange -> Maybe ProcessId
+linkedProducer db ex =
+    findProducer (dbProcessIdLookup db) ex
+        <|> (exchangeActivityLinkId ex >>= findProcessIdByActivityUUID db)
 
 {- | Warning text for an exchange whose declared producer cannot be located.
 Zero-amount placeholder exchanges produce no warning.

--- a/src/EcoSpold/Writer1.hs
+++ b/src/EcoSpold/Writer1.hs
@@ -173,23 +173,28 @@ component of its 'sdbActivities' key — that a technosphere input's
 'techActivityLinkId' points at. Shared by the writer and
 'checkEcoSpold1Exportable'.
 -}
-orderedActivities :: ActivityMap -> [(UUID, Activity)]
+orderedActivities :: ActivityMap -> [((UUID, UUID), Activity)]
 orderedActivities =
     sortOn (\(_, a) -> (activityName a, activityLocation a))
-        . map (\((actU, _), a) -> (actU, a))
         . M.toList
 
-{- | Map each supplier activity's stored UUID to the dataset number it is assigned
-in canonical order. A technosphere input links to its supplier by
-'techActivityLinkId' — the supplier's stored activity UUID, the first component of
-its 'sdbActivities' key — and the parser reads the input's @number@ attribute back
-as that supplier dataset number ('EcoSpold.Parser1.closeExchange'). Keying by the
-stored UUID rather than re-deriving one lets a link resolve whatever namespace the
-source format minted the UUID in.
+{- | Map each exported row to the dataset number it is assigned in canonical
+order. A technosphere input names its supplier by the pair 'techActivityLinkId'
+plus 'techFlowId' — the supplier row's 'sdbActivities' key — and the parser reads
+the input's @number@ attribute back as that supplier dataset number
+('EcoSpold.Parser1.closeExchange'). Keying by the stored UUIDs rather than
+re-deriving them lets a link resolve whatever namespace the source format minted
+them in.
+
+The key is the whole pair because an allocated activity is exported as one
+dataset per coproduct, each with its own number. Keying on the activity UUID
+alone kept one of them and gave every link to that supplier the number of an
+arbitrary coproduct, which the parser then read back as a link to the wrong
+product.
 -}
-supplierNumberIndex :: [(UUID, Activity)] -> M.Map UUID Int
+supplierNumberIndex :: [((UUID, UUID), Activity)] -> M.Map (UUID, UUID) Int
 supplierNumberIndex ordered =
-    M.fromList [(actU, n) | (n, (actU, _)) <- zip [1 ..] ordered]
+    M.fromList [(key, n) | (n, (key, _)) <- zip [1 ..] ordered]
 
 {- | Map each flow that is not a reference product to the number the export
 gives it, once, across every dataset that carries it.
@@ -202,7 +207,7 @@ happens to occupy, which is exactly the splintering the parser stopped doing.
 Numbers start above the dataset numbers, which occupy @1 .. length ordered@ and
 are what a reference product and a linked input carry.
 -}
-flowNumberIndex :: [(UUID, Activity)] -> M.Map UUID Int
+flowNumberIndex :: [((UUID, UUID), Activity)] -> M.Map UUID Int
 flowNumberIndex ordered =
     M.fromList (zip flows [length ordered + 1 ..])
   where
@@ -222,10 +227,10 @@ emit silently wrong data:
   * __Dangling supplier links.__ The format names a supplier from a
     technosphere input's @number@ attribute, which the parser reads as the
     supplier's dataset number. The writer can only re-emit that number when the
-    linked supplier activity is itself being exported (present in
-    'supplierNumberIndex'). A linked input pointing at an activity absent from
-    the database would otherwise force a positional index the parser would
-    misread as a different supplier.
+    supplier row the link names — the (activity, product) pair — is itself being
+    exported (present in 'supplierNumberIndex'). A linked input naming a pair
+    absent from the database would otherwise force a positional index the parser
+    would misread as a different supplier.
 
   * __Reference inputs.__ EcoSpold1 has no marker for a reference /input/, so
     the writer would emit @outputGroup 0@ and the parser would read it back as
@@ -330,9 +335,9 @@ checkEcoSpold1Exportable db =
     danglingLinks =
         [ (activityName act, link)
         | act <- M.elems (sdbActivities db)
-        , TechnosphereExchange{techRole = Input, techActivityLinkId = link} <- exchanges act
+        , TechnosphereExchange{techRole = Input, techActivityLinkId = link, techFlowId = fid} <- exchanges act
         , link /= UUID.nil
-        , not (M.member link index)
+        , not (M.member (link, fid) index)
         ]
     amountOffenders =
         [ (activityName act, amt)
@@ -392,7 +397,7 @@ data Resolvers = Resolvers
     , rBio :: !BioFlowDB
     , rWaste :: !WasteFlowDB
     , rUnits :: !UnitDB
-    , rSupplierNumbers :: !(M.Map UUID Int)
+    , rSupplierNumbers :: !(M.Map (UUID, UUID) Int)
     , rFlowNumbers :: !(M.Map UUID Int)
     }
 
@@ -476,17 +481,18 @@ two agree on one number for one product. Everything else — co-products,
 biosphere, waste, and unlinked inputs — carries the number its flow was given
 once for the whole export ('flowNumberIndex').
 
-'checkEcoSpold1Exportable' guarantees any resolved link is present in the
-supplier index before export, so that fallback is unreachable on the wired-up
-path; the flow index covers every non-reference exchange by construction.
+'checkEcoSpold1Exportable' guarantees any resolved link's (activity, product)
+pair is present in the supplier index before export, so that fallback is
+unreachable on the wired-up path; the flow index covers every non-reference
+exchange by construction.
 -}
 exchangeNumber :: Resolvers -> Int -> Exchange -> Int
 exchangeNumber res datasetNum ex
     | exchangeIsReference ex = datasetNum
     | otherwise = case ex of
-        TechnosphereExchange{techRole = Input, techActivityLinkId = link}
+        TechnosphereExchange{techRole = Input, techActivityLinkId = link, techFlowId = fid}
             | link /= UUID.nil ->
-                M.findWithDefault flowNum link (rSupplierNumbers res)
+                M.findWithDefault flowNum (link, fid) (rSupplierNumbers res)
         TechnosphereExchange{} -> flowNum
         BiosphereExchange{} -> flowNum
         WasteExchange{} -> flowNum

--- a/src/Matrix/Export.hs
+++ b/src/Matrix/Export.hs
@@ -43,7 +43,6 @@ data MatrixDebugInfo = MatrixDebugInfo
     , mdBioTriples :: U.Vector SparseTriple
     , mdActivityIndex :: V.Vector Int32
     , mdBioFlowUUIDs :: V.Vector UUID
-    , mdTargetUUID :: UUID
     , mdTargetProcessId :: ProcessId
     , mdDatabase :: Database
     , mdSupplyVector :: [Double]
@@ -51,9 +50,13 @@ data MatrixDebugInfo = MatrixDebugInfo
     , mdInventoryVector :: [Double]
     }
 
--- | Extract matrix debug information from Database
-extractMatrixDebugInfo :: Database -> UUID -> Maybe Text -> IO MatrixDebugInfo
-extractMatrixDebugInfo database targetUUID flowFilter = do
+{- | Extract matrix debug information from Database. The target arrives as the
+row it is, which is the row the caller resolved: an activity UUID would have to
+be resolved again here, and would answer with an arbitrary product of an
+activity written as several coproduct rows.
+-}
+extractMatrixDebugInfo :: Database -> ProcessId -> Maybe Text -> IO MatrixDebugInfo
+extractMatrixDebugInfo database targetProcessId flowFilter = do
     let activities = dbActivities database
         bioFlows = dbBioFlows database
         techTriples = dbTechnosphereTriples database
@@ -63,9 +66,6 @@ extractMatrixDebugInfo database targetUUID flowFilter = do
         activityCount = dbActivityCount database
         bioFlowCount = dbBiosphereCount database
 
-        targetProcessId = case findProcessIdByActivityUUID database targetUUID of
-            Just pid -> pid
-            Nothing -> error $ "Activity " <> show targetUUID <> " has no ProcessId in database for debug-matrices"
         demandVec = buildDemandVectorFromIndex activityIndexVec targetProcessId
         demandList = toList demandVec
 
@@ -102,7 +102,6 @@ extractMatrixDebugInfo database targetUUID flowFilter = do
             , mdBioTriples = filteredBioTriples
             , mdActivityIndex = activityIndexVec
             , mdBioFlowUUIDs = bioFlowUUIDs
-            , mdTargetUUID = targetUUID
             , mdTargetProcessId = targetProcessId
             , mdDatabase = database
             , mdSupplyVector = supplyList

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -2868,29 +2868,26 @@ exportMatrixDebugData :: Database -> Text -> DebugMatricesOptions -> IO (Either 
 exportMatrixDebugData database processIdText opts = do
     case resolveActivityAndProcessId database processIdText of
         Left err -> return $ Left err
-        Right (_processId, targetActivity) -> do
-            case refActivityUUID processIdText of
-                Nothing -> return $ Left $ InvalidUUID $ "Invalid activity UUID: " <> processIdText
-                Just activityUuid -> do
-                    matrixData <- MatrixExport.extractMatrixDebugInfo database activityUuid (debugFlowFilter opts)
-                    let inventoryList = MatrixExport.mdInventoryVector matrixData
-                        bioFlowUUIDs = MatrixExport.mdBioFlowUUIDs matrixData
-                        inventory = M.fromList $ zip (V.toList bioFlowUUIDs) inventoryList
+        Right (processId, targetActivity) -> do
+            matrixData <- MatrixExport.extractMatrixDebugInfo database processId (debugFlowFilter opts)
+            let inventoryList = MatrixExport.mdInventoryVector matrixData
+                bioFlowUUIDs = MatrixExport.mdBioFlowUUIDs matrixData
+                inventory = M.fromList $ zip (V.toList bioFlowUUIDs) inventoryList
 
-                    Progress.reportProgress Progress.Info $ "DEBUG: Starting CSV export to " ++ debugOutput opts
-                    MatrixExport.exportMatrixDebugCSVs (debugOutput opts) matrixData
-                    Progress.reportProgress Progress.Info "DEBUG: CSV export completed"
+            Progress.reportProgress Progress.Info $ "DEBUG: Starting CSV export to " ++ debugOutput opts
+            MatrixExport.exportMatrixDebugCSVs (debugOutput opts) matrixData
+            Progress.reportProgress Progress.Info "DEBUG: CSV export completed"
 
-                    let summary =
-                            M.fromList
-                                [ ("activity_uuid" :: Text, UUID.toText activityUuid)
-                                , ("activity_name" :: Text, activityName targetActivity)
-                                , ("total_inventory_flows" :: Text, T.pack $ show $ M.size inventory)
-                                , ("matrix_debug_exported" :: Text, "CSV_EXPORTED")
-                                , ("supply_chain_file" :: Text, T.pack $ debugOutput opts ++ "_supply_chain.csv")
-                                , ("biosphere_matrix_file" :: Text, T.pack $ debugOutput opts ++ "_biosphere_matrix.csv")
-                                ]
-                    return $ Right $ toJSON summary
+            let summary =
+                    M.fromList
+                        [ ("activity_uuid" :: Text, maybe "" (UUID.toText . prActivity) (processIdToRef database processId))
+                        , ("activity_name" :: Text, activityName targetActivity)
+                        , ("total_inventory_flows" :: Text, T.pack $ show $ M.size inventory)
+                        , ("matrix_debug_exported" :: Text, "CSV_EXPORTED")
+                        , ("supply_chain_file" :: Text, T.pack $ debugOutput opts ++ "_supply_chain.csv")
+                        , ("biosphere_matrix_file" :: Text, T.pack $ debugOutput opts ++ "_biosphere_matrix.csv")
+                        ]
+            return $ Right $ toJSON summary
 
 -- | Export matrices in universal matrix format (delegates to Matrix.Export)
 exportUniversalMatrixFormat :: FilePath -> Database -> IO ()

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -125,6 +125,11 @@ matchClassifications activity filters =
 data ServiceError
     = InvalidUUID Text
     | InvalidProcessId Text
+    | {- | A bare activity UUID naming an activity written as several rows. The
+      activity exists, so this is not a not-found; it is under-specified, and
+      the caller has to name the product too.
+      -}
+      AmbiguousActivity Text
     | ActivityNotFound Text
     | FlowNotFound Text
     | MatrixError Text -- Generic error from matrix computations
@@ -162,14 +167,24 @@ resolveActivityAndProcessId db queryText =
     notFound = ActivityNotFound queryText
     -- A syntactically valid identifier that does not resolve is not-found, not
     -- a format error. Only genuinely malformed input is 'InvalidProcessId'.
+    -- An activity written as several rows is neither: it is there, and the
+    -- query names it without saying which of its products is meant.
     findPid
         | Just ref <- parseProcessRef queryText = maybe (Left notFound) Right (findProcessId db (prActivity ref) (prProduct ref))
         -- Bare activity UUID fallback (EcoInvent compatibility).
-        | Just uuid <- UUID.fromText queryText = maybe (Left notFound) Right (findProcessIdByActivityUUID db uuid)
+        | Just uuid <- UUID.fromText queryText = case M.lookup uuid (dbActivityUUIDIndex db) of
+            Just (pid NE.:| []) -> Right pid
+            Just rows -> Left (AmbiguousActivity (ambiguous rows))
+            Nothing -> Left notFound
         | otherwise =
             Left $ InvalidProcessId $ "Query must be a ProcessId (activityUUID_productUUID) or a valid UUID: " <> queryText
     resolveActivity pid =
         maybe (Left notFound) (\act -> Right (pid, act)) (findActivityByProcessId db pid)
+    ambiguous rows =
+        queryText
+            <> " names an activity written as "
+            <> T.pack (show (NE.length rows))
+            <> " processes, one per product it makes. Name one of them as activityUUID_productUUID."
 
 {- | Validate that a ProcessId exists in the matrix activity index
 This check ensures we fail fast with clear error messages before expensive matrix operations
@@ -2087,6 +2102,7 @@ resolveRootOnly db t
         case resolveActivityAndProcessId db t of
             Right (pid, _) -> Right pid
             Left (InvalidProcessId msg) -> Left msg
+            Left (AmbiguousActivity msg) -> Left msg
             Left (ActivityNotFound msg) -> Left ("activity not found: " <> msg)
             Left e -> Left (T.pack (show e))
 

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -1318,14 +1318,10 @@ getActivityReferenceProductDetail db activity = do
 -- | Get activities that use a specific flow as ActivitySummary list.
 getActivitiesUsingFlow :: Database -> UUID -> [ActivitySummary]
 getActivitiesUsingFlow db flowUUID =
-    case M.lookup flowUUID (idxByFlow $ dbIndexes db) of
-        Nothing -> []
-        Just activityUUIDs ->
-            [ mkActivitySummary db processId proc
-            | procUUID <- S.toList (S.fromList activityUUIDs)
-            , Just proc <- [findActivityByActivityUUID db procUUID]
-            , Just processId <- [findProcessIdForActivity db proc]
-            ]
+    [ mkActivitySummary db pid act
+    | pid <- maybe [] (S.toList . S.fromList) (M.lookup flowUUID (idxByFlow (dbIndexes db)))
+    , Just act <- [getActivity db pid]
+    ]
 
 {- | Sentinel returned only when an exchange's unit UUID failed to resolve.
 The exchange unit-name field already surfaces the same gap via

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -39,9 +39,8 @@ import qualified Search.Fuzzy as Fuzzy
 import qualified Search.Normalize as Normalize
 import SharedSolver (SharedSolver, getFactorization, solveWithSharedSolver)
 import qualified SharedSolver
-import Tree (buildLoopAwareTree)
 import Types
-import UnitConversion (UnitConfig, convertUnit, defaultUnitConfig, unitsCompatible)
+import UnitConversion (UnitConfig, convertUnit, unitsCompatible)
 
 {- | Fields shared by every activity-oriented endpoint (search, supply chain,
 consumers). Split out from the endpoint-specific filters so each filter
@@ -363,23 +362,16 @@ findProcessIdByProductFlowWithFallback unitCfg db flowUUID =
             (ex : _) -> getUnitNameForExchange (dbUnits db') ex
             [] -> ""
 
-{- | Helper to get node ID from LoopAwareTree (returns ProcessId format)
-For all node types, we attempt to return ProcessId format for consistency
+{- | Node id of a tree node, in ProcessId format. Every node but one names the
+row it was built from; a declared link no row satisfies has none to name, so it
+answers with the UUID it carries under a prefix no process id can wear.
 -}
 getTreeNodeId :: Database -> LoopAwareTree -> Text
-getTreeNodeId db (TreeLeaf activity) =
-    case findProcessIdForActivity db activity of
-        Just processId -> processIdToText db processId
-        Nothing -> "unknown-activity" -- Fallback
-getTreeNodeId db (TreeLoop uuid _ _) =
-    -- Use ProcessId format for consistency, maintain UUID_UUID format even in fallback
-    case findProcessIdByActivityUUID db uuid of
-        Just processId -> processIdToText db processId
-        Nothing -> processRefText (ProcessRef uuid uuid) -- Fallback maintains ProcessId format
-getTreeNodeId db (TreeNode activity _) =
-    case findProcessIdForActivity db activity of
-        Just processId -> processIdToText db processId
-        Nothing -> "unknown-activity" -- Fallback
+getTreeNodeId db = \case
+    TreeLeaf pid _ -> processIdToText db pid
+    TreeNode pid _ _ -> processIdToText db pid
+    TreeLoop pid _ _ -> processIdToText db pid
+    TreeMissing uuid _ _ -> "missing:" <> UUID.toText uuid
 
 -- | Count potential children for navigation (technosphere inputs that could be expanded)
 countPotentialChildren :: Database -> Activity -> Int
@@ -390,8 +382,7 @@ countPotentialChildren db activity =
         , isTechnosphereExchange ex
         , exchangeIsInput ex
         , not (exchangeIsReference ex)
-        , Just targetUUID <- [exchangeActivityLinkId ex]
-        , Just _ <- [findProcessIdByActivityUUID db targetUUID]
+        , Just _ <- [linkedProducer db ex]
         ]
 
 -- | Helper to extract compartment from flow category
@@ -486,12 +477,12 @@ mkActivityExportNode db activity nodeId depth parentId =
         , enCompartment = Nothing
         }
 
-{- | ExportNode for a TreeLoop. Looks up the referenced activity for its real
-unit and location; falls back to "N/A" sentinels when the referent is missing.
+{- | ExportNode for a TreeLoop. Reads the row it points at for its real unit
+and location; falls back to "N/A" sentinels when the referent is missing.
 -}
-mkLoopExportNode :: Database -> UUID -> Text -> Text -> Int -> Maybe Text -> ExportNode
-mkLoopExportNode db uuid nodeId name loopDepth parentId =
-    let (actualLocation, actualUnit) = case findActivityByActivityUUID db uuid of
+mkLoopExportNode :: Database -> ProcessId -> Text -> Text -> Int -> Maybe Text -> ExportNode
+mkLoopExportNode db pid nodeId name loopDepth parentId =
+    let (actualLocation, actualUnit) = case getActivity db pid of
             Just act -> (activityLocation act, activityUnit act)
             Nothing -> ("N/A", "N/A")
      in ExportNode
@@ -502,11 +493,31 @@ mkLoopExportNode db uuid nodeId name loopDepth parentId =
             , enUnit = actualUnit
             , enNodeType = LoopNode
             , enDepth = loopDepth
-            , enLoopTarget = Just (UUID.toText uuid)
+            , enLoopTarget = Just (processIdToText db pid)
             , enParentId = parentId
             , enChildrenCount = 0
             , enCompartment = Nothing
             }
+
+{- | ExportNode for a TreeMissing: a link the source declares that no row in
+this database satisfies. It gets a node of its own so the branch stays visible,
+and no loop target, having no row to point at.
+-}
+mkMissingExportNode :: Text -> Text -> Int -> Maybe Text -> ExportNode
+mkMissingExportNode nodeId name missingDepth parentId =
+    ExportNode
+        { enId = nodeId
+        , enName = name
+        , enDescription = ["Declared link, not loaded"]
+        , enLocation = ""
+        , enUnit = ""
+        , enNodeType = MissingNode
+        , enDepth = missingDepth
+        , enLoopTarget = Nothing
+        , enParentId = parentId
+        , enChildrenCount = 0
+        , enCompartment = Nothing
+        }
 
 {- | Attach biosphere nodes/edges to the accumulator when we're at the root of
 the tree (depth == 0). Below the root we leave the accumulator untouched to
@@ -538,16 +549,20 @@ mkTechnosphereTreeEdge units fromPid toPid quantity flow =
 -- | Extract nodes and edges from a 'LoopAwareTree'.
 extractNodesAndEdges :: Database -> LoopAwareTree -> Int -> Maybe Text -> M.Map Text ExportNode -> [TreeEdge] -> (M.Map Text ExportNode, [TreeEdge], TreeStats)
 extractNodesAndEdges db tree depth parentId nodeAcc edgeAcc = case tree of
-    TreeLeaf activity ->
+    TreeLeaf _ activity ->
         let nodeId = getTreeNodeId db tree
             nodes' = M.insert nodeId (mkActivityExportNode db activity nodeId depth parentId) nodeAcc
             (nodes'', edges') = withRootBiosphere db activity nodeId depth (nodes', edgeAcc)
          in (nodes'', edges', TreeStats 1 0 1)
-    TreeLoop uuid name loopDepth ->
+    TreeLoop pid name loopDepth ->
         let nodeId = getTreeNodeId db tree
-            nodes' = M.insert nodeId (mkLoopExportNode db uuid nodeId name loopDepth parentId) nodeAcc
+            nodes' = M.insert nodeId (mkLoopExportNode db pid nodeId name loopDepth parentId) nodeAcc
          in (nodes', edgeAcc, TreeStats 1 1 0)
-    TreeNode activity children ->
+    TreeMissing _ name missingDepth ->
+        let nodeId = getTreeNodeId db tree
+            nodes' = M.insert nodeId (mkMissingExportNode nodeId name missingDepth parentId) nodeAcc
+         in (nodes', edgeAcc, TreeStats 1 0 1)
+    TreeNode _ activity children ->
         let nodeId = getTreeNodeId db tree
             nodes' = M.insert nodeId (mkActivityExportNode db activity nodeId depth parentId) nodeAcc
             (childNodes, childEdges, childStats) = foldr (processChild nodeId) (nodes', edgeAcc, TreeStats 1 0 0) children
@@ -576,20 +591,6 @@ convertToTreeExport db _rootProcessId maxDepth tree =
                 , tmExpandableNodes = length [() | (_, node) <- M.toList nodes, enChildrenCount node > 0]
                 }
      in TreeExport metadata nodes edges
-
--- | Get activity tree as rich TreeExport with configurable depth
-getActivityTree :: Database -> Text -> Int -> Maybe Text -> Either ServiceError Value
-getActivityTree db queryText maxDepth nameFilter = do
-    (_processId, _activity) <- resolveActivityAndProcessId db queryText
-    case refActivityUUID queryText of
-        Just activityUuid ->
-            let loopAwareTree = buildLoopAwareTree defaultUnitConfig db activityUuid maxDepth
-                treeExport = convertToTreeExport db queryText maxDepth loopAwareTree
-                filtered = case nameFilter of
-                    Nothing -> treeExport
-                    Just pat -> filterTreeExport pat treeExport
-             in Right $ toJSON filtered
-        Nothing -> Left $ InvalidUUID $ "Invalid activity UUID: " <> queryText
 
 {- | Post-filter a TreeExport by name: keep matching nodes plus all their ancestors up to root.
 Uses the enParentId chain already stored in each ExportNode — no extra graph traversal.

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -30,7 +30,7 @@ import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import Database (applyStructuredFilters, findActivitiesByFields, findFlowsBySynonym, flowNameRelevance)
-import Database.MatrixBuild (findProducer)
+import Database.MatrixBuild (findProducer, linkedProducer)
 import Matrix (DepDemands, Inventory, accumulateDepDemandsWith, activityNormalizationFactor, applyBiosphereMatrix, buildDemandVectorFromIndex, computeInventoryMatrix, depDemandsToVector, perturbA, perturbABatch, perturbGlobal, toList)
 import qualified Matrix.Export as MatrixExport
 import qualified Progress
@@ -1091,21 +1091,14 @@ crossDBLinkToTarget link =
         (cdlLocation link)
         (supplierRefText link)
 
--- | EcoSpold path: resolve a target by activity UUID.
-resolveByActivityUUID :: Database -> UUID -> Maybe TargetRef
-resolveByActivityUUID db linkId
-    | linkId == UUID.nil = Nothing
-    | otherwise = do
-        pid <- findProcessIdByActivityUUID db linkId
-        act <- getActivity db pid
-        pure (activityToTarget db pid act)
+-- | The target one row names, when that row is in the database.
+targetOf :: Database -> ProcessId -> Maybe TargetRef
+targetOf db pid = activityToTarget db pid <$> getActivity db pid
 
 -- | SimaPro path: resolve a target by product flow UUID.
 resolveByProductFlow :: UnitConfig -> Database -> UUID -> Maybe TargetRef
-resolveByProductFlow cfg db fId = do
-    pid <- findProcessIdByProductFlowWithFallback cfg db fId
-    act <- getActivity db pid
-    pure (activityToTarget db pid act)
+resolveByProductFlow cfg db fId =
+    findProcessIdByProductFlowWithFallback cfg db fId >>= targetOf db
 
 -- | Cross-database link resolution (orphan waste outputs, missing tech links).
 resolveByCrossDBLink :: M.Map UUID CrossDBLink -> UUID -> Maybe TargetRef
@@ -1118,16 +1111,23 @@ a multi-product activity, and would name a treatment for a pair the matrix never
 routed.
 -}
 resolveByRoutedProducer :: Database -> Exchange -> Maybe TargetRef
-resolveByRoutedProducer db ex = do
-    pid <- findProducer (dbProcessIdLookup db) ex
-    act <- getActivity db pid
-    pure (activityToTarget db pid act)
+resolveByRoutedProducer db ex = findProducer (dbProcessIdLookup db) ex >>= targetOf db
+
+{- | The target an incoming link names: the routed row, else the row its
+activity UUID alone names ('linkedProducer'). An input's link is a statement
+about where the flow comes from, so answering it with a row of the right
+activity but the wrong product is what this replaces.
+-}
+resolveByLinkedProducer :: Database -> Exchange -> Maybe TargetRef
+resolveByLinkedProducer db ex = linkedProducer db ex >>= targetOf db
 
 {- | Resolve the target activity (if any) for one exchange. Technosphere broken
 links (linkId set but unresolvable) do NOT fall through to the product-flow
 path — that matches the original behaviour. Use '<|>' to chain fallbacks only
-where the original code did. A waste output is the one arm resolved the way the
-matrix routes it; the others answer from the activity UUID alone.
+where the original code did. Every linked arm resolves the way the matrix
+routes it; a waste output is the one that stops there, with no fallback to the
+activity UUID, because a link it cannot route is a treatment this database does
+not hold and reporting a row for it would hide that.
 -}
 resolveTarget ::
     UnitConfig ->
@@ -1136,13 +1136,13 @@ resolveTarget ::
     Exchange ->
     Maybe TargetRef
 resolveTarget cfg db links = \case
-    TechnosphereExchange{techRole = role, techActivityLinkId = lid, techFlowId = fid}
+    ex@TechnosphereExchange{techRole = role, techActivityLinkId = lid, techFlowId = fid}
         | role /= Input && role /= ReferenceInput -> Nothing
-        | lid /= UUID.nil -> resolveByActivityUUID db lid
+        | lid /= UUID.nil -> resolveByLinkedProducer db ex
         | otherwise -> resolveByProductFlow cfg db fid <|> resolveByCrossDBLink links fid
     BiosphereExchange{} -> Nothing
-    WasteExchange{waIsInput = True, waActivityLinkId = lid}
-        | lid /= UUID.nil -> resolveByActivityUUID db lid
+    ex@WasteExchange{waIsInput = True, waActivityLinkId = lid}
+        | lid /= UUID.nil -> resolveByLinkedProducer db ex
         | otherwise -> Nothing
     -- An output's link names the activity that treats the waste, exactly as an
     -- input's names the one that supplies it. Reading it as no target at all
@@ -1297,10 +1297,9 @@ getAllProductsForActivity db groupKey =
 -- | Get target activity for technosphere navigation.
 getTargetActivity :: Database -> Exchange -> Maybe ActivitySummary
 getTargetActivity db exchange = do
-    targetId <- exchangeActivityLinkId exchange
-    targetActivity <- findActivityByActivityUUID db targetId
-    processId <- findProcessIdForActivity db targetActivity
-    pure (mkActivitySummary db processId targetActivity)
+    pid <- linkedProducer db exchange
+    act <- getActivity db pid
+    pure (mkActivitySummary db pid act)
 
 {- | Get reference product as FlowDetail (if exists). Reference products are
 technosphere by definition.

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -39,6 +39,7 @@ import qualified Search.Fuzzy as Fuzzy
 import qualified Search.Normalize as Normalize
 import SharedSolver (SharedSolver, getFactorization, solveWithSharedSolver)
 import qualified SharedSolver
+import Tree (childTarget)
 import Types
 import UnitConversion (UnitConfig, convertUnit, unitsCompatible)
 
@@ -373,7 +374,12 @@ getTreeNodeId db = \case
     TreeLoop pid _ _ -> processIdToText db pid
     TreeMissing uuid _ _ -> "missing:" <> UUID.toText uuid
 
--- | Count potential children for navigation (technosphere inputs that could be expanded)
+{- | Count potential children for navigation (technosphere inputs that could be
+expanded). It counts what the traversal descends into, 'Tree.childTarget', so a
+node's count and the edges leaving it in the same export agree: an input whose
+declared supplier is in no loaded database is a child too, the one the export
+names a missing node.
+-}
 countPotentialChildren :: Database -> Activity -> Int
 countPotentialChildren db activity =
     length
@@ -382,7 +388,7 @@ countPotentialChildren db activity =
         , isTechnosphereExchange ex
         , exchangeIsInput ex
         , not (exchangeIsReference ex)
-        , Just _ <- [linkedProducer db ex]
+        , Just _ <- [childTarget db ex]
         ]
 
 -- | Helper to extract compartment from flow category
@@ -2863,12 +2869,16 @@ getConsumers db dbName processIdText cnf = do
 
     Right $ ConsumersResponse (SearchResults page total offset limit hasMore 0.0) edges
 
--- | Export matrix debug data (delegates to Matrix.Export)
+{- | Export matrix debug data (delegates to Matrix.Export). The row's own
+reference is read up front rather than defaulted later: the summary states the
+activity it exported, and a row the process id table cannot name is a broken
+database, not an empty field.
+-}
 exportMatrixDebugData :: Database -> Text -> DebugMatricesOptions -> IO (Either ServiceError Value)
 exportMatrixDebugData database processIdText opts = do
-    case resolveActivityAndProcessId database processIdText of
+    case resolveActivityAndProcessId database processIdText >>= withRef of
         Left err -> return $ Left err
-        Right (processId, targetActivity) -> do
+        Right (processId, targetActivity, ref) -> do
             matrixData <- MatrixExport.extractMatrixDebugInfo database processId (debugFlowFilter opts)
             let inventoryList = MatrixExport.mdInventoryVector matrixData
                 bioFlowUUIDs = MatrixExport.mdBioFlowUUIDs matrixData
@@ -2880,7 +2890,7 @@ exportMatrixDebugData database processIdText opts = do
 
             let summary =
                     M.fromList
-                        [ ("activity_uuid" :: Text, maybe "" (UUID.toText . prActivity) (processIdToRef database processId))
+                        [ ("activity_uuid" :: Text, UUID.toText (prActivity ref))
                         , ("activity_name" :: Text, activityName targetActivity)
                         , ("total_inventory_flows" :: Text, T.pack $ show $ M.size inventory)
                         , ("matrix_debug_exported" :: Text, "CSV_EXPORTED")
@@ -2888,6 +2898,12 @@ exportMatrixDebugData database processIdText opts = do
                         , ("biosphere_matrix_file" :: Text, T.pack $ debugOutput opts ++ "_biosphere_matrix.csv")
                         ]
             return $ Right $ toJSON summary
+  where
+    withRef (pid, act) =
+        maybe
+            (Left (InvalidUUID ("No activity reference for " <> processIdText)))
+            (\ref -> Right (pid, act, ref))
+            (processIdToRef database pid)
 
 -- | Export matrices in universal matrix format (delegates to Matrix.Export)
 exportUniversalMatrixFormat :: FilePath -> Database -> IO ()

--- a/src/Tree.hs
+++ b/src/Tree.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Tree (buildLoopAwareTree) where
+module Tree (buildLoopAwareTree, childTarget) where
 
 import Control.Monad.Trans.State.Strict (State, evalState, get, modify)
 import qualified Data.Map as M
 import qualified Data.Set as S
+import Data.Text (Text)
 import Database.MatrixBuild (linkedProducer)
 import Numeric.Natural (Natural)
 import Types
@@ -19,18 +20,17 @@ isTechnosphereInput ex =
         WasteExchange{} -> False -- waste flows aren't upstream tech inputs in the tree-builder sense
 
 {- | Get converted exchange amount ensuring unit compatibility.
-Converts exchange amount to the target activity's reference unit for proper scaling.
-A target that resolved to nothing has no reference unit, so the amount is left
-as the exchange states it.
+Converts the exchange amount into the unit the edge carrying it declares, for
+proper scaling. Either side reading "unknown" leaves the amount as the exchange
+states it, there being nothing to convert between.
 -}
-getConvertedExchangeAmount :: UnitConfig -> Database -> Exchange -> Maybe Activity -> Double
-getConvertedExchangeAmount unitCfg db exchange mTarget =
+getConvertedExchangeAmount :: UnitConfig -> Database -> Exchange -> Text -> Double
+getConvertedExchangeAmount unitCfg db exchange targetUnit =
     let originalAmount = exchangeAmount exchange
         exchangeUnitName = maybe "unknown" unitName (M.lookup (exchangeUnitId exchange) (dbUnits db))
-        targetReferenceUnit = maybe "unknown" activityUnit mTarget
-     in if exchangeUnitName == "unknown" || targetReferenceUnit == "unknown"
+     in if exchangeUnitName == "unknown" || targetUnit == "unknown"
             then originalAmount
-            else convertExchangeAmount unitCfg exchangeUnitName targetReferenceUnit originalAmount
+            else convertExchangeAmount unitCfg exchangeUnitName targetUnit originalAmount
 
 {- | Read-only context threaded through tree construction. @tcMaxDepth@ is a
 'Natural' so negative depths are unrepresentable; the public entrypoint
@@ -55,8 +55,13 @@ childTarget db ex =
         Just row -> Just (Right row)
         Nothing -> Left <$> exchangeActivityLinkId ex
 
-childActivity :: ChildTarget -> Maybe Activity
-childActivity = either (const Nothing) (Just . snd)
+{- | The unit the amount on the edge to this child is stated in: the row's own
+reference unit when there is a row, and otherwise the flow's, which is what the
+edge is labelled with either way. A missing target with no unit of its own would
+leave a number in the exchange's unit under a label naming another.
+-}
+childUnit :: Database -> TechnosphereFlow -> ChildTarget -> Text
+childUnit db flow = either (const (getUnitNameForTechFlow (dbUnits db) flow)) (activityUnit . snd)
 
 {- | Build loop-aware tree for SVG export with maximum depth and a fixed
 per-tree node budget (300) to keep export latency bounded. Negative
@@ -105,7 +110,7 @@ buildChildren cfg (ex : exs) visited depth = do
         then pure []
         else case (childTarget db ex, M.lookup (exchangeFlowId ex) (dbTechFlows db)) of
             (Just target, Just flow) -> do
-                let amount = getConvertedExchangeAmount (tcUnitConfig cfg) db ex (childActivity target)
+                let amount = getConvertedExchangeAmount (tcUnitConfig cfg) db ex (childUnit db flow target)
                 subtree <- buildTarget cfg target visited depth
                 rest <- buildChildren cfg exs visited depth
                 pure ((amount, flow, subtree) : rest)

--- a/src/Tree.hs
+++ b/src/Tree.hs
@@ -5,6 +5,7 @@ module Tree (buildLoopAwareTree) where
 import Control.Monad.Trans.State.Strict (State, evalState, get, modify)
 import qualified Data.Map as M
 import qualified Data.Set as S
+import Database.MatrixBuild (linkedProducer)
 import Numeric.Natural (Natural)
 import Types
 import UnitConversion (UnitConfig, convertExchangeAmount)
@@ -19,12 +20,14 @@ isTechnosphereInput ex =
 
 {- | Get converted exchange amount ensuring unit compatibility.
 Converts exchange amount to the target activity's reference unit for proper scaling.
+A target that resolved to nothing has no reference unit, so the amount is left
+as the exchange states it.
 -}
-getConvertedExchangeAmount :: UnitConfig -> Database -> Exchange -> UUID -> Double
-getConvertedExchangeAmount unitCfg db exchange targetActivityUUID =
+getConvertedExchangeAmount :: UnitConfig -> Database -> Exchange -> Maybe Activity -> Double
+getConvertedExchangeAmount unitCfg db exchange mTarget =
     let originalAmount = exchangeAmount exchange
         exchangeUnitName = maybe "unknown" unitName (M.lookup (exchangeUnitId exchange) (dbUnits db))
-        targetReferenceUnit = maybe "unknown" activityUnit (findActivityByActivityUUID db targetActivityUUID)
+        targetReferenceUnit = maybe "unknown" activityUnit mTarget
      in if exchangeUnitName == "unknown" || targetReferenceUnit == "unknown"
             then originalAmount
             else convertExchangeAmount unitCfg exchangeUnitName targetReferenceUnit originalAmount
@@ -39,61 +42,80 @@ data TreeConfig = TreeConfig
     , tcMaxDepth :: !Natural
     }
 
+{- | What one technosphere input points at: the row that supplies it, or a
+declared activity link no row satisfies. An input declaring no link at all is
+'Nothing' — the SimaPro shape, resolved by product flow elsewhere, which this
+traversal has always skipped.
+-}
+type ChildTarget = Either UUID (ProcessId, Activity)
+
+childTarget :: Database -> Exchange -> Maybe ChildTarget
+childTarget db ex =
+    case linkedProducer db ex >>= \pid -> (,) pid <$> getActivity db pid of
+        Just row -> Just (Right row)
+        Nothing -> Left <$> exchangeActivityLinkId ex
+
+childActivity :: ChildTarget -> Maybe Activity
+childActivity = either (const Nothing) (Just . snd)
+
 {- | Build loop-aware tree for SVG export with maximum depth and a fixed
 per-tree node budget (300) to keep export latency bounded. Negative
-@maxDepth@ arguments are clamped to 0.
+@maxDepth@ arguments are clamped to 0. The root arrives as the row it sits at
+and the activity that row holds, so a root outside the database is
+unrepresentable rather than reported as a missing node.
 -}
-buildLoopAwareTree :: UnitConfig -> Database -> UUID -> Int -> LoopAwareTree
-buildLoopAwareTree unitCfg db rootUUID maxDepth =
+buildLoopAwareTree :: UnitConfig -> Database -> Int -> (ProcessId, Activity) -> LoopAwareTree
+buildLoopAwareTree unitCfg db maxDepth (rootPid, rootActivity) =
     let cfg = TreeConfig unitCfg db (fromIntegral (max 0 maxDepth))
         maxNodes = 300
-     in evalState (buildNode cfg rootUUID S.empty 0) maxNodes
+     in evalState (buildNode cfg rootPid rootActivity S.empty 0) maxNodes
 
 {- | Recursive tree builder running in 'State Int' for the node budget.
 Every visit that produces a node (loop, leaf, missing, or branch)
 decrements the budget by one; when the budget hits zero further
 exploration is cut off and a truncation leaf is emitted.
 -}
-buildNode :: TreeConfig -> UUID -> S.Set UUID -> Int -> State Int LoopAwareTree
-buildNode cfg activityUUID visited depth = do
+buildNode :: TreeConfig -> ProcessId -> Activity -> S.Set ProcessId -> Int -> State Int LoopAwareTree
+buildNode cfg pid activity visited depth = do
     budget <- get
-    let mActivity = findActivityByActivityUUID (tcDatabase cfg) activityUUID
-        name = maybe "Missing Activity" activityName mActivity
     if budget <= 0
-        then pure (TreeLoop activityUUID name depth)
+        then pure (TreeLoop pid (activityName activity) depth)
         else do
             modify (subtract 1)
-            if fromIntegral depth >= tcMaxDepth cfg || activityUUID `S.member` visited
-                then pure (TreeLoop activityUUID name depth)
-                else case mActivity of
-                    Nothing -> pure (TreeLoop activityUUID "Missing Activity" depth)
-                    Just activity -> do
-                        let visited' = S.insert activityUUID visited
-                            techInputs =
-                                [ ex
-                                | ex <- exchanges activity
-                                , isTechnosphereInput ex
-                                ]
-                        children <- buildChildren cfg techInputs visited' (depth + 1)
-                        pure $
-                            if null children
-                                then TreeLeaf activity
-                                else TreeNode activity children
+            if fromIntegral depth >= tcMaxDepth cfg || pid `S.member` visited
+                then pure (TreeLoop pid (activityName activity) depth)
+                else do
+                    let visited' = S.insert pid visited
+                        techInputs = filter isTechnosphereInput (exchanges activity)
+                    children <- buildChildren cfg techInputs visited' (depth + 1)
+                    pure $
+                        if null children
+                            then TreeLeaf pid activity
+                            else TreeNode pid activity children
 
-{- | Fold over technosphere input exchanges, pairing each resolvable child
+{- | Fold over technosphere input exchanges, pairing each linked child
 with its converted amount and recursing. Bails out early when the node
 budget runs out so the tree stays within the 300-node envelope.
 -}
-buildChildren :: TreeConfig -> [Exchange] -> S.Set UUID -> Int -> State Int [(Double, TechnosphereFlow, LoopAwareTree)]
+buildChildren :: TreeConfig -> [Exchange] -> S.Set ProcessId -> Int -> State Int [(Double, TechnosphereFlow, LoopAwareTree)]
 buildChildren _ [] _ _ = pure []
 buildChildren cfg (ex : exs) visited depth = do
     budget <- get
     if budget <= 0
         then pure []
-        else case (exchangeActivityLinkId ex, M.lookup (exchangeFlowId ex) (dbTechFlows (tcDatabase cfg))) of
-            (Just targetUUID, Just flow) -> do
-                let amount = getConvertedExchangeAmount (tcUnitConfig cfg) (tcDatabase cfg) ex targetUUID
-                subtree <- buildNode cfg targetUUID visited depth
+        else case (childTarget db ex, M.lookup (exchangeFlowId ex) (dbTechFlows db)) of
+            (Just target, Just flow) -> do
+                let amount = getConvertedExchangeAmount (tcUnitConfig cfg) db ex (childActivity target)
+                subtree <- buildTarget cfg target visited depth
                 rest <- buildChildren cfg exs visited depth
                 pure ((amount, flow, subtree) : rest)
             _ -> buildChildren cfg exs visited depth
+  where
+    db = tcDatabase cfg
+
+buildTarget :: TreeConfig -> ChildTarget -> S.Set ProcessId -> Int -> State Int LoopAwareTree
+buildTarget cfg target visited depth = case target of
+    Right (pid, activity) -> buildNode cfg pid activity visited depth
+    Left uuid -> do
+        modify (subtract 1)
+        pure (TreeMissing uuid "Missing Activity" depth)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -35,6 +35,7 @@ import GHC.Generics (Generic)
 
 import Control.Lens ((&), (?~))
 import Data.List (find, nub)
+import Data.List.NonEmpty (NonEmpty (..))
 import Data.OpenApi (NamedSchema (..), OpenApiType (..), ToSchema (..), enum_, type_)
 import Search.BM25.Types (BM25Index)
 import SubstanceRegistry (CASNumber (..), NormName (..), nonEmptyCAS)
@@ -884,7 +885,7 @@ data MatrixFactorization = MatrixFactorization
 Used for: (1) upstream link resolution for SimaPro data, (2) future product search
 -}
 data ProductIndex = ProductIndex
-    { piByUUID :: !(M.Map UUID ProcessId) -- Product flow UUID → ProcessId (for upstream links)
+    { piByUUID :: !(M.Map UUID (NonEmpty ProcessId)) -- Product flow UUID → the rows producing it (for upstream links)
     , piByName :: !(M.Map Text [ProcessId]) -- Normalized product name → [ProcessId] (for search)
     , piByLocation :: !(M.Map Text [ProcessId]) -- Location → [ProcessId] (for search)
     }
@@ -1067,13 +1068,20 @@ findActivityByActivityUUID db searchUUID = do
     pid <- M.lookup searchUUID (dbActivityUUIDIndex db)
     getActivity db pid
 
-{- | Find supplier ProcessId by product flow UUID
+{- | Find supplier ProcessId by product flow UUID.
 ESSENTIAL for SimaPro data: exchanges have techActivityLinkId = nil, but techFlowId is valid.
-Uses the ProductIndex to resolve the supplier activity from the product flow.
+
+Answers only when exactly one row produces the flow. A product made in several
+geographies is produced by several rows, and naming one of them would answer a
+question the caller never asked; 'Service.findProcessIdByProductFlowWithFallback'
+applies the same rule to its name-and-unit rung.
 -}
 findProcessIdByProductFlow :: Database -> UUID -> Maybe ProcessId
 findProcessIdByProductFlow db flowUUID =
-    M.lookup flowUUID (piByUUID $ dbProductIndex db)
+    M.lookup flowUUID (piByUUID $ dbProductIndex db) >>= soleProducer
+  where
+    soleProducer (pid :| []) = Just pid
+    soleProducer (_ :| (_ : _)) = Nothing
 
 {- | Look up an exchange's flow on the appropriate side. Each exchange variant
 has exactly one flow side by construction (tech, bio, or waste), so the

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -577,11 +577,17 @@ data ActivityTree
     = Leaf !Activity
     | Node !Activity ![(Double, ActivityTree)] -- Activities and weighted sub-activities
 
--- | Loop-aware tree for SVG export
+{- | Loop-aware tree for SVG export. Every node that exists names the row it
+sits at, so an allocated activity written as several coproduct rows is several
+nodes here rather than one. A declared link that no row satisfies is its own
+constructor: it keeps the branch visible instead of dropping it, and it is the
+only node with no row to name.
+-}
 data LoopAwareTree
-    = TreeLeaf !Activity
-    | TreeNode !Activity ![(Double, TechnosphereFlow, LoopAwareTree)] -- Activity + (quantity, child product flow, subtree)
-    | TreeLoop !UUID !Text !Int -- Loop reference: UUID + ActivityName + Depth
+    = TreeLeaf !ProcessId !Activity
+    | TreeNode !ProcessId !Activity ![(Double, TechnosphereFlow, LoopAwareTree)] -- Row + activity + (quantity, child product flow, subtree)
+    | TreeLoop !ProcessId !Text !Int -- Already visited, or depth/budget spent: row + ActivityName + Depth
+    | TreeMissing !UUID !Text !Int -- Declared link no row satisfies: activity UUID + name + Depth
 
 -- | Technosphere flow database (deduplicated by UUID)
 type TechFlowDB = M.Map UUID TechnosphereFlow

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -900,7 +900,7 @@ data Database = Database
     { -- UUID interning tables for ProcessId ↔ (UUID, UUID) conversion
       dbProcessIdTable :: !(V.Vector (UUID, UUID)) -- ProcessId (Int32) → (activityUUID, productUUID)
     , dbProcessIdLookup :: !(M.Map (UUID, UUID) ProcessId) -- reverse lookup
-    , dbActivityUUIDIndex :: !(M.Map UUID ProcessId) -- Activity UUID → ProcessId (for O(1) lookups)
+    , dbActivityUUIDIndex :: !(M.Map UUID (NonEmpty ProcessId)) -- Activity UUID → the rows that activity was written as
     , dbActivityProductsIndex :: !(M.Map (UUID, Maybe NativeProcessId) [ProcessId]) -- 'activityGroupKey' → the ProcessIds of one source block (its coproducts)
     , dbProductIndex :: !ProductIndex -- Product flow → ProcessId lookups (for SimaPro links & product search)
     , dbActivities :: !ActivityDB -- Vector of activities indexed by ProcessId
@@ -1049,24 +1049,22 @@ findProcessId :: Database -> UUID -> UUID -> Maybe ProcessId
 findProcessId db actUUID prodUUID =
     M.lookup (actUUID, prodUUID) (dbProcessIdLookup db)
 
-{- | Find any ProcessId matching an activity UUID
-Returns the first ProcessId found with the given activity UUID.
-ESSENTIAL for EcoSpold data: exchange links only contain activity UUIDs (not full ProcessIds),
-so we must translate from UUID → ProcessId to handle multi-product activities.
+{- | The row an activity UUID names, when it names one.
+
+An EcoSpold link and a bare activity UUID typed into the API both carry the
+activity alone, while a row is a pair. An allocated activity is written as one
+row per coproduct, so the UUID names several and there is no way to tell which
+one the caller meant: answering with any of them is guesswork the caller cannot
+see. Callers that hold the product too should use 'findProcessId'.
 -}
 findProcessIdByActivityUUID :: Database -> UUID -> Maybe ProcessId
 findProcessIdByActivityUUID db searchUUID =
-    M.lookup searchUUID (dbActivityUUIDIndex db)
+    M.lookup searchUUID (dbActivityUUIDIndex db) >>= sole
 
-{- | Find activity by activity UUID (returns first matching product)
-ESSENTIAL for EcoSpold data: exchange links only contain activity UUIDs (not full ProcessIds).
-When multiple products exist for one activity, this returns an arbitrary match.
-Uses O(1) Map lookup for efficient resolution
--}
-findActivityByActivityUUID :: Database -> UUID -> Maybe Activity
-findActivityByActivityUUID db searchUUID = do
-    pid <- M.lookup searchUUID (dbActivityUUIDIndex db)
-    getActivity db pid
+-- | The one element of a 'NonEmpty' that has exactly one.
+sole :: NonEmpty a -> Maybe a
+sole (x :| []) = Just x
+sole (_ :| (_ : _)) = Nothing
 
 {- | Find supplier ProcessId by product flow UUID.
 ESSENTIAL for SimaPro data: exchanges have techActivityLinkId = nil, but techFlowId is valid.
@@ -1078,10 +1076,7 @@ applies the same rule to its name-and-unit rung.
 -}
 findProcessIdByProductFlow :: Database -> UUID -> Maybe ProcessId
 findProcessIdByProductFlow db flowUUID =
-    M.lookup flowUUID (piByUUID $ dbProductIndex db) >>= soleProducer
-  where
-    soleProducer (pid :| []) = Just pid
-    soleProducer (_ :| (_ : _)) = Nothing
+    M.lookup flowUUID (piByUUID $ dbProductIndex db) >>= sole
 
 {- | Look up an exchange's flow on the appropriate side. Each exchange variant
 has exactly one flow side by construction (tech, bio, or waste), so the

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -761,8 +761,11 @@ type NameIndex = M.Map Text [UUID] -- Name -> [ActivityUUID]
 -- | Index by location - geographic search
 type LocationIndex = M.Map Text [UUID] -- Location -> [ActivityUUID]
 
--- | Index by flow - find activities that use a given flow
-type FlowIndex = M.Map UUID [UUID] -- FlowID -> [ActivityUUID]
+{- | Index by flow - find the rows that use a given flow. Keyed on the row and
+not on the activity UUID, so an activity written as several coproduct rows is
+listed once per row rather than once per activity.
+-}
+type FlowIndex = M.Map UUID [ProcessId] -- FlowID -> [ProcessId]
 
 -- | Index of exchanges by flow - find all exchanges using a flow
 type ExchangeIndex = M.Map UUID [(UUID, Exchange)] -- FlowID -> [(ActivityID, Exchange)]

--- a/test/CoproductTargetSpec.hs
+++ b/test/CoproductTargetSpec.hs
@@ -3,7 +3,7 @@
 {- | An allocated dataset is one activity written as one row per coproduct, all
 sharing an activity UUID. Anything keyed on that UUID alone therefore answers
 with an arbitrary one of them. These tests pin the places a consumer reads a
-coproduct back.
+coproduct back: the target of an exchange, and the tree it descends.
 
 The fixture is built so the wrong answer is visible: the input names the
 coproduct with the /lower/ product UUID, which is exactly the row a
@@ -16,9 +16,10 @@ import Data.Text (Text)
 import qualified Data.UUID as UUID
 import Test.Hspec
 
-import API.Types (ActivityForAPI (..), ActivitySummary (..), ExchangeDetail (..), ExchangeWithUnit (..))
+import API.Types (ActivityForAPI (..), ActivitySummary (..), ExchangeDetail (..), ExchangeWithUnit (..), ExportNode (..), NodeType (..), TreeExport (..))
 import Database (buildDatabaseWithMatrices)
 import qualified Service
+import Tree (buildLoopAwareTree)
 import Types
 import UnitConversion (defaultUnitConfig)
 
@@ -36,6 +37,31 @@ spec = do
         it "reports a waste output whose treatment is not loaded as such" $ do
             db <- untreatedWasteFixture
             wasteLineOf db `shouldBe` (Nothing, Just TreatmentNotLoaded)
+
+    describe "the tree" $ do
+        it "descends into the coproduct the input asks for" $ do
+            db <- twoCoproductFixture
+            case treeOfConsumer db of
+                Right (TreeNode _ _ [(_, _, TreeLeaf pid _)]) -> processIdToText db pid `shouldBe` pidText milkId
+                Right other -> expectationFailure ("unexpected tree shape: " <> show (shapeOf other))
+                Left err -> expectationFailure (show err)
+
+        it "keeps a declared link no row satisfies as a visible node" $ do
+            db <- danglingLinkFixture
+            case treeOfConsumer db of
+                Right (TreeNode _ _ [(_, _, TreeMissing uuid _ _)]) -> uuid `shouldBe` ghostActId
+                Right other -> expectationFailure ("unexpected tree shape: " <> show (shapeOf other))
+                Left err -> expectationFailure (show err)
+
+        it "exports that node instead of dropping the branch" $ do
+            db <- danglingLinkFixture
+            case treeOfConsumer db of
+                Left err -> expectationFailure (show err)
+                Right tree -> do
+                    let export = Service.convertToTreeExport db (pidText consumerProdId) 10 tree
+                        missing = [n | n <- M.elems (teNodes export), enNodeType n == MissingNode]
+                    map enLoopTarget missing `shouldBe` [Nothing]
+                    length (teEdges export) `shouldBe` 1
 
 -- ---------------------------------------------------------------------------
 -- Reading one exchange back
@@ -66,6 +92,18 @@ wasteLineOf db = case consumerRow db of
             [ewu] -> (ewuTargetProcessId ewu, ewuWasteRole ewu)
             _ -> (Just "no waste output", Nothing)
 
+treeOfConsumer :: Database -> Either Text LoopAwareTree
+treeOfConsumer db = case consumerRow db of
+    Nothing -> Left "no consumer row"
+    Just root -> Right (buildLoopAwareTree defaultUnitConfig db 10 root)
+
+-- | Constructor names only, so a shape mismatch reports something readable.
+shapeOf :: LoopAwareTree -> [Text]
+shapeOf (TreeLeaf _ _) = ["leaf"]
+shapeOf (TreeLoop{}) = ["loop"]
+shapeOf (TreeMissing{}) = ["missing"]
+shapeOf (TreeNode _ _ children) = "node" : concatMap (\(_, _, t) -> shapeOf t) children
+
 consumerRow :: Database -> Maybe (ProcessId, Activity)
 consumerRow db = do
     pid <- findProcessId db consumerActId consumerProdId
@@ -81,6 +119,12 @@ the one with the lower product UUID.
 -}
 twoCoproductFixture :: IO Database
 twoCoproductFixture = buildFixture (consumerActivity [milkInput] []) supplierRows supplierFlows
+
+{- | The same consumer, its input naming an activity no row in the database
+carries.
+-}
+danglingLinkFixture :: IO Database
+danglingLinkFixture = buildFixture (consumerActivity [ghostInput] []) supplierRows supplierFlows
 
 {- | A consumer whose waste output names a treatment the database does not hold
 at that pair. The treatment activity is present, but under another flow, so an
@@ -137,6 +181,10 @@ consumerActivity inputs outputs =
 -- | An input naming the supplier's lower-UUID coproduct.
 milkInput :: Exchange
 milkInput = techExchange milkId 2.0 Input supplierActId
+
+-- | An input naming an activity the database does not hold.
+ghostInput :: Exchange
+ghostInput = techExchange milkId 2.0 Input ghostActId
 
 {- | A waste output naming the supplier: the activity exists, no row of it
 produces the waste flow, so nothing routes it.
@@ -221,8 +269,9 @@ mkUUID n = UUID.fromWords64 (fromIntegral n) 0
 {- | The supplier's two products are ordered on purpose: 'milkId' is the one a
 map keyed on the activity UUID alone drops.
 -}
-supplierActId, milkId, creamId, consumerActId, consumerProdId, scrapId, kgUnitId :: UUID
+supplierActId, milkId, creamId, consumerActId, consumerProdId, ghostActId, scrapId, kgUnitId :: UUID
 supplierActId = mkUUID 1
+ghostActId = mkUUID 77
 milkId = mkUUID 2
 creamId = mkUUID 9
 consumerActId = mkUUID 3

--- a/test/CoproductTargetSpec.hs
+++ b/test/CoproductTargetSpec.hs
@@ -17,12 +17,12 @@ import Data.Text (Text)
 import qualified Data.UUID as UUID
 import Test.Hspec
 
-import API.Types (ActivityForAPI (..), ActivitySummary (..), ExchangeDetail (..), ExchangeWithUnit (..), ExportNode (..), NodeType (..), TreeExport (..))
+import API.Types (ActivityForAPI (..), ActivitySummary (..), ExchangeDetail (..), ExchangeWithUnit (..), ExportNode (..), NodeType (..), TreeEdge (..), TreeExport (..))
 import Database (buildDatabaseWithMatrices)
 import qualified Service
 import Tree (buildLoopAwareTree)
 import Types
-import UnitConversion (defaultUnitConfig)
+import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig)
 
 spec :: Spec
 spec = do
@@ -64,6 +64,21 @@ spec = do
                     map enLoopTarget missing `shouldBe` [Nothing]
                     length (teEdges export) `shouldBe` 1
 
+        it "states the amount reaching it in the unit the edge is labelled with" $ do
+            db <- danglingLinkGramsFixture
+            case consumerRow db of
+                Nothing -> expectationFailure "no consumer row"
+                Just root ->
+                    -- 2000 g of a flow measured in kg, on an edge that says kg.
+                    let tree = buildLoopAwareTree gramsAware db 10 root
+                     in case teEdges (Service.convertToTreeExport db (pidText consumerProdId) 10 tree) of
+                            [edge] -> (teQuantity edge, teUnit edge) `shouldBe` (2.0, "kg")
+                            other -> expectationFailure ("expected one edge, got " <> show (length other))
+
+        it "counts a link no row satisfies among the children it can expand" $ do
+            db <- danglingLinkFixture
+            map enChildrenCount (rootNodes db) `shouldBe` [1]
+
     describe "the activities that use a flow" $
         it "lists every coproduct row that carries it" $ do
             db <- twoCoproductFixture
@@ -104,6 +119,16 @@ treeOfConsumer db = case consumerRow db of
     Nothing -> Left "no consumer row"
     Just root -> Right (buildLoopAwareTree defaultUnitConfig db 10 root)
 
+-- | The exported nodes sitting at depth 0.
+rootNodes :: Database -> [ExportNode]
+rootNodes db = case treeOfConsumer db of
+    Left _ -> []
+    Right tree ->
+        [ n
+        | n <- M.elems (teNodes (Service.convertToTreeExport db (pidText consumerProdId) 10 tree))
+        , enDepth n == 0
+        ]
+
 -- | Constructor names only, so a shape mismatch reports something readable.
 shapeOf :: LoopAwareTree -> [Text]
 shapeOf (TreeLeaf _ _) = ["leaf"]
@@ -132,6 +157,14 @@ carries.
 -}
 danglingLinkFixture :: IO Database
 danglingLinkFixture = buildFixture (consumerActivity [ghostInput] []) supplierRows supplierFlows
+
+{- | The same, the input stated in grams while the flow is measured in
+kilogrammes. Nothing resolves, so nothing carries a reference unit but the
+flow, and the edge is labelled with it.
+-}
+danglingLinkGramsFixture :: IO Database
+danglingLinkGramsFixture =
+    buildFixture (consumerActivity [ghostInput{techAmount = 2000.0, techUnitId = gUnitId}] []) supplierRows supplierFlows
 
 {- | A consumer whose waste output names a treatment the database does not hold
 at that pair. The treatment activity is present, but under another flow, so an
@@ -268,7 +301,22 @@ wasteFlow fid name =
         }
 
 unitTable :: M.Map UUID Unit
-unitTable = M.singleton kgUnitId Unit{unitId = kgUnitId, unitName = "kg", unitSymbol = "kg", unitComment = ""}
+unitTable =
+    M.fromList
+        [ (kgUnitId, Unit{unitId = kgUnitId, unitName = "kg", unitSymbol = "kg", unitComment = ""})
+        , (gUnitId, Unit{unitId = gUnitId, unitName = "g", unitSymbol = "g", unitComment = ""})
+        ]
+
+{- | The default unit table knows no gramme, and a conversion it cannot make
+leaves the amount alone, which would hide the very thing the edge test is
+about.
+-}
+gramsAware :: UnitConfig
+gramsAware =
+    defaultUnitConfig
+        { ucUnits = M.insert "g" (UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 0.001) (ucUnits defaultUnitConfig)
+        , ucOriginalKeys = M.insert "g" "g" (ucOriginalKeys defaultUnitConfig)
+        }
 
 mkUUID :: Int -> UUID
 mkUUID n = UUID.fromWords64 (fromIntegral n) 0
@@ -276,9 +324,10 @@ mkUUID n = UUID.fromWords64 (fromIntegral n) 0
 {- | The supplier's two products are ordered on purpose: 'milkId' is the one a
 map keyed on the activity UUID alone drops.
 -}
-supplierActId, milkId, creamId, consumerActId, consumerProdId, ghostActId, scrapId, kgUnitId :: UUID
+supplierActId, milkId, creamId, consumerActId, consumerProdId, ghostActId, scrapId, kgUnitId, gUnitId :: UUID
 supplierActId = mkUUID 1
 ghostActId = mkUUID 77
+gUnitId = mkUUID 11
 milkId = mkUUID 2
 creamId = mkUUID 9
 consumerActId = mkUUID 3

--- a/test/CoproductTargetSpec.hs
+++ b/test/CoproductTargetSpec.hs
@@ -3,7 +3,8 @@
 {- | An allocated dataset is one activity written as one row per coproduct, all
 sharing an activity UUID. Anything keyed on that UUID alone therefore answers
 with an arbitrary one of them. These tests pin the places a consumer reads a
-coproduct back: the target of an exchange, and the tree it descends.
+coproduct back: the target of an exchange, the tree it descends, and the rows
+that use a flow.
 
 The fixture is built so the wrong answer is visible: the input names the
 coproduct with the /lower/ product UUID, which is exactly the row a
@@ -62,6 +63,12 @@ spec = do
                         missing = [n | n <- M.elems (teNodes export), enNodeType n == MissingNode]
                     map enLoopTarget missing `shouldBe` [Nothing]
                     length (teEdges export) `shouldBe` 1
+
+    describe "the activities that use a flow" $
+        it "lists every coproduct row that carries it" $ do
+            db <- twoCoproductFixture
+            map prsProcessId (Service.getActivitiesUsingFlow db milkId)
+                `shouldBe` [pidText milkId, pidText creamId, consumerPid]
 
 -- ---------------------------------------------------------------------------
 -- Reading one exchange back
@@ -282,3 +289,6 @@ kgUnitId = mkUUID 10
 -- | Process id text of a supplier coproduct row.
 pidText :: UUID -> Text
 pidText prodId = UUID.toText supplierActId <> "_" <> UUID.toText prodId
+
+consumerPid :: Text
+consumerPid = UUID.toText consumerActId <> "_" <> UUID.toText consumerProdId

--- a/test/CoproductTargetSpec.hs
+++ b/test/CoproductTargetSpec.hs
@@ -1,0 +1,235 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | An allocated dataset is one activity written as one row per coproduct, all
+sharing an activity UUID. Anything keyed on that UUID alone therefore answers
+with an arbitrary one of them. These tests pin the places a consumer reads a
+coproduct back.
+
+The fixture is built so the wrong answer is visible: the input names the
+coproduct with the /lower/ product UUID, which is exactly the row a
+UUID-keyed map drops.
+-}
+module CoproductTargetSpec (spec) where
+
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.UUID as UUID
+import Test.Hspec
+
+import API.Types (ActivityForAPI (..), ActivitySummary (..), ExchangeDetail (..), ExchangeWithUnit (..))
+import Database (buildDatabaseWithMatrices)
+import qualified Service
+import Types
+import UnitConversion (defaultUnitConfig)
+
+spec :: Spec
+spec = do
+    describe "the target of an exchange" $ do
+        it "names the coproduct the input asks for, not another product of the same activity" $ do
+            db <- twoCoproductFixture
+            targetPidOfInput db `shouldBe` Just (pidText milkId)
+
+        it "names it on the exchange-details path too" $ do
+            db <- twoCoproductFixture
+            targetSummaryOfInput db `shouldBe` Just (pidText milkId)
+
+        it "reports a waste output whose treatment is not loaded as such" $ do
+            db <- untreatedWasteFixture
+            wasteLineOf db `shouldBe` (Nothing, Just TreatmentNotLoaded)
+
+-- ---------------------------------------------------------------------------
+-- Reading one exchange back
+-- ---------------------------------------------------------------------------
+
+-- | The target process id of the consumer's single technosphere input.
+targetPidOfInput :: Database -> Maybe Text
+targetPidOfInput db = do
+    (pid, act) <- consumerRow db
+    case [ewu | ewu <- pfaExchanges (Service.convertActivityForAPI defaultUnitConfig db pid act), exchangeIsInput (ewuExchange ewu)] of
+        [ewu] -> ewuTargetProcessId ewu
+        _ -> Nothing
+
+-- | The same, read through 'Service.getActivityInputDetails'.
+targetSummaryOfInput :: Database -> Maybe Text
+targetSummaryOfInput db = do
+    (_, act) <- consumerRow db
+    case Service.getActivityInputDetails db act of
+        [ed] -> prsProcessId <$> edTargetActivity ed
+        _ -> Nothing
+
+-- | Target and waste role of the consumer's single waste output.
+wasteLineOf :: Database -> (Maybe Text, Maybe WasteRole)
+wasteLineOf db = case consumerRow db of
+    Nothing -> (Just "no consumer row", Nothing)
+    Just (pid, act) ->
+        case [ewu | ewu <- pfaExchanges (Service.convertActivityForAPI defaultUnitConfig db pid act), WasteExchange{waIsInput = False} <- [ewuExchange ewu]] of
+            [ewu] -> (ewuTargetProcessId ewu, ewuWasteRole ewu)
+            _ -> (Just "no waste output", Nothing)
+
+consumerRow :: Database -> Maybe (ProcessId, Activity)
+consumerRow db = do
+    pid <- findProcessId db consumerActId consumerProdId
+    act <- getActivity db pid
+    pure (pid, act)
+
+-- ---------------------------------------------------------------------------
+-- Fixtures
+-- ---------------------------------------------------------------------------
+
+{- | A supplier written as two coproduct rows, and a consumer whose input names
+the one with the lower product UUID.
+-}
+twoCoproductFixture :: IO Database
+twoCoproductFixture = buildFixture (consumerActivity [milkInput] []) supplierRows supplierFlows
+
+{- | A consumer whose waste output names a treatment the database does not hold
+at that pair. The treatment activity is present, but under another flow, so an
+answer built from the activity UUID alone would name it anyway.
+-}
+untreatedWasteFixture :: IO Database
+untreatedWasteFixture =
+    buildFixture
+        (consumerActivity [] [wasteOutput])
+        supplierRows
+        supplierFlows
+
+buildFixture :: Activity -> M.Map (UUID, UUID) Activity -> M.Map UUID TechnosphereFlow -> IO Database
+buildFixture consumer rows flows = do
+    r <-
+        buildDatabaseWithMatrices
+            defaultUnitConfig
+            (M.insert (consumerActId, consumerProdId) consumer rows)
+            (M.insert consumerProdId (techFlow consumerProdId "cheese") flows)
+            M.empty
+            (M.singleton scrapId (wasteFlow scrapId "scrap"))
+            unitTable
+    either (fail . show) pure r
+
+supplierRows :: M.Map (UUID, UUID) Activity
+supplierRows =
+    M.fromList
+        [ ((supplierActId, milkId), supplierActivity)
+        , ((supplierActId, creamId), supplierActivity)
+        ]
+
+supplierFlows :: M.Map UUID TechnosphereFlow
+supplierFlows =
+    M.fromList
+        [ (milkId, techFlow milkId "milk")
+        , (creamId, techFlow creamId "cream")
+        ]
+
+-- | The supplier: one activity, two produced coproducts.
+supplierActivity :: Activity
+supplierActivity =
+    bareActivity
+        "milk production"
+        [ techExchange milkId 1.0 ReferenceProduct supplierActId
+        , techExchange creamId 0.3 Coproduct supplierActId
+        ]
+
+consumerActivity :: [Exchange] -> [Exchange] -> Activity
+consumerActivity inputs outputs =
+    bareActivity
+        "cheese production"
+        ([techExchange consumerProdId 1.0 ReferenceProduct consumerActId] ++ inputs ++ outputs)
+
+-- | An input naming the supplier's lower-UUID coproduct.
+milkInput :: Exchange
+milkInput = techExchange milkId 2.0 Input supplierActId
+
+{- | A waste output naming the supplier: the activity exists, no row of it
+produces the waste flow, so nothing routes it.
+-}
+wasteOutput :: Exchange
+wasteOutput =
+    WasteExchange
+        { waFlowId = scrapId
+        , waAmount = 0.5
+        , waUnitId = kgUnitId
+        , waIsInput = False
+        , waActivityLinkId = supplierActId
+        , waProcessLinkId = Nothing
+        , waLocation = ""
+        , waComment = Nothing
+        , waPedigree = Nothing
+        }
+
+techExchange :: UUID -> Double -> TechRole -> UUID -> Exchange
+techExchange flowId amount role link =
+    TechnosphereExchange
+        { techFlowId = flowId
+        , techAmount = amount
+        , techUnitId = kgUnitId
+        , techRole = role
+        , techActivityLinkId = link
+        , techProcessLinkId = Nothing
+        , techLocation = ""
+        , techComment = Nothing
+        , techPedigree = Nothing
+        }
+
+bareActivity :: Text -> [Exchange] -> Activity
+bareActivity name exs =
+    Activity
+        { activityName = name
+        , activityDescription = []
+        , activityDocumentation = []
+        , activitySynonyms = M.empty
+        , activityClassification = M.empty
+        , activityLocation = "FR"
+        , activityLocationSource = LocationDeclared
+        , activityUnit = "kg"
+        , exchanges = exs
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        , activityAllocationPercent = Nothing
+        , activityAllocationFormula = Nothing
+        , activityNativeType = Nothing
+        , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
+        }
+
+techFlow :: UUID -> Text -> TechnosphereFlow
+techFlow fid name =
+    TechnosphereFlow
+        { tfId = fid
+        , tfName = name
+        , tfUnitId = kgUnitId
+        , tfSynonyms = M.empty
+        , tfCAS = Nothing
+        , tfSubstanceId = Nothing
+        }
+
+wasteFlow :: UUID -> Text -> WasteFlow
+wasteFlow fid name =
+    WasteFlow
+        { wfId = fid
+        , wfName = name
+        , wfUnitId = kgUnitId
+        , wfSynonyms = M.empty
+        , wfCAS = Nothing
+        , wfSubstanceId = Nothing
+        }
+
+unitTable :: M.Map UUID Unit
+unitTable = M.singleton kgUnitId Unit{unitId = kgUnitId, unitName = "kg", unitSymbol = "kg", unitComment = ""}
+
+mkUUID :: Int -> UUID
+mkUUID n = UUID.fromWords64 (fromIntegral n) 0
+
+{- | The supplier's two products are ordered on purpose: 'milkId' is the one a
+map keyed on the activity UUID alone drops.
+-}
+supplierActId, milkId, creamId, consumerActId, consumerProdId, scrapId, kgUnitId :: UUID
+supplierActId = mkUUID 1
+milkId = mkUUID 2
+creamId = mkUUID 9
+consumerActId = mkUUID 3
+consumerProdId = mkUUID 4
+scrapId = mkUUID 5
+kgUnitId = mkUUID 10
+
+-- | Process id text of a supplier coproduct row.
+pidText :: UUID -> Text
+pidText prodId = UUID.toText supplierActId <> "_" <> UUID.toText prodId

--- a/test/EcoSpold1WriterSpec.hs
+++ b/test/EcoSpold1WriterSpec.hs
@@ -239,6 +239,39 @@ linkedDb link =
     -- The consumer's input consumes the supplier's product and links to it.
     consumer = mkAct "bbb consumer" conU [TechnosphereExchange supU 2.0 kgUnit Input link Nothing "" Nothing Nothing]
 
+{- | A supplier written as two coproduct rows sharing one activity UUID, and a
+consumer whose input names the first of them. Canonical order gives the two
+supplier rows datasets 1 and 2, so a link resolved on the pair re-emits 1 while
+a link resolved on the activity UUID alone re-emits whichever row the index kept.
+-}
+coproductDb :: SimpleDatabase
+coproductDb =
+    SimpleDatabase
+        { sdbActivities =
+            M.fromList
+                [ ((supU, prodAU), mkAct "aaa supplier" prodAU [])
+                , ((supU, prodBU), mkAct "aaa supplier" prodBU [])
+                , ((conU, conU), mkAct "bbb consumer" conU [inputOnA])
+                ]
+        , sdbTechFlows =
+            M.fromList
+                [ (prodAU, TechnosphereFlow prodAU "aaa product a" kgUnit M.empty Nothing Nothing)
+                , (prodBU, TechnosphereFlow prodBU "aaa product b" kgUnit M.empty Nothing Nothing)
+                , (conU, TechnosphereFlow conU "bbb consumer" kgUnit M.empty Nothing Nothing)
+                ]
+        , sdbBioFlows = M.empty
+        , sdbWasteFlows = M.empty
+        , sdbUnits = units1
+        }
+  where
+    supU = supplierLink
+    prodAU = read "44444444-0000-4000-8000-00000000000a"
+    prodBU = read "44444444-0000-4000-8000-00000000000b"
+    conU = read "33333333-0000-4000-8000-000000000001"
+    mkAct nm prodU exs = Activity nm [] [] M.empty M.empty "GLO" LocationDeclared "kg" (refOf prodU : exs) M.empty M.empty Nothing Nothing Nothing Nothing Nothing
+    refOf prodU = TechnosphereExchange prodU 1.0 kgUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing
+    inputOnA = TechnosphereExchange prodAU 2.0 kgUnit Input supU Nothing "" Nothing Nothing
+
 {- | The supplier's stored activity UUID — the first component of its
 'sdbActivities' key, and the value a solver-resolved input carries in
 'techActivityLinkId'. Deliberately a literal in a different namespace from
@@ -499,6 +532,16 @@ spec = do
             -- The link targets a UUID not among the exported datasets, so its
             -- dataset number is unknown; fail loudly instead of mislabelling it.
             checkEcoSpold1Exportable (linkedDb danglingLink) `shouldSatisfy` isLeft
+
+        it "names the coproduct the link asks for, not the activity's last row" $
+            -- The supplier is allocated into two datasets sharing one activity
+            -- UUID; the consumer's input names the first. Keyed on the activity
+            -- UUID alone the index kept only the second, and the parser read the
+            -- link back as a link to the other coproduct.
+            roundTripSupplierLinks coproductDb `shouldBe` Right [1]
+
+        it "passes the export-boundary check for a link naming one coproduct" $
+            checkEcoSpold1Exportable coproductDb `shouldBe` Right ()
 
         it "preserves a linked input semantically across a write→parse round-trip" $
             -- SimpleDatabase carries no supplier link, so a bare re-parse can't

--- a/test/IndexInjectivitySpec.hs
+++ b/test/IndexInjectivitySpec.hs
@@ -25,7 +25,12 @@ producingRows db =
     ]
 
 spec :: Spec
-spec = describe "product index" $ do
+spec = do
+    productIndexSpec
+    activityIndexSpec
+
+productIndexSpec :: Spec
+productIndexSpec = describe "product index" $ do
     -- SAMPLE.ilcd holds two activities producing one and the same product flow,
     -- the ordinary shape of a product made in more than one geography.
     it "lists every row producing a product flow" $ do
@@ -44,3 +49,24 @@ spec = describe "product index" $ do
         db <- loadSampleDatabase "SAMPLE.min"
         let named = [findProcessIdByProductFlow db f | (_, f) <- producingRows db]
         named `shouldBe` [Just pid | (pid, _) <- producingRows db]
+
+activityIndexSpec :: Spec
+activityIndexSpec = describe "activity index" $ do
+    -- SAMPLE.switching writes two activities as two coproducts each, the
+    -- ordinary shape of an allocated dataset.
+    it "lists every row an activity was written as" $ do
+        db <- loadSampleDatabase "SAMPLE.switching"
+        let listed = sum (map NE.length (M.elems (dbActivityUUIDIndex db)))
+        listed `shouldBe` V.length (dbProcessIdTable db)
+
+    it "names no row when the activity was written as several" $ do
+        db <- loadSampleDatabase "SAMPLE.switching"
+        let allocated = M.keys (M.filter ((> 1) . NE.length) (dbActivityUUIDIndex db))
+        case allocated of
+            [] -> expectationFailure "fixture no longer has an activity written as several rows"
+            (actUUID : _) -> findProcessIdByActivityUUID db actUUID `shouldBe` Nothing
+
+    it "names the row when the activity was written as one" $ do
+        db <- loadSampleDatabase "SAMPLE.min"
+        let named = [findProcessIdByActivityUUID db a | (a, _) <- V.toList (dbProcessIdTable db)]
+        named `shouldBe` [Just pid | pid <- [0 .. fromIntegral (V.length (dbProcessIdTable db)) - 1]]

--- a/test/IndexInjectivitySpec.hs
+++ b/test/IndexInjectivitySpec.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | An index built with 'M.fromList' asserts that its key determines its value.
+Where that assertion is false the extra rows vanish with no error and every
+reader answers with an arbitrary one of them. These examples hold the product
+index to the rows the database actually contains.
+-}
+module IndexInjectivitySpec (spec) where
+
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map as M
+import qualified Data.Vector as V
+import Test.Hspec
+import TestHelpers (loadSampleDatabase)
+import Types
+
+{- | The rows whose reference product is a technosphere flow, which is exactly
+what 'Database.buildProductIndex' indexes.
+-}
+producingRows :: Database -> [(ProcessId, UUID)]
+producingRows db =
+    [ (pid, prodUUID)
+    | (pid, (_, prodUUID)) <- zip [0 ..] (V.toList (dbProcessIdTable db))
+    , M.member prodUUID (dbTechFlows db)
+    ]
+
+spec :: Spec
+spec = describe "product index" $ do
+    -- SAMPLE.ilcd holds two activities producing one and the same product flow,
+    -- the ordinary shape of a product made in more than one geography.
+    it "lists every row producing a product flow" $ do
+        db <- loadSampleDatabase "SAMPLE.ilcd"
+        let listed = sum (map NE.length (M.elems (piByUUID (dbProductIndex db))))
+        listed `shouldBe` length (producingRows db)
+
+    it "names no supplier when several rows produce the flow" $ do
+        db <- loadSampleDatabase "SAMPLE.ilcd"
+        let shared = M.keys (M.filter ((> 1) . NE.length) (piByUUID (dbProductIndex db)))
+        case shared of
+            [] -> expectationFailure "fixture no longer has a product flow with several producers"
+            (flowUUID : _) -> findProcessIdByProductFlow db flowUUID `shouldBe` Nothing
+
+    it "names the supplier when one row produces the flow" $ do
+        db <- loadSampleDatabase "SAMPLE.min"
+        let named = [findProcessIdByProductFlow db f | (_, f) <- producingRows db]
+        named `shouldBe` [Just pid | (pid, _) <- producingRows db]

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -426,6 +426,34 @@ spec = do
             usFoundLinks summary `shouldBe` 1
 
     -- -----------------------------------------------------------------------
+    -- fixEcoSpold1ActivityLinks (name-only fallback, EcoSpold1 style)
+    -- -----------------------------------------------------------------------
+    describe "fixEcoSpold1ActivityLinks" $ do
+        let consumerUUID = read "cccccccc-0000-0000-0000-000000000003" :: UUID.UUID
+            breadUUID = read "bbbbbbbb-0000-0000-0000-000000000003" :: UUID.UUID
+            wheatFR = ((actUUID1, flowUUID1), minimalActivity "wheat production" "FR" [refExchange flowUUID1])
+            wheatDE = ((actUUID2, flowUUID2), minimalActivity "wheat production" "DE" [refExchange flowUUID2])
+            bread =
+                ( (consumerUUID, breadUUID)
+                , minimalActivity "bread production" "CH" [refExchange breadUUID, inputExchange flowUUID1 ""]
+                )
+            flowNames = [(flowUUID1, "Wheat"), (flowUUID2, "Wheat"), (breadUUID, "Bread")]
+            -- The supplier the consumer's unlocated wheat input ends up naming.
+            wheatLink sdb =
+                [ link
+                | Just act <- [M.lookup (consumerUUID, breadUUID) (sdbActivities sdb)]
+                , TechnosphereExchange{techRole = Input, techActivityLinkId = link} <- exchanges act
+                ]
+
+        it "leaves an unlocated input unlinked when the product name covers several geographies" $ do
+            fixed <- fixEcoSpold1ActivityLinks M.empty M.empty M.empty (simpleDBOf [wheatFR, wheatDE, bread] flowNames)
+            wheatLink fixed `shouldBe` [UUID.nil]
+
+        it "links an unlocated input when the product name covers one dataset" $ do
+            fixed <- fixEcoSpold1ActivityLinks M.empty M.empty M.empty (simpleDBOf [wheatFR, bread] flowNames)
+            wheatLink fixed `shouldBe` [actUUID1]
+
+    -- -----------------------------------------------------------------------
     -- countTotalTechInputs / countUnlinkedExchanges / collectUnlinkedProductNames
     -- (integration tests via SAMPLE.min3)
     -- -----------------------------------------------------------------------

--- a/test/MatrixExportSpec.hs
+++ b/test/MatrixExportSpec.hs
@@ -2,9 +2,9 @@
 
 module MatrixExportSpec (spec) where
 
+import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
-import qualified Data.UUID as UUID
 import Matrix.Export (
     MatrixDebugInfo (..),
     escapeCsvField,
@@ -155,29 +155,25 @@ spec = do
     describe "extractMatrixDebugInfo" $ do
         it "returns supply, demand, and inventory vectors of correct length" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
-            let targetUUID = read "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" :: UUID.UUID
-            info <- extractMatrixDebugInfo db targetUUID Nothing
+            info <- extractMatrixDebugInfo db (targetRow db) Nothing
             let n = fromIntegral (dbActivityCount db)
             length (mdSupplyVector info) `shouldBe` n
             length (mdDemandVector info) `shouldBe` n
 
         it "demand vector has exactly one non-zero entry" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
-            let targetUUID = read "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" :: UUID.UUID
-            info <- extractMatrixDebugInfo db targetUUID Nothing
+            info <- extractMatrixDebugInfo db (targetRow db) Nothing
             length (filter (/= 0.0) (mdDemandVector info)) `shouldBe` 1
 
         it "inventory vector is non-empty (has biosphere contributions)" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
-            let targetUUID = read "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" :: UUID.UUID
-            info <- extractMatrixDebugInfo db targetUUID Nothing
+            info <- extractMatrixDebugInfo db (targetRow db) Nothing
             any (/= 0.0) (mdInventoryVector info) `shouldBe` True
 
         it "flow filter restricts biosphere triples" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
-            let targetUUID = read "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" :: UUID.UUID
-            infoAll <- extractMatrixDebugInfo db targetUUID Nothing
-            infoFiltered <- extractMatrixDebugInfo db targetUUID (Just "carbon")
+            infoAll <- extractMatrixDebugInfo db (targetRow db) Nothing
+            infoFiltered <- extractMatrixDebugInfo db (targetRow db) (Just "carbon")
             -- Filtered should have ≤ triples than unfiltered
             let nAll = length (mdInventoryVector infoAll)
                 nFiltered = length (mdInventoryVector infoFiltered)
@@ -186,8 +182,7 @@ spec = do
     describe "exportMatrixDebugCSVs" $ do
         it "creates supply chain and biosphere CSV files" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
-            let targetUUID = read "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" :: UUID.UUID
-            info <- extractMatrixDebugInfo db targetUUID Nothing
+            info <- extractMatrixDebugInfo db (targetRow db) Nothing
             withSystemTempDirectory "acv-debug" $ \tmpDir -> do
                 let base = tmpDir </> "debug"
                 exportMatrixDebugCSVs base info
@@ -198,11 +193,20 @@ spec = do
 
         it "supply chain CSV has one row per activity" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
-            let targetUUID = read "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" :: UUID.UUID
-            info <- extractMatrixDebugInfo db targetUUID Nothing
+            info <- extractMatrixDebugInfo db (targetRow db) Nothing
             withSystemTempDirectory "acv-debug" $ \tmpDir -> do
                 let base = tmpDir </> "debug"
                 exportMatrixDebugCSVs base info
                 content <- TIO.readFile (base ++ "_supply_chain.csv")
                 -- header + 3 activities (SAMPLE.min3)
                 length (lines (T.unpack content)) `shouldBe` 4
+
+{- | The row SAMPLE.min3's activity X sits at. Row 0 when it is missing, which
+only happens if the fixture changes: the assertions below would then fail on a
+different activity rather than on a resolution error, which is the shape hspec
+reports best.
+-}
+targetRow :: Database -> ProcessId
+targetRow db =
+    let targetUUID = read "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" :: UUID
+     in fromMaybe 0 (findProcessIdByActivityUUID db targetUUID)

--- a/test/RoutesSpec.hs
+++ b/test/RoutesSpec.hs
@@ -191,6 +191,8 @@ errorMappingSpec = describe "serviceErrorToServerError (HTTP status contract)" $
         errHTTPCode (serviceErrorToServerError (InvalidUUID "x")) `shouldBe` 400
     it "maps InvalidProcessId to 400" $
         errHTTPCode (serviceErrorToServerError (InvalidProcessId "x")) `shouldBe` 400
+    it "maps AmbiguousActivity to 400, not the 404 of a missing one" $
+        errHTTPCode (serviceErrorToServerError (AmbiguousActivity "x")) `shouldBe` 400
     it "maps ActivityNotFound to 404" $
         errHTTPCode (serviceErrorToServerError (ActivityNotFound "x")) `shouldBe` 404
     it "maps FlowNotFound to 404" $

--- a/test/ServiceSpec.hs
+++ b/test/ServiceSpec.hs
@@ -11,6 +11,7 @@ import API.Types (
     TreeExport (..),
     TreeMetadata (..),
  )
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.Text (Text)
@@ -115,6 +116,15 @@ spec = do
                 Left (ActivityNotFound _) -> return ()
                 Left err -> expectationFailure $ "Expected ActivityNotFound but got: " ++ show err
                 Right _ -> expectationFailure "Expected ActivityNotFound but got a hit"
+
+        it "refuses a bare activity UUID naming an activity written as several processes" $ do
+            db <- loadSampleDatabase "SAMPLE.switching"
+            case M.keys (M.filter ((> 1) . NE.length) (dbActivityUUIDIndex db)) of
+                [] -> expectationFailure "fixture no longer has an activity written as several rows"
+                (actUUID : _) -> case resolveActivityAndProcessId db (toText actUUID) of
+                    Left (AmbiguousActivity _) -> return ()
+                    Left err -> expectationFailure $ "Expected AmbiguousActivity but got: " ++ show err
+                    Right _ -> expectationFailure "Expected AmbiguousActivity but got a hit"
 
         it "returns InvalidProcessId for a genuinely malformed query" $ do
             db <- loadSampleDatabase "SAMPLE.min3"

--- a/test/TreeSpec.hs
+++ b/test/TreeSpec.hs
@@ -118,7 +118,7 @@ rootOf db uuid = do
 rootByName :: Database -> Text -> Maybe (ProcessId, Activity)
 rootByName db name =
     case [ (pid, act)
-         | (_, pid) <- M.toList (dbActivityUUIDIndex db)
+         | pid <- [0 .. dbActivityCount db - 1]
          , Just act <- [getActivity db pid]
          , activityName act == name
          ] of

--- a/test/TreeSpec.hs
+++ b/test/TreeSpec.hs
@@ -20,43 +20,35 @@ spec = do
         -- -----------------------------------------------------------------------
         describe "linear chain (SAMPLE.min3)" $ do
             it "builds TreeNode at root with one child" $ do
-                db <- loadSampleDatabase "SAMPLE.min3"
-                let Just xUUID = UUID.fromString sampleMin3ActivityX
-                    tree = buildLoopAwareTree defaultUnitConfig db xUUID 10
+                tree <- treeFromSample "SAMPLE.min3" sampleMin3ActivityX 10
                 case tree of
-                    TreeNode act children -> do
+                    TreeNode _ act children -> do
                         activityName act `shouldBe` "production of product X"
                         length children `shouldBe` 1
                     _ -> expectationFailure "Expected TreeNode for X"
 
             it "second level is also a TreeNode (Y)" $ do
-                db <- loadSampleDatabase "SAMPLE.min3"
-                let Just xUUID = UUID.fromString sampleMin3ActivityX
-                    tree = buildLoopAwareTree defaultUnitConfig db xUUID 10
+                tree <- treeFromSample "SAMPLE.min3" sampleMin3ActivityX 10
                 case tree of
-                    TreeNode _ [(_, _, subtree)] ->
+                    TreeNode _ _ [(_, _, subtree)] ->
                         case subtree of
-                            TreeNode act _ -> activityName act `shouldBe` "production of product Y"
+                            TreeNode _ act _ -> activityName act `shouldBe` "production of product Y"
                             _ -> expectationFailure "Expected TreeNode for Y"
                     _ -> expectationFailure "Unexpected tree shape for X"
 
             it "leaf node Z is a TreeLeaf with no children" $ do
-                db <- loadSampleDatabase "SAMPLE.min3"
-                let Just xUUID = UUID.fromString sampleMin3ActivityX
-                    tree = buildLoopAwareTree defaultUnitConfig db xUUID 10
+                tree <- treeFromSample "SAMPLE.min3" sampleMin3ActivityX 10
                 case tree of
-                    TreeNode _ [(_, _, TreeNode _ [(_, _, leaf)])] ->
+                    TreeNode _ _ [(_, _, TreeNode _ _ [(_, _, leaf)])] ->
                         case leaf of
-                            TreeLeaf act -> activityName act `shouldBe` "production of product Z"
+                            TreeLeaf _ act -> activityName act `shouldBe` "production of product Z"
                             _ -> expectationFailure "Expected TreeLeaf for Z"
                     _ -> expectationFailure "Unexpected tree shape"
 
             it "edge amount from X to Y is 0.6" $ do
-                db <- loadSampleDatabase "SAMPLE.min3"
-                let Just xUUID = UUID.fromString sampleMin3ActivityX
-                    tree = buildLoopAwareTree defaultUnitConfig db xUUID 10
+                tree <- treeFromSample "SAMPLE.min3" sampleMin3ActivityX 10
                 case tree of
-                    TreeNode _ [(amount, _, _)] -> amount `shouldBe` 0.6
+                    TreeNode _ _ [(amount, _, _)] -> amount `shouldBe` 0.6
                     _ -> expectationFailure "Expected TreeNode for X"
 
         -- -----------------------------------------------------------------------
@@ -64,30 +56,24 @@ spec = do
         -- -----------------------------------------------------------------------
         describe "maxDepth" $ do
             it "depth=1 — Y becomes a TreeLoop (depth limit)" $ do
-                db <- loadSampleDatabase "SAMPLE.min3"
-                let Just xUUID = UUID.fromString sampleMin3ActivityX
-                    tree = buildLoopAwareTree defaultUnitConfig db xUUID 1
+                tree <- treeFromSample "SAMPLE.min3" sampleMin3ActivityX 1
                 case tree of
-                    TreeNode _ [(_, _, child)] ->
+                    TreeNode _ _ [(_, _, child)] ->
                         case child of
                             TreeLoop{} -> return ()
                             _ -> expectationFailure "Expected TreeLoop for Y at depth 1"
                     _ -> expectationFailure "Expected TreeNode for X"
 
             it "depth=0 — root X itself is a TreeLoop" $ do
-                db <- loadSampleDatabase "SAMPLE.min3"
-                let Just xUUID = UUID.fromString sampleMin3ActivityX
-                    tree = buildLoopAwareTree defaultUnitConfig db xUUID 0
+                tree <- treeFromSample "SAMPLE.min3" sampleMin3ActivityX 0
                 case tree of
                     TreeLoop{} -> return ()
                     _ -> expectationFailure "Expected TreeLoop for X at maxDepth=0"
 
             it "depth=2 — Z becomes a TreeLoop at depth 2" $ do
-                db <- loadSampleDatabase "SAMPLE.min3"
-                let Just xUUID = UUID.fromString sampleMin3ActivityX
-                    tree = buildLoopAwareTree defaultUnitConfig db xUUID 2
+                tree <- treeFromSample "SAMPLE.min3" sampleMin3ActivityX 2
                 case tree of
-                    TreeNode _ [(_, _, TreeNode _ [(_, _, leaf)])] ->
+                    TreeNode _ _ [(_, _, TreeNode _ _ [(_, _, leaf)])] ->
                         case leaf of
                             TreeLoop{} -> return ()
                             _ -> expectationFailure "Expected TreeLoop for Z at depth 2"
@@ -99,53 +85,54 @@ spec = do
         describe "loop detection (SAMPLE.edge)" $ do
             it "circular chain terminates and contains at least one TreeLoop" $ do
                 db <- loadSampleDatabase "SAMPLE.edge"
-                case findActivityUUIDByName db "circular loop A (dependency test)" of
+                case rootByName db "circular loop A (dependency test)" of
                     Nothing -> pendingWith "Activity A not found in SAMPLE.edge"
-                    Just uuid -> do
-                        let tree = buildLoopAwareTree defaultUnitConfig db uuid 10
-                        treeContainsLoop tree `shouldBe` True
+                    Just root -> treeContainsLoop (buildLoopAwareTree defaultUnitConfig db 10 root) `shouldBe` True
 
             it "circular chain does not expand indefinitely (node count bounded)" $ do
                 db <- loadSampleDatabase "SAMPLE.edge"
-                case findActivityUUIDByName db "circular loop A (dependency test)" of
+                case rootByName db "circular loop A (dependency test)" of
                     Nothing -> pendingWith "Activity A not found in SAMPLE.edge"
-                    Just uuid -> do
-                        let tree = buildLoopAwareTree defaultUnitConfig db uuid 100
-                        countNodes tree `shouldSatisfy` (<= 300)
-
-        -- -----------------------------------------------------------------------
-        -- Missing activity UUID
-        -- -----------------------------------------------------------------------
-        describe "missing activity" $ do
-            it "returns TreeLoop with 'Missing Activity' when UUID not in DB" $ do
-                db <- loadSampleDatabase "SAMPLE.min3"
-                let Just missingUUID = UUID.fromString "99999999-9999-9999-9999-999999999999"
-                    tree = buildLoopAwareTree defaultUnitConfig db missingUUID 10
-                case tree of
-                    TreeLoop _ name _ -> name `shouldBe` "Missing Activity"
-                    _ -> expectationFailure "Expected TreeLoop for missing UUID"
+                    Just root -> countNodes (buildLoopAwareTree defaultUnitConfig db 100 root) `shouldSatisfy` (<= 300)
 
 -- ---------------------------------------------------------------------------
 -- Helpers
 -- ---------------------------------------------------------------------------
 
--- | Find the activity UUID for an activity with the given name.
-findActivityUUIDByName :: Database -> Text -> Maybe UUID
-findActivityUUIDByName db name =
-    case [ uuid
-         | (uuid, pid) <- M.toList (dbActivityUUIDIndex db)
+-- | The tree of one sample activity, named by its activity UUID.
+treeFromSample :: String -> String -> Int -> IO LoopAwareTree
+treeFromSample sample activityUUID maxDepth = do
+    db <- loadSampleDatabase sample
+    case UUID.fromString activityUUID >>= rootOf db of
+        Nothing -> fail ("no row for " <> activityUUID <> " in " <> sample)
+        Just root -> pure (buildLoopAwareTree defaultUnitConfig db maxDepth root)
+
+-- | The row an activity UUID names, with the activity it holds.
+rootOf :: Database -> UUID -> Maybe (ProcessId, Activity)
+rootOf db uuid = do
+    pid <- findProcessIdByActivityUUID db uuid
+    act <- getActivity db pid
+    pure (pid, act)
+
+-- | The first row whose activity carries the given name.
+rootByName :: Database -> Text -> Maybe (ProcessId, Activity)
+rootByName db name =
+    case [ (pid, act)
+         | (_, pid) <- M.toList (dbActivityUUIDIndex db)
          , Just act <- [getActivity db pid]
          , activityName act == name
          ] of
-        (uuid : _) -> Just uuid
+        (root : _) -> Just root
         [] -> Nothing
 
 treeContainsLoop :: LoopAwareTree -> Bool
-treeContainsLoop (TreeLeaf _) = False
+treeContainsLoop (TreeLeaf _ _) = False
+treeContainsLoop (TreeMissing{}) = False
 treeContainsLoop (TreeLoop{}) = True
-treeContainsLoop (TreeNode _ children) = any (\(_, _, t) -> treeContainsLoop t) children
+treeContainsLoop (TreeNode _ _ children) = any (\(_, _, t) -> treeContainsLoop t) children
 
 countNodes :: LoopAwareTree -> Int
-countNodes (TreeLeaf _) = 1
+countNodes (TreeLeaf _ _) = 1
+countNodes (TreeMissing{}) = 1
 countNodes (TreeLoop{}) = 1
-countNodes (TreeNode _ children) = 1 + sum (map (\(_, _, t) -> countNodes t) children)
+countNodes (TreeNode _ _ children) = 1 + sum (map (\(_, _, t) -> countNodes t) children)

--- a/test/TreeSpec.hs
+++ b/test/TreeSpec.hs
@@ -2,7 +2,6 @@
 
 module TreeSpec (spec) where
 
-import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.UUID as UUID
 import GoldenData

--- a/volca.cabal
+++ b/volca.cabal
@@ -230,6 +230,7 @@ test-suite lca-tests
                      , MatrixConstructionSpec
                      , WasteTreatmentSignSpec
                      , InventorySpec
+                     , IndexInjectivitySpec
                      , MatrixExportSpec
                      , MethodSpec
                      , MethodPatchSpec

--- a/volca.cabal
+++ b/volca.cabal
@@ -251,6 +251,7 @@ test-suite lca-tests
                      , SupplyChainSpec
                      , HotspotSpec
                      , TreeSpec
+                     , CoproductTargetSpec
                      , ServiceSpec
                      , CrossLinkingSpec
                      , CrossDBActivityLinkSpec


### PR DESCRIPTION
## What was wrong

A dataset whose production is allocated is written as one activity per
coproduct, all sharing one activity identifier and each carrying its own
process id. The engine kept an index from that identifier to a single one of
those rows, so anything that resolved a link through it answered with an
arbitrary coproduct.

The report that started this: asking for a cheese consumption mix, the input
that supplies the cheese came back naming the whey permeate produced alongside
it. The interface showed nothing wrong, because both rows carry the same
activity name and the product column is read from the exchange's own flow.

Four places read that index: the target of an exchange, the tree export, the
list of activities that use a flow, and the matrix debug export.

## What this changes

Scores were never affected: the matrix resolves the pair (activity, product),
and that is the resolution everything now uses, with the activity identifier
kept as a fallback for links whose pair is no row at all.

What was affected is everything a client does with the identifier it gets
back: asking for that activity, anchoring an edit on that exchange,
substituting that supplier.

Three changes are visible on the wire, all on the tree export:

- an activity written as several coproducts is now several nodes instead of one;
- an input whose declared supplier is in no loaded database is a node of its
  own type, `MissingNode`, instead of a branch that quietly vanished. That
  case is real (a partial EcoSpold2 import), and it used to arrive as a loop
  node named "Missing Activity"; resolving children by row alone would have
  dropped it;
- a loop node's `loopTarget` is now the process id the schema always said it
  was, rather than a bare activity identifier.

The waste-output arm deliberately keeps resolving on the pair alone, with no
fallback: a link it cannot route names a treatment this database does not
hold, and answering it with some row of that activity would turn a reportable
gap into a treatment nothing ever charged. A test now pins that.

Every database cache is rebuilt on first load: the flow index changed payload
type, and the cache signature is derived from the identity of `Database` and
never from the types inside it, so the salt had to move with it.

## Every sibling of the same defect

The same shape turned up four more times while sweeping every `fromList` in
`src/`, and all four are fixed here.

The index from a product flow to its producer mapped to a single row. The same
product is usually made by several activities, one per geography, so it kept
whichever came last, and an input that names only the product it consumes was
attached to a producer the data never named. It now holds every producer and
answers only when there is exactly one, which is the rule the name-and-unit
fallback beside it already applied. Scores never read it.

The EcoSpold 1 writer numbers each exported dataset and re-emits that number on
every link pointing at it. An allocated activity is one dataset per coproduct,
but the index from a link to a number was keyed on the activity alone, so every
link to that supplier carried the number of the last coproduct and reading the
file back moved the link to the wrong product. The key is now the (activity,
product) pair the link already carries, and the export-boundary check reads the
pair too, so an unexportable link is refused rather than mislabelled.

The index from an activity identifier to a row is the one the fallback above
leans on, and it had the same shape: one row per activity. It also serves the
bare activity identifier the API, the CLI and the edit journal accept, and
three of its call sites documented the honest contract in prose ("when the
activity has a unique reference product") while the code guessed. It now holds
every row and answers only when there is one.

The EcoSpold 1 loader looks a supplier up by product name when the input
carries no location. An EcoSpold 1 product name has no location in it, so one
name covers every geography the product is made in: BAFU 2026 v1 has 787 such
names over 4 526 of its 11 947 datasets, and the location tells them apart
every time. The index kept one dataset per name and the loader counted the
result as a resolved link. It now keeps them all and leaves the input
unresolved, in the unlinked report where the cross-database linker can still
reach it, when the name does not say which dataset is meant. Measured on both
EcoSpold 1 databases at hand this moves no link: BAFU resolves all 114 369 of
its links by dataset number first, and the other has no shared name.

`compare_impacts` aligns two databases on a flow's name, medium and
subcompartment, since their identifiers are unrelated by construction. Two
flows in one database can share those three, and the map kept the last, so a
contribution vanished from the comparison or showed as present on one side
only. Both sides now read from summed totals.

Two more sites were measured and left alone. The SimaPro name index has no
collision at all in Agribalyse 3.1.1 (18 268 products, 18 268 distinct names),
because a SimaPro product name carries its geography. A Brightway workbook with
two columns under one heading does lose one, so the load now warns; which
column is right is the workbook author's business, not the loader's.

One site is reported and not fixed: `dcLookup` in `API.Routes` maps an impact
category to its damage category, and an endpoint method can list one impact
under two damage categories. Under that key the wrong normalisation factor is
picked in silence. No shipped collection has damage categories, so there is
nothing to measure against, and the fix is not an index change: an LCIA result
holds one damage category, so the data model cannot express the case at all.

`AGENTS.md` gains the rule all of these broke. It was not missing from the
codebase, it was in a docstring saying the lookup "returns an arbitrary match",
which no compiler reads.

## Checks

`cabal build all` and `cabal test` green (2360 examples), `fourmolu` and
`hlint` clean. The pyvolca suite is green too (299 passed, 7 skipped) and
`gen_api_md.py --check` passes.

Every new example was run against the behaviour it replaces, to confirm it
discriminates rather than passing by accident. The EcoSpold 1 writer example
reports dataset 2 where the link asks for 1. With the single-element helper
weakened back to "take the first", the three refusal examples fail and their
three controls pass.

## Wire revision

The revision moves to 12, for `MissingNode` and the `missing:` prefixed id it
carries: both are things the engine learnt to say, and a client could not tell
a new engine from an old one before asking. The `loopTarget` change is not part
of that: the schema always said ProcessId and the code emitted a bare activity
UUID, so this brings the engine to the shape already published.

pyvolca decodes a tree as a plain mapping, so nothing there breaks, but its
`KNOWN_WIRE` ceiling moves with the engine, otherwise every user of a current
client is warned the engine is newer than it understands. Its README
compatibility line is regenerated from that constant.

