### PR TITLE
Give the Brightway Excel export the manifest every reader opens it through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 
 ### Fixed
+- A Brightway Excel export can now be opened by the tools it is written for.
+  The `.xlsx` was missing the manifest a spreadsheet reader looks up before
+  anything else, so openpyxl, bw2io and Excel all refused the file even though
+  the sheet inside it was complete. VoLCA's own importer reads the sheet
+  directly and never needed the manifest, which is why the file looked fine
+  from here.
 - An EcoSpold 2 dataset whose block a key divides into several processes now
   says that only one of them will be kept. A process is identified by its file
   name there, which names a single product, so the coproducts a key had just

--- a/src/BrightwayExcel/Writer.hs
+++ b/src/BrightwayExcel/Writer.hs
@@ -40,7 +40,9 @@ depends on ambient state (timestamps, tool version, machine).
 An @.xlsx@ is a zip of XML parts. We mirror the parser's toolchain exactly
 (@zip-archive@ + hand-built SpreadsheetML, the same shape openpyxl/bw2io emit),
 rather than pulling in a new dependency: one worksheet @xl/worksheets/sheet1.xml@
-of inline-string / numeric cells, wired through @xl/workbook.xml@ and its rels.
+of inline-string / numeric cells, wired through @xl/workbook.xml@ and its rels,
+and announced by the OPC package manifest (@[Content_Types].xml@ and
+@_rels/.rels@) that every reader but our own parser opens the archive through.
 Inline strings (@t="inlineStr"@) are used throughout, so no shared-string table
 is needed — and the parser already resolves either form.
 
@@ -127,7 +129,9 @@ renderWorkbook cfg db = do
     checkBrightwayExportable db
     pure $
         zipFiles
-            [ ("xl/workbook.xml", enc workbookXml)
+            [ ("[Content_Types].xml", enc contentTypesXml)
+            , ("_rels/.rels", enc packageRelsXml)
+            , ("xl/workbook.xml", enc workbookXml)
             , ("xl/_rels/workbook.xml.rels", enc relsXml)
             , ("xl/worksheets/sheet1.xml", enc (sheetXml (sheetRows cfg db)))
             ]
@@ -528,6 +532,34 @@ formatAmount d
 -- ---------------------------------------------------------------------------
 -- SpreadsheetML emitter (hand-built, mirrors the parser's reader)
 -- ---------------------------------------------------------------------------
+
+{- | The OPC package manifest. Our parser reads @xl/worksheets/sheet1.xml@
+straight out of the zip, but openpyxl (and so @bw2io@, and Excel) resolves parts
+through this map of extension and part name to content type, and fails with a
+plain @KeyError@ when the archive has none.
+-}
+contentTypesXml :: Text
+contentTypesXml =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        <> "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">"
+        <> "<Default Extension=\"rels\""
+        <> " ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>"
+        <> "<Default Extension=\"xml\" ContentType=\"application/xml\"/>"
+        <> "<Override PartName=\"/xl/workbook.xml\""
+        <> " ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\"/>"
+        <> "<Override PartName=\"/xl/worksheets/sheet1.xml\""
+        <> " ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>"
+        <> "</Types>"
+
+-- | Package-level relationships: which part is the workbook.
+packageRelsXml :: Text
+packageRelsXml =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        <> "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">"
+        <> "<Relationship Id=\"rId1\""
+        <> " Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\""
+        <> " Target=\"xl/workbook.xml\"/>"
+        <> "</Relationships>"
 
 workbookXml :: Text
 workbookXml =

--- a/test/BrightwayExcelWriterSpec.hs
+++ b/test/BrightwayExcelWriterSpec.hs
@@ -36,6 +36,7 @@ import BrightwayExcel.Writer (
     renderWorkbook,
     wasteManifest,
  )
+import Codec.Archive.Zip (filesInArchive, toArchive)
 import Control.Monad ((>=>))
 import qualified Data.ByteString.Lazy as BL
 import Data.Either (isLeft, isRight)
@@ -77,6 +78,23 @@ spec = describe "BrightwayExcel.Writer" $ do
             renderCategories (Just (Compartment "air" Nothing)) `shouldBe` "air"
         it "emits empty for no recorded compartment" $
             renderCategories Nothing `shouldBe` ""
+
+    describe "package" $
+        it "carries the OPC manifest every xlsx reader opens the archive through" $
+            -- openpyxl (so bw2io, so Excel) resolves parts through
+            -- [Content_Types].xml and fails with a bare KeyError without it;
+            -- our own parser reads the sheet straight out of the zip and would
+            -- never notice.
+            case renderWorkbook defaultWriterConfig fixtureDb of
+                Left err -> expectationFailure (T.unpack err)
+                Right bytes ->
+                    filesInArchive (toArchive bytes)
+                        `shouldBe` [ "[Content_Types].xml"
+                                   , "_rels/.rels"
+                                   , "xl/workbook.xml"
+                                   , "xl/_rels/workbook.xml.rels"
+                                   , "xl/worksheets/sheet1.xml"
+                                   ]
 
     describe "round-trip" $ do
         it "(b) parse (write D) is structurally equal to D" $


### PR DESCRIPTION
A Brightway Excel export could not be opened by the tool it is written for. An
.xlsx is an OPC package: readers find its parts through `[Content_Types].xml`
and `_rels/.rels`, and the writer emitted neither, only the workbook, its
relationships and the worksheet. openpyxl fails on such an archive with a bare
`KeyError: "There is no item named '[Content_Types].xml' in the archive"`, so
bw2io and Excel never get to the rows either.

Our own parser reads the worksheet straight out of the zip and needs no
manifest, which is why the round-trip suite stayed green over a workbook nobody
else could read.

The writer now emits the two manifest parts alongside the three it already had.
Nothing about the sheet itself changes, so the parser and the round-trip
contracts are untouched.

Checked end to end rather than by inspection: exported a database from a running
engine with `database export <db> --format brightway`, then opened the result
with openpyxl. It loads, the sheet is named `data`, and the rows read back as
written, down to `Carbon dioxide, fossil 0.5 biosphere`. A new test pins the
five parts of the archive, so dropping one fails here instead of in someone
else's importer.
