### PR TITLE
Give the benchmarks the unit table the engine carries

### DIFF
--- a/bench/Bench/Helpers.hs
+++ b/bench/Bench/Helpers.hs
@@ -24,15 +24,15 @@ expected to invoke it once at registration time and reuse the result.
 Returns 'Left' with a human-readable message if the parse or matrix build
 fails. The bench module is responsible for skipping its specs in that case.
 -}
-loadFullDatabase :: FilePath -> IO (Either Text Database)
-loadFullDatabase path = do
-    res <- Loader.loadDatabase UC.defaultUnitConfig path
+loadFullDatabase :: UC.UnitConfig -> FilePath -> IO (Either Text Database)
+loadFullDatabase unitCfg path = do
+    res <- Loader.loadDatabase unitCfg path
     case res of
         Left err -> pure (Left ("loadDatabase failed: " <> err))
         Right sdb -> do
             built <-
                 buildDatabaseWithMatrices
-                    (BuildInputs UC.defaultUnitConfig mempty)
+                    (BuildInputs unitCfg mempty)
                     (sdbActivities sdb)
                     (sdbTechFlows sdb)
                     (sdbBioFlows sdb)

--- a/bench/Bench/Lcia.hs
+++ b/bench/Bench/Lcia.hs
@@ -246,10 +246,10 @@ benchSetBatched fx =
 -- Public registration
 -- ---------------------------------------------------------------------------
 
-register :: IO [BenchSpec]
-register = do
+register :: UC.UnitConfig -> IO [BenchSpec]
+register unitCfg = do
     syn <- registerSynthetic
-    real <- registerReal
+    real <- registerReal unitCfg
     pure (syn ++ real)
 
 -- ---------------------------------------------------------------------------
@@ -315,14 +315,14 @@ registerSynthetic = do
 -- Real-data benches (need both a loaded Database and a parsed Method)
 -- ---------------------------------------------------------------------------
 
-registerReal :: IO [BenchSpec]
-registerReal = do
+registerReal :: UC.UnitConfig -> IO [BenchSpec]
+registerReal unitCfg = do
     mDb <- pickDbFixture
     mMethod <- F.lookupFixture F.MethodEFIlcd
     case (mDb, mMethod) of
         (Just (src, dbPath), Just methodPath) -> do
             putStrLn "[bench] lcia.real.score_method: loading database..."
-            dbRes <- H.loadFullDatabase dbPath
+            dbRes <- H.loadFullDatabase unitCfg dbPath
             case dbRes of
                 Left err -> do
                     putStrLn $ "[bench] lcia.real.score_method: load failed (" <> show err <> "), skipping"
@@ -343,7 +343,7 @@ registerReal = do
                             let unitDB = dbUnits db
                                 flowDB = dbBioFlows db
                                 tables0 = buildMethodTables (cfFamily (methodUnit method)) M.empty M.empty mappings
-                                !tables = fillBroadcastVector UC.defaultUnitConfig unitDB flowDB tables0
+                                !tables = fillBroadcastVector unitCfg unitDB flowDB tables0
                                 !nCFs = length (methodFactors method)
                             putStrLn "[bench] lcia.real.score_method: computing inventory for first product..."
                             inventory <- Matrix.computeInventoryMatrix db 0
@@ -371,7 +371,7 @@ registerReal = do
                                             }
                                     , bsAction =
                                         nf
-                                            (\inv -> loScore (computeLCIAScoreFromTables UC.defaultUnitConfig unitDB flowDB inv tables))
+                                            (\inv -> loScore (computeLCIAScoreFromTables unitCfg unitDB flowDB inv tables))
                                             inventory
                                     }
                                 ]

--- a/bench/Bench/Loader.hs
+++ b/bench/Bench/Loader.hs
@@ -34,10 +34,10 @@ import Bench.Json (BenchSpec (..), UnitOfWork (..))
 import qualified Bench.Json as J
 import qualified Fixtures as F
 
-register :: IO [BenchSpec]
-register = do
-    single <- registerSingleDb
-    cross <- registerCrossDbLinking
+register :: UC.UnitConfig -> IO [BenchSpec]
+register unitCfg = do
+    single <- registerSingleDb unitCfg
+    cross <- registerCrossDbLinking unitCfg
     pure (single ++ cross)
 
 -- ---------------------------------------------------------------------------
@@ -48,8 +48,8 @@ register = do
 fixture among (Agribalyse → Bafu → Ecoinvent) so the bench runs on
 whatever happens to be on disk. Reports the actual process count.
 -}
-registerSingleDb :: IO [BenchSpec]
-registerSingleDb = do
+registerSingleDb :: UC.UnitConfig -> IO [BenchSpec]
+registerSingleDb unitCfg = do
     mFx <- pickFirstAvailable [F.Agribalyse, F.Bafu, F.Ecoinvent]
     case mFx of
         Nothing -> do
@@ -57,7 +57,7 @@ registerSingleDb = do
             pure []
         Just (src, path) -> do
             -- One probe load to learn the process count for the unit_of_work.
-            res <- Loader.loadDatabase UC.defaultUnitConfig path
+            res <- Loader.loadDatabase unitCfg path
             case res of
                 Left err -> do
                     putStrLn $
@@ -79,13 +79,13 @@ registerSingleDb = do
                             , bsUnitOfWork = UnitOfWork{uowKind = "processes", uowN = n}
                             , bsMetric = "seconds"
                             , bsFixture = J.Fixture{J.fSource = F.fixtureSourceLabel src, J.fSlice = "whole database"}
-                            , bsAction = loadBench path
+                            , bsAction = loadBench unitCfg path
                             }
                         ]
 
-loadBench :: FilePath -> Benchmarkable
-loadBench path = nfIO $ do
-    r <- Loader.loadDatabase UC.defaultUnitConfig path
+loadBench :: UC.UnitConfig -> FilePath -> Benchmarkable
+loadBench unitCfg path = nfIO $ do
+    r <- Loader.loadDatabase unitCfg path
     case r of
         Left err -> evaluate (T.length err)
         Right sdb -> evaluate (M.size (sdbActivities sdb))
@@ -98,8 +98,8 @@ loadBench path = nfIO $ do
 in the background, so unlinked technosphere inputs resolve against the
 Ecoinvent supplier index. Requires both fixtures.
 -}
-registerCrossDbLinking :: IO [BenchSpec]
-registerCrossDbLinking = do
+registerCrossDbLinking :: UC.UnitConfig -> IO [BenchSpec]
+registerCrossDbLinking unitCfg = do
     mFg <- F.lookupFixture F.Agribalyse
     mBg <- F.lookupFixture F.Ecoinvent
     case (mFg, mBg) of
@@ -109,7 +109,7 @@ registerCrossDbLinking = do
             -- attach to it). The bench iteration only re-runs the
             -- foreground load + linking step.
             putStrLn "[bench] loader.multi_db_cross_link: pre-loading background DB..."
-            bgRes <- Loader.loadDatabase UC.defaultUnitConfig bgPath
+            bgRes <- Loader.loadDatabase unitCfg bgPath
             case bgRes of
                 Left err -> do
                     putStrLn $
@@ -130,7 +130,7 @@ registerCrossDbLinking = do
                             M.empty
                             [bgIndex]
                             Syn.emptySynonymDB
-                            UC.defaultUnitConfig
+                            unitCfg
                             M.empty
                             GeoGlobal
                             fgPath
@@ -164,21 +164,21 @@ registerCrossDbLinking = do
                                             { J.fSource = T.pack "agribalyse + ecoinvent"
                                             , J.fSlice = "whole databases (foreground reload each iteration)"
                                             }
-                                    , bsAction = crossLinkBench bgIndex fgPath
+                                    , bsAction = crossLinkBench unitCfg bgIndex fgPath
                                     }
                                 ]
         _ -> do
             putStrLn "[bench] loader.multi_db_cross_link: need both VOLCA_BENCH_AGRIBALYSE and VOLCA_BENCH_ECOINVENT, skipping"
             pure []
 
-crossLinkBench :: CL.IndexedDatabase -> FilePath -> Benchmarkable
-crossLinkBench bgIndex fgPath = nfIO $ do
+crossLinkBench :: UC.UnitConfig -> CL.IndexedDatabase -> FilePath -> Benchmarkable
+crossLinkBench unitCfg bgIndex fgPath = nfIO $ do
     r <-
         Loader.loadDatabaseWithCrossDBLinking
             M.empty
             [bgIndex]
             Syn.emptySynonymDB
-            UC.defaultUnitConfig
+            unitCfg
             M.empty
             GeoGlobal
             fgPath

--- a/bench/Bench/Parsers.hs
+++ b/bench/Bench/Parsers.hs
@@ -54,11 +54,11 @@ nProcessFiles = 1000
 -- Public registration
 -- ---------------------------------------------------------------------------
 
-register :: IO [BenchSpec]
-register = do
+register :: UC.UnitConfig -> IO [BenchSpec]
+register unitCfg = do
     es2 <- registerEcoSpold2
     es1 <- registerEcoSpold1
-    sp <- registerSimaPro
+    sp <- registerSimaPro unitCfg
     ilcd <- registerIlcd
     methods <- registerMethodParsers
     pure (es2 ++ es1 ++ sp ++ ilcd ++ methods)
@@ -170,14 +170,14 @@ registerEcoSpold1 = do
 -- SimaPro CSV (single-file, parallel internally)
 -- ---------------------------------------------------------------------------
 
-registerSimaPro :: IO [BenchSpec]
-registerSimaPro = do
+registerSimaPro :: UC.UnitConfig -> IO [BenchSpec]
+registerSimaPro unitCfg = do
     mPath <- F.lookupFixture F.Agribalyse
     case mPath of
         Nothing -> pure []
         Just path -> do
             -- Parse once to learn N_actual; the bench measurement re-parses fresh.
-            parsed <- SP.parseSimaProCSV UC.defaultUnitConfig path
+            parsed <- SP.parseSimaProCSV unitCfg path
             case parsed of
                 Left err -> do
                     putStrLn $ "[bench] parser.simapro: parse failed (" <> T.unpack err <> "), skipping"
@@ -197,7 +197,7 @@ registerSimaPro = do
                             , bsMetric = "seconds"
                             , bsFixture = J.Fixture{J.fSource = F.fixtureSourceLabel F.Agribalyse, J.fSlice = "whole file"}
                             , bsAction = nfIO $ do
-                                reparsed <- SP.parseSimaProCSV UC.defaultUnitConfig path
+                                reparsed <- SP.parseSimaProCSV unitCfg path
                                 evaluate (fmap (\(acts', _, _, _, _) -> length acts') reparsed)
                             }
                         ]

--- a/bench/Bench/Solve.hs
+++ b/bench/Bench/Solve.hs
@@ -38,6 +38,7 @@ import Types (
     ProcessId,
     SparseTriple (..),
  )
+import qualified UnitConversion as UC
 
 import qualified Bench.Helpers as H
 import Bench.Json (BenchSpec (..), UnitOfWork (..))
@@ -51,8 +52,8 @@ import qualified Fixtures as F
 nBatchProducts :: Int
 nBatchProducts = 100
 
-register :: IO [BenchSpec]
-register = do
+register :: UC.UnitConfig -> IO [BenchSpec]
+register unitCfg = do
     mFx <- pickSolveFixture
     case mFx of
         Nothing -> do
@@ -60,7 +61,7 @@ register = do
             pure []
         Just (src, path) -> do
             putStrLn $ "[bench] solve.*: loading database from " <> path <> " ..."
-            res <- H.loadFullDatabase path
+            res <- H.loadFullDatabase unitCfg path
             case res of
                 Left err -> do
                     putStrLn $ "[bench] solve.*: load failed (" <> T.unpack err <> "), skipping"

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -22,6 +22,7 @@ import Data.Time.Format.ISO8601 (iso8601Show)
 import GHC.Conc (getNumProcessors)
 import GHC.IO.Exception (ExitCode (ExitSuccess))
 import System.Environment (getArgs, lookupEnv)
+import System.Exit (exitFailure)
 import System.IO (hFlush, stdout)
 import System.Process (readProcessWithExitCode)
 import Text.Printf (printf)
@@ -29,6 +30,9 @@ import Text.Printf (printf)
 import qualified Criterion.Measurement as Meas
 import qualified Criterion.Measurement.Types as MeasTypes
 import System.Mem (performMajorGC)
+
+import qualified Builtin as B
+import qualified UnitConversion as UC
 
 import qualified Bench.Json as J
 import qualified Bench.Lcia as Lcia
@@ -41,14 +45,16 @@ main = do
     outPath <- resolveOutput
     putStrLn $ "[bench] output: " <> outPath
 
+    unitCfg <- resolveUnitConfig
+
     putStrLn "[bench] collecting bench specs..."
     specs <-
         concat
             <$> sequence
-                [ Parsers.register
-                , Loader.register
-                , Solve.register
-                , Lcia.register
+                [ Parsers.register unitCfg
+                , Loader.register unitCfg
+                , Solve.register unitCfg
+                , Lcia.register unitCfg
                 ]
     putStrLn $ "[bench] " <> show (length specs) <> " benchs ready"
 
@@ -66,6 +72,22 @@ main = do
                 }
     J.writeBenchResults outPath out
     putStrLn $ "[bench] wrote " <> outPath <> " (" <> show (length results) <> " results)"
+
+{- | The unit table every bench reads a real database with: the one the
+engine carries in its binary, which is what an engine started with no
+configuration runs on. 'UC.defaultUnitConfig' knows four units, so a real
+database refuses to load against it: two rows written in kg and in g are
+then two flows no conversion relates.
+-}
+resolveUnitConfig :: IO UC.UnitConfig
+resolveUnitConfig =
+    case UC.buildFromCSV (B.builtinContent B.BuiltinUnits) of
+        Left err -> do
+            putStrLn $ "[bench] cannot read the built-in unit table: " <> T.unpack err
+            exitFailure
+        Right cfg -> do
+            putStrLn $ "[bench] unit table: " <> show (UC.unitCount cfg) <> " units"
+            pure cfg
 
 resolveOutput :: IO FilePath
 resolveOutput = do


### PR DESCRIPTION
The benchmarks compile again since #366, but none of them could read a real
database, and a run reported the two synthetic LCIA benches alone.

Every bench that opens a fixture loaded it with
`UnitConversion.defaultUnitConfig`, the four-unit bootstrap table (kg, m, s,
item). This cycle refuses two rows as one flow when no conversion relates
their units, and Agribalyse writes some rows in grams and others in
kilograms, so the load stopped at:

```
flow 'Chemical, organic {GLO}| market for | Cut-off, S - Copied from Ecoinvent U'
is written in two units that no conversion relates ('kg' and 'g')
```

The refusal is right; the table was wrong. It used to appear to work because
the parser dropped one of the two rows in silence, which is exactly what
this cycle stopped doing.

The table is now read once in the orchestrator, from the one built into the
binary, and passed to each `register` function. An engine started with no
configuration runs on that same table, so the benches measure what a user
gets rather than a configuration nobody has.

The synthetic LCIA fixture keeps the bootstrap table: it invents its own
flows and units and never reads a file.

## Measured

Cold `cabal build all --enable-tests --enable-benchmarks --ghc-options=-Werror`,
then a run against a real Agribalyse 3.2 export with the EF 3.1 ILCD method.
Before, three results; now nine:

```
[bench] unit table: 227 units
parser.simapro           n=20440 simapro_processes
parser.method_ilcd_xml   n=398   characterization_factors
loader.single_db         n=21510 processes
solve.scaling_vector     n=21510 matrix_processes
solve.inventory_matrix   n=21510 matrix_processes
solve.batch_multi_rhs    n=100   products_batched
lcia.synthetic.fanout    n=27    lcia_methods
lcia.synthetic.set_batched n=27  lcia_methods
lcia.real.score_method   n=398   characterization_factors
```
