### PR TITLE
Say when two entries claim one name

### DIFF
--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -123,6 +123,9 @@ module Database.Manager (
     -- * Internal (for tests: pure dependency-list builder)
     buildDependencyChoices,
 
+    -- * Internal (for tests: the names two entries both claim)
+    shadowedNames,
+
     -- * Installing a database the caller built itself
     solverFor,
     publishLoaded,
@@ -1179,11 +1182,16 @@ discoverDatabases config = do
         return dbConfig{dcPath = resolvedPath, dcFormat = Just format}
     -- Uploaded databases are self-describing, through their meta.toml
     uploaded <- discoverUploadedDatabases
-    return (configured ++ uploaded)
+    let combined = configured ++ uploaded
+    mapM_ (reportProgress Warning) (shadowedNames "database" dcName dcPath combined)
+    return combined
 
 -- | Configured method collections plus the uploaded ones.
 discoverMethods :: Config -> IO [MethodConfig]
-discoverMethods config = (cfgMethods config ++) <$> discoverUploadedMethodConfigs
+discoverMethods config = do
+    combined <- (cfgMethods config ++) <$> discoverUploadedMethodConfigs
+    mapM_ (reportProgress Warning) (shadowedNames "method collection" mcName mcPath combined)
+    return combined
 
 -- | Configured reference data plus whatever sits under @uploads/<kind>/@.
 discoverRefDataSources :: Config -> IO RefDataSources
@@ -1197,21 +1205,25 @@ discoverRefDataSources config =
     withUploads :: String -> [RefDataConfig] -> FilePath -> IO [RefDataConfig]
     withUploads kind configured dir = do
         combined <- (configured ++) <$> discoverUploadedRefData dir
-        mapM_ (reportProgress Warning) (shadowedSources kind combined)
+        mapM_ (reportProgress Warning) (shadowedNames (kind <> " source") rdName (describeSource . rdSource) combined)
         pure combined
 
-{- | One warning per name held by more than one source. 'newManager' indexes
-these by name, so a repeated one keeps the last and drops the rest: an uploaded
-directory named like a configured source is all it takes, and the configuration
-checks duplicates for databases and method collections but not for these. Which
-one wins follows from a concatenation order nothing states, so name the file
-being read as well as the ones being ignored.
+{- | One warning per name held by more than one entry, naming the one that is
+read and the ones that are not.
+
+'newManager' indexes databases, method collections and reference sources by
+name, so a repeated one keeps the last and drops the rest. The configuration
+refuses a repeated name, but it only ever sees the configured half: what
+reaches these indexes is that half concatenated with whatever the uploads
+directory holds, so an uploaded directory named like a configured entry is all
+it takes to replace it. Which one wins then follows from a concatenation order
+nothing states, and it used to be said nowhere.
 -}
-shadowedSources :: String -> [RefDataConfig] -> [String]
-shadowedSources kind rds =
-    [ "Reference data: more than one "
+shadowedNames :: String -> (a -> Text) -> (a -> String) -> [a] -> [String]
+shadowedNames kind nameOf describe entries =
+    [ "More than one "
         <> kind
-        <> " source named "
+        <> " named "
         <> T.unpack name
         <> "; reading "
         <> winner
@@ -1220,10 +1232,10 @@ shadowedSources kind rds =
     | (name, winner : ignored@(_ : _)) <- M.toList lastFirst
     ]
   where
-    -- 'M.fromListWith' prepends, so a group comes out last source first, and
+    -- 'M.fromListWith' prepends, so a group comes out last entry first, and
     -- that first one is what 'M.fromList' keeps.
     lastFirst :: Map Text [String]
-    lastFirst = M.fromListWith (++) [(rdName rd, [describeSource (rdSource rd)]) | rd <- rds]
+    lastFirst = M.fromListWith (++) [(nameOf e, [describe e]) | e <- entries]
 
 {- | The location hierarchy this run scores against. Falling back to the
 built-in hierarchy when a named file cannot be read would change every

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -125,6 +125,7 @@ module Database.Manager (
 
     -- * Internal (for tests: the names two entries both claim)
     shadowedNames,
+    shadowedMethods,
 
     -- * Installing a database the caller built itself
     solverFor,
@@ -148,6 +149,7 @@ import Data.Char (toLower)
 import qualified Data.Csv as Csv
 import Data.Either (fromRight, lefts, partitionEithers, rights)
 import Data.Indexing (uniqueIndex)
+import qualified Data.Indexing as Indexing
 import Data.List (intercalate, isPrefixOf, sort, sortOn)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
@@ -1190,7 +1192,7 @@ discoverDatabases config = do
 discoverMethods :: Config -> IO [MethodConfig]
 discoverMethods config = do
     combined <- (cfgMethods config ++) <$> discoverUploadedMethodConfigs
-    mapM_ (reportProgress Warning) (shadowedNames "method collection" mcName mcPath combined)
+    mapM_ (reportProgress Warning) (shadowedMethods combined)
     return combined
 
 -- | Configured reference data plus whatever sits under @uploads/<kind>/@.
@@ -1211,13 +1213,13 @@ discoverRefDataSources config =
 {- | One warning per name held by more than one entry, naming the one that is
 read and the ones that are not.
 
-'newManager' indexes databases, method collections and reference sources by
-name, so a repeated one keeps the last and drops the rest. The configuration
-refuses a repeated name, but it only ever sees the configured half: what
-reaches these indexes is that half concatenated with whatever the uploads
-directory holds, so an uploaded directory named like a configured entry is all
-it takes to replace it. Which one wins then follows from a concatenation order
-nothing states, and it used to be said nowhere.
+'newManager' indexes databases and reference sources by name, so a repeated one
+keeps the last and drops the rest. The configuration refuses a repeated name,
+but it only ever sees the configured half: what reaches these indexes is that
+half concatenated with whatever the uploads directory holds, so an uploaded
+directory named like a configured entry is all it takes to replace it. Which
+one wins then follows from a concatenation order nothing states, and it used to
+be said nowhere.
 -}
 shadowedNames :: String -> (a -> Text) -> (a -> String) -> [a] -> [String]
 shadowedNames kind nameOf describe entries =
@@ -1226,16 +1228,32 @@ shadowedNames kind nameOf describe entries =
         <> " named "
         <> T.unpack name
         <> "; reading "
-        <> winner
+        <> NE.last paths
         <> ", ignoring "
-        <> intercalate ", " (reverse ignored)
-    | (name, winner : ignored@(_ : _)) <- M.toList lastFirst
+        <> intercalate ", " (NE.init paths)
+    | (name, paths) <- Indexing.collisions [(nameOf e, describe e) | e <- entries]
     ]
-  where
-    -- 'M.fromListWith' prepends, so a group comes out last entry first, and
-    -- that first one is what 'M.fromList' keeps.
-    lastFirst :: Map Text [String]
-    lastFirst = M.fromListWith (++) [(nameOf e, [describe e]) | e <- entries]
+
+{- | The same for method collections, which cannot be told which one is read,
+because two registries answer and they disagree.
+
+'dmAvailableMethods' is indexed like the others and keeps the last entry, so a
+listing describes the uploaded collection. The boot load walks the configured
+list instead and takes the active ones, and an uploaded collection is never
+active, so what is actually scored with is the configured one. Under a repeated
+name those are two different collections, and neither is simply ignored.
+-}
+shadowedMethods :: [MethodConfig] -> [String]
+shadowedMethods mcs =
+    [ "More than one method collection named "
+        <> T.unpack name
+        <> "; listed from "
+        <> NE.last paths
+        <> " and loaded from "
+        <> NE.head paths
+        <> ", so the name answers with two different collections"
+    | (name, paths) <- Indexing.collisions [(mcName mc, mcPath mc) | mc <- mcs]
+    ]
 
 {- | The location hierarchy this run scores against. Falling back to the
 built-in hierarchy when a named file cannot be read would change every

--- a/test/ShadowedNamesSpec.hs
+++ b/test/ShadowedNamesSpec.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | A database, a method collection and a reference source are each reached by
+name, and what reaches those indexes is the configuration concatenated with the
+uploads directory. A name held twice therefore drops one of its bearers, and
+this is what says so.
+-}
+module ShadowedNamesSpec (spec) where
+
+import Data.Text (Text)
+import Database.Manager (shadowedNames)
+import Test.Hspec
+
+named :: [(Text, String)] -> [String]
+named = shadowedNames "database" fst snd
+
+spec :: Spec
+spec = describe "shadowedNames" $ do
+    it "says nothing when every name is held once" $
+        named [("agri", "a.toml"), ("eco", "b.toml")] `shouldBe` []
+
+    it "names the entry that is read and the one that is not" $
+        named [("agri", "configured.toml"), ("agri", "uploads/agri")]
+            `shouldBe` ["More than one database named agri; reading uploads/agri, ignoring configured.toml"]
+
+    it "names every entry a winner hides, in the order they were given" $
+        named [("agri", "first"), ("agri", "second"), ("agri", "third")]
+            `shouldBe` ["More than one database named agri; reading third, ignoring first, second"]
+
+    it "reports one line per name, not one per entry" $
+        length (named [("agri", "a"), ("eco", "b"), ("agri", "c"), ("eco", "d")]) `shouldBe` 2

--- a/test/ShadowedNamesSpec.hs
+++ b/test/ShadowedNamesSpec.hs
@@ -7,8 +7,9 @@ this is what says so.
 -}
 module ShadowedNamesSpec (spec) where
 
+import Config (MethodConfig (..))
 import Data.Text (Text)
-import Database.Manager (shadowedNames)
+import Database.Manager (shadowedMethods, shadowedNames)
 import Test.Hspec
 
 named :: [(Text, String)] -> [String]
@@ -17,15 +18,37 @@ named = shadowedNames "database" fst snd
 spec :: Spec
 spec = describe "shadowedNames" $ do
     it "says nothing when every name is held once" $
-        named [("agri", "a.toml"), ("eco", "b.toml")] `shouldBe` []
+        named [("one", "a.toml"), ("other", "b.toml")] `shouldBe` []
 
     it "names the entry that is read and the one that is not" $
-        named [("agri", "configured.toml"), ("agri", "uploads/agri")]
-            `shouldBe` ["More than one database named agri; reading uploads/agri, ignoring configured.toml"]
+        named [("one", "configured.toml"), ("one", "uploads/one")]
+            `shouldBe` ["More than one database named one; reading uploads/one, ignoring configured.toml"]
 
     it "names every entry a winner hides, in the order they were given" $
-        named [("agri", "first"), ("agri", "second"), ("agri", "third")]
-            `shouldBe` ["More than one database named agri; reading third, ignoring first, second"]
+        named [("one", "first"), ("one", "second"), ("one", "third")]
+            `shouldBe` ["More than one database named one; reading third, ignoring first, second"]
 
     it "reports one line per name, not one per entry" $
-        length (named [("agri", "a"), ("eco", "b"), ("agri", "c"), ("eco", "d")]) `shouldBe` 2
+        length (named [("one", "a"), ("other", "b"), ("one", "c"), ("other", "d")]) `shouldBe` 2
+
+    -- A method collection answers through two registries, and under a repeated
+    -- name they answer with two different collections: the listing keeps the
+    -- last entry, the boot load takes the active one, and an uploaded
+    -- collection is never active.
+    it "names both registries for a method collection, rather than a winner" $
+        shadowedMethods [collection "one" "configured", collection "one" "uploads/one"]
+            `shouldBe` ["More than one method collection named one; listed from uploads/one and loaded from configured, so the name answers with two different collections"]
+
+collection :: Text -> FilePath -> MethodConfig
+collection name path =
+    MethodConfig
+        { mcName = name
+        , mcPath = path
+        , mcActive = True
+        , mcIsUploaded = False
+        , mcDescription = Nothing
+        , mcFormat = Nothing
+        , mcScoringSets = []
+        , mcGlobalMethods = []
+        , mcPatches = []
+        }

--- a/volca.cabal
+++ b/volca.cabal
@@ -282,6 +282,7 @@ test-suite lca-tests
                      , MappingSpec
                      , BuiltinSpec
                      , ManagerBuiltinSpec
+                     , ShadowedNamesSpec
                      , MethodSetTablesSpec
                      , MethodCollectionCacheSpec
                      , DependencyFlowClosureSpec


### PR DESCRIPTION
## Problem

The manager reaches a database, a method collection and a reference source by
name: `newManager` builds an index keyed on the name for each of the three, and
`M.fromList` keeps the last row of a repeated key.

What reaches those indexes is the configuration concatenated with whatever the
uploads directory holds. The configuration does refuse a repeated name, but it
only ever sees the configured half, so an uploaded directory named like a
configured database replaced it, and nothing said so. The same for a method
collection.

Reference sources already warned about exactly this, in a comment that credits
the configuration with checking databases and method collections. It checks
them on the half it can see.

## Solution

One function, called for databases and for reference sources, naming the entry
that is read and the ones that are not. What it prints for reference sources is
what it printed before, minus a redundant prefix.

Method collections get their own sentence, because there is no single winner to
name: the listing is indexed like the others and keeps the last entry, while
the boot load walks the configured list and takes the active ones, and an
uploaded collection is never active. Under a repeated name a listing therefore
describes one collection and the scoring uses another, so the warning names
both and says which registry each answers.

## Remarks

Which entry wins is unchanged: it still follows from the concatenation order,
so an upload still shadows a configured database rather than the other way
round. Whether that is the right precedence is a separate question, and so is
the method registries' disagreement; this only stops both from happening in
silence.

## How to test

`cabal test all` - 2598 examples, 0 failures, 2 pending. Five new examples: a
name held once says nothing, a name held twice names the winner and the loser,
a name held three times names both losers in the order they were given, the
report is one line per name rather than one per entry, and a method collection
name held twice names the two registries instead of a winner.
