### PR TITLE
Read a guest night as a count over a time, not as a count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@
   ambiguities are documented where a reader looks for them.
 
 ### Changed
+- A guest night is no longer read as a plain count. It is one guest for one
+  night, a count over a time, and the shipped unit table filed it beside
+  `piece`, `item` and `TEU` at the reference unit's own factor. Every spelling
+  of a count therefore converted into it at 1.0, reading one shipping container
+  or one piece as one night of one guest, and an exchange stated in either
+  would link to a product stated in the other. What a unit is described as is
+  the whole of what decides that, so nothing downstream could notice. It is now
+  described as a count over a time, the way `kgy` is described as a mass over a
+  time, and it is the reference unit of that description since the table holds
+  no other spelling of one. A reference product stated in guest nights is
+  therefore recorded under `guestnight` where it used to be recorded under `p`,
+  which moves that product flow's identifier and the activity's process id.
+  `TEU` stays a count, of shipping containers, which is what a count is for.
+  Data version 4. A cache records the unit table it was built with, so every
+  cache rebuilds itself from its source on the next load.
 - A water scarcity indicator's unit is no longer read as a volume.
   `m3-world equivalents` is what such an indicator states its result in, a
   cubic metre of water weighted by how scarce water is where it was taken, and

--- a/data/units.csv
+++ b/data/units.csv
@@ -106,8 +106,8 @@ pieces,count,1.0
 item,count,1.0
 items,count,1.0
 dimensionless,count,1.0
-guest night,count,1.0
-guestnight,count,1.0
+guest night,count*time,1.0
+guestnight,count*time,1.0
 TEU,count,1.0
 EUR,currency,1.0
 EUR2005,currency,1.0

--- a/test/UnitConversionSpec.hs
+++ b/test/UnitConversionSpec.hs
@@ -233,6 +233,7 @@ spec = do
                     , ("kg*day", Just "kgy")
                     , ("km*year", Just "my")
                     , ("passenger-km", Just "pkm")
+                    , ("guest night", Just "guestnight")
                     , -- A result expression is the reference of its own
                       -- dimension and of nothing else, which is what keeps it
                       -- from being the unit an amount is recorded in.
@@ -302,6 +303,17 @@ spec = do
             cfg <- loadFullUnitConfig
             unitsCompatible cfg "kgy" "kg*year" `shouldBe` True
             unitsCompatible cfg "kgy" "unit" `shouldBe` False
+
+        -- A guest night is one guest for one night, a count over a time, and
+        -- the table filed it as a bare count. Every spelling of a count then
+        -- converted into it at 1.0, reading one piece or one shipping
+        -- container as one night of one guest, and the dimension vector is the
+        -- whole of what decides, so nothing downstream could notice.
+        it "reads a guest night as a count over a time, not as a count" $ do
+            cfg <- loadFullUnitConfig
+            unitsCompatible cfg "guest night" "guestnight" `shouldBe` True
+            unitsCompatible cfg "guest night" "p" `shouldBe` False
+            unitsCompatible cfg "guest night" "TEU" `shouldBe` False
 
         it "returns Nothing for incompatible units" $ do
             cfg <- loadFullUnitConfig


### PR DESCRIPTION
## The problem

`data/units.csv` filed twelve spellings under `count`, every one at factor 1.0,
`guest night`, `guestnight` and `TEU` among them. The dimension is the whole of
what `unitsCompatible` and `convertUnit` judge on, so every pair of the twelve
converted into every other at 1.0. `convertUnit cfg "TEU" "guest night" 1`
answered `Just 1.0`, reading one shipping container as one night of one guest,
and `unitsCompatible cfg "TEU" "piece"` answered `True`, so the two gates that
accept a link between an exchange and a product, in `Database.Loader` and
`Database.CrossLinking`, accepted one stated in either.

Ten of the twelve are genuinely one thing under ten names: a piece, an item and
a unit are one countable object, and treating them as interchangeable is what a
count is for. A guest night is not a count at all. It is one guest for one
night, a count over a time, the same shape as the `kgy` that #437 moved out of
this bucket and into a mass over a time.

No corpus database has been shown to state an exchange in one of these against
a product in another, so this was a latent silent conversion rather than an
observed wrong number. It is worth fixing anyway, because the failure is silent
by construction: with the dimension wrong there is nothing left for anything
downstream to notice with.

## What the diff does

The two guest night rows move to `count*time` at 1.0. Nothing else in the table
carries that dimension, so the guest night is its reference unit, which is the
same choice `kgy`, `pkm`, `m2a` and `tkm` already make: the unit the data is
authored in rather than the SI product of the parts, which nobody writes. #437
requires every dimension to declare one, and the test that says so stays green.

A guest night no longer converts into a piece, an item or a container, and no
longer links against a product stated in one. Two tests say so: the new case,
and the entry added to the list that pins the reference unit of every dimension,
so the election between the two spellings is deliberate rather than an accident
of which sorts first. `mkUnitConfig` elects `guestnight`, being the shorter.

`TEU` stays a count, of shipping containers. A count cannot know what is being
counted, which is why `piece` and `item` share it too; whether a container
should convert into a piece is the separate judgement the issue asks to keep
separate, and removing the row would make every amount stated in it unreadable
in a source that does not declare its own unit table.

## Worth a reader's attention

A reference product stated in guest nights is recorded in the reference unit of
its dimension, which was `p` and is now `guestnight`. The product flow's UUID
derives from the unit name, and the process id from the flow, so both move for
such an activity. This is the same disclosure #437 made for its own move. A
cache records the unit table it was built with, so every cache rebuilds itself
from its source on the next load.

`data/VERSION` is already 4 against 3 at `v0.12.0`, so it needs no bump;
`scripts/check-data-version.sh` agrees. The CHANGELOG entry names it.

## How to check

```
./gen-version.sh
cabal test lca-tests --test-options='--match "/UnitConversion/"'
```

With the two test hunks applied and the table left alone, two examples fail:
the new case, and the canonical pin, which answers `Just "p"` for a guest night
today. With the table row moved as well, `73 examples, 0 failures`. The whole
suite is green here, `2576 examples, 0 failures, 2 pending`, and
`./scripts/check-data-version.sh` passes.

Closes #439
