### PR TITLE
Open 0.12.1 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.12.0] - 2026-09-02
 
 ### Added

--- a/volca.cabal
+++ b/volca.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                volca
-version:             0.12.0
+version:             0.12.1-dev
 build-type:          Simple
 
 license:             Apache-2.0


### PR DESCRIPTION
Reopens main after the `v0.12.0` tag: `volca.cabal` carries the development suffix again and the changelog gets an empty section for the next cycle.

The number is a patch because nothing removed is planned. Not knowing yet counts as nothing removed, and the release procedure raises it again if a change that breaks a working script lands.