### PR TITLE
Read a dataset file name the dataset number precedes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,12 +165,14 @@
   reader accepted only two, so every file carrying one was refused and dropped
   with a warning, and what loaded was the handful of files named the other way:
   an archive of several thousand datasets arrived as a few dozen, and said
-  nothing about the rest. The pair is now read as the last two parts of the
-  name, which reads both shapes, and the number is dropped, since this format
-  names the supplier of an input by its identifier and numbers no dataset. A
-  file whose name carries no pair at all is now a refusal that names the file
-  and stops the load, where before it was a warning in passing and a dataset
-  quietly missing from the result.
+  nothing about the rest. A name of two parts is read as before, and a longer
+  one is read as its last two when both of them are identifiers, which is what
+  tells a dataset number in front of a pair from a part added to the end of a
+  name. The number itself is dropped, since this format names the supplier of
+  an input by its identifier and numbers no dataset. A name this leaves no
+  reading of is now a refusal that names the file and stops the load, where
+  before it was a warning in passing and a dataset quietly missing from the
+  result.
 - The unit table now agrees with the units its entries are composed of. A
   composed factor was typed by hand and five were wrong, and the load carried
   the error into the amounts: a hectare year read as 3.1536e11 square metre

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,17 @@
   before this are rebuilt on the next load. Wire revision 23.
 
 ### Fixed
+- An EcoSpold 2 archive whose file names carry the dataset number in front of
+  the two identifiers now loads in full. Such a name has three parts where the
+  reader accepted only two, so every file carrying one was refused and dropped
+  with a warning, and what loaded was the handful of files named the other way:
+  an archive of several thousand datasets arrived as a few dozen, and said
+  nothing about the rest. The pair is now read as the last two parts of the
+  name, which reads both shapes, and the number is dropped, since this format
+  names the supplier of an input by its identifier and numbers no dataset. A
+  file whose name carries no pair at all is now a refusal that names the file
+  and stops the load, where before it was a warning in passing and a dataset
+  quietly missing from the result.
 - The unit table now agrees with the units its entries are composed of. A
   composed factor was typed by hand and five were wrong, and the load carried
   the error into the amounts: a hectare year read as 3.1536e11 square metre

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -1472,14 +1472,15 @@ loadEcoSpoldDirectory opts dir = do
             prodUUID = getReferenceProductUUID activity
          in Right ((actUUID, prodUUID), activity)
     buildProcEntry False filepath activity =
-        -- EcoSpold2: Parse UUIDs from filename
-        let filename = T.pack $ takeBaseName filepath
-         in case T.splitOn "_" filename of
-                [actUUIDText, prodUUIDText] ->
-                    let actUUID = parseUUID actUUIDText
-                        prodUUID = parseUUID prodUUIDText
-                     in Right ((actUUID, prodUUID), activity)
-                _ -> Left $ T.pack $ "Invalid filename format (expected activityUUID_productUUID.spold): " ++ filepath
+        -- EcoSpold2: the identifiers are in the file name. Some publishers put
+        -- the dataset number in front of the pair; neither a UUID nor the
+        -- number holds the separator, so the pair is the last two parts either
+        -- way. The number is dropped: this format addresses its suppliers by
+        -- UUID and numbers no dataset.
+        case reverse (T.splitOn "_" (T.pack (takeBaseName filepath))) of
+            (prodUUIDText : actUUIDText : _) ->
+                Right ((parseUUID actUUIDText, parseUUID prodUUIDText), activity)
+            _ -> Left $ T.pack $ "Invalid filename format (expected [datasetNumber_]activityUUID_productUUID.spold): " ++ filepath
 
 {- | Load a single EcoSpold1 file containing multiple datasets
 This handles files where <ecoSpold> contains multiple <dataset> elements.

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -1473,13 +1473,21 @@ loadEcoSpoldDirectory opts dir = do
          in Right ((actUUID, prodUUID), activity)
     buildProcEntry False filepath activity =
         -- EcoSpold2: the identifiers are in the file name. Some publishers put
-        -- the dataset number in front of the pair; neither a UUID nor the
-        -- number holds the separator, so the pair is the last two parts either
-        -- way. The number is dropped: this format addresses its suppliers by
-        -- UUID and numbers no dataset.
+        -- the dataset number in front of the pair, and the pair is then the
+        -- last two parts. What says the leading part is a number rather than
+        -- half of the name is that the two behind it are both identifiers, so
+        -- a longer name is read only when they are: in any other name a part
+        -- could as easily have been added at the end as at the front, and
+        -- there is nothing to choose between the two readings. The number is
+        -- dropped, this format addressing its suppliers by UUID and numbering
+        -- no dataset.
         case reverse (T.splitOn "_" (T.pack (takeBaseName filepath))) of
-            (prodUUIDText : actUUIDText : _) ->
+            [prodUUIDText, actUUIDText] ->
                 Right ((parseUUID actUUIDText, parseUUID prodUUIDText), activity)
+            prodUUIDText : actUUIDText : _ : _
+                | Just prodUUID <- UUID.fromText prodUUIDText
+                , Just actUUID <- UUID.fromText actUUIDText ->
+                    Right ((actUUID, prodUUID), activity)
             _ -> Left $ T.pack $ "Invalid filename format (expected [datasetNumber_]activityUUID_productUUID.spold): " ++ filepath
 
 {- | Load a single EcoSpold1 file containing multiple datasets

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -19,7 +19,6 @@ import EcoSpold.Common (ParsedDataset (..), bsToDouble, bsToInt, bsToIntMaybe, b
 import qualified Expr
 import Progress (ProgressLevel (..), reportProgress)
 import SubstanceRegistry (nonEmptyCAS)
-import System.FilePath (takeBaseName)
 import Types
 import qualified Xeno.SAX as X
 
@@ -55,18 +54,6 @@ parseUUID txt = case UUID.fromText txt of
                     then Nothing
                     else Just $ "Invalid UUID format: " ++ T.unpack txt ++ " - generated UUID: " ++ show generatedUUID
          in (generatedUUID, warning)
-
-{- | Parse ProcessId from filename (no Database needed here)
-Expects format: activity_uuid_product_uuid.spold
--}
-parseProcessId :: Text -> Maybe ProcessId
-parseProcessId filename = case T.splitOn "_" filename of
-    [_, _]
-        | not (T.null filename) ->
-            -- During parsing we don't have ProcessId yet, just return a placeholder
-            -- The actual ProcessId will be assigned during database construction
-            Just 0 -- Temporary ProcessId, will be replaced during DB construction
-    _ -> Nothing
 
 -- ============================================================================
 -- Xeno SAX Parser Implementation (8-15x faster than xml-conduit)
@@ -658,10 +645,10 @@ placeholdersUsed st =
     ]
 
 -- | Xeno SAX parser implementation
-parseWithXeno :: BS.ByteString -> ProcessId -> Either String ParsedDataset
-parseWithXeno xmlContent processId = do
+parseWithXeno :: BS.ByteString -> Either String ParsedDataset
+parseWithXeno xmlContent = do
     finalState <- first show (X.fold openTag attribute endOpen text closeTag cdata initialParseState xmlContent)
-    buildResult finalState processId
+    buildResult finalState
   where
     -- Open tag handler - update path and context
     openTag state tagName =
@@ -1019,8 +1006,8 @@ parseWithXeno xmlContent processId = do
     cdata = text
 
     -- Build final result from parse state
-    buildResult :: ParseState -> ProcessId -> Either String ParsedDataset
-    buildResult st _pid =
+    buildResult :: ParseState -> Either String ParsedDataset
+    buildResult st =
         let name = fromMaybe "Unknown Activity" (psActivityName st)
             location = fromMaybe "GLO" (psLocation st)
             -- "GLO" above is this loader's stand-in, not something the dataset
@@ -1071,13 +1058,9 @@ parseWithXeno xmlContent processId = do
 streamParseActivityAndFlowsFromFile :: FilePath -> IO (Either String ParsedDataset)
 streamParseActivityAndFlowsFromFile path = do
     !xmlContent <- BS.readFile path
-    let filenameBase = T.pack $ takeBaseName path
-    case EcoSpold.Parser2.parseProcessId filenameBase of
-        Nothing -> return $ Left $ "Invalid filename format for ProcessId: " ++ path
-        Just pid -> do
-            let parsed = parseWithXeno xmlContent pid
-            either (const (pure ())) (reportReading path) parsed
-            return parsed
+    let parsed = parseWithXeno xmlContent
+    either (const (pure ())) (reportReading path) parsed
+    return parsed
 
 -- | Send what a reading had to say to the progress log, the one place it can go.
 reportReading :: FilePath -> ParsedDataset -> IO ()

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -20,17 +20,10 @@ import Types
 
 {- | The bundled fixture has a `<comment xml:lang="en">...</comment>` on each
 of its four exchanges (1 input, 1 reference output, 2 emissions).
-
-streamParseActivityAndFlowsFromFile derives a synthetic ProcessId from the
-filename and rejects names that don't match `actUUID_prodUUID`, so we copy
-the fixture into a temp path with that shape.
 -}
 withFixture :: (ParsedDataset -> IO ()) -> IO ()
-withFixture k = withSystemTempDirectory "es2-spec" $ \dir -> do
-    bytes <- BS.readFile "test-data/electricity-production.spold"
-    let path = dir </> "12345678-1234-5678-9abc-123456789001_12345678-1234-5678-9abc-123456789002.spold"
-    BS.writeFile path bytes
-    result <- streamParseActivityAndFlowsFromFile path
+withFixture k = do
+    result <- streamParseActivityAndFlowsFromFile "test-data/electricity-production.spold"
     case result of
         Left err -> expectationFailure $ "Parse failed: " ++ err
         Right res -> k res

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -9,7 +9,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
-import System.Directory (createDirectoryIfMissing)
+import System.Directory (copyFile, createDirectoryIfMissing, listDirectory)
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
@@ -391,6 +391,32 @@ spec = do
                 actUUIDs <- loadedActUUIDs dir
                 length actUUIDs `shouldBe` 2
                 actUUIDs `shouldSatisfy` notElem fileUUID
+
+    -- -----------------------------------------------------------------------
+    -- EcoSpold2 file-name identity, end to end through loadDatabase
+    -- -----------------------------------------------------------------------
+    describe "EcoSpold2 file-name identity" $ do
+        let plainDir = "test-data/SAMPLE.min4"
+            loadedKeys dir = do
+                result <- loadDatabase defaultUnitConfig dir
+                either (fail . show) (return . M.keys . sdbActivities) result
+            copyRenamed dir rename = do
+                names <- listDirectory plainDir
+                sequence_ [copyFile (plainDir </> n) (dir </> rename i n) | (i, n) <- zip [22971 :: Int ..] names]
+
+        it "reads a name the dataset number precedes, and keys it on the pair alone" $
+            withSystemTempDirectory "es2-numbered" $ \dir -> do
+                copyRenamed dir (\i n -> show i ++ "_" ++ n)
+                numbered <- loadedKeys dir
+                plain <- loadedKeys plainDir
+                numbered `shouldMatchList` plain
+
+        it "reads an archive that numbers some of its files and not others" $
+            withSystemTempDirectory "es2-mixed" $ \dir -> do
+                copyRenamed dir (\i n -> if even i then show i ++ "_" ++ n else n)
+                mixed <- loadedKeys dir
+                plain <- loadedKeys plainDir
+                mixed `shouldMatchList` plain
 
     -- -----------------------------------------------------------------------
     -- getReferenceProductUUID

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -9,7 +9,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
-import System.Directory (copyFile, createDirectoryIfMissing, listDirectory)
+import System.Directory (copyFile, createDirectoryIfMissing)
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
@@ -396,27 +396,34 @@ spec = do
     -- EcoSpold2 file-name identity, end to end through loadDatabase
     -- -----------------------------------------------------------------------
     describe "EcoSpold2 file-name identity" $ do
-        let plainDir = "test-data/SAMPLE.min4"
+        let dataset = "test-data/SAMPLE.min4/activityA_productX.spold"
+            spoldActUUID = read "f0cc71ac-2d3e-49da-b798-f9b81fb6c0d2" :: UUID.UUID
+            spoldProdUUID = read "759b89bd-3aa6-42ad-b767-5bb9ef5d331d" :: UUID.UUID
+            numberedName = "22971_" ++ show spoldActUUID ++ "_" ++ show spoldProdUUID ++ ".spold"
             loadedKeys dir = do
                 result <- loadDatabase defaultUnitConfig dir
                 either (fail . show) (return . M.keys . sdbActivities) result
-            copyRenamed dir rename = do
-                names <- listDirectory plainDir
-                sequence_ [copyFile (plainDir </> n) (dir </> rename i n) | (i, n) <- zip [22971 :: Int ..] names]
 
         it "reads a name the dataset number precedes, and keys it on the pair alone" $
             withSystemTempDirectory "es2-numbered" $ \dir -> do
-                copyRenamed dir (\i n -> show i ++ "_" ++ n)
-                numbered <- loadedKeys dir
-                plain <- loadedKeys plainDir
-                numbered `shouldMatchList` plain
+                copyFile dataset (dir </> numberedName)
+                keys <- loadedKeys dir
+                keys `shouldBe` [(spoldActUUID, spoldProdUUID)]
 
         it "reads an archive that numbers some of its files and not others" $
             withSystemTempDirectory "es2-mixed" $ \dir -> do
-                copyRenamed dir (\i n -> if even i then show i ++ "_" ++ n else n)
-                mixed <- loadedKeys dir
-                plain <- loadedKeys plainDir
-                mixed `shouldMatchList` plain
+                copyFile dataset (dir </> numberedName)
+                copyFile "test-data/SAMPLE.min4/activityB_productY.spold" (dir </> "activityB_productY.spold")
+                keys <- loadedKeys dir
+                length keys `shouldBe` 2
+
+        it "refuses a longer name whose last two parts are not identifiers" $
+            withSystemTempDirectory "es2-suffixed" $ \dir -> do
+                copyFile dataset (dir </> "activityA_productX_v2.spold")
+                result <- loadDatabase defaultUnitConfig dir
+                case result of
+                    Right _ -> expectationFailure "expected the load to refuse a name it cannot read"
+                    Left err -> T.unpack err `shouldContain` "activityA_productX_v2.spold"
 
     -- -----------------------------------------------------------------------
     -- getReferenceProductUUID


### PR DESCRIPTION
## The problem

Some publishers name an EcoSpold 2 dataset file with the dataset number in front
of the two identifiers:

```
22971_f0cc71ac-2d3e-49da-b798-f9b81fb6c0d2_759b89bd-3aa6-42ad-b767-5bb9ef5d331d.spold
```

That is three underscore-separated parts where the reader accepted exactly two, so
every file named that way was refused and dropped with a warning. An archive of
several thousand datasets loaded as the few dozen files that happened to be named
the other way, and then reported itself complete and ready: the counters describe
what was kept, never what was offered.

The rule was written twice, in `EcoSpold.Parser2` and in `Database.Loader`, and
both copies demanded exactly two parts.

## What the change does

The copy in the parser was the one doing the dropping, and it guarded nothing: the
process id it produced was always `0`, and `parseWithXeno` never looked at it. It is
gone, together with the dead parameter it fed, so the rule now lives only where the
name is actually used, in `buildProcEntry`, where the pair becomes the activity key.

There, a name of two parts is read as before, minting an identifier for a half that
is not one, which is how most of the fixtures are named. A longer name is read as
its last two parts only when both of them parse as identifiers. That condition is
the whole point: it is what tells a dataset number put in front of a pair from a
part added to the end of a name. Without it, `<activity>_<product>_v2.spold`, the
copy someone leaves beside the original, would read as a dataset keyed on its own
product identifier with a phantom product nothing links to. Two readings, nothing
to choose between them, so the load refuses and names the file.

The number itself is dropped: this format names the supplier of an input by
identifier and numbers no dataset, so keeping it would fill a table nothing reads.

One behaviour moves as a consequence. A name the rule leaves no reading of used to
be a warning and a dataset quietly missing from the result; it is now a refusal that
names the file and stops the load. A stray or truncated `.spold` still only warns,
because it fails earlier, at the parse.

## Worth knowing

This is the first half of #401. The second half, a status that says how many files
were offered and how many became activities, is a different subject with its own
release mechanics: it adds a field to `DatabaseSetupInfo`, so a wire revision, a
changelog entry and the companion frontend change, and the tally has to be carried
out of the five readers `readSourceUnder` dispatches to, none of which returns
anything but a `SimpleDatabase` today. The channel to the status already exists
(`CrossDBLinkingStats` carries `cdlUnknownUnits` the same way); what is missing is
the count at its source. So this pull request says `Refs #401`, not `Closes`, and
the issue stays open for that half.

## How to check it

`cabal test lca-tests --test-options='--match "/EcoSpold2 file-name identity/"'`

Three cases in `test/LoaderSpec.hs`, each loading a temporary directory holding a
copy of a bundled dataset:

- a file named `22971_<activityUUID>_<productUUID>.spold` loads, keyed on the pair
  alone. Before the change the directory yields no activity at all.
- a directory holding that file and an unnumbered one loads both. Before, only the
  unnumbered one.
- a file named `activityA_productX_v2.spold` makes the load refuse and name the
  file, rather than loading it under a key read off the wrong end of the name.

Full suite: 2596 examples, 0 failures. `fourmolu --mode check src test` and
`hlint src test app` are clean, and a cold `cabal build all --enable-tests
--ghc-options=-Werror` links.
