### PR TITLE
Ask a database for another allocation key without editing a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 ### Fixed
+- An EcoSpold 2 dataset whose block a key divides into several processes now
+  says that only one of them will be kept. A process is identified by its file
+  name there, which names a single product, so the coproducts a key had just
+  separated all claimed the same identity and the registry kept the last one:
+  a database quietly missing the very products the key was named to produce.
 - A released Linux binary now reports the commit it was built from, and a
   release binary the tag it carries. Both used to come out as `unknown` and
   an empty tag on Linux alone (`volca --version`, `GET /api/v1/version`),
@@ -30,6 +35,27 @@
   unit to restate it in.
 
 ### Added
+- A database can now be asked for another allocation key without editing the
+  configuration file: `POST /api/v1/db/{name}/derive/{newName}?allocation=wet
+  mass`, the `derive_database` tool, and `Client.derive_database` in pyvolca.
+  Until now naming a key meant writing a second `[[databases]]` entry and
+  restarting, which nobody hosting an engine can do and which cost the person
+  running one their own file. The source is untouched and both stay loadable,
+  so the two allocations of one study can be compared side by side.
+
+  This is a load, not a copy: the key decides the inventory of every process a
+  load produces, so the sources are read again. Seconds to minutes on a large
+  database, against the milliseconds a copy takes, and it answers with what a
+  load answers with.
+
+  A key that divides no block of the source is refused, naming both numbers:
+  such a load is that database under a second name, costing a second database
+  in memory and a second matrix cache on disk. An unreadable key is refused
+  with the list of keys there are, never read as `declared`.
+
+  The key a database was divided under, and the source whose files it reads,
+  now travel with its status, so a column of shares can say whether the source
+  stated them or a property recomputed them. Wire revision 20.
 - A flow search can name several kinds at once: `kind=biosphere,waste` keeps
   what is exchanged with nature or discarded and nothing else, in one listing.
   `search-counts` already answers that pair as a single number, and there was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,16 @@
 
   A key that divides no block of the source is refused, naming both numbers:
   such a load is that database under a second name, costing a second database
-  in memory and a second matrix cache on disk. An unreadable key is refused
-  with the list of keys there are, never read as `declared`.
+  in memory and a second matrix cache on disk. So is the key the source
+  already reads under, before the load rather than after it: that duplicate is
+  the one no count of divided blocks can see, since dividing the same blocks a
+  second time divides them just as well. An unreadable key is refused with the
+  list of keys there are, never read as `declared` -- in a `meta.toml` either,
+  where it now leaves the database out of the listing and says so, rather than
+  handing back declared shares under a name promising otherwise.
+
+  A database's recorded source is the same before and after a restart: a copy
+  named none in memory and its own source's name once read back.
 
   The key a database was divided under, and the source whose files it reads,
   now travel with its status, so a column of shares can say whether the source

--- a/README.md
+++ b/README.md
@@ -137,7 +137,9 @@ allocation = "declared"        # how a multi-output block is divided:
                                # declared | dry mass | wet mass. Naming a mass
                                # recomputes the shares from it instead of
                                # reading the ones the source states; to have
-                               # both, configure the same path twice.
+                               # both, configure the same path twice, or ask
+                               # for the second one at runtime with
+                               # POST /db/{name}/derive/{newName}?allocation=
 # locationAliases = { "FR" = "France" }   # per-database location renames
 
 [[methods]]
@@ -274,6 +276,7 @@ GET    /api/v1/db                                                        List da
 POST   /api/v1/db/upload                                                 Upload a database archive
 POST   /api/v1/db/{dbName}/load                                          Load a configured database
 POST   /api/v1/db/{dbName}/unload                                        Unload (keep config, free memory)
+POST   /api/v1/db/{dbName}/derive/{newName}?allocation=                  Read the same sources under another allocation key
 POST   /api/v1/db/{dbName}/relink                                        Re-resolve cross-DB links (optional JSON body: depDb + mappingCsv for an alias relink)
 GET    /api/v1/db/{dbName}/gap-report                                    Supplier-gap report (what is still unsupplied after linking)
 GET    /api/v1/db/{dbName}/quality-report                                Dataset-soundness report (what is malformed in the database)
@@ -540,6 +543,7 @@ volca method delete ef-31                        # delete
 | Relink / finalize | `POST /db/{name}/(relink\|finalize)` | `database relink DB --to DEP --mapping CSV` |
 | Setup / dependencies | `GET /db/{name}/setup`, `POST .../{add,remove}-dependency/{dep}`, `POST .../set-data-path` | — |
 | Copy database | `POST /db/{name}/copy/{newName}` | `database copy SRC NEW_NAME` |
+| Re-key database | `POST /db/{name}/derive/{newName}?allocation=` | — |
 | Delete activities (by filter or ids) | `POST /db/{name}/delete` | `database delete-activities DB [filters\|--id …]` |
 | Export database | `POST /db/{name}/export` | `database export DB --format FMT --out FILE` |
 | Delete database | `DELETE /db/{name}` | `database delete NAME` |

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -534,6 +534,21 @@ Delete a method collection: unload it and remove its staged file.
 
 Delete a reference-data set of ``kind`` and remove its staged file.
 
+##### `Client.derive_database(new_name: str, allocation: str = 'wet mass', db_name: str | None = None) -> dict`
+
+Read a database's sources again under another allocation key.
+
+Divides every multi-output block by a physical property of the
+products instead of by the shares the source declares: ``"wet mass"``
+weighs each product as it is, ``"dry mass"`` weighs its dry matter,
+``"declared"`` keeps the source's own shares. The source is untouched
+and both stay loadable side by side, so two allocations of one study
+can be compared.
+
+This is a full load, not a copy: seconds to minutes on a large
+database. Refused when the key divides no block of the source, which
+would leave that source under a second name.
+
 ##### `Client.download_flow_synonyms(name: str) -> bytes`
 
 Download a flow-synonyms set as its raw CSV bytes.

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -534,7 +534,7 @@ Delete a method collection: unload it and remove its staged file.
 
 Delete a reference-data set of ``kind`` and remove its staged file.
 
-##### `Client.derive_database(new_name: str, allocation: str = 'wet mass', db_name: str | None = None) -> dict`
+##### `Client.derive_database(new_name: str, allocation: str, db_name: str | None = None) -> dict`
 
 Read a database's sources again under another allocation key.
 
@@ -546,8 +546,9 @@ and both stay loadable side by side, so two allocations of one study
 can be compared.
 
 This is a full load, not a copy: seconds to minutes on a large
-database. Refused when the key divides no block of the source, which
-would leave that source under a second name.
+database. Refused when the key divides no block of the source, or when
+it is the key that source already reads under: either would leave that
+source under a second name.
 
 ##### `Client.download_flow_synonyms(name: str) -> bytes`
 

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -847,6 +847,32 @@ class Client:
         """
         return self._call("unload_database", db_name=db_name)
 
+    def derive_database(
+        self,
+        new_name: str,
+        allocation: str = "wet mass",
+        db_name: str | None = None,
+    ) -> dict:
+        """Read a database's sources again under another allocation key.
+
+        Divides every multi-output block by a physical property of the
+        products instead of by the shares the source declares: ``"wet mass"``
+        weighs each product as it is, ``"dry mass"`` weighs its dry matter,
+        ``"declared"`` keeps the source's own shares. The source is untouched
+        and both stay loadable side by side, so two allocations of one study
+        can be compared.
+
+        This is a full load, not a copy: seconds to minutes on a large
+        database. Refused when the key divides no block of the source, which
+        would leave that source under a second name.
+        """
+        return self._call(
+            "derive_database",
+            db_name=self._db(db_name),
+            new_name=new_name,
+            allocation=allocation,
+        )
+
     # -- Database write operations --
     #
     # These mutate a loaded database (copy / delete / relink / export /

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -850,7 +850,7 @@ class Client:
     def derive_database(
         self,
         new_name: str,
-        allocation: str = "wet mass",
+        allocation: str,
         db_name: str | None = None,
     ) -> dict:
         """Read a database's sources again under another allocation key.
@@ -863,9 +863,11 @@ class Client:
         can be compared.
 
         This is a full load, not a copy: seconds to minutes on a large
-        database. Refused when the key divides no block of the source, which
-        would leave that source under a second name.
+        database. Refused when the key divides no block of the source, or when
+        it is the key that source already reads under: either would leave that
+        source under a second name.
         """
+        self._require_wire(20, "derive_database", engine_hint="0.12.1")
         return self._call(
             "derive_database",
             db_name=self._db(db_name),

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -27,6 +27,7 @@ module API.DatabaseHandlers (
     coverageReportToAPI,
     explainCFToAPI,
     copyDatabaseHandler,
+    deriveDatabaseHandler,
     deleteDatabaseHandler,
     deleteActivitiesHandler,
     createActivitiesHandler,
@@ -62,6 +63,7 @@ module API.DatabaseHandlers (
     memoryRefusal,
     loadRefusal,
     copyRefusal,
+    quotaCounts,
     loadQuotaRefusal,
     simpleAction,
     formatToText,
@@ -158,6 +160,7 @@ import Database.Edit (
     WriteVerb (..),
     copyDatabase,
     deleteActivitiesInDB,
+    deriveDatabase,
     editExchanges,
     refusalMessage,
     writeActivities,
@@ -236,10 +239,12 @@ import Types (
     Database (..),
     GeographyPolicy (..),
     ProcessRef (..),
+    allocationKeyText,
     bfCompartmentName,
     bfCompartmentSub,
     blockerReasonDetail,
     getUnitNameForBioFlow,
+    parseAllocationKey,
     processRefText,
     unresolvedCount,
  )
@@ -523,6 +528,39 @@ copyDatabaseHandler dbName newName = do
         Just msg -> pure (ActivateResponse False msg Nothing)
         Nothing ->
             simpleAction (copyDatabase dbManager dbName newName) ("Copied database: " <> dbName <> " -> " <> newName)
+
+{- | Read a loaded or configured database's own files again under another
+allocation key, and register the result under @newName@.
+
+Answers with what a load answers with, not with what a copy answers with: it
+is a load, of tens of seconds on a large source, and the page that asks for it
+is the one that already waits on that answer and shows the progress lines
+underneath it.
+
+An unreadable key is a 400 naming the keys there are. A key that divided
+nothing is a refusal from the engine, carried in the same @LoadFailed@ as
+every other reason a load produced no database.
+-}
+deriveDatabaseHandler :: Text -> Text -> Maybe Text -> AppM LoadDatabaseResponse
+deriveDatabaseHandler dbName newName mAllocation = do
+    guardMutation
+    key <- either badKey pure (parseAllocationKey (fromMaybe "declared" mAllocation))
+    dbManager <- asks aeDbManager
+    hostingConfig <- asks aeHostingConfig
+    -- A derived database is another database of the user's own, already
+    -- loaded, so it spends both budgets exactly as a copy does.
+    refusal <- liftIO $ do
+        (uploaded, loadedUploads) <- quotaCounts dbManager
+        pure (copyRefusal uploaded loadedUploads hostingConfig)
+    case refusal of
+        Just msg -> pure (LoadFailed msg)
+        Nothing ->
+            liftIO (deriveDatabase dbManager dbName newName key) >>= \case
+                Left err -> pure (LoadFailed err)
+                Right (loadedDb, depResults) -> pure (LoadSucceeded (makeStatusFromLoadedDb loadedDb) depResults)
+  where
+    badKey :: Text -> AppM a
+    badKey err = throwError err400{errBody = BSL.fromStrict (T.encodeUtf8 ("allocation: " <> err))}
 
 -- | Delete an uploaded database (move to trash)
 deleteDatabaseHandler :: Text -> AppM ActivateResponse
@@ -934,6 +972,7 @@ uploadDatabaseHandler mName mDesc src = do
                             , UploadedDB.umDataPath = makeRelative uploadDir (urPath uploadResult)
                             , UploadedDB.umDepends = []
                             , UploadedDB.umSource = Nothing
+                            , UploadedDB.umAllocation = Declared
                             }
                 liftIO $ UploadedDB.writeUploadMeta uploadDir meta
 
@@ -953,6 +992,7 @@ uploadDatabaseHandler mName mDesc src = do
                             , dcDeletable = True
                             , dcGeographyPolicy = GeoGlobal
                             , dcAllocation = Declared
+                            , dcSource = Nothing
                             }
 
                 -- Add to manager
@@ -979,6 +1019,8 @@ convertDbStatus ds =
         , dsaFormat = formatDisplayText <$> dsFormat ds
         , dsaActivityCount = dsActivityCount ds
         , dsaDependsOn = dsDependsOn ds
+        , dsaAllocation = allocationKeyText (dsAllocation ds)
+        , dsaSource = dsSource ds
         }
   where
     statusToText Unloaded = "unloaded"
@@ -1005,6 +1047,8 @@ makeStatusFromLoadedDb loaded =
             , dsaFormat = formatDisplayText <$> dcFormat config
             , dsaActivityCount = V.length (dbActivities db)
             , dsaDependsOn = dcDepends config
+            , dsaAllocation = allocationKeyText (dcAllocation config)
+            , dsaSource = dcSource config
             }
 
 -- uploadFormatToMeta removed - types are now unified (UploadedDB re-exports from Upload)
@@ -1133,6 +1177,7 @@ uploadMethodHandler mName mDesc src =
                             , UploadedDB.umDataPath = makeRelative uploadDir methodDir
                             , UploadedDB.umDepends = []
                             , UploadedDB.umSource = Nothing
+                            , UploadedDB.umAllocation = Declared
                             }
                 liftIO $ UploadedDB.writeUploadMeta uploadDir meta
 

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -21,6 +21,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.UUID as UUID
+import qualified Data.Vector as V
 import Network.HTTP.Types (hContentType, status200, status202, status405)
 import Network.Wai (Application, requestHeaders, requestMethod, responseLBS, strictRequestBody)
 import System.Random (randomIO)
@@ -34,12 +35,12 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Except (ExceptT (..), except, runExceptT, throwE)
 import Data.Bifunctor (first)
 import Database (filterByName, flowSearchFields)
-import Database.Edit (editExchanges, refusalMessage)
+import Database.Edit (deriveDatabase, editExchanges, refusalMessage)
 import Database.Manager (DatabaseManager (..), LoadedDatabase (..), getDatabase)
 import qualified Database.Manager as DM
 
 import qualified API.BatchImpacts as BI
-import API.DatabaseHandlers (coverageReportToAPI, editReportToAPI, explainCFToAPI, gapReportToAPI, loadQuotaRefusal, qualityReportToAPI)
+import API.DatabaseHandlers (copyRefusal, coverageReportToAPI, editReportToAPI, explainCFToAPI, gapReportToAPI, loadQuotaRefusal, qualityReportToAPI, quotaCounts)
 import API.MCP.Columnar (resolveSingleScoringSet, toColumnarBatch)
 import API.MCP.Enrich (addWebUrlMaybe, attachMarketHintByName, encodeSegment, filterScoringSets, scoreActivityWebUrl, slimLCIAPanel, webUrlField)
 import API.Routes (collectionNotLoadedMessage)
@@ -59,7 +60,7 @@ import qualified Service
 import qualified Service.Aggregate as Agg
 import SharedSolver (SharedSolver, computeInventoryMatrixWithDepsCached, crossDBProcessContributions)
 import qualified SharedSolver
-import Types (Activity (..), BiosphereFlow (..), Database (..), FlowKind (BioKind), Indexes (..), KindFilter (..), ProcessId, UUID, UnitDB, activityLocation, activityName, bfCompartmentName, bfCompartmentSub, exchangeIsInput, exchangeKindChoices, exchangeKindOf, getUnitNameForBioFlow, lookupExchangeFlow, parseExchangeKind, parseKindNames, processIdToText, qualifyRef, unresolvedCount)
+import Types (Activity (..), BiosphereFlow (..), Database (..), FlowKind (BioKind), Indexes (..), KindFilter (..), ProcessId, UUID, UnitDB, activityLocation, activityName, allocationKeyText, bfCompartmentName, bfCompartmentSub, exchangeIsInput, exchangeKindChoices, exchangeKindOf, getUnitNameForBioFlow, lookupExchangeFlow, parseAllocationKey, parseExchangeKind, parseKindNames, processIdToText, qualifyRef, unresolvedCount)
 
 -- ---------------------------------------------------------------------------
 -- JSON-RPC 2.0 types
@@ -472,6 +473,7 @@ callTool dbManager presets mHosting mBaseUrl rid name args = case name of
     "list_databases" -> callListDatabases dbManager rid
     "load_database" -> callLoadDatabase dbManager mHosting rid args
     "unload_database" -> callUnloadDatabase dbManager rid args
+    "derive_database" -> callDeriveDatabase dbManager mHosting rid args
     "list_presets" -> callListPresets presets rid
     "search_activities" -> withDb dbManager rid args $ callSearchActivities presets rid args
     "search_flows" -> withDb dbManager rid args $ callSearchFlows rid args
@@ -683,6 +685,31 @@ callUnloadDatabase dbManager rid args = runTool rid $ do
             object
                 [ "status" .= ("unloaded" :: Text)
                 , "database" .= dbName
+                ]
+
+{- | Read a database's sources again under another allocation key. Wraps
+'Edit.deriveDatabase', which refuses a key that divides no block rather than
+registering the source a second time under a name promising otherwise. The
+hosting quota applies as it does to a copy: what comes out is another loaded
+database of the user's own.
+-}
+callDeriveDatabase :: DatabaseManager -> Maybe HostingConfig -> Value -> KeyMap Value -> IO Value
+callDeriveDatabase dbManager mHosting rid args = runTool rid $ do
+    dbName <- except (requireText "database" args)
+    newName <- except (requireText "new_name" args)
+    key <- except (parseAllocationKey (fromMaybe "declared" (textArg "allocation" args)))
+    liftIO (quotaCounts dbManager) >>= \(uploaded, loadedUploads) ->
+        maybe (pure ()) throwE (copyRefusal uploaded loadedUploads mHosting)
+    (loaded, deps) <- ExceptT (deriveDatabase dbManager dbName newName key)
+    pure $
+        toolSuccessJson rid $
+            object
+                [ "status" .= ("loaded" :: Text)
+                , "database" .= newName
+                , "source" .= dbName
+                , "allocation" .= allocationKeyText key
+                , "activities" .= V.length (dbActivities (ldDatabase loaded))
+                , "dependencies" .= deps
                 ]
 
 callListPresets :: [ClassificationPreset] -> Value -> IO Value

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -325,8 +325,9 @@ description r = case r of
         \mass of each product, 'dry mass' by its dry matter, 'declared' keeps the \
         \source's own shares. The source is untouched and both stay usable side by \
         \side. This is a full load, not a copy: seconds to minutes on a large \
-        \database. Refused when the key divides no block, when the products carry no \
-        \such property, and on a read-only instance."
+        \database. Refused when the key divides no block, when it is the key the \
+        \source already reads under, when the products carry no such property, and \
+        \on a read-only instance."
     ListPresets ->
         "LCA / ACV: list named classification filter presets configured in this \
         \instance. Each preset bundles multiple (system, value, mode) classification \

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -43,8 +43,11 @@ import Network.HTTP.Types.Method (StdMethod (..))
 {- | Every operation VoLCA exposes through its user-facing surfaces.
 
 What belongs here is what an analyst does. That covers the analysis operations,
-and loading or unloading a database: those change which databases are in the
-working set rather than the data itself. It also covers editing the inventory
+and loading, unloading or re-keying a database: those change which databases
+are in the working set rather than the data itself, and which key divides a
+multi-output block is a choice of analysis, not of installation -- it is the
+question "what would this study look like allocated by mass", asked of a
+source nobody may edit. It also covers editing the inventory
 of an activity: adjusting an imported dataset to the study at hand is analysis
 work, done on a database of one's own, and the engine refuses it on the
 background data it reads from its configuration.
@@ -58,6 +61,7 @@ data Resource
     = ListDatabases
     | LoadDatabase
     | UnloadDatabase
+    | DeriveDatabase
     | ListPresets
     | SearchActivities
     | SearchFlows
@@ -138,6 +142,7 @@ resourceMutates :: Resource -> Bool
 resourceMutates r = case r of
     LoadDatabase -> True
     UnloadDatabase -> True
+    DeriveDatabase -> True
     ListDatabases -> False
     ListPresets -> False
     SearchActivities -> False
@@ -195,6 +200,7 @@ apiPath r = case r of
     ListDatabases -> Just (GET, ["db"])
     LoadDatabase -> Just (POST, ["db", "{dbName}", "load"])
     UnloadDatabase -> Just (POST, ["db", "{dbName}", "unload"])
+    DeriveDatabase -> Just (POST, ["db", "{dbName}", "derive", "{newName}"])
     ListPresets -> Just (GET, ["classification-presets"])
     SearchActivities -> Just (GET, ["db", "{dbName}", "activities"])
     SearchFlows -> Just (GET, ["db", "{dbName}", "flows"])
@@ -244,6 +250,7 @@ mcpName r = case r of
     ListDatabases -> "list_databases"
     LoadDatabase -> "load_database"
     UnloadDatabase -> "unload_database"
+    DeriveDatabase -> "derive_database"
     ListPresets -> "list_presets"
     SearchActivities -> "search_activities"
     SearchFlows -> "search_flows"
@@ -310,6 +317,16 @@ description r = case r of
         "LCA / ACV: unload a database from memory to free RAM. The on-disk data is \
         \kept and the database can be reloaded later with load_database. Refuses if \
         \another loaded database still depends on it: unload the dependents first."
+    DeriveDatabase ->
+        "LCA / ACV: read a database's source files again under another allocation \
+        \key, and register the result under a new name. Use it to ask what a study \
+        \would look like with the multi-output blocks divided by a physical property \
+        \instead of the shares the source declares: 'wet mass' divides a block by the \
+        \mass of each product, 'dry mass' by its dry matter, 'declared' keeps the \
+        \source's own shares. The source is untouched and both stay usable side by \
+        \side. This is a full load, not a copy: seconds to minutes on a large \
+        \database. Refused when the key divides no block, when the products carry no \
+        \such property, and on a read-only instance."
     ListPresets ->
         "LCA / ACV: list named classification filter presets configured in this \
         \instance. Each preset bundles multiple (system, value, mode) classification \
@@ -756,6 +773,11 @@ params r = case r of
     ListDatabases -> []
     LoadDatabase -> [pDatabase]
     UnloadDatabase -> [pDatabase]
+    DeriveDatabase ->
+        [ pDatabase
+        , Param "new_name" "string" Required "Name to register the re-keyed database under. Must not already exist."
+        , Param "allocation" "string" Optional "The key its multi-output blocks are divided by: declared (the source's own shares, the default) | dry mass | wet mass."
+        ]
     ListPresets -> []
     SearchActivities ->
         [ pDatabase

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -143,6 +143,9 @@ type LCAAPI =
                 -- Characterization-coverage report: flows a method collection scores only through a name bridge
                 :<|> "db" :> Capture "dbName" Text :> "characterization-coverage" :> QueryParam "collection" Text :> QueryParam "limit" Int :> Get '[JSON] CoverageReportAPI
                 :<|> "db" :> Capture "dbName" Text :> "copy" :> Capture "newName" Text :> Post '[JSON] ActivateResponse
+                -- Read a source again under another allocation key. A load, not a
+                -- copy: the key decides the inventory, so it answers as a load does
+                :<|> "db" :> Capture "dbName" Text :> "derive" :> Capture "newName" Text :> QueryParam "allocation" Text :> Post '[JSON] LoadDatabaseResponse
                 :<|> "db" :> Capture "dbName" Text :> Delete '[JSON] ActivateResponse
                 -- Delete the whole filtered set of activities (selection in JSON body)
                 :<|> "db" :> Capture "dbName" Text :> "delete" :> ReqBody '[JSON] DeleteSelectionRequest :> Post '[JSON] DeleteSelectionResponse
@@ -1313,7 +1316,10 @@ appears that a client must know about /before/ calling it. Adding a route
 does not exempt a change from the bump: an absent route answers 404, and so
 does a request naming a database the engine has not loaded, so a client
 cannot tell "this engine is too old" from "you asked for the wrong thing"
-(revision 19: the @kind@ parameter of a flow search naming several kinds,
+(revision 20: the @derive@ route, which reads a source again under another
+allocation key, and the @allocation@ and @source@ a database status carries,
+without which a column of shares cannot say whether the source stated them;
+revision 19: the @kind@ parameter of a flow search naming several kinds,
 comma-separated, so the biosphere-and-waste bucket the search counts report is
 listable in one call;
 revision 18: the @properties@ a technosphere exchange carries, the dry and
@@ -1347,7 +1353,7 @@ the whole filtered set).
 Clients compare it to decide compatibility and to gate such capabilities.
 -}
 currentWireVersion :: Int
-currentWireVersion = 19
+currentWireVersion = 20
 
 getVersion :: AppM Value
 getVersion = do
@@ -2295,6 +2301,7 @@ lcaServer env = hoistServer lcaAPI (runApp env) handlers
             :<|> computedQualityReportCsvH
             :<|> DBHandlers.coverageReportHandler
             :<|> DBHandlers.copyDatabaseHandler
+            :<|> DBHandlers.deriveDatabaseHandler
             :<|> DBHandlers.deleteDatabaseHandler
             :<|> DBHandlers.deleteActivitiesHandler
             :<|> DBHandlers.createActivitiesHandler

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -836,6 +836,14 @@ data DatabaseStatusAPI = DatabaseStatusAPI
     , dsaFormat :: Maybe Text -- Database format (EcoSpold 2, EcoSpold 1, SimaPro CSV)
     , dsaActivityCount :: Int -- Number of activities (0 if unloaded)
     , dsaDependsOn :: [Text] -- Names of databases this one depends on (for cross-DB linking)
+    , dsaAllocation :: Text
+    {- ^ The key its multi-output blocks were divided under: @declared@, @dry
+    mass@ or @wet mass@. On the wire because a reader looking at a column of
+    shares has no other way to tell whether the source stated them or a
+    property recomputed them, and a column headed @declared@ over recomputed
+    shares says something untrue.
+    -}
+    , dsaSource :: Maybe Text -- The database whose files it reads, when it owns none (a copy, or a re-keyed load)
     }
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped DatabaseStatusAPI)

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -371,6 +371,7 @@ executeDbUpload fmt manager args = do
                         , UploadedDB.umDataPath = makeRelative uploadDir (urPath uploadResult)
                         , UploadedDB.umDepends = []
                         , UploadedDB.umSource = Nothing
+                        , UploadedDB.umAllocation = Types.Declared
                         }
             UploadedDB.writeUploadMeta uploadDir meta
 
@@ -389,6 +390,7 @@ executeDbUpload fmt manager args = do
                         , dcDeletable = True
                         , dcGeographyPolicy = Types.GeoGlobal
                         , dcAllocation = Types.Declared
+                        , dcSource = Nothing
                         }
             addDatabase manager dbConfig
             reportProgress Info $ "Database uploaded: " ++ T.unpack slug
@@ -440,6 +442,7 @@ executeMcUpload fmt manager args = do
                         , UploadedDB.umDataPath = makeRelative uploadDir (urPath uploadResult)
                         , UploadedDB.umDepends = []
                         , UploadedDB.umSource = Nothing
+                        , UploadedDB.umAllocation = Types.Declared
                         }
             UploadedDB.writeUploadMeta uploadDir meta
 

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -85,7 +85,7 @@ import System.Directory (doesFileExist)
 import System.Environment (lookupEnv)
 import System.FilePath (isAbsolute, normalise, takeDirectory, takeFileName, (</>))
 import TOML (DecodeTOML (..), Decoder, TOMLError, Table, Value (..), decode, decodeFile, getArrayOf, getField, getFieldOpt, getFieldOptWith, getFieldWith)
-import Types (AllocationKey (..), AllocationProperty (..), GeographyPolicy (..))
+import Types (AllocationKey (..), GeographyPolicy (..), parseAllocationKey)
 
 -- | A single classification filter entry (system + value)
 data ClassificationEntry = ClassificationEntry
@@ -226,6 +226,12 @@ data DatabaseConfig = DatabaseConfig
     , dcDeletable :: !Bool -- May the UI delete this entry? Defaults to dcIsUploaded.
     , dcGeographyPolicy :: !GeographyPolicy -- How aggressively to widen geography when linking suppliers
     , dcAllocation :: !AllocationKey -- How a multi-output block is divided; the same source under two keys is two databases
+    , dcSource :: !(Maybe Text)
+    {- ^ The database whose files this one reads, when it does not own them: a
+    copy, or a source re-keyed under another allocation. Carried here rather
+    than left in the upload metadata because a reader of a re-keyed database
+    needs to know the shares were recomputed, and from what.
+    -}
     }
     deriving (Show, Eq, Generic)
 
@@ -526,6 +532,7 @@ instance DecodeTOML DatabaseConfig where
         dcDeletable <- fromMaybe dcIsUploaded <$> getFieldOpt "deletable"
         dcGeographyPolicy <- fromMaybe GeoGlobal <$> getFieldOptWith geographyPolicyDecoder "geography_policy"
         dcAllocation <- fromMaybe Declared <$> getFieldOptWith allocationKeyDecoder "allocation"
+        let dcSource = Nothing -- A configured database owns the files it names
         pure DatabaseConfig{..}
 
 {- | @allocation@ on a database entry: how its multi-output blocks are divided.
@@ -538,11 +545,7 @@ carries one key.
 allocationKeyDecoder :: Decoder AllocationKey
 allocationKeyDecoder = do
     raw <- tomlDecoder :: Decoder Text
-    case T.toLower raw of
-        "declared" -> pure Declared
-        "dry mass" -> pure (ByProperty DryMass)
-        "wet mass" -> pure (ByProperty WetMass)
-        other -> fail $ "allocation: expected one of declared|dry mass|wet mass, got: " <> T.unpack other
+    either (fail . T.unpack . ("allocation: " <>)) pure (parseAllocationKey raw)
 
 geographyPolicyDecoder :: Decoder GeographyPolicy
 geographyPolicyDecoder = do

--- a/src/Database/Allocation.hs
+++ b/src/Database/Allocation.hs
@@ -239,12 +239,6 @@ describeRefusal refusal = case refusal of
     NoSingleReference 0 -> "no reference exchange: one product output must be the reference"
     NoSingleReference k -> T.pack (show k) <> " reference exchanges where exactly one is needed"
 
--- | The word a message uses for a property.
-propertyName :: AllocationProperty -> Text
-propertyName prop = case prop of
-    DryMass -> "dry mass"
-    WetMass -> "wet mass"
-
 -- | Why a physical property cannot serve as the key of a block.
 data PropertyRefusal
     = -- | A product of the block states nothing of the property, and nothing stands in for it.

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -29,6 +29,7 @@ while any copy of it is loaded.
 -}
 module Database.Edit (
     copyDatabase,
+    deriveDatabase,
     resolveDeleteSelection,
     DeleteSelection (..),
     DeleteRequest (..),
@@ -45,7 +46,7 @@ module Database.Edit (
     refusalMessage,
 ) where
 
-import Control.Concurrent.STM (atomically, modifyTVar', readTVar, readTVarIO)
+import Control.Concurrent.STM (STM, atomically, modifyTVar', readTVar, readTVarIO)
 import Control.Exception (SomeException, try)
 import Control.Monad (when)
 import qualified Data.IntSet as IS
@@ -82,26 +83,34 @@ import Database.Journal (
 import qualified Database.Loader as Loader
 import Database.Manager (
     DatabaseManager (..),
+    DepLoadResult,
     LoadedDatabase (..),
     clearMethodMappingCacheForDb,
     editHome,
     getDatabase,
     getMergedSynonymDB,
     getMergedUnitConfig,
+    loadDatabase,
     publishLoaded,
     relinkDatabase,
+    removeDatabase,
     solverFor,
+    unloadDatabase,
     withReservedName,
  )
 import Database.Rebuild (processKey, renderKey, resolveProcess)
 import Database.Upload (DatabaseFormat (..), slugify)
 import qualified Database.UploadedDatabase as UploadedDB
 import Matrix (clearCachedSolver)
+import Progress (ProgressLevel (..), reportProgress)
 import qualified Search.BM25 as BM25
 import Service (bm25Retrieve)
 import Types (
+    AllocationKey,
     Database (..),
+    NativeProcessId,
     ProcessId,
+    allocationKeyText,
     findProcessIdByActivityUUID,
     getActivity,
     initializeRuntimeFields,
@@ -136,17 +145,172 @@ copyDatabase manager srcName newName = do
             getDatabase manager srcName >>= \case
                 Nothing -> pure $ Left $ "Database not loaded: " <> srcName
                 Just src ->
-                    withReservedName manager slug (nameIsFree slug) $ \() ->
+                    withReservedName manager slug (nameIsFree manager slug) $ \() ->
                         registerCopy manager slug src
+
+{- | Whether a name designates nothing yet: not loaded, not configured, and
+not being written under by somebody else.
+
+Read inside the transaction that claims it, which is what leaves no window
+between finding a name free and taking it.
+-}
+nameIsFree :: DatabaseManager -> Text -> STM (Either Text ())
+nameIsFree manager slug = do
+    loadedDbs <- readTVar (dmLoadedDbs manager)
+    availableDbs <- readTVar (dmAvailableDbs manager)
+    stagingDbs <- readTVar (dmStagingDbs manager)
+    pure $
+        if M.member slug loadedDbs || M.member slug availableDbs || S.member slug stagingDbs
+            then Left ("Database already exists: " <> slug)
+            else Right ()
+
+{- | Read a source's own files again under another allocation key, and
+register the result under @newName@.
+
+Not a copy. A copy shares the source's value as it stands, and the key is what
+produced that value: it decides the inventory of every process the load
+produces, so a re-keyed database has to be read from the files again. That is
+a full load -- tens of seconds where a copy is instantaneous -- which is why
+this hands back what a load hands back rather than what a copy does.
+
+The home it writes is a copy's home: no data of its own, 'umDataPath' pointing
+at the source's files and 'umSource' naming whose they are, plus the key,
+without which a restart would rebuild the database as @declared@ under a name
+promising otherwise. The source's journal is deliberately left behind: an edit
+is recorded against a process the source's key produced, and under another key
+that process need not exist.
+-}
+deriveDatabase ::
+    DatabaseManager ->
+    Text ->
+    Text ->
+    AllocationKey ->
+    IO (Either Text (LoadedDatabase, [DepLoadResult]))
+deriveDatabase manager srcName newName key = do
+    availableDbs <- readTVarIO (dmAvailableDbs manager)
+    case M.lookup srcName availableDbs of
+        Nothing -> pure (Left ("Database not found: " <> srcName))
+        Just srcConfig
+            | T.null slug -> pure (Left ("Invalid name (no usable characters): " <> newName))
+            | otherwise ->
+                withReservedName manager slug (nameIsFree manager slug) $ \() ->
+                    loadDerived manager slug srcConfig key
   where
-    nameIsFree slug = do
-        loadedDbs <- readTVar (dmLoadedDbs manager)
-        availableDbs <- readTVar (dmAvailableDbs manager)
-        stagingDbs <- readTVar (dmStagingDbs manager)
-        pure $
-            if M.member slug loadedDbs || M.member slug availableDbs || S.member slug stagingDbs
-                then Left ("Database already exists: " <> slug)
-                else Right ()
+    slug :: Text
+    slug = slugify newName
+
+{- | Give the derived database a home, register it, load it, and keep it only
+if the key actually divided something.
+
+A key that divided no block leaves a database identical to its source, under a
+name saying its shares were recomputed, and costing a second database in
+memory and a second matrix cache on disk. There is no way to know that without
+loading -- what a property divides depends on what each block states -- so the
+load happens and is then thrown away, home and cache with it.
+-}
+loadDerived ::
+    DatabaseManager ->
+    Text ->
+    DatabaseConfig ->
+    AllocationKey ->
+    IO (Either Text (LoadedDatabase, [DepLoadResult]))
+loadDerived manager slug srcConfig key =
+    recordDerived slug srcConfig key >>= \case
+        Left err -> pure (Left err)
+        Right derivedConfig -> do
+            atomically $ modifyTVar' (dmAvailableDbs manager) (M.insert slug derivedConfig)
+            loadDatabase manager slug >>= \case
+                Left err -> Left err <$ discardDerived manager slug
+                Right (loaded, deps) -> case dividedRefusal key (dcName srcConfig) (ldDatabase loaded) of
+                    Nothing -> pure (Right (loaded, deps))
+                    Just refusal -> Left refusal <$ discardDerived manager slug
+
+{- | Why the key divided nothing worth keeping, when it did.
+
+The coproducts a key divided share an 'activityGroupKey', so a block it
+divided is several processes under one key and a block it could not is the
+single process it came in as. Counting the first is the only measure of what a
+key did to a database, and both numbers are named: @0 of 4087@ says the source
+carries blocks and none of them could be weighed, where @0 of 0@ would say it
+carries none at all.
+-}
+dividedRefusal :: AllocationKey -> Text -> Database -> Maybe Text
+dividedRefusal key srcName db
+    | divided > 0 = Nothing
+    | otherwise =
+        Just $
+            allocationKeyText key
+                <> " divided 0 of the "
+                <> T.pack (show (M.size blocks))
+                <> " blocks of "
+                <> srcName
+                <> ": the result would be that database under another name"
+  where
+    blocks :: M.Map (UUID.UUID, Maybe NativeProcessId) [ProcessId]
+    blocks = dbActivityProductsIndex db
+
+    divided :: Int
+    divided = length (filter ((> 1) . length) (M.elems blocks))
+
+{- | Undo a derivation that will not be kept: unload it, then take its home
+and its cache with 'removeDatabase', which refuses a loaded database.
+
+Both steps are reported rather than dropped: what is left behind if either
+fails is a registry entry or a directory nobody asked for, and the caller is
+already on its way to returning the refusal that brought us here.
+-}
+discardDerived :: DatabaseManager -> Text -> IO ()
+discardDerived manager slug = do
+    unloadDatabase manager slug >>= warnLeftover "unload"
+    removeDatabase manager slug >>= warnLeftover "delete"
+  where
+    warnLeftover :: Text -> Either Text () -> IO ()
+    warnLeftover step =
+        either
+            (\err -> reportProgress Warning . T.unpack $ "could not " <> step <> " " <> slug <> ": " <> err)
+            pure
+
+{- | Write the derived database's home and return the config it loads from.
+
+The path is the source's own, made absolute for the same reason a copy's is:
+it is read back from a home of its own, where a path relative to the working
+directory would mean somewhere else.
+-}
+recordDerived :: Text -> DatabaseConfig -> AllocationKey -> IO (Either Text DatabaseConfig)
+recordDerived slug srcConfig key = do
+    written <- try $ do
+        uploadsDir <- UploadedDB.getDatabaseUploadsDir
+        let home = uploadsDir </> T.unpack slug
+        createDirectoryIfMissing True home
+        sourcePath <- makeAbsolute (dcPath srcConfig)
+        UploadedDB.writeUploadMeta
+            home
+            UploadedDB.UploadMeta
+                { UploadedDB.umVersion = UploadedDB.metaVersion
+                , UploadedDB.umDisplayName = slug
+                , UploadedDB.umDescription = dcDescription srcConfig
+                , UploadedDB.umFormat = fromMaybe UnknownFormat (dcFormat srcConfig)
+                , UploadedDB.umDataPath = sourcePath
+                , UploadedDB.umDepends = dcDepends srcConfig
+                , UploadedDB.umSource = Just (dcName srcConfig)
+                , UploadedDB.umAllocation = key
+                }
+        pure
+            srcConfig
+                { dcName = slug
+                , dcDisplayName = slug
+                , dcPath = sourcePath
+                , dcLoad = False
+                , dcDefault = False
+                , dcIsUploaded = True
+                , dcDeletable = True
+                , dcAllocation = key
+                , dcSource = Just (dcName srcConfig)
+                }
+    pure $ case written of
+        Right config -> Right config
+        Left (err :: SomeException) ->
+            Left $ "could not record the derived database " <> slug <> ": " <> T.pack (show err)
 
 {- | Build the copy's solver/index and insert it under @slug@. Caller holds the
 'dmStagingDbs' reservation for @slug@.
@@ -218,6 +382,9 @@ recordCopy slug src = do
                 , UploadedDB.umDataPath = sourcePath
                 , UploadedDB.umDepends = dbDependsOn (ldDatabase src)
                 , UploadedDB.umSource = Just (dcName config)
+                , -- A copy holds the source's value as it stands, which the
+                  -- source's own key produced.
+                  UploadedDB.umAllocation = dcAllocation config
                 }
     pure $ case written of
         Right () -> Right ()

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -178,7 +178,11 @@ at the source's files and 'umSource' naming whose they are, plus the key,
 without which a restart would rebuild the database as @declared@ under a name
 promising otherwise. The source's journal is deliberately left behind: an edit
 is recorded against a process the source's key produced, and under another key
-that process need not exist.
+that process need not exist. The load says so when there is one.
+
+Asking for the key the source already reads under is refused before the load:
+that result is the source, and it is the one duplicate no load can detect,
+since a key dividing the same blocks a second time divides them just as well.
 -}
 deriveDatabase ::
     DatabaseManager ->
@@ -192,6 +196,12 @@ deriveDatabase manager srcName newName key = do
         Nothing -> pure (Left ("Database not found: " <> srcName))
         Just srcConfig
             | T.null slug -> pure (Left ("Invalid name (no usable characters): " <> newName))
+            | key == dcAllocation srcConfig ->
+                pure . Left $
+                    srcName
+                        <> " is already read under "
+                        <> allocationKeyText key
+                        <> ": the result would be that database under another name"
             | otherwise ->
                 withReservedName manager slug (nameIsFree manager slug) $ \() ->
                     loadDerived manager slug srcConfig key
@@ -255,13 +265,18 @@ dividedRefusal key srcName db
 {- | Undo a derivation that will not be kept: unload it, then take its home
 and its cache with 'removeDatabase', which refuses a loaded database.
 
-Both steps are reported rather than dropped: what is left behind if either
-fails is a registry entry or a directory nobody asked for, and the caller is
-already on its way to returning the refusal that brought us here.
+The unload is skipped when the load is what failed, since nothing was
+registered to unload and the refusal it answers would be a second warning
+saying so beside the real one.
+
+What is left behind if a step fails is a registry entry or a directory nobody
+asked for, so both are reported: the caller is already on its way to returning
+the refusal that brought us here.
 -}
 discardDerived :: DatabaseManager -> Text -> IO ()
 discardDerived manager slug = do
-    unloadDatabase manager slug >>= warnLeftover "unload"
+    loaded <- M.member slug <$> readTVarIO (dmLoadedDbs manager)
+    when loaded $ unloadDatabase manager slug >>= warnLeftover "unload"
     removeDatabase manager slug >>= warnLeftover "delete"
   where
     warnLeftover :: Text -> Either Text () -> IO ()
@@ -283,6 +298,13 @@ recordDerived slug srcConfig key = do
         let home = uploadsDir </> T.unpack slug
         createDirectoryIfMissing True home
         sourcePath <- makeAbsolute (dcPath srcConfig)
+        hasJournal <- doesFileExist (journalPath (uploadsDir </> T.unpack (dcName srcConfig)))
+        when hasJournal . reportProgress Warning . T.unpack $
+            "the edits recorded on "
+                <> dcName srcConfig
+                <> " stay behind: each names a process its key produced, and "
+                <> slug
+                <> " reads the same files under another one"
         UploadedDB.writeUploadMeta
             home
             UploadedDB.UploadMeta
@@ -394,6 +416,9 @@ recordCopy slug src = do
 {- | Rename a config for the copy: new internal name, derived display name, and
 forced deletable/uploaded so the copy can be removed again via the normal
 delete path (the source may be a TOML-pinned, non-deletable database).
+
+The source it names is the one 'recordCopy' writes to the copy's home, so a
+listing says the same thing before and after the restart that reads it back.
 -}
 renameConfig :: Text -> DatabaseConfig -> DatabaseConfig
 renameConfig newName cfg =
@@ -402,6 +427,7 @@ renameConfig newName cfg =
         , dcDisplayName = newName
         , dcIsUploaded = True
         , dcDeletable = True
+        , dcSource = Just (dcName cfg)
         }
 
 -- ---------------------------------------------------------------------------

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -827,6 +827,23 @@ defaultLoadOptions unitConfig =
 -- | Everything one EcoSpold dataset parses to, before it is keyed.
 type ParsedDataset = (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit], Int, M.Map UUID.UUID Int)
 
+{- | Say that an EcoSpold 2 dataset divided into several processes will come
+back as one.
+
+'buildProcEntry' reads a process's identity off the file name, which carries
+one @activityUUID_productUUID@ pair whatever the file holds, so the coproducts
+a key just separated all claim it and the registry keeps the last. Loud rather
+than silent: the alternative is a database quietly missing the very products
+the key was named to produce. Keying an EcoSpold 2 process on its own product
+rather than on its file name is what would fix it.
+-}
+warnSplitKeyedOnFileName :: FilePath -> IO ()
+warnSplitKeyedOnFileName file =
+    reportProgress Warning $
+        "only one product will be kept of "
+            <> file
+            <> ": an EcoSpold 2 process is identified by its file name, which names a single product"
+
 {- | Allocate a parsed dataset before it is keyed: one entry per process
 'allocate' splits it into, each carrying the file's flows and units, so the
 entry is then keyed on its own reference product.
@@ -1101,7 +1118,10 @@ loadEcoSpoldDirectory opts dir = do
         let (errs, oks) = partitionEithers paired
         forM_ errs $ \e ->
             reportProgress Warning e
-        let (okFiles, okResults) = unzip [(f, r') | (f, r) <- oks, r' <- allocateParsed opts r]
+        let split = [(f, allocateParsed opts r) | (f, r) <- oks]
+            (okFiles, okResults) = unzip [(f, r') | (f, rs) <- split, r' <- rs]
+        unless isEcoSpold1 $
+            mapM_ (warnSplitKeyedOnFileName . fst) (filter ((> 1) . length . snd) split)
         let procs = [a | (a, _, _, _, _, _, _) <- okResults]
             techLists = [ts | (_, ts, _, _, _, _, _) <- okResults]
             bioLists = [bs | (_, _, bs, _, _, _, _) <- okResults]

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -505,8 +505,10 @@ instance FromJSON DatabaseStatus where
             <*> v .:? "dsDependsOn" A..!= []
             -- A status written before the key was on the wire describes a
             -- database divided the way its source declares, which is what it
-            -- was; an unreadable word means the same rather than a guess.
-            <*> (either (const Declared) id . parseAllocationKey <$> v .:? "dsAllocation" A..!= "declared")
+            -- was. A word this client cannot read is not that: showing
+            -- "declared" beside shares some other key produced is the silent
+            -- misreading the field was put on the wire to end.
+            <*> (v .:? "dsAllocation" A..!= "declared" >>= either (fail . T.unpack) pure . parseAllocationKey)
             <*> v .:? "dsSource"
 
 -- | Status of a method collection (e.g., EF-3.1) for API responses

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -244,6 +244,7 @@ import Types (
     UUID,
     Unit (..),
     UnitDB,
+    allocationKeyText,
     bfCompartmentName,
     bfCompartmentSub,
     blockerReasonDetail,
@@ -256,6 +257,7 @@ import Types (
     enrichBioFlowCAS,
     flowClosure,
     initializeRuntimeFields,
+    parseAllocationKey,
     toSimpleDatabase,
     unresolvedCount,
  )
@@ -466,6 +468,8 @@ data DatabaseStatus = DatabaseStatus
     , dsFormat :: !(Maybe Upload.DatabaseFormat) -- Detected format
     , dsActivityCount :: !Int -- Number of activities (0 if unloaded)
     , dsDependsOn :: ![Text] -- Names of databases this one depends on (for cross-DB linking)
+    , dsAllocation :: !AllocationKey -- The key its multi-output blocks were divided under
+    , dsSource :: !(Maybe Text) -- The database whose files it reads, when it owns none
     }
     deriving (Show, Eq, Generic)
 
@@ -482,6 +486,8 @@ instance ToJSON DatabaseStatus where
             , "dsFormat" .= dsFormat
             , "dsActivityCount" .= dsActivityCount
             , "dsDependsOn" .= dsDependsOn
+            , "dsAllocation" .= allocationKeyText dsAllocation
+            , "dsSource" .= dsSource
             ]
 
 instance FromJSON DatabaseStatus where
@@ -497,6 +503,11 @@ instance FromJSON DatabaseStatus where
             <*> v .:? "dsFormat"
             <*> v .: "dsActivityCount"
             <*> v .:? "dsDependsOn" A..!= []
+            -- A status written before the key was on the wire describes a
+            -- database divided the way its source declares, which is what it
+            -- was; an unreadable word means the same rather than a guess.
+            <*> (either (const Declared) id . parseAllocationKey <$> v .:? "dsAllocation" A..!= "declared")
+            <*> v .:? "dsSource"
 
 -- | Status of a method collection (e.g., EF-3.1) for API responses
 data MethodCollectionStatus = MethodCollectionStatus
@@ -1567,7 +1578,12 @@ uploadMetaToConfig slug dirPath meta =
         , dcIsUploaded = True -- Discovered from uploads/ directory
         , dcDeletable = True
         , dcGeographyPolicy = GeoGlobal -- Uploads can't yet express policy; default to permissive
-        , dcAllocation = Declared
+        , -- Read, never assumed: a database derived under a property key is
+          -- rebuilt from this config at every restart, and a hardcoded
+          -- 'Declared' here handed it back divided the way its source
+          -- declares under a name promising the opposite.
+          dcAllocation = UploadedDB.umAllocation meta
+        , dcSource = UploadedDB.umSource meta
         }
 
 {- | Record an uploaded database's dependency pin where a restart can find it.
@@ -1714,6 +1730,8 @@ listDatabases manager = do
                 , dsFormat = dcFormat config
                 , dsActivityCount = actCount
                 , dsDependsOn = dcDepends config
+                , dsAllocation = dcAllocation config
+                , dsSource = dcSource config
                 }
 
 -- | File extensions 'resolveDataPath' knows how to extract as archives.

--- a/src/Database/UploadedDatabase.hs
+++ b/src/Database/UploadedDatabase.hs
@@ -29,6 +29,7 @@ module Database.UploadedDatabase (
 
 import Control.Exception (SomeException, try)
 import Control.Monad (filterM, forM)
+import Data.Either (fromRight)
 import Data.Maybe (catMaybes)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -41,6 +42,7 @@ import Text.Read (readMaybe)
 
 -- Re-export DatabaseFormat from Database.Upload (single definition)
 import Database.Upload (DatabaseFormat (..))
+import Types (AllocationKey (..), allocationKeyText, parseAllocationKey)
 
 -- | Metadata for an uploaded database
 data UploadMeta = UploadMeta
@@ -63,16 +65,24 @@ data UploadMeta = UploadMeta
     A file written before this field existed is not a copy, which is what it
     meant.
     -}
+    , umAllocation :: !AllocationKey
+    {- ^ The key this database's multi-output blocks were divided under. The
+    only durable record of it: a re-keyed database owns no files of its own,
+    so nothing else on disk says the shares it loads are not the ones its
+    source declares. A file written before this field existed reads back as
+    'Declared', which is what it meant.
+    -}
     }
     deriving (Show, Eq, Generic)
 
 {- | The @meta.toml@ shape this engine writes, stamped by every writer.
-Version 3 added @source@, which is what tells a copy from an upload. The
-parser reads every version, taking absent fields to mean what their absence
-meant when they did not exist.
+Version 3 added @source@, which is what tells a copy from an upload; version 4
+added @allocation@, without which a re-keyed database came back declared after
+a restart. The parser reads every version, taking absent fields to mean what
+their absence meant when they did not exist.
 -}
 metaVersion :: Int
-metaVersion = 3
+metaVersion = 4
 
 -- | Name of the metadata file in each upload directory
 metaFileName :: FilePath
@@ -163,6 +173,11 @@ parseMetaToml content = do
             , umDataPath = dataPath
             , umDepends = maybe [] parseStringList (getValue "depends")
             , umSource = unquote <$> getValue "source"
+            , -- A key nobody wrote is the declared one, which is what every
+              -- file written before this field existed means. A key nobody
+              -- can read is refused for the same reason: dividing a database
+              -- on a guess would restate its inventory in silence.
+              umAllocation = fromRight Declared (parseAllocationKey (maybe "declared" unquote (getValue "allocation")))
             }
 
 {- | Undo the escaping 'formatMetaToml' writes, so a value survives the round
@@ -221,6 +236,7 @@ formatMetaToml UploadMeta{..} =
             ++ [ "format = " <> quote (formatToText umFormat)
                , "dataPath = " <> quote (T.pack umDataPath)
                , "depends = [" <> T.intercalate ", " (map quote umDepends) <> "]"
+               , "allocation = " <> quote (allocationKeyText umAllocation)
                ]
             ++ maybe [] (\s -> ["source = " <> quote s]) umSource
   where

--- a/src/Database/UploadedDatabase.hs
+++ b/src/Database/UploadedDatabase.hs
@@ -29,7 +29,6 @@ module Database.UploadedDatabase (
 
 import Control.Exception (SomeException, try)
 import Control.Monad (filterM, forM)
-import Data.Either (fromRight)
 import Data.Maybe (catMaybes)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -42,7 +41,8 @@ import Text.Read (readMaybe)
 
 -- Re-export DatabaseFormat from Database.Upload (single definition)
 import Database.Upload (DatabaseFormat (..))
-import Types (AllocationKey (..), allocationKeyText, parseAllocationKey)
+import Progress (ProgressLevel (..), reportProgress)
+import Types (AllocationKey, allocationKeyText, parseAllocationKey)
 
 -- | Metadata for an uploaded database
 data UploadMeta = UploadMeta
@@ -164,6 +164,15 @@ parseMetaToml content = do
     format <- getValue "format" >>= parseFormat . unquote
     dataPath <- T.unpack . unquote <$> getValue "dataPath"
 
+    -- A key nobody wrote is the declared one, which is what every file
+    -- written before this field existed means. A key nobody can read stops
+    -- the whole file: dividing a database on a guess would restate its
+    -- inventory in silence, where a database the scan refuses is named in
+    -- the log and still on disk for a binary that knows the key.
+    allocation <-
+        either (const Nothing) Just $
+            parseAllocationKey (maybe "declared" unquote (getValue "allocation"))
+
     return
         UploadMeta
             { umVersion = version
@@ -173,11 +182,7 @@ parseMetaToml content = do
             , umDataPath = dataPath
             , umDepends = maybe [] parseStringList (getValue "depends")
             , umSource = unquote <$> getValue "source"
-            , -- A key nobody wrote is the declared one, which is what every
-              -- file written before this field existed means. A key nobody
-              -- can read is refused for the same reason: dividing a database
-              -- on a guess would restate its inventory in silence.
-              umAllocation = fromRight Declared (parseAllocationKey (maybe "declared" unquote (getValue "allocation")))
+            , umAllocation = allocation
             }
 
 {- | Undo the escaping 'formatMetaToml' writes, so a value survives the round
@@ -269,9 +274,11 @@ scanUploadsIn dir = do
             dirsOnly <- filterM (doesDirectoryExist . snd) fullPaths
             results <- forM dirsOnly $ \(slug, dirPath) -> do
                 maybeMeta <- readUploadMeta dirPath
-                return $ case maybeMeta of
-                    Just meta -> Just (slug, dirPath, meta)
-                    Nothing -> Nothing
+                case maybeMeta of
+                    Just meta -> pure (Just (slug, dirPath, meta))
+                    Nothing ->
+                        Nothing
+                            <$ reportProgress Warning (dirPath <> ": meta.toml could not be read, the database is left out")
             return (catMaybes results)
 
 {- | Discover all uploaded databases by scanning the uploads directory

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1570,6 +1570,39 @@ data AllocationKey
     | ByProperty !AllocationProperty
     deriving (Show, Eq, Generic, NFData, Store)
 
+{- | The word a property is written as, wherever one is written: a warning, a
+TOML file, a @meta.toml@, a query parameter.
+-}
+propertyName :: AllocationProperty -> Text
+propertyName prop = case prop of
+    DryMass -> "dry mass"
+    WetMass -> "wet mass"
+
+-- | The word a key is written as. Inverse of 'parseAllocationKey'.
+allocationKeyText :: AllocationKey -> Text
+allocationKeyText key = case key of
+    Declared -> "declared"
+    ByProperty prop -> propertyName prop
+
+{- | The key a word names, case-blind, with the words it could have been when
+it names none.
+
+One vocabulary for the config file, the upload metadata and the request that
+asks for a key, so a word that works in one works in all three. An unknown
+word is refused rather than read as 'Declared': a database loaded under a key
+nobody asked for, carrying the name of the key they did ask for, is the silent
+misbehaviour this returns 'Left' to avoid.
+-}
+parseAllocationKey :: Text -> Either Text AllocationKey
+parseAllocationKey raw =
+    maybe (Left refusal) Right (lookup (T.toLower (T.strip raw)) table)
+  where
+    table :: [(Text, AllocationKey)]
+    table = [(allocationKeyText k, k) | k <- [Declared, ByProperty DryMass, ByProperty WetMass]]
+
+    refusal :: Text
+    refusal = "expected one of " <> T.intercalate " | " (map fst table) <> ", got: " <> raw
+
 {- | Per-database knob controlling how aggressively geography may be widened when
 linking an exchange to a supplier. Maps to TOML field @geography_policy@.
 

--- a/test/ActivityWriteHandlerSpec.hs
+++ b/test/ActivityWriteHandlerSpec.hs
@@ -403,6 +403,7 @@ uploadedConfig name dataDir =
         , dcDeletable = True
         , dcGeographyPolicy = GeoGlobal
         , dcAllocation = Declared
+        , dcSource = Nothing
         }
 
 -- ---------------------------------------------------------------------------

--- a/test/CopySpec.hs
+++ b/test/CopySpec.hs
@@ -218,6 +218,7 @@ mkConfig name =
         , dcDeletable = False
         , dcGeographyPolicy = GeoGlobal
         , dcAllocation = Declared
+        , dcSource = Nothing
         }
 
 buildOrFail :: SimpleParts -> IO Database

--- a/test/DatabaseStatusSpec.hs
+++ b/test/DatabaseStatusSpec.hs
@@ -11,6 +11,7 @@ import Test.Hspec
 import API.DatabaseHandlers (convertDbStatus)
 import API.Types (DatabaseStatusAPI (..))
 import Database.Manager (DatabaseLoadStatus (..), DatabaseStatus (..))
+import Types (AllocationKey (..), AllocationProperty (..))
 
 mkStatus :: [A.Value -> A.Value] -> DatabaseStatus
 mkStatus _ =
@@ -25,6 +26,8 @@ mkStatus _ =
         , dsFormat = Nothing
         , dsActivityCount = 42
         , dsDependsOn = ["ecoinvent-3-9-1-adapted", "wfldb"]
+        , dsAllocation = ByProperty WetMass
+        , dsSource = Just "agribalyse-3-2-declared"
         }
 
 spec :: Spec
@@ -49,7 +52,12 @@ spec = do
                         ]
             let decoded = A.fromJSON legacy :: A.Result DatabaseStatus
             case decoded of
-                A.Success ds -> dsDependsOn ds `shouldBe` []
+                A.Success ds -> do
+                    dsDependsOn ds `shouldBe` []
+                    -- Written before a database could be re-keyed, so it was
+                    -- divided the way its source declares.
+                    dsAllocation ds `shouldBe` Declared
+                    dsSource ds `shouldBe` Nothing
                 A.Error e -> expectationFailure e
 
     describe "convertDbStatus" $ do
@@ -70,3 +78,8 @@ spec = do
             let api = convertDbStatus (mkStatus [])
                 roundTripped = fromJust (decode (encode api)) :: DatabaseStatusAPI
             dsaDependsOn roundTripped `shouldBe` dsaDependsOn api
+
+        it "says which key divided it, and whose files it reads" $ do
+            let api = convertDbStatus (mkStatus [])
+            dsaAllocation api `shouldBe` "wet mass"
+            dsaSource api `shouldBe` Just "agribalyse-3-2-declared"

--- a/test/DeleteSelectionSpec.hs
+++ b/test/DeleteSelectionSpec.hs
@@ -412,6 +412,7 @@ mkConfig name =
         , dcDeletable = True
         , dcGeographyPolicy = GeoGlobal
         , dcAllocation = Declared
+        , dcSource = Nothing
         }
 
 buildOrFail :: SimpleParts -> IO Database

--- a/test/DependencyChoiceSpec.hs
+++ b/test/DependencyChoiceSpec.hs
@@ -32,6 +32,7 @@ cfg name display =
         , dcDeletable = False
         , dcGeographyPolicy = GeoGlobal
         , dcAllocation = Declared
+        , dcSource = Nothing
         }
 
 -- IndexedDatabase whose idbByProductName has 'n' distinct dummy keys, so

--- a/test/DependencyFlowClosureSpec.hs
+++ b/test/DependencyFlowClosureSpec.hs
@@ -119,6 +119,7 @@ dbConfigFor name =
         , dcDeletable = False
         , dcGeographyPolicy = GeoGlobal
         , dcAllocation = Declared
+        , dcSource = Nothing
         }
 
 -- | Install a database in the manager's loaded set, solver and config included.

--- a/test/DeriveSpec.hs
+++ b/test/DeriveSpec.hs
@@ -11,6 +11,8 @@ the source's files again. What that has to get right is checked here:
 * a key that divides nothing is refused and leaves nothing behind: such a
   load is its source under a second name, at the price of a second database
   in memory and a second cache on disk;
+* so is the key the source already reads under, which is the duplicate no
+  count of divided blocks can see;
 * the key survives a restart, which is the one thing a derived database
   cannot work out for itself -- it owns no files, so nothing else on disk
   says its shares are not the ones its source declares.
@@ -72,6 +74,19 @@ spec = around_ withScratchDataDir $ describe "Database.Edit.deriveDatabase" $ do
                     loaded <- readTVarIO (dmLoadedDbs manager)
                     M.member "steel-wet" available `shouldBe` False
                     M.member "steel-wet" loaded `shouldBe` False
+
+    it "refuses the key its source already reads under" $
+        withSource coproductCSV $ \manager -> do
+            -- The block divides under 'Declared' as well as it does under a
+            -- property, so the count of divided blocks says nothing here: the
+            -- duplicate is the key, and it is known before any load.
+            derived <- deriveDatabase manager source "dairy-again" Declared
+            case derived of
+                Right _ -> expectationFailure "expected a refusal, the derivation was kept"
+                Left err -> do
+                    err `shouldSatisfy` isInfixOf "is already read under declared"
+                    available <- readTVarIO (dmAvailableDbs manager)
+                    M.member "dairy-again" available `shouldBe` False
 
     it "is still under its key after a restart" $
         withSource coproductCSV $ \manager -> do

--- a/test/DeriveSpec.hs
+++ b/test/DeriveSpec.hs
@@ -1,0 +1,191 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Tests for re-keying a database ('Database.Edit.deriveDatabase').
+
+Deriving is not copying: a copy shares the value the source's own key
+produced, and the key is what produced it, so a derived database is read from
+the source's files again. What that has to get right is checked here:
+
+* a block is divided by the property instead of by the shares its source
+  declares, and the inventory of every product follows;
+* a key that divides nothing is refused and leaves nothing behind: such a
+  load is its source under a second name, at the price of a second database
+  in memory and a second cache on disk;
+* the key survives a restart, which is the one thing a derived database
+  cannot work out for itself -- it owns no files, so nothing else on disk
+  says its shares are not the ones its source declares.
+-}
+module DeriveSpec (spec) where
+
+import Control.Concurrent.STM (atomically, modifyTVar', readTVarIO)
+import qualified Data.ByteString.Char8 as BS
+import Data.List (sortOn)
+import qualified Data.Map.Strict as M
+import Data.Text (Text, isInfixOf)
+import qualified Data.Vector as V
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+
+import Config (DatabaseConfig (..), defaultConfig)
+import Database.Edit (deriveDatabase)
+import Database.Manager (
+    CachePolicy (..),
+    DatabaseManager (..),
+    LoadedDatabase (..),
+    initDatabaseManager,
+ )
+import Database.Upload (DatabaseFormat (..))
+import TestHelpers (withScratchDataDir, withinTolerance)
+import Types (
+    Activity (..),
+    AllocationKey (..),
+    AllocationProperty (..),
+    Database (..),
+    Exchange,
+    GeographyPolicy (..),
+    exchangeAmount,
+    exchangeIsProductOutput,
+ )
+
+spec :: Spec
+spec = around_ withScratchDataDir $ describe "Database.Edit.deriveDatabase" $ do
+    it "divides a block by the property instead of by the declared shares" $
+        withSource coproductCSV $ \manager -> do
+            derived <- deriveDatabase manager source "cheese-wet" (ByProperty WetMass)
+            db <- either (fail . show) (pure . ldDatabase . fst) derived
+            V.length (dbActivities db) `shouldBe` 2
+            M.size (dbActivityProductsIndex db) `shouldBe` 1
+            -- The source declares 51 / 49 and would put 5.1 kg of milk behind
+            -- the cheese. 1 kg of cheese beside 3 kg of whey is 25 / 75, and
+            -- the whole inventory follows the key that divided the block.
+            milkAmounts db `shouldSatisfy` near [2.5, 7.5]
+
+    it "refuses a key that divides nothing, and registers nothing" $
+        withSource singleProductCSV $ \manager -> do
+            derived <- deriveDatabase manager source "steel-wet" (ByProperty WetMass)
+            case derived of
+                Right _ -> expectationFailure "expected a refusal, the derivation was kept"
+                Left err -> do
+                    err `shouldSatisfy` isInfixOf "divided 0 of the 1 blocks"
+                    available <- readTVarIO (dmAvailableDbs manager)
+                    loaded <- readTVarIO (dmLoadedDbs manager)
+                    M.member "steel-wet" available `shouldBe` False
+                    M.member "steel-wet" loaded `shouldBe` False
+
+    it "is still under its key after a restart" $
+        withSource coproductCSV $ \manager -> do
+            _ <- either (fail . show) pure =<< deriveDatabase manager source "cheese-wet" (ByProperty WetMass)
+            -- A boot rebuilds every uploaded database's configuration from its
+            -- meta.toml. Written without the key, the derivation came back
+            -- divided the way its source declares, under a name promising the
+            -- opposite.
+            rebooted <- initDatabaseManager defaultConfig NoCache
+            available <- readTVarIO (dmAvailableDbs rebooted)
+            fmap dcAllocation (M.lookup "cheese-wet" available) `shouldBe` Just (ByProperty WetMass)
+            fmap dcSource (M.lookup "cheese-wet" available) `shouldBe` Just (Just source)
+
+{- | The milk behind each product of the block, ordered by the product's own
+amount, which is what tells the 1 kg of cheese from the 3 kg of whey.
+-}
+milkAmounts :: Database -> [Double]
+milkAmounts db = map snd (sortOn fst [(amountOf products a, amountOf inputs a) | a <- V.toList (dbActivities db)])
+  where
+    amountOf :: (Activity -> [Exchange]) -> Activity -> Double
+    amountOf pick = sum . map exchangeAmount . pick
+
+    products, inputs :: Activity -> [Exchange]
+    products = filter exchangeIsProductOutput . exchanges
+    inputs = filter (not . exchangeIsProductOutput) . exchanges
+
+-- | Whether every amount lands on the one expected of it.
+near :: [Double] -> [Double] -> Bool
+near expected actual =
+    length expected == length actual
+        && and (zipWith (withinTolerance 1e-9) expected actual)
+
+source :: Text
+source = "dairy"
+
+{- | A manager holding one SimaPro CSV under 'source', unloaded: deriving
+reads the files, so the source need not be in memory.
+-}
+withSource :: BS.ByteString -> (DatabaseManager -> IO ()) -> IO ()
+withSource csv k = withSystemTempDirectory "derive-source" $ \dir -> do
+    let csvPath = dir </> "source.csv"
+    BS.writeFile csvPath csv
+    manager <- initDatabaseManager defaultConfig NoCache
+    atomically $ modifyTVar' (dmAvailableDbs manager) (M.insert source (sourceConfig csvPath))
+    k manager
+
+sourceConfig :: FilePath -> DatabaseConfig
+sourceConfig csvPath =
+    DatabaseConfig
+        { dcName = source
+        , dcDisplayName = "Dairy"
+        , dcPath = csvPath
+        , dcDescription = Nothing
+        , dcLoad = False
+        , dcDefault = False
+        , dcDepends = []
+        , dcLocationAliases = M.empty
+        , dcFormat = Just SimaProCSV
+        , dcIsUploaded = False
+        , dcDeletable = False
+        , dcGeographyPolicy = GeoGlobal
+        , dcAllocation = Declared
+        , dcSource = Nothing
+        }
+
+{- | One block of two products, declared 51 / 49, whose masses say 25 / 75:
+the disagreement a property key exists to settle.
+-}
+coproductCSV :: BS.ByteString
+coproductCSV =
+    simaProFile
+        [ "Products"
+        , "Cheese;kg;1;51;not defined;material;"
+        , "Whey;kg;3;49;not defined;material;"
+        , ""
+        , "Materials/fuels"
+        , "Cow milk;kg;10;Undefined;0;0;0;"
+        ]
+
+-- | One block of one product: nothing a key could divide.
+singleProductCSV :: BS.ByteString
+singleProductCSV =
+    simaProFile
+        [ "Products"
+        , "Steel;kg;1;100;not defined;material;"
+        , ""
+        , "Materials/fuels"
+        , "Iron ore;kg;2;Undefined;0;0;0;"
+        ]
+
+-- | One SimaPro process block, wrapped in the header its parser expects.
+simaProFile :: [BS.ByteString] -> BS.ByteString
+simaProFile body =
+    BS.intercalate
+        "\r\n"
+        ( [ "{SimaPro 9.6.0.1}"
+          , "{CSV separator: semicolon}"
+          , "{Decimal separator: .}"
+          , ""
+          , "Process"
+          , ""
+          , "Category type"
+          , "material"
+          , ""
+          , "Process name"
+          , "Dairy"
+          , ""
+          , "Type"
+          , "Unit process"
+          , ""
+          , "Geography"
+          , "GLO"
+          , ""
+          ]
+            ++ body
+            ++ ["", "End"]
+        )

--- a/test/MCPDispatchSpec.hs
+++ b/test/MCPDispatchSpec.hs
@@ -118,6 +118,7 @@ sampleConfig =
         , dcDeletable = False
         , dcGeographyPolicy = GeoGlobal
         , dcAllocation = Declared
+        , dcSource = Nothing
         }
 
 -- | Call a tool against that fixture, freshly loaded.

--- a/test/PersistenceSpec.hs
+++ b/test/PersistenceSpec.hs
@@ -335,6 +335,7 @@ baseConfig name =
         , dcDeletable = True
         , dcGeographyPolicy = GeoGlobal
         , dcAllocation = Declared
+        , dcSource = Nothing
         }
 
 uploadedConfig :: Text -> FilePath -> DatabaseConfig

--- a/test/ReadOnlySpec.hs
+++ b/test/ReadOnlySpec.hs
@@ -195,7 +195,7 @@ spec = do
 
     describe "Resource registry" $
         it "counts exactly the operations that change shared state as mutations" $
-            filter resourceMutates allResources `shouldBe` [LoadDatabase, UnloadDatabase, EditExchanges]
+            filter resourceMutates allResources `shouldBe` [LoadDatabase, UnloadDatabase, DeriveDatabase, EditExchanges]
 
     describe "REST handlers under read_only" $ do
         it "refuse every mutating endpoint with 403" $

--- a/test/ResourcesDriftSpec.hs
+++ b/test/ResourcesDriftSpec.hs
@@ -82,6 +82,8 @@ knownDivergences =
     , ("compute_sensitivity", "process_id")
     , ("count_search_matches", "database")
     , ("count_search_matches", "query")
+    , ("derive_database", "database")
+    , ("derive_database", "new_name")
     , ("edit_exchanges", "add_biosphere")
     , ("edit_exchanges", "add_inputs")
     , ("edit_exchanges", "add_waste_outputs")

--- a/test/SetupInfoSpec.hs
+++ b/test/SetupInfoSpec.hs
@@ -124,6 +124,7 @@ stubConfig =
         , dcDeletable = False
         , dcGeographyPolicy = GeoGlobal
         , dcAllocation = Declared
+        , dcSource = Nothing
         }
 
 buildDb :: [((UUID.UUID, UUID.UUID), Activity)] -> [(UUID.UUID, Text)] -> IO Database

--- a/test/StrictPinSpec.hs
+++ b/test/StrictPinSpec.hs
@@ -199,6 +199,7 @@ consumerConfig path =
         , dcDeletable = False
         , dcGeographyPolicy = GeoGlobal
         , dcAllocation = Declared
+        , dcSource = Nothing
         }
 
 -- ---------------------------------------------------------------------------

--- a/test/UploadQuotaSpec.hs
+++ b/test/UploadQuotaSpec.hs
@@ -57,6 +57,7 @@ uploadedEntry name =
         , dcDeletable = True
         , dcGeographyPolicy = GeoGlobal
         , dcAllocation = Declared
+        , dcSource = Nothing
         }
 
 spec :: Spec

--- a/test/UploadedDatabaseSpec.hs
+++ b/test/UploadedDatabaseSpec.hs
@@ -7,7 +7,7 @@ import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
 import Database.UploadedDatabase
-import Types (AllocationKey (..), AllocationProperty (..))
+import Types (AllocationKey (..))
 
 -- | Minimal UploadMeta without description
 baseMeta :: UploadMeta

--- a/test/UploadedDatabaseSpec.hs
+++ b/test/UploadedDatabaseSpec.hs
@@ -7,6 +7,7 @@ import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
 import Database.UploadedDatabase
+import Types (AllocationKey (..), AllocationProperty (..))
 
 -- | Minimal UploadMeta without description
 baseMeta :: UploadMeta
@@ -19,6 +20,7 @@ baseMeta =
         , umDataPath = "data"
         , umDepends = []
         , umSource = Nothing
+        , umAllocation = Declared
         }
 
 spec :: Spec
@@ -94,6 +96,7 @@ spec = do
                         , umDataPath = "data"
                         , umDepends = []
                         , umSource = Nothing
+                        , umAllocation = Declared
                         }
 
         it "parses meta with description" $ do

--- a/volca.cabal
+++ b/volca.cabal
@@ -339,6 +339,7 @@ test-suite lca-tests
                      , NumericEdgesSpec
                      , AggregateSpec
                      , CopySpec
+                     , DeriveSpec
                      , AuthorSpec
                      , JournalSpec
                      , ActivityWriteHandlerSpec


### PR DESCRIPTION
## Why

An engine can divide a multi-output block on the mass of its products instead of on the shares its source declares, and until now the only way to say so was the configuration file. Someone using a hosted engine could not say it at all; someone running their own had to declare the same source twice and restart, and lost the original if they edited the entry in place. The feature was in the engine and out of reach.

## What this adds

`POST /api/v1/db/{name}/derive/{newName}?allocation=wet mass` registers a second database that reads the same files under that key. The source is untouched and both stay loadable, so the two allocations of one study sit side by side. The same operation is a `derive_database` MCP tool and `Client.derive_database` in pyvolca, because choosing how a block is divided is a question about the study rather than about the installation.

It is a load, not a copy. A copy shares the value the source's own key produced, and the key is what produced it, so the sources are read again: 38 seconds on Agribalyse 3.2 against the milliseconds a copy takes. The route therefore answers with a `LoadDatabaseResponse`, which is what the page asking for it already waits on.

## The two refusals

A key that divides no block of the source is refused, naming both numbers. Such a load is that database under a second name, at the price of a second database in memory and a second matrix cache on disk. The count is read off the block index: a block a key divided is several processes under one `activityGroupKey`, and a block it could not is the single process it came in as.

An unreadable key is a 400 listing the keys there are, never a fallback to `declared`. The word is now parsed in one place (`parseAllocationKey`) that the TOML file, the upload metadata and the query parameter all share.

## The restart

`meta.toml` gains the key and moves to version 4, and `uploadMetaToConfig` reads it. Without that a derived database was rebuilt as `declared` at the first restart, in silence, under a name promising the opposite. A file written before the field reads back as `declared`, which is what it meant.

The source a database reads and the key it was divided under also travel with its status now (wire revision 20), because a column of shares that cannot say whether the source stated them or a property recomputed them is a column headed with something untrue.

## Checks

Against a live engine on Agribalyse 3.2, derived under `wet mass`: the Abondance block gives 11.69 / 9.07 / 65.28 / 0.80 / 13.16 % where its source declares 51.4 / 4.4 / 24.3 / 2.3 / 17.6, which is the oracle the mass column already showed. After a restart it comes back under `wet mass` and gives the same figures. A bad key answers 400 with the list; an existing name is refused.

`DeriveSpec` covers the three in a temp directory: a block divided by the property rather than by the declared shares with the inventory following, a key that divides nothing refused and leaving nothing registered, and the key still in place after a second `initDatabaseManager` reads the uploads back.

## Also here

An EcoSpold 2 dataset whose block a key divides into several processes now says only one of them will be kept. A process is identified by its file name there, which names a single product, so the coproducts a key had just separated all claimed the same identity and the registry kept the last: a database quietly missing exactly what the key was named to produce. Keying such a process on its own product instead is an identity change with cache and cross-database consequences, so this only stops the silence.

## After review

A fresh reviewer found four things worth fixing, all shipped here.

The refusal only knew how to see one duplicate. A key that divides no block is caught by counting, but asking for the key the source already reads under produces that source byte for byte and divides exactly as many blocks, so nothing in the count says a word. It is refused before the load now, which is also the only refusal that costs nothing.

Both readers of the key said they refused what they could not read and both fell back to `declared`, which is the silent restatement this change exists to end. An unreadable key in a `meta.toml` now leaves the database out of the listing and names it in the log, and the client's status decoder fails rather than showing `declared` beside shares another key produced.

Two silences on the way out: a source carrying edits now says its journal stays behind, and undoing a derivation no longer logs "could not unload" for a load that never registered anything. A copy also names its source in memory, where it said null before the restart and the source's name after.

`derive_database` in pyvolca gates on wire 20 like every other wire-tied capability, and its allocation key is required: it defaulted to `wet mass` where the route defaults to `declared`, so one omission meant two things.
