### PR TITLE
Split the SimaPro section type, so neither router wildcards the other

### DIFF
--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -213,8 +213,10 @@ emptyProcessBlock =
 -- Parser State Machine
 -- ============================================================================
 
--- | Section types within a process block
-data SectionType
+{- | A section of the process block being read. Each one owns one list of
+'ProcessBlock', and 'addRowToBlock' is the only thing that reads it.
+-}
+data BlockSection
     = SecProducts
     | SecAvoidedProducts
     | SecMaterials
@@ -227,12 +229,32 @@ data SectionType
     | SecFinalWaste
     | SecInputParams
     | SecCalcParams
-    | SecDbInputParams
+    deriving (Show, Eq)
+
+{- | A section of the file rather than of a block: the four parameter tables in
+scope for every process it declares, and the trailing @name;unit;cas;comment@
+substance registry. Each one owns one field of 'ParseAcc'.
+-}
+data FileSection
+    = SecDbInputParams
     | SecDbCalcParams
     | SecProjInputParams
     | SecProjCalcParams
-    | SecSubstanceRegistry -- trailing name;unit;cas;comment substance list
-    | SecNone
+    | SecSubstanceRegistry
+    deriving (Show, Eq)
+
+{- | What a recognised section header opens.
+
+The split is what keeps the two functions that route a row from wildcarding
+over each other's half: a block section can only reach 'addRowToBlock', a file
+section can only reach the accumulator, and neither match has anything left to
+cover. 'SecIgnored' is a header read on purpose and dropped; it still opens a
+section, so the rows under it are swallowed rather than read as metadata.
+-}
+data SectionType
+    = InBlock BlockSection
+    | FileLevel FileSection
+    | SecIgnored
     deriving (Show, Eq)
 
 -- | Parser state
@@ -334,26 +356,26 @@ updateConfigFromHeader cfg key value = case BS8.map toLower key of
 -- | Detect section type from line (ByteString)
 detectSection :: BS.ByteString -> Maybe SectionType
 detectSection line = case BS8.strip line of
-    "Products" -> Just SecProducts
-    "Waste treatment" -> Just SecProducts
-    "Avoided products" -> Just SecAvoidedProducts
-    "Materials/fuels" -> Just SecMaterials
-    "Electricity/heat" -> Just SecElectricity
-    "Waste to treatment" -> Just SecWasteToTreatment
-    "Resources" -> Just SecResources
-    "Emissions to air" -> Just SecEmissionsAir
-    "Emissions to water" -> Just SecEmissionsWater
-    "Emissions to soil" -> Just SecEmissionsSoil
-    "Final waste flows" -> Just SecFinalWaste
-    "Input parameters" -> Just SecInputParams
-    "Calculated parameters" -> Just SecCalcParams
-    "Database Input parameters" -> Just SecDbInputParams
-    "Database Calculated parameters" -> Just SecDbCalcParams
-    "Project Input parameters" -> Just SecProjInputParams
-    "Project Calculated parameters" -> Just SecProjCalcParams
-    "Non material emissions" -> Just SecNone -- Ignore
-    "Social issues" -> Just SecNone
-    "Economic issues" -> Just SecNone
+    "Products" -> Just (InBlock SecProducts)
+    "Waste treatment" -> Just (InBlock SecProducts)
+    "Avoided products" -> Just (InBlock SecAvoidedProducts)
+    "Materials/fuels" -> Just (InBlock SecMaterials)
+    "Electricity/heat" -> Just (InBlock SecElectricity)
+    "Waste to treatment" -> Just (InBlock SecWasteToTreatment)
+    "Resources" -> Just (InBlock SecResources)
+    "Emissions to air" -> Just (InBlock SecEmissionsAir)
+    "Emissions to water" -> Just (InBlock SecEmissionsWater)
+    "Emissions to soil" -> Just (InBlock SecEmissionsSoil)
+    "Final waste flows" -> Just (InBlock SecFinalWaste)
+    "Input parameters" -> Just (InBlock SecInputParams)
+    "Calculated parameters" -> Just (InBlock SecCalcParams)
+    "Database Input parameters" -> Just (FileLevel SecDbInputParams)
+    "Database Calculated parameters" -> Just (FileLevel SecDbCalcParams)
+    "Project Input parameters" -> Just (FileLevel SecProjInputParams)
+    "Project Calculated parameters" -> Just (FileLevel SecProjCalcParams)
+    "Non material emissions" -> Just SecIgnored
+    "Social issues" -> Just SecIgnored
+    "Economic issues" -> Just SecIgnored
     _ -> Nothing
 
 {- | Classify a section header, resolving the two names a SimaPro file reuses
@@ -369,7 +391,7 @@ as before).
 -}
 classifyHeader :: Bool -> BS.ByteString -> Maybe SectionType
 classifyHeader inProcess line
-    | not inProcess, BS8.strip line `elem` registryHeaders = Just SecSubstanceRegistry
+    | not inProcess, BS8.strip line `elem` registryHeaders = Just (FileLevel SecSubstanceRegistry)
     | otherwise = detectSection line
   where
     registryHeaders =
@@ -646,26 +668,13 @@ processLine acc@ParseAcc{..} line
     -- Section detection (trailer registry blocks resolve against paInProcess)
     | Just sec <- classifyHeader paInProcess line =
         acc{paState = InSection sec}
-    -- In a section, parse row (route db/project params to ParseAcc, process params to block)
+    -- In a section, parse row (file-level sections to ParseAcc, block sections to the block)
     | InSection sec <- paState
     , not (BS.null (BS8.strip line)) =
         case sec of
-            SecDbInputParams -> case parseParamRow paConfig line of
-                Just p -> acc{paDbInputParams = p : paDbInputParams}
-                Nothing -> acc
-            SecDbCalcParams -> case parseParamRow paConfig line of
-                Just p -> acc{paDbCalcParams = p : paDbCalcParams}
-                Nothing -> acc
-            SecProjInputParams -> case parseParamRow paConfig line of
-                Just p -> acc{paProjInputParams = p : paProjInputParams}
-                Nothing -> acc
-            SecProjCalcParams -> case parseParamRow paConfig line of
-                Just p -> acc{paProjCalcParams = p : paProjCalcParams}
-                Nothing -> acc
-            SecSubstanceRegistry -> case parseSubstanceRow paConfig line of
-                Just nc -> acc{paSubstanceCAS = nc : paSubstanceCAS}
-                Nothing -> acc
-            _ -> acc{paCurrentBlock = addRowToBlock paConfig sec line paCurrentBlock}
+            FileLevel f -> addFileRow paConfig f line acc
+            InBlock b -> acc{paCurrentBlock = addRowToBlock paConfig b line paCurrentBlock}
+            SecIgnored -> acc
     -- Metadata key-value pairs
     | paState == BetweenBlocks || isMetadataKey (BS8.strip line) =
         if isMetadataKey (BS8.strip line)
@@ -685,8 +694,24 @@ processLine acc@ParseAcc{..} line
             }
     | otherwise = acc{paLineNum = paLineNum + 1}
 
+{- | Add a row of a file-level section to the accumulator field it belongs to.
+The four parameter tables are in scope for every process the file declares;
+the registry is the trailing substance list every name draws its CAS from.
+-}
+addFileRow :: SimaProConfig -> FileSection -> BS.ByteString -> ParseAcc -> ParseAcc
+addFileRow cfg sec line acc = case sec of
+    SecDbInputParams -> withParam $ \p -> acc{paDbInputParams = p : paDbInputParams acc}
+    SecDbCalcParams -> withParam $ \p -> acc{paDbCalcParams = p : paDbCalcParams acc}
+    SecProjInputParams -> withParam $ \p -> acc{paProjInputParams = p : paProjInputParams acc}
+    SecProjCalcParams -> withParam $ \p -> acc{paProjCalcParams = p : paProjCalcParams acc}
+    SecSubstanceRegistry ->
+        maybe acc (\nc -> acc{paSubstanceCAS = nc : paSubstanceCAS acc}) (parseSubstanceRow cfg line)
+  where
+    withParam :: ((Text, Text) -> ParseAcc) -> ParseAcc
+    withParam k = maybe acc k (parseParamRow cfg line)
+
 -- | Add a row to the appropriate list in the block (ByteString)
-addRowToBlock :: SimaProConfig -> SectionType -> BS.ByteString -> ProcessBlock -> ProcessBlock
+addRowToBlock :: SimaProConfig -> BlockSection -> BS.ByteString -> ProcessBlock -> ProcessBlock
 addRowToBlock cfg sec line block = case sec of
     SecProducts -> case parseProductRow cfg line of
         Just row -> block{pbProducts = row : pbProducts block}
@@ -724,7 +749,6 @@ addRowToBlock cfg sec line block = case sec of
     SecCalcParams -> case parseParamRow cfg line of
         Just p -> block{pbCalcParams = p : pbCalcParams block}
         Nothing -> block
-    _ -> block
 
 -- | Set metadata field in block (ByteString key, decode value to Text)
 setMetadata :: BS.ByteString -> BS.ByteString -> ProcessBlock -> ProcessBlock

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -811,6 +811,24 @@ spec = do
             -- Raw material amount should be lbtokg = 0.453592
             techInputAmounts act `shouldContain` [0.453592]
 
+        it "reads all four file-level parameter tables" $ do
+            (activities, _, _, _, _) <- parseAllParamCSV
+            let act = head activities
+            -- dbin, dbin*3, projin, projin*7
+            techInputAmounts act `shouldMatchList` [2.0, 6.0, 5.0, 35.0]
+
+    describe "SimaPro sections read and dropped" $ do
+        it "adds nothing from a section the parser recognises and ignores" $ do
+            (activities, _, _, _, _) <- parseIgnoredSectionCSV
+            let act = head activities
+            -- the reference product and the one air emission, nothing else
+            length (exchanges act) `shouldBe` 2
+
+        it "does not read a row under an ignored header as metadata" $ do
+            (activities, _, _, _, _) <- parseIgnoredSectionCSV
+            let act = head activities
+            activityLocation act `shouldBe` "FR"
+
     describe "SimaPro yield chain formulas" $ do
         it "resolves chained division (weight_g/1000/yield1/yield2)" $ do
             (activities, _, _, _, _) <- parseYieldChainCSV
@@ -1894,6 +1912,114 @@ noProcessNameCSV =
 parseNoProcessNameCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)
 parseNoProcessNameCSV = withSystemTempFile "no-process-name.csv" $ \path handle -> do
     BS.hPut handle noProcessNameCSV
+    hClose handle
+    parseOrFail defaultUnitConfig path
+
+{- | A block carrying the three headers the parser recognises and drops, one of
+them followed by a line that is also a metadata key.
+
+Those rows are consumed as section rows: the header opens a section, and every
+row under it is swallowed by the section routing. Were a header to stop opening
+a section, @Geography@ would reach the metadata arm instead and the line after
+it would become the activity's location.
+-}
+ignoredSectionCSV :: BS.ByteString
+ignoredSectionCSV =
+    BS.intercalate
+        "\r\n"
+        [ "{SimaPro 9.6.0.1}"
+        , "{CSV separator: semicolon}"
+        , "{Decimal separator: .}"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , "Ignored section probe"
+        , ""
+        , "Type"
+        , "Unit process"
+        , ""
+        , "Geography"
+        , "FR"
+        , ""
+        , "Products"
+        , "Probe product;kg;1;100;not defined;material;"
+        , ""
+        , "Emissions to air"
+        , "Carbon dioxide;;kg;2.5;;;;"
+        , ""
+        , "Non material emissions"
+        , "Noise;;kg;7;;;;"
+        , ""
+        , "Social issues"
+        , "Geography"
+        , "XX"
+        , ""
+        , "Economic issues"
+        , "Revenue;;EUR;9;;;;"
+        , ""
+        , "End"
+        ]
+
+parseIgnoredSectionCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)
+parseIgnoredSectionCSV = withSystemTempFile "ignored-section.csv" $ \path handle -> do
+    BS.hPut handle ignoredSectionCSV
+    hClose handle
+    parseOrFail defaultUnitConfig path
+
+{- | The four file-level parameter tables, each used by one exchange amount, so
+every one of them is read back through a number rather than only through its
+header being recognised.
+-}
+allParamTestCSV :: BS.ByteString
+allParamTestCSV =
+    BS.intercalate
+        "\r\n"
+        [ "{SimaPro 9.6.0.1}"
+        , "{CSV separator: semicolon}"
+        , "{Decimal separator: .}"
+        , ""
+        , "Database Input parameters"
+        , "dbin;2;Undefined;0;0;No;"
+        , ""
+        , "Database Calculated parameters"
+        , "dbcalc;dbin*3;;"
+        , ""
+        , "Project Input parameters"
+        , "projin;5;Undefined;0;0;No;"
+        , ""
+        , "Project Calculated parameters"
+        , "projcalc;projin*7;;"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , "Every parameter table"
+        , ""
+        , "Type"
+        , "Unit process"
+        , ""
+        , "Products"
+        , "Assembled product;kg;1;100;not defined;material;"
+        , ""
+        , "Materials/fuels"
+        , "From database input;kg;dbin;Undefined;;;;;;"
+        , "From database calculated;kg;dbcalc;Undefined;;;;;;"
+        , "From project input;kg;projin;Undefined;;;;;;"
+        , "From project calculated;kg;projcalc;Undefined;;;;;;"
+        , ""
+        , "End"
+        ]
+
+parseAllParamCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)
+parseAllParamCSV = withSystemTempFile "all-param.csv" $ \path handle -> do
+    BS.hPut handle allParamTestCSV
     hClose handle
     parseOrFail defaultUnitConfig path
 


### PR DESCRIPTION
**Target.** `SectionType` stops mixing the sections of a process block with the sections of the file itself, so each of the two functions that route a row matches a sum that is entirely its own.

**Axis.** Invalid states.

**Problem.** `SectionType` (`src/SimaPro/Parser.hs:217-236`) held seventeen constructors from three families: twelve sections of a process block, five sections of the file (four parameter tables and the trailing substance registry), and `SecNone` for a header recognised and deliberately dropped. Each of the two functions that consume it covered one family and closed with a wildcard over the other's: `processLine` sent everything it did not name to `addRowToBlock` (`:668`), and `addRowToBlock` dropped everything it did not name (`:727`). `-Wall` reads both matches as complete, so a constructor added tomorrow is routed into a process block by one function and silently discarded by the other, and nothing in the type says which family it belongs to.

**Transformation.** `BlockSection` holds the twelve and `FileSection` the five, with `SectionType = InBlock BlockSection | FileLevel FileSection | SecIgnored`. `addRowToBlock` takes a `BlockSection` and has nothing left to wildcard; the five file-level arms move out of `processLine` into `addFileRow`, which owns the `ParseAcc` fields the way `addRowToBlock` owns the block's lists. `detectSection` and `classifyHeader` keep their signatures and answer with the wrapped constructors. The call chain is `processLine -> classifyHeader -> detectSection` and `processLine -> addRowToBlock`, and it does not leave the module: nothing outside `src/SimaPro/Parser.hs` names any of these types, and none of them is exported.

**Behaviour preserved.** Which list of `ProcessBlock` (twelve) or of `ParseAcc` (five) each header's rows land in; the trailer-registry resolution `classifyHeader` performs against `paInProcess`; the three headers read and ignored still adding nothing. `SecNone` becomes `SecIgnored` and keeps an arm of its own, `SecIgnored -> acc`: dropping the arm instead would let a row under one of those headers reach the metadata arm, and a row whose first cell is a metadata key would then set metadata on the open block. Five constructors were pinned by no test, so the first commit writes them: the three ignored headers, including that trap, and the row routing of `SecDbCalcParams`, `SecProjInputParams` and `SecProjCalcParams`.

**Done when.** Met: three constructors on `SectionType`, twelve and five on the two halves; the wildcards at `:668` and `:727` gone, the two on `ParseState` untouched; `addRowToBlock` typed on `BlockSection`; `SecNone` gone by that name; the string-literal diff over the file empty; 2472 examples, 0 failures, 2 pending, the same as before. This target needs no second pass.

<details>
<summary>For the next run: not chosen, behaviour changes, numbers</summary>

**Would change behaviour, so reported and not fixed**

- `src/Database/Loader.hs:350` — `getReferenceProductUUID` answers `UUID.nil` for an activity with no reference product, and three keying sites (`:373`, `:1184`, `:1240`) register it under that; should be `Maybe UUID`, with the dataset named in the log. `test/LoaderSpec.hs:309` asserts the nil today.
- `src/Database/Loader.hs:319` — Loader's `parseUUID` mints a UUID under a namespace named `acvengine.test` when an EcoSpold 2 file name is not one, silently; `EcoSpold.Parser2`'s copy at `:36` does the same and warns. One function, and the warning.
- `src/Database/Manager.hs:2071` — `loadCSV` is a second format dispatch that never calls `fixActivityLinksWithCrossDB`, so a configured SimaPro CSV and an uploaded one are linked differently; the arm should go through `narrowToDataFile`/`loadStructured` like every other format.
- `src/Database/Manager.hs:3245` — `rankMissingProducts` appends two name-keyed maps, so a product name in both is listed and ranked twice; should be a union with the demands summed and the first blocker kept.
- `src/Database/Manager.hs:321` — `MissingSupplier.msLocation` is `Nothing` at its only construction site and is on the wire; compute it from `LinkBlocker` or delete the field.
- `src/API/MCP.hs:1530`, `src/Database/Author.hs:1065`, `src/Method/Mapping.hs:1712` and `SubstanceRegistry.normalizeName` — four spellings of "the same flow name" that disagree on interior whitespace (`toLower . strip` against `toLower . unwords . words`); one `FlowKey` changes how names with doubled spaces align.
- `src/Database/Manager.hs:1846` — two format detectors whose own comment says they must agree, with nothing making them agree; typing `pcFormat` as `Upload.DatabaseFormat` is behaviour-free, unifying the detectors is not.

**Not chosen, ranked**

Invalid states:
- `ClassificationFilter` for `(Text, Text, Bool)` crossing ten signatures in seven modules (`src/API/MCP.hs:736`, `src/Service.hs:56`, `src/Database.hs:240`, `src/Database/Edit.hs:883`, `src/API/Routes.hs:1159`) — strongest candidate after this one, dropped on locality alone.
- `AmountCell` — `src/SimaPro/Parser.hs:112` keeps a `Double` beside the `Text` it is a function of, and `parseAmount` (`:430`) is `fromMaybe 0.0`; same file, obvious next run there.
- `BioSection` — `bioRowToExchange` (`src/SimaPro/Parser.hs:1050`) takes a `Bool` and a `Text` for one of four sections: eight spellings for four states.
- `EcoSpoldVersion` — `isEcoSpold1 :: Bool` threaded through three functions (`src/Database/Loader.hs:1031`, `:1114`, `:1186`), with the layout decision at `:1025` wanting to be pure.
- `Supplier.supProducedUnit` — `""` means "a treatment process has none", rediscovered by `T.null` at `src/Database/Author.hs:743`, `:938`, `:1101`.
- `FlowHome` — `findBioFlow` returns a `Bool` meaning "lives in the edited database" (`src/Database/Author.hs:1048`), destructured five times, while `SupplierHome` already names that for providers.
- `RequestId` — the JSON-RPC id is a bare `Value` beside other `Value`s in twenty-seven handlers (`src/API/MCP.hs:83`); `rpcResult` accepts its two arguments swapped.
- `DbName` — forty-five `DatabaseManager -> Text ->` signatures in `src/Database/Manager.hs`, with `RootDb`/`ThisDb` already newtyped on the wire side; too broad as it stands.
- `CollectionName` in the six loaded-method signatures (`src/Database/Manager.hs:4021`), wrapped after the fact at `src/API/MCP.hs:1916`.
- `ExchangeFilter` — `callGetActivity`'s `where` block (`src/API/MCP.hs:849`) recomputes `noFilters` from raw text and wildcards `_ -> True` over an already-refused invalid kind.
- `MethodFormat` — a method collection's format is `Text` guessed from the path by three literals (`src/Database/Manager.hs:3959`, `src/Config.hs:245`).
- `relinkDatabaseWithMapping` takes the database and its dependency as two neighbouring `Text`s while `DependencyEdit` names that pair (`src/Database/Manager.hs:2478`).
- `riKey :: (UUID, UUID)` (`src/Database/Author.hs:229`) spells the key `ProcessRef`'s own doc comment argues against.
- Mapping's compartment predicates split between `Text` and `Subcompartment` (`src/Method/Mapping.hs:2620`) — #388 deferred this pending the compartment divergence, still open.
- `FlowClosure` keyed by `Text` where `NormName` and `CASNumber` exist (`src/Types.hs:1426`); `Database` is `Store`-serialised, so it has to be decided with the cache-layout history open, the way #390 decided its own.
- `FlowContribution` — `(BiosphereFlow, Double, Double)` through eight signatures (`src/Method/Mapping.hs:2818`), read by position at `src/API/MCP.hs:1521`.

Duplication:
- Three Loader linking functions take the five fields of `LinkingContext` positionally and rebuild the record inside (`src/Database/Loader.hs:1428`, `:1498`, `:1612`).

Cosmetic:
- `Match`/`CFMapping` for `(MethodCF, Maybe (BiosphereFlow, MatchStrategy))` through thirty signatures (`src/Method/Mapping.hs:264`) — #388's own "strongest candidate for the next run", ranked below this one because its axis is a tuple crossing a signature, not a state the type allows and the code forbids.
- `FlowVocabulary` — `UnitConfig -> UnitDB -> BioFlowDB ->` opens seventeen `Mapping` signatures (`:1851` to `:3376`).
- `ParsedDataset` — every parser returns a 5- or 7-tuple and Loader an unzipped 9-tuple (`src/Database/Loader.hs:835`).
- `WorkerParse` — `unzip9` (`src/Database/Loader.hs:205`) and seven `M.unions` are a `Monoid` instance.
- `Geography` — `(Text, [Text])` under a `Text` code through nine signatures, rewrapped at `src/Database/Manager.hs:4170`.
- `McpEnv` — four dispatchers thread the same four values, and `mcpApp` takes a `Bool` for "a frontend is bundled" (`src/API/MCP.hs:146`).
- `mkMcpCrossDBEntry` takes eight positional arguments, four of which `LcaRequest` already holds (`src/API/MCP.hs:1818`).
- `FlowByName Text Compartment Text` names its fields in a comment (`src/Database/Author.hs:162`).
- `LoadSource` and `LoadOrigin` name one fact twice, translated at `src/Database/Manager.hs:2225`.
- `paInProcess :: Bool` and `classifyHeader :: Bool -> ...` (`src/SimaPro/Parser.hs:250`, `:370`) — one call site, kept out to leave this one conceptual change.

Module organisation:
- `src/Database/Manager.hs` is 4700 lines and the five move checks put a seam under "load, stage, relink, finalize, setup" (`:1366-3741`, about 2380 lines), with the `DatabaseManager` record having to move first to a module both halves import.

**Seen, not touched.** Nothing.

**Numbers.** `src/SimaPro/Parser.hs` 1713 lines to 1737 and 50 signatures to 51 (two declarations and their doc comments); tuples 20, `Bool` 5, bare primitives 57, deepest column 37, all unchanged. `processLine` 70 lines to 57.

**Falsifier.** Problem holds, with two corrections applied to the block (the wildcard is at `:727`, and the file family is four parameter tables plus the registry, not three). Preserves, on the condition that `SecIgnored` keeps an arm in the section routing and that `detectSection` keeps answering `Just` for those three headers, both of which the change does. Narrow enough: one file, zero other modules. "Done when" checkable, once its wildcard line is scoped to `:668` and `:727` (the two `ParseState` wildcards at `:623` and `:679` are not this target's); it named `test/SimaProWriterSpec.hs:449` as the only cover `SecAvoidedProducts` has, and the five constructors covered by nothing, which the first commit writes.

**Scope of the run.** Six files read: `Database/Manager.hs`, `Method/Mapping.hs`, `Database/Loader.hs`, `SimaPro/Parser.hs`, `Database/Author.hs`, `API/MCP.hs`. Left out because the signature listing of the whole tree is 8528 lines: `API/Types.hs`, `Types.hs`, `Service.hs`, `API/Routes.hs`, `Config.hs`, `CLI/Types.hs` and the rest. Reader on `claude-fable-5-1`, falsifier on `claude-opus-5`.

</details>
