### PR TITLE
Leave out an EcoSpold exchange whose amount is not a number

### DIFF
--- a/src/EcoSpold/Common.hs
+++ b/src/EcoSpold/Common.hs
@@ -6,8 +6,6 @@ module EcoSpold.Common (
     decodeXmlEntities,
     decodeXmlEntitiesFull,
     numericRefChar,
-    bsToDouble,
-    bsToInt,
     bsToIntMaybe,
     isElement,
     distributeFiles,
@@ -20,10 +18,9 @@ module EcoSpold.Common (
     ParsedDataset (..),
 ) where
 
-import Amount (readAmount)
 import qualified Data.ByteString as BS
 import Data.Char (chr)
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
@@ -130,16 +127,6 @@ numericRefChar body = case T.uncons body of
         Right (n, leftover)
             | T.null leftover, n >= 0, n <= 0x10FFFF -> Just (chr (fromInteger n))
         _ -> Nothing
-
--- | ByteString to Double conversion (strict - errors on parse failure)
-bsToDouble :: BS.ByteString -> Double
-bsToDouble bs = fromMaybe (error $ "Failed to parse double from: " ++ show bs) (readAmount (bsToText bs))
-
--- | ByteString to Int conversion (strict - errors on parse failure)
-bsToInt :: BS.ByteString -> Int
-bsToInt bs = case TR.decimal (bsToText bs) of
-    Right (val, _) -> val
-    Left _ -> error $ "Failed to parse int from: " ++ show bs
 
 {- | ByteString to Int conversion that returns Nothing on parse failure.
 Use for attribute values that are user-controlled or optional and where

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -19,6 +19,7 @@ module EcoSpold.Parser1 (
     generateUnitUUID,
 ) where
 
+import Amount (readAmount)
 import Control.Monad (forM_)
 import Data.Bifunctor (first)
 import qualified Data.ByteString as BS
@@ -32,7 +33,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.UUID.V5 as UUID5
-import EcoSpold.Common (ParsedDataset (..), bsToDouble, bsToIntMaybe, bsToText, docSection, isElement, joinParts, nonEmptyText)
+import EcoSpold.Common (ParsedDataset (..), bsToIntMaybe, bsToText, docSection, isElement, joinParts, nonEmptyText)
 import Progress (ProgressLevel (..), reportProgress)
 import Types
 import qualified Xeno.SAX as X
@@ -118,7 +119,7 @@ data ExchangeData = ExchangeData
     , exSubCategory :: !Text -- Subcategory
     , exLocation :: !Text -- Location (for technosphere)
     , exUnit :: !Text -- Unit name
-    , exMeanValue :: !Double -- Amount
+    , exMeanValue :: !(Maybe Double) -- Amount, absent when the row states none a reader can make sense of
     , exInputGroup :: !Text -- Input group (1-4 = technosphere input, 4 = resource)
     , exOutputGroup :: !Text -- Output group (0 = reference, 1-3 = byproduct, 4 = emission)
     , exCASNumber :: !Text -- CAS number (optional)
@@ -130,7 +131,7 @@ data ExchangeData = ExchangeData
 
 -- | Initial exchange data
 emptyExchangeData :: ExchangeData
-emptyExchangeData = ExchangeData 0 "" "" "" "" "" 0.0 "" "" "" "" False ""
+emptyExchangeData = ExchangeData 0 "" "" "" "" "" Nothing "" "" "" "" False ""
 
 {- | One @\<source\>@ of the dataset's own bibliography. EcoSpold1 numbers them
 within the dataset, and @dataGeneratorAndPublication\@referenceToPublishedSource@
@@ -202,6 +203,12 @@ data ParseState = ParseState
     characterization factor reaches it and every method scores it zero: the
     reading names the word instead of letting the zero pass for an answer.
     -}
+    , psUnreadableAmounts :: !(S.Set Text)
+    {- ^ The exchanges of this dataset whose @meanValue@ is not a number. Such
+    a row states no amount, so it is left out rather than read as zero: a zero
+    row cannot be told apart from a flow the dataset really put at zero, and
+    every score drawn from it would undercount without saying so.
+    -}
     , psCompletedActivities :: ![Either String ParsedDataset]
     }
 
@@ -225,6 +232,7 @@ initialParseState =
         , psTextAccum = []
         , psDocs = emptyDatasetDocs
         , psUnplacedMedia = S.empty
+        , psUnreadableAmounts = S.empty
         , psCompletedActivities = []
         }
 
@@ -280,8 +288,7 @@ onAttribute state name value = case psContext state of
     --
     -- A number that will not parse leaves the dataset with none, which drops
     -- it out of the supplier index the same way a dataset carrying no number
-    -- does. 'bsToInt' would call @error@ from inside the pure fold instead,
-    -- killing the whole load over one malformed attribute.
+    -- does, rather than killing the whole load over one malformed attribute.
     datasetNumberAttr
         | isElement name "number"
         , currentElement : _ <- psPath state
@@ -346,14 +353,17 @@ setExchangeAttr :: BS.ByteString -> BS.ByteString -> ExchangeData -> ExchangeDat
 setExchangeAttr name value e
     -- An unparseable number leaves the exchange at 0, which merges it with the
     -- other unnumbered exchanges of the same name and compartment rather than
-    -- killing the load; 'bsToInt' would call @error@ from inside the fold.
+    -- killing the load.
     | isElement name "number" = e{exNumber = fromMaybe 0 (bsToIntMaybe value)}
     | isElement name "name" = e{exName = bsToText value}
     | isElement name "category" = e{exCategory = bsToText value}
     | isElement name "subCategory" = e{exSubCategory = bsToText value}
     | isElement name "location" = e{exLocation = bsToText value}
     | isElement name "unit" = e{exUnit = bsToText value}
-    | isElement name "meanValue" = e{exMeanValue = bsToDouble value}
+    -- The amount is the row's whole point, so a meanValue that will not read as
+    -- a number is not stood in for: the row states none, and 'closeExchange'
+    -- leaves it out.
+    | isElement name "meanValue" = e{exMeanValue = readAmount (bsToText value)}
     | isElement name "CASNumber" = e{exCASNumber = bsToText value}
     | isElement name "formula" = e{exFormula = bsToText value}
     | isElement name "infrastructureProcess" = e{exInfrastructure = bsToText value == "true"}
@@ -476,17 +486,23 @@ record the supplier link for technosphere inputs.
 -}
 closeExchange :: ParseState -> ParseState
 closeExchange state = case psContext state of
-    InExchange edata ->
-        let (exchange, parsedFlow, unit) = buildExchange (psLocation state) edata
-            (techs, bios) = case parsedFlow of
-                ParsedTech tf -> (tf : psTechFlows state, psBioFlows state)
-                ParsedBio bf -> (psTechFlows state, bf : psBioFlows state)
-         in (popElement state)
-                { psExchanges = exchange : psExchanges state
-                , psTechFlows = techs
-                , psBioFlows = bios
-                , psUnits = unit : psUnits state
-                , psUnplacedMedia = maybe id S.insert (unplacedMedium edata parsedFlow) (psUnplacedMedia state)
+    InExchange edata
+        | Just amount <- exMeanValue edata ->
+            let (exchange, parsedFlow, unit) = buildExchange (psLocation state) amount edata
+                (techs, bios) = case parsedFlow of
+                    ParsedTech tf -> (tf : psTechFlows state, psBioFlows state)
+                    ParsedBio bf -> (psTechFlows state, bf : psBioFlows state)
+             in (popElement state)
+                    { psExchanges = exchange : psExchanges state
+                    , psTechFlows = techs
+                    , psBioFlows = bios
+                    , psUnits = unit : psUnits state
+                    , psUnplacedMedia = maybe id S.insert (unplacedMedium edata parsedFlow) (psUnplacedMedia state)
+                    , psContext = Other
+                    }
+        | otherwise ->
+            (popElement state)
+                { psUnreadableAmounts = S.insert (exName edata) (psUnreadableAmounts state)
                 , psContext = Other
                 }
     InInputGroup _ -> popPath state
@@ -524,6 +540,7 @@ resetDataset state =
         , psTextAccum = []
         , psDocs = emptyDatasetDocs
         , psUnplacedMedia = S.empty
+        , psUnreadableAmounts = S.empty
         }
 
 {- | The category an elementary exchange was filed under, when that word names
@@ -548,8 +565,8 @@ medium 'Waste' whatever group it carries, so it is read as biosphere
 before the groups are consulted. Waste that does have a treatment is not
 written that way and stays on the technosphere side.
 -}
-buildExchange :: Maybe Text -> ExchangeData -> (Exchange, ParsedFlow, Unit)
-buildExchange activityLoc edata
+buildExchange :: Maybe Text -> Double -> ExchangeData -> (Exchange, ParsedFlow, Unit)
+buildExchange activityLoc amount edata
     | isBiosphere = (bioEx, ParsedBio bioFlow, unit)
     | otherwise = (techEx, ParsedTech techFlow, unit)
   where
@@ -608,7 +625,7 @@ buildExchange activityLoc edata
     bioEx =
         BiosphereExchange
             { bioFlowId = flowId
-            , bioAmount = exMeanValue edata
+            , bioAmount = amount
             , bioUnitId = unitId
             , bioDirection = if inputGroup == "4" then Resource else Emission
             , bioLocation = exchangeLocation
@@ -620,7 +637,7 @@ buildExchange activityLoc edata
     techEx =
         TechnosphereExchange
             { techFlowId = flowId
-            , techAmount = exMeanValue edata
+            , techAmount = amount
             , techUnitId = unitId
             , techRole = techRoleFor
             , techActivityLinkId = Nothing
@@ -732,6 +749,30 @@ unplacedMediaSeen st
     quoted "" = "no category"
     quoted t = "\"" <> t <> "\""
 
+{- | The exchanges of this dataset that stated no amount a reader could make
+sense of, said once for the dataset rather than once per row.
+
+The row is left out, so the dataset is short a flow. Naming the rows is what
+lets a reader tell that from a dataset that never carried them.
+-}
+unreadableAmountsSeen :: ParseState -> [Text]
+unreadableAmountsSeen st
+    | S.null names = []
+    | otherwise =
+        [ datasetPrefix st
+            <> "exchanges named "
+            <> T.intercalate ", " (map named (S.toList names))
+            <> " state no amount that reads as a number, and are left out"
+        ]
+  where
+    names :: S.Set Text
+    names = psUnreadableAmounts st
+
+    -- A row can carry no name at all, and "named \"\"" would name nothing.
+    named :: Text -> Text
+    named "" = "no name"
+    named t = "\"" <> t <> "\""
+
 -- | Build the final per-dataset result, applying the cut-off strategy.
 buildResult :: ParseState -> Either String ParsedDataset
 buildResult st =
@@ -775,7 +816,7 @@ buildResult st =
                   pdWasteFlows = []
                 , pdUnits = reverse (psUnits st)
                 , pdDatasetNumber = psDatasetNumber st
-                , pdWarnings = placeholdersUsed st ++ unplacedMediaSeen st
+                , pdWarnings = placeholdersUsed st ++ unplacedMediaSeen st ++ unreadableAmountsSeen st
                 }
      in -- A file that yields no exchange at all is not a dataset: a stray or
         -- truncated XML the SAX fold walked through without complaint.

--- a/src/EcoSpold/Parser1.hs
+++ b/src/EcoSpold/Parser1.hs
@@ -819,10 +819,15 @@ buildResult st =
                 , pdWarnings = placeholdersUsed st ++ unplacedMediaSeen st ++ unreadableAmountsSeen st
                 }
      in -- A file that yields no exchange at all is not a dataset: a stray or
-        -- truncated XML the SAX fold walked through without complaint.
-        if null (exchanges activity)
-            then Left "not an EcoSpold1 dataset: no exchange found"
-            else Right (pack activity)
+        -- truncated XML the SAX fold walked through without complaint. A
+        -- dataset whose every exchange was left out is a different story and
+        -- says so: the reading is the reason, and the only thing a reader can
+        -- act on, so it travels on the refusal rather than dying on the branch
+        -- 'pdWarnings' never reaches.
+        case (exchanges activity, unreadableAmountsSeen st) of
+            (_ : _, _) -> Right (pack activity)
+            ([], []) -> Left "not an EcoSpold1 dataset: no exchange found"
+            ([], reading) -> Left (T.unpack (T.intercalate "; " reading))
 
 -- | Run the shared SAX fold, surfacing any Xeno error as a String.
 foldEcoSpold1 :: BS.ByteString -> Either String ParseState

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -15,7 +15,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V5 as UUID5
-import EcoSpold.Common (ParsedDataset (..), bsToDouble, bsToInt, bsToIntMaybe, bsToText, docSection, isElement, joinParts, nonEmptyText)
+import EcoSpold.Common (ParsedDataset (..), bsToIntMaybe, bsToText, docSection, isElement, joinParts, nonEmptyText)
 import qualified Expr
 import Progress (ProgressLevel (..), reportProgress)
 import SubstanceRegistry (nonEmptyCAS)
@@ -65,14 +65,14 @@ data ElementContext
     | InGeographyShortname
     | InIntermediateExchange !IntermediateData
     | InElementaryExchange !ElementaryData
-    | InGeneralCommentText !Int -- Track index
+    | InGeneralCommentText
     | Other
     deriving (Eq)
 
 -- | Intermediate exchange accumulator
 data IntermediateData = IntermediateData
     { idFlowId :: !Text
-    , idAmount :: !Double
+    , idAmount :: !(Maybe Double)
     , idUnitId :: !Text
     , idFlowName :: !Text
     , idUnitName :: !Text
@@ -91,7 +91,7 @@ data IntermediateData = IntermediateData
 -- | Elementary exchange accumulator
 data ElementaryData = ElementaryData
     { edFlowId :: !Text
-    , edAmount :: !Double
+    , edAmount :: !(Maybe Double)
     , edUnitId :: !Text
     , edFlowName :: !Text
     , edUnitName :: !Text
@@ -363,7 +363,7 @@ mapExchange fi fe = \case
     InElementaryExchange d -> InElementaryExchange (fe d)
     InActivityName -> InActivityName
     InGeographyShortname -> InGeographyShortname
-    InGeneralCommentText i -> InGeneralCommentText i
+    InGeneralCommentText -> InGeneralCommentText
     Other -> Other
 
 -- | Apply per-kind updates to the open exchange accumulator, then pop path+text.
@@ -381,7 +381,7 @@ currentIntermediate st = case psContext st of
     InElementaryExchange _ -> Nothing
     InActivityName -> Nothing
     InGeographyShortname -> Nothing
-    InGeneralCommentText _ -> Nothing
+    InGeneralCommentText -> Nothing
     Other -> Nothing
 
 -- | The currently-open elementary exchange, if any.
@@ -391,13 +391,13 @@ currentElementary st = case psContext st of
     InIntermediateExchange _ -> Nothing
     InActivityName -> Nothing
     InGeographyShortname -> Nothing
-    InGeneralCommentText _ -> Nothing
+    InGeneralCommentText -> Nothing
     Other -> Nothing
 
 -- | Are we inside a @generalComment@ @\<text\>@ element?
 inGeneralComment :: ParseState -> Bool
 inGeneralComment st = case psContext st of
-    InGeneralCommentText _ -> True
+    InGeneralCommentText -> True
     InIntermediateExchange _ -> False
     InElementaryExchange _ -> False
     InActivityName -> False
@@ -555,6 +555,20 @@ missingUnitWarning kind flowId unitNm =
     | T.null unitNm
     ]
 
+{- | An exchange whose @amount@ attribute is not a number states no amount, so
+it is left out of the dataset rather than read as zero. A zero row is
+indistinguishable from a flow the dataset really put at zero, and every score
+drawn from it would undercount without saying so.
+-}
+unreadableAmountWarning :: String -> Text -> [String]
+unreadableAmountWarning kind flowId =
+    [ "[WARNING] Dropping "
+        ++ kind
+        ++ " exchange with flow ID: "
+        ++ T.unpack flowId
+        ++ " - amount missing or not a number"
+    ]
+
 -- | Parse a UUID, treating the empty string as the nil UUID (no warning).
 parseUUIDOrNil :: Text -> (UUID, Maybe String)
 parseUUIDOrNil t
@@ -577,18 +591,22 @@ addBioFlow f st = st{psBioFlows = f : psBioFlows st}
 addWasteFlow :: WasteFlow -> ParseState -> ParseState
 addWasteFlow f st = st{psWasteFlows = f : psWasteFlows st}
 
-{- | Common exchange-close bookkeeping: leave the exchange context, pop the
-path/text, clear pending groups, record the unit and any warnings.
+{- | Leave the exchange context: pop the path/text, clear the pending groups
+and file whatever the reading has to say. The exchange itself contributes
+nothing, which is what closing a dropped one amounts to.
 -}
-finishExchange :: Unit -> [String] -> ParseState -> ParseState
-finishExchange unit warns st =
+leaveExchange :: [String] -> ParseState -> ParseState
+leaveExchange warns st =
     (popText st)
         { psContext = Other
         , psPendingInputGroup = ""
         , psPendingOutputGroup = ""
-        , psUnits = unit : psUnits st
         , psWarnings = warns ++ psWarnings st
         }
+
+-- | Leave the exchange context, recording the unit it named.
+finishExchange :: Unit -> [String] -> ParseState -> ParseState
+finishExchange unit warns st = (leaveExchange warns st){psUnits = unit : psUnits st}
 
 {- | Check exchange @mathematicalRelation@ formulas against the dataset-local
 environment: the dataset's @\<parameter\>@ variables plus every exchange's own
@@ -693,10 +711,10 @@ parseWithXeno xmlContent = do
                 | isElement tagName "activityName" = InActivityName
                 | isElement tagName "shortname" && any (isElement "geography") (psPath cleanState) = InGeographyShortname
                 | isElement tagName "intermediateExchange" =
-                    InIntermediateExchange (IntermediateData "" 0.0 "" "" "" "" "" "" M.empty Nothing M.empty "" "" noProperties)
+                    InIntermediateExchange (IntermediateData "" Nothing "" "" "" "" "" "" M.empty Nothing M.empty "" "" noProperties)
                 | isElement tagName "elementaryExchange" =
-                    InElementaryExchange (ElementaryData "" 0.0 "" "" "" "" "" [] [] M.empty Nothing Nothing "" "")
-                | isElement tagName "text" && any (isElement "generalComment") (psPath cleanState) = InGeneralCommentText 0
+                    InElementaryExchange (ElementaryData "" Nothing "" "" "" "" "" [] [] M.empty Nothing Nothing "" "")
+                | isElement tagName "text" && any (isElement "generalComment") (psPath cleanState) = InGeneralCommentText
                 -- Classification elements: don't switch context. Handled via psTextAccum + psPendingClassSystem.
                 -- Switching context here would destroy InIntermediateExchange when classifications appear inside exchanges.
                 -- DON'T switch context for child elements (synonym, compartment, etc) - keep parent exchange context
@@ -731,7 +749,7 @@ parseWithXeno xmlContent = do
                 InIntermediateExchange idata ->
                     let updated
                             | isElement name "intermediateExchangeId" = idata{idFlowId = bsToText value}
-                            | isElement name "amount" && not isInsideProperty = idata{idAmount = bsToDouble value}
+                            | isElement name "amount" && not isInsideProperty = idata{idAmount = readAmount (bsToText value)}
                             | isElement name "unitId" && not isInsideProperty = idata{idUnitId = bsToText value}
                             | isElement name "inputGroup" = idata{idInputGroup = bsToText value}
                             | isElement name "outputGroup" = idata{idOutputGroup = bsToText value}
@@ -743,7 +761,7 @@ parseWithXeno xmlContent = do
                 InElementaryExchange edata ->
                     let updated
                             | isElement name "elementaryExchangeId" = edata{edFlowId = bsToText value}
-                            | isElement name "amount" && not isInsideProperty = edata{edAmount = bsToDouble value}
+                            | isElement name "amount" && not isInsideProperty = edata{edAmount = readAmount (bsToText value)}
                             | isElement name "unitId" && not isInsideProperty = edata{edUnitId = bsToText value}
                             | isElement name "inputGroup" = edata{edInputGroup = bsToText value}
                             | isElement name "outputGroup" = edata{edOutputGroup = bsToText value}
@@ -752,9 +770,7 @@ parseWithXeno xmlContent = do
                             | isElement name "mathematicalRelation" && not isInsideProperty = edata{edMathRel = bsToText value}
                             | otherwise = edata
                      in onProperty (withLang state{psContext = InElementaryExchange updated})
-                InGeneralCommentText _ ->
-                    let idx = if isElement name "index" then bsToInt value else 0
-                     in withLang state{psContext = InGeneralCommentText idx}
+                InGeneralCommentText -> withLang state
                 _ ->
                     -- Attributes on the <activity> opening tag carry the
                     -- ecospold2 activityType and specialActivityType enums;
@@ -810,137 +826,143 @@ parseWithXeno xmlContent = do
         | isElement tagName "intermediateExchange" =
             case currentIntermediate state of
                 Nothing -> popPath state
-                Just idata ->
-                    let (finalInputGroup, finalOutputGroup) = resolveGroups (idInputGroup idata) (idOutputGroup idata) state
-                        isInput = not (T.null finalInputGroup)
-                        isOutput = T.null finalInputGroup
-                        -- Reference products are identified ONLY by outputGroup="0"; this holds for
-                        -- normal production (positive amount) and waste treatment (negative amount).
-                        -- Negative inputs (e.g. wastewater discharge) are never reference products.
-                        isReferenceProduct = isOutput && finalOutputGroup == "0"
-                        -- The one waste marker EcoSpold2 carries: an intermediateExchange
-                        -- classified (System='By-product classification', Value='Waste'), a waste
-                        -- output that consumers treat via a treatment activity.
-                        isWasteFlow = M.lookup "By-product classification" (idClassifications idata) == Just "Waste"
-                        (flowUUID, flowWarn) = parseUUID (idFlowId idata)
-                        (unitUUID, unitWarn) = parseUUID (idUnitId idata)
-                        (linkUUID, linkWarn) = parseUUIDOrNil (idActivityLinkId idata)
-                        warns =
-                            catMaybes [flowWarn, unitWarn, linkWarn]
-                                ++ missingUnitWarning "intermediate" (idFlowId idata) (idUnitName idata)
-                        techRoleFor
-                            | isReferenceProduct = ReferenceProduct
-                            | isInput = Input
-                            | otherwise = Coproduct
-                        resolvedFlowName = nonBlankOr (idFlowId idata) (idFlowName idata)
-                        unit = mkUnit unitUUID (idUnitName idata)
-                        techExchange =
-                            TechnosphereExchange
-                                { techFlowId = flowUUID
-                                , techAmount = idAmount idata
-                                , techUnitId = unitUUID
-                                , techRole = techRoleFor
-                                , techActivityLinkId = nonNil linkUUID
-                                , techSupplierClaim = maybe ClaimByProduct ClaimById (nonNil linkUUID)
-                                , techLocation = "" -- EcoSpold2: no per-exchange location
-                                , techComment = snd <$> idComment idata
-                                , techPedigree = Nothing
-                                , techShare = Nothing
-                                , techClassification = M.empty
-                                , techProperties = idProperties idata
-                                }
-                        techFlow = TechnosphereFlow flowUUID resolvedFlowName unitUUID (idSynonyms idata) Nothing Nothing
-                        wasteExchange =
-                            WasteExchange
-                                { waFlowId = flowUUID
-                                , waAmount = idAmount idata
-                                , waUnitId = unitUUID
-                                , waIsInput = isInput
-                                , waActivityLinkId = nonNil linkUUID
-                                , waSupplierClaim = maybe ClaimByProduct ClaimById (nonNil linkUUID)
-                                , waLocation = ""
-                                , waComment = snd <$> idComment idata
-                                , waPedigree = Nothing
-                                }
-                        wasteFlow = WasteFlow flowUUID resolvedFlowName unitUUID (idSynonyms idata) Nothing Nothing
-                        -- A waste-classified flow normally routes to the waste axis. The one
-                        -- exception is the reference flow of a waste-treatment / market-for-waste
-                        -- activity: it is itself waste (negative amount, outputGroup="0") yet it
-                        -- IS the reference product. Diverting it to the waste axis leaves the
-                        -- activity with no reference product, so 'applyCutoffStrategy' rejects it
-                        -- and the whole dataset is dropped — silently severing every input that
-                        -- links into the treatment subsystem.
-                        refOnWasteAxis = isWasteFlow && not isReferenceProduct
-                        newRefUnit =
-                            if isReferenceProduct && not (T.null (idUnitName idata))
-                                then Just (idUnitName idata)
-                                else psRefUnit state
-                        formula = ExchangeFormula (nonEmptyText (idVariableName idata)) (nonEmptyText (idMathRel idata))
-                        base = (finishExchange unit warns state){psRefUnit = newRefUnit}
-                     in if refOnWasteAxis
-                            then addExchange wasteExchange formula (addWasteFlow wasteFlow base)
-                            else addExchange techExchange formula (addTechFlow techFlow base)
+                Just idata
+                    | Just amount <- idAmount idata ->
+                        let (finalInputGroup, finalOutputGroup) = resolveGroups (idInputGroup idata) (idOutputGroup idata) state
+                            isInput = not (T.null finalInputGroup)
+                            isOutput = T.null finalInputGroup
+                            -- Reference products are identified ONLY by outputGroup="0"; this holds for
+                            -- normal production (positive amount) and waste treatment (negative amount).
+                            -- Negative inputs (e.g. wastewater discharge) are never reference products.
+                            isReferenceProduct = isOutput && finalOutputGroup == "0"
+                            -- The one waste marker EcoSpold2 carries: an intermediateExchange
+                            -- classified (System='By-product classification', Value='Waste'), a waste
+                            -- output that consumers treat via a treatment activity.
+                            isWasteFlow = M.lookup "By-product classification" (idClassifications idata) == Just "Waste"
+                            (flowUUID, flowWarn) = parseUUID (idFlowId idata)
+                            (unitUUID, unitWarn) = parseUUID (idUnitId idata)
+                            (linkUUID, linkWarn) = parseUUIDOrNil (idActivityLinkId idata)
+                            warns =
+                                catMaybes [flowWarn, unitWarn, linkWarn]
+                                    ++ missingUnitWarning "intermediate" (idFlowId idata) (idUnitName idata)
+                            techRoleFor
+                                | isReferenceProduct = ReferenceProduct
+                                | isInput = Input
+                                | otherwise = Coproduct
+                            resolvedFlowName = nonBlankOr (idFlowId idata) (idFlowName idata)
+                            unit = mkUnit unitUUID (idUnitName idata)
+                            techExchange =
+                                TechnosphereExchange
+                                    { techFlowId = flowUUID
+                                    , techAmount = amount
+                                    , techUnitId = unitUUID
+                                    , techRole = techRoleFor
+                                    , techActivityLinkId = nonNil linkUUID
+                                    , techSupplierClaim = maybe ClaimByProduct ClaimById (nonNil linkUUID)
+                                    , techLocation = "" -- EcoSpold2: no per-exchange location
+                                    , techComment = snd <$> idComment idata
+                                    , techPedigree = Nothing
+                                    , techShare = Nothing
+                                    , techClassification = M.empty
+                                    , techProperties = idProperties idata
+                                    }
+                            techFlow = TechnosphereFlow flowUUID resolvedFlowName unitUUID (idSynonyms idata) Nothing Nothing
+                            wasteExchange =
+                                WasteExchange
+                                    { waFlowId = flowUUID
+                                    , waAmount = amount
+                                    , waUnitId = unitUUID
+                                    , waIsInput = isInput
+                                    , waActivityLinkId = nonNil linkUUID
+                                    , waSupplierClaim = maybe ClaimByProduct ClaimById (nonNil linkUUID)
+                                    , waLocation = ""
+                                    , waComment = snd <$> idComment idata
+                                    , waPedigree = Nothing
+                                    }
+                            wasteFlow = WasteFlow flowUUID resolvedFlowName unitUUID (idSynonyms idata) Nothing Nothing
+                            -- A waste-classified flow normally routes to the waste axis. The one
+                            -- exception is the reference flow of a waste-treatment / market-for-waste
+                            -- activity: it is itself waste (negative amount, outputGroup="0") yet it
+                            -- IS the reference product. Diverting it to the waste axis leaves the
+                            -- activity with no reference product, so 'applyCutoffStrategy' rejects it
+                            -- and the whole dataset is dropped — silently severing every input that
+                            -- links into the treatment subsystem.
+                            refOnWasteAxis = isWasteFlow && not isReferenceProduct
+                            newRefUnit =
+                                if isReferenceProduct && not (T.null (idUnitName idata))
+                                    then Just (idUnitName idata)
+                                    else psRefUnit state
+                            formula = ExchangeFormula (nonEmptyText (idVariableName idata)) (nonEmptyText (idMathRel idata))
+                            base = (finishExchange unit warns state){psRefUnit = newRefUnit}
+                         in if refOnWasteAxis
+                                then addExchange wasteExchange formula (addWasteFlow wasteFlow base)
+                                else addExchange techExchange formula (addTechFlow techFlow base)
+                    | otherwise ->
+                        leaveExchange (unreadableAmountWarning "intermediate" (idFlowId idata)) state
         | isElement tagName "elementaryExchange" =
             case currentElementary state of
                 Nothing -> popPath state
-                Just edata ->
-                    let (finalInputGroup, finalOutputGroup) = resolveGroups (edInputGroup edata) (edOutputGroup edata) state
-                        -- A missing compartment becomes 'Nothing', not an empty 'Compartment ""'
-                        -- sentinel — the latter used to silently collide with method-side empty mediums.
-                        -- A medium the reader cannot place is reported and the
-                        -- compartment dropped, rather than carried as a string
-                        -- nothing downstream can bucket.
-                        mediumReading = case edCompartments edata of
-                            (c : _) | not (T.null c) -> Just (parseMedium c)
-                            _ -> Nothing
-                        mCompName = mediumReading >>= either (const Nothing) Just
-                        subCompartment = case edSubcompartments edata of
-                            (s : _) | not (T.null s) -> Just s
-                            _ -> Nothing
-                        compartment = case (mCompName, subCompartment) of
-                            (Nothing, Nothing) -> Nothing
-                            (Just c, sc) -> Just (Compartment c sc)
-                            (Nothing, Just _) -> Nothing -- sub without medium is meaningless; drop
-                            -- Biosphere direction: prefer inputGroup/outputGroup, else fall back to the
-                            -- compartment heuristic (natural-resource flows are extractions).
-                            -- An inventory indicator is the exception: it counts what the activity
-                            -- sends away, and a source writes the same indicator under both groups
-                            -- from one dataset to the next, so the group is not information. Reading
-                            -- it would make the direction of a flow depend on which dataset one
-                            -- happens to look at, and cost the writers that reconstruct direction
-                            -- from the compartment their round-trip.
-                        direction
-                            | isInventoryIndicator = Emission
-                            | not (T.null finalInputGroup) = Resource
-                            | not (T.null finalOutputGroup) = Emission
-                            | mCompName == Just NaturalResource = Resource
-                            | otherwise = Emission
-                        isInventoryIndicator = mCompName == Just InventoryIndicator
-                        (flowUUID, flowWarn) = parseUUID (edFlowId edata)
-                        (unitUUID, unitWarn) = parseUUID (edUnitId edata)
-                        mediumWarn = case mediumReading of
-                            Just (Left got) -> Just (unknownMedium got)
-                            Just (Right _) -> Nothing
-                            Nothing -> Nothing
-                        warns =
-                            catMaybes [flowWarn, unitWarn, mediumWarn]
-                                ++ missingUnitWarning "elementary" (edFlowId edata) (edUnitName edata)
-                        resolvedFlowName = nonBlankOr (edFlowId edata) (edFlowName edata)
-                        unit = mkUnit unitUUID (edUnitName edata)
-                        bioExchange =
-                            BiosphereExchange
-                                { bioFlowId = flowUUID
-                                , bioAmount = edAmount edata
-                                , bioUnitId = unitUUID
-                                , bioDirection = direction
-                                , bioLocation = "" -- EcoSpold2: no per-exchange location
-                                , bioComment = snd <$> edComment edata
-                                , bioPedigree = Nothing
-                                }
-                        bioFlow = BiosphereFlow flowUUID resolvedFlowName unitUUID (edSynonyms edata) (edCAS edata) Nothing compartment
-                        formula = ExchangeFormula (nonEmptyText (edVariableName edata)) (nonEmptyText (edMathRel edata))
-                        base = finishExchange unit warns state
-                     in addExchange bioExchange formula (addBioFlow bioFlow base)
+                Just edata
+                    | Just amount <- edAmount edata ->
+                        let (finalInputGroup, finalOutputGroup) = resolveGroups (edInputGroup edata) (edOutputGroup edata) state
+                            -- A missing compartment becomes 'Nothing', not an empty 'Compartment ""'
+                            -- sentinel — the latter used to silently collide with method-side empty mediums.
+                            -- A medium the reader cannot place is reported and the
+                            -- compartment dropped, rather than carried as a string
+                            -- nothing downstream can bucket.
+                            mediumReading = case edCompartments edata of
+                                (c : _) | not (T.null c) -> Just (parseMedium c)
+                                _ -> Nothing
+                            mCompName = mediumReading >>= either (const Nothing) Just
+                            subCompartment = case edSubcompartments edata of
+                                (s : _) | not (T.null s) -> Just s
+                                _ -> Nothing
+                            compartment = case (mCompName, subCompartment) of
+                                (Nothing, Nothing) -> Nothing
+                                (Just c, sc) -> Just (Compartment c sc)
+                                (Nothing, Just _) -> Nothing -- sub without medium is meaningless; drop
+                                -- Biosphere direction: prefer inputGroup/outputGroup, else fall back to the
+                                -- compartment heuristic (natural-resource flows are extractions).
+                                -- An inventory indicator is the exception: it counts what the activity
+                                -- sends away, and a source writes the same indicator under both groups
+                                -- from one dataset to the next, so the group is not information. Reading
+                                -- it would make the direction of a flow depend on which dataset one
+                                -- happens to look at, and cost the writers that reconstruct direction
+                                -- from the compartment their round-trip.
+                            direction
+                                | isInventoryIndicator = Emission
+                                | not (T.null finalInputGroup) = Resource
+                                | not (T.null finalOutputGroup) = Emission
+                                | mCompName == Just NaturalResource = Resource
+                                | otherwise = Emission
+                            isInventoryIndicator = mCompName == Just InventoryIndicator
+                            (flowUUID, flowWarn) = parseUUID (edFlowId edata)
+                            (unitUUID, unitWarn) = parseUUID (edUnitId edata)
+                            mediumWarn = case mediumReading of
+                                Just (Left got) -> Just (unknownMedium got)
+                                Just (Right _) -> Nothing
+                                Nothing -> Nothing
+                            warns =
+                                catMaybes [flowWarn, unitWarn, mediumWarn]
+                                    ++ missingUnitWarning "elementary" (edFlowId edata) (edUnitName edata)
+                            resolvedFlowName = nonBlankOr (edFlowId edata) (edFlowName edata)
+                            unit = mkUnit unitUUID (edUnitName edata)
+                            bioExchange =
+                                BiosphereExchange
+                                    { bioFlowId = flowUUID
+                                    , bioAmount = amount
+                                    , bioUnitId = unitUUID
+                                    , bioDirection = direction
+                                    , bioLocation = "" -- EcoSpold2: no per-exchange location
+                                    , bioComment = snd <$> edComment edata
+                                    , bioPedigree = Nothing
+                                    }
+                            bioFlow = BiosphereFlow flowUUID resolvedFlowName unitUUID (edSynonyms edata) (edCAS edata) Nothing compartment
+                            formula = ExchangeFormula (nonEmptyText (edVariableName edata)) (nonEmptyText (edMathRel edata))
+                            base = finishExchange unit warns state
+                         in addExchange bioExchange formula (addBioFlow bioFlow base)
+                    | otherwise ->
+                        leaveExchange (unreadableAmountWarning "elementary" (edFlowId edata)) state
         | isElement tagName "text" =
             if inGeneralComment state
                 then
@@ -971,7 +993,7 @@ parseWithXeno xmlContent = do
                     InElementaryExchange _ -> state
                     InActivityName -> state
                     InGeographyShortname -> state
-                    InGeneralCommentText _ -> state
+                    InGeneralCommentText -> state
                     Other -> state
              in (popText filed){psPendingProperty = emptyPendingProperty}
         | isElement tagName "synonym" =

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -7,6 +7,7 @@ module EcoSpold.Parser2 (streamParseActivityAndFlowsFromFile) where
 import Amount (readAmount)
 import Data.Bifunctor (first)
 import qualified Data.ByteString as BS
+import Data.List (intercalate)
 import qualified Data.Map as M
 import Data.Maybe (catMaybes, fromMaybe, isNothing, listToMaybe)
 import qualified Data.Set as S
@@ -1099,10 +1100,15 @@ parseWithXeno xmlContent = do
                     , activityFormulaCheck = formulaCheck
                     }
          in -- A file that yields no exchange at all is not a dataset: a stray or
-            -- truncated XML the SAX fold walked through without complaint.
-            if null (exchanges activity)
-                then Left "not an EcoSpold2 dataset: no exchange found"
-                else
+            -- truncated XML the SAX fold walked through without complaint. A
+            -- dataset whose every exchange was left out is a different story and
+            -- says so: the reading is the reason, and the only thing a reader can
+            -- act on, so it travels on the refusal rather than dying on the branch
+            -- 'pdWarnings' never reaches.
+            case (exchanges activity, reverse (psWarnings st)) of
+                ([], []) -> Left "not an EcoSpold2 dataset: no exchange found"
+                ([], reading) -> Left (intercalate "; " reading)
+                (_ : _, _) ->
                     Right
                         ParsedDataset
                             { pdActivity = activity

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -4,6 +4,7 @@
 module EcoSpold1Spec (spec) where
 
 import qualified Data.ByteString.Char8 as BC
+import Data.List (isInfixOf)
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -469,6 +470,32 @@ unreadableAmountXml =
         , "</ecoSpold>"
         ]
 
+{- | A dataset whose only exchange states a meanValue that is not a number,
+so leaving the row out leaves the dataset with none.
+-}
+everyAmountUnreadableXml :: BC.ByteString
+everyAmountUnreadableXml =
+    BC.unlines
+        [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold01\">"
+        , "  <dataset number=\"8\">"
+        , "    <metaInformation>"
+        , "      <processInformation>"
+        , "        <referenceFunction name=\"heat production\" category=\"Energy\""
+        , "                           subCategory=\"Heat\" unit=\"MJ\"/>"
+        , "        <geography location=\"FR\" />"
+        , "      </processInformation>"
+        , "    </metaInformation>"
+        , "    <flowData>"
+        , "      <exchange number=\"1\" name=\"heat, district\" category=\"Energy\""
+        , "                subCategory=\"Heat\" unit=\"MJ\" meanValue=\"n/a\">"
+        , "        <outputGroup>0</outputGroup>"
+        , "      </exchange>"
+        , "    </flowData>"
+        , "  </dataset>"
+        , "</ecoSpold>"
+        ]
+
 -- ---------------------------------------------------------------------------
 -- Spec
 -- ---------------------------------------------------------------------------
@@ -820,3 +847,13 @@ spec = do
                 Right ParsedDataset{pdBioFlows = bios, pdWarnings = warns} -> do
                     length bios `shouldBe` 0
                     warns `shouldSatisfy` any (T.isInfixOf "Carbon dioxide, fossil")
+
+        it "refuses a dataset it emptied with the reading, not with no exchange found" $
+            -- The reading only ever rode on pdWarnings, which the caller
+            -- reads on the Right branch alone. A dataset left with nothing
+            -- would otherwise be refused for a reason that is not the one.
+            case parseWithXeno everyAmountUnreadableXml of
+                Right _ -> expectationFailure "expected the emptied dataset to be refused"
+                Left err -> do
+                    err `shouldSatisfy` isInfixOf "heat, district"
+                    err `shouldNotSatisfy` isInfixOf "no exchange found"

--- a/test/EcoSpold1Spec.hs
+++ b/test/EcoSpold1Spec.hs
@@ -439,6 +439,36 @@ withDocumented k = case parseWithXeno documentedXml of
     Left err -> expectationFailure $ "Parse failed: " ++ err
     Right ParsedDataset{pdActivity = act} -> k act
 
+{- | A dataset whose emission states a meanValue that is not a number. The row
+states no amount at all, so nothing here can say what it should be read as.
+-}
+unreadableAmountXml :: BC.ByteString
+unreadableAmountXml =
+    BC.unlines
+        [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        , "<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold01\">"
+        , "  <dataset number=\"7\">"
+        , "    <metaInformation>"
+        , "      <processInformation>"
+        , "        <referenceFunction name=\"heat production\" category=\"Energy\""
+        , "                           subCategory=\"Heat\" unit=\"MJ\"/>"
+        , "        <geography location=\"FR\" />"
+        , "      </processInformation>"
+        , "    </metaInformation>"
+        , "    <flowData>"
+        , "      <exchange number=\"1\" name=\"heat, district\" category=\"Energy\""
+        , "                subCategory=\"Heat\" unit=\"MJ\" meanValue=\"1.0\">"
+        , "        <outputGroup>0</outputGroup>"
+        , "      </exchange>"
+        , "      <exchange number=\"2\" name=\"Carbon dioxide, fossil\" category=\"air\""
+        , "                subCategory=\"low population density\" unit=\"kg\" meanValue=\"n/a\">"
+        , "        <outputGroup>4</outputGroup>"
+        , "      </exchange>"
+        , "    </flowData>"
+        , "  </dataset>"
+        , "</ecoSpold>"
+        ]
+
 -- ---------------------------------------------------------------------------
 -- Spec
 -- ---------------------------------------------------------------------------
@@ -776,3 +806,17 @@ spec = do
                 Right ParsedDataset{pdBioFlows = bios, pdWarnings = warns} -> do
                     map bfCompartment bios `shouldBe` [Nothing]
                     warns `shouldSatisfy` any (T.isInfixOf "Luft")
+
+    describe "an exchange whose meanValue is not a number" $ do
+        it "reads the rest of the dataset rather than failing the whole load" $
+            case parseWithXeno unreadableAmountXml of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right ParsedDataset{pdActivity = act} ->
+                    map exchangeAmount (exchanges act) `shouldBe` [1.0]
+
+        it "leaves the row out and names it, rather than reading it as zero" $
+            case parseWithXeno unreadableAmountXml of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right ParsedDataset{pdBioFlows = bios, pdWarnings = warns} -> do
+                    length bios `shouldBe` 0
+                    warns `shouldSatisfy` any (T.isInfixOf "Carbon dioxide, fossil")

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -423,6 +423,59 @@ spec = describe "per-exchange comments" $ do
                 sectionNamed "Sampling procedure" act `shouldBe` Just "Test sampling"
                 sectionNamed "Extrapolations" act `shouldBe` Just "Test extrapolation"
 
+    describe "an exchange whose amount is not a number" $ do
+        let runOnBytes bytes = withSystemTempDirectory "es2-amount" $ \dir -> do
+                let path = dir </> "12345678-1234-5678-9abc-123456789001_12345678-1234-5678-9abc-123456789002.spold"
+                BS.writeFile path bytes
+                streamParseActivityAndFlowsFromFile path
+
+        it "reads the rest of the dataset rather than failing the whole load" $ do
+            result <- runOnBytes unreadableAmountXml
+            case result of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right parsed ->
+                    map exchangeAmount (exchanges (pdActivity parsed)) `shouldBe` [1.0]
+
+        it "leaves the row out and names it, rather than reading it as zero" $ do
+            result <- runOnBytes unreadableAmountXml
+            case result of
+                Left err -> expectationFailure $ "Parse failed: " ++ err
+                Right parsed -> do
+                    length (pdBioFlows parsed) `shouldBe` 0
+                    pdWarnings parsed
+                        `shouldSatisfy` any (T.isInfixOf "cccccccc-cccc-cccc-cccc-cccccccccccc")
+
+{- | A dataset whose emission states an amount that is not a number. The row
+states no amount at all, so nothing here can say what it should be read as.
+-}
+unreadableAmountXml :: BS.ByteString
+unreadableAmountXml =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+    \<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold02\">\n\
+    \  <activityDataset>\n\
+    \    <activityDescription>\n\
+    \      <activity id=\"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\" activityNameId=\"amount-test\" activityType=\"1\">\n\
+    \        <activityName xml:lang=\"en\">amount test activity</activityName>\n\
+    \      </activity>\n\
+    \      <geography geographyId=\"TEST\"><shortname xml:lang=\"en\">TEST</shortname></geography>\n\
+    \    </activityDescription>\n\
+    \    <flowData>\n\
+    \      <intermediateExchange id=\"ref\" unitId=\"unit-kg\" amount=\"1.0\"\n\
+    \                           intermediateExchangeId=\"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb\">\n\
+    \        <name xml:lang=\"en\">amount test product</name>\n\
+    \        <unitName xml:lang=\"en\">kg</unitName>\n\
+    \        <outputGroup>0</outputGroup>\n\
+    \      </intermediateExchange>\n\
+    \      <elementaryExchange id=\"emission\" unitId=\"unit-kg\" amount=\"n/a\"\n\
+    \                          elementaryExchangeId=\"cccccccc-cccc-cccc-cccc-cccccccccccc\">\n\
+    \        <name xml:lang=\"en\">Carbon dioxide, fossil</name>\n\
+    \        <unitName xml:lang=\"en\">kg</unitName>\n\
+    \        <outputGroup>4</outputGroup>\n\
+    \      </elementaryExchange>\n\
+    \    </flowData>\n\
+    \  </activityDataset>\n\
+    \</ecoSpold>\n"
+
 {- | Synthetic dataset in the shape a real ecoinvent file uses: every free text
 wrapped in @\<comment\>\<text\>@, a published source spread over three
 attributes, one review with details, and one @[System]@ review whose only

--- a/test/EcoSpold2Spec.hs
+++ b/test/EcoSpold2Spec.hs
@@ -445,6 +445,42 @@ spec = describe "per-exchange comments" $ do
                     pdWarnings parsed
                         `shouldSatisfy` any (T.isInfixOf "cccccccc-cccc-cccc-cccc-cccccccccccc")
 
+        it "refuses a dataset it emptied with the reading, not with no exchange found" $ do
+            -- The reading only ever rode on pdWarnings, which the caller
+            -- reads on the Right branch alone. A dataset left with nothing
+            -- would otherwise be refused for a reason that is not the one.
+            result <- runOnBytes everyAmountUnreadableXml
+            case result of
+                Right _ -> expectationFailure "expected the emptied dataset to be refused"
+                Left err -> do
+                    err `shouldSatisfy` isInfixOf "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+                    err `shouldNotSatisfy` isInfixOf "no exchange found"
+
+{- | A dataset whose only exchange states an amount that is not a number, so
+leaving the row out leaves the dataset with none.
+-}
+everyAmountUnreadableXml :: BS.ByteString
+everyAmountUnreadableXml =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+    \<ecoSpold xmlns=\"http://www.EcoInvent.org/EcoSpold02\">\n\
+    \  <activityDataset>\n\
+    \    <activityDescription>\n\
+    \      <activity id=\"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\" activityNameId=\"amount-test\" activityType=\"1\">\n\
+    \        <activityName xml:lang=\"en\">amount test activity</activityName>\n\
+    \      </activity>\n\
+    \      <geography geographyId=\"TEST\"><shortname xml:lang=\"en\">TEST</shortname></geography>\n\
+    \    </activityDescription>\n\
+    \    <flowData>\n\
+    \      <intermediateExchange id=\"ref\" unitId=\"unit-kg\" amount=\"n/a\"\n\
+    \                           intermediateExchangeId=\"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb\">\n\
+    \        <name xml:lang=\"en\">amount test product</name>\n\
+    \        <unitName xml:lang=\"en\">kg</unitName>\n\
+    \        <outputGroup>0</outputGroup>\n\
+    \      </intermediateExchange>\n\
+    \    </flowData>\n\
+    \  </activityDataset>\n\
+    \</ecoSpold>\n"
+
 {- | A dataset whose emission states an amount that is not a number. The row
 states no amount at all, so nothing here can say what it should be read as.
 -}


### PR DESCRIPTION
## The problem

`EcoSpold.Common` exported two helpers that call `error`: `bsToDouble` and
`bsToInt`. Both parsers read an exchange amount through the first one, from
inside a pure SAX fold, so a single `meanValue="n/a"` or `amount="n/a"`
anywhere in a file aborted the whole load rather than the one row carrying it.
The repair that suggests itself is equally forbidden here: a row read as zero
cannot be told apart from a flow the dataset really put at zero, so every score
drawn from it would undercount and nothing would say so.

## The solution as the diff leaves it

- The amount an exchange states is a `Maybe Double` in all three accumulators
  (`ExchangeData`, `IntermediateData`, `ElementaryData`), read through
  `Amount.readAmount`. That is already how the `<property>` and `<parameter>`
  accumulators sitting next to them read theirs.
- A row that states no amount a reader can make sense of is left out of the
  dataset and named in that dataset's reading. EcoSpold 2 files the line in the
  `psWarnings` it already carries; EcoSpold 1 collects the row names per dataset
  and derives one line the way it already derives the compartments it could not
  place. Both end up in `pdWarnings`, which `reportReading` sends to the
  progress log as warnings.
- `InGeneralCommentText` carried an `Int` index written from `bsToInt` and read
  by nothing: every other site matched it with `_`. The payload is gone, and
  with it the only call.
- `bsToDouble` and `bsToInt` are deleted and unexported. `bsToIntMaybe`, the
  total counterpart the module already documented, stays.
- Two spec groups, one per format, feed a fragment whose second exchange carries
  a non-numeric amount and check that the reading survives, that the row is not
  there, and that the warnings name it.

## Remarks

**The shape chosen, and the one rejected.** Three readings were possible for a
row that states no number: keep it at zero, drop the row and say so, or refuse
the whole dataset. Zero is out, for the reason above. Refusing the dataset was
the real alternative, and it loses more than it saves: the row is one flow,
while the dataset is an activity that every consumer links to, and severing it
takes a whole subsystem out of everyone's supply chain with nothing named. The
file already reasons this way in two places, one of them in prose: a
`<parameter>` with no usable amount is dropped with a warning, and the comment
on `refOnWasteAxis` spells out why losing a dataset is the worse outcome. So
the row goes and the reading names it.

**A silent zero left standing, deliberately.** `exNumber` and `psDatasetNumber`
still read `fromMaybe 0 (bsToIntMaybe value)`, and that zero is not reported. It
is not the same case: zero there is the format's own reading of "this row is
unnumbered", a supplier claim rather than a quantity, and a dataset that
legitimately carries no number reads identically. Making that visible is worth
doing and is a different subject from this one.

**A dataset the drop empties is refused with the reading, not with the wrong
reason.** The reading only ever rode on `pdWarnings`, which the caller reads
on the `Right` branch alone. A file whose every exchange stated no readable
amount therefore came back as "no exchange found", which is false: there were
exchanges, and every one was left out. Both `buildResult` functions now put
the reading on the refusal, and a dataset that genuinely held no exchange
still answers as before, so the two stay distinguishable.

## How to test

```
./gen-version.sh
./build.sh --test
```

or the two new groups alone:

```
cabal test lca-tests --test-options="--match /an exchange whose/"
```

Reverting either parser hunk turns both "reads the rest of the dataset" cases
into a crash inside the fold. Making the emptied-dataset arm answer "no
exchange found" again fails "refuses a dataset it emptied with the reading"
in both specs.

