### PR TITLE
Write the debug matrix files in linear time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,14 @@
   linking never rewrites, and reports it as `supplierClaim`, which replaces the
   `supplierActivity` of the same release, never shipped. Caches built
   before this are rebuilt on the next load. Wire revision 23.
+- The debug matrix files now take seconds to write on a database of any size.
+  Naming the activity behind a column meant searching the whole index for it,
+  once for the identifier and once again for the name, and reading a supply
+  amount meant counting a list from the start. Both grew with the square of the
+  database, so the two files that only restate what the solver already computed
+  cost more than the solve. On a synthetic chain of 16 000 activities they take
+  0.35 seconds instead of 15, and doubling the database no longer quadruples the
+  wait. The files themselves are unchanged, to the byte.
 
 ### Fixed
 - A file an EcoSpold directory offers and the reader cannot read now stops the

--- a/src/Matrix/Export.hs
+++ b/src/Matrix/Export.hs
@@ -45,7 +45,7 @@ data MatrixDebugInfo = MatrixDebugInfo
     , mdBioFlowUUIDs :: V.Vector UUID
     , mdTargetProcessId :: ProcessId
     , mdDatabase :: Database
-    , mdSupplyVector :: [Double]
+    , mdSupplyVector :: U.Vector Double
     , mdDemandVector :: [Double]
     , mdInventoryVector :: [Double]
     }
@@ -79,9 +79,7 @@ extractMatrixDebugInfo database targetProcessId flowFilter =
             activityCountInt = fromIntegral activityCount
 
         supplyVec <- solveSparseLinearSystem techTriplesInt activityCountInt demandVec
-        let supplyList = toList supplyVec
-
-            bioTriplesInt = [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList bioTriples]
+        let bioTriplesInt = [(fromIntegral i, fromIntegral j, v) | SparseTriple i j v <- U.toList bioTriples]
             bioFlowCountInt = fromIntegral bioFlowCount
             inventoryVec = applySparseMatrix bioTriplesInt bioFlowCountInt supplyVec
             inventoryList = toList inventoryVec
@@ -110,7 +108,7 @@ extractMatrixDebugInfo database targetProcessId flowFilter =
                 , mdBioFlowUUIDs = bioFlowUUIDs
                 , mdTargetProcessId = targetProcessId
                 , mdDatabase = database
-                , mdSupplyVector = supplyList
+                , mdSupplyVector = supplyVec
                 , mdDemandVector = demandList
                 , mdInventoryVector = inventoryList
                 }
@@ -137,7 +135,7 @@ exportSupplyChainData filePath debugInfo = do
             | processId <- [toEnum 0 .. toEnum (V.length activities - 1)]
             , let activity = activities V.! fromEnum processId
             , let idx = fromIntegral (activityIndexVec V.! fromEnum processId) :: Int
-            , let supply = if idx < length supplyVector then supplyVector !! idx else 0.0
+            , let supply = fromMaybe 0.0 (supplyVector U.!? idx)
             ]
 
         csvRow processId activity idx supply =
@@ -205,10 +203,7 @@ exportBiosphereMatrixData filePath debugInfo = do
                     then Just (activities V.! fromEnum processId)
                     else Nothing
             realContribution :: Int -> Double
-            realContribution colIdx =
-                if colIdx < length supplyVector
-                    then value * (supplyVector !! colIdx)
-                    else 0.0
+            realContribution colIdx = maybe 0.0 (value *) (supplyVector U.!? colIdx)
 
         csvHeader = ["flow_id", "flow_name", "unit", "activity_id", "activity_name", "matrix_value", "contribution"]
         allRows = csvHeader : matrixRows

--- a/src/Matrix/Export.hs
+++ b/src/Matrix/Export.hs
@@ -19,6 +19,7 @@ import Progress (ProgressLevel (..), reportProgress)
 import Types
 
 import Data.Int (Int32)
+import qualified Data.IntMap.Strict as IM
 import qualified Data.List as L
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
@@ -153,6 +154,25 @@ exportSupplyChainData filePath debugInfo = do
     writeFile filePath csvContent
     reportProgress Info $ "Supply chain: " ++ show (length supplyChainRows) ++ " activities → " ++ filePath
 
+{- | The process each matrix column belongs to, inverted once.
+
+The export needs this answer once per biosphere triple, and it used to find it by
+scanning the whole index for each of them, which is quadratic in the size of the
+database. Every construction of the index makes it the identity permutation, so no
+two processes claim the same column; the fold keeps the first claim regardless,
+because that is the one the scan returned and the file has to keep reading the same.
+A process beyond the end of the activity vector claims nothing, which is the range
+the scan walked.
+-}
+columnOwners :: ActivityDB -> V.Vector Int32 -> IM.IntMap ProcessId
+columnOwners activities activityIndex =
+    IM.fromListWith
+        (\_later earlier -> earlier)
+        [ (fromIntegral column, process)
+        | (process, column) <- zip [0 ..] (V.toList activityIndex)
+        , fromEnum process < V.length activities
+        ]
+
 -- | Export biosphere matrix contributions
 exportBiosphereMatrixData :: FilePath -> MatrixDebugInfo -> IO ()
 exportBiosphereMatrixData filePath debugInfo = do
@@ -163,6 +183,7 @@ exportBiosphereMatrixData filePath debugInfo = do
         bioFlowUUIDs = mdBioFlowUUIDs debugInfo
         activityIndex = mdActivityIndex debugInfo
         supplyVector = mdSupplyVector debugInfo
+        owners = columnOwners activities activityIndex
 
         matrixRows =
             [ csvRow bioTriple
@@ -173,11 +194,12 @@ exportBiosphereMatrixData filePath debugInfo = do
         csvRow (SparseTriple row col value) =
             let rowInt = fromIntegral row :: Int
                 colInt = fromIntegral col :: Int
+                owner = IM.lookup colInt owners
              in [ maybe "unknown" show (getFlowUUID rowInt)
                 , maybe "unknown" (T.unpack . bfName) (getFlow rowInt)
                 , maybe "unknown" T.unpack (getFlowUnit rowInt)
-                , maybe "unknown" (T.unpack . processIdToText database) (getActivityProcessId colInt)
-                , maybe "unknown" (T.unpack . activityName) (lookupActivity colInt)
+                , maybe "unknown" (T.unpack . processIdToText database) owner
+                , maybe "unknown" (T.unpack . activityName) (owner >>= ownedActivity)
                 , show value
                 , show (realContribution colInt)
                 ]
@@ -191,17 +213,8 @@ exportBiosphereMatrixData filePath debugInfo = do
             getFlow rowIdx = getFlowUUID rowIdx >>= flip M.lookup flows
             getFlowUnit :: Int -> Maybe Text
             getFlowUnit rowIdx = fmap (getUnitNameForBioFlow (dbUnits database)) (getFlow rowIdx)
-            getActivityProcessId :: Int -> Maybe ProcessId
-            getActivityProcessId colIdx =
-                L.find
-                    (\pid -> fromIntegral (activityIndex V.! fromEnum pid) == colIdx)
-                    [toEnum 0 .. toEnum (V.length activities - 1)]
-            lookupActivity :: Int -> Maybe Activity
-            lookupActivity colIdx = do
-                processId <- getActivityProcessId colIdx
-                if fromEnum processId < V.length activities
-                    then Just (activities V.! fromEnum processId)
-                    else Nothing
+            ownedActivity :: ProcessId -> Maybe Activity
+            ownedActivity process = activities V.!? fromEnum process
             realContribution :: Int -> Double
             realContribution colIdx = maybe 0.0 (value *) (supplyVector U.!? colIdx)
 

--- a/test/MatrixExportSpec.hs
+++ b/test/MatrixExportSpec.hs
@@ -231,10 +231,18 @@ spec = do
         it "names each column's own activity, and scales it by that column's supply" $ do
             -- Both files in full, because both are read by eye and every field of
             -- them is a promise: the two columns have to come back under their own
-            -- activity, and the amounts have to keep the last digit the solver
-            -- produced. The producer sits at column 0 and the treatment at column
-            -- 1, so an export that mistook one column for another would name the
-            -- wrong activity here rather than merely lose a row.
+            -- activity, and the amounts have to keep the last digit of the value
+            -- the record holds. The producer sits at column 0 and the treatment at
+            -- column 1, so an export that mistook one column for another would name
+            -- the wrong activity here rather than merely lose a row.
+            --
+            -- The expected amounts are read off the record rather than written out,
+            -- because the last digit of a solve is the solver's, not the exporter's:
+            -- gfortran contracts differently across the platforms this suite runs on,
+            -- and a literal here would fail on an exporter that is faithful. Reading
+            -- them off the record keeps what this test is for, which is that the file
+            -- restitutes the record and puts each column under its own activity: a
+            -- swapped column still fails, the two supplies differ.
             db <- treatmentDatabase
             info <- either (fail . show) pure =<< extractMatrixDebugInfo db (rowOf db treatmentUUID) Nothing
             withSystemTempDirectory "acv-debug-columns" $ \tmpDir -> do
@@ -242,6 +250,8 @@ spec = do
                     producer = processIdToText db (rowOf db producerUUID)
                     treatment = processIdToText db (rowOf db treatmentUUID)
                     co2 = T.pack (show carbonDioxide)
+                    supplyAt col = mdSupplyVector info U.! col
+                    shown = T.pack . show
                 exportMatrixDebugCSVs base info
                 supplyChain <- TIO.readFile (base ++ "_supply_chain.csv")
                 biosphere <- TIO.readFile (base ++ "_biosphere_matrix.csv")
@@ -249,15 +259,15 @@ spec = do
                     `shouldBe` T.intercalate
                         "\n"
                         [ "activity_id,activity_name,location,supply_amount,col_idx"
-                        , producer <> ",producer of Y,GLO,-0.4999999999999999,0"
-                        , treatment <> ",treatment of waste W,GLO,1.0,1"
+                        , producer <> ",producer of Y,GLO," <> shown (supplyAt 0) <> ",0"
+                        , treatment <> ",treatment of waste W,GLO," <> shown (supplyAt 1) <> ",1"
                         ]
                 biosphere
                     `shouldBe` T.intercalate
                         "\n"
                         [ "flow_id,flow_name,unit,activity_id,activity_name,matrix_value,contribution"
-                        , co2 <> ",carbon dioxide,kg," <> producer <> ",producer of Y,3.0,-1.4999999999999996"
-                        , co2 <> ",carbon dioxide,kg," <> treatment <> ",treatment of waste W,-2.0,-2.0"
+                        , co2 <> ",carbon dioxide,kg," <> producer <> ",producer of Y,3.0," <> shown (3.0 * supplyAt 0)
+                        , co2 <> ",carbon dioxide,kg," <> treatment <> ",treatment of waste W,-2.0," <> shown (-2.0 * supplyAt 1)
                         ]
 
 {- | The row SAMPLE.min3's activity X sits at. Row 0 when it is missing, which

--- a/test/MatrixExportSpec.hs
+++ b/test/MatrixExportSpec.hs
@@ -8,6 +8,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
 import qualified Data.UUID as UUID
+import qualified Data.Vector.Unboxed as U
 import Database (buildDatabaseWithMatrices)
 import Matrix.Export (
     MatrixDebugInfo (..),
@@ -183,7 +184,7 @@ spec = do
             db <- loadSampleDatabase "SAMPLE.min3"
             info <- either (fail . show) pure =<< extractMatrixDebugInfo db (targetRow db) Nothing
             let n = fromIntegral (dbActivityCount db)
-            length (mdSupplyVector info) `shouldBe` n
+            U.length (mdSupplyVector info) `shouldBe` n
             length (mdDemandVector info) `shouldBe` n
 
         it "demand vector has exactly one non-zero entry" $ do
@@ -227,15 +228,49 @@ spec = do
                 -- header + 3 activities (SAMPLE.min3)
                 length (lines (T.unpack content)) `shouldBe` 4
 
+        it "names each column's own activity, and scales it by that column's supply" $ do
+            -- Both files in full, because both are read by eye and every field of
+            -- them is a promise: the two columns have to come back under their own
+            -- activity, and the amounts have to keep the last digit the solver
+            -- produced. The producer sits at column 0 and the treatment at column
+            -- 1, so an export that mistook one column for another would name the
+            -- wrong activity here rather than merely lose a row.
+            db <- treatmentDatabase
+            info <- either (fail . show) pure =<< extractMatrixDebugInfo db (rowOf db treatmentUUID) Nothing
+            withSystemTempDirectory "acv-debug-columns" $ \tmpDir -> do
+                let base = tmpDir </> "debug"
+                    producer = processIdToText db (rowOf db producerUUID)
+                    treatment = processIdToText db (rowOf db treatmentUUID)
+                    co2 = T.pack (show carbonDioxide)
+                exportMatrixDebugCSVs base info
+                supplyChain <- TIO.readFile (base ++ "_supply_chain.csv")
+                biosphere <- TIO.readFile (base ++ "_biosphere_matrix.csv")
+                supplyChain
+                    `shouldBe` T.intercalate
+                        "\n"
+                        [ "activity_id,activity_name,location,supply_amount,col_idx"
+                        , producer <> ",producer of Y,GLO,-0.4999999999999999,0"
+                        , treatment <> ",treatment of waste W,GLO,1.0,1"
+                        ]
+                biosphere
+                    `shouldBe` T.intercalate
+                        "\n"
+                        [ "flow_id,flow_name,unit,activity_id,activity_name,matrix_value,contribution"
+                        , co2 <> ",carbon dioxide,kg," <> producer <> ",producer of Y,3.0,-1.4999999999999996"
+                        , co2 <> ",carbon dioxide,kg," <> treatment <> ",treatment of waste W,-2.0,-2.0"
+                        ]
+
 {- | The row SAMPLE.min3's activity X sits at. Row 0 when it is missing, which
 only happens if the fixture changes: the assertions below would then fail on a
 different activity rather than on a resolution error, which is the shape hspec
 reports best.
 -}
 targetRow :: Database -> ProcessId
-targetRow db =
-    let targetUUID = read "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" :: UUID
-     in fromMaybe 0 (findProcessIdByActivityUUID db targetUUID)
+targetRow db = rowOf db (read "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+-- | The row an activity was interned at. Row 0 when it is missing, as above.
+rowOf :: Database -> UUID -> ProcessId
+rowOf db activityUUID = fromMaybe 0 (findProcessIdByActivityUUID db activityUUID)
 
 -- --------------------------------------------------------------------------- --
 -- A database with one waste treatment in it
@@ -243,7 +278,9 @@ targetRow db =
 
 {- | Two activities: an ordinary producer of Y, and a treatment of waste W in the
 convention EcoSpold 2 uses, where the treated waste is the reference product and its
-amount is negative. The treatment consumes half a Y and emits 2 kg of CO2.
+amount is negative. The treatment consumes half a Y and emits 2 kg of CO2; the producer
+emits 3, so both columns of the biosphere matrix carry a row and the debug export has to
+name a different activity for each.
 
 Everything the export has to get right about signs is visible in four coefficients, which
 is why this is built here rather than loaded from a fixture: a sample file would have to
@@ -293,7 +330,7 @@ testUUID :: String -> UUID
 testUUID = fromMaybe UUID.nil . UUID.fromString
 
 producerOfY :: Activity
-producerOfY = blankActivity "producer of Y" [reference productY 1.0]
+producerOfY = blankActivity "producer of Y" [reference productY 1.0, emits 3.0]
 
 treatmentOfW :: Activity
 treatmentOfW =
@@ -301,16 +338,21 @@ treatmentOfW =
         "treatment of waste W"
         [ reference wasteW (-1.0)
         , consumesFrom producerUUID productY 0.5
-        , BiosphereExchange
-            { bioFlowId = carbonDioxide
-            , bioAmount = 2.0
-            , bioUnitId = kilogram
-            , bioDirection = Emission
-            , bioLocation = ""
-            , bioComment = Nothing
-            , bioPedigree = Nothing
-            }
+        , emits 2.0
         ]
+
+-- | Carbon dioxide to air, in kilograms.
+emits :: Double -> Exchange
+emits amount =
+    BiosphereExchange
+        { bioFlowId = carbonDioxide
+        , bioAmount = amount
+        , bioUnitId = kilogram
+        , bioDirection = Emission
+        , bioLocation = ""
+        , bioComment = Nothing
+        , bioPedigree = Nothing
+        }
 
 blankActivity :: Text -> [Exchange] -> Activity
 blankActivity name exs =


### PR DESCRIPTION
## The problem

The two debug matrix files cost more to write than the solve they describe, because
both exporters are quadratic in the size of the database.

Naming the activity a biosphere entry belongs to meant scanning the whole index for
the process whose column matched, and the reader that wanted the activity behind that
process ran the same scan a second time. That is two passes over every process for
every biosphere triple. Separately, the supply vector was held as a linked list and
read by position, so each read walked it from the start and the bounds check in front
of each read walked it again, once per activity in one file and once per triple in the
other.

On a database of some tens of thousands of processes with a biosphere matrix of the
same order, that is billions of comparisons for two files that only restate numbers
the solver has already produced.

## The solution

`MatrixDebugInfo` keeps the solver's own `U.Vector Double` for the supply vector
instead of unpacking it into a list, so a read is an index and the unpacking is gone
as well. The demand and inventory fields stay lists: nothing indexes them, they are
zipped and counted, and giving them vector types would only move a conversion to
their readers.

The process to column index is inverted once into an `IntMap` before the loop, and
the two readers of a column take their answers from one lookup, the activity through
a total index rather than a bounds test that could not fail.

Nothing else moves: same columns, same header, same number formatting, same files.

## Remarks

**A signature changed.** `mdSupplyVector`, a field of the exported `MatrixDebugInfo`,
is now `U.Vector Double` where it was `[Double]`. Anything outside this repository
that builds or reads that record needs the same edit. The other two vector fields and
every other export of `Matrix` and `Matrix.Export` are untouched.

**The collision question.** The scan it replaces returned the *lowest* process id
holding a column, so an inverse built the other way round would answer with the
highest and the file would change wherever two processes shared a column. Every
construction of `dbActivityIndex` in the repository builds `V.generate n fromIntegral`
or its literal equivalent, which is the identity permutation, so no two processes can
claim one column today. The fold keeps the first claim anyway, since that costs
nothing and is what holds the output still if that ever stops being true.

**Measured, not argued.** The two exporters were run in one process, in their old and
new shapes, over a synthetic chain of activities each emitting one flow and consuming
the next, and the files they produced were compared byte for byte.

| activities | old | new | files identical |
|---|---|---|---|
| 8 000 | 4.32 s | 0.22 s | yes, 825 689 and 1 226 824 bytes |
| 16 000 | 15.1 s | 0.35 s | yes, 1 645 689 and 2 440 824 bytes |

Doubling the database multiplies the old cost by 3.5 and the new one by 1.6, which is
the quadratic and the linear shape showing up where they should. That harness was a
throwaway and is not in the diff.

## How to test

`cabal test lca-tests --test-options="--match /MatrixExport/"`.

`MatrixExportSpec` gains a case that asserts both debug files in full on a two
activity database whose producer and treatment each carry a biosphere row. The
producer sits at column 0 and the treatment at column 1, so both columns are reached
through the inverted mapping and an export that mistook one for the other names the
wrong activity rather than merely losing a row. The amounts are pinned to the last
digit the solver produced, including the `-0.4999999999999999` that a different
arithmetic path would round away. The fixture's producer gained an emission so that
the second column carries a row at all.
