### PR TITLE
Read an EcoSpold 1 final waste flow as the elementary flow it is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 ## [Unreleased]
 
 ### Fixed
+- An EcoSpold 1 database no longer reports supplier gaps that cannot exist.
+  A file of that format files waste with no modelled treatment under a
+  category of its own, on an input group, because the format has only four
+  flow types and this is a fifth. The loader read the input direction
+  literally and turned every such row into a demand waiting for a supplier,
+  which no database can ever close: the completeness report filled with edges
+  that had nothing to point at. Those rows are elementary flows now, of the
+  same medium the equivalent rows of the other formats already use, so a
+  method characterizes them and the report only counts what a supplier could
+  answer. An export writes them the way it reads them: waste that names no
+  treatment goes out as an inventory flow, waste that is consumed by one goes
+  out as a technosphere input, and an output that names a treatment is refused
+  rather than written with the link silently dropped. One thing is lost along
+  the way: an unlinked waste output used to be matched by name to a treatment
+  carried by another loaded database, and an elementary flow is matched
+  against methods instead. Caches built before this are rebuilt on the next
+  load.
 - Waste that leaves a system with no treatment modelled for it is now
   characterized. A SimaPro CSV files such waste in a section of its own, and a
   method that scores it writes the same word in its compartment column. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@
   answer. An export writes them the way it reads them: waste that names no
   treatment goes out as an inventory flow, waste that is consumed by one goes
   out as a technosphere input, and an output that names a treatment is refused
-  rather than written with the link silently dropped. One thing is lost along
-  the way: an unlinked waste output used to be matched by name to a treatment
-  carried by another loaded database, and an elementary flow is matched
-  against methods instead. Caches built before this are rebuilt on the next
-  load.
+  rather than written with the link silently dropped. Two things change for a
+  reader beyond the gap report: such a row no longer carries a waste role, so
+  the activity holding it stops being described as treating waste; and in a
+  file this engine wrote itself, where the row was on the output side, it used
+  to be matched by name to a treatment carried by another loaded database, and
+  an elementary flow is matched against methods instead. Caches built before
+  this are rebuilt on the next load.
 - Waste that leaves a system with no treatment modelled for it is now
   characterized. A SimaPro CSV files such waste in a section of its own, and a
   method that scores it writes the same word in its compartment column. The

--- a/pyvolca/tests/test_waste_exchange.py
+++ b/pyvolca/tests/test_waste_exchange.py
@@ -3,8 +3,10 @@
 The engine emits waste flows as their own kind (PR #83): they share the
 technosphere matrix with product flows but are tagged separately so callers
 can distinguish "waste sent to landfill" from a product input. Orphan waste
-(``activityLinkId == nil``, ``targetActivity == null``) is the typical case
-for SimaPro "Final waste flows".
+(``activityLinkId == nil``, ``targetActivity == null``) is what a partial
+export leaves behind: waste whose treatment is modelled somewhere, but not in
+the file that was read. Waste with no treatment modelled at all is not on this
+axis, it is an elementary flow of medium ``waste``.
 
 This module covers the wire shape for both envelopes:
 

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -312,6 +312,10 @@ History of manual bumps:
      "waste", not a waste exchange. Nothing changes type, so a cache written
      just before this would pass the fingerprint and keep those flows on an
      axis no method reads.
+- 27: the same row read from an EcoSpold 1 file is an elementary flow too, and
+     an export writes it as one. Nothing changes type, so a cache written just
+     before this would pass the fingerprint and keep those flows on the waste
+     axis, still counted as demands the gap report can never close.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.
@@ -319,7 +323,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeRep (Proxy :: Proxy Database))
-     in hi `xor` lo `xor` 26
+     in hi `xor` lo `xor` 27
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -538,27 +538,34 @@ resetDataset state =
 EcoSpold1 groups:
   Input:  1-3 = technosphere, 4 = resource (biosphere)
   Output: 0 = reference product, 1-3 = byproduct/co-product, 4 = emission (biosphere)
+
+A row filed under @category="Final waste flows"@ is an elementary flow of
+medium 'wasteMedium' whatever group it carries, so it is read as biosphere
+before the groups are consulted. Waste that does have a treatment is not
+written that way and stays on the technosphere side.
 -}
 buildExchange :: Maybe Text -> ExchangeData -> (Exchange, ParsedFlow, Unit)
 buildExchange activityLoc edata
-    | isWasteFlow = (wasteEx, ParsedWaste wasteFlow, unit)
     | isBiosphere = (bioEx, ParsedBio bioFlow, unit)
     | otherwise = (techEx, ParsedTech techFlow, unit)
   where
-    flowId = generateFlowUUID (exNumber edata) (exName edata) (exCategory edata) (exSubCategory edata) (exUnit edata)
+    flowId = generateFlowUUID (exNumber edata) (exName edata) category (exSubCategory edata) (exUnit edata)
     unitId = generateUnitUUID (exUnit edata)
     unit = Unit unitId (exUnit edata) (exUnit edata) ""
 
     inputGroup = exInputGroup edata
     outputGroup = exOutputGroup edata
-    isBiosphere = inputGroup == "4" || outputGroup == "4"
+    isBiosphere = inputGroup == "4" || outputGroup == "4" || isFinalWaste
     isInput = not (T.null inputGroup)
     isReferenceProduct = outputGroup == "0"
-    -- SimaPro's third flow class ('Final waste flows'). EcoSpold1 exports
-    -- surface them on inputGroup=5 to fit the 4-type input/output model, but
-    -- the category attribute survives. Routed to WasteExchange so they bypass
-    -- cross-DB technosphere linking (orphan outputs, not demands).
-    isWasteFlow = exCategory edata == "Final waste flows"
+    -- Waste with no treatment modelled for it, which an EcoSpold1 export files
+    -- under this category. It surfaces on inputGroup=5, the export's way of
+    -- fitting a fifth flow class into a 4-type input/output model, but nothing
+    -- treats it, so nothing produces it: it is an elementary flow, and reading
+    -- it as an input would ask for a supplier no database can provide.
+    isFinalWaste = exCategory edata == "Final waste flows"
+    -- The medium a method characterizes it under, and what the flow stores.
+    category = if isFinalWaste then wasteMedium else exCategory edata
 
     -- Technosphere: leave empty if unspecified so the Loader can do name-only
     -- lookup. Biosphere: fall back to the activity location (no supplier link).
@@ -575,29 +582,11 @@ buildExchange activityLoc edata
         | isInput = Input
         | otherwise = Coproduct
 
-    -- activityLinkId stays nil; the Loader resolves it later via
-    -- (flowName, exchangeLocation) against supplier activities.
-    wasteFlow = WasteFlow flowId (exName edata) unitId M.empty cas Nothing
-    wasteEx =
-        WasteExchange
-            { waFlowId = flowId
-            , waAmount = exMeanValue edata
-            , waUnitId = unitId
-            , -- Mirror isInput: final waste flows surface on inputGroup=5
-              -- (consumer's POV: input from a hypothetical treatment service).
-              waIsInput = isInput
-            , waActivityLinkId = UUID.nil
-            , waProcessLinkId = Nothing
-            , waLocation = exchangeLocation
-            , waComment = nonEmptyText (exComment edata)
-            , waPedigree = Nothing
-            }
-
     subCat = if T.null (exSubCategory edata) then Nothing else Just (exSubCategory edata)
     compartment =
-        if T.null (exCategory edata) && isNothing subCat
+        if T.null category && isNothing subCat
             then Nothing
-            else Just (Compartment (exCategory edata) subCat)
+            else Just (Compartment category subCat)
     bioFlow = BiosphereFlow flowId (exName edata) unitId M.empty cas Nothing compartment
     bioEx =
         BiosphereExchange

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -190,7 +190,6 @@ data ParseState = ParseState
     , psExchanges :: ![Exchange]
     , psTechFlows :: ![TechnosphereFlow]
     , psBioFlows :: ![BiosphereFlow]
-    , psWasteFlows :: ![WasteFlow]
     , psUnits :: ![Unit]
     , psPath :: ![BS.ByteString]
     , psContext :: !ElementContext
@@ -214,7 +213,6 @@ initialParseState =
         , psExchanges = []
         , psTechFlows = []
         , psBioFlows = []
-        , psWasteFlows = []
         , psUnits = []
         , psPath = []
         , psContext = Other
@@ -481,15 +479,13 @@ closeExchange state = case psContext state of
                 TechnosphereExchange{} -> psSupplierLinks state
                 BiosphereExchange{} -> psSupplierLinks state
                 WasteExchange{} -> psSupplierLinks state
-            (techs, bios, wastes) = case parsedFlow of
-                ParsedTech tf -> (tf : psTechFlows state, psBioFlows state, psWasteFlows state)
-                ParsedBio bf -> (psTechFlows state, bf : psBioFlows state, psWasteFlows state)
-                ParsedWaste wf -> (psTechFlows state, psBioFlows state, wf : psWasteFlows state)
+            (techs, bios) = case parsedFlow of
+                ParsedTech tf -> (tf : psTechFlows state, psBioFlows state)
+                ParsedBio bf -> (psTechFlows state, bf : psBioFlows state)
          in (popElement state)
                 { psExchanges = exchange : psExchanges state
                 , psTechFlows = techs
                 , psBioFlows = bios
-                , psWasteFlows = wastes
                 , psUnits = unit : psUnits state
                 , psSupplierLinks = supplierLinks
                 , psContext = Other
@@ -524,7 +520,6 @@ resetDataset state =
         , psExchanges = []
         , psTechFlows = []
         , psBioFlows = []
-        , psWasteFlows = []
         , psUnits = []
         , psContext = Other
         , psTextAccum = []
@@ -700,7 +695,10 @@ buildResult st =
             ( act
             , reverse (psTechFlows st)
             , reverse (psBioFlows st)
-            , reverse (psWasteFlows st)
+            , -- This format has no waste axis. Waste sent to treatment is a
+              -- technosphere input like any other, and waste with none is an
+              -- elementary flow, so nothing here builds a waste flow.
+              []
             , reverse (psUnits st)
             , psDatasetNumber st
             , psSupplierLinks st

--- a/src/EcoSpold/Writer1.hs
+++ b/src/EcoSpold/Writer1.hs
@@ -15,10 +15,13 @@ __canonical and deterministic__:
     dataset's number, a linked technosphere input carries its supplier's, and
     every other exchange carries a number assigned once per distinct flow.
     That makes the writer's output __self-stable for every exchange except a
-    linked technosphere input__: reference products, co-products, biosphere and
-    waste exchanges, and /unlinked/ inputs all reproduce the same flow UUIDs on
+    linked technosphere input__: reference products, co-products, biosphere
+    exchanges and /unlinked/ inputs all reproduce the same flow UUIDs on
     a write→parse→write cycle, and one substance stays one flow across the
-    re-imported export. This is fixed-point stability of the writer's own
+    re-imported export. A waste exchange is the one row that changes axis by
+    design: EcoSpold1 has no third flow class, so it is written as the
+    technosphere or biosphere row the mapping below names, and it is that shape
+    which is stable from then on. This is fixed-point stability of the writer's own
     canonical form, __not__ reproduction of the UUIDs of an arbitrary parsed
     source file — that source carried its own numbering, which the writer does
     not preserve;
@@ -48,17 +51,32 @@ The mapping mirrors 'EcoSpold.Parser1.buildExchange' exactly:
     (parser treats any non-empty inputGroup as a tech input)
   * biosphere 'Resource'                 → @\<inputGroup\>4\</inputGroup\>@
   * biosphere 'Emission'                 → @\<outputGroup\>4\</outputGroup\>@
-  * waste output (waIsInput=False)       → @\<outputGroup\>1\</outputGroup\>@,
-    category="Final waste flows"
   * waste input  (waIsInput=True)        → @\<inputGroup\>5\</inputGroup\>@,
-    category="Final waste flows"
+    written as a technosphere input, carrying its supplier's dataset number
+    when the treatment it names is exported too
+  * waste output, unlinked                → @\<outputGroup\>4\</outputGroup\>@,
+    category=@"waste"@, written as a biosphere emission
+  * waste output naming a treatment       → rejected by
+    'checkEcoSpold1Exportable'
+
+One rule shapes those three: EcoSpold1 can name a supplier only from an
+input's @number@ attribute. A waste input is therefore the only waste row the
+format can carry with its link intact, and an output that names a treatment
+has to be refused rather than written with the link dropped. An output that
+names none is what a final waste flow is, and the parser reads it back as the
+elementary flow of medium 'wasteMedium' that it is.
+
+The SimaPro writer partitions on the link alone, so it sends an /unlinked/
+waste input to its own final-waste section, where this writer sends it to the
+technosphere. The matrix agrees with this one: an unlinked input is a demand
+of +1 still waiting for a supplier, and a technosphere input keeps it.
 
 Flow names, categories, CAS numbers and units are not stored on the
 'Exchange'; they live on the flow / unit tables and are resolved by UUID.
 A biosphere flow's @category@ / @subCategory@ come from its 'Compartment';
 technosphere flows carry no category (the parser only used it to seed the
-UUID), and waste flows always re-emit @category="Final waste flows"@ so the
-parser's waste-routing rule fires again.
+UUID), and a waste flow borrows whichever of the two shapes its row was
+written in.
 -}
 module EcoSpold.Writer1 (
     -- * Options
@@ -239,10 +257,15 @@ emit silently wrong data:
     the writer would emit @outputGroup 0@ and the parser would read it back as
     a reference product — a direction flip.
 
-  * __Waste-marker collision.__ A biosphere flow whose compartment name is the
-    waste-routing category @"Final waste flows"@ would re-import as a waste
-    exchange, because the parser tests that category before the biosphere group
-    — a silent biosphere → waste kind flip. Rejected.
+  * __Waste outputs naming a treatment.__ The format names a supplier only
+    from an input's @number@ attribute, so the link of a waste /output/ cannot
+    be written. Emitting the row anyway would re-import it as waste nothing
+    treats, silently deleting the treatment it named.
+
+  * __Waste-marker collision.__ A biosphere flow whose compartment name is
+    @"Final waste flows"@ would re-import under compartment @"waste"@, because
+    the parser reads that category as the marker of a final waste flow — a
+    silent change of the compartment a method characterizes it under. Rejected.
 
   * __Missing flows / units.__ An exchange whose flow or unit is absent from
     the tables would be written with a blank name and re-parse as a different
@@ -259,7 +282,7 @@ Databases free of all of these pass unchanged.
 -}
 checkEcoSpold1Exportable :: SimpleDatabase -> Either Text ()
 checkEcoSpold1Exportable db =
-    case lefts [checkLinks, checkRefInputs, checkWasteSentinel, checkFlows, checkUnits, checkAmounts, checkAmountRoundTrip] of
+    case lefts [checkLinks, checkRefInputs, checkLinkedWasteOutputs, checkWasteSentinel, checkFlows, checkUnits, checkAmounts, checkAmountRoundTrip] of
         [] -> Right ()
         violations -> Left (T.intercalate "\n\n" violations)
   where
@@ -283,6 +306,16 @@ checkEcoSpold1Exportable db =
                         <> "\": the format has no marker for it, so the writer would emit"
                         <> " outputGroup 0 and the parser would read it back as a reference"
                         <> " product — a direction flip from input to output."
+    checkLinkedWasteOutputs =
+        case linkedWasteOutputs of
+            [] -> Right ()
+            (producer : _) ->
+                Left $
+                    "EcoSpold1 export cannot encode the treatment named by a waste output in \""
+                        <> producer
+                        <> "\": the format names a supplier only from an input's number"
+                        <> " attribute, so the writer would have to drop the link and the"
+                        <> " parser would read the row back as waste nothing treats."
     checkWasteSentinel =
         case wasteSentinelOffenders of
             [] -> Right ()
@@ -292,9 +325,11 @@ checkEcoSpold1Exportable db =
                         <> consumer
                         <> "\": a biosphere flow's compartment is \""
                         <> finalWasteFlowsCategory
-                        <> "\", which 'EcoSpold.Parser1' reads as the waste-routing marker —"
-                        <> " the flow would re-import as a waste exchange, not a biosphere one"
-                        <> " (a silent biosphere → waste kind flip)."
+                        <> "\", which 'EcoSpold.Parser1' reads as the marker of a final waste"
+                        <> " flow — the flow would re-import under compartment \""
+                        <> wasteMedium
+                        <> "\", so a method would characterize it as waste rather than under"
+                        <> " the compartment it was written with."
     checkFlows =
         case flowOffenders of
             [] -> Right ()
@@ -338,9 +373,27 @@ checkEcoSpold1Exportable db =
     danglingLinks =
         [ (activityName act, link)
         | act <- M.elems (sdbActivities db)
-        , TechnosphereExchange{techRole = Input, techActivityLinkId = link, techFlowId = fid} <- exchanges act
-        , link /= UUID.nil
+        , ex <- exchanges act
+        , (link, fid) <- namedSupplier ex
         , not (M.member (link, fid) index)
+        ]
+    -- The rows whose number names a supplier: a technosphere input, and a
+    -- waste input, which the writer emits as one. An output names none, on
+    -- either axis.
+    namedSupplier :: Exchange -> [(UUID, UUID)]
+    namedSupplier ex = case ex of
+        TechnosphereExchange{techRole = Input, techActivityLinkId = link, techFlowId = fid}
+            | link /= UUID.nil -> [(link, fid)]
+        TechnosphereExchange{} -> []
+        BiosphereExchange{} -> []
+        WasteExchange{waIsInput = True, waActivityLinkId = link, waFlowId = fid}
+            | link /= UUID.nil -> [(link, fid)]
+        WasteExchange{} -> []
+    linkedWasteOutputs =
+        [ activityName act
+        | act <- M.elems (sdbActivities db)
+        , ex <- exchanges act
+        , linkedWaste ex && not (exchangeIsInput ex)
         ]
     amountOffenders =
         [ (activityName act, amt)
@@ -480,9 +533,10 @@ A reference product carries its own dataset's number, which is what every
 EcoSpold1 export observed here does and what lets a consumer name its supplier.
 A technosphere input the loader resolved carries its supplier's dataset number
 ('EcoSpold.Parser1.closeExchange' reads it back as the supplier link), so the
-two agree on one number for one product. Everything else — co-products,
-biosphere, waste, and unlinked inputs — carries the number its flow was given
-once for the whole export ('flowNumberIndex').
+two agree on one number for one product; a resolved waste input does the same,
+being written as a technosphere input. Everything else — co-products,
+biosphere, waste outputs, and unlinked inputs — carries the number its flow was
+given once for the whole export ('flowNumberIndex').
 
 'checkEcoSpold1Exportable' guarantees any resolved link's (activity, product)
 pair is present in the supplier index before export, so that fallback is
@@ -498,6 +552,11 @@ exchangeNumber res datasetNum ex
                 M.findWithDefault flowNum (link, fid) (rSupplierNumbers res)
         TechnosphereExchange{} -> flowNum
         BiosphereExchange{} -> flowNum
+        -- A waste input is written as a technosphere input, so it names its
+        -- treatment the same way. An output carries no link to name.
+        WasteExchange{waIsInput = True, waActivityLinkId = link, waFlowId = fid}
+            | link /= UUID.nil ->
+                M.findWithDefault flowNum (link, fid) (rSupplierNumbers res)
         WasteExchange{} -> flowNum
   where
     flowNum = M.findWithDefault datasetNum (exchangeFlowId ex) (rFlowNumbers res)
@@ -545,8 +604,12 @@ groupElement ex = case ex of
     BiosphereExchange{bioDirection = dir} -> case dir of
         Resource -> wrapIn "4"
         Emission -> wrapOut "4"
+    -- An input is the only side of the format that can name a supplier, so a
+    -- waste input goes where a technosphere input goes. An output cannot name
+    -- one; the linked case is refused before it gets here, and the unlinked
+    -- case is an elementary flow.
     WasteExchange{waIsInput = isInput} ->
-        if isInput then wrapIn "5" else wrapOut "1"
+        if isInput then wrapIn "5" else wrapOut "4"
   where
     wrapIn g = "<inputGroup>" <> g <> "</inputGroup>"
     wrapOut g = "<outputGroup>" <> g <> "</outputGroup>"
@@ -555,13 +618,13 @@ groupElement ex = case ex of
 -- Flow-field resolution (name / category / subCategory / CAS by UUID)
 -- ----------------------------------------------------------------------------
 
-{- | The category label EcoSpold1 exports use for SimaPro's third flow class.
-'EcoSpold.Parser1.buildExchange' routes any exchange carrying this category to a
-'WasteExchange' — and it checks that /before/ the biosphere and technosphere
-groups. So the writer emits it for every waste flow, and
-'checkEcoSpold1Exportable' rejects any /non-waste/ flow whose category would
-collide with it (the only such flow is a biosphere one whose compartment name
-happens to be this string), which would otherwise re-import as a waste exchange.
+{- | The category label an EcoSpold1 export files waste with no modelled
+treatment under. 'EcoSpold.Parser1.buildExchange' reads any exchange carrying
+it as an elementary flow of medium 'wasteMedium', whatever group it is on and
+before the groups are consulted. The writer no longer emits it — it writes the
+medium itself, which re-imports unchanged — so this is now only what
+'checkEcoSpold1Exportable' compares a biosphere compartment against, to reject
+a flow that would come back under a compartment it was not written with.
 -}
 finalWasteFlowsCategory :: Text
 finalWasteFlowsCategory = "Final waste flows"
@@ -572,10 +635,11 @@ name, category, subCategory, CAS. Positional — always consumed as a whole.
 data FlowFields = FlowFields !Text !Text !Text !(Maybe Text)
 
 {- | Resolve a flow's serialised fields from the matching table. A biosphere
-flow's compartment becomes category/subCategory; a waste flow always carries
-@category="Final waste flows"@ so the parser re-routes it to the waste
-bucket; a technosphere flow has no category. A UUID absent from its table
-yields empty/Nothing — never a crash.
+flow's compartment becomes category/subCategory; a technosphere flow has no
+category; a waste flow takes the shape of the row it is written in, blank for
+an input (a technosphere row) and 'wasteMedium' for an output (a biosphere
+row, which is the compartment the parser reads back). A UUID absent from its
+table yields empty/Nothing — never a crash.
 -}
 flowFields :: Resolvers -> Exchange -> FlowFields
 flowFields res ex = case ex of
@@ -592,10 +656,11 @@ flowFields res ex = case ex of
                     (fromMaybe "" (bfCompartmentSub bf))
                     (bfCAS bf)
             Nothing -> FlowFields "" "" "" Nothing
-    WasteExchange{waFlowId = fid} ->
-        case M.lookup fid (rWaste res) of
-            Just wf -> FlowFields (wfName wf) finalWasteFlowsCategory "" (wfCAS wf)
-            Nothing -> FlowFields "" finalWasteFlowsCategory "" Nothing
+    WasteExchange{waFlowId = fid, waIsInput = isInput} ->
+        let category = if isInput then "" else wasteMedium
+         in case M.lookup fid (rWaste res) of
+                Just wf -> FlowFields (wfName wf) category "" (wfCAS wf)
+                Nothing -> FlowFields "" category "" Nothing
 
 {- | Resolve a unit UUID to its name. The parser stored both unit name and
 symbol as the source unit string, so the name field is the faithful echo.

--- a/src/EcoSpold/Writer1.hs
+++ b/src/EcoSpold/Writer1.hs
@@ -420,9 +420,10 @@ checkEcoSpold1Exportable db =
         , TechnosphereExchange{techRole = ReferenceInput} <- exchanges act
         ]
     -- A biosphere flow is serialised with @category = bfCompartmentName@. If that
-    -- equals the waste-routing marker, the parser (which tests the category first)
-    -- re-imports it as a waste exchange — a silent kind flip. A missing flow is
-    -- caught by 'checkFlows', so only resolvable biosphere flows are inspected here.
+    -- equals the final-waste marker, the parser (which tests the category before
+    -- the groups) re-imports it under the "waste" compartment instead, so a method
+    -- scores it as waste. A missing flow is caught by 'checkFlows', so only
+    -- resolvable biosphere flows are inspected here.
     wasteSentinelOffenders =
         [ activityName act
         | act <- M.elems (sdbActivities db)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -800,7 +800,6 @@ parsers never produce unresolved entries.
 data ParsedFlow
     = ParsedTech !TechnosphereFlow
     | ParsedBio !BiosphereFlow
-    | ParsedWaste !WasteFlow
     deriving (Generic, NFData)
 
 {- | A resolved flow tagged with its kind. Returned by lookup/search code

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -175,11 +175,12 @@ multiDatasetXml =
         , "</ecoSpold>"
         ]
 
-{- | Fixture exercising the 'Final waste flows' export shape. SimaPro's
-third flow class lands on inputGroup=5 (consumer-side) in the EcoSpold1
-serialisation, with the category attribute preserved. Exchange #1 is the
-reference product, #2 is a real waste output the parser must route to
-WasteExchange instead of treating it as an unresolved tech input.
+{- | Fixture exercising the 'Final waste flows' export shape. Waste with no
+modelled treatment lands on inputGroup=5, the export's way of fitting a fifth
+flow class into a four-type model, with the category attribute preserved.
+Exchange #1 is the reference product, #2 is such a row: nothing treats it, so
+the parser must read it as an elementary flow rather than as a demand on a
+supplier that cannot exist.
 -}
 wasteFlowXml :: BC.ByteString
 wasteFlowXml =
@@ -200,7 +201,8 @@ wasteFlowXml =
         , "        <outputGroup>0</outputGroup>"
         , "      </exchange>"
         , "      <exchange number=\"2\" name=\"Organic carbon, placed in landfill\""
-        , "                category=\"Final waste flows\" unit=\"kg\" meanValue=\"0.02\">"
+        , "                category=\"Final waste flows\" subCategory=\"landfill\""
+        , "                unit=\"kg\" meanValue=\"0.02\">"
         , "        <inputGroup>5</inputGroup>"
         , "      </exchange>"
         , "    </flowData>"
@@ -562,18 +564,21 @@ spec = do
                      in locs `shouldBe` ["CH", "FR"]
 
     -- -----------------------------------------------------------------------
-    -- Waste-flow routing: category="Final waste flows" must surface as
-    -- WasteExchange + WasteFlow, not a technosphere input. This is the
-    -- inputGroup=5 export path that motivated the three-flow-kind series.
+    -- Final waste flows: waste with no modelled treatment is an elementary
+    -- flow of medium "waste". Nothing treats it, so nothing produces it, and
+    -- reading it as an input would demand a supplier no database can provide.
     -- -----------------------------------------------------------------------
     describe "Final waste flows routing" $ do
-        it "routes category=\"Final waste flows\" to WasteExchange" $
+        it "reads category=\"Final waste flows\" as a biosphere flow of medium waste" $
             case parseWithXeno wasteFlowXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, wastes, _, _, _) -> do
-                    let wasteExchanges = [e | e@WasteExchange{} <- exchanges act]
-                    length wasteExchanges `shouldBe` 1
-                    length wastes `shouldBe` 1
+                Right (act, _, bios, wastes, _, _, _) -> do
+                    let bioExchanges = [e | e@BiosphereExchange{} <- exchanges act]
+                    length bioExchanges `shouldBe` 1
+                    map bfName bios `shouldBe` ["Organic carbon, placed in landfill"]
+                    map bfCompartment bios
+                        `shouldBe` [Just (Compartment wasteMedium (Just "landfill"))]
+                    length wastes `shouldBe` 0
 
         it "does not route the waste flow to the technosphere bucket" $
             case parseWithXeno wasteFlowXml of
@@ -583,10 +588,17 @@ spec = do
                     -- the Final-waste-flows row must not show up there.
                     map tfName techs `shouldBe` ["aluminium ingot"]
 
-        it "preserves waIsInput from inputGroup (5 → True)" $
+        it "reads it as an emission despite the input group" $
             case parseWithXeno wasteFlowXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
                 Right (act, _, _, _, _, _, _) ->
-                    -- Final waste flows surface on inputGroup=5; preserve
-                    -- that consumer-side semantic in the resulting WasteExchange.
-                    [waIsInput e | e@WasteExchange{} <- exchanges act] `shouldBe` [True]
+                    -- inputGroup=5 is an artefact of the format, not a
+                    -- direction: the row is waste leaving the system.
+                    [bioDirection e | e@BiosphereExchange{} <- exchanges act]
+                        `shouldBe` [Emission]
+
+        it "falls back to the activity location, as for any elementary flow" $
+            case parseWithXeno wasteFlowXml of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right (act, _, _, _, _, _, _) ->
+                    [bioLocation e | e@BiosphereExchange{} <- exchanges act] `shouldBe` ["RoW"]

--- a/test/EcoSpold1WriterSpec.hs
+++ b/test/EcoSpold1WriterSpec.hs
@@ -392,6 +392,10 @@ dbViews sdb =
 -- Parse helper: write → parse back into a SimpleDatabase
 -- ---------------------------------------------------------------------------
 
+-- | Every exchange of a database, order irrelevant to the assertions using it.
+allExchanges :: SimpleDatabase -> [Exchange]
+allExchanges = concatMap exchanges . M.elems . sdbActivities
+
 roundTrip :: SimpleDatabase -> Either String SimpleDatabase
 roundTrip sdb =
     case writeSimpleDatabase canonicalWriterOptions sdb of
@@ -580,8 +584,12 @@ spec = do
                 Left err -> expectationFailure ("round-trip failed: " ++ err)
                 Right sdb' -> map activityName (M.elems (sdbActivities sdb')) `shouldBe` [nm]
 
-    describe "Final waste flows" $
-        it "round-trips a waste output as a waste flow (not a coproduct)" $ do
+    -- EcoSpold1 has no third flow class, so a waste exchange is written as the
+    -- technosphere or biosphere row that keeps its meaning: an input names its
+    -- treatment the way a technosphere input does, an output that names none is
+    -- an elementary flow, and an output that names one cannot be written at all.
+    describe "Final waste flows" $ do
+        it "writes an unlinked waste output as an elementary flow of medium waste" $ do
             let prodU = read "55555555-0000-4000-8000-000000000001" :: UUID
                 wasteU = read "55555555-0000-4000-8000-0000000000a0" :: UUID
                 wasteEx = WasteExchange wasteU 0.3 kgUnit False UUID.nil Nothing "" Nothing Nothing
@@ -590,11 +598,48 @@ spec = do
             case roundTrip sdb of
                 Left err -> expectationFailure ("round-trip failed: " ++ err)
                 Right sdb' -> do
-                    map wfName (M.elems (sdbWasteFlows sdb')) `shouldBe` ["spent solvent"]
-                    let isWasteOutput WasteExchange{waIsInput = i} = not i
-                        isWasteOutput TechnosphereExchange{} = False
-                        isWasteOutput BiosphereExchange{} = False
-                    any isWasteOutput (concatMap exchanges (M.elems (sdbActivities sdb'))) `shouldBe` True
+                    map bfName (M.elems (sdbBioFlows sdb')) `shouldBe` ["spent solvent"]
+                    map bfCompartment (M.elems (sdbBioFlows sdb'))
+                        `shouldBe` [Just (Compartment wasteMedium Nothing)]
+                    M.size (sdbWasteFlows sdb') `shouldBe` 0
+                    let directions = [d | BiosphereExchange{bioDirection = d} <- allExchanges sdb']
+                    directions `shouldBe` [Emission]
+
+        it "writes a waste input as a technosphere input" $ do
+            let prodU = read "55555555-0000-4000-8000-000000000002" :: UUID
+                wasteU = read "55555555-0000-4000-8000-0000000000a1" :: UUID
+                wasteEx = WasteExchange wasteU 0.3 kgUnit True UUID.nil Nothing "" Nothing Nothing
+                wastes = M.singleton wasteU (WasteFlow wasteU "spent solvent" kgUnit M.empty Nothing Nothing)
+                sdb = soloDb "solvent user" prodU [wasteEx] M.empty M.empty wastes
+            case roundTrip sdb of
+                Left err -> expectationFailure ("round-trip failed: " ++ err)
+                Right sdb' -> do
+                    let roles = [r | TechnosphereExchange{techRole = r} <- allExchanges sdb']
+                    roles `shouldBe` [ReferenceProduct, Input]
+                    M.size (sdbBioFlows sdb') `shouldBe` 0
+
+        it "rejects a waste output that names the treatment it goes to" $ do
+            -- The number attribute names a supplier only on an input, so the
+            -- link would have to be dropped and the row would come back as
+            -- waste nothing treats.
+            let prodU = read "55555555-0000-4000-8000-000000000003" :: UUID
+                wasteU = read "55555555-0000-4000-8000-0000000000a2" :: UUID
+                treatU = read "55555555-0000-4000-8000-0000000000b2" :: UUID
+                wasteEx = WasteExchange wasteU 0.3 kgUnit False treatU Nothing "" Nothing Nothing
+                wastes = M.singleton wasteU (WasteFlow wasteU "spent solvent" kgUnit M.empty Nothing Nothing)
+                sdb = soloDb "solvent user" prodU [wasteEx] M.empty M.empty wastes
+            checkEcoSpold1Exportable sdb `shouldSatisfy` isLeft
+
+        it "rejects a waste input whose treatment is not exported alongside it" $ do
+            -- Same rule as a technosphere input: the writer can only emit a
+            -- supplier number for a row that is in the export.
+            let prodU = read "55555555-0000-4000-8000-000000000004" :: UUID
+                wasteU = read "55555555-0000-4000-8000-0000000000a3" :: UUID
+                treatU = read "55555555-0000-4000-8000-0000000000b3" :: UUID
+                wasteEx = WasteExchange wasteU 0.3 kgUnit True treatU Nothing "" Nothing Nothing
+                wastes = M.singleton wasteU (WasteFlow wasteU "spent solvent" kgUnit M.empty Nothing Nothing)
+                sdb = soloDb "solvent user" prodU [wasteEx] M.empty M.empty wastes
+            checkEcoSpold1Exportable sdb `shouldSatisfy` isLeft
 
     describe "non-finite amounts" $
         it "rejects an Infinity exchange amount rather than exporting it as 0.0" $ do
@@ -645,9 +690,10 @@ spec = do
 
     describe "waste-marker collision" $
         it "rejects a biosphere flow whose compartment is the waste-routing category" $ do
-            -- "Final waste flows" is the parser's waste-routing marker, tested
-            -- before the biosphere group, so a biosphere flow carrying it as its
-            -- compartment name would silently re-import as a waste exchange.
+            -- "Final waste flows" is what the parser reads as the marker of a
+            -- final waste flow, before the groups, so a biosphere flow carrying
+            -- it as its compartment name would silently come back under the
+            -- "waste" compartment instead.
             let prodU = read "bbbb0000-0000-4000-8000-000000000001" :: UUID
                 bioU = read "bbbb0000-0000-4000-8000-0000000000c0" :: UUID
                 comp = Compartment "Final waste flows" Nothing


### PR DESCRIPTION
Closes #403.

An EcoSpold 1 file puts waste with no modelled treatment under a category of
its own, on an input group, because the format has four flow types and this is
a fifth. The parser read that direction literally, so every such row became a
demand waiting for a supplier that cannot exist and the completeness report
filled with edges no database could close. The same rows read from the other
two formats have been elementary flows since #402; this makes EcoSpold 1 agree.

Reading the category as a medium is the whole of the parser change: the row
joins the biosphere branch, the input group then reads as an emission, the
activity location fills in the way it does for any elementary flow, and the
compartment is the medium a method scores it under.

The writer needed a decision, because it used that same category as a marker so
a waste exchange would survive a round trip, and the parser no longer reads it
that way. One rule covers the three cases: EcoSpold 1 names a supplier only
from an input's number attribute.

| waste row | written as | read back as |
|---|---|---|
| input | technosphere input, keeping its supplier number | technosphere input, link intact |
| output naming no treatment | inventory flow of medium `waste` | elementary flow, unchanged |
| output naming a treatment | refused | n/a |

Refusing the third is the same choice `checkRefInputs` already makes for what
the format cannot mark: writing it would drop the treatment it names without
saying so. The dangling-link check follows the rule too and now covers a waste
input, the only waste row that carries a number a reader resolves.

One thing is lost and the CHANGELOG says so: an unlinked waste output used to be
matched by name to a treatment carried by another loaded database, and an
elementary flow is matched against methods instead. That is the trade #402 made
on the other side and it is the same one here.

The two writers still disagree on an unlinked waste **input**: this one sends it
to the technosphere, the SimaPro writer to its own final-waste section, where it
would come back as an emission. The matrix agrees with this side, an unlinked
input being a demand of +1 still waiting for a supplier. The divergence is noted
in the module haddock and left to its own change.

No database in reach uses the category, which is why #403 was filed rather than
fixed alongside #402, so the proof is in the tests rather than in a measurement:
the parser routing tests, and four writer cases including the two refusals.

Cache signature 26 to 27; nothing under `data/` moves, and no wire shape changes.