### PR TITLE
Name the three tuples that cross a signature, one of them inside the cache

### DIFF
--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -625,7 +625,7 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
             [] -> CrossDBNotLinked (AliasTargetMissing targetName (Just targetLoc))
             atLoc@((_, firstSe) : _) ->
                 case filter (\(_, se) -> unitsAreCompatible lcUnitConfig unit (seUnit se)) atLoc of
-                    [] -> CrossDBNotLinked (UnitIncompatible unit (seUnit firstSe))
+                    [] -> CrossDBNotLinked UnitIncompatible{uiQueryUnit = unit, uiSupplierUnit = seUnit firstSe}
                     compatible@(_ : _) ->
                         let scored = map (scoreEntry effectiveLocation) compatible
                             !best = maximumBy (comparing cdbScore) scored
@@ -642,7 +642,7 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
                  in if null unitCompatible
                         then
                             -- All candidates failed unit check — report the first supplier's unit
-                            CrossDBNotLinked (UnitIncompatible unit (seUnit firstSe))
+                            CrossDBNotLinked UnitIncompatible{uiQueryUnit = unit, uiSupplierUnit = seUnit firstSe}
                         else
                             -- Filter candidates geographically via policy, then rank survivors
                             let accepted = mapMaybe (classifyEntry effectiveLocation) unitCompatible
@@ -653,7 +653,12 @@ findSupplierInIndexedDBs LinkingContext{..} productName location unit =
                                         -- from "policy rejected an otherwise valid match".
                                         case rejectionReason effectiveLocation unitCompatible of
                                             Just (bestLoc, bestKind) ->
-                                                CrossDBNotLinked (LocationRejectedByPolicy effectiveLocation bestLoc bestKind)
+                                                CrossDBNotLinked
+                                                    LocationRejectedByPolicy
+                                                        { lrRequested = effectiveLocation
+                                                        , lrBestCandidate = bestLoc
+                                                        , lrBestKind = bestKind
+                                                        }
                                             Nothing ->
                                                 CrossDBNotLinked (LocationUnavailable effectiveLocation)
                                     _ ->

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -1862,7 +1862,7 @@ mkGapEdge db stats actUUID prodUUID ex = case ex of
     TechnosphereExchange{} ->
         let name = flowNameOr tfName (sdbTechFlows db)
             reason = case exchangeActivityLinkId ex of
-                Nothing -> GapBlocked (maybe NoNameMatch snd (M.lookup name (cdlUnresolvedProducts stats)))
+                Nothing -> GapBlocked (maybe NoNameMatch upBlocker (M.lookup name (cdlUnresolvedProducts stats)))
                 Just _ -> GapDanglingIdentity
          in Just (edge name reason)
     WasteExchange{} -> Just (edge (flowNameOr wfName (sdbWasteFlows db)) GapWasteInput)
@@ -2150,7 +2150,7 @@ findExchangeCrossDBLink LinkScan{lsCtx = ctx, lsOwnKeys = ownKeys, lsTechFlows =
                 UnitIncompatible _ _ -> []
                 AliasTargetMissing _ _ -> []
          in mempty
-                { cdlUnresolvedProducts = M.singleton (tfName flow) (1, blocker)
+                { cdlUnresolvedProducts = M.singleton (tfName flow) UnresolvedProduct{upDemands = 1, upBlocker = blocker}
                 , cdlLocationUnresolved = unresolved
                 }
 findExchangeCrossDBLink _ _ _ BiosphereExchange{} = mempty
@@ -2250,13 +2250,17 @@ reportCrossDBLinkingStats nActivities stats = do
                 wCutoff
 
     -- Missing suppliers
-    let !missing = sortOn (\(_, (cnt, _)) -> Down cnt) $ M.toList (cdlUnresolvedProducts stats)
+    let !missing = sortOn (Down . upDemands . snd) $ M.toList (cdlUnresolvedProducts stats)
     unless (null missing) $ do
         reportProgress Warning $
             printf "Missing suppliers: %d products unresolved" (length missing)
-        forM_ (take 20 missing) $ \(name, (cnt, blocker)) ->
+        forM_ (take 20 missing) $ \(name, unresolved) ->
             reportProgress Warning $
-                printf "  - %s (%d activities) — %s" (T.unpack name) cnt (showBlocker blocker)
+                printf
+                    "  - %s (%d activities) — %s"
+                    (T.unpack name)
+                    (upDemands unresolved)
+                    (showBlocker (upBlocker unresolved))
         when (length missing > 20) $
             reportProgress Warning $
                 printf "  ... and %d more" (length missing - 20)

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -2132,7 +2132,7 @@ findExchangeCrossDBLink LinkScan{lsCtx = ctx, lsOwnKeys = ownKeys, lsTechFlows =
                 | otherwise -> mempty
     unresolvedStats flow blocker =
         let unresolved = case blocker of
-                LocationRejectedByPolicy req actLoc kind ->
+                LocationRejectedByPolicy{lrRequested = req, lrBestCandidate = actLoc, lrBestKind = kind} ->
                     [ LocationUnresolved
                         { luProduct = tfName flow
                         , luRequested = req
@@ -2147,8 +2147,8 @@ findExchangeCrossDBLink LinkScan{lsCtx = ctx, lsOwnKeys = ownKeys, lsTechFlows =
                         }
                     ]
                 NoNameMatch -> []
-                UnitIncompatible _ _ -> []
-                AliasTargetMissing _ _ -> []
+                UnitIncompatible{} -> []
+                AliasTargetMissing{} -> []
          in mempty
                 { cdlUnresolvedProducts = M.singleton (tfName flow) UnresolvedProduct{upDemands = 1, upBlocker = blocker}
                 , cdlLocationUnresolved = unresolved
@@ -2320,9 +2320,9 @@ reportCrossDBLinkingStats nActivities stats = do
 
 showBlocker :: LinkBlocker -> String
 showBlocker NoNameMatch = "Not found"
-showBlocker (UnitIncompatible q s) = printf "Unit: %s vs %s" (T.unpack q) (T.unpack s)
+showBlocker UnitIncompatible{uiQueryUnit = q, uiSupplierUnit = s} = printf "Unit: %s vs %s" (T.unpack q) (T.unpack s)
 showBlocker (LocationUnavailable loc) = printf "Location: %s" (T.unpack loc)
-showBlocker (LocationRejectedByPolicy req act kind) =
+showBlocker LocationRejectedByPolicy{lrRequested = req, lrBestCandidate = act, lrBestKind = kind} =
     printf "Rejected by policy: %s → %s (%s)" (T.unpack req) (T.unpack act) (T.unpack (locationKindCode kind))
 showBlocker (AliasTargetMissing name mLoc) =
     printf "Mapping target not found: %s%s" (T.unpack name) (maybe "" ((" @ " <>) . T.unpack) mLoc)

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -245,6 +245,7 @@ import Types (
     UUID,
     Unit (..),
     UnitDB,
+    UnresolvedProduct (..),
     allocationKeyText,
     bfCompartmentName,
     bfCompartmentSub,
@@ -3241,11 +3242,11 @@ carry the rich blockers the attribute matcher produced; dangling non-nil gaps
 are tagged 'NoNameMatch'. The two sets are disjoint (nil vs non-nil), so the
 concatenation never duplicates.
 -}
-rankMissingProducts :: Map Text (Int, LinkBlocker) -> Map Text Int -> [(Text, Int, LinkBlocker)]
+rankMissingProducts :: Map Text UnresolvedProduct -> Map Text Int -> [(Text, Int, LinkBlocker)]
 rankMissingProducts blocked dangling =
     sortOn
         (\(_, cnt, _) -> Down cnt)
-        ( [(name, cnt, blocker) | (name, (cnt, blocker)) <- M.toList blocked]
+        ( [(name, upDemands u, upBlocker u) | (name, u) <- M.toList blocked]
             <> [(name, cnt, NoNameMatch) | (name, cnt) <- M.toList dangling]
         )
 

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -299,8 +299,8 @@ data StagedDatabase = StagedDatabase
     -- ^ Parsed data (activities, flows, units)
     , sdConfig :: !DatabaseConfig
     -- ^ Configuration
-    , sdMissingProducts :: ![(Text, Int, LinkBlocker)]
-    -- ^ (product name, count, reason)
+    , sdMissingProducts :: ![(Text, UnresolvedProduct)]
+    -- ^ Product name, and the demands it left unsupplied
     , sdSelectedDeps :: ![Text]
     -- ^ Selected dependency database names
     , sdCrossDBLinks :: ![CrossDBLink]
@@ -3242,25 +3242,25 @@ carry the rich blockers the attribute matcher produced; dangling non-nil gaps
 are tagged 'NoNameMatch'. The two sets are disjoint (nil vs non-nil), so the
 concatenation never duplicates.
 -}
-rankMissingProducts :: Map Text UnresolvedProduct -> Map Text Int -> [(Text, Int, LinkBlocker)]
+rankMissingProducts :: Map Text UnresolvedProduct -> Map Text Int -> [(Text, UnresolvedProduct)]
 rankMissingProducts blocked dangling =
     sortOn
-        (\(_, cnt, _) -> Down cnt)
-        ( [(name, upDemands u, upBlocker u) | (name, u) <- M.toList blocked]
-            <> [(name, cnt, NoNameMatch) | (name, cnt) <- M.toList dangling]
+        (Down . upDemands . snd)
+        ( M.toList blocked
+            <> [(name, UnresolvedProduct{upDemands = cnt, upBlocker = NoNameMatch}) | (name, cnt) <- M.toList dangling]
         )
 
 -- | Project one ranked missing product onto its wire shape.
-blockerToMissingSupplier :: (Text, Int, LinkBlocker) -> MissingSupplier
-blockerToMissingSupplier (name, cnt, blocker) =
-    let reason = blockerReason blocker
-     in MissingSupplier name cnt Nothing (brReason reason) (brDetail reason)
+blockerToMissingSupplier :: (Text, UnresolvedProduct) -> MissingSupplier
+blockerToMissingSupplier (name, unresolved) =
+    let reason = blockerReason (upBlocker unresolved)
+     in MissingSupplier name (upDemands unresolved) Nothing (brReason reason) (brDetail reason)
 
 {- | Missing-supplier list for a staged database: rich blockers from the
 linking stats plus dangling background links a partial import leaves behind
 ('Loader.collectStagedDanglingProductNames'), ranked by demand.
 -}
-stagedMissingProducts :: SimpleDatabase -> CrossDBLinkingStats -> [(Text, Int, LinkBlocker)]
+stagedMissingProducts :: SimpleDatabase -> CrossDBLinkingStats -> [(Text, UnresolvedProduct)]
 stagedMissingProducts sdb stats =
     rankMissingProducts
         (cdlUnresolvedProducts stats)
@@ -3280,7 +3280,7 @@ data SetupSource = SetupSource
     { ssConfig :: !DatabaseConfig
     , ssCounts :: !LinkCounts
     , ssStats :: !CrossDBLinkingStats
-    , ssMissing :: ![(Text, Int, LinkBlocker)]
+    , ssMissing :: ![(Text, UnresolvedProduct)]
     , ssDependencies :: ![DependencyChoice]
     , ssOrigin :: !SetupOrigin
     }

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -568,8 +568,8 @@ extractNodesAndEdges db tree depth parentId acc = case tree of
   where
     insertNode :: Text -> ExportNode -> TreeBuild -> TreeBuild
     insertNode nodeId node built = built{tbNodes = M.insert nodeId node (tbNodes built)}
-    processChild :: Text -> (Double, TechnosphereFlow, LoopAwareTree) -> TreeBuild -> TreeBuild
-    processChild parentPid (quantity, flow, subtree) built =
+    processChild :: Text -> TreeChild -> TreeBuild -> TreeBuild
+    processChild parentPid TreeChild{childAmount = quantity, childFlow = flow, childSubtree = subtree} built =
         let childBuilt = extractNodesAndEdges db subtree (depth + 1) (Just parentPid) built
             edge = mkTechnosphereTreeEdge (dbUnits db) parentPid (getTreeNodeId db subtree) quantity flow
          in childBuilt{tbEdges = edge : tbEdges childBuilt}

--- a/src/Tree.hs
+++ b/src/Tree.hs
@@ -102,7 +102,7 @@ buildNode cfg pid activity visited depth = do
 with its converted amount and recursing. Bails out early when the node
 budget runs out so the tree stays within the 300-node envelope.
 -}
-buildChildren :: TreeConfig -> [Exchange] -> S.Set ProcessId -> Int -> State Int [(Double, TechnosphereFlow, LoopAwareTree)]
+buildChildren :: TreeConfig -> [Exchange] -> S.Set ProcessId -> Int -> State Int [TreeChild]
 buildChildren _ [] _ _ = pure []
 buildChildren cfg (ex : exs) visited depth = do
     budget <- get
@@ -113,7 +113,7 @@ buildChildren cfg (ex : exs) visited depth = do
                 let amount = getConvertedExchangeAmount (tcUnitConfig cfg) db ex (childUnit db flow target)
                 subtree <- buildTarget cfg target visited depth
                 rest <- buildChildren cfg exs visited depth
-                pure ((amount, flow, subtree) : rest)
+                pure (TreeChild{childAmount = amount, childFlow = flow, childSubtree = subtree} : rest)
             _ -> buildChildren cfg exs visited depth
   where
     db = tcDatabase cfg

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1802,9 +1802,13 @@ data AttributeFallback = AttributeFallback
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped AttributeFallback)
 
 {- | One product no dependency supplies: how many activities asked for it,
-and what stopped the first of them. Merging two stats sums the demands and
-keeps that first blocker, so a name blocked for several reasons is reported
-under one of them and counted under all.
+and what stopped the first of them.
+
+The single blocker is a known gap, not a decision: merging two linking runs
+sums the demands and keeps the first blocker, so a product blocked for two
+different reasons is counted under both and named after one. Widening it to a
+count per blocker changes what the setup page and the load log display, so it
+is issue #391 rather than a field of this record.
 -}
 data UnresolvedProduct = UnresolvedProduct
     { upDemands :: !Int

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -733,9 +733,18 @@ only node with no row to name.
 -}
 data LoopAwareTree
     = TreeLeaf !ProcessId !Activity
-    | TreeNode !ProcessId !Activity ![(Double, TechnosphereFlow, LoopAwareTree)] -- Row + activity + (quantity, child product flow, subtree)
+    | TreeNode !ProcessId !Activity ![TreeChild] -- Row + activity + what it consumes
     | TreeLoop !ProcessId !Text !Int -- Already visited, or depth/budget spent: row + ActivityName + Depth
     | TreeMissing !UUID !Text !Int -- Declared link no row satisfies: activity UUID + name + Depth
+
+{- | One branch under a 'TreeNode': how much the parent consumes, the product
+flow the edge is labelled with, and the subtree that supplies it.
+-}
+data TreeChild = TreeChild
+    { childAmount :: !Double
+    , childFlow :: !TechnosphereFlow
+    , childSubtree :: !LoopAwareTree
+    }
 
 -- | Technosphere flow database (deduplicated by UUID)
 type TechFlowDB = M.Map UUID TechnosphereFlow

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1534,14 +1534,19 @@ toSimpleDatabase db =
 data LinkBlocker
     = -- | Product not found at all
       NoNameMatch
-    | -- | queryUnit, supplierUnit
-      UnitIncompatible !Text !Text
+    | -- | The supplier ships that product under a unit the demand cannot use.
+      UnitIncompatible
+        { uiQueryUnit :: !Text
+        , uiSupplierUnit :: !Text
+        }
     | -- | requestedLoc (no fallback found above threshold)
       LocationUnavailable !Text
-    | {- | requestedLoc, bestCandidateLoc, bestCandidateKind — match existed but the database's
-      geography_policy rejected it
-      -}
-      LocationRejectedByPolicy !Text !Text !LocationKind
+    | -- | A match existed and the database's geography_policy rejected it.
+      LocationRejectedByPolicy
+        { lrRequested :: !Text
+        , lrBestCandidate :: !Text
+        , lrBestKind :: !LocationKind
+        }
     | {- | targetName, targetLocation — a relink-mapping row designated a supplier
       that no pinned dependency ships ('Nothing' when the name matches nowhere,
       'Just' the pinned location when the name exists but not there). A curated
@@ -1671,9 +1676,10 @@ surfaces can never name the same blocker differently.
 blockerReason :: LinkBlocker -> BlockerReason
 blockerReason blocker = case blocker of
     NoNameMatch -> BlockerReason "no_name_match" Nothing
-    UnitIncompatible q s -> BlockerReason "unit_incompatible" (Just (q <> " vs " <> s))
+    UnitIncompatible{uiQueryUnit = q, uiSupplierUnit = s} ->
+        BlockerReason "unit_incompatible" (Just (q <> " vs " <> s))
     LocationUnavailable loc -> BlockerReason "location_unavailable" (Just loc)
-    LocationRejectedByPolicy req act kind ->
+    LocationRejectedByPolicy{lrRequested = req, lrBestCandidate = act, lrBestKind = kind} ->
         BlockerReason "location_rejected" (Just (req <> " ↛ " <> act <> " (" <> locationKindCode kind <> ")"))
     AliasTargetMissing name mLoc ->
         BlockerReason "alias_target_missing" (Just (name <> maybe "" (" @ " <>) mLoc))

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1786,14 +1786,27 @@ data AttributeFallback = AttributeFallback
     deriving (Show, Eq, Generic, NFData, Store)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped AttributeFallback)
 
+{- | One product no dependency supplies: how many activities asked for it,
+and what stopped the first of them. Merging two stats sums the demands and
+keeps that first blocker, so a name blocked for several reasons is reported
+under one of them and counted under all.
+-}
+data UnresolvedProduct = UnresolvedProduct
+    { upDemands :: !Int
+    -- ^ Activities that asked for this product
+    , upBlocker :: !LinkBlocker
+    -- ^ What stopped the first of them
+    }
+    deriving (Show, Eq, Generic, NFData, Store)
+
 {- | Statistics from cross-database linking
 Only essential state is stored; counts are derived via accessor functions.
 -}
 data CrossDBLinkingStats = CrossDBLinkingStats
     { cdlLinks :: ![CrossDBLink]
     -- ^ Resolved cross-DB links (technosphere + waste)
-    , cdlUnresolvedProducts :: !(M.Map Text (Int, LinkBlocker))
-    -- ^ Product name -> (count, reason)
+    , cdlUnresolvedProducts :: !(M.Map Text UnresolvedProduct)
+    -- ^ Product name -> the demands it left unsupplied
     , cdlUnknownUnits :: !(S.Set Text)
     -- ^ Unknown units from sdbUnits
     , cdlLocationFallbacks :: ![LocationFallback]
@@ -1815,8 +1828,7 @@ data CrossDBLinkingStats = CrossDBLinkingStats
 
 {- | Field-wise '<>'. On unresolved-product collision counts are summed
 and the first 'LinkBlocker' wins (tiebreaker). Hand-written: bare 'Int'
-has no canonical 'Monoid', and the @(Int, LinkBlocker)@ map value is
-not itself a 'Monoid'.
+has no canonical 'Monoid', and 'UnresolvedProduct' is not one either.
 -}
 instance Semigroup CrossDBLinkingStats where
     s1 <> s2 =
@@ -1833,7 +1845,7 @@ instance Semigroup CrossDBLinkingStats where
             , cdlCutoffWasteCount = cdlCutoffWasteCount s1 + cdlCutoffWasteCount s2
             }
       where
-        mergeUnresolved (c1, b) (c2, _) = (c1 + c2, b)
+        mergeUnresolved u1 u2 = u1{upDemands = upDemands u1 + upDemands u2}
 
 instance Monoid CrossDBLinkingStats where
     mempty =
@@ -1880,7 +1892,7 @@ crossDBLinksCount = length . cdlLinks
 
 -- | Number of unresolved inputs
 unresolvedCount :: CrossDBLinkingStats -> Int
-unresolvedCount = sum . map fst . M.elems . cdlUnresolvedProducts
+unresolvedCount = sum . map upDemands . M.elems . cdlUnresolvedProducts
 
 -- | Cross-DB links grouped by source database
 crossDBBySource :: CrossDBLinkingStats -> M.Map Text Int

--- a/test/CacheLayoutSpec.hs
+++ b/test/CacheLayoutSpec.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | The database cache is bytes, and naming a shape it holds must not move them.
+
+'Database.Loader.schemaSignature' hashes the identity of 'Types.Database' and
+nothing inside it, so a layout that shifted under a cache built before the shift
+would not be rejected, it would be decoded as the layout it is not. Giving a
+tuple a constructor and field names is meant to cost exactly nothing here: a
+type with one constructor carries no tag, so it pokes the fields of the tuple it
+replaces, in the order it replaced them. This says that out loud, and fails the
+day it stops being true.
+-}
+module CacheLayoutSpec (spec) where
+
+import Data.Store (encode)
+import Test.Hspec
+
+import Types (LinkBlocker (..), UnresolvedProduct (..))
+
+spec :: Spec
+spec =
+    describe "the shapes the database cache holds" $
+        it "records an unsupplied product as the pair that record replaced" $
+            encode unresolved `shouldBe` encode (upDemands unresolved, upBlocker unresolved)
+  where
+    unresolved :: UnresolvedProduct
+    unresolved = UnresolvedProduct{upDemands = 7, upBlocker = LocationUnavailable "FR"}

--- a/test/CoproductTargetSpec.hs
+++ b/test/CoproductTargetSpec.hs
@@ -43,14 +43,14 @@ spec = do
         it "descends into the coproduct the input asks for" $ do
             db <- twoCoproductFixture
             case treeOfConsumer db of
-                Right (TreeNode _ _ [(_, _, TreeLeaf pid _)]) -> processIdToText db pid `shouldBe` pidText milkId
+                Right (TreeNode _ _ [TreeChild{childSubtree = TreeLeaf pid _}]) -> processIdToText db pid `shouldBe` pidText milkId
                 Right other -> expectationFailure ("unexpected tree shape: " <> show (shapeOf other))
                 Left err -> expectationFailure (show err)
 
         it "keeps a declared link no row satisfies as a visible node" $ do
             db <- danglingLinkFixture
             case treeOfConsumer db of
-                Right (TreeNode _ _ [(_, _, TreeMissing uuid _ _)]) -> uuid `shouldBe` ghostActId
+                Right (TreeNode _ _ [TreeChild{childSubtree = TreeMissing uuid _ _}]) -> uuid `shouldBe` ghostActId
                 Right other -> expectationFailure ("unexpected tree shape: " <> show (shapeOf other))
                 Left err -> expectationFailure (show err)
 
@@ -169,7 +169,7 @@ shapeOf :: LoopAwareTree -> [Text]
 shapeOf (TreeLeaf _ _) = ["leaf"]
 shapeOf (TreeLoop{}) = ["loop"]
 shapeOf (TreeMissing{}) = ["missing"]
-shapeOf (TreeNode _ _ children) = "node" : concatMap (\(_, _, t) -> shapeOf t) children
+shapeOf (TreeNode _ _ children) = "node" : concatMap (shapeOf . childSubtree) children
 
 consumerRow :: Database -> Maybe (ProcessId, Activity)
 consumerRow db = do

--- a/test/CrossLinkingSpec.hs
+++ b/test/CrossLinkingSpec.hs
@@ -23,11 +23,11 @@ spec = do
     -- -----------------------------------------------------------------------
     describe "CrossDBLinkingStats <>" $ do
         it "sums unresolved-product counts per key and keeps the first blocker" $ do
-            let s1 = mempty{cdlUnresolvedProducts = M.fromList [("wheat", (2, NoNameMatch))]} :: CrossDBLinkingStats
-                s2 = mempty{cdlUnresolvedProducts = M.fromList [("wheat", (3, LocationUnavailable "FR")), ("maize", (1, NoNameMatch))]}
+            let s1 = mempty{cdlUnresolvedProducts = M.fromList [("wheat", unresolved 2 NoNameMatch)]} :: CrossDBLinkingStats
+                s2 = mempty{cdlUnresolvedProducts = M.fromList [("wheat", unresolved 3 (LocationUnavailable "FR")), ("maize", unresolved 1 NoNameMatch)]}
                 merged = s1 <> s2
-            M.lookup "wheat" (cdlUnresolvedProducts merged) `shouldBe` Just (5, NoNameMatch)
-            M.lookup "maize" (cdlUnresolvedProducts merged) `shouldBe` Just (1, NoNameMatch)
+            M.lookup "wheat" (cdlUnresolvedProducts merged) `shouldBe` Just (unresolved 5 NoNameMatch)
+            M.lookup "maize" (cdlUnresolvedProducts merged) `shouldBe` Just (unresolved 1 NoNameMatch)
 
         it "adds the scalar counters" $ do
             let s1 = mempty{cdlTotalInputs = 4, cdlWasteExactLinks = 1} :: CrossDBLinkingStats
@@ -447,3 +447,7 @@ loadMin3IndexedDB = do
     case result of
         Left err -> error $ "Failed to load SAMPLE.min3: " ++ show err
         Right simpleDb -> return $ buildIndexedDatabase "SAMPLE.min3" emptySynonymDB simpleDb
+
+-- | An unresolved product with @n@ demands behind it, blocked by @b@.
+unresolved :: Int -> LinkBlocker -> UnresolvedProduct
+unresolved n b = UnresolvedProduct{upDemands = n, upBlocker = b}

--- a/test/CrossLinkingSpec.hs
+++ b/test/CrossLinkingSpec.hs
@@ -226,7 +226,7 @@ spec = do
                         }
             -- "product Y" exists in kg; asking for m3 should fail unit check
             case findSupplierInIndexedDBs ctx "product Y" "GLO" "m3" of
-                CrossDBNotLinked (UnitIncompatible _ _) -> return ()
+                CrossDBNotLinked UnitIncompatible{} -> return ()
                 CrossDBNotLinked reason -> expectationFailure $ "Expected UnitIncompatible but got: " ++ show reason
                 CrossDBLinked{} -> expectationFailure "Expected CrossDBNotLinked for unit mismatch"
 
@@ -323,7 +323,7 @@ spec = do
         it "GeoExact rejects FR query against a GLO candidate with kind=GlobalLoc" $ do
             idb <- loadMin3IndexedDB
             case findSupplierInIndexedDBs (mkCtx GeoExact idb) "product Y" "FR" "kg" of
-                CrossDBNotLinked (LocationRejectedByPolicy req actLoc kind) -> do
+                CrossDBNotLinked LocationRejectedByPolicy{lrRequested = req, lrBestCandidate = actLoc, lrBestKind = kind} -> do
                     req `shouldBe` "FR"
                     actLoc `shouldBe` "GLO"
                     kind `shouldBe` GlobalLoc
@@ -334,7 +334,7 @@ spec = do
         it "GeoParent also rejects a GLO candidate (parent-only does not include global)" $ do
             idb <- loadMin3IndexedDB
             case findSupplierInIndexedDBs (mkCtx GeoParent idb) "product Y" "FR" "kg" of
-                CrossDBNotLinked (LocationRejectedByPolicy _ _ kind) ->
+                CrossDBNotLinked LocationRejectedByPolicy{lrBestKind = kind} ->
                     kind `shouldBe` GlobalLoc
                 CrossDBNotLinked reason ->
                     expectationFailure $ "Expected LocationRejectedByPolicy GlobalLoc but got: " ++ show reason

--- a/test/RelinkMappingSpec.hs
+++ b/test/RelinkMappingSpec.hs
@@ -261,7 +261,7 @@ spec = do
 
         it "surfaces a unit mismatch as UnitIncompatible, never a silent drop" $
             case findSupplierInIndexedDBs (mkCtx aliasMap) consumerName "FR" "m3" of
-                CrossDBNotLinked (UnitIncompatible req got) -> do
+                CrossDBNotLinked UnitIncompatible{uiQueryUnit = req, uiSupplierUnit = got} -> do
                     req `shouldBe` "m3"
                     got `shouldBe` "kg"
                 CrossDBNotLinked other -> expectationFailure $ "Expected UnitIncompatible, got: " ++ show other

--- a/test/TreeSpec.hs
+++ b/test/TreeSpec.hs
@@ -29,7 +29,7 @@ spec = do
             it "second level is also a TreeNode (Y)" $ do
                 tree <- treeFromSample "SAMPLE.min3" sampleMin3ActivityX 10
                 case tree of
-                    TreeNode _ _ [(_, _, subtree)] ->
+                    TreeNode _ _ [TreeChild{childSubtree = subtree}] ->
                         case subtree of
                             TreeNode _ act _ -> activityName act `shouldBe` "production of product Y"
                             _ -> expectationFailure "Expected TreeNode for Y"
@@ -38,7 +38,7 @@ spec = do
             it "leaf node Z is a TreeLeaf with no children" $ do
                 tree <- treeFromSample "SAMPLE.min3" sampleMin3ActivityX 10
                 case tree of
-                    TreeNode _ _ [(_, _, TreeNode _ _ [(_, _, leaf)])] ->
+                    TreeNode _ _ [TreeChild{childSubtree = TreeNode _ _ [TreeChild{childSubtree = leaf}]}] ->
                         case leaf of
                             TreeLeaf _ act -> activityName act `shouldBe` "production of product Z"
                             _ -> expectationFailure "Expected TreeLeaf for Z"
@@ -47,7 +47,7 @@ spec = do
             it "edge amount from X to Y is 0.6" $ do
                 tree <- treeFromSample "SAMPLE.min3" sampleMin3ActivityX 10
                 case tree of
-                    TreeNode _ _ [(amount, _, _)] -> amount `shouldBe` 0.6
+                    TreeNode _ _ [TreeChild{childAmount = amount}] -> amount `shouldBe` 0.6
                     _ -> expectationFailure "Expected TreeNode for X"
 
         -- -----------------------------------------------------------------------
@@ -57,7 +57,7 @@ spec = do
             it "depth=1 — Y becomes a TreeLoop (depth limit)" $ do
                 tree <- treeFromSample "SAMPLE.min3" sampleMin3ActivityX 1
                 case tree of
-                    TreeNode _ _ [(_, _, child)] ->
+                    TreeNode _ _ [TreeChild{childSubtree = child}] ->
                         case child of
                             TreeLoop{} -> return ()
                             _ -> expectationFailure "Expected TreeLoop for Y at depth 1"
@@ -72,7 +72,7 @@ spec = do
             it "depth=2 — Z becomes a TreeLoop at depth 2" $ do
                 tree <- treeFromSample "SAMPLE.min3" sampleMin3ActivityX 2
                 case tree of
-                    TreeNode _ _ [(_, _, TreeNode _ _ [(_, _, leaf)])] ->
+                    TreeNode _ _ [TreeChild{childSubtree = TreeNode _ _ [TreeChild{childSubtree = leaf}]}] ->
                         case leaf of
                             TreeLoop{} -> return ()
                             _ -> expectationFailure "Expected TreeLoop for Z at depth 2"
@@ -128,10 +128,10 @@ treeContainsLoop :: LoopAwareTree -> Bool
 treeContainsLoop (TreeLeaf _ _) = False
 treeContainsLoop (TreeMissing{}) = False
 treeContainsLoop (TreeLoop{}) = True
-treeContainsLoop (TreeNode _ _ children) = any (\(_, _, t) -> treeContainsLoop t) children
+treeContainsLoop (TreeNode _ _ children) = any (treeContainsLoop . childSubtree) children
 
 countNodes :: LoopAwareTree -> Int
 countNodes (TreeLeaf _ _) = 1
 countNodes (TreeMissing{}) = 1
 countNodes (TreeLoop{}) = 1
-countNodes (TreeNode _ _ children) = 1 + sum (map (\(_, _, t) -> countNodes t) children)
+countNodes (TreeNode _ _ children) = 1 + sum (map (countNodes . childSubtree) children)

--- a/volca.cabal
+++ b/volca.cabal
@@ -345,6 +345,7 @@ test-suite lca-tests
                      , JournalSpec
                      , ActivityWriteHandlerSpec
                      , PersistenceSpec
+                     , CacheLayoutSpec
                      , DeleteSelectionSpec
                      , ExportSpec
                      , ExportHandlerSpec
@@ -382,6 +383,7 @@ test-suite lca-tests
                      , toml-reader
                      , openapi3
                      , lens
+                     , store
   build-tool-depends:  hspec-discover:hspec-discover
 
   default-language:    Haskell2010


### PR DESCRIPTION
Three tuples that crossed signatures become records. One of them sits inside the database cache, which is why it was kept out of the previous readability pass and decided here, with the cache-version history open.

Nothing computes differently and nothing on the wire moves: the string literals of every touched file are identical to their previous state, and the 2459 examples are green.

## The one that lives in the cache

`cdlUnresolvedProducts` mapped a product name to `(Int, LinkBlocker)`, and that pair crossed every signature that reads it: the merge of two link runs, the count of unresolved inputs, the gap report, the ranked list the setup page shows, and the load log. It is written to the cache file, and `Database.Loader.schemaSignature` hashes the identity of `Database` and nothing inside it, so a layout that moved here would not be rejected on load, it would be decoded as the layout it is not. That is why the previous pass wrote this one down instead of applying it.

It is now `UnresolvedProduct`, and the merge shrinks to the field that actually changes: the demands add, the first blocker stays, exactly as before. A type with one constructor carries no `Store` tag, so it pokes the fields of the pair it replaces, in order. `test/CacheLayoutSpec.hs` asserts exactly that, byte for byte, and would fail the day it stops holding. No cache-version bump: nothing moved.

Once the record exists, the setup page carries it whole rather than unpacking it into a `(Text, Int, LinkBlocker)` triple that crossed five more signatures.

## The two that do not

`UnitIncompatible` carried the unit asked for and the unit shipped; `LocationRejectedByPolicy` the location asked for and the one that came closest. Both pairs are adjacent `Text`, spelled positionally at every site that builds or reads them, with a comment above the declaration as the only thing saying which was which. Swap either pair and the engine reports the mismatch backwards, in the load log and on the setup page, with nothing to catch it. They now carry field names, and the sites that build them and the four that read a pair out of them use those names.

`TreeNode` held `[(Double, TechnosphereFlow, LoopAwareTree)]`, a triple crossing three signatures. It is now `TreeChild`. That tree is built for SVG export and is never serialised, so nothing about the cache moves with it.

## What was deliberately left positional

`AliasTargetMissing`, `TreeLoop` and `TreeMissing` keep their positional fields. The review that produced this pull request listed all three, and each turns out to be safe by type: `AliasTargetMissing` holds `Text` and `Maybe Text`, `TreeLoop` and `TreeMissing` three arguments of three different types. The swap this change is about does not compile there, and the trailing comment already names them.

The fourth finding of that review, the key `dbActivityProductsIndex` was built on, is gone rather than named: #392 removed the key and the index with it.

## Numbers

`src/Types.hs` is unchanged on all three depth measures (deepest line starts at column 19, none past column 28 or 40): this pass was never about layout. The file grew by the field names and their doc lines.

## What still waits

- Renaming `Activity`'s `exchanges` field to `activityExchanges`: mechanically safe, 509 references across 75 files, and it would bury any other diff beside it.
- The hand-written `Store Database` instance, which lists the same twenty-one fields three times and whose `peek` returns a legal database with no flow indexes. That one changes behaviour and is described in full in the review notes rather than applied.
- A re-read of the three `deduplicate*` helpers, whose key `(product, requested)` is only part of the identity.
- #391: one product keeps one blocker, so a name blocked for two reasons is named after one of them on the setup page and in the load log. Naming the pair made that visible; closing it changes what those two surfaces display.
