### PR TITLE
Read a SimaPro formula's // as the comment it is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,7 +197,10 @@
   negative. On one food database's twenty-two affected products, ozone
   depletion was computed at three to six per cent of the value that database
   publishes. Formulas without `//` are unchanged, and every cache rebuilds
-  itself from its source on the next load.
+  itself from its source on the next load. One evaluator reads every formula
+  the engine meets, so the same comment now ends an EcoSpold 2
+  `mathematicalRelation` and a scoring set's weighting formula, where `a//b` is
+  `a` rather than the error it used to be.
 - A file an EcoSpold directory offers and the reader cannot read now stops the
   load instead of disappearing from it. Such a file used to be a warning in
   passing and a dataset silently absent, and the load then described a complete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,18 @@
   wait. The files themselves are unchanged, to the byte.
 
 ### Fixed
+- A SimaPro formula now stops at `//`, the way SimaPro itself stops there.
+  SimaPro is a Delphi program and its formula parser keeps Pascal's line
+  comment, so `weight_g//yield1/yield2` is the weight and the two yields are a
+  note. The reader here refused the whole formula instead: the parameter never
+  entered the block's environment, and every amount that referred to it fell
+  back to zero. Where that parameter was the weight of a packaging material,
+  the material, its forming and its transport all left the result while the
+  end-of-life credit for the same material stayed, and the packaging came out
+  negative. On one food database's twenty-two affected products, ozone
+  depletion was computed at three to six per cent of the value that database
+  publishes. Formulas without `//` are unchanged, and every cache rebuilds
+  itself from its source on the next load.
 - A file an EcoSpold directory offers and the reader cannot read now stops the
   load instead of disappearing from it. Such a file used to be a warning in
   passing and a dataset silently absent, and the load then described a complete

--- a/src/Database/Loader.hs
+++ b/src/Database/Loader.hs
@@ -490,6 +490,10 @@ History of manual bumps:
      the payload, so an old cache holds a count and a single blocker where the
      decoder now reads a map, and every field after it would be read at the
      wrong offset.
+- 37: a SimaPro formula stops at '//', which that program reads as a comment,
+     where the expression parser used to refuse the whole line and leave every
+     amount under it at zero. Nothing changes type, so a cache written just
+     before this would pass the fingerprint and keep the zeros.
 
 The signature is stored inside the cache file and checked on load.
 If it doesn't match, the cache is automatically invalidated and rebuilt.
@@ -497,7 +501,7 @@ If it doesn't match, the cache is automatically invalidated and rebuilt.
 schemaSignature :: Word64
 schemaSignature =
     let Fingerprint hi lo = typeRepFingerprint (typeRep (Proxy :: Proxy Database))
-     in hi `xor` lo `xor` 36
+     in hi `xor` lo `xor` 37
 
 {- |
 Helper function to parse UUID from Text with deterministic UUID generation fallback.

--- a/src/Expr.hs
+++ b/src/Expr.hs
@@ -1,7 +1,14 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 {- | Expression evaluator.
-Supports arithmetic (+, -, *, /, ^), variables, parentheses, and common functions.
+Supports arithmetic (+, -, *, /, ^), variables, parentheses, common functions,
+and a @\/\/@ line comment, which is where an expression ends.
+
+The language is SimaPro's, and the comment is Pascal's because that program is
+written in Delphi. Three other callers read their formulas with this evaluator
+all the same - an EcoSpold 2 @mathematicalRelation@, a scoring set's weighting
+and its computed variables - so the comment applies to them too, and @a\/\/b@
+there is @a@ rather than the error it used to be.
 -}
 module Expr (
     evaluate,
@@ -199,11 +206,17 @@ collectIdentifiers decimalSep input =
 pCollect :: Parser [Text]
 pCollect = catMaybes <$> many pToken
 
+{- | One token, or one character of whatever this is not meant to collect.
+
+Even that one character goes through 'lexeme', so a comment opening after it is
+skipped here exactly as it is skipped when the expression is evaluated. Without
+it, @(a)\/\/b@ would be read as naming @b@, which the evaluation never sees.
+-}
 pToken :: Parser (Maybe Text)
 pToken =
     try (Just <$> pIdentTok)
         <|> (Nothing <$ try (lexeme pNumber))
-        <|> (Nothing <$ anySingle)
+        <|> (Nothing <$ lexeme anySingle)
 
 pIdentTok :: Parser Text
 pIdentTok = lexeme (T.pack <$> ((:) <$> (letterChar <|> char '_') <*> many (alphaNumChar <|> char '_')))

--- a/src/Expr.hs
+++ b/src/Expr.hs
@@ -43,9 +43,17 @@ normalizeExpr '.' = T.map (\c -> if c == ',' then ';' else c)
 normalizeExpr ',' = T.map (\c -> if c == ',' then '.' else c)
 normalizeExpr _ = id
 
--- Whitespace consumer
+{- | Whitespace, and the rest of a line once @\/\/@ opens a comment.
+
+SimaPro is a Delphi program and its formula parser keeps Pascal's line comment,
+so @weight_PET_g\/\/process1_yield\/process2_yield@ is the weight and nothing
+else: the two yields are commented out, and the number the author meant to
+divide is the number that goes into the result. Reading @\/\/@ as a division
+gives a different result, and reading it as an error gives none at all, which is
+how the amounts under it became zero.
+-}
 sc :: Parser ()
-sc = L.space space1 empty empty
+sc = L.space space1 (L.skipLineComment "//") empty
 
 lexeme :: Parser a -> Parser a
 lexeme = L.lexeme sc

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -684,6 +684,20 @@ spec = do
             evaluate env "Qper*DMper" `shouldBe` Right (60530841.0 * 5.0)
             evaluate env "qper*dmper" `shouldBe` Right (60530841.0 * 5.0)
 
+        -- Regression: a packaging dataset corrects a plastic weight by two process
+        -- yields and types "weight_PET_g//process1_yield/process2_yield". SimaPro,
+        -- a Delphi program, reads "//" as Pascal's line comment and keeps the
+        -- weight; the yields never apply. Refusing the expression instead left the
+        -- amounts under it at zero, and the packaging went missing from the result.
+        it "stops at a // comment, as SimaPro does" $ do
+            let env = M.fromList [("weight_PET_g", 9.29), ("process1_yield", 0.946), ("process2_yield", 0.997)]
+            evaluate env "weight_PET_g//process1_yield/process2_yield" `shouldBe` Right 9.29
+            evaluate env "weight_PET_g/process1_yield" `shouldBe` Right (9.29 / 0.946)
+            evaluate env "1+2 // and the rest is a note" `shouldBe` Right 3.0
+
+        it "rejects an expression that is only a comment" $
+            evaluate M.empty "// nothing but a note" `shouldSatisfy` isLeft
+
         it "normalizes comma decimal separator" $ do
             normalizeExpr ',' "0,82" `shouldBe` "0.82"
             normalizeExpr ',' "Qb*0,5" `shouldBe` "Qb*0.5"

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -10,7 +10,7 @@ import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import Database.Loader (defaultLoadOptions, getReferenceProductUUID, loadSimaProCSV)
-import Expr (evaluate, isExpression, normalizeExpr)
+import Expr (collectIdentifiers, evaluate, isExpression, normalizeExpr)
 import SimaPro.Parser (
     BioExchangeRow (..),
     Located (..),
@@ -697,6 +697,13 @@ spec = do
 
         it "rejects an expression that is only a comment" $
             evaluate M.empty "// nothing but a note" `shouldSatisfy` isLeft
+
+        -- What a formula names and what it computes have to be the same list,
+        -- or a scoring breakdown shows a variable the score never read.
+        it "collects no identifier the evaluation does not reach" $ do
+            collectIdentifiers '.' "(a)//b" `shouldBe` ["a"]
+            collectIdentifiers '.' "a//b" `shouldBe` ["a"]
+            collectIdentifiers '.' "a+b" `shouldBe` ["a", "b"]
 
         it "normalizes comma decimal separator" $ do
             normalizeExpr ',' "0,82" `shouldBe` "0.82"


### PR DESCRIPTION
## The problem

A SimaPro CSV block can define a calculated parameter, and one packaging
dataset corrects a plastic weight by two process yields:

```
Calculated parameters
weight_PET_corrected_p1p2_g;weight_PET_g//process1_yield/process2_yield;
```

SimaPro is a Delphi program and its formula parser keeps Pascal's line comment,
so it reads `weight_PET_g` and treats the rest as a note. The expression parser
here refused the whole formula. The parameter never entered the block's
environment, so every amount that referred to it stopped being resolvable and
took the lenient zero fallback: the plastic, its extrusion, and its two
transport legs all left the result. The end-of-life credit for the same plastic
is stated as a literal weight, so it stayed. The packaging came out negative.

Nine such formulas exist in one food database, over PET, PP and glue. On the
twenty-two products they reach, ozone depletion computed here was three to six
per cent of the value that database publishes, and its published table for
fifteen impact categories had fifty-two products outside a one per cent band.

## The solution

`Expr`'s whitespace consumer now skips a `//` comment to the end of the line,
which is one argument to `L.space`. `weight_PET_g//process1_yield/process2_yield`
evaluates to the weight; a formula without `//` is unchanged; a formula that is
only a comment is still refused, because an empty expression is not a number.

The cache schema signature goes to 37. Nothing changes type, so a cache written
before this would pass the fingerprint and keep the zeros.

## Remarks

Three readings of `//` were possible and the published numbers separate them.
On one product, published ozone depletion is 1.19e-06 kg CFC11 eq:

| reading of `a//b/c` | weight used | computed | vs published |
|---|---|---|---|
| refuse the formula (before) | 0 g | 3.80e-08 | -96.8% |
| a divided by b and by c | 9.85 g | 1.26e-06 | +5.7% |
| comment, so a (this change) | 9.29 g | 1.19e-06 | +0.4% |

Only one lands inside the band, and it is the one a Delphi parser gives.

The fallback itself is not silent: `fallbackAmounts` already warns for every
amount it replaces, naming the raw text and the value used. Nobody saw those
warnings here because they are written when a file is parsed, and a database
that comes back from its cache is not parsed.

## How to test

```
cabal test lca-tests --test-options='--match "/SimaPro expression evaluator/"'
```

covers the comment, the division without it, and the refusal of a formula that
is only a comment.

Against the database that has these formulas, and after removing its cache:
the same fifteen published categories go from fifty-two products outside a one
per cent band to fifteen, twelve of the fifteen categories have none at all,
and every median sits within 0.01 per cent of the published value. What remains
outside is unrelated to packaging weights: eleven products at +3.4 per cent on
fossil resource use, and four others between 1.1 and 1.5 per cent.
