### PR TITLE
A compartment's medium is a value, not a spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,25 @@
   to be matched by name to a treatment carried by another loaded database, and
   an elementary flow is matched against methods instead. Caches built before
   this are rebuilt on the next load.
+- Two databases read from two formats now describe one physical flow the same
+  way. Every format spells a compartment's medium differently: an EcoSpold 2
+  file writes `natural resource`, an EcoSpold 1 file writes `resource`, a
+  SimaPro file heads the section `Raw`. Each was stored as written, so the same
+  extraction carried a different medium depending on which file it came from,
+  and every reader, writer and comparison that needed them to agree carried its
+  own list of spellings. The medium is now one value with one name, read at the
+  boundary and written back in each format's own vocabulary, so a database
+  exported and read again comes back with the medium it went out with. Two
+  consequences are visible: an inventory from a SimaPro or EcoSpold 1 source
+  now reports `natural resource` where it used to report `resource`, and the
+  elementary flows of such a database change identity, since the medium is part
+  of it. Caches built before this are rebuilt on the next load.
+- A technosphere input whose amount is zero is now kept. A SimaPro or Brightway
+  Excel file writes one when the author disabled an input or a parameter
+  evaluates to zero in this scenario, and dropping it lost what the file said
+  without a word, while the loader went on reporting a link rate over the rows
+  that survived. No computed number moves, a zero coefficient having no weight
+  in any matrix; an export now carries the rows its source carried.
 - Waste that leaves a system with no treatment modelled for it is now
   characterized. A SimaPro CSV files such waste in a section of its own, and a
   method that scores it writes the same word in its compartment column. The

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -1904,7 +1904,7 @@ another consumes, ``"biosphere"`` for a substance exchanged with nature,
 ``"waste"`` for a waste. It is ``None`` against an engine older than wire
 revision 9, which did not report it.
 
-``category`` is the medium alone ("air", "water", "soil", "resource") and
+``category`` is the medium alone ("air", "water", "soil", "natural resource") and
 ``compartment`` the sub-compartment ("agricultural"), which is often all
 that tells two same-named flows apart. Only a biosphere flow has either:
 that is where "taken from nature" and "released to nature" are told apart.

--- a/pyvolca/src/volca/types.py
+++ b/pyvolca/src/volca/types.py
@@ -597,7 +597,7 @@ class Flow(FromJson):
     ``"waste"`` for a waste. It is ``None`` against an engine older than wire
     revision 9, which did not report it.
 
-    ``category`` is the medium alone ("air", "water", "soil", "resource") and
+    ``category`` is the medium alone ("air", "water", "soil", "natural resource") and
     ``compartment`` the sub-compartment ("agricultural"), which is often all
     that tells two same-named flows apart. Only a biosphere flow has either:
     that is where "taken from nature" and "released to nature" are told apart.

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -43,7 +43,6 @@ import Types (
     Exchange,
     ExchangeKind (..),
     FlowKind (..),
-    Medium,
     NativeActivityType (..),
     NativeProcessId (..),
     Pedigree,

--- a/src/API/Types.hs
+++ b/src/API/Types.hs
@@ -13,6 +13,7 @@ import API.JsonOptions (Stripped (..))
 import Control.Lens ((&), (.~), (?~))
 import Data.Aeson
 import Data.Aeson.Types (Parser)
+import Data.Bifunctor (first)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import Data.Either (partitionEithers)
@@ -34,7 +35,28 @@ import Database.Author (
  )
 import GHC.Generics
 import Servant.API.ContentTypes (MimeRender (..), MimeUnrender (..), OctetStream)
-import Types (BioDirection (..), BiosphereFlow (..), Compartment (..), DocSection (..), Exchange, ExchangeKind (..), FlowKind (..), NativeActivityType (..), NativeProcessId (..), Pedigree, Severity, TechnosphereFlow (..), UUID, Unit, WasteFlow (..), WasteRole (..), exchangeKindName)
+import Types (
+    BioDirection (..),
+    BiosphereFlow (..),
+    Compartment (..),
+    DocSection (..),
+    Exchange,
+    ExchangeKind (..),
+    FlowKind (..),
+    Medium,
+    NativeActivityType (..),
+    NativeProcessId (..),
+    Pedigree,
+    Severity,
+    TechnosphereFlow (..),
+    UUID,
+    Unit,
+    WasteFlow (..),
+    WasteRole (..),
+    exchangeKindName,
+    parseMedium,
+    unknownMedium,
+ )
 
 {- | Tagged wire representation of either side of the flow split.
 
@@ -2060,11 +2082,12 @@ bioFlowRef be = case (beFlow be, beName be) of
         -- new one (see 'Database.Author.authoredBioFlowUUID'), so it cannot be
         -- defaulted.
         (_, Nothing) -> Left ("biosphere flow \"" <> name <> "\" needs a unit")
-        (Just medium, Just unit) ->
+        (Just medium, Just unit) -> do
+            reading <- first (T.pack . unknownMedium) (parseMedium medium)
             Right $
                 FlowByName
                     name
-                    Compartment{compartmentName = medium, compartmentSub = beSubCompartment be}
+                    Compartment{compartmentName = reading, compartmentSub = beSubCompartment be}
                     unit
 
 {- | A name written into the identifier field is the common mistake, so the

--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -413,12 +413,14 @@ exchangeRowOut cfg actName f =
 key 'Database.Loader.buildSupplierIndexByName' matches against), with the
 supplier location preserved for geography-aware cross-DB linking: an 'Input'
 for a @technosphere@ row, an 'AvoidedProduct' for a @substitution@ row.
-Zero-amount rows are dropped (parity with the SimaPro importer).
+
+A zero amount is kept, like every other amount and like the SimaPro importer:
+it says the author disabled this input, which is a statement about the model,
+not an empty row.
 -}
 technosphereRowOut :: UC.UnitConfig -> TechRole -> Text -> M.Map Text CellValue -> RowOut
 technosphereRowOut cfg role actName f
     | T.null name = emptyRowOut{roWarn = ["activity '" <> actName <> "': skipped technosphere row with no name"]}
-    | amount == 0 = emptyRowOut
     | otherwise = RowOut (Just exch) [flow] [] [unit] []
   where
     name = fromMaybe "" (fieldText f "reference product" <|> fieldText f "name")

--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -478,7 +478,9 @@ biosphereRowOut cfg actName f
             , bfSynonyms = M.empty
             , bfCAS = Nothing
             , bfSubstanceId = Nothing
-            , bfCompartment = Just (Compartment comp (if T.null sub then Nothing else Just sub))
+            , bfCompartment = case parseMedium comp of
+                Right medium -> Just (Compartment medium (if T.null sub then Nothing else Just sub))
+                Left _ -> Nothing
             }
     unit = Unit unitUUID unitName' unitName' ""
 

--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -47,7 +47,6 @@ module BrightwayExcel.Parser (
     sheetToActivities,
     skippedSheetWarning,
     splitCategories,
-    isResourceCompartment,
 ) where
 
 import Amount (readAmount)
@@ -453,7 +452,7 @@ compartment string as the SimaPro importer so LCIA characterization matches.
 biosphereRowOut :: UC.UnitConfig -> Text -> M.Map Text CellValue -> RowOut
 biosphereRowOut cfg actName f
     | T.null name = emptyRowOut{roWarn = ["activity '" <> actName <> "': skipped biosphere row with no name"]}
-    | otherwise = RowOut (Just exch) [] [flow] [unit] []
+    | otherwise = RowOut (Just exch) [] [flow] [unit] mediumWarn
   where
     name = fromMaybe "" (fieldText f "name")
     (unitName', amount) = canonicalRow cfg (fromMaybe "" (fieldText f "unit")) (fromMaybe 0 (fieldNum f "amount"))
@@ -465,7 +464,7 @@ biosphereRowOut cfg actName f
             { bioFlowId = flowUUID
             , bioAmount = amount
             , bioUnitId = unitUUID
-            , bioDirection = if isResourceCompartment comp then Resource else Emission
+            , bioDirection = if parseMedium comp == Right NaturalResource then Resource else Emission
             , bioLocation = fromMaybe "" (fieldText f "location")
             , bioComment = fieldText f "comment"
             , bioPedigree = Nothing
@@ -482,6 +481,13 @@ biosphereRowOut cfg actName f
                 Right medium -> Just (Compartment medium (if T.null sub then Nothing else Just sub))
                 Left _ -> Nothing
             }
+    -- A medium nothing can bucket leaves the flow without a compartment, which
+    -- costs it every characterization factor. Say which word did it.
+    mediumWarn = case parseMedium comp of
+        Right _ -> []
+        Left got ->
+            [ "activity '" <> actName <> "', flow '" <> name <> "': " <> T.pack (unknownMedium got)
+            ]
     unit = Unit unitUUID unitName' unitName' ""
 
 {- | Split a Brightway @categories@ cell (@"air"@, @"air::urban air"@) into
@@ -492,10 +498,6 @@ splitCategories cats = case T.splitOn "::" cats of
     [] -> ("", "")
     [a] -> (T.strip a, "")
     (a : rest) -> (T.strip a, T.strip (T.intercalate "::" rest))
-
-isResourceCompartment :: Text -> Bool
-isResourceCompartment comp =
-    T.toLower (T.strip comp) `elem` ["natural resource", "resource", "resources", "raw"]
 
 fieldText :: M.Map Text CellValue -> Text -> Maybe Text
 fieldText m k = cellText =<< M.lookup k m

--- a/src/BrightwayExcel/Writer.hs
+++ b/src/BrightwayExcel/Writer.hs
@@ -474,8 +474,8 @@ renderCategories :: Maybe Compartment -> Text
 renderCategories = \case
     Nothing -> ""
     Just (Compartment comp sub) -> case sub of
-        Just s | not (T.null (T.strip s)) -> comp <> "::" <> s
-        _ -> comp
+        Just s | not (T.null (T.strip s)) -> mediumText comp <> "::" <> s
+        _ -> mediumText comp
 
 -- ---------------------------------------------------------------------------
 -- Lookups (pure)

--- a/src/BrightwayExcel/Writer.hs
+++ b/src/BrightwayExcel/Writer.hs
@@ -76,7 +76,6 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 
 import Amount (readAmount)
-import BrightwayExcel.Parser (isResourceCompartment)
 import EcoSpold.Common (showFFloatTrim)
 import Types
 import Zip (zipFiles)
@@ -154,10 +153,10 @@ exchange (no producer link) never enters the matrix, so 'exchangeRow' instead
 best-efforts it as technosphere and 'wasteManifest' reports it.
 
 A biosphere exchange's 'BioDirection' is likewise never written: the parser
-re-derives it from the @categories@ compartment, reading 'Resource' only when the
-compartment matches 'isResourceCompartment'. A 'Resource' flow whose compartment
-is outside that whitelist would round-trip as an 'Emission' — a sign flip, since
-the two directions act as input vs output. Such a flow is rejected here too.
+re-derives it from the @categories@ compartment, reading 'Resource' only for
+'NaturalResource'. A 'Resource' flow of any other medium would round-trip as an
+'Emission' — a sign flip, since the two directions act as input vs output. Such
+a flow is rejected here too.
 
 An amount that does not re-parse to itself is rejected. The written decimal must
 re-parse through 'Amount.readAmount' (the importer's correctly-rounded reader);
@@ -250,16 +249,16 @@ checkBrightwayExportable db =
     amountRoundTrips amt = readAmount (formatAmount amt) == Just amt
 
 {- | A 'Resource' biosphere exchange whose compartment would not re-parse as a
-resource: the writer never records the direction, so the parser reconstructs
-it from the @categories@ compartment via 'isResourceCompartment'. When that
-whitelist rejects the compartment, 'Resource' silently flips to 'Emission'.
-A flow absent from the map is left to 'flowResolvable' to report.
+resource: the writer never records the direction, so the parser reconstructs it
+from the @categories@ compartment, which names a resource only when the medium
+is 'NaturalResource'. Under any other medium 'Resource' silently flips to
+'Emission'. A flow absent from the map is left to 'flowResolvable' to report.
 -}
 resourceDirectionLost :: SimpleDatabase -> Exchange -> Bool
 resourceDirectionLost db = \case
     ex@BiosphereExchange{bioDirection = Resource} ->
         case M.lookup (exchangeFlowId ex) (sdbBioFlows db) of
-            Just flow -> not (isResourceCompartment (bfCompartmentName flow))
+            Just flow -> (compartmentName <$> bfCompartment flow) /= Just NaturalResource
             Nothing -> False
     BiosphereExchange{bioDirection = Emission} -> False
     TechnosphereExchange{} -> False

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -84,6 +84,7 @@ import Types (
     Compartment (..),
     Database (..),
     Exchange (..),
+    Medium (..),
     ProcessId,
     ProcessRef (..),
     TechRole (..),
@@ -96,6 +97,7 @@ import Types (
     exchangeIsReference,
     findProcessIdByActivityUUID,
     getUnitNameForExchange,
+    mediumText,
     noProperties,
     parseProcessRef,
  )
@@ -139,7 +141,7 @@ instead, which for SimaPro is the name and the compartment alone.
 -}
 authoredBioFlowUUID :: Text -> Compartment -> Text -> UUID
 authoredBioFlowUUID name comp unit =
-    mintAuthored ["flow", name, compartmentName comp, fromMaybe "" (compartmentSub comp), unit]
+    mintAuthored ["flow", name, mediumText (compartmentName comp), fromMaybe "" (compartmentSub comp), unit]
 
 -- ---------------------------------------------------------------------------
 -- What an author writes
@@ -1054,8 +1056,7 @@ findBioFlowsByName ctx name comp = case matchesIn True (acDb ctx) of
     wantedCompartment = compartmentKey comp
     matchesIn local db =
         [ (flow, dbUnits db, local)
-        | not (T.null (fst wantedCompartment))
-        , flow <- M.elems (dbBioFlows db)
+        | flow <- M.elems (dbBioFlows db)
         , foldName (bfName flow) == wantedName
         , Just flowComp <- [bfCompartment flow]
         , compartmentKey flowComp == wantedCompartment
@@ -1065,11 +1066,11 @@ findBioFlowsByName ctx name comp = case matchesIn True (acDb ctx) of
 foldName :: Text -> Text
 foldName = T.toLower . T.unwords . T.words
 
-compartmentKey :: Compartment -> (Text, Text)
-compartmentKey comp = (foldName (compartmentName comp), foldName (fromMaybe "" (compartmentSub comp)))
+compartmentKey :: Compartment -> (Medium, Text)
+compartmentKey comp = (compartmentName comp, foldName (fromMaybe "" (compartmentSub comp)))
 
 renderCompartment :: Compartment -> Text
-renderCompartment comp = compartmentName comp <> maybe "" ("/" <>) (compartmentSub comp)
+renderCompartment comp = mediumText (compartmentName comp) <> maybe "" ("/" <>) (compartmentSub comp)
 
 {- | Find a biosphere flow, with the unit table that can name its unit and
 whether it lives in the edited database itself.

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -316,6 +316,9 @@ History of manual bumps:
      an export writes it as one. Nothing changes type, so a cache written just
      before this would pass the fingerprint and keep those flows on the waste
      axis, still counted as demands the gap report can never close.
+- 28: a compartment's medium is a 'Types.Medium', not text. The stored shape
+     changes and the resource flows of a SimaPro-sourced database change
+     identity, since the medium is hashed into it.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.
@@ -323,7 +326,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeRep (Proxy :: Proxy Database))
-     in hi `xor` lo `xor` 27
+     in hi `xor` lo `xor` 28
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -1584,10 +1584,15 @@ Biosphere flows need no supplier. Reference exchanges sit on the diagonal of
 'ReferenceInput' is a self-edge, not a supplier demand — counting it would drag
 completeness below 100% for a perfectly solvable database. Waste *outputs* are
 generated, not demanded; only waste/technosphere *inputs* remain.
+
+An input of zero demands nothing either: the matrix builder emits no entry for
+it, so no producer is ever looked up, and counting it as an unmet demand would
+report a gap that no solve can encounter.
 -}
 isSupplierDemand :: Exchange -> Bool
 isSupplierDemand ex =
-    not (isBiosphereExchange ex)
+    exchangeAmount ex /= 0
+        && not (isBiosphereExchange ex)
         && exchangeIsInput ex
         && not (exchangeIsReference ex)
 

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -535,7 +535,7 @@ EcoSpold1 groups:
   Output: 0 = reference product, 1-3 = byproduct/co-product, 4 = emission (biosphere)
 
 A row filed under @category="Final waste flows"@ is an elementary flow of
-medium 'wasteMedium' whatever group it carries, so it is read as biosphere
+medium 'Waste' whatever group it carries, so it is read as biosphere
 before the groups are consulted. Waste that does have a treatment is not
 written that way and stays on the technosphere side.
 -}
@@ -560,7 +560,7 @@ buildExchange activityLoc edata
     -- it as an input would ask for a supplier no database can provide.
     isFinalWaste = exCategory edata == "Final waste flows"
     -- The medium a method characterizes it under, and what the flow stores.
-    category = if isFinalWaste then wasteMedium else exCategory edata
+    category = if isFinalWaste then mediumText Waste else exCategory edata
 
     -- Technosphere: leave empty if unspecified so the Loader can do name-only
     -- lookup. Biosphere: fall back to the activity location (no supplier link).
@@ -578,10 +578,14 @@ buildExchange activityLoc edata
         | otherwise = Coproduct
 
     subCat = if T.null (exSubCategory edata) then Nothing else Just (exSubCategory edata)
-    compartment =
-        if T.null category && isNothing subCat
-            then Nothing
-            else Just (Compartment category subCat)
+    -- The medium of a group-4 exchange is its @category@, and the vocabulary
+    -- EcoSpold 1 writes there is the four 'parseMedium' reads. A category it
+    -- cannot place leaves the flow with no compartment: this reader assembles
+    -- its result purely and has no channel to report on, which is a limitation
+    -- of the reader rather than a judgement about the file.
+    compartment = case parseMedium category of
+        Right medium -> Just (Compartment medium subCat)
+        Left _ -> Nothing
     bioFlow = BiosphereFlow flowId (exName edata) unitId M.empty cas Nothing compartment
     bioEx =
         BiosphereExchange

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -25,7 +25,7 @@ import qualified Data.ByteString as BS
 import Data.Either (lefts, rights)
 import qualified Data.IntMap.Strict as IM
 import qualified Data.Map as M
-import Data.Maybe (fromMaybe, isNothing)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -849,9 +849,13 @@ parseWithXeno xmlContent processId = do
                     let (finalInputGroup, finalOutputGroup) = resolveGroups (edInputGroup edata) (edOutputGroup edata) state
                         -- A missing compartment becomes 'Nothing', not an empty 'Compartment ""'
                         -- sentinel — the latter used to silently collide with method-side empty mediums.
-                        mCompName = case edCompartments edata of
-                            (c : _) | not (T.null c) -> Just c
+                        -- A medium the reader cannot place is reported and the
+                        -- compartment dropped, rather than carried as a string
+                        -- nothing downstream can bucket.
+                        mediumReading = case edCompartments edata of
+                            (c : _) | not (T.null c) -> Just (parseMedium c)
                             _ -> Nothing
+                        mCompName = mediumReading >>= either (const Nothing) Just
                         subCompartment = case edSubcompartments edata of
                             (s : _) | not (T.null s) -> Just s
                             _ -> Nothing
@@ -871,15 +875,17 @@ parseWithXeno xmlContent processId = do
                             | isInventoryIndicator = Emission
                             | not (T.null finalInputGroup) = Resource
                             | not (T.null finalOutputGroup) = Emission
-                            | otherwise = case edCompartments edata of
-                                (comp : _) | T.toLower comp == "natural resource" -> Resource
-                                _ -> Emission
-                        isInventoryIndicator =
-                            maybe False ((== inventoryIndicatorMedium) . T.toLower . T.strip) mCompName
+                            | mCompName == Just NaturalResource = Resource
+                            | otherwise = Emission
+                        isInventoryIndicator = mCompName == Just InventoryIndicator
                         (flowUUID, flowWarn) = parseUUID (edFlowId edata)
                         (unitUUID, unitWarn) = parseUUID (edUnitId edata)
+                        mediumWarn = case mediumReading of
+                            Just (Left got) -> Just (unknownMedium got)
+                            Just (Right _) -> Nothing
+                            Nothing -> Nothing
                         warns =
-                            catMaybes [flowWarn, unitWarn]
+                            catMaybes [flowWarn, unitWarn, mediumWarn]
                                 ++ missingUnitWarning "elementary" (edFlowId edata) (edUnitName edata)
                         resolvedFlowName = nonBlankOr (edFlowId edata) (edFlowName edata)
                         unit = mkUnit unitUUID (edUnitName edata)

--- a/src/EcoSpold/Writer1.hs
+++ b/src/EcoSpold/Writer1.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 {- | EcoSpold1 export writer — the canonical re-emitter for "EcoSpold.Parser1".
@@ -64,7 +65,7 @@ input's @number@ attribute. A waste input is therefore the only waste row the
 format can carry with its link intact, and an output that names a treatment
 has to be refused rather than written with the link dropped. An output that
 names none is what a final waste flow is, and the parser reads it back as the
-elementary flow of medium 'wasteMedium' that it is.
+elementary flow of medium 'Waste' that it is.
 
 The SimaPro writer partitions on the link alone, so it sends an /unlinked/
 waste input to its own final-waste section, where this writer sends it to the
@@ -282,7 +283,7 @@ Databases free of all of these pass unchanged.
 -}
 checkEcoSpold1Exportable :: SimpleDatabase -> Either Text ()
 checkEcoSpold1Exportable db =
-    case lefts [checkLinks, checkRefInputs, checkLinkedWasteOutputs, checkWasteSentinel, checkFlows, checkUnits, checkAmounts, checkAmountRoundTrip] of
+    case lefts [checkLinks, checkRefInputs, checkLinkedWasteOutputs, checkFlows, checkUnits, checkAmounts, checkAmountRoundTrip] of
         [] -> Right ()
         violations -> Left (T.intercalate "\n\n" violations)
   where
@@ -316,20 +317,6 @@ checkEcoSpold1Exportable db =
                         <> "\": the format names a supplier only from an input's number"
                         <> " attribute, so the writer would have to drop the link and the"
                         <> " parser would read the row back as waste nothing treats."
-    checkWasteSentinel =
-        case wasteSentinelOffenders of
-            [] -> Right ()
-            (consumer : _) ->
-                Left $
-                    "EcoSpold1 export cannot represent activity \""
-                        <> consumer
-                        <> "\": a biosphere flow's compartment is \""
-                        <> finalWasteFlowsCategory
-                        <> "\", which 'EcoSpold.Parser1' reads as the marker of a final waste"
-                        <> " flow — the flow would re-import under compartment \""
-                        <> wasteMedium
-                        <> "\", so a method would characterize it as waste rather than under"
-                        <> " the compartment it was written with."
     checkFlows =
         case flowOffenders of
             [] -> Right ()
@@ -418,18 +405,6 @@ checkEcoSpold1Exportable db =
         [ activityName act
         | act <- M.elems (sdbActivities db)
         , TechnosphereExchange{techRole = ReferenceInput} <- exchanges act
-        ]
-    -- A biosphere flow is serialised with @category = bfCompartmentName@. If that
-    -- equals the final-waste marker, the parser (which tests the category before
-    -- the groups) re-imports it under the "waste" compartment instead, so a method
-    -- scores it as waste. A missing flow is caught by 'checkFlows', so only
-    -- resolvable biosphere flows are inspected here.
-    wasteSentinelOffenders =
-        [ activityName act
-        | act <- M.elems (sdbActivities db)
-        , BiosphereExchange{bioFlowId = fid} <- exchanges act
-        , Just bf <- [M.lookup fid (sdbBioFlows db)]
-        , bfCompartmentName bf == finalWasteFlowsCategory
         ]
     flowOffenders =
         [ activityName act
@@ -621,7 +596,7 @@ groupElement ex = case ex of
 
 {- | The category label an EcoSpold1 export files waste with no modelled
 treatment under. 'EcoSpold.Parser1.buildExchange' reads any exchange carrying
-it as an elementary flow of medium 'wasteMedium', whatever group it is on and
+it as an elementary flow of medium 'Waste', whatever group it is on and
 before the groups are consulted. The writer no longer emits it — it writes the
 medium itself, which re-imports unchanged — so this is now only what
 'checkEcoSpold1Exportable' compares a biosphere compartment against, to reject
@@ -638,7 +613,7 @@ data FlowFields = FlowFields !Text !Text !Text !(Maybe Text)
 {- | Resolve a flow's serialised fields from the matching table. A biosphere
 flow's compartment becomes category/subCategory; a technosphere flow has no
 category; a waste flow takes the shape of the row it is written in, blank for
-an input (a technosphere row) and 'wasteMedium' for an output (a biosphere
+an input (a technosphere row) and 'Waste' for an output (a biosphere
 row, which is the compartment the parser reads back). A UUID absent from its
 table yields empty/Nothing — never a crash.
 -}
@@ -653,15 +628,33 @@ flowFields res ex = case ex of
             Just bf ->
                 FlowFields
                     (bfName bf)
-                    (bfCompartmentName bf)
+                    (maybe "" (categoryText . compartmentName) (bfCompartment bf))
                     (fromMaybe "" (bfCompartmentSub bf))
                     (bfCAS bf)
             Nothing -> FlowFields "" "" "" Nothing
     WasteExchange{waFlowId = fid, waIsInput = isInput} ->
-        let category = if isInput then "" else wasteMedium
+        let category = if isInput then "" else mediumText Waste
          in case M.lookup fid (rWaste res) of
                 Just wf -> FlowFields (wfName wf) category "" (wfCAS wf)
                 Nothing -> FlowFields "" category "" Nothing
+
+{- | A medium as EcoSpold 1 spells it in @category@.
+
+The format writes @resource@ where EcoSpold 2 and ILCD write @natural
+resource@, and 'EcoSpold.Parser1' hashes this attribute into the flow's
+identity. Emitting anything but the format's own word would give our export a
+different identity from the file it came from, and make writing it twice
+produce two different files.
+-}
+categoryText :: Medium -> Text
+categoryText = \case
+    NaturalResource -> "resource"
+    Air -> mediumText Air
+    Water -> mediumText Water
+    Soil -> mediumText Soil
+    InventoryIndicator -> mediumText InventoryIndicator
+    Economic -> mediumText Economic
+    Waste -> mediumText Waste
 
 {- | Resolve a unit UUID to its name. The parser stored both unit name and
 symbol as the source unit string, so the name field is the faithful echo.

--- a/src/EcoSpold/Writer1.hs
+++ b/src/EcoSpold/Writer1.hs
@@ -594,17 +594,6 @@ groupElement ex = case ex of
 -- Flow-field resolution (name / category / subCategory / CAS by UUID)
 -- ----------------------------------------------------------------------------
 
-{- | The category label an EcoSpold1 export files waste with no modelled
-treatment under. 'EcoSpold.Parser1.buildExchange' reads any exchange carrying
-it as an elementary flow of medium 'Waste', whatever group it is on and
-before the groups are consulted. The writer no longer emits it — it writes the
-medium itself, which re-imports unchanged — so this is now only what
-'checkEcoSpold1Exportable' compares a biosphere compartment against, to reject
-a flow that would come back under a compartment it was not written with.
--}
-finalWasteFlowsCategory :: Text
-finalWasteFlowsCategory = "Final waste flows"
-
 {- | The four flow-derived attribute values the parser stored on a flow:
 name, category, subCategory, CAS. Positional — always consumed as a whole.
 -}

--- a/src/EcoSpold/Writer2.hs
+++ b/src/EcoSpold/Writer2.hs
@@ -548,7 +548,7 @@ parser expects. Omitted when the flow carries no compartment.
 compartmentBlock :: Maybe Compartment -> [Text]
 compartmentBlock Nothing = []
 compartmentBlock (Just (Compartment name mSub)) =
-    ["        <compartment>", "          <compartment xml:lang=\"en\">" <> escapeText name <> "</compartment>"]
+    ["        <compartment>", "          <compartment xml:lang=\"en\">" <> escapeText (mediumText name) <> "</compartment>"]
         ++ subLine mSub
         ++ ["        </compartment>"]
   where

--- a/src/ILCD/Parser.hs
+++ b/src/ILCD/Parser.hs
@@ -94,6 +94,7 @@ parseILCDDirectory unitConfig key dir = do
 
     -- Step 3: Build TechFlowDB, BioFlowDB, WasteFlowDB and UnitDB from parsed data
     let (techFlowDB, bioFlowDB, wasteFlowDB, unitDB) = buildFlowAndUnitDB flowInfoMap flowPropMap unitGroupMap
+    mapM_ (reportProgress Warning . T.unpack) (unplaceableMedia flowInfoMap)
 
     -- Step 4: Parse process XMLs in parallel
     processFiles <- listXMLFiles (dir </> "processes")
@@ -240,6 +241,27 @@ parseFlowPropertyXML bytes =
 --------------------------------------------------------------------------------
 -- Build FlowDB and UnitDB from ILCD data
 --------------------------------------------------------------------------------
+
+{- | One line per medium the flow files name that this engine cannot place.
+
+An ILCD category tree is open: 'Method.FlowResolver.parseCompartment' lowercases
+whatever level 1 holds when it recognises none of its four phrasings. Such a flow
+loads without a compartment, which costs it every characterization factor, so the
+word that did it is named rather than dropped.
+-}
+unplaceableMedia :: M.Map UUID ILCDFlowInfo -> [Text]
+unplaceableMedia flowInfoMap =
+    [ T.pack (unknownMedium got) <> ", on " <> T.pack (show n) <> " ILCD flow(s)"
+    | (got, n) <- M.toList (M.fromListWith (+) [(got, 1 :: Int) | got <- refused])
+    ]
+  where
+    refused :: [Text]
+    refused =
+        [ got
+        | info <- M.elems flowInfoMap
+        , Just (MT.Compartment m _ _) <- [ilcdCompartment info]
+        , Left got <- [parseMedium m]
+        ]
 
 buildFlowAndUnitDB ::
     M.Map UUID ILCDFlowInfo ->

--- a/src/ILCD/Parser.hs
+++ b/src/ILCD/Parser.hs
@@ -296,9 +296,13 @@ buildFlowAndUnitDB flowInfoMap fpMap ugMap = (techFlows, bioFlows, wasteFlows, a
             , wfSubstanceId = Nothing
             }
 
+    -- The method-side reader still carries the medium as text; a medium it
+    -- read that names no known medium leaves the flow without a compartment
+    -- rather than with one nothing can bucket.
     toCompartment Nothing = Nothing
-    toCompartment (Just (MT.Compartment m sc _)) =
-        Just $ Compartment m (if T.null sc then Nothing else Just sc)
+    toCompartment (Just (MT.Compartment m sc _)) = case parseMedium m of
+        Right medium -> Just (Compartment medium (if T.null sc then Nothing else Just sc))
+        Left _ -> Nothing
 
     resolveUnit info =
         Data.Maybe.fromMaybe UUID.nil $

--- a/src/ILCD/Writer.hs
+++ b/src/ILCD/Writer.hs
@@ -207,11 +207,11 @@ A multi-output activity is /not/ one of those: ILCD keys a process by a single
 dataset UUID, but 'ilcdProcessUUID' hands each @(activity, product)@ entry a
 distinct one, so each product becomes its own process dataset.
 
-* /Non-canonical biosphere media./ 'compartmentBlock' emits @"Emissions to
-  <medium>"@ for any non-resource medium, but the parser's @extractMedium@ only
-  inverts the canonical air\/water\/soil\/natural-resource phrasings; any other
-  medium (e.g. @"resource"@ from ES1\/ES2, or @"fresh water"@) re-imports under a
-  different compartment, silently shifting LCIA scores.
+* /Media this classification cannot name./ 'compartmentBlock' emits
+  @"Emissions to <medium>"@ for any non-resource medium, but the parser's
+  @extractMedium@ only inverts the air\/water\/soil\/natural-resource phrasings.
+  A flow of any other medium ('Waste', 'InventoryIndicator', 'Economic')
+  re-imports under a different compartment, silently shifting LCIA scores.
 
 * /Empty classification levels./ 'classificationBlock' joins levels with @"/"@
   and the parser splits on it, dropping empty parts. A value with an empty level

--- a/src/ILCD/Writer.hs
+++ b/src/ILCD/Writer.hs
@@ -234,9 +234,8 @@ checkILCDExportable db =
         [] -> Right ()
         violations -> Left (T.intercalate "\n\n" violations)
   where
-    -- Media the parser's @extractMedium@ inverts back, after canonicalising
-    -- aliases like "resource" → "natural resource".
-    canonicalMedia = ["air", "water", "soil", "natural resource"]
+    -- The media the parser's @extractMedium@ inverts back.
+    canonicalMedia = [Air, Water, Soil, NaturalResource]
     checkMedia =
         case [f | f <- M.elems (sdbBioFlows db), notInvertible f] of
             [] -> Right ()
@@ -252,7 +251,7 @@ checkILCDExportable db =
                         <> "only air, water, soil and natural resource round-trip."
     notInvertible f = case bfCompartment f of
         Nothing -> False
-        Just c -> canonicalMedium (compartmentName c) `notElem` canonicalMedia
+        Just c -> compartmentName c `notElem` canonicalMedia
 
     nameOf actUUID =
         case [activityName act | ((a, _), act) <- M.toList (sdbActivities db), a == actUUID] of
@@ -546,15 +545,6 @@ casBlock (Just cas)
 'parseCompartment': level 0 is "Emissions"/"Resources", level 1 names the
 medium, level 2 (when a sub-compartment exists) is "<medium-phrase>, <sub>".
 -}
-
-{- | Canonicalise a biosphere compartment medium to the spelling ILCD's
-classification — and the parser's 'extractMedium' — round-trips. SimaPro-sourced
-databases label natural-resource flows "resource"; ILCD uses "natural resource".
--}
-canonicalMedium :: Text -> Text
-canonicalMedium "resource" = "natural resource"
-canonicalMedium m = m
-
 compartmentBlock :: Maybe Compartment -> [Text]
 compartmentBlock Nothing = []
 compartmentBlock (Just (Compartment medium sub)) =
@@ -568,8 +558,8 @@ compartmentBlock (Just (Compartment medium sub)) =
            , "      </classificationInformation>"
            ]
   where
-    m = canonicalMedium medium
-    isResource = m == "natural resource"
+    m = mediumText medium
+    isResource = medium == NaturalResource
     level0 = if isResource then "Resources" else "Emissions"
     level1
         | isResource = "Resources"

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -3241,7 +3241,7 @@ findSimilarCFs syns idx flow maxN
     | otherwise =
         let flowName' = bfName flow
             flowCAS' = bfCAS flow
-            flowMedium = normalizeMedium . T.takeWhile (/= '/') . T.toLower $ VT.bfCompartmentName flow
+            flowMedium = normalizeMedium (VT.bfCompartmentName flow)
 
             flowRawTokens = S.fromList (T.words (normalizeName flowName'))
             flowExpTokens = expandedTokens syns flowName'

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -364,7 +364,7 @@ selectsFlow cf = \f -> prefix `T.isPrefixOf` T.toCaseFold (bfName f) && casFits 
     compFits f = case mcfCompartment cf of
         Nothing -> True
         Just (Compartment med sub _) ->
-            maybe False (\c -> mediumEq med (VT.compartmentName c) && subFits sub c) (bfCompartment f)
+            maybe False (\c -> mediumEq med (VT.mediumText (VT.compartmentName c)) && subFits sub c) (bfCompartment f)
     subFits sub c = subcompartmentFits sub (fromMaybe "" (VT.compartmentSub c))
     mediumEq = sameMedium
 
@@ -452,7 +452,7 @@ expandPatternCF flows exclusions cf
             , mcfCompartment = fromFlowCompartment <$> bfCompartment f
             }
     fromFlowCompartment c =
-        Compartment (VT.compartmentName c) (fromMaybe "" (VT.compartmentSub c)) ""
+        Compartment (VT.mediumText (VT.compartmentName c)) (fromMaybe "" (VT.compartmentSub c)) ""
 
 {- | Take the exclusions' flows back out of a finished mapping list.
 
@@ -1161,12 +1161,7 @@ projectRegionalResourceFlows ::
 projectRegionalResourceFlows synDB bioFlows mappings =
     mappings ++ projected
   where
-    -- Strip a @"medium/sub"@ category tail before normalizing, exactly as
-    -- 'flowMediumSub' and 'findSimilarCFs' do: a resource encoded as
-    -- @"natural resource/in water"@ must still resolve to medium @"resource"@,
-    -- or the scope guard below misses it and the region-tagged flow is silently
-    -- not projected (the very withdrawal credit this function exists to recover).
-    flowMedium = normalizeMedium . T.takeWhile (/= '/') . T.toLower . VT.bfCompartmentName
+    flowMedium = normalizeMedium . VT.bfCompartmentName
     cfMedium cf = case mcfCompartment cf of
         Just (Compartment m _ _) -> normalizeMedium (T.toLower m)
         Nothing -> ""

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -326,9 +326,7 @@ compartment. Now type-restricted to BiosphereFlow — technosphere can't reach
 this code path at compile time.
 -}
 isResourceExtraction :: BiosphereFlow -> Bool
-isResourceExtraction flow =
-    let cat = T.toLower (bfCompartmentName flow)
-     in "natural resource" `T.isPrefixOf` cat || "resource" `T.isPrefixOf` cat
+isResourceExtraction flow = (compartmentName <$> bfCompartment flow) == Just NaturalResource
 
 -- | Get activity inventory as rich InventoryExport (same as API)
 getActivityInventory :: Database -> Text -> IO (Either ServiceError Value)

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -846,9 +846,10 @@ silently dropped.
 Normalization rules:
 
 * lower-case + trim both inputs
-* map @raw@ / @resources@ → @resource@ (SimaPro method CSVs use \"Raw\" as
-  the section header for elementary resource inputs, while the inventory
-  parser already passes the canonical @resource@)
+* put the medium through 'parseMedium', so the SimaPro method CSVs' \"Raw\"
+  section header and the inventory side's own word reach one spelling. A
+  medium the reader cannot place is kept as written: this is a hash input, and
+  refusing it here would leave the flow with no identity at all
 * collapse the SimaPro placeholder sub @(unspecified)@ to empty so a CF
   carrying an explicit @(unspecified)@ subcompartment lands on the same
   UUID as an inventory row whose sub column is blank
@@ -856,10 +857,7 @@ Normalization rules:
 -}
 normalizeSimaProCompartment :: Text -> Text -> Text
 normalizeSimaProCompartment comp sub =
-    let lcComp = case T.toLower (T.strip comp) of
-            "raw" -> "resource"
-            "resources" -> "resource"
-            c -> c
+    let lcComp = either id mediumText (parseMedium comp)
         lcSub = T.toLower (T.strip sub)
         normSub
             | T.null lcSub || lcSub == "(unspecified)" = T.empty
@@ -1073,11 +1071,11 @@ processBlockToActivity unitCfg gp pb@ProcessBlock{..} =
         unzip3 (techRowToExchange unitCfg env <$> (pbMaterials ++ pbElectricity ++ pbWasteToTreatment))
     (bioExs, bioFlows, bioUnits) =
         unzip3 $
-            (bioRowToExchange unitCfg env True "resource" <$> pbResources)
-                ++ (bioRowToExchange unitCfg env False "air" <$> pbEmissionsAir)
-                ++ (bioRowToExchange unitCfg env False "water" <$> pbEmissionsWater)
-                ++ (bioRowToExchange unitCfg env False "soil" <$> pbEmissionsSoil)
-                ++ (bioRowToExchange unitCfg env False wasteMedium <$> pbFinalWaste)
+            (bioRowToExchange unitCfg env True NaturalResource <$> pbResources)
+                ++ (bioRowToExchange unitCfg env False Air <$> pbEmissionsAir)
+                ++ (bioRowToExchange unitCfg env False Water <$> pbEmissionsWater)
+                ++ (bioRowToExchange unitCfg env False Soil <$> pbEmissionsSoil)
+                ++ (bioRowToExchange unitCfg env False Waste <$> pbFinalWaste)
 
     -- Exchanges/flows/units the block's products share. They are written once,
     -- unscaled: "Database.Allocation" splits the block into one process per
@@ -1353,7 +1351,7 @@ treatment modelled for it, hence elementary. That spelling of the medium is
 also the one the flow's UUID is hashed from, and the one a method writes in
 its compartment column, so the two sides of a CF match meet on it.
 -}
-bioRowToExchange :: UnitConversion.UnitConfig -> M.Map Text Double -> Bool -> Text -> BioExchangeRow -> (Exchange, BiosphereFlow, Unit)
+bioRowToExchange :: UnitConversion.UnitConfig -> M.Map Text Double -> Bool -> Medium -> BioExchangeRow -> (Exchange, BiosphereFlow, Unit)
 bioRowToExchange unitCfg env isInput compartment BioExchangeRow{..} =
     let
         -- Keep SimaPro's per-region flow variants (`Nitrogen dioxide, FR`,
@@ -1369,7 +1367,7 @@ bioRowToExchange unitCfg env isInput compartment BioExchangeRow{..} =
         -- compartment case or the SimaPro CF placeholder '(unspecified)'
         -- (which inventory rows leave blank in the same medium).
         (effUnitName, amount) = canonicalRow unitCfg berUnit (resolveAmount env berAmountRaw berAmount)
-        flowUUID = generateFlowUUID cleanName (normalizeSimaProCompartment compartment berCompartment)
+        flowUUID = generateFlowUUID cleanName (normalizeSimaProCompartment (mediumText compartment) berCompartment)
         unitUUID = generateUnitUUID effUnitName
         subcomp = if T.null berCompartment then Nothing else Just berCompartment
         (pedigree, cleanedComment) = parsePedigreePrefix berComment
@@ -1391,14 +1389,7 @@ bioRowToExchange unitCfg env isInput compartment BioExchangeRow{..} =
                 , bfSynonyms = M.empty
                 , bfCAS = Nothing
                 , bfSubstanceId = Nothing
-                , -- SimaPro section header always supplies a non-empty
-                  -- medium ("air", "water", "raw", …); guard against an
-                  -- accidentally-empty value so the wire shape never
-                  -- carries a bogus 'Compartment "" Nothing'.
-                  bfCompartment =
-                    if T.null compartment && isNothing subcomp
-                        then Nothing
-                        else Just (Compartment compartment subcomp)
+                , bfCompartment = Just (Compartment compartment subcomp)
                 }
         unit = Unit{unitId = unitUUID, unitName = effUnitName, unitSymbol = effUnitName, unitComment = ""}
      in

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -1069,7 +1069,7 @@ processBlockToActivity unitCfg gp pb@ProcessBlock{..} =
     -- which goes to the technosphere with the rest.
     (avoidedExs, avoidedFlows, avoidedUnits) =
         unzip3 (productToExchange unitCfg env AvoidedProduct <$> pbAvoidedProducts)
-    (techMaybeExs, techFlows, techUnits) =
+    (techExs, techFlows, techUnits) =
         unzip3 (techRowToExchange unitCfg env <$> (pbMaterials ++ pbElectricity ++ pbWasteToTreatment))
     (bioExs, bioFlows, bioUnits) =
         unzip3 $
@@ -1082,8 +1082,7 @@ processBlockToActivity unitCfg gp pb@ProcessBlock{..} =
     -- Exchanges/flows/units the block's products share. They are written once,
     -- unscaled: "Database.Allocation" splits the block into one process per
     -- product and scales them by each product's declared share.
-    -- Tech rows with a zero amount yield no exchange but still contribute a flow.
-    sharedExchanges = avoidedExs ++ catMaybes techMaybeExs ++ bioExs
+    sharedExchanges = avoidedExs ++ techExs ++ bioExs
     sharedTechFlows = avoidedFlows ++ techFlows
     sharedBioFlows = bioFlows
     -- The format has no waste axis: its two waste sections are elementary
@@ -1299,10 +1298,17 @@ parsePedigreePrefix raw =
     -- the comment proper. Strip leading separators and whitespace.
     stripCommentSeparators = T.dropWhile (`elem` (",;. \t" :: String))
 
-{- | Convert technosphere row to exchange (if non-zero), flow, and unit.
-Always returns the flow/unit; exchange is Nothing for zero-amount rows.
+{- | Convert a technosphere row to its exchange, flow and unit.
+
+A row whose amount is zero is kept like any other. Zero is a modelling
+statement: an input the author disabled, or a parameter that evaluates to zero
+in this scenario, and the file says so on purpose. Dropping it lost that
+statement without a word, made the reader disagree with the writer, and left
+the biosphere side (which never dropped a zero) reading a different rule from
+the same file. Nothing downstream is disturbed by the coefficient itself: both
+matrix builders skip a zero entry on their own.
 -}
-techRowToExchange :: UnitConversion.UnitConfig -> M.Map Text Double -> TechExchangeRow -> (Maybe Exchange, TechnosphereFlow, Unit)
+techRowToExchange :: UnitConversion.UnitConfig -> M.Map Text Double -> TechExchangeRow -> (Exchange, TechnosphereFlow, Unit)
 techRowToExchange unitCfg env TechExchangeRow{..} =
     let reading = extractLocation terName
         cleanName = maybe terName locatedName reading
@@ -1312,24 +1318,20 @@ techRowToExchange unitCfg env TechExchangeRow{..} =
         unitUUID = generateUnitUUID effUnitName
         (pedigree, cleanedComment) = parsePedigreePrefix terComment
         exchange =
-            if resolvedAmount == 0
-                then Nothing
-                else
-                    Just
-                        TechnosphereExchange
-                            { techFlowId = flowUUID
-                            , techAmount = resolvedAmount
-                            , techUnitId = unitUUID
-                            , techRole = Input
-                            , techActivityLinkId = UUID.nil
-                            , techProcessLinkId = Nothing
-                            , techLocation = location
-                            , techComment = cleanedComment
-                            , techPedigree = pedigree
-                            , techShare = Nothing
-                            , techClassification = M.empty
-                            , techProperties = noProperties
-                            }
+            TechnosphereExchange
+                { techFlowId = flowUUID
+                , techAmount = resolvedAmount
+                , techUnitId = unitUUID
+                , techRole = Input
+                , techActivityLinkId = UUID.nil
+                , techProcessLinkId = Nothing
+                , techLocation = location
+                , techComment = cleanedComment
+                , techPedigree = pedigree
+                , techShare = Nothing
+                , techClassification = M.empty
+                , techProperties = noProperties
+                }
         flow =
             TechnosphereFlow
                 { tfId = flowUUID

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -1343,13 +1343,13 @@ techRowToExchange unitCfg env TechExchangeRow{..} =
      in (exchange, flow, unit)
 
 {- | Convert biosphere row to exchange, flow, and unit in one pass
-The compartment parameter is the section-level compartment ("air", "water", "soil", "resource", "waste")
-and berCompartment is the row-level sub-compartment ("high. pop.", "river", etc. or empty)
+The compartment parameter is the medium the section names; berCompartment is
+the row-level sub-compartment ("high. pop.", "river", etc. or empty).
 
-The "waste" case is @Final waste flows@: waste that leaves the system with no
-treatment modelled for it, hence elementary. That spelling of the medium is
-also the one the flow's UUID is hashed from, and the one a method writes in
-its compartment column, so the two sides of a CF match meet on it.
+'Waste' is @Final waste flows@: waste that leaves the system with no treatment
+modelled for it, hence elementary. The flow's UUID is hashed from the medium's
+canonical spelling, and the method reader hashes the same one, so the two sides
+of a CF match meet on it.
 -}
 bioRowToExchange :: UnitConversion.UnitConfig -> M.Map Text Double -> Bool -> Medium -> BioExchangeRow -> (Exchange, BiosphereFlow, Unit)
 bioRowToExchange unitCfg env isInput compartment BioExchangeRow{..} =

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -605,11 +605,16 @@ bioSection cats ex@BiosphereExchange{bioDirection = dir}
         Resource -> Just SecRes
         -- Unknown flow → Nothing, mirroring 'bioLine' so an emission keeps a
         -- section only when it also keeps a row (the two are paired in
-        -- 'serializeActivity'); no dead "unknown → air" arm.
-        Emission -> sectionForMedium <$> medium
+        -- 'serializeActivity'). A *known* flow that records no compartment
+        -- keeps both: it has a row, so it needs a section, and air is where
+        -- this format files an emission it cannot place.
+        Emission -> maybe SecAir sectionForMedium medium <$ flow
   where
+    flow :: Maybe BiosphereFlow
+    flow = M.lookup (exchangeFlowId ex) (catBio cats)
+
     medium :: Maybe Medium
-    medium = compartmentName <$> (bfCompartment =<< M.lookup (exchangeFlowId ex) (catBio cats))
+    medium = compartmentName <$> (bfCompartment =<< flow)
     sectionForMedium :: Medium -> BioSec
     sectionForMedium = \case
         Water -> SecWater

--- a/src/SimaPro/Writer.hs
+++ b/src/SimaPro/Writer.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -296,12 +297,10 @@ checkSimaProExportable db =
         | act <- M.elems (sdbActivities db)
         , ex@BiosphereExchange{bioDirection = Emission} <- exchanges act
         , Just flow <- [M.lookup (exchangeFlowId ex) (sdbBioFlows db)]
-        , let medium = T.toLower (bfCompartmentName flow)
-        , not (T.null medium)
+        , Just comp <- [bfCompartment flow]
         , -- A final waste flow is not an emission to a medium; it has its own
         -- section ('SecWaste'), so it is not held to the emission media.
-        medium `notElem` [wasteMedium, inventoryIndicatorMedium]
-        , medium `notElem` ["air", "water", "soil"]
+        compartmentName comp `notElem` [Waste, InventoryIndicator, Air, Water, Soil]
         ]
     amountOffenders =
         [ (activityName act, amt)
@@ -601,7 +600,7 @@ decides first.
 -}
 bioSection :: Catalogs -> Exchange -> Maybe BioSec
 bioSection cats ex@BiosphereExchange{bioDirection = dir}
-    | medium `elem` [Just wasteMedium, Just inventoryIndicatorMedium] = Just SecWaste
+    | medium `elem` [Just Waste, Just InventoryIndicator] = Just SecWaste
     | otherwise = case dir of
         Resource -> Just SecRes
         -- Unknown flow → Nothing, mirroring 'bioLine' so an emission keeps a
@@ -609,16 +608,19 @@ bioSection cats ex@BiosphereExchange{bioDirection = dir}
         -- 'serializeActivity'); no dead "unknown → air" arm.
         Emission -> sectionForMedium <$> medium
   where
-    medium :: Maybe Text
-    medium = T.toLower . bfCompartmentName <$> M.lookup (exchangeFlowId ex) (catBio cats)
-    sectionForMedium :: Text -> BioSec
-    sectionForMedium name = case name of
-        "water" -> SecWater
-        "soil" -> SecSoil
-        -- air, unspecified, or any other medium → air. 'checkSimaProExportable'
-        -- rejects non air/water/soil media at the export boundary, so a real
-        -- export only ever lands air or empty here.
-        _ -> SecAir
+    medium :: Maybe Medium
+    medium = compartmentName <$> (bfCompartment =<< M.lookup (exchangeFlowId ex) (catBio cats))
+    sectionForMedium :: Medium -> BioSec
+    sectionForMedium = \case
+        Water -> SecWater
+        Soil -> SecSoil
+        -- 'checkSimaProExportable' rejects every medium but air, water and soil
+        -- at the export boundary, so a real export only ever lands air here.
+        Air -> SecAir
+        NaturalResource -> SecAir
+        InventoryIndicator -> SecAir
+        Economic -> SecAir
+        Waste -> SecAir
 bioSection _ TechnosphereExchange{} = Nothing
 bioSection _ WasteExchange{} = Nothing
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -15,7 +16,7 @@ module Types (
 
 import API.JsonOptions (Stripped (..))
 import Control.DeepSeq (NFData)
-import Control.Monad ((<=<))
+import Control.Monad ((<=<), (>=>))
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Int (Int32)
 import qualified Data.IntSet as IS
@@ -78,13 +79,97 @@ data ProcessRef = ProcessRef
     }
     deriving (Eq, Ord, Show)
 
+{- | The medium a biosphere flow exchanges with.
+
+Every format spells these differently and none of them spells more than these:
+EcoSpold 2 writes @natural resource@ where SimaPro writes @Raw@ and EcoSpold 1
+writes @resource@, and the whole vocabulary observed across EcoSpold 1 and 2,
+SimaPro CSV and ILCD is the six constructors below. Holding it as text meant
+two databases loaded side by side described one physical flow with two strings,
+and every reader and writer that needed them to agree carried its own list of
+spellings. The medium is the closed part; the subcompartment underneath it
+("high. pop.", "river water") is genuinely open and stays 'Text'.
+
+'Economic', 'InventoryIndicator' and 'Waste' are not media in the physical
+sense. They are what the sources file those flows under, and a flow has to keep
+saying which it is for the readers and writers that bucket by medium.
+-}
+data Medium
+    = Air
+    | Water
+    | Soil
+    | NaturalResource
+    | InventoryIndicator
+    | Economic
+    | {- | Waste that leaves the system with no treatment modelled for it, so
+      no activity produces or consumes it. SimaPro files these in their own
+      section and a method characterizes them under this name, which is why
+      they are elementary flows rather than a demand on the technosphere.
+      Waste that IS sent to treatment keeps its producer and stays on the
+      technosphere side.
+      -}
+      Waste
+    deriving (Eq, Ord, Show, Enum, Bounded, Generic, NFData, Store)
+    deriving anyclass (ToSchema)
+
+{- | The one spelling the engine says out loud: on the wire, in an identity, and
+wherever a medium is compared to itself. A file's own spelling belongs to the
+writer that emits that format, not here.
+-}
+mediumText :: Medium -> Text
+mediumText = \case
+    Air -> "air"
+    Water -> "water"
+    Soil -> "soil"
+    NaturalResource -> "natural resource"
+    InventoryIndicator -> "inventory indicator"
+    Economic -> "economic"
+    Waste -> "waste"
+
+{- | Read a medium as any format writes it. Case and surrounding space are
+ignored; @raw@, @resource@ and @resources@ are the three ways the formats name
+'NaturalResource'.
+
+'Left' names the string it could not place, so an unknown medium is reported
+rather than turned into a flow that quietly belongs nowhere.
+-}
+parseMedium :: Text -> Either Text Medium
+parseMedium raw = case T.toLower (T.strip raw) of
+    "air" -> Right Air
+    "water" -> Right Water
+    "soil" -> Right Soil
+    "natural resource" -> Right NaturalResource
+    "raw" -> Right NaturalResource
+    "resource" -> Right NaturalResource
+    "resources" -> Right NaturalResource
+    "inventory indicator" -> Right InventoryIndicator
+    "economic" -> Right Economic
+    "waste" -> Right Waste
+    other -> Left other
+
+-- | On the wire a medium is its canonical spelling, and reads back from any.
+instance ToJSON Medium where
+    toJSON = toJSON . mediumText
+
+instance FromJSON Medium where
+    parseJSON = parseJSON >=> either (fail . unknownMedium) pure . parseMedium
+
+-- | What to say about a medium string that belongs to no known medium.
+unknownMedium :: Text -> String
+unknownMedium got =
+    "unknown compartment medium "
+        <> show got
+        <> " (expected one of: "
+        <> T.unpack (T.intercalate ", " (map mediumText [minBound .. maxBound]))
+        <> ")"
+
 {- | Biosphere compartment — the natural medium a biosphere flow exchanges
 with. Present only on `BiosphereFlow`; technosphere flows have no
 compartment (their taxonomy, when meaningful, lives on the producing
 activity's `activityClassification`).
 -}
 data Compartment = Compartment
-    { compartmentName :: !Text -- air | water | soil | natural resource
+    { compartmentName :: !Medium
     , compartmentSub :: !(Maybe Text) -- "high. pop.", "river water", …
     }
     deriving (Eq, Show, Generic, NFData, Store)
@@ -95,34 +180,13 @@ source dataset omitted the compartment. Use 'bfCompartment' directly when
 you need to distinguish "absent" from "empty string".
 -}
 bfCompartmentName :: BiosphereFlow -> Text
-bfCompartmentName = maybe "" compartmentName . bfCompartment
+bfCompartmentName = maybe "" (mediumText . compartmentName) . bfCompartment
 
 {- | The biosphere flow's sub-compartment (e.g. "high. pop."), or @Nothing@
 when neither the source nor the medium recorded one.
 -}
 bfCompartmentSub :: BiosphereFlow -> Maybe Text
 bfCompartmentSub = compartmentSub <=< bfCompartment
-
-{- | The medium of an inventory indicator: an elementary flow that counts what
-an activity accounts for rather than naming a substance exchanged with the
-environment, so that a method can characterize the total. It is neither an
-emission to a medium nor an extraction from one, which is why the readers and
-writers that bucket a flow by its medium all need to recognise it. Compared
-lowercased and stripped, as sources vary in spacing and case.
--}
-inventoryIndicatorMedium :: Text
-inventoryIndicatorMedium = "inventory indicator"
-
-{- | The medium of a final waste flow: waste that leaves the system with no
-treatment modelled for it, so no activity produces or consumes it. SimaPro
-files these in their own section and a method characterizes them under this
-name (the compartment column of an ecofactor for landfilled waste reads
-@Waste@), which is why they are elementary flows rather than a demand on the
-technosphere. Waste that IS sent to treatment keeps its producer and stays on
-the technosphere side. Compared lowercased and stripped.
--}
-wasteMedium :: Text
-wasteMedium = "waste"
 
 {- | Direction of a biosphere exchange. Mirrors the @TechRole@ sum so the
 biosphere side also gets named variants instead of a load-bearing 'Bool'.
@@ -333,7 +397,7 @@ data Exchange
         , waIsInput :: !Bool
         {- ^ True when consumed by a treatment activity; False when generated
         by it. Waste with no treatment modelled at all is not on this axis:
-        it is an elementary flow of medium 'wasteMedium'.
+        it is an elementary flow of medium 'Waste'.
         -}
         , waActivityLinkId :: !UUID -- Target treatment activity (UUID.nil if orphan)
         , waProcessLinkId :: !(Maybe ProcessId) -- Target process ID (matches techProcessLinkId)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -84,7 +84,7 @@ data ProcessRef = ProcessRef
 Every format spells these differently and none of them spells more than these:
 EcoSpold 2 writes @natural resource@ where SimaPro writes @Raw@ and EcoSpold 1
 writes @resource@, and the whole vocabulary observed across EcoSpold 1 and 2,
-SimaPro CSV and ILCD is the six constructors below. Holding it as text meant
+SimaPro CSV and ILCD is the constructors below. Holding it as text meant
 two databases loaded side by side described one physical flow with two strings,
 and every reader and writer that needed them to agree carried its own list of
 spellings. The medium is the closed part; the subcompartment underneath it

--- a/test/ActivityWriteHandlerSpec.hs
+++ b/test/ActivityWriteHandlerSpec.hs
@@ -62,6 +62,7 @@ import Types (
     Exchange (..),
     GeographyPolicy (..),
     LocationSource (..),
+    Medium (..),
     SimpleDatabase (..),
     SparseTriple (..),
     TechRole (..),
@@ -500,7 +501,7 @@ co2Flow =
         , bfSynonyms = M.empty
         , bfCAS = Just "124-38-9"
         , bfSubstanceId = Nothing
-        , bfCompartment = Just Compartment{compartmentName = "air", compartmentSub = Nothing}
+        , bfCompartment = Just Compartment{compartmentName = Air, compartmentSub = Nothing}
         }
 
 milkActivity :: Activity

--- a/test/AuthorSpec.hs
+++ b/test/AuthorSpec.hs
@@ -50,6 +50,7 @@ import Types (
     DeclaredShare (..),
     Exchange (..),
     LocationSource (..),
+    Medium (..),
     Pedigree (..),
     SimpleDatabase (..),
     SparseTriple (..),
@@ -312,7 +313,7 @@ spec = do
                 bioFlowIds r `shouldBe` [co2Id]
 
             it "keeps a name in another compartment apart" $ do
-                let urban = Compartment{compartmentName = "air", compartmentSub = Just "urban air"}
+                let urban = Compartment{compartmentName = Air, compartmentSub = Just "urban air"}
                 r <- resolveOrFail fixtureDb baseActivity{aaExchanges = [bioOf (FlowByName "Carbon dioxide" urban "kg") 2 Nothing]}
                 map bfName (riNewBioFlows r) `shouldBe` ["Carbon dioxide"]
                 bioFlowIds r `shouldSatisfy` (/= [co2Id])
@@ -660,7 +661,7 @@ bioOf flow amount unit =
         }
 
 air :: Compartment
-air = Compartment{compartmentName = "air", compartmentSub = Nothing}
+air = Compartment{compartmentName = Air, compartmentSub = Nothing}
 
 -- ---------------------------------------------------------------------------
 -- Fixture: an activity as a database file would have brought it in

--- a/test/BrightwayExcelSpec.hs
+++ b/test/BrightwayExcelSpec.hs
@@ -33,6 +33,7 @@ import Types (
     BiosphereFlow (..),
     Compartment (..),
     Exchange (..),
+    Medium (..),
     SimpleDatabase (..),
     TechRole (..),
     TechnosphereFlow (..),
@@ -104,9 +105,9 @@ spec = describe "BrightwayExcel.Parser" $ do
                 Left err -> expectationFailure (T.unpack err)
                 Right (acts, _, bioDB, _, _) -> do
                     co2 <- requireBioFlow bioDB "Carbon dioxide, fossil"
-                    bfCompartment co2 `shouldBe` Just (Compartment "air" Nothing)
+                    bfCompartment co2 `shouldBe` Just (Compartment Air Nothing)
                     water <- requireBioFlow bioDB "Water"
-                    bfCompartment water `shouldBe` Just (Compartment "natural resource" (Just "in water"))
+                    bfCompartment water `shouldBe` Just (Compartment NaturalResource (Just "in water"))
                     directionOf bioDB acts "Carbon dioxide, fossil" `shouldBe` Just Emission
                     directionOf bioDB acts "Water" `shouldBe` Just Resource
 

--- a/test/BrightwayExcelWriterSpec.hs
+++ b/test/BrightwayExcelWriterSpec.hs
@@ -72,10 +72,10 @@ spec = describe "BrightwayExcel.Writer" $ do
 
     describe "renderCategories" $ do
         it "joins compartment and subcompartment with ::" $
-            renderCategories (Just (Compartment "natural resource" (Just "in water")))
+            renderCategories (Just (Compartment NaturalResource (Just "in water")))
                 `shouldBe` "natural resource::in water"
         it "emits the bare medium when there is no sub" $
-            renderCategories (Just (Compartment "air" Nothing)) `shouldBe` "air"
+            renderCategories (Just (Compartment Air Nothing)) `shouldBe` "air"
         it "emits empty for no recorded compartment" $
             renderCategories Nothing `shouldBe` ""
 
@@ -765,7 +765,7 @@ co2 =
         , bfSynonyms = M.empty
         , bfCAS = Nothing
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (Compartment "air" Nothing)
+        , bfCompartment = Just (Compartment Air Nothing)
         }
 
 kwh, m3, kg :: Unit

--- a/test/CASBackfillSpec.hs
+++ b/test/CASBackfillSpec.hs
@@ -10,7 +10,12 @@ import Test.Hspec
 
 import SubstanceRegistry (CASNumber (..), NormName (..))
 import SynonymDB (normalizeName)
-import Types (BiosphereFlow (..), Compartment (..), fillBioFlowCAS)
+import Types (
+    BiosphereFlow (..),
+    Compartment (..),
+    Medium (..),
+    fillBioFlowCAS,
+ )
 
 mkUUID :: Integer -> UUID
 mkUUID n = UUID.fromWords64 (fromIntegral n) 0
@@ -24,7 +29,7 @@ mkFlow i name cas =
         , bfSynonyms = M.empty
         , bfCAS = cas
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (Compartment "water" Nothing)
+        , bfCompartment = Just (Compartment Water Nothing)
         }
 
 -- Key the binding through the same normalizer 'fillBioFlowCAS' applies, so the

--- a/test/CASBridgeAmbiguitySpec.hs
+++ b/test/CASBridgeAmbiguitySpec.hs
@@ -27,7 +27,10 @@ import Method.Mapping (MatchStrategy (..), buildMethodTables, cfValue, lookupCFF
 import Method.Types (CFFamily (..), Compartment (..), FlowDirection (..), Medium (..), MethodCF (..))
 import SubstanceRegistry (CASNumber (..))
 import SynonymDB (emptySynonymDB)
-import Types (BiosphereFlow (..))
+import Types (
+    BiosphereFlow (..),
+    Medium (..),
+ )
 import qualified Types as VT
 
 mkUUID :: Integer -> UUID
@@ -55,7 +58,7 @@ mkFlow i name cas =
         , bfSynonyms = M.empty
         , bfCAS = cas
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (VT.Compartment "resource" Nothing)
+        , bfCompartment = Just (VT.Compartment NaturalResource Nothing)
         }
 
 water :: Maybe Text

--- a/test/CharacterizedFlowsSpec.hs
+++ b/test/CharacterizedFlowsSpec.hs
@@ -16,7 +16,11 @@ import Test.Hspec
 
 import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, characterizedFlowIds)
 import Method.Types (CFFamily (..), Compartment (..), FlowDirection (..), MethodCF (..))
-import Types (BioFlowDB, BiosphereFlow (..))
+import Types (
+    BioFlowDB,
+    BiosphereFlow (..),
+    Medium (..),
+ )
 import qualified Types as VT
 
 mkUUID :: Integer -> UUID
@@ -46,7 +50,7 @@ mkFlow i name sub =
         , bfSynonyms = M.empty
         , bfCAS = Nothing
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (VT.Compartment "air" sub)
+        , bfCompartment = Just (VT.Compartment Air sub)
         }
 
 -- The database side: ammonia in two subcompartments, methane in one.

--- a/test/CrossDBInventorySpec.hs
+++ b/test/CrossDBInventorySpec.hs
@@ -179,7 +179,7 @@ spec = do
                     M.empty
                     Nothing
                     Nothing
-                    (Just (Compartment "air" (Just "low. pop.")))
+                    (Just (Compartment Air (Just "low. pop.")))
             flowDep =
                 BiosphereFlow
                     uuidDep
@@ -188,7 +188,7 @@ spec = do
                     M.empty
                     Nothing
                     Nothing
-                    (Just (Compartment "air" (Just "low. pop.")))
+                    (Just (Compartment Air (Just "low. pop.")))
 
             rootOnlyFlowDB = M.singleton uuidRoot flowRoot
             mergedFlowDB = M.fromList [(uuidRoot, flowRoot), (uuidDep, flowDep)]

--- a/test/CrossDBRegionalLCIAFixture.hs
+++ b/test/CrossDBRegionalLCIAFixture.hs
@@ -90,7 +90,7 @@ testFlow =
         , bfSynonyms = M.empty
         , bfCAS = Nothing
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (VT.Compartment "air" Nothing)
+        , bfCompartment = Just (VT.Compartment Air Nothing)
         }
 
 mkActivity :: Int -> Text -> Activity

--- a/test/DependencyFlowClosureSpec.hs
+++ b/test/DependencyFlowClosureSpec.hs
@@ -48,7 +48,7 @@ riverWater =
         , bfSynonyms = M.empty
         , bfCAS = Nothing
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (Compartment "natural resource" Nothing)
+        , bfCompartment = Just (Compartment NaturalResource Nothing)
         }
 
 -- | A flow the root database owns itself, unrelated to the dependency's.
@@ -61,7 +61,7 @@ methane =
         , bfSynonyms = M.empty
         , bfCAS = Nothing
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (Compartment "air" Nothing)
+        , bfCompartment = Just (Compartment Air Nothing)
         }
 
 {- | The root's own flow under the name the dependency also uses, with a lower

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -577,7 +577,7 @@ spec = do
                     length bioExchanges `shouldBe` 1
                     map bfName bios `shouldBe` ["Organic carbon, placed in landfill"]
                     map bfCompartment bios
-                        `shouldBe` [Just (Compartment wasteMedium (Just "landfill"))]
+                        `shouldBe` [Just (Compartment Waste (Just "landfill"))]
                     length wastes `shouldBe` 0
 
         it "does not route the waste flow to the technosphere bucket" $

--- a/test/EcoSpold1WriterSpec.hs
+++ b/test/EcoSpold1WriterSpec.hs
@@ -600,7 +600,7 @@ spec = do
                 Right sdb' -> do
                     map bfName (M.elems (sdbBioFlows sdb')) `shouldBe` ["spent solvent"]
                     map bfCompartment (M.elems (sdbBioFlows sdb'))
-                        `shouldBe` [Just (Compartment wasteMedium Nothing)]
+                        `shouldBe` [Just (Compartment Waste Nothing)]
                     M.size (sdbWasteFlows sdb') `shouldBe` 0
                     let directions = [d | BiosphereExchange{bioDirection = d} <- allExchanges sdb']
                     directions `shouldBe` [Emission]
@@ -687,20 +687,6 @@ spec = do
                 bios = M.singleton bioU (BiosphereFlow bioU "trace" kgUnit M.empty Nothing Nothing Nothing)
                 sdb = soloDb "subnormal emitter" prodU [bioEx] M.empty bios M.empty
             checkEcoSpold1Exportable sdb `shouldSatisfy` isRight
-
-    describe "waste-marker collision" $
-        it "rejects a biosphere flow whose compartment is the waste-routing category" $ do
-            -- "Final waste flows" is what the parser reads as the marker of a
-            -- final waste flow, before the groups, so a biosphere flow carrying
-            -- it as its compartment name would silently come back under the
-            -- "waste" compartment instead.
-            let prodU = read "bbbb0000-0000-4000-8000-000000000001" :: UUID
-                bioU = read "bbbb0000-0000-4000-8000-0000000000c0" :: UUID
-                comp = Compartment "Final waste flows" Nothing
-                bioEx = BiosphereExchange bioU 0.05 kgUnit Emission "" Nothing Nothing
-                bios = M.singleton bioU (BiosphereFlow bioU "oddly classified" kgUnit M.empty Nothing Nothing (Just comp))
-                sdb = soloDb "confused process" prodU [bioEx] M.empty bios M.empty
-            checkEcoSpold1Exportable sdb `shouldSatisfy` isLeft
 
     describe "general comment (activity description)" $
         it "re-imports a multi-paragraph description as one joined paragraph" $ do

--- a/test/EcoSpold2WriterSpec.hs
+++ b/test/EcoSpold2WriterSpec.hs
@@ -90,8 +90,8 @@ fixtureSimple =
                 ]
         , sdbBioFlows =
             M.fromList
-                [ (co2, BiosphereFlow co2 "Carbon dioxide, fossil" unitKg M.empty (Just "124-38-9") Nothing (Just (Compartment "air" (Just "unspecified"))))
-                , (land, BiosphereFlow land "Occupation, arable land" unitM2a M.empty Nothing Nothing (Just (Compartment "natural resource" (Just "land"))))
+                [ (co2, BiosphereFlow co2 "Carbon dioxide, fossil" unitKg M.empty (Just "124-38-9") Nothing (Just (Compartment Air (Just "unspecified"))))
+                , (land, BiosphereFlow land "Occupation, arable land" unitM2a M.empty Nothing Nothing (Just (Compartment NaturalResource (Just "land"))))
                 ]
         , sdbWasteFlows = M.empty
         , sdbUnits =
@@ -154,7 +154,7 @@ fixtureDupBio =
     SimpleDatabase
         { sdbActivities = M.singleton (actA, prodA) activityDup
         , sdbTechFlows = M.singleton prodA (TechnosphereFlow prodA "product A" unitKg M.empty Nothing Nothing)
-        , sdbBioFlows = M.singleton co2 (BiosphereFlow co2 "Carbon dioxide, fossil" unitKg M.empty Nothing Nothing (Just (Compartment "air" (Just "unspecified"))))
+        , sdbBioFlows = M.singleton co2 (BiosphereFlow co2 "Carbon dioxide, fossil" unitKg M.empty Nothing Nothing (Just (Compartment Air (Just "unspecified"))))
         , sdbWasteFlows = M.empty
         , sdbUnits = M.singleton unitKg (Unit unitKg "kg" "kg" "")
         }
@@ -188,7 +188,7 @@ fixtureWithExchange ex =
     SimpleDatabase
         { sdbActivities = M.singleton (actA, prodA) activity
         , sdbTechFlows = M.singleton prodA (TechnosphereFlow prodA "product A" unitKg M.empty Nothing Nothing)
-        , sdbBioFlows = M.singleton co2 (BiosphereFlow co2 "Carbon dioxide, fossil" unitKg M.empty Nothing Nothing (Just (Compartment "air" (Just "unspecified"))))
+        , sdbBioFlows = M.singleton co2 (BiosphereFlow co2 "Carbon dioxide, fossil" unitKg M.empty Nothing Nothing (Just (Compartment Air (Just "unspecified"))))
         , sdbWasteFlows = M.empty
         , sdbUnits = M.singleton unitKg (Unit unitKg "kg" "kg" "")
         }
@@ -224,7 +224,7 @@ fixtureWithBioSynonyms =
         , sdbBioFlows =
             M.singleton
                 co2
-                (BiosphereFlow co2 "Carbon dioxide, fossil" unitKg syns (Just "124-38-9") Nothing (Just (Compartment "air" (Just "unspecified"))))
+                (BiosphereFlow co2 "Carbon dioxide, fossil" unitKg syns (Just "124-38-9") Nothing (Just (Compartment Air (Just "unspecified"))))
         , sdbWasteFlows = M.empty
         , sdbUnits = M.singleton unitKg (Unit unitKg "kg" "kg" "")
         }
@@ -522,7 +522,7 @@ bioFingerprint f =
     ( UUID.toText (bfId f)
     , bfName f
     , bfCAS f
-    , maybe "" compartmentName (bfCompartment f)
+    , maybe "" (mediumText . compartmentName) (bfCompartment f)
     , bfCompartment f >>= compartmentSub
     )
 

--- a/test/EnergyDensityCFSpec.hs
+++ b/test/EnergyDensityCFSpec.hs
@@ -36,7 +36,12 @@ import Test.Hspec
 import Method.Mapping
 import Method.Types (Compartment (..), EnergyDensity (..), EnergyDensityMap, FlowDirection (..), MethodCF (..), buildEnergyDensityMapFromCSV)
 import SynonymDB (normalizeName)
-import Types (BiosphereFlow (..), Unit (..), UnitDB)
+import Types (
+    BiosphereFlow (..),
+    Medium (..),
+    Unit (..),
+    UnitDB,
+ )
 import qualified Types as VT
 import UnitConversion (UnitConfig, buildFromCSV, defaultUnitConfig)
 
@@ -90,7 +95,7 @@ coalFlowIn unitId =
         , bfSynonyms = M.empty
         , bfCAS = Nothing
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (VT.Compartment "natural resource" Nothing)
+        , bfCompartment = Just (VT.Compartment NaturalResource Nothing)
         }
 
 -- An energy-denominated CF (value 1.0, unit MJ) matched to the coal flow by

--- a/test/EnergyResourceFillSpec.hs
+++ b/test/EnergyResourceFillSpec.hs
@@ -11,7 +11,10 @@ import Test.Hspec
 import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, cfValue, lookupCFForFlow)
 import Method.Types (CFFamily (..), Compartment (..), EnergyDensity (..), EnergyDensityMap, FlowDirection (..), MethodCF (..), parseEnergyDensitySuffix)
 import SynonymDB (normalizeName)
-import Types (BiosphereFlow (..))
+import Types (
+    BiosphereFlow (..),
+    Medium (..),
+ )
 import qualified Types as VT
 
 mkUUID :: Integer -> UUID
@@ -40,7 +43,7 @@ mkFlow i name =
         , bfSynonyms = M.empty
         , bfCAS = Nothing
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (VT.Compartment "resource" Nothing)
+        , bfCompartment = Just (VT.Compartment NaturalResource Nothing)
         }
 
 -- Tables where "Coal, hard" carries the generic resource CF (1 per MJ), and the

--- a/test/ExplainCFSpec.hs
+++ b/test/ExplainCFSpec.hs
@@ -36,7 +36,12 @@ import Method.Mapping (
  )
 import Method.Types (CFFamily (..), Compartment (..), EnergyDensity (..), EnergyDensityMap, FlowDirection (..), MethodCF (..))
 import SynonymDB (normalizeName)
-import Types (BiosphereFlow (..), Unit (..), UnitDB)
+import Types (
+    BiosphereFlow (..),
+    Medium (..),
+    Unit (..),
+    UnitDB,
+ )
 import qualified Types as VT
 import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig, mkUnitConfig)
 
@@ -84,7 +89,7 @@ waterLine :: Text -> Text -> Double -> MethodCF
 waterLine name sub val =
     (cfLine name sub "kg" val){mcfCompartment = Just (Compartment "water" sub "")}
 
-flowIn :: Integer -> Text -> Text -> Maybe Text -> BiosphereFlow
+flowIn :: Integer -> Text -> VT.Medium -> Maybe Text -> BiosphereFlow
 flowIn i name medium sub =
     BiosphereFlow
         { bfId = mkUUID i
@@ -236,7 +241,7 @@ spec = do
 
     describe "explainFlowCF (replaying the cascade)" $ do
         it "reports the rung that answered and stops there" $ do
-            let flow = flowIn 1 "Methane, fossil" "air" Nothing
+            let flow = flowIn 1 "Methane, fossil" Air Nothing
                 tables = tablesFor M.empty [(cfLine "Methane, fossil" "" "kg" 29.8, Just (flow, ByUUID))] [flow]
                 explained = explainOf defaultUnitConfig tables flow
             case ceResolution explained of
@@ -249,7 +254,7 @@ spec = do
             -- A name-matched factor with no subcompartment lands in the
             -- compartment-level table, so the trail must show the rungs above
             -- it being tried and missing.
-            let flow = flowIn 11 "Methane, fossil" "air" Nothing
+            let flow = flowIn 11 "Methane, fossil" Air Nothing
                 tables = tablesFor M.empty [(cfLine "Methane, fossil" "" "kg" 29.8, Just (flow, ByName))] [flow]
                 explained = explainOf defaultUnitConfig tables flow
                 results = resultsFor explained
@@ -266,8 +271,8 @@ spec = do
             -- A method that names the sea somewhere meant to leave this
             -- emission out, so its freshwater factor must not reach the ocean,
             -- and the trail must say the veto is what stopped it.
-            let ocean = flowIn 2 "Water" "water" (Just "ocean")
-                fresh = flowIn 3 "Water" "water" Nothing
+            let ocean = flowIn 2 "Water" Water (Just "ocean")
+                fresh = flowIn 3 "Water" Water Nothing
                 tables =
                     tablesFor
                         M.empty
@@ -284,8 +289,8 @@ spec = do
         it "lets a method that never names the sea characterize an ocean flow" $ do
             -- The mirror case: silence about sea water is not an exclusion, so
             -- the freshwater default applies and no veto appears in the trail.
-            let ocean = flowIn 12 "Water" "water" (Just "ocean")
-                fresh = flowIn 13 "Water" "water" Nothing
+            let ocean = flowIn 12 "Water" Water (Just "ocean")
+                fresh = flowIn 13 "Water" Water Nothing
                 tables = tablesFor M.empty [(waterLine "Water" "" 1.0, Just (fresh, ByName))] [ocean, fresh]
                 explained = explainOf defaultUnitConfig tables ocean
             [rung | (rung, StepVetoed ForeignMediumVeto) <- resultsFor explained] `shouldBe` []
@@ -295,7 +300,7 @@ spec = do
 
         it "marks a rung the flow cannot use as not applicable" $ do
             -- No CAS on the flow, so the CAS bridge is not a miss: it never ran.
-            let flow = flowIn 4 "Nitrous oxide" "air" Nothing
+            let flow = flowIn 4 "Nitrous oxide" Air Nothing
                 tables = tablesFor M.empty [(cfLine "Something else" "" "kg" 1.0, Nothing)] [flow]
                 explained = explainOf defaultUnitConfig tables flow
             lookup RungCasBridge (resultsFor explained) `shouldBe` Just StepNotApplicable
@@ -303,9 +308,9 @@ spec = do
         it "refuses to guess between disagreeing energy-family factors" $ do
             -- Two coal factors that disagree: the family factor is ambiguous,
             -- and the trail says so rather than reporting an ordinary miss.
-            let coal = flowIn 5 "Coal, 18 MJ per kg" "resource" Nothing
-                hard = flowIn 6 "Coal, hard" "resource" Nothing
-                brown = flowIn 7 "Coal, brown" "resource" Nothing
+            let coal = flowIn 5 "Coal, 18 MJ per kg" NaturalResource Nothing
+                hard = flowIn 6 "Coal, hard" NaturalResource Nothing
+                brown = flowIn 7 "Coal, brown" NaturalResource Nothing
                 densities =
                     M.fromList
                         [ (normalizeName "Coal, hard", EnergyDensity 18.0 "MJ" "kg")
@@ -323,8 +328,8 @@ spec = do
             ceResolution explained `shouldBe` Uncharacterized
 
         it "explains a factor borrowed through the flow's energy content" $ do
-            let coal = flowIn 8 "Coal, 18 MJ per kg" "resource" Nothing
-                hard = flowIn 9 "Coal, hard" "resource" Nothing
+            let coal = flowIn 8 "Coal, 18 MJ per kg" NaturalResource Nothing
+                hard = flowIn 9 "Coal, hard" NaturalResource Nothing
                 densities = M.singleton (normalizeName "Coal, 18 MJ per kg") (EnergyDensity 18.0 "MJ" "kg")
                 tables =
                     tablesFor
@@ -342,7 +347,7 @@ spec = do
             -- A per-m3 factor against a kg flow with no density to bridge them:
             -- the flow looks characterized and scores nothing, and the
             -- explanation is what says so.
-            let flow = flowIn 10 "Water" "resource" Nothing
+            let flow = flowIn 10 "Water" NaturalResource Nothing
                 tables = tablesFor M.empty [(resourceLine "Water" "m3" 42.95, Just (flow, ByName))] [flow]
                 explained = explainOf volumeMassConfig tables flow
             case ceResolution explained of
@@ -368,12 +373,12 @@ spec = do
                             `shouldBe` (bfName f, replayedKind cfg tables f)
 
         it "agrees for a direct hit" $ do
-            let flow = flowIn 20 "Methane, fossil" "air" Nothing
+            let flow = flowIn 20 "Methane, fossil" Air Nothing
             agreesFor defaultUnitConfig M.empty [(cfLine "Methane, fossil" "" "kg" 29.8, Just (flow, ByUUID))] [flow]
 
         it "agrees under the sea-water veto, factor served and factor withheld" $ do
-            let ocean = flowIn 21 "Water" "water" (Just "ocean")
-                fresh = flowIn 22 "Water" "water" Nothing
+            let ocean = flowIn 21 "Water" Water (Just "ocean")
+                fresh = flowIn 22 "Water" Water Nothing
             agreesFor
                 defaultUnitConfig
                 M.empty
@@ -383,9 +388,9 @@ spec = do
                 [ocean, fresh]
 
         it "agrees when the energy family refuses to guess" $ do
-            let coal = flowIn 23 "Coal, 18 MJ per kg" "resource" Nothing
-                hard = flowIn 24 "Coal, hard" "resource" Nothing
-                brown = flowIn 25 "Coal, brown" "resource" Nothing
+            let coal = flowIn 23 "Coal, 18 MJ per kg" NaturalResource Nothing
+                hard = flowIn 24 "Coal, hard" NaturalResource Nothing
+                brown = flowIn 25 "Coal, brown" NaturalResource Nothing
                 densities =
                     M.fromList
                         [ (normalizeName "Coal, hard", EnergyDensity 18.0 "MJ" "kg")
@@ -402,7 +407,7 @@ spec = do
         it "agrees for a factor found but refused on units" $ do
             -- The refused flow must still annotate: it scores 0, but its
             -- match kind is the rung that found the factor, not "none".
-            let flow = flowIn 26 "Water" "resource" Nothing
+            let flow = flowIn 26 "Water" NaturalResource Nothing
             agreesFor volumeMassConfig M.empty [(resourceLine "Water" "m3" 42.95, Just (flow, ByName))] [flow]
   where
     -- kg and m3 known but dimensionally apart, so the pair is a mismatch.

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -29,14 +29,14 @@ import UnitConversion (defaultUnitConfig)
 spec :: Spec
 spec = describe "Database.Export dispatcher" $ do
     it "serializes a simple database to every writable format" $ do
-        db <- buildFixture (Compartment "air" (Just "unspecified"))
+        db <- buildFixture (Compartment Air (Just "unspecified"))
         forM_ [SimaProCSV, EcoSpold1, EcoSpold2, ILCDProcess, BrightwayExcel] $ \fmt ->
             case serializeDatabase fmt db of
                 Left err -> expectationFailure (show fmt <> ": " <> T.unpack err)
                 Right (bytes, _warnings) -> BL.null bytes `shouldBe` False
 
     it "fails loudly for formats with no writer (never a silent empty file)" $ do
-        db <- buildFixture (Compartment "air" (Just "unspecified"))
+        db <- buildFixture (Compartment Air (Just "unspecified"))
         serializeDatabase OpenLcaJsonLd db `shouldSatisfy` isLeft
         serializeDatabase UnknownFormat db `shouldSatisfy` isLeft
 
@@ -78,7 +78,7 @@ spec = describe "Database.Export dispatcher" $ do
         -- A "raw" emission compartment has no faithful SimaPro section, so the
         -- SimaPro writer's own guard rejects it; the dispatcher must surface that
         -- Left rather than emit a corrupt file.
-        db <- buildFixture (Compartment "raw" Nothing)
+        db <- buildFixture (Compartment NaturalResource Nothing)
         serializeDatabase SimaProCSV db `shouldSatisfy` isLeft
 
 {- | One activity: a reference product and a single biosphere emission whose

--- a/test/FlowSearchSpec.hs
+++ b/test/FlowSearchSpec.hs
@@ -23,6 +23,7 @@ import Types (
     ExchangeKind (..),
     FlowKind (..),
     KindFilter (..),
+    Medium (..),
     TechnosphereFlow (..),
     UUID,
     WasteFlow (..),
@@ -240,16 +241,16 @@ them — deliberately not the order they should come out in.
 -}
 deltamethrins :: [FlowKind]
 deltamethrins =
-    [ bioFlow 1 "soil" Nothing
-    , bioFlow 2 "water" (Just "groundwater")
-    , bioFlow 3 "air" (Just "low. pop.")
-    , bioFlow 4 "soil" (Just "agricultural")
-    , bioFlow 5 "soil" (Just "forestry")
-    , bioFlow 6 "water" (Just "river")
-    , bioFlow 7 "air" (Just "low. pop., long-term")
+    [ bioFlow 1 Soil Nothing
+    , bioFlow 2 Water (Just "groundwater")
+    , bioFlow 3 Air (Just "low. pop.")
+    , bioFlow 4 Soil (Just "agricultural")
+    , bioFlow 5 Soil (Just "forestry")
+    , bioFlow 6 Water (Just "river")
+    , bioFlow 7 Air (Just "low. pop., long-term")
     ]
 
-bioFlow :: Int -> Text -> Maybe Text -> FlowKind
+bioFlow :: Int -> Medium -> Maybe Text -> FlowKind
 bioFlow n medium sub =
     BioKind (biosphere n "Deltamethrin" []){bfCompartment = Just (Compartment medium sub)}
 

--- a/test/ILCDWriterSpec.hs
+++ b/test/ILCDWriterSpec.hs
@@ -413,31 +413,32 @@ spec = describe "ILCD.Writer round-trip" $ do
                     ]
             refIdxs `shouldBe` [2]
 
-        it "rejects a non-canonical biosphere medium at the export boundary" $
-            checkILCDExportable (bioMediumDb "fresh water") `shouldSatisfy` isLeft
+        it "rejects a medium the ILCD classification cannot name" $
+            checkILCDExportable (bioMediumDb Waste) `shouldSatisfy` isLeft
 
         it "accepts a canonical biosphere medium" $
-            checkILCDExportable (bioMediumDb "air") `shouldBe` Right ()
+            checkILCDExportable (bioMediumDb Air) `shouldBe` Right ()
 
-        it "accepts and canonicalises the SimaPro \"resource\" medium to \"natural resource\"" $ do
-            -- SimaPro labels natural-resource flows "resource"; the writer maps it
-            -- to ILCD's "natural resource", which the parser reads back, so the
-            -- flow is representable rather than rejected.
-            checkILCDExportable (bioMediumDb "resource") `shouldBe` Right ()
-            db' <- roundTrip (bioMediumDb "resource")
+        it "round-trips a natural resource under its own medium" $ do
+            -- Every format spells this medium its own way and each writer emits
+            -- the spelling its own reader inverts, so the medium that comes back
+            -- is the medium that went out.
+            checkILCDExportable (bioMediumDb NaturalResource) `shouldBe` Right ()
+            db' <- roundTrip (bioMediumDb NaturalResource)
             map (fmap compartmentName . bfCompartment) (M.elems (sdbBioFlows db'))
-                `shouldBe` [Just "natural resource"]
+                `shouldBe` [Just NaturalResource]
 
         it "reports every violation category in one message, not just the first" $ do
-            -- A flow with both a non-canonical medium and a non-finite amount trips
-            -- two independent checks; the collected report must carry both.
+            -- A flow with both a medium the classification cannot name and a
+            -- non-finite amount trips two independent checks; the collected
+            -- report must carry both.
             let db =
                     oneActivityDb
-                        (M.singleton fEmitU (fEmission{bfCompartment = Just (Compartment "fresh water" Nothing)}))
+                        (M.singleton fEmitU (fEmission{bfCompartment = Just (Compartment Waste Nothing)}))
                         [BiosphereExchange fEmitU (1 / 0) fUnitU Emission "" Nothing Nothing, refProductEx]
             case checkILCDExportable db of
                 Left msg -> do
-                    msg `shouldSatisfy` T.isInfixOf "fresh water"
+                    msg `shouldSatisfy` T.isInfixOf "waste"
                     msg `shouldSatisfy` T.isInfixOf "non-finite"
                 Right () -> expectationFailure "expected violations"
 
@@ -561,12 +562,12 @@ fProduct = TechnosphereFlow fProdU "product P" fUnitU M.empty Nothing Nothing
 fEmission :: BiosphereFlow
 fEmission =
     BiosphereFlow fEmitU "Carbon dioxide" fUnitU M.empty Nothing Nothing $
-        Just (Compartment "air" (Just "high. pop."))
+        Just (Compartment Air (Just "high. pop."))
 
 fResource :: BiosphereFlow
 fResource =
     BiosphereFlow fResU "Iron ore" fUnitU M.empty Nothing Nothing $
-        Just (Compartment "natural resource" (Just "in ground"))
+        Just (Compartment NaturalResource (Just "in ground"))
 
 {- | A one-activity database wrapping the given biosphere catalog and exchanges,
 sharing one technosphere product flow and one unit. The activity name carries
@@ -618,11 +619,11 @@ richDb =
         ]
 
 {- | One activity with a single biosphere emission under the given medium.
-A non-canonical medium ("fresh water", …) is what 'checkILCDExportable' must
-reject; a canonical one (or an alias the writer canonicalises, like
-"resource" → "natural resource") passes.
+A medium the ILCD classification has no place for ('Waste', 'Economic',
+'InventoryIndicator') is what 'checkILCDExportable' must reject; the four the
+classification names pass.
 -}
-bioMediumDb :: Text -> SimpleDatabase
+bioMediumDb :: Medium -> SimpleDatabase
 bioMediumDb medium =
     oneActivityDb
         (M.singleton fEmitU (fEmission{bfCompartment = Just (Compartment medium Nothing)}))

--- a/test/JournalSpec.hs
+++ b/test/JournalSpec.hs
@@ -53,6 +53,7 @@ import Types (
     Database (..),
     Exchange (..),
     LocationSource (..),
+    Medium (..),
     SimpleDatabase (..),
     TechRole (..),
     TechnosphereFlow (..),
@@ -281,7 +282,7 @@ cheese =
                 { abFlow =
                     FlowByName
                         "Methane"
-                        Compartment{compartmentName = "air", compartmentSub = Just "low population density"}
+                        Compartment{compartmentName = Air, compartmentSub = Just "low population density"}
                         "kg"
                 , abDirection = Emission
                 , abAmount = 0.01
@@ -298,7 +299,7 @@ methane =
         { abFlow =
             FlowByName
                 "Methane"
-                Compartment{compartmentName = "air", compartmentSub = Just "low population density"}
+                Compartment{compartmentName = Air, compartmentSub = Just "low population density"}
                 "kg"
         , abDirection = Emission
         , abAmount = 0.01
@@ -484,7 +485,7 @@ co2Flow =
         , bfSynonyms = M.empty
         , bfCAS = Nothing
         , bfSubstanceId = Nothing
-        , bfCompartment = Just Compartment{compartmentName = "air", compartmentSub = Nothing}
+        , bfCompartment = Just Compartment{compartmentName = Air, compartmentSub = Nothing}
         }
 
 supplierActivity :: Activity

--- a/test/LongTermExclusionSpec.hs
+++ b/test/LongTermExclusionSpec.hs
@@ -30,7 +30,13 @@ import Test.Hspec
 import Matrix (Inventory)
 import Method.Mapping
 import Method.Types (Compartment (..), FlowDirection (..), MethodCF (..))
-import Types (BioFlowDB, BiosphereFlow (..), Unit (..), UnitDB)
+import Types (
+    BioFlowDB,
+    BiosphereFlow (..),
+    Medium (..),
+    Unit (..),
+    UnitDB,
+ )
 import qualified Types as VT
 import UnitConversion (UnitConfig, buildFromCSV, defaultUnitConfig)
 
@@ -69,7 +75,7 @@ bioFlow fid sub =
         , bfSynonyms = M.empty
         , bfCAS = Nothing
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (VT.Compartment "water" sub)
+        , bfCompartment = Just (VT.Compartment Water sub)
         }
 
 ltFlow, stFlow :: BiosphereFlow

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -17,7 +17,11 @@ import Method.Mapping
 import Method.ParserCSV (parseMethodCSVBytes)
 import Method.Types (Compartment (..), EnergyDensity (..), FlowDirection (..), Method (..), MethodCF (..), buildCompartmentMapFromCSV)
 import SynonymDB (BridgeDirection (..), SynEdge (..), buildFromEdges, buildFromPairs, emptySynonymDB, normalizeName)
-import Types (BiosphereFlow (..), Unit (..))
+import Types (
+    BiosphereFlow (..),
+    Medium (..),
+    Unit (..),
+ )
 import qualified Types as VT
 import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig, mkUnitConfig)
 
@@ -25,7 +29,7 @@ import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig, mkUnitC
 -- Helpers
 -- ---------------------------------------------------------------------------
 
-mkFlow :: UUID -> Text -> Text -> Maybe Text -> BiosphereFlow
+mkFlow :: UUID -> Text -> VT.Medium -> Maybe Text -> BiosphereFlow
 mkFlow fid name cat msub =
     BiosphereFlow
         { bfId = fid
@@ -91,7 +95,7 @@ spec = do
     describe "findFlowByUUID" $ do
         it "finds a flow by its UUID" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "CO2" "air" Nothing
+            let flow = mkFlow fid "CO2" Air Nothing
                 db = M.singleton fid flow
             fmap bfId (findFlowByUUID db fid) `shouldBe` Just fid
 
@@ -106,16 +110,16 @@ spec = do
         it "returns first flow when no compartment preference" $ do
             fid1 <- nextRandom
             fid2 <- nextRandom
-            let f1 = mkFlow fid1 "co2" "air" Nothing
-                f2 = mkFlow fid2 "co2" "water" Nothing
+            let f1 = mkFlow fid1 "co2" Air Nothing
+                f2 = mkFlow fid2 "co2" Water Nothing
                 byName = M.singleton "co2" [f1, f2]
             fmap bfId (findFlowByNameComp M.empty byName "co2" Nothing) `shouldBe` Just fid1
 
         it "prefers exact medium+subcomp match" $ do
             fid1 <- nextRandom
             fid2 <- nextRandom
-            let fAir = mkFlow fid1 "co2" "air" (Just "urban air")
-                fWater = mkFlow fid2 "co2" "water" (Just "surface water")
+            let fAir = mkFlow fid1 "co2" Air (Just "urban air")
+                fWater = mkFlow fid2 "co2" Water (Just "surface water")
                 byName = M.singleton "co2" [fWater, fAir]
                 comp = Compartment "air" "urban air" ""
             fmap bfId (findFlowByNameComp M.empty byName "co2" (Just comp)) `shouldBe` Just fid1
@@ -123,8 +127,8 @@ spec = do
         it "falls back to medium match when no exact subcomp" $ do
             fid1 <- nextRandom
             fid2 <- nextRandom
-            let fAir = mkFlow fid1 "co2" "air" (Just "non-urban air")
-                fWater = mkFlow fid2 "co2" "water" Nothing
+            let fAir = mkFlow fid1 "co2" Air (Just "non-urban air")
+                fWater = mkFlow fid2 "co2" Water Nothing
                 byName = M.singleton "co2" [fWater, fAir]
                 comp = Compartment "air" "unspecified" ""
             fmap bfId (findFlowByNameComp M.empty byName "co2" (Just comp)) `shouldBe` Just fid1
@@ -134,7 +138,7 @@ spec = do
             -- the same name, so the name matcher has found nothing and the
             -- cascade is free to try the next one.
             fid1 <- nextRandom
-            let fWater = mkFlow fid1 "co2" "water" Nothing
+            let fWater = mkFlow fid1 "co2" Water Nothing
                 byName = M.singleton "co2" [fWater]
                 comp = Compartment "air" "" ""
             fmap bfId (findFlowByNameComp M.empty byName "co2" (Just comp)) `shouldBe` Nothing
@@ -145,9 +149,9 @@ spec = do
             -- normalized medium, so a match here promised a factor scoring
             -- never served (volca#346). A compartment rule is what bridges it.
             fid <- nextRandom
-            let flow = mkFlow fid "ammonia" "emissions to air" Nothing
+            let flow = mkFlow fid "ammonia" Air Nothing
                 byName = M.singleton "ammonia" [flow]
-                comp = Compartment "air" "" ""
+                comp = Compartment "emissions to air" "" ""
                 rule = M.singleton ("emissions to air", "", "") (Compartment "air" "" "")
             fmap bfId (findFlowByNameComp M.empty byName "ammonia" (Just comp)) `shouldBe` Nothing
             fmap bfId (findFlowByNameComp rule byName "ammonia" (Just comp)) `shouldBe` Just fid
@@ -158,8 +162,8 @@ spec = do
             -- the subcompartment it names and not the one merely containing it.
             fidLongTerm <- nextRandom
             fidNow <- nextRandom
-            let fLongTerm = mkFlow fidLongTerm "co2" "air" (Just "low. pop., long-term")
-                fNow = mkFlow fidNow "co2" "air" (Just "low. pop.")
+            let fLongTerm = mkFlow fidLongTerm "co2" Air (Just "low. pop., long-term")
+                fNow = mkFlow fidNow "co2" Air (Just "low. pop.")
                 byName = M.singleton "co2" [fLongTerm, fNow]
                 comp = Compartment "air" "low. pop." ""
             fmap bfId (findFlowByNameComp M.empty byName "co2" (Just comp)) `shouldBe` Just fidNow
@@ -169,7 +173,7 @@ spec = do
             -- spelling an ILCD method writes for what a database files under
             -- "air". Both sides go through the table, as scoring does.
             fid <- nextRandom
-            let fAir = mkFlow fid "co2" "air" Nothing
+            let fAir = mkFlow fid "co2" Air Nothing
                 byName = M.singleton "co2" [fAir]
                 cmap = M.singleton ("emissions to air", "", "") (Compartment "air" "" "")
                 comp = Compartment "Emissions to air" "" ""
@@ -181,8 +185,8 @@ spec = do
             -- row is left with, and it must not depend on the index order.
             fidLongTerm <- nextRandom
             fidPlain <- nextRandom
-            let fLongTerm = mkFlow fidLongTerm "co2" "air" (Just "low. pop., long-term")
-                fPlain = mkFlow fidPlain "co2" "air" Nothing
+            let fLongTerm = mkFlow fidLongTerm "co2" Air (Just "low. pop., long-term")
+                fPlain = mkFlow fidPlain "co2" Air Nothing
                 comp = Compartment "air" "low. pop." ""
             fmap bfId (findFlowByNameComp M.empty (M.singleton "co2" [fLongTerm, fPlain]) "co2" (Just comp))
                 `shouldBe` Just fidPlain
@@ -192,7 +196,7 @@ spec = do
     describe "findFlowByCAS" $ do
         it "finds flow by CAS number" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "Carbon dioxide" "air" Nothing
+            let flow = mkFlow fid "Carbon dioxide" Air Nothing
                 byCAS = M.singleton "124-38-9" [flow]
             fmap bfId (findFlowByCAS M.empty byCAS "124-38-9" Nothing) `shouldBe` Just fid
 
@@ -204,7 +208,7 @@ spec = do
         -- factor goes silently missing.
         it "meets a canonically indexed flow from a zero-padded query" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "Carbon dioxide" "air" Nothing
+            let flow = mkFlow fid "Carbon dioxide" Air Nothing
                 byCAS = M.singleton "124-38-9" [flow]
             fmap bfId (findFlowByCAS M.empty byCAS "000124-38-9" Nothing) `shouldBe` Just fid
 
@@ -212,14 +216,14 @@ spec = do
         -- would collide every CAS-less flow onto one key.
         it "refuses an all-zeros placeholder rather than treating it as a CAS" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "Unknown" "air" Nothing
+            let flow = mkFlow fid "Unknown" Air Nothing
                 byCAS = M.singleton "0-00-0" [flow]
             fmap bfId (findFlowByCAS M.empty byCAS "000-00-0" Nothing) `shouldBe` Nothing
 
     describe "findFlowByName" $ do
         it "finds a flow by name (case-insensitive via normalization)" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "Carbon dioxide" "air" Nothing
+            let flow = mkFlow fid "Carbon dioxide" Air Nothing
                 byName = M.singleton "carbon dioxide" [flow]
             fmap bfId (findFlowByName M.empty byName "Carbon dioxide") `shouldBe` Just fid
 
@@ -229,7 +233,7 @@ spec = do
     describe "findFlowBySynonym" $ do
         it "returns Nothing when synonym not in DB" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "Carbon dioxide" "air" Nothing
+            let flow = mkFlow fid "Carbon dioxide" Air Nothing
                 byName = M.singleton "carbon dioxide" [flow]
             fmap bfId (findFlowBySynonym (SynonymSearch emptySynonymDB byName M.empty) "CO2") `shouldBe` Nothing
 
@@ -238,8 +242,8 @@ spec = do
             fid1 <- nextRandom
             fid2 <- nextRandom
             let synDB = buildFromPairs [("CO2", "Carbon dioxide")]
-                fAir = mkFlow fid1 "Carbon dioxide" "air" Nothing
-                fWater = mkFlow fid2 "Carbon dioxide" "water" Nothing
+                fAir = mkFlow fid1 "Carbon dioxide" Air Nothing
+                fWater = mkFlow fid2 "Carbon dioxide" Water Nothing
                 byName = M.singleton "carbon dioxide" [fWater, fAir]
                 comp = Compartment "air" "" ""
             fmap bfId (findFlowBySynonymComp (SynonymSearch synDB byName M.empty) "CO2" (Just comp))
@@ -248,7 +252,7 @@ spec = do
         it "returns Nothing when synonym not in DB" $ do
             fid <- nextRandom
             let synDB = buildFromPairs [("CO2", "Carbon dioxide")]
-                flow = mkFlow fid "Carbon dioxide" "air" Nothing
+                flow = mkFlow fid "Carbon dioxide" Air Nothing
                 byName = M.singleton "carbon dioxide" [flow]
             fmap bfId (findFlowBySynonymComp (SynonymSearch synDB byName M.empty) "methane" Nothing)
                 `shouldBe` Nothing
@@ -264,7 +268,7 @@ spec = do
         -- must not fan out onto the resource flow through it — else a release
         -- inherits a withdrawal scarcity factor (wrong sign/magnitude).
         let synDB = buildFromEdges [SynEdge "freshwater" "Water, unspecified natural origin" BridgeInput]
-            resourceFlow fid = mkFlow fid "Water, unspecified natural origin" "natural resource" Nothing
+            resourceFlow fid = mkFlow fid "Water, unspecified natural origin" NaturalResource Nothing
             flowsByName fid = M.singleton "water unspecified natural origin" [resourceFlow fid]
             inputCF = (mkCF "freshwater" Nothing 1.0){mcfDirection = Input}
             outputCF = (mkCF "freshwater" Nothing 1.0){mcfDirection = Output}
@@ -294,7 +298,7 @@ spec = do
 
         it "fans out through a pivot alias that is neither a flow nor a CF name" $ do
             fid <- nextRandom
-            let coalFlow = mkFlow fid "Coal, hard" "resource" Nothing
+            let coalFlow = mkFlow fid "Coal, hard" NaturalResource Nothing
                 flowsByName = M.singleton "coal hard" [coalFlow]
             [ bfId flow
               | (_, Just (flow, BySynonym)) <-
@@ -309,7 +313,7 @@ spec = do
         -- method carried none. The loader surfaces these so the loss is
         -- distinguishable from a genuinely uncharacterized flow.
         let synDB = buildFromEdges [SynEdge "freshwater" "Water, unspecified natural origin" BridgeInput]
-            flowsByName fid = M.singleton "water unspecified natural origin" [mkFlow fid "Water, unspecified natural origin" "natural resource" Nothing]
+            flowsByName fid = M.singleton "water unspecified natural origin" [mkFlow fid "Water, unspecified natural origin" NaturalResource Nothing]
             inputCF = (mkCF "freshwater" Nothing 1.0){mcfDirection = Input}
             outputCF = (mkCF "freshwater" Nothing 1.0){mcfDirection = Output}
 
@@ -328,9 +332,9 @@ spec = do
             fid1 <- nextRandom
             fid2 <- nextRandom
             fid3 <- nextRandom
-            let f1 = mkFlow fid1 "co2" "air" Nothing
-                f2 = mkFlow fid2 "methane" "air" Nothing
-                f3 = mkFlow fid3 "n2o" "air" Nothing
+            let f1 = mkFlow fid1 "co2" Air Nothing
+                f2 = mkFlow fid2 "methane" Air Nothing
+                f3 = mkFlow fid3 "n2o" Air Nothing
                 cf1 = mkCF "co2" Nothing 1.0
                 cf2 = mkCF "methane" Nothing 25.0
                 cf3 = mkCF "n2o" Nothing 298.0
@@ -358,7 +362,7 @@ spec = do
     describe "computeLCIAScore" $ do
         it "sums UUID-matched flows" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "co2" "air" Nothing
+            let flow = mkFlow fid "co2" Air Nothing
                 unit = Unit{unitId = nil, unitName = "kg", unitSymbol = "kg", unitComment = ""}
                 cf = mkCF "co2" Nothing 1.0
                 mapping = [(cf, Just (flow, ByUUID))]
@@ -375,7 +379,7 @@ spec = do
 
         it "skips zero-quantity flows" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "co2" "air" Nothing
+            let flow = mkFlow fid "co2" Air Nothing
                 cf = mkCF "co2" Nothing 1.0
                 mapping = [(cf, Just (flow, ByUUID))]
                 inventory = M.singleton fid 0.0
@@ -384,7 +388,7 @@ spec = do
 
         it "scores via fallback CF (name+medium, empty subcomp)" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "Carbon dioxide" "air" Nothing
+            let flow = mkFlow fid "Carbon dioxide" Air Nothing
                 cf = mkCFComp "Carbon dioxide" "air" "" 2.5
                 mapping = [(cf, Nothing)] -- unmatched → name-based lookup
                 inventory = M.singleton fid 10.0
@@ -394,7 +398,7 @@ spec = do
 
         it "scores via exact CF (name+medium+subcomp)" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "Carbon dioxide" "air" (Just "urban air close to ground")
+            let flow = mkFlow fid "Carbon dioxide" Air (Just "urban air close to ground")
                 cf = mkCFComp "Carbon dioxide" "air" "urban air close to ground" 3.0
                 mapping = [(cf, Nothing)]
                 inventory = M.singleton fid 5.0
@@ -404,7 +408,7 @@ spec = do
 
         it "normalizes 'natural resource' category to 'resource'" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "crude oil" "natural resource" Nothing
+            let flow = mkFlow fid "crude oil" NaturalResource Nothing
                 cf = mkCFComp "crude oil" "natural resource" "" 1.5
                 mapping = [(cf, Nothing)]
                 inventory = M.singleton fid 4.0
@@ -426,8 +430,8 @@ spec = do
         -- both sides, the lookup misses and the flow silently scores zero.
         it "scores zero without a compartment map (regression)" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "ammonia" "emissions to air/low. pop." Nothing
-                cf = mkCFComp "ammonia" "air" "low. pop." 0.747
+            let flow = mkFlow fid "ammonia" Air (Just "low. pop.")
+                cf = mkCFComp "ammonia" "emissions to air" "low. pop." 0.747
                 tables = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Nothing)]
                 inventory = M.singleton fid 10.0
                 flowDB = M.singleton fid flow
@@ -436,8 +440,8 @@ spec = do
 
         it "bridges 'emissions to air' → 'air' via a medium-only rule" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "ammonia" "emissions to air/low. pop." Nothing
-                cf = mkCFComp "ammonia" "air" "low. pop." 0.747
+            let flow = mkFlow fid "ammonia" Air (Just "low. pop.")
+                cf = mkCFComp "ammonia" "emissions to air" "low. pop." 0.747
                 cmap = M.singleton ("emissions to air", "", "") (Compartment "air" "" "")
                 tables = buildMethodTables OtherCFFamily cmap M.empty [(cf, Nothing)]
                 inventory = M.singleton fid 10.0
@@ -447,9 +451,10 @@ spec = do
 
         it "bridges full (medium, sub, qual) triples for subcompartment rewrites" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "ammonia" "emissions to air/low. pop." Nothing
-                -- ILCD-style CF on a different subcompartment than the BAFU flow.
-                cf = mkCFComp "ammonia" "air" "non-urban air or from high stacks" 0.747
+            let flow = mkFlow fid "ammonia" Air (Just "non-urban air or from high stacks")
+                -- A CF categorized the way BAFU categorizes it, on a different
+                -- subcompartment than the flow.
+                cf = mkCFComp "ammonia" "emissions to air" "low. pop." 0.747
                 cmap =
                     M.singleton
                         ("emissions to air", "low. pop.", "")
@@ -465,7 +470,7 @@ spec = do
         -- Now an unconvertible flow contributes 0, matching the "no-CF" branch.
         it "returns 0 when unit conversion fails (dimension mismatch)" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "co2" "air" Nothing
+            let flow = mkFlow fid "co2" Air Nothing
                 cf = mkCF "co2" Nothing 1.0 -- mcfUnit = "kg"
                 mapping = [(cf, Just (flow, ByUUID))]
                 inventory = M.singleton fid 100.0
@@ -476,7 +481,7 @@ spec = do
 
         it "applies conversion factor when units differ but are compatible (g→kg)" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "co2" "air" Nothing
+            let flow = mkFlow fid "co2" Air Nothing
                 cf = mkCF "co2" Nothing 2.0 -- mcfUnit = "kg"
                 mapping = [(cf, Just (flow, ByUUID))]
                 inventory = M.singleton fid 1000.0 -- 1000 g
@@ -506,7 +511,7 @@ spec = do
         it "the verbatim-named CF wins over the higher-valued homonym" $ do
             fid <- nextRandom
             uidM3 <- nextRandom
-            let flow = (mkFlow fid "Gas, natural/m3" "natural resource" (Just "in ground")){bfUnitId = uidM3}
+            let flow = (mkFlow fid "Gas, natural/m3" NaturalResource (Just "in ground")){bfUnitId = uidM3}
                 mappings = [(cfPerKg, Just (flow, ByName)), (cfPerM3, Just (flow, ByName))]
                 unitDB = M.singleton uidM3 Unit{unitId = uidM3, unitName = "m3", unitSymbol = "m3", unitComment = ""}
                 flowDB = M.singleton fid flow
@@ -535,8 +540,8 @@ spec = do
             servedFor mappings = do
                 targetId <- nextRandom
                 probeId <- nextRandom
-                let target = mkFlow targetId "phosphate" "water" Nothing
-                    probe = mkFlow probeId "phosphate" "water" Nothing
+                let target = mkFlow targetId "phosphate" Water Nothing
+                    probe = mkFlow probeId "phosphate" Water Nothing
                     tables = buildMethodTables OtherCFFamily M.empty M.empty (mappings target)
                 pure (cfValue <$> lookupCFForFlow tables probeId (Just probe))
 
@@ -582,7 +587,7 @@ spec = do
             sea = mkCFComp "Nitrogen, total" "water" "ocean" 0.0
             scoreWith cfs sub = do
                 fid <- nextRandom
-                let flow = mkFlow fid "Nitrogen, total" "water" (Just sub)
+                let flow = mkFlow fid "Nitrogen, total" Water (Just sub)
                     tables =
                         buildMethodTables
                             OtherCFFamily
@@ -624,7 +629,7 @@ spec = do
                     pure
                     (buildCompartmentMapFromCSV "source_medium,source_sub,source_qualifier,target_medium,target_sub,target_qualifier\nwater,sea water,,water,ocean,\n")
             fid <- nextRandom
-            let flow = mkFlow fid "Nitrogen, total" "water" (Just "sea water")
+            let flow = mkFlow fid "Nitrogen, total" Water (Just "sea water")
                 score cfs =
                     loScore $
                         computeLCIAScoreFromTables
@@ -651,10 +656,10 @@ spec = do
             scoreVia cm fam name mCas sub = do
                 fid <- nextRandom
                 mid <- nextRandom
-                let flow = (mkFlow fid name "water" (Just sub)){bfCAS = mCas}
+                let flow = (mkFlow fid name Water (Just sub)){bfCAS = mCas}
                     -- cfUns matched ByCAS on a sibling flow, so it also
                     -- populates the CAS bridge (mtCasCF).
-                    matched = (mkFlow mid "Iron, ion" "water" Nothing){bfCAS = Just "7439-89-6"}
+                    matched = (mkFlow mid "Iron, ion" Water Nothing){bfCAS = Just "7439-89-6"}
                     tables = buildMethodTables fam cm M.empty [(cfUns, Just (matched, ByCAS)), (cfLt, Nothing)]
                     flowDB = M.singleton fid flow
                 pure (loScore (computeLCIAScoreFromTables defaultUnitConfig M.empty flowDB (M.singleton fid 1.0) tables))
@@ -714,23 +719,23 @@ spec = do
                         tables
 
         it "characterizes a flow filed under the medium the method names" $
-            scoreOf "waste" Nothing `shouldReturn` 24.0
+            scoreOf Waste Nothing `shouldReturn` 24.0
 
         it "characterizes an inventory indicator whose subcompartment is waste" $
-            scoreOf "inventory indicator" (Just "waste") `shouldReturn` 24.0
+            scoreOf InventoryIndicator (Just "waste") `shouldReturn` 24.0
 
         it "leaves the indicators that are not waste alone" $ do
             -- The same compartment name also covers secondary materials and
             -- exported energy. A rule keyed on the medium alone would hand
             -- them a waste factor; this one is keyed on the pair.
-            scoreOf "inventory indicator" (Just "resource use") `shouldReturn` 0.0
-            scoreOf "inventory indicator" (Just "output flow") `shouldReturn` 0.0
+            scoreOf InventoryIndicator (Just "resource use") `shouldReturn` 0.0
+            scoreOf InventoryIndicator (Just "output flow") `shouldReturn` 0.0
 
     describe "inventoryContributions" $ do
         -- Regression: same fallback bug as computeLCIAScoreFromTables.
         it "yields zero contribution when unit conversion fails" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "co2" "air" Nothing
+            let flow = mkFlow fid "co2" Air Nothing
                 cf = mkCF "co2" Nothing 1.0
                 tables = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flow, ByUUID))]
                 inventory = M.singleton fid 100.0
@@ -769,7 +774,7 @@ spec = do
     describe "computeMappingStats" $ do
         it "counts BySynonym matches" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "co2" "air" Nothing
+            let flow = mkFlow fid "co2" Air Nothing
                 cf = mkCF "co2" Nothing 1.0
                 stats = computeMappingStats [(cf, Just (flow, BySynonym))]
             msBySynonym stats `shouldBe` 1
@@ -778,7 +783,7 @@ spec = do
         it "finds flow via synonym group (no compartment)" $ do
             fid <- nextRandom
             let synDB = buildFromPairs [("co2", "carbon dioxide")]
-                flow = mkFlow fid "carbon dioxide" "air" Nothing
+                flow = mkFlow fid "carbon dioxide" Air Nothing
                 byName = M.singleton "carbon dioxide" [flow]
             fmap bfId (findFlowBySynonym (SynonymSearch synDB byName M.empty) "co2")
                 `shouldBe` Just fid
@@ -786,7 +791,7 @@ spec = do
     describe "pickByCompartment M.empty (matchMedium edge cases)" $ do
         it "null medium matches any flow" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "co2" "water" Nothing
+            let flow = mkFlow fid "co2" Water Nothing
                 byName = M.singleton "co2" [flow]
                 comp = Compartment "" "" ""
             fmap bfId (findFlowByNameComp M.empty byName "co2" (Just comp)) `shouldBe` Just fid
@@ -798,10 +803,10 @@ spec = do
             -- spellings are one medium.
             fid1 <- nextRandom
             fid2 <- nextRandom
-            let fUrbanAir = mkFlow fid1 "nox" "urban air" Nothing
-                fWater = mkFlow fid2 "nox" "water" Nothing
+            let fUrbanAir = mkFlow fid1 "nox" Air (Just "urban")
+                fWater = mkFlow fid2 "nox" Water Nothing
                 byName = M.singleton "nox" [fWater, fUrbanAir]
-                comp = Compartment "air" "urban" ""
+                comp = Compartment "urban air" "" ""
                 rule = M.singleton ("urban air", "", "") (Compartment "air" "urban" "")
             fmap bfId (findFlowByNameComp M.empty byName "nox" (Just comp)) `shouldBe` Nothing
             fmap bfId (findFlowByNameComp rule byName "nox" (Just comp)) `shouldBe` Just fid1
@@ -809,10 +814,10 @@ spec = do
     describe "compartmentGapWarning" $ do
         it "names both vocabularies when a factor's name is filed under another medium" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "ammonia" "emissions to air" Nothing
-                cf = mkCFComp "ammonia" "air" "" 0.747
+            let flow = mkFlow fid "ammonia" Air Nothing
+                cf = mkCFComp "ammonia" "emissions to air" "" 0.747
             compartmentGapWarning M.empty (M.singleton "ammonia" [flow]) [(cf, Nothing)]
-                `shouldBe` Just "1 factor(s) name a flow this database files under another compartment (method: \"air\"; database: \"emissions to air\"). Declare a [[compartment-mappings]] table bridging them."
+                `shouldBe` Just "1 factor(s) name a flow this database files under another compartment (method: \"emissions to air\"; database: \"air\"). Declare a [[compartment-mappings]] table bridging them."
 
         it "stays silent when the name is simply absent" $ do
             let cf = mkCFComp "ammonia" "air" "" 0.747
@@ -823,15 +828,15 @@ spec = do
             -- not its vocabulary: nothing to declare.
             fid1 <- nextRandom
             fid2 <- nextRandom
-            let nitrite = mkFlow fid1 "nitrite" "water" Nothing
-                co2 = mkFlow fid2 "co2" "air" Nothing
+            let nitrite = mkFlow fid1 "nitrite" Water Nothing
+                co2 = mkFlow fid2 "co2" Air Nothing
                 byName = M.fromList [("nitrite", [nitrite]), ("co2", [co2])]
                 cf = mkCFComp "nitrite" "air" "" 1.0
             compartmentGapWarning M.empty byName [(cf, Nothing)] `shouldBe` Nothing
 
         it "stays silent for a factor that resolved" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "ammonia" "air" Nothing
+            let flow = mkFlow fid "ammonia" Air Nothing
                 cf = mkCFComp "ammonia" "air" "" 0.747
             compartmentGapWarning M.empty (M.singleton "ammonia" [flow]) [(cf, Just (flow, ByName))] `shouldBe` Nothing
 
@@ -841,7 +846,7 @@ spec = do
         it "scoring with empty broadcast equals scoring with filled broadcast (UUID match)" $ do
             fid <- nextRandom
             uidKg <- nextRandom
-            let flow = (mkFlow fid "co2" "air" Nothing){bfUnitId = uidKg}
+            let flow = (mkFlow fid "co2" Air Nothing){bfUnitId = uidKg}
                 cf = (mkCF "co2" Nothing 2.5){mcfUnit = "kg"}
                 rawTables = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flow, ByUUID))]
                 flowDB = M.singleton fid flow
@@ -867,7 +872,7 @@ spec = do
                         (M.fromList [("kg", "kg"), ("g", "g")])
             fid <- nextRandom
             uidKg <- nextRandom
-            let flow = (mkFlow fid "co2" "air" Nothing){bfUnitId = uidKg}
+            let flow = (mkFlow fid "co2" Air Nothing){bfUnitId = uidKg}
                 cf = (mkCF "co2" Nothing 1.0e-3){mcfUnit = "g"}
                 tables0 = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flow, ByUUID))]
                 flowDB = M.singleton fid flow
@@ -886,7 +891,7 @@ spec = do
         it "broadcast covers exact (name, medium, subcomp) cascade" $ do
             fid <- nextRandom
             uidKg <- nextRandom
-            let flow = (mkFlow fid "co2" "air" (Just "high pop")){bfUnitId = uidKg}
+            let flow = (mkFlow fid "co2" Air (Just "high pop")){bfUnitId = uidKg}
                 cf = (mkCFComp "co2" "air" "high pop" 3.0){mcfUnit = "kg"}
                 tables0 = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flow, ByName))]
                 flowDB = M.singleton fid flow
@@ -902,7 +907,7 @@ spec = do
             fid <- nextRandom
             uidKg <- nextRandom
             -- Flow has subcomp "high pop", but CF only has medium-level entry (subcomp "")
-            let flow = (mkFlow fid "co2" "air" (Just "high pop")){bfUnitId = uidKg}
+            let flow = (mkFlow fid "co2" Air (Just "high pop")){bfUnitId = uidKg}
                 cf = (mkCFComp "co2" "air" "" 5.0){mcfUnit = "kg"}
                 tables0 = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flow, ByName))]
                 flowDB = M.singleton fid flow
@@ -918,7 +923,7 @@ spec = do
             fidLocal <- nextRandom
             fidExtra <- nextRandom -- in inventory but NOT in flowDB at fill time
             uidKg <- nextRandom
-            let flowLocal = (mkFlow fidLocal "co2" "air" Nothing){bfUnitId = uidKg}
+            let flowLocal = (mkFlow fidLocal "co2" Air Nothing){bfUnitId = uidKg}
                 cf = (mkCF "co2" Nothing 1.5){mcfUnit = "kg"}
                 tables0 = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flowLocal, ByUUID))]
                 flowDBAtBuild = M.singleton fidLocal flowLocal
@@ -948,7 +953,7 @@ spec = do
             fillWith densities unitName' cf = do
                 fid <- nextRandom
                 uid <- nextRandom
-                let flow = (mkFlow fid "gas" "air" Nothing){bfUnitId = uid}
+                let flow = (mkFlow fid "gas" Air Nothing){bfUnitId = uid}
                     flowDB = M.singleton fid flow
                     unitDB = M.singleton uid ((unitNamed unitName'){unitId = uid})
                     filled =
@@ -1019,7 +1024,7 @@ spec = do
 
         it "returns no candidates from an empty method" $ do
             fid <- nextRandom
-            let flow = (mkFlow fid "Carbon dioxide" "air" Nothing){bfCAS = Nothing}
+            let flow = (mkFlow fid "Carbon dioxide" Air Nothing){bfCAS = Nothing}
                 idx = buildMethodIndex (mkMethod [])
             findSimilarCFs emptyChemSynonyms idx flow 3 `shouldBe` []
 
@@ -1032,7 +1037,7 @@ spec = do
                 co2 = (mkCFComp "CO2" "air" "" 1.0){mcfCompartment = airComp}
                 ch4 = (mkCFComp "Methane" "air" "" 27.0){mcfCompartment = airComp}
                 idx = buildMethodIndex (mkMethod [co2, ch4])
-                flow = (mkFlow fid "Carbon dioxide" "air" Nothing){bfCAS = Nothing}
+                flow = (mkFlow fid "Carbon dioxide" Air Nothing){bfCAS = Nothing}
                 cands = findSimilarCFs syns idx flow 3
             -- The CO2 candidate must be present, with the synonym-expansion reason.
             let names = map scfMethodFlowName cands
@@ -1050,7 +1055,7 @@ spec = do
                         }
                 idx = buildMethodIndex (mkMethod [oddName])
                 flow =
-                    (mkFlow fid "Random unrelated text" "air" Nothing)
+                    (mkFlow fid "Random unrelated text" Air Nothing)
                         { bfCAS = Just "124-38-9"
                         }
                 cands = findSimilarCFs emptyChemSynonyms idx flow 3
@@ -1062,7 +1067,7 @@ spec = do
             let close = mkCFComp "Methane biogenic" "air" "" 27.0
                 far = mkCFComp "Crude oil" "air" "" 0.0
                 idx = buildMethodIndex (mkMethod [far, close])
-                flow = mkFlow fid "Methane, biogenic" "air" Nothing
+                flow = mkFlow fid "Methane, biogenic" Air Nothing
                 cands = findSimilarCFs emptyChemSynonyms idx flow 2
             map scfMethodFlowName cands `shouldSatisfy` (\ns -> not (null ns) && head ns == "Methane biogenic")
 
@@ -1070,7 +1075,7 @@ spec = do
             fid <- nextRandom
             let cfs = [mkCFComp ("foo " <> tShow i) "air" "" 1.0 | i <- [1 .. 10 :: Int]]
                 idx = buildMethodIndex (mkMethod cfs)
-                flow = mkFlow fid "foo bar" "air" Nothing
+                flow = mkFlow fid "foo bar" Air Nothing
                 cands = findSimilarCFs emptyChemSynonyms idx flow 3
             length cands `shouldSatisfy` (<= 3)
 
@@ -1088,7 +1093,7 @@ spec = do
 
         it "returns [] when uoMaxFlows is 0" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "co2" "air" Nothing
+            let flow = mkFlow fid "co2" Air Nothing
                 inv = M.singleton fid 100.0
                 tables = buildMethodTables OtherCFFamily M.empty M.empty []
                 idx = buildMethodIndex (mkMethod [])
@@ -1107,8 +1112,8 @@ spec = do
         it "drops flows below the absolute-weight threshold" $ do
             big <- nextRandom
             small <- nextRandom
-            let bigFlow = mkFlow big "tiny stuff" "air" Nothing
-                smallFlow = mkFlow small "huge stuff" "air" Nothing
+            let bigFlow = mkFlow big "tiny stuff" Air Nothing
+                smallFlow = mkFlow small "huge stuff" Air Nothing
                 inv = M.fromList [(big, 999.0), (small, 1.0)]
                 flowDB = M.fromList [(big, bigFlow), (small, smallFlow)]
                 tables = buildMethodTables OtherCFFamily M.empty M.empty []
@@ -1129,7 +1134,7 @@ spec = do
 
         it "skips flows that DO have a CF (they're characterized)" $ do
             fid <- nextRandom
-            let flow = mkFlow fid "co2" "air" Nothing
+            let flow = mkFlow fid "co2" Air Nothing
                 cf = (mkCF "co2" Nothing 1.0){mcfFlowRef = fid}
                 tables = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Just (flow, ByUUID))]
                 idx = buildMethodIndex (mkMethod [cf])
@@ -1170,19 +1175,19 @@ spec = do
                 , occIndustrial
                 , occBenthos
                 ]
-            occAnnual = mkFlow (u 1) "Occupation, annual crop" "resource" Nothing
-            occOrchard = mkFlow (u 2) "Occupation, permanent crop, fruit" "resource" Nothing
+            occAnnual = mkFlow (u 1) "Occupation, annual crop" NaturalResource Nothing
+            occOrchard = mkFlow (u 2) "Occupation, permanent crop, fruit" NaturalResource Nothing
             -- The sea floor and a factory yard sit in one occupation family, and
             -- the drowned one shares its prefix with the dry one: the case
             -- exclusions exist for, since no set of prefixes separates them.
-            occSea = mkFlow (u 8) "Occupation, sea and ocean" "resource" Nothing
-            occIndustrial = mkFlow (u 9) "Occupation, industrial area" "resource" Nothing
-            occBenthos = mkFlow (u 10) "Occupation, industrial area, benthos" "resource" Nothing
-            transformation = mkFlow (u 3) "Transformation, to annual crop" "resource" Nothing
-            waterRiver = mkFlow (u 4) "Water, river" "resource" Nothing
-            waterWell = mkFlow (u 7) "Water, well" "resource" (Just "in ground")
-            methaneAir = (mkFlow (u 5) "Methane, fossil" "air" Nothing){bfCAS = Just "74-82-8"}
-            methaneWater = (mkFlow (u 6) "Methane, fossil" "water" Nothing){bfCAS = Just "74-82-8"}
+            occSea = mkFlow (u 8) "Occupation, sea and ocean" NaturalResource Nothing
+            occIndustrial = mkFlow (u 9) "Occupation, industrial area" NaturalResource Nothing
+            occBenthos = mkFlow (u 10) "Occupation, industrial area, benthos" NaturalResource Nothing
+            transformation = mkFlow (u 3) "Transformation, to annual crop" NaturalResource Nothing
+            waterRiver = mkFlow (u 4) "Water, river" NaturalResource Nothing
+            waterWell = mkFlow (u 7) "Water, well" NaturalResource (Just "in ground")
+            methaneAir = (mkFlow (u 5) "Methane, fossil" Air Nothing){bfCAS = Just "74-82-8"}
+            methaneWater = (mkFlow (u 6) "Methane, fossil" Water Nothing){bfCAS = Just "74-82-8"}
             occupationFlows = [occAnnual, occOrchard, occSea, occIndustrial, occBenthos]
             u = uuidFromInt
             -- Compare by UUID: BiosphereFlow has no Eq/Show instance.

--- a/test/MatrixConstructionSpec.hs
+++ b/test/MatrixConstructionSpec.hs
@@ -178,7 +178,7 @@ spec = do
                         }
                 activityMap = M.singleton (actUUID, prodUUID) activity
                 techFlowDB = M.singleton prodUUID (TechnosphereFlow prodUUID "energy product" mjUnitId M.empty Nothing Nothing)
-                bioFlowDB = M.singleton bioFlowUUID (BiosphereFlow bioFlowUUID "trace pollutant" kgUnitId M.empty Nothing Nothing (Just (Compartment "air" Nothing)))
+                bioFlowDB = M.singleton bioFlowUUID (BiosphereFlow bioFlowUUID "trace pollutant" kgUnitId M.empty Nothing Nothing (Just (Compartment Air Nothing)))
                 unitDB =
                     M.fromList
                         [ (mjUnitId, Unit mjUnitId "mj" "mj" "")
@@ -263,7 +263,7 @@ spec = do
                         }
                 activityMap = M.singleton (actUUID, prodUUID) activity
                 techFlowDB = M.singleton prodUUID (TechnosphereFlow prodUUID "energy product" mjUnitId M.empty Nothing Nothing)
-                bioFlowDB = M.singleton bioFlowUUID (BiosphereFlow bioFlowUUID "trace pollutant" kgUnitId M.empty Nothing Nothing (Just (Compartment "air" Nothing)))
+                bioFlowDB = M.singleton bioFlowUUID (BiosphereFlow bioFlowUUID "trace pollutant" kgUnitId M.empty Nothing Nothing (Just (Compartment Air Nothing)))
                 unitDB =
                     M.fromList
                         [ (mjUnitId, Unit mjUnitId "mj" "mj" "")
@@ -391,7 +391,7 @@ spec = do
                         [ (wW, TechnosphereFlow wW "waste W" kgU M.empty Nothing Nothing)
                         , (yY, TechnosphereFlow yY "product Y" kgU M.empty Nothing Nothing)
                         ]
-                bioFlowDB = M.singleton co2 (BiosphereFlow co2 "carbon dioxide" kgU M.empty Nothing Nothing (Just (Compartment "air" Nothing)))
+                bioFlowDB = M.singleton co2 (BiosphereFlow co2 "carbon dioxide" kgU M.empty Nothing Nothing (Just (Compartment Air Nothing)))
                 wasteFlowDB = M.singleton wW (WasteFlow wW "waste W" kgU M.empty Nothing Nothing)
                 unitDB = M.singleton kgU (Unit kgU "kg" "kg" "")
 

--- a/test/MethodSetTablesSpec.hs
+++ b/test/MethodSetTablesSpec.hs
@@ -25,7 +25,12 @@ import Matrix (Inventory)
 import Method.Mapping
 import Method.Types (Compartment (..), Location (..), Method (..), MethodCF (..))
 import qualified Method.Types as MT
-import Types (BiosphereFlow (..), Database, Unit (..))
+import Types (
+    BiosphereFlow (..),
+    Database,
+    Medium (..),
+    Unit (..),
+ )
 import qualified Types as VT
 import qualified UnitConversion
 
@@ -48,7 +53,7 @@ mkFlow fid name uId =
         , bfSynonyms = M.empty
         , bfCAS = Nothing
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (VT.Compartment "air" Nothing)
+        , bfCompartment = Just (VT.Compartment Air Nothing)
         }
 
 mkCF :: UUID -> Double -> MethodCF
@@ -419,11 +424,11 @@ spec = do
                 uidKg = mkUuid 200
                 flowUns =
                     (mkFlow fidUns "water" uidKg)
-                        { bfCompartment = Just (VT.Compartment "water" (Just "(unspecified)"))
+                        { bfCompartment = Just (VT.Compartment Water (Just "(unspecified)"))
                         }
                 flowOcean =
                     (mkFlow fidOcean "water" uidKg)
-                        { bfCompartment = Just (VT.Compartment "water" (Just "ocean"))
+                        { bfCompartment = Just (VT.Compartment Water (Just "ocean"))
                         }
                 cfUns =
                     (mkCF fidUns 3.0)
@@ -463,7 +468,7 @@ spec = do
                 uidKg = mkUuid 200
                 flowRiver =
                     (mkFlow fid "water" uidKg)
-                        { bfCompartment = Just (VT.Compartment "water" (Just "river"))
+                        { bfCompartment = Just (VT.Compartment Water (Just "river"))
                         }
                 cfEmpty =
                     (mkCF fid 2.0)
@@ -504,7 +509,7 @@ spec = do
                 uidKg = mkUuid 200
                 flowRiver =
                     (mkFlow fid "water" uidKg)
-                        { bfCompartment = Just (VT.Compartment "water" (Just "river"))
+                        { bfCompartment = Just (VT.Compartment Water (Just "river"))
                         }
                 cfAt sub value =
                     (mkCF fid value)
@@ -530,7 +535,7 @@ spec = do
                 uidKg = mkUuid 200
                 flowOcean =
                     (mkFlow fid "water" uidKg)
-                        { bfCompartment = Just (VT.Compartment "water" (Just "ocean"))
+                        { bfCompartment = Just (VT.Compartment Water (Just "ocean"))
                         }
                 cfAt sub value =
                     (mkCF fid value)
@@ -559,7 +564,7 @@ spec = do
                 uidKg = mkUuid 200
                 flowOcean =
                     (mkFlow fid "nitrogen, total" uidKg)
-                        { bfCompartment = Just (VT.Compartment "water" (Just "ocean"))
+                        { bfCompartment = Just (VT.Compartment Water (Just "ocean"))
                         }
                 cfUnspecified =
                     (mkCF fid 1.0)
@@ -584,7 +589,7 @@ spec = do
                 uidKg = mkUuid 200
                 flowSub s =
                     (mkFlow fid "nickel" uidKg)
-                        { bfCompartment = Just (VT.Compartment "water" (Just s))
+                        { bfCompartment = Just (VT.Compartment Water (Just s))
                         }
                 cfUnspecified =
                     (mkCF fid 7.0)
@@ -603,7 +608,7 @@ spec = do
                 uidKg = mkUuid 200
                 flowAny =
                     (mkFlow fid "water" uidKg)
-                        { bfCompartment = Just (VT.Compartment "air" (Just "groundwater, long-term"))
+                        { bfCompartment = Just (VT.Compartment Air (Just "groundwater, long-term"))
                         }
                 cf =
                     (mkCF fid 4.0)

--- a/test/MethodSpec.hs
+++ b/test/MethodSpec.hs
@@ -23,7 +23,10 @@ import Method.ParserNW (parseNormWeightCSVBytes)
 import Method.ParserSimaPro (isSimaProMethodCSV, parseSimaProMethodCSVBytes)
 import Method.Types
 import SynonymDB
-import Types (BiosphereFlow (..))
+import Types (
+    BiosphereFlow (..),
+    Medium (..),
+ )
 import qualified Types as VT
 import UnitConversion (defaultUnitConfig)
 
@@ -1140,5 +1143,5 @@ mkTestFlow uuid name =
         , bfCAS = Nothing
         , bfSubstanceId = Nothing
         , bfSynonyms = M.empty
-        , bfCompartment = Just (VT.Compartment "air" Nothing)
+        , bfCompartment = Just (VT.Compartment Air Nothing)
         }

--- a/test/PersistenceSpec.hs
+++ b/test/PersistenceSpec.hs
@@ -71,6 +71,7 @@ import Types (
     Exchange (..),
     GeographyPolicy (..),
     LocationSource (..),
+    Medium (..),
     SimpleDatabase (..),
     SparseTriple (..),
     TechRole (..),
@@ -396,7 +397,7 @@ milkFlow =
         }
 
 air :: Compartment
-air = Compartment{compartmentName = "air", compartmentSub = Nothing}
+air = Compartment{compartmentName = Air, compartmentSub = Nothing}
 
 co2Flow :: BiosphereFlow
 co2Flow =

--- a/test/ProjectRegionalSpec.hs
+++ b/test/ProjectRegionalSpec.hs
@@ -11,7 +11,10 @@ import Test.Hspec
 import Method.Mapping (MatchStrategy (..), projectRegionalResourceFlows)
 import Method.Types (Compartment (..), FlowDirection (..), MethodCF (..))
 import SynonymDB (BridgeDirection (..), SynEdge (..), buildFromEdges, buildFromPairs)
-import Types (BiosphereFlow (..))
+import Types (
+    BiosphereFlow (..),
+    Medium (..),
+ )
 import qualified Types as VT
 
 mkUUID :: Integer -> UUID
@@ -40,7 +43,7 @@ mkResourceFlow i name =
         , bfSynonyms = M.empty
         , bfCAS = Nothing
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (VT.Compartment "natural resource" Nothing)
+        , bfCompartment = Just (VT.Compartment NaturalResource Nothing)
         }
 
 -- A projection nulls the CF's consumer location (it becomes a GLOBAL entry) and
@@ -97,7 +100,7 @@ spec = describe "projectRegionalResourceFlows" $ do
             cfGeneric = mkLocatedCF "river water" 42.95 Nothing
             rowRelease =
                 (mkResourceFlow 18 "Water, river, RoW")
-                    { bfCompartment = Just (VT.Compartment "water" Nothing)
+                    { bfCompartment = Just (VT.Compartment Water Nothing)
                     }
             flows = M.fromList [(bfId f, f) | f <- [baseFlow, rowRelease]]
         projected (projectRegionalResourceFlows inSynDB flows [(cfFR, Just (baseFlow, BySynonym)), (cfGeneric, Just (baseFlow, BySynonym))])
@@ -114,12 +117,12 @@ spec = describe "projectRegionalResourceFlows" $ do
         projected (projectRegionalResourceFlows synDB flows [(airCF, Nothing), (cfGeneric, Just (baseFlow, BySynonym))])
             `shouldNotContain` [("Water, river, RoW", Nothing, 42.95)]
 
-    it "derives the medium across a 'medium/sub' category, so a slash-encoded resource flow still projects" $ do
-        let frFlowSlashed =
+    it "projects a resource flow that names a subcompartment as well as its medium" $ do
+        let frFlowSubbed =
                 (mkResourceFlow 13 "Water, river, FR")
-                    { bfCompartment = Just (VT.Compartment "natural resource/in water" Nothing)
+                    { bfCompartment = Just (VT.Compartment VT.NaturalResource (Just "in water"))
                     }
-        runWith [baseFlow, frFlowSlashed] `shouldContain` [frProjection]
+        runWith [baseFlow, frFlowSubbed] `shouldContain` [frProjection]
 
     it "dedups colliding located CFs deterministically — higher value wins, order-independent" $ do
         let cfLo = mkLocatedCF "river water" 6.98 (Just "FR")
@@ -159,11 +162,11 @@ spec = describe "projectRegionalResourceFlows" $ do
                     }
             waterFR =
                 (mkResourceFlow 20 "Water, FR")
-                    { bfCompartment = Just (VT.Compartment "water" Nothing)
+                    { bfCompartment = Just (VT.Compartment Water Nothing)
                     }
             bareWater =
                 (mkResourceFlow 21 "Water")
-                    { bfCompartment = Just (VT.Compartment "water" Nothing)
+                    { bfCompartment = Just (VT.Compartment Water Nothing)
                     }
         projected
             ( projectRegionalResourceFlows
@@ -180,11 +183,11 @@ spec = describe "projectRegionalResourceFlows" $ do
                     }
             so2FR =
                 (mkResourceFlow 22 "Sulfur dioxide, FR")
-                    { bfCompartment = Just (VT.Compartment "air" Nothing)
+                    { bfCompartment = Just (VT.Compartment Air Nothing)
                     }
             bareSo2 =
                 (mkResourceFlow 23 "Sulfur dioxide")
-                    { bfCompartment = Just (VT.Compartment "air" Nothing)
+                    { bfCompartment = Just (VT.Compartment Air Nothing)
                     }
         projected
             ( projectRegionalResourceFlows

--- a/test/ProxyEdgeSpec.hs
+++ b/test/ProxyEdgeSpec.hs
@@ -20,7 +20,10 @@ import Method.Mapping (
  )
 import Method.Types (CFFamily (..), Compartment (..), FlowDirection (..), MethodCF (..))
 import qualified SubstanceRegistry as SR
-import Types (BiosphereFlow (..))
+import Types (
+    BiosphereFlow (..),
+    Medium (..),
+ )
 import qualified Types as VT
 
 mkUUID :: Integer -> UUID
@@ -49,7 +52,7 @@ mkFlow i name cas =
         , bfSynonyms = M.empty
         , bfCAS = cas
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (VT.Compartment "water" Nothing)
+        , bfCompartment = Just (VT.Compartment Water Nothing)
         }
 
 nameKey :: Text -> SR.SubstanceKey

--- a/test/RegionFallbackSpec.hs
+++ b/test/RegionFallbackSpec.hs
@@ -11,7 +11,10 @@ import Test.Hspec
 import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, cfValue, lookupCFForFlow)
 import Method.Types (CFFamily (..), Compartment (..), EnergyDensity (..), EnergyDensityMap, FlowDirection (..), MethodCF (..), extractLocationSuffix, lookupEnergyDensity)
 import SynonymDB (normalizeName)
-import Types (BiosphereFlow (..))
+import Types (
+    BiosphereFlow (..),
+    Medium (..),
+ )
 import qualified Types as VT
 
 mkUUID :: Integer -> UUID
@@ -40,7 +43,7 @@ mkFlow i name =
         , bfSynonyms = M.empty
         , bfCAS = Nothing
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (VT.Compartment "air" Nothing)
+        , bfCompartment = Just (VT.Compartment Air Nothing)
         }
 
 {- | Tables holding a name-matched CF for a base substance (no region tag), the

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -30,6 +30,7 @@ import Types (
     Database (..),
     Indexes (..),
     LocationSource (..),
+    Medium (..),
     SparseTriple (..),
     Unit (..),
     emptyProductIndex,
@@ -73,7 +74,7 @@ testFlow =
         , bfSynonyms = M.empty
         , bfCAS = Nothing
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (VT.Compartment "air" Nothing)
+        , bfCompartment = Just (VT.Compartment Air Nothing)
         }
 
 mkActivity :: Text -> Activity

--- a/test/ServiceSpec.hs
+++ b/test/ServiceSpec.hs
@@ -138,15 +138,15 @@ spec = do
     -- -----------------------------------------------------------------------
     describe "isResourceExtraction" $ do
         it "detects natural resource category" $ do
-            let flow = mkBioFlow "natural resource"
+            let flow = mkBioFlow NaturalResource
             isResourceExtraction flow `shouldBe` True
 
         it "detects resource category prefix" $ do
-            let flow = mkBioFlow "resource"
+            let flow = mkBioFlow NaturalResource
             isResourceExtraction flow `shouldBe` True
 
         it "returns False for air emission" $ do
-            let flow = mkBioFlow "air"
+            let flow = mkBioFlow Air
             isResourceExtraction flow `shouldBe` False
     -- Technosphere flows can't reach this function under the new type system.
 
@@ -262,7 +262,7 @@ spec = do
 -- Helpers
 -- ---------------------------------------------------------------------------
 
-mkBioFlow :: Text -> BiosphereFlow
+mkBioFlow :: VT.Medium -> BiosphereFlow
 mkBioFlow cat =
     BiosphereFlow
         { bfId = nil

--- a/test/SharedCASCoverageSpec.hs
+++ b/test/SharedCASCoverageSpec.hs
@@ -38,7 +38,10 @@ import Method.ParserSimaPro (parseSimaProMethodCSVBytes)
 import Method.Types (Compartment (..), FlowDirection (..), Location (..), Medium (..), Method (..), MethodCF (..), MethodCollection (..))
 import SubstanceRegistry (CASNumber (..))
 import SynonymDB (buildFromPairs, emptySynonymDB, normalizeName)
-import Types (BiosphereFlow (..))
+import Types (
+    BiosphereFlow (..),
+    Medium (..),
+ )
 import qualified Types as VT
 import UnitConversion (defaultUnitConfig)
 
@@ -53,7 +56,7 @@ waterCAS :: Text
 waterCAS = "7732-18-5"
 
 -- bfUnitId = mkUUID 0 with an empty UnitDB ⇒ identity unit conversion.
-mkWaterFlow :: Integer -> Text -> Text -> BiosphereFlow
+mkWaterFlow :: Integer -> Text -> VT.Medium -> BiosphereFlow
 mkWaterFlow i name medium =
     BiosphereFlow
         { bfId = mkUUID i
@@ -82,9 +85,9 @@ mkWaterCF name medium dir val =
 
 -- Real ecoinvent flow names (CAS 7732-18-5).
 river, cooling, emWater :: BiosphereFlow
-river = mkWaterFlow 1 "Water, river" "natural resource"
-cooling = mkWaterFlow 2 "Water, cooling, unspecified natural origin" "natural resource"
-emWater = mkWaterFlow 3 "Water" "water"
+river = mkWaterFlow 1 "Water, river" NaturalResource
+cooling = mkWaterFlow 2 "Water, cooling, unspecified natural origin" NaturalResource
+emWater = mkWaterFlow 3 "Water" Water
 
 allFlows :: [BiosphereFlow]
 allFlows = [river, cooling, emWater]
@@ -181,7 +184,7 @@ mkMethane i name =
         , bfSynonyms = M.empty
         , bfCAS = Just methaneCAS
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (VT.Compartment "air" Nothing)
+        , bfCompartment = Just (VT.Compartment Air Nothing)
         }
 
 methaneNonFossil, methaneFossil :: BiosphereFlow
@@ -288,7 +291,7 @@ mkAirFlow i name sub =
         , bfSynonyms = M.empty
         , bfCAS = Nothing
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (VT.Compartment "air" (if sub == "" then Nothing else Just sub))
+        , bfCompartment = Just (VT.Compartment Air (if sub == "" then Nothing else Just sub))
         }
 
 mkAirCF :: Text -> Text -> Double -> MethodCF

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -46,6 +46,7 @@ import Types (
     DeclaredShare (..),
     Exchange (..),
     LocationSource (..),
+    Medium (..),
     NativeActivityType (..),
     Pedigree (..),
     SimpleDatabase (..),
@@ -1299,7 +1300,7 @@ spec = do
             length wastes `shouldBe` 0
             map bioDirection bios `shouldBe` [Emission]
             map bfCompartment (M.elems bioFlows)
-                `shouldBe` [Just (Compartment "waste" Nothing)]
+                `shouldBe` [Just (Compartment Waste Nothing)]
             M.size wasteFlows `shouldBe` 0
 
         it "parses location from process name {XX} pattern" $ do

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -59,6 +59,7 @@ import Types (
     WasteFlowDB,
     activityDeclaredShares,
     activityReferenceShare,
+    exchangeAmount,
     exchangeComment,
     exchangeFlowId,
     exchangeIsInput,
@@ -459,6 +460,47 @@ parseSummedAmountCSV = withSystemTempFile "summed-amount-test.csv" $ \path handl
     hClose handle
     parseOrFail defaultUnitConfig path
 
+{- | A block with one input at zero and one above it, plus an emission at zero:
+the two sides of the file that used to be read by two different rules.
+-}
+zeroAmountTestCSV :: BS.ByteString
+zeroAmountTestCSV =
+    BS.intercalate
+        "\r\n"
+        [ "{SimaPro 9.6.0.1}"
+        , "{CSV separator: semicolon}"
+        , "{Decimal separator: ,}"
+        , ""
+        , "Process"
+        , ""
+        , "Category type"
+        , "material"
+        , ""
+        , "Process name"
+        , "Blend with a disabled input"
+        , ""
+        , "Type"
+        , "Unit process"
+        , ""
+        , "Products"
+        , "Blend {GLO} U;kg;1;100;not defined;material;"
+        , ""
+        , "Materials/fuels"
+        , "Filler {GLO} U;kg;0,4;Undefined;;;;;;"
+        , "Additive, switched off {GLO} U;kg;0;Undefined;;;;;;"
+        , ""
+        , "Emissions to air"
+        , "Carbon dioxide;;kg;0;Undefined;;;;"
+        , ""
+        , "End"
+        ]
+
+parseZeroAmountCSV :: IO ([Activity], M.Map UUID TechnosphereFlow, M.Map UUID BiosphereFlow, M.Map UUID WasteFlow, M.Map UUID Unit)
+parseZeroAmountCSV = withSystemTempFile "zero-amount-test.csv" $ \path handle -> do
+    BS.hPut handle zeroAmountTestCSV
+    hClose handle
+    parseOrFail defaultUnitConfig path
+
 -- Helper: get all tech input amounts
 techInputAmounts :: Activity -> [Double]
 techInputAmounts act =
@@ -805,6 +847,21 @@ spec = do
             let mix = head activities
             refProductAmount mix `shouldBe` Just 1.0
             sum (techInputAmounts mix) `shouldSatisfy` (\x -> abs (x - 1.0) < 1e-9)
+
+    describe "SimaPro rows with a zero amount" $ do
+        it "keeps an input the author switched off" $ do
+            (activities, _, _, _, _) <- parseZeroAmountCSV
+            let blend = findByName "Blend with a disabled input" activities
+            techInputAmounts blend `shouldMatchList` [0.4, 0.0]
+
+        it "reads an input at zero by the same rule as an emission at zero" $ do
+            (activities, _, _, _, _) <- parseZeroAmountCSV
+            let blend = findByName "Blend with a disabled input" activities
+                zeroed = [e | e <- exchanges blend, exchangeAmount e == 0]
+            -- One switched-off input and one emission at zero. The parser used
+            -- to drop the first and keep the second, reading one file by two
+            -- rules and losing what the author wrote.
+            length zeroed `shouldBe` 2
 
     describe "SimaPro database-level parameters" $ do
         it "resolves database input params in exchange amounts" $ do

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -506,13 +506,13 @@ spec = describe "SimaPro.Writer round-trip" $ do
 
     describe "checkSimaProExportable (emission-medium guard)" $ do
         it "accepts air / water / soil emissions" $
-            checkSimaProExportable (emissionDb (Compartment Air Nothing))
+            checkSimaProExportable (emissionDb (Just (Compartment Air Nothing)))
                 `shouldBe` Right ()
 
         it "rejects an emission whose medium has no faithful SimaPro section" $
             -- A "raw" medium would otherwise be silently filed under
             -- "Emissions to air" and re-parse as air; reject it loudly instead.
-            checkSimaProExportable (emissionDb (Compartment NaturalResource Nothing))
+            checkSimaProExportable (emissionDb (Just (Compartment NaturalResource Nothing)))
                 `shouldSatisfy` either (const True) (const False)
 
         -- An inventory indicator is neither an emission to a medium nor an
@@ -521,7 +521,7 @@ spec = describe "SimaPro.Writer round-trip" $ do
         -- "Emissions to air" it would re-parse as an emission to air, and the
         -- guard alone would refuse every database carrying one.
         it "accepts an inventory indicator and files it under Final waste flows" $ do
-            let db = emissionDb (Compartment InventoryIndicator (Just "waste"))
+            let db = emissionDb (Just (Compartment InventoryIndicator (Just "waste")))
             checkSimaProExportable db `shouldBe` Right ()
             case serializeSimaProCSV defaultWriterConfig db of
                 Left err -> expectationFailure (T.unpack err)
@@ -530,8 +530,20 @@ spec = describe "SimaPro.Writer round-trip" $ do
                         `shouldBe` ["Some emission;waste;kg;0.5;Undefined;;;;;;"]
                     firstRowUnder out "Emissions to air" `shouldBe` []
 
+        -- A flow the map knows but that records no compartment keeps its row,
+        -- so it must keep a section. Dropping the section drops the pair, and
+        -- the export loses the exchange with the check still reporting success.
+        it "files an emission whose flow records no compartment under air" $ do
+            let db = emissionDb Nothing
+            checkSimaProExportable db `shouldBe` Right ()
+            case serializeSimaProCSV defaultWriterConfig db of
+                Left err -> expectationFailure (T.unpack err)
+                Right out ->
+                    firstRowUnder out "Emissions to air"
+                        `shouldBe` ["Some emission;;kg;0.5;Undefined;;;;;;"]
+
         it "accepts a final waste flow, whose medium is the section's own name" $
-            checkSimaProExportable (emissionDb (Compartment Waste Nothing))
+            checkSimaProExportable (emissionDb (Just (Compartment Waste Nothing)))
                 `shouldBe` Right ()
 
     -- This format has no waste axis of its own, so a waste exchange from
@@ -660,12 +672,12 @@ testUUID n = UUID.fromWords n 0x4000 0x8000 1
 Used to exercise 'checkSimaProExportable': air/water/soil pass, anything else is
 rejected.
 -}
-emissionDb :: Compartment -> SimpleDatabase
+emissionDb :: Maybe Compartment -> SimpleDatabase
 emissionDb comp =
     SimpleDatabase
         { sdbActivities = M.singleton (actU, prodU) act
         , sdbTechFlows = M.singleton prodU (TechnosphereFlow prodU "thing" unitU M.empty Nothing Nothing)
-        , sdbBioFlows = M.singleton bioU (BiosphereFlow bioU "Some emission" unitU M.empty Nothing Nothing (Just comp))
+        , sdbBioFlows = M.singleton bioU (BiosphereFlow bioU "Some emission" unitU M.empty Nothing Nothing comp)
         , sdbWasteFlows = M.empty
         , sdbUnits = M.singleton unitU (Unit unitU "kg" "kg" "")
         }

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -501,18 +501,18 @@ spec = describe "SimaPro.Writer round-trip" $ do
         -- medium, and the section is what the writer has to find it again by.
         let (_, _, bioFlows, wasteFlows, _) = original
         map bfCompartment (M.elems bioFlows)
-            `shouldBe` [Just (Compartment "waste" Nothing)]
+            `shouldBe` [Just (Compartment Waste Nothing)]
         M.size wasteFlows `shouldBe` 0
 
     describe "checkSimaProExportable (emission-medium guard)" $ do
         it "accepts air / water / soil emissions" $
-            checkSimaProExportable (emissionDb (Compartment "air" Nothing))
+            checkSimaProExportable (emissionDb (Compartment Air Nothing))
                 `shouldBe` Right ()
 
         it "rejects an emission whose medium has no faithful SimaPro section" $
             -- A "raw" medium would otherwise be silently filed under
             -- "Emissions to air" and re-parse as air; reject it loudly instead.
-            checkSimaProExportable (emissionDb (Compartment "raw" Nothing))
+            checkSimaProExportable (emissionDb (Compartment NaturalResource Nothing))
                 `shouldSatisfy` either (const True) (const False)
 
         -- An inventory indicator is neither an emission to a medium nor an
@@ -521,7 +521,7 @@ spec = describe "SimaPro.Writer round-trip" $ do
         -- "Emissions to air" it would re-parse as an emission to air, and the
         -- guard alone would refuse every database carrying one.
         it "accepts an inventory indicator and files it under Final waste flows" $ do
-            let db = emissionDb (Compartment "inventory indicator" (Just "waste"))
+            let db = emissionDb (Compartment InventoryIndicator (Just "waste"))
             checkSimaProExportable db `shouldBe` Right ()
             case serializeSimaProCSV defaultWriterConfig db of
                 Left err -> expectationFailure (T.unpack err)
@@ -531,7 +531,7 @@ spec = describe "SimaPro.Writer round-trip" $ do
                     firstRowUnder out "Emissions to air" `shouldBe` []
 
         it "accepts a final waste flow, whose medium is the section's own name" $
-            checkSimaProExportable (emissionDb (Compartment "waste" Nothing))
+            checkSimaProExportable (emissionDb (Compartment Waste Nothing))
                 `shouldBe` Right ()
 
     -- This format has no waste axis of its own, so a waste exchange from
@@ -957,7 +957,7 @@ guardDb alloc ntype exs =
                 , (gMat, TechnosphereFlow gMat "some material" gUnit M.empty Nothing Nothing)
                 ]
         , sdbBioFlows =
-            M.singleton gBio (BiosphereFlow gBio "an emission" gUnit M.empty Nothing Nothing (Just (Compartment "air" Nothing)))
+            M.singleton gBio (BiosphereFlow gBio "an emission" gUnit M.empty Nothing Nothing (Just (Compartment Air Nothing)))
         , sdbWasteFlows = M.empty
         , sdbUnits = M.singleton gUnit (Unit gUnit "kg" "kg" "")
         }

--- a/test/SubBlindCFSpec.hs
+++ b/test/SubBlindCFSpec.hs
@@ -10,7 +10,10 @@ import Test.Hspec
 
 import Method.Mapping (MatchStrategy (..), buildMethodTables, cfValue, lookupCFForFlow)
 import Method.Types (CFFamily (..), Compartment (..), FlowDirection (..), MethodCF (..))
-import Types (BiosphereFlow (..))
+import Types (
+    BiosphereFlow (..),
+    Medium (..),
+ )
 import qualified Types as VT
 
 mkUUID :: Integer -> UUID
@@ -39,7 +42,7 @@ mkFlow i name sub =
         , bfSynonyms = M.empty
         , bfCAS = Nothing
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (VT.Compartment "resource" sub)
+        , bfCompartment = Just (VT.Compartment NaturalResource sub)
         }
 
 score :: [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> BiosphereFlow -> Maybe Double

--- a/test/UnitVariantCFSpec.hs
+++ b/test/UnitVariantCFSpec.hs
@@ -20,7 +20,10 @@ import Test.Hspec
 
 import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, cfValue, lookupCFForFlow)
 import Method.Types (CFFamily (..), Compartment (..), FlowDirection (..), MethodCF (..))
-import Types (BiosphereFlow (..))
+import Types (
+    BiosphereFlow (..),
+    Medium (..),
+ )
 import qualified Types as VT
 
 mkUUID :: Integer -> UUID
@@ -56,7 +59,7 @@ mkFlowAt i name sub =
         , bfSynonyms = M.empty
         , bfCAS = Nothing
         , bfSubstanceId = Nothing
-        , bfCompartment = Just (VT.Compartment "resource" sub)
+        , bfCompartment = Just (VT.Compartment NaturalResource sub)
         }
 
 lookupFor :: MethodTables -> BiosphereFlow -> Maybe Double

--- a/test/WasteTreatmentSignSpec.hs
+++ b/test/WasteTreatmentSignSpec.hs
@@ -137,7 +137,7 @@ producer waste =
         }
 
 co2Flow :: BiosphereFlow
-co2Flow = BiosphereFlow co2 "carbon dioxide" kgU M.empty Nothing Nothing (Just (Compartment "air" Nothing))
+co2Flow = BiosphereFlow co2 "carbon dioxide" kgU M.empty Nothing Nothing (Just (Compartment Air Nothing))
 
 wasteFlowDB :: M.Map UUID WasteFlow
 wasteFlowDB = M.singleton wW (WasteFlow wW "waste W" kgU M.empty Nothing Nothing)


### PR DESCRIPTION
Builds on #408, whose commit is the first of the two here. Merge that one first
and this diff shrinks to its own commit.

Every database format names a compartment's medium its own way. An EcoSpold 2
file writes `natural resource`, an EcoSpold 1 file writes `resource`, a SimaPro
file heads the section `Raw`, and ILCD says `Resources` in a category path.
Each parser stored the word it read, so two databases loaded side by side
described one physical flow with two different strings, and everything that
needed them to agree carried its own list of spellings: `normalizeMedium`
folded one way, `canonicalMedium` folded the other, and four more places each
accepted their own subset of `{raw, resource, resources, natural resource}`.
The symptom that surfaced it was an ILCD export coming back with 741 flows
re-filed, but the export was only reporting what storage already disagreed
about.

The vocabulary turns out to be closed. Measured across the four formats it is
seven values, and the type declaration already said so in a comment:

    compartmentName :: !Text -- air | water | soil | natural resource

So it is a `Medium` now. `parseMedium` reads any spelling and names the string
it cannot place instead of inventing a medium from it; each writer renders the
value in its own format's vocabulary. That last point is what makes a round
trip stable, and EcoSpold 1 is the case that proves it: that format hashes the
`category` attribute into the flow's identity, so writing the canonical word
there would give our own export a different identity from the file it came
from. Its writer emits `resource`, the word EcoSpold 1 uses, and the
idempotence test in this repository fails without it.

The subcompartment stays text. That vocabulary is genuinely open, hundreds of
values, and nothing is gained by pretending otherwise.

Three things the type removes rather than repairs:

- a compartment can no longer carry a `medium/sub` tail, so the category
  splitting in `projectRegionalResourceFlows` goes;
- a biosphere flow can no longer be filed under EcoSpold 1's waste-routing
  marker, so the export check that guarded that collision goes with the test
  that exercised it;
- the two loose medium constants become constructors, and a handful of
  `T.toLower`-and-compare sites become equality on a value.

Several specs moved the foreign vocabulary from the flow to the characterization
factor, which is where it still lives: the method side is text until its own
`Compartment` follows, and the compartment map is what bridges the two. That
is a separate change, and it is where the measurable cost is, the factor tables
being where the string comparisons happen in bulk.

Two consequences a user sees. An inventory from a SimaPro or EcoSpold 1 source
reports `natural resource` where it reported `resource`. And the elementary
flows of such a database change identity, the medium being hashed into it, so a
script holding a flow UUID from one of them needs to look it up again. Cache
signature 28 rebuilds every cache on the next load.

The suite passes, 2490 examples.

