### PR TITLE
Read a formula in the language it was written in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,10 +197,19 @@
   negative. On one food database's twenty-two affected products, ozone
   depletion was computed at three to six per cent of the value that database
   publishes. Formulas without `//` are unchanged, and every cache rebuilds
-  itself from its source on the next load. One evaluator reads every formula
-  the engine meets, so the same comment now ends an EcoSpold 2
-  `mathematicalRelation` and a scoring set's weighting formula, where `a//b` is
-  `a` rather than the error it used to be.
+  itself from its source on the next load.
+- A formula is now read in the language it was written in, and the two the
+  engine meets no longer borrow each other's punctuation. The comment above is
+  SimaPro's, because that program is written in Delphi; an EcoSpold 2
+  `mathematicalRelation` and the formulas someone writes in a scoring set have
+  no line comment at all, and used to be read as though they did, so
+  `total = "cch + acd // and the rest"` quietly became `cch` and a weighted sum
+  lost every term after the slashes. Those two now refuse a `//` instead of
+  truncating at it. They also separate two arguments of a function with a
+  comma, which is what someone writing a scoring set types: `min(a, b)` used to
+  fail and blame `min` for being an unknown variable, and now reads. Every
+  entry point of the evaluator asks which language it is reading, so neither
+  can inherit the other's edges again.
 - A file an EcoSpold directory offers and the reader cannot read now stops the
   load instead of disappearing from it. Such a file used to be a warning in
   passing and a dataset silently absent, and the load then described a complete

--- a/src/API/Routes.hs
+++ b/src/API/Routes.hs
@@ -2408,7 +2408,7 @@ computeAllScoringSets scoringSets rawScoreMap = do
     -- Intermediate helpers (consumed by `computed` but not referenced in any
     -- `scores.*` formula) are hidden from the breakdown.
     toIndicators ss e =
-        let displayed = S.fromList (concatMap (Expr.collectIdentifiers '.') (M.elems (ssScores ss)))
+        let displayed = S.fromList (concatMap (Expr.collectIdentifiers Expr.Arithmetic) (M.elems (ssScores ss)))
             names = ssLabels ss <> ssVariables ss
          in M.mapWithKey
                 ( \var val ->

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -642,7 +642,7 @@ checkFormulas params pairs = case checked of
         amountsAgreedOn $
             M.toList params
                 ++ [(v, exchangeAmount ex) | (ex, ef) <- pairs, Just v <- [efVariableName ef]]
-    checked = [(ex, rel, Expr.evaluate env (Expr.normalizeExpr '.' rel)) | (ex, ef) <- pairs, Just rel <- [efMathRel ef]]
+    checked = [(ex, rel, Expr.evaluate Expr.Arithmetic env rel) | (ex, ef) <- pairs, Just rel <- [efMathRel ef]]
     evaluated = [(ex, rel, v) | (ex, rel, Right v) <- checked]
     divergent = [(ex, rel, v) | (ex, rel, v) <- evaluated, not (nearlyEqual v (exchangeAmount ex))]
     example (ex, rel, v) =

--- a/src/EcoSpold/Parser2.hs
+++ b/src/EcoSpold/Parser2.hs
@@ -615,9 +615,11 @@ environment: the dataset's @\<parameter\>@ variables plus every exchange's own
 
 The stored amount always stays authoritative. EcoSpold2 sources carry
 pre-evaluated amounts, and this evaluator only supports a subset of the
-formula language (no @UnitConversion@, no cross-dataset @Ref@) with
-SimaPro-flavoured semantics, so its result serves as a consistency check, not
-a replacement. Divergences are expected in real EcoSpold2 databases
+formula language (no @UnitConversion@, no cross-dataset @Ref@), so its result
+serves as a consistency check, not a replacement. It reads that subset as this
+language writes it and not as SimaPro does: a @\/\/@ has no meaning here, so a
+relation carrying one is counted unevaluable rather than cut short at it.
+Divergences are expected in real EcoSpold2 databases
 (system-model exports rescale amounts without updating the copied formulas),
 so nothing is logged: the outcome is recorded on the activity for the
 database quality report.

--- a/src/Expr.hs
+++ b/src/Expr.hs
@@ -1,16 +1,15 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-{- | Expression evaluator.
-Supports arithmetic (+, -, *, /, ^), variables, parentheses, common functions,
-and a @\/\/@ line comment, which is where an expression ends.
+{- | Expression evaluator: arithmetic (+, -, *, \/, ^), variables, parentheses
+and a few functions, over formulas written in more than one language.
 
-The language is SimaPro's, and the comment is Pascal's because that program is
-written in Delphi. Three other callers read their formulas with this evaluator
-all the same - an EcoSpold 2 @mathematicalRelation@, a scoring set's weighting
-and its computed variables - so the comment applies to them too, and @a\/\/b@
-there is @a@ rather than the error it used to be.
+One grammar reads them all, because they agree on everything an expression is
+made of. Where they disagree is at the edges, and a 'Dialect' says which set of
+edges a formula was written against: every entry point asks for one, so no
+formula is read in a language nobody chose for it.
 -}
 module Expr (
+    Dialect (..),
     evaluate,
     normalizeExpr,
     isExpression,
@@ -32,15 +31,48 @@ import qualified Text.Megaparsec.Char.Lexer as L
 
 type Parser = Parsec Void Text
 
-{- | Evaluate a SimaPro expression with variable substitution.
-All expressions must be pre-normalized via 'normalizeExpr' (decimal = '.', arg separator = ';').
-Variable lookup is case-insensitive to match SimaPro semantics: Agribalyse and other
-databases freely mix casing (e.g. param defined as @Dmper@, referenced as @DMper@).
+{- | The language a formula was written in.
+
+Two, because two are what the callers actually have. A third belongs here the
+day a third language is read, and not before.
 -}
-evaluate :: M.Map Text Double -> Text -> Either String Double
-evaluate env input =
+data Dialect
+    = {- | SimaPro's own, as its Delphi formula parser reads it: @\/\/@ opens a
+      comment and the expression ends there. Its text reaches the evaluator
+      already through 'normalizeExpr', which is where the file's decimal
+      separator is known.
+      -}
+      SimaPro
+    | {- | Arithmetic with no comment and a comma between two arguments: an
+      EcoSpold 2 @mathematicalRelation@, and the formulas someone writes in
+      a scoring set. Neither language has a line comment, so a @\/\/@ in one
+      of them is a mistake and reads as one.
+      -}
+      Arithmetic
+    deriving (Eq, Show)
+
+{- | Bring a formula to the one form the grammar reads.
+
+Cutting a comment off as text rather than skipping it in the lexer is what lets
+one grammar serve both dialects, and it also keeps 'collectIdentifiers' and
+'evaluate' looking at the very same characters. Per line, because a formula
+that spans two of them ends its comment at the first.
+-}
+readable :: Dialect -> Text -> Text
+readable SimaPro = T.strip . T.intercalate "\n" . map (fst . T.breakOn "//") . T.lines
+readable Arithmetic = T.strip . normalizeExpr '.'
+
+{- | Evaluate an expression of the given dialect, with variable substitution.
+
+Variable lookup is case-insensitive in every dialect: SimaPro sources mix the
+casing of one name freely (a parameter defined as @Dmper@ and referenced as
+@DMper@), and the two others hand over an environment whose keys are folded
+already, so folding here is what makes their lookups land.
+-}
+evaluate :: Dialect -> M.Map Text Double -> Text -> Either String Double
+evaluate dialect env input =
     let envCI = M.mapKeys T.toLower env
-     in case parse (sc *> pExpr envCI <* eof) "" (T.strip input) of
+     in case parse (sc *> pExpr envCI <* eof) "" (readable dialect input) of
             Left err -> Left (errorBundlePretty err)
             Right val -> Right val
 
@@ -50,17 +82,9 @@ normalizeExpr '.' = T.map (\c -> if c == ',' then ';' else c)
 normalizeExpr ',' = T.map (\c -> if c == ',' then '.' else c)
 normalizeExpr _ = id
 
-{- | Whitespace, and the rest of a line once @\/\/@ opens a comment.
-
-SimaPro is a Delphi program and its formula parser keeps Pascal's line comment,
-so @weight_PET_g\/\/process1_yield\/process2_yield@ is the weight and nothing
-else: the two yields are commented out, and the number the author meant to
-divide is the number that goes into the result. Reading @\/\/@ as a division
-gives a different result, and reading it as an error gives none at all, which is
-how the amounts under it became zero.
--}
+-- | Whitespace consumer. A comment, where a dialect has one, is gone before this runs.
 sc :: Parser ()
-sc = L.space space1 (L.skipLineComment "//") empty
+sc = L.space space1 empty empty
 
 lexeme :: Parser a -> Parser a
 lexeme = L.lexeme sc
@@ -187,17 +211,17 @@ pFunc2 name f env = try $ do
 Does NOT evaluate — accepts any variable name without needing an environment.
 Used to detect allocation fields vs waste type descriptions in SimaPro CSV.
 -}
-isExpression :: Char -> Text -> Bool
-isExpression decimalSep input =
-    isRight $ parse (sc *> pSynExpr <* eof) "" (T.strip (normalizeExpr decimalSep input))
+isExpression :: Dialect -> Text -> Bool
+isExpression dialect input =
+    isRight $ parse (sc *> pSynExpr <* eof) "" (readable dialect input)
 
 {- | Collect all variable identifiers referenced in an expression.
 Built-in function names (abs, sqrt, log, exp, ln, min, max) are excluded.
 Returns the empty list if the expression cannot be tokenized.
 -}
-collectIdentifiers :: Char -> Text -> [Text]
-collectIdentifiers decimalSep input =
-    case parse (sc *> pCollect <* eof) "" (T.strip (normalizeExpr decimalSep input)) of
+collectIdentifiers :: Dialect -> Text -> [Text]
+collectIdentifiers dialect input =
+    case parse (sc *> pCollect <* eof) "" (readable dialect input) of
         Right names -> filter (`notElem` reservedFuncs) names
         Left _ -> []
   where

--- a/src/Expr.hs
+++ b/src/Expr.hs
@@ -64,10 +64,12 @@ readable Arithmetic = T.strip . normalizeExpr '.'
 
 {- | Evaluate an expression of the given dialect, with variable substitution.
 
-Variable lookup is case-insensitive in every dialect: SimaPro sources mix the
-casing of one name freely (a parameter defined as @Dmper@ and referenced as
-@DMper@), and the two others hand over an environment whose keys are folded
-already, so folding here is what makes their lookups land.
+Variable lookup is case-insensitive in every dialect. SimaPro needs it, mixing
+the casing of one name freely - a parameter defined as @Dmper@ and referenced
+as @DMper@ - and the other two are served rather than harmed by it: an
+EcoSpold 2 environment arrives folded already, and a scoring set writes its own
+variable names on both sides of the formula. Two names that differ only in case
+are therefore one name, and an environment stating both keeps one of them.
 -}
 evaluate :: Dialect -> M.Map Text Double -> Text -> Either String Double
 evaluate dialect env input =
@@ -230,17 +232,12 @@ collectIdentifiers dialect input =
 pCollect :: Parser [Text]
 pCollect = catMaybes <$> many pToken
 
-{- | One token, or one character of whatever this is not meant to collect.
-
-Even that one character goes through 'lexeme', so a comment opening after it is
-skipped here exactly as it is skipped when the expression is evaluated. Without
-it, @(a)\/\/b@ would be read as naming @b@, which the evaluation never sees.
--}
+-- | One token, or one character of whatever this is not meant to collect.
 pToken :: Parser (Maybe Text)
 pToken =
     try (Just <$> pIdentTok)
         <|> (Nothing <$ try (lexeme pNumber))
-        <|> (Nothing <$ lexeme anySingle)
+        <|> (Nothing <$ anySingle)
 
 pIdentTok :: Parser Text
 pIdentTok = lexeme (T.pack <$> ((:) <$> (letterChar <|> char '_') <*> many (alphaNumChar <|> char '_')))

--- a/src/Method/Types.hs
+++ b/src/Method/Types.hs
@@ -260,7 +260,7 @@ computeFormulaScores ss rawScores = do
     scores <-
         M.traverseWithKey
             ( \scoreName formula ->
-                case Expr.evaluate nwEnv formula of
+                case Expr.evaluate Expr.Arithmetic nwEnv formula of
                     Left err ->
                         Left $
                             "Score '"
@@ -287,7 +287,7 @@ resolveComputed env formulas = foldl step (Right env) sorted
     sorted = sortOn (T.length . snd) (M.toList formulas)
     step (Left err) _ = Left err
     step (Right currentEnv) (varName, formula) =
-        case Expr.evaluate currentEnv formula of
+        case Expr.evaluate Expr.Arithmetic currentEnv formula of
             Left err ->
                 Left $
                     "Computed variable '"

--- a/src/SimaPro/Parser.hs
+++ b/src/SimaPro/Parser.hs
@@ -547,7 +547,8 @@ Uses the Megaparsec expression parser syntactically — accepts any identifier w
 needing parameter values. Waste type descriptions ("All waste types") fail to parse.
 -}
 isAllocationField :: SimaProConfig -> BS.ByteString -> Bool
-isAllocationField cfg bs = Expr.isExpression (spDecimal cfg) (decodeBS (BS8.strip bs))
+isAllocationField cfg bs =
+    Expr.isExpression Expr.SimaPro (Expr.normalizeExpr (spDecimal cfg) (decodeBS (BS8.strip bs)))
 
 -- | Parse a technosphere exchange row (ByteString input, Text output)
 
@@ -964,7 +965,7 @@ resolveAmount env raw fallback
 
 -- | A number, or an expression over the parameter environment. Nothing: neither.
 resolveExpr :: M.Map Text Double -> Text -> Maybe Double
-resolveExpr env raw = readAmount raw <|> either (const Nothing) Just (Expr.evaluate env raw)
+resolveExpr env raw = readAmount raw <|> either (const Nothing) Just (Expr.evaluate Expr.SimaPro env raw)
 
 {- | Every raw amount in a block that 'resolveAmount' will replace with its
 lenient fallback: not a number, and not an expression the block's parameter
@@ -1005,7 +1006,7 @@ buildParamEnv inputGroups calcGroups =
     )
   where
     evalParam acc (name, rawVal) =
-        either (const acc) (\v -> M.insert name v acc) (Expr.evaluate acc rawVal)
+        either (const acc) (\v -> M.insert name v acc) (Expr.evaluate Expr.SimaPro acc rawVal)
     evalToFixpoint acc params =
         let acc' = foldl' evalParam acc params
          in if M.size acc' == M.size acc then acc' else evalToFixpoint acc' params

--- a/test/SimaProParserSpec.hs
+++ b/test/SimaProParserSpec.hs
@@ -10,7 +10,8 @@ import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import Database.Loader (defaultLoadOptions, getReferenceProductUUID, loadSimaProCSV)
-import Expr (collectIdentifiers, evaluate, isExpression, normalizeExpr)
+import Expr (Dialect (..), collectIdentifiers, isExpression, normalizeExpr)
+import qualified Expr
 import SimaPro.Parser (
     BioExchangeRow (..),
     Located (..),
@@ -583,97 +584,97 @@ spec = do
             map exchangeAmount undeclared `shouldBe` [3]
     describe "SimaPro expression evaluator" $ do
         it "evaluates numeric literals" $ do
-            evaluate M.empty "42" `shouldBe` Right 42.0
-            evaluate M.empty "3.14" `shouldBe` Right 3.14
+            Expr.evaluate SimaPro M.empty "42" `shouldBe` Right 42.0
+            Expr.evaluate SimaPro M.empty "3.14" `shouldBe` Right 3.14
 
         it "evaluates arithmetic" $ do
-            evaluate M.empty "2+3" `shouldBe` Right 5.0
-            evaluate M.empty "10-4" `shouldBe` Right 6.0
-            evaluate M.empty "3*4" `shouldBe` Right 12.0
-            evaluate M.empty "10/4" `shouldBe` Right 2.5
+            Expr.evaluate SimaPro M.empty "2+3" `shouldBe` Right 5.0
+            Expr.evaluate SimaPro M.empty "10-4" `shouldBe` Right 6.0
+            Expr.evaluate SimaPro M.empty "3*4" `shouldBe` Right 12.0
+            Expr.evaluate SimaPro M.empty "10/4" `shouldBe` Right 2.5
 
         it "evaluates parenthesized expressions" $ do
-            evaluate M.empty "(2+3)*4" `shouldBe` Right 20.0
-            evaluate M.empty "2*(3+4)" `shouldBe` Right 14.0
+            Expr.evaluate SimaPro M.empty "(2+3)*4" `shouldBe` Right 20.0
+            Expr.evaluate SimaPro M.empty "2*(3+4)" `shouldBe` Right 14.0
 
         it "evaluates variables" $ do
             let env = M.fromList [("Qm", 20.53), ("Qb", 1.0)]
-            evaluate env "Qm" `shouldBe` Right 20.53
-            evaluate env "Qb" `shouldBe` Right 1.0
+            Expr.evaluate SimaPro env "Qm" `shouldBe` Right 20.53
+            Expr.evaluate SimaPro env "Qb" `shouldBe` Right 1.0
 
         it "evaluates complex expressions with variables" $ do
             let env = M.fromList [("Qb", 1.0), ("DMb", 0.82), ("Qm", 20.53), ("DMm", 0.118)]
             -- Butter allocation formula: (Qb*DMb/(Qb*DMb+Qm*DMm))*100
-            let result = evaluate env "(Qb*DMb/(Qb*DMb+Qm*DMm))*100"
+            let result = Expr.evaluate SimaPro env "(Qb*DMb/(Qb*DMb+Qm*DMm))*100"
             case result of
                 Right v -> v `shouldSatisfy` (\x -> abs (x - 25.29) < 0.1)
                 Left e -> expectationFailure $ "Evaluation failed: " ++ e
 
         it "evaluates yield correction chains" $ do
             let env = M.fromList [("weight_kg", 0.25), ("yield1", 0.95), ("yield2", 0.90)]
-            let result = evaluate env "weight_kg/yield1/yield2"
+            let result = Expr.evaluate SimaPro env "weight_kg/yield1/yield2"
             case result of
                 Right v -> v `shouldSatisfy` (\x -> abs (x - 0.2924) < 0.001)
                 Left e -> expectationFailure $ "Evaluation failed: " ++ e
 
         it "evaluates power operator" $ do
-            evaluate M.empty "2^3" `shouldBe` Right 8.0
-            evaluate M.empty "3^2" `shouldBe` Right 9.0
+            Expr.evaluate SimaPro M.empty "2^3" `shouldBe` Right 8.0
+            Expr.evaluate SimaPro M.empty "3^2" `shouldBe` Right 9.0
 
         -- Regression: SimaPro writes a scale factor as a signed power of ten.
         -- The exponent used to be parsed by the power rule itself, which knows
         -- numbers but not signs, so the '-' failed the whole expression and the
         -- amount fell back to something else entirely.
         it "evaluates a signed exponent" $ do
-            evaluate M.empty "10^-6" `shouldEvalTo` 1.0e-6
-            evaluate M.empty "10^+3" `shouldEvalTo` 1000.0
-            evaluate M.empty "1*10^-3*50" `shouldEvalTo` 0.05
-            evaluate M.empty "2^-2" `shouldEvalTo` 0.25
+            Expr.evaluate SimaPro M.empty "10^-6" `shouldEvalTo` 1.0e-6
+            Expr.evaluate SimaPro M.empty "10^+3" `shouldEvalTo` 1000.0
+            Expr.evaluate SimaPro M.empty "1*10^-3*50" `shouldEvalTo` 0.05
+            Expr.evaluate SimaPro M.empty "2^-2" `shouldEvalTo` 0.25
 
         it "keeps exponentiation right-associative and below unary minus" $ do
             -- Reading the exponent through the unary rule must not flatten the
             -- tower nor take the sign away from the operand in front of it.
             -- 512 rather than 64 is the whole point: a flattened tower would be
             -- (2^3)^2, and no rounding tolerance can hide that difference.
-            evaluate M.empty "2^3^2" `shouldEvalTo` 512.0
-            evaluate M.empty "-2^2" `shouldEvalTo` (-4.0)
-            evaluate M.empty "2^-3^2" `shouldEvalTo` (2 ** (-9))
+            Expr.evaluate SimaPro M.empty "2^3^2" `shouldEvalTo` 512.0
+            Expr.evaluate SimaPro M.empty "-2^2" `shouldEvalTo` (-4.0)
+            Expr.evaluate SimaPro M.empty "2^-3^2" `shouldEvalTo` (2 ** (-9))
 
         it "accepts a signed exponent as syntax, not only as a value" $ do
             -- `isExpression` runs a parallel parser that takes no environment,
             -- so it has to learn the same shape or the cell reads as prose.
-            isExpression ',' "10^-6" `shouldBe` True
-            isExpression ',' "(38-15)*4185*30/0,9*10^-6" `shouldBe` True
+            isExpression SimaPro (normalizeExpr ',' "10^-6") `shouldBe` True
+            isExpression SimaPro (normalizeExpr ',' "(38-15)*4185*30/0,9*10^-6") `shouldBe` True
 
         it "evaluates unary minus" $ do
-            evaluate M.empty "-5" `shouldBe` Right (-5.0)
-            evaluate M.empty "-(2+3)" `shouldBe` Right (-5.0)
+            Expr.evaluate SimaPro M.empty "-5" `shouldBe` Right (-5.0)
+            Expr.evaluate SimaPro M.empty "-(2+3)" `shouldBe` Right (-5.0)
 
         it "rejects unknown variables" $ do
-            evaluate M.empty "xyz" `shouldSatisfy` isLeft
+            Expr.evaluate SimaPro M.empty "xyz" `shouldSatisfy` isLeft
 
         -- Regression: SimaPro exports drop the integer part of a decimal, and
         -- Agribalyse sums a pesticide mix in place — "0,45+0,247+,067". The
         -- last term made the whole expression unparseable, and the amount
         -- silently became its leading number: 0.45 where the file says 0.764.
         it "evaluates decimals written without their integer part" $ do
-            evaluate M.empty ".067" `shouldBe` Right 0.067
-            evaluate M.empty "0.45+0.247+.067" `shouldBe` Right (0.45 + 0.247 + 0.067)
-            evaluate M.empty ".5*2" `shouldBe` Right 1.0
-            evaluate M.empty "-.5" `shouldBe` Right (-0.5)
-            evaluate M.empty "(.25+.75)*4" `shouldBe` Right 4.0
-            evaluate M.empty ".5e1" `shouldBe` Right 5.0
+            Expr.evaluate SimaPro M.empty ".067" `shouldBe` Right 0.067
+            Expr.evaluate SimaPro M.empty "0.45+0.247+.067" `shouldBe` Right (0.45 + 0.247 + 0.067)
+            Expr.evaluate SimaPro M.empty ".5*2" `shouldBe` Right 1.0
+            Expr.evaluate SimaPro M.empty "-.5" `shouldBe` Right (-0.5)
+            Expr.evaluate SimaPro M.empty "(.25+.75)*4" `shouldBe` Right 4.0
+            Expr.evaluate SimaPro M.empty ".5e1" `shouldBe` Right 5.0
 
         it "still rejects a point that is not part of a number" $ do
-            evaluate M.empty "." `shouldSatisfy` isLeft
-            evaluate M.empty "1+." `shouldSatisfy` isLeft
-            evaluate M.empty ".+1" `shouldSatisfy` isLeft
+            Expr.evaluate SimaPro M.empty "." `shouldSatisfy` isLeft
+            Expr.evaluate SimaPro M.empty "1+." `shouldSatisfy` isLeft
+            Expr.evaluate SimaPro M.empty ".+1" `shouldSatisfy` isLeft
 
         it "reads a literal in an expression exactly as it reads it alone" $ do
             -- Not 'read'/'L.float' rounding: both paths go through readAmount,
             -- so a literal keeps its value when an operator is put next to it.
-            evaluate M.empty "0.0000010897906999999999"
-                `shouldBe` evaluate M.empty "0.0000010897906999999999*1"
+            Expr.evaluate SimaPro M.empty "0.0000010897906999999999"
+                `shouldBe` Expr.evaluate SimaPro M.empty "0.0000010897906999999999*1"
 
         -- Regression: Agribalyse Emmental defines the dry-matter param as "Dmper"
         -- but references "DMper" in the allocation formula. SimaPro treats parameter
@@ -681,8 +682,8 @@ spec = do
         -- whole activity shows zero impacts.
         it "looks up variables case-insensitively" $ do
             let env = M.fromList [("Dmper", 5.0), ("Qper", 60530841.0)]
-            evaluate env "Qper*DMper" `shouldBe` Right (60530841.0 * 5.0)
-            evaluate env "qper*dmper" `shouldBe` Right (60530841.0 * 5.0)
+            Expr.evaluate SimaPro env "Qper*DMper" `shouldBe` Right (60530841.0 * 5.0)
+            Expr.evaluate SimaPro env "qper*dmper" `shouldBe` Right (60530841.0 * 5.0)
 
         -- Regression: a packaging dataset corrects a plastic weight by two process
         -- yields and types "weight_PET_g//process1_yield/process2_yield". SimaPro,
@@ -691,19 +692,31 @@ spec = do
         -- amounts under it at zero, and the packaging went missing from the result.
         it "stops at a // comment, as SimaPro does" $ do
             let env = M.fromList [("weight_PET_g", 9.29), ("process1_yield", 0.946), ("process2_yield", 0.997)]
-            evaluate env "weight_PET_g//process1_yield/process2_yield" `shouldBe` Right 9.29
-            evaluate env "weight_PET_g/process1_yield" `shouldBe` Right (9.29 / 0.946)
-            evaluate env "1+2 // and the rest is a note" `shouldBe` Right 3.0
+            Expr.evaluate SimaPro env "weight_PET_g//process1_yield/process2_yield" `shouldBe` Right 9.29
+            Expr.evaluate SimaPro env "weight_PET_g/process1_yield" `shouldBe` Right (9.29 / 0.946)
+            Expr.evaluate SimaPro env "1+2 // and the rest is a note" `shouldBe` Right 3.0
 
         it "rejects an expression that is only a comment" $
-            evaluate M.empty "// nothing but a note" `shouldSatisfy` isLeft
+            Expr.evaluate SimaPro M.empty "// nothing but a note" `shouldSatisfy` isLeft
 
         -- What a formula names and what it computes have to be the same list,
         -- or a scoring breakdown shows a variable the score never read.
         it "collects no identifier the evaluation does not reach" $ do
-            collectIdentifiers '.' "(a)//b" `shouldBe` ["a"]
-            collectIdentifiers '.' "a//b" `shouldBe` ["a"]
-            collectIdentifiers '.' "a+b" `shouldBe` ["a", "b"]
+            collectIdentifiers SimaPro "(a)//b" `shouldBe` ["a"]
+            collectIdentifiers SimaPro "a//b" `shouldBe` ["a"]
+            collectIdentifiers Arithmetic "a+b" `shouldBe` ["a", "b"]
+
+        -- A scoring set's formulas and an EcoSpold 2 mathematicalRelation are
+        -- not written in SimaPro, and used to be read as if they were: "//" cut
+        -- a weighted sum short, and the comma SimaPro spells ";" made the
+        -- evaluator call a function name an unknown variable.
+        it "reads a formula of the other dialect in its own terms" $ do
+            let env = M.fromList [("cch", 3.0), ("acd", 4.0)]
+            Expr.evaluate Arithmetic env "cch + acd" `shouldBe` Right 7.0
+            Expr.evaluate Arithmetic env "cch //+ acd" `shouldSatisfy` isLeft
+            Expr.evaluate Arithmetic env "min(cch,acd)" `shouldBe` Right 3.0
+            Expr.evaluate SimaPro env "min(cch;acd)" `shouldBe` Right 3.0
+            Expr.evaluate SimaPro env "cch //+ acd" `shouldBe` Right 3.0
 
         it "normalizes comma decimal separator" $ do
             normalizeExpr ',' "0,82" `shouldBe` "0.82"


### PR DESCRIPTION
## The problem

`Expr` is the engine's only expression evaluator, and it parses SimaPro's
formula language. Three callers use it, and only one of them reads SimaPro:

| caller | language it hands over |
|---|---|
| `SimaPro.Parser` | SimaPro formulas, amounts and allocations |
| `EcoSpold.Parser2` | an EcoSpold 2 `mathematicalRelation`, cross-checked against the stored amount |
| `Method.Types` / `API.Routes` | the formulas someone writes in a scoring set's TOML |

Nothing asked a caller which language it was in, so the other two inherited
SimaPro's punctuation. Measured on `main` before this change, with `cch = 3` and
`acd = 4`:

```
Expr.evaluate env "cch + acd"     →  Right 7.0
Expr.evaluate env "cch //+ acd"   →  Right 3.0
Expr.evaluate env "min(a,b)"      →  Left "Unknown variable: min"
Expr.evaluate env "min(a;b)"      →  Right 3.0
```

The second is a weighted sum losing every term after the slashes, quietly, in a
file SimaPro has never seen. The third is a function call failing because the
argument separator belongs to another language, with an error that blames the
function name for being an unknown variable.

## The solution

A `Dialect` names the language, and `evaluate`, `isExpression` and
`collectIdentifiers` all ask for one. `SimaPro` keeps the comment and arrives
through `normalizeExpr`, which is where the file's decimal separator is known;
`Arithmetic` has no comment and separates arguments with a comma.

It is a text step, not a parameter threaded through twenty parsers. `readable`
brings a formula to the one form the grammar reads, which is the idiom
`normalizeExpr` already established, and it has a second benefit: cutting the
comment off before parsing means `collectIdentifiers` and `evaluate` look at
exactly the same characters, so the divergence fixed in #474 cannot come back by
another route.

Two dialects, because two are what the callers have. The variable lookup stays
case-folded in both: SimaPro sources mix the casing of one name, and the other
two hand over an environment whose keys are folded already.

## Remarks

This answers the third finding of the review on #474, which named the borrowing
but could not name a fix short enough to be worth it. It also settles a question
that came up alongside: moving `Expr` under `SimaPro/` would have made
`Method.Types` import a SimaPro module to read our own configuration. Separating
the dialect is what the move was reaching for.

Nothing in the cache changes type and no cached value moves. The only content
that could differ is a formula-check count for an EcoSpold 2 dataset whose
relation contains `//`, which is not part of that language, so the schema
signature stays where #474 left it.

## How to test

```
cabal test lca-tests --test-options='--match "/SimaPro expression evaluator/"'
```

"reads a formula of the other dialect in its own terms" covers all four lines
measured above, from both sides: the sum that no longer truncates, the `//` that
is now refused where no comment exists and still read where one does, and the
comma that now separates two arguments.
