### PR TITLE
Refuse a demand vector for a process the index does not hold

### DIFF
--- a/src/Matrix.hs
+++ b/src/Matrix.hs
@@ -477,17 +477,19 @@ The caller must supply a 'MatrixFactorization' — typically obtained from
 would re-factorize per demand vector (~2 s each on Ecoinvent), defeating
 the point of batching.
 
-Precondition: every ProcessId must resolve against 'dbActivityIndex'. Callers
-should validate with 'Service.resolveActivityAndProcessId' first —
-'buildDemandVectorFromIndex' crashes on an out-of-range id.
+Every ProcessId must name a column of 'dbActivityIndex'; the batch is refused
+as a whole, naming the first that does not. Callers resolve with
+'Service.resolveActivityAndProcessId', which clears the same bound.
 -}
-computeInventoryMatrixBatch :: Database -> MatrixFactorization -> [ProcessId] -> IO [Inventory]
-computeInventoryMatrixBatch _ _ [] = pure []
-computeInventoryMatrixBatch db fact pids = do
-    let activityIndex = dbActivityIndex db
-        demandVecs = map (buildDemandVectorFromIndex activityIndex) pids
-    scalingVecs <- solveSparseLinearSystemWithFactorizationMulti fact (coerce demandVecs)
-    mapConcurrently (\x -> evaluate $! applyBiosphereMatrix db x) scalingVecs
+computeInventoryMatrixBatch :: Database -> MatrixFactorization -> [ProcessId] -> IO (Either Text [Inventory])
+computeInventoryMatrixBatch _ _ [] = pure (Right [])
+computeInventoryMatrixBatch db fact pids =
+    either (pure . Left) solveAll (traverse (buildDemandVectorFromIndex (dbActivityIndex db)) pids)
+  where
+    solveAll :: [Demand] -> IO (Either Text [Inventory])
+    solveAll demandVecs = do
+        scalingVecs <- solveSparseLinearSystemWithFactorizationMulti fact (coerce demandVecs)
+        Right <$> mapConcurrently (\x -> evaluate $! applyBiosphereMatrix db x) scalingVecs
 
 {- |
 Solve the fundamental LCA equation (I - A) * x = b using MUMPS direct solver.
@@ -549,13 +551,17 @@ Compute the scaling vector by solving (I - A)x = d.
 Returns the supply vector where x[i] is the scaling factor for activity i
 (how much of activity i is needed to produce one unit of the root activity).
 -}
-computeScalingVector :: Database -> ProcessId -> IO Vector
-computeScalingVector db rootProcessId = do
-    let activityCount = dbActivityCount db
-        techTriples = dbTechnosphereTriples db
-        activityIndex = dbActivityIndex db
-        demandVec = buildDemandVectorFromIndex activityIndex rootProcessId
-    solveSparseLinearSystem [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList techTriples] (fromIntegral activityCount) (unDemand demandVec)
+computeScalingVector :: Database -> ProcessId -> IO (Either Text Vector)
+computeScalingVector db rootProcessId =
+    either (pure . Left) solve (buildDemandVectorFromIndex (dbActivityIndex db) rootProcessId)
+  where
+    solve :: Demand -> IO (Either Text Vector)
+    solve demandVec =
+        Right
+            <$> solveSparseLinearSystem
+                [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList (dbTechnosphereTriples db)]
+                (fromIntegral (dbActivityCount db))
+                (unDemand demandVec)
 
 {- |
 Apply the biosphere matrix to a scaling vector: g = B * x.
@@ -593,9 +599,9 @@ applyBiosphereMatrix db supplyVec =
             , i < invLen
             ]
 
-computeInventoryMatrix :: Database -> ProcessId -> IO Inventory
+computeInventoryMatrix :: Database -> ProcessId -> IO (Either Text Inventory)
 computeInventoryMatrix db rootProcessId =
-    applyBiosphereMatrix db <$> computeScalingVector db rootProcessId
+    fmap (applyBiosphereMatrix db) <$> computeScalingVector db rootProcessId
 
 {- |
 Per-process LCIA contributions for one impact category.
@@ -960,15 +966,26 @@ Build the final demand vector f for LCA calculations.
 The demand vector represents external demand for products from each activity:
 - f[i] = 1.0 for the root activity (functional unit)
 - f[i] = 0.0 for all other activities
+
+A process id the index does not hold names no column, so there is no vector
+to build and the caller is told. A vector of zeros would solve to an
+inventory of zeros and be reported as an answer.
 -}
-buildDemandVectorFromIndex :: V.Vector Int32 -> ProcessId -> Demand
+buildDemandVectorFromIndex :: V.Vector Int32 -> ProcessId -> Either Text Demand
 buildDemandVectorFromIndex activityIndex rootProcessId =
-    let n = V.length activityIndex
-        rootIndex =
-            if fromIntegral rootProcessId >= (0 :: Int) && fromIntegral rootProcessId < n
-                then fromIntegral $ activityIndex V.! fromIntegral rootProcessId
-                else error $ "FATAL: ProcessId not found in activity index: " ++ show rootProcessId
-     in Demand $ fromList [if i == rootIndex then 1.0 else 0.0 | i <- [0 .. n - 1 :: Int]]
+    maybe (Left noColumn) (Right . loadColumn) (activityIndex V.!? fromIntegral rootProcessId)
+  where
+    n :: Int
+    n = V.length activityIndex
+    loadColumn :: Int32 -> Demand
+    loadColumn col = Demand $ fromList [if i == fromIntegral col then 1.0 else 0.0 | i <- [0 .. n - 1 :: Int]]
+    noColumn :: Text
+    noColumn =
+        "ProcessId "
+            <> T.pack (show rootProcessId)
+            <> " is not in the activity index ("
+            <> T.pack (show n)
+            <> " processes), so it names no column to put the functional unit in"
 
 {- |
 Pre-compute matrix factorization for concurrent inventory calculations.

--- a/src/Matrix/Export.hs
+++ b/src/Matrix/Export.hs
@@ -14,7 +14,7 @@ module Matrix.Export (
 ) where
 
 import Database (filterByName, flowSearchFields)
-import Matrix (Demand (..), applySparseMatrix, buildDemandVectorFromIndex, solveSparseLinearSystem, toList)
+import Matrix (Demand (..), Vector, applySparseMatrix, buildDemandVectorFromIndex, solveSparseLinearSystem, toList)
 import Progress (ProgressLevel (..), reportProgress)
 import Types
 
@@ -55,59 +55,65 @@ row it is, which is the row the caller resolved: an activity UUID would have to
 be resolved again here, and would answer with an arbitrary product of an
 activity written as several coproduct rows.
 -}
-extractMatrixDebugInfo :: Database -> ProcessId -> Maybe Text -> IO MatrixDebugInfo
-extractMatrixDebugInfo database targetProcessId flowFilter = do
-    let activities = dbActivities database
-        bioFlows = dbBioFlows database
-        techTriples = dbTechnosphereTriples database
-        bioTriples = dbBiosphereTriples database
-        activityIndexVec = dbActivityIndex database
-        bioFlowUUIDs = dbBiosphereOrder database
-        activityCount = dbActivityCount database
-        bioFlowCount = dbBiosphereCount database
+extractMatrixDebugInfo :: Database -> ProcessId -> Maybe Text -> IO (Either Text MatrixDebugInfo)
+extractMatrixDebugInfo database targetProcessId flowFilter =
+    either
+        (pure . Left)
+        (fmap Right . withDemand . unDemand)
+        (buildDemandVectorFromIndex (dbActivityIndex database) targetProcessId)
+  where
+    withDemand :: Vector -> IO MatrixDebugInfo
+    withDemand demandVec = do
+        let activities = dbActivities database
+            bioFlows = dbBioFlows database
+            techTriples = dbTechnosphereTriples database
+            bioTriples = dbBiosphereTriples database
+            activityIndexVec = dbActivityIndex database
+            bioFlowUUIDs = dbBiosphereOrder database
+            activityCount = dbActivityCount database
+            bioFlowCount = dbBiosphereCount database
 
-        demandVec = unDemand (buildDemandVectorFromIndex activityIndexVec targetProcessId)
-        demandList = toList demandVec
+            demandList = toList demandVec
 
-        techTriplesInt = [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList techTriples]
-        activityCountInt = fromIntegral activityCount
+            techTriplesInt = [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList techTriples]
+            activityCountInt = fromIntegral activityCount
 
-    supplyVec <- solveSparseLinearSystem techTriplesInt activityCountInt demandVec
-    let supplyList = toList supplyVec
+        supplyVec <- solveSparseLinearSystem techTriplesInt activityCountInt demandVec
+        let supplyList = toList supplyVec
 
-        bioTriplesInt = [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList bioTriples]
-        bioFlowCountInt = fromIntegral bioFlowCount
-        inventoryVec = applySparseMatrix bioTriplesInt bioFlowCountInt supplyVec
-        inventoryList = toList inventoryVec
+            bioTriplesInt = [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList bioTriples]
+            bioFlowCountInt = fromIntegral bioFlowCount
+            inventoryVec = applySparseMatrix bioTriplesInt bioFlowCountInt supplyVec
+            inventoryList = toList inventoryVec
 
-        filteredBioTriples = case flowFilter of
-            Nothing -> bioTriples
-            Just filterText ->
-                -- The filter read the way a flow search reads a query: the
-                -- words in any order, punctuation of the name left to the name.
-                let candidates =
-                        [ (idx, flow)
-                        | (uuid, idx) <- zip (V.toList bioFlowUUIDs) ([0 ..] :: [Int])
-                        , Just flow <- [M.lookup uuid bioFlows]
-                        ]
-                    matchingFlowIndices =
-                        map fst (filterByName filterText (flowSearchFields . BioKind . snd) candidates)
-                    matchingFlowIndicesInt32 = map fromIntegral matchingFlowIndices :: [Int32]
-                 in U.filter (\(SparseTriple row _ _) -> row `elem` matchingFlowIndicesInt32) bioTriples
-    return
-        MatrixDebugInfo
-            { mdActivities = activities
-            , mdBioFlows = bioFlows
-            , mdTechTriples = techTriples
-            , mdBioTriples = filteredBioTriples
-            , mdActivityIndex = activityIndexVec
-            , mdBioFlowUUIDs = bioFlowUUIDs
-            , mdTargetProcessId = targetProcessId
-            , mdDatabase = database
-            , mdSupplyVector = supplyList
-            , mdDemandVector = demandList
-            , mdInventoryVector = inventoryList
-            }
+            filteredBioTriples = case flowFilter of
+                Nothing -> bioTriples
+                Just filterText ->
+                    -- The filter read the way a flow search reads a query: the
+                    -- words in any order, punctuation of the name left to the name.
+                    let candidates =
+                            [ (idx, flow)
+                            | (uuid, idx) <- zip (V.toList bioFlowUUIDs) ([0 ..] :: [Int])
+                            , Just flow <- [M.lookup uuid bioFlows]
+                            ]
+                        matchingFlowIndices =
+                            map fst (filterByName filterText (flowSearchFields . BioKind . snd) candidates)
+                        matchingFlowIndicesInt32 = map fromIntegral matchingFlowIndices :: [Int32]
+                     in U.filter (\(SparseTriple row _ _) -> row `elem` matchingFlowIndicesInt32) bioTriples
+        return
+            MatrixDebugInfo
+                { mdActivities = activities
+                , mdBioFlows = bioFlows
+                , mdTechTriples = techTriples
+                , mdBioTriples = filteredBioTriples
+                , mdActivityIndex = activityIndexVec
+                , mdBioFlowUUIDs = bioFlowUUIDs
+                , mdTargetProcessId = targetProcessId
+                , mdDatabase = database
+                , mdSupplyVector = supplyList
+                , mdDemandVector = demandList
+                , mdInventoryVector = inventoryList
+                }
 
 -- | Export matrix debug CSVs
 exportMatrixDebugCSVs :: FilePath -> MatrixDebugInfo -> IO ()

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -231,6 +231,14 @@ validateProcessIdInMatrixIndex db processId =
                         <> T.pack (show processId)
                         <> ". This activity may exist in the database but is not indexed for inventory calculations."
 
+{- | The demand vector that puts the functional unit on @processId@, with the
+builder's refusal carried as the matrix error it is. A process id that reached
+here without being resolved is the only way to get a 'Left'.
+-}
+demandFor :: Database -> ProcessId -> Either ServiceError Demand
+demandFor db processId =
+    either (Left . MatrixError) Right (buildDemandVectorFromIndex (dbActivityIndex db) processId)
+
 -- | Rich activity info (returns same format as API)
 getActivityInfo :: Database -> Text -> Either ServiceError Value
 getActivityInfo db queryText = do
@@ -334,10 +342,12 @@ getActivityInventory db processIdText =
     case resolveScorable db processIdText >>= \(pid, act) -> validateProcessIdInMatrixIndex db pid >> Right (pid, act) of
         Left err -> return $ Left err
         Right (processId, activity) -> do
-            -- Matrix computation (will not fail if validation passed)
-            inventory <- computeInventoryMatrix db processId
-            let !inventoryExport = convertToInventoryExport db (dbBioFlows db) (dbUnits db) processId activity inventory
-            return $ Right $ toJSON inventoryExport
+            inventoryE <- computeInventoryMatrix db processId
+            return $ case inventoryE of
+                Left err -> Left (MatrixError err)
+                Right inventory ->
+                    let !inventoryExport = convertToInventoryExport db (dbBioFlows db) (dbUnits db) processId activity inventory
+                     in Right (toJSON inventoryExport)
 
 {- | The nodes and edges a tree walk has reached so far. Threaded through the
 walk in visit order and never combined out of it: a node id can be inserted
@@ -704,10 +714,10 @@ Uses efficient sparse matrix operations to extract connections.
 -}
 buildActivityGraph :: Database -> SharedSolver -> Text -> Double -> IO (Either ServiceError GraphExport)
 buildActivityGraph db sharedSolver queryText cutoffPercent =
-    case resolveActivityAndProcessId db queryText of
+    case resolveActivityAndProcessId db queryText >>= \(pid, _) -> (,) pid <$> demandFor db pid of
         Left err -> pure (Left err)
-        Right (processId, _activity) -> do
-            supplyVec <- solveWithSharedSolver sharedSolver (buildDemandVectorFromIndex (dbActivityIndex db) processId)
+        Right (processId, demandVec) -> do
+            supplyVec <- solveWithSharedSolver sharedSolver demandVec
             let supplyList = toList supplyVec
                 threshold = sum (map abs supplyList) * (cutoffPercent / 100.0)
                 significantActivities = selectSignificantActivities threshold processId supplyList
@@ -1669,11 +1679,11 @@ getSupplyChain unitCfg geographies depLookup db dbName sharedSolver processIdTex
     case resolveScorable db processIdText of
         Left err -> return $ Left err
         Right (processId, _rootActivity) ->
-            case validateProcessIdInMatrixIndex db processId of
+            -- Building the demand vector is the matrix-index check: an id with
+            -- no column is refused here, by name.
+            case demandFor db processId of
                 Left err -> return $ Left err
-                Right () -> do
-                    let activityIndex = dbActivityIndex db
-                        demandVec = buildDemandVectorFromIndex activityIndex processId
+                Right demandVec -> do
                     supplyVec <- solveWithSharedSolver sharedSolver demandVec
                     buildSupplyChainFromScalingVectorCrossDB
                         unitCfg
@@ -2239,12 +2249,10 @@ computeScalingVectorWithSubstitutions ::
     IO (Either ServiceError (U.Vector Double))
 computeScalingVectorWithSubstitutions db sharedSolver processId subs =
     case subs of
-        [] -> Right <$> solveWithSharedSolver sharedSolver demandVec
+        [] -> either (pure . Left) (fmap Right . solveWithSharedSolver sharedSolver) (demandFor db processId)
         _ ->
             pure . Left . MatrixError $
                 "computeScalingVectorWithSubstitutions: substitutions must be applied via the cross-DB path"
-  where
-    demandVec = buildDemandVectorFromIndex (dbActivityIndex db) processId
 
 {- | Run sensitivity analysis on a process: compute the baseline scaling
 vector @x₀@ once, then resolve every 'Perturbation' to a (consumer column,
@@ -2271,34 +2279,34 @@ computeSensitivities ::
     ProcessId ->
     [Perturbation] ->
     IO (Either ServiceError (U.Vector Double, [(Perturbation, Either Text (U.Vector Double))]))
-computeSensitivities db sharedSolver processId perts = do
-    let activityIndex = dbActivityIndex db
-        demandVec = buildDemandVectorFromIndex activityIndex processId
-    -- The baseline solve and factorization retrieval hit MUMPS through the FFI
-    -- and can throw via exceptions (singular A, allocation failure, …). Wrap
-    -- them so the documented 'Left' branch of the signature is reachable,
-    -- instead of letting raw exceptions escape to the caller.
-    eBaseline <- try @SomeException $ do
-        baselineX <- solveWithSharedSolver sharedSolver demandVec
-        mFact <- getFactorization sharedSolver
-        pure (baselineX, mFact)
-    case eBaseline of
-        Left ex ->
-            pure $
-                Left $
-                    MatrixError $
-                        "baseline solve failed: " <> T.pack (show ex)
-        Right (baselineX, mFact) -> do
-            -- Resolve each perturbation up-front. Resolution errors graft onto
-            -- the final result; resolved specs go to the batch (a Left becomes
-            -- a no-op empty spec so the batch preserves indexing).
-            let resolved = map (resolveSpec db) perts
-            smResults <-
-                perturbABatch db mFact baselineX (map (fromRight (0, [])) resolved)
-            let combined = zipWith3 step perts resolved smResults
-                step p (Left e) _ = (p, Left e)
-                step p (Right _) sm = (p, sm)
-            pure $ Right (baselineX, combined)
+computeSensitivities db sharedSolver processId perts = case demandFor db processId of
+    Left err -> pure (Left err)
+    Right demandVec -> do
+        -- The baseline solve and factorization retrieval hit MUMPS through the FFI
+        -- and can throw via exceptions (singular A, allocation failure, …). Wrap
+        -- them so the documented 'Left' branch of the signature is reachable,
+        -- instead of letting raw exceptions escape to the caller.
+        eBaseline <- try @SomeException $ do
+            baselineX <- solveWithSharedSolver sharedSolver demandVec
+            mFact <- getFactorization sharedSolver
+            pure (baselineX, mFact)
+        case eBaseline of
+            Left ex ->
+                pure $
+                    Left $
+                        MatrixError $
+                            "baseline solve failed: " <> T.pack (show ex)
+            Right (baselineX, mFact) -> do
+                -- Resolve each perturbation up-front. Resolution errors graft onto
+                -- the final result; resolved specs go to the batch (a Left becomes
+                -- a no-op empty spec so the batch preserves indexing).
+                let resolved = map (resolveSpec db) perts
+                smResults <-
+                    perturbABatch db mFact baselineX (map (fromRight (0, [])) resolved)
+                let combined = zipWith3 step perts resolved smResults
+                    step p (Left e) _ = (p, Left e)
+                    step p (Right _) sm = (p, sm)
+                pure $ Right (baselineX, combined)
 
 resolveSpec :: Database -> Perturbation -> Either Text (Int, [(Int, Double)])
 resolveSpec db p = do
@@ -2377,17 +2385,18 @@ inventoryWithSubsAndDeps unitCfg depLookup db rootDbName solver pid subs =
             eValid <- validateAnchorDbs depLookup db rootDb subs
             case eValid of
                 Left e -> pure (Left e)
-                Right () -> do
-                    let demand = buildDemandVectorFromIndex (dbActivityIndex db) pid
-                    res <- goWithSubsAndDeps unitCfg depLookup db (ThisDb rootDbName) rootDb solver [demand] subs 0
-                    pure $ case res of
-                        Left err -> Left err
-                        Right (sol : _) -> Right sol
-                        Right [] ->
-                            -- unreachable: K=1 single-demand always yields one solution.
-                            -- Surface as Left rather than fabricate an empty solution
-                            -- with no 'csScalings' (NonEmpty forbids it).
-                            Left $ MatrixError "inventoryWithSubsAndDeps: empty result for single demand"
+                Right () -> case demandFor db pid of
+                    Left e -> pure (Left e)
+                    Right demand -> do
+                        res <- goWithSubsAndDeps unitCfg depLookup db (ThisDb rootDbName) rootDb solver [demand] subs 0
+                        pure $ case res of
+                            Left err -> Left err
+                            Right (sol : _) -> Right sol
+                            Right [] ->
+                                -- unreachable: K=1 single-demand always yields one solution.
+                                -- Surface as Left rather than fabricate an empty solution
+                                -- with no 'csScalings' (NonEmpty forbids it).
+                                Left $ MatrixError "inventoryWithSubsAndDeps: empty result for single demand"
   where
     rootDb = RootDb rootDbName
 
@@ -2569,15 +2578,16 @@ computeScalingVectorWithSubstitutionsCrossDB unitCfg depLookup db rootDbName sol
                     Left $
                         MatrixError $
                             "substitution consumer must live in root database (got: " <> cDb <> ")"
-            Nothing -> do
-                let demandVec = buildDemandVectorFromIndex (dbActivityIndex db) pid
-                originalX <- solveWithSharedSolver solver demandVec
-                res <- applySubstitutionsAt unitCfg depLookup db (ThisDb rootDbName) rootDb solver [originalX] subs
-                pure $ case res of
-                    Left e -> Left e
-                    Right ([x'], links) -> Right (x', links)
-                    Right (x' : _, links) -> Right (x', links) -- unreachable: K=1
-                    Right ([], _) -> Right (originalX, []) -- unreachable
+            Nothing -> case demandFor db pid of
+                Left e -> pure (Left e)
+                Right demandVec -> do
+                    originalX <- solveWithSharedSolver solver demandVec
+                    res <- applySubstitutionsAt unitCfg depLookup db (ThisDb rootDbName) rootDb solver [originalX] subs
+                    pure $ case res of
+                        Left e -> Left e
+                        Right ([x'], links) -> Right (x', links)
+                        Right (x' : _, links) -> Right (x', links) -- unreachable: K=1
+                        Right ([], _) -> Right (originalX, []) -- unreachable
   where
     rootDb = RootDb rootDbName
     firstNonRootAnchor =
@@ -3124,25 +3134,28 @@ exportMatrixDebugData database processIdText opts = do
     case resolveScorable database processIdText >>= withRef of
         Left err -> return $ Left err
         Right (processId, targetActivity, ref) -> do
-            matrixData <- MatrixExport.extractMatrixDebugInfo database processId (debugFlowFilter opts)
-            let inventoryList = MatrixExport.mdInventoryVector matrixData
-                bioFlowUUIDs = MatrixExport.mdBioFlowUUIDs matrixData
-                inventory = M.fromList $ zip (V.toList bioFlowUUIDs) inventoryList
+            matrixDataE <- MatrixExport.extractMatrixDebugInfo database processId (debugFlowFilter opts)
+            case matrixDataE of
+                Left err -> return $ Left $ MatrixError err
+                Right matrixData -> do
+                    let inventoryList = MatrixExport.mdInventoryVector matrixData
+                        bioFlowUUIDs = MatrixExport.mdBioFlowUUIDs matrixData
+                        inventory = M.fromList $ zip (V.toList bioFlowUUIDs) inventoryList
 
-            Progress.reportProgress Progress.Info $ "DEBUG: Starting CSV export to " ++ debugOutput opts
-            MatrixExport.exportMatrixDebugCSVs (debugOutput opts) matrixData
-            Progress.reportProgress Progress.Info "DEBUG: CSV export completed"
+                    Progress.reportProgress Progress.Info $ "DEBUG: Starting CSV export to " ++ debugOutput opts
+                    MatrixExport.exportMatrixDebugCSVs (debugOutput opts) matrixData
+                    Progress.reportProgress Progress.Info "DEBUG: CSV export completed"
 
-            let summary =
-                    M.fromList
-                        [ ("activity_uuid" :: Text, UUID.toText (prActivity ref))
-                        , ("activity_name" :: Text, activityName targetActivity)
-                        , ("total_inventory_flows" :: Text, T.pack $ show $ M.size inventory)
-                        , ("matrix_debug_exported" :: Text, "CSV_EXPORTED")
-                        , ("supply_chain_file" :: Text, T.pack $ debugOutput opts ++ "_supply_chain.csv")
-                        , ("biosphere_matrix_file" :: Text, T.pack $ debugOutput opts ++ "_biosphere_matrix.csv")
-                        ]
-            return $ Right $ toJSON summary
+                    let summary =
+                            M.fromList
+                                [ ("activity_uuid" :: Text, UUID.toText (prActivity ref))
+                                , ("activity_name" :: Text, activityName targetActivity)
+                                , ("total_inventory_flows" :: Text, T.pack $ show $ M.size inventory)
+                                , ("matrix_debug_exported" :: Text, "CSV_EXPORTED")
+                                , ("supply_chain_file" :: Text, T.pack $ debugOutput opts ++ "_supply_chain.csv")
+                                , ("biosphere_matrix_file" :: Text, T.pack $ debugOutput opts ++ "_biosphere_matrix.csv")
+                                ]
+                    return $ Right $ toJSON summary
   where
     withRef (pid, act) =
         maybe

--- a/src/Service/Aggregate.hs
+++ b/src/Service/Aggregate.hs
@@ -184,22 +184,23 @@ aggregate unitConfig geographies flowDB unitDB db dbName solver depLookup pidTex
             case apScope params of
                 ScopeDirect ->
                     return $ Right $ reduce params (rowsFromDirect db activity)
-                ScopeSupplyChain -> do
-                    let demandVec = buildDemandVectorFromIndex (dbActivityIndex db) processId
-                    supplyVec <- solveWithSharedSolver solver demandVec
-                    let af = emptyFilter (apMaxDepth params)
-                    eResp <-
-                        buildSupplyChainFromScalingVectorCrossDB
-                            unitConfig
-                            geographies
-                            depLookup
-                            db
-                            dbName
-                            processId
-                            supplyVec
-                            []
-                            af
-                    return $ fmap (reduce params . rowsFromSupplyChain) eResp
+                ScopeSupplyChain -> case buildDemandVectorFromIndex (dbActivityIndex db) processId of
+                    Left err -> return (Left (MatrixError err))
+                    Right demandVec -> do
+                        supplyVec <- solveWithSharedSolver solver demandVec
+                        let af = emptyFilter (apMaxDepth params)
+                        eResp <-
+                            buildSupplyChainFromScalingVectorCrossDB
+                                unitConfig
+                                geographies
+                                depLookup
+                                db
+                                dbName
+                                processId
+                                supplyVec
+                                []
+                                af
+                        return $ fmap (reduce params . rowsFromSupplyChain) eResp
                 ScopeBiosphere -> do
                     solE <- computeInventoryMatrixWithDepsCached unitConfig depLookup db dbName solver processId
                     case solE of

--- a/src/Service/Aggregate.hs
+++ b/src/Service/Aggregate.hs
@@ -40,7 +40,7 @@ import API.Types (
     apiFlowName,
  )
 import Database (Geographies)
-import Matrix (activityNormalizationFactor, buildDemandVectorFromIndex)
+import Matrix (activityNormalizationFactor)
 import Service (
     ActivityFilterCore (..),
     Edges (..),
@@ -48,6 +48,7 @@ import Service (
     SupplyChainFilter (..),
     buildSupplyChainFromScalingVectorCrossDB,
     convertToInventoryExport,
+    demandFor,
     getActivityExchangeDetails,
     getReferenceProductAmount,
     getReferenceProductName,
@@ -184,8 +185,8 @@ aggregate unitConfig geographies flowDB unitDB db dbName solver depLookup pidTex
             case apScope params of
                 ScopeDirect ->
                     return $ Right $ reduce params (rowsFromDirect db activity)
-                ScopeSupplyChain -> case buildDemandVectorFromIndex (dbActivityIndex db) processId of
-                    Left err -> return (Left (MatrixError err))
+                ScopeSupplyChain -> case demandFor db processId of
+                    Left err -> return (Left err)
                     Right demandVec -> do
                         supplyVec <- solveWithSharedSolver solver demandVec
                         let af = emptyFilter (apMaxDepth params)

--- a/src/SharedSolver.hs
+++ b/src/SharedSolver.hs
@@ -153,18 +153,21 @@ lazy factorization cache. Same shape as 'Matrix.computeScalingVector' but
 amortizes factorization across every call in a server's lifetime — the
 right default for endpoint handlers.
 -}
-computeScalingVectorCached :: Database -> SharedSolver -> ProcessId -> IO Vector
+computeScalingVectorCached :: Database -> SharedSolver -> ProcessId -> IO (Either Text Vector)
 computeScalingVectorCached db solver pid =
-    solveWithSharedSolver solver (buildDemandVectorFromIndex (dbActivityIndex db) pid)
+    either
+        (pure . Left)
+        (fmap Right . solveWithSharedSolver solver)
+        (buildDemandVectorFromIndex (dbActivityIndex db) pid)
 
 -- | Inventory for @pid@ using the shared-solver factorization cache.
-computeInventoryMatrixCached :: Database -> SharedSolver -> ProcessId -> IO Inventory
+computeInventoryMatrixCached :: Database -> SharedSolver -> ProcessId -> IO (Either Text Inventory)
 computeInventoryMatrixCached db solver pid =
-    applyBiosphereMatrix db <$> computeScalingVectorCached db solver pid
+    fmap (applyBiosphereMatrix db) <$> computeScalingVectorCached db solver pid
 
 -- | Batch inventories for many pids using one MUMPS multi-RHS call against the cached factorization.
-computeInventoryMatrixBatchCached :: Database -> SharedSolver -> [ProcessId] -> IO [Inventory]
-computeInventoryMatrixBatchCached _ _ [] = pure []
+computeInventoryMatrixBatchCached :: Database -> SharedSolver -> [ProcessId] -> IO (Either Text [Inventory])
+computeInventoryMatrixBatchCached _ _ [] = pure (Right [])
 computeInventoryMatrixBatchCached db solver pids = do
     fact <- ensureFactorization solver
     computeInventoryMatrixBatch db fact pids
@@ -236,14 +239,10 @@ computeInventoryMatrixBatchWithDepsCached ::
     IO (Either Text [CrossDBSolution])
 computeInventoryMatrixBatchWithDepsCached _ _ _ _ _ [] = pure (Right [])
 computeInventoryMatrixBatchWithDepsCached unitConfig depLookup db dbName solver pids =
-    goWithDeps
-        unitConfig
-        depLookup
-        db
-        dbName
-        solver
-        (map (buildDemandVectorFromIndex (dbActivityIndex db)) pids)
-        0
+    either
+        (pure . Left)
+        (\demands -> goWithDeps unitConfig depLookup db dbName solver demands 0)
+        (traverse (buildDemandVectorFromIndex (dbActivityIndex db)) pids)
 
 -- | Single-process convenience wrapper. One-element batch.
 computeInventoryMatrixWithDepsCached ::
@@ -426,12 +425,10 @@ crossDBProcessContributions ::
     LongTermMode ->
     IO (Either Text (M.Map (Text, ProcessId) Double))
 crossDBProcessContributions unitConfig unitDB flowDB depLookup rootDb rootName rootSolver rootPid tables ltMode =
-    go
-        rootDb
-        rootName
-        rootSolver
-        [buildDemandVectorFromIndex (dbActivityIndex rootDb) rootPid]
-        0
+    either
+        (pure . Left)
+        (\demand -> go rootDb rootName rootSolver [demand] 0)
+        (buildDemandVectorFromIndex (dbActivityIndex rootDb) rootPid)
   where
     go ::
         Database ->

--- a/test/BrightwayExcelWriterSpec.hs
+++ b/test/BrightwayExcelWriterSpec.hs
@@ -904,7 +904,7 @@ co2Inventory sdb = do
     case built of
         Left err -> pure (Left err)
         Right db -> do
-            inv <- computeInventoryMatrix db 0
+            inv <- either (fail . show) pure =<< computeInventoryMatrix db 0
             pure (Right (lookupCo2 db inv))
   where
     lookupCo2 db inv =

--- a/test/CoalescingSolverSpec.hs
+++ b/test/CoalescingSolverSpec.hs
@@ -58,7 +58,7 @@ spec = do
     describe "single-RHS regression (batch of 1)" $ do
         it "submitOne path produces the oracle result" $ do
             (_solver, fact, db) <- min3CachedSolver
-            let demand = unDemand (buildDemandVectorFromIndex (dbActivityIndex db) 0)
+            demand <- unDemand <$> either (fail . show) pure (buildDemandVectorFromIndex (dbActivityIndex db) 0)
             expected <- oracleSolve db demand
             actual <- solveSparseLinearSystemWithFactorization fact demand
             U.toList actual `shouldSatisfy` closeTo (U.toList expected)
@@ -92,7 +92,7 @@ spec = do
     describe "solve counter" $ do
         it "moves on the cached path, the batch path and the fresh path" $ do
             (_solver, fact, db) <- min3CachedSolver
-            let demand = unDemand (buildDemandVectorFromIndex (dbActivityIndex db) 0)
+            demand <- unDemand <$> either (fail . show) pure (buildDemandVectorFromIndex (dbActivityIndex db) 0)
             before <- readSolveCounter
             _ <- solveSparseLinearSystemWithFactorization fact demand
             afterSingle <- readSolveCounter
@@ -106,7 +106,7 @@ spec = do
     describe "clean shutdown" $ do
         it "clearCachedSolver lets the next request fall back without deadlock" $ do
             (_solver, fact, db) <- min3CachedSolver
-            let demand = unDemand (buildDemandVectorFromIndex (dbActivityIndex db) 0)
+            demand <- unDemand <$> either (fail . show) pure (buildDemandVectorFromIndex (dbActivityIndex db) 0)
             expected <- oracleSolve db demand
             clearCachedSolver cacheKey
             -- After clear, the cache lookup misses and we fall back to a fresh
@@ -133,7 +133,7 @@ min3CachedSolver = do
     db <- loadSampleDatabase "SAMPLE.min3"
     solver <- mkSolverFromDb db cacheKey
     let demand = buildDemandVectorFromIndex (dbActivityIndex db) 0
-    _ <- SS.solveWithSharedSolver solver demand
+    _ <- SS.solveWithSharedSolver solver =<< either (fail . show) pure demand
     Just fact <- SS.getFactorization solver
     pure (solver, fact, db)
 
@@ -142,7 +142,7 @@ Repeating these via 'cycle' gives us many varied (but reproducible) inputs.
 -}
 basicDemands :: Database -> [Vector]
 basicDemands db =
-    let n = U.length (unDemand (buildDemandVectorFromIndex (dbActivityIndex db) 0))
+    let n = fromIntegral (dbActivityCount db)
      in [ unitOn n 0
         , unitOn n 1
         , unitOn n 2

--- a/test/CopySpec.hs
+++ b/test/CopySpec.hs
@@ -132,7 +132,7 @@ spec = around_ withScratchDataDir $ describe "Database.Edit copy primitive" $ do
             copySolver = ldSharedSolver (loaded M.! "mycopy")
 
         -- Force the source solver's lazy factorization via a first solve.
-        _ <- solveWithSharedSolver srcSolver (buildDemandVectorFromIndex (dbActivityIndex srcDb) 0)
+        _ <- solveWithSharedSolver srcSolver =<< either (fail . show) pure (buildDemandVectorFromIndex (dbActivityIndex srcDb) 0)
         -- MatrixFactorization has no Show instance, so assert on the Bool.
         getFactorization srcSolver >>= (`shouldBe` True) . isJust
 

--- a/test/CrossDBInventorySpec.hs
+++ b/test/CrossDBInventorySpec.hs
@@ -136,7 +136,7 @@ spec = do
             let pids = [0]
                 noDeps _ = pure Nothing
 
-            localInvs <- computeInventoryMatrixBatchCached db solver pids
+            localInvs <- either (fail . show) pure =<< computeInventoryMatrixBatchCached db solver pids
             withDepsE <- computeInventoryMatrixBatchWithDepsCached defaultUnitConfig noDeps db "SAMPLE.min3" solver pids
 
             case withDepsE of

--- a/test/EcoSpold1WriterSpec.hs
+++ b/test/EcoSpold1WriterSpec.hs
@@ -431,7 +431,7 @@ buildDb sdb = do
 inventoryByName :: Database -> IO (M.Map Text Double)
 inventoryByName db = do
     let pid = 0 -- single-activity fixture
-    inv <- Matrix.computeInventoryMatrix db pid
+    inv <- either (fail . show) pure =<< Matrix.computeInventoryMatrix db pid
     pure $
         M.fromListWith
             (+)

--- a/test/EcoSpold2WriterSpec.hs
+++ b/test/EcoSpold2WriterSpec.hs
@@ -340,14 +340,14 @@ assertInventoryRoundTrips sdb = do
     db' <- buildDb sdb'
     let pids = [0 .. fromIntegral (V.length (dbProcessIdTable db)) - 1] :: [ProcessId]
     forM_ pids $ \pid -> do
-        inv <- computeInventoryMatrix db pid
+        inv <- either (fail . show) pure =<< computeInventoryMatrix db pid
         -- The round-tripped DB may order activities differently; locate the
         -- matching process by its (actUUID, prodUUID) key.
         let key = dbProcessIdTable db V.! fromIntegral pid
         case V.elemIndex key (dbProcessIdTable db') of
             Nothing -> expectationFailure $ "process key missing after round-trip: " ++ show key
             Just pid' -> do
-                inv' <- computeInventoryMatrix db' (fromIntegral pid')
+                inv' <- either (fail . show) pure =<< computeInventoryMatrix db' (fromIntegral pid')
                 inventoriesClose inv inv' `shouldBe` True
 
 spec :: Spec

--- a/test/GlobalSubstitutionSpec.hs
+++ b/test/GlobalSubstitutionSpec.hs
@@ -52,7 +52,7 @@ spec = do
                     let sub = Substitution (processIdToText db aPid) (processIdToText db bPid) AllConsumers
                     gRes <- computeScalingVectorWithSubstitutionsCrossDB defaultUnitConfig noDeps db "root" solver 0 [sub]
                     refSolver <- createSharedSolver "ref" (relocateRow db aPid bPid) (fromIntegral (dbActivityCount db))
-                    xRef <- solveWithSharedSolver refSolver (buildDemandVectorFromIndex (dbActivityIndex db) 0)
+                    xRef <- solveWithSharedSolver refSolver =<< either (fail . show) pure (buildDemandVectorFromIndex (dbActivityIndex db) 0)
                     case gRes of
                         Right (xGlobal, links) -> do
                             links `shouldBe` []
@@ -116,7 +116,7 @@ spec = do
                         sub = Substitution (processIdToText root aPid) ("dep::" <> processIdToText dep bPid) AllConsumers
                     gRes <- computeScalingVectorWithSubstitutionsCrossDB defaultUnitConfig lookup_ root "root" rootSolver 0 [sub]
                     refSolver <- createSharedSolver "ref" (deleteRow root aPid) (fromIntegral (dbActivityCount root))
-                    xRef <- solveWithSharedSolver refSolver (buildDemandVectorFromIndex (dbActivityIndex root) 0)
+                    xRef <- solveWithSharedSolver refSolver =<< either (fail . show) pure (buildDemandVectorFromIndex (dbActivityIndex root) 0)
                     case gRes of
                         Right (xGlobal, links) -> do
                             length links `shouldBe` nConsumers

--- a/test/HotspotSpec.hs
+++ b/test/HotspotSpec.hs
@@ -19,7 +19,7 @@ spec = do
             case co2Flow of
                 Nothing -> expectationFailure "CO2 flow not found in SAMPLE.min3"
                 Just co2 -> do
-                    scalingVec <- computeScalingVector db 0
+                    scalingVec <- either (fail . show) pure =<< computeScalingVector db 0
                     let cfMap = M.singleton (bfId co2) 1.0
                     let contribs = computeProcessLCIAContributions db scalingVec cfMap
                     let nonZero = M.filter (\v -> abs v > 1e-15) contribs
@@ -32,7 +32,7 @@ spec = do
             case co2Flow of
                 Nothing -> expectationFailure "CO2 flow not found in SAMPLE.min3"
                 Just co2 -> do
-                    scalingVec <- computeScalingVector db 0
+                    scalingVec <- either (fail . show) pure =<< computeScalingVector db 0
                     let cfMap = M.singleton (bfId co2) 1.0
                     let contribs = computeProcessLCIAContributions db scalingVec cfMap
                     let total = sum (M.elems contribs)
@@ -46,7 +46,7 @@ spec = do
             case co2Flow of
                 Nothing -> expectationFailure "CO2 flow not found in SAMPLE.min3"
                 Just co2 -> do
-                    scalingVec <- computeScalingVector db 0
+                    scalingVec <- either (fail . show) pure =<< computeScalingVector db 0
                     let cfMap = M.singleton (bfId co2) 1.0
                     let nonZero =
                             M.filter (\v -> abs v > 1e-15) $
@@ -61,7 +61,7 @@ spec = do
             db <- loadSampleDatabase "SAMPLE.min3"
             -- A random UUID that doesn't exist in the database
             let ghostUUID = read "00000000-0000-0000-0000-000000000001" :: UUID
-            scalingVec <- computeScalingVector db 0
+            scalingVec <- either (fail . show) pure =<< computeScalingVector db 0
             let cfMap = M.singleton ghostUUID 1.0
             let contribs = computeProcessLCIAContributions db scalingVec cfMap
             sum (M.elems contribs) `shouldBe` 0.0

--- a/test/ILCDWriterSpec.hs
+++ b/test/ILCDWriterSpec.hs
@@ -212,7 +212,7 @@ inventoryByName db target = do
                     ]
             case pids of
                 (pid : _) -> do
-                    inv <- computeInventoryMatrix d pid
+                    inv <- either (fail . show) pure =<< computeInventoryMatrix d pid
                     pure (M.mapKeys (flowName d) inv)
                 [] -> expectationFailure ("no activity named " <> T.unpack target) >> pure M.empty
   where

--- a/test/InventorySpec.hs
+++ b/test/InventorySpec.hs
@@ -20,7 +20,7 @@ spec = do
             let rootProcessId = 0 :: ProcessId
 
             -- Compute inventory
-            inventory <- computeInventoryMatrix db rootProcessId
+            inventory <- either (fail . show) pure =<< computeInventoryMatrix db rootProcessId
 
             -- Find CO2 and Zinc flows
             let co2Flow = findFlowByName db "carbon dioxide"
@@ -43,7 +43,7 @@ spec = do
             db <- loadSampleDatabase "SAMPLE.min3"
 
             let rootProcessId = 0 :: ProcessId
-            inventory <- computeInventoryMatrix db rootProcessId
+            inventory <- either (fail . show) pure =<< computeInventoryMatrix db rootProcessId
 
             -- All inventory values should be finite
             let allFinite = all (\(_, v) -> not (isInfinite v) && not (isNaN v)) (M.toList inventory)
@@ -57,7 +57,7 @@ spec = do
             let rootProcessId = 0 :: ProcessId
 
             -- Compute inventory
-            inventory <- computeInventoryMatrix db rootProcessId
+            inventory <- either (fail . show) pure =<< computeInventoryMatrix db rootProcessId
 
             -- All values should be finite
             let allFinite = all (\(_, v) -> not (isInfinite v) && not (isNaN v)) (M.toList inventory)
@@ -67,7 +67,7 @@ spec = do
             db <- loadSampleDatabase "SAMPLE.min"
 
             let rootProcessId = 0 :: ProcessId
-            inventory <- computeInventoryMatrix db rootProcessId
+            inventory <- either (fail . show) pure =<< computeInventoryMatrix db rootProcessId
 
             -- Most biosphere values should be positive (emissions)
             let positiveCount = length $ filter (\(_, v) -> v > 0) (M.toList inventory)
@@ -78,7 +78,7 @@ spec = do
             db <- loadSampleDatabase "SAMPLE.min3"
 
             let rootProcessId = 0 :: ProcessId
-            inventory <- computeInventoryMatrix db rootProcessId
+            inventory <- either (fail . show) pure =<< computeInventoryMatrix db rootProcessId
 
             -- Inventory should not be empty
             M.size inventory `shouldSatisfy` (> 0)
@@ -87,7 +87,7 @@ spec = do
             db <- loadSampleDatabase "SAMPLE.min3"
 
             -- Activity 0 (Product X) should have inventory from downstream
-            inventory0 <- computeInventoryMatrix db 0
+            inventory0 <- either (fail . show) pure =<< computeInventoryMatrix db 0
             M.size inventory0 `shouldSatisfy` (> 0)
 
             -- All inventory values should be reasonable (not astronomically large)
@@ -107,14 +107,14 @@ spec = do
         it "empty batch returns empty list" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
             fact <- makeFact db "SAMPLE.min3.empty"
-            result <- computeInventoryMatrixBatch db fact []
+            result <- either (fail . show) pure =<< computeInventoryMatrixBatch db fact []
             result `shouldBe` []
 
         it "singleton batch matches single-solve inventory" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
             fact <- makeFact db "SAMPLE.min3.single"
-            single <- computeInventoryMatrix db 0
-            [batched] <- computeInventoryMatrixBatch db fact [0]
+            single <- either (fail . show) pure =<< computeInventoryMatrix db 0
+            [batched] <- either (fail . show) pure =<< computeInventoryMatrixBatch db fact [0]
             M.keys single `shouldBe` M.keys batched
             mapM_
                 ( \k ->
@@ -130,8 +130,8 @@ spec = do
             db <- loadSampleDatabase "SAMPLE.min3"
             fact <- makeFact db "SAMPLE.min3.k3"
             let pids = [0, 1, 2]
-            singles <- mapM (computeInventoryMatrix db) pids
-            batched <- computeInventoryMatrixBatch db fact pids
+            singles <- either (fail . show) pure . sequence =<< mapM (computeInventoryMatrix db) pids
+            batched <- either (fail . show) pure =<< computeInventoryMatrixBatch db fact pids
             length batched `shouldBe` length singles
             mapM_
                 ( \(s, b) -> do

--- a/test/MatrixConstructionSpec.hs
+++ b/test/MatrixConstructionSpec.hs
@@ -2,6 +2,7 @@
 
 module MatrixConstructionSpec (spec) where
 
+import Data.Either (isLeft)
 import Data.List (elemIndex)
 import qualified Data.Map as M
 import qualified Data.Text as T
@@ -9,7 +10,7 @@ import qualified Data.UUID as UUID
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU
 import Database (buildDatabaseWithMatrices)
-import Matrix (computeInventoryMatrix)
+import Matrix (Demand (..), buildDemandVectorFromIndex, computeInventoryMatrix)
 import Test.Hspec
 import TestHelpers
 import Types
@@ -93,6 +94,18 @@ spec = do
             -- Activity index should be identity mapping for simple case
             let activityIndex = dbActivityIndex db
             V.length activityIndex `shouldBe` 3
+
+        it "refuses a demand vector for a process the index does not hold" $ do
+            db <- loadSampleDatabase "SAMPLE.min3"
+
+            -- One unit of demand lands in the column the process occupies; an id
+            -- with no column is refused rather than answered with a vector of
+            -- zeros, which would solve to an inventory of zeros.
+            let activityIndex = dbActivityIndex db
+                offEnd = fromIntegral (V.length activityIndex) :: ProcessId
+            fmap (VU.sum . unDemand) (buildDemandVectorFromIndex activityIndex 0) `shouldBe` Right 1.0
+            isLeft (buildDemandVectorFromIndex activityIndex offEnd) `shouldBe` True
+            isLeft (buildDemandVectorFromIndex activityIndex (-1)) `shouldBe` True
 
     describe "Matrix Sparsity" $ do
         it "produces only well above-zero entries on the basic SAMPLE.min3 fixture" $ do
@@ -410,6 +423,6 @@ spec = do
                 Right db -> case elemIndex (pA, yY) (V.toList (dbProcessIdTable db)) of
                     Nothing -> expectationFailure "producer activity was not interned"
                     Just ix -> do
-                        inv <- computeInventoryMatrix db (fromIntegral ix)
+                        inv <- either (fail . show) pure =<< computeInventoryMatrix db (fromIntegral ix)
                         -- 3 kg waste × 2 kg CO2/kg treated = +6 kg CO2 (positive!)
                         withinTolerance 1.0e-9 6.0 (M.findWithDefault 0.0 co2 inv) `shouldBe` True

--- a/test/MatrixExportSpec.hs
+++ b/test/MatrixExportSpec.hs
@@ -181,25 +181,25 @@ spec = do
     describe "extractMatrixDebugInfo" $ do
         it "returns supply, demand, and inventory vectors of correct length" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
-            info <- extractMatrixDebugInfo db (targetRow db) Nothing
+            info <- either (fail . show) pure =<< extractMatrixDebugInfo db (targetRow db) Nothing
             let n = fromIntegral (dbActivityCount db)
             length (mdSupplyVector info) `shouldBe` n
             length (mdDemandVector info) `shouldBe` n
 
         it "demand vector has exactly one non-zero entry" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
-            info <- extractMatrixDebugInfo db (targetRow db) Nothing
+            info <- either (fail . show) pure =<< extractMatrixDebugInfo db (targetRow db) Nothing
             length (filter (/= 0.0) (mdDemandVector info)) `shouldBe` 1
 
         it "inventory vector is non-empty (has biosphere contributions)" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
-            info <- extractMatrixDebugInfo db (targetRow db) Nothing
+            info <- either (fail . show) pure =<< extractMatrixDebugInfo db (targetRow db) Nothing
             any (/= 0.0) (mdInventoryVector info) `shouldBe` True
 
         it "flow filter restricts biosphere triples" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
-            infoAll <- extractMatrixDebugInfo db (targetRow db) Nothing
-            infoFiltered <- extractMatrixDebugInfo db (targetRow db) (Just "carbon")
+            infoAll <- either (fail . show) pure =<< extractMatrixDebugInfo db (targetRow db) Nothing
+            infoFiltered <- either (fail . show) pure =<< extractMatrixDebugInfo db (targetRow db) (Just "carbon")
             -- Filtered should have ≤ triples than unfiltered
             let nAll = length (mdInventoryVector infoAll)
                 nFiltered = length (mdInventoryVector infoFiltered)
@@ -208,7 +208,7 @@ spec = do
     describe "exportMatrixDebugCSVs" $ do
         it "creates supply chain and biosphere CSV files" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
-            info <- extractMatrixDebugInfo db (targetRow db) Nothing
+            info <- either (fail . show) pure =<< extractMatrixDebugInfo db (targetRow db) Nothing
             withSystemTempDirectory "acv-debug" $ \tmpDir -> do
                 let base = tmpDir </> "debug"
                 exportMatrixDebugCSVs base info
@@ -219,7 +219,7 @@ spec = do
 
         it "supply chain CSV has one row per activity" $ do
             db <- loadSampleDatabase "SAMPLE.min3"
-            info <- extractMatrixDebugInfo db (targetRow db) Nothing
+            info <- either (fail . show) pure =<< extractMatrixDebugInfo db (targetRow db) Nothing
             withSystemTempDirectory "acv-debug" $ \tmpDir -> do
                 let base = tmpDir </> "debug"
                 exportMatrixDebugCSVs base info

--- a/test/NestedSubstitutionSpec.hs
+++ b/test/NestedSubstitutionSpec.hs
@@ -55,7 +55,7 @@ spec = do
             solver <- mkSolver db "root"
             let pid = 0
                 demandVec = buildDemandVectorFromIndex (dbActivityIndex db) pid
-            baselineX <- solveWithSharedSolver solver demandVec
+            baselineX <- solveWithSharedSolver solver =<< either (fail . show) pure demandVec
             let qualifiedPid = "other-db::aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa_bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
                 sub =
                     Substitution
@@ -77,7 +77,7 @@ spec = do
             solver <- mkSolver db "root"
             let pid = 0
                 demandVec = buildDemandVectorFromIndex (dbActivityIndex db) pid
-            baselineX <- solveWithSharedSolver solver demandVec
+            baselineX <- solveWithSharedSolver solver =<< either (fail . show) pure demandVec
             let noDeps _ = pure Nothing
             res <- applySubstitutionsAt defaultUnitConfig noDeps db (ThisDb "root") (RootDb "root") solver [baselineX] []
             case res of
@@ -94,7 +94,7 @@ spec = do
             solver <- mkSolver db "dep"
             let pid = 0
                 demandVec = buildDemandVectorFromIndex (dbActivityIndex db) pid
-            baselineX <- solveWithSharedSolver solver demandVec
+            baselineX <- solveWithSharedSolver solver =<< either (fail . show) pure demandVec
             let qualifiedToRoot = "root::aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa_bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
                 sub =
                     Substitution
@@ -118,7 +118,7 @@ spec = do
             solver <- mkSolver db "dep"
             let pid = 0
                 demandVec = buildDemandVectorFromIndex (dbActivityIndex db) pid
-            baselineX <- solveWithSharedSolver solver demandVec
+            baselineX <- solveWithSharedSolver solver =<< either (fail . show) pure demandVec
             let bareRootPid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa_bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
                 sub =
                     Substitution
@@ -275,7 +275,7 @@ spec = do
             let lookup_ = mkDepLookupFromMap (M.singleton "dep" (dep, depSolver))
                 pid = 0
                 demandVec = buildDemandVectorFromIndex (dbActivityIndex root) pid
-            scaling <- solveWithSharedSolver rootSolver demandVec
+            scaling <- solveWithSharedSolver rootSolver =<< either (fail . show) pure demandVec
             let scf =
                     SupplyChainFilter
                         { scfCore =

--- a/test/SensitivitySpec.hs
+++ b/test/SensitivitySpec.hs
@@ -33,7 +33,7 @@ spec = do
             db <- loadSampleDatabase "SAMPLE.min3"
             solver <- mkSolverFromDb db "SAMPLE.min3"
             let demand = buildDemandVectorFromIndex (dbActivityIndex db) 0
-            x <- solveWithSharedSolver solver demand
+            x <- solveWithSharedSolver solver =<< either (fail . show) pure demand
             mFact <- getFactorization solver
             r <- perturbA db mFact x 0 []
             case r of
@@ -188,7 +188,7 @@ spec = do
                     | SparseTriple i j v <- techTriples
                     ]
                 n = fromIntegral (dbActivityCount db)
-                demand = unDemand (buildDemandVectorFromIndex (dbActivityIndex db) 0)
+            demand <- unDemand <$> either (fail . show) pure (buildDemandVectorFromIndex (dbActivityIndex db) 0)
             xRef <- solveSparseLinearSystem scaledTriples n demand
 
             -- Compare element-wise within tight numerical tolerance.

--- a/test/SharedSolverSpec.hs
+++ b/test/SharedSolverSpec.hs
@@ -37,7 +37,7 @@ spec = do
         it "scaling vector matches golden values [1.0, 0.6, 0.24]" $ do
             (solver, db) <- min3Solver
             let demandVec = buildDemandVectorFromIndex (dbActivityIndex db) 0
-            result <- solveWithSharedSolver solver demandVec
+            result <- solveWithSharedSolver solver =<< either (fail . show) pure demandVec
             assertVectorNear "scaling vector" defaultTolerance result sampleMin3ExpectedSupply
 
     -- -----------------------------------------------------------------------
@@ -47,8 +47,8 @@ spec = do
         it "second solve produces the same result" $ do
             (solver, db) <- min3Solver
             let demandVec = buildDemandVectorFromIndex (dbActivityIndex db) 0
-            result1 <- solveWithSharedSolver solver demandVec
-            result2 <- solveWithSharedSolver solver demandVec
+            result1 <- solveWithSharedSolver solver =<< either (fail . show) pure demandVec
+            result2 <- solveWithSharedSolver solver =<< either (fail . show) pure demandVec
             U.toList result1 `shouldBe` U.toList result2
 
 -- ---------------------------------------------------------------------------
@@ -66,5 +66,5 @@ min3Solver = do
     solver <- createSharedSolver "SAMPLE.min3" techTriples actCount
     -- Trigger lazy factorization via first solve
     let demandVec = buildDemandVectorFromIndex (dbActivityIndex db) 0
-    _ <- solveWithSharedSolver solver demandVec
+    _ <- solveWithSharedSolver solver =<< either (fail . show) pure demandVec
     return (solver, db)

--- a/test/SimaProWriterSpec.hs
+++ b/test/SimaProWriterSpec.hs
@@ -360,7 +360,7 @@ inventoryByName (acts, tech, bio, waste, units) target = do
                     ]
             case pidFor of
                 (pid : _) -> do
-                    inv <- computeInventoryMatrix db pid
+                    inv <- either (fail . show) pure =<< computeInventoryMatrix db pid
                     pure (M.mapKeys (flowName db) inv)
                 [] -> expectationFailure ("no activity named " <> T.unpack target) >> pure M.empty
 

--- a/test/SupplyChainSpec.hs
+++ b/test/SupplyChainSpec.hs
@@ -67,7 +67,7 @@ spec = do
 
             -- SAMPLE.min3: X → Y(0.6) → Z(0.24), all refAmounts = 1 kg
             let rootProcessId = 0 :: ProcessId
-            supplyVec <- computeScalingVector db rootProcessId
+            supplyVec <- either (fail . show) pure =<< computeScalingVector db rootProcessId
 
             let response = buildSupplyChainFromScalingVector shippedGeographies db "test-db" rootProcessId supplyVec emptySupply
                 entries = scrSupplyChain response
@@ -85,7 +85,7 @@ spec = do
             db <- loadSampleDatabase "SAMPLE.min3"
 
             let rootProcessId = 0 :: ProcessId
-            supplyVec <- computeScalingVector db rootProcessId
+            supplyVec <- either (fail . show) pure =<< computeScalingVector db rootProcessId
 
             let response = buildSupplyChainFromScalingVector shippedGeographies db "test-db" rootProcessId supplyVec emptySupply
                 entries = scrSupplyChain response
@@ -98,7 +98,7 @@ spec = do
             db <- loadSampleDatabase "SAMPLE.min3"
 
             let rootProcessId = 0 :: ProcessId
-            supplyVec <- computeScalingVector db rootProcessId
+            supplyVec <- either (fail . show) pure =<< computeScalingVector db rootProcessId
 
             -- No depth filter: should get Y (depth 1) and Z (depth 2)
             let noFilter = buildSupplyChainFromScalingVector shippedGeographies db "test-db" rootProcessId supplyVec emptySupply
@@ -136,7 +136,7 @@ spec = do
         it "narrows to single entry when token matches only one activity" $ do
             db <- loadWithIndex
             let rootPid = 0 :: ProcessId
-            supplyVec <- computeScalingVector db rootPid
+            supplyVec <- either (fail . show) pure =<< computeScalingVector db rootPid
             -- Only pid 1's name contains the token "y".
             let entries = scrSupplyChain (buildWithName db rootPid supplyVec (Just "Y"))
             map sceActivityName entries `shouldBe` ["production of product Y"]
@@ -144,7 +144,7 @@ spec = do
         it "accepts typos via edit-distance expansion" $ do
             db <- loadWithIndex
             let rootPid = 0 :: ProcessId
-            supplyVec <- computeScalingVector db rootPid
+            supplyVec <- either (fail . show) pure =<< computeScalingVector db rootPid
             -- "prodcution" is "production" with two characters transposed.
             let entries = scrSupplyChain (buildWithName db rootPid supplyVec (Just "prodcution"))
             length entries `shouldSatisfy` (>= 1)
@@ -152,7 +152,7 @@ spec = do
         it "accepts stems via prefix-coverage expansion" $ do
             db <- loadWithIndex
             let rootPid = 0 :: ProcessId
-            supplyVec <- computeScalingVector db rootPid
+            supplyVec <- either (fail . show) pure =<< computeScalingVector db rootPid
             -- "produc" is a stem of "production" — both Y and Z pass.
             let entries = scrSupplyChain (buildWithName db rootPid supplyVec (Just "produc"))
             length entries `shouldBe` 2
@@ -160,7 +160,7 @@ spec = do
         it "is case-insensitive" $ do
             db <- loadWithIndex
             let rootPid = 0 :: ProcessId
-            supplyVec <- computeScalingVector db rootPid
+            supplyVec <- either (fail . show) pure =<< computeScalingVector db rootPid
             let nUpper = scrFilteredActivities (buildWithName db rootPid supplyVec (Just "PRODUCT"))
                 nLower = scrFilteredActivities (buildWithName db rootPid supplyVec (Just "product"))
             nUpper `shouldBe` nLower
@@ -168,7 +168,7 @@ spec = do
         it "blank name query is equivalent to no filter" $ do
             db <- loadWithIndex
             let rootPid = 0 :: ProcessId
-            supplyVec <- computeScalingVector db rootPid
+            supplyVec <- either (fail . show) pure =<< computeScalingVector db rootPid
             let nNone = scrFilteredActivities (buildWithName db rootPid supplyVec Nothing)
                 nBlank = scrFilteredActivities (buildWithName db rootPid supplyVec (Just "   "))
             nBlank `shouldBe` nNone
@@ -176,7 +176,7 @@ spec = do
         it "non-matching name query returns zero entries" $ do
             db <- loadWithIndex
             let rootPid = 0 :: ProcessId
-            supplyVec <- computeScalingVector db rootPid
+            supplyVec <- either (fail . show) pure =<< computeScalingVector db rootPid
             scrFilteredActivities (buildWithName db rootPid supplyVec (Just "zzznomatch"))
                 `shouldBe` 0
 
@@ -186,14 +186,14 @@ spec = do
             -- absent filter.
             db <- loadWithIndex
             let rootPid = 0 :: ProcessId
-            supplyVec <- computeScalingVector db rootPid
+            supplyVec <- either (fail . show) pure =<< computeScalingVector db rootPid
             scrFilteredActivities (buildWithName db rootPid supplyVec (Just "???"))
                 `shouldBe` 0
 
         it "preserves depth sort order across filtered entries" $ do
             db <- loadWithIndex
             let rootPid = 0 :: ProcessId
-            supplyVec <- computeScalingVector db rootPid
+            supplyVec <- either (fail . show) pure =<< computeScalingVector db rootPid
             let resp =
                     buildSupplyChainFromScalingVector
                         shippedGeographies

--- a/test/WasteTreatmentSignSpec.hs
+++ b/test/WasteTreatmentSignSpec.hs
@@ -174,7 +174,7 @@ scoreIntra name acts = do
     db <- buildDB name acts
     case processIdOf db (pA, yY) of
         Nothing -> fail "producer not interned"
-        Just pid -> co2Of <$> computeInventoryMatrix db (fromIntegral pid)
+        Just pid -> co2Of <$> (either (fail . show) pure =<< computeInventoryMatrix db (fromIntegral pid))
 
 -- | A linking context holding one dependency database.
 ctxWithDep :: T.Text -> Database -> LinkingContext


### PR DESCRIPTION
## The problem

`buildDemandVectorFromIndex` in `src/Matrix.hs` is a pure function that ended in
`error` when the process id it was given fell outside the activity index. The
precondition was written as prose in the haddock of `computeInventoryMatrixBatch`
("Callers should validate with `Service.resolveActivityAndProcessId` first"),
which is exactly the kind of guarantee the type system is for.

## The solution

`buildDemandVectorFromIndex` now returns `Either Text Demand`. That is the shape
`depDemandsToVector` already uses for the same job in the same module, so no
third way was invented. The refusal names the process id and the size of the
index it was judged against.

Propagation stops at the solver wrappers that take a raw process id
(`computeScalingVector`, `computeInventoryMatrix`, `computeInventoryMatrixBatch`
and their shared-solver twins, plus `extractMatrixDebugInfo`), which gain
`IO (Either Text …)`. Every production caller past them already carried an error
channel, so no route and no tool grew one. `Service.demandFor` is the one place
the refusal becomes a `MatrixError`.

One site in `Service`, `getSupplyChain`, called `validateProcessIdInMatrixIndex`
and then built the vector; it now does only the second, because the build is
that same bound check and its message is the more concrete of the two.
`getActivityInventory` and `getPathTo` still do both. Collapsing them is the
same one-line change and no risk, but it is tidying rather than this subject,
so it is left out.

`Service.Aggregate` built its vector and wrapped the refusal by hand, which is
what `demandFor` already is; it now calls it, so the service layer turns a
builder refusal into a service error in exactly one place.

The haddock that documented the crash now says what the code does.

## Remarks

**This needs a companion change in the deployment repository before its
submodule pointer moves.** That repository's `perf/bench` links against this
one and is compiled by its CI precisely so a signature change here cannot rot
it. Four call sites use the three changed functions bare:
`Bench/Solve.hs:128,133,138` and `Bench/Lcia.hs:350`. They will not typecheck
against `IO (Either Text ...)` and need the same one-line unwrap the test
sites got. The companion cannot land before this one, since it compiles
against whichever commit of this repository the pointer names.

**The crash was latent, not reachable.** Every process id that reaches a demand
vector comes from `Service.resolveActivityAndProcessId` (directly, or through
`resolveScorable` / `API.Routes.resolveOrThrow` / `API.MCP.loadLcaRequest`),
whose `resolveActivity` step rejects anything outside `dbActivities`. That is the
same bound `buildDemandVectorFromIndex` checks, because
`Database.MatrixBuild.buildInterningTables` builds `dbActivities`,
`dbActivityCount` and `dbActivityIndex` from one list. No HTTP route, MCP tool or
CLI command could get an unvalidated id that far. So this removes a crash nobody
could trigger, and the reason to remove it is that the next caller of a pure
function should not have to read a comment to use it safely.

A vector of zeros in place of the crash was the other tempting shape, and it is
worse than both: it solves to an inventory of zeros and is reported as an answer.

The cost of the shape was measured before committing to it: the `src` side is
five files, because the production paths already returned `Either Text`. The
test side is a single mechanical unwrap at each site that calls one of the
wrappers, which is most of the diff.

## How to test

```
./gen-version.sh
./build.sh --test
```

2635 examples, 0 failures, 2 pending. `MatrixConstructionSpec` gains one example
pinning the new contract: an in-range id yields a demand vector whose entries sum
to exactly one, and an id past the end of the index (or a negative one) is
refused rather than answered.

Also run, and clean: `fourmolu --mode check src app test`, `hlint src app test`
("No hints"), and a cold `cabal build all --enable-tests --ghc-options=-Werror`
in a fresh build directory.

