### PR TITLE
Characterize a database over its dependencies' flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+### Fixed
+- A database whose inventory comes from a database it depends on is now
+  characterized with the same factors as that database itself. The cascade
+  that ties a method's factors to a database's flows was built over the root
+  database's own flows alone, while scoring reads the merged inventory of the
+  whole cross-database solve. A dependency's flow therefore only ever reached
+  the rungs that need no flow to point at: never the synonym bridge, never the
+  proxy edges, never the regional projection. Measured on eight processes
+  written against Agribalyse, that lost 13% of fossil climate change; and
+  because a database with no regional factor of its own is scored on the flat
+  path, it also put water use 78 times too high, land use at zero and fossil
+  resource use at 44% of its value. The mapping is now built over the flows
+  the database reaches, its dependencies' included, and the scores match the
+  dependency's own. A database that depends on none is unaffected.
+- A database taking part in a cross-database regionalized score no longer
+  contributes zero when it carries no regional factor for the method. Its
+  emissions were dropped whole rather than scored against the broadcast
+  factors, which is where a flow with no regional factor belongs.
+
 ## [0.11.0] - 2026-08-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@
   emissions were dropped whole rather than scored against the broadcast
   factors, which is where a flow with no regional factor belongs.
 
+### Changed
+- A database whose regional factors all come from a database it depends on is
+  now scored on the regionalized path, like the database it mirrors. Two
+  consequences, both of them that path's existing behaviour reaching a new set
+  of databases: `exclude_long_term` is ignored there, so a request that used it
+  against such a database stops filtering; and the per-flow shares reported
+  next to a score are still computed region-blind, so they no longer add up to
+  a regionalized total. Both were already the case for a database carrying its
+  own regional factors.
+
 ## [0.11.0] - 2026-08-28
 
 ### Fixed

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -294,7 +294,7 @@ class FlowContribution(FromJson):
     category: str  # e.g. "air/urban air"
     cf_value: float = 0.0  # raw characterization factor
     compartment: str | None = None
-    match_kind: str | None = None  # how the factor was found; None when the method's tables never walked this flow
+    match_kind: str | None = None  # how the factor was found; None when no factor in the method reaches this flow
 
 
 @dataclass

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -388,9 +388,8 @@ description r = case r of
         \eutrophication, land use, water scarcity, resource depletion. Prefer this \
         \over web estimates for grounded, database-backed answers. Each \
         \contributing flow carries 'match_kind': how its factor was found, in \
-        \the rung names documented on explain_cf; null means the method's \
-        \tables never walked this flow (it arrived from a dependency database), \
-        \not that it is uncharacterized. Ask explain_cf for the full story on \
+        \the rung names documented on explain_cf; null means no factor in the \
+        \method reaches this flow. Ask explain_cf for the full story on \
         \one flow."
             <> webUrlTip "impacts"
     ComputeSensitivity ->
@@ -455,8 +454,7 @@ description r = case r of
         \contribute most to a specific impact category. Answers 'which emissions \
         \drive my climate change score?'. Each flow carries 'match_kind': how \
         \its factor was found, in the rung names documented on explain_cf; null \
-        \means the method's tables never walked this flow (it arrived from a \
-        \dependency database), not that it is uncharacterized. Ask explain_cf \
+        \means no factor in the method reaches this flow. Ask explain_cf \
         \for the full story on one flow."
             <> webUrlTip "contributing-flows"
     GetContributingActivities ->

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -496,7 +496,7 @@ data FlowContributionEntry = FlowContributionEntry
     , fcoCategory :: Text -- Medium only (e.g. "air")
     , fcoCompartment :: Maybe Text -- Sub-compartment (e.g. "urban air")
     , fcoCfValue :: Double -- Raw characterization factor value
-    , fcoMatchKind :: Maybe Text -- How the factor was found ("exact_name", "cas_number", …); absent for a flow the method's tables never walked
+    , fcoMatchKind :: Maybe Text -- How the factor was found ("exact_name", "cas_number", …); absent for a flow no rung of the cascade reached
     }
     deriving (Generic)
     deriving (ToJSON, ToSchema) via (Stripped FlowContributionEntry)

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -639,14 +639,18 @@ flow to the coarse rungs — no synonym bridge, no proxy edge, no regional
 projection — and the score changes without anything reporting a gap.
 -}
 getFlowClosure :: DatabaseManager -> Text -> Database -> IO FlowClosure
-getFlowClosure manager dbName db = do
-    cached <- readTVarIO (dmFlowClosureCache manager)
+getFlowClosure manager dbName db = atomically $ do
+    cached <- readTVar (dmFlowClosureCache manager)
     case M.lookup dbName cached of
         Just closure -> pure closure
         Nothing -> do
-            loaded <- readTVarIO (dmLoadedDbs manager)
+            -- The union is built inside the transaction that publishes it, so a
+            -- dependency edit committing mid-build invalidates this read of
+            -- 'dmLoadedDbs' and the closure is rebuilt rather than cached
+            -- against flows that no longer exist.
+            loaded <- readTVar (dmLoadedDbs manager)
             let !closure = flowClosure db (dependencyClosure loaded dbName)
-            atomically $ modifyTVar' (dmFlowClosureCache manager) (M.insert dbName closure)
+            modifyTVar' (dmFlowClosureCache manager) (M.insert dbName closure)
             pure closure
 
 {- | Cached flow mapping: avoids re-matching method CFs to database flows on every LCIA call.
@@ -722,8 +726,9 @@ buildMethodTablesFor manager dbName collection db method = do
     -- usual cause is a method whose parser defaulted the direction (no
     -- metadata). Warn so the loss is distinguishable from a genuinely
     -- uncharacterized flow.
+    closure <- getFlowClosure manager dbName db
     let dirExcluded =
-            directionExcludedCFs (fromMaybe emptySynonymDB (dbSynonymDB db)) (dbFlowsByName db) expanded
+            directionExcludedCFs (fromMaybe emptySynonymDB (dbSynonymDB db)) (fcByName closure) expanded
     unless (null dirExcluded) $
         reportProgress Warning $
             "[LCIA "

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -180,7 +180,8 @@ import Method.Mapping (
     fillBroadcastVector,
     fillRegionalActivityWeights,
     isExclusionCF,
-    mapMethodToFlows,
+    mapContextFor,
+    mapMethodFlows,
     mtExactCF,
     mtFallbackCF,
     mtRegionalActivityWeights,
@@ -218,6 +219,7 @@ import Types (
     CrossDBLink (..),
     CrossDBLinkingStats (..),
     Database (..),
+    FlowClosure (..),
     GeographyPolicy (..),
     LinkBlocker (..),
     LocationFallback (..),
@@ -239,6 +241,7 @@ import Types (
     enrichBioFlowCAS,
     exchangeFlowId,
     exchangeIsReference,
+    flowClosure,
     initializeRuntimeFields,
     toSimpleDatabase,
     unresolvedCount,
@@ -606,7 +609,45 @@ data DatabaseManager = DatabaseManager
     {- ^ Memoized merge of every loaded unit-definition set.
     Invalidated on 'dmLoadedUnitDefs' mutation.
     -}
+    , dmFlowClosureCache :: !(TVar (Map Text FlowClosure))
+    {- ^ Memoized 'FlowClosure' per root database: the flows its
+    characterization has to reach, its dependencies' included. Invalidated
+    with that database's method caches, which are built from it.
+    -}
     }
+
+{- | The databases a root reaches, transitively, through 'dbDependsOn'. The
+root itself is excluded, and a name already seen is not walked again, so a
+dependency cycle terminates instead of looping.
+-}
+dependencyClosure :: Map Text LoadedDatabase -> Text -> [Database]
+dependencyClosure loaded root = go (S.singleton root) (depsOf root)
+  where
+    depsOf name = maybe [] (dbDependsOn . ldDatabase) (M.lookup name loaded)
+    go _ [] = []
+    go seen (name : rest)
+        | S.member name seen = go seen rest
+        | otherwise = case M.lookup name loaded of
+            Nothing -> go (S.insert name seen) rest
+            Just ld -> ldDatabase ld : go (S.insert name seen) (rest ++ depsOf name)
+
+{- | The flows a database's characterization has to reach, memoized per root.
+
+Scoring reads the merged inventory of the whole cross-database solve, so a
+mapping cascade built on the root's own flows alone leaves every dependency
+flow to the coarse rungs — no synonym bridge, no proxy edge, no regional
+projection — and the score changes without anything reporting a gap.
+-}
+getFlowClosure :: DatabaseManager -> Text -> Database -> IO FlowClosure
+getFlowClosure manager dbName db = do
+    cached <- readTVarIO (dmFlowClosureCache manager)
+    case M.lookup dbName cached of
+        Just closure -> pure closure
+        Nothing -> do
+            loaded <- readTVarIO (dmLoadedDbs manager)
+            let !closure = flowClosure db (dependencyClosure loaded dbName)
+            atomically $ modifyTVar' (dmFlowClosureCache manager) (M.insert dbName closure)
+            pure closure
 
 {- | Cached flow mapping: avoids re-matching method CFs to database flows on every LCIA call.
 The mapping depends only on (database, method), not on the process being evaluated.
@@ -618,7 +659,9 @@ mapMethodToFlowsCached manager dbName collection db method = do
     case M.lookup key cache of
         Just cached -> return cached
         Nothing -> do
-            result <- mapMethodToFlows db method
+            closure <- getFlowClosure manager dbName db
+            let ctx = mapContextFor closure (fromMaybe emptySynonymDB (dbSynonymDB db))
+            result <- mapMethodFlows ctx method
             atomically $ modifyTVar' (dmMethodMappingCache manager) (M.insert key result)
             return result
 
@@ -638,13 +681,14 @@ shares a synonym group with (see 'dropExcludedMappings').
 effectiveMethodMappings :: DatabaseManager -> Text -> Text -> Database -> Method -> IO [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))]
 effectiveMethodMappings manager dbName collection db method = do
     mappings <- mapMethodToFlowsCached manager dbName collection db method
+    closure <- getFlowClosure manager dbName db
     let synDB = fromMaybe emptySynonymDB (dbSynonymDB db)
-        proxyTargets = ProxyTargets (dbFlowsByName db) (dbFlowsByCAS db) (dbBioFlows db)
+        proxyTargets = ProxyTargets (fcByName closure) (fcByCAS closure) (fcByUUID closure)
     pure $
         dropExcludedMappings (filter isExclusionCF (methodFactors method)) $
             expandProxyEdges proxyTargets (dmSubstanceEdges manager) $
-                projectRegionalResourceFlows synDB (dbBioFlows db) $
-                    expandSynonymMappings synDB (dbFlowsByName db) mappings
+                projectRegionalResourceFlows synDB (fcByUUID closure) $
+                    expandSynonymMappings synDB (fcByName closure) mappings
 
 -- | Cached prepared CF tables: built once per (db, method), reused across inventories.
 mapMethodToTablesCached :: DatabaseManager -> Text -> Text -> Database -> Method -> IO MethodTables
@@ -770,6 +814,11 @@ caller installs a slot and runs the build; others block on the same result
 rather than duplicating the work. @onSuccess@ runs in the slot-clearing
 transaction, so a built value lands in its cache atomically with the release. A
 failed build clears the slot — the next caller retries — and re-throws.
+
+A cache purge that ran while the build was in flight takes the slot away. The
+value was computed from the state that purge invalidated, so the owner returns
+it to its callers but does not put it in the cache: publishing it would refill,
+behind the purge's back, exactly what the purge emptied.
 -}
 singleFlight ::
     (Ord k) =>
@@ -792,8 +841,10 @@ singleFlight inflightVar key onSuccess build = do
         else do
             result <- try build
             atomically $ do
-                modifyTVar' inflightVar (M.delete key)
-                either (const (pure ())) onSuccess result
+                inflight <- readTVar inflightVar
+                when (M.lookup key inflight == Just slot) $ do
+                    writeTVar inflightVar (M.delete key inflight)
+                    either (const (pure ())) onSuccess result
                 putTMVar slot result
             either Control.Exception.throwIO pure result
 
@@ -933,20 +984,44 @@ clearMethodMappingCache manager = atomically $ do
     writeTVar (dmMethodIndexCache manager) M.empty
     writeTVar (dmMergedFlowMetadataCache manager) Nothing
     writeTVar (dmMergedUnitConfigCache manager) Nothing
+    writeTVar (dmFlowClosureCache manager) M.empty
 
-{- | Clear cached flow mappings for a specific database.
+{- | Clear cached flow mappings for a specific database, and for every database
+that depends on it: a mapping is built over the root's flow closure, so a
+dependency that changes invalidates its dependents' tables as much as its own.
+
 The merged flow/unit snapshots span every loaded DB, so a single-DB mutation
 still invalidates them fully.
 -}
 clearMethodMappingCacheForDb :: DatabaseManager -> Text -> IO ()
 clearMethodMappingCacheForDb manager dbName = atomically $ do
-    modifyTVar' (dmMethodMappingCache manager) (M.filterWithKey (\(dn, _, _) _ -> dn /= dbName))
-    modifyTVar' (dmMethodTablesCache manager) (M.filterWithKey (\(dn, _, _) _ -> dn /= dbName))
-    modifyTVar' (dmMethodTablesInflight manager) (M.filterWithKey (\(dn, _, _) _ -> dn /= dbName))
-    modifyTVar' (dmMethodSetTablesCache manager) (M.filterWithKey (\(dn, _, _) _ -> dn /= dbName))
-    modifyTVar' (dmMethodIndexCache manager) (M.filterWithKey (\(dn, _, _) _ -> dn /= dbName))
+    loaded <- readTVar (dmLoadedDbs manager)
+    let stale = dependentsClosure loaded dbName
+        keep (dn, _, _) _ = not (S.member dn stale)
+    modifyTVar' (dmMethodMappingCache manager) (M.filterWithKey keep)
+    modifyTVar' (dmMethodTablesCache manager) (M.filterWithKey keep)
+    modifyTVar' (dmMethodTablesInflight manager) (M.filterWithKey keep)
+    modifyTVar' (dmMethodSetTablesCache manager) (M.filterWithKey keep)
+    modifyTVar' (dmMethodIndexCache manager) (M.filterWithKey keep)
+    modifyTVar' (dmFlowClosureCache manager) (M.filterWithKey (\dn _ -> not (S.member dn stale)))
     writeTVar (dmMergedFlowMetadataCache manager) Nothing
     writeTVar (dmMergedUnitConfigCache manager) Nothing
+
+{- | A database and everything that reaches it through 'dbDependsOn',
+transitively. The seen set is what makes a dependency cycle terminate.
+-}
+dependentsClosure :: Map Text LoadedDatabase -> Text -> S.Set Text
+dependentsClosure loaded = go S.empty . pure
+  where
+    go seen [] = seen
+    go seen (name : rest)
+        | S.member name seen = go seen rest
+        | otherwise = go (S.insert name seen) (rest ++ directDependents name)
+    directDependents name =
+        [ other
+        | (other, ld) <- M.toList loaded
+        , name `elem` dbDependsOn (ldDatabase ld)
+        ]
 
 {- | Initialize database manager from config
 Pre-loads databases with load=true at startup
@@ -1051,6 +1126,7 @@ initDatabaseManager config noCache = do
                 <> " ignored)"
     mergedFlowMetadataCacheVar <- newTVarIO Nothing
     mergedUnitConfigCacheVar <- newTVarIO Nothing
+    flowClosureCacheVar <- newTVarIO M.empty
 
     let manager =
             DatabaseManager
@@ -1082,6 +1158,7 @@ initDatabaseManager config noCache = do
                 , dmCasBindings = substanceCasBindings
                 , dmMergedFlowMetadataCache = mergedFlowMetadataCacheVar
                 , dmMergedUnitConfigCache = mergedUnitConfigCacheVar
+                , dmFlowClosureCache = flowClosureCacheVar
                 }
 
     -- Auto-load active reference data (flow synonyms, compartment mappings, units)

--- a/src/Impact.hs
+++ b/src/Impact.hs
@@ -19,13 +19,16 @@ took its total from here and its shares from there would publish percentages
 that no longer sum. The contributions have to move with the total, and that
 walk does not exist yet.
 
-Two further gaps, both older than this module and neither fixed by it:
+One further gap, older than this module and not fixed by it: long-term-emission
+filtering applies to the inventory only, so the regionalized path ignores
+@exclude_long_term@. A database whose regional factors all arrive from a
+dependency now takes that path, so it stops honouring the flag — which is what
+the dependency it mirrors already did.
 
-  * The dispatch below asks the /root/ database's tables whether the method is
-    regionalized. A root database with no matching regional factors scores its
-    dependencies' regional flows flat.
-  * Long-term-emission filtering applies to the inventory only, so the
-    regionalized path ignores @exclude_long_term@.
+The dispatch below still asks the /root/ database's tables whether the method is
+regionalized. That reads right now only because those tables are built over the
+root's flow closure and so carry its dependencies' regional factors; it is a
+property of the method, and asking one database's tables for it is incidental.
 -}
 module Impact (
     scoreSolution,

--- a/src/Method/Explain.hs
+++ b/src/Method/Explain.hs
@@ -181,9 +181,11 @@ broadcast vector was filled rather than replayed. This is the cheap answer, for
 annotating a whole table of contributing flows at once; 'explainFlowCF' is the
 full one, for the flow somebody clicked.
 
-'Nothing' means the tables hold no recorded resolution for this flow: it was
-never walked, which a cross-DB flow arriving from a dependency has not been.
-That is an absent answer, not a negative one.
+'Nothing' means the tables hold no recorded resolution for this flow: no rung
+of the cascade reached it. The tables are built over the flows the database
+reaches, its dependencies' included, so a flow arriving from a dependency is
+walked like any other and this answer is about the method's coverage, not
+about where the flow came from.
 -}
 flowMatchKind :: MethodTables -> UUID -> Maybe Text
 flowMatchKind tables fid = rungName . ftRung <$> M.lookup fid (mtResolution tables)

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -2122,6 +2122,9 @@ computeRegionalizedLCIAScore unitConfig unitDB flowDB db scalingVec _hier tables
             -- this method's business — they just all go through the broadcast
             -- tables — so score its own slice flat instead of contributing a
             -- zero that reads exactly like a database with nothing to say.
+            -- Unlike the fast path this walks the DB's biosphere triples once
+            -- per score call; precompute it the way
+            -- 'fillRegionalActivityWeights' does if a batch ever makes it hot.
             | M.null (mtRegionalizedCF tables) ->
                 Right
                     ( loScore
@@ -2978,8 +2981,11 @@ up that method's tables in each DB's 'MethodSetTables' and summing the
 per-DB dot products via 'sumRegionalizedLCIAScoreCrossDB'.
 
 A DB whose 'MethodSetTables' has no entry for a given methodId (mismatched
-sets) contributes 0 for that method — the same neutral element as a DB
-whose mappings caught none of the method's regional CFs.
+sets) is skipped, and its emissions are dropped from that method's sum. This
+is not the same as a DB whose mappings caught none of the method's regional
+CFs: that one is scored flat by 'computeRegionalizedLCIAScore'. Method sets
+are built from one collection and are expected to agree, so the skip is a
+defensive case rather than a live one.
 -}
 scoreRegionalCrossDB ::
     UnitConfig ->

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -23,6 +23,7 @@ module Method.Mapping (
     dropExcludedMappings,
     exclusionWarning,
     buildMapContext,
+    mapContextFor,
 
     -- * LCIA scoring
     CF (..),
@@ -136,14 +137,14 @@ import Data.Word (Word8)
 import GHC.Generics (Generic)
 
 import qualified Data.Set as Set
-import Matrix (Inventory, Vector, chunksOf)
+import Matrix (Inventory, Vector, applyBiosphereMatrix, chunksOf)
 import Method.ChemSynonyms (ChemSynonyms, expandedTokens)
 import Method.Types
 import Progress (ProgressLevel (..), reportProgress)
 import SubstanceRegistry (nonEmptyCAS, normalizeCAS)
 import qualified SubstanceRegistry as SR
 import SynonymDB
-import Types (Activity (..), BioFlowDB, BiosphereFlow (..), Database (..), ProcessId, SparseTriple (..), Unit (..), UnitDB)
+import Types (Activity (..), BioFlowDB, BiosphereFlow (..), Database (..), FlowClosure (..), ProcessId, SparseTriple (..), Unit (..), UnitDB, ownFlowClosure)
 import qualified Types as VT
 import UnitConversion (UnitConfig, convertUnit, isKnownUnit, normalizeToCanonical, normalizeUnit, unitsCompatible)
 
@@ -225,17 +226,26 @@ data MapContext = MapContext
     -}
     }
 
--- | Build a MapContext from a Database (convenience for callers)
-buildMapContext :: Database -> MapContext
-buildMapContext db =
+{- | Build a MapContext over the flows a database's characterization has to
+reach, which is its dependencies' as much as its own — see 'FlowClosure'.
+-}
+mapContextFor :: FlowClosure -> SynonymDB -> MapContext
+mapContextFor closure synDB =
     MapContext
-        { mcBioFlowsByUUID = dbBioFlows db
-        , mcBioFlowsByName = dbFlowsByName db
-        , mcBioFlowsByCAS = dbFlowsByCAS db
-        , mcSynonymDB = fromMaybe emptySynonymDB (dbSynonymDB db)
+        { mcBioFlowsByUUID = fcByUUID closure
+        , mcBioFlowsByName = fcByName closure
+        , mcBioFlowsByCAS = fcByCAS closure
+        , mcSynonymDB = synDB
         , mcActivities = M.empty
         , mcSynGroupFlows = M.empty
         }
+
+{- | Build a MapContext from one Database alone. For callers holding no manager
+and therefore no dependencies to close over — the CLI, and the tests.
+-}
+buildMapContext :: Database -> MapContext
+buildMapContext db =
+    mapContextFor (ownFlowClosure db) (fromMaybe emptySynonymDB (dbSynonymDB db))
 
 {- | Map every method CF to a database biosphere flow via the built-in matcher
 cascade ('resolveCF'). Each CF resolves independently (no cross-CF state), so
@@ -2101,18 +2111,22 @@ computeRegionalizedLCIAScore ::
     M.Map Location [Location] ->
     MethodTables ->
     Either Text Double
-computeRegionalizedLCIAScore _unitConfig _unitDB _flowDB _db scalingVec _hier tables =
+computeRegionalizedLCIAScore unitConfig unitDB flowDB db scalingVec _hier tables =
     case mtRegionalActivityWeights tables of
         Just raw -> scoreFromPrecomputed raw scalingVec
         Nothing
             -- Cross-DB scoring passes per-DB tables in; a dep DB whose flow
             -- mappings caught none of this method's regional CFs has empty
             -- 'mtRegionalizedCF', so 'fillRegionalActivityWeights' left
-            -- 'mtRegionalActivityWeights' unfilled. Treat as a 0
-            -- contribution rather than erroring — non-regional emissions
-            -- from that DB are handled by the broadcast pass for which the
-            -- DB built 'rawWeights' from its own broadcast cell.
-            | M.null (mtRegionalizedCF tables) -> Right 0
+            -- 'mtRegionalActivityWeights' unfilled. Its emissions are still
+            -- this method's business — they just all go through the broadcast
+            -- tables — so score its own slice flat instead of contributing a
+            -- zero that reads exactly like a database with nothing to say.
+            | M.null (mtRegionalizedCF tables) ->
+                Right
+                    ( loScore
+                        (computeLCIAScoreFromTables unitConfig unitDB flowDB (applyBiosphereMatrix db scalingVec) tables)
+                    )
             | otherwise ->
                 Left
                     "Regionalized score requested but precomputed activity weights\

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1216,6 +1216,35 @@ addFlowNameIndexToDatabase db =
         , dbProductSearchIndex = buildProductSearchIndex (dbActivities db) (dbTechFlows db)
         }
 
+{- | The biosphere flows a database's characterization has to reach: its own,
+plus those of every database it depends on.
+
+A cross-database inventory carries the dependencies' flows, so a matcher
+cascade built on the root's flows alone resolves nothing for them — the
+synonym, proxy and regional bridges all need a flow to point at. The score
+then loses whatever those bridges would have found, silently, because the
+inventory is right and only the factors are missing.
+-}
+data FlowClosure = FlowClosure
+    { fcByUUID :: !BioFlowDB
+    , fcByName :: !(M.Map Text [BiosphereFlow])
+    , fcByCAS :: !(M.Map Text [BiosphereFlow])
+    }
+
+-- | The closure of a database that depends on nothing: its own prebuilt indexes.
+ownFlowClosure :: Database -> FlowClosure
+ownFlowClosure db = FlowClosure (dbBioFlows db) (dbFlowsByName db) (dbFlowsByCAS db)
+
+{- | The closure of a database over its dependencies. The root is unioned first,
+so a UUID two databases both declare keeps the root's metadata — the same
+precedence the matcher cascade applies when it prefers the root's own flow.
+-}
+flowClosure :: Database -> [Database] -> FlowClosure
+flowClosure root [] = ownFlowClosure root
+flowClosure root deps =
+    let !merged = M.unions (dbBioFlows root : map dbBioFlows deps)
+     in FlowClosure merged (buildFlowNameIndex merged) (buildFlowCASIndex merged)
+
 {- | Fill empty @bfCAS@ from registry name→CAS bindings, then rebuild the CAS
 index so the native CAS bridge fires. Holes only — a CAS the database itself
 provided is authoritative and never overwritten, which bounds any risk from a

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1235,15 +1235,22 @@ data FlowClosure = FlowClosure
 ownFlowClosure :: Database -> FlowClosure
 ownFlowClosure db = FlowClosure (dbBioFlows db) (dbFlowsByName db) (dbFlowsByCAS db)
 
-{- | The closure of a database over its dependencies. The root is unioned first,
-so a UUID two databases both declare keeps the root's metadata — the same
-precedence the matcher cascade applies when it prefers the root's own flow.
+{- | The closure of a database over its dependencies. The root comes first
+everywhere: a UUID two databases both declare keeps the root's metadata, and a
+name or CAS two of them declare under /different/ UUIDs still resolves to the
+root's flow, since 'Method.Mapping.pickByCompartment' reads its candidates in
+order. Adding a dependency therefore never moves a resolution the root already
+had.
 -}
 flowClosure :: Database -> [Database] -> FlowClosure
 flowClosure root [] = ownFlowClosure root
 flowClosure root deps =
-    let !merged = M.unions (dbBioFlows root : map dbBioFlows deps)
-     in FlowClosure merged (buildFlowNameIndex merged) (buildFlowCASIndex merged)
+    let !depFlows = M.unions (map dbBioFlows deps) `M.difference` dbBioFlows root
+        !merged = M.union (dbBioFlows root) depFlows
+     in FlowClosure
+            merged
+            (M.unionWith (++) (dbFlowsByName root) (buildFlowNameIndex depFlows))
+            (M.unionWith (++) (dbFlowsByCAS root) (buildFlowCASIndex depFlows))
 
 {- | Fill empty @bfCAS@ from registry name→CAS bindings, then rebuild the CAS
 index so the native CAS bridge fires. Holes only — a CAS the database itself

--- a/test/DependencyFlowClosureSpec.hs
+++ b/test/DependencyFlowClosureSpec.hs
@@ -1,0 +1,213 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | A database has to characterize the flows it reaches, not only the ones it
+owns.
+
+An activity whose inventory comes from a dependency database carries that
+dependency's biosphere flows: scoring reads the merged inventory of the whole
+cross-database solve. The mapping cascade, though, used to be built on the root
+database's own flows alone, so a dependency's flow reached only the rungs that
+need no flow to point at — never the synonym bridge, the proxy edges or the
+regional projection. The inventory was right, the factors were missing, and
+nothing said so.
+-}
+module DependencyFlowClosureSpec (spec) where
+
+import Control.Concurrent.STM (atomically, modifyTVar', readTVarIO)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as U
+import Test.Hspec
+
+import Config (DatabaseConfig (..), defaultConfig)
+import qualified Database.Manager as DM
+import Method.Mapping (
+    MatchStrategy (..),
+    computeRegionalizedLCIAScore,
+    mtRegionalizedCF,
+ )
+import Method.Types (Method (..), MethodCF (..))
+import qualified Method.Types as MT
+import qualified SharedSolver as SS
+import SynonymDB (buildFromPairs)
+import Types
+
+import CrossDBRegionalLCIAFixture (buildTables, kgUnit, kgUnitConfig, mkDB, mkUUID)
+
+collection :: Text
+collection = "EF-3.1"
+
+-- | The flow only the dependency database owns.
+riverWater :: BiosphereFlow
+riverWater =
+    BiosphereFlow
+        { bfId = mkUUID 501
+        , bfName = "Water, river"
+        , bfUnitId = unitId kgUnit
+        , bfSynonyms = M.empty
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfCompartment = Just (Compartment "natural resource" Nothing)
+        }
+
+-- | A flow the root database owns itself, unrelated to the dependency's.
+methane :: BiosphereFlow
+methane =
+    BiosphereFlow
+        { bfId = mkUUID 502
+        , bfName = "Methane"
+        , bfUnitId = unitId kgUnit
+        , bfSynonyms = M.empty
+        , bfCAS = Nothing
+        , bfSubstanceId = Nothing
+        , bfCompartment = Just (Compartment "air" Nothing)
+        }
+
+{- | A CF named for the method's own spelling of the substance. Only the synonym
+bridge ties it to a flow, so it resolves nothing unless the flow is in reach.
+-}
+namedCF :: Text -> Double -> MethodCF
+namedCF name value =
+    MethodCF
+        { mcfFlowRef = mkUUID 0
+        , mcfFlowName = name
+        , mcfDirection = MT.Input
+        , mcfValue = value
+        , mcfCompartment = Nothing
+        , mcfCAS = Nothing
+        , mcfUnit = "kg"
+        , mcfConsumerLocation = Nothing
+        }
+
+mkMethod :: Text -> [MethodCF] -> Method
+mkMethod name factors =
+    Method
+        { methodId = mkUUID 7001
+        , methodName = name
+        , methodDescription = Nothing
+        , methodUnit = "kg"
+        , methodCategory = name
+        , methodMethodology = Nothing
+        , methodFactors = factors
+        }
+
+-- | Replace a fixture database's own biosphere flows, rebuilding its indexes.
+withOwnFlows :: [BiosphereFlow] -> Database -> Database
+withOwnFlows flows db =
+    addFlowNameIndexToDatabase db{dbBioFlows = M.fromList [(bfId f, f) | f <- flows]}
+
+dbConfigFor :: Text -> DatabaseConfig
+dbConfigFor name =
+    DatabaseConfig
+        { dcName = name
+        , dcDisplayName = name
+        , dcPath = ""
+        , dcDescription = Nothing
+        , dcLoad = True
+        , dcDefault = False
+        , dcDepends = []
+        , dcLocationAliases = M.empty
+        , dcFormat = Nothing
+        , dcIsUploaded = False
+        , dcDeletable = False
+        , dcGeographyPolicy = GeoGlobal
+        }
+
+-- | Install a database in the manager's loaded set, solver and config included.
+install :: DM.DatabaseManager -> Text -> Database -> IO ()
+install manager name db = do
+    solver <-
+        SS.createSharedSolver
+            name
+            [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList (dbTechnosphereTriples db)]
+            (fromIntegral (dbActivityCount db))
+    atomically $
+        modifyTVar' (DM.dmLoadedDbs manager) $
+            M.insert
+                name
+                DM.LoadedDatabase
+                    { DM.ldDatabase = db
+                    , DM.ldSharedSolver = solver
+                    , DM.ldConfig = dbConfigFor name
+                    }
+
+-- | The flows the effective mappings actually reach.
+reachedFlows :: [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> [UUID]
+reachedFlows mappings = [bfId f | (_, Just (f, _)) <- mappings]
+
+{- | Root and dependency, both loaded. The root owns @rootFlows@ and declares
+the dependency; the dependency owns 'riverWater'.
+-}
+setup :: [BiosphereFlow] -> IO (DM.DatabaseManager, Database)
+setup rootFlows = do
+    manager <- DM.initDatabaseManager defaultConfig True
+    let dep = withOwnFlows [riverWater] (mkDB 1 ["FR"] [])
+        root =
+            (withOwnFlows rootFlows (mkDB 100 ["FR"] []))
+                { dbDependsOn = ["dep"]
+                , dbSynonymDB = Just (buildFromPairs [("river water", "Water, river")])
+                }
+    install manager "dep" dep
+    install manager "root" root
+    pure (manager, root)
+
+spec :: Spec
+spec = do
+    describe "characterization over a database's flow closure" $ do
+        it "reaches a dependency's flow through the synonym bridge" $ do
+            (manager, root) <- setup []
+            mappings <-
+                DM.effectiveMethodMappings manager "root" collection root $
+                    mkMethod "Water use" [namedCF "river water" 6.98]
+            reachedFlows mappings `shouldContain` [bfId riverWater]
+
+        it "leaves the root's own resolution alone when it also has dependencies" $ do
+            (managerAlone, rootAlone) <- setup [methane]
+            -- Same root, dependency removed: the baseline resolution to compare against.
+            let solo = rootAlone{dbDependsOn = []}
+            soloMappings <-
+                DM.effectiveMethodMappings managerAlone "solo" collection solo $
+                    mkMethod "Climate change" [namedCF "Methane" 29.8]
+            (manager, root) <- setup [methane]
+            mappings <-
+                DM.effectiveMethodMappings manager "root" collection root $
+                    mkMethod "Climate change" [namedCF "Methane" 29.8]
+            reachedFlows mappings `shouldBe` reachedFlows soloMappings
+
+        it "drops a dependent's cached mapping when the dependency changes" $ do
+            (manager, root) <- setup []
+            _ <-
+                DM.effectiveMethodMappings manager "root" collection root $
+                    mkMethod "Water use" [namedCF "river water" 6.98]
+            before <- readTVarIO (DM.dmMethodMappingCache manager)
+            M.keys before `shouldSatisfy` any (\(dn, _, _) -> dn == "root")
+            DM.clearMethodMappingCacheForDb manager "dep"
+            after <- readTVarIO (DM.dmMethodMappingCache manager)
+            M.keys after `shouldSatisfy` all (\(dn, _, _) -> dn /= "root")
+
+    describe "cross-DB regionalized scoring" $
+        it "scores a participating database that carries no regional factor, instead of zero" $ do
+            -- One activity emitting 1 kg of the flow, and a method whose only
+            -- factor is global: the regionalized dispatch still has to count it.
+            let db = withOwnFlows [riverWater] (mkDB 1 ["FR"] [(0, 1.0)])
+                emitting = db{dbBiosphereOrder = V.singleton (bfId riverWater)}
+                mappings =
+                    [
+                        ( (namedCF "Water, river" 6.98){mcfFlowRef = bfId riverWater}
+                        , Just (riverWater, ByUUID)
+                        )
+                    ]
+                tables = buildTables emitting mappings
+            -- No regional factor, so 'fillRegionalActivityWeights' leaves the
+            -- precomputed weights unfilled and the old code returned 0 here.
+            mtRegionalizedCF tables `shouldBe` M.empty
+            computeRegionalizedLCIAScore
+                kgUnitConfig
+                (dbUnits emitting)
+                (dbBioFlows emitting)
+                emitting
+                (U.fromList [1.0])
+                M.empty
+                tables
+                `shouldBe` Right 6.98

--- a/test/DependencyFlowClosureSpec.hs
+++ b/test/DependencyFlowClosureSpec.hs
@@ -64,6 +64,12 @@ methane =
         , bfCompartment = Just (Compartment "air" Nothing)
         }
 
+{- | The root's own flow under the name the dependency also uses, with a lower
+UUID so the merged map iterates it before the dependency's homonym.
+-}
+rootRiverWater :: BiosphereFlow
+rootRiverWater = riverWater{bfId = mkUUID 500}
+
 {- | A CF named for the method's own spelling of the substance. Only the synonym
 bridge ties it to a flow, so it resolves nothing unless the flow is in reach.
 -}
@@ -174,6 +180,18 @@ spec = do
                 DM.effectiveMethodMappings manager "root" collection root $
                     mkMethod "Climate change" [namedCF "Methane" 29.8]
             reachedFlows mappings `shouldBe` reachedFlows soloMappings
+
+        it "binds a name both databases declare to the root's own flow" $ do
+            -- pickByCompartment reads its candidates in order, so a name index
+            -- rebuilt over the merged map hands the homonym that sorts first —
+            -- the dependency's — a factor the root used to resolve itself. The
+            -- synonym fan-out downstream reaches both, which is its job; what
+            -- the cascade picks here is the root's.
+            (manager, root) <- setup [rootRiverWater]
+            mappings <-
+                DM.mapMethodToFlowsCached manager "root" collection root $
+                    mkMethod "Water use" [namedCF "Water, river" 6.98]
+            reachedFlows mappings `shouldBe` [bfId rootRiverWater]
 
         it "drops a dependent's cached mapping when the dependency changes" $ do
             (manager, root) <- setup []

--- a/volca.cabal
+++ b/volca.cabal
@@ -280,6 +280,7 @@ test-suite lca-tests
                      , MappingSpec
                      , MethodSetTablesSpec
                      , MethodCollectionCacheSpec
+                     , DependencyFlowClosureSpec
                      , MethodResolveSpec
                      , ChemSynonymsSpec
                      , SubstanceRegistrySpec


### PR DESCRIPTION
A database whose inventory comes from a database it depends on was scored with
the wrong characterization factors, silently. The inventory was right; only the
factors were missing, so nothing anywhere reported a gap.

## What was wrong

Scoring reads the merged inventory of the whole cross-database solve, but the
cascade that ties a method's factors to a database's flows was built over the
root database's own flows alone (`buildMapContext`), and `resolveCF` further
required the flow it picked to be present in that root index. A flow arriving
from a dependency therefore only ever reached the rungs that need no flow to
point at. It never reached the synonym bridge, the proxy edges or the regional
projection.

That has two visible effects, which is why only some categories moved:

- factors found through a synonym went missing. `Carbon dioxide, land
  transformation` is characterized in Agribalyse through a synonym to
  `Carbon dioxide, peat oxidation`, and was uncharacterized in a database
  depending on Agribalyse, for the same flow UUID;
- with no regional factors of its own, such a database has an empty
  `mtRegionalizedCF`, so `Impact.scoreSolution` sent it down the flat path.
  Every `Water, FR` then took the generic factor -42.955 through the
  `region_base_name` rung instead of the French -6.98, and the `Water, turbine
  use` returns that offset them disappeared entirely.

Measured on eight processes written against Agribalyse and scored under three
method collections, against the same processes inside Agribalyse itself:

| category | before | after |
|---|---|---|
| Water use | 7857% | equal |
| Land use | 0% | equal |
| Resource use, fossils | 44% | equal |
| Ozone depletion | 0.4% | equal |
| Climate change - Fossil | 87% | equal |

## What changed

The mapping is now built over the flows the database actually reaches: a
`FlowClosure` unioning the root's biosphere flows with its transitive
dependencies', root first so a UUID two databases both declare keeps the root's
metadata. It is memoized per database on the manager, and
`clearMethodMappingCacheForDb` now drops the named database and its dependents,
transitively, since a dependency that changes invalidates its dependents'
tables as much as its own.

Two things follow from that and are part of the change:

- the root's tables now carry its dependency's regional factors, so the
  dispatch in `Impact.scoreSolution` takes the regionalized path, which is the
  only path that can apply a located factor;
- a database taking part in that per-database sum used to contribute
  `Right 0` when it carried no regional factor at all, dropping its emissions
  rather than scoring them against the broadcast tables. The dispatch change
  would have made that reachable far more often, so it is fixed here.

The widened purge is also why the `singleFlight` race is closed in the same
commit: an owner whose slot a purge took away no longer republishes the value
it built from the state that purge invalidated.

A last commit corrects three descriptions that told the reader a null
`match_kind` meant the flow came from a dependency and was not to be read as
uncharacterized. That was describing this bug.

## How it was checked

`test/DependencyFlowClosureSpec.hs` covers four cases: a dependency-only flow
reached through the synonym bridge, a root with its own flows keeping its
resolution unchanged when a dependency is added, the dependent's cache being
dropped when its dependency changes, and a participant with no regional factor
being scored rather than zeroed. Each of the three regression cases was
confirmed to fail with its fix removed. The full suite is green.

End to end, on a real database of eight processes depending on Agribalyse: all
twenty-five categories of the three collections now match the same processes
inside Agribalyse, except on the five datasets whose exporter wrote ten
biosphere exchanges with no flow name, which is a fault in that file.

Agribalyse scored alone is unaffected. Comparing the unmodified build to this
one shows 88 of 600 scores differing in the fourteenth digit; comparing two
processes of the *same* build shows 94 differing by slightly more (worst
relative 1.73e-14 against 1.22e-14). The engine's own run-to-run noise is
larger than anything this change does.
