### PR TITLE
Rank the suppliers a name and a location reach

### DIFF
--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -538,21 +538,17 @@ data NameProducer = NameProducer
     }
     deriving (Eq, Show)
 
-{- | Type alias for name-only supplier lookup (for SimaPro and Brightway Excel)
-Maps normalizedProductName → every activity producing it, ranked by
-'producerOrder' so the head is the one the tie-break picks.
+{- | Name-only supplier lookup, mapping a normalized product name to every
+activity producing it, ranked by 'producerOrder' so the head is the one the
+tie-break picks.
+
+Several is the ordinary shape, not the exception: a product name carries no
+location, so one name covers every geography the product is made in. The
+SimaPro and Brightway Excel readers take the head; the EcoSpold1 reader refuses
+a name covering more than one dataset, because there a location was expected
+and is missing.
 -}
 type NameOnlyIndex = M.Map T.Text (NE.NonEmpty NameProducer)
-
-{- | Name-only supplier lookup for EcoSpold1, mapping a normalized product name
-to every dataset producing it as @(activityUUID, productUUID, location)@.
-
-Several is the ordinary shape here, not the exception: an EcoSpold1 product name
-carries no location, so one name covers every geography the product is made in.
-That is why the value is a 'NE.NonEmpty' and why both readers refuse a name that
-covers more than one dataset instead of taking whichever it finds.
--}
-type SupplierByNameWithLocation = M.Map T.Text (NE.NonEmpty (UUID.UUID, UUID.UUID, T.Text))
 
 {- | Dataset number → the datasets carrying it, for EcoSpold1 Tier 1 linking.
 
@@ -725,6 +721,11 @@ Two blocks the file gives no way to tell apart are ordered by activity name
 then by location, never by identifier: a change in how identity is minted must
 not move a supply chain. The identifier breaks the last tie only.
 
+'activityIsObsolete' answers on a spelling: a @Category@ whose segments include
+one reading @Obsolete@. A format that marks a retired block some other way, or
+not at all, therefore answers 'False' for every dataset, and the ranking starts
+at the activity name. The axis is there for the formats that say it.
+
 The duplication is a defect in its own right, and 'Database.Quality' reports it
 as one, along with an input a retired block supplies.
 -}
@@ -768,20 +769,6 @@ buildSupplierIndexByName = rankedProducers const
 -- | The rank a producer holds among those sharing a product name.
 producerOrder :: NameProducer -> (Bool, T.Text, T.Text, UUID.UUID)
 producerOrder p = (npObsolete p, npActivityName p, npLocation p, npActivityUUID p)
-
-{- | Build the name-only supplier index for EcoSpold1 linking, keeping every
-dataset a name covers rather than the last one seen.
--}
-buildSupplierIndexByNameWithLocation :: ActivityMap -> TechFlowDB -> SupplierByNameWithLocation
-buildSupplierIndexByNameWithLocation activities techFlowDb =
-    M.fromListWith
-        (flip (<>))
-        [ (normalizeText (tfName flow), (actUUID, prodUUID, activityLocation act) NE.:| [])
-        | ((actUUID, prodUUID), act) <- M.toList activities
-        , ex <- exchanges act
-        , exchangeIsReference ex
-        , Just flow <- [M.lookup (exchangeFlowId ex) techFlowDb]
-        ]
 
 {- | Fix EcoSpold1 activity links by resolving supplier references.
 An input's dataset number names its supplier first, checked against the
@@ -853,7 +840,7 @@ argument and makes the dependencies explicit.
 data ExchangeLinkContext = ExchangeLinkContext
     { elcLocationAliases :: !(M.Map T.Text T.Text)
     , elcSupplierIndex :: !SupplierIndex
-    , elcNameIndex :: !SupplierByNameWithLocation
+    , elcNameIndex :: !NameOnlyIndex
     , elcDatasetIndex :: !DatasetNumberIndex
     , elcFlowDB :: !TechFlowDB
     , elcActivities :: !ActivityMap
@@ -865,8 +852,8 @@ ecoSpold1LinkContext locationAliases dsIndex db =
     ExchangeLinkContext
         { elcLocationAliases = locationAliases
         , elcSupplierIndex = buildSupplierIndex (sdbUnits db) (sdbActivities db) (sdbTechFlows db)
-        , -- Name-only index, with location, for exchanges missing the location attribute
-          elcNameIndex = buildSupplierIndexByNameWithLocation (sdbActivities db) (sdbTechFlows db)
+        , -- Name-only index, for exchanges missing the location attribute
+          elcNameIndex = buildSupplierIndexByName (sdbUnits db) (sdbActivities db) (sdbTechFlows db)
         , elcDatasetIndex = dsIndex
         , elcFlowDB = sdbTechFlows db
         , elcActivities = sdbActivities db
@@ -913,7 +900,7 @@ fixExchangeLink ExchangeLinkContext{..} consumer ex@TechnosphereExchange{techFlo
                             -- Tier 2: name + location lookup
                             let soleSupplier = M.lookup (normalizeText (tfName flow)) elcNameIndex >>= sole
                                 lookupLoc
-                                    | T.null declaredLoc = maybe declaredLoc (\(_, _, actLoc) -> actLoc) soleSupplier
+                                    | T.null declaredLoc = maybe declaredLoc npLocation soleSupplier
                                     | otherwise = declaredLoc
                                 key = (normalizeText (tfName flow), lookupLoc)
                              in case M.lookup key elcSupplierIndex of
@@ -925,7 +912,7 @@ fixExchangeLink ExchangeLinkContext{..} consumer ex@TechnosphereExchange{techFlo
                                         -- covers a single dataset. A name shared by
                                         -- several geographies names none of them.
                                         case soleSupplier of
-                                            Just (actUUID, prodUUID, _) -> linked [] [] actUUID prodUUID
+                                            Just p -> linked [] [] (npActivityUUID p) (npProductUUID p)
                                             Nothing -> unlinked flow lookupLoc
                 Nothing ->
                     (ex, mempty{usTotalLinks = 1, usMissingLinks = 1})

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -510,8 +510,16 @@ indexActivities activities =
             <> activityLocation kept
             <> "': they differ only in case, no process identifier tells them apart, and only the last read keeps its inventory"
 
--- | Type alias for supplier lookup index (with location)
-type SupplierIndex = M.Map (T.Text, T.Text) (UUID.UUID, UUID.UUID)
+{- | Supplier lookup for EcoSpold1, mapping @(normalized product name,
+location)@ to every activity answering it, ranked by 'producerOrder' so the head
+is the one the tie-break picks.
+
+Several is not the exception it looks like: a name and a location leave a block
+exported twice, and an allocated block's coproducts, indistinguishable. Keeping
+one entry kept whichever the map ordering of the identifiers put last, which is
+a ranking on minted identity and the one thing the ranking must never be.
+-}
+type SupplierIndex = M.Map (T.Text, T.Text) (NE.NonEmpty NameProducer)
 
 {- | One activity of this database producing a given product name.
 
@@ -703,28 +711,15 @@ reportUnlinkedActivities summary
 normalizeText :: T.Text -> T.Text
 normalizeText = T.toLower . T.strip . normalizeUnicode
 
-{- | Build supplier index: (normalizedProductName, location) → (activityUUID, productUUID)
-For each activity, we index it by its reference product name + activity location
--}
-buildSupplierIndex :: ActivityMap -> TechFlowDB -> SupplierIndex
-buildSupplierIndex activities techFlowDb =
-    M.fromList
-        [ ((normalizeText (tfName flow), activityLocation act), (actUUID, prodUUID))
-        | ((actUUID, prodUUID), act) <- M.toList activities
-        , ex <- exchanges act
-        , exchangeIsReference ex
-        , Just flow <- [M.lookup (exchangeFlowId ex) techFlowDb]
-        ]
+{- | Every activity of the database under the key its reference product gives
+it, ranked best first.
 
-{- | Build name-only supplier index for SimaPro linking, on the reference
-product name and nothing else.
-
-When several activities produce one product name they are duplicates of each
-other, a block exported twice, most often because one of the two has been
-retired. The file says which: a retired block is filed under an obsolete
-category, and 'activityIsObsolete' reads it, so the block still in service
-supplies and the retired one supplies nothing. On the Agribalyse 4.0 export of
-13 May 2026 that settles all ten of its duplicated products.
+When several activities answer one key they are duplicates of each other, a
+block exported twice, most often because one of the two has been retired. The
+file says which: a retired block is filed under an obsolete category, and
+'activityIsObsolete' reads it, so the block still in service supplies and the
+retired one supplies nothing. On the Agribalyse 4.0 export of 13 May 2026 that
+settles all ten of its duplicated products.
 
 Two blocks the file gives no way to tell apart are ordered by activity name
 then by location, never by identifier: a change in how identity is minted must
@@ -733,27 +728,42 @@ not move a supply chain. The identifier breaks the last tie only.
 The duplication is a defect in its own right, and 'Database.Quality' reports it
 as one, along with an input a retired block supplies.
 -}
-buildSupplierIndexByName :: UnitDB -> ActivityMap -> TechFlowDB -> NameOnlyIndex
-buildSupplierIndexByName unitDB activities techFlowDb =
+rankedProducers ::
+    (Ord k) =>
+    (T.Text -> Activity -> k) ->
+    UnitDB ->
+    ActivityMap ->
+    TechFlowDB ->
+    M.Map k (NE.NonEmpty NameProducer)
+rankedProducers keyOf unitDB activities techFlowDb =
     M.map (NE.sortWith producerOrder) $
         M.fromListWith
             (<>)
-            [ ( normalizeText (tfName flow)
-              , NameProducer
-                    { npActivityUUID = actUUID
-                    , npProductUUID = prodUUID
-                    , npActivityName = activityName act
-                    , npLocation = activityLocation act
-                    , npObsolete = activityIsObsolete act
-                    , npReferenceUnit = getUnitNameForExchange unitDB ex
-                    }
-                    NE.:| []
-              )
+            [ (keyOf (normalizeText (tfName flow)) act, producing actUUID prodUUID act ex NE.:| [])
             | ((actUUID, prodUUID), act) <- M.toList activities
             , ex <- exchanges act
             , exchangeIsReference ex
             , Just flow <- [M.lookup (exchangeFlowId ex) techFlowDb]
             ]
+  where
+    producing :: UUID.UUID -> UUID.UUID -> Activity -> Exchange -> NameProducer
+    producing actUUID prodUUID act ex =
+        NameProducer
+            { npActivityUUID = actUUID
+            , npProductUUID = prodUUID
+            , npActivityName = activityName act
+            , npLocation = activityLocation act
+            , npObsolete = activityIsObsolete act
+            , npReferenceUnit = getUnitNameForExchange unitDB ex
+            }
+
+-- | Supplier lookup for EcoSpold1: the reference product name and the location.
+buildSupplierIndex :: UnitDB -> ActivityMap -> TechFlowDB -> SupplierIndex
+buildSupplierIndex = rankedProducers (\name act -> (name, activityLocation act))
+
+-- | Supplier lookup for SimaPro: the reference product name and nothing else.
+buildSupplierIndexByName :: UnitDB -> ActivityMap -> TechFlowDB -> NameOnlyIndex
+buildSupplierIndexByName = rankedProducers const
 
 -- | The rank a producer holds among those sharing a product name.
 producerOrder :: NameProducer -> (Bool, T.Text, T.Text, UUID.UUID)
@@ -854,7 +864,7 @@ ecoSpold1LinkContext :: M.Map T.Text T.Text -> DatasetNumberIndex -> SimpleDatab
 ecoSpold1LinkContext locationAliases dsIndex db =
     ExchangeLinkContext
         { elcLocationAliases = locationAliases
-        , elcSupplierIndex = buildSupplierIndex (sdbActivities db) (sdbTechFlows db)
+        , elcSupplierIndex = buildSupplierIndex (sdbUnits db) (sdbActivities db) (sdbTechFlows db)
         , -- Name-only index, with location, for exchanges missing the location attribute
           elcNameIndex = buildSupplierIndexByNameWithLocation (sdbActivities db) (sdbTechFlows db)
         , elcDatasetIndex = dsIndex
@@ -886,9 +896,9 @@ Returns (fixed exchange, UnlinkedSummary)
 fixExchangeLink :: ExchangeLinkContext -> Activity -> Exchange -> (Exchange, UnlinkedSummary)
 fixExchangeLink ExchangeLinkContext{..} consumer ex@TechnosphereExchange{techFlowId = fid, techRole = role, techSupplierClaim = claim, techLocation = loc}
     | role == Input || role == ReferenceInput =
-        let linked overrides actUUID prodUUID =
+        let linked overrides ties actUUID prodUUID =
                 ( ex{techFlowId = prodUUID, techActivityLinkId = Just actUUID}
-                , mempty{usTotalLinks = 1, usFoundLinks = 1, usLocationOverrides = overrides}
+                , mempty{usTotalLinks = 1, usFoundLinks = 1, usLocationOverrides = overrides, usAmbiguousProducers = ties}
                 )
             unlinked flow lookupLoc =
                 let ue = UnlinkedExchange (tfName flow) lookupLoc
@@ -898,7 +908,7 @@ fixExchangeLink ExchangeLinkContext{..} consumer ex@TechnosphereExchange{techFlo
                     -- Tier 1: dataset-number lookup with name validation
                     case claimedNumber claim >>= \dsNum -> (,) dsNum <$> (M.lookup dsNum elcDatasetIndex >>= supplierNamed flow) of
                         Just (dsNum, (actUUID, prodUUID)) ->
-                            linked (locationOverride flow dsNum (actUUID, prodUUID)) actUUID prodUUID
+                            linked (locationOverride flow dsNum (actUUID, prodUUID)) [] actUUID prodUUID
                         Nothing ->
                             -- Tier 2: name + location lookup
                             let soleSupplier = M.lookup (normalizeText (tfName flow)) elcNameIndex >>= sole
@@ -907,13 +917,15 @@ fixExchangeLink ExchangeLinkContext{..} consumer ex@TechnosphereExchange{techFlo
                                     | otherwise = declaredLoc
                                 key = (normalizeText (tfName flow), lookupLoc)
                              in case M.lookup key elcSupplierIndex of
-                                    Just (actUUID, prodUUID) -> linked [] actUUID prodUUID
+                                    Just producers ->
+                                        let chosen = NE.head producers
+                                         in linked [] (tiedOn (tfName flow) producers) (npActivityUUID chosen) (npProductUUID chosen)
                                     Nothing ->
                                         -- Tier 3: the name alone, and only when it
                                         -- covers a single dataset. A name shared by
                                         -- several geographies names none of them.
                                         case soleSupplier of
-                                            Just (actUUID, prodUUID, _) -> linked [] actUUID prodUUID
+                                            Just (actUUID, prodUUID, _) -> linked [] [] actUUID prodUUID
                                             Nothing -> unlinked flow lookupLoc
                 Nothing ->
                     (ex, mempty{usTotalLinks = 1, usMissingLinks = 1})

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -441,8 +441,9 @@ spec = do
                         [refExchange flowUUID1]
                 acts = M.fromList [((actUUID1, flowUUID1), act)]
                 flows = M.fromList [(flowUUID1, minimalFlow flowUUID1 "Wheat")]
-                idx = buildSupplierIndex acts flows
-            M.lookup ("wheat", "GLO") idx `shouldBe` Just (actUUID1, flowUUID1)
+                idx = buildSupplierIndex M.empty acts flows
+            fmap (fmap npActivityUUID) (M.lookup ("wheat", "GLO") idx)
+                `shouldBe` Just (actUUID1 NE.:| [])
 
         it "does not index input (non-reference) exchanges" $ do
             let act =
@@ -452,8 +453,25 @@ spec = do
                         [inputExchange flowUUID1 "GLO"]
                 acts = M.fromList [((actUUID1, flowUUID1), act)]
                 flows = M.fromList [(flowUUID1, minimalFlow flowUUID1 "Wheat")]
-                idx = buildSupplierIndex acts flows
+                idx = buildSupplierIndex M.empty acts flows
             M.null idx `shouldBe` True
+
+        -- A name and a location do not tell two exports of one block apart, so
+        -- the key holds both and the ranking says which supplies. The retired
+        -- block here is the one a table keeping a single entry would have kept:
+        -- it holds the later identifier and the earlier name.
+        it "ranks a retired block behind the one still in service, at one location" $ do
+            let live = minimalActivity "wheat production, z" "GLO" [refExchange flowUUID1]
+                old = retired (minimalActivity "wheat production, a" "GLO" [refExchange flowUUID2])
+                acts = M.fromList [((actUUID1, flowUUID1), live), ((actUUID2, flowUUID2), old)]
+                flows =
+                    M.fromList
+                        [ (flowUUID1, minimalFlow flowUUID1 "Wheat")
+                        , (flowUUID2, minimalFlow flowUUID2 "Wheat")
+                        ]
+                idx = buildSupplierIndex M.empty acts flows
+            fmap (NE.toList . fmap npActivityUUID) (M.lookup ("wheat", "GLO") idx)
+                `shouldBe` Just [actUUID1, actUUID2]
 
     -- -----------------------------------------------------------------------
     -- buildSupplierIndexByName (name-only keyed, SimaPro style)
@@ -802,6 +820,23 @@ spec = do
                 db = simpleDBOf [heatA, heatB, greenhouse] names
                 (acts, _) = fixAllActivities (ecoSpold1LinkContext M.empty dsIndex db) (sdbActivities db)
             inputLinksIn acts `shouldBe` [Nothing]
+
+        -- Two exports of one block share a product name and a location, so the
+        -- key reaches both and the ranking picks; the retired one holds the
+        -- later identifier, which is what used to decide.
+        it "links to the block still in service, and says the choice was made" $ do
+            let live = ((actUUID1, flowUUID1), minimalActivity "wheat production, z" "GLO" [refExchange flowUUID1])
+                old = ((actUUID2, flowUUID2), retired (minimalActivity "wheat production, a" "GLO" [refExchange flowUUID2]))
+                consumer =
+                    ( (consumerUUID, breadUUID)
+                    , minimalActivity "bread production" "CH" [refExchange breadUUID, inputExchange flowUUID1 "GLO"]
+                    )
+                names = [(flowUUID1, "Wheat"), (flowUUID2, "Wheat"), (breadUUID, "Bread")]
+                db = simpleDBOf [live, old, consumer] names
+                (acts, summary) = fixAllActivities (ecoSpold1LinkContext M.empty M.empty db) (sdbActivities db)
+            inputLinksIn acts `shouldBe` [Just actUUID1]
+            usAmbiguousProducers summary
+                `shouldBe` [AmbiguousProducer{apProduct = "Wheat", apChosen = "wheat production, z", apCandidates = 2}]
 
     -- -----------------------------------------------------------------------
     -- countTotalTechInputs / countUnlinkedExchanges / collectUnlinkedProductNames


### PR DESCRIPTION
## The problem

The EcoSpold 1 supplier index is keyed on `(normalized product name, location)`
and held one activity per key. A name and a location do not tell two exports of
one block apart, nor the coproducts of an allocated block, so the key reaches
several activities often enough, and `M.fromList` kept whichever the map
ordering of `(activityUUID, productUUID)` put last.

That makes the identifier decide which supplier a database links. It is the one
ranking the code next door exists to avoid: `buildSupplierIndexByName` ranks the
same candidates on whether the source retired the block, then the activity name,
then the location, and takes the identifier only as the last tie-break, because
a change in how identity is minted must not move a supply chain.

The choice was also silent. Nothing in the load said a key had answered with
several activities.

## The solution

The index holds every activity a key reaches, ranked by `producerOrder`, and the
linker takes the head: a block the source filed under an obsolete category never
supplies while one still in service answers the same key, then the activity
name, then the location, and the identifier breaks the last tie only.

The ranking is now written once. `buildSupplierIndex` and
`buildSupplierIndexByName` were the same fold over reference exchanges under two
different keys, so they become one builder taking the key function, and the
paragraph describing the ranking lives with it. The name-only index the
EcoSpold1 linker kept for itself goes with them: its value was three fields of
the record the other one holds, and its single reader only accepts a name
covering one dataset, so the ordering costs it nothing.

A key answered by several activities is reported through `AmbiguousProducer` and
`reportAmbiguousProducers`, already in place for the name-only index and already
called on this path.

## Remarks

This changes which supplier some inputs link to, and that is the point: the
order it replaces was the order of the identifiers. On the axes where both
orders are arbitrary it swaps one deterministic tie-break for another; on the
axis that matters it can no longer prefer a retired block to one in service.

That last axis is dormant on EcoSpold 1 today, and the doc now says so.
`activityIsObsolete` answers on a `Category` segment reading `Obsolete`, a
spelling EcoSpold 1 does not write, so every dataset of that format answers
`False` and the ranking starts at the activity name. Teaching the reader the
spelling that format does use is a change of its own, on a function two other
readers share.

The index carries a reference unit per candidate it does not use, because it
now shares `NameProducer` with the name-only index. A second near-identical
record to drop one field would cost more than it saves.

## How to test

```
cabal test lca-tests
```

`LoaderSpec` gains two examples: the ranking puts a retired block behind one
still in service at the same location, and an input reaching both links to the
one in service while the summary records that two answered. Both fixtures give
the retired block the later identifier, which is what the previous index kept.

Run here: 2578 examples, 0 failures, 2 pending. `fourmolu --mode check` and
`hlint` clean on both files.
