### PR TITLE
Keep a result expression out of the quantity it is expressed per

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@
   ambiguities are documented where a reader looks for them.
 
 ### Changed
+- A water scarcity indicator's unit is no longer read as a volume.
+  `m3-world equivalents` is what such an indicator states its result in, a
+  cubic metre of water weighted by how scarce water is where it was taken, and
+  the shipped unit table filed it as a plain cubic metre at the reference
+  unit's own factor. It therefore converted into every other volume: an
+  exchange stated in it would link to a product in litres, and an amount
+  recorded in it came back named `m3`. It is now described as a result
+  expressed per a volume, a description nothing else in the table carries, so
+  nothing converts into it and nothing links against it. What a factor written
+  in it does is unchanged, because it is still read as written per cubic metre:
+  a water flow in litres reaches it, a flow in kilograms reaches it through the
+  density of water, and a flow in kilograms with no density is refused as
+  before. Data version 4. A cache records the unit table it was built with, so
+  every cache rebuilds itself from its source on the next load.
 - Area and volume are read as powers of length rather than as quantities of
   their own. A square metre is a length squared and a cubic metre a length
   cubed, but a unit table could write both conventions, so a density written

--- a/data/units.csv
+++ b/data/units.csv
@@ -96,7 +96,7 @@ cm3,volume,1e-06
 cm³,volume,1e-06
 gallon,volume,0.003785411784
 gal,volume,0.003785411784
-m3-world equivalents,volume,1.0
+m3-world equivalents,result*volume,1.0
 unit,count,1.0
 units,count,1.0
 p,count,1.0

--- a/src/Method/Mapping.hs
+++ b/src/Method/Mapping.hs
@@ -148,7 +148,7 @@ import qualified SubstanceRegistry as SR
 import SynonymDB
 import Types (Activity (..), BioFlowDB, BiosphereFlow (..), Database (..), FlowClosure (..), Medium (..), ProcessId, SparseTriple (..), Unit (..), UnitDB, ownFlowClosure, parseMedium)
 import qualified Types as VT
-import UnitConversion (UnitConfig, convertUnit, isKnownUnit, normalizeToCanonical, unitKey, unitsCompatible)
+import UnitConversion (UnitConfig, convertOntoFactorBasis, convertUnit, isKnownUnit, normalizeToCanonical, unitKey)
 
 -- | Matching strategy used to find a flow
 data MatchStrategy
@@ -1816,9 +1816,11 @@ convertedQuantity (Unconvertible _) = 0
 expects, for characterization.
 
   * Units match, or the flow carries no unit → @qty@ unchanged.
-  * Both units known to the 'UnitConfig' → ordinary same-dimension conversion;
-    a dimensional mismatch (flow @m@, CF @kg@) hard-fails to @0@ rather than
-    injecting wrong-dimension data into the score.
+  * Both units known to the 'UnitConfig' → ordinary same-dimension conversion,
+    read onto the basis the CF is written per, so a factor in
+    @"m3-world equivalents"@ is reached by a flow in litres
+    ('convertOntoFactorBasis'); a dimensional mismatch (flow @m@, CF @kg@)
+    hard-fails to @0@ rather than injecting wrong-dimension data into the score.
   * The CF unit is a result expression unknown to the 'UnitConfig' (e.g.
     @"kg CO2 eq"@ — the common ILCD/EF case, where 'mcfUnit' carries the impact
     unit, not the flow's reference unit) → the CF value is defined per the
@@ -1845,7 +1847,7 @@ characterizationOutcome cfg flowUnit (CFUnit cfu) qty
         maybe
             (Unconvertible (DimensionalMismatch flowUnit cfu))
             (`Converted` UnitConverted flowUnit cfu)
-            (convertUnit cfg flowUnit cfu qty)
+            (convertOntoFactorBasis cfg flowUnit cfu qty)
     | otherwise =
         maybe
             (Unconvertible (NoCanonicalBase flowUnit))
@@ -2730,26 +2732,31 @@ energyAwareOutcome cfg flowUnit cfu@(CFUnit rawCfUnit) mDensity qty =
         Just density@(EnergyDensity ev targetUnit nativeUnit)
             | crossDimension
             , ev > 0
-            , unitsCompatible cfg rawCfUnit targetUnit ->
+            , cfIsWrittenPer targetUnit ->
                 bridged density DensityForward $ do
                     qtyNative <- toUnit nativeUnit
-                    factor <- convertUnit cfg targetUnit rawCfUnit ev
+                    factor <- convertOntoFactorBasis cfg targetUnit rawCfUnit ev
                     pure (qtyNative * factor)
             | crossDimension
             , ev > 0
-            , unitsCompatible cfg rawCfUnit nativeUnit ->
+            , cfIsWrittenPer nativeUnit ->
                 bridged density DensityInverse $ do
                     qtyTarget <- toUnit targetUnit
-                    convertUnit cfg nativeUnit rawCfUnit (qtyTarget / ev)
+                    convertOntoFactorBasis cfg nativeUnit rawCfUnit (qtyTarget / ev)
         _ -> characterizationOutcome cfg flowUnit cfu qty
   where
     bridged density dir =
         maybe (Unconvertible (EnergyBridgeRefused density)) (`Converted` EnergyBridged density dir)
+    -- What the CF is written per, which for a result expression the table holds
+    -- ("m3-world equivalents") is the quantity the result is expressed per, and
+    -- for one it does not know ("kg CO2 eq") is nothing, so that one is never
+    -- bridged.
+    cfIsWrittenPer :: Text -> Bool
+    cfIsWrittenPer u = isJust (convertOntoFactorBasis cfg rawCfUnit u 1)
     -- Both arms need the flow's unit to be unreachable from the CF's: a
-    -- same-dimension pair belongs to the ordinary conversion, and a CF unit the
-    -- config does not know (a result expression like "kg CO2 eq") is compatible
-    -- with neither leg, so it is never bridged.
-    crossDimension = not (unitsCompatible cfg rawCfUnit flowUnit)
+    -- same-dimension pair belongs to the ordinary conversion.
+    crossDimension :: Bool
+    crossDimension = not (cfIsWrittenPer flowUnit)
     -- Bring the inventory quantity into the leg the arm applies the density
     -- against: identical units need no table entry, otherwise a same-dimension
     -- conversion. An incompatible or unknown unit yields 'Nothing' → 0.

--- a/src/UnitConversion.hs
+++ b/src/UnitConversion.hs
@@ -34,6 +34,7 @@ module UnitConversion (
     isKnownUnit,
     unitsCompatible,
     convertUnit,
+    convertOntoFactorBasis,
     lookupUnitDef,
     canonicalUnitFor,
     normalizeToCanonical,
@@ -71,11 +72,15 @@ import GHC.Generics (Generic)
 import Progress (ProgressLevel (Info), reportProgress)
 
 {- | Dimension as exponent vector.
-Order: [mass, length, time, energy, count, currency]
+Order: [mass, length, time, energy, count, currency, result]
 
 Area and volume are not among them: they are powers of length, and a table
 free to write both spellings is a table where one quantity has two vectors
 that never convert. 'dimensionShorthands' is where the two are spent.
+
+@result@ is the mirror of that argument and the reason 'resultDimension'
+exists: two things that must never convert into one another cannot share a
+vector, because the vector is the whole of what decides.
 -}
 type Dimension = [Int]
 
@@ -110,7 +115,23 @@ instance Store UnitConfig
 
 -- | Default dimension order.
 defaultDimensionOrder :: [Text]
-defaultDimensionOrder = ["mass", "length", "time", "energy", "count", "currency"]
+defaultDimensionOrder = ["mass", "length", "time", "energy", "count", "currency", resultDimension]
+
+{- | The slot that separates a result expression from the quantity it is
+expressed per.
+
+@m3-world equivalents@ is what a water scarcity indicator states its result in:
+a cubic metre of water weighted by how scarce water is where it was taken. It
+is not a volume, and an exchange may not be stated in it, but a factor written
+in it is written per cubic metre. Writing it @result*volume@ keeps both facts:
+nothing converts it into a litre, and 'convertOntoFactorBasis' still reads it
+as a factor per cubic metre.
+
+A unit of the quantity itself leaves this slot at zero, which is every other
+row of the table.
+-}
+resultDimension :: Text
+resultDimension = "result"
 
 {- | The dimension names that stand for a power of a base dimension.
 
@@ -217,12 +238,43 @@ unitsCompatible cfg u1 u2 =
 Returns Nothing if units are incompatible or unknown.
 -}
 convertUnit :: UnitConfig -> Text -> Text -> Double -> Maybe Double
-convertUnit cfg fromUnit toUnit amount = do
+convertUnit = convertRead id
+
+{- | Convert an amount onto the basis a characterization factor is written per.
+
+'convertUnit' with one difference: a result expression is read as the quantity
+its result is expressed per, so a factor in @m3-world equivalents@ is reached
+by a flow in litres and not by one in kilograms. Characterization is the only
+question that wants that reading. Everywhere else a result expression is a
+thing no exchange may be stated in and nothing may link against, which is what
+'convertUnit' and 'unitsCompatible' answer.
+-}
+convertOntoFactorBasis :: UnitConfig -> Text -> Text -> Double -> Maybe Double
+convertOntoFactorBasis cfg = convertRead (onFactorBasis (ucDimensionOrder cfg)) cfg
+
+{- | 'convertUnit' and 'convertOntoFactorBasis', which differ only in how each
+reads a dimension before comparing two of them.
+-}
+convertRead :: (Dimension -> Dimension) -> UnitConfig -> Text -> Text -> Double -> Maybe Double
+convertRead readDim cfg fromUnit toUnit amount = do
     UnitDef dimFrom factorFrom <- lookupUnitDef cfg fromUnit
     UnitDef dimTo factorTo <- lookupUnitDef cfg toUnit
-    if dimFrom == dimTo && factorTo /= 0
+    if readDim dimFrom == readDim dimTo && factorTo /= 0
         then Just (amount * factorFrom / factorTo)
         else Nothing
+
+{- | A dimension with its 'resultDimension' slot spent: what a factor written
+in that unit is written per.
+
+Read by the slot's index, not by walking the two lists together: an order
+shorter than the vectors would otherwise drop the slots past its end, and every
+dimension would compare equal to every other.
+-}
+onFactorBasis :: [Text] -> Dimension -> Dimension
+onFactorBasis dimOrder = maybe id zeroAt (elemIndex resultDimension dimOrder)
+  where
+    zeroAt :: Int -> Dimension -> Dimension
+    zeroAt idx = zipWith (\slot e -> if slot == idx then 0 else e) [0 :: Int ..]
 
 {- | Canonical (reference) unit name for the dimension of a given unit.
 

--- a/test/EnergyDensityCFSpec.hs
+++ b/test/EnergyDensityCFSpec.hs
@@ -134,10 +134,10 @@ waterFlowIn unitId = (coalFlowIn unitId){bfId = waterId, bfName = "Water"}
 volumeCF :: MethodCF
 volumeCF = energyCF{mcfFlowRef = waterId, mcfFlowName = "Water", mcfValue = 42.95, mcfUnit = "m3"}
 
--- The same factor as the JRC ILCD collection actually writes it: the method's
--- reference quantity is a result expression, "m3-world equivalents", and the
--- parser copies that string onto every factor. It is not a volume, but it is
--- written per one.
+-- The same factor as the ILCD collection carrying this indicator writes it:
+-- the method's reference quantity is a result expression,
+-- "m3-world equivalents", and the parser copies that string onto every factor.
+-- It is not a volume, but it is written per one.
 volumeResultCF :: MethodCF
 volumeResultCF = volumeCF{mcfUnit = "m3-world equivalents"}
 

--- a/test/EnergyDensityCFSpec.hs
+++ b/test/EnergyDensityCFSpec.hs
@@ -55,7 +55,7 @@ import UnitConversion (UnitConfig, buildFromCSV, defaultUnitConfig)
 unitConfig :: UnitConfig
 unitConfig =
     fromRight defaultUnitConfig $
-        buildFromCSV (BLC.pack "name,dimension,factor\nkg,mass,1.0\ntonne,mass,1000.0\nm3,volume,1.0\nmj,energy,1.0\n")
+        buildFromCSV (BLC.pack "name,dimension,factor\nkg,mass,1.0\ntonne,mass,1000.0\nm3,volume,1.0\nmj,energy,1.0\nm3-world equivalents,result*volume,1.0\n")
 
 uidKg, uidTonne, uidM3, uidMJ :: UUID
 uidKg = UUID.fromWords64 1 0
@@ -133,6 +133,13 @@ waterFlowIn unitId = (coalFlowIn unitId){bfId = waterId, bfName = "Water"}
 -- A volume-denominated CF (an AWARE-style water-scarcity factor per m³).
 volumeCF :: MethodCF
 volumeCF = energyCF{mcfFlowRef = waterId, mcfFlowName = "Water", mcfValue = 42.95, mcfUnit = "m3"}
+
+-- The same factor as the JRC ILCD collection actually writes it: the method's
+-- reference quantity is a result expression, "m3-world equivalents", and the
+-- parser copies that string onto every factor. It is not a volume, but it is
+-- written per one.
+volumeResultCF :: MethodCF
+volumeResultCF = volumeCF{mcfUnit = "m3-world equivalents"}
 
 -- A per-kilogram water CF — the shape a non-regionalized method takes when it
 -- writes water deprivation against a mass basis instead of a volume one.
@@ -241,6 +248,28 @@ spec = do
         it "still scores 0 without a density (cross-dimensional, no bridge)" $ do
             let flow = waterFlowIn uidKg
                 tables = tablesFor flow M.empty volumeCF
+            scoreFlow flow 1.0 tables `shouldSatisfy` near 0
+
+    -- The factor as the collection writes it, in a result expression rather
+    -- than in a unit. The three cases above have to come out the same, because
+    -- the factor is the same factor: what the result is expressed in says
+    -- nothing about what it is written per. This is also what says the row may
+    -- not simply leave data/units.csv — take it away and the first case stops
+    -- bridging and scores the kilogram under a per-cubic-metre factor.
+    describe "The same factor written as a result expression" $ do
+        it "bridges a kg flow exactly as the per-m3 spelling does" $ do
+            let flow = waterFlowIn uidKg
+                tables = tablesFor flow waterDensities volumeResultCF
+            scoreFlow flow 1.0 tables `shouldSatisfy` near (0.001 * 42.95)
+
+        it "leaves a flow already in the unit the factor is written per untouched" $ do
+            let flow = waterFlowIn uidM3
+                tables = tablesFor flow waterDensities volumeResultCF
+            scoreFlow flow 1.0 tables `shouldSatisfy` near 42.95
+
+        it "refuses a kg flow with no density rather than scoring the kilogram" $ do
+            let flow = waterFlowIn uidKg
+                tables = tablesFor flow M.empty volumeResultCF
             scoreFlow flow 1.0 tables `shouldSatisfy` near 0
 
     describe "Density bridge, inverse direction: mass CF vs. volume flow" $ do

--- a/test/UnitConversionSpec.hs
+++ b/test/UnitConversionSpec.hs
@@ -45,19 +45,19 @@ spec = do
         let dimOrder = defaultDimensionOrder
 
         it "parses single dimension" $ do
-            parseDimension dimOrder "mass" `shouldBe` Right [1, 0, 0, 0, 0, 0]
+            parseDimension dimOrder "mass" `shouldBe` Right [1, 0, 0, 0, 0, 0, 0]
 
         it "parses product of dimensions (mass*length)" $ do
-            parseDimension dimOrder "mass*length" `shouldBe` Right [1, 1, 0, 0, 0, 0]
+            parseDimension dimOrder "mass*length" `shouldBe` Right [1, 1, 0, 0, 0, 0, 0]
 
         it "parses division (length/time)" $ do
-            parseDimension dimOrder "length/time" `shouldBe` Right [0, 1, -1, 0, 0, 0]
+            parseDimension dimOrder "length/time" `shouldBe` Right [0, 1, -1, 0, 0, 0, 0]
 
         it "parses repeated division (length/time/time)" $ do
-            parseDimension dimOrder "length/time/time" `shouldBe` Right [0, 1, -2, 0, 0, 0]
+            parseDimension dimOrder "length/time/time" `shouldBe` Right [0, 1, -2, 0, 0, 0, 0]
 
         it "parses complex expression (mass*length/time)" $ do
-            parseDimension dimOrder "mass*length/time" `shouldBe` Right [1, 1, -1, 0, 0, 0]
+            parseDimension dimOrder "mass*length/time" `shouldBe` Right [1, 1, -1, 0, 0, 0, 0]
 
         it "rejects empty expression" $
             parseDimension dimOrder "" `shouldSatisfy` isLeft
@@ -233,8 +233,31 @@ spec = do
                     , ("kg*day", Just "kgy")
                     , ("km*year", Just "my")
                     , ("passenger-km", Just "pkm")
+                    , -- A result expression is the reference of its own
+                      -- dimension and of nothing else, which is what keeps it
+                      -- from being the unit an amount is recorded in.
+                      ("m3-world equivalents", Just "m3-world equivalents")
                     ]
             map (fmap T.toLower . canonicalUnitFor cfg . fst) canonicals `shouldBe` map snd canonicals
+
+        -- A water scarcity indicator states its result in cubic metres of water
+        -- weighted by how scarce water is where it was taken. That is not a
+        -- volume, and the dimension vector is the whole of what decides what
+        -- converts into what, so it may not carry a volume's. Filed as one it
+        -- was the reference unit's equal: an exchange stated in it linked to a
+        -- product in litres, and an amount recorded in it came back named m3.
+        it "keeps a result expression out of the volume it is expressed per" $ do
+            cfg <- loadFullUnitConfig
+            unitsCompatible cfg "m3-world equivalents" "gallon" `shouldBe` False
+            convertUnit cfg "l" "m3-world equivalents" 1.0 `shouldBe` Nothing
+
+        -- The other half: characterization has to see through the distinction,
+        -- because a factor written in that result *is* written per cubic metre.
+        -- A flow in litres reaches it; one in kilograms does not.
+        it "still reads a result expression as the quantity it is written per" $ do
+            cfg <- loadFullUnitConfig
+            convertOntoFactorBasis cfg "l" "m3-world equivalents" 1.0 `shouldBe` Just 1.0e-3
+            convertOntoFactorBasis cfg "kg" "m3-world equivalents" 1.0 `shouldBe` Nothing
 
         -- A dimension with no row at 1.0 has no reference unit, so
         -- 'normalizeToCanonical' answers Nothing and the amount is recorded in


### PR DESCRIPTION
## The problem

`data/units.csv` filed `m3-world equivalents` as a volume at 1.0. That is not a
volume. It is the unit a water scarcity indicator states its result in, a cubic
metre of water weighted by how scarce water is where it was taken, which is why
the spelling carries "world equivalents" at all. Filed as a volume at the
reference unit's own factor, it was a plain cubic metre's equal.

The dimension vector is the whole of what `unitsCompatible` and `convertUnit`
judge on, so the row converted into every other volume.
`convertUnit cfg "l" "m3-world equivalents" 1` answered `Just 1.0e-3` and
`unitsCompatible cfg "m3-world equivalents" "gallon"` answered `True`, so an
exchange stated in world equivalents and a product stated in litres would link;
`normalizeToCanonical` answered `m3` for it, so an amount recorded in a
weighted unit came back named as an unweighted one.

The row could not simply leave the table, which is what the issue proposed. It
is there for the density bridge: `energyAwareOutcome` asks whether the factor's
unit is compatible with the density's target unit, `m3` for water. With no row
that question answers no, a water flow in kilograms stops bridging, and it
falls to the arm that reads a result expression as written per the flow's own
canonical base, where the kilogram is left untouched under a factor written per
cubic metre. The refusal a kilogram flow gets today when no density applies
would go the same way.

## What the diff does

The table says what the row is. `result` becomes a slot in the dimension
vector and the row is written `result*volume`, a description nothing else in
the table carries. Every question about what an exchange may be stated in, or
linked to, or recorded as, then refuses it through the comparison it already
makes, with no gate for anyone to forget at the next call site.

Characterization is the one question that has to see through the distinction,
because a factor written in that result is written per cubic metre. It asks
through `convertOntoFactorBasis`, which is `convertUnit` with the result slot
spent, and `Method.Mapping` is its only caller. Every characterization case
comes out where it was: a water flow in litres converts at 0.001, one in
kilograms bridges through the density of water, one in kilograms with no
density is refused rather than scored.

## Worth a reader's attention

**Every cache rebuilds itself.** `BuildInputs` records the unit table a cache
was built with, so the next load rebuilds from source. No stored amount moves:
no database states an exchange in this unit.

**`onFactorBasis` reads the slot by its index.** Walking the dimension order
and the vector together looks tidier and is wrong: a config whose order is
shorter than its vectors drops every slot past the end, and every dimension
then compares equal to every other. A spec that builds a config with an empty
order caught it.

**This is one spelling, not the class.** It is the spelling the ILCD
collections carrying this indicator write, and it is the one the table holds. A
method that writes the same result another way, `m3 world eq` among them, still
reaches the arm that reads a result expression as written per the flow's own
canonical base, and a kilogram flow against it is still scored as a kilogram.
What a result expression is written per, in general, is a larger question, and
the obvious rule does not survive the data: `dimensionless (pt)` begins with a
unit the table holds and is not written per it.

## How to test

```
cabal test lca-tests
```

Put `volume` back on the row in `data/units.csv` and two cases of
`UnitConversionSpec` fail, which is what says they reach the shipped table.
`EnergyDensityCFSpec` scores the same factor under both spellings, and is what
says the row may not simply leave.

Closes #440. Data version 4.
