### PR TITLE
Read Service.hs through its types, and land the behaviour-free half

### DIFF
--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -911,20 +911,22 @@ callGetSupplyChain dbManager presets rid args = runTool rid $ do
                         }
                 , Service.scfMaxDepth = intArg "max_depth" args
                 , Service.scfMinQuantity = doubleArg "min_quantity" args
+                , -- No MCP tool asks for the subgraph's edges; the REST route does.
+                  Service.scfEdges = Service.EntriesOnly
                 }
     subs <- except (parseArrayArg "substitutions" Nothing args :: Either Text [Substitution])
     unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
     payload <-
         if null subs
             then -- Plain cross-DB supply chain.
-                toJSON <$> (liftIO (Service.getSupplyChain unitCfg depLookup db dbName solver pid scf False) >>= liftShow)
+                toJSON <$> (liftIO (Service.getSupplyChain unitCfg depLookup db dbName solver pid scf) >>= liftShow)
             else do
                 -- Substitution-aware: re-solve the root scaling, then build from it.
                 (processId, _) <- liftService (Service.resolveScorable db pid)
                 (scalingVec, virtualLinks) <-
                     liftIO (Service.computeScalingVectorWithSubstitutionsCrossDB unitCfg depLookup db dbName solver processId subs) >>= liftShow
                 resp <-
-                    liftIO (Service.buildSupplyChainFromScalingVectorCrossDB unitCfg depLookup db dbName processId scalingVec virtualLinks scf False) >>= liftShow
+                    liftIO (Service.buildSupplyChainFromScalingVectorCrossDB unitCfg depLookup db dbName processId scalingVec virtualLinks scf) >>= liftShow
                 pure (toJSON resp)
     pure $ toolSuccessJson rid payload
 

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -1032,7 +1032,7 @@ callGetConsumers presets rid args (db, _) = runTool rid $ do
                         , Service.afcOrder = Nothing
                         }
                 , Service.cnfMaxDepth = intArg "max_depth" args
-                , Service.cnfIncludeEdges = fromMaybe False (boolArg "include_edges" args)
+                , Service.cnfEdges = if fromMaybe False (boolArg "include_edges" args) then Service.WithEdges else Service.EntriesOnly
                 }
     results <- liftShow (Service.getConsumers db dbName pid cnf)
     pure (toolSuccessJson rid (toJSON results))

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -1008,7 +1008,7 @@ callGetPathTo :: Value -> KeyMap Value -> (Database, SharedSolver) -> IO Value
 callGetPathTo rid args (db, solver) = runTool rid $ do
     pid <- except (requireText "process_id" args)
     target <- except (requireText "target" args)
-    val <- liftIO (Service.getPathTo db solver pid target) >>= liftShow
+    val <- liftIO (Service.getPathTo db solver pid (Service.NamePattern target)) >>= liftShow
     pure (toolSuccessJson rid val)
 
 callGetConsumers :: [ClassificationPreset] -> Value -> KeyMap Value -> (Database, SharedSolver) -> IO Value

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1852,7 +1852,7 @@ getActivityPathTo dbName processIdText targetParam = do
             (throwError err400{errBody = "Missing required 'target' query parameter"})
             pure
             targetParam
-    result <- liftIO $ Service.getPathTo db solver processIdText target
+    result <- liftIO $ Service.getPathTo db solver processIdText (Service.NamePattern target)
     case result of
         Left (Service.ActivityNotFound msg) ->
             throwError err404{errBody = BSL.fromStrict $ T.encodeUtf8 msg}

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1180,8 +1180,9 @@ buildSupplyChainFilter ::
     [Text] ->
     Maybe Text ->
     Maybe Text ->
+    Service.Edges ->
     Either Text Service.SupplyChainFilter
-buildSupplyChainFilter presets nameFilter limitParam minQuantity offsetParam maxDepthParam locationFilter productFilter presetParam classSystems classValues classModes sortParam orderParam = do
+buildSupplyChainFilter presets nameFilter limitParam minQuantity offsetParam maxDepthParam locationFilter productFilter presetParam classSystems classValues classModes sortParam orderParam edges = do
     classifications <- mergeClassFilters presets presetParam classSystems classValues classModes
     pure
         Service.SupplyChainFilter
@@ -1198,6 +1199,7 @@ buildSupplyChainFilter presets nameFilter limitParam minQuantity offsetParam max
                     }
             , Service.scfMaxDepth = maxDepthParam
             , Service.scfMinQuantity = minQuantity
+            , Service.scfEdges = edges
             }
 
 buildFlowEntry :: Database -> MethodTables -> UUID -> FlowCFEntry
@@ -1545,7 +1547,7 @@ activitySupplyChainCore dbName processIdText nameFilter limitParam minQuantity o
     dbManager <- asks aeDbManager
     presets <- asks aeClassificationPresets
     (db, sharedSolver) <- requireDatabaseByName dbName
-    let includeEdges = fromMaybe False includeEdgesParam
+    let edges = if fromMaybe False includeEdgesParam then Service.WithEdges else Service.EntriesOnly
     scf <-
         either badRequest pure $
             buildSupplyChainFilter
@@ -1563,10 +1565,11 @@ activitySupplyChainCore dbName processIdText nameFilter limitParam minQuantity o
                 classModes
                 sortParam
                 orderParam
+                edges
     case mSub of
         Nothing -> do
             unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
-            result <- liftIO $ Service.getSupplyChain unitCfg (DM.mkDepSolverLookup dbManager) db dbName sharedSolver processIdText scf includeEdges
+            result <- liftIO $ Service.getSupplyChain unitCfg (DM.mkDepSolverLookup dbManager) db dbName sharedSolver processIdText scf
             either throwServiceError pure result
         Just subReq -> do
             unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
@@ -1595,7 +1598,6 @@ activitySupplyChainCore dbName processIdText nameFilter limitParam minQuantity o
                                 scalingVec
                                 virtualLinks
                                 scf
-                                includeEdges
                     either throwServiceError pure eResp
 
 getActivitySupplyChain ::

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1842,7 +1842,7 @@ getActivityConsumers dbName processIdText nameFilter locationFilter productFilte
                         , Service.afcOrder = orderParam
                         }
                 , Service.cnfMaxDepth = maxDepthParam
-                , Service.cnfIncludeEdges = fromMaybe False includeEdgesParam
+                , Service.cnfEdges = if fromMaybe False includeEdgesParam then Service.WithEdges else Service.EntriesOnly
                 }
     either throwServiceError pure (Service.getConsumers db dbName processIdText cnf)
 

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -90,7 +90,7 @@ data SupplyChainFilter = SupplyChainFilter
 data ConsumerFilter = ConsumerFilter
     { cnfCore :: !ActivityFilterCore
     , cnfMaxDepth :: !(Maybe Int)
-    , cnfIncludeEdges :: !Bool -- when True, emit every technosphere edge inside the reachable consumer subgraph
+    , cnfEdges :: !Edges -- 'WithEdges' emits every technosphere edge inside the reachable consumer subgraph
     }
 
 {- | Filter for flow search. 'ffQuery' is required; callers that have no
@@ -1713,7 +1713,7 @@ four separate parameters they admitted sixteen combinations, of which the code
 only ever built these two.
 -}
 data WalkLevel
-    = RootLevel {rlRoot :: !ProcessId, rlRefAmount :: !Double}
+    = RootLevel {rlRoot :: !ProcessId}
     | DepLevel {dlDepthOffset :: !Int}
 
 {- | What one database contributes to a supply chain: how many non-zero rows it
@@ -1755,12 +1755,13 @@ collectSupplyChainEntries db dbName level supplyVec scf =
     let core = scfCore scf
         minQ = fromMaybe 0 (scfMinQuantity scf)
 
-        -- The four facts that used to arrive as four correlated parameters.
         mRootPid = case level of
             RootLevel{rlRoot = r} -> Just r
             DepLevel{} -> Nothing
+        -- A root chain is stated per the root's reference product; a dep level
+        -- receives a scaling that is already physical.
         quantityMult = case level of
-            RootLevel{rlRefAmount = a} -> a
+            RootLevel{rlRoot = r} -> getReferenceProductAmount (dbActivities db V.! fromIntegral r)
             DepLevel{} -> 1.0
         depthOffset = case level of
             RootLevel{} -> 0
@@ -1908,7 +1909,7 @@ buildSupplyChainFromScalingVector db dbName processId supplyVec scf =
             collectSupplyChainEntries
                 db
                 dbName
-                (RootLevel processId rootRefAmount)
+                (RootLevel processId)
                 supplyVec
                 scf
         rootSummary =
@@ -1965,7 +1966,7 @@ buildSupplyChainFromScalingVectorCrossDB unitCfg depLookup rootDb rootDbName roo
             collectSupplyChainEntries
                 rootDb
                 rootDbName
-                (RootLevel rootPid rootRefAmount)
+                (RootLevel rootPid)
                 rootScaling
                 scf
         rootSummary =
@@ -2929,7 +2930,7 @@ findTechCoefficient db link =
 
 {- | Find all activities that transitively depend on a given supplier.
 BFS through the technosphere matrix tracking depth; optional max-depth cap.
-When cnfIncludeEdges is set, every technosphere coefficient whose endpoints
+When 'cnfEdges' is 'WithEdges', every technosphere coefficient whose endpoints
 are both reachable from the supplier is emitted alongside the paginated
 result list, mirroring SupplyChainResponse.scrEdges.
 -}
@@ -3017,25 +3018,24 @@ getConsumers db dbName processIdText cnf = do
 
         -- Every (supplier, consumer) technosphere coefficient whose endpoints
         -- are both reachable from the queried supplier. Populated only when
-        -- the caller opts in via cnfIncludeEdges; keeps the default payload
-        -- identical to the pre-edges wire shape.
+        -- the caller asks for edges; keeps the default payload identical to
+        -- the pre-edges wire shape.
         visitedSet = M.insert processId 0 allConsumers
-        edges =
-            if cnfIncludeEdges cnf
-                then
-                    [ SupplyChainEdge
-                        { sceEdgeFrom = processIdToText db (fromIntegral row :: ProcessId)
-                        , sceEdgeFromDb = dbName
-                        , sceEdgeTo = processIdToText db (fromIntegral col :: ProcessId)
-                        , sceEdgeToDb = dbName
-                        , sceEdgeAmount = val
-                        }
-                    | SparseTriple row col val <- U.toList (dbTechnosphereTriples db)
-                    , row /= col
-                    , M.member (fromIntegral row :: ProcessId) visitedSet
-                    , M.member (fromIntegral col :: ProcessId) visitedSet
-                    ]
-                else []
+        edges = case cnfEdges cnf of
+            EntriesOnly -> []
+            WithEdges ->
+                [ SupplyChainEdge
+                    { sceEdgeFrom = processIdToText db (fromIntegral row :: ProcessId)
+                    , sceEdgeFromDb = dbName
+                    , sceEdgeTo = processIdToText db (fromIntegral col :: ProcessId)
+                    , sceEdgeToDb = dbName
+                    , sceEdgeAmount = val
+                    }
+                | SparseTriple row col val <- U.toList (dbTechnosphereTriples db)
+                , row /= col
+                , M.member (fromIntegral row :: ProcessId) visitedSet
+                , M.member (fromIntegral col :: ProcessId) visitedSet
+                ]
 
     Right $ ConsumersResponse (SearchResults page total offset limit hasMore 0.0) edges
 

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -397,8 +397,8 @@ maxBiosphereFlows :: Int
 maxBiosphereFlows = 50
 
 -- | ExportNode for a single biosphere flow attached to a parent activity.
-mkBiosphereExportNode :: UnitDB -> BiosphereFlow -> Text -> Int -> Bool -> ExportNode
-mkBiosphereExportNode units flow parentPid depth isEmission =
+mkBiosphereExportNode :: UnitDB -> BiosphereFlow -> Text -> Int -> BioDirection -> ExportNode
+mkBiosphereExportNode units flow parentPid depth direction =
     let compartmentTxt = bfCompartmentName flow
      in ExportNode
             { enId = UUID.toText (bfId flow)
@@ -406,7 +406,9 @@ mkBiosphereExportNode units flow parentPid depth isEmission =
             , enDescription = [compartmentTxt]
             , enLocation = ""
             , enUnit = getUnitNameForBioFlow units flow
-            , enNodeType = if isEmission then BiosphereEmissionNode else BiosphereResourceNode
+            , enNodeType = case direction of
+                Emission -> BiosphereEmissionNode
+                Resource -> BiosphereResourceNode
             , enDepth = depth
             , enLoopTarget = Nothing
             , enParentId = Just parentPid
@@ -417,13 +419,12 @@ mkBiosphereExportNode units flow parentPid depth isEmission =
 {- | Edge linking an activity to a biosphere flow. Direction depends on whether
 the exchange is an emission (activity -> flow) or a resource (flow -> activity).
 -}
-mkBiosphereTreeEdge :: UnitDB -> BiosphereFlow -> Text -> Bool -> Exchange -> TreeEdge
-mkBiosphereTreeEdge units flow activityPid isEmission ex =
+mkBiosphereTreeEdge :: UnitDB -> BiosphereFlow -> Text -> BioDirection -> Exchange -> TreeEdge
+mkBiosphereTreeEdge units flow activityPid direction ex =
     let flowIdText = UUID.toText (bfId flow)
-        (edgeFrom, edgeTo, edgeType) =
-            if isEmission
-                then (activityPid, flowIdText, BiosphereEmissionEdge)
-                else (flowIdText, activityPid, BiosphereResourceEdge)
+        (edgeFrom, edgeTo, edgeType) = case direction of
+            Emission -> (activityPid, flowIdText, BiosphereEmissionEdge)
+            Resource -> (flowIdText, activityPid, BiosphereResourceEdge)
      in TreeEdge
             { teFrom = edgeFrom
             , teTo = edgeTo
@@ -438,17 +439,21 @@ extractBiosphereNodesAndEdges :: Database -> Activity -> Text -> Int -> M.Map Te
 extractBiosphereNodesAndEdges db activity activityProcessId depth nodeAcc edgeAcc =
     foldr step (nodeAcc, edgeAcc) topBiosphereExchanges
   where
+    units :: UnitDB
     units = dbUnits db
+    -- The generator both selects the biosphere rows and reads the direction off
+    -- the constructor that carries it, so no later step has to recover it.
+    topBiosphereExchanges :: [(BioDirection, Exchange)]
     topBiosphereExchanges =
         take maxBiosphereFlows $
-            L.sortBy (\a b -> compare (abs (exchangeAmount b)) (abs (exchangeAmount a))) $
-                filter isBiosphereExchange (exchanges activity)
-    step ex acc@(nodes, edges) = case M.lookup (exchangeFlowId ex) (dbBioFlows db) of
+            L.sortBy (\a b -> compare (abs (exchangeAmount (snd b))) (abs (exchangeAmount (snd a)))) $
+                [(dir, ex) | ex@BiosphereExchange{bioDirection = dir} <- exchanges activity]
+    step :: (BioDirection, Exchange) -> (M.Map Text ExportNode, [TreeEdge]) -> (M.Map Text ExportNode, [TreeEdge])
+    step (direction, ex) acc@(nodes, edges) = case M.lookup (exchangeFlowId ex) (dbBioFlows db) of
         Nothing -> acc
         Just flow ->
-            let isEmission = not (exchangeIsInput ex)
-                node = mkBiosphereExportNode units flow activityProcessId depth isEmission
-                edge = mkBiosphereTreeEdge units flow activityProcessId isEmission ex
+            let node = mkBiosphereExportNode units flow activityProcessId depth direction
+                edge = mkBiosphereTreeEdge units flow activityProcessId direction ex
              in (M.insert (UUID.toText (bfId flow)) node nodes, edge : edges)
 
 -- | ExportNode for an activity-bearing tree node (TreeLeaf or TreeNode).

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -2527,7 +2527,7 @@ data DepRef = DepRef
     { drDbName :: !Text
     , drDb :: !Database
     , drPid :: !ProcessId
-    , drUUIDs :: !(UUID, UUID)
+    , drRef :: !ProcessRef
     }
 
 {- | A planned rank-1 perturbation of one consumer column plus any virtual
@@ -2773,7 +2773,7 @@ applySubstitutionsAt unitCfg depLookup thisDb thisDbObj rootDb solver scalings a
 
     requireStatic sub cPid fromRef =
         maybe (Left $ noStaticLink sub cPid (drDbName fromRef) (drPid fromRef)) Right $
-            findStaticCrossDBLink thisDb cPid (drDbName fromRef) (drUUIDs fromRef)
+            findStaticCrossDBLink thisDb cPid (drDbName fromRef) (drRef fromRef)
 
     applyRankOne mFact xs upd = do
         -- Apply the same rank-1 update to each of the K vectors. z depends
@@ -2836,7 +2836,7 @@ applySubstitutionsAt unitCfg depLookup thisDb thisDbObj rootDb solver scalings a
                                     { drDbName = refDb
                                     , drDb = depDb
                                     , drPid = p
-                                    , drUUIDs = dbProcessIdTable depDb V.! fromIntegral p
+                                    , drRef = uncurry ProcessRef (dbProcessIdTable depDb V.! fromIntegral p)
                                     }
 
 {- | Build a synthesized 'CrossDBLink' for a what-if substitution targeting a
@@ -2855,19 +2855,19 @@ mkVirtualLink ::
     -- | raw exchange coefficient (pre-normalization)
     Double ->
     CrossDBLink
-mkVirtualLink rootDb consumerPid DepRef{drDbName = depDbName, drDb = depDb, drPid = supPid, drUUIDs = (supActU, supProdU)} coef =
-    let (cActU, cProdU) = dbProcessIdTable rootDb V.! fromIntegral consumerPid
+mkVirtualLink rootDb consumerPid DepRef{drDbName = depDbName, drDb = depDb, drPid = supPid, drRef = supRef} coef =
+    let consumerRef = uncurry ProcessRef (dbProcessIdTable rootDb V.! fromIntegral consumerPid)
         supAct = dbActivities depDb V.! fromIntegral supPid
         refUnit = maybe "" (getUnitNameForExchange (dbUnits depDb)) (L.find isReferenceOutput (exchanges supAct))
      in CrossDBLink
-            { cdlConsumerActUUID = cActU
-            , cdlConsumerProdUUID = cProdU
+            { cdlConsumerActUUID = prActivity consumerRef
+            , cdlConsumerProdUUID = prProduct consumerRef
             , -- Substitution links never enter 'dbCrossDBLinks' and the API
               -- surface only indexes load-time links by 'cdlConsumerFlowId',
               -- so the discriminator is unused for synthetic links.
               cdlConsumerFlowId = UUID.nil
-            , cdlSupplierActUUID = supActU
-            , cdlSupplierProdUUID = supProdU
+            , cdlSupplierActUUID = prActivity supRef
+            , cdlSupplierProdUUID = prProduct supRef
             , cdlCoefficient = coef
             , cdlExchangeUnit = refUnit
             , cdlFlowName = activityName supAct
@@ -2880,14 +2880,14 @@ mkVirtualLink rootDb consumerPid DepRef{drDbName = depDbName, drDb = depDb, drPi
 Returns 'Nothing' if no link exists — caller surfaces as 422 rather than
 silently no-op.
 -}
-findStaticCrossDBLink :: Database -> ProcessId -> Text -> (UUID, UUID) -> Maybe CrossDBLink
-findStaticCrossDBLink rootDb consumerPid depDbName depSupUUIDs =
-    let (cActU, cProdU) = dbProcessIdTable rootDb V.! fromIntegral consumerPid
+findStaticCrossDBLink :: Database -> ProcessId -> Text -> ProcessRef -> Maybe CrossDBLink
+findStaticCrossDBLink rootDb consumerPid depDbName depSupRef =
+    let consumerRef = uncurry ProcessRef (dbProcessIdTable rootDb V.! fromIntegral consumerPid)
         matches lk =
             cdlSourceDatabase lk == depDbName
-                && cdlConsumerActUUID lk == cActU
-                && cdlConsumerProdUUID lk == cProdU
-                && (cdlSupplierActUUID lk, cdlSupplierProdUUID lk) == depSupUUIDs
+                && cdlConsumerActUUID lk == prActivity consumerRef
+                && cdlConsumerProdUUID lk == prProduct consumerRef
+                && ProcessRef (cdlSupplierActUUID lk) (cdlSupplierProdUUID lk) == depSupRef
      in case filter matches (dbCrossDBLinks rootDb) of
             (lk : _) -> Just lk
             [] -> Nothing

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -2225,7 +2225,7 @@ resolveSpec :: Database -> Perturbation -> Either Text (Int, [(Int, Double)])
 resolveSpec db p = do
     consumerPid <- resolveRootOnly db (perConsumer p)
     supplierPid <- resolveRootOnly db (perSupplier p)
-    case findTechCoefficient db consumerPid supplierPid of
+    case findTechCoefficient db (TechLink consumerPid supplierPid) of
         Nothing ->
             Left $
                 "no technosphere link from consumer "
@@ -2554,6 +2554,25 @@ data GlobalRankOneUpdate = GlobalRankOneUpdate
     , gruExtras :: ![CrossDBLink]
     }
 
+{- | The two ends of one technosphere coefficient @A[supplier, consumer]@.
+Named because the ends are both a 'ProcessId': read the matrix at
+@A[consumer, supplier]@ and you get a well-formed answer about the wrong
+edge, which no test would notice.
+-}
+data TechLink = TechLink
+    { tlConsumer :: !ProcessId
+    , tlSupplier :: !ProcessId
+    }
+
+{- | A global substitution within one database: every consumer of @swapFrom@
+buys @swapTo@ instead. Two 'ProcessId's again, and swapping them inverts the
+unit factor κ rather than failing.
+-}
+data Swap = Swap
+    { swapFrom :: !ProcessId
+    , swapTo :: !ProcessId
+    }
+
 {- | The replaced supplier's technosphere row: every consumer that sources
 from @supplier@, paired with the (normalized) coefficient. Index space
 matches 'perturbA' / 'findTechCoefficient' (ProcessId == matrix index).
@@ -2595,8 +2614,8 @@ give @κ = 1@ (matching the per-edge path, which assumes same-unit
 suppliers). 'Left' when the two reference products are dimensionally
 incompatible — never a silently wrong coefficient.
 -}
-substitutionUnitFactor :: UnitConfig -> Database -> ProcessId -> ProcessId -> Either ServiceError Double
-substitutionUnitFactor unitCfg db fromPid toPid = do
+substitutionUnitFactor :: UnitConfig -> Database -> Swap -> Either ServiceError Double
+substitutionUnitFactor unitCfg db (Swap fromPid toPid) = do
     fromUnit <- maybe (Left $ noRefUnit fromPid) Right $ referenceProductUnit db fromPid
     toUnit <- maybe (Left $ noRefUnit toPid) Right $ referenceProductUnit db toPid
     -- Identical units are κ = 1 by definition, independent of the conversion
@@ -2614,10 +2633,10 @@ substitutionUnitFactor unitCfg db fromPid toPid = do
 removes it from every consumer; the @-κ@ at @to@ adds the unit-converted
 demand. No virtual links (both suppliers live in this DB).
 -}
-planGlobalWithinDB :: UnitConfig -> Database -> ProcessId -> ProcessId -> Either ServiceError GlobalRankOneUpdate
-planGlobalWithinDB unitCfg db fromPid toPid = do
+planGlobalWithinDB :: UnitConfig -> Database -> Swap -> Either ServiceError GlobalRankOneUpdate
+planGlobalWithinDB unitCfg db swap@(Swap fromPid toPid) = do
     v <- requireConsumers db fromPid
-    kappa <- substitutionUnitFactor unitCfg db fromPid toPid
+    kappa <- substitutionUnitFactor unitCfg db swap
     Right $ GlobalRankOneUpdate [(fromIntegral fromPid, 1.0), (fromIntegral toPid, negate kappa)] v []
 
 {- | Apply all substitutions whose consumer lives in @thisDbName@ to the
@@ -2755,7 +2774,7 @@ applySubstitutionsAt unitCfg depLookup thisDb thisDbObj rootDb solver scalings a
         Elsewhere _ ->
             Left $ MatrixError "global substitution requires the replaced activity (from) to live in the root database"
         Here fromPid -> case toEp of
-            Here toPid -> planGlobalWithinDB unitCfg thisDb fromPid toPid
+            Here toPid -> planGlobalWithinDB unitCfg thisDb (Swap fromPid toPid)
             Elsewhere toRef -> do
                 v <- requireConsumers thisDb fromPid
                 let links =
@@ -2769,7 +2788,7 @@ applySubstitutionsAt unitCfg depLookup thisDb thisDbObj rootDb solver scalings a
 
     requireTech sub cPid fromPid =
         maybe (Left $ noTechLink sub cPid) Right $
-            findTechCoefficient thisDb cPid fromPid
+            findTechCoefficient thisDb (TechLink cPid fromPid)
 
     requireStatic sub cPid fromRef =
         maybe (Left $ noStaticLink sub cPid (drDbName fromRef) (drPid fromRef)) Right $
@@ -2893,13 +2912,13 @@ findStaticCrossDBLink rootDb consumerPid depDbName depSupRef =
             [] -> Nothing
 
 -- | Find the technosphere coefficient A[supplier, consumer] from the sparse triples
-findTechCoefficient :: Database -> ProcessId -> ProcessId -> Maybe Double
-findTechCoefficient db consumer supplier =
+findTechCoefficient :: Database -> TechLink -> Maybe Double
+findTechCoefficient db link =
     coefficient <$> U.find isWanted (dbTechnosphereTriples db)
   where
     consumerIdx, supplierIdx :: Int32
-    consumerIdx = fromIntegral consumer
-    supplierIdx = fromIntegral supplier
+    consumerIdx = fromIntegral (tlConsumer link)
+    supplierIdx = fromIntegral (tlSupplier link)
     isWanted :: SparseTriple -> Bool
     isWanted (SparseTriple row col _) = row == supplierIdx && col == consumerIdx
     coefficient :: SparseTriple -> Double

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -332,14 +332,16 @@ getActivityInventory db processIdText =
             let !inventoryExport = convertToInventoryExport db (dbBioFlows db) (dbUnits db) processId activity inventory
             return $ Right $ toJSON inventoryExport
 
--- | Tree-traversal counters (total nodes / loop nodes / leaf nodes).
-data TreeStats = TreeStats Int Int Int -- total, loops, leaves
-
-instance Semigroup TreeStats where
-    TreeStats t1 l1 v1 <> TreeStats t2 l2 v2 = TreeStats (t1 + t2) (l1 + l2) (v1 + v2)
-
-instance Monoid TreeStats where
-    mempty = TreeStats 0 0 0
+{- | The nodes and edges a tree walk has reached so far. Threaded through the
+walk in visit order and never combined out of it: a node id can be inserted
+twice (two branches looping to the same row give two 'TreeLoop' nodes, and one
+row reached under two consumers gives two nodes with different parents), and
+the walk order is what decides which one the export carries.
+-}
+data TreeBuild = TreeBuild
+    { tbNodes :: M.Map Text ExportNode
+    , tbEdges :: [TreeEdge]
+    }
 
 {- | Helper to find ProcessId for an activity by searching the database
 This is needed because activities don't store their own ProcessId/UUID
@@ -435,9 +437,9 @@ mkBiosphereTreeEdge units flow activityPid direction ex =
             }
 
 -- | Extract biosphere exchanges from an activity and create nodes and edges.
-extractBiosphereNodesAndEdges :: Database -> Activity -> Text -> Int -> M.Map Text ExportNode -> [TreeEdge] -> (M.Map Text ExportNode, [TreeEdge])
-extractBiosphereNodesAndEdges db activity activityProcessId depth nodeAcc edgeAcc =
-    foldr step (nodeAcc, edgeAcc) topBiosphereExchanges
+extractBiosphereNodesAndEdges :: Database -> Activity -> Text -> Int -> TreeBuild -> TreeBuild
+extractBiosphereNodesAndEdges db activity activityProcessId depth acc0 =
+    foldr step acc0 topBiosphereExchanges
   where
     units :: UnitDB
     units = dbUnits db
@@ -448,13 +450,13 @@ extractBiosphereNodesAndEdges db activity activityProcessId depth nodeAcc edgeAc
         take maxBiosphereFlows $
             L.sortBy (\a b -> compare (abs (exchangeAmount (snd b))) (abs (exchangeAmount (snd a)))) $
                 [(dir, ex) | ex@BiosphereExchange{bioDirection = dir} <- exchanges activity]
-    step :: (BioDirection, Exchange) -> (M.Map Text ExportNode, [TreeEdge]) -> (M.Map Text ExportNode, [TreeEdge])
-    step (direction, ex) acc@(nodes, edges) = case M.lookup (exchangeFlowId ex) (dbBioFlows db) of
+    step :: (BioDirection, Exchange) -> TreeBuild -> TreeBuild
+    step (direction, ex) acc = case M.lookup (exchangeFlowId ex) (dbBioFlows db) of
         Nothing -> acc
         Just flow ->
             let node = mkBiosphereExportNode units flow activityProcessId depth direction
                 edge = mkBiosphereTreeEdge units flow activityProcessId direction ex
-             in (M.insert (UUID.toText (bfId flow)) node nodes, edge : edges)
+             in TreeBuild (M.insert (UUID.toText (bfId flow)) node (tbNodes acc)) (edge : tbEdges acc)
 
 -- | ExportNode for an activity-bearing tree node (TreeLeaf or TreeNode).
 mkActivityExportNode :: Database -> Activity -> Text -> Int -> Maybe Text -> ExportNode
@@ -519,15 +521,9 @@ mkMissingExportNode nodeId name missingDepth parentId =
 the tree (depth == 0). Below the root we leave the accumulator untouched to
 keep the graph readable.
 -}
-withRootBiosphere ::
-    Database ->
-    Activity ->
-    Text ->
-    Int ->
-    (M.Map Text ExportNode, [TreeEdge]) ->
-    (M.Map Text ExportNode, [TreeEdge])
-withRootBiosphere db activity pid depth acc@(nodes, edges)
-    | depth == 0 = extractBiosphereNodesAndEdges db activity pid depth nodes edges
+withRootBiosphere :: Database -> Activity -> Text -> Int -> TreeBuild -> TreeBuild
+withRootBiosphere db activity pid depth acc
+    | depth == 0 = extractBiosphereNodesAndEdges db activity pid depth acc
     | otherwise = acc
 
 -- | Technosphere edge from the current node to a child subtree.
@@ -543,37 +539,36 @@ mkTechnosphereTreeEdge units fromPid toPid quantity flow =
         }
 
 -- | Extract nodes and edges from a 'LoopAwareTree'.
-extractNodesAndEdges :: Database -> LoopAwareTree -> Int -> Maybe Text -> M.Map Text ExportNode -> [TreeEdge] -> (M.Map Text ExportNode, [TreeEdge], TreeStats)
-extractNodesAndEdges db tree depth parentId nodeAcc edgeAcc = case tree of
+extractNodesAndEdges :: Database -> LoopAwareTree -> Int -> Maybe Text -> TreeBuild -> TreeBuild
+extractNodesAndEdges db tree depth parentId acc = case tree of
     TreeLeaf _ activity ->
         let nodeId = getTreeNodeId db tree
-            nodes' = M.insert nodeId (mkActivityExportNode db activity nodeId depth parentId) nodeAcc
-            (nodes'', edges') = withRootBiosphere db activity nodeId depth (nodes', edgeAcc)
-         in (nodes'', edges', TreeStats 1 0 1)
+         in withRootBiosphere db activity nodeId depth $
+                insertNode nodeId (mkActivityExportNode db activity nodeId depth parentId) acc
     TreeLoop pid name loopDepth ->
         let nodeId = getTreeNodeId db tree
-            nodes' = M.insert nodeId (mkLoopExportNode db pid nodeId name loopDepth parentId) nodeAcc
-         in (nodes', edgeAcc, TreeStats 1 1 0)
+         in insertNode nodeId (mkLoopExportNode db pid nodeId name loopDepth parentId) acc
     TreeMissing _ name missingDepth ->
         let nodeId = getTreeNodeId db tree
-            nodes' = M.insert nodeId (mkMissingExportNode nodeId name missingDepth parentId) nodeAcc
-         in (nodes', edgeAcc, TreeStats 1 0 1)
+         in insertNode nodeId (mkMissingExportNode nodeId name missingDepth parentId) acc
     TreeNode _ activity children ->
         let nodeId = getTreeNodeId db tree
-            nodes' = M.insert nodeId (mkActivityExportNode db activity nodeId depth parentId) nodeAcc
-            (childNodes, childEdges, childStats) = foldr (processChild nodeId) (nodes', edgeAcc, TreeStats 1 0 0) children
-            (finalNodes, finalEdges) = withRootBiosphere db activity nodeId depth (childNodes, childEdges)
-         in (finalNodes, finalEdges, childStats)
+            withSelf = insertNode nodeId (mkActivityExportNode db activity nodeId depth parentId) acc
+         in withRootBiosphere db activity nodeId depth $
+                foldr (processChild nodeId) withSelf children
   where
-    processChild parentPid (quantity, flow, subtree) (nodes, edges, stats) =
-        let (n', e', s') = extractNodesAndEdges db subtree (depth + 1) (Just parentPid) nodes edges
+    insertNode :: Text -> ExportNode -> TreeBuild -> TreeBuild
+    insertNode nodeId node built = built{tbNodes = M.insert nodeId node (tbNodes built)}
+    processChild :: Text -> (Double, TechnosphereFlow, LoopAwareTree) -> TreeBuild -> TreeBuild
+    processChild parentPid (quantity, flow, subtree) built =
+        let childBuilt = extractNodesAndEdges db subtree (depth + 1) (Just parentPid) built
             edge = mkTechnosphereTreeEdge (dbUnits db) parentPid (getTreeNodeId db subtree) quantity flow
-         in (n', edge : e', stats <> s')
+         in childBuilt{tbEdges = edge : tbEdges childBuilt}
 
 -- | Convert LoopAwareTree to TreeExport format for JSON serialization
 convertToTreeExport :: Database -> Int -> LoopAwareTree -> TreeExport
 convertToTreeExport db maxDepth tree =
-    let (nodes, edges, _stats) = extractNodesAndEdges db tree 0 Nothing M.empty []
+    let TreeBuild nodes edges = extractNodesAndEdges db tree 0 Nothing (TreeBuild M.empty [])
         -- The tree's own root, so tmRootId always names a key in the nodes map.
         actualRootId = getTreeNodeId db tree
         metadata =

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -101,6 +101,13 @@ data FlowFilter = FlowFilter
     , ffOrder :: Maybe Text
     }
 
+{- | A case-blind substring a name is searched for, as opposed to a name, a
+process reference or a database name. Compared with
+'Normalize.caseInsensitiveInfixOf', never parsed.
+-}
+newtype NamePattern = NamePattern {unNamePattern :: Text}
+    deriving (Eq, Show)
+
 -- | Empty flow-search response used by callers that have no query to run.
 emptyFlowSearchResults :: Value
 emptyFlowSearchResults = toJSON (SearchResults ([] :: [FlowSearchResult]) 0 0 50 False 0.0)
@@ -578,10 +585,10 @@ convertToTreeExport db maxDepth tree =
 {- | Post-filter a TreeExport by name: keep matching nodes plus all their ancestors up to root.
 Uses the enParentId chain already stored in each ExportNode — no extra graph traversal.
 -}
-filterTreeExport :: Text -> TreeExport -> TreeExport
+filterTreeExport :: NamePattern -> TreeExport -> TreeExport
 filterTreeExport pat export =
     let nodes = teNodes export
-        matchingIds = M.keysSet $ M.filter (Normalize.caseInsensitiveInfixOf pat . enName) nodes
+        matchingIds = M.keysSet $ M.filter (Normalize.caseInsensitiveInfixOf (unNamePattern pat) . enName) nodes
         ancestorsOf nId = case enParentId =<< M.lookup nId nodes of
             Nothing -> S.empty
             Just pid -> S.insert pid (ancestorsOf pid)
@@ -1621,7 +1628,7 @@ whose name contains the given substring (case-insensitive).
 Returns path steps ordered root → target, each with cumulative quantity, scaling factor,
 and local_step_ratio (upstream ÷ downstream scaling factors).
 -}
-getPathTo :: Database -> SharedSolver -> Text -> Text -> IO (Either ServiceError Value)
+getPathTo :: Database -> SharedSolver -> Text -> NamePattern -> IO (Either ServiceError Value)
 getPathTo db solver pidText target = do
     case resolveScorable db pidText of
         Left err -> return $ Left err
@@ -1640,7 +1647,7 @@ getPathTo db solver pidText target = do
                                         (fromIntegral rootPid)
                                         ( \i ->
                                             Normalize.caseInsensitiveInfixOf
-                                                target
+                                                (unNamePattern target)
                                                 (activityName (dbActivities db V.! i))
                                         )
                                         adj
@@ -1648,7 +1655,7 @@ getPathTo db solver pidText target = do
                                     Nothing ->
                                         Left $
                                             ActivityNotFound $
-                                                "No upstream node matching '" <> target <> "' reachable from " <> pidText
+                                                "No upstream node matching '" <> unNamePattern target <> "' reachable from " <> pidText
                                     Just [] ->
                                         Left $
                                             ActivityNotFound $

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -69,6 +69,11 @@ data SearchFilter = SearchFilter
     , sfExactMatch :: !Bool
     }
 
+{- | Whether a walk also reports every technosphere edge inside the subgraph it
+reached. Edges cost an extra pass over the triples, so they are asked for.
+-}
+data Edges = WithEdges | EntriesOnly
+
 {- | Filter for supply-chain walks. Adds the depth cap and the magnitude
 cut-off that only make sense downstream from a root activity.
 -}
@@ -76,6 +81,7 @@ data SupplyChainFilter = SupplyChainFilter
     { scfCore :: !ActivityFilterCore
     , scfMaxDepth :: !(Maybe Int)
     , scfMinQuantity :: !(Maybe Double)
+    , scfEdges :: !Edges
     }
 
 {- | Filter for reverse-walk (/consumers). Adds a depth cap but no
@@ -1600,9 +1606,8 @@ getSupplyChain ::
     SharedSolver ->
     Text ->
     SupplyChainFilter ->
-    Bool ->
     IO (Either ServiceError SupplyChainResponse)
-getSupplyChain unitCfg depLookup db dbName sharedSolver processIdText af includeEdges =
+getSupplyChain unitCfg depLookup db dbName sharedSolver processIdText af =
     case resolveScorable db processIdText of
         Left err -> return $ Left err
         Right (processId, _rootActivity) ->
@@ -1621,7 +1626,6 @@ getSupplyChain unitCfg depLookup db dbName sharedSolver processIdText af include
                         supplyVec
                         []
                         af
-                        includeEdges
 
 {- | Find the shortest supply chain path from a root process to the first upstream activity
 whose name contains the given substring (case-insensitive).
@@ -1698,38 +1702,72 @@ getPathTo db solver pidText target = do
                                                     , "total_ratio" .= totalRatio
                                                     ]
 
+{- | Where a supply-chain collection stands.
+
+At the root the root row is left out of its own chain, quantities are scaled by
+the root's reference amount, process ids stay bare, and depth counts from zero.
+In a dependency database nothing is excluded, the scaling that arrives is
+already physical, ids are qualified with @db::@, and depth continues from the
+level that reached it. The two are one fact, so they travel as one value: as
+four separate parameters they admitted sixteen combinations, of which the code
+only ever built these two.
+-}
+data WalkLevel
+    = RootLevel {rlRoot :: !ProcessId, rlRefAmount :: !Double}
+    | DepLevel {dlDepthOffset :: !Int}
+
+{- | What one database contributes to a supply chain: how many non-zero rows it
+had before filtering, the entries that passed, and the edges. Summed across
+levels, pointwise, nearer level first.
+-}
+data Collected = Collected
+    { cUnfilteredCount :: !Int
+    , cEntries :: ![SupplyChainEntry]
+    , cEdges :: ![SupplyChainEdge]
+    }
+
+instance Semigroup Collected where
+    Collected t1 es1 ed1 <> Collected t2 es2 ed2 =
+        Collected (t1 + t2) (es1 ++ es2) (ed1 ++ ed2)
+
+instance Monoid Collected where
+    mempty = Collected 0 [] []
+
 {- | Collect filtered supply-chain entries + edges from a single DB's scaling
 vector. Applies @minQuantity@, name/location/product/class/maxDepth filters,
 BFS depth assignment, and upstream-count accumulation — but deliberately
 does NOT sort, limit, or offset. Callers merge collections from multiple
 databases and then apply sorting/pagination once on the combined list.
 
-Entry @sceProcessId@ is qualified with @dbName::@ iff @qualifyPids@ is True
-(used for dep-DB entries in cross-DB expansion; root entries stay bare for
-backward compatibility with callers that navigate on bare root PIDs).
+Entry @sceProcessId@ is qualified with @dbName::@ at a dep level only; root
+entries stay bare for callers that navigate on bare root PIDs.
 -}
 collectSupplyChainEntries ::
     Database ->
     -- | DB name
     Text ->
-    -- | root PID to exclude (Nothing at dep levels)
-    Maybe ProcessId ->
+    WalkLevel ->
     -- | scaling vector
     U.Vector Double ->
     SupplyChainFilter ->
-    -- | include edges
-    Bool ->
-    -- | qualify processIds with @dbName::@
-    Bool ->
-    -- | multiplier for sceQuantity (rootRefAmount at root, 1.0 at dep)
-    Double ->
-    -- | depth offset added to per-DB BFS depth
-    Int ->
-    -- | (unfiltered non-zero count, filtered entries, edges)
-    (Int, [SupplyChainEntry], [SupplyChainEdge])
-collectSupplyChainEntries db dbName mRootPid supplyVec scf includeEdges qualifyPids quantityMult depthOffset =
+    Collected
+collectSupplyChainEntries db dbName level supplyVec scf =
     let core = scfCore scf
         minQ = fromMaybe 0 (scfMinQuantity scf)
+
+        -- The four facts that used to arrive as four correlated parameters.
+        mRootPid = case level of
+            RootLevel{rlRoot = r} -> Just r
+            DepLevel{} -> Nothing
+        quantityMult = case level of
+            RootLevel{rlRefAmount = a} -> a
+            DepLevel{} -> 1.0
+        depthOffset = case level of
+            RootLevel{} -> 0
+            DepLevel{dlDepthOffset = d} -> d
+        qualifyPids = case level of
+            RootLevel{} -> False
+            DepLevel{} -> True
         n = U.length supplyVec
 
         allEntries =
@@ -1812,26 +1850,25 @@ collectSupplyChainEntries db dbName mRootPid supplyVec scf includeEdges qualifyP
             ]
 
         allIdxSet = S.fromList (maybe [] ((: []) . fromIntegral) mRootPid ++ map (fromIntegral . fst) allEntries)
-        edges =
-            if not includeEdges
-                then []
-                else
-                    U.foldl'
-                        ( \acc (SparseTriple row col val) ->
-                            if S.member (fromIntegral row :: Int) allIdxSet && S.member (fromIntegral col :: Int) allIdxSet
-                                then
-                                    SupplyChainEdge
-                                        (qualify (fromIntegral row))
-                                        dbName
-                                        (qualify (fromIntegral col))
-                                        dbName
-                                        val
-                                        : acc
-                                else acc
-                        )
-                        []
-                        (dbTechnosphereTriples db)
-     in (length allEntries, filteredEntries, edges)
+        edges = case scfEdges scf of
+            EntriesOnly -> []
+            WithEdges ->
+                U.foldl'
+                    ( \acc (SparseTriple row col val) ->
+                        if S.member (fromIntegral row :: Int) allIdxSet && S.member (fromIntegral col :: Int) allIdxSet
+                            then
+                                SupplyChainEdge
+                                    (qualify (fromIntegral row))
+                                    dbName
+                                    (qualify (fromIntegral col))
+                                    dbName
+                                    val
+                                    : acc
+                            else acc
+                    )
+                    []
+                    (dbTechnosphereTriples db)
+     in Collected (length allEntries) filteredEntries edges
 
 {- | Sort, offset, and limit a list of supply-chain entries using the shared
 filter core's @afcSort@ / @afcOrder@ / @afcLimit@ / @afcOffset@. All
@@ -1863,23 +1900,17 @@ buildSupplyChainFromScalingVector ::
     ProcessId ->
     U.Vector Double ->
     SupplyChainFilter ->
-    -- | include edges (expensive: extra pass over technosphere triples)
-    Bool ->
     SupplyChainResponse
-buildSupplyChainFromScalingVector db dbName processId supplyVec scf includeEdges =
+buildSupplyChainFromScalingVector db dbName processId supplyVec scf =
     let rootActivity = dbActivities db V.! fromIntegral processId
         rootRefAmount = getReferenceProductAmount rootActivity
-        (totalActs, entries, edges) =
+        Collected totalActs entries edges =
             collectSupplyChainEntries
                 db
                 dbName
-                (Just processId)
+                (RootLevel processId rootRefAmount)
                 supplyVec
                 scf
-                includeEdges
-                False
-                rootRefAmount
-                0
         rootSummary =
             ActivitySummary
                 { prsProcessId = processIdToText db processId
@@ -1926,23 +1957,17 @@ buildSupplyChainFromScalingVectorCrossDB ::
     -- | extra virtual links from subs
     [CrossDBLink] ->
     SupplyChainFilter ->
-    -- | include edges
-    Bool ->
     IO (Either ServiceError SupplyChainResponse)
-buildSupplyChainFromScalingVectorCrossDB unitCfg depLookup rootDb rootDbName rootPid rootScaling extraLinks scf includeEdges = do
+buildSupplyChainFromScalingVectorCrossDB unitCfg depLookup rootDb rootDbName rootPid rootScaling extraLinks scf = do
     let rootActivity = dbActivities rootDb V.! fromIntegral rootPid
         rootRefAmount = getReferenceProductAmount rootActivity
-        (rootTotal, rootEntries, rootEdges) =
+        rootCollected =
             collectSupplyChainEntries
                 rootDb
                 rootDbName
-                (Just rootPid)
+                (RootLevel rootPid rootRefAmount)
                 rootScaling
                 scf
-                includeEdges
-                False
-                rootRefAmount
-                0
         rootSummary =
             ActivitySummary
                 { prsProcessId = processIdToText rootDb rootPid
@@ -1959,19 +1984,18 @@ buildSupplyChainFromScalingVectorCrossDB unitCfg depLookup rootDb rootDbName roo
                 , prsMassAllocationPercent = Nothing
                 , prsNativeType = activityNativeType rootActivity
                 }
-    eDep <- walkDepLevels unitCfg depLookup rootDb rootScaling extraLinks scf includeEdges 1 S.empty
+    eDep <- walkDepLevels unitCfg depLookup rootDb rootScaling extraLinks scf 1 S.empty
     pure $ case eDep of
         Left err -> Left err
-        Right (depTotal, depEntries, depEdges) ->
-            let combinedEntries = rootEntries ++ depEntries
-                combinedEdges = rootEdges ++ depEdges
+        Right depCollected ->
+            let Collected total entries edges = rootCollected <> depCollected
              in Right
                     SupplyChainResponse
                         { scrRoot = rootSummary
-                        , scrTotalActivities = rootTotal + depTotal
-                        , scrFilteredActivities = length combinedEntries
-                        , scrSupplyChain = sortAndPaginate (scfCore scf) combinedEntries
-                        , scrEdges = combinedEdges
+                        , scrTotalActivities = total
+                        , scrFilteredActivities = length entries
+                        , scrSupplyChain = sortAndPaginate (scfCore scf) entries
+                        , scrEdges = edges
                         }
 
 {- | Recursive helper: for every cross-DB link emerging from @consumerScaling@,
@@ -1991,25 +2015,22 @@ walkDepLevels ::
     -- | extra virtual links visible at this level
     [CrossDBLink] ->
     SupplyChainFilter ->
-    Bool ->
     -- | current depth
     Int ->
     -- | visited DB names (cycle guard)
     S.Set Text ->
-    IO (Either ServiceError (Int, [SupplyChainEntry], [SupplyChainEdge]))
-walkDepLevels unitCfg depLookup consumerDb consumerScaling extras scf includeEdges depth visited
-    | depth >= SharedSolver.maxDepsDepth = pure (Right (0, [], []))
+    IO (Either ServiceError Collected)
+walkDepLevels unitCfg depLookup consumerDb consumerScaling extras scf depth visited
+    | depth >= SharedSolver.maxDepsDepth = pure (Right mempty)
     | otherwise = do
         let demandsMap = accumulateDepDemandsWith consumerDb extras consumerScaling
         results <-
             mapM
-                (resolveOneDep unitCfg depLookup scf includeEdges depth visited)
+                (resolveOneDep unitCfg depLookup scf depth visited)
                 (M.toList demandsMap)
         pure $ case lefts results of
             (err : _) -> Left err
-            [] -> Right (foldr merge3 (0, [], []) (rights results))
-  where
-    merge3 (t1, es1, ed1) (t2, es2, ed2) = (t1 + t2, es1 ++ es2, ed1 ++ ed2)
+            [] -> Right (mconcat (rights results))
 
 {- | For a single dep DB: solve its induced demand, collect filtered entries
 using the shared 'collectSupplyChainEntries' helper (so it gets the same
@@ -2019,34 +2040,29 @@ resolveOneDep ::
     UnitConfig ->
     SharedSolver.DepSolverLookup ->
     SupplyChainFilter ->
-    Bool ->
     -- | current depth (the one we're entering)
     Int ->
     -- | visited
     S.Set Text ->
     (Text, SupplierDemands) ->
-    IO (Either ServiceError (Int, [SupplyChainEntry], [SupplyChainEdge]))
-resolveOneDep unitCfg depLookup scf includeEdges depth visited (depDbName, demands)
-    | depDbName `S.member` visited = pure (Right (0, [], []))
+    IO (Either ServiceError Collected)
+resolveOneDep unitCfg depLookup scf depth visited (depDbName, demands)
+    | depDbName `S.member` visited = pure (Right mempty)
     | otherwise = do
         mDep <- depLookup depDbName
         case mDep of
-            Nothing -> pure (Right (0, [], [])) -- unloaded dep DB: silent skip (matches LCIA path)
+            Nothing -> pure (Right mempty) -- unloaded dep DB: silent skip (matches LCIA path)
             Just (depDb, depSolver) -> case depDemandsToVector unitCfg depDbName depDb demands of
                 Left err -> pure (Left (MatrixError err))
                 Right demandVec -> do
                     depScaling <- solveWithSharedSolver depSolver demandVec
-                    let (localTotal, localEntries, localEdges) =
+                    let local =
                             collectSupplyChainEntries
                                 depDb
                                 depDbName
-                                Nothing
+                                (DepLevel depth)
                                 depScaling
                                 scf
-                                includeEdges
-                                True
-                                1.0
-                                depth
                     eDeeper <-
                         walkDepLevels
                             unitCfg
@@ -2055,17 +2071,9 @@ resolveOneDep unitCfg depLookup scf includeEdges depth visited (depDbName, deman
                             depScaling
                             []
                             scf
-                            includeEdges
                             (depth + 1)
                             (S.insert depDbName visited)
-                    pure $ case eDeeper of
-                        Left err -> Left err
-                        Right (deeperTotal, deeperEntries, deeperEdges) ->
-                            Right
-                                ( localTotal + deeperTotal
-                                , localEntries ++ deeperEntries
-                                , localEdges ++ deeperEdges
-                                )
+                    pure $ (local <>) <$> eDeeper
 
 {- | Build reverse adjacency (consumer -> [supplier]) from a vector of
 technosphere sparse triplets. Each triplet @(row=supplier, col=consumer)@

--- a/src/Service/Aggregate.hs
+++ b/src/Service/Aggregate.hs
@@ -42,6 +42,7 @@ import API.Types (
 import Matrix (activityNormalizationFactor, buildDemandVectorFromIndex)
 import Service (
     ActivityFilterCore (..),
+    Edges (..),
     ServiceError (..),
     SupplyChainFilter (..),
     buildSupplyChainFromScalingVectorCrossDB,
@@ -195,7 +196,6 @@ aggregate unitConfig flowDB unitDB db dbName solver depLookup pidText params =
                             supplyVec
                             []
                             af
-                            False
                     return $ fmap (reduce params . rowsFromSupplyChain) eResp
                 ScopeBiosphere -> do
                     solE <- computeInventoryMatrixWithDepsCached unitConfig depLookup db dbName solver processId
@@ -231,6 +231,7 @@ aggregate unitConfig flowDB unitDB db dbName solver depLookup pidText params =
                     }
             , scfMaxDepth = maxD
             , scfMinQuantity = Nothing
+            , scfEdges = EntriesOnly
             }
 
 -- ---------------------------------------------------------------------------

--- a/test/GlobalSubstitutionSpec.hs
+++ b/test/GlobalSubstitutionSpec.hs
@@ -28,6 +28,7 @@ import qualified Data.Vector.Unboxed as U
 import Matrix (buildDemandVectorFromIndex)
 import Service (
     ServiceError (..),
+    Swap (..),
     computeScalingVectorWithSubstitutionsCrossDB,
     substitutionUnitFactor,
     technosphereRow,
@@ -128,8 +129,8 @@ spec = do
             -- electricity is in MJ, steel in kg — energy vs mass, no conversion.
             case (activityByInfix db "electricity generation", activityByInfix db "steel production") of
                 (Just elec, Just steel) -> do
-                    substitutionUnitFactor defaultUnitConfig db elec steel `shouldSatisfy` isLeft
-                    substitutionUnitFactor defaultUnitConfig db elec elec `shouldSatisfy` isRightNear 1.0
+                    substitutionUnitFactor defaultUnitConfig db (Swap elec steel) `shouldSatisfy` isLeft
+                    substitutionUnitFactor defaultUnitConfig db (Swap elec elec) `shouldSatisfy` isRightNear 1.0
                 _ -> expectationFailure "SAMPLE.units missing electricity/steel activities"
 
 -- | A fresh 'SharedSolver' over a database's own technosphere triples.

--- a/test/NestedSubstitutionSpec.hs
+++ b/test/NestedSubstitutionSpec.hs
@@ -18,6 +18,7 @@ import qualified Data.Vector.Unboxed as U
 import Matrix (buildDemandVectorFromIndex)
 import Service (
     ActivityFilterCore (..),
+    Edges (..),
     ServiceError (..),
     SupplyChainFilter (..),
     applySubstitutionsAt,
@@ -289,6 +290,7 @@ spec = do
                                 }
                         , scfMaxDepth = Nothing
                         , scfMinQuantity = Nothing
+                        , scfEdges = EntriesOnly
                         }
             eResp <-
                 buildSupplyChainFromScalingVectorCrossDB
@@ -300,7 +302,6 @@ spec = do
                     scaling
                     []
                     scf
-                    False
             case eResp of
                 Left e -> expectationFailure ("supply-chain CrossDB failed: " <> show e)
                 Right resp -> do

--- a/test/ServiceSpec.hs
+++ b/test/ServiceSpec.hs
@@ -17,6 +17,7 @@ import qualified Data.Set as S
 import Data.Text (Text)
 import Data.UUID (fromWords, nil, toText)
 import Service (
+    NamePattern (..),
     ServiceError (..),
     TargetRef (..),
     buildUnitGroups,
@@ -220,7 +221,7 @@ spec = do
                         , ("sibling", Just "root", "Unrelated Process")
                         ]
                         [("root", "child"), ("root", "sibling")]
-                filtered = filterTreeExport "widget" export
+                filtered = filterTreeExport (NamePattern "widget") export
              in M.keysSet (teNodes filtered) `shouldBe` S.fromList ["root", "child"]
 
         it "excludes edges whose endpoints are filtered out" $
@@ -231,7 +232,7 @@ spec = do
                         , ("sibling", Just "root", "Unrelated Process")
                         ]
                         [("root", "child"), ("root", "sibling")]
-                filtered = filterTreeExport "widget" export
+                filtered = filterTreeExport (NamePattern "widget") export
              in length (teEdges filtered) `shouldBe` 1
 
         it "returns all nodes when pattern matches all" $
@@ -239,12 +240,12 @@ spec = do
                     mkTreeExport
                         [("a", Nothing, "Alpha"), ("b", Just "a", "Beta")]
                         [("a", "b")]
-                filtered = filterTreeExport "a" export -- matches "Alpha"
+                filtered = filterTreeExport (NamePattern "a") export -- matches "Alpha"
              in M.size (teNodes filtered) `shouldBe` 2
 
         it "returns empty when no match" $
             let export = mkTreeExport [("a", Nothing, "Alpha")] []
-                filtered = filterTreeExport "zzz" export
+                filtered = filterTreeExport (NamePattern "zzz") export
              in M.size (teNodes filtered) `shouldBe` 0
 
         it "updates tmTotalNodes in metadata" $
@@ -254,7 +255,7 @@ spec = do
                         , ("child", Just "root", "Match Me")
                         ]
                         [("root", "child")]
-                filtered = filterTreeExport "match" export
+                filtered = filterTreeExport (NamePattern "match") export
              in tmTotalNodes (teTree filtered) `shouldBe` 2
 
 -- ---------------------------------------------------------------------------

--- a/test/SupplyChainSpec.hs
+++ b/test/SupplyChainSpec.hs
@@ -17,6 +17,7 @@ import qualified Search.BM25 as BM25
 import Service (
     ActivityFilterCore (..),
     ConsumerFilter (..),
+    NamePattern (..),
     SupplyChainFilter (..),
     bfsToPattern,
     buildSupplyChainFromScalingVector,
@@ -317,29 +318,29 @@ spec = do
                     }
 
         it "filter matching leaf keeps leaf + all ancestors" $ do
-            let result = filterTreeExport "leaf" tree
+            let result = filterTreeExport (NamePattern "leaf") tree
             M.keys (teNodes result) `shouldMatchList` ["r", "m", "l"]
             length (teEdges result) `shouldBe` 2
 
         it "filter matching middle node keeps middle + root only" $ do
-            let result = filterTreeExport "middle" tree
+            let result = filterTreeExport (NamePattern "middle") tree
             M.keys (teNodes result) `shouldMatchList` ["r", "m"]
             map (\e -> (teFrom e, teTo e)) (teEdges result) `shouldMatchList` [("r", "m")]
 
         it "filter matching root keeps root only" $ do
-            let result = filterTreeExport "root" tree
+            let result = filterTreeExport (NamePattern "root") tree
             M.keys (teNodes result) `shouldMatchList` ["r"]
             length (teEdges result) `shouldBe` 0
 
         it "filter with no match returns empty" $ do
-            let result = filterTreeExport "nonexistent" tree
+            let result = filterTreeExport (NamePattern "nonexistent") tree
             M.size (teNodes result) `shouldBe` 0
             length (teEdges result) `shouldBe` 0
 
         it "updates tmTotalNodes to match filtered count" $ do
-            let result = filterTreeExport "leaf" tree
+            let result = filterTreeExport (NamePattern "leaf") tree
             tmTotalNodes (teTree result) `shouldBe` 3
-            let result2 = filterTreeExport "middle" tree
+            let result2 = filterTreeExport (NamePattern "middle") tree
             tmTotalNodes (teTree result2) `shouldBe` 2
 
     -- -----------------------------------------------------------------------
@@ -374,7 +375,7 @@ spec = do
                 actCount = fromIntegral (dbActivityCount db)
             solver <- createSharedSolver "test" techTriples actCount
             let rootPid = processIdToText db 0
-            result <- getPathTo db solver rootPid "product Z"
+            result <- getPathTo db solver rootPid (NamePattern "product Z")
             case result of
                 Left err -> expectationFailure $ "Expected Right but got Left: " ++ show err
                 Right val -> do
@@ -392,7 +393,7 @@ spec = do
                 actCount = fromIntegral (dbActivityCount db)
             solver <- createSharedSolver "test" techTriples actCount
             let rootPid = processIdToText db 0
-            result <- getPathTo db solver rootPid "no such activity"
+            result <- getPathTo db solver rootPid (NamePattern "no such activity")
             case result of
                 Left _ -> return ()
                 Right _ -> expectationFailure "Expected Left but got Right"

--- a/test/SupplyChainSpec.hs
+++ b/test/SupplyChainSpec.hs
@@ -17,6 +17,7 @@ import qualified Search.BM25 as BM25
 import Service (
     ActivityFilterCore (..),
     ConsumerFilter (..),
+    Edges (..),
     NamePattern (..),
     SupplyChainFilter (..),
     bfsToPattern,
@@ -45,7 +46,7 @@ emptyCore =
         }
 
 emptySupply :: SupplyChainFilter
-emptySupply = SupplyChainFilter emptyCore Nothing Nothing
+emptySupply = SupplyChainFilter emptyCore Nothing Nothing EntriesOnly
 
 emptyConsumer :: ConsumerFilter
 emptyConsumer = ConsumerFilter emptyCore Nothing False
@@ -68,7 +69,7 @@ spec = do
             let rootProcessId = 0 :: ProcessId
             supplyVec <- computeScalingVector db rootProcessId
 
-            let response = buildSupplyChainFromScalingVector db "test-db" rootProcessId supplyVec emptySupply False
+            let response = buildSupplyChainFromScalingVector db "test-db" rootProcessId supplyVec emptySupply
                 entries = scrSupplyChain response
 
             -- With rootRefAmount = 1, sceQuantity must equal sceScalingFactor exactly
@@ -86,7 +87,7 @@ spec = do
             let rootProcessId = 0 :: ProcessId
             supplyVec <- computeScalingVector db rootProcessId
 
-            let response = buildSupplyChainFromScalingVector db "test-db" rootProcessId supplyVec emptySupply False
+            let response = buildSupplyChainFromScalingVector db "test-db" rootProcessId supplyVec emptySupply
                 entries = scrSupplyChain response
 
             -- All entries should have depth > 0 (root is excluded from supply chain)
@@ -100,7 +101,7 @@ spec = do
             supplyVec <- computeScalingVector db rootProcessId
 
             -- No depth filter: should get Y (depth 1) and Z (depth 2)
-            let noFilter = buildSupplyChainFromScalingVector db "test-db" rootProcessId supplyVec emptySupply False
+            let noFilter = buildSupplyChainFromScalingVector db "test-db" rootProcessId supplyVec emptySupply
             scrFilteredActivities noFilter `shouldSatisfy` (>= 2)
 
             -- Depth 1: should only get Y (direct supplier)
@@ -111,7 +112,6 @@ spec = do
                         rootProcessId
                         supplyVec
                         emptySupply{scfMaxDepth = Just 1}
-                        False
             scrFilteredActivities depth1 `shouldSatisfy` (< scrFilteredActivities noFilter)
 
     -- -----------------------------------------------------------------------
@@ -130,7 +130,6 @@ spec = do
                     pid
                     vec
                     (mapSupplyCore (\c -> c{afcName = nameQ}) emptySupply)
-                    False
 
         it "narrows to single entry when token matches only one activity" $ do
             db <- loadWithIndex
@@ -200,7 +199,6 @@ spec = do
                         rootPid
                         supplyVec
                         (mapSupplyCore (\c -> c{afcName = Just "produc", afcSort = Just "depth"}) emptySupply)
-                        False
             map sceDepth (scrSupplyChain resp) `shouldBe` [1, 2]
 
     describe "Fuzzy name filter on consumers" $ do

--- a/test/SupplyChainSpec.hs
+++ b/test/SupplyChainSpec.hs
@@ -49,7 +49,7 @@ emptySupply :: SupplyChainFilter
 emptySupply = SupplyChainFilter emptyCore Nothing Nothing EntriesOnly
 
 emptyConsumer :: ConsumerFilter
-emptyConsumer = ConsumerFilter emptyCore Nothing False
+emptyConsumer = ConsumerFilter emptyCore Nothing EntriesOnly
 
 -- | Update the shared core inside a 'SupplyChainFilter'.
 mapSupplyCore :: (ActivityFilterCore -> ActivityFilterCore) -> SupplyChainFilter -> SupplyChainFilter
@@ -258,7 +258,7 @@ spec = do
         it "emits technosphere edges whose endpoints are both reachable from the supplier" $ do
             db <- loadWithIndex
             let pidZ = processIdToText db 2
-                cnf = emptyConsumer{cnfIncludeEdges = True}
+                cnf = emptyConsumer{cnfEdges = WithEdges}
             case getConsumers db "test-db" pidZ cnf of
                 Left err -> expectationFailure $ "getConsumers failed: " ++ show err
                 Right cr -> do


### PR DESCRIPTION
The types half of a two-pass read of `src/Service.hs`. PR #383 read the same file on two axes and applied the small, uncontested half; this one reads nothing but the declarations and signatures, proposes the vocabulary the file should be written in, and lands the part of it that changes no behaviour. Nothing here changes what the program does.

One reader built the vocabulary, a second agent then attacked it against the file. That second pass earned its keep again: it found six claims that did not hold on the lines they quoted, three findings that would have changed behaviour while carrying no marker, and three ordering constraints the plan had missed. It also cut the plan, and this pull request follows that cut rather than the one I had written.

## What landed

Six commits, smallest first.

- **A name pattern is not a process reference.** `getPathTo` took both as adjacent `Text` parameters, so a caller could swap them and get "no upstream node matching" instead of an error. `NamePattern` gives the two parameters different types.
- **A biosphere exchange already knows its direction.** Every `BiosphereExchange` carries `bioDirection`, and `exchangeIsInput` on one is that field spelled as a `Bool`. The tree export threw the field away, recovered `not (exchangeIsInput ex)` under the name `isEmission`, and handed that `Bool` to two builders. The generator that selects the biosphere rows now binds the direction off the constructor.
- **A cross-database supplier is a `ProcessRef`.** `DepRef` held the supplier's two UUIDs as a bare `(UUID, UUID)` that `mkVirtualLink` unpacked positionally. `Types.ProcessRef` exists for exactly this pair and its own comment says why. The indexing is unchanged, out-of-range included.
- **`TechLink` and `Swap`.** `findTechCoefficient`, `substitutionUnitFactor` and `planGlobalWithinDB` each took two `ProcessId` parameters in a row: `A[consumer, supplier]` read as `A[supplier, consumer]` answers about a different edge, and a reversed swap inverts the unit factor kappa instead of failing.
- **The tree walk has one accumulator, and the counters are gone.** `extractNodesAndEdges` threaded a node map, an edge list and a `TreeStats` triple whose only consumer dropped it as `_stats` and recounted from the map. `TreeBuild` replaces the pair, threaded in visit order exactly as the tuple was.
- **`WalkLevel`, `Collected`, `Edges`.** `collectSupplyChainEntries` took a root to exclude, a "qualify ids" flag, a quantity multiplier and a depth offset: sixteen combinations expressible, two ever built. `WalkLevel` says which of the two. `Collected` replaces the `(count, entries, edges)` triple three walkers returned and merged by hand in two places. `Edges` joins `SupplyChainFilter`, where `ConsumerFilter` already carries the same question.

## Numbers

|  | before | after |
|---|---|---|
| signatures | 124 | 124 |
| tuples in signatures | 35 | 25 |
| `Bool` in signatures | 16 | 7 |
| bare `Text` / `Int` / `Double` in signatures | 137 | 124 |
| file length | 3046 | 3080 |

The file got 34 lines longer, which a types pass usually does: five declarations and their doc comments cost lines. What was bought is states that no longer exist and swaps the compiler now sees.

## Verification

Cold `-Werror` build of the library, the executable and the test suite in a builddir of its own, then the same three plus the suite after every commit. `hlint src app test` reports no hints and `fourmolu` is clean, both before and after.

The suite reports **2446 examples, 0 failures, 2 pending**, the same as before the first commit.

Diffing the string literals of `src/Service.hs` across the whole change is **empty**: no message moved, none was dropped, and no sentinel string vanished. Emission sites were not moved either.

One check worth naming because it was the falsifier's sharpest finding: `Collected`'s `Semigroup` is exactly the `merge3` that was written out by hand, pointwise and nearer-level-first, so entry and edge order is unchanged and `sortAndPaginate`'s stability is unaffected. `TreeBuild` deliberately gets **no** `Semigroup`: `M.union` is left-biased, while the code it would replace threads one accumulator and lets `M.insert` keep the last writer, and duplicate node ids do occur. Reversing that winner would have changed `enParentId` and `enDepth` on the wire.

## The vocabulary that waits

The reader proposed sixteen types. Ten landed. The rest are recorded here because this is where the next pass will read them.

**Marked as behaviour changes, not applied:**

- **`DbName`** — the identity of one loaded database: the key `DepSolverLookup` resolves, the left half of `db::activityUUID_productUUID`, the value `dbDependsOn` and `cdlSourceDatabase` carry. It has the most sites of anything in the file and would stop a database name from meeting a process reference in the same slot, but it belongs in `Types` and crosses `SharedSolver`, `Matrix` and `Database.Manager`. A move, not an edit.
- **`LoadedDb {ldName, ldDb, ldSolver}`** — the triple every level of the cross-database walk is about, today three or four adjacent positionals in eight signatures. It would stop a solver from one database standing beside the rows of another. Also a cross-module move, and it depends on `DbName`. Note for whoever picks it up: `SharedSolver.csScalings` is `NonEmpty (Text, Database, Vector)` whose third component is a scaling vector, not a solver, so `LoadedDb` does not fit there.
- **`ReferenceExchange`** — the largest win in the whole reading, and the one I most want reviewed. A production process is defined by the product it makes, a treatment process by the waste it takes in and has no product unit to normalise a column to. Today that is `("", 1.0, "")` standing for "none", `maybe 1.0 exchangeAmount` inventing an amount, `maybe ""` inventing a unit, and an activity summary named "Unknown". A `Maybe ReferenceExchange` with a `Produced | Treated` side would decide in one place what five sites decide differently. It changes what `prsProductName` and `prsProductAmount` carry for an activity with no reference, so it is its own pull request.
- **Sort as a type per listing** — `ActivitySort`, `SupplyChainSort`, `ConsumerSort`, `FlowSort`, plus `SortOrder`. Four listings, four different column sets, today one `Maybe Text` with a wildcard arm: `sort=depth` on `/activities` is not an error, it silently runs the BM25 path. Parsing at the edge would make an unknown column a 400. Note: `afcSort` is one field on the shared `ActivityFilterCore` read by three comparators, so this needs the record split or parameterised first.
- **`ClassificationFilter`** with a `ValueMatch` — a triple with a comment explaining its positions, built in four places by `m == "exact"`, and matched by two copies of one rule (`Service.matchClassifications` and `Database.applyStructuredFilters`). It belongs in `Database`, where the second copy already lives.

**Behaviour-free, but their own review:**

- **`NodeId` and `Depth`.** Wire-safe as newtypes: every field they touch is a `Text` or an `Int`, the derived `ToJSONKeyText` coerces the `Text` instance unchanged, `Ord` comes from `Text` so map ordering is identical, and no golden fixture pins the schemas. Held back for one honest reason: they reach `API/Types.hs` and `Types.hs`, which is the same cross-module move refused above for `DbName` and `LoadedDb`, and applying the marker to one and not the other would be inconsistent. Two corrections for whoever lands it: `Depth` needs `Bounded` (`IM.findWithDefault maxBound`), and the dep-graph recursion counts *databases*, not hops from a root, so those two sites are not a `Depth`. Once it lands, `WalkLevel`'s offset and `TreeBuild`'s map key can take their intended types.
- **`TextMatch = Exactly | Loosely`** — `sfExactMatch`, `caExact` and the `Bool` that `findActivitiesByFields` and `applyStructuredFilters` take, whose doc comment has to explain that it also switches the geography and product comparisons. Five modules plus tests.
- **`Page {pageOffset, pageLimit}`** — moved out of this pull request as a behaviour change, on two counts. `API/Types.hs`'s `SearchResults` is a wire record, and collapsing `srOffset` and `srLimit` into one field nests two flat JSON keys. And two of the four paginators clamp the offset while two do not, so stating "the two clamps one shape" would start clamping `/consumers`, which hands the raw value to `srOffset` and to `hasMore = offset + limit < total`; `offset=-5` is reachable. It can come back once it says explicitly that `SearchResults` keeps its two flat fields and each site keeps its own clamp as well as its own default.
- **`ProcessQuery`** — the widest blast radius (every `Capture "processId" Text`, the MCP readers, the CLI) and the weakest of the sixteen, since validation stays in the resolver. Its site list also has to be re-derived: two of the thirteen are flow UUIDs answered with `FlowNotFound`, and one is a database name.

**Considered and dropped, with reasons:** `(ProcessId, Activity)` across nine signatures (two distinct types, no swap possible); the `Either Text` of `resolveRootOnly` (it is the wire's `peResult`, and the rendering rule belongs with the API's error rendering); `exportUniversalMatrixFormat`'s `IO ()` (a one-line pass-through whose type belongs to `Matrix.Export`); the `[(Int, Double)]` sparse columns (`Matrix` owns that shape); `Int` graph node numbers.

**Two honest notes that are not proposed as work.** `isResourceExtraction` decides from a compartment prefix what `bioDirection` states, because an inventory has flows and no exchanges: two rules for one fact by construction, and unifying them would change behaviour. And two branches looping to the same row give two `TreeLoop` nodes with one id, where `M.insert` keeps the last; `Map NodeId (NonEmpty ExportNode)` would be the honest index and would change the wire.

## Splitting the file

Recorded, not proposed. From the signatures alone the file is five clusters that share only `ProcessId` and the loaded database: resolve-and-describe under everything, search and the tree export touching nothing but it, the supply-chain walk reaching into search and into substitutions. No back edge was visible in the signatures, and the bodies were not read to confirm. It should follow the vocabulary rather than precede it.

## What comes next

The bodies pass on the same file, once this merges: the two passes rewrite the same signatures and conflict on every one if run side by side.

## Review round

A fresh reviewer with no author context read the branch and raised three points. All three held, and a seventh commit applies them.

- `RootLevel` carried its reference amount as a second field, which the database and the root process id already determine: exactly the invalid state the type was introduced to remove, since a third caller could write `RootLevel pid 1.0` for an activity whose reference amount is 2.5 and get a chain stated per 1 unit next to a summary saying 2.5. The amount is now read where it is used.
- `ConsumerFilter` asked the same question as `SupplyChainFilter` and answered it with a `Bool`, so after this change one question had two types in one file. It carries `Edges` too, as `cnfEdges`.
- One comment said what the parameters used to be, which describes the diff rather than the code.

Nothing was rejected. The reviewer independently checked the behaviour-preservation claims against the code rather than the description: `exchangeIsInput` on a `BiosphereExchange` is `bioDirection == Resource`, `ProcessRef`'s field order matches `dbProcessIdTable`'s, `Collected`'s `Semigroup` equals the `merge3` fold, the two `WalkLevel` constructions map one-to-one onto the old four-argument tuples, `TreeBuild` threads in the same order with the last writer kept, and `TreeStats` really was dead. Build, suite and string-literal diff were re-run after the fixes with the same result.
