### PR TITLE
Release pyvolca 0.11.0

### DIFF
--- a/pyvolca/CHANGELOG.md
+++ b/pyvolca/CHANGELOG.md
@@ -18,6 +18,41 @@ git cliff --unreleased --tag pyvolca-v0.X.Y   # render as a released section
 
 Then paste the rendered block at the top of this file and tighten wording.
 
+## [0.11.0] - 2026-09-02
+
+The minor is for two additions a strict reader cannot ignore: the exchange
+role gains a value, and a batch result gains a field.
+
+### Added
+
+- `TechRole.AVOIDED_PRODUCT`: a substitution, the product the activity
+  displaces, credited to that product's producer. Code that matches the four
+  previous roles exhaustively has a fifth case to answer.
+- `BatchScores.unscorable`, the process ids that resolve but name an activity
+  the engine refuses to score; the `unallocated` check of its quality report
+  says why, which this build reads through `Client.call`. An older engine
+  sends none and the field reads empty.
+- `UnmappedFlow.compartment`, the compartment the method row states, so a
+  vocabulary gap is visible without reading the engine log. It is None when
+  the row states none, and when the engine predates wire revision 13.
+
+### Changed
+
+- This build knows wire revision 14, so it no longer warns that an engine
+  running v0.12.0 speaks a format newer than it understands. Revision 13 adds
+  the compartment an unmapped factor of the mapping report carries; revision
+  14 adds the `AvoidedProduct` exchange role, the `unallocated` quality check,
+  and the declared share and classification a technosphere exchange now
+  carries on the wire, which this build passes through rather than decoding
+  into fields of its own. The oldest revision this client accepts is still 2,
+  and it still runs against any engine from v0.9.1 on.
+- `COPRODUCT` now describes a product output the source left unallocated, and
+  an activity still carrying one is refused a score. The value did not move;
+  what it means did.
+- The match strategy a mapping or a characterization factor reports lists
+  `proxy` where it listed `fuzzy`. No matcher ever returned `fuzzy`, and the
+  engine has removed it.
+
 ## [0.10.1] - 2026-08-28
 
 ### Changed

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -24,7 +24,7 @@ The other direction is a promise about pyvolca's own names. A name this client p
 
 _Generated from `volca._compat`: run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.10.1** speaks wire formats **2 to 14** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error. A name this build has retired keeps working until pyvolca **1.0**.
+This build of **pyvolca 0.11.0** speaks wire formats **2 to 14** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error. A name this build has retired keeps working until pyvolca **1.0**.
 
 <!-- END: compatibility -->
 

--- a/pyvolca/pyproject.toml
+++ b/pyvolca/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvolca"
-version = "0.10.1"
+version = "0.11.0"
 description = "Python client for VoLCA, the Life Cycle Assessment engine"
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
Cuts pyvolca 0.11.0, the companion release to engine v0.12.0.

**Why a minor.** Two additions a strict reader cannot ignore: `TechRole`
gains `AVOIDED_PRODUCT`, and `BatchScores` gains `unscorable`. Code that
matches the four previous roles exhaustively has a fifth case to answer, and
code that builds a `BatchScores` by position has a fifth field.

`KNOWN_WIRE` reaches 14, which is what stops this build warning that a
v0.12.0 engine speaks a format newer than it understands. `REQUIRED_WIRE`
stays at 2 and `MIN_ENGINE_HINT` at 0.9.1: `unscorable` is read with a
default, so this client still decodes an engine that does not send it, and
nothing here needs a newer engine than before.

git-cliff is not installed here, so the changelog section is written by
hand, which is how that file expects it to end up anyway. The README
compatibility block is respliced by `scripts/gen_api_md.py --write`; its one
changed line is the version in the sentence the site publishes.

`uv run pytest`: 299 passed, 7 skipped.

**Order.** Tag `pyvolca-v0.11.0` after `v0.12.0` is tagged. Not because the
Python preflight needs it, which only checks that some engine at or past
`MIN_ENGINE_HINT` is released, but because the changelog entry names a
v0.12.0 engine: publishing to PyPI first would ship a sentence about a
release that does not exist yet.
