### PR TITLE
Report what the mass would allocate, beside the declared share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 ### Added
 - The products of a multi-output block now each report what their share
-  would be if the allocation key were their mass (`massPercent`), beside
+  would be if the allocation key were their mass (`massAllocationPercent`), beside
   the share the source declared. Nothing is split and nothing is scored
   differently: it is a second column to read against the first, and the
   impact per kilo under one key over the other is the quotient of the two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,19 @@
   same exchange to a local supplier is converted. It is refused, naming the
   unit to restate it in.
 
+### Added
+- The products of a multi-output block now each report what their share
+  would be if the allocation key were their mass (`massPercent`), beside
+  the share the source declared. Nothing is split and nothing is scored
+  differently: it is a second column to read against the first, and the
+  impact per kilo under one key over the other is the quotient of the two
+  numbers. The Abondance cheese block of a French agricultural database
+  declares 51.4 % to the cheese where its mass is 11.7 % of the block, so
+  a kilo of that cheese carries 4.4 times more under the declared key than
+  under the mass. Amounts are converted to kilograms before being summed,
+  and a block whose products are not all stated in a mass reports nothing
+  rather than a number read off mismatched units. Wire revision 15.
+
 ## [0.12.0] - 2026-09-02
 
 ### Added

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -24,7 +24,7 @@ The other direction is a promise about pyvolca's own names. A name this client p
 
 _Generated from `volca._compat`: run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.11.0** speaks wire formats **2 to 14** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error. A name this build has retired keeps working until pyvolca **1.0**.
+This build of **pyvolca 0.11.0** speaks wire formats **2 to 15** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error. A name this build has retired keeps working until pyvolca **1.0**.
 
 <!-- END: compatibility -->
 
@@ -1263,6 +1263,14 @@ processes. ``allocation_formula`` carries the raw symbolic formula when
 the source expressed the share as an expression rather than a number,
 else ``None``.
 
+``mass_percent`` is the share the same product would carry if the key
+were its mass rather than what the source declared, so the two read
+side by side: the cheese above is declared 51.4 % of its block where its
+mass is 11.7 %, and a kilo of it therefore carries 4.4 times more under
+the declared key. It is ``None`` outside an activity's own product list,
+when the block's products are not all stated in a mass, and against an
+engine older than wire revision 15.
+
 | Field | Type | Default |
 |-------|------|---------|
 | `process_id` | `str` | _required_ |
@@ -1273,6 +1281,7 @@ else ``None``.
 | `product_unit` | `str` | _required_ |
 | `allocation_percent` | `float \| None` | None |
 | `allocation_formula` | `str \| None` | None |
+| `mass_percent` | `float \| None` | None |
 
 ### `ActivityContribution`
 

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -1263,7 +1263,7 @@ processes. ``allocation_formula`` carries the raw symbolic formula when
 the source expressed the share as an expression rather than a number,
 else ``None``.
 
-``mass_percent`` is the share the same product would carry if the key
+``mass_allocation_percent`` is the share the same product would carry if the key
 were its mass rather than what the source declared, so the two read
 side by side: the cheese above is declared 51.4 % of its block where its
 mass is 11.7 %, and a kilo of it therefore carries 4.4 times more under
@@ -1281,7 +1281,7 @@ engine older than wire revision 15.
 | `product_unit` | `str` | _required_ |
 | `allocation_percent` | `float \| None` | None |
 | `allocation_formula` | `str \| None` | None |
-| `mass_percent` | `float \| None` | None |
+| `mass_allocation_percent` | `float \| None` | None |
 
 ### `ActivityContribution`
 

--- a/pyvolca/src/volca/_compat.py
+++ b/pyvolca/src/volca/_compat.py
@@ -34,7 +34,7 @@ before sending anything."""
 
 KNOWN_WIRE = 15
 """The newest wire revision this pyvolca understands (revision 15 adds
-``mass_percent`` on a product of a multi-output block, the share it would
+``mass_allocation_percent`` on a product of a multi-output block, the share it would
 carry if the allocation key were its mass; revision 14 added the
 ``AvoidedProduct`` exchange role, the ``unallocated`` quality check and the
 ``share`` and ``classification`` fields of a technosphere exchange; revision

--- a/pyvolca/src/volca/_compat.py
+++ b/pyvolca/src/volca/_compat.py
@@ -33,7 +33,9 @@ the client works against it except the revision-gated capabilities (see
 before sending anything."""
 
 KNOWN_WIRE = 15
-"""The newest wire revision this pyvolca understands (revision 14 adds the
+"""The newest wire revision this pyvolca understands (revision 15 adds
+``mass_percent`` on a product of a multi-output block, the share it would
+carry if the allocation key were its mass; revision 14 added the
 ``AvoidedProduct`` exchange role, the ``unallocated`` quality check and the
 ``share`` and ``classification`` fields of a technosphere exchange; revision
 13 added the compartment an unmapped factor of the mapping report carries;

--- a/pyvolca/src/volca/_compat.py
+++ b/pyvolca/src/volca/_compat.py
@@ -32,7 +32,7 @@ the client works against it except the revision-gated capabilities (see
 ``Client._require_wire``), which check the engine's advertised revision
 before sending anything."""
 
-KNOWN_WIRE = 14
+KNOWN_WIRE = 15
 """The newest wire revision this pyvolca understands (revision 14 adds the
 ``AvoidedProduct`` exchange role, the ``unallocated`` quality check and the
 ``share`` and ``classification`` fields of a technosphere exchange; revision

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -549,7 +549,7 @@ class Activity(FromJson):
     the source expressed the share as an expression rather than a number,
     else ``None``.
 
-    ``mass_percent`` is the share the same product would carry if the key
+    ``mass_allocation_percent`` is the share the same product would carry if the key
     were its mass rather than what the source declared, so the two read
     side by side: the cheese above is declared 51.4 % of its block where its
     mass is 11.7 %, and a kilo of it therefore carries 4.4 times more under
@@ -566,7 +566,7 @@ class Activity(FromJson):
     product_unit: str
     allocation_percent: float | None = None
     allocation_formula: str | None = None
-    mass_percent: float | None = None
+    mass_allocation_percent: float | None = None
 
 
 @dataclass

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -548,6 +548,14 @@ class Activity(FromJson):
     processes. ``allocation_formula`` carries the raw symbolic formula when
     the source expressed the share as an expression rather than a number,
     else ``None``.
+
+    ``mass_percent`` is the share the same product would carry if the key
+    were its mass rather than what the source declared, so the two read
+    side by side: the cheese above is declared 51.4 % of its block where its
+    mass is 11.7 %, and a kilo of it therefore carries 4.4 times more under
+    the declared key. It is ``None`` outside an activity's own product list,
+    when the block's products are not all stated in a mass, and against an
+    engine older than wire revision 15.
     """
 
     process_id: str
@@ -558,6 +566,7 @@ class Activity(FromJson):
     product_unit: str
     allocation_percent: float | None = None
     allocation_formula: str | None = None
+    mass_percent: float | None = None
 
 
 @dataclass

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1301,7 +1301,9 @@ appears that a client must know about /before/ calling it. Adding a route
 does not exempt a change from the bump: an absent route answers 404, and so
 does a request naming a database the engine has not loaded, so a client
 cannot tell "this engine is too old" from "you asked for the wrong thing"
-(revision 14: the @AvoidedProduct@ role a technosphere exchange can report,
+(revision 15: the @massPercent@ a product of a multi-output block carries
+beside its declared share, saying what the mass would allocate;
+revision 14: the @AvoidedProduct@ role a technosphere exchange can report,
 which a client decoding the role enumeration has to know, the @unallocated@
 check of the quality report, and the @share@ and @classification@ fields a
 technosphere exchange carries;
@@ -1324,7 +1326,7 @@ the whole filtered set).
 Clients compare it to decide compatibility and to gate such capabilities.
 -}
 currentWireVersion :: Int
-currentWireVersion = 14
+currentWireVersion = 15
 
 getVersion :: AppM Value
 getVersion = do

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1301,7 +1301,7 @@ appears that a client must know about /before/ calling it. Adding a route
 does not exempt a change from the bump: an absent route answers 404, and so
 does a request naming a database the engine has not loaded, so a client
 cannot tell "this engine is too old" from "you asked for the wrong thing"
-(revision 15: the @massPercent@ a product of a multi-output block carries
+(revision 15: the @massAllocationPercent@ a product of a multi-output block carries
 beside its declared share, saying what the mass would allocate;
 revision 14: the @AvoidedProduct@ role a technosphere exchange can report,
 which a client decoding the role enumeration has to know, the @unallocated@

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -193,7 +193,7 @@ data ActivitySummary = ActivitySummary
     , prsProductUnit :: Text -- Reference product unit name
     , prsAllocationPercent :: Maybe Double -- SimaPro coproduct allocation (%, 0..100); Nothing for non-allocated bases
     , prsAllocationFormula :: Maybe Text -- Raw SimaPro allocation formula; Nothing if purely numeric
-    , prsMassPercent :: Maybe Double -- What the share would be if the key were the product's mass (%, 0..100), to be read beside the declared one; Nothing outside a block's own product list, on a block of one product or one whose source declares no share, and when its products are not all stated in a mass
+    , prsMassAllocationPercent :: Maybe Double -- What the share would be if the key were the product's mass (%, 0..100), to be read beside the declared one; Nothing outside a block's own product list, on a block of one product or one whose source declares no share, and when its products are not all stated in a mass
     , prsNativeType :: Maybe NativeActivityType -- Source-native activity type (ecospold @activityType, SimaPro Type, ILCD processType); Nothing when source lacks the field
     }
     deriving (Generic)

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -193,6 +193,7 @@ data ActivitySummary = ActivitySummary
     , prsProductUnit :: Text -- Reference product unit name
     , prsAllocationPercent :: Maybe Double -- SimaPro coproduct allocation (%, 0..100); Nothing for non-allocated bases
     , prsAllocationFormula :: Maybe Text -- Raw SimaPro allocation formula; Nothing if purely numeric
+    , prsMassPercent :: Maybe Double -- What the share would be if the key were the product's mass (%, 0..100), to be read beside the declared one; Nothing outside a block's own product list, and when its products are not all stated in a mass
     , prsNativeType :: Maybe NativeActivityType -- Source-native activity type (ecospold @activityType, SimaPro Type, ILCD processType); Nothing when source lacks the field
     }
     deriving (Generic)

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -193,7 +193,7 @@ data ActivitySummary = ActivitySummary
     , prsProductUnit :: Text -- Reference product unit name
     , prsAllocationPercent :: Maybe Double -- SimaPro coproduct allocation (%, 0..100); Nothing for non-allocated bases
     , prsAllocationFormula :: Maybe Text -- Raw SimaPro allocation formula; Nothing if purely numeric
-    , prsMassPercent :: Maybe Double -- What the share would be if the key were the product's mass (%, 0..100), to be read beside the declared one; Nothing outside a block's own product list, and when its products are not all stated in a mass
+    , prsMassPercent :: Maybe Double -- What the share would be if the key were the product's mass (%, 0..100), to be read beside the declared one; Nothing outside a block's own product list, on a block of one product or one whose source declares no share, and when its products are not all stated in a mass
     , prsNativeType :: Maybe NativeActivityType -- Source-native activity type (ecospold @activityType, SimaPro Type, ILCD processType); Nothing when source lacks the field
     }
     deriving (Generic)

--- a/src/Database/Allocation.hs
+++ b/src/Database/Allocation.hs
@@ -33,6 +33,7 @@ module Database.Allocation (
     describeRefusal,
     scaleExchange,
     MassKeyRefusal (..),
+    StatedAmount (..),
     massShares,
 ) where
 
@@ -130,6 +131,13 @@ describeRefusal refusal = case refusal of
     NoSingleReference 0 -> "no reference exchange: one product output must be the reference"
     NoSingleReference k -> T.pack (show k) <> " reference exchanges where exactly one is needed"
 
+-- | One product row's amount and the unit it states that amount in.
+data StatedAmount = StatedAmount
+    { saUnit :: !Text
+    , saAmount :: !Double
+    }
+    deriving (Eq, Show)
+
 -- | Why the mass of a block's products cannot serve as a key.
 data MassKeyRefusal
     = -- | The unit a product is stated in, which is not a mass.
@@ -151,13 +159,15 @@ written would hand the half-kilo of a 1 kg / 500 g pair 99.8 % of the load.
 A unit that is not a mass, or an amount at or below zero, refuses the whole
 block rather than dropping one product to a silent zero.
 -}
-massShares :: UnitConfig -> NonEmpty (Text, Double) -> Either MassKeyRefusal (NonEmpty Double)
+massShares :: UnitConfig -> NonEmpty StatedAmount -> Either MassKeyRefusal (NonEmpty Double)
 massShares cfg products = share <$> traverse mass products
   where
-    mass :: (Text, Double) -> Either MassKeyRefusal Double
-    mass (unitName, amount)
-        | amount <= 0 = Left (NonPositiveMass amount)
-        | otherwise = maybe (Left (NotAMass unitName)) Right (convertUnit cfg unitName "kg" amount)
+    mass :: StatedAmount -> Either MassKeyRefusal Double
+    mass stated
+        | saAmount stated <= 0 = Left (NonPositiveMass (saAmount stated))
+        | otherwise =
+            maybe (Left (NotAMass (saUnit stated))) Right $
+                convertUnit cfg (saUnit stated) "kg" (saAmount stated)
 
     -- Every mass is strictly positive, so their total is too.
     share :: NonEmpty Double -> NonEmpty Double

--- a/src/Database/Allocation.hs
+++ b/src/Database/Allocation.hs
@@ -32,6 +32,8 @@ module Database.Allocation (
     asAllocated,
     describeRefusal,
     scaleExchange,
+    MassKeyRefusal (..),
+    massShares,
 ) where
 
 import Data.List (partition)
@@ -42,6 +44,7 @@ import Data.Maybe (fromMaybe, isNothing)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Types
+import UnitConversion (UnitConfig, convertUnit)
 
 -- | How the shares of a multi-output activity are decided.
 data AllocationKey
@@ -126,6 +129,39 @@ describeRefusal refusal = case refusal of
             <> " without a declared share: state a share on every product row, or load the dataset already allocated"
     NoSingleReference 0 -> "no reference exchange: one product output must be the reference"
     NoSingleReference k -> T.pack (show k) <> " reference exchanges where exactly one is needed"
+
+-- | Why the mass of a block's products cannot serve as a key.
+data MassKeyRefusal
+    = -- | The unit a product is stated in, which is not a mass.
+      NotAMass !Text
+    | -- | The amount a product states, which no share can be read from.
+      NonPositiveMass !Double
+    deriving (Eq, Show)
+
+{- | The share each product of one source block would carry if the key were
+its mass, as percentages in the order given.
+
+This is not an 'AllocationKey'. Nothing is split and nothing is scored: it
+answers what the mass would say beside what the source declared, and the
+reader draws the comparison. An impact per kilo is the quotient of the two
+fractions, so the whole comparison follows from these numbers alone.
+
+Every amount is converted to kilograms first, because summing amounts as
+written would hand the half-kilo of a 1 kg / 500 g pair 99.8 % of the load.
+A unit that is not a mass, or an amount at or below zero, refuses the whole
+block rather than dropping one product to a silent zero.
+-}
+massShares :: UnitConfig -> NonEmpty (Text, Double) -> Either MassKeyRefusal (NonEmpty Double)
+massShares cfg products = share <$> traverse mass products
+  where
+    mass :: (Text, Double) -> Either MassKeyRefusal Double
+    mass (unitName, amount)
+        | amount <= 0 = Left (NonPositiveMass amount)
+        | otherwise = maybe (Left (NotAMass unitName)) Right (convertUnit cfg unitName "kg" amount)
+
+    -- Every mass is strictly positive, so their total is too.
+    share :: NonEmpty Double -> NonEmpty Double
+    share masses = (* (100 / sum masses)) <$> masses
 
 {- | The two rules the EcoSpold parsers used to apply to every dataset: a
 zero-amount coproduct the source states no share for is not an output, and

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -290,7 +290,7 @@ convertToInventoryExport db bioFlowDB unitDB processId rootActivity inventory =
                         , prsProductUnit = prodUnit
                         , prsAllocationPercent = dsPercent <$> activityReferenceShare rootActivity
                         , prsAllocationFormula = dsFormula =<< activityReferenceShare rootActivity
-                        , prsMassPercent = Nothing
+                        , prsMassAllocationPercent = Nothing
                         , prsNativeType = activityNativeType rootActivity
                         }
                 , imTotalFlows = length flowDetails
@@ -1268,7 +1268,7 @@ mkActivitySummary db processId activity =
             , prsProductUnit = prodUnit
             , prsAllocationPercent = dsPercent <$> activityReferenceShare activity
             , prsAllocationFormula = dsFormula =<< activityReferenceShare activity
-            , prsMassPercent = Nothing
+            , prsMassAllocationPercent = Nothing
             , prsNativeType = activityNativeType activity
             }
 
@@ -1287,7 +1287,7 @@ unknownActivitySummary db pid =
         , prsProductUnit = ""
         , prsAllocationPercent = Nothing
         , prsAllocationFormula = Nothing
-        , prsMassPercent = Nothing
+        , prsMassAllocationPercent = Nothing
         , prsNativeType = Nothing
         }
 
@@ -1300,7 +1300,7 @@ getAllProductsForActivity db groupKey =
     case M.lookup groupKey (dbActivityProductsIndex db) of
         Nothing -> []
         Just processIds ->
-            withMassPercent (biUnitConfig (dbBuiltWith db)) $
+            withMassAllocationPercent (biUnitConfig (dbBuiltWith db)) $
                 [ maybe (unknownActivitySummary db pid) (mkActivitySummary db pid) (findActivityByProcessId db pid)
                 | pid <- processIds
                 ]
@@ -1318,8 +1318,8 @@ nothing to be compared against.
 Left as it is again when the mass cannot serve as a key. The comparison is one
 extra column, so a block whose products are not all stated in a mass has none.
 -}
-withMassPercent :: UnitConfig -> [ActivitySummary] -> [ActivitySummary]
-withMassPercent unitCfg summaries
+withMassAllocationPercent :: UnitConfig -> [ActivitySummary] -> [ActivitySummary]
+withMassAllocationPercent unitCfg summaries
     | length summaries < 2 = summaries
     | not (all (isJust . prsAllocationPercent) summaries) = summaries
     | otherwise = maybe summaries attachAll (NE.nonEmpty summaries)
@@ -1335,7 +1335,7 @@ withMassPercent unitCfg summaries
     stated s = StatedAmount{saUnit = prsProductUnit s, saAmount = prsProductAmount s}
 
     attach :: ActivitySummary -> Double -> ActivitySummary
-    attach s percent = s{prsMassPercent = Just percent}
+    attach s percent = s{prsMassAllocationPercent = Just percent}
 
 -- | Get target activity for technosphere navigation.
 getTargetActivity :: Database -> Exchange -> Maybe ActivitySummary
@@ -1388,7 +1388,7 @@ crossDBLinkToSummary link =
         , prsProductUnit = cdlExchangeUnit link
         , prsAllocationPercent = Nothing
         , prsAllocationFormula = Nothing
-        , prsMassPercent = Nothing
+        , prsMassAllocationPercent = Nothing
         , prsNativeType = Nothing
         }
 
@@ -1777,7 +1777,7 @@ buildSupplyChainFromScalingVector db dbName processId supplyVec scf includeEdges
                 , prsProductUnit = activityUnit rootActivity
                 , prsAllocationPercent = dsPercent <$> activityReferenceShare rootActivity
                 , prsAllocationFormula = dsFormula =<< activityReferenceShare rootActivity
-                , prsMassPercent = Nothing
+                , prsMassAllocationPercent = Nothing
                 , prsNativeType = activityNativeType rootActivity
                 }
      in SupplyChainResponse
@@ -1840,7 +1840,7 @@ buildSupplyChainFromScalingVectorCrossDB unitCfg depLookup rootDb rootDbName roo
                 , prsProductUnit = activityUnit rootActivity
                 , prsAllocationPercent = dsPercent <$> activityReferenceShare rootActivity
                 , prsAllocationFormula = dsFormula =<< activityReferenceShare rootActivity
-                , prsMassPercent = Nothing
+                , prsMassAllocationPercent = Nothing
                 , prsNativeType = activityNativeType rootActivity
                 }
     eDep <- walkDepLevels unitCfg depLookup rootDb rootScaling extraLinks scf includeEdges 1 S.empty

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -1308,12 +1308,21 @@ getAllProductsForActivity db groupKey =
 {- | Fill in what each product of one block would carry under a mass key, to be
 read beside the share its source declared.
 
-The list is left as it is when the mass cannot serve as a key here. The
-comparison is one extra column, so a block whose products are not all stated in
-a mass simply has none.
+Only a block of several products, each carrying a share its source stated,
+gets one. That condition is what says these amounts are the joint outputs of
+one run: a database whose datasets arrive already allocated declares no share
+and normalises each product to one of its own unit, so summing those amounts
+would compare quantities that never occurred together. And a lone product has
+nothing to be compared against.
+
+Left as it is again when the mass cannot serve as a key. The comparison is one
+extra column, so a block whose products are not all stated in a mass has none.
 -}
 withMassPercent :: UnitConfig -> [ActivitySummary] -> [ActivitySummary]
-withMassPercent unitCfg summaries = maybe summaries attachAll (NE.nonEmpty summaries)
+withMassPercent unitCfg summaries
+    | length summaries < 2 = summaries
+    | not (all (isJust . prsAllocationPercent) summaries) = summaries
+    | otherwise = maybe summaries attachAll (NE.nonEmpty summaries)
   where
     attachAll :: NE.NonEmpty ActivitySummary -> [ActivitySummary]
     attachAll block =

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -30,7 +30,7 @@ import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import Database (applyStructuredFilters, findActivitiesByFields, findFlowsBySynonym, flowNameRelevance)
-import Database.Allocation (asAllocated, describeRefusal)
+import Database.Allocation (asAllocated, describeRefusal, massShares)
 import Database.MatrixBuild (findProducer, linkedProducer)
 import Matrix (DepDemands, Inventory, accumulateDepDemandsWith, activityNormalizationFactor, applyBiosphereMatrix, buildDemandVectorFromIndex, computeInventoryMatrix, depDemandsToVector, perturbA, perturbABatch, perturbGlobal, toList)
 import qualified Matrix.Export as MatrixExport
@@ -290,6 +290,7 @@ convertToInventoryExport db bioFlowDB unitDB processId rootActivity inventory =
                         , prsProductUnit = prodUnit
                         , prsAllocationPercent = dsPercent <$> activityReferenceShare rootActivity
                         , prsAllocationFormula = dsFormula =<< activityReferenceShare rootActivity
+                        , prsMassPercent = Nothing
                         , prsNativeType = activityNativeType rootActivity
                         }
                 , imTotalFlows = length flowDetails
@@ -1267,6 +1268,7 @@ mkActivitySummary db processId activity =
             , prsProductUnit = prodUnit
             , prsAllocationPercent = dsPercent <$> activityReferenceShare activity
             , prsAllocationFormula = dsFormula =<< activityReferenceShare activity
+            , prsMassPercent = Nothing
             , prsNativeType = activityNativeType activity
             }
 
@@ -1285,6 +1287,7 @@ unknownActivitySummary db pid =
         , prsProductUnit = ""
         , prsAllocationPercent = Nothing
         , prsAllocationFormula = Nothing
+        , prsMassPercent = Nothing
         , prsNativeType = Nothing
         }
 
@@ -1297,9 +1300,33 @@ getAllProductsForActivity db groupKey =
     case M.lookup groupKey (dbActivityProductsIndex db) of
         Nothing -> []
         Just processIds ->
-            [ maybe (unknownActivitySummary db pid) (mkActivitySummary db pid) (findActivityByProcessId db pid)
-            | pid <- processIds
-            ]
+            withMassPercent (biUnitConfig (dbBuiltWith db)) $
+                [ maybe (unknownActivitySummary db pid) (mkActivitySummary db pid) (findActivityByProcessId db pid)
+                | pid <- processIds
+                ]
+
+{- | Fill in what each product of one block would carry under a mass key, to be
+read beside the share its source declared.
+
+The list is left as it is when the mass cannot serve as a key here. The
+comparison is one extra column, so a block whose products are not all stated in
+a mass simply has none.
+-}
+withMassPercent :: UnitConfig -> [ActivitySummary] -> [ActivitySummary]
+withMassPercent unitCfg summaries = maybe summaries attachAll (NE.nonEmpty summaries)
+  where
+    attachAll :: NE.NonEmpty ActivitySummary -> [ActivitySummary]
+    attachAll block =
+        either
+            (const summaries)
+            (NE.toList . NE.zipWith attach block)
+            (massShares unitCfg (NE.map stated block))
+
+    stated :: ActivitySummary -> (Text, Double)
+    stated s = (prsProductUnit s, prsProductAmount s)
+
+    attach :: ActivitySummary -> Double -> ActivitySummary
+    attach s percent = s{prsMassPercent = Just percent}
 
 -- | Get target activity for technosphere navigation.
 getTargetActivity :: Database -> Exchange -> Maybe ActivitySummary
@@ -1352,6 +1379,7 @@ crossDBLinkToSummary link =
         , prsProductUnit = cdlExchangeUnit link
         , prsAllocationPercent = Nothing
         , prsAllocationFormula = Nothing
+        , prsMassPercent = Nothing
         , prsNativeType = Nothing
         }
 
@@ -1740,6 +1768,7 @@ buildSupplyChainFromScalingVector db dbName processId supplyVec scf includeEdges
                 , prsProductUnit = activityUnit rootActivity
                 , prsAllocationPercent = dsPercent <$> activityReferenceShare rootActivity
                 , prsAllocationFormula = dsFormula =<< activityReferenceShare rootActivity
+                , prsMassPercent = Nothing
                 , prsNativeType = activityNativeType rootActivity
                 }
      in SupplyChainResponse
@@ -1802,6 +1831,7 @@ buildSupplyChainFromScalingVectorCrossDB unitCfg depLookup rootDb rootDbName roo
                 , prsProductUnit = activityUnit rootActivity
                 , prsAllocationPercent = dsPercent <$> activityReferenceShare rootActivity
                 , prsAllocationFormula = dsFormula =<< activityReferenceShare rootActivity
+                , prsMassPercent = Nothing
                 , prsNativeType = activityNativeType rootActivity
                 }
     eDep <- walkDepLevels unitCfg depLookup rootDb rootScaling extraLinks scf includeEdges 1 S.empty

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -30,7 +30,7 @@ import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import Database (applyStructuredFilters, findActivitiesByFields, findFlowsBySynonym, flowNameRelevance)
-import Database.Allocation (asAllocated, describeRefusal, massShares)
+import Database.Allocation (StatedAmount (..), asAllocated, describeRefusal, massShares)
 import Database.MatrixBuild (findProducer, linkedProducer)
 import Matrix (DepDemands, Inventory, accumulateDepDemandsWith, activityNormalizationFactor, applyBiosphereMatrix, buildDemandVectorFromIndex, computeInventoryMatrix, depDemandsToVector, perturbA, perturbABatch, perturbGlobal, toList)
 import qualified Matrix.Export as MatrixExport
@@ -1322,8 +1322,8 @@ withMassPercent unitCfg summaries = maybe summaries attachAll (NE.nonEmpty summa
             (NE.toList . NE.zipWith attach block)
             (massShares unitCfg (NE.map stated block))
 
-    stated :: ActivitySummary -> (Text, Double)
-    stated s = (prsProductUnit s, prsProductAmount s)
+    stated :: ActivitySummary -> StatedAmount
+    stated s = StatedAmount{saUnit = prsProductUnit s, saAmount = prsProductAmount s}
 
     attach :: ActivitySummary -> Double -> ActivitySummary
     attach s percent = s{prsMassPercent = Just percent}

--- a/test/AllocationSpec.hs
+++ b/test/AllocationSpec.hs
@@ -29,8 +29,8 @@ import Types
 import UnitConversion (UnitConfig, UnitDef (..), defaultUnitConfig, mkUnitConfig, ucDimensionOrder, ucOriginalKeys, ucUnits)
 
 -- | Amounts of the five products of the Abondance cheese block, in kilograms.
-abondance :: NE.NonEmpty (Text, Double)
-abondance = NE.fromList [("kg", q) | q <- [1.0, 5.58318, 1.12527, 0.775791, 0.0686462]]
+abondance :: NE.NonEmpty StatedAmount
+abondance = NE.fromList [StatedAmount{saUnit = "kg", saAmount = q} | q <- [1.0, 5.58318, 1.12527, 0.775791, 0.0686462]]
 
 -- | 'defaultUnitConfig' plus a gram and a megajoule, to have a second mass and a non-mass.
 massUnits :: UnitConfig
@@ -43,6 +43,9 @@ massUnits =
     mass, energy :: [Int]
     mass = [1, 0, 0, 0, 0, 0, 0, 0]
     energy = [0, 0, 0, 1, 0, 0, 0, 0]
+
+kg :: Double -> StatedAmount
+kg amount = StatedAmount{saUnit = "kg", saAmount = amount}
 
 round1 :: Double -> Double
 round1 x = fromIntegral (round (x * 10) :: Int) / 10
@@ -147,16 +150,16 @@ spec = do
                 `shouldBe` Right [11.7, 65.3, 13.2, 9.1, 0.8]
 
         it "converts before summing, so a half-kilo is a third and not almost everything" $
-            fmap (map round1 . NE.toList) (massShares massUnits (NE.fromList [("kg", 1.0), ("g", 500.0)]))
+            fmap (map round1 . NE.toList) (massShares massUnits (NE.fromList [kg 1.0, StatedAmount{saUnit = "g", saAmount = 500.0}]))
                 `shouldBe` Right [66.7, 33.3]
 
         it "refuses a block whose product is not stated in a mass" $
-            massShares massUnits (NE.fromList [("kg", 1.0), ("MJ", 4.0)])
+            massShares massUnits (NE.fromList [kg 1.0, StatedAmount{saUnit = "MJ", saAmount = 4.0}])
                 `shouldBe` Left (NotAMass "MJ")
 
         it "refuses an amount no share can be read from, rather than dropping it to zero" $ do
-            massShares massUnits (NE.fromList [("kg", 1.0), ("kg", 0.0)]) `shouldBe` Left (NonPositiveMass 0.0)
-            massShares massUnits (NE.fromList [("kg", -1.0)]) `shouldBe` Left (NonPositiveMass (-1.0))
+            massShares massUnits (NE.fromList [kg 1.0, kg 0.0]) `shouldBe` Left (NonPositiveMass 0.0)
+            massShares massUnits (NE.fromList [kg (-1.0)]) `shouldBe` Left (NonPositiveMass (-1.0))
 
     describe "the matrix" $ do
         it "gives a refused activity no column, and says why" $ do

--- a/test/AllocationSpec.hs
+++ b/test/AllocationSpec.hs
@@ -19,6 +19,7 @@ import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
+import API.Types (ActivitySummary (..))
 import Database (buildDatabaseWithMatrices)
 import Database.Allocation
 import Database.Loader (loadDatabaseWithLocationAliases)
@@ -43,6 +44,22 @@ massUnits =
     mass, energy :: [Int]
     mass = [1, 0, 0, 0, 0, 0, 0, 0]
     energy = [0, 0, 0, 1, 0, 0, 0, 0]
+
+-- | A product row of a block, as an 'ActivitySummary' reports it.
+product_ :: Text -> Double -> Maybe Double -> ActivitySummary
+product_ unitName amount declared =
+    ActivitySummary
+        { prsProcessId = ""
+        , prsActivityName = ""
+        , prsLocation = ""
+        , prsProductName = ""
+        , prsProductAmount = amount
+        , prsProductUnit = unitName
+        , prsAllocationPercent = declared
+        , prsAllocationFormula = Nothing
+        , prsMassPercent = Nothing
+        , prsNativeType = Nothing
+        }
 
 kg :: Double -> StatedAmount
 kg amount = StatedAmount{saUnit = "kg", saAmount = amount}
@@ -160,6 +177,25 @@ spec = do
         it "refuses an amount no share can be read from, rather than dropping it to zero" $ do
             massShares massUnits (NE.fromList [kg 1.0, kg 0.0]) `shouldBe` Left (NonPositiveMass 0.0)
             massShares massUnits (NE.fromList [kg (-1.0)]) `shouldBe` Left (NonPositiveMass (-1.0))
+
+    describe "withMassPercent" $ do
+        it "fills a block whose source states a share on every product" $
+            map prsMassPercent (Service.withMassPercent massUnits [product_ "kg" 1 (Just 60), product_ "kg" 3 (Just 40)])
+                `shouldBe` [Just 25, Just 75]
+
+        it "leaves a lone product alone, there being nothing to compare it against" $
+            map prsMassPercent (Service.withMassPercent massUnits [product_ "kg" 1 (Just 100)])
+                `shouldBe` [Nothing]
+
+        it "leaves a block whose datasets arrived already allocated alone" $
+            -- Each is normalised to one of its own product and states no
+            -- share, so the amounts are not one run's joint outputs.
+            map prsMassPercent (Service.withMassPercent massUnits [product_ "kg" 1 Nothing, product_ "kg" 1 Nothing])
+                `shouldBe` [Nothing, Nothing]
+
+        it "leaves a block whose products are not all a mass alone" $
+            map prsMassPercent (Service.withMassPercent massUnits [product_ "kg" 1 (Just 60), product_ "MJ" 3 (Just 40)])
+                `shouldBe` [Nothing, Nothing]
 
     describe "the matrix" $ do
         it "gives a refused activity no column, and says why" $ do

--- a/test/AllocationSpec.hs
+++ b/test/AllocationSpec.hs
@@ -26,7 +26,26 @@ import Database.MatrixBuild (InterningTables (..), buildInterningTables, buildSu
 import Database.Quality (QualityCheck (..), QualityOffender (..), QualityReport (..), qualityReport)
 import qualified Service
 import Types
-import UnitConversion (defaultUnitConfig)
+import UnitConversion (UnitConfig, UnitDef (..), defaultUnitConfig, mkUnitConfig, ucDimensionOrder, ucOriginalKeys, ucUnits)
+
+-- | Amounts of the five products of the Abondance cheese block, in kilograms.
+abondance :: NE.NonEmpty (Text, Double)
+abondance = NE.fromList [("kg", q) | q <- [1.0, 5.58318, 1.12527, 0.775791, 0.0686462]]
+
+-- | 'defaultUnitConfig' plus a gram and a megajoule, to have a second mass and a non-mass.
+massUnits :: UnitConfig
+massUnits =
+    mkUnitConfig
+        (ucDimensionOrder defaultUnitConfig)
+        (M.union (M.fromList [("g", UnitDef mass 0.001), ("mj", UnitDef energy 1.0)]) (ucUnits defaultUnitConfig))
+        (M.union (M.fromList [("g", "g"), ("mj", "MJ")]) (ucOriginalKeys defaultUnitConfig))
+  where
+    mass, energy :: [Int]
+    mass = [1, 0, 0, 0, 0, 0, 0, 0]
+    energy = [0, 0, 0, 1, 0, 0, 0, 0]
+
+round1 :: Double -> Double
+round1 x = fromIntegral (round (x * 10) :: Int) / 10
 
 spec :: Spec
 spec = do
@@ -119,6 +138,25 @@ spec = do
             describeRefusal (UnallocatedOutputs 3 3) `shouldSatisfy` T.isInfixOf "state a share on every product row"
             describeRefusal (NoSingleReference 0) `shouldSatisfy` T.isInfixOf "no reference exchange"
             describeRefusal (NoSingleReference 2) `shouldSatisfy` T.isInfixOf "2 reference exchanges"
+
+    describe "massShares" $ do
+        it "reads the Abondance block the way the mass would, against its declared key" $
+            -- Quantities of AGRIBALU000000003100165, whose declared key is dry matter:
+            -- cheese 51.4 %, permeate 24.3 %, concentrated whey 17.6 %, whey 4.4 %, cream 2.3 %.
+            fmap (map round1 . NE.toList) (massShares massUnits abondance)
+                `shouldBe` Right [11.7, 65.3, 13.2, 9.1, 0.8]
+
+        it "converts before summing, so a half-kilo is a third and not almost everything" $
+            fmap (map round1 . NE.toList) (massShares massUnits (NE.fromList [("kg", 1.0), ("g", 500.0)]))
+                `shouldBe` Right [66.7, 33.3]
+
+        it "refuses a block whose product is not stated in a mass" $
+            massShares massUnits (NE.fromList [("kg", 1.0), ("MJ", 4.0)])
+                `shouldBe` Left (NotAMass "MJ")
+
+        it "refuses an amount no share can be read from, rather than dropping it to zero" $ do
+            massShares massUnits (NE.fromList [("kg", 1.0), ("kg", 0.0)]) `shouldBe` Left (NonPositiveMass 0.0)
+            massShares massUnits (NE.fromList [("kg", -1.0)]) `shouldBe` Left (NonPositiveMass (-1.0))
 
     describe "the matrix" $ do
         it "gives a refused activity no column, and says why" $ do

--- a/test/AllocationSpec.hs
+++ b/test/AllocationSpec.hs
@@ -289,12 +289,13 @@ refusedActId = u "a1"
 consumerActId = u "a2"
 
 -- ---------------------------------------------------------------------------
--- End to end: an unlinked EcoSpold 2 dataset with two reference outputs.
+-- End to end: an unlinked EcoSpold 2 dataset with a reference product and
+-- a coproduct the source declares no share for.
 -- ---------------------------------------------------------------------------
 
 endToEnd :: Spec
 endToEnd =
-    describe "an EcoSpold 2 dataset with two reference outputs, loaded" $ do
+    describe "an EcoSpold 2 dataset with an unallocated coproduct, loaded" $ do
         it "loads, reads, is refused a score and is named by the quality report" $
             withTwoOutputDataset $ \(simpleDb, db) -> do
                 V.length (dbActivities db) `shouldBe` 1

--- a/test/AllocationSpec.hs
+++ b/test/AllocationSpec.hs
@@ -57,7 +57,7 @@ product_ unitName amount declared =
         , prsProductUnit = unitName
         , prsAllocationPercent = declared
         , prsAllocationFormula = Nothing
-        , prsMassPercent = Nothing
+        , prsMassAllocationPercent = Nothing
         , prsNativeType = Nothing
         }
 
@@ -178,23 +178,23 @@ spec = do
             massShares massUnits (NE.fromList [kg 1.0, kg 0.0]) `shouldBe` Left (NonPositiveMass 0.0)
             massShares massUnits (NE.fromList [kg (-1.0)]) `shouldBe` Left (NonPositiveMass (-1.0))
 
-    describe "withMassPercent" $ do
+    describe "withMassAllocationPercent" $ do
         it "fills a block whose source states a share on every product" $
-            map prsMassPercent (Service.withMassPercent massUnits [product_ "kg" 1 (Just 60), product_ "kg" 3 (Just 40)])
+            map prsMassAllocationPercent (Service.withMassAllocationPercent massUnits [product_ "kg" 1 (Just 60), product_ "kg" 3 (Just 40)])
                 `shouldBe` [Just 25, Just 75]
 
         it "leaves a lone product alone, there being nothing to compare it against" $
-            map prsMassPercent (Service.withMassPercent massUnits [product_ "kg" 1 (Just 100)])
+            map prsMassAllocationPercent (Service.withMassAllocationPercent massUnits [product_ "kg" 1 (Just 100)])
                 `shouldBe` [Nothing]
 
         it "leaves a block whose datasets arrived already allocated alone" $
             -- Each is normalised to one of its own product and states no
             -- share, so the amounts are not one run's joint outputs.
-            map prsMassPercent (Service.withMassPercent massUnits [product_ "kg" 1 Nothing, product_ "kg" 1 Nothing])
+            map prsMassAllocationPercent (Service.withMassAllocationPercent massUnits [product_ "kg" 1 Nothing, product_ "kg" 1 Nothing])
                 `shouldBe` [Nothing, Nothing]
 
         it "leaves a block whose products are not all a mass alone" $
-            map prsMassPercent (Service.withMassPercent massUnits [product_ "kg" 1 (Just 60), product_ "MJ" 3 (Just 40)])
+            map prsMassAllocationPercent (Service.withMassAllocationPercent massUnits [product_ "kg" 1 (Just 60), product_ "MJ" 3 (Just 40)])
                 `shouldBe` [Nothing, Nothing]
 
     describe "the matrix" $ do


### PR DESCRIPTION
The products of a multi-output block now each report what their share would be if the allocation key were their mass, beside the share the source declared.

## Why

An activity that makes several products has to split its inventory between them, and the split follows a key its author chose. Reading a database, you see the result of that choice and never its weight. On the Abondance cheese block of Agribalyse 3.2 the declared key is dry matter, and it gives the cheese 51.4 % of the block where the cheese is 11.7 % of its mass: a kilo of that cheese carries 4.4 times more under the key the source picked than it would under the mass. That factor is invisible today.

It costs nothing to show, because the impact per kilo under one key over another is exactly the quotient of the two fractions. No score has to be recomputed to establish it.

## What this is, and what it is not

`massShares` is a pure function, and deliberately not a second `AllocationKey`. Nothing is split, nothing is scored differently, no database is derived. Every product of a block simply carries `massAllocationPercent` next to `allocationPercent`, and the reader compares.

A real second key still has to answer three questions this change does not touch: what a refusal means inside `allocate`, which never refuses today; where a computed share lives, given that `techShare` means "what the source declared" and is read by the SimaPro writer; and what becomes of the product rows a source deliberately declares at 0 %, which a recomputed key would give a non-zero share and so overturn a modelling choice rather than refine it. Those are worth answering in front of the measured gaps rather than before them.

## Honesty

Amounts convert to kilograms before they are summed. Taken as written, a 1 kg / 500 g pair would hand the half-kilo 99.8 % of the load.

Two named refusals rather than a silent zero, which is the accidental cut-off the allocation gate has just removed: `NotAMass` when a product's unit is not a mass, `NonPositiveMass` when an amount admits no share. A block that hits either reports nothing at all.

`massAllocationPercent` is filled only on a block's own product list. Elsewhere, in search results for instance, it is null: a product's mass share means nothing outside the block it is a share of.

## Final state

Wire revision 15, `mass_allocation_percent` in pyvolca, and the generated API reference refreshed.

Verified on Agribalyse 3.2 loaded from source: the block reproduces the whole table, cheese x4.40, permeate x0.37, concentrated whey x1.34, whey x0.48, cream x2.83. Engine suite 2410 examples, 0 failures.

A companion pull request on the deployment side shows the two columns in the products table and follows the wire revision.

