### PR TITLE
Report the functional unit a score is actually per

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@
   complete. They are elementary flows again: they appear in the inventory
   where a method can characterize them, and the gap report is empty. Caches
   built before this are rebuilt on the next load.
+- The functional unit reported beside a score now says what the score is
+  actually per: one unit of the reference product. It used to repeat the
+  amount the source declares the process produces, which for a coproduct is
+  rarely one: the cream of an Agribalyse cheese block is stated at
+  0.0686462 kg, so the score came back labelled `0.07 kg of cream` while the
+  number itself was per kilogram, every coefficient of the column having been
+  divided by that amount. The same applies to a reference product ingested in
+  a canonical unit, a 1 kWh product read as 3.6 mj and scored per megajoule.
+  The Python client's documentation said the same thing wrongly and now
+  states that `product_amount` describes what the block produces, not the
+  basis of the score.
 - An EcoSpold 2 dataset whose block a key divides into several processes now
   says that only one of them will be kept. A process is identified by its file
   name there, which names a single product, so the coproducts a key had just

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -1297,12 +1297,13 @@ and is what you pass to every detail endpoint (`Client.get_activity`,
 ``activity_name`` is the activity name (e.g. ``"wheat flour, at plant"``);
 ``product_name`` is the reference output product (e.g. ``"wheat flour"``);
 ``product_amount`` and ``product_unit`` are what the source says this
-process produces, in the canonical unit of its dimension (typically
-``1.0`` of ``"kg"`` / ``"mj"``; a 1 kWh reference product imported from
-SimaPro or Brightway Excel reads ``3.6`` of ``"mj"``, and a coproduct a
-block states at 0.0686462 kg reads that). It is not the basis a score or
-an inventory is reported against: those are always per **one**
-``product_unit``, whatever the amount here.
+process produces (typically ``1.0`` of ``"kg"`` / ``"mj"`` / etc.; a
+database imported from SimaPro or Brightway Excel states it in the
+canonical unit of its dimension, so a 1 kWh reference product reads
+``3.6`` of ``"mj"``, and a coproduct its block states at 0.0686462 kg
+reads that). It is not the basis a score or an inventory is reported
+against: those are always per **one** ``product_unit``, whatever the
+amount here.
 ``location`` is the
 geography code (``"FR"``, ``"GLO"``, ``"RoW"``…). A process has no name of
 its own; compose a label from ``activity_name`` + ``product_name``.

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -1296,10 +1296,13 @@ and is what you pass to every detail endpoint (`Client.get_activity`,
 `Client.get_supply_chain`, `Client.get_impacts`, …).
 ``activity_name`` is the activity name (e.g. ``"wheat flour, at plant"``);
 ``product_name`` is the reference output product (e.g. ``"wheat flour"``);
-``product_amount`` and ``product_unit`` describe the functional unit
-(typically ``1.0`` of ``"kg"`` / ``"mj"`` / etc.; a database imported from
-SimaPro or Brightway Excel states it in the canonical unit of its
-dimension, so a 1 kWh reference product reads ``3.6`` of ``"mj"``).
+``product_amount`` and ``product_unit`` are what the source says this
+process produces, in the canonical unit of its dimension (typically
+``1.0`` of ``"kg"`` / ``"mj"``; a 1 kWh reference product imported from
+SimaPro or Brightway Excel reads ``3.6`` of ``"mj"``, and a coproduct a
+block states at 0.0686462 kg reads that). It is not the basis a score or
+an inventory is reported against: those are always per **one**
+``product_unit``, whatever the amount here.
 ``location`` is the
 geography code (``"FR"``, ``"GLO"``, ``"RoW"``…). A process has no name of
 its own; compose a label from ``activity_name`` + ``product_name``.
@@ -2093,6 +2096,10 @@ LCIA score for one impact category on one activity.
 
 Returned directly by `Client.get_impacts`, and nested inside
 `LCIABatchResult.results` (one entry per impact category).
+
+``functional_unit`` is the basis ``score`` is reported against, and it is
+always one unit of the reference product (``"1.00 kg of cream"``) however
+much of it the source says the process produces.
 
 | Field | Type | Default |
 |-------|------|---------|

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -538,12 +538,13 @@ class Activity(FromJson):
     ``activity_name`` is the activity name (e.g. ``"wheat flour, at plant"``);
     ``product_name`` is the reference output product (e.g. ``"wheat flour"``);
     ``product_amount`` and ``product_unit`` are what the source says this
-    process produces, in the canonical unit of its dimension (typically
-    ``1.0`` of ``"kg"`` / ``"mj"``; a 1 kWh reference product imported from
-    SimaPro or Brightway Excel reads ``3.6`` of ``"mj"``, and a coproduct a
-    block states at 0.0686462 kg reads that). It is not the basis a score or
-    an inventory is reported against: those are always per **one**
-    ``product_unit``, whatever the amount here.
+    process produces (typically ``1.0`` of ``"kg"`` / ``"mj"`` / etc.; a
+    database imported from SimaPro or Brightway Excel states it in the
+    canonical unit of its dimension, so a 1 kWh reference product reads
+    ``3.6`` of ``"mj"``, and a coproduct its block states at 0.0686462 kg
+    reads that). It is not the basis a score or an inventory is reported
+    against: those are always per **one** ``product_unit``, whatever the
+    amount here.
     ``location`` is the
     geography code (``"FR"``, ``"GLO"``, ``"RoW"``…). A process has no name of
     its own; compose a label from ``activity_name`` + ``product_name``.

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -303,6 +303,10 @@ class LCIAResult:
 
     Returned directly by :meth:`Client.get_impacts`, and nested inside
     :class:`LCIABatchResult.results` (one entry per impact category).
+
+    ``functional_unit`` is the basis ``score`` is reported against, and it is
+    always one unit of the reference product (``"1.00 kg of cream"``) however
+    much of it the source says the process produces.
     """
 
     method_id: str
@@ -533,10 +537,13 @@ class Activity(FromJson):
     :meth:`Client.get_supply_chain`, :meth:`Client.get_impacts`, …).
     ``activity_name`` is the activity name (e.g. ``"wheat flour, at plant"``);
     ``product_name`` is the reference output product (e.g. ``"wheat flour"``);
-    ``product_amount`` and ``product_unit`` describe the functional unit
-    (typically ``1.0`` of ``"kg"`` / ``"mj"`` / etc.; a database imported from
-    SimaPro or Brightway Excel states it in the canonical unit of its
-    dimension, so a 1 kWh reference product reads ``3.6`` of ``"mj"``).
+    ``product_amount`` and ``product_unit`` are what the source says this
+    process produces, in the canonical unit of its dimension (typically
+    ``1.0`` of ``"kg"`` / ``"mj"``; a 1 kWh reference product imported from
+    SimaPro or Brightway Excel reads ``3.6`` of ``"mj"``, and a coproduct a
+    block states at 0.0686462 kg reads that). It is not the basis a score or
+    an inventory is reported against: those are always per **one**
+    ``product_unit``, whatever the amount here.
     ``location`` is the
     geography code (``"FR"``, ``"GLO"``, ``"RoW"``…). A process has no name of
     its own; compose a label from ``activity_name`` + ``product_name``.

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -53,7 +53,6 @@ import Method.Mapping (LCIAOutcome (..), MappingStats (..), SimilarCF (..), Simi
 import qualified Method.Mapping as Mapping
 import Method.Types (FlowDirection (..), Method (..), MethodCF (..), MethodCollection (..), ScoringSet (..))
 import Network.HTTP.Types.Header (RequestHeaders, hAccept, hAllow, hHost)
-import Numeric (showFFloat)
 import Progress (ProgressLevel (Warning), reportProgress)
 import qualified Search.Normalize as Normalize
 import qualified Service
@@ -1174,9 +1173,8 @@ data ImpactsResult = ImpactsResult
     , irContribs :: ![(BiosphereFlow, Double, Double)]
     -- ^ Sorted descending by absolute contribution.
     , irUnknownUuids :: ![UUID.UUID]
-    , irRefProductName :: !Text
-    , irRefProductAmount :: !Double
-    , irRefProductUnit :: !Text
+    , irFunctionalUnit :: !Text
+    -- ^ What one score is reported against, per 'Service.functionalUnitOf'.
     }
 
 {- | Run a fully resolved LCA request: solve inventory, map flows, score.
@@ -1223,7 +1221,7 @@ runImpactsRequest dbManager args req = do
         baseOutcome = computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables
         (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
         contribs = L.sortOn (\(_, _, c) -> negate (abs c)) rawContribs
-        (prodName, prodAmount, prodUnit) = Service.getReferenceProductInfo (dbTechFlows db) mUnits (raActivity ra)
+        functionalUnit = Service.functionalUnitOf (dbTechFlows db) mUnits (raActivity ra)
     -- Diagnostics path: opt-in via include_diagnostics. Skips the suggester
     -- work entirely when not requested, so the hot path stays bit-identical
     -- to runs without the flag.
@@ -1251,9 +1249,7 @@ runImpactsRequest dbManager args req = do
             , irTables = tables
             , irContribs = contribs
             , irUnknownUuids = unknownUuids
-            , irRefProductName = prodName
-            , irRefProductAmount = prodAmount
-            , irRefProductUnit = prodUnit
+            , irFunctionalUnit = functionalUnit
             }
 
 {- | Handler for the 'get_impacts' MCP tool (computes LCIA score).
@@ -1273,12 +1269,7 @@ callGetImpacts dbManager mBaseUrl rid args =
             ra = lrResolved req
             score = loScore (irOutcome ir)
             stats = irMappingStats ir
-            functionalUnit =
-                T.pack (showFFloat (Just 2) (irRefProductAmount ir) "")
-                    <> " "
-                    <> irRefProductUnit ir
-                    <> " of "
-                    <> irRefProductName ir
+            functionalUnit = irFunctionalUnit ir
             contribs = irContribs ir
             topFlows = take topN contribs
             webUrlPair = webUrlField mBaseUrl ("/db/" <> dbName <> "/activity/" <> raText ra <> "/impacts/" <> encodeSegment (DM.unCollectionName (lrCollection req)) <> "/" <> lrMethodIdText req)

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -715,8 +715,7 @@ computeCategoryResult dbManager dbName collection db sol activity topFlows preco
         Right score -> buildResult unitCfg mFlows mUnits inventory tables stats score
   where
     buildResult unitCfg mFlows mUnits inventory tables stats score = do
-        let (prodName, prodAmount, prodUnit) = Service.getReferenceProductInfo (dbTechFlows db) mUnits activity
-            functionalUnit = T.pack (showFFloat (Just 2) prodAmount "") <> " " <> prodUnit <> " of " <> prodName
+        let functionalUnit = Service.functionalUnitOf (dbTechFlows db) mUnits activity
             (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
             contribs = sortOn (\(_, _, c) -> negate (abs c)) rawContribs
             topContribs = take topFlows contribs
@@ -807,8 +806,7 @@ buildLCIABatchResultCached dbManager dbName collectionName db actPid activity co
         if topFlows > 0
             then Just <$> getMergedUnitConfig dbManager
             else pure Nothing
-    let (prodName, prodAmount, prodUnit) = Service.getReferenceProductInfo (dbTechFlows db) mUnits activity
-        functionalUnit = T.pack (showFFloat (Just 2) prodAmount "") <> " " <> prodUnit <> " of " <> prodName
+    let functionalUnit = Service.functionalUnitOf (dbTechFlows db) mUnits activity
         mkResultIO ctx = do
             let method = mctxMethod ctx
             case resolveBatchedScore method scoreMap of

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -558,7 +558,7 @@ data LCIAResult = LCIAResult
     , lrNormalizedScore :: Maybe Double -- score * normalization factor
     , lrWeightedScore :: Maybe Double -- normalized * weight (in Pt)
     , lrMappedFlows :: Int -- Number of flows successfully mapped
-    , lrFunctionalUnit :: Text -- e.g. "1.0 kg of Butter, unsalted"
+    , lrFunctionalUnit :: Text -- What the score is per: one unit of the reference product, e.g. "1.00 kg of Butter, unsalted"
     , lrTopContributors :: [FlowContributionEntry] -- Top contributing elementary flows
     }
     deriving (Generic)

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -1341,6 +1341,22 @@ getReferenceProductInfo flows units activity =
         , getUnitNameForExchange units ex
         )
 
+{- | The functional unit a score is reported against: one unit of the
+activity's reference product, named in the unit its matrix column was
+normalised to.
+
+Never the amount the source declared. "Database.MatrixBuild" divides every
+coefficient of a column by that amount, so a coproduct a source states at
+0.0686462 kg is still scored per kilogram, and a reference product ingested
+as 3.6 mj is still scored per megajoule. Reporting the declared amount here
+described the block, not the number beside it.
+-}
+functionalUnitOf :: TechFlowDB -> UnitDB -> Activity -> Text
+functionalUnitOf flows units activity = "1.00 " <> prodUnit <> " of " <> prodName
+  where
+    prodName, prodUnit :: Text
+    (prodName, _, prodUnit) = getReferenceProductInfo flows units activity
+
 {- | Build an 'ActivitySummary' from a (ProcessId, Activity) pair. Encapsulates
 the reference-product + allocation + native-type projection shared by
 search results, supply-chain entries, inventory metadata, and exchange-target

--- a/test/AllocationSpec.hs
+++ b/test/AllocationSpec.hs
@@ -167,6 +167,16 @@ spec = do
             let substituting = activity [productRow cheeseId 1.0 ReferenceProduct (Just 50) M.empty, avoided 2.0]
             concatMap avoidedAmounts (allocate declaredOn substituting) `shouldBe` [1.0]
 
+    {- The question a user of a multi-output block asks first, and the one the
+    functional unit used to answer wrongly: a coproduct row states 3 kg where
+    its block states 1 kg of cheese, and the matrix column is divided by that
+    3, so the score beside it is per kilogram. -}
+    describe "the functional unit of a split process" $ do
+        it "names one unit of the product, not the amount the block states" $ do
+            let processes = NE.toList (allocate declaredOn block)
+            map (Service.functionalUnitOf flows units) processes
+                `shouldBe` ["1.00 kg of cheese", "1.00 MJ of whey", "1.00 kg of cream"]
+
     describe "allocate normalises first, as the EcoSpold parsers used to" $ do
         it "drops a zero-amount coproduct the source states no share for" $ do
             let act = activity [productRow cheeseId 1.0 ReferenceProduct Nothing M.empty, productRow wheyId 0.0 Coproduct Nothing M.empty]
@@ -450,6 +460,13 @@ activity exs =
 
 units :: UnitDB
 units = M.fromList [(kgId, Unit kgId "kg" "kg" ""), (mjId, Unit mjId "MJ" "MJ" "")]
+
+flows :: TechFlowDB
+flows =
+    M.fromList
+        [ (fid, TechnosphereFlow fid name kgId M.empty Nothing Nothing)
+        | (fid, name) <- [(cheeseId, "cheese"), (wheyId, "whey"), (creamId, "cream")]
+        ]
 
 inputAmounts, bioAmounts, avoidedAmounts :: Activity -> [Double]
 inputAmounts act = [techAmount ex | ex@TechnosphereExchange{techRole = Input} <- exchanges act]


### PR DESCRIPTION
## Why

A score is per **one** unit of the reference product. `Database.MatrixBuild` divides every coefficient of an activity's column by the amount its source declares, and the demand vector asks for one unit; that is what makes a coproduct comparable to anything else.

The label the API reports beside the score said something different. It repeated the declared amount, which for a coproduct is rarely one:

- Agribalyse's Abondance cheese block states its cream row at `Qc/Qp` = 0.0686462 kg, with a declared share of 2.2689 %.
- `get_impacts` on that process returned `functional_unit = "0.07 kg of ... 1 kg of cream (PGi) {FR} U"`, while `score` was per kilogram.

A user reading the two together cannot tell which one to believe, and the answer they need (per kilogram) is the one the label denies. The same applies to a reference product ingested in the canonical unit of its dimension: a 1 kWh product is read as 3.6 mj and scored per megajoule, and was labelled `3.60 mj`.

## What changed

`Service.functionalUnitOf` names the unit the column was normalised to, and the three places that built the string by hand call it: the REST single-category path, the batch path, and the MCP `get_impacts` tool. `ImpactsResult` now carries the finished label instead of the three pieces only one consumer reassembled.

The Python client's documentation carried the same mistake and now says that `product_amount` describes what the block produces, not the basis of the score, with the `functional_unit` field stating the basis itself.

No shape on the wire changed: the field is the same field, with a value that no longer contradicts the number next to it.

## Checks

- `cabal build all --ghc-options=-Werror` in a fresh build directory: clean.
- `cabal test lca-tests`: 2473 examples, 0 failures, 2 pending.
- `pytest` in `pyvolca/`: 299 passed, 7 skipped.
- `hlint` on the touched files: no hints.
- New test in `AllocationSpec`: the three processes a cheese block splits into report `1.00 kg of cheese`, `1.00 MJ of whey`, `1.00 kg of cream`, where their rows state 1, 2 and 3.