### PR TITLE
Write a substitution once, under its own header

### DIFF
--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -538,8 +538,9 @@ renderPedigree Pedigree{..} =
 only inputs. 'Nothing' for every other role, and for an input whose flow is
 unknown to the tech-flow catalogue.
 
-Each of the other roles is an output with a section of its own: the reference
-and the coproducts go to @Products@, a substitution to @Avoided products@.
+Each of the other roles has a section of its own: the reference, product or
+treatment input, and the coproducts go to @Products@, a substitution to
+@Avoided products@.
 Writing one here as well puts it in the file twice, and a reader then sees two
 exchanges where the source had one. On a substitution that is not a duplicate
 but a cancellation: the credit meets an equal input, and the activity loses the

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -534,25 +534,36 @@ renderPedigree Pedigree{..} =
             (map (T.pack . show) [pedReliability, pedCompleteness, pedTemporal, pedGeographical, pedTechnological])
         <> ")"
 
-{- | Build a 'Line' for a technosphere input exchange. Returns 'Nothing' for
-the reference/coproduct outputs (those go to the Products section) and for
-exchanges whose flow is unknown to the tech-flow DB.
+{- | Build a 'Line' for the @Materials\/fuels@ section, which holds inputs and
+only inputs. 'Nothing' for every other role, and for an input whose flow is
+unknown to the tech-flow catalogue.
+
+Each of the other roles is an output with a section of its own: the reference
+and the coproducts go to @Products@, a substitution to @Avoided products@.
+Writing one here as well puts it in the file twice, and a reader then sees two
+exchanges where the source had one. On a substitution that is not a duplicate
+but a cancellation: the credit meets an equal input, and the activity loses the
+benefit it existed to record, along with every chain standing on it.
 -}
 techInputLine :: Catalogs -> Exchange -> Maybe Line
-techInputLine cats ex@TechnosphereExchange{..} =
-    if exchangeIsReference ex
-        then Nothing
-        else case M.lookup techFlowId (catTech cats) of
-            Nothing -> Nothing
-            Just flow ->
-                Just
-                    Line
-                        { lName = tfName flow
-                        , lCompartment = ""
-                        , lUnit = unitNameOf (catUnits cats) techUnitId
-                        , lAmount = techAmount
-                        , lComment = renderComment techPedigree techComment
-                        }
+techInputLine cats TechnosphereExchange{..} = case techRole of
+    Input -> inputLine
+    ReferenceProduct -> Nothing
+    ReferenceInput -> Nothing
+    Coproduct -> Nothing
+    AvoidedProduct -> Nothing
+  where
+    inputLine :: Maybe Line
+    inputLine = do
+        flow <- M.lookup techFlowId (catTech cats)
+        pure
+            Line
+                { lName = tfName flow
+                , lCompartment = ""
+                , lUnit = unitNameOf (catUnits cats) techUnitId
+                , lAmount = techAmount
+                , lComment = renderComment techPedigree techComment
+                }
 techInputLine _ BiosphereExchange{} = Nothing
 techInputLine _ WasteExchange{} = Nothing
 

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -128,6 +128,11 @@ fixtureCSV =
 {- | A single process with one reference product and one coproduct (in the
 @Avoided products@ section, which the parser reads back as a 'Coproduct').
 -}
+
+-- | How many lines of a written file start with the given prefix.
+countOf :: BS.ByteString -> BS.ByteString -> Int
+countOf prefix written = length (filter (BS.isPrefixOf prefix) (BS.split 10 written))
+
 coproductCSV :: BS.ByteString
 coproductCSV =
     BS.intercalate
@@ -459,6 +464,18 @@ spec = describe "SimaPro.Writer round-trip" $ do
         -- count stable and preserves the AvoidedProduct role.
         length acts1 `shouldBe` length acts0
         (AvoidedProduct `elem` roles) `shouldBe` True
+
+    it "(regression) writes an avoided product once, not as an input as well" $ do
+        original <- parseBytes coproductCSV
+        f0 <- serBytes (toSimple original)
+        -- Written under "Avoided products" and nowhere else. Under
+        -- "Materials/fuels" as well, the re-import pairs the credit with an
+        -- equal input and the substitution cancels itself out.
+        countOf "Butter;kg;0.3" f0 `shouldBe` 1
+        reparsed <- parseBytes f0
+        let roles = [techRole e | a <- activitiesOf reparsed, e@TechnosphereExchange{} <- exchanges a]
+        length (filter (== AvoidedProduct) roles) `shouldBe` 1
+        length (filter (== Input) roles) `shouldBe` 0
 
     it "(regression) omits the Type line for an activity with no native type" $ do
         original <- parseBytes noTypeCSV

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -125,14 +125,13 @@ fixtureCSV =
         , "End"
         ]
 
-{- | A single process with one reference product and one coproduct (in the
-@Avoided products@ section, which the parser reads back as a 'Coproduct').
--}
-
 -- | How many lines of a written file start with the given prefix.
 countOf :: BS.ByteString -> BS.ByteString -> Int
 countOf prefix written = length (filter (BS.isPrefixOf prefix) (BS.split 10 written))
 
+{- | A single process with one reference product and one substitution, in the
+@Avoided products@ section the parser reads back as an 'AvoidedProduct'.
+-}
 coproductCSV :: BS.ByteString
 coproductCSV =
     BS.intercalate


### PR DESCRIPTION
Exporting a large SimaPro database and reading it back changed the numbers. No
flow was lost and none was invented; more than half of a twenty-activity sample
came back heavier, by anything from a hair to a factor of three.

Following one of them down to where the two sides stop agreeing lands on an
end-of-life process whose substitution is written twice:

```
Avoided products
Incineration, Energy recovery, Heat and Electricity ...;mj;34.7;100;...

Materials/fuels
Incineration, Energy recovery, Heat and Electricity ...;mj;34.7;Undefined;...
```

`techInputLine` builds the `Materials/fuels` rows and excluded only the
reference product, so every coproduct and every substitution was written under
its own header and then again as an input. Its doc comment claimed it excluded
them, which is presumably why nobody looked.

A duplicated input would already be wrong. A duplicated substitution is worse:
the credit meets an equal input and the two cancel, so the process records none
of the benefit it exists to record, and everything upstream of it reads heavier.
Every substitution in the file was affected, and they are the end-of-life
credits of the packaging chains, which is why the damage is concentrated on
recipes rather than spread evenly.

The section a role belongs to is now decided by the role, one arm per
constructor, so a role added later cannot silently fall through into the input
section.

The regression test writes the existing coproduct fixture and counts the line:
once, not twice. It fails on the old writer.
