### PR TITLE
Repair the benchmark build, and a changelog pointer to nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,9 @@
   dataset two identifiers on two servers. From now on an activity is named by
   the "Process identifier" its block publishes, and a flow by its name folded in
   case and its compartment. The identifiers of these two formats therefore move
-  once more, and `volca/examples/process_id_remap` converts a stored list.
+  once more. Converting a stored list means asking the engine for every activity
+  it holds and recomputing the ids each one used to answer to: a uuid5 cannot be
+  inverted, so that is the only direction that works.
   EcoSpold 1 and 2 and ILCD are untouched: they carry identifiers of their own.
 - Every row of these two formats is recorded in the reference unit of its
   dimension, where only the reference product was before. An input written in

--- a/bench/Bench/Helpers.hs
+++ b/bench/Bench/Helpers.hs
@@ -14,7 +14,7 @@ import Data.Text (Text)
 
 import Database (buildDatabaseWithMatrices)
 import qualified Database.Loader as Loader
-import Types (Database, sdbActivities, sdbBioFlows, sdbTechFlows, sdbUnits, sdbWasteFlows)
+import Types (BuildInputs (..), Database, sdbActivities, sdbBioFlows, sdbTechFlows, sdbUnits, sdbWasteFlows)
 import qualified UnitConversion as UC
 
 {- | Parse a fixture path and build the indexed 'Database' with matrices.
@@ -32,7 +32,7 @@ loadFullDatabase path = do
         Right sdb -> do
             built <-
                 buildDatabaseWithMatrices
-                    UC.defaultUnitConfig
+                    (BuildInputs UC.defaultUnitConfig mempty)
                     (sdbActivities sdb)
                     (sdbTechFlows sdb)
                     (sdbBioFlows sdb)

--- a/bench/Bench/Lcia.hs
+++ b/bench/Bench/Lcia.hs
@@ -43,6 +43,7 @@ import Method.Types (Method (..), MethodCF (..))
 import qualified Method.Types as MT
 import Types (
     BiosphereFlow (..),
+    BuildInputs (..),
     Compartment (..),
     Database (..),
     Indexes (..),
@@ -160,6 +161,7 @@ emptyDatabase =
         , dbFlowsByCAS = M.empty
         , dbProductSearchIndex = M.empty
         , dbBM25Index = Nothing
+        , dbBuiltWith = BuildInputs UC.defaultUnitConfig mempty
         }
 
 data SynFixture = SynFixture
@@ -334,7 +336,10 @@ registerReal = do
                             pure []
                         Right method -> do
                             putStrLn "[bench] lcia.real.score_method: mapping CFs to flows + filling broadcast..."
-                            mappings <- mapMethodToFlows db method
+                            -- No compartment map: a bench has no database manager to
+                            -- merge one from, and this is what the bench measured before
+                            -- the bridge became a parameter.
+                            mappings <- mapMethodToFlows M.empty db method
                             let unitDB = dbUnits db
                                 flowDB = dbBioFlows db
                                 tables0 = buildMethodTables (cfFamily (methodUnit method)) M.empty M.empty mappings

--- a/bench/Bench/Parsers.hs
+++ b/bench/Bench/Parsers.hs
@@ -177,25 +177,30 @@ registerSimaPro = do
         Nothing -> pure []
         Just path -> do
             -- Parse once to learn N_actual; the bench measurement re-parses fresh.
-            (acts, _, _, _, _) <- SP.parseSimaProCSV UC.defaultUnitConfig path
-            let !n = length acts
-            pure
-                [ BenchSpec
-                    { bsCapability = "parser.simapro"
-                    , bsLabel = T.pack ("Parse " <> show n <> " processes from a SimaPro CSV")
-                    , bsDescription =
-                        "Reads a SimaPro CSV export (Windows-1252 encoded) and parses every process block into \
-                        \Haskell structures. Internally splits the file across worker threads at process \
-                        \boundaries. SimaPro CSV is the dominant interchange format from food and agriculture LCA \
-                        \databases; this benches the cold-start parsing cost."
-                    , bsUnitOfWork = UnitOfWork{uowKind = "simapro_processes", uowN = n}
-                    , bsMetric = "seconds"
-                    , bsFixture = J.Fixture{J.fSource = F.fixtureSourceLabel F.Agribalyse, J.fSlice = "whole file"}
-                    , bsAction = nfIO $ do
-                        (acts', _, _, _, _) <- SP.parseSimaProCSV UC.defaultUnitConfig path
-                        evaluate (length acts')
-                    }
-                ]
+            parsed <- SP.parseSimaProCSV UC.defaultUnitConfig path
+            case parsed of
+                Left err -> do
+                    putStrLn $ "[bench] parser.simapro: parse failed (" <> T.unpack err <> "), skipping"
+                    pure []
+                Right (acts, _, _, _, _) -> do
+                    let !n = length acts
+                    pure
+                        [ BenchSpec
+                            { bsCapability = "parser.simapro"
+                            , bsLabel = T.pack ("Parse " <> show n <> " processes from a SimaPro CSV")
+                            , bsDescription =
+                                "Reads a SimaPro CSV export (Windows-1252 encoded) and parses every process block into \
+                                \Haskell structures. Internally splits the file across worker threads at process \
+                                \boundaries. SimaPro CSV is the dominant interchange format from food and agriculture LCA \
+                                \databases; this benches the cold-start parsing cost."
+                            , bsUnitOfWork = UnitOfWork{uowKind = "simapro_processes", uowN = n}
+                            , bsMetric = "seconds"
+                            , bsFixture = J.Fixture{J.fSource = F.fixtureSourceLabel F.Agribalyse, J.fSlice = "whole file"}
+                            , bsAction = nfIO $ do
+                                reparsed <- SP.parseSimaProCSV UC.defaultUnitConfig path
+                                evaluate (fmap (\(acts', _, _, _, _) -> length acts') reparsed)
+                            }
+                        ]
 
 -- ---------------------------------------------------------------------------
 -- ILCD directory parser


### PR DESCRIPTION
Two things the release preflight found. Neither reaches a shipped artifact,
and both had to be fixed before cutting the release.

## The benchmark tree no longer compiled

Four signatures moved during this cycle and the benchmarks were never
rebuilt against them: `buildDatabaseWithMatrices` takes a `BuildInputs`
record, `parseSimaProCSV` returns an `Either`, `Database` gained
`dbBuiltWith`, and `mapMethodToFlows` takes the compartment map ahead of
the database.

Nothing caught it, because CI builds the library, the executables and the
tests, but not the benchmarks. A local build with `--enable-benchmarks`
does, and so the failure only appeared when the release preflight ran one.

The SimaPro registration now reports a parse failure and skips its spec,
the way the loader and solve registrations already report a failed load.
The LCIA benchmark passes an empty compartment map, which is what it
measured before that argument existed.

Checked with a cold `cabal build all --enable-tests --enable-benchmarks
--ghc-options=-Werror`, then by running the benchmark binary against a real
Agribalyse 3.2 export: it registers, runs and writes its results file.

## A changelog entry pointed at a path this repository does not have

The entry on the SimaPro and Brightway identity change sent the reader to
`volca/examples/process_id_remap`, a path that does not exist. It now says what converting a stored list takes, which
is the part that matters and holds wherever the script sits.
