### PR TITLE
Sum what the readers harvested, instead of unzipping eight lists

### DIFF
--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -206,12 +206,77 @@ mergeBioFlows a b =
         , bfCAS = bfCAS a <|> bfCAS b
         }
 
--- | 8-element unzip helper (Data.List ships 7-tuple as max).
-unzip8 :: [(a, b, c, d, e, f, g, h)] -> ([a], [b], [c], [d], [e], [f], [g], [h])
-unzip8 = foldr step ([], [], [], [], [], [], [], [])
+{- | What one reader harvested from the files it was given: a piece of the
+database, the dataset numbers those files carried, and how many flow and unit
+declarations it read before deduplication. A load is the sum of its harvests.
+
+Summing is not the same operation as harvesting, and the two must not be
+collapsed into one. Inside a harvest the last dataset read wins a duplicate key:
+'M.fromList' keeps the last entry, and 'MS.fromListWith' hands the newer row to
+'mergeTechFlows' as the base. Between two harvests the earlier reader wins:
+'M.union' keeps the leftmost, and 'MS.unionWith' keeps its left argument as the
+base. 'LoaderSpec' pins both directions. The qualifiers are not interchangeable
+either: the flow tables are merged strictly, for the reason the import of
+'Data.Map.Strict' gives, and the rest is left as the build sites had it.
+-}
+data Harvest = Harvest
+    { hvActivities :: !ActivityMap
+    , hvTechFlows :: !TechFlowDB
+    , hvBioFlows :: !BioFlowDB
+    , hvWasteFlows :: !WasteFlowDB
+    , hvUnits :: !UnitDB
+    , hvDatasetNumbers :: !DatasetNumberIndex
+    , hvRawFlows :: !Int
+    -- ^ flow declarations read, before deduplication
+    , hvRawUnits :: !Int
+    -- ^ unit declarations read, before deduplication
+    }
+
+instance Semigroup Harvest where
+    a <> b =
+        Harvest
+            { hvActivities = M.union (hvActivities a) (hvActivities b)
+            , hvTechFlows = MS.unionWith mergeTechFlows (hvTechFlows a) (hvTechFlows b)
+            , hvBioFlows = MS.unionWith mergeBioFlows (hvBioFlows a) (hvBioFlows b)
+            , hvWasteFlows = M.union (hvWasteFlows a) (hvWasteFlows b)
+            , hvUnits = M.union (hvUnits a) (hvUnits b)
+            , hvDatasetNumbers = M.union (hvDatasetNumbers a) (hvDatasetNumbers b)
+            , hvRawFlows = hvRawFlows a + hvRawFlows b
+            , hvRawUnits = hvRawUnits a + hvRawUnits b
+            }
+
+instance Monoid Harvest where
+    mempty = Harvest M.empty MS.empty MS.empty M.empty M.empty M.empty 0 0
+
+{- | Harvest a batch of parsed datasets, each already keyed by the (activity,
+product) pair its source names it under.
+-}
+harvestOf :: [((UUID, UUID), ParsedDataset)] -> Harvest
+harvestOf entries =
+    Harvest
+        { hvActivities = M.fromList [(key, pdActivity parsed) | (key, parsed) <- entries]
+        , hvTechFlows = MS.fromListWith mergeTechFlows [(tfId f, f) | f <- techs]
+        , hvBioFlows = MS.fromListWith mergeBioFlows [(bfId f, f) | f <- bios]
+        , hvWasteFlows = M.fromList [(wfId f, f) | f <- wastes]
+        , hvUnits = M.fromList [(unitId u, u) | u <- units]
+        , hvDatasetNumbers = M.fromList [(pdDatasetNumber parsed, key) | (key, parsed) <- entries, pdDatasetNumber parsed /= 0]
+        , hvRawFlows = length techs + length bios + length wastes
+        , hvRawUnits = length units
+        }
   where
-    step (a, b, c, d, e, f, g, h) (as, bs, cs, ds, es, fs, gs, hs) =
-        (a : as, b : bs, c : cs, d : ds, e : es, f : fs, g : gs, h : hs)
+    techs :: [TechnosphereFlow]
+    techs = concatMap (pdTechFlows . snd) entries
+    bios :: [BiosphereFlow]
+    bios = concatMap (pdBioFlows . snd) entries
+    wastes :: [WasteFlow]
+    wastes = concatMap (pdWasteFlows . snd) entries
+    units :: [Unit]
+    units = concatMap (pdUnits . snd) entries
+
+-- | The five tables of a harvest that make a database; the other three describe the reading.
+harvestDatabase :: Harvest -> SimpleDatabase
+harvestDatabase h =
+    SimpleDatabase (hvActivities h) (hvTechFlows h) (hvBioFlows h) (hvWasteFlows h) (hvUnits h)
 
 {- |
 Schema signature of the cache payload.
@@ -1272,50 +1337,43 @@ loadEcoSpoldDirectory opts dir = do
         case errors of
             (firstErr : _) -> return $ Left firstErr
             [] -> do
-                let successResults = rights results
-                let (procMaps, techFlowMaps, bioFlowMaps, wasteFlowMaps, unitMaps, rawFlowCounts, rawUnitCounts, dsIndexes) = unzip8 successResults
-                let !finalProcMap = M.unions procMaps
-                let !finalTechFlowMap = MS.unionsWith mergeTechFlows techFlowMaps
-                let !finalBioFlowMap = MS.unionsWith mergeBioFlows bioFlowMaps
-                let !finalWasteFlowMap = M.unions wasteFlowMaps
-                let !finalUnitMap = M.unions unitMaps
-                let !finalDsIndex = M.unions dsIndexes
+                let !harvested = mconcat (rights results)
 
                 endTime <- getCurrentTime
                 let totalDuration = realToFrac $ diffUTCTime endTime startTime
                 let totalFiles = length allFiles
                 let avgFilesPerSec = fromIntegral totalFiles / totalDuration
-                let totalRawFlows = sum rawFlowCounts
-                let totalRawUnits = sum rawUnitCounts
-                let totalFlows = M.size finalTechFlowMap + M.size finalBioFlowMap
+                let totalRawFlows = hvRawFlows harvested
+                let totalRawUnits = hvRawUnits harvested
+                let totalFlows = M.size (hvTechFlows harvested) + M.size (hvBioFlows harvested)
                 let flowDeduplication = if totalRawFlows > 0 then 100.0 * (1.0 - fromIntegral totalFlows / fromIntegral totalRawFlows) else 0.0 :: Double
-                let unitDeduplication = if totalRawUnits > 0 then 100.0 * (1.0 - fromIntegral (M.size finalUnitMap) / fromIntegral totalRawUnits) else 0.0 :: Double
+                let unitDeduplication = if totalRawUnits > 0 then 100.0 * (1.0 - fromIntegral (M.size (hvUnits harvested)) / fromIntegral totalRawUnits) else 0.0 :: Double
 
                 reportProgress Info $ printf "Parsing completed (%s, %.1f files/sec):" (formatDuration totalDuration) avgFilesPerSec
-                reportProgress Info $ printf "  Activities: %d processes" (M.size finalProcMap)
+                reportProgress Info $ printf "  Activities: %d processes" (M.size (hvActivities harvested))
                 reportProgress Info $
                     printf
                         "  Flows: %d tech + %d bio (%.1f%% deduplication from %d raw)"
-                        (M.size finalTechFlowMap)
-                        (M.size finalBioFlowMap)
+                        (M.size (hvTechFlows harvested))
+                        (M.size (hvBioFlows harvested))
                         flowDeduplication
                         totalRawFlows
                 reportProgress Info $
                     printf
                         "  Units: %d unique (%.1f%% deduplication from %d raw)"
-                        (M.size finalUnitMap)
+                        (M.size (hvUnits harvested))
                         unitDeduplication
                         totalRawUnits
                 reportMemoryUsage "Final parsing memory usage"
 
                 -- For EcoSpold1: fix activity links using supplier lookup table
-                let simpleDb = SimpleDatabase finalProcMap finalTechFlowMap finalBioFlowMap finalWasteFlowMap finalUnitMap
+                let simpleDb = harvestDatabase harvested
                 if isEcoSpold1
-                    then Right <$> fixEcoSpold1ActivityLinks locationAliases finalDsIndex simpleDb
+                    then Right <$> fixEcoSpold1ActivityLinks locationAliases (hvDatasetNumbers harvested) simpleDb
                     else return $ Right simpleDb
 
     -- Process one worker's share of files
-    processWorker :: UTCTime -> Bool -> (Int, [FilePath]) -> IO (Either T.Text (ActivityMap, TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB, Int, Int, DatasetNumberIndex))
+    processWorker :: UTCTime -> Bool -> (Int, [FilePath]) -> IO (Either T.Text Harvest)
     processWorker _startTime isEcoSpold1 (workerNum, workerFiles) = do
         workerStartTime <- getCurrentTime
         reportProgress Info $ printf "Worker %d started: processing %d files" workerNum (length workerFiles)
@@ -1336,48 +1394,28 @@ loadEcoSpoldDirectory opts dir = do
             (okFiles, okResults) = unzip [(f, r') | (f, rs) <- split, r' <- rs]
         unless isEcoSpold1 $
             mapM_ (warnSplitKeyedOnFileName . fst) (filter ((> 1) . length . snd) split)
-        let procs = map pdActivity okResults
-            techLists = map pdTechFlows okResults
-            bioLists = map pdBioFlows okResults
-            wasteLists = map pdWasteFlows okResults
-            unitLists = map pdUnits okResults
-            dsNums = map pdDatasetNumber okResults
-        let !allTechs = concat techLists
-        let !allBios = concat bioLists
-        let !allWastes = concat wasteLists
-        let !allUnits = concat unitLists
-
-        let procEntries = zipWith (buildProcEntry isEcoSpold1) okFiles procs
+        let procEntries = zipWith (buildProcEntry isEcoSpold1) okFiles (map pdActivity okResults)
 
         case lefts procEntries of
             (firstErr : _) -> return $ Left firstErr
             [] -> do
-                let !procMap = M.fromList (rights procEntries)
-                let !techFlowMap = MS.fromListWith mergeTechFlows [(tfId f, f) | f <- allTechs]
-                let !bioFlowMap = MS.fromListWith mergeBioFlows [(bfId f, f) | f <- allBios]
-                let !wasteFlowMap = M.fromList [(wfId f, f) | f <- allWastes]
-                let !unitMap = M.fromList [(unitId u, u) | u <- allUnits]
-                let !dsIndex =
-                        M.fromList
-                            [(n, key) | (n, Right (key, _)) <- zip dsNums procEntries, n /= 0]
+                let !harvested = harvestOf (zip (map fst (rights procEntries)) okResults)
 
                 workerEndTime <- getCurrentTime
                 let workerDuration = realToFrac $ diffUTCTime workerEndTime workerStartTime
                 let filesPerSec = fromIntegral (length workerFiles) / workerDuration
-                let rawFlowCount = length allTechs + length allBios + length allWastes
-                let rawUnitCount = length allUnits
                 reportProgress Info $
                     printf
                         "Worker %d completed: %d activities, %d tech + %d bio + %d waste flows (%s, %.1f files/sec)"
                         workerNum
-                        (M.size procMap)
-                        (M.size techFlowMap)
-                        (M.size bioFlowMap)
-                        (M.size wasteFlowMap)
+                        (M.size (hvActivities harvested))
+                        (M.size (hvTechFlows harvested))
+                        (M.size (hvBioFlows harvested))
+                        (M.size (hvWasteFlows harvested))
                         (formatDuration workerDuration)
                         filesPerSec
 
-                return $ Right (procMap, techFlowMap, bioFlowMap, wasteFlowMap, unitMap, rawFlowCount, rawUnitCount, dsIndex)
+                return $ Right harvested
 
     -- Build a single process entry, returning Either for error handling
     buildProcEntry :: Bool -> FilePath -> Activity -> Either T.Text ((UUID, UUID), Activity)
@@ -1417,33 +1455,20 @@ loadSingleEcoSpold1File opts filepath = do
     let fileUUID = case results of
             [_] -> datasetUUIDFromPath filepath
             _ -> Nothing
-        expanded = map (buildProcEntryFromResult fileUUID) results
-        !procMap = M.fromList expanded
-        !techFlowMap = MS.fromListWith mergeTechFlows [(tfId f, f) | r <- results, f <- pdTechFlows r]
-        !bioFlowMap = MS.fromListWith mergeBioFlows [(bfId f, f) | r <- results, f <- pdBioFlows r]
-        !wasteFlowMap = M.fromList [(wfId f, f) | r <- results, f <- pdWasteFlows r]
-        !unitMap = M.fromList [(unitId u, u) | r <- results, u <- pdUnits r]
-        !dsIndex =
-            M.fromList
-                [(pdDatasetNumber r, key) | (r, (key, _)) <- zip results expanded, pdDatasetNumber r /= 0]
-        simpleDb = SimpleDatabase procMap techFlowMap bioFlowMap wasteFlowMap unitMap
+        !harvested = harvestOf [(datasetKey fileUUID r, r) | r <- results]
+        simpleDb = harvestDatabase harvested
 
-    let totalTechs = sum (map (length . pdTechFlows) results)
-    let totalBios = sum (map (length . pdBioFlows) results)
-    let totalWastes = sum (map (length . pdWasteFlows) results)
-    let totalUnits = sum (map (length . pdUnits) results)
-    reportProgress Info $ printf "  Activities: %d processes" (M.size procMap)
-    reportProgress Info $ printf "  Flows: %d tech + %d bio + %d waste (from %d raw)" (M.size techFlowMap) (M.size bioFlowMap) (M.size wasteFlowMap) (totalTechs + totalBios + totalWastes)
-    reportProgress Info $ printf "  Units: %d unique (from %d raw)" (M.size unitMap) totalUnits
+    reportProgress Info $ printf "  Activities: %d processes" (M.size (hvActivities harvested))
+    reportProgress Info $ printf "  Flows: %d tech + %d bio + %d waste (from %d raw)" (M.size (hvTechFlows harvested)) (M.size (hvBioFlows harvested)) (M.size (hvWasteFlows harvested)) (hvRawFlows harvested)
+    reportProgress Info $ printf "  Units: %d unique (from %d raw)" (M.size (hvUnits harvested)) (hvRawUnits harvested)
 
-    Right <$> fixEcoSpold1ActivityLinks locationAliases dsIndex simpleDb
+    Right <$> fixEcoSpold1ActivityLinks locationAliases (hvDatasetNumbers harvested) simpleDb
   where
-    buildProcEntryFromResult :: Maybe UUID.UUID -> ParsedDataset -> ((UUID.UUID, UUID.UUID), Activity)
-    buildProcEntryFromResult fileUUID parsed =
+    datasetKey :: Maybe UUID.UUID -> ParsedDataset -> (UUID.UUID, UUID.UUID)
+    datasetKey fileUUID parsed =
         let activity = pdActivity parsed
             actUUID = fromMaybe (generateActivityUUIDFromActivity activity) fileUUID
-            prodUUID = getReferenceProductUUID activity
-         in ((actUUID, prodUUID), activity)
+         in (actUUID, getReferenceProductUUID activity)
 
 {- |
 Generate filename for matrix cache.

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -80,6 +80,8 @@ module Database.Loader (
     normalizeText,
     mergeTechFlows,
     mergeBioFlows,
+    Harvest (..),
+    harvestOf,
     generateActivityUUIDFromActivity,
     datasetUUIDFromPath,
     getReferenceProductUUID,
@@ -215,7 +217,8 @@ collapsed into one. Inside a harvest the last dataset read wins a duplicate key:
 'M.fromList' keeps the last entry, and 'MS.fromListWith' hands the newer row to
 'mergeTechFlows' as the base. Between two harvests the earlier reader wins:
 'M.union' keeps the leftmost, and 'MS.unionWith' keeps its left argument as the
-base. 'LoaderSpec' pins both directions. The qualifiers are not interchangeable
+base. 'LoaderSpec' pins both directions through 'harvestOf' and this instance,
+which is why the two are exported. The qualifiers are not interchangeable
 either: the flow tables are merged strictly, for the reason the import of
 'Data.Map.Strict' gives, and the rest is left as the build sites had it.
 -}

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -219,6 +219,37 @@ spec = do
             tfName (mergeTechFlows a b) `shouldBe` "flow-a"
 
     -- -----------------------------------------------------------------------
+    -- Which row wins a duplicate key. The answer is not one rule but two
+    -- facing opposite ways, and a load reads both: the files one reader
+    -- harvested are folded into a table with 'fromListWith', several readers'
+    -- tables are then merged with 'unionsWith'. Written down here because
+    -- 'mergeTechFlows' above says what merging two flows does and nothing says
+    -- which of the two is handed to it first.
+    -- -----------------------------------------------------------------------
+    describe "duplicate keys inside a harvest and between harvests" $ do
+        it "keeps the last dataset read, inside one reader's share" $ do
+            let a = (minimalFlow flowUUID1 "flow-a"){tfCAS = Just "7732-18-5"}
+                b = minimalFlow flowUUID1 "flow-b"
+                table = M.fromListWith mergeTechFlows [(tfId f, f) | f <- [a, b]]
+            fmap tfName (M.lookup flowUUID1 table) `shouldBe` Just "flow-b"
+            -- The loser is not lost entirely: its CAS fills the gap.
+            fmap tfCAS (M.lookup flowUUID1 table) `shouldBe` Just (Just "7732-18-5")
+
+        it "keeps the first reader's, when two shares meet" $ do
+            let a = minimalFlow flowUUID1 "flow-a"
+                b = (minimalFlow flowUUID1 "flow-b"){tfCAS = Just "7732-18-5"}
+                merged = M.unionsWith mergeTechFlows [M.singleton flowUUID1 a, M.singleton flowUUID1 b]
+            fmap tfName (M.lookup flowUUID1 merged) `shouldBe` Just "flow-a"
+            fmap tfCAS (M.lookup flowUUID1 merged) `shouldBe` Just (Just "7732-18-5")
+
+        it "keeps the first reader's activity, when two shares meet" $ do
+            let key = (actUUID1, flowUUID1)
+                a = minimalActivity "activity-a" "GLO" []
+                b = minimalActivity "activity-b" "GLO" []
+                merged = M.unions [M.singleton key a, M.singleton key b]
+            fmap activityName (M.lookup key merged) `shouldBe` Just "activity-a"
+
+    -- -----------------------------------------------------------------------
     describe "indexActivities" $ do
         it "names the two spellings a case fold brings together, and keeps the last read" $ do
             let acts =

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -15,6 +15,7 @@ import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
 import Database.Loader
+import EcoSpold.Common (ParsedDataset (..))
 import TestHelpers (loadSampleDatabase)
 import Types
 import UnitConversion (defaultUnitConfig)
@@ -61,6 +62,25 @@ minimalActivity name loc exs =
 -- | The same activity, filed in the source's obsolete category.
 retired :: Activity -> Activity
 retired act = act{activityClassification = M.singleton "Category" "Autres\\Obsolete"}
+
+-- | One dataset as a reader hands it over: an activity and the flows it declared.
+minimalDataset :: Activity -> [TechnosphereFlow] -> ParsedDataset
+minimalDataset act techs =
+    ParsedDataset
+        { pdActivity = act
+        , pdTechFlows = techs
+        , pdBioFlows = []
+        , pdWasteFlows = []
+        , pdUnits = []
+        , pdDatasetNumber = 0
+        , pdWarnings = []
+        }
+
+{- | One reader's share of a load, always under the same (activity, product)
+key, so that two of them collide and the merging law has to decide.
+-}
+share :: Text -> [TechnosphereFlow] -> ((UUID.UUID, UUID.UUID), ParsedDataset)
+share name techs = ((actUUID1, flowUUID1), minimalDataset (minimalActivity name "GLO" []) techs)
 
 refExchange :: UUID.UUID -> Exchange
 refExchange fid =
@@ -230,24 +250,22 @@ spec = do
         it "keeps the last dataset read, inside one reader's share" $ do
             let a = (minimalFlow flowUUID1 "flow-a"){tfCAS = Just "7732-18-5"}
                 b = minimalFlow flowUUID1 "flow-b"
-                table = M.fromListWith mergeTechFlows [(tfId f, f) | f <- [a, b]]
-            fmap tfName (M.lookup flowUUID1 table) `shouldBe` Just "flow-b"
+                harvest = harvestOf [share "activity-a" [a], share "activity-b" [b]]
+            fmap tfName (M.lookup flowUUID1 (hvTechFlows harvest)) `shouldBe` Just "flow-b"
             -- The loser is not lost entirely: its CAS fills the gap.
-            fmap tfCAS (M.lookup flowUUID1 table) `shouldBe` Just (Just "7732-18-5")
+            fmap tfCAS (M.lookup flowUUID1 (hvTechFlows harvest)) `shouldBe` Just (Just "7732-18-5")
 
-        it "keeps the first reader's, when two shares meet" $ do
+        it "keeps the first reader's flow, when two shares meet" $ do
             let a = minimalFlow flowUUID1 "flow-a"
                 b = (minimalFlow flowUUID1 "flow-b"){tfCAS = Just "7732-18-5"}
-                merged = M.unionsWith mergeTechFlows [M.singleton flowUUID1 a, M.singleton flowUUID1 b]
-            fmap tfName (M.lookup flowUUID1 merged) `shouldBe` Just "flow-a"
-            fmap tfCAS (M.lookup flowUUID1 merged) `shouldBe` Just (Just "7732-18-5")
+                merged = harvestOf [share "activity-a" [a]] <> harvestOf [share "activity-b" [b]]
+            fmap tfName (M.lookup flowUUID1 (hvTechFlows merged)) `shouldBe` Just "flow-a"
+            fmap tfCAS (M.lookup flowUUID1 (hvTechFlows merged)) `shouldBe` Just (Just "7732-18-5")
 
         it "keeps the first reader's activity, when two shares meet" $ do
-            let key = (actUUID1, flowUUID1)
-                a = minimalActivity "activity-a" "GLO" []
-                b = minimalActivity "activity-b" "GLO" []
-                merged = M.unions [M.singleton key a, M.singleton key b]
-            fmap activityName (M.lookup key merged) `shouldBe` Just "activity-a"
+            let merged = harvestOf [share "activity-a" []] <> harvestOf [share "activity-b" []]
+            fmap activityName (M.lookup (actUUID1, flowUUID1) (hvActivities merged))
+                `shouldBe` Just "activity-a"
 
     -- -----------------------------------------------------------------------
     describe "indexActivities" $ do


### PR DESCRIPTION
**Target.** The eight things a reader harvested from its share of the EcoSpold files stop travelling as an eight-tuple merged by hand, and become one record whose `Semigroup` is the merge, so the two load paths state the merging law once instead of three times.

**Axis.** Invalid states.

**Problem.** `processWorker` answered `IO (Either Text (ActivityMap, TechFlowDB, BioFlowDB, WasteFlowDB, UnitDB, Int, Int, DatasetNumberIndex))` (`src/Database/Loader.hs:1318`). Nothing in that signature said which `Int` was the raw flow count and which the raw unit count, and swapping them was invisible to the compiler and to every test, since they are only ever divided into a deduplication percentage in a log line (`:1288-1292`). Reading it took an `unzip8` written here because `Data.List` stops at seven (`:210`), then six `let` bindings restating the merging law (`:1277-1282`), inside the function the ranking script puts first on `let` density in its scope (177 lines, 43 lets). The law itself was written three times and not identically: `MS.fromListWith mergeTechFlows` inside a reader (`:1356`), `MS.unionsWith mergeTechFlows` between readers (`:1278`), and `MS.fromListWith mergeTechFlows` again in the multi-dataset path (`:1422`), which rebuilt the same five maps and the same dataset-number index from scratch, expression for expression.

**Transformation.** One record local to `Database.Loader`, `Harvest`, with the eight fields named and banged; its `Semigroup` spells the between-readers merge exactly as `M.unions` / `MS.unionsWith` spelled it, and one pure `harvestOf :: [((UUID, UUID), ParsedDataset)] -> Harvest` spells the within-batch build exactly as `M.fromList` / `MS.fromListWith` spelled it. The two are deliberately not one function: `M.fromList` keeps the last entry on a key collision and `M.union` keeps the leftmost. `Data.Map.Strict` stays on the flow tables and `Data.Map` on the rest, as the build sites had it, and the bang patterns stay because `mconcat` folds right where `M.unions` folded left. `unzip8` is deleted.

**Behaviour preserved.** The `SimpleDatabase` both paths return, field by field, including which row survives a duplicate key: within a batch the last read wins, between two batches the first does, and this holds for the flow tables as much as for the activities. The dataset-number index and its `/= 0` filter; every `reportProgress` line, its wording, its level and where it is emitted. Pinned end to end by `TestHelpers.loadSampleDatabase` through `loadDatabase`, which most specs go through, and by `LoaderSpec` for the multi-dataset path. The two collision biases were pinned by nothing, because the fixtures that collide declare identical flows, so the first commit writes them down.

**Done when.** Met: `Harvest` declared with eight named fields and its doc comment; `processWorker` answers `IO (Either Text Harvest)`; `unzip8` gone from the tree; the merge is `mconcat`; the multi-dataset path goes through the same `harvestOf`; `mergeTechFlows` and `mergeBioFlows` named in two places and still exported; no signature outside `src/Database/Loader.hs` changed and no `Store`/`ToJSON` instance touched; string-literal diff over the file empty; cold `-Werror` build green, `hlint src app test` clean, suite at 2523 examples, 0 failures, 2 pending (2520 before, plus the three the characterisation adds). This target needs no second pass.

<details>
<summary>For the next run: not chosen, behaviour changes, numbers</summary>

**Would change behaviour, so reported and not fixed**

- `src/EcoSpold/Common.hs:136` and `:142` — `bsToDouble` and `bsToInt` call `error` from a pure fold on parser input, so a malformed number crashes the load; `Parser1` avoids them, `Parser2` calls them at `:721`, `:733`, `:743`. `bsToIntMaybe` exists (`:148`); the `Double` counterpart and a `psWarnings` entry are the fix.
- `src/Database/Upload.hs:72` — `DatabaseFormat` carries `UnknownFormat` and the manager wraps it in a `Maybe` as well, so "unrecognised" has two spellings and `formatDisplayText UnknownFormat` is `""` on the wire (`:88`, `:95`, `:106`, `Database/Edit.hs:314`, `Database/Manager.hs:1174`).
- `src/Database/Upload.hs:487` — `findDataDirectory :: FilePath -> IO FilePath` answers the root when it recognises nothing, so an archive with no readable file fails three steps later with a message about its format; `findMethodDirectory` (`:577`) does the same.
- `src/Database/Loader.hs:1083` — `linkUnitsCompatible` accepts an empty unit as compatible; `CrossLinking.unitsAreCompatible` (`:1138`) decides the same question and refuses it.
- `src/Database/Loader.hs:358` — `Loader.parseUUID` mints a deterministic UUID when a file name is not one and says nothing; `EcoSpold/Parser2.hs:45` does the same and warns.
- `src/Database/MatrixBuild.hs:96` — `safeDenom` substitutes `1.0` for a zero normalisation factor, so an activity whose reference quantity is zero enters the matrix with raw amounts and a score "per 1 unit" that does not exist.
- `src/ILCD/Parser.hs:352` — `_ -> TechClass` reads any unrecognised flow type as a technosphere flow in silence.
- `src/SimaPro/Parser.hs:478` — a CSV line the parser refuses is re-split naively, with no warning.
- `src/EcoSpold/Parser2.hs:552`, `src/EcoSpold/Parser1.hs:369` — input group and output group are two `Text` with `""` for "not this one", so a code outside the schema's table reads as an ordinary input.
- `src/ILCD/Parser.hs:72` — `ierDirection :: Text -- "Input" / "Output"`, compared once against `"Input"`, everything else read as an output.

**Not chosen, ranked**

Invalid states:
- `ProcessRef` for the bare `(UUID, UUID)` — the type exists (`src/Types.hs:67`) and its own doc comment says the pair must not be a tuple; the chain spells it as one at `Loader.hs:405`, `:425`, `:461`, `:834`, `:1383`, `:2210`, `:2235`, `CrossLinking.hs:137`, `:418`, `ILCD/Parser.hs:759`, `MatrixBuild.hs:43`, `:50`, `:100`, `:208`. Strongest candidate after this one; dropped on locality, since `ActivityMap` and the two interning tables are the same pair and are `Store`-serialised, so it either stops halfway or reaches the cache layout. #398 deferred its `InterningTables` half for the same reason.
- `ParsedDataset` (`EcoSpold/Common.hs:42`) for the five-tuple SimaPro and Brightway return instead (`SimaPro/Parser.hs:1026`, `:1642`, `BrightwayExcel/Parser.hs:125`, consumed by position at `Loader.hs:995`, `:1024`).
- `pdDatasetNumber :: Int` with `0` for "this format does not number its datasets" (`EcoSpold/Common.hs:48`, `Parser2.hs:1066`, filtered `/= 0` in the function this run just rewrote).
- `LinkingContext`'s five fields passed positionally, then rebuilt inside (`Loader.hs:1633`, `:1703`, `:1744`, `:1842`) — also flagged by #395; reaches `Database/Manager.hs` and two specs.
- `SupplierByNameWithLocation`'s `(UUID, UUID, Text)` where `NameProducer` names the same three things (`Loader.hs:458` against `:434`).
- `ColumnExchange` for `techTriple`'s nine positional parameters, two of them an `Int32` and a `ProcessId` (`MatrixBuild.hs:163`) — #398 named this one too.
- `FlowTables` for `buildFlowAndUnitDB`'s four-tuple and `buildActivity`'s six positional parameters (`ILCD/Parser.hs:96`, `:613`).
- Two `Bool` positionals naming a `BioDirection` and a `TechRole` the type system already has (`SimaPro/Parser.hs:1354`, `BrightwayExcel/Parser.hs:370`).
- `InputParams` / `CalcParams` for `buildParamEnv`'s two same-typed neighbours (`SimaPro/Parser.hs:999`).
- `DatabaseName` newtype for the ~20 bare-`Text` database names, sharpest at `CrossLinking.hs:442` against `:919`: one type, opposite meanings. Dropped on locality, as #398 dropped it.
- `LocationAliases` newtype (`Loader.hs:687`, `Types.hs:1217`) — touches the cache.
- `generateFlowUUID`'s four adjacent `Text` (`EcoSpold/Parser1.hs:77`, one call site unpacking four fields of one record).
- `parseWithXeno`'s `ProcessId` parameter, always `0` and ignored (`EcoSpold/Parser2.hs:62`).

Mixed effects:
- `EcoSpoldSource` sum for the five-arm `case` at `Loader.hs:1234` and the `isEcoSpold1 :: Bool` threaded through three functions — #395 flagged it as `EcoSpoldVersion`. Same function as this target, kept out to land one conceptual change; the obvious next pass on this file.
- `guessFormat` pure, for the extension-to-format table `detectDatabaseFormat` writes twice at 65 columns of indentation (`Upload.hs:709`).

Duplication:
- `Loader.normalizeText`, `ecospold1Namespace`, `testDataNamespace` (`:355`, `:362`, `:606`) are byte-identical copies of `CrossLinking.hs:343`, `Parser1.hs:41`, `Parser2.hs:38`, all three already imported.
- `pickComment` (`Parser2.hs:216`) and `pickILCDComment` (`ILCD/Parser.hs:58`) are the same "English wins" rule, line for line.
- The same guards decide the technosphere role in `Parser1.hs:563` and `Parser2.hs:818`.

Module organisation:
- `src/Database/Loader.hs`, whose export list already names five subjects (loading, internal linking, cache, cross-database linking, gap report) with no back edge between them. After the types above.
- `src/SimaPro/Parser.hs`, with `ProcessBlock` as the seam between lines-to-block and block-to-activity.

**Seen, not touched.** Nothing.

**Numbers.** `src/Database/Loader.hs` 2591 lines to 2616, which is what the record and its doc comment cost. `loadEcoSpoldDirectory` 177 lines to 150 and 43 `let` to 24; `loadSingleEcoSpold1File` 39 to 26 and 8 `let` to 4; lines past column 28, 112 to 111. Signatures 79 to 80, tuples in signatures 17 to 16, `Bool` 7 unchanged, bare primitives 46 unchanged.

**Falsifier, four verdicts.**
1. Problem holds. Three line numbers corrected (`:1278`, `:1356`, and the two build blocks at `:1355-1362` and `:1421-1428`).
2. Preserves, on all eight fields, with two conditions the block did not state and now does: the file picks `Data.Map` or `Data.Map.Strict` per field and the instance must keep that choice, and the bang patterns are load-bearing because `mconcat` folds right where `M.unions` folded left. `mergeTechFlows` and `mergeBioFlows` are associative, so the fold direction cannot move a result. It also confirmed the two build sites are the same expressions, so one `harvestOf` serves both.
3. Narrow enough: the change reaches `src/Database/Loader.hs` and nothing else; every function involved is unexported or `where`-local.
4. Checkable, with one correction: the multi-dataset path is pinned by `LoaderSpec:314-325`, not `:299-309` — the test at `:307-312` writes two files and is the worker path. The multi-worker path really runs on the three-file fixture, but its collisions are invisible because the colliding declarations are identical, which is why the characterisation is written as pure assertions on the merging law rather than as a load.
</details>
