### PR TITLE
Name the right-hand side of the LCA equation

### DIFF
--- a/src/Matrix.hs
+++ b/src/Matrix.hs
@@ -33,6 +33,7 @@ Performance characteristics:
 -}
 module Matrix (
     Vector,
+    Demand (..),
     Inventory,
     SupplierDemands,
     DepDemands,
@@ -81,6 +82,7 @@ import Control.Concurrent.STM (
  )
 import Control.Exception (SomeException, catch, evaluate, throwIO, toException, try)
 import Control.Monad (forM_, unless, void, when)
+import Data.Coerce (coerce)
 import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
 import Data.Int (Int32)
 import qualified Data.Map as M
@@ -99,6 +101,13 @@ import qualified UnitConversion
 
 -- | Simple vector operations (replacing hmatrix dependency)
 type Vector = U.Vector Double
+
+{- | The right-hand side @d@ of @(I - A) x = d@: what a functional unit asks
+of the system, one entry per activity column. The solution @x@ it produces
+is a plain 'Vector', which is what keeps the two from being confused: a
+demand can be solved, and nothing else accepts one.
+-}
+newtype Demand = Demand {unDemand :: Vector}
 
 -- | Final inventory vector mapping biosphere flow UUIDs to quantities.
 type Inventory = M.Map UUID Double
@@ -477,7 +486,7 @@ computeInventoryMatrixBatch _ _ [] = pure []
 computeInventoryMatrixBatch db fact pids = do
     let activityIndex = dbActivityIndex db
         demandVecs = map (buildDemandVectorFromIndex activityIndex) pids
-    scalingVecs <- solveSparseLinearSystemWithFactorizationMulti fact demandVecs
+    scalingVecs <- solveSparseLinearSystemWithFactorizationMulti fact (coerce demandVecs)
     mapConcurrently (\x -> evaluate $! applyBiosphereMatrix db x) scalingVecs
 
 {- |
@@ -546,7 +555,7 @@ computeScalingVector db rootProcessId = do
         techTriples = dbTechnosphereTriples db
         activityIndex = dbActivityIndex db
         demandVec = buildDemandVectorFromIndex activityIndex rootProcessId
-    solveSparseLinearSystem [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList techTriples] (fromIntegral activityCount) demandVec
+    solveSparseLinearSystem [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList techTriples] (fromIntegral activityCount) (unDemand demandVec)
 
 {- |
 Apply the biosphere matrix to a scaling vector: g = B * x.
@@ -904,12 +913,12 @@ depDemandsToVector ::
     Text ->
     Database ->
     SupplierDemands ->
-    Either Text Vector
+    Either Text Demand
 depDemandsToVector unitConfig depDbName depDb demands = do
     converted <- traverse convertEntry (M.toList demands)
     let n = fromIntegral (dbActivityCount depDb) :: Int
         entries = catMaybes converted
-    Right $ U.accum (+) (U.replicate n 0.0) entries
+    Right $ Demand $ U.accum (+) (U.replicate n 0.0) entries
   where
     actIdx = dbActivityIndex depDb
     procLookup = dbProcessIdLookup depDb
@@ -952,14 +961,14 @@ The demand vector represents external demand for products from each activity:
 - f[i] = 1.0 for the root activity (functional unit)
 - f[i] = 0.0 for all other activities
 -}
-buildDemandVectorFromIndex :: V.Vector Int32 -> ProcessId -> Vector
+buildDemandVectorFromIndex :: V.Vector Int32 -> ProcessId -> Demand
 buildDemandVectorFromIndex activityIndex rootProcessId =
     let n = V.length activityIndex
         rootIndex =
             if fromIntegral rootProcessId >= (0 :: Int) && fromIntegral rootProcessId < n
                 then fromIntegral $ activityIndex V.! fromIntegral rootProcessId
                 else error $ "FATAL: ProcessId not found in activity index: " ++ show rootProcessId
-     in fromList [if i == rootIndex then 1.0 else 0.0 | i <- [0 .. n - 1 :: Int]]
+     in Demand $ fromList [if i == rootIndex then 1.0 else 0.0 | i <- [0 .. n - 1 :: Int]]
 
 {- |
 Pre-compute matrix factorization for concurrent inventory calculations.

--- a/src/Matrix/Export.hs
+++ b/src/Matrix/Export.hs
@@ -14,7 +14,7 @@ module Matrix.Export (
 ) where
 
 import Database (filterByName, flowSearchFields)
-import Matrix (applySparseMatrix, buildDemandVectorFromIndex, solveSparseLinearSystem, toList)
+import Matrix (Demand (..), applySparseMatrix, buildDemandVectorFromIndex, solveSparseLinearSystem, toList)
 import Progress (ProgressLevel (..), reportProgress)
 import Types
 
@@ -66,7 +66,7 @@ extractMatrixDebugInfo database targetProcessId flowFilter = do
         activityCount = dbActivityCount database
         bioFlowCount = dbBiosphereCount database
 
-        demandVec = buildDemandVectorFromIndex activityIndexVec targetProcessId
+        demandVec = unDemand (buildDemandVectorFromIndex activityIndexVec targetProcessId)
         demandList = toList demandVec
 
         techTriplesInt = [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList techTriples]

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -32,7 +32,7 @@ import qualified Data.Vector.Unboxed as U
 import Database (IdentifierReach (..), activitiesIdentifiedBy, applyStructuredFilters, findActivitiesByFields, findFlowsBySynonym, flowNameRelevance)
 import Database.Allocation (asAllocated, describeRefusal, propertyShares)
 import Database.MatrixBuild (findProducer, linkedProducer)
-import Matrix (DepDemands, Inventory, SupplierDemands, accumulateDepDemandsWith, activityNormalizationFactor, applyBiosphereMatrix, buildDemandVectorFromIndex, computeInventoryMatrix, depDemandsToVector, perturbA, perturbABatch, perturbGlobal, toList)
+import Matrix (Demand (..), DepDemands, Inventory, SupplierDemands, accumulateDepDemandsWith, activityNormalizationFactor, applyBiosphereMatrix, buildDemandVectorFromIndex, computeInventoryMatrix, depDemandsToVector, perturbA, perturbABatch, perturbGlobal, toList)
 import qualified Matrix.Export as MatrixExport
 import qualified Progress
 import qualified Search.BM25 as BM25
@@ -2432,7 +2432,7 @@ goWithSubsAndDeps ::
     -- | THIS DB's cached solver
     SharedSolver ->
     -- | demand vectors at this level
-    [U.Vector Double] ->
+    [Demand] ->
     -- | full sub list (filtered per level)
     [Substitution] ->
     -- | recursion depth

--- a/src/SharedSolver.hs
+++ b/src/SharedSolver.hs
@@ -43,6 +43,7 @@ module SharedSolver (
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Concurrent.MVar (MVar, modifyMVar_, newMVar, readMVar, withMVar)
 import Control.Exception (SomeException, try)
+import Data.Coerce (coerce)
 import Data.List (transpose)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
@@ -51,6 +52,7 @@ import Data.Maybe (catMaybes)
 import qualified Data.Set as S
 import Data.Text (Text)
 import Matrix (
+    Demand (..),
     DepDemands,
     Inventory,
     Vector,
@@ -110,8 +112,8 @@ computeAndStoreFactorization solver = do
     pure fact
 
 -- | Solve using shared solver. On first call, triggers lazy factorization.
-solveWithSharedSolver :: SharedSolver -> Vector -> IO Vector
-solveWithSharedSolver solver demandVector =
+solveWithSharedSolver :: SharedSolver -> Demand -> IO Vector
+solveWithSharedSolver solver (Demand demandVector) =
     withMVar (solverLock solver) $ \_ ->
         readMVar (solverFactorizationVar solver) >>= \case
             Just fact -> do
@@ -141,10 +143,10 @@ ensureFactorization solver = withMVar (solverLock solver) $ \_ ->
 {- | Solve with multiple RHS vectors in one MUMPS call, using the cached factorization.
 Forces factorization on first call. Subsequent calls reuse the cached LU.
 -}
-solveMultiWithSharedSolver :: SharedSolver -> [Vector] -> IO [Vector]
+solveMultiWithSharedSolver :: SharedSolver -> [Demand] -> IO [Vector]
 solveMultiWithSharedSolver solver demandVecs = do
     fact <- ensureFactorization solver
-    solveSparseLinearSystemWithFactorizationMulti fact demandVecs
+    solveSparseLinearSystemWithFactorizationMulti fact (coerce demandVecs)
 
 {- | Compute the scaling vector for @pid@, routing through the shared solver's
 lazy factorization cache. Same shape as 'Matrix.computeScalingVector' but
@@ -276,7 +278,7 @@ goWithDeps ::
     Text ->
     SharedSolver ->
     -- | K demand vectors, length = dbActivityCount db
-    [Vector] ->
+    [Demand] ->
     -- | recursion depth
     Int ->
     IO (Either Text [CrossDBSolution])
@@ -365,7 +367,7 @@ vectors, performing unit conversion. Picks out @depDbName@'s share of each
 root's demands. Shared by every dep resolver (inventory, contributions, and
 the substitution-aware path in 'Service').
 -}
-prepareDepDemandVecs :: UnitConfig -> Text -> Database -> [DepDemands] -> Either Text [Vector]
+prepareDepDemandVecs :: UnitConfig -> Text -> Database -> [DepDemands] -> Either Text [Demand]
 prepareDepDemandVecs unitConfig depDbName depDb =
     traverse (depDemandsToVector unitConfig depDbName depDb . M.findWithDefault M.empty depDbName)
 
@@ -435,7 +437,7 @@ crossDBProcessContributions unitConfig unitDB flowDB depLookup rootDb rootName r
         Database ->
         Text ->
         SharedSolver ->
-        [Vector] ->
+        [Demand] ->
         Int ->
         IO (Either Text (M.Map (Text, ProcessId) Double))
     go db dbName solver demands depth = do

--- a/test/CoalescingSolverSpec.hs
+++ b/test/CoalescingSolverSpec.hs
@@ -15,6 +15,7 @@ import Control.Concurrent.Async (concurrently, mapConcurrently)
 import qualified Data.Text as T
 import qualified Data.Vector.Unboxed as U
 import Matrix (
+    Demand (..),
     Vector,
     buildDemandVectorFromIndex,
     clearCachedSolver,
@@ -57,7 +58,7 @@ spec = do
     describe "single-RHS regression (batch of 1)" $ do
         it "submitOne path produces the oracle result" $ do
             (_solver, fact, db) <- min3CachedSolver
-            let demand = buildDemandVectorFromIndex (dbActivityIndex db) 0
+            let demand = unDemand (buildDemandVectorFromIndex (dbActivityIndex db) 0)
             expected <- oracleSolve db demand
             actual <- solveSparseLinearSystemWithFactorization fact demand
             U.toList actual `shouldSatisfy` closeTo (U.toList expected)
@@ -91,7 +92,7 @@ spec = do
     describe "solve counter" $ do
         it "moves on the cached path, the batch path and the fresh path" $ do
             (_solver, fact, db) <- min3CachedSolver
-            let demand = buildDemandVectorFromIndex (dbActivityIndex db) 0
+            let demand = unDemand (buildDemandVectorFromIndex (dbActivityIndex db) 0)
             before <- readSolveCounter
             _ <- solveSparseLinearSystemWithFactorization fact demand
             afterSingle <- readSolveCounter
@@ -105,7 +106,7 @@ spec = do
     describe "clean shutdown" $ do
         it "clearCachedSolver lets the next request fall back without deadlock" $ do
             (_solver, fact, db) <- min3CachedSolver
-            let demand = buildDemandVectorFromIndex (dbActivityIndex db) 0
+            let demand = unDemand (buildDemandVectorFromIndex (dbActivityIndex db) 0)
             expected <- oracleSolve db demand
             clearCachedSolver cacheKey
             -- After clear, the cache lookup misses and we fall back to a fresh
@@ -141,7 +142,7 @@ Repeating these via 'cycle' gives us many varied (but reproducible) inputs.
 -}
 basicDemands :: Database -> [Vector]
 basicDemands db =
-    let n = U.length (buildDemandVectorFromIndex (dbActivityIndex db) 0)
+    let n = U.length (unDemand (buildDemandVectorFromIndex (dbActivityIndex db) 0))
      in [ unitOn n 0
         , unitOn n 1
         , unitOn n 2

--- a/test/CrossDBInventorySpec.hs
+++ b/test/CrossDBInventorySpec.hs
@@ -11,6 +11,8 @@ we test:
    cross-DB links reduces exactly to the local-only batch variant.
 3. that 'depDemandsToVector' honours the supplier's reference unit and
    fails hard on unknown unit pairs.
+4. that 'prepareDepDemandVecs' answers one vector per root, and picks out
+   this dep's share of each root's demands rather than another dep's.
 -}
 module CrossDBInventorySpec (spec) where
 
@@ -22,7 +24,7 @@ import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
-import Matrix (accumulateDepDemands, depDemandsToVector)
+import Matrix (DepDemands, accumulateDepDemands, depDemandsToVector)
 import Method.Mapping (CF (..), CFUnit (..), MethodTables (..), inventoryContributions)
 import qualified Method.Mapping as Mapping
 import Method.Types (CFFamily (..), FlowDirection (..), MethodCF (..))
@@ -95,6 +97,32 @@ spec = do
                         Left err -> do
                             err `shouldSatisfy` T.isInfixOf "Unknown unit conversion"
                             err `shouldSatisfy` T.isInfixOf "dep-test"
+
+    describe "prepareDepDemandVecs" $ do
+        it "returns one vector per root, each as long as the dep DB" $ do
+            db <- loadSampleDatabase "SAMPLE.min3"
+            let n = fromIntegral (dbActivityCount db) :: Int
+                perRoot = [M.empty, M.empty, M.empty] :: [DepDemands]
+            case SharedSolver.prepareDepDemandVecs defaultUnitConfig "SAMPLE.min3" db perRoot of
+                Right vecs -> do
+                    length vecs `shouldBe` 3
+                    map U.length vecs `shouldBe` replicate 3 n
+                Left err -> expectationFailure (T.unpack err)
+
+        it "gives an all-zero vector for a root that demands nothing of this dep" $ do
+            db <- loadSampleDatabase "SAMPLE.min3"
+            case firstActivityWithRefUnit db of
+                Nothing -> pendingWith "SAMPLE.min3 has no activity with a reference output unit"
+                Just (supplierKey, supplierIdx, refUnit) -> do
+                    -- Two roots: the first demands of another dep, the second of this one.
+                    let otherDep = M.singleton "some-other-db" (M.singleton supplierKey (7.5, refUnit))
+                        thisDep = M.singleton "SAMPLE.min3" (M.singleton supplierKey (7.5, refUnit))
+                    case SharedSolver.prepareDepDemandVecs defaultUnitConfig "SAMPLE.min3" db [otherDep, thisDep] of
+                        Right [absent, present] -> do
+                            U.all (== 0.0) absent `shouldBe` True
+                            present U.! supplierIdx `shouldBe` 7.5
+                        Right _ -> expectationFailure "expected one vector per root"
+                        Left err -> expectationFailure (T.unpack err)
 
     describe "computeInventoryMatrixBatchWithDepsCached" $ do
         it "matches local-only batch for a DB with no cross-DB links" $ do

--- a/test/CrossDBInventorySpec.hs
+++ b/test/CrossDBInventorySpec.hs
@@ -24,7 +24,7 @@ import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
-import Matrix (DepDemands, accumulateDepDemands, depDemandsToVector)
+import Matrix (Demand (..), DepDemands, accumulateDepDemands, depDemandsToVector)
 import Method.Mapping (CF (..), CFUnit (..), MethodTables (..), inventoryContributions)
 import qualified Method.Mapping as Mapping
 import Method.Types (CFFamily (..), FlowDirection (..), MethodCF (..))
@@ -59,7 +59,7 @@ spec = do
             db <- loadSampleDatabase "SAMPLE.min3"
             let n = fromIntegral (dbActivityCount db) :: Int
             case depDemandsToVector defaultUnitConfig "SAMPLE.min3" db M.empty of
-                Right vec -> do
+                Right (Demand vec) -> do
                     U.length vec `shouldBe` n
                     U.all (== 0.0) vec `shouldBe` True
                 Left err -> expectationFailure (T.unpack err)
@@ -70,7 +70,7 @@ spec = do
                 fakeSupplier = (UUID.nil, UUID.nil)
                 demands = M.singleton fakeSupplier (42.0, "kg")
             case depDemandsToVector defaultUnitConfig "SAMPLE.min3" db demands of
-                Right vec -> do
+                Right (Demand vec) -> do
                     U.length vec `shouldBe` n
                     U.all (== 0.0) vec `shouldBe` True
                 Left err -> expectationFailure (T.unpack err)
@@ -82,7 +82,7 @@ spec = do
                 Just (supplierKey, supplierIdx, refUnit) -> do
                     let demands = M.singleton supplierKey (7.5, refUnit)
                     case depDemandsToVector defaultUnitConfig "SAMPLE.min3" db demands of
-                        Right vec -> vec U.! supplierIdx `shouldBe` 7.5
+                        Right (Demand vec) -> vec U.! supplierIdx `shouldBe` 7.5
                         Left err -> expectationFailure (T.unpack err)
 
         it "fails hard when the unit pair is unknown" $ do
@@ -106,7 +106,7 @@ spec = do
             case SharedSolver.prepareDepDemandVecs defaultUnitConfig "SAMPLE.min3" db perRoot of
                 Right vecs -> do
                     length vecs `shouldBe` 3
-                    map U.length vecs `shouldBe` replicate 3 n
+                    map (U.length . unDemand) vecs `shouldBe` replicate 3 n
                 Left err -> expectationFailure (T.unpack err)
 
         it "gives an all-zero vector for a root that demands nothing of this dep" $ do
@@ -118,7 +118,7 @@ spec = do
                     let otherDep = M.singleton "some-other-db" (M.singleton supplierKey (7.5, refUnit))
                         thisDep = M.singleton "SAMPLE.min3" (M.singleton supplierKey (7.5, refUnit))
                     case SharedSolver.prepareDepDemandVecs defaultUnitConfig "SAMPLE.min3" db [otherDep, thisDep] of
-                        Right [absent, present] -> do
+                        Right [Demand absent, Demand present] -> do
                             U.all (== 0.0) absent `shouldBe` True
                             present U.! supplierIdx `shouldBe` 7.5
                         Right _ -> expectationFailure "expected one vector per root"

--- a/test/SensitivitySpec.hs
+++ b/test/SensitivitySpec.hs
@@ -19,7 +19,7 @@ import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector.Unboxed as U
-import Matrix (applyShermanMorrison, buildDemandVectorFromIndex, perturbA, solveSparseLinearSystem)
+import Matrix (Demand (..), applyShermanMorrison, buildDemandVectorFromIndex, perturbA, solveSparseLinearSystem)
 import Service (computeSensitivities)
 import SharedSolver (getFactorization, solveWithSharedSolver)
 import Test.Hspec
@@ -188,7 +188,7 @@ spec = do
                     | SparseTriple i j v <- techTriples
                     ]
                 n = fromIntegral (dbActivityCount db)
-                demand = buildDemandVectorFromIndex (dbActivityIndex db) 0
+                demand = unDemand (buildDemandVectorFromIndex (dbActivityIndex db) 0)
             xRef <- solveSparseLinearSystem scaledTriples n demand
 
             -- Compare element-wise within tight numerical tolerance.


### PR DESCRIPTION
**Target.** A demand stops being spelled like everything else the solver
touches: the right-hand side of `(I - A) x = d` gets a name of its own, so a
function that wants a solution can no longer be handed one.

**Axis.** Invalid states (a convention kept in every reader's head).

**Problem.** `type Vector = U.Vector Double` (`src/Matrix.hs:101`) was the only
name the engine had for both sides of `(I - A) x = d`. What told the two apart
was a doc comment, and the sharpest proof is a pair of adjacent functions:
`goWithDeps` takes a `[Vector]` documented `-- | K demand vectors`
(`src/SharedSolver.hs:278`) and calls `goWithDepsFromScalings`, whose `[Vector]`
is documented `-- | K pre-computed root scaling vectors`
(`src/SharedSolver.hs:309`). The parameter is the same type and the opposite
thing. `applyBiosphereMatrix :: Database -> Vector -> Inventory`
(`src/Matrix.hs:565`) needs a solution: handed a demand it returns an inventory
that is arithmetically well formed and wrong, and nothing stopped that call.
`Service.hs` wrote the same alias out longhand as `U.Vector Double` in eleven
places across nine signatures (`:1779`, `:1932`, `:1986`, `:2049`, `:2199`,
`:2233`, `:2423`, `:2516`, `:2708`), so the vocabulary does not even have one
spelling.

**Transformation.** One newtype, `Demand`, over `U.Vector Double`, declared and
exported by `Matrix`. The three functions that produce a right-hand side return
it (`buildDemandVectorFromIndex`, `depDemandsToVector`, `prepareDepDemandVecs`),
and the four that consume one take it (`solveWithSharedSolver`,
`solveMultiWithSharedSolver`, `goWithDeps` and Service's own
`goWithSubsAndDeps`). Solutions keep `Vector`, which is what makes
the change small and what makes it bite: `goWithDeps` and
`goWithDepsFromScalings` are then told apart by the compiler rather than by
their comments, and `applyBiosphereMatrix` can no longer be given a demand.

**Behaviour to preserve.** Every number the engine computes: a newtype erases at
runtime, so the arithmetic is unchanged and the only real risk is a producer
wrapped where a consumer was meant. Nothing serialises one of these vectors:
the sole vector instances in the tree are on `SparseTriple`
(`src/Types.hs:997`, `:1016`, `:1042`), `Matrix/Export.hs` converts to
`[Double]` before exporting, and the MUMPS FFI marshals
`Data.Vector.Storable` inside `solveChunk` and `solveSparseLinearSystemMUMPS`,
below the seam. The list positions (`[Demand]`) are written with `coerce`, not
`map Demand`, so "erases at runtime" stays literally true. Pinned by
`SharedSolverSpec`, `CoalescingSolverSpec`, `CrossDBInventorySpec`,
`SensitivitySpec`, `CopySpec`, `GlobalSubstitutionSpec` and
`NestedSubstitutionSpec`. `prepareDepDemandVecs` was pinned by nothing, so the
first commit writes what it answers: one vector per root, and this dependency's
share of each root's demands rather than another's.

**Done when.** Met:
- `Demand` is declared and exported by `Matrix`, over `U.Vector Double`, with the doc comment saying which side of the equation it is.
- `buildDemandVectorFromIndex`, `depDemandsToVector` and `prepareDepDemandVecs` return a `Demand`.
- `solveWithSharedSolver :: SharedSolver -> Demand -> IO Vector` and `solveMultiWithSharedSolver :: SharedSolver -> [Demand] -> IO [Vector]`.
- `goWithDeps` takes `[Demand]` while `goWithDepsFromScalings` keeps `[Vector]`, so a doc comment is no longer what distinguishes them.
- `applyBiosphereMatrix db demand` no longer type-checks.
- Solutions are untouched: no `Scaling` type, `csScalings` unchanged, the Sherman-Morrison path unchanged, `Method/Mapping.hs`, `API/Routes.hs`, `API/MCP.hs` and `Impact.hs` unopened.
- Every `[Demand]` position is `coerce`, not `map Demand`.
- No `Store`, `ToJSON` or `FromJSON` instance moved, no wildcard arm added.
- `hlint src app test` clean, cold `-Werror` build green, suite at 2475 examples, 0 failures, 2 pending (2473 before, plus the two the characterisation adds), string-literal diff over the touched files carrying only the five literals that test brings.

This target needs no second pass.

<details>
<summary>For the next run: not chosen, behaviour changes, numbers</summary>

**Cut from this target by the falsifier, so first on the list**

- `Scaling`, the other side of `(I - A) x = d`, for the solution positions in `src/Matrix.hs`, `src/SharedSolver.hs`, `src/Service.hs`, `src/Impact.hs`, `src/Method/Mapping.hs` (six positions), `src/API/Routes.hs:616`, `src/API/MCP.hs:1369` and `src/Matrix/Export.hs`. It wants `LevelScaling` and `csScalings` with it, and it has to answer what the Sherman-Morrison `z` is called, since it is neither a demand nor a scaling of anything.

**Would change behaviour, so reported and not fixed**

- `src/Tree.hs:111-117` — an exchange whose flow UUID is in no flow table is dropped by `_ -> buildChildren cfg exs visited depth`, while a link no row satisfies becomes `TreeMissing`. The right behaviour is to match `(Just target, Nothing)` and emit a missing-shaped leaf, or at the least count it in `TreeMetadata`; a data gap the quality report counts currently vanishes from the tree the SPA draws.
- `src/Matrix.hs:970` — `error $ "FATAL: ProcessId not found in activity index"`, a range check the caller has usually already made as `Service.validateProcessIdInMatrixIndex` (`src/Service.hs:223`). Should be `Either Text`.
- `src/Service.hs:808`, `:1925`, `:3045` — four `_ ->` arms make a misspelt sort column fall back to the default order in silence; `sort=nmae` answers as if nothing were wrong. The right behaviour is a sum type per listing and a 400 on an unknown word.
- `src/Config.hs:114-118` — `ceMode == "exact"` reads any misspelt classification mode as `contains`; should be a parsed sum and a configuration error.
- `src/Service.hs:1333` returns `("", 1.0, "")` for an activity with no reference product while `src/API/MCP.hs:1226`, `:1843` and `src/API/Routes.hs:375` fall back to `("", 0, "")`; one `Maybe ReferenceProduct` is behaviour-free, but making the two defaults agree is not.
- `src/Database.hs:92` — `dbActivityIndex` is `V.generate n fromIntegral` at both construction sites, so it can only be the identity; deleting it is a cache-layout change, and `Method/Mapping.hs:2896` inverts it to recover what it never changed.

**Not chosen, ranked**

Invalid states:
- `DbName` newtype for the ~35 signatures that name a database with a bare `Text` (`src/SharedSolver.hs:85`, `:174`, `:231`; `src/Matrix.hs:142`, `:904`; `src/Service.hs:2866` `resolveEndpoint :: Text -> Text`) — the strongest candidate after this one, and the natural next run; dropped on locality, since it also rewrites `RootDb`/`ThisDb` in `API/Types.hs`.
- `ClassificationFilter` record for `(Text, Text, Bool)` across nine modules (`src/Service.hs:56`, `src/Database.hs:305`) — was also #395's runner-up, dropped on locality again.
- `NameReach = WholeName | NameOrFragment` for the exact-match `Bool` (`src/Database.hs:192`, `src/Service.hs:69`), with `IdentifierReach` two hundred lines away already naming the same choice for identifiers.
- `Maybe ReferenceProduct` for `getReferenceProductInfo`'s `("", 1.0, "")` (`src/Service.hs:1333`).
- `SupplierDemands = M.Map ProcessRef StatedAmount` (`src/Matrix.hs:109`) — both types already exist in `Types.hs`; a swappable UUID pair and an amount travelling without its unit, in three modules.
- `NodeId` for the tree node key, which is a process id or `missing:<uuid>` (`src/Service.hs:351`); `mkTechnosphereTreeEdge` takes two of them in a row.
- `LevelScaling` record for `csScalings :: NonEmpty (Text, Database, Vector)` (`src/SharedSolver.hs:196`) — where `DbName` and `Scaling` meet, so it wants both first.
- `ProcessRef` in `InterningTables` and the two `dbProcessIdTable`/`dbProcessIdLookup` fields (`src/Database/MatrixBuild.hs:43`) — needs the cache-bytes assertion #390 wrote.
- `PathToResponse`/`PathStep` for `getPathTo`'s untyped `Value` (`src/Service.hs:1669`), one of eight `Value`-returning Service functions.
- `ConsumerColumn` for `techTriple`'s nine positional parameters (`src/Database/MatrixBuild.hs:163`) — smallest thing here, one file.
- `computeScalingVectorWithSubstitutions` takes a `[Substitution]` its own comment says must be empty, and all three callers pass `[]` (`src/Service.hs:2199`).

Hidden dependencies:
- `cachedSolver`, a module-level `MVar (Map Text CoalescingSolver)` keyed by database name (`src/Matrix.hs:142`), beside `SharedSolver`, the per-database handle that is passed by signature; `clearCachedSolver` keeps them in step by hand from four call sites.

Duplication:
- The solver keeps A as a boxed `[(Int, Int, Double)]` unpacked from the `VU.Vector SparseTriple` the database holds (`src/SharedSolver.hs:81`), a second spelling of the technosphere matrix kept alive for the solver's lifetime.

Module organisation:
- `src/Service.hs` is 3120 lines, and the five move checks put a seam under supply chain plus substitutions (about 1340 lines, `:1635-2975`), which imports `Service` the way `Service/Aggregate.hs` already does and adds no back edge. After the types above have made that boundary read as one subject.

**Seen, not touched.** Nothing.

**Numbers.** `src/Matrix.hs` 998 lines to 1007, the declaration and its doc comment; `src/SharedSolver.hs` 474 to 476; `src/Service.hs` 3120 and `src/Matrix/Export.hs` 367, both unchanged. Signatures, tuples, `Bool` counts and every depth number unchanged; bare primitives in `src/Service.hs` 124 to 123. The code got nine lines longer, which is what a new type costs; what was bought is a demand the compiler can tell from a solution.

**Falsifier, four verdicts.**
1. Problem holds. Two corrections applied: eleven occurrences across nine
   signatures in `Service.hs`, not twelve; and it is the `[Vector]` *parameter*
   that the two walkers share, not their whole type, since
   `goWithDepsFromScalings` carries an extra `[CrossDBLink]`.
2. Preserves. No instance, no `unsafeCoerce`, no FFI or unboxed operation
   depends on the bare type; the MUMPS marshalling is `Data.Vector.Storable`
   and sits below the seam. It asked for `coerce` at the list positions rather
   than `map`, which the block now requires.
3. **Boundary rejected and replaced.** The original target typed solutions too,
   which reached nine modules (four outside the run's scope) and, worse, made
   `applyShermanMorrisonV :: Scaling -> [(Int, Double)] -> Scaling -> ...` carry
   two parameters of one new type at the one place the arithmetic is asymmetric
   (`x` and `z` are not interchangeable) - the swap hazard the target exists to
   remove, reintroduced. It also showed the seam could not be literal:
   `Matrix.toList` is called on a demand at `Matrix/Export.hs:70` and on a
   solution at `Service.hs:713`. `Demand` alone is its proposal, taken as
   written: five source modules, no `z` to name, and the
   `applyBiosphereMatrix` bug still killed.
4. "Done when" checkable, with three corrections applied: `computeInventoryMatrix`
   takes no vector at all (`src/Matrix.hs:587` is `Database -> ProcessId -> IO
   Inventory`), so that line is gone with the rest of the solution side;
   `accumulateDepDemandsWith`'s untested non-empty case is no longer in the
   boundary; and `prepareDepDemandVecs` is pinned by nothing, which the first
   commit fixes.

**Scope of the run.** Seven files read, the computation core: `Service.hs`, `Matrix.hs`, `Database.hs`, `SharedSolver.hs`, `Impact.hs`, `Tree.hs`, `Database/MatrixBuild.hs`. Left out because the whole tree's signature listing is 8541 lines: `API/Types.hs`, `Types.hs`, `API/Routes.hs`, `Database/Manager.hs`, `Database/Loader.hs`, `Config.hs` and the rest. Reader on `claude-fable-5-1`, falsifier on `claude-opus-5`.

</details>
