### PR TITLE
Let a match strategy name only the bridges a matcher can take

### DIFF
--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -231,7 +231,7 @@ import Database.Upload (
 import qualified Database.UploadedDatabase as UploadedDB
 import qualified Method.Coverage as Coverage
 import qualified Method.Explain as Explain
-import Method.Mapping (BuildProvenance (..), CF (..), CFUnit (..), MatchStrategy (..), strategyToText)
+import Method.Mapping (BuildProvenance (..), CF (..), CFUnit (..), provenanceStrategyText, strategyToText)
 import Method.Types (Method (..), MethodCF (..))
 import Types (
     AllocationKey (..),
@@ -498,17 +498,8 @@ coverageReportToAPI mLimit r =
     flowToAPI f =
         BridgedFlowAPI
             { cvfFlowName = Coverage.brfFlowName f
-            , cvfStrategy = strategyLabel (Coverage.brfStrategy f)
+            , cvfStrategy = strategyToText (Coverage.brfStrategy f)
             }
-
--- | Wire label for the bridge that reached a flow (only bridge strategies occur).
-strategyLabel :: MatchStrategy -> Text
-strategyLabel ByCAS = "cas"
-strategyLabel BySynonym = "synonym"
-strategyLabel ByProxy = "proxy"
-strategyLabel ByName = "name"
-strategyLabel ByUUID = "uuid"
-strategyLabel NoMatch = "none"
 
 {- | Copy a loaded database under a new name. The copy is an independent
 in-memory database registered under @newName@; the source is untouched.
@@ -1410,7 +1401,7 @@ explainCFToAPI db method flow explanation =
                 , emaCfUnit = unit
                 , emaMethodFlowName = mcfFlowName (bpSource provenance)
                 , emaMethodCas = mcfCAS (bpSource provenance)
-                , emaMatchStrategy = strategyToText (bpStrategy provenance)
+                , emaMatchStrategy = provenanceStrategyText provenance
                 , emaUnitConversion = Nothing
                 , emaRefusal = Nothing
                 }

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -47,7 +47,7 @@ import qualified GHC.Stats
 import qualified Impact
 import Matrix (Inventory, Vector)
 import qualified Method.Explain as Explain
-import Method.Mapping (BuildProvenance (..), CF (..), LCIAOutcome (..), LongTermMode (..), MappingStats (..), MethodTables (..), TableEntry (..), applyLongTermMode, characterizedFlowIds, computeLCIAScoreFromTables, computeLCIAScoreSetFromTables, computeMappingStats, inventoryContributions, longTermModeFromExclude, lookupEntryForFlow, strategyToText)
+import Method.Mapping (BuildProvenance (..), CF (..), LCIAOutcome (..), LongTermMode (..), MappingStats (..), MethodTables (..), TableEntry (..), applyLongTermMode, characterizedFlowIds, computeLCIAScoreFromTables, computeLCIAScoreSetFromTables, computeMappingStats, inventoryContributions, longTermModeFromExclude, lookupEntryForFlow, provenanceStrategyText, strategyToText)
 import qualified Method.Mapping
 import Method.Types (DamageCategory (..), Method (..), MethodCF (..), MethodCollection (..), NormWeightSet (..), ScoringEvaluation (..), ScoringSet (..), computeFormulaScores)
 import qualified Method.Types as MT
@@ -1222,7 +1222,7 @@ buildFlowEntry db tables uuid =
             , fceFlowCategory = maybe "" bfCompartmentName mFlow
             , fceCfValue = cfValue . teCF . snd <$> mServed
             , fceCfFlowName = mcfFlowName . bpSource <$> provenance
-            , fceMatchStrategy = strategyToText . bpStrategy <$> provenance
+            , fceMatchStrategy = provenanceStrategyText <$> provenance
             }
 
 matchesQuery :: Maybe Text -> Text -> Text -> Bool

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -38,7 +38,7 @@ import Database.RelinkMapping (relinkWithMappingFile)
 import Database.Upload (UploadData (..), UploadResult (..), findMethodDirectory, handleUpload)
 import qualified Database.Upload
 import qualified Database.UploadedDatabase as UploadedDB
-import Method.Mapping (MappingStats (..), MatchStrategy (..), computeMappingStats, mapMethodToFlows)
+import Method.Mapping (MappingStats (..), computeMappingStats, mapMethodToFlows, strategyToText)
 import Method.Types (MethodCF (..))
 import qualified Method.Types
 import Progress
@@ -790,7 +790,7 @@ executeFlowMappingCommand fmt database manager opts = do
                                     ( \(cf, f, strat) ->
                                         putStrLn $
                                             "  ["
-                                                ++ T.unpack (strategyText strat)
+                                                ++ T.unpack (strategyToText strat)
                                                 ++ "] "
                                                 ++ T.unpack (mcfFlowName cf)
                                                 ++ " → "
@@ -843,7 +843,7 @@ executeFlowMappingCommand fmt database manager opts = do
                                                         [ object
                                                             [ "cfName" .= mcfFlowName cf
                                                             , "dbFlowName" .= Types.bfName f
-                                                            , "strategy" .= strategyText strat
+                                                            , "strategy" .= strategyToText strat
                                                             , "cfUUID" .= mcfFlowRef cf
                                                             , "dbFlowUUID" .= Types.bfId f
                                                             ]
@@ -872,14 +872,6 @@ executeFlowMappingCommand fmt database manager opts = do
 
     when True action = action
     when False _ = pure ()
-
-strategyText :: MatchStrategy -> Text
-strategyText ByUUID = "uuid"
-strategyText ByCAS = "cas"
-strategyText ByName = "name"
-strategyText BySynonym = "synonym"
-strategyText ByProxy = "proxy"
-strategyText NoMatch = "none"
 
 -- | Get names of biosphere flows not matched by any CF
 uncharacterizedFlowNames :: Types.Database -> S.Set UUID.UUID -> [Text]

--- a/src/Method/Coverage.hs
+++ b/src/Method/Coverage.hs
@@ -82,8 +82,7 @@ data Reach = Exact | Bridged
 
 {- | An exact-name match is what an exact-string consumer also sees; every other
 strategy is a bridge it would miss. Total on 'MatchStrategy' so a new variant
-forces a decision here. ('NoMatch' cannot occur on a resolved tuple, but the
-match must stay exhaustive.)
+forces a decision here.
 -}
 strategyReach :: MatchStrategy -> Reach
 strategyReach ByName = Exact
@@ -91,7 +90,6 @@ strategyReach ByUUID = Exact
 strategyReach ByCAS = Bridged
 strategyReach BySynonym = Bridged
 strategyReach ByProxy = Bridged
-strategyReach NoMatch = Bridged
 
 {- | Fold a collection's effective per-method mappings into its bridge groups.
 'total' and 'characterized' are the caller's honest counts (from

--- a/src/Method/Explain.hs
+++ b/src/Method/Explain.hs
@@ -299,15 +299,15 @@ direct match, where the rung sentence already says it.
 -}
 provenanceSentence :: BuildProvenance -> Text
 provenanceSentence provenance = case bpStrategy provenance of
-    ByUUID -> ""
-    ByName -> ""
-    BySynonym ->
+    Just ByUUID -> ""
+    Just ByName -> ""
+    Just BySynonym ->
         "That line was tied to this flow's name through a known synonym when the method was loaded."
-    ByCAS ->
+    Just ByCAS ->
         "That line was tied to this flow by CAS number when the method was loaded."
-    ByProxy ->
+    Just ByProxy ->
         "That line stands in for a related substance, and its factor was scaled by a curated conversion factor."
-    NoMatch ->
+    Nothing ->
         "No database flow claimed that line when the method was loaded; it is filed under the name the method itself uses."
 
 {- | The factor as applied, so the sentence stands on its own. The bridge says

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -97,6 +97,7 @@ module Method.Mapping (
     -- * Matching strategies
     MatchStrategy (..),
     strategyToText,
+    provenanceStrategyText,
     findFlowByUUID,
     findFlowByName,
     findFlowByNameComp,
@@ -164,8 +165,6 @@ data MatchStrategy
       direct match so an explicit CF always wins.
       -}
       ByProxy
-    | -- | No match found
-      NoMatch
     deriving (Eq, Show)
 
 {- | Per-strategy mapping counters. Forms a 'Monoid' (field-wise sum, all-zero
@@ -538,7 +537,13 @@ strategyToText ByCAS = "cas"
 strategyToText ByName = "name"
 strategyToText BySynonym = "synonym"
 strategyToText ByProxy = "proxy"
-strategyToText NoMatch = "none"
+
+{- | How an entry was attached, as every surface that reports it words the
+answer. An entry no build-side resolution reached reads @"none"@: it is filed
+under the name the method itself uses, and the read cascade may still serve it.
+-}
+provenanceStrategyText :: BuildProvenance -> Text
+provenanceStrategyText = maybe "none" strategyToText . bpStrategy
 
 -- ──────────────────────────────────────────────
 -- Low-level matching functions (used by built-in MapperHandles)
@@ -698,9 +703,6 @@ computeMappingStats = foldMap (tally . fmap snd . snd)
     tally (Just ByName) = one{msByName = 1}
     tally (Just BySynonym) = one{msBySynonym = 1}
     tally (Just ByProxy) = one{msByProxy = 1}
-    -- 'NoMatch' is not produced by the current matchers; this row exists only
-    -- to keep the match exhaustive. Counts as unmatched if ever introduced.
-    tally (Just NoMatch) = one{msUnmatched = 1}
 
 {- | The unit a CF value is denominated in ('mcfUnit' as parsed — a flow
 reference unit like @"kg"@, or an impact-result expression like @"kg CO2 eq"@).
@@ -724,12 +726,11 @@ data CF = CF
 so keeping provenance in the tables costs a few words per entry.
 -}
 data BuildProvenance = BuildProvenance
-    { bpStrategy :: !MatchStrategy
-    {- ^ 'ByUUID' \/ 'ByName' \/ 'BySynonym' \/ 'ByCAS' \/ 'ByProxy' when a
-    build-side resolution attached the line to a database flow; 'NoMatch'
-    when the entry is keyed under the method's own flow name because no
-    database flow resolved at build time (the read-time cascade can still
-    serve it to a flow arriving at that key).
+    { bpStrategy :: !(Maybe MatchStrategy)
+    {- ^ The bridge a build-side resolution took to attach the line to a
+    database flow; 'Nothing' when the entry is keyed under the method's own
+    flow name because no database flow resolved at build time (the read-time
+    cascade can still serve it to a flow arriving at that key).
     -}
     , bpSource :: !MethodCF
     -- ^ The method line that authored the entry.
@@ -1315,7 +1316,13 @@ strategyPriority ByName = 1
 strategyPriority BySynonym = 2
 strategyPriority ByCAS = 3
 strategyPriority ByProxy = 4
-strategyPriority NoMatch = 4
+
+{- | Cascade rank of a table entry. One no build-side resolution reached ranks
+with 'ByProxy', the least discriminating match: two such entries meeting on one
+key tie here and the comparison falls through to the factor.
+-}
+entryPriority :: BuildProvenance -> Int
+entryPriority = maybe (strategyPriority ByProxy) strategyPriority . bpStrategy
 
 {- | The medium and subcompartment a characterization factor keys on, or
 'Nothing' when it states no compartment at all.
@@ -1695,16 +1702,14 @@ buildMethodTables methodFamily cmap energyDensities mappings =
         | cfValue (teCF ea) >= cfValue (teCF eb) = a
         | otherwise = b
       where
-        p1 = strategyPriority (bpStrategy (teProvenance ea))
-        p2 = strategyPriority (bpStrategy (teProvenance eb))
+        p1 = entryPriority (teProvenance ea)
+        p2 = entryPriority (teProvenance eb)
 
     rawNameMatches cf mflow = case mflow of
         Just (flow, _) -> T.toLower (T.strip (mcfFlowName cf)) == T.toLower (T.strip (bfName flow))
         Nothing -> False
 
-    matchStrategy mflow = case mflow of
-        Just (_, s) -> s
-        Nothing -> NoMatch
+    matchStrategy = fmap snd
 
     -- Use matched flow's name only for name/synonym/proxy matches: those key
     -- the CF under the database flow it resolved to, not the method CF's own name.

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -110,7 +110,7 @@ module Method.Mapping (
     -- * Statistics
     MappingStats (..),
     computeMappingStats,
-    strategyPriority,
+    entryPriority,
 ) where
 
 import Control.Applicative ((<|>))
@@ -1307,8 +1307,8 @@ data SubMatch = ExactSub | MediumLevelSub
 
 {- | Cascade-order rank of a match strategy (UUID → name → synonym → CAS →
 heuristic/expanded): when two CFs collide on one flow or table key, the lower
-rank — the more discriminating match — wins. Exported so diagnostics dedup
-with the same preference the score tables use.
+rank — the more discriminating match — wins. What the score tables actually
+compare is 'entryPriority', which also ranks an entry no resolution reached.
 -}
 strategyPriority :: MatchStrategy -> Int
 strategyPriority ByUUID = 0
@@ -1318,8 +1318,11 @@ strategyPriority ByCAS = 3
 strategyPriority ByProxy = 4
 
 {- | Cascade rank of a table entry. One no build-side resolution reached ranks
-with 'ByProxy', the least discriminating match: two such entries meeting on one
-key tie here and the comparison falls through to the factor.
+with 'ByProxy', the least discriminating match, so the two tie here and the
+entry is chosen on the rungs below: the raw-name rank first, then the factor.
+
+Exported so a consumer ranking entries outside this module reaches the same
+verdict as the score tables do.
 -}
 entryPriority :: BuildProvenance -> Int
 entryPriority = maybe (strategyPriority ByProxy) strategyPriority . bpStrategy
@@ -1566,7 +1569,7 @@ buildMethodTables methodFamily cmap energyDensities mappings =
   where
     cfOf cf = CF (mcfValue cf) (CFUnit (mcfUnit cf))
 
-    entryOf cf mflow = TableEntry (cfOf cf) (BuildProvenance (matchStrategy mflow) cf)
+    entryOf cf mflow = TableEntry (cfOf cf) (BuildProvenance (snd <$> mflow) cf)
 
     -- The Bool rode along only for 'preferBetter''s raw-name rank.
     dropRank = M.map fst
@@ -1708,8 +1711,6 @@ buildMethodTables methodFamily cmap energyDensities mappings =
     rawNameMatches cf mflow = case mflow of
         Just (flow, _) -> T.toLower (T.strip (mcfFlowName cf)) == T.toLower (T.strip (bfName flow))
         Nothing -> False
-
-    matchStrategy = fmap snd
 
     -- Use matched flow's name only for name/synonym/proxy matches: those key
     -- the CF under the database flow it resolved to, not the method CF's own name.

--- a/test/CrossDBInventorySpec.hs
+++ b/test/CrossDBInventorySpec.hs
@@ -169,7 +169,7 @@ spec = do
             uuidEntry fid name v =
                 Mapping.TableEntry (CF v (CFUnit "kg CO2 eq")) $
                     Mapping.BuildProvenance
-                        Mapping.ByUUID
+                        (Just Mapping.ByUUID)
                         MethodCF
                             { mcfFlowRef = fid
                             , mcfFlowName = name

--- a/test/ExplainCFSpec.hs
+++ b/test/ExplainCFSpec.hs
@@ -135,6 +135,13 @@ spec = do
                            , "The factor applied is 29.8 per kg."
                            ]
 
+        it "says a line no database flow claimed is filed under the method's own name" $
+            renderResolution (Characterized (match RungExactName NoMatch) UnitsIdentical)
+                `shouldBe` [ "The factor line \"Methane, fossil\" matches this flow's name and compartment."
+                           , "No database flow claimed that line when the method was loaded; it is filed under the name the method itself uses."
+                           , "The factor applied is 29.8 per kg."
+                           ]
+
         it "spells out the energy content that bridges the units" $
             renderResolution
                 ( Characterized

--- a/test/ExplainCFSpec.hs
+++ b/test/ExplainCFSpec.hs
@@ -110,7 +110,7 @@ flowDBOf flows = M.fromList [(bfId f, f) | f <- flows]
 
 -- | Any match will do where only the outcome's name is under test.
 sampleMatch :: CFMatch
-sampleMatch = CFMatch RungExactName (CF 1 (CFUnit "kg")) (BuildProvenance ByName (cfLine "Methane, fossil" "" "kg" 1))
+sampleMatch = CFMatch RungExactName (CF 1 (CFUnit "kg")) (BuildProvenance (Just ByName) (cfLine "Methane, fossil" "" "kg" 1))
 
 resultsFor :: CFExplanation -> [(RungId, StepResult)]
 resultsFor e = [(stRung s, stResult s) | s <- ceTrail e]
@@ -123,20 +123,20 @@ spec = do
             matchIn unit rung strat = CFMatch rung (CF 29.8 (CFUnit unit)) (provenance strat)
 
         it "a direct name match reads as one" $
-            renderResolution (Characterized (match RungExactName ByName) UnitsIdentical)
+            renderResolution (Characterized (match RungExactName (Just ByName)) UnitsIdentical)
                 `shouldBe` [ "The factor line \"Methane, fossil\" matches this flow's name and compartment."
                            , "The factor applied is 29.8 per kg."
                            ]
 
         it "names the synonym bridge that attached the line" $
-            renderResolution (Characterized (match RungExactName BySynonym) UnitsIdentical)
+            renderResolution (Characterized (match RungExactName (Just BySynonym)) UnitsIdentical)
                 `shouldBe` [ "The factor line \"Methane, fossil\" matches this flow's name and compartment."
                            , "That line was tied to this flow's name through a known synonym when the method was loaded."
                            , "The factor applied is 29.8 per kg."
                            ]
 
         it "says a line no database flow claimed is filed under the method's own name" $
-            renderResolution (Characterized (match RungExactName NoMatch) UnitsIdentical)
+            renderResolution (Characterized (match RungExactName Nothing) UnitsIdentical)
                 `shouldBe` [ "The factor line \"Methane, fossil\" matches this flow's name and compartment."
                            , "No database flow claimed that line when the method was loaded; it is filed under the name the method itself uses."
                            , "The factor applied is 29.8 per kg."
@@ -145,7 +145,7 @@ spec = do
         it "spells out the energy content that bridges the units" $
             renderResolution
                 ( Characterized
-                    (matchIn "MJ" RungEnergyResource ByName)
+                    (matchIn "MJ" RungEnergyResource (Just ByName))
                     (EnergyBridged (EnergyDensity 18.0 "MJ" "kg") DensityForward)
                 )
                 `shouldBe` [ "No factor carries this flow's name. The flow is an energy resource, so its family's factor per unit of energy, from \"Methane, fossil\", applies."
@@ -157,14 +157,14 @@ spec = do
         -- ("kg CO2 eq"): the factor yields that much per base unit, so the
         -- sentence must not read "per kg CO2 eq" — that is the factor backwards.
         it "states a result-expression factor on the flow's base unit" $
-            renderResolution (Characterized (matchIn "kg CO2 eq" RungExactName ByName) (NormalizedToBase "kg"))
+            renderResolution (Characterized (matchIn "kg CO2 eq" RungExactName (Just ByName)) (NormalizedToBase "kg"))
                 `shouldBe` [ "The factor line \"Methane, fossil\" matches this flow's name and compartment."
                            , "The factor is written per kg, so the amount was brought to kg first."
                            , "The factor applied is 29.8 kg CO2 eq per kg."
                            ]
 
         it "says why a refused conversion scores nothing" $
-            renderResolution (ConversionRefused (match RungCasBridge ByCAS) (DimensionalMismatch "kg" "m3"))
+            renderResolution (ConversionRefused (match RungCasBridge (Just ByCAS)) (DimensionalMismatch "kg" "m3"))
                 `shouldBe` [ "No factor carries this flow's name. \"Methane, fossil\" describes the same substance in the same compartment, so its factor applies."
                            , "That line was tied to this flow by CAS number when the method was loaded."
                            , "The factor is written per m3, which does not measure the same thing as this flow's kg. The engine refuses to convert between them, so the flow adds nothing to the score."
@@ -176,7 +176,7 @@ spec = do
 
         it "gives every rung a sentence of its own" $ do
             let sentences =
-                    [ renderResolution (Characterized (match rung ByName) UnitsIdentical)
+                    [ renderResolution (Characterized (match rung (Just ByName)) UnitsIdentical)
                     | rung <- [minBound .. maxBound]
                     ]
             length sentences `shouldBe` length [minBound .. maxBound :: RungId]

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -515,6 +515,43 @@ spec = do
             -- insertion order must not matter
             score (reverse mappings) `shouldBe` 2.0 * 34.5
 
+    describe "a row no database flow claimed at build time" $ do
+        -- Such a row is filed under the method's own flow name, and the
+        -- table-key comparison ranks it with a proxy match: the least
+        -- discriminating rank there is. Two rows meeting on one name key, one
+        -- borrowed through a proxy edge and one nothing resolved, therefore
+        -- tie on rank, and the comparison falls through to the higher factor.
+        -- The tie is stated in one rank table and read in one comparison, and
+        -- neither says it out loud, so it is pinned here.
+        let borrowed = mkCFComp "phosphorus" "water" "" 5.0
+            unresolved = mkCFComp "phosphate" "water" "" 20.0
+
+        it "ranks with a proxy match, so the higher factor decides the key" $ do
+            targetId <- nextRandom
+            probeId <- nextRandom
+            let target = mkFlow targetId "phosphate" "water" Nothing
+                probe = mkFlow probeId "phosphate" "water" Nothing
+                tables =
+                    buildMethodTables
+                        OtherCFFamily
+                        M.empty
+                        M.empty
+                        [ (borrowed, Just (target, ByProxy))
+                        , (unresolved, Nothing)
+                        ]
+            cfValue <$> lookupCFForFlow tables probeId (Just probe) `shouldBe` Just 20.0
+
+        it "borrows the proxy row's own name, which is what makes the two meet" $ do
+            -- Without this the test above proves nothing: the two rows have
+            -- different names, and they compete only because a proxy match
+            -- files its row under the flow it borrowed from.
+            targetId <- nextRandom
+            probeId <- nextRandom
+            let target = mkFlow targetId "phosphate" "water" Nothing
+                probe = mkFlow probeId "phosphate" "water" Nothing
+                proxyOnly = buildMethodTables OtherCFFamily M.empty M.empty [(borrowed, Just (target, ByProxy))]
+            cfValue <$> lookupCFForFlow proxyOnly probeId (Just probe) `shouldBe` Just 5.0
+
     describe "sea-water gate on wildcard fallbacks" $ do
         -- The same emission to the sea, under two methods that differ in one
         -- thing: whether they write a sea-water factor of their own. A method

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -520,37 +520,48 @@ spec = do
         -- table-key comparison ranks it with a proxy match: the least
         -- discriminating rank there is. Two rows meeting on one name key, one
         -- borrowed through a proxy edge and one nothing resolved, therefore
-        -- tie on rank, and the comparison falls through to the higher factor.
+        -- tie on rank, and the entry is chosen on the rungs below: the
+        -- raw-name rank, which neither row here passes, then the factor.
         -- The tie is stated in one rank table and read in one comparison, and
         -- neither says it out loud, so it is pinned here.
-        let borrowed = mkCFComp "phosphorus" "water" "" 5.0
-            unresolved = mkCFComp "phosphate" "water" "" 20.0
+        --
+        -- One case would not pin it: whichever factor is the larger, a rank
+        -- that moved in one direction still returns that row. So both are
+        -- asserted, the higher factor once on each side. Together they fail
+        -- whichever way the unresolved row's rank moves.
+        let borrowedAt = mkCFComp "phosphorus" "water" ""
+            unresolvedAt = mkCFComp "phosphate" "water" ""
 
-        it "ranks with a proxy match, so the higher factor decides the key" $ do
-            targetId <- nextRandom
-            probeId <- nextRandom
-            let target = mkFlow targetId "phosphate" "water" Nothing
-                probe = mkFlow probeId "phosphate" "water" Nothing
-                tables =
-                    buildMethodTables
-                        OtherCFFamily
-                        M.empty
-                        M.empty
-                        [ (borrowed, Just (target, ByProxy))
-                        , (unresolved, Nothing)
-                        ]
-            cfValue <$> lookupCFForFlow tables probeId (Just probe) `shouldBe` Just 20.0
+            servedFor mappings = do
+                targetId <- nextRandom
+                probeId <- nextRandom
+                let target = mkFlow targetId "phosphate" "water" Nothing
+                    probe = mkFlow probeId "phosphate" "water" Nothing
+                    tables = buildMethodTables OtherCFFamily M.empty M.empty (mappings target)
+                pure (cfValue <$> lookupCFForFlow tables probeId (Just probe))
+
+        it "loses the key to a larger factor a proxy match carries" $ do
+            served <-
+                servedFor $ \target ->
+                    [ (borrowedAt 20.0, Just (target, ByProxy))
+                    , (unresolvedAt 5.0, Nothing)
+                    ]
+            served `shouldBe` Just 20.0
+
+        it "takes the key from a smaller factor a proxy match carries" $ do
+            served <-
+                servedFor $ \target ->
+                    [ (borrowedAt 5.0, Just (target, ByProxy))
+                    , (unresolvedAt 20.0, Nothing)
+                    ]
+            served `shouldBe` Just 20.0
 
         it "borrows the proxy row's own name, which is what makes the two meet" $ do
-            -- Without this the test above proves nothing: the two rows have
+            -- Without this the two tests above prove nothing: the rows have
             -- different names, and they compete only because a proxy match
             -- files its row under the flow it borrowed from.
-            targetId <- nextRandom
-            probeId <- nextRandom
-            let target = mkFlow targetId "phosphate" "water" Nothing
-                probe = mkFlow probeId "phosphate" "water" Nothing
-                proxyOnly = buildMethodTables OtherCFFamily M.empty M.empty [(borrowed, Just (target, ByProxy))]
-            cfValue <$> lookupCFForFlow proxyOnly probeId (Just probe) `shouldBe` Just 5.0
+            served <- servedFor $ \target -> [(borrowedAt 5.0, Just (target, ByProxy))]
+            served `shouldBe` Just 5.0
 
     describe "sea-water gate on wildcard fallbacks" $ do
         -- The same emission to the sea, under two methods that differ in one


### PR DESCRIPTION
**Target.** `MatchStrategy` stops being able to say "no match", and the one field that meant it says so with a `Maybe`.

**Axis.** Invalid states.

**Problem.** `MatchStrategy` carries a sixth constructor, `NoMatch` (`Method/Mapping.hs:168`), beside the five bridges a matcher can take; since every matcher already returns `Maybe (BiosphereFlow, MatchStrategy)`, absence has two spellings and `Just (flow, NoMatch)` type-checks, a flow found by not being found. Four functions carry an arm for a value that never reaches them, two of them saying so in a comment rather than in a type (`Method/Mapping.hs:701`, `Method/Coverage.hs:85`).

**Transformation.** Drop `NoMatch`; make `bpStrategy :: !(Maybe MatchStrategy)` and let the compiler enumerate the sites. `provenanceStrategyText` becomes the one place `"none"` lives and `entryPriority` the one place that says an unresolved entry ranks with `ByProxy`, which is what two adjacent lines of `strategyPriority` said between them. The three copies of the strategy-to-string table in `Method/Mapping.hs`, `API/DatabaseHandlers.hs` and `CLI/Command.hs` become one, since once the arm is gone they are identical to a function two of the three files already import.

**Behaviour preserved.** The five bridge words and `"none"` on both API surfaces; the entry that wins a table-key collision; the sentence `provenanceSentence` gives an unresolved entry; the coverage counts. Nothing in the chain derives `Store` or `ToJSON`, so no cache format and no wire schema moves. Three of those were pinned by no test, so the first commit writes them.

**Done when.** Met: five constructors, `Just (flow, NoMatch)` unspellable, one strategy table in the tree, string-literal diff empty over the six files, suite green at 2458 examples. This target needs no second pass.

<details>
<summary>For the next run: not chosen, behaviour changes, numbers</summary>

**Would change behaviour, so reported and not fixed**

- `API/Routes.hs:2172-2174` re-decides with a wildcard a status `Database/Manager.hs:447` already decides, so a `PartiallyLinked` method collection reaches the client as `"unloaded"`; the field is `mcaStatus :: Text` at `API/Types.hs:469` and should hold the status type.
- `cfMediumSub` case-folds the output of `normalizeCompartment` and `flowMediumSub` folds its input, so build and read side key differently as soon as a compartment map's target column carries a capital, and every factor for that medium goes unmatched.
- Seven handlers answer an untyped JSON value; `getHosting` is `toJSON . hostingInfo`, erasing a wire type built two lines earlier whose own comment says it exists so the shape has a name.
- Enumerated query parameters are `Text` in the route type, validated against literals in the handler, whose wildcard re-lists the valid values by hand while the sum type exists.

**Not chosen, ranked**

- `mtBroadcast` and `mtResolution` are one `Map UUID (Double, FlowCFTag)` split by `M.map fst` / `M.map snd` at `Mapping.hs:1847`, two fields whose key sets are equal by construction and by nothing the type says. Behaviour-free, local, strongest candidate for the next run.
- `Medium` and `Subcompartment` carry a normalisation invariant nothing enforces (`Mapping.hs:376-404`); dropped here because the three predicates that would take them fold and normalise their own arguments by design, so it waits until the compartment divergence above is closed.
- Four adjacent `Text` arguments in the LCIA handler chain (`Routes.hs:1710`, `:866`, `:1290`): four namespaces in a row, and `CollectionName` already exists two frames deeper.
- `rawTainted` is a `U.Vector Word8` holding a two-valued fact (`Mapping.hs:886`); the packed `Bool` vector costs nothing. Smallest thing here.
- Below the line: fifteen scoring functions opening on the same three unnamed arguments (a `ScoringBasis` record); the supply-chain query travelling as fifteen to seventeen positional parameters through four signatures in `Routes.hs`; and the compartment vocabulary of `Mapping.hs` (about 230 lines) moving to `Method/Types.hs`, which the five move checks say is pure and cannot cycle, but which should also wait on that divergence.
- Dropped by the reader: all 33 partial-function grep hits are in comments; no wildcard arm is on a sum type; the four "arbitrary" comments each describe a case the code refuses rather than picks; `rawWeights`/`rawTainted` as a vector of records would cost the unboxed layout the precomputation exists for; widening the scoring result to a typed error touches every scoring signature at once.

**Seen, not touched.** Nothing.

**Numbers.** `Method/Mapping.hs` 84 signatures to 86 and 3383 lines to 3389, tuples and `Bool` counts unchanged; `API/Routes.hs` unchanged on every count; the six source files together 8694 lines to 8680.

**Falsifier.** Problem holds; preserves on every count; narrow enough, its smaller boundary rejected because leaving the duplicate tables is this change left half done; three lines pinned by no test, written first.

</details>
