### PR TITLE
Say once that a report keeps the first row of a key

### DIFF
--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -108,7 +108,6 @@ import Control.Monad
 import Data.Bits (xor)
 import qualified Data.ByteString as BS
 import Data.Char (toLower)
-import Data.Containers.ListUtils (nubOrdOn)
 import Data.Either (lefts, partitionEithers, rights)
 import Data.List (intercalate, sort, sortBy, sortOn)
 import qualified Data.List.NonEmpty as NE
@@ -646,10 +645,12 @@ reportAmbiguousProducers ties = do
                 apCandidates
                 (T.unpack apChosen)
   where
-    -- One line per choice made, and the first one made: the count it carries
-    -- is the same on every row that shares the product and the activity.
+    -- One line per choice made, and the first one made. A later row for the
+    -- same product and activity can carry a different count, when its input
+    -- named its supplier and narrowed the field; the line says which choice was
+    -- made, and the report below names the inputs that named one.
     unique :: [AmbiguousProducer]
-    unique = nubOrdOn (\t -> (apProduct t, apChosen t)) ties
+    unique = oncePerKey (\t -> (apProduct t, apChosen t)) ties
 
 -- | Report grouped summary of unlinked exchanges
 reportUnlinkedActivities :: UnlinkedSummary -> IO ()

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -108,6 +108,7 @@ import Control.Monad
 import Data.Bits (xor)
 import qualified Data.ByteString as BS
 import Data.Char (toLower)
+import Data.Containers.ListUtils (nubOrdOn)
 import Data.Either (lefts, partitionEithers, rights)
 import Data.List (intercalate, sort, sortBy, sortOn)
 import qualified Data.List.NonEmpty as NE
@@ -645,8 +646,10 @@ reportAmbiguousProducers ties = do
                 apCandidates
                 (T.unpack apChosen)
   where
+    -- One line per choice made, and the first one made: the count it carries
+    -- is the same on every row that shares the product and the activity.
     unique :: [AmbiguousProducer]
-    unique = M.elems $ M.fromList [((apProduct t, apChosen t), t) | t <- ties]
+    unique = nubOrdOn (\t -> (apProduct t, apChosen t)) ties
 
 -- | Report grouped summary of unlinked exchanges
 reportUnlinkedActivities :: UnlinkedSummary -> IO ()

--- a/src/Method/Coverage.hs
+++ b/src/Method/Coverage.hs
@@ -26,6 +26,7 @@ module Method.Coverage (
     collectionBridges,
 ) where
 
+import Data.Containers.ListUtils (nubOrdOn)
 import Data.List (sortOn)
 import qualified Data.Map.Strict as M
 import Data.Maybe (catMaybes, listToMaybe)
@@ -139,8 +140,8 @@ collectionBridges name total characterized perMethod =
     -- keeps its first-seen strategy.
     flowsOf items =
         sortOn brfFlowName $
-            [ BridgedFlow fname strat
-            | (fname, strat) <- M.toList (M.fromListWith (\_ old -> old) [(bfName f, s) | (_, f, s) <- items])
+            [ BridgedFlow (bfName f) s
+            | (_, f, s) <- nubOrdOn (\(_, f, _) -> bfName f) items
             ]
 
 isExact :: Reach -> Bool

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -36,6 +36,7 @@ import qualified Data.Vector.Unboxed as VU
 import GHC.Generics (Generic)
 
 import Control.Lens ((&), (?~))
+import Data.Containers.ListUtils (nubOrdOn)
 import Data.List (find, nub)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
@@ -2041,37 +2042,26 @@ instance Monoid CrossDBLinkingStats where
             , cdlCutoffWasteCount = 0
             }
 
--- | Deduplicate location fallbacks by (product, requestedLoc)
+-- The four report lists below keep one row per (product, requested location):
+-- the same fallback is taken once per input that asks for it, and a reader
+-- wants the case, not the tally. The first row seen is the one kept, so each
+-- list stays in the order the load found them.
+
+-- | One location fallback per (product, requested location).
 deduplicateFallbacks :: [LocationFallback] -> [LocationFallback]
-deduplicateFallbacks =
-    map snd
-        . M.toList
-        . M.fromListWith (\_ b -> b)
-        . map (\f -> ((lfProduct f, lfRequested f), f))
+deduplicateFallbacks = nubOrdOn (\f -> (lfProduct f, lfRequested f))
 
--- | Deduplicate unresolved entries by (product, requestedLoc)
+-- | One unresolved entry per (product, requested location).
 deduplicateUnresolved :: [LocationUnresolved] -> [LocationUnresolved]
-deduplicateUnresolved =
-    map snd
-        . M.toList
-        . M.fromListWith (\_ b -> b)
-        . map (\u -> ((luProduct u, luRequested u), u))
+deduplicateUnresolved = nubOrdOn (\u -> (luProduct u, luRequested u))
 
--- | Deduplicate attribute fallbacks by (product, requestedLoc)
+-- | One attribute fallback per (product, requested location).
 deduplicateAttributeFallbacks :: [AttributeFallback] -> [AttributeFallback]
-deduplicateAttributeFallbacks =
-    map snd
-        . M.toList
-        . M.fromListWith (\_ b -> b)
-        . map (\a -> ((afProduct a, afRequested a), a))
+deduplicateAttributeFallbacks = nubOrdOn (\a -> (afProduct a, afRequested a))
 
--- | Deduplicate supplier ambiguities by (product, requestedLoc)
+-- | One supplier ambiguity per (product, requested location).
 deduplicateSupplierAmbiguities :: [SupplierAmbiguity] -> [SupplierAmbiguity]
-deduplicateSupplierAmbiguities =
-    map snd
-        . M.toList
-        . M.fromListWith (\_ b -> b)
-        . map (\a -> ((saProduct a, saRequested a), a))
+deduplicateSupplierAmbiguities = nubOrdOn (\a -> (saProduct a, saRequested a))
 
 -- | Number of resolved cross-DB links
 crossDBLinksCount :: CrossDBLinkingStats -> Int

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -37,7 +37,7 @@ import GHC.Generics (Generic)
 
 import Control.Lens ((&), (?~))
 import Data.Containers.ListUtils (nubOrdOn)
-import Data.List (find, nub)
+import Data.List (find, nub, sortOn)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import Data.OpenApi (NamedSchema (..), OpenApiType (..), ToSchema (..), enum_, type_)
@@ -2042,26 +2042,32 @@ instance Monoid CrossDBLinkingStats where
             , cdlCutoffWasteCount = 0
             }
 
--- The four report lists below keep one row per (product, requested location):
--- the same fallback is taken once per input that asks for it, and a reader
--- wants the case, not the tally. The first row seen is the one kept, so each
--- list stays in the order the load found them.
+{- | One row per key, the first one seen, ordered by the key.
+
+A report list holds one row per occurrence, and the same case is met once per
+input that runs into it: a reader wants the case, not the tally. Which of the
+rows survives has to be said rather than left to the argument order of
+'M.fromListWith', and the key order is what groups a product's rows together on
+the page that shows them.
+-}
+oncePerKey :: (Ord k) => (a -> k) -> [a] -> [a]
+oncePerKey key = sortOn key . nubOrdOn key
 
 -- | One location fallback per (product, requested location).
 deduplicateFallbacks :: [LocationFallback] -> [LocationFallback]
-deduplicateFallbacks = nubOrdOn (\f -> (lfProduct f, lfRequested f))
+deduplicateFallbacks = oncePerKey (\f -> (lfProduct f, lfRequested f))
 
 -- | One unresolved entry per (product, requested location).
 deduplicateUnresolved :: [LocationUnresolved] -> [LocationUnresolved]
-deduplicateUnresolved = nubOrdOn (\u -> (luProduct u, luRequested u))
+deduplicateUnresolved = oncePerKey (\u -> (luProduct u, luRequested u))
 
 -- | One attribute fallback per (product, requested location).
 deduplicateAttributeFallbacks :: [AttributeFallback] -> [AttributeFallback]
-deduplicateAttributeFallbacks = nubOrdOn (\a -> (afProduct a, afRequested a))
+deduplicateAttributeFallbacks = oncePerKey (\a -> (afProduct a, afRequested a))
 
 -- | One supplier ambiguity per (product, requested location).
 deduplicateSupplierAmbiguities :: [SupplierAmbiguity] -> [SupplierAmbiguity]
-deduplicateSupplierAmbiguities = nubOrdOn (\a -> (saProduct a, saRequested a))
+deduplicateSupplierAmbiguities = oncePerKey (\a -> (saProduct a, saRequested a))
 
 -- | Number of resolved cross-DB links
 crossDBLinksCount :: CrossDBLinkingStats -> Int


### PR DESCRIPTION
## The problem

Five places collapse a report list to one row per key, and none of them said
which row survives.

Four of them wrote `M.fromListWith (\_ b -> b)`. `fromListWith f` calls
`f newValue oldValue`, so `b` is the *older* row and the expression keeps the
first one seen, which is the opposite of what it reads like. A reader who takes
it at face value reads the policy backwards.

The fifth wrote plain `M.fromList`, which keeps the last. So one of the five had
a policy contrary to the other four, and nothing on the page said so.

## The solution

All five go through `oncePerKey`, which keeps the first occurrence of a key and
then orders by that key: `nubOrdOn` from `containers` says which row survives,
the sort keeps the order the intermediate map used to give. The four in
`Types.hs` become one line each, under a comment saying what a row of these
lists is and why one per key is enough.

## Remarks

One behaviour change falls out, on report output, not on a computed number:
`reportAmbiguousProducers` keeps the first choice made for a
(product, activity) pair rather than the last. A later row for that pair can
carry a different count, when its input named its supplier and narrowed the
field, so this is a real choice and the comment says what it is.

Everything else keeps the output it had. Four of these lists are the payload of
the setup page as well as the log, and that page renders them in the order it is
given, so the key order is worth keeping: dropping the map dropped the order
with it, and `oncePerKey` puts it back.

`Method/Coverage.hs` sorts its rows by name immediately after, so it keeps the
plain `nubOrdOn` and nothing there changes at all.

## How to test

```
cabal test lca-tests
```

Run here: 2576 examples, 0 failures, 2 pending. `fourmolu --mode check` and
`hlint` clean on the three files.
