### PR TITLE
Release pyvolca 0.10.1

### DIFF
--- a/pyvolca/CHANGELOG.md
+++ b/pyvolca/CHANGELOG.md
@@ -18,6 +18,19 @@ git cliff --unreleased --tag pyvolca-v0.X.Y   # render as a released section
 
 Then paste the rendered block at the top of this file and tighten wording.
 
+## [0.10.1] - 2026-08-28
+
+### Changed
+
+- This build knows wire revision 12, so it no longer warns that an engine
+  running v0.11.0 speaks a format newer than it understands. Revision 12 adds
+  the node type a tree export reports for a link that names a row no loaded
+  database holds. Nothing else moves: the oldest revision this client accepts
+  is still 2, and it still runs against any engine from v0.9.1 on.
+- The documentation link points at `www.volca.run`, which is the host that
+  answers. `volca.run` without the prefix does not, so the link shown on PyPI,
+  the one in the README and the one in the package docstring all led nowhere.
+
 ## [0.10.0] - 2026-08-22
 
 The minor is for one rename: `Decomposition.electricity_kwh` is now

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -24,7 +24,7 @@ The other direction is a promise about pyvolca's own names. A name this client p
 
 _Generated from `volca._compat`: run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.10.0** speaks wire formats **2 to 12** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error. A name this build has retired keeps working until pyvolca **1.0**.
+This build of **pyvolca 0.10.1** speaks wire formats **2 to 12** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error. A name this build has retired keeps working until pyvolca **1.0**.
 
 <!-- END: compatibility -->
 

--- a/pyvolca/pyproject.toml
+++ b/pyvolca/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvolca"
-version = "0.10.0"
+version = "0.10.1"
 description = "Python client for VoLCA, the Life Cycle Assessment engine"
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
Cuts the Python client release. Two commits landed on main since
`pyvolca-v0.10.0` without moving the version, and both are additive, so this is
a patch.

`KNOWN_WIRE` reached 12 with the coproduct work, which stops the client warning
that a v0.11.0 engine speaks a format it does not understand. The documentation
links now name `www.volca.run`; `volca.run` on its own does not answer, so the
link on PyPI, the one in the README and the one in the package docstring all
led nowhere.

The compatibility sentence in the README is regenerated from `volca._compat`
and now reads "pyvolca 0.10.1 speaks wire formats 2 to 12". That sentence is
also what the published Python page shows, so the site refresh at the end of
the rollout is what makes it true for a reader.

The tag goes on after the engine tag, since the Python release preflight
expects it to exist.