### PR TITLE
Count a request while it runs, not only when it arrives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@
   before this are rebuilt on the next load. Wire revision 23.
 
 ### Fixed
+- A load slower than the idle timeout no longer shuts the server down under the
+  caller. The timeout counted the moment a request *arrived*, so a request that
+  is itself long counted as silence for its whole duration: reading a gigabyte
+  of source and building its matrices takes longer than the five minutes a
+  client typically arms, and the process exited mid-load, leaving a closed
+  socket and no answer to say what happened. A request now counts while it
+  runs, and the deadline cannot pass while one is in flight. A server that is
+  genuinely unused still shuts down on time.
 - A SimaPro export now writes a substitution once. The `Materials/fuels` section
   holds inputs, but the line that built it excluded only the reference product, so
   a coproduct and an avoided product were written there as well as under the header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,12 @@
   is itself long counted as silence for its whole duration: reading a gigabyte
   of source and building its matrices takes longer than the five minutes a
   client typically arms, and the process exited mid-load, leaving a closed
-  socket and no answer to say what happened. A request now counts while it
-  runs, and the deadline cannot pass while one is in flight. A server that is
-  genuinely unused still shuts down on time.
+  socket and no answer to say what happened. A request now counts while it runs,
+  and the deadline cannot pass while one is in flight. That holds for an
+  assistant's tool call as much as for an HTTP one, which is where a load is
+  most often asked for. A server that is genuinely unused still shuts down on
+  time, and a log stream left open is not mistaken for someone working: it says
+  the server was in use when it was opened, and nothing after that.
 - A SimaPro export now writes a substitution once. The `Materials/fuels` section
   holds inputs, but the line that built it excluded only the reference product, so
   a coproduct and an avoided product were written there as well as under the header

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -24,7 +24,7 @@ import Text.Read (readMaybe)
 
 -- VoLCA imports
 import API.Auth (authMiddleware)
-import App.Idle (IdleState (..), idleTrackingMiddleware, idleWatchdog, newIdleState, stampIdle)
+import App.Idle (IdleState (..), idleTrackingMiddleware, idleWatchdog, newIdleState, stampIdle, whileWorking)
 import CLI.Client (executeRemoteCommand, resolveRemoteConfig)
 import CLI.Command (executeCommand)
 import CLI.Parser (cliParserInfo)
@@ -41,7 +41,7 @@ import Progress
 
 import API.DatabaseHandlers (uploadBodyCeiling)
 import API.Licenses (licensesResponse)
-import API.MCP (mcpApp, toolDefinitions)
+import API.MCP (WhileWorking, mcpApp, toolDefinitions)
 import API.Routes (lcaAPI, lcaServer, volcaOpenApi)
 import App.Env (AppEnv (..))
 import Data.Aeson (encode, object, (.=))
@@ -286,7 +286,7 @@ runServerWithConfig cliConfig serverOpts mCfgFile = do
             staticDir
             (serverDesktopMode serverOpts)
             (scName (cfgServer config))
-            (stampIdle idle)
+            (whileWorking idle)
     let finalApp =
             uploadSizeLimitMiddleware (cfgHosting config) $
                 wrapWithMiddleware password (cfgHosting config) idle baseApp
@@ -402,15 +402,15 @@ logRequest req = do
     hFlush stdout
 
 -- | Create a Wai application over a ready environment.
-createServerApp :: AppEnv -> FilePath -> Bool -> Maybe ServerName -> IO () -> IO Application
-createServerApp env staticDir desktopMode serverName markActivity = do
+createServerApp :: AppEnv -> FilePath -> Bool -> Maybe ServerName -> WhileWorking -> IO Application
+createServerApp env staticDir desktopMode serverName whileCalling = do
     -- The MCP @web_url@ deep links point at Elm SPA routes served from
     -- 'staticDir'. When the SPA is not bundled (backend-only image), those
     -- URLs would 404, so we omit 'web_url' from MCP responses entirely.
     hasFrontend <- doesFileExist (staticDir </> "index.html")
     unless (desktopMode || hasFrontend) $
         reportProgress Info "Frontend not bundled. MCP responses will omit 'web_url'"
-    mcp <- mcpApp (aeDbManager env) (aeClassificationPresets env) hasFrontend (aeHostingConfig env) serverName markActivity
+    mcp <- mcpApp (aeDbManager env) (aeClassificationPresets env) hasFrontend (aeHostingConfig env) serverName whileCalling
     let apiApp = serve lcaAPI (lcaServer env)
     pure $ \req respond -> do
         unless desktopMode (logRequest req)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,7 +13,6 @@ import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
 import Foreign.C.Types (CInt (..))
 import Options.Applicative
 import System.Directory (doesFileExist)
@@ -25,6 +24,7 @@ import Text.Read (readMaybe)
 
 -- VoLCA imports
 import API.Auth (authMiddleware)
+import App.Idle (IdleState (..), idleTrackingMiddleware, idleWatchdog, newIdleState, stampIdle)
 import CLI.Client (executeRemoteCommand, resolveRemoteConfig)
 import CLI.Command (executeCommand)
 import CLI.Parser (cliParserInfo)
@@ -50,7 +50,6 @@ import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Char8 as C8
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import Data.String (fromString)
-import qualified Matrix
 import Network.HTTP.Types (status200, status403)
 import Network.HTTP.Types.Header (hCacheControl, hContentType, hPragma)
 import Network.Wai (Application, Middleware, Request (..), Response, ResponseReceived, mapResponseHeaders, pathInfo, rawPathInfo, rawQueryString, requestHeaders, requestMethod, responseLBS, responseStream)
@@ -223,28 +222,27 @@ logServerStartup serverOpts host port password
             Nothing -> "Authentication: DISABLED (use --password or VOLCA_PASSWORD to enable)"
         reportProgress Info ("Web interface available at: http://" ++ T.unpack (clientHost host) ++ ":" ++ show port ++ "/")
 
-{- | Allocate the idle-tracking refs and fork the watchdog when
-@--idle-timeout@ is positive. The refs are returned for both the
+{- | Allocate the idle-tracking state and fork the watchdog when
+@--idle-timeout@ is positive. The state is returned for both the
 tracking and the shutdown middleware.
 -}
-setupIdleTimeout :: ServerOptions -> IO (IORef UTCTime, IORef Bool)
+setupIdleTimeout :: ServerOptions -> IO IdleState
 setupIdleTimeout serverOpts = do
-    lastRequestRef <- newIORef =<< getCurrentTime
-    idleActiveRef <- newIORef False
+    idle <- newIdleState
     let idleTimeout = serverIdleTimeout serverOpts
     when (idleTimeout > 0) $ do
         reportProgress Info ("Idle timeout: " ++ show idleTimeout ++ "s")
-        writeIORef idleActiveRef True
-        _ <- forkIO (idleWatchdog lastRequestRef idleActiveRef idleTimeout)
+        writeIORef (idleArmed idle) True
+        _ <- forkIO (idleWatchdog idle idleTimeout (shutDownIdle idleTimeout))
         pure ()
-    pure (lastRequestRef, idleActiveRef)
+    pure idle
 
 -- | Stack idle-tracking, shutdown-endpoint and (optionally) auth middleware.
-wrapWithMiddleware :: Maybe String -> Maybe HostingConfig -> IORef UTCTime -> IORef Bool -> Application -> Application
-wrapWithMiddleware password mHosting lastRequestRef idleActiveRef baseApp =
+wrapWithMiddleware :: Maybe String -> Maybe HostingConfig -> IdleState -> Application -> Application
+wrapWithMiddleware password mHosting idle baseApp =
     let withIdleAndShutdown =
-            idleTrackingMiddleware lastRequestRef $
-                shutdownEndpoint mHosting lastRequestRef idleActiveRef baseApp
+            idleTrackingMiddleware idle $
+                shutdownEndpoint mHosting idle baseApp
      in case password of
             Just pwd -> authMiddleware (C8.pack pwd) withIdleAndShutdown
             Nothing -> withIdleAndShutdown
@@ -271,7 +269,7 @@ runServerWithConfig cliConfig serverOpts mCfgFile = do
     logLoadedDatabases dbManager
     let staticDir = fromMaybe "web/dist" (serverStaticDir serverOpts)
     password <- resolvePassword (globalOptions cliConfig) (cfgServer config)
-    (lastRequestRef, idleActiveRef) <- setupIdleTimeout serverOpts
+    idle <- setupIdleTimeout serverOpts
     dataVersion <- readDataVersion config
     let env =
             AppEnv
@@ -288,10 +286,10 @@ runServerWithConfig cliConfig serverOpts mCfgFile = do
             staticDir
             (serverDesktopMode serverOpts)
             (scName (cfgServer config))
-            (getCurrentTime >>= writeIORef lastRequestRef)
+            (stampIdle idle)
     let finalApp =
             uploadSizeLimitMiddleware (cfgHosting config) $
-                wrapWithMiddleware password (cfgHosting config) lastRequestRef idleActiveRef baseApp
+                wrapWithMiddleware password (cfgHosting config) idle baseApp
         settings = setTimeout 600 defaultSettings
     case listenOn (serverPort serverOpts) (cfgServer config) of
         ListenOnFreeLoopbackPort -> do
@@ -460,18 +458,6 @@ validateCLIConfig (CLIConfig globalOpts mCmd) =
   where
     ownCsv = maybe False rendersOwnCsv mCmd
 
-{- | WAI middleware that updates the last-request timestamp on every request.
-
-@\/mcp@ is exempt: a connected assistant polls it on its own initiative, so
-counting those requests would keep an idle server alive with nobody at the
-other end. That endpoint marks activity itself, for the calls that are someone
-asking a question ('API.MCP.mcpCountsAsActivity').
--}
-idleTrackingMiddleware :: IORef UTCTime -> Application -> Application
-idleTrackingMiddleware ref app req respond = do
-    unless (rawPathInfo req == "/mcp") (getCurrentTime >>= writeIORef ref)
-    app req respond
-
 {- | Middleware that handles POST /api/v1/idle-timeout/{seconds} and POST /api/v1/shutdown
 0 = cancel timeout, N>0 = activate/restart idle watchdog
 
@@ -479,8 +465,8 @@ Both endpoints decide the lifetime of the whole process, so a read-only
 instance refuses them: on a server answering many unrelated callers, one of
 them must not be able to shut it down under the others.
 -}
-shutdownEndpoint :: Maybe HostingConfig -> IORef UTCTime -> IORef Bool -> Application -> Application
-shutdownEndpoint mHosting lastRequestRef idleActiveRef app req respond =
+shutdownEndpoint :: Maybe HostingConfig -> IdleState -> Application -> Application
+shutdownEndpoint mHosting idle app req respond =
     case (requestMethod req, BS.stripPrefix "/api/v1/idle-timeout/" path, path) of
         ("POST", _, "/api/v1/shutdown")
             | isReadOnly readOnly -> refuse
@@ -494,14 +480,14 @@ shutdownEndpoint mHosting lastRequestRef idleActiveRef app req respond =
                 let seconds = fromMaybe 30 (readMaybe (C8.unpack secondsBS)) :: Int
                 if seconds <= 0
                     then do
-                        writeIORef idleActiveRef False
+                        writeIORef (idleArmed idle) False
                         reportProgress Info "Idle timeout cancelled"
                     else do
-                        alreadyActive <- readIORef idleActiveRef
-                        writeIORef idleActiveRef True
-                        getCurrentTime >>= writeIORef lastRequestRef
+                        alreadyActive <- readIORef (idleArmed idle)
+                        writeIORef (idleArmed idle) True
+                        stampIdle idle
                         unless alreadyActive $ do
-                            _ <- forkIO $ idleWatchdog lastRequestRef idleActiveRef seconds
+                            _ <- forkIO $ idleWatchdog idle seconds (shutDownIdle seconds)
                             pure ()
                         reportProgress Info $ "Idle timeout: " ++ show seconds ++ "s"
                 ok
@@ -517,32 +503,8 @@ shutdownEndpoint mHosting lastRequestRef idleActiveRef app req respond =
                 [(hContentType, "application/json")]
                 (encode (object ["error" .= readOnlyRefusalFor mHosting]))
 
-{- | Background thread that exits the server after the idle timeout (seconds).
-
-Two things count as being in use, because one alone would be wrong. An HTTP
-request proves someone is there: reading a process sheet resolves no matrix,
-and that reader must not lose the server under them. A matrix solve proves
-expensive work is under way, which may well outlast the request that asked for
-it. So the deadline moves on either, and the solve count is read first: a solve
-that lands in the last seconds has to be seen before the deadline is judged.
--}
-idleWatchdog :: IORef UTCTime -> IORef Bool -> Int -> IO ()
-idleWatchdog ref activeRef timeoutSecs = go =<< Matrix.readSolveCounter
-  where
-    checkInterval = min (timeoutSecs * 1000000) (5 * 1000000) -- check every 5s or timeout, whichever is shorter
-    go lastSeen = do
-        threadDelay checkInterval
-        active <- readIORef activeRef
-        if not active
-            then pure ()
-            else do
-                solves <- Matrix.readSolveCounter
-                when (solves /= lastSeen) (getCurrentTime >>= writeIORef ref)
-                now <- getCurrentTime
-                lastReq <- readIORef ref
-                let idleSeconds = realToFrac (diffUTCTime now lastReq) :: Double
-                if idleSeconds >= fromIntegral timeoutSecs
-                    then do
-                        reportProgress Info $ "Idle for " ++ show timeoutSecs ++ "s, shutting down."
-                        hardExit
-                    else go solves
+-- | Say why the process is going, then go: the log line is the only trace left.
+shutDownIdle :: Int -> IO ()
+shutDownIdle timeoutSecs = do
+    reportProgress Info $ "Idle for " ++ show timeoutSecs ++ "s, shutting down."
+    hardExit

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -5,7 +5,7 @@ Implements Streamable HTTP transport (MCP spec 2025-03-26).
 POST /mcp handles initialize, tools/list, tools/call (JSON or SSE response).
 GET  /mcp opens an SSE stream for server-initiated messages (stateless: closes immediately).
 -}
-module API.MCP (mcpApp, mcpCountsAsActivity, toolDefinitions, callTool, selectMethod, handleInitialize, webUrlBase, RpcRequest (..)) where
+module API.MCP (mcpApp, mcpCountsAsActivity, WhileWorking, toolDefinitions, callTool, selectMethod, handleInitialize, webUrlBase, RpcRequest (..)) where
 
 import Control.Concurrent.STM (readTVarIO)
 import Data.Aeson
@@ -45,7 +45,7 @@ import API.MCP.Columnar (resolveSingleScoringSet, toColumnarBatch)
 import API.MCP.Enrich (addWebUrlMaybe, attachMarketHintByName, encodeSegment, filterScoringSets, scoreActivityWebUrl, slimLCIAPanel, webUrlField)
 import API.Routes (collectionNotLoadedMessage)
 import API.Types (ActivityForAPI (..), ActivityInfo (..), ClassificationSystem (..), ExchangeEditRequest (..), ExchangeWithUnit (..), InventoryExport (..), InventoryFlowDetail (..), Perturbation (..), Substitution (..), SubstitutionRequest (..), toExchangeEdits)
-import Control.Monad (mfilter, unless, when)
+import Control.Monad (mfilter, unless)
 import qualified Data.List as L
 import Matrix (applyBiosphereMatrix)
 import qualified Method.Explain as Explain
@@ -157,15 +157,23 @@ webUrlBase hasFrontend hdrs
         "" -> "localhost"
         h -> h
 
+{- | Runs one MCP call with the server counted as in use for its whole duration.
+
+A tool call is not an instant: it can be a load that reads a gigabyte of source
+and builds its matrices. A server that shuts itself down when idle must not
+decide it is idle in the middle of one, so the call is wrapped rather than
+merely noted as it arrives. A server with no such policy passes 'id'.
+-}
+type WhileWorking = IO (Maybe Value) -> IO (Maybe Value)
+
 {- | Build the @\/mcp@ endpoint.
 
-@markActivity@ is called for every request that 'mcpCountsAsActivity' accepts.
-A server that shuts itself down when idle uses it to tell a working client from
-a merely connected one; a server with no such policy passes an action that does
-nothing.
+@whileWorking@ wraps every request that 'mcpCountsAsActivity' accepts, which is
+how a server that shuts itself down when idle tells a working client from a
+merely connected one.
 -}
-mcpApp :: DatabaseManager -> [ClassificationPreset] -> Bool -> Maybe HostingConfig -> Maybe ServerName -> IO () -> IO Application
-mcpApp dbManager presets hasFrontend mHosting mName markActivity = do
+mcpApp :: DatabaseManager -> [ClassificationPreset] -> Bool -> Maybe HostingConfig -> Maybe ServerName -> WhileWorking -> IO Application
+mcpApp dbManager presets hasFrontend mHosting mName whileWorking = do
     (a, b) <- (,) <$> (randomIO :: IO Int) <*> (randomIO :: IO Int)
     let sessionId = T.pack $ show (abs a) ++ "-" ++ show (abs b)
     stateRef <- newIORef McpState{mcpSessionId = sessionId}
@@ -183,8 +191,8 @@ mcpApp dbManager presets hasFrontend mHosting mName markActivity = do
                     Left err ->
                         respond $ jsonResponse (mcpSessionId st) $ rpcError Null (-32700) (T.pack $ "Parse error: " ++ err)
                     Right rpcReq -> do
-                        when (mcpCountsAsActivity (rpcMethod rpcReq)) markActivity
-                        resp <- handleRpc dbManager presets mHosting mBaseUrl mName st rpcReq
+                        let runCall = if mcpCountsAsActivity (rpcMethod rpcReq) then whileWorking else id
+                        resp <- runCall (handleRpc dbManager presets mHosting mBaseUrl mName st rpcReq)
                         case resp of
                             Nothing ->
                                 respond $

--- a/src/App/Idle.hs
+++ b/src/App/Idle.hs
@@ -14,6 +14,9 @@ module App.Idle (
     IdleState (..),
     newIdleState,
     stampIdle,
+    whileWorking,
+    Bearing (..),
+    bearingOf,
     idleTrackingMiddleware,
     idleWatchdog,
 ) where
@@ -21,6 +24,7 @@ module App.Idle (
 import Control.Concurrent (threadDelay)
 import Control.Exception (bracket_)
 import Control.Monad (when)
+import Data.ByteString (ByteString)
 import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef, writeIORef)
 import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
 import Network.Wai (Application, rawPathInfo)
@@ -44,22 +48,57 @@ newIdleState = IdleState <$> (newIORef =<< getCurrentTime) <*> newIORef 0 <*> ne
 stampIdle :: IdleState -> IO ()
 stampIdle idle = getCurrentTime >>= writeIORef (idleLastRequest idle)
 
-{- | WAI middleware that records that a request is happening, and while it runs.
+-- | What a request on a given path says about the server being in use.
+data Bearing
+    = {- | The ordinary answer: someone asked, and the server is in use until
+      they have their reply, however long that takes.
+      -}
+      Counted
+    | {- | Someone asked, and how long the answer takes says nothing. A log
+      stream stays open for as long as a reader leaves a terminal open;
+      counting that would keep the server alive, and billing, for ever.
+      -}
+      Stamped
+    | {- | It says nothing at all, because that endpoint answers the question
+      itself: a connected assistant polls @\/mcp@ on its own initiative, and
+      counting those would keep an idle server alive with nobody there.
+      -}
+      Ignored
+    deriving (Eq, Show)
 
-@\/mcp@ is exempt: a connected assistant polls it on its own initiative, so
-counting those requests would keep an idle server alive with nobody at the
-other end. That endpoint marks activity itself, for the calls that are someone
-asking a question ('API.MCP.mcpCountsAsActivity').
+bearingOf :: ByteString -> Bearing
+bearingOf path = case path of
+    "/mcp" -> Ignored
+    "/api/v1/logs/stream" -> Stamped
+    _ -> Counted
+
+{- | Count the server as in use for as long as an action runs.
+
+Both stamps carry their weight. The one before the count rises closes the
+window where a watchdog tick lands after the request arrived and before it was
+counted; the one before the count falls closes the same window at the other
+end.
 -}
-idleTrackingMiddleware :: IdleState -> Application -> Application
-idleTrackingMiddleware idle app req respond
-    | rawPathInfo req == "/mcp" = app req respond
-    | otherwise = do
-        stampIdle idle
-        bracket_ (bump 1) (bump (-1) >> stampIdle idle) (app req respond)
+whileWorking :: IdleState -> IO a -> IO a
+whileWorking idle action = do
+    stampIdle idle
+    bracket_ (bump 1) (stampIdle idle >> bump (-1)) action
   where
     bump :: Int -> IO ()
     bump delta = atomicModifyIORef' (idleInFlight idle) (\n -> (n + delta, ()))
+
+{- | WAI middleware that records that a request is happening, and while it runs.
+
+The timestamp alone said when a request /arrived/, which is not when the server
+was last in use: a load that reads a gigabyte of source and builds its matrices
+can outlast the whole timeout, and the watchdog would then shut the process down
+under the caller, who sees a closed socket and no answer.
+-}
+idleTrackingMiddleware :: IdleState -> Application -> Application
+idleTrackingMiddleware idle app req respond = case bearingOf (rawPathInfo req) of
+    Counted -> whileWorking idle (app req respond)
+    Stamped -> stampIdle idle >> app req respond
+    Ignored -> app req respond
 
 {- | Watch until the server has gone unused for @timeoutSecs@, then run
 @onIdle@ - the process exits in production, and a test records that it would

--- a/src/App/Idle.hs
+++ b/src/App/Idle.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | When a server has gone unused, and what counts as being used.
+
+Three things count, because any two alone would be wrong. An HTTP request
+proves someone is there. A matrix solve proves expensive work is under way,
+which may well outlast the request that asked for it. And a request still
+running is the server being used right now, however long it takes: a load that
+reads a gigabyte of source and builds its matrices can outlast the whole
+timeout, and shutting down under it hands the caller a closed socket and no
+answer at all.
+-}
+module App.Idle (
+    IdleState (..),
+    newIdleState,
+    stampIdle,
+    idleTrackingMiddleware,
+    idleWatchdog,
+) where
+
+import Control.Concurrent (threadDelay)
+import Control.Exception (bracket_)
+import Control.Monad (when)
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef, writeIORef)
+import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
+import Network.Wai (Application, rawPathInfo)
+
+import qualified Matrix
+
+-- | What the idle watchdog reads to decide the server is unused.
+data IdleState = IdleState
+    { idleLastRequest :: !(IORef UTCTime)
+    -- ^ When the server was last known to be in use.
+    , idleInFlight :: !(IORef Int)
+    -- ^ How many requests are running right now.
+    , idleArmed :: !(IORef Bool)
+    -- ^ Whether a watchdog is watching at all.
+    }
+
+newIdleState :: IO IdleState
+newIdleState = IdleState <$> (newIORef =<< getCurrentTime) <*> newIORef 0 <*> newIORef False
+
+-- | Move the idle deadline to now.
+stampIdle :: IdleState -> IO ()
+stampIdle idle = getCurrentTime >>= writeIORef (idleLastRequest idle)
+
+{- | WAI middleware that records that a request is happening, and while it runs.
+
+@\/mcp@ is exempt: a connected assistant polls it on its own initiative, so
+counting those requests would keep an idle server alive with nobody at the
+other end. That endpoint marks activity itself, for the calls that are someone
+asking a question ('API.MCP.mcpCountsAsActivity').
+-}
+idleTrackingMiddleware :: IdleState -> Application -> Application
+idleTrackingMiddleware idle app req respond
+    | rawPathInfo req == "/mcp" = app req respond
+    | otherwise = do
+        stampIdle idle
+        bracket_ (bump 1) (bump (-1) >> stampIdle idle) (app req respond)
+  where
+    bump :: Int -> IO ()
+    bump delta = atomicModifyIORef' (idleInFlight idle) (\n -> (n + delta, ()))
+
+{- | Watch until the server has gone unused for @timeoutSecs@, then run
+@onIdle@ - the process exits in production, and a test records that it would
+have. Returns as soon as the watchdog is disarmed.
+
+The solve count is read before the deadline is judged: a solve that lands in
+the last seconds has to be seen before the clock is.
+-}
+idleWatchdog :: IdleState -> Int -> IO () -> IO ()
+idleWatchdog idle timeoutSecs onIdle = go =<< Matrix.readSolveCounter
+  where
+    checkInterval :: Int
+    checkInterval = min (timeoutSecs * 1000000) (5 * 1000000) -- every 5s, or the timeout when shorter
+    go :: Int -> IO ()
+    go lastSeen = do
+        threadDelay checkInterval
+        armed <- readIORef (idleArmed idle)
+        when armed $ do
+            solves <- Matrix.readSolveCounter
+            running <- readIORef (idleInFlight idle)
+            when (solves /= lastSeen || running > 0) (stampIdle idle)
+            elapsed <- secondsSinceLastRequest
+            if elapsed >= fromIntegral timeoutSecs
+                then onIdle
+                else go solves
+
+    secondsSinceLastRequest :: IO Double
+    secondsSinceLastRequest = do
+        now <- getCurrentTime
+        realToFrac . diffUTCTime now <$> readIORef (idleLastRequest idle)

--- a/test/IdleSpec.hs
+++ b/test/IdleSpec.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | The idle watchdog decides when a server is unused. It must not decide that
+while the server is answering.
+-}
+module IdleSpec (spec) where
+
+import Control.Concurrent (forkIO, threadDelay)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Network.HTTP.Types (status200)
+import Network.Wai (Application, defaultRequest, responseLBS)
+import Network.Wai.Internal (ResponseReceived (..))
+import Test.Hspec
+
+import App.Idle (IdleState (..), idleTrackingMiddleware, idleWatchdog, newIdleState)
+
+spec :: Spec
+spec = describe "Idle watchdog" $ do
+    it "does not shut down under a request that outlasts the timeout" $ do
+        idle <- armed
+        fired <- newIORef False
+        _ <- forkIO (idleWatchdog idle 1 (writeIORef fired True))
+        runOnce (idleTrackingMiddleware idle (slowApp 2500000))
+        readIORef fired `shouldReturn` False
+
+    it "shuts down once nothing is running any more" $ do
+        idle <- armed
+        fired <- newIORef False
+        _ <- forkIO (idleWatchdog idle 1 (writeIORef fired True))
+        runOnce (idleTrackingMiddleware idle (slowApp 0))
+        threadDelay 3000000
+        readIORef fired `shouldReturn` True
+
+armed :: IO IdleState
+armed = do
+    idle <- newIdleState
+    writeIORef (idleArmed idle) True
+    pure idle
+
+-- | An application that takes its time before answering.
+slowApp :: Int -> Application
+slowApp micros _ respond = do
+    threadDelay micros
+    respond (responseLBS status200 [] "ok")
+
+{- | Put one request through an application. It returns when the application
+has answered, which is what makes the first test a test: the watchdog gets its
+chance to fire while this is still waiting.
+-}
+runOnce :: Application -> IO ()
+runOnce app = do
+    ResponseReceived <- app defaultRequest (\_ -> pure ResponseReceived)
+    pure ()

--- a/test/IdleSpec.hs
+++ b/test/IdleSpec.hs
@@ -6,30 +6,49 @@ while the server is answering.
 module IdleSpec (spec) where
 
 import Control.Concurrent (forkIO, threadDelay)
+import Data.ByteString (ByteString)
 import Data.IORef (newIORef, readIORef, writeIORef)
 import Network.HTTP.Types (status200)
-import Network.Wai (Application, defaultRequest, responseLBS)
+import Network.Wai (Application, Request (..), defaultRequest, responseLBS)
 import Network.Wai.Internal (ResponseReceived (..))
 import Test.Hspec
 
-import App.Idle (IdleState (..), idleTrackingMiddleware, idleWatchdog, newIdleState)
+import App.Idle (Bearing (..), IdleState (..), bearingOf, idleTrackingMiddleware, idleWatchdog, newIdleState)
 
 spec :: Spec
-spec = describe "Idle watchdog" $ do
-    it "does not shut down under a request that outlasts the timeout" $ do
-        idle <- armed
-        fired <- newIORef False
-        _ <- forkIO (idleWatchdog idle 1 (writeIORef fired True))
-        runOnce (idleTrackingMiddleware idle (slowApp 2500000))
-        readIORef fired `shouldReturn` False
+spec = do
+    describe "Idle watchdog" $ do
+        it "does not shut down under a request that outlasts the timeout" $ do
+            idle <- armed
+            fired <- newIORef False
+            _ <- forkIO (idleWatchdog idle 1 (writeIORef fired True))
+            runOnce (idleTrackingMiddleware idle (slowApp 2500000)) "/api/v1/db"
+            readIORef fired `shouldReturn` False
 
-    it "shuts down once nothing is running any more" $ do
-        idle <- armed
-        fired <- newIORef False
-        _ <- forkIO (idleWatchdog idle 1 (writeIORef fired True))
-        runOnce (idleTrackingMiddleware idle (slowApp 0))
-        threadDelay 3000000
-        readIORef fired `shouldReturn` True
+        it "shuts down once nothing is running any more" $ do
+            idle <- armed
+            fired <- newIORef False
+            _ <- forkIO (idleWatchdog idle 1 (writeIORef fired True))
+            runOnce (idleTrackingMiddleware idle (slowApp 0)) "/api/v1/db"
+            threadDelay 3000000
+            readIORef fired `shouldReturn` True
+
+        it "shuts down under a log stream left open" $ do
+            idle <- armed
+            fired <- newIORef False
+            _ <- forkIO (idleWatchdog idle 1 (writeIORef fired True))
+            runOnce (idleTrackingMiddleware idle (slowApp 3000000)) "/api/v1/logs/stream"
+            readIORef fired `shouldReturn` True
+
+    describe "What a path says about the server being in use" $ do
+        it "counts an ordinary request for as long as it runs" $
+            bearingOf "/api/v1/db" `shouldBe` Counted
+
+        it "does not let an open log stream stand for someone working" $
+            bearingOf "/api/v1/logs/stream" `shouldBe` Stamped
+
+        it "leaves the assistant endpoint to judge its own calls" $
+            bearingOf "/mcp" `shouldBe` Ignored
 
 armed :: IO IdleState
 armed = do
@@ -43,11 +62,11 @@ slowApp micros _ respond = do
     threadDelay micros
     respond (responseLBS status200 [] "ok")
 
-{- | Put one request through an application. It returns when the application
-has answered, which is what makes the first test a test: the watchdog gets its
-chance to fire while this is still waiting.
+{- | Put one request for a path through an application. It returns when the
+application has answered, which is what makes the first test a test: the
+watchdog gets its chance to fire while this is still waiting.
 -}
-runOnce :: Application -> IO ()
-runOnce app = do
-    ResponseReceived <- app defaultRequest (\_ -> pure ResponseReceived)
+runOnce :: Application -> ByteString -> IO ()
+runOnce app path = do
+    ResponseReceived <- app defaultRequest{rawPathInfo = path} (\_ -> pure ResponseReceived)
     pure ()

--- a/test/MCPStreamSpec.hs
+++ b/test/MCPStreamSpec.hs
@@ -29,7 +29,7 @@ report its status and the methods it says are allowed.
 answer :: Method -> IO (Int, Maybe ByteString)
 answer m = do
     manager <- initDatabaseManager defaultConfig NoCache
-    app <- mcpApp manager [] False Nothing Nothing (pure ())
+    app <- mcpApp manager [] False Nothing Nothing id
     ref <- newIORef Nothing
     _ <- app defaultRequest{requestMethod = m} $ \resp -> do
         writeIORef ref (Just resp)

--- a/volca.cabal
+++ b/volca.cabal
@@ -38,6 +38,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Types
                      , App.Env
+                     , App.Idle
                      , Data.Validation
                      , Progress
                      , UnitConversion
@@ -191,7 +192,6 @@ executable volca
                      , containers
                      , bytestring
                      , stm
-                     , time
                      , warp
                      , wai
                      , wai-extra >=3.1.1
@@ -246,6 +246,7 @@ test-suite lca-tests
                      , CharacterizedFlowsSpec
                      , SubBlindCFSpec
                      , ServerSpec
+                     , IdleSpec
                      , ILCDParserSpec
                      , SupplyChainSpec
                      , HotspotSpec


### PR DESCRIPTION
A client that arms an idle timeout and then asks for a large database to be loaded gets a closed socket and no answer, with nothing in its own logs to explain it. The server had decided it was unused, while it was in the middle of answering.

**Why.** The watchdog stamped its clock the moment a request arrived and never again, so a request that is itself long counted as silence for its whole duration. Loading a large database reads a gigabyte of source and builds its matrices, which takes longer than the five minutes a client typically arms. The existing docstring already made this argument for a matrix solve, which "may well outlast the request that asked for it" - a load outlasts it too, and resolves no matrix, so the solve counter never saw it.

**What changes.** A request is counted while it runs, and the deadline cannot move past one in flight. A server that is genuinely unused still shuts down on time.

**Where it lives.** The machinery moves out of the executable into `App.Idle`, which is what lets a spec drive it at all: the watchdog now takes what to do when the server has gone unused - the process exiting in production, a test recording that it would have.

Reproduced before the fix and verified after, on a real load: a 44-second load under a 20-second timeout died mid-flight with `Idle for 20s, shutting down.` in the log, and now completes. The two spec cases pull against each other on purpose - a long request must not shut it down, a quiet one still must - and the first fails on the unfixed code.

Suite green: 2522 examples, 0 failures.