### PR TITLE
An identity, and a supplier, come from what the file says

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,23 +76,32 @@
   move, and every one of them moves down, by 0.5% at the median and by up to
   56%. The engine reports those ten as unlinked, where it used to report 169113
   of 169113 resolved.
-- When several activities produce one product name, which of them supplies an
-  input no longer depends on the identifiers: the first by activity name, then
-  by location, wins. What that rule cannot know is which twin the file meant:
-  on Agribalyse 4.0 it lands on the retired copy of the pork slaughterhouse
-  block, because "whitout" sorts before "without". Any rule would land
-  somewhere; what must not happen is the answer moving because identity is
-  minted differently, and what must not stay quiet is that a rule of ours
-  answered at all, which the next entry is for.
-- The quality report says when two activities declare one product. Which of
-  them answers an input naming it is settled by a rule of ours, on a question
-  only the file can settle, so the file has to be told. The duplicate-activities
-  check cannot see these, because it groups on the activity name and the two
-  spell theirs differently. On the Agribalyse 4.0 export of 13 May 2026 it finds
-  twenty, and they are one case: the pork slaughterhouse block shipped twice,
-  once current and once retired under `Autres\Obsolete`, their process names a
-  typo apart ("whitout" against "without"), declaring the same ten products. The
-  retired one is what currently supplies the whole downstream pork chain.
+- When several activities produce one product name, the file says which one to
+  use: a retired block is filed under an obsolete category, and the block still
+  in service supplies. On the Agribalyse 4.0 export of 13 May 2026 that settles
+  all ten of its duplicated products, which are the ten coproducts of a pork
+  slaughterhouse block shipped twice, once under `Autres\Obsolete`. Until now
+  the retired copy won, because "whitout" sorts before "without". The category
+  is a convention of the tool that writes these files, which shows retired
+  processes under an `Obsolete` subcategory and warns whenever a calculation
+  reaches one: 1036 of Agribalyse 4.0's 22822 product rows carry it, and 2551
+  of ecoinvent 3.11's 28594. Two blocks the file gives no way to tell apart are
+  still ordered by activity name then by location, never by identifier: a
+  change in how identity is minted must not move a supply chain.
+- Scores of a SimaPro database move where a retired block was supplying.
+  Measured on Agribalyse 4.0 over 1062 activities, 771 of them in the pork
+  chain and 291 drawn at random, 11453 of 26550 category readings move, on 800
+  activities: 9739 rise and 1714 fall, by 1.1% at the median and 1.5% at the
+  ninth decile. The largest is black pudding, at 2.8x on several categories: it
+  is mostly pork blood, and blood is one of the ten coproducts the two blocks
+  allocate differently.
+- The quality report says when two activities declare one product, since only
+  one of them can supply it. The duplicate-activities check cannot see these,
+  because it groups on the activity name and the two spell theirs differently.
+  On the Agribalyse 4.0 export of 13 May 2026 it finds twenty, and they are one
+  case: the pork slaughterhouse block shipped twice, once current and once
+  retired under `Autres\Obsolete`, their process names a typo apart ("whitout"
+  against "without"), declaring the same ten products.
 - The quality report gains the other half of a pair it only had one side of: an
   input naming a product no reference product of this database supplies, beside
   the reference product nothing consumes. Expected of a foreground database,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,6 @@
   next to a score are still computed region-blind, so they no longer add up to
   a regionalized total. Both were already the case for a database carrying its
   own regional factors.
-
-### Changed
 - What identifies a dataset read from a SimaPro CSV or a Brightway Excel
   workbook is now what the file publishes, not what the engine calls things.
   Two problems came from the old rule. The unit was part of a flow identifier,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,40 @@
   a regionalized total. Both were already the case for a database carrying its
   own regional factors.
 
+### Changed
+- What identifies a dataset read from a SimaPro CSV or a Brightway Excel
+  workbook is now what the file publishes, not what the engine calls things.
+  Two problems came from the old rule. The unit was part of a flow identifier,
+  so renaming a reference unit in the engine's own table moved about twelve
+  percent of Agribalyse process ids in release 0.10.0 without a single number
+  changing. And an activity was named after its process name, so two exports of
+  one Agribalyse that disagree on the case of a product name gave the same
+  dataset two identifiers on two servers. From now on an activity is named by
+  the "Process identifier" its block publishes, and a flow by its name folded in
+  case and its compartment. The identifiers of these two formats therefore move
+  once more, and `volca/examples/process_id_remap` converts a stored list.
+  EcoSpold 1 and 2 and ILCD are untouched: they carry identifiers of their own.
+- Every row of these two formats is recorded in the reference unit of its
+  dimension, where only the reference product was before. An input written in
+  grams is held in kilograms, one written in kWh in MJ, and displays and
+  exports show it in that unit. No score moves: the matrix already converted
+  what it summed. Two rows that would land on one flow in units no conversion
+  relates, an energy against a mass, are now refused by name rather than one of
+  them being dropped in silence.
+- The SimaPro writer emits the "Process identifier" line it always read.
+  Exporting a database and reading it back used to rename every process in it.
+- Scores of a SimaPro database move, and not because of the identity. An input
+  that names a product no reference product matches exactly falls back to a
+  prefix of that name, and the index from a prefix to its producer keeps one
+  producer, whichever the map happened to hold last, in activity-identifier
+  order. In Agribalyse 4.0, 2797 prefixes name several producers. Every
+  identifier moved here, so the producer kept moved with it: sunflower grain now
+  draws its urea from the Chinese market rather than the North American one, and
+  its organic-carcinogen score with it. Measured over 250 activities, half the
+  category readings move, by 0.13% at the median and by up to 43%. The choice
+  was already arbitrary; what changed is which arbitrary answer comes out.
+- Every database cache is rebuilt on first load.
+
 ## [0.11.0] - 2026-08-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,12 @@
   by location, wins. They are duplicates of each other, a block exported twice
   under a name differing by a typo, so either answers; what must not happen is
   the answer moving because identity is minted differently.
+- The quality report gains the other half of a pair it only had one side of: an
+  input naming a product no reference product of this database supplies, beside
+  the reference product nothing consumes. Expected of a foreground database,
+  which draws its background from another; a hole in one meant to stand alone.
+  On the Agribalyse 4.0 export of 13 May 2026 it names the nine that were being
+  filled with a supplier nobody asked for.
 - Every database cache is rebuilt on first load.
 
 ## [0.11.0] - 2026-08-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,13 @@
   case: the pork slaughterhouse block shipped twice, once current and once
   retired under `Autres\Obsolete`, their process names a typo apart ("whitout"
   against "without"), declaring the same ten products.
+- The quality report says when an input's only producer is a dataset the source
+  retired. Such a dataset still carries its exchanges and still computes, so
+  the score is a number; it is the superseded number, and its author expects it
+  to be replaced. This is the warning the tool that writes these files raises
+  when a calculation reaches one. On the Agribalyse 4.0 export of 13 May 2026
+  it names 874 inputs. A product a retired block and a live block both declare
+  is not named: the live one supplies it.
 - The quality report gains the other half of a pair it only had one side of: an
   input naming a product no reference product of this database supplies, beside
   the reference product nothing consumes. Expected of a foreground database,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,16 +53,34 @@
   them being dropped in silence.
 - The SimaPro writer emits the "Process identifier" line it always read.
   Exporting a database and reading it back used to rename every process in it.
-- Scores of a SimaPro database move, and not because of the identity. An input
-  that names a product no reference product matches exactly falls back to a
-  prefix of that name, and the index from a prefix to its producer keeps one
-  producer, whichever the map happened to hold last, in activity-identifier
-  order. In Agribalyse 4.0, 2797 prefixes name several producers. Every
-  identifier moved here, so the producer kept moved with it: sunflower grain now
-  draws its urea from the Chinese market rather than the North American one, and
-  its organic-carcinogen score with it. Measured over 250 activities, half the
-  category readings move, by 0.13% at the median and by up to 43%. The choice
-  was already arbitrary; what changed is which arbitrary answer comes out.
+- An input is no longer answered with a supplier the file did not name. When a
+  product name matched no reference product, the engine fell back to a prefix of
+  that name: the text before the first `//`, ` {`, ` [` or ` |`. What follows
+  those separators is the geography and the model variant, which is exactly what
+  tells two producers apart, so `Urea {RoW}| urea production` was answered with
+  whichever activity named `Urea …` the map happened to hold last. Measured on
+  ten SimaPro exports the rule earns nothing: on seven of them every input
+  already has an exact producer, and it fires on ten rows of one Agribalyse 4.0
+  export and one row of Ginko, eight of those eleven choosing among several
+  candidates. Between databases it is worse: of the 169 lines pastoeco resolves
+  in Agribalyse 3.2, 148 match by name and 21 by prefix, 17 of them ambiguously,
+  one choosing among 148 electricity markets. The rule is gone on both sides. An
+  input nobody supplies stays unlinked, and the cross-database linker gets its
+  turn on it.
+- Scores of a SimaPro database fall where an invented supplier used to be
+  counted. On the Agribalyse 4.0 export of 13 May 2026, ten inputs name
+  ecoinvent unit processes the export does not carry: four French fertiliser
+  mixes and one lorry. They were being answered with a market of another
+  geography, so every product fertilised in France carried a burden its file
+  never asked for. Over a sample of 250 activities half the category readings
+  move, and every one of them moves down, by 0.5% at the median and by up to
+  56%. The engine reports those ten as unlinked, where it used to report 169113
+  of 169113 resolved.
+- When several activities produce one product name, which of them supplies an
+  input no longer depends on the identifiers: the first by activity name, then
+  by location, wins. They are duplicates of each other, a block exported twice
+  under a name differing by a typo, so either answers; what must not happen is
+  the answer moving because identity is minted differently.
 - Every database cache is rebuilt on first load.
 
 ## [0.11.0] - 2026-08-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,9 +78,21 @@
   of 169113 resolved.
 - When several activities produce one product name, which of them supplies an
   input no longer depends on the identifiers: the first by activity name, then
-  by location, wins. They are duplicates of each other, a block exported twice
-  under a name differing by a typo, so either answers; what must not happen is
-  the answer moving because identity is minted differently.
+  by location, wins. What that rule cannot know is which twin the file meant:
+  on Agribalyse 4.0 it lands on the retired copy of the pork slaughterhouse
+  block, because "whitout" sorts before "without". Any rule would land
+  somewhere; what must not happen is the answer moving because identity is
+  minted differently, and what must not stay quiet is that a rule of ours
+  answered at all, which the next entry is for.
+- The quality report says when two activities declare one product. Which of
+  them answers an input naming it is settled by a rule of ours, on a question
+  only the file can settle, so the file has to be told. The duplicate-activities
+  check cannot see these, because it groups on the activity name and the two
+  spell theirs differently. On the Agribalyse 4.0 export of 13 May 2026 it finds
+  twenty, and they are one case: the pork slaughterhouse block shipped twice,
+  once current and once retired under `Autres\Obsolete`, their process names a
+  typo apart ("whitout" against "without"), declaring the same ten products. The
+  retired one is what currently supplies the whole downstream pork chain.
 - The quality report gains the other half of a pair it only had one side of: an
   input naming a product no reference product of this database supplies, beside
   the reference product nothing consumes. Expected of a foreground database,

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -462,8 +462,8 @@ engine reports ``success=false``.
 Write new activities into a database that can hold them.
 
 Each activity's ``process_id`` is minted by the engine from its name,
-its location and its product name, case-insensitively (you do not
-choose it), and comes back in ``written``. Writing the same activity twice is therefore
+its location, and its product name and unit (you do not choose it),
+and comes back in ``written``. Writing the same activity twice is therefore
 a conflict, not a second row; use `replace_activity` to correct
 one that is already there.
 
@@ -951,8 +951,8 @@ Returns the updated ``DatabaseSetupInfo`` dict.
 Rewrite one activity the database already holds, keeping its identity.
 
 ``process_id`` must be the identity ``activity`` mints to; that is,
-the name, the location and the product name must be the ones the row
-already has, up to case. Change any of those and you are describing a different
+the name, the location, and the product name and unit must be the ones
+the row already has, spelling and case included. Change any of those and you are describing a different
 activity, which the engine refuses rather than writing to a second row;
 create that one and delete the old one instead.
 
@@ -1368,8 +1368,8 @@ The inventory is three lists rather than one, so a field that means
 something on a supplier link cannot be sent on an emission.
 
 You do not choose the ``process_id``. The engine mints it from the name,
-the location and the product name, case-insensitively, which is what makes
-writing the same activity twice a correction of one row rather than two. One
+the location, and the product name and unit, which is what makes writing
+the same activity twice a correction of one row rather than two. One
 reference product per activity: coproducts and allocation are not supported
 yet, and this type does not pretend they are.
 

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -462,8 +462,8 @@ engine reports ``success=false``.
 Write new activities into a database that can hold them.
 
 Each activity's ``process_id`` is minted by the engine from its name,
-location, product name and product unit (you do not choose it), and
-comes back in ``written``. Writing the same activity twice is therefore
+its location and its product name, case-insensitively (you do not
+choose it), and comes back in ``written``. Writing the same activity twice is therefore
 a conflict, not a second row; use `replace_activity` to correct
 one that is already there.
 
@@ -951,8 +951,8 @@ Returns the updated ``DatabaseSetupInfo`` dict.
 Rewrite one activity the database already holds, keeping its identity.
 
 ``process_id`` must be the identity ``activity`` mints to; that is,
-the name, location, product name and product unit must be the ones the
-row already has. Change any of those and you are describing a different
+the name, the location and the product name must be the ones the row
+already has, up to case. Change any of those and you are describing a different
 activity, which the engine refuses rather than writing to a second row;
 create that one and delete the old one instead.
 
@@ -1368,8 +1368,8 @@ The inventory is three lists rather than one, so a field that means
 something on a supplier link cannot be sent on an emission.
 
 You do not choose the ``process_id``. The engine mints it from the name,
-location, product name and product unit, which is what makes writing the
-same activity twice a correction of one row rather than two rows. One
+the location and the product name, case-insensitively, which is what makes
+writing the same activity twice a correction of one row rather than two. One
 reference product per activity: coproducts and allocation are not supported
 yet, and this type does not pretend they are.
 

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -1007,8 +1007,8 @@ class Client:
         """Write new activities into a database that can hold them.
 
         Each activity's ``process_id`` is minted by the engine from its name,
-        its location and its product name, case-insensitively (you do not
-        choose it), and comes back in ``written``. Writing the same activity twice is therefore
+        its location, and its product name and unit (you do not choose it),
+        and comes back in ``written``. Writing the same activity twice is therefore
         a conflict, not a second row; use :meth:`replace_activity` to correct
         one that is already there.
 
@@ -1048,8 +1048,8 @@ class Client:
         """Rewrite one activity the database already holds, keeping its identity.
 
         ``process_id`` must be the identity ``activity`` mints to; that is,
-        the name, the location and the product name must be the ones the row
-        already has, up to case. Change any of those and you are describing a different
+        the name, the location, and the product name and unit must be the ones
+        the row already has, spelling and case included. Change any of those and you are describing a different
         activity, which the engine refuses rather than writing to a second row;
         create that one and delete the old one instead.
 

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -1007,8 +1007,8 @@ class Client:
         """Write new activities into a database that can hold them.
 
         Each activity's ``process_id`` is minted by the engine from its name,
-        location, product name and product unit (you do not choose it), and
-        comes back in ``written``. Writing the same activity twice is therefore
+        its location and its product name, case-insensitively (you do not
+        choose it), and comes back in ``written``. Writing the same activity twice is therefore
         a conflict, not a second row; use :meth:`replace_activity` to correct
         one that is already there.
 
@@ -1048,8 +1048,8 @@ class Client:
         """Rewrite one activity the database already holds, keeping its identity.
 
         ``process_id`` must be the identity ``activity`` mints to; that is,
-        the name, location, product name and product unit must be the ones the
-        row already has. Change any of those and you are describing a different
+        the name, the location and the product name must be the ones the row
+        already has, up to case. Change any of those and you are describing a different
         activity, which the engine refuses rather than writing to a second row;
         create that one and delete the old one instead.
 

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -2173,8 +2173,8 @@ class ActivityInput:
     something on a supplier link cannot be sent on an emission.
 
     You do not choose the ``process_id``. The engine mints it from the name,
-    location, product name and product unit, which is what makes writing the
-    same activity twice a correction of one row rather than two rows. One
+    the location and the product name, case-insensitively, which is what makes
+    writing the same activity twice a correction of one row rather than two. One
     reference product per activity: coproducts and allocation are not supported
     yet, and this type does not pretend they are.
     """

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -2173,8 +2173,8 @@ class ActivityInput:
     something on a supplier link cannot be sent on an emission.
 
     You do not choose the ``process_id``. The engine mints it from the name,
-    the location and the product name, case-insensitively, which is what makes
-    writing the same activity twice a correction of one row rather than two. One
+    the location, and the product name and unit, which is what makes writing
+    the same activity twice a correction of one row rather than two. One
     reference product per activity: coproducts and allocation are not supported
     yet, and this type does not pretend they are.
     """

--- a/src/API/Csv.hs
+++ b/src/API/Csv.hs
@@ -59,6 +59,7 @@ qualityReportCsv r =
         , ("truncated_name_collisions", qraTruncatedNameCollisions r)
         , ("missing_pedigree", qraMissingPedigree r)
         , ("unconsumed_products", qraUnconsumedProducts r)
+        , ("unsupplied_inputs", qraUnsuppliedInputs r)
         , ("land_transformation_balance", qraLandTransformationBalance r)
         , ("oxygen_demand_order", qraOxygenDemandOrder r)
         , ("invalid_cas", qraInvalidCas r)

--- a/src/API/Csv.hs
+++ b/src/API/Csv.hs
@@ -52,6 +52,7 @@ qualityReportCsv r =
         [ ("reference_product", qraReferenceProduct r)
         , ("allocation_sums", qraAllocationSums r)
         , ("duplicate_activities", qraDuplicateActivities r)
+        , ("duplicate_products", qraDuplicateProducts r)
         , ("suspicious_amounts", qraSuspiciousAmounts r)
         , ("missing_metadata", qraMissingMetadata r)
         , ("undeclared_geography", qraUndeclaredGeography r)

--- a/src/API/Csv.hs
+++ b/src/API/Csv.hs
@@ -61,6 +61,7 @@ qualityReportCsv r =
         , ("missing_pedigree", qraMissingPedigree r)
         , ("unconsumed_products", qraUnconsumedProducts r)
         , ("unsupplied_inputs", qraUnsuppliedInputs r)
+        , ("obsolete_inputs", qraObsoleteInputs r)
         , ("land_transformation_balance", qraLandTransformationBalance r)
         , ("oxygen_demand_order", qraOxygenDemandOrder r)
         , ("invalid_cas", qraInvalidCas r)

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -403,6 +403,7 @@ qualityReportToAPI mLimit r =
         , qraTruncatedNameCollisions = checkToAPI mLimit (Quality.qrTruncatedNameCollisions r)
         , qraMissingPedigree = checkToAPI mLimit (Quality.qrMissingPedigree r)
         , qraUnconsumedProducts = checkToAPI mLimit (Quality.qrUnconsumedProducts r)
+        , qraUnsuppliedInputs = checkToAPI mLimit (Quality.qrUnsuppliedInputs r)
         , qraLandTransformationBalance = checkToAPI mLimit (Quality.qrLandTransformationBalance r)
         , qraOxygenDemandOrder = checkToAPI mLimit (Quality.qrOxygenDemandOrder r)
         , qraInvalidCas = checkToAPI mLimit (Quality.qrInvalidCas r)

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -405,6 +405,7 @@ qualityReportToAPI mLimit r =
         , qraMissingPedigree = checkToAPI mLimit (Quality.qrMissingPedigree r)
         , qraUnconsumedProducts = checkToAPI mLimit (Quality.qrUnconsumedProducts r)
         , qraUnsuppliedInputs = checkToAPI mLimit (Quality.qrUnsuppliedInputs r)
+        , qraObsoleteInputs = checkToAPI mLimit (Quality.qrObsoleteInputs r)
         , qraLandTransformationBalance = checkToAPI mLimit (Quality.qrLandTransformationBalance r)
         , qraOxygenDemandOrder = checkToAPI mLimit (Quality.qrOxygenDemandOrder r)
         , qraInvalidCas = checkToAPI mLimit (Quality.qrInvalidCas r)

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -396,6 +396,7 @@ qualityReportToAPI mLimit r =
         , qraReferenceProduct = checkToAPI mLimit (Quality.qrReferenceProduct r)
         , qraAllocationSums = checkToAPI mLimit (Quality.qrAllocationSums r)
         , qraDuplicateActivities = checkToAPI mLimit (Quality.qrDuplicateActivities r)
+        , qraDuplicateProducts = checkToAPI mLimit (Quality.qrDuplicateProducts r)
         , qraSuspiciousAmounts = checkToAPI mLimit (Quality.qrSuspiciousAmounts r)
         , qraMissingMetadata = checkToAPI mLimit (Quality.qrMissingMetadata r)
         , qraUndeclaredGeography = checkToAPI mLimit (Quality.qrUndeclaredGeography r)

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -965,6 +965,7 @@ data QualityReportAPI = QualityReportAPI
     , qraMissingPedigree :: QualityCheckAPI
     , qraUnconsumedProducts :: QualityCheckAPI
     , qraUnsuppliedInputs :: QualityCheckAPI
+    , qraObsoleteInputs :: QualityCheckAPI
     , qraLandTransformationBalance :: QualityCheckAPI
     , qraOxygenDemandOrder :: QualityCheckAPI
     , qraInvalidCas :: QualityCheckAPI

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -956,6 +956,7 @@ data QualityReportAPI = QualityReportAPI
     , qraReferenceProduct :: QualityCheckAPI
     , qraAllocationSums :: QualityCheckAPI
     , qraDuplicateActivities :: QualityCheckAPI
+    , qraDuplicateProducts :: QualityCheckAPI
     , qraSuspiciousAmounts :: QualityCheckAPI
     , qraMissingMetadata :: QualityCheckAPI
     , qraUndeclaredGeography :: QualityCheckAPI

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -963,6 +963,7 @@ data QualityReportAPI = QualityReportAPI
     , qraTruncatedNameCollisions :: QualityCheckAPI
     , qraMissingPedigree :: QualityCheckAPI
     , qraUnconsumedProducts :: QualityCheckAPI
+    , qraUnsuppliedInputs :: QualityCheckAPI
     , qraLandTransformationBalance :: QualityCheckAPI
     , qraOxygenDemandOrder :: QualityCheckAPI
     , qraInvalidCas :: QualityCheckAPI

--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -73,6 +73,7 @@ import Progress (ProgressLevel (..), reportProgress)
 import SimaPro.Parser (
     generateFlowUUID,
     generateUnitUUID,
+    indexFlows,
     normalizeSimaProCompartment,
  )
 import Types
@@ -133,15 +134,13 @@ parseBrightwayExcel cfg path = do
                 bioFlows = concat [fs | (_, _, fs, _, _) <- results]
                 units = concat [us | (_, _, _, us, _) <- results]
                 warnings = concat [ws | (_, _, _, _, ws) <- results] ++ mapMaybe skippedSheetWarning skipped
+                unitDB = M.fromList [(unitId u, u) | u <- units]
+                unitNames = M.map unitName unitDB
             mapM_ (reportProgress Warning . T.unpack) warnings
-            pure $
-                Right
-                    ( activities
-                    , M.fromList [(tfId f, f) | f <- techFlows]
-                    , M.fromList [(bfId f, f) | f <- bioFlows]
-                    , M.empty
-                    , M.fromList [(unitId u, u) | u <- units]
-                    )
+            pure $ do
+                techFlowDB <- indexFlows unitNames (\f -> (tfId f, tfUnitId f, tfName f)) techFlows
+                bioFlowDB <- indexFlows unitNames (\f -> (bfId f, bfUnitId f, bfName f)) bioFlows
+                pure (activities, techFlowDB, bioFlowDB, M.empty, unitDB)
 
 {- | A worksheet is imported only when its first cell (A1) is a non-empty string
 that is not the sentinel @"skip"@ (matches @bw2io@'s @valid_first_cell@).

--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -379,7 +379,7 @@ productRowOut cfg meta isRef f =
     rawUnit = fromMaybe "" (fieldText f "unit" <|> metaText meta "unit")
     rawAmount = fromMaybe 1 (fieldNum f "amount" <|> metaNum meta "production amount")
     (effUnit, effAmount) = canonicalRow cfg rawUnit rawAmount
-    flowUUID = generateFlowUUID name "" effUnit
+    flowUUID = generateFlowUUID name ""
     unitUUID = generateUnitUUID effUnit
     exch =
         TechnosphereExchange
@@ -420,7 +420,7 @@ technosphereRowOut cfg actName f
   where
     name = fromMaybe "" (fieldText f "reference product" <|> fieldText f "name")
     (unitName', amount) = canonicalRow cfg (fromMaybe "" (fieldText f "unit")) (fromMaybe 0 (fieldNum f "amount"))
-    flowUUID = generateFlowUUID name "" unitName'
+    flowUUID = generateFlowUUID name ""
     unitUUID = generateUnitUUID unitName'
     exch =
         TechnosphereExchange
@@ -450,7 +450,7 @@ biosphereRowOut cfg actName f
     name = fromMaybe "" (fieldText f "name")
     (unitName', amount) = canonicalRow cfg (fromMaybe "" (fieldText f "unit")) (fromMaybe 0 (fieldNum f "amount"))
     (comp, sub) = splitCategories (fromMaybe "" (fieldText f "categories"))
-    flowUUID = generateFlowUUID name (normalizeSimaProCompartment comp sub) unitName'
+    flowUUID = generateFlowUUID name (normalizeSimaProCompartment comp sub)
     unitUUID = generateUnitUUID unitName'
     exch =
         BiosphereExchange

--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -71,6 +71,7 @@ import qualified Data.Vector as V
 import EcoSpold.Common (numericRefChar)
 import Progress (ProgressLevel (..), reportProgress)
 import SimaPro.Parser (
+    canonicalRow,
     generateFlowUUID,
     generateUnitUUID,
     indexFlows,
@@ -377,9 +378,7 @@ productRowOut cfg meta isRef f =
             fieldText f "reference product" <|> fieldText f "name" <|> metaText meta "reference product"
     rawUnit = fromMaybe "" (fieldText f "unit" <|> metaText meta "unit")
     rawAmount = fromMaybe 1 (fieldNum f "amount" <|> metaNum meta "production amount")
-    (effUnit, effAmount)
-        | isRef = fromMaybe (rawUnit, rawAmount) (UC.normalizeToCanonical cfg rawUnit rawAmount)
-        | otherwise = (rawUnit, rawAmount)
+    (effUnit, effAmount) = canonicalRow cfg rawUnit rawAmount
     flowUUID = generateFlowUUID name "" effUnit
     unitUUID = generateUnitUUID effUnit
     exch =
@@ -399,10 +398,10 @@ productRowOut cfg meta isRef f =
 
 -- | Build a technosphere or biosphere exchange from a non-production row.
 exchangeRowOut :: UC.UnitConfig -> Text -> M.Map Text CellValue -> RowOut
-exchangeRowOut _cfg actName f =
+exchangeRowOut cfg actName f =
     case T.toLower <$> fieldText f "type" of
-        Just "technosphere" -> technosphereRowOut actName f
-        Just "biosphere" -> biosphereRowOut actName f
+        Just "technosphere" -> technosphereRowOut cfg actName f
+        Just "biosphere" -> biosphereRowOut cfg actName f
         Just other ->
             emptyRowOut{roWarn = ["activity '" <> actName <> "': skipped exchange with unrecognized type '" <> other <> "'"]}
         Nothing ->
@@ -413,15 +412,14 @@ key 'Database.Loader.buildSupplierIndexByName' matches against), with the
 supplier location preserved for geography-aware cross-DB linking. Zero-amount
 rows are dropped (parity with the SimaPro importer).
 -}
-technosphereRowOut :: Text -> M.Map Text CellValue -> RowOut
-technosphereRowOut actName f
+technosphereRowOut :: UC.UnitConfig -> Text -> M.Map Text CellValue -> RowOut
+technosphereRowOut cfg actName f
     | T.null name = emptyRowOut{roWarn = ["activity '" <> actName <> "': skipped technosphere row with no name"]}
     | amount == 0 = emptyRowOut
     | otherwise = RowOut (Just exch) [flow] [] [unit] []
   where
     name = fromMaybe "" (fieldText f "reference product" <|> fieldText f "name")
-    unitName' = fromMaybe "" (fieldText f "unit")
-    amount = fromMaybe 0 (fieldNum f "amount")
+    (unitName', amount) = canonicalRow cfg (fromMaybe "" (fieldText f "unit")) (fromMaybe 0 (fieldNum f "amount"))
     flowUUID = generateFlowUUID name "" unitName'
     unitUUID = generateUnitUUID unitName'
     exch =
@@ -444,14 +442,13 @@ a @natural resource@ compartment is read as an extraction ('Resource'),
 everything else as an 'Emission'. Flow UUIDs use the same normalized
 compartment string as the SimaPro importer so LCIA characterization matches.
 -}
-biosphereRowOut :: Text -> M.Map Text CellValue -> RowOut
-biosphereRowOut actName f
+biosphereRowOut :: UC.UnitConfig -> Text -> M.Map Text CellValue -> RowOut
+biosphereRowOut cfg actName f
     | T.null name = emptyRowOut{roWarn = ["activity '" <> actName <> "': skipped biosphere row with no name"]}
     | otherwise = RowOut (Just exch) [] [flow] [unit] []
   where
     name = fromMaybe "" (fieldText f "name")
-    unitName' = fromMaybe "" (fieldText f "unit")
-    amount = fromMaybe 0 (fieldNum f "amount")
+    (unitName', amount) = canonicalRow cfg (fromMaybe "" (fieldText f "unit")) (fromMaybe 0 (fieldNum f "amount"))
     (comp, sub) = splitCategories (fromMaybe "" (fieldText f "categories"))
     flowUUID = generateFlowUUID name (normalizeSimaProCompartment comp sub) unitName'
     unitUUID = generateUnitUUID unitName'

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -131,9 +131,10 @@ module header on why @milk@ in @kg@ and @milk@ in @l@ are two flows.
 authoredProductUUID :: Text -> Text -> UUID
 authoredProductUUID productName unit = mintAuthored ["product", productName, unit]
 
-{- | Identity of a biosphere flow an author introduces. Same three coordinates
-the SimaPro parser mints on (name, compartment, unit), so re-declaring the
-same flow in a second activity reuses the first one instead of forking it.
+{- | Identity of a biosphere flow an author introduces: name, compartment and
+unit, so re-declaring the same flow in a second activity reuses the first one
+instead of forking it. An imported flow is identified by what its file says
+instead, which for SimaPro is the name and the compartment alone.
 -}
 authoredBioFlowUUID :: Text -> Compartment -> Text -> UUID
 authoredBioFlowUUID name comp unit =

--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -717,9 +717,6 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
                 Nothing -> []
          in firstNonEmpty [byExact, bySynonym]
 
-    -- Try each prefix from compound name splitting; for each prefix run the
-    -- same (exact, then synonym) sub-cascade; return the first prefix that
-    -- yields anything.
     classifyEntry :: Text -> (Text, SupplierEntry) -> Maybe ((Text, SupplierEntry), LocationKind)
     classifyEntry queryLoc entry@(_, SupplierEntry{seLocation}) =
         case acceptableLocation lcGeographyPolicy lcLocationHierarchy (Location queryLoc) (Location seLocation) of

--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -66,10 +66,7 @@ module Database.CrossLinking (
     locationHierarchy,
 
     -- * Compound Name Parsing
-    extractProductPrefixes,
     extractBracketedLocation,
-    stripTrailingDBTag,
-    stripTrailingLocationSuffix,
 
     -- * Text Normalization
     normalizeText,
@@ -78,7 +75,7 @@ module Database.CrossLinking (
 
 import Control.Applicative ((<|>))
 import Data.Bifunctor (first)
-import Data.Char (isAlpha, isUpper)
+import Data.Char (isUpper)
 import Data.Foldable (find)
 import Data.List (maximumBy, nub)
 import qualified Data.Map.Strict as M
@@ -297,82 +294,6 @@ normalizeUnicode = T.map replaceChar
 normalizeText :: Text -> Text
 normalizeText = T.toLower . T.strip . normalizeUnicode
 
-{- | Separators that may appear between product name and additional info
-in SimaPro compound process names (e.g. "product//[GLO] activity name").
-Ordered by priority.
--}
-compoundSeparators :: [Text]
-compoundSeparators = ["//", " {", " [", " |"]
-
-{- | Strip a trailing database tag from a product name.
-Matches patterns like "(WFLDB)", "(AGRIBALYSE)", "(SALCA)" — a parenthesized
-suffix where the content is all uppercase letters.
-Returns Just strippedName if a tag was found, Nothing otherwise.
--}
-stripTrailingDBTag :: Text -> Maybe Text
-stripTrailingDBTag name
-    | T.null name = Nothing
-    | T.last name /= ')' = Nothing
-    | otherwise =
-        let withoutClose = T.init name -- drop trailing ')'
-            (before, tag) = T.breakOnEnd "(" withoutClose
-         in if T.null before
-                then Nothing -- no opening paren found
-                else
-                    let prefix = T.init before -- drop the '(' at end of 'before'
-                        stripped = T.strip prefix
-                     in if not (T.null tag)
-                            && T.all (\c -> isUpper c || c == '-') tag
-                            && T.any isAlpha tag -- at least one letter
-                            && not (T.null stripped)
-                            then Just stripped
-                            else Nothing
-
-{- | Strip a trailing @\/LOCATION MARKER@ suffix from a product name.
-WFLDB names use the pattern @ProductName (WFLDB)\/CA U@ where the suffix
-encodes location (2-3 uppercase letters) and unit type (1 uppercase letter).
--}
-stripTrailingLocationSuffix :: Text -> Maybe Text
-stripTrailingLocationSuffix name =
-    case T.breakOnEnd "/" name of
-        ("", _) -> Nothing
-        (beforeSlash, afterSlash) ->
-            case T.words afterSlash of
-                [loc, marker]
-                    | T.length loc >= 2
-                    , T.length loc <= 3
-                    , T.all isUpper loc
-                    , T.length marker == 1
-                    , T.all isUpper marker ->
-                        Just (T.stripEnd (T.init beforeSlash))
-                _ -> Nothing
-
-{- | Extract product name prefixes from a compound name.
-Tries splitting at each separator and returns candidate prefixes (stripped).
-Also tries stripping a trailing database tag like "(WFLDB)" and a trailing
-location suffix like "/CA U" (WFLDB convention).
-Returns empty list if no separator is found and no tag detected.
--}
-extractProductPrefixes :: Text -> [Text]
-extractProductPrefixes name =
-    let separatorPrefixes =
-            [ T.strip prefix
-            | sep <- compoundSeparators
-            , let (prefix, rest) = T.breakOn sep name
-            , not (T.null rest) -- separator was found
-            , not (T.null prefix) -- non-empty prefix
-            ]
-        tagStripped = case stripTrailingDBTag name of
-            Just stripped -> [stripped]
-            Nothing -> []
-        locationSuffixStripped = case stripTrailingLocationSuffix name of
-            Just stripped ->
-                stripped : case stripTrailingDBTag stripped of
-                    Just alsoTagStripped -> [alsoTagStripped]
-                    Nothing -> []
-            Nothing -> []
-     in separatorPrefixes ++ tagStripped ++ locationSuffixStripped
-
 {- | Extract a location code from any bracket pattern in a name.
 Tries {XX} first (standard LCA geography notation), then [XX] with
 validation to avoid chemical notation like [thio] or metadata like [Dummy].
@@ -408,14 +329,14 @@ This should be called once when a database is loaded
 buildIndexedDatabase :: Text -> SynonymDB -> SimpleDatabase -> IndexedDatabase
 buildIndexedDatabase dbName synDB db =
     let entries = buildSupplierEntries db
-        -- Index by normalized product name + extracted prefixes
+        -- Index by normalized product name, and by nothing else: a prefix of
+        -- a product name is a different product.
         byName =
             M.fromListWith
                 (++)
-                [ (normalizeText name, [entry])
+                [ (normalizeText prodName, [entry])
                 | (prodName, entry) <- entries
-                , name <- prodName : extractProductPrefixes prodName
-                , not (T.null (normalizeText name))
+                , not (T.null (normalizeText prodName))
                 ]
         -- Index by synonym group (for synonym matching)
         bySynonym =
@@ -481,14 +402,14 @@ This is the preferred method as it works with cached databases
 buildIndexedDatabaseFromDB :: Text -> SynonymDB -> Database -> IndexedDatabase
 buildIndexedDatabaseFromDB dbName synDB db =
     let entries = buildSupplierEntriesFromDB db
-        -- Index by normalized product name + extracted prefixes
+        -- Index by normalized product name, and by nothing else: a prefix of
+        -- a product name is a different product.
         byName =
             M.fromListWith
                 (++)
-                [ (normalizeText name, [entry])
+                [ (normalizeText prodName, [entry])
                 | (prodName, entry) <- entries
-                , name <- prodName : extractProductPrefixes prodName
-                , not (T.null (normalizeText name))
+                , not (T.null (normalizeText prodName))
                 ]
         -- Index by synonym group (for synonym matching)
         bySynonym =
@@ -665,14 +586,12 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
             -- non-empty result via 'firstNonEmpty':
             --   1. Exact product-name match across all indexed DBs.
             --   2. Synonym-group match if exact yielded nothing.
-            --   3. Prefix-splitting fallback for compound names (e.g. SimaPro).
             resolveCandidates $
                 firstNonEmpty
                     [ concatMap (lookupExact (normalizeText productName)) lcIndexedDatabases
                     , case lookupSynonymGroup lcSynonymDB (normalizeName productName) of
                         Just groupId -> concatMap (lookupBySynonym groupId) lcIndexedDatabases
                         Nothing -> []
-                    , tryPrefixes (extractProductPrefixes productName)
                     ]
   where
     -- Effective location: if raw location is empty, try extracting from compound name
@@ -681,13 +600,13 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
             then extractBracketedLocation productName
             else location
 
-    -- Resolve an alias row's designated target: the exact/synonym/prefix
-    -- sub-cascade on the target name, then either the normal geography-policy
-    -- pipeline (no pinned location) or the literal designated link. A target
-    -- name that matches nowhere is a loud curated-mapping error
-    -- ('AliasTargetMissing'), never a silent 'NoNameMatch'.
+    -- Resolve an alias row's designated target by its name, then either the
+    -- normal geography-policy pipeline (no pinned location) or the literal
+    -- designated link. A target name that matches nowhere is a loud
+    -- curated-mapping error ('AliasTargetMissing'), never a silent
+    -- 'NoNameMatch'.
     resolveDesignated (AliasTarget targetName mTargetLoc) =
-        case firstNonEmpty [tryName targetName, tryPrefixes (extractProductPrefixes targetName)] of
+        case tryName targetName of
             [] -> CrossDBNotLinked (AliasTargetMissing targetName Nothing)
             candidates -> case mTargetLoc of
                 Nothing -> resolveCandidates candidates
@@ -801,9 +720,6 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
     -- Try each prefix from compound name splitting; for each prefix run the
     -- same (exact, then synonym) sub-cascade; return the first prefix that
     -- yields anything.
-    tryPrefixes :: [Text] -> [(Text, SupplierEntry)]
-    tryPrefixes = firstNonEmpty . map tryName
-
     classifyEntry :: Text -> (Text, SupplierEntry) -> Maybe ((Text, SupplierEntry), LocationKind)
     classifyEntry queryLoc entry@(_, SupplierEntry{seLocation}) =
         case acceptableLocation lcGeographyPolicy lcLocationHierarchy (Location queryLoc) (Location seLocation) of

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -630,24 +630,26 @@ loadDatabaseWithLocationAliases unitConfig locationAliases path = do
 -- | Load SimaPro CSV file
 loadSimaProCSV :: UC.UnitConfig -> FilePath -> IO (Either T.Text SimpleDatabase)
 loadSimaProCSV unitConfig csvPath = do
-    (activities, techFlowDB, bioFlowDB, wasteFlowDB, unitDB) <- SimaPro.parseSimaProCSV unitConfig csvPath
+    parsed <- SimaPro.parseSimaProCSV unitConfig csvPath
+    case parsed of
+        Left err -> return (Left err)
+        Right (activities, techFlowDB, bioFlowDB, wasteFlowDB, unitDB) ->
+            if null activities
+                then return $ Left "No activities found in SimaPro CSV file."
+                else do
+                    -- Build ActivityMap with generated ProcessIds
+                    -- For SimaPro: use the same UUID for both activity and product (like EcoSpold1)
+                    let procMap =
+                            M.fromList
+                                [ ((SimaPro.generateActivityUUID act, getReferenceProductUUID act), act)
+                                | act <- activities
+                                ]
 
-    if null activities
-        then return $ Left "No activities found in SimaPro CSV file."
-        else do
-            -- Build ActivityMap with generated ProcessIds
-            -- For SimaPro: use the same UUID for both activity and product (like EcoSpold1)
-            let procMap =
-                    M.fromList
-                        [ ((SimaPro.generateActivityUUID act, getReferenceProductUUID act), act)
-                        | act <- activities
-                        ]
+                    -- Build initial database
+                    let simpleDb = SimpleDatabase procMap techFlowDB bioFlowDB wasteFlowDB unitDB
 
-            -- Build initial database
-            let simpleDb = SimpleDatabase procMap techFlowDB bioFlowDB wasteFlowDB unitDB
-
-            -- Fix activity links using supplier lookup (same as EcoSpold1)
-            Right <$> fixSimaProActivityLinks unitConfig simpleDb
+                    -- Fix activity links using supplier lookup (same as EcoSpold1)
+                    Right <$> fixSimaProActivityLinks unitConfig simpleDb
 
 {- | Load a Brightway Excel (.xlsx) inventory.
 

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -274,7 +274,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeRep (Proxy :: Proxy Database))
-     in hi `xor` lo `xor` 17
+     in hi `xor` lo `xor` 18
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -79,6 +79,7 @@ module Database.Loader (
     generateActivityUUIDFromActivity,
     datasetUUIDFromPath,
     getReferenceProductUUID,
+    indexActivities,
     UnlinkedSummary (..),
     buildSupplierIndex,
     buildSupplierIndexByName,
@@ -105,7 +106,7 @@ import qualified Data.Map as M
 -- per dataset) is real, and the lazy API would stack one unforced merge per
 -- occurrence, holding every superseded record until something forced the chain.
 import qualified Data.Map.Strict as MS
-import Data.Maybe (fromMaybe, isJust, isNothing)
+import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe)
 import Data.Ord (Down (..))
 import Data.Proxy (Proxy (..))
 import qualified Data.Set as S
@@ -321,6 +322,38 @@ getReferenceProductUUID act =
     case filter exchangeIsReference (exchanges act) of
         (ref : _) -> exchangeFlowId ref
         [] -> UUID.nil -- No reference product found
+
+{- | Key the activities of a name-linked file by @(activityUUID, productUUID)@,
+naming every key two blocks claimed.
+
+A block with no published identifier is named by its name folded in case and
+its location, so two blocks whose names differ only in case claim one key, and
+a map keeps one activity: the last read, as 'M.fromList' always did. Keeping it
+in silence is what is not acceptable, since the other block's inventory goes
+with it, so each contested key is described for the caller to report.
+-}
+indexActivities :: [Activity] -> (ActivityMap, [T.Text])
+indexActivities activities =
+    (M.map NE.head grouped, mapMaybe contested (M.elems grouped))
+  where
+    grouped :: M.Map (UUID.UUID, UUID.UUID) (NE.NonEmpty Activity)
+    grouped =
+        M.fromListWith
+            (<>)
+            [ ((SimaPro.generateActivityUUID act, getReferenceProductUUID act), pure act)
+            | act <- activities
+            ]
+    contested :: NE.NonEmpty Activity -> Maybe T.Text
+    contested group = describe (NE.head group) . NE.toList <$> snd (NE.uncons group)
+    describe :: Activity -> [Activity] -> T.Text
+    describe kept dropped =
+        "'"
+            <> activityName kept
+            <> "' and "
+            <> T.intercalate ", " ["'" <> activityName act <> "'" | act <- dropped]
+            <> " are one activity at '"
+            <> activityLocation kept
+            <> "': they differ only in case, no process identifier tells them apart, and only the last read keeps its inventory"
 
 -- | Type alias for supplier lookup index (with location)
 type SupplierIndex = M.Map (T.Text, T.Text) (UUID.UUID, UUID.UUID)
@@ -652,11 +685,8 @@ loadSimaProCSV unitConfig csvPath = do
                 else do
                     -- Build ActivityMap with generated ProcessIds
                     -- For SimaPro: use the same UUID for both activity and product (like EcoSpold1)
-                    let procMap =
-                            M.fromList
-                                [ ((SimaPro.generateActivityUUID act, getReferenceProductUUID act), act)
-                                | act <- activities
-                                ]
+                    let (procMap, collisions) = indexActivities activities
+                    forM_ collisions $ reportProgress Warning . T.unpack
 
                     -- Build initial database
                     let simpleDb = SimpleDatabase procMap techFlowDB bioFlowDB wasteFlowDB unitDB
@@ -680,12 +710,9 @@ loadBrightwayExcel unitConfig xlsxPath = do
         Right (activities, techFlowDB, bioFlowDB, wasteFlowDB, unitDB)
             | null activities -> return $ Left "No activities found in Brightway Excel file."
             | otherwise -> do
-                let procMap =
-                        M.fromList
-                            [ ((SimaPro.generateActivityUUID act, getReferenceProductUUID act), act)
-                            | act <- activities
-                            ]
+                let (procMap, collisions) = indexActivities activities
                     simpleDb = SimpleDatabase procMap techFlowDB bioFlowDB wasteFlowDB unitDB
+                forM_ collisions $ reportProgress Warning . T.unpack
                 Right <$> fixSimaProActivityLinks unitConfig simpleDb
 
 {- | Fix SimaPro activity links by resolving supplier references

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -424,22 +424,26 @@ buildSupplierIndex activities techFlowDb =
 product name and nothing else.
 
 When several activities produce one product name they are duplicates of each
-other, a block exported twice under a name that differs by a typo, and either
-answers. Which one is picked must not depend on the identifiers, or a change in
-how identity is minted would silently move the supply chain: the first by
-activity name, then by location, wins. The identifier breaks a tie only between
-two rows the file itself gives no way to tell apart.
+other, a block exported twice, most often because one of the two has been
+retired. The file says which: a retired block is filed under an obsolete
+category, and 'activityIsObsolete' reads it, so the block still in service
+supplies and the retired one supplies nothing. On the Agribalyse 4.0 export of
+13 May 2026 that settles all ten of its duplicated products.
+
+Two blocks the file gives no way to tell apart are ordered by activity name
+then by location, never by identifier: a change in how identity is minted must
+not move a supply chain. The identifier breaks the last tie only.
 
 The duplication is a defect in its own right, and 'Database.Quality' reports it
-as one.
+as one, along with an input a retired block supplies.
 -}
 buildSupplierIndexByName :: UnitDB -> ActivityMap -> TechFlowDB -> NameOnlyIndex
 buildSupplierIndexByName unitDB activities techFlowDb =
-    M.map (\candidates -> let (_, _, _, entry) = minimum candidates in entry) $
+    M.map (\candidates -> let (_, _, _, _, entry) = minimum candidates in entry) $
         M.fromListWith
             (<>)
             [ ( normalizeText (tfName flow)
-              , [(activityName act, activityLocation act, actUUID, (actUUID, prodUUID, getUnitNameForExchange unitDB ex))]
+              , [(activityIsObsolete act, activityName act, activityLocation act, actUUID, (actUUID, prodUUID, getUnitNameForExchange unitDB ex))]
               )
             | ((actUUID, prodUUID), act) <- M.toList activities
             , ex <- exchanges act

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -130,7 +130,6 @@ import Database.CrossLinking (
     defaultLinkingThreshold,
     emptyAliasMap,
     extractBracketedLocation,
-    extractProductPrefixes,
     findSupplierAcrossDatabases,
     findSupplierByActivityProduct,
     findWasteTreatmentAcrossDatabases,
@@ -421,28 +420,32 @@ buildSupplierIndex activities techFlowDb =
         , Just flow <- [M.lookup (exchangeFlowId ex) techFlowDb]
         ]
 
-{- | Build name-only supplier index for SimaPro linking
-Uses the normalized product name + extracted prefixes (no location required).
-Exact names take priority via M.union.
+{- | Build name-only supplier index for SimaPro linking, on the reference
+product name and nothing else.
+
+When several activities produce one product name they are duplicates of each
+other, a block exported twice under a name that differs by a typo, and either
+answers. Which one is picked must not depend on the identifiers, or a change in
+how identity is minted would silently move the supply chain: the first by
+activity name, then by location, wins. The identifier breaks a tie only between
+two rows the file itself gives no way to tell apart.
+
+The duplication is a defect in its own right, and 'Database.Quality' reports it
+as one.
 -}
 buildSupplierIndexByName :: UnitDB -> ActivityMap -> TechFlowDB -> NameOnlyIndex
 buildSupplierIndexByName unitDB activities techFlowDb =
-    let entries =
-            [ (tfName flow, (actUUID, prodUUID, getUnitNameForExchange unitDB ex))
+    M.map (\candidates -> let (_, _, _, entry) = minimum candidates in entry) $
+        M.fromListWith
+            (<>)
+            [ ( normalizeText (tfName flow)
+              , [(activityName act, activityLocation act, actUUID, (actUUID, prodUUID, getUnitNameForExchange unitDB ex))]
+              )
             | ((actUUID, prodUUID), act) <- M.toList activities
             , ex <- exchanges act
             , exchangeIsReference ex
             , Just flow <- [M.lookup (exchangeFlowId ex) techFlowDb]
             ]
-        exactIndex = M.fromList [(normalizeText name, val) | (name, val) <- entries]
-        prefixIndex =
-            M.fromList
-                [ (normalizeText p, val)
-                | (name, val) <- entries
-                , p <- extractProductPrefixes name
-                , normalizeText p /= normalizeText name
-                ]
-     in M.union exactIndex prefixIndex
 
 {- | Build the name-only supplier index for EcoSpold1 linking, keeping every
 dataset a name covers rather than the last one seen.
@@ -736,10 +739,13 @@ linkUnitsCompatible unitConfig consumerUnit supplierUnit =
 Inputs and non-reference outputs (coproducts / avoided-production credits)
 are eligible for relinking. A candidate is accepted only if its
 reference-product unit is dimensionally compatible with the consumer exchange
-('linkUnitsCompatible'); an incompatible candidate is skipped (falling through
-to the prefix fallback, then to unlinked) rather than forming a link the matrix
-builder cannot convert — which would otherwise abort the whole load. Returns
-(fixed exchange, UnlinkedSummary).
+('linkUnitsCompatible'); an incompatible candidate is skipped rather than
+forming a link the matrix builder cannot convert — which would otherwise abort
+the whole load.
+
+There is no second guess. An input naming a product no activity of this
+database produces stays unlinked, and the cross-database linker gets its turn
+on it. Returns (fixed exchange, UnlinkedSummary).
 -}
 fixExchangeLinkByName :: UC.UnitConfig -> UnitDB -> NameOnlyIndex -> TechFlowDB -> T.Text -> Exchange -> (Exchange, UnlinkedSummary)
 fixExchangeLinkByName unitConfig unitDB idx techFlowDb consumerName ex@TechnosphereExchange{techFlowId = fid, techRole = role, techLocation = loc}
@@ -757,18 +763,9 @@ fixExchangeLinkByName unitConfig unitDB idx techFlowDb consumerName ex@Technosph
                         Just (actUUID, prodUUID) ->
                             (relink actUUID prodUUID, UnlinkedSummary M.empty 1 1 0)
                         Nothing ->
-                            let prefixes = extractProductPrefixes (tfName flow)
-                                tryPrefix [] = Nothing
-                                tryPrefix (p : ps) = case M.lookup (normalizeText p) idx >>= accept of
-                                    Just result -> Just result
-                                    Nothing -> tryPrefix ps
-                             in case tryPrefix prefixes of
-                                    Just (actUUID, prodUUID) ->
-                                        (relink actUUID prodUUID, UnlinkedSummary M.empty 1 1 0)
-                                    Nothing ->
-                                        let unlinked = UnlinkedExchange (tfName flow) loc
-                                            unlinkedMap = M.singleton consumerName [unlinked]
-                                         in (ex, UnlinkedSummary unlinkedMap 1 0 1)
+                            let unlinked = UnlinkedExchange (tfName flow) loc
+                                unlinkedMap = M.singleton consumerName [unlinked]
+                             in (ex, UnlinkedSummary unlinkedMap 1 0 1)
             Nothing ->
                 -- Flow not in technosphere map — shouldn't happen but be safe
                 (ex, UnlinkedSummary M.empty 1 0 1)

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -266,6 +266,12 @@ History of manual bumps:
      identity of Database, never the types inside it, so an old cache would
      pass the check and be decoded reading 16-byte UUIDs as 4-byte row
      numbers, or one row number as a list of them.
+- 18: a dataset read from SimaPro or Brightway Excel is identified by the
+     identifier its file publishes, a flow by its name folded in case and its
+     compartment with no unit, and every row is recorded in the reference unit
+     of its dimension. Process ids, flow ids and amounts all move, and none of
+     it changes a type, so an old cache would pass the fingerprint and answer
+     with identifiers no request would name again.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1865,18 +1865,21 @@ loadDatabaseRawWithCrossDB dbName locationAliases sourcePath noCache synonymDB u
   where
     loadCSV csvFile = do
         reportProgress Info $ "Parsing SimaPro CSV: " <> csvFile
-        (activities, techFlowDB, bioFlowDB, wasteFlowDB, unitDB) <- SimaPro.parseSimaProCSV unitConfig csvFile
-        reportProgress Info $ "Building database from " <> show (length activities) <> " activities"
-        let simpleDb = SimpleDatabase (buildActivityMap activities) techFlowDB bioFlowDB wasteFlowDB unitDB
-        linkedDb <- Loader.fixSimaProActivityLinks unitConfig simpleDb
-        dbResult <- buildDatabaseWithMatrices unitConfig (sdbActivities linkedDb) techFlowDB bioFlowDB (sdbWasteFlows linkedDb) unitDB
-        case dbResult of
+        parsed <- SimaPro.parseSimaProCSV unitConfig csvFile
+        case parsed of
             Left err -> return $ Left err
-            Right db -> do
-                unless noCache $
-                    Loader.saveCachedDatabaseWithMatrices dbName sourcePath db
-                Loader.reportCrossDBLinkingStats (fromIntegral (dbActivityCount db)) (dbLinkingStats db)
-                return $ Right (db, False)
+            Right (activities, techFlowDB, bioFlowDB, wasteFlowDB, unitDB) -> do
+                reportProgress Info $ "Building database from " <> show (length activities) <> " activities"
+                let simpleDb = SimpleDatabase (buildActivityMap activities) techFlowDB bioFlowDB wasteFlowDB unitDB
+                linkedDb <- Loader.fixSimaProActivityLinks unitConfig simpleDb
+                dbResult <- buildDatabaseWithMatrices unitConfig (sdbActivities linkedDb) techFlowDB bioFlowDB (sdbWasteFlows linkedDb) unitDB
+                case dbResult of
+                    Left err -> return $ Left err
+                    Right db -> do
+                        unless noCache $
+                            Loader.saveCachedDatabaseWithMatrices dbName sourcePath db
+                        Loader.reportCrossDBLinkingStats (fromIntegral (dbActivityCount db)) (dbLinkingStats db)
+                        return $ Right (db, False)
 
     loadStructured path = do
         loadResult <-

--- a/src/Database/Quality.hs
+++ b/src/Database/Quality.hs
@@ -60,10 +60,12 @@ import Types (
     WasteFlow (..),
     activityGroupKey,
     activityIsObsolete,
+    exchangeActivityLinkId,
     exchangeAmount,
     exchangeFlowId,
     exchangeIsReference,
     exchangePedigree,
+    exchangeProcessLinkId,
     exchangeUnitId,
     processRefText,
  )
@@ -366,9 +368,25 @@ qualityReport dbName db =
         , n > 1
         ]
 
-    {- Two activities declaring one product. The supplier index is keyed by the
-    product, so an input naming it is answered by one of them and the others
-    supply nothing. Which one answers is settled by a rule of ours, on a
+    {- An input the file leaves the loader to place: it names a product and no
+    supplier. EcoSpold 2 names the supplying activity on the exchange itself,
+    so a product several activities declare is answered without any rule of
+    ours; SimaPro, Brightway and EcoSpold 1 let the product name speak alone,
+    and that is when a second declarer can take the answer.
+    -}
+    contestedProductIds =
+        S.fromList
+            [ exchangeFlowId ex
+            | (_, act) <- entries
+            , ex <- exchanges act
+            , needsSupplier ex
+            , isNothing (exchangeActivityLinkId ex)
+            , isNothing (exchangeProcessLinkId ex)
+            ]
+
+    {- Two activities declaring one product an input has to choose between. The
+    supplier index is keyed by the product, so an input naming it is answered
+    by one of them and the others supply nothing. Which one answers is settled by a rule of ours, on a
     question only the file can answer, and a stale twin left in an export wins
     as easily as the current entry. Reported per activity, each naming the
     others, so the maker can see both ends of the collision.
@@ -390,6 +408,7 @@ qualityReport dbName db =
         [ offender WarningSev key act (Just (anyFlowName fid)) $
             "this product is also the reference product of " <> otherProducerNames others <> "; an input naming it is answered by one of them"
         | (fid, group) <- M.toList productProducers
+        , fid `S.member` contestedProductIds
         , (key, act) <- group
         , let others = [a | (k, a) <- group, k /= key]
         , not (null others)

--- a/src/Database/Quality.hs
+++ b/src/Database/Quality.hs
@@ -10,7 +10,8 @@ amounts that aren't finite, missing metadata, stored amounts that disagree
 with the formulas documenting them, distinct names that merge under
 SimaPro's 80-character truncation, exchanges without the pedigree scores
 their database otherwise carries, reference products nothing in the
-database consumes, geography no dataset declared (read off the name
+database consumes, inputs no reference product in the database supplies,
+geography no dataset declared (read off the name
 or filled in by the loader instead), land transformation whose "to" and
 "from" areas don't balance within an activity, oxygen-demand or
 organic-carbon measures reported in a physically impossible order, CAS
@@ -111,6 +112,7 @@ data QualityReport = QualityReport
     , qrTruncatedNameCollisions :: !QualityCheck
     , qrMissingPedigree :: !QualityCheck
     , qrUnconsumedProducts :: !QualityCheck
+    , qrUnsuppliedInputs :: !QualityCheck
     , qrLandTransformationBalance :: !QualityCheck
     , qrOxygenDemandOrder :: !QualityCheck
     , qrInvalidCas :: !QualityCheck
@@ -135,6 +137,7 @@ qualityChecks r =
     , qrTruncatedNameCollisions r
     , qrMissingPedigree r
     , qrUnconsumedProducts r
+    , qrUnsuppliedInputs r
     , qrLandTransformationBalance r
     , qrOxygenDemandOrder r
     , qrInvalidCas r
@@ -236,6 +239,7 @@ qualityReport dbName db =
         , qrTruncatedNameCollisions = QualityCheck True (worstFirst truncationOffenders)
         , qrMissingPedigree = QualityCheck pedigreeApplicable (worstFirst pedigreeOffenders)
         , qrUnconsumedProducts = QualityCheck True (worstFirst unconsumedOffenders)
+        , qrUnsuppliedInputs = QualityCheck True (worstFirst unsuppliedOffenders)
         , qrLandTransformationBalance = QualityCheck landBalanceApplicable (worstFirst landBalanceOffenders)
         , qrOxygenDemandOrder = QualityCheck oxygenApplicable (worstFirst oxygenOffenders)
         , qrInvalidCas = QualityCheck casApplicable (worstFirst casOffenders)
@@ -522,6 +526,27 @@ qualityReport dbName db =
         , [refEx] <- [filter exchangeIsReference (exchanges act)]
         , exchangeFlowId refEx `S.notMember` usedFlowIds
         , let prodName = fromMaybe (UUID.toText (exchangeFlowId refEx)) (techOrWasteFlowName (exchangeFlowId refEx))
+        ]
+
+    {- The other direction: an input naming a product no reference product of
+    this database supplies. Expected of a foreground database, which draws its
+    background from another; a hole in one that is meant to stand alone. Either
+    way the engine says so rather than resolving the input to something else,
+    which is what a shortened or mistyped product name used to get.
+    -}
+    suppliedFlowIds =
+        S.fromList [exchangeFlowId ex | act <- acts, ex <- exchanges act, exchangeIsReference ex]
+    needsSupplier ex = case ex of
+        TechnosphereExchange{techRole = role} -> role `elem` [Input, ReferenceInput, Coproduct]
+        BiosphereExchange{} -> False
+        WasteExchange{} -> False
+    unsuppliedOffenders =
+        [ offender InfoSev key act (Just (anyFlowName fid)) "no reference product of this database supplies this input; it comes from a database this one depends on, or from nowhere"
+        | (key, act) <- entries
+        , ex <- exchanges act
+        , needsSupplier ex
+        , let fid = exchangeFlowId ex
+        , fid `S.notMember` suppliedFlowIds
         ]
 
     -- Land transformation is conserved: a parcel changed into one use was

--- a/src/Database/Quality.hs
+++ b/src/Database/Quality.hs
@@ -12,6 +12,7 @@ with the formulas documenting them, distinct names that merge under
 SimaPro's 80-character truncation, exchanges without the pedigree scores
 their database otherwise carries, reference products nothing in the
 database consumes, inputs no reference product in the database supplies,
+inputs a dataset the source retired supplies,
 geography no dataset declared (read off the name
 or filled in by the loader instead), land transformation whose "to" and
 "from" areas don't balance within an activity, oxygen-demand or
@@ -58,6 +59,7 @@ import Types (
     Unit (..),
     WasteFlow (..),
     activityGroupKey,
+    activityIsObsolete,
     exchangeAmount,
     exchangeFlowId,
     exchangeIsReference,
@@ -115,6 +117,7 @@ data QualityReport = QualityReport
     , qrMissingPedigree :: !QualityCheck
     , qrUnconsumedProducts :: !QualityCheck
     , qrUnsuppliedInputs :: !QualityCheck
+    , qrObsoleteInputs :: !QualityCheck
     , qrLandTransformationBalance :: !QualityCheck
     , qrOxygenDemandOrder :: !QualityCheck
     , qrInvalidCas :: !QualityCheck
@@ -141,6 +144,7 @@ qualityChecks r =
     , qrMissingPedigree r
     , qrUnconsumedProducts r
     , qrUnsuppliedInputs r
+    , qrObsoleteInputs r
     , qrLandTransformationBalance r
     , qrOxygenDemandOrder r
     , qrInvalidCas r
@@ -244,6 +248,7 @@ qualityReport dbName db =
         , qrMissingPedigree = QualityCheck pedigreeApplicable (worstFirst pedigreeOffenders)
         , qrUnconsumedProducts = QualityCheck True (worstFirst unconsumedOffenders)
         , qrUnsuppliedInputs = QualityCheck True (worstFirst unsuppliedOffenders)
+        , qrObsoleteInputs = QualityCheck True (worstFirst obsoleteInputOffenders)
         , qrLandTransformationBalance = QualityCheck landBalanceApplicable (worstFirst landBalanceOffenders)
         , qrOxygenDemandOrder = QualityCheck oxygenApplicable (worstFirst oxygenOffenders)
         , qrInvalidCas = QualityCheck casApplicable (worstFirst casOffenders)
@@ -580,6 +585,24 @@ qualityReport dbName db =
         , needsSupplier ex
         , let fid = exchangeFlowId ex
         , fid `S.notMember` suppliedFlowIds
+        ]
+
+    {- An input whose every producer is a dataset the source filed as obsolete.
+    Such a dataset still carries its exchanges and still computes, so the score
+    is a number; it is the superseded number, and its author expects it to be
+    replaced. The tool that writes these files raises the same warning when a
+    calculation reaches one. A product one obsolete block and one live block
+    both declare is not flagged: the live one supplies it.
+    -}
+    obsoleteProductIds =
+        M.keysSet (M.filter (all (activityIsObsolete . snd)) productProducers)
+    obsoleteInputOffenders =
+        [ offender WarningSev key act (Just (anyFlowName fid)) "this input is supplied only by a dataset its source filed as obsolete, which the source expects to be replaced"
+        | (key, act) <- entries
+        , ex <- exchanges act
+        , needsSupplier ex
+        , let fid = exchangeFlowId ex
+        , fid `S.member` obsoleteProductIds
         ]
 
     -- Land transformation is conserved: a parcel changed into one use was

--- a/src/Database/Quality.hs
+++ b/src/Database/Quality.hs
@@ -6,6 +6,7 @@ A score tells you whether a database computes; it says nothing about whether
 the dataset is well formed. These checks look for the structural defects a
 score can't reveal: processes without exactly one reference exchange,
 coproduct allocation that doesn't sum to 100%, entries duplicated outright,
+products two activities both declare,
 amounts that aren't finite, missing metadata, stored amounts that disagree
 with the formulas documenting them, distinct names that merge under
 SimaPro's 80-character truncation, exchanges without the pedigree scores
@@ -105,6 +106,7 @@ data QualityReport = QualityReport
     , qrReferenceProduct :: !QualityCheck
     , qrAllocationSums :: !QualityCheck
     , qrDuplicateActivities :: !QualityCheck
+    , qrDuplicateProducts :: !QualityCheck
     , qrSuspiciousAmounts :: !QualityCheck
     , qrMissingMetadata :: !QualityCheck
     , qrUndeclaredGeography :: !QualityCheck
@@ -130,6 +132,7 @@ qualityChecks r =
     [ qrReferenceProduct r
     , qrAllocationSums r
     , qrDuplicateActivities r
+    , qrDuplicateProducts r
     , qrSuspiciousAmounts r
     , qrMissingMetadata r
     , qrUndeclaredGeography r
@@ -232,6 +235,7 @@ qualityReport dbName db =
         , qrReferenceProduct = QualityCheck True (worstFirst referenceOffenders)
         , qrAllocationSums = QualityCheck allocationApplicable (worstFirst allocationOffenders)
         , qrDuplicateActivities = QualityCheck True (worstFirst duplicateOffenders)
+        , qrDuplicateProducts = QualityCheck True (worstFirst duplicateProductOffenders)
         , qrSuspiciousAmounts = QualityCheck True (worstFirst amountOffenders)
         , qrMissingMetadata = QualityCheck True (worstFirst metadataOffenders)
         , qrUndeclaredGeography = QualityCheck True (worstFirst geographyOffenders)
@@ -355,6 +359,35 @@ qualityReport dbName db =
             T.pack (show n) <> " identical entries (same name, location and reference product)"
         | ((name, location, productName), (Min pid, Sum n)) <- M.toList duplicateGroups
         , n > 1
+        ]
+
+    {- Two activities declaring one product. The supplier index is keyed by the
+    product, so an input naming it is answered by one of them and the others
+    supply nothing. Which one answers is settled by a rule of ours, on a
+    question only the file can answer, and a stale twin left in an export wins
+    as easily as the current entry. Reported per activity, each naming the
+    others, so the maker can see both ends of the collision.
+    -}
+    productProducers =
+        M.fromListWith
+            (<>)
+            [ (exchangeFlowId refEx, [(key, act)])
+            | (key, act) <- entries
+            , [refEx] <- [filter exchangeIsReference (exchanges act)]
+            ]
+    otherProducerNames as = case S.toAscList (S.fromList (map activityName as)) of
+        names ->
+            T.intercalate ", " (map (\n -> "\"" <> n <> "\"") (take 3 names))
+                <> if length names > 3
+                    then " and " <> T.pack (show (length names - 3)) <> " more"
+                    else ""
+    duplicateProductOffenders =
+        [ offender WarningSev key act (Just (anyFlowName fid)) $
+            "this product is also the reference product of " <> otherProducerNames others <> "; an input naming it is answered by one of them"
+        | (fid, group) <- M.toList productProducers
+        , (key, act) <- group
+        , let others = [a | (k, a) <- group, k /= key]
+        , not (null others)
         ]
 
     -- A non-finite amount poisons every downstream sum; a zero reference amount

--- a/src/Database/Quality.hs
+++ b/src/Database/Quality.hs
@@ -60,12 +60,10 @@ import Types (
     WasteFlow (..),
     activityGroupKey,
     activityIsObsolete,
-    exchangeActivityLinkId,
     exchangeAmount,
     exchangeFlowId,
     exchangeIsReference,
     exchangePedigree,
-    exchangeProcessLinkId,
     exchangeUnitId,
     processRefText,
  )
@@ -368,33 +366,32 @@ qualityReport dbName db =
         , n > 1
         ]
 
-    {- An input the file leaves the loader to place: it names a product and no
-    supplier. EcoSpold 2 names the supplying activity on the exchange itself,
-    so a product several activities declare is answered without any rule of
-    ours; SimaPro, Brightway and EcoSpold 1 let the product name speak alone,
-    and that is when a second declarer can take the answer.
-    -}
-    contestedProductIds =
-        S.fromList
-            [ exchangeFlowId ex
-            | (_, act) <- entries
-            , ex <- exchanges act
-            , needsSupplier ex
-            , isNothing (exchangeActivityLinkId ex)
-            , isNothing (exchangeProcessLinkId ex)
-            ]
-
-    {- Two activities declaring one product an input has to choose between. The
-    supplier index is keyed by the product, so an input naming it is answered
-    by one of them and the others supply nothing. Which one answers is settled by a rule of ours, on a
-    question only the file can answer, and a stale twin left in an export wins
-    as easily as the current entry. Reported per activity, each naming the
-    others, so the maker can see both ends of the collision.
-    -}
     productProducers =
         M.fromListWith
             (<>)
             [ (exchangeFlowId refEx, [(key, act)])
+            | (key, act) <- entries
+            , [refEx] <- [filter exchangeIsReference (exchanges act)]
+            ]
+
+    {- Two activities declaring one product at one location, which an input
+    naming that product has to choose between. The supplier index is keyed by
+    the product, so one of them answers and the others supply nothing. Which
+    one is settled by a rule of ours, on a question only the file can answer,
+    and a stale twin left in an export wins as easily as the current entry.
+    Reported per activity, each naming the others, so the maker can see both
+    ends of the collision.
+
+    The location belongs in the key because making one product in several
+    places is how a database is meant to be written: ecoinvent carries hundreds
+    of activities producing "electricity, high voltage", one per geography, and
+    an input names the one it means. Two of them at one location is what no
+    file states a difference between.
+    -}
+    coLocatedProducers =
+        M.fromListWith
+            (<>)
+            [ ((exchangeFlowId refEx, activityLocation act), [(key, act)])
             | (key, act) <- entries
             , [refEx] <- [filter exchangeIsReference (exchanges act)]
             ]
@@ -406,9 +403,8 @@ qualityReport dbName db =
                     else ""
     duplicateProductOffenders =
         [ offender WarningSev key act (Just (anyFlowName fid)) $
-            "this product is also the reference product of " <> otherProducerNames others <> "; an input naming it is answered by one of them"
-        | (fid, group) <- M.toList productProducers
-        , fid `S.member` contestedProductIds
+            "this product is also the reference product of " <> otherProducerNames others <> " at the same location; an input naming it is answered by one of them"
+        | ((fid, _), group) <- M.toList coLocatedProducers
         , (key, act) <- group
         , let others = [a | (k, a) <- group, k /= key]
         , not (null others)

--- a/src/Method/ParserSimaPro.hs
+++ b/src/Method/ParserSimaPro.hs
@@ -307,12 +307,14 @@ parseCFRow cfg line =
                 -- UUID hashed via the shared 'generateFlowUUID' +
                 -- 'normalizeSimaProCompartment' so the CF side and
                 -- 'SimaPro.Parser.bioRowToExchange' produce the same UUID for
-                -- the same flow.
+                -- the same flow. The unit stays out of the hash on both sides:
+                -- a factor written per kg answers an inventory row written per
+                -- g, and 'convertForCharacterization' puts the quantity on the
+                -- factor's basis. 'mcfUnit' keeps the unit the method states.
                 !flowRef =
                     generateFlowUUID
                         rawName
                         (normalizeSimaProCompartment (decodeBS comp) (decodeBS sub))
-                        cfUnitT
                 !cf =
                     MethodCF
                         { mcfFlowRef = flowRef

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -17,7 +17,6 @@ module SimaPro.Parser (
     emptyProcessBlock,
     fallbackAmounts,
     dropAmbiguousNativeIds,
-    foldedNameCollisions,
     generateActivityUUID,
     generateFlowUUID,
     generateUnitUUID,
@@ -793,24 +792,6 @@ dropAmbiguousNativeIds activities =
     forget act = case activityNativeId act of
         Just (NativeProcessId nativeId) | nativeId `S.member` ambiguous -> act{activityNativeId = Nothing}
         _ -> act
-
-{- | The blocks a case fold brings together.
-
-A block with no published identifier is named by its name folded in case and
-its location, which is what makes two exports of one database agree. Inside a
-single file two blocks whose names differ only in case are a naming mistake
-instead, and they now share a key: the last read wins it and the other's
-inventory is gone. Each group is returned so the caller can say so.
--}
-foldedNameCollisions :: [Activity] -> [[Text]]
-foldedNameCollisions activities =
-    filter ((> 1) . length) . map S.toAscList . M.elems $
-        M.fromListWith
-            S.union
-            [ ((T.toCaseFold (activityName act), activityLocation act), S.singleton (activityName act))
-            | act <- activities
-            , isNothing (activityNativeId act)
-            ]
 
 {- | Generate deterministic flow UUID from name and compartment.
 
@@ -1657,11 +1638,6 @@ parseSimaProCSV unitCfg path = do
             printf
                 "process identifier '%s' names more than one process; those blocks are identified by name and location instead"
                 (T.unpack nativeId)
-    forM_ (foldedNameCollisions activities) $ \spellings ->
-        reportProgress Warning $
-            printf
-                "%s are one activity: they differ only in case and no process identifier tells them apart"
-                (T.unpack (T.intercalate ", " (map (\n -> "'" <> n <> "'") spellings)))
     let
         allTechFlows = concatMap (\(_, tf, _, _, _) -> tf) converted
         allBioFlows = concatMap (\(_, _, bf, _, _) -> bf) converted

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -16,6 +16,7 @@ module SimaPro.Parser (
     GlobalParams (..),
     emptyProcessBlock,
     fallbackAmounts,
+    dropAmbiguousNativeIds,
     generateActivityUUID,
     generateFlowUUID,
     generateUnitUUID,
@@ -748,12 +749,49 @@ setMetadata key value block = case key of
 simaproNamespace :: UUID
 simaproNamespace = UUID5.generateNamed UUID5.namespaceURL (BS.unpack $ TE.encodeUtf8 "simapro.pre.nl")
 
--- | Generate deterministic activity UUID from Activity (uses name + location)
+{- | Generate deterministic activity UUID from an Activity.
+
+A SimaPro block publishes its own identifier on the "Process identifier" line,
+and that is what names the activity when it is there. It is what the producer
+says the dataset is, it survives a re-export of the same version, and it
+survives the producer changing the spelling or the case of a name.
+
+Without it the identifier falls back to the name and the location, folded in
+case for the same reason the flow name is: two exports of one database write
+one product two ways. 'dropAmbiguousNativeIds' has already taken away any
+identifier that named more than one process, so this stays a total function of
+the activity.
+-}
 generateActivityUUID :: Activity -> UUID
 generateActivityUUID act =
-    UUID5.generateNamed
-        simaproNamespace
-        (BS.unpack $ TE.encodeUtf8 $ "activity:" <> activityName act <> "@" <> activityLocation act)
+    UUID5.generateNamed simaproNamespace . BS.unpack . TE.encodeUtf8 $ case activityNativeId act of
+        Just (NativeProcessId nativeId) -> "process:" <> nativeId
+        Nothing -> "activity:" <> T.toCaseFold (activityName act) <> "@" <> activityLocation act
+
+{- | Take a native identifier away from the activities when it names more than
+one process.
+
+Every coproduct of one block shares the block's identifier, which is the point:
+they are one process with several outputs. Two /different/ blocks sharing one
+is a naming mistake on the producer's side, and the identifier then names
+neither: those activities fall back to their name and location. The file still
+loads, and the identifiers dropped are returned so the caller can name them.
+-}
+dropAmbiguousNativeIds :: [Activity] -> ([Activity], [Text])
+dropAmbiguousNativeIds activities =
+    (map forget activities, S.toList ambiguous)
+  where
+    named =
+        M.fromListWith
+            S.union
+            [ (nativeId, S.singleton (activityName act, activityLocation act))
+            | act <- activities
+            , Just (NativeProcessId nativeId) <- [activityNativeId act]
+            ]
+    ambiguous = M.keysSet (M.filter ((> 1) . S.size) named)
+    forget act = case activityNativeId act of
+        Just (NativeProcessId nativeId) | nativeId `S.member` ambiguous -> act{activityNativeId = Nothing}
+        _ -> act
 
 {- | Generate deterministic flow UUID from name and compartment.
 
@@ -1594,7 +1632,13 @@ parseSimaProCSV unitCfg path = do
                 (T.unpack raw)
                 (T.unpack name)
                 fallback
-    let activities = map (\(a, _, _, _, _) -> a) converted
+    let (activities, ambiguousIds) = dropAmbiguousNativeIds (map (\(a, _, _, _, _) -> a) converted)
+    forM_ ambiguousIds $ \nativeId ->
+        reportProgress Warning $
+            printf
+                "process identifier '%s' names more than one process; those blocks are identified by name and location instead"
+                (T.unpack nativeId)
+    let
         allTechFlows = concatMap (\(_, tf, _, _, _) -> tf) converted
         allBioFlows = concatMap (\(_, _, bf, _, _) -> bf) converted
         allWasteFlows = concatMap (\(_, _, _, wf, _) -> wf) converted

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -755,10 +755,22 @@ generateActivityUUID act =
         simaproNamespace
         (BS.unpack $ TE.encodeUtf8 $ "activity:" <> activityName act <> "@" <> activityLocation act)
 
--- | Generate deterministic flow UUID from name, compartment, unit
-generateFlowUUID :: Text -> Text -> Text -> UUID
-generateFlowUUID name compartment unit =
-    UUID5.generateNamed simaproNamespace (BS.unpack $ TE.encodeUtf8 $ "flow:" <> name <> ":" <> compartment <> ":" <> unit)
+{- | Generate deterministic flow UUID from name and compartment.
+
+The unit is deliberately absent. It is a property of the row, not of the flow:
+the same substance written in g by one block and in kg by another is one flow,
+and 'canonicalRow' has already brought both rows to the reference unit of the
+dimension. Keeping the unit in the key also made the identifier depend on the
+engine's own unit table, so renaming a reference unit moved identifiers no data
+had touched.
+
+The name is folded in case for the same reason: two exports of one database
+disagree on the case of a product name, and a flow is not two flows because a
+producer capitalised it differently.
+-}
+generateFlowUUID :: Text -> Text -> UUID
+generateFlowUUID name compartment =
+    UUID5.generateNamed simaproNamespace (BS.unpack $ TE.encodeUtf8 $ "flow:" <> T.toCaseFold name <> ":" <> compartment)
 
 {- | Canonical (compartment, subcompartment) string for SimaPro flow UUIDs.
 
@@ -1130,7 +1142,7 @@ productToExchange unitCfg env isRef ProductRow{..} =
         prodRowLoc = foldMap locatedLocation reading
         rawAmount = resolveAmount env prAmountRaw prAmount
         (effUnitName, amount) = canonicalRow unitCfg prUnit rawAmount
-        flowUUID = generateFlowUUID cleanName "" effUnitName
+        flowUUID = generateFlowUUID cleanName ""
         unitUUID = generateUnitUUID effUnitName
         (pedigree, cleanedComment) = parsePedigreePrefix prComment
         exchange =
@@ -1218,7 +1230,7 @@ techRowToExchange unitCfg env TechExchangeRow{..} =
         cleanName = maybe terName locatedName reading
         location = foldMap locatedLocation reading
         (effUnitName, resolvedAmount) = canonicalRow unitCfg terUnit (resolveAmount env terAmountRaw terAmount)
-        flowUUID = generateFlowUUID cleanName "" effUnitName
+        flowUUID = generateFlowUUID cleanName ""
         unitUUID = generateUnitUUID effUnitName
         (pedigree, cleanedComment) = parsePedigreePrefix terComment
         exchange =
@@ -1269,7 +1281,7 @@ bioRowToExchange unitCfg env isInput compartment BioExchangeRow{..} =
         -- compartment case or the SimaPro CF placeholder '(unspecified)'
         -- (which inventory rows leave blank in the same medium).
         (effUnitName, amount) = canonicalRow unitCfg berUnit (resolveAmount env berAmountRaw berAmount)
-        flowUUID = generateFlowUUID cleanName (normalizeSimaProCompartment compartment berCompartment) effUnitName
+        flowUUID = generateFlowUUID cleanName (normalizeSimaProCompartment compartment berCompartment)
         unitUUID = generateUnitUUID effUnitName
         subcomp = if T.null berCompartment then Nothing else Just berCompartment
         (pedigree, cleanedComment) = parsePedigreePrefix berComment
@@ -1319,7 +1331,7 @@ wasteRowToExchange unitCfg env BioExchangeRow{..} =
         -- for these flows before they were reclassified -- so impact methods
         -- that match by the (name, "waste") combination keep matching.
         (effUnitName, amount) = canonicalRow unitCfg berUnit (resolveAmount env berAmountRaw berAmount)
-        flowUUID = generateFlowUUID cleanName (normalizeSimaProCompartment "waste" berCompartment) effUnitName
+        flowUUID = generateFlowUUID cleanName (normalizeSimaProCompartment "waste" berCompartment)
         unitUUID = generateUnitUUID effUnitName
         (pedigree, cleanedComment) = parsePedigreePrefix berComment
         exchange =

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -20,6 +20,7 @@ module SimaPro.Parser (
     generateFlowUUID,
     generateUnitUUID,
     normalizeSimaProCompartment,
+    indexFlows,
     extractLocation,
     Located (..),
     NameReading (..),
@@ -43,7 +44,7 @@ import Control.Applicative ((<|>))
 import Control.Concurrent.Async (mapConcurrently)
 import Control.DeepSeq (NFData, force)
 import Control.Exception (evaluate)
-import Control.Monad (forM_, mfilter)
+import Control.Monad (foldM, forM_, mfilter)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as BL
@@ -1507,7 +1508,36 @@ Reference-product amounts are normalized to the canonical base unit of their
 dimension (e.g. 1 t → 1000 kg) during parsing, so downstream matrix
 construction yields per-base-unit columns.
 -}
-parseSimaProCSV :: UnitConversion.UnitConfig -> FilePath -> IO ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB)
+
+{- | Index flows by their identifier, refusing a pair that disagrees on the unit.
+
+Two rows of the same name and compartment land on one entry. When their units
+convert into each other the conversion at ingest has already brought both to
+the reference unit of the dimension, so they agree. When no conversion relates
+them -- an energy against a mass -- nothing can make them one flow, and
+'M.fromList' would silently keep whichever row came last. Refuse the file
+instead, naming the flow and both units.
+-}
+indexFlows :: M.Map UUID.UUID Text -> (a -> (UUID.UUID, UUID.UUID, Text)) -> [a] -> Either Text (M.Map UUID.UUID a)
+indexFlows unitNames identity = foldM add M.empty
+  where
+    add acc flow =
+        let (flowId, unitRef, name) = identity flow
+         in case identity <$> M.lookup flowId acc of
+                Just (_, seen, _)
+                    | seen /= unitRef ->
+                        Left $
+                            "flow '"
+                                <> name
+                                <> "' is written in two units that no conversion relates ('"
+                                <> nameOf seen
+                                <> "' and '"
+                                <> nameOf unitRef
+                                <> "'), so they cannot be one flow"
+                _ -> Right (M.insert flowId flow acc)
+    nameOf u = M.findWithDefault (UUID.toText u) u unitNames
+
+parseSimaProCSV :: UnitConversion.UnitConfig -> FilePath -> IO (Either Text ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB))
 parseSimaProCSV unitCfg path = do
     reportProgress Info $ "Loading SimaPro CSV file: " ++ path
     startTime <- getCurrentTime
@@ -1554,40 +1584,46 @@ parseSimaProCSV unitCfg path = do
     -- Build deduplicated maps — UUID disjointness across kinds is guaranteed
     -- by construction (tech flows hash with empty compartment, bio flows hash
     -- with their compartment, waste flows hash with "waste" compartment).
-    let techFlowDB = M.fromList [(tfId f, f) | f <- allTechFlows]
-        -- Fill empty flow CAS from the file's own substance registry (the
-        -- trailing name;unit;cas blocks) so the native CAS bridge fires on a
-        -- SimaPro export, which otherwise carries no per-flow CAS at all.
-        (bioFlowDB, casConflicts) = fillCASFromRegistry substanceCAS (M.fromList [(bfId f, f) | f <- allBioFlows])
-        wasteFlowDB = M.fromList [(wfId f, f) | f <- allWasteFlows]
-        unitDB = M.fromList [(unitId u, u) | u <- allUnits]
+    let unitDB = M.fromList [(unitId u, u) | u <- allUnits]
+        unitNames = M.map unitName unitDB
+        indexed = do
+            techFlowDB <- indexFlows unitNames (\f -> (tfId f, tfUnitId f, tfName f)) allTechFlows
+            -- Fill empty flow CAS from the file's own substance registry (the
+            -- trailing name;unit;cas blocks) so the native CAS bridge fires on
+            -- a SimaPro export, which otherwise carries no per-flow CAS at all.
+            bioIndexed <- indexFlows unitNames (\f -> (bfId f, bfUnitId f, bfName f)) allBioFlows
+            wasteFlowDB <- indexFlows unitNames (\f -> (wfId f, wfUnitId f, wfName f)) allWasteFlows
+            pure (techFlowDB, fillCASFromRegistry substanceCAS bioIndexed, wasteFlowDB)
 
-    forM_ casConflicts $ \(NormName n, (CASNumber kept, CASNumber ignored)) ->
-        reportProgress Warning $
-            printf
-                "substance registry binds '%s' to two CAS (%s kept, %s ignored)"
-                (T.unpack n)
-                (T.unpack kept)
-                (T.unpack ignored)
+    case indexed of
+        Left err -> pure (Left err)
+        Right (techFlowDB, (bioFlowDB, casConflicts), wasteFlowDB) -> do
+            forM_ casConflicts $ \(NormName n, (CASNumber kept, CASNumber ignored)) ->
+                reportProgress Warning $
+                    printf
+                        "substance registry binds '%s' to two CAS (%s kept, %s ignored)"
+                        (T.unpack n)
+                        (T.unpack kept)
+                        (T.unpack ignored)
 
-    -- Force evaluation before returning
-    let !numActivities = length activities
-    let !numTechFlows = M.size techFlowDB
-    let !numBioFlows = M.size bioFlowDB
-    let !numBioFlowsCAS = length [() | f <- M.elems bioFlowDB, maybe False (not . T.null) (bfCAS f)]
-    let !numWasteFlows = M.size wasteFlowDB
-    let !numUnits = M.size unitDB
+            -- Force evaluation before returning
+            let !numActivities = length activities
+            let !numTechFlows = M.size techFlowDB
+            let !numBioFlows = M.size bioFlowDB
+            let !numBioFlowsCAS = length [() | f <- M.elems bioFlowDB, maybe False (not . T.null) (bfCAS f)]
+            let !numWasteFlows = M.size wasteFlowDB
+            let !numUnits = M.size unitDB
 
-    endTime <- getCurrentTime
-    let duration = realToFrac (diffUTCTime endTime startTime) :: Double
-    reportProgress Info $ printf "SimaPro parsing completed in %.2fs:" duration
-    reportProgress Info $ printf "  Activities: %d processes" numActivities
-    reportProgress Info $ printf "  Technosphere flows: %d unique" numTechFlows
-    reportProgress Info $ printf "  Biosphere flows: %d unique (%d carry a CAS)" numBioFlows numBioFlowsCAS
-    reportProgress Info $ printf "  Waste flows: %d unique" numWasteFlows
-    reportProgress Info $ printf "  Units: %d unique" numUnits
+            endTime <- getCurrentTime
+            let duration = realToFrac (diffUTCTime endTime startTime) :: Double
+            reportProgress Info $ printf "SimaPro parsing completed in %.2fs:" duration
+            reportProgress Info $ printf "  Activities: %d processes" numActivities
+            reportProgress Info $ printf "  Technosphere flows: %d unique" numTechFlows
+            reportProgress Info $ printf "  Biosphere flows: %d unique (%d carry a CAS)" numBioFlows numBioFlowsCAS
+            reportProgress Info $ printf "  Waste flows: %d unique" numWasteFlows
+            reportProgress Info $ printf "  Units: %d unique" numUnits
 
-    return (activities, techFlowDB, bioFlowDB, wasteFlowDB, unitDB)
+            return (Right (activities, techFlowDB, bioFlowDB, wasteFlowDB, unitDB))
   where
     -- Strip Windows \r from ByteString (fast, often no-op)
     stripCR :: BS.ByteString -> BS.ByteString

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -17,6 +17,7 @@ module SimaPro.Parser (
     emptyProcessBlock,
     fallbackAmounts,
     dropAmbiguousNativeIds,
+    foldedNameCollisions,
     generateActivityUUID,
     generateFlowUUID,
     generateUnitUUID,
@@ -792,6 +793,24 @@ dropAmbiguousNativeIds activities =
     forget act = case activityNativeId act of
         Just (NativeProcessId nativeId) | nativeId `S.member` ambiguous -> act{activityNativeId = Nothing}
         _ -> act
+
+{- | The blocks a case fold brings together.
+
+A block with no published identifier is named by its name folded in case and
+its location, which is what makes two exports of one database agree. Inside a
+single file two blocks whose names differ only in case are a naming mistake
+instead, and they now share a key: the last read wins it and the other's
+inventory is gone. Each group is returned so the caller can say so.
+-}
+foldedNameCollisions :: [Activity] -> [[Text]]
+foldedNameCollisions activities =
+    filter ((> 1) . length) . map S.toAscList . M.elems $
+        M.fromListWith
+            S.union
+            [ ((T.toCaseFold (activityName act), activityLocation act), S.singleton (activityName act))
+            | act <- activities
+            , isNothing (activityNativeId act)
+            ]
 
 {- | Generate deterministic flow UUID from name and compartment.
 
@@ -1638,6 +1657,11 @@ parseSimaProCSV unitCfg path = do
             printf
                 "process identifier '%s' names more than one process; those blocks are identified by name and location instead"
                 (T.unpack nativeId)
+    forM_ (foldedNameCollisions activities) $ \spellings ->
+        reportProgress Warning $
+            printf
+                "%s are one activity: they differ only in case and no process identifier tells them apart"
+                (T.unpack (T.intercalate ", " (map (\n -> "'" <> n <> "'") spellings)))
     let
         allTechFlows = concatMap (\(_, tf, _, _, _) -> tf) converted
         allBioFlows = concatMap (\(_, _, bf, _, _) -> bf) converted

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -19,6 +19,7 @@ module SimaPro.Parser (
     generateActivityUUID,
     generateFlowUUID,
     generateUnitUUID,
+    canonicalRow,
     normalizeSimaProCompartment,
     indexFlows,
     extractLocation,
@@ -996,15 +997,15 @@ processBlockToActivity unitCfg gp pb@ProcessBlock{..} =
     (avoidedExs, avoidedFlows, avoidedUnits) =
         unzip3 (productToExchange unitCfg env False <$> pbAvoidedProducts)
     (techMaybeExs, techFlows, techUnits) =
-        unzip3 (techRowToExchange env <$> (pbMaterials ++ pbElectricity ++ pbWasteToTreatment))
+        unzip3 (techRowToExchange unitCfg env <$> (pbMaterials ++ pbElectricity ++ pbWasteToTreatment))
     (bioExs, bioFlows, bioUnits) =
         unzip3 $
-            (bioRowToExchange env True "resource" <$> pbResources)
-                ++ (bioRowToExchange env False "air" <$> pbEmissionsAir)
-                ++ (bioRowToExchange env False "water" <$> pbEmissionsWater)
-                ++ (bioRowToExchange env False "soil" <$> pbEmissionsSoil)
+            (bioRowToExchange unitCfg env True "resource" <$> pbResources)
+                ++ (bioRowToExchange unitCfg env False "air" <$> pbEmissionsAir)
+                ++ (bioRowToExchange unitCfg env False "water" <$> pbEmissionsWater)
+                ++ (bioRowToExchange unitCfg env False "soil" <$> pbEmissionsSoil)
     (wasteExs, wasteFlows, wasteUnits) =
-        unzip3 (wasteRowToExchange env <$> pbFinalWaste)
+        unzip3 (wasteRowToExchange unitCfg env <$> pbFinalWaste)
 
     -- Exchanges/flows/units shared by every coproduct (scaled per product below).
     -- Tech rows with a zero amount yield no exchange but still contribute a flow.
@@ -1101,17 +1102,26 @@ scaleExchange factor ex@TechnosphereExchange{} = ex{techAmount = techAmount ex *
 scaleExchange factor ex@BiosphereExchange{} = ex{bioAmount = bioAmount ex * factor}
 scaleExchange factor ex@WasteExchange{} = ex{waAmount = waAmount ex * factor}
 
+{- | The reference unit of a row's dimension, and the row's amount in it.
+
+Every row is recorded in the reference unit of its dimension (kg for a mass,
+mj for an energy, m3 for a volume), so one flow carries one unit and a matrix
+row never sums two of them. A unit the table does not know is left as written:
+an import stays tolerant, and the matrix builder in "Database" surfaces the
+unknown unit with its own message.
+-}
+canonicalRow :: UnitConversion.UnitConfig -> Text -> Double -> (Text, Double)
+canonicalRow unitCfg unit amount =
+    fromMaybe (unit, amount) (UnitConversion.normalizeToCanonical unitCfg unit amount)
+
 {- | Convert product row to exchange, flow, and unit in one pass.
 
-For reference products ('isRef == True'), the declared amount is converted to
-the canonical base unit of its dimension (kg for mass, mj for energy, m3 for
-volume, and so on). This ensures 'activityNormFactor' and the resulting matrix
-column are expressed per 1 base unit: a reference declared as "1 ton" would
-otherwise produce impacts 1000x too large.
-
-If the unit is unknown to the config or its dimension has no base unit, the
-raw values are kept (the downstream matrix builder in 'Database.hs' surfaces
-unknown-unit errors with a clear message).
+The declared amount is converted to the reference unit of its dimension by
+'canonicalRow', reference product and coproduct alike. For the reference that
+is what makes 'activityNormFactor' and the matrix column read per 1 base unit:
+a reference declared as "1 ton" would otherwise produce impacts 1000x too
+large. For a coproduct it is what lets the row carry the same identifier as
+the input that consumes it elsewhere.
 -}
 productToExchange :: UnitConversion.UnitConfig -> M.Map Text Double -> Bool -> ProductRow -> (Exchange, TechnosphereFlow, Unit)
 productToExchange unitCfg env isRef ProductRow{..} =
@@ -1119,10 +1129,7 @@ productToExchange unitCfg env isRef ProductRow{..} =
         cleanName = maybe prName locatedName reading
         prodRowLoc = foldMap locatedLocation reading
         rawAmount = resolveAmount env prAmountRaw prAmount
-        (effUnitName, amount) =
-            if isRef
-                then fromMaybe (prUnit, rawAmount) (UnitConversion.normalizeToCanonical unitCfg prUnit rawAmount)
-                else (prUnit, rawAmount)
+        (effUnitName, amount) = canonicalRow unitCfg prUnit rawAmount
         flowUUID = generateFlowUUID cleanName "" effUnitName
         unitUUID = generateUnitUUID effUnitName
         (pedigree, cleanedComment) = parsePedigreePrefix prComment
@@ -1205,14 +1212,14 @@ parsePedigreePrefix raw =
 {- | Convert technosphere row to exchange (if non-zero), flow, and unit.
 Always returns the flow/unit; exchange is Nothing for zero-amount rows.
 -}
-techRowToExchange :: M.Map Text Double -> TechExchangeRow -> (Maybe Exchange, TechnosphereFlow, Unit)
-techRowToExchange env TechExchangeRow{..} =
+techRowToExchange :: UnitConversion.UnitConfig -> M.Map Text Double -> TechExchangeRow -> (Maybe Exchange, TechnosphereFlow, Unit)
+techRowToExchange unitCfg env TechExchangeRow{..} =
     let reading = extractLocation terName
         cleanName = maybe terName locatedName reading
         location = foldMap locatedLocation reading
-        flowUUID = generateFlowUUID cleanName "" terUnit
-        unitUUID = generateUnitUUID terUnit
-        resolvedAmount = resolveAmount env terAmountRaw terAmount
+        (effUnitName, resolvedAmount) = canonicalRow unitCfg terUnit (resolveAmount env terAmountRaw terAmount)
+        flowUUID = generateFlowUUID cleanName "" effUnitName
+        unitUUID = generateUnitUUID effUnitName
         (pedigree, cleanedComment) = parsePedigreePrefix terComment
         exchange =
             if resolvedAmount == 0
@@ -1239,15 +1246,15 @@ techRowToExchange env TechExchangeRow{..} =
                 , tfCAS = Nothing
                 , tfSubstanceId = Nothing
                 }
-        unit = Unit{unitId = unitUUID, unitName = terUnit, unitSymbol = terUnit, unitComment = ""}
+        unit = Unit{unitId = unitUUID, unitName = effUnitName, unitSymbol = effUnitName, unitComment = ""}
      in (exchange, flow, unit)
 
 {- | Convert biosphere row to exchange, flow, and unit in one pass
 The compartment parameter is the section-level compartment ("air", "water", "soil", "resource", "waste")
 and berCompartment is the row-level sub-compartment ("high. pop.", "river", etc. or empty)
 -}
-bioRowToExchange :: M.Map Text Double -> Bool -> Text -> BioExchangeRow -> (Exchange, BiosphereFlow, Unit)
-bioRowToExchange env isInput compartment BioExchangeRow{..} =
+bioRowToExchange :: UnitConversion.UnitConfig -> M.Map Text Double -> Bool -> Text -> BioExchangeRow -> (Exchange, BiosphereFlow, Unit)
+bioRowToExchange unitCfg env isInput compartment BioExchangeRow{..} =
     let
         -- Keep SimaPro's per-region flow variants (`Nitrogen dioxide, FR`,
         -- `Water, FR`, …) as distinct elementary flows. EF 3.1 (and any
@@ -1261,9 +1268,9 @@ bioRowToExchange env isInput compartment BioExchangeRow{..} =
         -- 'Method.ParserSimaPro' agree on the hash, regardless of sub-
         -- compartment case or the SimaPro CF placeholder '(unspecified)'
         -- (which inventory rows leave blank in the same medium).
-        flowUUID = generateFlowUUID cleanName (normalizeSimaProCompartment compartment berCompartment) berUnit
-        unitUUID = generateUnitUUID berUnit
-        amount = resolveAmount env berAmountRaw berAmount
+        (effUnitName, amount) = canonicalRow unitCfg berUnit (resolveAmount env berAmountRaw berAmount)
+        flowUUID = generateFlowUUID cleanName (normalizeSimaProCompartment compartment berCompartment) effUnitName
+        unitUUID = generateUnitUUID effUnitName
         subcomp = if T.null berCompartment then Nothing else Just berCompartment
         (pedigree, cleanedComment) = parsePedigreePrefix berComment
         exchange =
@@ -1293,7 +1300,7 @@ bioRowToExchange env isInput compartment BioExchangeRow{..} =
                         then Nothing
                         else Just (Compartment compartment subcomp)
                 }
-        unit = Unit{unitId = unitUUID, unitName = berUnit, unitSymbol = berUnit, unitComment = ""}
+        unit = Unit{unitId = unitUUID, unitName = effUnitName, unitSymbol = effUnitName, unitComment = ""}
      in
         (exchange, flow, unit)
 
@@ -1303,17 +1310,17 @@ kind so the cross-DB linker doesn't try to find a producer (these are
 end-of-life markers, not technosphere demands). Modelled as an output
 (waIsInput = False) -- the activity generates the waste.
 -}
-wasteRowToExchange :: M.Map Text Double -> BioExchangeRow -> (Exchange, WasteFlow, Unit)
-wasteRowToExchange env BioExchangeRow{..} =
+wasteRowToExchange :: UnitConversion.UnitConfig -> M.Map Text Double -> BioExchangeRow -> (Exchange, WasteFlow, Unit)
+wasteRowToExchange unitCfg env BioExchangeRow{..} =
     let
         cleanName = berName
         -- Compartment "waste" keeps the UUID generation aligned with
         -- whatever historical biosphere-side hashing the SimaPro path used
         -- for these flows before they were reclassified -- so impact methods
         -- that match by the (name, "waste") combination keep matching.
-        flowUUID = generateFlowUUID cleanName (normalizeSimaProCompartment "waste" berCompartment) berUnit
-        unitUUID = generateUnitUUID berUnit
-        amount = resolveAmount env berAmountRaw berAmount
+        (effUnitName, amount) = canonicalRow unitCfg berUnit (resolveAmount env berAmountRaw berAmount)
+        flowUUID = generateFlowUUID cleanName (normalizeSimaProCompartment "waste" berCompartment) effUnitName
+        unitUUID = generateUnitUUID effUnitName
         (pedigree, cleanedComment) = parsePedigreePrefix berComment
         exchange =
             WasteExchange
@@ -1338,7 +1345,7 @@ wasteRowToExchange env BioExchangeRow{..} =
                 , wfCAS = Nothing
                 , wfSubstanceId = Nothing
                 }
-        unit = Unit{unitId = unitUUID, unitName = berUnit, unitSymbol = berUnit, unitComment = ""}
+        unit = Unit{unitId = unitUUID, unitName = effUnitName, unitSymbol = effUnitName, unitComment = ""}
      in
         (exchange, flow, unit)
 

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -467,6 +467,7 @@ yields an empty "Type" value, so @meta@ omits the line and a re-parse yields
 activityMetaLines :: Activity -> [(Text, Text)]
 activityMetaLines Activity{..} =
     [ ("Category type", M.findWithDefault "" "Category type" activityClassification)
+    , ("Process identifier", foldMap (\(NativeProcessId nativeId) -> nativeId) activityNativeId)
     , ("Process name", activityName)
     , ("Type", typeLabelOf activityNativeType)
     , ("Geography", activityLocation)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -573,6 +573,22 @@ identifier fall back to grouping by activity UUID, as before.
 activityGroupKey :: UUID -> Activity -> (UUID, Maybe NativeProcessId)
 activityGroupKey actUUID act = (actUUID, activityNativeId act)
 
+{- | Is this dataset filed in its source's obsolete category?
+
+The tool that writes SimaPro CSV files keeps a retired process in the export,
+under a category whose last segment is @Obsolete@ (@Others\\Obsolete@, or
+@Autres\\Obsolete@ in a French export). Such a process still carries its
+exchanges and still computes; what its author says is that a newer one has
+replaced it, and the writing tool warns whenever a calculation reaches one.
+Read here on the @Category@ classification, which is the cell the block's
+product row carries. Formats with no such convention never say yes.
+-}
+activityIsObsolete :: Activity -> Bool
+activityIsObsolete =
+    maybe False (elem "obsolete" . map T.toCaseFold . T.splitOn "\\")
+        . M.lookup "Category"
+        . activityClassification
+
 -- | LCA computation tree (recursive representation)
 data ActivityTree
     = Leaf !Activity

--- a/src/UnitConversion.hs
+++ b/src/UnitConversion.hs
@@ -13,7 +13,8 @@ module UnitConversion (
     -- * Types
     Dimension,
     UnitDef (..),
-    UnitConfig (..),
+    UnitConfig (ucDimensionOrder, ucUnits, ucOriginalKeys, ucCanonical),
+    mkUnitConfig,
 
     -- * Loading
     defaultUnitConfig,
@@ -48,7 +49,7 @@ import Control.Monad (unless)
 import qualified Data.ByteString.Lazy as BL
 import Data.Csv (HasHeader (..), decode)
 import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
-import Data.List (elemIndex, sortOn)
+import Data.List (elemIndex)
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as S
@@ -77,6 +78,7 @@ data UnitConfig = UnitConfig
     { ucDimensionOrder :: ![Text] -- ["mass", "length", "time", ...]
     , ucUnits :: !(M.Map Text UnitDef) -- normalized (lowercase, trimmed) keys
     , ucOriginalKeys :: !(M.Map Text Text) -- normalized -> original (for error messages)
+    , ucCanonical :: !(M.Map Text Text) -- normalized -> reference unit of its dimension
     }
     deriving (Show, Generic)
 
@@ -136,17 +138,7 @@ Returns 'Nothing' if the input unit is unknown or its dimension defines no
 reference unit.
 -}
 canonicalUnitFor :: UnitConfig -> Text -> Maybe Text
-canonicalUnitFor cfg unitText = do
-    UnitDef dim _ <- lookupUnitDef cfg unitText
-    case sortOn
-        (\k -> (T.length k, k))
-        [ normKey
-        | (normKey, UnitDef d f) <- M.toList (ucUnits cfg)
-        , d == dim
-        , f == 1.0
-        ] of
-        (normKey : _) -> Just $ M.findWithDefault normKey normKey (ucOriginalKeys cfg)
-        [] -> Nothing
+canonicalUnitFor cfg = flip M.lookup (ucCanonical cfg) . normalizeUnit
 
 {- | Convert an amount to the canonical base unit of its dimension.
 Returns '(canonicalUnitName, convertedAmount)'. 'Nothing' if the input unit is
@@ -213,12 +205,7 @@ buildFromCSV csvData =
     buildFromRows dimOrder rows = do
         pairs <- mapM (parseRow dimOrder) rows
         let units = M.fromList pairs
-        Right
-            UnitConfig
-                { ucDimensionOrder = dimOrder
-                , ucUnits = units
-                , ucOriginalKeys = M.mapWithKey const units
-                }
+        Right (mkUnitConfig dimOrder units (M.mapWithKey const units))
 
     parseRow dimOrder (name, dimExpr, factor) = do
         dim <- parseDimension dimOrder dimExpr
@@ -230,11 +217,10 @@ buildFromCSV csvData =
 mergeUnitConfigs :: [UnitConfig] -> UnitConfig
 mergeUnitConfigs [] = defaultUnitConfig
 mergeUnitConfigs cfgs@(first : _) =
-    UnitConfig
-        { ucDimensionOrder = ucDimensionOrder first
-        , ucUnits = M.unions (reverse $ map ucUnits cfgs)
-        , ucOriginalKeys = M.unions (reverse $ map ucOriginalKeys cfgs)
-        }
+    mkUnitConfig
+        (ucDimensionOrder first)
+        (M.unions (reverse $ map ucUnits cfgs))
+        (M.unions (reverse $ map ucOriginalKeys cfgs))
 
 -- | Number of unit definitions.
 unitCount :: UnitConfig -> Int
@@ -243,17 +229,41 @@ unitCount = M.size . ucUnits
 -- | Minimal bootstrap unit config (kg, m, s, item) for when no CSV is loaded.
 defaultUnitConfig :: UnitConfig
 defaultUnitConfig =
+    mkUnitConfig
+        defaultDimensionOrder
+        ( M.fromList
+            [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
+            , ("m", UnitDef [0, 1, 0, 0, 0, 0, 0, 0] 1.0)
+            , ("s", UnitDef [0, 0, 1, 0, 0, 0, 0, 0] 1.0)
+            , ("item", UnitDef [0, 0, 0, 0, 0, 0, 1, 0] 1.0)
+            ]
+        )
+        (M.fromList [("kg", "kg"), ("m", "m"), ("s", "s"), ("item", "item")])
+
+{- | Assemble a config, indexing the reference unit of every dimension once.
+
+'canonicalUnitFor' is asked once per row of every file read, and answering it
+by scanning the table is the whole table walked per row. The answer depends
+only on the table, so it is computed here.
+-}
+mkUnitConfig :: [Text] -> M.Map Text UnitDef -> M.Map Text Text -> UnitConfig
+mkUnitConfig dimOrder units originalKeys =
     UnitConfig
-        { ucDimensionOrder = defaultDimensionOrder
-        , ucUnits =
-            M.fromList
-                [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
-                , ("m", UnitDef [0, 1, 0, 0, 0, 0, 0, 0] 1.0)
-                , ("s", UnitDef [0, 0, 1, 0, 0, 0, 0, 0] 1.0)
-                , ("item", UnitDef [0, 0, 0, 0, 0, 0, 1, 0] 1.0)
-                ]
-        , ucOriginalKeys = M.fromList [("kg", "kg"), ("m", "m"), ("s", "s"), ("item", "item")]
+        { ucDimensionOrder = dimOrder
+        , ucUnits = units
+        , ucOriginalKeys = originalKeys
+        , ucCanonical = M.mapMaybe (\(UnitDef dim _) -> snd <$> M.lookup dim references) units
         }
+  where
+    references =
+        M.fromListWith
+            shorter
+            [ (udDimension def, (normKey, M.findWithDefault normKey normKey originalKeys))
+            | (normKey, def) <- M.toList units
+            , udFactor def == 1.0
+            ]
+    shorter a b = if sortKey a <= sortKey b then a else b
+    sortKey (normKey, _) = (T.length normKey, normKey)
 
 -- | Tracker for unknown units encountered during parsing.
 data UnknownUnitTracker = UnknownUnitTracker

--- a/test/BrightwayExcelWriterSpec.hs
+++ b/test/BrightwayExcelWriterSpec.hs
@@ -277,7 +277,7 @@ elec =
 prodExch :: Exchange
 prodExch =
     TechnosphereExchange
-        { techFlowId = generateFlowUUID "electricity, high voltage" "" "kilowatt hour"
+        { techFlowId = generateFlowUUID "electricity, high voltage" ""
         , techAmount = 1
         , techUnitId = generateUnitUUID "kilowatt hour"
         , techRole = ReferenceProduct
@@ -291,7 +291,7 @@ prodExch =
 gasExch :: Exchange
 gasExch =
     TechnosphereExchange
-        { techFlowId = generateFlowUUID "natural gas, high pressure" "" "cubic meter"
+        { techFlowId = generateFlowUUID "natural gas, high pressure" ""
         , techAmount = 8.5
         , techUnitId = generateUnitUUID "cubic meter"
         , techRole = Input
@@ -317,7 +317,7 @@ co2Exch =
 elecFlow :: TechnosphereFlow
 elecFlow =
     TechnosphereFlow
-        (generateFlowUUID "electricity, high voltage" "" "kilowatt hour")
+        (generateFlowUUID "electricity, high voltage" "")
         "electricity, high voltage"
         (generateUnitUUID "kilowatt hour")
         M.empty
@@ -327,7 +327,7 @@ elecFlow =
 gasFlow :: TechnosphereFlow
 gasFlow =
     TechnosphereFlow
-        (generateFlowUUID "natural gas, high pressure" "" "cubic meter")
+        (generateFlowUUID "natural gas, high pressure" "")
         "natural gas, high pressure"
         (generateUnitUUID "cubic meter")
         M.empty
@@ -401,7 +401,7 @@ specialAct =
 specialProdFlow :: TechnosphereFlow
 specialProdFlow =
     TechnosphereFlow
-        (generateFlowUUID specialProductName "" "kilogram")
+        (generateFlowUUID specialProductName "")
         specialProductName
         (generateUnitUUID "kilogram")
         M.empty
@@ -411,7 +411,7 @@ specialProdFlow =
 specialInputFlow :: TechnosphereFlow
 specialInputFlow =
     TechnosphereFlow
-        (generateFlowUUID specialInputName "" "kilogram")
+        (generateFlowUUID specialInputName "")
         specialInputName
         (generateUnitUUID "kilogram")
         M.empty
@@ -421,7 +421,7 @@ specialInputFlow =
 specialBio :: BiosphereFlow
 specialBio =
     co2
-        { bfId = generateFlowUUID specialBioName "air" "kilogram"
+        { bfId = generateFlowUUID specialBioName "air"
         , bfName = specialBioName
         }
 
@@ -440,7 +440,7 @@ specialNormalized =
 solventFlow :: TechnosphereFlow
 solventFlow =
     TechnosphereFlow
-        (generateFlowUUID "spent solvent" "" "kilogram")
+        (generateFlowUUID "spent solvent" "")
         "spent solvent"
         (generateUnitUUID "kilogram")
         M.empty
@@ -511,7 +511,7 @@ chpHeatFlow = kgFlow "recovered heat"
 kgFlow :: Text -> TechnosphereFlow
 kgFlow n =
     TechnosphereFlow
-        (generateFlowUUID n "" "kilogram")
+        (generateFlowUUID n "")
         n
         (generateUnitUUID "kilogram")
         M.empty
@@ -599,7 +599,7 @@ gramProdFlow = flowInUnit "milled flour" "g"
 -- | A flow whose generated UUIDs key off the given unit string.
 flowInUnit :: Text -> Text -> TechnosphereFlow
 flowInUnit n u =
-    TechnosphereFlow (generateFlowUUID n "" u) n (generateUnitUUID u) M.empty Nothing Nothing
+    TechnosphereFlow (generateFlowUUID n "") n (generateUnitUUID u) M.empty Nothing Nothing
 
 {- | One activity whose reference product is stated in grams (1000 g). On import
 under 'gramConfig' the parser rewrites it to 1 kg, so it is not a fixed point of
@@ -662,7 +662,7 @@ wasteDb =
 scrapFlow :: WasteFlow
 scrapFlow =
     WasteFlow
-        { wfId = generateFlowUUID "metal scrap" "" "kilogram"
+        { wfId = generateFlowUUID "metal scrap" ""
         , wfName = "metal scrap"
         , wfUnitId = generateUnitUUID "kilogram"
         , wfSynonyms = M.empty
@@ -722,7 +722,7 @@ subnormalDb =
 co2 :: BiosphereFlow
 co2 =
     BiosphereFlow
-        { bfId = generateFlowUUID "Carbon dioxide, fossil" "air" "kilogram"
+        { bfId = generateFlowUUID "Carbon dioxide, fossil" "air"
         , bfName = "Carbon dioxide, fossil"
         , bfUnitId = generateUnitUUID "kilogram"
         , bfSynonyms = M.empty

--- a/test/CrossDBRegionalLCIAFixture.hs
+++ b/test/CrossDBRegionalLCIAFixture.hs
@@ -55,7 +55,7 @@ import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, fill
 import Method.Types (CFFamily (..), FlowDirection (..), MethodCF (..))
 import Types
 import qualified Types as VT
-import UnitConversion (UnitConfig (..), UnitDef (..))
+import UnitConversion (UnitConfig (..), UnitDef (..), mkUnitConfig)
 
 -- | One biosphere flow shared by both DBs (cross-DB merging keys on UUID).
 flowUUID :: UUID
@@ -76,12 +76,10 @@ kgUnit = Unit{unitId = mkUUID 9, unitName = "kg", unitSymbol = "kg", unitComment
 
 kgUnitConfig :: UnitConfig
 kgUnitConfig =
-    UnitConfig
-        { ucDimensionOrder =
-            ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
-        , ucUnits = M.fromList [("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)]
-        , ucOriginalKeys = M.fromList [("kg", "kg")]
-        }
+    mkUnitConfig
+        (["mass", "length", "time", "energy", "area", "volume", "count", "currency"])
+        (M.fromList [("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)])
+        (M.fromList [("kg", "kg")])
 
 testFlow :: BiosphereFlow
 testFlow =

--- a/test/CrossDBRegionalLCIAFixture.hs
+++ b/test/CrossDBRegionalLCIAFixture.hs
@@ -77,7 +77,7 @@ kgUnit = Unit{unitId = mkUUID 9, unitName = "kg", unitSymbol = "kg", unitComment
 kgUnitConfig :: UnitConfig
 kgUnitConfig =
     mkUnitConfig
-        (["mass", "length", "time", "energy", "area", "volume", "count", "currency"])
+        ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
         (M.fromList [("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)])
         (M.fromList [("kg", "kg")])
 

--- a/test/CrossLinkingSpec.hs
+++ b/test/CrossLinkingSpec.hs
@@ -71,57 +71,6 @@ spec = do
             normalizeText "bio\x202Fgas" `shouldBe` "bio gas"
 
     -- -----------------------------------------------------------------------
-    -- stripTrailingDBTag
-    -- -----------------------------------------------------------------------
-    describe "stripTrailingDBTag" $ do
-        it "strips '(WFLDB)' suffix" $
-            stripTrailingDBTag "wheat (WFLDB)" `shouldBe` Just "wheat"
-
-        it "strips '(AGRIBALYSE)' suffix" $
-            stripTrailingDBTag "tomato (AGRIBALYSE)" `shouldBe` Just "tomato"
-
-        it "returns Nothing when no tag present" $
-            stripTrailingDBTag "wheat" `shouldBe` Nothing
-
-        it "returns Nothing for lowercase content" $
-            stripTrailingDBTag "wheat (organic)" `shouldBe` Nothing
-
-        it "returns Nothing for empty string" $
-            stripTrailingDBTag "" `shouldBe` Nothing
-
-    -- -----------------------------------------------------------------------
-    -- stripTrailingLocationSuffix
-    -- -----------------------------------------------------------------------
-    describe "stripTrailingLocationSuffix" $ do
-        it "strips '/CA U' suffix" $
-            stripTrailingLocationSuffix "wheat (WFLDB)/CA U" `shouldBe` Just "wheat (WFLDB)"
-
-        it "strips '/GLO S' suffix" $
-            stripTrailingLocationSuffix "electricity/GLO S" `shouldBe` Just "electricity"
-
-        it "returns Nothing when no slash present" $
-            stripTrailingLocationSuffix "wheat" `shouldBe` Nothing
-
-        it "returns Nothing when suffix has wrong format" $
-            stripTrailingLocationSuffix "a/b/c" `shouldBe` Nothing
-
-    -- -----------------------------------------------------------------------
-    -- extractProductPrefixes
-    -- -----------------------------------------------------------------------
-    describe "extractProductPrefixes" $ do
-        it "splits on '//' separator" $
-            extractProductPrefixes "wheat//[GLO] wheat production" `shouldContain` ["wheat"]
-
-        it "splits on ' {' separator" $
-            extractProductPrefixes "electricity {FR}" `shouldContain` ["electricity"]
-
-        it "strips DB tag" $
-            extractProductPrefixes "wheat (WFLDB)" `shouldContain` ["wheat"]
-
-        it "returns empty list for plain name with no separator" $
-            extractProductPrefixes "wheat" `shouldBe` []
-
-    -- -----------------------------------------------------------------------
     -- extractBracketedLocation
     -- -----------------------------------------------------------------------
     describe "extractBracketedLocation" $ do
@@ -194,19 +143,6 @@ spec = do
             let synDB = buildFromPairs [("co2", "carbon dioxide")]
             -- After normalization both resolve to the same group in a symmetric pair
             matchProductName synDB "CO2" "carbon dioxide" `shouldSatisfy` (>= 45)
-
-    -- -----------------------------------------------------------------------
-    -- extractProductPrefixes — additional cases
-    -- -----------------------------------------------------------------------
-    describe "extractProductPrefixes (additional)" $ do
-        it "strips location suffix /CA U" $
-            extractProductPrefixes "wheat (WFLDB)/CA U" `shouldContain` ["wheat (WFLDB)"]
-
-        it "strips both tag and location suffix" $
-            extractProductPrefixes "wheat (WFLDB)/CA U" `shouldContain` ["wheat"]
-
-        it "splits on ' |' separator" $
-            extractProductPrefixes "heat | natural gas | CH" `shouldContain` ["heat"]
 
     -- -----------------------------------------------------------------------
     -- isSubregionOf — additional location pairs

--- a/test/ExplainCFSpec.hs
+++ b/test/ExplainCFSpec.hs
@@ -38,7 +38,7 @@ import Method.Types (CFFamily (..), Compartment (..), EnergyDensity (..), Energy
 import SynonymDB (normalizeName)
 import Types (BiosphereFlow (..), Unit (..), UnitDB)
 import qualified Types as VT
-import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig)
+import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig, mkUnitConfig)
 
 mkUUID :: Integer -> UUID
 mkUUID n = UUID.fromWords64 (fromIntegral n) 0
@@ -54,15 +54,14 @@ than an unknown unit.
 -}
 massEnergyConfig :: UnitConfig
 massEnergyConfig =
-    UnitConfig
-        { ucDimensionOrder = ["mass", "energy"]
-        , ucUnits =
-            M.fromList
-                [ ("kg", UnitDef [1, 0] 1.0)
-                , ("mj", UnitDef [0, 1] 1.0)
-                ]
-        , ucOriginalKeys = M.fromList [("kg", "kg"), ("mj", "MJ")]
-        }
+    mkUnitConfig
+        (["mass", "energy"])
+        ( M.fromList
+            [ ("kg", UnitDef [1, 0] 1.0)
+            , ("mj", UnitDef [0, 1] 1.0)
+            ]
+        )
+        (M.fromList [("kg", "kg"), ("mj", "MJ")])
 
 cfLine :: Text -> Text -> Text -> Double -> MethodCF
 cfLine name sub unit val =
@@ -401,8 +400,7 @@ spec = do
   where
     -- kg and m3 known but dimensionally apart, so the pair is a mismatch.
     volumeMassConfig =
-        UnitConfig
-            { ucDimensionOrder = ["mass", "volume"]
-            , ucUnits = M.fromList [("kg", UnitDef [1, 0] 1.0), ("m3", UnitDef [0, 1] 1.0)]
-            , ucOriginalKeys = M.fromList [("kg", "kg"), ("m3", "m3")]
-            }
+        mkUnitConfig
+            (["mass", "volume"])
+            (M.fromList [("kg", UnitDef [1, 0] 1.0), ("m3", UnitDef [0, 1] 1.0)])
+            (M.fromList [("kg", "kg"), ("m3", "m3")])

--- a/test/ExplainCFSpec.hs
+++ b/test/ExplainCFSpec.hs
@@ -55,7 +55,7 @@ than an unknown unit.
 massEnergyConfig :: UnitConfig
 massEnergyConfig =
     mkUnitConfig
-        (["mass", "energy"])
+        ["mass", "energy"]
         ( M.fromList
             [ ("kg", UnitDef [1, 0] 1.0)
             , ("mj", UnitDef [0, 1] 1.0)
@@ -401,6 +401,6 @@ spec = do
     -- kg and m3 known but dimensionally apart, so the pair is a mismatch.
     volumeMassConfig =
         mkUnitConfig
-            (["mass", "volume"])
+            ["mass", "volume"]
             (M.fromList [("kg", UnitDef [1, 0] 1.0), ("m3", UnitDef [0, 1] 1.0)])
             (M.fromList [("kg", "kg"), ("m3", "m3")])

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -5,6 +5,7 @@ module LoaderSpec (spec) where
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.Text (Text)
+import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import System.Directory (createDirectoryIfMissing)
@@ -13,7 +14,6 @@ import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
 import Database.Loader
-import SimaPro.Parser (foldedNameCollisions)
 import TestHelpers (loadSampleDatabase)
 import Types
 import UnitConversion (defaultUnitConfig)
@@ -187,25 +187,44 @@ spec = do
             tfName (mergeTechFlows a b) `shouldBe` "flow-a"
 
     -- -----------------------------------------------------------------------
-    describe "foldedNameCollisions" $ do
-        it "names two spellings a case fold brings together" $ do
+    describe "indexActivities" $ do
+        it "names the two spellings a case fold brings together, and keeps the last read" $ do
             let acts =
                     [ minimalActivity "Steel, low-alloyed" "GLO" [refExchange flowUUID1]
                     , minimalActivity "steel, low-alloyed" "GLO" [refExchange flowUUID1]
                     ]
-            foldedNameCollisions acts `shouldBe` [["Steel, low-alloyed", "steel, low-alloyed"]]
+                (procMap, collisions) = indexActivities acts
+            M.size procMap `shouldBe` 1
+            map activityName (M.elems procMap) `shouldBe` ["steel, low-alloyed"]
+            length collisions `shouldBe` 1
+            head collisions `shouldSatisfy` \msg ->
+                all (`T.isInfixOf` msg) ["'Steel, low-alloyed'", "'steel, low-alloyed'", "GLO"]
 
         it "says nothing about one spelling written twice at two locations" $ do
             let acts =
                     [ minimalActivity "Steel, low-alloyed" "GLO" [refExchange flowUUID1]
                     , minimalActivity "Steel, low-alloyed" "FR" [refExchange flowUUID1]
                     ]
-            foldedNameCollisions acts `shouldBe` []
+                (procMap, collisions) = indexActivities acts
+            M.size procMap `shouldBe` 2
+            collisions `shouldBe` []
+
+        it "says nothing when the two blocks state two products" $ do
+            let acts =
+                    [ minimalActivity "Steel, low-alloyed" "GLO" [refExchange flowUUID1]
+                    , minimalActivity "steel, low-alloyed" "GLO" [refExchange flowUUID2]
+                    ]
+                (procMap, collisions) = indexActivities acts
+            M.size procMap `shouldBe` 2
+            collisions `shouldBe` []
 
         it "leaves blocks their file identifies alone" $ do
             let published name = (minimalActivity name "GLO" [refExchange flowUUID1]){activityNativeId = Just (NativeProcessId name)}
-            foldedNameCollisions [published "Steel, low-alloyed", published "steel, low-alloyed"] `shouldBe` []
+                (procMap, collisions) = indexActivities [published "Steel, low-alloyed", published "steel, low-alloyed"]
+            M.size procMap `shouldBe` 2
+            collisions `shouldBe` []
 
+    -- -----------------------------------------------------------------------
     -- generateActivityUUIDFromActivity
     -- -----------------------------------------------------------------------
     describe "generateActivityUUIDFromActivity" $ do

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -13,6 +13,7 @@ import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
 import Database.Loader
+import SimaPro.Parser (foldedNameCollisions)
 import TestHelpers (loadSampleDatabase)
 import Types
 import UnitConversion (defaultUnitConfig)
@@ -186,6 +187,25 @@ spec = do
             tfName (mergeTechFlows a b) `shouldBe` "flow-a"
 
     -- -----------------------------------------------------------------------
+    describe "foldedNameCollisions" $ do
+        it "names two spellings a case fold brings together" $ do
+            let acts =
+                    [ minimalActivity "Steel, low-alloyed" "GLO" [refExchange flowUUID1]
+                    , minimalActivity "steel, low-alloyed" "GLO" [refExchange flowUUID1]
+                    ]
+            foldedNameCollisions acts `shouldBe` [["Steel, low-alloyed", "steel, low-alloyed"]]
+
+        it "says nothing about one spelling written twice at two locations" $ do
+            let acts =
+                    [ minimalActivity "Steel, low-alloyed" "GLO" [refExchange flowUUID1]
+                    , minimalActivity "Steel, low-alloyed" "FR" [refExchange flowUUID1]
+                    ]
+            foldedNameCollisions acts `shouldBe` []
+
+        it "leaves blocks their file identifies alone" $ do
+            let published name = (minimalActivity name "GLO" [refExchange flowUUID1]){activityNativeId = Just (NativeProcessId name)}
+            foldedNameCollisions [published "Steel, low-alloyed", published "steel, low-alloyed"] `shouldBe` []
+
     -- generateActivityUUIDFromActivity
     -- -----------------------------------------------------------------------
     describe "generateActivityUUIDFromActivity" $ do

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -58,6 +58,10 @@ minimalActivity name loc exs =
         , activityFormulaCheck = Nothing
         }
 
+-- | The same activity, filed in the source's obsolete category.
+retired :: Activity -> Activity
+retired act = act{activityClassification = M.singleton "Category" "Autres\\Obsolete"}
+
 refExchange :: UUID.UUID -> Exchange
 refExchange fid =
     TechnosphereExchange
@@ -345,6 +349,23 @@ spec = do
             -- "whitout" sorts before "without", and holds flowUUID2.
             M.lookup "pork, bone" (buildSupplierIndexByName M.empty acts flows)
                 `shouldBe` Just (actUUID2, flowUUID2, "unknown")
+
+        it "lets the block the source retired lose the tie" $ do
+            -- The same pair, one of them now filed under an obsolete
+            -- category. The file says which of the two it means, so the name
+            -- sort is not consulted and the block still in service supplies.
+            let acts =
+                    M.fromList
+                        [ ((actUUID1, flowUUID1), minimalActivity "Pork, meat without bone" "FR" [refExchange flowUUID1])
+                        , ((actUUID2, flowUUID2), retired (minimalActivity "Pork, meat whitout bone" "FR" [refExchange flowUUID2]))
+                        ]
+                flows =
+                    M.fromList
+                        [ (flowUUID1, minimalFlow flowUUID1 "Pork, bone")
+                        , (flowUUID2, minimalFlow flowUUID2 "Pork, bone")
+                        ]
+            M.lookup "pork, bone" (buildSupplierIndexByName M.empty acts flows)
+                `shouldBe` Just (actUUID1, flowUUID1, "unknown")
 
         it "does not index a prefix of a product name" $ do
             -- "Urea {RER}| urea production" and "Urea {RoW}| urea production"

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -328,6 +328,33 @@ spec = do
             -- empty UnitDB → reference unit resolves to the "unknown" sentinel
             M.lookup "wheat production" idx `shouldBe` Just (actUUID1, flowUUID1, "unknown")
 
+        it "picks a duplicate producer by name, never by identifier" $ do
+            -- The typo pair: two blocks exported under names differing by one
+            -- letter, both declaring the same product. Either answers, and the
+            -- one picked must not move when identity is minted differently.
+            let acts =
+                    M.fromList
+                        [ ((actUUID1, flowUUID1), minimalActivity "Pork, meat without bone" "FR" [refExchange flowUUID1])
+                        , ((actUUID2, flowUUID2), minimalActivity "Pork, meat whitout bone" "FR" [refExchange flowUUID2])
+                        ]
+                flows =
+                    M.fromList
+                        [ (flowUUID1, minimalFlow flowUUID1 "Pork, bone")
+                        , (flowUUID2, minimalFlow flowUUID2 "Pork, bone")
+                        ]
+            -- "whitout" sorts before "without", and holds flowUUID2.
+            M.lookup "pork, bone" (buildSupplierIndexByName M.empty acts flows)
+                `shouldBe` Just (actUUID2, flowUUID2, "unknown")
+
+        it "does not index a prefix of a product name" $ do
+            -- "Urea {RER}| urea production" and "Urea {RoW}| urea production"
+            -- are not the same product, and neither is "Urea".
+            let act = minimalActivity "urea market" "RER" [refExchange flowUUID1]
+                acts = M.fromList [((actUUID1, flowUUID1), act)]
+                flows = M.fromList [(flowUUID1, minimalFlow flowUUID1 "Urea {RER}| market for urea | Cut-off, S")]
+                idx = buildSupplierIndexByName M.empty acts flows
+            M.keys idx `shouldBe` ["urea {rer}| market for urea | cut-off, s"]
+
         it "does not index non-reference exchanges" $ do
             let act =
                     minimalActivity
@@ -355,6 +382,17 @@ spec = do
         it "leaves exchange unlinked when supplier not in index" $ do
             let flows = M.fromList [(flowUUID1, minimalFlow flowUUID1 "wheat")]
                 idx = M.empty
+                ex = inputExchange flowUUID1 "GLO"
+                (fixed, summary) = fixExchangeLinkByName defaultUnitConfig M.empty idx flows "consumer" ex
+            techActivityLinkId fixed `shouldBe` UUID.nil
+            usMissingLinks summary `shouldBe` 1
+
+        it "leaves an input unlinked rather than resolving a prefix of its name" $ do
+            -- The nine rows of the Agribalyse 4.0 export that name an ecoinvent
+            -- unit process the export does not carry. Answering with the
+            -- Chinese market because both start with "Urea" is not an answer.
+            let flows = M.fromList [(flowUUID1, minimalFlow flowUUID1 "Urea {RoW}| urea production | Cut-off, S")]
+                idx = M.fromList [("urea", (actUUID1, flowUUID2, ""))]
                 ex = inputExchange flowUUID1 "GLO"
                 (fixed, summary) = fixExchangeLinkByName defaultUnitConfig M.empty idx flows "consumer" ex
             techActivityLinkId fixed `shouldBe` UUID.nil

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -63,7 +63,7 @@ unitNamed n = Unit{unitId = nil, unitName = n, unitSymbol = n, unitComment = ""}
 gKgUnitConfig :: UnitConfig
 gKgUnitConfig =
     mkUnitConfig
-        (["mass", "length", "time", "energy", "area", "volume", "count", "currency"])
+        ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
         ( M.fromList
             [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
             , ("g", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 0.001)
@@ -78,7 +78,7 @@ branch's hard-fail to 0.
 gOnlyUnitConfig :: UnitConfig
 gOnlyUnitConfig =
     mkUnitConfig
-        (["mass", "length", "time", "energy", "area", "volume", "count", "currency"])
+        ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
         (M.fromList [("g", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 0.001)])
         (M.fromList [("g", "g")])
 
@@ -452,7 +452,7 @@ spec = do
             m3Def = UnitDef [0, 3, 0, 0, 0, 0, 0, 0] 1.0
             cfg =
                 mkUnitConfig
-                    ([])
+                    []
                     (M.fromList [("kg", kgDef), ("m3", m3Def)])
                     (M.fromList [("kg", "kg"), ("m3", "m3")])
             cfPerKg = (mkCFComp "Gas, natural/kg" "natural resource" "" 43.1){mcfUnit = "kg"}
@@ -781,7 +781,7 @@ spec = do
         -- exactly the silent undercount this scan exists to surface.
         let cfg =
                 mkUnitConfig
-                    ([])
+                    []
                     ( M.fromList
                         [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
                         , ("m3", UnitDef [0, 1, 0, 0, 0, 0, 0, 0] 1.0)

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -19,7 +19,7 @@ import Method.Types (Compartment (..), EnergyDensity (..), FlowDirection (..), M
 import SynonymDB (BridgeDirection (..), SynEdge (..), buildFromEdges, buildFromPairs, emptySynonymDB, normalizeName)
 import Types (BiosphereFlow (..), Unit (..))
 import qualified Types as VT
-import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig)
+import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig, mkUnitConfig)
 
 -- ---------------------------------------------------------------------------
 -- Helpers
@@ -62,15 +62,14 @@ unitNamed n = Unit{unitId = nil, unitName = n, unitSymbol = n, unitComment = ""}
 -- | UnitConfig with both kg and g (mass) so g→kg conversion succeeds.
 gKgUnitConfig :: UnitConfig
 gKgUnitConfig =
-    UnitConfig
-        { ucDimensionOrder = ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
-        , ucUnits =
-            M.fromList
-                [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
-                , ("g", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 0.001)
-                ]
-        , ucOriginalKeys = M.fromList [("kg", "kg"), ("g", "g")]
-        }
+    mkUnitConfig
+        (["mass", "length", "time", "energy", "area", "volume", "count", "currency"])
+        ( M.fromList
+            [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
+            , ("g", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 0.001)
+            ]
+        )
+        (M.fromList [("kg", "kg"), ("g", "g")])
 
 {- | UnitConfig whose mass dimension has NO canonical base (g only, no kg at
 factor 1.0), so 'normalizeToCanonical' fails — exercises the result-expression
@@ -78,11 +77,10 @@ branch's hard-fail to 0.
 -}
 gOnlyUnitConfig :: UnitConfig
 gOnlyUnitConfig =
-    UnitConfig
-        { ucDimensionOrder = ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
-        , ucUnits = M.fromList [("g", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 0.001)]
-        , ucOriginalKeys = M.fromList [("g", "g")]
-        }
+    mkUnitConfig
+        (["mass", "length", "time", "energy", "area", "volume", "count", "currency"])
+        (M.fromList [("g", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 0.001)])
+        (M.fromList [("g", "g")])
 
 -- ---------------------------------------------------------------------------
 -- Spec
@@ -453,11 +451,10 @@ spec = do
         let kgDef = UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0
             m3Def = UnitDef [0, 3, 0, 0, 0, 0, 0, 0] 1.0
             cfg =
-                UnitConfig
-                    { ucDimensionOrder = []
-                    , ucUnits = M.fromList [("kg", kgDef), ("m3", m3Def)]
-                    , ucOriginalKeys = M.fromList [("kg", "kg"), ("m3", "m3")]
-                    }
+                mkUnitConfig
+                    ([])
+                    (M.fromList [("kg", kgDef), ("m3", m3Def)])
+                    (M.fromList [("kg", "kg"), ("m3", "m3")])
             cfPerKg = (mkCFComp "Gas, natural/kg" "natural resource" "" 43.1){mcfUnit = "kg"}
             cfPerM3 = (mkCFComp "Gas, natural/m3" "natural resource" "" 34.5){mcfUnit = "m3"}
 
@@ -708,11 +705,10 @@ spec = do
             let kgDef = UnitConversion.UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0
                 gDef = UnitConversion.UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0e-3
                 cfg =
-                    UnitConversion.UnitConfig
-                        { UnitConversion.ucDimensionOrder = []
-                        , UnitConversion.ucUnits = M.fromList [("kg", kgDef), ("g", gDef)]
-                        , UnitConversion.ucOriginalKeys = M.fromList [("kg", "kg"), ("g", "g")]
-                        }
+                    UnitConversion.mkUnitConfig
+                        []
+                        (M.fromList [("kg", kgDef), ("g", gDef)])
+                        (M.fromList [("kg", "kg"), ("g", "g")])
             fid <- nextRandom
             uidKg <- nextRandom
             let flow = (mkFlow fid "co2" "air" Nothing){bfUnitId = uidKg}
@@ -784,16 +780,15 @@ spec = do
         -- kg-denominated CF matched by an m3 flow is refused and scores 0 —
         -- exactly the silent undercount this scan exists to surface.
         let cfg =
-                UnitConfig
-                    { ucDimensionOrder = []
-                    , ucUnits =
-                        M.fromList
-                            [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
-                            , ("m3", UnitDef [0, 1, 0, 0, 0, 0, 0, 0] 1.0)
-                            , ("mj", UnitDef [0, 0, 1, 0, 0, 0, 0, 0] 1.0)
-                            ]
-                    , ucOriginalKeys = M.fromList [("kg", "kg"), ("m3", "m3"), ("mj", "MJ")]
-                    }
+                mkUnitConfig
+                    ([])
+                    ( M.fromList
+                        [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
+                        , ("m3", UnitDef [0, 1, 0, 0, 0, 0, 0, 0] 1.0)
+                        , ("mj", UnitDef [0, 0, 1, 0, 0, 0, 0, 0] 1.0)
+                        ]
+                    )
+                    (M.fromList [("kg", "kg"), ("m3", "m3"), ("mj", "MJ")])
             fillWith densities unitName' cf = do
                 fid <- nextRandom
                 uid <- nextRandom

--- a/test/QualityCsvSpec.hs
+++ b/test/QualityCsvSpec.hs
@@ -60,6 +60,7 @@ everyCheck =
         , qraMissingPedigree = finding "missing pedigree"
         , qraUnconsumedProducts = finding "unconsumed products"
         , qraUnsuppliedInputs = finding "unsupplied inputs"
+        , qraObsoleteInputs = finding "obsolete inputs"
         , qraLandTransformationBalance = finding "land transformation balance"
         , qraOxygenDemandOrder = finding "oxygen demand order"
         , qraInvalidCas = finding "invalid cas"
@@ -85,6 +86,7 @@ oneFinding detail =
         , qraMissingPedigree = quiet
         , qraUnconsumedProducts = quiet
         , qraUnsuppliedInputs = quiet
+        , qraObsoleteInputs = quiet
         , qraLandTransformationBalance = quiet
         , qraOxygenDemandOrder = quiet
         , qraInvalidCas = quiet
@@ -150,6 +152,7 @@ spec = describe "Quality report CSV" $ do
                        , "missing_pedigree"
                        , "unconsumed_products"
                        , "unsupplied_inputs"
+                       , "obsolete_inputs"
                        , "land_transformation_balance"
                        , "oxygen_demand_order"
                        , "invalid_cas"

--- a/test/QualityCsvSpec.hs
+++ b/test/QualityCsvSpec.hs
@@ -51,6 +51,7 @@ everyCheck =
         , qraReferenceProduct = finding "reference product"
         , qraAllocationSums = finding "allocation sums"
         , qraDuplicateActivities = finding "duplicate activities"
+        , qraDuplicateProducts = finding "duplicate products"
         , qraSuspiciousAmounts = finding "suspicious amounts"
         , qraMissingMetadata = finding "missing metadata"
         , qraUndeclaredGeography = finding "undeclared geography"
@@ -75,6 +76,7 @@ oneFinding detail =
         , qraReferenceProduct = finding detail
         , qraAllocationSums = quiet
         , qraDuplicateActivities = quiet
+        , qraDuplicateProducts = quiet
         , qraSuspiciousAmounts = quiet
         , qraMissingMetadata = quiet
         , qraUndeclaredGeography = quiet
@@ -139,6 +141,7 @@ spec = describe "Quality report CSV" $ do
                        , "reference_product"
                        , "allocation_sums"
                        , "duplicate_activities"
+                       , "duplicate_products"
                        , "suspicious_amounts"
                        , "missing_metadata"
                        , "undeclared_geography"

--- a/test/QualityCsvSpec.hs
+++ b/test/QualityCsvSpec.hs
@@ -58,6 +58,7 @@ everyCheck =
         , qraTruncatedNameCollisions = finding "truncated name collisions"
         , qraMissingPedigree = finding "missing pedigree"
         , qraUnconsumedProducts = finding "unconsumed products"
+        , qraUnsuppliedInputs = finding "unsupplied inputs"
         , qraLandTransformationBalance = finding "land transformation balance"
         , qraOxygenDemandOrder = finding "oxygen demand order"
         , qraInvalidCas = finding "invalid cas"
@@ -81,6 +82,7 @@ oneFinding detail =
         , qraTruncatedNameCollisions = quiet
         , qraMissingPedigree = quiet
         , qraUnconsumedProducts = quiet
+        , qraUnsuppliedInputs = quiet
         , qraLandTransformationBalance = quiet
         , qraOxygenDemandOrder = quiet
         , qraInvalidCas = quiet
@@ -144,6 +146,7 @@ spec = describe "Quality report CSV" $ do
                        , "truncated_name_collisions"
                        , "missing_pedigree"
                        , "unconsumed_products"
+                       , "unsupplied_inputs"
                        , "land_transformation_balance"
                        , "oxygen_demand_order"
                        , "invalid_cas"

--- a/test/QualityReportSpec.hs
+++ b/test/QualityReportSpec.hs
@@ -129,6 +129,10 @@ input fid amount = techExchange fid amount Input
 referenceInput :: UUID -> Exchange
 referenceInput fid = techExchange fid 1.0 ReferenceInput
 
+-- | An input that names its supplier, the way EcoSpold 2 writes one.
+linkedInput :: UUID -> UUID -> Exchange
+linkedInput supplier fid = (input fid 1.0){techActivityLinkId = supplier}
+
 -- | The same technosphere line with pedigree scores attached.
 pedigreed :: Exchange -> Exchange
 pedigreed ex = ex{techPedigree = mkPedigree 3 3 2 1 2}
@@ -340,6 +344,7 @@ spec = do
                     dbOf
                         [ ((actA, prodA), mkActivity "pork, meat whitout bone" [reference breadFlow])
                         , ((actB, prodB), mkActivity "pork, meat without bone" [reference breadFlow])
+                        , ((actC, prodC), mkActivity "sausage" [reference flourFlow, input breadFlow 1.0])
                         ]
                 check = qrDuplicateProducts (qualityReport "testdb" db)
             severities check `shouldBe` [WarningSev, WarningSev]
@@ -360,6 +365,18 @@ spec = do
 
         it "skips entries whose reference is broken, leaving them to the reference check" $ do
             let db = dbOf [((actA, prodA), mkActivity "bread" []), ((actB, prodB), mkActivity "bread" [])]
+            qcOffenders (qrDuplicateProducts (qualityReport "testdb" db)) `shouldBe` []
+
+        it "passes a duplicated product every input names its supplier for" $ do
+            -- EcoSpold 2 shape: one product, many producers, and each input
+            -- says which one it means. Nothing has to be guessed, so nothing
+            -- is wrong.
+            let db =
+                    dbOf
+                        [ ((actA, prodA), mkActivity "bakery FR" [reference breadFlow])
+                        , ((actB, prodB), mkActivity "bakery DE" [reference breadFlow])
+                        , ((actC, prodC), mkActivity "sausage" [reference flourFlow, linkedInput actA breadFlow])
+                        ]
             qcOffenders (qrDuplicateProducts (qualityReport "testdb" db)) `shouldBe` []
 
     describe "suspicious amounts check" $ do

--- a/test/QualityReportSpec.hs
+++ b/test/QualityReportSpec.hs
@@ -325,6 +325,37 @@ spec = do
             let db = dbOf [((actA, prodA), mkActivity "bread" []), ((actB, prodB), mkActivity "bread" [])]
             qcOffenders (qrDuplicateActivities (qualityReport "testdb" db)) `shouldBe` []
 
+    describe "duplicate products check" $ do
+        it "flags two activities declaring one reference product" $ do
+            -- The shape a stale export leaves behind: one block kept, one
+            -- retired, both still declaring the product, their names apart by
+            -- a typo so the duplicate-activities check cannot see them.
+            let db =
+                    dbOf
+                        [ ((actA, prodA), mkActivity "pork, meat whitout bone" [reference breadFlow])
+                        , ((actB, prodB), mkActivity "pork, meat without bone" [reference breadFlow])
+                        ]
+                check = qrDuplicateProducts (qualityReport "testdb" db)
+            severities check `shouldBe` [WarningSev, WarningSev]
+            details check
+                `shouldBe` [ "this product is also the reference product of \"pork, meat without bone\"; an input naming it is answered by one of them"
+                           , "this product is also the reference product of \"pork, meat whitout bone\"; an input naming it is answered by one of them"
+                           ]
+            processIds check `shouldBe` [pidOf actA prodA, pidOf actB prodB]
+            map qoProductName (qcOffenders check) `shouldBe` [Just "bread", Just "bread"]
+
+        it "passes a product only one activity declares" $ do
+            let db =
+                    dbOf
+                        [ ((actA, prodA), mkActivity "bakery" [reference breadFlow])
+                        , ((actB, prodB), mkActivity "mill" [reference flourFlow])
+                        ]
+            qcOffenders (qrDuplicateProducts (qualityReport "testdb" db)) `shouldBe` []
+
+        it "skips entries whose reference is broken, leaving them to the reference check" $ do
+            let db = dbOf [((actA, prodA), mkActivity "bread" []), ((actB, prodB), mkActivity "bread" [])]
+            qcOffenders (qrDuplicateProducts (qualityReport "testdb" db)) `shouldBe` []
+
     describe "suspicious amounts check" $ do
         it "flags a non-finite amount" $ do
             let check = qrSuspiciousAmounts (reportOf (mkActivity "bread" [reference breadFlow, input flourFlow (0 / 0)]))

--- a/test/QualityReportSpec.hs
+++ b/test/QualityReportSpec.hs
@@ -509,6 +509,25 @@ spec = do
             qcOffenders (qrUnconsumedProducts (reportOf (mkActivity "no reference" [input flourFlow 1.0])))
                 `shouldBe` []
 
+    describe "unsupplied inputs check" $ do
+        it "flags an input no reference product of the database supplies" $ do
+            let db = dbOf [((actA, prodA), mkActivity "bread" [reference breadFlow, input flourFlow 1.0])]
+                check = qrUnsuppliedInputs (qualityReport "testdb" db)
+            severities check `shouldBe` [InfoSev]
+            processIds check `shouldBe` [pidOf actA prodA]
+
+        it "passes when the database produces what it consumes" $ do
+            let db =
+                    dbOf
+                        [ ((actA, prodA), mkActivity "bread" [reference breadFlow, input flourFlow 1.0])
+                        , ((actB, prodB), mkActivity "flour mill" [reference flourFlow])
+                        ]
+            qcOffenders (qrUnsuppliedInputs (qualityReport "testdb" db)) `shouldBe` []
+
+        it "says nothing about a biosphere exchange, which has no supplier" $ do
+            let db = dbOf [((actA, prodA), mkActivity "bread" [reference breadFlow, bioExchange flourFlow 1.0])]
+            qcOffenders (qrUnsuppliedInputs (qualityReport "testdb" db)) `shouldBe` []
+
     describe "land transformation balance check" $ do
         it "flags an activity whose transformed-from and transformed-to areas diverge" $ do
             let act = mkActivity "land clearing" [reference breadFlow, bioExchange transFromFlow 10, bioExchange transToFlow 4]

--- a/test/QualityReportSpec.hs
+++ b/test/QualityReportSpec.hs
@@ -85,14 +85,17 @@ obsolete :: Activity -> Activity
 obsolete act = act{activityClassification = M.insert "Category" "Others\\Obsolete" (activityClassification act)}
 
 mkActivity :: Text -> [Exchange] -> Activity
-mkActivity name exs =
+mkActivity name = mkActivityAt name "FR"
+
+mkActivityAt :: Text -> Text -> [Exchange] -> Activity
+mkActivityAt name location exs =
     Activity
         { activityName = name
         , activityDescription = ["A described activity"]
         , activityDocumentation = []
         , activitySynonyms = M.empty
         , activityClassification = M.singleton "ISIC" "1071"
-        , activityLocation = "FR"
+        , activityLocation = location
         , activityLocationSource = LocationDeclared
         , activityUnit = "kg"
         , exchanges = exs
@@ -128,10 +131,6 @@ input fid amount = techExchange fid amount Input
 -- | A treatment activity is defined by the waste it consumes, not by an output.
 referenceInput :: UUID -> Exchange
 referenceInput fid = techExchange fid 1.0 ReferenceInput
-
--- | An input that names its supplier, the way EcoSpold 2 writes one.
-linkedInput :: UUID -> UUID -> Exchange
-linkedInput supplier fid = (input fid 1.0){techActivityLinkId = supplier}
 
 -- | The same technosphere line with pedigree scores attached.
 pedigreed :: Exchange -> Exchange
@@ -344,13 +343,12 @@ spec = do
                     dbOf
                         [ ((actA, prodA), mkActivity "pork, meat whitout bone" [reference breadFlow])
                         , ((actB, prodB), mkActivity "pork, meat without bone" [reference breadFlow])
-                        , ((actC, prodC), mkActivity "sausage" [reference flourFlow, input breadFlow 1.0])
                         ]
                 check = qrDuplicateProducts (qualityReport "testdb" db)
             severities check `shouldBe` [WarningSev, WarningSev]
             details check
-                `shouldBe` [ "this product is also the reference product of \"pork, meat without bone\"; an input naming it is answered by one of them"
-                           , "this product is also the reference product of \"pork, meat whitout bone\"; an input naming it is answered by one of them"
+                `shouldBe` [ "this product is also the reference product of \"pork, meat without bone\" at the same location; an input naming it is answered by one of them"
+                           , "this product is also the reference product of \"pork, meat whitout bone\" at the same location; an input naming it is answered by one of them"
                            ]
             processIds check `shouldBe` [pidOf actA prodA, pidOf actB prodB]
             map qoProductName (qcOffenders check) `shouldBe` [Just "bread", Just "bread"]
@@ -367,15 +365,15 @@ spec = do
             let db = dbOf [((actA, prodA), mkActivity "bread" []), ((actB, prodB), mkActivity "bread" [])]
             qcOffenders (qrDuplicateProducts (qualityReport "testdb" db)) `shouldBe` []
 
-        it "passes a duplicated product every input names its supplier for" $ do
-            -- EcoSpold 2 shape: one product, many producers, and each input
-            -- says which one it means. Nothing has to be guessed, so nothing
-            -- is wrong.
+        it "passes one product made in two places" $ do
+            -- How a database is meant to be written: ecoinvent produces one
+            -- product in hundreds of geographies, and an input names the one
+            -- it means. Only two at one location have nothing to tell them
+            -- apart.
             let db =
                     dbOf
-                        [ ((actA, prodA), mkActivity "bakery FR" [reference breadFlow])
-                        , ((actB, prodB), mkActivity "bakery DE" [reference breadFlow])
-                        , ((actC, prodC), mkActivity "sausage" [reference flourFlow, linkedInput actA breadFlow])
+                        [ ((actA, prodA), mkActivityAt "bakery" "FR" [reference breadFlow])
+                        , ((actB, prodB), mkActivityAt "bakery" "DE" [reference breadFlow])
                         ]
             qcOffenders (qrDuplicateProducts (qualityReport "testdb" db)) `shouldBe` []
 

--- a/test/QualityReportSpec.hs
+++ b/test/QualityReportSpec.hs
@@ -68,15 +68,21 @@ docFlow = u "0d"
 tocFlow = u "0e"
 mercuryFlow = u "0f"
 
-actA, actB, prodA, prodB :: UUID
+actA, actB, actC, prodA, prodB, prodC :: UUID
 actA = u "0a"
 actB = u "0b"
+actC = u "0c"
 prodA = u "1a"
 prodB = u "1b"
+prodC = u "1c"
 
 -- ---------------------------------------------------------------------------
 -- Fixture building blocks
 -- ---------------------------------------------------------------------------
+
+-- | The same activity, filed in the source's obsolete category.
+obsolete :: Activity -> Activity
+obsolete act = act{activityClassification = M.insert "Category" "Others\\Obsolete" (activityClassification act)}
 
 mkActivity :: Text -> [Exchange] -> Activity
 mkActivity name exs =
@@ -558,6 +564,37 @@ spec = do
         it "says nothing about a biosphere exchange, which has no supplier" $ do
             let db = dbOf [((actA, prodA), mkActivity "bread" [reference breadFlow, bioExchange flourFlow 1.0])]
             qcOffenders (qrUnsuppliedInputs (qualityReport "testdb" db)) `shouldBe` []
+
+    describe "obsolete inputs check" $ do
+        it "flags an input only a retired dataset supplies" $ do
+            let db =
+                    dbOf
+                        [ ((actA, prodA), mkActivity "bread" [reference breadFlow, input flourFlow 1.0])
+                        , ((actB, prodB), obsolete (mkActivity "old flour mill" [reference flourFlow]))
+                        ]
+                check = qrObsoleteInputs (qualityReport "testdb" db)
+            severities check `shouldBe` [WarningSev]
+            processIds check `shouldBe` [pidOf actA prodA]
+            map qoProductName (qcOffenders check) `shouldBe` [Just "flour"]
+
+        it "says nothing when a live dataset also supplies the product" $ do
+            -- The retired block and the one that replaced it declare one
+            -- product; the live one is what the linker answers with.
+            let db =
+                    dbOf
+                        [ ((actA, prodA), mkActivity "bread" [reference breadFlow, input flourFlow 1.0])
+                        , ((actB, prodB), obsolete (mkActivity "old flour mill" [reference flourFlow]))
+                        , ((actC, prodC), mkActivity "flour mill" [reference flourFlow])
+                        ]
+            qcOffenders (qrObsoleteInputs (qualityReport "testdb" db)) `shouldBe` []
+
+        it "says nothing about a database whose datasets are all in service" $ do
+            let db =
+                    dbOf
+                        [ ((actA, prodA), mkActivity "bread" [reference breadFlow, input flourFlow 1.0])
+                        , ((actB, prodB), mkActivity "flour mill" [reference flourFlow])
+                        ]
+            qcOffenders (qrObsoleteInputs (qualityReport "testdb" db)) `shouldBe` []
 
     describe "land transformation balance check" $ do
         it "flags an activity whose transformed-from and transformed-to areas diverge" $ do

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -60,7 +60,7 @@ kgUnit = Unit{unitId = mkUUID 9, unitName = "kg", unitSymbol = "kg", unitComment
 kgUnitConfig :: UnitConfig
 kgUnitConfig =
     mkUnitConfig
-        (["mass", "length", "time", "energy", "area", "volume", "count", "currency"])
+        ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
         (M.fromList [("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)])
         (M.fromList [("kg", "kg")])
 

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -35,7 +35,7 @@ import Types (
     emptyProductIndex,
  )
 import qualified Types as VT
-import UnitConversion (UnitConfig (..), UnitDef (..))
+import UnitConversion (UnitConfig (..), UnitDef (..), mkUnitConfig)
 
 -- ---------------------------------------------------------------------------
 -- Fixture
@@ -59,12 +59,10 @@ kgUnit = Unit{unitId = mkUUID 9, unitName = "kg", unitSymbol = "kg", unitComment
 
 kgUnitConfig :: UnitConfig
 kgUnitConfig =
-    UnitConfig
-        { ucDimensionOrder =
-            ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
-        , ucUnits = M.fromList [("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)]
-        , ucOriginalKeys = M.fromList [("kg", "kg")]
-        }
+    mkUnitConfig
+        (["mass", "length", "time", "energy", "area", "volume", "count", "currency"])
+        (M.fromList [("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)])
+        (M.fromList [("kg", "kg")])
 
 testFlow :: BiosphereFlow
 testFlow =

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -7,6 +7,7 @@ import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.Text (Text)
+import qualified Data.Text as T
 import Database.Loader (getReferenceProductUUID)
 import Database.MatrixBuild (InterningTables (..), buildInterningTables)
 import Expr (evaluate, isExpression, normalizeExpr)
@@ -24,6 +25,7 @@ import SimaPro.Parser (
     generateActivityUUID,
     generateFlowUUID,
     generateUnitUUID,
+    indexFlows,
     normalizeSimaProCompartment,
     parseAmount,
     parseBioRow,
@@ -38,17 +40,21 @@ import System.IO.Temp (withSystemTempFile)
 import Test.Hspec
 import Types (
     Activity (..),
+    BioFlowDB,
     BiosphereFlow,
     Exchange (..),
     LocationSource (..),
     NativeActivityType (..),
     NativeProcessId (..),
     Pedigree (..),
+    TechFlowDB,
     TechRole (..),
-    TechnosphereFlow,
+    TechnosphereFlow (..),
     UUID,
     Unit (..),
+    UnitDB,
     WasteFlow,
+    WasteFlowDB,
     exchangeComment,
     exchangeFlowId,
     exchangeIsInput,
@@ -111,7 +117,7 @@ parseTestCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID Biospher
 parseTestCSV = withSystemTempFile "test.csv" $ \path handle -> do
     BS.hPut handle testCSV
     hClose handle
-    parseSimaProCSV defaultUnitConfig path
+    parseOrFail defaultUnitConfig path
 
 -- | Test CSV with waste treatment process and waste-to-treatment demand
 wasteTestCSV :: BS.ByteString
@@ -198,14 +204,14 @@ parseWasteNoAllocCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID 
 parseWasteNoAllocCSV = withSystemTempFile "waste-noalloc-test.csv" $ \path handle -> do
     BS.hPut handle wasteNoAllocCSV
     hClose handle
-    parseSimaProCSV defaultUnitConfig path
+    parseOrFail defaultUnitConfig path
 
 -- | Parse the waste test CSV via a temp file
 parseWasteCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)
 parseWasteCSV = withSystemTempFile "waste-test.csv" $ \path handle -> do
     BS.hPut handle wasteTestCSV
     hClose handle
-    parseSimaProCSV defaultUnitConfig path
+    parseOrFail defaultUnitConfig path
 
 {- | Test CSV where one flow is both a producer's reference product (carrying
 the SimaPro "Category" column) and a later process's Materials/fuels input
@@ -261,7 +267,7 @@ parseSharedFlowCategoryCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map
 parseSharedFlowCategoryCSV = withSystemTempFile "shared-flow-cat-test.csv" $ \path handle -> do
     BS.hPut handle sharedFlowCategoryCSV
     hClose handle
-    parseSimaProCSV defaultUnitConfig path
+    parseOrFail defaultUnitConfig path
 
 -- ============================================================================
 -- Expression evaluator tests
@@ -312,7 +318,7 @@ parseParamCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID Biosphe
 parseParamCSV = withSystemTempFile "param-test.csv" $ \path handle -> do
     BS.hPut handle paramTestCSV
     hClose handle
-    parseSimaProCSV defaultUnitConfig path
+    parseOrFail defaultUnitConfig path
 
 -- | Test CSV with database-level parameters
 dbParamTestCSV :: BS.ByteString
@@ -352,7 +358,7 @@ parseDbParamCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID Biosp
 parseDbParamCSV = withSystemTempFile "dbparam-test.csv" $ \path handle -> do
     BS.hPut handle dbParamTestCSV
     hClose handle
-    parseSimaProCSV defaultUnitConfig path
+    parseOrFail defaultUnitConfig path
 
 -- | Test CSV with yield chain formula (most common pattern in Agribalyse)
 yieldChainTestCSV :: BS.ByteString
@@ -396,7 +402,7 @@ parseYieldChainCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID Bi
 parseYieldChainCSV = withSystemTempFile "yield-test.csv" $ \path handle -> do
     BS.hPut handle yieldChainTestCSV
     hClose handle
-    parseSimaProCSV defaultUnitConfig path
+    parseOrFail defaultUnitConfig path
 
 {- | The shape Agribalyse writes a pesticide emission mix in: the amount is
 summed in place, and one term drops its integer part (@,067@).
@@ -439,7 +445,7 @@ parseSummedAmountCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID 
 parseSummedAmountCSV = withSystemTempFile "summed-amount-test.csv" $ \path handle -> do
     BS.hPut handle summedAmountTestCSV
     hClose handle
-    parseSimaProCSV defaultUnitConfig path
+    parseOrFail defaultUnitConfig path
 
 -- Helper: get all tech input amounts
 techInputAmounts :: Activity -> [Double]
@@ -1081,6 +1087,21 @@ spec = do
         it "generateFlowUUID differs when compartment differs" $
             generateFlowUUID "CO2" "air" "kg" `shouldNotBe` generateFlowUUID "CO2" "water" "kg"
 
+    describe "indexFlows" $ do
+        let kg = generateUnitUUID "kg"
+            mj = generateUnitUUID "mj"
+            flow name unitRef = TechnosphereFlow (generateFlowUUID name "" "") name unitRef M.empty Nothing Nothing
+            names = M.fromList [(kg, "kg"), (mj, "mj")]
+
+        it "folds two rows of one flow into a single entry when the unit agrees" $
+            M.size <$> indexFlows names (\f -> (tfId f, tfUnitId f, tfName f)) [flow "steel" kg, flow "steel" kg]
+                `shouldBe` Right 1
+
+        it "refuses two rows of one flow written in units no conversion relates" $
+            case indexFlows names (\f -> (tfId f, tfUnitId f, tfName f)) [flow "heat" mj, flow "heat" kg] of
+                Left err -> err `shouldSatisfy` \e -> "heat" `T.isInfixOf` e && "mj" `T.isInfixOf` e && "kg" `T.isInfixOf` e
+                Right db -> expectationFailure ("expected a refusal, got " ++ show (M.size db))
+
     -- -----------------------------------------------------------------------
     -- CF ↔ biosphere UUID alignment (regression: see PR #65)
     --
@@ -1535,7 +1556,7 @@ parseIdentifiedBlocksCSV blocks =
                     ++ ["", "End", ""]
         BS.hPut handle (BS.intercalate "\r\n" (header ++ concatMap block blocks))
         hClose handle
-        (activities, _, _, _, _) <- parseSimaProCSV defaultUnitConfig path
+        (activities, _, _, _, _) <- parseOrFail defaultUnitConfig path
         pure activities
 
 {- | The coproduct groups the products index builds, as their sizes, ordered by
@@ -1575,7 +1596,7 @@ parseProductsCSV procName productsRows =
                            ]
         BS.hPut handle content
         hClose handle
-        parseSimaProCSV defaultUnitConfig path
+        parseOrFail defaultUnitConfig path
 
 parseNamedCSV :: BS.ByteString -> [BS.ByteString] -> IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)
 parseNamedCSV procName sectionLines =
@@ -1607,7 +1628,7 @@ parseNamedCSV procName sectionLines =
                            ]
         BS.hPut handle content
         hClose handle
-        parseSimaProCSV defaultUnitConfig path
+        parseOrFail defaultUnitConfig path
 
 -- | CSV with comma as separator
 commaCSV :: BS.ByteString
@@ -1639,7 +1660,7 @@ parseCommaCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID Biosphe
 parseCommaCSV = withSystemTempFile "comma-test.csv" $ \path handle -> do
     BS.hPut handle commaCSV
     hClose handle
-    parseSimaProCSV defaultUnitConfig path
+    parseOrFail defaultUnitConfig path
 
 -- | Unit config that knows about "ton" (1000 kg) in addition to kg.
 tonUnitConfig :: UnitConfig
@@ -1684,7 +1705,7 @@ parseTonRefCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID Biosph
 parseTonRefCSV = withSystemTempFile "ton-ref.csv" $ \path handle -> do
     BS.hPut handle tonRefCSV
     hClose handle
-    parseSimaProCSV tonUnitConfig path
+    parseOrFail tonUnitConfig path
 
 isLeft :: Either a b -> Bool
 isLeft (Left _) = True
@@ -1744,7 +1765,7 @@ parseMultiCoproductCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUI
 parseMultiCoproductCSV = withSystemTempFile "multi-coproduct.csv" $ \path handle -> do
     BS.hPut handle multiCoproductCSV
     hClose handle
-    parseSimaProCSV defaultUnitConfig path
+    parseOrFail defaultUnitConfig path
 
 {- | Single-product CSV with an empty Process name field. Mirrors mono-product
 SimaPro exports that leave the "Process name" line blank: the parser must
@@ -1782,4 +1803,10 @@ parseNoProcessNameCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID
 parseNoProcessNameCSV = withSystemTempFile "no-process-name.csv" $ \path handle -> do
     BS.hPut handle noProcessNameCSV
     hClose handle
-    parseSimaProCSV defaultUnitConfig path
+    parseOrFail defaultUnitConfig path
+
+{- | Parse, failing the example when the parser refuses the file. The parser
+now returns 'Left' for a flow written in two units no conversion relates.
+-}
+parseOrFail :: UnitConfig -> FilePath -> IO ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB)
+parseOrFail cfg path = either (fail . show) pure =<< parseSimaProCSV cfg path

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -1082,15 +1082,15 @@ spec = do
             generateUnitUUID "kg" `shouldNotBe` generateUnitUUID "MJ"
 
         it "generateFlowUUID is deterministic" $
-            generateFlowUUID "CO2" "air" "kg" `shouldBe` generateFlowUUID "CO2" "air" "kg"
+            generateFlowUUID "CO2" "air" `shouldBe` generateFlowUUID "CO2" "air"
 
         it "generateFlowUUID differs when compartment differs" $
-            generateFlowUUID "CO2" "air" "kg" `shouldNotBe` generateFlowUUID "CO2" "water" "kg"
+            generateFlowUUID "CO2" "air" `shouldNotBe` generateFlowUUID "CO2" "water"
 
     describe "indexFlows" $ do
         let kg = generateUnitUUID "kg"
             mj = generateUnitUUID "mj"
-            flow name unitRef = TechnosphereFlow (generateFlowUUID name "" "") name unitRef M.empty Nothing Nothing
+            flow name unitRef = TechnosphereFlow (generateFlowUUID name "") name unitRef M.empty Nothing Nothing
             names = M.fromList [(kg, "kg"), (mj, "mj")]
 
         it "folds two rows of one flow into a single entry when the unit agrees" $
@@ -1109,46 +1109,44 @@ spec = do
     -- ('Method.ParserSimaPro') both hash flow UUIDs via 'generateFlowUUID'
     -- composed with 'normalizeSimaProCompartment'. These tests pin the
     -- invariant that the two call sites land on the same UUID for the same
-    -- elementary flow — the bug they prevent silently routed every regional,
-    -- non-kg or '(unspecified)'-sub CF through the slower name cascade.
+    -- elementary flow — the bug they prevent silently routed every regional
+    -- or '(unspecified)'-sub CF through the slower name cascade.
     -- -----------------------------------------------------------------------
     describe "CF / biosphere flow UUID alignment" $ do
-        let cfSide name comp sub =
-                generateFlowUUID name (normalizeSimaProCompartment comp sub)
-            bioSide name comp sub =
-                generateFlowUUID name (normalizeSimaProCompartment comp sub)
+        let cfSide name comp sub = generateFlowUUID name (normalizeSimaProCompartment comp sub)
+            bioSide name comp sub = generateFlowUUID name (normalizeSimaProCompartment comp sub)
 
-        it "regional water in m³: CF 'Raw'/'(unspecified)' matches bio 'resource'/blank" $
-            cfSide "Water, FR" "Raw" "(unspecified)" "m3"
-                `shouldBe` bioSide "Water, FR" "resource" "" "m3"
-
-        it "non-kg energy resource: CF unit must come from the CF row, not 'kg'" $
-            cfSide "Energy, gross calorific value, in biomass" "Raw" "(unspecified)" "MJ"
-                `shouldBe` bioSide "Energy, gross calorific value, in biomass" "resource" "" "MJ"
+        it "regional water: CF 'Raw'/'(unspecified)' matches bio 'resource'/blank" $
+            cfSide "Water, FR" "Raw" "(unspecified)"
+                `shouldBe` bioSide "Water, FR" "resource" ""
 
         it "regional air emission: CF 'Air'/'(unspecified)' matches bio 'air'/blank" $
-            cfSide "Nitrogen dioxide, FR" "Air" "(unspecified)" "kg"
-                `shouldBe` bioSide "Nitrogen dioxide, FR" "air" "" "kg"
+            cfSide "Nitrogen dioxide, FR" "Air" "(unspecified)"
+                `shouldBe` bioSide "Nitrogen dioxide, FR" "air" ""
 
         it "subcompartment case is normalized on both sides" $
-            cfSide "NOx" "Air" "Low. Pop." "kg"
-                `shouldBe` bioSide "NOx" "air" "low. pop." "kg"
+            cfSide "NOx" "Air" "Low. Pop." `shouldBe` bioSide "NOx" "air" "low. pop."
 
         it "CF 'resources' header matches bio 'resource' literal" $
-            cfSide "Iron" "Resources" "in ground" "kg"
-                `shouldBe` bioSide "Iron" "resource" "in ground" "kg"
-
-        it "differs when units differ (kg vs m³ are distinct flows)" $
-            cfSide "Water" "Raw" "(unspecified)" "kg"
-                `shouldNotBe` cfSide "Water" "Raw" "(unspecified)" "m3"
+            cfSide "Iron" "Resources" "in ground" `shouldBe` bioSide "Iron" "resource" "in ground"
 
         it "differs when the regional suffix differs" $
-            cfSide "Water, FR" "Raw" "(unspecified)" "m3"
-                `shouldNotBe` cfSide "Water, DE" "Raw" "(unspecified)" "m3"
+            cfSide "Water, FR" "Raw" "(unspecified)"
+                `shouldNotBe` cfSide "Water, DE" "Raw" "(unspecified)"
 
-        it "preserves the unit signal in the hash (CF unit is not stripped)" $
-            generateFlowUUID "Water" (normalizeSimaProCompartment "Raw" "(unspecified)") "m3"
-                `shouldNotBe` generateFlowUUID "Water" (normalizeSimaProCompartment "Raw" "(unspecified)") "kg"
+    -- -----------------------------------------------------------------------
+    -- What the flow identifier is made of
+    -- -----------------------------------------------------------------------
+    describe "flow identity" $ do
+        it "is the same flow whatever unit the row states" $
+            generateFlowUUID "Water" "resource" `shouldBe` generateFlowUUID "Water" "resource"
+
+        it "is the same flow whatever case the producer wrote" $
+            generateFlowUUID "Blending, from must, 1 L" ""
+                `shouldBe` generateFlowUUID "blending, from must, 1 l" ""
+
+        it "still separates two names that differ by more than case" $
+            generateFlowUUID "Water, FR" "" `shouldNotBe` generateFlowUUID "Water, DE" ""
 
     -- -----------------------------------------------------------------------
     -- Uncovered CSV sections

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -41,7 +41,7 @@ import Test.Hspec
 import Types (
     Activity (..),
     BioFlowDB,
-    BiosphereFlow,
+    BiosphereFlow (..),
     Exchange (..),
     LocationSource (..),
     NativeActivityType (..),
@@ -1354,6 +1354,22 @@ spec = do
             techAmount (head refExs) `shouldBe` 1.0
             activityUnit steel `shouldBe` "kg"
 
+        it "converts an input row to the reference unit of its dimension" $ do
+            (activities, techFlows, _, _, _) <- parseMixedUnitsCSV
+            let act = head activities
+                input = head [ex | ex <- exchanges act, exchangeIsInput ex, case ex of TechnosphereExchange{} -> True; _ -> False]
+            techAmount input `shouldBe` 0.25
+            fmap tfUnitId (M.lookup (exchangeFlowId input) techFlows)
+                `shouldBe` Just (generateUnitUUID "kg")
+
+        it "converts a resource row to the reference unit of its dimension" $ do
+            (activities, _, bioFlows, _, _) <- parseMixedUnitsCSV
+            let act = head activities
+                resource = head [ex | ex <- exchanges act, case ex of BiosphereExchange{} -> True; _ -> False]
+            bioAmount resource `shouldBe` 3.6
+            fmap bfUnitId (M.lookup (exchangeFlowId resource) bioFlows)
+                `shouldBe` Just (generateUnitUUID "mj")
+
     describe "SimaPro multi-product processes (coproducts)" $ do
         -- One Process block declares 5 coproducts with mass-allocation formulas.
         -- The 5 resulting Activity records must share one activityUUID (so
@@ -1662,6 +1678,23 @@ parseCommaCSV = withSystemTempFile "comma-test.csv" $ \path handle -> do
     hClose handle
     parseOrFail defaultUnitConfig path
 
+{- | Unit config knowing a non-canonical spelling in two dimensions: g (mass)
+and kWh (energy), so a row written in either has somewhere to be converted to.
+-}
+mixedUnitConfig :: UnitConfig
+mixedUnitConfig =
+    UnitConfig
+        { ucDimensionOrder = ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
+        , ucUnits =
+            M.fromList
+                [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
+                , ("g", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 0.001)
+                , ("mj", UnitDef [0, 0, 0, 1, 0, 0, 0, 0] 1.0)
+                , ("kwh", UnitDef [0, 0, 0, 1, 0, 0, 0, 0] 3.6)
+                ]
+        , ucOriginalKeys = M.fromList [("kg", "kg"), ("g", "g"), ("mj", "mj"), ("kwh", "kWh")]
+        }
+
 -- | Unit config that knows about "ton" (1000 kg) in addition to kg.
 tonUnitConfig :: UnitConfig
 tonUnitConfig =
@@ -1706,6 +1739,46 @@ parseTonRefCSV = withSystemTempFile "ton-ref.csv" $ \path handle -> do
     BS.hPut handle tonRefCSV
     hClose handle
     parseOrFail tonUnitConfig path
+
+{- | One block whose rows are written in units that are not the reference unit
+of their dimension: 250 g of feedstock and 1 kWh of energy taken from nature.
+-}
+mixedUnitsCSV :: BS.ByteString
+mixedUnitsCSV =
+    BS.intercalate
+        "\r\n"
+        [ "{SimaPro 9.6.0.1}"
+        , "{CSV separator: semicolon}"
+        , "{Decimal separator: .}"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , "Mixed units {FR} U"
+        , ""
+        , "Type"
+        , "Unit process"
+        , ""
+        , "Products"
+        , "Mixed units {FR} U;kg;1.0;100;not defined;material;"
+        , ""
+        , "Materials/fuels"
+        , "Feedstock;g;250;Undefined;;;;;;"
+        , ""
+        , "Resources"
+        , "Energy, from nature;;kWh;1;Undefined;;;;;;"
+        , ""
+        , "End"
+        ]
+
+parseMixedUnitsCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)
+parseMixedUnitsCSV = withSystemTempFile "mixed-units.csv" $ \path handle -> do
+    BS.hPut handle mixedUnitsCSV
+    hClose handle
+    parseOrFail mixedUnitConfig path
 
 isLeft :: Either a b -> Bool
 isLeft (Left _) = True

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -1714,7 +1714,7 @@ follow it.
 volumeUnitConfig :: Text -> UnitConfig
 volumeUnitConfig reference =
     mkUnitConfig
-        (["mass", "length", "time", "energy", "area", "volume", "count", "currency"])
+        ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
         ( M.fromList
             [ (reference, UnitDef [0, 0, 0, 0, 0, 1, 0, 0] 1.0)
             , ("l", UnitDef [0, 0, 0, 0, 0, 1, 0, 0] 0.001)
@@ -1728,7 +1728,7 @@ and kWh (energy), so a row written in either has somewhere to be converted to.
 mixedUnitConfig :: UnitConfig
 mixedUnitConfig =
     mkUnitConfig
-        (["mass", "length", "time", "energy", "area", "volume", "count", "currency"])
+        ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
         ( M.fromList
             [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
             , ("g", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 0.001)
@@ -1742,7 +1742,7 @@ mixedUnitConfig =
 tonUnitConfig :: UnitConfig
 tonUnitConfig =
     mkUnitConfig
-        (["mass", "length", "time", "energy", "area", "volume", "count", "currency"])
+        ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
         ( M.fromList
             [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
             , ("ton", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1000.0)

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -1368,6 +1368,35 @@ spec = do
             fmap bfUnitId (M.lookup (exchangeFlowId resource) bioFlows)
                 `shouldBe` Just (generateUnitUUID "mj")
 
+    describe "what a process identifier is made of" $ do
+        let processIds = map (\a -> (generateActivityUUID a, getReferenceProductUUID a))
+            oneBlock spelling =
+                parseIdentifiedBlocksCSV
+                    [("AGRIBALU000000003101635", "Blending, from must {FR} U", [spelling <> ";l;1;100;not defined;material;"])]
+
+        it "does not move when the producer changes the case of a name" $ do
+            written <- oneBlock "French production mix, at plant, 1 L of must {FR} U"
+            rewritten <- oneBlock "french production mix, at plant, 1 l of must {FR} U"
+            processIds written `shouldBe` processIds rewritten
+
+        it "does not move when a reference unit is renamed in the table" $ do
+            -- The drift release 0.10.0 walked into: "cubic meter" became "m3"
+            -- in units.csv and twelve percent of Agribalyse changed identity
+            -- with no datum touched.
+            let block = [("AGRIBALU000000003101635", "Blending {FR} U", ["Must {FR} U;l;1;100;not defined;material;"])]
+            before <- parseIdentifiedBlocksWith (volumeUnitConfig "cubic meter") block
+            after <- parseIdentifiedBlocksWith (volumeUnitConfig "m3") block
+            processIds before `shouldBe` processIds after
+
+        it "falls back to the name when one identifier names two processes" $ do
+            activities <-
+                parseIdentifiedBlocksCSV
+                    [ ("DUPLICATE0001", "First process {FR} U", ["First product {FR} U;kg;1;100;not defined;material;"])
+                    , ("DUPLICATE0001", "Second process {FR} U", ["Second product {FR} U;kg;1;100;not defined;material;"])
+                    ]
+            map activityNativeId activities `shouldBe` [Nothing, Nothing]
+            S.size (S.fromList (map generateActivityUUID activities)) `shouldBe` 2
+
     describe "SimaPro multi-product processes (coproducts)" $ do
         -- One Process block declares 5 coproducts with mass-allocation formulas.
         -- The 5 resulting Activity records must share one activityUUID (so
@@ -1440,11 +1469,10 @@ spec = do
             S.fromList (map activityName activities)
                 `shouldBe` S.singleton "Tuna, main product {FR} U"
 
-        it "groups the coproducts of one block, and only those" $ do
-            -- Agribalyse 4.0 truncates "Process name" to 80 characters, so three
-            -- unrelated lorry blocks carry one name and hash to one activityUUID.
-            -- The products index must still keep them apart, because the block
-            -- identifier does.
+        it "keeps two blocks apart when one truncated name covers both" $ do
+            -- Agribalyse 4.0 truncates "Process name" to 80 characters, so
+            -- unrelated lorry blocks carry one name. They are still two
+            -- processes, and the identifier each one publishes says so.
             let truncated = "market for transport, freight, lorry with refrigeration machine, 7.5-16 ton, die"
             activities <-
                 parseIdentifiedBlocksCSV
@@ -1456,8 +1484,7 @@ spec = do
                     [ Just (NativeProcessId "TraiEVEA000064241304182")
                     , Just (NativeProcessId "TraiEVEA000064241304183")
                     ]
-            -- The collision this fix deliberately keeps: one UUID, two blocks.
-            S.size (S.fromList (map generateActivityUUID activities)) `shouldBe` 1
+            S.size (S.fromList (map generateActivityUUID activities)) `shouldBe` 2
             map length (productGroups activities) `shouldBe` [1, 1]
 
         it "groups a block's coproducts together under its own identifier" $ do
@@ -1541,7 +1568,11 @@ parseSectionCSV =
 @Process name@ and @Products@ rows. Activities come back in file order.
 -}
 parseIdentifiedBlocksCSV :: [(BS.ByteString, BS.ByteString, [BS.ByteString])] -> IO [Activity]
-parseIdentifiedBlocksCSV blocks =
+parseIdentifiedBlocksCSV = parseIdentifiedBlocksWith defaultUnitConfig
+
+-- | 'parseIdentifiedBlocksCSV' under a chosen unit table.
+parseIdentifiedBlocksWith :: UnitConfig -> [(BS.ByteString, BS.ByteString, [BS.ByteString])] -> IO [Activity]
+parseIdentifiedBlocksWith unitCfg blocks =
     withSystemTempFile "identified-blocks-test.csv" $ \path handle -> do
         let header =
                 [ "{SimaPro 9.6.0.1}"
@@ -1570,7 +1601,7 @@ parseIdentifiedBlocksCSV blocks =
                     ++ ["", "End", ""]
         BS.hPut handle (BS.intercalate "\r\n" (header ++ concatMap block blocks))
         hClose handle
-        (activities, _, _, _, _) <- parseOrFail defaultUnitConfig path
+        (activities, _, _, _, _) <- parseOrFail unitCfg path
         pure activities
 
 {- | The coproduct groups the products index builds, as their sizes, ordered by
@@ -1675,6 +1706,22 @@ parseCommaCSV = withSystemTempFile "comma-test.csv" $ \path handle -> do
     BS.hPut handle commaCSV
     hClose handle
     parseOrFail defaultUnitConfig path
+
+{- | A volume table whose reference unit carries the spelling the caller
+chooses. Renaming it is exactly what release 0.10.0 did, and no identifier may
+follow it.
+-}
+volumeUnitConfig :: Text -> UnitConfig
+volumeUnitConfig reference =
+    UnitConfig
+        { ucDimensionOrder = ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
+        , ucUnits =
+            M.fromList
+                [ (reference, UnitDef [0, 0, 0, 0, 0, 1, 0, 0] 1.0)
+                , ("l", UnitDef [0, 0, 0, 0, 0, 1, 0, 0] 0.001)
+                ]
+        , ucOriginalKeys = M.fromList [(reference, reference), ("l", "l")]
+        }
 
 {- | Unit config knowing a non-canonical spelling in two dimensions: g (mass)
 and kWh (energy), so a row written in either has somewhere to be converted to.

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -62,7 +62,7 @@ import Types (
     exchangePedigree,
     tfName,
  )
-import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig, isKnownUnit)
+import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig, isKnownUnit, mkUnitConfig)
 
 -- | Test CSV content with a quoted product name containing the delimiter (;)
 testCSV :: BS.ByteString
@@ -1713,45 +1713,42 @@ follow it.
 -}
 volumeUnitConfig :: Text -> UnitConfig
 volumeUnitConfig reference =
-    UnitConfig
-        { ucDimensionOrder = ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
-        , ucUnits =
-            M.fromList
-                [ (reference, UnitDef [0, 0, 0, 0, 0, 1, 0, 0] 1.0)
-                , ("l", UnitDef [0, 0, 0, 0, 0, 1, 0, 0] 0.001)
-                ]
-        , ucOriginalKeys = M.fromList [(reference, reference), ("l", "l")]
-        }
+    mkUnitConfig
+        (["mass", "length", "time", "energy", "area", "volume", "count", "currency"])
+        ( M.fromList
+            [ (reference, UnitDef [0, 0, 0, 0, 0, 1, 0, 0] 1.0)
+            , ("l", UnitDef [0, 0, 0, 0, 0, 1, 0, 0] 0.001)
+            ]
+        )
+        (M.fromList [(reference, reference), ("l", "l")])
 
 {- | Unit config knowing a non-canonical spelling in two dimensions: g (mass)
 and kWh (energy), so a row written in either has somewhere to be converted to.
 -}
 mixedUnitConfig :: UnitConfig
 mixedUnitConfig =
-    UnitConfig
-        { ucDimensionOrder = ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
-        , ucUnits =
-            M.fromList
-                [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
-                , ("g", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 0.001)
-                , ("mj", UnitDef [0, 0, 0, 1, 0, 0, 0, 0] 1.0)
-                , ("kwh", UnitDef [0, 0, 0, 1, 0, 0, 0, 0] 3.6)
-                ]
-        , ucOriginalKeys = M.fromList [("kg", "kg"), ("g", "g"), ("mj", "mj"), ("kwh", "kWh")]
-        }
+    mkUnitConfig
+        (["mass", "length", "time", "energy", "area", "volume", "count", "currency"])
+        ( M.fromList
+            [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
+            , ("g", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 0.001)
+            , ("mj", UnitDef [0, 0, 0, 1, 0, 0, 0, 0] 1.0)
+            , ("kwh", UnitDef [0, 0, 0, 1, 0, 0, 0, 0] 3.6)
+            ]
+        )
+        (M.fromList [("kg", "kg"), ("g", "g"), ("mj", "mj"), ("kwh", "kWh")])
 
 -- | Unit config that knows about "ton" (1000 kg) in addition to kg.
 tonUnitConfig :: UnitConfig
 tonUnitConfig =
-    UnitConfig
-        { ucDimensionOrder = ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
-        , ucUnits =
-            M.fromList
-                [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
-                , ("ton", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1000.0)
-                ]
-        , ucOriginalKeys = M.fromList [("kg", "kg"), ("ton", "ton")]
-        }
+    mkUnitConfig
+        (["mass", "length", "time", "energy", "area", "volume", "count", "currency"])
+        ( M.fromList
+            [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
+            , ("ton", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1000.0)
+            ]
+        )
+        (M.fromList [("kg", "kg"), ("ton", "ton")])
 
 -- | A minimal SimaPro CSV declaring a reference product of "1 ton" (mass).
 tonRefCSV :: BS.ByteString

--- a/test/SimaProRegistryCASSpec.hs
+++ b/test/SimaProRegistryCASSpec.hs
@@ -18,8 +18,8 @@ import SimaPro.Parser (parseSimaProCSV)
 import System.IO (hClose)
 import System.IO.Temp (withSystemTempFile)
 import Test.Hspec
-import Types (BioFlowDB, BiosphereFlow (..))
-import UnitConversion (defaultUnitConfig)
+import Types (Activity, BioFlowDB, BiosphereFlow (..), TechFlowDB, UnitDB, WasteFlowDB)
+import UnitConversion (UnitConfig, defaultUnitConfig)
 
 {- | One process emitting four substances, then a trailer substance registry
 giving three of them a CAS. Methane and fossil CO2 are listed under the
@@ -90,7 +90,7 @@ parseRegistryCSV :: IO BioFlowDB
 parseRegistryCSV = withSystemTempFile "registry-cas-test.csv" $ \path handle -> do
     BS.hPut handle registryCSV
     hClose handle
-    (_, _, bioFlowDB, _, _) <- parseSimaProCSV defaultUnitConfig path
+    (_, _, bioFlowDB, _, _) <- parseOrFail defaultUnitConfig path
     pure bioFlowDB
 
 casOf :: Text -> BioFlowDB -> Maybe Text
@@ -120,3 +120,9 @@ spec = describe "SimaPro trailing substance registry backfills flow CAS" $ do
         -- The later Waterborne block re-binds Methane to 56-23-5; the
         -- Airborne binding came first in the file and must survive.
         casOf "Methane" db `shouldBe` Just "74-82-8"
+
+{- | Parse, failing the example when the parser refuses the file. The parser
+now returns 'Left' for a flow written in two units no conversion relates.
+-}
+parseOrFail :: UnitConfig -> FilePath -> IO ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB)
+parseOrFail cfg path = either (fail . show) pure =<< parseSimaProCSV cfg path

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -48,7 +48,7 @@ import System.IO (hClose)
 import System.IO.Temp (withSystemTempFile)
 import Test.Hspec
 import Types
-import UnitConversion (defaultUnitConfig)
+import UnitConversion (UnitConfig, defaultUnitConfig)
 
 -- ---------------------------------------------------------------------------
 -- Fixture: a small SimaPro CSV exercising every section the writer emits
@@ -218,7 +218,7 @@ parseBytes :: BS.ByteString -> IO ([Activity], TechFlowDB, BioFlowDB, WasteFlowD
 parseBytes bytes = withSystemTempFile "writer-spec.csv" $ \path h -> do
     BS.hPut h bytes
     hClose h
-    parseSimaProCSV defaultUnitConfig path
+    parseOrFail defaultUnitConfig path
 
 -- | Wrap parser output in a 'SimpleDatabase' keyed by generated UUIDs.
 toSimple :: ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB) -> SimpleDatabase
@@ -862,3 +862,9 @@ describedDb :: [Text] -> SimpleDatabase
 describedDb paragraphs =
     let db = guardDb Nothing Nothing [refProd]
      in db{sdbActivities = M.map (\a -> a{activityDescription = paragraphs}) (sdbActivities db)}
+
+{- | Parse, failing the example when the parser refuses the file. The parser
+now returns 'Left' for a flow written in two units no conversion relates.
+-}
+parseOrFail :: UnitConfig -> FilePath -> IO ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB)
+parseOrFail cfg path = either (fail . show) pure =<< parseSimaProCSV cfg path


### PR DESCRIPTION
## What this changes

Two things, both about not answering a question the file did not ask.

**An identity comes from what the file publishes.** An activity read from a
SimaPro CSV or a Brightway Excel workbook is named by the `Process identifier`
its block publishes, falling back to its name folded in case plus its location
when the file publishes none. A flow is named by its name folded in case and
its compartment; the unit leaves the key, and every row is converted to the
reference unit of its dimension on the way in instead.

**A supplier comes from what the file names.** The prefix fallback is gone.

## Why

Release 0.10.0 renamed the reference unit of six dimensions in `units.csv`.
Twelve percent of Agribalyse process ids changed, and not a single number did.
An identity that follows a rename in our own table is not an identity. Two
exports of one database also disagree on the case of a product name, so one
dataset carried two identifiers on two machines, which is how this started: a
user found three thousand of his stored ids no longer resolving. The file
publishes an identifier the parser already read and used only to group
coproducts. It is present and distinct on every block of Agribalyse 3.1.1, 3.2
and 4.0 and of ecoinvent 3.9.1, which is why the fallback stays for the rest.

The prefix fallback answered an input whose product name matched no reference
product with a prefix of that name, cut at the first `//`, ` {`, ` [` or ` |`.
What follows those separators is the geography and the model variant, which is
exactly what tells two producers apart. Measured on ten SimaPro exports it
earns ten lines, all of them in one incomplete export, eight by choosing among
several candidates. Between databases it is worse: of the 169 lines pastoeco
resolves in Agribalyse 3.2, 21 match by prefix, 17 of them ambiguously, one
choosing among 148 electricity markets.

## Measured

Agribalyse 4.0 against EF 3.1 adapted, before and after:

- The same 22 822 activities, and no flow loses its characterization factor in
  any of the 25 categories.
- 6 980 biosphere flows become 6 348 and 24 554 technosphere flows become
  22 821: two spellings of one substance are one flow now.
- Inputs resolved: 169 103 of 169 113, and the engine names the ten it cannot
  resolve instead of claiming all of them.
- 3 300 of 6 250 category readings move, **every one of them down**, by 0.5 %
  at the median and 56 % at the largest. What goes away is a burden the file
  never asked for: every product fertilised in France was carrying an upstream
  that had been guessed for it.

## The retired block loses the tie

When two blocks declare one product, the file still says which one it means:
the tool that writes these files puts a retired process under an `Obsolete`
subcategory and warns whenever a calculation reaches one. So the block still in
service supplies, and the retired one supplies nothing. That settles all ten of
Agribalyse 4.0's duplicated products, the slaughterhouse block shipped twice
among them, whose retired copy used to win because "whitout" sorts before
"without".

Measured over 1062 activities: 11 453 of 26 550 readings move, by 1.1 % at the
median, largest 2.8x on black pudding, which is mostly blood, one of the ten
coproducts the two blocks allocate differently. Two blocks the file gives no
way to tell apart are still ordered by name then location, never by identifier.

## Also here

- Two rows of one flow written in units no conversion relates are refused by
  name, rather than one of them being dropped in silence.
- The SimaPro writer emits the `Process identifier` line it always read.
  Exporting a database and reading it back used to rename every process in it.
- Three quality checks: **unsupplied inputs**, the mirror of the unconsumed
  products check; **duplicate products**, twenty on Agribalyse 4.0 and
  invisible to the duplicate-activities check, which groups on activity name;
  and **obsolete inputs**, 874, whose only producer is a retired block that
  still computes a superseded number.

## The edit journal

Identifiers moving is what an edit journal is built to refuse: it replays by
process id and stops the whole database when one no longer mints the same way.
EcoSpold 1 and 2 and ILCD carry identifiers of their own and are untouched. A
journal written over a SimaPro database before this change is refused by name,
and the way out is to delete it; the sources it was written over are immutable.
