### PR TITLE
Let a Linux build say which commit it is

### DIFF
--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -405,6 +405,15 @@ jobs:
           # Windows: re-source GHCup env in this MSYS2 shell since the wrapper
           # does not inherit PATH from the previous step.
           [[ -f /d/ghcup/env ]] && source /d/ghcup/env
+          # The Linux rows run in an Alpine container that has no git when
+          # checkout runs, so checkout falls back to the REST tarball and
+          # leaves no .git behind: gen-version.sh found nothing to read and
+          # every released Linux binary reported its commit as "unknown".
+          # The runner knows what it checked out, and the script already
+          # prefers these variables over git, so hand them over on every
+          # platform rather than making one row special.
+          export GIT_HASH="${GITHUB_SHA:0:7}"
+          [[ "$GITHUB_REF_TYPE" == "tag" ]] && export GIT_TAG="$GITHUB_REF_NAME"
           # Per-platform behaviour:
           # - Windows: only platform with indefinite test hangs
           #   (waitForProcess never reaping volca.exe). Wrap with GNU

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed
+- A released Linux binary now reports the commit it was built from, and a
+  release binary the tag it carries. Both used to come out as `unknown` and
+  an empty tag on Linux alone (`volca --version`, `GET /api/v1/version`),
+  because that build runs in a container without git and had nothing to
+  read; the macOS and Windows binaries were already correct.
+
 ## [0.12.0] - 2026-09-02
 
 ### Added


### PR DESCRIPTION
A released Linux binary cannot say which commit it is. It answers `volca 0.12.0 (unknown, linux)` on the command line and `"gitHash":"unknown","gitTag":""` on `GET /api/v1/version`, so any interface that shows the build shows the word "unknown" instead. The macOS and Windows binaries of the same release are stamped correctly.

The cause is visible in the v0.12.0 release log, one line apart:

```
build / linux-arm64    The repository will be downloaded using the GitHub REST API
build / linux-arm64    Generated src/Version.hs (hash=unknown, target=linux)
build / macos-arm64    Generated src/Version.hs (hash=52095f0, target=macos)
```

The Linux rows run in an Alpine container. Git is not installed there when the checkout action runs, so the action downloads a source tarball instead of cloning, and no `.git` is left behind. `gen-version.sh` asks git for the commit, gets nothing, and falls back to its own defaults, which is exactly what "unknown" is.

The fix hands the script what the runner already knows. `gen-version.sh` prefers `GIT_HASH` and `GIT_TAG` over asking git, so the build step exports both, on every platform rather than only the broken one: the value is the same commit git would have reported, and one rule is easier to keep true than a per-platform one. The tag is set only when the build is a tag build, which is what makes `gitTag` meaningful on the rows that had none: macOS already resolved it from its own checkout.

Checked by running `gen-version.sh` in a directory with no `.git`, which is the condition inside the container: it writes `hash=unknown` on its own, and `gitHash = "4d0f88a"` with `gitTag = "v0.12.1"` when the two variables are present. The proof it works in CI is the next release log line reading `hash=` followed by a real commit on the Linux rows.

