### PR TITLE
Refuse a file that is offered and becomes no dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,19 @@
   before this are rebuilt on the next load. Wire revision 23.
 
 ### Fixed
+- A file an EcoSpold directory offers and the reader cannot read now stops the
+  load instead of disappearing from it. Such a file used to be a warning in
+  passing and a dataset silently absent, and the load then described a complete
+  database: the counters say what was kept and never what was offered, so
+  nothing told a small database from one missing datasets. The warning did not
+  even name the file, and it was gone from the log as soon as a longer load
+  filled the buffer, or never written at all when the database came back from
+  its cache. The load now refuses, says how many of the files it was offered
+  became no dataset, and names the first ten of them. A single file holding
+  several datasets and yielding none refuses in the same way, as an empty CSV
+  already did. A file that is read and then divided into several products still
+  only warns: there the file is read, and what cannot be kept is a product its
+  name has no room to key.
 - An EcoSpold 2 archive whose file names carry the dataset number in front of
   the two identifiers now loads in full. Such a name has three parts where the
   reader accepted only two, so every file carrying one was refused and dropped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,7 +170,9 @@
   its cache. The load now refuses, says how many of the files it was offered
   became no dataset, and names the first ten of them. A single file holding
   several datasets and yielding none refuses in the same way, as an empty CSV
-  already did. A file that is read and then divided into several products still
+  already did, and says which of the two it is: a file nothing could be parsed
+  from, or one whose datasets were each skipped, with the reasons they were
+  skipped for. A file that is read and then divided into several products still
   only warns: there the file is read, and what cannot be kept is a product its
   name has no room to key.
 - An EcoSpold 2 archive whose file names carry the dataset number in front of

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -1080,6 +1080,28 @@ than silent: the alternative is a database quietly missing the very products
 the key was named to produce. Keying an EcoSpold 2 process on its own product
 rather than on its file name is what would fix it.
 -}
+
+{- | Everything a directory load was offered and could not turn into a dataset.
+
+Named together rather than one at a time: a publisher writes its file names by
+one convention, so a directory that has one unreadable file usually has
+thousands, and naming the first alone would take as many loads to find that out
+as there are files. The first ten are named and the count says how many there
+were, the way 'reportKeyRefusals' names what the allocation key refused.
+-}
+refusedFiles :: Int -> NE.NonEmpty T.Text -> T.Text
+refusedFiles offered refusals =
+    T.intercalate "\n" (header : map ("  " <>) (NE.take 10 refusals) <> rest)
+  where
+    refused :: Int
+    refused = length refusals
+
+    header :: T.Text
+    header = T.pack $ printf "%d of %d files became no dataset:" refused offered
+
+    rest :: [T.Text]
+    rest = ["  ... and " <> T.pack (show (refused - 10)) <> " more" | refused > 10]
+
 warnSplitKeyedOnFileName :: FilePath -> IO ()
 warnSplitKeyedOnFileName file =
     reportProgress Warning $
@@ -1377,10 +1399,11 @@ loadEcoSpoldDirectory opts dir = do
         scoped <- inheritLogScope
         results <- mapConcurrently (scoped . processWorker startTime isEcoSpold1) (zip [1 ..] workers)
 
-        -- Check for errors from any worker
-        let errors = lefts results
-        case errors of
-            (firstErr : _) -> return $ Left firstErr
+        -- Every file no worker could turn into a dataset, in one message: the
+        -- workers each hold a share of the directory, so what one of them
+        -- refused is a share of the answer.
+        case concatMap NE.toList (lefts results) of
+            (refusal : rest) -> return $ Left $ refusedFiles (length allFiles) (refusal NE.:| rest)
             [] -> do
                 let !harvested = mconcat (rights results)
 
@@ -1418,7 +1441,7 @@ loadEcoSpoldDirectory opts dir = do
                     else return $ Right simpleDb
 
     -- Process one worker's share of files
-    processWorker :: UTCTime -> Bool -> (Int, [FilePath]) -> IO (Either T.Text Harvest)
+    processWorker :: UTCTime -> Bool -> (Int, [FilePath]) -> IO (Either (NE.NonEmpty T.Text) Harvest)
     processWorker _startTime isEcoSpold1 (workerNum, workerFiles) = do
         workerStartTime <- getCurrentTime
         reportProgress Info $ printf "Worker %d started: processing %d files" workerNum (length workerFiles)
@@ -1431,18 +1454,19 @@ loadEcoSpoldDirectory opts dir = do
                     then streamParseActivityAndFlowsFromFile1
                     else streamParseActivityAndFlowsFromFile
         workerResults <- mapM parseFile workerFiles
-        let paired = zipWith (\f r -> fmap (f,) r) workerFiles workerResults
-        let (errs, oks) = partitionEithers paired
-        forM_ errs $ \e ->
-            reportProgress Warning e
+        let paired = zipWith (\f -> either (Left . T.pack) (Right . (f,))) workerFiles workerResults
+        let (unread, oks) = partitionEithers paired
         let split = [(f, allocateParsed opts r) | (f, r) <- oks]
             (okFiles, okResults) = unzip [(f, r') | (f, rs) <- split, r' <- rs]
         unless isEcoSpold1 $
             mapM_ (warnSplitKeyedOnFileName . fst) (filter ((> 1) . length . snd) split)
         let procEntries = zipWith (buildProcEntry isEcoSpold1) okFiles (map pdActivity okResults)
 
-        case lefts procEntries of
-            (firstErr : _) -> return $ Left firstErr
+        -- A file whose content has no reading and a file whose name has none
+        -- are the same answer: it was offered and it becomes no dataset. They
+        -- refuse together rather than one of them being dropped with a word.
+        case unread <> lefts procEntries of
+            (refusal : rest) -> return $ Left (refusal NE.:| rest)
             [] -> do
                 let !harvested = harvestOf (zip (map fst (rights procEntries)) okResults)
 
@@ -1488,7 +1512,7 @@ loadEcoSpoldDirectory opts dir = do
                 | Just prodUUID <- UUID.fromText prodUUIDText
                 , Just actUUID <- UUID.fromText actUUIDText ->
                     Right ((actUUID, prodUUID), activity)
-            _ -> Left $ T.pack $ "Invalid filename format (expected [datasetNumber_]activityUUID_productUUID.spold): " ++ filepath
+            _ -> Left $ T.pack $ filepath ++ ": the name is not [datasetNumber_]activityUUID_productUUID"
 
 {- | Load a single EcoSpold1 file containing multiple datasets
 This handles files where <ecoSpold> contains multiple <dataset> elements.
@@ -1503,20 +1527,26 @@ loadSingleEcoSpold1File opts filepath = do
     reportProgress Info "Parsing multi-dataset EcoSpold1 file..."
     parsed <- streamParseAllDatasetsFromFile1 filepath
     reportProgress Info $ "Parsed " ++ show (length parsed) ++ " datasets from file"
-    let results = concatMap (allocateParsed opts) parsed
+    -- The parser answers with a list, and a file it could not read at all
+    -- answers with an empty one. An empty database is not what was asked for
+    -- and reads as a complete one, so it is a refusal, as it is for a CSV.
+    if null parsed
+        then return $ Left $ T.pack filepath <> ": no dataset could be read from this file"
+        else do
+            let results = concatMap (allocateParsed opts) parsed
 
-    -- Build activity map from all parsed activities
-    let fileUUID = case results of
-            [_] -> datasetUUIDFromPath filepath
-            _ -> Nothing
-        !harvested = harvestOf [(datasetKey fileUUID r, r) | r <- results]
-        simpleDb = harvestDatabase harvested
+            -- Build activity map from all parsed activities
+            let fileUUID = case results of
+                    [_] -> datasetUUIDFromPath filepath
+                    _ -> Nothing
+                !harvested = harvestOf [(datasetKey fileUUID r, r) | r <- results]
+                simpleDb = harvestDatabase harvested
 
-    reportProgress Info $ printf "  Activities: %d processes" (M.size (hvActivities harvested))
-    reportProgress Info $ printf "  Flows: %d tech + %d bio + %d waste (from %d raw)" (M.size (hvTechFlows harvested)) (M.size (hvBioFlows harvested)) (M.size (hvWasteFlows harvested)) (hvRawFlows harvested)
-    reportProgress Info $ printf "  Units: %d unique (from %d raw)" (M.size (hvUnits harvested)) (hvRawUnits harvested)
+            reportProgress Info $ printf "  Activities: %d processes" (M.size (hvActivities harvested))
+            reportProgress Info $ printf "  Flows: %d tech + %d bio + %d waste (from %d raw)" (M.size (hvTechFlows harvested)) (M.size (hvBioFlows harvested)) (M.size (hvWasteFlows harvested)) (hvRawFlows harvested)
+            reportProgress Info $ printf "  Units: %d unique (from %d raw)" (M.size (hvUnits harvested)) (hvRawUnits harvested)
 
-    Right <$> fixEcoSpold1ActivityLinks locationAliases (hvDatasetNumbers harvested) simpleDb
+            Right <$> fixEcoSpold1ActivityLinks locationAliases (hvDatasetNumbers harvested) simpleDb
   where
     datasetKey :: Maybe UUID.UUID -> ParsedDataset -> (UUID.UUID, UUID.UUID)
     datasetKey fileUUID parsed =

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -1457,18 +1457,17 @@ loadEcoSpoldDirectory opts dir = do
         let paired = zipWith (\f -> either (Left . T.pack) (Right . (f,))) workerFiles workerResults
         let (unread, oks) = partitionEithers paired
         let split = [(f, allocateParsed opts r) | (f, r) <- oks]
-            (okFiles, okResults) = unzip [(f, r') | (f, rs) <- split, r' <- rs]
         unless isEcoSpold1 $
             mapM_ (warnSplitKeyedOnFileName . fst) (filter ((> 1) . length . snd) split)
-        let procEntries = zipWith (buildProcEntry isEcoSpold1) okFiles (map pdActivity okResults)
+        let (unreadableNames, keyed) = partitionEithers [keyDatasetsOf isEcoSpold1 f rs | (f, rs) <- split]
 
         -- A file whose content has no reading and a file whose name has none
         -- are the same answer: it was offered and it becomes no dataset. They
         -- refuse together rather than one of them being dropped with a word.
-        case unread <> lefts procEntries of
+        case unread <> unreadableNames of
             (refusal : rest) -> return $ Left (refusal NE.:| rest)
             [] -> do
-                let !harvested = harvestOf (zip (map fst (rights procEntries)) okResults)
+                let !harvested = harvestOf (concat keyed)
 
                 workerEndTime <- getCurrentTime
                 let workerDuration = realToFrac $ diffUTCTime workerEndTime workerStartTime
@@ -1486,16 +1485,29 @@ loadEcoSpoldDirectory opts dir = do
 
                 return $ Right harvested
 
-    -- Build a single process entry, returning Either for error handling
-    buildProcEntry :: Bool -> FilePath -> Activity -> Either T.Text ((UUID, UUID), Activity)
-    buildProcEntry True filepath activity =
+    -- \| The datasets one file becomes, each under its own key, or the one
+    --    reason it becomes none.
+    --
+    --    The key is read once per process the file holds, but the reason a file has
+    --    none is read once for the file: an EcoSpold 2 key is read from the name,
+    --    which is the same name however many processes the allocation divided the
+    --    file into, so reading it per process would name a refused file once per
+    --    process and count more refusals than the directory offered files.
+    --
+    keyDatasetsOf :: Bool -> FilePath -> [ParsedDataset] -> Either T.Text [((UUID, UUID), ParsedDataset)]
+    keyDatasetsOf isEcoSpold1 filepath =
+        traverse (\parsed -> (,parsed) <$> processKeyOf isEcoSpold1 filepath (pdActivity parsed))
+
+    -- The (activity, product) pair one process is filed under
+    processKeyOf :: Bool -> FilePath -> Activity -> Either T.Text (UUID, UUID)
+    processKeyOf True filepath activity =
         -- EcoSpold1: prefer the identifier the file itself carries, so a
         -- dataset keeps its identity across releases; mint from name and
         -- location only when the file name carries none.
         let actUUID = fromMaybe (generateActivityUUIDFromActivity activity) (datasetUUIDFromPath filepath)
             prodUUID = getReferenceProductUUID activity
-         in Right ((actUUID, prodUUID), activity)
-    buildProcEntry False filepath activity =
+         in Right (actUUID, prodUUID)
+    processKeyOf False filepath _activity =
         -- EcoSpold2: the identifiers are in the file name. Some publishers put
         -- the dataset number in front of the pair, and the pair is then the
         -- last two parts. What says the leading part is a number rather than
@@ -1507,11 +1519,11 @@ loadEcoSpoldDirectory opts dir = do
         -- no dataset.
         case reverse (T.splitOn "_" (T.pack (takeBaseName filepath))) of
             [prodUUIDText, actUUIDText] ->
-                Right ((parseUUID actUUIDText, parseUUID prodUUIDText), activity)
+                Right (parseUUID actUUIDText, parseUUID prodUUIDText)
             prodUUIDText : actUUIDText : _ : _
                 | Just prodUUID <- UUID.fromText prodUUIDText
                 , Just actUUID <- UUID.fromText actUUIDText ->
-                    Right ((actUUID, prodUUID), activity)
+                    Right (actUUID, prodUUID)
             _ -> Left $ T.pack $ filepath ++ ": the name is not [datasetNumber_]activityUUID_productUUID"
 
 {- | Load a single EcoSpold1 file containing multiple datasets
@@ -1525,14 +1537,14 @@ loadSingleEcoSpold1File :: LoadOptions -> FilePath -> IO (Either T.Text SimpleDa
 loadSingleEcoSpold1File opts filepath = do
     let locationAliases = loLocationAliases opts
     reportProgress Info "Parsing multi-dataset EcoSpold1 file..."
-    parsed <- streamParseAllDatasetsFromFile1 filepath
-    reportProgress Info $ "Parsed " ++ show (length parsed) ++ " datasets from file"
-    -- The parser answers with a list, and a file it could not read at all
-    -- answers with an empty one. An empty database is not what was asked for
-    -- and reads as a complete one, so it is a refusal, as it is for a CSV.
-    if null parsed
-        then return $ Left $ T.pack filepath <> ": no dataset could be read from this file"
-        else do
+    read1 <- streamParseAllDatasetsFromFile1 filepath
+    -- A file that holds no dataset would otherwise load as an empty database,
+    -- which reads exactly like a complete one. It refuses instead, and says
+    -- what the parser made of it, as it does for a CSV holding no process.
+    case read1 of
+        Left reason -> return $ Left (T.pack reason)
+        Right parsed -> do
+            reportProgress Info $ "Parsed " ++ show (length parsed) ++ " datasets from file"
             let results = concatMap (allocateParsed opts) parsed
 
             -- Build activity map from all parsed activities

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -805,7 +805,10 @@ parseAllWithXeno = fmap (reverse . psCompletedActivities) . foldEcoSpold1
 streamParseActivityAndFlowsFromFile1 :: FilePath -> IO (Either String ParsedDataset)
 streamParseActivityAndFlowsFromFile1 path = do
     !xmlContent <- BS.readFile path
-    let parsed = parseWithXeno xmlContent
+    -- The failure is named after its file like the warnings below: read across
+    -- a directory of several thousand, a reason that names no file is a reason
+    -- nobody can act on.
+    let parsed = first ((path ++ ": ") ++) (parseWithXeno xmlContent)
     either (const (pure ())) (reportReading path) parsed
     return parsed
 

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -24,6 +24,7 @@ import Data.Bifunctor (first)
 import qualified Data.ByteString as BS
 import Data.Either (lefts, rights)
 import qualified Data.IntMap.Strict as IM
+import Data.List (intercalate)
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe, isNothing)
 import qualified Data.Set as S
@@ -823,16 +824,27 @@ reportReading path = mapM_ (reportProgress Warning . ((path ++ ": ") ++) . T.unp
 {- | Parse ALL datasets from a single EcoSpold1 file
 Used for multi-dataset files where <ecoSpold> contains multiple <dataset> elements
 Skips activities that fail (e.g. no reference product) and logs warnings
+
+A file that yields not one dataset answers with the reason rather than with an
+empty list: the caller has nothing to load and is going to say so, and the only
+place the reason would otherwise be is a log line it cannot quote.
 -}
-streamParseAllDatasetsFromFile1 :: FilePath -> IO [ParsedDataset]
+streamParseAllDatasetsFromFile1 :: FilePath -> IO (Either String [ParsedDataset])
 streamParseAllDatasetsFromFile1 path = do
     !xmlContent <- BS.readFile path
     case parseAllWithXeno xmlContent of
+        Left err -> return $ Left (path ++ ": " ++ err)
         Right results -> do
             forM_ (lefts results) $ \e ->
                 reportProgress Warning $ "Skipping dataset in " ++ path ++ ": " ++ e
             mapM_ (reportReading path) (rights results)
-            return (rights results)
-        Left err -> do
-            reportProgress Warning $ "Failed to parse " ++ path ++ ": " ++ err
-            return []
+            return $ case rights results of
+                [] -> Left (yieldedNothing path (lefts results))
+                kept -> Right kept
+
+{- | Why a file that parsed holds no dataset: what each of them was skipped
+for, or that there were none to skip.
+-}
+yieldedNothing :: FilePath -> [String] -> String
+yieldedNothing path [] = path ++ ": the file holds no dataset"
+yieldedNothing path skipped = path ++ ": every dataset in it was skipped: " ++ intercalate "; " skipped

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -1098,7 +1098,10 @@ parseWithXeno xmlContent = do
 streamParseActivityAndFlowsFromFile :: FilePath -> IO (Either String ParsedDataset)
 streamParseActivityAndFlowsFromFile path = do
     !xmlContent <- BS.readFile path
-    let parsed = parseWithXeno xmlContent
+    -- The failure is named after its file like the warnings below: read across
+    -- an archive of several thousand, a reason that names no file is a reason
+    -- nobody can act on.
+    let parsed = first ((path ++ ": ") ++) (parseWithXeno xmlContent)
     either (const (pure ())) (reportReading path) parsed
     return parsed
 

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -461,12 +461,24 @@ spec = do
                 err <- refusalOf dir
                 err `shouldContain` "broken.xml"
 
-        it "refuses a lone EcoSpold1 file no dataset could be read from" $
+        it "refuses a lone EcoSpold1 file no dataset could be read from, and says why" $
             withSystemTempDirectory "es1-empty" $ \dir -> do
                 writeFile (dir </> "broken.xml") notADataset
                 err <- refusalOf dir
                 err `shouldContain` "broken.xml"
-                err `shouldContain` "no dataset could be read"
+                err `shouldContain` "holds no dataset"
+
+        -- A block divided into several processes is keyed on its file name
+        -- once, not once per process, so a name with no reading is one
+        -- refusal. Read per process it would name the file as many times as
+        -- the block divided and count more refusals than files offered.
+        it "counts a name with no reading once for the file, not once per product" $
+            withSystemTempDirectory "es2-divided" $ \dir -> do
+                let dividing = (defaultLoadOptions defaultUnitConfig){loAllocation = ByProperty DryMass}
+                writeFile (dir </> "cheese_and_whey_v2.spold") twoProductsCarryingDryMass
+                refused <- loadDatabaseWithLocationAliases dividing dir
+                err <- either (return . T.unpack) (const (fail "expected the load to refuse")) refused
+                err `shouldContain` "1 of 1 files became no dataset"
 
     -- -----------------------------------------------------------------------
     -- getReferenceProductUUID
@@ -1089,3 +1101,52 @@ spec = do
             let cls = activityClassification (head activities)
             M.lookup "Category" cls `shouldBe` Just "Energy"
             M.lookup "SubCategory" cls `shouldBe` Just "Electricity"
+
+{- | One EcoSpold 2 block with two product outputs, each stating a dry mass, so
+a load keyed on that property divides it into two processes. Written here
+rather than kept under @test-data@ because what it is for is the division, not
+the numbers.
+-}
+twoProductsCarryingDryMass :: String
+twoProductsCarryingDryMass =
+    unlines
+        [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold02\">"
+        , "  <activityDataset>"
+        , "    <activityDescription>"
+        , "      <activity id=\"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\" activityNameId=\"two-outputs\">"
+        , "        <activityName xml:lang=\"en\">Two outputs</activityName>"
+        , "      </activity>"
+        , "      <geography geographyId=\"TEST\"><shortname xml:lang=\"en\">TEST</shortname></geography>"
+        , "    </activityDescription>"
+        , "    <flowData>"
+        , "      <intermediateExchange id=\"ref\" unitId=\"unit-kg\" amount=\"1.0\""
+        , "                            intermediateExchangeId=\"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb\">"
+        , "        <name xml:lang=\"en\">Cheese</name>"
+        , "        <unitName xml:lang=\"en\">kg</unitName>"
+        , "        <property propertyId=\"p1\" amount=\"0.6\" unitId=\"unit-kg\">"
+        , "          <name xml:lang=\"en\">dry mass</name>"
+        , "          <unitName xml:lang=\"en\">kg</unitName>"
+        , "        </property>"
+        , "        <outputGroup>0</outputGroup>"
+        , "      </intermediateExchange>"
+        , "      <intermediateExchange id=\"co\" unitId=\"unit-kg\" amount=\"2.0\""
+        , "                            intermediateExchangeId=\"cccccccc-cccc-cccc-cccc-cccccccccccc\">"
+        , "        <name xml:lang=\"en\">Whey</name>"
+        , "        <unitName xml:lang=\"en\">kg</unitName>"
+        , "        <property propertyId=\"p1\" amount=\"0.1\" unitId=\"unit-kg\">"
+        , "          <name xml:lang=\"en\">dry mass</name>"
+        , "          <unitName xml:lang=\"en\">kg</unitName>"
+        , "        </property>"
+        , "        <outputGroup>2</outputGroup>"
+        , "      </intermediateExchange>"
+        , "      <intermediateExchange id=\"in\" unitId=\"unit-kg\" amount=\"10.0\""
+        , "                            intermediateExchangeId=\"dddddddd-dddd-dddd-dddd-dddddddddddd\">"
+        , "        <name xml:lang=\"en\">Milk</name>"
+        , "        <unitName xml:lang=\"en\">kg</unitName>"
+        , "        <inputGroup>5</inputGroup>"
+        , "      </intermediateExchange>"
+        , "    </flowData>"
+        , "  </activityDataset>"
+        , "</ecoSpold>"
+        ]

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -426,6 +426,49 @@ spec = do
                     Left err -> T.unpack err `shouldContain` "activityA_productX_v2.spold"
 
     -- -----------------------------------------------------------------------
+    -- A file offered to a load that becomes no dataset
+    -- -----------------------------------------------------------------------
+    describe "a file that becomes no dataset" $ do
+        -- The unreadable files are named in two parts, so their names read and
+        -- only their content can refuse: this pins the parse gate rather than
+        -- the file-name gate beside it.
+        let notADataset = "<ecoSpold><nothing/></ecoSpold>"
+            refusalOf dir = do
+                result <- loadDatabase defaultUnitConfig dir
+                either (return . T.unpack) (const (fail "expected the load to refuse")) result
+
+        it "refuses an EcoSpold2 archive holding a file the parser cannot read" $
+            withSystemTempDirectory "es2-unreadable" $ \dir -> do
+                copyFile "test-data/SAMPLE.min4/activityA_productX.spold" (dir </> "activityA_productX.spold")
+                writeFile (dir </> "brokenA_brokenX.spold") notADataset
+                err <- refusalOf dir
+                err `shouldContain` "brokenA_brokenX.spold"
+
+        it "names every file it refused and counts them against what was offered" $
+            withSystemTempDirectory "es2-two-unreadable" $ \dir -> do
+                copyFile "test-data/SAMPLE.min4/activityA_productX.spold" (dir </> "activityA_productX.spold")
+                writeFile (dir </> "brokenA_brokenX.spold") notADataset
+                writeFile (dir </> "brokenB_brokenY.spold") notADataset
+                err <- refusalOf dir
+                err `shouldContain` "2 of 3 files became no dataset"
+                err `shouldContain` "brokenA_brokenX.spold"
+                err `shouldContain` "brokenB_brokenY.spold"
+
+        it "refuses an EcoSpold1 directory holding a file the parser cannot read" $
+            withSystemTempDirectory "es1-unreadable" $ \dir -> do
+                copyFile "test-data/SAMPLE.ecospold1/process1.xml" (dir </> "process1.xml")
+                writeFile (dir </> "broken.xml") notADataset
+                err <- refusalOf dir
+                err `shouldContain` "broken.xml"
+
+        it "refuses a lone EcoSpold1 file no dataset could be read from" $
+            withSystemTempDirectory "es1-empty" $ \dir -> do
+                writeFile (dir </> "broken.xml") notADataset
+                err <- refusalOf dir
+                err `shouldContain` "broken.xml"
+                err `shouldContain` "no dataset could be read"
+
+    -- -----------------------------------------------------------------------
     -- getReferenceProductUUID
     -- -----------------------------------------------------------------------
     describe "getReferenceProductUUID" $ do


### PR DESCRIPTION
## The problem

An EcoSpold directory load could be offered N files, return a database built
from fewer, and say nothing a caller could read. A file the parser refused was
logged as a warning and skipped; the load returned `Right`, and the status that
follows describes what was kept and never what was offered, so nothing
separates a small database from one missing datasets.

Three things made that warning worth less than it looks:

- it did not name the file. The path lived on the `Right` side of the parse
  result, and `partitionEithers` kept the parser's message alone;
- it goes to a 1000-line in-memory ring buffer, so a load longer than that
  overwrites it before anyone reads it;
- a database served from its matrix cache never emits it at all, because
  nothing is parsed.

A single file holding several datasets and yielding none had the same shape one
level up: `streamParseAllDatasetsFromFile1` answers with an empty list, and the
loader turned that into an empty database and a `Right`.

## What the change does

A file that is offered and becomes no dataset now refuses the load, through the
gate a file name with no reading already goes through. The two say the same
thing, and one of them had no reason to be the quieter.

A worker's refusals travel as a list rather than a first error, so one message
names every file instead of one per load, which is what an archive named by a
single convention needs: it has one unreadable file or thousands, rarely
anything between. The message counts them against what the directory offered
and names the first ten, the way the load already reports what the allocation
key refused.

The reason is read once for the file, and the key once per process the
allocation divided the file into, which is what each of them is about: an
EcoSpold 2 key is read from the name, which does not change with the division,
so reading the refusal per process would name the file once per process and
count more refusals than files.

Both parsers now prefix a failure with the path, as they already prefix the
warnings a reading produces, and the multi-dataset reader answers with the
reason rather than an empty list, so a file holding several datasets and
yielding none refuses with what the parser made of it.

## Worth knowing

**This replaces the count the issue asks for, and says so.** #401 asks for a
number on the status, "N files were offered, M became activities", and the
first half of it said that half would add a field to `DatabaseSetupInfo`. This
does not, because that ratio is not readable: `allocateParsed` turns one file
into one entry per allocated product, so M is above N on a healthy archive that
divides a block, and below it wherever a file name has room for fewer products
than the file produced. A caller could not read the pair without also knowing
the allocation and the collisions. What the issue wants from the number is the
sentence after it, "so that a caller can tell a small database from a mutilated
one", and a refusal answers that more strongly: no mutilated database exists to
be told apart. So this says `Refs #401`, not `Closes`, and the choice between
the two is the author's.

**A behaviour change to weigh.** The same function serves the EcoSpold 1
directory path, so a stray top-level `.xml` that is not a dataset now refuses
the load where it used to be skipped. That is the intended direction, and the
message names the file so the answer is to remove it, but an archive that loads
today may stop.

**Left silent on purpose.** Two files whose names carry the same identifier
pair still collapse in `harvestOf`, and a file that is read and then divided
into several products still only warns: there the file is read, and what cannot
be kept is a product an EcoSpold 2 file name has no room to key. The ILCD
reader drops a process file it cannot parse with no warning at all
(`parseProcessFilesParallel` keeps only the `Just`s). Each is its own subject.

## How to check it

```
cabal test lca-tests --test-options='--match "/a file that becomes no dataset/"'
```

Five cases in `test/LoaderSpec.hs`, each on a temporary directory. The
unreadable files are named in two parts so their names read and only their
content can refuse:

- an EcoSpold 2 directory holding a readable dataset and one unreadable file
  refuses and names it. Before the change it loaded one activity and returned
  `Right`;
- with two unreadable files, the message says `2 of 3 files became no dataset`
  and names both;
- an EcoSpold 1 directory holding a readable dataset and one unreadable file
  refuses and names it;
- a lone EcoSpold 1 file no dataset can be read from refuses instead of loading
  an empty database, and says which of the two empty answers it is;
- a block divided into several processes whose name has no reading refuses
  once, `1 of 1`, rather than once per process.

The first four fail on `main` with `expected the load to refuse`; the fifth
answers `2 of 1 files became no dataset` and names the file twice.

Full suite through `./build.sh --test`: 2622 examples, 0 failures, 2 pending.
`fourmolu --mode check src test` and `hlint src test app` are clean, and CI's
Linux leg builds it cold through `./build.sh --test --werror`.
