### PR TITLE
Leave a formula variable unbound when two declarations disagree

### DIFF
--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -247,6 +247,7 @@ data ParseState = ParseState
     , psActivityType :: !(Maybe Int) -- ecospold2 <activity activityType="1..8"> attribute
     , psSpecialActivityType :: !(Maybe Int) -- ecospold2 <activity specialActivityType="…"> attribute
     , psParams :: !(M.Map Text Double) -- <parameter> variableName → amount (amounts are pre-evaluated in the source)
+    , psAmbiguousParams :: !(S.Set Text) -- variableNames declared twice with two amounts, struck from psParams at the end
     , psParamExprs :: !(M.Map Text Text) -- <parameter> variableName → mathematicalRelation (raw formula, for inspection)
     , psPendingParam :: !PendingParam -- attribute accumulator for the open <parameter>
     , psPendingProperty :: !PendingProperty -- attribute and child accumulator for the open <property>
@@ -278,6 +279,7 @@ initialParseState =
         , psActivityType = Nothing
         , psSpecialActivityType = Nothing
         , psParams = M.empty
+        , psAmbiguousParams = S.empty
         , psParamExprs = M.empty
         , psPendingParam = emptyPendingParam
         , psPendingProperty = emptyPendingProperty
@@ -627,7 +629,8 @@ checkFormulas params pairs = case checked of
                 }
   where
     -- Left-biased union: a <parameter> wins over an exchange variable of the same name.
-    env = M.union params (M.fromList [(v, exchangeAmount ex) | (ex, ef) <- pairs, Just v <- [efVariableName ef]])
+    env :: M.Map Text Double
+    env = M.union params (amountsAgreedOn [(v, exchangeAmount ex) | (ex, ef) <- pairs, Just v <- [efVariableName ef]])
     checked = [(ex, rel, Expr.evaluate env (Expr.normalizeExpr '.' rel)) | (ex, ef) <- pairs, Just rel <- [efMathRel ef]]
     evaluated = [(ex, rel, v) | (ex, rel, Right v) <- checked]
     divergent = [(ex, rel, v) | (ex, rel, v) <- evaluated, not (nearlyEqual v (exchangeAmount ex))]
@@ -639,6 +642,20 @@ checkFormulas params pairs = case checked of
             <> " but the dataset stores "
             <> T.pack (show (exchangeAmount ex))
     nearlyEqual a b = abs (a - b) <= 1e-9 * max 1 (max (abs a) (abs b))
+
+{- | Bind each variable the rows agree on, and leave the rest unbound.
+
+Two exchanges declaring one @variableName@ with two amounts leave the formulas
+that use it no single reading, and taking whichever was read last would make
+the check above answer on a coin toss. Unbound, those formulas come back
+unevaluable, which is what this check already reports when it cannot judge.
+-}
+amountsAgreedOn :: [(Text, Double)] -> M.Map Text Double
+amountsAgreedOn kvs = M.mapMaybe agreed (M.fromListWith (++) [(k, [v]) | (k, v) <- kvs])
+  where
+    agreed :: [Double] -> Maybe Double
+    agreed [] = Nothing
+    agreed (v : vs) = if all (== v) vs then Just v else Nothing
 
 {- | The fields the dataset left out and this reader stood in for.
 
@@ -986,11 +1003,20 @@ parseWithXeno xmlContent processId = do
         | isElement tagName "parameter" =
             let PendingParam var amt rel = psPendingParam state
                 committed = case (nonEmptyText var, amt) of
-                    (Just v, Just a) ->
-                        state
-                            { psParams = M.insert v a (psParams state)
-                            , psParamExprs = maybe (psParamExprs state) (\r -> M.insert v r (psParamExprs state)) (nonEmptyText rel)
-                            }
+                    (Just v, Just a)
+                        | Just previous <- M.lookup v (psParams state)
+                        , previous /= a ->
+                            state
+                                { psAmbiguousParams = S.insert v (psAmbiguousParams state)
+                                , psWarnings =
+                                    ("[WARNING] Ignoring <parameter> \"" ++ T.unpack v ++ "\" - declared twice with two amounts")
+                                        : psWarnings state
+                                }
+                        | otherwise ->
+                            state
+                                { psParams = M.insert v a (psParams state)
+                                , psParamExprs = maybe (psParamExprs state) (\r -> M.insert v r (psParamExprs state)) (nonEmptyText rel)
+                                }
                     (Just v, Nothing) ->
                         state
                             { psWarnings =
@@ -1030,7 +1056,11 @@ parseWithXeno xmlContent processId = do
             refUnit = fromMaybe "UNKNOWN_UNIT" (psRefUnit st)
             nativeType = ecoSpoldNativeType (psActivityType st) (psSpecialActivityType st)
             pairs = reverse (psExchanges st)
-            formulaCheck = checkFormulas (psParams st) pairs
+            -- A variable the file declared twice with two amounts names no
+            -- value, so it is not one of the dataset's parameters.
+            params = M.withoutKeys (psParams st) (psAmbiguousParams st)
+            paramExprs = M.withoutKeys (psParamExprs st) (psAmbiguousParams st)
+            formulaCheck = checkFormulas params pairs
             -- Apply cutoff strategy to exchanges
             activity =
                 Activity
@@ -1043,8 +1073,8 @@ parseWithXeno xmlContent processId = do
                     , activityLocationSource = locationSource
                     , activityUnit = refUnit
                     , exchanges = map fst pairs
-                    , activityParams = psParams st
-                    , activityParamExprs = psParamExprs st
+                    , activityParams = params
+                    , activityParamExprs = paramExprs
                     , activityNativeType = nativeType
                     , activityNativeId = Nothing
                     , activityFormulaCheck = formulaCheck

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -628,9 +628,14 @@ checkFormulas params pairs = case checked of
                 , fcExample = listToMaybe (map example divergent)
                 }
   where
-    -- Left-biased union: a <parameter> wins over an exchange variable of the same name.
+    -- A <parameter> and an exchange variableName share one space of names, so
+    -- both go in together and a name they disagree on is as unreadable as one
+    -- two exchanges disagree on.
     env :: M.Map Text Double
-    env = M.union params (amountsAgreedOn [(v, exchangeAmount ex) | (ex, ef) <- pairs, Just v <- [efVariableName ef]])
+    env =
+        amountsAgreedOn $
+            M.toList params
+                ++ [(v, exchangeAmount ex) | (ex, ef) <- pairs, Just v <- [efVariableName ef]]
     checked = [(ex, rel, Expr.evaluate env (Expr.normalizeExpr '.' rel)) | (ex, ef) <- pairs, Just rel <- [efMathRel ef]]
     evaluated = [(ex, rel, v) | (ex, rel, Right v) <- checked]
     divergent = [(ex, rel, v) | (ex, rel, v) <- evaluated, not (nearlyEqual v (exchangeAmount ex))]
@@ -643,15 +648,19 @@ checkFormulas params pairs = case checked of
             <> T.pack (show (exchangeAmount ex))
     nearlyEqual a b = abs (a - b) <= 1e-9 * max 1 (max (abs a) (abs b))
 
-{- | Bind each variable the rows agree on, and leave the rest unbound.
+{- | Bind each variable the declarations agree on, and leave the rest unbound.
 
-Two exchanges declaring one @variableName@ with two amounts leave the formulas
-that use it no single reading, and taking whichever was read last would make
-the check above answer on a coin toss. Unbound, those formulas come back
-unevaluable, which is what this check already reports when it cannot judge.
+Two declarations of one name with two amounts leave the formulas that use it no
+single reading, and taking whichever was read last would make the check above
+answer on a coin toss. Unbound, those formulas come back unevaluable, which is
+what this check already reports when it cannot judge.
+
+The names are folded to lower case because 'Expr.evaluate' looks them up that
+way: judging agreement on the exact spelling would let @Water@ and @water@ both
+bind, and the evaluator would then silently keep one of the two.
 -}
 amountsAgreedOn :: [(Text, Double)] -> M.Map Text Double
-amountsAgreedOn kvs = M.mapMaybe agreed (M.fromListWith (++) [(k, [v]) | (k, v) <- kvs])
+amountsAgreedOn kvs = M.mapMaybe agreed (M.fromListWith (++) [(T.toLower k, [v]) | (k, v) <- kvs])
   where
     agreed :: [Double] -> Maybe Double
     agreed [] = Nothing
@@ -1004,6 +1013,7 @@ parseWithXeno xmlContent processId = do
             let PendingParam var amt rel = psPendingParam state
                 committed = case (nonEmptyText var, amt) of
                     (Just v, Just a)
+                        | S.member v (psAmbiguousParams state) -> state
                         | Just previous <- M.lookup v (psParams state)
                         , previous /= a ->
                             state

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -280,11 +280,22 @@ spec = describe "per-exchange comments" $ do
                 case activityFormulaCheck act of
                     Nothing -> expectationFailure "expected a FormulaCheck on the activity"
                     Just fc -> do
-                        -- "shared" is claimed by two exchanges and "twice" by
-                        -- two parameters; only "production" is named once.
-                        fcUnevaluable fc `shouldBe` 2
+                        -- "shared" is claimed by two exchanges, "twice" by two
+                        -- parameters, and "both" by one of each; only
+                        -- "production" is named once.
+                        fcUnevaluable fc `shouldBe` 3
                         fcEvaluated fc `shouldBe` 1
                         fcDivergent fc `shouldBe` 0
+
+        -- A <parameter> and an exchange variableName share one space of names.
+        -- Letting the parameter win would report a divergence against an amount
+        -- the dataset never agreed on, where the two other shapes of the same
+        -- contradiction report that the check could not judge.
+        it "cannot judge a formula over a name an exchange and a parameter share" $
+            withTwiceDeclaredFixture $ \ParsedDataset{pdActivity = act} ->
+                case activityFormulaCheck act of
+                    Nothing -> expectationFailure "expected a FormulaCheck on the activity"
+                    Just fc -> fcExample fc `shouldBe` Nothing
 
         it "logs the parameter two declarations disagree on" $ do
             (since, _) <- getLogLines 0
@@ -758,6 +769,7 @@ formulaXml =
 {- | Synthetic dataset where two declarations claim one variable name:
   - two inputs both carrying variableName="shared", with two amounts
   - two <parameter> elements both named "twice", with two amounts
+  - an input and a <parameter> both named "both", with two amounts
   - one formula per ambiguous variable, and one over the reference output's
     "production", which stays unambiguous
 -}
@@ -812,6 +824,23 @@ twiceDeclaredXml =
     \        <unitName xml:lang=\"en\">kg</unitName>\n\
     \        <inputGroup>5</inputGroup>\n\
     \      </intermediateExchange>\n\
+    \      <intermediateExchange id=\"alsoParam\" unitId=\"unit-kg\" amount=\"8.0\" variableName=\"both\"\n\
+    \                           intermediateExchangeId=\"11111111-1111-1111-1111-111111111111\">\n\
+    \        <name xml:lang=\"en\">Claims a parameter name</name>\n\
+    \        <unitName xml:lang=\"en\">kg</unitName>\n\
+    \        <inputGroup>5</inputGroup>\n\
+    \      </intermediateExchange>\n\
+    \      <intermediateExchange id=\"usesBoth\" unitId=\"unit-kg\" amount=\"8.0\"\n\
+    \                           mathematicalRelation=\"both\"\n\
+    \                           intermediateExchangeId=\"22222222-2222-2222-2222-222222222222\">\n\
+    \        <name xml:lang=\"en\">Reads the name both claim</name>\n\
+    \        <unitName xml:lang=\"en\">kg</unitName>\n\
+    \        <inputGroup>5</inputGroup>\n\
+    \      </intermediateExchange>\n\
+    \      <parameter parameterId=\"par-3\" variableName=\"both\" amount=\"4.0\">\n\
+    \        <name xml:lang=\"en\">both</name>\n\
+    \        <unitName xml:lang=\"en\">kg</unitName>\n\
+    \      </parameter>\n\
     \      <parameter parameterId=\"par-1\" variableName=\"twice\" amount=\"2.0\" mathematicalRelation=\"4.0 / 2\">\n\
     \        <name xml:lang=\"en\">twice</name>\n\
     \        <unitName xml:lang=\"en\">kg</unitName>\n\

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -266,6 +266,33 @@ spec = describe "per-exchange comments" $ do
                         fcUnevaluable fc `shouldBe` 1
                         fcExample fc `shouldBe` Just "\"fuel_input * 2 + production\" evaluates to 5.0 but the dataset stores 4.0"
 
+        -- A variable two declarations claim with two amounts names no value.
+        -- Binding whichever was read last would make the check answer on a coin
+        -- toss, so it stays unbound and the formulas that use it come back
+        -- unevaluable, which is what the check says when it cannot judge.
+        it "does not keep a <parameter> two declarations disagree on" $
+            withTwiceDeclaredFixture $ \ParsedDataset{pdActivity = act} -> do
+                M.member "twice" (activityParams act) `shouldBe` False
+                M.member "twice" (activityParamExprs act) `shouldBe` False
+
+        it "cannot judge a formula over a variable claimed twice" $
+            withTwiceDeclaredFixture $ \ParsedDataset{pdActivity = act} ->
+                case activityFormulaCheck act of
+                    Nothing -> expectationFailure "expected a FormulaCheck on the activity"
+                    Just fc -> do
+                        -- "shared" is claimed by two exchanges and "twice" by
+                        -- two parameters; only "production" is named once.
+                        fcUnevaluable fc `shouldBe` 2
+                        fcEvaluated fc `shouldBe` 1
+                        fcDivergent fc `shouldBe` 0
+
+        it "logs the parameter two declarations disagree on" $ do
+            (since, _) <- getLogLines 0
+            withTwiceDeclaredFixture $ \_ -> pure ()
+            (_, newLines) <- getLogLines since
+            any (("Ignoring <parameter> \"twice\"" `isInfixOf`) . llText) newLines
+                `shouldBe` True
+
         it "logs the dropped parameter but nothing about the formulas" $ do
             (since, _) <- getLogLines 0
             withFormulaFixture $ \_ -> pure ()
@@ -727,6 +754,84 @@ formulaXml =
     \    </flowData>\n\
     \  </activityDataset>\n\
     \</ecoSpold>\n"
+
+{- | Synthetic dataset where two declarations claim one variable name:
+  - two inputs both carrying variableName="shared", with two amounts
+  - two <parameter> elements both named "twice", with two amounts
+  - one formula per ambiguous variable, and one over the reference output's
+    "production", which stays unambiguous
+-}
+twiceDeclaredXml :: BS.ByteString
+twiceDeclaredXml =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+    \<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold02\">\n\
+    \  <activityDataset>\n\
+    \    <activityDescription>\n\
+    \      <activity id=\"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\" activityNameId=\"twice-test\">\n\
+    \        <activityName xml:lang=\"en\">Twice declared activity</activityName>\n\
+    \      </activity>\n\
+    \      <geography geographyId=\"TEST\"><shortname xml:lang=\"en\">TEST</shortname></geography>\n\
+    \    </activityDescription>\n\
+    \    <flowData>\n\
+    \      <intermediateExchange id=\"ref\" unitId=\"unit-kwh\" amount=\"1.0\" variableName=\"production\"\n\
+    \                           intermediateExchangeId=\"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb\">\n\
+    \        <name xml:lang=\"en\">Twice declared product</name>\n\
+    \        <unitName xml:lang=\"en\">kWh</unitName>\n\
+    \        <outputGroup>0</outputGroup>\n\
+    \      </intermediateExchange>\n\
+    \      <intermediateExchange id=\"dupA\" unitId=\"unit-kg\" amount=\"2.0\" variableName=\"shared\"\n\
+    \                           intermediateExchangeId=\"cccccccc-cccc-cccc-cccc-cccccccccccc\">\n\
+    \        <name xml:lang=\"en\">First claimant</name>\n\
+    \        <unitName xml:lang=\"en\">kg</unitName>\n\
+    \        <inputGroup>5</inputGroup>\n\
+    \      </intermediateExchange>\n\
+    \      <intermediateExchange id=\"dupB\" unitId=\"unit-kg\" amount=\"5.0\" variableName=\"shared\"\n\
+    \                           intermediateExchangeId=\"dddddddd-dddd-dddd-dddd-dddddddddddd\">\n\
+    \        <name xml:lang=\"en\">Second claimant</name>\n\
+    \        <unitName xml:lang=\"en\">kg</unitName>\n\
+    \        <inputGroup>5</inputGroup>\n\
+    \      </intermediateExchange>\n\
+    \      <intermediateExchange id=\"usesShared\" unitId=\"unit-kg\" amount=\"2.0\"\n\
+    \                           mathematicalRelation=\"shared\"\n\
+    \                           intermediateExchangeId=\"eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee\">\n\
+    \        <name xml:lang=\"en\">Reads the shared variable</name>\n\
+    \        <unitName xml:lang=\"en\">kg</unitName>\n\
+    \        <inputGroup>5</inputGroup>\n\
+    \      </intermediateExchange>\n\
+    \      <intermediateExchange id=\"usesTwice\" unitId=\"unit-kg\" amount=\"2.0\"\n\
+    \                           mathematicalRelation=\"twice\"\n\
+    \                           intermediateExchangeId=\"ffffffff-ffff-ffff-ffff-ffffffffffff\">\n\
+    \        <name xml:lang=\"en\">Reads the parameter</name>\n\
+    \        <unitName xml:lang=\"en\">kg</unitName>\n\
+    \        <inputGroup>5</inputGroup>\n\
+    \      </intermediateExchange>\n\
+    \      <intermediateExchange id=\"usesProduction\" unitId=\"unit-kg\" amount=\"1.0\"\n\
+    \                           mathematicalRelation=\"production\"\n\
+    \                           intermediateExchangeId=\"99999999-9999-9999-9999-999999999999\">\n\
+    \        <name xml:lang=\"en\">Reads the reference output</name>\n\
+    \        <unitName xml:lang=\"en\">kg</unitName>\n\
+    \        <inputGroup>5</inputGroup>\n\
+    \      </intermediateExchange>\n\
+    \      <parameter parameterId=\"par-1\" variableName=\"twice\" amount=\"2.0\" mathematicalRelation=\"4.0 / 2\">\n\
+    \        <name xml:lang=\"en\">twice</name>\n\
+    \        <unitName xml:lang=\"en\">kg</unitName>\n\
+    \      </parameter>\n\
+    \      <parameter parameterId=\"par-2\" variableName=\"twice\" amount=\"9.0\">\n\
+    \        <name xml:lang=\"en\">twice again</name>\n\
+    \        <unitName xml:lang=\"en\">kg</unitName>\n\
+    \      </parameter>\n\
+    \    </flowData>\n\
+    \  </activityDataset>\n\
+    \</ecoSpold>\n"
+
+withTwiceDeclaredFixture :: (ParsedDataset -> IO ()) -> IO ()
+withTwiceDeclaredFixture k = withSystemTempDirectory "es2-twice" $ \dir -> do
+    let path = dir </> "12345678-1234-5678-9abc-123456789001_12345678-1234-5678-9abc-123456789002.spold"
+    BS.writeFile path twiceDeclaredXml
+    result <- streamParseActivityAndFlowsFromFile path
+    case result of
+        Left err -> expectationFailure $ "Parse failed: " ++ err
+        Right res -> k res
 
 withFormulaFixture :: (ParsedDataset -> IO ()) -> IO ()
 withFormulaFixture k = withSystemTempDirectory "es2-formula" $ \dir -> do


### PR DESCRIPTION
## Problem

An EcoSpold 2 dataset binds formula variables from two places at once: every
exchange's `variableName` holds its stored amount, and every `<parameter>`
holds its own. Both tables were built with the last declaration winning in
silence, and they were then folded together with a left-biased union, so the
`<parameter>` won a name an exchange also claimed.

So a name declared twice with two amounts was read as whichever the file
happened to list last, or as the parameter's, and the `mathematicalRelation`
consistency check answered on that: the same dataset could be reported as
consistent, as divergent, or as unevaluable depending on the order its elements
appear in.

## Solution

Both sides go into one environment, and a name whose declarations disagree is
left unbound. The formulas that use it then come back unevaluable, which is
what the check already reports when it cannot judge, and `fcUnevaluable` counts
them. The union and the precedence rule it carried are gone with it.

Agreement is judged on the lower-cased name, because that is the key the
evaluator looks up: on the exact spelling, `Water` and `water` would both bind
and the evaluator would silently keep one.

A `<parameter>` claimed twice with two amounts is logged the same way as one
whose amount could not be read, once however many times it is claimed, and is
struck from the dataset's parameters and from their expressions both, so the
two stay keyed alike.

Declarations that agree still bind. Two rows carrying the same amount are one
reading, not a conflict.

## Remarks

Only the check's verdict moves. The stored amounts stay authoritative, as they
already were: this evaluator supports a subset of the formula language and
serves as a consistency control, never as a source of numbers.

## How to test

`cabal test all` - 2597 examples, 0 failures, 2 pending. A new fixture declares
one name from two exchanges, another from two parameters, and a third from one
of each, with a formula over every one of them and a fourth over an unambiguous
name: the check reports three unevaluable, one evaluated, none divergent and no
example, and the parameter is absent from the activity with one line in the log
naming it.
