### PR TITLE
Stop the load when one unit identifier is given two names

### DIFF
--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -83,6 +83,7 @@ module Database.Loader (
     mergeWasteFlows,
     Harvest (..),
     harvestOf,
+    unitNameConflicts,
     generateActivityUUIDFromActivity,
     datasetUUIDFromPath,
     getReferenceProductUUID,
@@ -250,6 +251,12 @@ data Harvest = Harvest
     -- ^ flow declarations read, before deduplication
     , hvRawUnits :: !Int
     -- ^ unit declarations read, before deduplication
+    , hvUnitNames :: !(M.Map UUID.UUID (S.Set T.Text))
+    {- ^ Every name the files gave each unit identifier. The identifier is the
+    file's own and the name is what a writer prints and what a conversion looks
+    up, so a file giving one identifier two names has said two things where the
+    table can hold one; 'unitNameConflicts' is where they are said.
+    -}
     }
 
 instance Semigroup Harvest where
@@ -260,13 +267,14 @@ instance Semigroup Harvest where
             , hvBioFlows = MS.unionWith mergeBioFlows (hvBioFlows a) (hvBioFlows b)
             , hvWasteFlows = MS.unionWith mergeWasteFlows (hvWasteFlows a) (hvWasteFlows b)
             , hvUnits = M.union (hvUnits a) (hvUnits b)
+            , hvUnitNames = MS.unionWith S.union (hvUnitNames a) (hvUnitNames b)
             , hvDatasetNumbers = MS.unionWith (<>) (hvDatasetNumbers a) (hvDatasetNumbers b)
             , hvRawFlows = hvRawFlows a + hvRawFlows b
             , hvRawUnits = hvRawUnits a + hvRawUnits b
             }
 
 instance Monoid Harvest where
-    mempty = Harvest M.empty MS.empty MS.empty MS.empty M.empty M.empty 0 0
+    mempty = Harvest M.empty MS.empty MS.empty MS.empty M.empty M.empty 0 0 M.empty
 
 {- | Harvest a batch of parsed datasets, each already keyed by the (activity,
 product) pair its source names it under.
@@ -278,12 +286,19 @@ harvestOf entries =
         , hvTechFlows = MS.fromListWith mergeTechFlows [(tfId f, f) | f <- techs]
         , hvBioFlows = MS.fromListWith mergeBioFlows [(bfId f, f) | f <- bios]
         , hvWasteFlows = MS.fromListWith mergeWasteFlows [(wfId f, f) | f <- wastes]
-        , hvUnits = M.fromList [(unitId u, u) | u <- units]
+        , hvUnits = MS.fromListWith firstRead [(unitId u, u) | u <- units]
         , hvDatasetNumbers = MS.fromListWith (flip (<>)) [(pdDatasetNumber parsed, key NE.:| []) | (key, parsed) <- entries, pdDatasetNumber parsed /= 0]
         , hvRawFlows = length techs + length bios + length wastes
         , hvRawUnits = length units
+        , hvUnitNames = MS.fromListWith S.union [(unitId u, S.singleton (unitName u)) | u <- units]
         }
   where
+    -- 'M.fromListWith' hands the new row first, so keeping the second argument
+    -- keeps the row read first, which is the rule two harvests meeting already
+    -- follow for this table. One rule, so 'unitNameConflicts' can name it.
+    firstRead :: Unit -> Unit -> Unit
+    firstRead _ old = old
+
     techs :: [TechnosphereFlow]
     techs = concatMap (pdTechFlows . snd) entries
     bios :: [BiosphereFlow]
@@ -292,6 +307,24 @@ harvestOf entries =
     wastes = concatMap (pdWasteFlows . snd) entries
     units :: [Unit]
     units = concatMap (pdUnits . snd) entries
+
+{- | One line per unit identifier the files gave more than one name.
+
+The identifier is the file's own, so two names under it is the file
+contradicting itself, and the table can hold one of them. It holds the one read
+first, in the order the files were given; the other names are said here rather
+than dropped without a word.
+-}
+unitNameConflicts :: Harvest -> [String]
+unitNameConflicts h =
+    [ "Unit "
+        <> UUID.toString uid
+        <> " is given more than one name: "
+        <> T.unpack (T.intercalate ", " (S.toList names))
+        <> "; the first one read is kept"
+    | (uid, names) <- M.toList (hvUnitNames h)
+    , S.size names > 1
+    ]
 
 -- | The five tables of a harvest that make a database; the other three describe the reading.
 harvestDatabase :: Harvest -> SimpleDatabase
@@ -1420,6 +1453,7 @@ loadEcoSpoldDirectory opts dir = do
                         (M.size (hvUnits harvested))
                         unitDeduplication
                         totalRawUnits
+                mapM_ (reportProgress Warning) (unitNameConflicts harvested)
                 reportMemoryUsage "Final parsing memory usage"
 
                 -- For EcoSpold1: fix activity links using supplier lookup table
@@ -1526,6 +1560,7 @@ loadSingleEcoSpold1File opts filepath = do
     reportProgress Info $ printf "  Activities: %d processes" (M.size (hvActivities harvested))
     reportProgress Info $ printf "  Flows: %d tech + %d bio + %d waste (from %d raw)" (M.size (hvTechFlows harvested)) (M.size (hvBioFlows harvested)) (M.size (hvWasteFlows harvested)) (hvRawFlows harvested)
     reportProgress Info $ printf "  Units: %d unique (from %d raw)" (M.size (hvUnits harvested)) (hvRawUnits harvested)
+    mapM_ (reportProgress Warning) (unitNameConflicts harvested)
 
     Right <$> fixEcoSpold1ActivityLinks locationAliases (hvDatasetNumbers harvested) simpleDb
   where

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -83,7 +83,7 @@ module Database.Loader (
     mergeWasteFlows,
     Harvest (..),
     harvestOf,
-    unitNameConflicts,
+    unitNamesDisagreeing,
     generateActivityUUIDFromActivity,
     datasetUUIDFromPath,
     getReferenceProductUUID,
@@ -234,6 +234,10 @@ which is why the two are exported. The qualifiers are not interchangeable
 either: the flow tables are merged strictly, for the reason the import of
 'Data.Map.Strict' gives, and the rest is left as the build sites had it.
 
+'hvUnits' is under neither law and needs no arbitration: an identifier given
+two names stops the load, and the only merge left is a real name displacing the
+placeholder a nameless declaration carries.
+
 'hvDatasetNumbers' is the one table under neither law: a repeated number is the
 ordinary shape there, not a collision to arbitrate, so both sides are kept and
 the reader picks by product name. See 'DatasetNumberIndex'. It is built and
@@ -252,10 +256,10 @@ data Harvest = Harvest
     , hvRawUnits :: !Int
     -- ^ unit declarations read, before deduplication
     , hvUnitNames :: !(M.Map UUID.UUID (S.Set T.Text))
-    {- ^ Every name the files gave each unit identifier. The identifier is the
-    file's own and the name is what a writer prints and what a conversion looks
-    up, so a file giving one identifier two names has said two things where the
-    table can hold one; 'unitNameConflicts' is where they are said.
+    {- ^ The names the files gave each unit identifier, the placeholder of a
+    nameless declaration aside. The identifier is the file's own and the name
+    is what a writer prints and what a conversion looks up, so two names under
+    one identifier are two units, not two spellings: see 'unitNamesDisagreeing'.
     -}
     }
 
@@ -266,7 +270,7 @@ instance Semigroup Harvest where
             , hvTechFlows = MS.unionWith mergeTechFlows (hvTechFlows a) (hvTechFlows b)
             , hvBioFlows = MS.unionWith mergeBioFlows (hvBioFlows a) (hvBioFlows b)
             , hvWasteFlows = MS.unionWith mergeWasteFlows (hvWasteFlows a) (hvWasteFlows b)
-            , hvUnits = M.union (hvUnits a) (hvUnits b)
+            , hvUnits = MS.unionWith (\l r -> if isPlaceholderUnit l then r else l) (hvUnits a) (hvUnits b)
             , hvUnitNames = MS.unionWith S.union (hvUnitNames a) (hvUnitNames b)
             , hvDatasetNumbers = MS.unionWith (<>) (hvDatasetNumbers a) (hvDatasetNumbers b)
             , hvRawFlows = hvRawFlows a + hvRawFlows b
@@ -286,18 +290,18 @@ harvestOf entries =
         , hvTechFlows = MS.fromListWith mergeTechFlows [(tfId f, f) | f <- techs]
         , hvBioFlows = MS.fromListWith mergeBioFlows [(bfId f, f) | f <- bios]
         , hvWasteFlows = MS.fromListWith mergeWasteFlows [(wfId f, f) | f <- wastes]
-        , hvUnits = MS.fromListWith firstRead [(unitId u, u) | u <- units]
+        , hvUnits = MS.fromListWith namedOverPlaceholder [(unitId u, u) | u <- units]
         , hvDatasetNumbers = MS.fromListWith (flip (<>)) [(pdDatasetNumber parsed, key NE.:| []) | (key, parsed) <- entries, pdDatasetNumber parsed /= 0]
         , hvRawFlows = length techs + length bios + length wastes
         , hvRawUnits = length units
-        , hvUnitNames = MS.fromListWith S.union [(unitId u, S.singleton (unitName u)) | u <- units]
+        , hvUnitNames = MS.fromListWith S.union [(unitId u, S.singleton (unitName u)) | u <- units, not (isPlaceholderUnit u)]
         }
   where
-    -- 'M.fromListWith' hands the new row first, so keeping the second argument
-    -- keeps the row read first, which is the rule two harvests meeting already
-    -- follow for this table. One rule, so 'unitNameConflicts' can name it.
-    firstRead :: Unit -> Unit -> Unit
-    firstRead _ old = old
+    -- The only two rows under one identifier that can be reconciled: a
+    -- declaration with no name carries a placeholder, and a real name takes
+    -- its place whichever was read first. Two real names stop the load.
+    namedOverPlaceholder :: Unit -> Unit -> Unit
+    namedOverPlaceholder new old = if isPlaceholderUnit old then new else old
 
     techs :: [TechnosphereFlow]
     techs = concatMap (pdTechFlows . snd) entries
@@ -308,25 +312,34 @@ harvestOf entries =
     units :: [Unit]
     units = concatMap (pdUnits . snd) entries
 
-{- | One line per unit identifier the files gave more than one name.
+{- | The placeholder a declaration with no name carries.
 
-The identifier is the file's own, so two names under it is the file
-contradicting itself, and the table can hold one of them. It holds the one read
-first, in the order the files were given; the other names are said here rather
-than dropped without a word.
+'EcoSpold.Parser2.mkUnit' writes it so that an exchange whose unit the file left
+blank still has a unit; it is not a name the file gave, so it neither displaces
+a real name nor counts as one.
 -}
-unitNameConflicts :: Harvest -> [String]
-unitNameConflicts h =
+isPlaceholderUnit :: Unit -> Bool
+isPlaceholderUnit u = unitName u == "UNKNOWN_UNIT"
+
+{- | The unit identifiers the files gave more than one name, with the names.
+
+The identifier is the file's own and the name is what a writer prints and what
+a conversion looks up, so @kg@ and @t@ under one identifier are not two
+spellings of one unit: they are two units, and every amount carrying that
+identifier is a thousand times one or the other. Nothing in the files says
+which, so the load stops rather than picking.
+-}
+unitNamesDisagreeing :: Harvest -> [T.Text]
+unitNamesDisagreeing h =
     [ "Unit "
-        <> UUID.toString uid
+        <> T.pack (UUID.toString uid)
         <> " is given more than one name: "
-        <> T.unpack (T.intercalate ", " (S.toList names))
-        <> "; the first one read is kept"
+        <> T.intercalate ", " (S.toList names)
     | (uid, names) <- M.toList (hvUnitNames h)
     , S.size names > 1
     ]
 
--- | The five tables of a harvest that make a database; the other three describe the reading.
+-- | The five tables of a harvest that make a database; the rest describes the reading.
 harvestDatabase :: Harvest -> SimpleDatabase
 harvestDatabase h =
     SimpleDatabase (hvActivities h) (hvTechFlows h) (hvBioFlows h) (hvWasteFlows h) (hvUnits h)
@@ -1453,14 +1466,15 @@ loadEcoSpoldDirectory opts dir = do
                         (M.size (hvUnits harvested))
                         unitDeduplication
                         totalRawUnits
-                mapM_ (reportProgress Warning) (unitNameConflicts harvested)
                 reportMemoryUsage "Final parsing memory usage"
 
                 -- For EcoSpold1: fix activity links using supplier lookup table
                 let simpleDb = harvestDatabase harvested
-                if isEcoSpold1
-                    then Right <$> fixEcoSpold1ActivityLinks locationAliases (hvDatasetNumbers harvested) simpleDb
-                    else return $ Right simpleDb
+                case unitNamesDisagreeing harvested of
+                    (conflict : more) -> return (Left (T.intercalate "; " (conflict : more)))
+                    []
+                        | isEcoSpold1 -> Right <$> fixEcoSpold1ActivityLinks locationAliases (hvDatasetNumbers harvested) simpleDb
+                        | otherwise -> return (Right simpleDb)
 
     -- Process one worker's share of files
     processWorker :: UTCTime -> Bool -> (Int, [FilePath]) -> IO (Either T.Text Harvest)
@@ -1560,7 +1574,6 @@ loadSingleEcoSpold1File opts filepath = do
     reportProgress Info $ printf "  Activities: %d processes" (M.size (hvActivities harvested))
     reportProgress Info $ printf "  Flows: %d tech + %d bio + %d waste (from %d raw)" (M.size (hvTechFlows harvested)) (M.size (hvBioFlows harvested)) (M.size (hvWasteFlows harvested)) (hvRawFlows harvested)
     reportProgress Info $ printf "  Units: %d unique (from %d raw)" (M.size (hvUnits harvested)) (hvRawUnits harvested)
-    mapM_ (reportProgress Warning) (unitNameConflicts harvested)
 
     Right <$> fixEcoSpold1ActivityLinks locationAliases (hvDatasetNumbers harvested) simpleDb
   where

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -2,6 +2,7 @@
 
 module LoaderSpec (spec) where
 
+import Data.List (isInfixOf)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
@@ -100,6 +101,17 @@ minimalWaste fid name syns =
         , wfCAS = Nothing
         , wfSubstanceId = Nothing
         }
+
+{- | One reader's share carrying units instead of flows, so two spellings of one
+unit identifier can meet.
+-}
+metering :: Text -> [Unit] -> ((UUID.UUID, UUID.UUID), ParsedDataset)
+metering name units =
+    ((actUUID1, flowUUID1), (minimalDataset (minimalActivity name "GLO" []) []){pdUnits = units})
+
+-- | The unit identifier the tests above and below spell two ways.
+unitUUID1 :: UUID.UUID
+unitUUID1 = read "dddddddd-0000-0000-0000-000000000001"
 
 {- | One coproduct of a block published under dataset number 7: allocation gives
 each of them its own key, and they all carry the number the block was read under.
@@ -308,6 +320,22 @@ spec = do
                 merged = harvestOf [wasting "activity-a" [a]] <> harvestOf [wasting "activity-b" [b]]
             fmap wfSynonyms (M.lookup flowUUID2 (hvWasteFlows merged))
                 `shouldBe` Just (M.singleton "en" (S.fromList ["mine spoil", "overburden"]))
+
+        -- A unit identifier is the file's own, and the name under it is what a
+        -- writer prints and what a conversion looks up. Two names for one
+        -- identifier is the file contradicting itself.
+        it "keeps the first name read for a unit identifier" $ do
+            let harvest = harvestOf [metering "activity-a" [Unit unitUUID1 "kg" "kg" ""], metering "activity-b" [Unit unitUUID1 "kilogram" "kilogram" ""]]
+            fmap unitName (M.lookup unitUUID1 (hvUnits harvest)) `shouldBe` Just "kg"
+
+        it "keeps the first reader's name too, when two shares meet" $ do
+            let merged = harvestOf [metering "activity-a" [Unit unitUUID1 "kg" "kg" ""]] <> harvestOf [metering "activity-b" [Unit unitUUID1 "kilogram" "kilogram" ""]]
+            fmap unitName (M.lookup unitUUID1 (hvUnits merged)) `shouldBe` Just "kg"
+
+        it "names both spellings rather than dropping one without a word" $ do
+            let merged = harvestOf [metering "activity-a" [Unit unitUUID1 "kg" "kg" ""]] <> harvestOf [metering "activity-b" [Unit unitUUID1 "kilogram" "kilogram" ""]]
+            unitNameConflicts merged
+                `shouldSatisfy` any (\line -> "kg" `isInfixOf` line && "kilogram" `isInfixOf` line)
 
         -- The dataset-number table is under neither law: an allocated block is
         -- written once per coproduct, all of them under the block's number, so

--- a/test/LoaderSpec.hs
+++ b/test/LoaderSpec.hs
@@ -2,7 +2,6 @@
 
 module LoaderSpec (spec) where
 
-import Data.List (isInfixOf)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
@@ -322,20 +321,31 @@ spec = do
                 `shouldBe` Just (M.singleton "en" (S.fromList ["mine spoil", "overburden"]))
 
         -- A unit identifier is the file's own, and the name under it is what a
-        -- writer prints and what a conversion looks up. Two names for one
-        -- identifier is the file contradicting itself.
-        it "keeps the first name read for a unit identifier" $ do
-            let harvest = harvestOf [metering "activity-a" [Unit unitUUID1 "kg" "kg" ""], metering "activity-b" [Unit unitUUID1 "kilogram" "kilogram" ""]]
-            fmap unitName (M.lookup unitUUID1 (hvUnits harvest)) `shouldBe` Just "kg"
+        -- writer prints and what a conversion looks up. Two names under one
+        -- identifier are two units, not two spellings of one.
+        it "names both units when one identifier is given two names" $ do
+            let harvest = harvestOf [metering "activity-a" [Unit unitUUID1 "kg" "kg" ""], metering "activity-b" [Unit unitUUID1 "t" "t" ""]]
+            unitNamesDisagreeing harvest
+                `shouldSatisfy` any (\line -> "kg" `T.isInfixOf` line && "t" `T.isInfixOf` line)
 
-        it "keeps the first reader's name too, when two shares meet" $ do
-            let merged = harvestOf [metering "activity-a" [Unit unitUUID1 "kg" "kg" ""]] <> harvestOf [metering "activity-b" [Unit unitUUID1 "kilogram" "kilogram" ""]]
-            fmap unitName (M.lookup unitUUID1 (hvUnits merged)) `shouldBe` Just "kg"
+        it "names them across two readers as well" $ do
+            let merged = harvestOf [metering "activity-a" [Unit unitUUID1 "kg" "kg" ""]] <> harvestOf [metering "activity-b" [Unit unitUUID1 "t" "t" ""]]
+            unitNamesDisagreeing merged `shouldSatisfy` not . null
 
-        it "names both spellings rather than dropping one without a word" $ do
-            let merged = harvestOf [metering "activity-a" [Unit unitUUID1 "kg" "kg" ""]] <> harvestOf [metering "activity-b" [Unit unitUUID1 "kilogram" "kilogram" ""]]
-            unitNameConflicts merged
-                `shouldSatisfy` any (\line -> "kg" `isInfixOf` line && "kilogram" `isInfixOf` line)
+        it "says nothing about an identifier every file names the same way" $ do
+            let merged = harvestOf [metering "activity-a" [Unit unitUUID1 "kg" "kg" ""]] <> harvestOf [metering "activity-b" [Unit unitUUID1 "kg" "kg" ""]]
+            unitNamesDisagreeing merged `shouldBe` []
+
+        -- A declaration with no name carries a placeholder, which is not a name
+        -- the file gave: a real name takes its place and nothing is refused.
+        it "lets a real name take the place of the placeholder, whichever came first" $ do
+            let placeheld = Unit unitUUID1 "UNKNOWN_UNIT" "?" ""
+                named = Unit unitUUID1 "kg" "kg" ""
+                afterFirst = harvestOf [metering "activity-a" [placeheld], metering "activity-b" [named]]
+                afterSecond = harvestOf [metering "activity-a" [named], metering "activity-b" [placeheld]]
+            fmap unitName (M.lookup unitUUID1 (hvUnits afterFirst)) `shouldBe` Just "kg"
+            fmap unitName (M.lookup unitUUID1 (hvUnits afterSecond)) `shouldBe` Just "kg"
+            unitNamesDisagreeing afterFirst `shouldBe` []
 
         -- The dataset-number table is under neither law: an allocated block is
         -- written once per coproduct, all of them under the block's number, so


### PR DESCRIPTION
## Problem

A harvest keys its unit table on the identifier the file gives each unit. In
EcoSpold 2 that identifier comes from the file rather than from the name, so
two datasets can carry one identifier under two names, and `M.fromList` kept
one of them without a word.

Two names under one identifier are not two spellings of one unit. The
identifier is the file's own, and the name is what a writer prints and what a
conversion looks up, so `kg` and `t` under one identifier make every amount
carrying that identifier a thousand times one or the other.

Which name survived was not even stable: the two folds face opposite ways, so a
divergence inside one reader's share kept the last name while one spanning two
shares kept the first, and how the files are shared out follows the machine's
core count. The order the files are read in is an unsorted directory listing on
top of that.

## Solution

The load stops and names the identifier and both names. Nothing in the files
says which unit was meant, and no reading order can be made to answer it.

The one pair that can be reconciled stays reconciled: a declaration whose unit
name the file left blank carries a placeholder, which is not a name the file
gave, so a real name takes its place whichever was read first, and that is not
a divergence.

The harvest carries the names each identifier was given, the way the flow
tables already carry every synonym. The type's documentation said this table
follows the harvest's two-direction law; it no longer does, and says so.

## Remarks

A file that names each identifier once is unaffected, and so is a database
where several datasets name one identifier the same way.

EcoSpold 1 derives the identifier from the name, so the divergence cannot arise
there; the check sits on the shared path and costs nothing.

## How to test

`cabal test all` - 2629 examples, 0 failures, 2 pending. Four new examples,
beside the ones pinning the harvest's laws for flows: one identifier given two
names is named inside one reader's share and across two, an identifier every
file names the same way says nothing, and a real name takes the placeholder's
place from either side without being refused.
