### PR TITLE
Report unmapped what scoring cannot serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,17 @@
   an external diff. BAFU 2026 v1 has eleven, most of them power plants whose
   gas input carries the number of their own country's supply under an `RER`
   label, and the published BAFU results follow the number.
+- Each unmapped factor of the method mapping report now carries the
+  compartment the method states (`compartment`), so a consumer can see a
+  vocabulary gap without reading the log. Wire revision 13.
 
 ### Fixed
+- The method mapping report no longer counts as matched a factor whose only
+  name hit is filed under another compartment vocabulary ("air" against
+  "emissions to air"). Such a method used to report 82% coverage and score
+  every activity at zero; it now reports those factors unmapped, and the log
+  says which two vocabularies never met and that a `[[compartment-mappings]]`
+  table bridges them.
 - A database whose inventory comes from a database it depends on is now
   characterized with the same factors as that database itself. The cascade
   that ties a method's factors to a database's flows was built over the root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@
   "emissions to air"). Such a method used to report 82% coverage and score
   every activity at zero; it now reports those factors unmapped, and the log
   says which two vocabularies never met and that a `[[compartment-mappings]]`
-  table bridges them.
+  table bridges them. Reported by @mklarmann (#346), whose independent
+  Brightway comparison showed the engine was right and the report was not.
 - A database whose inventory comes from a database it depends on is now
   characterized with the same factors as that database itself. The cascade
   that ties a method's factors to a database's flows was built over the root

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -24,7 +24,7 @@ The other direction is a promise about pyvolca's own names. A name this client p
 
 _Generated from `volca._compat`: run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.10.1** speaks wire formats **2 to 12** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error. A name this build has retired keeps working until pyvolca **1.0**.
+This build of **pyvolca 0.10.1** speaks wire formats **2 to 13** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error. A name this build has retired keeps working until pyvolca **1.0**.
 
 <!-- END: compatibility -->
 
@@ -2480,6 +2480,7 @@ A method factor with no matching database flow (in `MappingStatus`).
 | `flow_ref` | `str` | _required_ |
 | `flow_name` | `str` | _required_ |
 | `direction` | `str` | _required_ |
+| `compartment` | `str \| None` | None |
 
 ### `WasteExchange`
 

--- a/pyvolca/src/volca/_compat.py
+++ b/pyvolca/src/volca/_compat.py
@@ -32,10 +32,11 @@ the client works against it except the revision-gated capabilities (see
 ``Client._require_wire``), which check the engine's advertised revision
 before sending anything."""
 
-KNOWN_WIRE = 12
-"""The newest wire revision this pyvolca understands (revision 12 adds the
-node type a tree export reports where a link names a row no loaded database
-holds; revision 11 added the
+KNOWN_WIRE = 13
+"""The newest wire revision this pyvolca understands (revision 13 adds the
+compartment an unmapped factor of the mapping report carries; revision 12
+added the node type a tree export reports where a link names a row no loaded
+database holds; revision 11 added the
 data bundle's version on the version route; revision 10 added the role
 a waste line reports; revision 9 added the kind
 a flow search reports and filters on; revision 8 added the two

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -1880,6 +1880,9 @@ class UnmappedFlow(FromJson):
     flow_ref: str
     flow_name: str
     direction: str
+    #: The compartment the method states, as written ("air", "air/low. pop.");
+    #: None when the row states none, or when the engine predates wire revision 13.
+    compartment: str | None = None
 
 
 @dataclass

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -1880,8 +1880,9 @@ class UnmappedFlow(FromJson):
     flow_ref: str
     flow_name: str
     direction: str
-    #: The compartment the method states, as written ("air", "air/low. pop.");
-    #: None when the row states none, or when the engine predates wire revision 13.
+    #: The compartment the method states, rendered as the factors route renders
+    #: it ("air", "water/groundwater/long-term"); None when the row states none,
+    #: or when the engine predates wire revision 13.
     compartment: str | None = None
 
 

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1982,7 +1982,7 @@ getMethodMapping dbName methodIdText = do
                     , ufaDirection = case mcfDirection cf of
                         MT.Input -> "Input"
                         MT.Output -> "Output"
-                    , ufaCompartment = MT.compartmentText <$> mcfCompartment cf
+                    , ufaCompartment = compartmentPath <$> mcfCompartment cf
                     }
                 | (cf, Nothing) <- mappings
                 ]

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1295,7 +1295,8 @@ appears that a client must know about /before/ calling it. Adding a route
 does not exempt a change from the bump: an absent route answers 404, and so
 does a request naming a database the engine has not loaded, so a client
 cannot tell "this engine is too old" from "you asked for the wrong thing"
-(revision 12: the @MissingNode@ a tree export reports where a link names a
+(revision 13: the @compartment@ an unmapped factor of the mapping report
+carries; revision 12: the @MissingNode@ a tree export reports where a link names a
 row no loaded database holds, and the @missing:@ prefixed id such a node and
 its edge carry in place of a process id;
 revision 11: the @dataVersion@ the version route reports; revision 10: the
@@ -1313,7 +1314,7 @@ the whole filtered set).
 Clients compare it to decide compatibility and to gate such capabilities.
 -}
 currentWireVersion :: Int
-currentWireVersion = 12
+currentWireVersion = 13
 
 getVersion :: AppM Value
 getVersion = do
@@ -1981,6 +1982,7 @@ getMethodMapping dbName methodIdText = do
                     , ufaDirection = case mcfDirection cf of
                         MT.Input -> "Input"
                         MT.Output -> "Output"
+                    , ufaCompartment = MT.compartmentText <$> mcfCompartment cf
                     }
                 | (cf, Nothing) <- mappings
                 ]

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -650,7 +650,7 @@ data UnmappedFlowAPI = UnmappedFlowAPI
     { ufaFlowRef :: UUID -- Flow UUID in method
     , ufaFlowName :: Text -- Flow name in method
     , ufaDirection :: Text -- "Input" or "Output"
-    , ufaCompartment :: Maybe Text -- The compartment the method states, as written ("air", "air/low. pop."); Nothing when the row states none
+    , ufaCompartment :: Maybe Text -- The compartment the method states, rendered as the factors route renders it ("air", "water/groundwater/long-term"); Nothing when the row states none
     }
     deriving (Generic)
     deriving (ToJSON, ToSchema) via (Stripped UnmappedFlowAPI)

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -650,6 +650,7 @@ data UnmappedFlowAPI = UnmappedFlowAPI
     { ufaFlowRef :: UUID -- Flow UUID in method
     , ufaFlowName :: Text -- Flow name in method
     , ufaDirection :: Text -- "Input" or "Output"
+    , ufaCompartment :: Maybe Text -- The compartment the method states, as written ("air", "air/low. pop."); Nothing when the row states none
     }
     deriving (Generic)
     deriving (ToJSON, ToSchema) via (Stripped UnmappedFlowAPI)

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -22,6 +22,7 @@ module Method.Mapping (
     expandPatternCF,
     dropExcludedMappings,
     exclusionWarning,
+    compartmentGapWarning,
     buildMapContext,
     mapContextFor,
 
@@ -123,7 +124,7 @@ import Data.List (find, partition, sortOn)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
-import Data.Maybe (fromMaybe, isJust, isNothing, listToMaybe, mapMaybe)
+import Data.Maybe (fromMaybe, isJust, isNothing, listToMaybe, mapMaybe, maybeToList)
 import Data.Ord (Down (..))
 import Data.STRef (modifySTRef', newSTRef, readSTRef)
 import qualified Data.Set as S
@@ -278,6 +279,7 @@ mapMethodFlows ctx0 method = do
             then mapM resolve cfs
             else concat <$> mapConcurrently (mapM resolve) (chunksOf (max 1 ((n + caps - 1) `div` caps)) cfs)
     mapM_ (warn . pure) (mapMaybe (exclusionWarning (mcBioFlowsByUUID ctx0)) exclusionCFs)
+    warn (maybeToList (compartmentGapWarning (mcCompartmentMap ctx0) (mcBioFlowsByName ctx0) concrete))
     expanded <- fmap concat . mapM (materialize exclusionCFs) $ patternCFs
     pure (concrete ++ expanded)
   where
@@ -489,6 +491,37 @@ exclusionWarning flows cf
     | otherwise = Nothing
   where
     why reason = "exclusion CF '" <> mcfFlowName cf <> "' " <> reason
+
+{- | The factors the cascade left unmatched although a flow of their name is
+in the database, filed under a medium the row does not state. That is a
+vocabulary gap ("air" against "emissions to air"), which a compartment
+mapping bridges and nothing else will: said once per method, with both
+vocabularies, so the operator knows what to declare.
+-}
+compartmentGapWarning :: CompartmentMap -> M.Map Text [BiosphereFlow] -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> Maybe Text
+compartmentGapWarning cmap flowsByName mappings
+    | null gaps = Nothing
+    | otherwise =
+        Just $
+            T.pack (show (length gaps))
+                <> " factor(s) name a flow this database files under another compartment (method: "
+                <> quoted (S.fromList (map fst gaps))
+                <> "; database: "
+                <> quoted (S.unions (map snd gaps))
+                <> "). Declare a [[compartment-mappings]] table bridging them."
+  where
+    gaps :: [(Text, S.Set Text)]
+    gaps =
+        [ (stated, seen)
+        | (cf, Nothing) <- mappings
+        , Just (Medium stated, _) <- [cfMediumSub cmap cf]
+        , Just flows <- [M.lookup (normalizeName (mcfFlowName cf)) flowsByName]
+        , let seen = S.fromList [m | fl <- flows, let (Medium m, _) = flowMediumSub cmap fl]
+        , not (S.null seen)
+        , stated `S.notMember` seen
+        ]
+    quoted :: S.Set Text -> Text
+    quoted = T.intercalate ", " . map (\t -> "\"" <> t <> "\"") . S.toList
 
 -- | Wire name for a match strategy.
 strategyToText :: MatchStrategy -> Text

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -493,10 +493,14 @@ exclusionWarning flows cf
     why reason = "exclusion CF '" <> mcfFlowName cf <> "' " <> reason
 
 {- | The factors the cascade left unmatched although a flow of their name is
-in the database, filed under a medium the row does not state. That is a
-vocabulary gap ("air" against "emissions to air"), which a compartment
-mapping bridges and nothing else will: said once per method, with both
-vocabularies, so the operator knows what to declare.
+in the database, stated in a medium no flow of the database is filed under.
+That is a vocabulary gap ("air" against "emissions to air"), which a
+compartment mapping bridges and nothing else will: said once per method,
+with both vocabularies, so the operator knows what to declare.
+
+Judged on the whole database, not on the flows of that name: a substance the
+database has in water and not in air leaves a factor stated in air unmatched
+too, and that is the database's inventory, not its vocabulary.
 -}
 compartmentGapWarning :: CompartmentMap -> M.Map Text [BiosphereFlow] -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> Maybe Text
 compartmentGapWarning cmap flowsByName mappings
@@ -510,15 +514,19 @@ compartmentGapWarning cmap flowsByName mappings
                 <> quoted (S.unions (map snd gaps))
                 <> "). Declare a [[compartment-mappings]] table bridging them."
   where
+    mediumOf :: BiosphereFlow -> Text
+    mediumOf fl = let (Medium m, _) = flowMediumSub cmap fl in m
+    databaseMedia :: S.Set Text
+    databaseMedia = S.fromList (map mediumOf (concat (M.elems flowsByName)))
     gaps :: [(Text, S.Set Text)]
     gaps =
         [ (stated, seen)
         | (cf, Nothing) <- mappings
         , Just (Medium stated, _) <- [cfMediumSub cmap cf]
+        , stated `S.notMember` databaseMedia
         , Just flows <- [M.lookup (normalizeName (mcfFlowName cf)) flowsByName]
-        , let seen = S.fromList [m | fl <- flows, let (Medium m, _) = flowMediumSub cmap fl]
+        , let seen = S.fromList (map mediumOf flows)
         , not (S.null seen)
-        , stated `S.notMember` seen
         ]
     quoted :: S.Set Text -> Text
     quoted = T.intercalate ", " . map (\t -> "\"" <> t <> "\"") . S.toList

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -374,16 +374,16 @@ under "resource".
 sameMedium :: Text -> Text -> Bool
 sameMedium a b = normalizeMedium (T.toCaseFold a) == normalizeMedium (T.toCaseFold b)
 
-{- | Does a flow's medium satisfy the one a method row states? The row's medium
-may be the broader spelling of the flow's, as "air" is of "urban air", which is
-the row widening to cover a narrower filing and not the other way round. An
-empty statement constrains nothing.
+{- | Does a flow's medium satisfy the one a method row states? Equal after
+normalization, as the scoring tables key it: 'buildMethodTables' indexes a
+factor under the row's normalized medium and 'flowMediumSub' files a flow
+under its own, so a match judged any looser here promises a factor the read
+side never serves. "air" against "emissions to air" is a vocabulary gap that
+only a compartment rule bridges, not a widening. An empty statement
+constrains nothing.
 -}
 mediumFits :: Text -> Text -> Bool
-mediumFits stated actual =
-    T.null stated || sameMedium stated actual || norm stated `T.isInfixOf` norm actual
-  where
-    norm = normalizeMedium . T.toCaseFold
+mediumFits stated actual = T.null stated || sameMedium stated actual
 
 {- | Does a flow's subcompartment satisfy the one a method row states? A
 statement that names no particular subcompartment constrains only the medium,

--- a/src/Method/Types.hs
+++ b/src/Method/Types.hs
@@ -14,7 +14,6 @@ module Method.Types (
     MethodCF (..),
     FlowDirection (..),
     Compartment (..),
-    compartmentText,
     Location (..),
     Medium (..),
     Subcompartment (..),
@@ -84,12 +83,6 @@ qualifier: "long-term" or ""
 -}
 data Compartment = Compartment !Text !Text !Text
     deriving (Eq, Show, Generic, NFData, Store, ToJSON, FromJSON)
-
--- | The compartment as a person reads it in a method file: @medium@ or @medium/sub@.
-compartmentText :: Compartment -> Text
-compartmentText (Compartment med sub _)
-    | T.null sub = med
-    | otherwise = med <> T.singleton '/' <> sub
 
 {- | A normalized compartment medium (the output of 'normalizeMedium' applied to
 a 'normalizeCompartment'-ed medium, e.g. @"air"@, @"water"@, @"resource"@). A

--- a/src/Method/Types.hs
+++ b/src/Method/Types.hs
@@ -14,6 +14,7 @@ module Method.Types (
     MethodCF (..),
     FlowDirection (..),
     Compartment (..),
+    compartmentText,
     Location (..),
     Medium (..),
     Subcompartment (..),
@@ -83,6 +84,12 @@ qualifier: "long-term" or ""
 -}
 data Compartment = Compartment !Text !Text !Text
     deriving (Eq, Show, Generic, NFData, Store, ToJSON, FromJSON)
+
+-- | The compartment as a person reads it in a method file: @medium@ or @medium/sub@.
+compartmentText :: Compartment -> Text
+compartmentText (Compartment med sub _)
+    | T.null sub = med
+    | otherwise = med <> T.singleton '/' <> sub
 
 {- | A normalized compartment medium (the output of 'normalizeMedium' applied to
 a 'normalizeCompartment'-ed medium, e.g. @"air"@, @"water"@, @"resource"@). A

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -15,7 +15,7 @@ import Data.Maybe (isJust)
 import Method.ChemSynonyms (emptyChemSynonyms, parseChemSynonymsCSV)
 import Method.Mapping
 import Method.ParserCSV (parseMethodCSVBytes)
-import Method.Types (Compartment (..), EnergyDensity (..), FlowDirection (..), Method (..), MethodCF (..), buildCompartmentMapFromCSV, compartmentText)
+import Method.Types (Compartment (..), EnergyDensity (..), FlowDirection (..), Method (..), MethodCF (..), buildCompartmentMapFromCSV)
 import SynonymDB (BridgeDirection (..), SynEdge (..), buildFromEdges, buildFromPairs, emptySynonymDB, normalizeName)
 import Types (BiosphereFlow (..), Unit (..))
 import qualified Types as VT
@@ -721,12 +721,6 @@ spec = do
                 rule = M.singleton ("urban air", "", "") (Compartment "air" "urban" "")
             fmap bfId (findFlowByNameComp M.empty byName "nox" (Just comp)) `shouldBe` Nothing
             fmap bfId (findFlowByNameComp rule byName "nox" (Just comp)) `shouldBe` Just fid1
-
-    describe "compartmentText" $ do
-        it "writes the medium alone when there is no subcompartment" $
-            compartmentText (Compartment "air" "" "") `shouldBe` "air"
-        it "writes medium/sub otherwise" $
-            compartmentText (Compartment "air" "low. pop." "") `shouldBe` "air/low. pop."
 
     describe "compartmentGapWarning" $ do
         it "names both vocabularies when a factor's name is filed under another medium" $ do

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -15,7 +15,7 @@ import Data.Maybe (isJust)
 import Method.ChemSynonyms (emptyChemSynonyms, parseChemSynonymsCSV)
 import Method.Mapping
 import Method.ParserCSV (parseMethodCSVBytes)
-import Method.Types (Compartment (..), EnergyDensity (..), FlowDirection (..), Method (..), MethodCF (..), buildCompartmentMapFromCSV)
+import Method.Types (Compartment (..), EnergyDensity (..), FlowDirection (..), Method (..), MethodCF (..), buildCompartmentMapFromCSV, compartmentText)
 import SynonymDB (BridgeDirection (..), SynEdge (..), buildFromEdges, buildFromPairs, emptySynonymDB, normalizeName)
 import Types (BiosphereFlow (..), Unit (..))
 import qualified Types as VT
@@ -721,6 +721,12 @@ spec = do
                 rule = M.singleton ("urban air", "", "") (Compartment "air" "urban" "")
             fmap bfId (findFlowByNameComp M.empty byName "nox" (Just comp)) `shouldBe` Nothing
             fmap bfId (findFlowByNameComp rule byName "nox" (Just comp)) `shouldBe` Just fid1
+
+    describe "compartmentText" $ do
+        it "writes the medium alone when there is no subcompartment" $
+            compartmentText (Compartment "air" "" "") `shouldBe` "air"
+        it "writes medium/sub otherwise" $
+            compartmentText (Compartment "air" "low. pop." "") `shouldBe` "air/low. pop."
 
     describe "compartmentGapWarning" $ do
         it "names both vocabularies when a factor's name is filed under another medium" $ do

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -139,6 +139,19 @@ spec = do
                 comp = Compartment "air" "" ""
             fmap bfId (findFlowByNameComp M.empty byName "co2" (Just comp)) `shouldBe` Nothing
 
+        it "does not read a medium that merely contains the stated one as that medium" $ do
+            -- "air" is a substring of "emissions to air", which is another
+            -- vocabulary, not a widening. The scoring tables key on the exact
+            -- normalized medium, so a match here promised a factor scoring
+            -- never served (volca#346). A compartment rule is what bridges it.
+            fid <- nextRandom
+            let flow = mkFlow fid "ammonia" "emissions to air" Nothing
+                byName = M.singleton "ammonia" [flow]
+                comp = Compartment "air" "" ""
+                rule = M.singleton ("emissions to air", "", "") (Compartment "air" "" "")
+            fmap bfId (findFlowByNameComp M.empty byName "ammonia" (Just comp)) `shouldBe` Nothing
+            fmap bfId (findFlowByNameComp rule byName "ammonia" (Just comp)) `shouldBe` Just fid
+
         it "does not read a long-term subcompartment as the immediate one" $ do
             -- "low. pop." is contained in "low. pop., long-term"; a delayed
             -- emission is not the immediate one, so the row takes the flow at
@@ -694,14 +707,20 @@ spec = do
                 comp = Compartment "" "" ""
             fmap bfId (findFlowByNameComp M.empty byName "co2" (Just comp)) `shouldBe` Just fid
 
-        it "medium isInfixOf category matches (air in urban air)" $ do
+        it "does not read a medium the stated one is only part of as the stated one (air in urban air)" $ do
+            -- A flow filed under the medium "urban air" is not in the row's
+            -- medium "air": the tables would index the row under "air" and
+            -- never serve that flow. A compartment rule is what says the two
+            -- spellings are one medium.
             fid1 <- nextRandom
             fid2 <- nextRandom
             let fUrbanAir = mkFlow fid1 "nox" "urban air" Nothing
                 fWater = mkFlow fid2 "nox" "water" Nothing
                 byName = M.singleton "nox" [fWater, fUrbanAir]
                 comp = Compartment "air" "urban" ""
-            fmap bfId (findFlowByNameComp M.empty byName "nox" (Just comp)) `shouldBe` Just fid1
+                rule = M.singleton ("urban air", "", "") (Compartment "air" "urban" "")
+            fmap bfId (findFlowByNameComp M.empty byName "nox" (Just comp)) `shouldBe` Nothing
+            fmap bfId (findFlowByNameComp rule byName "nox" (Just comp)) `shouldBe` Just fid1
 
     describe "fillBroadcastVector + computeLCIAScoreFromTables (Phase 1)" $ do
         let mkUnit uid name = Unit{unitId = uid, unitName = name, unitSymbol = name, unitComment = ""}

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -722,6 +722,24 @@ spec = do
             fmap bfId (findFlowByNameComp M.empty byName "nox" (Just comp)) `shouldBe` Nothing
             fmap bfId (findFlowByNameComp rule byName "nox" (Just comp)) `shouldBe` Just fid1
 
+    describe "compartmentGapWarning" $ do
+        it "names both vocabularies when a factor's name is filed under another medium" $ do
+            fid <- nextRandom
+            let flow = mkFlow fid "ammonia" "emissions to air" Nothing
+                cf = mkCFComp "ammonia" "air" "" 0.747
+            compartmentGapWarning M.empty (M.singleton "ammonia" [flow]) [(cf, Nothing)]
+                `shouldBe` Just "1 factor(s) name a flow this database files under another compartment (method: \"air\"; database: \"emissions to air\"). Declare a [[compartment-mappings]] table bridging them."
+
+        it "stays silent when the name is simply absent" $ do
+            let cf = mkCFComp "ammonia" "air" "" 0.747
+            compartmentGapWarning M.empty M.empty [(cf, Nothing)] `shouldBe` Nothing
+
+        it "stays silent for a factor that resolved" $ do
+            fid <- nextRandom
+            let flow = mkFlow fid "ammonia" "air" Nothing
+                cf = mkCFComp "ammonia" "air" "" 0.747
+            compartmentGapWarning M.empty (M.singleton "ammonia" [flow]) [(cf, Just (flow, ByName))] `shouldBe` Nothing
+
     describe "fillBroadcastVector + computeLCIAScoreFromTables (Phase 1)" $ do
         let mkUnit uid name = Unit{unitId = uid, unitName = name, unitSymbol = name, unitComment = ""}
 

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -734,6 +734,17 @@ spec = do
             let cf = mkCFComp "ammonia" "air" "" 0.747
             compartmentGapWarning M.empty M.empty [(cf, Nothing)] `shouldBe` Nothing
 
+        it "stays silent when the database speaks the stated medium, only not for that substance" $ do
+            -- Nitrite in water and not in air is the database's inventory,
+            -- not its vocabulary: nothing to declare.
+            fid1 <- nextRandom
+            fid2 <- nextRandom
+            let nitrite = mkFlow fid1 "nitrite" "water" Nothing
+                co2 = mkFlow fid2 "co2" "air" Nothing
+                byName = M.fromList [("nitrite", [nitrite]), ("co2", [co2])]
+                cf = mkCFComp "nitrite" "air" "" 1.0
+            compartmentGapWarning M.empty byName [(cf, Nothing)] `shouldBe` Nothing
+
         it "stays silent for a factor that resolved" $ do
             fid <- nextRandom
             let flow = mkFlow fid "ammonia" "air" Nothing


### PR DESCRIPTION
Closes #346.

## The problem

A method whose compartments are written `air` / `soil`, run against an EcoSpold 1 database that files its flows under `emissions to air`, with no `[[compartment-mappings]]` declared: the mapping report said 82% coverage and 33 factors matched by name, `uniqueDbFlowsMatched` said 0, and every score was 0.0.

Both numbers were produced by the same engine judging "same medium" two different ways. At build time the name matcher accepted a flow whose medium merely *contained* the row's (`"air"` inside `"emissions to air"`, a substring test). At read time the lookup tables key a factor under the row's exact normalized medium and file a flow under its own, so that match could never be served. The report counted a promise scoring never kept.

## What changes

- **A medium has to be the same after normalization on both sides.** The substring clause is gone; a vocabulary gap is left to the compartment mapping, which is the one thing that bridges it. The report for the scenario above now says `unmapped: 3`, `coverage: 0`, and `mappedFlows: 0` in the impact responses, consistent with the scores.
- **The log names the two vocabularies, once per method,** the first time a method is mapped against a database: `3 factor(s) name a flow this database files under another compartment (method: "air"; database: "emissions to air"). Declare a [[compartment-mappings]] table bridging them.`
- **Each unmapped factor of the mapping report carries the compartment the method states** (`compartment`), so an API consumer sees the gap without the log. Wire revision 13; pyvolca reads the field.

## Measured

Agribalyse 3.2 × EF 3.1 (adapted) 1.03, 25 categories, per-flow readings of `flow-mapping` (cfValue, matchStrategy, cfFlowName) before and after:

    137125 flow readings, 0 changed

The substring clause never produced a match the tables could serve, so removing it moves nothing where a compartment mapping is active.

BAFU 2025 EcoSpold 1 (11 748 files) × a 3-row tabular method saying `air`, no compartment mapping, `GET .../method/{id}/mapping`:

| | mappedByName | unmapped | coverage | uniqueDbFlowsMatched |
|---|---|---|---|---|
| before | 3 | 0 | 100.0 | 0 |
| after | 0 | 3 | 0.0 | 0 |
| after, mapping declared | 3 | 0 | 100.0 | 12 |

After, each entry of `unmappedFlows` carries `"compartment": "air"`, and the server log shows the warning above. With `data/compartments.csv` declared there is no warning.

I did not take the issue's second suggestion (a hard error when a score characterizes zero flows): a process with no radionuclide legitimately characterizes zero flows under ionizing radiation. The honest signal is per (database, method), at mapping time, which is where it now lives.
