### PR TITLE
Give a dataset reading a name and a voice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,13 @@
 ## [Unreleased]
 
 ### Fixed
-- Loading an EcoSpold 1 file now says when the file named neither its activity
-  nor its reference unit. Such a dataset still loads, under a placeholder no
-  reader downstream can tell from a name the file really carried, so a database
-  could show an activity called "Unknown Activity" measured in "UNKNOWN_UNIT"
-  with nothing in the log to say where it came from. The equivalent reader for
-  EcoSpold 2 already said so; this one had nowhere to say it from, and now has.
+- Loading an EcoSpold 1 or EcoSpold 2 file now says when the file named neither
+  its activity nor its reference unit. Such a dataset still loads, under a
+  placeholder no reader downstream can tell from a name the file really
+  carried, so a database could show an activity called "Unknown Activity"
+  measured in "UNKNOWN_UNIT" with nothing in the log to say where it came from.
+  Both readers name the file they were reading when they say it, which the
+  EcoSpold 2 reader did not do for the remarks it already made.
 - An EcoSpold 1 database no longer reports supplier gaps that cannot exist.
   A file of that format files waste with no modelled treatment under a
   category of its own, on an input group, because the format has only four

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 
 ### Fixed
+- Loading an EcoSpold 1 file now says when the file named neither its activity
+  nor its reference unit. Such a dataset still loads, under a placeholder no
+  reader downstream can tell from a name the file really carried, so a database
+  could show an activity called "Unknown Activity" measured in "UNKNOWN_UNIT"
+  with nothing in the log to say where it came from. The equivalent reader for
+  EcoSpold 2 already said so; this one had nowhere to say it from, and now has.
 - An EcoSpold 1 database no longer reports supplier gaps that cannot exist.
   A file of that format files waste with no modelled treatment under a
   category of its own, on an input group, because the format has only four

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -154,7 +154,7 @@ import Database.CrossLinking (
  )
 import Database.MatrixBuild (findProducer)
 import Database.Upload (listDirectoryRecursive)
-import EcoSpold.Common (distributeFiles)
+import EcoSpold.Common (ParsedDataset (..), distributeFiles)
 import EcoSpold.Parser1 (streamParseActivityAndFlowsFromFile1, streamParseAllDatasetsFromFile1)
 import EcoSpold.Parser2 (streamParseActivityAndFlowsFromFile)
 import GHC.Conc (getNumCapabilities)
@@ -844,8 +844,23 @@ defaultLoadOptions unitConfig =
         , loAllocation = Declared
         }
 
--- | Everything one EcoSpold dataset parses to, before it is keyed.
-type ParsedDataset = (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit], Int, M.Map UUID.UUID Int)
+{- | An EcoSpold 2 reading, said in the shape both readers share. That format
+addresses a supplier by UUID rather than by the dataset number EcoSpold 1
+writes, and its reader reports its own remarks at its own edge, so three fields
+stay empty.
+-}
+es2Parsed :: (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]) -> ParsedDataset
+es2Parsed (act, techs, bios, wastes, units) =
+    ParsedDataset
+        { pdActivity = act
+        , pdTechFlows = techs
+        , pdBioFlows = bios
+        , pdWasteFlows = wastes
+        , pdUnits = units
+        , pdDatasetNumber = 0
+        , pdSupplierLinks = M.empty
+        , pdWarnings = []
+        }
 
 {- | Say that an EcoSpold 2 dataset divided into several processes will come
 back as one.
@@ -869,10 +884,13 @@ warnSplitKeyedOnFileName file =
 entry is then keyed on its own reference product.
 -}
 allocateParsed :: LoadOptions -> ParsedDataset -> [ParsedDataset]
-allocateParsed opts (act, techs, bios, wastes, units, dsNum, links) =
-    [ (act', techs, bios, wastes, units, dsNum, links)
-    | act' <- NE.toList (allocate (allocating opts (M.fromList [(unitId u, u) | u <- units])) act)
+allocateParsed opts parsed =
+    [ parsed{pdActivity = act}
+    | act <- NE.toList (allocate (allocating opts unitMap) (pdActivity parsed))
     ]
+  where
+    unitMap :: UnitDB
+    unitMap = M.fromList [(unitId u, u) | u <- pdUnits parsed]
 
 -- | Load SimaPro CSV file
 loadSimaProCSV :: LoadOptions -> FilePath -> IO (Either T.Text SimpleDatabase)
@@ -1124,14 +1142,13 @@ loadEcoSpoldDirectory opts dir = do
         workerStartTime <- getCurrentTime
         reportProgress Info $ printf "Worker %d started: processing %d files" workerNum (length workerFiles)
 
-        -- Parse all files for this worker using appropriate parser.
-        -- Both paths return (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit], Int, M.Map UUID Int).
-        -- For EcoSpold2: dataset number = 0, supplier links = empty. WasteFlows now flow
-        -- through (intermediateExchange classified By-product:Waste).
+        -- Parse all files for this worker using appropriate parser. Both paths
+        -- return a 'ParsedDataset'; EcoSpold 2 addresses its suppliers by UUID
+        -- rather than by dataset number, so it fills neither of those fields.
         let parseFile =
                 if isEcoSpold1
                     then streamParseActivityAndFlowsFromFile1
-                    else fmap (fmap (\(a, ts, bs, ws, us) -> (a, ts, bs, ws, us, 0, M.empty))) . streamParseActivityAndFlowsFromFile
+                    else fmap (fmap es2Parsed) . streamParseActivityAndFlowsFromFile
         workerResults <- mapM parseFile workerFiles
         let paired = zipWith (\f r -> fmap (f,) r) workerFiles workerResults
         let (errs, oks) = partitionEithers paired
@@ -1141,13 +1158,13 @@ loadEcoSpoldDirectory opts dir = do
             (okFiles, okResults) = unzip [(f, r') | (f, rs) <- split, r' <- rs]
         unless isEcoSpold1 $
             mapM_ (warnSplitKeyedOnFileName . fst) (filter ((> 1) . length . snd) split)
-        let procs = [a | (a, _, _, _, _, _, _) <- okResults]
-            techLists = [ts | (_, ts, _, _, _, _, _) <- okResults]
-            bioLists = [bs | (_, _, bs, _, _, _, _) <- okResults]
-            wasteLists = [ws | (_, _, _, ws, _, _, _) <- okResults]
-            unitLists = [us | (_, _, _, _, us, _, _) <- okResults]
-            dsNums = [n | (_, _, _, _, _, n, _) <- okResults]
-            supplierLinksList = [sl | (_, _, _, _, _, _, sl) <- okResults]
+        let procs = map pdActivity okResults
+            techLists = map pdTechFlows okResults
+            bioLists = map pdBioFlows okResults
+            wasteLists = map pdWasteFlows okResults
+            unitLists = map pdUnits okResults
+            dsNums = map pdDatasetNumber okResults
+            supplierLinksList = map pdSupplierLinks okResults
         let !allTechs = concat techLists
         let !allBios = concat bioLists
         let !allWastes = concat wasteLists
@@ -1226,29 +1243,30 @@ loadSingleEcoSpold1File opts filepath = do
             _ -> Nothing
         expanded = map (buildProcEntryFromResult fileUUID) results
         !procMap = M.fromList expanded
-        !techFlowMap = MS.fromListWith mergeTechFlows [(tfId f, f) | (_, techs, _, _, _, _, _) <- results, f <- techs]
-        !bioFlowMap = MS.fromListWith mergeBioFlows [(bfId f, f) | (_, _, bios, _, _, _, _) <- results, f <- bios]
-        !wasteFlowMap = M.fromList [(wfId f, f) | (_, _, _, wastes, _, _, _) <- results, f <- wastes]
-        !unitMap = M.fromList [(unitId u, u) | (_, _, _, _, units, _, _) <- results, u <- units]
+        !techFlowMap = MS.fromListWith mergeTechFlows [(tfId f, f) | r <- results, f <- pdTechFlows r]
+        !bioFlowMap = MS.fromListWith mergeBioFlows [(bfId f, f) | r <- results, f <- pdBioFlows r]
+        !wasteFlowMap = M.fromList [(wfId f, f) | r <- results, f <- pdWasteFlows r]
+        !unitMap = M.fromList [(unitId u, u) | r <- results, u <- pdUnits r]
         !dsIndex =
             M.fromList
-                [(dsNum, key) | ((_, _, _, _, _, dsNum, _), (key, _)) <- zip results expanded, dsNum /= 0]
-        !supplierLinks = M.unions [sl | (_, _, _, _, _, _, sl) <- results]
+                [(pdDatasetNumber r, key) | (r, (key, _)) <- zip results expanded, pdDatasetNumber r /= 0]
+        !supplierLinks = M.unions (map pdSupplierLinks results)
         simpleDb = SimpleDatabase procMap techFlowMap bioFlowMap wasteFlowMap unitMap
 
-    let totalTechs = sum [length techs | (_, techs, _, _, _, _, _) <- results]
-    let totalBios = sum [length bios | (_, _, bios, _, _, _, _) <- results]
-    let totalWastes = sum [length wastes | (_, _, _, wastes, _, _, _) <- results]
-    let totalUnits = sum [length units | (_, _, _, _, units, _, _) <- results]
+    let totalTechs = sum (map (length . pdTechFlows) results)
+    let totalBios = sum (map (length . pdBioFlows) results)
+    let totalWastes = sum (map (length . pdWasteFlows) results)
+    let totalUnits = sum (map (length . pdUnits) results)
     reportProgress Info $ printf "  Activities: %d processes" (M.size procMap)
     reportProgress Info $ printf "  Flows: %d tech + %d bio + %d waste (from %d raw)" (M.size techFlowMap) (M.size bioFlowMap) (M.size wasteFlowMap) (totalTechs + totalBios + totalWastes)
     reportProgress Info $ printf "  Units: %d unique (from %d raw)" (M.size unitMap) totalUnits
 
     Right <$> fixEcoSpold1ActivityLinks locationAliases dsIndex supplierLinks simpleDb
   where
-    buildProcEntryFromResult :: Maybe UUID.UUID -> (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit], Int, M.Map UUID.UUID Int) -> ((UUID.UUID, UUID.UUID), Activity)
-    buildProcEntryFromResult fileUUID (activity, _, _, _, _, _, _) =
-        let actUUID = fromMaybe (generateActivityUUIDFromActivity activity) fileUUID
+    buildProcEntryFromResult :: Maybe UUID.UUID -> ParsedDataset -> ((UUID.UUID, UUID.UUID), Activity)
+    buildProcEntryFromResult fileUUID parsed =
+        let activity = pdActivity parsed
+            actUUID = fromMaybe (generateActivityUUIDFromActivity activity) fileUUID
             prodUUID = getReferenceProductUUID activity
          in ((actUUID, prodUUID), activity)
 

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -844,24 +844,6 @@ defaultLoadOptions unitConfig =
         , loAllocation = Declared
         }
 
-{- | An EcoSpold 2 reading, said in the shape both readers share. That format
-addresses a supplier by UUID rather than by the dataset number EcoSpold 1
-writes, and its reader reports its own remarks at its own edge, so three fields
-stay empty.
--}
-es2Parsed :: (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]) -> ParsedDataset
-es2Parsed (act, techs, bios, wastes, units) =
-    ParsedDataset
-        { pdActivity = act
-        , pdTechFlows = techs
-        , pdBioFlows = bios
-        , pdWasteFlows = wastes
-        , pdUnits = units
-        , pdDatasetNumber = 0
-        , pdSupplierLinks = M.empty
-        , pdWarnings = []
-        }
-
 {- | Say that an EcoSpold 2 dataset divided into several processes will come
 back as one.
 
@@ -1148,7 +1130,7 @@ loadEcoSpoldDirectory opts dir = do
         let parseFile =
                 if isEcoSpold1
                     then streamParseActivityAndFlowsFromFile1
-                    else fmap (fmap es2Parsed) . streamParseActivityAndFlowsFromFile
+                    else streamParseActivityAndFlowsFromFile
         workerResults <- mapM parseFile workerFiles
         let paired = zipWith (\f r -> fmap (f,) r) workerFiles workerResults
         let (errs, oks) = partitionEithers paired

--- a/src/EcoSpold/Common.hs
+++ b/src/EcoSpold/Common.hs
@@ -15,18 +15,42 @@ module EcoSpold.Common (
     docSection,
     joinParts,
     showFFloatTrim,
+
+    -- * What one dataset yields
+    ParsedDataset (..),
 ) where
 
 import Amount (readAmount)
 import qualified Data.ByteString as BS
 import Data.Char (chr)
+import qualified Data.Map as M
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Read as TR
 import Numeric (showFFloat)
-import Types (DocSection (..))
+import Types (Activity, BiosphereFlow, DocSection (..), TechnosphereFlow, UUID, Unit, WasteFlow)
+
+{- | One dataset as a reader read it: the activity, the flows and units it
+names, and whatever the reader has to say about the reading.
+
+'pdDatasetNumber' and 'pdSupplierLinks' are EcoSpold 1's: that format numbers
+its datasets and points an exchange at the numbered dataset that supplies it,
+where EcoSpold 2 addresses a supplier by UUID. A reader with nothing to say
+there leaves them empty.
+-}
+data ParsedDataset = ParsedDataset
+    { pdActivity :: !Activity
+    , pdTechFlows :: ![TechnosphereFlow]
+    , pdBioFlows :: ![BiosphereFlow]
+    , pdWasteFlows :: ![WasteFlow]
+    , pdUnits :: ![Unit]
+    , pdDatasetNumber :: !Int
+    , pdSupplierLinks :: !(M.Map UUID Int)
+    , pdWarnings :: ![Text]
+    -- ^ What the reader could not make sense of, for the caller to report.
+    }
 
 -- | ByteString to Text conversion with UTF-8 decoding and XML entity decoding
 bsToText :: BS.ByteString -> Text

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -668,13 +668,18 @@ The geography is not among them: a dataset that declares none is recorded as
 -}
 placeholdersUsed :: ParseState -> [Text]
 placeholdersUsed st =
-    [ "dataset " <> T.pack (show (psDatasetNumber st)) <> ": " <> what
+    [ named <> what
     | (what, absent) <-
         [ ("no activity name, read as \"Unknown Activity\"", isNothing (psActivityName st))
         , ("no reference unit, read as \"UNKNOWN_UNIT\"", isNothing (psRefUnit st))
         ]
     , absent
     ]
+  where
+    -- A dataset that declared no number is left unnamed rather than called
+    -- number zero, which is how 'datasetIdentifier' reads the same field.
+    named :: Text
+    named = maybe "" (\(NativeProcessId n) -> "dataset " <> n <> ": ") (datasetIdentifier (psDatasetNumber st))
 
 -- | Build the final per-dataset result, applying the cut-off strategy.
 buildResult :: ParseState -> Either String ParsedDataset

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -31,7 +31,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V5 as UUID5
-import EcoSpold.Common (bsToDouble, bsToIntMaybe, bsToText, docSection, isElement, joinParts, nonEmptyText)
+import EcoSpold.Common (ParsedDataset (..), bsToDouble, bsToIntMaybe, bsToText, docSection, isElement, joinParts, nonEmptyText)
 import Progress (ProgressLevel (..), reportProgress)
 import Types
 import qualified Xeno.SAX as X
@@ -196,7 +196,7 @@ data ParseState = ParseState
     , psTextAccum :: ![BS.ByteString]
     , psSupplierLinks :: !(M.Map UUID Int) -- flowId → supplier dataset number (technosphere inputs)
     , psDocs :: !DatasetDocs -- Provenance the dataset states about itself
-    , psCompletedActivities :: ![Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit], Int, M.Map UUID Int)]
+    , psCompletedActivities :: ![Either String ParsedDataset]
     }
 
 -- | Initial parsing state
@@ -659,8 +659,25 @@ datasetIdentifier :: Int -> Maybe NativeProcessId
 datasetIdentifier 0 = Nothing
 datasetIdentifier n = Just (NativeProcessId (T.pack (show n)))
 
+{- | The fields the dataset left out and this reader stood in for.
+
+A placeholder is indistinguishable downstream from a name the file really
+carried, so the substitution is said out loud rather than merged into the data.
+The geography is not among them: a dataset that declares none is recorded as
+'LocationUnspecified', which says so in the type.
+-}
+placeholdersUsed :: ParseState -> [Text]
+placeholdersUsed st =
+    [ "dataset " <> T.pack (show (psDatasetNumber st)) <> ": " <> what
+    | (what, absent) <-
+        [ ("no activity name, read as \"Unknown Activity\"", isNothing (psActivityName st))
+        , ("no reference unit, read as \"UNKNOWN_UNIT\"", isNothing (psRefUnit st))
+        ]
+    , absent
+    ]
+
 -- | Build the final per-dataset result, applying the cut-off strategy.
-buildResult :: ParseState -> Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit], Int, M.Map UUID Int)
+buildResult :: ParseState -> Either String ParsedDataset
 buildResult st =
     let name = fromMaybe "Unknown Activity" (psActivityName st)
         location = fromMaybe "GLO" (psLocation st)
@@ -692,17 +709,19 @@ buildResult st =
                 , activityFormulaCheck = Nothing
                 }
         pack act =
-            ( act
-            , reverse (psTechFlows st)
-            , reverse (psBioFlows st)
-            , -- This format has no waste axis. Waste sent to treatment is a
-              -- technosphere input like any other, and waste with none is an
-              -- elementary flow, so nothing here builds a waste flow.
-              []
-            , reverse (psUnits st)
-            , psDatasetNumber st
-            , psSupplierLinks st
-            )
+            ParsedDataset
+                { pdActivity = act
+                , pdTechFlows = reverse (psTechFlows st)
+                , pdBioFlows = reverse (psBioFlows st)
+                , -- This format has no waste axis. Waste sent to treatment is a
+                  -- technosphere input like any other, and waste with none is an
+                  -- elementary flow, so nothing here builds a waste flow.
+                  pdWasteFlows = []
+                , pdUnits = reverse (psUnits st)
+                , pdDatasetNumber = psDatasetNumber st
+                , pdSupplierLinks = psSupplierLinks st
+                , pdWarnings = placeholdersUsed st
+                }
      in -- A file that yields no exchange at all is not a dataset: a stray or
         -- truncated XML the SAX fold walked through without complaint.
         if null (exchanges activity)
@@ -715,7 +734,7 @@ foldEcoSpold1 =
     first show . X.fold onOpenTag onAttribute onEndOpen onText onCloseTag onText initialParseState
 
 -- | Xeno SAX parser for EcoSpold1 — first dataset in the file.
-parseWithXeno :: BS.ByteString -> Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit], Int, M.Map UUID Int)
+parseWithXeno :: BS.ByteString -> Either String ParsedDataset
 parseWithXeno xmlContent = do
     finalState <- foldEcoSpold1 xmlContent
     case psCompletedActivities finalState of
@@ -725,14 +744,20 @@ parseWithXeno xmlContent = do
 {- | Parse ALL datasets from an EcoSpold1 file (multi-dataset support).
 Outer Either = XML parse failure; inner Either = per-activity failure.
 -}
-parseAllWithXeno :: BS.ByteString -> Either String [Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit], Int, M.Map UUID Int)]
+parseAllWithXeno :: BS.ByteString -> Either String [Either String ParsedDataset]
 parseAllWithXeno = fmap (reverse . psCompletedActivities) . foldEcoSpold1
 
 -- | Parse EcoSpold1 file using Xeno SAX parser
-streamParseActivityAndFlowsFromFile1 :: FilePath -> IO (Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit], Int, M.Map UUID Int))
+streamParseActivityAndFlowsFromFile1 :: FilePath -> IO (Either String ParsedDataset)
 streamParseActivityAndFlowsFromFile1 path = do
     !xmlContent <- BS.readFile path
-    return (parseWithXeno xmlContent)
+    let parsed = parseWithXeno xmlContent
+    either (const (pure ())) (reportReading path) parsed
+    return parsed
+
+-- | Send what a reading had to say to the progress log, the one place it can go.
+reportReading :: FilePath -> ParsedDataset -> IO ()
+reportReading path = mapM_ (reportProgress Warning . ((path ++ ": ") ++) . T.unpack) . pdWarnings
 
 -- ============================================================================
 -- Multi-dataset file support
@@ -742,13 +767,14 @@ streamParseActivityAndFlowsFromFile1 path = do
 Used for multi-dataset files where <ecoSpold> contains multiple <dataset> elements
 Skips activities that fail (e.g. no reference product) and logs warnings
 -}
-streamParseAllDatasetsFromFile1 :: FilePath -> IO [(Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit], Int, M.Map UUID Int)]
+streamParseAllDatasetsFromFile1 :: FilePath -> IO [ParsedDataset]
 streamParseAllDatasetsFromFile1 path = do
     !xmlContent <- BS.readFile path
     case parseAllWithXeno xmlContent of
         Right results -> do
             forM_ (lefts results) $ \e ->
                 reportProgress Warning $ "Skipping dataset in " ++ path ++ ": " ++ e
+            mapM_ (reportReading path) (rights results)
             return (rights results)
         Left err -> do
             reportProgress Warning $ "Failed to parse " ++ path ++ ": " ++ err

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -8,14 +8,14 @@ import Amount (readAmount)
 import Data.Bifunctor (first)
 import qualified Data.ByteString as BS
 import qualified Data.Map as M
-import Data.Maybe (catMaybes, fromMaybe, listToMaybe)
+import Data.Maybe (catMaybes, fromMaybe, isNothing, listToMaybe)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V5 as UUID5
-import EcoSpold.Common (bsToDouble, bsToInt, bsToIntMaybe, bsToText, docSection, isElement, joinParts, nonEmptyText)
+import EcoSpold.Common (ParsedDataset (..), bsToDouble, bsToInt, bsToIntMaybe, bsToText, docSection, isElement, joinParts, nonEmptyText)
 import qualified Expr
 import Progress (ProgressLevel (..), reportProgress)
 import SubstanceRegistry (nonEmptyCAS)
@@ -631,12 +631,28 @@ checkFormulas params pairs = case checked of
             <> T.pack (show (exchangeAmount ex))
     nearlyEqual a b = abs (a - b) <= 1e-9 * max 1 (max (abs a) (abs b))
 
+{- | The fields the dataset left out and this reader stood in for.
+
+A placeholder is indistinguishable downstream from a name the file really
+carried, so the substitution is said out loud rather than merged into the data.
+The geography is not among them: a dataset that declares none is recorded as
+'LocationUnspecified', which says so in the type.
+-}
+placeholdersUsed :: ParseState -> [Text]
+placeholdersUsed st =
+    [ what
+    | (what, absent) <-
+        [ ("no activity name, read as \"Unknown Activity\"", isNothing (psActivityName st))
+        , ("no reference unit, read as \"UNKNOWN_UNIT\"", isNothing (psRefUnit st))
+        ]
+    , absent
+    ]
+
 -- | Xeno SAX parser implementation
-parseWithXeno :: BS.ByteString -> ProcessId -> Either String ((Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]), [String])
+parseWithXeno :: BS.ByteString -> ProcessId -> Either String ParsedDataset
 parseWithXeno xmlContent processId = do
     finalState <- first show (X.fold openTag attribute endOpen text closeTag cdata initialParseState xmlContent)
-    result <- buildResult finalState processId
-    pure (result, reverse (psWarnings finalState))
+    buildResult finalState processId
   where
     -- Open tag handler - update path and context
     openTag state tagName =
@@ -988,7 +1004,7 @@ parseWithXeno xmlContent processId = do
     cdata = text
 
     -- Build final result from parse state
-    buildResult :: ParseState -> ProcessId -> Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit])
+    buildResult :: ParseState -> ProcessId -> Either String ParsedDataset
     buildResult st _pid =
         let name = fromMaybe "Unknown Activity" (psActivityName st)
             location = fromMaybe "GLO" (psLocation st)
@@ -1018,25 +1034,37 @@ parseWithXeno xmlContent processId = do
                     , activityNativeId = Nothing
                     , activityFormulaCheck = formulaCheck
                     }
-            techs = reverse (psTechFlows st)
-            bios = reverse (psBioFlows st)
-            wastes = reverse (psWasteFlows st)
-            units = reverse (psUnits st)
          in -- A file that yields no exchange at all is not a dataset: a stray or
             -- truncated XML the SAX fold walked through without complaint.
             if null (exchanges activity)
                 then Left "not an EcoSpold2 dataset: no exchange found"
-                else Right (activity, techs, bios, wastes, units)
+                else
+                    Right
+                        ParsedDataset
+                            { pdActivity = activity
+                            , pdTechFlows = reverse (psTechFlows st)
+                            , pdBioFlows = reverse (psBioFlows st)
+                            , pdWasteFlows = reverse (psWasteFlows st)
+                            , pdUnits = reverse (psUnits st)
+                            , -- This format addresses a supplier by UUID, so it
+                              -- numbers no dataset and links none by number.
+                              pdDatasetNumber = 0
+                            , pdSupplierLinks = M.empty
+                            , pdWarnings = map T.pack (reverse (psWarnings st)) ++ placeholdersUsed st
+                            }
 
 -- | Parse EcoSpold file using Xeno SAX parser
-streamParseActivityAndFlowsFromFile :: FilePath -> IO (Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]))
+streamParseActivityAndFlowsFromFile :: FilePath -> IO (Either String ParsedDataset)
 streamParseActivityAndFlowsFromFile path = do
     !xmlContent <- BS.readFile path
     let filenameBase = T.pack $ takeBaseName path
     case EcoSpold.Parser2.parseProcessId filenameBase of
         Nothing -> return $ Left $ "Invalid filename format for ProcessId: " ++ path
-        Just pid -> case parseWithXeno xmlContent pid of
-            Left err -> return $ Left err
-            Right (result, warnings) -> do
-                mapM_ (reportProgress Warning) warnings
-                return $ Right result
+        Just pid -> do
+            let parsed = parseWithXeno xmlContent pid
+            either (const (pure ())) (reportReading path) parsed
+            return parsed
+
+-- | Send what a reading had to say to the progress log, the one place it can go.
+reportReading :: FilePath -> ParsedDataset -> IO ()
+reportReading path = mapM_ (reportProgress Warning . ((path ++ ": ") ++) . T.unpack) . pdWarnings

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -8,6 +8,7 @@ import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import Test.Hspec
 
+import EcoSpold.Common (ParsedDataset (..))
 import EcoSpold.Parser1
 import Types
 
@@ -47,6 +48,30 @@ minimalXml =
         , "      <exchange number=\"4\" name=\"fuel oil\" category=\"Liquid fuels\""
         , "                unit=\"kg\" meanValue=\"2.0\">"
         , "        <inputGroup>5</inputGroup>"
+        , "      </exchange>"
+        , "    </flowData>"
+        , "  </dataset>"
+        , "</ecoSpold>"
+        ]
+
+{- | A dataset naming neither its activity nor its reference unit: both are
+read as placeholders, which is what the reading has to say out loud.
+-}
+namelessXml :: BC.ByteString
+namelessXml =
+    BC.unlines
+        [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold01\">"
+        , "  <dataset number=\"7\">"
+        , "    <metaInformation>"
+        , "      <processInformation>"
+        , "        <geography location=\"DE\" />"
+        , "      </processInformation>"
+        , "    </metaInformation>"
+        , "    <flowData>"
+        , "      <exchange number=\"1\" name=\"electricity, high voltage\" category=\"Energy\""
+        , "                subCategory=\"Electricity\" unit=\"kWh\" meanValue=\"1.0\">"
+        , "        <outputGroup>0</outputGroup>"
         , "      </exchange>"
         , "    </flowData>"
         , "  </dataset>"
@@ -321,7 +346,7 @@ example rather than the whole run when the fixture stops parsing.
 withDocumented :: (Activity -> Expectation) -> Expectation
 withDocumented k = case parseWithXeno documentedXml of
     Left err -> expectationFailure $ "Parse failed: " ++ err
-    Right (act, _, _, _, _, _, _) -> k act
+    Right ParsedDataset{pdActivity = act} -> k act
 
 -- ---------------------------------------------------------------------------
 -- Spec
@@ -354,12 +379,12 @@ spec = do
         it "prefers the dates over the years when a dataset states both" $
             case parseWithXeno (datedPeriodXml "<startYear>2000</startYear><endYear>2020</endYear><startDate>2000-01</startDate><endDate>2020-01</endDate>") of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _, _, _) -> sectionNamed "Time period" act `shouldBe` Just "2000-01 - 2020-01"
+                Right ParsedDataset{pdActivity = act} -> sectionNamed "Time period" act `shouldBe` Just "2000-01 - 2020-01"
 
         it "reads a period stated only as dates, the form most of a real export uses" $
             case parseWithXeno (datedPeriodXml "<startDate>2000-01</startDate><endDate>2020-01</endDate>") of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _, _, _) -> sectionNamed "Time period" act `shouldBe` Just "2000-01 - 2020-01"
+                Right ParsedDataset{pdActivity = act} -> sectionNamed "Time period" act `shouldBe` Just "2000-01 - 2020-01"
 
         it "names the proof reader by the person number the validation points at" $
             withDocumented $ \act ->
@@ -368,14 +393,14 @@ spec = do
         it "reads an exporter's null placeholder as an unfilled rubric" $
             case parseWithXeno nullMarkerXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _, _, _) -> do
+                Right ParsedDataset{pdActivity = act} -> do
                     sectionNamed "Geography" act `shouldBe` Nothing
                     sectionNamed "Technology" act `shouldBe` Just "Port distances."
 
         it "records no section for a dataset that states none" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _, _, _) -> activityDocumentation act `shouldBe` []
+                Right ParsedDataset{pdActivity = act} -> activityDocumentation act `shouldBe` []
 
     describe "generateFlowUUID" $ do
         it "produces a stable UUID for known inputs" $
@@ -401,19 +426,19 @@ spec = do
     describe "flow identity across datasets" $ do
         it "gives one substance one flow id in every dataset that draws it" $
             case (parseWithXeno minimalXml, parseWithXeno otherAuthorXml) of
-                (Right (_, _, bios1, _, _, _, _), Right (_, _, bios2, _, _, _, _)) ->
+                (Right ParsedDataset{pdBioFlows = bios1}, Right ParsedDataset{pdBioFlows = bios2}) ->
                     map bfId bios1 `shouldBe` map bfId bios2
                 (Left err, _) -> expectationFailure ("minimalXml: " <> err)
                 (_, Left err) -> expectationFailure ("otherAuthorXml: " <> err)
 
         it "reads the dataset number off <dataset>, not off a numbered <person>" $
             case parseWithXeno otherAuthorXml of
-                Right (_, _, _, _, _, dsNum, _) -> dsNum `shouldBe` 43
+                Right ParsedDataset{pdDatasetNumber = dsNum} -> dsNum `shouldBe` 43
                 Left err -> expectationFailure err
 
         it "reads every dataset's own number when a numbered person precedes them" $
             case parseAllWithXeno multiDatasetXml of
-                Right results -> map (fmap (\(_, _, _, _, _, n, _) -> n)) results `shouldBe` [Right 1, Right 2]
+                Right results -> map (fmap pdDatasetNumber) results `shouldBe` [Right 1, Right 2]
                 Left err -> expectationFailure err
 
     describe "generateUnitUUID" $ do
@@ -447,27 +472,27 @@ spec = do
         it "parses activity name from referenceFunction" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _, _, _) -> activityName act `shouldBe` "electricity production"
+                Right ParsedDataset{pdActivity = act} -> activityName act `shouldBe` "electricity production"
 
         it "parses activity location from geography" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _, _, _) -> activityLocation act `shouldBe` "DE"
+                Right ParsedDataset{pdActivity = act} -> activityLocation act `shouldBe` "DE"
 
         it "parses activity unit from referenceFunction" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _, _, _) -> activityUnit act `shouldBe` "kWh"
+                Right ParsedDataset{pdActivity = act} -> activityUnit act `shouldBe` "kWh"
 
         it "parses dataset number" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (_, _, _, _, _, num, _) -> num `shouldBe` 42
+                Right ParsedDataset{pdDatasetNumber = num} -> num `shouldBe` 42
 
         it "keeps the dataset number as the identifier the source gave it" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _, _, _) ->
+                Right ParsedDataset{pdActivity = act} ->
                     activityNativeId act `shouldBe` Just (NativeProcessId "42")
 
         -- A missing or unparseable number is read as 0, which is the loader
@@ -476,35 +501,35 @@ spec = do
         it "gives no identifier to a dataset that publishes no number" $
             case parseWithXeno unnumberedXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _, _, _) -> activityNativeId act `shouldBe` Nothing
+                Right ParsedDataset{pdActivity = act} -> activityNativeId act `shouldBe` Nothing
 
         it "produces 4 exchanges" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _, _, _) -> length (exchanges act) `shouldBe` 4
+                Right ParsedDataset{pdActivity = act} -> length (exchanges act) `shouldBe` 4
 
         it "produces 4 flows (1 tech reference + 3 bio)" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (_, techs, bios, _, _, _, _) ->
+                Right ParsedDataset{pdTechFlows = techs, pdBioFlows = bios} ->
                     (length techs + length bios) `shouldBe` 4
 
         it "marks the reference output (outputGroup 0) as isReference" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _, _, _) ->
+                Right ParsedDataset{pdActivity = act} ->
                     length (filter exchangeIsReference (exchanges act)) `shouldBe` 1
 
         it "marks biosphere exchange (outputGroup 4) as BiosphereExchange" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _, _, _) ->
+                Right ParsedDataset{pdActivity = act} ->
                     let bios = filter (\case BiosphereExchange{} -> True; _ -> False) (exchanges act)
                      in length bios `shouldBe` 2 -- CO2 output + natural gas input (inputGroup 4)
         it "parses flow with CAS number" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (_, _, bios, _, _, _, _) ->
+                Right ParsedDataset{pdBioFlows = bios} ->
                     let co2Flows = filter (\f -> bfName f == "Carbon dioxide, fossil") bios
                      in case co2Flows of
                             [f] -> bfCAS f `shouldBe` Just "124-38-9"
@@ -513,20 +538,33 @@ spec = do
         it "sets activity classification from category/subCategory" $
             case parseWithXeno minimalXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _, _, _) ->
+                Right ParsedDataset{pdActivity = act} ->
                     M.lookup "Category" (activityClassification act) `shouldBe` Just "Energy"
 
         it "captures per-exchange generalComment as exchangeComment" $
             case parseWithXeno commentXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _, _, _) ->
+                Right ParsedDataset{pdActivity = act} ->
                     map exchangeComment (exchanges act) `shouldBe` [Just "Global", Nothing]
 
         it "still routes referenceFunction generalComment to activity description" $
             case parseWithXeno commentXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _, _, _) ->
+                Right ParsedDataset{pdActivity = act} ->
                     activityDescription act `shouldBe` ["Process-level note"]
+
+        it "says which fields it stood in for" $
+            case parseWithXeno namelessXml of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right ParsedDataset{pdActivity = act, pdWarnings = warns} -> do
+                    activityName act `shouldBe` "Unknown Activity"
+                    activityUnit act `shouldBe` "UNKNOWN_UNIT"
+                    length warns `shouldBe` 2
+
+        it "has nothing to say about a dataset that named both" $
+            case parseWithXeno minimalXml of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right ParsedDataset{pdWarnings = warns} -> warns `shouldBe` []
 
     -- -----------------------------------------------------------------------
     -- parseAllWithXeno — multi-dataset
@@ -546,21 +584,21 @@ spec = do
             case parseAllWithXeno multiDatasetXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
                 Right results ->
-                    let names = [activityName act | Right (act, _, _, _, _, _, _) <- results]
+                    let names = [activityName act | Right ParsedDataset{pdActivity = act} <- results]
                      in names `shouldBe` ["process A", "process B"]
 
         it "preserves dataset numbers in order" $
             case parseAllWithXeno multiDatasetXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
                 Right results ->
-                    let nums = [n | Right (_, _, _, _, _, n, _) <- results]
+                    let nums = [n | Right ParsedDataset{pdDatasetNumber = n} <- results]
                      in nums `shouldBe` [1, 2]
 
         it "parses location from each dataset" $
             case parseAllWithXeno multiDatasetXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
                 Right results ->
-                    let locs = [activityLocation act | Right (act, _, _, _, _, _, _) <- results]
+                    let locs = [activityLocation act | Right ParsedDataset{pdActivity = act} <- results]
                      in locs `shouldBe` ["CH", "FR"]
 
     -- -----------------------------------------------------------------------
@@ -572,7 +610,7 @@ spec = do
         it "reads category=\"Final waste flows\" as a biosphere flow of medium waste" $
             case parseWithXeno wasteFlowXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, bios, wastes, _, _, _) -> do
+                Right ParsedDataset{pdActivity = act, pdBioFlows = bios, pdWasteFlows = wastes} -> do
                     let bioExchanges = [e | e@BiosphereExchange{} <- exchanges act]
                     length bioExchanges `shouldBe` 1
                     map bfName bios `shouldBe` ["Organic carbon, placed in landfill"]
@@ -583,7 +621,7 @@ spec = do
         it "does not route the waste flow to the technosphere bucket" $
             case parseWithXeno wasteFlowXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (_, techs, _, _, _, _, _) ->
+                Right ParsedDataset{pdTechFlows = techs} ->
                     -- Only the reference product remains on the tech side;
                     -- the Final-waste-flows row must not show up there.
                     map tfName techs `shouldBe` ["aluminium ingot"]
@@ -591,7 +629,7 @@ spec = do
         it "reads it as an emission despite the input group" $
             case parseWithXeno wasteFlowXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _, _, _) ->
+                Right ParsedDataset{pdActivity = act} ->
                     -- inputGroup=5 is an artefact of the format, not a
                     -- direction: the row is waste leaving the system.
                     [bioDirection e | e@BiosphereExchange{} <- exchanges act]
@@ -600,5 +638,5 @@ spec = do
         it "falls back to the activity location, as for any elementary flow" $
             case parseWithXeno wasteFlowXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _, _, _) ->
+                Right ParsedDataset{pdActivity = act} ->
                     [bioLocation e | e@BiosphereExchange{} <- exchanges act] `shouldBe` ["RoW"]

--- a/test/EcoSpold1WriterSpec.hs
+++ b/test/EcoSpold1WriterSpec.hs
@@ -27,6 +27,7 @@ import qualified Data.UUID as UUID
 import Test.Hspec
 
 import qualified Database as DB
+import EcoSpold.Common (ParsedDataset (..))
 import EcoSpold.Parser1 (parseAllWithXeno)
 import EcoSpold.Writer1
 import qualified Matrix
@@ -150,17 +151,15 @@ fixtureDb = case parseAllWithXeno minimalXml of
         Left err -> fail ("fixture dataset failed: " ++ err)
         Right datasets -> pure (assembleSimpleDb datasets)
 
--- | Fold parser per-dataset tuples into a 'SimpleDatabase'.
-assembleSimpleDb ::
-    [(Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit], Int, M.Map UUID Int)] ->
-    SimpleDatabase
+-- | Fold the per-dataset readings into a 'SimpleDatabase'.
+assembleSimpleDb :: [ParsedDataset] -> SimpleDatabase
 assembleSimpleDb datasets =
     SimpleDatabase
-        { sdbActivities = M.fromList [(processKey a, a) | (a, _, _, _, _, _, _) <- datasets]
-        , sdbTechFlows = M.fromList [(tfId f, f) | (_, tfs, _, _, _, _, _) <- datasets, f <- tfs]
-        , sdbBioFlows = M.fromList [(bfId f, f) | (_, _, bfs, _, _, _, _) <- datasets, f <- bfs]
-        , sdbWasteFlows = M.fromList [(wfId f, f) | (_, _, _, wfs, _, _, _) <- datasets, f <- wfs]
-        , sdbUnits = M.fromList [(unitId u, u) | (_, _, _, _, us, _, _) <- datasets, u <- us]
+        { sdbActivities = M.fromList [(processKey a, a) | ParsedDataset{pdActivity = a} <- datasets]
+        , sdbTechFlows = M.fromList [(tfId f, f) | ParsedDataset{pdTechFlows = tfs} <- datasets, f <- tfs]
+        , sdbBioFlows = M.fromList [(bfId f, f) | ParsedDataset{pdBioFlows = bfs} <- datasets, f <- bfs]
+        , sdbWasteFlows = M.fromList [(wfId f, f) | ParsedDataset{pdWasteFlows = wfs} <- datasets, f <- wfs]
+        , sdbUnits = M.fromList [(unitId u, u) | ParsedDataset{pdUnits = us} <- datasets, u <- us]
         }
 
 {- | An injective @(activityUUID, productUUID)@ key for the matrix builder. The
@@ -302,7 +301,7 @@ roundTripSupplierLinks sdb =
             case parseAllWithXeno (TE.encodeUtf8 txt) of
                 Left err -> Left err
                 Right results ->
-                    concatMap (\(_, _, _, _, _, _, links) -> M.elems links) <$> sequence results
+                    concatMap (\ParsedDataset{pdSupplierLinks = links} -> M.elems links) <$> sequence results
 
 -- ---------------------------------------------------------------------------
 -- Order-insensitive observable projection of an activity, for semantic equality

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -13,6 +13,7 @@ import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
+import EcoSpold.Common (ParsedDataset (..))
 import EcoSpold.Parser2 (streamParseActivityAndFlowsFromFile)
 import Progress (LogLine (llText), getLogLines)
 import Types
@@ -24,7 +25,7 @@ streamParseActivityAndFlowsFromFile derives a synthetic ProcessId from the
 filename and rejects names that don't match `actUUID_prodUUID`, so we copy
 the fixture into a temp path with that shape.
 -}
-withFixture :: ((Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]) -> IO ()) -> IO ()
+withFixture :: (ParsedDataset -> IO ()) -> IO ()
 withFixture k = withSystemTempDirectory "es2-spec" $ \dir -> do
     bytes <- BS.readFile "test-data/electricity-production.spold"
     let path = dir </> "12345678-1234-5678-9abc-123456789001_12345678-1234-5678-9abc-123456789002.spold"
@@ -37,7 +38,7 @@ withFixture k = withSystemTempDirectory "es2-spec" $ \dir -> do
 spec :: Spec
 spec = describe "per-exchange comments" $ do
     it "captures English <comment> on intermediateExchange and elementaryExchange" $
-        withFixture $ \(act, _, _, _, _) ->
+        withFixture $ \ParsedDataset{pdActivity = act} ->
             map exchangeComment (exchanges act)
                 `shouldMatchList` [ Just "Coal input for electricity generation"
                                   , Just "Electricity output (reference product)"
@@ -47,10 +48,10 @@ spec = describe "per-exchange comments" $ do
 
     it "preserves all four exchanges" $
         withFixture $
-            \(act, _, _, _, _) -> length (exchanges act) `shouldBe` 4
+            \ParsedDataset{pdActivity = act} -> length (exchanges act) `shouldBe` 4
 
     it "comments contain no &-entity artefacts" $
-        withFixture $ \(act, _, _, _, _) ->
+        withFixture $ \ParsedDataset{pdActivity = act} ->
             let comments = [c | ex <- exchanges act, Just c <- [exchangeComment ex]]
              in not (any (T.isInfixOf "&") comments) `shouldBe` True
 
@@ -61,7 +62,7 @@ spec = describe "per-exchange comments" $ do
         result <- streamParseActivityAndFlowsFromFile "test-data/sawnwood-properties_12345678-1234-5678-9abc-12345678aaaa.spold"
         case result of
             Left err -> expectationFailure $ "Parse failed: " ++ err
-            Right (act, _, _, _, _) ->
+            Right ParsedDataset{pdActivity = act} ->
                 map exchangeComment (exchanges act)
                     `shouldMatchList` [ Nothing -- ex1 has no top-level comment, only property comments
                                       , Just "Adhesive applied during pressing" -- ex2's exchange-level comment, NOT the noisy property comment
@@ -99,7 +100,7 @@ spec = describe "per-exchange comments" $ do
     -- supplier demand no activity can meet.
     describe "waste flow detection" $ do
         it "keeps an elementary 'inventory indicator/waste' input on the biosphere axis" $
-            withWastePatternsFixture $ \(act, _, bios, wastes, _) -> do
+            withWastePatternsFixture $ \ParsedDataset{pdActivity = act, pdBioFlows = bios, pdWasteFlows = wastes} -> do
                 length [e | e@WasteExchange{} <- exchanges act] `shouldBe` 1
                 length wastes `shouldBe` 1
                 -- the indicator input joins the genuine CO2 emission
@@ -111,11 +112,11 @@ spec = describe "per-exchange comments" $ do
         -- recording one direction is what lets a writer that reconstructs
         -- direction from the compartment round-trip the flow.
         it "records an inventory indicator as an output whichever group it carries" $
-            withWastePatternsFixture $ \(act, _, _, _, _) ->
+            withWastePatternsFixture $ \ParsedDataset{pdActivity = act} ->
                 [bioDirection e | e@BiosphereExchange{} <- exchanges act]
                     `shouldBe` [Emission, Emission]
         it "routes an intermediate classified 'By-product:Waste' to WasteExchange" $
-            withWastePatternsFixture $ \(act, _, _, _, _) -> do
+            withWastePatternsFixture $ \ParsedDataset{pdActivity = act} -> do
                 let wasteInputs = [e | e@WasteExchange{waIsInput = True} <- exchanges act]
                     wasteOutputs = [e | e@WasteExchange{waIsInput = False} <- exchanges act]
                 length wasteInputs `shouldBe` 1
@@ -136,17 +137,17 @@ spec = describe "per-exchange comments" $ do
                 Right _ -> pure ()
 
         it "keeps the reference on the technosphere axis, not the waste axis" $
-            withWasteReferenceFixture $ \(act, techs, _, wastes, _) -> do
+            withWasteReferenceFixture $ \ParsedDataset{pdActivity = act, pdTechFlows = techs, pdWasteFlows = wastes} -> do
                 [techRole e | e@TechnosphereExchange{} <- exchanges act] `shouldBe` [ReferenceProduct]
                 length [() | WasteExchange{} <- exchanges act] `shouldBe` 0
                 length techs `shouldBe` 1 -- reference registered as a TechnosphereFlow
                 length wastes `shouldBe` 0 -- and not as a WasteFlow
         it "carries the reference unit through (not UNKNOWN_UNIT)" $
-            withWasteReferenceFixture $ \(act, _, _, _, _) ->
+            withWasteReferenceFixture $ \ParsedDataset{pdActivity = act} ->
                 activityUnit act `shouldBe` "kg"
 
         it "preserves the negative reference amount for the matrix diagonal" $
-            withWasteReferenceFixture $ \(act, _, _, _, _) ->
+            withWasteReferenceFixture $ \ParsedDataset{pdActivity = act} ->
                 [exchangeAmount e | e@TechnosphereExchange{techRole = ReferenceProduct} <- exchanges act]
                     `shouldBe` [-1.0]
 
@@ -192,7 +193,7 @@ spec = describe "per-exchange comments" $ do
             result <- runOnBytes (activityTypeFixtureXml "2" (Just "1"))
             case result of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _) ->
+                Right ParsedDataset{pdActivity = act} ->
                     activityNativeType act
                         `shouldBe` Just
                             EcoSpoldActivityType
@@ -206,7 +207,7 @@ spec = describe "per-exchange comments" $ do
             result <- runOnBytes (activityTypeFixtureXml "1" Nothing)
             case result of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _) ->
+                Right ParsedDataset{pdActivity = act} ->
                     activityNativeType act
                         `shouldBe` Just
                             EcoSpoldActivityType
@@ -220,7 +221,7 @@ spec = describe "per-exchange comments" $ do
             result <- runOnBytes wastePatternsXml -- existing fixture has no activityType
             case result of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _) ->
+                Right ParsedDataset{pdActivity = act} ->
                     activityNativeType act `shouldBe` Nothing
 
     -- -----------------------------------------------------------------------
@@ -233,7 +234,7 @@ spec = describe "per-exchange comments" $ do
     -- -----------------------------------------------------------------------
     describe "mathematicalRelation formulas" $ do
         it "keeps the stored amount when the formula evaluates to a different value" $
-            withFormulaFixture $ \(act, _, _, _, _) ->
+            withFormulaFixture $ \ParsedDataset{pdActivity = act} ->
                 -- fuel_input(2.0) * 2 + production(1.0) = 5.0 diverges from the
                 -- stored 4.0; the stored amount wins (the recorded divergence is
                 -- asserted below, proving the nested <property>'s own
@@ -242,21 +243,21 @@ spec = describe "per-exchange comments" $ do
                     `shouldBe` [4.0]
 
         it "stores <parameter> values and raw formulas on the activity" $
-            withFormulaFixture $ \(act, _, _, _, _) -> do
+            withFormulaFixture $ \ParsedDataset{pdActivity = act} -> do
                 activityParams act `shouldBe` M.fromList [("fuel_input", 2.0)]
                 activityParamExprs act `shouldBe` M.fromList [("fuel_input", "4.0 / 2")]
 
         it "keeps the stored amount when a formula references an unknown variable" $
-            withFormulaFixture $ \(act, _, _, _, _) ->
+            withFormulaFixture $ \ParsedDataset{pdActivity = act} ->
                 [exchangeAmount e | e@BiosphereExchange{} <- exchanges act]
                     `shouldBe` [3.0]
 
         it "does not keep a <parameter> without a usable amount" $
-            withFormulaFixture $ \(act, _, _, _, _) ->
+            withFormulaFixture $ \ParsedDataset{pdActivity = act} ->
                 M.member "ghost" (activityParams act) `shouldBe` False
 
         it "records the check outcome on the activity, with the divergent example" $
-            withFormulaFixture $ \(act, _, _, _, _) ->
+            withFormulaFixture $ \ParsedDataset{pdActivity = act} ->
                 case activityFormulaCheck act of
                     Nothing -> expectationFailure "expected a FormulaCheck on the activity"
                     Just fc -> do
@@ -288,7 +289,7 @@ spec = describe "per-exchange comments" $ do
             result <- runOnBytes (activityTypeFixtureXml "1" Nothing)
             case result of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _) -> do
+                Right ParsedDataset{pdActivity = act} -> do
                     activityLocation act `shouldBe` "TEST"
                     activityLocationSource act `shouldBe` LocationDeclared
 
@@ -296,9 +297,36 @@ spec = describe "per-exchange comments" $ do
             result <- runOnBytes noGeographyXml
             case result of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
-                Right (act, _, _, _, _) -> do
+                Right ParsedDataset{pdActivity = act} -> do
                     activityLocation act `shouldBe` "GLO"
                     activityLocationSource act `shouldBe` LocationUnspecified
+
+    describe "placeholders the reader stood in for" $ do
+        let runOnBytes bytes = withSystemTempDirectory "es2-placeholder" $ \dir -> do
+                let path = dir </> "12345678-1234-5678-9abc-123456789001_12345678-1234-5678-9abc-123456789002.spold"
+                BS.writeFile path bytes
+                streamParseActivityAndFlowsFromFile path
+            -- The fixtures name their unit "unit-kg", which is not a UUID, so
+            -- each reading also remarks on that. Only the stand-ins are read here.
+            standIns = filter (T.isInfixOf "read as") . pdWarnings
+
+        it "says which fields it stood in for" $ do
+            result <- runOnBytes namelessXml
+            case result of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right parsed -> do
+                    activityName (pdActivity parsed) `shouldBe` "Unknown Activity"
+                    activityUnit (pdActivity parsed) `shouldBe` "UNKNOWN_UNIT"
+                    standIns parsed
+                        `shouldBe` [ "no activity name, read as \"Unknown Activity\""
+                                   , "no reference unit, read as \"UNKNOWN_UNIT\""
+                                   ]
+
+        it "has nothing to say about a dataset that named both" $ do
+            result <- runOnBytes (activityTypeFixtureXml "1" Nothing)
+            case result of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right parsed -> standIns parsed `shouldBe` []
 
     describe "dataset documentation" $ do
         let sectionNamed label act = lookup label [(docLabel s, docText s) | s <- activityDocumentation act]
@@ -308,7 +336,7 @@ spec = describe "per-exchange comments" $ do
                 result <- streamParseActivityAndFlowsFromFile path
                 case result of
                     Left err -> expectationFailure $ "Parse failed: " ++ err
-                    Right (act, _, _, _, _) -> k act
+                    Right ParsedDataset{pdActivity = act} -> k act
 
         it "reads the sections of a dataset whose general comment runs to several paragraphs" $
             -- The shape four ecoinvent datasets in five have. Each paragraph of
@@ -349,16 +377,16 @@ spec = describe "per-exchange comments" $ do
                         "Carl Vadenbo (2012-06-29): The amounts of the exchanges were reviewed.\nGregor Wernet (2014-06-03)"
 
         it "reads a comment written straight into the element, with no <text> child" $
-            withFixture $ \(act, _, _, _, _) -> do
+            withFixture $ \ParsedDataset{pdActivity = act} -> do
                 sectionNamed "Technology" act `shouldBe` Just "Coal-fired power plant"
                 sectionNamed "Geography" act `shouldBe` Just "Test geography"
 
         it "reads the period as its dates followed by what the dataset says about them" $
-            withFixture $ \(act, _, _, _, _) ->
+            withFixture $ \ParsedDataset{pdActivity = act} ->
                 sectionNamed "Time period" act `shouldBe` Just "2020-01-01 - 2020-12-31 Test time period"
 
         it "reads what the dataset includes, and how it was sampled" $
-            withFixture $ \(act, _, _, _, _) -> do
+            withFixture $ \ParsedDataset{pdActivity = act} -> do
                 sectionNamed "Included activities" act `shouldBe` Just "Coal combustion Electricity generation"
                 sectionNamed "System model" act `shouldBe` Just "Test system model"
                 sectionNamed "Sampling procedure" act `shouldBe` Just "Test sampling"
@@ -458,6 +486,31 @@ activityTypeFixtureXml actType mSpec =
                \  </activityDataset>\n\
                \</ecoSpold>\n"
 
+{- | Same dataset as 'activityTypeFixtureXml' but naming neither its activity
+nor the unit of its reference product: both are read as placeholders, which is
+what the reading has to say out loud.
+-}
+namelessXml :: BS.ByteString
+namelessXml =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+    \<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold02\">\n\
+    \  <activityDataset>\n\
+    \    <activityDescription>\n\
+    \      <activity id=\"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\" activityNameId=\"nameless\">\n\
+    \      </activity>\n\
+    \      <geography geographyId=\"TEST\"><shortname xml:lang=\"en\">TEST</shortname></geography>\n\
+    \    </activityDescription>\n\
+    \    <flowData>\n\
+    \      <intermediateExchange id=\"ref\" unitId=\"unit-kg\" amount=\"1.0\"\n\
+    \                           intermediateExchangeId=\"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb\">\n\
+    \        <name xml:lang=\"en\">nameless product</name>\n\
+    \        <unitName xml:lang=\"en\"></unitName>\n\
+    \        <outputGroup>0</outputGroup>\n\
+    \      </intermediateExchange>\n\
+    \    </flowData>\n\
+    \  </activityDataset>\n\
+    \</ecoSpold>\n"
+
 -- | Same dataset as 'activityTypeFixtureXml' but with no @\<geography\>@ element.
 noGeographyXml :: BS.ByteString
 noGeographyXml =
@@ -486,7 +539,7 @@ withPropertyFixture k = do
     result <- streamParseActivityAndFlowsFromFile "test-data/sawnwood-properties_12345678-1234-5678-9abc-12345678aaaa.spold"
     case result of
         Left err -> expectationFailure $ "Parse failed: " ++ err
-        Right (act, _, _, _, _) -> k act
+        Right ParsedDataset{pdActivity = act} -> k act
 
 -- | The properties recorded on the exchange of a given flow, by flow id.
 propertiesOf :: Text -> Activity -> Maybe ExchangeProperties
@@ -497,7 +550,7 @@ propertiesOf flowId act =
         , Just (exchangeFlowId ex) == UUID.fromText flowId
         ]
 
-withWastePatternsFixture :: ((Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]) -> IO ()) -> IO ()
+withWastePatternsFixture :: (ParsedDataset -> IO ()) -> IO ()
 withWastePatternsFixture k = withSystemTempDirectory "es2-waste-spec" $ \dir -> do
     let path = dir </> "12345678-1234-5678-9abc-123456789001_12345678-1234-5678-9abc-123456789002.spold"
     BS.writeFile path wastePatternsXml
@@ -604,13 +657,13 @@ wasteReferenceXml =
     \  </activityDataset>\n\
     \</ecoSpold>\n"
 
-parseWasteReference :: IO (Either String (Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]))
+parseWasteReference :: IO (Either String ParsedDataset)
 parseWasteReference = withSystemTempDirectory "es2-waste-ref" $ \dir -> do
     let path = dir </> "12345678-1234-5678-9abc-123456789001_12345678-1234-5678-9abc-123456789002.spold"
     BS.writeFile path wasteReferenceXml
     streamParseActivityAndFlowsFromFile path
 
-withWasteReferenceFixture :: ((Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]) -> IO ()) -> IO ()
+withWasteReferenceFixture :: (ParsedDataset -> IO ()) -> IO ()
 withWasteReferenceFixture k =
     parseWasteReference >>= either (expectationFailure . ("Parse failed: " ++)) k
 
@@ -675,7 +728,7 @@ formulaXml =
     \  </activityDataset>\n\
     \</ecoSpold>\n"
 
-withFormulaFixture :: ((Activity, [TechnosphereFlow], [BiosphereFlow], [WasteFlow], [Unit]) -> IO ()) -> IO ()
+withFormulaFixture :: (ParsedDataset -> IO ()) -> IO ()
 withFormulaFixture k = withSystemTempDirectory "es2-formula" $ \dir -> do
     let path = dir </> "12345678-1234-5678-9abc-123456789001_12345678-1234-5678-9abc-123456789002.spold"
     BS.writeFile path formulaXml


### PR DESCRIPTION
## Why

Neither EcoSpold reader could report a stand-in it had used. A dataset that
names no activity loads as "Unknown Activity", one that names no reference
unit as "UNKNOWN_UNIT", and nothing in the log says so: downstream, a
placeholder is indistinguishable from a name the file really carried.

For the EcoSpold 1 reader the reason was the shape it returned. Everything a
dataset parses to travelled as a seven element tuple across five signatures
and some forty pattern matches, most of them a row of underscores around the
single slot the caller wanted. Adding a warning meant an eighth element in a
tuple that was already unreadable. The EcoSpold 2 reader had a channel, and
used it for exchange units alone, without naming the file it was reading.

## What changes

`ParsedDataset` is a record, in `EcoSpold.Common` since both readers produce
one, with a field for what the reading has to say. The loader reads it by
field name instead of by position, and both parsers report the remarks at
their IO edge, each naming the file.

The EcoSpold 2 entry point returned a five element tuple of its own, which
the loader padded into the record at the single call site; it returns the
record, and the adapter goes.

Nothing computed moves. The visible change is the four new warnings, two per
format, and they fire only where a placeholder was already being substituted
in silence.

## Checks

Full suite green (2492 examples, 0 failures), hlint silent, fourmolu applied.
