### PR TITLE
Stop building thirteen dependencies nothing imports

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -60,13 +60,10 @@ licenses are uniformly BSD-style or MIT and can be re-derived from a fresh
 | base64-bytestring | BSD-3-Clause | <https://hackage.haskell.org/package/base64-bytestring> |
 | bytestring | BSD-3-Clause | bundled with GHC |
 | cassava | BSD-3-Clause | <https://hackage.haskell.org/package/cassava> |
-| conduit | MIT | <https://hackage.haskell.org/package/conduit> |
 | containers | BSD-3-Clause | bundled with GHC |
 | deepseq | BSD-3-Clause | bundled with GHC |
 | directory | BSD-3-Clause | bundled with GHC |
-| filelock | CC0-1.0 | <https://hackage.haskell.org/package/filelock> |
 | filepath | BSD-3-Clause | bundled with GHC |
-| hashable | BSD-3-Clause | <https://hackage.haskell.org/package/hashable> |
 | haskeline | BSD-3-Clause | <https://hackage.haskell.org/package/haskeline> |
 | http-client | MIT | <https://hackage.haskell.org/package/http-client> |
 | http-types | BSD-3-Clause | <https://hackage.haskell.org/package/http-types> |
@@ -77,17 +74,14 @@ licenses are uniformly BSD-style or MIT and can be re-derived from a fresh
 | network-uri | BSD-3-Clause | <https://hackage.haskell.org/package/network-uri> |
 | openapi3 | BSD-3-Clause | <https://hackage.haskell.org/package/openapi3> |
 | optparse-applicative | BSD-3-Clause | <https://hackage.haskell.org/package/optparse-applicative> |
-| parallel | BSD-3-Clause | bundled with GHC |
 | process | BSD-3-Clause | bundled with GHC |
 | random | BSD-3-Clause | bundled with GHC |
 | scientific | BSD-3-Clause | <https://hackage.haskell.org/package/scientific> |
 | servant | BSD-3-Clause | <https://hackage.haskell.org/package/servant> |
-| servant-multipart | BSD-3-Clause | <https://hackage.haskell.org/package/servant-multipart> |
 | servant-openapi3 | BSD-3-Clause | <https://hackage.haskell.org/package/servant-openapi3> |
 | servant-server | BSD-3-Clause | <https://hackage.haskell.org/package/servant-server> |
 | stm | BSD-3-Clause | bundled with GHC |
 | store | MIT | <https://hackage.haskell.org/package/store> |
-| streaming-commons | MIT | <https://hackage.haskell.org/package/streaming-commons> |
 | temporary | BSD-3-Clause | <https://hackage.haskell.org/package/temporary> |
 | text | BSD-2-Clause | bundled with GHC |
 | time | BSD-3-Clause | bundled with GHC |
@@ -98,10 +92,8 @@ licenses are uniformly BSD-style or MIT and can be re-derived from a fresh
 | vector | BSD-3-Clause | <https://hackage.haskell.org/package/vector> |
 | wai | MIT | <https://hackage.haskell.org/package/wai> |
 | wai-app-static | MIT | <https://hackage.haskell.org/package/wai-app-static> |
-| wai-cors | MIT | <https://hackage.haskell.org/package/wai-cors> |
 | warp | MIT | <https://hackage.haskell.org/package/warp> |
 | xeno | BSD-3-Clause | <https://hackage.haskell.org/package/xeno> |
-| xml-types | MIT | <https://hackage.haskell.org/package/xml-types> |
 | zstd | BSD-3-Clause | <https://hackage.haskell.org/package/zstd> |
 
 ## Regenerating this list

--- a/volca.cabal
+++ b/volca.cabal
@@ -23,10 +23,11 @@ common warnings
   --
   -- -Wunused-packages keeps the dependency list honest: every package here is
   -- fetched and built by the whole CI matrix, so one that nothing imports is
-  -- paid for five times per pull request. -Wredundant-constraints is the free
-  -- companion. Not -Wincomplete-record-selectors yet: it is right, and what it
-  -- currently finds needs the writer to stop applying a constructor's
-  -- selectors to a value typed as the whole sum, which is its own change.
+  -- paid for on every row of it, every pull request. -Wredundant-constraints
+  -- is the free companion. Not -Wincomplete-record-selectors yet: it is right,
+  -- and what it currently finds needs the writer to stop applying a
+  -- constructor's selectors to a value typed as the whole sum, which is its
+  -- own change.
   ghc-options:         -Wall -Wredundant-constraints -Wunused-packages
 
 common rtsdefaults

--- a/volca.cabal
+++ b/volca.cabal
@@ -20,7 +20,14 @@ common warnings
   -- to 1 for faster compiles). A hardcoded -O2 here would win over that
   -- per-package setting (ghc-options beat the project optimization flag), so
   -- it lives in the project file, not here.
-  ghc-options:         -Wall
+  --
+  -- -Wunused-packages keeps the dependency list honest: every package here is
+  -- fetched and built by the whole CI matrix, so one that nothing imports is
+  -- paid for five times per pull request. -Wredundant-constraints is the free
+  -- companion. Not -Wincomplete-record-selectors yet: it is right, and what it
+  -- currently finds needs the writer to stop applying a constructor's
+  -- selectors to a value typed as the whole sum, which is its own change.
+  ghc-options:         -Wall -Wredundant-constraints -Wunused-packages
 
 common rtsdefaults
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
@@ -128,42 +135,31 @@ library
                      , exceptions
                      , bytestring
                      , deepseq
-                     , parallel
                      , stm
                      , async
-                     , conduit
-                     , xml-types
                      , servant-server
                      , servant
-                     , servant-multipart
                      , servant-openapi3
                      , openapi3
                      , insert-ordered-containers
                      , lens
-                     , warp
                      , aeson
                      , aeson-pretty
                      , scientific
                      , attoparsec
                      , wai
-                     , wai-cors
-                     , wai-app-static
                      , store
                      , zstd
                      , time
-                     , hashable
                      , uuid
                      , http-types
                      , http-media
                      , network-uri
-                     , streaming-commons
                      , vector
                      , random
                      , mumps-hs
                      , base64-bytestring
                      , toml-reader
-                     , filelock
-                     , temporary
                      , process
                      , cassava
                      , http-client
@@ -197,7 +193,6 @@ executable volca
                      , wai
                      , wai-extra >=3.1.1
                      , wai-app-static
-                     , servant
                      , servant-server
                      , http-types
                      , http-client
@@ -358,7 +353,6 @@ test-suite lca-tests
                      , bytestring
                      , zip-archive
                      , temporary
-                     , time
                      , aeson
                      , stm
                      , toml-reader
@@ -369,11 +363,9 @@ test-suite lca-tests
                      , filepath
                      , directory
                      , async
-                     , warp
                      , wai
                      , servant-server
                      , servant
-                     , network-uri
                      , base64-bytestring
                      , optparse-applicative
                      , QuickCheck


### PR DESCRIPTION
The engine compiled with `-Wall` and nothing else. Adding
`-Wunused-packages` shows thirteen dependency entries that no module imports,
and each one is fetched and compiled by the whole build matrix on every pull
request, then again for the Docker image.

## What goes

**Library** (ten): `conduit`, `filelock`, `hashable`, `parallel`,
`servant-multipart`, `streaming-commons`, `temporary`, `wai-app-static`,
`wai-cors`, `xml-types`.

Two of those are alive elsewhere, `wai-app-static` in the executable and
`temporary` in the tests, and both stanzas already declare them for
themselves. Nothing moves between stanzas.

**Executable** (one): `servant`. Its only use is `serve`, which
`servant-server` re-exports.

**Tests** (three): `network-uri`, `time`, `warp`. No matching import anywhere
under `test/`.

`-Wredundant-constraints` comes along for free and reports nothing.

## What is deliberately left out

`-Wincomplete-record-selectors` reports twenty-two, and all of them are in
`src/EcoSpold/Writer2.hs`. `renderTechnosphere`, `renderWaste` and
`renderBiosphere` each take the whole `Exchange` sum and then apply one
constructor's selectors:

```haskell
renderTechnosphere :: ResolveEnv -> Exchange -> [Text]
renderTechnosphere env ex = ... (techUnitId ex) (techAmount ex) ...
```

`techUnitId` on a `BiosphereExchange` crashes. The caller dispatches on the
constructor and the type does not record that. Making the state
unrepresentable means those three taking the constructor's payload rather
than the sum, which reaches into the writer's signatures, so it belongs in
its own change rather than behind a silenced flag. The reason is written next
to the flags in the cabal file so the next person does not have to rediscover
it.

## Checked

Cold build across the library, the executable, the test suite and the
benchmark: no warnings left. `cabal test`: 2365 examples, 0 failures,
1 pending.
