### PR TITLE
Give a capitalised unit prefix a row of its own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,24 @@
   ambiguities are documented where a reader looks for them.
 
 ### Changed
+- A unit written with a capital prefix is no longer read as its lower-case
+  twin. The shipped unit table held `mg` and not `Mg`, `ml` and not `ML`, `MJ`
+  and not `mJ`, `MWh` and not `mWh`, `mm` and not `Mm`. A source writing the
+  half the table lacked found the half it had, the single candidate looked
+  settled, and the amount was read against it: a megagram came through as a
+  milligram and a megalitre as a millilitre, a factor of a billion and of a
+  thousand billion, with nothing but a note saying the table spells the unit
+  differently. Each of those spellings now has a row of its own, so both halves
+  of a pair are read as written, and a database whose own unit list tells a
+  megagram from a milligram loads where it used to be refused. The litre also
+  gains the `L` and `mL` spellings the standard allows, so neither is read as a
+  respelling of the other. The other side of the same change: a spelling that
+  discards the case of a pair now lands on two rows with nothing to decide
+  between them, so the load stops and names them rather than guess. Those are
+  `MG`, `mG`, `MM`, `mM`, `Ml`, `mj`, `Mj`, `mwh` and `MWH`. Correct the
+  spelling in the source, or give the unit you mean a row in a `[[units]]` file
+  of your own. Data version 4. A cache records the unit table it was built
+  with, so every cache rebuilds itself from its source on the next load.
 - A guest night is no longer read as a plain count. It is one guest for one
   night, a count over a time, and the shipped unit table filed it beside
   `piece`, `item` and `TEU` at the reference unit's own factor. Every spelling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@
   thousand billion, with nothing but a note saying the table spells the unit
   differently. Each of those spellings now has a row of its own, so both halves
   of a pair are read as written, and a database whose own unit list tells a
-  megagram from a milligram loads where it used to be refused. The litre also
-  gains the `L` and `mL` spellings the standard allows, so neither is read as a
-  respelling of the other. The other side of the same change: a spelling that
+  megagram from a milligram loads where it used to be refused. The millilitre
+  also gains the `mL` spelling the standard allows, so it is not read as the
+  megalitre. The other side of the same change: a spelling that
   discards the case of a pair now lands on two rows with nothing to decide
   between them, so the load stops and names them rather than guess. Those are
   `MG`, `mG`, `MM`, `mM`, `Ml`, `mj`, `Mj`, `mwh` and `MWH`. Correct the

--- a/data/units.csv
+++ b/data/units.csv
@@ -94,7 +94,6 @@ Sm3,volume,1.0
 l,volume,0.001
 liter,volume,0.001
 litre,volume,0.001
-L,volume,0.001
 dm3,volume,0.001
 ml,volume,1e-06
 mL,volume,1e-06

--- a/data/units.csv
+++ b/data/units.csv
@@ -5,6 +5,7 @@ g,mass,0.001
 gram,mass,0.001
 mg,mass,1e-06
 milligram,mass,1e-06
+Mg,mass,1000.0
 t,mass,1000.0
 ton,mass,1000.0
 tonne,mass,1000.0
@@ -25,6 +26,7 @@ centimetre,length,0.01
 mm,length,0.001
 millimeter,length,0.001
 millimetre,length,0.001
+Mm,length,1000000.0
 mile,length,1609.344
 ft,length,0.3048
 foot,length,0.3048
@@ -47,6 +49,7 @@ y,time,31536000.0
 month,time,2592000.0
 MJ,energy,1.0
 megajoule,energy,1.0
+mJ,energy,1e-09
 J,energy,1e-06
 joule,energy,1e-06
 kJ,energy,0.001
@@ -61,6 +64,7 @@ kilowatt-hour,energy,3.6
 MWh,energy,3600.0
 megawatt hour,energy,3600.0
 megawatt-hour,energy,3600.0
+mWh,energy,3.6e-06
 Wh,energy,0.0036
 watt hour,energy,0.0036
 watt-hour,energy,0.0036
@@ -90,8 +94,11 @@ Sm3,volume,1.0
 l,volume,0.001
 liter,volume,0.001
 litre,volume,0.001
+L,volume,0.001
 dm3,volume,0.001
 ml,volume,1e-06
+mL,volume,1e-06
+ML,volume,1000.0
 cm3,volume,1e-06
 cm³,volume,1e-06
 gallon,volume,0.003785411784

--- a/test/UnitConversionSpec.hs
+++ b/test/UnitConversionSpec.hs
@@ -356,6 +356,18 @@ spec = do
             readUnit cfg "kg" `shouldSatisfy` exact
             readUnit cfg " kg " `shouldSatisfy` exact
 
+        it "reads a capitalised prefix as the unit it spells" $ do
+            -- The table holds both halves of each pair, so neither is read as
+            -- the other. Without the capitalised row a megagram folds onto the
+            -- milligram, the single candidate looks settled, and the amount is
+            -- carried through a billion times small.
+            cfg <- loadFullUnitConfig
+            lookupUnitDef cfg "Mg" `shouldBe` Just (unitDef "mass" 1000.0)
+            lookupUnitDef cfg "ML" `shouldBe` Just (unitDef "volume" 1000.0)
+            lookupUnitDef cfg "mJ" `shouldBe` Just (unitDef "energy" 1.0e-9)
+            lookupUnitDef cfg "mWh" `shouldBe` Just (unitDef "energy" 3.6e-6)
+            lookupUnitDef cfg "Mm" `shouldBe` Just (unitDef "length" 1000000.0)
+
         it "refuses when two spellings differ only by case" $ do
             let Right cfg = buildFromCSV "name,dimension,factor\nMJ,energy,1.0\nmJ,energy,1.0e-9\n"
             readUnit cfg "mj" `shouldBe` ReadAmbiguous "MJ" "mJ" []

--- a/test/UnitConversionSpec.hs
+++ b/test/UnitConversionSpec.hs
@@ -367,6 +367,10 @@ spec = do
             lookupUnitDef cfg "mJ" `shouldBe` Just (unitDef "energy" 1.0e-9)
             lookupUnitDef cfg "mWh" `shouldBe` Just (unitDef "energy" 3.6e-6)
             lookupUnitDef cfg "Mm" `shouldBe` Just (unitDef "length" 1000000.0)
+            -- Both halves of the pair are exact, so `Ml` lands on two rows and
+            -- the table decides nothing.
+            lookupUnitDef cfg "mL" `shouldBe` Just (unitDef "volume" 1.0e-6)
+            lookupUnitDef cfg "Ml" `shouldBe` Nothing
 
         it "refuses when two spellings differ only by case" $ do
             let Right cfg = buildFromCSV "name,dimension,factor\nMJ,energy,1.0\nmJ,energy,1.0e-9\n"


### PR DESCRIPTION
## Problem

The shipped unit table holds one half of five case-significant pairs: `mg` and
not `Mg`, `ml` and not `ML`, `MJ` and not `mJ`, `MWh` and not `mWh`, `mm` and
not `Mm`. The lookup reads the exact spelling first and falls back to the
case-folded index, so a source writing the half the table lacks finds the one it
has, the single candidate looks settled, and the amount is read against it.
Against the table as it ships today:

```
lookupUnitDef cfg "Mg"  -- UnitDef {udDimension = mass, udFactor = 1.0e-6}
```

A megagram read as a milligram, a factor of a billion, with nothing but a note
saying the table spells the unit differently. `ML` against `ml` is a factor of a
thousand billion.

#434 made the reading exact-first and gave the load a refusal for a spelling
that folds onto two rows; #437 spelled the table's own rows the way their
standards write them. Both say in their own remarks that this half was left
open.

Closes #430.

## Solution

Six rows in `data/units.csv`, and no Haskell:

| row | meaning |
|---|---|
| `Mg,mass,1000.0` | megagram |
| `Mm,length,1000000.0` | megametre |
| `ML,volume,1000.0` | megalitre |
| `mL,volume,1e-06` | millilitre |
| `mJ,energy,1e-09` | millijoule |
| `mWh,energy,3.6e-06` | milliwatt hour |

Each factor is against its dimension's reference unit: `kg`, `m`, `m3`, `MJ`.

Adding the twin row does both halves of the rule at once. The correct spellings
become exact matches, so a megagram is read as a megagram. And a spelling that
discards the case of a pair now lands on two rows with nothing to decide between
them, so `judgeUnits` stops the load and names both instead of guessing: `MG`,
`mG`, `MM`, `mM`, `Ml`, `Mj`, `mj`, `mwh`, `MWH`. Correcting the source or adding
the intended spelling to a `[[units]]` file resolves it.

`mL` comes with `ML`: the standard allows both symbols for the litre, and
without the `mL` row adding `ML` would have turned a settled millilitre into a
refusal.

A cache records the unit table it was built with, so every cache rebuilds itself
from its source on the next load, with no version to bump. `data/VERSION` stays
at 4, which already moved since the last release.

## Remarks

**Measured over the reference databases whose declared unit names are readable**
(a SimaPro file's own unit block, an EcoSpold 2 master data unit list, ILCD unit
groups). Seven declare `Mg` beside `mg`. The ILCD ones register both in the
database's unit registry and therefore refuse to load today, which is the
collapse #434 added; they now load, and read a megagram at the size their own
unit list gives it. None of them uses `MG`, `mG`, `MM`, `mM`, `Mj`, `mj`, `mwh`
or `MWH` on an exchange row, which is what the database's registry carries and
therefore what the load is judged on, so nothing that loads today starts
refusing.

**A file that declares one of these spellings for itself keeps loading.** Two
SimaPro exports do *declare* `Mj` as one `MJ` and `Ml` as 1000 `m3` in their
unit block, though neither uses them on a row. One that both declared and used
them would be unaffected: #438 lays the block over the shipped table, and every
row is then recorded in the reference unit of its dimension, so the amount
reaches the database's unit registry as `MJ` or `m3` and the verdict never sees
the spelling the file wrote. Measured against the table this PR ships, such a
file loads, with `Mj` read as 2 MJ and `Ml` as 2000 m3. What this change moves
is the file that uses `Mj` *without* declaring it: read as `MJ` before, refused
now, both candidates named.

**A source that discards case entirely is read at face value.** One writing `ML`
where it means a millilitre now gets a megalitre, exactly and without a
candidate to weigh. Nothing can tell that from one spelling.

**Authoring resolves a unit by the table's spelling.** An exchange stated in
`mL` against a database whose own rows are written `ml` no longer resolves, the
way one stated in `kilogram` against a database writing `kg` does not today. It
is refused, not misread.

**Left out, each for its own reason.** `MBq` and `mBq`: the table has neither, so
both read as unknown and warn rather than misread, which is a missing unit and
not a misread row. `kGy` folds onto `kgy`, but the table has no dose dimension
and no row at factor 1.0 for one, so a `kGy` row would leave that dimension with
no reference unit. `Cal` beside `cal` is a convention rather than an SI prefix,
and no source measured here writes it.

## How to test

```
cabal test lca-tests --test-options="--match /UnitConversion/"
```

The new case reads the table the engine ships, pins all five readings and the
`mL` / `Ml` pair. Removing the `Mg` row, re-running `./gen-version.sh` and
running the suite again fails exactly that case, with `1.0e-6` in place of
`1000.0`, which is what says the case reaches the table.

