### PR TITLE
Group a block by its activity, which is all the key ever did

### DIFF
--- a/src/Database.hs
+++ b/src/Database.hs
@@ -80,7 +80,6 @@ buildDatabaseWithMatrices inputs SimpleDatabase{sdbActivities = activityMap, sdb
                         { dbProcessIdTable = itProcessIdTable tables
                         , dbProcessIdLookup = itProcessIdLookup tables
                         , dbActivityUUIDIndex = itActivityUUIDIndex tables
-                        , dbActivityProductsIndex = itActivityProductsIndex tables
                         , dbProductIndex = productIndex
                         , dbActivities = itActivities tables
                         , dbTechFlows = techFlowDB

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -50,6 +50,8 @@ import Control.Concurrent.STM (STM, atomically, modifyTVar', readTVar, readTVarI
 import Control.Exception (SomeException, try)
 import Control.Monad (when)
 import qualified Data.IntSet as IS
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, isJust)
 import qualified Data.Set as S
@@ -108,7 +110,6 @@ import Service (bm25Retrieve)
 import Types (
     AllocationKey,
     Database (..),
-    NativeProcessId,
     ProcessId,
     allocationKeyText,
     findProcessIdByActivityUUID,
@@ -237,12 +238,12 @@ loadDerived manager slug srcConfig key =
 
 {- | Why the key divided nothing worth keeping, when it did.
 
-The coproducts a key divided share an 'activityGroupKey', so a block it
-divided is several processes under one key and a block it could not is the
-single process it came in as. Counting the first is the only measure of what a
-key did to a database, and both numbers are named: @0 of 4087@ says the source
-carries blocks and none of them could be weighed, where @0 of 0@ would say it
-carries none at all.
+The coproducts a key divided share an activity, so a block it divided is
+several processes under one activity and a block it could not is the single
+process it came in as. Counting the first is the only measure of what a key did
+to a database, and both numbers are named: @0 of 4087@ says the source carries
+blocks and none of them could be weighed, where @0 of 0@ would say it carries
+none at all.
 -}
 dividedRefusal :: AllocationKey -> Text -> Database -> Maybe Text
 dividedRefusal key srcName db
@@ -256,11 +257,11 @@ dividedRefusal key srcName db
                 <> srcName
                 <> ": the result would be that database under another name"
   where
-    blocks :: M.Map (UUID.UUID, Maybe NativeProcessId) [ProcessId]
-    blocks = dbActivityProductsIndex db
+    blocks :: M.Map UUID.UUID (NonEmpty ProcessId)
+    blocks = dbActivityUUIDIndex db
 
     divided :: Int
-    divided = length (filter ((> 1) . length) (M.elems blocks))
+    divided = length (filter ((> 1) . NE.length) (M.elems blocks))
 
 {- | Undo a derivation that will not be kept: unload it, then take its home
 and its cache with 'removeDatabase', which refuses a loaded database.

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -296,6 +296,9 @@ History of manual bumps:
 - 22: the payload records the allocation key the database was divided under
      ('dbBuiltWith'), so a cache of one key is not served to a load asking for
      another. Old caches end before the field.
+- 23: the index of a block's products is gone, the activity UUID index being
+     the same map: the payload has one field fewer, and every field after it
+     would be read at the wrong offset.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.
@@ -303,7 +306,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeRep (Proxy :: Proxy Database))
-     in hi `xor` lo `xor` 22
+     in hi `xor` lo `xor` 23
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.

--- a/src/Database/MatrixBuild.hs
+++ b/src/Database/MatrixBuild.hs
@@ -43,7 +43,6 @@ data InterningTables = InterningTables
     { itProcessIdTable :: !(V.Vector (UUID, UUID))
     , itProcessIdLookup :: !(M.Map (UUID, UUID) ProcessId)
     , itActivityUUIDIndex :: !(M.Map UUID (NonEmpty ProcessId))
-    , itActivityProductsIndex :: !(M.Map (UUID, Maybe NativeProcessId) [ProcessId])
     , itActivities :: !(V.Vector Activity)
     , itActivityCount :: !Int32
     }
@@ -53,12 +52,11 @@ buildInterningTables activityMap =
     InterningTables
         { itProcessIdTable = V.fromList [k | (_, k, _) <- indexed]
         , itProcessIdLookup = M.fromList [(k, pid) | (pid, k, _) <- indexed]
-        , -- One activity, every row it was written as: an allocated activity is
+        , -- One activity, every row it was written as, which is also the
+          -- products of the block it came out of: an allocated activity is
           -- written once per coproduct, and 'M.fromList' would have kept
           -- whichever row came last.
           itActivityUUIDIndex = M.fromListWith (flip (<>)) [(actUUID, pid :| []) | (pid, (actUUID, _), _) <- indexed]
-        , itActivityProductsIndex =
-            M.fromListWith (++) [(activityGroupKey actUUID act, [pid]) | (pid, (actUUID, _), act) <- indexed]
         , itActivities = V.fromList [act | (_, _, act) <- indexed]
         , itActivityCount = fromIntegral (length indexed)
         }

--- a/src/Database/Quality.hs
+++ b/src/Database/Quality.hs
@@ -61,7 +61,6 @@ import Types (
     Unit (..),
     WasteFlow (..),
     activityDeclaredShares,
-    activityGroupKey,
     activityIsObsolete,
     exchangeAmount,
     exchangeFlowId,
@@ -293,16 +292,16 @@ qualityReport dbName db =
         , n /= 1
         ]
 
-    -- The coproducts of one source block share an 'activityGroupKey'. A block
-    -- whose source format has no identifier falls back to grouping by activity
-    -- UUID alone: two SimaPro blocks whose names collide after the format's
-    -- 80-character truncation would then merge, and their percentages sum to
-    -- ~200%. That is the same over-grouping 'Database.MatrixBuild' accepts.
+    -- The coproducts of one source block share an activity. Two SimaPro blocks
+    -- whose names collide after the format's 80-character truncation, and which
+    -- publish no identifier to be told apart by, hash to one activity and merge
+    -- here: their percentages then sum to ~200%. That is the same over-grouping
+    -- 'Database.MatrixBuild' accepts.
     allocationApplicable = any (any isJust . activityDeclaredShares) acts
     allocationGroups =
         M.fromListWith
             (<>)
-            [ (activityGroupKey actUUID act, [(key, act)])
+            [ (actUUID, [(key, act)])
             | (key@(actUUID, _productUUID), act) <- entries
             ]
     allocationOffenders = concatMap allocationGroupOffenders (M.elems allocationGroups)

--- a/src/Database/Rebuild.hs
+++ b/src/Database/Rebuild.hs
@@ -182,7 +182,6 @@ rebuildFromActivities unitConfig db activities =
                         { dbProcessIdTable = itProcessIdTable tables
                         , dbProcessIdLookup = itProcessIdLookup tables
                         , dbActivityUUIDIndex = itActivityUUIDIndex tables
-                        , dbActivityProductsIndex = itActivityProductsIndex tables
                         , dbProductIndex = productIndex
                         , dbActivities = itActivities tables
                         , dbIndexes = indexes

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -287,7 +287,7 @@ convertToInventoryExport db bioFlowDB unitDB processId rootActivity inventory =
                     M.fromListWith (+) [(ifdCategory f, 1) | f <- flowDetails]
 
         !(prodName, prodAmount, prodUnit) = getReferenceProductInfo (dbTechFlows db) unitDB rootActivity
-        !rootBlock = sourceBlockOf db processId rootActivity
+        !rootBlock = sourceBlockOf db processId
 
         !metadata =
             InventoryMetadata
@@ -1121,7 +1121,7 @@ Note: This function requires the ProcessId to get the activity UUID
 convertActivityForAPI :: Database -> ProcessId -> Activity -> ActivityForAPI
 convertActivityForAPI db processId activity =
     let allProducts = case processIdToRef db processId of
-            Just ref -> getAllProductsForActivity db (activityGroupKey (prActivity ref) activity)
+            Just ref -> getAllProductsForActivity db (prActivity ref)
             Nothing -> []
         (refProdName, refProdAmount, refProdUnit) = getReferenceProductInfo (dbTechFlows db) (dbUnits db) activity
         linkMap = buildCrossDBLinkMap db processId
@@ -1325,7 +1325,7 @@ cross-DB unit DB build the record by hand.
 mkActivitySummary :: Database -> ProcessId -> Activity -> ActivitySummary
 mkActivitySummary db processId activity =
     let (prodName, prodAmount, prodUnit) = getReferenceProductInfo (dbTechFlows db) (dbUnits db) activity
-        block = sourceBlockOf db processId activity
+        block = sourceBlockOf db processId
      in ActivitySummary
             { prsProcessId = processIdToText db processId
             , prsActivityName = activityName activity
@@ -1363,15 +1363,14 @@ unknownActivitySummary db pid =
         }
 
 {- | The coproducts of one source dataset block, as 'ActivitySummary'. Keyed on
-'activityGroupKey', not on the activity UUID alone: SimaPro reuses one process
-name across unrelated blocks, which the UUID hashes to a single value.
+the activity, which is what a block is: its rows differ by their product.
 -}
-getAllProductsForActivity :: Database -> (UUID, Maybe NativeProcessId) -> [ActivitySummary]
-getAllProductsForActivity db groupKey =
-    case M.lookup groupKey (dbActivityProductsIndex db) of
+getAllProductsForActivity :: Database -> UUID -> [ActivitySummary]
+getAllProductsForActivity db actUUID =
+    case M.lookup actUUID (dbActivityUUIDIndex db) of
         Nothing -> []
         Just processIds ->
-            withMassAllocationPercent (biUnitConfig (dbBuiltWith db)) (dbUnits db) (map described processIds)
+            withMassAllocationPercent (biUnitConfig (dbBuiltWith db)) (dbUnits db) (map described (NE.toList processIds))
   where
     {- Each product with the row it was split from, because what a mass key
     would give this block is read from that row: the property it states if it
@@ -1922,7 +1921,7 @@ buildSupplyChainFromScalingVector db dbName processId supplyVec scf =
                 (RootLevel processId)
                 supplyVec
                 scf
-        rootBlock = sourceBlockOf db processId rootActivity
+        rootBlock = sourceBlockOf db processId
         rootSummary =
             ActivitySummary
                 { prsProcessId = processIdToText db processId
@@ -1975,7 +1974,7 @@ buildSupplyChainFromScalingVectorCrossDB ::
 buildSupplyChainFromScalingVectorCrossDB unitCfg depLookup rootDb rootDbName rootPid rootScaling extraLinks scf = do
     let rootActivity = dbActivities rootDb V.! fromIntegral rootPid
         rootRefAmount = getReferenceProductAmount rootActivity
-        rootBlock = sourceBlockOf rootDb rootPid rootActivity
+        rootBlock = sourceBlockOf rootDb rootPid
         rootCollected =
             collectSupplyChainEntries
                 rootDb

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -1068,10 +1068,11 @@ processBlockToActivity unitCfg gp pb@ProcessBlock{..} =
     descriptionLines = maybeToList (nonEmptyText pbComment)
     nativeType = SimaProProcessType <$> nonEmptyText pbType
 
-    -- Block identity. The products' processes share it, so they group together
-    -- even though the activity UUID (a hash of name and location) is not unique:
-    -- a SimaPro "Process name" is truncated to 80 characters and reused verbatim
-    -- across unrelated blocks.
+    -- Block identity, and what 'generateActivityUUID' mints the activity from
+    -- when the block publishes one. That is what keeps two blocks apart where
+    -- their name would not: a SimaPro "Process name" is truncated to 80
+    -- characters and reused verbatim across unrelated blocks, so blocks with no
+    -- identifier fall back to name and location and can still collide there.
     nativeId = NativeProcessId <$> nonEmptyText pbIdentifier
 
     block :: ProductRow -> [ProductRow] -> (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit])

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -671,23 +671,12 @@ data Activity = Activity
     }
     deriving (Generic, NFData, Store)
 
-{- | The coproducts of one source dataset block share this key: the activity,
-and the block identifier its source published when it published one.
-
-A SimaPro export mints the activity UUID from that identifier, so today the
-second half separates nothing the first does not. It stays because it is what
-says a block, and it is what would tell apart a format that publishes a block
-identifier without minting its UUID from it.
--}
-activityGroupKey :: UUID -> Activity -> (UUID, Maybe NativeProcessId)
-activityGroupKey actUUID act = (actUUID, activityNativeId act)
-
 {- | The source block one process came out of, as a listing needs to know it.
 
 'sbName' is for comparing, never for reading: every process of one block
-carries the same one and nothing else does. It renders 'activityGroupKey', the
-key a block's coproducts are indexed under, so a row's name and its product
-count are read off one key.
+carries the same one and nothing else does. It is the activity UUID, because
+that is what a block is: a block is written as one row per product, and those
+rows differ by their product, never by their activity.
 
 'sbProducts' is how many products the block holds, and it is the second field
 rather than something a reader could count for itself: a page showing the last
@@ -705,24 +694,20 @@ A process no longer in the table is its own block of one, named the way
 'processIdToText' names it: it is not grouped with anything, which is the
 truth about a row nothing resolves.
 -}
-sourceBlockOf :: Database -> ProcessId -> Activity -> SourceBlock
-sourceBlockOf db pid act = maybe orphan blockOfRef (processIdToRef db pid)
+sourceBlockOf :: Database -> ProcessId -> SourceBlock
+sourceBlockOf db pid = maybe orphan blockOfRef (processIdToRef db pid)
   where
     orphan :: SourceBlock
     orphan = SourceBlock{sbName = processIdToText db pid, sbProducts = 1}
 
     blockOfRef :: ProcessRef -> SourceBlock
     blockOfRef ref =
-        let key = activityGroupKey (prActivity ref) act
-         in SourceBlock
-                { -- The UUID is 36 characters whatever it holds, so the
-                  -- separator cannot be read as part of either half and two
-                  -- different keys cannot spell one name.
-                  sbName = UUID.toText (fst key) <> "/" <> foldMap (\(NativeProcessId native) -> native) (snd key)
-                , -- A key the index does not know is a block of one, which is
-                  -- what 'orphan' says of a row the table does not know.
-                  sbProducts = maybe 1 length (M.lookup key (dbActivityProductsIndex db))
-                }
+        SourceBlock
+            { sbName = UUID.toText (prActivity ref)
+            , -- An activity the index does not know is a block of one, which
+              -- is what 'orphan' says of a row the table does not know.
+              sbProducts = maybe 1 NE.length (M.lookup (prActivity ref) (dbActivityUUIDIndex db))
+            }
 
 {- | Is this dataset filed in its source's obsolete category?
 
@@ -1102,8 +1087,7 @@ data Database = Database
     { -- UUID interning tables for ProcessId ↔ (UUID, UUID) conversion
       dbProcessIdTable :: !(V.Vector (UUID, UUID)) -- ProcessId (Int32) → (activityUUID, productUUID)
     , dbProcessIdLookup :: !(M.Map (UUID, UUID) ProcessId) -- reverse lookup
-    , dbActivityUUIDIndex :: !(M.Map UUID (NonEmpty ProcessId)) -- Activity UUID → the rows that activity was written as
-    , dbActivityProductsIndex :: !(M.Map (UUID, Maybe NativeProcessId) [ProcessId]) -- 'activityGroupKey' → the ProcessIds of one source block (its coproducts)
+    , dbActivityUUIDIndex :: !(M.Map UUID (NonEmpty ProcessId)) -- Activity UUID → the rows that activity was written as, which is also the products of one source block
     , dbProductIndex :: !ProductIndex -- Product flow → ProcessId lookups (for SimaPro links & product search)
     , dbActivities :: !ActivityDB -- Vector of activities indexed by ProcessId
     , dbTechFlows :: !TechFlowDB -- Technosphere flows by UUID
@@ -1144,7 +1128,6 @@ instance Store Database where
         getSize (dbProcessIdTable db)
             + getSize (dbProcessIdLookup db)
             + getSize (dbActivityUUIDIndex db)
-            + getSize (dbActivityProductsIndex db)
             + getSize (dbProductIndex db)
             + getSize (dbActivities db)
             + getSize (dbTechFlows db)
@@ -1167,7 +1150,6 @@ instance Store Database where
         poke (dbProcessIdTable db)
         poke (dbProcessIdLookup db)
         poke (dbActivityUUIDIndex db)
-        poke (dbActivityProductsIndex db)
         poke (dbProductIndex db)
         poke (dbActivities db)
         poke (dbTechFlows db)
@@ -1193,7 +1175,6 @@ instance Store Database where
         processIdTable <- peek
         processIdLookup <- peek
         activityUUIDIndex <- peek
-        activityProductsIndex <- peek
         productIndex <- peek
         activities <- peek
         techFlows <- peek
@@ -1216,7 +1197,6 @@ instance Store Database where
                 { dbProcessIdTable = processIdTable
                 , dbProcessIdLookup = processIdLookup
                 , dbActivityUUIDIndex = activityUUIDIndex
-                , dbActivityProductsIndex = activityProductsIndex
                 , dbProductIndex = productIndex
                 , dbActivities = activities
                 , dbTechFlows = techFlows

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -666,7 +666,7 @@ data Activity = Activity
     , activityParams :: !(M.Map Text Double) -- Resolved dataset parameter values (SimaPro parameters, EcoSpold2 <parameter> variables)
     , activityParamExprs :: !(M.Map Text Text) -- Raw parameter expressions/formulas keyed like activityParams (for inspection and re-evaluation)
     , activityNativeType :: !(Maybe NativeActivityType) -- Source-format-native activity type (ecospold @activityType, SimaPro Type, ILCD processType); Nothing when source format lacks the field
-    , activityNativeId :: !(Maybe NativeProcessId) -- Source dataset block this activity was read from; groups the coproducts of one block. Nothing when the source format lacks the field
+    , activityNativeId :: !(Maybe NativeProcessId) -- Source dataset block this activity was read from: what the SimaPro parser mints the activity UUID from, and what its writer writes back. Nothing when the source format lacks the field
     , activityFormulaCheck :: !(Maybe FormulaCheck) -- Outcome of the mathematicalRelation consistency check; Nothing when the dataset has no formulas or the format has none
     }
     deriving (Generic, NFData, Store)

--- a/test/CrossDBRegionalLCIAFixture.hs
+++ b/test/CrossDBRegionalLCIAFixture.hs
@@ -138,7 +138,6 @@ mkDB offset locs bioTriples =
             { dbProcessIdTable = procIds
             , dbProcessIdLookup = procIdLookup
             , dbActivityUUIDIndex = M.empty
-            , dbActivityProductsIndex = M.empty
             , dbProductIndex = emptyProductIndex
             , dbActivities = activities
             , dbTechFlows = M.empty

--- a/test/DeriveSpec.hs
+++ b/test/DeriveSpec.hs
@@ -57,7 +57,7 @@ spec = around_ withScratchDataDir $ describe "Database.Edit.deriveDatabase" $ do
             derived <- deriveDatabase manager source "cheese-wet" (ByProperty WetMass)
             db <- either (fail . show) (pure . ldDatabase . fst) derived
             V.length (dbActivities db) `shouldBe` 2
-            M.size (dbActivityProductsIndex db) `shouldBe` 1
+            M.size (dbActivityUUIDIndex db) `shouldBe` 1
             -- The source declares 51 / 49 and would put 5.1 kg of milk behind
             -- the cheese. 1 kg of cheese beside 3 kg of whey is 25 / 75, and
             -- the whole inventory follows the key that divided the block.

--- a/test/QualityReportSpec.hs
+++ b/test/QualityReportSpec.hs
@@ -302,9 +302,12 @@ spec = do
             let db = dbOf [((actA, prodA), allocated "block" (Just (0 / 0)) (Just "b1"))]
             length (qcOffenders (qrAllocationSums (qualityReport "testdb" db))) `shouldBe` 1
 
-        it "keeps same-named blocks with distinct identifiers apart" $ do
+        it "keeps same-named blocks under different activities apart" $ do
             -- Both blocks are internally complete at 100%. Merging them by name
-            -- would sum to 200% and invent two findings.
+            -- would sum to 200% and invent two findings. Their identifiers are
+            -- what earns them two activities: the parser mints the UUID from
+            -- the identifier, so only a block publishing none falls back to a
+            -- name that another block may share.
             let db = dbOf [((actA, prodA), allocated "truncated name" (Just 100) (Just "b1")), ((actB, prodB), allocated "truncated name" (Just 100) (Just "b2"))]
             qcOffenders (qrAllocationSums (qualityReport "testdb" db)) `shouldBe` []
 

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -111,7 +111,6 @@ mkDB locsAndEmissions =
             { dbProcessIdTable = V.fromList [(actUUID i, mkUUID 0) | i <- [0 .. n - 1]]
             , dbProcessIdLookup = M.empty
             , dbActivityUUIDIndex = M.empty
-            , dbActivityProductsIndex = M.empty
             , dbProductIndex = emptyProductIndex
             , dbActivities = activities
             , dbTechFlows = M.empty

--- a/test/SourceBlockSpec.hs
+++ b/test/SourceBlockSpec.hs
@@ -3,10 +3,9 @@
 {- | The block name an activity summary carries ('Types.sourceBlockOf').
 
 A listing that wants to show the coproducts of one block together cannot group
-on the process id, which names the product. The block name renders
-'activityGroupKey', the key a block's coproducts are indexed under, and it
-travels with the count of products the block holds so a page can say when it
-is showing only part of one.
+on the process id, which names the product. The block name is the activity the
+products were written under, and it travels with the count of products the
+block holds so a page can say when it is showing only part of one.
 -}
 module SourceBlockSpec (spec) where
 


### PR DESCRIPTION
A block's coproducts were indexed under a pair: the activity UUID, and the block identifier the source published when it published one. The second half was justified as what would tell apart a format that publishes a block identifier without minting its UUID from it.

No format does. Only the SimaPro parser fills the field at all, and it mints the activity UUID from that same identifier, so two blocks with different identifiers already have different UUIDs, and two blocks with none are both keyed on `Nothing`. The half separated nothing, anywhere.

Once it goes, the block index is keyed on the activity UUID alone, which is exactly what `dbActivityUUIDIndex` already held. So it goes too: one index instead of two identical ones, with a `NonEmpty` that says a key always has a member. `sourceBlockOf` no longer needs the activity to say which block a process came from, and the opaque name a listing groups on is the UUID rather than the UUID with an identifier glued behind a slash.

The identifier itself stays on the activity, where the SimaPro parser mints the UUID from it and the writer reads it to write the `Process identifier` line back out. A second commit corrects the three comments that still described it as what groups a block, one of which had been wrong since the minting started.

No wire field changes shape, and nothing new is said, so the wire revision does not move. Two things do move that a reader should know about:

- The order of `all_products` is reversed. The index that is kept builds its lists in insertion order where the one that is dropped prefixed them, and insertion order is the order of the product UUIDs. Both are hash order, neither is the order of the source file, and no number depends on which: `withMassAllocationPercent` computes shares in the same order it is handed.
- The cache payload has one field fewer, so its schema signature moves to 23. Every cache is read again from source once, which the CHANGELOG already says of this cycle.

`SourceBlockSpec` is the falsification: two blocks written under one process name, told apart only by their `Process identifier`, still come out as two blocks.

Checked with a cold `cabal build all --ghc-options=-Werror`, `hlint src app test`, and the full suite (2454 examples, 0 failures).