### PR TITLE
Say what the geo option does on the command line

### DIFF
--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -301,7 +301,7 @@ flowSubCommandParser =
 searchActivitiesParser :: Parser Command
 searchActivitiesParser = do
     searchName <- optTextOpt "name" Nothing "TERM" "Search by activity name"
-    searchGeo <- optTextOpt "geo" Nothing "LOCATION" "Filter by geography (exact match)"
+    searchGeo <- optTextOpt "geo" Nothing "LOCATION" "Filter by geography: the location itself or one written under it"
     searchProduct <- optTextOpt "product" Nothing "PRODUCT" "Filter by reference product"
     searchLimit <- optIntOpt "limit" Nothing "N" "Limit number of results (max 1000, default 50)"
     searchOffset <- optIntOpt "offset" Nothing "N" "Offset for pagination (default 0)"


### PR DESCRIPTION
## Problem

`volca search-activities --geo` advertised itself as an exact match. The command it builds sets `sfExactMatch = False`, and since the filter now answers for a location and the ones written under it, the help was wrong on both counts.

## Solution

One help string: "Filter by geography: the location itself or one written under it". The same sentence the HTTP parameter and the MCP tool already carry.

## Remarks

Nothing else in the parser describes a geography, so this is the last place the old wording survived.

## How to test

`volca search-activities --help` and read the `--geo` line.