### PR TITLE
Read the allocation key an ILCD dataset states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@
   lists the activities that make it, `?role=consumer` those that use it. The
   route answered both at once before, which is two questions in one list.
   Asking with no `role` still answers both. Wire revision 16.
+- An ILCD dataset that states an allocation key is now read with it. The
+  format carries a fraction per product output, which the parser dropped, so
+  a multi-output ILCD dataset had no shares to split on and was refused as
+  unallocated. Only the fraction a product allocates to itself is read: the
+  format also allows a matrix allocating one exchange to another product, and
+  a dataset written that way is still refused rather than split on a number
+  that meant something else.
 - The products of a multi-output block now each report what their share
   would be if the allocation key were their mass (`massAllocationPercent`), beside
   the share the source declared. Nothing is split and nothing is scored

--- a/src/ILCD/Parser.hs
+++ b/src/ILCD/Parser.hs
@@ -340,12 +340,19 @@ data ProcState = ProcState
     , psExAmount :: !Double
     , psExLocation :: !Text
     , psExComment :: !(Maybe (Text, Text))
-    , psExAllocations :: ![(Int, Double)] -- (internalReferenceToCoProduct, allocatedFraction) read so far on this exchange
-    , psAllocRef :: !(Maybe Int) -- the attributes of one <allocation> arrive separately, so they are paired at its close
-    , psAllocFraction :: !(Maybe Double)
     {- ^ (xml:lang, comment text) for the open `<exchange>`. English wins;
     otherwise first non-empty. Reset on each `<exchange>` open.
     -}
+    , psExAllocations :: ![(Int, Double)]
+    {- ^ Every (internalReferenceToCoProduct, allocatedFraction) of the open
+    `<exchange>`. All of them, because how many there are is what says
+    which of the format's two meanings the file is using.
+    -}
+    , psAllocRef :: !(Maybe Int)
+    {- ^ The attributes of one `<allocation>` arrive separately, so they are
+    paired at its close.
+    -}
+    , psAllocFraction :: !(Maybe Double)
     , psPendingCommentLang :: !Text
     {- ^ xml:lang on the currently-open `<common:generalComment>`. Reset
     on every comment open.
@@ -514,10 +521,29 @@ parseProcessXML bytes =
                         , ierAmount = psExAmount s
                         , ierLocation = psExLocation s
                         , ierComment = snd <$> psExComment s
-                        , ierShare = lookup (psExInternalId s) (psExAllocations s)
+                        , ierShare = soleSelfAllocation (psExInternalId s) (psExAllocations s)
                         }
              in s{psInExchange = False, psExchanges = ex : psExchanges s, psTextAccum = []}
         | otherwise = s{psTextAccum = []}
+
+    -- \| The share an exchange declares for itself, and only when it is the
+    --    only thing that exchange allocates.
+    --
+    --    The attribute carries two different meanings in ILCD. One entry pointing
+    --    at the exchange itself is the ordinary form: "this product takes this
+    --    share of the process". Several entries are the general form, where the
+    --    exchange is distributed across the co-products and the entry pointing at
+    --    itself is its own share of itself, which is 100 and says nothing about
+    --    allocation. Reading that as a declared share would give every product
+    --    100 % and hand each one the whole inventory.
+    --
+    --    So several entries yield no share at all, and the allocation gate refuses
+    --    the dataset. Refused is the right answer for a form we cannot represent.
+    --
+    soleSelfAllocation :: Int -> [(Int, Double)] -> Maybe Double
+    soleSelfAllocation ownId allocations = case allocations of
+        [(ref, fraction)] | ref == ownId -> Just fraction
+        _ -> Nothing
 
     cdata = txt
     accum s = T.strip $ T.concat $ reverse $ map bsToText (psTextAccum s)
@@ -618,8 +644,17 @@ buildActivity flowInfoMap techFlowDB bioFlowDB wasteFlowDB unitDB p =
     --    refuses it, which is the honest outcome: better refused than split on a
     --    number that meant something else.
     --
-    declaredShareOf :: ILCDExchangeRaw -> Maybe DeclaredShare
-    declaredShareOf raw = flip DeclaredShare Nothing <$> ierShare raw
+    declaredShareOf :: TechRole -> ILCDExchangeRaw -> Maybe DeclaredShare
+    declaredShareOf role raw = case role of
+        ReferenceProduct -> shareOf raw
+        Coproduct -> shareOf raw
+        ReferenceInput -> Nothing
+        Input -> Nothing
+        AvoidedProduct -> Nothing
+
+    -- \| The number itself, once the role says a share belongs on the exchange.
+    shareOf :: ILCDExchangeRaw -> Maybe DeclaredShare
+    shareOf raw = flip DeclaredShare Nothing <$> ierShare raw
 
     -- Look up the reference exchange's flow unit. Reference exchange is typically
     -- a technosphere product, but for waste-treatment processes it may be a
@@ -683,7 +718,7 @@ buildActivity flowInfoMap techFlowDB bioFlowDB wasteFlowDB unitDB p =
                         , techLocation = ierLocation raw
                         , techComment = ierComment raw
                         , techPedigree = Nothing
-                        , techShare = declaredShareOf raw
+                        , techShare = declaredShareOf techRoleFor raw
                         , techClassification = M.empty
                         }
 

--- a/src/ILCD/Parser.hs
+++ b/src/ILCD/Parser.hs
@@ -72,6 +72,7 @@ data ILCDExchangeRaw = ILCDExchangeRaw
     , ierAmount :: !Double
     , ierLocation :: !Text
     , ierComment :: !(Maybe Text) -- per-exchange <common:generalComment>
+    , ierShare :: !(Maybe Double) -- <allocation allocatedFraction>, in percent, when the exchange allocates to itself
     }
 
 {- | Parse an ILCD directory into a SimpleDatabase.
@@ -339,6 +340,9 @@ data ProcState = ProcState
     , psExAmount :: !Double
     , psExLocation :: !Text
     , psExComment :: !(Maybe (Text, Text))
+    , psExAllocations :: ![(Int, Double)] -- (internalReferenceToCoProduct, allocatedFraction) read so far on this exchange
+    , psAllocRef :: !(Maybe Int) -- the attributes of one <allocation> arrive separately, so they are paired at its close
+    , psAllocFraction :: !(Maybe Double)
     {- ^ (xml:lang, comment text) for the open `<exchange>`. English wins;
     otherwise first non-empty. Reset on each `<exchange>` open.
     -}
@@ -376,6 +380,9 @@ parseProcessXML bytes =
             , psExAmount = 0
             , psExLocation = ""
             , psExComment = Nothing
+            , psExAllocations = []
+            , psAllocRef = Nothing
+            , psAllocFraction = Nothing
             , psPendingCommentLang = ""
             , psTextAccum = []
             , psInName = False
@@ -400,6 +407,9 @@ parseProcessXML bytes =
                 , psExAmount = 0
                 , psExLocation = ""
                 , psExComment = Nothing
+                , psExAllocations = []
+                , psAllocRef = Nothing
+                , psAllocFraction = Nothing
                 }
         | isElement tag "generalComment" =
             s{psPendingCommentLang = "", psTextAccum = []}
@@ -416,6 +426,12 @@ parseProcessXML bytes =
                 Left _ -> s
         | isElement name "refObjectId" && psInExchange s && T.null (psExFlowRef s) =
             s{psExFlowRef = bsToText value}
+        | isElement name "internalReferenceToCoProduct" && psInExchange s =
+            case TR.decimal (bsToText value) of
+                Right (n, _) -> s{psAllocRef = Just n}
+                Left _ -> s
+        | isElement name "allocatedFraction" && psInExchange s =
+            s{psAllocFraction = readAmount (bsToText value)}
         | isElement name "location" && not (psInExchange s) && T.null (psLocation s) =
             s{psLocation = bsToText value}
         | isElement name "name" && not (psInExchange s) && not (psInName s) =
@@ -481,6 +497,14 @@ parseProcessXML bytes =
             -- Guard psInExchange just in case a future ILCD revision reuses the tag name
             -- elsewhere; first occurrence wins to be deterministic.
             s{psProcessType = accum s, psTextAccum = []}
+        | isElement tag "allocation" && psInExchange s =
+            let paired = (,) <$> psAllocRef s <*> psAllocFraction s
+             in s
+                    { psExAllocations = maybe (psExAllocations s) (: psExAllocations s) paired
+                    , psAllocRef = Nothing
+                    , psAllocFraction = Nothing
+                    , psTextAccum = []
+                    }
         | isElement tag "exchange" =
             let ex =
                     ILCDExchangeRaw
@@ -490,6 +514,7 @@ parseProcessXML bytes =
                         , ierAmount = psExAmount s
                         , ierLocation = psExLocation s
                         , ierComment = snd <$> psExComment s
+                        , ierShare = lookup (psExInternalId s) (psExAllocations s)
                         }
              in s{psInExchange = False, psExchanges = ex : psExchanges s, psTextAccum = []}
         | otherwise = s{psTextAccum = []}
@@ -582,6 +607,20 @@ buildActivity flowInfoMap techFlowDB bioFlowDB wasteFlowDB unitDB p =
         , activityFormulaCheck = Nothing
         }
   where
+    -- \| The share the source declared for one product output, read from its
+    --    own @<allocation allocatedFraction>@.
+    --
+    --    ILCD lets an exchange allocate to any co-product by internal id, which
+    --    would be a matrix of shares. Only the entry pointing at the exchange
+    --    itself is read, because that is the one that says "this product's share
+    --    of the process" and the only one 'DeclaredShare' can hold. A dataset
+    --    using the general form keeps no share here and the allocation gate
+    --    refuses it, which is the honest outcome: better refused than split on a
+    --    number that meant something else.
+    --
+    declaredShareOf :: ILCDExchangeRaw -> Maybe DeclaredShare
+    declaredShareOf raw = flip DeclaredShare Nothing <$> ierShare raw
+
     -- Look up the reference exchange's flow unit. Reference exchange is typically
     -- a technosphere product, but for waste-treatment processes it may be a
     -- biosphere input — try both maps before falling back to "kg".
@@ -644,7 +683,7 @@ buildActivity flowInfoMap techFlowDB bioFlowDB wasteFlowDB unitDB p =
                         , techLocation = ierLocation raw
                         , techComment = ierComment raw
                         , techPedigree = Nothing
-                        , techShare = Nothing
+                        , techShare = declaredShareOf raw
                         , techClassification = M.empty
                         }
 

--- a/src/ILCD/Writer.hs
+++ b/src/ILCD/Writer.hs
@@ -27,8 +27,13 @@ What round-trips: process UUID, name, location, classifications, processType,
 every exchange (flow ref, direction, amount, location, per-exchange comment), and the
 full flow + unit catalog (names, CAS, biosphere compartment, flow type, the
 flow→unit reference). These are exactly the fields "ILCD.Parser" reads back;
-fields the parser drops (activity description, synonyms, params, allocation,
-pedigree) are not representable in this ILCD profile and are not emitted.
+fields the parser drops (activity description, synonyms, params, pedigree)
+are not representable in this ILCD profile and are not emitted.
+
+The declared allocation fractions are the exception: the parser now reads
+them, and this writer does not yet write them back, so a block exported here
+loses the shares it was loaded with and its re-import is refused by the
+allocation gate. Emitting @<allocations>@ is what closes that.
 
 The flow→unit indirection mirrors the parser's resolution chain
 @flow → flowProperty → unitGroup@: we emit one flowProperty and one unitGroup

--- a/test/ILCDParserSpec.hs
+++ b/test/ILCDParserSpec.hs
@@ -3,7 +3,7 @@
 module ILCDParserSpec (spec) where
 
 import qualified Data.ByteString as BS
-import Data.List (find)
+import Data.List (find, sortOn)
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.UUID as UUID
@@ -283,6 +283,22 @@ spec = do
             fmap iprProcessType (parseProcessXML ilcdProcessWithClassification)
                 `shouldBe` Just ""
 
+    describe "the shares an ILCD dataset declares" $ do
+        it "reads the fraction a product output allocates to itself" $
+            fmap (map ierShare . sortOn ierInternalId . iprExchanges) (parseProcessXML ilcdAllocatedProcess)
+                `shouldBe` Just [Just 60.0, Just 40.0]
+
+        it "leaves a dataset that declares none without shares" $
+            fmap (map ierShare . iprExchanges) (parseProcessXML ilcdProcessWithClassification)
+                `shouldBe` Just [Nothing]
+
+        it "ignores a fraction allocated to another co-product" $
+            -- ILCD lets an exchange allocate to any co-product by internal id.
+            -- Only the entry naming the exchange itself says "this product's
+            -- share", which is the one DeclaredShare can hold.
+            fmap (map ierShare . sortOn ierInternalId . iprExchanges) (parseProcessXML ilcdCrossAllocatedProcess)
+                `shouldBe` Just [Just 60.0, Nothing]
+
     describe "parseProcessXML exchange fields" $ do
         it "parses single exchange flow ref" $ do
             let Just raw = parseProcessXML ilcdProcessWithClassification
@@ -506,3 +522,56 @@ ilcdProcessWithProcessType =
     \</exchange>\
     \</exchanges>\
     \</processDataSet>"
+
+{- | Two product outputs, each allocating a fraction to itself: the shape a
+dataset takes when its author states an allocation key.
+-}
+ilcdAllocatedProcess :: BS.ByteString
+ilcdAllocatedProcess = allocatedProcess "0" "60.0" "1" "40.0"
+
+{- | The same block, except the second exchange allocates to the first. No
+share is then readable for it, and the allocation gate refuses the dataset
+rather than splitting on a number that meant something else.
+-}
+ilcdCrossAllocatedProcess :: BS.ByteString
+ilcdCrossAllocatedProcess = allocatedProcess "0" "60.0" "0" "40.0"
+
+-- | A two-output dataset whose two @<allocation>@ entries are given.
+allocatedProcess :: BS.ByteString -> BS.ByteString -> BS.ByteString -> BS.ByteString -> BS.ByteString
+allocatedProcess ref0 pct0 ref1 pct1 =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+    \<processDataSet xmlns=\"http://lca.jrc.it/ILCD/Process\" \
+    \xmlns:common=\"http://lca.jrc.it/ILCD/Common\">\
+    \<processInformation>\
+    \<dataSetInformation>\
+    \<common:UUID>52345678-1234-1234-1234-123456789abc</common:UUID>\
+    \<name><baseName>Allocated block</baseName></name>\
+    \</dataSetInformation>\
+    \<geography location=\"FR\"/>\
+    \<quantitativeReference>\
+    \<referenceToReferenceFlow>0</referenceToReferenceFlow>\
+    \</quantitativeReference>\
+    \</processInformation>\
+    \<exchanges>\
+    \<exchange dataSetInternalID=\"0\">\
+    \<referenceToFlowDataSet refObjectId=\"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\"/>\
+    \<exchangeDirection>Output</exchangeDirection>\
+    \<resultingAmount>1.0</resultingAmount>\
+    \<allocations><allocation internalReferenceToCoProduct=\""
+        <> ref0
+        <> "\" allocatedFraction=\""
+        <> pct0
+        <> "\"/></allocations>\
+           \</exchange>\
+           \<exchange dataSetInternalID=\"1\">\
+           \<referenceToFlowDataSet refObjectId=\"bbbbbbbb-cccc-dddd-eeee-ffffffffffff\"/>\
+           \<exchangeDirection>Output</exchangeDirection>\
+           \<resultingAmount>2.0</resultingAmount>\
+           \<allocations><allocation internalReferenceToCoProduct=\""
+        <> ref1
+        <> "\" allocatedFraction=\""
+        <> pct1
+        <> "\"/></allocations>\
+           \</exchange>\
+           \</exchanges>\
+           \</processDataSet>"

--- a/test/ILCDParserSpec.hs
+++ b/test/ILCDParserSpec.hs
@@ -292,6 +292,14 @@ spec = do
             fmap (map ierShare . iprExchanges) (parseProcessXML ilcdProcessWithClassification)
                 `shouldBe` Just [Nothing]
 
+        it "reads no share when the exchange allocates to several co-products" $
+            -- The general form: each exchange is distributed across the
+            -- co-products, and its entry pointing at itself is its own share
+            -- of itself. Reading that as a declared share would give every
+            -- product 100 % and hand each one the whole inventory.
+            fmap (map ierShare . iprExchanges) (parseProcessXML ilcdMatrixAllocatedProcess)
+                `shouldBe` Just [Nothing, Nothing]
+
         it "ignores a fraction allocated to another co-product" $
             -- ILCD lets an exchange allocate to any co-product by internal id.
             -- Only the entry naming the exchange itself says "this product's
@@ -529,6 +537,13 @@ dataset takes when its author states an allocation key.
 ilcdAllocatedProcess :: BS.ByteString
 ilcdAllocatedProcess = allocatedProcess "0" "60.0" "1" "40.0"
 
+{- | Both exchanges written in the general form: each distributes itself
+across the two co-products, so the entry naming the exchange itself is 100
+and says nothing about allocation.
+-}
+ilcdMatrixAllocatedProcess :: BS.ByteString
+ilcdMatrixAllocatedProcess = matrixAllocatedProcess
+
 {- | The same block, except the second exchange allocates to the first. No
 share is then readable for it, and the allocation gate refuses the dataset
 rather than splitting on a number that meant something else.
@@ -575,3 +590,43 @@ allocatedProcess ref0 pct0 ref1 pct1 =
            \</exchange>\
            \</exchanges>\
            \</processDataSet>"
+
+{- | A two-output dataset where each exchange spreads itself over both
+co-products, the general form ILCD also allows.
+-}
+matrixAllocatedProcess :: BS.ByteString
+matrixAllocatedProcess =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+    \<processDataSet xmlns=\"http://lca.jrc.it/ILCD/Process\" \
+    \xmlns:common=\"http://lca.jrc.it/ILCD/Common\">\
+    \<processInformation>\
+    \<dataSetInformation>\
+    \<common:UUID>62345678-1234-1234-1234-123456789abc</common:UUID>\
+    \<name><baseName>Matrix allocated block</baseName></name>\
+    \</dataSetInformation>\
+    \<geography location=\"FR\"/>\
+    \<quantitativeReference>\
+    \<referenceToReferenceFlow>0</referenceToReferenceFlow>\
+    \</quantitativeReference>\
+    \</processInformation>\
+    \<exchanges>\
+    \<exchange dataSetInternalID=\"0\">\
+    \<referenceToFlowDataSet refObjectId=\"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\"/>\
+    \<exchangeDirection>Output</exchangeDirection>\
+    \<resultingAmount>1.0</resultingAmount>\
+    \<allocations>\
+    \<allocation internalReferenceToCoProduct=\"0\" allocatedFraction=\"100.0\"/>\
+    \<allocation internalReferenceToCoProduct=\"1\" allocatedFraction=\"0.0\"/>\
+    \</allocations>\
+    \</exchange>\
+    \<exchange dataSetInternalID=\"1\">\
+    \<referenceToFlowDataSet refObjectId=\"bbbbbbbb-cccc-dddd-eeee-ffffffffffff\"/>\
+    \<exchangeDirection>Output</exchangeDirection>\
+    \<resultingAmount>2.0</resultingAmount>\
+    \<allocations>\
+    \<allocation internalReferenceToCoProduct=\"0\" allocatedFraction=\"0.0\"/>\
+    \<allocation internalReferenceToCoProduct=\"1\" allocatedFraction=\"100.0\"/>\
+    \</allocations>\
+    \</exchange>\
+    \</exchanges>\
+    \</processDataSet>"


### PR DESCRIPTION
## Why

An ILCD dataset with several product outputs states how it wants to be allocated: the format carries a fraction on each product exchange. The parser dropped that, so every product arrived with no share, the split had nothing to work from, and the allocation gate refused the dataset as unallocated.

The refusal was correct given what had been read, and wrong about the file. The file said what it wanted; we were not listening.

## What changes

The parser reads `<allocation allocatedFraction>` and attaches it as the product's declared share, exactly as the SimaPro parser does with its allocation column. A multi-output ILCD dataset now splits on the key its author stated.

Only the fraction an exchange allocates to **itself** is read. ILCD also allows `internalReferenceToCoProduct` to name a *different* co-product, which is a matrix of shares rather than one share per product, and `DeclaredShare` cannot hold it. A dataset written that way keeps no share and stays refused. That is deliberate: better refused with the right words than split on a number that meant something else.

## What this does not do

The writer does not yet emit the fractions back, so exporting a block through ILCD still loses them and the re-import is refused. That was already true; what changed is that it is now an asymmetry rather than a uniform gap, so the writer's header says it instead of listing allocation among the fields the parser drops. Closing it means emitting `<allocations>`, which is a separate subject.

## On the evidence

No ILCD database with declared allocations is loaded here, so this is written against the format's own shape and exercised by fixtures in the spec, not against a real file. The reading is deliberately narrow for that reason: the self-allocating entry is the unambiguous case, and anything else is refused rather than guessed. A real allocated ILCD dataset would be worth running through this before leaning on it.

## Checks

Three examples: the fraction is read on a two-output block, a block declaring none still has no shares, and a cross-allocated block is left without one. Full suite 2417 examples, hlint clean, cold `-Werror` build green.
