### PR TITLE
Read the second vocabulary an EcoSpold 1 file states its media in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,20 @@
   before this are rebuilt on the next load. Wire revision 23.
 
 ### Fixed
+- Emissions read from an EcoSpold 1 file now reach the methods that
+  characterize them. An elementary exchange names its medium in a `category`
+  attribute, and the format is written in two vocabularies there: some exports
+  write the bare medium, `air`, and others state the direction as well,
+  `emissions to air`. Only the first was read, so in a file of the second kind
+  every emission arrived with no compartment at all, matched no
+  characterization factor, and scored exactly zero. What made it hard to see is
+  that resources are spelled the same way in both, so land use, water use and
+  the resource categories came out right while climate change and acidification
+  came out as a clean zero, which reads like an empty inventory rather than a
+  reading fault. Both vocabularies are now read. A word that still names no
+  medium leaves the flow uncharacterizable, as it must, but the reading now
+  says which word it was instead of letting the zero pass for an answer. Caches
+  built before this are rebuilt on the next load.
 - A load slower than the idle timeout no longer shuts the server down under the
   caller. The timeout counted the moment a request *arrived*, so a request that
   is itself long counted as silence for its whole duration: reading a gigabyte

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -407,6 +407,12 @@ History of manual bumps:
 - 32: the supplier an exchange resolved to is a 'Maybe', not a UUID with nil
      standing for none. The field changes width, so every field after it would
      be read at the wrong offset.
+- 33: an EcoSpold 1 elementary exchange whose category states the direction as
+     well as the medium ("emissions to air") is placed in that medium, where it
+     used to be left with no compartment at all. Nothing changes type, so a
+     cache written just before this would pass the fingerprint and go on
+     holding every emission of such an export uncharacterizable - a zero score
+     under every method, beside resource categories that look right.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.
@@ -414,7 +420,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeRep (Proxy :: Proxy Database))
-     in hi `xor` lo `xor` 32
+     in hi `xor` lo `xor` 33
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -26,6 +26,7 @@ import Data.Either (lefts, rights)
 import qualified Data.IntMap.Strict as IM
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe, isNothing)
+import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
@@ -194,6 +195,12 @@ data ParseState = ParseState
     , psContext :: !ElementContext
     , psTextAccum :: ![BS.ByteString]
     , psDocs :: !DatasetDocs -- Provenance the dataset states about itself
+    , psUnplacedMedia :: !(S.Set Text)
+    {- ^ The categories this dataset filed an elementary exchange under that
+    'parseMedium' could not place. Such a flow carries no compartment, so no
+    characterization factor reaches it and every method scores it zero: the
+    reading names the word instead of letting the zero pass for an answer.
+    -}
     , psCompletedActivities :: ![Either String ParsedDataset]
     }
 
@@ -216,6 +223,7 @@ initialParseState =
         , psContext = Other
         , psTextAccum = []
         , psDocs = emptyDatasetDocs
+        , psUnplacedMedia = S.empty
         , psCompletedActivities = []
         }
 
@@ -477,6 +485,7 @@ closeExchange state = case psContext state of
                 , psTechFlows = techs
                 , psBioFlows = bios
                 , psUnits = unit : psUnits state
+                , psUnplacedMedia = maybe id S.insert (unplacedMedium edata parsedFlow) (psUnplacedMedia state)
                 , psContext = Other
                 }
     InInputGroup _ -> popPath state
@@ -513,6 +522,7 @@ resetDataset state =
         , psContext = Other
         , psTextAccum = []
         , psDocs = emptyDatasetDocs
+        , psUnplacedMedia = S.empty
         }
 
 {- | Build exchange, flow, and unit from exchange data.
@@ -527,6 +537,17 @@ medium 'Waste' whatever group it carries, so it is read as biosphere
 before the groups are consulted. Waste that does have a treatment is not
 written that way and stays on the technosphere side.
 -}
+
+{- | The category an elementary exchange was filed under, when that word names
+no medium this reader knows and the flow therefore came back with no
+compartment. A technosphere row has no compartment to place, and says nothing.
+-}
+unplacedMedium :: ExchangeData -> ParsedFlow -> Maybe Text
+unplacedMedium edata (ParsedBio flow)
+    | isNothing (bfCompartment flow) = Just (exCategory edata)
+    | otherwise = Nothing
+unplacedMedium _ (ParsedTech _) = Nothing
+
 buildExchange :: Maybe Text -> ExchangeData -> (Exchange, ParsedFlow, Unit)
 buildExchange activityLoc edata
     | isBiosphere = (bioEx, ParsedBio bioFlow, unit)
@@ -574,11 +595,12 @@ buildExchange activityLoc edata
         | otherwise = ClaimByProduct
 
     subCat = if T.null (exSubCategory edata) then Nothing else Just (exSubCategory edata)
-    -- The medium of a group-4 exchange is its @category@, and the vocabulary
-    -- EcoSpold 1 writes there is the four 'parseMedium' reads. A category it
-    -- cannot place leaves the flow with no compartment: this reader assembles
-    -- its result purely and has no channel to report on, which is a limitation
-    -- of the reader rather than a judgement about the file.
+    -- The medium of a group-4 exchange is its @category@, and EcoSpold 1 is
+    -- written in more than one vocabulary there: one family of exports names
+    -- the bare medium, another states the direction too. 'parseMedium' reads
+    -- both. A category it still cannot place leaves the flow with no
+    -- compartment, and 'unplacedMedium' carries the word to the dataset's
+    -- warnings so the resulting zero score is not silent.
     compartment = case parseMedium category of
         Right medium -> Just (Compartment medium subCat)
         Left _ -> Nothing
@@ -668,18 +690,44 @@ The geography is not among them: a dataset that declares none is recorded as
 -}
 placeholdersUsed :: ParseState -> [Text]
 placeholdersUsed st =
-    [ named <> what
+    [ datasetPrefix st <> what
     | (what, absent) <-
         [ ("no activity name, read as \"Unknown Activity\"", isNothing (psActivityName st))
         , ("no reference unit, read as \"UNKNOWN_UNIT\"", isNothing (psRefUnit st))
         ]
     , absent
     ]
+
+{- | What a warning about this dataset calls it. A dataset that declared no
+number is left unnamed rather than called number zero, which is how
+'datasetIdentifier' reads the same field.
+-}
+datasetPrefix :: ParseState -> Text
+datasetPrefix st =
+    maybe "" (\(NativeProcessId n) -> "dataset " <> n <> ": ") (datasetIdentifier (psDatasetNumber st))
+
+{- | The compartment vocabularies this dataset used that the reader could not
+place, said once for the dataset rather than once per exchange.
+
+An elementary flow with no compartment is characterized by no method, so it
+contributes zero to every score while looking like any other flow. The reading
+names the words it could not place, which is what a reader needs to add them.
+-}
+unplacedMediaSeen :: ParseState -> [Text]
+unplacedMediaSeen st
+    | S.null media = []
+    | otherwise =
+        [ datasetPrefix st
+            <> "elementary exchanges filed under "
+            <> T.intercalate ", " (map quoted (S.toList media))
+            <> " carry no compartment, so no method characterizes them"
+        ]
   where
-    -- A dataset that declared no number is left unnamed rather than called
-    -- number zero, which is how 'datasetIdentifier' reads the same field.
-    named :: Text
-    named = maybe "" (\(NativeProcessId n) -> "dataset " <> n <> ": ") (datasetIdentifier (psDatasetNumber st))
+    media :: S.Set Text
+    media = psUnplacedMedia st
+
+    quoted :: Text -> Text
+    quoted t = "\"" <> t <> "\""
 
 -- | Build the final per-dataset result, applying the cut-off strategy.
 buildResult :: ParseState -> Either String ParsedDataset
@@ -724,7 +772,7 @@ buildResult st =
                   pdWasteFlows = []
                 , pdUnits = reverse (psUnits st)
                 , pdDatasetNumber = psDatasetNumber st
-                , pdWarnings = placeholdersUsed st
+                , pdWarnings = placeholdersUsed st ++ unplacedMediaSeen st
                 }
      in -- A file that yields no exchange at all is not a dataset: a stray or
         -- truncated XML the SAX fold walked through without complaint.

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -525,6 +525,16 @@ resetDataset state =
         , psUnplacedMedia = S.empty
         }
 
+{- | The category an elementary exchange was filed under, when that word names
+no medium this reader knows and the flow therefore came back with no
+compartment. A technosphere row has no compartment to place, and says nothing.
+-}
+unplacedMedium :: ExchangeData -> ParsedFlow -> Maybe Text
+unplacedMedium edata (ParsedBio flow)
+    | isNothing (bfCompartment flow) = Just (exCategory edata)
+    | otherwise = Nothing
+unplacedMedium _ (ParsedTech _) = Nothing
+
 {- | Build exchange, flow, and unit from exchange data.
 @activityLoc@ is the activity's location, used as a biosphere fallback.
 
@@ -537,17 +547,6 @@ medium 'Waste' whatever group it carries, so it is read as biosphere
 before the groups are consulted. Waste that does have a treatment is not
 written that way and stays on the technosphere side.
 -}
-
-{- | The category an elementary exchange was filed under, when that word names
-no medium this reader knows and the flow therefore came back with no
-compartment. A technosphere row has no compartment to place, and says nothing.
--}
-unplacedMedium :: ExchangeData -> ParsedFlow -> Maybe Text
-unplacedMedium edata (ParsedBio flow)
-    | isNothing (bfCompartment flow) = Just (exCategory edata)
-    | otherwise = Nothing
-unplacedMedium _ (ParsedTech _) = Nothing
-
 buildExchange :: Maybe Text -> ExchangeData -> (Exchange, ParsedFlow, Unit)
 buildExchange activityLoc edata
     | isBiosphere = (bioEx, ParsedBio bioFlow, unit)
@@ -726,7 +725,10 @@ unplacedMediaSeen st
     media :: S.Set Text
     media = psUnplacedMedia st
 
+    -- A group-4 row can carry no category at all, and "filed under \"\"" would
+    -- name nothing; the absence is what there is to report about it.
     quoted :: Text -> Text
+    quoted "" = "no category"
     quoted t = "\"" <> t <> "\""
 
 -- | Build the final per-dataset result, applying the cut-off strategy.

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -213,7 +213,8 @@ data MapContext = MapContext
     , mcCompartmentMap :: !CompartmentMap
     {- ^ The table both sides of a compartment comparison go through, so the
     cascade reads a compartment the way the scoring tables do. Without it a row
-    written "Emissions to air" would not meet a flow filed under "air".
+    written "urban air" would not meet a flow filed under "air", subcompartment
+    "urban": only the table relates a spelling that carries more than a medium.
     -}
     , mcSynGroupFlows :: !(M.Map (FlowDirection, Int) [BiosphereFlow])
     {- ^ Memoized @(direction, synonym-group id)@ → candidate flows, precomputed
@@ -397,9 +398,10 @@ type MediumKey = Maybe Medium
 the same value, as the scoring tables key it: 'buildMethodTables' indexes a
 factor under the row's normalized medium and 'flowMediumSub' files a flow
 under its own, so a match judged any looser here promises a factor the read
-side never serves. "air" against "emissions to air" is a vocabulary gap that
-only a compartment rule bridges, not a widening. An empty statement
-constrains nothing.
+side never serves. Both sides read their words with 'parseMedium', so two
+spellings of one medium meet in the value they name; "air" against "urban air"
+is a vocabulary gap that only a compartment rule bridges, not a widening. An
+empty statement constrains nothing.
 -}
 mediumFits :: Text -> MediumKey -> Bool
 mediumFits stated actual
@@ -513,9 +515,10 @@ exclusionWarning flows cf
 
 {- | The factors the cascade left unmatched although a flow of their name is
 in the database, stated in a medium no flow of the database is filed under.
-That is a vocabulary gap ("air" against "emissions to air"), which a
-compartment mapping bridges and nothing else will: said once per method,
-with both vocabularies, so the operator knows what to declare.
+That is a vocabulary gap ("air" against "urban air"), which a compartment
+mapping bridges and nothing else will: said once per method, with both
+vocabularies, so the operator knows what to declare. A spelling that names
+only a medium is not one of these, 'parseMedium' having read it already.
 
 Judged on the whole database, not on the flows of that name: a substance the
 database has in water and not in air leaves a factor stated in air unmatched
@@ -686,10 +689,10 @@ name: the one whose subcompartment the row states, else the one filed under no
 particular subcompartment, else any in the row's medium.
 
 Both sides go through 'normalizeCompartment' first, which is what lets a row
-written "Emissions to air" meet a flow filed under "air"; the scoring tables
-read the same table, so the cascade and the tables agree on what a compartment
-is. Without it the row's medium, now a condition, would veto a spelling only
-the table relates.
+written "urban air" meet a flow filed under "air", subcompartment "urban"; the
+scoring tables read the same table, so the cascade and the tables agree on what
+a compartment is. Without it the row's medium, now a condition, would veto a
+spelling only the table relates.
 
 A compartment a row states is a condition, not a preference. When no candidate
 is in that medium this answers Nothing, so 'resolveCF' moves on to the next

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -128,7 +128,8 @@ mediumText = \case
 
 {- | Read a medium as any format writes it. Case and surrounding space are
 ignored; @raw@, @resource@ and @resources@ are the three ways the formats name
-'NaturalResource'.
+'NaturalResource', and a file that states the direction as well as the medium
+(@emissions to air@) names the same three emission media as the bare words do.
 
 'Left' names the string it could not place, so an unknown medium is reported
 rather than turned into a flow that quietly belongs nowhere.
@@ -136,8 +137,11 @@ rather than turned into a flow that quietly belongs nowhere.
 parseMedium :: Text -> Either Text Medium
 parseMedium raw = case T.toLower (T.strip raw) of
     "air" -> Right Air
+    "emissions to air" -> Right Air
     "water" -> Right Water
+    "emissions to water" -> Right Water
     "soil" -> Right Soil
+    "emissions to soil" -> Right Soil
     "natural resource" -> Right NaturalResource
     "raw" -> Right NaturalResource
     "resource" -> Right NaturalResource

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -6,6 +6,7 @@ module EcoSpold1Spec (spec) where
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
+import qualified Data.Text as T
 import Test.Hspec
 
 import EcoSpold.Common (ParsedDataset (..))
@@ -229,6 +230,87 @@ wasteFlowXml =
         , "                category=\"Final waste flows\" subCategory=\"landfill\""
         , "                unit=\"kg\" meanValue=\"0.02\">"
         , "        <inputGroup>5</inputGroup>"
+        , "      </exchange>"
+        , "    </flowData>"
+        , "  </dataset>"
+        , "</ecoSpold>"
+        ]
+
+{- | The second compartment vocabulary EcoSpold 1 is written in. One family of
+exports files an elementary exchange under the bare medium (@air@, as
+'minimalXml' has it); another spells the direction out, @emissions to air@, and
+abbreviates the subcompartment. Both are the same three media, and a reader
+that places only the first leaves every emission of the second with no
+compartment at all - which characterizes to zero in every method, in silence.
+-}
+spelledOutMediaXml :: BC.ByteString
+spelledOutMediaXml =
+    BC.unlines
+        [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold01\">"
+        , "  <dataset number=\"11\">"
+        , "    <metaInformation>"
+        , "      <processInformation>"
+        , "        <referenceFunction name=\"heat production\" category=\"heat\""
+        , "                           subCategory=\"others\" unit=\"MJ\"/>"
+        , "        <geography location=\"CH\" />"
+        , "      </processInformation>"
+        , "    </metaInformation>"
+        , "    <flowData>"
+        , "      <exchange number=\"1\" name=\"heat\" category=\"heat\""
+        , "                subCategory=\"others\" unit=\"MJ\" meanValue=\"1.0\">"
+        , "        <outputGroup>0</outputGroup>"
+        , "      </exchange>"
+        , "      <exchange number=\"2\" name=\"Carbon dioxide, fossil\""
+        , "                category=\"emissions to air\" subCategory=\"high. pop.\""
+        , "                unit=\"kg\" meanValue=\"0.07\" CASNumber=\"124-38-9\">"
+        , "        <outputGroup>4</outputGroup>"
+        , "      </exchange>"
+        , "      <exchange number=\"3\" name=\"BOD5, Biological Oxygen Demand\""
+        , "                category=\"emissions to water\" subCategory=\"river\""
+        , "                unit=\"kg\" meanValue=\"0.001\">"
+        , "        <outputGroup>4</outputGroup>"
+        , "      </exchange>"
+        , "      <exchange number=\"4\" name=\"Cadmium\" category=\"emissions to soil\""
+        , "                subCategory=\"agricultural\" unit=\"kg\" meanValue=\"1.0E-9\">"
+        , "        <outputGroup>4</outputGroup>"
+        , "      </exchange>"
+        , "      <exchange number=\"5\" name=\"Water, cooling, unspecified natural origin\""
+        , "                category=\"resources\" subCategory=\"in water\""
+        , "                unit=\"m3\" meanValue=\"0.024\">"
+        , "        <inputGroup>4</inputGroup>"
+        , "      </exchange>"
+        , "    </flowData>"
+        , "  </dataset>"
+        , "</ecoSpold>"
+        ]
+
+{- | An elementary exchange filed under a word that belongs to no medium this
+reader knows. There is no right compartment to give it, so the reading says
+which word it could not place rather than handing back a flow that scores zero
+everywhere and looks like an answer.
+-}
+unplaceableMediumXml :: BC.ByteString
+unplaceableMediumXml =
+    BC.unlines
+        [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold01\">"
+        , "  <dataset number=\"12\">"
+        , "    <metaInformation>"
+        , "      <processInformation>"
+        , "        <referenceFunction name=\"heat production\" category=\"heat\""
+        , "                           subCategory=\"others\" unit=\"MJ\"/>"
+        , "        <geography location=\"CH\" />"
+        , "      </processInformation>"
+        , "    </metaInformation>"
+        , "    <flowData>"
+        , "      <exchange number=\"1\" name=\"heat\" category=\"heat\""
+        , "                subCategory=\"others\" unit=\"MJ\" meanValue=\"1.0\">"
+        , "        <outputGroup>0</outputGroup>"
+        , "      </exchange>"
+        , "      <exchange number=\"2\" name=\"Carbon dioxide, fossil\""
+        , "                category=\"Luft\" subCategory=\"hoch\" unit=\"kg\" meanValue=\"0.07\">"
+        , "        <outputGroup>4</outputGroup>"
         , "      </exchange>"
         , "    </flowData>"
         , "  </dataset>"
@@ -650,3 +732,31 @@ spec = do
                 Left err -> expectationFailure $ "Parse failed: " ++ err
                 Right ParsedDataset{pdActivity = act} ->
                     [bioLocation e | e@BiosphereExchange{} <- exchanges act] `shouldBe` ["RoW"]
+
+    -- -----------------------------------------------------------------------
+    -- Compartment vocabularies: EcoSpold 1 is written in more than one, and a
+    -- flow left with no compartment is characterized by no method at all.
+    -- -----------------------------------------------------------------------
+    describe "Elementary compartments" $ do
+        it "places the media an export spells out in full" $
+            case parseWithXeno spelledOutMediaXml of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right ParsedDataset{pdBioFlows = bios} ->
+                    map bfCompartment bios
+                        `shouldBe` [ Just (Compartment Air (Just "high. pop."))
+                                   , Just (Compartment Water (Just "river"))
+                                   , Just (Compartment Soil (Just "agricultural"))
+                                   , Just (Compartment NaturalResource (Just "in water"))
+                                   ]
+
+        it "has nothing to say about a dataset whose media it placed" $
+            case parseWithXeno spelledOutMediaXml of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right ParsedDataset{pdWarnings = warns} -> warns `shouldBe` []
+
+        it "names the word it could not place, rather than scoring zero in silence" $
+            case parseWithXeno unplaceableMediumXml of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right ParsedDataset{pdBioFlows = bios, pdWarnings = warns} -> do
+                    map bfCompartment bios `shouldBe` [Nothing]
+                    warns `shouldSatisfy` any (T.isInfixOf "Luft")

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -317,6 +317,15 @@ unplaceableMediumXml =
         , "</ecoSpold>"
         ]
 
+-- | 'unplaceableMediumXml' with the offending category taken off entirely.
+uncategorizedMediumXml :: BC.ByteString
+uncategorizedMediumXml = BC.unlines (map withoutCategory (BC.lines unplaceableMediumXml))
+  where
+    withoutCategory :: BC.ByteString -> BC.ByteString
+    withoutCategory line
+        | "                category=\"Luft\"" `BC.isPrefixOf` line = BC.pack "                category=\"\" subCategory=\"hoch\" unit=\"kg\" meanValue=\"0.07\">"
+        | otherwise = line
+
 {- | Fixture carrying the provenance blocks a real export writes: two numbered
 sources of which only the second is the one the dataset was published in, a
 numbered person who proof-read it, and the free texts of the process
@@ -753,6 +762,13 @@ spec = do
             case parseWithXeno spelledOutMediaXml of
                 Left err -> expectationFailure $ "Parse failed: " ++ err
                 Right ParsedDataset{pdWarnings = warns} -> warns `shouldBe` []
+
+        it "reports the absence when the exchange carries no category at all" $
+            case parseWithXeno uncategorizedMediumXml of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right ParsedDataset{pdBioFlows = bios, pdWarnings = warns} -> do
+                    map bfCompartment bios `shouldBe` [Nothing]
+                    warns `shouldSatisfy` any (T.isInfixOf "no category")
 
         it "names the word it could not place, rather than scoring zero in silence" $
             case parseWithXeno unplaceableMediumXml of

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -143,18 +143,17 @@ spec = do
                 comp = Compartment "air" "" ""
             fmap bfId (findFlowByNameComp M.empty byName "co2" (Just comp)) `shouldBe` Nothing
 
-        it "does not read a medium that merely contains the stated one as that medium" $ do
-            -- "air" is a substring of "emissions to air", which is another
-            -- vocabulary, not a widening. The scoring tables key on the exact
-            -- normalized medium, so a match here promised a factor scoring
-            -- never served (volca#346). A compartment rule is what bridges it.
+        it "reads a medium stated with its direction as that medium" $ do
+            -- "emissions to air" is how one family of sources spells the air
+            -- medium. The direction is already recorded on the exchange, so
+            -- the two words name one medium and need no rule between them.
+            -- A spelling that carries more than the medium does need one, and
+            -- the "urban air" case below is where that is pinned.
             fid <- nextRandom
             let flow = mkFlow fid "ammonia" Air Nothing
                 byName = M.singleton "ammonia" [flow]
                 comp = Compartment "emissions to air" "" ""
-                rule = M.singleton ("emissions to air", "", "") (Compartment "air" "" "")
-            fmap bfId (findFlowByNameComp M.empty byName "ammonia" (Just comp)) `shouldBe` Nothing
-            fmap bfId (findFlowByNameComp rule byName "ammonia" (Just comp)) `shouldBe` Just fid
+            fmap bfId (findFlowByNameComp M.empty byName "ammonia" (Just comp)) `shouldBe` Just fid
 
         it "does not read a long-term subcompartment as the immediate one" $ do
             -- "low. pop." is contained in "low. pop., long-term"; a delayed
@@ -425,10 +424,11 @@ spec = do
             score `shouldBe` 0.0
 
     describe "buildMethodTables compartment normalization" $ do
-        -- Regression: BAFU categorizes air emissions as "emissions to air/low. pop.",
-        -- ILCD CFs are keyed on bare "air/...". Without a compartment map applied to
-        -- both sides, the lookup misses and the flow silently scores zero.
-        it "scores zero without a compartment map (regression)" $ do
+        -- Two sides, one vocabulary. A factor table and an inventory each state
+        -- a medium in the words their own format uses, and the tables key on
+        -- the medium those words name. What the reader can place needs nothing
+        -- declared; what it cannot is what a compartment rule is for.
+        it "meets a factor whose medium states its direction, with nothing declared" $ do
             fid <- nextRandom
             let flow = mkFlow fid "ammonia" Air (Just "low. pop.")
                 cf = mkCFComp "ammonia" "emissions to air" "low. pop." 0.747
@@ -436,13 +436,23 @@ spec = do
                 inventory = M.singleton fid 10.0
                 flowDB = M.singleton fid flow
                 score = loScore (computeLCIAScoreFromTables defaultUnitConfig M.empty flowDB inventory tables)
-            score `shouldBe` 0.0
+            score `shouldBe` 7.47
 
-        it "bridges 'emissions to air' → 'air' via a medium-only rule" $ do
+        it "scores zero when the factor's medium is one no reader can place" $ do
             fid <- nextRandom
             let flow = mkFlow fid "ammonia" Air (Just "low. pop.")
-                cf = mkCFComp "ammonia" "emissions to air" "low. pop." 0.747
-                cmap = M.singleton ("emissions to air", "", "") (Compartment "air" "" "")
+                cf = mkCFComp "ammonia" "urban air" "low. pop." 0.747
+                tables = buildMethodTables OtherCFFamily M.empty M.empty [(cf, Nothing)]
+                inventory = M.singleton fid 10.0
+                flowDB = M.singleton fid flow
+                score = loScore (computeLCIAScoreFromTables defaultUnitConfig M.empty flowDB inventory tables)
+            score `shouldBe` 0.0
+
+        it "bridges 'urban air' → 'air' via a medium-only rule" $ do
+            fid <- nextRandom
+            let flow = mkFlow fid "ammonia" Air (Just "low. pop.")
+                cf = mkCFComp "ammonia" "urban air" "low. pop." 0.747
+                cmap = M.singleton ("urban air", "", "") (Compartment "air" "" "")
                 tables = buildMethodTables OtherCFFamily cmap M.empty [(cf, Nothing)]
                 inventory = M.singleton fid 10.0
                 flowDB = M.singleton fid flow
@@ -815,9 +825,9 @@ spec = do
         it "names both vocabularies when a factor's name is filed under another medium" $ do
             fid <- nextRandom
             let flow = mkFlow fid "ammonia" Air Nothing
-                cf = mkCFComp "ammonia" "emissions to air" "" 0.747
+                cf = mkCFComp "ammonia" "urban air" "" 0.747
             compartmentGapWarning M.empty (M.singleton "ammonia" [flow]) [(cf, Nothing)]
-                `shouldBe` Just "1 factor(s) name a flow this database files under another compartment (method: \"emissions to air\"; database: \"air\"). Declare a [[compartment-mappings]] table bridging them."
+                `shouldBe` Just "1 factor(s) name a flow this database files under another compartment (method: \"urban air\"; database: \"air\"). Declare a [[compartment-mappings]] table bridging them."
 
         it "stays silent when the name is simply absent" $ do
             let cf = mkCFComp "ammonia" "air" "" 0.747


### PR DESCRIPTION
**Problem.** An EcoSpold 1 elementary exchange names its medium in a `category` attribute, and the format is written two ways there: some exports write the bare medium, `air`, and others state the direction as well, `emissions to air`. `parseMedium` read only the first. In a file of the second kind every emission arrived with no compartment at all, matched no characterization factor, and scored exactly zero under every method.

What hid it is that resources are spelled the same way in both dialects (`resource`, `resources`). So land use, water use and the resource categories came out right, beside a clean zero on climate change and acidification. A zero reads like an empty inventory, not like a reading fault, and the mapping report says the factors matched: it counts factors resolved by name, and the compartment refuses them one step later.

The vocabulary was known: `data/compartments.csv` has bridged it since before compartments carried a `Medium`. That bridge worked while a flow kept the words its file wrote. Once a medium became a value rather than text, an unreadable word stopped being a spelling to translate and became an absence, and no rule table can bridge one.

**Solution.** `parseMedium` reads the three spellings that state the direction as well as the medium. It is the one conversion both sides go through - `Method.Mapping` reads a factor's stated medium with it too - so a factor table written the same way now meets the inventory without anything declared.

These three words name only a medium, which is why they are synonyms and not a compartment rule. A spelling that carries a subcompartment as well, `urban air`, still needs one, and both `MappingSpec` and the four comments in `Method.Mapping` that used the old example now name that one instead.

A word that still names no medium leaves the flow uncharacterizable, as it must. It no longer does so in silence: the dataset's warnings name the word, through the channel `ParsedDataset` already carries and this reader was not using. A row carrying no category at all says that rather than naming an empty string.

The cache signature moves to 33. Nothing changes type, so a cache written just before this would pass the fingerprint and go on holding every emission of such an export with no compartment.

**Remarks.** Measured against a publisher's own results for an export of the second kind, under an EF 3.1 method: climate change and acidification move from exactly 0.0 to a median ratio of 1.0000, and fifteen of twenty-two categories land between 0.985 and 1.047. What is left is not this: a category-naming mismatch on the ecotoxicity trio, and a scatter of outliers where a published name resolves to the wrong activity. Neither is a reading fault, and neither is in this diff.

Flow identities do not move. The UUID a flow is minted under has always been keyed on the raw `category` text, which is untouched, so the fix changes what a flow *is filed under*, never which flow it is.

One thing this does not do: the warning is said once per dataset, so a whole export in a third dialect would say it once per file. The EcoSpold 2 reader beside it says its own once per *exchange*, and saying a per-load fact once per load means changing both readers and the type they share. That is its own subject.

**How to test.** `cabal test lca-tests --test-options="--match /Elementary compartments/"` covers both dialects, the unplaceable word and the absent category. `--match /Mapping/` covers the two sides meeting, and the rule that is still needed for a spelling carrying a subcompartment. Full suite: 2534 examples, 0 failures, 2 pending.
