### PR TITLE
Release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.12.0] - 2026-09-02
 
 ### Added
 - Reading an EcoSpold 1 database from its files now reports, as a warning,

--- a/volca.cabal
+++ b/volca.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                volca
-version:             0.11.1-dev
+version:             0.12.0
 build-type:          Simple
 
 license:             Apache-2.0


### PR DESCRIPTION
Cuts release 0.12.0: the changelog section is dated and `volca.cabal` drops
its development suffix.

**Why a minor and not a patch.** The question the release rule asks is
whether a script that works today survives. This one it does not, on four
counts:

- a dataset read from a SimaPro CSV or a Brightway Excel workbook is now
  identified by what the file publishes, so its process ids move;
- every row of those two formats is recorded in the reference unit of its
  dimension, so an input written in kWh is held and displayed in MJ;
- the exchange role gains a fifth value, `AvoidedProduct`;
- an activity the engine cannot allocate is refused a score with a 422,
  where it used to be scored on its reference product alone.

Scores move too, where an invented supplier or a retired block used to be
counted. All of it is in the changelog section this PR dates.

**Nothing else moves.** The wire revision is already 14, raised by the two
changes that needed it during the cycle, so no client check changes here.
The reference data bundle stays at 3: nothing under `data/` changed, which
`check-data-version.sh` confirms on every run.

Checked with a cold `cabal build all --enable-tests --enable-benchmarks
--ghc-options=-Werror`. The build regenerates no tracked file.

After merge: tag `v0.12.0` on the squashed commit, then reopen main on
`0.12.1-dev`.
