### PR TITLE
Publish a waste treatment's column in the matrix format's own sign convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,14 @@
   this medium, so a database carrying such flows is now refused at that export
   rather than written in a shape the reader turns into something else. Caches
   built before this are rebuilt on the next load.
+- A waste treatment is published in the universal matrix format with the sign
+  the format uses. That format is unnormalised: a coefficient is positive when
+  the activity produces and negative when it consumes. A treatment records the
+  waste it treats as its reference product with a negative amount, and the
+  engine's own coefficients are normalised by that reference, so the whole
+  column came out reversed while only its diagonal was corrected. A solver
+  reading the export saw an activity that consumed waste on the diagonal and
+  produced its own inputs everywhere else.
 - A Brightway Excel export can now be opened by the tools it is written for.
   The `.xlsx` was missing the manifest a spreadsheet reader looks up before
   anything else, so openpyxl, bw2io and Excel all refused the file even though

--- a/src/Matrix/Export.hs
+++ b/src/Matrix/Export.hs
@@ -312,14 +312,13 @@ own inputs everywhere else, which no solver can read.
 referenceSigns :: Database -> U.Vector Double
 referenceSigns db = U.generate (fromIntegral (dbActivityCount db)) columnSign
   where
-    acts :: ActivityDB
-    acts = dbActivities db
-
+    -- The very quantity the triples were divided by, so the export undoes the
+    -- normalisation it is undoing rather than a rule that resembles it: a
+    -- treatment whose reference is a negative *input* normalises on its
+    -- absolute value and is not flipped at all, and reading the raw amount
+    -- would reverse its whole column for nothing.
     columnSign :: Int -> Double
-    columnSign i = if any negativeReference (exchanges (acts V.! i)) then -1.0 else 1.0
-
-    negativeReference :: Exchange -> Bool
-    negativeReference ex = exchangeIsReference ex && exchangeAmount ex < 0
+    columnSign i = signum (activityNormFactor (dbActivities db V.! i) (dbProcessIdTable db V.! i))
 
 -- | Export A_public.csv (Technosphere Matrix)
 exportAMatrix :: FilePath -> Database -> IO ()

--- a/src/Matrix/Export.hs
+++ b/src/Matrix/Export.hs
@@ -299,32 +299,46 @@ exportEEIndex filePath db = do
     TIO.writeFile filePath content
     reportProgress Info $ "ee_index: " ++ show (length rows) ++ " biosphere flows → " ++ filePath
 
+{- | The sign the published convention gives each activity's whole column.
+
+A waste treatment records the waste it treats as its reference product, with a negative
+amount, and our triples are normalised by that reference, so its column comes out with
+every sign reversed against the universal matrix format, where a coefficient is simply
+positive when the activity produces and negative when it consumes. One sign per column
+puts it back, and the diagonal takes the same sign as the rest of the column: signing the
+diagonal alone publishes an activity that consumes waste on the diagonal and produces its
+own inputs everywhere else, which no solver can read.
+-}
+referenceSigns :: Database -> U.Vector Double
+referenceSigns db = U.generate (fromIntegral (dbActivityCount db)) columnSign
+  where
+    acts :: ActivityDB
+    acts = dbActivities db
+
+    columnSign :: Int -> Double
+    columnSign i = if any negativeReference (exchanges (acts V.! i)) then -1.0 else 1.0
+
+    negativeReference :: Exchange -> Bool
+    negativeReference ex = exchangeIsReference ex && exchangeAmount ex < 0
+
 -- | Export A_public.csv (Technosphere Matrix)
 exportAMatrix :: FilePath -> Database -> IO ()
 exportAMatrix filePath db = do
     let techTriples = dbTechnosphereTriples db
         activityCount = dbActivityCount db
-        activities = dbActivities db
-
-        -- Waste activities have their reference product stored as outputGroup=0 with a
-        -- NEGATIVE amount (e.g., hard coal ash = -1.0 kg). These use -1.0 on the diagonal
-        -- in the (I-A) convention. Production activities use 1.0.
-        diagValue i =
-            let act = activities V.! i
-             in if any (\ex -> exchangeIsReference ex && exchangeAmount ex < 0) (exchanges act)
-                    then "-1.0"
-                    else "1.0"
+        signs = referenceSigns db
 
         diagonalEntries =
-            [ T.pack (show i ++ ";" ++ show i ++ ";" ++ diagValue i) <> emptyCsvUncertainty
+            [ T.pack (show i ++ ";" ++ show i ++ ";" ++ show (signs U.! i)) <> emptyCsvUncertainty
             | i <- [0 .. fromIntegral activityCount - 1 :: Int]
             ]
 
         offDiagonalRows =
             U.foldr
                 ( \(SparseTriple row col value) acc ->
-                    let rowStr =
-                            T.pack (show row ++ ";" ++ show col ++ ";" ++ show (-value))
+                    let coefficient = negate value * (signs U.! fromIntegral col)
+                        rowStr =
+                            T.pack (show row ++ ";" ++ show col ++ ";" ++ show coefficient)
                                 <> emptyCsvUncertainty
                      in rowStr : acc
                 )
@@ -348,12 +362,14 @@ exportAMatrix filePath db = do
 exportBMatrix :: FilePath -> Database -> IO ()
 exportBMatrix filePath db = do
     let bioTriples = dbBiosphereTriples db
+        signs = referenceSigns db
 
         rows =
             U.foldr
                 ( \(SparseTriple row col value) acc ->
-                    let rowStr =
-                            T.pack (show row ++ ";" ++ show col ++ ";" ++ show value)
+                    let coefficient = value * (signs U.! fromIntegral col)
+                        rowStr =
+                            T.pack (show row ++ ";" ++ show col ++ ";" ++ show coefficient)
                                 <> emptyCsvUncertainty
                      in rowStr : acc
                 )

--- a/test/MatrixExportSpec.hs
+++ b/test/MatrixExportSpec.hs
@@ -2,9 +2,13 @@
 
 module MatrixExportSpec (spec) where
 
+import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
+import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
+import qualified Data.UUID as UUID
+import Database (buildDatabaseWithMatrices)
 import Matrix.Export (
     MatrixDebugInfo (..),
     escapeCsvField,
@@ -16,7 +20,9 @@ import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 import TestHelpers
+import Text.Read (readMaybe)
 import Types
+import UnitConversion (defaultUnitConfig)
 
 spec :: Spec
 spec = do
@@ -93,6 +99,26 @@ spec = do
                 -- Check header and 2 flows (CO2, Zinc)
                 let lines = T.lines indexContent
                 length lines `shouldBe` 3 -- header + 2 flows
+        it "publishes a waste treatment's column in the format's own sign convention" $ do
+            db <- treatmentDatabase
+            withSystemTempDirectory "acv-matrix-sign" $ \tmpDir -> do
+                exportUniversalMatrixFormat tmpDir db
+                columns <- indexByName (tmpDir </> "ie_index.csv")
+                technosphere <- cells (tmpDir </> "A_public.csv")
+                biosphere <- cells (tmpDir </> "B_public.csv")
+                case (lookup "treatment of waste W" columns, lookup "producer of Y" columns) of
+                    (Just treatment, Just producer) -> do
+                        -- The waste it treats: consumed, so negative, and the rest of the
+                        -- column has to read in the convention the diagonal announces.
+                        lookup (treatment, treatment) technosphere `shouldBe` Just (-1.0)
+                        -- What it consumes to do the treating stays an input, not a product.
+                        lookup (producer, treatment) technosphere `shouldBe` Just (-0.5)
+                        -- What it emits stays an emission. Treating waste adds burden.
+                        lookup (0, treatment) biosphere `shouldBe` Just 2.0
+                        -- An ordinary activity is untouched by any of this.
+                        lookup (producer, producer) technosphere `shouldBe` Just 1.0
+                    _ -> expectationFailure ("ie_index names " <> show (map fst columns))
+
     describe "Export CSV Format Validation" $ do
         it "uses semicolon as delimiter" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
@@ -210,3 +236,150 @@ targetRow :: Database -> ProcessId
 targetRow db =
     let targetUUID = read "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" :: UUID
      in fromMaybe 0 (findProcessIdByActivityUUID db targetUUID)
+
+-- --------------------------------------------------------------------------- --
+-- A database with one waste treatment in it
+-- --------------------------------------------------------------------------- --
+
+{- | Two activities: an ordinary producer of Y, and a treatment of waste W in the
+convention EcoSpold 2 uses, where the treated waste is the reference product and its
+amount is negative. The treatment consumes half a Y and emits 2 kg of CO2.
+
+Everything the export has to get right about signs is visible in four coefficients, which
+is why this is built here rather than loaded from a fixture: a sample file would have to
+be read first to know what the answer should be.
+-}
+treatmentDatabase :: IO Database
+treatmentDatabase =
+    buildDatabaseWithMatrices
+        (BuildInputs defaultUnitConfig mempty Declared)
+        SimpleDatabase
+            { sdbActivities =
+                M.fromList
+                    [ ((producerUUID, productY), producerOfY)
+                    , ((treatmentUUID, wasteW), treatmentOfW)
+                    ]
+            , sdbTechFlows =
+                M.fromList
+                    [ (productY, TechnosphereFlow productY "product Y" kilogram M.empty Nothing Nothing)
+                    , (wasteW, TechnosphereFlow wasteW "waste W" kilogram M.empty Nothing Nothing)
+                    ]
+            , sdbBioFlows =
+                M.singleton
+                    carbonDioxide
+                    ( BiosphereFlow
+                        carbonDioxide
+                        "carbon dioxide"
+                        kilogram
+                        M.empty
+                        Nothing
+                        Nothing
+                        (Just (Compartment "air" Nothing))
+                    )
+            , sdbWasteFlows = M.empty
+            , sdbUnits = M.singleton kilogram (Unit kilogram "kg" "kg" "")
+            }
+        >>= either (fail . T.unpack) pure
+
+producerUUID, treatmentUUID, productY, wasteW, carbonDioxide, kilogram :: UUID
+producerUUID = testUUID "11111111-1111-1111-1111-111111111111"
+treatmentUUID = testUUID "22222222-2222-2222-2222-222222222222"
+productY = testUUID "33333333-3333-3333-3333-333333333333"
+wasteW = testUUID "44444444-4444-4444-4444-444444444444"
+carbonDioxide = testUUID "55555555-5555-5555-5555-555555555555"
+kilogram = testUUID "66666666-6666-6666-6666-666666666666"
+
+testUUID :: String -> UUID
+testUUID = fromMaybe UUID.nil . UUID.fromString
+
+producerOfY :: Activity
+producerOfY = blankActivity "producer of Y" [reference productY 1.0]
+
+treatmentOfW :: Activity
+treatmentOfW =
+    blankActivity
+        "treatment of waste W"
+        [ reference wasteW (-1.0)
+        , consumesFrom producerUUID productY 0.5
+        , BiosphereExchange
+            { bioFlowId = carbonDioxide
+            , bioAmount = 2.0
+            , bioUnitId = kilogram
+            , bioDirection = Emission
+            , bioLocation = ""
+            , bioComment = Nothing
+            , bioPedigree = Nothing
+            }
+        ]
+
+blankActivity :: Text -> [Exchange] -> Activity
+blankActivity name exs =
+    Activity
+        { activityName = name
+        , activityDescription = []
+        , activityDocumentation = []
+        , activitySynonyms = M.empty
+        , activityClassification = M.empty
+        , activityLocation = "GLO"
+        , activityLocationSource = LocationDeclared
+        , activityUnit = "kg"
+        , exchanges = exs
+        , activityParams = M.empty
+        , activityParamExprs = M.empty
+        , activityNativeType = Nothing
+        , activityNativeId = Nothing
+        , activityFormulaCheck = Nothing
+        }
+
+-- | The activity's own product, in the amount its dataset records. Negative for a treatment.
+reference :: UUID -> Double -> Exchange
+reference flow amount = technosphere flow amount ReferenceProduct UUID.nil
+
+-- | An input taken from a named producer.
+consumesFrom :: UUID -> UUID -> Double -> Exchange
+consumesFrom supplier flow amount = technosphere flow amount Input supplier
+
+technosphere :: UUID -> Double -> TechRole -> UUID -> Exchange
+technosphere flow amount role supplier =
+    TechnosphereExchange
+        { techFlowId = flow
+        , techAmount = amount
+        , techUnitId = kilogram
+        , techRole = role
+        , techActivityLinkId = supplier
+        , techProcessLinkId = Nothing
+        , techLocation = "GLO"
+        , techComment = Nothing
+        , techPedigree = Nothing
+        , techShare = Nothing
+        , techClassification = M.empty
+        , techProperties = noProperties
+        }
+
+-- | Activity name -> the column it was given, read back out of the index the export wrote.
+indexByName :: FilePath -> IO [(Text, Int)]
+indexByName path = do
+    rows <- drop 1 . T.lines <$> TIO.readFile path
+    pure (concatMap entry rows)
+  where
+    entry :: Text -> [(Text, Int)]
+    entry row = case T.splitOn ";" row of
+        (name : _geography : _product : _unit : position : _) ->
+            [(name, i) | Just i <- [readMaybe (T.unpack position)]]
+        _ -> []
+
+-- | (row, column) -> coefficient, from one of the sparse matrix files.
+cells :: FilePath -> IO [((Int, Int), Double)]
+cells path = do
+    rows <- drop 1 . T.lines <$> TIO.readFile path
+    pure (concatMap cell rows)
+  where
+    cell :: Text -> [((Int, Int), Double)]
+    cell line = case T.splitOn ";" line of
+        (r : c : v : _) ->
+            [ ((i, j), x)
+            | Just i <- [readMaybe (T.unpack r)]
+            , Just j <- [readMaybe (T.unpack c)]
+            , Just x <- [readMaybe (T.unpack v)]
+            ]
+        _ -> []

--- a/test/MatrixExportSpec.hs
+++ b/test/MatrixExportSpec.hs
@@ -274,7 +274,7 @@ treatmentDatabase =
                         M.empty
                         Nothing
                         Nothing
-                        (Just (Compartment "air" Nothing))
+                        (Just (Compartment Air Nothing))
                     )
             , sdbWasteFlows = M.empty
             , sdbUnits = M.singleton kilogram (Unit kilogram "kg" "kg" "")
@@ -333,13 +333,13 @@ blankActivity name exs =
 
 -- | The activity's own product, in the amount its dataset records. Negative for a treatment.
 reference :: UUID -> Double -> Exchange
-reference flow amount = technosphere flow amount ReferenceProduct UUID.nil
+reference flow amount = technosphere flow amount ReferenceProduct Nothing
 
 -- | An input taken from a named producer.
 consumesFrom :: UUID -> UUID -> Double -> Exchange
-consumesFrom supplier flow amount = technosphere flow amount Input supplier
+consumesFrom supplier flow amount = technosphere flow amount Input (Just supplier)
 
-technosphere :: UUID -> Double -> TechRole -> UUID -> Exchange
+technosphere :: UUID -> Double -> TechRole -> Maybe UUID -> Exchange
 technosphere flow amount role supplier =
     TechnosphereExchange
         { techFlowId = flow
@@ -347,7 +347,7 @@ technosphere flow amount role supplier =
         , techUnitId = kilogram
         , techRole = role
         , techActivityLinkId = supplier
-        , techProcessLinkId = Nothing
+        , techSupplierClaim = maybe ClaimByProduct ClaimById supplier
         , techLocation = "GLO"
         , techComment = Nothing
         , techPedigree = Nothing


### PR DESCRIPTION
The universal matrix export was writing a waste treatment's column with every
sign reversed, and only its diagonal was right.

The format's convention is uniform: a coefficient is positive when the activity
produces and negative when it consumes, whatever the activity does. Our
technosphere and biosphere triples are normalised by the reference product,
which for a treatment is a negative amount of the waste it treats, so
normalising flips that column. The exporter negated the technosphere triples to
undo the internal convention and wrote the treatment diagonal as -1 by hand,
which made the diagonal agree and left everything above and below it saying the
opposite of what it meant: an activity that consumes waste on the diagonal and
produces its own electricity everywhere else.

The fix is one sign per column, read from the same place the diagonal already
read it, and applied to both matrices. Nothing inside the engine changes: the
triples are untouched and scoring never went through this code. What changes is
what someone gets when they ask for the matrices and take them to their own
solver.

Checked coefficient by coefficient against the matrices a publisher ships
alongside a large EcoSpold 2 database: both matrices now agree everywhere, where
before a large share of each disagreed on sign alone.

A new test in `MatrixExportSpec` builds a two-activity database with one
treatment in it and pins the four coefficients that say whether the convention
holds. It fails on the old exporter.
