### PR TITLE
Keep the license table honest without reading it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,3 +48,14 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       - run: scripts/check-data-version.sh
+
+  # THIRD_PARTY_LICENSES.md is the license inventory /api/v1/licenses points
+  # readers at, and it is written by hand, so a dependency added or removed
+  # leaves it wrong with nothing failing. Same shape as the check above:
+  # no build needed, the PR shows the mismatch at once.
+  licenses-table:
+    name: THIRD_PARTY_LICENSES.md follows volca.cabal
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: scripts/check-licenses-table.sh

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ cbits/*.o
 !/scripts/build_chem_synonyms.py
 !/scripts/propose_flow_bridges.py
 !/scripts/check-data-version.sh
+!/scripts/check-licenses-table.sh
 node_modules/
 
 # Generated source

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -107,9 +107,11 @@ build when this table and `volca.cabal` disagree.
 After `cabal build all`, the canonical license for every direct dep is in the
 matching `~/.cabal/store/ghc-<ver>/package.db/<name>-<version>-<hash>.conf`
 file (`grep ^license:`). The list above was last reconciled by reading those
-conf files for every entry of `volca:lib:volca`'s `depends` set in
-`dist-newstyle/cache/plan.json`. Re-run that reconciliation at release time
-and update any drifted entries.
+conf files for every entry of the `depends` sets of `volca:lib:volca` and
+`volca:exe:volca` in `dist-newstyle/cache/plan.json`. Those two components are
+the scope of the table, so reading the library alone would skip the packages
+only the executable links, `warp`, `wai-app-static` and `wai-extra`. Re-run
+that reconciliation at release time and update any drifted entries.
 
 `scripts/check-licenses-table.sh` only compares the names, which is what
 changes when a dependency comes or goes. A package that relicenses keeps its

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -46,16 +46,19 @@ Haskell FFI bindings to MUMPS, maintained inside this repository
 
 ## Haskell direct dependencies
 
-The following table covers the libraries declared in `volca.cabal`'s
-`build-depends`. Transitive dependencies are not listed individually; their
+The following table covers the libraries the shipped binary links: the direct
+`build-depends` of `volca.cabal`'s `library` and `executable` stanzas. Test and
+benchmark dependencies are out of scope, and so are transitive ones, whose
 licenses are uniformly BSD-style or MIT and can be re-derived from a fresh
-`cabal-plan license-report` run.
+`cabal-plan license-report` run. `scripts/check-licenses-table.sh` fails the
+build when this table and `volca.cabal` disagree.
 
 | Package | License | Source |
 |---|---|---|
 | aeson | BSD-3-Clause | <https://hackage.haskell.org/package/aeson> |
 | aeson-pretty | BSD-3-Clause | <https://hackage.haskell.org/package/aeson-pretty> |
 | async | BSD-3-Clause | <https://hackage.haskell.org/package/async> |
+| attoparsec | BSD-3-Clause | <https://hackage.haskell.org/package/attoparsec> |
 | base | BSD-3-Clause (with GHC exceptions) | bundled with GHC |
 | base64-bytestring | BSD-3-Clause | <https://hackage.haskell.org/package/base64-bytestring> |
 | bytestring | BSD-3-Clause | bundled with GHC |
@@ -63,9 +66,11 @@ licenses are uniformly BSD-style or MIT and can be re-derived from a fresh
 | containers | BSD-3-Clause | bundled with GHC |
 | deepseq | BSD-3-Clause | bundled with GHC |
 | directory | BSD-3-Clause | bundled with GHC |
+| exceptions | BSD-3-Clause | bundled with GHC |
 | filepath | BSD-3-Clause | bundled with GHC |
 | haskeline | BSD-3-Clause | <https://hackage.haskell.org/package/haskeline> |
 | http-client | MIT | <https://hackage.haskell.org/package/http-client> |
+| http-media | MIT | <https://hackage.haskell.org/package/http-media> |
 | http-types | BSD-3-Clause | <https://hackage.haskell.org/package/http-types> |
 | insert-ordered-containers | BSD-3-Clause | <https://hackage.haskell.org/package/insert-ordered-containers> |
 | lens | BSD-2-Clause | <https://hackage.haskell.org/package/lens> |
@@ -82,7 +87,6 @@ licenses are uniformly BSD-style or MIT and can be re-derived from a fresh
 | servant-server | BSD-3-Clause | <https://hackage.haskell.org/package/servant-server> |
 | stm | BSD-3-Clause | bundled with GHC |
 | store | MIT | <https://hackage.haskell.org/package/store> |
-| temporary | BSD-3-Clause | <https://hackage.haskell.org/package/temporary> |
 | text | BSD-2-Clause | bundled with GHC |
 | time | BSD-3-Clause | bundled with GHC |
 | toml-reader | BSD-3-Clause | <https://hackage.haskell.org/package/toml-reader> |
@@ -92,8 +96,10 @@ licenses are uniformly BSD-style or MIT and can be re-derived from a fresh
 | vector | BSD-3-Clause | <https://hackage.haskell.org/package/vector> |
 | wai | MIT | <https://hackage.haskell.org/package/wai> |
 | wai-app-static | MIT | <https://hackage.haskell.org/package/wai-app-static> |
+| wai-extra | MIT | <https://hackage.haskell.org/package/wai-extra> |
 | warp | MIT | <https://hackage.haskell.org/package/warp> |
 | xeno | BSD-3-Clause | <https://hackage.haskell.org/package/xeno> |
+| zip-archive | BSD-3-Clause | <https://hackage.haskell.org/package/zip-archive> |
 | zstd | BSD-3-Clause | <https://hackage.haskell.org/package/zstd> |
 
 ## Regenerating this list
@@ -104,3 +110,7 @@ file (`grep ^license:`). The list above was last reconciled by reading those
 conf files for every entry of `volca:lib:volca`'s `depends` set in
 `dist-newstyle/cache/plan.json`. Re-run that reconciliation at release time
 and update any drifted entries.
+
+`scripts/check-licenses-table.sh` only compares the names, which is what
+changes when a dependency comes or goes. A package that relicenses keeps its
+name, so the reconciliation above is still the only thing that catches it.

--- a/scripts/check-licenses-table.sh
+++ b/scripts/check-licenses-table.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# Refuse a THIRD_PARTY_LICENSES.md that disagrees with volca.cabal.
+#
+# The table is the license inventory of the shipped binary, and /api/v1/licenses
+# sends every reader to it through haskell_dependencies_url. It is written by
+# hand, so it drifts in both directions: a dependency removed leaves a row
+# claiming a library the binary no longer links, and a dependency added leaves
+# no row at all. Neither shows up in a build.
+#
+# Scope is what ships: the direct build-depends of the library and executable
+# stanzas. Test and benchmark dependencies never reach a user, and the two
+# packages that live in this repository are covered by their own sections.
+set -eu
+
+cd "$(dirname "$0")/.."
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+awk '
+    # A stanza header sits at column 0. Only the shipped ones count.
+    /^[a-z-]+( |$)/ { ship = ($0 == "library" || $0 ~ /^executable /); deps = 0 }
+    /^[ \t]*--/     { next }
+    {
+        line = $0
+        if (ship && line ~ /^[ \t]*build-depends:/) {
+            deps = 1
+            sub(/^[ \t]*build-depends:[ \t]*/, "", line)   # first name shares the line
+        } else if (deps && line ~ /^[ \t]*[A-Za-z][A-Za-z0-9-]*:[ \t]*/) {
+            deps = 0                                        # the next field ends the list
+        }
+        if (!deps) next
+        gsub(/^[ \t]*,?[ \t]*/, "", line)
+        if (line == "") next
+        split(line, field, /[ \t]/)                         # drop the version constraint
+        if (field[1] != "") print field[1]
+    }
+' volca.cabal | grep -vxE 'volca|mumps-hs' | sort -u > "$work/cabal"
+
+# The package column of the table, minus its header row.
+grep -oE '^\| [A-Za-z0-9][A-Za-z0-9-]*' THIRD_PARTY_LICENSES.md \
+    | cut -c3- | grep -vx 'Package' | sort -u > "$work/table"
+
+missing=$(comm -23 "$work/cabal" "$work/table")
+extra=$(comm -13 "$work/cabal" "$work/table")
+
+status=0
+if [ -n "$missing" ]; then
+    echo "Declared in volca.cabal and absent from THIRD_PARTY_LICENSES.md:"
+    echo "$missing" | sed 's/^/  /'
+    status=1
+fi
+if [ -n "$extra" ]; then
+    echo "Listed in THIRD_PARTY_LICENSES.md and no longer shipped:"
+    echo "$extra" | sed 's/^/  /'
+    status=1
+fi
+
+if [ "$status" -ne 0 ]; then
+    echo ""
+    echo "The table names the libraries the binary links. Add or remove the rows above."
+    exit 1
+fi
+
+echo "THIRD_PARTY_LICENSES.md matches volca.cabal."

--- a/scripts/check-licenses-table.sh
+++ b/scripts/check-licenses-table.sh
@@ -18,8 +18,9 @@ work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 
 awk '
-    # A stanza header sits at column 0. Only the shipped ones count.
-    /^[a-z-]+( |$)/ { ship = ($0 == "library" || $0 ~ /^executable /); deps = 0 }
+    # A stanza header sits at column 0. Only the shipped ones count, and a
+    # library carries a name once there is more than one of them.
+    /^[a-z-]+( |$)/ { ship = ($0 ~ /^library( |$)/ || $0 ~ /^executable /); deps = 0 }
     /^[ \t]*--/     { next }
     {
         line = $0


### PR DESCRIPTION
`THIRD_PARTY_LICENSES.md` is the inventory `/api/v1/licenses` sends a reader
to, through `haskell_dependencies_url`. It is written by hand and nothing
compares it with anything, so it had drifted in both directions at once:
`attoparsec`, `exceptions`, `http-media`, `wai-extra` and `zip-archive` are
linked into the binary and had no row, while `temporary` still had one after
becoming test-only. Removing a dependency in #358 is what made the second kind
visible, and neither kind fails a build today.

`scripts/check-licenses-table.sh` compares the two lists of names and fails
with the packages that are on one side and not the other. It runs beside the
`data/VERSION` check in `build.yml`: no compiler, no build plan, so a pull
request sees the mismatch in a few seconds.

The table now says what it covers, which is what ships: the direct
`build-depends` of the `library` and `executable` stanzas. Test and benchmark
dependencies never reach a user, which is why `temporary` leaves rather than
gains a row. The check reads names alone, so a package that relicenses under
the same name still needs the reconciliation the file already describes, and
that limit is written next to it.