### PR TITLE
Read area and volume as powers of length, not as dimensions of their own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,11 @@
   quantity and would never have converted into one another, with nothing able
   to notice they should. Both spellings now land on one description, and `area`
   and `volume` stay names you may write in your own `[[units]]` table. No unit
-  the engine ships changes what it converts into and no amount moves; every
-  cache rebuilds once on the next load, because a cache records the unit table
-  it was built with.
+  the engine ships changes what it converts into and no amount moves. A cache
+  records the unit table it was built with, so every cache rebuilds itself from
+  its source on the next load; a host that ships a cache with no source archive
+  beside it needs that archive rebuilt, since there is nothing there to rebuild
+  from.
 - A SimaPro file's own unit table is now read. The file carries one at the end,
   a row per unit giving what it is called, what it is expressed in and how many
   of that it makes, and it is the table its amounts were written against. What

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@
   ambiguities are documented where a reader looks for them.
 
 ### Changed
+- Area and volume are read as powers of length rather than as quantities of
+  their own. A square metre is a length squared and a cubic metre a length
+  cubed, but a unit table could write both conventions, so a density written
+  `mass/volume` and one written `mass/length/length/length` described the same
+  quantity and would never have converted into one another, with nothing able
+  to notice they should. Both spellings now land on one description, and `area`
+  and `volume` stay names you may write in your own `[[units]]` table. No unit
+  the engine ships changes what it converts into and no amount moves; every
+  cache rebuilds once on the next load, because a cache records the unit table
+  it was built with.
 - A SimaPro file's own unit table is now read. The file carries one at the end,
   a row per unit giving what it is called, what it is expressed in and how many
   of that it makes, and it is the table its amounts were written against. What

--- a/src/UnitConversion.hs
+++ b/src/UnitConversion.hs
@@ -19,6 +19,7 @@ module UnitConversion (
     UnitDeclaration (..),
 
     -- * Loading
+    defaultDimensionOrder,
     defaultUnitConfig,
     buildFromCSV,
     addDeclaredUnits,
@@ -70,7 +71,11 @@ import GHC.Generics (Generic)
 import Progress (ProgressLevel (Info), reportProgress)
 
 {- | Dimension as exponent vector.
-Order: [mass, length, time, energy, area, volume, count, currency]
+Order: [mass, length, time, energy, count, currency]
+
+Area and volume are not among them: they are powers of length, and a table
+free to write both spellings is a table where one quantity has two vectors
+that never convert. 'inBaseDimensions' is where the two are spent.
 -}
 type Dimension = [Int]
 
@@ -105,7 +110,27 @@ instance Store UnitConfig
 
 -- | Default dimension order.
 defaultDimensionOrder :: [Text]
-defaultDimensionOrder = ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
+defaultDimensionOrder = ["mass", "length", "time", "energy", "count", "currency"]
+
+{- | The dimension names that stand for a power of a base dimension.
+
+A square metre is a length squared and a cubic metre a length cubed, so area
+and volume are spellings rather than dimensions: with a slot of their own, a
+density written @mass/volume@ and one written @mass/length/length/length@ are
+two vectors for one quantity, and nothing converts between them or can notice
+that it should. Both spellings stay writable and both land on the same vector.
+
+Energy keeps a slot of its own rather than becoming
+@mass*length*length/time/time@, because the unit its characterization factors
+are authored in is @MJ@ and merging it would make a joule convert into a
+newton metre and so into a torque.
+-}
+dimensionShorthands :: [(Text, (Text, Int))]
+dimensionShorthands = [("area", ("length", 2)), ("volume", ("length", 3))]
+
+-- | The base dimension a name is written against, and the power it is raised to.
+inBaseDimensions :: Text -> (Text, Int)
+inBaseDimensions name = fromMaybe (name, 1) (lookup name dimensionShorthands)
 
 {- | The case-blind key a spelling is filed under.
 
@@ -265,15 +290,19 @@ parseDimension dimOrder expr
   where
     addExp :: [Text] -> Int -> Dimension -> Text -> Either Text Dimension
     addExp order delta vec dimName =
-        case elemIndex dimName order of
-            Just idx -> Right $ modifyAt idx (+ delta) vec
+        case elemIndex base order of
+            Just idx -> Right $ modifyAt idx (+ (delta * power)) vec
             Nothing ->
                 Left $
                     "Unknown dimension: "
                         <> dimName
                         <> " (valid: "
-                        <> T.intercalate ", " order
+                        <> T.intercalate ", " (order <> map fst dimensionShorthands)
                         <> ")"
+      where
+        base :: Text
+        power :: Int
+        (base, power) = inBaseDimensions dimName
 
     modifyAt :: Int -> (Int -> Int) -> [Int] -> [Int]
     modifyAt idx f = zipWith (\i x -> if i == idx then f x else x) [0 ..]
@@ -449,18 +478,27 @@ mergeUnitConfigs cfgs@(first : _) =
 unitCount :: UnitConfig -> Int
 unitCount = M.size . ucUnits
 
--- | Minimal bootstrap unit config (kg, m, s, item) for when no CSV is loaded.
+{- | Minimal bootstrap unit config (kg, m, s, item) for when no CSV is loaded.
+
+The four vectors are read off 'defaultDimensionOrder' rather than written out.
+A vector written by hand is a copy of the slot list with no author: it keeps
+parsing the day a slot is added or removed, and the kilogram here quietly stops
+being the kilogram the table parses, which 'mergeUnitConfigs' would then hold
+both of. "UnitConversionSpec" pins the four against 'parseDimension'.
+-}
 defaultUnitConfig :: UnitConfig
 defaultUnitConfig =
     mkUnitConfig
         defaultDimensionOrder
         ( M.fromList
-            [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
-            , ("m", UnitDef [0, 1, 0, 0, 0, 0, 0, 0] 1.0)
-            , ("s", UnitDef [0, 0, 1, 0, 0, 0, 0, 0] 1.0)
-            , ("item", UnitDef [0, 0, 0, 0, 0, 0, 1, 0] 1.0)
+            [ (name, UnitDef (onlySlot dim) 1.0)
+            | (name, dim) <- [("kg", "mass"), ("m", "length"), ("s", "time"), ("item", "count")]
             ]
         )
+  where
+    -- 1 in the slot this base dimension occupies, 0 in every other.
+    onlySlot :: Text -> Dimension
+    onlySlot dim = [if slot == dim then 1 else 0 | slot <- defaultDimensionOrder]
 
 {- | Assemble a config, indexing once what every read of a unit would rescan.
 

--- a/src/UnitConversion.hs
+++ b/src/UnitConversion.hs
@@ -75,7 +75,7 @@ Order: [mass, length, time, energy, count, currency]
 
 Area and volume are not among them: they are powers of length, and a table
 free to write both spellings is a table where one quantity has two vectors
-that never convert. 'inBaseDimensions' is where the two are spent.
+that never convert. 'dimensionShorthands' is where the two are spent.
 -}
 type Dimension = [Int]
 
@@ -127,10 +127,6 @@ newton metre and so into a torque.
 -}
 dimensionShorthands :: [(Text, (Text, Int))]
 dimensionShorthands = [("area", ("length", 2)), ("volume", ("length", 3))]
-
--- | The base dimension a name is written against, and the power it is raised to.
-inBaseDimensions :: Text -> (Text, Int)
-inBaseDimensions name = fromMaybe (name, 1) (lookup name dimensionShorthands)
 
 {- | The case-blind key a spelling is filed under.
 
@@ -300,9 +296,10 @@ parseDimension dimOrder expr
                         <> T.intercalate ", " (order <> map fst dimensionShorthands)
                         <> ")"
       where
+        -- The base dimension this name is written against, and its power.
         base :: Text
         power :: Int
-        (base, power) = inBaseDimensions dimName
+        (base, power) = fromMaybe (dimName, 1) (lookup dimName dimensionShorthands)
 
     modifyAt :: Int -> (Int -> Int) -> [Int] -> [Int]
     modifyAt idx f = zipWith (\i x -> if i == idx then f x else x) [0 ..]

--- a/test/AllocationSpec.hs
+++ b/test/AllocationSpec.hs
@@ -26,8 +26,9 @@ import Database.Loader (defaultLoadOptions, loadDatabaseWithLocationAliases)
 import Database.MatrixBuild (InterningTables (..), buildInterningTables, buildSupplierRefUnits, buildTechTriples)
 import Database.Quality (QualityCheck (..), QualityOffender (..), QualityReport (..), qualityReport)
 import qualified Service
+import TestHelpers (unitDef)
 import Types
-import UnitConversion (UnitConfig, UnitDef (..), defaultUnitConfig, mkUnitConfig, ucDimensionOrder, ucUnits)
+import UnitConversion (UnitConfig, defaultUnitConfig, mkUnitConfig, ucDimensionOrder, ucUnits)
 
 -- | Amounts of the five products of the Abondance cheese block, in kilograms.
 abondance :: NE.NonEmpty StatedAmount
@@ -38,11 +39,7 @@ massUnits :: UnitConfig
 massUnits =
     mkUnitConfig
         (ucDimensionOrder defaultUnitConfig)
-        (M.union (M.fromList [("g", UnitDef mass 0.001), ("MJ", UnitDef energy 1.0)]) (ucUnits defaultUnitConfig))
-  where
-    mass, energy :: [Int]
-    mass = [1, 0, 0, 0, 0, 0, 0, 0]
-    energy = [0, 0, 0, 1, 0, 0, 0, 0]
+        (M.union (M.fromList [("g", unitDef "mass" 0.001), ("MJ", unitDef "energy" 1.0)]) (ucUnits defaultUnitConfig))
 
 {- | A product of a block as the products table reports it: the summary the
 reader sees, and the row it was split from, which is where a mass is read.

--- a/test/AutoRelinkSpec.hs
+++ b/test/AutoRelinkSpec.hs
@@ -38,8 +38,9 @@ import Test.Hspec
 import Database.Loader (LoadOptions (..))
 import Database.Manager (CachePolicy (..), LoadSource (..), RawLoad (..), loadDatabaseRawWithCrossDB)
 import SynonymDB (emptySynonymDB)
+import TestHelpers (unitDef)
 import Types (AllocationKey (..), GeographyPolicy (..))
-import UnitConversion (UnitConfig, UnitDef (..), defaultUnitConfig, mkUnitConfig, ucDimensionOrder, ucUnits)
+import UnitConversion (UnitConfig, defaultUnitConfig, mkUnitConfig, ucDimensionOrder, ucUnits)
 
 {- | Copy regular files from one directory into another (non-recursive,
 which is all the EcoSpold v2 fixtures here need).
@@ -84,7 +85,7 @@ withGram :: UnitConfig
 withGram =
     mkUnitConfig
         (ucDimensionOrder defaultUnitConfig)
-        (M.insert "g" (UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 0.001) (ucUnits defaultUnitConfig))
+        (M.insert "g" (unitDef "mass" 0.001) (ucUnits defaultUnitConfig))
 
 spec :: Spec
 spec = do

--- a/test/CoproductTargetSpec.hs
+++ b/test/CoproductTargetSpec.hs
@@ -20,9 +20,10 @@ import Test.Hspec
 import API.Types (ActivityForAPI (..), ActivitySummary (..), ExchangeDetail (..), ExchangeWithUnit (..), ExportNode (..), NodeType (..), ProducerFilter (..), TreeEdge (..), TreeExport (..))
 import Database (buildDatabaseWithMatrices)
 import qualified Service
+import TestHelpers (unitDef)
 import Tree (buildLoopAwareTree)
 import Types
-import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig)
+import UnitConversion (UnitConfig (..), defaultUnitConfig)
 
 spec :: Spec
 spec = do
@@ -369,7 +370,7 @@ about.
 gramsAware :: UnitConfig
 gramsAware =
     defaultUnitConfig
-        { ucUnits = M.insert "g" (UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 0.001) (ucUnits defaultUnitConfig)
+        { ucUnits = M.insert "g" (unitDef "mass" 0.001) (ucUnits defaultUnitConfig)
         }
 
 mkUUID :: Int -> UUID

--- a/test/CrossDBRegionalLCIAFixture.hs
+++ b/test/CrossDBRegionalLCIAFixture.hs
@@ -56,7 +56,7 @@ import Method.Types (CFFamily (..), FlowDirection (..), MethodCF (..))
 import TestHelpers (unitDef)
 import Types
 import qualified Types as VT
-import UnitConversion (UnitConfig (..), defaultUnitConfig, mkUnitConfig)
+import UnitConversion (UnitConfig (..), defaultDimensionOrder, defaultUnitConfig, mkUnitConfig)
 
 -- | One biosphere flow shared by both DBs (cross-DB merging keys on UUID).
 flowUUID :: UUID
@@ -78,7 +78,7 @@ kgUnit = Unit{unitId = mkUUID 9, unitName = "kg", unitSymbol = "kg", unitComment
 kgUnitConfig :: UnitConfig
 kgUnitConfig =
     mkUnitConfig
-        ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
+        defaultDimensionOrder
         (M.fromList [("kg", unitDef "mass" 1.0)])
 
 testFlow :: BiosphereFlow

--- a/test/CrossDBRegionalLCIAFixture.hs
+++ b/test/CrossDBRegionalLCIAFixture.hs
@@ -53,9 +53,10 @@ import qualified Data.Vector.Unboxed as U
 
 import Method.Mapping (MatchStrategy (..), MethodTables, buildMethodTables, fillBroadcastVector, fillRegionalActivityWeights)
 import Method.Types (CFFamily (..), FlowDirection (..), MethodCF (..))
+import TestHelpers (unitDef)
 import Types
 import qualified Types as VT
-import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig, mkUnitConfig)
+import UnitConversion (UnitConfig (..), defaultUnitConfig, mkUnitConfig)
 
 -- | One biosphere flow shared by both DBs (cross-DB merging keys on UUID).
 flowUUID :: UUID
@@ -78,7 +79,7 @@ kgUnitConfig :: UnitConfig
 kgUnitConfig =
     mkUnitConfig
         ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
-        (M.fromList [("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)])
+        (M.fromList [("kg", unitDef "mass" 1.0)])
 
 testFlow :: BiosphereFlow
 testFlow =

--- a/test/ExplainCFSpec.hs
+++ b/test/ExplainCFSpec.hs
@@ -36,6 +36,7 @@ import Method.Mapping (
  )
 import Method.Types (CFFamily (..), Compartment (..), EnergyDensity (..), EnergyDensityMap, FlowDirection (..), MethodCF (..))
 import SynonymDB (normalizeName)
+import TestHelpers (unitDef)
 import Types (
     BiosphereFlow (..),
     Medium (..),
@@ -43,7 +44,7 @@ import Types (
     UnitDB,
  )
 import qualified Types as VT
-import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig, mkUnitConfig)
+import UnitConversion (UnitConfig (..), defaultDimensionOrder, defaultUnitConfig, mkUnitConfig)
 
 mkUUID :: Integer -> UUID
 mkUUID n = UUID.fromWords64 (fromIntegral n) 0
@@ -60,10 +61,10 @@ than an unknown unit.
 massEnergyConfig :: UnitConfig
 massEnergyConfig =
     mkUnitConfig
-        ["mass", "energy"]
+        defaultDimensionOrder
         ( M.fromList
-            [ ("kg", UnitDef [1, 0] 1.0)
-            , ("MJ", UnitDef [0, 1] 1.0)
+            [ ("kg", unitDef "mass" 1.0)
+            , ("MJ", unitDef "energy" 1.0)
             ]
         )
 
@@ -412,5 +413,5 @@ spec = do
     -- kg and m3 known but dimensionally apart, so the pair is a mismatch.
     volumeMassConfig =
         mkUnitConfig
-            ["mass", "volume"]
-            (M.fromList [("kg", UnitDef [1, 0] 1.0), ("m3", UnitDef [0, 1] 1.0)])
+            defaultDimensionOrder
+            (M.fromList [("kg", unitDef "mass" 1.0), ("m3", unitDef "volume" 1.0)])

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -17,13 +17,14 @@ import Method.Mapping
 import Method.ParserCSV (parseMethodCSVBytes)
 import Method.Types (Compartment (..), EnergyDensity (..), FlowDirection (..), Method (..), MethodCF (..), buildCompartmentMapFromCSV)
 import SynonymDB (BridgeDirection (..), SynEdge (..), buildFromEdges, buildFromPairs, emptySynonymDB, normalizeName)
+import TestHelpers (unitDef)
 import Types (
     BiosphereFlow (..),
     Medium (..),
     Unit (..),
  )
 import qualified Types as VT
-import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig, mkUnitConfig)
+import UnitConversion (UnitConfig (..), defaultUnitConfig, mkUnitConfig)
 
 -- ---------------------------------------------------------------------------
 -- Helpers
@@ -69,8 +70,8 @@ gKgUnitConfig =
     mkUnitConfig
         ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
         ( M.fromList
-            [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
-            , ("g", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 0.001)
+            [ ("kg", unitDef "mass" 1.0)
+            , ("g", unitDef "mass" 0.001)
             ]
         )
 
@@ -82,7 +83,7 @@ gOnlyUnitConfig :: UnitConfig
 gOnlyUnitConfig =
     mkUnitConfig
         ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
-        (M.fromList [("g", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 0.001)])
+        (M.fromList [("g", unitDef "mass" 0.001)])
 
 -- ---------------------------------------------------------------------------
 -- Spec
@@ -506,8 +507,8 @@ spec = do
         -- on one name key. The row whose raw name equals the flow's raw name
         -- must win: the other variant is dimensionally incompatible with the
         -- flow and would silently convert to 0.
-        let kgDef = UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0
-            m3Def = UnitDef [0, 3, 0, 0, 0, 0, 0, 0] 1.0
+        let kgDef = unitDef "mass" 1.0
+            m3Def = unitDef "volume" 1.0
             cfg =
                 mkUnitConfig
                     []
@@ -870,8 +871,8 @@ spec = do
         it "pre-multiplied broadcast equals legacy when CF unit absorbs into flow unit" $ do
             -- Build a custom config with both kg and g (default config only has kg).
             -- 1 g = 0.001 kg → factor 0.001 against the SI base.
-            let kgDef = UnitConversion.UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0
-                gDef = UnitConversion.UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0e-3
+            let kgDef = unitDef "mass" 1.0
+                gDef = unitDef "mass" 1.0e-3
                 cfg =
                     UnitConversion.mkUnitConfig
                         []
@@ -950,9 +951,9 @@ spec = do
                 mkUnitConfig
                     []
                     ( M.fromList
-                        [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
-                        , ("m3", UnitDef [0, 1, 0, 0, 0, 0, 0, 0] 1.0)
-                        , ("mj", UnitDef [0, 0, 1, 0, 0, 0, 0, 0] 1.0)
+                        [ ("kg", unitDef "mass" 1.0)
+                        , ("m3", unitDef "volume" 1.0)
+                        , ("mj", unitDef "energy" 1.0)
                         ]
                     )
             fillWith densities unitName' cf = do

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -24,7 +24,7 @@ import Types (
     Unit (..),
  )
 import qualified Types as VT
-import UnitConversion (UnitConfig (..), defaultUnitConfig, mkUnitConfig)
+import UnitConversion (UnitConfig (..), defaultDimensionOrder, defaultUnitConfig, mkUnitConfig)
 
 -- ---------------------------------------------------------------------------
 -- Helpers
@@ -68,7 +68,7 @@ unitNamed n = Unit{unitId = nil, unitName = n, unitSymbol = n, unitComment = ""}
 gKgUnitConfig :: UnitConfig
 gKgUnitConfig =
     mkUnitConfig
-        ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
+        defaultDimensionOrder
         ( M.fromList
             [ ("kg", unitDef "mass" 1.0)
             , ("g", unitDef "mass" 0.001)
@@ -82,7 +82,7 @@ branch's hard-fail to 0.
 gOnlyUnitConfig :: UnitConfig
 gOnlyUnitConfig =
     mkUnitConfig
-        ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
+        defaultDimensionOrder
         (M.fromList [("g", unitDef "mass" 0.001)])
 
 -- ---------------------------------------------------------------------------

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -37,7 +37,7 @@ import Types (
     emptyProductIndex,
  )
 import qualified Types as VT
-import UnitConversion (UnitConfig (..), defaultUnitConfig, mkUnitConfig)
+import UnitConversion (UnitConfig (..), defaultDimensionOrder, defaultUnitConfig, mkUnitConfig)
 
 -- ---------------------------------------------------------------------------
 -- Fixture
@@ -62,7 +62,7 @@ kgUnit = Unit{unitId = mkUUID 9, unitName = "kg", unitSymbol = "kg", unitComment
 kgUnitConfig :: UnitConfig
 kgUnitConfig =
     mkUnitConfig
-        ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
+        defaultDimensionOrder
         (M.fromList [("kg", unitDef "mass" 1.0)])
 
 testFlow :: BiosphereFlow

--- a/test/RegionalLCIASpec.hs
+++ b/test/RegionalLCIASpec.hs
@@ -24,6 +24,7 @@ import Method.Types (
     Location (..),
     MethodCF (..),
  )
+import TestHelpers (unitDef)
 import Types (
     Activity (..),
     BiosphereFlow (..),
@@ -36,7 +37,7 @@ import Types (
     emptyProductIndex,
  )
 import qualified Types as VT
-import UnitConversion (UnitConfig (..), UnitDef (..), defaultUnitConfig, mkUnitConfig)
+import UnitConversion (UnitConfig (..), defaultUnitConfig, mkUnitConfig)
 
 -- ---------------------------------------------------------------------------
 -- Fixture
@@ -62,7 +63,7 @@ kgUnitConfig :: UnitConfig
 kgUnitConfig =
     mkUnitConfig
         ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
-        (M.fromList [("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)])
+        (M.fromList [("kg", unitDef "mass" 1.0)])
 
 testFlow :: BiosphereFlow
 testFlow =

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -72,7 +72,7 @@ import Types (
     exchangePedigree,
     tfName,
  )
-import UnitConversion (UnitConfig (..), UnitDeclaration (..), buildFromCSV, defaultUnitConfig, isKnownUnit, mkUnitConfig)
+import UnitConversion (UnitConfig (..), UnitDeclaration (..), buildFromCSV, defaultDimensionOrder, defaultUnitConfig, isKnownUnit, mkUnitConfig)
 
 -- | Test CSV content with a quoted product name containing the delimiter (;)
 testCSV :: BS.ByteString
@@ -1846,7 +1846,7 @@ follow it.
 volumeUnitConfig :: Text -> UnitConfig
 volumeUnitConfig reference =
     mkUnitConfig
-        ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
+        defaultDimensionOrder
         ( M.fromList
             [ (reference, unitDef "volume" 1.0)
             , ("l", unitDef "volume" 0.001)
@@ -1859,7 +1859,7 @@ and kWh (energy), so a row written in either has somewhere to be converted to.
 mixedUnitConfig :: UnitConfig
 mixedUnitConfig =
     mkUnitConfig
-        ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
+        defaultDimensionOrder
         ( M.fromList
             [ ("kg", unitDef "mass" 1.0)
             , ("g", unitDef "mass" 0.001)
@@ -1872,7 +1872,7 @@ mixedUnitConfig =
 tonUnitConfig :: UnitConfig
 tonUnitConfig =
     mkUnitConfig
-        ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
+        defaultDimensionOrder
         ( M.fromList
             [ ("kg", unitDef "mass" 1.0)
             , ("ton", unitDef "mass" 1000.0)

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -39,6 +39,7 @@ import SimaPro.Parser (
 import System.IO (hClose)
 import System.IO.Temp (withSystemTempFile)
 import Test.Hspec
+import TestHelpers (unitDef)
 import Types (
     Activity (..),
     BioDirection (..),
@@ -71,7 +72,7 @@ import Types (
     exchangePedigree,
     tfName,
  )
-import UnitConversion (UnitConfig (..), UnitDeclaration (..), UnitDef (..), buildFromCSV, defaultUnitConfig, isKnownUnit, mkUnitConfig)
+import UnitConversion (UnitConfig (..), UnitDeclaration (..), buildFromCSV, defaultUnitConfig, isKnownUnit, mkUnitConfig)
 
 -- | Test CSV content with a quoted product name containing the delimiter (;)
 testCSV :: BS.ByteString
@@ -1847,8 +1848,8 @@ volumeUnitConfig reference =
     mkUnitConfig
         ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
         ( M.fromList
-            [ (reference, UnitDef [0, 0, 0, 0, 0, 1, 0, 0] 1.0)
-            , ("l", UnitDef [0, 0, 0, 0, 0, 1, 0, 0] 0.001)
+            [ (reference, unitDef "volume" 1.0)
+            , ("l", unitDef "volume" 0.001)
             ]
         )
 
@@ -1860,10 +1861,10 @@ mixedUnitConfig =
     mkUnitConfig
         ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
         ( M.fromList
-            [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
-            , ("g", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 0.001)
-            , ("MJ", UnitDef [0, 0, 0, 1, 0, 0, 0, 0] 1.0)
-            , ("kWh", UnitDef [0, 0, 0, 1, 0, 0, 0, 0] 3.6)
+            [ ("kg", unitDef "mass" 1.0)
+            , ("g", unitDef "mass" 0.001)
+            , ("MJ", unitDef "energy" 1.0)
+            , ("kWh", unitDef "energy" 3.6)
             ]
         )
 
@@ -1873,8 +1874,8 @@ tonUnitConfig =
     mkUnitConfig
         ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
         ( M.fromList
-            [ ("kg", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1.0)
-            , ("ton", UnitDef [1, 0, 0, 0, 0, 0, 0, 0] 1000.0)
+            [ ("kg", unitDef "mass" 1.0)
+            , ("ton", unitDef "mass" 1000.0)
             ]
         )
 

--- a/test/TestHelpers.hs
+++ b/test/TestHelpers.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module TestHelpers (
+    unitDef,
     withScratchDataDir,
     loadSampleDatabase,
     loadSampleDatabaseWithPath,
@@ -17,6 +18,7 @@ import Builtin (builtinGeographies)
 import Control.Exception (bracket_)
 import Control.Monad (zipWithM_)
 import qualified Data.ByteString.Lazy as BL
+import Data.Either (fromRight)
 import qualified Data.Map as M
 import qualified Data.Map.Strict as MS
 import Data.Text (Text)
@@ -32,7 +34,22 @@ import System.Environment (setEnv, unsetEnv)
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 import Types
-import UnitConversion (defaultUnitConfig)
+import UnitConversion (UnitDef (..), defaultDimensionOrder, defaultUnitConfig, parseDimension)
+
+{- | A unit definition written the way the shipped table writes one: a dimension
+expression and a factor.
+
+A hand-written exponent vector is a copy of 'defaultDimensionOrder' with no
+author. It keeps parsing the day a slot is added or removed, so an example goes
+on comparing a kilogram of its own against a kilogram of the table's and finding
+them different dimensions - and only the examples that mix the two notice. Going
+through 'parseDimension' leaves the slot list one author.
+
+An expression the parser refuses yields an empty vector, which no unit has, so
+the example that asked for it fails rather than passing on a wrong shape.
+-}
+unitDef :: Text -> Double -> UnitDef
+unitDef dimExpr = UnitDef (fromRight [] (parseDimension defaultDimensionOrder dimExpr))
 
 {- | Run an example with the engine's data directory pointed at a scratch
 tree. Anything that writes there - an upload, a copy, an edit journal - then

--- a/test/TestHelpers.hs
+++ b/test/TestHelpers.hs
@@ -46,7 +46,10 @@ them different dimensions - and only the examples that mix the two notice. Going
 through 'parseDimension' leaves the slot list one author.
 
 An expression the parser refuses yields an empty vector, which no unit has, so
-the example that asked for it fails rather than passing on a wrong shape.
+it converts with nothing well formed beside it and the example that asked for
+it fails. Two refused expressions in one fixture are the hole in that: they
+share the empty vector, so they convert into one another at the ratio of their
+factors. Only a typo repeated across every row of a fixture reaches it.
 -}
 unitDef :: Text -> Double -> UnitDef
 unitDef dimExpr = UnitDef (fromRight [] (parseDimension defaultDimensionOrder dimExpr))

--- a/test/UnitConversionSpec.hs
+++ b/test/UnitConversionSpec.hs
@@ -9,6 +9,7 @@ import Data.Maybe (isNothing)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Test.Hspec
+import TestHelpers (unitDef)
 import UnitConversion
 
 -- Helper for testing Left results
@@ -41,22 +42,22 @@ loadFullUnitConfig = do
 spec :: Spec
 spec = do
     describe "Dimension Parsing" $ do
-        let dimOrder = ["mass", "length", "time", "energy", "area", "volume", "count", "currency"]
+        let dimOrder = defaultDimensionOrder
 
         it "parses single dimension" $ do
-            parseDimension dimOrder "mass" `shouldBe` Right [1, 0, 0, 0, 0, 0, 0, 0]
+            parseDimension dimOrder "mass" `shouldBe` Right [1, 0, 0, 0, 0, 0]
 
         it "parses product of dimensions (mass*length)" $ do
-            parseDimension dimOrder "mass*length" `shouldBe` Right [1, 1, 0, 0, 0, 0, 0, 0]
+            parseDimension dimOrder "mass*length" `shouldBe` Right [1, 1, 0, 0, 0, 0]
 
         it "parses division (length/time)" $ do
-            parseDimension dimOrder "length/time" `shouldBe` Right [0, 1, -1, 0, 0, 0, 0, 0]
+            parseDimension dimOrder "length/time" `shouldBe` Right [0, 1, -1, 0, 0, 0]
 
         it "parses repeated division (length/time/time)" $ do
-            parseDimension dimOrder "length/time/time" `shouldBe` Right [0, 1, -2, 0, 0, 0, 0, 0]
+            parseDimension dimOrder "length/time/time" `shouldBe` Right [0, 1, -2, 0, 0, 0]
 
         it "parses complex expression (mass*length/time)" $ do
-            parseDimension dimOrder "mass*length/time" `shouldBe` Right [1, 1, -1, 0, 0, 0, 0, 0]
+            parseDimension dimOrder "mass*length/time" `shouldBe` Right [1, 1, -1, 0, 0, 0]
 
         it "rejects empty expression" $
             parseDimension dimOrder "" `shouldSatisfy` isLeft
@@ -69,6 +70,47 @@ spec = do
 
         it "rejects unknown dimension in denominator" $
             parseDimension dimOrder "mass/velocity" `shouldSatisfy` isLeft
+
+        it "offers the shorthands as well as the slots when it refuses" $
+            first (T.isInfixOf "area") (parseDimension dimOrder "velocity") `shouldBe` Left True
+
+    {- A square metre is a length squared, so the two spellings have to land on
+    one vector: with a slot of its own, a density written "mass/volume" and one
+    written "mass/length/length/length" are two quantities that never convert,
+    and nothing downstream can notice that they should.
+    -}
+    describe "Area and volume are powers of length" $ do
+        let dimOrder = defaultDimensionOrder
+
+        it "reads an area as a length squared" $
+            parseDimension dimOrder "area" `shouldBe` parseDimension dimOrder "length*length"
+
+        it "reads a volume as a length cubed" $
+            parseDimension dimOrder "volume" `shouldBe` parseDimension dimOrder "length*length*length"
+
+        it "leaves a density one vector, whichever way the table writes it" $
+            parseDimension dimOrder "mass/volume" `shouldBe` parseDimension dimOrder "mass/length/length/length"
+
+        it "carries the power through a denominator" $
+            parseDimension dimOrder "count/area" `shouldBe` parseDimension dimOrder "count/length/length"
+
+        it "still tells an area from a volume" $ do
+            cfg <- loadFullUnitConfig
+            unitsCompatible cfg "m2" "m3" `shouldBe` False
+
+        it "converts an area and a volume as it did before" $ do
+            cfg <- loadFullUnitConfig
+            convertUnit cfg "ha" "m2" 1 `shouldBe` Just 10000
+            convertUnit cfg "l" "m3" 1 `shouldBe` Just 0.001
+
+    describe "The bootstrap table" $
+        it "stands its four units on the slots the shipped table parses into" $
+            mapM_
+                ( \(name, dim) ->
+                    (udDimension <$> M.lookup name (ucUnits defaultUnitConfig))
+                        `shouldBe` either (const Nothing) Just (parseDimension defaultDimensionOrder dim)
+                )
+                [("kg", "mass"), ("m", "length"), ("s", "time"), ("item", "count")]
 
     describe "Unit Compatibility" $ do
         it "tkm and kgkm are compatible (both mass*length)" $ do
@@ -284,7 +326,7 @@ spec = do
             readUnit cfg "mj" `shouldBe` ReadAmbiguous "MJ" "mJ" []
             lookupUnitDef cfg "mj" `shouldBe` Nothing
             isKnownUnit cfg "mj" `shouldBe` False
-            readUnit cfg "MJ" `shouldBe` ReadExact (UnitDef [0, 0, 0, 1, 0, 0, 0, 0] 1.0)
+            readUnit cfg "MJ" `shouldBe` ReadExact (unitDef "energy" 1.0)
 
         it "refuses a table that spells one unit twice" $ do
             buildFromCSV "name,dimension,factor\nkg,mass,1.0\nkg,mass,2.0\n"


### PR DESCRIPTION
## The problem

A unit's dimension is an exponent vector, and two of its eight slots were area and volume. Both are powers of length, so the table could describe one quantity two ways, and `unitsCompatible` judges on the vector alone: a density written `mass/volume` and one written `mass/length/length/length` would never have converted into one another, and nothing in the loader or the matrix build could notice that they should.

`data/units.csv` already writes both conventions. `m2` and `m3` are filed under `area` and `volume`; `kg/m3` and `kg/l` are filed under `mass/length/length/length`. The two halves happen not to meet today, which is the only reason no number is wrong.

This is the question #433 named as the one behind it: "correcting four strings without that decision would leave the table half in one convention and half in the other." The four strings themselves were carried away by #437.

## What the diff does

Area and volume become spellings rather than slots. `parseDimension` expands `area` into a length squared and `volume` into a length cubed, so both conventions land on one vector and neither can be written against the other. Six slots remain, and `area` and `volume` stay names a user may write in their own `[[units]]` table.

Energy keeps a slot of its own rather than becoming `mass*length*length/time/time`. The unit its characterization factors are authored in is `MJ`, and merging it would make a joule convert into a newton metre and so into a torque.

The specs stop hand-writing exponent vectors. `TestHelpers.unitDef` builds one through `parseDimension`, and `defaultUnitConfig` reads its four off the slot list.

## Worth a reader's attention

**No shipped unit changes what it converts into.** No row in the table is written in the other convention, so this removes a state that was representable rather than a conversion that was wrong. Every cache rebuilds once on the next load, because `BuildInputs` records the unit table a cache was built with and `builtWithDifference` refuses one built against another; there is no version to bump and no amount moves.

**A hand-written vector is a copy of the slot list with no author.** Nine spec files held one. Only the three that mixed a literal with `defaultUnitConfig` would have failed loudly, because `mkUnitConfig` never checks a vector's length against the dimension order; the other six would have gone on passing on a stale shape. Two of them already disagreed with each other about what `m3` is, one writing it as a length cubed and one as a length. That is the same defect as the one this PR is about, sitting inside the test suite.

**`data/` is untouched**, so no data version moves.

## Testing

`cabal test lca-tests` passes, 2570 examples. The new examples in `UnitConversionSpec` pin that `area` parses equal to `length*length`, `volume` to `length*length*length`, and `mass/volume` to `mass/length/length/length`; that a hectare and a litre still convert as before; and that an area and a volume are still told apart. Writing the volume shorthand as a squared length instead of a cubed one fails three of them.

Closes #433. The two leftovers that issue also named are filed separately, as #439 for the countable things that convert into one another at one to one, and #440 for the water scarcity indicator unit filed as a volume.
