### PR TITLE
Read Service.hs on two axes, and apply the small half

### DIFF
--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1495,7 +1495,7 @@ getActivityTree dbName processId = do
     (db, _) <- requireDatabaseByName dbName
     root <- either throwServiceError pure (Service.resolveActivityAndProcessId db processId)
     unitCfg <- liftIO $ getMergedUnitConfig dbManager
-    return $ Service.convertToTreeExport db processId maxTreeDepth (buildLoopAwareTree unitCfg db maxTreeDepth root)
+    return $ Service.convertToTreeExport db maxTreeDepth (buildLoopAwareTree unitCfg db maxTreeDepth root)
 
 {- | Inventory with optional substitutions; goes through the cross-DB
 back-substitution path so dep-DB inventories merge into the response.

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -383,20 +383,6 @@ countPotentialChildren db activity =
         , Just _ <- [childTarget db ex]
         ]
 
--- | Helper to extract compartment from flow category
-extractCompartment :: Text -> Text
-extractCompartment category =
-    let lowerCategory = T.toLower category
-     in if "air" `T.isInfixOf` lowerCategory
-            then "air"
-            else
-                if "water" `T.isInfixOf` lowerCategory || "aquatic" `T.isInfixOf` lowerCategory
-                    then "water"
-                    else
-                        if "soil" `T.isInfixOf` lowerCategory || "ground" `T.isInfixOf` lowerCategory
-                            then "soil"
-                            else "other"
-
 {- | Cap on biosphere flows shown per activity. System processes can declare
 hundreds; we keep the top-N by |amount| to keep graphs renderable.
 -}
@@ -573,11 +559,10 @@ extractNodesAndEdges db tree depth parentId nodeAcc edgeAcc = case tree of
          in (n', edge : e', stats <> s')
 
 -- | Convert LoopAwareTree to TreeExport format for JSON serialization
-convertToTreeExport :: Database -> Text -> Int -> LoopAwareTree -> TreeExport
-convertToTreeExport db _rootProcessId maxDepth tree =
+convertToTreeExport :: Database -> Int -> LoopAwareTree -> TreeExport
+convertToTreeExport db maxDepth tree =
     let (nodes, edges, _stats) = extractNodesAndEdges db tree 0 Nothing M.empty []
-        -- Use the actual root node ID from the tree, not the passed parameter
-        -- This ensures tmRootId always matches a key in the nodes map
+        -- The tree's own root, so tmRootId always names a key in the nodes map.
         actualRootId = getTreeNodeId db tree
         metadata =
             TreeMetadata
@@ -2425,7 +2410,7 @@ goWithSubsAndDeps unitCfg depLookup thisDb thisDbName rootDb solver demands allS
                     else do
                         depResults <-
                             mapConcurrently
-                                (resolveDepWithSubs unitCfg depLookup rootDb perRootDepDemands allSubs depth (length scalings'))
+                                (resolveDepWithSubs unitCfg depLookup rootDb perRootDepDemands allSubs depth)
                                 allDepDbs
                         pure $ case sequence depResults of
                             Left err -> Left err
@@ -2451,16 +2436,15 @@ resolveDepWithSubs ::
     [DepDemands] ->
     [Substitution] ->
     Int ->
-    Int ->
     Text ->
     IO (Either ServiceError [Maybe SharedSolver.CrossDBSolution])
-resolveDepWithSubs unitCfg depLookup rootDb perRootDepDemands allSubs depth k depDbName = do
+resolveDepWithSubs unitCfg depLookup rootDb perRootDepDemands allSubs depth depDbName = do
     depM <- depLookup depDbName
     case depM of
         Nothing ->
             -- Same shape as 'SharedSolver.resolveDep': absent dep DB
             -- contributes 'Nothing' at every root; dropped before merge.
-            pure (Right (replicate k Nothing))
+            pure (Right (replicate (length perRootDepDemands) Nothing))
         Just (depDb, depSolver) ->
             case SharedSolver.prepareDepDemandVecs unitCfg depDbName depDb perRootDepDemands of
                 Left err -> pure (Left (MatrixError err))
@@ -2527,7 +2511,7 @@ The ADT replaces a @(Bool, Bool)@ dispatch on @(fromDb == thisDbName,
 toDb == thisDbName)@: each constructor names what the boolean meant.
 -}
 data Endpoint
-    = Here !ProcessId !(UUID, UUID)
+    = Here !ProcessId
     | Elsewhere !DepRef
 
 -- | An endpoint that lives in a dependency database.
@@ -2723,7 +2707,7 @@ applySubstitutionsAt unitCfg depLookup thisDb thisDbObj rootDb solver scalings a
         Endpoint ->
         Either ServiceError RankOneUpdate
     -- Case A: both suppliers in this DB. Symmetric rank-1 on the consumer column.
-    planUpdate sub cPid (Here fromPid _) (Here toPid _) = do
+    planUpdate sub cPid (Here fromPid) (Here toPid) = do
         a <- requireTech sub cPid fromPid
         Right $
             RankOneUpdate
@@ -2732,13 +2716,13 @@ applySubstitutionsAt unitCfg depLookup thisDb thisDbObj rootDb solver scalings a
                 []
     -- Case B: drop this-DB oldSup, route demand to other-DB newSup.
     -- aRaw = aNorm * normFactor (the cross-DB link stores *raw* coefficients).
-    planUpdate sub cPid (Here fromPid _) (Elsewhere toRef) = do
+    planUpdate sub cPid (Here fromPid) (Elsewhere toRef) = do
         a <- requireTech sub cPid fromPid
         let aRaw = a * activityNormalizationFactor thisDb cPid
             newLk = virtualLinkTo cPid toRef aRaw
         Right $ RankOneUpdate cPid [(fromIntegral fromPid, a)] [newLk]
     -- Case C: cancel existing cross-DB link, pull new this-DB supplier.
-    planUpdate sub cPid (Elsewhere fromRef) (Here toPid _) = do
+    planUpdate sub cPid (Elsewhere fromRef) (Here toPid) = do
         s <- requireStatic sub cPid fromRef
         let aRaw = cdlCoefficient s
             aNorm = aRaw / activityNormalizationFactor thisDb cPid
@@ -2762,8 +2746,8 @@ applySubstitutionsAt unitCfg depLookup thisDb thisDbObj rootDb solver scalings a
     planGlobalUpdate fromEp toEp = case fromEp of
         Elsewhere _ ->
             Left $ MatrixError "global substitution requires the replaced activity (from) to live in the root database"
-        Here fromPid _ -> case toEp of
-            Here toPid _ -> planGlobalWithinDB unitCfg thisDb fromPid toPid
+        Here fromPid -> case toEp of
+            Here toPid -> planGlobalWithinDB unitCfg thisDb fromPid toPid
             Elsewhere toRef -> do
                 v <- requireConsumers thisDb fromPid
                 let links =
@@ -2824,10 +2808,7 @@ applySubstitutionsAt unitCfg depLookup thisDb thisDbObj rootDb solver scalings a
     resolveEndpoint :: Text -> Text -> IO (Either ServiceError Endpoint)
     resolveEndpoint refDb pidText
         | refDb == thisDbName =
-            pure $ case resolveScorable thisDb pidText of
-                Left e -> Left e
-                Right (p, _) ->
-                    Right $ Here p (dbProcessIdTable thisDb V.! fromIntegral p)
+            pure $ Here . fst <$> resolveScorable thisDb pidText
         | otherwise = do
             mPair <- depLookup refDb
             pure $ case mPair of

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -636,13 +636,10 @@ silently dropped.
 -}
 mkGraphEdgeFromTriple ::
     Database ->
-    V.Vector Activity ->
-    UnitDB ->
-    TechFlowDB ->
     M.Map ProcessId Int ->
     SparseTriple ->
     Maybe GraphEdge
-mkGraphEdgeFromTriple db activities units flows nodeIdMap (SparseTriple row col value)
+mkGraphEdgeFromTriple db nodeIdMap (SparseTriple row col value)
     | value == 0.0 = Nothing
     | otherwise = do
         let sourcePid = fromIntegral row :: ProcessId
@@ -650,11 +647,11 @@ mkGraphEdgeFromTriple db activities units flows nodeIdMap (SparseTriple row col 
         src <- M.lookup sourcePid nodeIdMap
         tgt <- M.lookup targetPid nodeIdMap
         let matchingExchange = do
-                srcAct <- activities V.!? fromIntegral row
+                srcAct <- dbActivities db V.!? fromIntegral row
                 targetUUID <- prActivity <$> processIdToRef db targetPid
                 L.find (isInputLinkTo targetUUID) (exchanges srcAct)
-            flowInfo = matchingExchange >>= \ex -> M.lookup (exchangeFlowId ex) flows
-            uName = maybe "<unresolved unit>" (getUnitNameForTechFlow units) flowInfo
+            flowInfo = matchingExchange >>= \ex -> M.lookup (exchangeFlowId ex) (dbTechFlows db)
+            uName = maybe "<unresolved unit>" (getUnitNameForTechFlow (dbUnits db)) flowInfo
             flowName = case (flowInfo, matchingExchange) of
                 (Just f, _) -> tfName f
                 (Nothing, Just ex) -> unresolvedFlowName (exchangeFlowId ex)
@@ -665,10 +662,10 @@ mkGraphEdgeFromTriple db activities units flows nodeIdMap (SparseTriple row col 
 sentinel node rather than crashing — preserves the project's "no silent
 errors, no silent successes" stance.
 -}
-mkGraphNode :: Database -> V.Vector Activity -> Int -> (ProcessId, Double) -> GraphNode
-mkGraphNode db activities nodeId (pid, cumulativeVal) =
+mkGraphNode :: Database -> Int -> (ProcessId, Double) -> GraphNode
+mkGraphNode db nodeId (pid, cumulativeVal) =
     let processIdText = processIdToText db pid
-     in case activities V.!? fromIntegral pid of
+     in case dbActivities db V.!? fromIntegral pid of
             Just activity ->
                 GraphNode
                     { gnNodeId = nodeId
@@ -701,12 +698,11 @@ buildActivityGraph db sharedSolver queryText cutoffPercent =
                 threshold = sum (map abs supplyList) * (cutoffPercent / 100.0)
                 significantActivities = selectSignificantActivities threshold processId supplyList
                 nodeIdMap = M.fromList [(pid, idx) | (idx, (pid, _)) <- zip [0 ..] significantActivities]
-                activities = dbActivities db
                 edges =
                     mapMaybe
-                        (mkGraphEdgeFromTriple db activities (dbUnits db) (dbTechFlows db) nodeIdMap)
+                        (mkGraphEdgeFromTriple db nodeIdMap)
                         (U.toList (dbTechnosphereTriples db))
-                nodes = zipWith (mkGraphNode db activities) [0 ..] significantActivities
+                nodes = zipWith (mkGraphNode db) [0 ..] significantActivities
                 unitGroups = buildUnitGroups (map gnUnit nodes)
             pure $ Right $ GraphExport nodes edges unitGroups
 
@@ -2756,8 +2752,8 @@ applySubstitutionsAt unitCfg depLookup thisDb thisDbObj rootDb solver scalings a
                         ]
                 Right $ GlobalRankOneUpdate [(fromIntegral fromPid, 1.0)] v links
 
-    virtualLinkTo cPid toRef =
-        mkVirtualLink thisDb cPid (drDb toRef) (drDbName toRef) (drUUIDs toRef) (drPid toRef)
+    virtualLinkTo :: ProcessId -> DepRef -> Double -> CrossDBLink
+    virtualLinkTo = mkVirtualLink thisDb
 
     requireTech sub cPid fromPid =
         maybe (Left $ noTechLink sub cPid) Right $
@@ -2842,22 +2838,15 @@ mkVirtualLink ::
     Database ->
     -- | consumer's root ProcessId
     ProcessId ->
-    -- | dep DB (supplier side)
-    Database ->
-    -- | dep DB name
-    Text ->
-    -- | supplier's (actUUID, prodUUID) in dep DB
-    (UUID, UUID) ->
-    -- | supplier's dep-DB ProcessId
-    ProcessId ->
+    -- | the supplier, in its own dependency database
+    DepRef ->
     -- | raw exchange coefficient (pre-normalization)
     Double ->
     CrossDBLink
-mkVirtualLink rootDb consumerPid depDb depDbName supUUIDs supPid coef =
+mkVirtualLink rootDb consumerPid DepRef{drDbName = depDbName, drDb = depDb, drPid = supPid, drUUIDs = (supActU, supProdU)} coef =
     let (cActU, cProdU) = dbProcessIdTable rootDb V.! fromIntegral consumerPid
         supAct = dbActivities depDb V.! fromIntegral supPid
         refUnit = maybe "" (getUnitNameForExchange (dbUnits depDb)) (L.find isReferenceOutput (exchanges supAct))
-        (supActU, supProdU) = supUUIDs
      in CrossDBLink
             { cdlConsumerActUUID = cActU
             , cdlConsumerProdUUID = cProdU

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -32,7 +32,7 @@ import qualified Data.Vector.Unboxed as U
 import Database (applyStructuredFilters, findActivitiesByFields, findFlowsBySynonym, flowNameRelevance)
 import Database.Allocation (asAllocated, describeRefusal, propertyShares)
 import Database.MatrixBuild (findProducer, linkedProducer)
-import Matrix (DepDemands, Inventory, accumulateDepDemandsWith, activityNormalizationFactor, applyBiosphereMatrix, buildDemandVectorFromIndex, computeInventoryMatrix, depDemandsToVector, perturbA, perturbABatch, perturbGlobal, toList)
+import Matrix (DepDemands, Inventory, SupplierDemands, accumulateDepDemandsWith, activityNormalizationFactor, applyBiosphereMatrix, buildDemandVectorFromIndex, computeInventoryMatrix, depDemandsToVector, perturbA, perturbABatch, perturbGlobal, toList)
 import qualified Matrix.Export as MatrixExport
 import qualified Progress
 import qualified Search.BM25 as BM25
@@ -343,14 +343,10 @@ findProcessIdForActivity db activity =
     let actName = activityName activity
         actLoc = activityLocation activity
         actUnit = activityUnit activity
-        refFlowId = case [exchangeFlowId ex | ex <- exchanges activity, exchangeIsReference ex] of
-            (fid : _) -> Just fid
-            [] -> Nothing
+        refFlowId = exchangeFlowId <$> L.find exchangeIsReference (exchanges activity)
 
         matchesActivity dbActivity =
-            let dbRefFlowId = case [exchangeFlowId ex | ex <- exchanges dbActivity, exchangeIsReference ex] of
-                    (dbFid : _) -> Just dbFid
-                    [] -> Nothing
+            let dbRefFlowId = exchangeFlowId <$> L.find exchangeIsReference (exchanges dbActivity)
              in activityName dbActivity == actName
                     && activityLocation dbActivity == actLoc
                     && activityUnit dbActivity == actUnit
@@ -1091,9 +1087,7 @@ calculateActivityMetadata db activity =
         wasteExchanges = [(fid, linkId) | WasteExchange{waFlowId = fid, waActivityLinkId = linkId} <- allExchanges]
         wasteLinked = length [() | (fid, linkId) <- wasteExchanges, linkId /= UUID.nil || S.member fid resolved]
         wasteOrphan = length wasteExchanges - wasteLinked
-        refProduct = case [ex | ex <- allExchanges, exchangeIsReference ex] of
-            [] -> Nothing
-            (ex : _) -> Just (exchangeFlowId ex)
+        refProduct = exchangeFlowId <$> L.find exchangeIsReference allExchanges
      in ActivityMetadata
             { pmTotalFlows = uniqueFlows
             , pmTechnosphereInputs = techInputs
@@ -1289,7 +1283,7 @@ toExchangeWithUnit ::
 toExchangeWithUnit db links exchange =
     -- Surface the raw UUID when the flow does not resolve — a clear failure
     -- the consumer can debug, not a silent "unknown".
-    let unresolvedName = "<unresolved flow " <> UUID.toText (exchangeFlowId exchange) <> ">"
+    let unresolvedName = unresolvedFlowName (exchangeFlowId exchange)
         (flowName, compartment) = fromMaybe (unresolvedName, Nothing) (resolveFlow db exchange)
         target = resolveTarget db links exchange
      in ExchangeWithUnit
@@ -1309,21 +1303,21 @@ toExchangeWithUnit db links exchange =
 are always technosphere.
 -}
 getReferenceProductName :: TechFlowDB -> Activity -> Maybe Text
-getReferenceProductName flows activity =
-    case [ex | ex <- exchanges activity, exchangeIsReference ex] of
-        (ex : _) -> fmap tfName (M.lookup (exchangeFlowId ex) flows)
-        [] -> Nothing
+getReferenceProductName flows activity = do
+    ex <- L.find exchangeIsReference (exchanges activity)
+    tfName <$> M.lookup (exchangeFlowId ex) flows
 
 -- | Get reference product info (name, amount, unit) from activity exchanges
 getReferenceProductInfo :: TechFlowDB -> UnitDB -> Activity -> (Text, Double, Text)
 getReferenceProductInfo flows units activity =
-    case [ex | ex <- exchanges activity, exchangeIsReference ex] of
-        (ex : _) ->
-            let name = maybe "" tfName (M.lookup (exchangeFlowId ex) flows)
-                amount = exchangeAmount ex
-                uName = getUnitNameForExchange units ex
-             in (name, amount, uName)
-        [] -> ("", 1.0, "")
+    maybe ("", 1.0, "") describe (L.find exchangeIsReference (exchanges activity))
+  where
+    describe :: Exchange -> (Text, Double, Text)
+    describe ex =
+        ( maybe "" tfName (M.lookup (exchangeFlowId ex) flows)
+        , exchangeAmount ex
+        , getUnitNameForExchange units ex
+        )
 
 {- | Build an 'ActivitySummary' from a (ProcessId, Activity) pair. Encapsulates
 the reference-product + allocation + native-type projection shared by
@@ -1431,9 +1425,7 @@ technosphere by definition.
 -}
 getActivityReferenceProductDetail :: Database -> Activity -> Maybe FlowDetail
 getActivityReferenceProductDetail db activity = do
-    refExchange <- case filter exchangeIsReference (exchanges activity) of
-        [] -> Nothing
-        (ex : _) -> Just ex
+    refExchange <- L.find exchangeIsReference (exchanges activity)
     flow <- M.lookup (exchangeFlowId refExchange) (dbTechFlows db)
     let usageCount = getFlowUsageCount db (tfId flow)
     let uName = getUnitNameForTechFlow (dbUnits db) flow
@@ -2018,7 +2010,7 @@ walkDepLevels ::
     S.Set Text ->
     IO (Either ServiceError (Int, [SupplyChainEntry], [SupplyChainEdge]))
 walkDepLevels unitCfg depLookup consumerDb consumerScaling extras scf includeEdges depth visited
-    | depth >= maxSubsDepth = pure (Right (0, [], []))
+    | depth >= SharedSolver.maxDepsDepth = pure (Right (0, [], []))
     | otherwise = do
         let demandsMap = accumulateDepDemandsWith consumerDb extras consumerScaling
         results <-
@@ -2044,7 +2036,7 @@ resolveOneDep ::
     Int ->
     -- | visited
     S.Set Text ->
-    (Text, M.Map (UUID, UUID) (Double, Text)) ->
+    (Text, SupplierDemands) ->
     IO (Either ServiceError (Int, [SupplyChainEntry], [SupplyChainEdge]))
 resolveOneDep unitCfg depLookup scf includeEdges depth visited (depDbName, demands)
     | depDbName `S.member` visited = pure (Right (0, [], []))
@@ -2158,9 +2150,7 @@ bfsToPattern from matches adj = go (Empty |> from) (IM.singleton from from)
 -- | Get reference product amount for an activity (defaults to 1.0)
 getReferenceProductAmount :: Activity -> Double
 getReferenceProductAmount activity =
-    case [exchangeAmount ex | ex <- exchanges activity, exchangeIsReference ex] of
-        (amt : _) -> amt
-        [] -> 1.0
+    maybe 1.0 exchangeAmount (L.find exchangeIsReference (exchanges activity))
 
 {- | Root-only scaling vector: solve @(I-A)x = d@. Substitutions are applied by
 the cross-DB applicator ('applySubstitutionsAt', via
@@ -2266,10 +2256,6 @@ resolveRootOnly db t
             Left (ActivityNotFound msg) -> Left ("activity not found: " <> msg)
             Left (NotScorable msg) -> Left msg
             Left e -> Left (T.pack (show e))
-
--- | Safety net against pathological dep chains. Matches 'SharedSolver.maxDepsDepth'.
-maxSubsDepth :: Int
-maxSubsDepth = 10
 
 {- | A global ('AllConsumers') substitution enumerates the replaced supplier's
 consumers from the __root__ technosphere row, so @from@ must live in the
@@ -2429,7 +2415,7 @@ goWithSubsAndDeps unitCfg depLookup thisDb thisDbName rootDb solver demands allS
                     (\inv s -> SharedSolver.CrossDBSolution inv (NE.singleton (unThisDb thisDbName, thisDb, s)))
                     localInvs
                     scalings'
-        if depth >= maxSubsDepth
+        if depth >= SharedSolver.maxDepsDepth
             then pure (Right baseSolutions)
             else do
                 let perRootDepDemands = map (accumulateDepDemandsWith thisDb virtualLks) scalings'
@@ -2597,12 +2583,18 @@ requireConsumers db supplier = case technosphereRow db supplier of
     [] -> Left $ MatrixError $ "global substitution: activity is consumed nowhere: " <> processIdToText db supplier
     row -> Right row
 
+{- | The reference exchange a substitution reads, which is the produced one.
+Deliberately narrower than 'exchangeIsReference' alone: an activity that
+treats a waste has a reference input, and no unit to normalize a column to.
+-}
+isReferenceOutput :: Exchange -> Bool
+isReferenceOutput ex = exchangeIsReference ex && not (exchangeIsInput ex)
+
 -- | Reference-product unit an activity's technosphere column is normalized to.
 referenceProductUnit :: Database -> ProcessId -> Maybe Text
 referenceProductUnit db pid =
-    case [ex | ex <- exchanges (dbActivities db V.! fromIntegral pid), exchangeIsReference ex, not (exchangeIsInput ex)] of
-        (ex : _) -> Just (getUnitNameForExchange (dbUnits db) ex)
-        [] -> Nothing
+    getUnitNameForExchange (dbUnits db)
+        <$> L.find isReferenceOutput (exchanges (dbActivities db V.! fromIntegral pid))
 
 {- | Unit-conversion factor κ for a within-DB substitution @from → to@: how
 many reference units of @to@'s product equal one of @from@'s, so the
@@ -2883,9 +2875,7 @@ mkVirtualLink ::
 mkVirtualLink rootDb consumerPid depDb depDbName supUUIDs supPid coef =
     let (cActU, cProdU) = dbProcessIdTable rootDb V.! fromIntegral consumerPid
         supAct = dbActivities depDb V.! fromIntegral supPid
-        refUnit = case [ex | ex <- exchanges supAct, exchangeIsReference ex, not (exchangeIsInput ex)] of
-            (ex : _) -> getUnitNameForExchange (dbUnits depDb) ex
-            [] -> ""
+        refUnit = maybe "" (getUnitNameForExchange (dbUnits depDb)) (L.find isReferenceOutput (exchanges supAct))
         (supActU, supProdU) = supUUIDs
      in CrossDBLink
             { cdlConsumerActUUID = cActU

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -158,10 +158,7 @@ findActivityByProcessId db processId =
 
 -- | Resolve activity query using ProcessId format with UUID fallback for compatibility
 resolveActivityByProcessId :: Database -> Text -> Either ServiceError Activity
-resolveActivityByProcessId db queryText =
-    case resolveActivityAndProcessId db queryText of
-        Right (_processId, activity) -> Right activity
-        Left err -> Left err
+resolveActivityByProcessId db = fmap snd . resolveActivityAndProcessId db
 
 {- | Resolve an activity that is about to be scored. One the allocation gate
 refused resolves for inspection, never for a score: the refusal names what is
@@ -2362,17 +2359,17 @@ validateAnchorDbs depLookup rootDbObj rootDb subs = do
         then pure (Right ())
         else do
             reachable <- reachableDepDbs depLookup rootDbName rootDbObj
-            let unreachable = externalAnchorDbs `S.difference` reachable
-            case S.toList unreachable of
-                [] -> pure (Right ())
-                (d : _) -> do
-                    mLoad <- depLookup d
-                    pure $ Left $ MatrixError $ case mLoad of
-                        Nothing -> "substitution consumer references unloaded database: " <> d
-                        Just _ ->
-                            "substitution consumer database '"
-                                <> d
-                                <> "' is not reachable from root database's dep-graph"
+            maybe (pure (Right ())) refuse (S.lookupMin (externalAnchorDbs `S.difference` reachable))
+  where
+    refuse :: Text -> IO (Either ServiceError ())
+    refuse d = do
+        mLoad <- depLookup d
+        pure $ Left $ MatrixError $ case mLoad of
+            Nothing -> "substitution consumer references unloaded database: " <> d
+            Just _ ->
+                "substitution consumer database '"
+                    <> d
+                    <> "' is not reachable from root database's dep-graph"
 
 {- | BFS the loaded portion of the dep-DB DAG from @rootDbName@. Returns
 the set of DB names that are statically reachable via 'dbCrossDBLinks'
@@ -2926,16 +2923,15 @@ findStaticCrossDBLink rootDb consumerPid depDbName depSupUUIDs =
 -- | Find the technosphere coefficient A[supplier, consumer] from the sparse triples
 findTechCoefficient :: Database -> ProcessId -> ProcessId -> Maybe Double
 findTechCoefficient db consumer supplier =
-    let techTriples = dbTechnosphereTriples db
-        consumerIdx = fromIntegral consumer :: Int32
-        supplierIdx = fromIntegral supplier :: Int32
-        matching =
-            U.filter
-                (\(SparseTriple row col _) -> row == supplierIdx && col == consumerIdx)
-                techTriples
-     in if U.null matching
-            then Nothing
-            else let SparseTriple _ _ val = U.head matching in Just val
+    coefficient <$> U.find isWanted (dbTechnosphereTriples db)
+  where
+    consumerIdx, supplierIdx :: Int32
+    consumerIdx = fromIntegral consumer
+    supplierIdx = fromIntegral supplier
+    isWanted :: SparseTriple -> Bool
+    isWanted (SparseTriple row col _) = row == supplierIdx && col == consumerIdx
+    coefficient :: SparseTriple -> Double
+    coefficient (SparseTriple _ _ val) = val
 
 {- | Find all activities that transitively depend on a given supplier.
 BFS through the technosphere matrix tracking depth; optional max-depth cap.

--- a/src/SharedSolver.hs
+++ b/src/SharedSolver.hs
@@ -34,6 +34,7 @@ module SharedSolver (
     computeInventoryMatrixWithDepsCached,
     computeInventoryMatrixBatchWithDepsCached,
     goWithDepsFromScalings,
+    maxDepsDepth,
     mergeSolutions,
     prepareDepDemandVecs,
     crossDBProcessContributions,

--- a/test/CoproductTargetSpec.hs
+++ b/test/CoproductTargetSpec.hs
@@ -59,7 +59,7 @@ spec = do
             case treeOfConsumer db of
                 Left err -> expectationFailure (show err)
                 Right tree -> do
-                    let export = Service.convertToTreeExport db (pidText consumerProdId) 10 tree
+                    let export = Service.convertToTreeExport db 10 tree
                         missing = [n | n <- M.elems (teNodes export), enNodeType n == MissingNode]
                     map enLoopTarget missing `shouldBe` [Nothing]
                     length (teEdges export) `shouldBe` 1
@@ -71,7 +71,7 @@ spec = do
                 Just root ->
                     -- 2000 g of a flow measured in kg, on an edge that says kg.
                     let tree = buildLoopAwareTree gramsAware db 10 root
-                     in case teEdges (Service.convertToTreeExport db (pidText consumerProdId) 10 tree) of
+                     in case teEdges (Service.convertToTreeExport db 10 tree) of
                             [edge] -> (teQuantity edge, teUnit edge) `shouldBe` (2.0, "kg")
                             other -> expectationFailure ("expected one edge, got " <> show (length other))
 
@@ -160,7 +160,7 @@ rootNodes db = case treeOfConsumer db of
     Left _ -> []
     Right tree ->
         [ n
-        | n <- M.elems (teNodes (Service.convertToTreeExport db (pidText consumerProdId) 10 tree))
+        | n <- M.elems (teNodes (Service.convertToTreeExport db 10 tree))
         , enDepth n == 0
         ]
 

--- a/test/ServiceSpec.hs
+++ b/test/ServiceSpec.hs
@@ -20,7 +20,6 @@ import Service (
     ServiceError (..),
     TargetRef (..),
     buildUnitGroups,
-    extractCompartment,
     filterTreeExport,
     isResourceExtraction,
     resolveActivityAndProcessId,
@@ -149,31 +148,6 @@ spec = do
             let flow = mkBioFlow "air"
             isResourceExtraction flow `shouldBe` False
     -- Technosphere flows can't reach this function under the new type system.
-
-    -- -----------------------------------------------------------------------
-    -- extractCompartment
-    -- -----------------------------------------------------------------------
-    describe "extractCompartment" $ do
-        it "classifies air compartment" $
-            extractCompartment "air" `shouldBe` "air"
-
-        it "classifies high population air" $
-            extractCompartment "Emissions to air/high. pop." `shouldBe` "air"
-
-        it "classifies water compartment" $
-            extractCompartment "water" `shouldBe` "water"
-
-        it "classifies aquatic compartment" $
-            extractCompartment "Aquatic" `shouldBe` "water"
-
-        it "classifies soil compartment" $
-            extractCompartment "soil/agricultural" `shouldBe` "soil"
-
-        it "classifies ground as soil" $
-            extractCompartment "ground" `shouldBe` "soil"
-
-        it "falls back to other for unknown" $
-            extractCompartment "biotic resource" `shouldBe` "other"
 
     -- -----------------------------------------------------------------------
     -- buildUnitGroups


### PR DESCRIPTION
Thirteen small readability findings on `src/Service.hs`, the module's largest file, applied in four commits by subject. Nothing here changes what the program does.

The file was read twice in parallel on two axes, what the code looks like and what it means, and a third agent then checked the resulting plan against the file. That check earned its keep: it found nine claims that did not hold as written, one supposedly behaviour-free finding that would have changed behaviour, and eight findings that contradict each other once applied together. It also rejected my proposed first pull request. This one follows the cut it named instead.

## What changed

- **Say it the short way.** `findTechCoefficient` filtered the whole triple vector to take its head behind a null guard, where `U.find` answers the same `Maybe`. `resolveActivityByProcessId` rebuilt an `Either` to drop a component. `validateAnchorDbs` matched a list it had just converted from a set.
- **Say it once.** Nine places spelled "the first reference exchange" as a list comprehension matched against `(x : _)`, while one already used `L.find`. The narrower outputs-only rule now has a name, `isReferenceOutput`, so the two spellings stop looking like one rule written carelessly. `maxSubsDepth` carried a comment saying it matches `SharedSolver.maxDepsDepth`, which is a comment doing an import's job; the unresolved-flow text and the supplier-demand map likewise already had owners in `API.Types` and `Matrix`.
- **Drop what nothing reads.** The `Endpoint` constructor `Here` carried a `(UUID, UUID)` pair every match discarded, and building it indexed the process-id table partially for a value nobody wanted. `resolveDepWithSubs` took a count its own argument list determines, as two adjacent `Int`s a caller could swap unnoticed. `convertToTreeExport` took a root process id it ignored while three tests and one route computed one to pass. `extractCompartment` classified a compartment by substring and had no caller outside its own tests.
- **Pass the database, not four things read out of it.** `mkGraphEdgeFromTriple` and `mkGraphNode` took the activity vector, the unit table and the flow table alongside the `Database` they all came from. `mkVirtualLink` took seven positionals of which four were the fields of a `DepRef` its only caller unpacked one by one.

## Depth

|  | before | after |
|---|---|---|
| deepest line starts at column | 69 | 69 |
| lines starting past column 40 | 59 | 59 |
| lines starting past column 28 | 132 | 127 |
| file length | 3090 | 3046 |

Modest, and it should be: this pull request is deliberately the set of small, uncontested changes. Every function that actually makes this file deep is on the waiting list below. The deepest line is in `getPathTo`, which is one of them.

## Verification

Cold `-Werror` build of the library, the executable and the test suite in a builddir of its own, then the same three plus the suite after every group. `hlint` reports no hints, `fourmolu` is clean.

The suite reports **2446 examples, 0 failures, 2 pending**, where it reported 2453 before. The seven missing examples are exactly the `extractCompartment` tests, deleted with the function they tested.

Diffing the string literals across the change leaves two lines, both explainable: `"<unresolved flow "` moved into `API.Types.unresolvedFlowName`, which already owned that text and which this file now calls (`Data.UUID`'s `show` is `toString`, which is what `toText` builds on, so the rendered text is identical); the other is a fragment of the deleted `extractCompartment` staircase, not a message.

## What was deliberately not touched

Twenty-one findings change behaviour and are recorded, each naming the file, the line and what the right behaviour would be, but none is applied. The ones worth knowing about now:

- **Three rules are each written two or three times, and the copies disagree.** Which activities match a filter (three copies, and the product filter differs on whether a reference *input* counts, which decides whether waste-treatment activities appear). Which activity an exchange points to (`resolveTarget` refuses an activity-UUID fallback for waste outputs and explains why; `resolveTargetSummary` and `getTargetActivity` use exactly that fallback, so two endpoints can name two different rows for the same exchange). Which exchange is the reference product (either direction in four places, outputs only in three, so a waste-treatment row has a reference amount but no reference unit).
- **The dep-graph walk is written three times** and only one of the three carries a cycle guard.
- **An unknown `sort=` value is silently ignored** and sorts by the default; four pagination sites carry four different default limits.
- **`searchTimeMs` measures the bracket, not the search**, because nothing between the two clock reads forces the lazy result list.
- Several sentinels standing in for failures: `("", 1.0, "")` for a missing reference product, an activity summary named "Unknown" for a broken index, `fromMaybe 0.0` for a root outside the supply vector.

## What waits for the next pull request

Findings that are behaviour-free but too large or too entangled to mix in: hoisting `applySubstitutionsAt`'s pure planners out of a 199-line function; giving `collectSupplyChainEntries` a `WalkLevel` sum type so its four correlated parameters stop admitting a meaningless combination (with the `Collected` record and the `includeEdges` move, which touch the same signature); `getConsumers`' 105-line `let`; `goWithSubsAndDeps`; the `runExceptT` rewrite of the `Either`-passing ladders, once its two false call-outs are corrected, because two of the arms it named short-circuit to *success* on purpose and rewriting them as failures would turn a partial cross-database answer into an error; the `TreeStats` deletion; the new types that cross signatures; and, last of all, the type signatures on `where` helpers, since half those helpers are deleted or retyped by the findings above.

Splitting the file into five modules is also recorded, with the cluster boundaries and the one shared constant that stands in the way, but it should follow the work above rather than precede it.
