### PR TITLE
Open 0.11.1 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.11.0] - 2026-08-28
 
 ### Fixed

--- a/volca.cabal
+++ b/volca.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                volca
-version:             0.11.0
+version:             0.11.1-dev
 build-type:          Simple
 
 license:             Apache-2.0


### PR DESCRIPTION
Reopens main after the 0.11.0 tag: the dev suffix comes back and the changelog gets an empty section to collect the next cycle.

The number is a patch because nothing removed is planned. Not knowing yet counts as nothing removed, and the release procedure raises it again if a change that breaks a working script lands.