### PR TITLE
Merge two declarations of one waste flow

### DIFF
--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -80,6 +80,7 @@ module Database.Loader (
     normalizeText,
     mergeTechFlows,
     mergeBioFlows,
+    mergeWasteFlows,
     Harvest (..),
     harvestOf,
     generateActivityUUIDFromActivity,
@@ -208,6 +209,16 @@ mergeBioFlows a b =
         , bfCAS = bfCAS a <|> bfCAS b
         }
 
+{- | Waste counterpart of 'mergeTechFlows'. A waste flow carries the same two
+fields, and an EcoSpold 2 file fills its synonyms from the same place.
+-}
+mergeWasteFlows :: WasteFlow -> WasteFlow -> WasteFlow
+mergeWasteFlows a b =
+    a
+        { wfSynonyms = M.unionWith S.union (wfSynonyms a) (wfSynonyms b)
+        , wfCAS = wfCAS a <|> wfCAS b
+        }
+
 {- | What one reader harvested from the files it was given: a piece of the
 database, the dataset numbers those files carried, and how many flow and unit
 declarations it read before deduplication. A load is the sum of its harvests.
@@ -247,7 +258,7 @@ instance Semigroup Harvest where
             { hvActivities = M.union (hvActivities a) (hvActivities b)
             , hvTechFlows = MS.unionWith mergeTechFlows (hvTechFlows a) (hvTechFlows b)
             , hvBioFlows = MS.unionWith mergeBioFlows (hvBioFlows a) (hvBioFlows b)
-            , hvWasteFlows = M.union (hvWasteFlows a) (hvWasteFlows b)
+            , hvWasteFlows = MS.unionWith mergeWasteFlows (hvWasteFlows a) (hvWasteFlows b)
             , hvUnits = M.union (hvUnits a) (hvUnits b)
             , hvDatasetNumbers = MS.unionWith (<>) (hvDatasetNumbers a) (hvDatasetNumbers b)
             , hvRawFlows = hvRawFlows a + hvRawFlows b
@@ -266,7 +277,7 @@ harvestOf entries =
         { hvActivities = M.fromList [(key, pdActivity parsed) | (key, parsed) <- entries]
         , hvTechFlows = MS.fromListWith mergeTechFlows [(tfId f, f) | f <- techs]
         , hvBioFlows = MS.fromListWith mergeBioFlows [(bfId f, f) | f <- bios]
-        , hvWasteFlows = M.fromList [(wfId f, f) | f <- wastes]
+        , hvWasteFlows = MS.fromListWith mergeWasteFlows [(wfId f, f) | f <- wastes]
         , hvUnits = M.fromList [(unitId u, u) | u <- units]
         , hvDatasetNumbers = MS.fromListWith (flip (<>)) [(pdDatasetNumber parsed, key NE.:| []) | (key, parsed) <- entries, pdDatasetNumber parsed /= 0]
         , hvRawFlows = length techs + length bios + length wastes

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -266,7 +266,7 @@ instance Semigroup Harvest where
             }
 
 instance Monoid Harvest where
-    mempty = Harvest M.empty MS.empty MS.empty M.empty M.empty M.empty 0 0
+    mempty = Harvest M.empty MS.empty MS.empty MS.empty M.empty M.empty 0 0
 
 {- | Harvest a batch of parsed datasets, each already keyed by the (activity,
 product) pair its source names it under.

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -82,6 +82,25 @@ key, so that two of them collide and the merging law has to decide.
 share :: Text -> [TechnosphereFlow] -> ((UUID.UUID, UUID.UUID), ParsedDataset)
 share name techs = ((actUUID1, flowUUID1), minimalDataset (minimalActivity name "GLO" []) techs)
 
+{- | One reader's share carrying a waste flow instead of a technosphere one.
+An EcoSpold 2 file fills a waste flow's synonyms from the same place as a
+technosphere flow's, so the same collision is reachable there.
+-}
+wasting :: Text -> [WasteFlow] -> ((UUID.UUID, UUID.UUID), ParsedDataset)
+wasting name wastes =
+    ((actUUID1, flowUUID1), (minimalDataset (minimalActivity name "GLO" []) []){pdWasteFlows = wastes})
+
+minimalWaste :: UUID.UUID -> Text -> [Text] -> WasteFlow
+minimalWaste fid name syns =
+    WasteFlow
+        { wfId = fid
+        , wfName = name
+        , wfUnitId = UUID.nil
+        , wfSynonyms = M.singleton "en" (S.fromList syns)
+        , wfCAS = Nothing
+        , wfSubstanceId = Nothing
+        }
+
 {- | One coproduct of a block published under dataset number 7: allocation gives
 each of them its own key, and they all carry the number the block was read under.
 -}
@@ -272,6 +291,23 @@ spec = do
             let merged = harvestOf [share "activity-a" []] <> harvestOf [share "activity-b" []]
             fmap activityName (M.lookup (actUUID1, flowUUID1) (hvActivities merged))
                 `shouldBe` Just "activity-a"
+
+        -- A waste flow carries the same synonyms and the same CAS as the two
+        -- tables beside it, and it used to keep one row of a repeated key
+        -- whole, so a synonym declared only by the file that lost was gone.
+        it "keeps the synonyms of every file that declared one waste flow" $ do
+            let a = minimalWaste flowUUID2 "spoil" ["mine spoil"]
+                b = minimalWaste flowUUID2 "spoil" ["overburden"]
+                harvest = harvestOf [wasting "activity-a" [a], wasting "activity-b" [b]]
+            fmap wfSynonyms (M.lookup flowUUID2 (hvWasteFlows harvest))
+                `shouldBe` Just (M.singleton "en" (S.fromList ["mine spoil", "overburden"]))
+
+        it "keeps them across two readers as well" $ do
+            let a = minimalWaste flowUUID2 "spoil" ["mine spoil"]
+                b = minimalWaste flowUUID2 "spoil" ["overburden"]
+                merged = harvestOf [wasting "activity-a" [a]] <> harvestOf [wasting "activity-b" [b]]
+            fmap wfSynonyms (M.lookup flowUUID2 (hvWasteFlows merged))
+                `shouldBe` Just (M.singleton "en" (S.fromList ["mine spoil", "overburden"]))
 
         -- The dataset-number table is under neither law: an allocated block is
         -- written once per coproduct, all of them under the block's number, so


### PR DESCRIPTION
## Problem

A harvest folds its technosphere and biosphere flows with a merge that keeps
the synonyms and the CAS of every file declaring the flow. One flow is declared
in many datasets and each may name it differently, which is what that merge
exists for, and its documentation says so.

The waste flows of the same harvest were folded with plain `M.fromList`, and
merged between harvests with plain `M.union`. A `WasteFlow` carries the same
two fields, and an EcoSpold 2 file fills its synonyms from the same place as a
technosphere flow's, so a synonym declared only by a file that lost was gone.

Which file lost was not stable either. The two plain folds face opposite ways:
`fromList` keeps the last row, `union` keeps the first, so a duplicate inside
one reader's share kept the last while a duplicate spanning two shares kept the
first, and how the files are shared out follows the machine's core count.

## Solution

One more merge beside the two that were already there, doing for a waste flow
what they do for their own: union the synonyms, keep whichever declaration
carries a CAS.

## Remarks

Nothing else in the harvest changes. A waste flow declared once is unaffected,
and no database gains or loses a flow: only what a kept flow carries.

## How to test

`cabal test all` - 2611 examples, 0 failures, 2 pending. Two new examples, next
to the ones that pin the same two laws for technosphere flows: two datasets in
one reader's share declaring one waste flow under two synonyms keep both, and
so do two readers' shares meeting.
