### PR TITLE
Read an inventory indicator as the elementary flow it is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@
   the sheet inside it was complete. VoLCA's own importer reads the sheet
   directly and never needed the manifest, which is why the file looked fine
   from here.
+- An EcoSpold 2 database no longer reports supplier gaps that cannot exist.
+  A source of that format declares a handful of inventory indicators, which
+  are elementary flows recording how much waste an activity accounts for so
+  that a method can characterize the total. The loader read the word "waste"
+  in their compartment and moved them to the technosphere waste side, where a
+  dataset that writes one as an input reads as a process demanding a supplier
+  no activity can be. Two of them are written that way throughout, which was
+  enough to leave thousands of unsupplied edges on a database that is in fact
+  complete. They are elementary flows again: they appear in the inventory
+  where a method can characterize them, and the gap report is empty. Caches
+  built before this are rebuilt on the next load.
 - An EcoSpold 2 dataset whose block a key divides into several processes now
   says that only one of them will be kept. A process is identified by its file
   name there, which names a single product, so the coproducts a key had just

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -303,6 +303,11 @@ History of manual bumps:
      under, in a field that already existed and was already stored. Nothing
      changes type, so a cache written just before this would pass the
      fingerprint and go on reporting that those datasets have no identifier.
+- 25: an EcoSpold 2 elementary exchange in the "inventory indicator"
+     compartment is a biosphere flow again, not a waste one. Nothing changes
+     type, so a cache written just before this would pass the fingerprint and
+     go on holding those flows on the waste axis - invisible to every method,
+     and demanding a supplier no activity can be.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.
@@ -310,7 +315,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeRep (Proxy :: Proxy Database))
-     in hi `xor` lo `xor` 24
+     in hi `xor` lo `xor` 25
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.
@@ -1114,8 +1119,7 @@ loadEcoSpoldDirectory opts dir = do
         -- Parse all files for this worker using appropriate parser.
         -- Both paths return (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit], Int, M.Map UUID Int).
         -- For EcoSpold2: dataset number = 0, supplier links = empty. WasteFlows now flow
-        -- through (Pattern A: elementaryExchange compartment=inventory indicator/waste;
-        -- Pattern B: intermediateExchange classification=By-product:Waste).
+        -- through (intermediateExchange classified By-product:Waste).
         let parseFile =
                 if isEcoSpold1
                     then streamParseActivityAndFlowsFromFile1

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -780,9 +780,9 @@ parseWithXeno xmlContent processId = do
                         -- normal production (positive amount) and waste treatment (negative amount).
                         -- Negative inputs (e.g. wastewater discharge) are never reference products.
                         isReferenceProduct = isOutput && finalOutputGroup == "0"
-                        -- Pattern B: intermediateExchange tagged Waste via classification
-                        -- (System='By-product classification', Value='Waste') — a waste output that
-                        -- consumers treat via a treatment activity.
+                        -- The one waste marker EcoSpold2 carries: an intermediateExchange
+                        -- classified (System='By-product classification', Value='Waste') — a waste
+                        -- output that consumers treat via a treatment activity.
                         isWasteFlow = M.lookup "By-product classification" (idClassifications idata) == Just "Waste"
                         (flowUUID, flowWarn) = parseUUID (idFlowId idata)
                         (unitUUID, unitWarn) = parseUUID (idUnitId idata)
@@ -867,14 +867,6 @@ parseWithXeno xmlContent processId = do
                             | otherwise = case edCompartments edata of
                                 (comp : _) | T.toLower comp == "natural resource" -> Resource
                                 _ -> Emission
-                        -- Pattern A: compartment="inventory indicator" / subcompartment="waste".
-                        -- Surfaced through the elementary axis but semantically technosphere waste —
-                        -- route to WasteExchange instead of BiosphereExchange.
-                        isInventoryIndicatorWaste = case (mCompName, subCompartment) of
-                            (Just c, Just s) ->
-                                T.toLower (T.strip c) == "inventory indicator"
-                                    && T.toLower (T.strip s) == "waste"
-                            _ -> False
                         (flowUUID, flowWarn) = parseUUID (edFlowId edata)
                         (unitUUID, unitWarn) = parseUUID (edUnitId edata)
                         warns =
@@ -893,24 +885,9 @@ parseWithXeno xmlContent processId = do
                                 , bioPedigree = Nothing
                                 }
                         bioFlow = BiosphereFlow flowUUID resolvedFlowName unitUUID (edSynonyms edata) (edCAS edata) Nothing compartment
-                        wasteExchange =
-                            WasteExchange
-                                { waFlowId = flowUUID
-                                , waAmount = edAmount edata
-                                , waUnitId = unitUUID
-                                , waIsInput = not (T.null finalInputGroup)
-                                , waActivityLinkId = UUID.nil
-                                , waProcessLinkId = Nothing
-                                , waLocation = ""
-                                , waComment = snd <$> edComment edata
-                                , waPedigree = Nothing
-                                }
-                        wasteFlow = WasteFlow flowUUID resolvedFlowName unitUUID (edSynonyms edata) (edCAS edata) Nothing
                         formula = ExchangeFormula (nonEmptyText (edVariableName edata)) (nonEmptyText (edMathRel edata))
                         base = finishExchange unit warns state
-                     in if isInventoryIndicatorWaste
-                            then addExchange wasteExchange formula (addWasteFlow wasteFlow base)
-                            else addExchange bioExchange formula (addBioFlow bioFlow base)
+                     in addExchange bioExchange formula (addBioFlow bioFlow base)
         | isElement tagName "text" =
             if inGeneralComment state
                 then

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -781,7 +781,7 @@ parseWithXeno xmlContent processId = do
                         -- Negative inputs (e.g. wastewater discharge) are never reference products.
                         isReferenceProduct = isOutput && finalOutputGroup == "0"
                         -- The one waste marker EcoSpold2 carries: an intermediateExchange
-                        -- classified (System='By-product classification', Value='Waste') — a waste
+                        -- classified (System='By-product classification', Value='Waste'), a waste
                         -- output that consumers treat via a treatment activity.
                         isWasteFlow = M.lookup "By-product classification" (idClassifications idata) == Just "Waste"
                         (flowUUID, flowWarn) = parseUUID (idFlowId idata)
@@ -861,12 +861,21 @@ parseWithXeno xmlContent processId = do
                             (Nothing, Just _) -> Nothing -- sub without medium is meaningless; drop
                             -- Biosphere direction: prefer inputGroup/outputGroup, else fall back to the
                             -- compartment heuristic (natural-resource flows are extractions).
+                            -- An inventory indicator is the exception: it counts what the activity
+                            -- sends away, and a source writes the same indicator under both groups
+                            -- from one dataset to the next, so the group is not information. Reading
+                            -- it would make the direction of a flow depend on which dataset one
+                            -- happens to look at, and cost the writers that reconstruct direction
+                            -- from the compartment their round-trip.
                         direction
+                            | isInventoryIndicator = Emission
                             | not (T.null finalInputGroup) = Resource
                             | not (T.null finalOutputGroup) = Emission
                             | otherwise = case edCompartments edata of
                                 (comp : _) | T.toLower comp == "natural resource" -> Resource
                                 _ -> Emission
+                        isInventoryIndicator =
+                            maybe False ((== inventoryIndicatorMedium) . T.toLower . T.strip) mCompName
                         (flowUUID, flowWarn) = parseUUID (edFlowId edata)
                         (unitUUID, unitWarn) = parseUUID (edUnitId edata)
                         warns =

--- a/src/EcoSpold/Writer2.hs
+++ b/src/EcoSpold/Writer2.hs
@@ -408,7 +408,7 @@ renderTechnosphere env ex =
         ReferenceInput -> techAmount ex
 
 {- | Waste exchange → @intermediateExchange@ tagged with the
-@By-product classification = Waste@ classification (parser "Pattern B"). The
+@By-product classification = Waste@ classification. The
 @waIsInput@ flag picks the group so direction round-trips: an input takes
 @inputGroup 5@ (from technosphere), an output the @outputGroup 2@ (by-product) —
 the only output groups EcoSpold2 defines for an intermediate exchange besides the

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -298,6 +298,9 @@ checkSimaProExportable db =
         , Just flow <- [M.lookup (exchangeFlowId ex) (sdbBioFlows db)]
         , let medium = T.toLower (bfCompartmentName flow)
         , not (T.null medium)
+        , -- An inventory indicator is not an emission to a medium; it has its own
+        -- section ('SecWaste'), so it is not held to the emission media.
+        medium /= inventoryIndicatorMedium
         , medium `notElem` ["air", "water", "soil"]
         ]
     amountOffenders =
@@ -588,20 +591,27 @@ wasteLine _ TechnosphereExchange{} = Nothing
 wasteLine _ BiosphereExchange{} = Nothing
 
 {- | The medium a biosphere exchange belongs to, derived from the flow's
-compartment name. SimaPro splits biosphere rows into four sections keyed on
-the medium: Resources, Emissions to air/water/soil. Resources are the
-'Resource' direction; emissions are bucketed by compartment name.
+compartment name. SimaPro splits biosphere rows into five sections keyed on
+the medium: Resources, Emissions to air/water/soil, and Final waste flows.
+Resources are the 'Resource' direction; emissions are bucketed by compartment
+name. An inventory indicator counts what the activity sends away rather than
+naming a substance, and the same source's own SimaPro export files all of them
+under Final waste flows, so its medium decides before its direction does.
 -}
 bioSection :: Catalogs -> Exchange -> Maybe BioSec
-bioSection cats ex@BiosphereExchange{bioDirection = dir} =
-    case dir of
+bioSection cats ex@BiosphereExchange{bioDirection = dir}
+    | medium == Just inventoryIndicatorMedium = Just SecWaste
+    | otherwise = case dir of
         Resource -> Just SecRes
         -- Unknown flow → Nothing, mirroring 'bioLine' so an emission keeps a
         -- section only when it also keeps a row (the two are paired in
         -- 'serializeActivity'); no dead "unknown → air" arm.
-        Emission -> sectionForMedium . bfCompartmentName <$> M.lookup (exchangeFlowId ex) (catBio cats)
+        Emission -> sectionForMedium <$> medium
   where
-    sectionForMedium name = case T.toLower name of
+    medium :: Maybe Text
+    medium = T.toLower . bfCompartmentName <$> M.lookup (exchangeFlowId ex) (catBio cats)
+    sectionForMedium :: Text -> BioSec
+    sectionForMedium name = case name of
         "water" -> SecWater
         "soil" -> SecSoil
         -- air, unspecified, or any other medium → air. 'checkSimaProExportable'
@@ -611,7 +621,7 @@ bioSection cats ex@BiosphereExchange{bioDirection = dir} =
 bioSection _ TechnosphereExchange{} = Nothing
 bioSection _ WasteExchange{} = Nothing
 
-data BioSec = SecRes | SecAir | SecWater | SecSoil
+data BioSec = SecRes | SecAir | SecWater | SecSoil | SecWaste
     deriving (Eq)
 
 {- | Output rows (@name;unit;amount;allocation;waste_type;category;comment@) for
@@ -757,7 +767,9 @@ serializeActivity cats act@Activity{..} =
             , withBlank (section "Emissions to air" bioRowText (bioByName SecAir))
             , withBlank (section "Emissions to water" bioRowText (bioByName SecWater))
             , withBlank (section "Emissions to soil" bioRowText (bioByName SecSoil))
-            , withBlank (section "Final waste flows" bioRowText wasteLines)
+            , -- Both kinds of final waste flow: the waste axis, and the inventory
+              -- indicators the biosphere axis carries ('bioSection').
+              withBlank (section "Final waste flows" bioRowText (bioByName SecWaste ++ wasteLines))
             , ["End", ""]
             ]
   where

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -103,6 +103,16 @@ when neither the source nor the medium recorded one.
 bfCompartmentSub :: BiosphereFlow -> Maybe Text
 bfCompartmentSub = compartmentSub <=< bfCompartment
 
+{- | The medium of an inventory indicator: an elementary flow that counts what
+an activity accounts for rather than naming a substance exchanged with the
+environment, so that a method can characterize the total. It is neither an
+emission to a medium nor an extraction from one, which is why the readers and
+writers that bucket a flow by its medium all need to recognise it. Compared
+lowercased and stripped, as sources vary in spacing and case.
+-}
+inventoryIndicatorMedium :: Text
+inventoryIndicatorMedium = "inventory indicator"
+
 {- | Direction of a biosphere exchange. Mirrors the @TechRole@ sum so the
 biosphere side also gets named variants instead of a load-bearing 'Bool'.
 

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -105,6 +105,15 @@ spec = describe "per-exchange comments" $ do
                 -- the indicator input joins the genuine CO2 emission
                 map bfName bios
                     `shouldMatchList` ["Carbon dioxide", "Waste mass placed in landfill"]
+        -- The fixture writes the indicator with inputGroup 4, which would
+        -- otherwise read as Resource. A source writes the same indicator under
+        -- both groups from one dataset to the next, so the group says nothing;
+        -- recording one direction is what lets a writer that reconstructs
+        -- direction from the compartment round-trip the flow.
+        it "records an inventory indicator as an output whichever group it carries" $
+            withWastePatternsFixture $ \(act, _, _, _, _) ->
+                [bioDirection e | e@BiosphereExchange{} <- exchanges act]
+                    `shouldBe` [Emission, Emission]
         it "routes an intermediate classified 'By-product:Waste' to WasteExchange" $
             withWastePatternsFixture $ \(act, _, _, _, _) -> do
                 let wasteInputs = [e | e@WasteExchange{waIsInput = True} <- exchanges act]

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -90,24 +90,27 @@ spec = describe "per-exchange comments" $ do
             withPropertyFixture $ \act ->
                 map exchangeAmount (exchanges act) `shouldMatchList` [1.0, 0.1]
 
-    -- Pattern A: elementaryExchange with compartment=inventory indicator
-    -- subcompartment=waste must surface as a WasteExchange / WasteFlow,
-    -- not a BiosphereExchange. Pattern B: intermediateExchange with
-    -- classification (By-product classification=Waste) likewise.
+    -- The waste axis has exactly one EcoSpold2 marker: an intermediateExchange
+    -- classified By-product classification=Waste. Elementary exchanges stay
+    -- biosphere whatever their compartment reads - a flow in the "inventory
+    -- indicator" compartment is an accounting total a method characterizes, not
+    -- a demand. Routing it to the waste axis both hid it from every LCIA method
+    -- and, since such a flow is commonly written with inputGroup 4, invented a
+    -- supplier demand no activity can meet.
     describe "waste flow detection" $ do
-        it "routes Pattern A (elementary 'inventory indicator/waste') to WasteExchange" $
+        it "keeps an elementary 'inventory indicator/waste' input on the biosphere axis" $
             withWastePatternsFixture $ \(act, _, bios, wastes, _) -> do
-                let waste = [e | e@WasteExchange{} <- exchanges act]
-                length waste `shouldBe` 2 -- one Pattern A + one Pattern B
-                length wastes `shouldBe` 2 -- WasteFlow registry populated
-                length bios `shouldBe` 1 -- the genuine CO2 emission stays biosphere
-        it "routes Pattern B (intermediate classification 'By-product:Waste') to WasteExchange" $
+                length [e | e@WasteExchange{} <- exchanges act] `shouldBe` 1
+                length wastes `shouldBe` 1
+                -- the indicator input joins the genuine CO2 emission
+                map bfName bios
+                    `shouldMatchList` ["Carbon dioxide", "Waste mass placed in landfill"]
+        it "routes an intermediate classified 'By-product:Waste' to WasteExchange" $
             withWastePatternsFixture $ \(act, _, _, _, _) -> do
                 let wasteInputs = [e | e@WasteExchange{waIsInput = True} <- exchanges act]
                     wasteOutputs = [e | e@WasteExchange{waIsInput = False} <- exchanges act]
-                -- Pattern B sample is an input; Pattern A sample is an output.
                 length wasteInputs `shouldBe` 1
-                length wasteOutputs `shouldBe` 1
+                length wasteOutputs `shouldBe` 0
 
     -- Regression: e17dc21 established "all 25,412 ecoinvent .spold parse"; the
     -- WasteFlow axis (#83) silently re-broke it. A treatment / market-for-waste
@@ -494,11 +497,13 @@ withWastePatternsFixture k = withSystemTempDirectory "es2-waste-spec" $ \dir -> 
         Left err -> expectationFailure $ "Parse failed: " ++ err
         Right res -> k res
 
-{- | Synthetic fixture exercising both EcoSpold2 waste patterns:
-  - Pattern A: elementary exchange with compartment "inventory indicator"
-    / "waste" (waste output surfaced through the elementary axis)
-  - Pattern B: intermediate exchange tagged via classification
-    (System="By-product classification", Value="Waste")
+{- | Synthetic fixture separating the one real EcoSpold2 waste marker from the
+look-alike that is not one:
+  - an intermediate exchange tagged via classification
+    (System="By-product classification", Value="Waste") - the waste axis
+  - an elementary exchange with compartment "inventory indicator" / "waste",
+    written the way such an indicator usually is (inputGroup 4) - the
+    biosphere axis
 Plus one genuine biosphere emission and the mandatory reference output.
 -}
 wastePatternsXml :: BS.ByteString
@@ -520,7 +525,7 @@ wastePatternsXml =
     \        <unitName xml:lang=\"en\">kg</unitName>\n\
     \        <outputGroup>0</outputGroup>\n\
     \      </intermediateExchange>\n\
-    \      <!-- Pattern B: intermediate exchange with By-product:Waste classification (treated as INPUT)-->\n\
+    \      <!-- Intermediate exchange with By-product:Waste classification (treated as INPUT)-->\n\
     \      <intermediateExchange id=\"pat-b\" unitId=\"unit-kg\" amount=\"0.4\"\n\
     \                           intermediateExchangeId=\"cccccccc-cccc-cccc-cccc-cccccccccccc\">\n\
     \        <name xml:lang=\"en\">Spent solvent for treatment</name>\n\
@@ -531,16 +536,16 @@ wastePatternsXml =
     \          <classificationValue xml:lang=\"en\">Waste</classificationValue>\n\
     \        </classification>\n\
     \      </intermediateExchange>\n\
-    \      <!-- Pattern A: elementary exchange with compartment=inventory indicator / waste -->\n\
-    \      <elementaryExchange id=\"pat-a\" unitId=\"unit-kg\" amount=\"0.2\"\n\
+    \      <!-- Inventory indicator: elementary, compartment=inventory indicator / waste -->\n\
+    \      <elementaryExchange id=\"indicator\" unitId=\"unit-kg\" amount=\"0.2\"\n\
     \                         elementaryExchangeId=\"dddddddd-dddd-dddd-dddd-dddddddddddd\">\n\
-    \        <name xml:lang=\"en\">Hazardous waste, to inventory</name>\n\
+    \        <name xml:lang=\"en\">Waste mass placed in landfill</name>\n\
     \        <unitName xml:lang=\"en\">kg</unitName>\n\
     \        <compartment>\n\
     \          <compartment xml:lang=\"en\">inventory indicator</compartment>\n\
     \          <subcompartment xml:lang=\"en\">waste</subcompartment>\n\
     \        </compartment>\n\
-    \        <outputGroup>4</outputGroup>\n\
+    \        <inputGroup>4</inputGroup>\n\
     \      </elementaryExchange>\n\
     \      <!-- Genuine biosphere emission for contrast -->\n\
     \      <elementaryExchange id=\"bio\" unitId=\"unit-kg\" amount=\"0.1\"\n\

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -31,6 +31,7 @@ import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import Data.Word (Word32)
@@ -508,6 +509,25 @@ spec = describe "SimaPro.Writer round-trip" $ do
             -- "Emissions to air" and re-parse as air; reject it loudly instead.
             checkSimaProExportable (emissionDb (Compartment "raw" Nothing))
                 `shouldSatisfy` either (const True) (const False)
+
+        -- An inventory indicator is neither an emission to a medium nor an
+        -- extraction from one. It has a section of its own, so the medium guard
+        -- must let it through and the writer must file it there: under
+        -- "Emissions to air" it would re-parse as an emission to air, and the
+        -- guard alone would refuse every database carrying one.
+        it "accepts an inventory indicator and files it under Final waste flows" $ do
+            let db = emissionDb (Compartment "inventory indicator" (Just "waste"))
+            checkSimaProExportable db `shouldBe` Right ()
+            case serializeSimaProCSV defaultWriterConfig db of
+                Left err -> expectationFailure (T.unpack err)
+                Right out -> do
+                    -- the writer joins with CRLF; drop the carriage returns
+                    let ls = map (T.dropWhileEnd (== '\r')) (T.lines (TE.decodeUtf8 out))
+                        after header = drop 1 (dropWhile (/= header) ls)
+                        firstRow header = take 1 (takeWhile (not . T.null) (after header))
+                    firstRow "Final waste flows"
+                        `shouldBe` ["Some emission;waste;kg;0.5;Undefined;;;;;;"]
+                    firstRow "Emissions to air" `shouldBe` []
 
     describe "checkSimaProExportable (round-trip guards)" $ do
         it "refuses an activity whose product rows carry no share: each row would claim the whole" $


### PR DESCRIPTION
## The problem

Loading a database in EcoSpold 2 reported thousands of unsupplied edges on the gap report, and a completeness just under 100%, on a database that is in fact complete.

Every one of those edges demanded one of two flows whose names end in "placed in landfill". Neither is a product. An EcoSpold 2 source declares a handful of **inventory indicators**: elementary flows that record how much waste an activity accounts for, so that a method can characterize the total. They sit in compartment `inventory indicator`, subcompartment `waste`, and they have no producer by construction.

## The cause

The parser matched that compartment and routed those `elementaryExchange` entries to the technosphere waste axis. A dataset commonly writes such an indicator with `inputGroup 4`, and on the waste axis an input is a supplier demand. Two of the indicators are written that way throughout, so each dataset carrying them asked for a supplier no activity in any database can be.

The same move had a second, quieter effect: only biosphere flows are characterized, so an indicator built to carry a method's factors could no longer carry any.

A detail that settles the intent: the same indicator appears as `inputGroup 4` in some datasets and `outputGroup 4` in others. It is a counter, not an edge.

## The fix

An `elementaryExchange` stays on the biosphere axis whatever its compartment reads. The one waste marker EcoSpold 2 carries is the `intermediateExchange` classified `By-product classification = Waste`, which is untouched.

Cache signature raised to 25: nothing changes type, so a cache written before this would pass the fingerprint and keep serving those flows from the wrong axis.

## The consequence for the SimaPro writer

Handing these flows back to the biosphere axis gave that writer a medium it had no section for. Its export guard refuses any emission whose medium is not air, water or soil, so a database carrying an indicator written as an output would have been refused outright; one written as an input would have been filed under "Resources" and read back as an extraction.

SimaPro has the right section already, and a source's own SimaPro export uses it: every inventory indicator is filed under **Final waste flows**. The writer now does the same, keyed on the medium rather than the direction, and the medium guard lets it through.

The direction is settled at parse, for the same reason the group is not information: recording the output direction keeps a flow's direction from depending on which dataset one happens to look at, and keeps the Brightway writer's round-trip exact, since that writer does not store direction and the reader rebuilds it from the compartment.

## Verification

Full reload of a large EcoSpold 2 database, cache bypassed:

| | before | after |
|---|---|---|
| unsupplied edges | thousands | **0** |
| completeness | 99.3% | **100%** |

The technosphere input count drops by exactly the number of edges that disappeared: those were the phantom demands. On a landfill dataset, the indicators come back as biosphere flows carrying their `inventory indicator / waste` compartment, while the genuine waste input beside them stays on the waste axis and resolves.

The SimaPro export of that same database succeeds and files all four of its inventory indicators under "Final waste flows", in the counts the source itself states. The Brightway Excel export of it is still refused, for two reasons that predate this change and that it does not touch: a waste exchange that links to a producer, and a resource-direction flow in an `air` compartment.

Full suite: 2,474 examples, 6 environment-only failures (ServerSpec looks for the binary under `dist-newstyle`; the build was made elsewhere).
