### PR TITLE
Write a set with a set

### DIFF
--- a/src/Search/BM25.hs
+++ b/src/Search/BM25.hs
@@ -20,6 +20,7 @@ import Control.Monad.ST (runST)
 import Data.Int (Int32)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
+import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Vector as V
@@ -120,7 +121,7 @@ tokenTrigrams t
                 | T.length s < 3 = []
                 | otherwise = T.take 3 s : go (T.drop 1 s)
             raw = go t
-         in M.keys (M.fromList [(tg, ()) | tg <- raw]) -- dedupe
+         in S.toAscList (S.fromList raw)
 
 {- | Extract searchable tokens for one activity: name + reference product
 name(s). Location is deliberately excluded: it's a structured filter

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -1099,7 +1099,7 @@ matches what the score actually consumes.
 calculateActivityMetadata :: Database -> Activity -> ActivityMetadata
 calculateActivityMetadata db activity =
     let allExchanges = exchanges activity
-        uniqueFlows = length $ M.fromList [(exchangeFlowId ex, ()) | ex <- allExchanges]
+        uniqueFlows = S.size (S.fromList [exchangeFlowId ex | ex <- allExchanges])
         techInputs = length [ex | ex <- allExchanges, isTechnosphereExchange ex, exchangeIsInput ex, not (exchangeIsReference ex)]
         bioExchanges = length [ex | ex <- allExchanges, isBiosphereExchange ex]
         resolved = crossDBResolvedFlowIds db activity


### PR DESCRIPTION
## The problem

Two expressions built a `Map` to `()` and then asked it for its keys or its
size. That is a `Set` spelled the long way round, and the trigram helper
carried a `-- dedupe` comment to say out loud what the expression itself did
not.

## The solution

`Search.BM25.tokenTrigrams` returns `S.toAscList (S.fromList raw)`, and
`Service.calculateActivityMetadata` counts distinct flows with
`S.size (S.fromList ...)`. The comment goes with them, because the code now
says it.

## Remarks

No behaviour change, and both halves of that are checkable rather than
plausible: `M.keys` hands back the keys in ascending order, which is exactly
what `S.toAscList` hands back, and the number of keys in a `Map` built from a
list is the number of elements in a `Set` built from the same list.

The Haddock above `tokenTrigrams` already promised "the set of 3-char
substrings", so this is the code catching up with its own documentation.

## How to test

```
cabal build lib:volca exe:volca --ghc-options=-Werror
cabal test lca-tests
```

2575 examples, no failures.
