### PR TITLE
Keep an input the author switched off

### DIFF
--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -413,12 +413,14 @@ exchangeRowOut cfg actName f =
 key 'Database.Loader.buildSupplierIndexByName' matches against), with the
 supplier location preserved for geography-aware cross-DB linking: an 'Input'
 for a @technosphere@ row, an 'AvoidedProduct' for a @substitution@ row.
-Zero-amount rows are dropped (parity with the SimaPro importer).
+
+A zero amount is kept, like every other amount and like the SimaPro importer:
+it says the author disabled this input, which is a statement about the model,
+not an empty row.
 -}
 technosphereRowOut :: UC.UnitConfig -> TechRole -> Text -> M.Map Text CellValue -> RowOut
 technosphereRowOut cfg role actName f
     | T.null name = emptyRowOut{roWarn = ["activity '" <> actName <> "': skipped technosphere row with no name"]}
-    | amount == 0 = emptyRowOut
     | otherwise = RowOut (Just exch) [flow] [] [unit] []
   where
     name = fromMaybe "" (fieldText f "reference product" <|> fieldText f "name")

--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -421,6 +421,8 @@ not an empty row.
 technosphereRowOut :: UC.UnitConfig -> TechRole -> Text -> M.Map Text CellValue -> RowOut
 technosphereRowOut cfg role actName f
     | T.null name = emptyRowOut{roWarn = ["activity '" <> actName <> "': skipped technosphere row with no name"]}
+    | isNothing (fieldNum f "amount") =
+        emptyRowOut{roWarn = ["activity '" <> actName <> "', row '" <> name <> "': skipped, its amount cell holds no number"]}
     | otherwise = RowOut (Just exch) [flow] [] [unit] []
   where
     name = fromMaybe "" (fieldText f "reference product" <|> fieldText f "name")

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -1581,14 +1581,24 @@ Biosphere flows need no supplier. Reference exchanges sit on the diagonal of
 completeness below 100% for a perfectly solvable database. Waste *outputs* are
 generated, not demanded; only waste/technosphere *inputs* remain.
 
-An input of zero demands nothing either: the matrix builder emits no entry for
-it, so no producer is ever looked up, and counting it as an unmet demand would
-report a gap that no solve can encounter.
+An input of zero demands nothing either. It reaches no matrix: the builders drop
+a zero triple ('Database.MatrixBuild.triplesFor' and 'buildBioTriples'), and
+'missingActivityWarning' does not warn about one, so counting it as an unmet
+demand would report a gap no solve can encounter.
+
+Whether a row should be *linked* is the other question, and 'namesASupplier'
+answers it. A disabled input still points at a producer, and the author who
+re-enables it expects the link to be there.
 -}
 isSupplierDemand :: Exchange -> Bool
-isSupplierDemand ex =
-    exchangeAmount ex /= 0
-        && not (isBiosphereExchange ex)
+isSupplierDemand ex = namesASupplier ex && exchangeAmount ex /= 0
+
+{- | An input that names a supplier, whatever it asks of it. The linker's
+question, where 'isSupplierDemand' is the completeness report's.
+-}
+namesASupplier :: Exchange -> Bool
+namesASupplier ex =
+    not (isBiosphereExchange ex)
         && exchangeIsInput ex
         && not (exchangeIsReference ex)
 
@@ -2064,7 +2074,7 @@ findExchangeCrossDBLink ::
     Exchange ->
     CrossDBLinkingStats
 findExchangeCrossDBLink LinkScan{lsCtx = ctx, lsOwnKeys = ownKeys, lsTechFlows = techFlowDb, lsUnits = unitDb} consumerActUUID consumerProdUUID ex@TechnosphereExchange{techFlowId = fid, techAmount = amt, techActivityLinkId = linkId, techLocation = loc}
-    | isSupplierDemand ex && not resolvesInternally =
+    | namesASupplier ex && not resolvesInternally =
         maybe mempty resolveTechInput (M.lookup fid techFlowDb)
     | otherwise = mempty
   where

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -1580,10 +1580,15 @@ Biosphere flows need no supplier. Reference exchanges sit on the diagonal of
 'ReferenceInput' is a self-edge, not a supplier demand — counting it would drag
 completeness below 100% for a perfectly solvable database. Waste *outputs* are
 generated, not demanded; only waste/technosphere *inputs* remain.
+
+An input of zero demands nothing either: the matrix builder emits no entry for
+it, so no producer is ever looked up, and counting it as an unmet demand would
+report a gap that no solve can encounter.
 -}
 isSupplierDemand :: Exchange -> Bool
 isSupplierDemand ex =
-    not (isBiosphereExchange ex)
+    exchangeAmount ex /= 0
+        && not (isBiosphereExchange ex)
         && exchangeIsInput ex
         && not (exchangeIsReference ex)
 

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -1069,7 +1069,7 @@ processBlockToActivity unitCfg gp pb@ProcessBlock{..} =
     -- which goes to the technosphere with the rest.
     (avoidedExs, avoidedFlows, avoidedUnits) =
         unzip3 (productToExchange unitCfg env AvoidedProduct <$> pbAvoidedProducts)
-    (techMaybeExs, techFlows, techUnits) =
+    (techExs, techFlows, techUnits) =
         unzip3 (techRowToExchange unitCfg env <$> (pbMaterials ++ pbElectricity ++ pbWasteToTreatment))
     (bioExs, bioFlows, bioUnits) =
         unzip3 $
@@ -1082,8 +1082,7 @@ processBlockToActivity unitCfg gp pb@ProcessBlock{..} =
     -- Exchanges/flows/units the block's products share. They are written once,
     -- unscaled: "Database.Allocation" splits the block into one process per
     -- product and scales them by each product's declared share.
-    -- Tech rows with a zero amount yield no exchange but still contribute a flow.
-    sharedExchanges = avoidedExs ++ catMaybes techMaybeExs ++ bioExs
+    sharedExchanges = avoidedExs ++ techExs ++ bioExs
     sharedTechFlows = avoidedFlows ++ techFlows
     sharedBioFlows = bioFlows
     -- The format has no waste axis: its two waste sections are elementary
@@ -1299,10 +1298,17 @@ parsePedigreePrefix raw =
     -- the comment proper. Strip leading separators and whitespace.
     stripCommentSeparators = T.dropWhile (`elem` (",;. \t" :: String))
 
-{- | Convert technosphere row to exchange (if non-zero), flow, and unit.
-Always returns the flow/unit; exchange is Nothing for zero-amount rows.
+{- | Convert a technosphere row to its exchange, flow and unit.
+
+A row whose amount is zero is kept like any other. Zero is a modelling
+statement: an input the author disabled, or a parameter that evaluates to zero
+in this scenario, and the file says so on purpose. Dropping it lost that
+statement without a word, made the reader disagree with the writer, and left
+the biosphere side (which never dropped a zero) reading a different rule from
+the same file. Nothing downstream is disturbed by the coefficient itself: both
+matrix builders skip a zero entry on their own.
 -}
-techRowToExchange :: UnitConversion.UnitConfig -> M.Map Text Double -> TechExchangeRow -> (Maybe Exchange, TechnosphereFlow, Unit)
+techRowToExchange :: UnitConversion.UnitConfig -> M.Map Text Double -> TechExchangeRow -> (Exchange, TechnosphereFlow, Unit)
 techRowToExchange unitCfg env TechExchangeRow{..} =
     let reading = extractLocation terName
         cleanName = maybe terName locatedName reading
@@ -1312,24 +1318,20 @@ techRowToExchange unitCfg env TechExchangeRow{..} =
         unitUUID = generateUnitUUID effUnitName
         (pedigree, cleanedComment) = parsePedigreePrefix terComment
         exchange =
-            if resolvedAmount == 0
-                then Nothing
-                else
-                    Just
-                        TechnosphereExchange
-                            { techFlowId = flowUUID
-                            , techAmount = resolvedAmount
-                            , techUnitId = unitUUID
-                            , techRole = Input
-                            , techActivityLinkId = UUID.nil
-                            , techProcessLinkId = Nothing
-                            , techLocation = location
-                            , techComment = cleanedComment
-                            , techPedigree = pedigree
-                            , techShare = Nothing
-                            , techClassification = M.empty
-                            , techProperties = noProperties
-                            }
+            TechnosphereExchange
+                { techFlowId = flowUUID
+                , techAmount = resolvedAmount
+                , techUnitId = unitUUID
+                , techRole = Input
+                , techActivityLinkId = UUID.nil
+                , techProcessLinkId = Nothing
+                , techLocation = location
+                , techComment = cleanedComment
+                , techPedigree = pedigree
+                , techShare = Nothing
+                , techClassification = M.empty
+                , techProperties = noProperties
+                }
         flow =
             TechnosphereFlow
                 { tfId = flowUUID

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -59,6 +59,7 @@ import Types (
     WasteFlowDB,
     activityDeclaredShares,
     activityReferenceShare,
+    exchangeAmount,
     exchangeComment,
     exchangeFlowId,
     exchangeIsInput,
@@ -459,6 +460,47 @@ parseSummedAmountCSV = withSystemTempFile "summed-amount-test.csv" $ \path handl
     hClose handle
     parseOrFail defaultUnitConfig path
 
+{- | A block with one input at zero and one above it, plus an emission at zero:
+the two sides of the file that used to be read by two different rules.
+-}
+zeroAmountTestCSV :: BS.ByteString
+zeroAmountTestCSV =
+    BS.intercalate
+        "\r\n"
+        [ "{SimaPro 9.6.0.1}"
+        , "{CSV separator: semicolon}"
+        , "{Decimal separator: ,}"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , "Blend with a disabled input"
+        , ""
+        , "Type"
+        , "Unit process"
+        , ""
+        , "Products"
+        , "Blend {GLO} U;kg;1;100;not defined;material;"
+        , ""
+        , "Materials/fuels"
+        , "Filler {GLO} U;kg;0,4;Undefined;;;;;;"
+        , "Additive, switched off {GLO} U;kg;0;Undefined;;;;;;"
+        , ""
+        , "Emissions to air"
+        , "Carbon dioxide;;kg;0;Undefined;;;;"
+        , ""
+        , "End"
+        ]
+
+parseZeroAmountCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)
+parseZeroAmountCSV = withSystemTempFile "zero-amount-test.csv" $ \path handle -> do
+    BS.hPut handle zeroAmountTestCSV
+    hClose handle
+    parseOrFail defaultUnitConfig path
+
 -- Helper: get all tech input amounts
 techInputAmounts :: Activity -> [Double]
 techInputAmounts act =
@@ -805,6 +847,21 @@ spec = do
             let mix = head activities
             refProductAmount mix `shouldBe` Just 1.0
             sum (techInputAmounts mix) `shouldSatisfy` (\x -> abs (x - 1.0) < 1e-9)
+
+    describe "SimaPro rows with a zero amount" $ do
+        it "keeps an input the author switched off" $ do
+            (activities, _, _, _, _) <- parseZeroAmountCSV
+            let blend = findByName "Blend with a disabled input" activities
+            techInputAmounts blend `shouldMatchList` [0.4, 0.0]
+
+        it "reads an input at zero by the same rule as an emission at zero" $ do
+            (activities, _, _, _, _) <- parseZeroAmountCSV
+            let blend = findByName "Blend with a disabled input" activities
+                zeroed = [e | e <- exchanges blend, exchangeAmount e == 0]
+            -- One switched-off input and one emission at zero. The parser used
+            -- to drop the first and keep the second, reading one file by two
+            -- rules and losing what the author wrote.
+            length zeroed `shouldBe` 2
 
     describe "SimaPro database-level parameters" $ do
         it "resolves database input params in exchange amounts" $ do


### PR DESCRIPTION
A technosphere row whose amount is zero was thrown away at import, in the
SimaPro reader and in the Brightway Excel reader that had copied the rule for
parity. The biosphere side of the same file never threw one away, so one file
was being read by two rules.

A zero is a modelling statement. It is an input the author disabled, or a
parameter that evaluates to zero in this scenario, and it is written down on
purpose. Dropping it lost that statement without a word, and it made the
report that follows dishonest: the loader announces a link rate over a set it
has already reduced, so a large database reads "100% resolved, 0 unresolved"
having quietly lost a thousand rows.

No number computed by the engine moves. Both matrix builders skip a zero entry
on their own, so no coefficient, no inventory and no score changes. What
changes is what a reader and a writer see, and an export now carries the rows
its source carried.

`isSupplierDemand` gains the same reading, and this is the one judgement call
in the change. Its own documentation says it is the exact set the matrix
builder tries to resolve; the matrix builder emits nothing for a zero, so an
unlinked input at zero was being counted as an unmet demand that no solve can
ever encounter. Counting it would have turned this change into a visible drop
in completeness for rows that weigh nothing.

The two new tests read one block holding a switched-off input and an emission
at zero, and check that the two are read by the same rule.
