### PR TITLE
Skip the cascade for a flow the broadcast fill already judged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,12 @@
   On the Agribalyse 4.0 export of 13 May 2026 it names the nine that were being
   filled with a supplier nobody asked for.
 - Every database cache is rebuilt on first load.
+- Scoring a batch of activities is faster on a database whose inventories
+  carry many flows no method characterizes: on Agribalyse 3.2 with EF 3.1 a
+  batch of 500 activities takes about 25 seconds instead of about 70. Such a
+  flow used to be looked up again by name, for every method and every
+  activity, although the tables had already found it carries no factor; it
+  is now skipped. No score changes.
 
 ### Removed
 - The fuzzy match strategy, which nothing produced. No matcher ever returned

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -843,12 +843,14 @@ data MethodTables = MethodTables
     method's own zero" — this map is what keeps those three apart. Absent key
     = the cascade found no CF at all.
     -}
-    , mtFilledOver :: !BioFlowDB
-    {- ^ The flow table 'fillBroadcastVector' walked. A flow it holds that
-    'mtBroadcast' omits was judged by the cascade then and carries no factor,
-    so a scorer need not ask again; a flow it does not hold arrived after the
-    fill (a what-if substitution into a database loaded since) and still takes
-    the cascade. Empty until the fill.
+    , mtJudged :: !(S.Set UUID)
+    {- ^ The flows 'fillBroadcastVector' walked, the keys of the flow table it
+    was given. Each went through the cascade, so one this set holds that
+    'mtBroadcast' omits carries no factor and a scorer need not ask again; a
+    flow outside it arrived after the fill (a what-if substitution into a
+    database loaded since) and still takes the cascade. Only the keys are
+    kept: the records themselves would outlive their database's unload.
+    Empty until the fill.
     -}
     , mtBroadcast :: !(M.Map UUID Double)
     {- ^ Pre-multiplied broadcast CFs: flow UUID → effective CF (CF value × flow→CF unit conversion).
@@ -1550,7 +1552,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
         , mtCompartmentMap = cmap
         , mtEnergyDensities = energyDensities
         , mtResolution = M.empty -- filled alongside 'mtBroadcast'
-        , mtFilledOver = M.empty -- filled alongside 'mtBroadcast'
+        , mtJudged = S.empty -- filled alongside 'mtBroadcast'
         , mtBroadcast = M.empty -- fill via 'fillBroadcastVector' to enable the fast path
         , mtRegionalActivityWeights = Nothing -- fill via 'fillRegionalActivityWeights' for regional fast path
         }
@@ -1845,7 +1847,7 @@ fillBroadcastVector unitConfig unitDB flowDB tables =
     tables
         { mtBroadcast = M.map fst resolved
         , mtResolution = M.map snd resolved
-        , mtFilledOver = flowDB
+        , mtJudged = M.keysSet flowDB
         }
   where
     resolved = M.mapMaybeWithKey buildEntry flowDB
@@ -2967,7 +2969,7 @@ data BatchedTables = BatchedTables
     -}
     , btJudged :: !(Set.Set UUID)
     {- ^ Flows every method's fill walked and none characterizes: the
-    intersection of the 'mtFilledOver' tables, minus 'btUuidIndex'. Such a
+    intersection of the methods' 'mtJudged', minus 'btUuidIndex'. Such a
     flow contributes nothing, and the scoring loop knows it in one lookup
     instead of one cascade per method.
     -}
@@ -3008,7 +3010,7 @@ buildBatchedTables entries =
         uuidList = Set.toAscList uuidSet
         uuidIndex = M.fromList (zip uuidList [0 ..])
         nFlows = length uuidList
-        judged = intersections (map (M.keysSet . mtFilledOver . mseTables) (V.toList entries)) `Set.difference` uuidSet
+        judged = intersections (map (mtJudged . mseTables) (V.toList entries)) `Set.difference` uuidSet
         mat = U.create $ do
             mv <- MU.replicate (nFlows * nMethods) (0.0 :: Double)
             V.iforM_ entries $ \i e ->
@@ -3118,9 +3120,8 @@ For each non-zero @(uuid, qty)@ in the inventory, accumulates
 major layout) so the cost is @nnz × nMethods@ FMAs with cache-friendly
 reads. A UUID outside the broadcast that every method's fill walked
 ('btJudged') carries no factor and is skipped; any other falls back to each
-non-regional method's 'lookupCascadeCF' (same fix as the mono-method
-'fastScore') so an inventory reaching flows the fill never saw does not
-silently lose them.
+non-regional method's 'lookupCascadeCF', so an inventory reaching flows the
+fill never saw does not silently lose them.
 -}
 scoreBatched ::
     UnitConfig ->

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -843,6 +843,13 @@ data MethodTables = MethodTables
     method's own zero" — this map is what keeps those three apart. Absent key
     = the cascade found no CF at all.
     -}
+    , mtFilledOver :: !BioFlowDB
+    {- ^ The flow table 'fillBroadcastVector' walked. A flow it holds that
+    'mtBroadcast' omits was judged by the cascade then and carries no factor,
+    so a scorer need not ask again; a flow it does not hold arrived after the
+    fill (a what-if substitution into a database loaded since) and still takes
+    the cascade. Empty until the fill.
+    -}
     , mtBroadcast :: !(M.Map UUID Double)
     {- ^ Pre-multiplied broadcast CFs: flow UUID → effective CF (CF value × flow→CF unit conversion).
     Collapses the UUID/exact/fallback cascade into a single Map and absorbs unit conversion
@@ -1543,6 +1550,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
         , mtCompartmentMap = cmap
         , mtEnergyDensities = energyDensities
         , mtResolution = M.empty -- filled alongside 'mtBroadcast'
+        , mtFilledOver = M.empty -- filled alongside 'mtBroadcast'
         , mtBroadcast = M.empty -- fill via 'fillBroadcastVector' to enable the fast path
         , mtRegionalActivityWeights = Nothing -- fill via 'fillRegionalActivityWeights' for regional fast path
         }
@@ -1837,6 +1845,7 @@ fillBroadcastVector unitConfig unitDB flowDB tables =
     tables
         { mtBroadcast = M.map fst resolved
         , mtResolution = M.map snd resolved
+        , mtFilledOver = flowDB
         }
   where
     resolved = M.mapMaybeWithKey buildEntry flowDB
@@ -2956,6 +2965,12 @@ data BatchedTables = BatchedTables
     {- ^ Column-major dense broadcast, length @btNFlows * btNMethods@. Empty
     when @btNMethods == 0@.
     -}
+    , btJudged :: !(Set.Set UUID)
+    {- ^ Flows every method's fill walked and none characterizes: the
+    intersection of the 'mtFilledOver' tables, minus 'btUuidIndex'. Such a
+    flow contributes nothing, and the scoring loop knows it in one lookup
+    instead of one cascade per method.
+    -}
     }
 
 {- | Build 'MethodSetTables' from per-method 'MethodTables'. The list order
@@ -2993,6 +3008,7 @@ buildBatchedTables entries =
         uuidList = Set.toAscList uuidSet
         uuidIndex = M.fromList (zip uuidList [0 ..])
         nFlows = length uuidList
+        judged = intersections (map (M.keysSet . mtFilledOver . mseTables) (V.toList entries)) `Set.difference` uuidSet
         mat = U.create $ do
             mv <- MU.replicate (nFlows * nMethods) (0.0 :: Double)
             V.iforM_ entries $ \i e ->
@@ -3009,7 +3025,12 @@ buildBatchedTables entries =
             , btNFlows = nFlows
             , btNMethods = nMethods
             , btMat = mat
+            , btJudged = judged
             }
+  where
+    intersections :: [Set.Set UUID] -> Set.Set UUID
+    intersections [] = Set.empty
+    intersections (x : xs) = foldr Set.intersection x xs
 
 {- | Score an inventory against every method in a 'MethodSetTables', emitting
 @(methodId, Right score)@ on success and @(methodId, Left err)@ for a
@@ -3095,10 +3116,11 @@ For each non-zero @(uuid, qty)@ in the inventory, accumulates
 @qty * btMat[j*nMethods + i]@ into score @i@ for every method @i@, where
 @j@ is the flow's row. The inner loop walks contiguous CF cells (column-
 major layout) so the cost is @nnz × nMethods@ FMAs with cache-friendly
-reads. An out-of-broadcast UUID falls back to each non-regional method's
-'lookupCascadeCF' (same fix as the mono-method 'fastScore') so cross-DB
-merged inventories don't silently lose flows that the per-method path
-would have caught via name/compartment cascade.
+reads. A UUID outside the broadcast that every method's fill walked
+('btJudged') carries no factor and is skipped; any other falls back to each
+non-regional method's 'lookupCascadeCF' (same fix as the mono-method
+'fastScore') so an inventory reaching flows the fill never saw does not
+silently lose them.
 -}
 scoreBatched ::
     UnitConfig ->
@@ -3135,13 +3157,15 @@ scoreBatched unitCfg unitDB flowDB bt inventory
                                                 MU.unsafeModify mv (+ qty * cf) i
                                                 loop (i + 1)
                                     loop 0
-                                Nothing ->
-                                    V.imapM_
-                                        ( \i e -> do
-                                            let !c = cascadeContrib (mseTables e) uuid qty
-                                            MU.unsafeModify mv (+ c) i
-                                        )
-                                        entriesV
+                                Nothing
+                                    | Set.member uuid (btJudged bt) -> pure ()
+                                    | otherwise ->
+                                        V.imapM_
+                                            ( \i e -> do
+                                                let !c = cascadeContrib (mseTables e) uuid qty
+                                                MU.unsafeModify mv (+ c) i
+                                            )
+                                            entriesV
                     )
                     (M.toList inventory)
                 pure mv

--- a/test/CrossDBInventorySpec.hs
+++ b/test/CrossDBInventorySpec.hs
@@ -200,7 +200,7 @@ spec = do
                     , mtCompartmentMap = M.empty
                     , mtEnergyDensities = M.empty
                     , mtResolution = M.empty
-                    , mtFilledOver = M.empty
+                    , mtJudged = S.empty
                     , mtBroadcast = M.empty
                     , mtRegionalActivityWeights = Nothing
                     }

--- a/test/CrossDBInventorySpec.hs
+++ b/test/CrossDBInventorySpec.hs
@@ -200,6 +200,7 @@ spec = do
                     , mtCompartmentMap = M.empty
                     , mtEnergyDensities = M.empty
                     , mtResolution = M.empty
+                    , mtFilledOver = M.empty
                     , mtBroadcast = M.empty
                     , mtRegionalActivityWeights = Nothing
                     }

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -13,6 +13,7 @@ module MethodSetTablesSpec (spec) where
 
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
+import qualified Data.Set as Set
 import Data.Text (Text)
 import Data.UUID (UUID)
 import qualified Data.UUID as UUID
@@ -270,6 +271,48 @@ spec = do
                         M.empty
                         (NE.singleton (unusedDatabase, U.empty, mst))
             -- Both contribute against CF=3: (2 + 4) × 3 = 18.
+            map snd results `shouldBe` [Right 18.0]
+
+        it "skips a flow the fill judged without a factor, still cascades one the fill never saw" $ do
+            -- The fill walked fidBuild (characterized) and fidNoCF (no factor
+            -- anywhere); fidCrossDB reaches the inventory later, as a what-if
+            -- substitution into a database loaded since would, and resolves
+            -- through the UUID rung. Only fidNoCF is judged: it costs no
+            -- cascade, and the two others still score.
+            let fidBuild = mkUuid 100
+                fidNoCF = mkUuid 101
+                fidCrossDB = mkUuid 999
+                uidKg = mkUuid 200
+                cfBuild = mkCF fidBuild 3.0
+                cfCross = mkCF fidCrossDB 3.0
+                m1 = mkMethod 1 "m1" [cfBuild, cfCross]
+                buildFlowDB =
+                    M.fromList
+                        [ (fidBuild, mkFlow fidBuild "co2" uidKg)
+                        , (fidNoCF, mkFlow fidNoCF "argon" uidKg)
+                        ]
+                scoringFlowDB = M.insert fidCrossDB (mkFlow fidCrossDB "co2" uidKg) buildFlowDB
+                udb = M.singleton uidKg (mkUnit uidKg "kg")
+                t =
+                    fillBroadcastVector UnitConversion.defaultUnitConfig udb buildFlowDB $
+                        buildMethodTables
+                            OtherCFFamily
+                            M.empty
+                            M.empty
+                            [ (cfBuild, Just (mkFlow fidBuild "co2" uidKg, ByUUID))
+                            , (cfCross, Just (mkFlow fidCrossDB "co2" uidKg, ByUUID))
+                            ]
+                mst = buildMethodSetTables [(m1, t)]
+                inv = M.fromList [(fidBuild, 2.0), (fidNoCF, 5.0), (fidCrossDB, 4.0)]
+                results =
+                    computeLCIAScoreSetFromTables
+                        UnitConversion.defaultUnitConfig
+                        udb
+                        scoringFlowDB
+                        inv
+                        M.empty
+                        (NE.singleton (unusedDatabase, U.empty, mst))
+            btJudged (msBatched mst) `shouldBe` Set.singleton fidNoCF
             map snd results `shouldBe` [Right 18.0]
 
     describe "msAllMethods preserves caller-given order" $ do


### PR DESCRIPTION
## Why

Scoring a batch of activities spent most of its time after the solve, and not in the matvec. `scoreBatched` scores every non-regional method in one pass over the broadcast tables, and falls back to the name cascade (`lookupCascadeCF`: name normalisation, then the exact, medium, CAS and sub-blind lookups) for any inventory flow the broadcast index does not hold. The broadcast, though, was filled by walking the merged flow table through that very cascade. So a flow the fill walked and the broadcast omits carries no factor, and the fallback could only repeat the miss: once per non-regional method, thirteen in EF 3.1, for every activity, on every flow of a cumulative inventory that no method characterizes.

## What changes

The tables remember what their fill judged. `MethodTables` gains `mtJudged`, the keys of the flow table `fillBroadcastVector` walked; `BatchedTables` gains `btJudged`, the flows every method of the set walked and none characterizes. The scoring loop skips such a flow in one lookup.

A flow the fill never saw still takes the cascade. That case is real: a what-if substitution can point into a database loaded after the tables were built, and its flows then reach the inventory through the merged flow table. The existing regression test pins it (it caught a first version of this change that skipped any flow the merged table holds), and a new one pins which flows are judged and that the two others still score.

## What does not change

Every score. Measured on Agribalyse 3.2 with EF 3.1, all 21 510 activities in batches of 500, on the same data directory before and after:

| | solve | after the solve | batch of 500 |
|---|---|---|---|
| before | 21 ms per activity | 119 ms per activity | 65 to 75 s |
| after | 18 ms per activity | 31 ms per activity | 16 to 39 s, median 24 s |

580 770 score rows compared pairwise by (process, category): same ids, worst relative difference 9.8e-13, which is the sparse solver rounding differently between two runs.

One case can move a score, and the review named it: two loaded databases describing the same flow UUID with different metadata, which the merged flow table already reports as a collision and settles by name order. When a later load flips which record wins, the tables of the other database survive, and a flow the fill judged without a factor on its own record used to be re-read through the fallback with the other database's record, sometimes finding a factor there (a CAS bridge, say). It is now skipped, which is what the broadcast already did for every characterized flow of that same table: one snapshot for the whole batch, the one the fill saw.

What remains after the solve is mostly the inventory itself: `goWithDepsFromScalings` maps `applyBiosphereMatrix` lazily over the scalings, so each inventory (a walk of every biosphere triple, then a map over every flow) is forced during the per-activity loop, in sequence. That is a separate change.
