### PR TITLE
Read a geography filter's containment from the table, not from the spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,20 +14,24 @@
   ambiguities are documented where a reader looks for them.
 
 ### Changed
-- A geography filter now names a place. Asking `search_activities`,
-  `get_consumers` or `get_supply_chain` for a location matched that text
-  anywhere inside one, and location codes overlap: `DE` sits inside `NORDEL`,
-  `SE` inside `US-SERC`,
-  `CH` inside `RER w/o CH+DE`, a region defined by excluding Switzerland. So a
-  question about Germany was answered with the Nordic grid and one about
-  Switzerland with the region that leaves it out, and nothing in the answer
-  said so. A location now answers when it is the geography asked for or one
-  written under it, `US` for `US-WECC` and `Europe` for `Europe without
-  Switzerland`, which leaves a filter typed one letter at a time working and
-  leaves no way for a code to match inside an unrelated one. `exact=true` is
-  unchanged and still means the location itself. The same filter narrows a
-  delete, so this decides what a delete removes as well as what a search
-  returns.
+- A geography filter now names a place, and reads which places are inside it
+  from the location table rather than from how a code is spelled. Asking
+  `search_activities`, `get_consumers` or `get_supply_chain` for a location
+  compared the two as text, and location codes overlap: `NO` opens `NORDEL`
+  and `Northern Cyprus`, `GL` opens `GLO`, `RO` opens `RoW`, `CA` opens
+  `Canary Islands`. So a question about Norway was answered with the Nordic
+  grid, one about Greenland with every global dataset, and nothing in the
+  answer said so. Across the geographies one recent EcoSpold 2 release
+  declares, forty pairs answered that way. Containment now comes from the
+  shipped location table, which says that `US-WECC` is inside `US` and that
+  `FR` is inside `RER`, so a filter also answers for places it never could
+  before: `RER` finds French datasets, `NAFTA` the eighty-four states and
+  provinces it covers. `GLO` and `RoW` are places, not containers, so asking
+  for either returns the datasets written that way rather than the whole
+  database. A location the table does not list answers for itself alone.
+  `exact=true` is unchanged and still means the location itself. The same
+  filter narrows a delete, so this decides what a delete removes as well as
+  what a search returns.
 - An exchange that resolved to no supplier now reports `activityLinkId` as
   null. It used to report the all-zero UUID, a value that reads as an
   identifier and is not one: every consumer had to know that one UUID means

--- a/data/geographies.csv
+++ b/data/geographies.csv
@@ -246,7 +246,7 @@ CU,Cuba,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 CV,Cape Verde,UN-WAFRICA|Africa|GLO|RoW
 CW,Curaçao,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 Canada without Alberta,Canada without Alberta,CA|North America|NAFTA|GLO|RoW
-Canada without Alberta and Quebec,Canada without Alberta and Quebec,Canada without Alberta|CA|North America|NAFTA|GLO|RoW
+Canada without Alberta and Quebec,Canada without Alberta and Quebec,Canada without Alberta|Canada without Quebec|CA|North America|NAFTA|GLO|RoW
 Canary Islands,Canary Islands,ES|Europe|GLO|RoW
 Central Asia,Central Asia,Asia|GLO|RoW
 China w/o Inner Mongol,China without Inner Mongol,CN|Asia|UN-EASIA|GLO|RoW
@@ -412,11 +412,11 @@ PW,Palau,UN-MICRONESIA|Oceania|GLO|RoW
 PY,Paraguay,UN-SAMERICA|South America|Latin America|GLO|RoW
 QA,Qatar,UN-WASIA|Asia|GLO|RoW
 RE,Réunion,UN-EAFRICA|Africa|GLO|RoW
-RER w/o AT+BE+CH+DE+FR+IT,"Europe without Austria, Belgium, France, Germany, Italy, Liechtenstein, Monaco, San Marino, Switzerland, and the Vatican",Europe|RER|GLO|RoW
+RER w/o AT+BE+CH+DE+FR+IT,"Europe without Austria, Belgium, France, Germany, Italy, Liechtenstein, Monaco, San Marino, Switzerland, and the Vatican",RER w/o CH+DE|Europe|RER|GLO|RoW
 RER w/o CH+DE,Europe without Germany and Switzerland,Europe|RER|GLO|RoW
 RER w/o DE+NL+NO,"Europe without Germany, the Netherlands, and Norway",Europe|RER|GLO|RoW
-RER w/o DE+NL+NO+RU,"Europe without Germany, the Netherlands, Norway, and Russia",RER w/o DE+NL+NO|Europe|RER|GLO|RoW
-RER w/o DE+NL+RU,"Europe without Germany, the Netherlands, and Russia",Europe|RER|GLO|RoW
+RER w/o DE+NL+NO+RU,"Europe without Germany, the Netherlands, Norway, and Russia",RER w/o DE+NL+NO|RER w/o DE+NL+RU|RER w/o RU|Europe|RER|GLO|RoW
+RER w/o DE+NL+RU,"Europe without Germany, the Netherlands, and Russia",RER w/o RU|Europe|RER|GLO|RoW
 RER w/o RU,Europe without Russia,Europe|RER|GLO|RoW
 RFC,ReliabilityFirst Corporation,US|North America|NAFTA|GLO|RoW
 "RFC, US only",ReliabilityFirst Corporation,US|North America|NAFTA|GLO|RoW
@@ -467,7 +467,7 @@ TZ,Tanzania,UN-EAFRICA|Africa|GLO|RoW
 UA,Ukraine,"UN-EEUROPE|Europe, Eastern|Europe|GLO|RoW"
 UCTE without France,UCTE without France,Europe|RER|UCTE|GLO|RoW
 UCTE without Germany,UCTE without Germany,Europe|RER|UCTE|GLO|RoW
-UCTE without Germany and France,UCTE without Germany and France,UCTE without Germany|Europe|RER|UCTE|GLO|RoW
+UCTE without Germany and France,UCTE without Germany and France,UCTE without Germany|UCTE without France|Europe|RER|UCTE|GLO|RoW
 UG,Uganda,UN-EAFRICA|Africa|GLO|RoW
 UN-AMERICAS,Americas,North America|Latin America|GLO|RoW
 UN-ASIA,"Asia, UN Region",Asia|GLO|RoW

--- a/data/geographies.csv
+++ b/data/geographies.csv
@@ -42,9 +42,9 @@ EE,Estonia,Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO
 LU,Luxembourg,"Europe without Switzerland|Europe without Austria|Europe|EU|RER|ENTSO-E|WEU|Europe, Western|GLO|RoW"
 MT,Malta,Europe without Switzerland|Europe without Austria|Europe|EU|RER|UN-SEUROPE|GLO|RoW
 CY,Cyprus,Europe without Switzerland|Europe without Austria|Europe|EU|RER|UN-WASIA|Asia|GLO|RoW
-EU,European Union,Europe without Switzerland|Europe without Austria|Europe|RER|GLO|RoW
-EU-27,European Union (27),Europe without Switzerland|Europe without Austria|Europe|EU|RER|GLO|RoW
-EU-28,European Union (28),Europe without Switzerland|Europe without Austria|Europe|EU|RER|GLO|RoW
+EU,European Union,Europe without Switzerland|Europe|RER|GLO|RoW
+EU-27,European Union (27),Europe without Switzerland|Europe|EU|RER|GLO|RoW
+EU-28,European Union (28),Europe without Switzerland|Europe|EU|RER|GLO|RoW
 RER,Rest of Europe,Europe|GLO|RoW
 ENTSO-E,Europe (ENTSO-E grid),Europe|RER|GLO|RoW
 NORDEL,Nordic countries,Europe|ENTSO-E|RER|GLO|RoW
@@ -246,7 +246,7 @@ CU,Cuba,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 CV,Cape Verde,UN-WAFRICA|Africa|GLO|RoW
 CW,Curaçao,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 Canada without Alberta,Canada without Alberta,CA|North America|NAFTA|GLO|RoW
-Canada without Alberta and Quebec,Canada without Alberta and Quebec,CA|North America|NAFTA|GLO|RoW
+Canada without Alberta and Quebec,Canada without Alberta and Quebec,Canada without Alberta|CA|North America|NAFTA|GLO|RoW
 Canary Islands,Canary Islands,ES|Europe|GLO|RoW
 Central Asia,Central Asia,Asia|GLO|RoW
 China w/o Inner Mongol,China without Inner Mongol,CN|Asia|UN-EASIA|GLO|RoW
@@ -263,8 +263,8 @@ EH,Western Sahara,UN-NAFRICA|Africa|GLO|RoW
 ER,Eritrea,UN-EAFRICA|Africa|GLO|RoW
 ET,Ethiopia,UN-EAFRICA|Africa|GLO|RoW
 Europe without NORDEL (NCPA),Europe without NORDEL (NCPA),Europe|RER|GLO|RoW
-Europe without Switzerland and Austria,Europe without Switzerland and Austria,Europe|RER|GLO|RoW
-Europe without Switzerland and France,Europe without Switzerland and France,Europe|RER|GLO|RoW
+Europe without Switzerland and Austria,Europe without Switzerland and Austria,Europe without Switzerland|Europe without Austria|Europe|RER|GLO|RoW
+Europe without Switzerland and France,Europe without Switzerland and France,Europe without Switzerland|Europe|RER|GLO|RoW
 "Europe, Eastern",Eastern Europe,Europe|RER|GLO|RoW
 "Europe, Western",Western Europe,Europe|RER|GLO|RoW
 "Europe, without Russia and Türkiye","Europe, without Russia and Türkiye",Europe|RER|GLO|RoW
@@ -301,7 +301,7 @@ HT,Haiti,UN-CARIBBEAN|North America|Latin America|GLO|RoW
 "IAI Area, EU27 & EFTA","IAI Area, EU27 & EFTA",Europe|RER|GLO|RoW
 "IAI Area, Gulf Cooperation Council","IAI Area, Gulf Cooperation Council",Asia|GLO|RoW
 "IAI Area, North America","IAI Area, North America",North America|GLO|RoW
-"IAI Area, North America, without Quebec","IAI Area, North America, without Quebec",North America|GLO|RoW
+"IAI Area, North America, without Quebec","IAI Area, North America, without Quebec","IAI Area, North America|North America|GLO|RoW"
 "IAI Area, Russia & RER w/o EU27 & EFTA","IAI Area, Russia & Europe outside EU27 & EFTA",Europe|GLO|RoW
 "IAI Area, South America","IAI Area, South America",South America|Latin America|GLO|RoW
 IM,Isle of Man,UN-NEUROPE|Europe|GLO|RoW
@@ -415,7 +415,7 @@ RE,Réunion,UN-EAFRICA|Africa|GLO|RoW
 RER w/o AT+BE+CH+DE+FR+IT,"Europe without Austria, Belgium, France, Germany, Italy, Liechtenstein, Monaco, San Marino, Switzerland, and the Vatican",Europe|RER|GLO|RoW
 RER w/o CH+DE,Europe without Germany and Switzerland,Europe|RER|GLO|RoW
 RER w/o DE+NL+NO,"Europe without Germany, the Netherlands, and Norway",Europe|RER|GLO|RoW
-RER w/o DE+NL+NO+RU,"Europe without Germany, the Netherlands, Norway, and Russia",Europe|RER|GLO|RoW
+RER w/o DE+NL+NO+RU,"Europe without Germany, the Netherlands, Norway, and Russia",RER w/o DE+NL+NO|Europe|RER|GLO|RoW
 RER w/o DE+NL+RU,"Europe without Germany, the Netherlands, and Russia",Europe|RER|GLO|RoW
 RER w/o RU,Europe without Russia,Europe|RER|GLO|RoW
 RFC,ReliabilityFirst Corporation,US|North America|NAFTA|GLO|RoW
@@ -467,7 +467,7 @@ TZ,Tanzania,UN-EAFRICA|Africa|GLO|RoW
 UA,Ukraine,"UN-EEUROPE|Europe, Eastern|Europe|GLO|RoW"
 UCTE without France,UCTE without France,Europe|RER|UCTE|GLO|RoW
 UCTE without Germany,UCTE without Germany,Europe|RER|UCTE|GLO|RoW
-UCTE without Germany and France,UCTE without Germany and France,Europe|RER|UCTE|GLO|RoW
+UCTE without Germany and France,UCTE without Germany and France,UCTE without Germany|Europe|RER|UCTE|GLO|RoW
 UG,Uganda,UN-EAFRICA|Africa|GLO|RoW
 UN-AMERICAS,Americas,North America|Latin America|GLO|RoW
 UN-ASIA,"Asia, UN Region",Asia|GLO|RoW

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -1075,9 +1075,11 @@ the server-reported total across all pages.
 Args:
     name: Substring (or exact match) on activity name.
     geo: Geography code (``"FR"``, ``"GLO"``, ``"RoW"``…). Answers for
-        that location or one written under it (``"US"`` for
-        ``"US-WECC"``), never for a code sitting inside an unrelated
-        one; ``exact=True`` narrows it to the location itself.
+        that location, or for one the engine's location table places
+        inside it (``"US"`` for ``"US-WECC"``, ``"RER"`` for ``"FR"``).
+        Containment comes from that table and never from how a code is
+        spelled, so ``"GL"`` does not answer for ``"GLO"``;
+        ``exact=True`` narrows it to the location itself.
     product: Substring on the reference product name.
     preset: Apply a named classification preset configured in the engine.
     classification: System name (``"ISIC rev.4 ecoinvent"``).

--- a/pyvolca/README.md
+++ b/pyvolca/README.md
@@ -1074,11 +1074,11 @@ the server-reported total across all pages.
 
 Args:
     name: Substring (or exact match) on activity name.
-    geo: Geography code (``"FR"``, ``"GLO"``, ``"RoW"``…). Answers for
-        that location, or for one the engine's location table places
-        inside it (``"US"`` for ``"US-WECC"``, ``"RER"`` for ``"FR"``).
-        Containment comes from that table and never from how a code is
-        spelled, so ``"GL"`` does not answer for ``"GLO"``;
+    geo: Geography code (``"FR"``, ``"GLO"``, ``"RoW"``…). Matches that
+        location, plus every location inside it (``"US"`` also matches
+        ``"US-WECC"``, ``"RER"`` matches ``"FR"``). Which place sits
+        inside which comes from the engine's location table, never from
+        how a code is spelled, so ``"GL"`` does not match ``"GLO"``;
         ``exact=True`` narrows it to the location itself.
     product: Substring on the reference product name.
     preset: Apply a named classification preset configured in the engine.

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -1434,9 +1434,11 @@ class Client:
         Args:
             name: Substring (or exact match) on activity name.
             geo: Geography code (``"FR"``, ``"GLO"``, ``"RoW"``…). Answers for
-                that location or one written under it (``"US"`` for
-                ``"US-WECC"``), never for a code sitting inside an unrelated
-                one; ``exact=True`` narrows it to the location itself.
+                that location, or for one the engine's location table places
+                inside it (``"US"`` for ``"US-WECC"``, ``"RER"`` for ``"FR"``).
+                Containment comes from that table and never from how a code is
+                spelled, so ``"GL"`` does not answer for ``"GLO"``;
+                ``exact=True`` narrows it to the location itself.
             product: Substring on the reference product name.
             preset: Apply a named classification preset configured in the engine.
             classification: System name (``"ISIC rev.4 ecoinvent"``).

--- a/pyvolca/src/volca/client.py
+++ b/pyvolca/src/volca/client.py
@@ -1433,11 +1433,11 @@ class Client:
 
         Args:
             name: Substring (or exact match) on activity name.
-            geo: Geography code (``"FR"``, ``"GLO"``, ``"RoW"``…). Answers for
-                that location, or for one the engine's location table places
-                inside it (``"US"`` for ``"US-WECC"``, ``"RER"`` for ``"FR"``).
-                Containment comes from that table and never from how a code is
-                spelled, so ``"GL"`` does not answer for ``"GLO"``;
+            geo: Geography code (``"FR"``, ``"GLO"``, ``"RoW"``…). Matches that
+                location, plus every location inside it (``"US"`` also matches
+                ``"US-WECC"``, ``"RER"`` matches ``"FR"``). Which place sits
+                inside which comes from the engine's location table, never from
+                how a code is spelled, so ``"GL"`` does not match ``"GLO"``;
                 ``exact=True`` narrows it to the location itself.
             product: Substring on the reference product name.
             preset: Apply a named classification preset configured in the engine.

--- a/src/API/MCP.hs
+++ b/src/API/MCP.hs
@@ -34,7 +34,7 @@ import Control.Applicative ((<|>))
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Except (ExceptT (..), except, runExceptT, throwE)
 import Data.Bifunctor (first)
-import Database (filterByName, flowSearchFields)
+import Database (Geographies, filterByName, flowSearchFields)
 import Database.Edit (deriveDatabase, editExchanges, refusalMessage)
 import Database.Manager (DatabaseManager (..), LoadedDatabase (..), getDatabase)
 import qualified Database.Manager as DM
@@ -482,9 +482,9 @@ callTool dbManager presets mHosting mBaseUrl rid name args = case name of
     "unload_database" -> callUnloadDatabase dbManager rid args
     "derive_database" -> callDeriveDatabase dbManager mHosting rid args
     "list_presets" -> callListPresets presets rid
-    "search_activities" -> withDb dbManager rid args $ callSearchActivities presets rid args
+    "search_activities" -> withDb dbManager rid args $ callSearchActivities (DM.managerGeographies dbManager) presets rid args
     "search_flows" -> withDb dbManager rid args $ callSearchFlows rid args
-    "count_search_matches" -> withDb dbManager rid args $ callCountSearchMatches rid args
+    "count_search_matches" -> withDb dbManager rid args $ callCountSearchMatches (DM.managerGeographies dbManager) rid args
     "get_activity" -> withDb dbManager rid args $ callGetActivity rid args
     "get_supply_chain" -> callGetSupplyChain dbManager presets rid args
     "aggregate" -> withDb dbManager rid args $ callAggregate dbManager presets rid args
@@ -500,7 +500,7 @@ callTool dbManager presets mHosting mBaseUrl rid name args = case name of
     "list_geographies" -> callListGeographies dbManager rid args
     "list_classifications" -> withDb dbManager rid args $ callListClassifications rid args
     "get_path_to" -> withDb dbManager rid args $ callGetPathTo rid args
-    "get_consumers" -> withDb dbManager rid args $ callGetConsumers presets rid args
+    "get_consumers" -> withDb dbManager rid args $ callGetConsumers (DM.managerGeographies dbManager) presets rid args
     "compare_impacts" -> callCompareImpacts dbManager rid args
     "score_activity" -> callScoreActivity dbManager mBaseUrl rid args
     "score_activities" -> callScoreActivities dbManager mBaseUrl rid args
@@ -757,8 +757,8 @@ filter. Shared by the search and consumers handlers.
 classificationFilters :: [ClassificationPreset] -> KeyMap Value -> Either Text [(Text, Text, Bool)]
 classificationFilters presets args = (++ explicitClassFilter args) <$> presetFilters presets args
 
-callSearchActivities :: [ClassificationPreset] -> Value -> KeyMap Value -> (Database, SharedSolver) -> IO Value
-callSearchActivities presets rid args (db, _) = runTool rid $ do
+callSearchActivities :: Geographies -> [ClassificationPreset] -> Value -> KeyMap Value -> (Database, SharedSolver) -> IO Value
+callSearchActivities geographies presets rid args (db, _) = runTool rid $ do
     classifications <- except (classificationFilters presets args)
     let sf =
             Service.SearchFilter
@@ -775,7 +775,7 @@ callSearchActivities presets rid args (db, _) = runTool rid $ do
                         }
                 , Service.sfExactMatch = fromMaybe False (boolArg "exact" args)
                 }
-    val <- liftIO (Service.searchActivities db sf) >>= liftShow
+    val <- liftIO (Service.searchActivities geographies db sf) >>= liftShow
     pure (toolSuccessJson rid val)
 
 callListClassifications :: Value -> KeyMap Value -> (Database, SharedSolver) -> IO Value
@@ -803,12 +803,12 @@ callListClassifications rid args (db, _) =
 A missing query is an error rather than three zeros: zeros would read as "this
 database has nothing", which is a different answer from "you asked nothing".
 -}
-callCountSearchMatches :: Value -> KeyMap Value -> (Database, SharedSolver) -> IO Value
-callCountSearchMatches rid args (db, _) =
+callCountSearchMatches :: Geographies -> Value -> KeyMap Value -> (Database, SharedSolver) -> IO Value
+callCountSearchMatches geographies rid args (db, _) =
     case mfilter (not . null . Normalize.queryWords) (textArg "query" args) of
         Nothing -> return $ toolError rid "query is required: there is nothing to count without one"
         Just query ->
-            let counts = Service.searchCounts db Service.countAsListed query
+            let counts = Service.searchCounts geographies db Service.countAsListed query
              in return $
                     toolSuccessJson rid $
                         object
@@ -953,14 +953,14 @@ callGetSupplyChain dbManager presets rid args = runTool rid $ do
     payload <-
         if null subs
             then -- Plain cross-DB supply chain.
-                toJSON <$> (liftIO (Service.getSupplyChain unitCfg depLookup db dbName solver pid scf) >>= liftShow)
+                toJSON <$> (liftIO (Service.getSupplyChain unitCfg (DM.managerGeographies dbManager) depLookup db dbName solver pid scf) >>= liftShow)
             else do
                 -- Substitution-aware: re-solve the root scaling, then build from it.
                 (processId, _) <- liftService (Service.resolveScorable db pid)
                 (scalingVec, virtualLinks) <-
                     liftIO (Service.computeScalingVectorWithSubstitutionsCrossDB unitCfg depLookup db dbName solver processId subs) >>= liftShow
                 resp <-
-                    liftIO (Service.buildSupplyChainFromScalingVectorCrossDB unitCfg depLookup db dbName processId scalingVec virtualLinks scf) >>= liftShow
+                    liftIO (Service.buildSupplyChainFromScalingVectorCrossDB unitCfg (DM.managerGeographies dbManager) depLookup db dbName processId scalingVec virtualLinks scf) >>= liftShow
                 pure (toJSON resp)
     pure $ toolSuccessJson rid payload
 
@@ -1004,7 +1004,7 @@ callAggregate dbManager presets rid args (db, solver) =
                                             }
                                 unitCfg <- DM.getMergedUnitConfig dbManager
                                 (mFlows, mUnits) <- DM.getMergedFlowMetadata dbManager
-                                result <- Agg.aggregate unitCfg mFlows mUnits db dbName solver (DM.mkDepSolverLookup dbManager) pid params
+                                result <- Agg.aggregate unitCfg (DM.managerGeographies dbManager) mFlows mUnits db dbName solver (DM.mkDepSolverLookup dbManager) pid params
                                 case result of
                                     Left err -> return $ toolError rid (T.pack $ show err)
                                     Right agg -> return $ toolSuccessJson rid (toJSON agg)
@@ -1047,8 +1047,8 @@ callGetPathTo rid args (db, solver) = runTool rid $ do
     val <- liftIO (Service.getPathTo db solver pid (Service.NamePattern target)) >>= liftShow
     pure (toolSuccessJson rid val)
 
-callGetConsumers :: [ClassificationPreset] -> Value -> KeyMap Value -> (Database, SharedSolver) -> IO Value
-callGetConsumers presets rid args (db, _) = runTool rid $ do
+callGetConsumers :: Geographies -> [ClassificationPreset] -> Value -> KeyMap Value -> (Database, SharedSolver) -> IO Value
+callGetConsumers geographies presets rid args (db, _) = runTool rid $ do
     pid <- except (requireText "process_id" args)
     classifications <- except (classificationFilters presets args)
     let dbName = fromMaybe "" (textArg "database" args) -- validated by withDb
@@ -1068,7 +1068,7 @@ callGetConsumers presets rid args (db, _) = runTool rid $ do
                 , Service.cnfMaxDepth = intArg "max_depth" args
                 , Service.cnfEdges = if fromMaybe False (boolArg "include_edges" args) then Service.WithEdges else Service.EntriesOnly
                 }
-    results <- liftShow (Service.getConsumers db dbName pid cnf)
+    results <- liftShow (Service.getConsumers geographies db dbName pid cnf)
     pure (toolSuccessJson rid (toJSON results))
 
 {- | MCP get_inventory: route through the cross-DB back-substitution path

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -783,7 +783,7 @@ params r = case r of
     SearchActivities ->
         [ pDatabase
         , Param "name" "string" Required "Name substring to search for (or exact name if exact=true). The identifier a source file gave a dataset (a SimaPro 'Process identifier'), whole or the four or more characters that tell it apart, brings that dataset's products to the top of the results."
-        , Param "geo" "string" Optional "Geography/location filter (e.g. 'FR', 'DE', 'GLO'). Matches the location itself, or one the location table places inside it ('US' answers for 'US-WECC', 'RER' for 'FR'). Containment is read from that table and never from how a code is spelled, so 'GL' does not answer for 'GLO'."
+        , Param "geo" "string" Optional "Geography/location filter (e.g. 'FR', 'DE', 'GLO'). Matches that location, plus every location inside it ('US' also matches 'US-WECC', 'RER' matches 'FR'). Which place sits inside which comes from the engine's location table, never from how a code is spelled, so 'GL' does not match 'GLO'."
         , Param "product" "string" Optional "Product name filter"
         , Param "exact" "boolean" Optional "If true, the name and the geography must match exactly (case-insensitive equality) instead of a substring, respectively prefix, search"
         , Param "preset" "string" Optional "Name of a classification preset (from list_presets): expands to its bundled filters. Can be combined with explicit classification filters."
@@ -827,7 +827,7 @@ params r = case r of
         [ pDatabase
         , pProcessId
         , Param "name" "string" Optional "Filter by activity name"
-        , Param "location" "string" Optional "Filter by geography/location: the location itself, or one the location table places inside it, case-insensitive"
+        , Param "location" "string" Optional "Filter by geography/location: that location, plus every location inside it ('US' also matches 'US-WECC'), case-insensitive"
         , pLimit "Max results (default 100)"
         , Param "min_quantity" "number" Optional "Min scaled quantity threshold"
         , Param "max_depth" "integer" Optional "Max depth from root (1 = direct inputs only)"
@@ -931,7 +931,7 @@ params r = case r of
         [ pDatabase
         , Param "process_id" "string" Required "Process ID of the supplier (activityUUID_productUUID format)"
         , Param "name" "string" Optional "Filter by name (case-insensitive substring)"
-        , Param "location" "string" Optional "Filter by geography/location (e.g. 'FR', 'DE'): the location itself, or one the location table places inside it, case-insensitive"
+        , Param "location" "string" Optional "Filter by geography/location (e.g. 'FR', 'DE'): that location, plus every location inside it ('RER' also matches 'FR'), case-insensitive"
         , Param "product" "string" Optional "Filter by product name (case-insensitive substring)"
         , Param "preset" "string" Optional "Name of a classification preset (from list_presets): expands to its bundled filters"
         , Param "classification" "string" Optional "Classification system name (e.g. 'ISIC rev.4 ecoinvent')"

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -785,7 +785,7 @@ params r = case r of
         , Param "name" "string" Required "Name substring to search for (or exact name if exact=true). The identifier a source file gave a dataset (a SimaPro 'Process identifier'), whole or the four or more characters that tell it apart, brings that dataset's products to the top of the results."
         , Param "geo" "string" Optional "Geography/location filter (e.g. 'FR', 'DE', 'GLO'). Matches that location, plus every location inside it ('US' also matches 'US-WECC', 'RER' matches 'FR'). Which place sits inside which comes from the engine's location table, never from how a code is spelled, so 'GL' does not match 'GLO'."
         , Param "product" "string" Optional "Product name filter"
-        , Param "exact" "boolean" Optional "If true, the name and the geography must match exactly (case-insensitive equality) instead of a substring, respectively prefix, search"
+        , Param "exact" "boolean" Optional "If true, the name must match exactly (case-insensitive equality) rather than as a substring, and the geography must be the location itself rather than that location plus every location inside it"
         , Param "preset" "string" Optional "Name of a classification preset (from list_presets): expands to its bundled filters. Can be combined with explicit classification filters."
         , Param "classification" "string" Optional "Classification system name to filter by (e.g. 'ISIC rev.4 ecoinvent', 'CPC'). Use list_classifications to see available systems."
         , Param "classification_value" "string" Optional "Value within the classification system to match"

--- a/src/API/Resources.hs
+++ b/src/API/Resources.hs
@@ -783,7 +783,7 @@ params r = case r of
     SearchActivities ->
         [ pDatabase
         , Param "name" "string" Required "Name substring to search for (or exact name if exact=true). The identifier a source file gave a dataset (a SimaPro 'Process identifier'), whole or the four or more characters that tell it apart, brings that dataset's products to the top of the results."
-        , Param "geo" "string" Optional "Geography/location filter (e.g. 'FR', 'DE', 'GLO'). Matches the location itself or one written under it ('US' answers for 'US-WECC'), never a code inside an unrelated one."
+        , Param "geo" "string" Optional "Geography/location filter (e.g. 'FR', 'DE', 'GLO'). Matches the location itself, or one the location table places inside it ('US' answers for 'US-WECC', 'RER' for 'FR'). Containment is read from that table and never from how a code is spelled, so 'GL' does not answer for 'GLO'."
         , Param "product" "string" Optional "Product name filter"
         , Param "exact" "boolean" Optional "If true, the name and the geography must match exactly (case-insensitive equality) instead of a substring, respectively prefix, search"
         , Param "preset" "string" Optional "Name of a classification preset (from list_presets): expands to its bundled filters. Can be combined with explicit classification filters."
@@ -827,7 +827,7 @@ params r = case r of
         [ pDatabase
         , pProcessId
         , Param "name" "string" Optional "Filter by activity name"
-        , Param "location" "string" Optional "Filter by geography/location: the location itself or one written under it, case-insensitive"
+        , Param "location" "string" Optional "Filter by geography/location: the location itself, or one the location table places inside it, case-insensitive"
         , pLimit "Max results (default 100)"
         , Param "min_quantity" "number" Optional "Min scaled quantity threshold"
         , Param "max_depth" "integer" Optional "Max depth from root (1 = direct inputs only)"
@@ -931,7 +931,7 @@ params r = case r of
         [ pDatabase
         , Param "process_id" "string" Required "Process ID of the supplier (activityUUID_productUUID format)"
         , Param "name" "string" Optional "Filter by name (case-insensitive substring)"
-        , Param "location" "string" Optional "Filter by geography/location (e.g. 'FR', 'DE'): the location itself or one written under it, case-insensitive"
+        , Param "location" "string" Optional "Filter by geography/location (e.g. 'FR', 'DE'): the location itself, or one the location table places inside it, case-insensitive"
         , Param "product" "string" Optional "Filter by product name (case-insensitive substring)"
         , Param "preset" "string" Optional "Name of a classification preset (from list_presets): expands to its bundled filters"
         , Param "classification" "string" Optional "Classification system name (e.g. 'ISIC rev.4 ecoinvent')"

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -1583,7 +1583,7 @@ activitySupplyChainCore dbName processIdText nameFilter limitParam minQuantity o
     case mSub of
         Nothing -> do
             unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
-            result <- liftIO $ Service.getSupplyChain unitCfg (DM.mkDepSolverLookup dbManager) db dbName sharedSolver processIdText scf
+            result <- liftIO $ Service.getSupplyChain unitCfg (DM.managerGeographies dbManager) (DM.mkDepSolverLookup dbManager) db dbName sharedSolver processIdText scf
             either throwServiceError pure result
         Just subReq -> do
             unitCfg <- liftIO $ DM.getMergedUnitConfig dbManager
@@ -1605,6 +1605,7 @@ activitySupplyChainCore dbName processIdText nameFilter limitParam minQuantity o
                         liftIO $
                             Service.buildSupplyChainFromScalingVectorCrossDB
                                 unitCfg
+                                (DM.managerGeographies dbManager)
                                 (DM.mkDepSolverLookup dbManager)
                                 db
                                 dbName
@@ -1706,7 +1707,7 @@ getActivityAggregate dbName processId scopeParam isInputParam maxDepthParam fnam
                 }
     unitCfg <- liftIO $ getMergedUnitConfig dbManager
     (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
-    result <- liftIO $ Agg.aggregate unitCfg mFlows mUnits db dbName sharedSolver (DM.mkDepSolverLookup dbManager) processId params
+    result <- liftIO $ Agg.aggregate unitCfg (DM.managerGeographies dbManager) mFlows mUnits db dbName sharedSolver (DM.mkDepSolverLookup dbManager) processId params
     either throwServiceError pure result
 
 {- | LCIA single-method core. GET passes a top-flows param and logs;
@@ -1840,6 +1841,7 @@ getActivityConsumers ::
     AppM ConsumersResponse
 getActivityConsumers dbName processIdText nameFilter locationFilter productFilter presetParam classSystems classValues classModes limitParam offsetParam maxDepthParam sortParam orderParam includeEdgesParam = do
     presets <- asks aeClassificationPresets
+    dbManager <- asks aeDbManager
     (db, _) <- requireDatabaseByName dbName
     classifications <- either badRequest pure (mergeClassFilters presets presetParam classSystems classValues classModes)
     let cnf =
@@ -1858,7 +1860,7 @@ getActivityConsumers dbName processIdText nameFilter locationFilter productFilte
                 , Service.cnfMaxDepth = maxDepthParam
                 , Service.cnfEdges = if fromMaybe False includeEdgesParam then Service.WithEdges else Service.EntriesOnly
                 }
-    either throwServiceError pure (Service.getConsumers db dbName processIdText cnf)
+    either throwServiceError pure (Service.getConsumers (DM.managerGeographies dbManager) db dbName processIdText cnf)
 
 getActivityPathTo :: Text -> Text -> Maybe Text -> AppM Value
 getActivityPathTo dbName processIdText targetParam = do
@@ -2222,6 +2224,7 @@ searchFlows dbName queryParam langParam kindParam limitParam offsetParam sortPar
 searchActivitiesWithCount :: Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Bool -> Maybe Text -> [Text] -> [Text] -> [Text] -> Maybe Int -> Maybe Int -> Maybe Text -> Maybe Text -> AppM (SearchResults ActivitySummary)
 searchActivitiesWithCount dbName nameParam geoParam productParam exactParam presetParam classSystems classValues classModes limitParam offsetParam sortParam orderParam = do
     presets <- asks aeClassificationPresets
+    dbManager <- asks aeDbManager
     (db, _) <- requireDatabaseByName dbName
     classifications <- either badRequest pure (mergeClassFilters presets presetParam classSystems classValues classModes)
     let exactMatch = fromMaybe False exactParam
@@ -2240,7 +2243,7 @@ searchActivitiesWithCount dbName nameParam geoParam productParam exactParam pres
                         }
                 , Service.sfExactMatch = exactMatch
                 }
-    result <- liftIO $ Service.searchActivities db sf
+    result <- liftIO $ Service.searchActivities (DM.managerGeographies dbManager) db sf
     case result of
         Left err -> throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ T.pack $ show err}
         Right jsonValue -> case fromJSON jsonValue of
@@ -2443,10 +2446,11 @@ decide which matcher runs and therefore how many rows there are.
 -}
 countSearchMatches :: Text -> Maybe Text -> Maybe Text -> Maybe Bool -> AppM SearchCountsAPI
 countSearchMatches dbName mQuery sortParam exactParam = do
+    dbManager <- asks aeDbManager
     (db, _) <- requireDatabaseByName dbName
     query <- maybe (badRequest "q is required: there is nothing to count without a query") pure (nonBlank mQuery)
     let listedAs = Service.CountAs{Service.caSort = sortParam, Service.caExact = fromMaybe False exactParam}
-        counts = Service.searchCounts db listedAs query
+        counts = Service.searchCounts (DM.managerGeographies dbManager) db listedAs query
     pure
         SearchCountsAPI
             { scaProcesses = Service.scProcesses counts

--- a/src/CLI/Command.hs
+++ b/src/CLI/Command.hs
@@ -19,6 +19,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
+import Database (Geographies)
 import Database.Edit (
     DeleteOutcome (..),
     DeleteRequest (..),
@@ -32,7 +33,7 @@ import Database.Edit (
     writeActivities,
  )
 import Database.Export (exportDatabase, exportMethodCollection, parseExportFormat, parseMethodExportFormat)
-import Database.Manager (DatabaseManager (..), LoadedDatabase (..), RelinkResult (..), addDatabase, addMethodCollection)
+import Database.Manager (DatabaseManager (..), LoadedDatabase (..), RelinkResult (..), addDatabase, addMethodCollection, managerGeographies)
 import qualified Database.Manager as DM
 import Database.RelinkMapping (relinkWithMappingFile)
 import Database.Upload (UploadData (..), UploadResult (..), findMethodDirectory, handleUpload)
@@ -153,28 +154,28 @@ executeCommand (CLIConfig globalOpts _) cmd manager = do
         -- Database-level commands
         Activity _ -> do
             (database, _solver) <- requireDatabase manager (dbName globalOpts)
-            executeDbCommand outputFormat globalOpts database cmd
+            executeDbCommand outputFormat globalOpts (managerGeographies manager) database cmd
         Inventory _ -> do
             (database, _solver) <- requireDatabase manager (dbName globalOpts)
-            executeDbCommand outputFormat globalOpts database cmd
+            executeDbCommand outputFormat globalOpts (managerGeographies manager) database cmd
         Flow _ _ -> do
             (database, _solver) <- requireDatabase manager (dbName globalOpts)
-            executeDbCommand outputFormat globalOpts database cmd
+            executeDbCommand outputFormat globalOpts (managerGeographies manager) database cmd
         SearchActivities _ -> do
             (database, _solver) <- requireDatabase manager (dbName globalOpts)
-            executeDbCommand outputFormat globalOpts database cmd
+            executeDbCommand outputFormat globalOpts (managerGeographies manager) database cmd
         SearchFlows _ -> do
             (database, _solver) <- requireDatabase manager (dbName globalOpts)
-            executeDbCommand outputFormat globalOpts database cmd
+            executeDbCommand outputFormat globalOpts (managerGeographies manager) database cmd
         Impacts _ _ -> do
             (database, _solver) <- requireDatabase manager (dbName globalOpts)
-            executeDbCommand outputFormat globalOpts database cmd
+            executeDbCommand outputFormat globalOpts (managerGeographies manager) database cmd
         DebugMatrices _ _ -> do
             (database, _solver) <- requireDatabase manager (dbName globalOpts)
-            executeDbCommand outputFormat globalOpts database cmd
+            executeDbCommand outputFormat globalOpts (managerGeographies manager) database cmd
         ExportMatrices _ -> do
             (database, _solver) <- requireDatabase manager (dbName globalOpts)
-            executeDbCommand outputFormat globalOpts database cmd
+            executeDbCommand outputFormat globalOpts (managerGeographies manager) database cmd
         QualityReport _ -> do
             reportError "quality-report is served over HTTP; Main.hs routes it to the client"
             exitFailure
@@ -190,8 +191,8 @@ executeCommand (CLIConfig globalOpts _) cmd manager = do
         Dump _ -> reportError "A dump command is answered before a database is loaded."
 
 -- | Execute commands that require a loaded database
-executeDbCommand :: OutputFormat -> GlobalOptions -> Database -> Command -> IO ()
-executeDbCommand fmt _globalOpts database = \case
+executeDbCommand :: OutputFormat -> GlobalOptions -> Geographies -> Database -> Command -> IO ()
+executeDbCommand fmt _globalOpts geographies database = \case
     Activity uuid ->
         executeActivityCommand fmt database uuid
     Inventory uuid ->
@@ -201,7 +202,7 @@ executeDbCommand fmt _globalOpts database = \case
     Flow flowId (Just FlowActivities) ->
         executeFlowActivitiesCommand fmt database flowId
     SearchActivities opts ->
-        executeSearchActivitiesCommand fmt database opts
+        executeSearchActivitiesCommand fmt geographies database opts
     SearchFlows opts ->
         executeSearchFlowsCommand fmt database opts
     Impacts uuid lciaOpts ->
@@ -258,8 +259,8 @@ executeFlowActivitiesCommand fmt database flowId =
         Right result -> outputResult fmt result
 
 -- | Execute search activities command
-executeSearchActivitiesCommand :: OutputFormat -> Database -> SearchActivitiesOptions -> IO ()
-executeSearchActivitiesCommand fmt database opts = do
+executeSearchActivitiesCommand :: OutputFormat -> Geographies -> Database -> SearchActivitiesOptions -> IO ()
+executeSearchActivitiesCommand fmt geographies database opts = do
     let sf =
             Service.SearchFilter
                 { Service.sfCore =
@@ -275,7 +276,7 @@ executeSearchActivitiesCommand fmt database opts = do
                         }
                 , Service.sfExactMatch = False
                 }
-    searchResult <- Service.searchActivities database sf
+    searchResult <- Service.searchActivities geographies database sf
     case searchResult of
         Left err -> reportServiceError err
         Right result -> outputResult fmt result

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -301,7 +301,7 @@ flowSubCommandParser =
 searchActivitiesParser :: Parser Command
 searchActivitiesParser = do
     searchName <- optTextOpt "name" Nothing "TERM" "Search by activity name"
-    searchGeo <- optTextOpt "geo" Nothing "LOCATION" "Filter by geography (exact match)"
+    searchGeo <- optTextOpt "geo" Nothing "LOCATION" "Filter by geography: the location itself, or one the location table places inside it"
     searchProduct <- optTextOpt "product" Nothing "PRODUCT" "Filter by reference product"
     searchLimit <- optIntOpt "limit" Nothing "N" "Limit number of results (max 1000, default 50)"
     searchOffset <- optIntOpt "offset" Nothing "N" "Offset for pagination (default 0)"

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -301,7 +301,7 @@ flowSubCommandParser =
 searchActivitiesParser :: Parser Command
 searchActivitiesParser = do
     searchName <- optTextOpt "name" Nothing "TERM" "Search by activity name"
-    searchGeo <- optTextOpt "geo" Nothing "LOCATION" "Filter by geography: the location itself, or one the location table places inside it"
+    searchGeo <- optTextOpt "geo" Nothing "LOCATION" "Filter by geography: that location, plus every location inside it ('RER' also finds 'FR')"
     searchProduct <- optTextOpt "product" Nothing "PRODUCT" "Filter by reference product"
     searchLimit <- optIntOpt "limit" Nothing "N" "Limit number of results (max 1000, default 50)"
     searchOffset <- optIntOpt "offset" Nothing "N" "Offset for pagination (default 0)"

--- a/src/Database.hs
+++ b/src/Database.hs
@@ -12,7 +12,9 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU
+import Database.CrossLinking (placelessLocations)
 import Database.MatrixBuild
+import Method.Types (Location (..))
 import Progress
 import qualified Search.BM25.Types as BM25T
 import qualified Search.Fuzzy as Fuzzy
@@ -291,21 +293,65 @@ bm25DocsMatchingName idx name =
     intersectAll [] = IS.empty
     intersectAll (x : xs) = foldl IS.intersection x xs
 
+{- | The location table as a filter reads it: every name folded once, and every
+place carrying the wider places it was declared inside.
+
+Folded once, because the alternative is folding the whole table again for every
+activity a query walks. Held in its own type, because a table folded on one side
+and not the other answers differently depending on which side was asked, and
+there is no way to see that in a 'M.Map'.
+-}
+newtype Geographies = Geographies (M.Map Text (S.Set Text))
+    deriving (Eq, Show)
+
+{- | Read the declared location table, the one shipped as @data/geographies.csv@
+and carried by the database manager.
+
+An entry lists the wider places its data may fall back to, and it lists them all
+the way up rather than one step at a time, so a filter is answered by a lookup
+and never by a walk. Where a row stops short - @Canary Islands@ names @ES@ and
+not @RER@ - the filter stops there too, which is the same reading
+'Database.CrossLinking.isSubregionOf' has always taken of the same table.
+-}
+readGeographies :: M.Map Location [Location] -> Geographies
+readGeographies = Geographies . M.fromListWith S.union . map entry . M.toList
+  where
+    entry :: (Location, [Location]) -> (Text, S.Set Text)
+    entry (Location place, wider) = (asked place, S.fromList [asked w | Location w <- wider])
+
+{- | Places that are a fallback rather than a container, as a filter reads them.
+The table lists them among the parents of every country, so that a
+characterization factor found only for the world can still answer for a country.
+A filter asking for one of them is asking for the places written that way, not
+for every place on earth.
+
+The same three codes as 'placelessLocations', which is where they are decided;
+folded here because that is how a filter compares them.
+-}
+placeless :: S.Set Text
+placeless = S.fromList [asked l | Location l <- placelessLocations]
+
 {- | Does a location answer a geography filter?
 
 A location is a code from a controlled vocabulary rather than free text, and those
-codes overlap as text: @SE@ sits inside @US-SERC@, @DE@ inside @NORDEL@, and @CH@
-inside @RER w/o CH+DE@, a region defined by excluding Switzerland. Matching anywhere
-in the string answers all three with places nobody asked for, and the answer carries
-nothing that says so.
+codes overlap as text: @GL@ (Greenland) opens @GLO@, @RO@ (Romania) opens @RoW@,
+@NO@ (Norway) opens both @NORDEL@ and @Northern Cyprus@. Reading a place out of the
+letters another one starts with answers all of those with somewhere nobody asked
+for, and says nothing about having done so.
 
-So a location answers when it is the geography asked for, or one written under it:
-@US@ answers for @US-WECC@ and @Europe@ for @Europe without Switzerland@, which is
-what keeps a filter typed one letter at a time useful, and leaves no way for a code
-to match inside an unrelated one.
+So containment is read from the declared table and from nowhere else: a location
+answers when it is the geography asked for, or when the table puts it inside that
+geography. @US@ answers for @US-WECC@ and @RER@ for @FR@ because those rows say so,
+and a place the table does not know answers for itself alone.
 -}
-locationAnswers :: Text -> Text -> Bool
-locationAnswers wanted location = asked wanted `T.isPrefixOf` asked location
+locationAnswers :: Geographies -> Text -> Text -> Bool
+locationAnswers (Geographies table) wanted location
+    | locationIs wanted location = True
+    | S.member here placeless = False
+    | otherwise = S.member here (M.findWithDefault S.empty (asked location) table)
+  where
+    here :: Text
+    here = asked wanted
 
 -- | The same question asked of one location only: 'locationAnswers' under @exact@.
 locationIs :: Text -> Text -> Bool
@@ -323,6 +369,8 @@ Does NOT touch the name query: callers (BM25 retrieval or name-candidate lookup)
 produce the initial list.
 -}
 applyStructuredFilters ::
+    -- | the declared location table, which is what a geography filter reads
+    Geographies ->
     Database ->
     -- | geo
     Maybe Text ->
@@ -334,7 +382,7 @@ applyStructuredFilters ::
     Bool ->
     [(ProcessId, Activity)] ->
     [(ProcessId, Activity)]
-applyStructuredFilters db geoParam productParam classFilters exactMatch candidates =
+applyStructuredFilters geographies db geoParam productParam classFilters exactMatch candidates =
     let actVec = dbActivities db
         pidx = dbProductSearchIndex db
 
@@ -343,7 +391,7 @@ applyStructuredFilters db geoParam productParam classFilters exactMatch candidat
             Nothing -> candidates
             Just geo
                 | exactMatch -> [(pid, a) | (pid, a) <- candidates, locationIs geo (activityLocation a)]
-                | otherwise -> [(pid, a) | (pid, a) <- candidates, locationAnswers geo (activityLocation a)]
+                | otherwise -> [(pid, a) | (pid, a) <- candidates, locationAnswers geographies geo (activityLocation a)]
 
         -- exchangeIsReference covers both ReferenceProduct (output) and
         -- ReferenceInput (treatment-process input). Both are the activity's
@@ -401,9 +449,10 @@ applyStructuredFilters db geoParam productParam classFilters exactMatch candidat
 Non-BM25 path: name filter is substring AND-of-tokens on activity name only.
 Returns (ProcessId, Activity) pairs so callers don't need to re-scan for ProcessId.
 -}
-findActivitiesByFields :: Database -> Maybe Text -> Maybe Text -> Maybe Text -> [(Text, Text, Bool)] -> Bool -> [(ProcessId, Activity)]
-findActivitiesByFields db nameParam geoParam productParam classFilters exactMatch =
+findActivitiesByFields :: Geographies -> Database -> Maybe Text -> Maybe Text -> Maybe Text -> [(Text, Text, Bool)] -> Bool -> [(ProcessId, Activity)]
+findActivitiesByFields geographies db nameParam geoParam productParam classFilters exactMatch =
     applyStructuredFilters
+        geographies
         db
         geoParam
         productParam

--- a/src/Database/CrossLinking.hs
+++ b/src/Database/CrossLinking.hs
@@ -69,6 +69,7 @@ module Database.CrossLinking (
     -- * Location Hierarchy
     isSubregionOf,
     locationHierarchy,
+    placelessLocations,
 
     -- * Compound Name Parsing
     extractBracketedLocation,

--- a/src/Database/Edit.hs
+++ b/src/Database/Edit.hs
@@ -63,6 +63,7 @@ import System.Directory (copyFile, createDirectoryIfMissing, doesFileExist, make
 import System.FilePath ((</>))
 
 import Config (DatabaseConfig (..))
+import Database (Geographies)
 import Database.Author (
     AuthorContext (..),
     AuthoredActivity,
@@ -92,6 +93,7 @@ import Database.Manager (
     getMergedSynonymDB,
     getMergedUnitConfig,
     loadDatabase,
+    managerGeographies,
     publishLoaded,
     relinkDatabase,
     removeDatabase,
@@ -871,6 +873,7 @@ was not, the button would delete rows the table never showed.
 Order is irrelevant: the result is consumed as a set.
 -}
 filteredProcessIds ::
+    Geographies ->
     Database ->
     Maybe Text -> -- name
     Maybe Text -> -- location
@@ -878,8 +881,8 @@ filteredProcessIds ::
     [(Text, Text, Bool)] -> -- classification (system, value, isExact)
     Bool -> -- exact name match
     [ProcessId]
-filteredProcessIds db nameP geoP prodP classFilters exactMatch =
-    map fst (activityMatches db (SearchFilter core exactMatch))
+filteredProcessIds geographies db nameP geoP prodP classFilters exactMatch =
+    map fst (activityMatches geographies db (SearchFilter core exactMatch))
   where
     core :: ActivityFilterCore
     core =
@@ -949,6 +952,7 @@ deleteActivitiesInDB manager dbName DeleteRequest{drName = nameP, drLocation = g
         Nothing -> pure $ Left $ "Database not loaded: " <> dbName
         Just loaded -> do
             let db = ldDatabase loaded
+                geographies = managerGeographies manager
                 -- The two selection modes are exclusive: ids name the set
                 -- verbatim, filters compute it. A request carrying both is
                 -- ambiguous, so it is refused rather than guessed at: exact
@@ -959,7 +963,7 @@ deleteActivitiesInDB manager dbName DeleteRequest{drName = nameP, drLocation = g
                     Just ids
                         | hasFilter -> Left "ids cannot be combined with name/location/product/classification/exact filters"
                         | otherwise -> traverse (resolveProcess db) ids
-                    Nothing -> Right (filteredProcessIds db nameP geoP prodP classFilters exactMatch)
+                    Nothing -> Right (filteredProcessIds geographies db nameP geoP prodP classFilters exactMatch)
             case (,,) <$> traverse (resolveProcess db) keep <*> traverse (resolveProcess db) extra <*> selectionE of
                 Left err -> pure $ Left err
                 Right (keepPids, extraPids, filtered) -> do

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -61,6 +61,7 @@ module Database.Manager (
     removeMethodCollection,
 
     -- * Geography
+    parseGeographies,
     parseGeographiesCSV,
 
     -- * Reference Data Operations
@@ -88,6 +89,7 @@ module Database.Manager (
     getMergedUnitConfig,
     getMergedFlowMetadata,
     hierarchyFromGeographies,
+    managerGeographies,
 
     -- * Staged Database Operations
     getStagedDatabase,
@@ -164,7 +166,7 @@ import Config
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import Data.Time (diffUTCTime, getCurrentTime)
-import Database (buildDatabaseWithMatrices)
+import Database (Geographies, buildDatabaseWithMatrices, readGeographies)
 import qualified Database.Loader as Loader
 import qualified Database.Quality as Quality
 import Matrix (clearCachedSolver)
@@ -4177,6 +4179,13 @@ under test is the shape the matcher gets.
 -}
 hierarchyFromGeographies :: M.Map Text (Text, [Text]) -> M.Map Location [Location]
 hierarchyFromGeographies = M.map (map Location . snd) . M.mapKeysMonotonic Location
+
+{- | The same table in the shape a geography filter reads it. Read here rather
+than at each of the dozen call sites, so a filter and the count beside it cannot
+end up reading the same table two different ways.
+-}
+managerGeographies :: DatabaseManager -> Geographies
+managerGeographies = readGeographies . dmLocationHierarchy
 
 {- | Merged biosphere flow metadata + units across all loaded DBs. Technosphere
 flows are not merged here because characterization (the only consumer of

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -29,7 +29,7 @@ import Data.Time (diffUTCTime, getCurrentTime)
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
-import Database (IdentifierReach (..), activitiesIdentifiedBy, applyStructuredFilters, findActivitiesByFields, findFlowsBySynonym, flowNameRelevance, locationAnswers)
+import Database (Geographies, IdentifierReach (..), activitiesIdentifiedBy, applyStructuredFilters, findActivitiesByFields, findFlowsBySynonym, flowNameRelevance, locationAnswers)
 import Database.Allocation (asAllocated, describeRefusal, propertyShares)
 import Database.MatrixBuild (findProducer, linkedProducer)
 import Matrix (Demand (..), DepDemands, Inventory, SupplierDemands, accumulateDepDemandsWith, activityNormalizationFactor, applyBiosphereMatrix, buildDemandVectorFromIndex, computeInventoryMatrix, depDemandsToVector, perturbA, perturbABatch, perturbGlobal, toList)
@@ -917,10 +917,10 @@ paginateSearchResults offsetParam limitParam searchTimeMs project xs =
 {- | Search activities (returns same format as API). The exact-match toggle is
 carried on 'SearchFilter' itself, so there is no separate positional flag.
 -}
-searchActivities :: Database -> SearchFilter -> IO (Either ServiceError Value)
-searchActivities db sFilter@(SearchFilter core _) = do
+searchActivities :: Geographies -> Database -> SearchFilter -> IO (Either ServiceError Value)
+searchActivities geographies db sFilter@(SearchFilter core _) = do
     startTime <- getCurrentTime
-    let allResults = activityMatches db sFilter
+    let allResults = activityMatches geographies db sFilter
     endTime <- getCurrentTime
     let searchTimeMs = realToFrac (diffUTCTime endTime startTime) * 1000 :: Double
         results = paginateSearchResults (afcOffset core) (afcLimit core) searchTimeMs (uncurry (mkActivitySummary db)) allResults
@@ -933,8 +933,8 @@ Split out of 'searchActivities' so a caller that only wants how many there
 are counts the same rows the list would show. Two matchers would drift, and a
 tab counter disagreeing with the tab it labels is worse than no counter.
 -}
-activityMatches :: Database -> SearchFilter -> [(ProcessId, Activity)]
-activityMatches db sFilter@(SearchFilter core exactMatch) =
+activityMatches :: Geographies -> Database -> SearchFilter -> [(ProcessId, Activity)]
+activityMatches geographies db sFilter@(SearchFilter core exactMatch) =
     identified ++ filter (not . alreadyIdentified) searched
   where
     -- The blocks the query names by identifier, ahead of the search rather than
@@ -960,10 +960,10 @@ activityMatches db sFilter@(SearchFilter core exactMatch) =
         Just ranked -> structured False ranked
         -- Non-BM25 path: AND-of-tokens name filter + lex sort.
         Nothing ->
-            L.sortBy ordered (findActivitiesByFields db (afcName core) (afcLocation core) (afcProduct core) (afcClassifications core) exactMatch)
+            L.sortBy ordered (findActivitiesByFields geographies db (afcName core) (afcLocation core) (afcProduct core) (afcClassifications core) exactMatch)
 
     structured :: Bool -> [(ProcessId, Activity)] -> [(ProcessId, Activity)]
-    structured = applyStructuredFilters db (afcLocation core) (afcProduct core) (afcClassifications core)
+    structured = applyStructuredFilters geographies db (afcLocation core) (afcProduct core) (afcClassifications core)
 
     ordered :: (ProcessId, Activity) -> (ProcessId, Activity) -> Ordering
     ordered
@@ -1002,10 +1002,10 @@ countAsListed :: CountAs
 countAsListed = CountAs{caSort = Nothing, caExact = False}
 
 -- | The counts one query finds. The query is required: an empty box has nothing to count.
-searchCounts :: Database -> CountAs -> Text -> SearchCounts
-searchCounts db listedAs query =
+searchCounts :: Geographies -> Database -> CountAs -> Text -> SearchCounts
+searchCounts geographies db listedAs query =
     SearchCounts
-        { scProcesses = length (activityMatches db (nameOnly query))
+        { scProcesses = length (activityMatches geographies db (nameOnly query))
         , scProducts = count KindTechnosphere
         , scFlows = length matchedFlows - count KindTechnosphere
         }
@@ -1657,6 +1657,7 @@ Returns all upstream activities with their scaling factors and subgraph edges.
 -}
 getSupplyChain ::
     UnitConfig ->
+    Geographies ->
     SharedSolver.DepSolverLookup ->
     Database ->
     Text ->
@@ -1664,7 +1665,7 @@ getSupplyChain ::
     Text ->
     SupplyChainFilter ->
     IO (Either ServiceError SupplyChainResponse)
-getSupplyChain unitCfg depLookup db dbName sharedSolver processIdText af =
+getSupplyChain unitCfg geographies depLookup db dbName sharedSolver processIdText af =
     case resolveScorable db processIdText of
         Left err -> return $ Left err
         Right (processId, _rootActivity) ->
@@ -1676,6 +1677,7 @@ getSupplyChain unitCfg depLookup db dbName sharedSolver processIdText af =
                     supplyVec <- solveWithSharedSolver sharedSolver demandVec
                     buildSupplyChainFromScalingVectorCrossDB
                         unitCfg
+                        geographies
                         depLookup
                         db
                         dbName
@@ -1800,6 +1802,8 @@ Entry @sceProcessId@ is qualified with @dbName::@ at a dep level only; root
 entries stay bare for callers that navigate on bare root PIDs.
 -}
 collectSupplyChainEntries ::
+    -- | the declared location table, which is what a geography filter reads
+    Geographies ->
     Database ->
     -- | DB name
     Text ->
@@ -1808,7 +1812,7 @@ collectSupplyChainEntries ::
     U.Vector Double ->
     SupplyChainFilter ->
     Collected
-collectSupplyChainEntries db dbName level supplyVec scf =
+collectSupplyChainEntries geographies db dbName level supplyVec scf =
     let core = scfCore scf
         minQ = fromMaybe 0 (scfMinQuantity scf)
 
@@ -1875,7 +1879,7 @@ collectSupplyChainEntries db dbName level supplyVec scf =
 
         matchesFilters activity pid =
             let nameOk = nameMatchesPid pid
-                locOk = maybe True (\pat -> locationAnswers pat (activityLocation activity)) (afcLocation core)
+                locOk = maybe True (\pat -> locationAnswers geographies pat (activityLocation activity)) (afcLocation core)
                 productOk = maybe True (\pat -> any (textMatches pat) (getProductNames activity)) (afcProduct core)
                 classOk = matchClassifications activity (afcClassifications core)
                 localDepth = IM.findWithDefault maxBound (fromIntegral pid) depthMap
@@ -1953,17 +1957,19 @@ sortAndPaginate core entries =
 Used by both GET (normal) and POST (with substitutions) supply-chain endpoints.
 -}
 buildSupplyChainFromScalingVector ::
+    Geographies ->
     Database ->
     Text ->
     ProcessId ->
     U.Vector Double ->
     SupplyChainFilter ->
     SupplyChainResponse
-buildSupplyChainFromScalingVector db dbName processId supplyVec scf =
+buildSupplyChainFromScalingVector geographies db dbName processId supplyVec scf =
     let rootActivity = dbActivities db V.! fromIntegral processId
         rootRefAmount = getReferenceProductAmount rootActivity
         Collected totalActs entries edges =
             collectSupplyChainEntries
+                geographies
                 db
                 dbName
                 (RootLevel processId)
@@ -2008,6 +2014,7 @@ carries virtual cross-DB links synthesised by the substitution classifier.
 -}
 buildSupplyChainFromScalingVectorCrossDB ::
     UnitConfig ->
+    Geographies ->
     SharedSolver.DepSolverLookup ->
     Database ->
     -- | root DB + name
@@ -2019,12 +2026,13 @@ buildSupplyChainFromScalingVectorCrossDB ::
     [CrossDBLink] ->
     SupplyChainFilter ->
     IO (Either ServiceError SupplyChainResponse)
-buildSupplyChainFromScalingVectorCrossDB unitCfg depLookup rootDb rootDbName rootPid rootScaling extraLinks scf = do
+buildSupplyChainFromScalingVectorCrossDB unitCfg geographies depLookup rootDb rootDbName rootPid rootScaling extraLinks scf = do
     let rootActivity = dbActivities rootDb V.! fromIntegral rootPid
         rootRefAmount = getReferenceProductAmount rootActivity
         rootBlock = sourceBlockOf rootDb rootPid
         rootCollected =
             collectSupplyChainEntries
+                geographies
                 rootDb
                 rootDbName
                 (RootLevel rootPid)
@@ -2048,7 +2056,7 @@ buildSupplyChainFromScalingVectorCrossDB unitCfg depLookup rootDb rootDbName roo
                 , prsBlock = sbName rootBlock
                 , prsBlockProducts = sbProducts rootBlock
                 }
-    eDep <- walkDepLevels unitCfg depLookup rootDb rootScaling extraLinks scf 1 S.empty
+    eDep <- walkDepLevels unitCfg geographies depLookup rootDb rootScaling extraLinks scf 1 S.empty
     pure $ case eDep of
         Left err -> Left err
         Right depCollected ->
@@ -2071,6 +2079,7 @@ at the top level on the merged list.
 -}
 walkDepLevels ::
     UnitConfig ->
+    Geographies ->
     SharedSolver.DepSolverLookup ->
     -- | current consumer DB
     Database ->
@@ -2084,13 +2093,13 @@ walkDepLevels ::
     -- | visited DB names (cycle guard)
     S.Set Text ->
     IO (Either ServiceError Collected)
-walkDepLevels unitCfg depLookup consumerDb consumerScaling extras scf depth visited
+walkDepLevels unitCfg geographies depLookup consumerDb consumerScaling extras scf depth visited
     | depth >= SharedSolver.maxDepsDepth = pure (Right mempty)
     | otherwise = do
         let demandsMap = accumulateDepDemandsWith consumerDb extras consumerScaling
         results <-
             mapM
-                (resolveOneDep unitCfg depLookup scf depth visited)
+                (resolveOneDep unitCfg geographies depLookup scf depth visited)
                 (M.toList demandsMap)
         pure $ case lefts results of
             (err : _) -> Left err
@@ -2102,6 +2111,7 @@ minQuantity/maxDepth pruning as the root walk), then recurse.
 -}
 resolveOneDep ::
     UnitConfig ->
+    Geographies ->
     SharedSolver.DepSolverLookup ->
     SupplyChainFilter ->
     -- | current depth (the one we're entering)
@@ -2110,7 +2120,7 @@ resolveOneDep ::
     S.Set Text ->
     (Text, SupplierDemands) ->
     IO (Either ServiceError Collected)
-resolveOneDep unitCfg depLookup scf depth visited (depDbName, demands)
+resolveOneDep unitCfg geographies depLookup scf depth visited (depDbName, demands)
     | depDbName `S.member` visited = pure (Right mempty)
     | otherwise = do
         mDep <- depLookup depDbName
@@ -2122,6 +2132,7 @@ resolveOneDep unitCfg depLookup scf depth visited (depDbName, demands)
                     depScaling <- solveWithSharedSolver depSolver demandVec
                     let local =
                             collectSupplyChainEntries
+                                geographies
                                 depDb
                                 depDbName
                                 (DepLevel depth)
@@ -2130,6 +2141,7 @@ resolveOneDep unitCfg depLookup scf depth visited (depDbName, demands)
                     eDeeper <-
                         walkDepLevels
                             unitCfg
+                            geographies
                             depLookup
                             depDb
                             depScaling
@@ -2997,8 +3009,8 @@ When 'cnfEdges' is 'WithEdges', every technosphere coefficient whose endpoints
 are both reachable from the supplier is emitted alongside the paginated
 result list, mirroring SupplyChainResponse.scrEdges.
 -}
-getConsumers :: Database -> Text -> Text -> ConsumerFilter -> Either ServiceError ConsumersResponse
-getConsumers db dbName processIdText cnf = do
+getConsumers :: Geographies -> Database -> Text -> Text -> ConsumerFilter -> Either ServiceError ConsumersResponse
+getConsumers geographies db dbName processIdText cnf = do
     (processId, _) <- resolveActivityAndProcessId db processIdText
     let core = cnfCore cnf
         -- Build adjacency list: supplier → [direct consumers]
@@ -3034,7 +3046,7 @@ getConsumers db dbName processIdText cnf = do
 
         locationMatches activity = case afcLocation core of
             Nothing -> True
-            Just pat -> locationAnswers pat (activityLocation activity)
+            Just pat -> locationAnswers geographies pat (activityLocation activity)
 
         productMatches prodName = case afcProduct core of
             Nothing -> True

--- a/src/Service/Aggregate.hs
+++ b/src/Service/Aggregate.hs
@@ -39,6 +39,7 @@ import API.Types (
     SupplyChainResponse (..),
     apiFlowName,
  )
+import Database (Geographies)
 import Matrix (activityNormalizationFactor, buildDemandVectorFromIndex)
 import Service (
     ActivityFilterCore (..),
@@ -166,6 +167,7 @@ data AggRow = AggRow
 
 aggregate ::
     UnitConfig ->
+    Geographies ->
     BioFlowDB -> -- merged (root + deps) for biosphere scope
     UnitDB -> -- merged (root + deps) for biosphere scope
     Database ->
@@ -175,7 +177,7 @@ aggregate ::
     Text -> -- processId text
     AggregateParams ->
     IO (Either ServiceError Aggregation)
-aggregate unitConfig flowDB unitDB db dbName solver depLookup pidText params =
+aggregate unitConfig geographies flowDB unitDB db dbName solver depLookup pidText params =
     case resolveScorable db pidText of
         Left err -> return (Left err)
         Right (processId, activity) ->
@@ -189,6 +191,7 @@ aggregate unitConfig flowDB unitDB db dbName solver depLookup pidText params =
                     eResp <-
                         buildSupplyChainFromScalingVectorCrossDB
                             unitConfig
+                            geographies
                             depLookup
                             db
                             dbName

--- a/test/AggregateSpec.hs
+++ b/test/AggregateSpec.hs
@@ -23,7 +23,7 @@ import Test.Hspec
 import qualified API.Types as API
 import qualified Service.Aggregate as Agg
 import qualified SharedSolver as SS
-import TestHelpers (loadSampleDatabase, mkDepLookupFromMap, mkSolverFromDb)
+import TestHelpers (loadSampleDatabase, mkDepLookupFromMap, mkSolverFromDb, shippedGeographies)
 import Types (CrossDBLink (..), Database (..), ExchangeKind (..), processIdToText)
 import qualified Types
 import qualified UnitConversion as UC
@@ -53,6 +53,7 @@ runAggWith depLookup db params = do
     result <-
         Agg.aggregate
             UC.defaultUnitConfig
+            shippedGeographies
             (dbBioFlows db)
             (dbUnits db)
             db

--- a/test/NestedSubstitutionSpec.hs
+++ b/test/NestedSubstitutionSpec.hs
@@ -38,6 +38,7 @@ import TestHelpers (
     loadSampleDatabase,
     mkDepLookupFromMap,
     mkSolverFromDb,
+    shippedGeographies,
  )
 import Types
 import UnitConversion (defaultUnitConfig)
@@ -295,6 +296,7 @@ spec = do
             eResp <-
                 buildSupplyChainFromScalingVectorCrossDB
                     defaultUnitConfig
+                    shippedGeographies
                     lookup_
                     root
                     "root"

--- a/test/SearchCountsSpec.hs
+++ b/test/SearchCountsSpec.hs
@@ -11,30 +11,30 @@ module SearchCountsSpec (spec) where
 
 import Service (CountAs (..), SearchCounts (..), countAsListed, searchCounts)
 import Test.Hspec
-import TestHelpers (loadSampleDatabase)
+import TestHelpers (loadSampleDatabase, shippedGeographies)
 
 spec :: Spec
 spec = describe "the counts behind a search box's tabs" $ do
     it "counts the processes a term matches" $ do
         db <- loadSampleDatabase "SAMPLE.ilcd"
-        scProcesses (searchCounts db countAsListed "Coal") `shouldBe` 1
+        scProcesses (searchCounts shippedGeographies db countAsListed "Coal") `shouldBe` 1
 
     it "counts a product under products, not under flows" $ do
         -- SAMPLE.ilcd's outputs are technosphere flows, so a term matching
         -- them belongs to the middle tab and leaves the right-hand one empty.
         db <- loadSampleDatabase "SAMPLE.ilcd"
-        let counts = searchCounts db countAsListed "Coal"
+        let counts = searchCounts shippedGeographies db countAsListed "Coal"
         (scProducts counts > 0, scFlows counts) `shouldBe` (True, 0)
 
     it "answers zero everywhere for a term the database does not have" $ do
         db <- loadSampleDatabase "SAMPLE.ilcd"
-        searchCounts db countAsListed "zirconium" `shouldBe` SearchCounts 0 0 0
+        searchCounts shippedGeographies db countAsListed "zirconium" `shouldBe` SearchCounts 0 0 0
 
     it "counts the way an exact listing would list, not the way a fuzzy one would" $ do
         -- Two matchers answer this query: BM25 keeps a row matching one token,
         -- the exact path keeps only a row matching them all. A tab labelled
         -- with one number over a table built by the other is the bug.
         db <- loadSampleDatabase "SAMPLE.ilcd"
-        let fuzzy = searchCounts db countAsListed "Coal extraction"
-            exact = searchCounts db CountAs{caSort = Nothing, caExact = True} "Coal extraction"
+        let fuzzy = searchCounts shippedGeographies db countAsListed "Coal extraction"
+            exact = searchCounts shippedGeographies db CountAs{caSort = Nothing, caExact = True} "Coal extraction"
         (scProcesses fuzzy >= scProcesses exact) `shouldBe` True

--- a/test/SourceBlockSpec.hs
+++ b/test/SourceBlockSpec.hs
@@ -29,6 +29,7 @@ import qualified Data.Text as T
 import Database (buildDatabaseWithMatrices)
 import Database.Loader (defaultLoadOptions, loadDatabaseWithLocationAliases)
 import Service (ActivityFilterCore (..), SearchFilter (..), activityMatches, mkActivitySummary)
+import TestHelpers (shippedGeographies)
 import Types (AllocationKey (..), BuildInputs (..), Database (..))
 import UnitConversion (defaultUnitConfig)
 
@@ -135,7 +136,7 @@ exactProductsFound db = productsMatching db True
 -- | Both of the above, carrying the exact-match flag a 'SearchFilter' holds.
 productsMatching :: Database -> Bool -> Text -> [Text]
 productsMatching db exact query =
-    [prsProductName (mkActivitySummary db pid act) | (pid, act) <- activityMatches db (SearchFilter (nameOnly query) exact)]
+    [prsProductName (mkActivitySummary db pid act) | (pid, act) <- activityMatches shippedGeographies db (SearchFilter (nameOnly query) exact)]
   where
     nameOnly :: Text -> ActivityFilterCore
     nameOnly q =

--- a/test/StructuredFiltersSpec.hs
+++ b/test/StructuredFiltersSpec.hs
@@ -8,9 +8,10 @@ codes overlap as text and the same filter narrows a delete.
 -}
 module StructuredFiltersSpec (spec) where
 
+import Data.Text (Text)
 import Database (findActivitiesByFields, locationAnswers, locationIs)
 import Test.Hspec
-import TestHelpers (loadSampleDatabase)
+import TestHelpers (loadSampleDatabase, shippedGeographies)
 import Types
 
 spec :: Spec
@@ -21,27 +22,62 @@ spec = do
 geographyFilter :: Spec
 geographyFilter = describe "a geography filter names a place" $ do
     it "answers for the location itself, whatever the case" $
-        map (`locationAnswers` "FR") ["FR", "fr", " FR "] `shouldBe` [True, True, True]
+        map (`answers` "FR") ["FR", "fr", " FR "] `shouldBe` [True, True, True]
 
-    it "answers for a location written under the one asked for" $
-        map (uncurry locationAnswers) [("US", "US-WECC"), ("CH", "CH-VD"), ("Europe", "Europe without Switzerland")]
-            `shouldBe` [True, True, True]
+    it "answers for a location the table declares inside the one asked for" $
+        map
+            (uncurry answers)
+            [ ("US", "US-WECC")
+            , ("RER", "FR")
+            , ("NAFTA", "CA-QC")
+            , ("Europe", "Europe without Switzerland")
+            , ("Europe without Switzerland", "Europe without Switzerland and France")
+            ]
+            `shouldBe` [True, True, True, True, True]
 
-    it "does not answer for a code that merely sits inside another" $
-        -- DE inside NORDEL, SE inside US-SERC: different places whose codes
-        -- share letters, which a substring match cannot tell apart.
-        map (uncurry locationAnswers) [("DE", "NORDEL"), ("SE", "US-SERC"), ("IN", "CN-IN")]
-            `shouldBe` [False, False, False]
+    it "does not answer for a place that merely starts with the same letters" $
+        -- Greenland is not the world, Romania is not the rest of it, and Norway
+        -- is neither the Nordic grid nor a part of Cyprus. Reading a place out
+        -- of the letters another one begins with answers all of those.
+        map
+            (uncurry answers)
+            [ ("GL", "GLO")
+            , ("RO", "RoW")
+            , ("NO", "NORDEL")
+            , ("NO", "Northern Cyprus")
+            , ("CA", "Canary Islands")
+            , ("RE", "RER")
+            , ("NA", "NAFTA")
+            , ("MR", "MRO")
+            ]
+            `shouldBe` replicate 8 False
 
     it "does not answer for a region named after the place it excludes" $
         -- "RER w/o CH+DE" is Europe minus Switzerland and Germany, so answering
         -- a question about either with it states the opposite of the truth.
-        map (uncurry locationAnswers) [("CH", "RER w/o CH+DE"), ("DE", "RER w/o CH+DE")]
+        map (uncurry answers) [("CH", "RER w/o CH+DE"), ("DE", "RER w/o CH+DE")]
             `shouldBe` [False, False]
 
-    it "answers a filter typed one letter at a time" $
-        map (uncurry locationAnswers) [("F", "FR"), ("F", "FI"), ("F", "DE")]
-            `shouldBe` [True, True, False]
+    it "answers for a place wider than the one asked for in neither direction" $
+        -- Containment runs one way. US-WECC is inside the US; the US is not
+        -- inside US-WECC, and a filter that answered both would hand back data
+        -- more precise than the question.
+        map (uncurry answers) [("US", "US-WECC"), ("US-WECC", "US")]
+            `shouldBe` [True, False]
+
+    it "answers for the world with the world, not with everywhere in it" $
+        -- The table lists GLO and RoW among the wider places of every country,
+        -- so a characterization factor found only for the world can still
+        -- answer for a country. A filter asking for the world is asking for the
+        -- datasets written that way.
+        map (uncurry answers) [("GLO", "GLO"), ("GLO", "FR"), ("RoW", "CN"), ("RoW", "GLO")]
+            `shouldBe` [True, False, False, False]
+
+    it "answers for a place the table does not know with that place alone" $
+        -- Nothing here is inferred from how the name is spelled, so a location
+        -- nobody declared is a location with no places inside it.
+        map (uncurry answers) [("Commonwealth", "Commonwealth"), ("Commonwealth", "GB"), ("Common", "Commonwealth")]
+            `shouldBe` [True, False, False]
 
     it "reads a location the same way under exact, so only the question differs" $
         -- Whitespace and case are not part of a place. Reading them on one arm
@@ -50,24 +86,33 @@ geographyFilter = describe "a geography filter names a place" $ do
         map (uncurry locationIs) [(" FR ", "fr"), ("US", "US-WECC"), ("F", "FR")]
             `shouldBe` [True, False, False]
 
+{- | The filter asked against the location table the engine actually ships, not
+a fixture: the pairs above are the ones real databases write, and a hand-made
+table would pin the test to itself rather than to the shipped answer. A table
+that failed to load would answer no to everything, which the pairs expecting
+yes above are what catches.
+-}
+answers :: Text -> Text -> Bool
+answers = locationAnswers shippedGeographies
+
 exactProductFilter :: Spec
 exactProductFilter = describe "exact product filter" $ do
     it "matches the full product name only" $ do
         db <- loadSampleDatabase "SAMPLE.min"
-        let hits = findActivitiesByFields db Nothing Nothing (Just "product C") [] True
+        let hits = findActivitiesByFields shippedGeographies db Nothing Nothing (Just "product C") [] True
         map (activityName . snd) hits `shouldBe` ["production of product C"]
 
     it "is case-insensitive" $ do
         db <- loadSampleDatabase "SAMPLE.min"
-        let hits = findActivitiesByFields db Nothing Nothing (Just "PRODUCT c") [] True
+        let hits = findActivitiesByFields shippedGeographies db Nothing Nothing (Just "PRODUCT c") [] True
         map (activityName . snd) hits `shouldBe` ["production of product C"]
 
     it "rejects a partial product name" $ do
         db <- loadSampleDatabase "SAMPLE.min"
-        let hits = findActivitiesByFields db Nothing Nothing (Just "product") [] True
+        let hits = findActivitiesByFields shippedGeographies db Nothing Nothing (Just "product") [] True
         map (activityName . snd) hits `shouldBe` []
 
     it "combines with an exact name filter" $ do
         db <- loadSampleDatabase "SAMPLE.min"
-        let hits = findActivitiesByFields db (Just "production of product C") Nothing (Just "product C") [] True
+        let hits = findActivitiesByFields shippedGeographies db (Just "production of product C") Nothing (Just "product C") [] True
         map (activityName . snd) hits `shouldBe` ["production of product C"]

--- a/test/SupplyChainSpec.hs
+++ b/test/SupplyChainSpec.hs
@@ -69,7 +69,7 @@ spec = do
             let rootProcessId = 0 :: ProcessId
             supplyVec <- computeScalingVector db rootProcessId
 
-            let response = buildSupplyChainFromScalingVector db "test-db" rootProcessId supplyVec emptySupply
+            let response = buildSupplyChainFromScalingVector shippedGeographies db "test-db" rootProcessId supplyVec emptySupply
                 entries = scrSupplyChain response
 
             -- With rootRefAmount = 1, sceQuantity must equal sceScalingFactor exactly
@@ -87,7 +87,7 @@ spec = do
             let rootProcessId = 0 :: ProcessId
             supplyVec <- computeScalingVector db rootProcessId
 
-            let response = buildSupplyChainFromScalingVector db "test-db" rootProcessId supplyVec emptySupply
+            let response = buildSupplyChainFromScalingVector shippedGeographies db "test-db" rootProcessId supplyVec emptySupply
                 entries = scrSupplyChain response
 
             -- All entries should have depth > 0 (root is excluded from supply chain)
@@ -101,12 +101,13 @@ spec = do
             supplyVec <- computeScalingVector db rootProcessId
 
             -- No depth filter: should get Y (depth 1) and Z (depth 2)
-            let noFilter = buildSupplyChainFromScalingVector db "test-db" rootProcessId supplyVec emptySupply
+            let noFilter = buildSupplyChainFromScalingVector shippedGeographies db "test-db" rootProcessId supplyVec emptySupply
             scrFilteredActivities noFilter `shouldSatisfy` (>= 2)
 
             -- Depth 1: should only get Y (direct supplier)
             let depth1 =
                     buildSupplyChainFromScalingVector
+                        shippedGeographies
                         db
                         "test-db"
                         rootProcessId
@@ -125,6 +126,7 @@ spec = do
         let loadWithIndex = fmap BM25.addBM25Index (loadSampleDatabase "SAMPLE.min3")
             buildWithName db pid vec nameQ =
                 buildSupplyChainFromScalingVector
+                    shippedGeographies
                     db
                     "test-db"
                     pid
@@ -194,6 +196,7 @@ spec = do
             supplyVec <- computeScalingVector db rootPid
             let resp =
                     buildSupplyChainFromScalingVector
+                        shippedGeographies
                         db
                         "test-db"
                         rootPid
@@ -208,7 +211,7 @@ spec = do
             db <- loadWithIndex
             -- Consumers of Z (pid 2) are Y (pid 1, direct) and X (pid 0, transitive).
             let pidZ = processIdToText db 2
-            case getConsumers db "test-db" pidZ (mapConsumerCore (\c -> c{afcName = Just "X"}) emptyConsumer) of
+            case getConsumers shippedGeographies db "test-db" pidZ (mapConsumerCore (\c -> c{afcName = Just "X"}) emptyConsumer) of
                 Left err -> expectationFailure $ "getConsumers failed: " ++ show err
                 Right cr -> do
                     map crActivityName (srResults (crrResults cr)) `shouldBe` ["production of product X"]
@@ -217,21 +220,21 @@ spec = do
         it "accepts typos in the name filter" $ do
             db <- loadWithIndex
             let pidZ = processIdToText db 2
-            case getConsumers db "test-db" pidZ (mapConsumerCore (\c -> c{afcName = Just "prodcution"}) emptyConsumer) of
+            case getConsumers shippedGeographies db "test-db" pidZ (mapConsumerCore (\c -> c{afcName = Just "prodcution"}) emptyConsumer) of
                 Left err -> expectationFailure $ "getConsumers failed: " ++ show err
                 Right cr -> length (srResults (crrResults cr)) `shouldSatisfy` (>= 1)
 
         it "returns all consumers when name filter is absent" $ do
             db <- loadWithIndex
             let pidZ = processIdToText db 2
-            case getConsumers db "test-db" pidZ emptyConsumer of
+            case getConsumers shippedGeographies db "test-db" pidZ emptyConsumer of
                 Left err -> expectationFailure $ "getConsumers failed: " ++ show err
                 Right cr -> length (srResults (crrResults cr)) `shouldBe` 2
 
         it "non-matching name query returns zero consumers" $ do
             db <- loadWithIndex
             let pidZ = processIdToText db 2
-            case getConsumers db "test-db" pidZ (mapConsumerCore (\c -> c{afcName = Just "zzznomatch"}) emptyConsumer) of
+            case getConsumers shippedGeographies db "test-db" pidZ (mapConsumerCore (\c -> c{afcName = Just "zzznomatch"}) emptyConsumer) of
                 Left err -> expectationFailure $ "getConsumers failed: " ++ show err
                 Right cr -> length (srResults (crrResults cr)) `shouldBe` 0
 
@@ -241,7 +244,7 @@ spec = do
         it "populates crClassifications from the consumer's activityClassification" $ do
             db <- loadWithIndex
             let pidZ = processIdToText db 2
-            case getConsumers db "test-db" pidZ emptyConsumer of
+            case getConsumers shippedGeographies db "test-db" pidZ emptyConsumer of
                 Left err -> expectationFailure $ "getConsumers failed: " ++ show err
                 Right cr -> not (any (M.null . crClassifications) (srResults (crrResults cr))) `shouldBe` True
 
@@ -251,7 +254,7 @@ spec = do
         it "returns empty edges by default" $ do
             db <- loadWithIndex
             let pidZ = processIdToText db 2
-            case getConsumers db "test-db" pidZ emptyConsumer of
+            case getConsumers shippedGeographies db "test-db" pidZ emptyConsumer of
                 Left err -> expectationFailure $ "getConsumers failed: " ++ show err
                 Right cr -> length (crrEdges cr) `shouldBe` 0
 
@@ -259,7 +262,7 @@ spec = do
             db <- loadWithIndex
             let pidZ = processIdToText db 2
                 cnf = emptyConsumer{cnfEdges = WithEdges}
-            case getConsumers db "test-db" pidZ cnf of
+            case getConsumers shippedGeographies db "test-db" pidZ cnf of
                 Left err -> expectationFailure $ "getConsumers failed: " ++ show err
                 Right cr -> do
                     -- SAMPLE.min3 wiring: X(0) -> Y(1) -> Z(2). Querying Z reaches

--- a/test/TestHelpers.hs
+++ b/test/TestHelpers.hs
@@ -10,10 +10,13 @@ module TestHelpers (
     mkDepLookupFromMap,
     linkDatabases,
     mkSolverFromDb,
+    shippedGeographies,
 ) where
 
+import Builtin (builtinGeographies)
 import Control.Exception (bracket_)
 import Control.Monad (zipWithM_)
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.Map as M
 import qualified Data.Map.Strict as MS
 import Data.Text (Text)
@@ -21,8 +24,9 @@ import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
-import Database (buildDatabaseWithMatrices)
+import Database (Geographies, buildDatabaseWithMatrices, readGeographies)
 import Database.Loader (loadDatabase)
+import Database.Manager (hierarchyFromGeographies, parseGeographies)
 import qualified SharedSolver as SS
 import System.Environment (setEnv, unsetEnv)
 import System.IO.Temp (withSystemTempDirectory)
@@ -130,3 +134,14 @@ linkDatabases consumerDb supplierDb supplierName coeff =
                 , cdlTiedAlternatives = []
                 }
      in consumerDb{dbCrossDBLinks = link : dbCrossDBLinks consumerDb}
+
+{- | The location table the engine ships, read the way a geography filter reads
+it. A fixture would pin a test to itself; this pins it to the answer a user
+gets. 'StructuredFiltersSpec' checks the table is actually there, so an empty
+one cannot pass unnoticed.
+-}
+shippedGeographies :: Geographies
+shippedGeographies =
+    readGeographies $
+        either (const mempty) hierarchyFromGeographies $
+            parseGeographies "the built-in geographies" (BL.toStrict builtinGeographies)


### PR DESCRIPTION
Closes #435.

## The problem

A geography filter answered for any location whose text began with the code
asked for. Location codes are a controlled vocabulary and they overlap as text,
so the letters one place starts with are regularly another place. Across the
541 geographies one recent EcoSpold 2 release declares, forty pairs answered
that way:

| asking for | also returned |
|---|---|
| `GL` Greenland | `GLO`, so every global dataset |
| `RO` Romania | `RoW`, so everything else |
| `NO` Norway | `NORDEL`, `Northern Cyprus`, `North America without Quebec` |
| `CA` Canada | `Canary Islands` |
| `RE` Réunion | `RER` and its seven exclusion variants |
| `NA` Namibia | `NAFTA` |
| `MR` Mauritania | `MRO` |
| `SE` Sweden | `Serranilla Bank` |

Nothing in the answer said so. The same filter narrows a delete, so it decided
what a delete removed as well as what a search returned.

## What the diff does

The engine already ships a location table, `data/geographies.csv`, and already
reads containment from it when linking one database to another. Only the search
filter judged places by their spelling.

A location now answers when it is the geography asked for, or when the table
declares it inside that geography. Nothing is read out of how a code is
written, so a place the table does not list answers for itself alone, and a
place someone invents answers only once it is declared.

That also lets a filter answer for places it never could. Against a loaded
EcoSpold 2 database:

| filter | before | after |
|---|---|---|
| `geo=RER` | the datasets spelled `RER*` | 1703, across 35 European countries |
| `geo=US` | `US` and `US-*` by spelling | 242, across every regional grid written `US-*` |
| `geo=GL` | every global dataset | 0 |
| `geo=NO` | Norway plus `NORDEL` | 40, all Norway |
| `geo=RO` | Romania plus `RoW` | 24, all Romania |
| `geo=GLO` | global datasets | 3163, all `GLO` |

`exact=true` is unchanged and still means the location itself.

The first commit is data, and corrects the table in both directions. Six
regions defined by exclusion listed only the continent above them and skipped
the intermediate region they are carved out of, so `Europe without Switzerland
and France` was not inside `Europe without Switzerland`. Three rows went the
other way: the European Union and its 27- and 28-member forms listed `Europe
without Austria` among their wider places, and Austria is in all three. Those
rows were wrong for cross-database linking too, before this change read them.

## Worth a reader's attention

**`GLO` and `RoW` are places, not containers.** The table lists them among the
wider places of every country so that a characterization factor found only for
the world can still answer for a country. Read as containment by a filter, that
would return the whole database for `geo=GLO`. They answer for themselves. The
three codes come from `CrossLinking.placelessLocations`, which is where they
are already decided.

**A filter typed one letter at a time no longer matches on the way.** `geo=F`
used to return `FR`, `FI`, `FJ`; it now returns nothing until the code is
complete. That was the deliberate behaviour a test pinned, and the price of it
was the forty pairs above. A free-text geography box wants a picker fed by
`list_geographies` rather than a prefix; that belongs to whatever serves the
box, not here.

**The table is not transitively closed, and the filter does not close it.**
`Canary Islands` names `ES` and stops, so `geo=RER` does not reach it;
`UCTE without France` names `UCTE` and not `ENTSO-E`. Fifty-five such edges
remain. Closing them automatically would be wrong - it would put Austria inside
`Europe without Austria` by way of `EU` - so each is a judgement about a place.
This is the reading `CrossLinking.isSubregionOf` has always taken of the same
table, and the filter now shares it rather than inventing a second one.

**Fifteen names in that same EcoSpold 2 release have no row in the table at
all** (`BQ`, `BV`, `CC`, `CS`, `CX`, `GF`, `GI`, `SJ`, `TK`, `UM`, `YT`,
`UN-SASIA`, two IAI areas, one grid). They answer for themselves, which is
correct rather than wrong, and no worse than before.

**Two signatures are now long.** `findActivitiesByFields` and
`applyStructuredFilters` were already past the four-parameter line and this adds
one more. Gathering their filter arguments into a record is worth doing and is
not this change.

**`Geographies` is read once per query, not per comparison**, and folded on the
way in, so a table folded on one side and raw on the other is visible as a
misuse rather than hiding in a `Map`. It is a name, not a wall: `Database` has
no export list, so the constructor is reachable. `readGeographies` is called in
one place, `Database.Manager.managerGeographies`, and it refolds the table on
each call rather than holding a second copy of it beside the one the manager
already carries for cross-database linking.

## How to test

```
cabal test lca-tests
```

`test/StructuredFiltersSpec.hs` asks the table the engine ships, not a fixture.
Reintroducing the prefix comparison in `locationAnswers` fails two of its cases
with all eight accidents flipping to true, which is what says the tests reach
the rule.

End to end, against any loaded EcoSpold 2 database:

```
curl -sG 'http://HOST/api/v1/db/DB/activities' \
  --data-urlencode 'name=electricity, high voltage' --data-urlencode 'geo=RER'
curl -sG 'http://HOST/api/v1/db/DB/activities' \
  --data-urlencode 'name=market for' --data-urlencode 'geo=GL'
```

The first returns European datasets across many countries, the second nothing.

