### PR TITLE
Key the factor tables on the medium itself

### DIFF
--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -207,7 +207,6 @@ import Method.Types (
     CompartmentMap,
     EnergyDensityMap,
     Location (..),
-    Medium (..),
     Method (..),
     MethodCF (..),
     MethodCollection (..),
@@ -240,6 +239,7 @@ import Types (
     LinkBlocker (..),
     LocationFallback (..),
     LocationUnresolved (..),
+    Medium (..),
     SimpleDatabase (..),
     SparseTriple (..),
     UUID,
@@ -853,8 +853,8 @@ buildMethodTablesFor manager dbName collection db method = do
       where
         waterCFs :: Int
         waterCFs =
-            length [() | (_, Medium "water", _) <- M.keys (mtExactCF tables)]
-                + length [() | (_, Medium "water") <- M.keys (mtFallbackCF tables)]
+            length [() | (_, Just Water, _) <- M.keys (mtExactCF tables)]
+                + length [() | (_, Just Water) <- M.keys (mtFallbackCF tables)]
 
     -- A CF that matched (broadcast or regionalized) but cannot be
     -- unit-converted scores an (intentional) 0 - refusing wrong-dimension data

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -146,7 +146,7 @@ import Progress (ProgressLevel (..), reportProgress)
 import SubstanceRegistry (nonEmptyCAS, normalizeCAS)
 import qualified SubstanceRegistry as SR
 import SynonymDB
-import Types (Activity (..), BioFlowDB, BiosphereFlow (..), Database (..), FlowClosure (..), ProcessId, SparseTriple (..), Unit (..), UnitDB, ownFlowClosure)
+import Types (Activity (..), BioFlowDB, BiosphereFlow (..), Database (..), FlowClosure (..), Medium (..), ProcessId, SparseTriple (..), Unit (..), UnitDB, ownFlowClosure, parseMedium)
 import qualified Types as VT
 import UnitConversion (UnitConfig, convertUnit, isKnownUnit, normalizeToCanonical, normalizeUnit, unitsCompatible)
 
@@ -364,27 +364,33 @@ selectsFlow cf = \f -> prefix `T.isPrefixOf` T.toCaseFold (bfName f) && casFits 
     compFits f = case mcfCompartment cf of
         Nothing -> True
         Just (Compartment med sub _) ->
-            maybe False (\c -> mediumEq med (VT.mediumText (VT.compartmentName c)) && subFits sub c) (bfCompartment f)
+            maybe False (\c -> mediumEq med (VT.compartmentName c) && subFits sub c) (bfCompartment f)
     subFits sub c = subcompartmentFits sub (fromMaybe "" (VT.compartmentSub c))
-    mediumEq = sameMedium
+    -- The stated word against the flow's own value: a statement this reader
+    -- cannot place names no medium the flow could be filed under.
+    mediumEq :: Text -> Medium -> Bool
+    mediumEq stated actual = parseMedium stated == Right actual
 
-{- | Two spellings of one medium. Folded in case and put through
-'normalizeMedium', so a method writing "Natural resource" meets a flow filed
-under "resource".
+{- | The medium axis of a lookup key: the medium a source stated, or 'Nothing'
+where it stated none. A flow whose file gave it no compartment keys on
+'Nothing' and meets no factor, which is also what a factor without one gets:
+'cfMediumSub' leaves such a factor out of these tables rather than filing it
+under a medium it never claimed.
 -}
-sameMedium :: Text -> Text -> Bool
-sameMedium a b = normalizeMedium (T.toCaseFold a) == normalizeMedium (T.toCaseFold b)
+type MediumKey = Maybe Medium
 
 {- | Does a flow's medium satisfy the one a method row states? Equal after
-normalization, as the scoring tables key it: 'buildMethodTables' indexes a
+the same value, as the scoring tables key it: 'buildMethodTables' indexes a
 factor under the row's normalized medium and 'flowMediumSub' files a flow
 under its own, so a match judged any looser here promises a factor the read
 side never serves. "air" against "emissions to air" is a vocabulary gap that
 only a compartment rule bridges, not a widening. An empty statement
 constrains nothing.
 -}
-mediumFits :: Text -> Text -> Bool
-mediumFits stated actual = T.null stated || sameMedium stated actual
+mediumFits :: Text -> MediumKey -> Bool
+mediumFits stated actual
+    | T.null stated = True
+    | otherwise = either (const False) (\m -> actual == Just m) (parseMedium stated)
 
 {- | Does a flow's subcompartment satisfy the one a method row states? A
 statement that names no particular subcompartment constrains only the medium,
@@ -510,21 +516,30 @@ compartmentGapWarning cmap flowsByName mappings
                 <> " factor(s) name a flow this database files under another compartment (method: "
                 <> quoted (S.fromList (map fst gaps))
                 <> "; database: "
-                <> quoted (S.unions (map snd gaps))
+                <> quoted (S.map VT.mediumText (S.unions (map snd gaps)))
                 <> "). Declare a [[compartment-mappings]] table bridging them."
   where
-    mediumOf :: BiosphereFlow -> Text
-    mediumOf fl = let (Medium m, _) = flowMediumSub cmap fl in m
-    databaseMedia :: S.Set Text
-    databaseMedia = S.fromList (map mediumOf (concat (M.elems flowsByName)))
-    gaps :: [(Text, S.Set Text)]
+    -- The gap is between vocabularies, so the method's side stays the word the
+    -- method wrote: the ones worth reporting are precisely those this reader
+    -- cannot place, and a value would have nothing left to print.
+    statedMedium :: MethodCF -> Maybe Text
+    statedMedium cf = do
+        comp <- mcfCompartment cf
+        let Compartment med _ _ = normalizeCompartment cmap comp
+        pure med
+    databaseMedia :: S.Set Medium
+    databaseMedia =
+        S.fromList (mapMaybe (fst . flowMediumSub cmap) (concat (M.elems flowsByName)))
+    speaks :: Text -> Bool
+    speaks med = either (const False) (`S.member` databaseMedia) (parseMedium med)
+    gaps :: [(Text, S.Set Medium)]
     gaps =
         [ (stated, seen)
         | (cf, Nothing) <- mappings
-        , Just (Medium stated, _) <- [cfMediumSub cmap cf]
-        , stated `S.notMember` databaseMedia
+        , Just stated <- [statedMedium cf]
+        , not (speaks stated)
         , Just flows <- [M.lookup (normalizeName (mcfFlowName cf)) flowsByName]
-        , let seen = S.fromList (map mediumOf flows)
+        , let seen = S.fromList (mapMaybe (fst . flowMediumSub cmap) flows)
         , not (S.null seen)
         ]
     quoted :: S.Set Text -> Text
@@ -683,7 +698,7 @@ pickByCompartment cmap flows (Just stated) =
     flowSub :: BiosphereFlow -> Text
     flowSub = unSub . snd . flowMediumSub cmap
     inMedium :: BiosphereFlow -> Bool
-    inMedium fl = let (Medium m, _) = flowMediumSub cmap fl in mediumFits statedMed m
+    inMedium fl = mediumFits statedMed (fst (flowMediumSub cmap fl))
     exactMatch :: BiosphereFlow -> Bool
     exactMatch fl = inMedium fl && subcompartmentFits statedSub (flowSub fl)
     catchAllSub :: BiosphereFlow -> Bool
@@ -754,7 +769,7 @@ should be computed once per method and reused across inventories.
 data MethodTables = MethodTables
     { mtUuidCF :: !(M.Map UUID TableEntry)
     -- ^ UUID-matched CFs: exact flow id → CF
-    , mtUnitVariantCF :: !(M.Map (SR.NormName, Medium) TableEntry)
+    , mtUnitVariantCF :: !(M.Map (SR.NormName, MediumKey) TableEntry)
     {- ^ (unit-suffix-preserving normalized name, medium) → CF, holding only
     rows whose name carries a SimaPro unit suffix (@"Gas, natural\/m3"@).
     'normalizeName' strips that suffix, so a method's own per-unit rows
@@ -766,11 +781,11 @@ data MethodTables = MethodTables
     declared in its own unit. Consulted before the collapsed-name tables;
     same-key rows that disagree are dropped ('agreedValue' — never guess).
     -}
-    , mtExactCF :: !(M.Map (SR.NormName, Medium, Subcompartment) TableEntry)
+    , mtExactCF :: !(M.Map (SR.NormName, MediumKey, Subcompartment) TableEntry)
     -- ^ (normalized name, medium, subcompartment) → CF
-    , mtFallbackCF :: !(M.Map (SR.NormName, Medium) TableEntry)
+    , mtFallbackCF :: !(M.Map (SR.NormName, MediumKey) TableEntry)
     -- ^ (normalized name, medium) → CF for entries with unspecified subcompartment
-    , mtLongTermFallbackCF :: !(M.Map (SR.NormName, Medium) TableEntry)
+    , mtLongTermFallbackCF :: !(M.Map (SR.NormName, MediumKey) TableEntry)
     {- ^ (normalized name, medium) → CF for entries with the long-term
     UNSPECIFIED subcompartment ("unspecified (long-term)"). A long-term flow at an
     uncovered specific subcompartment ("groundwater, long-term") inherits this —
@@ -778,7 +793,7 @@ data MethodTables = MethodTables
     immediate-emission 'mtFallbackCF', so JRC scores delayed emissions with the
     method's own long-term factor rather than the immediate one.
     -}
-    , mtSubBlindCF :: !(M.Map (SR.NormName, Medium) TableEntry)
+    , mtSubBlindCF :: !(M.Map (SR.NormName, MediumKey) TableEntry)
     {- ^ (normalized name, medium) → CF, but only where the substance's
     factor is the SAME across every subcompartment — i.e. the subcompartment
     genuinely doesn't change it (mineral/metal extraction: "Cadmium, in ground"
@@ -786,7 +801,7 @@ data MethodTables = MethodTables
     unspecified fallback still resolve, without guessing for a substance whose
     factor DOES vary by sub (water by source), which is omitted as ambiguous.
     -}
-    , mtCasCF :: !(M.Map (SR.CASNumber, Medium) TableEntry)
+    , mtCasCF :: !(M.Map (SR.CASNumber, MediumKey) TableEntry)
     {- ^ (CAS, normalized medium) → CF, from non-regionalized CFs.
     Read-path fallback after UUID and name. Without it, a CF resolves to a
     single database flow at build time, so when many flows share one CAS in a
@@ -799,7 +814,7 @@ data MethodTables = MethodTables
     (minerals are reachable only through this bridge). Empty for methods whose
     CFs carry no CAS.
     -}
-    , mtRegionalCasCF :: !(M.Map (SR.CASNumber, Medium) (M.Map Location CF))
+    , mtRegionalCasCF :: !(M.Map (SR.CASNumber, MediumKey) (M.Map Location CF))
     {- ^ (CAS, normalized medium) → (location → CF), from regionalized
     CFs. The regionalized analogue of 'mtCasCF': lets the regionalized build
     characterize every same-CAS flow per location, not just the one a CF
@@ -906,16 +921,16 @@ the suggester is opt-in and only consulted on the small uncharacterized tail.
 
 * 'miCFs' — all CFs in source order; vector-indexed for cheap parallel arrays.
 * 'miCFTokens' — parallel to 'miCFs', each CF's normalized-name tokens.
-* 'miByMedium' — lowercase normalized medium → indices into 'miCFs', for
-  short-circuiting candidate scans to the same compartment medium.
-  Empty key holds CFs without compartment metadata.
+* 'miByMedium' — medium → indices into 'miCFs', for short-circuiting
+  candidate scans to the same compartment medium. The 'Nothing' key holds the
+  CFs whose compartment metadata names no medium this reader can place.
 * 'miByCAS' — normalized CAS → indices into 'miCFs'. Multiple CFs can share a
   CAS (same substance in different compartments); caller picks the best.
 -}
 data MethodIndex = MethodIndex
     { miCFs :: !(V.Vector MethodCF)
     , miCFTokens :: !(V.Vector (S.Set Text))
-    , miByMedium :: !(M.Map Text [Int])
+    , miByMedium :: !(M.Map MediumKey [Int])
     , miByCAS :: !(M.Map Text [Int])
     }
 
@@ -1037,10 +1052,10 @@ buildMethodIndex method =
     cfTokens :: MethodCF -> S.Set Text
     cfTokens = S.fromList . T.words . normalizeName . mcfFlowName
 
-    cfMedium :: MethodCF -> Text
-    cfMedium cf = case mcfCompartment cf of
-        Nothing -> ""
-        Just (Compartment med _ _) -> normalizeMedium (T.toLower med)
+    cfMedium :: MethodCF -> MediumKey
+    cfMedium cf = do
+        Compartment med _ _ <- mcfCompartment cf
+        either (const Nothing) Just (parseMedium med)
 
 {- | Build 'MethodTables' from raw mappings and a 'CompartmentMap'.
 
@@ -1161,10 +1176,12 @@ projectRegionalResourceFlows ::
 projectRegionalResourceFlows synDB bioFlows mappings =
     mappings ++ projected
   where
-    flowMedium = normalizeMedium . VT.bfCompartmentName
-    cfMedium cf = case mcfCompartment cf of
-        Just (Compartment m _ _) -> normalizeMedium (T.toLower m)
-        Nothing -> ""
+    flowMedium :: BiosphereFlow -> MediumKey
+    flowMedium = fmap VT.compartmentName . VT.bfCompartment
+    cfMedium :: MethodCF -> MediumKey
+    cfMedium cf = do
+        Compartment m _ _ <- mcfCompartment cf
+        either (const Nothing) Just (parseMedium m)
     -- A projection key (group/name, medium, region) drops the subcompartment, so
     -- two located CFs of the same substance can land on one key. 'M.fromList' would
     -- then keep whichever came last in 'mappings' — order-dependent and silent.
@@ -1176,7 +1193,7 @@ projectRegionalResourceFlows synDB bioFlows mappings =
     -- the output view, so an input-only bridge (@"river water"@ → @"Water,
     -- river"@) never lets a release flow inherit a withdrawal CF. On untyped data
     -- both views coincide, so this preserves today's grouping.
-    dirView med = viewFor (if med == "water" then Output else Input) synDB
+    dirView med = viewFor (if med == Just Water then Output else Input) synDB
     -- CFs reached two ways: by the matched flow's synonym GROUP — a CF whose
     -- name is bridged to the flow (withdrawal @"river water"@ → @"Water,
     -- river"@) — and by the CF's own NAME — a CF whose name equals the flow's
@@ -1184,7 +1201,7 @@ projectRegionalResourceFlows synDB bioFlows mappings =
     -- Keyed by 'Maybe' region: 'Just' entries are the located factors,
     -- 'Nothing' the method's own location-less (world-average) ones — the
     -- last step of the fallback chain.
-    byGroup :: M.Map (Int, Text, Maybe Text) MethodCF
+    byGroup :: M.Map (Int, MediumKey, Maybe Text) MethodCF
     byGroup =
         M.fromListWith
             preferHigherCF
@@ -1193,7 +1210,7 @@ projectRegionalResourceFlows synDB bioFlows mappings =
             , let med = flowMedium flow
             , Just grp <- [lookupSynonymGroup (dirView med) (bfName flow)]
             ]
-    byName :: M.Map (Text, Text, Maybe Text) MethodCF
+    byName :: M.Map (Text, MediumKey, Maybe Text) MethodCF
     byName =
         M.fromListWith
             preferHigherCF
@@ -1209,7 +1226,7 @@ projectRegionalResourceFlows synDB bioFlows mappings =
     -- carry located CFs too, but they must stay GLOBAL to match an unregionalized
     -- reference, so projecting their region-tagged flows would wrongly regionalize
     -- them.
-    isWaterMedium med = med == "resource" || med == "water"
+    isWaterMedium med = med == Just NaturalResource || med == Just Water
     -- The walk runs only for a method with located CFs in the water media: a
     -- location on an air/soil CF alone must not open the water fallback, and a
     -- method whose CFs are all unlocated (the name-regionalized SimaPro
@@ -1358,11 +1375,12 @@ foldSub (Subcompartment s) = Subcompartment (T.toLower (T.strip s))
 unSub :: Subcompartment -> Text
 unSub (Subcompartment s) = s
 
-cfMediumSub :: CompartmentMap -> MethodCF -> Maybe (Medium, Subcompartment)
+cfMediumSub :: CompartmentMap -> MethodCF -> Maybe (MediumKey, Subcompartment)
 cfMediumSub cmap cf = do
     comp <- mcfCompartment cf
     let Compartment normMedRaw normSub _ = normalizeCompartment cmap comp
-    pure (Medium (normalizeMedium (T.toLower normMedRaw)), Subcompartment normSub)
+    medium <- either (const Nothing) Just (parseMedium normMedRaw)
+    pure (Just medium, Subcompartment normSub)
 
 buildMethodTables :: CFFamily -> CompartmentMap -> EnergyDensityMap -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> MethodTables
 buildMethodTables methodFamily cmap energyDensities mappings =
@@ -2507,8 +2525,7 @@ cascadeTrail tables flowDB fid =
         -- stays unresolved. Self-scoping and last in the cascade: 'resourceCF'
         -- returns Nothing when the base element has no CF in the method.
         oreGradeOutcome
-            | Medium med <- baseMed
-            , med == "resource"
+            | baseMed == Just NaturalResource
             , "%" `T.isInfixOf` bfName flow
             , (base, rest) <- T.breakOn "," (bfName flow)
             , not (T.null rest) =
@@ -2526,12 +2543,6 @@ lookupCascadeEntry tables flowDB fid =
 
 lookupCascadeCF :: MethodTables -> BioFlowDB -> UUID -> Maybe CF
 lookupCascadeCF tables flowDB fid = teCF . snd <$> lookupCascadeEntry tables flowDB fid
-
--- | Normalize medium names between method CFs and database flows.
-normalizeMedium :: Text -> Text
-normalizeMedium m
-    | m == "natural resource" = "resource"
-    | otherwise = m
 
 {- | A subcompartment that names no specific subcompartment — empty, or either
 spelling of unspecified. Such a CF is the medium-level default: it
@@ -2670,19 +2681,13 @@ compartment normalization. Shared by the name/CAS read path
 same way. Subcomp resolution prefers the explicit 'compartmentSub' field,
 falling back to the tail of a @"medium/sub"@ category name.
 -}
-flowMediumSub :: CompartmentMap -> BiosphereFlow -> (Medium, Subcompartment)
+flowMediumSub :: CompartmentMap -> BiosphereFlow -> (MediumKey, Subcompartment)
 flowMediumSub cmap flow =
-    let rawCategory = T.toLower (VT.bfCompartmentName flow)
-        (rawMed, rawSubFromCat) = case T.breakOn "/" rawCategory of
-            (m, rest)
-                | T.null rest -> (m, T.empty)
-                | otherwise -> (m, T.drop 1 rest)
-        rawSub =
-            let s = T.toLower (fromMaybe T.empty (VT.bfCompartmentSub flow))
-             in if T.null s then rawSubFromCat else s
+    let rawMed = VT.bfCompartmentName flow
+        rawSub = T.toLower (fromMaybe T.empty (VT.bfCompartmentSub flow))
         Compartment normMedRaw normSub _ =
             normalizeCompartment cmap (Compartment rawMed rawSub T.empty)
-     in (Medium (normalizeMedium normMedRaw), Subcompartment normSub)
+     in (either (const Nothing) Just (parseMedium normMedRaw), Subcompartment normSub)
 
 {- | Flow→CF conversion factor for @qty@ units of flow, applying the
 energy-density bridge when it is needed and available.
@@ -3241,7 +3246,7 @@ findSimilarCFs syns idx flow maxN
     | otherwise =
         let flowName' = bfName flow
             flowCAS' = bfCAS flow
-            flowMedium = normalizeMedium (VT.bfCompartmentName flow)
+            flowMedium = VT.compartmentName <$> VT.bfCompartment flow
 
             flowRawTokens = S.fromList (T.words (normalizeName flowName'))
             flowExpTokens = expandedTokens syns flowName'

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -371,6 +371,20 @@ selectsFlow cf = \f -> prefix `T.isPrefixOf` T.toCaseFold (bfName f) && casFits 
     mediumEq :: Text -> Medium -> Bool
     mediumEq stated actual = parseMedium stated == Right actual
 
+{- | The medium a word names, or 'Nothing' when this reader cannot place it.
+The one conversion from a source's spelling to the value the tables key on.
+-}
+mediumKey :: Text -> MediumKey
+mediumKey = either (const Nothing) Just . parseMedium
+
+{- | The medium a factor states, after the compartment rules but before any
+table: 'Nothing' when it names none, or none this reader can place.
+-}
+cfMedium :: MethodCF -> MediumKey
+cfMedium cf = do
+    Compartment med _ _ <- mcfCompartment cf
+    mediumKey med
+
 {- | The medium axis of a lookup key: the medium a source stated, or 'Nothing'
 where it stated none. A flow whose file gave it no compartment keys on
 'Nothing' and meets no factor, which is also what a factor without one gets:
@@ -1052,11 +1066,6 @@ buildMethodIndex method =
     cfTokens :: MethodCF -> S.Set Text
     cfTokens = S.fromList . T.words . normalizeName . mcfFlowName
 
-    cfMedium :: MethodCF -> MediumKey
-    cfMedium cf = do
-        Compartment med _ _ <- mcfCompartment cf
-        either (const Nothing) Just (parseMedium med)
-
 {- | Build 'MethodTables' from raw mappings and a 'CompartmentMap'.
 
 The map is applied to each CF's compartment before keying the lookup
@@ -1178,10 +1187,6 @@ projectRegionalResourceFlows synDB bioFlows mappings =
   where
     flowMedium :: BiosphereFlow -> MediumKey
     flowMedium = fmap VT.compartmentName . VT.bfCompartment
-    cfMedium :: MethodCF -> MediumKey
-    cfMedium cf = do
-        Compartment m _ _ <- mcfCompartment cf
-        either (const Nothing) Just (parseMedium m)
     -- A projection key (group/name, medium, region) drops the subcompartment, so
     -- two located CFs of the same substance can land on one key. 'M.fromList' would
     -- then keep whichever came last in 'mappings' — order-dependent and silent.
@@ -1340,25 +1345,23 @@ entryPriority :: BuildProvenance -> Int
 entryPriority = maybe (strategyPriority ByProxy) strategyPriority . bpStrategy
 
 {- | The medium and subcompartment a characterization factor keys on, or
-'Nothing' when it states no compartment at all.
+'Nothing' when it states no compartment, and 'Nothing' too when it states a
+medium 'parseMedium' cannot place: such a factor is left out of the tables
+rather than filed under a word no flow is ever looked up by.
 
 The compartment-keyed tables 'buildMethodTables' fills are spelled in terms of
 this — one derivation rather than one per table. (It still runs per table; what
 is shared is the derivation, not its result. 'mtUuidCF' and 'mtRegionalizedCF'
 key on the flow, not on this pair.)
 
-It carries the newtypes rather than a bare pair of 'Text', for the reason its
-read-path twin 'flowMediumSub' does: the two components are both text, so a
-transposed binding would key every table with the medium and the subcompartment
-swapped, and type-check.
-
-The two are not yet interchangeable. 'flowMediumSub' case-folds its input
-before normalizing where this folds the medium after, and neither folds the
-subcompartment the table keys on. On a compartment map whose target columns
-carry a capital — nothing forbids one, and the shipped file simply has none —
-the two sides key differently and every factor for that medium goes silently
-unmatched. Closing that changes which factors resolve, so it wants its own
-change and its own test rather than a quiet edit here.
+The subcompartment is the half still spelled as its source wrote it, and this
+and its read-path twin 'flowMediumSub' do not fold it. On a compartment map
+whose target subcompartment column carries a capital — nothing forbids one, and
+the shipped file simply has none — the two sides key differently and every
+factor for that subcompartment goes silently unmatched. Closing that changes
+which factors resolve, so it wants its own change and its own test rather than
+a quiet edit here. The medium half is no longer exposed to it: both sides read
+their word with 'parseMedium', which folds.
 -}
 
 {- | A subcompartment as the matchers compare them: case-folded and trimmed.
@@ -1379,7 +1382,7 @@ cfMediumSub :: CompartmentMap -> MethodCF -> Maybe (MediumKey, Subcompartment)
 cfMediumSub cmap cf = do
     comp <- mcfCompartment cf
     let Compartment normMedRaw normSub _ = normalizeCompartment cmap comp
-    medium <- either (const Nothing) Just (parseMedium normMedRaw)
+    medium <- mediumKey normMedRaw
     pure (Just medium, Subcompartment normSub)
 
 buildMethodTables :: CFFamily -> CompartmentMap -> EnergyDensityMap -> [(MethodCF, Maybe (BiosphereFlow, MatchStrategy))] -> MethodTables
@@ -2687,7 +2690,7 @@ flowMediumSub cmap flow =
         rawSub = T.toLower (fromMaybe T.empty (VT.bfCompartmentSub flow))
         Compartment normMedRaw normSub _ =
             normalizeCompartment cmap (Compartment rawMed rawSub T.empty)
-     in (either (const Nothing) Just (parseMedium normMedRaw), Subcompartment normSub)
+     in (mediumKey normMedRaw, Subcompartment normSub)
 
 {- | Flow→CF conversion factor for @qty@ units of flow, applying the
 energy-density bridge when it is needed and available.

--- a/src/Method/Types.hs
+++ b/src/Method/Types.hs
@@ -15,7 +15,6 @@ module Method.Types (
     FlowDirection (..),
     Compartment (..),
     Location (..),
-    Medium (..),
     Subcompartment (..),
     CFFamily (..),
     cfFamily,
@@ -83,15 +82,6 @@ qualifier: "long-term" or ""
 -}
 data Compartment = Compartment !Text !Text !Text
     deriving (Eq, Show, Generic, NFData, Store, ToJSON, FromJSON)
-
-{- | A normalized compartment medium (the output of 'normalizeMedium' applied to
-a 'normalizeCompartment'-ed medium, e.g. @"air"@, @"water"@, @"resource"@). A
-lookup-key axis: distinguishing it from a bare 'Text' (and from a
-'Subcompartment') keeps the CF lookup tables from silently confusing a medium
-with a name or subcompartment.
--}
-newtype Medium = Medium Text
-    deriving (Eq, Ord, Show)
 
 {- | A normalized compartment subcompartment (e.g. @"surface water"@,
 @"(unspecified)"@). The third lookup-key axis alongside 'Medium' and a

--- a/src/Method/Types.hs
+++ b/src/Method/Types.hs
@@ -84,8 +84,8 @@ data Compartment = Compartment !Text !Text !Text
     deriving (Eq, Show, Generic, NFData, Store, ToJSON, FromJSON)
 
 {- | A normalized compartment subcompartment (e.g. @"surface water"@,
-@"(unspecified)"@). The third lookup-key axis alongside 'Medium' and a
-normalized name; a newtype so it can't be swapped with a medium in a key tuple.
+@"(unspecified)"@). A lookup-key axis alongside the medium and a normalized
+name; a newtype so it can't be swapped with either in a key tuple.
 -}
 newtype Subcompartment = Subcompartment Text
     deriving (Eq, Ord, Show)

--- a/test/CASBridgeAmbiguitySpec.hs
+++ b/test/CASBridgeAmbiguitySpec.hs
@@ -24,7 +24,7 @@ import qualified Data.UUID as UUID
 import Test.Hspec
 
 import Method.Mapping (MatchStrategy (..), buildMethodTables, cfValue, lookupCFForFlow, mtCasCF, mtRegionalCasCF, projectRegionalResourceFlows)
-import Method.Types (CFFamily (..), Compartment (..), FlowDirection (..), Medium (..), MethodCF (..))
+import Method.Types (CFFamily (..), Compartment (..), FlowDirection (..), MethodCF (..))
 import SubstanceRegistry (CASNumber (..))
 import SynonymDB (emptySynonymDB)
 import Types (
@@ -140,8 +140,8 @@ spec = describe "CAS bridge ambiguity guard" $ do
                     projectRegionalResourceFlows emptySynonymDB bioFlows mappings
 
         it "the projected copies veto both CAS bridges" $ do
-            M.lookup (CASNumber "7732-18-5", Medium "resource") (mtCasCF tables) `shouldBe` Nothing
-            M.lookup (CASNumber "7732-18-5", Medium "resource") (mtRegionalCasCF tables) `shouldBe` Nothing
+            M.lookup (CASNumber "7732-18-5", Just NaturalResource) (mtCasCF tables) `shouldBe` Nothing
+            M.lookup (CASNumber "7732-18-5", Just NaturalResource) (mtRegionalCasCF tables) `shouldBe` Nothing
 
         it "a deliberately excluded flow stays uncharacterized" $ do
             let turbine = mkFlow 99 "Water, turbine use" water

--- a/test/SharedCASCoverageSpec.hs
+++ b/test/SharedCASCoverageSpec.hs
@@ -35,7 +35,7 @@ import Test.Hspec
 
 import Method.Mapping
 import Method.ParserSimaPro (parseSimaProMethodCSVBytes)
-import Method.Types (Compartment (..), FlowDirection (..), Location (..), Medium (..), Method (..), MethodCF (..), MethodCollection (..))
+import Method.Types (Compartment (..), FlowDirection (..), Location (..), Method (..), MethodCF (..), MethodCollection (..))
 import SubstanceRegistry (CASNumber (..))
 import SynonymDB (buildFromPairs, emptySynonymDB, normalizeName)
 import Types (
@@ -469,9 +469,9 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
         it "routes a location-bearing CAS-matched CF to mtRegionalCasCF only" $ do
             mappings <- mapMethodFlows mapCtx regionalCasMethod
             let tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
-            M.lookup (CASNumber waterCAS, Medium "resource") (mtRegionalCasCF tables)
+            M.lookup (CASNumber waterCAS, Just NaturalResource) (mtRegionalCasCF tables)
                 `shouldBe` Just (M.fromList [(Location "FR", CF 9 (CFUnit "m3"))])
-            M.member (CASNumber waterCAS, Medium "resource") (mtCasCF tables) `shouldBe` False
+            M.member (CASNumber waterCAS, Just NaturalResource) (mtCasCF tables) `shouldBe` False
 
         it "keeps regionalized UUID-matched rows out of mtUuidCF" $ do
             mappings <- mapMethodFlows mapCtx uuidRegionalMethod
@@ -515,9 +515,9 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
                 Right coll -> do
                     mappings <- concat <$> mapM (mapMethodFlows mapCtx) (mcMethods coll)
                     let tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
-                    M.lookup (CASNumber waterCAS, Medium "resource") (mtCasCF tables)
+                    M.lookup (CASNumber waterCAS, Just NaturalResource) (mtCasCF tables)
                         `shouldBe` Nothing
-                    M.lookup (CASNumber waterCAS, Medium "water") (mtCasCF tables)
+                    M.lookup (CASNumber waterCAS, Just Water) (mtCasCF tables)
                         `shouldBe` Nothing
 
     describe "unspecified subcompartment is the medium-level fallback" $ do
@@ -543,7 +543,7 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
             mappings <- mapMethodFlows acrCtx acrMethod
             let tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
             -- indoor air is 100x; the bridge must not broadcast it.
-            fmap teCF (M.lookup (CASNumber acrCAS, Medium "air") (mtCasCF tables)) `shouldBe` Just (CF 1 (CFUnit "kg"))
+            fmap teCF (M.lookup (CASNumber acrCAS, Just Air) (mtCasCF tables)) `shouldBe` Just (CF 1 (CFUnit "kg"))
 
         it "reaches the flow with the unspecified factor, not the indoor max" $ do
             mappings <- mapMethodFlows acrCtx acrMethod
@@ -557,5 +557,5 @@ spec = describe "Water-use sign: CAS-shared resource flows must be characterized
             -- niche max — same rule as the non-regional 'mtCasCF'.
             mappings <- mapMethodFlows acrCtx acrRegionalMethod
             let tables = buildMethodTables OtherCFFamily M.empty M.empty mappings
-            M.lookup (CASNumber acrCAS, Medium "air") (mtRegionalCasCF tables)
+            M.lookup (CASNumber acrCAS, Just Air) (mtRegionalCasCF tables)
                 `shouldBe` Just (M.fromList [(Location "FR", CF 1 (CFUnit "kg"))])


### PR DESCRIPTION
#417 gave a flow's compartment a `Medium` value. The factor tables it is
looked up in still keyed on text: a `newtype Medium = Medium Text` holding
whatever `normalizeMedium` made of the method's own spelling, which is to say
`"natural resource"` folded to `"resource"` and everything else passed
through. Six sites lowercased and folded on their own account, and a key is
right only as long as every one of them folds the same way.

The key is the value now. `parseMedium` reads the spellings the four formats
write, so a factor and a flow either name the same medium or they do not, and
a medium no reader can place is a refusal rather than a key nothing ever asks
for. `normalizeMedium` goes, the method side's newtype goes, and the medium
axis of every lookup key reads `Maybe Medium`: `Nothing` is a source that
stated no medium, which meets nothing, exactly as the empty string did.

Two places keep text on purpose. The compartment gap warning reports the word
the method wrote, since a word this reader cannot place is what it exists to
report and a value would have nothing left to print. And `mediumFits` still
takes the method's stated word, parsing it where it compares.

Nothing a user sees changes: the same factors match the same flows, the same
warning fires on the same methods. The suite passes, 2490 examples.
