### PR TITLE
Say which command builds and tests, and what it settles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,20 +33,22 @@ See `README.md` for the full feature spec.
 ./build.sh --test       # Build + run the test suite, at -O0: it only has to pass
 ./build.sh --coverage   # Build + tests + HTML coverage report
 cabal test lca-tests --test-options="--match /Inventory/" # Re-run one spec group in a tree ./build.sh --test already built
+VOLCA_EXE=$(cabal list-bin exe:volca) cabal test lca-tests --test-options="--match /Server/" # ... and Server and Routes want the binary named
 ```
 
 **Build and test through `./build.sh --test`, not through `cabal` directly.** It
 settles four things a bare `cabal test` leaves to you: it runs `./gen-version.sh`;
-it compiles volca's own modules at `-O0`, where cabal's own default is `-O1` and
-a test binary only has to pass; it builds `exe:volca`; and it exports `VOLCA_EXE`
-so `test/ServerSpec.hs` does not spawn a `cabal list-bin` from inside `cabal test`.
-Skip it and the suite is slower to compile and `ServerSpec` and `RoutesSpec` report
-`volca executable not found`. `VOLCA_OPT_LEVEL` overrides the level. The two levels
-do not share a build tree, so alternating costs one cold build each way and stays
-incremental on both sides after that.
+it compiles volca's own modules at `-O0`, since a test binary only has to pass and
+cabal's own default is `-O1`; it builds `exe:volca`; and it exports `VOLCA_EXE` so
+`ServerSpec` and `RoutesSpec` do not spawn a `cabal list-bin` from inside `cabal
+test`. Skip it on a tree the script has not built and those two report `volca
+executable not found`; on Windows they do worse, the spawned cabal blocking on the
+build lock the parent already holds until the job is killed. `VOLCA_OPT_LEVEL`
+overrides the level. The two levels do not share a build tree, so alternating costs
+one cold build each way and stays incremental on both sides after that; a bare
+`cabal` in between inherits whichever level the last run of the script wrote.
 
-`src/Version.hs` is generated, not committed — a native `cabal build`/`cabal test`
-fails without running `./gen-version.sh` first. Tests use hspec + hspec-discover;
+`src/Version.hs` is generated and gitignored. Tests use hspec + hspec-discover;
 spec modules are `*Spec.hs` under `test/` and auto-discovered. New behavior needs a
 `*Spec.hs`; integration fixtures (sample databases, golden values) live in `test-data/`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,12 +29,21 @@ See `README.md` for the full feature spec.
 
 ```bash
 ./gen-version.sh        # Generate src/Version.hs and src/Builtin/Literals.hs (git metadata, built-in reference data) — REQUIRED before a native build
-./build.sh              # Build the engine
-./build.sh --test       # Build + run the test suite
+./build.sh              # Build the engine, at -O1: this binary is going to be run
+./build.sh --test       # Build + run the test suite, at -O0: it only has to pass
 ./build.sh --coverage   # Build + tests + HTML coverage report
-cabal test lca-tests --test-show-details=streaming        # Run tests directly
-cabal test lca-tests --test-options="--match /Inventory/" # Run a single spec group
+cabal test lca-tests --test-options="--match /Inventory/" # Re-run one spec group in a tree ./build.sh --test already built
 ```
+
+**Build and test through `./build.sh --test`, not through `cabal` directly.** It
+settles four things a bare `cabal test` leaves to you: it runs `./gen-version.sh`;
+it compiles volca's own modules at `-O0`, where cabal's own default is `-O1` and
+a test binary only has to pass; it builds `exe:volca`; and it exports `VOLCA_EXE`
+so `test/ServerSpec.hs` does not spawn a `cabal list-bin` from inside `cabal test`.
+Skip it and the suite is slower to compile and `ServerSpec` and `RoutesSpec` report
+`volca executable not found`. `VOLCA_OPT_LEVEL` overrides the level. The two levels
+do not share a build tree, so alternating costs one cold build each way and stays
+incremental on both sides after that.
 
 `src/Version.hs` is generated, not committed — a native `cabal build`/`cabal test`
 fails without running `./gen-version.sh` first. Tests use hspec + hspec-discover;

--- a/README.md
+++ b/README.md
@@ -688,9 +688,15 @@ docker run -p 8080:8080 -v /path/to/data:/data volca
 ```bash
 ./build.sh --test
 
-# Or manually
-cabal test --test-show-details=streaming
+# One spec group, in a tree that script has already built
+cabal test lca-tests --test-options="--match /Inventory/"
 ```
+
+`./build.sh --test` is the way in: it generates `src/Version.hs`, compiles at
+`-O0`, builds the `volca` executable and names it to the specs that start a
+server. A bare `cabal test` from a fresh clone does none of those: it stops on
+the missing `src/Version.hs`, and once that is generated the specs that want the
+executable stop too. `AGENTS.md` says the rest.
 
 Tests cover matrix construction (sign convention), inventory calculation (golden values), parsers (EcoSpold1/2, ILCD, SimaPro, Brightway Excel, classification fields), and matrix export format compliance.
 


### PR DESCRIPTION
## The problem

The commands block lists `./build.sh --test` and a bare `cabal test lca-tests`
side by side with nothing to choose between them, and says nothing about what
the script decides. A reader reaches for cabal and gets three surprises: the
compile runs at cabal's own default `-O1` where a test binary only has to pass,
`exe:volca` is not built, and `VOLCA_EXE` is not exported, so `ServerSpec` and
`RoutesSpec` fail with `volca executable not found`. On Windows they do worse:
the spawned `cabal list-bin` blocks on the build lock the parent `cabal test`
already holds, until the job is killed.

Both of those defaults live in `build.sh`'s own comments, which is the file
nobody reads before running a build. The README says the same thing under "Or
manually", and it is the file a fresh clone reads first.

## What the change does

Names `./build.sh --test` as the way to build and run the suite, in `AGENTS.md`
and in the README, and says what it settles: `gen-version.sh`, `-O0`,
`exe:volca`, `VOLCA_EXE`. The two `build.sh` lines say which level each picks
and why. The bare `cabal` line stays, retitled as what it is good for, re-running
one spec group against a tree the script has already built, with a second line
for `Server` and `Routes`, which want the binary named on the command.

## Worth knowing

Two claims are narrower than they first read, and are written that way. Cabal's
`-O1` default holds only in a tree no run of the script has written
`cabal.project.local` in; after one, a bare `cabal` inherits the level that run
asked for. And `--test-show-details=streaming` is gone rather than retitled: it
did the same thing as the line below it, one spec group at a time being the
reason to reach for cabal at all.

## How to check it

Both documented commands, run against a tree `./build.sh --test` had built:

```
cabal test lca-tests --test-options="--match /Inventory/"                      # 9 examples, 0 failures
VOLCA_EXE=$(cabal list-bin exe:volca) cabal test lca-tests --test-options="--match /Server/"  # 5 examples, 0 failures
```

Nothing under `src/` or `test/` changes.