### PR TITLE
Detect a repeated key in one place

### DIFF
--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -59,6 +59,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as BL
 import Data.Char (isAsciiUpper, ord, toUpper)
+import Data.Indexing (repeated)
 import Data.List (find, findIndex, partition)
 import qualified Data.Map.Strict as M
 import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing, listToMaybe, mapMaybe, maybeToList)
@@ -262,11 +263,7 @@ carries a value; the reader is told which labels rather than losing a column in
 silence.
 -}
 duplicateLabels :: [(Int, Text)] -> [Text]
-duplicateLabels headers =
-    [ lbl
-    | (lbl, n) <- M.toList (M.fromListWith (+) [(lbl, 1 :: Int) | (_, lbl) <- headers])
-    , n > 1
-    ]
+duplicateLabels headers = repeated [lbl | (_, lbl) <- headers]
 
 -- ---------------------------------------------------------------------------
 -- Domain construction (pure)

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -70,6 +70,7 @@ module Config (
 
 import Builtin (BuiltinTable (..), DataVersion (..), builtinDataVersion, builtinName)
 import Control.Monad (forM_, unless, when)
+import Data.Indexing (repeated)
 import Data.List (find, isPrefixOf)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
@@ -971,19 +972,19 @@ validateConfig :: Config -> Either Text Config
 validateConfig cfg = do
     -- Check for duplicate database names
     let dbNames = map dcName (cfgDatabases cfg)
-        duplicates = findDuplicates dbNames
+        duplicates = repeated dbNames
     unless (null duplicates) $
         Left $
             "Duplicate database names: " <> T.intercalate ", " duplicates
 
     -- A duplicate name would silently shadow one of its bearers everywhere the
     -- name is the key (preset expansion, method lookup), so refuse it up front.
-    let presetDupes = findDuplicates (map cpName (cfgClassificationPresets cfg))
+    let presetDupes = repeated (map cpName (cfgClassificationPresets cfg))
     unless (null presetDupes) $
         Left $
             "Duplicate classification preset names: " <> T.intercalate ", " presetDupes
 
-    let methodDupes = findDuplicates (map mcName (cfgMethods cfg))
+    let methodDupes = repeated (map mcName (cfgMethods cfg))
     unless (null methodDupes) $
         Left $
             "Duplicate method collection names: " <> T.intercalate ", " methodDupes
@@ -1008,15 +1009,6 @@ validateConfig cfg = do
     case resolveLoadOrder allLoaded of
         Left err -> Left err
         Right _ -> Right cfg
-
--- | Find duplicates in a list
-findDuplicates :: (Eq a) => [a] -> [a]
-findDuplicates = go [] []
-  where
-    go _ dups [] = dups
-    go seen dups (x : rest)
-        | x `elem` seen = go seen (if x `elem` dups then dups else x : dups) rest
-        | otherwise = go (x : seen) dups rest
 
 {- | Expand load=true transitively through depends, then topologically sort.
 Returns Left on cycle, Right with ordered list of DB names to load.

--- a/src/Data/Indexing.hs
+++ b/src/Data/Indexing.hs
@@ -1,0 +1,48 @@
+{- | Building an index asserts that the key determines the value. This module
+holds the three things there are to do when a key turns out not to.
+
+'Data.Map.fromList' keeps the last row of a repeated key and says nothing, so a
+list read out of a file - where nothing guarantees the key is a primary key -
+needs one of these instead:
+
+* 'uniqueIndex' refuses, naming the keys that repeat. For a table where two rows
+  give two answers and nothing can choose between them.
+* 'collisions' hands back every row a key carried, so the caller can say what
+  they disagreed on. For a message that has to name both.
+* 'repeated' answers the yes-or-no version: which keys appear more than once.
+
+Keeping all the rows instead of refusing is 'Data.Map.fromListWith', which needs
+no help from here; pass @flip (<>)@ to keep them in the order they were read.
+-}
+module Data.Indexing (
+    repeated,
+    collisions,
+    uniqueIndex,
+) where
+
+import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as M
+
+-- | The keys a list carries more than once, ascending, each named once.
+repeated :: (Ord k) => [k] -> [k]
+repeated ks = M.keys (M.filter (> (1 :: Int)) (M.fromListWith (+) [(k, 1) | k <- ks]))
+
+{- | The keys carried by more than one row, each with every row it carried, in
+the order the rows were given.
+-}
+collisions :: (Ord k) => [(k, v)] -> [(k, NonEmpty v)]
+collisions kvs =
+    [ (k, vs)
+    | (k, vs) <- M.toList (M.fromListWith (flip (<>)) [(k, v :| []) | (k, v) <- kvs])
+    , NE.length vs > 1
+    ]
+
+{- | Index rows on a key that must not repeat, or refuse and name the keys that
+did. The caller owns the wording: a unit table and a method archive fail for the
+same reason and do not say it the same way.
+-}
+uniqueIndex :: (Ord k) => [(k, v)] -> Either (NonEmpty k) (M.Map k v)
+uniqueIndex kvs = case repeated (map fst kvs) of
+    [] -> Right (M.fromList kvs)
+    (k : ks) -> Left (k :| ks)

--- a/src/Database/Author.hs
+++ b/src/Database/Author.hs
@@ -67,6 +67,7 @@ module Database.Author (
 
 import qualified Data.ByteString as BS
 import Data.Either (partitionEithers)
+import Data.Indexing (repeated)
 import Data.List (nub)
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
@@ -261,7 +262,7 @@ validateAuthored ctx activities =
     case partitionEithers (map (validateOne ctx) activities) of
         ([], oks) ->
             let inserts = map fst oks
-             in case duplicateKeys (map riKey inserts) of
+             in case repeated (map riKey inserts) of
                     [] -> Right (inserts, concatMap snd oks)
                     dups -> Left (map duplicateMessage dups)
         (errs, _) -> Left (concat errs)
@@ -272,9 +273,6 @@ validateAuthored ctx activities =
             <> "_"
             <> UUID.toText p
             <> "): same name, location, product and unit."
-
-duplicateKeys :: [(UUID, UUID)] -> [(UUID, UUID)]
-duplicateKeys keys = M.keys (M.filter (> (1 :: Int)) (M.fromListWith (+) [(k, 1) | k <- keys]))
 
 validateOne :: AuthorContext -> AuthoredActivity -> Either [Text] (ResolvedInsert, [Text])
 validateOne ctx a =

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -144,7 +144,10 @@ import Data.Bifunctor (first)
 import Data.Char (toLower)
 import qualified Data.Csv as Csv
 import Data.Either (fromRight, lefts, partitionEithers, rights)
+import Data.Indexing (uniqueIndex)
 import Data.List (intercalate, isPrefixOf, sort, sortOn)
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import Data.Maybe (catMaybes, fromMaybe, isNothing, mapMaybe)
@@ -4540,14 +4543,13 @@ parseGeographies :: Text -> BS.ByteString -> Either Text (Map Text (Text, [Text]
 parseGeographies label bytes = do
     content <- first (\decodeErr -> label <> ": not valid UTF-8 (" <> T.pack (show decodeErr) <> ")") (TE.decodeUtf8' bytes)
     rows <- first (\err -> label <> ": " <> T.pack err) (Csv.decode Csv.NoHeader (BL.fromStrict (TE.encodeUtf8 (T.unlines (filter meaningful (T.lines content))))))
-    let parsed = map entry (V.toList rows)
-        dups = M.keys (M.filter (> (1 :: Int)) (M.fromListWith (+) [(fst p, 1) | p <- parsed]))
     -- A duplicated code would silently shadow the earlier row in the map;
     -- refuse the table instead.
-    if null dups
-        then Right (M.fromList parsed)
-        else Left (label <> ": duplicate codes: " <> T.intercalate ", " dups)
+    first duplicateCodes (uniqueIndex (map entry (V.toList rows)))
   where
+    duplicateCodes :: NonEmpty Text -> Text
+    duplicateCodes codes = label <> ": duplicate codes: " <> T.intercalate ", " (NE.toList codes)
+
     meaningful :: Text -> Bool
     meaningful line =
         let stripped = T.strip line

--- a/src/ILCD/Writer.hs
+++ b/src/ILCD/Writer.hs
@@ -67,6 +67,7 @@ module ILCD.Writer (
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import Data.Either (lefts)
+import Data.Indexing (repeated)
 import Data.List (sortOn)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
@@ -114,9 +115,7 @@ ilcdExportNamespace =
 
 -- | The activity UUIDs carried by more than one @(activity, product)@ entry.
 sharedActivityUUIDs :: SimpleDatabase -> S.Set UUID
-sharedActivityUUIDs db =
-    M.keysSet . M.filter (> (1 :: Int)) . M.fromListWith (+) $
-        [(actUUID, 1) | (actUUID, _) <- M.keys (sdbActivities db)]
+sharedActivityUUIDs db = S.fromList (repeated [actUUID | (actUUID, _) <- M.keys (sdbActivities db)])
 
 {- | The @common:UUID@ — and the filename — of one exported process dataset.
 

--- a/src/Method/WriterILCD.hs
+++ b/src/Method/WriterILCD.hs
@@ -53,7 +53,10 @@ module Method.WriterILCD (
 ) where
 
 import qualified Data.ByteString as BS
+import Data.Indexing (collisions)
 import Data.List (sortOn)
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import Data.Maybe (catMaybes, fromMaybe, listToMaybe, mapMaybe, maybeToList)
 import Data.Text (Text)
@@ -110,14 +113,16 @@ checkIlcdMethodExportable mc = do
     firstError (concatMap methodErrors ms)
     firstError (map flowConflict (M.toList (flowDefs ms)))
   where
-    duplicateIds ms =
-        M.toList $ M.filter ((> 1) . length) $ M.fromListWith (++) [(methodId m, [methodName m]) | m <- ms]
+    duplicateIds :: [Method] -> [(UUID, NonEmpty Text)]
+    duplicateIds ms = collisions [(methodId m, methodName m) | m <- ms]
+
+    noDuplicateId :: (UUID, NonEmpty Text) -> Maybe Text
     noDuplicateId (u, names) =
         Just $
             "Two methods share the id "
                 <> UUID.toText u
                 <> " ("
-                <> T.intercalate ", " names
+                <> T.intercalate ", " (NE.toList names)
                 <> "); their ILCD files would overwrite each other."
 
 methodErrors :: Method -> [Maybe Text]

--- a/src/Method/WriterOlcaSchema.hs
+++ b/src/Method/WriterOlcaSchema.hs
@@ -31,8 +31,9 @@ import Data.Aeson.Encoding (Encoding, Series, encodingToLazyByteString, list, pa
 import qualified Data.Aeson.Key as K
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
+import Data.Indexing (collisions)
 import Data.List (sortOn)
-import qualified Data.Map.Strict as M
+import qualified Data.List.NonEmpty as NE
 import Data.Maybe (mapMaybe)
 import qualified Data.Set as S
 import Data.Text (Text)
@@ -166,14 +167,14 @@ checkOlcaExportable mc
         mapM_ checkMethod (mcMethods mc)
   where
     checkUniqueIds ms =
-        case M.toList (M.filter ((> 1) . length) (M.fromListWith (<>) [(methodId m, [methodName m]) | m <- ms])) of
+        case collisions [(methodId m, methodName m) | m <- ms] of
             [] -> Right ()
             (mid, names) : _ ->
                 Left
                     ( "impact categories share the id "
                         <> UUID.toText mid
                         <> " ("
-                        <> T.intercalate ", " names
+                        <> T.intercalate ", " (NE.toList names)
                         <> "); their archive entries would overwrite each other"
                     )
     checkMethod m = mapM_ (checkCF (methodName m)) (methodFactors m)

--- a/src/Method/WriterOlcaSchema.hs
+++ b/src/Method/WriterOlcaSchema.hs
@@ -166,6 +166,7 @@ checkOlcaExportable mc
         checkUniqueIds (mcMethods mc)
         mapM_ checkMethod (mcMethods mc)
   where
+    checkUniqueIds :: [Method] -> Either Text ()
     checkUniqueIds ms =
         case collisions [(methodId m, methodName m) | m <- ms] of
             [] -> Right ()

--- a/src/UnitConversion.hs
+++ b/src/UnitConversion.hs
@@ -60,7 +60,9 @@ import qualified Data.ByteString.Lazy as BL
 import Data.Csv (HasHeader (..), decode)
 import Data.Either (partitionEithers)
 import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
+import Data.Indexing (uniqueIndex)
 import Data.List (elemIndex)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, isJust)
 import qualified Data.Set as S
@@ -384,9 +386,9 @@ buildFromCSV csvData =
     {- A table that spells one unit twice has two factors for it and no way to
     say which is meant, and 'M.fromList' would keep the last in silence. -}
     withoutRepeats :: [(Text, UnitDef)] -> Either Text (M.Map Text UnitDef)
-    withoutRepeats pairs = case M.keys (M.filter (> (1 :: Int)) (M.fromListWith (+) [(k, 1) | (k, _) <- pairs])) of
-        [] -> Right (M.fromList pairs)
-        repeats -> Left $ "unit spelled more than once: " <> T.intercalate ", " repeats
+    withoutRepeats pairs = case uniqueIndex pairs of
+        Right table -> Right table
+        Left repeats -> Left $ "unit spelled more than once: " <> T.intercalate ", " (NE.toList repeats)
 
 {- | One row of the unit table a database file carries for itself: what the
 unit is called, the unit it is expressed in, and how many of that it makes.

--- a/test/IndexingSpec.hs
+++ b/test/IndexingSpec.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Tests for "Data.Indexing", the three answers to a key that does not
+determine its value.
+
+What they pin is what the callers rely on and a rewrite could quietly lose: a
+repeated key is named once however many rows carried it, the rows a key
+collected come back in the order they were read, and a key seen once is not a
+collision.
+-}
+module IndexingSpec (spec) where
+
+import Data.Indexing (collisions, repeated, uniqueIndex)
+import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "repeated" $ do
+        it "finds nothing in a list without repeats" $
+            repeated ["a", "b", "c" :: Text] `shouldBe` []
+
+        it "names a repeated key once, however many times it appears" $
+            repeated ["a", "b", "a", "a" :: Text] `shouldBe` ["a"]
+
+        it "returns the keys in ascending order, whatever the input order" $
+            repeated ["c", "a", "c", "a" :: Text] `shouldBe` ["a", "c"]
+
+        it "finds nothing in an empty list" $
+            repeated ([] :: [Text]) `shouldBe` []
+
+    describe "collisions" $ do
+        it "keeps the rows of a colliding key in the order they were read" $
+            collisions [("a", 1 :: Int), ("b", 2), ("a", 3), ("a", 4)]
+                `shouldBe` [("a" :: Text, 1 :| [3, 4])]
+
+        it "ignores a key carried by a single row" $
+            collisions [("a", 1 :: Int), ("b", 2 :: Int)] `shouldBe` ([] :: [(Text, NonEmpty Int)])
+
+    describe "uniqueIndex" $ do
+        it "indexes rows whose keys are all distinct" $
+            uniqueIndex [("a", 1 :: Int), ("b", 2)]
+                `shouldBe` Right (M.fromList [("a" :: Text, 1), ("b", 2)])
+
+        it "refuses, naming every key that repeats, and indexes nothing" $
+            uniqueIndex [("a", 1 :: Int), ("b", 2), ("a", 3), ("c", 4), ("c", 5)]
+                `shouldBe` Left ("a" :| ["c" :: Text])
+
+        it "accepts an empty list" $
+            uniqueIndex ([] :: [(Text, Int)]) `shouldBe` Right M.empty

--- a/volca.cabal
+++ b/volca.cabal
@@ -39,6 +39,7 @@ library
   exposed-modules:     Types
                      , App.Env
                      , App.Idle
+                     , Data.Indexing
                      , Data.Validation
                      , Progress
                      , UnitConversion
@@ -222,6 +223,7 @@ test-suite lca-tests
                      , GoldenData
                      , DetectFormatSpec
                      , AmountSpec
+                     , IndexingSpec
                      , AutoRelinkSpec
                      , AutoSynonymsSpec
                      , RelinkMappingSpec


### PR DESCRIPTION
## The problem

Eight functions across eight modules each answered the same question: which
keys does this list carry more than once. Two of them were the same expression
written out twice, one was a quadratic scan over `Eq`, and none of them lived
where a reader looking for the answer would think to look.

`UnitConversion.withoutRepeats`, `Database.Author.duplicateKeys`,
`Config.findDuplicates`, `BrightwayExcel.Parser.duplicateLabels`,
`ILCD.Writer.sharedActivityUUIDs`, `Method.WriterILCD.duplicateIds`,
`Method.WriterOlcaSchema.checkUniqueIds`, `Database.Manager.parseGeographies`.

## The solution

`Data.Indexing` sits next to `Data.Validation`, which is the same kind of
module: pure, no domain, small. It holds the three answers there are to a key
that turns out not to determine its value.

- `repeated :: Ord k => [k] -> [k]` names the offending keys, ascending, once
  each however many rows carried them. Five of the eight wanted only this.
- `collisions :: Ord k => [(k, v)] -> [(k, NonEmpty v)]` hands back every row a
  key collected, in reading order. The two method writers need it: their
  message names the values that collided ("two methods share the id X (A, B)"),
  which `repeated` would have thrown away.
- `uniqueIndex :: Ord k => [(k, v)] -> Either (NonEmpty k) (Map k v)` indexes or
  refuses, naming what repeated. The caller owns the wording, because a unit
  table, a geography table and a method archive fail for the same reason and do
  not say it the same way.

Keeping every row instead of refusing stays `Data.Map.fromListWith`, which needs
no wrapper; the module header says so rather than adding a fourth function.

`Database.Author.duplicateKeys` and `Config.findDuplicates` are gone entirely,
replaced by direct calls.

## Remarks

Two messages change, and neither changes what it says, only the order it says
it in. Both orders were accidents of the operator that built the map, not
choices, and both are now the order the rows were read in.

- `Config.validateConfig` listed duplicate database, preset and method names in
  the reverse order of their discovery, and now lists them ascending, so the
  message no longer depends on where in the file the second spelling sat.
- The two method writers' "share the id X (A, B)" named the colliding methods
  in reverse. `M.fromListWith (++)` prepended the newer row to the older one;
  `collisions` keeps reading order.

Every other message is unchanged, word for word.

The context is `AGENTS.md`'s rule that an index asserts its key determines its
value. Making the refusal as short to write as the silent overwrite is what
lets the rest of that work happen; this pull request is the tool, not the
survey of what still needs it.

## How to test

```
cabal build lib:volca exe:volca --ghc-options=-Werror
cabal test lca-tests
```

`IndexingSpec` pins the three functions, including the two things a rewrite
could quietly lose: a key is named once however many rows carried it, and the
rows a key collected come back in the order they were read. `UnitConversionSpec`,
`ConfigSpec`, `AuthorSpec`, `ILCDWriterSpec`, the geography specs and the two
Brightway specs cover the rewritten callers. 2584 examples, no failures.
