### PR TITLE
Copy a dependency's product flow into the database being written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@
   rather than copied. The same applies to an inventory edit that adds such a
   line, and to replaying one from a journal.
 
+  An amount to a supplier in another database must now be stated in that
+  supplier's product's own unit. A cross-database link carries the product
+  flow's unit rather than the exchange's, and the amount is converted from it,
+  so a convertible-but-different unit would have entered the matrix as a
+  number in the wrong one (two tonnes demanded as two kilograms) where the
+  same exchange to a local supplier is converted. It is refused, naming the
+  unit to restate it in.
+
 ## [0.12.0] - 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@
   because that build runs in a container without git and had nothing to
   read; the macOS and Windows binaries were already correct.
 
+### Fixed
+- Writing an activity whose supplier lives in a dependency database no longer
+  produces an exchange that contributes nothing. The write was accepted, but
+  the supplier's product flow was never copied into the database being
+  written, and cross-database relinking reads the consumer's own flow table:
+  finding nothing there it dropped the exchange in silence, leaving an empty
+  supply chain and a score of zero. The flow is now copied in with its unit
+  remapped, exactly as a biosphere flow from a dependency already was, and a
+  product stated in a unit the writing database does not have is refused
+  rather than copied. The same applies to an inventory edit that adds such a
+  line, and to replaying one from a journal.
+
 ## [0.12.0] - 2026-09-02
 
 ### Added

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -153,9 +153,10 @@ them mint a twin of a curated flow, uncharacterized and scoring as zero.
 
 There is deliberately no technosphere counterpart. A technosphere input always
 names a *supplier* — a product that something in scope produces — so the flow
-is whatever that supplier's process key already says it is. The only new
-technosphere flow authoring can create is the authored activity's own product,
-and that one is minted from the activity itself, never stated as an input.
+is whatever that supplier's process key already says it is. Authoring therefore
+never mints a technosphere flow from words: the activity's own product is
+minted from the activity, and a supplier living in a dependency has its product
+flow copied out of that dependency ('adoptTechFlow'), never invented.
 -}
 data FlowRef
     = FlowById UUID
@@ -305,7 +306,9 @@ validateOne ctx a =
                     ( ResolvedInsert
                         { riKey = key
                         , riActivity = buildActivity a unitLabel (productExchange : map reExchange resolved)
-                        , riNewTechFlows = [productFlow | not (M.member (snd key) (dbTechFlows (acDb ctx)))]
+                        , riNewTechFlows =
+                            [productFlow | not (M.member (snd key) (dbTechFlows (acDb ctx)))]
+                                <> mapMaybe reNewTechFlow resolved
                         , riNewBioFlows = mapMaybe reNewBioFlow resolved
                         }
                     , map here (concatMap reWarnings resolved)
@@ -415,6 +418,7 @@ data EditedActivity = EditedActivity
     { eaActivity :: Activity
     , eaMatched :: [Int]
     , eaNewBioFlows :: [BiosphereFlow]
+    , eaNewTechFlows :: [TechnosphereFlow]
     , eaWarnings :: [Text]
     }
 
@@ -438,6 +442,7 @@ applyExchangeEdits ctx edits act = case accErrors final of
                 { eaActivity = act{exchanges = accExchanges final}
                 , eaMatched = accMatched final
                 , eaNewBioFlows = accNewFlows final
+                , eaNewTechFlows = accNewTechFlows final
                 , eaWarnings = accWarnings final
                 }
     errs -> Left errs
@@ -448,6 +453,7 @@ applyExchangeEdits ctx edits act = case accErrors final of
             { accExchanges = exchanges act
             , accMatched = []
             , accNewFlows = []
+            , accNewTechFlows = []
             , accWarnings = []
             , accErrors = []
             }
@@ -457,6 +463,7 @@ data EditAcc = EditAcc
     { accExchanges :: [Exchange]
     , accMatched :: [Int]
     , accNewFlows :: [BiosphereFlow]
+    , accNewTechFlows :: [TechnosphereFlow]
     , accWarnings :: [Text]
     , accErrors :: [Text]
     }
@@ -473,6 +480,7 @@ applyStep ctx acc edit = case applyOneEdit ctx (accExchanges acc) edit of
             { accExchanges = esExchanges step
             , accMatched = accMatched acc <> [esMatched step]
             , accNewFlows = accNewFlows acc <> esNewFlows step
+            , accNewTechFlows = accNewTechFlows acc <> esNewTechFlows step
             , accWarnings = accWarnings acc <> esWarnings step
             }
 
@@ -481,6 +489,7 @@ data EditStep = EditStep
     { esExchanges :: [Exchange]
     , esMatched :: Int
     , esNewFlows :: [BiosphereFlow]
+    , esNewTechFlows :: [TechnosphereFlow]
     , esWarnings :: [Text]
     }
 
@@ -504,11 +513,18 @@ applyOneEdit ctx current edit = case edit of
                     { esExchanges = current <> [reExchange resolved]
                     , esMatched = 1
                     , esNewFlows = maybeToList (reNewBioFlow resolved)
+                    , esNewTechFlows = maybeToList (reNewTechFlow resolved)
                     , esWarnings = reWarnings resolved
                     }
   where
     changed exchangeList matched =
-        EditStep{esExchanges = exchangeList, esMatched = matched, esNewFlows = [], esWarnings = []}
+        EditStep
+            { esExchanges = exchangeList
+            , esMatched = matched
+            , esNewFlows = []
+            , esNewTechFlows = []
+            , esWarnings = []
+            }
     restate isSelected amount ex = if isSelected ex then withAmount amount ex else ex
 
 {- | The lines a selector names, and how many there are. Zero is a refusal: an
@@ -602,6 +618,7 @@ describeSelector sel = case sel of
 data ResolvedExchange = ResolvedExchange
     { reExchange :: Exchange
     , reNewBioFlow :: Maybe BiosphereFlow
+    , reNewTechFlow :: Maybe TechnosphereFlow
     , reWarnings :: [Text]
     }
 
@@ -651,17 +668,25 @@ resolveLinked ::
     Either [Text] ResolvedExchange
 resolveLinked ctx provider amount mUnit build =
     case (amountCheck amount, resolveSupplier ctx provider) of
-        ([], Right sup) ->
-            let stated = fromMaybe (defaultUnit sup) mUnit
-             in case lookupUnit ctx stated of
-                    Nothing -> Left ["unknown unit \"" <> stated <> "\""]
-                    Just (unitRef, unitLabel) ->
-                        case unitError ctx sup unitLabel of
-                            Just err -> Left [err]
-                            Nothing -> Right (ResolvedExchange (build sup unitRef) Nothing [])
+        ([], Right sup) -> mapLeft (: []) (resolved sup)
         (errs, Right _) -> Left errs
         (errs, Left err) -> Left (errs <> [err])
   where
+    resolved :: Supplier -> Either Text ResolvedExchange
+    resolved sup = do
+        let stated = fromMaybe (defaultUnit sup) mUnit
+        (unitRef, unitLabel) <-
+            maybe (Left ("unknown unit \"" <> stated <> "\"")) Right (lookupUnit ctx stated)
+        maybe (Right ()) Left (unitError ctx sup unitLabel)
+        newTechFlow <- adoptTechFlow ctx sup
+        pure
+            ResolvedExchange
+                { reExchange = build sup unitRef
+                , reNewBioFlow = Nothing
+                , reNewTechFlow = newTechFlow
+                , reWarnings = []
+                }
+    defaultUnit :: Supplier -> Text
     defaultUnit sup =
         case (supProducedUnit sup, supAnyRefUnit sup) of
             ("", "") -> ""
@@ -821,6 +846,7 @@ resolveBio ctx flowRef direction amount mUnit comment
                     , bioPedigree = Nothing
                     }
                 mNew
+                Nothing
                 warnings
             )
     -- The biosphere matrix carries amounts through unconverted, so a unit the
@@ -869,24 +895,70 @@ data Supplier = Supplier
     {- ^ unit of the first reference exchange either way, used only to default
     an omitted unit — a treatment provider has no produced unit to borrow.
     -}
+    , supHome :: SupplierHome
+    -- ^ which database the provider was found in, and what has to be copied out of it.
     }
+
+{- | Where a resolved provider lives, carrying what a foreign one obliges the
+edited database to adopt: its product flow, and the name of the unit that flow
+is stated in over there.
+-}
+data SupplierHome
+    = OwnDatabase
+    | Dependency TechnosphereFlow Text
 
 resolveSupplier :: AuthorContext -> Text -> Either Text Supplier
 resolveSupplier ctx provider =
-    case mapMaybe inDatabase (acDb ctx : acDeps ctx) of
+    case mapMaybe inDatabase (zip (True : repeat False) (acDb ctx : acDeps ctx)) of
         [] -> Left ("unknown provider \"" <> provider <> "\"")
         (sup : _) -> Right sup
   where
-    inDatabase db = do
+    inDatabase (local, db) = do
         pid <- resolveProcess db provider
         key <- dbProcessIdTable db V.!? fromIntegral pid
         act <- dbActivities db V.!? fromIntegral pid
+        home <- if local then Just OwnDatabase else foreignHome db (snd key)
         pure
             Supplier
                 { supKey = uncurry ProcessRef key
                 , supProducedUnit = refUnitOf db act (\e -> exchangeIsReference e && not (exchangeIsInput e))
                 , supAnyRefUnit = refUnitOf db act exchangeIsReference
+                , supHome = home
                 }
+    -- A dependency that cannot show the product flow behind its own process id
+    -- cannot supply anything writable, so it is passed over rather than
+    -- resolved into an exchange nothing would link.
+    foreignHome db flowId = do
+        flow <- M.lookup flowId (dbTechFlows db)
+        pure (Dependency flow (unitNameOf (dbUnits db) (tfUnitId flow)))
+
+{- | The product flow the edited database has to gain before this exchange can
+be linked, if any.
+
+Cross-database relinking reads the *consumer's* flow table
+('Database.Loader.findExchangeCrossDBLink' opens on @M.lookup fid techFlowDb@)
+and drops in silence what it does not find there, so an exchange must never
+reference a product flow only a dependency declares. The biosphere side already
+copies for exactly this reason; this is the same rule on the technosphere side.
+
+The unit is remapped into the edited database's own table, because the link
+carries the flow's unit name and would otherwise read it out of the wrong one.
+-}
+adoptTechFlow :: AuthorContext -> Supplier -> Either Text (Maybe TechnosphereFlow)
+adoptTechFlow ctx sup = case supHome sup of
+    OwnDatabase -> Right Nothing
+    Dependency flow flowUnit
+        | M.member (tfId flow) (dbTechFlows (acDb ctx)) -> Right Nothing
+        | otherwise -> case lookupUnit ctx flowUnit of
+            Nothing ->
+                Left
+                    ( "the product \""
+                        <> tfName flow
+                        <> "\" of this provider is stated in \""
+                        <> flowUnit
+                        <> "\", a unit this database does not have"
+                    )
+            Just (unitRef, _) -> Right (Just flow{tfUnitId = unitRef})
 
 {- | Resolve a process id string the same two ways the rest of the engine
 does: the canonical @activityUUID_productUUID@ pair, or a bare activity UUID

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -679,6 +679,7 @@ resolveLinked ctx provider amount mUnit build =
             maybe (Left ("unknown unit \"" <> stated <> "\"")) Right (lookupUnit ctx stated)
         maybe (Right ()) Left (unitError ctx sup unitLabel)
         newTechFlow <- adoptTechFlow ctx sup
+        maybe (Right ()) Left (dependencyUnitError ctx sup unitLabel)
         pure
             ResolvedExchange
                 { reExchange = build sup unitRef
@@ -899,38 +900,49 @@ data Supplier = Supplier
     -- ^ which database the provider was found in, and what has to be copied out of it.
     }
 
-{- | Where a resolved provider lives, carrying what a foreign one obliges the
-edited database to adopt: its product flow, and the name of the unit that flow
-is stated in over there.
+{- | Where a resolved provider lives, and what a foreign one obliges the edited
+database to adopt.
+
+'Dependency' carries the product flow that database declares for the provider
+and the name of the unit that flow is stated in over there — or nothing, when
+that database names a process whose product flow it never declared. That is a
+malformed database rather than an impossible one, so it is a state here and
+'adoptTechFlow' says which of the two it is.
 -}
 data SupplierHome
     = OwnDatabase
-    | Dependency TechnosphereFlow Text
+    | Dependency (Maybe (TechnosphereFlow, Text))
 
 resolveSupplier :: AuthorContext -> Text -> Either Text Supplier
 resolveSupplier ctx provider =
-    case mapMaybe inDatabase (zip (True : repeat False) (acDb ctx : acDeps ctx)) of
+    case mapMaybe inDatabase (zip (OwnDatabase : repeat foreign') (acDb ctx : acDeps ctx)) of
         [] -> Left ("unknown provider \"" <> provider <> "\"")
         (sup : _) -> Right sup
   where
-    inDatabase (local, db) = do
+    -- The first database in the list is the one being written, and the rest
+    -- are its dependencies; only those oblige a flow to be copied in.
+    foreign' :: SupplierHome
+    foreign' = Dependency Nothing
+
+    inDatabase :: (SupplierHome, Database) -> Maybe Supplier
+    inDatabase (home, db) = do
         pid <- resolveProcess db provider
         key <- dbProcessIdTable db V.!? fromIntegral pid
         act <- dbActivities db V.!? fromIntegral pid
-        home <- if local then Just OwnDatabase else foreignHome db (snd key)
         pure
             Supplier
                 { supKey = uncurry ProcessRef key
                 , supProducedUnit = refUnitOf db act (\e -> exchangeIsReference e && not (exchangeIsInput e))
                 , supAnyRefUnit = refUnitOf db act exchangeIsReference
-                , supHome = home
+                , supHome = case home of
+                    OwnDatabase -> OwnDatabase
+                    Dependency _ -> Dependency (declaredFlow db (snd key))
                 }
-    -- A dependency that cannot show the product flow behind its own process id
-    -- cannot supply anything writable, so it is passed over rather than
-    -- resolved into an exchange nothing would link.
-    foreignHome db flowId = do
+
+    declaredFlow :: Database -> UUID -> Maybe (TechnosphereFlow, Text)
+    declaredFlow db flowId = do
         flow <- M.lookup flowId (dbTechFlows db)
-        pure (Dependency flow (unitNameOf (dbUnits db) (tfUnitId flow)))
+        pure (flow, unitNameOf (dbUnits db) (tfUnitId flow))
 
 {- | The product flow the edited database has to gain before this exchange can
 be linked, if any.
@@ -947,7 +959,9 @@ carries the flow's unit name and would otherwise read it out of the wrong one.
 adoptTechFlow :: AuthorContext -> Supplier -> Either Text (Maybe TechnosphereFlow)
 adoptTechFlow ctx sup = case supHome sup of
     OwnDatabase -> Right Nothing
-    Dependency flow flowUnit
+    Dependency Nothing ->
+        Left "the database declaring this provider does not declare its product flow"
+    Dependency (Just (flow, flowUnit))
         | M.member (tfId flow) (dbTechFlows (acDb ctx)) -> Right Nothing
         | otherwise -> case lookupUnit ctx flowUnit of
             Nothing ->
@@ -959,6 +973,46 @@ adoptTechFlow ctx sup = case supHome sup of
                         <> "\", a unit this database does not have"
                     )
             Just (unitRef, _) -> Right (Just flow{tfUnitId = unitRef})
+
+{- | Whether two unit names denote the same unit, spelling aside.
+
+Two databases keep two unit tables, so one unit can be written @kg@ in one and
+@kilogram@ in the other. What decides is the factor between them, not the
+string.
+-}
+sameUnit :: UnitConfig -> Text -> Text -> Bool
+sameUnit cfg stated other =
+    normalizeUnit stated == normalizeUnit other
+        || maybe False (\factor -> abs (factor - 1) < 1e-12) (convertUnit cfg stated other 1)
+
+{- | Judge the unit an exchange to a dependency's supplier is stated in.
+
+A link into a dependency carries the *flow's* unit, not the exchange's
+('Database.Loader.findExchangeCrossDBLink' reads it off the flow), and
+'Matrix.depDemandsToVector' then converts the raw amount from that unit. So an
+exchange stated in anything else enters the matrix as a number in the wrong
+unit — two tonnes of a product recorded in kilograms would be demanded as two
+kilograms — where the same exchange to a local supplier is converted. Refuse
+and name the unit to restate in, exactly as a biosphere amount is.
+-}
+dependencyUnitError :: AuthorContext -> Supplier -> Text -> Maybe Text
+dependencyUnitError ctx sup stated = case supHome sup of
+    OwnDatabase -> Nothing
+    Dependency Nothing -> Nothing
+    Dependency (Just (_, flowUnit))
+        | T.null flowUnit -> Nothing
+        | sameUnit (acUnitConfig ctx) stated flowUnit -> Nothing
+        | otherwise ->
+            Just
+                ( "this provider's product is recorded in \""
+                    <> flowUnit
+                    <> "\" but the exchange states \""
+                    <> stated
+                    <> "\"; an amount to a supplier in another database is not "
+                    <> "converted, so restate it in \""
+                    <> flowUnit
+                    <> "\""
+                )
 
 {- | Resolve a process id string the same two ways the rest of the engine
 does: the canonical @activityUUID_productUUID@ pair, or a bare activity UUID

--- a/src/Database/Journal.hs
+++ b/src/Database/Journal.hs
@@ -412,7 +412,7 @@ applyOp ctx = \case
                     [ ResolvedInsert
                         { riKey = key
                         , riActivity = eaActivity edited
-                        , riNewTechFlows = []
+                        , riNewTechFlows = eaNewTechFlows edited
                         , riNewBioFlows = eaNewBioFlows edited
                         }
                     ]

--- a/test/AuthorSpec.hs
+++ b/test/AuthorSpec.hs
@@ -203,6 +203,44 @@ spec = do
                             other -> expectationFailure ("expected one dependency input, got " <> show (length other))
                     Right (rs, _) -> expectationFailure ("expected one insert, got " <> show (length rs))
 
+            it "copies a dependency's product flow into the edited database" $ do
+                -- Cross-database relinking reads the consumer's own flow table
+                -- and drops in silence what is not in it, so an exchange on a
+                -- flow only the dependency declares would score zero.
+                depDb <- buildFixture
+                let writing = (emptyOf fixtureDb){dbTechFlows = M.empty}
+                    ctx = (contextOf writing){acDeps = [depDb]}
+                    authored = baseActivity{aaExchanges = [techInput supplierPid 3 Nothing]}
+                case validateAuthored ctx [authored] of
+                    Left errs -> expectationFailure ("expected acceptance, got " <> show errs)
+                    Right ([r], _) -> do
+                        map tfName (riNewTechFlows r) `shouldSatisfy` elem "milk"
+                        [tfUnitId f | f <- riNewTechFlows r, tfName f == "milk"] `shouldBe` [kgUnitId]
+                    Right (rs, _) -> expectationFailure ("expected one insert, got " <> show (length rs))
+
+            it "refuses a dependency's supplier whose product unit is not here" $ do
+                -- Same rule the biosphere side states: a flow copied in has to
+                -- carry a unit this database can name, or the link would read
+                -- its unit out of the wrong table. Two databases are two unit
+                -- tables, so the dependency records its product in one the
+                -- writing database does not have.
+                built <- buildFixture
+                let depDb =
+                        built
+                            { dbTechFlows =
+                                M.adjust (\f -> f{tfUnitId = metreUnitId}) supplierProdId (dbTechFlows built)
+                            }
+                    writing =
+                        (emptyOf fixtureDb)
+                            { dbTechFlows = M.empty
+                            , dbUnits = M.delete metreUnitId (dbUnits fixtureDb)
+                            }
+                    ctx = (contextOf writing){acDeps = [depDb]}
+                case validateAuthored ctx [baseActivity{aaExchanges = [techInput supplierPid 3 Nothing]}] of
+                    Left errs ->
+                        errs `shouldSatisfy` any (isInfixOf "a unit this database does not have")
+                    Right _ -> expectationFailure "expected a refusal on the copied flow's unit"
+
             it "warns about a biosphere flow new to the database without refusing it" $ do
                 let authored = baseActivity{aaExchanges = [bioOf (FlowByName "Nitrous oxide" air "kg") 0.5 Nothing]}
                 case validateAuthored (contextOf fixtureDb) [authored] of
@@ -441,6 +479,17 @@ spec = do
                 eaMatched edited `shouldBe` [1]
                 map bfName (eaNewBioFlows edited) `shouldBe` ["Nitrous oxide"]
                 eaWarnings edited `shouldSatisfy` any (isInfixOf "no characterization factor matches it")
+
+            it "brings along the product flow an added dependency line needs" $ do
+                -- The technosphere twin of the line above: an added input whose
+                -- supplier lives in a dependency has to bring that supplier's
+                -- product flow with it, or the relink drops the line.
+                depDb <- buildFixture
+                let writing = (emptyOf fixtureDb){dbTechFlows = M.empty}
+                    ctx = (contextOf writing){acDeps = [depDb]}
+                case applyExchangeEdits ctx [AddExchange (techInput supplierPid 2 Nothing)] importedActivity of
+                    Left errs -> expectationFailure ("expected acceptance, got " <> show errs)
+                    Right edited -> map tfName (eaNewTechFlows edited) `shouldBe` ["milk"]
 
             it "refuses a selector that matches nothing" $
                 editRefused "matches no exchange" [RemoveExchange (SelectBiosphere (mkUUID 998))]

--- a/test/AuthorSpec.hs
+++ b/test/AuthorSpec.hs
@@ -218,6 +218,36 @@ spec = do
                         [tfUnitId f | f <- riNewTechFlows r, tfName f == "milk"] `shouldBe` [kgUnitId]
                     Right (rs, _) -> expectationFailure ("expected one insert, got " <> show (length rs))
 
+            it "refuses an amount to a dependency stated in another unit than its product's" $ do
+                -- The link into a dependency carries the flow's unit, not the
+                -- exchange's, and the matrix converts the raw amount from it.
+                -- A unit the local path would convert would land here as a
+                -- number in the wrong one, which is the silent kind of wrong.
+                built <- buildFixture
+                let depDb =
+                        built
+                            { dbTechFlows =
+                                M.adjust (\f -> f{tfUnitId = metreUnitId}) supplierProdId (dbTechFlows built)
+                            }
+                    writing = (emptyOf fixtureDb){dbTechFlows = M.empty}
+                    ctx = (contextOf writing){acDeps = [depDb]}
+                case validateAuthored ctx [baseActivity{aaExchanges = [techInput supplierPid 3 Nothing]}] of
+                    Left errs ->
+                        errs `shouldSatisfy` any (isInfixOf "is not converted, so restate it")
+                    Right _ -> expectationFailure "expected a refusal on the unit the amount is stated in"
+
+            it "takes a dependency's supplier in its product's own unit" $ do
+                -- The ordinary case, and the one the refusal above must not
+                -- catch: the flow and the reference exchange agree, so an
+                -- omitted unit defaults to the right one.
+                depDb <- buildFixture
+                let writing = (emptyOf fixtureDb){dbTechFlows = M.empty}
+                    ctx = (contextOf writing){acDeps = [depDb]}
+                case validateAuthored ctx [baseActivity{aaExchanges = [techInput supplierPid 3 (Just "kg")]}] of
+                    Left errs -> expectationFailure ("expected acceptance, got " <> show errs)
+                    Right ([_], _) -> pure ()
+                    Right (rs, _) -> expectationFailure ("expected one insert, got " <> show (length rs))
+
             it "refuses a dependency's supplier whose product unit is not here" $ do
                 -- Same rule the biosphere side states: a flow copied in has to
                 -- carry a unit this database can name, or the link would read

--- a/test/JournalSpec.hs
+++ b/test/JournalSpec.hs
@@ -169,6 +169,17 @@ spec = do
                 Left err -> expectationFailure ("replay: " <> show err)
                 Right db -> map bfName (M.elems (dbBioFlows db)) `shouldSatisfy` elem "Methane"
 
+        it "brings along the product flow an added dependency line needs" $ do
+            -- The technosphere twin of the line above. A replay that dropped
+            -- the flow would rebuild a database whose exchange links nothing,
+            -- and the edit would score zero where the live one did not.
+            depDb <- buildDepFixture
+            let depCtx = ctx{acDeps = [depDb]}
+                added = AuthoredTechInput depPid 2.0 (Just "kg") Nothing
+            case replayJournal depCtx [event (Edited supplierPid [(AddExchange added, 1)])] of
+                Left err -> expectationFailure ("replay: " <> show err)
+                Right db -> M.member depProdId (dbTechFlows db) `shouldBe` True
+
         it "refuses an edit whose selectors no longer match what they matched" $
             -- The guard that makes a recorded edit safe to replay: the
             -- inventory it was made against must still be the one it named.
@@ -366,6 +377,21 @@ expectedEditJSON =
 -- Fixture: one supplier producing milk in kg, emitting CO2
 -- ---------------------------------------------------------------------------
 
+{- | A second database, sharing nothing with the fixture but its unit table:
+the dependency a replayed edit consumes from.
+-}
+buildDepFixture :: IO Database
+buildDepFixture = do
+    built <-
+        buildDatabaseWithMatrices
+            (BuildInputs defaultUnitConfig mempty)
+            (M.singleton (depActId, depProdId) depActivity)
+            (M.singleton depProdId wheatFlow)
+            M.empty
+            M.empty
+            unitTable
+    either (fail . show) pure built
+
 buildFixture :: IO Database
 buildFixture = do
     built <-
@@ -381,14 +407,50 @@ buildFixture = do
 mkUUID :: Int -> UUID
 mkUUID n = UUID.fromWords64 (fromIntegral n) 0
 
-supplierActId, supplierProdId, co2Id, kgUnitId :: UUID
+supplierActId, supplierProdId, co2Id, depActId, depProdId, kgUnitId :: UUID
 supplierActId = mkUUID 1
 supplierProdId = mkUUID 2
 co2Id = mkUUID 3
+depActId = mkUUID 4
+depProdId = mkUUID 5
 kgUnitId = mkUUID 10
 
-supplierPid :: Text
+supplierPid, depPid :: Text
 supplierPid = renderKey (supplierActId, supplierProdId)
+depPid = renderKey (depActId, depProdId)
+
+wheatFlow :: TechnosphereFlow
+wheatFlow =
+    TechnosphereFlow
+        { tfId = depProdId
+        , tfName = "wheat"
+        , tfUnitId = kgUnitId
+        , tfSynonyms = M.empty
+        , tfCAS = Nothing
+        , tfSubstanceId = Nothing
+        }
+
+-- | The dependency's one activity: a reference product and nothing else.
+depActivity :: Activity
+depActivity =
+    supplierActivity
+        { activityName = "wheat production"
+        , exchanges =
+            [ TechnosphereExchange
+                { techFlowId = depProdId
+                , techAmount = 1.0
+                , techUnitId = kgUnitId
+                , techRole = ReferenceProduct
+                , techActivityLinkId = depActId
+                , techProcessLinkId = Nothing
+                , techLocation = ""
+                , techComment = Nothing
+                , techPedigree = Nothing
+                , techShare = Nothing
+                , techClassification = M.empty
+                }
+            ]
+        }
 
 unitTable :: M.Map UUID Unit
 unitTable =


### PR DESCRIPTION
## The symptom

Writing an activity whose supplier lives in an attached dependency was **accepted**, and then that input contributed **nothing**. The exchange carried the right activity link, but its flow showed as `<unresolved flow ...>`, `supply-chain` came back empty, and every impact score was 0.0.

An accepted write that silently contributes zero is worse than a refused one: the caller has no way to tell.

## What was actually missing

Resolving a supplier that lives in a dependency is deliberate. The `Supplier` comment says such a provider "resolves the same way through cross-database relinking", and a test requires that resolution to succeed. That part was right.

What was missing came one step later. `findExchangeCrossDBLink` opens on `M.lookup fid techFlowDb`, where `techFlowDb` is the **consumer's** own flow table, and returns `mempty` when the flow is not in it. And the writing path only ever carried the authored activity's own product flow, never the one it was consuming from the dependency.

The biosphere side has always known this rule and states it in words: "an exchange must never reference a flow only a dependency declares". `emitKnown` copies the dependency's flow in, with its unit remapped into the writing database's table. The technosphere side did not. That asymmetry was the whole defect.

## The change

The product flow is copied the same way `emitKnown` copies a biosphere one, with its unit remapped, and a product stated in a unit the writing database does not have is refused rather than copied into a table that could not name it.

Three paths carried the omission, and a fix to fewer than three would have been half a fix:

- writing an activity;
- adding a line to an existing inventory (the edit step only ever carried biosphere flows);
- replaying either of those from a journal, which hardcoded an empty list.

Nothing downstream needed adding: the rebuild already merges the list into the flow table, and the relink makes the link itself.

## How it was checked

Two small databases, one attached as the other's dependency, and one authored activity consuming a supplier from the dependency. The same binary, the same fixtures, only the two source files differing:

| | supply chain | elementary flows |
|---|---|---|
| before | empty | 0 |
| after | names the dependency's activity | 1 |

A unit test alone would not have proved this: the existing test passed the whole time the score was zero. So the suite gains three that bite on the actual mechanism, one per path, and the full suite is green (2404 examples). Built cold with `-Werror`; fourmolu and hlint clean.

No wire change: nothing about the shape on the wire moves, only what reaches the matrix behind it.