### PR TITLE
Let an ILCD dataset's version say which file declares it

### DIFF
--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -3793,7 +3793,7 @@ loadMethodCollectionFromConfig mc = runExceptT $ do
     files <- liftIO $ methodFilesOf source
     when (noMethodFiles files) $
         throwE ("No method files (.xml/.csv/.json) found in: " <> T.pack (mfDirectory files))
-    flowInfo <- liftIO $ flowDefinitionsFor source (mfDirectory files)
+    flowInfo <- ExceptT $ flowDefinitionsFor source (mfDirectory files)
     parsed <- liftIO $ parseMethodFiles flowInfo files
     collection <- except (collectionOf parsed)
     liftIO $ reportProgress Info (parseCounts parsed)
@@ -3857,18 +3857,18 @@ loadMethodCollectionFromConfig mc = runExceptT $ do
     {- Scanning a coincidental neighbouring flows/ would parse unrelated flow
     XMLs and register foreign synonyms under this collection's name, so only a
     real ILCD directory is looked at. -}
-    flowDefinitionsFor :: MethodSource -> FilePath -> IO (M.Map UUID ILCDFlowInfo)
-    flowDefinitionsFor (BareMethodFile _) _ = pure M.empty
+    flowDefinitionsFor :: MethodSource -> FilePath -> IO (Either Text (M.Map UUID ILCDFlowInfo))
+    flowDefinitionsFor (BareMethodFile _) _ = pure (Right M.empty)
     flowDefinitionsFor (MethodDirectory _) dir =
         FlowResolver.resolveFlowDirectory dir >>= \case
             Nothing -> do
                 reportProgress Info "  No flows/ directory found, using shortDescription fallback"
-                pure M.empty
+                pure (Right M.empty)
             Just flowsDir -> do
                 reportProgress Info $ "  Loading ILCD flow XMLs from: " <> flowsDir
-                info <- FlowResolver.parseFlowDirectory flowsDir
-                reportProgress Info $ "  Loaded " <> show (M.size info) <> " flow definitions"
-                pure info
+                outcome <- FlowResolver.parseFlowDirectory flowsDir
+                mapM_ (\info -> reportProgress Info $ "  Loaded " <> show (M.size info) <> " flow definitions") outcome
+                pure outcome
 
     parseMethodFiles :: M.Map UUID ILCDFlowInfo -> MethodFiles -> IO ParsedMethodFiles
     parseMethodFiles flowInfo files = do

--- a/src/ILCD/Common.hs
+++ b/src/ILCD/Common.hs
@@ -1,0 +1,190 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{- | What an ILCD file declares about itself, and what a directory of them adds
+up to.
+
+An ILCD package holds one XML file per dataset, and a dataset is named by the
+UUID inside the file, not by the file's name. Two files can therefore claim one
+UUID - which is how the format publishes a revision, the superseded file often
+staying beside the new one - and a directory listing says nothing about which
+is which. The version each file declares does, and that is what 'latestByUUID'
+reads.
+-}
+module ILCD.Common (
+    listXMLFiles,
+    DataSetVersion,
+    readDataSetVersion,
+    showDataSetVersion,
+    declaredVersion,
+    Claimed (..),
+    Indexed (..),
+    latestByUUID,
+) where
+
+import qualified Data.ByteString as BS
+import Data.Char (toLower)
+import Data.List (sort, sortOn)
+import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as M
+import Data.Maybe (isNothing)
+import Data.Ord (Down (..), comparing)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Read as TR
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
+import EcoSpold.Common (bsToText, isElement)
+import System.Directory (listDirectory)
+import System.FilePath (takeExtension, (</>))
+import qualified Xeno.SAX as X
+
+{- | The XML files of a directory, in one order.
+
+Sorted, because 'listDirectory' answers in whatever order the file system holds
+them: an unsorted listing makes a database depend on the machine it was read on
+before anything else has a chance to.
+-}
+listXMLFiles :: FilePath -> IO [FilePath]
+listXMLFiles d = do
+    fs <- listDirectory d
+    return (sort [d </> f | f <- fs, map toLower (takeExtension f) == ".xml"])
+
+{- | The version an ILCD dataset declares, as the numbers it is compared on.
+
+@\<common:dataSetVersion\>@ is written @03.00.000@, three groups counting major,
+minor and patch. The comparison is on the numbers and not on the text, where
+@10.00.000@ would sort below @09.00.000@.
+-}
+newtype DataSetVersion = DataSetVersion (NonEmpty Int)
+    deriving (Eq, Ord, Show)
+
+-- | Read a declared version, or nothing when it is not a run of dotted numbers.
+readDataSetVersion :: Text -> Maybe DataSetVersion
+readDataSetVersion t = DataSetVersion <$> (NE.nonEmpty =<< traverse group (T.splitOn "." (T.strip t)))
+  where
+    group :: Text -> Maybe Int
+    group g = case TR.decimal g of
+        Right (n, rest) | T.null rest -> Just n
+        _ -> Nothing
+
+-- | The version as a message names it: the numbers, without the source padding.
+showDataSetVersion :: DataSetVersion -> Text
+showDataSetVersion (DataSetVersion ns) = T.intercalate "." (map (T.pack . show) (NE.toList ns))
+
+{- | The version an ILCD file declares, read on its own.
+
+Every kind of ILCD dataset carries @\<common:dataSetVersion\>@ in the same place
+and nothing else does, so one reader serves the four the engine opens and none
+of their parsers has to grow a field for a value they only need when two files
+collide. The first one wins, since a file that names another dataset names it
+by reference and not by repeating the element.
+-}
+declaredVersion :: BS.ByteString -> Maybe DataSetVersion
+declaredVersion bytes = case X.fold openTag attr endOpen txt closeTag cdata (VState Nothing []) bytes of
+    Left _ -> Nothing
+    Right s -> vsVersion s
+  where
+    openTag s _ = s{vsAccum = []}
+    attr s _ _ = s
+    endOpen s _ = s
+    txt s content = s{vsAccum = content : vsAccum s}
+    cdata = txt
+    closeTag s tag
+        | isElement tag "dataSetVersion" && isNothing (vsVersion s) =
+            s{vsVersion = readDataSetVersion (T.concat (reverse (map bsToText (vsAccum s)))), vsAccum = []}
+        | otherwise = s{vsAccum = []}
+
+data VState = VState
+    { vsVersion :: !(Maybe DataSetVersion)
+    , vsAccum :: ![BS.ByteString]
+    }
+
+-- | One file, the UUID it claimed, and what was read out of it.
+data Claimed a = Claimed
+    { claimFile :: !FilePath
+    , claimUUID :: !UUID
+    , claimContent :: !a
+    }
+
+{- | A directory read into one dataset per UUID, and the files that lost.
+
+'ixSuperseded' carries one line per file a newer version replaced, for the
+caller to report: a file dropped without a word is a dataset the user believes
+they loaded.
+-}
+data Indexed a = Indexed
+    { ixByUUID :: !(M.Map UUID a)
+    , ixSuperseded :: ![Text]
+    }
+
+{- | One dataset per UUID: the file declaring the highest version, and a word
+about each file it replaces.
+
+Two files at the same highest version name no winner, and neither do two that
+both leave the version out. Either way the read stops instead of keeping
+whichever the listing reached first, because the answer is supposed to be in
+the files and a listing would decide it by file name.
+
+Only the files of a UUID that two of them claim are read again for their
+version: where every UUID appears once there is nothing to arbitrate, which is
+every directory that is in order.
+-}
+latestByUUID :: forall a. [Claimed a] -> IO (Either Text (Indexed a))
+latestByUUID claimed = decided <$> traverse rank grouped
+  where
+    grouped :: [(UUID, NonEmpty (Claimed a))]
+    grouped = M.toList (M.fromListWith (<>) [(claimUUID c, c :| []) | c <- claimed])
+
+    -- The claims on one UUID, highest version first. One claim answers alone.
+    rank :: (UUID, NonEmpty (Claimed a)) -> IO (NonEmpty (Declared a))
+    rank (_, only :| []) = return (Declared only Nothing :| [])
+    rank (_, claims) = NE.sortBy (comparing (Down . declVersion)) <$> traverse declaring claims
+
+    declaring :: Claimed a -> IO (Declared a)
+    declaring c = Declared c . declaredVersion <$> BS.readFile (claimFile c)
+
+    decided :: [NonEmpty (Declared a)] -> Either Text (Indexed a)
+    decided ranked = case concatMap tied ranked of
+        (t : ts) -> Left (refusal (t :| ts))
+        [] ->
+            Right
+                Indexed
+                    { ixByUUID = M.fromList [(claimUUID (declClaim best), claimContent (declClaim best)) | best :| _ <- ranked]
+                    , ixSuperseded = concatMap superseded ranked
+                    }
+
+    -- The files sharing the highest version, when more than one does.
+    tied :: NonEmpty (Declared a) -> [NonEmpty FilePath]
+    tied (best :| rest) = case filter ((== declVersion best) . declVersion) rest of
+        [] -> []
+        others -> [NE.sort (fileOf best :| map fileOf others)]
+
+    superseded :: NonEmpty (Declared a) -> [Text]
+    superseded (best :| rest) =
+        [ T.pack (fileOf beaten)
+            <> " is superseded: "
+            <> UUID.toText (claimUUID (declClaim best))
+            <> " is also declared by "
+            <> T.pack (fileOf best)
+            <> maybe "" (\v -> ", at version " <> showDataSetVersion v) (declVersion best)
+        | beaten <- sortOn fileOf rest
+        ]
+
+    fileOf :: Declared a -> FilePath
+    fileOf = claimFile . declClaim
+
+    refusal :: NonEmpty (NonEmpty FilePath) -> Text
+    refusal clashes =
+        "two files declare one dataset at the same version, and nothing says which is meant: "
+            <> T.intercalate "; " (map named (NE.toList clashes))
+
+    named :: NonEmpty FilePath -> Text
+    named files = T.intercalate ", " (map T.pack (NE.toList files))
+
+-- | A claim, once the version behind it had to be read.
+data Declared a = Declared
+    { declClaim :: !(Claimed a)
+    , declVersion :: !(Maybe DataSetVersion)
+    }

--- a/src/ILCD/Parser.hs
+++ b/src/ILCD/Parser.hs
@@ -101,13 +101,7 @@ parseILCDDirectory unitConfig key dir = runExceptT $ do
     processFiles <- liftIO $ listXMLFiles (dir </> "processes")
     liftIO $ reportProgress Info $ printf "Parsing %d ILCD process files..." (length processFiles)
     claimedProcesses <- liftIO $ parseProcessFilesParallel processFiles
-    processes <- ExceptT $ do
-        outcome <- latestByUUID claimedProcesses
-        case outcome of
-            Left err -> return (Left err)
-            Right indexed -> do
-                mapM_ (reportProgress Warning . T.unpack) (ixSuperseded indexed)
-                return (Right (M.elems (ixByUUID indexed)))
+    processes <- M.elems <$> ExceptT (oneDataSetPerUUID claimedProcesses)
 
     liftIO $ reportProgress Info $ printf "Parsed %d processes, building activity map..." (length processes)
 
@@ -136,15 +130,22 @@ readDataSets :: forall a. FilePath -> (BS.ByteString -> Maybe (UUID, a)) -> IO (
 readDataSets dir parse = do
     files <- listXMLFiles dir
     claims <- mapM claimOf files
-    outcome <- latestByUUID (Data.Maybe.catMaybes claims)
+    oneDataSetPerUUID (Data.Maybe.catMaybes claims)
+  where
+    claimOf :: FilePath -> IO (Maybe (Claimed a))
+    claimOf f = fmap (uncurry (Claimed f)) . parse <$> BS.readFile f
+
+{- | One dataset per UUID out of what a directory was read as, saying which
+files a newer version superseded.
+-}
+oneDataSetPerUUID :: [Claimed a] -> IO (Either Text (M.Map UUID a))
+oneDataSetPerUUID claims = do
+    outcome <- latestByUUID claims
     case outcome of
         Left err -> return (Left err)
         Right indexed -> do
             mapM_ (reportProgress Warning . T.unpack) (ixSuperseded indexed)
             return (Right (ixByUUID indexed))
-  where
-    claimOf :: FilePath -> IO (Maybe (Claimed a))
-    claimOf f = fmap (uncurry (Claimed f)) . parse <$> BS.readFile f
 
 --------------------------------------------------------------------------------
 -- Unit Groups: unitGroupUUID → (refUnitName, refUnitInternalId)

--- a/src/ILCD/Parser.hs
+++ b/src/ILCD/Parser.hs
@@ -19,8 +19,9 @@ import Amount (readAmount)
 import Control.Applicative ((<|>))
 import Control.Concurrent (getNumCapabilities)
 import Control.Concurrent.Async (mapConcurrently)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Except (ExceptT (..), runExceptT)
 import qualified Data.ByteString as BS
-import Data.Char (toLower)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import qualified Data.Maybe
@@ -29,13 +30,13 @@ import qualified Data.Text as T
 import qualified Data.Text.Read as TR
 import qualified Data.UUID as UUID
 import Database.Allocation (Allocating (..), allocate)
-import System.Directory (listDirectory)
-import System.FilePath (takeExtension, (</>))
+import System.FilePath ((</>))
 import Text.Printf (printf)
 import UnitConversion (UnitConfig)
 import qualified Xeno.SAX as X
 
 import EcoSpold.Common (bsToText, distributeFiles, isElement)
+import ILCD.Common (Claimed (..), Indexed (..), latestByUUID, listXMLFiles)
 import Method.FlowResolver (ILCDFlowInfo (..), parseFlowDirectory)
 import qualified Method.Types as MT
 import Progress (ProgressLevel (..), reportProgress)
@@ -80,60 +81,77 @@ data ILCDExchangeRaw = ILCDExchangeRaw
 Expects subdirectories: processes/, flows/, flowproperties/, unitgroups/
 -}
 parseILCDDirectory :: UnitConfig -> AllocationKey -> FilePath -> IO (Either Text SimpleDatabase)
-parseILCDDirectory unitConfig key dir = do
-    reportProgress Info $ "Loading ILCD database from: " ++ dir
+parseILCDDirectory unitConfig key dir = runExceptT $ do
+    liftIO $ reportProgress Info $ "Loading ILCD database from: " ++ dir
 
     -- Step 1: Parse unit groups and flow properties (small, sequential)
-    unitGroupMap <- parseUnitGroups (dir </> "unitgroups")
-    flowPropMap <- parseFlowProperties (dir </> "flowproperties")
-    reportProgress Info $ printf "Parsed %d unit groups, %d flow properties" (M.size unitGroupMap) (M.size flowPropMap)
+    unitGroupMap <- ExceptT $ parseUnitGroups (dir </> "unitgroups")
+    flowPropMap <- ExceptT $ parseFlowProperties (dir </> "flowproperties")
+    liftIO $ reportProgress Info $ printf "Parsed %d unit groups, %d flow properties" (M.size unitGroupMap) (M.size flowPropMap)
 
     -- Step 2: Parse flows (reuse FlowResolver, parallel + cached)
-    flowInfoMap <- parseFlowDirectory (dir </> "flows")
-    reportProgress Info $ printf "Parsed %d flows" (M.size flowInfoMap)
+    flowInfoMap <- ExceptT $ parseFlowDirectory (dir </> "flows")
+    liftIO $ reportProgress Info $ printf "Parsed %d flows" (M.size flowInfoMap)
 
     -- Step 3: Build TechFlowDB, BioFlowDB, WasteFlowDB and UnitDB from parsed data
     let (techFlowDB, bioFlowDB, wasteFlowDB, unitDB) = buildFlowAndUnitDB flowInfoMap flowPropMap unitGroupMap
-    mapM_ (reportProgress Warning . T.unpack) (unplaceableMedia flowInfoMap)
+    liftIO $ mapM_ (reportProgress Warning . T.unpack) (unplaceableMedia flowInfoMap)
 
     -- Step 4: Parse process XMLs in parallel
-    processFiles <- listXMLFiles (dir </> "processes")
-    reportProgress Info $ printf "Parsing %d ILCD process files..." (length processFiles)
-    rawProcesses <- parseProcessFilesParallel processFiles
+    processFiles <- liftIO $ listXMLFiles (dir </> "processes")
+    liftIO $ reportProgress Info $ printf "Parsing %d ILCD process files..." (length processFiles)
+    claimedProcesses <- liftIO $ parseProcessFilesParallel processFiles
+    processes <- ExceptT $ do
+        outcome <- latestByUUID claimedProcesses
+        case outcome of
+            Left err -> return (Left err)
+            Right indexed -> do
+                mapM_ (reportProgress Warning . T.unpack) (ixSuperseded indexed)
+                return (Right (M.elems (ixByUUID indexed)))
 
-    reportProgress Info $ printf "Parsed %d processes, building activity map..." (length rawProcesses)
+    liftIO $ reportProgress Info $ printf "Parsed %d processes, building activity map..." (length processes)
 
     -- Step 5: Build ActivityMap
     let alloc = Allocating{alKey = key, alUnitConfig = unitConfig, alUnitDB = unitDB}
-        activityMap = buildActivityMap alloc flowInfoMap techFlowDB bioFlowDB wasteFlowDB rawProcesses
+        activityMap = buildActivityMap alloc flowInfoMap techFlowDB bioFlowDB wasteFlowDB processes
 
     -- Step 6: Fix supplier links (name-based, like SimaPro)
     let simpleDb = SimpleDatabase activityMap techFlowDB bioFlowDB wasteFlowDB unitDB
-    fixedDb <- fixILCDActivityLinks simpleDb
-    reportProgress Info $
-        printf
-            "ILCD database loaded: %d activities, %d tech flows, %d bio flows, %d units"
-            (M.size $ sdbActivities fixedDb)
-            (M.size $ sdbTechFlows fixedDb)
-            (M.size $ sdbBioFlows fixedDb)
-            (M.size $ sdbUnits fixedDb)
-    return $ Right fixedDb
+    fixedDb <- liftIO $ fixILCDActivityLinks simpleDb
+    liftIO $
+        reportProgress Info $
+            printf
+                "ILCD database loaded: %d activities, %d tech flows, %d bio flows, %d units"
+                (M.size $ sdbActivities fixedDb)
+                (M.size $ sdbTechFlows fixedDb)
+                (M.size $ sdbBioFlows fixedDb)
+                (M.size $ sdbUnits fixedDb)
+    return fixedDb
 
--- | List XML files in a directory
-listXMLFiles :: FilePath -> IO [FilePath]
-listXMLFiles d = do
-    fs <- listDirectory d
-    return [d </> f | f <- fs, map toLower (takeExtension f) == ".xml"]
+{- | Read a directory of one kind of ILCD dataset into one value per UUID,
+saying which files a newer version superseded and refusing when two files
+declare one dataset at the same version.
+-}
+readDataSets :: forall a. FilePath -> (BS.ByteString -> Maybe (UUID, a)) -> IO (Either Text (M.Map UUID a))
+readDataSets dir parse = do
+    files <- listXMLFiles dir
+    claims <- mapM claimOf files
+    outcome <- latestByUUID (Data.Maybe.catMaybes claims)
+    case outcome of
+        Left err -> return (Left err)
+        Right indexed -> do
+            mapM_ (reportProgress Warning . T.unpack) (ixSuperseded indexed)
+            return (Right (ixByUUID indexed))
+  where
+    claimOf :: FilePath -> IO (Maybe (Claimed a))
+    claimOf f = fmap (uncurry (Claimed f)) . parse <$> BS.readFile f
 
 --------------------------------------------------------------------------------
 -- Unit Groups: unitGroupUUID → (refUnitName, refUnitInternalId)
 --------------------------------------------------------------------------------
 
-parseUnitGroups :: FilePath -> IO (M.Map UUID (Text, Int))
-parseUnitGroups dir = do
-    files <- listXMLFiles dir
-    results <- mapM (fmap parseUnitGroupXML . BS.readFile) files
-    return $ M.fromList (Data.Maybe.catMaybes results)
+parseUnitGroups :: FilePath -> IO (Either Text (M.Map UUID (Text, Int)))
+parseUnitGroups dir = readDataSets dir parseUnitGroupXML
 
 data UGState = UGState
     { ugUUID :: !Text
@@ -194,11 +212,8 @@ parseUnitGroupXML bytes =
 -- Flow Properties: flowPropertyUUID → unitGroupUUID
 --------------------------------------------------------------------------------
 
-parseFlowProperties :: FilePath -> IO (M.Map UUID UUID)
-parseFlowProperties dir = do
-    files <- listXMLFiles dir
-    results <- mapM (fmap parseFlowPropertyXML . BS.readFile) files
-    return $ M.fromList (Data.Maybe.catMaybes results)
+parseFlowProperties :: FilePath -> IO (Either Text (M.Map UUID UUID))
+parseFlowProperties dir = readDataSets dir parseFlowPropertyXML
 
 data FPState = FPState
     { fpUUID :: !Text
@@ -595,16 +610,21 @@ parseProcessXML bytes =
                         }
 
 -- | Parse process files in parallel using worker pattern
-parseProcessFilesParallel :: [FilePath] -> IO [ILCDProcessRaw]
+parseProcessFilesParallel :: [FilePath] -> IO [Claimed ILCDProcessRaw]
 parseProcessFilesParallel files = do
     numWorkers <- getNumCapabilities
     let workers = distributeFiles numWorkers files
     workerResults <- mapConcurrently parseWorker workers
-    return $ concat workerResults
+    return (concat workerResults)
   where
+    parseWorker :: [FilePath] -> IO [Claimed ILCDProcessRaw]
     parseWorker paths = do
-        results <- mapM (fmap parseProcessXML . BS.readFile) paths
-        return (Data.Maybe.catMaybes results)
+        results <- mapM parseOneFile paths
+        return [Claimed path (iprUUID raw) raw | (path, Just raw) <- results]
+    parseOneFile :: FilePath -> IO (FilePath, Maybe ILCDProcessRaw)
+    parseOneFile path = do
+        bytes <- BS.readFile path
+        return (path, parseProcessXML bytes)
 
 --------------------------------------------------------------------------------
 -- Build ActivityMap from raw processes

--- a/src/Method/FlowResolver.hs
+++ b/src/Method/FlowResolver.hs
@@ -30,6 +30,7 @@ import Control.Concurrent (getNumCapabilities)
 import Control.Concurrent.Async (mapConcurrently)
 import Control.DeepSeq (NFData, force)
 import Control.Exception (SomeException, catch, evaluate)
+import Control.Monad (when)
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as M
 import Data.Store (Store, decodeEx, encode)
@@ -84,11 +85,17 @@ parseFlowDirectory dir = do
     let cacheFile = flowCacheFile dir
     cached <- loadFlowCache cacheFile dir
     case cached of
-        Just info -> return (Right info)
+        Just flows -> do
+            -- The cache stands in for the directory read, so it has to stand
+            -- in for what that read said as well: a file a newer version
+            -- superseded is named on every start, not only on the one that
+            -- happened to build the cache.
+            mapM_ (reportProgress Warning . T.unpack) (cfSuperseded flows)
+            return (Right (cfByUUID flows))
         Nothing -> do
             parsed <- parseFlowDirectoryFresh dir
             mapM_ (saveFlowCache cacheFile) parsed
-            return parsed
+            return (fmap cfByUUID parsed)
 
 {- | Parse all flow XMLs from scratch using worker-based parallelism.
 
@@ -96,7 +103,7 @@ The workers hand back what they read rather than a map each: merging maps made
 the flow a duplicated UUID resolved to depend on which chunk each file fell
 into, and therefore on the number of cores the machine has.
 -}
-parseFlowDirectoryFresh :: FilePath -> IO (Either Text (M.Map UUID ILCDFlowInfo))
+parseFlowDirectoryFresh :: FilePath -> IO (Either Text CachedFlows)
 parseFlowDirectoryFresh dir = do
     xmlFiles <- listXMLFiles dir
     numWorkers <- getNumCapabilities
@@ -107,24 +114,44 @@ parseFlowDirectoryFresh dir = do
         Left err -> return (Left err)
         Right indexed -> do
             mapM_ (reportProgress Warning . T.unpack) (ixSuperseded indexed)
-            return (Right (ixByUUID indexed))
+            return (Right (CachedFlows (ixByUUID indexed) (ixSuperseded indexed)))
   where
     parseWorker :: [FilePath] -> IO [Claimed ILCDFlowInfo]
     parseWorker paths = do
         results <- mapM parseOneFile paths
-        return $! [Claimed path uuid info | (path, Just (uuid, info)) <- results]
+        return [Claimed path uuid info | (path, Just (uuid, info)) <- results]
     parseOneFile :: FilePath -> IO (FilePath, Maybe (UUID, ILCDFlowInfo))
     parseOneFile path = do
         bytes <- BS.readFile path
-        return (path, parseFlowXML bytes)
+        -- Parsed here and not where the result is used, or the whole directory
+        -- would be parsed on whichever thread first looks at the list, with
+        -- every file's bytes held until it does.
+        parsed <- evaluate (force (parseFlowXML bytes))
+        return (path, parsed)
 
--- | Cache file path for a flows directory
+{- | What a flows directory read comes to: one flow per UUID, and the lines
+about the files a newer version superseded.
+-}
+data CachedFlows = CachedFlows
+    { cfByUUID :: !(M.Map UUID ILCDFlowInfo)
+    , cfSuperseded :: ![Text]
+    }
+    deriving (Generic, NFData, Store)
+
+{- | Cache file path for a flows directory.
+
+The name carries the shape of what is inside it. A cache written before the
+directory read learnt to arbitrate between two files holds a flow that was
+picked by the machine's core count, and it must not be read back as though the
+arbitration had happened.
+-}
 flowCacheFile :: FilePath -> FilePath
-flowCacheFile dir = dir </> ".volca.flows.cache.zst"
+flowCacheFile dir = dir </> ".volca.flows.v2.cache.zst"
 
 -- | Load flow info from cache if valid (file exists and is newer than directory)
-loadFlowCache :: FilePath -> FilePath -> IO (Maybe (M.Map UUID ILCDFlowInfo))
+loadFlowCache :: FilePath -> FilePath -> IO (Maybe CachedFlows)
 loadFlowCache cacheFile dir = do
+    dropSupersededCache dir
     exists <- doesFileExist cacheFile
     if not exists
         then return Nothing
@@ -142,9 +169,9 @@ loadFlowCache cacheFile dir = do
                             compressed <- BS.readFile cacheFile
                             case Zstd.decompress compressed of
                                 Zstd.Decompress raw -> do
-                                    let !info = decodeEx raw
-                                    result <- evaluate (force info)
-                                    reportProgress Info $ "[FLOWS-CACHE] Loaded " <> show (M.size result) <> " flow definitions from cache"
+                                    let !flows = decodeEx raw
+                                    result <- evaluate (force flows)
+                                    reportProgress Info $ "[FLOWS-CACHE] Loaded " <> show (M.size (cfByUUID result)) <> " flow definitions from cache"
                                     return (Just result)
                                 _ -> do
                                     reportProgress Warning "[FLOWS-CACHE] Decompression failed, reparsing"
@@ -153,15 +180,26 @@ loadFlowCache cacheFile dir = do
                 )
                 (\(_ :: SomeException) -> return Nothing)
 
--- | Save parsed flow info to cache
-saveFlowCache :: FilePath -> M.Map UUID ILCDFlowInfo -> IO ()
-saveFlowCache cacheFile info =
+-- | Remove a cache left by a version that wrote a different shape.
+dropSupersededCache :: FilePath -> IO ()
+dropSupersededCache dir =
     catch
         ( do
-            let serialized = encode info
+            let old = dir </> ".volca.flows.cache.zst"
+            stale <- doesFileExist old
+            when stale (removeFile old)
+        )
+        (\(_ :: SomeException) -> return ())
+
+-- | Save parsed flow info to cache
+saveFlowCache :: FilePath -> CachedFlows -> IO ()
+saveFlowCache cacheFile flows =
+    catch
+        ( do
+            let serialized = encode flows
                 compressed = Zstd.compress 1 serialized
             BS.writeFile cacheFile compressed
-            reportProgress Info $ "[FLOWS-CACHE] Saved " <> show (M.size info) <> " flow definitions to cache"
+            reportProgress Info $ "[FLOWS-CACHE] Saved " <> show (M.size (cfByUUID flows)) <> " flow definitions to cache"
         )
         (\(_ :: SomeException) -> return ())
 

--- a/src/Method/FlowResolver.hs
+++ b/src/Method/FlowResolver.hs
@@ -31,7 +31,6 @@ import Control.Concurrent.Async (mapConcurrently)
 import Control.DeepSeq (NFData, force)
 import Control.Exception (SomeException, catch, evaluate)
 import qualified Data.ByteString as BS
-import Data.Char (toLower)
 import qualified Data.Map.Strict as M
 import Data.Store (Store, decodeEx, encode)
 import Data.Text (Text)
@@ -40,11 +39,12 @@ import qualified Data.Text.Read as TR
 import Data.UUID (UUID)
 import qualified Data.UUID as UUID
 import GHC.Generics (Generic)
-import System.Directory (doesDirectoryExist, doesFileExist, getModificationTime, listDirectory, removeFile)
-import System.FilePath (takeDirectory, takeExtension, (</>))
+import System.Directory (doesDirectoryExist, doesFileExist, getModificationTime, removeFile)
+import System.FilePath (takeDirectory, (</>))
 import qualified Xeno.SAX as X
 
 import EcoSpold.Common (bsToText, decodeXmlEntitiesFull, distributeFiles, isElement)
+import ILCD.Common (Claimed (..), Indexed (..), latestByUUID, listXMLFiles)
 import Method.Types (Compartment (..))
 import Progress (ProgressLevel (..), reportProgress)
 import SubstanceRegistry (normalizeCAS)
@@ -79,33 +79,44 @@ resolveFlowDirectory methodDir = do
   Uses a zstd-compressed cache to skip re-parsing on subsequent startups.
   Falls back to worker-based parallel parsing on cache miss.
 -}
-parseFlowDirectory :: FilePath -> IO (M.Map UUID ILCDFlowInfo)
+parseFlowDirectory :: FilePath -> IO (Either Text (M.Map UUID ILCDFlowInfo))
 parseFlowDirectory dir = do
     let cacheFile = flowCacheFile dir
     cached <- loadFlowCache cacheFile dir
     case cached of
-        Just info -> return info
+        Just info -> return (Right info)
         Nothing -> do
-            info <- parseFlowDirectoryFresh dir
-            saveFlowCache cacheFile info
-            return info
+            parsed <- parseFlowDirectoryFresh dir
+            mapM_ (saveFlowCache cacheFile) parsed
+            return parsed
 
--- | Parse all flow XMLs from scratch using worker-based parallelism
-parseFlowDirectoryFresh :: FilePath -> IO (M.Map UUID ILCDFlowInfo)
+{- | Parse all flow XMLs from scratch using worker-based parallelism.
+
+The workers hand back what they read rather than a map each: merging maps made
+the flow a duplicated UUID resolved to depend on which chunk each file fell
+into, and therefore on the number of cores the machine has.
+-}
+parseFlowDirectoryFresh :: FilePath -> IO (Either Text (M.Map UUID ILCDFlowInfo))
 parseFlowDirectoryFresh dir = do
-    files <- listDirectory dir
-    let xmlFiles = [dir </> f | f <- files, map toLower (takeExtension f) == ".xml"]
+    xmlFiles <- listXMLFiles dir
     numWorkers <- getNumCapabilities
     let workers = distributeFiles numWorkers xmlFiles
     workerResults <- mapConcurrently parseWorker workers
-    return $! M.unions workerResults
+    outcome <- latestByUUID (concat workerResults)
+    case outcome of
+        Left err -> return (Left err)
+        Right indexed -> do
+            mapM_ (reportProgress Warning . T.unpack) (ixSuperseded indexed)
+            return (Right (ixByUUID indexed))
   where
+    parseWorker :: [FilePath] -> IO [Claimed ILCDFlowInfo]
     parseWorker paths = do
         results <- mapM parseOneFile paths
-        return $! M.fromList [(uuid, info) | Just (uuid, info) <- results]
+        return $! [Claimed path uuid info | (path, Just (uuid, info)) <- results]
+    parseOneFile :: FilePath -> IO (FilePath, Maybe (UUID, ILCDFlowInfo))
     parseOneFile path = do
         bytes <- BS.readFile path
-        return $ parseFlowXML bytes
+        return (path, parseFlowXML bytes)
 
 -- | Cache file path for a flows directory
 flowCacheFile :: FilePath -> FilePath

--- a/test/FlowResolverSpec.hs
+++ b/test/FlowResolverSpec.hs
@@ -3,11 +3,56 @@
 module FlowResolverSpec (spec) where
 
 import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.List (isInfixOf)
+import qualified Data.Map.Strict as M
 import qualified Data.UUID as UUID
 import EcoSpold.Common (decodeXmlEntities, decodeXmlEntitiesFull)
-import Method.FlowResolver (ILCDFlowInfo (..), parseFlowXML, splitIlcdSynonyms)
+import Method.FlowResolver (ILCDFlowInfo (..), parseFlowDirectory, parseFlowXML, splitIlcdSynonyms)
 import Method.Types (Compartment (..))
+import Progress (LogLine (..), getLogLines)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
+
+{- | A flow claiming the twin UUID, under the given declared version and base
+name, so two files can be written that differ only where the reader looks.
+-}
+twinFlow :: ByteString -> ByteString -> ByteString
+twinFlow version baseName =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+    \<flowDataSet xmlns=\"http://lca.jrc.it/ILCD/Flow\"\n\
+    \             xmlns:common=\"http://lca.jrc.it/ILCD/Common\">\n\
+    \  <flowInformation>\n\
+    \    <dataSetInformation>\n\
+    \      <common:UUID>aaaaaaaa-0000-0000-0000-00000000000f</common:UUID>\n\
+    \      <name>\n\
+    \        <baseName xml:lang=\"en\">"
+        <> baseName
+        <> "</baseName>\n\
+           \      </name>\n\
+           \    </dataSetInformation>\n\
+           \  </flowInformation>\n\
+           \  <modellingAndValidation>\n\
+           \    <LCIMethod>\n\
+           \      <typeOfDataSet>Elementary flow</typeOfDataSet>\n\
+           \    </LCIMethod>\n\
+           \  </modellingAndValidation>\n\
+           \  <administrativeInformation>\n\
+           \    <publicationAndOwnership>\n\
+           \      <common:dataSetVersion>"
+        <> version
+        <> "</common:dataSetVersion>\n\
+           \    </publicationAndOwnership>\n\
+           \  </administrativeInformation>\n\
+           \</flowDataSet>\n"
+
+-- | A flows directory holding the two twins, and nothing else.
+withTwinFlows :: (FilePath -> IO a) -> IO a
+withTwinFlows k = withSystemTempDirectory "ilcd-flows" $ \dir -> do
+    BS.writeFile (dir </> "z-first-edition.xml") (twinFlow "01.00.000" "Carbon dioxide, first edition")
+    BS.writeFile (dir </> "a-second-edition.xml") (twinFlow "02.00.000" "Carbon dioxide, second edition")
+    k dir
 
 spec :: Spec
 spec = do
@@ -51,6 +96,28 @@ spec = do
             splitIlcdSynonyms "a;b othernames c" `shouldBe` ["a", "b", "c"]
 
     -- -----------------------------------------------------------------------
+    -- -----------------------------------------------------------------------
+    -- A flows directory is read once and then cached, so the cache has to
+    -- stand in for what the read said as well as for what it produced.
+    -- -----------------------------------------------------------------------
+    describe "parseFlowDirectory" $ do
+        it "keeps the flow declaring the higher version" $
+            withTwinFlows $ \dir -> do
+                result <- parseFlowDirectory dir
+                case result of
+                    Left err -> expectationFailure $ "Expected Right but got: " ++ show err
+                    Right flows ->
+                        map ilcdBaseName (M.elems flows) `shouldBe` ["Carbon dioxide, second edition"]
+
+        it "names the superseded file again when the flows come from the cache" $
+            withTwinFlows $ \dir -> do
+                _ <- parseFlowDirectory dir
+                (since, _) <- getLogLines 0
+                _ <- parseFlowDirectory dir
+                (_, afterCache) <- getLogLines since
+                let texts = map llText afterCache
+                any ("z-first-edition.xml" `isInfixOf`) texts `shouldBe` True
+
     -- parseFlowXML — well-formed elementary flow
     -- -----------------------------------------------------------------------
     describe "parseFlowXML" $ do

--- a/test/ILCDParserSpec.hs
+++ b/test/ILCDParserSpec.hs
@@ -2,12 +2,19 @@
 
 module ILCDParserSpec (spec) where
 
+import Control.Monad (forM_)
 import qualified Data.ByteString as BS
 import Data.List (find, sortOn)
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
+import qualified Data.Text as T
 import qualified Data.UUID as UUID
+import GHC.Conc (getNumCapabilities, setNumCapabilities)
+import ILCD.Common (readDataSetVersion)
 import ILCD.Parser (ILCDExchangeRaw (..), ILCDProcessRaw (..), buildSupplierIndex, fixActivityExchanges, parseILCDDirectory, parseProcessXML)
+import System.Directory (copyFile, createDirectoryIfMissing, listDirectory)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 import Types
 import UnitConversion (defaultUnitConfig)
@@ -93,6 +100,66 @@ activityWithInputExchange fid =
         , activityNativeId = Nothing
         , activityFormulaCheck = Nothing
         }
+
+-- ---------------------------------------------------------------------------
+-- Two files, one dataset
+-- ---------------------------------------------------------------------------
+
+{- | A process claiming the twin UUID, under the given declared version and
+base name. Everything else is the sample's coal extraction, so the two files
+differ only where the test reads them.
+-}
+twinProcess :: BS.ByteString -> BS.ByteString -> BS.ByteString
+twinProcess version baseName =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+    \<processDataSet xmlns=\"http://lca.jrc.it/ILCD/Process\"\n\
+    \                xmlns:common=\"http://lca.jrc.it/ILCD/Common\">\n\
+    \  <processInformation>\n\
+    \    <dataSetInformation>\n\
+    \      <common:UUID>aaaaaaaa-0000-0000-0000-000000000009</common:UUID>\n\
+    \      <name>\n\
+    \        <baseName xml:lang=\"en\">"
+        <> baseName
+        <> "</baseName>\n\
+           \      </name>\n\
+           \    </dataSetInformation>\n\
+           \    <geography location=\"GLO\"/>\n\
+           \    <quantitativeReference>\n\
+           \      <referenceToReferenceFlow>0</referenceToReferenceFlow>\n\
+           \    </quantitativeReference>\n\
+           \  </processInformation>\n\
+           \  <exchanges>\n\
+           \    <exchange dataSetInternalID=\"0\">\n\
+           \      <referenceToFlowDataSet refObjectId=\"aaaaaaaa-0000-0000-0000-000000000004\"\n\
+           \                              type=\"flow data set\"/>\n\
+           \      <exchangeDirection>Output</exchangeDirection>\n\
+           \      <resultingAmount>1.0</resultingAmount>\n\
+           \    </exchange>\n\
+           \  </exchanges>\n\
+           \  <administrativeInformation>\n\
+           \    <publicationAndOwnership>\n\
+           \      <common:dataSetVersion>"
+        <> version
+        <> "</common:dataSetVersion>\n\
+           \    </publicationAndOwnership>\n\
+           \  </administrativeInformation>\n\
+           \</processDataSet>\n"
+
+{- | The sample package copied beside the given extra process files, so a test
+can add a twin without touching the fixture every other test reads.
+-}
+withSampleAnd :: [(FilePath, BS.ByteString)] -> (FilePath -> IO a) -> IO a
+withSampleAnd extra k = withSystemTempDirectory "ilcd-twin" $ \dir -> do
+    forM_ ["processes", "flows", "flowproperties", "unitgroups"] $ \sub -> do
+        createDirectoryIfMissing True (dir </> sub)
+        names <- listDirectory ("test-data/SAMPLE.ilcd" </> sub)
+        forM_ names $ \n -> copyFile ("test-data/SAMPLE.ilcd" </> sub </> n) (dir </> sub </> n)
+    forM_ extra $ \(name, bytes) -> BS.writeFile (dir </> "processes" </> name) bytes
+    k dir
+
+-- | The activity names of a loaded database, sorted.
+namesOf :: SimpleDatabase -> [Text]
+namesOf db = sortOn id [activityName a | a <- M.elems (sdbActivities db)]
 
 spec :: Spec
 spec = do
@@ -246,6 +313,63 @@ spec = do
                     fid `shouldBe` flowUUID1 -- unchanged
                     role `shouldBe` ReferenceProduct
                 _ -> expectationFailure "expected one TechnosphereExchange"
+
+    -- -----------------------------------------------------------------------
+    -- An ILCD dataset is named by the UUID in the file, so two files can claim
+    -- one dataset. The version each declares says which, and nothing else can.
+    -- -----------------------------------------------------------------------
+    describe "two files claiming one dataset" $ do
+        -- The file names are chosen so the higher version sorts first: a table
+        -- keeping whichever file came last would take the older dataset, and a
+        -- listing in the other order would take the newer one.
+        let older = ("z-first-edition.xml", twinProcess "01.00.000" "Coal extraction, first edition")
+            newer = ("a-second-edition.xml", twinProcess "02.00.000" "Coal extraction, second edition")
+
+        it "keeps the dataset declaring the higher version" $
+            withSampleAnd [older, newer] $ \dir -> do
+                result <- parseILCDDirectory defaultUnitConfig Declared dir
+                case result of
+                    Left err -> expectationFailure $ "Expected Right but got: " ++ show err
+                    Right db -> namesOf db `shouldSatisfy` elem "Coal extraction, second edition"
+
+        it "does not keep the dataset it replaces" $
+            withSampleAnd [older, newer] $ \dir -> do
+                result <- parseILCDDirectory defaultUnitConfig Declared dir
+                case result of
+                    Left err -> expectationFailure $ "Expected Right but got: " ++ show err
+                    Right db -> namesOf db `shouldSatisfy` notElem "Coal extraction, first edition"
+
+        -- The files are read by as many workers as the machine has cores, and
+        -- the answer used to depend on which worker each file fell to.
+        it "answers the same on one core as on four" $
+            withSampleAnd [older, newer] $ \dir -> do
+                cores <- getNumCapabilities
+                setNumCapabilities 1
+                onOne <- parseILCDDirectory defaultUnitConfig Declared dir
+                setNumCapabilities 4
+                onFour <- parseILCDDirectory defaultUnitConfig Declared dir
+                setNumCapabilities cores
+                fmap namesOf onOne `shouldBe` fmap namesOf onFour
+
+        it "refuses when two files declare one dataset at the same version"
+            $ withSampleAnd
+                [ ("twin-a.xml", twinProcess "03.00.000" "Coal extraction, one way")
+                , ("twin-b.xml", twinProcess "03.00.000" "Coal extraction, another way")
+                ]
+            $ \dir -> do
+                result <- parseILCDDirectory defaultUnitConfig Declared dir
+                case result of
+                    Right _ -> expectationFailure "Expected the load to stop on two files at one version"
+                    Left err -> do
+                        err `shouldSatisfy` T.isInfixOf "twin-a.xml"
+                        err `shouldSatisfy` T.isInfixOf "twin-b.xml"
+
+    describe "readDataSetVersion" $ do
+        it "compares the numbers and not the text" $
+            (readDataSetVersion "10.00.000" > readDataSetVersion "09.00.000") `shouldBe` True
+
+        it "reads nothing from a version that is not dotted numbers" $
+            readDataSetVersion "draft" `shouldBe` Nothing
 
     -- -----------------------------------------------------------------------
     -- parseProcessXML: basic fields

--- a/volca.cabal
+++ b/volca.cabal
@@ -118,6 +118,7 @@ library
                      , BrightwayExcel.Writer
                      , Expr
                      , Zip
+                     , ILCD.Common
                      , ILCD.Parser
                      , ILCD.Writer
                      , Database.Export


### PR DESCRIPTION
## Problem

An ILCD dataset is named by the UUID inside its file, not by the file's name,
so two files can claim one dataset. That is how the format publishes a
revision, and the superseded file often stays in the directory beside the new
one.

Four indexes were built over such a directory with `M.fromList`, which keeps
the last row and says nothing, and the directory listing was never sorted. So
which of the two files ended up in the database came from the file system's
order: unit groups, flow properties, flows and processes alike.

The flows made it worse. Each worker built its own map and the maps were merged
with `M.unions`, which is first-wins where `M.fromList` is last-wins. Two files
in one chunk kept the second, two files in different chunks kept the first, and
the chunks are cut by `getNumCapabilities`. The same package read on a
four-core machine and on a one-core machine gave two different databases.

## Solution

The listing is sorted, and the four indexes go through one reducer,
`ILCD.Common.latestByUUID`. For each UUID it keeps the file declaring the
highest `<common:dataSetVersion>`, names in the log every file a newer version
replaces, and stops the load when two files declare one dataset at the same
version, or when neither declares one at all. The version is compared on its
numbers, so `10.00.000` is above `09.00.000`.

Nothing read that element before. It is read on its own rather than added to
each of the four parsers, and only for the files of a UUID that two of them
claim: a directory where every UUID appears once pays for nothing.

The flows are cached on disk, and the cache stands in for the directory read,
so it carries the superseded lines too and replays them on every start. Its
file name carries the shape of what is inside, because a cache written before
this change holds a flow the core count picked; the old file is removed when
found.

## Remarks

`parseFlowDirectory` and the two small readers gained an `Either Text` result,
and the method loader threads it: a flows directory that names one dataset
twice at one version now stops the method collection from loading rather than
enriching its factors from whichever file was read first.

## How to test

`cabal test all` - 2601 examples, 0 failures, 2 pending. Eight new examples.
Two process files claiming one UUID at versions 01.00.000 and 02.00.000 load as
the second edition and not the first, with the file names chosen so that the
lower version sorts first; the same directory gives the same answer with one
capability and with four; two files at 03.00.000 stop the load and are both
named in the message; a version reads as numbers, so 10 is above 09; and for
the flows, the higher version wins and the superseded file is named again on
the start that reads the cache rather than the directory.
