### PR TITLE
Read a year written "y"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@
   before this are rebuilt on the next load. Wire revision 23.
 
 ### Fixed
+- A year written `y` is now read as a year. The unit table already knew
+  `year`, `a` and `yr`, and the compound units built on it, `my` for a metre
+  year and `kmy` for a kilometre year, so the one spelling missing was the
+  bare letter. A reference product measured in it converted to nothing at all
+  rather than to a wrong number, which is why it took a source that uses it to
+  notice (data version 4).
 - Emissions read from an EcoSpold 1 file now reach the methods that
   characterize them. An elementary exchange names its medium in a `category`
   attribute, and the format is written in two vocabularies there: some exports

--- a/data/units.csv
+++ b/data/units.csv
@@ -43,6 +43,7 @@ day,time,86400.0
 year,time,31536000.0
 a,time,31536000.0
 yr,time,31536000.0
+y,time,31536000.0
 month,time,2592000.0
 j,energy,1.0e-6
 joule,energy,1.0e-6

--- a/test/UnitConversionSpec.hs
+++ b/test/UnitConversionSpec.hs
@@ -116,6 +116,15 @@ spec = do
                 Just v -> v `shouldSatisfy` (\x -> abs (x - 3.6) < 0.001)
                 Nothing -> expectationFailure "conversion failed"
 
+        -- A year is written four ways in the wild, and a source that writes it
+        -- "y" was reading as a unit nobody knew: every conversion through it
+        -- failed rather than being off, which is why it went unnoticed.
+        it "reads every spelling of a year as the same unit" $ do
+            cfg <- loadFullUnitConfig
+            mapM_
+                (\spelling -> convertUnit cfg spelling "day" 1.0 `shouldBe` Just 365.0)
+                ["year", "a", "yr", "y"]
+
         it "converts 1 kBq to 1000 Bq" $ do
             cfg <- loadFullUnitConfig
             convertUnit cfg "kBq" "Bq" 1.0 `shouldBe` Just 1000.0


### PR DESCRIPTION
## Problem

The unit table knows `year`, `a` and `yr`, and the compound units built on the
letter, `my` for a metre year and `kmy` for a kilometre year. The bare `y` is
missing, so a reference product measured in it converts to nothing at all.

That is why it went unnoticed: a missing spelling does not give a wrong number,
it gives no number, and nothing downstream says which unit it could not read.

## Solution

One row, next to the three spellings already there.

## Remarks

`kg/year`, `kg/a` and `kg/yr` have the same gap for `kg/y`, and the other
per-year compounds likewise. They are left alone: no source seen so far writes
them that way, and guessing at spellings is how a unit table stops being a
record of what has actually been read.

Data version 4 already covers this release, so the number does not move again.

## Testing

    cabal test lca-tests --test-options="--match /UnitConversion/"

The new example converts each of the four spellings to a day and expects 365
from all of them. Removing the row makes it fail with `Nothing`, which is the
shape of the original defect.
