### PR TITLE
Stop building our library the dynamic way, in every mode

### DIFF
--- a/gen-cabal-config.sh
+++ b/gen-cabal-config.sh
@@ -30,8 +30,25 @@ VOLCA_OPT_LEVEL="${VOLCA_OPT_LEVEL:-2}"
 # which copy only volca.cabal + mumps-hs/ into the build context and write a
 # minimal cabal.project without `packages: .` machinery — still get jobs +
 # RTS allocation area + per-module GHC parallelism.
+#
+# shared / executable-dynamic sit here for the same reason: they apply to
+# every mode, not one. On a dynamic GHC, which is what ghcup installs for
+# macOS and for glibc Linux, cabal builds our library both ways unless told
+# not to, and every module is compiled twice. The CI log shows it plainly: a
+# `.dyn_o` next to the `.o` on every macOS Compiling line, where the Alpine
+# leg shows the `.o` alone. It buys nothing anywhere here, since no module in
+# this tree uses TemplateHaskell and the packaged binaries are standalone, so
+# a dynamic copy of our own library is never loaded.
+#
+# Both fields are needed, not one. Up to cabal-install 3.12 they are combined
+# with `liftM2 (||)`, so `shared: False` with the other unset is Nothing and
+# the compiler's own default wins - True, on a dynamic GHC. 3.14 honours
+# `shared` alone. Setting both makes the pair definite on either version.
 cat > "$OUTPUT" << 'EOF'
 jobs: $ncpus
+
+shared: False
+executable-dynamic: False
 
 program-options
   ghc-options: -j +RTS -A128m -RTS
@@ -87,7 +104,6 @@ EOF
         cat >> "$OUTPUT" << EOF
 optimization: 2
 split-sections: True
-shared: False
 executable-static: True
 
 extra-lib-dirs: $MUMPS_LIB_DIR
@@ -183,27 +199,9 @@ EOF
             DARWIN_NUMERIC_FLAGS=" -optl-L${OPENBLAS_PREFIX}/lib -optl-lopenblas -optl-L${GFORTRAN_LIB_DIR} -optl-lgfortran -optl-lquadmath"
         fi
         DARWIN_LINK_FLAGS="$DARWIN_MUMPS_FLAGS$DARWIN_NUMERIC_FLAGS $DARWIN_TAIL_FLAGS"
-        # shared: False, for the same reason musl mode sets it. Left to itself,
-        # cabal builds the library both ways on aarch64-darwin, and every
-        # module is compiled twice: the CI log shows a `.dyn_o` next to the
-        # `.o` on every line, where the Linux leg shows the `.o` alone. It buys
-        # nothing here - no module in this tree uses TemplateHaskell, and the
-        # packaged macOS binary is standalone, so a dynamic copy of our own
-        # library is never loaded.
-        #
-        # executable-dynamic: False is not redundant, it is what makes the line
-        # above bite on every cabal. Up to cabal-install 3.12 the two fields are
-        # combined with `liftM2 (||)`, so `shared: False` with the other unset
-        # is `Nothing` and the compiler's own default wins - and on a dynamic
-        # GHC, which is what ghcup installs for macOS, that default is True.
-        # 3.14 honours `shared` alone. Setting both makes the pair definite
-        # either way, so a developer on an older cabal gets the same build as
-        # CI instead of silently keeping the double compile.
         cat >> "$OUTPUT" << EOF
 optimization: 2
 split-sections: True
-shared: False
-executable-dynamic: False
 
 extra-lib-dirs: $MUMPS_LIB_DIR
 extra-include-dirs: $MUMPS_INCLUDE_DIR

--- a/gen-cabal-config.sh
+++ b/gen-cabal-config.sh
@@ -44,6 +44,14 @@ VOLCA_OPT_LEVEL="${VOLCA_OPT_LEVEL:-2}"
 # with `liftM2 (||)`, so `shared: False` with the other unset is Nothing and
 # the compiler's own default wins - True, on a dynamic GHC. 3.14 honours
 # `shared` alone. Setting both makes the pair definite on either version.
+#
+# The price is `cabal repl` on a GHC that is itself dynamic: the interpreter
+# loads packages the dynamic way only, so a repl on exe:volca or on the test
+# suite, both of which depend on the library, can no longer link it. Nothing
+# here runs a repl, and HLS is unaffected because it loads local components
+# from source. If you want one, build that invocation with --enable-shared.
+# In a checkout built before this line existed, delete dist-newstyle first:
+# the stale .so is still there, and a repl would quietly load it.
 cat > "$OUTPUT" << 'EOF'
 jobs: $ncpus
 

--- a/gen-cabal-config.sh
+++ b/gen-cabal-config.sh
@@ -183,9 +183,17 @@ EOF
             DARWIN_NUMERIC_FLAGS=" -optl-L${OPENBLAS_PREFIX}/lib -optl-lopenblas -optl-L${GFORTRAN_LIB_DIR} -optl-lgfortran -optl-lquadmath"
         fi
         DARWIN_LINK_FLAGS="$DARWIN_MUMPS_FLAGS$DARWIN_NUMERIC_FLAGS $DARWIN_TAIL_FLAGS"
+        # shared: False, for the same reason musl mode sets it. Left to itself,
+        # cabal builds the library both ways on aarch64-darwin, and every
+        # module is compiled twice: the CI log shows a `.dyn_o` next to the
+        # `.o` on every line, where the Linux leg shows the `.o` alone. It buys
+        # nothing here - no module in this tree uses TemplateHaskell, and the
+        # packaged macOS binary is standalone, so a dynamic copy of our own
+        # library is never loaded.
         cat >> "$OUTPUT" << EOF
 optimization: 2
 split-sections: True
+shared: False
 
 extra-lib-dirs: $MUMPS_LIB_DIR
 extra-include-dirs: $MUMPS_INCLUDE_DIR

--- a/gen-cabal-config.sh
+++ b/gen-cabal-config.sh
@@ -190,10 +190,20 @@ EOF
         # nothing here - no module in this tree uses TemplateHaskell, and the
         # packaged macOS binary is standalone, so a dynamic copy of our own
         # library is never loaded.
+        #
+        # executable-dynamic: False is not redundant, it is what makes the line
+        # above bite on every cabal. Up to cabal-install 3.12 the two fields are
+        # combined with `liftM2 (||)`, so `shared: False` with the other unset
+        # is `Nothing` and the compiler's own default wins - and on a dynamic
+        # GHC, which is what ghcup installs for macOS, that default is True.
+        # 3.14 honours `shared` alone. Setting both makes the pair definite
+        # either way, so a developer on an older cabal gets the same build as
+        # CI instead of silently keeping the double compile.
         cat >> "$OUTPUT" << EOF
 optimization: 2
 split-sections: True
 shared: False
+executable-dynamic: False
 
 extra-lib-dirs: $MUMPS_LIB_DIR
 extra-include-dirs: $MUMPS_INCLUDE_DIR


### PR DESCRIPTION
## Why

The macOS legs compile every library module twice. It is visible on every `Compiling` line of a build log:

```
macos-arm64 : Compiling API.Resources ( src/API/Resources.hs, .../API/Resources.o, .../API/Resources.dyn_o )
linux-amd64 : Compiling API.Resources ( src/API/Resources.hs, .../API/Resources.o )
```

A `.dyn_o` next to the `.o` on macOS, the `.o` alone on the Linux leg. That leg builds in Alpine, whose GHC is not dynamic, so the shared way was already off there. Everywhere GHC *is* dynamic, which is what ghcup installs for macOS and for glibc Linux, cabal builds our library both ways unless told not to.

It is worth separating this from "the macOS runners are slow", because the numbers say otherwise. From one run of the matrix, both legs restoring the same cache key and compiling the same 195 modules:

| phase | macos-arm64 | linux-amd64 (Alpine) |
|---|---|---|
| library, 87 modules | **2108 s** | 688 s |
| test suite, 108 modules | **61 s** | 141 s |

On the test suite, which is compiled one way only, macOS is more than twice as fast as Linux. Only the half that is compiled twice is slow. Everything outside `Build and test` totals under 150 s on either leg, so nothing else in the job is worth looking at.

## What changed

`shared: False` and `executable-dynamic: False`, in the preamble of `gen-cabal-config.sh` that the header already calls shared by every LINK_MODE. That covers the macOS CI legs and, for the same non-reason, a developer building on glibc Linux. It also drops musl's own copy of the flag, so the setting now has one home.

Two things worth knowing about the pair:

- **Both fields are needed, not one.** Up to cabal-install 3.12 they are combined with `liftM2 (||)`, so `shared: False` with the other unset yields `Nothing` and the compiler's default wins, which on a dynamic GHC is True. 3.14 honours `shared` alone. Setting both makes the pair definite on either version, so someone on an older cabal gets the same build as CI rather than silently keeping the double compile.
- **It reaches our own packages only.** Top-level fields in `cabal.project.local` apply to local packages, and cabal propagates the shared requirement downward from packages that need it, never upward. The dependency closure keeps its default, so the prebuilt cabal store still matches, and its hash does not cover this file anyway.

Nothing wants the dynamic copy: no module in this tree uses TemplateHaskell, and the packaged binaries are standalone.

## How this gets checked

`cabal build --dry-run` accepts the generated file and resolves a plan, so the two fields parse and are not rejected at top level.

The speed claim cannot be checked here, and this PR will not show it either: removing a build way never forces a recompilation, so a branch that touches no Haskell source restores its `dist-newstyle` and compiles nothing. The number lands on the first PR after this one that touches a module, against the 2108 s above.

What CI on this PR does show is the other half of the risk. If anything did want the dynamic library, it fails at link, loudly, on five platforms at once.


## What it costs

`cabal repl`, on a GHC that is itself dynamic. The interpreter loads packages the dynamic way only, so a repl on `exe:volca` or on the test suite, both of which depend on the library, can no longer link it. HLS is unaffected, since it loads local components from source, and nothing in the repository runs a repl. `--enable-shared` on that one invocation brings it back.

Worth knowing rather than discovering: a checkout built before this still holds its `.so`, so a repl there loads an outdated library instead of failing. Delete `dist-newstyle` once. The script says all of this at the line that sets the flags.

Checked and found nothing else that wants a shared Haskell object: no `foreign-library` stanza, no `foreign export`, no TemplateHaskell or plugins, `build-type: Simple` on both packages, pyvolca is HTTP only with no `ctypes` or `cffi`, and the container images build in musl mode, where the flag was already set.

One honest gap: no CI leg exercises `dynamic` mode. Both Linux rows run in the Alpine container, so that mode reaches developer machines unverified. What it does with the library is the static link the macOS legs already prove, so the gap is narrow, but it is there.
