### PR TITLE
Rank the processes an ILCD product flow reaches

### DIFF
--- a/src/ILCD/Parser.hs
+++ b/src/ILCD/Parser.hs
@@ -776,26 +776,61 @@ buildActivity flowInfoMap techFlowDB bioFlowDB wasteFlowDB unitDB p =
 -- Fix activity links (supplier resolution by name)
 --------------------------------------------------------------------------------
 
--- | Flow UUID → (activityUUID, productUUID) for reference exchanges
-type SupplierIndex = M.Map UUID (UUID, UUID)
+{- | Flow UUID → every process declaring that flow as its reference output,
+the first of them being the one an input naming only the flow is linked to.
+
+Several is the ordinary shape rather than the exception: one product made in
+two places is two processes declaring one product flow, and an ILCD exchange
+names the flow, never the process. The file therefore does not say which one an
+input meant, and something has to choose.
+-}
+type SupplierIndex = M.Map UUID (NE.NonEmpty (UUID, UUID))
 
 fixILCDActivityLinks :: SimpleDatabase -> IO SimpleDatabase
 fixILCDActivityLinks db = do
     let idx = buildSupplierIndex (sdbActivities db)
     reportProgress Info $ printf "Built supplier index with %d entries for ILCD linking" (M.size idx)
+    mapM_ (reportProgress Warning) (sharedProducts idx)
     return db{sdbActivities = M.map (fixActivityExchanges idx) (sdbActivities db)}
 
-{- | Build a flow-UUID-keyed index of (activityUUID, productUUID) from reference exchanges.
-UUID-based: no name collisions, no indirection through flowDB.
+{- | How many product flows more than one process makes, said once.
+
+One line per flow would be one line per product with a regional variant, which
+is most of a package; the count is what tells a reader that the linking below
+chose, and the ranking is what makes the choice the same everywhere.
+-}
+sharedProducts :: SupplierIndex -> [String]
+sharedProducts idx =
+    [ printf
+        "%d product flow(s) are made by more than one process; each input naming one of them is linked to the process still in service, then the first by name and location"
+        shared
+    | let shared = length [() | producers <- M.elems idx, NE.length producers > 1]
+    , shared > 0
+    ]
+
+{- | Build a flow-UUID-keyed index of the processes producing each flow.
+
+Ranked on what the datasets say - in service before retired, then the name and
+the location - because the alternative is the order of the identifiers, which
+ranks on the identity a file was minted with and can put a retired process
+first. The activity UUID breaks the last tie so that two processes agreeing on
+all of it still come out in the same order on every machine.
 -}
 buildSupplierIndex :: ActivityMap -> SupplierIndex
 buildSupplierIndex activities =
-    M.fromList
-        [ (exchangeFlowId ex, (actUUID, prodUUID))
-        | ((actUUID, prodUUID), act) <- M.toList activities
-        , ex <- exchanges act
-        , exchangeIsReference ex
-        ]
+    M.map (NE.sortWith supplierOrder) $
+        M.fromListWith
+            (<>)
+            [ (exchangeFlowId ex, (actUUID, prodUUID) NE.:| [])
+            | ((actUUID, prodUUID), act) <- M.toList activities
+            , ex <- exchanges act
+            , exchangeIsReference ex
+            ]
+  where
+    supplierOrder :: (UUID, UUID) -> (Bool, Text, Text, UUID, UUID)
+    supplierOrder (actUUID, prodUUID) = case M.lookup (actUUID, prodUUID) activities of
+        Just act -> (activityIsObsolete act, activityName act, activityLocation act, actUUID, prodUUID)
+        Nothing -> (True, "", "", actUUID, prodUUID)
 
 fixActivityExchanges :: SupplierIndex -> Activity -> Activity
 fixActivityExchanges idx act =
@@ -806,7 +841,7 @@ fixActivityExchanges idx act =
     -- (it is a reference exchange) but rewriting it would point the activity
     -- at itself and erase the role, breaking 'activityNormFactor'.
     fixEx ex@TechnosphereExchange{techFlowId = fid, techRole = Input} =
-        case M.lookup fid idx of
+        case NE.head <$> M.lookup fid idx of
             Just (actUUID, prodUUID) ->
                 ex
                     { techFlowId = prodUUID
@@ -818,7 +853,7 @@ fixActivityExchanges idx act =
     -- A waste input awaiting treatment-activity resolution follows the same
     -- name-lookup logic as a technosphere Input.
     fixEx ex@WasteExchange{waFlowId = fid, waIsInput = True} =
-        case M.lookup fid idx of
+        case NE.head <$> M.lookup fid idx of
             Just (actUUID, prodUUID) ->
                 ex
                     { waFlowId = prodUUID

--- a/src/ILCD/Parser.hs
+++ b/src/ILCD/Parser.hs
@@ -12,6 +12,7 @@ module ILCD.Parser (
     ILCDProcessRaw (..),
     ILCDExchangeRaw (..),
     buildSupplierIndex,
+    ILCDProducer (..),
     fixActivityExchanges,
 ) where
 
@@ -776,15 +777,27 @@ buildActivity flowInfoMap techFlowDB bioFlowDB wasteFlowDB unitDB p =
 -- Fix activity links (supplier resolution by name)
 --------------------------------------------------------------------------------
 
+{- | One process declaring a product flow as its reference output, and where it
+declares it.
+
+The location is carried because an ILCD exchange states one of its own, and
+that is the only thing in the file that says which producer an input meant.
+-}
+data ILCDProducer = ILCDProducer
+    { ipActivity :: !UUID
+    , ipProduct :: !UUID
+    , ipLocation :: !Text
+    }
+    deriving (Eq, Show)
+
 {- | Flow UUID → every process declaring that flow as its reference output,
-the first of them being the one an input naming only the flow is linked to.
+ranked so the head is the one an input that says nothing more is linked to.
 
 Several is the ordinary shape rather than the exception: one product made in
 two places is two processes declaring one product flow, and an ILCD exchange
-names the flow, never the process. The file therefore does not say which one an
-input meant, and something has to choose.
+names the flow, never the process.
 -}
-type SupplierIndex = M.Map UUID (NE.NonEmpty (UUID, UUID))
+type SupplierIndex = M.Map UUID (NE.NonEmpty ILCDProducer)
 
 fixILCDActivityLinks :: SimpleDatabase -> IO SimpleDatabase
 fixILCDActivityLinks db = do
@@ -802,7 +815,7 @@ chose, and the ranking is what makes the choice the same everywhere.
 sharedProducts :: SupplierIndex -> [String]
 sharedProducts idx =
     [ printf
-        "%d product flow(s) are made by more than one process; each input naming one of them is linked to the process still in service, then the first by name and location"
+        "%d product flow(s) are made by more than one process; an input stating a location is linked to a process there, and one that states none to the process still in service, then the first by name and location"
         shared
     | let shared = length [() | producers <- M.elems idx, NE.length producers > 1]
     , shared > 0
@@ -818,19 +831,21 @@ all of it still come out in the same order on every machine.
 -}
 buildSupplierIndex :: ActivityMap -> SupplierIndex
 buildSupplierIndex activities =
-    M.map (NE.sortWith supplierOrder) $
+    M.map (NE.map snd . NE.sortWith fst) $
         M.fromListWith
             (<>)
-            [ (exchangeFlowId ex, (actUUID, prodUUID) NE.:| [])
+            [ (exchangeFlowId ex, (supplierOrder act actUUID prodUUID, producing act actUUID prodUUID) NE.:| [])
             | ((actUUID, prodUUID), act) <- M.toList activities
             , ex <- exchanges act
             , exchangeIsReference ex
             ]
   where
-    supplierOrder :: (UUID, UUID) -> (Bool, Text, Text, UUID, UUID)
-    supplierOrder (actUUID, prodUUID) = case M.lookup (actUUID, prodUUID) activities of
-        Just act -> (activityIsObsolete act, activityName act, activityLocation act, actUUID, prodUUID)
-        Nothing -> (True, "", "", actUUID, prodUUID)
+    producing :: Activity -> UUID -> UUID -> ILCDProducer
+    producing act actUUID prodUUID = ILCDProducer actUUID prodUUID (activityLocation act)
+
+    supplierOrder :: Activity -> UUID -> UUID -> (Bool, Text, Text, UUID, UUID)
+    supplierOrder act actUUID prodUUID =
+        (activityIsObsolete act, activityName act, activityLocation act, actUUID, prodUUID)
 
 fixActivityExchanges :: SupplierIndex -> Activity -> Activity
 fixActivityExchanges idx act =
@@ -840,24 +855,40 @@ fixActivityExchanges idx act =
     -- own waste-treatment reference flow — it appears in the supplier index
     -- (it is a reference exchange) but rewriting it would point the activity
     -- at itself and erase the role, breaking 'activityNormFactor'.
-    fixEx ex@TechnosphereExchange{techFlowId = fid, techRole = Input} =
-        case NE.head <$> M.lookup fid idx of
-            Just (actUUID, prodUUID) ->
+    fixEx ex@TechnosphereExchange{techFlowId = fid, techRole = Input, techLocation = loc} =
+        case supplierFor loc fid of
+            Just p ->
                 ex
-                    { techFlowId = prodUUID
-                    , techActivityLinkId = Just actUUID
+                    { techFlowId = ipProduct p
+                    , techActivityLinkId = Just (ipActivity p)
                     }
             Nothing -> ex
     fixEx ex@TechnosphereExchange{} = ex
     fixEx ex@BiosphereExchange{} = ex
     -- A waste input awaiting treatment-activity resolution follows the same
     -- name-lookup logic as a technosphere Input.
-    fixEx ex@WasteExchange{waFlowId = fid, waIsInput = True} =
-        case NE.head <$> M.lookup fid idx of
-            Just (actUUID, prodUUID) ->
+    fixEx ex@WasteExchange{waFlowId = fid, waIsInput = True, waLocation = loc} =
+        case supplierFor loc fid of
+            Just p ->
                 ex
-                    { waFlowId = prodUUID
-                    , waActivityLinkId = Just actUUID
+                    { waFlowId = ipProduct p
+                    , waActivityLinkId = Just (ipActivity p)
                     }
             Nothing -> ex
     fixEx ex@WasteExchange{} = ex
+
+    {- The exchange's own location is the only thing an ILCD file says about
+    which producer an input meant, so a process there answers ahead of the
+    ranking. Where the file says nothing, or names a location no producer of
+    that flow sits at, the ranking answers instead. -}
+    supplierFor :: Text -> UUID -> Maybe ILCDProducer
+    supplierFor loc fid = do
+        producers <- M.lookup fid idx
+        pure (Data.Maybe.fromMaybe (NE.head producers) (Data.Maybe.listToMaybe (atLocation loc producers)))
+
+    atLocation :: Text -> NE.NonEmpty ILCDProducer -> [ILCDProducer]
+    atLocation loc producers
+        | T.null declared = []
+        | otherwise = NE.filter ((== declared) . ipLocation) producers
+      where
+        declared = T.strip loc

--- a/test/ILCDParserSpec.hs
+++ b/test/ILCDParserSpec.hs
@@ -5,6 +5,7 @@ module ILCDParserSpec (spec) where
 import Control.Monad (forM_)
 import qualified Data.ByteString as BS
 import Data.List (find, sortOn)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -32,6 +33,15 @@ prodUUID1 = read "bbbbbbbb-0000-0000-0000-000000000001"
 prodUUID2 = read "bbbbbbbb-0000-0000-0000-000000000002"
 
 -- An activity with a single reference output exchange for the given flow UUID
+
+-- | The same activity under another name, so a ranking has something to rank on.
+named :: Text -> Activity -> Activity
+named name act = act{activityName = name}
+
+-- | The same activity, marked retired the way an EcoSpold 1 file marks one.
+retired :: Activity -> Activity
+retired act = act{activityClassification = M.singleton "Category" "material, obsolete"}
+
 activityWithRefExchange :: UUID.UUID -> Activity
 activityWithRefExchange fid =
     Activity
@@ -260,8 +270,8 @@ spec = do
                         , ((actUUID2, prodUUID2), activityWithRefExchange flowUUID2)
                         ]
                 idx = buildSupplierIndex activities
-            M.lookup flowUUID1 idx `shouldBe` Just (actUUID1, prodUUID1)
-            M.lookup flowUUID2 idx `shouldBe` Just (actUUID2, prodUUID2)
+            M.lookup flowUUID1 idx `shouldBe` Just ((actUUID1, prodUUID1) NE.:| [])
+            M.lookup flowUUID2 idx `shouldBe` Just ((actUUID2, prodUUID2) NE.:| [])
 
         it "does not index non-reference exchanges" $ do
             let activities =
@@ -281,12 +291,33 @@ spec = do
                 idx = buildSupplierIndex activities
             M.size idx `shouldBe` 2
 
+        -- One product made in two places is two processes declaring one
+        -- product flow, and an exchange names the flow. Keeping one entry kept
+        -- whichever the identifiers put last.
+        it "keeps every process declaring one product flow" $ do
+            let activities =
+                    M.fromList
+                        [ ((actUUID1, prodUUID1), named "wheat production, a" (activityWithRefExchange flowUUID1))
+                        , ((actUUID2, prodUUID2), named "wheat production, b" (activityWithRefExchange flowUUID1))
+                        ]
+                idx = buildSupplierIndex activities
+            fmap NE.length (M.lookup flowUUID1 idx) `shouldBe` Just 2
+
+        it "links to the process still in service, whatever its identifier" $ do
+            let activities =
+                    M.fromList
+                        [ ((actUUID1, prodUUID1), retired (named "wheat production, a" (activityWithRefExchange flowUUID1)))
+                        , ((actUUID2, prodUUID2), named "wheat production, b" (activityWithRefExchange flowUUID1))
+                        ]
+                idx = buildSupplierIndex activities
+            fmap NE.head (M.lookup flowUUID1 idx) `shouldBe` Just (actUUID2, prodUUID2)
+
     -- -------------------------------------------------------------------
     -- fixActivityExchanges: resolves input exchanges via supplier index
     -- -------------------------------------------------------------------
     describe "fixActivityExchanges" $ do
         it "resolves input exchange flow UUID to supplier (actUUID, prodUUID)" $ do
-            let idx = M.fromList [(flowUUID1, (actUUID1, prodUUID1))]
+            let idx = M.fromList [(flowUUID1, (actUUID1, prodUUID1) NE.:| [])]
                 act = activityWithInputExchange flowUUID1
                 fixed = fixActivityExchanges idx act
             case exchanges fixed of
@@ -305,7 +336,7 @@ spec = do
                 _ -> expectationFailure "expected one TechnosphereExchange"
 
         it "does not touch output (reference) exchanges" $ do
-            let idx = M.fromList [(flowUUID1, (actUUID1, prodUUID1))]
+            let idx = M.fromList [(flowUUID1, (actUUID1, prodUUID1) NE.:| [])]
                 act = activityWithRefExchange flowUUID1
                 fixed = fixActivityExchanges idx act
             case exchanges fixed of

--- a/test/ILCDParserSpec.hs
+++ b/test/ILCDParserSpec.hs
@@ -12,7 +12,7 @@ import qualified Data.Text as T
 import qualified Data.UUID as UUID
 import GHC.Conc (getNumCapabilities, setNumCapabilities)
 import ILCD.Common (readDataSetVersion)
-import ILCD.Parser (ILCDExchangeRaw (..), ILCDProcessRaw (..), buildSupplierIndex, fixActivityExchanges, parseILCDDirectory, parseProcessXML)
+import ILCD.Parser (ILCDExchangeRaw (..), ILCDProcessRaw (..), ILCDProducer (..), buildSupplierIndex, fixActivityExchanges, parseILCDDirectory, parseProcessXML)
 import System.Directory (copyFile, createDirectoryIfMissing, listDirectory)
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
@@ -33,6 +33,22 @@ prodUUID1 = read "bbbbbbbb-0000-0000-0000-000000000001"
 prodUUID2 = read "bbbbbbbb-0000-0000-0000-000000000002"
 
 -- An activity with a single reference output exchange for the given flow UUID
+
+-- | The pair an index entry names, for tests written before it carried a location.
+asPair :: ILCDProducer -> (UUID.UUID, UUID.UUID)
+asPair p = (ipActivity p, ipProduct p)
+
+-- | The same activity somewhere else.
+at :: Text -> Activity -> Activity
+at loc act = act{activityLocation = loc}
+
+-- | The same activity, its input exchange stating where it wants its supplier.
+inputFrom :: Text -> Activity -> Activity
+inputFrom loc act = act{exchanges = map stating (exchanges act)}
+  where
+    stating :: Exchange -> Exchange
+    stating ex@TechnosphereExchange{} = ex{techLocation = loc}
+    stating ex = ex
 
 -- | The same activity under another name, so a ranking has something to rank on.
 named :: Text -> Activity -> Activity
@@ -270,8 +286,8 @@ spec = do
                         , ((actUUID2, prodUUID2), activityWithRefExchange flowUUID2)
                         ]
                 idx = buildSupplierIndex activities
-            M.lookup flowUUID1 idx `shouldBe` Just ((actUUID1, prodUUID1) NE.:| [])
-            M.lookup flowUUID2 idx `shouldBe` Just ((actUUID2, prodUUID2) NE.:| [])
+            fmap (NE.map asPair) (M.lookup flowUUID1 idx) `shouldBe` Just ((actUUID1, prodUUID1) NE.:| [])
+            fmap (NE.map asPair) (M.lookup flowUUID2 idx) `shouldBe` Just ((actUUID2, prodUUID2) NE.:| [])
 
         it "does not index non-reference exchanges" $ do
             let activities =
@@ -310,14 +326,36 @@ spec = do
                         , ((actUUID2, prodUUID2), named "wheat production, b" (activityWithRefExchange flowUUID1))
                         ]
                 idx = buildSupplierIndex activities
-            fmap NE.head (M.lookup flowUUID1 idx) `shouldBe` Just (actUUID2, prodUUID2)
+            fmap (asPair . NE.head) (M.lookup flowUUID1 idx) `shouldBe` Just (actUUID2, prodUUID2)
+
+        -- An ILCD exchange states a location of its own, and that is the one
+        -- thing in the file saying which producer of the flow was meant.
+        it "links an input to a process at the location it states" $ do
+            let activities =
+                    M.fromList
+                        [ ((actUUID1, prodUUID1), at "DE" (named "electricity production" (activityWithRefExchange flowUUID1)))
+                        , ((actUUID2, prodUUID2), at "FR" (named "electricity production" (activityWithRefExchange flowUUID1)))
+                        ]
+                idx = buildSupplierIndex activities
+                act = fixActivityExchanges idx (inputFrom "FR" (activityWithInputExchange flowUUID1))
+            [techActivityLinkId e | e@TechnosphereExchange{} <- exchanges act] `shouldBe` [Just actUUID2]
+
+        it "falls back to the ranking when no process sits at the stated location" $ do
+            let activities =
+                    M.fromList
+                        [ ((actUUID1, prodUUID1), at "DE" (named "electricity production" (activityWithRefExchange flowUUID1)))
+                        , ((actUUID2, prodUUID2), at "FR" (named "electricity production" (activityWithRefExchange flowUUID1)))
+                        ]
+                idx = buildSupplierIndex activities
+                act = fixActivityExchanges idx (inputFrom "CN" (activityWithInputExchange flowUUID1))
+            [techActivityLinkId e | e@TechnosphereExchange{} <- exchanges act] `shouldBe` [Just actUUID1]
 
     -- -------------------------------------------------------------------
     -- fixActivityExchanges: resolves input exchanges via supplier index
     -- -------------------------------------------------------------------
     describe "fixActivityExchanges" $ do
         it "resolves input exchange flow UUID to supplier (actUUID, prodUUID)" $ do
-            let idx = M.fromList [(flowUUID1, (actUUID1, prodUUID1) NE.:| [])]
+            let idx = M.fromList [(flowUUID1, ILCDProducer actUUID1 prodUUID1 "" NE.:| [])]
                 act = activityWithInputExchange flowUUID1
                 fixed = fixActivityExchanges idx act
             case exchanges fixed of
@@ -336,7 +374,7 @@ spec = do
                 _ -> expectationFailure "expected one TechnosphereExchange"
 
         it "does not touch output (reference) exchanges" $ do
-            let idx = M.fromList [(flowUUID1, (actUUID1, prodUUID1) NE.:| [])]
+            let idx = M.fromList [(flowUUID1, ILCDProducer actUUID1 prodUUID1 "" NE.:| [])]
                 act = activityWithRefExchange flowUUID1
                 fixed = fixActivityExchanges idx act
             case exchanges fixed of


### PR DESCRIPTION
## Problem

An ILCD exchange names the flow it wants, never the process that makes it, so
the linker needs an index from product flow to process. That index held one
process per flow, built with `M.fromList`.

One product made in two places is two processes declaring one product flow,
which is the ordinary shape of any package carrying regional variants. Every
input of such a flow was linked to whichever process came last in the map of
identifiers: a ranking on the identity a file happens to have been minted with,
and one that can put a retired process in front of one still in service.

An exchange does state a location of its own, and the parser already reads it
onto the exchange. Nothing used it here.

## Solution

The index keeps every process declaring a flow, with the location each declares
it at.

An input that states a location is linked to a process there. Where it states
none, or names a location no producer of that flow sits at, the processes are
ranked on what the datasets say: in service before retired, then the activity
name, then the location, with the identifiers breaking only the last tie.

A retired process can therefore no longer supply an input that a process still
in service also makes, and the link stops moving with the identifiers.

How many flows carry more than one producer is reported once at load. One line
per flow would be one line per product with a regional variant, which is most
of a package; the count is what tells a reader that the linking chose.

## Remarks

Where the file states no location the choice is deterministic, not informed:
the input does not say which producer was meant, and the file holds nothing
else to read. Ranking replaces an arbitrary answer with a stated one, and says
how often it was needed.

## How to test

`cabal test all` - 2613 examples, 0 failures, 2 pending. Four new examples: two
processes declaring one product flow are both indexed; the one still in service
is linked to even when the retired one holds the lower identifier; an input
stating FR reaches the FR process rather than the one that sorts first; and an
input stating a location no producer sits at falls back to the ranking.
