### PR TITLE
Let the URL mint the collection name it captures

### DIFF
--- a/src/API/BatchImpacts.hs
+++ b/src/API/BatchImpacts.hs
@@ -29,7 +29,7 @@ import qualified Data.Map as M
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-import Database.Manager (DatabaseManager (..))
+import Database.Manager (CollectionName (..), DatabaseManager (..))
 import Method.Mapping (LongTermMode (..))
 import Servant (ServerError (..))
 import qualified Servant
@@ -82,7 +82,7 @@ runActivityLCIABatch ::
     LongTermMode ->
     IO (Either BatchError LCIABatchResult)
 runActivityLCIABatch dbm dbName pid coll mSub ltMode =
-    runBare dbm (activityLCIABatchH dbName pid coll mSub ltMode)
+    runBare dbm (activityLCIABatchH dbName pid (CollectionName coll) mSub ltMode)
 
 {- | Score N activities against every method in a collection in one
 multi-RHS MUMPS solve plus parallel characterization. Unresolved process
@@ -103,7 +103,7 @@ runBatchImpacts ::
     [Text] ->
     IO (Either BatchError BatchImpactsResponse)
 runBatchImpacts dbm dbName coll topFlows ltMode pids =
-    runBare dbm (batchImpactsH dbName coll topFlows ltMode BatchImpactsRequest{birProcessIds = pids})
+    runBare dbm (batchImpactsH dbName (CollectionName coll) topFlows ltMode BatchImpactsRequest{birProcessIds = pids})
 
 {- | Computed-checks report over the whole catalogue of a loaded database.
 Same wire shape as the REST endpoint ('computedQualityReportH'), so both

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -98,17 +98,17 @@ type LCAAPI =
                     :> QueryParam "group_by" Text
                     :> QueryParam "aggregate" Text
                     :> Get '[JSON] Aggregation
-                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "impacts" :> Capture "collection" Text :> QueryParam "exclude-long-term" Bool :> Get '[JSON] LCIABatchResult
-                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "impacts" :> Capture "collection" Text :> QueryParam "exclude-long-term" Bool :> ReqBody '[JSON] SubstitutionRequest :> Post '[JSON] LCIABatchResult
-                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "impacts" :> Capture "collection" Text :> Capture "methodId" Text :> QueryParam "top-flows" Int :> Get '[JSON] LCIAResult
-                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "impacts" :> Capture "collection" Text :> Capture "methodId" Text :> ReqBody '[JSON] SubstitutionRequest :> Post '[JSON] LCIAResult
-                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "sensitivity" :> Capture "collection" Text :> Capture "methodId" Text :> ReqBody '[JSON] SensitivityRequest :> Post '[JSON] SensitivityResponse
+                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "impacts" :> Capture "collection" DM.CollectionName :> QueryParam "exclude-long-term" Bool :> Get '[JSON] LCIABatchResult
+                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "impacts" :> Capture "collection" DM.CollectionName :> QueryParam "exclude-long-term" Bool :> ReqBody '[JSON] SubstitutionRequest :> Post '[JSON] LCIABatchResult
+                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "impacts" :> Capture "collection" DM.CollectionName :> Capture "methodId" Text :> QueryParam "top-flows" Int :> Get '[JSON] LCIAResult
+                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "impacts" :> Capture "collection" DM.CollectionName :> Capture "methodId" Text :> ReqBody '[JSON] SubstitutionRequest :> Post '[JSON] LCIAResult
+                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "sensitivity" :> Capture "collection" DM.CollectionName :> Capture "methodId" Text :> ReqBody '[JSON] SensitivityRequest :> Post '[JSON] SensitivityResponse
                 :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "inventory" :> ReqBody '[JSON] SubstitutionRequest :> Post '[JSON] InventoryExport
                 :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "supply-chain" :> QueryParam "name" Text :> QueryParam "limit" Int :> QueryParam "min-quantity" Double :> QueryParam "offset" Int :> QueryParam "max-depth" Int :> QueryParam "location" Text :> QueryParam "product" Text :> QueryParam "preset" Text :> QueryParams "classification" Text :> QueryParams "classification-value" Text :> QueryParams "classification-mode" Text :> QueryParam "sort" Text :> QueryParam "order" Text :> QueryParam "include-edges" Bool :> ReqBody '[JSON] SubstitutionRequest :> Post '[JSON] SupplyChainResponse
                 :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "consumers" :> QueryParam "name" Text :> QueryParam "location" Text :> QueryParam "product" Text :> QueryParam "preset" Text :> QueryParams "classification" Text :> QueryParams "classification-value" Text :> QueryParams "classification-mode" Text :> QueryParam "limit" Int :> QueryParam "offset" Int :> QueryParam "max-depth" Int :> QueryParam "sort" Text :> QueryParam "order" Text :> QueryParam "include-edges" Bool :> Get '[JSON] ConsumersResponse
                 :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "path-to" :> QueryParam "target" Text :> Get '[JSON] Value
-                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "contributing-flows" :> Capture "collection" Text :> Capture "methodId" Text :> QueryParam "limit" Int :> QueryParam "exclude-long-term" Bool :> Get '[JSON] ContributingFlowsResult
-                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "contributing-activities" :> Capture "collection" Text :> Capture "methodId" Text :> QueryParam "limit" Int :> QueryParam "exclude-long-term" Bool :> Get '[JSON] ContributingActivitiesResult
+                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "contributing-flows" :> Capture "collection" DM.CollectionName :> Capture "methodId" Text :> QueryParam "limit" Int :> QueryParam "exclude-long-term" Bool :> Get '[JSON] ContributingFlowsResult
+                :<|> "db" :> Capture "dbName" Text :> "activity" :> Capture "processId" Text :> "contributing-activities" :> Capture "collection" DM.CollectionName :> Capture "methodId" Text :> QueryParam "limit" Int :> QueryParam "exclude-long-term" Bool :> Get '[JSON] ContributingActivitiesResult
                 :<|> "db" :> Capture "dbName" Text :> "flow" :> Capture "flowId" Text :> Get '[JSON] FlowDetail
                 :<|> "db" :> Capture "dbName" Text :> "flow" :> Capture "flowId" Text :> "activities" :> QueryParam "role" Text :> Get '[JSON] [ActivitySummary]
                 :<|> "methods" :> Get '[JSON] [MethodSummary]
@@ -116,14 +116,14 @@ type LCAAPI =
                 :<|> "method" :> Capture "methodId" Text :> "factors" :> Get '[JSON] [MethodFactorAPI]
                 :<|> "db" :> Capture "dbName" Text :> "method" :> Capture "methodId" Text :> "mapping" :> Get '[JSON] MappingStatus
                 :<|> "db" :> Capture "dbName" Text :> "method" :> Capture "methodId" Text :> "flow-mapping" :> Get '[JSON] FlowCFMapping
-                :<|> "db" :> Capture "dbName" Text :> "method-collection" :> Capture "collection" Text :> "coverage" :> Get '[JSON] CollectionCoverage
+                :<|> "db" :> Capture "dbName" Text :> "method-collection" :> Capture "collection" DM.CollectionName :> "coverage" :> Get '[JSON] CollectionCoverage
                 :<|> "db" :> Capture "dbName" Text :> "method" :> Capture "methodId" Text :> "characterization" :> QueryParam "flow" Text :> QueryParam "limit" Int :> Get '[JSON] CharacterizationResult
                 :<|> "db" :> Capture "dbName" Text :> "method" :> Capture "methodId" Text :> "explain-cf" :> Capture "flowId" Text :> Get '[JSON] ExplainCFResult
                 :<|> "db" :> Capture "dbName" Text :> "flows" :> QueryParam "q" Text :> QueryParam "lang" Text :> QueryParam "kind" Text :> QueryParam "limit" Int :> QueryParam "offset" Int :> QueryParam "sort" Text :> QueryParam "order" Text :> Get '[JSON] (SearchResults FlowSearchResult)
                 :<|> "db" :> Capture "dbName" Text :> "search-counts" :> QueryParam "q" Text :> QueryParam "sort" Text :> QueryParam "exact" Bool :> Get '[JSON] SearchCountsAPI
                 :<|> "db" :> Capture "dbName" Text :> "activities" :> QueryParam "name" Text :> QueryParam "geo" Text :> QueryParam "product" Text :> QueryParam "exact" Bool :> QueryParam "preset" Text :> QueryParams "classification" Text :> QueryParams "classification-value" Text :> QueryParams "classification-mode" Text :> QueryParam "limit" Int :> QueryParam "offset" Int :> QueryParam "sort" Text :> QueryParam "order" Text :> Get '[JSON] (SearchResults ActivitySummary)
                 :<|> "db" :> Capture "dbName" Text :> "classifications" :> Get '[JSON] [ClassificationSystem]
-                :<|> "db" :> Capture "dbName" Text :> "impacts" :> Capture "collection" Text :> QueryParam "top-flows" Int :> QueryParam "exclude-long-term" Bool :> ReqBody '[JSON] BatchImpactsRequest :> Post '[JSON] BatchImpactsResponse
+                :<|> "db" :> Capture "dbName" Text :> "impacts" :> Capture "collection" DM.CollectionName :> QueryParam "top-flows" Int :> QueryParam "exclude-long-term" Bool :> ReqBody '[JSON] BatchImpactsRequest :> Post '[JSON] BatchImpactsResponse
                 -- Database management endpoints
                 :<|> "db" :> Get '[JSON] DatabaseListResponse
                 -- Load/Unload/Delete endpoints
@@ -878,12 +878,11 @@ routes (via thin where-aliases) and by API.BatchImpacts.
 activityLCIABatchH ::
     Text ->
     Text ->
-    Text ->
+    DM.CollectionName ->
     Maybe SubstitutionRequest ->
     LongTermMode ->
     AppM LCIABatchResult
-activityLCIABatchH dbName processIdText collectionNameText mSub ltMode = do
-    let collectionName = DM.CollectionName collectionNameText
+activityLCIABatchH dbName processIdText collectionName mSub ltMode = do
     dbManager <- asks aeDbManager
     (db, sharedSolver) <- requireDatabaseByName dbName
     (actProcessId, activity) <- resolveOrThrow db processIdText
@@ -898,7 +897,7 @@ activityLCIABatchH dbName processIdText collectionNameText mSub ltMode = do
     when (isNothing mSub) $
         liftIO $ do
             reportProgress Info $
-                "[LCIA batch] " <> T.unpack collectionNameText <> " for " <> T.unpack (activityName activity)
+                "[LCIA batch] " <> T.unpack (DM.unCollectionName collectionName) <> " for " <> T.unpack (activityName activity)
             reportProgress Info $
                 "  Inventory: "
                     <> show invSize
@@ -944,20 +943,19 @@ by API.BatchImpacts.
 -}
 batchImpactsH ::
     Text ->
-    Text ->
+    DM.CollectionName ->
     Maybe Int ->
     LongTermMode ->
     BatchImpactsRequest ->
     AppM BatchImpactsResponse
-batchImpactsH dbName collectionNameText topFlowsParam ltMode req = do
-    let collectionName = DM.CollectionName collectionNameText
+batchImpactsH dbName collectionName topFlowsParam ltMode req = do
     dbManager <- asks aeDbManager
     (db, sharedSolver) <- requireDatabaseByName dbName
     loadedCollections <- liftIO $ readTVarIO (dmLoadedMethods dbManager)
-    collection <- case M.lookup collectionNameText loadedCollections of
+    collection <- case M.lookup (DM.unCollectionName collectionName) loadedCollections of
         Just mc -> pure mc
         Nothing ->
-            throwError err404{errBody = collectionNotLoadedBody collectionNameText (M.keys loadedCollections)}
+            throwError err404{errBody = collectionNotLoadedBody (DM.unCollectionName collectionName) (M.keys loadedCollections)}
     let resolved =
             [ (pidText, Service.resolveScorable db pidText)
             | pidText <- birProcessIds req
@@ -1009,7 +1007,7 @@ batchImpactsH dbName collectionNameText topFlowsParam ltMode req = do
             "[batch-impacts] "
                 <> T.unpack dbName
                 <> " / "
-                <> T.unpack collectionNameText
+                <> T.unpack (DM.unCollectionName collectionName)
                 <> ": "
                 <> show (length valid)
                 <> " activities"
@@ -1049,8 +1047,8 @@ computedQualityReportH dbName mCollection mLimit = do
     (db, _solver) <- requireDatabaseByName dbName
     loadedCollections <- liftIO $ readTVarIO (dmLoadedMethods dbManager)
     collection <- case (mCollection, M.keys loadedCollections) of
-        (Just c, _) -> pure c -- an unknown name answers 404 in batchImpactsH below
-        (Nothing, [only]) -> pure only
+        (Just c, _) -> pure (DM.CollectionName c) -- an unknown name answers 404 in batchImpactsH below
+        (Nothing, [only]) -> pure (DM.CollectionName only)
         (Nothing, []) ->
             throwError err400{errBody = "No method collection loaded - the computed checks judge scores, so they need one"}
         (Nothing, several) ->
@@ -1102,7 +1100,7 @@ computedQualityReportH dbName mCollection mLimit = do
             | e <- concatMap birResults responses
             , Just act <- [M.lookup (bieProcessId e) entriesByPid]
             ]
-    pure (DBHandlers.computedQualityReportToAPI mLimit (CQ.computedQualityReport dbName collection scored))
+    pure (DBHandlers.computedQualityReportToAPI mLimit (CQ.computedQualityReport dbName (DM.unCollectionName collection) scored))
 
 {- | The same two reports as a downloadable file. They answer the question the
 JSON answers, in the shape the person asking it works in: a spreadsheet, or a
@@ -1727,9 +1725,8 @@ getActivityAggregate dbName processId scopeParam isInputParam maxDepthParam fnam
 {- | LCIA single-method core. GET passes a top-flows param and logs;
 POST carries substitutions instead and skips logging.
 -}
-activityLCIACore :: Text -> Text -> Text -> Text -> Maybe Int -> Maybe SubstitutionRequest -> AppM LCIAResult
-activityLCIACore dbName processIdText collectionNameText methodIdText topFlowsParam mSub = do
-    let collectionName = DM.CollectionName collectionNameText
+activityLCIACore :: Text -> Text -> DM.CollectionName -> Text -> Maybe Int -> Maybe SubstitutionRequest -> AppM LCIAResult
+activityLCIACore dbName processIdText collectionName methodIdText topFlowsParam mSub = do
     dbManager <- asks aeDbManager
     (db, sharedSolver) <- requireDatabaseByName dbName
     method <- loadMethodInCollection collectionName methodIdText
@@ -1740,20 +1737,19 @@ activityLCIACore dbName processIdText collectionNameText methodIdText topFlowsPa
     when (isNothing mSub) $ liftIO $ logLCIAResult result method
     pure result
 
-getActivityLCIA :: Text -> Text -> Text -> Text -> Maybe Int -> AppM LCIAResult
+getActivityLCIA :: Text -> Text -> DM.CollectionName -> Text -> Maybe Int -> AppM LCIAResult
 getActivityLCIA dbName processIdText collectionName methodIdText topFlowsParam =
     activityLCIACore dbName processIdText collectionName methodIdText topFlowsParam Nothing
 
-postActivityLCIA :: Text -> Text -> Text -> Text -> SubstitutionRequest -> AppM LCIAResult
+postActivityLCIA :: Text -> Text -> DM.CollectionName -> Text -> SubstitutionRequest -> AppM LCIAResult
 postActivityLCIA dbName processIdText collectionName methodIdText subReq =
     activityLCIACore dbName processIdText collectionName methodIdText Nothing (Just subReq)
 
 {- | Sensitivity sweep: rank-1 perturbations on the root scaling, scored
 through the cross-DB graph (regional CFs on dep DBs still apply).
 -}
-postActivitySensitivity :: Text -> Text -> Text -> Text -> SensitivityRequest -> AppM SensitivityResponse
-postActivitySensitivity dbName processIdText collectionNameText methodIdText senReq = do
-    let collectionName = DM.CollectionName collectionNameText
+postActivitySensitivity :: Text -> Text -> DM.CollectionName -> Text -> SensitivityRequest -> AppM SensitivityResponse
+postActivitySensitivity dbName processIdText collectionName methodIdText senReq = do
     dbManager <- asks aeDbManager
     (db, sharedSolver) <- requireDatabaseByName dbName
     requireFullyLinked dbName db
@@ -1803,11 +1799,11 @@ postActivitySensitivity dbName processIdText collectionNameText methodIdText sen
             mapConcurrently (buildEntry baselineLcia) perResults
     pure SensitivityResponse{srBaseline = baselineLcia, srPerturbed = perturbed}
 
-getActivityLCIABatch :: Text -> Text -> Text -> Maybe Bool -> AppM LCIABatchResult
+getActivityLCIABatch :: Text -> Text -> DM.CollectionName -> Maybe Bool -> AppM LCIABatchResult
 getActivityLCIABatch dbName processIdText collectionName mExcludeLT =
     activityLCIABatchH dbName processIdText collectionName Nothing (longTermModeFromExclude (fromMaybe False mExcludeLT))
 
-postActivityLCIABatch :: Text -> Text -> Text -> Maybe Bool -> SubstitutionRequest -> AppM LCIABatchResult
+postActivityLCIABatch :: Text -> Text -> DM.CollectionName -> Maybe Bool -> SubstitutionRequest -> AppM LCIABatchResult
 postActivityLCIABatch dbName processIdText collectionName mExcludeLT subReq =
     activityLCIABatchH dbName processIdText collectionName (Just subReq) (longTermModeFromExclude (fromMaybe False mExcludeLT))
 
@@ -1896,88 +1892,86 @@ getActivityPathTo dbName processIdText targetParam = do
             throwError err500{errBody = BSL.fromStrict $ T.encodeUtf8 $ T.pack $ show err}
         Right val -> return val
 
-getContributingFlows :: Text -> Text -> Text -> Text -> Maybe Int -> Maybe Bool -> AppM ContributingFlowsResult
-getContributingFlows dbName processIdText collectionNameText methodIdText limitParam mExcludeLT =
-    let collectionName = DM.CollectionName collectionNameText
-     in withActivityAndMethod dbName collectionName processIdText methodIdText $ \db sharedSolver actProcessId _ method -> do
-            dbManager <- asks aeDbManager
-            let lim = fromMaybe 20 limitParam
-                ltMode = longTermModeFromExclude (fromMaybe False mExcludeLT)
-            unitCfg <- liftIO $ getMergedUnitConfig dbManager
-            (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
-            inventory <- applyLongTermMode mFlows ltMode <$> inventoryWithDeps dbName db sharedSolver actProcessId
-            tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName collectionName db method
-            let score = loScore (computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables)
-                (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
-                contribs = sortOn (\(_, _, c) -> negate (abs c)) rawContribs
-                topFlows =
-                    [ FlowContributionEntry
-                        { fcoFlowName = bfName f
-                        , fcoContribution = c
-                        , fcoSharePct = if score /= 0 then c / score * 100 else 0
-                        , fcoFlowId = UUID.toText (bfId f)
-                        , fcoCategory = bfCompartmentName f
-                        , fcoCompartment = bfCompartmentSub f
-                        , fcoCfValue = cfVal
-                        , fcoMatchKind = Explain.flowMatchKind tables (bfId f)
-                        }
-                    | (f, cfVal, c) <- take lim contribs
-                    ]
-            liftIO $
-                unless (null unknownUuids) $
-                    reportProgress Warning $
-                        "[contributing-flows "
-                            <> T.unpack (methodName method)
-                            <> "] "
-                            <> show (length unknownUuids)
-                            <> " inventory flow UUID(s) absent from merged FlowDB. Samples: "
-                            <> show (take 3 unknownUuids)
-            return
-                ContributingFlowsResult
-                    { cfrMethod = methodName method
-                    , cfrUnit = methodUnit method
-                    , cfrTotalScore = score
-                    , cfrTopFlows = topFlows
+getContributingFlows :: Text -> Text -> DM.CollectionName -> Text -> Maybe Int -> Maybe Bool -> AppM ContributingFlowsResult
+getContributingFlows dbName processIdText collectionName methodIdText limitParam mExcludeLT =
+    withActivityAndMethod dbName collectionName processIdText methodIdText $ \db sharedSolver actProcessId _ method -> do
+        dbManager <- asks aeDbManager
+        let lim = fromMaybe 20 limitParam
+            ltMode = longTermModeFromExclude (fromMaybe False mExcludeLT)
+        unitCfg <- liftIO $ getMergedUnitConfig dbManager
+        (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
+        inventory <- applyLongTermMode mFlows ltMode <$> inventoryWithDeps dbName db sharedSolver actProcessId
+        tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName collectionName db method
+        let score = loScore (computeLCIAScoreFromTables unitCfg mUnits mFlows inventory tables)
+            (rawContribs, unknownUuids) = inventoryContributions unitCfg mUnits mFlows inventory tables
+            contribs = sortOn (\(_, _, c) -> negate (abs c)) rawContribs
+            topFlows =
+                [ FlowContributionEntry
+                    { fcoFlowName = bfName f
+                    , fcoContribution = c
+                    , fcoSharePct = if score /= 0 then c / score * 100 else 0
+                    , fcoFlowId = UUID.toText (bfId f)
+                    , fcoCategory = bfCompartmentName f
+                    , fcoCompartment = bfCompartmentSub f
+                    , fcoCfValue = cfVal
+                    , fcoMatchKind = Explain.flowMatchKind tables (bfId f)
                     }
+                | (f, cfVal, c) <- take lim contribs
+                ]
+        liftIO $
+            unless (null unknownUuids) $
+                reportProgress Warning $
+                    "[contributing-flows "
+                        <> T.unpack (methodName method)
+                        <> "] "
+                        <> show (length unknownUuids)
+                        <> " inventory flow UUID(s) absent from merged FlowDB. Samples: "
+                        <> show (take 3 unknownUuids)
+        return
+            ContributingFlowsResult
+                { cfrMethod = methodName method
+                , cfrUnit = methodUnit method
+                , cfrTotalScore = score
+                , cfrTopFlows = topFlows
+                }
 
-getContributingActivities :: Text -> Text -> Text -> Text -> Maybe Int -> Maybe Bool -> AppM ContributingActivitiesResult
-getContributingActivities dbName processIdText collectionNameText methodIdText limitParam mExcludeLT =
-    let collectionName = DM.CollectionName collectionNameText
-     in withActivityAndMethod dbName collectionName processIdText methodIdText $ \db sharedSolver actProcessId _ method -> do
-            dbManager <- asks aeDbManager
-            let lim = fromMaybe 10 limitParam
-                ltMode = longTermModeFromExclude (fromMaybe False mExcludeLT)
-            requireFullyLinked dbName db
-            unitCfg <- liftIO $ getMergedUnitConfig dbManager
-            (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
-            tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName collectionName db method
-            eContribs <-
-                liftIO $
-                    SharedSolver.crossDBProcessContributions
-                        unitCfg
-                        mUnits
-                        mFlows
-                        (DM.mkDepSolverLookup dbManager)
-                        db
-                        dbName
-                        sharedSolver
-                        actProcessId
-                        tables
-                        ltMode
-            case eContribs of
-                Left err -> throwError err422{errBody = BSL.fromStrict $ T.encodeUtf8 err}
-                Right contributions -> do
-                    let score = sum (M.elems contributions)
-                        sorted = sortOn (\(_, c) -> negate (abs c)) (M.toList contributions)
-                        top = take lim sorted
-                    rows <- liftIO $ mapM (mkCrossDBContrib dbManager dbName mFlows mUnits score) top
-                    return
-                        ContributingActivitiesResult
-                            { carMethod = methodName method
-                            , carUnit = methodUnit method
-                            , carTotalScore = score
-                            , carActivities = rows
-                            }
+getContributingActivities :: Text -> Text -> DM.CollectionName -> Text -> Maybe Int -> Maybe Bool -> AppM ContributingActivitiesResult
+getContributingActivities dbName processIdText collectionName methodIdText limitParam mExcludeLT =
+    withActivityAndMethod dbName collectionName processIdText methodIdText $ \db sharedSolver actProcessId _ method -> do
+        dbManager <- asks aeDbManager
+        let lim = fromMaybe 10 limitParam
+            ltMode = longTermModeFromExclude (fromMaybe False mExcludeLT)
+        requireFullyLinked dbName db
+        unitCfg <- liftIO $ getMergedUnitConfig dbManager
+        (mFlows, mUnits) <- liftIO $ DM.getMergedFlowMetadata dbManager
+        tables <- liftIO $ DM.mapMethodToTablesCached dbManager dbName collectionName db method
+        eContribs <-
+            liftIO $
+                SharedSolver.crossDBProcessContributions
+                    unitCfg
+                    mUnits
+                    mFlows
+                    (DM.mkDepSolverLookup dbManager)
+                    db
+                    dbName
+                    sharedSolver
+                    actProcessId
+                    tables
+                    ltMode
+        case eContribs of
+            Left err -> throwError err422{errBody = BSL.fromStrict $ T.encodeUtf8 err}
+            Right contributions -> do
+                let score = sum (M.elems contributions)
+                    sorted = sortOn (\(_, c) -> negate (abs c)) (M.toList contributions)
+                    top = take lim sorted
+                rows <- liftIO $ mapM (mkCrossDBContrib dbManager dbName mFlows mUnits score) top
+                return
+                    ContributingActivitiesResult
+                        { carMethod = methodName method
+                        , carUnit = methodUnit method
+                        , carTotalScore = score
+                        , carActivities = rows
+                        }
 
 getFlowDetail :: Text -> Text -> AppM FlowDetail
 getFlowDetail dbName flowIdText = do
@@ -2105,16 +2099,15 @@ Distinct across methods, because they overlap — every climate-change variant
 characterizes the same gases — so this number cannot be recovered from the
 per-method mapping statuses.
 -}
-getCollectionCoverage :: Text -> Text -> AppM CollectionCoverage
-getCollectionCoverage dbName collectionNameText = do
-    let collectionName = DM.CollectionName collectionNameText
+getCollectionCoverage :: Text -> DM.CollectionName -> AppM CollectionCoverage
+getCollectionCoverage dbName collectionName = do
     dbManager <- asks aeDbManager
     (db, _) <- requireDatabaseByName dbName
     (methods, _, _, _) <- loadCollection collectionName
     tablesList <- liftIO $ mapM (DM.mapMethodToTablesCached dbManager dbName collectionName db) methods
     return
         CollectionCoverage
-            { ccvCollection = collectionNameText
+            { ccvCollection = DM.unCollectionName collectionName
             , ccvDbName = dbName
             , ccvTotalFlows = fromIntegral (dbBiosphereCount db)
             , ccvCharacterizedFlows = S.size (S.unions (map (`characterizedFlowIds` dbBioFlows db) tablesList))
@@ -2269,7 +2262,7 @@ getClassifications dbName = do
     (db, _) <- requireDatabaseByName dbName
     return $ Service.getClassifications db
 
-postImpactsBatch :: Text -> Text -> Maybe Int -> Maybe Bool -> BatchImpactsRequest -> AppM BatchImpactsResponse
+postImpactsBatch :: Text -> DM.CollectionName -> Maybe Int -> Maybe Bool -> BatchImpactsRequest -> AppM BatchImpactsResponse
 postImpactsBatch dbName collectionName topFlowsParam mExcludeLT =
     batchImpactsH dbName collectionName topFlowsParam (longTermModeFromExclude (fromMaybe False mExcludeLT))
 

--- a/src/Database/Manager.hs
+++ b/src/Database/Manager.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -156,7 +157,7 @@ import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import Data.Maybe (catMaybes, fromMaybe, isNothing, mapMaybe)
-import Data.OpenApi (NamedSchema (..), OpenApiType (..), ToSchema (..), enum_, type_)
+import Data.OpenApi (NamedSchema (..), OpenApiType (..), ToParamSchema, ToSchema (..), enum_, type_)
 import Data.Ord (Down (..))
 import qualified Data.Set as S
 import Data.Text (Text)
@@ -229,6 +230,7 @@ import Method.Types (
  )
 import Progress (ProgressLevel (..), reportError, reportProgress, reportProgressWithTiming, withLogScope)
 import qualified Search.BM25 as BM25
+import Servant.API (FromHttpApiData)
 import SharedSolver (SharedSolver, createSharedSolver)
 import qualified SharedSolver
 import SubstanceRegistry (CASNumber (..), KeyNormalizers (..), NormName (..), SubstanceEdge, casBindingsFromEdges, normalizeCAS, parseSubstanceEdges)
@@ -708,9 +710,15 @@ getFlowClosure manager dbName db = atomically $ do
 {- | The name of a method collection. A newtype because it travels next to a
 database name, of the same type, through every cache lookup below: swapped,
 the two would read and fill the wrong cache entry and nothing would say so.
+
+'FromHttpApiData' and 'ToParamSchema' are derived from 'Text', not written, so
+the URL segment a route captures parses and documents itself exactly as it did
+when it was a 'Text'. They are what lets the name be minted at the capture
+rather than a few lines into each handler.
 -}
 newtype CollectionName = CollectionName {unCollectionName :: Text}
-    deriving (Eq, Ord, Show)
+    deriving stock (Eq, Ord, Show)
+    deriving newtype (FromHttpApiData, ToParamSchema)
 
 {- | Cached flow mapping: avoids re-matching method CFs to database flows on every LCIA call.
 The mapping depends only on (database, method), not on the process being evaluated.

--- a/test/CollectionParamSpec.hs
+++ b/test/CollectionParamSpec.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | What shape does the published spec give the @collection@ parameter?
+
+A method collection is named in a path capture on nine routes and in a query
+parameter on three more, and the Haskell type behind those positions is what
+decides the schema the published spec carries. 'ResourcesDriftSpec' compares
+parameter /names/ only, so a parameter whose schema changed underneath keeps
+every test in this suite green. This is the test that notices, and it is what
+lets the type behind a capture change without changing the contract pyvolca is
+generated from.
+
+No server and no database: the spec is a pure value.
+-}
+module CollectionParamSpec (spec) where
+
+import Control.Lens ((^.))
+import Data.Foldable (toList)
+import Data.List (nub)
+import Data.Maybe (mapMaybe)
+import Data.OpenApi (OpenApiType (..), Operation, Param, ParamLocation (..), PathItem, Referenced (..), Schema)
+import qualified Data.OpenApi.Lens as OA
+import Data.Text (Text)
+import Test.Hspec
+
+import API.Routes (volcaOpenApi)
+
+-- | Every parameter named @collection@ the published spec carries.
+collectionParams :: [Param]
+collectionParams =
+    [ p
+    | item <- toList (volcaOpenApi ^. OA.paths)
+    , op <- operationsOf item
+    , Inline p <- op ^. OA.parameters
+    , p ^. OA.name == "collection"
+    ]
+
+-- | The operations a path item carries, whatever verb they answer.
+operationsOf :: PathItem -> [Operation]
+operationsOf item =
+    mapMaybe
+        (item ^.)
+        [OA.get, OA.put, OA.post, OA.delete, OA.patch, OA.head_, OA.options]
+
+-- | The parameters named @collection@ that sit in one place.
+paramsIn :: ParamLocation -> [Param]
+paramsIn loc = [p | p <- collectionParams, p ^. OA.in_ == loc]
+
+{- | What the published spec says a parameter is, in the words a reader of the
+document would use. Written as a sentence rather than a predicate so a failure
+says which of the four things it became.
+-}
+shapeOf :: Param -> Text
+shapeOf p = case p ^. OA.schema of
+    Nothing -> "no schema at all"
+    Just (Ref _) -> "a named schema reference"
+    Just (Inline s) -> inlineShape s
+
+inlineShape :: Schema -> Text
+inlineShape s
+    | s ^. OA.type_ /= Just OpenApiString = "not a string"
+    | not (null (s ^. OA.format)) = "a string carrying a format"
+    | not (null (s ^. OA.enum_)) = "a string carrying an enumeration"
+    | otherwise = "a plain string"
+
+spec :: Spec
+spec = describe "the collection parameter of the published spec" $ do
+    it "appears both as a path capture and as a query parameter" $ do
+        paramsIn ParamPath `shouldSatisfy` not . null
+        paramsIn ParamQuery `shouldSatisfy` not . null
+
+    it "is a plain string in every one of them" $
+        nub (map shapeOf collectionParams) `shouldBe` ["a plain string"]

--- a/test/CollectionParamSpec.hs
+++ b/test/CollectionParamSpec.hs
@@ -2,8 +2,8 @@
 
 {- | What shape does the published spec give the @collection@ parameter?
 
-A method collection is named in a path capture on nine routes and in a query
-parameter on three more, and the Haskell type behind those positions is what
+A method collection is named by a path capture on some routes and by a query
+parameter on others, and the Haskell type behind those positions is what
 decides the schema the published spec carries. 'ResourcesDriftSpec' compares
 parameter /names/ only, so a parameter whose schema changed underneath keeps
 every test in this suite green. This is the test that notices, and it is what

--- a/volca.cabal
+++ b/volca.cabal
@@ -339,6 +339,7 @@ test-suite lca-tests
                      , CLISpec
                      , CLIRenderSpec
                      , ResourcesDriftSpec
+                     , CollectionParamSpec
                      , RoutesSpec
                      , ScoringKeySpec
                      , NumericEdgesSpec


### PR DESCRIPTION
**Target.** A method collection name is minted as `CollectionName` by the URL capture that names it, instead of eight lines into the handler, so no signature between the URL and the lookup can confuse it with the database, process and method names travelling beside it.

**Axis.** Invalid states.

**Problem.** `CollectionName` already exists and its own doc comment says why (`src/Database/Manager.hs:708-711`, declaration at `:712-713`): a collection name "travels next to a database name, of the same type, through every cache lookup below: swapped, the two would read and fill the wrong cache entry and nothing would say so". The five cache keys honour it (`:602`, `:609`, `:614`, `:621`, `:629`); nothing between the URL and those caches did. The route type captured the segment as `Text` nine times (`src/API/Routes.hs:101`, `:102`, `:103`, `:104`, `:105`, `:110`, `:111`, `:119`, `:126`) and seven handlers opened by wrapping it on their first line (`:886`, `:953`, `:1732`, `:1756`, `:1901`, `:1945`, `:2110`). In the stretch between, `activityLCIACore :: Text -> Text -> Text -> Text -> Maybe Int -> ...` (`:1730`) took four adjacent `Text` - database, process, collection, method - that the compiler could not tell apart; `getActivityLCIA`, `postActivityLCIA`, `postActivitySensitivity`, `getContributingFlows` and `getContributingActivities` took the same four, and `activityLCIABatchH` three.

**Transformation.** `CollectionName` gains `FromHttpApiData` and `ToParamSchema` by `deriving newtype`, so the nine `Capture "collection"` positions read `DM.CollectionName` and the seven wraps have nothing left to do; the handler signatures behind them, listed under "Done when", carry the newtype in the collection position. The chain is `LCAAPI` capture -> handler -> `loadCollection` / `withActivityAndMethod` / `mapMethodToTablesCached`, all three of which already took a `CollectionName`.

**Behaviour preserved.** Every URL answers as before: `parseUrlPiece` for a newtype over `Text` is `Text`'s, which is total, so nothing that routes today stops routing and no new 400 appears. The `collection` parameter of the published spec keeps its name, its `in`, its `required` and its `type: string` schema - `API/OpenApi.hs:133` finds a parameter by name, which does not move, and a newtype-derived `ToParamSchema` is definitionally `Text`'s. The 404 body for a collection that is not loaded quotes the same name on both paths (`:590` and `:960`, which spell it differently and still agree). That schema was pinned by **nothing** - `ResourcesDriftSpec` compares parameter *names* only (`:39`) and would stay green through a schema change - so the first commit characterises it.

**Left as `Text` on purpose, and not by oversight.** `dmLoadedMethods` stays `TVar (Map Text MethodCollection)`, so `loadCollection` still unwraps once at the map; the three `QueryParam "collection"` positions stay `Text`, the run being scoped to the captures; and `runActivityLCIABatch` / `runBatchImpacts` keep their `Text` signatures and mint at their own door. That is what keeps this to three source files and no edited spec. Each is written up below, with what it would actually cost.

**Done when.** Met:
- `CollectionName` derives `FromHttpApiData` and `ToParamSchema` newtype-wise, and nothing else about the type changes.
- The nine `Capture "collection"` positions read `DM.CollectionName`; the seven `let collectionName = DM.CollectionName collectionNameText` lines are gone.
- Every constructor application left in `src/API/Routes.hs` mints at a door this run leaves as `Text`: `computedQualityReportH`'s two (`:1050`, `:1051`) and `loadMethodByUUID`'s (`:1282`).
- `activityLCIACore`, `getActivityLCIA`, `postActivityLCIA`, `postActivitySensitivity`, `getContributingFlows`, `getContributingActivities`, `activityLCIABatchH`, `batchImpactsH`, `postImpactsBatch` and `getCollectionCoverage` carry a `CollectionName` in the collection position.
- `runActivityLCIABatch` and `runBatchImpacts` still take `Text` and mint inside, so `src/API/BatchImpacts.hs` changes by one import and two constructor applications and none of *their* callers changes: `src/API/MCP.hs:2196`, `:2256` and `test/BatchImpactsSpec.hs:86`, `:96` are untouched.
- A new spec asserts the `collection` parameter's schema on the pure `volcaOpenApi` value, and was green before the rewrite as well as after.
- `hlint src app test` reports no hints, a cold `-Werror` build is green, the suite is 2645 examples, 0 failures, 2 pending (2643 before, plus the two the characterisation adds), and no existing spec was edited.

**Reading the diff.** `src/API/Routes.hs` shows 227 changed lines and `git diff -w` shows 83. The difference is reindentation: `getContributingFlows` and `getContributingActivities` were `let collectionName = ... in withActivityAndMethod ...`, and losing the `let` dedents each body by one level, which the formatter did.

This target needs no second pass. What it deliberately left is a target of its own, first on the list below.

<details>
<summary>For the next run: not chosen, behaviour changes, numbers</summary>

**Cut from this target by the falsifier, so first on the list**

- Rekeying `dmLoadedMethods` to `Map CollectionName MethodCollection` (`src/Database/Manager.hs:582`, eighteen read and write sites): reaches `Database/Manager.hs`, `API/DatabaseHandlers.hs`, `CLI/Command.hs`, `Database/ComputedQuality.hs`, `API/MCP.hs`, `API/BatchImpacts.hs`, and edits `test/MethodResolveSpec.hs` and `test/BatchImpactsSpec.hs`.
- The second collection-keyed map, `dmAvailableMethods :: !(TVar (Map Text MethodConfig))` (`:581`), which `Manager.hs:800` already unwraps a `CollectionName` to key: whoever takes the line above takes both maps or says why not.
- The three `QueryParam "collection"` positions (`src/API/Routes.hs:141`, `:142`, `:144`), and they do not cost the same. Typing `:144` pulls in `coverageReportHandler` (`src/API/DatabaseHandlers.hs:466`); typing `:141` and `:142` pulls in nothing at all, since `computedQualityReportH` lives in `src/API/Routes.hs` and its only caller outside it is `src/API/BatchImpacts.hs:122`, a file this pull request already edits, while `Database/ComputedQuality.hs` stays untouched either way because the unwrap sits at the call (`:1103`). Those two were left out because the run was scoped to the captures, not because they reach further - a cheap next pass.

**Would change behaviour, so reported and not fixed**

- `src/Database/Manager.hs:1926` - `detectDirectoryFormat` and `Upload.detectDatabaseFormat` are two detectors over two sum types for one set of formats, with a comment at `:1955` saying they must agree in probe order and nothing making them; the upload one content-checks a `.csv` and a `.xml`, the other does not.
- `src/Database/Manager.hs:2099` - the `FormatCSV` arm goes through `loadCSV` (`:2114`), which never runs cross-database linking, so a configured CSV links differently from the same file uploaded (`:2795`).
- `src/API/DatabaseHandlers.hs:1241` - the method upload puts the database detector's verdict on the wire two lines after computing the method detector's, which the comment at `:1202` says is the right one.
- `src/Database/Manager.hs:3288` - `rankMissingProducts` appends two name-keyed maps whose comment argues disjointness on exchanges, not on names, so one product name can be listed and ranked twice.
- `src/Database/Manager.hs:3999` - `mcsFormat` is guessed by substring on the path while `Upload.detectMethodFormat` exists, so one collection can be labelled two ways.
- `src/Database/Manager.hs:3419` - `PathCandidate.pcFormat` is rendered by a hand-written `case` over a type that already renders itself, and the two disagree on the unknown format (`""` against `"Unknown"`).
- `src/Database/Manager.hs:3406` - `buildDependencyChoices` is passed `[]` for the redundant dependencies on the loaded path, so a loaded database never shows one.
- `src/Database/Manager.hs:337` - `MissingSupplier.msLocation` is `Nothing` at its only construction site (`:3300`) and has no reader, yet is on the wire.
- `src/API/DatabaseHandlers.hs:1148` - the set-data-path body is a raw `Value` scanned by hand, with two wildcard arms (`:1156`, `:1157`); typing it moves the 400 text to Servant's.
- `src/API/Routes.hs:2427` - `paginateResults` is in `IO` only to time a `take . drop` and reports that as `srSearchTimeMs`.

**Not chosen, ranked**

Invalid states:
- `ClassificationFilter` for the `(Text, Text, Bool)` crossing twelve signatures in seven modules (`src/Service.hs:56`, `src/API/Routes.hs:1153`, `src/API/MCP.hs:743`, `src/Config.hs:115`, `src/Database/Edit.hs:881`, `src/Service/Aggregate.hs:108`, `src/Database.hs:380`) - strongest candidate after this one, and dropped on locality for the third run running, which is itself worth reading as a signal.
- `GeographyRow` for the `Map Text (Text, [Text])` geography table, with `Location` keys minted by the parser rather than at `:4214` (`src/Database/Manager.hs:596`, `:1262`, `:4572`).
- `DependencyEdit` for `relinkDatabaseWithMapping`'s two adjacent `Text` (`src/Database/Manager.hs:2521`, the record at `:3579`).
- `QuotaCounts` for `quotaCounts`'s `([Text], [Text])`, the second list a subset of the first (`src/API/DatabaseHandlers.hs:819`).
- `UploadIntent` for `withStreamedUpload`'s two adjacent `Maybe Text` (`src/API/DatabaseHandlers.hs:904`).
- `HostingInfo` for `getHosting :: AppM Value`, which erases the wire type built in the line below it (`src/API/Routes.hs:1395`).
- `DbScaling` for `csScalings :: NonEmpty (Text, Database, Vector)` (`src/API/Routes.hs:632`) - reaches `SharedSolver` and LCIA, and #398 left it for the same reason.
- `DbName` for the database names in four `Map Text` fields and most of this scope (`src/Database/Manager.hs:576-580`) - the reader says plainly there is no boundary that lands it alone, which is why #398 and #423 both dropped it.

Mixed effects:
- `deleteRefusal`, a pure verdict hoisted out of `removeDatabase` (`src/Database/Manager.hs:2935`), modelled on `unloadRefusal` twenty lines above it (`:2906`).

Duplication:
- The three wire status fields are `Text` re-rendered by hand from `DatabaseLoadStatus`, which already serialises to exactly those words, and two renderers wildcard `PartiallyLinked` into `"unloaded"` (`src/API/Routes.hs:2195`, `src/API/DatabaseHandlers.hs:1315`, `src/API/Types.hs:490`, `:511`, `:865`) - no producer emits `PartiallyLinked` on those two paths today, so the wildcards are a trap rather than a bug.
- "Partially linked iff a product is unresolved" is decided in three places (`src/Database/Manager.hs:1762`, `src/API/DatabaseHandlers.hs:1067`, `src/API/Routes.hs:266`), and `makeStatusFromLoadedDb` rebuilds as strings the row `listDatabases` builds as a record.
- `parseScope` and `parseAggregateFn` are written twice, in `Routes` (`:1680`) and in `MCP` (`:1012`), while `AggScope` and `AggregateFn` exist and `scopeText` renders them (`src/Service/Aggregate.hs:87`, `:500`).
- `mkCrossDBContrib` exists twice (`src/API/Routes.hs:352`, `src/API/MCP.hs:1817`), each stacking a `("", 0, "")` sentinel on the `("", 1.0, "")` `Service.getReferenceProductInfo` already returns (`src/Service.hs:1350`).
- `rdOps` returns a six-tuple destructured with five underscores per handler, re-tupling the `RefDataOps` record Manager already has, and the upload subdirectory is written twice (`src/API/DatabaseHandlers.hs:1293`, `src/Database/Manager.hs:4310`).
- `batchImpactsH` and `computedQualityReportH` read `dmLoadedMethods` directly to give the 404 `loadCollection` already gives (`src/API/Routes.hs:956`, `:1050`).

Cosmetic:
- `MethodKey` for the `(Text, CollectionName, UUID)` cache keys (`src/Database/Manager.hs:602`) - the natural second pass on this target, deliberately left out of it.
- `ScoringOutcome` for `computeAllScoringSets`'s pair of maps, received as two of seven positionals (`src/API/Routes.hs:488`, `:2391`).
- `batchedScoresFor` takes a database name and a `Database` it never reads, and `mkCrossDBContrib` a `BioFlowDB` it never reads (`src/API/Routes.hs:649`, `:364`).
- `loadDatabaseFromConfigWithCrossDB` takes six positionals, three of which are exactly a `LoadLevel` (`src/Database/Manager.hs:1835`).
- `Page` for `paginateResults`'s two adjacent `Maybe Int` (`src/API/Routes.hs:2427`) - the rest of that candidate changes behaviour.

Module organisation:
- `src/Database/Manager.hs` holds three subjects joined by one record, with one back edge (a reference-data load purges the method caches while the method table build reads the merged reference tables), so a split starts by hoisting `DatabaseManager`, `publishLoaded` and the purges into a state module. Not before the types above.

**Seen, not touched.** `hspec-discover` is not on the language server's PATH, so `test/Spec.hs` shows a diagnostic that `cabal test` does not; unrelated to this change.

**Scope of the run.** `volca-public/src` is 92 files and 58467 lines and its `sigs.awk` listing is 8874 lines, so the reader was given the three highest-counting files no earlier run had read: `src/Database/Manager.hs`, `src/API/Routes.hs`, `src/API/DatabaseHandlers.hs`. Left out, and the next narrowing: `src/Service.hs` (3168 lines, 24 tuples in signatures) and `src/API/MCP.hs` (2307 lines, deepest in the tree at 182 lines past column 28).

**Numbers.** `src/API/Routes.hs` 2482 lines to 2475 and bare primitives in signatures 288 to 276, lines past column 28 57 to 47; `src/Database/Manager.hs` 4740 to 4748, which is the doc comment explaining the two derived instances, every count unchanged; `src/API/BatchImpacts.hs` 183 lines, unchanged. Deepest column is 37 in both files, before and after. Signature, tuple and `Bool` counts move nowhere: what was bought is nine signatures on which the collection can no longer be swapped with its three neighbours.

**Falsifier, four verdicts.**
1. Problem holds; five line numbers corrected (the doc comment is `:708-711`; eighteen read and write sites, not twenty; `activityLCIABatchH`'s signature spans `:878-884`; only one of `loadCollection`'s two unwraps keys the map; `src/API/BatchImpacts.hs` is 183 lines). It also found the second collection-keyed map the reader missed.
2. Preserves, on the OpenAPI parameter, on key order, and on the two 404 bodies - but it rejected the claim that `ResourcesDriftSpec` pins the parameter, which is why the characterisation exists.
3. **Boundary rejected and replaced.** The original target rekeyed `dmLoadedMethods` as well, reaching eight modules and editing two specs. Its narrower proposal is what landed.
4. "Done when" checkable after three corrections, all applied: the constructor-application line now names the three doors left as `Text`; "the four other `Map Text` fields" was wrong (`DatabaseManager` has fourteen, two keyed by collection name) and became the two explicit exclusions; and the characterisation is the OpenAPI schema, not the 404 body, which the narrowed boundary does not touch.
</details>
