### PR TITLE
Trust a matrix cache only if it was built with the current unit table and aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@
   vocabulary gap without reading the log. Wire revision 13.
 
 ### Fixed
+- A database's matrix cache (`volca.cache.<name>.bin.zst`, beside its
+  source) is now trusted only when the unit table and the location aliases
+  it was built with are the ones in force. It used to be read back
+  regardless, so a cache built while the unit table was missing kept every
+  exchange it could not convert unlinked at every later start (one SimaPro
+  database: 1,335 unlinked from such a cache, none from a fresh read). The
+  log now says which of the two changed, and every existing cache is
+  rebuilt once.
 - The method mapping report no longer counts as matched a factor whose only
   name hit is filed under another compartment vocabulary ("air" against
   "emissions to air"). Such a method used to report 82% coverage and score

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It loads EcoSpold2, EcoSpold1, SimaPro CSV, ILCD process, and Brightway Excel da
 - **Fuzzy search**: Trigram-based typo and stem tolerance on activity and supply-chain name filters
 - **Auto-extracted synonyms**: Synonym pairs extracted automatically from loaded databases and method packages, available for toggling and download
 - **Reference data management**: Flow synonyms, compartment mappings, and unit definitions can be configured in TOML, uploaded via the API, or toggled independently
-- **Fast cache**: Per-database cache co-located with the source path, with automatic schema-based invalidation (figures in the Performance table below)
+- **Fast cache**: Per-database cache co-located with the source path, rebuilt when the cache schema changes or when the unit table or location aliases it was built with are no longer the ones in force (figures in the Performance table below)
 - **Optional access control**: Single-code login with cookie-based session
 
 ---

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -18,7 +18,6 @@ import qualified Search.BM25.Types as BM25T
 import qualified Search.Fuzzy as Fuzzy
 import qualified Search.Normalize as Normalize
 import Types
-import UnitConversion (UnitConfig)
 
 {- | Build complete database with pre-computed sparse matrices
 
@@ -40,8 +39,8 @@ Matrix Construction:
   * Self-loop NOT exported as matrix entry (matches Ecoinvent convention)
 - Solver constructs (I-A) by adding identity and negating technosphere triplets
 -}
-buildDatabaseWithMatrices :: UnitConfig -> M.Map (UUID, UUID) Activity -> TechFlowDB -> BioFlowDB -> WasteFlowDB -> UnitDB -> IO (Either Text Database)
-buildDatabaseWithMatrices unitConfig activityMap techFlowDB bioFlowDB wasteFlowDB unitDB = do
+buildDatabaseWithMatrices :: BuildInputs -> M.Map (UUID, UUID) Activity -> TechFlowDB -> BioFlowDB -> WasteFlowDB -> UnitDB -> IO (Either Text Database)
+buildDatabaseWithMatrices inputs activityMap techFlowDB bioFlowDB wasteFlowDB unitDB = do
     reportMatrixOperation "Building database with pre-computed sparse matrices"
     let !tables = buildInterningTables activityMap
         !supplierRefUnits = buildSupplierRefUnits unitDB (itActivities tables)
@@ -50,7 +49,7 @@ buildDatabaseWithMatrices unitConfig activityMap techFlowDB bioFlowDB wasteFlowD
 
     reportMatrixOperation ("Activity index built: " ++ show activityCount ++ " activities")
     reportMatrixOperation "Building technosphere matrix triplets"
-    case buildTechTriples unitConfig unitDB tables supplierRefUnits of
+    case buildTechTriples (biUnitConfig inputs) unitDB tables supplierRefUnits of
         Left err -> pure (Left err)
         Right (techTriples, techWarnings) -> do
             mapM_ (reportProgress Warning) techWarnings
@@ -98,6 +97,7 @@ buildDatabaseWithMatrices unitConfig activityMap techFlowDB bioFlowDB wasteFlowD
                         , dbCrossDBLinks = []
                         , dbDependsOn = []
                         , dbLinkingStats = mempty
+                        , dbBuiltWith = inputs
                         , dbSynonymDB = Nothing
                         , dbFlowsByName = M.empty
                         , dbFlowsByCAS = M.empty

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -1182,8 +1182,9 @@ loadCachedDatabaseWithMatrices dbName dataDir inputs = do
         else do
             -- Delegate to the shared reader; a Nothing here means the cache
             -- is corrupted or was written by another schema, and the database
-            -- is rebuilt from source. The file is left alone: a rebuild
-            -- overwrites it anyway, and a host that ships only the cache (see
+            -- is rebuilt from source, as it is when the cache was built under
+            -- other inputs. The file is left alone: a rebuild overwrites it
+            -- anyway, and a host that ships only the cache (see
             -- 'Manager.loadDatabaseRawWithCrossDB') has no source to rebuild
             -- from, so deleting it there destroyed the only copy of the data.
             result <- loadCompressedCacheFile zstdFile

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -17,7 +17,7 @@ for subsequent runs.
 
 Key performance features:
 - Parallel parsing with controlled concurrency (prevents resource exhaustion)
-- Automatic cache invalidation based on source file changes
+- Automatic cache invalidation when the schema or the build inputs change
 - Memory-efficient chunked processing for large databases
 - Hash-based cache filenames for multi-dataset support
 
@@ -38,7 +38,6 @@ module Database.Loader (
     -- * Cache Operations
     loadCachedDatabaseWithMatrices,
     saveCachedDatabaseWithMatrices,
-    loadDatabaseFromCacheFile,
     generateMatrixCacheFilename,
 
     -- * Cross-Database Linking
@@ -101,7 +100,7 @@ import Data.Bits (xor)
 import qualified Data.ByteString as BS
 import Data.Char (toLower)
 import Data.Either (lefts, partitionEithers, rights)
-import Data.List (sort, sortBy, sortOn)
+import Data.List (intercalate, sort, sortBy, sortOn)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
 
@@ -155,7 +154,7 @@ import Method.Types (Location)
 import Progress
 import qualified SimaPro.Parser as SimaPro
 import SynonymDB (SynonymDB)
-import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist, getFileSize, listDirectory)
+import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist, listDirectory)
 import System.FilePath (takeBaseName, takeDirectory, takeExtension, (</>))
 import Text.Printf (printf)
 import Types
@@ -200,17 +199,13 @@ unzip9 = foldr step ([], [], [], [], [], [], [], [], [])
         (a : as, b : bs, c : cs, d : ds, e : es, f : fs, g : gs, h : hs, i : is)
 
 {- |
-Schema signature automatically derived from the Database type structure.
+Schema signature of the cache payload.
 
-Automatically changes when:
-- Fields are added/removed from Database or nested types
-- Type names change
-- Type structure changes
-
-The trailing 'xor' constant is a manual cache-busting salt — bump it (e.g.
-4 → 5) when the semantics of the cached matrices change without any type
-change, so existing caches are treated as incompatible and rebuilt on the
-next load instead of silently returning stale numbers.
+The 'Typeable' fingerprint names the 'Database' type (package, module, name)
+and nothing more: it does not move when a field is added or a nested type
+changes. Every change to what the cache holds, layout or meaning, therefore
+needs a bump of the trailing constant, so existing caches are rebuilt on the
+next load instead of being misread or silently returning stale numbers.
 
 History of manual bumps:
 - 5: reference-product amounts normalized to canonical base unit at ingest
@@ -282,6 +277,9 @@ History of manual bumps:
      share and its category, and every activity passes the allocation gate
      before the matrix. The cached exchanges of an allocated database say
      less than the loader now reads, so they are read again.
+- 20: the payload records the unit table and location aliases the database
+     was built with ('dbBuiltWith'), compared before a cache is trusted. Old
+     caches end before the field.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.
@@ -289,7 +287,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeRep (Proxy :: Proxy Database))
-     in hi `xor` lo `xor` 19
+     in hi `xor` lo `xor` 20
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.
@@ -1159,30 +1157,6 @@ generateMatrixCacheFilename dbName sourcePath = do
     return $ cacheDir </> cacheFilename
 
 {- |
-Validate cache file integrity before attempting to decode.
-
-Checks:
-- File size is reasonable (> 1KB to avoid empty/corrupted files)
-- File exists and is readable
-
-Returns True if cache file appears valid, False otherwise.
--}
-validateCacheFile :: FilePath -> IO Bool
-validateCacheFile cacheFile = do
-    exists <- doesFileExist cacheFile
-    if not exists
-        then return False
-        else do
-            fileSize <- getFileSize cacheFile
-            -- Cache file should be at least 1KB for a valid database
-            -- Typical size is 100MB-600MB
-            if fileSize < 1024
-                then do
-                    reportCacheOperation $ "Cache file is too small (" ++ show fileSize ++ " bytes), likely corrupted"
-                    return False
-                else return True
-
-{- |
 Load Database with pre-computed matrices from cache (second-tier).
 
 This is the fastest loading method (~0.5s) as it bypasses both
@@ -1192,10 +1166,12 @@ XML parsing and matrix construction. The Database includes:
 - Pre-computed sparse matrices (technosphere A, biosphere B)
 - Activity and flow UUID mappings for matrix operations
 
-Returns Nothing if no matrix cache exists.
+Returns Nothing if no matrix cache exists, or if the one found was built with
+other inputs than the ones in force: what it holds would not be what a fresh
+read produces.
 -}
-loadCachedDatabaseWithMatrices :: T.Text -> FilePath -> IO (Maybe Database)
-loadCachedDatabaseWithMatrices dbName dataDir = do
+loadCachedDatabaseWithMatrices :: T.Text -> FilePath -> BuildInputs -> IO (Maybe Database)
+loadCachedDatabaseWithMatrices dbName dataDir inputs = do
     cacheFile <- generateMatrixCacheFilename dbName dataDir
     let zstdFile = cacheFile ++ ".zst"
     zstdExists <- doesFileExist zstdFile
@@ -1212,37 +1188,21 @@ loadCachedDatabaseWithMatrices dbName dataDir = do
             -- from, so deleting it there destroyed the only copy of the data.
             result <- loadCompressedCacheFile zstdFile
             case result of
-                Just _ -> return result
-                Nothing -> do
-                    reportCacheOperation "Will rebuild database from source files"
-                    return Nothing
+                Just db | dbBuiltWith db == inputs -> return (Just db)
+                Just db -> do
+                    reportCacheOperation $ "Cache was built with another " ++ builtWithDifference (dbBuiltWith db) inputs
+                    rebuild
+                Nothing -> rebuild
+  where
+    rebuild :: IO (Maybe Database)
+    rebuild = Nothing <$ reportCacheOperation "Will rebuild database from source files"
 
-{- |
-Load Database directly from a specified cache file.
-
-Similar to loadCachedDatabaseWithMatrices but takes an explicit cache file path
-instead of generating it from a data directory. Supports both compressed (.bin.zst)
-and uncompressed (.bin) formats.
-
-This is useful for deploying just the cache file without the original .spold files.
-
-Returns Nothing if the file cannot be loaded.
--}
-loadDatabaseFromCacheFile :: FilePath -> IO (Maybe Database)
-loadDatabaseFromCacheFile cacheFile = do
-    let ext = takeExtension cacheFile
-    let isCompressed = ext == ".zst"
-
-    -- Validate file exists
-    fileExists <- doesFileExist cacheFile
-    if not fileExists
-        then do
-            reportError $ "Cache file not found: " ++ cacheFile
-            return Nothing
-        else do
-            if isCompressed
-                then loadCompressedCacheFile cacheFile
-                else loadUncompressedCacheFile cacheFile
+-- | Which of the build inputs a cache disagrees with, for the log line.
+builtWithDifference :: BuildInputs -> BuildInputs -> String
+builtWithDifference cached current =
+    intercalate " and " $
+        ["unit table" | biUnitConfig cached /= biUnitConfig current]
+            ++ ["location aliases" | biLocationAliases cached /= biLocationAliases current]
 
 -- | Load compressed (.bin.zst) cache file with header validation
 loadCompressedCacheFile :: FilePath -> IO (Maybe Database)
@@ -1300,36 +1260,6 @@ loadCompressedCacheFile zstdFile = do
             reportCacheOperation "The compressed cache file is corrupted or incompatible"
             return Nothing
         )
-
--- | Load uncompressed (.bin) cache file
-loadUncompressedCacheFile :: FilePath -> IO (Maybe Database)
-loadUncompressedCacheFile cacheFile = do
-    -- Validate cache file before attempting to decode
-    isValid <- validateCacheFile cacheFile
-    if not isValid
-        then do
-            reportCacheOperation "Cache file validation failed"
-            return Nothing
-        else do
-            reportCacheInfo cacheFile
-            catch
-                ( withProgressTiming Cache "Matrix cache load" $ do
-                    !db <- BS.readFile cacheFile >>= \bs -> evaluate (force (decodeEx bs))
-                    reportCacheOperation $
-                        "Matrix cache loaded: "
-                            ++ show (dbActivityCount db)
-                            ++ " activities, "
-                            ++ show (VU.length $ dbTechnosphereTriples db)
-                            ++ " tech entries, "
-                            ++ show (VU.length $ dbBiosphereTriples db)
-                            ++ " bio entries"
-                    return (Just db)
-                )
-                ( \(e :: SomeException) -> do
-                    reportError $ "Cache load failed: " ++ show e
-                    reportCacheOperation "The cache file is corrupted or incompatible with the current version"
-                    return Nothing
-                )
 
 {- |
 Save Database with pre-computed matrices to cache.

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -217,6 +217,7 @@ import Types (
     AttributeFallback (..),
     BioFlowDB,
     BiosphereFlow (..),
+    BuildInputs (..),
     CrossDBLink (..),
     CrossDBLinkingStats (..),
     Database (..),
@@ -1820,7 +1821,7 @@ loadDatabaseRawWithCrossDB dbName locationAliases sourcePath noCache synonymDB u
     mCachedDb <-
         if noCache
             then return Nothing
-            else Loader.loadCachedDatabaseWithMatrices dbName sourcePath
+            else Loader.loadCachedDatabaseWithMatrices dbName sourcePath inputs
     let cacheUsable = case mCachedDb of
             Just db
                 | unresolvedCount (dbLinkingStats db) > 0
@@ -1866,7 +1867,7 @@ loadDatabaseRawWithCrossDB dbName locationAliases sourcePath noCache synonymDB u
             Left err -> return $ Left err
             Right linkedDb -> do
                 reportProgress Info $ "Building database from " <> show (M.size (sdbActivities linkedDb)) <> " activities"
-                dbResult <- buildDatabaseWithMatrices unitConfig (sdbActivities linkedDb) (sdbTechFlows linkedDb) (sdbBioFlows linkedDb) (sdbWasteFlows linkedDb) (sdbUnits linkedDb)
+                dbResult <- buildDatabaseWithMatrices inputs (sdbActivities linkedDb) (sdbTechFlows linkedDb) (sdbBioFlows linkedDb) (sdbWasteFlows linkedDb) (sdbUnits linkedDb)
                 case dbResult of
                     Left err -> return $ Left err
                     Right db -> do
@@ -1890,7 +1891,7 @@ loadDatabaseRawWithCrossDB dbName locationAliases sourcePath noCache synonymDB u
             Right (simpleDb, stats) -> do
                 dbResult <-
                     buildDatabaseWithMatrices
-                        unitConfig
+                        inputs
                         (sdbActivities simpleDb)
                         (sdbTechFlows simpleDb)
                         (sdbBioFlows simpleDb)
@@ -1910,6 +1911,9 @@ loadDatabaseRawWithCrossDB dbName locationAliases sourcePath noCache synonymDB u
                         unless noCache $
                             Loader.saveCachedDatabaseWithMatrices dbName sourcePath dbWithLinks
                         return $ Right (dbWithLinks, False)
+
+    inputs :: BuildInputs
+    inputs = BuildInputs unitConfig locationAliases
 
 -- | Load a single database without auto-loading dependencies
 loadDatabaseSingle :: DatabaseManager -> Text -> IO (Either Text LoadedDatabase)
@@ -2450,35 +2454,22 @@ stageUploadedDatabase manager dbConfig = withLogScope (dcName dbConfig) $ do
     reportProgress Info $ "[STARTING] Staging: " <> T.unpack (dcDisplayName dbConfig)
 
     -- Try cache first: if valid, reconstruct StagedDatabase without re-parsing
-    mCachedDb <- Loader.loadCachedDatabaseWithMatrices dbName (dcPath dbConfig)
+    inputs <- currentBuildInputs manager dbConfig
+    mCachedDb <- Loader.loadCachedDatabaseWithMatrices dbName (dcPath dbConfig) inputs
 
     case mCachedDb of
         Just cachedDb -> do
             -- Cache hit: auto-load dependencies so cross-DB solving works
             _ <- autoLoadDeps manager (dbDependsOn cachedDb)
-            -- Recompute unknownUnits against the current unitConfig (cache may be stale)
-            unitConfig <- getMergedUnitConfig manager
-            let simpleDb = toSimpleDatabase cachedDb
-                freshUnknownUnits =
-                    S.fromList
-                        [ unitName u
-                        | u <- M.elems (sdbUnits simpleDb)
-                        , not (UnitConversion.isKnownUnit unitConfig (unitName u))
-                        , not (T.null (unitName u))
-                        ]
-                freshStats =
-                    (dbLinkingStats cachedDb)
-                        { cdlUnknownUnits = freshUnknownUnits
-                        }
-                staged =
+            let staged =
                     StagedDatabase
-                        { sdSimpleDB = simpleDb
+                        { sdSimpleDB = toSimpleDatabase cachedDb
                         , sdConfig = dbConfig
                         , sdUnlinkedCount = 0 -- was finalized successfully
                         , sdMissingProducts = []
                         , sdSelectedDeps = dbDependsOn cachedDb
                         , sdCrossDBLinks = dbCrossDBLinks cachedDb
-                        , sdLinkingStats = freshStats
+                        , sdLinkingStats = dbLinkingStats cachedDb
                         , sdCachedDB = Just cachedDb
                         }
             atomically $ modifyTVar' (dmStagedDbs manager) (M.insert dbName staged)
@@ -3302,10 +3293,10 @@ finalizeDatabase manager dbName = withLogScope dbName $ do
                                         || not (sameSet (dbCrossDBLinks cachedDb) (sdCrossDBLinks staged))
                             return $ Right (BM25.addBM25Index (initializeRuntimeFields pinned synonymDB), needsSave)
                         Nothing -> do
-                            unitConfig <- getMergedUnitConfig manager
+                            inputs <- currentBuildInputs manager (sdConfig staged)
                             dbResult <-
                                 buildDatabaseWithMatrices
-                                    unitConfig
+                                    inputs
                                     (sdbActivities (sdSimpleDB staged))
                                     (sdbTechFlows (sdSimpleDB staged))
                                     (sdbBioFlows (sdSimpleDB staged))
@@ -3702,6 +3693,15 @@ getMergedUnitConfig manager = do
                         else UnitConversion.mergeUnitConfigs (M.elems loaded)
             atomically $ writeTVar (dmMergedUnitConfigCache manager) (Just cfg)
             pure cfg
+
+{- | What a database of this configuration is parsed under right now: the
+merged unit table and the location aliases its configuration declares. A
+cache is trusted only if it records the same pair.
+-}
+currentBuildInputs :: DatabaseManager -> DatabaseConfig -> IO BuildInputs
+currentBuildInputs manager dbConfig = do
+    unitConfig <- getMergedUnitConfig manager
+    pure (BuildInputs unitConfig (dcLocationAliases dbConfig))
 
 {- | Snapshot of flow + unit metadata across every currently-loaded DB.
 Used to characterize or display a cross-DB-merged 'Inventory', whose

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -292,6 +292,12 @@ data StagedDatabase = StagedDatabase
     -- ^ Cross-DB links found so far
     , sdLinkingStats :: !CrossDBLinkingStats
     -- ^ Linking statistics
+    , sdBuiltWith :: !BuildInputs
+    {- ^ What the parse ran under. The finalized database is stamped with it,
+    not with whatever is in force at finalize time: the amounts and the
+    unknown units were read under this table, so a table that changed in
+    between makes the next start read the source again.
+    -}
     , sdCachedDB :: !(Maybe Database)
     -- ^ Pre-built DB from cache (skip rebuild)
     }
@@ -1790,8 +1796,11 @@ narrowToDataFile fmt path = case dataFileExtension fmt of
 
 The cache lives next to @sourcePath@ (see 'Loader.generateMatrixCacheFilename').
 We probe it first using the unresolved @sourcePath@, so a deployment that ships
-only the cache (no source archive on disk) still loads. On cache miss/stale we
-'resolveDataPath' and parse, saving a fresh cache on success.
+only the cache (no source archive on disk) still loads, as long as the cache
+was built under the unit table and location aliases in force: one that was not
+is refused like a stale one, and with no source to read the load fails. On
+cache miss/stale we 'resolveDataPath' and parse, saving a fresh cache on
+success.
 -}
 loadDatabaseRawWithCrossDB ::
     -- | Database name
@@ -2470,6 +2479,7 @@ stageUploadedDatabase manager dbConfig = withLogScope (dcName dbConfig) $ do
                         , sdSelectedDeps = dbDependsOn cachedDb
                         , sdCrossDBLinks = dbCrossDBLinks cachedDb
                         , sdLinkingStats = dbLinkingStats cachedDb
+                        , sdBuiltWith = dbBuiltWith cachedDb
                         , sdCachedDB = Just cachedDb
                         }
             atomically $ modifyTVar' (dmStagedDbs manager) (M.insert dbName staged)
@@ -2495,7 +2505,7 @@ stageUploadedDatabase manager dbConfig = withLogScope (dcName dbConfig) $ do
 
             -- Parse and run cross-DB linking (but don't build matrices)
             synonymDB <- getMergedSynonymDB manager
-            unitConfig <- getMergedUnitConfig manager
+            let unitConfig = biUnitConfig inputs
             loadResult <-
                 Loader.loadDatabaseWithCrossDBLinking
                     locationAliases
@@ -2547,6 +2557,7 @@ stageUploadedDatabase manager dbConfig = withLogScope (dcName dbConfig) $ do
                                 , sdSelectedDeps = minimalDeps
                                 , sdCrossDBLinks = Loader.cdlLinks finalStats
                                 , sdLinkingStats = finalStats
+                                , sdBuiltWith = inputs
                                 , sdCachedDB = Nothing
                                 }
 
@@ -3144,6 +3155,7 @@ restageLoadedDatabase manager dbName ld = do
                 , sdSelectedDeps = dbDependsOn db
                 , sdCrossDBLinks = dbCrossDBLinks db
                 , sdLinkingStats = stats
+                , sdBuiltWith = dbBuiltWith db
                 , sdCachedDB = Nothing
                 }
     atomically $ do
@@ -3293,10 +3305,9 @@ finalizeDatabase manager dbName = withLogScope dbName $ do
                                         || not (sameSet (dbCrossDBLinks cachedDb) (sdCrossDBLinks staged))
                             return $ Right (BM25.addBM25Index (initializeRuntimeFields pinned synonymDB), needsSave)
                         Nothing -> do
-                            inputs <- currentBuildInputs manager (sdConfig staged)
                             dbResult <-
                                 buildDatabaseWithMatrices
-                                    inputs
+                                    (sdBuiltWith staged)
                                     (sdbActivities (sdSimpleDB staged))
                                     (sdbTechFlows (sdSimpleDB staged))
                                     (sdbBioFlows (sdSimpleDB staged))

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -42,6 +42,7 @@ import Search.BM25.Types (BM25Index)
 import SubstanceRegistry (CASNumber (..), NormName (..), nonEmptyCAS)
 import SynonymDB (normalizeName)
 import SynonymDB.Types (SynonymDB)
+import UnitConversion (UnitConfig)
 
 -- | Orphan Store instance for UUID (16 bytes, host-native word order)
 instance Store UUID where
@@ -969,6 +970,25 @@ data ProductIndex = ProductIndex
 emptyProductIndex :: ProductIndex
 emptyProductIndex = ProductIndex M.empty M.empty M.empty
 
+{- | What the loader read besides the source files, and what shapes a database
+as much as they do. The unit table decides which exchanges convert, which of
+them link, and the unit every amount is recorded in; the location aliases
+decide which dataset an EcoSpold 1 exchange resolves to. A database records
+the pair it was built with in 'dbBuiltWith', and its matrix cache is trusted
+only while that pair is the one in force.
+
+Everything else the loader is handed (the synonym set, the geography
+hierarchy and policy, the other databases) shapes the cross-database links
+alone, and every cache hit derives those again. It is left out on purpose:
+the synonym set grows after every load, so stamping it would rebuild every
+database at the next start.
+-}
+data BuildInputs = BuildInputs
+    { biUnitConfig :: !UnitConfig
+    , biLocationAliases :: !(M.Map Text Text)
+    }
+    deriving (Eq, Show, Generic, NFData, Store)
+
 -- | Complete database with indexes for efficient searches
 data Database = Database
     { -- UUID interning tables for ProcessId ↔ (UUID, UUID) conversion
@@ -995,8 +1015,10 @@ data Database = Database
     , dbDependsOn :: ![Text] -- Names of databases this database depends on
     -- Linking statistics (serialized to cache for setup page)
     , dbLinkingStats :: !CrossDBLinkingStats -- Cross-DB linking statistics (completeness, fallbacks, etc.)
-    -- Runtime-only fields (not serialized to cache)
-    , dbSynonymDB :: !(Maybe SynonymDB) -- Embedded synonym database for flow matching
+    -- What it was built with (serialized to cache, compared before a cache is trusted)
+    , dbBuiltWith :: !BuildInputs
+    , -- Runtime-only fields (not serialized to cache)
+      dbSynonymDB :: !(Maybe SynonymDB) -- Embedded synonym database for flow matching
     , dbFlowsByName :: !(M.Map Text [BiosphereFlow]) -- Biosphere flow name index for LCIA matching
     , dbFlowsByCAS :: !(M.Map Text [BiosphereFlow]) -- CAS → biosphere flows for LCIA matching
     -- Product name search index: word token → ProcessId set (built at runtime)
@@ -1031,6 +1053,7 @@ instance Store Database where
             + getSize (dbCrossDBLinks db)
             + getSize (dbDependsOn db)
             + getSize (dbLinkingStats db)
+            + getSize (dbBuiltWith db)
 
     poke db = do
         poke (dbProcessIdTable db)
@@ -1054,6 +1077,7 @@ instance Store Database where
         poke (dbCrossDBLinks db)
         poke (dbDependsOn db)
         poke (dbLinkingStats db)
+        poke (dbBuiltWith db)
 
     -- Runtime-only fields are NOT serialized
 
@@ -1078,6 +1102,7 @@ instance Store Database where
         crossDBLinks <- peek
         dependsOn <- peek
         linkingStats <- peek
+        builtWith <- peek
         return
             Database
                 { dbProcessIdTable = processIdTable
@@ -1101,6 +1126,7 @@ instance Store Database where
                   dbCrossDBLinks = crossDBLinks
                 , dbDependsOn = dependsOn
                 , dbLinkingStats = linkingStats
+                , dbBuiltWith = builtWith
                 , -- Runtime-only fields set to defaults
                   dbSynonymDB = Nothing
                 , dbFlowsByName = M.empty

--- a/src/UnitConversion.hs
+++ b/src/UnitConversion.hs
@@ -53,6 +53,7 @@ import Data.List (elemIndex)
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as S
+import Data.Store (Store)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Vector as V
@@ -72,6 +73,7 @@ data UnitDef = UnitDef
     deriving (Eq, Show, Generic)
 
 instance NFData UnitDef
+instance Store UnitDef
 
 -- | Unit configuration loaded from CSV.
 data UnitConfig = UnitConfig
@@ -80,9 +82,10 @@ data UnitConfig = UnitConfig
     , ucOriginalKeys :: !(M.Map Text Text) -- normalized -> original (for error messages)
     , ucCanonical :: !(M.Map Text Text) -- normalized -> reference unit of its dimension
     }
-    deriving (Show, Generic)
+    deriving (Eq, Show, Generic)
 
 instance NFData UnitConfig
+instance Store UnitConfig
 
 -- | Default dimension order.
 defaultDimensionOrder :: [Text]

--- a/test/ActivityWriteHandlerSpec.hs
+++ b/test/ActivityWriteHandlerSpec.hs
@@ -55,6 +55,7 @@ import Types (
     Activity (..),
     BioDirection (..),
     BiosphereFlow (..),
+    BuildInputs (..),
     Compartment (..),
     Database (..),
     Exchange (..),
@@ -449,7 +450,7 @@ buildFixture :: IO Database
 buildFixture = do
     r <-
         buildDatabaseWithMatrices
-            defaultUnitConfig
+            (BuildInputs defaultUnitConfig mempty)
             (M.singleton (supplierActId, supplierProdId) milkActivity)
             (M.singleton supplierProdId milkFlow)
             (M.singleton co2Id co2Flow)

--- a/test/AllocationSpec.hs
+++ b/test/AllocationSpec.hs
@@ -277,7 +277,7 @@ withTwoOutputDataset k = withSystemTempDirectory "es2-two-outputs" $ \dir -> do
     BS.writeFile (dir </> "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa_bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.spold") twoOutputsXml
     loaded <- loadDatabaseWithLocationAliases defaultUnitConfig M.empty dir
     simpleDb <- either (fail . T.unpack) pure loaded
-    built <- buildDatabaseWithMatrices defaultUnitConfig (sdbActivities simpleDb) (sdbTechFlows simpleDb) (sdbBioFlows simpleDb) (sdbWasteFlows simpleDb) (sdbUnits simpleDb)
+    built <- buildDatabaseWithMatrices (BuildInputs defaultUnitConfig mempty) (sdbActivities simpleDb) (sdbTechFlows simpleDb) (sdbBioFlows simpleDb) (sdbWasteFlows simpleDb) (sdbUnits simpleDb)
     db <- either (fail . T.unpack) pure built
     k (simpleDb, db)
 

--- a/test/AuthorSpec.hs
+++ b/test/AuthorSpec.hs
@@ -43,6 +43,7 @@ import Types (
     Activity (..),
     BioDirection (..),
     BiosphereFlow (..),
+    BuildInputs (..),
     Compartment (..),
     Database (..),
     DeclaredShare (..),
@@ -740,7 +741,7 @@ buildFixtureAt :: UUID -> UUID -> IO Database
 buildFixtureAt actId prodId = do
     r <-
         buildDatabaseWithMatrices
-            defaultUnitConfig
+            (BuildInputs defaultUnitConfig mempty)
             ( M.fromList
                 [ ((actId, prodId), supplierActivityAt actId prodId)
                 , ((treatActId, usedOilId), treatmentActivity)
@@ -764,7 +765,7 @@ buildTwoProductTreatment :: IO Database
 buildTwoProductTreatment = do
     r <-
         buildDatabaseWithMatrices
-            defaultUnitConfig
+            (BuildInputs defaultUnitConfig mempty)
             ( M.fromList
                 [ ((supplierActId, supplierProdId), supplierActivityAt supplierActId supplierProdId)
                 , ((treatActId, usedOilId), treatmentWithHeat)
@@ -791,7 +792,7 @@ buildBareFixture = do
         noBio = act{exchanges = filter isTechnosphereExchange (exchanges act)}
     r <-
         buildDatabaseWithMatrices
-            defaultUnitConfig
+            (BuildInputs defaultUnitConfig mempty)
             (M.singleton (supplierActId, supplierProdId) noBio)
             (M.singleton supplierProdId (milkFlowAt supplierProdId))
             M.empty

--- a/test/AutoRelinkSpec.hs
+++ b/test/AutoRelinkSpec.hs
@@ -9,6 +9,9 @@ The PR these tests guard introduced two related changes:
      (i.e. cross-DB linking was NOT freshly run against 'otherIndexes').
   2. 'loadDatabaseSingleFromConfig' uses that flag to skip the no-op
      self-relink on fresh parses.
+  3. A cache is a hit only when the unit table and the location aliases it
+     was built with are the ones in force; with either changed, the source
+     is read again, since both shape what the cache holds.
 
 The 'fromCache' flag is the contract these tests pin down. The end-to-end
 dep-set-swap scenario (load consumer with deps A → swap to B → reload
@@ -34,7 +37,7 @@ import Test.Hspec
 import Database.Manager (loadDatabaseRawWithCrossDB)
 import SynonymDB (emptySynonymDB)
 import Types (GeographyPolicy (..))
-import UnitConversion (defaultUnitConfig)
+import UnitConversion (UnitConfig, UnitDef (..), defaultUnitConfig, mkUnitConfig, ucDimensionOrder, ucOriginalKeys, ucUnits)
 
 {- | Copy regular files from one directory into another (non-recursive,
 which is all the EcoSpold v2 fixtures here need).
@@ -50,19 +53,31 @@ test cares about. Cross-DB linking is not exercised; we only need the
 cache-hit detection.
 -}
 runRaw :: FilePath -> IO (Either T.Text Bool)
-runRaw dstDir = do
+runRaw = runRawWith defaultUnitConfig M.empty
+
+-- | The same, under a chosen unit table and location aliases.
+runRawWith :: UnitConfig -> M.Map T.Text T.Text -> FilePath -> IO (Either T.Text Bool)
+runRawWith unitConfig locationAliases dstDir = do
     result <-
         loadDatabaseRawWithCrossDB
             "test"
-            M.empty
+            locationAliases
             dstDir
             False -- noCache disabled: cache must be written/read
             emptySynonymDB
-            defaultUnitConfig
+            unitConfig
             []
             M.empty
             GeoGlobal
     return (fmap snd result)
+
+-- | The default unit table plus one unit, so the table differs in content.
+withGram :: UnitConfig
+withGram =
+    mkUnitConfig
+        (ucDimensionOrder defaultUnitConfig)
+        (M.insert "g" (UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 0.001) (ucUnits defaultUnitConfig))
+        (M.insert "g" "g" (ucOriginalKeys defaultUnitConfig))
 
 spec :: Spec
 spec = do
@@ -93,3 +108,21 @@ spec = do
                 -- Second call: must come back from the cache.
                 r2 <- runRaw dstDir
                 r2 `shouldBe` Right True
+
+        it "reads the source again when the cache was built with another unit table" $
+            withSystemTempDirectory "volca-relink" $ \tmp -> do
+                let dstDir = tmp </> "sample"
+                copyDirContents "test-data/SAMPLE.min1" dstDir
+
+                _ <- runRaw dstDir
+                runRawWith withGram M.empty dstDir `shouldReturn` Right False
+                -- The rebuilt cache records the new table and is trusted again.
+                runRawWith withGram M.empty dstDir `shouldReturn` Right True
+
+        it "reads the source again when the cache was built with other location aliases" $
+            withSystemTempDirectory "volca-relink" $ \tmp -> do
+                let dstDir = tmp </> "sample"
+                copyDirContents "test-data/SAMPLE.min1" dstDir
+
+                _ <- runRaw dstDir
+                runRawWith defaultUnitConfig (M.fromList [("CH", "GLO")]) dstDir `shouldReturn` Right False

--- a/test/BrightwayExcelWriterSpec.hs
+++ b/test/BrightwayExcelWriterSpec.hs
@@ -847,7 +847,7 @@ co2Inventory :: SimpleDatabase -> IO (Either Text (Maybe Double))
 co2Inventory sdb = do
     built <-
         buildDatabaseWithMatrices
-            defaultUnitConfig
+            (BuildInputs defaultUnitConfig mempty)
             (sdbActivities sdb)
             (sdbTechFlows sdb)
             (sdbBioFlows sdb)

--- a/test/CoproductTargetSpec.hs
+++ b/test/CoproductTargetSpec.hs
@@ -181,7 +181,7 @@ buildFixture :: Activity -> M.Map (UUID, UUID) Activity -> M.Map UUID Technosphe
 buildFixture consumer rows flows = do
     r <-
         buildDatabaseWithMatrices
-            defaultUnitConfig
+            (BuildInputs defaultUnitConfig mempty)
             (M.insert (consumerActId, consumerProdId) consumer rows)
             (M.insert consumerProdId (techFlow consumerProdId "cheese") flows)
             M.empty

--- a/test/CopySpec.hs
+++ b/test/CopySpec.hs
@@ -42,6 +42,7 @@ import SharedSolver (
 import TestHelpers (withScratchDataDir)
 import Types (
     Activity (..),
+    BuildInputs (..),
     Database (..),
     Exchange (..),
     GeographyPolicy (..),
@@ -216,7 +217,7 @@ mkConfig name =
 
 buildOrFail :: SimpleParts -> IO Database
 buildOrFail (SimpleParts acts flows units) = do
-    r <- buildDatabaseWithMatrices defaultUnitConfig acts flows M.empty M.empty units
+    r <- buildDatabaseWithMatrices (BuildInputs defaultUnitConfig M.empty) acts flows M.empty M.empty units
     case r of
         Right db -> pure db
         Left err -> fail ("buildDatabaseWithMatrices: " <> show err)

--- a/test/CrossDBRegionalLCIAFixture.hs
+++ b/test/CrossDBRegionalLCIAFixture.hs
@@ -55,7 +55,7 @@ import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, fill
 import Method.Types (CFFamily (..), FlowDirection (..), MethodCF (..))
 import Types
 import qualified Types as VT
-import UnitConversion (UnitConfig (..), UnitDef (..), mkUnitConfig)
+import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig, mkUnitConfig)
 
 -- | One biosphere flow shared by both DBs (cross-DB merging keys on UUID).
 flowUUID :: UUID
@@ -155,6 +155,7 @@ mkDB offset locs bioTriples =
             , dbCrossDBLinks = []
             , dbDependsOn = []
             , dbLinkingStats = mempty
+            , dbBuiltWith = BuildInputs defaultUnitConfig mempty
             , dbSynonymDB = Nothing
             , dbFlowsByName = M.empty
             , dbFlowsByCAS = M.empty

--- a/test/DeleteSelectionSpec.hs
+++ b/test/DeleteSelectionSpec.hs
@@ -49,6 +49,7 @@ import Database.Rebuild (deleteActivities)
 import SharedSolver (SharedSolver, createSharedSolver)
 import Types (
     Activity (..),
+    BuildInputs (..),
     Database (..),
     Exchange (..),
     GeographyPolicy (..),
@@ -410,7 +411,7 @@ mkConfig name =
 
 buildOrFail :: SimpleParts -> IO Database
 buildOrFail (SimpleParts acts flows units) = do
-    r <- buildDatabaseWithMatrices defaultUnitConfig acts flows M.empty M.empty units
+    r <- buildDatabaseWithMatrices (BuildInputs defaultUnitConfig mempty) acts flows M.empty M.empty units
     case r of
         Right db -> pure db
         Left err -> fail ("buildDatabaseWithMatrices: " <> show err)

--- a/test/EcoSpold1WriterSpec.hs
+++ b/test/EcoSpold1WriterSpec.hs
@@ -414,7 +414,7 @@ buildDb :: SimpleDatabase -> IO Database
 buildDb sdb = do
     result <-
         DB.buildDatabaseWithMatrices
-            defaultUnitConfig
+            (BuildInputs defaultUnitConfig mempty)
             (sdbActivities sdb)
             (sdbTechFlows sdb)
             (sdbBioFlows sdb)

--- a/test/EcoSpold2WriterSpec.hs
+++ b/test/EcoSpold2WriterSpec.hs
@@ -302,7 +302,7 @@ buildDb :: SimpleDatabase -> IO Database
 buildDb sdb = do
     res <-
         buildDatabaseWithMatrices
-            defaultUnitConfig
+            (BuildInputs defaultUnitConfig mempty)
             (sdbActivities sdb)
             (sdbTechFlows sdb)
             (sdbBioFlows sdb)

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -88,7 +88,7 @@ buildFixture :: Compartment -> IO Database
 buildFixture comp = do
     r <-
         DB.buildDatabaseWithMatrices
-            defaultUnitConfig
+            (BuildInputs defaultUnitConfig mempty)
             (M.singleton (actU, prodU) act)
             (M.singleton prodU (TechnosphereFlow prodU "product" unitU M.empty Nothing Nothing))
             (M.singleton co2U (BiosphereFlow co2U "Carbon dioxide" unitU M.empty Nothing Nothing (Just comp)))

--- a/test/ILCDWriterSpec.hs
+++ b/test/ILCDWriterSpec.hs
@@ -201,7 +201,7 @@ inventoryByName :: SimpleDatabase -> Text -> IO (M.Map Text Double)
 inventoryByName db target = do
     built <-
         buildDatabaseWithMatrices
-            defaultUnitConfig
+            (BuildInputs defaultUnitConfig mempty)
             (sdbActivities db)
             (sdbTechFlows db)
             (sdbBioFlows db)

--- a/test/JournalSpec.hs
+++ b/test/JournalSpec.hs
@@ -47,6 +47,7 @@ import Types (
     Activity (..),
     BioDirection (..),
     BiosphereFlow (..),
+    BuildInputs (..),
     Compartment (..),
     Database (..),
     Exchange (..),
@@ -369,7 +370,7 @@ buildFixture :: IO Database
 buildFixture = do
     built <-
         buildDatabaseWithMatrices
-            defaultUnitConfig
+            (BuildInputs defaultUnitConfig mempty)
             (M.singleton (supplierActId, supplierProdId) supplierActivity)
             (M.singleton supplierProdId milkFlow)
             (M.singleton co2Id co2Flow)

--- a/test/MatrixConstructionSpec.hs
+++ b/test/MatrixConstructionSpec.hs
@@ -184,7 +184,7 @@ spec = do
                         , (kgUnitId, Unit kgUnitId "kg" "kg" "")
                         ]
 
-            result <- buildDatabaseWithMatrices defaultUnitConfig activityMap techFlowDB bioFlowDB M.empty unitDB
+            result <- buildDatabaseWithMatrices (BuildInputs defaultUnitConfig mempty) activityMap techFlowDB bioFlowDB M.empty unitDB
             case result of
                 Left err -> expectationFailure $ "buildDatabaseWithMatrices failed: " <> T.unpack err
                 Right db -> do
@@ -259,7 +259,7 @@ spec = do
                         , (kgUnitId, Unit kgUnitId "kg" "kg" "")
                         ]
 
-            result <- buildDatabaseWithMatrices defaultUnitConfig activityMap techFlowDB bioFlowDB M.empty unitDB
+            result <- buildDatabaseWithMatrices (BuildInputs defaultUnitConfig mempty) activityMap techFlowDB bioFlowDB M.empty unitDB
             case result of
                 Left err -> expectationFailure $ "buildDatabaseWithMatrices failed: " <> T.unpack err
                 Right db ->
@@ -373,7 +373,7 @@ spec = do
                 wasteFlowDB = M.singleton wW (WasteFlow wW "waste W" kgU M.empty Nothing Nothing)
                 unitDB = M.singleton kgU (Unit kgU "kg" "kg" "")
 
-            result <- buildDatabaseWithMatrices defaultUnitConfig activityMap techFlowDB bioFlowDB wasteFlowDB unitDB
+            result <- buildDatabaseWithMatrices (BuildInputs defaultUnitConfig mempty) activityMap techFlowDB bioFlowDB wasteFlowDB unitDB
             case result of
                 Left err -> expectationFailure $ "buildDatabaseWithMatrices failed: " <> T.unpack err
                 Right db -> case elemIndex (pA, yY) (V.toList (dbProcessIdTable db)) of

--- a/test/PersistenceSpec.hs
+++ b/test/PersistenceSpec.hs
@@ -63,6 +63,7 @@ import Types (
     Activity (..),
     BioDirection (..),
     BiosphereFlow (..),
+    BuildInputs (..),
     Compartment (..),
     Database (..),
     Exchange (..),
@@ -354,7 +355,7 @@ buildFrom :: M.Map (UUID, UUID) Activity -> IO Database
 buildFrom activities = do
     r <-
         buildDatabaseWithMatrices
-            defaultUnitConfig
+            (BuildInputs defaultUnitConfig mempty)
             activities
             (M.singleton supplierProdId milkFlow)
             (M.singleton co2Id co2Flow)

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -35,7 +35,7 @@ import Types (
     emptyProductIndex,
  )
 import qualified Types as VT
-import UnitConversion (UnitConfig (..), UnitDef (..), mkUnitConfig)
+import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig, mkUnitConfig)
 
 -- ---------------------------------------------------------------------------
 -- Fixture
@@ -128,6 +128,7 @@ mkDB locsAndEmissions =
             , dbCrossDBLinks = []
             , dbDependsOn = []
             , dbLinkingStats = mempty
+            , dbBuiltWith = VT.BuildInputs defaultUnitConfig mempty
             , dbSynonymDB = Nothing
             , dbFlowsByName = M.empty
             , dbFlowsByCAS = M.empty

--- a/test/SetupInfoSpec.hs
+++ b/test/SetupInfoSpec.hs
@@ -126,7 +126,7 @@ buildDb :: [((UUID.UUID, UUID.UUID), Activity)] -> [(UUID.UUID, Text)] -> IO Dat
 buildDb acts flows = do
     res <-
         buildDatabaseWithMatrices
-            defaultUnitConfig
+            (BuildInputs defaultUnitConfig mempty)
             (M.fromList acts)
             (M.fromList [(fid, minimalFlow fid name) | (fid, name) <- flows])
             M.empty

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -334,7 +334,7 @@ across the round-trip, but keying by name is robust either way).
 inventoryByName :: ([Activity], TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB) -> Text -> IO (M.Map Text Double)
 inventoryByName (acts, tech, bio, waste, units) target = do
     let actMap = M.fromList [(activityKey a, a) | a <- acts]
-    built <- buildDatabaseWithMatrices defaultUnitConfig actMap tech bio waste units
+    built <- buildDatabaseWithMatrices (BuildInputs defaultUnitConfig mempty) actMap tech bio waste units
     case built of
         Left err -> expectationFailure (T.unpack err) >> pure M.empty
         Right db -> do

--- a/test/StrictPinSpec.hs
+++ b/test/StrictPinSpec.hs
@@ -43,6 +43,7 @@ import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import Types (
     Activity (..),
+    BuildInputs (..),
     CrossDBLink (..),
     Database (..),
     Exchange (..),
@@ -159,7 +160,7 @@ supplierLoadedConfig name =
 
 buildOrFail :: SimpleParts -> IO Database
 buildOrFail (SimpleParts acts flows units) = do
-    r <- buildDatabaseWithMatrices defaultUnitConfig acts flows M.empty M.empty units
+    r <- buildDatabaseWithMatrices (BuildInputs defaultUnitConfig mempty) acts flows M.empty M.empty units
     case r of
         Right db -> pure db
         Left err -> fail ("buildDatabaseWithMatrices: " <> show err)

--- a/test/TestHelpers.hs
+++ b/test/TestHelpers.hs
@@ -50,7 +50,7 @@ loadSampleDatabaseWithPath path = do
     case loadResult of
         Left err -> error $ "Failed to load test database: " ++ show err
         Right simpleDb -> do
-            dbResult <- buildDatabaseWithMatrices defaultUnitConfig (sdbActivities simpleDb) (sdbTechFlows simpleDb) (sdbBioFlows simpleDb) (sdbWasteFlows simpleDb) (sdbUnits simpleDb)
+            dbResult <- buildDatabaseWithMatrices (BuildInputs defaultUnitConfig mempty) (sdbActivities simpleDb) (sdbTechFlows simpleDb) (sdbBioFlows simpleDb) (sdbWasteFlows simpleDb) (sdbUnits simpleDb)
             case dbResult of
                 Left err -> error $ "Failed to build matrix: " ++ show err
                 Right db -> return db

--- a/test/WasteTreatmentSignSpec.hs
+++ b/test/WasteTreatmentSignSpec.hs
@@ -151,7 +151,7 @@ techFlowDB =
 buildDB :: T.Text -> M.Map (UUID, UUID) Activity -> IO Database
 buildDB name acts =
     buildDatabaseWithMatrices
-        defaultUnitConfig
+        (BuildInputs defaultUnitConfig mempty)
         acts
         techFlowDB
         (M.singleton co2 co2Flow)


### PR DESCRIPTION
## Why

The engine writes `volca.cache.<name>.bin.zst` beside each database and reads it back without checking what it was built with. The header's schema signature identifies the `Database` type by name (the Typeable fingerprint does not change when a field is added, contrary to what its comment said) plus a hand-bumped constant. Neither says anything about the unit table or the location aliases the parse used, and both shape what the cache holds: the unit table decides which exchanges convert and link and the unit every amount is recorded in, the aliases decide which dataset an EcoSpold 1 exchange resolves to.

On one SimaPro database, a cache built while the unit table was missing kept 1,335 exchanges unlinked at every start. A fresh read had none.

## What changes

- A database records the unit table and location aliases it was parsed under (`dbBuiltWith`), set where the matrices are built, so no database exists without it. The cache is trusted only when that pair is the one in force. Otherwise the log says which of the two changed and the source is read again.
- Left out on purpose: the synonym set, the geography hierarchy and policy, and the other databases. They shape only the cross-database links, which every cache hit derives again, and the synonym set grows after every load, so stamping it would rebuild every database at the next start.
- A staged database carries the inputs of its parse, and finalize builds and stamps with those, not with whatever table is in force at finalize time. A table uploaded between staging and finalize is caught at the next start, which reads the source again.
- A deployment that ships only the cache, with no source beside it, still loads as long as the cache was built under the unit table and aliases in force. One that was not is refused like a stale cache, and with no source the load fails and says so. The deploy repository ships sources with its preloaded archives, so it is not affected.
- The schema constant moves to 20: every existing cache is rebuilt once.
- Two cache readers that bypassed the header check had no caller and are removed. The staging path no longer recomputes unknown units in case the cache was stale.
- The signature's comment now says what the fingerprint actually covers.

## Verification

- `AutoRelinkSpec` gains two cases, red before the fix (the cache was trusted, `Right True`) and green after: a cache built under one unit table is read again under another and trusted again on the next load; same for location aliases.
- Full `cabal test lca-tests`: 2,399 examples, 0 failures, 2 pending.
- Cold build in a fresh directory with `-Werror`: clean.
- fourmolu check and hlint: clean.
