### PR TITLE
Release 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.11.0] - 2026-08-28
 
 ### Fixed
 - An exchange now names the coproduct it actually asks for. A dataset whose

--- a/volca.cabal
+++ b/volca.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                volca
-version:             0.10.1-dev
+version:             0.11.0
 build-type:          Simple
 
 license:             Apache-2.0


### PR DESCRIPTION
Cuts the engine release. Two lines: the changelog section gets its number and
date, and `volca.cabal` drops the dev suffix.

The number is 0.11.0 rather than the 0.10.1 the suffix announced. The coproduct
work merged after that suffix was picked, and it changes what a client is given
and what it may ask for: an exchange names the coproduct it actually consumes,
an activity identifier on its own is refused with a 400 rather than resolved to
whichever coproduct was written last, `loopTarget` carries a process identifier,
and a tree export can report a fifth node type. A script written against 0.10.0
does not survive any of those, which is what makes the release a minor.

The reference data bundle stays at 3. Nothing under `data/` moved, so the two
numbers move independently this time: only the engine's does.

Wire revision 12 and pyvolca's matching `KNOWN_WIRE` already landed with the
coproduct work, so there is nothing to bump here.