### PR TITLE
Reach every coproduct a dataset number names

### DIFF
--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -109,7 +109,6 @@ import Data.Bits (xor)
 import qualified Data.ByteString as BS
 import Data.Char (toLower)
 import Data.Either (lefts, partitionEithers, rights)
-import Data.Foldable (find)
 import Data.List (intercalate, sort, sortBy, sortOn)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
@@ -225,7 +224,9 @@ either: the flow tables are merged strictly, for the reason the import of
 
 'hvDatasetNumbers' is the one table under neither law: a repeated number is the
 ordinary shape there, not a collision to arbitrate, so both sides are kept and
-the reader picks by product name. See 'DatasetNumberIndex'.
+the reader picks by product name. See 'DatasetNumberIndex'. It is built and
+merged strictly, like the flow tables and for the same reason: its value grows
+by repeated '<>', and the lazy API would leave that chain unforced.
 -}
 data Harvest = Harvest
     { hvActivities :: !ActivityMap
@@ -924,9 +925,13 @@ fixExchangeLink ExchangeLinkContext{..} consumer ex@TechnosphereExchange{techFlo
     -- The number names several datasets whenever the block it came from was
     -- allocated into coproducts, and then only the product name says which one
     -- the input asked for. That name was already what Tier 1 checked when the
-    -- number named a single dataset; here it also chooses.
+    -- number named a single dataset; here it also chooses. Two coproducts
+    -- published under one name leave it with nothing to choose on, so the
+    -- number answers nothing and the tiers below take their turn, exactly as
+    -- when the name does not match at all.
     supplierNamed :: TechnosphereFlow -> NE.NonEmpty (UUID.UUID, UUID.UUID) -> Maybe (UUID.UUID, UUID.UUID)
-    supplierNamed flow = find (produces (normalizeText (tfName flow)))
+    supplierNamed flow candidates =
+        NE.nonEmpty (NE.filter (produces (normalizeText (tfName flow))) candidates) >>= sole
 
     produces :: T.Text -> (UUID.UUID, UUID.UUID) -> Bool
     produces name (_, prodUUID) = Just name == (normalizeText . tfName <$> M.lookup prodUUID elcFlowDB)

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -109,6 +109,7 @@ import Data.Bits (xor)
 import qualified Data.ByteString as BS
 import Data.Char (toLower)
 import Data.Either (lefts, partitionEithers, rights)
+import Data.Foldable (find)
 import Data.List (intercalate, sort, sortBy, sortOn)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
@@ -221,6 +222,10 @@ base. 'LoaderSpec' pins both directions through 'harvestOf' and this instance,
 which is why the two are exported. The qualifiers are not interchangeable
 either: the flow tables are merged strictly, for the reason the import of
 'Data.Map.Strict' gives, and the rest is left as the build sites had it.
+
+'hvDatasetNumbers' is the one table under neither law: a repeated number is the
+ordinary shape there, not a collision to arbitrate, so both sides are kept and
+the reader picks by product name. See 'DatasetNumberIndex'.
 -}
 data Harvest = Harvest
     { hvActivities :: !ActivityMap
@@ -243,7 +248,7 @@ instance Semigroup Harvest where
             , hvBioFlows = MS.unionWith mergeBioFlows (hvBioFlows a) (hvBioFlows b)
             , hvWasteFlows = M.union (hvWasteFlows a) (hvWasteFlows b)
             , hvUnits = M.union (hvUnits a) (hvUnits b)
-            , hvDatasetNumbers = M.union (hvDatasetNumbers a) (hvDatasetNumbers b)
+            , hvDatasetNumbers = MS.unionWith (<>) (hvDatasetNumbers a) (hvDatasetNumbers b)
             , hvRawFlows = hvRawFlows a + hvRawFlows b
             , hvRawUnits = hvRawUnits a + hvRawUnits b
             }
@@ -262,7 +267,7 @@ harvestOf entries =
         , hvBioFlows = MS.fromListWith mergeBioFlows [(bfId f, f) | f <- bios]
         , hvWasteFlows = M.fromList [(wfId f, f) | f <- wastes]
         , hvUnits = M.fromList [(unitId u, u) | u <- units]
-        , hvDatasetNumbers = M.fromList [(pdDatasetNumber parsed, key) | (key, parsed) <- entries, pdDatasetNumber parsed /= 0]
+        , hvDatasetNumbers = MS.fromListWith (flip (<>)) [(pdDatasetNumber parsed, key NE.:| []) | (key, parsed) <- entries, pdDatasetNumber parsed /= 0]
         , hvRawFlows = length techs + length bios + length wastes
         , hvRawUnits = length units
         }
@@ -540,8 +545,16 @@ covers more than one dataset instead of taking whichever it finds.
 -}
 type SupplierByNameWithLocation = M.Map T.Text (NE.NonEmpty (UUID.UUID, UUID.UUID, T.Text))
 
--- | Dataset number → (activityUUID, productUUID) for EcoSpold1 Tier 1 linking
-type DatasetNumberIndex = M.Map Int (UUID.UUID, UUID.UUID)
+{- | Dataset number → the datasets carrying it, for EcoSpold1 Tier 1 linking.
+
+One number names several datasets rather than one whenever the block it came
+from declares more than one product: allocation rewrites such a block into one
+dataset per coproduct, all of them carrying the number the block was read
+under. Keeping one would leave the others unreachable by number, and the
+reading order does not say which coproduct an input meant. The product name
+does, and that is what Tier 1 already checks.
+-}
+type DatasetNumberIndex = M.Map Int (NE.NonEmpty (UUID.UUID, UUID.UUID))
 
 -- | Information about an unlinked technosphere exchange
 data UnlinkedExchange = UnlinkedExchange
@@ -882,12 +895,10 @@ fixExchangeLink ExchangeLinkContext{..} consumer ex@TechnosphereExchange{techFlo
          in case M.lookup fid elcFlowDB of
                 Just flow ->
                     -- Tier 1: dataset-number lookup with name validation
-                    case claimedNumber claim >>= \dsNum -> (,) dsNum <$> M.lookup dsNum elcDatasetIndex of
-                        Just (dsNum, (actUUID, prodUUID))
-                            | Just supplierFlow <- M.lookup prodUUID elcFlowDB
-                            , normalizeText (tfName supplierFlow) == normalizeText (tfName flow) ->
-                                linked (locationOverride flow dsNum (actUUID, prodUUID)) actUUID prodUUID
-                        _ ->
+                    case claimedNumber claim >>= \dsNum -> (,) dsNum <$> (M.lookup dsNum elcDatasetIndex >>= supplierNamed flow) of
+                        Just (dsNum, (actUUID, prodUUID)) ->
+                            linked (locationOverride flow dsNum (actUUID, prodUUID)) actUUID prodUUID
+                        Nothing ->
                             -- Tier 2: name + location lookup
                             let soleSupplier = M.lookup (normalizeText (tfName flow)) elcNameIndex >>= sole
                                 lookupLoc
@@ -909,6 +920,16 @@ fixExchangeLink ExchangeLinkContext{..} consumer ex@TechnosphereExchange{techFlo
   where
     declaredLoc :: T.Text
     declaredLoc = fromMaybe loc (M.lookup loc elcLocationAliases)
+
+    -- The number names several datasets whenever the block it came from was
+    -- allocated into coproducts, and then only the product name says which one
+    -- the input asked for. That name was already what Tier 1 checked when the
+    -- number named a single dataset; here it also chooses.
+    supplierNamed :: TechnosphereFlow -> NE.NonEmpty (UUID.UUID, UUID.UUID) -> Maybe (UUID.UUID, UUID.UUID)
+    supplierNamed flow = find (produces (normalizeText (tfName flow)))
+
+    produces :: T.Text -> (UUID.UUID, UUID.UUID) -> Bool
+    produces name (_, prodUUID) = Just name == (normalizeText . tfName <$> M.lookup prodUUID elcFlowDB)
 
     -- The number named a dataset. When the declared location names another
     -- dataset of the same product, the number still wins: it is what the file

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -787,6 +787,22 @@ spec = do
                 (acts, _) = fixAllActivities (ecoSpold1LinkContext M.empty dsIndex db) (sdbActivities db)
             inputLinksIn acts `shouldBe` [Just actUUID1]
 
+        -- Two coproducts of one block published under one product name leave
+        -- the number nothing to choose on, so it answers nothing and the tiers
+        -- below take their turn.
+        it "leaves a numbered input unlinked when two coproducts share its product name" $ do
+            let heatA = ((actUUID1, flowUUID1), minimalActivity "cogeneration, heat a" "GLO" [refExchange flowUUID1])
+                heatB = ((actUUID2, flowUUID2), minimalActivity "cogeneration, heat b" "GLO" [refExchange flowUUID2])
+                greenhouse =
+                    ( (consumerUUID, breadUUID)
+                    , minimalActivity "greenhouse" "CH" [refExchange breadUUID, buyingDataset 7 (inputExchange flowUUID1 "")]
+                    )
+                names = [(flowUUID1, "Heat"), (flowUUID2, "Heat"), (breadUUID, "Bread")]
+                dsIndex = hvDatasetNumbers (harvestOf [numbered (actUUID1, flowUUID1), numbered (actUUID2, flowUUID2)])
+                db = simpleDBOf [heatA, heatB, greenhouse] names
+                (acts, _) = fixAllActivities (ecoSpold1LinkContext M.empty dsIndex db) (sdbActivities db)
+            inputLinksIn acts `shouldBe` [Nothing]
+
     -- -----------------------------------------------------------------------
     -- countTotalTechInputs / countUnlinkedExchanges / collectUnlinkedProductNames
     -- (integration tests via SAMPLE.min3)

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -82,6 +82,12 @@ key, so that two of them collide and the merging law has to decide.
 share :: Text -> [TechnosphereFlow] -> ((UUID.UUID, UUID.UUID), ParsedDataset)
 share name techs = ((actUUID1, flowUUID1), minimalDataset (minimalActivity name "GLO" []) techs)
 
+{- | One coproduct of a block published under dataset number 7: allocation gives
+each of them its own key, and they all carry the number the block was read under.
+-}
+numbered :: (UUID.UUID, UUID.UUID) -> ((UUID.UUID, UUID.UUID), ParsedDataset)
+numbered key = (key, (minimalDataset (minimalActivity "cogeneration" "GLO" []) []){pdDatasetNumber = 7})
+
 refExchange :: UUID.UUID -> Exchange
 refExchange fid =
     TechnosphereExchange
@@ -266,6 +272,19 @@ spec = do
             let merged = harvestOf [share "activity-a" []] <> harvestOf [share "activity-b" []]
             fmap activityName (M.lookup (actUUID1, flowUUID1) (hvActivities merged))
                 `shouldBe` Just "activity-a"
+
+        -- The dataset-number table is under neither law: an allocated block is
+        -- written once per coproduct, all of them under the block's number, so
+        -- a repeated number is the ordinary shape and every side is kept.
+        it "keeps every coproduct of one dataset number, in reading order" $ do
+            let harvest = harvestOf [numbered (actUUID1, flowUUID1), numbered (actUUID2, flowUUID2)]
+            M.lookup 7 (hvDatasetNumbers harvest)
+                `shouldBe` Just ((actUUID1, flowUUID1) NE.:| [(actUUID2, flowUUID2)])
+
+        it "keeps both readers' datasets under one number, the first reader's first" $ do
+            let merged = harvestOf [numbered (actUUID1, flowUUID1)] <> harvestOf [numbered (actUUID2, flowUUID2)]
+            M.lookup 7 (hvDatasetNumbers merged)
+                `shouldBe` Just ((actUUID1, flowUUID1) NE.:| [(actUUID2, flowUUID2)])
 
     -- -----------------------------------------------------------------------
     describe "indexActivities" $ do
@@ -700,7 +719,7 @@ spec = do
             gasNames = [(flowUUID1, "Natural gas"), (flowUUID2, "Natural gas"), (breadUUID, "Heat")]
             linkPlantDeclaring loc =
                 let db = simpleDBOf [gasBG, gasRER, plantDeclaring loc] gasNames
-                    ctx = ecoSpold1LinkContext M.empty (M.singleton 300474 (actUUID1, flowUUID1)) db
+                    ctx = ecoSpold1LinkContext M.empty (M.singleton 300474 ((actUUID1, flowUUID1) NE.:| [])) db
                  in fixAllActivities ctx (sdbActivities db)
 
         -- The number is on the row that carries it. Held in one map per
@@ -716,7 +735,7 @@ spec = do
                 ctx =
                     ecoSpold1LinkContext
                         M.empty
-                        (M.fromList [(1, (actUUID1, flowUUID1)), (2, (actUUID2, flowUUID2))])
+                        (M.fromList [(1, (actUUID1, flowUUID1) NE.:| []), (2, (actUUID2, flowUUID2) NE.:| [])])
                         db
                 (acts, _) = fixAllActivities ctx (sdbActivities db)
                 supplierOf key =
@@ -745,6 +764,28 @@ spec = do
             let (acts, summary) = linkPlantDeclaring "ENTSO"
             inputLinksIn acts `shouldBe` [Just actUUID1]
             usLocationOverrides summary `shouldBe` []
+
+        -- One number, several suppliers: the block was allocated into a heat
+        -- dataset and an electricity one, both published under number 7. Only
+        -- the product name says which the input meant, and nothing else can:
+        -- "Heat" is made in two places, so neither the name alone nor the name
+        -- with a location the input does not declare reaches a dataset.
+        it "links a numbered input to the coproduct its product names" $ do
+            let rivalHeatUUID = read "bbbbbbbb-0000-0000-0000-000000000004" :: UUID.UUID
+                cogenHeat = ((actUUID1, flowUUID1), minimalActivity "cogeneration, heat" "GLO" [refExchange flowUUID1])
+                cogenPower = ((actUUID2, flowUUID2), minimalActivity "cogeneration, electricity" "GLO" [refExchange flowUUID2])
+                boilerHeat = ((missingActUUID, rivalHeatUUID), minimalActivity "heat, boiler" "FR" [refExchange rivalHeatUUID])
+                greenhouse =
+                    ( (consumerUUID, breadUUID)
+                    , minimalActivity "greenhouse" "CH" [refExchange breadUUID, buyingDataset 7 (inputExchange flowUUID1 "")]
+                    )
+                names = [(flowUUID1, "Heat"), (flowUUID2, "Electricity"), (rivalHeatUUID, "Heat"), (breadUUID, "Bread")]
+                -- The electricity coproduct is read last, which is the one a
+                -- table keeping a single dataset per number would have kept.
+                dsIndex = hvDatasetNumbers (harvestOf [numbered (actUUID1, flowUUID1), numbered (actUUID2, flowUUID2)])
+                db = simpleDBOf [cogenHeat, cogenPower, boilerHeat, greenhouse] names
+                (acts, _) = fixAllActivities (ecoSpold1LinkContext M.empty dsIndex db) (sdbActivities db)
+            inputLinksIn acts `shouldBe` [Just actUUID1]
 
     -- -----------------------------------------------------------------------
     -- countTotalTechInputs / countUnlinkedExchanges / collectUnlinkedProductNames


### PR DESCRIPTION
## The problem

An EcoSpold 1 block that declares several products is not one dataset. Loading
allocates it into one dataset per coproduct, each with its own key, and every
one of them carries the number the block was published under. The index from
dataset number to dataset was a `Map Int (activityUUID, productUUID)`, so it
kept whichever coproduct was read last and dropped the rest.

An input that names that number is then resolved against the wrong product.
The first linking tier checks the candidate's product name against the input's,
so the mismatch stops it linking to the wrong dataset, but the link is lost:
the name and location tiers that follow cannot separate two geographies sharing
one product name, and an input with no declared location is left unlinked.

The same table also dropped one side when two readers both carried a number,
because harvests were merged with `M.union`.

## The solution

The index holds every dataset a number covers:
`Map Int (NonEmpty (activityUUID, productUUID))`, built with `fromListWith` in
reading order, merged between readers with `unionWith (<>)` so the first
reader's datasets come first.

The first tier picks among the candidates by product name. That is not a new
rule: it is the check the tier already made against the single candidate it
used to find, now applied to all of them. Where the name reaches one candidate
the tier links it; where two coproducts of a block carry the same product name,
the name says nothing and the tier answers nothing, so the tiers below take
their turn exactly as they do when the name does not match at all. Nothing else
in the linking chain changes, and a number that still covers one dataset
behaves exactly as before.

## Remarks

This makes links that were previously lost, so a database built from
multi-product blocks resolves more of its inputs than it did. It cannot move a
link from one dataset to another: where the product name reaches exactly one
candidate that candidate is the one the previous table would have had to hold
to link at all, and where it reaches several the tier refuses rather than
choose.

`MatrixBuild` made the same correction for the activity-UUID index, with the
same reason written next to it ("an allocated activity is written once per
coproduct"). This is that fix applied to the one remaining table with the shape.

## How to test

```
cabal test lca-tests
```

`LoaderSpec` gains four examples: the harvest keeps every coproduct of one
number in reading order, two readers' datasets are both kept under one number,
an input naming a number links to the coproduct its product names, and an input
whose number reaches two coproducts of one name stays unlinked. The third fails
on the previous behaviour, verified by pinning the index to its last entry: the
input comes back unlinked.

Run here: 2580 examples, 0 failures, 2 pending. `fourmolu --mode check` and
`hlint` clean on both files.
