### PR TITLE
Refuse a reference table that answers a key twice

### DIFF
--- a/src/Method/ParserNW.hs
+++ b/src/Method/ParserNW.hs
@@ -22,6 +22,8 @@ module Method.ParserNW (
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BC
 import Data.Char (isAsciiUpper)
+import Data.Indexing (uniqueIndex)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -50,13 +52,21 @@ parseNormWeightCSVBytes fallbackName bs =
             [] -> ';'
      in case dropHeader rest of
             [] -> Left "NW CSV: no data rows after header"
-            rows ->
+            rows -> do
                 let parsed = [parseRow delim l | l <- rows, not (BS.null (BC.strip l))]
-                    normMap = M.fromList [(cat, n) | (cat, n, _) <- parsed, not (T.null cat)]
-                    weightMap = M.fromList [(cat, w) | (cat, _, w) <- parsed, not (T.null cat)]
-                 in if M.null normMap && M.null weightMap
-                        then Left "NW CSV: no valid rows parsed"
-                        else Right $ NormWeightSet name normMap weightMap
+                -- One category named twice carries two normalization factors and
+                -- two weights, and the file says nothing about which is meant.
+                normMap <- categoryIndex [(cat, n) | (cat, n, _) <- parsed, not (T.null cat)]
+                weightMap <- categoryIndex [(cat, w) | (cat, _, w) <- parsed, not (T.null cat)]
+                if M.null normMap && M.null weightMap
+                    then Left "NW CSV: no valid rows parsed"
+                    else Right $ NormWeightSet name normMap weightMap
+
+-- | Index rows on their category, or refuse and name the ones spelled twice.
+categoryIndex :: [(Text, Double)] -> Either String (M.Map Text Double)
+categoryIndex rows = case uniqueIndex rows of
+    Right table -> Right table
+    Left cats -> Left $ "NW CSV: two rows for the same category: " <> T.unpack (T.intercalate ", " (NE.toList cats))
 
 -- | Extract set name from "# normalization-weighting set: NAME" comment.
 extractName :: [BS.ByteString] -> Text -> Text

--- a/src/Method/ParserNW.hs
+++ b/src/Method/ParserNW.hs
@@ -56,14 +56,13 @@ parseNormWeightCSVBytes fallbackName bs =
                 let parsed = [parseRow delim l | l <- rows, not (BS.null (BC.strip l))]
                 -- One category named twice carries two normalization factors and
                 -- two weights, and the file says nothing about which is meant.
-                normMap <- categoryIndex [(cat, n) | (cat, n, _) <- parsed, not (T.null cat)]
-                weightMap <- categoryIndex [(cat, w) | (cat, _, w) <- parsed, not (T.null cat)]
-                if M.null normMap && M.null weightMap
+                factors <- categoryIndex [(cat, (n, w)) | (cat, n, w) <- parsed, not (T.null cat)]
+                if M.null factors
                     then Left "NW CSV: no valid rows parsed"
-                    else Right $ NormWeightSet name normMap weightMap
+                    else Right $ NormWeightSet name (M.map fst factors) (M.map snd factors)
 
 -- | Index rows on their category, or refuse and name the ones spelled twice.
-categoryIndex :: [(Text, Double)] -> Either String (M.Map Text Double)
+categoryIndex :: [(Text, (Double, Double))] -> Either String (M.Map Text (Double, Double))
 categoryIndex rows = case uniqueIndex rows of
     Right table -> Right table
     Left cats -> Left $ "NW CSV: two rows for the same category: " <> T.unpack (T.intercalate ", " (NE.toList cats))

--- a/src/Method/Types.hs
+++ b/src/Method/Types.hs
@@ -51,10 +51,14 @@ module Method.Types (
 import Control.Applicative ((<|>))
 import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON, ToJSON)
+import Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as BL
 import Data.Char (isAsciiLower, isAsciiUpper)
 import Data.Csv (HasHeader (..), decode)
+import Data.Indexing (uniqueIndex)
 import Data.List (sortOn)
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import qualified Data.Maybe
 import Data.Store (Store)
@@ -316,7 +320,17 @@ buildCompartmentMapFromCSV csvData =
                       )
                     | (sm, ss, sq, tm, ts, tq) <- entries
                     ]
-             in Right $ M.fromList pairs
+             in first repeatedCompartments (uniqueIndex pairs)
+  where
+    -- Two rows for one source compartment give two targets, and the file says
+    -- nothing about which was meant.
+    repeatedCompartments :: NonEmpty (Text, Text, Text) -> String
+    repeatedCompartments keys =
+        "two rows normalize the same compartment: "
+            <> T.unpack (T.intercalate (T.pack "; ") (map spelt (NE.toList keys)))
+
+    spelt :: (Text, Text, Text) -> Text
+    spelt (sm, ss, sq) = T.intercalate (T.pack ",") [sm, ss, sq]
 
 {- | Normalize a compartment using the mapping.
 
@@ -426,8 +440,16 @@ buildEnergyDensityMapFromCSV csvData =
     case decode HasHeader csvData of
         Left err -> Left $ "CSV parse error: " <> err
         Right rows ->
-            M.fromList <$> traverse toEntry (V.toList (rows :: V.Vector (Text, Double, Text, Text)))
+            traverse toEntry (V.toList (rows :: V.Vector (Text, Double, Text, Text)))
+                >>= first repeatedFlows . uniqueIndex
   where
+    -- Two densities for one flow are two answers at score time, and normalizing
+    -- the name can bring together two rows that were spelt apart.
+    repeatedFlows :: NonEmpty Text -> String
+    repeatedFlows names =
+        "two rows give a density for the same flow: " <> T.unpack (T.intercalate (T.pack ", ") (NE.toList names))
+
+    toEntry :: (Text, Double, Text, Text) -> Either String (Text, EnergyDensity)
     toEntry (name, value, targetUnit, nativeUnit)
         | value <= 0 =
             Left $ "density must be positive (flow: " <> T.unpack name <> ")"

--- a/src/Method/Types.hs
+++ b/src/Method/Types.hs
@@ -55,7 +55,7 @@ import Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as BL
 import Data.Char (isAsciiLower, isAsciiUpper)
 import Data.Csv (HasHeader (..), decode)
-import Data.Indexing (uniqueIndex)
+import Data.Indexing (collisions, uniqueIndex)
 import Data.List (sortOn)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
@@ -439,15 +439,27 @@ buildEnergyDensityMapFromCSV :: BL.ByteString -> Either String EnergyDensityMap
 buildEnergyDensityMapFromCSV csvData =
     case decode HasHeader csvData of
         Left err -> Left $ "CSV parse error: " <> err
-        Right rows ->
-            traverse toEntry (V.toList (rows :: V.Vector (Text, Double, Text, Text)))
-                >>= first repeatedFlows . uniqueIndex
+        Right rows -> do
+            let entries = V.toList (rows :: V.Vector (Text, Double, Text, Text))
+            table <- traverse toEntry entries
+            case collisions [(normalizeName name, name) | (name, _, _, _) <- entries] of
+                [] -> Right (M.fromList table)
+                clashes -> Left (repeatedFlows clashes)
   where
-    -- Two densities for one flow are two answers at score time, and normalizing
-    -- the name can bring together two rows that were spelt apart.
-    repeatedFlows :: NonEmpty Text -> String
-    repeatedFlows names =
-        "two rows give a density for the same flow: " <> T.unpack (T.intercalate (T.pack ", ") (NE.toList names))
+    -- Two densities for one flow are two answers at score time, and the file
+    -- has to give one row instead. The spellings are what the message names:
+    -- the key is the normalized name, which lowercases and drops a unit
+    -- suffix, so two rows can collide without looking alike.
+    repeatedFlows :: [(Text, NonEmpty Text)] -> String
+    repeatedFlows clashes =
+        "two rows give a density for the same flow, where the table needs one: "
+            <> T.unpack (T.intercalate (T.pack "; ") (map spelt clashes))
+
+    spelt :: (Text, NonEmpty Text) -> Text
+    spelt (key, names) = key <> T.pack " (" <> T.intercalate (T.pack ", ") (map quoted (NE.toList names)) <> T.pack ")"
+
+    quoted :: Text -> Text
+    quoted t = T.pack "\"" <> t <> T.pack "\""
 
     toEntry :: (Text, Double, Text, Text) -> Either String (Text, EnergyDensity)
     toEntry (name, value, targetUnit, nativeUnit)

--- a/test/EnergyDensityCFSpec.hs
+++ b/test/EnergyDensityCFSpec.hs
@@ -339,9 +339,14 @@ spec = do
             csv <- BL.readFile "data/energy_density.csv"
             buildEnergyDensityMapFromCSV csv `shouldSatisfy` isRight
 
-        it "rejects two rows whose names normalize to the same key" $
-            buildEnergyDensityMapFromCSV (BLC.pack "flow_name,value,target_unit,native_unit\n\"Gas, natural/m3\",38.29,MJ,m3\n\"Gas, natural\",45.0,MJ,kg\n")
-                `shouldSatisfy` isLeft
+        it "rejects two rows whose names normalize to the same key, naming both spellings" $
+            case buildEnergyDensityMapFromCSV (BLC.pack "flow_name,value,target_unit,native_unit\n\"Gas, natural/m3\",38.29,MJ,m3\n\"Gas, natural\",45.0,MJ,kg\n") of
+                Left err -> do
+                    -- The key alone would send the reader looking for a string
+                    -- the file does not contain.
+                    err `shouldContain` "Gas, natural/m3"
+                    err `shouldContain` "Gas, natural\""
+                Right _ -> expectationFailure "Should have refused two densities for one key"
 
         it "rejects a non-positive value" $
             buildEnergyDensityMapFromCSV (BLC.pack "flow_name,value,target_unit,native_unit\nPeat,0,MJ,kg\n")

--- a/test/EnergyDensityCFSpec.hs
+++ b/test/EnergyDensityCFSpec.hs
@@ -25,8 +25,9 @@ Plus the CSV reader: it keys by normalized name and rejects malformed rows.
 -}
 module EnergyDensityCFSpec (spec) where
 
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as BLC
-import Data.Either (fromRight, isLeft)
+import Data.Either (fromRight, isLeft, isRight)
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import Data.UUID (UUID)
@@ -327,6 +328,20 @@ spec = do
             case buildEnergyDensityMapFromCSV (BLC.pack "flow_name,value,target_unit,native_unit\n\"Coal, hard\",18.01,MJ,kg\n") of
                 Left err -> expectationFailure err
                 Right m -> M.lookup (normalizeName "Coal, hard") m `shouldBe` Just (EnergyDensity 18.01 "MJ" "kg")
+
+        -- The key is the normalized name, and normalizing drops a unit suffix,
+        -- so a table listing a substance per m3 and per kg lands both rows on
+        -- one key. Keeping whichever came last would score the flow on the
+        -- wrong basis, which is what the two units are there to prevent.
+        -- The table the engine ships goes through the same refusal, and nothing
+        -- else reads it here: a row added twice would stop the load.
+        it "accepts the table shipped with the engine" $ do
+            csv <- BL.readFile "data/energy_density.csv"
+            buildEnergyDensityMapFromCSV csv `shouldSatisfy` isRight
+
+        it "rejects two rows whose names normalize to the same key" $
+            buildEnergyDensityMapFromCSV (BLC.pack "flow_name,value,target_unit,native_unit\n\"Gas, natural/m3\",38.29,MJ,m3\n\"Gas, natural\",45.0,MJ,kg\n")
+                `shouldSatisfy` isLeft
 
         it "rejects a non-positive value" $
             buildEnergyDensityMapFromCSV (BLC.pack "flow_name,value,target_unit,native_unit\nPeat,0,MJ,kg\n")

--- a/test/MappingSpec.hs
+++ b/test/MappingSpec.hs
@@ -11,6 +11,7 @@ import Data.UUID (UUID, fromWords, nil)
 import Data.UUID.V4 (nextRandom)
 import Test.Hspec
 
+import Data.Either (isLeft)
 import Data.Maybe (isJust)
 import Method.ChemSynonyms (emptyChemSynonyms, parseChemSynonymsCSV)
 import Method.Mapping
@@ -625,6 +626,13 @@ spec = do
             -- what scores, not merely that the wildcard was blocked: a gate that
             -- only blocked would leave this uncharacterized, at 0.
             scoreWith [uns, mkCFComp "Nitrogen, total" "water" "ocean" 5.0] "ocean" `shouldReturn` 5.0
+
+        -- The key is lowercased and stripped, so two rows that differ only in
+        -- case are one rule with two targets, and the file says nothing about
+        -- which was meant.
+        it "refuses two rows normalizing the same source compartment" $
+            buildCompartmentMapFromCSV "source_medium,source_sub,source_qualifier,target_medium,target_sub,target_qualifier\nwater,sea water,,water,ocean,\nWater,Sea water,,water,river,\n"
+                `shouldSatisfy` isLeft
 
         it "recognizes the sea through the spelling compartments.csv translates" $ do
             -- 'isForeignMediumSub' names the canonical subcompartment only, so

--- a/test/MethodSpec.hs
+++ b/test/MethodSpec.hs
@@ -1094,6 +1094,12 @@ spec = do
                 Left err -> expectationFailure $ "Parse failed: " ++ err
                 Right nw -> nwName nw `shouldBe` "my-fallback"
 
+        it "refuses a category that carries two sets of factors" $ do
+            let csv = "category;normalization;weighting\nCC;1e-4;0.21\nCC;2e-4;0.79\n"
+            case parseNormWeightCSVBytes "x" (TE.encodeUtf8 (T.pack csv)) of
+                Left err -> err `shouldContain` "CC"
+                Right _ -> expectationFailure "Should have refused the repeated category"
+
         it "fails on empty data" $ do
             let csv = "# normalization-weighting set: Empty\ncategory;normalization;weighting\n"
             case parseNormWeightCSVBytes "x" (TE.encodeUtf8 (T.pack csv)) of


### PR DESCRIPTION
## Problem

Three tables the engine ships and reads from CSV build their index with
`M.fromList`, which keeps the last row of a repeated key and says nothing:
the compartment normalization table, the energy density table, and the
normalization/weighting parser.

The keys are normalized before they are compared, which is where the silence
hurts most. The compartment key is lowercased and stripped, so two rows that
differ only in case are one rule with two targets. The energy density key goes
through `normalizeName`, which drops a unit suffix, so a table listing a
substance per m3 and per kg lands both rows on one key and keeps whichever came
last. The flow then scores on the wrong basis, which is the opposite of what
naming a native unit is for, and of what `buildEnergyDensityMapFromCSV`'s
documentation already promised: "never a silently inert or wrong-dimension
entry".

## Solution

Each of the three builders now refuses and names the keys that repeated.

The density refusal names the spellings as well as the key, because the key is
normalized and need not appear in the file: a table holding "Gas, natural/m3"
and "Gas, natural" is refused on those two names, not on "gas natural". It also
says what the table needs instead, which is one row denominated in one native
unit - there is no way to keep both, since the read path looks a flow up by the
normalized name.

The tables shipped today have no repeats, so nothing that loads now stops
loading. One new test reads the shipped energy density table through the
builder and asserts it is accepted, which nothing did before.

## Remarks

The normalization/weighting parser has no caller outside the tests, and no such
CSV lives under `data/`. It is corrected for consistency, not to protect a
startup path.

## How to test

`cabal test all` - 2594 examples, 0 failures, 2 pending. The four new examples:
two rows normalizing to one compartment key are refused, two density rows whose
names normalize to one key are refused with both spellings named, the shipped
density table is accepted, and a normalization/weighting category carrying two
sets of factors is refused by name.
