### PR TITLE
Ask a flow which activities make it, and how many

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@
   unit to restate it in.
 
 ### Added
+- A flow search result now reports how many activities make the flow
+  (`producerCount`), which is the number of ways the database offers to
+  produce it: one on most of a French agricultural database, up to a few
+  thousand on a large industrial one. It is absent on a flow no activity can
+  produce, rather than zero, which would be the different statement that
+  nothing makes it.
+- The activities of a flow can be asked for one side of it: `?role=producer`
+  lists the activities that make it, `?role=consumer` those that use it. The
+  route answered both at once before, which is two questions in one list.
+  Asking with no `role` still answers both. Wire revision 16.
 - The products of a multi-output block now each report what their share
   would be if the allocation key were their mass (`massAllocationPercent`), beside
   the share the source declared. Nothing is split and nothing is scored

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ POST   /api/v1/db/{dbName}/impacts/{collection}                          Batch-i
 GET    /api/v1/db/{dbName}/activities?name=&geo=&product=&preset=&classification=&sort=  Search activities
 GET    /api/v1/db/{dbName}/flows?q=&lang=&kind=                          Search flows
 GET    /api/v1/db/{dbName}/flow/{flowId}                                 Flow details
-GET    /api/v1/db/{dbName}/flow/{flowId}/activities                      Activities using a flow
+GET    /api/v1/db/{dbName}/flow/{flowId}/activities?role=                Activities on one side of a flow (producer, consumer, any)
 GET    /api/v1/db/{dbName}/classifications                               Classification systems available in this DB
 GET    /api/v1/db/{dbName}/method/{methodId}/mapping                     Mapping coverage stats
 GET    /api/v1/db/{dbName}/method/{methodId}/flow-mapping                Per-flow mapping detail

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -692,9 +692,22 @@ method unless you pin it.
 
 Detail of one flow: its record, unit, and how many exchanges use it.
 
-##### `Client.get_flow_activities(flow_id: str, db_name: str | None = None) -> list[Activity]`
+##### `Client.get_flow_activities(flow_id: str, db_name: str | None = None, *, role: str | None = None) -> list[Activity]`
 
-Activities that produce or consume a given flow.
+Activities on one side of a flow, or both.
+
+Args:
+    flow_id: The flow to ask about.
+    db_name: Database to ask; the current one by default.
+    role: ``"producer"`` for the activities that make the flow,
+        ``"consumer"`` for those that use it, ``"any"`` or omitted for
+        both. Needs engine wire revision 16; an older engine would
+        ignore the parameter and answer with both sides, so the
+        request is refused rather than sent.
+
+Note that both sides together are narrower than asking for both: an
+avoided product is an exchange on the flow that neither makes it for
+sale nor consumes it, and only the unfiltered call lists it.
 
 ##### `Client.get_flow_mapping(method_id: str) -> FlowMapping`
 

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -24,7 +24,7 @@ The other direction is a promise about pyvolca's own names. A name this client p
 
 _Generated from `volca._compat`: run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.11.0** speaks wire formats **2 to 15** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error. A name this build has retired keeps working until pyvolca **1.0**.
+This build of **pyvolca 0.11.0** speaks wire formats **2 to 16** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error. A name this build has retired keeps working until pyvolca **1.0**.
 
 <!-- END: compatibility -->
 
@@ -1848,6 +1848,12 @@ that is where "taken from nature" and "released to nature" are told apart.
 ``synonyms`` maps language code → list of synonym strings (empty when the
 database carries no synonym index).
 
+``producer_count`` is how many activities make this flow, which is the
+number of ways a database offers to produce it. It is ``None`` on a flow
+no activity can produce (biosphere, waste) and against an engine older
+than wire revision 16; a zero would be the different statement that
+nothing makes it.
+
 | Field | Type | Default |
 |-------|------|---------|
 | `id` | `str` | _required_ |
@@ -1857,6 +1863,7 @@ database carries no synonym index).
 | `kind` | `str \| None` | None |
 | `compartment` | `str \| None` | None |
 | `synonyms` | `dict[str, list[str]]` | dict() |
+| `producer_count` | `int \| None` | None |
 
 ### `FlowContribution`
 

--- a/pyvolca/src/volca/_compat.py
+++ b/pyvolca/src/volca/_compat.py
@@ -32,10 +32,13 @@ the client works against it except the revision-gated capabilities (see
 ``Client._require_wire``), which check the engine's advertised revision
 before sending anything."""
 
-KNOWN_WIRE = 15
-"""The newest wire revision this pyvolca understands (revision 15 adds
-``mass_allocation_percent`` on a product of a multi-output block, the share it would
-carry if the allocation key were its mass; revision 14 added the
+KNOWN_WIRE = 16
+"""The newest wire revision this pyvolca understands (revision 16 adds
+``producer_count`` on a flow search result, the number of activities that
+make it, and the ``role`` parameter asking a flow's activities for one side
+of it only; revision 15 added ``mass_allocation_percent`` on a product of a
+multi-output block, the share it would carry if the allocation key were its
+mass; revision 14 added the
 ``AvoidedProduct`` exchange role, the ``unallocated`` quality check and the
 ``share`` and ``classification`` fields of a technosphere exchange; revision
 13 added the compartment an unmapped factor of the mapping report carries;

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -2333,12 +2333,31 @@ class Client:
         )
 
     def get_flow_activities(
-        self, flow_id: str, db_name: str | None = None
+        self, flow_id: str, db_name: str | None = None, *, role: str | None = None
     ) -> list[Activity]:
-        """Activities that produce or consume a given flow."""
+        """Activities on one side of a flow, or both.
+
+        Args:
+            flow_id: The flow to ask about.
+            db_name: Database to ask; the current one by default.
+            role: ``"producer"`` for the activities that make the flow,
+                ``"consumer"`` for those that use it, ``"any"`` or omitted for
+                both. Needs engine wire revision 16; an older engine would
+                ignore the parameter and answer with both sides, so the
+                request is refused rather than sent.
+
+        Note that both sides together are narrower than asking for both: an
+        avoided product is an exchange on the flow that neither makes it for
+        sale nor consumes it, and only the unfiltered call lists it.
+        """
+        if role is not None:
+            self._require_wire(16, "get_flow_activities(role=...)", engine_hint="0.12.1")
         target = self._db(db_name)
         raw = self._json(
-            self._session.get(f"{self.base_url}/api/v1/db/{target}/flow/{flow_id}/activities")
+            self._session.get(
+                f"{self.base_url}/api/v1/db/{target}/flow/{flow_id}/activities",
+                params=None if role is None else {"role": role},
+            )
         )
         return [Activity.from_json(a) for a in raw]
 

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -585,6 +585,12 @@ class Flow(FromJson):
     that is where "taken from nature" and "released to nature" are told apart.
     ``synonyms`` maps language code → list of synonym strings (empty when the
     database carries no synonym index).
+
+    ``producer_count`` is how many activities make this flow, which is the
+    number of ways a database offers to produce it. It is ``None`` on a flow
+    no activity can produce (biosphere, waste) and against an engine older
+    than wire revision 16; a zero would be the different statement that
+    nothing makes it.
     """
 
     id: str
@@ -594,6 +600,7 @@ class Flow(FromJson):
     kind: str | None = None
     compartment: str | None = None
     synonyms: dict[str, list[str]] = field(default_factory=dict)
+    producer_count: int | None = None
 
 
 @dataclass

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -11,7 +11,7 @@ import API.Csv (CSV)
 import API.DatabaseHandlers (explainCFToAPI, simpleAction)
 import qualified API.DatabaseHandlers as DBHandlers
 import qualified API.OpenApi
-import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivityInput (..), ActivitySummary (..), ActivityWriteRequest (..), ActivityWriteResponse (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), CollectionCoverage (..), ComputedQualityReportAPI (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CoverageReportAPI (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExchangeEditRequest (..), ExchangeEditResponse (..), ExplainCFResult (..), ExportRequest (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GapReportAPI (..), GraphExport (..), HostingInfo (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), QualityReportAPI (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadChunk (..), UploadResponse (..), apiFlowOfKind)
+import API.Types (ActivateResponse (..), ActivityContribution (..), ActivityInfo (..), ActivityInput (..), ActivitySummary (..), ActivityWriteRequest (..), ActivityWriteResponse (..), Aggregation (..), BatchImpactsEntry (..), BatchImpactsRequest (..), BatchImpactsResponse (..), BinaryContent (..), CharacterizationEntry (..), CharacterizationResult (..), ClassificationEntryInfo (..), ClassificationPresetInfo (..), ClassificationSystem (..), CollectionCoverage (..), ComputedQualityReportAPI (..), ConsumersResponse (..), ContributingActivitiesResult (..), ContributingFlowsResult (..), CoverageReportAPI (..), CutoffWasteFlow (..), DatabaseListResponse (..), DeleteSelectionRequest (..), DeleteSelectionResponse (..), ExchangeDetail (..), ExchangeEditRequest (..), ExchangeEditResponse (..), ExplainCFResult (..), ExportRequest (..), FlowCFEntry (..), FlowCFMapping (..), FlowContributionEntry (..), FlowDetail (..), FlowSearchResult (..), FlowSummary (..), GapReportAPI (..), GraphExport (..), HostingInfo (..), InventoryExport (..), LCIABatchResult (..), LCIAResult (..), LoadDatabaseResponse (..), MappingStatus (..), MethodCollectionListResponse (..), MethodCollectionStatusAPI (..), MethodDetail (..), MethodFactorAPI (..), MethodSummary (..), PerturbedEntry (..), QualityReportAPI (..), RefDataListResponse (..), RelinkRequest (..), RelinkResponse (..), ScoringIndicator (..), SearchResults (..), SensitivityRequest (..), SensitivityResponse (..), SubstitutionRequest (..), SupplyChainResponse (..), SynonymGroupsResponse (..), TreeExport (..), UnmappedFlowAPI (..), UploadChunk (..), UploadResponse (..), apiFlowOfKind, parseProducerFilter)
 import App.Env (AppEnv (..), AppM, runApp)
 import qualified Config
 import Control.Concurrent.Async (mapConcurrently)
@@ -109,7 +109,7 @@ type LCAAPI =
                 :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "contributing-flows" :> Capture "collection" Text :> Capture "methodId" Text :> QueryParam "limit" Int :> QueryParam "exclude-long-term" Bool :> Get '[JSON] ContributingFlowsResult
                 :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "contributing-activities" :> Capture "collection" Text :> Capture "methodId" Text :> QueryParam "limit" Int :> QueryParam "exclude-long-term" Bool :> Get '[JSON] ContributingActivitiesResult
                 :<|> "db" :> Capture "dbName" Text :> "flow" :> Capture "flowId" Text :> Get '[JSON] FlowDetail
-                :<|> "db" :> Capture "dbName" Text :> "flow" :> Capture "flowId" Text :> "activities" :> Get '[JSON] [ActivitySummary]
+                :<|> "db" :> Capture "dbName" Text :> "flow" :> Capture "flowId" Text :> "activities" :> QueryParam "role" Text :> Get '[JSON] [ActivitySummary]
                 :<|> "methods" :> Get '[JSON] [MethodSummary]
                 :<|> "method" :> Capture "methodId" Text :> Get '[JSON] MethodDetail
                 :<|> "method" :> Capture "methodId" Text :> "factors" :> Get '[JSON] [MethodFactorAPI]
@@ -1301,7 +1301,9 @@ appears that a client must know about /before/ calling it. Adding a route
 does not exempt a change from the bump: an absent route answers 404, and so
 does a request naming a database the engine has not loaded, so a client
 cannot tell "this engine is too old" from "you asked for the wrong thing"
-(revision 15: the @massAllocationPercent@ a product of a multi-output block carries
+(revision 16: the @producerCount@ a flow search result carries, and the
+@role@ parameter that asks a flow's activities for one side of it only;
+revision 15: the @massAllocationPercent@ a product of a multi-output block carries
 beside its declared share, saying what the mass would allocate;
 revision 14: the @AvoidedProduct@ role a technosphere exchange can report,
 which a client decoding the role enumeration has to know, the @unallocated@
@@ -1326,7 +1328,7 @@ the whole filtered set).
 Clients compare it to decide compatibility and to gate such capabilities.
 -}
 currentWireVersion :: Int
-currentWireVersion = 15
+currentWireVersion = 16
 
 getVersion :: AppM Value
 getVersion = do
@@ -1931,11 +1933,18 @@ getFlowDetail dbName flowIdText = do
             usageCount = Service.getFlowUsageCount db fid
         return $ FlowDetail (apiFlowOfKind flow) unitName' usageCount
 
-getFlowActivities :: Text -> Text -> AppM [ActivitySummary]
-getFlowActivities dbName flowIdText = do
+{- | The activities on one side of a flow. @role@ picks the side; an
+unrecognised value is refused rather than answered with the other question.
+-}
+getFlowActivities :: Text -> Text -> Maybe Text -> AppM [ActivitySummary]
+getFlowActivities dbName flowIdText mRole = do
     (db, _) <- requireDatabaseByName dbName
+    side <- maybe (badRequest unknownRole) pure (parseProducerFilter mRole)
     withValidatedFlow db flowIdText $ \flow ->
-        return $ Service.getActivitiesUsingFlow db (flowKindId flow)
+        return $ Service.getActivitiesUsingFlow db side (flowKindId flow)
+  where
+    unknownRole :: Text
+    unknownRole = "unknown role: use producer, consumer or any"
 
 getMethods :: AppM [MethodSummary]
 getMethods = do
@@ -2378,7 +2387,7 @@ searchFlowsInternal db ff@Service.FlowFilter{Service.ffQuery = query, Service.ff
     -- Language filtering not yet implemented, search all synonyms
     liftIO $
         paginateResults
-            (Service.flowSearchResults (dbUnits db) ff (findFlowsBySynonym db query))
+            (Service.flowSearchResults (dbUnits db) (Service.producerCount db) ff (findFlowsBySynonym db query))
             limitParam
             offsetParam
 

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -238,6 +238,7 @@ data FlowSearchResult = FlowSearchResult
     , fsrCompartment :: Maybe Text -- Sub-compartment (e.g. "agricultural")
     , fsrUnitName :: Text
     , fsrSynonyms :: M.Map Text [Text] -- Synonyms by language (converted from Set to List for JSON)
+    , fsrProducerCount :: Maybe Int -- How many activities make this flow; Nothing on a flow no activity can produce (biosphere, waste), never 0 as a stand-in for "not asked"
     }
     deriving (Generic)
     deriving (ToJSON, ToSchema) via (Stripped FlowSearchResult)
@@ -394,6 +395,28 @@ data FlowSummary = FlowSummary
 data FlowRole = InputFlow | OutputFlow | ReferenceProductFlow
     deriving (Show, Generic)
     deriving anyclass (ToSchema)
+
+{- | Which side of a flow the caller is asking about: the activities that make
+it, the ones that use it, or both.
+
+The two questions have different answers and only one of them is "how is this
+product made". 'EitherSide' is what the route answered before it could be
+asked, and stays its default.
+-}
+data ProducerFilter = ProducersOnly | ConsumersOnly | EitherSide
+    deriving (Eq, Show)
+
+{- | Read the @role@ query parameter. An absent parameter is 'EitherSide'; an
+unrecognised one is 'Nothing', so the route can refuse it rather than quietly
+answer a different question.
+-}
+parseProducerFilter :: Maybe Text -> Maybe ProducerFilter
+parseProducerFilter mRole = case mRole of
+    Nothing -> Just EitherSide
+    Just "producer" -> Just ProducersOnly
+    Just "consumer" -> Just ConsumersOnly
+    Just "any" -> Just EitherSide
+    Just _ -> Nothing
 
 -- Synonym types removed - synonyms are now included directly in flow responses
 

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -3,7 +3,7 @@
 
 module CLI.Command where
 
-import API.Types (ActivityInput, ActivityWriteRequest (..), toAuthoredActivities, toExchangeEdits)
+import API.Types (ActivityInput, ActivityWriteRequest (..), ProducerFilter (..), toAuthoredActivities, toExchangeEdits)
 import CLI.Client (readJsonFile)
 import CLI.Types (CLIConfig (..), Command (..), DatabaseAction (..), DbActivityArgs (..), DbDeleteArgs (..), DbExportArgs (..), DbRelinkArgs (..), DbWriteArgs (..), DebugMatricesOptions (..), FlowSubCommand (..), GlobalOptions (..), LCIAOptions (..), MappingOptions (..), McExportArgs (..), MethodAction (..), OutputFormat (..), SearchActivitiesOptions (..), SearchFlowsOptions (..), UploadArgs (..))
 import Config (DatabaseConfig (..), MethodConfig (..))
@@ -253,7 +253,7 @@ executeFlowCommand fmt database flowId =
 -- | Execute flow activities command
 executeFlowActivitiesCommand :: OutputFormat -> Database -> T.Text -> IO ()
 executeFlowActivitiesCommand fmt database flowId =
-    case Service.getFlowActivities database flowId of
+    case Service.getFlowActivities database EitherSide flowId of
         Left err -> reportServiceError err
         Right result -> outputResult fmt result
 

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -5,7 +5,7 @@
 
 module Service where
 
-import API.Types (ActivityForAPI (..), ActivityInfo (..), ActivityLinks (..), ActivityMetadata (..), ActivityStats (..), ActivitySummary (..), ApiFlow (..), ClassificationSystem (..), ConsumerResult (..), ConsumersResponse (..), CutoffWasteFlow (..), EdgeType (..), ExchangeDetail (..), ExchangeWithUnit (..), ExportNode (..), FlowDetail (..), FlowInfo (..), FlowRole (..), FlowSearchResult (..), FlowSummary (..), GraphEdge (..), GraphExport (..), GraphNode (..), InventoryExport (..), InventoryFlowDetail (..), InventoryMetadata (..), InventoryStatistics (..), NodeType (..), Perturbation (..), RootDb (..), SearchResults (..), Substitution (..), SubstitutionScope (..), SupplyChainEdge (..), SupplyChainEntry (..), SupplyChainResponse (..), ThisDb (..), TreeEdge (..), TreeExport (..), TreeMetadata (..), apiFlowOfKind, parseSubRef, subAnchorRef, unresolvedFlowName)
+import API.Types (ActivityForAPI (..), ActivityInfo (..), ActivityLinks (..), ActivityMetadata (..), ActivityStats (..), ActivitySummary (..), ApiFlow (..), ClassificationSystem (..), ConsumerResult (..), ConsumersResponse (..), CutoffWasteFlow (..), EdgeType (..), ExchangeDetail (..), ExchangeWithUnit (..), ExportNode (..), FlowDetail (..), FlowInfo (..), FlowRole (..), FlowSearchResult (..), FlowSummary (..), GraphEdge (..), GraphExport (..), GraphNode (..), InventoryExport (..), InventoryFlowDetail (..), InventoryMetadata (..), InventoryStatistics (..), NodeType (..), Perturbation (..), ProducerFilter (..), RootDb (..), SearchResults (..), Substitution (..), SubstitutionScope (..), SupplyChainEdge (..), SupplyChainEntry (..), SupplyChainResponse (..), ThisDb (..), TreeEdge (..), TreeExport (..), TreeMetadata (..), apiFlowOfKind, parseSubRef, subAnchorRef, unresolvedFlowName)
 import CLI.Types (DebugMatricesOptions (..))
 import Control.Applicative ((<|>))
 import Control.Concurrent.Async (mapConcurrently)
@@ -800,8 +800,8 @@ table sorted by name must stay alphabetical.
 Shared by the REST and MCP/CLI search paths, which differ only in how they
 paginate.
 -}
-flowSearchResults :: UnitDB -> FlowFilter -> [FlowKind] -> [FlowSearchResult]
-flowSearchResults units FlowFilter{ffQuery = query, ffKind = kindParam, ffSort = sortParam, ffOrder = orderParam} =
+flowSearchResults :: UnitDB -> (FlowKind -> Maybe Int) -> FlowFilter -> [FlowKind] -> [FlowSearchResult]
+flowSearchResults units producersOfFlow FlowFilter{ffQuery = query, ffKind = kindParam, ffSort = sortParam, ffOrder = orderParam} =
     L.sortBy (direction (\a b -> compare (sortKey a) (sortKey b))) . map toResult . filter askedFor
   where
     askedFor flow = maybe True (== kindOfFlow flow) kindParam
@@ -826,6 +826,10 @@ flowSearchResults units FlowFilter{ffQuery = query, ffKind = kindParam, ffSort =
             , fsrCompartment = flowKindCompartmentSub flow
             , fsrUnitName = flowKindUnitName units flow
             , fsrSynonyms = M.map S.toList (flowKindSynonyms flow)
+            , -- Left unforced on purpose: the caller sorts and paginates these
+              -- rows, so counting the producers of a flow that never reaches a
+              -- page costs nothing.
+              fsrProducerCount = producersOfFlow flow
             }
 
 {- | Search flows (returns same format as API). The query is required by the
@@ -836,7 +840,7 @@ searchFlows db ff@FlowFilter{ffQuery = query, ffLimit = limitParam, ffOffset = o
     startTime <- getCurrentTime
     let limit = maybe 50 (min 1000) limitParam
         offset = maybe 0 (max 0) offsetParam
-        allResults = flowSearchResults (dbUnits db) ff (findFlowsBySynonym db query)
+        allResults = flowSearchResults (dbUnits db) (producerCount db) ff (findFlowsBySynonym db query)
         total = length allResults
         taken = take (limit + 1) (drop offset allResults)
         hasMore = length taken > limit
@@ -1357,10 +1361,59 @@ getActivityReferenceProductDetail db activity = do
     let uName = getUnitNameForTechFlow (dbUnits db) flow
     return $ FlowDetail (ApiTechFlow flow) uName usageCount
 
--- | Get activities that use a specific flow as ActivitySummary list.
-getActivitiesUsingFlow :: Database -> UUID -> [ActivitySummary]
-getActivitiesUsingFlow db flowUUID =
+{- | The activities on one side of a flow: those that make it, those that use
+it, or both.
+
+'EitherSide' is what this answered before the side could be asked, so the
+route's default is unchanged.
+-}
+getActivitiesUsingFlow :: Database -> ProducerFilter -> UUID -> [ActivitySummary]
+getActivitiesUsingFlow db side flowUUID =
     [ mkActivitySummary db pid act
+    | (pid, act) <- activitiesTouching db flowUUID
+    , any (onSide side flowUUID) (exchanges act)
+    ]
+
+{- | Whether one exchange puts its activity on the asked side of the flow.
+
+Producing is stated by the exchange's role, not by its sign: a waste treatment
+activity's reference is an input, and a coproduct is an output that is not the
+reference. 'exchangeIsProductOutput' is the one place that judgement lives.
+-}
+onSide :: ProducerFilter -> UUID -> Exchange -> Bool
+onSide side flowUUID ex =
+    exchangeFlowId ex == flowUUID && case side of
+        ProducersOnly -> exchangeIsProductOutput ex
+        ConsumersOnly -> exchangeIsInput ex
+        EitherSide -> True
+
+{- | How many activities make this flow.
+
+'Nothing' where the question does not apply, never 0: a zero would assert that
+nothing produces the flow, which is a different statement from "this kind of
+flow has no producers".
+
+ponytail: counted by reading every activity the flow index names, which on
+ecoinvent is up to 2506 for one product. Fine for a page of results; index the
+producing side if a caller ever asks for the whole database at once.
+-}
+producerCount :: Database -> FlowKind -> Maybe Int
+producerCount db flow = case flow of
+    TechKind tf -> Just (length (producersOf (tfId tf)))
+    BioKind _ -> Nothing
+    WasteKind _ -> Nothing
+  where
+    producersOf :: UUID -> [(ProcessId, Activity)]
+    producersOf fid =
+        [ pair
+        | pair@(_, act) <- activitiesTouching db fid
+        , any (onSide ProducersOnly fid) (exchanges act)
+        ]
+
+-- | The activities the flow index names for one flow, each with its id, once.
+activitiesTouching :: Database -> UUID -> [(ProcessId, Activity)]
+activitiesTouching db flowUUID =
+    [ (pid, act)
     | pid <- maybe [] (S.toList . S.fromList) (M.lookup flowUUID (idxByFlow (dbIndexes db)))
     , Just act <- [getActivity db pid]
     ]
@@ -1464,13 +1517,13 @@ getFlowInfo db flowIdText = do
 {- | Get activities that use a specific flow as JSON (for CLI). Resolves
 against either flow side so biosphere flow IDs work too.
 -}
-getFlowActivities :: Database -> Text -> Either ServiceError Value
-getFlowActivities db flowIdText = do
+getFlowActivities :: Database -> ProducerFilter -> Text -> Either ServiceError Value
+getFlowActivities db side flowIdText = do
     case UUID.fromText flowIdText of
         Nothing -> Left $ InvalidUUID $ "Invalid flow UUID: " <> flowIdText
         Just fId
             | M.member fId (dbTechFlows db) || M.member fId (dbBioFlows db) ->
-                Right $ toJSON (getActivitiesUsingFlow db fId)
+                Right $ toJSON (getActivitiesUsingFlow db side fId)
             | otherwise -> Left $ FlowNotFound flowIdText
 
 {- | Compute the supply chain for an activity using the scaling vector.

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -826,10 +826,7 @@ flowSearchResults units producersOfFlow FlowFilter{ffQuery = query, ffKind = kin
             , fsrCompartment = flowKindCompartmentSub flow
             , fsrUnitName = flowKindUnitName units flow
             , fsrSynonyms = M.map S.toList (flowKindSynonyms flow)
-            , -- Left unforced on purpose: the caller sorts and paginates these
-              -- rows, so counting the producers of a flow that never reaches a
-              -- page costs nothing.
-              fsrProducerCount = producersOfFlow flow
+            , fsrProducerCount = producersOfFlow flow
             }
 
 {- | Search flows (returns same format as API). The query is required by the
@@ -1365,50 +1362,55 @@ getActivityReferenceProductDetail db activity = do
 it, or both.
 
 'EitherSide' is what this answered before the side could be asked, so the
-route's default is unchanged.
+route's default is unchanged. It is wider than the two sides put together: an
+avoided product is an exchange on the flow that neither makes it for sale nor
+consumes it, so it appears under 'EitherSide' alone. Adding the two sides is
+therefore not the same as asking for both.
 -}
 getActivitiesUsingFlow :: Database -> ProducerFilter -> UUID -> [ActivitySummary]
-getActivitiesUsingFlow db side flowUUID =
-    [ mkActivitySummary db pid act
-    | (pid, act) <- activitiesTouching db flowUUID
-    , any (onSide side flowUUID) (exchanges act)
-    ]
+getActivitiesUsingFlow db side flowUUID = case side of
+    ProducersOnly -> [mkActivitySummary db pid act | (pid, act) <- producingRows db flowUUID]
+    ConsumersOnly -> touching (any consumes . exchanges)
+    EitherSide -> touching (const True)
+  where
+    touching :: (Activity -> Bool) -> [ActivitySummary]
+    touching keep = [mkActivitySummary db pid act | (pid, act) <- activitiesTouching db flowUUID, keep act]
 
-{- | Whether one exchange puts its activity on the asked side of the flow.
+    consumes :: Exchange -> Bool
+    consumes ex = exchangeFlowId ex == flowUUID && exchangeIsInput ex
 
-Producing is stated by the exchange's role, not by its sign: a waste treatment
-activity's reference is an input, and a coproduct is an output that is not the
-reference. 'exchangeIsProductOutput' is the one place that judgement lives.
+{- | The rows that make a flow, as the matrix sees them.
+
+Read from the product index rather than judged exchange by exchange, because
+that index /is/ the answer: it holds one entry per process row keyed by the
+flow that row produces, built from 'exchangeIsReference'. That matters beyond
+saving a scan. A waste treatment activity's reference is an /input/, so
+'exchangeIsProductOutput' says no to it and would hide every treatment
+activity from "what makes this flow" - the same mistake 'Database.hs' records
+having already made once with product filters.
+
+Each coproduct of an allocated block is its own row with its own reference
+product, so they are in here too. A block the allocation gate refused has no
+row and no honest column either, so it is absent from both.
 -}
-onSide :: ProducerFilter -> UUID -> Exchange -> Bool
-onSide side flowUUID ex =
-    exchangeFlowId ex == flowUUID && case side of
-        ProducersOnly -> exchangeIsProductOutput ex
-        ConsumersOnly -> exchangeIsInput ex
-        EitherSide -> True
+producingRows :: Database -> UUID -> [(ProcessId, Activity)]
+producingRows db flowUUID =
+    [ (pid, act)
+    | pid <- maybe [] NE.toList (M.lookup flowUUID (piByUUID (dbProductIndex db)))
+    , Just act <- [getActivity db pid]
+    ]
 
 {- | How many activities make this flow.
 
-'Nothing' where the question does not apply, never 0: a zero would assert that
-nothing produces the flow, which is a different statement from "this kind of
-flow has no producers".
-
-ponytail: counted by reading every activity the flow index names, which on
-ecoinvent is up to 2506 for one product. Fine for a page of results; index the
-producing side if a caller ever asks for the whole database at once.
+'Nothing' where the question does not apply, never 0 as a stand-in: a zero
+here is the true statement that no row produces the flow, and 'Nothing' the
+different one that this kind of flow has no producing side at all.
 -}
 producerCount :: Database -> FlowKind -> Maybe Int
 producerCount db flow = case flow of
-    TechKind tf -> Just (length (producersOf (tfId tf)))
+    TechKind tf -> Just (maybe 0 NE.length (M.lookup (tfId tf) (piByUUID (dbProductIndex db))))
     BioKind _ -> Nothing
     WasteKind _ -> Nothing
-  where
-    producersOf :: UUID -> [(ProcessId, Activity)]
-    producersOf fid =
-        [ pair
-        | pair@(_, act) <- activitiesTouching db fid
-        , any (onSide ProducersOnly fid) (exchanges act)
-        ]
 
 -- | The activities the flow index names for one flow, each with its id, once.
 activitiesTouching :: Database -> UUID -> [(ProcessId, Activity)]

--- a/test/CoproductTargetSpec.hs
+++ b/test/CoproductTargetSpec.hs
@@ -17,7 +17,7 @@ import Data.Text (Text)
 import qualified Data.UUID as UUID
 import Test.Hspec
 
-import API.Types (ActivityForAPI (..), ActivitySummary (..), ExchangeDetail (..), ExchangeWithUnit (..), ExportNode (..), NodeType (..), TreeEdge (..), TreeExport (..))
+import API.Types (ActivityForAPI (..), ActivitySummary (..), ExchangeDetail (..), ExchangeWithUnit (..), ExportNode (..), NodeType (..), ProducerFilter (..), TreeEdge (..), TreeExport (..))
 import Database (buildDatabaseWithMatrices)
 import qualified Service
 import Tree (buildLoopAwareTree)
@@ -79,11 +79,33 @@ spec = do
             db <- danglingLinkFixture
             map enChildrenCount (rootNodes db) `shouldBe` [1]
 
-    describe "the activities that use a flow" $
+    describe "the activities that use a flow" $ do
         it "lists the row that produces it and the row that consumes it" $ do
             db <- twoCoproductFixture
-            map prsProcessId (Service.getActivitiesUsingFlow db milkId)
+            map prsProcessId (Service.getActivitiesUsingFlow db EitherSide milkId)
                 `shouldBe` [pidText milkId, consumerPid]
+
+        it "asked for producers, leaves the consumer out" $ do
+            db <- twoCoproductFixture
+            map prsProcessId (Service.getActivitiesUsingFlow db ProducersOnly milkId)
+                `shouldBe` [pidText milkId]
+
+        it "asked for consumers, leaves the producer out" $ do
+            db <- twoCoproductFixture
+            map prsProcessId (Service.getActivitiesUsingFlow db ConsumersOnly milkId)
+                `shouldBe` [consumerPid]
+
+        it "counts the producers, not everyone who touches the flow" $ do
+            db <- twoCoproductFixture
+            fmap (Service.producerCount db . TechKind) (M.lookup milkId (dbTechFlows db))
+                `shouldBe` Just (Just 1)
+
+        it "counts no producer for a biosphere flow, rather than none at all" $ do
+            -- A zero would say "nothing makes it"; Nothing says the question
+            -- does not apply to this side of the inventory.
+            db <- twoCoproductFixture
+            map (Service.producerCount db . BioKind) (M.elems (dbBioFlows db))
+                `shouldSatisfy` all (== Nothing)
 
 -- ---------------------------------------------------------------------------
 -- Reading one exchange back

--- a/test/CoproductTargetSpec.hs
+++ b/test/CoproductTargetSpec.hs
@@ -100,6 +100,19 @@ spec = do
             fmap (Service.producerCount db . TechKind) (M.lookup milkId (dbTechFlows db))
                 `shouldBe` Just (Just 1)
 
+        it "counts a treatment activity among the producers of what it treats" $ do
+            -- A treatment activity's reference is an input, so a producer test
+            -- written on "is this an output" answers no to every one of them
+            -- and reports that nothing makes the flow.
+            db <- treatmentFixture
+            fmap (Service.producerCount db . TechKind) (M.lookup milkId (dbTechFlows db))
+                `shouldBe` Just (Just 1)
+
+        it "lists that treatment activity when asked for producers" $ do
+            db <- treatmentFixture
+            map prsProcessId (Service.getActivitiesUsingFlow db ProducersOnly milkId)
+                `shouldBe` [pidText milkId]
+
         it "counts no producer for a biosphere flow, rather than none at all" $ do
             -- A zero would say "nothing makes it"; Nothing says the question
             -- does not apply to this side of the inventory.
@@ -173,6 +186,23 @@ the one with the lower product UUID.
 -}
 twoCoproductFixture :: IO Database
 twoCoproductFixture = buildFixture (consumerActivity [milkInput] []) supplierRows supplierFlows
+
+{- | A row whose reference exchange is an /input/: the shape of an activity
+that treats what it is given rather than selling what it makes. It still
+produces its reference flow as far as the matrix is concerned.
+-}
+treatmentFixture :: IO Database
+treatmentFixture =
+    buildFixture
+        (consumerActivity [milkInput] [])
+        (M.singleton (supplierActId, milkId) treatmentProcess)
+        (M.singleton milkId (techFlow milkId "milk"))
+
+treatmentProcess :: Activity
+treatmentProcess =
+    bareActivity
+        "milk treatment"
+        [(techExchange milkId 1.0 ReferenceProduct supplierActId){techRole = ReferenceInput}]
 
 {- | The same consumer, its input naming an activity no row in the database
 carries.

--- a/test/FlowSearchSpec.hs
+++ b/test/FlowSearchSpec.hs
@@ -211,7 +211,7 @@ compartmentOf r = (fsrCategory r, fsrCompartment r)
 
 -- | No unit database: every flow reports the same unit, so unit never breaks a tie.
 search :: FlowFilter -> [FlowKind] -> [FlowSearchResult]
-search = flowSearchResults M.empty
+search = flowSearchResults M.empty (const Nothing)
 
 sortByName :: FlowFilter
 sortByName =


### PR DESCRIPTION
## Why

A database usually offers several ways to make the same product, and nothing said so. Asking a flow for its activities returned the ones that make it and the ones that consume it in a single flat list, so "how is this product made" could not be put as a question at all. On a large industrial database one product can be made a few thousand different ways; on a French agricultural one, almost always exactly one. That difference is a property of the data worth showing, and it was invisible.

## What changes

`?role=producer` on `db/{dbName}/flow/{flowId}/activities` lists the activities that make the flow, `?role=consumer` those that use it, and no `role` still answers both, so no existing caller moves. An unrecognised value is refused rather than quietly answered with the other question.

What counts as producing is `exchangeIsProductOutput`, the same judgement the matrix builder uses: a waste treatment activity produces its reference input, and a coproduct counts as produced. The role is not read off the sign of the amount.

A flow search result gains `producerCount`, because choosing among ways to make something is what a reader is doing on that screen. It is `null` on a flow no activity can produce rather than `0`, since a zero would assert that nothing makes it.

## Cost

The count reads every activity the flow index names, which on a large database is a few thousand for one flow. It stays unforced until a row survives sorting and pagination, so only the rows actually displayed are ever counted. If a caller ever wants the whole database at once, the producing side needs an index; a page of results does not.

## Checks

Five examples on the two-coproduct fixture: both sides, each side alone, the count, and that a biosphere flow answers `null` rather than `0`. Full suite 2418 examples, hlint clean, cold `-Werror` build green.

## Note on the registry

`flow/{flowId}/activities` predates this change and has no entry in `API.Resources`, so it reaches REST but not MCP. Adding one is worth doing and is a different subject; this PR does not widen to it.
