### PR TITLE
Let a build that ships nothing pay less for itself

### DIFF
--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -692,10 +692,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: volca-${{ matrix.name }}
-          # The penultimate segment is `opt/build/` with optimization: 2,
-          # `build/` without it; ** absorbs both layouts. List the binary
-          # names explicitly — a trailing `volca*` glob also matches the
-          # sibling `volca-tmp/` build dir and uploads its Main.hi/Main.o.
+          # cabal names the penultimate segment after the optimization level:
+          # `opt/build/` at 2, `build/` at 1, `noopt/build/` at 0. ** absorbs
+          # all three. List the binary names explicitly, because a trailing
+          # `volca*` glob also matches the sibling `volca-tmp/` build dir and
+          # uploads its Main.hi/Main.o.
           path: |
             dist-newstyle/build/*/ghc-*/volca-*/x/volca/**/build/volca/volca
             dist-newstyle/build/*/ghc-*/volca-*/x/volca/**/build/volca/volca.exe

--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -395,12 +395,15 @@ jobs:
 
       - name: Build and test
         if: needs.preflight.outputs.skip != 'true'
-        # PR/smoke builds compile volca's own code at -O1 (gen-cabal-config.sh
+        # PR/smoke builds compile volca's own code at -O0 (gen-cabal-config.sh
         # turns this into a per-package override; deps stay -O2 so the prebuilt
-        # store still matches). Release builds keep -O2 — the packaged binary
-        # is built in this very step, so the level must be right here.
+        # store still matches). This row exists to run the suite: the suite
+        # itself takes a few seconds longer unoptimised, against a compile it
+        # waits on that is more than ten times shorter. Release builds keep
+        # -O2, since the packaged binary is built in this very step, so the
+        # level has to be right here.
         env:
-          VOLCA_OPT_LEVEL: ${{ inputs.release && '2' || '1' }}
+          VOLCA_OPT_LEVEL: ${{ inputs.release && '2' || '0' }}
         run: |
           # Windows: re-source GHCup env in this MSYS2 shell since the wrapper
           # does not inherit PATH from the previous step.

--- a/README.md
+++ b/README.md
@@ -607,6 +607,21 @@ Install the [Haskell toolchain via GHCup](https://www.haskell.org/ghcup/), then:
   tooling needs to rewrite the binary's dynamic load commands
   (`dylibbundler`, `install_name_tool` for the macOS `.app`).
 
+A build that ships splits every object into one ELF section per top-level
+symbol so the executable can be pruned to size, and that link is the one the
+default `ld.bfd` is slowest at: about 22 seconds, where every alternative
+takes one or two. Below `-O2` the split is off, since nothing prunes a test
+suite and the sections would be pure cost, and the link is a few seconds
+whatever the linker. Changing linker changes the link alone, so it costs
+nothing on an already compiled tree:
+
+```bash
+cabal build exe:volca --ghc-options=-optl-fuse-ld=lld
+```
+
+`-fuse-ld=` looks for a plain `ld.lld`, `ld.mold` or `ld.gold` on the
+`PATH`, and will not find a versioned `ld.lld-21`.
+
 ### macOS (Apple Silicon)
 
 Tested on macOS 13 Ventura and later, arm64 only. The build pins

--- a/build.sh
+++ b/build.sh
@@ -478,9 +478,15 @@ else
     LINK_MODE="dynamic"
 fi
 
+# A build run from a working copy is there to be run and tested, not shipped,
+# so it defaults to -O1 rather than the -O2 gen-cabal-config.sh keeps for
+# artifacts. What that buys is not spread evenly over the tree: one module of
+# generic JSON instances holds the whole compile behind it at -O2. An explicit
+# VOLCA_OPT_LEVEL still wins, which is how the release rows of CI ask for 2.
 MUMPS_LIB_DIR="$MUMPS_LIB_DIR" \
 MUMPS_INCLUDE_DIR="$MUMPS_INCLUDE_DIR" \
 LINK_MODE="$LINK_MODE" \
+VOLCA_OPT_LEVEL="${VOLCA_OPT_LEVEL:-1}" \
 ./gen-cabal-config.sh
 
 # If --no-optimize was requested but a previous build left a UPX'd binary

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -130,6 +130,11 @@ COPY gen-cabal-config.sh /build/volca/
 # from the repository's own cabal.project: the hold on
 # insert-ordered-containers has to be repeated, and allow-newer above
 # would let the breaking version in otherwise.
+# 2 because this image is normally the published one. A caller building an
+# image from source to try something out can pass 1 and get the compile back
+# in a fraction of the time; see gen-cabal-config.sh for what each level is for.
+ARG VOLCA_OPT_LEVEL=2
+
 RUN echo "packages: ./volca ./mumps-hs" > /build/cabal.project \
     && echo "allow-newer: true" >> /build/cabal.project \
     && echo "constraints: insert-ordered-containers < 0.3" >> /build/cabal.project \
@@ -138,6 +143,7 @@ RUN echo "packages: ./volca ./mumps-hs" > /build/cabal.project \
     OPENBLAS_LIB_DIR="/build/openblas/lib" \
     LINK_MODE="musl" \
     OUTPUT_DIR="/build" \
+    VOLCA_OPT_LEVEL="$VOLCA_OPT_LEVEL" \
     /build/volca/gen-cabal-config.sh
 
 # Update cabal and build ONLY dependencies (cached layer)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -130,11 +130,6 @@ COPY gen-cabal-config.sh /build/volca/
 # from the repository's own cabal.project: the hold on
 # insert-ordered-containers has to be repeated, and allow-newer above
 # would let the breaking version in otherwise.
-# 2 because this image is normally the published one. A caller building an
-# image from source to try something out can pass 1 and get the compile back
-# in a fraction of the time; see gen-cabal-config.sh for what each level is for.
-ARG VOLCA_OPT_LEVEL=2
-
 RUN echo "packages: ./volca ./mumps-hs" > /build/cabal.project \
     && echo "allow-newer: true" >> /build/cabal.project \
     && echo "constraints: insert-ordered-containers < 0.3" >> /build/cabal.project \
@@ -143,7 +138,6 @@ RUN echo "packages: ./volca ./mumps-hs" > /build/cabal.project \
     OPENBLAS_LIB_DIR="/build/openblas/lib" \
     LINK_MODE="musl" \
     OUTPUT_DIR="/build" \
-    VOLCA_OPT_LEVEL="$VOLCA_OPT_LEVEL" \
     /build/volca/gen-cabal-config.sh
 
 # Update cabal and build ONLY dependencies (cached layer)
@@ -157,6 +151,26 @@ COPY . /build/volca
 ARG GIT_HASH=unknown
 ARG GIT_TAG=""
 RUN cd /build/volca && GIT_HASH="$GIT_HASH" GIT_TAG="$GIT_TAG" ./gen-version.sh
+
+# The level volca's own code is compiled at. 2, because this image is normally
+# the published one; a caller building from source to try something out passes
+# 1 and gets the compile back in a fraction of the time. See
+# gen-cabal-config.sh for what each level means.
+#
+# Declared here rather than beside the first call, which is why that call is
+# regenerating the same file: docker adds an ARG to the cache key of every
+# layer from its first use onwards, so naming the level any earlier would
+# rebuild the whole musl dependency tree each time it changed. Dependencies
+# compile at the global optimization: 2 whatever this is, so they have no
+# business depending on it.
+ARG VOLCA_OPT_LEVEL=2
+RUN MUMPS_LIB_DIR="/build/mumps/lib" \
+    MUMPS_INCLUDE_DIR="/build/mumps/include" \
+    OPENBLAS_LIB_DIR="/build/openblas/lib" \
+    LINK_MODE="musl" \
+    OUTPUT_DIR="/build" \
+    VOLCA_OPT_LEVEL="$VOLCA_OPT_LEVEL" \
+    /build/volca/gen-cabal-config.sh
 
 # Build volca (only recompiles app code, deps already cached)
 RUN cd /build && cabal build volca

--- a/gen-cabal-config.sh
+++ b/gen-cabal-config.sh
@@ -7,6 +7,7 @@
 #   MUMPS_INCLUDE_DIR       Path to MUMPS headers (default: /usr/include)
 #   LINK_MODE               "dynamic" (default), "musl", "darwin", "windows"
 #   OUTPUT_DIR              Where to write cabal.project.local (default: current dir)
+#   VOLCA_OPT_LEVEL         0, 1 or 2 (default 2) - see the block below
 #
 # Output: writes cabal.project.local in OUTPUT_DIR
 

--- a/gen-cabal-config.sh
+++ b/gen-cabal-config.sh
@@ -19,11 +19,38 @@ OUTPUT="${OUTPUT_DIR:-.}/cabal.project.local"
 
 # Optimization level for volca's own code, as a per-package override of the
 # global `optimization: 2` (which must stay 2 so the prebuilt cabal store's
-# deps keep matching). Default 2 — shipped artifacts (Docker, release, local
-# builds) are unaffected. CI PR/test builds export VOLCA_OPT_LEVEL=1 to halve
-# the cold compile of volca's ~100 modules; -O2 buys runtime speed the smoke
-# build doesn't need. Deps stay -O2 either way.
+# deps keep matching). Deps stay -O2 whatever this is, which is what makes the
+# knob cheap: only volca's own modules move.
+#
+# The level follows what the build is for, and each caller picks its own:
+#   0  CI test rows, which only have to run the suite
+#   1  a build from a working copy (build.sh), and a from-source image
+#   2  anything published: the release rows, the engine image
+# Default 2, because an unset variable must never quietly under-optimise
+# something that ships.
+#
+# The spread is wider than it looks. On a 24-core machine a cold build of the
+# library plus the test suite takes 547 s at -O2 and 42 s at -O0; one module
+# of generic JSON instances accounts for 397 s of the -O2 figure and holds
+# everything that imports it behind that. The runtime it buys is real too:
+# unoptimised generic instances encode and decode 10 to 20 % slower, which is
+# why what ships stays at 2.
 VOLCA_OPT_LEVEL="${VOLCA_OPT_LEVEL:-2}"
+
+# Section splitting follows the same rule, for the same reason, and that is
+# why it is decided here rather than left to cabal.project's `package *`.
+# Splitting earns its keep on what ships: the executable prunes what nothing
+# references and comes out several megabytes smaller. Nothing prunes the test
+# suite, which links every section it was handed, and the default linker
+# spends minutes resolving them (302 s and 2.3 GB against 3.6 s without, on a
+# tree built at -O0, where there are more symbols to split). Dependencies keep
+# splitting either way: they are prebuilt, and they are most of what the
+# executable links.
+if [ "$VOLCA_OPT_LEVEL" -lt 2 ]; then
+    VOLCA_SPLIT_SECTIONS="  split-sections: False"
+else
+    VOLCA_SPLIT_SECTIONS="  split-sections: True"
+fi
 
 # Parallelism preamble shared by every LINK_MODE.
 # Lives in cabal.project.local (not cabal.project) so that Docker builds —
@@ -74,6 +101,7 @@ extra-include-dirs: $MUMPS_INCLUDE_DIR
 
 package volca
   optimization: $VOLCA_OPT_LEVEL
+$VOLCA_SPLIT_SECTIONS
 EOF
         ;;
 
@@ -120,6 +148,7 @@ extra-include-dirs: $MUMPS_INCLUDE_DIR
 
 package volca
   optimization: $VOLCA_OPT_LEVEL
+$VOLCA_SPLIT_SECTIONS
   ghc-options: $MUSL_LINK_FLAGS
 EOF
         ;;
@@ -220,6 +249,7 @@ package mumps-hs
 
 package volca
   optimization: $VOLCA_OPT_LEVEL
+$VOLCA_SPLIT_SECTIONS
   ghc-options: $DARWIN_LINK_FLAGS
 EOF
         ;;
@@ -258,6 +288,7 @@ extra-include-dirs: $MUMPS_INCLUDE_DIR
 
 package volca
   optimization: $VOLCA_OPT_LEVEL
+$VOLCA_SPLIT_SECTIONS
   ghc-options: -optl-Wl,--allow-multiple-definition -optl-L$GCC_LIB_DIR -optl-L$MSYS2_LIB_DIR -optl-L$MUMPS_LIB_DIR -optl-ldmumps_seq -optl-lmumps_common_seq -optl-lpord_seq -optl-lmpiseq_seq -optl-lopenblas -optl-lgfortran -optl-lgcc -optl-lquadmath -optl-lmingwex -optl-lpthread -optl-lmsvcrt
 EOF
         ;;


### PR DESCRIPTION
Closes #420.

## Problem

A cold build of the library and the test suite takes 547 s. One module of
generic JSON instances accounts for 397 s of that, and every module that
imports it waits behind. `VOLCA_OPT_LEVEL` existed to lower it, but only
ever moved between 2 and 1, which brings the build to 411 s and no further.

## Solution

`gen-cabal-config.sh` decides both the optimisation level and section
splitting from what the build is for:

| `VOLCA_OPT_LEVEL` | who asks for it | sections split |
|---|---|---|
| 0 | the CI test rows | no |
| 1 | a build from a working copy, an image built from source | no |
| 2 | anything published | yes |

An unset variable still means 2, so nothing that ships can be
under-optimised by forgetting.

Scoping the split is what makes level 0 worth anything. `cabal.project`
splits every package into one section per top-level symbol, while the
pruning that pays for the split is set on the executable alone, so the test
suite links every section it was handed and prunes none. At -O0, where GHC
emits far more symbols, that link took 302 s and 2.3 GB and gave back
everything the compile had saved. It is now 3.6 s, and the whole cold build
44 s.

The second commit adds the linker line the issue asks for, in the README.
The committed build is unchanged there.

## Remarks

The issue proposed `{-# OPTIONS_GHC -O0 #-}` on the one expensive module.
Dropped: unoptimised generic instances encode and decode 9 to 19 % slower,
and a file pragma wins over every cabal setting, so that cost would have
reached the published binary. Deriving `ToSchema` is not the expensive
part either, so moving the schema instances aside would have gained
nothing: on a module of twenty records they compile in 1 s against 71 s
for the JSON instances.

## How to test

`./build.sh --test` builds at the new local default. `VOLCA_OPT_LEVEL=2
./build.sh` still produces the shipping shape.

The CI matrix, against the previous run on main:

| row | before | after |
|---|---|---|
| linux-amd64 | 14 min 00 | 3 min 51 |
| linux-arm64 | 12 min 35 | 3 min 18 |
| macos-intel | 18 min 47 | 5 min 40 |
| macos-arm64 | 32 min 04 | 5 min 53 |
| windows-amd64 | 16 min 45 | 9 min 04 |
