### PR TITLE
Say when an EcoSpold 1 dataset number overrides the declared location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## [Unreleased]
 
 ### Added
-- Loading an EcoSpold 1 database now reports, as a warning, each input whose
-  dataset number and declared location name two different datasets of the
-  same product. The number is what the file links and it still wins, as it
+- Reading an EcoSpold 1 database from its files now reports, as a warning,
+  each input whose dataset number and declared location name two different
+  datasets of the same product. A database served from its cache is not
+  re-read, so the report appears once, when the cache is built. The number is what the file links and it still wins, as it
   did before; the report names the location declared, the location the number
   resolved to and the number itself, so the contradiction is visible without
   an external diff. BAFU 2026 v1 has eleven, most of them power plants whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+- Loading an EcoSpold 1 database now reports, as a warning, each input whose
+  dataset number and declared location name two different datasets of the
+  same product. The number is what the file links and it still wins, as it
+  did before; the report names the location declared, the location the number
+  resolved to and the number itself, so the contradiction is visible without
+  an external diff. BAFU 2026 v1 has eleven, most of them power plants whose
+  gas input carries the number of their own country's supply under an `RER`
+  label, and the published BAFU results follow the number.
+
 ### Fixed
 - A database whose inventory comes from a database it depends on is now
   characterized with the same factors as that database itself. The cascade

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -524,7 +524,10 @@ buildSupplierIndexByNameWithLocation activities techFlowDb =
         ]
 
 {- | Fix EcoSpold1 activity links by resolving supplier references.
-Matches input exchanges to suppliers by (flowName, location).
+An input's dataset number names its supplier first, checked against the
+product name; (flowName, location) is the fallback when the number resolves
+to nothing, and the name alone when it covers a single dataset. A number that
+contradicts the declared location is reported, not overruled.
 Unlinked exchanges stay unlinked so that cross-DB linking can resolve them.
 Location aliases map wrongLocation → correctLocation (e.g., "ENTSO" → "ENTSO-E")
 -}
@@ -582,7 +585,7 @@ reportLocationOverrides overrides = do
     shown = take 20 (sort overrides)
 
 {- | Bundle of lookup tables threaded through EcoSpold1 activity-link resolution.
-Previously these six fields were passed as positional parameters through
+Previously these fields were passed as positional parameters through
 'fixAllActivities' -> 'fixActivityExchanges' -> 'fixExchangeLink', each call
 re-forwarding the same values. The record collapses the cascade to a single
 argument and makes the dependencies explicit.

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -81,6 +81,9 @@ module Database.Loader (
     getReferenceProductUUID,
     indexActivities,
     UnlinkedSummary (..),
+    LocationOverride (..),
+    ecoSpold1LinkContext,
+    fixAllActivities,
     buildSupplierIndex,
     buildSupplierIndexByName,
     fixExchangeLinkByName,
@@ -386,7 +389,22 @@ data UnlinkedExchange = UnlinkedExchange
     }
     deriving (Eq, Ord, Show)
 
-{- | Summary of unlinked exchanges grouped by consumer activity.
+{- | An EcoSpold1 input whose dataset number and declared location name two
+different datasets of the product. The number is what the file links, so it
+wins; this is the trace that the file contradicted itself.
+-}
+data LocationOverride = LocationOverride
+    { loConsumer :: !T.Text
+    , loConsumerLocation :: !T.Text
+    , loFlowName :: !T.Text
+    , loDeclared :: !T.Text -- the location the exchange declares
+    , loLinked :: !T.Text -- the location of the dataset its number names
+    , loDatasetNumber :: !Int
+    }
+    deriving (Eq, Ord, Show)
+
+{- | Summary of unlinked exchanges grouped by consumer activity, and of the
+linked ones worth a word.
 'Monoid' is hand-written: bare 'Int' has no canonical instance, and using
 'Sum Int' would force every reader to unwrap.
 -}
@@ -395,15 +413,16 @@ data UnlinkedSummary = UnlinkedSummary
     , usTotalLinks :: !Int
     , usFoundLinks :: !Int
     , usMissingLinks :: !Int
+    , usLocationOverrides :: ![LocationOverride]
     }
     deriving (Show)
 
 instance Semigroup UnlinkedSummary where
-    UnlinkedSummary a1 t1 f1 m1 <> UnlinkedSummary a2 t2 f2 m2 =
-        UnlinkedSummary (M.unionWith (++) a1 a2) (t1 + t2) (f1 + f2) (m1 + m2)
+    UnlinkedSummary a1 t1 f1 m1 o1 <> UnlinkedSummary a2 t2 f2 m2 o2 =
+        UnlinkedSummary (M.unionWith (++) a1 a2) (t1 + t2) (f1 + f2) (m1 + m2) (o1 ++ o2)
 
 instance Monoid UnlinkedSummary where
-    mempty = UnlinkedSummary M.empty 0 0 0
+    mempty = UnlinkedSummary M.empty 0 0 0 []
 
 -- | Report grouped summary of unlinked exchanges
 reportUnlinkedSummary :: UnlinkedSummary -> IO ()
@@ -511,29 +530,15 @@ Location aliases map wrongLocation → correctLocation (e.g., "ENTSO" → "ENTSO
 -}
 fixEcoSpold1ActivityLinks :: M.Map T.Text T.Text -> DatasetNumberIndex -> M.Map UUID.UUID Int -> SimpleDatabase -> IO SimpleDatabase
 fixEcoSpold1ActivityLinks locationAliases dsIndex supplierLinks db = do
-    -- Build supplier index
-    let supplierIndex = buildSupplierIndex (sdbActivities db) (sdbTechFlows db)
-    -- Build name-only index with location for exchanges missing location attribute
-    let nameIndex = buildSupplierIndexByNameWithLocation (sdbActivities db) (sdbTechFlows db)
+    let ctx = ecoSpold1LinkContext locationAliases dsIndex supplierLinks db
+        (fixedActivities, summary) = fixAllActivities ctx (sdbActivities db)
     reportProgress Info $
         printf
             "Built supplier index with %d entries for activity linking (%d location aliases, %d name-only entries, %d dataset-number entries)"
-            (M.size supplierIndex)
+            (M.size (elcSupplierIndex ctx))
             (M.size locationAliases)
-            (M.size nameIndex)
+            (M.size (elcNameIndex ctx))
             (M.size dsIndex)
-
-    -- Count and report statistics
-    let ctx =
-            ExchangeLinkContext
-                { elcLocationAliases = locationAliases
-                , elcSupplierIndex = supplierIndex
-                , elcNameIndex = nameIndex
-                , elcDatasetIndex = dsIndex
-                , elcSupplierLinks = supplierLinks
-                , elcFlowDB = sdbTechFlows db
-                }
-        (fixedActivities, summary) = fixAllActivities ctx (sdbActivities db)
 
     reportProgress Info $
         printf
@@ -545,8 +550,36 @@ fixEcoSpold1ActivityLinks locationAliases dsIndex supplierLinks db = do
 
     -- Report grouped summary of unlinked exchanges
     reportUnlinkedSummary summary
+    reportLocationOverrides (usLocationOverrides summary)
 
     return $ db{sdbActivities = fixedActivities}
+
+{- | One line per input whose dataset number and declared location named two
+different datasets, sorted so one consumer's lines sit together.
+-}
+reportLocationOverrides :: [LocationOverride] -> IO ()
+reportLocationOverrides [] = pure ()
+reportLocationOverrides overrides = do
+    reportProgress Warning $
+        printf
+            "Dataset number overrides the declared location on %d inputs (the number is the supplier the file links; the location is a label)"
+            (length overrides)
+    forM_ shown $ \o ->
+        reportProgress Warning $
+            printf
+                "  - %s [%s]: %s declares %s, dataset %d is %s"
+                (T.unpack (loConsumer o))
+                (T.unpack (loConsumerLocation o))
+                (T.unpack (loFlowName o))
+                (T.unpack (loDeclared o))
+                (loDatasetNumber o)
+                (T.unpack (loLinked o))
+    when (length overrides > length shown) $
+        reportProgress Warning $
+            printf "  ... and %d more" (length overrides - length shown)
+  where
+    shown :: [LocationOverride]
+    shown = take 20 (sort overrides)
 
 {- | Bundle of lookup tables threaded through EcoSpold1 activity-link resolution.
 Previously these six fields were passed as positional parameters through
@@ -561,7 +594,22 @@ data ExchangeLinkContext = ExchangeLinkContext
     , elcDatasetIndex :: !DatasetNumberIndex
     , elcSupplierLinks :: !(M.Map UUID.UUID Int)
     , elcFlowDB :: !TechFlowDB
+    , elcActivities :: !ActivityMap
     }
+
+-- | The lookup tables 'fixAllActivities' links an EcoSpold1 database with.
+ecoSpold1LinkContext :: M.Map T.Text T.Text -> DatasetNumberIndex -> M.Map UUID.UUID Int -> SimpleDatabase -> ExchangeLinkContext
+ecoSpold1LinkContext locationAliases dsIndex supplierLinks db =
+    ExchangeLinkContext
+        { elcLocationAliases = locationAliases
+        , elcSupplierIndex = buildSupplierIndex (sdbActivities db) (sdbTechFlows db)
+        , -- Name-only index, with location, for exchanges missing the location attribute
+          elcNameIndex = buildSupplierIndexByNameWithLocation (sdbActivities db) (sdbTechFlows db)
+        , elcDatasetIndex = dsIndex
+        , elcSupplierLinks = supplierLinks
+        , elcFlowDB = sdbTechFlows db
+        , elcActivities = sdbActivities db
+        }
 
 -- | Fix all activities and return statistics with unlinked summary
 fixAllActivities :: ExchangeLinkContext -> ActivityMap -> (ActivityMap, UnlinkedSummary)
@@ -575,7 +623,7 @@ fixAllActivities ctx activities =
 -- | Fix activity exchanges and return (fixed activity, UnlinkedSummary)
 fixActivityExchanges :: ExchangeLinkContext -> Activity -> (Activity, UnlinkedSummary)
 fixActivityExchanges ctx act =
-    let (fixedExchanges, summaries) = unzip $ map (fixExchangeLink ctx (activityName act)) (exchanges act)
+    let (fixedExchanges, summaries) = unzip $ map (fixExchangeLink ctx act) (exchanges act)
         combinedSummary = mconcat summaries
      in (act{exchanges = fixedExchanges}, combinedSummary)
 
@@ -584,41 +632,63 @@ fixActivityExchanges ctx act =
 Unlinked exchanges stay unlinked for cross-DB resolution.
 Returns (fixed exchange, UnlinkedSummary)
 -}
-fixExchangeLink :: ExchangeLinkContext -> T.Text -> Exchange -> (Exchange, UnlinkedSummary)
-fixExchangeLink ExchangeLinkContext{..} consumerName ex@TechnosphereExchange{techFlowId = fid, techRole = role, techLocation = loc}
+fixExchangeLink :: ExchangeLinkContext -> Activity -> Exchange -> (Exchange, UnlinkedSummary)
+fixExchangeLink ExchangeLinkContext{..} consumer ex@TechnosphereExchange{techFlowId = fid, techRole = role, techLocation = loc}
     | role == Input || role == ReferenceInput =
-        let linked actUUID prodUUID = (ex{techFlowId = prodUUID, techActivityLinkId = actUUID}, UnlinkedSummary M.empty 1 1 0)
+        let linked overrides actUUID prodUUID = (ex{techFlowId = prodUUID, techActivityLinkId = actUUID}, UnlinkedSummary M.empty 1 1 0 overrides)
             unlinked flow lookupLoc =
                 let ue = UnlinkedExchange (tfName flow) lookupLoc
-                 in (ex, UnlinkedSummary (M.singleton consumerName [ue]) 1 0 1)
+                 in (ex, UnlinkedSummary (M.singleton (activityName consumer) [ue]) 1 0 1 [])
          in case M.lookup fid elcFlowDB of
                 Just flow ->
                     -- Tier 1: dataset-number lookup with name validation
-                    case M.lookup fid elcSupplierLinks >>= \dsNum -> M.lookup dsNum elcDatasetIndex of
-                        Just (actUUID, prodUUID)
+                    case M.lookup fid elcSupplierLinks >>= \dsNum -> (,) dsNum <$> M.lookup dsNum elcDatasetIndex of
+                        Just (dsNum, (actUUID, prodUUID))
                             | Just supplierFlow <- M.lookup prodUUID elcFlowDB
                             , normalizeText (tfName supplierFlow) == normalizeText (tfName flow) ->
-                                linked actUUID prodUUID
+                                linked (locationOverride flow dsNum (actUUID, prodUUID)) actUUID prodUUID
                         _ ->
                             -- Tier 2: name + location lookup
-                            let normalizedLoc = fromMaybe loc (M.lookup loc elcLocationAliases)
-                                soleSupplier = M.lookup (normalizeText (tfName flow)) elcNameIndex >>= sole
+                            let soleSupplier = M.lookup (normalizeText (tfName flow)) elcNameIndex >>= sole
                                 lookupLoc
-                                    | T.null normalizedLoc = maybe normalizedLoc (\(_, _, actLoc) -> actLoc) soleSupplier
-                                    | otherwise = normalizedLoc
+                                    | T.null declaredLoc = maybe declaredLoc (\(_, _, actLoc) -> actLoc) soleSupplier
+                                    | otherwise = declaredLoc
                                 key = (normalizeText (tfName flow), lookupLoc)
                              in case M.lookup key elcSupplierIndex of
-                                    Just (actUUID, prodUUID) -> linked actUUID prodUUID
+                                    Just (actUUID, prodUUID) -> linked [] actUUID prodUUID
                                     Nothing ->
                                         -- Tier 3: the name alone, and only when it
                                         -- covers a single dataset. A name shared by
                                         -- several geographies names none of them.
                                         case soleSupplier of
-                                            Just (actUUID, prodUUID, _) -> linked actUUID prodUUID
+                                            Just (actUUID, prodUUID, _) -> linked [] actUUID prodUUID
                                             Nothing -> unlinked flow lookupLoc
                 Nothing ->
-                    (ex, UnlinkedSummary M.empty 1 0 1)
+                    (ex, UnlinkedSummary M.empty 1 0 1 [])
     | otherwise = (ex, mempty)
+  where
+    declaredLoc :: T.Text
+    declaredLoc = fromMaybe loc (M.lookup loc elcLocationAliases)
+
+    -- The number named a dataset. When the declared location names another
+    -- dataset of the same product, the number still wins: it is what the file
+    -- links, and the results a database publishes follow it. The override is
+    -- recorded so a reader can see the file contradict itself.
+    locationOverride :: TechnosphereFlow -> Int -> (UUID.UUID, UUID.UUID) -> [LocationOverride]
+    locationOverride flow dsNum supplierKey =
+        [ LocationOverride
+            { loConsumer = activityName consumer
+            , loConsumerLocation = activityLocation consumer
+            , loFlowName = tfName flow
+            , loDeclared = loc
+            , loLinked = activityLocation supplier
+            , loDatasetNumber = dsNum
+            }
+        | not (T.null declaredLoc)
+        , Just supplier <- [M.lookup supplierKey elcActivities]
+        , activityLocation supplier /= declaredLoc
+        , M.member (normalizeText (tfName flow), declaredLoc) elcSupplierIndex
+        ]
 fixExchangeLink _ _ ex@BiosphereExchange{} = (ex, mempty)
 -- A WasteExchange in input direction (consumed by treatment) would benefit
 -- from the same supplier-lookup logic as a technosphere Input, but at this
@@ -798,14 +868,14 @@ fixExchangeLinkByName unitConfig unitDB idx techFlowDb consumerName ex@Technosph
                         | otherwise = Nothing
                  in case M.lookup key idx >>= accept of
                         Just (actUUID, prodUUID) ->
-                            (relink actUUID prodUUID, UnlinkedSummary M.empty 1 1 0)
+                            (relink actUUID prodUUID, UnlinkedSummary M.empty 1 1 0 [])
                         Nothing ->
                             let unlinked = UnlinkedExchange (tfName flow) loc
                                 unlinkedMap = M.singleton consumerName [unlinked]
-                             in (ex, UnlinkedSummary unlinkedMap 1 0 1)
+                             in (ex, UnlinkedSummary unlinkedMap 1 0 1 [])
             Nothing ->
                 -- Flow not in technosphere map — shouldn't happen but be safe
-                (ex, UnlinkedSummary M.empty 1 0 1)
+                (ex, UnlinkedSummary M.empty 1 0 1 [])
     | otherwise = (ex, mempty) -- Reference products: nothing to relink
 fixExchangeLinkByName _ _ _ _ _ ex@BiosphereExchange{} = (ex, mempty)
 -- Waste link resolution is deferred to the cross-DB linker path.

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -552,7 +552,7 @@ spec = do
             fixed <- fixEcoSpold1ActivityLinks M.empty M.empty M.empty (simpleDBOf [wheatFR, bread] flowNames)
             wheatLink fixed `shouldBe` [actUUID1]
 
-        -- BAFU 2026 v1 has nine power plants whose gas input carries the number of
+        -- BAFU 2026 v1 has power plants whose gas input carries the number of
         -- their own country's gas supply and the label RER (volca#347). The number
         -- is what the file links, and the official results follow it.
         let gasBG = ((actUUID1, flowUUID1), minimalActivity "gas supply" "BG" [refExchange flowUUID1])

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -309,21 +309,21 @@ spec = do
     -- -----------------------------------------------------------------------
     describe "UnlinkedSummary Monoid" $ do
         it "sums all counters via (<>)" $ do
-            let s1 = UnlinkedSummary M.empty 10 8 2
-                s2 = UnlinkedSummary M.empty 5 3 2
+            let s1 = UnlinkedSummary M.empty 10 8 2 []
+                s2 = UnlinkedSummary M.empty 5 3 2 []
                 m = s1 <> s2
             usTotalLinks m `shouldBe` 15
             usFoundLinks m `shouldBe` 11
             usMissingLinks m `shouldBe` 4
 
         it "unions activity maps via (<>)" $ do
-            let s1 = UnlinkedSummary (M.singleton "actA" []) 1 0 1
-                s2 = UnlinkedSummary (M.singleton "actB" []) 1 0 1
+            let s1 = UnlinkedSummary (M.singleton "actA" []) 1 0 1 []
+                s2 = UnlinkedSummary (M.singleton "actB" []) 1 0 1 []
                 m = s1 <> s2
             M.size (usActivities m) `shouldBe` 2
 
         it "mempty is the identity" $ do
-            let s = UnlinkedSummary M.empty 3 2 1
+            let s = UnlinkedSummary M.empty 3 2 1 []
                 m = s <> mempty
             usTotalLinks m `shouldBe` 3
             usFoundLinks m `shouldBe` 2
@@ -536,12 +536,13 @@ spec = do
                 , minimalActivity "bread production" "CH" [refExchange breadUUID, inputExchange flowUUID1 ""]
                 )
             flowNames = [(flowUUID1, "Wheat"), (flowUUID2, "Wheat"), (breadUUID, "Bread")]
-            -- The supplier the consumer's unlocated wheat input ends up naming.
-            wheatLink sdb =
+            -- The suppliers the consumer's inputs end up naming.
+            inputLinksIn acts =
                 [ link
-                | Just act <- [M.lookup (consumerUUID, breadUUID) (sdbActivities sdb)]
+                | Just act <- [M.lookup (consumerUUID, breadUUID) acts]
                 , TechnosphereExchange{techRole = Input, techActivityLinkId = link} <- exchanges act
                 ]
+            wheatLink = inputLinksIn . sdbActivities
 
         it "leaves an unlocated input unlinked when the product name covers several geographies" $ do
             fixed <- fixEcoSpold1ActivityLinks M.empty M.empty M.empty (simpleDBOf [wheatFR, wheatDE, bread] flowNames)
@@ -550,6 +551,40 @@ spec = do
         it "links an unlocated input when the product name covers one dataset" $ do
             fixed <- fixEcoSpold1ActivityLinks M.empty M.empty M.empty (simpleDBOf [wheatFR, bread] flowNames)
             wheatLink fixed `shouldBe` [actUUID1]
+
+        -- BAFU 2026 v1 has nine power plants whose gas input carries the number of
+        -- their own country's gas supply and the label RER (volca#347). The number
+        -- is what the file links, and the official results follow it.
+        let gasBG = ((actUUID1, flowUUID1), minimalActivity "gas supply" "BG" [refExchange flowUUID1])
+            gasRER = ((actUUID2, flowUUID2), minimalActivity "gas supply" "RER" [refExchange flowUUID2])
+            plantDeclaring loc =
+                ( (consumerUUID, breadUUID)
+                , minimalActivity "power plant" "BG" [refExchange breadUUID, inputExchange flowUUID1 loc]
+                )
+            gasNames = [(flowUUID1, "Natural gas"), (flowUUID2, "Natural gas"), (breadUUID, "Heat")]
+            linkPlantDeclaring loc =
+                let db = simpleDBOf [gasBG, gasRER, plantDeclaring loc] gasNames
+                    ctx = ecoSpold1LinkContext M.empty (M.singleton 300474 (actUUID1, flowUUID1)) (M.singleton flowUUID1 300474) db
+                 in fixAllActivities ctx (sdbActivities db)
+
+        it "follows the dataset number over the declared location, and records the override" $ do
+            let (acts, summary) = linkPlantDeclaring "RER"
+            inputLinksIn acts `shouldBe` [actUUID1]
+            usLocationOverrides summary
+                `shouldBe` [ LocationOverride
+                                { loConsumer = "power plant"
+                                , loConsumerLocation = "BG"
+                                , loFlowName = "Natural gas"
+                                , loDeclared = "RER"
+                                , loLinked = "BG"
+                                , loDatasetNumber = 300474
+                                }
+                           ]
+
+        it "records no override when the declared location names no dataset" $ do
+            let (acts, summary) = linkPlantDeclaring "ENTSO"
+            inputLinksIn acts `shouldBe` [actUUID1]
+            usLocationOverrides summary `shouldBe` []
 
     -- -----------------------------------------------------------------------
     -- countTotalTechInputs / countUnlinkedExchanges / collectUnlinkedProductNames


### PR DESCRIPTION
Refs #347.

## Why

An EcoSpold 1 technosphere input names its supplier twice: `number` is the dataset number of the supplier (the number that dataset stamps on its own reference product), and `location` is a label. The two can disagree. In BAFU 2026 v1 they do on 11 of 114 369 inputs: eight `Natural gas, burned in power plant or heat plant` datasets (BG CN HR IN MY PL RO RU) and one US polylactide dataset declare `RER` on a gas input whose number names their own country's supply, and `Granite, natural stone council, at mine | CH` declares `CH` on a transport input whose number names `RER`.

The linker follows the number, checked against the product name, and falls back to name plus location only when the number resolves to nothing. #347 asked for the declared location to win when a dataset exists for it. It should not: the LCIA results BAFU publishes with the database follow the number. For the five European plants, whose combustion emissions are identical, the plant's climate-change score minus its own combustion matches its own country's gas supply within 0.05 %, and would be off by 3 to 11 % on the RER supply. What was wrong is that the override was silent, so the reporter needed an external matrix diff to find it.

## What changes

Loading an EcoSpold 1 database now reports each input whose number and declared location name two different datasets of the same product, at most twenty lines, sorted by consumer:

```
[WARN] Dataset number overrides the declared location on 11 inputs (the number is the supplier the file links; the location is a label)
[WARN]   - Granite, natural stone council, at mine [CH]: Transport, passenger car, fleet average declares CH, dataset 176928 is RER
[WARN]   - Natural gas, burned in power plant or heat plant [BG]: Natural gas, high pressure, at consumer declares RER, dataset 300474 is BG
...
```

A declared location that no dataset of the product carries (`ENTSO` before aliasing, 23 inputs here) is not an override: there was nothing else to link to.

The lookup tables the linker uses are now built by a pure function, so the test drives the linking directly and reads the overrides off the summary.

## Checks

- Full suite: 2372 examples, 0 failures.
- Loaded BAFU 2026 v1 with the built binary: 114 369 of 114 369 inputs linked as before, the 11 lines above reported.
