### PR TITLE
Let a flow search name several kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@
   unit to restate it in.
 
 ### Added
+- A flow search can name several kinds at once: `kind=biosphere,waste` keeps
+  what is exchanged with nature or discarded and nothing else, in one listing.
+  `search-counts` already answers that pair as a single number, and there was
+  no way to list it: a search box putting a count beside a tab had to show a
+  count and a table that disagreed. One name it cannot read refuses the whole
+  parameter, the way one unreadable name always did. Wire revision 19; a
+  single kind is written exactly as before.
 - A database can be divided on the mass of its products instead of on the
   shares its source declares. A database entry names the key it is read
   under: `allocation = "declared"` (the default, unchanged), `"dry mass"` or

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -1091,9 +1091,11 @@ Args:
         commas, as in ``"biosphere,waste"``, which is what is
         exchanged with nature or discarded and the bucket
         `count_search_matches` reports as ``flows``. One kind
-        needs engine wire revision 9 and several need revision 19; an
-        older engine would drop the filter and answer with every kind,
-        so the request is refused rather than sent.
+        needs engine wire revision 9: an older engine would drop the
+        filter and answer with every kind. Several need revision 19,
+        where an older engine reads the whole value as one name and
+        refuses it. Either way the request is refused here first, with
+        a message naming the revision, rather than sent.
     page / page_size: Web-style pagination; convert to wire-level
         ``offset`` / ``limit``.
     limit / offset: Wire-level escape hatch.

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -24,7 +24,7 @@ The other direction is a promise about pyvolca's own names. A name this client p
 
 _Generated from `volca._compat`: run `python scripts/gen_api_md.py` to regenerate._
 
-This build of **pyvolca 0.11.0** speaks wire formats **2 to 18** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error. A name this build has retired keeps working until pyvolca **1.0**.
+This build of **pyvolca 0.11.0** speaks wire formats **2 to 19** and requires a VoLCA engine **≥ v0.9.1**; a capability gated on a newer wire than the engine speaks refuses to run with a clear error. A name this build has retired keeps working until pyvolca **1.0**.
 
 <!-- END: compatibility -->
 
@@ -1086,10 +1086,14 @@ Args:
         ``water fossil`` and ``water, fossil`` search alike. With no
         ``sort`` asked for, names carrying the query as typed come
         first. An empty query returns nothing.
-    kind: Keep one kind only: ``"technosphere"``, ``"biosphere"`` or
-        ``"waste"``. Omit for all three. Needs engine wire revision 9;
-        an older engine would drop the filter and answer with every
-        kind, so the request is refused rather than sent.
+    kind: Keep only these kinds: ``"technosphere"``, ``"biosphere"``
+        or ``"waste"``. Omit for all three. Name several separated by
+        commas, as in ``"biosphere,waste"``, which is what is
+        exchanged with nature or discarded and the bucket
+        `count_search_matches` reports as ``flows``. One kind
+        needs engine wire revision 9 and several need revision 19; an
+        older engine would drop the filter and answer with every kind,
+        so the request is refused rather than sent.
     page / page_size: Web-style pagination; convert to wire-level
         ``offset`` / ``limit``.
     limit / offset: Wire-level escape hatch.

--- a/pyvolca/src/volca/_compat.py
+++ b/pyvolca/src/volca/_compat.py
@@ -32,8 +32,10 @@ the client works against it except the revision-gated capabilities (see
 ``Client._require_wire``), which check the engine's advertised revision
 before sending anything."""
 
-KNOWN_WIRE = 18
-"""The newest wire revision this pyvolca understands (revision 18 adds
+KNOWN_WIRE = 19
+"""The newest wire revision this pyvolca understands (revision 19 lets a flow
+search name several kinds at once, comma-separated, so the biosphere-and-waste
+bucket the search counts report is listable in one call; revision 18 added
 ``properties`` on a technosphere exchange, the dry and wet mass its source
 states of that line; revision 17 added
 ``count_search_matches``, how many processes, products and flows one query

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -1545,9 +1545,11 @@ class Client:
                 commas, as in ``"biosphere,waste"``, which is what is
                 exchanged with nature or discarded and the bucket
                 :meth:`count_search_matches` reports as ``flows``. One kind
-                needs engine wire revision 9 and several need revision 19; an
-                older engine would drop the filter and answer with every kind,
-                so the request is refused rather than sent.
+                needs engine wire revision 9: an older engine would drop the
+                filter and answer with every kind. Several need revision 19,
+                where an older engine reads the whole value as one name and
+                refuses it. Either way the request is refused here first, with
+                a message naming the revision, rather than sent.
             page / page_size: Web-style pagination; convert to wire-level
                 ``offset`` / ``limit``.
             limit / offset: Wire-level escape hatch.

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -1540,10 +1540,14 @@ class Client:
                 ``water fossil`` and ``water, fossil`` search alike. With no
                 ``sort`` asked for, names carrying the query as typed come
                 first. An empty query returns nothing.
-            kind: Keep one kind only: ``"technosphere"``, ``"biosphere"`` or
-                ``"waste"``. Omit for all three. Needs engine wire revision 9;
-                an older engine would drop the filter and answer with every
-                kind, so the request is refused rather than sent.
+            kind: Keep only these kinds: ``"technosphere"``, ``"biosphere"``
+                or ``"waste"``. Omit for all three. Name several separated by
+                commas, as in ``"biosphere,waste"``, which is what is
+                exchanged with nature or discarded and the bucket
+                :meth:`count_search_matches` reports as ``flows``. One kind
+                needs engine wire revision 9 and several need revision 19; an
+                older engine would drop the filter and answer with every kind,
+                so the request is refused rather than sent.
             page / page_size: Web-style pagination; convert to wire-level
                 ``offset`` / ``limit``.
             limit / offset: Wire-level escape hatch.
@@ -1552,6 +1556,10 @@ class Client:
         """
         if kind is not None:
             self._require_wire(9, "search_flows(kind=...)", engine_hint="0.9.6")
+            if "," in kind:
+                self._require_wire(
+                    19, "search_flows(kind=...) naming several kinds", engine_hint="0.12.1"
+                )
         wire_limit, wire_offset = _resolve_page_args(page, page_size, limit, offset)
 
         def fetch(o: int, l: int | None) -> dict:

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -59,7 +59,7 @@ import qualified Service
 import qualified Service.Aggregate as Agg
 import SharedSolver (SharedSolver, computeInventoryMatrixWithDepsCached, crossDBProcessContributions)
 import qualified SharedSolver
-import Types (Activity (..), BiosphereFlow (..), Database (..), FlowKind (BioKind), Indexes (..), KindFilter (..), ProcessId, UUID, UnitDB, activityLocation, activityName, bfCompartmentName, bfCompartmentSub, exchangeIsInput, exchangeKindChoices, exchangeKindOf, getUnitNameForBioFlow, lookupExchangeFlow, parseExchangeKind, parseKindFilter, processIdToText, qualifyRef, unresolvedCount)
+import Types (Activity (..), BiosphereFlow (..), Database (..), FlowKind (BioKind), Indexes (..), KindFilter (..), ProcessId, UUID, UnitDB, activityLocation, activityName, bfCompartmentName, bfCompartmentSub, exchangeIsInput, exchangeKindChoices, exchangeKindOf, getUnitNameForBioFlow, lookupExchangeFlow, parseExchangeKind, parseKindNames, processIdToText, qualifyRef, unresolvedCount)
 
 -- ---------------------------------------------------------------------------
 -- JSON-RPC 2.0 types
@@ -813,7 +813,7 @@ callSearchFlows rid args (db, _) =
     readKind = case KM.lookup (fromText "kind") args of
         Nothing -> Right AnyKind
         Just Null -> Right AnyKind
-        Just (String raw) -> parseKindFilter raw
+        Just (String raw) -> OnlyKinds <$> parseKindNames raw
         Just other -> Left (badKind (TE.decodeUtf8Lenient (BSL.toStrict (encode other))))
 
     badKind :: Text -> Text

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -59,7 +59,7 @@ import qualified Service
 import qualified Service.Aggregate as Agg
 import SharedSolver (SharedSolver, computeInventoryMatrixWithDepsCached, crossDBProcessContributions)
 import qualified SharedSolver
-import Types (Activity (..), BiosphereFlow (..), Database (..), FlowKind (BioKind), Indexes (..), ProcessId, UUID, UnitDB, activityLocation, activityName, bfCompartmentName, bfCompartmentSub, exchangeIsInput, exchangeKindChoices, exchangeKindOf, getUnitNameForBioFlow, lookupExchangeFlow, parseExchangeKind, processIdToText, qualifyRef, unresolvedCount)
+import Types (Activity (..), BiosphereFlow (..), Database (..), FlowKind (BioKind), Indexes (..), KindFilter (..), ProcessId, UUID, UnitDB, activityLocation, activityName, bfCompartmentName, bfCompartmentSub, exchangeIsInput, exchangeKindChoices, exchangeKindOf, getUnitNameForBioFlow, lookupExchangeFlow, parseExchangeKind, parseKindFilter, processIdToText, qualifyRef, unresolvedCount)
 
 -- ---------------------------------------------------------------------------
 -- JSON-RPC 2.0 types
@@ -787,7 +787,7 @@ callSearchFlows :: Value -> KeyMap Value -> (Database, SharedSolver) -> IO Value
 callSearchFlows rid args (db, _) =
     case readKind of
         Left err -> return $ toolError rid err
-        Right kind -> case textArg "query" args of
+        Right kinds -> case textArg "query" args of
             Nothing -> return $ toolSuccessJson rid Service.emptyFlowSearchResults
             Just query -> do
                 let limit = intArg "limit" args
@@ -795,7 +795,7 @@ callSearchFlows rid args (db, _) =
                         Service.FlowFilter
                             { Service.ffQuery = query
                             , Service.ffLang = Nothing
-                            , Service.ffKind = kind
+                            , Service.ffKind = kinds
                             , Service.ffLimit = limit <|> Just 20
                             , Service.ffOffset = Nothing
                             , Service.ffSort = Nothing
@@ -809,14 +809,14 @@ callSearchFlows rid args (db, _) =
     -- A typo must not read as "every kind", the way a dropped filter would,
     -- and neither must a value that is not text at all: 'textArg' cannot tell
     -- @{"kind": true}@ from an absent key, so the lookup is read here.
+    readKind :: Either Text KindFilter
     readKind = case KM.lookup (fromText "kind") args of
-        Nothing -> Right Nothing
-        Just Null -> Right Nothing
-        Just (String raw) -> case parseExchangeKind raw of
-            Just k -> Right (Just k)
-            Nothing -> Left (badKind raw)
+        Nothing -> Right AnyKind
+        Just Null -> Right AnyKind
+        Just (String raw) -> parseKindFilter raw
         Just other -> Left (badKind (TE.decodeUtf8Lenient (BSL.toStrict (encode other))))
 
+    badKind :: Text -> Text
     badKind got = "kind must be one of: " <> exchangeKindChoices <> " (got " <> got <> ")"
 
 callGetActivity :: Value -> KeyMap Value -> (Database, SharedSolver) -> IO Value

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -772,7 +772,7 @@ params r = case r of
     SearchFlows ->
         [ pDatabase
         , Param "query" "string" Required "Flow name to search for"
-        , Param "kind" "string" Optional "Keep one kind of flow only: technosphere | biosphere | waste. Omit for all three."
+        , Param "kind" "string" Optional "Keep only these kinds of flow: technosphere | biosphere | waste. Name several separated by commas, as in \"biosphere,waste\". Omit for all three."
         , pLimit "Max results (default 20)"
         ]
     GetActivity ->

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -2182,7 +2182,7 @@ unloadMethodCollectionHandler name = do
 searchFlows :: Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Int -> Maybe Int -> Maybe Text -> Maybe Text -> AppM (SearchResults FlowSearchResult)
 searchFlows dbName queryParam langParam kindParam limitParam offsetParam sortParam orderParam = do
     (db, _) <- requireDatabaseByName dbName
-    kinds <- maybe (pure AnyKind) (either badRequest pure . parseKindFilter) kindParam
+    kinds <- maybe (pure AnyKind) namedKinds kindParam
     case queryParam of
         Nothing -> return (SearchResults [] 0 0 50 False 0.0)
         Just query -> do
@@ -2197,6 +2197,11 @@ searchFlows dbName queryParam langParam kindParam limitParam offsetParam sortPar
                         , Service.ffOrder = orderParam
                         }
             searchFlowsInternal db ff
+  where
+    -- An absent parameter is the only reading that means every kind; a
+    -- present one naming nothing is refused, see 'parseKindNames'.
+    namedKinds :: Text -> AppM KindFilter
+    namedKinds raw = either badRequest (pure . OnlyKinds) (parseKindNames raw)
 
 searchActivitiesWithCount :: Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Bool -> Maybe Text -> [Text] -> [Text] -> [Text] -> Maybe Int -> Maybe Int -> Maybe Text -> Maybe Text -> AppM (SearchResults ActivitySummary)
 searchActivitiesWithCount dbName nameParam geoParam productParam exactParam presetParam classSystems classValues classModes limitParam offsetParam sortParam orderParam = do

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1313,7 +1313,10 @@ appears that a client must know about /before/ calling it. Adding a route
 does not exempt a change from the bump: an absent route answers 404, and so
 does a request naming a database the engine has not loaded, so a client
 cannot tell "this engine is too old" from "you asked for the wrong thing"
-(revision 18: the @properties@ a technosphere exchange carries, the dry and
+(revision 19: the @kind@ parameter of a flow search naming several kinds,
+comma-separated, so the biosphere-and-waste bucket the search counts report is
+listable in one call;
+revision 18: the @properties@ a technosphere exchange carries, the dry and
 wet mass its source states of that line;
 revision 17: the @search-counts@ route and its @count_search_matches@ tool,
 answering how many processes, products and flows one query matches;
@@ -1344,7 +1347,7 @@ the whole filtered set).
 Clients compare it to decide compatibility and to gate such capabilities.
 -}
 currentWireVersion :: Int
-currentWireVersion = 18
+currentWireVersion = 19
 
 getVersion :: AppM Value
 getVersion = do
@@ -2179,7 +2182,7 @@ unloadMethodCollectionHandler name = do
 searchFlows :: Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Int -> Maybe Int -> Maybe Text -> Maybe Text -> AppM (SearchResults FlowSearchResult)
 searchFlows dbName queryParam langParam kindParam limitParam offsetParam sortParam orderParam = do
     (db, _) <- requireDatabaseByName dbName
-    kind <- traverse readKind kindParam
+    kinds <- maybe (pure AnyKind) (either badRequest pure . parseKindFilter) kindParam
     case queryParam of
         Nothing -> return (SearchResults [] 0 0 50 False 0.0)
         Just query -> do
@@ -2187,19 +2190,13 @@ searchFlows dbName queryParam langParam kindParam limitParam offsetParam sortPar
                     Service.FlowFilter
                         { Service.ffQuery = query
                         , Service.ffLang = langParam
-                        , Service.ffKind = kind
+                        , Service.ffKind = kinds
                         , Service.ffLimit = limitParam
                         , Service.ffOffset = offsetParam
                         , Service.ffSort = sortParam
                         , Service.ffOrder = orderParam
                         }
             searchFlowsInternal db ff
-  where
-    -- A typo must not read as "every kind": that would answer a question
-    -- nobody asked with no sign the filter was dropped.
-    readKind raw = case parseExchangeKind raw of
-        Just k -> pure k
-        Nothing -> badRequest ("kind must be one of: " <> exchangeKindChoices <> " (got " <> raw <> ")")
 
 searchActivitiesWithCount :: Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Bool -> Maybe Text -> [Text] -> [Text] -> [Text] -> Maybe Int -> Maybe Int -> Maybe Text -> Maybe Text -> AppM (SearchResults ActivitySummary)
 searchActivitiesWithCount dbName nameParam geoParam productParam exactParam presetParam classSystems classValues classModes limitParam offsetParam sortParam orderParam = do

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -290,7 +290,7 @@ executeSearchFlowsCommand fmt database opts =
                     Service.FlowFilter
                         { Service.ffQuery = query
                         , Service.ffLang = searchLang opts
-                        , Service.ffKind = Nothing
+                        , Service.ffKind = Types.AnyKind
                         , Service.ffLimit = searchFlowsLimit opts
                         , Service.ffOffset = searchFlowsOffset opts
                         , Service.ffSort = Nothing

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -94,7 +94,7 @@ before building this record.
 data FlowFilter = FlowFilter
     { ffQuery :: Text
     , ffLang :: Maybe Text
-    , ffKind :: Maybe ExchangeKind
+    , ffKind :: KindFilter
     , ffLimit :: Maybe Int
     , ffOffset :: Maybe Int
     , ffSort :: Maybe Text
@@ -804,7 +804,7 @@ flowSearchResults :: UnitDB -> (FlowKind -> Maybe Int) -> FlowFilter -> [FlowKin
 flowSearchResults units producersOfFlow FlowFilter{ffQuery = query, ffKind = kindParam, ffSort = sortParam, ffOrder = orderParam} =
     L.sortBy (direction (\a b -> compare (sortKey a) (sortKey b))) . map toResult . filter askedFor
   where
-    askedFor flow = maybe True (== kindOfFlow flow) kindParam
+    askedFor flow = kindFilterKeeps kindParam (kindOfFlow flow)
     direction = if orderParam == Just "desc" then flip else id
     -- Parsers turn an absent sub-compartment into 'Nothing', never @""@, so
     -- the empty string sorts where 'Nothing' would: ahead of every named one.

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -37,6 +37,7 @@ import GHC.Generics (Generic)
 import Control.Lens ((&), (?~))
 import Data.List (find, nub)
 import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NE
 import Data.OpenApi (NamedSchema (..), OpenApiType (..), ToSchema (..), enum_, type_)
 import Search.BM25.Types (BM25Index)
 import SubstanceRegistry (CASNumber (..), NormName (..), nonEmptyCAS)
@@ -863,6 +864,36 @@ Read off the type, so a fourth kind cannot go unmentioned.
 -}
 exchangeKindChoices :: Text
 exchangeKindChoices = T.intercalate " | " (map exchangeKindName [minBound .. maxBound])
+
+{- | Which kinds of flow a search keeps.
+
+Not a list, because an empty list would have to mean either "every kind" or
+"no kind at all" and a caller could not tell which it had asked for. A search
+box offering a tab per bucket needs more than one kind at a time: the third
+bucket is what is exchanged with nature or discarded, which is two of them.
+-}
+data KindFilter = AnyKind | OnlyKinds (NonEmpty ExchangeKind)
+    deriving (Eq, Show)
+
+{- | Read the kinds a request named, comma-separated. One unreadable name
+refuses the whole thing: a typo dropped from the list would widen the search
+in silence, which is the same mistake as reading it as "every kind".
+-}
+parseKindFilter :: Text -> Either Text KindFilter
+parseKindFilter raw = case NE.nonEmpty (filter (not . T.null) (map T.strip (T.splitOn "," raw))) of
+    Nothing -> Right AnyKind
+    Just named -> OnlyKinds <$> traverse readOne named
+  where
+    readOne :: Text -> Either Text ExchangeKind
+    readOne name =
+        maybe (Left ("kind must be one of: " <> exchangeKindChoices <> " (got " <> name <> ")")) Right $
+            parseExchangeKind name
+
+-- | Whether a search that asked for these kinds keeps this one.
+kindFilterKeeps :: KindFilter -> ExchangeKind -> Bool
+kindFilterKeeps kinds kind = case kinds of
+    AnyKind -> True
+    OnlyKinds named -> kind `elem` named
 
 -- | Unit database (deduplicated)
 type UnitDB = M.Map UUID Unit

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -875,14 +875,19 @@ bucket is what is exchanged with nature or discarded, which is two of them.
 data KindFilter = AnyKind | OnlyKinds (NonEmpty ExchangeKind)
     deriving (Eq, Show)
 
-{- | Read the kinds a request named, comma-separated. One unreadable name
-refuses the whole thing: a typo dropped from the list would widen the search
-in silence, which is the same mistake as reading it as "every kind".
+{- | Read the kinds a request named, comma-separated.
+
+Every reading that names no kind is a refusal, an empty parameter included.
+@kind=@ and @kind=,@ come from a caller that meant to name something, and
+answering them with every kind would widen the search with no sign the filter
+was dropped - the same mistake as reading a typo as "every kind". Only an
+absent parameter means every kind, and that is its caller's own arm, not a
+reading of the text.
 -}
-parseKindFilter :: Text -> Either Text KindFilter
-parseKindFilter raw = case NE.nonEmpty (filter (not . T.null) (map T.strip (T.splitOn "," raw))) of
-    Nothing -> Right AnyKind
-    Just named -> OnlyKinds <$> traverse readOne named
+parseKindNames :: Text -> Either Text (NonEmpty ExchangeKind)
+parseKindNames raw = case NE.nonEmpty (filter (not . T.null) (map T.strip (T.splitOn "," raw))) of
+    Nothing -> Left ("kind names no kind: use " <> exchangeKindChoices <> ", separated by commas")
+    Just named -> traverse readOne named
   where
     readOne :: Text -> Either Text ExchangeKind
     readOne name =

--- a/test/FlowSearchSpec.hs
+++ b/test/FlowSearchSpec.hs
@@ -9,6 +9,7 @@ interleaves the media, shows them as duplicate rows.
 module FlowSearchSpec (spec) where
 
 import API.Types (FlowSearchResult (..))
+import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map as M
 import qualified Data.Set as S
 import Data.Text (Text)
@@ -21,14 +22,17 @@ import Types (
     Compartment (..),
     ExchangeKind (..),
     FlowKind (..),
+    KindFilter (..),
     TechnosphereFlow (..),
     UUID,
     WasteFlow (..),
     flowKindName,
+    parseKindFilter,
  )
 
 spec :: Spec
 spec = do
+    kindFilterSpec
     matchSpec
     filterSpec
     orderSpec
@@ -158,8 +162,14 @@ orderSpec = describe "Service.flowSearchResults" $ do
                        ]
 
     it "keeps the one kind asked for" $
-        map fsrName (search byName{ffKind = Just KindBiosphere} threeKinds)
+        map fsrName (search byName{ffKind = OnlyKinds (KindBiosphere :| [])} threeKinds)
             `shouldBe` ["Water, fossil"]
+
+    it "keeps every kind asked for, which is how the third search tab is listed" $
+        -- Biosphere and waste together: what is exchanged with nature or
+        -- discarded, the bucket the search counts report as one number.
+        map fsrName (search byName{ffKind = OnlyKinds (KindBiosphere :| [KindWaste])} threeKinds)
+            `shouldBe` ["Waste water", "Water, fossil"]
 
     it "keeps all three when no kind is asked for" $
         length (search byName threeKinds) `shouldBe` 3
@@ -218,7 +228,7 @@ sortByName =
     FlowFilter
         { ffQuery = "Deltamethrin"
         , ffLang = Nothing
-        , ffKind = Nothing
+        , ffKind = AnyKind
         , ffLimit = Nothing
         , ffOffset = Nothing
         , ffSort = Nothing
@@ -257,3 +267,31 @@ biosphere n name syns =
 
 mkUUID :: Int -> UUID
 mkUUID n = UUID.fromWords64 (fromIntegral n) 0
+
+{- | What a request may name in @kind@.
+
+A dropped name would widen the search in silence, which is the mistake the
+single-kind reader was already written to avoid, so a list holding one
+unreadable name is refused whole rather than filtered down to the rest.
+-}
+kindFilterSpec :: Spec
+kindFilterSpec = describe "the kinds a request names" $ do
+    it "reads one" $
+        parseKindFilter "biosphere" `shouldBe` Right (OnlyKinds (KindBiosphere :| []))
+
+    it "reads several, which is how the third search tab is asked for" $
+        parseKindFilter "biosphere,waste"
+            `shouldBe` Right (OnlyKinds (KindBiosphere :| [KindWaste]))
+
+    it "ignores the spaces someone writes after the commas" $
+        parseKindFilter " biosphere , waste "
+            `shouldBe` Right (OnlyKinds (KindBiosphere :| [KindWaste]))
+
+    it "reads an empty parameter as every kind, the way an absent one is read" $
+        parseKindFilter "" `shouldBe` Right AnyKind
+
+    it "refuses the whole list for one name it cannot read" $
+        parseKindFilter "biosphere,bioshpere" `shouldSatisfy` isLeft
+  where
+    isLeft :: Either a b -> Bool
+    isLeft = either (const True) (const False)

--- a/test/FlowSearchSpec.hs
+++ b/test/FlowSearchSpec.hs
@@ -27,7 +27,7 @@ import Types (
     UUID,
     WasteFlow (..),
     flowKindName,
-    parseKindFilter,
+    parseKindNames,
  )
 
 spec :: Spec
@@ -277,21 +277,24 @@ unreadable name is refused whole rather than filtered down to the rest.
 kindFilterSpec :: Spec
 kindFilterSpec = describe "the kinds a request names" $ do
     it "reads one" $
-        parseKindFilter "biosphere" `shouldBe` Right (OnlyKinds (KindBiosphere :| []))
+        parseKindNames "biosphere" `shouldBe` Right (KindBiosphere :| [])
 
     it "reads several, which is how the third search tab is asked for" $
-        parseKindFilter "biosphere,waste"
-            `shouldBe` Right (OnlyKinds (KindBiosphere :| [KindWaste]))
+        parseKindNames "biosphere,waste" `shouldBe` Right (KindBiosphere :| [KindWaste])
 
     it "ignores the spaces someone writes after the commas" $
-        parseKindFilter " biosphere , waste "
-            `shouldBe` Right (OnlyKinds (KindBiosphere :| [KindWaste]))
+        parseKindNames " biosphere , waste " `shouldBe` Right (KindBiosphere :| [KindWaste])
 
-    it "reads an empty parameter as every kind, the way an absent one is read" $
-        parseKindFilter "" `shouldBe` Right AnyKind
+    it "refuses a parameter that names no kind, rather than widening" $
+        -- Someone joined an empty set of ticked boxes. Answering with every
+        -- kind would label a tab with a filter nobody asked for.
+        parseKindNames "" `shouldSatisfy` isLeft
+
+    it "refuses a list of nothing but separators for the same reason" $
+        parseKindNames " , " `shouldSatisfy` isLeft
 
     it "refuses the whole list for one name it cannot read" $
-        parseKindFilter "biosphere,bioshpere" `shouldSatisfy` isLeft
+        parseKindNames "biosphere,bioshpere" `shouldSatisfy` isLeft
   where
     isLeft :: Either a b -> Bool
     isLeft = either (const True) (const False)


### PR DESCRIPTION
`search-counts` answers three disjoint numbers for one query: processes, products, and what is exchanged with nature or discarded. The third is two kinds at once, biosphere and waste, and nothing could list it. `kind` took one name, so a search box putting a count beside a tab would have shown a count and a table that disagreed with it - which is the sort of quiet inconsistency that makes a reader stop trusting both numbers.

`kind` now reads a comma-separated list: `kind=biosphere,waste`. A single name is written exactly as before.

Two things were decided rather than wired.

**Comma-separated rather than a repeated parameter.** The same string crosses REST, MCP and the Python client without any of them changing shape: one reader, one line in the resource registry that drives the OpenAPI description and the MCP tool schema together, and no signature moves. A repeated query parameter would have been idiomatic for REST alone and would have needed a different spelling for the other two.

**A sum type rather than a list.** `AnyKind | OnlyKinds (NonEmpty ExchangeKind)`. An empty list would have to mean either "every kind" or "no kind at all", and a caller could not tell which it had asked for.

One name the parser cannot read refuses the whole parameter. A name quietly dropped from the list would widen the search with no sign the filter was reduced, which is the same mistake as reading a typo as "every kind" - the mistake the single-kind reader carried a comment about avoiding.

Wire revision 19. The Python client refuses a multi-kind value against an engine below it rather than sending a request that comes back a 400.
