### PR TITLE
Read the retired marker wherever a source puts it

### DIFF
--- a/src/Types.hs
+++ b/src/Types.hs
@@ -22,7 +22,7 @@ import Data.Int (Int32)
 import qualified Data.IntSet as IS
 import qualified Data.Map as M
 import qualified Data.Map.Strict as MS
-import Data.Maybe (isJust, listToMaybe)
+import Data.Maybe (isJust, listToMaybe, mapMaybe)
 import qualified Data.Set as S
 import Data.Store (Size (..), Store (..))
 import Data.Text (Text)
@@ -844,28 +844,30 @@ sourceBlockOf db pid = maybe orphan blockOfRef (processIdToRef db pid)
 
 {- | Is this dataset filed in its source's obsolete category?
 
-A source that keeps a retired process in its export says so in the category,
-and the two conventions put the word in different places. A SimaPro CSV export
-gives it a segment of its own (@Others\\Obsolete@, or @Autres\\Obsolete@ in a
-French export). An EcoSpold 1 export appends it to the words a segment is
-already made of, one segment at a time: @material, obsolete@, or
-@wood, obsolete\\extraction, obsolete@.
+A source that keeps a retired process in its export says so in its
+classification, and the two conventions differ in where the word goes and which
+cell carries it. A SimaPro CSV export gives it a segment of its own in the
+category (@Others\\Obsolete@, or @Autres\\Obsolete@ in a French export). An
+EcoSpold 1 export appends it to the words a segment is already made of, one
+segment at a time, and writes it in whichever of the two cells describes the
+retired thing: @category="material, obsolete"@, or a category that says nothing
+beside @subCategory="transport, obsolete\\road, obsolete"@.
 
-Both are the same statement, so both are read: the category is cut into
-segments and each segment into its comma-separated words, and the dataset is
+Both are the same statement, so both cells are read and cut the same way: into
+segments, then each segment into its comma-separated words, and the dataset is
 retired when one of those words is @obsolete@. Such a process still carries its
 exchanges and still computes; what its author says is that a newer one has
-replaced it. Read on the @Category@ classification, which is the cell the
-block's product row carries. Formats with no such convention never say yes.
+replaced it. Formats with no such convention never say yes.
 -}
 activityIsObsolete :: Activity -> Bool
-activityIsObsolete =
-    maybe False (elem "obsolete" . map T.toCaseFold . categoryWords)
-        . M.lookup "Category"
-        . activityClassification
+activityIsObsolete act =
+    any (elem "obsolete" . classificationWords) (mapMaybe cell ["Category", "SubCategory"])
   where
-    categoryWords :: Text -> [Text]
-    categoryWords = concatMap (map T.strip . T.splitOn ",") . T.splitOn "\\"
+    cell :: Text -> Maybe Text
+    cell k = M.lookup k (activityClassification act)
+
+    classificationWords :: Text -> [Text]
+    classificationWords = map (T.toCaseFold . T.strip) . concatMap (T.splitOn ",") . T.splitOn "\\"
 
 {- | Loop-aware tree for SVG export. Every node that exists names the row it
 sits at, so an allocated activity written as several coproduct rows is several

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -844,19 +844,28 @@ sourceBlockOf db pid = maybe orphan blockOfRef (processIdToRef db pid)
 
 {- | Is this dataset filed in its source's obsolete category?
 
-The tool that writes SimaPro CSV files keeps a retired process in the export,
-under a category whose last segment is @Obsolete@ (@Others\\Obsolete@, or
-@Autres\\Obsolete@ in a French export). Such a process still carries its
+A source that keeps a retired process in its export says so in the category,
+and the two conventions put the word in different places. A SimaPro CSV export
+gives it a segment of its own (@Others\\Obsolete@, or @Autres\\Obsolete@ in a
+French export). An EcoSpold 1 export appends it to the words a segment is
+already made of, one segment at a time: @material, obsolete@, or
+@wood, obsolete\\extraction, obsolete@.
+
+Both are the same statement, so both are read: the category is cut into
+segments and each segment into its comma-separated words, and the dataset is
+retired when one of those words is @obsolete@. Such a process still carries its
 exchanges and still computes; what its author says is that a newer one has
-replaced it, and the writing tool warns whenever a calculation reaches one.
-Read here on the @Category@ classification, which is the cell the block's
-product row carries. Formats with no such convention never say yes.
+replaced it. Read on the @Category@ classification, which is the cell the
+block's product row carries. Formats with no such convention never say yes.
 -}
 activityIsObsolete :: Activity -> Bool
 activityIsObsolete =
-    maybe False (elem "obsolete" . map T.toCaseFold . T.splitOn "\\")
+    maybe False (elem "obsolete" . map T.toCaseFold . categoryWords)
         . M.lookup "Category"
         . activityClassification
+  where
+    categoryWords :: Text -> [Text]
+    categoryWords = concatMap (map T.strip . T.splitOn ",") . T.splitOn "\\"
 
 {- | Loop-aware tree for SVG export. Every node that exists names the row it
 sits at, so an allocated activity written as several coproduct rows is several

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -487,6 +487,23 @@ spec = do
             firstProducer "pork, bone" (buildSupplierIndexByName M.empty acts flows)
                 `shouldBe` Just (actUUID1, flowUUID1, "unknown")
 
+        it "reads the marker a source appends to the words of a category" $ do
+            -- The other convention: no segment of its own, the word is added to
+            -- the words the segment already carries, one segment at a time.
+            let obsoleteWords act = act{activityClassification = M.singleton "Category" "wood, obsolete\\extraction, obsolete"}
+                acts =
+                    M.fromList
+                        [ ((actUUID1, flowUUID1), obsoleteWords (minimalActivity "sawnwood, a" "FR" [refExchange flowUUID1]))
+                        , ((actUUID2, flowUUID2), minimalActivity "sawnwood, z" "FR" [refExchange flowUUID2])
+                        ]
+                flows =
+                    M.fromList
+                        [ (flowUUID1, minimalFlow flowUUID1 "Sawnwood")
+                        , (flowUUID2, minimalFlow flowUUID2 "Sawnwood")
+                        ]
+            firstProducer "sawnwood" (buildSupplierIndexByName M.empty acts flows)
+                `shouldBe` Just (actUUID2, flowUUID2, "unknown")
+
         it "does not index a prefix of a product name" $ do
             -- "Urea {RER}| urea production" and "Urea {RoW}| urea production"
             -- are not the same product, and neither is "Urea".

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -487,21 +487,30 @@ spec = do
             firstProducer "pork, bone" (buildSupplierIndexByName M.empty acts flows)
                 `shouldBe` Just (actUUID1, flowUUID1, "unknown")
 
-        it "reads the marker a source appends to the words of a category" $ do
+        it "reads the marker a source appends to the words of a subcategory" $ do
             -- The other convention: no segment of its own, the word is added to
-            -- the words the segment already carries, one segment at a time.
-            let obsoleteWords act = act{activityClassification = M.singleton "Category" "wood, obsolete\\extraction, obsolete"}
+            -- the words a segment already carries, one segment at a time, and
+            -- written in whichever cell describes the retired thing. Here the
+            -- category says nothing and the subcategory carries it all.
+            let obsoleteWords act =
+                    act
+                        { activityClassification =
+                            M.fromList
+                                [ ("Category", "transport systems")
+                                , ("SubCategory", "transport, obsolete\\road, obsolete")
+                                ]
+                        }
                 acts =
                     M.fromList
-                        [ ((actUUID1, flowUUID1), obsoleteWords (minimalActivity "sawnwood, a" "FR" [refExchange flowUUID1]))
-                        , ((actUUID2, flowUUID2), minimalActivity "sawnwood, z" "FR" [refExchange flowUUID2])
+                        [ ((actUUID1, flowUUID1), obsoleteWords (minimalActivity "lorry transport, a" "FR" [refExchange flowUUID1]))
+                        , ((actUUID2, flowUUID2), minimalActivity "lorry transport, z" "FR" [refExchange flowUUID2])
                         ]
                 flows =
                     M.fromList
-                        [ (flowUUID1, minimalFlow flowUUID1 "Sawnwood")
-                        , (flowUUID2, minimalFlow flowUUID2 "Sawnwood")
+                        [ (flowUUID1, minimalFlow flowUUID1 "Transport, lorry")
+                        , (flowUUID2, minimalFlow flowUUID2 "Transport, lorry")
                         ]
-            firstProducer "sawnwood" (buildSupplierIndexByName M.empty acts flows)
+            firstProducer "transport, lorry" (buildSupplierIndexByName M.empty acts flows)
                 `shouldBe` Just (actUUID2, flowUUID2, "unknown")
 
         it "does not index a prefix of a product name" $ do


### PR DESCRIPTION
## The problem

`activityIsObsolete` decides whether a source has retired a dataset, and it read
one of the two conventions in use.

A SimaPro CSV export gives the word a category segment of its own:
`Others\Obsolete`, or `Autres\Obsolete` in a French export. An EcoSpold 1 export
appends it to the words a segment is already made of, one segment at a time, and
writes it in whichever of the two classification cells describes the retired
thing: `category="material, obsolete"`, or a category that says nothing beside
`subCategory="transport, obsolete\road, obsolete"`.

Splitting the category on backslashes and looking for a segment reading
`obsolete` sees the first spelling and never the second, and reading the
category alone misses the datasets that carry the word only in the subcategory.
So every EcoSpold 1 dataset answered "in service", including the ones its own
file had retired, and the two readers that ask the question were reading a
constant.

## The solution

Both classification cells are cut into segments, and each segment into its
comma-separated words; the dataset is retired when one of those words is
`obsolete`. Both conventions are the same statement and both are now read. A
classification that carries the word nowhere still answers no, as before.

## Remarks

Two readers change answer on EcoSpold 1 data, both in the direction the file
asked for:

- the supplier ranking (`producerOrder`) puts a retired block behind one still
  in service, so a product made by both stops being supplied by the retired one;
- the quality report can name a product every producer of which is retired,
  which it could not do for that format.

The word has to be a whole comma-separated component, not a substring, so a
category that merely mentions obsolescence in a longer phrase is unaffected.

## How to test

```
cabal test lca-tests
```

`LoaderSpec` gains one example, on the shape the parser emits for that format: a
category naming a subject and a subcategory carrying the word. The retired
activity holds the earlier name, and the ranking still puts it second.

Run here: 2577 examples, 0 failures, 2 pending. `fourmolu --mode check` and
`hlint` clean on both files.
