### PR TITLE
Let the drift tests find the engine at any optimisation level

### DIFF
--- a/pyvolca/tests/conftest.py
+++ b/pyvolca/tests/conftest.py
@@ -535,22 +535,37 @@ def readme_namespace() -> dict[str, Any]:
 def live_spec() -> dict[str, Any] | None:
     """The OpenAPI spec dumped from the currently-built engine binary.
 
-    Returns None if the binary isn't built; callers should skip their
-    drift test rather than fail CI hard in that case.
+    Returns None when no binary is there at all, so a checkout that has
+    never built the engine skips the drift tests rather than failing. A
+    binary that is present and will not answer is a failure, not an
+    absence: the whole point of these tests is that nobody notices when
+    they stop running.
     """
     # Walk up from pyvolca/tests/ to find the cabal dist-newstyle dir.
     here = Path(__file__).resolve()
     # .../volca-public/pyvolca/tests/conftest.py
     #                   ^~~~~~~~~ 2 levels up = pyvolca dir
     volca_public = here.parent.parent.parent
-    candidates = list(
-        (volca_public / "dist-newstyle").rglob("build/*/ghc-*/volca-*/x/volca/opt/build/volca/volca")
-    )
-    if not candidates:
+    binary = _newest_engine_binary(volca_public / "dist-newstyle")
+    if binary is None:
         return None
-    binary = sorted(candidates)[-1]
     try:
         out = subprocess.check_output([str(binary), "dump-openapi"], timeout=30)
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
-        return None
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(f"{binary} will not dump its OpenAPI spec: {exc}") from exc
     return json.loads(out)
+
+
+def _newest_engine_binary(dist_newstyle: Path) -> Path | None:
+    """The most recently built engine executable, whatever level it was built at.
+
+    cabal names the directory above `build/` after the optimization level:
+    `opt/` at -O2, `noopt/` at -O0, and nothing at all at -O1. Matching only
+    one of the three is how these tests came to skip themselves silently for
+    months: CI downloads the engine artefact into `dist-newstyle/`, the level
+    moved, and the glob stopped matching a binary that was sitting right
+    there. `**` matches all three and the next one too.
+    """
+    pattern = "build/*/ghc-*/volca-*/x/volca/**/build/volca/volca"
+    found = [p for p in dist_newstyle.rglob(pattern) if p.is_file()]
+    return max(found, key=lambda p: p.stat().st_mtime) if found else None


### PR DESCRIPTION
## Problem

The drift tests have not run since #107. `live_spec` looked for the engine
under `x/volca/opt/build/volca/volca`, but cabal names that directory after
the optimisation level: `opt/` at -O2, `noopt/` at -O0, nothing at all at
-O1. When #107 moved pull request builds to -O1 the glob stopped matching a
binary that was sitting right there, the fixture returned `None`, and both
tests have reported themselves as skipped on every run since.

Run 34334580627 shows it: `Downloading engine artefact from build.yml run
34320531548`, and underneath it both `test_drift.py` tests `SKIPPED`. The
workflow does its job and then nothing is checked.

## Solution

The glob matches any level, and takes the most recently built binary rather
than the last in alphabetical order, which with three layouts in one tree
would otherwise be an arbitrary choice.

A binary that is present and will not dump its spec now raises instead of
returning `None`. `None` is for a checkout that has never built the engine,
which is a real case worth skipping for; using the same value for a failure
is what let this sit unnoticed.

## Remarks

The pattern is now the one the artefact upload step already uses, so the
two ends of the hand-off agree.

## How to test

In CI on this pull request: `302 passed, 5 skipped`, with both
`test_drift.py` tests PASSED. Before, on the same download, it was
`300 passed, 7 skipped`. The five that remain are the smoke tests, which
want a running server.

Locally, build the engine at any level and run `pytest tests/test_drift.py`
from `pyvolca/`.
