### PR TITLE
Read the first byte of a sniffed upload totally

### DIFF
--- a/src/Database/Upload.hs
+++ b/src/Database/Upload.hs
@@ -241,7 +241,9 @@ detectArchiveFormat content
                 && BS.isInfixOf "\"ImpactCategory\"" header2k
         _ -> False
     -- Check if first byte is printable ASCII (plain text / CSV)
-    isPlainText = let b = BL.head content in b == 0x7B || (b >= 0x20 && b < 0x7F)
+    isPlainText = case bytes of
+        b : _ -> b == 0x7B || (b >= 0x20 && b < 0x7F)
+        [] -> False
 
 {- | Extract an archive file on disk to a target directory.
 Reuses extractUpload (reads file, detects format, extracts).

--- a/src/Database/Upload.hs
+++ b/src/Database/Upload.hs
@@ -240,9 +240,12 @@ detectArchiveFormat content
             BS.isInfixOf "\"@type\"" header2k
                 && BS.isInfixOf "\"ImpactCategory\"" header2k
         _ -> False
-    -- Check if first byte is printable ASCII (plain text / CSV)
+    -- Check if first byte is printable ASCII (plain text / CSV). 0x7B, the
+    -- opening brace a JSON document starts with, sits inside that range and
+    -- needs no disjunct of its own: the sniff above routes JSON-LD before
+    -- this one is asked.
     isPlainText = case bytes of
-        b : _ -> b == 0x7B || (b >= 0x20 && b < 0x7F)
+        b : _ -> b >= 0x20 && b < 0x7F
         [] -> False
 
 {- | Extract an archive file on disk to a target directory.

--- a/test/MethodUploadSpec.hs
+++ b/test/MethodUploadSpec.hs
@@ -77,6 +77,19 @@ spec = do
             -- marker, so the sniff must not over-fire.
             detectArchiveFormat miniProcessJson `shouldBe` ArchivePlainCSV
 
+    describe "detectArchiveFormat on the plain-text sniff" $ do
+        it "answers ArchiveUnknown on empty input" $
+            -- The emptiness guard answers first, so this passes whether or not
+            -- the sniff below it reads the first byte totally. It pins the
+            -- result the guard owes; the byte set is what the cases below pin.
+            detectArchiveFormat BL.empty `shouldBe` ArchiveUnknown
+
+        it "accepts the printable ASCII range and nothing under it" $ do
+            detectArchiveFormat (BL.pack [0x20]) `shouldBe` ArchivePlainCSV
+            detectArchiveFormat (BL.pack [0x7E]) `shouldBe` ArchivePlainCSV
+            detectArchiveFormat (BL.pack [0x1F]) `shouldBe` ArchiveUnknown
+            detectArchiveFormat (BL.pack [0x7F]) `shouldBe` ArchiveUnknown
+
     describe "handleUpload writes JSON-LD as .json" $
         it "persists data.json (not data.csv) so the loader can dispatch through OlcaSchema" $
             withSystemTempDirectory "volca-method-upload" $ \tmp -> do

--- a/test/MethodUploadSpec.hs
+++ b/test/MethodUploadSpec.hs
@@ -84,7 +84,7 @@ spec = do
             -- result the guard owes; the byte set is what the cases below pin.
             detectArchiveFormat BL.empty `shouldBe` ArchiveUnknown
 
-        it "accepts the printable ASCII range and nothing under it" $ do
+        it "accepts the printable ASCII range and nothing outside it" $ do
             detectArchiveFormat (BL.pack [0x20]) `shouldBe` ArchivePlainCSV
             detectArchiveFormat (BL.pack [0x7E]) `shouldBe` ArchivePlainCSV
             detectArchiveFormat (BL.pack [0x1F]) `shouldBe` ArchiveUnknown


### PR DESCRIPTION
## Problem

The plain-text sniff in `detectArchiveFormat` read its byte with `BL.head`, a partial function. It could not actually throw, because the first guard of the same function returns `ArchiveUnknown` on empty input thirty lines higher up. That makes it total by distance: hold it together with guard order and lazy evaluation, and the day someone reorders the guards or reuses the binding elsewhere, nothing fails to compile.

## Solution

`isPlainText` now matches on `bytes`, the `[Word8]` the `where` block already unpacks from the first ten bytes, and answers `False` when the list is empty. Same value the guard above produces, and the accepted byte set is unchanged. No new binding, no partial function left in the file.

## Remarks

The empty-input test goes through the emptiness guard, so it would pass with `BL.head` still in place; it pins the result the guard owes rather than the sniff. `isPlainText` is a `where` binding and not reachable on its own, so the byte set is pinned instead through `detectArchiveFormat` at both edges of the range: `0x20` and `0x7E` accepted, `0x1F` and `0x7F` refused.

## How to test

    ./gen-version.sh
    ./build.sh --test

The new cases are under `detectArchiveFormat on the plain-text sniff` in `test/MethodUploadSpec.hs`.
