### PR TITLE
Report the identifier a source file gave a process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@
   `AGRIBALU000000003103728`, and the number an EcoSpold 1 dataset is published
   under. It is what a reader copies to find the dataset back in the file it
   came from. EcoSpold 2 and ILCD name a dataset by a UUID, which is already the
-  first half of every process id, so they report nothing new here.
+  first half of every process id, so they report nothing new here. Wire
+  revision 22.
 - A database can now be asked for another allocation key without editing the
   configuration file: `POST /api/v1/db/{name}/derive/{newName}?allocation=wet
   mass`, the `derive_database` tool, and `Client.derive_database` in pyvolca.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@
   unit to restate it in.
 
 ### Added
+- An activity now reports the identifier its source file gave it, beside its
+  location: SimaPro's `Process identifier`, which on Agribalyse reads
+  `AGRIBALU000000003103728`, and the number an EcoSpold 1 dataset is published
+  under. It is what a reader copies to find the dataset back in the file it
+  came from. EcoSpold 2 and ILCD name a dataset by a UUID, which is already the
+  first half of every process id, so they report nothing new here.
 - A database can now be asked for another allocation key without editing the
   configuration file: `POST /api/v1/db/{name}/derive/{newName}?allocation=wet
   mass`, the `derive_database` tool, and `Client.derive_database` in pyvolca.

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1318,7 +1318,9 @@ appears that a client must know about /before/ calling it. Adding a route
 does not exempt a change from the bump: an absent route answers 404, and so
 does a request naming a database the engine has not loaded, so a client
 cannot tell "this engine is too old" from "you asked for the wrong thing"
-(revision 21: the @block@ an activity summary carries, and the
+(revision 22: the @nativeId@ an activity carries, the identifier its source
+file gave the dataset block it was read from;
+revision 21: the @block@ an activity summary carries, and the
 @blockProducts@ beside it, so a listing can gather the coproducts of one
 source block and say when it is showing only part of one;
 revision 20: the @derive@ route, which reads a source again under another
@@ -1358,7 +1360,7 @@ the whole filtered set).
 Clients compare it to decide compatibility and to gate such capabilities.
 -}
 currentWireVersion :: Int
-currentWireVersion = 21
+currentWireVersion = 22
 
 getVersion :: AppM Value
 getVersion = do

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -34,7 +34,7 @@ import Database.Author (
  )
 import GHC.Generics
 import Servant.API.ContentTypes (MimeRender (..), MimeUnrender (..), OctetStream)
-import Types (BioDirection (..), BiosphereFlow (..), Compartment (..), DocSection (..), Exchange, ExchangeKind (..), FlowKind (..), NativeActivityType (..), Pedigree, Severity, TechnosphereFlow (..), UUID, Unit, WasteFlow (..), WasteRole (..), exchangeKindName)
+import Types (BioDirection (..), BiosphereFlow (..), Compartment (..), DocSection (..), Exchange, ExchangeKind (..), FlowKind (..), NativeActivityType (..), NativeProcessId (..), Pedigree, Severity, TechnosphereFlow (..), UUID, Unit, WasteFlow (..), WasteRole (..), exchangeKindName)
 
 {- | Tagged wire representation of either side of the flow split.
 
@@ -1614,6 +1614,7 @@ data ActivityForAPI = ActivityForAPI
     , pfaAllProducts :: [ActivitySummary] -- All products from same activityUUID
     , pfaExchanges :: [ExchangeWithUnit] -- Exchanges with unit names
     , pfaNativeType :: Maybe NativeActivityType -- Source-native activity type
+    , pfaNativeId :: Maybe NativeProcessId -- The identifier the source gave the dataset block this came out of (SimaPro's "Process identifier", EcoSpold 1's dataset number); Nothing when the format has none, and when the format's identifier is the activity UUID the process id already spells
     }
     deriving (Generic)
     deriving (ToJSON, FromJSON, ToSchema) via (Stripped ActivityForAPI)
@@ -1861,6 +1862,20 @@ instance ToSchema NativeActivityType where
                             , ("special_label", Inline nullableTextSchema)
                             ]
                     & required .~ ["source", "label"]
+
+{- | A native identifier reaches the wire as the bare string the source wrote,
+because that is the only form it has: we neither parse it nor compare it to
+anything but itself, and a reader is going to paste it back into the file it
+came from.
+-}
+instance ToJSON NativeProcessId where
+    toJSON (NativeProcessId nativeId) = toJSON nativeId
+
+instance FromJSON NativeProcessId where
+    parseJSON = fmap NativeProcessId . parseJSON
+
+instance ToSchema NativeProcessId where
+    declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy Text)
 
 instance ToJSON NodeType
 instance ToJSON EdgeType

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -299,6 +299,10 @@ History of manual bumps:
 - 23: the index of a block's products is gone, the activity UUID index being
      the same map: the payload has one field fewer, and every field after it
      would be read at the wrong offset.
+- 24: an EcoSpold 1 activity now carries the number its dataset is published
+     under, in a field that already existed and was already stored. Nothing
+     changes type, so a cache written just before this would pass the
+     fingerprint and go on reporting that those datasets have no identifier.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.
@@ -306,7 +310,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeRep (Proxy :: Proxy Database))
-     in hi `xor` lo `xor` 23
+     in hi `xor` lo `xor` 24
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -664,6 +664,17 @@ documentationSections d =
     otherSources = IM.elems (IM.delete (ddPublishedSource d) (ddSources d))
     reviewer = maybe "" (\p -> "(" <> p <> ")") (IM.lookup (ddValidator d) (ddPersons d) >>= nonEmptyText)
 
+{- | The number a dataset is published under, as the identifier its source gave
+it. It is what an EcoSpold 1 file prints beside a process and what its own
+exchanges name to reach it, so it is the string a reader has in hand.
+
+Zero is 'psDatasetNumber' saying the dataset declared no number, or one that
+would not parse, rather than a dataset numbered zero.
+-}
+datasetIdentifier :: Int -> Maybe NativeProcessId
+datasetIdentifier 0 = Nothing
+datasetIdentifier n = Just (NativeProcessId (T.pack (show n)))
+
 -- | Build the final per-dataset result, applying the cut-off strategy.
 buildResult :: ParseState -> Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit], Int, M.Map UUID Int)
 buildResult st =
@@ -693,7 +704,7 @@ buildResult st =
                 , activityParams = M.empty
                 , activityParamExprs = M.empty
                 , activityNativeType = Nothing
-                , activityNativeId = Nothing
+                , activityNativeId = datasetIdentifier (psDatasetNumber st)
                 , activityFormulaCheck = Nothing
                 }
         pack act =

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -1140,6 +1140,7 @@ convertActivityForAPI db processId activity =
             , pfaAllProducts = allProducts
             , pfaExchanges = map (toExchangeWithUnit db linkMap) (exchanges activity)
             , pfaNativeType = activityNativeType activity
+            , pfaNativeId = activityNativeId activity
             }
 
 {- | Resolved target activity for a technosphere or waste exchange. Either all

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -579,10 +579,15 @@ data NativeActivityType
     deriving (Show, Eq, Generic, NFData, Store)
 
 {- | The identifier a source format gives the dataset block an activity was read
-from (SimaPro's @Process identifier@ header). Two blocks that happen to share a
-name and a location are still two activities, and 'activityUUID' — a hash of
-name and location — cannot tell them apart; this can. 'Nothing' when the source
-format has no such field, which restores grouping by 'activityUUID' alone.
+from: SimaPro's @Process identifier@ header, EcoSpold 1's @number@ attribute on
+the dataset. It is what the SimaPro parser mints the activity UUID from, so it
+is also what keeps two blocks apart where their name and location would not, and
+it is what a reader copies to find the dataset back in its source file.
+
+'Nothing' when the source format has no such field, and also when EcoSpold 2 or
+ILCD name a dataset: there the identifier /is/ the activity UUID, already
+spelled out in every process id, and repeating it here would give one fact two
+homes.
 
 Not a 'ProcessId': that one is a matrix row index, minted by 'buildInterningTables'.
 This is the source's own string, opaque to us and stable only within one release

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -53,6 +53,15 @@ minimalXml =
         , "</ecoSpold>"
         ]
 
+-- | 'minimalXml' with the @number@ attribute taken off its dataset element.
+unnumberedXml :: BC.ByteString
+unnumberedXml = BC.unlines (map withoutNumber (BC.lines minimalXml))
+  where
+    withoutNumber :: BC.ByteString -> BC.ByteString
+    withoutNumber line
+        | "  <dataset number=" `BC.isPrefixOf` line = "  <dataset>"
+        | otherwise = line
+
 {- | The same two elementary flows as 'minimalXml', in another dataset written
 by another author. The @<person number>@ sits where EcoSpold1 metadata really
 carries one: under @<dataset>@, after the dataset's own number. The reference
@@ -452,6 +461,20 @@ spec = do
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
                 Right (_, _, _, _, _, num, _) -> num `shouldBe` 42
+
+        it "keeps the dataset number as the identifier the source gave it" $
+            case parseWithXeno minimalXml of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right (act, _, _, _, _, _, _) ->
+                    activityNativeId act `shouldBe` Just (NativeProcessId "42")
+
+        -- A missing or unparseable number is read as 0, which is the loader
+        -- saying the dataset published none. Displaying that as the identifier
+        -- would put a number on a dataset that never had one.
+        it "gives no identifier to a dataset that publishes no number" $
+            case parseWithXeno unnumberedXml of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right (act, _, _, _, _, _, _) -> activityNativeId act `shouldBe` Nothing
 
         it "produces 4 exchanges" $
             case parseWithXeno minimalXml of


### PR DESCRIPTION
A dataset carries two names: one a reader searches, and one a reader matches.
Only the first reached the wire. Somebody holding a SimaPro export open beside
the engine reads `AGRIBALU000000003103728` on the page and has no way to ask
the engine what it made of that block.

An activity now reports it, as `nativeId`.

## What each format has to say

| Format | Its identifier | Before | After |
|---|---|---|---|
| SimaPro CSV | `Process identifier` | read, hashed into the activity UUID, never shown | reported |
| EcoSpold 1 | `<dataset number="...">` | read only to resolve links between datasets, then dropped | reported |
| EcoSpold 2 | activity id | it *is* the activity UUID | unchanged, nothing new to report |
| ILCD | process UUID | it *is* the activity UUID | unchanged, nothing new to report |
| Brightway Excel | none | | |

EcoSpold 2 and ILCD are left silent on purpose. Their identifier is already
spelled out as the first half of every process id, and copying it into a second
field would give one fact two homes that could disagree.

## Consequences worth knowing

Filling the field for EcoSpold 1 also means a database read from that format
and written back out as SimaPro now carries its dataset numbers into the
`Process identifier` line, which is where they belong.

A dataset that publishes no number keeps no identifier: the parser reads a
missing or unparseable number as zero, and zero is it saying there was none,
not a dataset numbered zero. A test holds that.

The `NativeProcessId` haddock claimed the activity UUID was a hash of name and
location that this field could tell apart. That has been circular since the
SimaPro parser started minting the UUID from this very field. It now says what
the field is actually for.

Wire revision 22, cache signature 24.

## Review

Reviewed by a fresh agent with no author context.

**Confirmed, fixed in `facf331`.** The cache signature had to move. It is a type
fingerprint, and filling a field that already existed changes no type, so a
cache written by an engine built since the previous bump would have passed the
check and gone on reporting that its EcoSpold 1 datasets have no identifier,
with nothing to tell the reader why. The signature list at 18 was written for
exactly that class. The CHANGELOG entry also names its wire revision now, the
way every other entry that moved one does.

**Rejected.** That `psDatasetNumber` should become a `Maybe Int` rather than
keep its `0` sentinel for `datasetIdentifier` to re-lift. The observation is
right and the sentinel is not lovely, but it is older than this change and it is
read by the link-resolution path (`DatasetNumberIndex`, `loDatasetNumber`),
which is the one thing in EcoSpold 1 loading that must not regress. Widening it
belongs to a change whose subject is that, not to one whose subject is showing
a string. `datasetIdentifier` is three total lines with a name and a test, and
it makes the sentinel visible at the single point where it becomes user-facing.

## Checks

Cold build with `-Werror`, `hlint src app test` clean, 2456 examples, 0
failures, 2 pending.
