### PR TITLE
Say which source block a process came out of, and how big it is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,13 @@
   The key a database was divided under, and the source whose files it reads,
   now travel with its status, so a column of shares can say whether the source
   stated them or a property recomputed them. Wire revision 20.
+- An activity summary now names the source block the process came out of, and
+  says how many products that block holds. A listing showing the five
+  coproducts of one dairy block had no way to gather them: the process id
+  names the product, and the activity UUID alone hashes together the SimaPro
+  blocks that share a truncated process name. The block name is for comparing
+  and never for reading, and the count is what lets a page say it is showing
+  only part of a block rather than the whole of it. Wire revision 20.
 - A flow search can name several kinds at once: `kind=biosphere,waste` keeps
   what is exchanged with nature or discarded and nothing else, in one listing.
   `search-counts` already answers that pair as a single number, and there was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,8 @@
 - An activity summary now names the source block the process came out of, and
   says how many products that block holds. A listing showing the five
   coproducts of one dairy block had no way to gather them: the process id
-  names the product, and the activity UUID alone hashes together the SimaPro
-  blocks that share a truncated process name. The block name is for comparing
+  names the product, not the block it was written in. The block name is for
+  comparing
   and never for reading, and the count is what lets a page say it is showing
   only part of a block rather than the whole of it. Wire revision 20.
 - A flow search can name several kinds at once: `kind=biosphere,waste` keeps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
   names the product, not the block it was written in. The block name is for
   comparing
   and never for reading, and the count is what lets a page say it is showing
-  only part of a block rather than the whole of it. Wire revision 20.
+  only part of a block rather than the whole of it. Wire revision 21.
 - A flow search can name several kinds at once: `kind=biosphere,waste` keeps
   what is exchanged with nature or discarded and nothing else, in one listing.
   `search-counts` already answers that pair as a single number, and there was

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -1326,7 +1326,7 @@ and nothing else does, which is what lets a listing gather them.
 ``block_products`` is how many products that block holds, so a page
 showing fewer rows than that knows it is showing part of a block and not
 the whole of it. Both are ``None`` against an engine older than wire
-revision 20.
+revision 21.
 
 | Field | Type | Default |
 |-------|------|---------|

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -1320,6 +1320,14 @@ the declared key. It is ``None`` outside an activity's own product list,
 when the block's products are not all stated in a mass, and against an
 engine older than wire revision 15.
 
+``block`` names the source block the process came out of, as a value to
+compare and never to read: the coproducts of one block carry the same one
+and nothing else does, which is what lets a listing gather them.
+``block_products`` is how many products that block holds, so a page
+showing fewer rows than that knows it is showing part of a block and not
+the whole of it. Both are ``None`` against an engine older than wire
+revision 20.
+
 | Field | Type | Default |
 |-------|------|---------|
 | `process_id` | `str` | _required_ |
@@ -1331,6 +1339,8 @@ engine older than wire revision 15.
 | `allocation_percent` | `float \| None` | None |
 | `allocation_formula` | `str \| None` | None |
 | `mass_allocation_percent` | `float \| None` | None |
+| `block` | `str \| None` | None |
+| `block_products` | `int \| None` | None |
 
 ### `ActivityContribution`
 

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -556,6 +556,14 @@ class Activity(FromJson):
     the declared key. It is ``None`` outside an activity's own product list,
     when the block's products are not all stated in a mass, and against an
     engine older than wire revision 15.
+
+    ``block`` names the source block the process came out of, as a value to
+    compare and never to read: the coproducts of one block carry the same one
+    and nothing else does, which is what lets a listing gather them.
+    ``block_products`` is how many products that block holds, so a page
+    showing fewer rows than that knows it is showing part of a block and not
+    the whole of it. Both are ``None`` against an engine older than wire
+    revision 20.
     """
 
     process_id: str
@@ -567,6 +575,8 @@ class Activity(FromJson):
     allocation_percent: float | None = None
     allocation_formula: str | None = None
     mass_allocation_percent: float | None = None
+    block: str | None = None
+    block_products: int | None = None
 
 
 @dataclass

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -563,7 +563,7 @@ class Activity(FromJson):
     ``block_products`` is how many products that block holds, so a page
     showing fewer rows than that knows it is showing part of a block and not
     the whole of it. Both are ``None`` against an engine older than wire
-    revision 20.
+    revision 21.
     """
 
     process_id: str

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1318,7 +1318,10 @@ appears that a client must know about /before/ calling it. Adding a route
 does not exempt a change from the bump: an absent route answers 404, and so
 does a request naming a database the engine has not loaded, so a client
 cannot tell "this engine is too old" from "you asked for the wrong thing"
-(revision 20: the @derive@ route, which reads a source again under another
+(revision 21: the @block@ an activity summary carries, and the
+@blockProducts@ beside it, so a listing can gather the coproducts of one
+source block and say when it is showing only part of one;
+revision 20: the @derive@ route, which reads a source again under another
 allocation key, and the @allocation@ and @source@ a database status carries,
 without which a column of shares cannot say whether the source stated them;
 revision 19: the @kind@ parameter of a flow search naming several kinds,
@@ -1355,7 +1358,7 @@ the whole filtered set).
 Clients compare it to decide compatibility and to gate such capabilities.
 -}
 currentWireVersion :: Int
-currentWireVersion = 20
+currentWireVersion = 21
 
 getVersion :: AppM Value
 getVersion = do

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -199,8 +199,7 @@ data ActivitySummary = ActivitySummary
     {- ^ The source block this process came out of, as a name to compare and
     never to read: the coproducts of one block carry the same one and nothing
     else does. A listing gathers its rows on it, which the process id cannot
-    do -- it names the product, and the activity UUID alone hashes together
-    the SimaPro blocks that share a process name.
+    do: it names the product, not the block it was written in.
     -}
     , prsBlockProducts :: Int
     {- ^ How many products that block holds, which is not the number of rows

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -195,6 +195,18 @@ data ActivitySummary = ActivitySummary
     , prsAllocationFormula :: Maybe Text -- Raw SimaPro allocation formula; Nothing if purely numeric
     , prsMassAllocationPercent :: Maybe Double -- What the share would be if the key were the product's mass (%, 0..100), to be read beside the declared one; Nothing outside a block's own product list, on a block of one product or one whose source declares no share, and when its products are not all stated in a mass
     , prsNativeType :: Maybe NativeActivityType -- Source-native activity type (ecospold @activityType, SimaPro Type, ILCD processType); Nothing when source lacks the field
+    , prsBlock :: Text
+    {- ^ The source block this process came out of, as a name to compare and
+    never to read: the coproducts of one block carry the same one and nothing
+    else does. A listing gathers its rows on it, which the process id cannot
+    do -- it names the product, and the activity UUID alone hashes together
+    the SimaPro blocks that share a process name.
+    -}
+    , prsBlockProducts :: Int
+    {- ^ How many products that block holds, which is not the number of rows
+    a page shows of it: a page holding the last row of a block has no other
+    way to say the block goes on.
+    -}
     }
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped ActivitySummary)

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -287,6 +287,7 @@ convertToInventoryExport db bioFlowDB unitDB processId rootActivity inventory =
                     M.fromListWith (+) [(ifdCategory f, 1) | f <- flowDetails]
 
         !(prodName, prodAmount, prodUnit) = getReferenceProductInfo (dbTechFlows db) unitDB rootActivity
+        !rootBlock = sourceBlockOf db processId rootActivity
 
         !metadata =
             InventoryMetadata
@@ -302,6 +303,8 @@ convertToInventoryExport db bioFlowDB unitDB processId rootActivity inventory =
                         , prsAllocationFormula = dsFormula =<< activityReferenceShare rootActivity
                         , prsMassAllocationPercent = Nothing
                         , prsNativeType = activityNativeType rootActivity
+                        , prsBlock = sbName rootBlock
+                        , prsBlockProducts = sbProducts rootBlock
                         }
                 , imTotalFlows = length flowDetails
                 , imEmissionFlows = emissionFlows
@@ -1322,6 +1325,7 @@ cross-DB unit DB build the record by hand.
 mkActivitySummary :: Database -> ProcessId -> Activity -> ActivitySummary
 mkActivitySummary db processId activity =
     let (prodName, prodAmount, prodUnit) = getReferenceProductInfo (dbTechFlows db) (dbUnits db) activity
+        block = sourceBlockOf db processId activity
      in ActivitySummary
             { prsProcessId = processIdToText db processId
             , prsActivityName = activityName activity
@@ -1333,6 +1337,8 @@ mkActivitySummary db processId activity =
             , prsAllocationFormula = dsFormula =<< activityReferenceShare activity
             , prsMassAllocationPercent = Nothing
             , prsNativeType = activityNativeType activity
+            , prsBlock = sbName block
+            , prsBlockProducts = sbProducts block
             }
 
 {- | Placeholder summary surfaced when the products index points at a
@@ -1352,6 +1358,8 @@ unknownActivitySummary db pid =
         , prsAllocationFormula = Nothing
         , prsMassAllocationPercent = Nothing
         , prsNativeType = Nothing
+        , prsBlock = processIdToText db pid
+        , prsBlockProducts = 1
         }
 
 {- | The coproducts of one source dataset block, as 'ActivitySummary'. Keyed on
@@ -1512,6 +1520,8 @@ crossDBLinkToSummary link =
         , prsAllocationFormula = Nothing
         , prsMassAllocationPercent = Nothing
         , prsNativeType = Nothing
+        , prsBlock = supplierRefText link
+        , prsBlockProducts = 1
         }
 
 {- | Resolve an exchange's target as 'ActivitySummary', falling back to the
@@ -1912,6 +1922,7 @@ buildSupplyChainFromScalingVector db dbName processId supplyVec scf =
                 (RootLevel processId)
                 supplyVec
                 scf
+        rootBlock = sourceBlockOf db processId rootActivity
         rootSummary =
             ActivitySummary
                 { prsProcessId = processIdToText db processId
@@ -1927,6 +1938,8 @@ buildSupplyChainFromScalingVector db dbName processId supplyVec scf =
                 , prsAllocationFormula = dsFormula =<< activityReferenceShare rootActivity
                 , prsMassAllocationPercent = Nothing
                 , prsNativeType = activityNativeType rootActivity
+                , prsBlock = sbName rootBlock
+                , prsBlockProducts = sbProducts rootBlock
                 }
      in SupplyChainResponse
             { scrRoot = rootSummary
@@ -1962,6 +1975,7 @@ buildSupplyChainFromScalingVectorCrossDB ::
 buildSupplyChainFromScalingVectorCrossDB unitCfg depLookup rootDb rootDbName rootPid rootScaling extraLinks scf = do
     let rootActivity = dbActivities rootDb V.! fromIntegral rootPid
         rootRefAmount = getReferenceProductAmount rootActivity
+        rootBlock = sourceBlockOf rootDb rootPid rootActivity
         rootCollected =
             collectSupplyChainEntries
                 rootDb
@@ -1984,6 +1998,8 @@ buildSupplyChainFromScalingVectorCrossDB unitCfg depLookup rootDb rootDbName roo
                 , prsAllocationFormula = dsFormula =<< activityReferenceShare rootActivity
                 , prsMassAllocationPercent = Nothing
                 , prsNativeType = activityNativeType rootActivity
+                , prsBlock = sbName rootBlock
+                , prsBlockProducts = sbProducts rootBlock
                 }
     eDep <- walkDepLevels unitCfg depLookup rootDb rootScaling extraLinks scf 1 S.empty
     pure $ case eDep of

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -671,11 +671,13 @@ data Activity = Activity
     }
     deriving (Generic, NFData, Store)
 
-{- | The coproducts of one source dataset block share this key. A SimaPro CSV
-reuses one @Process name@ across unrelated blocks (it is truncated to 80
-characters, and duplicated outright), so the activity UUID alone over-groups
-them; 'activityNativeId' splits them back apart. Formats without a block
-identifier fall back to grouping by activity UUID, as before.
+{- | The coproducts of one source dataset block share this key: the activity,
+and the block identifier its source published when it published one.
+
+A SimaPro export mints the activity UUID from that identifier, so today the
+second half separates nothing the first does not. It stays because it is what
+says a block, and it is what would tell apart a format that publishes a block
+identifier without minting its UUID from it.
 -}
 activityGroupKey :: UUID -> Activity -> (UUID, Maybe NativeProcessId)
 activityGroupKey actUUID act = (actUUID, activityNativeId act)
@@ -683,9 +685,9 @@ activityGroupKey actUUID act = (actUUID, activityNativeId act)
 {- | The source block one process came out of, as a listing needs to know it.
 
 'sbName' is for comparing, never for reading: every process of one block
-carries the same one and nothing else does. It renders 'activityGroupKey', so
-it tells apart the SimaPro blocks that share a process name where the activity
-UUID alone hashes them together.
+carries the same one and nothing else does. It renders 'activityGroupKey', the
+key a block's coproducts are indexed under, so a row's name and its product
+count are read off one key.
 
 'sbProducts' is how many products the block holds, and it is the second field
 rather than something a reader could count for itself: a page showing the last
@@ -717,7 +719,9 @@ sourceBlockOf db pid act = maybe orphan blockOfRef (processIdToRef db pid)
                   -- separator cannot be read as part of either half and two
                   -- different keys cannot spell one name.
                   sbName = UUID.toText (fst key) <> "/" <> foldMap (\(NativeProcessId native) -> native) (snd key)
-                , sbProducts = max 1 (length (M.findWithDefault [] key (dbActivityProductsIndex db)))
+                , -- A key the index does not know is a block of one, which is
+                  -- what 'orphan' says of a row the table does not know.
+                  sbProducts = maybe 1 length (M.lookup key (dbActivityProductsIndex db))
                 }
 
 {- | Is this dataset filed in its source's obsolete category?

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -680,6 +680,46 @@ identifier fall back to grouping by activity UUID, as before.
 activityGroupKey :: UUID -> Activity -> (UUID, Maybe NativeProcessId)
 activityGroupKey actUUID act = (actUUID, activityNativeId act)
 
+{- | The source block one process came out of, as a listing needs to know it.
+
+'sbName' is for comparing, never for reading: every process of one block
+carries the same one and nothing else does. It renders 'activityGroupKey', so
+it tells apart the SimaPro blocks that share a process name where the activity
+UUID alone hashes them together.
+
+'sbProducts' is how many products the block holds, and it is the second field
+rather than something a reader could count for itself: a page showing the last
+row of a block has no other way to know the block goes on.
+-}
+data SourceBlock = SourceBlock
+    { sbName :: !Text
+    , sbProducts :: !Int
+    }
+    deriving (Show, Eq)
+
+{- | The block a process belongs to, read off the database that holds it.
+
+A process no longer in the table is its own block of one, named the way
+'processIdToText' names it: it is not grouped with anything, which is the
+truth about a row nothing resolves.
+-}
+sourceBlockOf :: Database -> ProcessId -> Activity -> SourceBlock
+sourceBlockOf db pid act = maybe orphan blockOfRef (processIdToRef db pid)
+  where
+    orphan :: SourceBlock
+    orphan = SourceBlock{sbName = processIdToText db pid, sbProducts = 1}
+
+    blockOfRef :: ProcessRef -> SourceBlock
+    blockOfRef ref =
+        let key = activityGroupKey (prActivity ref) act
+         in SourceBlock
+                { -- The UUID is 36 characters whatever it holds, so the
+                  -- separator cannot be read as part of either half and two
+                  -- different keys cannot spell one name.
+                  sbName = UUID.toText (fst key) <> "/" <> foldMap (\(NativeProcessId native) -> native) (snd key)
+                , sbProducts = max 1 (length (M.findWithDefault [] key (dbActivityProductsIndex db)))
+                }
+
 {- | Is this dataset filed in its source's obsolete category?
 
 The tool that writes SimaPro CSV files keeps a retired process in the export,

--- a/test/AllocationSpec.hs
+++ b/test/AllocationSpec.hs
@@ -65,6 +65,8 @@ product_ unitName amount declared = (summary, Just row)
             , prsAllocationFormula = Nothing
             , prsMassAllocationPercent = Nothing
             , prsNativeType = Nothing
+            , prsBlock = ""
+            , prsBlockProducts = 2
             }
 
     row :: Exchange

--- a/test/SourceBlockSpec.hs
+++ b/test/SourceBlockSpec.hs
@@ -3,12 +3,10 @@
 {- | The block name an activity summary carries ('Types.sourceBlockOf').
 
 A listing that wants to show the coproducts of one block together cannot group
-on the process id, which names the product, and must not group on the activity
-UUID alone: a SimaPro export reuses one @Process name@ across unrelated blocks,
-and the UUID minted from a name hashes those into one. The block name renders
-'activityGroupKey', which is the pair that tells them apart, and it travels
-with the count of products the block holds so a page can say when it is
-showing only part of one.
+on the process id, which names the product. The block name renders
+'activityGroupKey', the key a block's coproducts are indexed under, and it
+travels with the count of products the block holds so a page can say when it
+is showing only part of one.
 -}
 module SourceBlockSpec (spec) where
 
@@ -61,8 +59,7 @@ withDatabase csv k = withSystemTempDirectory "source-block" $ \dir -> do
 
 {- | Two blocks written under one process name, each with two coproducts. The
 producer tells them apart by their @Process identifier@ line and nothing else,
-which is the one case where the block name has to say more than the activity
-UUID.
+which is what a block name has to survive.
 -}
 twoBlocksSharingAName :: BS.ByteString
 twoBlocksSharingAName =

--- a/test/SourceBlockSpec.hs
+++ b/test/SourceBlockSpec.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | The block name an activity summary carries ('Types.sourceBlockOf').
+
+A listing that wants to show the coproducts of one block together cannot group
+on the process id, which names the product, and must not group on the activity
+UUID alone: a SimaPro export reuses one @Process name@ across unrelated blocks,
+and the UUID minted from a name hashes those into one. The block name renders
+'activityGroupKey', which is the pair that tells them apart, and it travels
+with the count of products the block holds so a page can say when it is
+showing only part of one.
+-}
+module SourceBlockSpec (spec) where
+
+import qualified Data.ByteString.Char8 as BS
+import Data.List (nub, sort)
+import qualified Data.Vector as V
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+
+import API.Types (ActivitySummary (..))
+import qualified Data.Text as T
+import Database (buildDatabaseWithMatrices)
+import Database.Loader (defaultLoadOptions, loadDatabaseWithLocationAliases)
+import Service (mkActivitySummary)
+import Types (AllocationKey (..), BuildInputs (..), Database (..))
+import UnitConversion (defaultUnitConfig)
+
+spec :: Spec
+spec = describe "the source block an activity summary names" $ do
+    it "separates two blocks that share a process name" $
+        withDatabase twoBlocksSharingAName $ \summaries -> do
+            -- Four processes, two blocks of two products.
+            map prsProductName summaries
+                `shouldMatchList` ["Cheese", "Whey", "Steel", "Slag"]
+            length (nub (map prsBlock summaries)) `shouldBe` 2
+            sort (map prsBlockProducts summaries) `shouldBe` [2, 2, 2, 2]
+
+    it "gives the coproducts of one block the same name" $
+        withDatabase twoBlocksSharingAName $ \summaries -> do
+            let blockOf name = [prsBlock s | s <- summaries, prsProductName s == name]
+            blockOf "Cheese" `shouldBe` blockOf "Whey"
+            blockOf "Cheese" `shouldNotBe` blockOf "Steel"
+
+    it "names a block of one product too, so every row has one" $
+        withDatabase oneBlockOneProduct $ \summaries -> do
+            map prsBlockProducts summaries `shouldBe` [1]
+            map (T.null . prsBlock) summaries `shouldBe` [False]
+
+-- | Every process of a SimaPro file, summarised the way a search result is.
+withDatabase :: BS.ByteString -> ([ActivitySummary] -> IO ()) -> IO ()
+withDatabase csv k = withSystemTempDirectory "source-block" $ \dir -> do
+    let path = dir </> "source.csv"
+    BS.writeFile path csv
+    loaded <- loadDatabaseWithLocationAliases (defaultLoadOptions defaultUnitConfig) path
+    simpleDb <- either (fail . T.unpack) pure loaded
+    built <- buildDatabaseWithMatrices (BuildInputs defaultUnitConfig mempty Declared) simpleDb
+    db <- either (fail . T.unpack) pure built
+    k [mkActivitySummary db pid act | (pid, act) <- zip [0 ..] (V.toList (dbActivities db))]
+
+{- | Two blocks written under one process name, each with two coproducts. The
+producer tells them apart by their @Process identifier@ line and nothing else,
+which is the one case where the block name has to say more than the activity
+UUID.
+-}
+twoBlocksSharingAName :: BS.ByteString
+twoBlocksSharingAName =
+    simaProFile
+        ( block "P-1" ["Cheese;kg;1;60;not defined;material;", "Whey;kg;3;40;not defined;material;"]
+            ++ block "P-2" ["Steel;kg;1;70;not defined;material;", "Slag;kg;2;30;not defined;material;"]
+        )
+
+-- | One block, one product: it is still a block, and it holds one product.
+oneBlockOneProduct :: BS.ByteString
+oneBlockOneProduct = simaProFile (block "P-1" ["Cheese;kg;1;100;not defined;material;"])
+
+-- | One SimaPro process block under a fixed name, identified by @identifier@.
+block :: BS.ByteString -> [BS.ByteString] -> [BS.ByteString]
+block identifier products =
+    [ "Process"
+    , ""
+    , "Category type"
+    , "material"
+    , ""
+    , "Process identifier"
+    , identifier
+    , ""
+    , "Process name"
+    , "One name for two blocks"
+    , ""
+    , "Type"
+    , "Unit process"
+    , ""
+    , "Geography"
+    , "GLO"
+    , ""
+    , "Products"
+    ]
+        ++ products
+        ++ ["", "End", ""]
+
+simaProFile :: [BS.ByteString] -> BS.ByteString
+simaProFile body =
+    BS.intercalate
+        "\r\n"
+        ( [ "{SimaPro 9.6.0.1}"
+          , "{CSV separator: semicolon}"
+          , "{Decimal separator: .}"
+          , ""
+          ]
+            ++ body
+        )

--- a/volca.cabal
+++ b/volca.cabal
@@ -340,6 +340,7 @@ test-suite lca-tests
                      , AggregateSpec
                      , CopySpec
                      , DeriveSpec
+                     , SourceBlockSpec
                      , AuthorSpec
                      , JournalSpec
                      , ActivityWriteHandlerSpec


### PR DESCRIPTION
## Why

On Agribalyse 3.2, 522 of the 20 019 process blocks carry more than one product, and they account for 1 592 rows that look nearly identical in a search: the five products of the Abondance dairy block differ only in the tail of their names. A listing that wanted to show them as one group with five children had nothing to group on.

The process id names the product, not the block. `activityGroupKey` is the key the engine already indexes a block's coproducts under, and it never left the engine.

## What this adds

Two fields on `ActivitySummary`, so every listing that returns one gets them:

- `block`, that pair rendered as a name to compare and never to read. Two processes of one block carry the same one and nothing else does.
- `blockProducts`, how many products the block holds.

The count is a field rather than something a reader could work out from the rows it has, because it usually cannot: a page holding the last row of a block has no way to know the block goes on, and a group that silently looks complete is worse than showing no group at all.

Every summary carries a name. A process nothing resolves is its own block of one, named the way its process id is; a cross-database link target is named by its qualified reference. Neither is grouped with anything, which is the truth about them.

Wire revision 21, #384 having landed first and taken 20.

## Checks

`SourceBlockSpec` loads a SimaPro file holding two blocks written under one `Process name`, two coproducts each, and checks that the four rows fall into two block names, that the coproducts of one block share theirs, and that a block of a single product still has a name and reports one product.

A review found the first version of this text arguing the key on a claim that stopped being true at #355, where a SimaPro activity UUID began being minted from the block's own `Process identifier`: the UUID no longer hashes unrelated blocks together, and the native half of the pair no longer separates anything the first half does not. The key stays the pair, which is what the products index is keyed on and what a format publishing a block identifier outside its UUID would be told apart by, but the four places that justified it the old way now say so honestly. Collapsing the pair-keyed index onto the UUID-keyed one is a separate cleanup, not this change.

The Python client now declares the two fields; without them `Activity.from_json` dropped both.


