### PR TITLE
Keep the export warnings inside a header a client will read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,12 @@
   column came out reversed while only its diagonal was corrected. A solver
   reading the export saw an activity that consumed waste on the diagonal and
   produced its own inputs everywhere else.
+- An export of a large database reaches the client again. The warnings an
+  export collects travel in a response header, one line per warning, and a
+  database with thousands of multi-output activities produced a header longer
+  than an HTTP client will read: the request died on the header and the archive,
+  complete on the server, never arrived. The header now carries as many
+  warnings as fit and ends with a line saying how many more there were.
 - A Brightway Excel export can now be opened by the tools it is written for.
   The `.xlsx` was missing the manifest a spreadsheet reader looks up before
   anything else, so openpyxl, bw2io and Excel all refused the file even though

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -736,7 +736,13 @@ encodeExportWarnings warnings = encode (kept ++ [omitted | not (null dropped)])
     dropped = drop (length kept) warnings
 
     omitted :: Text
-    omitted = "and " <> T.pack (show (length dropped)) <> " further warnings, too many to carry in a header"
+    omitted = "and " <> T.pack (show n) <> plural <> ", too many to carry in a header"
+      where
+        n :: Int
+        n = length dropped
+
+        plural :: Text
+        plural = if n == 1 then " further warning" else " further warnings"
 
     -- The longest prefix whose encoding stays inside the budget, measured warning by
     -- warning so the header always ends on a whole one.

--- a/src/API/DatabaseHandlers.hs
+++ b/src/API/DatabaseHandlers.hs
@@ -35,6 +35,7 @@ module API.DatabaseHandlers (
     editExchangesHandler,
     exportDatabaseHandler,
     exportMethodHandler,
+    encodeExportWarnings,
     uploadDatabaseHandler,
     uploadMethodHandler,
     deleteMethodHandler,
@@ -714,9 +715,46 @@ exportMethodHandler name req = do
 
 {- | Join export warnings for the response header, percent-encoded because
 flow and activity names are arbitrary Unicode.
+
+A header is not a log. An ILCD export of a full database names every activity it
+approximated, which on a twenty-thousand-activity database runs to hundreds of kilobytes,
+and a header that long is refused by every proxy and HTTP client on the way back: the
+archive itself is lost along with the warnings. So the header carries as many whole
+warnings as fit in 'warningHeaderBudget' and then says how many it left out, which is the
+one thing a caller cannot work out for itself.
 -}
 encodeExportWarnings :: [Text] -> Text
-encodeExportWarnings = T.decodeUtf8 . urlEncode False . T.encodeUtf8 . T.intercalate "\n"
+encodeExportWarnings warnings = encode (kept ++ [omitted | not (null dropped)])
+  where
+    encode :: [Text] -> Text
+    encode = T.decodeUtf8 . urlEncode False . T.encodeUtf8 . T.intercalate "\n"
+
+    kept :: [Text]
+    kept = fitting warningHeaderBudget warnings
+
+    dropped :: [Text]
+    dropped = drop (length kept) warnings
+
+    omitted :: Text
+    omitted = "and " <> T.pack (show (length dropped)) <> " further warnings, too many to carry in a header"
+
+    -- The longest prefix whose encoding stays inside the budget, measured warning by
+    -- warning so the header always ends on a whole one.
+    fitting :: Int -> [Text] -> [Text]
+    fitting _ [] = []
+    fitting left (w : rest)
+        | cost > left = []
+        | otherwise = w : fitting (left - cost) rest
+      where
+        cost :: Int
+        cost = T.length (encode [w]) + 3 -- the encoded newline that joins it
+
+{- | How much encoded text the warning header may hold. Well under the 4 kB a reverse
+proxy typically allows one response header, which is itself well under what an HTTP
+client will read.
+-}
+warningHeaderBudget :: Int
+warningHeaderBudget = 3000
 
 exportErr :: ServerError -> Text -> AppM a
 exportErr status msg = throwError status{errBody = BSL.fromStrict (T.encodeUtf8 msg)}

--- a/test/ExportHandlerSpec.hs
+++ b/test/ExportHandlerSpec.hs
@@ -12,11 +12,12 @@ empty 'Database.Manager.DatabaseManager' (no databases loaded), exactly as
 -}
 module ExportHandlerSpec (spec) where
 
-import API.DatabaseHandlers (exportDatabaseHandler)
+import API.DatabaseHandlers (encodeExportWarnings, exportDatabaseHandler)
 import API.Types (BinaryContent, ExportRequest (..))
 import App.Env (AppEnv (..), runApp)
 import Config (defaultConfig)
 import Data.Text (Text)
+import qualified Data.Text as T
 import Database.Manager (CachePolicy (..), initDatabaseManager)
 import Servant (Header, Headers, ServerError, errHTTPCode, runHandler)
 import Test.Hspec
@@ -40,15 +41,33 @@ runExport dbName fmt = do
     runHandler (runApp env (exportDatabaseHandler dbName (ExportRequest fmt)))
 
 spec :: Spec
-spec = describe "exportDatabaseHandler (HTTP error mapping)" $ do
-    it "returns 404 when the database is not loaded" $ do
-        res <- runExport "no-such-db" "simapro"
-        case res of
-            Left e -> errHTTPCode e `shouldBe` 404
-            Right _ -> expectationFailure "expected a 404, got a successful export"
+spec = do
+    describe "exportDatabaseHandler (HTTP error mapping)" $ do
+        it "returns 404 when the database is not loaded" $ do
+            res <- runExport "no-such-db" "simapro"
+            case res of
+                Left e -> errHTTPCode e `shouldBe` 404
+                Right _ -> expectationFailure "expected a 404, got a successful export"
 
-    it "returns 400 for an unknown export format" $ do
-        res <- runExport "no-such-db" "not-a-format"
-        case res of
-            Left e -> errHTTPCode e `shouldBe` 400
-            Right _ -> expectationFailure "expected a 400, got a successful export"
+        it "returns 400 for an unknown export format" $ do
+            res <- runExport "no-such-db" "not-a-format"
+            case res of
+                Left e -> errHTTPCode e `shouldBe` 400
+                Right _ -> expectationFailure "expected a 400, got a successful export"
+
+    describe "encodeExportWarnings" $ do
+        it "carries a short list whole" $ do
+            let encoded = encodeExportWarnings ["first thing", "second thing"]
+            T.isInfixOf "first" encoded `shouldBe` True
+            T.isInfixOf "second" encoded `shouldBe` True
+            T.isInfixOf "further" encoded `shouldBe` False
+
+        it "stays small enough to be a header when a writer has thousands to say" $ do
+            let plenty = [T.pack ("approximated activity number " <> show n) | n <- [1 :: Int .. 20000]]
+            T.length (encodeExportWarnings plenty) `shouldSatisfy` (< 4096)
+
+        it "says how many it left out rather than dropping them in silence" $ do
+            let plenty = [T.pack ("warning " <> show n) | n <- [1 :: Int .. 20000]]
+                encoded = encodeExportWarnings plenty
+            T.isInfixOf "warning%201%0A" encoded `shouldBe` True
+            T.isInfixOf "further%20warnings" encoded `shouldBe` True


### PR DESCRIPTION
Exporting a large database to ILCD returned nothing a client could read. Not a
500, not a truncated archive: the HTTP client gave up while still reading the
response headers, having passed 64 kB on a single line.

The line was `X-Volca-Export-Warnings`. The ILCD writer emits one warning per
multi-output activity, because ILCD cannot say that several process datasets
came from one activity and the caller deserves to hear that before re-importing.
On a database with tens of thousands of activities that is hundreds of
kilobytes, all of it in one header. Every HTTP client caps a header line, and
every reverse proxy caps it lower, so the response was lost in full: the
archive, which was fine, went with the warnings.

A header is not a log. It now carries as many whole warnings as fit in a budget
well under what a proxy allows, and ends with a line saying how many it could
not carry. That number is the one thing the caller cannot work out for itself,
and leaving it out would have been the same defect one layer down: a truncation
nobody was told about.

The encoder is now exported so a test can hold it to its budget, and the test
feeds it twenty thousand warnings.
