### PR TITLE
Answer a geography filter with the place it names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@
   ambiguities are documented where a reader looks for them.
 
 ### Changed
+- A geography filter now names a place. Asking `search_activities` or
+  `get_consumers` for a location matched that text anywhere inside one, and
+  location codes overlap: `DE` sits inside `NORDEL`, `SE` inside `US-SERC`,
+  `CH` inside `RER w/o CH+DE`, a region defined by excluding Switzerland. So a
+  question about Germany was answered with the Nordic grid and one about
+  Switzerland with the region that leaves it out, and nothing in the answer
+  said so. A location now answers when it is the geography asked for or one
+  written under it, `US` for `US-WECC` and `Europe` for `Europe without
+  Switzerland`, which leaves a filter typed one letter at a time working and
+  leaves no way for a code to match inside an unrelated one. `exact=true` is
+  unchanged and still means the location itself. The same filter narrows a
+  delete, so this decides what a delete removes as well as what a search
+  returns.
 - An exchange that resolved to no supplier now reports `activityLinkId` as
   null. It used to report the all-zero UUID, a value that reads as an
   identifier and is not one: every consumer had to know that one UUID means

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@
   ambiguities are documented where a reader looks for them.
 
 ### Changed
-- A geography filter now names a place. Asking `search_activities` or
-  `get_consumers` for a location matched that text anywhere inside one, and
-  location codes overlap: `DE` sits inside `NORDEL`, `SE` inside `US-SERC`,
+- A geography filter now names a place. Asking `search_activities`,
+  `get_consumers` or `get_supply_chain` for a location matched that text
+  anywhere inside one, and location codes overlap: `DE` sits inside `NORDEL`,
+  `SE` inside `US-SERC`,
   `CH` inside `RER w/o CH+DE`, a region defined by excluding Switzerland. So a
   question about Germany was answered with the Nordic grid and one about
   Switzerland with the region that leaves it out, and nothing in the answer

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -1074,7 +1074,10 @@ the server-reported total across all pages.
 
 Args:
     name: Substring (or exact match) on activity name.
-    geo: Geography code (``"FR"``, ``"GLO"``, ``"RoW"``…).
+    geo: Geography code (``"FR"``, ``"GLO"``, ``"RoW"``…). Answers for
+        that location or one written under it (``"US"`` for
+        ``"US-WECC"``), never for a code sitting inside an unrelated
+        one; ``exact=True`` narrows it to the location itself.
     product: Substring on the reference product name.
     preset: Apply a named classification preset configured in the engine.
     classification: System name (``"ISIC rev.4 ecoinvent"``).

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -1433,7 +1433,10 @@ class Client:
 
         Args:
             name: Substring (or exact match) on activity name.
-            geo: Geography code (``"FR"``, ``"GLO"``, ``"RoW"``…).
+            geo: Geography code (``"FR"``, ``"GLO"``, ``"RoW"``…). Answers for
+                that location or one written under it (``"US"`` for
+                ``"US-WECC"``), never for a code sitting inside an unrelated
+                one; ``exact=True`` narrows it to the location itself.
             product: Substring on the reference product name.
             preset: Apply a named classification preset configured in the engine.
             classification: System name (``"ISIC rev.4 ecoinvent"``).

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -827,7 +827,7 @@ params r = case r of
         [ pDatabase
         , pProcessId
         , Param "name" "string" Optional "Filter by activity name"
-        , Param "location" "string" Optional "Filter by location"
+        , Param "location" "string" Optional "Filter by geography/location: the location itself or one written under it, case-insensitive"
         , pLimit "Max results (default 100)"
         , Param "min_quantity" "number" Optional "Min scaled quantity threshold"
         , Param "max_depth" "integer" Optional "Max depth from root (1 = direct inputs only)"

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -783,9 +783,9 @@ params r = case r of
     SearchActivities ->
         [ pDatabase
         , Param "name" "string" Required "Name substring to search for (or exact name if exact=true). The identifier a source file gave a dataset (a SimaPro 'Process identifier'), whole or the four or more characters that tell it apart, brings that dataset's products to the top of the results."
-        , Param "geo" "string" Optional "Geography/location filter (e.g. 'FR', 'DE', 'GLO')"
+        , Param "geo" "string" Optional "Geography/location filter (e.g. 'FR', 'DE', 'GLO'). Matches the location itself or one written under it ('US' answers for 'US-WECC'), never a code inside an unrelated one."
         , Param "product" "string" Optional "Product name filter"
-        , Param "exact" "boolean" Optional "If true, name and geo must match exactly (case-insensitive equality) instead of substring search"
+        , Param "exact" "boolean" Optional "If true, the name and the geography must match exactly (case-insensitive equality) instead of a substring, respectively prefix, search"
         , Param "preset" "string" Optional "Name of a classification preset (from list_presets): expands to its bundled filters. Can be combined with explicit classification filters."
         , Param "classification" "string" Optional "Classification system name to filter by (e.g. 'ISIC rev.4 ecoinvent', 'CPC'). Use list_classifications to see available systems."
         , Param "classification_value" "string" Optional "Value within the classification system to match"
@@ -931,7 +931,7 @@ params r = case r of
         [ pDatabase
         , Param "process_id" "string" Required "Process ID of the supplier (activityUUID_productUUID format)"
         , Param "name" "string" Optional "Filter by name (case-insensitive substring)"
-        , Param "location" "string" Optional "Filter by geography/location (case-insensitive substring, e.g. 'FR', 'DE')"
+        , Param "location" "string" Optional "Filter by geography/location (e.g. 'FR', 'DE'): the location itself or one written under it, case-insensitive"
         , Param "product" "string" Optional "Filter by product name (case-insensitive substring)"
         , Param "preset" "string" Optional "Name of a classification preset (from list_presets): expands to its bundled filters"
         , Param "classification" "string" Optional "Classification system name (e.g. 'ISIC rev.4 ecoinvent')"

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -291,6 +291,23 @@ bm25DocsMatchingName idx name =
     intersectAll [] = IS.empty
     intersectAll (x : xs) = foldl IS.intersection x xs
 
+{- | Does a location answer a geography filter?
+
+A location is a code from a controlled vocabulary rather than free text, and those
+codes overlap as text: @SE@ sits inside @US-SERC@, @DE@ inside @NORDEL@, and @CH@
+inside @RER w/o CH+DE@, a region defined by excluding Switzerland. Matching anywhere
+in the string answers all three with places nobody asked for, and the answer carries
+nothing that says so.
+
+So a location answers when it is the geography asked for, or one written under it:
+@US@ answers for @US-WECC@ and @Europe@ for @Europe without Switzerland@, which is
+what keeps a filter typed one letter at a time useful, and leaves no way for a code
+to match inside an unrelated one.
+-}
+locationAnswers :: Text -> Text -> Bool
+locationAnswers wanted location =
+    T.toCaseFold (T.strip wanted) `T.isPrefixOf` T.toCaseFold (T.strip location)
+
 {- | Apply geo, product, and classification filters to a pre-built candidate list.
 Does NOT touch the name query: callers (BM25 retrieval or name-candidate lookup)
 produce the initial list.
@@ -319,8 +336,7 @@ applyStructuredFilters db geoParam productParam classFilters exactMatch candidat
                     let geoFold = T.toCaseFold geo
                      in [(pid, a) | (pid, a) <- candidates, T.toCaseFold (activityLocation a) == geoFold]
                 | otherwise ->
-                    let geoLower = T.toLower geo
-                     in [(pid, a) | (pid, a) <- candidates, T.isInfixOf geoLower (T.toLower (activityLocation a))]
+                    [(pid, a) | (pid, a) <- candidates, locationAnswers geo (activityLocation a)]
 
         -- exchangeIsReference covers both ReferenceProduct (output) and
         -- ReferenceInput (treatment-process input). Both are the activity's

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -305,8 +305,18 @@ what keeps a filter typed one letter at a time useful, and leaves no way for a c
 to match inside an unrelated one.
 -}
 locationAnswers :: Text -> Text -> Bool
-locationAnswers wanted location =
-    T.toCaseFold (T.strip wanted) `T.isPrefixOf` T.toCaseFold (T.strip location)
+locationAnswers wanted location = asked wanted `T.isPrefixOf` asked location
+
+-- | The same question asked of one location only: 'locationAnswers' under @exact@.
+locationIs :: Text -> Text -> Bool
+locationIs wanted location = asked wanted == asked location
+
+{- | A location as the question is about it: whitespace around a code is not part
+of the place, and neither is the case it was typed in. Both filters read it the
+same way, or the answer would depend on which of the two was asked.
+-}
+asked :: Text -> Text
+asked = T.toCaseFold . T.strip
 
 {- | Apply geo, product, and classification filters to a pre-built candidate list.
 Does NOT touch the name query: callers (BM25 retrieval or name-candidate lookup)
@@ -332,11 +342,8 @@ applyStructuredFilters db geoParam productParam classFilters exactMatch candidat
         geoFiltered = case geoParam of
             Nothing -> candidates
             Just geo
-                | exactMatch ->
-                    let geoFold = T.toCaseFold geo
-                     in [(pid, a) | (pid, a) <- candidates, T.toCaseFold (activityLocation a) == geoFold]
-                | otherwise ->
-                    [(pid, a) | (pid, a) <- candidates, locationAnswers geo (activityLocation a)]
+                | exactMatch -> [(pid, a) | (pid, a) <- candidates, locationIs geo (activityLocation a)]
+                | otherwise -> [(pid, a) | (pid, a) <- candidates, locationAnswers geo (activityLocation a)]
 
         -- exchangeIsReference covers both ReferenceProduct (output) and
         -- ReferenceInput (treatment-process input). Both are the activity's

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -1875,7 +1875,7 @@ collectSupplyChainEntries db dbName level supplyVec scf =
 
         matchesFilters activity pid =
             let nameOk = nameMatchesPid pid
-                locOk = maybe True (\pat -> textMatches pat (activityLocation activity)) (afcLocation core)
+                locOk = maybe True (\pat -> locationAnswers pat (activityLocation activity)) (afcLocation core)
                 productOk = maybe True (\pat -> any (textMatches pat) (getProductNames activity)) (afcProduct core)
                 classOk = matchClassifications activity (afcClassifications core)
                 localDepth = IM.findWithDefault maxBound (fromIntegral pid) depthMap

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -29,7 +29,7 @@ import Data.Time (diffUTCTime, getCurrentTime)
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
-import Database (IdentifierReach (..), activitiesIdentifiedBy, applyStructuredFilters, findActivitiesByFields, findFlowsBySynonym, flowNameRelevance)
+import Database (IdentifierReach (..), activitiesIdentifiedBy, applyStructuredFilters, findActivitiesByFields, findFlowsBySynonym, flowNameRelevance, locationAnswers)
 import Database.Allocation (asAllocated, describeRefusal, propertyShares)
 import Database.MatrixBuild (findProducer, linkedProducer)
 import Matrix (Demand (..), DepDemands, Inventory, SupplierDemands, accumulateDepDemandsWith, activityNormalizationFactor, applyBiosphereMatrix, buildDemandVectorFromIndex, computeInventoryMatrix, depDemandsToVector, perturbA, perturbABatch, perturbGlobal, toList)
@@ -3034,7 +3034,7 @@ getConsumers db dbName processIdText cnf = do
 
         locationMatches activity = case afcLocation core of
             Nothing -> True
-            Just pat -> Normalize.caseInsensitiveInfixOf pat (activityLocation activity)
+            Just pat -> locationAnswers pat (activityLocation activity)
 
         productMatches prodName = case afcProduct core of
             Nothing -> True

--- a/test/StructuredFiltersSpec.hs
+++ b/test/StructuredFiltersSpec.hs
@@ -8,7 +8,7 @@ codes overlap as text and the same filter narrows a delete.
 -}
 module StructuredFiltersSpec (spec) where
 
-import Database (findActivitiesByFields, locationAnswers)
+import Database (findActivitiesByFields, locationAnswers, locationIs)
 import Test.Hspec
 import TestHelpers (loadSampleDatabase)
 import Types
@@ -42,6 +42,13 @@ geographyFilter = describe "a geography filter names a place" $ do
     it "answers a filter typed one letter at a time" $
         map (uncurry locationAnswers) [("F", "FR"), ("F", "FI"), ("F", "DE")]
             `shouldBe` [True, True, False]
+
+    it "reads a location the same way under exact, so only the question differs" $
+        -- Whitespace and case are not part of a place. Reading them on one arm
+        -- and not the other would make " FR " answer or not depending on which
+        -- of the two filters was asked.
+        map (uncurry locationIs) [(" FR ", "fr"), ("US", "US-WECC"), ("F", "FR")]
+            `shouldBe` [True, False, False]
 
 exactProductFilter :: Spec
 exactProductFilter = describe "exact product filter" $ do

--- a/test/StructuredFiltersSpec.hs
+++ b/test/StructuredFiltersSpec.hs
@@ -3,17 +3,48 @@
 {- | The structured (geo, product, classification) filters applied on top of
 name candidates. Pins the exact-match contract: @exact=true@ turns the
 product filter into case-insensitive equality, matching what it already
-meant for names and geographies.
+meant for names; and pins what a geography filter answers, since location
+codes overlap as text and the same filter narrows a delete.
 -}
 module StructuredFiltersSpec (spec) where
 
-import Database (findActivitiesByFields)
+import Database (findActivitiesByFields, locationAnswers)
 import Test.Hspec
 import TestHelpers (loadSampleDatabase)
 import Types
 
 spec :: Spec
-spec = describe "exact product filter" $ do
+spec = do
+    exactProductFilter
+    geographyFilter
+
+geographyFilter :: Spec
+geographyFilter = describe "a geography filter names a place" $ do
+    it "answers for the location itself, whatever the case" $
+        map (`locationAnswers` "FR") ["FR", "fr", " FR "] `shouldBe` [True, True, True]
+
+    it "answers for a location written under the one asked for" $
+        map (uncurry locationAnswers) [("US", "US-WECC"), ("CH", "CH-VD"), ("Europe", "Europe without Switzerland")]
+            `shouldBe` [True, True, True]
+
+    it "does not answer for a code that merely sits inside another" $
+        -- DE inside NORDEL, SE inside US-SERC: different places whose codes
+        -- share letters, which a substring match cannot tell apart.
+        map (uncurry locationAnswers) [("DE", "NORDEL"), ("SE", "US-SERC"), ("IN", "CN-IN")]
+            `shouldBe` [False, False, False]
+
+    it "does not answer for a region named after the place it excludes" $
+        -- "RER w/o CH+DE" is Europe minus Switzerland and Germany, so answering
+        -- a question about either with it states the opposite of the truth.
+        map (uncurry locationAnswers) [("CH", "RER w/o CH+DE"), ("DE", "RER w/o CH+DE")]
+            `shouldBe` [False, False]
+
+    it "answers a filter typed one letter at a time" $
+        map (uncurry locationAnswers) [("F", "FR"), ("F", "FI"), ("F", "DE")]
+            `shouldBe` [True, True, False]
+
+exactProductFilter :: Spec
+exactProductFilter = describe "exact product filter" $ do
     it "matches the full product name only" $ do
         db <- loadSampleDatabase "SAMPLE.min"
         let hits = findActivitiesByFields db Nothing Nothing (Just "product C") [] True


### PR DESCRIPTION
## Problem

A location filter matched its text anywhere inside a location, and location
codes overlap as text:

| asked for | also answered by | which is |
|---|---|---|
| `DE` | `NORDEL` | the Nordic grid |
| `SE` | `US-SERC` | a region of the United States |
| `CH` | `RER w/o CH+DE` | Europe *without* Switzerland |

So a question about Germany came back with the Nordic grid, one about
Switzerland with the region defined by leaving it out, and nothing in the answer
said it had happened. The caller sees plausible activities with plausible
numbers for a place they did not ask about.

Three surfaces read a location filter, each with its own copy of the match: the
activity search, the consumers walk and the supply-chain walk. The search one
also narrows `delete_activities`, so it decided what a delete removed as well as
what a search returned.

## Solution

A location answers when it is the geography asked for, or one written under it:
`US` answers for `US-WECC`, `Europe` for `Europe without Switzerland`. One
predicate, `Database.locationAnswers`, used by all three.

`exact=true` still means the location itself, through `Database.locationIs`.
Both read a location the same way first, so whitespace and case cannot make one
filter answer where the other does not.

## Remarks

Plain equality would have been simpler and is what a code deserves, but the
activity search is what a filter box types into one letter at a time, and
equality makes every keystroke before the last one return nothing. Matching a
location written under the one asked for keeps that working and still closes
every overlap above.

`US` answering for `US-WECC` is a choice rather than a fact: a sub-region is not
the country. It is the same choice the filter made before, minus the
coincidences, and `exact=true` is there for a caller who means the country
itself.

The published parameter descriptions say what the filter now does, in the
resource registry and in the Python client, whose generated README block follows
its docstring. The engine's own documentation is complete; the generated
`mcp-tools.json` and `openapi.json` that live outside this repository carry the
old wording until they are refreshed at release time.

## Testing

    cabal test lca-tests --test-options="--match /StructuredFilters/"
    cd pyvolca && pytest tests/test_api_reference_drift.py

Six examples pin the filter: the location itself in any case, one written under
it, a code merely sitting inside another, a region named after the place it
excludes, a filter typed one letter at a time, and the two arms reading a
location the same way. The whole suite is green, 2540 examples.
