### PR TITLE
Refuse a workbook block that answers one metadata key two ways

### DIFF
--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -177,6 +177,11 @@ table header (column index → lowercased label) and the data rows.
 data RawActivity = RawActivity
     { raName :: !Text
     , raMeta :: !(M.Map Text CellValue)
+    , raMetaRepeats :: ![Text]
+    {- ^ The metadata keys the block spells more than once. 'raMeta' keys on
+    the label, so one row of each survives and the others are dropped; the
+    reader is told which keys rather than losing a field in silence.
+    -}
     , raHeaders :: ![(Int, Text)]
     , raRows :: ![Row]
     , raHasParams :: !Bool
@@ -219,13 +224,13 @@ parseBlock block0 = do
         parIdx = findIndex (rowKeyIs "parameters") block
         metaEnd = minimum (length block : catMaybes [excIdx, parIdx])
         metaRows = take (metaEnd - 1) (drop 1 block)
-        meta =
-            M.fromList
-                [ (T.toLower (T.strip k), v)
-                | row <- metaRows
-                , Just k <- [textAt 0 row]
-                , Just v <- [M.lookup 1 row]
-                ]
+        metaPairs =
+            [ (T.toLower (T.strip k), v)
+            | row <- metaRows
+            , Just k <- [textAt 0 row]
+            , Just v <- [M.lookup 1 row]
+            ]
+        meta = M.fromList metaPairs
         -- Everything after the Exchanges header is taken as exchange data. This
         -- assumes a @parameters@ section (if any) precedes Exchanges, as bw2io
         -- writes it; a trailing parameters block would be read as exchange rows
@@ -239,6 +244,7 @@ parseBlock block0 = do
         RawActivity
             { raName = T.strip name
             , raMeta = meta
+            , raMetaRepeats = repeated (map fst metaPairs)
             , raHeaders = headers
             , raRows = dataRows
             , raHasParams = isJust parIdx
@@ -331,6 +337,9 @@ rawToActivity cfg ra =
                ]
             ++ [ "activity '" <> raName ra <> "': column '" <> lbl <> "' appears more than once; one of them is read per row and the others are dropped"
                | lbl <- duplicateLabels (raHeaders ra)
+               ]
+            ++ [ "activity '" <> raName ra <> "': metadata key '" <> key <> "' appears more than once; the last row is read and the others are dropped"
+               | key <- raMetaRepeats ra
                ]
 
     location = fromMaybe "" (metaText meta "location")

--- a/src/BrightwayExcel/Parser.hs
+++ b/src/BrightwayExcel/Parser.hs
@@ -59,8 +59,9 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as BL
 import Data.Char (isAsciiUpper, ord, toUpper)
-import Data.Indexing (repeated)
+import Data.Indexing (collisions, repeated)
 import Data.List (find, findIndex, partition)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing, listToMaybe, mapMaybe, maybeToList)
 import Data.Text (Text)
@@ -130,7 +131,8 @@ parseBrightwayExcel cfg path = do
         Left err -> pure (Left ("Brightway Excel: " <> err))
         Right sheets -> do
             let (dataSheets, skipped) = partition (validFirstCell . snd) sheets
-                results = concatMap (sheetToActivities cfg . snd) dataSheets
+                blocks = concatMap (mapMaybe parseBlock . activityBlocks . snd) dataSheets
+                results = map (rawToActivity cfg) blocks
                 activities = [a | (a, _, _, _, _) <- results]
                 techFlows = concat [fs | (_, fs, _, _, _) <- results]
                 bioFlows = concat [fs | (_, _, fs, _, _) <- results]
@@ -140,6 +142,7 @@ parseBrightwayExcel cfg path = do
                 unitNames = M.map unitName unitDB
             mapM_ (reportProgress Warning . T.unpack) warnings
             pure $ do
+                mapM_ refuseConflictingMeta blocks
                 techFlowDB <- indexFlows unitNames (\f -> (tfId f, tfUnitId f, tfName f)) techFlows
                 bioFlowDB <- indexFlows unitNames (\f -> (bfId f, bfUnitId f, bfName f)) bioFlows
                 pure (activities, techFlowDB, bioFlowDB, M.empty, unitDB)
@@ -176,16 +179,55 @@ table header (column index → lowercased label) and the data rows.
 -}
 data RawActivity = RawActivity
     { raName :: !Text
-    , raMeta :: !(M.Map Text CellValue)
-    , raMetaRepeats :: ![Text]
-    {- ^ The metadata keys the block spells more than once. 'raMeta' keys on
-    the label, so one row of each survives and the others are dropped; the
-    reader is told which keys rather than losing a field in silence.
+    , raMetaPairs :: ![(Text, CellValue)]
+    {- ^ Every metadata row the block wrote, in order, the way 'raHeaders'
+    carries every column its header row wrote. 'metaOf' is the map.
     -}
     , raHeaders :: ![(Int, Text)]
     , raRows :: ![Row]
     , raHasParams :: !Bool
     }
+
+{- | The metadata a block states, one value per key.
+
+A key stated twice with one value is one answer; a key stated twice with two is
+refused before this is read, by 'conflictingMeta'.
+-}
+metaOf :: RawActivity -> M.Map Text CellValue
+metaOf = M.fromList . raMetaPairs
+
+{- | The metadata keys a block answers two ways, with the answers.
+
+A metadata key fixes the whole activity - its location, its unit, its reference
+product - so two values for one key name no activity, and nothing in the block
+says which was meant. A repeated column is not the same case: it carries one
+field of one exchange row, and the reader is told which column and goes on.
+-}
+conflictingMeta :: RawActivity -> [(Text, NE.NonEmpty CellValue)]
+conflictingMeta ra =
+    [ (key, values)
+    | (key, values) <- collisions (raMetaPairs ra)
+    , NE.length (NE.nub values) > 1
+    ]
+
+-- | Refuse a block that answers one metadata key two ways, naming both answers.
+refuseConflictingMeta :: RawActivity -> Either Text ()
+refuseConflictingMeta ra = case conflictingMeta ra of
+    [] -> Right ()
+    ((key, values) : _) ->
+        Left $
+            "Brightway Excel: activity '"
+                <> raName ra
+                <> "' states '"
+                <> key
+                <> "' more than once, as "
+                <> T.intercalate " and " (map spelt (NE.toList values))
+                <> "; nothing says which is meant"
+  where
+    spelt :: CellValue -> Text
+    spelt v = case v of
+        CellText t -> T.strip t
+        CellNumber n -> T.pack (show n)
 
 sectionKeyword :: Row -> Maybe Text
 sectionKeyword row = T.toLower . T.strip <$> textAt 0 row
@@ -230,7 +272,6 @@ parseBlock block0 = do
             , Just k <- [textAt 0 row]
             , Just v <- [M.lookup 1 row]
             ]
-        meta = M.fromList metaPairs
         -- Everything after the Exchanges header is taken as exchange data. This
         -- assumes a @parameters@ section (if any) precedes Exchanges, as bw2io
         -- writes it; a trailing parameters block would be read as exchange rows
@@ -243,8 +284,7 @@ parseBlock block0 = do
     pure
         RawActivity
             { raName = T.strip name
-            , raMeta = meta
-            , raMetaRepeats = repeated (map fst metaPairs)
+            , raMetaPairs = metaPairs
             , raHeaders = headers
             , raRows = dataRows
             , raHasParams = isJust parIdx
@@ -301,7 +341,7 @@ rawToActivity ::
 rawToActivity cfg ra =
     (activity, techFlows, bioFlows, units, warnings)
   where
-    meta = raMeta ra
+    meta = metaOf ra
     fieldRows = map (rowFields (raHeaders ra)) (raRows ra)
     isType t r = (T.toLower <$> fieldText r "type") == Just t
     prodRows = filter (isType "production") fieldRows
@@ -337,9 +377,6 @@ rawToActivity cfg ra =
                ]
             ++ [ "activity '" <> raName ra <> "': column '" <> lbl <> "' appears more than once; one of them is read per row and the others are dropped"
                | lbl <- duplicateLabels (raHeaders ra)
-               ]
-            ++ [ "activity '" <> raName ra <> "': metadata key '" <> key <> "' appears more than once; the last row is read and the others are dropped"
-               | key <- raMetaRepeats ra
                ]
 
     location = fromMaybe "" (metaText meta "location")

--- a/test/BrightwayExcelSpec.hs
+++ b/test/BrightwayExcelSpec.hs
@@ -15,7 +15,7 @@ import BrightwayExcel.Parser (CellValue (..), parseBrightwayExcel, parseSheetXml
 import Codec.Archive.Zip (addEntryToArchive, emptyArchive, fromArchive, toEntry)
 import qualified Data.ByteString.Lazy as BL
 import Data.Char (chr, ord)
-import Data.List (find)
+import Data.List (find, isInfixOf)
 import qualified Data.Map.Strict as M
 import Data.Maybe (isJust, listToMaybe, mapMaybe)
 import Data.Text (Text)
@@ -24,6 +24,7 @@ import qualified Data.Text.Encoding as TE
 import qualified Data.UUID as UUID
 import Database.Loader (loadDatabase)
 import Database.Upload (ArchiveFormat (..), detectArchiveFormat)
+import Progress (LogLine (..), getLogLines)
 import System.IO (hClose)
 import System.IO.Temp (withSystemTempFile)
 import Test.Hspec
@@ -85,6 +86,16 @@ spec = describe "BrightwayExcel.Parser" $ do
                                           , "Widget manufacturing"
                                           , "Cotton fibre production"
                                           ]
+
+        -- A header column stated twice is already reported; a metadata row
+        -- stated twice was not, and it is dropped the same way.
+        it "names a metadata key the block states twice" $
+            withWorkbook (buildWorkbook [("data", twiceStatedSheet)]) $ \path -> do
+                (since, _) <- getLogLines 0
+                _ <- parseBrightwayExcel defaultUnitConfig path
+                (_, newLines) <- getLogLines since
+                any (("metadata key 'location' appears more than once" `isInfixOf`) . llText) newLines
+                    `shouldBe` True
 
         it "keys the reference product by its product name" $ withFixture $ \path -> do
             parseBrightwayExcel defaultUnitConfig path >>= \case
@@ -280,6 +291,22 @@ buildWorkbook sheets =
                   ]
   where
     enc = BL.fromStrict . TE.encodeUtf8
+
+{- | A worksheet whose block states one metadata key twice. A workbook can do
+that, and only one of the two rows reaches the activity.
+-}
+twiceStatedSheet :: [[Cell]]
+twiceStatedSheet =
+    [ [CT "Activity", CT "Widget manufacturing"]
+    , [CT "production amount", CN 1]
+    , [CT "reference product", CT "widget"]
+    , [CT "location", CT "GLO"]
+    , [CT "location", CT "FR"]
+    , [CT "unit", CT "kilogram"]
+    , [CT "Exchanges"]
+    , [CT "name", CT "amount", CT "reference product", CT "location", CT "unit", CT "categories", CT "type", CT "database"]
+    , [CT "Widget manufacturing", CN 1, CT "widget", CT "GLO", CT "kilogram", CE, CT "production", CT "DB"]
+    ]
 
 -- | A single-activity worksheet (standard column order) for multi-sheet tests.
 activitySheet :: Text -> Text -> [[Cell]]

--- a/test/BrightwayExcelSpec.hs
+++ b/test/BrightwayExcelSpec.hs
@@ -15,7 +15,7 @@ import BrightwayExcel.Parser (CellValue (..), parseBrightwayExcel, parseSheetXml
 import Codec.Archive.Zip (addEntryToArchive, emptyArchive, fromArchive, toEntry)
 import qualified Data.ByteString.Lazy as BL
 import Data.Char (chr, ord)
-import Data.List (find, isInfixOf)
+import Data.List (find)
 import qualified Data.Map.Strict as M
 import Data.Maybe (isJust, listToMaybe, mapMaybe)
 import Data.Text (Text)
@@ -24,7 +24,6 @@ import qualified Data.Text.Encoding as TE
 import qualified Data.UUID as UUID
 import Database.Loader (loadDatabase)
 import Database.Upload (ArchiveFormat (..), detectArchiveFormat)
-import Progress (LogLine (..), getLogLines)
 import System.IO (hClose)
 import System.IO.Temp (withSystemTempFile)
 import Test.Hspec
@@ -87,15 +86,23 @@ spec = describe "BrightwayExcel.Parser" $ do
                                           , "Cotton fibre production"
                                           ]
 
-        -- A header column stated twice is already reported; a metadata row
-        -- stated twice was not, and it is dropped the same way.
-        it "names a metadata key the block states twice" $
+        -- A metadata key fixes the whole activity, and two values for one key
+        -- name no activity. A repeated column is the other case: it carries
+        -- one field of one exchange row, and is reported rather than refused.
+        it "refuses a block that states one metadata key two ways" $
             withWorkbook (buildWorkbook [("data", twiceStatedSheet)]) $ \path -> do
-                (since, _) <- getLogLines 0
-                _ <- parseBrightwayExcel defaultUnitConfig path
-                (_, newLines) <- getLogLines since
-                any (("metadata key 'location' appears more than once" `isInfixOf`) . llText) newLines
-                    `shouldBe` True
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Right _ -> expectationFailure "Expected the load to stop on two values for one key"
+                    Left err -> do
+                        err `shouldSatisfy` T.isInfixOf "location"
+                        err `shouldSatisfy` T.isInfixOf "GLO"
+                        err `shouldSatisfy` T.isInfixOf "FR"
+
+        it "reads a metadata key the block states twice with one value" $
+            withWorkbook (buildWorkbook [("data", twiceAgreeingSheet)]) $ \path -> do
+                parseBrightwayExcel defaultUnitConfig path >>= \case
+                    Left err -> expectationFailure (T.unpack err)
+                    Right (acts, _, _, _, _) -> map activityLocation acts `shouldBe` ["GLO"]
 
         it "keys the reference product by its product name" $ withFixture $ \path -> do
             parseBrightwayExcel defaultUnitConfig path >>= \case
@@ -292,8 +299,8 @@ buildWorkbook sheets =
   where
     enc = BL.fromStrict . TE.encodeUtf8
 
-{- | A worksheet whose block states one metadata key twice. A workbook can do
-that, and only one of the two rows reaches the activity.
+{- | A worksheet whose block states one metadata key twice, with two values.
+A workbook can do that, and nothing in it says which value was meant.
 -}
 twiceStatedSheet :: [[Cell]]
 twiceStatedSheet =
@@ -307,6 +314,14 @@ twiceStatedSheet =
     , [CT "name", CT "amount", CT "reference product", CT "location", CT "unit", CT "categories", CT "type", CT "database"]
     , [CT "Widget manufacturing", CN 1, CT "widget", CT "GLO", CT "kilogram", CE, CT "production", CT "DB"]
     ]
+
+-- | The same block, stating its repeated key the same way both times.
+twiceAgreeingSheet :: [[Cell]]
+twiceAgreeingSheet = map keepGLO twiceStatedSheet
+  where
+    keepGLO :: [Cell] -> [Cell]
+    keepGLO [CT "location", CT _] = [CT "location", CT "GLO"]
+    keepGLO row = row
 
 -- | A single-activity worksheet (standard column order) for multi-sheet tests.
 activitySheet :: Text -> Text -> [[Cell]]


### PR DESCRIPTION
## Problem

An activity block in a Brightway Excel workbook carries its metadata as rows of
label and value, and the reader keyed them on the label with `M.fromList`. A
workbook stating one label twice with two values therefore kept the last row
and said nothing.

That key is not one field of one row: it fixes the whole activity. `location`,
`unit` and `reference product` all arrive this way, and the reference unit and
the supplier links are computed from them. Two values name no activity, and
nothing in the block says which was meant.

## Solution

The load stops on such a block, naming the activity, the key and both answers.

A key stated twice with one value is one answer and is read as before. A
repeated header column keeps its warning rather than refusing: it carries one
field of one exchange row, the values may legitimately differ per row, and the
reader is told which column.

The block now carries the metadata rows it wrote, the way it already carried
every column of its header row, and the map is derived where it is used.

## Remarks

No workbook that states each key once, or states one twice the same way, is
affected. The refusal travels through the `Either Text` the reader already
returns.

## How to test

`cabal test all` - 2611 examples, 0 failures, 2 pending. Two new examples: a
block stating `location` as GLO and as FR stops the load with all three named,
and a block stating it as GLO twice loads with GLO.
