### PR TITLE
Give each EcoSpold 1 input the supplier its own number names

### DIFF
--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -206,12 +206,12 @@ mergeBioFlows a b =
         , bfCAS = bfCAS a <|> bfCAS b
         }
 
--- | 9-element unzip helper (Data.List ships 7-tuple as max).
-unzip9 :: [(a, b, c, d, e, f, g, h, i)] -> ([a], [b], [c], [d], [e], [f], [g], [h], [i])
-unzip9 = foldr step ([], [], [], [], [], [], [], [], [])
+-- | 8-element unzip helper (Data.List ships 7-tuple as max).
+unzip8 :: [(a, b, c, d, e, f, g, h)] -> ([a], [b], [c], [d], [e], [f], [g], [h])
+unzip8 = foldr step ([], [], [], [], [], [], [], [])
   where
-    step (a, b, c, d, e, f, g, h, i) (as, bs, cs, ds, es, fs, gs, hs, is) =
-        (a : as, b : bs, c : cs, d : ds, e : es, f : fs, g : gs, h : hs, i : is)
+    step (a, b, c, d, e, f, g, h) (as, bs, cs, ds, es, fs, gs, hs) =
+        (a : as, b : bs, c : cs, d : ds, e : es, f : fs, g : gs, h : hs)
 
 {- |
 Schema signature of the cache payload.
@@ -681,9 +681,9 @@ contradicts the declared location is reported, not overruled.
 Unlinked exchanges stay unlinked so that cross-DB linking can resolve them.
 Location aliases map wrongLocation → correctLocation (e.g., "ENTSO" → "ENTSO-E")
 -}
-fixEcoSpold1ActivityLinks :: M.Map T.Text T.Text -> DatasetNumberIndex -> M.Map UUID.UUID Int -> SimpleDatabase -> IO SimpleDatabase
-fixEcoSpold1ActivityLinks locationAliases dsIndex supplierLinks db = do
-    let ctx = ecoSpold1LinkContext locationAliases dsIndex supplierLinks db
+fixEcoSpold1ActivityLinks :: M.Map T.Text T.Text -> DatasetNumberIndex -> SimpleDatabase -> IO SimpleDatabase
+fixEcoSpold1ActivityLinks locationAliases dsIndex db = do
+    let ctx = ecoSpold1LinkContext locationAliases dsIndex db
         (fixedActivities, summary) = fixAllActivities ctx (sdbActivities db)
     reportProgress Info $
         printf
@@ -745,21 +745,19 @@ data ExchangeLinkContext = ExchangeLinkContext
     , elcSupplierIndex :: !SupplierIndex
     , elcNameIndex :: !SupplierByNameWithLocation
     , elcDatasetIndex :: !DatasetNumberIndex
-    , elcSupplierLinks :: !(M.Map UUID.UUID Int)
     , elcFlowDB :: !TechFlowDB
     , elcActivities :: !ActivityMap
     }
 
 -- | The lookup tables 'fixAllActivities' links an EcoSpold1 database with.
-ecoSpold1LinkContext :: M.Map T.Text T.Text -> DatasetNumberIndex -> M.Map UUID.UUID Int -> SimpleDatabase -> ExchangeLinkContext
-ecoSpold1LinkContext locationAliases dsIndex supplierLinks db =
+ecoSpold1LinkContext :: M.Map T.Text T.Text -> DatasetNumberIndex -> SimpleDatabase -> ExchangeLinkContext
+ecoSpold1LinkContext locationAliases dsIndex db =
     ExchangeLinkContext
         { elcLocationAliases = locationAliases
         , elcSupplierIndex = buildSupplierIndex (sdbActivities db) (sdbTechFlows db)
         , -- Name-only index, with location, for exchanges missing the location attribute
           elcNameIndex = buildSupplierIndexByNameWithLocation (sdbActivities db) (sdbTechFlows db)
         , elcDatasetIndex = dsIndex
-        , elcSupplierLinks = supplierLinks
         , elcFlowDB = sdbTechFlows db
         , elcActivities = sdbActivities db
         }
@@ -786,7 +784,7 @@ Unlinked exchanges stay unlinked for cross-DB resolution.
 Returns (fixed exchange, UnlinkedSummary)
 -}
 fixExchangeLink :: ExchangeLinkContext -> Activity -> Exchange -> (Exchange, UnlinkedSummary)
-fixExchangeLink ExchangeLinkContext{..} consumer ex@TechnosphereExchange{techFlowId = fid, techRole = role, techLocation = loc}
+fixExchangeLink ExchangeLinkContext{..} consumer ex@TechnosphereExchange{techFlowId = fid, techRole = role, techSupplierClaim = claim, techLocation = loc}
     | role == Input || role == ReferenceInput =
         let linked overrides actUUID prodUUID =
                 ( ex{techFlowId = prodUUID, techActivityLinkId = actUUID}
@@ -798,7 +796,7 @@ fixExchangeLink ExchangeLinkContext{..} consumer ex@TechnosphereExchange{techFlo
          in case M.lookup fid elcFlowDB of
                 Just flow ->
                     -- Tier 1: dataset-number lookup with name validation
-                    case M.lookup fid elcSupplierLinks >>= \dsNum -> (,) dsNum <$> M.lookup dsNum elcDatasetIndex of
+                    case claimedNumber claim >>= \dsNum -> (,) dsNum <$> M.lookup dsNum elcDatasetIndex of
                         Just (dsNum, (actUUID, prodUUID))
                             | Just supplierFlow <- M.lookup prodUUID elcFlowDB
                             , normalizeText (tfName supplierFlow) == normalizeText (tfName flow) ->
@@ -1145,6 +1143,14 @@ fixExchangeLinkByName _ _ _ _ _ ex@BiosphereExchange{} = (ex, mempty)
 -- Waste link resolution is deferred to the cross-DB linker path.
 fixExchangeLinkByName _ _ _ _ _ ex@WasteExchange{} = (ex, mempty)
 
+-- | The dataset number a claim names, when it names one.
+claimedNumber :: SupplierClaim -> Maybe Int
+claimedNumber = \case
+    ClaimByDatasetNumber n -> Just n
+    ClaimByProduct -> Nothing
+    ClaimById _ -> Nothing
+    ClaimByName _ -> Nothing
+
 -- | The supplier activity a claim names, when it names one by name.
 claimedName :: SupplierClaim -> Maybe T.Text
 claimedName = \case
@@ -1264,14 +1270,13 @@ loadEcoSpoldDirectory opts dir = do
             (firstErr : _) -> return $ Left firstErr
             [] -> do
                 let successResults = rights results
-                let (procMaps, techFlowMaps, bioFlowMaps, wasteFlowMaps, unitMaps, rawFlowCounts, rawUnitCounts, dsIndexes, supplierLinksLists) = unzip9 successResults
+                let (procMaps, techFlowMaps, bioFlowMaps, wasteFlowMaps, unitMaps, rawFlowCounts, rawUnitCounts, dsIndexes) = unzip8 successResults
                 let !finalProcMap = M.unions procMaps
                 let !finalTechFlowMap = MS.unionsWith mergeTechFlows techFlowMaps
                 let !finalBioFlowMap = MS.unionsWith mergeBioFlows bioFlowMaps
                 let !finalWasteFlowMap = M.unions wasteFlowMaps
                 let !finalUnitMap = M.unions unitMaps
                 let !finalDsIndex = M.unions dsIndexes
-                let !finalSupplierLinks = M.unions supplierLinksLists
 
                 endTime <- getCurrentTime
                 let totalDuration = realToFrac $ diffUTCTime endTime startTime
@@ -1303,11 +1308,11 @@ loadEcoSpoldDirectory opts dir = do
                 -- For EcoSpold1: fix activity links using supplier lookup table
                 let simpleDb = SimpleDatabase finalProcMap finalTechFlowMap finalBioFlowMap finalWasteFlowMap finalUnitMap
                 if isEcoSpold1
-                    then Right <$> fixEcoSpold1ActivityLinks locationAliases finalDsIndex finalSupplierLinks simpleDb
+                    then Right <$> fixEcoSpold1ActivityLinks locationAliases finalDsIndex simpleDb
                     else return $ Right simpleDb
 
     -- Process one worker's share of files
-    processWorker :: UTCTime -> Bool -> (Int, [FilePath]) -> IO (Either T.Text (ActivityMap, TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB, Int, Int, DatasetNumberIndex, M.Map UUID.UUID Int))
+    processWorker :: UTCTime -> Bool -> (Int, [FilePath]) -> IO (Either T.Text (ActivityMap, TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB, Int, Int, DatasetNumberIndex))
     processWorker _startTime isEcoSpold1 (workerNum, workerFiles) = do
         workerStartTime <- getCurrentTime
         reportProgress Info $ printf "Worker %d started: processing %d files" workerNum (length workerFiles)
@@ -1334,7 +1339,6 @@ loadEcoSpoldDirectory opts dir = do
             wasteLists = map pdWasteFlows okResults
             unitLists = map pdUnits okResults
             dsNums = map pdDatasetNumber okResults
-            supplierLinksList = map pdSupplierLinks okResults
         let !allTechs = concat techLists
         let !allBios = concat bioLists
         let !allWastes = concat wasteLists
@@ -1353,7 +1357,6 @@ loadEcoSpoldDirectory opts dir = do
                 let !dsIndex =
                         M.fromList
                             [(n, key) | (n, Right (key, _)) <- zip dsNums procEntries, n /= 0]
-                let !allSupplierLinks = M.unions supplierLinksList
 
                 workerEndTime <- getCurrentTime
                 let workerDuration = realToFrac $ diffUTCTime workerEndTime workerStartTime
@@ -1371,7 +1374,7 @@ loadEcoSpoldDirectory opts dir = do
                         (formatDuration workerDuration)
                         filesPerSec
 
-                return $ Right (procMap, techFlowMap, bioFlowMap, wasteFlowMap, unitMap, rawFlowCount, rawUnitCount, dsIndex, allSupplierLinks)
+                return $ Right (procMap, techFlowMap, bioFlowMap, wasteFlowMap, unitMap, rawFlowCount, rawUnitCount, dsIndex)
 
     -- Build a single process entry, returning Either for error handling
     buildProcEntry :: Bool -> FilePath -> Activity -> Either T.Text ((UUID, UUID), Activity)
@@ -1420,7 +1423,6 @@ loadSingleEcoSpold1File opts filepath = do
         !dsIndex =
             M.fromList
                 [(pdDatasetNumber r, key) | (r, (key, _)) <- zip results expanded, pdDatasetNumber r /= 0]
-        !supplierLinks = M.unions (map pdSupplierLinks results)
         simpleDb = SimpleDatabase procMap techFlowMap bioFlowMap wasteFlowMap unitMap
 
     let totalTechs = sum (map (length . pdTechFlows) results)
@@ -1431,7 +1433,7 @@ loadSingleEcoSpold1File opts filepath = do
     reportProgress Info $ printf "  Flows: %d tech + %d bio + %d waste (from %d raw)" (M.size techFlowMap) (M.size bioFlowMap) (M.size wasteFlowMap) (totalTechs + totalBios + totalWastes)
     reportProgress Info $ printf "  Units: %d unique (from %d raw)" (M.size unitMap) totalUnits
 
-    Right <$> fixEcoSpold1ActivityLinks locationAliases dsIndex supplierLinks simpleDb
+    Right <$> fixEcoSpold1ActivityLinks locationAliases dsIndex simpleDb
   where
     buildProcEntryFromResult :: Maybe UUID.UUID -> ParsedDataset -> ((UUID.UUID, UUID.UUID), Activity)
     buildProcEntryFromResult fileUUID parsed =

--- a/src/EcoSpold/Common.hs
+++ b/src/EcoSpold/Common.hs
@@ -23,22 +23,21 @@ module EcoSpold.Common (
 import Amount (readAmount)
 import qualified Data.ByteString as BS
 import Data.Char (chr)
-import qualified Data.Map as M
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Read as TR
 import Numeric (showFFloat)
-import Types (Activity, BiosphereFlow, DocSection (..), TechnosphereFlow, UUID, Unit, WasteFlow)
+import Types (Activity, BiosphereFlow, DocSection (..), TechnosphereFlow, Unit, WasteFlow)
 
 {- | One dataset as a reader read it: the activity, the flows and units it
 names, and whatever the reader has to say about the reading.
 
-'pdDatasetNumber' and 'pdSupplierLinks' are EcoSpold 1's: that format numbers
-its datasets and points an exchange at the numbered dataset that supplies it,
-where EcoSpold 2 addresses a supplier by UUID. A reader with nothing to say
-there leaves them empty.
+'pdDatasetNumber' is EcoSpold 1's: that format numbers its datasets, and an
+exchange points at the numbered dataset that supplies it on its own row, where
+EcoSpold 2 addresses a supplier by UUID. A reader with nothing to say there
+leaves it empty.
 -}
 data ParsedDataset = ParsedDataset
     { pdActivity :: !Activity
@@ -47,7 +46,6 @@ data ParsedDataset = ParsedDataset
     , pdWasteFlows :: ![WasteFlow]
     , pdUnits :: ![Unit]
     , pdDatasetNumber :: !Int
-    , pdSupplierLinks :: !(M.Map UUID Int)
     , pdWarnings :: ![Text]
     -- ^ What the reader could not make sense of, for the caller to report.
     }

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -194,7 +194,6 @@ data ParseState = ParseState
     , psPath :: ![BS.ByteString]
     , psContext :: !ElementContext
     , psTextAccum :: ![BS.ByteString]
-    , psSupplierLinks :: !(M.Map UUID Int) -- flowId → supplier dataset number (technosphere inputs)
     , psDocs :: !DatasetDocs -- Provenance the dataset states about itself
     , psCompletedActivities :: ![Either String ParsedDataset]
     }
@@ -217,7 +216,6 @@ initialParseState =
         , psPath = []
         , psContext = Other
         , psTextAccum = []
-        , psSupplierLinks = M.empty
         , psDocs = emptyDatasetDocs
         , psCompletedActivities = []
         }
@@ -472,13 +470,6 @@ closeExchange :: ParseState -> ParseState
 closeExchange state = case psContext state of
     InExchange edata ->
         let (exchange, parsedFlow, unit) = buildExchange (psLocation state) edata
-            !supplierLinks = case exchange of
-                TechnosphereExchange{techRole = Input}
-                    | exNumber edata /= 0 ->
-                        M.insert (exchangeFlowId exchange) (exNumber edata) (psSupplierLinks state)
-                TechnosphereExchange{} -> psSupplierLinks state
-                BiosphereExchange{} -> psSupplierLinks state
-                WasteExchange{} -> psSupplierLinks state
             (techs, bios) = case parsedFlow of
                 ParsedTech tf -> (tf : psTechFlows state, psBioFlows state)
                 ParsedBio bf -> (psTechFlows state, bf : psBioFlows state)
@@ -487,7 +478,6 @@ closeExchange state = case psContext state of
                 , psTechFlows = techs
                 , psBioFlows = bios
                 , psUnits = unit : psUnits state
-                , psSupplierLinks = supplierLinks
                 , psContext = Other
                 }
     InInputGroup _ -> popPath state
@@ -523,7 +513,6 @@ resetDataset state =
         , psUnits = []
         , psContext = Other
         , psTextAccum = []
-        , psSupplierLinks = M.empty
         , psDocs = emptyDatasetDocs
         }
 
@@ -736,7 +725,6 @@ buildResult st =
                   pdWasteFlows = []
                 , pdUnits = reverse (psUnits st)
                 , pdDatasetNumber = psDatasetNumber st
-                , pdSupplierLinks = psSupplierLinks st
                 , pdWarnings = placeholdersUsed st
                 }
      in -- A file that yields no exchange at all is not a dataset: a stray or

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -1063,7 +1063,6 @@ parseWithXeno xmlContent processId = do
                             , -- This format addresses a supplier by UUID, so it
                               -- numbers no dataset and links none by number.
                               pdDatasetNumber = 0
-                            , pdSupplierLinks = M.empty
                             , pdWarnings = map T.pack (reverse (psWarnings st)) ++ placeholdersUsed st
                             }
 

--- a/test/EcoSpold1WriterSpec.hs
+++ b/test/EcoSpold1WriterSpec.hs
@@ -287,7 +287,7 @@ carrying it has no resolvable dataset number, a dangling link. Distinct from
 danglingLink :: UUID
 danglingLink = read "99999999-0000-4000-8000-000000000099"
 
-{- | All supplier-dataset-number values recorded across a parser round-trip of
+{- | Every supplier dataset number read back across a parser round-trip of
 @sdb@. 'EcoSpold.Parser1.closeExchange' fills 'psSupplierLinks' (the 7th tuple
 slot) for every technosphere input whose @number@ attribute is non-zero, i.e.
 the supplier dataset number the writer must re-emit. A surviving link therefore
@@ -301,7 +301,11 @@ roundTripSupplierLinks sdb =
             case parseAllWithXeno (TE.encodeUtf8 txt) of
                 Left err -> Left err
                 Right results ->
-                    concatMap (\ParsedDataset{pdSupplierLinks = links} -> M.elems links) <$> sequence results
+                    concatMap claimedNumbers <$> sequence results
+  where
+    claimedNumbers :: ParsedDataset -> [Int]
+    claimedNumbers ParsedDataset{pdActivity = act} =
+        [n | TechnosphereExchange{techSupplierClaim = ClaimByDatasetNumber n} <- exchanges act]
 
 -- ---------------------------------------------------------------------------
 -- Order-insensitive observable projection of an activity, for semantic equality

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -148,6 +148,10 @@ es1Xml datasets =
             <> "    </flowData>\n"
             <> "  </dataset>\n"
 
+-- | An input naming the dataset number its supplier is published under.
+buyingDataset :: Int -> Exchange -> Exchange
+buyingDataset n ex = ex{techSupplierClaim = ClaimByDatasetNumber n}
+
 -- | An input linked (non-nil) to producer activity @actId@ producing @prodId@.
 linkedInput :: UUID.UUID -> UUID.UUID -> Exchange
 linkedInput actId prodId = (inputExchange prodId "GLO"){techActivityLinkId = actId}
@@ -628,11 +632,11 @@ spec = do
             wheatLink = inputLinksIn . sdbActivities
 
         it "leaves an unlocated input unlinked when the product name covers several geographies" $ do
-            fixed <- fixEcoSpold1ActivityLinks M.empty M.empty M.empty (simpleDBOf [wheatFR, wheatDE, bread] flowNames)
+            fixed <- fixEcoSpold1ActivityLinks M.empty M.empty (simpleDBOf [wheatFR, wheatDE, bread] flowNames)
             wheatLink fixed `shouldBe` [UUID.nil]
 
         it "links an unlocated input when the product name covers one dataset" $ do
-            fixed <- fixEcoSpold1ActivityLinks M.empty M.empty M.empty (simpleDBOf [wheatFR, bread] flowNames)
+            fixed <- fixEcoSpold1ActivityLinks M.empty M.empty (simpleDBOf [wheatFR, bread] flowNames)
             wheatLink fixed `shouldBe` [actUUID1]
 
         -- BAFU 2026 v1 has power plants whose gas input carries the number of
@@ -642,13 +646,37 @@ spec = do
             gasRER = ((actUUID2, flowUUID2), minimalActivity "gas supply" "RER" [refExchange flowUUID2])
             plantDeclaring loc =
                 ( (consumerUUID, breadUUID)
-                , minimalActivity "power plant" "BG" [refExchange breadUUID, inputExchange flowUUID1 loc]
+                , minimalActivity "power plant" "BG" [refExchange breadUUID, buyingDataset 300474 (inputExchange flowUUID1 loc)]
                 )
             gasNames = [(flowUUID1, "Natural gas"), (flowUUID2, "Natural gas"), (breadUUID, "Heat")]
             linkPlantDeclaring loc =
                 let db = simpleDBOf [gasBG, gasRER, plantDeclaring loc] gasNames
-                    ctx = ecoSpold1LinkContext M.empty (M.singleton 300474 (actUUID1, flowUUID1)) (M.singleton flowUUID1 300474) db
+                    ctx = ecoSpold1LinkContext M.empty (M.singleton 300474 (actUUID1, flowUUID1)) db
                  in fixAllActivities ctx (sdbActivities db)
+
+        -- The number is on the row that carries it. Held in one map per
+        -- database keyed by the flow, it said the same thing (the flow
+        -- identifier is minted from that very number), but a reader had to
+        -- know that to trust it.
+        it "gives each consumer of one product the supplier its own number names" $ do
+            let plantBuying n loc =
+                    minimalActivity ("power plant " <> loc) loc [refExchange breadUUID, buyingDataset n (inputExchange flowUUID1 "")]
+                plantBG = ((consumerUUID, breadUUID), plantBuying 1 "BG")
+                plantRER = ((missingActUUID, flowUUID2), plantBuying 2 "RER")
+                db = simpleDBOf [gasBG, gasRER, plantBG, plantRER] gasNames
+                ctx =
+                    ecoSpold1LinkContext
+                        M.empty
+                        (M.fromList [(1, (actUUID1, flowUUID1)), (2, (actUUID2, flowUUID2))])
+                        db
+                (acts, _) = fixAllActivities ctx (sdbActivities db)
+                supplierOf key =
+                    [ link
+                    | Just act <- [M.lookup key acts]
+                    , TechnosphereExchange{techRole = Input, techActivityLinkId = link} <- exchanges act
+                    ]
+            supplierOf (consumerUUID, breadUUID) `shouldBe` [actUUID1]
+            supplierOf (missingActUUID, flowUUID2) `shouldBe` [actUUID2]
 
         it "follows the dataset number over the declared location, and records the override" $ do
             let (acts, summary) = linkPlantDeclaring "RER"


### PR DESCRIPTION
Stacked on #412, itself on #411 and #400. Review and merge in that order.

An EcoSpold 1 input carries the number of the dataset producing it, written on
the input's own row. The parser collected those numbers into one map per
database keyed by the flow, and the linker looked the flow up in it.

That map said the same thing the row does. `generateFlowUUID` mints an
EcoSpold 1 flow identifier from the exchange number first, so the key
determined the value and two inputs naming two different suppliers never shared
an entry. But nothing in the type said so: `Map UUID Int` asserts that a flow
determines a supplier number, which is true here only by a coincidence of how
the identifier is built, three modules away.

**This is a simplification, not a fix.** No behaviour changes, no cached bytes
move, and no signature is bumped. An earlier draft of this PR claimed a
wrong-supplier bug; the review found the flow identity that rules it out.

## What changes

The number has been on the exchange since `SupplierClaim` landed, as
`ClaimByDatasetNumber`. The linker reads it there, from the row it belongs to,
and the parallel channel goes with it:

- `psSupplierLinks` on the parser state;
- `pdSupplierLinks` on the shared parsed-dataset record, which the EcoSpold 2
  reader was filling with an empty map to say it had nothing to put there;
- `elcSupplierLinks` on the linking context;
- `unzip9`, back down to `unzip8`.

A test pins what the map could only imply: two power plants, one product, two
numbers, each linked to the supplier its own row names.

Suite green (2514 examples, 0 failures), fourmolu, hlint.
