### PR TITLE
Compile a test build at -O0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,10 @@
 #   --help              Show this help message
 #   --clean             Clean build artifacts before building
 #   --all               Force clean rebuild
-#   --test              Run tests after building
+#   --test              Run tests after building. Compiles volca's own modules
+#                       at -O0, since the binary only has to make the suite
+#                       pass; VOLCA_OPT_LEVEL overrides that, and a build
+#                       without --test stays at -O1 because it is going to run
 #   --coverage          Run tests with coverage and generate HTML report (implies --test)
 #   --werror            Treat warnings as errors (-Werror) when compiling — the
 #                       strict gate CI uses; -Wall-clean is a hard project rule
@@ -478,15 +481,38 @@ else
     LINK_MODE="dynamic"
 fi
 
-# A build run from a working copy is there to be run and tested, not shipped,
-# so it defaults to -O1 rather than the -O2 gen-cabal-config.sh keeps for
-# artifacts. What that buys is not spread evenly over the tree: one module of
-# generic JSON instances holds the whole compile behind it at -O2. An explicit
-# VOLCA_OPT_LEVEL still wins, which is how the release rows of CI ask for 2.
+# A build run from a working copy is not shipped, so it defaults below the -O2
+# gen-cabal-config.sh keeps for artifacts. Which level below follows what the
+# build is for, the same rule that file states:
+#
+#   --test   0   the binary only has to make the suite pass, and one module of
+#                generic JSON instances holds the whole compile behind it above
+#                that level
+#   plain    1   the binary is going to be run, and unoptimised generic
+#                instances encode and decode 10 to 20 % slower
+#
+# The two do not share a build tree - cabal puts level 0 under `noopt/` - so
+# alternating between them costs one cold build each and then stays
+# incremental on both sides.
+#
+# An explicit VOLCA_OPT_LEVEL wins over both, which is how the release rows of
+# CI ask for 2 while its test rows ask for 0.
+if [[ "$RUN_TESTS" == "true" ]]; then
+    DEFAULT_OPT_LEVEL=0
+else
+    DEFAULT_OPT_LEVEL=1
+fi
+OPT_LEVEL="${VOLCA_OPT_LEVEL:-$DEFAULT_OPT_LEVEL}"
+
+# Said out loud because the level decides how fast the binary runs, and a
+# developer who builds with --test and then serves that binary would otherwise
+# find it slow with nothing on screen to say why.
+log_info "Optimization level: -O$OPT_LEVEL"
+
 MUMPS_LIB_DIR="$MUMPS_LIB_DIR" \
 MUMPS_INCLUDE_DIR="$MUMPS_INCLUDE_DIR" \
 LINK_MODE="$LINK_MODE" \
-VOLCA_OPT_LEVEL="${VOLCA_OPT_LEVEL:-1}" \
+VOLCA_OPT_LEVEL="$OPT_LEVEL" \
 ./gen-cabal-config.sh
 
 # If --no-optimize was requested but a previous build left a UPX'd binary

--- a/gen-cabal-config.sh
+++ b/gen-cabal-config.sh
@@ -24,8 +24,10 @@ OUTPUT="${OUTPUT_DIR:-.}/cabal.project.local"
 # knob cheap: only volca's own modules move.
 #
 # The level follows what the build is for, and each caller picks its own:
-#   0  CI test rows, which only have to run the suite
-#   1  a build from a working copy (build.sh), and a from-source image
+#   0  anything that only has to run the suite: the CI test rows, and
+#      `build.sh --test` from a working copy
+#   1  a working-copy binary that is going to be run (`build.sh` with no
+#      --test), and a from-source image
 #   2  anything published: the release rows, the engine image
 # Default 2, because an unset variable must never quietly under-optimise
 # something that ships.

--- a/volca.cabal
+++ b/volca.cabal
@@ -16,8 +16,8 @@ extra-source-files:  README.md CHANGELOG.md
 common warnings
   -- Optimization is set in cabal.project.local (see gen-cabal-config.sh):
   -- global `optimization: 2` keeps deps at -O2, and a per-package override
-  -- sets volca itself from $VOLCA_OPT_LEVEL (default 2; CI PR builds drop it
-  -- to 1 for faster compiles). A hardcoded -O2 here would win over that
+  -- sets volca itself from $VOLCA_OPT_LEVEL (default 2; anything that only has
+  -- to run the suite drops it to 0). A hardcoded -O2 here would win over that
   -- per-package setting (ghc-options beat the project optimization flag), so
   -- it lives in the project file, not here.
   --


### PR DESCRIPTION
## The problem

`build.sh` already defaulted below the -O2 `gen-cabal-config.sh` keeps for
artifacts, but it used one level for both of the things it is asked to do, and
those two want opposite answers.

`build.sh --test` produces a binary whose only job is to make the suite pass.
One module of generic JSON instances holds the whole compile behind it above
-O0, so every local check paid for optimisation nothing was going to use.

`build.sh` alone produces a binary that is going to be run, where unoptimised
generic instances encode and decode 10 to 20 % slower.

## The solution

The working-copy default follows which of the two was asked for, the same rule
`gen-cabal-config.sh` already states for the levels it owns:

```
--test   0
plain    1
```

An explicit `VOLCA_OPT_LEVEL` still wins over both, so CI is untouched: it sets
the variable on every row, 0 for the test rows and 2 for the release ones. The
Dockerfile keeps its own `ARG VOLCA_OPT_LEVEL=2`.

The chosen level is logged. It decides how fast the binary runs, and someone
who builds with `--test` and then serves that binary would otherwise find it
slow with nothing on screen to say why.

Two comments that described the old split are corrected in the same commit,
since this change is what makes them false: `gen-cabal-config.sh`'s table said
a working-copy build was 1 without qualification, and `volca.cabal` still said
CI drops to 1, which stopped being true when the test rows moved to 0.

## Remarks

Switching between the two modes is cheaper than it looks: cabal keys the build
directory on the package's optimisation level, putting level 0 under `noopt/`,
so the two modes do not share a tree. Alternating costs one cold build on each
side and a second copy of volca's objects on disk, then stays incremental in
both directions.

This only moves `build.sh`'s own default. The rule that an unset
`VOLCA_OPT_LEVEL` means 2 stays where it is, in `gen-cabal-config.sh`, so
nothing that ships can be under-optimised by a variable nobody set.

## How to test

```
./build.sh --test                     # logs "Optimization level: -O0"
./build.sh                            # logs "Optimization level: -O1"
VOLCA_OPT_LEVEL=0 ./build.sh          # logs -O0: the override wins
```

Run here: `./build.sh --test` logged `-O0`, built, and the suite passed with
2575 examples and no failures; `VOLCA_OPT_LEVEL=0 ./build.sh` logged `-O0`,
which is the override path CI depends on. `shellcheck --severity=warning` is
clean on both scripts.
