### PR TITLE
Read the masses an EcoSpold 2 exchange declares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@
   unit to restate it in.
 
 ### Added
+- A technosphere exchange now reports the physical properties its source
+  states of that line, the dry and wet mass (`properties`). EcoSpold 2 writes
+  them per unit of the line, so a board of 1 m3 declaring 614.4 kg of dry
+  matter per m3 is reported as 614.4 kg; a property stated in something that
+  is not a mass keeps its own unit rather than being read as kilograms, and a
+  property this engine has no field for is dropped rather than guessed at.
+  This is the material an allocation key other than the one the source
+  declares is computed from. Wire revision 18.
+
+  Every database cache is rebuilt once on the first load after this release:
+  the cached exchanges say less than the loader now reads.
 - A flow search result now reports how many activities make the flow
   (`producerCount`), which is the number of ways the database offers to
   produce it: one on most of a French agricultural database, up to a few

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -24,7 +24,7 @@ The other direction is a promise about pyvolca's own names. A name this client p
 
 _Generated from `volca._compat`: run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.11.0** speaks wire formats **2 to 17** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error. A name this build has retired keeps working until pyvolca **1.0**.
+This build of **pyvolca 0.11.0** speaks wire formats **2 to 18** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error. A name this build has retired keeps working until pyvolca **1.0**.
 
 <!-- END: compatibility -->
 

--- a/pyvolca/src/volca/_compat.py
+++ b/pyvolca/src/volca/_compat.py
@@ -32,8 +32,10 @@ the client works against it except the revision-gated capabilities (see
 ``Client._require_wire``), which check the engine's advertised revision
 before sending anything."""
 
-KNOWN_WIRE = 17
-"""The newest wire revision this pyvolca understands (revision 17 adds
+KNOWN_WIRE = 18
+"""The newest wire revision this pyvolca understands (revision 18 adds
+``properties`` on a technosphere exchange, the dry and wet mass its source
+states of that line; revision 17 added
 ``count_search_matches``, how many processes, products and flows one query
 matches; revision 16 added ``producer_count`` on a flow search result, the
 number of activities that make it, and the ``role`` parameter asking a

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1313,7 +1313,9 @@ appears that a client must know about /before/ calling it. Adding a route
 does not exempt a change from the bump: an absent route answers 404, and so
 does a request naming a database the engine has not loaded, so a client
 cannot tell "this engine is too old" from "you asked for the wrong thing"
-(revision 17: the @search-counts@ route and its @count_search_matches@ tool,
+(revision 18: the @properties@ a technosphere exchange carries, the dry and
+wet mass its source states of that line;
+revision 17: the @search-counts@ route and its @count_search_matches@ tool,
 answering how many processes, products and flows one query matches;
 revision 16: the @producerCount@ a flow search result carries, and the
 @role@ parameter that asks a flow's activities for one side of it only;
@@ -1342,7 +1344,7 @@ the whole filtered set).
 Clients compare it to decide compatibility and to gate such capabilities.
 -}
 currentWireVersion :: Int
-currentWireVersion = 17
+currentWireVersion = 18
 
 getVersion :: AppM Value
 getVersion = do

--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -392,6 +392,7 @@ productRowOut cfg meta isRef f =
             , techPedigree = Nothing
             , techShare = Nothing
             , techClassification = M.empty
+            , techProperties = noProperties
             }
     flow = TechnosphereFlow flowUUID name unitUUID M.empty Nothing Nothing
     unit = Unit unitUUID effUnit effUnit ""
@@ -437,6 +438,7 @@ technosphereRowOut cfg role actName f
             , techPedigree = Nothing
             , techShare = Nothing
             , techClassification = M.empty
+            , techProperties = noProperties
             }
     flow = TechnosphereFlow flowUUID name unitUUID M.empty Nothing Nothing
     unit = Unit unitUUID unitName' unitName' ""

--- a/src/Database/Allocation.hs
+++ b/src/Database/Allocation.hs
@@ -192,19 +192,10 @@ normalise act = promote act{exchanges = filter keep (exchanges act)}
         | exchangeFlowId ex == exchangeFlowId single && exchangeIsProductOutput ex = asReference ex
         | otherwise = ex
 
-{- | Scale an exchange amount by a factor.
-
-A technosphere line's stated properties describe the line as a whole, so they
-are scaled with it: half a line of 2 kg weighs 1 kg, and a property left
-behind at 2 kg would contradict the amount printed beside it.
--}
+-- | Scale an exchange amount by a factor.
 scaleExchange :: Double -> Exchange -> Exchange
 scaleExchange factor ex = case ex of
-    TechnosphereExchange{} ->
-        ex
-            { techAmount = techAmount ex * factor
-            , techProperties = scaleProperties factor (techProperties ex)
-            }
+    TechnosphereExchange{} -> ex{techAmount = techAmount ex * factor}
     BiosphereExchange{} -> ex{bioAmount = bioAmount ex * factor}
     WasteExchange{} -> ex{waAmount = waAmount ex * factor}
 

--- a/src/Database/Allocation.hs
+++ b/src/Database/Allocation.hs
@@ -33,7 +33,6 @@ module Database.Allocation (
     describeRefusal,
     scaleExchange,
     MassKeyRefusal (..),
-    StatedAmount (..),
     massShares,
 ) where
 
@@ -131,13 +130,6 @@ describeRefusal refusal = case refusal of
     NoSingleReference 0 -> "no reference exchange: one product output must be the reference"
     NoSingleReference k -> T.pack (show k) <> " reference exchanges where exactly one is needed"
 
--- | One product row's amount and the unit it states that amount in.
-data StatedAmount = StatedAmount
-    { saUnit :: !Text
-    , saAmount :: !Double
-    }
-    deriving (Eq, Show)
-
 -- | Why the mass of a block's products cannot serve as a key.
 data MassKeyRefusal
     = -- | The unit a product is stated in, which is not a mass.
@@ -200,10 +192,19 @@ normalise act = promote act{exchanges = filter keep (exchanges act)}
         | exchangeFlowId ex == exchangeFlowId single && exchangeIsProductOutput ex = asReference ex
         | otherwise = ex
 
--- | Scale an exchange amount by a factor.
+{- | Scale an exchange amount by a factor.
+
+A technosphere line's stated properties describe the line as a whole, so they
+are scaled with it: half a line of 2 kg weighs 1 kg, and a property left
+behind at 2 kg would contradict the amount printed beside it.
+-}
 scaleExchange :: Double -> Exchange -> Exchange
 scaleExchange factor ex = case ex of
-    TechnosphereExchange{} -> ex{techAmount = techAmount ex * factor}
+    TechnosphereExchange{} ->
+        ex
+            { techAmount = techAmount ex * factor
+            , techProperties = scaleProperties factor (techProperties ex)
+            }
     BiosphereExchange{} -> ex{bioAmount = bioAmount ex * factor}
     WasteExchange{} -> ex{waAmount = waAmount ex * factor}
 

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -96,6 +96,7 @@ import Types (
     exchangeIsReference,
     findProcessIdByActivityUUID,
     getUnitNameForExchange,
+    noProperties,
     parseProcessRef,
  )
 import UnitConversion (UnitConfig, convertUnit, normalizeUnit)
@@ -292,6 +293,7 @@ validateOne ctx a =
                         , techPedigree = Nothing
                         , techShare = Nothing
                         , techClassification = M.empty
+                        , techProperties = noProperties
                         }
                 productFlow =
                     TechnosphereFlow
@@ -638,6 +640,7 @@ resolveOne ctx ex = case ex of
                 , techPedigree = Nothing
                 , techShare = Nothing
                 , techClassification = M.empty
+                , techProperties = noProperties
                 }
     AuthoredWasteOutput provider amount mUnit comment ->
         resolveLinked ctx provider amount mUnit $ \sup unitRef ->

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -280,6 +280,9 @@ History of manual bumps:
 - 20: the payload records the unit table and location aliases the database
      was built with ('dbBuiltWith'), compared before a cache is trusted. Old
      caches end before the field.
+- 21: a technosphere line carries the physical properties its source states
+     ('techProperties'), the material an allocation key other than the declared
+     one is computed from. Cached exchanges end before the field.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.
@@ -287,7 +290,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeRep (Proxy :: Proxy Database))
-     in hi `xor` lo `xor` 20
+     in hi `xor` lo `xor` 21
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -624,6 +624,7 @@ buildExchange activityLoc edata
             , techPedigree = Nothing
             , techShare = Nothing
             , techClassification = M.empty
+            , techProperties = noProperties
             }
 
 {- | One bibliographic line for a @\<source\>@. ecoinvent files put the

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -88,6 +88,7 @@ data IntermediateData = IntermediateData
     , idClassifications :: !(M.Map Text Text) -- per-exchange classifications (e.g. By-product classification → Waste)
     , idVariableName :: !Text -- variableName attribute (referencable from other formulas in the dataset)
     , idMathRel :: !Text -- mathematicalRelation attribute (formula defining the amount)
+    , idProperties :: !ExchangeProperties -- <property> children, per unit of the exchange amount until it closes
     }
     deriving (Eq)
 
@@ -130,6 +131,35 @@ data PendingParam = PendingParam
 
 emptyPendingParam :: PendingParam
 emptyPendingParam = PendingParam "" Nothing ""
+
+{- | The @\<property\>@ currently open, assembled from its @amount@ attribute
+and its @\<name\>@ and @\<unitName\>@ children, which arrive in no fixed order
+and are only complete when the element closes.
+-}
+data PendingProperty = PendingProperty
+    { ppyName :: !Text
+    , ppyUnit :: !Text
+    , ppyAmount :: !Double
+    }
+
+emptyPendingProperty :: PendingProperty
+emptyPendingProperty = PendingProperty "" "" 0
+
+{- | File a closed @\<property\>@ under the exchange property it names, if any.
+
+The name is the one ecoinvent writes; a property this engine has no field for
+is dropped rather than guessed at. The amount is left as the file states it,
+per unit of the exchange, and multiplied by the exchange amount when the
+exchange itself closes.
+-}
+recordProperty :: PendingProperty -> ExchangeProperties -> ExchangeProperties
+recordProperty pending props = case T.toLower (T.strip (ppyName pending)) of
+    "dry mass" -> props{epDryMass = Just stated}
+    "wet mass" -> props{epWetMass = Just stated}
+    _ -> props
+  where
+    stated :: StatedAmount
+    stated = StatedAmount{saUnit = T.strip (ppyUnit pending), saAmount = ppyAmount pending}
 
 -- | One @\<review\>@ of the dataset: who read it, when, and what they said.
 data Review = Review
@@ -207,6 +237,7 @@ data ParseState = ParseState
     , psParams :: !(M.Map Text Double) -- <parameter> variableName → amount (amounts are pre-evaluated in the source)
     , psParamExprs :: !(M.Map Text Text) -- <parameter> variableName → mathematicalRelation (raw formula, for inspection)
     , psPendingParam :: !PendingParam -- attribute accumulator for the open <parameter>
+    , psPendingProperty :: !PendingProperty -- attribute and child accumulator for the open <property>
     , psDocs :: !DatasetDocs -- Provenance the dataset states about itself
     }
 
@@ -237,6 +268,7 @@ initialParseState =
         , psParams = M.empty
         , psParamExprs = M.empty
         , psPendingParam = emptyPendingParam
+        , psPendingProperty = emptyPendingProperty
         , psDocs = emptyDatasetDocs
         }
 
@@ -304,6 +336,12 @@ popPath st = st{psPath = drop 1 (psPath st)}
 -- | The common close-tag epilogue: pop the path and discard accumulated text.
 popText :: ParseState -> ParseState
 popText st = (popPath st){psTextAccum = []}
+
+{- | Transform the open @\<property\>@ accumulator and close the child that
+carried the text, whichever child it was.
+-}
+onPendingProperty :: (PendingProperty -> PendingProperty) -> ParseState -> ParseState
+onPendingProperty f st = (popText st){psPendingProperty = f (psPendingProperty st)}
 
 -- | Is the element at the given depth (0 = currently-open tag) named @name@?
 pathAt :: Int -> BS.ByteString -> ParseState -> Bool
@@ -607,12 +645,14 @@ parseWithXeno xmlContent processId = do
                     state{psPendingCommentLang = ""}
                 | isElement tagName "parameter" =
                     state{psPendingParam = emptyPendingParam}
+                | isElement tagName "property" =
+                    state{psPendingProperty = emptyPendingProperty}
                 | otherwise = state
             newContext
                 | isElement tagName "activityName" = InActivityName
                 | isElement tagName "shortname" && any (isElement "geography") (psPath cleanState) = InGeographyShortname
                 | isElement tagName "intermediateExchange" =
-                    InIntermediateExchange (IntermediateData "" 0.0 "" "" "" "" "" "" M.empty Nothing M.empty "" "")
+                    InIntermediateExchange (IntermediateData "" 0.0 "" "" "" "" "" "" M.empty Nothing M.empty "" "" noProperties)
                 | isElement tagName "elementaryExchange" =
                     InElementaryExchange (ElementaryData "" 0.0 "" "" "" "" "" [] [] M.empty Nothing Nothing "" "")
                 | isElement tagName "text" && any (isElement "generalComment") (psPath cleanState) = InGeneralCommentText 0
@@ -633,6 +673,13 @@ parseWithXeno xmlContent processId = do
     -- Attribute handler - extract attributes
     attribute state name value =
         let isInsideProperty = pathAt 0 "property" state
+            -- The amount and unit an open <property> states. The exchange arms
+            -- above refuse both under the same guard, so this is the only
+            -- reader of them.
+            onProperty st
+                | isInsideProperty && isElement name "amount" =
+                    st{psPendingProperty = (psPendingProperty st){ppyAmount = bsToDouble value}}
+                | otherwise = st
             -- xml:lang on the currently-open <comment>; remembered until closeTag.
             -- Attribute order is not significant for entity ref selection — we
             -- only need the lang at close-time.
@@ -651,7 +698,7 @@ parseWithXeno xmlContent processId = do
                             | isElement name "variableName" && not isInsideProperty = idata{idVariableName = bsToText value}
                             | isElement name "mathematicalRelation" && not isInsideProperty = idata{idMathRel = bsToText value}
                             | otherwise = idata
-                     in withLang state{psContext = InIntermediateExchange updated}
+                     in onProperty (withLang state{psContext = InIntermediateExchange updated})
                 InElementaryExchange edata ->
                     let updated
                             | isElement name "elementaryExchangeId" = edata{edFlowId = bsToText value}
@@ -663,7 +710,7 @@ parseWithXeno xmlContent processId = do
                             | isElement name "variableName" && not isInsideProperty = edata{edVariableName = bsToText value}
                             | isElement name "mathematicalRelation" && not isInsideProperty = edata{edMathRel = bsToText value}
                             | otherwise = edata
-                     in withLang state{psContext = InElementaryExchange updated}
+                     in onProperty (withLang state{psContext = InElementaryExchange updated})
                 InGeneralCommentText _ ->
                     let idx = if isElement name "index" then bsToInt value else 0
                      in withLang state{psContext = InGeneralCommentText idx}
@@ -687,7 +734,7 @@ parseWithXeno xmlContent processId = do
                             | onParameter && isElement name "mathematicalRelation" =
                                 state{psPendingParam = pending{ppMathRel = bsToText value}}
                             | otherwise = docAttr name value state
-                     in withLang captured
+                     in onProperty (withLang captured)
 
     -- End of opening tag - no action needed for SAX
     endOpen state _tagName = state
@@ -759,6 +806,7 @@ parseWithXeno xmlContent processId = do
                                 , techPedigree = Nothing
                                 , techShare = Nothing
                                 , techClassification = M.empty
+                                , techProperties = scaleProperties (idAmount idata) (idProperties idata)
                                 }
                         techFlow = TechnosphereFlow flowUUID resolvedFlowName unitUUID (idSynonyms idata) Nothing Nothing
                         wasteExchange =
@@ -876,13 +924,23 @@ parseWithXeno xmlContent processId = do
         | isElement tagName "name" =
             let txt = accumText state
              in if pathAt 1 "property" state
-                    then popText state
+                    then onPendingProperty (\pending -> pending{ppyName = txt}) state
                     else onExchange (\d -> d{idFlowName = txt}) (\d -> d{edFlowName = txt}) state
         | isElement tagName "unitName" =
             let txt = accumText state
              in if pathAt 1 "property" state
-                    then popText state
+                    then onPendingProperty (\pending -> pending{ppyUnit = txt}) state
                     else onExchange (\d -> d{idUnitName = txt}) (\d -> d{edUnitName = txt}) state
+        | isElement tagName "property" =
+            let filed = case psContext state of
+                    InIntermediateExchange idata ->
+                        state{psContext = InIntermediateExchange idata{idProperties = recordProperty (psPendingProperty state) (idProperties idata)}}
+                    InElementaryExchange _ -> state
+                    InActivityName -> state
+                    InGeographyShortname -> state
+                    InGeneralCommentText _ -> state
+                    Other -> state
+             in (popText filed){psPendingProperty = emptyPendingProperty}
         | isElement tagName "synonym" =
             let txt = T.strip (accumText state)
                 ins m = if T.null txt then m else M.insertWith S.union "en" (S.singleton txt) m

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -88,7 +88,7 @@ data IntermediateData = IntermediateData
     , idClassifications :: !(M.Map Text Text) -- per-exchange classifications (e.g. By-product classification → Waste)
     , idVariableName :: !Text -- variableName attribute (referencable from other formulas in the dataset)
     , idMathRel :: !Text -- mathematicalRelation attribute (formula defining the amount)
-    , idProperties :: !ExchangeProperties -- <property> children, per unit of the exchange amount until it closes
+    , idProperties :: !ExchangeProperties -- <property> children, each per unit of the exchange amount
     }
     deriving (Eq)
 
@@ -139,27 +139,30 @@ and are only complete when the element closes.
 data PendingProperty = PendingProperty
     { ppyName :: !Text
     , ppyUnit :: !Text
-    , ppyAmount :: !Double
+    , ppyAmount :: !(Maybe Double)
     }
 
 emptyPendingProperty :: PendingProperty
-emptyPendingProperty = PendingProperty "" "" 0
+emptyPendingProperty = PendingProperty "" "" Nothing
 
 {- | File a closed @\<property\>@ under the exchange property it names, if any.
 
 The name is the one ecoinvent writes; a property this engine has no field for
-is dropped rather than guessed at. The amount is left as the file states it,
-per unit of the exchange, and multiplied by the exchange amount when the
-exchange itself closes.
+is dropped rather than guessed at, and so is one whose @amount@ the file omits
+or writes as something no number can be read from. The schema requires that
+attribute, so a file missing it is malformed, and recording the zero the
+absence would otherwise leave says the line weighs nothing.
+
+The amount stays as the file states it, per unit of the exchange.
 -}
 recordProperty :: PendingProperty -> ExchangeProperties -> ExchangeProperties
-recordProperty pending props = case T.toLower (T.strip (ppyName pending)) of
-    "dry mass" -> props{epDryMass = Just stated}
-    "wet mass" -> props{epWetMass = Just stated}
+recordProperty pending props = case (T.toLower (T.strip (ppyName pending)), ppyAmount pending) of
+    ("dry mass", Just amount) -> props{epDryMass = Just (stated amount)}
+    ("wet mass", Just amount) -> props{epWetMass = Just (stated amount)}
     _ -> props
   where
-    stated :: StatedAmount
-    stated = StatedAmount{saUnit = T.strip (ppyUnit pending), saAmount = ppyAmount pending}
+    stated :: Double -> StatedAmount
+    stated amount = StatedAmount{saUnit = T.strip (ppyUnit pending), saAmount = amount}
 
 -- | One @\<review\>@ of the dataset: who read it, when, and what they said.
 data Review = Review
@@ -678,7 +681,7 @@ parseWithXeno xmlContent processId = do
             -- reader of them.
             onProperty st
                 | isInsideProperty && isElement name "amount" =
-                    st{psPendingProperty = (psPendingProperty st){ppyAmount = bsToDouble value}}
+                    st{psPendingProperty = (psPendingProperty st){ppyAmount = readAmount (bsToText value)}}
                 | otherwise = st
             -- xml:lang on the currently-open <comment>; remembered until closeTag.
             -- Attribute order is not significant for entity ref selection — we
@@ -806,7 +809,7 @@ parseWithXeno xmlContent processId = do
                                 , techPedigree = Nothing
                                 , techShare = Nothing
                                 , techClassification = M.empty
-                                , techProperties = scaleProperties (idAmount idata) (idProperties idata)
+                                , techProperties = idProperties idata
                                 }
                         techFlow = TechnosphereFlow flowUUID resolvedFlowName unitUUID (idSynonyms idata) Nothing Nothing
                         wasteExchange =

--- a/src/ILCD/Parser.hs
+++ b/src/ILCD/Parser.hs
@@ -720,6 +720,7 @@ buildActivity flowInfoMap techFlowDB bioFlowDB wasteFlowDB unitDB p =
                         , techPedigree = Nothing
                         , techShare = declaredShareOf techRoleFor raw
                         , techClassification = M.empty
+                        , techProperties = noProperties
                         }
 
 --------------------------------------------------------------------------------

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -30,7 +30,7 @@ import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import Database (applyStructuredFilters, findActivitiesByFields, findFlowsBySynonym, flowNameRelevance)
-import Database.Allocation (StatedAmount (..), asAllocated, describeRefusal, massShares)
+import Database.Allocation (asAllocated, describeRefusal, massShares)
 import Database.MatrixBuild (findProducer, linkedProducer)
 import Matrix (DepDemands, Inventory, accumulateDepDemandsWith, activityNormalizationFactor, applyBiosphereMatrix, buildDemandVectorFromIndex, computeInventoryMatrix, depDemandsToVector, perturbA, perturbABatch, perturbGlobal, toList)
 import qualified Matrix.Export as MatrixExport

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -1198,6 +1198,7 @@ productToExchange unitCfg env role ProductRow{..} =
                 , techPedigree = pedigree
                 , techShare = share
                 , techClassification = M.fromList [("Category", prCategory) | not (T.null prCategory)]
+                , techProperties = noProperties
                 }
         -- A product row states its share of the block; an avoided product row
         -- has the same columns but names a substitution, not a share of anything.
@@ -1299,6 +1300,7 @@ techRowToExchange unitCfg env TechExchangeRow{..} =
                             , techPedigree = pedigree
                             , techShare = Nothing
                             , techClassification = M.empty
+                            , techProperties = noProperties
                             }
         flow =
             TechnosphereFlow

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -147,6 +147,59 @@ data DeclaredShare = DeclaredShare
     deriving (Eq, Show, Generic, NFData, Store)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped DeclaredShare)
 
+{- | An amount together with the unit it is stated in.
+
+Kept as written rather than converted: the conversion needs the unit table,
+which the parsers do not carry, and a number whose unit has been forgotten
+cannot be checked against the file it came from.
+-}
+data StatedAmount = StatedAmount
+    { saUnit :: !Text
+    , saAmount :: !Double
+    }
+    deriving (Eq, Show, Generic, NFData, Store)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped StatedAmount)
+
+{- | The physical properties of one exchange, as the source states them.
+
+Each is the property of the exchange /as a whole/, not per unit of it: an
+EcoSpold 2 @\<property\>@ states kilograms per unit of the exchange amount and
+is multiplied by that amount when it is read, so 614.4 kg\/m3 on a line of
+2 m3 is recorded as 1228.8 kg. That is what an allocation key needs to sum,
+and it is what 'Database.Allocation.scaleExchange' keeps in step when an
+exchange is scaled.
+
+'Nothing' is "the source states none", never a zero standing in for it: a
+product of no mass and a product whose mass is unknown are different answers
+to whether the mass can serve as a key.
+-}
+data ExchangeProperties = ExchangeProperties
+    { epDryMass :: !(Maybe StatedAmount)
+    , epWetMass :: !(Maybe StatedAmount)
+    }
+    deriving (Eq, Show, Generic, NFData, Store)
+    deriving (ToJSON, FromJSON, ToSchema) via (Stripped ExchangeProperties)
+
+-- | An exchange whose source states no property.
+noProperties :: ExchangeProperties
+noProperties = ExchangeProperties{epDryMass = Nothing, epWetMass = Nothing}
+
+{- | Multiply every property an exchange states by a factor.
+
+Two callers, one meaning: the EcoSpold 2 parser turns a property stated per
+unit into the property of the whole line, and 'Database.Allocation.allocate'
+keeps a scaled line's properties in step with its amount.
+-}
+scaleProperties :: Double -> ExchangeProperties -> ExchangeProperties
+scaleProperties factor props =
+    ExchangeProperties
+        { epDryMass = scaleStated <$> epDryMass props
+        , epWetMass = scaleStated <$> epWetMass props
+        }
+  where
+    scaleStated :: StatedAmount -> StatedAmount
+    scaleStated stated = stated{saAmount = saAmount stated * factor}
+
 -- | Unit representation (kg, MJ, m³, etc.)
 data Unit = Unit
     { unitId :: !UUID -- Unique unit identifier
@@ -265,6 +318,7 @@ data Exchange
         , techPedigree :: !(Maybe Pedigree) -- LCA data-quality scores when available
         , techShare :: !(Maybe DeclaredShare) -- The share a product output was declared with; Nothing on inputs and where the source states none
         , techClassification :: !(M.Map Text Text) -- What the source says of this product row (SimaPro "Category"); carried onto the process split for it
+        , techProperties :: !ExchangeProperties -- Physical properties the source states of this line, the material an allocation key other than the declared one is computed from
         }
     | BiosphereExchange
         { bioFlowId :: !UUID -- Flow being exchanged

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -162,12 +162,15 @@ data StatedAmount = StatedAmount
 
 {- | The physical properties of one exchange, as the source states them.
 
-Each is the property of the exchange /as a whole/, not per unit of it: an
-EcoSpold 2 @\<property\>@ states kilograms per unit of the exchange amount and
-is multiplied by that amount when it is read, so 614.4 kg\/m3 on a line of
-2 m3 is recorded as 1228.8 kg. That is what an allocation key needs to sum,
-and it is what 'Database.Allocation.scaleExchange' keeps in step when an
-exchange is scaled.
+Each is stated /per unit of the exchange amount/, which is how EcoSpold 2
+writes them: 614.4 kg of dry matter per m3 of board is recorded as 614.4 kg,
+whether the line is 1 m3 or 2. The mass of the whole line is the product of
+the two, taken where it is needed.
+
+Per unit rather than per line on purpose. A property that referred to the
+amount would have to be recomputed by every operation that touches an amount,
+and the one that forgot would leave a line saying 2 m3 and 614.4 kg. Referring
+to the unit instead, it cannot contradict the amount beside it.
 
 'Nothing' is "the source states none", never a zero standing in for it: a
 product of no mass and a product whose mass is unknown are different answers
@@ -183,22 +186,6 @@ data ExchangeProperties = ExchangeProperties
 -- | An exchange whose source states no property.
 noProperties :: ExchangeProperties
 noProperties = ExchangeProperties{epDryMass = Nothing, epWetMass = Nothing}
-
-{- | Multiply every property an exchange states by a factor.
-
-Two callers, one meaning: the EcoSpold 2 parser turns a property stated per
-unit into the property of the whole line, and 'Database.Allocation.allocate'
-keeps a scaled line's properties in step with its amount.
--}
-scaleProperties :: Double -> ExchangeProperties -> ExchangeProperties
-scaleProperties factor props =
-    ExchangeProperties
-        { epDryMass = scaleStated <$> epDryMass props
-        , epWetMass = scaleStated <$> epWetMass props
-        }
-  where
-    scaleStated :: StatedAmount -> StatedAmount
-    scaleStated stated = stated{saAmount = saAmount stated * factor}
 
 -- | Unit representation (kg, MJ, m³, etc.)
 data Unit = Unit

--- a/test/ActivityWriteHandlerSpec.hs
+++ b/test/ActivityWriteHandlerSpec.hs
@@ -66,6 +66,7 @@ import Types (
     TechnosphereFlow (..),
     UUID,
     Unit (..),
+    noProperties,
  )
 import UnitConversion (defaultUnitConfig)
 
@@ -520,6 +521,7 @@ milkActivity =
                 , techPedigree = Nothing
                 , techShare = Nothing
                 , techClassification = M.empty
+                , techProperties = noProperties
                 }
             , BiosphereExchange
                 { bioFlowId = co2Id

--- a/test/AllocationSpec.hs
+++ b/test/AllocationSpec.hs
@@ -261,6 +261,7 @@ tech fid amount role =
         , techPedigree = Nothing
         , techShare = Nothing
         , techClassification = M.empty
+        , techProperties = noProperties
         }
 
 bio :: Double -> Exchange

--- a/test/AuthorSpec.hs
+++ b/test/AuthorSpec.hs
@@ -62,6 +62,7 @@ import Types (
     findProcessId,
     getActivity,
     isTechnosphereExchange,
+    noProperties,
     processIdToText,
  )
 import UnitConversion (defaultUnitConfig)
@@ -731,6 +732,7 @@ importedActivity =
                 , techPedigree = Nothing
                 , techShare = Nothing
                 , techClassification = M.empty
+                , techProperties = noProperties
                 }
             , TechnosphereExchange
                 { techFlowId = coproductId
@@ -744,6 +746,7 @@ importedActivity =
                 , techPedigree = Nothing
                 , techShare = Nothing
                 , techClassification = M.empty
+                , techProperties = noProperties
                 }
             , TechnosphereExchange
                 { techFlowId = supplierProdId
@@ -757,6 +760,7 @@ importedActivity =
                 , techPedigree = Just milkPedigree
                 , techShare = Nothing
                 , techClassification = M.empty
+                , techProperties = noProperties
                 }
             , BiosphereExchange
                 { bioFlowId = co2Id
@@ -987,6 +991,7 @@ treatmentWithHeat =
                         , techPedigree = Nothing
                         , techShare = Nothing
                         , techClassification = M.empty
+                        , techProperties = noProperties
                         }
                    ]
         }
@@ -1018,6 +1023,7 @@ treatmentActivity =
                 , techPedigree = Nothing
                 , techShare = Nothing
                 , techClassification = M.empty
+                , techProperties = noProperties
                 }
             ]
         , activityParams = M.empty
@@ -1051,6 +1057,7 @@ supplierActivityAt actId prodId =
                 , techPedigree = Nothing
                 , techShare = Nothing
                 , techClassification = M.empty
+                , techProperties = noProperties
                 }
             , BiosphereExchange
                 { bioFlowId = co2Id

--- a/test/BM25Spec.hs
+++ b/test/BM25Spec.hs
@@ -54,6 +54,7 @@ mkRefOutput fid =
         , techPedigree = Nothing
         , techShare = Nothing
         , techClassification = M.empty
+        , techProperties = noProperties
         }
 
 mkFlow :: UUID -> Text -> TechnosphereFlow

--- a/test/BrightwayExcelWriterSpec.hs
+++ b/test/BrightwayExcelWriterSpec.hs
@@ -286,6 +286,7 @@ prodExch =
         , techPedigree = Nothing
         , techShare = Nothing
         , techClassification = M.empty
+        , techProperties = noProperties
         }
 
 gasExch :: Exchange
@@ -302,6 +303,7 @@ gasExch =
         , techPedigree = Nothing
         , techShare = Nothing
         , techClassification = M.empty
+        , techProperties = noProperties
         }
 
 co2Exch :: Exchange
@@ -378,6 +380,7 @@ specialAct =
                 , techPedigree = Nothing
                 , techShare = Nothing
                 , techClassification = M.empty
+                , techProperties = noProperties
                 }
             , TechnosphereExchange
                 { techFlowId = tfId specialInputFlow
@@ -391,6 +394,7 @@ specialAct =
                 , techPedigree = Nothing
                 , techShare = Nothing
                 , techClassification = M.empty
+                , techProperties = noProperties
                 }
             , BiosphereExchange
                 { bioFlowId = bfId specialBio
@@ -471,6 +475,7 @@ refInputAct =
                 , techPedigree = Nothing
                 , techShare = Nothing
                 , techClassification = M.empty
+                , techProperties = noProperties
                 }
             ]
         }
@@ -555,6 +560,7 @@ kgProduction flow role amount =
         , techPedigree = Nothing
         , techShare = Nothing
         , techClassification = M.empty
+        , techProperties = noProperties
         }
 
 coproductDb :: SimpleDatabase
@@ -642,6 +648,7 @@ gramRefDb =
                     , techPedigree = Nothing
                     , techShare = Nothing
                     , techClassification = M.empty
+                    , techProperties = noProperties
                     }
                 ]
             }

--- a/test/CoproductTargetSpec.hs
+++ b/test/CoproductTargetSpec.hs
@@ -309,6 +309,7 @@ techExchange flowId amount role link =
         , techPedigree = Nothing
         , techShare = Nothing
         , techClassification = M.empty
+        , techProperties = noProperties
         }
 
 bareActivity :: Text -> [Exchange] -> Activity

--- a/test/CopySpec.hs
+++ b/test/CopySpec.hs
@@ -52,6 +52,7 @@ import Types (
     TechnosphereFlow (..),
     UUID,
     Unit (..),
+    noProperties,
  )
 import UnitConversion (defaultUnitConfig)
 
@@ -273,6 +274,7 @@ supplierDB offset products =
                         , techPedigree = Nothing
                         , techShare = Nothing
                         , techClassification = M.empty
+                        , techProperties = noProperties
                         }
                   act =
                     Activity

--- a/test/CrossDBActivityLinkSpec.hs
+++ b/test/CrossDBActivityLinkSpec.hs
@@ -94,6 +94,7 @@ refEx fid =
         , techPedigree = Nothing
         , techShare = Nothing
         , techClassification = M.empty
+        , techProperties = noProperties
         }
 
 -- | An input for @flowId@, linked to producer activity @linkId@ (nil = unlinked).
@@ -111,6 +112,7 @@ inputEx flowId linkId =
         , techPedigree = Nothing
         , techShare = Nothing
         , techClassification = M.empty
+        , techProperties = noProperties
         }
 
 mkDB :: [((UUID.UUID, UUID.UUID), Activity)] -> [TechnosphereFlow] -> SimpleDatabase

--- a/test/CrossLinkingSpec.hs
+++ b/test/CrossLinkingSpec.hs
@@ -406,6 +406,7 @@ mkRefExchangeAt loc =
         , techPedigree = Nothing
         , techShare = Nothing
         , techClassification = M.empty
+        , techProperties = noProperties
         }
   where
     flowUUID = read "aaaaaaaa-0000-0000-0000-000000000001"

--- a/test/DeleteSelectionSpec.hs
+++ b/test/DeleteSelectionSpec.hs
@@ -61,6 +61,7 @@ import Types (
     UUID,
     Unit (..),
     findProcessId,
+    noProperties,
     processIdToText,
  )
 import UnitConversion (defaultUnitConfig)
@@ -463,6 +464,7 @@ refOut actUUID prodUUID =
         , techPedigree = Nothing
         , techShare = Nothing
         , techClassification = M.empty
+        , techProperties = noProperties
         }
 
 -- | An input exchange linking to a supplier's @(supplierActUUID, supplierProdUUID)@.
@@ -480,6 +482,7 @@ inputFrom supplierActUUID supplierProdUUID =
         , techPedigree = Nothing
         , techShare = Nothing
         , techClassification = M.empty
+        , techProperties = noProperties
         }
 
 {- | A waste output linking to a treatment activity's

--- a/test/EcoSpold1WriterSpec.hs
+++ b/test/EcoSpold1WriterSpec.hs
@@ -204,7 +204,7 @@ soloDb name prodU extra techs bios wastes =
         , sdbUnits = units1
         }
   where
-    ref = TechnosphereExchange prodU 1.0 kgUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty
+    ref = TechnosphereExchange prodU 1.0 kgUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
     act = Activity name [] [] M.empty M.empty "GLO" LocationDeclared "kg" (ref : extra) M.empty M.empty Nothing Nothing Nothing
 
 -- | Empty database: no activities, no flows.
@@ -234,10 +234,10 @@ linkedDb link =
     supU = supplierLink
     conU = read "33333333-0000-4000-8000-000000000001"
     mkAct nm prodU exs = Activity nm [] [] M.empty M.empty "GLO" LocationDeclared "kg" (refOf prodU : exs) M.empty M.empty Nothing Nothing Nothing
-    refOf prodU = TechnosphereExchange prodU 1.0 kgUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty
+    refOf prodU = TechnosphereExchange prodU 1.0 kgUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
     supplier = mkAct "aaa supplier" supU []
     -- The consumer's input consumes the supplier's product and links to it.
-    consumer = mkAct "bbb consumer" conU [TechnosphereExchange supU 2.0 kgUnit Input link Nothing "" Nothing Nothing Nothing M.empty]
+    consumer = mkAct "bbb consumer" conU [TechnosphereExchange supU 2.0 kgUnit Input link Nothing "" Nothing Nothing Nothing M.empty noProperties]
 
 {- | A supplier written as two coproduct rows sharing one activity UUID, and a
 consumer whose input names the first of them. Canonical order gives the two
@@ -269,8 +269,8 @@ coproductDb =
     prodBU = read "44444444-0000-4000-8000-00000000000b"
     conU = read "33333333-0000-4000-8000-000000000001"
     mkAct nm prodU exs = Activity nm [] [] M.empty M.empty "GLO" LocationDeclared "kg" (refOf prodU : exs) M.empty M.empty Nothing Nothing Nothing
-    refOf prodU = TechnosphereExchange prodU 1.0 kgUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty
-    inputOnA = TechnosphereExchange prodAU 2.0 kgUnit Input supU Nothing "" Nothing Nothing Nothing M.empty
+    refOf prodU = TechnosphereExchange prodU 1.0 kgUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
+    inputOnA = TechnosphereExchange prodAU 2.0 kgUnit Input supU Nothing "" Nothing Nothing Nothing M.empty noProperties
 
 {- | The supplier's stored activity UUID — the first component of its
 'sdbActivities' key, and the value a solver-resolved input carries in
@@ -617,7 +617,7 @@ spec = do
             -- would re-parse it as a reference product (input → output flip).
             let prodU = read "77777777-0000-4000-8000-000000000001" :: UUID
                 refInU = read "77777777-0000-4000-8000-0000000000a0" :: UUID
-                refInEx = TechnosphereExchange refInU 1.0 kgUnit ReferenceInput UUID.nil Nothing "" Nothing Nothing Nothing M.empty
+                refInEx = TechnosphereExchange refInU 1.0 kgUnit ReferenceInput UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
                 techs = M.singleton refInU (TechnosphereFlow refInU "waste to treat" kgUnit M.empty Nothing Nothing)
                 sdb = soloDb "treatment process" prodU [refInEx] techs M.empty M.empty
             checkEcoSpold1Exportable sdb `shouldSatisfy` isLeft
@@ -668,7 +668,7 @@ spec = do
             -- does not round-trip: the joined text survives, but the parser reads
             -- it back as one element. This pins that documented behaviour.
             let prodU = read "cccc0000-0000-4000-8000-000000000001" :: UUID
-                ref = TechnosphereExchange prodU 1.0 kgUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty
+                ref = TechnosphereExchange prodU 1.0 kgUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
                 act =
                     Activity
                         "documented process"

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -5,7 +5,10 @@ module EcoSpold2Spec (spec) where
 import qualified Data.ByteString as BS
 import Data.List (isInfixOf)
 import qualified Data.Map as M
+import Data.Maybe (listToMaybe)
+import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.UUID as UUID
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
@@ -63,6 +66,28 @@ spec = describe "per-exchange comments" $ do
                     `shouldMatchList` [ Nothing -- ex1 has no top-level comment, only property comments
                                       , Just "Adhesive applied during pressing" -- ex2's exchange-level comment, NOT the noisy property comment
                                       ]
+
+    {- The same fixture, read for what those <property> children say rather
+    than for what they must not leak. A property is stated per unit of the
+    exchange, so the board's 614.4 kg/m3 on a line of 1 m3 is 614.4 kg of dry
+    matter; the glue's is 1.0 of a dimensionless quantity on 0.1 kg, and the
+    unit is kept as written so that whoever needs a mass can refuse it rather
+    than read 0.1 kg into it. "carbon content" names no property this engine
+    holds and is dropped rather than guessed at. -}
+    describe "properties an exchange states" $ do
+        it "reads the product's dry mass, scaled from per unit to the whole line" $
+            withPropertyFixture $ \act ->
+                propertiesOf "22222222-2222-2222-2222-222222222222" act
+                    `shouldBe` Just noProperties{epDryMass = Just (StatedAmount "kg" 614.4)}
+
+        it "keeps a property's own unit rather than assuming a mass" $
+            withPropertyFixture $ \act ->
+                propertiesOf "55555555-5555-5555-5555-555555555555" act
+                    `shouldBe` Just noProperties{epDryMass = Just (StatedAmount "dimensionless" 0.1)}
+
+        it "leaves the exchange amounts exactly as the file states them" $
+            withPropertyFixture $ \act ->
+                map exchangeAmount (exchanges act) `shouldMatchList` [1.0, 0.1]
 
     -- Pattern A: elementaryExchange with compartment=inventory indicator
     -- subcompartment=waste must surface as a WasteExchange / WasteFlow,
@@ -441,6 +466,23 @@ noGeographyXml =
     \    </flowData>\n\
     \  </activityDataset>\n\
     \</ecoSpold>\n"
+
+-- | The sawnwood fixture, whose two exchanges carry @\<property\>@ children.
+withPropertyFixture :: (Activity -> IO ()) -> IO ()
+withPropertyFixture k = do
+    result <- streamParseActivityAndFlowsFromFile "test-data/sawnwood-properties_12345678-1234-5678-9abc-12345678aaaa.spold"
+    case result of
+        Left err -> expectationFailure $ "Parse failed: " ++ err
+        Right (act, _, _, _, _) -> k act
+
+-- | The properties recorded on the exchange of a given flow, by flow id.
+propertiesOf :: Text -> Activity -> Maybe ExchangeProperties
+propertiesOf flowId act =
+    listToMaybe
+        [ techProperties ex
+        | ex@TechnosphereExchange{} <- exchanges act
+        , Just (exchangeFlowId ex) == UUID.fromText flowId
+        ]
 
 withWastePatternsFixture :: ((Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]) -> IO ()) -> IO ()
 withWastePatternsFixture k = withSystemTempDirectory "es2-waste-spec" $ \dir -> do

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -68,22 +68,23 @@ spec = describe "per-exchange comments" $ do
                                       ]
 
     {- The same fixture, read for what those <property> children say rather
-    than for what they must not leak. A property is stated per unit of the
-    exchange, so the board's 614.4 kg/m3 on a line of 1 m3 is 614.4 kg of dry
-    matter; the glue's is 1.0 of a dimensionless quantity on 0.1 kg, and the
-    unit is kept as written so that whoever needs a mass can refuse it rather
-    than read 0.1 kg into it. "carbon content" names no property this engine
-    holds and is dropped rather than guessed at. -}
+    than for what they must not leak. A property is recorded per unit of the
+    exchange, as the file states it: the glue line is 0.1 kg and declares 1.0,
+    so 1.0 is what is recorded and 0.1 would mean the record had been made to
+    depend on the amount beside it. Its unit is kept as written, so whoever
+    needs a mass can refuse a dimensionless quantity rather than read
+    kilograms into it. "carbon content" names no property this engine holds
+    and is dropped rather than guessed at. -}
     describe "properties an exchange states" $ do
-        it "reads the product's dry mass, scaled from per unit to the whole line" $
+        it "reads the dry mass a product declares" $
             withPropertyFixture $ \act ->
                 propertiesOf "22222222-2222-2222-2222-222222222222" act
                     `shouldBe` Just noProperties{epDryMass = Just (StatedAmount "kg" 614.4)}
 
-        it "keeps a property's own unit rather than assuming a mass" $
+        it "records the property per unit of the line, not per line" $
             withPropertyFixture $ \act ->
                 propertiesOf "55555555-5555-5555-5555-555555555555" act
-                    `shouldBe` Just noProperties{epDryMass = Just (StatedAmount "dimensionless" 0.1)}
+                    `shouldBe` Just noProperties{epDryMass = Just (StatedAmount "dimensionless" 1.0)}
 
         it "leaves the exchange amounts exactly as the file states them" $
             withPropertyFixture $ \act ->

--- a/test/EcoSpold2WriterSpec.hs
+++ b/test/EcoSpold2WriterSpec.hs
@@ -112,8 +112,8 @@ fixtureSimple =
             "GLO"
             LocationDeclared
             "kg"
-            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty
-            , TechnosphereExchange prodB 2.0 unitMJ Input actB Nothing "" (Just "energy input") Nothing Nothing M.empty
+            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
+            , TechnosphereExchange prodB 2.0 unitMJ Input actB Nothing "" (Just "energy input") Nothing Nothing M.empty noProperties
             , BiosphereExchange co2 0.5 unitKg Emission "" Nothing Nothing
             ]
             M.empty
@@ -131,7 +131,7 @@ fixtureSimple =
             "GLO"
             LocationDeclared
             "MJ"
-            [ TechnosphereExchange prodB 1.0 unitMJ ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty
+            [ TechnosphereExchange prodB 1.0 unitMJ ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
             , BiosphereExchange land 0.1 unitM2a Resource "" Nothing Nothing
             ]
             M.empty
@@ -169,7 +169,7 @@ fixtureDupBio =
             "GLO"
             LocationDeclared
             "kg"
-            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty
+            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
             , BiosphereExchange co2 0.5 unitKg Emission "" Nothing Nothing
             , BiosphereExchange co2 0.3 unitKg Emission "" Nothing Nothing
             ]
@@ -203,7 +203,7 @@ fixtureWithExchange ex =
             "GLO"
             LocationDeclared
             "kg"
-            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty
+            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
             , ex
             ]
             M.empty
@@ -240,7 +240,7 @@ fixtureWithBioSynonyms =
             "GLO"
             LocationDeclared
             "kg"
-            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty
+            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
             , BiosphereExchange co2 0.5 unitKg Emission "" Nothing Nothing
             ]
             M.empty
@@ -286,8 +286,8 @@ fixtureWasteCoproduct =
             "GLO"
             LocationDeclared
             "kg"
-            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty
-            , TechnosphereExchange coprodU 0.4 unitKg Coproduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty
+            [ TechnosphereExchange prodA 1.0 unitKg ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
+            , TechnosphereExchange coprodU 0.4 unitKg Coproduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
             , WasteExchange wasteInU 0.2 unitKg True UUID.nil Nothing "" Nothing Nothing
             , WasteExchange wasteOutU 0.3 unitKg False UUID.nil Nothing "" Nothing Nothing
             ]
@@ -424,7 +424,7 @@ spec = describe "EcoSpold2 writer round-trip" $ do
 
         it "rejects a reference input (no EcoSpold2 encoding)" $
             checkEcoSpold2Exportable
-                (fixtureWithExchange (TechnosphereExchange co2 2.0 unitKg ReferenceInput UUID.nil Nothing "" Nothing Nothing Nothing M.empty))
+                (fixtureWithExchange (TechnosphereExchange co2 2.0 unitKg ReferenceInput UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties))
                 `shouldSatisfy` isLeft
 
         it "rejects an exchange whose unit is absent from the registry" $

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -111,7 +111,7 @@ buildFixture comp = do
             "GLO"
             LocationDeclared
             "kg"
-            [ TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty
+            [ TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
             , BiosphereExchange co2U 0.5 unitU Emission "" Nothing Nothing
             ]
             M.empty

--- a/test/GapReportSpec.hs
+++ b/test/GapReportSpec.hs
@@ -48,6 +48,7 @@ import Types (
     TechnosphereFlow (..),
     Unit (..),
     WasteFlow (..),
+    noProperties,
  )
 import UnitConversion (defaultUnitConfig)
 
@@ -124,6 +125,7 @@ techInput fid amount =
         , techPedigree = Nothing
         , techShare = Nothing
         , techClassification = M.empty
+        , techProperties = noProperties
         }
 
 wasteInput :: UUID -> Double -> Exchange

--- a/test/ILCDParserSpec.hs
+++ b/test/ILCDParserSpec.hs
@@ -48,6 +48,7 @@ activityWithRefExchange fid =
                 , techPedigree = Nothing
                 , techShare = Nothing
                 , techClassification = M.empty
+                , techProperties = noProperties
                 }
             ]
         , activityParams = M.empty
@@ -82,6 +83,7 @@ activityWithInputExchange fid =
                 , techPedigree = Nothing
                 , techShare = Nothing
                 , techClassification = M.empty
+                , techProperties = noProperties
                 }
             ]
         , activityParams = M.empty

--- a/test/ILCDWriterSpec.hs
+++ b/test/ILCDWriterSpec.hs
@@ -257,7 +257,7 @@ spec = describe "ILCD.Writer round-trip" $ do
         let sdb =
                 oneActivityDb
                     (M.singleton fEmitU fEmission)
-                    [ TechnosphereExchange fProdU 1.0 fUnitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty
+                    [ TechnosphereExchange fProdU 1.0 fUnitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
                     , BiosphereExchange fEmitU 3.3e-20 fUnitU Emission "" Nothing Nothing
                     ]
         db' <- roundTrip sdb
@@ -527,7 +527,7 @@ multiOutputDb =
             "GLO"
             LocationDeclared
             "kg"
-            [TechnosphereExchange prod 1.0 moUnitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty]
+            [TechnosphereExchange prod 1.0 moUnitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties]
             M.empty
             M.empty
             Nothing
@@ -607,7 +607,7 @@ oneActivityDb bios exs =
             }
 
 refProductEx :: Exchange
-refProductEx = TechnosphereExchange fProdU 1.0 fUnitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty
+refProductEx = TechnosphereExchange fProdU 1.0 fUnitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
 
 {- | The reference product sits at index 2, after an air emission with a
 subcompartment and a natural-resource input. One exchange carries a non-empty

--- a/test/JournalSpec.hs
+++ b/test/JournalSpec.hs
@@ -56,6 +56,7 @@ import Types (
     TechnosphereFlow (..),
     UUID,
     Unit (..),
+    noProperties,
  )
 import UnitConversion (defaultUnitConfig)
 
@@ -448,6 +449,7 @@ depActivity =
                 , techPedigree = Nothing
                 , techShare = Nothing
                 , techClassification = M.empty
+                , techProperties = noProperties
                 }
             ]
         }
@@ -503,6 +505,7 @@ supplierActivity =
                 , techPedigree = Nothing
                 , techShare = Nothing
                 , techClassification = M.empty
+                , techProperties = noProperties
                 }
             , BiosphereExchange
                 { bioFlowId = co2Id

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -75,6 +75,7 @@ refExchange fid =
         , techPedigree = Nothing
         , techShare = Nothing
         , techClassification = M.empty
+        , techProperties = noProperties
         }
 
 inputExchange :: UUID.UUID -> Text -> Exchange
@@ -91,6 +92,7 @@ inputExchange fid loc =
         , techPedigree = Nothing
         , techShare = Nothing
         , techClassification = M.empty
+        , techProperties = noProperties
         }
 
 actUUID2, missingActUUID :: UUID.UUID
@@ -671,6 +673,7 @@ spec = do
                     , techPedigree = Nothing
                     , techShare = Nothing
                     , techClassification = M.empty
+                    , techProperties = noProperties
                     }
         it "returns the reference output amount for a normal producer" $ do
             let act = minimalActivity "producer" "GLO" [withRole ReferenceProduct 3.0 prodUUID]

--- a/test/MatrixConstructionSpec.hs
+++ b/test/MatrixConstructionSpec.hs
@@ -147,6 +147,7 @@ spec = do
                         , techPedigree = Nothing
                         , techShare = Nothing
                         , techClassification = M.empty
+                        , techProperties = noProperties
                         }
                 bioExchange =
                     BiosphereExchange
@@ -222,6 +223,7 @@ spec = do
                         , techPedigree = Nothing
                         , techShare = Nothing
                         , techClassification = M.empty
+                        , techProperties = noProperties
                         }
                 zeroBio =
                     BiosphereExchange
@@ -292,6 +294,7 @@ spec = do
                         , techPedigree = Nothing
                         , techShare = Nothing
                         , techClassification = M.empty
+                        , techProperties = noProperties
                         }
                 tCO2 =
                     BiosphereExchange
@@ -333,6 +336,7 @@ spec = do
                         , techPedigree = Nothing
                         , techShare = Nothing
                         , techClassification = M.empty
+                        , techProperties = noProperties
                         }
                 pWaste =
                     WasteExchange

--- a/test/MinimalCoverIntegrationSpec.hs
+++ b/test/MinimalCoverIntegrationSpec.hs
@@ -37,6 +37,7 @@ import Types (
     Unit (..),
     computeMinimalSelectedDeps,
     crossDBRedundantSources,
+    noProperties,
  )
 import UnitConversion (defaultUnitConfig)
 
@@ -134,6 +135,7 @@ supplierDB offset =
                 , techPedigree = Nothing
                 , techShare = Nothing
                 , techClassification = M.empty
+                , techProperties = noProperties
                 }
         act =
             Activity
@@ -202,6 +204,7 @@ consumerDB offset n =
                         , techPedigree = Nothing
                         , techShare = Nothing
                         , techClassification = M.empty
+                        , techProperties = noProperties
                         }
                 unlinkedInput =
                     TechnosphereExchange
@@ -216,6 +219,7 @@ consumerDB offset n =
                         , techPedigree = Nothing
                         , techShare = Nothing
                         , techClassification = M.empty
+                        , techProperties = noProperties
                         }
                 act =
                     Activity

--- a/test/PersistenceSpec.hs
+++ b/test/PersistenceSpec.hs
@@ -74,6 +74,7 @@ import Types (
     TechnosphereFlow (..),
     UUID,
     Unit (..),
+    noProperties,
  )
 import UnitConversion (defaultUnitConfig)
 
@@ -426,6 +427,7 @@ milkActivity name =
                 , techPedigree = Nothing
                 , techShare = Nothing
                 , techClassification = M.empty
+                , techProperties = noProperties
                 }
             , BiosphereExchange
                 { bioFlowId = co2Id

--- a/test/QualityReportSpec.hs
+++ b/test/QualityReportSpec.hs
@@ -41,6 +41,7 @@ import Types (
     Unit (..),
     WasteFlow (..),
     mkPedigree,
+    noProperties,
  )
 
 -- ---------------------------------------------------------------------------
@@ -121,6 +122,7 @@ techExchange fid amount role =
         , techPedigree = Nothing
         , techShare = Nothing
         , techClassification = M.empty
+        , techProperties = noProperties
         }
 
 reference :: UUID -> Exchange

--- a/test/RelinkMappingSpec.hs
+++ b/test/RelinkMappingSpec.hs
@@ -51,6 +51,7 @@ import Types (
     SimpleDatabase (..),
     TechRole (..),
     TechnosphereFlow (..),
+    noProperties,
  )
 import UnitConversion (defaultUnitConfig)
 
@@ -87,6 +88,7 @@ targetDB =
                         , techPedigree = Nothing
                         , techShare = Nothing
                         , techClassification = M.empty
+                        , techProperties = noProperties
                         }
                     ]
                 , activityParams = M.empty

--- a/test/ServiceSpec.hs
+++ b/test/ServiceSpec.hs
@@ -233,7 +233,7 @@ spec = do
 
         it "leaves every other kind of line without a role" $ do
             let bio = BiosphereExchange nil 1.0 nil Emission "" Nothing Nothing
-                tech = TechnosphereExchange nil 1.0 nil Input nil Nothing "" Nothing Nothing Nothing M.empty
+                tech = TechnosphereExchange nil 1.0 nil Input nil Nothing "" Nothing Nothing Nothing M.empty noProperties
             wasteRoleOf Nothing bio `shouldBe` Nothing
             wasteRoleOf (Just treatment) tech `shouldBe` Nothing
 

--- a/test/SetupInfoSpec.hs
+++ b/test/SetupInfoSpec.hs
@@ -83,6 +83,7 @@ refExchange fid =
         , techPedigree = Nothing
         , techShare = Nothing
         , techClassification = M.empty
+        , techProperties = noProperties
         }
 
 -- | A technosphere input for @prodId@ linked to producer activity @actId@.
@@ -100,6 +101,7 @@ linkedInput actId prodId =
         , techPedigree = Nothing
         , techShare = Nothing
         , techClassification = M.empty
+        , techProperties = noProperties
         }
 
 {- | A loaded database has no UI picker; only its name/path matter to the setup

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -630,7 +630,7 @@ emissionDb comp =
             "GLO"
             LocationDeclared
             "kg"
-            [ TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty
+            [ TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
             , BiosphereExchange bioU 0.5 unitU Emission "" Nothing Nothing
             ]
             M.empty
@@ -677,8 +677,8 @@ allocationDb =
             "GLO"
             LocationDeclared
             "kg"
-            [ TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing (Just (DeclaredShare 50 Nothing)) M.empty
-            , TechnosphereExchange matU 10.0 unitU Input UUID.nil Nothing "" Nothing Nothing Nothing M.empty
+            [ TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing (Just (DeclaredShare 50 Nothing)) M.empty noProperties
+            , TechnosphereExchange matU 10.0 unitU Input UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
             ]
             M.empty
             M.empty
@@ -719,8 +719,8 @@ zeroAllocationDb =
             "GLO"
             LocationDeclared
             "kg"
-            [ TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing (Just (DeclaredShare 0 Nothing)) M.empty
-            , TechnosphereExchange matU 0.0 unitU Input UUID.nil Nothing "" Nothing Nothing Nothing M.empty
+            [ TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing (Just (DeclaredShare 0 Nothing)) M.empty noProperties
+            , TechnosphereExchange matU 0.0 unitU Input UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
             ]
             M.empty
             M.empty
@@ -764,8 +764,8 @@ commentDb ped cmt =
             "GLO"
             LocationDeclared
             "kg"
-            [ TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty
-            , TechnosphereExchange matU 2.0 unitU Input UUID.nil Nothing "" cmt ped Nothing M.empty
+            [ TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
+            , TechnosphereExchange matU 2.0 unitU Input UUID.nil Nothing "" cmt ped Nothing M.empty noProperties
             ]
             M.empty
             M.empty
@@ -800,7 +800,7 @@ namedDb name =
             "GLO"
             LocationDeclared
             "kg"
-            [TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty]
+            [TechnosphereExchange prodU 1.0 unitU ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties]
             M.empty
             M.empty
             Nothing
@@ -820,15 +820,15 @@ gUnit = testUUID 0x53
 
 -- | A valid reference product output for the catalog above.
 refProd :: Exchange
-refProd = TechnosphereExchange gProd 1.0 gUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty
+refProd = TechnosphereExchange gProd 1.0 gUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
 
 -- | A second reference product (on the material flow) — an invalid second head.
 refProd2 :: Exchange
-refProd2 = TechnosphereExchange gMat 1.0 gUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty
+refProd2 = TechnosphereExchange gMat 1.0 gUnit ReferenceProduct UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
 
 -- | A plain material input (no reference product in the activity).
 matInput :: Exchange
-matInput = TechnosphereExchange gMat 2.0 gUnit Input UUID.nil Nothing "" Nothing Nothing Nothing M.empty
+matInput = TechnosphereExchange gMat 2.0 gUnit Input UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
 
 -- | An emission carrying a non-finite (+Infinity) amount.
 bioInf :: Exchange
@@ -836,7 +836,7 @@ bioInf = BiosphereExchange gBio (1 / 0) gUnit Emission "" Nothing Nothing
 
 -- | A material input referencing a unit UUID absent from the unit registry.
 matMissingUnit :: Exchange
-matMissingUnit = TechnosphereExchange gMat 2.0 (testUUID 0xbad) Input UUID.nil Nothing "" Nothing Nothing Nothing M.empty
+matMissingUnit = TechnosphereExchange gMat 2.0 (testUUID 0xbad) Input UUID.nil Nothing "" Nothing Nothing Nothing M.empty noProperties
 
 {- | A one-activity database whose exchanges are supplied verbatim, against a
 fixed catalog (a reference product flow, a material flow, an emission flow, and

--- a/test/StrictPinSpec.hs
+++ b/test/StrictPinSpec.hs
@@ -54,6 +54,7 @@ import Types (
     TechnosphereFlow (..),
     UUID,
     Unit (..),
+    noProperties,
  )
 import UnitConversion (defaultUnitConfig)
 
@@ -240,6 +241,7 @@ supplierDB offset products =
                         , techPedigree = Nothing
                         , techShare = Nothing
                         , techClassification = M.empty
+                        , techProperties = noProperties
                         }
                   act =
                     Activity
@@ -292,6 +294,7 @@ consumerDB offset products =
                         , techPedigree = Nothing
                         , techShare = Nothing
                         , techClassification = M.empty
+                        , techProperties = noProperties
                         }
                   unlinkedInput =
                     TechnosphereExchange
@@ -306,6 +309,7 @@ consumerDB offset products =
                         , techPedigree = Nothing
                         , techShare = Nothing
                         , techClassification = M.empty
+                        , techProperties = noProperties
                         }
                   act =
                     Activity

--- a/test/WasteTreatmentSignSpec.hs
+++ b/test/WasteTreatmentSignSpec.hs
@@ -87,6 +87,7 @@ techEx flow amt role link =
         , techPedigree = Nothing
         , techShare = Nothing
         , techClassification = M.empty
+        , techProperties = noProperties
         }
 
 co2Emission :: Double -> Exchange


### PR DESCRIPTION
## Why

An activity that makes several products has to divide its inventory between them, and the engine can only do that when the source states each share. Where the source states none, or where a reader wants a different division than the one it states, there is nothing to compute from: no physical quantity of the products is recorded anywhere.

EcoSpold 2 records them. Every `<intermediateExchange>` may carry `<property>` children, and among them the dry mass and the wet mass of that line. The parser was throwing all of them away.

## What this changes

A technosphere exchange now carries the properties its source states, and the EcoSpold 2 parser fills them. Nothing computes anything from them yet: this is the material, not the key.

Three decisions worth naming, because each of them is a place where a wrong choice would be invisible:

**A property is recorded per unit of the line, as the file writes it.** 614.4 kg of dry matter per m3 of board stays 614.4, whether the line is 1 m3 or 2, and the mass of the whole line is the product of the two taken where it is needed. The first version of this branch recorded the whole line instead, which made the property a second number that every operation touching an amount had to recompute; two already did not, so a set-amount edit and the SimaPro writer's un-allocating divide each left a line stating one amount and a mass belonging to another. Per unit, the property does not refer to the amount and cannot contradict it.

**A property keeps the unit it was written in.** ecoinvent writes some properties as dimensionless. Reading 0.1 of a dimensionless quantity as 0.1 kg would invent a number the file does not state, so the unit travels with the amount and whoever needs kilograms converts it or refuses the line.

**Absent is not zero.** A product of no mass and a product whose mass is unknown are different answers to the question "can the mass serve as a key here", and a zero standing in for the second would answer the first. A property whose `amount` the file omits, or writes as something no number can be read from, is therefore dropped rather than recorded at zero; reading it also costs the property alone and not the load of the whole database, where the parser's usual conversion calls `error`.

The guard that was discarding the properties (`not isInsideProperty`) stays exactly as it was: it is what keeps a property's own amount and unit from overwriting the exchange's, and one of the examples pins that the exchange amounts did not move.

## What it costs

Every database cache rebuilds once on the first load after this release. The signature is derived from the fingerprint of the `Database` type, which does not change when a nested record gains a field, so the counter beside it is what invalidates; the note in `Loader` says why.

The field is visible on the wire, which is what lets the reading be checked against the file it came from, so it takes wire revision 18.

## Checks

Three examples on the fixture that already existed to prove property comments do not leak onto an exchange, read now for what those properties say. The fixture's glue line is what tells the two conventions apart: it declares 1.0 on an amount of 0.1. Full suite 2431 examples, 0 failures. hlint clean. Cold `-Werror` build green.

## What comes next, and is not here

The key itself. A `ByProperty` allocation key, and the pure function that says what one product line's mass is under it: the property when the source states one, and the line's own amount when that amount is already a mass, which is how the formats with no property table at all (SimaPro, ILCD, EcoSpold 1) become computable. That rule belongs in one place for every format rather than in five parsers, which is why it is not in this pull request.
